### PR TITLE
fix: 修复通讯录联系人详情弹窗出现双关闭按钮问题

### DIFF
--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -765,6 +765,7 @@ export default class ContactsList extends Component<any, ContactsState> {
                         visible={this.state.userInfoVisible}
                         onCancel={() => this.setState({ userInfoVisible: false })}
                         className="wk-base-modal-userinfo wk-base-modal"
+                        options={{ closable: false }}
                     >
                         {this.state.userInfoUid && (
                             <UserInfo


### PR DESCRIPTION
## 问题描述

通讯录中点击 human 联系人查看联系人详情时，弹窗出现两个关闭按钮（左边一个、右边一个）。

## 根本原因

两个关闭按钮来自不同层级：

| 位置 | 来源 |
|------|------|
| 左边 | `UserInfo` 内部 `RoutePage` 组件 header 中固定渲染的关闭按钮 |
| 右边 | `WKModal` 在 `title=null` 且 `closable` 默认为 `true` 时自动渲染的自定义关闭按钮 |

`WKModal` 触发逻辑（`WKModal/index.tsx`）：
```ts
const needCustomCloseBtn = title === null && closable  // closable 默认 true
```

## 修复方案

在 `packages/dmworkcontacts/src/Contacts/index.tsx` 的 `WKModal` 调用处添加 `options={{ closable: false }}`，禁用 WKModal 层的冗余关闭按钮，保留 RoutePage 内部已有的关闭按钮。与 `dmworkbase/WKBase/index.tsx` 中同类弹窗的写法保持一致。