### PR TITLE
feat(mention): UI input + render for @所有人 / @所有AI (PR-C, closes #58)

### DIFF
--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -657,3 +657,128 @@ describe('end-to-end: formatMentionTextV2 -> parseMentionWithEntities', () => {
         expect(parts![3].text).toBe('@陈皮皮');
     });
 });
+
+// ═════════════════════════════════════════════════════════════════
+// Three-state mention render matrix (PR-C / GH#58)
+//
+// Mirrors the production logic in:
+//   - packages/dmworkbase/src/Components/Conversation/index.tsx
+//     ::getMessageMentions  (synthesizes @所有人 / @所有AI MentionInfo entries
+//     so MarkdownContent applies the existing mention-highlight class)
+//
+// Matrix:
+//   humans=1                       → highlight @所有人
+//   ais=1                          → highlight @所有AI
+//   humans=1 + ais=1               → highlight @所有人 + @所有AI
+//   all=1 (legacy / server outbound double-write) → highlight @所有人
+// ═════════════════════════════════════════════════════════════════
+
+interface MentionInfo {
+    name: string
+    uid: string
+}
+
+interface RenderMention {
+    all?: boolean | number
+    humans?: number
+    ais?: number
+    uids?: string[]
+    entities?: MentionEntity[]
+}
+
+// Mirrors Conversation.getMessageMentions sticky-highlight logic.
+// MarkdownContent applies the @member highlight (mention-highlight class)
+// when MentionInfo.uid === 'all'. We reuse that style for three-state by
+// emitting synthetic MentionInfo entries.
+function buildMessageMentions(
+    baseParts: Array<{ type: PartType; text: string; data?: { uid?: string } }>,
+    mention?: RenderMention,
+): MentionInfo[] {
+    const base: MentionInfo[] = baseParts
+        .filter((p) => p.type === PartType.mention && p.data?.uid)
+        .map((p) => ({ name: p.text, uid: p.data!.uid! }))
+
+    if (!mention) return base
+
+    const all = mention.all === true || mention.all === 1
+    const highlightAll = !!mention.humans || all
+    const highlightAis = !!mention.ais
+
+    const synthetic: MentionInfo[] = []
+    if (highlightAll) synthetic.push({ name: '@所有人', uid: 'all' })
+    if (highlightAis) synthetic.push({ name: '@所有AI', uid: 'all' })
+
+    const seen = new Set(base.map((m) => m.name))
+    for (const s of synthetic) {
+        if (!seen.has(s.name)) {
+            base.push(s)
+            seen.add(s.name)
+        }
+    }
+    return base
+}
+
+describe('render matrix: three-state mention highlight (GH#58)', () => {
+    it('humans=1 only → highlights @所有人', () => {
+        const text = '通知 @所有人 准时集合'
+        const mentions = buildMessageMentions([], { humans: 1 })
+
+        const names = mentions.map((m) => m.name)
+        expect(names).toContain('@所有人')
+        expect(names).not.toContain('@所有AI')
+        // All synthesized highlights reuse the existing "@member" highlight
+        // pathway by setting uid='all' (mention-highlight class).
+        expect(mentions.every((m) => m.uid === 'all')).toBe(true)
+        // sanity: the literal "@所有人" text exists in the message body so
+        // MarkdownContent will actually match it.
+        expect(text.includes('@所有人')).toBe(true)
+    })
+
+    it('ais=1 only → highlights @所有AI', () => {
+        const text = '请 @所有AI 协助回答'
+        const mentions = buildMessageMentions([], { ais: 1 })
+
+        const names = mentions.map((m) => m.name)
+        expect(names).toContain('@所有AI')
+        expect(names).not.toContain('@所有人')
+        expect(mentions.every((m) => m.uid === 'all')).toBe(true)
+        expect(text.includes('@所有AI')).toBe(true)
+    })
+
+    it('humans=1 + ais=1 → highlights @所有人 + @所有AI', () => {
+        const text = '@所有人 + @所有AI 同步'
+        const mentions = buildMessageMentions([], { humans: 1, ais: 1 })
+
+        const names = mentions.map((m) => m.name)
+        expect(names).toContain('@所有人')
+        expect(names).toContain('@所有AI')
+        expect(mentions).toHaveLength(2)
+        expect(mentions.every((m) => m.uid === 'all')).toBe(true)
+    })
+
+    it('all=1 (legacy) → highlights @所有人 (server outbound rewrites all→humans, both must work)', () => {
+        const text = '@所有人 集合'
+        const mentions = buildMessageMentions([], { all: 1 })
+
+        const names = mentions.map((m) => m.name)
+        expect(names).toContain('@所有人')
+        expect(names).not.toContain('@所有AI')
+        expect(mentions[0].uid).toBe('all')
+    })
+
+    it('regression: undefined mention does not synthesize anything', () => {
+        const mentions = buildMessageMentions([], undefined)
+        expect(mentions).toHaveLength(0)
+    })
+
+    it('regression: @member parts coexist with synthetic @所有AI (no de-dup collision)', () => {
+        const parts = [
+            { type: PartType.mention, text: '@陈皮皮', data: { uid: 'uid_chen' } },
+        ]
+        const mentions = buildMessageMentions(parts, { ais: 1 })
+
+        expect(mentions).toHaveLength(2)
+        expect(mentions[0]).toEqual({ name: '@陈皮皮', uid: 'uid_chen' })
+        expect(mentions[1]).toEqual({ name: '@所有AI', uid: 'all' })
+    })
+})

--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -5,6 +5,22 @@
  * - parseMentionLegacy: renders mentions using uids + regex (v1 fallback)
  */
 
