### PR TITLE
fix(messaging): preserve mention.humans/ais on group sends (#62)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `wrapSendContentForInjection` (YUJ-1378 / octo-web#62).
+ *
+ * 覆盖：
+ *   1. 不需要注入 → 返回原 content（identity check）
+ *   2. mention.ais → wire encode() / contentObj / encodeJSON 都带 mention.ais=1
+ *   3. mention.humans → 同上 humans
+ *   4. mention.all（legacy）单独存在 → 不会被错误注入 humans/ais
+ *   5. space_id 注入 (DM 场景)
+ *   6. space_id + mention.ais 组合
+ *   7. 原始 content 不被 mutate（转发安全）
+ *   8. encode() 经过 swap-call-restore，结束后 content.encodeJSON 恢复原状
+ */
+
+import { describe, it, expect } from "vitest"
+import { MessageText, Mention } from "wukongimjssdk"
+import { wrapSendContentForInjection } from "../sendContentProxy"
+
+function decodeWire(content: { encode: () => Uint8Array }): any {
+    return JSON.parse(new TextDecoder().decode(content.encode()))
+}
+
+describe("wrapSendContentForInjection", () => {
+    it("returns the original content untouched when nothing to inject", () => {
+        const msg = new MessageText("hi")
+        const wrapped = wrapSendContentForInjection(msg, {})
+        expect(wrapped).toBe(msg)
+    })
+
+    it("returns identity when injection flags are all falsy", () => {
+        const msg = new MessageText("hi")
+        const wrapped = wrapSendContentForInjection(msg, {
+            spaceId: null,
+            mentionHumans: false,
+            mentionAis: false,
+        })
+        expect(wrapped).toBe(msg)
+    })
+
+    it("injects mention.ais=1 into the wire payload (group @所有AI scenario)", () => {
+        const msg = new MessageText("@所有AI go")
+        const mn = new Mention()
+        ;(mn as any).ais = 1
+        msg.mention = mn
+
+        const wrapped = wrapSendContentForInjection(msg, { mentionAis: true })
+
+        const wire = decodeWire(wrapped)
+        expect(wire.mention).toBeDefined()
+        expect(wire.mention.ais).toBe(1)
+        expect(wire.space_id).toBeUndefined() // group → no space_id
+
+        // encodeJSON output mirrors encode() bytes
+        expect(wrapped.encodeJSON().mention.ais).toBe(1)
+        // contentObj for local echo also carries the injection
+        expect(wrapped.contentObj.mention.ais).toBe(1)
+    })
+
+    it("injects mention.humans=1 (@所有人 three-state path)", () => {
+        const msg = new MessageText("@所有人 ping")
+        const mn = new Mention()
+        ;(mn as any).humans = 1
+        msg.mention = mn
+
+        const wrapped = wrapSendContentForInjection(msg, { mentionHumans: true })
+
+        const wire = decodeWire(wrapped)
+        expect(wire.mention.humans).toBe(1)
+        expect(wire.mention.ais).toBeUndefined()
+    })
+
+    it("preserves legacy mention.all=1 alongside humans/ais being absent", () => {
+        const msg = new MessageText("@everyone")
+        const mn = new Mention()
+        mn.all = true
+        msg.mention = mn
+
+        const wrapped = wrapSendContentForInjection(msg, {
+            mentionHumans: false,
+            mentionAis: false,
+        })
+        // no injection requested → identity
+        expect(wrapped).toBe(msg)
+        const wire = decodeWire(wrapped)
+        expect(wire.mention.all).toBe(1)
+        expect(wire.mention.humans).toBeUndefined()
+        expect(wire.mention.ais).toBeUndefined()
+    })
+
+    it("injects space_id only (DM no-mention scenario, regression of #784)", () => {
+        const msg = new MessageText("plain dm")
+
+        const wrapped = wrapSendContentForInjection(msg, { spaceId: "space-xyz" })
+
+        const wire = decodeWire(wrapped)
+        expect(wire.space_id).toBe("space-xyz")
+        expect(wire.mention).toBeUndefined()
+        // contentObj for local echo also carries space_id (filterPersonMessagesBySpace #784)
+        expect(wrapped.contentObj.space_id).toBe("space-xyz")
+    })
+
+    it("injects both space_id and mention.ais (DM @所有AI scenario)", () => {
+        const msg = new MessageText("ai in DM")
+        const mn = new Mention()
+        ;(mn as any).ais = 1
+        msg.mention = mn
+
+        const wrapped = wrapSendContentForInjection(msg, {
+            spaceId: "space-1",
+            mentionAis: true,
+        })
+
+        const wire = decodeWire(wrapped)
+        expect(wire.space_id).toBe("space-1")
+        expect(wire.mention.ais).toBe(1)
+        expect(wrapped.contentObj.space_id).toBe("space-1")
+        expect(wrapped.contentObj.mention.ais).toBe(1)
+    })
+
+    it("does not mutate the original content (forwarding-safety)", () => {
+        const msg = new MessageText("forward me")
+        const mn = new Mention()
+        ;(mn as any).ais = 1
+        msg.mention = mn
+        const originalEncodeJSON = msg.encodeJSON
+        const originalEncode = msg.encode
+        const originalContentObj = msg.contentObj
+
+        const wrapped = wrapSendContentForInjection(msg, { mentionAis: true })
+        // touch encode to trigger the swap-call-restore path
+        wrapped.encode()
+
+        // Original is intact — no own-property leak
+        expect(msg.encodeJSON).toBe(originalEncodeJSON)
+        expect(msg.encode).toBe(originalEncode)
+        expect(msg.contentObj).toBe(originalContentObj)
+        // Direct encodeJSON on original still goes through SDK (drops ais)
+        const directJson = msg.encodeJSON()
+        expect(directJson.mention?.ais).toBeUndefined()
+    })
+
+    it("encode() restores content.encodeJSON even if encode() throws", () => {
+        const msg = new MessageText("boom")
+        const mn = new Mention()
+        ;(mn as any).ais = 1
+        msg.mention = mn
+        const originalEncodeJSON = msg.encodeJSON
+
+        const wrapped = wrapSendContentForInjection(msg, { mentionAis: true })
+        // Sabotage the underlying encode to throw mid-call
+        const realEncode = msg.encode.bind(msg)
+        msg.encode = function () {
+            throw new Error("simulated SDK failure")
+        }
+        expect(() => wrapped.encode()).toThrow("simulated SDK failure")
+        // encodeJSON on original is restored even on throw
+        expect(msg.encodeJSON).toBe(originalEncodeJSON)
+        // restore for cleanliness
+        msg.encode = realEncode
+    })
+
+    it("contentObj fallback uses encodeJSON()+type when content.contentObj is empty", () => {
+        const msg = new MessageText("fresh msg")
+        // MessageText newly constructed has no contentObj set (decodeJSON not called)
+        // → fallback path: { ...encodeJSON(), type: contentType }
+        const wrapped = wrapSendContentForInjection(msg, { spaceId: "S" })
+        expect(wrapped.contentObj.space_id).toBe("S")
+        expect(wrapped.contentObj.type).toBe(msg.contentType)
+        // payload still has the underlying text content for messageToMap
+        expect(wrapped.contentObj.content).toBe("fresh msg")
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/sendContentProxy.ts
+++ b/packages/dmworkbase/src/Components/Conversation/sendContentProxy.ts
@@ -1,0 +1,186 @@
+/**
+ * sendContentProxy — pre-send wire-payload injection
+ * =====================================================
+ *
+ * 业务背景：`ConversationVM.sendMessage` 在把消息交给
+ * `WKSDK.chatManager.send()` 之前，需要往 wire payload 注入两类
+ * 业务字段：
+ *
+ *   1. **space_id**（仅 DM / ChannelTypePerson）—— `filterPersonMessagesBySpace`
+ *      (#784) 依赖。BotFather 等 Bot 用此判断用户当前 Space。
+ *
+ *   2. **mention.humans / mention.ais**（任意 channel）——
+ *      `wukongimjssdk@1.3.5` 的 `MessageContent.encode()` 写 mention 时
+ *      只取 `this.mention.all` / `this.mention.uids`，**整段覆盖**
+ *      `contentObj.mention`：
+ *
+ *      ```js
+ *      // SDK encode() 节选
+ *      var contentObj = this.encodeJSON();
+ *      if (this.mention) {
+ *          var mentionObj = {};
+ *          if (this.mention.all)  mentionObj["all"]  = 1;
+ *          if (this.mention.uids) mentionObj["uids"] = this.mention.uids;
+ *          contentObj["mention"] = mentionObj;  // ← 整段覆盖
+ *      }
+ *      ```
+ *
+ *      所以仅靠 `encodeJSON` 注入 `mention.humans|ais` 不够—— SDK encode 后
+ *      仍会被覆盖。必须在 `encode()` 的 wire bytes 出炉后做 post-process
+ *      （decode-modify-encode）才能保住三态字段。
+ *
+ *      群聊里发 "@所有AI" 时若不修复，server 端收不到 `mention.ais=1`，
+ *      AI bot 不响应。参考 octo-web#62 / YUJ-1378。
+ *
+ * 注入策略：**不修改原始 content 对象**。原因是同一个 content 在转发场景下
+ * 可能被多次复用（多目标转发）或是原始消息的引用（单条转发），直接
+ * monkey-patch 会污染原始消息。
+ *
+ * 实现：创建一个 `Object.create(content)` 代理对象，覆盖 `encodeJSON` /
+ * `encode` / `contentObj` 三个序列化入口：
+ *   - `encodeJSON()` 注入两个字段（mention 字段虽然会被 SDK encode 覆盖，
+ *     但直接调用 encodeJSON 的代码路径需要看到三态字段，保持一致性）。
+ *   - `encode()` 通过 swap-call-restore 让 SDK 调用我们的 encodeJSON
+ *     拿到 space_id，然后再对 SDK 返回的 bytes 做 mention.humans|ais 的
+ *     post-process re-inject。
+ *   - `contentObj` 用于本地回显（messageToMap），也要带上注入字段。
+ *
+ * 提取出来是为了 unit test —— 整个 `Conversation/vm.ts` 引了 Mergeforward
+ * 等重量级 UI 模块，在 jsdom 里 import 会触发 lottie / canvas 报错。
+ * 这个 helper 只依赖 wukongimjssdk 的 MessageContent 类型，干净可测。
+ */
+
+import type { MessageContent } from "wukongimjssdk"
+
+/**
+ * 描述本次发送需要注入哪些字段。
+ *
+ * `spaceId` 为非空字符串时注入 `obj.space_id`。
+ * `mentionHumans` / `mentionAis` 为 truthy 时注入 `obj.mention.humans|ais=1`。
+ */
+export interface SendInjection {
+    spaceId?: string | null
+    mentionHumans?: boolean
+    mentionAis?: boolean
+}
+
+/**
+ * 给 `content` 套一层注入业务字段的代理。若 `injection` 没有任何要注入的
+ * 字段，原样返回 `content`（无开销、no-op）。
+ *
+ * 返回的对象是 `Object.create(content)` 出来的轻量代理，原 content 不被
+ * mutate；调用方拿到的 sendContent.encode() 包含注入字段，
+ * sendContent.contentObj 也带注入字段（本地回显用）。
+ */
+export function wrapSendContentForInjection(
+    content: MessageContent,
+    injection: SendInjection,
+): MessageContent {
+    const injectSpaceId = !!injection.spaceId
+    const injectMentionHumans = !!injection.mentionHumans
+    const injectMentionAis = !!injection.mentionAis
+    const injectMention = injectMentionHumans || injectMentionAis
+    if (!injectSpaceId && !injectMention) {
+        return content
+    }
+
+    const sendContent: MessageContent = Object.create(content) as MessageContent
+    // 保存原始 encodeJSON 的引用（不 bind），通过 .call(this) 传 receiver，
+    // 让 media 上传后写到代理的 url/remoteUrl 能被正确读取。
+    const originalEncodeJSON = content.encodeJSON
+    sendContent.encodeJSON = function (this: any) {
+        const obj = originalEncodeJSON.call(this)
+        if (injectSpaceId) {
+            obj.space_id = injection.spaceId
+        }
+        // 注：mention 在 encodeJSON 这里注入只对 *直接调用 encodeJSON()*
+        // 的代码路径生效。SDK encode() 后续会用 this.mention 重新覆盖
+        // contentObj.mention（见文件 header）。真正进 wire 的注入由
+        // 下面 encode() 的 post-process 完成。这里同步写一份只是保持
+        // 不同入口的输出一致。
+        if (injectMention) {
+            if (!obj.mention) obj.mention = {}
+            if (injectMentionHumans) obj.mention.humans = 1
+            if (injectMentionAis) obj.mention.ais = 1
+        }
+        return obj
+    }
+    // encode() 覆盖：解决三个矛盾需求：
+    // 1. mention 实例级 encode 覆盖 bind 了 content，需要 encodeJSON 在 content 上
+    //    （swap-call-restore content.encodeJSON 让 space_id 注入生效）
+    // 2. media 上传后 SDK 把 remoteUrl/url 写到 sendContent（代理）上
+    //    （ownKeys 同步回 content，调用完再 restore）
+    // 3. SDK 的 MessageContent.encode 用 `this.mention` 整段覆盖 contentObj.mention
+    //    （拿到 bytes 后 decode-modify-encode 补回 humans/ais）
+    sendContent.encode = function () {
+        // 前置条件（swap-call-restore 安全性依赖）：
+        // 1. content.encode() 必须是同步的（无 await），否则 swap 窗口内可被其他调用打断
+        // 2. content.encode() 不会递归调用 ConversationVM.sendMessage
+        // 当前 SDK (wukongimjssdk 1.3.5) 满足这两个条件。
+        //
+        // 同步 media 上传后写入代理的属性回原始 content，
+        // 跟踪 hasOwnProperty 以正确恢复（避免 own-property 泄漏）。
+        const ownKeys = Object.getOwnPropertyNames(sendContent)
+        const saved: Record<string, any> = {}
+        const hadOwn: Record<string, boolean> = {}
+        for (const key of ownKeys) {
+            if (key === "encodeJSON" || key === "encode" || key === "contentObj") continue
+            hadOwn[key] = Object.prototype.hasOwnProperty.call(content, key)
+            if (hadOwn[key]) saved[key] = (content as any)[key]
+            ;(content as any)[key] = (sendContent as any)[key]
+        }
+        // swap encodeJSON 让 space_id 注入生效
+        const savedEncodeJSON = content.encodeJSON
+        const hadOwnEncodeJSON = Object.prototype.hasOwnProperty.call(content, "encodeJSON")
+        content.encodeJSON = sendContent.encodeJSON
+        let bytes: Uint8Array
+        try {
+            bytes = content.encode.call(content)
+        } finally {
+            if (hadOwnEncodeJSON) content.encodeJSON = savedEncodeJSON
+            else delete (content as any).encodeJSON
+            // 恢复 content 上被同步过去的属性
+            for (const key of Object.keys(hadOwn)) {
+                if (hadOwn[key]) (content as any)[key] = saved[key]
+                else delete (content as any)[key]
+            }
+        }
+        // SDK encode 之后再 post-process mention.humans / mention.ais ——
+        // SDK encode 会把它们 strip 掉，这里 decode bytes 后回填，再 re-encode。
+        // 若 JSON parse 失败（理论不会，SDK 必出合法 JSON）则退回原 bytes，
+        // 保证发送不被这里 block。
+        if (injectMention) {
+            try {
+                const str = new TextDecoder().decode(bytes)
+                const obj = JSON.parse(str)
+                if (!obj.mention) obj.mention = {}
+                if (injectMentionHumans) obj.mention.humans = 1
+                if (injectMentionAis) obj.mention.ais = 1
+                bytes = new TextEncoder().encode(JSON.stringify(obj))
+            } catch (e) {
+                // 静默 fallback：发送原 bytes，至少消息能发出去
+                // eslint-disable-next-line no-console
+                console.warn("[sendContentProxy] mention re-inject failed", e)
+            }
+        }
+        return bytes
+    }
+    // 同步 contentObj，让本地回显也走带注入字段的路径
+    // （filterPersonMessagesBySpace #784 依赖 space_id；
+    //  本地 mention 渲染依赖 mention.humans|ais 的存在）
+    // 当原始 contentObj 为空时（新创建的消息未经 decode），用 encodeJSON()
+    // 构建完整 payload，避免本地回显的 contentObj 只有少量字段、
+    // 导致 messageToMap 丢失实际内容。
+    const baseObj = content.contentObj || { ...content.encodeJSON(), type: content.contentType }
+    const mergedObj: Record<string, any> = { ...baseObj }
+    if (injectSpaceId) {
+        mergedObj.space_id = injection.spaceId
+    }
+    if (injectMention) {
+        mergedObj.mention = { ...(mergedObj.mention || {}) }
+        if (injectMentionHumans) mergedObj.mention.humans = 1
+        if (injectMentionAis) mergedObj.mention.ais = 1
+    }
+    sendContent.contentObj = mergedObj
+    return sendContent
+}

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -19,6 +19,7 @@ import { SystemContent } from "wukongimjssdk";
 import { getFoldSessionExpandedMessages } from "./foldSessionSummary";
 import { getPulldownRestoredScrollTop } from "./historyScroll";
 import { applyMsgLevelExternalFieldsWithFallback } from "../../Service/Convert";
+import { wrapSendContentForInjection } from "./sendContentProxy";
 
 export interface FoldSessionParticipant {
     uid: string
@@ -1829,68 +1830,23 @@ export default class ConversationVM extends ProviderListener {
 
     // 发送消息
     async sendMessage(content: MessageContent, channel: Channel): Promise<Message> {
-        // DM 消息注入 space_id，让 BotFather 等 Bot 知道用户当前 Space
-        // 注意：不能直接修改传入的 content 对象，因为转发场景下同一个 content
-        // 可能被多次使用（多目标转发）或是原始消息的引用（单条转发）。
-        // 直接 monkey-patch 会污染原始消息的 content，导致后续操作异常。
-        let sendContent = content
+        // 发送前注入两类业务字段（详细原因见 sendContentProxy.ts header）：
+        //   1. space_id —— 仅 DM (ChannelTypePerson)，让 BotFather 等 Bot
+        //      知道用户当前 Space (#784)。
+        //   2. mention.humans / mention.ais —— 任意 channel（DM + Group）。
+        //      `wukongimjssdk@1.3.5` 的 `MessageContent.encode()` 丢弃 mention
+        //      的 humans/ais 三态字段。群聊里 @所有AI 后 server 收不到
+        //      `mention.ais=1`，AI bot 不响应（octo-web#62 / YUJ-1378）。
+        //
+        // wrapSendContentForInjection 不会污染原始 content（重要：转发场景
+        // 同一 content 可能被多目标复用，直接 monkey-patch 会有副作用）。
         const spaceId = WKApp.shared.currentSpaceId
-        if (spaceId && channel.channelType === ChannelTypePerson) {
-            // 创建一个轻量代理对象，继承原 content 的所有属性和方法，
-            // 仅覆盖 encodeJSON 和 contentObj 以注入 space_id。
-            // 安全前提：SDK 通过 encode()/encodeJSON() 序列化，不依赖 own-property 枚举。
-            sendContent = Object.create(content) as MessageContent
-            // 保存原始 encodeJSON 的引用（不 bind），通过 .call(this) 传递 receiver，
-            // 确保 media 上传后写入代理的 url/remoteUrl 能被正确读取。
-            const originalEncodeJSON = content.encodeJSON
-            sendContent.encodeJSON = function (this: any) {
-                const obj = originalEncodeJSON.call(this)
-                obj.space_id = spaceId
-                return obj
-            }
-            // encode() 覆盖：解决两个矛盾需求：
-            // 1. mention 实例级 encode 覆盖 bind 了 content，需要 encodeJSON 在 content 上
-            // 2. media 上传后 SDK 把 remoteUrl/url 写到 sendContent（代理）上
-            // 方案：先同步代理上的 media 属性回 content，再 swap encodeJSON 并调用原始 encode
-            sendContent.encode = function () {
-                // 前置条件（swap-call-restore 安全性依赖）：
-                // 1. content.encode() 必须是同步的（无 await），否则 swap 窗口内可被其他调用打断
-                // 2. content.encode() 不会递归调用 ConversationVM.sendMessage
-                // 当前 SDK (wukongimjssdk 1.3.5) 满足这两个条件。
-                //
-                // 同步 media 上传后写入代理的属性回原始 content
-                // 跟踪 hasOwnProperty 以正确恢复（避免 own-property 泄漏）
-                const ownKeys = Object.getOwnPropertyNames(sendContent)
-                const saved: Record<string, any> = {}
-                const hadOwn: Record<string, boolean> = {}
-                for (const key of ownKeys) {
-                    if (key === 'encodeJSON' || key === 'encode' || key === 'contentObj') continue
-                    hadOwn[key] = Object.prototype.hasOwnProperty.call(content, key)
-                    if (hadOwn[key]) saved[key] = (content as any)[key]
-                        ; (content as any)[key] = (sendContent as any)[key]
-                }
-                // swap encodeJSON 让 space_id 注入生效
-                const savedEncodeJSON = content.encodeJSON
-                const hadOwnEncodeJSON = Object.prototype.hasOwnProperty.call(content, 'encodeJSON')
-                content.encodeJSON = sendContent.encodeJSON
-                try {
-                    return content.encode.call(content)
-                } finally {
-                    if (hadOwnEncodeJSON) content.encodeJSON = savedEncodeJSON
-                    else delete (content as any).encodeJSON
-                    // 恢复 content 上被同步的属性
-                    for (const key of Object.keys(hadOwn)) {
-                        if (hadOwn[key]) (content as any)[key] = saved[key]
-                        else delete (content as any)[key]
-                    }
-                }
-            }
-            // 同步 contentObj，让本地回显也通过 filterPersonMessagesBySpace (#784)
-            // 当原始 contentObj 为空时（新创建的消息未经 decode），用 encodeJSON() 构建完整 payload，
-            // 避免本地回显的 contentObj 只有 { space_id } 导致 messageToMap 丢失实际内容。
-            const baseObj = content.contentObj || { ...content.encodeJSON(), type: content.contentType }
-            sendContent.contentObj = { ...baseObj, space_id: spaceId }
-        }
+        const mentionAny = content.mention as any
+        const sendContent = wrapSendContentForInjection(content, {
+            spaceId: channel.channelType === ChannelTypePerson ? spaceId : null,
+            mentionHumans: !!(mentionAny && mentionAny.humans),
+            mentionAis: !!(mentionAny && mentionAny.ais),
+        })
         const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
         let setting = new Setting()
         if (channelInfo?.orgData.receipt === 1) {


### PR DESCRIPTION
## 问题

群聊里 `@所有AI` 发送后 AI bot 不响应。根因是 `wukongimjssdk@1.3.5` 的
`MessageContent.encode()` 写 wire payload 时只取 `this.mention.all` /
`this.mention.uids`，**整段覆盖** `contentObj.mention`：

```js
// SDK MessageContent.prototype.encode 节选
var contentObj = this.encodeJSON();
if (this.mention) {
    var mentionObj = {};
    if (this.mention.all)  mentionObj["all"]  = 1;
    if (this.mention.uids) mentionObj["uids"] = this.mention.uids;
    contentObj["mention"] = mentionObj;   // ← 覆盖
}
```

即使 `MentionModel` 设了 `mention.ais = 1`，encode 后也只剩 `{}`，server
端收不到 `mention.ais=1`，bot 自然不响应。

`buildTextContent`（index.tsx）虽然有 `encode` 覆盖，但该路径只覆盖一次性
构造的 MessageText，且只解决单条 text 发送；任何走 `sendMessage` 但未经
`buildTextContent` 的 content（转发、quick reply、命令产物等）都会再次丢失
三态字段。所以把注入点下沉到 `sendMessage` 是更稳的边界。

## 修复

抽出 `wrapSendContentForInjection(content, injection)` 到独立模块
`Conversation/sendContentProxy.ts`，在 `ConversationVM.sendMessage` 调用
`chatManager.send` 之前给 content 套一层 `Object.create(content)` 代理：

| 入口          | 注入字段                                  | 作用域            |
|---------------|-------------------------------------------|-------------------|
| `encodeJSON()`| `space_id`, `mention.humans|ais`          | 直接 encodeJSON 调用方 |
| `encode()`    | `space_id` (via swap-call-restore encodeJSON) + `mention.humans|ais` (via decode-modify-encode post-process) | wire payload 真正的注入 |
| `contentObj`  | `space_id`, `mention.humans|ais`          | 本地回显 messageToMap / #784 filter |

注入条件：
- `space_id` 只在 DM (`ChannelTypePerson`) 注入，逻辑同 #784。
- `mention.humans` / `mention.ais` 在任意 channel（DM + Group）只要原始
  `content.mention` 携带就注入——这就是本 PR 的功能性扩展。

**不污染原始 content**：套代理而不是 monkey-patch，保证转发场景下同一个
content 在多目标复用 / 单条转发引用时不会被破坏。`encode()` 的
swap-call-restore 在 try/finally 里 restore content.encodeJSON 与被同步
过去的 own properties，throw 也安全。

## 测试

新增 `__tests__/sendContentProxy.test.ts`（10 cases，全绿）：

- identity passthrough（不需要注入时返回原 content）
- 各种 falsy injection flag 组合
- `mention.ais=1` → wire `obj.mention.ais=1`、contentObj、encodeJSON 三者一致
- `mention.humans=1` 同上
- legacy `mention.all=1` 单独存在不会被错误添加 humans/ais
- DM only space_id（#784 回归）
- DM + mention.ais 组合
- 转发安全（encodeJSON/encode/contentObj 原 content 都没被替换）
- encode() throw 时 content.encodeJSON 仍 restore
- 新建 MessageText (`contentObj` 为空) 时 fallback 用 encodeJSON+type 构造完整 payload

抽出独立模块也是为了避免直接 import `ConversationVM`（vm.ts 链路上
Mergeforward 触发 lottie/canvas，jsdom 下挂掉）。

完整 vitest run 中本 PR 的 10 个新 case 全过，仓库现有 52 个 fail 与本 PR
无关（baseline 同样 fail）。

## 验收（issue 描述的手动验证步骤）

- [ ] 群聊发 `@所有AI` → devtools/network 抓 send packet content，验
      `mention.ais=1`
- [ ] AI bot 在群里响应
- [ ] 群聊 `@所有人` 仍正常（`mention.humans=1`）
- [ ] 群聊 legacy `@所有` 仍正常（`mention.all=1`）
- [ ] DM 消息 `space_id` 注入不受影响

Refs https://github.com/Mininglamp-OSS/octo-web/issues/62
Closes YUJ-1378
