### PR TITLE
fix(desktop): 修复 Electron 登录后白屏 (file:// protocol redirect)

### DIFF
--- a/apps/web/src/Components/InviteLanding/index.tsx
+++ b/apps/web/src/Components/InviteLanding/index.tsx
@@ -257,7 +257,9 @@ export default class InviteLanding extends Component<InviteLandingProps, InviteL
             const sid = this.findSid();
             // 使用安全的 basePath，避免当 pathname 为 /api/ 时跳到后端 API 路径（#1006）
             const basePath = this.getAppBasePath();
-            window.location.href = `${window.location.origin}${basePath}/${sid ? `?sid=${sid}` : ''}`;
+            // file:// (Electron desktop) has no SPA fallback — must target index.html explicitly
+            const entry = window.location.protocol === 'file:' ? '/index.html' : '/'
+            window.location.href = `${window.location.origin}${basePath}${entry}${sid ? `?sid=${sid}` : ''}`;
         } catch (e: any) {
             const msg = e?.message || "";
             const status = e?.status || 0;
@@ -285,7 +287,9 @@ export default class InviteLanding extends Component<InviteLandingProps, InviteL
         // 使用安全的 basePath，避免硬编码 /web 导致部署路径不匹配，
         // 同时剥离 /api 前缀防止登录页被错误托管在后端 API 路径下（#1006）
         const basePath = this.getAppBasePath();
-        window.location.href = `${window.location.origin}${basePath}/?invite=${encodeURIComponent(this.props.inviteCode)}&action=login`;
+        // file:// (Electron desktop) has no SPA fallback — must target index.html explicitly
+        const entry = window.location.protocol === 'file:' ? '/index.html' : '/'
+        window.location.href = `${window.location.origin}${basePath}${entry}?invite=${encodeURIComponent(this.props.inviteCode)}&action=login`;
     }
 
     /**

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -67,7 +67,9 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                     window.location.reload()
                     return
                 }
-                window.location.href = `${window.location.origin}${basePath}/${sidParam}`
+                // file:// (Electron desktop) has no SPA fallback — must target index.html explicitly
+                const entry = window.location.protocol === 'file:' ? '/index.html' : '/'
+                window.location.href = `${window.location.origin}${basePath}${entry}${sidParam}`
             }
 
             // 检查是否有待处理的邀请码（验证格式防止 XSS/Open Redirect）


### PR DESCRIPTION
## 问题

Electron 桌面端登录成功后白屏，DevTools 报 `net::ERR_FILE_NOT_FOUND`。

**根因**：登录后 redirect 到 `${basePath}/?sid=xxx`，web 端有 nginx SPA fallback 兜底，但 Electron 走 `file://` 协议没有 server，`file:///...build/?sid=xxx` 是目录路径，找不到文件。

## 修复

检测 `window.location.protocol === 'file:'` 时，redirect 目标加上 `/index.html`：
- `file:///...build/index.html?sid=xxx` ✅
- `https://im-test.xming.ai/` 不受影响 ✅

**涉及 3 处 redirect**：
1. `Layout/index.tsx` — 登录后跳主页
2. `InviteLanding/index.tsx` — 邀请加入后跳主页
3. `InviteLanding/index.tsx` — 跳登录页

## 验证

OCTO-v12 arm64 构建已在 macOS 上验证通过，登录不再白屏。