+// Render-side helpers are now imported from the production module so the
+// render-matrix tests exercise the same synthesis logic that ships in
+// Conversation.getMessageMentions, instead of a hand-maintained mirror.
+import {
+    buildMessageMentions as productionBuildMessageMentions,
+    readMentionFlags,
+    buildMentionDropdownItems,
+    MENTION_UID_HUMANS,
+    MENTION_UID_AIS,
+    MENTION_LABEL_HUMANS,
+    MENTION_LABEL_AIS,
+    type MentionRenderPart,
+    type MentionRenderFlags,
+    type MentionRenderInfo,
+} from '../../../../packages/dmworkbase/src/Utils/mentionRender'
+
 // ─── Type definitions ────────────────────────────────────────────
 
 interface MentionEntity {
@@ -686,36 +702,29 @@ interface RenderMention {
     entities?: MentionEntity[]
 }
 
-// Mirrors Conversation.getMessageMentions sticky-highlight logic.
-// MarkdownContent applies the @member highlight (mention-highlight class)
-// when MentionInfo.uid === 'all'. We reuse that style for three-state by
-// emitting synthetic MentionInfo entries.
+// Delegates to the production `buildMessageMentions` from
+// packages/dmworkbase/src/Utils/mentionRender. The test file's local
+// `PartType` enum starts at 0 (text) with `mention` at index 2, which
+// also matches the SDK's PartType.mention numeric value used by the
+// production caller — we pass that numeric value explicitly so the
+// helper does not have to import the SDK PartType.
 function buildMessageMentions(
     baseParts: Array<{ type: PartType; text: string; data?: { uid?: string } }>,
     mention?: RenderMention,
 ): MentionInfo[] {
-    const base: MentionInfo[] = baseParts
-        .filter((p) => p.type === PartType.mention && p.data?.uid)
-        .map((p) => ({ name: p.text, uid: p.data!.uid! }))
-
-    if (!mention) return base
-
-    const all = mention.all === true || mention.all === 1
-    const highlightAll = !!mention.humans || all
-    const highlightAis = !!mention.ais
-
-    const synthetic: MentionInfo[] = []
-    if (highlightAll) synthetic.push({ name: '@所有人', uid: 'all' })
-    if (highlightAis) synthetic.push({ name: '@所有AI', uid: 'all' })
-
-    const seen = new Set(base.map((m) => m.name))
-    for (const s of synthetic) {
-        if (!seen.has(s.name)) {
-            base.push(s)
-            seen.add(s.name)
-        }
-    }
-    return base
+    const parts: MentionRenderPart[] = baseParts.map((p) => ({
+        type: p.type as unknown as number,
+        text: p.text,
+        data: p.data,
+    }))
+    const flags: MentionRenderFlags | undefined = mention
+        ? { all: mention.all, humans: mention.humans, ais: mention.ais }
+        : undefined
+    return productionBuildMessageMentions(
+        parts,
+        flags,
+        PartType.mention as unknown as number,
+    ) as MentionInfo[]
 }
 
 describe('render matrix: three-state mention highlight (GH#58)', () => {
@@ -781,4 +790,182 @@ describe('render matrix: three-state mention highlight (GH#58)', () => {
         expect(mentions[0]).toEqual({ name: '@陈皮皮', uid: 'uid_chen' })
         expect(mentions[1]).toEqual({ name: '@所有AI', uid: 'all' })
     })
+
+    it('regression: edited content flags override original content (Conversation.getMessageMentions parity)', () => {
+        // Conversation.getMessageMentions reads mention flags from
+        // remoteExtra.contentEdit when message.remoteExtra.isEdit is true,
+        // matching the text source used by getMessageTextContent. Use
+        // readMentionFlags here to assert the same lookup precedence the
+        // production path performs.
+        const original = { mention: { humans: 1 } }
+        const edited = { mention: { ais: 1 } }
+        const editedFlags = readMentionFlags(edited)
+        expect(editedFlags).toEqual({ all: undefined, humans: undefined, ais: 1 })
+
+        const editedMentions = buildMessageMentions([], editedFlags)
+        const names = editedMentions.map((m) => m.name)
+        expect(names).toContain('@所有AI')
+        expect(names).not.toContain('@所有人')
+
+        // sanity: the original (non-edited) flags still synthesize @所有人
+        const originalFlags = readMentionFlags(original)
+        const originalMentions = buildMessageMentions([], originalFlags)
+        expect(originalMentions.map((m) => m.name)).toEqual(['@所有人'])
+    })
+
+    it('readMentionFlags falls back to contentObj.mention when SDK Mention is missing the new fields', () => {
+        // The wire payload arrives with humans/ais in `contentObj.mention`
+        // because the SDK does not yet declare those fields. The render
+        // path must still see them via the fallback branch.
+        const flags = readMentionFlags({ contentObj: { mention: { humans: 1, ais: 1 } } })
+        expect(flags).toEqual({ all: undefined, humans: 1, ais: 1 })
+    })
+
+    it('readMentionFlags returns undefined when content lacks any mention shape', () => {
+        expect(readMentionFlags(undefined)).toBeUndefined()
+        expect(readMentionFlags(null)).toBeUndefined()
+        expect(readMentionFlags({})).toBeUndefined()
+        expect(readMentionFlags({ contentObj: {} })).toBeUndefined()
+    })
 })
+
+// ═════════════════════════════════════════════════════════════════
+// PR #59 regression: @-mention dropdown keyboard selection
+//
+// Reproduces the blocking finding from Jerry-Xin's review: typing
+// `@Bob` then pressing Enter must select Bob (or whatever member
+// matches the filter), NOT the sticky `@所有人` broadcast item.
+//
+// Root cause was that the suggestion factory always prepended the
+// two sticky items ahead of `filteredMembers`. MentionList resets
+// `selectedIndex` to 0 whenever `props.items` changes, so Enter
+// always landed on `@所有人` (the prepended sticky) instead of the
+// typed-name match. Fix: hide sticky items when the query is
+// non-empty.
+// ═════════════════════════════════════════════════════════════════
+
+describe('@-mention dropdown keyboard selection (PR #59 regression)', () => {
+    const fakeMembers = [
+        { uid: 'uid_bob', name: 'Bob', orgData: { robot: 0 } },
+        { uid: 'uid_alice', name: 'Alice', orgData: { robot: 0 } },
+        { uid: 'uid_bot', name: 'Botzilla', orgData: { robot: 1 } },
+    ]
+
+    const stubResolvers = {
+        iconResolver: (m: { uid: string }) => `avatar://${m.uid}`,
+        externalResolver: (_: unknown) => ({ isExternal: false, sourceSpaceName: '' }),
+        stickyIcon: 'mention-all-icon',
+    }
+
+    it('empty query → sticky @所有人 + @所有AI prepended at index 0 and 1 (UX preserved)', () => {
+        const items = buildMentionDropdownItems({
+            query: '',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+
+        // Sticky items occupy the first two slots, followed by all members.
+        expect(items.length).toBe(2 + fakeMembers.length)
+        expect(items[0]).toMatchObject({
+            uid: MENTION_UID_HUMANS,
+            name: MENTION_LABEL_HUMANS,
+            isBot: false,
+        })
+        expect(items[1]).toMatchObject({
+            uid: MENTION_UID_AIS,
+            name: MENTION_LABEL_AIS,
+            isBot: true,
+        })
+        expect(items[2].uid).toBe('uid_bob')
+    })
+
+    it('typing @Bob then Enter → selects Bob, NOT the sticky @所有人', () => {
+        // MentionList's enterHandler calls selectItem(selectedIndex), and
+        // selectedIndex resets to 0 on every items change. Therefore
+        // items[0] IS the keyboard-Enter target. Asserting items[0] is
+        // exactly the typed member is the canonical regression guard.
+        const items = buildMentionDropdownItems({
+            query: 'Bob',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+
+        expect(items.length).toBe(1)
+        expect(items[0]).toMatchObject({ uid: 'uid_bob', name: 'Bob' })
+
+        // Triple-belt: no sticky leaks into the filtered list, regardless
+        // of where it sits.
+        expect(items.find((i) => i.uid === MENTION_UID_HUMANS)).toBeUndefined()
+        expect(items.find((i) => i.uid === MENTION_UID_AIS)).toBeUndefined()
+    })
+
+    it('case-insensitive filter still puts the typed member at index 0', () => {
+        const items = buildMentionDropdownItems({
+            query: 'alice',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+        expect(items[0]).toMatchObject({ uid: 'uid_alice', name: 'Alice' })
+        expect(items.length).toBe(1)
+    })
+
+    it('query with leading/trailing whitespace is treated as a filter (sticky still hidden)', () => {
+        const items = buildMentionDropdownItems({
+            query: '  Bob  ',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+        // Even with padding the user clearly typed a filter; sticky must
+        // not sneak back in or Enter would broadcast again.
+        expect(items.find((i) => i.uid === MENTION_UID_HUMANS)).toBeUndefined()
+        expect(items.find((i) => i.uid === MENTION_UID_AIS)).toBeUndefined()
+        expect(items[0]).toMatchObject({ uid: 'uid_bob' })
+    })
+
+    it('query matches zero members → empty list (no accidental sticky fallback to @所有人)', () => {
+        const items = buildMentionDropdownItems({
+            query: 'Zzz_no_such_member',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+        // No sticky, no match → empty. MentionList shows "没有找到成员"
+        // and Enter is a no-op (selectItem(0) on empty array → noop).
+        expect(items).toEqual([])
+    })
+
+    it('null members + empty query → sticky-only list (fallback path)', () => {
+        const items = buildMentionDropdownItems({
+            query: '',
+            members: null,
+            ...stubResolvers,
+        })
+        expect(items.length).toBe(2)
+        expect(items[0].uid).toBe(MENTION_UID_HUMANS)
+        expect(items[1].uid).toBe(MENTION_UID_AIS)
+    })
+
+    it('null members + non-empty query → empty list (no sticky, no crash)', () => {
+        const items = buildMentionDropdownItems({
+            query: 'Bob',
+            members: null,
+            ...stubResolvers,
+        })
+        // With sticky hidden during search and no members to filter, the
+        // dropdown is empty — matching the "没有找到成员" placeholder UX.
+        expect(items).toEqual([])
+    })
+
+    it('bot member surfaces with isBot=true (regression on isBot wiring)', () => {
+        const items = buildMentionDropdownItems({
+            query: 'Bot',
+            members: fakeMembers,
+            ...stubResolvers,
+        })
+        expect(items[0]).toMatchObject({ uid: 'uid_bot', name: 'Botzilla', isBot: true })
+    })
+})
+
+// Silence the unused-import warning for MentionRenderInfo: it is part of
+// the public surface tested by `buildMessageMentions` return-type checks
+// in the existing render-matrix `it` blocks above (TS inference).
+type _MentionRenderInfoUsed = MentionRenderInfo

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1052,13 +1052,49 @@ export class Conversation
   }
 
   getMessageMentions(message: MessageWrap): MentionInfo[] {
-    return (
+    const baseMentions: MentionInfo[] =
       message.parts
         ?.filter(
           (part: Part) => part.type === PartType.mention && part.data?.uid,
         )
-        .map((part: Part) => ({ name: part.text, uid: part.data.uid })) ?? []
-    );
+        .map((part: Part) => ({ name: part.text, uid: part.data.uid })) ?? [];
+
+    // ── 三态 mention 高亮（render matrix） ───────────────────────────
+    // 在普通 @member 的 Parts 之外，额外注入以下三个虚拟 highlight token，
+    // 让 MarkdownContent 用现有 @member 高亮样式（uid='all' → mention-highlight）
+    // 标亮文本中的 "@所有人" / "@所有AI":
+    //   - mention.humans=1  → "@所有人"
+    //   - mention.ais=1     → "@所有AI"
+    //   - mention.humans=1 + mention.ais=1 → 两者都高亮
+    //   - mention.all=1 (legacy / server outbound 双写) → "@所有人"
+    // 不动 message.parts，避免影响 markdown 子节点分段；MarkdownContent
+    // 按 name 字符串匹配文本节点。复用同一份 highlight class 保持视觉一致。
+    const content: any = message.content;
+    const mn = content?.mention;
+    const contentObjMn = content?.contentObj?.mention;
+    const humans = mn?.humans ?? contentObjMn?.humans;
+    const ais = mn?.ais ?? contentObjMn?.ais;
+    const all = mn?.all === true || mn?.all === 1;
+
+    const highlightAll = !!humans || all;
+    const highlightAis = !!ais;
+
+    const synthetic: MentionInfo[] = [];
+    if (highlightAll) {
+      synthetic.push({ name: "@所有人", uid: "all" });
+    }
+    if (highlightAis) {
+      synthetic.push({ name: "@所有AI", uid: "all" });
+    }
+
+    const seen = new Set(baseMentions.map((m) => m.name));
+    for (const s of synthetic) {
+      if (!seen.has(s.name)) {
+        baseMentions.push(s);
+        seen.add(s.name);
+      }
+    }
+    return baseMentions;
   }
 
   getMessageEmojis(message: MessageWrap): EmojiInfo[] {
@@ -2360,17 +2396,42 @@ export class Conversation
                             const mn = new Mention();
                             mn.all = blockMention.all;
                             mn.uids = blockMention.uids;
+                            // 三态 mention：SDK Mention 类型未声明 humans/ais，
+                            // 这里用 (mn as any) 把字段透传到 wire JSON。客户端
+                            // render 只读 contentObj.mention（下方 override 注入），
+                            // server 同时认 mn.humans/mn.ais（PR-A 已支持）。
+                            if (blockMention.humans) {
+                              (mn as any).humans = blockMention.humans;
+                            }
+                            if (blockMention.ais) {
+                              (mn as any).ais = blockMention.ais;
+                            }
                             msgContent.mention = mn;
-                            if (
+
+                            const hasEntities =
                               blockMention.entities &&
-                              blockMention.entities.length > 0
-                            ) {
+                              blockMention.entities.length > 0;
+                            const hasThreeState =
+                              !!(blockMention.humans || blockMention.ais);
+
+                            if (hasEntities || hasThreeState) {
                               const entities = blockMention.entities;
                               if (!msgContent.contentObj)
                                 msgContent.contentObj = {};
                               if (!msgContent.contentObj.mention)
                                 msgContent.contentObj.mention = {};
-                              msgContent.contentObj.mention.entities = entities;
+                              if (hasEntities) {
+                                msgContent.contentObj.mention.entities =
+                                  entities;
+                              }
+                              if (blockMention.humans) {
+                                msgContent.contentObj.mention.humans =
+                                  blockMention.humans;
+                              }
+                              if (blockMention.ais) {
+                                msgContent.contentObj.mention.ais =
+                                  blockMention.ais;
+                              }
                               const originalEncode =
                                 msgContent.encode.bind(msgContent);
                               msgContent.encode = () => {
@@ -2379,7 +2440,15 @@ export class Conversation
                                   const str = new TextDecoder().decode(bytes);
                                   const obj = JSON.parse(str);
                                   if (!obj.mention) obj.mention = {};
-                                  obj.mention.entities = entities;
+                                  if (hasEntities) {
+                                    obj.mention.entities = entities;
+                                  }
+                                  if (blockMention.humans) {
+                                    obj.mention.humans = blockMention.humans;
+                                  }
+                                  if (blockMention.ais) {
+                                    obj.mention.ais = blockMention.ais;
+                                  }
                                   return new TextEncoder().encode(
                                     JSON.stringify(obj),
                                   );

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -34,6 +34,10 @@ import {
 } from "../../Service/Const";
 import ConversationContext from "./context";
 import { subscriberDisplayName } from "../../Utils/displayName";
+import {
+  buildMessageMentions as buildMentionRenderInfo,
+  readMentionFlags,
+} from "../../Utils/mentionRender";
 import MessageInput, {
   MentionModel,
   MessageInputContext,
@@ -1052,13 +1056,6 @@ export class Conversation
   }
 
   getMessageMentions(message: MessageWrap): MentionInfo[] {
-    const baseMentions: MentionInfo[] =
-      message.parts
-        ?.filter(
-          (part: Part) => part.type === PartType.mention && part.data?.uid,
-        )
-        .map((part: Part) => ({ name: part.text, uid: part.data.uid })) ?? [];
-
     // ── 三态 mention 高亮（render matrix） ───────────────────────────
     // 在普通 @member 的 Parts 之外，额外注入以下三个虚拟 highlight token，
     // 让 MarkdownContent 用现有 @member 高亮样式（uid='all' → mention-highlight）
@@ -1069,32 +1066,25 @@ export class Conversation
     //   - mention.all=1 (legacy / server outbound 双写) → "@所有人"
     // 不动 message.parts，避免影响 markdown 子节点分段；MarkdownContent
     // 按 name 字符串匹配文本节点。复用同一份 highlight class 保持视觉一致。
-    const content: any = message.content;
-    const mn = content?.mention;
-    const contentObjMn = content?.contentObj?.mention;
-    const humans = mn?.humans ?? contentObjMn?.humans;
-    const ais = mn?.ais ?? contentObjMn?.ais;
-    const all = mn?.all === true || mn?.all === 1;
+    //
+    // Edited messages render text from `message.remoteExtra.contentEdit`
+    // (see `getMessageTextContent` below). The mention flags must be read
+    // from the same content source — otherwise an edited message whose
+    // edit text now contains `@所有人` / `@所有AI` (or removes them) would
+    // disagree with the highlight overlay. Prefer the edited content's
+    // mention flags when present, falling back to the original message
+    // content for non-edited messages or edits that did not re-emit flags.
+    const editContent: any = message.remoteExtra?.isEdit
+      ? message.remoteExtra?.contentEdit
+      : undefined;
+    const flags =
+      readMentionFlags(editContent) ?? readMentionFlags(message.content);
 
-    const highlightAll = !!humans || all;
-    const highlightAis = !!ais;
-
-    const synthetic: MentionInfo[] = [];
-    if (highlightAll) {
-      synthetic.push({ name: "@所有人", uid: "all" });
-    }
-    if (highlightAis) {
-      synthetic.push({ name: "@所有AI", uid: "all" });
-    }
-
-    const seen = new Set(baseMentions.map((m) => m.name));
-    for (const s of synthetic) {
-      if (!seen.has(s.name)) {
-        baseMentions.push(s);
-        seen.add(s.name);
-      }
-    }
-    return baseMentions;
+    return buildMentionRenderInfo(
+      message.parts as any,
+      flags,
+      PartType.mention as unknown as number,
+    ) as MentionInfo[];
   }
 
   getMessageEmojis(message: MessageWrap): EmojiInfo[] {

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -249,11 +249,17 @@ export class MentionModel {
 
 // Sentinel uids used by the @-dropdown sticky top items + voice transcription.
 // `-1` is the legacy "@所有人" (all=1). `-2` / `-3` are the new three-state items.
-const MENTION_UID_LEGACY_ALL = "-1";
-const MENTION_UID_HUMANS = "-2";
-const MENTION_UID_AIS = "-3";
-const MENTION_LABEL_HUMANS = "所有人";
-const MENTION_LABEL_AIS = "所有AI";
+// The canonical definitions live in Utils/mentionRender so the shared
+// dropdown helper (`buildMentionDropdownItems`) and unit tests can reuse
+// them without an import cycle through this large editor module.
+import {
+  MENTION_UID_LEGACY_ALL,
+  MENTION_UID_HUMANS,
+  MENTION_UID_AIS,
+  MENTION_LABEL_HUMANS,
+  MENTION_LABEL_AIS,
+  buildMentionDropdownItems,
+} from "../../Utils/mentionRender";
 
 // 解析 @[uid:name] 格式的 mention
 function formatMentionTextV2(text: string): {
@@ -644,53 +650,24 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             // 三态 mention 顶部两个固定项：
             //   - @所有人  → mention.humans=1
             //   - @所有AI → mention.ais=1
-            // 始终置顶展示，不受 query 过滤影响。
-            const stickyTop = [
-              {
-                uid: MENTION_UID_HUMANS,
-                name: MENTION_LABEL_HUMANS,
-                icon: mentionAllIcon,
-                isBot: false,
-                sourceSpaceName: "",
-              },
-              {
-                uid: MENTION_UID_AIS,
-                name: MENTION_LABEL_AIS,
-                icon: mentionAllIcon,
-                isBot: true,
-                sourceSpaceName: "",
-              },
-            ];
-
-            if (!localMembersRef.current) return stickyTop;
-
-            const items = localMembersRef.current.map((member) => {
-              // @选人弹窗按当前查看 Space 相对显示「@SpaceName」。
-              // 同 Space / 自己 / legacy 非外部 → 不显示 sourceSpaceName。
-              const ext = resolveExternalForViewer({
-                homeSpaceId: member.orgData?.home_space_id,
-                homeSpaceName: member.orgData?.home_space_name,
-                isExternalLegacy: member.orgData?.is_external,
-                sourceSpaceNameLegacy: member.orgData?.source_space_name,
-              });
-              return {
-                uid: member.uid,
-                name: member.name,
-                icon: WKApp.shared.avatarChannel(
-                  new Channel(member.uid, ChannelTypePerson)
+            // 只在 query 为空时置顶展示；query 非空时隐藏，避免 Enter
+            // 错误地把 @Bob 这种 query 选成 sticky @所有人（PR #59 回归）。
+            return buildMentionDropdownItems({
+              query,
+              members: localMembersRef.current,
+              iconResolver: (member) =>
+                WKApp.shared.avatarChannel(
+                  new Channel(member.uid, ChannelTypePerson),
                 ),
-                // 直接从 Subscriber.orgData 取，不依赖 channelInfo 缓存是否已热
-                isBot: member.orgData?.robot === 1,
-                sourceSpaceName: ext.isExternal ? ext.sourceSpaceName : "",
-              };
+              externalResolver: (member) =>
+                resolveExternalForViewer({
+                  homeSpaceId: member.orgData?.home_space_id,
+                  homeSpaceName: member.orgData?.home_space_name,
+                  isExternalLegacy: member.orgData?.is_external,
+                  sourceSpaceNameLegacy: member.orgData?.source_space_name,
+                }),
+              stickyIcon: mentionAllIcon,
             });
-
-            const filteredMembers = items.filter((item) =>
-              item.name.toLowerCase().includes(query.toLowerCase())
-            );
-
-            // sticky top 永远展示，即使被搜索 query 过滤也保留；置于成员列表上方。
-            return [...stickyTop, ...filteredMembers];
           },
           (active) => {
             mentionActiveRef.current = active;

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -233,7 +233,27 @@ export class MentionModel {
   all: boolean = false;
   uids?: Array<string>;
   entities?: MentionEntity[];
+  /**
+   * Three-state mention flags. Sent to server alongside literal "@所有人" / "@所有AI"
+   * text. Server normalizes legacy `all=1` into `humans=1` outbound, so renderers
+   * may see either field set; both must be honored.
+   *
+   * - humans: 1 → "@所有人" should be highlighted on receivers
+   * - ais:    1 → "@所有AI"  should be highlighted on receivers
+   *
+   * Stored as 0|1 to match the wire protocol (RFC: mention-three-state v1).
+   */
+  humans?: number;
+  ais?: number;
 }
+
+// Sentinel uids used by the @-dropdown sticky top items + voice transcription.
+// `-1` is the legacy "@所有人" (all=1). `-2` / `-3` are the new three-state items.
+const MENTION_UID_LEGACY_ALL = "-1";
+const MENTION_UID_HUMANS = "-2";
+const MENTION_UID_AIS = "-3";
+const MENTION_LABEL_HUMANS = "所有人";
+const MENTION_LABEL_AIS = "所有AI";
 
 // 解析 @[uid:name] 格式的 mention
 function formatMentionTextV2(text: string): {
@@ -245,6 +265,8 @@ function formatMentionTextV2(text: string): {
   let result = "";
   let cursor = 0;
   let all = false;
+  let humans = false;
+  let ais = false;
 
   const placeholderPattern = /@\[([^:]+):([^\]]+)\]/g;
   let match;
@@ -256,19 +278,24 @@ function formatMentionTextV2(text: string): {
     // 添加 match 之前的普通文本
     result += text.slice(cursor, match.index);
 
-    // 计算当前 @ 符号的实际位置
-    const atName =
-      uid === "-1"
-        ? "@所有人"
-        : membersRef.current?.find((m) => m.uid === uid)?.name
+    if (uid === MENTION_UID_LEGACY_ALL) {
+      // 老的 @所有人 输入路径继续走 mention.all=1（server 端会 rewrite 成 humans=1）
+      all = true;
+      result += `@${MENTION_LABEL_HUMANS}`;
+    } else if (uid === MENTION_UID_HUMANS) {
+      // 新的三态：humans=1，文本插入 @所有人，不进 entities 列表
+      humans = true;
+      result += `@${MENTION_LABEL_HUMANS}`;
+    } else if (uid === MENTION_UID_AIS) {
+      // 新的三态：ais=1，文本插入 @所有AI，不进 entities 列表
+      ais = true;
+      result += `@${MENTION_LABEL_AIS}`;
+    } else {
+      // 普通成员：以最新的 member.name 优先（avoid stale display label），fallback to label。
+      const atName = membersRef.current?.find((m) => m.uid === uid)?.name
         ? `@${membersRef.current.find((m) => m.uid === uid)!.name}`
         : `@${name}`;
-    const offset = result.length;
-
-    if (uid === "-1") {
-      all = true;
-      result += "@所有人";
-    } else {
+      const offset = result.length;
       uids.push(uid);
       entities.push({
         uid,
@@ -284,11 +311,13 @@ function formatMentionTextV2(text: string): {
   // 添加剩余文本
   result += text.slice(cursor);
 
-  if (all || entities.length > 0) {
+  if (all || humans || ais || entities.length > 0) {
     const mention = new MentionModel();
     mention.all = all;
     mention.uids = uids.length > 0 ? uids : undefined;
     mention.entities = entities.length > 0 ? entities : undefined;
+    if (humans) mention.humans = 1;
+    if (ais) mention.ais = 1;
     return { content: result, mention };
   }
 
@@ -612,16 +641,28 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         },
         suggestion: createMentionSuggestion(
           ({ query }) => {
-            if (!localMembersRef.current)
-              return [
-                {
-                  uid: "-1",
-                  name: "所有人",
-                  icon: mentionAllIcon,
-                  isBot: false,
-                  sourceSpaceName: "",
-                },
-              ];
+            // 三态 mention 顶部两个固定项：
+            //   - @所有人  → mention.humans=1
+            //   - @所有AI → mention.ais=1
+            // 始终置顶展示，不受 query 过滤影响。
+            const stickyTop = [
+              {
+                uid: MENTION_UID_HUMANS,
+                name: MENTION_LABEL_HUMANS,
+                icon: mentionAllIcon,
+                isBot: false,
+                sourceSpaceName: "",
+              },
+              {
+                uid: MENTION_UID_AIS,
+                name: MENTION_LABEL_AIS,
+                icon: mentionAllIcon,
+                isBot: true,
+                sourceSpaceName: "",
+              },
+            ];
+
+            if (!localMembersRef.current) return stickyTop;
 
             const items = localMembersRef.current.map((member) => {
               // @选人弹窗按当前查看 Space 相对显示「@SpaceName」。
@@ -644,17 +685,12 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
               };
             });
 
-            items.unshift({
-              uid: "-1",
-              name: "所有人",
-              icon: mentionAllIcon,
-              isBot: false,
-              sourceSpaceName: "",
-            });
-
-            return items.filter((item) =>
+            const filteredMembers = items.filter((item) =>
               item.name.toLowerCase().includes(query.toLowerCase())
             );
+
+            // sticky top 永远展示，即使被搜索 query 过滤也保留；置于成员列表上方。
+            return [...stickyTop, ...filteredMembers];
           },
           (active) => {
             mentionActiveRef.current = active;

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -1,0 +1,210 @@
+/**
+ * Shared render-side helpers for the three-state mention model
+ * (`@所有人` / `@所有AI` / member, with legacy `mention.all=1` support).
+ *
+ * Lives in Utils so both the production `Conversation.getMessageMentions`
+ * path and unit tests can exercise the same synthesis logic instead of
+ * maintaining a copy in the test file.
+ *
+ * Inputs are kept structural so the helper does not depend on any SDK
+ * type that is unfriendly to plain TS test environments.
+ */
+
+export interface MentionRenderInfo {
+  /** Visible mention label including the leading "@" (matched by MarkdownContent). */
+  name: string;
+  /** Member uid, or the sentinel string `"all"` for synthetic highlights. */
+  uid: string;
+}
+
+export interface MentionRenderPart {
+  type: number;
+  text: string;
+  data?: { uid?: string };
+}
+
+export interface MentionRenderFlags {
+  all?: boolean | number;
+  humans?: number;
+  ais?: number;
+}
+
+/**
+ * Build the render-time MentionInfo[] for a message: combine ordinary
+ * `@member` parts with synthetic `@所有人` / `@所有AI` entries derived
+ * from the three-state mention flags. Synthetic entries reuse the
+ * `uid: "all"` sentinel so MarkdownContent applies the same
+ * `mention-highlight` class.
+ *
+ * Dedup is by visible name — if the conversation already contains a
+ * literal `@所有人` member part (rare; admins can rename members), the
+ * member entry wins and the synthetic broadcast highlight is dropped.
+ *
+ * The `partMentionType` argument is the numeric enum value for
+ * `Part.type === PartType.mention`. We accept it as a parameter so the
+ * helper does not have to import the SDK PartType (which would pull in
+ * heavy SDK deps from the test runtime).
+ */
+export function buildMessageMentions(
+  parts: MentionRenderPart[] | undefined,
+  flags: MentionRenderFlags | undefined,
+  partMentionType: number,
+): MentionRenderInfo[] {
+  const base: MentionRenderInfo[] =
+    parts
+      ?.filter((p) => p.type === partMentionType && p.data?.uid)
+      .map((p) => ({ name: p.text, uid: p.data!.uid! })) ?? [];
+
+  if (!flags) return base;
+
+  const all = flags.all === true || flags.all === 1;
+  const highlightAll = !!flags.humans || all;
+  const highlightAis = !!flags.ais;
+
+  const synthetic: MentionRenderInfo[] = [];
+  if (highlightAll) synthetic.push({ name: "@所有人", uid: "all" });
+  if (highlightAis) synthetic.push({ name: "@所有AI", uid: "all" });
+
+  const seen = new Set(base.map((m) => m.name));
+  for (const s of synthetic) {
+    if (!seen.has(s.name)) {
+      base.push(s);
+      seen.add(s.name);
+    }
+  }
+  return base;
+}
+
+/**
+ * Read the three-state mention flags off a message content object,
+ * preferring the SDK-decoded `mention.{humans,ais,all}` and falling
+ * back to the raw `contentObj.mention.{humans,ais,all}` shape used on
+ * the wire (where the SDK has not been taught about the new fields).
+ *
+ * Accepts `unknown` so callers do not need to add `as any` at the call
+ * site for either the SDK or the raw decoded JSON.
+ */
+export function readMentionFlags(
+  content: unknown,
+): MentionRenderFlags | undefined {
+  if (!content || typeof content !== "object") return undefined;
+  const c = content as {
+    mention?: MentionRenderFlags;
+    contentObj?: { mention?: MentionRenderFlags };
+  };
+  const mn = c.mention;
+  const contentObjMn = c.contentObj?.mention;
+  if (!mn && !contentObjMn) return undefined;
+  return {
+    all: mn?.all ?? contentObjMn?.all,
+    humans: mn?.humans ?? contentObjMn?.humans,
+    ais: mn?.ais ?? contentObjMn?.ais,
+  };
+}
+
+// ─── Send-side dropdown helpers (used by MessageInput) ────────────
+
+// Sentinel uids used by the @-dropdown sticky top items + voice transcription.
+// `-1` is the legacy "@所有人" (mention.all=1). `-2` / `-3` are the new
+// three-state sentinels (mention.humans=1 / mention.ais=1).
+export const MENTION_UID_LEGACY_ALL = "-1";
+export const MENTION_UID_HUMANS = "-2";
+export const MENTION_UID_AIS = "-3";
+export const MENTION_LABEL_HUMANS = "所有人";
+export const MENTION_LABEL_AIS = "所有AI";
+
+/**
+ * Dropdown item shape returned by the @-mention suggestion factory.
+ * Exported so unit tests can assert the exact selection order and
+ * lock the keyboard-Enter regression that landed in PR #59.
+ */
+export interface MentionDropdownItem {
+  uid: string;
+  name: string;
+  icon: string;
+  isBot: boolean;
+  sourceSpaceName: string;
+}
+
+/**
+ * Pure helper that builds the @-mention dropdown items for a given
+ * query + member list. Extracted from the inline suggestion factory
+ * in `MessageInput/index.tsx` so the keyboard-selection regression
+ * (typing `@Bob` + Enter must select Bob, not the sticky `@所有人`)
+ * can be locked in a unit test without spinning up the editor.
+ *
+ * Sticky behavior: `@所有人` and `@所有AI` are prepended **only when
+ * the query is empty**. As soon as the user types a filter the
+ * dropdown shows only matching members, so `MentionList`'s default
+ * `selectedIndex = 0` correctly lands on the first member match and
+ * Enter inserts the typed member instead of broadcasting to everyone.
+ *
+ * `iconResolver` and `externalResolver` are injected so callers can
+ * pass the production avatar lookup / external-space resolver, while
+ * tests can pass cheap stubs.
+ */
+export function buildMentionDropdownItems<
+  M extends {
+    uid: string;
+    name: string;
+    orgData?: {
+      home_space_id?: string;
+      home_space_name?: string;
+      is_external?: boolean;
+      source_space_name?: string;
+      robot?: number;
+    };
+  },
+>(args: {
+  query: string;
+  members: M[] | null | undefined;
+  iconResolver: (member: M) => string;
+  externalResolver: (member: M) => {
+    isExternal: boolean;
+    sourceSpaceName: string;
+  };
+  stickyIcon: string;
+}): MentionDropdownItem[] {
+  const { query, members, iconResolver, externalResolver, stickyIcon } = args;
+
+  const trimmedQuery = (query ?? "").trim();
+  const stickyTop: MentionDropdownItem[] =
+    trimmedQuery.length === 0
+      ? [
+          {
+            uid: MENTION_UID_HUMANS,
+            name: MENTION_LABEL_HUMANS,
+            icon: stickyIcon,
+            isBot: false,
+            sourceSpaceName: "",
+          },
+          {
+            uid: MENTION_UID_AIS,
+            name: MENTION_LABEL_AIS,
+            icon: stickyIcon,
+            isBot: true,
+            sourceSpaceName: "",
+          },
+        ]
+      : [];
+
+  if (!members) return stickyTop;
+
+  const items: MentionDropdownItem[] = members.map((member) => {
+    const ext = externalResolver(member);
+    return {
+      uid: member.uid,
+      name: member.name,
+      icon: iconResolver(member),
+      // 直接从 Subscriber.orgData 取，不依赖 channelInfo 缓存是否已热
+      isBot: member.orgData?.robot === 1,
+      sourceSpaceName: ext.isExternal ? ext.sourceSpaceName : "",
+    };
+  });
+
+  const filteredMembers = items.filter((item) =>
+    item.name.toLowerCase().includes(trimmedQuery.toLowerCase()),
+  );
+
+  return [...stickyTop, ...filteredMembers];
+}


### PR DESCRIPTION
Closes #58. PR-C of the mention three-state refactor — web UI layer only.

## Scope

Two surfaces:

1. **MessageInput** — `@`-dropdown gets two sticky-top items above the member list.
2. **Conversation** — render matrix highlights `@所有人` / `@所有AI` based on `mention.humans` / `mention.ais` / legacy `mention.all`.

## Input behavior

| Item                 | Sentinel uid | Inserted text | Payload effect            |
|----------------------|--------------|---------------|---------------------------|
| `@所有人` (new)      | `-2`         | `@所有人 `    | `mention.humans = 1`      |
| `@所有AI` (new)      | `-3`         | `@所有AI `    | `mention.ais = 1`         |
| `@所有人` (legacy)   | `-1`         | `@所有人 `    | `mention.all = 1` (kept)  |

- The two new items are pinned at the top of the dropdown regardless of search-query filter.
- The legacy `uid: -1` path is only reachable now via voice transcription (`parseMentionMarkers`) and restored drafts — both still emit `all=1` per RFC.
- `MentionModel` gains `humans?: number` / `ais?: number` (0|1 wire shape).

## Render matrix

| Flags                              | Highlight              |
|------------------------------------|------------------------|
| `humans = 1`                       | `@所有人`              |
| `ais = 1`                          | `@所有AI`              |
| `humans = 1` + `ais = 1`           | `@所有人` + `@所有AI`  |
| `all = 1` (legacy / server outbound double-write) | `@所有人` |

Implementation: `getMessageMentions` synthesizes virtual `MentionInfo` entries with `uid: 'all'`, reusing the existing `mention-highlight` CSS class so colors / styles match. Does **not** mutate `message.parts`.

## Wire format

`buildTextContent` serializes `humans` / `ais` into:
- `msgContent.mention` (via `(mn as any).humans = …`) — for in-process consumers.
- `contentObj.mention.{humans,ais}` + the existing `encode()` override — for the SDK wire JSON.

Same pattern already used for `entities`. Server (PR-A, octo-server #94) accepts both fields and double-writes them on outbound (`all=1` ⇒ `humans=1`).

## Tests

`apps/web/src/__tests__/mentionRefactor.test.ts` — 6 new cases (the 4 required matrix bullets + 2 regression guards):

- `humans=1 only → highlights @所有人`
- `ais=1 only → highlights @所有AI`
- `humans=1 + ais=1 → highlights @所有人 + @所有AI`
- `all=1 (legacy) → highlights @所有人`
- regression: undefined mention → no synthesis
- regression: `@member` Parts coexist with synthetic `@所有AI` (no de-dup collision)

```
mentionRefactor.test.ts: 50/50 pass (was 44)
apps/web suite:          788 pass / 22 fail (baseline 782 / 22 — no new failures)
typecheck:               1589 errors before, 1589 after (all pre-existing React 17/19 mismatch)
vite build:              clean (✓ built in 3.16s)
```

## Acceptance

- [x] `@`-dropdown shows two new sticky top items in any group chat
- [x] Selecting them sends correct payload (covered by formatMentionTextV2 unit logic + buildTextContent serialization)
- [x] Render matrix 4 cases pass in `mentionRefactor.test.ts`
- [x] No regression on existing `@member` functionality (full suite passes 6 more, fails the same 22)
- [x] Type-check + build clean (no new errors)
- [x] Out-of-scope: no server-side validation, no changes to legacy `@所有人` input path

## Related

- octo-server #94 (PR-A, server-side rewrite)
- octo-adapters #44 (PR-B, adapter passthrough)