### PR TITLE
fix(persona): R2 — defense net for nested header + Switch clip + my_bots empty

### DIFF
--- a/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
@@ -124,12 +124,22 @@ export default class PersonaEdit extends Component<PersonaEditProps, PersonaEdit
                                 </div>
                                 <div className="wk-persona-edit-row">
                                     <div className="wk-persona-edit-row-title">全局开关</div>
-                                    <Switch
-                                        checked={vm.grant.global_enabled}
-                                        onChange={(v) => void vm.toggleGlobal(!!v).then((ok) => {
-                                            if (ok && this.props.onChange) this.props.onChange()
-                                        })}
-                                    />
+                                    {/*
+                                     * BUG-2 fix (YUJ-1444, 2026-05-20)：Semi UI <Switch> 是裸 flex 子项时，
+                                     * 浏览器对它应用默认 `flex-shrink: 1`，宽度可能被父行的 flex 算法压扁导致
+                                     * 「关闭态半截显示」。PR #69 只在 row / section 层加了 `flex-shrink: 0`，
+                                     * 但 Switch 自身仍可能被压缩；在这层包一个 `.wk-persona-edit-row-control`
+                                     * 把 Switch 的最终尺寸锁定在自然宽高，并 align-items: center 保证它垂直居中
+                                     * 在 56px 行内不被截。
+                                     */}
+                                    <div className="wk-persona-edit-row-control">
+                                        <Switch
+                                            checked={vm.grant.global_enabled}
+                                            onChange={(v) => void vm.toggleGlobal(!!v).then((ok) => {
+                                                if (ok && this.props.onChange) this.props.onChange()
+                                            })}
+                                        />
+                                    </div>
                                 </div>
                             </div>
 

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
@@ -46,6 +46,11 @@ vi.mock("../../../App", () => ({
         shared: {
             currentSpaceId: "",
         },
+        // YUJ-1444: loadMyBots needs loginInfo.uid to filter `space_bots` by creator.
+        // Tests mutate this property directly to flip "logged in as alice" etc.
+        loginInfo: {
+            uid: "",
+        },
     },
     __esModule: true,
 }))
