### PR TITLE
ci: add auto-add-to-project caller workflow

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,16 @@
+# Automatically add new issues and PRs to the org-level GitHub Project.
+name: Auto add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  add-to-project:
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -11,6 +11,6 @@ permissions: {}
 
 jobs:
   add-to-project:
-    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@239d0b47cfe1947d5e6de826e795feac4ed90562
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Add `auto-add-to-project.yml` caller workflow: automatically adds new issues and PRs to [Octo Board (Project #2)](https://github.com/orgs/Mininglamp-OSS/projects/2) when they are opened.

Calls the org-level reusable workflow at `Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main`.

## Dependency

Requires [Mininglamp-OSS/.github#12](https://github.com/Mininglamp-OSS/.github/pull/12) to be merged first.