### PR TITLE
feat(voice): add voice input support for all input fields

### DIFF
--- a/apps/web/src/__tests__/summaryCreatePageVoice.test.tsx
+++ b/apps/web/src/__tests__/summaryCreatePageVoice.test.tsx
@@ -1,0 +1,128 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+const mockUseTextareaVoice = vi.fn();
+vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
+  default: (opts: unknown) => mockUseTextareaVoice(opts),
+}));
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node,
+  };
+});
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Toast: { error: vi.fn(), warning: vi.fn(), success: vi.fn() },
+  Typography: { Text: ({ children }: any) => <span>{children}</span> },
+  Tag: ({ children }: any) => <span>{children}</span>,
+  Avatar: ({ children }: any) => <span>{children}</span>,
+  Dropdown: Object.assign(vi.fn(({ children }: any) => children), {
+    Menu: vi.fn(({ children }: any) => <div>{children}</div>),
+    Item: vi.fn(({ children }: any) => <div>{children}</div>),
+  }),
+}));
+
+vi.mock("@douyinfe/semi-icons", () => ({
+  IconPlus: () => <span>+</span>,
+}));
+
+vi.mock("@octo/base/src/App", () => ({
+  default: {
+    routeRight: {
+      popToRoot: vi.fn(),
+      push: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dmwork/summary/src/api/summaryApi", () => ({
+  getTemplates: vi.fn().mockResolvedValue([]),
+  createSummary: vi.fn().mockResolvedValue({ task_id: 1 }),
+  createSchedule: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@dmwork/summary/src/pages/SummaryDetailPage", () => ({
+  default: () => <div>SummaryDetailPage</div>,
+}));
+
+vi.mock("@dmwork/summary/src/components/ChatSelectorModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@dmwork/summary/src/components/MemberSelectorModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@dmwork/summary/src/components/ScheduleConfigModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@dmwork/summary/src/utils/summaryHelpers", () => ({
+  scheduleToCron: vi.fn(),
+}));
+
+import SummaryCreatePage from "@dmwork/summary/src/pages/SummaryCreatePage";
+
+function createMockReturn(overrides = {}) {
+  return {
+    isRecording: false,
+    isTranscribing: false,
+    startRecording: vi.fn(),
+    stopRecordingAndTranscribe: vi.fn(),
+    cancelRecording: vi.fn(),
+    isVoiceEnabled: true,
+    localAvailable: false,
+    ...overrides,
+  };
+}
+
+describe("SummaryCreatePage - voice input", () => {
+  beforeEach(() => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render VoiceInputButton alongside the topic textarea", () => {
+    const { container } = render(<SummaryCreatePage />);
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+
+    const voiceBtn = container.querySelector(".wk-vib");
+    expect(voiceBtn).toBeTruthy();
+  });
+
+  it("should position VoiceInputButton at top-right of textarea using wk-vib--textarea-corner class", () => {
+    const { container } = render(<SummaryCreatePage />);
+
+    const voiceBtn = container.querySelector(".wk-vib--textarea-corner");
+    expect(voiceBtn).toBeTruthy();
+
+    // Voice button should be inside a position: relative wrapper
+    const wrapper = voiceBtn?.parentElement;
+    expect(wrapper?.style.position).toBe("relative");
+  });
+
+  it("should render voice button within same container as textarea", () => {
+    const { container } = render(<SummaryCreatePage />);
+
+    const textarea = container.querySelector("textarea");
+    const voiceBtn = container.querySelector(".wk-vib--textarea-corner");
+
+    // Both should share the same parent (position: relative wrapper)
+    expect(textarea?.parentElement).toBe(voiceBtn?.parentElement);
+  });
+});

--- a/apps/web/src/__tests__/useTextareaVoice.test.ts
+++ b/apps/web/src/__tests__/useTextareaVoice.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+
+// Mock useVoiceInput hook
+const mockStartRecording = vi.fn();
+const mockStopRecordingAndTranscribe = vi.fn();
+const mockCancelRecording = vi.fn();
+let capturedOnTranscribed: ((text: string) => void) | undefined;
+
+vi.mock("@octo/base/src/Components/MessageInput/useVoiceInput", () => ({
+  default: (opts: { onTranscribed?: (text: string) => void }) => {
+    capturedOnTranscribed = opts?.onTranscribed;
+    return {
+      isRecording: false,
+      isTranscribing: false,
+      startRecording: mockStartRecording,
+      stopRecordingAndTranscribe: mockStopRecordingAndTranscribe,
+      cancelRecording: mockCancelRecording,
+      isVoiceEnabled: true,
+      currentMode: "append_only",
+      localAvailable: false,
+    };
+  },
+}));
+
+import useTextareaVoice from "@octo/base/src/Components/VoiceInputButton/useTextareaVoice";
+
+describe("useTextareaVoice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnTranscribed = undefined;
+  });
+
+  function createInputRef(
+    overrides: Partial<HTMLTextAreaElement> = {}
+  ): React.RefObject<HTMLTextAreaElement> {
+    const el = {
+      selectionStart: 0,
+      selectionEnd: 0,
+      ...overrides,
+    } as HTMLTextAreaElement;
+    return { current: el } as React.RefObject<HTMLTextAreaElement>;
+  }
+
+  it("should return voice state from useVoiceInput", () => {
+    const inputRef = createInputRef();
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.isTranscribing).toBe(false);
+    expect(result.current.isVoiceEnabled).toBe(true);
+  });
+
+  it("should call startRecording with mode when inputRef is valid", () => {
+    const inputRef = createInputRef({ selectionStart: 0, selectionEnd: 0 });
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording("append_only");
+    });
+
+    expect(mockStartRecording).toHaveBeenCalledWith("append_only");
+  });
+
+  it("should not call startRecording when inputRef.current is null", () => {
+    const inputRef = { current: null } as React.RefObject<HTMLTextAreaElement>;
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording();
+    });
+
+    expect(mockStartRecording).not.toHaveBeenCalled();
+  });
+
+  it("should detect selection when starting recording", () => {
+    const inputRef = createInputRef({ selectionStart: 2, selectionEnd: 8 });
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording("edit_only");
+    });
+
+    expect(mockStartRecording).toHaveBeenCalledWith("edit_only");
+
+    // Simulate transcription callback from useVoiceInput
+    act(() => {
+      capturedOnTranscribed?.("replaced text");
+    });
+
+    // edit_only + had selection → "selection" mode
+    expect(onTranscribed).toHaveBeenCalledWith("replaced text", "selection", { from: 2, to: 8 });
+  });
+
+  it("should use 'all' replaceMode for edit_only without selection", () => {
+    const inputRef = createInputRef({ selectionStart: 5, selectionEnd: 5 });
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording("edit_only");
+    });
+
+    act(() => {
+      capturedOnTranscribed?.("new text");
+    });
+
+    expect(onTranscribed).toHaveBeenCalledWith("new text", "all", { from: 5, to: 5 });
+  });
+
+  it("should use 'insert' replaceMode for append_only mode", () => {
+    const inputRef = createInputRef({ selectionStart: 3, selectionEnd: 3 });
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording("append_only");
+    });
+
+    act(() => {
+      capturedOnTranscribed?.("appended");
+    });
+
+    expect(onTranscribed).toHaveBeenCalledWith("appended", "insert", { from: 3, to: 3 });
+  });
+
+  it("should default to append_only mode when no mode specified", () => {
+    const inputRef = createInputRef();
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.startRecording();
+    });
+
+    expect(mockStartRecording).toHaveBeenCalledWith("append_only");
+  });
+
+  it("should pass contextText when stopping in edit_only mode", () => {
+    const inputRef = createInputRef();
+    const onTranscribed = vi.fn();
+    const getCurrentText = vi.fn().mockReturnValue("current content");
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({
+        inputRef,
+        onTranscribed,
+        getCurrentText,
+      })
+    );
+
+    // Start in edit_only mode
+    act(() => {
+      result.current.startRecording("edit_only");
+    });
+
+    act(() => {
+      result.current.stopRecordingAndTranscribe();
+    });
+
+    expect(mockStopRecordingAndTranscribe).toHaveBeenCalledWith(
+      "current content"
+    );
+  });
+
+  it("should not pass contextText when stopping in append_only mode", () => {
+    const inputRef = createInputRef();
+    const onTranscribed = vi.fn();
+    const getCurrentText = vi.fn().mockReturnValue("current content");
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({
+        inputRef,
+        onTranscribed,
+        getCurrentText,
+      })
+    );
+
+    act(() => {
+      result.current.startRecording("append_only");
+    });
+
+    act(() => {
+      result.current.stopRecordingAndTranscribe();
+    });
+
+    expect(mockStopRecordingAndTranscribe).toHaveBeenCalledWith(undefined);
+  });
+
+  it("should expose cancelRecording from useVoiceInput", () => {
+    const inputRef = createInputRef();
+    const onTranscribed = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTextareaVoice({ inputRef, onTranscribed })
+    );
+
+    act(() => {
+      result.current.cancelRecording();
+    });
+
+    expect(mockCancelRecording).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/voiceInputButton.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButton.test.tsx
@@ -1,0 +1,472 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import React from "react";
+
+// Mock useTextareaVoice hook
+const mockUseTextareaVoice = vi.fn();
+vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
+  default: (opts: unknown) => mockUseTextareaVoice(opts),
+}));
+
+// Mock createPortal
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node,
+  };
+});
+
+// Mock Toast
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+  Dropdown: Object.assign(vi.fn(({ children }: any) => children), {
+    Menu: vi.fn(({ children }: any) => children),
+    Item: vi.fn(({ children }: any) => children),
+  }),
+}));
+
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import { Toast } from "@douyinfe/semi-ui";
+
+function createMockReturn(overrides = {}) {
+  return {
+    isRecording: false,
+    isTranscribing: false,
+    startRecording: vi.fn(),
+    stopRecordingAndTranscribe: vi.fn(),
+    cancelRecording: vi.fn(),
+    isVoiceEnabled: true,
+    localAvailable: false,
+    ...overrides,
+  };
+}
+
+function createInputRef(): React.RefObject<HTMLTextAreaElement> {
+  const el = document.createElement("textarea");
+  return { current: el } as React.RefObject<HTMLTextAreaElement>;
+}
+
+describe("VoiceInputButton - rendering", () => {
+  beforeEach(() => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render nothing when voice is disabled", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isVoiceEnabled: false })
+    );
+
+    const { container } = render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render microphone button when enabled", () => {
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const button = document.querySelector(".wk-vib__btn");
+    expect(button).toBeTruthy();
+  });
+
+  it("should render with sm size class", () => {
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+        size="sm"
+      />
+    );
+
+    const root = document.querySelector(".wk-vib--sm");
+    expect(root).toBeTruthy();
+  });
+
+  it("should render recording state", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isRecording: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const recordingBtn = document.querySelector(".wk-vib__btn--recording");
+    expect(recordingBtn).toBeTruthy();
+  });
+
+  it("should render transcribing state", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isTranscribing: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const recordingBtn = document.querySelector(".wk-vib__btn--recording");
+    expect(recordingBtn).toBeTruthy();
+    expect(recordingBtn?.getAttribute("title")).toBe("转写中...");
+  });
+
+  it("should render disabled state when inputRef.current is null", () => {
+    const nullRef = {
+      current: null,
+    } as React.RefObject<HTMLTextAreaElement>;
+
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <VoiceInputButton inputRef={nullRef} onTranscribed={vi.fn()} />
+    );
+
+    const button = document.querySelector(".wk-vib__btn--disabled");
+    expect(button).toBeTruthy();
+  });
+
+  it("should render disabled state when offline and no local model", () => {
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ localAvailable: false })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const button = document.querySelector(".wk-vib__btn--disabled");
+    expect(button).toBeTruthy();
+  });
+
+  it("should apply custom className", () => {
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+        className="my-custom-class"
+      />
+    );
+
+    const root = document.querySelector(".my-custom-class");
+    expect(root).toBeTruthy();
+  });
+});
+
+describe("VoiceInputButton - interactions", () => {
+  beforeEach(() => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call startRecording on click", async () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const root = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(root!);
+    });
+
+    expect(mockStart).toHaveBeenCalledWith("append_only");
+  });
+
+  it("should call stopRecordingAndTranscribe when clicking during recording", async () => {
+    const mockStop = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        isRecording: true,
+        stopRecordingAndTranscribe: mockStop,
+      })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const root = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(root!);
+    });
+
+    expect(mockStop).toHaveBeenCalled();
+  });
+
+  it("should show warning Toast when clicking while offline", async () => {
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ localAvailable: false })
+    );
+
+    const inputRef = createInputRef();
+    const { container } = render(
+      <VoiceInputButton
+        inputRef={inputRef}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const disabledBtn = container.querySelector(".wk-vib__btn--disabled");
+    expect(disabledBtn).toBeTruthy();
+    expect(disabledBtn?.getAttribute("title")).toBe("网络不可用");
+  });
+
+  it("should not start recording when inputRef.current is null", async () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    const nullRef = {
+      current: null,
+    } as React.RefObject<HTMLTextAreaElement>;
+
+    render(
+      <VoiceInputButton inputRef={nullRef} onTranscribed={vi.fn()} />
+    );
+
+    const root = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(root!);
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should cancel recording on Escape key", async () => {
+    const mockCancel = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        isRecording: true,
+        cancelRecording: mockCancel,
+      })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+
+    expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it("should stop recording on window blur", async () => {
+    const mockStop = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        isRecording: true,
+        stopRecordingAndTranscribe: mockStop,
+      })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      fireEvent(window, new Event("blur"));
+    });
+
+    expect(mockStop).toHaveBeenCalled();
+  });
+});
+
+describe("VoiceInputButton - floating indicator", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should show wave animation during recording", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isRecording: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const waveContainer = document.querySelector(".wk-voice-wave-container");
+    expect(waveContainer).toBeTruthy();
+
+    const waveBars = document.querySelectorAll(".wk-voice-wave-bar");
+    expect(waveBars.length).toBe(16);
+  });
+
+  it("should show spinner during transcribing", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isTranscribing: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const spinner = document.querySelector(".wk-voice-transcribing-spinner");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("should show '语音输入' text during recording", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isRecording: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const text = document.querySelector(".wk-voice-floating-text");
+    expect(text?.textContent).toBe("语音输入");
+  });
+
+  it("should show '转写中' text during transcribing", () => {
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ isTranscribing: true })
+    );
+
+    render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+      />
+    );
+
+    const text = document.querySelector(".wk-voice-floating-text");
+    expect(text?.textContent).toBe("转写中");
+  });
+});
+
+describe("VoiceInputButton - mode menu", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should pass showModeMenu through to component rendering", () => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+
+    const { container } = render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+        showModeMenu
+      />
+    );
+
+    // With showModeMenu=true, the component tries to render Dropdown
+    // The button should still be present
+    const button = container.querySelector(".wk-vib__btn");
+    expect(button).toBeTruthy();
+  });
+
+  it("should render simple button without dropdown when showModeMenu is false", () => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+
+    const { container } = render(
+      <VoiceInputButton
+        inputRef={createInputRef()}
+        onTranscribed={vi.fn()}
+        showModeMenu={false}
+      />
+    );
+
+    const button = container.querySelector(".wk-vib__btn");
+    expect(button).toBeTruthy();
+  });
+});

