### PR TITLE
YUJ-446: make smart-summary upstream optional (fix nginx emerg at startup)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,13 @@
 
 set -eu
 
-envsubst '${API_URL}' < /nginx.conf.template > /etc/nginx/conf.d/default.conf
+# Default SUMMARY_API_URL to blank so the /summary/ location short-circuits
+# to 503 if smart-summary is not deployed. When running inside the OCTO
+# compose stack, set SUMMARY_API_URL=http://summary-api:8080 from .env.
+: "${SUMMARY_API_URL:=}"
+export SUMMARY_API_URL
+
+envsubst '${API_URL} ${SUMMARY_API_URL}' < /nginx.conf.template > /etc/nginx/conf.d/default.conf
 
 
 exec "$@"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -13,6 +13,12 @@ server {
         listen       80;
         server_name  localhost;
 
+        # Propagate env-provided values down into nginx variables so they
+        # can be referenced from inside location blocks. envsubst substitutes
+        # these at container start; leaving an env blank yields an empty
+        # string that the corresponding location block tests for.
+        set $summary_api_url "${SUMMARY_API_URL}";
+
         # Security headers
         # Prevent clickjacking attacks
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -31,10 +37,20 @@ server {
         # HSTS - uncomment when full HTTPS chain is confirmed
         # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-        # Smart Summary backend — single prefix rule
+        # Smart Summary backend — optional.
+        # Set SUMMARY_API_URL (e.g. http://summary-api:8080) at container
+        # start to enable the in-app summariser. Leaving it blank routes
+        # /summary/api/v1/* to a static 503 so missing the smart-summary
+        # service does not fail nginx startup.
         location /summary/api/v1/ {
-            # summary-api: the summary service, configure via SUMMARY_API_HOST env or docker-compose service name
-            proxy_pass  http://summary-api:8080/api/v1/;
+            if ($summary_api_url = "") {
+                return 503 '{"status":503,"msg":"smart-summary is not configured"}';
+            }
+            # nginx resolves proxy_pass variables at request time, not at
+            # startup, so an unresolvable hostname no longer hard-fails the
+            # whole container.
+            resolver 127.0.0.11 ipv6=off valid=30s;
+            proxy_pass  $summary_api_url/api/v1/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -43,6 +43,9 @@ server {
         # /summary/api/v1/* to a static 503 so missing the smart-summary
         # service does not fail nginx startup.
         location /summary/api/v1/ {
+            # nginx's `return` defaults to text/html; this location is an
+            # API proxy so JSON clients expect application/json.
+            default_type application/json;
             if ($summary_api_url = "") {
                 return 503 '{"status":503,"msg":"smart-summary is not configured"}';
             }
@@ -50,7 +53,13 @@ server {
             # startup, so an unresolvable hostname no longer hard-fails the
             # whole container.
             resolver 127.0.0.11 ipv6=off valid=30s;
-            proxy_pass  $summary_api_url/api/v1/;
+            # When proxy_pass contains a variable, nginx does NOT do the
+            # usual location-prefix→URI swap — the URI after the host
+            # would be sent verbatim. Use a rewrite to produce the final
+            # upstream URI, then proxy_pass *without* a URI so nginx
+            # forwards the rewritten request as-is.
+            rewrite ^/summary/api/v1/(.*)$ /api/v1/$1 break;
+            proxy_pass  $summary_api_url;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem

`nginx.conf.template` referenced the smart-summary service as a hard
proxy upstream:

```nginx
location /summary/api/v1/ {
    proxy_pass  http://summary-api:8080/api/v1/;
    ...
}
```

nginx resolves upstream hostnames at startup. If octo-web is deployed
without octo-smart-summary on the same docker network (including the
stock `Mininglamp-OSS/octo-server/docker/octo` compose stack in its
pre-YUJ-446 form), the container exits immediately:

```
[emerg] host not found in upstream "summary-api"
        in /etc/nginx/conf.d/default.conf:36
```

Blocks OSS users from running octo-web by itself and blocks the
`docker compose up -d` happy path.

## Fix

- `SUMMARY_API_URL` env variable (default empty).
- Entrypoint runs `envsubst` over a new variable slot so the value
  lands in an nginx `set` directive rather than as a raw upstream
  name.
- Empty → `/summary/api/v1/*` short-circuits to `503 {"msg":"smart-summary is not configured"}`.
- Set but unreachable → request-time resolution returns 502 (no
  startup impact).
- Set + reachable → proxied normally.

Explicit `resolver 127.0.0.11 ipv6=off valid=30s;` for Docker's
embedded DNS.

## Validation

Built `octo-web:yuj446` and ran three scenarios:

| `SUMMARY_API_URL`                 | Container up | `/` | `/summary/api/v1/foo` |
| --------------------------------- | :----------: | :-: | :--------------------: |
| _unset_                           | ✅           | 200 | 503 JSON              |
| `http://summary-api:8080` (stub)  | ✅           | 200 | 502 (runtime DNS fail) |
| `http://summary-api:8080` (real)  | ✅           | 200 | 200 (proxied)          |

Companion to `Mininglamp-OSS/octo-server` PR #2.