### PR TITLE
fix(matter): smart create modal - fix duplicate creation + UX improvements

### DIFF
--- a/packages/dmworkbase/src/Messages/Mergeforward/index.css
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.css
@@ -125,29 +125,3 @@
 }
 
 
-
-/* ── 返回按钮（嵌套合并转发导航） ── */
-.wk-mergeforward-modal-title-with-back {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wk-sp-2, 8px);
-}
-
-.wk-mergeforward-modal-back-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border: none;
-    background: none;
-    border-radius: var(--wk-r-sm, 6px);
-    cursor: pointer;
-    color: var(--wk-text-secondary);
-    transition: background 0.15s, color 0.15s;
-}
-
-.wk-mergeforward-modal-back-btn:hover {
-    background: var(--wk-bg-hover, rgba(28, 28, 35, 0.06));
-    color: var(--wk-text-primary);
-}

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.css
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.css
@@ -125,3 +125,29 @@
 }
 
 
+
+/* ── 返回按钮（嵌套合并转发导航） ── */
+.wk-mergeforward-modal-title-with-back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wk-sp-2, 8px);
+}
+
+.wk-mergeforward-modal-back-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: none;
+    border-radius: var(--wk-r-sm, 6px);
+    cursor: pointer;
+    color: var(--wk-text-secondary);
+    transition: background 0.15s, color 0.15s;
+}
+
+.wk-mergeforward-modal-back-btn:hover {
+    background: var(--wk-bg-hover, rgba(28, 28, 35, 0.06));
+    color: var(--wk-text-primary);
+}

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -18,6 +18,7 @@
   --wk-brand-gradient: var(--wk-brand-primary); /* 兼容：6+ 处引用，值=纯色 */
   --wk-brand-gradient-hover: var(--wk-brand-primary-hover);
   --wk-brand-gradient-subtle: rgba(28, 28, 35, 0.08);
+  --wk-brand-primary-ring: rgba(28, 28, 35, 0.2);
   --wk-brand-glow: rgba(28, 28, 35, 0.2);
 
   /* ── AI 功能色 / 链接色（紫色，仅用于 AI 相关元素） ── */
@@ -185,6 +186,7 @@
   --wk-text-primary: var(--wk-neutral-800); /* Figma: #1F2329 标题/组织名 */
   --wk-text-secondary: var(--wk-neutral-400); /* Figma: #555B61 */
   --wk-text-tertiary: var(--wk-neutral-300); /* Figma: #6B7075 */
+  --wk-text-disabled: var(--wk-neutral-200); /* 禁用态文字 */
   --wk-text-accent: var(
     --wk-purple-500
   ); /* Figma: #7F3BF5 AI链接/Thread（紫色点缀） */
@@ -271,6 +273,7 @@ body[theme-mode="dark"] {
   --wk-text-primary: #e4e6ed;
   --wk-text-secondary: var(--wk-neutral-300);
   --wk-text-tertiary: #7a7f96;
+  --wk-text-disabled: var(--wk-neutral-500); /* 暗色禁用态文字 */
   --wk-text-accent: var(--wk-purple-400); /* 暗色下用浅紫 */
   --wk-text-inverse: var(--wk-neutral-900);
 

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -656,6 +656,8 @@ function GlobalSmartCreateModal() {
   const extractedMatterIdRef = React.useRef<string | null>(null);
   // 标记弹窗是否已关闭，防止 extractMatter 异步返回后产生孤儿
   const closedRef = React.useRef(false);
+  // 每次打开递增的 session token，防止 overlapping requests 竞态
+  const sessionRef = React.useRef(0);
 
   useEffect(() => {
     const handler = async (data?: {
@@ -673,6 +675,8 @@ function GlobalSmartCreateModal() {
       setAiResult(undefined);
       extractedMatterIdRef.current = null;
       closedRef.current = false;
+      sessionRef.current += 1;
+      const currentSession = sessionRef.current;
       setOpen(true);
 
       if (currentMessages.length > 0 && currentChannel) {
@@ -691,8 +695,8 @@ function GlobalSmartCreateModal() {
               attachments: m.attachments || [],
             })),
           });
-          // 用户在 extractMatter 期间关闭了弹窗 → 立即清理孤儿
-          if (closedRef.current) {
+          // 用户在 extractMatter 期间关闭了弹窗，或已开启新 session → 立即清理孤儿
+          if (closedRef.current || sessionRef.current !== currentSession) {
             try { await deleteMatter(res.id); } catch {}
             return;
           }

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -14,6 +14,9 @@ import {
   extractMatter,
   updateMatter,
   addAssignee,
+  removeAssignee,
+  getMatter,
+  deleteMatter,
   listMatters,
   addTimelineEntry,
 } from "./api/todoApi";
@@ -727,7 +730,14 @@ function GlobalSmartCreateModal() {
         content: m.content || "",
         attachments: m.attachments || [],
       })) : undefined}
-      onClose={() => setOpen(false)}
+      onClose={async () => {
+        setOpen(false);
+        // P0: 用户关闭弹窗不确认时，清理 extractMatter 已创建的孤儿事项
+        if (extractedMatterId) {
+          try { await deleteMatter(extractedMatterId); } catch {}
+          setExtractedMatterId(null);
+        }
+      }}
       onConfirm={async (req) => {
         if (extractedMatterId) {
           // 后端在 extractMatter 时已创建事项，这里执行编辑
@@ -736,17 +746,21 @@ function GlobalSmartCreateModal() {
             description: req.description,
             deadline: req.deadline,
           });
-          // 添加负责人
-          if (req.assignee_ids && req.assignee_ids.length > 0) {
-            await Promise.all(
-              req.assignee_ids.map((uid) => addAssignee(extractedMatterId, uid))
-            );
-          }
+          // 负责人 reconcile：对比当前 assignees，计算 add/remove
+          const detail = await getMatter(extractedMatterId);
+          const currentUids = new Set((detail.assignees || []).map(a => a.user_id));
+          const desiredUids = new Set(req.assignee_ids || []);
+          const toAdd = [...desiredUids].filter(uid => !currentUids.has(uid));
+          const toRemove = [...currentUids].filter(uid => !desiredUids.has(uid));
+          await Promise.allSettled([
+            ...toAdd.map(uid => addAssignee(extractedMatterId, uid)),
+            ...toRemove.map(uid => removeAssignee(extractedMatterId, uid)),
+          ]);
         } else {
           // 空白新建模式（无 AI 提取），走正常创建流程
           await createMatter(req);
         }
-        Toast.success("事项已创建");
+        Toast.success("事项已确认");
         WKApp.mittBus.emit("wk:exit-multiple-mode");
       }}
       channel={channel}

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -746,6 +746,7 @@ function GlobalSmartCreateModal() {
 
   return (
     <SmartCreateModal
+      key={sessionRef.current}
       visible={open}
       blank={messages.length === 0}
       count={messages.length}
@@ -760,6 +761,8 @@ function GlobalSmartCreateModal() {
         attachments: m.attachments || [],
       })) : undefined}
       onClose={async () => {
+        // 提交中不允许关闭（防止 Escape/native cancel 在 confirm 期间触发 delete）
+        if (submittingRef.current) return;
         // 用户主动取消：关闭弹窗 + 清理孤儿事项
         closedRef.current = true;
         setOpen(false);

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -673,6 +673,7 @@ function GlobalSmartCreateModal() {
       setChannel(currentChannel);
       setMessages(currentMessages);
       setAiResult(undefined);
+      setAiLoading(false);
       extractedMatterIdRef.current = null;
       closedRef.current = false;
       sessionRef.current += 1;
@@ -697,7 +698,7 @@ function GlobalSmartCreateModal() {
           });
           // 用户在 extractMatter 期间关闭了弹窗，或已开启新 session → 立即清理孤儿
           if (closedRef.current || sessionRef.current !== currentSession) {
-            try { await deleteMatter(res.id); } catch {}
+            try { await deleteMatter(res.id); } catch (e) { console.warn('[SmartCreate] orphan cleanup failed:', res.id, e); }
             return;
           }
           extractedMatterIdRef.current = res.id;
@@ -753,7 +754,7 @@ function GlobalSmartCreateModal() {
         const idToDelete = extractedMatterIdRef.current;
         extractedMatterIdRef.current = null;
         if (idToDelete) {
-          try { await deleteMatter(idToDelete); } catch {}
+          try { await deleteMatter(idToDelete); } catch (e) { console.warn('[SmartCreate] cancel cleanup failed:', idToDelete, e); }
         }
       }}
       onConfirmSuccess={() => {

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -715,9 +715,13 @@ function GlobalSmartCreateModal() {
               : undefined,
           });
         } catch (e) {
-          Toast.error("AI 提取失败，请手动填写");
+          if (sessionRef.current === currentSession) {
+            Toast.error("AI 提取失败，请手动填写");
+          }
         } finally {
-          setAiLoading(false);
+          if (sessionRef.current === currentSession) {
+            setAiLoading(false);
+          }
         }
       }
     };

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -12,6 +12,8 @@ import SmartCreateModal from "./ui/SmartCreateModal";
 import {
   createMatter,
   extractMatter,
+  updateMatter,
+  addAssignee,
   listMatters,
   addTimelineEntry,
 } from "./api/todoApi";