--- a/apps/web/src/__tests__/voiceInputButtonPositioning.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButtonPositioning.test.tsx
@@ -1,0 +1,131 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import React, { useRef } from "react";
+
+const mockUseTextareaVoice = vi.fn();
+vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
+  default: (opts: unknown) => mockUseTextareaVoice(opts),
+}));
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node,
+  };
+});
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: { error: vi.fn(), warning: vi.fn() },
+  Dropdown: Object.assign(vi.fn(({ children }: any) => children), {
+    Menu: vi.fn(({ children }: any) => children),
+    Item: vi.fn(({ children }: any) => children),
+  }),
+}));
+
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+
+function createMockReturn(overrides = {}) {
+  return {
+    isRecording: false,
+    isTranscribing: false,
+    startRecording: vi.fn(),
+    stopRecordingAndTranscribe: vi.fn(),
+    cancelRecording: vi.fn(),
+    isVoiceEnabled: true,
+    localAvailable: false,
+    ...overrides,
+  };
+}
+
+function InputWithVoiceInline() {
+  const ref = useRef<HTMLInputElement>(null);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+      <input ref={ref} type="text" style={{ flex: 1 }} />
+      <VoiceInputButton inputRef={ref} onTranscribed={vi.fn()} size="sm" />
+    </div>
+  );
+}
+
+function TextareaWithVoiceCorner() {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  return (
+    <div style={{ position: "relative" }}>
+      <textarea ref={ref} rows={3} />
+      <VoiceInputButton
+        inputRef={ref}
+        onTranscribed={vi.fn()}
+        size="sm"
+        className="wk-vib--textarea-corner"
+      />
+    </div>
+  );
+}
+
+describe("VoiceInputButton positioning", () => {
+  beforeEach(() => {
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should position voice button beside input using flex layout", () => {
+    const { container } = render(<InputWithVoiceInline />);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.display).toBe("flex");
+    expect(wrapper.style.alignItems).toBe("center");
+
+    const voiceBtn = wrapper.querySelector(".wk-vib");
+    expect(voiceBtn).toBeTruthy();
+
+    const input = wrapper.querySelector("input");
+    expect(input).toBeTruthy();
+
+    // Voice button should be a sibling of input, not nested below
+    expect(voiceBtn?.parentElement).toBe(input?.parentElement);
+  });
+
+  it("should position voice button at top-right corner of textarea using absolute positioning class", () => {
+    const { container } = render(<TextareaWithVoiceCorner />);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.position).toBe("relative");
+
+    const voiceBtn = wrapper.querySelector(".wk-vib--textarea-corner");
+    expect(voiceBtn).toBeTruthy();
+
+    const textarea = wrapper.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+
+    // Both inside the same position:relative container
+    expect(voiceBtn?.parentElement).toBe(textarea?.parentElement);
+  });
+
+  it("should have wk-vib--textarea-corner class for absolute positioning", () => {
+    const { container } = render(<TextareaWithVoiceCorner />);
+
+    const voiceBtn = container.querySelector(".wk-vib--textarea-corner");
+    expect(voiceBtn).toBeTruthy();
+    expect(voiceBtn?.classList.contains("wk-vib")).toBe(true);
+    expect(voiceBtn?.classList.contains("wk-vib--textarea-corner")).toBe(true);
+  });
+
+  it("should render voice button as inline-flex element", () => {
+    const { container } = render(<InputWithVoiceInline />);
+
+    const voiceBtn = container.querySelector(".wk-vib") as HTMLElement;
+    expect(voiceBtn).toBeTruthy();
+    // The CSS class .wk-vib has display: inline-flex
+    // Just verify the element exists and is part of the flex flow
+    expect(voiceBtn.parentElement?.style.display).toBe("flex");
+  });
+});

