### PR TITLE
fix: use backend max_duration config for voice recording limit

### DIFF
--- a/apps/web/src/__tests__/useVoiceInput.test.ts
+++ b/apps/web/src/__tests__/useVoiceInput.test.ts
@@ -181,7 +181,16 @@ describe("useVoiceInput", () => {
   });
 
   it("should auto-stop recording after maxDuration timeout", async () => {
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_file_size: 3145728,
+    } as any);
+
     const { result } = renderHook(() => useVoiceInput({ maxDuration: 5 }));
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     await act(async () => {
       await result.current.startRecording();
@@ -190,7 +199,7 @@ describe("useVoiceInput", () => {
     expect(result.current.isRecording).toBe(true);
 
     await act(async () => {
-      vi.advanceTimersByTime(5000);
+      await vi.advanceTimersByTimeAsync(5001);
     });
 
     // maxDuration timeout should have triggered stopRecordingAndTranscribe
@@ -661,6 +670,10 @@ describe("useVoiceInput - personal voice context", () => {
     });
 
     await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    await act(async () => {
       result.current.stopRecordingAndTranscribe();
     });
 
@@ -762,5 +775,156 @@ describe("useVoiceInput - personal voice context", () => {
     // After cancel, the voiceContextRef should remain null
     // because spaceId check fails. We verify indirectly:
     // next recording should query fresh context
+  });
+});
+
+describe("useVoiceInput - max duration config", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setupMocks();
+    WKApp.shared.currentSpaceId = "test-space-id";
+    vi.mocked(VoiceService.shared.getVoiceContext).mockResolvedValue({
+      status: 200,
+      has_context: false,
+      context: "",
+      updated_at: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("should default to 60s when backend does not return max_duration", async () => {
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_file_size: 3145728,
+    } as any);
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance 59s — should still be recording
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59000);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance past 60s — should auto-stop
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1001);
+    });
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("should use backend max_duration when returned by getConfig", async () => {
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_duration: 30,
+      max_file_size: 3145728,
+    });
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance 29s — should still be recording
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29000);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance past 30s — should auto-stop
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1001);
+    });
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("should enforce safety floor of 5s when backend returns a smaller value", async () => {
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_duration: 2,
+      max_file_size: 3145728,
+    });
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance 2s — should NOT stop (floor is 5s)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance to 4.9s — still recording
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2900);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance past 5s — should auto-stop
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(101);
+    });
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("should allow explicit caller-passed maxDuration to override when no backend config", async () => {
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_file_size: 3145728,
+    } as any);
+
+    const { result } = renderHook(() => useVoiceInput({ maxDuration: 10 }));
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance 9s — should still be recording
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    // Advance past 10s — should auto-stop
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1001);
+    });
+    expect(result.current.isRecording).toBe(false);
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
@@ -43,7 +43,7 @@ export default function useVoiceInput(
   options: UseVoiceInputOptions = {}
 ): UseVoiceInputReturn {
   const {
-    maxDuration = 300, // PRD: 最长录音时长 300 秒
+    maxDuration = 60, // PRD: 最长录音时长 60秒
     onTranscribed,
     onError,
     onRecordingFailed,
@@ -76,6 +76,7 @@ export default function useVoiceInput(
     useRef<Promise<VoiceContextResponse | null> | null>(null);
   const voiceContextSpaceIdRef = useRef<string>("");
   const maxFileSizeRef = useRef<number>(0);
+  const backendMaxDurationRef = useRef<number | null>(null);
   const backendEnabledRef = useRef(false);
 
   // Load local model config from localStorage on mount, then fetch voice config
@@ -95,6 +96,9 @@ export default function useVoiceInput(
         setIsVoiceEnabled(config.enabled || localAllowed);
         backendEnabledRef.current = config.enabled;
         maxFileSizeRef.current = config.max_file_size || 0;
+        if (config.max_duration != null) {
+          backendMaxDurationRef.current = config.max_duration;
+        }
         const localTimeout = config.local_timeout_ms ?? LOCAL_DEFAULT_TIMEOUT_MS;
 
         if (localAllowed) {
@@ -211,9 +215,13 @@ export default function useVoiceInput(
         startTimeRef.current = Date.now();
 
         // 使用 setTimeout 替代 setInterval 处理 maxDuration 自动停止
+        const effectiveDuration = Math.max(
+          5,
+          backendMaxDurationRef.current ?? maxDuration
+        );
         maxDurationTimeoutRef.current = setTimeout(() => {
           stopFnRef.current();
-        }, maxDuration * 1000);
+        }, effectiveDuration * 1000);
       } catch (err) {
         const error =
           err instanceof Error ? err : new Error("Microphone access denied");


### PR DESCRIPTION
## Summary

Fixes #9 — `useVoiceInput` hook was ignoring the backend `max_duration` returned from `/voice/config`. Recording duration always used the hardcoded 300s default regardless of server configuration.

## Changes

- **Default reduced from 300s to 60s** — matches backend default, provides a more sensible fallback
- **Backend config takes priority** — `max_duration` from `/voice/config` is now read and applied to the recording timeout
- **5s safety floor** — prevents misconfiguration from making recording unusable (`Math.max(5, effectiveDuration)`)

## Implementation

1. Added `backendMaxDurationRef` to store the config value from the existing `getConfig()` call
2. In `startRecording`, compute effective duration: `Math.max(5, backendMaxDuration ?? callerMaxDuration)`
3. Backend value takes priority over the caller-passed `maxDuration` option (which now serves as fallback)

## Tests

Added 4 new test cases covering:
- Default 60s when backend omits max_duration
- Backend max_duration is honored when returned
- Safety floor of 5s enforced for very small values
- Caller-passed maxDuration works as fallback

All 32 tests pass.