### PR TITLE
feat(voice): skip @mention recognition in DM — frontend changes

### DIFF
--- a/apps/web/src/__tests__/buildChatContext.test.ts
+++ b/apps/web/src/__tests__/buildChatContext.test.ts
@@ -8,6 +8,7 @@ import {
 
 const ChannelTypePerson = 1
 const ChannelTypeGroup = 2
+const ChannelTypeCommunityTopic = 5
 
 const LOGIN_UID = "me"
 
@@ -274,8 +275,8 @@ describe("buildChatContext", () => {
         })
     })
 
-    describe("DM (person) chat", () => {
-        it("should inject partner name from channelInfo title", () => {
+    describe("DM (person) chat — skip memberContext", () => {
+        it("should NOT produce memberContext for DM", () => {
             const channelInfo: ChatContextChannelInfo = { title: "Alice" }
             const result = buildChatContext({
                 messages: [],
@@ -284,13 +285,26 @@ describe("buildChatContext", () => {
                 loginUID: LOGIN_UID,
                 channelInfo,
             })
-            expect(result.memberContext).toBe("聊天成员：Alice")
-            expect(result.chatContext).toBeUndefined()
+            expect(result.memberContext).toBeUndefined()
+            expect(result.channelType).toBe(ChannelTypePerson)
         })
 
-        it("should inject both title and remark when different", () => {
+        it("should prepend channel label from channelInfo title", () => {
+            const channelInfo: ChatContextChannelInfo = { title: "Alice" }
+            const messages = [makeMessage("alice_uid", "hi", "Alice")]
+            const result = buildChatContext({
+                messages,
+                subscribers: [],
+                channelType: ChannelTypePerson,
+                loginUID: LOGIN_UID,
+                channelInfo,
+            })
+            expect(result.memberContext).toBeUndefined()
+            expect(result.chatContext).toBe("私聊「Alice」\n[Alice]: hi")
+        })
+
+        it("should use orgData.remark as fallback for channel label", () => {
             const channelInfo: ChatContextChannelInfo = {
-                title: "Alice",
                 orgData: { remark: "小A" },
             }
             const result = buildChatContext({
@@ -300,14 +314,14 @@ describe("buildChatContext", () => {
                 loginUID: LOGIN_UID,
                 channelInfo,
             })
-            expect(result.memberContext).toBe("聊天成员：Alice,小A")
-            expect(result.chatContext).toBeUndefined()
+            expect(result.memberContext).toBeUndefined()
+            expect(result.chatContext).toBe("私聊「小A」")
         })
 
-        it("should not duplicate when remark equals title", () => {
+        it("should treat whitespace-only title as empty and fall back to remark", () => {
             const channelInfo: ChatContextChannelInfo = {
-                title: "Alice",
-                orgData: { remark: "Alice" },
+                title: "  ",
+                orgData: { remark: "小A" },
             }
             const result = buildChatContext({
                 messages: [],
@@ -316,11 +330,11 @@ describe("buildChatContext", () => {
                 loginUID: LOGIN_UID,
                 channelInfo,
             })
-            expect(result.memberContext).toBe("聊天成员：Alice")
-            expect(result.chatContext).toBeUndefined()
+            expect(result.memberContext).toBeUndefined()
+            expect(result.chatContext).toBe("私聊「小A」")
         })
 
-        it("should handle missing channelInfo", () => {
+        it("should handle missing channelInfo (no label, no memberContext)", () => {
             const result = buildChatContext({
                 messages: [],
                 subscribers: [],
@@ -332,25 +346,12 @@ describe("buildChatContext", () => {
             expect(result.chatContext).toBeUndefined()
         })
 
-        it("should skip whitespace-only title", () => {
-            const channelInfo: ChatContextChannelInfo = {
-                title: "  ",
-                orgData: { remark: "Nickname" },
-            }
-            const result = buildChatContext({
-                messages: [],
-                subscribers: [],
-                channelType: ChannelTypePerson,
-                loginUID: LOGIN_UID,
-                channelInfo,
-            })
-            expect(result.memberContext).toBe("聊天成员：Nickname")
-            expect(result.chatContext).toBeUndefined()
-        })
-
-        it("should append messages after partner name", () => {
+        it("should still build chatContext messages for DM", () => {
             const channelInfo: ChatContextChannelInfo = { title: "Alice" }
-            const messages = [makeMessage("alice_uid", "hi", "Alice")]
+            const messages = [
+                makeMessage("alice_uid", "你好", "Alice"),
+                makeMessage(LOGIN_UID, "嗯嗯", "Me"),
+            ]
             const result = buildChatContext({
                 messages,
                 subscribers: [],
@@ -358,8 +359,8 @@ describe("buildChatContext", () => {
                 loginUID: LOGIN_UID,
                 channelInfo,
             })
-            expect(result.memberContext).toBe("聊天成员：Alice")
-            expect(result.chatContext).toBe("[Alice]: hi")
+            expect(result.memberContext).toBeUndefined()
+            expect(result.chatContext).toBe("私聊「Alice」\n[Alice]: 你好\n[Me]: 嗯嗯")
         })
     })
 
@@ -408,8 +409,6 @@ describe("buildChatContext", () => {
     })
 
     describe("thread (ChannelTypeCommunityTopic) chat", () => {
-        const ChannelTypeCommunityTopic = 5
-
         it("should collect all member names (same as group)", () => {
             const subscribers = [
                 makeMember("u1", "Alice"),
@@ -458,6 +457,108 @@ describe("buildChatContext", () => {
         })
     })
 
+    describe("channel label", () => {
+        it("DM: chatContext starts with 私聊 label, no memberContext", () => {
+            const channelInfo: ChatContextChannelInfo = { title: "张三" }
+            const messages = [makeMessage("zhangsan", "你好", "张三")]
+            const result = buildChatContext({
+                messages,
+                subscribers: [],
+                channelType: ChannelTypePerson,
+                loginUID: LOGIN_UID,
+                channelInfo,
+            })
+            expect(result.memberContext).toBeUndefined()
+            expect(result.chatContext).toBe("私聊「张三」\n[张三]: 你好")
+            expect(result.channelType).toBe(1)
+        })
+
+        it("Group: chatContext starts with 群聊 label, has memberContext", () => {
+            const subscribers = [
+                makeMember("u1", "Alice"),
+                makeMember("u2", "Bob"),
+            ]
+            const messages = [makeMessage("u1", "hi", "Alice")]
+            const result = buildChatContext({
+                messages,
+                subscribers,
+                channelType: ChannelTypeGroup,
+                loginUID: LOGIN_UID,
+                groupName: "产品组",
+            })
+            expect(result.memberContext).toBe("聊天成员：Alice,Bob")
+            expect(result.chatContext).toBe("群聊「产品组」\n[Alice]: hi")
+            expect(result.channelType).toBe(2)
+        })
+
+        it("Thread: chatContext starts with 群聊+子区 label, has memberContext", () => {
+            const subscribers = [
+                makeMember("u1", "Alice"),
+                makeMember("u2", "Bob"),
+            ]
+            const messages = [makeMessage("u1", "hey", "Alice")]
+            const result = buildChatContext({
+                messages,
+                subscribers,
+                channelType: ChannelTypeCommunityTopic,
+                loginUID: LOGIN_UID,
+                groupName: "产品组",
+                threadName: "UI设计",
+            })
+            expect(result.memberContext).toBe("聊天成员：Alice,Bob")
+            expect(result.chatContext).toBe("群聊「产品组」- 子区「UI设计」\n[Alice]: hey")
+            expect(result.channelType).toBe(5)
+        })
+
+        it("Thread: only threadName provided (no groupName)", () => {
+            const subscribers = [makeMember("u1", "Alice")]
+            const result = buildChatContext({
+                messages: [],
+                subscribers,
+                channelType: ChannelTypeCommunityTopic,
+                loginUID: LOGIN_UID,
+                threadName: "UI设计",
+            })
+            expect(result.chatContext).toBe("子区「UI设计」")
+        })
+
+        it("backward compat: no groupName → no label line for group", () => {
+            const subscribers = [makeMember("u1", "Alice")]
+            const messages = [makeMessage("u1", "hi", "Alice")]
+            const result = buildChatContext({
+                messages,
+                subscribers,
+                channelType: ChannelTypeGroup,
+                loginUID: LOGIN_UID,
+            })
+            expect(result.memberContext).toBe("聊天成员：Alice")
+            expect(result.chatContext).toBe("[Alice]: hi")
+        })
+
+        it("backward compat: no groupName/threadName → no label line for thread", () => {
+            const subscribers = [makeMember("u1", "Alice")]
+            const messages = [makeMessage("u1", "hi", "Alice")]
+            const result = buildChatContext({
+                messages,
+                subscribers,
+                channelType: ChannelTypeCommunityTopic,
+                loginUID: LOGIN_UID,
+            })
+            expect(result.memberContext).toBe("聊天成员：Alice")
+            expect(result.chatContext).toBe("[Alice]: hi")
+        })
+
+        it("channelType is always set in result", () => {
+            const result = buildChatContext({
+                messages: [],
+                subscribers: [],
+                channelType: ChannelTypeGroup,
+                loginUID: LOGIN_UID,
+            })
+            expect(result.channelType).toBe(2)
+        })
+    })
+
     describe("edge cases", () => {
         it("should return empty result when no subscribers and no messages", () => {
             const result = buildChatContext({
@@ -483,7 +584,7 @@ describe("buildChatContext", () => {
             expect(result.chatContext).toBe("[User1]: hello")
         })
 
-        it("should handle unknown channel type (no name injection)", () => {
+        it("should handle unknown channel type (no name injection, no label)", () => {
             const subscribers = [makeMember("u1", "Alice")]
             const messages = [makeMessage("u1", "hello", "Alice")]
             const result = buildChatContext({

--- a/apps/web/src/__tests__/useVoiceInput.test.ts
+++ b/apps/web/src/__tests__/useVoiceInput.test.ts
@@ -325,6 +325,91 @@ describe("useVoiceInput - getChatContext", () => {
     });
   });
 
+  it("should pass channelType=1 (DM) to VoiceService.transcribe", async () => {
+    const getChatContext = vi.fn().mockReturnValue({
+      channelType: 1,
+      chatContext: "私聊「Alice」\n[Alice]: hi",
+    });
+    vi.mocked(VoiceService.shared.transcribe).mockResolvedValue({
+      text: "transcribed",
+      m: "whisper-1",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceInput({
+        getChatContext,
+        onTranscribed: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      result.current.stopRecordingAndTranscribe("input text");
+      await vi.runAllTimersAsync();
+    });
+
+    expect(VoiceService.shared.transcribe).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "input text",
+      "私聊「Alice」\n[Alice]: hi",
+      undefined,
+      undefined,
+      "smart",
+      true,
+      1
+    );
+  });
+
+  it("should pass channelType=2 (group) to VoiceService.transcribe", async () => {
+    const getChatContext = vi.fn().mockReturnValue({
+      channelType: 2,
+      chatContext: "群聊「产品组」\n[Bob]: hey",
+      memberContext: "聊天成员：Bob",
+    });
+    vi.mocked(VoiceService.shared.transcribe).mockResolvedValue({
+      text: "transcribed",
+      m: "whisper-1",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceInput({
+        getChatContext,
+        onTranscribed: vi.fn(),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      result.current.stopRecordingAndTranscribe();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(VoiceService.shared.transcribe).toHaveBeenCalledWith(
+      expect.any(Blob),
+      undefined,
+      "群聊「产品组」\n[Bob]: hey",
+      undefined,
+      "聊天成员：Bob",
+      "smart",
+      true,
+      2
+    );
+  });
+
   it("should handle undefined getChatContext gracefully", async () => {
     const { result } = renderHook(() =>
       useVoiceInput({
@@ -516,7 +601,8 @@ describe("useVoiceInput - personal voice context", () => {
       "个人纠错词", // personalContext
       "聊天成员：Alice,Bob", // memberContext
       "smart", // mode
-      true // skipLocal
+      true, // skipLocal
+      undefined // channelType
     );
     expect(getChatContext).toHaveBeenCalled();
   });
@@ -557,7 +643,8 @@ describe("useVoiceInput - personal voice context", () => {
       undefined, // personalContext (has_context=false)
       "聊天成员：Alice,Bob", // memberContext
       "smart", // mode
-      true // skipLocal
+      true, // skipLocal
+      undefined // channelType
     );
     expect(getChatContext).toHaveBeenCalled();
   });
@@ -598,7 +685,8 @@ describe("useVoiceInput - personal voice context", () => {
       undefined, // personalContext (context 为空字符串，视为无)
       "聊天成员：Alice", // memberContext
       "smart", // mode
-      true // skipLocal
+      true, // skipLocal
+      undefined // channelType
     );
   });
 
@@ -635,7 +723,8 @@ describe("useVoiceInput - personal voice context", () => {
       undefined, // personalContext (API 失败，voiceContextRef 为 null)
       "聊天成员：Alice", // memberContext
       "smart", // mode
-      true // skipLocal
+      true, // skipLocal
+      undefined // channelType
     );
   });
 
@@ -694,7 +783,8 @@ describe("useVoiceInput - personal voice context", () => {
       "延迟到达的纠错词", // personalContext
       undefined, // memberContext (无 getChatContext)
       "smart", // mode
-      true // skipLocal
+      true, // skipLocal
+      undefined // channelType
     );
   });
 

--- a/packages/dmworkbase/src/Components/Conversation/chatContext.ts
+++ b/packages/dmworkbase/src/Components/Conversation/chatContext.ts
@@ -21,8 +21,9 @@ export interface ChatContextChannelInfo {
 }
 
 export interface ChatContextResult {
-    memberContext?: string   // "聊天成员：Alice,Bob"
-    chatContext?: string     // "[Alice]: hi\n[Bob]: hello"
+    memberContext?: string   // "聊天成员：Alice,Bob" — undefined for DM
+    chatContext?: string     // "[channel label]\n[Alice]: hi\n[Bob]: hello"
+    channelType?: number     // pass-through for VoiceService to send as channel_type
 }
 
 export function buildChatContext(params: {
@@ -31,11 +32,28 @@ export function buildChatContext(params: {
     channelType: number
     loginUID: string
     channelInfo?: ChatContextChannelInfo | null
+    groupName?: string
+    threadName?: string
 }): ChatContextResult {
-    const { messages, subscribers, channelType, loginUID, channelInfo } = params
+    const { messages, subscribers, channelType, loginUID, channelInfo, groupName, threadName } = params
     const names: string[] = []
 
-    if (channelType === ChannelTypeGroup || channelType === ChannelTypeCommunityTopic) {
+    const result: ChatContextResult = {
+        channelType: channelType,
+    }
+
+    let channelLabel = ''
+    if (channelType === ChannelTypePerson) {
+        const peerName = channelInfo?.title?.trim() || channelInfo?.orgData?.remark?.trim() || ''
+        if (peerName) {
+            channelLabel = `私聊「${peerName}」`
+        }
+    } else if (channelType === ChannelTypeCommunityTopic) {
+        const parts: string[] = []
+        if (groupName) parts.push(`群聊「${groupName}」`)
+        if (threadName) parts.push(`子区「${threadName}」`)
+        channelLabel = parts.join('- ') || ''
+
         if (subscribers.length <= 100) {
             for (const sub of subscribers) {
                 if (sub.uid === loginUID) continue
@@ -62,30 +80,65 @@ export function buildChatContext(params: {
                 }
             }
         }
-    } else if (channelType === ChannelTypePerson) {
-        if (channelInfo?.title?.trim()) names.push(channelInfo.title)
-        if (channelInfo?.orgData?.remark?.trim()
-            && channelInfo.orgData.remark !== channelInfo.title) {
-            names.push(channelInfo.orgData.remark)
+    } else {
+        if (groupName) {
+            channelLabel = `群聊「${groupName}」`
+        }
+
+        if (channelType === ChannelTypeGroup) {
+            if (subscribers.length <= 100) {
+                for (const sub of subscribers) {
+                    if (sub.uid === loginUID) continue
+                    if (sub.isDeleted) continue
+                    if (sub.name?.trim()) names.push(sub.name)
+                    if (sub.remark?.trim() && sub.remark !== sub.name) {
+                        names.push(sub.remark)
+                    }
+                }
+            } else {
+                const activeUIDs = new Set<string>()
+                for (let i = messages.length - 1; i >= 0 && activeUIDs.size < 100; i--) {
+                    const uid = messages[i].fromUID
+                    if (uid && uid !== loginUID) {
+                        activeUIDs.add(uid)
+                    }
+                }
+                for (const sub of subscribers) {
+                    if (activeUIDs.has(sub.uid) && !sub.isDeleted) {
+                        if (sub.name?.trim()) names.push(sub.name)
+                        if (sub.remark?.trim() && sub.remark !== sub.name) {
+                            names.push(sub.remark)
+                        }
+                    }
+                }
+            }
         }
     }
 
-    const uniqueNames = [...new Set(names)]
+    if (channelType !== ChannelTypePerson) {
+        const uniqueNames = [...new Set(names)]
+        if (uniqueNames.length > 0) {
+            result.memberContext = `聊天成员：${uniqueNames.join(",")}`
+        }
+    }
 
-    const result: ChatContextResult = {}
+    const chatLines: string[] = []
 
-    if (uniqueNames.length > 0) {
-        result.memberContext = `聊天成员：${uniqueNames.join(",")}`
+    if (channelLabel) {
+        chatLines.push(channelLabel)
     }
 
     if (messages && messages.length > 0) {
         const last10 = messages.slice(-10)
-        const lines = last10.map(m => {
+        for (const m of last10) {
             const senderName = m.from?.title || m.fromUID
             const text = m.content?.text || ''
-            return `[${senderName}]: ${text}`
-        })
-        result.chatContext = lines.join('\n')
+            chatLines.push(`[${senderName}]: ${text}`)
+        }
+    }
+
+    if (chatLines.length > 0) {
+        result.chatContext = chatLines.join('\n')
     }
 
     return result

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -69,6 +69,7 @@ import { downloadFile } from "../../Utils/download";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
+import { parseThreadChannelId } from "../../Service/Thread";
 import FoldSessionExpandedList from "./FoldSessionExpandedList";
 
 /**
@@ -2228,6 +2229,24 @@ export class Conversation
                       getChatContext={async () => {
                         const { channel } = this.props;
                         await this.vm.ensureSubscribersLoaded();
+
+                        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+                        let groupName: string | undefined;
+                        let threadName: string | undefined;
+
+                        if (channel.channelType === ChannelTypeCommunityTopic) {
+                          threadName = channelInfo?.title;
+                          const parsed = parseThreadChannelId(channel.channelID);
+                          if (parsed) {
+                            const parentInfo = WKSDK.shared().channelManager.getChannelInfo(
+                              new Channel(parsed.groupNo, ChannelTypeGroup)
+                            );
+                            groupName = parentInfo?.title;
+                          }
+                        } else if (channel.channelType === ChannelTypeGroup) {
+                          groupName = channelInfo?.title;
+                        }
+
                         return buildChatContext({
                           messages: this.vm.messagesOfOrigin || [],
                           subscribers: this.vm.subscribers,
@@ -2239,6 +2258,8 @@ export class Conversation
                                   channel,
                                 ) as ChatContextChannelInfo | null)
                               : undefined,
+                          groupName,
+                          threadName,
                         });
                       }}
                       onSend={async (

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
@@ -329,7 +329,8 @@ export default function useVoiceInput(
               personalContext,
               memberContext,
               recordingModeRef.current,
-              true
+              true,
+              chatCtxResult.channelType,
             );
             if (result.text && onTranscribed) {
               onTranscribed(result.text);
@@ -367,7 +368,8 @@ export default function useVoiceInput(
             personalContext,
             memberContext,
             recordingModeRef.current,
-            true
+            true,
+            chatCtxResult.channelType,
           );
           if (result.text && onTranscribed) {
             onTranscribed(result.text);

--- a/packages/dmworkbase/src/Service/VoiceService.ts
+++ b/packages/dmworkbase/src/Service/VoiceService.ts
@@ -56,7 +56,8 @@ export default class VoiceService {
     personalContext?: string,
     memberContext?: string,
     mode?: VoiceMode,
-    skipLocal?: boolean
+    skipLocal?: boolean,
+    channelType?: number,
   ): Promise<TranscribeResult> {
     if (!skipLocal) {
       const localResult = await LocalModelService.shared.transcribe(audio, contextText, chatContext, personalContext, memberContext, mode);
@@ -82,6 +83,9 @@ export default class VoiceService {
     }
     if (mode) {
       formData.append("mode", mode);
+    }
+    if (channelType !== undefined) {
+      formData.append("channel_type", String(channelType));
     }
     return APIClient.shared.post("/voice/transcribe", formData);
   }


### PR DESCRIPTION
## Summary

Frontend counterpart for Mininglamp-OSS/octo-server#10. When the conversation is a DM (private chat), the frontend:
1. Skips building `member_context` (no @mention candidates in DM)
2. Prepends a channel label to `chat_context` (e.g. `私聊「张三」`, `群聊「产品组」`, `群聊「产品组」- 子区「UI设计」`)
3. Sends `channel_type=1` to the backend API to trigger server-side @mention skip

## Changes

### `chatContext.ts`
- Add `channelType` to `ChatContextResult`
- Accept `groupName`/`threadName` params in `buildChatContext`
- DM (`channelType=1`): skip `memberContext`, build `私聊「peerName」` label
- Group (`channelType=2`): build `群聊「groupName」` label, keep memberContext
- Thread (`channelType=5`): build `群聊「xxx」- 子区「yyy」` label
- Prepend label as first line of `chatContext`

### `VoiceService.ts`
- Add `channelType` param to `transcribe()`, sent as `channel_type` form field

### `useVoiceInput.ts`
- Pass `channelType` from `ChatContextResult` to both `transcribe` call sites

### `Conversation/index.tsx`
- Resolve `groupName`/`threadName` using channel info and `parseThreadChannelId`

### Tests
- 73 tests passing (buildChatContext + useVoiceInput + voiceService)
- Tests cover DM/Group/Thread label generation, memberContext skip, channelType passthrough

## Backward Compatibility
- All new params are optional — omitting them produces identical behavior to current code
- `channelType` not sent → backend defaults to `"2"` (group) with full @mention

Closes Mininglamp-OSS/octo-server#10