### PR TITLE
ci: improve GitHub Actions workflows for octo-web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      # TODO: Re-enable lint steps once package-level lint scripts are wired up
-      # See: https://github.com/Mininglamp-OSS/octo-web/pull/22
+      - name: Lint CSS
+        run: pnpm lint:css:ci
+      # TODO: Re-enable JS/TS lint once package-level lint scripts are wired up in Turbo
+      # (pnpm lint -> turbo run lint currently finds no tasks)
       - name: Build
         run: pnpm build
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build & Lint
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,3 +32,4 @@ jobs:
       # See: https://github.com/Mininglamp-OSS/octo-web/pull/22
       - name: Build
         run: pnpm build
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Lint
-        run: pnpm lint
-      - name: Lint CSS
-        run: pnpm lint:css:ci
+      # TODO: Re-enable lint steps once package-level lint scripts are wired up
+      # See: https://github.com/Mininglamp-OSS/octo-web/pull/22
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Lint CSS
+        run: pnpm lint:css:ci
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -17,6 +17,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Changes

### A1 — New CI workflow (`ci.yml`)

Adds a CI gate for the pnpm monorepo on push/PR to `main`.

- **Runtime:** Node.js 20 (Active LTS), pnpm 10.32.0 (matches `packageManager`)
- **Steps:** `pnpm install --frozen-lockfile` → `pnpm lint:css:ci` → `pnpm build`
- **CSS lint:** `pnpm lint:css:ci` runs stylelint with the CI config — a root-level script, no Turbo dependency
- **JS/TS lint deferred:** `pnpm lint` (turbo run lint) requires per-package `lint` scripts that are not yet defined; will be re-enabled as a follow-up
- `permissions: contents: read` — minimum required

### D — `pr-merged-done.yml`: add explicit `permissions: {}`

`GITHUB_TOKEN` is not used; only `PROJECT_TOKEN` is forwarded to the reusable workflow.