--- a/apps/web/src/__tests__/voiceInputButtonShiftLongPress.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButtonShiftLongPress.test.tsx
@@ -1,0 +1,394 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import React from "react";
+
+const mockUseTextareaVoice = vi.fn();
+vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
+  default: (opts: unknown) => mockUseTextareaVoice(opts),
+}));
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node,
+  };
+});
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+  Dropdown: Object.assign(vi.fn(({ children }: any) => children), {
+    Menu: vi.fn(({ children }: any) => children),
+    Item: vi.fn(({ children }: any) => children),
+  }),
+}));
+
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import { Toast } from "@douyinfe/semi-ui";
+
+function createMockReturn(overrides = {}) {
+  return {
+    isRecording: false,
+    isTranscribing: false,
+    startRecording: vi.fn(),
+    stopRecordingAndTranscribe: vi.fn(),
+    cancelRecording: vi.fn(),
+    isVoiceEnabled: true,
+    localAvailable: false,
+    ...overrides,
+  };
+}
+
+describe("VoiceInputButton - Left Shift long-press", () => {
+  let textarea: HTMLTextAreaElement;
+  let inputRef: React.RefObject<HTMLTextAreaElement>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    inputRef = { current: textarea } as React.RefObject<HTMLTextAreaElement>;
+    mockUseTextareaVoice.mockReturnValue(createMockReturn());
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    document.body.removeChild(textarea);
+  });
+
+  it("should start recording after holding ShiftLeft for 500ms when input is focused", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    textarea.focus();
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockStart).toHaveBeenCalledWith("append_only");
+  });
+
+  it("should NOT start recording if ShiftLeft is released before 500ms", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    textarea.focus();
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should NOT activate when input is not focused", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    // Do not focus the textarea
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should cancel timer when another key is pressed during hold", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    textarea.focus();
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Press another key (typing a capital letter)
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "KeyA",
+          key: "A",
+          shiftKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should cancel timer when modifier chord is detected", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    textarea.focus();
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Press Ctrl (modifier chord)
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ControlLeft",
+          key: "Control",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should show warning toast when offline", () => {
+    // Render with offline state from the start
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart, localAvailable: false })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    act(() => {
+      textarea.focus();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // Verify startRecording is NOT called when offline - this is the critical assertion
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("should stop recording when ShiftLeft is released after recording started", () => {
+    const mockStop = vi.fn();
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        startRecording: mockStart,
+        stopRecordingAndTranscribe: mockStop,
+        isRecording: true,
+      })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    // Simulate: the timer already fired and shiftRecordingRef.current = true
+    // We simulate this by dispatching keydown, advancing time past threshold,
+    // then re-rendering with isRecording=true, then releasing shift.
+    // Since the mock already returns isRecording=true, we just need to
+    // set up the internal shiftRecordingRef. Let's do a full sequence:
+
+    // Re-render with isRecording=false first to set up the timer
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        startRecording: mockStart,
+        stopRecordingAndTranscribe: mockStop,
+        isRecording: false,
+      })
+    );
+
+    const { rerender } = render(
+      <VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />
+    );
+
+    textarea.focus();
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockStart).toHaveBeenCalledWith("append_only");
+
+    // Now simulate that recording started
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({
+        startRecording: mockStart,
+        stopRecordingAndTranscribe: mockStop,
+        isRecording: true,
+      })
+    );
+
+    rerender(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    // Release shift
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(mockStop).toHaveBeenCalled();
+  });
+
+  it("should not conflict with repeated keydown events", () => {
+    const mockStart = vi.fn();
+    mockUseTextareaVoice.mockReturnValue(
+      createMockReturn({ startRecording: mockStart })
+    );
+
+    render(<VoiceInputButton inputRef={inputRef} onTranscribed={vi.fn()} />);
+
+    textarea.focus();
+
+    // First press
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+        })
+      );
+    });
+
+    // Repeated keydown (key repeat)
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ShiftLeft",
+          key: "Shift",
+          bubbles: true,
+          repeat: true,
+        })
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // Should only start once
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/__tests__/voiceInputIntegration.test.tsx
+++ b/apps/web/src/__tests__/voiceInputIntegration.test.tsx
@@ -1,0 +1,271 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import React, { useRef, useState } from "react";
+
+// Mock useVoiceInput
+let capturedOnTranscribed: ((text: string) => void) | undefined;
+let capturedStartRecording: ReturnType<typeof vi.fn>;
+
+vi.mock("@octo/base/src/Components/MessageInput/useVoiceInput", () => ({
+  default: (opts: { onTranscribed?: (text: string) => void }) => {
+    capturedOnTranscribed = opts?.onTranscribed;
+    return {
+      isRecording: false,
+      isTranscribing: false,
+      startRecording: capturedStartRecording,
+      stopRecordingAndTranscribe: vi.fn(),
+      cancelRecording: vi.fn(),
+      isVoiceEnabled: true,
+      currentMode: "append_only",
+      localAvailable: false,
+    };
+  },
+}));
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node,
+  };
+});
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: { error: vi.fn(), warning: vi.fn() },
+  Dropdown: Object.assign(vi.fn(({ children }: any) => children), {
+    Menu: vi.fn(({ children }: any) => children),
+    Item: vi.fn(({ children }: any) => children),
+  }),
+}));
+
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode } from "@octo/base/src/Components/VoiceInputButton";
+
+function TextareaWithVoice() {
+  const [value, setValue] = useState("hello world");
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  return (
+    <div>
+      <textarea
+        ref={ref}
+        data-testid="textarea"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <VoiceInputButton
+        inputRef={ref}
+        onTranscribed={(text: string, mode: ReplaceMode, savedRange?: { from: number; to: number }) => {
+          if (mode === "all") {
+            setValue(text);
+          } else if (mode === "selection" && savedRange) {
+            // Note: savedRange indices are from recording start; assumes input is read-only during recording
+            setValue((prev) => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+          } else {
+            setValue((prev) => {
+              const pos = savedRange?.from ?? prev.length;
+              return prev.slice(0, pos) + text + prev.slice(pos);
+            });
+          }
+        }}
+        getCurrentText={() => value}
+        size="sm"
+      />
+      <div data-testid="value">{value}</div>
+    </div>
+  );
+}
+
+function InputWithVoice() {
+  const [value, setValue] = useState("");
+  const ref = useRef<HTMLInputElement>(null);
+
+  return (
+    <div>
+      <input
+        ref={ref}
+        data-testid="input"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <VoiceInputButton
+        inputRef={ref}
+        onTranscribed={(text: string) => setValue((prev) => prev + text)}
+        size="sm"
+      />
+      <div data-testid="value">{value}</div>
+    </div>
+  );
+}
+
+function ConditionalTextareaWithVoice() {
+  const [show, setShow] = useState(false);
+  const [value, setValue] = useState("");
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  return (
+    <div>
+      <button data-testid="toggle" onClick={() => setShow(!show)}>
+        Toggle
+      </button>
+      {show && (
+        <div>
+          <textarea
+            ref={ref}
+            data-testid="textarea"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <VoiceInputButton
+            inputRef={ref}
+            onTranscribed={(text: string) =>
+              setValue((prev) => prev + text)
+            }
+            size="sm"
+          />
+        </div>
+      )}
+      <div data-testid="value">{value}</div>
+    </div>
+  );
+}
+
+describe("VoiceInputButton integration - textarea pattern", () => {
+  beforeEach(() => {
+    capturedStartRecording = vi.fn();
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render VoiceInputButton next to textarea", () => {
+    render(<TextareaWithVoice />);
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    expect(voiceBtn).toBeTruthy();
+
+    const textarea = document.querySelector('[data-testid="textarea"]');
+    expect(textarea).toBeTruthy();
+  });
+
+  it("should call startRecording when clicked", async () => {
+    render(<TextareaWithVoice />);
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(voiceBtn!);
+    });
+
+    expect(capturedStartRecording).toHaveBeenCalledWith("append_only");
+  });
+
+  it("should handle 'insert' mode transcription", async () => {
+    const { getByTestId } = render(<TextareaWithVoice />);
+
+    // Click to start recording first (sets up mode)
+    const voiceBtn = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(voiceBtn!);
+    });
+
+    // Simulate transcription callback
+    await act(async () => {
+      capturedOnTranscribed?.("test transcription");
+    });
+
+    // The onTranscribed callback processes it with mode "insert"
+    // (since append_only → insert in useTextareaVoice)
+    // Verify the component is functional
+    expect(getByTestId("value")).toBeTruthy();
+  });
+});
+
+describe("VoiceInputButton integration - input pattern", () => {
+  beforeEach(() => {
+    capturedStartRecording = vi.fn();
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render VoiceInputButton next to input", () => {
+    render(<InputWithVoice />);
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    expect(voiceBtn).toBeTruthy();
+
+    const input = document.querySelector('[data-testid="input"]');
+    expect(input).toBeTruthy();
+  });
+
+  it("should handle voice input for input element", async () => {
+    render(<InputWithVoice />);
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(voiceBtn!);
+    });
+
+    expect(capturedStartRecording).toHaveBeenCalledWith("append_only");
+  });
+});
+
+describe("VoiceInputButton integration - conditional rendering", () => {
+  beforeEach(() => {
+    capturedStartRecording = vi.fn();
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should not show VoiceInputButton when textarea is not rendered", () => {
+    render(<ConditionalTextareaWithVoice />);
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    expect(voiceBtn).toBeNull();
+  });
+
+  it("should show VoiceInputButton after toggling textarea", async () => {
+    const { getByTestId } = render(<ConditionalTextareaWithVoice />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("toggle"));
+    });
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    expect(voiceBtn).toBeTruthy();
+  });
+
+  it("should allow recording after textarea is shown", async () => {
+    const { getByTestId } = render(<ConditionalTextareaWithVoice />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("toggle"));
+    });
+
+    const voiceBtn = document.querySelector(".wk-vib");
+    await act(async () => {
+      fireEvent.click(voiceBtn!);
+    });
+
+    expect(capturedStartRecording).toHaveBeenCalledWith("append_only");
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     // to PR#1113.
     server: {
       deps: {
-        inline: [/@tiptap\/react/],
+        inline: [/@tiptap\/react/, /@douyinfe\/semi-icons/],
       },
     },
   },

--- a/packages/dmworkbase/src/Components/ThreadCreateModal/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreateModal/index.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react"
 import ThreadIcon from "../Icons/ThreadIcon"
 import classNames from "classnames"
 import WKApp from "../../App"
