### PR TITLE
ci: add Octo CI Status notification workflow

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -1,0 +1,24 @@
+name: Octo CI Status
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1
+    with:
+      repo_name: ${{ github.event.workflow_run.repository.name }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      conclusion: ${{ github.event.workflow_run.conclusion }}
+      run_id: ${{ github.event.workflow_run.id }}
+      run_url: ${{ github.event.workflow_run.html_url }}
+      project_group_id: "c6717c018f974c2793635f9fa2c0e629"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
## 变更

补充 `octo-ci-status.yml` caller workflow。

octo-web 的 CI 本身是通过的，但缺少状态变化推送。合并后当 main 分支 CI 从 success→failure 或 failure→success 时，会自动推送告警到 ci-status 群和 octo-web 项目群。

使用 `Mininglamp-OSS/.github` 的 reusable workflow `@v1`（已在 PR #24 修复了 startup_failure 根因）。