### PR TITLE
fix(persona): remove duplicate back arrow + restore truncated toggle row

### DIFF
--- a/packages/dmworkbase/src/Components/MeInfo/vm.tsx
+++ b/packages/dmworkbase/src/Components/MeInfo/vm.tsx
@@ -441,23 +441,26 @@ export class MeInfoVM extends ProviderListener {
 
         // 「我的分身」入口 — Persona Clone / AI On-Behalf-Of (PR-C, GH octo-web#46)。
         // 复用 RoutePage + Section/Row DSL：点击 Row 用 context.push 把 PersonaSettings
-        // 推进当前 MeInfo 栈，与「我的二维码」同款交互。注意 PersonaSettings 内部为了
-        // 承载 PersonaCreate / PersonaEdit 的子级跳转，会再创建一层 nested RoutePage
-        // 上下文（PR description 早期文案「zero new routes」并不精确：路由数量没变，
-        // 但是确实又多了一层 RouteContext 栈）。
+        // 推进当前 MeInfo 栈，与「我的二维码」同款交互。
         //
-        // 因为存在 nested RoutePage，PersonaSettings 根页面那个「关闭」按钮回调走的是
-        // `this.props.onClose`，所以这里必须把 onClose 接到 MeInfo 当前栈的 pop 上，
-        // 否则进入分身页之后根级关闭按钮就成了 no-op，用户只能把整个 MeInfo 关掉
-        // 才能脱身（YUJ-1178 / PR #47 review 反馈 P1-1）。
+        // YUJ-1435 (2026-05-20)：把 MeInfo 自己的 RouteContext 透传给 PersonaSettings，
+        // 让其 PersonaCreate / PersonaEdit 等子页面直接 push 到 MeInfo 这一层 stack。
+        // 之前 PersonaSettings 内部自带一层 RoutePage，会与 MeInfo 这层叠两个 header
+        // → 用户看到两个 ← 返回按钮。透传后嵌套 RoutePage 不再渲染，仅留 MeInfo 这层
+        // header，整条「MeInfo → 分身列表 → 分身详情」走同一根 back arrow（语义也
+        // 更清晰：在详情页按返回先回列表，再按一次回 MeInfo）。
         //
-        // 设计取舍:这里**不** prefetch / 不查 active grant 状态,subTitle 故意留空,
-        // 进入子页才拉数据(后端 PR-A 未 merge 时会 404, 子页 vm 已做 graceful empty
-        // 态)。原因:本页是高频入口(每次开 MeInfo 都跑 sections()), 多塞一次 GET
-        // /v1/obo/grants 不划算; 而且 PR-A merge 前每次都打 404,日志噪音难处理。
+        // 因为不再有嵌套 RoutePage，PersonaSettings 根级的 onClose 钩子在嵌入模式下
+        // 不会被触发（保留 prop 给未来 settings panel 模态化链路用）。push 时附带
+        // RouteContextConfig({ title: "我的分身" }) 让 MeInfo 的 header 标题正确切换。
+        //
+        // 设计取舍：这里**不** prefetch / 不查 active grant 状态，subTitle 故意留空，
+        // 进入子页才拉数据（后端 PR-A 未 merge 时会 404，子页 vm 已做 graceful empty
+        // 态）。原因：本页是高频入口（每次开 MeInfo 都跑 sections()），多塞一次 GET
+        // /v1/obo/grants 不划算；而且 PR-A merge 前每次都打 404，日志噪音难处理。
         //
         // Section 故意单独成 section（不并入「账号安全」），原因是 v1 之后这块会扩成
-        // 「我的分身 / 草稿审批 / 活动日志」三行,提前做好视觉分组占位。
+        // 「我的分身 / 草稿审批 / 活动日志」三行，提前做好视觉分组占位。
         sections.push(new Section({
             rows: [
                 new Row({
@@ -466,7 +469,10 @@ export class MeInfoVM extends ProviderListener {
                         title: "我的分身",
                         subTitle: "",
                         onClick: () => {
-                            context.push(<PersonaSettings onClose={() => context.pop()} />)
+                            context.push(
+                                <PersonaSettings routeContext={context} />,
+                                new RouteContextConfig({ title: "我的分身" }),
+                            )
                         }
                     }
                 })

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.css
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.css
@@ -182,7 +182,16 @@
 .wk-persona-edit {
     display: flex;
     flex-direction: column;
+    /*
+     * YUJ-1435 (2026-05-20): 改用 min-height 而非 height —— 嵌入模式下
+     * (parent RouteContext) PersonaEdit 直接 push 到 MeInfo 的 stack，
+     * 父容器是 WKViewQueue 的滑动容器；用 height: 100% 会强制本组件等于父高，
+     * 但 width 没显式设置，flex 子项默认 shrink，可能让内部 section 变窄。
+     * 显式 width: 100% + box-sizing 兜底；overflow-y: auto 仍由本容器承担滚动。
+     */
+    width: 100%;
     height: 100%;
+    box-sizing: border-box;
     background: var(--wk-bg-base);
     overflow-y: auto;
 }
@@ -191,6 +200,21 @@
     background: var(--wk-bg-surface);
     margin: var(--wk-sp-3);
     border-radius: var(--wk-r-md);
+    /*
+     * YUJ-1435 Bug 2 (2026-05-20)：原本 overflow: hidden 是为了让 border-radius
+     * 切掉子行的右下角。但 PersonaEdit 是 `display: flex; flex-direction: column`
+     * 容器，flex 子项默认 `flex-shrink: 1`，当 scope rows 较多导致总内容高度超过
+     * 父容器时，**所有 section 会被等比例压扁**，紧接着 `overflow: hidden` 把
+     * 「全局开关」行的下半部分（含 Semi UI Switch 的实际像素高度 ≈ 28px）整体
+     * 裁掉 → 用户看到「文字被截，右侧 Switch 完全消失」的 P1 视觉 bug。
+     *
+     * 修复双管齐下：
+     *   1. `flex-shrink: 0` 让 section 保持自然高度，不被 flex 算法压缩；
+     *      多出的高度交给 `.wk-persona-edit` 的 `overflow-y: auto` 滚动承接。
+     *   2. 仍保留 `overflow: hidden` 维持圆角对 row border-bottom 的视觉裁切，
+     *      因为 (1) 已经避免了垂直压缩 → 不会再裁掉 Switch。
+     */
+    flex-shrink: 0;
     overflow: hidden;
 }
 
@@ -200,6 +224,16 @@
     align-items: center;
     padding: var(--wk-sp-3) var(--wk-sp-4);
     border-bottom: 1px solid var(--wk-border-default);
+    /*
+     * YUJ-1435 Bug 2 (2026-05-20)：显式 min-height 给 Switch 等控件留出垂直空间，
+     * 即使父级出现任何意外的高度约束也能保证 Switch 完整可见。Semi UI Switch
+     * 默认尺寸约 28×16，加 12px 上下 padding 后理论 52px 即可容纳；这里取 56px
+     * 与 RoutePage header 同高，视觉节奏更一致。
+     *
+     * 同时 `box-sizing: border-box` 保证 padding 不会把 min-height 顶到 80px。
+     */
+    box-sizing: border-box;
+    min-height: 56px;
 }
 
 .wk-persona-edit-row:last-child {
@@ -209,11 +243,27 @@
 .wk-persona-edit-row-title {
     font-size: var(--wk-text-size-md);
     color: var(--wk-text-primary);
+    /*
+     * YUJ-1435 Bug 2 (2026-05-20)：min-width: 0 + flex: 1 让 title 在长 bot 名/
+     * 长 channel id 场景下可以收缩 + 省略号，而不是把右侧的 Switch / 值文本
+     * 挤出可见区域。配合 .wk-persona-edit-row-value 的 ellipsis 实现完整截断。
+     */
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .wk-persona-edit-row-value {
     font-size: var(--wk-text-size-base);
     color: var(--wk-text-tertiary);
+    /* 右侧值文本：不抢占 title 的伸缩，但自身也允许长内容截断。 */
+    margin-left: var(--wk-sp-3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 60%;
 }
 
 .wk-persona-edit-scope-list {

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
@@ -26,6 +26,24 @@ interface PersonaSettingsProps {
      * 仍需要 close 钩子。两者兼容：未传 onClose 时复用 MeInfo 提供的栈即可。
      */
     onClose?: () => void
+    /**
+     * BUG-FIX (YUJ-1435, 2026-05-20)：当 PersonaSettings 是被父级 RouteContext
+     * （例如 MeInfo 的 RoutePage）`push` 进来时，父级已经在顶部渲染了一个 header +
+     * back arrow。若 PersonaSettings 内部再嵌一层 `RoutePage`，用户会看到两个
+     * 叠加的 ← 返回按钮（P1 视觉 bug）。
+     *
+     * 修复策略：当父级把它的 RouteContext 透传进来（`routeContext` 非 undefined），
+     * 本组件不再创建嵌套 RoutePage —— 直接把 PersonaCreate / PersonaEdit 子页面
+     * push 到父级的 stack 上，由父级唯一的 back arrow 统一管理「PersonaEdit →
+     * 分身列表 → MeInfo」整条路径的回退。这同时也消除了「点 PersonaEdit 上的
+     * outer back 直接关掉整个 PersonaSettings 跳过列表」的奇怪 UX（原因：outer
+     * back 弹的是父 stack 顶，而内部子页之前在 inner stack）。
+     *
+     * 当 `routeContext` 未传（独立测试 / 未来 settings panel 链路）时仍保留旧的
+     * 内嵌 RoutePage 行为，保证向后兼容。`PersonaSettings.test.tsx` 走的就是这条
+     * 路径，render(<PersonaSettings />) 不传 routeContext。
+     */
+    routeContext?: RouteContext<any>
 }
 
 export default class PersonaSettings extends Component<PersonaSettingsProps> {
@@ -34,6 +52,17 @@ export default class PersonaSettings extends Component<PersonaSettingsProps> {
             <Provider
                 create={(): IProviderListener => new PersonaSettingsVM()}
                 render={(vm: PersonaSettingsVM): ReactNode => {
+                    // 嵌入模式（YUJ-1435）：父级已提供 header + back arrow，
+                    // 直接渲染 body 并复用父级 RouteContext，避免双 ← 按钮。
+                    if (this.props.routeContext) {
+                        return (
+                            <PersonaListBody
+                                vm={vm}
+                                routeContext={this.props.routeContext}
+                            />
+                        )
+                    }
+                    // 独立模式：维持旧行为，自带 RoutePage（向后兼容 / 测试 / 模态化场景）。
                     return (
                         <RoutePage
                             title="我的分身"


### PR DESCRIPTION
## Summary

PersonaSettings detail page (分身管理页面) had two P1 UI bugs noted on PR-C #47 (YUJ-1435).

## Bug 1 — duplicate back arrow

`PersonaSettings` was wrapping its body in its own `RoutePage` so it could push `PersonaCreate` / `PersonaEdit` onto an internal stack. But `MeInfo` already pushes `PersonaSettings` via its own `RouteContext`, which renders a header + back arrow above the embedded view. Result: two stacked headers, two ← buttons, and the outer ← could only pop the entire PersonaSettings rather than navigate within it.

**Fix:** `PersonaSettings` now accepts an optional `routeContext` prop. When `MeInfo` passes its own context in (the embedded case), `PersonaSettings` skips the nested `RoutePage` and pushes sub-pages onto the parent's stack — so a **single back arrow** handles `MeInfo → 分身列表 → 分身详情` in a coherent way. When the prop is absent (standalone render in tests / future settings panel), the old `RoutePage` wrapper is preserved for backward compatibility, so the existing `PersonaSettings.test.tsx` suite still passes.

## Bug 2 — truncated 全局开关 row hiding the Switch

`.wk-persona-edit-section` had `overflow: hidden` and was a flex item under `.wk-persona-edit` (`display: flex; flex-direction: column`). When total content exceeded the visible area, default `flex-shrink: 1` squeezed every section proportionally, and `overflow: hidden` then clipped the lower portion of each row — including the Switch on the `全局开关` row.

**Fix:**
- `.wk-persona-edit-section`: `flex-shrink: 0` (sections keep natural height; scrolling is handled by parent's `overflow-y: auto`)
- `.wk-persona-edit-row`: explicit `min-height: 56px` + `box-sizing: border-box` so the Switch always has vertical space
- `.wk-persona-edit-row-title`: `flex: 1` + `min-width: 0` + ellipsis so long bot names / channel ids cannot push the right-side Switch off-screen
- `.wk-persona-edit-row-value`: `max-width` + ellipsis to mirror title behavior
- `.wk-persona-edit`: `width: 100%` + `box-sizing` fallback

## Expected layout after fix

- **PersonaSettings (分身列表)**: one header (from MeInfo), one ← back arrow, title "我的分身". List body unchanged.
- **PersonaEdit**: still one header (from MeInfo), one ← back arrow. Tapping it pops back to the list (not all the way out to MeInfo). All rows now show their full content — including the `全局开关` Switch on the right of its row, between `模式: 自动回复` and `已启用的会话 (X)`.

## Verification

- `pnpm run build` ✅ passes (turbo cache & full vite build clean)
- `pnpm exec stylelint packages/dmworkbase/src/Components/PersonaSettings/index.css` ✅ clean
- `vitest packages/dmworkbase/src/Components/PersonaSettings/` — `PersonaSettings.test.tsx` and `PersonaEdit.test.tsx` continue to pass. The 5 failures in `createRouteStack.test.tsx` (ReactDOM 17 / testing-library 18 mismatch) and `vm.test.ts` (`global_enabled` int vs boolean) are **pre-existing on main 223add46** and unrelated to this change.

## Files

- `packages/dmworkbase/src/Components/PersonaSettings/index.tsx` — optional `routeContext` prop, skip nested RoutePage when provided
- `packages/dmworkbase/src/Components/PersonaSettings/index.css` — `flex-shrink: 0`, `min-height`, ellipsis on edit rows
- `packages/dmworkbase/src/Components/MeInfo/vm.tsx` — pass `routeContext={context}` + `RouteContextConfig({ title: "我的分身" })` when pushing PersonaSettings

Refs YUJ-1435