+import VoiceInputButton from "../VoiceInputButton"
 import "./index.css"
 
 export interface ThreadCreateModalProps {
@@ -23,6 +24,8 @@ export default class ThreadCreateModal extends Component<
   ThreadCreateModalProps,
   ThreadCreateModalState
 > {
+  private inputRef = React.createRef<HTMLInputElement>();
+
   constructor(props: ThreadCreateModalProps) {
     super(props)
     this.state = {
@@ -107,18 +110,41 @@ export default class ThreadCreateModal extends Component<
           </div>
 
           <div className="wk-thread-modal-body">
-            <input
-              className={classNames(
-                "wk-thread-modal-input",
-                error && "wk-thread-modal-input-error"
-              )}
-              type="text"
-              placeholder="输入话题名称"
-              value={name}
-              onChange={this.handleNameChange}
-              maxLength={50}
-              autoFocus
-            />
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <input
+                ref={this.inputRef}
+                className={classNames(
+                  "wk-thread-modal-input",
+                  error && "wk-thread-modal-input-error"
+                )}
+                type="text"
+                placeholder="输入话题名称"
+                value={name}
+                onChange={this.handleNameChange}
+                maxLength={50}
+                autoFocus
+                style={{ flex: 1 }}
+              />
+              <VoiceInputButton
+                inputRef={this.inputRef}
+                onTranscribed={(text, mode, savedRange) => {
+                  let newValue: string;
+                  if (mode === "all") {
+                    newValue = text;
+                  } else if (mode === "selection" && savedRange) {
+                    // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                    const prev = this.state.name;
+                    newValue = prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to);
+                  } else {
+                    const prev = this.state.name;
+                    const pos = savedRange?.from ?? prev.length;
+                    newValue = prev.slice(0, pos) + text + prev.slice(pos);
+                  }
+                  this.setState({ name: newValue.slice(0, 50), error: null });
+                }}
+                size="sm"
+              />
+            </div>
             {error && <div className="wk-thread-modal-error">{error}</div>}
           </div>
 

--- a/packages/dmworkbase/src/Components/VoiceInputButton/VoiceInputButton.stories.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/VoiceInputButton.stories.tsx
@@ -1,0 +1,209 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import React, { useRef } from 'react'
+import VoiceInputButton from './index'
+import VoiceService from '../../Service/VoiceService'
+
+// Patch VoiceService so the component renders without a real backend
+VoiceService.shared.getConfig = () =>
+  Promise.resolve({ enabled: true, max_file_size: 10_000_000 })
+
+const meta: Meta<typeof VoiceInputButton> = {
+  title: 'Base/VoiceInputButton',
+  component: VoiceInputButton,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+语音输入按钮，附加在 input/textarea 旁边，提供语音转文字功能。
+
+**使用约束：**
+- 必须传入 \`inputRef\`，指向一个已挂载的 \`<input>\` 或 \`<textarea>\`
+- 依赖 VoiceService 后端配置（\`/voice/config\`）——未启用时组件不渲染
+- 支持两种尺寸：\`sm\`（默认）和 \`md\`
+- 通过 \`showModeMenu\` 开启"语音输入/语音编辑"模式切换菜单
+- 可通过 \`className="wk-vib--textarea-corner"\` 绝对定位在 textarea 右上角
+        `,
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof VoiceInputButton>
+
+// ── 默认状态（带 input） ──
+export const Default: Story = {
+  name: '默认（sm + input）',
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="输入内容..."
+          style={{ width: 240, padding: '4px 8px', border: '1px solid var(--wk-border-default)', borderRadius: 4 }}
+        />
+        <VoiceInputButton
+          inputRef={inputRef}
+          onTranscribed={(text) => console.log('transcribed:', text)}
+        />
+      </div>
+    )
+  },
+}
+
+// ── 离线/禁用状态 ──
+export const DisabledOffline: Story = {
+  name: '禁用状态（离线模拟）',
+  parameters: {
+    docs: {
+      description: {
+        story: '当网络不可用且无本地模型时，按钮呈 disabled 状态（半透明 + not-allowed 光标）。此处通过不挂载 input 来模拟 disabled。',
+      },
+    },
+  },
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 12, color: 'var(--wk-text-tertiary)' }}>无可用输入框 →</span>
+        <VoiceInputButton
+          inputRef={inputRef}
+          onTranscribed={(text) => console.log('transcribed:', text)}
+        />
+      </div>
+    )
+  },
+}
+
+// ── 尺寸对比 ──
+export const Sizes: Story = {
+  name: '尺寸对比（sm vs md）',
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="共用 input"
+          style={{ width: 240, padding: '4px 8px', border: '1px solid var(--wk-border-default)', borderRadius: 4 }}
+        />
+        <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            <VoiceInputButton
+              inputRef={inputRef}
+              onTranscribed={(text) => console.log('transcribed:', text)}
+              size="sm"
+            />
+            <span style={{ fontSize: 12, color: 'var(--wk-text-tertiary)' }}>sm (24×24)</span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            <VoiceInputButton
+              inputRef={inputRef}
+              onTranscribed={(text) => console.log('transcribed:', text)}
+              size="md"
+            />
+            <span style={{ fontSize: 12, color: 'var(--wk-text-tertiary)' }}>md (28×28)</span>
+          </div>
+        </div>
+      </div>
+    )
+  },
+}
+
+// ── 带模式菜单 ──
+export const WithModeMenu: Story = {
+  name: '带模式菜单（showModeMenu）',
+  parameters: {
+    docs: {
+      description: {
+        story: '启用 `showModeMenu` 后，hover 时显示"语音输入/语音编辑"下拉菜单。需要 textarea 有内容时语音编辑才可用。',
+      },
+    },
+  },
+  render: () => {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <textarea
+          ref={inputRef}
+          defaultValue="这里有一些已有内容，hover 按钮可以看到模式菜单"
+          style={{ width: 320, height: 80, padding: 8, border: '1px solid var(--wk-border-default)', borderRadius: 4, resize: 'none' }}
+        />
+        <div>
+          <VoiceInputButton
+            inputRef={inputRef}
+            onTranscribed={(text) => console.log('transcribed:', text)}
+            getCurrentText={() => inputRef.current?.value ?? ''}
+            showModeMenu
+            size="md"
+          />
+        </div>
+      </div>
+    )
+  },
+}
+
+// ── Textarea 右上角定位 ──
+export const TextareaCorner: Story = {
+  name: 'Textarea 右上角定位',
+  parameters: {
+    docs: {
+      description: {
+        story: '使用 `className="wk-vib--textarea-corner"` 将按钮绝对定位在 textarea 的右上角。父容器需要 `position: relative`。',
+      },
+    },
+  },
+  render: () => {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+    return (
+      <div style={{ position: 'relative', width: 320 }}>
+        <textarea
+          ref={inputRef}
+          placeholder="按钮在右上角..."
+          style={{ width: '100%', height: 100, padding: 8, paddingRight: 36, border: '1px solid var(--wk-border-default)', borderRadius: 4, resize: 'none' }}
+        />
+        <VoiceInputButton
+          inputRef={inputRef}
+          onTranscribed={(text) => console.log('transcribed:', text)}
+          className="wk-vib--textarea-corner"
+        />
+      </div>
+    )
+  },
+}
+
+// ── 空内容时编辑模式不可用 ──
+export const EmptyContentEditGuard: Story = {
+  name: '空内容时编辑模式禁用',
+  parameters: {
+    docs: {
+      description: {
+        story: '当 `showModeMenu` 开启且 `getCurrentText()` 返回空字符串时，"语音编辑"选项置灰不可点击。',
+      },
+    },
+  },
+  render: () => {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <textarea
+          ref={inputRef}
+          placeholder="（空内容 — hover 按钮查看菜单）"
+          style={{ width: 320, height: 60, padding: 8, border: '1px solid var(--wk-border-default)', borderRadius: 4, resize: 'none' }}
+        />
+        <div>
+          <VoiceInputButton
+            inputRef={inputRef}
+            onTranscribed={(text) => console.log('transcribed:', text)}
+            getCurrentText={() => ''}
+            showModeMenu
+            size="md"
+          />
+        </div>
+      </div>
+    )
+  },
+}

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.css
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.css
@@ -1,0 +1,208 @@
+.wk-vib {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.wk-vib--textarea-corner {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+}
+
+.wk-vib--sm .wk-vib__btn {
+  width: 24px;
+  height: 24px;
+}
+
+.wk-vib__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s;
+  color: var(--wk-icon-muted);
+}
+
+.wk-vib__btn:hover {
+  background-color: var(--wk-bg-hover);
+  color: var(--wk-text-primary);
+}
+
+.wk-vib__btn:active {
+  opacity: 0.7;
+}
+
+.wk-vib__btn--recording {
+  background-color: var(--wk-voice-recording-bg);
+  color: var(--wk-voice-recording-color);
+}
+
+.wk-vib__btn--recording:hover {
+  background-color: var(--wk-voice-recording-bg);
+  color: var(--wk-voice-recording-color);
+  opacity: 0.85;
+}
+
+.wk-vib__btn--disabled {
+  color: var(--wk-icon-muted);
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.wk-vib__btn--disabled:hover {
+  background-color: transparent;
+  color: var(--wk-icon-muted);
+}
+
+/* Floating voice indicator */
+.wk-voice-floating-indicator {
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: 184px;
+  height: 48px;
+  padding: 4px 16px;
+  background-color: var(--wk-bg-surface);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: 1000px;
+  box-shadow: 0px 0px 20px 0px var(--wk-black-alpha-08);
+  box-sizing: border-box;
+}
+
+[theme-mode="dark"] .wk-voice-floating-indicator {
+  background-color: var(--wk-bg-surface);
+  border-color: var(--wk-border-subtle);
+  box-shadow: 0px 0px 20px 0px var(--wk-black-alpha-30);
+}
+
+.wk-voice-floating-content {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 0;
+  height: 32px;
+}
+
+.wk-voice-floating-text {
+  font-family: var(--wk-font-sans);
+  font-size: var(--wk-text-size-md);
+  font-weight: 500;
+  line-height: 22px;
+  color: var(--wk-text-primary);
+  white-space: nowrap;
+}
+
+.wk-voice-floating-divider {
+  width: 1px;
+  height: 20px;
+  margin: 0 8px;
+  background-color: var(--wk-border-default);
+  flex-shrink: 0;
+}
+
+.wk-voice-transcribing-spinner {
+  width: 80px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wk-voice-transcribing-spinner::after {
+  content: "";
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--wk-accent-tint-12);
+  border-top-color: var(--wk-color-accent);
+  border-radius: 50%;
+  animation: wk-voice-spin 0.6s linear infinite;
+}
+
+@keyframes wk-voice-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.wk-voice-wave-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 80px;
+  height: 24px;
+  gap: 2px;
+}
+
+.wk-voice-wave-bar {
+  width: 3px;
+  background-color: var(--wk-voice-wave-color);
+  border-radius: 1.5px;
+  animation: wk-voice-wave 0.8s ease-in-out infinite;
+}
+
+.wk-voice-wave-bar:nth-child(1) {
+  animation-delay: 0s;
+}
+.wk-voice-wave-bar:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.wk-voice-wave-bar:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.wk-voice-wave-bar:nth-child(4) {
+  animation-delay: 0.3s;
+}
+.wk-voice-wave-bar:nth-child(5) {
+  animation-delay: 0.4s;
+}
+.wk-voice-wave-bar:nth-child(6) {
+  animation-delay: 0.5s;
+}
+.wk-voice-wave-bar:nth-child(7) {
+  animation-delay: 0.6s;
+}
+.wk-voice-wave-bar:nth-child(8) {
+  animation-delay: 0.7s;
+}
+.wk-voice-wave-bar:nth-child(9) {
+  animation-delay: 0.6s;
+}
+.wk-voice-wave-bar:nth-child(10) {
+  animation-delay: 0.5s;
+}
+.wk-voice-wave-bar:nth-child(11) {
+  animation-delay: 0.4s;
+}
+.wk-voice-wave-bar:nth-child(12) {
+  animation-delay: 0.3s;
+}
+.wk-voice-wave-bar:nth-child(13) {
+  animation-delay: 0.2s;
+}
+.wk-voice-wave-bar:nth-child(14) {
+  animation-delay: 0.1s;
+}
+.wk-voice-wave-bar:nth-child(15) {
+  animation-delay: 0s;
+}
+.wk-voice-wave-bar:nth-child(16) {
+  animation-delay: 0.1s;
+}
+
+@keyframes wk-voice-wave {
+  0%,
+  100% {
+    height: 6px;
+  }
+  50% {
+    height: 20px;
+  }
+}

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -1,0 +1,432 @@
+import React, { useRef, useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { Toast, Dropdown } from "@douyinfe/semi-ui";
+import { Mic } from "lucide-react";
+import useTextareaVoice, { ReplaceMode, SelectionRange } from "./useTextareaVoice";
+import type { ChatContextResult } from "../Conversation/chatContext";
+import type { VoiceMode } from "../../Service/VoiceService";
+import "./index.css";
+
+const VOICE_MODES: { value: VoiceMode; label: string }[] = [
+  { value: "append_only", label: "语音输入" },
+  { value: "edit_only", label: "语音编辑" },
+];
+
+const FLOATING_GAP = 12;
+const INDICATOR_HEIGHT = 48;
+const PREPARING_DELAY_MS = 300;
+const RECORDING_DELAY_MS = 500;
+
+export interface VoiceInputButtonProps {
+  inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+  onTranscribed: (text: string, replaceMode: ReplaceMode, savedSelectionRange?: SelectionRange) => void;
+  getCurrentText?: () => string;
+  showModeMenu?: boolean;
+  size?: "sm" | "md";
+  getChatContext?: () => ChatContextResult | Promise<ChatContextResult>;
+  className?: string;
+  /** Called right before recording starts (useful for cancelling pending blur commits) */
+  onRecordingStart?: () => void;
+}
+
+export default function VoiceInputButton({
+  inputRef,
+  onTranscribed,
+  getCurrentText,
+  showModeMenu = false,
+  size = "sm",
+  getChatContext,
+  className,
+  onRecordingStart,
+}: VoiceInputButtonProps) {
+  const [showMenu, setShowMenu] = useState(false);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  const {
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecordingAndTranscribe,
+    cancelRecording,
+    isVoiceEnabled,
+    localAvailable,
+  } = useTextareaVoice({
+    inputRef,
+    onTranscribed,
+    getCurrentText,
+    enableEditMode: showModeMenu,
+    getChatContext,
+  });
+
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const isOnlineRef = useRef(isOnline);
+  isOnlineRef.current = isOnline;
+  const localAvailableRef = useRef(localAvailable);
+  localAvailableRef.current = localAvailable;
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  const canRecord = isOnline || localAvailable;
+  const isDisabled = !inputRef.current || !canRecord;
+
+  // Floating indicator position
+  const [floatingPosition, setFloatingPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  const updateFloatingPosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setFloatingPosition({
+      top: rect.top - FLOATING_GAP - INDICATOR_HEIGHT,
+      left: rect.left + rect.width / 2,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isRecording && !isTranscribing) {
+      setFloatingPosition(null);
+      return;
+    }
+    updateFloatingPosition();
+    const handleResize = () => updateFloatingPosition();
+    let rafId: number | null = null;
+    const handleScroll = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        updateFloatingPosition();
+        rafId = null;
+      });
+    };
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [isRecording, isTranscribing, updateFloatingPosition]);
+
+  // Esc to cancel during recording
+  useEffect(() => {
+    if (!isRecording) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelRecording();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isRecording, cancelRecording]);
+
+  // Window blur: auto-stop recording
+  useEffect(() => {
+    if (!isRecording) return;
+    const handleBlur = () => stopRecordingAndTranscribe();
+    window.addEventListener("blur", handleBlur);
+    return () => window.removeEventListener("blur", handleBlur);
+  }, [isRecording, stopRecordingAndTranscribe]);
+
+  // Left Shift long-press to start/stop recording
+  const shiftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preparingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shiftRecordingRef = useRef(false);
+  const cancelPendingRef = useRef(false);
+  const startRecordingRef = useRef(startRecording);
+  startRecordingRef.current = startRecording;
+  const stopRecordingRef = useRef(stopRecordingAndTranscribe);
+  stopRecordingRef.current = stopRecordingAndTranscribe;
+  const isRecordingRef = useRef(isRecording);
+  isRecordingRef.current = isRecording;
+  const isTranscribingRef = useRef(isTranscribing);
+  isTranscribingRef.current = isTranscribing;
+
+  const clearShiftTimer = useCallback(() => {
+    if (shiftTimerRef.current !== null) {
+      clearTimeout(shiftTimerRef.current);
+      shiftTimerRef.current = null;
+    }
+    if (preparingTimerRef.current !== null) {
+      clearTimeout(preparingTimerRef.current);
+      preparingTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isRecording && cancelPendingRef.current) {
+      cancelPendingRef.current = false;
+      shiftRecordingRef.current = false;
+      cancelRecording();
+    }
+  }, [isRecording, cancelRecording]);
+
+  useEffect(() => {
+    if (!isVoiceEnabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!inputRef.current || document.activeElement !== inputRef.current) return;
+
+      if (
+        e.code === "ShiftLeft" &&
+        !e.repeat &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        if (
+          !isRecordingRef.current &&
+          !isTranscribingRef.current &&
+          shiftTimerRef.current === null
+        ) {
+          cancelPendingRef.current = false;
+          preparingTimerRef.current = setTimeout(() => {
+            preparingTimerRef.current = null;
+          }, PREPARING_DELAY_MS);
+          shiftTimerRef.current = setTimeout(() => {
+            shiftTimerRef.current = null;
+            if (!isOnlineRef.current && !localAvailableRef.current) {
+              Toast.warning("网络不可用，无法使用语音功能");
+              return;
+            }
+            shiftRecordingRef.current = true;
+            startRecordingRef.current("append_only");
+          }, RECORDING_DELAY_MS);
+        }
+        return;
+      }
+
+      if (shiftTimerRef.current !== null && e.code !== "ShiftLeft") {
+        if (
+          e.code.startsWith("Control") ||
+          e.code.startsWith("Alt") ||
+          e.code.startsWith("Meta")
+        ) {
+          clearShiftTimer();
+          return;
+        }
+        const isIME =
+          e.code.startsWith("Shift") ||
+          e.key === "Process" ||
+          e.key === "Unidentified" ||
+          e.isComposing;
+        if (!isIME) {
+          clearShiftTimer();
+        }
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (!inputRef.current) return;
+      const isInputFocused = document.activeElement === inputRef.current;
+
+      if (!isRecordingRef.current && !isInputFocused) return;
+
+      if (e.code === "ShiftLeft" && shiftTimerRef.current !== null) {
+        clearShiftTimer();
+        return;
+      }
+
+      if (
+        e.code === "ShiftLeft" &&
+        shiftRecordingRef.current &&
+        !isRecordingRef.current
+      ) {
+        cancelPendingRef.current = true;
+        shiftRecordingRef.current = false;
+        return;
+      }
+
+      if (
+        e.code === "ShiftLeft" &&
+        shiftRecordingRef.current &&
+        isRecordingRef.current
+      ) {
+        shiftRecordingRef.current = false;
+        e.preventDefault();
+        stopRecordingRef.current();
+        return;
+      }
+    };
+
+    const handleBlurClear = () => {
+      clearShiftTimer();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlurClear);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlurClear);
+      clearShiftTimer();
+    };
+  }, [isVoiceEnabled, inputRef, clearShiftTimer]);
+
+  if (!isVoiceEnabled) return null;
+
+  const handleVoiceClick = () => {
+    setShowMenu(false);
+    if (!canRecord) {
+      Toast.warning("网络不可用，无法使用语音功能");
+      return;
+    }
+    if (!inputRef.current) return;
+    onRecordingStart?.();
+    startRecording("append_only");
+  };
+
+  const handleModeSelect = (selectedMode: VoiceMode) => {
+    setShowMenu(false);
+    if (!canRecord || !inputRef.current) return;
+    onRecordingStart?.();
+    startRecording(selectedMode);
+  };
+
+  const handleStopClick = () => {
+    stopRecordingAndTranscribe();
+  };
+
+  const iconSize = size === "sm" ? 16 : 18;
+
+  const rootClasses = [
+    "wk-vib",
+    size === "sm" ? "wk-vib--sm" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // Recording or transcribing state
+  if (isRecording || isTranscribing) {
+    const statusText = isTranscribing ? "转写中" : "语音输入";
+
+    const floatingIndicator = floatingPosition ? (
+      <div
+        className="wk-voice-floating-indicator"
+        style={{
+          top: floatingPosition.top,
+          left: floatingPosition.left,
+          transform: "translateX(-50%)",
+        }}
+      >
+        <div className="wk-voice-floating-content">
+          <span className="wk-voice-floating-text">{statusText}</span>
+        </div>
+        <span className="wk-voice-floating-divider" />
+        {isTranscribing ? (
+          <div className="wk-voice-transcribing-spinner" />
+        ) : (
+          <div className="wk-voice-wave-container">
+            {Array.from({ length: 16 }, (_, i) => (
+              <span key={i} className="wk-voice-wave-bar" />
+            ))}
+          </div>
+        )}
+      </div>
+    ) : null;
+
+    return (
+      <>
+        {floatingIndicator && createPortal(floatingIndicator, document.body)}
+        <div
+          className={rootClasses}
+          ref={buttonRef}
+          onClick={isRecording ? handleStopClick : undefined}
+          style={{ cursor: isRecording ? "pointer" : "default" }}
+        >
+          <div
+            className="wk-vib__btn wk-vib__btn--recording"
+            title={isTranscribing ? "转写中..." : "点击停止录音"}
+            role="button"
+            tabIndex={0}
+          >
+            <Mic size={iconSize} color="currentColor" />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // Default idle state
+  if (showModeMenu) {
+    const currentText = getCurrentText?.() ?? "";
+    const hasContent = currentText.trim().length > 0;
+    const dropdownMenu = (
+      <Dropdown.Menu style={{ width: 140 }}>
+        {VOICE_MODES.map((mode) => {
+          const isEditMode = mode.value === "edit_only";
+          const itemDisabled = isEditMode && !hasContent;
+          return (
+            <Dropdown.Item
+              key={mode.value}
+              onClick={() => !itemDisabled && handleModeSelect(mode.value)}
+              disabled={itemDisabled}
+              title={itemDisabled ? "输入框为空，无法使用语音编辑" : undefined}
+            >
+              {mode.label}
+            </Dropdown.Item>
+          );
+        })}
+      </Dropdown.Menu>
+    );
+
+    return (
+      <Dropdown
+        trigger="hover"
+        position="topRight"
+        render={dropdownMenu}
+        visible={canRecord && !!inputRef.current ? showMenu : false}
+        onVisibleChange={setShowMenu}
+        spacing={4}
+      >
+        <div
+          className={rootClasses}
+          ref={buttonRef}
+          onClick={handleVoiceClick}
+          style={{ cursor: isDisabled ? "not-allowed" : "pointer" }}
+        >
+          <div
+            className={`wk-vib__btn ${isDisabled ? "wk-vib__btn--disabled" : ""}`}
+            title={canRecord ? "语音输入" : "网络不可用"}
+            role="button"
+            tabIndex={isDisabled ? -1 : 0}
+          >
+            <Mic size={iconSize} color="currentColor" />
+          </div>
+        </div>
+      </Dropdown>
+    );
+  }
+
+  return (
+    <div
+      className={rootClasses}
+      ref={buttonRef}
+      onClick={handleVoiceClick}
+      style={{ cursor: isDisabled ? "not-allowed" : "pointer" }}
+    >
+      <div
+        className={`wk-vib__btn ${isDisabled ? "wk-vib__btn--disabled" : ""}`}
+        title={canRecord ? "语音输入" : "网络不可用"}
+        role="button"
+        tabIndex={isDisabled ? -1 : 0}
+      >
+        <Mic size={iconSize} color="currentColor" />
+      </div>
+    </div>
+  );
+}
+
+export type { ReplaceMode, SelectionRange };

--- a/packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts
@@ -1,0 +1,111 @@
+import { useRef, useCallback } from "react";
+import useVoiceInput from "../MessageInput/useVoiceInput";
+import type { ChatContextResult } from "../Conversation/chatContext";
+import type { VoiceMode } from "../../Service/VoiceService";
+
+export type ReplaceMode = "all" | "selection" | "insert";
+
+export interface SelectionRange {
+  from: number;
+  to: number;
+}
+
+export interface UseTextareaVoiceOptions {
+  inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+  onTranscribed: (text: string, replaceMode: ReplaceMode, savedSelectionRange?: SelectionRange) => void;
+  getCurrentText?: () => string;
+  enableEditMode?: boolean;
+  getChatContext?: () => ChatContextResult | Promise<ChatContextResult>;
+}
+
+export interface UseTextareaVoiceReturn {
+  isRecording: boolean;
+  isTranscribing: boolean;
+  startRecording: (mode?: VoiceMode) => void;
+  stopRecordingAndTranscribe: () => void;
+  cancelRecording: () => void;
+  isVoiceEnabled: boolean;
+  localAvailable: boolean;
+}
+
+export default function useTextareaVoice({
+  inputRef,
+  onTranscribed,
+  getCurrentText,
+  enableEditMode = false,
+  getChatContext,
+}: UseTextareaVoiceOptions): UseTextareaVoiceReturn {
+  const hadSelectionRef = useRef(false);
+  const savedSelectionRangeRef = useRef<SelectionRange>({ from: 0, to: 0 });
+  const savedSelectedTextRef = useRef<string | undefined>(undefined);
+  const recordingModeRef = useRef<VoiceMode>("append_only");
+
+  const onTranscribedRef = useRef(onTranscribed);
+  onTranscribedRef.current = onTranscribed;
+  const getCurrentTextRef = useRef(getCurrentText);
+  getCurrentTextRef.current = getCurrentText;
+
+  const {
+    isRecording,
+    isTranscribing,
+    startRecording: rawStartRecording,
+    stopRecordingAndTranscribe: rawStop,
+    cancelRecording,
+    isVoiceEnabled,
+    localAvailable,
+  } = useVoiceInput({
+    onTranscribed: (text: string) => {
+      const mode = recordingModeRef.current;
+      const range = savedSelectionRangeRef.current;
+      if (mode === "edit_only") {
+        if (hadSelectionRef.current) {
+          onTranscribedRef.current(text, "selection", range);
+        } else {
+          onTranscribedRef.current(text, "all", range);
+        }
+      } else {
+        onTranscribedRef.current(text, "insert", range);
+      }
+    },
+    getChatContext,
+    mode: "append_only",
+    onError: () => {},
+  });
+
+  const startRecording = useCallback(
+    (mode?: VoiceMode) => {
+      if (!inputRef.current) return;
+
+      const el = inputRef.current;
+      const selStart = el.selectionStart ?? 0;
+      const selEnd = el.selectionEnd ?? 0;
+      hadSelectionRef.current = selStart !== selEnd;
+      savedSelectionRangeRef.current = { from: selStart, to: selEnd };
+      const selectedText = (selStart !== selEnd) ? el.value.slice(selStart, selEnd) : undefined;
+      savedSelectedTextRef.current = selectedText;
+
+      const effectiveMode = mode ?? "append_only";
+      recordingModeRef.current = effectiveMode;
+      rawStartRecording(effectiveMode);
+    },
+    [inputRef, rawStartRecording],
+  );
+
+  const stopRecordingAndTranscribe = useCallback(() => {
+    const contextText =
+      recordingModeRef.current === "edit_only"
+        ? (savedSelectedTextRef.current || getCurrentTextRef.current?.())
+        : undefined;
+    rawStop(contextText);
+  }, [rawStop]);
+
+  return {
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecordingAndTranscribe,
+    cancelRecording,
+    isVoiceEnabled,
+    localAvailable,
+  };
+}

--- a/packages/dmworkbase/src/Components/WKViewQueue/index.tsx
+++ b/packages/dmworkbase/src/Components/WKViewQueue/index.tsx
@@ -106,28 +106,23 @@ export default class WKViewQueue extends Component<WKViewQueueProps, WKViewQueue
         })
     }
     pop(): void {
-       
-        const { viewCount,queues  } = this.state
-        if(queues.length === 0) {
-            return
-        }
-        this.setState({
-            status: WKViewQueueStatus.Pop,
-            viewCount: queues.length-1,
-        },()=>{
-            this.notifyRouteChange()
-        })
+        this.setState((prevState) => {
+            if (prevState.queues.length === 0) return null;
+            return {
+                status: WKViewQueueStatus.Pop,
+                viewCount: prevState.queues.length - 1,
+            };
+        }, () => {
+            this.notifyRouteChange();
+        });
     }
 
     poped() {
-        const {queues} = this.state
-        queues.splice(queues.length-1,1)
-        
-       this.setState({
-           queues:  queues,
-       },()=>{
-           this.notifyRouteChange()
-       })
+        this.setState((prevState) => ({
+            queues: prevState.queues.slice(0, -1),
+        }), () => {
+            this.notifyRouteChange();
+        });
     }
 
     popToRoot(): void {
@@ -141,12 +136,11 @@ export default class WKViewQueue extends Component<WKViewQueueProps, WKViewQueue
 
 
     push(view: JSX.Element): void {
-       const { queues,viewCount } = this.state
-       this.setState({
-           queues: [...queues,view],
-           viewCount:  queues.length + 1,
+       this.setState((prevState) => ({
+           queues: [...prevState.queues, view],
+           viewCount:  prevState.queues.length + 1,
            status: WKViewQueueStatus.Push,
-       },()=>{
+       }),()=>{
         this.notifyRouteChange()
        })
     }

--- a/packages/dmworksummary/src/components/SummaryEditor.tsx
+++ b/packages/dmworksummary/src/components/SummaryEditor.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 import { Button, Toast } from "@douyinfe/semi-ui";
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
 
 interface SummaryEditorProps {
@@ -84,14 +86,40 @@ export default class SummaryEditor extends Component<SummaryEditorProps, Summary
 
         return (
             <div className="summary-editor">
-                <textarea
-                    ref={this.textareaRef}
-                    className="summary-editor-textarea"
-                    value={content}
-                    onChange={this.handleChange}
-                    disabled={saving}
-                    placeholder="编辑总结内容..."
-                />
+                <div style={{ position: "relative" }}>
+                    <textarea
+                        ref={this.textareaRef}
+                        className="summary-editor-textarea"
+                        value={content}
+                        onChange={this.handleChange}
+                        disabled={saving}
+                        placeholder="编辑总结内容..."
+                    />
+                    {!saving && (
+                        <VoiceInputButton
+                            inputRef={this.textareaRef}
+                            onTranscribed={(text: string, mode: ReplaceMode, savedRange?: SelectionRange) => {
+                                if (mode === "all") {
+                                    this.setState({ content: text }, this.adjustHeight);
+                                } else if (mode === "selection" && savedRange) {
+                                    // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                                    this.setState(prev => ({
+                                        content: prev.content.slice(0, savedRange.from) + text + prev.content.slice(savedRange.to),
+                                    }), this.adjustHeight);
+                                } else {
+                                    this.setState(prev => {
+                                        const pos = savedRange?.from ?? prev.content.length;
+                                        return { content: prev.content.slice(0, pos) + text + prev.content.slice(pos) };
+                                    }, this.adjustHeight);
+                                }
+                            }}
+                            getCurrentText={() => this.state.content}
+                            showModeMenu
+                            size="md"
+                            className="wk-vib--textarea-corner"
+                        />
+                    )}
+                </div>
                 <div className="summary-editor-actions">
                     <Button onClick={onCancel} disabled={saving}>
                         取消

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -1225,6 +1225,21 @@
     border-radius: 0;
 }
 
+.summary-workbench-textarea {
+    display: block;
+    width: 100%;
+    border: none;
+    outline: none;
+    resize: none;
+    background: transparent;
+    padding: 12px 16px;
+    font-family: inherit;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--semi-color-text-0);
+    box-sizing: border-box;
+}
+
 .summary-workbench-actions {
     display: flex;
     align-items: center;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1,7 +1,6 @@
-import React, { Component } from "react";
+import React, { Component, createRef } from "react";
 import {
     Button,
-    TextArea,
     Toast,
     Typography,
     Tag,
@@ -9,6 +8,8 @@ import {
 } from "@douyinfe/semi-ui";
 import { IconPlus } from "@douyinfe/semi-icons";
 import WKApp from "@octo/base/src/App";
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
 import SummaryDetailPage from "./SummaryDetailPage";
 import ChatSelectorModal from "../components/ChatSelectorModal";
@@ -52,6 +53,8 @@ const TEMPLATE_ICONS: Record<string, string> = {
 };
 
 export default class SummaryCreatePage extends Component<SummaryCreatePageProps, SummaryCreatePageState> {
+    private textareaRef = createRef<HTMLTextAreaElement>();
+
     state: SummaryCreatePageState = {
         topic: "",
         templates: [],
@@ -96,6 +99,24 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     canSubmit(): boolean {
         return this.state.topic.trim().length > 0;
     }
+
+    handleVoiceTranscribed = (text: string, mode: ReplaceMode, savedRange?: SelectionRange) => {
+        if (mode === "all") {
+            this.setState({ topic: text.slice(0, 1000) });
+        } else if (mode === "selection" && savedRange) {
+            // Note: savedRange indices are from recording start; assumes input is read-only during recording
+            this.setState((prev) => {
+                const updated = prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to);
+                return { topic: updated.slice(0, 1000) };
+            });
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.topic.length;
+                const updated = prev.topic.slice(0, pos) + text + prev.topic.slice(pos);
+                return { topic: updated.slice(0, 1000) };
+            });
+        }
+    };
 
     handleSubmit = async () => {
         const { topic, selectedChats, selectedMembers, scheduleConfig } = this.state;
@@ -179,15 +200,25 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
                 {/* Main input */}
                 <div className="summary-workbench-input-area">
-                    <TextArea
-                        value={topic}
-                        onChange={(val) => this.setState({ topic: val.slice(0, 1000) })}
-                        placeholder="输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点..."
-                        rows={4}
-                        style={{ resize: "none", fontSize: 15 }}
-                        autosize={false}
-                        maxLength={1000}
-                    />
+                    <div style={{ position: "relative" }}>
+                        <textarea
+                            ref={this.textareaRef}
+                            className="summary-workbench-textarea"
+                            value={topic}
+                            onChange={(e) => this.setState({ topic: e.target.value.slice(0, 1000) })}
+                            placeholder="输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点..."
+                            rows={4}
+                            maxLength={1000}
+                        />
+                        <VoiceInputButton
+                            inputRef={this.textareaRef}
+                            onTranscribed={this.handleVoiceTranscribed}
+                            getCurrentText={() => this.state.topic}
+                            showModeMenu
+                            size="sm"
+                            className="wk-vib--textarea-corner"
+                        />
+                    </div>
                     {topic.length >= 1000 && (
                         <div style={{ color: "var(--semi-color-warning)", fontSize: 12, marginTop: 4, padding: "0 12px 8px" }}>
                             已达到 1000 字符上限

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { DatePicker } from "@douyinfe/semi-ui";
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type {
   MatterDetail,
   MatterStatus,
@@ -1816,6 +1817,7 @@ function ActivityPanel({
 
 function TimelineInput({ onSubmit }: { onSubmit: (content: string) => void }) {
   const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const handleSubmit = () => {
     if (!value.trim()) return;
     onSubmit(value);
@@ -1824,6 +1826,7 @@ function TimelineInput({ onSubmit }: { onSubmit: (content: string) => void }) {
   return (
     <div className="wk-mp-tl-input">
       <input
+        ref={inputRef}
         type="text"
         className="wk-mp-tl-input__field"
         placeholder="添加进展或评论..."
@@ -1832,6 +1835,23 @@ function TimelineInput({ onSubmit }: { onSubmit: (content: string) => void }) {
         onKeyDown={(e) => {
           if (e.key === "Enter") handleSubmit();
         }}
+      />
+      <VoiceInputButton
+        inputRef={inputRef}
+        onTranscribed={(text, mode, savedRange) => {
+          if (mode === "all") {
+            setValue(text);
+          } else if (mode === "selection" && savedRange) {
+            // Note: savedRange indices are from recording start; assumes input is read-only during recording
+            setValue((prev) => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+          } else {
+            setValue((prev) => {
+              const pos = savedRange?.from ?? prev.length;
+              return prev.slice(0, pos) + text + prev.slice(pos);
+            });
+          }
+        }}
+        size="sm"
       />
       <button
         type="button"
@@ -1857,6 +1877,8 @@ function EditableTitle({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setDraft(value);
@@ -1865,6 +1887,19 @@ function EditableTitle({
   useEffect(() => {
     if (editing) inputRef.current?.focus();
   }, [editing]);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    };
+  }, []);
+
+  const cancelPendingCommit = () => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+  };
 
   const commit = async () => {
     const trimmed = draft.trim();
@@ -1884,21 +1919,51 @@ function EditableTitle({
 
   if (editing) {
     return (
-      <input
-        ref={inputRef}
-        className="wk-mp-header__title wk-mp-header__title--editing"
-        value={draft}
-        maxLength={500}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") commit();
-          if (e.key === "Escape") {
-            setDraft(value);
-            setEditing(false);
-          }
-        }}
-      />
+      <div ref={containerRef} style={{ position: "relative", display: "flex", alignItems: "center", gap: 4 }}>
+        <input
+          ref={inputRef}
+          className="wk-mp-header__title wk-mp-header__title--editing"
+          value={draft}
+          maxLength={500}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={(e) => {
+            if (containerRef.current?.contains(e.relatedTarget as Node)) return;
+            cancelPendingCommit();
+            commitTimerRef.current = setTimeout(commit, 200);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { cancelPendingCommit(); commit(); }
+            if (e.key === "Escape") {
+              cancelPendingCommit();
+              setDraft(value);
+              setEditing(false);
+            }
+          }}
+        />
+        <VoiceInputButton
+          inputRef={inputRef}
+          onRecordingStart={cancelPendingCommit}
+          onTranscribed={(text, mode, savedRange) => {
+            cancelPendingCommit();
+            let newValue: string;
+            if (mode === "all") {
+              newValue = text;
+            } else if (mode === "selection" && savedRange) {
+              // Note: savedRange indices are from recording start; assumes input is read-only during recording
+              newValue = draft.slice(0, savedRange.from) + text + draft.slice(savedRange.to);
+            } else {
+              const pos = savedRange?.from ?? draft.length;
+              newValue = draft.slice(0, pos) + text + draft.slice(pos);
+            }
+            setDraft(newValue.slice(0, 500));
+            // Refocus so next click-away triggers blur → commit
+            setTimeout(() => inputRef.current?.focus(), 0);
+          }}
+          getCurrentText={() => draft}
+          showModeMenu
+          size="sm"
+        />
+      </div>
     );
   }
 
@@ -1925,6 +1990,8 @@ function EditableDescription({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setDraft(value);
@@ -1933,11 +2000,23 @@ function EditableDescription({
   useEffect(() => {
     if (editing && textareaRef.current) {
       textareaRef.current.focus();
-      // 自动调整高度
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = textareaRef.current.scrollHeight + "px";
     }
   }, [editing]);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    };
+  }, []);
+
+  const cancelPendingCommit = () => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+  };
 
   const commit = async () => {
     const trimmed = draft.trim();
@@ -1957,25 +2036,55 @@ function EditableDescription({
 
   if (editing) {
     return (
-      <textarea
-        ref={textareaRef}
-        className="wk-mp-goal__text wk-mp-goal__text--editing"
-        value={draft}
-        maxLength={10000}
-        onChange={(e) => {
-          setDraft(e.target.value);
-          // 动态调整高度
-          e.target.style.height = "auto";
-          e.target.style.height = e.target.scrollHeight + "px";
-        }}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            setDraft(value);
-            setEditing(false);
-          }
-        }}
-      />
+      <div ref={containerRef} style={{ position: "relative" }}>
+        <textarea
+          ref={textareaRef}
+          className="wk-mp-goal__text wk-mp-goal__text--editing"
+          value={draft}
+          maxLength={10000}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            e.target.style.height = "auto";
+            e.target.style.height = e.target.scrollHeight + "px";
+          }}
+          onBlur={(e) => {
+            if (containerRef.current?.contains(e.relatedTarget as Node)) return;
+            cancelPendingCommit();
+            commitTimerRef.current = setTimeout(commit, 200);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              cancelPendingCommit();
+              setDraft(value);
+              setEditing(false);
+            }
+          }}
+        />
+        <VoiceInputButton
+          inputRef={textareaRef}
+          onRecordingStart={cancelPendingCommit}
+          onTranscribed={(text, mode, savedRange) => {
+            cancelPendingCommit();
+            let newValue: string;
+            if (mode === "all") {
+              newValue = text;
+            } else if (mode === "selection" && savedRange) {
+              // Note: savedRange indices are from recording start; assumes input is read-only during recording
+              newValue = draft.slice(0, savedRange.from) + text + draft.slice(savedRange.to);
+            } else {
+              const pos = savedRange?.from ?? draft.length;
+              newValue = draft.slice(0, pos) + text + draft.slice(pos);
+            }
+            setDraft(newValue.slice(0, 10000));
+            // Refocus so next click-away triggers blur → commit
+            setTimeout(() => textareaRef.current?.focus(), 0);
+          }}
+          getCurrentText={() => draft}
+          showModeMenu
+          size="sm"
+          className="wk-vib--textarea-corner"
+        />
+      </div>
     );
   }
 

--- a/packages/dmworktodo/src/ui/CreateTaskModal/index.tsx
+++ b/packages/dmworktodo/src/ui/CreateTaskModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { Modal, DatePicker } from '@douyinfe/semi-ui';
+import VoiceInputButton from '@octo/base/src/Components/VoiceInputButton';
 import type { CreateMatterReq } from '../../bridge/types';
 import MemberPicker from '../MemberPicker';
 import './index.css';
@@ -95,6 +96,7 @@ export default function CreateTaskModal({
 
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLTextAreaElement>(null);
   // 用 join 做稳定的 key，避免每次渲染新数组引用触发 effect（比 JSON.stringify 更轻量）
   const prefillAssigneeUidsKey = prefillAssigneeUids.join(',');
   // stablePrefillAssigneeUids：用 key 做稳定化，避免每次渲染新数组引用导致 isDirty useMemo 失效
@@ -228,16 +230,41 @@ export default function CreateTaskModal({
         {/* 事项名 */}
         <div className="wk-create-task-modal__field">
           <label className="wk-create-task-modal__label">事项名</label>
-          <input
-            ref={titleInputRef}
-            type="text"
-            className={`wk-create-task-modal__input${sendOnConfirm ? ' wk-create-task-modal__input--readonly' : ''}`}
-            placeholder="输入事项名称..."
-            value={title}
-            onChange={sendOnConfirm ? () => {} : (e) => setTitle(e.target.value)}
-            readOnly={sendOnConfirm}
-            autoFocus={false}
-          />
+          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <input
+              ref={titleInputRef}
+              type="text"
+              className={`wk-create-task-modal__input${sendOnConfirm ? ' wk-create-task-modal__input--readonly' : ''}`}
+              placeholder="输入事项名称..."
+              value={title}
+              onChange={sendOnConfirm ? () => {} : (e) => setTitle(e.target.value)}
+              readOnly={sendOnConfirm}
+              autoFocus={false}
+              style={{ flex: 1 }}
+            />
+            {!sendOnConfirm && (
+              <VoiceInputButton
+                inputRef={titleInputRef}
+                onTranscribed={(text, mode, savedRange) => {
+                  let newValue: string;
+                  if (mode === "all") {
+                    newValue = text;
+                  } else if (mode === "selection" && savedRange) {
+                    // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                    const prev = title;
+                    newValue = prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to);
+                  } else {
+                    const prev = title;
+                    const pos = savedRange?.from ?? prev.length;
+                    newValue = prev.slice(0, pos) + text + prev.slice(pos);
+                  }
+                  setTitle(newValue.slice(0, 200));
+                }}
+                getCurrentText={() => title}
+                size="sm"
+              />
+            )}
+          </div>
         </div>
 
         {/* 负责人 */}
@@ -301,13 +328,36 @@ export default function CreateTaskModal({
           ) : (
             <>
               <label className="wk-create-task-modal__label">备注</label>
-              <textarea
-                className="wk-create-task-modal__textarea"
-                placeholder="添加事项备注..."
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                rows={3}
-              />
+              <div style={{ position: "relative" }}>
+                <textarea
+                  ref={descRef}
+                  className="wk-create-task-modal__textarea"
+                  placeholder="添加事项备注..."
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={3}
+                />
+                <VoiceInputButton
+                  inputRef={descRef}
+                  onTranscribed={(text, mode, savedRange) => {
+                    if (mode === "all") {
+                      setDescription(text);
+                    } else if (mode === "selection" && savedRange) {
+                      // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                      setDescription(prev => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+                    } else {
+                      setDescription(prev => {
+                        const pos = savedRange?.from ?? prev.length;
+                        return prev.slice(0, pos) + text + prev.slice(pos);
+                      });
+                    }
+                  }}
+                  getCurrentText={() => description}
+                  showModeMenu
+                  size="sm"
+                  className="wk-vib--textarea-corner"
+                />
+              </div>
             </>
           )}
         </div>

--- a/packages/dmworktodo/src/ui/QuickAddBar/index.tsx
+++ b/packages/dmworktodo/src/ui/QuickAddBar/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import * as api from '../../api/todoApi';
+import VoiceInputButton from '@octo/base/src/Components/VoiceInputButton';
 import type { CreateMatterReq, Matter } from '../../bridge/types';
 import CreateTaskModal from '../CreateTaskModal';
 import { Toast } from '../../utils/toast';
@@ -97,6 +98,23 @@ export default function QuickAddBar({
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={creating}
+        />
+        <VoiceInputButton
+          inputRef={inputRef}
+          onTranscribed={(text, mode, savedRange) => {
+            if (mode === "all") {
+              setTitle(text);
+            } else if (mode === "selection" && savedRange) {
+              // Note: savedRange indices are from recording start; assumes input is read-only during recording
+              setTitle((prev) => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+            } else {
+              setTitle((prev) => {
+                const pos = savedRange?.from ?? prev.length;
+                return prev.slice(0, pos) + text + prev.slice(pos);
+              });
+            }
+          }}
+          size="sm"
         />
         <button
           type="button"

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Modal, DatePicker, Spin } from "@douyinfe/semi-ui";
 import { WKApp } from "@octo/base";
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import type { CreateMatterReq, ExtractMessage } from "../../bridge/types";
 import MemberPicker from "../MemberPicker";
 import { Toast } from "../../utils/toast";
@@ -74,6 +76,7 @@ export default function SmartCreateModal({
   const [submitting, setSubmitting] = useState(false);
 
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const briefRef = useRef<HTMLTextAreaElement>(null);
 
   // 打开时聚焦标题输入框，设置默认负责人
   useEffect(() => {
@@ -215,14 +218,36 @@ export default function SmartCreateModal({
               <label className="wk-smart-create-modal__label">
                 标题 <span className="wk-smart-create-modal__req">*</span>
               </label>
-              <input
-                ref={titleInputRef}
-                type="text"
-                className="wk-smart-create-modal__input"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="事件标题"
-              />
+              <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 4 }}>
+                <input
+                  ref={titleInputRef}
+                  type="text"
+                  className="wk-smart-create-modal__input"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="事件标题"
+                  style={{ flex: 1 }}
+                />
+                <VoiceInputButton
+                  inputRef={titleInputRef}
+                  onTranscribed={(text, mode, savedRange) => {
+                    if (mode === "all") {
+                      setTitle(text);
+                    } else if (mode === "selection" && savedRange) {
+                      // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                      setTitle(prev => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+                    } else {
+                      setTitle(prev => {
+                        const pos = savedRange?.from ?? prev.length;
+                        return prev.slice(0, pos) + text + prev.slice(pos);
+                      });
+                    }
+                  }}
+                  getCurrentText={() => title}
+                  showModeMenu
+                  size="sm"
+                />
+              </div>
             </div>
 
             {/* 主要目标 */}
@@ -230,13 +255,36 @@ export default function SmartCreateModal({
               <label className="wk-smart-create-modal__label">
                 主要目标 <span className="wk-smart-create-modal__req">*</span>
               </label>
-              <textarea
-                className="wk-smart-create-modal__textarea"
-                value={brief}
-                onChange={(e) => setBrief(e.target.value)}
-                placeholder="一句话说清这件事"
-                rows={3}
-              />
+              <div style={{ position: "relative" }}>
+                <textarea
+                  ref={briefRef}
+                  className="wk-smart-create-modal__textarea"
+                  value={brief}
+                  onChange={(e) => setBrief(e.target.value)}
+                  placeholder="一句话说清这件事"
+                  rows={3}
+                />
+                <VoiceInputButton
+                  inputRef={briefRef}
+                  onTranscribed={(text, mode, savedRange) => {
+                    if (mode === "all") {
+                      setBrief(text);
+                    } else if (mode === "selection" && savedRange) {
+                      // Note: savedRange indices are from recording start; assumes input is read-only during recording
+                      setBrief(prev => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to));
+                    } else {
+                      setBrief(prev => {
+                        const pos = savedRange?.from ?? prev.length;
+                        return prev.slice(0, pos) + text + prev.slice(pos);
+                      });
+                    }
+                  }}
+                  getCurrentText={() => brief}
+                  showModeMenu
+                  size="sm"
+                  className="wk-vib--textarea-corner"
+                />
+              </div>
             </div>
 
             {/* 负责人 */}


### PR DESCRIPTION
## Summary

Add speech-to-text (voice input) capability to all text input fields across the application, not just the main chat composer.

Closes #43

## Scope

**6 scenarios, 9+ input fields:**

| Scenario | Input Fields | Voice Modes |
|----------|-------------|-------------|
| Thread creation modal | Thread name | Input |
| Create task modal | Title, Description | Input (title), Input + Edit (description) |
| Quick add bar | Quick input | Input |
| Smart create modal | Title, Main objective | Input + Edit |
| Matter detail panel | Timeline comment, Title (editable), Description (editable) | Input (comment), Input + Edit (title & description) |
| Summary creation page | Topic | Input + Edit |
| Summary editor | Content | Input + Edit |

## Key Design Decisions

### 1. Reusable `VoiceInputButton` Component
New shared component in `@octo/base` with:
- Configurable `showModeMenu` for dual-mode (input + edit) support
- `onRecordingStart` callback for blur coordination
- `getCurrentText` for empty-content guard on edit mode
- Left Shift long-press support (500ms threshold)
- Floating recording indicator via portal

### 2. Blur-Safe Integration for Inline-Editable Fields
Matter title and description use click-to-edit with blur-to-save. The Semi-UI Dropdown renders in a portal outside the container, so standard `relatedTarget` checks fail.

**Solution:** Delayed commit (200ms `setTimeout`) + `onRecordingStart` callback cancels the pending commit before recording begins. Post-transcription auto-refocus ensures subsequent click-away properly triggers save.

### 3. View Stack Race Condition Fix
`WKViewQueue.push()` used direct `this.state` read, causing stale state when `popToRoot()` + `push()` are called sequentially. Changed to functional `setState` to chain correctly.

### 4. Empty Content Guard
When `showModeMenu` is enabled, the "Voice Edit" dropdown item is disabled (grayed out) if the input field is empty, preventing errors from attempting to edit nonexistent content.

## Files Changed

**New files (3):**
- `packages/dmworkbase/src/Components/VoiceInputButton/index.tsx` — Main component
- `packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts` — Recording hook
- `packages/dmworkbase/src/Components/VoiceInputButton/index.css` — Styles

**Modified files (10):**
- `ThreadCreateModal` — Voice input for thread name
- `CreateTaskModal` — Voice input for title + description
- `QuickAddBar` — Voice input for quick add
- `SmartCreateModal` — Voice input + edit for title + objective
- `MatterDetailPanel` — Voice for timeline comment, editable title, editable description
- `SummaryCreatePage` — Voice input + edit for topic
- `SummaryEditor` — Voice input + edit for content
- `WKViewQueue` — Functional setState fix
- `packages/dmworksummary/src/index.css` — Textarea styles for SummaryCreatePage

**Test files (6):**
- `voiceInputButton.test.tsx` — Core component tests
- `voiceInputButtonPositioning.test.tsx` — Right-side positioning tests
- `voiceInputButtonShiftLongPress.test.tsx` — Shift long-press tests
- `summaryCreatePageVoice.test.tsx` — SummaryCreatePage integration
- `useTextareaVoice.test.ts` — Hook unit tests
- `voiceInputIntegration.test.tsx` — Cross-component integration tests