### PR TITLE
fix(upload): include fileSize on /file/upload/credentials per octo-server R6+ contract

### DIFF
--- a/packages/dmworkdatasource/src/task.ts
+++ b/packages/dmworkdatasource/src/task.ts
@@ -94,8 +94,9 @@ export class MediaMessageUploadTask extends MessageTask {
     async getUploadCredentials(file: File, path: string): Promise<UploadCredentials | undefined> {
         const contentType = file.type || "application/octet-stream"
         const fileName = file.name || 'file'
+        const fileSize = file.size
         const result = await WKApp.apiClient.get(
-            `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}`
+            `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}&fileSize=${fileSize}`
         )
         if(result && result.uploadUrl && result.downloadUrl) {
             return result as UploadCredentials


### PR DESCRIPTION
## Summary

Adds the required `fileSize` query parameter to `MediaMessageUploadTask.getUploadCredentials` so that chat media uploads continue to work after [octo-server PR #50](https://github.com/Mininglamp-OSS/octo-server/pull/50) (R6+) makes `fileSize` mandatory on `/v1/file/upload/credentials` (and its alias `/v1/file/upload/presigned`).

Without this patch, every chat media upload (image / video / file) issued by octo-web would receive a 4xx from the file-module presigned-PUT endpoint as soon as octo-server PR#50 lands.

## Change

`packages/dmworkdatasource/src/task.ts` — additive, +2/-1 lines:

```diff
 async getUploadCredentials(file: File, path: string): Promise<UploadCredentials | undefined> {
     const contentType = file.type || "application/octet-stream"
     const fileName = file.name || 'file'
+    const fileSize = file.size
     const result = await WKApp.apiClient.get(
-        `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}`
+        `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}&fileSize=${fileSize}`
     )
```

`file.size` is already in scope (line 58 uses it for the upload-timeout heuristic), so no extra plumbing is needed.

## Verification

```
pnpm --filter @octo/datasource test
# Test Files  2 passed (2)
# Tests       22 passed (22)
```

## Context

This is the OSS-side companion patch to octo-server PR #50.

- octo-server PR #50 — server-side enforcement of `fileSize` on the presigned-PUT endpoint (closes a `Content-Length` bypass)
- Multica YUJ-819 — client-compatibility audit run before PR#50 merge that surfaced this call site
- Multica YUJ-820 / YUJ-821 — the same one-line patch on the internal frontend (dmwork-web)
- Multica YUJ-832 — this dispatch

Once both PR #50 (octo-server) and this PR land, the OOTB stack rolls out cleanly with no 4xx regression on chat media upload.

## Reviewer note

Single behavioural change, fully covered by existing unit tests; please tag per CODEOWNERS.
