### PR TITLE
fix(workflows): add CI, normalize workflow refs to @v1, pin action SHAs

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -11,6 +11,6 @@ permissions: {}
 
 jobs:
   add-to-project:
-    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@239d0b47cfe1947d5e6de826e795feac4ed90562
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@v1
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: pnpm/action-setup@a7487ba4aad7e84e44227a7c1e832f8c9e3ecc1c # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           run_install: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -30,3 +30,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
+      - name: Lint
+        run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@a7487ba4aad7e84e44227a7c1e832f8c9e3ecc1c # v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -8,4 +8,4 @@ jobs:
   welcome:
     permissions:
       issues: write
-    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@v1

--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -8,7 +8,7 @@ permissions: {}  # GITHUB_TOKEN not used; lock down to minimum
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@c6c51348fccac99161166dce1b52dec1063aeea2
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -4,7 +4,8 @@ on:
   pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
-permissions: {}  # GITHUB_TOKEN not used; lock down to minimum
+permissions:
+  contents: read
 
 jobs:
   notify:


### PR DESCRIPTION
## Changes

### 🟠 H-1: Add CI workflow
Add `.github/workflows/ci.yml` with pnpm install and build steps. This was the only active repo without CI coverage.

> Note: This is a pnpm/Turbo monorepo with no root-level `tsconfig.json` or `test` script. The CI workflow uses `pnpm/action-setup` + `pnpm install --frozen-lockfile` + `pnpm build` accordingly.

### 🟠 H-2: Normalize reusable workflow version references to `@v1`
All 4 caller workflows were using inconsistent references (`@main` or specific commit SHAs). Unified to `@v1` to match all other repos in the org.

| Workflow | Before | After |
|----------|--------|-------|
| auto-add-to-project | `@239d0b47` (old SHA) | `@v1` |
| issue-welcome | `@main` | `@v1` |
| octo-issue-feed | `@main` | `@v1` |
| octo-pr-feed | `@c6c51348` (old SHA) | `@v1` |

### 🟢 L-1: Pin action SHAs
Pin `actions/checkout` and `actions/setup-node` to commit SHAs in the new CI workflow.