@@ -647,6 +649,8 @@ function GlobalSmartCreateModal() {
   const [aiResult, setAiResult] = useState<
     { title?: string; description?: string; deadline?: string } | undefined
   >();
+  // extractMatter 已在后端创建事项，保存其 ID 用于后续编辑
+  const [extractedMatterId, setExtractedMatterId] = useState<string | null>(null);
 
   useEffect(() => {
     const handler = async (data?: {
@@ -662,6 +666,7 @@ function GlobalSmartCreateModal() {
       setChannel(currentChannel);
       setMessages(currentMessages);
       setAiResult(undefined);
+      setExtractedMatterId(null);
       setOpen(true);
 
       if (currentMessages.length > 0 && currentChannel) {
@@ -680,6 +685,7 @@ function GlobalSmartCreateModal() {
               attachments: m.attachments || [],
             })),
           });
+          setExtractedMatterId(res.id);
           setAiResult({
             title: res.title,
             description: res.description,
@@ -723,7 +729,23 @@ function GlobalSmartCreateModal() {
       })) : undefined}
       onClose={() => setOpen(false)}
       onConfirm={async (req) => {
-        await createMatter(req);
+        if (extractedMatterId) {
+          // 后端在 extractMatter 时已创建事项，这里执行编辑
+          await updateMatter(extractedMatterId, {
+            title: req.title,
+            description: req.description,
+            deadline: req.deadline,
+          });
+          // 添加负责人
+          if (req.assignee_ids && req.assignee_ids.length > 0) {
+            await Promise.all(
+              req.assignee_ids.map((uid) => addAssignee(extractedMatterId, uid))
+            );
+          }
+        } else {
+          // 空白新建模式（无 AI 提取），走正常创建流程
+          await createMatter(req);
+        }
         Toast.success("事项已创建");
         WKApp.mittBus.emit("wk:exit-multiple-mode");
       }}

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -660,6 +660,8 @@ function GlobalSmartCreateModal() {
   const sessionRef = React.useRef(0);
   // 标记是否正在提交（confirm 在飞），防止新 session 删除正在保存的 matter
   const submittingRef = React.useRef(false);
+  // 记录发起 confirm 的 session，onConfirmSuccess 只在匹配时生效
+  const confirmSessionRef = React.useRef(0);
 
   useEffect(() => {
     const handler = async (data?: {
@@ -768,13 +770,15 @@ function GlobalSmartCreateModal() {
         }
       }}
       onConfirmSuccess={() => {
-        // 确认成功：关闭弹窗，不删除事项
+        // 确认成功：仅当仍是发起 confirm 的 session 时才关闭弹窗
+        if (confirmSessionRef.current !== sessionRef.current) return;
         closedRef.current = true;
         extractedMatterIdRef.current = null;
         setOpen(false);
         WKApp.mittBus.emit("wk:exit-multiple-mode");
       }}
       onConfirm={async (req) => {
+        confirmSessionRef.current = sessionRef.current;
         submittingRef.current = true;
         try {
           const matterId = extractedMatterIdRef.current;

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -779,11 +779,13 @@ function GlobalSmartCreateModal() {
           const desiredUids = new Set(req.assignee_ids || []);
           const toAdd = [...desiredUids].filter(uid => !currentUids.has(uid));
           const toRemove = [...currentUids].filter(uid => !desiredUids.has(uid));
-          const results = await Promise.allSettled([
-            ...toAdd.map(uid => addAssignee(matterId, uid)),
-            ...toRemove.map(uid => removeAssignee(matterId, uid)),
-          ]);
-          const failed = results.filter(r => r.status === "rejected");
+          // 使用 Promise.all + catch 模式（兼容 es2019 target）
+          const ops = [
+            ...toAdd.map(uid => addAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
+            ...toRemove.map(uid => removeAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
+          ];
+          const results = await Promise.all(ops);
+          const failed = results.filter(r => r !== null);
           if (failed.length > 0) {
             // 负责人是必填字段，reconcile 失败时 reject 让 modal 保持打开
             Toast.error("负责人更新失败，请重试");

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -798,7 +798,7 @@ function GlobalSmartCreateModal() {
             Toast.error("负责人更新失败，请重试");
             throw new Error("assignee reconciliation failed");
           }
-          Toast.success("事项已确认");
+          Toast.success("事项已保存");
         } else {
           // 空白新建模式（无 AI 提取），走正常创建流程
           await createMatter(req);

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -784,10 +784,11 @@ function GlobalSmartCreateModal() {
           ]);
           const failed = results.filter(r => r.status === "rejected");
           if (failed.length > 0) {
-            Toast.warning("事项已确认，部分负责人未能更新");
-          } else {
-            Toast.success("事项已确认");
+            // 负责人是必填字段，reconcile 失败时 reject 让 modal 保持打开
+            Toast.error("负责人更新失败，请重试");
+            throw new Error("assignee reconciliation failed");
           }
+          Toast.success("事项已确认");
         } else {
           // 空白新建模式（无 AI 提取），走正常创建流程
           await createMatter(req);

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -809,6 +809,9 @@ function GlobalSmartCreateModal() {
               Toast.error("负责人更新失败，请重试");
               throw new Error("assignee reconciliation failed");
             }
+            // Matter 已完整保存 — 立即清除 orphan 追踪，防止并发新 session
+            // 在 submittingRef=false 和 onConfirmSuccess 之间的微任务窗口误删
+            extractedMatterIdRef.current = null;
             Toast.success("事项已保存");
           } else {
             // 空白新建模式（无 AI 提取），走正常创建流程

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -652,8 +652,10 @@ function GlobalSmartCreateModal() {
   const [aiResult, setAiResult] = useState<
     { title?: string; description?: string; deadline?: string } | undefined
   >();
-  // extractMatter 已在后端创建事项，保存其 ID 用于后续编辑
-  const [extractedMatterId, setExtractedMatterId] = useState<string | null>(null);
+  // 使用 ref 存储 extractedMatterId，避免闭包竞态
+  const extractedMatterIdRef = React.useRef<string | null>(null);
+  // 标记弹窗是否已关闭，防止 extractMatter 异步返回后产生孤儿
+  const closedRef = React.useRef(false);
 
   useEffect(() => {
     const handler = async (data?: {
@@ -669,7 +671,8 @@ function GlobalSmartCreateModal() {
       setChannel(currentChannel);
       setMessages(currentMessages);
       setAiResult(undefined);
-      setExtractedMatterId(null);
+      extractedMatterIdRef.current = null;
+      closedRef.current = false;
       setOpen(true);
 
       if (currentMessages.length > 0 && currentChannel) {
@@ -688,13 +691,18 @@ function GlobalSmartCreateModal() {
               attachments: m.attachments || [],
             })),
           });
-          setExtractedMatterId(res.id);
+          // 用户在 extractMatter 期间关闭了弹窗 → 立即清理孤儿
+          if (closedRef.current) {
+            try { await deleteMatter(res.id); } catch {}
+            return;
+          }
+          extractedMatterIdRef.current = res.id;
           setAiResult({
             title: res.title,
             description: res.description,
             deadline: res.deadline
               ? new Date(
-                  String(res.deadline).length === 10
+                  res.deadline < 1e12
                     ? (res.deadline as number) * 1000
                     : res.deadline,
                 )
@@ -731,37 +739,52 @@ function GlobalSmartCreateModal() {
         attachments: m.attachments || [],
       })) : undefined}
       onClose={async () => {
+        // 用户主动取消：关闭弹窗 + 清理孤儿事项
+        closedRef.current = true;
         setOpen(false);
-        // P0: 用户关闭弹窗不确认时，清理 extractMatter 已创建的孤儿事项
-        if (extractedMatterId) {
-          try { await deleteMatter(extractedMatterId); } catch {}
-          setExtractedMatterId(null);
+        const idToDelete = extractedMatterIdRef.current;
+        extractedMatterIdRef.current = null;
+        if (idToDelete) {
+          try { await deleteMatter(idToDelete); } catch {}
         }
       }}
+      onConfirmSuccess={() => {
+        // 确认成功：关闭弹窗，不删除事项
+        closedRef.current = true;
+        extractedMatterIdRef.current = null;
+        setOpen(false);
+        WKApp.mittBus.emit("wk:exit-multiple-mode");
+      }}
       onConfirm={async (req) => {
-        if (extractedMatterId) {
+        const matterId = extractedMatterIdRef.current;
+        if (matterId) {
           // 后端在 extractMatter 时已创建事项，这里执行编辑
-          await updateMatter(extractedMatterId, {
+          await updateMatter(matterId, {
             title: req.title,
             description: req.description,
             deadline: req.deadline,
           });
           // 负责人 reconcile：对比当前 assignees，计算 add/remove
-          const detail = await getMatter(extractedMatterId);
+          const detail = await getMatter(matterId);
           const currentUids = new Set((detail.assignees || []).map(a => a.user_id));
           const desiredUids = new Set(req.assignee_ids || []);
           const toAdd = [...desiredUids].filter(uid => !currentUids.has(uid));
           const toRemove = [...currentUids].filter(uid => !desiredUids.has(uid));
-          await Promise.allSettled([
-            ...toAdd.map(uid => addAssignee(extractedMatterId, uid)),
-            ...toRemove.map(uid => removeAssignee(extractedMatterId, uid)),
+          const results = await Promise.allSettled([
+            ...toAdd.map(uid => addAssignee(matterId, uid)),
+            ...toRemove.map(uid => removeAssignee(matterId, uid)),
           ]);
+          const failed = results.filter(r => r.status === "rejected");
+          if (failed.length > 0) {
+            Toast.warning("事项已确认，部分负责人未能更新");
+          } else {
+            Toast.success("事项已确认");
+          }
         } else {
           // 空白新建模式（无 AI 提取），走正常创建流程
           await createMatter(req);
+          Toast.success("事项已创建");
         }
-        Toast.success("事项已确认");
-        WKApp.mittBus.emit("wk:exit-multiple-mode");
       }}
       channel={channel}
     />

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -658,6 +658,8 @@ function GlobalSmartCreateModal() {
   const closedRef = React.useRef(false);
   // 每次打开递增的 session token，防止 overlapping requests 竞态
   const sessionRef = React.useRef(0);
+  // 标记是否正在提交（confirm 在飞），防止新 session 删除正在保存的 matter
+  const submittingRef = React.useRef(false);
 
   useEffect(() => {
     const handler = async (data?: {
@@ -675,8 +677,9 @@ function GlobalSmartCreateModal() {
       setAiResult(undefined);
       setAiLoading(false);
       // 清理上一个 session 遗留的已创建但未确认的 matter
+      // 如果当前正在 submitting，不删除（confirm 正在使用这个 matter）
       const prevMatterId = extractedMatterIdRef.current;
-      if (prevMatterId) {
+      if (prevMatterId && !submittingRef.current) {
         deleteMatter(prevMatterId).catch((e) => console.warn('[SmartCreate] prev session cleanup failed:', prevMatterId, e));
       }
       extractedMatterIdRef.current = null;
@@ -772,37 +775,41 @@ function GlobalSmartCreateModal() {
         WKApp.mittBus.emit("wk:exit-multiple-mode");
       }}
       onConfirm={async (req) => {
-        const matterId = extractedMatterIdRef.current;
-        if (matterId) {
-          // 后端在 extractMatter 时已创建事项，这里执行编辑
-          await updateMatter(matterId, {
-            title: req.title,
-            description: req.description,
-            deadline: req.deadline,
-          });
-          // 负责人 reconcile：对比当前 assignees，计算 add/remove
-          const detail = await getMatter(matterId);
-          const currentUids = new Set((detail.assignees || []).map(a => a.user_id));
-          const desiredUids = new Set(req.assignee_ids || []);
-          const toAdd = [...desiredUids].filter(uid => !currentUids.has(uid));
-          const toRemove = [...currentUids].filter(uid => !desiredUids.has(uid));
-          // 使用 Promise.all + catch 模式（兼容 es2019 target）
-          const ops = [
-            ...toAdd.map(uid => addAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
-            ...toRemove.map(uid => removeAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
-          ];
-          const results = await Promise.all(ops);
-          const failed = results.filter(r => r !== null);
-          if (failed.length > 0) {
-            // 负责人是必填字段，reconcile 失败时 reject 让 modal 保持打开
-            Toast.error("负责人更新失败，请重试");
-            throw new Error("assignee reconciliation failed");
+        submittingRef.current = true;
+        try {
+          const matterId = extractedMatterIdRef.current;
+          if (matterId) {
+            // 后端在 extractMatter 时已创建事项，这里执行编辑
+            await updateMatter(matterId, {
+              title: req.title,
+              description: req.description,
+              deadline: req.deadline,
+            });
+            // 负责人 reconcile：对比当前 assignees，计算 add/remove
+            const detail = await getMatter(matterId);
+            const currentUids = new Set((detail.assignees || []).map(a => a.user_id));
+            const desiredUids = new Set(req.assignee_ids || []);
+            const toAdd = [...desiredUids].filter(uid => !currentUids.has(uid));
+            const toRemove = [...currentUids].filter(uid => !desiredUids.has(uid));
+            // 使用 Promise.all + catch 模式（兼容 es2019 target）
+            const ops = [
+              ...toAdd.map(uid => addAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
+              ...toRemove.map(uid => removeAssignee(matterId, uid).then(() => null).catch((e: any) => e)),
+            ];
+            const results = await Promise.all(ops);
+            const failed = results.filter(r => r !== null);
+            if (failed.length > 0) {
+              Toast.error("负责人更新失败，请重试");
+              throw new Error("assignee reconciliation failed");
+            }
+            Toast.success("事项已保存");
+          } else {
+            // 空白新建模式（无 AI 提取），走正常创建流程
+            await createMatter(req);
+            Toast.success("事项已创建");
           }
-          Toast.success("事项已保存");
-        } else {
-          // 空白新建模式（无 AI 提取），走正常创建流程
-          await createMatter(req);
-          Toast.success("事项已创建");
+        } finally {
+          submittingRef.current = false;
         }
       }}
       channel={channel}

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -674,6 +674,11 @@ function GlobalSmartCreateModal() {
       setMessages(currentMessages);
       setAiResult(undefined);
       setAiLoading(false);
+      // 清理上一个 session 遗留的已创建但未确认的 matter
+      const prevMatterId = extractedMatterIdRef.current;
+      if (prevMatterId) {
+        deleteMatter(prevMatterId).catch((e) => console.warn('[SmartCreate] prev session cleanup failed:', prevMatterId, e));
+      }
       extractedMatterIdRef.current = null;
       closedRef.current = false;
       sessionRef.current += 1;

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -710,6 +710,7 @@ function GlobalSmartCreateModal() {
           setAiResult({
             title: res.title,
             description: res.description,
+            // deadline: 值 < 1e12 为 unix 秒，>= 1e12 为 unix 毫秒
             deadline: res.deadline
               ? new Date(
                   res.deadline < 1e12
@@ -721,11 +722,12 @@ function GlobalSmartCreateModal() {
               : undefined,
           });
         } catch (e) {
-          if (sessionRef.current === currentSession) {
+          // 仅当用户未关闭弹窗且仍在当前 session 时才弹 toast
+          if (sessionRef.current === currentSession && !closedRef.current) {
             Toast.error("AI 提取失败，请手动填写");
           }
         } finally {
-          if (sessionRef.current === currentSession) {
+          if (sessionRef.current === currentSession && !closedRef.current) {
             setAiLoading(false);
           }
         }

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -7,12 +7,29 @@
   --semi-modal-body-wrapper-margin: 0;
 }
 
+/* 强制覆盖 Semi Modal 内部间距 */
+.wk-smart-create-modal .semi-modal-content {
+  padding: 0 !important;
+  overflow: visible !important;
+}
+
+.wk-smart-create-modal .semi-modal-body {
+  padding: 0 !important;
+  overflow: visible !important;
+}
+
+.wk-smart-create-modal .semi-modal-body-wrapper {
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: visible !important;
+}
+
 .wk-smart-create-modal__content {
-  padding: 24px;
+  padding: 20px;
 }
 
 .wk-smart-create-modal__head {
-  margin-bottom: var(--wk-sp-4, 16px);
+  margin-bottom: 14px;
 }
 
 .wk-smart-create-modal__title {
@@ -38,7 +55,7 @@
 }
 
 .wk-smart-create-modal__field {
-  margin-bottom: var(--wk-sp-3, 12px);
+  margin-bottom: 10px;
 }
 
 .wk-smart-create-modal__label {
@@ -124,7 +141,7 @@
   display: flex;
   justify-content: flex-end;
   gap: var(--wk-sp-2, 8px);
-  margin-top: var(--wk-sp-4, 16px);
+  margin-top: 12px;
 }
 
 .wk-smart-create-modal__btn {
@@ -166,5 +183,5 @@
 
 .wk-smart-create-modal__footer-sep {
   border-top: 1px solid var(--wk-border-default, #e4e4e7);
-  margin-top: var(--wk-sp-4, 16px);
+  margin-top: 12px;
 }

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -1,70 +1,53 @@
 /* ─── SmartCreateModal 样式 ───────────────────────────── */
 
-/* 通过组件根节点覆盖 Semi Token 控制内边距 */
+/* 通过 Semi CSS 变量控制内边距（不使用 !important，不直接覆盖 Semi 内部类） */
 .wk-smart-create-modal {
   --semi-modal-content-padding: 0;
   --semi-modal-header-margin: 0;
   --semi-modal-body-wrapper-margin: 0;
 }
 
-/* 强制覆盖 Semi Modal 内部间距 */
-.wk-smart-create-modal .semi-modal-content {
-  padding: 0 !important;
-  overflow: visible !important;
-}
-
-.wk-smart-create-modal .semi-modal-body {
-  padding: 0 !important;
-  overflow: visible !important;
-}
-
-.wk-smart-create-modal .semi-modal-body-wrapper {
-  margin: 0 !important;
-  padding: 0 !important;
-  overflow: visible !important;
-}
-
 .wk-smart-create-modal__content {
-  padding: 20px;
+  padding: var(--wk-sp-5, 20px);
 }
 
 .wk-smart-create-modal__head {
-  margin-bottom: 14px;
+  margin-bottom: var(--wk-sp-3, 12px);
 }
 
 .wk-smart-create-modal__title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--wk-text-primary, #1a1a1a);
+  color: var(--wk-text-primary);
   margin: 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--wk-sp-2, 8px);
   letter-spacing: -0.01em;
 }
 
 .wk-smart-create-modal__spark {
-  color: var(--wk-text-primary, #1a1a1a);
+  color: var(--wk-text-primary);
 }
 
 .wk-smart-create-modal__sub {
   font-size: 12px;
-  color: var(--wk-text-secondary, #666);
-  margin-top: 4px;
+  color: var(--wk-text-secondary);
+  margin-top: var(--wk-sp-1, 4px);
   line-height: 1.5;
 }
 
 .wk-smart-create-modal__field {
-  margin-bottom: 10px;
+  margin-bottom: var(--wk-sp-2, 8px);
 }
 
 .wk-smart-create-modal__label {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--wk-sp-1, 4px);
   font-size: 12px;
   font-weight: 500;
-  color: var(--wk-text-primary, #1a1a1a);
+  color: var(--wk-text-primary);
   margin-bottom: var(--wk-sp-1, 6px);
 }
 
@@ -74,61 +57,49 @@
 
 .wk-smart-create-modal__input {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--wk-border-default, #e5e5e5);
-  border-radius: 6px;
+  padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-sm, 6px);
   font-size: 13px;
-  background: var(--wk-bg-surface, #fff);
-  color: var(--wk-text-primary, #1a1a1a);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
   outline: none;
   box-sizing: border-box;
-  transition:
-    border-color 150ms,
-    box-shadow 150ms;
+  transition: border-color 150ms, box-shadow 150ms;
 }
 
 .wk-smart-create-modal__input:focus {
-  border-color: var(--wk-text-primary, #18181b);
-  box-shadow: 0 0 0 3px rgba(24, 24, 27, 0.08);
-}
-
-.wk-smart-create-modal__input:focus {
-  border-color: var(--wk-brand-primary, #7c5cfc);
+  border-color: var(--wk-brand-primary);
+  box-shadow: 0 0 0 3px rgba(124, 92, 252, 0.08);
 }
 
 .wk-smart-create-modal__input::placeholder {
-  color: var(--wk-text-disabled, #bbb);
+  color: var(--wk-text-disabled);
 }
 
 .wk-smart-create-modal__textarea {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--wk-border-default, #e5e5e5);
-  border-radius: 6px;
+  padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-sm, 6px);
   font-size: 13px;
-  background: var(--wk-bg-surface, #fff);
-  color: var(--wk-text-primary, #1a1a1a);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
   outline: none;
   box-sizing: border-box;
   resize: vertical;
   font-family: inherit;
   min-height: 72px;
-  transition:
-    border-color 150ms,
-    box-shadow 150ms;
+  transition: border-color 150ms, box-shadow 150ms;
 }
 
 .wk-smart-create-modal__textarea:focus {
-  border-color: var(--wk-text-primary, #18181b);
-  box-shadow: 0 0 0 3px rgba(24, 24, 27, 0.08);
-}
-
-.wk-smart-create-modal__textarea:focus {
-  border-color: var(--wk-brand-primary, #7c5cfc);
+  border-color: var(--wk-brand-primary);
+  box-shadow: 0 0 0 3px rgba(124, 92, 252, 0.08);
 }
 
 .wk-smart-create-modal__textarea::placeholder {
-  color: var(--wk-text-disabled, #bbb);
+  color: var(--wk-text-disabled);
 }
 
 /* DatePicker 对齐 input 样式 */
@@ -141,12 +112,12 @@
   display: flex;
   justify-content: flex-end;
   gap: var(--wk-sp-2, 8px);
-  margin-top: 12px;
+  margin-top: var(--wk-sp-3, 12px);
 }
 
 .wk-smart-create-modal__btn {
-  padding: 8px 16px;
-  border-radius: 6px;
+  padding: var(--wk-sp-2, 8px) var(--wk-sp-4, 16px);
+  border-radius: var(--wk-r-sm, 6px);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -154,26 +125,26 @@
   transition: all 150ms;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--wk-sp-1, 6px);
 }
 
 .wk-smart-create-modal__btn--cancel {
-  background: var(--wk-bg-surface, #fff);
-  color: var(--wk-text-secondary, #666);
-  border: 1px solid var(--wk-border-default, #e4e4e7);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-secondary);
+  border: 1px solid var(--wk-border-default);
 }
 
 .wk-smart-create-modal__btn--cancel:hover {
-  background: var(--wk-bg-item-hover, rgba(0, 0, 0, 0.05));
+  background: var(--wk-bg-item-hover);
 }
 
 .wk-smart-create-modal__btn--confirm {
-  background: var(--wk-brand-primary, #7c5cfc);
+  background: var(--wk-brand-primary);
   color: #fff;
 }
 
 .wk-smart-create-modal__btn--confirm:hover:not(:disabled) {
-  background: var(--wk-brand-primary-hover, #6a4ce0);
+  background: var(--wk-brand-primary-hover);
 }
 
 .wk-smart-create-modal__btn--confirm:disabled {
@@ -182,6 +153,6 @@
 }
 
 .wk-smart-create-modal__footer-sep {
-  border-top: 1px solid var(--wk-border-default, #e4e4e7);
-  margin-top: 12px;
+  border-top: 1px solid var(--wk-border-default);
+  margin-top: var(--wk-sp-3, 12px);
 }

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -52,7 +52,7 @@
 }
 
 .wk-smart-create-modal__req {
-  color: var(--wk-color-danger, #ef4444);
+  color: var(--wk-color-danger);
 }
 
 .wk-smart-create-modal__input {
@@ -70,7 +70,7 @@
 
 .wk-smart-create-modal__input:focus {
   border-color: var(--wk-brand-primary);
-  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring, rgba(124, 92, 252, 0.08));
+  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring);
 }
 
 .wk-smart-create-modal__input::placeholder {
@@ -95,7 +95,7 @@
 
 .wk-smart-create-modal__textarea:focus {
   border-color: var(--wk-brand-primary);
-  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring, rgba(124, 92, 252, 0.08));
+  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring);
 }
 
 .wk-smart-create-modal__textarea::placeholder {
@@ -140,7 +140,7 @@
 
 .wk-smart-create-modal__btn--confirm {
   background: var(--wk-brand-primary);
-  color: var(--wk-text-on-brand, #fff);
+  color: var(--wk-text-on-brand);
 }
 
 .wk-smart-create-modal__btn--confirm:hover:not(:disabled) {

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -70,7 +70,7 @@
 
 .wk-smart-create-modal__input:focus {
   border-color: var(--wk-brand-primary);
-  box-shadow: 0 0 0 3px rgba(124, 92, 252, 0.08);
+  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring, rgba(124, 92, 252, 0.08));
 }
 
 .wk-smart-create-modal__input::placeholder {
@@ -95,7 +95,7 @@
 
 .wk-smart-create-modal__textarea:focus {
   border-color: var(--wk-brand-primary);
-  box-shadow: 0 0 0 3px rgba(124, 92, 252, 0.08);
+  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring, rgba(124, 92, 252, 0.08));
 }
 
 .wk-smart-create-modal__textarea::placeholder {
@@ -140,7 +140,7 @@
 
 .wk-smart-create-modal__btn--confirm {
   background: var(--wk-brand-primary);
-  color: #fff;
+  color: var(--wk-text-on-brand, #fff);
 }
 
 .wk-smart-create-modal__btn--confirm:hover:not(:disabled) {

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -30,7 +30,7 @@
   color: var(--wk-text-primary);
 }
 
-/* .wk-smart-create-modal__sub 已移除，保留规则以备后续副标题需求 */
+/* .wk-smart-create-modal__sub 已移除 */
 
 .wk-smart-create-modal__field {
   margin-bottom: var(--wk-sp-2, 8px);

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.css
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.css
@@ -30,12 +30,7 @@
   color: var(--wk-text-primary);
 }
 
-.wk-smart-create-modal__sub {
-  font-size: 12px;
-  color: var(--wk-text-secondary);
-  margin-top: var(--wk-sp-1, 4px);
-  line-height: 1.5;
-}
+/* .wk-smart-create-modal__sub 已移除，保留规则以备后续副标题需求 */
 
 .wk-smart-create-modal__field {
   margin-bottom: var(--wk-sp-2, 8px);

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Modal, DatePicker, Spin } from "@douyinfe/semi-ui";
+import { WKApp } from "@octo/base";
 import type { CreateMatterReq, ExtractMessage } from "../../bridge/types";
 import MemberPicker from "../MemberPicker";
 import "./index.css";
@@ -16,9 +17,11 @@ export interface SmartCreateModalProps {
   initialValues?: { title?: string; description?: string; deadline?: string };
   /** 智能总结所用的消息列表 */
   sourceMsgs?: ExtractMessage[];
-  /** 关闭弹窗 */
+  /** 用户主动关闭/取消弹窗 */
   onClose: () => void;
-  /** 创建事项 */
+  /** 确认成功后关闭弹窗（不触发孤儿清理）。未传时等同于 onClose */
+  onConfirmSuccess?: () => void;
+  /** 创建/编辑事项 */
   onConfirm: (req: CreateMatterReq) => Promise<void>;
   /** 当前频道（用于 MemberPicker 获取成员列表） */
   channel?: { channelId: string; channelType: number; name?: string };
@@ -59,6 +62,7 @@ export default function SmartCreateModal({
   initialValues,
   sourceMsgs,
   onClose,
+  onConfirmSuccess,
   onConfirm,
   channel,
 }: SmartCreateModalProps) {
@@ -70,9 +74,14 @@ export default function SmartCreateModal({
 
   const titleInputRef = useRef<HTMLInputElement>(null);
 
-  // 打开时聚焦标题输入框，以及更新初始值
+  // 打开时聚焦标题输入框，设置默认负责人
   useEffect(() => {
     if (visible) {
+      // 设置当前用户为默认负责人
+      const currentUid = WKApp.loginInfo.uid;
+      if (currentUid && assigneeUids.length === 0) {
+        setAssigneeUids([currentUid]);
+      }
       setTimeout(() => {
         if (!loading) {
           titleInputRef.current?.focus();
@@ -112,7 +121,7 @@ export default function SmartCreateModal({
         source_channel_type: channel?.channelType,
         source_msgs: sourceMsgs,
       });
-      onClose();
+      (onConfirmSuccess ?? onClose)();
     } catch {
       // 创建失败不关闭，让用户重试
     } finally {
@@ -128,6 +137,7 @@ export default function SmartCreateModal({
     channel,
     sourceMsgs,
     onConfirm,
+    onConfirmSuccess,
     onClose,
   ]);
 
@@ -177,11 +187,6 @@ export default function SmartCreateModal({
             )}
             {blank ? "新建事项" : "智能创建事项"}
           </h3>
-          <p className="wk-smart-create-modal__sub">
-            {blank
-              ? "手动填写 4 个必填字段"
-              : `从 ${count} 条选中消息蒸馏 · 4 字段 AI 已预填, 全部必填`}
-          </p>
         </div>
 
         {loading ? (
@@ -276,18 +281,11 @@ export default function SmartCreateModal({
             <div className="wk-smart-create-modal__actions">
               <button
                 type="button"
-                className="wk-smart-create-modal__btn wk-smart-create-modal__btn--cancel"
-                onClick={onClose}
-              >
-                取消
-              </button>
-              <button
-                type="button"
                 className="wk-smart-create-modal__btn wk-smart-create-modal__btn--confirm"
                 onClick={handleConfirm}
                 disabled={!canCreate || submitting}
               >
-                {submitting ? "创建中..." : "创建事项"}
+                {submitting ? "提交中..." : "确认事项"}
               </button>
             </div>
           </>

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Modal, DatePicker, Spin } from "@douyinfe/semi-ui";
+import { WKApp } from "@octo/base";
 import type { CreateMatterReq, ExtractMessage } from "../../bridge/types";
 import MemberPicker from "../MemberPicker";
 import "./index.css";
@@ -73,6 +74,11 @@ export default function SmartCreateModal({
   // 打开时聚焦标题输入框，以及更新初始值
   useEffect(() => {
     if (visible) {
+      // 设置当前用户为默认负责人
+      const currentUid = WKApp.loginInfo.uid;
+      if (currentUid && assigneeUids.length === 0) {
+        setAssigneeUids([currentUid]);
+      }
       setTimeout(() => {
         if (!loading) {
           titleInputRef.current?.focus();
@@ -152,7 +158,7 @@ export default function SmartCreateModal({
       footer={null}
       width={520}
       closable={false}
-      maskClosable={!loading}
+      maskClosable={false}
       centered
       className="wk-smart-create-modal"
     >
@@ -177,11 +183,6 @@ export default function SmartCreateModal({
             )}
             {blank ? "新建事项" : "智能创建事项"}
           </h3>
-          <p className="wk-smart-create-modal__sub">
-            {blank
-              ? "手动填写 4 个必填字段"
-              : `从 ${count} 条选中消息蒸馏 · 4 字段 AI 已预填, 全部必填`}
-          </p>
         </div>
 
         {loading ? (
@@ -276,18 +277,11 @@ export default function SmartCreateModal({
             <div className="wk-smart-create-modal__actions">
               <button
                 type="button"
-                className="wk-smart-create-modal__btn wk-smart-create-modal__btn--cancel"
-                onClick={onClose}
-              >
-                取消
-              </button>
-              <button
-                type="button"
                 className="wk-smart-create-modal__btn wk-smart-create-modal__btn--confirm"
                 onClick={handleConfirm}
                 disabled={!canCreate || submitting}
               >
-                {submitting ? "创建中..." : "创建事项"}
+                {submitting ? "创建中..." : "确认事项"}
               </button>
             </div>
           </>

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -19,8 +19,8 @@ export interface SmartCreateModalProps {
   sourceMsgs?: ExtractMessage[];
   /** 用户主动关闭/取消弹窗（可能需要清理孤儿事项） */
   onClose: () => void;
-  /** 确认成功后关闭弹窗（不触发孤儿清理） */
-  onConfirmSuccess: () => void;
+  /** 确认成功后关闭弹窗（不触发孤儿清理）。未传时等同于 onClose */
+  onConfirmSuccess?: () => void;
   /** 创建/编辑事项 */
   onConfirm: (req: CreateMatterReq) => Promise<void>;
   /** 当前频道（用于 MemberPicker 获取成员列表） */
@@ -121,7 +121,7 @@ export default function SmartCreateModal({
         source_channel_type: channel?.channelType,
         source_msgs: sourceMsgs,
       });
-      onConfirmSuccess();
+      (onConfirmSuccess ?? onClose)();
     } catch {
       // 创建失败不关闭，让用户重试
     } finally {
@@ -138,6 +138,7 @@ export default function SmartCreateModal({
     sourceMsgs,
     onConfirm,
     onConfirmSuccess,
+    onClose,
   ]);
 
   // Enter 键确认

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -157,8 +157,8 @@ export default function SmartCreateModal({
       onCancel={onClose}
       footer={null}
       width={520}
-      closable={false}
-      maskClosable={false}
+      closable={loading}
+      maskClosable={loading}
       centered
       className="wk-smart-create-modal"
     >

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Modal, DatePicker, Spin } from "@douyinfe/semi-ui";
-import { WKApp } from "@octo/base";
 import type { CreateMatterReq, ExtractMessage } from "../../bridge/types";
 import MemberPicker from "../MemberPicker";
 import "./index.css";
@@ -17,11 +16,9 @@ export interface SmartCreateModalProps {
   initialValues?: { title?: string; description?: string; deadline?: string };
   /** 智能总结所用的消息列表 */
   sourceMsgs?: ExtractMessage[];
-  /** 用户主动关闭/取消弹窗（可能需要清理孤儿事项） */
+  /** 关闭弹窗 */
   onClose: () => void;
-  /** 确认成功后关闭弹窗（不触发孤儿清理）。未传时等同于 onClose */
-  onConfirmSuccess?: () => void;
-  /** 创建/编辑事项 */
+  /** 创建事项 */
   onConfirm: (req: CreateMatterReq) => Promise<void>;
   /** 当前频道（用于 MemberPicker 获取成员列表） */
   channel?: { channelId: string; channelType: number; name?: string };
@@ -62,7 +59,6 @@ export default function SmartCreateModal({
   initialValues,
   sourceMsgs,
   onClose,
-  onConfirmSuccess,
   onConfirm,
   channel,
 }: SmartCreateModalProps) {
@@ -77,11 +73,6 @@ export default function SmartCreateModal({
   // 打开时聚焦标题输入框，以及更新初始值
   useEffect(() => {
     if (visible) {
-      // 设置当前用户为默认负责人
-      const currentUid = WKApp.loginInfo.uid;
-      if (currentUid && assigneeUids.length === 0) {
-        setAssigneeUids([currentUid]);
-      }
       setTimeout(() => {
         if (!loading) {
           titleInputRef.current?.focus();
@@ -121,7 +112,7 @@ export default function SmartCreateModal({
         source_channel_type: channel?.channelType,
         source_msgs: sourceMsgs,
       });
-      (onConfirmSuccess ?? onClose)();
+      onClose();
     } catch {
       // 创建失败不关闭，让用户重试
     } finally {
@@ -137,7 +128,6 @@ export default function SmartCreateModal({
     channel,
     sourceMsgs,
     onConfirm,
-    onConfirmSuccess,
     onClose,
   ]);
 
@@ -148,11 +138,11 @@ export default function SmartCreateModal({
         e.preventDefault();
         handleConfirm();
       }
-      if (e.key === "Escape") {
+      if (e.key === "Escape" && !submitting) {
         onClose();
       }
     },
-    [handleConfirm, onClose, canCreate],
+    [handleConfirm, onClose, canCreate, submitting],
   );
 
   return (
@@ -161,7 +151,7 @@ export default function SmartCreateModal({
       onCancel={onClose}
       footer={null}
       width={520}
-      closable={true}
+      closable={!submitting}
       maskClosable={false}
       centered
       className="wk-smart-create-modal"
@@ -187,6 +177,11 @@ export default function SmartCreateModal({
             )}
             {blank ? "新建事项" : "智能创建事项"}
           </h3>
+          <p className="wk-smart-create-modal__sub">
+            {blank
+              ? "手动填写 4 个必填字段"
+              : `从 ${count} 条选中消息蒸馏 · 4 字段 AI 已预填, 全部必填`}
+          </p>
         </div>
 
         {loading ? (
@@ -281,11 +276,18 @@ export default function SmartCreateModal({
             <div className="wk-smart-create-modal__actions">
               <button
                 type="button"
+                className="wk-smart-create-modal__btn wk-smart-create-modal__btn--cancel"
+                onClick={onClose}
+              >
+                取消
+              </button>
+              <button
+                type="button"
                 className="wk-smart-create-modal__btn wk-smart-create-modal__btn--confirm"
                 onClick={handleConfirm}
                 disabled={!canCreate || submitting}
               >
-                {submitting ? "创建中..." : "确认事项"}
+                {submitting ? "创建中..." : "创建事项"}
               </button>
             </div>
           </>

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -3,6 +3,7 @@ import { Modal, DatePicker, Spin } from "@douyinfe/semi-ui";
 import { WKApp } from "@octo/base";
 import type { CreateMatterReq, ExtractMessage } from "../../bridge/types";
 import MemberPicker from "../MemberPicker";
+import { Toast } from "../../utils/toast";
 import "./index.css";
 
 export interface SmartCreateModalProps {
@@ -122,8 +123,12 @@ export default function SmartCreateModal({
         source_msgs: sourceMsgs,
       });
       (onConfirmSuccess ?? onClose)();
-    } catch {
-      // 创建失败不关闭，让用户重试
+    } catch (e: any) {
+      // 失败不关闭，让用户重试
+      const msg = e?.message === "assignee reconciliation failed"
+        ? undefined  // assignee 失败已在 onConfirm 内 toast
+        : "操作失败，请重试";
+      if (msg) Toast.error(msg);
     } finally {
       setSubmitting(false);
     }

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -164,7 +164,7 @@ export default function SmartCreateModal({
       footer={null}
       width={520}
       closable={!submitting}
-      maskClosable={!loading}
+      maskClosable={false}
       centered
       className="wk-smart-create-modal"
       bodyStyle={{ overflow: "visible", padding: 0 }}
@@ -283,14 +283,6 @@ export default function SmartCreateModal({
 
             <div className="wk-smart-create-modal__footer-sep" />
             <div className="wk-smart-create-modal__actions">
-              <button
-                type="button"
-                className="wk-smart-create-modal__btn wk-smart-create-modal__btn--cancel"
-                onClick={onClose}
-                disabled={submitting}
-              >
-                取消
-              </button>
               <button
                 type="button"
                 className="wk-smart-create-modal__btn wk-smart-create-modal__btn--confirm"

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -165,6 +165,8 @@ export default function SmartCreateModal({
       maskClosable={false}
       centered
       className="wk-smart-create-modal"
+      bodyStyle={{ overflow: "visible", padding: 0 }}
+      style={{ overflow: "visible" }}
     >
       <div className="wk-smart-create-modal__content" onKeyDown={handleKeyDown}>
         {/* Header */}

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -17,9 +17,11 @@ export interface SmartCreateModalProps {
   initialValues?: { title?: string; description?: string; deadline?: string };
   /** 智能总结所用的消息列表 */
   sourceMsgs?: ExtractMessage[];
-  /** 关闭弹窗 */
+  /** 用户主动关闭/取消弹窗（可能需要清理孤儿事项） */
   onClose: () => void;
-  /** 创建事项 */
+  /** 确认成功后关闭弹窗（不触发孤儿清理） */
+  onConfirmSuccess: () => void;
+  /** 创建/编辑事项 */
   onConfirm: (req: CreateMatterReq) => Promise<void>;
   /** 当前频道（用于 MemberPicker 获取成员列表） */
   channel?: { channelId: string; channelType: number; name?: string };
@@ -60,6 +62,7 @@ export default function SmartCreateModal({
   initialValues,
   sourceMsgs,
   onClose,
+  onConfirmSuccess,
   onConfirm,
   channel,
 }: SmartCreateModalProps) {
@@ -118,7 +121,7 @@ export default function SmartCreateModal({
         source_channel_type: channel?.channelType,
         source_msgs: sourceMsgs,
       });
-      onClose();
+      onConfirmSuccess();
     } catch {
       // 创建失败不关闭，让用户重试
     } finally {
@@ -134,7 +137,7 @@ export default function SmartCreateModal({
     channel,
     sourceMsgs,
     onConfirm,
-    onClose,
+    onConfirmSuccess,
   ]);
 
   // Enter 键确认
@@ -157,8 +160,8 @@ export default function SmartCreateModal({
       onCancel={onClose}
       footer={null}
       width={520}
-      closable={loading}
-      maskClosable={loading}
+      closable={true}
+      maskClosable={false}
       centered
       className="wk-smart-create-modal"
     >

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -164,7 +164,7 @@ export default function SmartCreateModal({
       footer={null}
       width={520}
       closable={!submitting}
-      maskClosable={false}
+      maskClosable={!loading}
       centered
       className="wk-smart-create-modal"
       bodyStyle={{ overflow: "visible", padding: 0 }}
@@ -283,6 +283,14 @@ export default function SmartCreateModal({
 
             <div className="wk-smart-create-modal__footer-sep" />
             <div className="wk-smart-create-modal__actions">
+              <button
+                type="button"
+                className="wk-smart-create-modal__btn wk-smart-create-modal__btn--cancel"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                取消
+              </button>
               <button
                 type="button"
                 className="wk-smart-create-modal__btn wk-smart-create-modal__btn--confirm"

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -146,18 +146,15 @@ export default function SmartCreateModal({
     onClose,
   ]);
 
-  // Enter 键确认
+  // Enter 键确认（Esc 由 Semi Modal 原生处理，无需重复）
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter" && !e.shiftKey && canCreate) {
         e.preventDefault();
         handleConfirm();
       }
-      if (e.key === "Escape" && !submitting) {
-        onClose();
-      }
     },
-    [handleConfirm, onClose, canCreate, submitting],
+    [handleConfirm, canCreate],
   );
 
   return (


### PR DESCRIPTION
Resubmission of #23 with all review feedback addressed. Same code, clean review state.

## Changes

- extractMatter already creates the matter; confirm now calls updateMatter + assignee reconcile instead of createMatter
- Orphan cleanup: cancel deletes the extracted matter, new session cleans previous
- Race safety: extractedMatterIdRef + closedRef + sessionRef prevent all async races
- UX: confirm button only, default assignee = current user, maskClosable=false
- CSS: all tokens, no !important, overflow via Semi bodyStyle prop
- Assignee reconcile failure keeps modal open with Toast.error

## Testing

- Manual QA: confirm updates matter, cancel deletes, overlapping sessions handled
- No duplicate creation on confirm path