### PR TITLE
fix(group-chat): create group first when starting group chat from private chat

### DIFF
--- a/packages/dmworkcontacts/package.json
+++ b/packages/dmworkcontacts/package.json
@@ -12,5 +12,13 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "wukongimjssdk": "^1.3.5"
+  },
+  "devDependencies": {
+    "jsdom": "^29.0.1",
+    "vitest": "^4.1.5"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
   }
 }

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.test.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  }
+
+  return {
+    default: { shared: vi.fn() },
+    Channel,
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    Subscriber: class Subscriber {
+      uid = "";
+    },
+  };
+});
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: () => null,
+  Space: () => null,
+  Tree: () => null,
+  Input: () => null,
+  CheckboxGroup: () => null,
+  Checkbox: () => null,
+  Toast: {
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@octo/base", () => ({
+  WKApp: {
+    loginInfo: { uid: "alice" },
+    dataSource: {
+      channelDataSource: {
+        createChannel: vi.fn(),
+        addSubscribers: vi.fn(),
+      },
+    },
+    endpoints: {
+      showConversation: vi.fn(),
+    },
+  },
+  ThemeMode: {},
+  WKViewQueueHeader: () => null,
+  WKModal: () => null,
+}));
+
+vi.mock("@octo/base/src/Components/WKAvatar", () => ({
+  default: () => null,
+}));
+
+vi.mock("@octo/base/src/Components/AiBadge", () => ({
+  default: () => null,
+}));
+
+vi.mock("@octo/base/src/Utils/const", () => ({
+  SuperGroup: 1,
+}));
+
+import { WKApp } from "@octo/base";
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+import {
+  OrganizationalGroupNew,
+  OrganizationalGroupNewAction,
+} from "./index";
+
+describe("OrganizationalGroupNew AddMember flow", () => {
+  const channelDataSource = WKApp.dataSource.channelDataSource as {
+    createChannel: ReturnType<typeof vi.fn>;
+    addSubscribers: ReturnType<typeof vi.fn>;
+  };
+  const showConversation = WKApp.endpoints.showConversation as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    WKApp.loginInfo.uid = "alice";
+    channelDataSource.createChannel.mockResolvedValue({ group_no: "group-1" });
+    channelDataSource.addSubscribers.mockResolvedValue(undefined);
+  });
+
+  it("creates a new group before navigating when adding members from a private chat", async () => {
+    const view = new OrganizationalGroupNew({
+      channel: { channelID: "bob", channelType: ChannelTypePerson },
+      action: OrganizationalGroupNewAction.AddMember,
+    });
+    view.state = {
+      ...view.state,
+      optPersonnelData: [{ uid: "carol" }],
+    };
+    view.onCancel = vi.fn();
+
+    await view.onOK();
+
+    expect(channelDataSource.createChannel).toHaveBeenCalledWith([
+      "alice",
+      "bob",
+      "carol",
+    ]);
+    expect(channelDataSource.addSubscribers).not.toHaveBeenCalled();
+    expect(showConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1", channelType: ChannelTypeGroup })
+    );
+    expect(view.onCancel).toHaveBeenCalled();
+  });
+
+  it("keeps adding subscribers directly for an existing group chat", async () => {
+    const groupChannel = { channelID: "existing-group", channelType: ChannelTypeGroup };
+    const view = new OrganizationalGroupNew({
+      channel: groupChannel,
+      action: OrganizationalGroupNewAction.AddMember,
+    });
+    view.state = {
+      ...view.state,
+      optPersonnelData: [{ uid: "carol" }],
+    };
+    view.onCancel = vi.fn();
+
+    await view.onOK();
+
+    expect(channelDataSource.addSubscribers).toHaveBeenCalledWith(groupChannel, ["carol"]);
+    expect(channelDataSource.createChannel).not.toHaveBeenCalled();
+    expect(showConversation).not.toHaveBeenCalled();
+    expect(view.onCancel).toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -479,15 +479,29 @@ export class OrganizationalGroupNew extends Component<
     // 添加联系人
     if (this.props.action === OrganizationalGroupNewAction.AddMember) {
       try {
-        await WKApp.dataSource.channelDataSource.addSubscribers(
-          channel,
-          getOptPersonnelData
-        );
+        if (this.props.channel.channelType === ChannelTypePerson) {
+          // Starting group chat from a private chat:
+          // must create a new group first, then navigate to it
+          const uids = [
+            WKApp.loginInfo.uid || "",
+            this.props.channel.channelID,
+            ...getOptPersonnelData,
+          ];
+          const result = await WKApp.dataSource.channelDataSource.createChannel(uids);
+          if (result?.group_no) {
+            WKApp.endpoints.showConversation(new Channel(result.group_no, ChannelTypeGroup));
+          }
+        } else {
+          // Adding members to an existing group: original logic
+          await WKApp.dataSource.channelDataSource.addSubscribers(
+            channel,
+            getOptPersonnelData
+          );
+        }
       } catch (error: any) {
         Toast.error(error.msg);
-        return
+        return;
       }
-
     }
     this.onCancel();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,13 @@ importers:
       wukongimjssdk:
         specifier: ^1.3.5
         version: 1.3.5
+    devDependencies:
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.2
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworkdatasource:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -59,6 +59,9 @@
     "lint": {
       "outputs": []
     },
+    "test": {
+      "cache": false
+    },
     "clean": {
       "dependsOn": [
         "^clean"


### PR DESCRIPTION
## Summary

Fix the 400 error when starting a group chat from the private chat three-dots menu. The action now correctly creates a new group first before navigating to it, instead of incorrectly trying to add members to a non-existent group.

## Related Issue

Fixes #51

## Changes

- In `onOK()` AddMember branch, added a `channelType` check:
  - `ChannelTypePerson`: build uid list `[self, otherPerson, ...selected]`, call `createChannel()`, then navigate to the new group via `showConversation()`
  - Group channel: keep the original `addSubscribers()` logic (unchanged)
- Added focused unit coverage for both AddMember branches:
  - Private chat creates a group first and navigates to it
  - Existing group chat still calls `addSubscribers()`

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

**Unit test:**

```bash
npx pnpm@10.32.0 --filter @octo/contacts exec vitest run src/Organizational/GroupNew/index.test.tsx
```

Result: 1 test file passed, 2 tests passed.

**Manual verification steps:**
1. Open any private chat conversation
2. Click ⋯ → Start Group Chat
3. Select one or more members → confirm
4. Group chat is created successfully and UI navigates to it ✅

Previously: `POST /groups/{userUID}/members` → 400 Bad Request
After fix: `POST /group/create` → success → navigate to new group

Local verification evidence is posted in the PR comments.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)
