### PR TITLE
fix(contextmenu): fix submenu hover gap — move bridge pseudo-element to parent li

### DIFF
--- a/packages/dmworkbase/src/Components/ContextMenus/index.css
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.css
@@ -122,15 +122,14 @@ body[theme-mode=dark] .wk-ctx-submenu {
     display: block;
 }
 
-/* 隐形桥接：覆盖父项与子菜单之间的 4px 间隙，
-   防止鼠标对角线移动时短暂离开父 li 触发 :hover 失效、子菜单消失 */
-.wk-ctx-submenu::before {
+/* Bridge: extend the hover area of the parent li rightward to cover the 4px gap */
+.wk-contextmenus li:has(> .wk-ctx-submenu)::after {
     content: "";
     position: absolute;
-    top: -4px;
-    bottom: -4px;
-    left: -8px;
+    top: 0;
+    right: -8px;
     width: 8px;
+    height: 100%;
 }
 
 /* 子菜单向左展开（靠近右侧视口边缘时） */
@@ -139,9 +138,9 @@ body[theme-mode=dark] .wk-ctx-submenu {
     right: calc(100% + 4px);
 }
 
-.wk-contextmenus-flip-submenu .wk-ctx-submenu::before {
-    left: auto;
-    right: -8px;
+.wk-contextmenus-flip-submenu li:has(> .wk-ctx-submenu)::after {
+    right: auto;
+    left: -8px;
 }
 
 .wk-ctx-submenu li {


### PR DESCRIPTION
## Summary

Fix the submenu disappearing issue when moving the mouse from a parent menu item toward its submenu. The submenu was nearly impossible to click due to a 4px gap where hover was lost.

## Related Issue

<!-- No existing issue tracked for this specific bug; discovered during manual testing of the context menu. -->

## Changes

- Remove broken `::before` bridge from `.wk-ctx-submenu` (was on the wrong element — cannot cover a gap outside its own boundary)
- Add correct `::after` bridge on the parent `li:has(> .wk-ctx-submenu)`, extending its hover area 8px rightward to bridge the 4px gap
- Mirror fix for `.wk-contextmenus-flip-submenu` (left-opening submenu) case

## Testing

- [ ] Unit tests added/updated
- [x] Manually verified

Reproduced the bug on latest `main`: hovering over 「更多」 in the chat list right-click menu and moving the mouse rightward caused the submenu to disappear immediately. After fix, the submenu stays open when crossing the gap.

**Root cause explanation:**

```
Parent <li> │ 4px gap │ .wk-ctx-submenu
             ↑
   Mouse crosses here → old ::before (on submenu) can't reach this area
   New ::after (on parent li) extends rightward and covers it ✓
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)