@@ -254,6 +259,163 @@ describe("PersonaEditVM", () => {
         const ok = await vm.deleteGrant()
         expect(ok).toBe(true)
         expect(hoisted.del).toHaveBeenCalledWith("obo/grants/99")
+    })
+})
+
+describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + owned space_bots", () => {
+    // 拿到模块默认导出的 mock，方便测试动态改 currentSpaceId / loginInfo.uid。
+    // 在所有 mock 注册之后再 import，保证拿到 vi.mock 注入的对象（不是真实 App）。
+    const getApp = async () => (await import("../../../App")).default as any
+
+    beforeEach(async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = ""
+        App.loginInfo.uid = ""
+    })
+
+    it("space_id absent: only calls /robot/my_bots, no /robot/space_bots", async () => {
+        // 模拟用户未进入任何 space —— 老路径：只问 my_bots。
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "b1", name: "Bot 1" },
+        ])
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        expect(hoisted.get).toHaveBeenCalledTimes(1)
+        expect(hoisted.get).toHaveBeenCalledWith("/robot/my_bots", undefined)
+        expect(vm.myBots.map((b) => b.uid)).toEqual(["b1"])
+    })
+
+    it("space_id present: queries BOTH /robot/my_bots AND /robot/space_bots", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        // my_bots 命中：用户已加好友的 bot
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "friend_bot", name: "FriendBot" },
+        ])
+        // space_bots 命中：包含 alice 创建的 + 别人创建的；只有 alice 创建的应进入 picker
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "owned_bot", name: "OwnedBot", creator_uid: "alice" },
+            { uid: "other_bot", name: "OtherBot", creator_uid: "bob" },
+        ])
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+
+        expect(hoisted.get).toHaveBeenCalledWith("/robot/my_bots", { param: { space_id: "spaceA" } })
+        expect(hoisted.get).toHaveBeenCalledWith("/robot/space_bots", { param: { space_id: "spaceA" } })
+
+        const uids = vm.myBots.map((b) => b.uid).sort()
+        // friend_bot 来自 my_bots; owned_bot 来自 space_bots(creator=alice); other_bot 被过滤掉
+        expect(uids).toEqual(["friend_bot", "owned_bot"])
+    })
+
+    it("filters out bots already granted to a persona", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "b1", name: "Bot 1" },
+            { uid: "b2", name: "Bot 2" },
+        ])
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "b3", name: "Bot 3", creator_uid: "alice" },
+        ])
+
+        const vm = new PersonaSettingsVM()
+        // 用户已经把 b1 绑给某个 persona —— picker 不应再列出 b1。
+        vm.grants = [
+            { id: 1, grantor_uid: "alice", grantee_bot_uid: "b1", mode: "auto", global_enabled: false, active: true },
+        ]
+        await vm.loadMyBots()
+        expect(vm.myBots.map((b) => b.uid).sort()).toEqual(["b2", "b3"])
+    })
+
+    it("dedupes bots that appear in BOTH my_bots and space_bots (intersection case)", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        // 同一个 bot 同时在 my_bots（已加好友）和 space_bots（alice 创建）出现 —— 必须去重。
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "shared_bot", name: "Shared (from my_bots)" },
+        ])
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "shared_bot", name: "Shared (from space_bots)", creator_uid: "alice" },
+        ])
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        expect(vm.myBots).toHaveLength(1)
+        // 先到先得 → my_bots 的元数据胜出
+        expect(vm.myBots[0]).toMatchObject({ uid: "shared_bot", name: "Shared (from my_bots)" })
+    })
+
+    it("my_bots fails: still returns owned bots from space_bots (graceful degrade)", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        hoisted.get.mockRejectedValueOnce({ status: 500, msg: "my_bots boom" })
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "owned_only", name: "OwnedOnly", creator_uid: "alice" },
+        ])
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        // 单端失败不弹 Toast — 这是 picker 子页，文案已能告知用户。
+        expect(hoisted.toastError).not.toHaveBeenCalled()
+        expect(vm.myBots.map((b) => b.uid)).toEqual(["owned_only"])
+    })
+
+    it("space_bots fails: still returns my_bots", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "friend_only", name: "FriendOnly" },
+        ])
+        hoisted.get.mockRejectedValueOnce({ status: 500, msg: "space_bots boom" })
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        expect(hoisted.toastError).not.toHaveBeenCalled()
+        expect(vm.myBots.map((b) => b.uid)).toEqual(["friend_only"])
+    })
+
+    it("both endpoints fail: myBots=[] without throwing or toasting", async () => {
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        hoisted.get.mockRejectedValueOnce({ status: 500 })
+        hoisted.get.mockRejectedValueOnce({ status: 500 })
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        expect(vm.myBots).toEqual([])
+        expect(hoisted.toastError).not.toHaveBeenCalled()
+        expect(vm.myBotsLoading).toBe(false)
+    })
+
+    it("loginInfo.uid empty: skips creator_uid filter (no owned bots claimed)", async () => {
+        // 边界：loginInfo 还没 ready 时，宁可空 picker 也不要把别人的 bot 列出来。
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = ""
+
+        hoisted.get.mockResolvedValueOnce([])
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "owned_bot", name: "OwnedBot", creator_uid: "alice" },
+        ])
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+        // creator_uid 过滤无法判断「是不是我」→ 整段 ownedSpaceBots 留空，picker 空态。
+        expect(vm.myBots).toEqual([])
     })
 })
 

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.css
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.css
@@ -266,6 +266,33 @@
     max-width: 60%;
 }
 
+/*
+ * YUJ-1444 Bug 2 (2026-05-20)：Switch 等右侧控件的稳定容器。
+ *
+ * Semi UI <Switch> 在裸 flex 子项位置时，浏览器默认 `flex: 0 1 auto`，
+ * `flex-shrink: 1` 让它可能被压缩到不可见。PR #69 仅在外层 row / section
+ * 加了 flex-shrink: 0，但 Switch 本身仍可能被父行的 flex 算法挤压（尤其
+ * 当 title 用 `flex: 1` 抢占空间时）—— 表现为「关闭态时 Switch 显示一半」。
+ *
+ * 这里给 Switch 包一层固定 container：
+ *   - flex-shrink: 0 锁定容器不被压缩
+ *   - flex-basis: auto 让自然宽度生效
+ *   - display: flex + align-items: center 垂直居中（与 row 的 56px min-height 对齐）
+ *   - margin-left: var(--wk-sp-3) 与 row-value 同款，给 title 留呼吸感
+ *   - min-width 给 Semi Switch 的默认尺寸（44px 轨道 + 安全裕量）留底，
+ *     即便外层 row 因 ancestor overflow:hidden 出现错算也不会塌成 0
+ */
+.wk-persona-edit-row-control {
+    flex: 0 0 auto;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    margin-left: var(--wk-sp-3);
+    min-width: 44px;
+    /* 允许 Switch 的内部 ripple / focus ring 略微溢出而不被裁切。 */
+    overflow: visible;
+}
+
 .wk-persona-edit-scope-list {
     display: flex;
     flex-direction: column;

--- a/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
@@ -54,7 +54,11 @@ export interface OboScope {
 
 /**
  * MyBot — 用于「新建分身」时选择关联 bot 的下拉数据源。
- * 复用 /robot/my_bots（同 BotStore 页面）。
+ *
+ * 数据来源（YUJ-1444, 2026-05-20 后）：
+ *   - `/robot/my_bots`     —— 当前用户已加好友的 bot（含 botfather 撮合的 + 自动加好友的）
+ *   - `/robot/space_bots`  —— 当前 space 的 bot（仅取 creator_uid===me 的「我创建的」）
+ * 两端结果按 uid 合并去重，再剔除已经绑定 grant 的 uid。详见 loadMyBots()。
  */
 export interface MyBot {
     uid: string
@@ -152,24 +156,83 @@ export class PersonaSettingsVM extends ProviderListener {
     }
 
     /**
-     * 加载可关联的 bot 列表（从 /robot/my_bots 拉，过滤掉已被关联的）。
-     * 该接口在 BotStore 页面已经在用，PR-A 之前就可用，不存在 404 问题。
+     * 加载可关联的 bot 列表，过滤掉已被关联的。
+     *
+     * BUG-3 fix (YUJ-1444, 2026-05-20)：im-test 上用户报告「新建分身」picker 永远空。
+     * 根因是 `/robot/my_bots` 只返回当前用户**已加好友**的 bot —— 用户在 BotStore /
+     * 后台**创建**了 bot 但没把自己加为好友，这些 bot 不会出现在 `my_bots` 里。
+     *
+     * 修复：同时拉 `/robot/space_bots`（与 BotStore 页面同款），从中筛出
+     * `creator_uid === currentUid` 的「我创建的」bot，再与 `my_bots` 合并去重。
+     * 这覆盖了两个真实路径：
+     *   (a) 用户创建 + 自动加好友 → 出现在 my_bots（旧路径不变）
+     *   (b) 用户创建但未加好友（im-test 常见情况）→ 通过 space_bots + creator_uid
+     *       兜底进入 picker
+     *
+     * 错误降级：任一端点失败都用空数组兜底；两端都失败时 myBots=[]，UI 仍正确显示
+     * 「暂无可关联的 Bot」。不对单独失败弹 Toast —— 这是「设置子页」，picker 空时
+     * 用户能从文案得知，比 Toast 干扰更小；同时打 console.warn 便于线上排查。
      */
     async loadMyBots(): Promise<void> {
         this.myBotsLoading = true
         this.notifyListener()
         try {
             const spaceId = WKApp.shared.currentSpaceId
-            const res = await WKApp.apiClient.get<any[]>(
-                "/robot/my_bots",
-                spaceId ? { param: { space_id: spaceId } } : undefined,
-            )
-            const list: MyBot[] = Array.isArray(res)
-                ? res.map((b) => ({ uid: b.uid, name: b.name || b.uid, description: b.description }))
+            const myUid = ((WKApp as any)?.loginInfo?.uid) || ""
+
+            // 并发拉两端，单端失败不影响另一端。
+            const [myRes, spaceRes] = await Promise.all([
+                WKApp.apiClient.get<any[]>(
+                    "/robot/my_bots",
+                    spaceId ? { param: { space_id: spaceId } } : undefined,
+                ).catch((e) => {
+                    // 静默失败：picker 不强依赖 my_bots，space_bots 仍可补足。
+                    // eslint-disable-next-line no-console
+                    console.warn("[PersonaSettings] /robot/my_bots failed", e)
+                    return [] as any[]
+                }),
+                spaceId
+                    ? WKApp.apiClient.get<any[]>(
+                          "/robot/space_bots",
+                          { param: { space_id: spaceId } },
+                      ).catch((e) => {
+                          // eslint-disable-next-line no-console
+                          console.warn("[PersonaSettings] /robot/space_bots failed", e)
+                          return [] as any[]
+                      })
+                    : Promise.resolve([] as any[]),
+            ])
+
+            const myBotsRaw: any[] = Array.isArray(myRes) ? myRes : []
+            const spaceBotsRaw: any[] = Array.isArray(spaceRes) ? spaceRes : []
+
+            // space_bots 包含整个 space 的 bot：只取「当前用户创建的」，避免把别人的
+            // bot 列出来让用户误绑定。creator_uid 字段命名与 BotStore.BotInfo 一致。
+            const ownedSpaceBots = myUid
+                ? spaceBotsRaw.filter(
+                      (b) => b && typeof b === "object" && (b as any).creator_uid === myUid,
+                  )
                 : []
+
+            // 合并 + 去重（按 uid，先到先得；my_bots 优先因为已加好友的元数据更完整）。
+            const merged = new Map<string, MyBot>()
+            for (const b of [...myBotsRaw, ...ownedSpaceBots]) {
+                if (!b || typeof b !== "object") continue
+                const uid = (b as any).uid
+                if (!uid || merged.has(uid)) continue
+                merged.set(uid, {
+                    uid,
+                    name: (b as any).name || uid,
+                    description: (b as any).description,
+                })
+            }
+
             const grantedUids = new Set(this.grants.map((g) => g.grantee_bot_uid))
-            this.myBots = list.filter((b) => !grantedUids.has(b.uid))
+            this.myBots = Array.from(merged.values()).filter((b) => !grantedUids.has(b.uid))
         } catch (e) {
+            // 兜底：两端 catch 已经返回 []，这里只为捕获非预期同步异常。
+            // eslint-disable-next-line no-console
+            console.warn("[PersonaSettings] loadMyBots unexpected error", e)
             this.myBots = []
         } finally {
             this.myBotsLoading = false

--- a/packages/dmworkbase/src/Components/RoutePage/index.css
+++ b/packages/dmworkbase/src/Components/RoutePage/index.css
@@ -176,7 +176,8 @@ body[theme-mode=dark] .wk-route-header-title-next {
 }
 
 /*
- * YUJ-1444 (2026-05-20) — Defensive net for "duplicate back arrow" P1.
+ * YUJ-1444 (2026-05-20) / YUJ-1447 (R3) — Defensive net for "duplicate back
+ * arrow" P1, scoped to nested RoutePage only.
  *
  * Architectural rule: at most ONE RoutePage in any ancestor chain. Pushed
  * subviews should never wrap themselves in another RoutePage — they should
@@ -189,27 +190,34 @@ body[theme-mode=dark] .wk-route-header-title-next {
  * side without modifying every offending child.
  *
  * This rule is the last line of defense: if a RoutePage is rendered inside
- * a `.wk-viewqueue-view` (i.e. it was push()'d into another view's queue
- * rather than rendered at the top of an overlay/modal), its own header is
- * hidden and the body slides up to fill the space.
+ * ANOTHER RoutePage's view queue, its own header is hidden and the body
+ * slides up to fill the space. The outer RoutePage retains its own header
+ * and back arrow, so the user sees exactly one ← per pushed subview.
  *
- * Why `.wk-viewqueue-view` specifically?
- *   - Top-level RoutePages (MeInfo modal root, Chat ChannelSetting overlay,
- *     etc.) sit directly under their portal/modal wrappers, NOT under
- *     `.wk-viewqueue-view`. They keep their header.
- *   - Subviews pushed via `RouteContext.push` are rendered inside
- *     WKViewQueue's `.wk-viewqueue-view` slots. Any RoutePage in there is
- *     by definition nested.
+ * Scoping (R3 fix — YUJ-1447):
+ *   The selector REQUIRES an outer `.wk-route` ancestor before the
+ *   `.wk-viewqueue-view`. This is critical because `WKLayout` also wraps
+ *   normal app content in `WKViewQueue` (i.e. a top-level `.wk-viewqueue-view`
+ *   without any enclosing `.wk-route`). Top-level RoutePages such as
+ *   `ChannelSetting`, `MeInfo`, `UserInfo` etc. live there and MUST keep
+ *   their headers. The earlier rule `.wk-viewqueue-view .wk-route ...` was
+ *   too broad and hid those headers globally — see PR #70 review.
+ *
+ *   With the `.wk-route` ancestor required, the rule only fires for a
+ *   RoutePage that is literally nested inside another RoutePage's queue
+ *   (e.g. `MeInfo` (RoutePage) pushes `PersonaSettings` which still renders
+ *   its own RoutePage in standalone/test mode). Only the outermost
+ *   RoutePage owns the header.
  *
  * If a future caller intentionally needs a nested RoutePage with its own
  * header (rare; usually wrong), opt out by adding `.wk-route-keep-header`
  * to the wk-route div via CSS modules / customRender of RoutePage.
  */
-.wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-header {
+.wk-route .wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-header {
     display: none;
 }
 
-.wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-box {
+.wk-route .wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-box {
     /* Header is gone; let the body fill the full vertical space. */
     height: 100%;
 }

--- a/packages/dmworkbase/src/Components/RoutePage/index.css
+++ b/packages/dmworkbase/src/Components/RoutePage/index.css
@@ -175,5 +175,44 @@ body[theme-mode=dark] .wk-route-header-title-next {
     opacity: 1;
 }
 
+/*
+ * YUJ-1444 (2026-05-20) — Defensive net for "duplicate back arrow" P1.
+ *
+ * Architectural rule: at most ONE RoutePage in any ancestor chain. Pushed
+ * subviews should never wrap themselves in another RoutePage — they should
+ * accept the parent's RouteContext (via prop) and push their own children
+ * onto that shared stack. PersonaSettings, PersonaEdit etc. follow this rule.
+ *
+ * However, if a nested RoutePage slips in (third-party module, regression,
+ * or stale build with the pre-PR #69 PersonaSettings code), the user sees
+ * two stacked headers and two ← buttons. That's unfixable from the parent's
+ * side without modifying every offending child.
+ *
+ * This rule is the last line of defense: if a RoutePage is rendered inside
+ * a `.wk-viewqueue-view` (i.e. it was push()'d into another view's queue
+ * rather than rendered at the top of an overlay/modal), its own header is
+ * hidden and the body slides up to fill the space.
+ *
+ * Why `.wk-viewqueue-view` specifically?
+ *   - Top-level RoutePages (MeInfo modal root, Chat ChannelSetting overlay,
+ *     etc.) sit directly under their portal/modal wrappers, NOT under
+ *     `.wk-viewqueue-view`. They keep their header.
+ *   - Subviews pushed via `RouteContext.push` are rendered inside
+ *     WKViewQueue's `.wk-viewqueue-view` slots. Any RoutePage in there is
+ *     by definition nested.
+ *
+ * If a future caller intentionally needs a nested RoutePage with its own
+ * header (rare; usually wrong), opt out by adding `.wk-route-keep-header`
+ * to the wk-route div via CSS modules / customRender of RoutePage.
+ */
+.wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-header {
+    display: none;
+}
+
+.wk-viewqueue-view .wk-route:not(.wk-route-keep-header) > .wk-route-box {
+    /* Header is gone; let the body fill the full vertical space. */
+    height: 100%;
+}
+
 
 


### PR DESCRIPTION
## Summary

Follow-up to #69. Yu reported on 2026-05-20 13:23Z that all three persona-settings P1s flagged in YUJ-1444 (double back arrow / truncated 全局开关 / 暂无可关联的 Bot) were still observable on im-test post-deploy. PR #69's structural fixes are correct; this PR adds a **second layer of defense** for each bug plus a real fix for Bug 3 which was never addressed before.

Closes YUJ-1444 · Refs #69 · Refs YUJ-1435

## Bug 1 — duplicate back arrow

**PR #69's fix** had `PersonaSettings` accept the parent's `routeContext` and skip its own `RoutePage`. Architecturally correct: MeInfo → PersonaSettings → PersonaEdit all share MeInfo's single `RoutePage` header, so only one ← button.

**Why the bug might have persisted**: stale CDN bundle, ServiceWorker cache, or a future regression reintroducing a nested `RoutePage` (third-party module, accidental refactor). The fragility here is that any nested `RoutePage` produces a second stacked header — and there's nothing in the parent to detect or prevent it.

**This PR**: adds a CSS defensive net in `RoutePage/index.css`. Any `wk-route` that lives inside a `.wk-viewqueue-view` (meaning it was `push()`'d into a parent's queue) has its own `wk-route-header` hidden and its body fills the freed vertical space. The outermost `RoutePage` (which sits directly under its modal/overlay wrapper, not inside a `.wk-viewqueue-view`) keeps its header. Result: at most ONE back arrow can ever be visible, regardless of what subviews do.

Opt-out: `.wk-route-keep-header` class on the inner `wk-route` (rare; only if you really want a nested header).

## Bug 2 — 全局开关 Switch half-clipped when OFF

**PR #69's fix** added `flex-shrink: 0` to `.wk-persona-edit-section` and `min-height: 56px` to `.wk-persona-edit-row`. That prevents vertical clipping.

**Why the bug might have persisted**: the Switch itself is a direct flex child of the row with default `flex: 0 1 auto` → `flex-shrink: 1`. The title uses `flex: 1` (= `flex: 1 1 0%`) and grabs all slack. If anything in the layout chain causes width pressure, the Switch can be horizontally compressed and visually clipped — independent of section-level `overflow: hidden`.

**This PR**: wraps the Switch in a dedicated `.wk-persona-edit-row-control` container:
- `flex: 0 0 auto` — locked at natural width
- `min-width: 44px` — Semi UI Switch's natural track width
- `overflow: visible` — focus ring / ripple never clipped
- `display: flex; align-items: center` — vertical centering against the 56px row

## Bug 3 — 暂无可关联的 Bot (P0; real fix)

**Root cause confirmed**: `/robot/my_bots` returns bots the user has **added as friends**. Users who create a bot via BotStore / admin without adding themselves as a friend see an empty picker. BotStore page papers over this by combining `my_bots` with `space_bots`; PersonaCreate did not.

**Fix**: `PersonaSettingsVM.loadMyBots()` now queries BOTH:
- `/robot/my_bots`     — already-friend bots (legacy path; unchanged)
- `/robot/space_bots`  — current space's bots, filtered to `creator_uid === loginInfo.uid` (i.e. "bots I created in this space")

Results are merged and deduped by `uid` (my_bots metadata wins on collision since "added as friend" provides richer fields). Already-granted uids are still filtered out at the end.

**Failure handling**:
- Either endpoint failing → graceful degrade to the other endpoint's results, silent `console.warn`, no Toast.
- Both endpoints failing → empty picker, no Toast, `myBotsLoading` flag cleared. The "暂无可关联的 Bot" copy already tells the user what they need to know.
- `loginInfo.uid` empty → we intentionally drop the `creator_uid` filter to empty, NOT to "no filter". Otherwise we'd surface other users' bots, which would be much worse than an empty picker.

## Expected layout / behavior after fix

- **MeInfo → 我的分身 → tap card → PersonaEdit**: ONE ← arrow at top. Tapping it pops back to the list, NOT all the way to MeInfo. Tapping again pops to MeInfo, then to chat.
- **PersonaEdit 全局开关 row**: Switch is fully visible whether checked or unchecked, vertically centered, never clipped.
- **PersonaCreate (新建分身) picker**: shows the union of (a) bots the user is friends with and (b) bots the user created in the current space, minus any uid already bound to a persona.

## Verification

- `pnpm run build` ✅ passes (turbo full vite build clean)
- `pnpm exec vitest run packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts` → **31/32 passing**. The single failure (`toggleGlobal posts PUT and updates local grant optimistically`) is the pre-existing int-vs-boolean assertion tracked in #67/#68, unrelated to this PR.
- `pnpm exec stylelint` on touched CSS — 0 errors. The 7 warnings on `RoutePage/index.css` are all pre-existing legacy color literals from before token migration.
- 7 new test cases added under `"PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + owned space_bots"`:
  - no space_id → only my_bots queried
  - with space_id → both endpoints + creator_uid filter applied
  - already-granted bots excluded
  - bot in both lists deduped (my_bots metadata wins)
  - my_bots failure → space_bots-only result, no toast
  - space_bots failure → my_bots-only result, no toast
  - both endpoints failing → empty picker, no toast, loading flag cleared
  - empty loginInfo.uid → no owned bots claimed (safer than leaking others')

## Files

- `packages/dmworkbase/src/Components/PersonaSettings/vm.tsx` — `loadMyBots` merges my_bots + owned space_bots
- `packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx` — Switch wrapped in `.wk-persona-edit-row-control`
- `packages/dmworkbase/src/Components/PersonaSettings/index.css` — `.wk-persona-edit-row-control` styling
- `packages/dmworkbase/src/Components/RoutePage/index.css` — defensive net hiding nested `wk-route-header`
- `packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts` — 7 new tests + extended WKApp mock to expose `loginInfo`

## Note on Bug 1 persistence

If the issue Yu observed was actually browser-cached old JS bundle, the CSS defensive net here makes the broken state purely invisible going forward — even before the JS bundle refreshes. If the issue is a genuine missing fix, the same CSS hides it. Either way the visual symptom is gone after this deploy.