### PR TITLE
feat(oidc): bind self-service flow + login page UX revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules
 
 # testing
 coverage
+test-results
+playwright-report
+.local-browsers
 
 # next.js
 .next/

--- a/apps/web/e2e/bind.config.ts
+++ b/apps/web/e2e/bind.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// bind 流程独立 Playwright 配置:
+//  - 根 playwright.config.ts 跑的是 im-test.deepminer.com.cn 联调环境;
+//    bind e2e 必须本地起 Vite + 用 page.route() mock 后端, 否则无法穷举
+//    410/401/429/409 错误码分支.
+//  - 只跑 Chromium 一种 browser; bind 是表单+路由, 跨浏览器差异极低,
+//    引入 firefox/webkit 仅增加 CI 时间, 没有收益.
+//  - 浏览器二进制由 PLAYWRIGHT_BROWSERS_PATH=0 锁到 node_modules, 不写
+//    用户级 ~/Library/Caches/ms-playwright. 见 README / scripts.
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: /.*\.spec\.ts$/,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    // bind 流程靠 page.route 拦截后端, 不应触达真实网络; 兜底关掉外发.
+    serviceWorkers: 'block',
+    trace: 'on-first-retry',
+  },
+
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+
+  webServer: {
+    command: 'pnpm dev',
+    cwd: '.',
+    url: 'http://localhost:3000',
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -305,13 +305,13 @@ test.describe('OIDC bind page', () => {
       expect(calls.find((c) => c.endpoint === 'confirm')).toBeDefined()
     })
 
-    // PR #72 round-5 (yujiawei/Jerry-Xin P1): runConfirm / runCreate must
-    // persist the real IdP id into WKApp.loginInfo.loginProvider (= the URL
-    // ?provider= value, or FALLBACK_PROVIDER_ID when omitted) — NOT a synthetic
-    // 'oidc-bind' / 'oidc-bind-create' label. Downstream NavSettingsPanel +
+    // runConfirm / runCreate must persist the real IdP id into
+    // WKApp.loginInfo.loginProvider (= the URL ?provider= value, or
+    // FALLBACK_PROVIDER_ID when omitted) — NOT a synthetic 'oidc-bind' /
+    // 'oidc-bind-create' label. Downstream NavSettingsPanel +
     // realnameVerifyUrl + login.tsx reset-password all do
-    // providers.find(p => p.id === loginProvider) and would fail closed on the
-    // synthetic value.
+    // providers.find(p => p.id === loginProvider) and would fail closed on
+    // the synthetic value.
     //
     // Why we assert via sessionStorage (not localStorage): LoginInfo.save()
     // routes through StorageService.shared.setItem (sessionStorage primary,
@@ -357,7 +357,7 @@ test.describe('OIDC bind page', () => {
       })
     }
 
-    test('P1 round-5: confirm persists URL ?provider= (not synthetic "oidc-bind")', async ({ page }) => {
+    test('loginProvider persists URL ?provider= on confirm (not synthetic "oidc-bind")', async ({ page }) => {
       await mockBindServer(page, 'happy_password')
       await gotoBindPage(page, { token: TOKEN, returnTo: '/', provider: 'xming' })
       await stubLocationReplace(page)
@@ -380,7 +380,7 @@ test.describe('OIDC bind page', () => {
       expect(persisted).not.toBe('oidc-bind')
     })
 
-    test('P1 round-5: confirm falls back to FALLBACK_PROVIDER_ID when URL omits ?provider=', async ({ page }) => {
+    test('loginProvider falls back to FALLBACK_PROVIDER_ID when URL omits ?provider=', async ({ page }) => {
       await mockBindServer(page, 'happy_password')
       // Inline-build URL to omit provider (gotoBindPage defaults to 'aegis').
       const qs = new URLSearchParams({
@@ -405,7 +405,52 @@ test.describe('OIDC bind page', () => {
       expect(persisted).not.toBe('oidc-bind')
     })
 
-    test('P1 round-5: create persists URL ?provider= (not synthetic "oidc-bind-create")', async ({ page }) => {
+    // The token must not survive in the Back stack. Earlier rounds only
+    // verified the *current* URL was scrubbed, but RouteManager's pageshow
+    // handler push()s a new sid entry on top of the original token-bearing
+    // one (Route.tsx:48), and clearBindUrl in BindPage only replaces the
+    // *current* entry — so the token URL stays in history. BindModule.init
+    // does a synchronous history.replaceState before pageshow fires to fix
+    // this. Regression below navigates from a non-bind URL into
+    // /oidc/bind?token=, then walks the Back stack asserting no entry exposes
+    // the token.
+    test('history Back does not expose bind token', async ({ page }) => {
+      await mockBindServer(page, 'happy_password')
+      // Seed the history with a non-bind URL so the bind entry has somewhere
+      // to go Back to. '/' resolves under the dev server's vite root.
+      await page.goto('/')
+      await gotoBindPage(page, { token: TOKEN })
+      // Wait until BindPage rendered — proves init() + the cleanup ran.
+      await expect(page.getByText('Alice')).toBeVisible()
+
+      // Current URL must already be clean (existing invariant, kept here so
+      // the regression localizes the failure).
+      expect(page.url()).not.toContain(TOKEN)
+
+      // Walk the entire Back stack and assert no entry contains the token.
+      // Without the BindModule.init replaceState, the original
+      // `/oidc/bind?token=…` entry sits between the seed `/` and the
+      // RouteManager-pushed `/oidc/bind?sid=…` — goBack would land on it.
+      //
+      // RouteManager's popstate handler will pushState a sid URL on top of
+      // whatever the browser navigates back to, so we sample page.url()
+      // *immediately* after goBack (before further script work) AND read
+      // window.history.length to bound the walk. waitForLoadState('load')
+      // ensures the popstate-triggered work has settled.
+      for (let i = 0; i < 5; i += 1) {
+        const before = page.url()
+        expect(before).not.toContain(TOKEN)
+        const canGoBack = await page.evaluate(() => window.history.length > 1)
+        if (!canGoBack) break
+        const navigated = await page.goBack().catch(() => null)
+        if (navigated === null) break
+        await page.waitForLoadState('load').catch(() => undefined)
+        expect(page.url()).not.toContain(TOKEN)
+        if (page.url() === before) break // popstate looped — stop
+      }
+    })
+
+    test('loginProvider persists URL ?provider= on create (not synthetic "oidc-bind-create")', async ({ page }) => {
       await mockBindServer(page, 'happy_create')
       await gotoBindPage(page, { token: TOKEN, returnTo: '/', provider: 'xming' })
       await stubLocationReplace(page)

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -304,5 +304,63 @@ test.describe('OIDC bind page', () => {
       expect(calls.find((c) => c.endpoint === 'verify_password')).toBeDefined()
       expect(calls.find((c) => c.endpoint === 'confirm')).toBeDefined()
     })
+
+    test('R4: bind/create with pendingInviteCode hands off to AppLayout invite-join flow', async ({ page }) => {
+      await mockBindServer(page, 'happy_create')
+
+      // Mock the two AppLayout.onLogin invite endpoints. mockBindServer only
+      // intercepts /v1/auth/oidc/* so /api/v1/space/* falls through to be
+      // handled here. Predicate route — Playwright's `**/api/v1/...` glob
+      // matched inconsistently against the proxied URL; the URL-object
+      // predicate is unambiguous and reads against the post-baseURL path.
+      let inviteFetched = false
+      let joinPosted = false
+      await page.route((url) => url.pathname.startsWith('/api/v1/space/'), (route) => {
+        const url = route.request().url()
+        if (url.endsWith('/api/v1/space/invite/INVITE-XYZ')) {
+          inviteFetched = true
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ space_id: 'space-1', space_name: 'Demo Space' }),
+          })
+        }
+        if (url.endsWith('/api/v1/space/join')) {
+          joinPosted = true
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ status: 'ok', space_id: 'space-1' }),
+          })
+        }
+        return route.continue()
+      })
+
+      // Pre-seed localStorage like LoginVM.didMount would. Use page.evaluate
+      // rather than addInitScript — the latter re-runs on every navigation,
+      // including the post-bind /space/join → goMain reload, which would
+      // immediately re-set the key after AppLayout.onLogin's .then cleared it.
+      // returnTo=/contacts to prove the invite path overrides it.
+      await gotoBindPage(page, { token: TOKEN, returnTo: '/contacts' })
+      await page.evaluate(() => {
+        localStorage.setItem('pendingInviteCode', 'INVITE-XYZ')
+      })
+
+      await page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' }).click()
+      // Give AppLayout.onLogin's fetch chain time to issue both calls and run
+      // the .then localStorage cleanup.
+      await page.waitForTimeout(800)
+
+      expect(inviteFetched).toBe(true)
+      expect(joinPosted).toBe(true)
+
+      // pendingInviteCode is cleared inside the /space/join .then in AppLayout
+      // (apps/web/src/Layout/index.tsx). Poll because the cleanup runs after
+      // the mocked response resolves, not synchronously with the request.
+      await expect.poll(
+        async () => page.evaluate(() => localStorage.getItem('pendingInviteCode')),
+        { timeout: 3000 },
+      ).toBeNull()
+    })
   })
 })

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -305,6 +305,119 @@ test.describe('OIDC bind page', () => {
       expect(calls.find((c) => c.endpoint === 'confirm')).toBeDefined()
     })
 
+    // PR #72 round-5 (yujiawei/Jerry-Xin P1): runConfirm / runCreate must
+    // persist the real IdP id into WKApp.loginInfo.loginProvider (= the URL
+    // ?provider= value, or FALLBACK_PROVIDER_ID when omitted) — NOT a synthetic
+    // 'oidc-bind' / 'oidc-bind-create' label. Downstream NavSettingsPanel +
+    // realnameVerifyUrl + login.tsx reset-password all do
+    // providers.find(p => p.id === loginProvider) and would fail closed on the
+    // synthetic value.
+    //
+    // Why we assert via sessionStorage (not localStorage): LoginInfo.save()
+    // routes through StorageService.shared.setItem (sessionStorage primary,
+    // localStorage only for the cross-tab whitelist token/uid/short_no/app_id/
+    // name/role/is_work/sex — login_provider is NOT in that whitelist, so it
+    // lives in sessionStorage only). See StorageService.tsx:1-31.
+    //
+    // Why we stub window.location.replace: finalizeBindSuccess schedules a
+    // location.replace(returnTo) ~200ms after save(). The outer beforeEach
+    // installs addInitScript clearing session+localStorage on every navigation,
+    // including that post-bind reload — so a naive read after waitForURL gets
+    // null. Stubbing replace lets save() persist while keeping us on /oidc/bind
+    // so the cleared-on-next-init storage stays intact.
+    async function readLoginProviderFromSession(
+      page: import('@playwright/test').Page,
+    ): Promise<string | null> {
+      // setStorageItemForSID writes 'login_provider' + sid, where sid comes
+      // from the live URL's ?sid= (LoginInfo.getSID, App.tsx:343). RouteManager
+      // injects sid on pageshow, so we read it back from the URL at assertion
+      // time rather than hardcoding.
+      return page.evaluate(() => {
+        const sid = new URLSearchParams(window.location.search).get('sid') ?? ''
+        return sessionStorage.getItem('login_provider' + sid)
+      })
+    }
+
+    async function stubLocationReplace(page: import('@playwright/test').Page): Promise<void> {
+      await page.evaluate(() => {
+        // Replace the method, not the whole location object (the latter is a
+        // browser-protected accessor and can't be reassigned in Chromium).
+        const noop = (): void => {
+          /* swallow navigation so storage observations stay on /oidc/bind */
+        }
+        try {
+          Object.defineProperty(window.location, 'replace', {
+            configurable: true,
+            value: noop,
+          })
+        } catch {
+          /* fallback: best-effort overwrite */
+          ;(window.location as unknown as { replace: () => void }).replace = noop
+        }
+      })
+    }
+
+    test('P1 round-5: confirm persists URL ?provider= (not synthetic "oidc-bind")', async ({ page }) => {
+      await mockBindServer(page, 'happy_password')
+      await gotoBindPage(page, { token: TOKEN, returnTo: '/', provider: 'xming' })
+      await stubLocationReplace(page)
+
+      await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+      await page.getByLabel(/Octo 账号/).fill('alice')
+      await page.locator('#bind-password').fill('pw-correct')
+      await page.getByRole('button', { name: '验证并绑定' }).click()
+
+      // Wait for the success stage — by the time '绑定成功' renders, save() has
+      // already run synchronously in runConfirm just before finalizeBindSuccess.
+      await expect(page.getByText('绑定成功，正在跳转…')).toBeVisible()
+
+      // Storage key is 'login_provider' + sid. RouteManager's pageshow handler
+      // injects ?sid=... into /oidc/bind, and LoginInfo.setStorageItemForSID
+      // suffixes the sid onto every key so different tabs/sessions don't
+      // collide. Derive sid from the live URL rather than hardcoding.
+      const persisted = await readLoginProviderFromSession(page)
+      expect(persisted).toBe('xming')
+      expect(persisted).not.toBe('oidc-bind')
+    })
+
+    test('P1 round-5: confirm falls back to FALLBACK_PROVIDER_ID when URL omits ?provider=', async ({ page }) => {
+      await mockBindServer(page, 'happy_password')
+      // Inline-build URL to omit provider (gotoBindPage defaults to 'aegis').
+      const qs = new URLSearchParams({
+        token: TOKEN,
+        authcode: 'ac-fe-12345',
+        return_to: '/',
+      })
+      await page.goto(`/oidc/bind?${qs.toString()}`)
+      await stubLocationReplace(page)
+
+      await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+      await page.getByLabel(/Octo 账号/).fill('alice')
+      await page.locator('#bind-password').fill('pw-correct')
+      await page.getByRole('button', { name: '验证并绑定' }).click()
+
+      await expect(page.getByText('绑定成功，正在跳转…')).toBeVisible()
+
+      const persisted = await readLoginProviderFromSession(page)
+      // FALLBACK_PROVIDER_ID is 'aegis' (api.ts:24). Keep the literal here to
+      // catch accidental changes to the fallback contract.
+      expect(persisted).toBe('aegis')
+      expect(persisted).not.toBe('oidc-bind')
+    })
+
+    test('P1 round-5: create persists URL ?provider= (not synthetic "oidc-bind-create")', async ({ page }) => {
+      await mockBindServer(page, 'happy_create')
+      await gotoBindPage(page, { token: TOKEN, returnTo: '/', provider: 'xming' })
+      await stubLocationReplace(page)
+
+      await page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' }).click()
+      await expect(page.getByText('绑定成功，正在跳转…')).toBeVisible()
+
+      const persisted = await readLoginProviderFromSession(page)
+      expect(persisted).toBe('xming')
+      expect(persisted).not.toBe('oidc-bind-create')
+    })
+
     test('R4: bind/create with pendingInviteCode hands off to AppLayout invite-join flow', async ({ page }) => {
       await mockBindServer(page, 'happy_create')
 

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -83,10 +83,17 @@ test.describe('OIDC bind page', () => {
     // 等到信息加载完毕才检查, 确保 clearBindUrl 已经跑过且后续渲染没把 token 写进 DOM.
     await expect(page.getByText('Alice')).toBeVisible()
 
-    // 1) URL 的 query 段应被 replaceState 清空
+    // 1) URL bind-flow params must be wiped, but non-bind params (sid in
+    // particular — used by LoginInfo storage bucket selection) must survive.
+    // Updated for PR #72 round-3 fix where clearBindUrl preserves sid.
     const url = new URL(page.url())
-    expect(url.search).toBe('')
     expect(url.pathname).toBe('/oidc/bind')
+    const params = new URLSearchParams(url.search)
+    expect(params.has('token')).toBe(false)
+    expect(params.has('authcode')).toBe(false)
+    expect(params.has('return_to')).toBe(false)
+    expect(params.has('provider')).toBe(false)
+    expect(url.search).not.toContain(TOKEN)
 
     // 2) 渲染出的 HTML 不能包含 token 字面值
     const html = await page.content()

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -1,0 +1,268 @@
+import { test, expect } from '@playwright/test'
+import { mockBindServer, gotoBindPage } from './fixtures/mockBindServer'
+
+const TOKEN = 'tok-secret-do-not-leak-xyz789'
+
+// 关闭 WKRemoteConfig 网络抖动: 这些请求与 bind 流程无关, 真实跑会被 vite proxy
+// 502 干扰日志. 让它们落空, 测试更稳.
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/v1/common/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ oidc_providers: [] }),
+    }),
+  )
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+  // 清登录态, 避免上一个测试残留把 BindPage 跳过.
+  await page.addInitScript(() => {
+    try {
+      localStorage.clear()
+      sessionStorage.clear()
+    } catch {
+      /* noop */
+    }
+  })
+})
+
+test.describe('OIDC bind page', () => {
+  test('happy path - password verifies and confirms then navigates to return_to', async ({ page }) => {
+    const { calls } = await mockBindServer(page, 'happy_password')
+    await gotoBindPage(page, { token: TOKEN, returnTo: '/contacts' })
+
+    // 渲染脱敏身份块
+    await expect(page.getByText('完成账号绑定')).toBeVisible()
+    await expect(page.getByText('a***@example.com')).toBeVisible()
+    await expect(page.getByText('****5678')).toBeVisible()
+
+    // 选 password
+    await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+    await page.getByLabel(/Octo 账号/).fill('alice')
+    await page.locator('#bind-password').fill('pw-correct')
+    await page.getByRole('button', { name: '验证并绑定' }).click()
+
+    // confirm 调用后 BindPage 200ms 内 setTimeout 跳转, 等到 URL 变化
+    await page.waitForURL((u) => u.pathname === '/contacts', { timeout: 5000 })
+
+    const verifyCall = calls.find((c) => c.endpoint === 'verify_password')
+    expect(verifyCall?.body).toMatchObject({
+      token: TOKEN,
+      identifier: 'alice',
+      password: 'pw-correct',
+    })
+    expect(calls.find((c) => c.endpoint === 'confirm')?.body).toMatchObject({
+      token: TOKEN,
+    })
+  })
+
+  test('happy path - sms_otp sends, verifies and confirms', async ({ page }) => {
+    const { calls } = await mockBindServer(page, 'happy_sms')
+    await gotoBindPage(page, { token: TOKEN, returnTo: '/' })
+
+    await page.getByRole('button', { name: '使用短信验证码验证' }).click()
+    // 用 OTP 输入框作为"发送完成"的稳定信号; Toast 与内联提示文案重叠会触发 strict 冲突.
+    await expect(page.locator('#bind-otp')).toBeVisible()
+    // /otp/send 不能带 phone (隐私 + 防号码探测)
+    const sendCall = calls.find((c) => c.endpoint === 'verify_otp_send')
+    expect(sendCall?.body).toEqual({ token: TOKEN })
+
+    await page.locator('#bind-otp').fill('123456')
+    await page.getByRole('button', { name: '验证并绑定' }).click()
+    await page.waitForURL((u) => u.pathname === '/', { timeout: 5000 })
+
+    const checkCall = calls.find((c) => c.endpoint === 'verify_otp_check')
+    expect(checkCall?.body).toMatchObject({ token: TOKEN, code: '123456' })
+  })
+
+  test('token safety: URL is cleaned and token never appears in DOM or window globals', async ({ page }) => {
+    await mockBindServer(page, 'happy_password')
+    await gotoBindPage(page, { token: TOKEN })
+
+    // 等到信息加载完毕才检查, 确保 clearBindUrl 已经跑过且后续渲染没把 token 写进 DOM.
+    await expect(page.getByText('Alice')).toBeVisible()
+
+    // 1) URL 的 query 段应被 replaceState 清空
+    const url = new URL(page.url())
+    expect(url.search).toBe('')
+    expect(url.pathname).toBe('/oidc/bind')
+
+    // 2) 渲染出的 HTML 不能包含 token 字面值
+    const html = await page.content()
+    expect(html).not.toContain(TOKEN)
+
+    // 3) window 上不能挂带 token 的字段; 包括前端契约要求的埋点钩子不能落 token
+    const leaked = await page.evaluate((tok) => {
+      const keys = Object.keys(window as unknown as Record<string, unknown>)
+      const found: string[] = []
+      for (const k of keys) {
+        try {
+          const v = (window as unknown as Record<string, unknown>)[k]
+          if (typeof v === 'string' && v.includes(tok)) found.push(k)
+        } catch {
+          /* skip prop access errors */
+        }
+      }
+      return found
+    }, TOKEN)
+    expect(leaked).toEqual([])
+  })
+
+  test('info 410 falls to fatal stage with "重新登录" CTA', async ({ page }) => {
+    await mockBindServer(page, 'info_410')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await expect(page.getByText('链接已过期，请重新发起登录')).toBeVisible()
+    await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+  })
+
+  test('verify_password 401 shows inline error and lets user retry', async ({ page }) => {
+    await mockBindServer(page, 'verify_password_401')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+    await page.getByLabel(/Octo 账号/).fill('alice')
+    await page.locator('#bind-password').fill('wrong-pw')
+    await page.getByRole('button', { name: '验证并绑定' }).click()
+
+    await expect(page.getByText('用户名或密码错误')).toBeVisible()
+    // 仍在 verify_password 阶段, 表单仍可见, 不要跳 fatal
+    await expect(page.locator('#bind-password')).toBeVisible()
+  })
+
+  test('verify_password 429 shows rate-limit copy non-terminal', async ({ page }) => {
+    await mockBindServer(page, 'verify_password_429')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+    await page.getByLabel(/Octo 账号/).fill('alice')
+    await page.locator('#bind-password').fill('pw')
+    await page.getByRole('button', { name: '验证并绑定' }).click()
+
+    await expect(page.getByText('尝试次数过多，请稍后再试')).toBeVisible()
+    await expect(page.locator('#bind-password')).toBeVisible()
+  })
+
+  test('confirm 409 (identity already bound) shows terminal copy guiding back to login', async ({ page }) => {
+    await mockBindServer(page, 'confirm_409')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+    await page.getByLabel(/Octo 账号/).fill('alice')
+    await page.locator('#bind-password').fill('pw')
+    await page.getByRole('button', { name: '验证并绑定' }).click()
+
+    await expect(page.getByText(/该账号已绑定/)).toBeVisible()
+    await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+  })
+
+  test('methods=[password] hides SMS button (dynamic rendering)', async ({ page }) => {
+    await mockBindServer(page, 'info_password_only')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await expect(page.getByRole('button', { name: '使用 Octo 密码验证' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '使用短信验证码验证' })).toHaveCount(0)
+  })
+
+  test('methods=[] falls to fatal with support_contact', async ({ page }) => {
+    await mockBindServer(page, 'info_empty_methods')
+    await gotoBindPage(page, { token: TOKEN })
+
+    await expect(page.getByText(/无可用的绑定方式/)).toBeVisible()
+    await expect(page.getByText('support@example.com')).toBeVisible()
+  })
+
+  // ============ PR#93: /bind/create paths ===================================
+  test.describe('create from SSO (PR#93)', () => {
+    test('happy create: primary button → POST /bind/create → navigate', async ({ page }) => {
+      const { calls } = await mockBindServer(page, 'happy_create')
+      await gotoBindPage(page, { token: TOKEN, returnTo: '/contacts' })
+
+      // 主按钮可见且可点
+      const createBtn = page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' })
+      await expect(createBtn).toBeVisible()
+      // verify 路径作为次入口仍存在 (但视觉降级)
+      await expect(page.getByRole('button', { name: '使用 Octo 密码验证' })).toBeVisible()
+      // 引导文案根据 methods[] 动态生成 (这里 happy_create 给的是 ['password','sms_otp'])
+      await expect(page.getByText('已有 Octo 账号，使用密码或短信验证关联')).toBeVisible()
+
+      await createBtn.click()
+      await page.waitForURL((u) => u.pathname === '/contacts', { timeout: 5000 })
+
+      const createCall = calls.find((c) => c.endpoint === 'create')
+      expect(createCall?.body).toEqual({ token: TOKEN })
+      // 不应该顺手打 confirm — 走的是独立的 create 端点
+      expect(calls.find((c) => c.endpoint === 'confirm')).toBeUndefined()
+    })
+
+    test('create disabled: button hidden, verify methods remain primary', async ({ page }) => {
+      await mockBindServer(page, 'create_disabled')
+      await gotoBindPage(page, { token: TOKEN })
+
+      // 主创建按钮不渲染
+      await expect(page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' })).toHaveCount(0)
+      // verify 路径仍然在
+      await expect(page.getByRole('button', { name: '使用 Octo 密码验证' })).toBeVisible()
+      // 没有引导文案 (因为没有主路径)
+      await expect(page.getByText('已有 Octo 账号，使用密码或短信验证关联')).toHaveCount(0)
+    })
+
+    test('create blocked - claims_incomplete: show reason, hide button, verify still usable', async ({
+      page,
+    }) => {
+      await mockBindServer(page, 'create_blocked_claims_incomplete')
+      await gotoBindPage(page, { token: TOKEN })
+
+      await expect(page.getByText(/SSO 身份信息不完整/)).toBeVisible()
+      await expect(page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' })).toHaveCount(0)
+      await expect(page.getByRole('button', { name: '使用 Octo 密码验证' })).toBeVisible()
+    })
+
+    test('create blocked - manual_conflict: show admin-contact hint', async ({ page }) => {
+      await mockBindServer(page, 'create_blocked_manual_conflict')
+      await gotoBindPage(page, { token: TOKEN })
+
+      await expect(page.getByText(/匹配到多个 Octo 账号/)).toBeVisible()
+      await expect(page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' })).toHaveCount(0)
+    })
+
+    test('methods=[] + create available: choose_method (NOT fatal)', async ({ page }) => {
+      await mockBindServer(page, 'create_only_no_verify')
+      await gotoBindPage(page, { token: TOKEN })
+
+      // 应该看到主创建按钮, NOT fatal "无可用的绑定方式"
+      await expect(page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' })).toBeVisible()
+      await expect(page.getByText(/无可用的绑定方式/)).toHaveCount(0)
+      // verify 按钮也不应该出现
+      await expect(page.getByRole('button', { name: '使用 Octo 密码验证' })).toHaveCount(0)
+    })
+
+    test('create 422 (claims incomplete at create time) → fatal terminal', async ({ page }) => {
+      await mockBindServer(page, 'create_422')
+      await gotoBindPage(page, { token: TOKEN })
+
+      await page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' }).click()
+      await expect(page.getByText(/SSO 身份信息不完整|无法自助创建/)).toBeVisible()
+      await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+    })
+
+    test('create 429 (max=1) → fatal "请重新发起 SSO 登录"', async ({ page }) => {
+      await mockBindServer(page, 'create_429')
+      await gotoBindPage(page, { token: TOKEN })
+
+      await page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' }).click()
+      await expect(page.getByText(/已尝试创建|重新发起 SSO/)).toBeVisible()
+      await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+    })
+
+    test('create 409 (manual conflict) → fatal "联系管理员"', async ({ page }) => {
+      await mockBindServer(page, 'create_409_manual')
+      await gotoBindPage(page, { token: TOKEN })
+
+      await page.getByRole('button', { name: '使用 SSO 身份创建 Octo 账号' }).click()
+      await expect(page.getByText(/账号信息冲突|联系管理员/)).toBeVisible()
+      await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+    })
+  })
+})

--- a/apps/web/e2e/bind.spec.ts
+++ b/apps/web/e2e/bind.spec.ts
@@ -265,4 +265,37 @@ test.describe('OIDC bind page', () => {
       await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
     })
   })
+
+  // PR #72 reviewer regressions ===========================================
+  test.describe('PR #72 review fixes', () => {
+    test('B1: confirm 429 surfaces fatal screen, not infinite spinner', async ({ page }) => {
+      await mockBindServer(page, 'confirm_429_terminal')
+      await gotoBindPage(page, { token: TOKEN })
+
+      // Drive verify → confirm → 429 path
+      await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+      await page.getByLabel(/Octo 账号/).fill('alice')
+      await page.locator('#bind-password').fill('pw-correct')
+      await page.getByRole('button', { name: '验证并绑定' }).click()
+
+      // Must reach a fatal screen with a recovery button — not stuck on spinner.
+      await expect(page.getByRole('button', { name: '返回登录' })).toBeVisible()
+      await expect(page.getByText(/重新发起 SSO|绑定失败/)).toBeVisible()
+    })
+
+    test('W2: verify_password 409 auto-advances to confirm (no inline dead-end)', async ({ page }) => {
+      const { calls } = await mockBindServer(page, 'verify_password_409_advance')
+      await gotoBindPage(page, { token: TOKEN, returnTo: '/' })
+
+      await page.getByRole('button', { name: '使用 Octo 密码验证' }).click()
+      await page.getByLabel(/Octo 账号/).fill('alice')
+      await page.locator('#bind-password').fill('pw-correct')
+      await page.getByRole('button', { name: '验证并绑定' }).click()
+
+      // verify returned 409 → BindPage should call confirm anyway and navigate.
+      await page.waitForURL((u) => u.pathname === '/', { timeout: 5000 })
+      expect(calls.find((c) => c.endpoint === 'verify_password')).toBeDefined()
+      expect(calls.find((c) => c.endpoint === 'confirm')).toBeDefined()
+    })
+  })
 })

--- a/apps/web/e2e/fixtures/mockBindServer.ts
+++ b/apps/web/e2e/fixtures/mockBindServer.ts
@@ -1,0 +1,305 @@
+import type { Page, Route } from '@playwright/test'
+
+// bind 后端响应的 scenario 套件. 每个 scenario 决定 5 个端点各自的状态码 + body.
+// 不在 Playwright 之外定义后端 — 端到端测试要的就是"前端在各种后端返回下表现正确".
+
+export type BindScenario =
+  | 'happy_password'
+  | 'happy_sms'
+  | 'info_410'
+  | 'info_empty_methods'
+  | 'info_password_only'
+  | 'verify_password_401'
+  | 'verify_password_429'
+  | 'confirm_409'
+  // PR#93 create paths
+  | 'happy_create'
+  | 'create_disabled'
+  | 'create_blocked_claims_incomplete'
+  | 'create_blocked_manual_conflict'
+  | 'create_only_no_verify'
+  | 'create_422'
+  | 'create_429'
+  | 'create_409_manual'
+
+interface EndpointResp {
+  status: number
+  body: object
+}
+
+interface ScenarioConfig {
+  info: EndpointResp
+  verify_password: EndpointResp
+  verify_otp_send: EndpointResp
+  verify_otp_check: EndpointResp
+  confirm: EndpointResp
+  create: EndpointResp
+}
+
+const STANDARD_INFO = {
+  masked_email: 'a***@example.com',
+  masked_phone: '****5678',
+  name: 'Alice',
+  methods: ['password', 'sms_otp'],
+  support_contact: 'support@example.com',
+}
+
+const STANDARD_LOGIN_RESP = JSON.stringify({
+  uid: 'u-12345',
+  token: 'tok-abc',
+  app_id: 'app1',
+  short_no: '0001',
+  name: 'Alice',
+  sex: 0,
+})
+
+// 把 /bind/create 也填一份默认值, 老 scenarios 不显示 create 按钮 (info 不返
+// allow_create), 这个 endpoint 永远不会被命中, 安全.
+const NEVER_HIT: EndpointResp = { status: 500, body: { msg: 'should_not_be_hit_in_this_scenario' } }
+
+// 主创建 happy path 用的 info shape: allow_create=true + create_blocked=''
+const CREATE_INFO = {
+  ...STANDARD_INFO,
+  allow_create: true,
+  create_blocked: '',
+}
+
+const SCENARIOS: Record<BindScenario, ScenarioConfig> = {
+  happy_password: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-12345' },
+    },
+    create: NEVER_HIT,
+  },
+  happy_sms: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-12345' },
+    },
+    create: NEVER_HIT,
+  },
+  info_410: {
+    info: { status: 410, body: { msg: 'expired' } },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  info_empty_methods: {
+    info: { status: 200, body: { ...STANDARD_INFO, methods: [] } },
+    verify_password: { status: 200, body: {} },
+    verify_otp_send: { status: 200, body: {} },
+    verify_otp_check: { status: 200, body: {} },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  info_password_only: {
+    info: { status: 200, body: { ...STANDARD_INFO, methods: ['password'] } },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: {} },
+    verify_otp_check: { status: 200, body: {} },
+    confirm: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-12345' },
+    },
+    create: NEVER_HIT,
+  },
+  verify_password_401: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 401, body: { msg: 'invalid_credential' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  verify_password_429: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 429, body: { msg: 'rate_limited' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  confirm_409: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 409, body: { msg: 'already_bound' } },
+    create: NEVER_HIT,
+  },
+  // ----- PR#93 create paths -----------------------------------------------
+  happy_create: {
+    info: { status: 200, body: CREATE_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-new-99' },
+    },
+  },
+  create_disabled: {
+    // allow_create=false 时 verify 路径仍可用, 用户走老 UX
+    info: {
+      status: 200,
+      body: { ...STANDARD_INFO, allow_create: false, create_blocked: 'disabled' },
+    },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-12345' },
+    },
+    create: NEVER_HIT,
+  },
+  create_blocked_claims_incomplete: {
+    // allow_create=true 但 claims 缺验证邮箱/手机, 显示阻塞文案
+    info: {
+      status: 200,
+      body: { ...STANDARD_INFO, allow_create: true, create_blocked: 'claims_incomplete' },
+    },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  create_blocked_manual_conflict: {
+    info: {
+      status: 200,
+      body: { ...STANDARD_INFO, allow_create: true, create_blocked: 'manual_conflict' },
+    },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: NEVER_HIT,
+  },
+  create_only_no_verify: {
+    // methods=[] 但 create 可用 — 应该进 choose_method 而不是 fatal
+    info: {
+      status: 200,
+      body: { ...STANDARD_INFO, methods: [], allow_create: true, create_blocked: '' },
+    },
+    verify_password: { status: 200, body: {} },
+    verify_otp_send: { status: 200, body: {} },
+    verify_otp_check: { status: 200, body: {} },
+    confirm: { status: 200, body: {} },
+    create: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-new-only' },
+    },
+  },
+  create_422: {
+    info: { status: 200, body: CREATE_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: { status: 422, body: { msg: 'claims missing required fields' } },
+  },
+  create_429: {
+    info: { status: 200, body: CREATE_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: { status: 429, body: { msg: 'too many create attempts' } },
+  },
+  create_409_manual: {
+    info: { status: 200, body: CREATE_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 200, body: {} },
+    create: { status: 409, body: { msg: 'account conflict needs manual resolution' } },
+  },
+}
+
+const PATH_MATCHERS: Array<{ test: RegExp; key: keyof ScenarioConfig }> = [
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/info(\?|$)/, key: 'info' },
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/verify\/password(\?|$)/, key: 'verify_password' },
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/verify\/otp\/send(\?|$)/, key: 'verify_otp_send' },
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/verify\/otp\/check(\?|$)/, key: 'verify_otp_check' },
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/confirm(\?|$)/, key: 'confirm' },
+  { test: /\/v1\/auth\/oidc\/[^/]+\/bind\/create(\?|$)/, key: 'create' },
+]
+
+/**
+ * mockBindServer 把 5 个 bind 端点全部拦截, 按 scenario 返回. 同时记录每次调用
+ * 让测试断言端点被命中以及请求体格式正确 (e.g. otp/send 不带 phone, password
+ * 体含 identifier+password 等).
+ *
+ * Vite dev server 在 /api 路径下做了 proxy 转发后端; 但 bind 端点用的是绝对路径
+ * /v1/auth/oidc/... (见 oidc/api.ts:AUTHCODE_PATH 同侧路径设计), 走的是 vite
+ * 默认 fallback. 这里 page.route 用 glob "(STAR)(STAR)/v1/auth/oidc/(STAR)(STAR)" 匹配 (STAR=*).
+ */
+export async function mockBindServer(
+  page: Page,
+  scenario: BindScenario,
+): Promise<{ calls: { endpoint: keyof ScenarioConfig; body?: unknown; url: string }[] }> {
+  const config = SCENARIOS[scenario]
+  const calls: { endpoint: keyof ScenarioConfig; body?: unknown; url: string }[] = []
+
+  await page.route('**/v1/auth/oidc/**', async (route: Route) => {
+    const url = route.request().url()
+    const matcher = PATH_MATCHERS.find((m) => m.test.test(url))
+    if (!matcher) return route.continue()
+    const ep = matcher.key
+    let body: unknown
+    try {
+      const postData = route.request().postData()
+      body = postData ? JSON.parse(postData) : undefined
+    } catch {
+      body = undefined
+    }
+    calls.push({ endpoint: ep, body, url })
+    const resp = config[ep]
+    await route.fulfill({
+      status: resp.status,
+      contentType: 'application/json',
+      body: JSON.stringify(resp.body),
+    })
+  })
+
+  return { calls }
+}
+
+/**
+ * gotoBindPage 用 query 形式打开 /oidc/bind. token / authcode / return_to /
+ * provider 都从这里注入. 默认值反映"后端 redirect 标准 payload".
+ */
+export async function gotoBindPage(
+  page: Page,
+  opts: {
+    token?: string
+    authcode?: string
+    returnTo?: string
+    provider?: string
+  } = {},
+): Promise<void> {
+  const token = opts.token ?? 'tok-secret-do-not-leak'
+  const authcode = opts.authcode ?? 'ac-fe-12345'
+  const returnTo = opts.returnTo ?? '/'
+  const provider = opts.provider ?? 'aegis'
+  const qs = new URLSearchParams({
+    token,
+    authcode,
+    return_to: returnTo,
+    provider,
+  })
+  await page.goto(`/oidc/bind?${qs.toString()}`)
+}

--- a/apps/web/e2e/fixtures/mockBindServer.ts
+++ b/apps/web/e2e/fixtures/mockBindServer.ts
@@ -21,6 +21,9 @@ export type BindScenario =
   | 'create_422'
   | 'create_429'
   | 'create_409_manual'
+  // PR #72 review fixes (B1, B2, W2)
+  | 'confirm_429_terminal'
+  | 'verify_password_409_advance'
 
 interface EndpointResp {
   status: number
@@ -226,6 +229,30 @@ const SCENARIOS: Record<BindScenario, ScenarioConfig> = {
     verify_otp_check: { status: 200, body: { status: 'verified' } },
     confirm: { status: 200, body: {} },
     create: { status: 409, body: { msg: 'account conflict needs manual resolution' } },
+  },
+  // PR #72 review B1 regression: confirm 429 must NOT leave the user on an
+  // infinite spinner — flow goes verify OK → confirming → 429 → fatal.
+  confirm_429_terminal: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 200, body: { status: 'verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: { status: 429, body: { msg: 'rate_limited' } },
+    create: NEVER_HIT,
+  },
+  // PR #72 review W2 regression: verify_password 409 must auto-advance to
+  // confirm (token already verified server-side) instead of stranding user
+  // with an inline "请继续完成绑定" message and no action.
+  verify_password_409_advance: {
+    info: { status: 200, body: STANDARD_INFO },
+    verify_password: { status: 409, body: { msg: 'already_verified' } },
+    verify_otp_send: { status: 200, body: { status: 'sent' } },
+    verify_otp_check: { status: 200, body: { status: 'verified' } },
+    confirm: {
+      status: 200,
+      body: { status: 'ok', login_resp: STANDARD_LOGIN_RESP, uid: 'u-12345' },
+    },
+    create: NEVER_HIT,
   },
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,8 @@
     "electron:build:linux-arm64": "electron-builder --linux --arm64 -c",
     "electron:build:all": "electron-builder -mw -c",
     "test": "vitest run",
+    "test:e2e:bind": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test -c e2e/bind.config.ts",
+    "test:e2e:bind:install": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium",
     "test:arch-builds": "./scripts/test-arch-builds.sh",
     "debug:build-structure": "./scripts/debug-build-structure.sh",
     "test:arch-specific": "./scripts/test-arch-specific-builds.sh",

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -247,6 +247,19 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             );
         }
 
+        // OIDC bind page must take precedence over the invite-landing branch
+        // below: if a future URL composition (deep link, stale cookie) ever puts
+        // ?invite= on a /oidc/bind URL, we must still render the bind page —
+        // otherwise the bind token gets silently dropped on the floor. Defense
+        // in depth even though no documented flow constructs such a URL today.
+        // PR #72 review yujiawei #2.
+        if (window.location.pathname === '/oidc/bind') {
+            const bindComponent = WKApp.route.get('/oidc/bind')
+            if (bindComponent) {
+                return bindComponent
+            }
+        }
+
         // 邀请链接检测
         const urlParams = new URLSearchParams(window.location.search);
         const inviteCode = urlParams.get("invite");
@@ -274,16 +287,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 }
             }
             return <InviteLanding inviteCode={inviteCode} />;
-        }
-
-        // OIDC 自助绑定页: 未登录态从后端 callback 302 进来, 不能走登录或主页
-        // 分支. 命中 /oidc/bind 直接渲染 BindModule 注册的组件; 绑定成功后
-        // BindPage 自身 navigate 到 return_to.
-        if (window.location.pathname === '/oidc/bind') {
-            const bindComponent = WKApp.route.get('/oidc/bind')
-            if (bindComponent) {
-                return bindComponent
-            }
         }
 
         return <Provider create={() => {

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -276,6 +276,16 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             return <InviteLanding inviteCode={inviteCode} />;
         }
 
+        // OIDC 自助绑定页: 未登录态从后端 callback 302 进来, 不能走登录或主页
+        // 分支. 命中 /oidc/bind 直接渲染 BindModule 注册的组件; 绑定成功后
+        // BindPage 自身 navigate 到 return_to.
+        if (window.location.pathname === '/oidc/bind') {
+            const bindComponent = WKApp.route.get('/oidc/bind')
+            if (bindComponent) {
+                return bindComponent
+            }
+        }
+
         return <Provider create={() => {
             return WKApp.shared
         }} render={(vm: WKApp): any => {

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -5,7 +5,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import  { BaseModule, WKApp } from '@octo/base';
-import  { LoginModule } from '@octo/login';
+import  { LoginModule, BindModule } from '@octo/login';
 import  { DataSourceModule } from '@octo/datasource';
 import {ContactsModule} from '@octo/contacts';
 import { MatterModule } from '@octo/todo';
@@ -53,6 +53,7 @@ WKApp.loginInfo.load() // 加载登录信息
 WKApp.shared.registerModule(new BaseModule()); // 基础模块
 WKApp.shared.registerModule(new DataSourceModule()) // 数据源模块
 WKApp.shared.registerModule(new LoginModule()); // 登录模块
+WKApp.shared.registerModule(new BindModule()); // OIDC 自助绑定页 (/oidc/bind)
 WKApp.shared.registerModule(new ContactsModule()); // 联系模块
 WKApp.shared.registerModule(new MatterModule()); // Matter module
 WKApp.shared.registerModule(new SummaryModule()); // 智能总结模块

--- a/packages/dmworklogin/src/__tests__/loginSession.test.ts
+++ b/packages/dmworklogin/src/__tests__/loginSession.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { applyLoginResp, parseLoginResp } from '../loginSession'
+
+vi.mock('@octo/base', () => ({
+  WKApp: {
+    loginInfo: {
+      appID: '',
+      uid: '',
+      token: '',
+      shortNo: '',
+      name: '',
+      sex: 0,
+      loginProvider: '',
+      realnameVerified: undefined,
+      realName: undefined,
+      realnameVerifiedAt: undefined,
+      save: vi.fn(),
+    },
+  },
+}))
+
+import { WKApp } from '@octo/base'
+
+beforeEach(() => {
+  // 重置 loginInfo 避免测试间污染
+  Object.assign(WKApp.loginInfo, {
+    appID: '',
+    uid: '',
+    token: '',
+    shortNo: '',
+    name: '',
+    sex: 0,
+    loginProvider: '',
+    realnameVerified: undefined,
+    realName: undefined,
+    realnameVerifiedAt: undefined,
+  })
+  ;(WKApp.loginInfo.save as ReturnType<typeof vi.fn>).mockClear()
+})
+
+describe('applyLoginResp', () => {
+  it('writes uid/token/provider and saves', () => {
+    applyLoginResp({ uid: 'u1', token: 'tok', app_id: 'a', name: 'Alice' }, 'oidc-bind')
+    expect(WKApp.loginInfo.uid).toBe('u1')
+    expect(WKApp.loginInfo.token).toBe('tok')
+    expect(WKApp.loginInfo.appID).toBe('a')
+    expect(WKApp.loginInfo.name).toBe('Alice')
+    expect(WKApp.loginInfo.loginProvider).toBe('oidc-bind')
+    expect(WKApp.loginInfo.save).toHaveBeenCalledOnce()
+  })
+
+  it('throws on missing uid', () => {
+    expect(() => applyLoginResp({ token: 't' }, 'p')).toThrow()
+  })
+
+  it('throws on missing token', () => {
+    expect(() => applyLoginResp({ uid: 'u' }, 'p')).toThrow()
+  })
+
+  it('throws on empty uid', () => {
+    expect(() => applyLoginResp({ uid: '', token: 't' }, 'p')).toThrow()
+  })
+
+  it('preserves tri-state realname (true)', () => {
+    applyLoginResp(
+      { uid: 'u', token: 't', realname_verified: true, real_name: 'Alice', realname_verified_at: 1700000000 },
+      'oidc',
+    )
+    expect(WKApp.loginInfo.realnameVerified).toBe(true)
+    expect(WKApp.loginInfo.realName).toBe('Alice')
+    expect(WKApp.loginInfo.realnameVerifiedAt).toBe(1700000000)
+  })
+
+  it('preserves tri-state realname (explicit false)', () => {
+    applyLoginResp(
+      { uid: 'u', token: 't', realname_verified: false },
+      'oidc',
+    )
+    expect(WKApp.loginInfo.realnameVerified).toBe(false)
+  })
+
+  it('preserves tri-state realname (missing → undefined, NOT false)', () => {
+    applyLoginResp({ uid: 'u', token: 't' }, 'oidc')
+    expect(WKApp.loginInfo.realnameVerified).toBeUndefined()
+    expect(WKApp.loginInfo.realName).toBeUndefined()
+    expect(WKApp.loginInfo.realnameVerifiedAt).toBeUndefined()
+  })
+
+  it('accepts realname_verified as "1" string', () => {
+    applyLoginResp({ uid: 'u', token: 't', realname_verified: '1' }, 'oidc')
+    expect(WKApp.loginInfo.realnameVerified).toBe(true)
+  })
+
+  it('accepts realname_verified_at as numeric string', () => {
+    applyLoginResp({ uid: 'u', token: 't', realname_verified_at: '1700000000' }, 'oidc')
+    expect(WKApp.loginInfo.realnameVerifiedAt).toBe(1700000000)
+  })
+
+  it('drops realname_verified_at when 0', () => {
+    applyLoginResp({ uid: 'u', token: 't', realname_verified_at: 0 }, 'oidc')
+    expect(WKApp.loginInfo.realnameVerifiedAt).toBeUndefined()
+  })
+})
+
+describe('parseLoginResp', () => {
+  it('parses JSON-encoded login response', () => {
+    const raw = JSON.stringify({ uid: 'u', token: 't' })
+    expect(parseLoginResp(raw)).toEqual({ uid: 'u', token: 't' })
+  })
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseLoginResp('{not json')).toThrow(/Invalid login_resp/)
+  })
+
+  it('throws on non-object JSON', () => {
+    expect(() => parseLoginResp('[1,2,3]')).toThrow(/not an object/)
+    expect(() => parseLoginResp('"string"')).toThrow(/not an object/)
+  })
+})

--- a/packages/dmworklogin/src/__tests__/loginSession.test.ts
+++ b/packages/dmworklogin/src/__tests__/loginSession.test.ts
@@ -40,12 +40,16 @@ beforeEach(() => {
 
 describe('applyLoginResp', () => {
   it('writes uid/token/provider and saves', () => {
-    applyLoginResp({ uid: 'u1', token: 'tok', app_id: 'a', name: 'Alice' }, 'oidc-bind')
+    // PR #72 round-5: 用真实 IdP id 而非 synthetic 'oidc-bind' 标签 —
+    // BindPage 现在传 entry.provider (resolveProvider 已对齐), 测试应当反映
+    // 真实合同, 不再锁死合成值. 下游 NavSettingsPanel/realnameVerifyUrl 按
+    // id 在 oidcProviders 中 find, synthetic 值会让 lookup 全部失败.
+    applyLoginResp({ uid: 'u1', token: 'tok', app_id: 'a', name: 'Alice' }, 'aegis')
     expect(WKApp.loginInfo.uid).toBe('u1')
     expect(WKApp.loginInfo.token).toBe('tok')
     expect(WKApp.loginInfo.appID).toBe('a')
     expect(WKApp.loginInfo.name).toBe('Alice')
-    expect(WKApp.loginInfo.loginProvider).toBe('oidc-bind')
+    expect(WKApp.loginInfo.loginProvider).toBe('aegis')
     expect(WKApp.loginInfo.save).toHaveBeenCalledOnce()
   })
 

--- a/packages/dmworklogin/src/__tests__/loginSession.test.ts
+++ b/packages/dmworklogin/src/__tests__/loginSession.test.ts
@@ -40,10 +40,10 @@ beforeEach(() => {
 
 describe('applyLoginResp', () => {
   it('writes uid/token/provider and saves', () => {
-    // PR #72 round-5: 用真实 IdP id 而非 synthetic 'oidc-bind' 标签 —
-    // BindPage 现在传 entry.provider (resolveProvider 已对齐), 测试应当反映
-    // 真实合同, 不再锁死合成值. 下游 NavSettingsPanel/realnameVerifyUrl 按
-    // id 在 oidcProviders 中 find, synthetic 值会让 lookup 全部失败.
+    // 用真实 IdP id 而非 synthetic 'oidc-bind' 标签 — BindPage 传
+    // entry.provider (resolveProvider 已对齐), 测试反映真实合同, 不锁死合成值.
+    // 下游 NavSettingsPanel/realnameVerifyUrl 按 id 在 oidcProviders 中 find,
+    // synthetic 值会让 lookup 全部失败.
     applyLoginResp({ uid: 'u1', token: 'tok', app_id: 'a', name: 'Alice' }, 'aegis')
     expect(WKApp.loginInfo.uid).toBe('u1')
     expect(WKApp.loginInfo.token).toBe('tok')

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -1,0 +1,612 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
+import { fetchHttpClient } from '../oidc'
+import { clearPendingOidcLogin } from '../oidc'
+import {
+  fetchBindInfo,
+  verifyBindPassword,
+  sendBindOtp,
+  checkBindOtp,
+  confirmBind,
+  createBind,
+  parseBindEntryParams,
+  clearBindUrl,
+  type BindEntryParams,
+  type BindInfoResp,
+  type BindMethod,
+  type BindApiOptions,
+} from '../oidc/bind'
+import { applyLoginResp, parseLoginResp } from '../loginSession'
+import { mapBindError, type BindEndpoint, type BindErrorDisplay } from './errorMessages'
+import './bind.css'
+
+type Stage =
+  | { kind: 'init' }
+  | { kind: 'loading_info' }
+  | { kind: 'choose_method'; info: BindInfoResp }
+  | { kind: 'verify_password'; info: BindInfoResp }
+  | { kind: 'verify_otp'; info: BindInfoResp; sent: boolean; sending: boolean }
+  | { kind: 'confirming'; info: BindInfoResp }
+  | { kind: 'creating'; info: BindInfoResp }
+  | { kind: 'success' }
+  | { kind: 'fatal'; display: BindErrorDisplay }
+
+// 把 info.allow_create / create_blocked 折叠成 UI 三态. PR#93 钦定: 只在
+// allow_create=true && create_blocked==='' 时显示可点的主创建按钮.
+type CreateState =
+  | { kind: 'available' }                       // 可点
+  | { kind: 'hidden' }                           // 不渲染 (disabled 开关 / 老后端无字段)
+  | { kind: 'blocked'; reason: string }          // 渲染说明文字, 不渲染按钮
+
+function deriveCreateState(info: BindInfoResp): CreateState {
+  if (info.allow_create !== true) return { kind: 'hidden' }
+  const blocked = info.create_blocked ?? ''
+  if (blocked === '') return { kind: 'available' }
+  // 'disabled' 这一支虽然 allow_create 应该已经是 false, 但后端 PR#93 precedence
+  // 是 disabled > claims_incomplete > manual_conflict > consumed, 防御性兜底.
+  if (blocked === 'disabled') return { kind: 'hidden' }
+  if (blocked === 'claims_incomplete') {
+    return { kind: 'blocked', reason: 'SSO 身份信息不完整，无法自助创建账号' }
+  }
+  if (blocked === 'manual_conflict') {
+    return { kind: 'blocked', reason: '您的 SSO 身份匹配到多个 Octo 账号，需要管理员协助处理' }
+  }
+  if (blocked === 'consumed') {
+    return { kind: 'blocked', reason: '当前链接已使用过，请重新发起 SSO 登录' }
+  }
+  return { kind: 'hidden' }
+}
+
+interface BindPageProps {
+  // 由 BindModule.init() 在 RouteManager 的 pageshow handler 冲掉 URL 之前
+  // 抓到的 location.search 快照. 不直接读 window.location.search 是因为
+  // RouteManager 会在 pageshow 时 push 一个带 sid= 的 URL, 把 bind 入口参数
+  // 全部丢掉.
+  initialSearch: string
+}
+
+const BindPage = ({ initialSearch }: BindPageProps) => {
+  // bind_token 与 entry 参数全程只在 useRef 持有, 不进 React state, 不进任何 store.
+  // 见 oidc-bind-frontend.md §2.2 — 这是 bind_token-in-URL 已知 limitation 的核心缓解.
+  const entryRef = useRef<BindEntryParams | null>(null)
+  const initRanRef = useRef(false)
+
+  const [stage, setStage] = useState<Stage>({ kind: 'init' })
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+  const [otp, setOtp] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [inlineError, setInlineError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (initRanRef.current) return
+    initRanRef.current = true
+
+    const params = parseBindEntryParams(initialSearch)
+    // **顺序很关键**: 先 capture 到 ref, 再清 URL. 反过来会丢 token.
+    if (params) entryRef.current = params
+    clearBindUrl()
+
+    if (!params) {
+      setStage({
+        kind: 'fatal',
+        display: { message: '链接无效，请重新发起登录', terminal: true },
+      })
+      return
+    }
+
+    void loadInfo(params)
+  }, [])
+
+  const apiOpts = (): BindApiOptions => ({
+    provider: entryRef.current?.provider,
+    telemetry: {
+      onProviderFallback: (reason) => {
+        // 上报埋点便于排查 redirect 没带 provider 的部署. 不打 token, 不打具体值,
+        // 只记一次 reason. WKApp 没暴露埋点 API, 这里挂在 window 对象上让运维抓.
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(window as any).__bindProviderFallback = reason
+        } catch {
+          /* noop */
+        }
+      },
+    },
+  })
+
+  async function loadInfo(params: BindEntryParams): Promise<void> {
+    setStage({ kind: 'loading_info' })
+    setInlineError(null)
+    try {
+      const info = await fetchBindInfo(fetchHttpClient, params.token, apiOpts())
+      const createState = deriveCreateState(info)
+      // 用户能进入选择阶段的条件: 至少有一个可用的 verify method OR create 可点.
+      // create 被 block 但仍渲染原因文字时, 只要还有 verify methods 也能进 choose_method;
+      // create + verify 都死才落 fatal.
+      const hasAnyAction =
+        info.methods.length > 0 || createState.kind === 'available'
+      if (!hasAnyAction) {
+        // create 被 blocked 而 methods 空 → 把 blocked 原因当 fatal 文案, 比泛"无可用绑定方式"更有信息.
+        const message =
+          createState.kind === 'blocked'
+            ? createState.reason
+            : info.support_contact
+              ? `无可用的绑定方式，请联系 ${info.support_contact}`
+              : '无可用的绑定方式，请联系管理员'
+        setStage({
+          kind: 'fatal',
+          display: { message, terminal: true },
+        })
+        return
+      }
+      setStage({ kind: 'choose_method', info })
+    } catch (err) {
+      setStage({ kind: 'fatal', display: mapBindError('info', err) })
+    }
+  }
+
+  function handleError(endpoint: BindEndpoint, err: unknown): void {
+    const display = mapBindError(endpoint, err)
+    if (display.terminal) {
+      setStage({ kind: 'fatal', display })
+    } else {
+      setInlineError(display.message)
+    }
+  }
+
+  async function onSelectMethod(m: BindMethod): Promise<void> {
+    if (stage.kind !== 'choose_method') return
+    setInlineError(null)
+    if (m === 'password') {
+      setStage({ kind: 'verify_password', info: stage.info })
+      return
+    }
+    // sms_otp: 自动发送一次
+    setStage({ kind: 'verify_otp', info: stage.info, sent: false, sending: true })
+    try {
+      const token = entryRef.current?.token
+      if (!token) return
+      await sendBindOtp(fetchHttpClient, token, apiOpts())
+      setStage({ kind: 'verify_otp', info: stage.info, sent: true, sending: false })
+      Toast.success('验证码已发送')
+    } catch (err) {
+      setStage({ kind: 'verify_otp', info: stage.info, sent: false, sending: false })
+      handleError('verify_otp_send', err)
+    }
+  }
+
+  async function onResendOtp(): Promise<void> {
+    if (stage.kind !== 'verify_otp') return
+    const token = entryRef.current?.token
+    if (!token) return
+    setBusy(true)
+    setInlineError(null)
+    try {
+      await sendBindOtp(fetchHttpClient, token, apiOpts())
+      Toast.success('验证码已重新发送')
+      setStage({ ...stage, sent: true })
+    } catch (err) {
+      handleError('verify_otp_send', err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function onSubmitPassword(): Promise<void> {
+    if (stage.kind !== 'verify_password') return
+    if (!identifier || !password) {
+      setInlineError('请输入账号和密码')
+      return
+    }
+    const token = entryRef.current?.token
+    if (!token) return
+    setBusy(true)
+    setInlineError(null)
+    try {
+      await verifyBindPassword(fetchHttpClient, token, identifier, password, apiOpts())
+      // verify 通过后立即清密码, 不留在 React state 里
+      setPassword('')
+      await runConfirm(stage.info)
+    } catch (err) {
+      handleError('verify_password', err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function onSubmitOtp(): Promise<void> {
+    if (stage.kind !== 'verify_otp') return
+    if (!otp || otp.length < 4) {
+      setInlineError('请输入验证码')
+      return
+    }
+    const token = entryRef.current?.token
+    if (!token) return
+    setBusy(true)
+    setInlineError(null)
+    try {
+      await checkBindOtp(fetchHttpClient, token, otp, apiOpts())
+      setOtp('')
+      await runConfirm(stage.info)
+    } catch (err) {
+      handleError('verify_otp_check', err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function runConfirm(info: BindInfoResp): Promise<void> {
+    setStage({ kind: 'confirming', info })
+    const token = entryRef.current?.token
+    const returnTo = postLoginReturnTo(entryRef.current?.returnTo)
+    if (!token) return
+    try {
+      const resp = await confirmBind(fetchHttpClient, token, apiOpts())
+      // login_resp 是 JSON-encoded string, JSON.parse 后与老 OIDC authstatus.result 同 schema.
+      const data = parseLoginResp(resp.login_resp)
+      applyLoginResp(data, 'oidc-bind')
+      // bind 已经把 login 态写入 loginInfo; 同一 tab 上 /login 的 OidcResumeEffect
+      // 若读到旧 pending 会再 poll 一次浪费 1-2s. 清掉避免冗余.
+      try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
+      // 写完登录态后 token 已无效 (后端 single-use consume), 直接清掉 ref.
+      entryRef.current = null
+      setStage({ kind: 'success' })
+      // 避免短暂的 success 闪屏: 给 200ms 让 Toast 看见再跳.
+      window.setTimeout(() => {
+        try {
+          window.location.replace(returnTo)
+        } catch {
+          window.location.href = returnTo
+        }
+      }, 200)
+    } catch (err) {
+      handleError('confirm', err)
+      // confirm 失败要回退到能让用户再点 confirm 的 stage; 但 verify 状态后端是
+      // verified, 重新走 verify 会返 409. 最稳是直接落 fatal 让用户重走 OIDC.
+      // 唯一例外: 429 / 503 — 允许再试 confirm. handleError 已经按 terminal 标识区分.
+    }
+  }
+
+  async function runCreate(info: BindInfoResp): Promise<void> {
+    setStage({ kind: 'creating', info })
+    const token = entryRef.current?.token
+    const returnTo = postLoginReturnTo(entryRef.current?.returnTo)
+    if (!token) return
+    try {
+      const resp = await createBind(fetchHttpClient, token, apiOpts())
+      // 与 confirm 同 schema 同 builder, login_resp 直接 parseLoginResp + applyLoginResp.
+      const data = parseLoginResp(resp.login_resp)
+      applyLoginResp(data, 'oidc-bind-create')
+      try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
+      entryRef.current = null
+      setStage({ kind: 'success' })
+      window.setTimeout(() => {
+        try {
+          window.location.replace(returnTo)
+        } catch {
+          window.location.href = returnTo
+        }
+      }, 200)
+    } catch (err) {
+      // create 端点的失败几乎全部 terminal (bindCreateMax=1; claims/conflict 都是确定性的).
+      // handleError 按 mapBindError 返回的 terminal 标识自动落 fatal vs inline.
+      handleError('create', err)
+    }
+  }
+
+  function goBackToLogin(): void {
+    entryRef.current = null
+    window.location.replace('/login')
+  }
+
+  // ---- render ------------------------------------------------------------
+  return (
+    <div className="wk-bind">
+      <div className="wk-bind-card">
+        <h2 className="wk-bind-title">完成账号绑定</h2>
+        {/* fatal 状态下隐藏教学话术 — 已经报错了, 用户不需要再被告知"为什么在这" */}
+        {stage.kind !== 'fatal' ? (
+          <p className="wk-bind-subtitle">
+            {stage.kind === 'success'
+              ? '绑定成功，正在跳转…'
+              : '您的 SSO 身份尚未关联到 Octo 账号，验证后即可继续使用。'}
+          </p>
+        ) : null}
+
+        {stage.kind === 'loading_info' || stage.kind === 'init' ? (
+          <div style={{ textAlign: 'center', padding: '40px 0' }}>
+            <Spin />
+          </div>
+        ) : null}
+
+        {stage.kind === 'fatal' ? (
+          <>
+            <div className="wk-bind-error" data-severity="hard">{stage.display.message}</div>
+            <div className="wk-bind-actions">
+              <Button type="primary" theme="solid" onClick={goBackToLogin}>
+                返回登录
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {stage.kind === 'success' ? (
+          <div style={{ textAlign: 'center', padding: '20px 0' }}>
+            <Spin />
+          </div>
+        ) : null}
+
+        {stage.kind === 'choose_method' ||
+        stage.kind === 'verify_password' ||
+        stage.kind === 'verify_otp' ||
+        stage.kind === 'confirming' ||
+        stage.kind === 'creating' ? (
+          <IdentityBlock info={(stage as { info: BindInfoResp }).info} />
+        ) : null}
+
+        {stage.kind === 'choose_method'
+          ? renderChooseMethod(stage.info, busy, onSelectMethod, () =>
+              void runCreate(stage.info),
+            )
+          : null}
+
+        {stage.kind === 'creating' ? (
+          <div className="wk-bind-loader">
+            <Spin size="large" />
+            <div className="wk-bind-loader-title">正在创建 Octo 账号</div>
+            <div className="wk-bind-loader-sub">请稍候，完成后将自动进入主界面…</div>
+          </div>
+        ) : null}
+
+        {stage.kind === 'verify_password' ? (
+          <>
+            {inlineError ? <div className="wk-bind-error" data-severity="soft">{inlineError}</div> : null}
+            <div className="wk-bind-field">
+              <label htmlFor="bind-username">Octo 账号（用户名/手机号/邮箱）</label>
+              <Input
+                id="bind-username"
+                size="large"
+                value={identifier}
+                onChange={setIdentifier}
+                disabled={busy}
+                autoComplete="username"
+              />
+            </div>
+            <div className="wk-bind-field">
+              <label htmlFor="bind-password">密码</label>
+              <Input
+                id="bind-password"
+                size="large"
+                type="password"
+                mode="password"
+                value={password}
+                onChange={setPassword}
+                disabled={busy}
+                autoComplete="current-password"
+              />
+            </div>
+            <div className="wk-bind-actions">
+              <Button
+                onClick={() => {
+                  setIdentifier('')
+                  setPassword('')
+                  setInlineError(null)
+                  setStage({ kind: 'choose_method', info: stage.info })
+                }}
+                disabled={busy}
+              >
+                返回
+              </Button>
+              <Button
+                type="primary"
+                theme="solid"
+                loading={busy}
+                onClick={onSubmitPassword}
+              >
+                验证并绑定
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {stage.kind === 'verify_otp' ? (
+          <>
+            {inlineError ? <div className="wk-bind-error" data-severity="soft">{inlineError}</div> : null}
+            <div className="wk-bind-field">
+              <label htmlFor="bind-otp">短信验证码</label>
+              <Input
+                id="bind-otp"
+                size="large"
+                value={otp}
+                onChange={setOtp}
+                disabled={busy || stage.sending}
+                maxLength={6}
+                autoComplete="one-time-code"
+              />
+              <div className="wk-bind-otp-hint">
+                验证码已发送至{' '}
+                {stage.info.masked_phone ?? '您的手机号'}
+                {' · '}
+                <a
+                  onClick={() => {
+                    if (!busy && !stage.sending) void onResendOtp()
+                  }}
+                  style={{ cursor: busy || stage.sending ? 'not-allowed' : 'pointer' }}
+                >
+                  重新发送
+                </a>
+              </div>
+            </div>
+            <div className="wk-bind-actions">
+              <Button
+                onClick={() => {
+                  setOtp('')
+                  setInlineError(null)
+                  setStage({ kind: 'choose_method', info: stage.info })
+                }}
+                disabled={busy}
+              >
+                返回
+              </Button>
+              <Button
+                type="primary"
+                theme="solid"
+                loading={busy}
+                disabled={stage.sending}
+                onClick={onSubmitOtp}
+              >
+                验证并绑定
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {stage.kind === 'confirming' ? (
+          <div className="wk-bind-loader">
+            <Spin size="large" />
+            <div className="wk-bind-loader-title">正在完成绑定</div>
+            <div className="wk-bind-loader-sub">请稍候，完成后将自动进入主界面…</div>
+          </div>
+        ) : null}
+
+        {stage.kind !== 'init' &&
+        stage.kind !== 'loading_info' &&
+        stage.kind !== 'fatal' &&
+        stage.kind !== 'success' &&
+        stage.kind !== 'creating' ? (
+          <div className="wk-bind-footer">
+            {(stage as { info: BindInfoResp }).info.support_contact ? (
+              <>
+                遇到问题？联系{' '}
+                <a href={`mailto:${(stage as { info: BindInfoResp }).info.support_contact}`}>
+                  {(stage as { info: BindInfoResp }).info.support_contact}
+                </a>
+              </>
+            ) : (
+              <span>遇到问题？请联系管理员</span>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * choose_method 阶段的渲染. 反转后的 UX:
+ *   主路径: 使用 SSO 身份直接创建 Octo 账号 (单击, 走 /bind/create)
+ *   次路径: 已有 Octo 账号 → 用密码 / 短信验证绑定 (展开 verify methods)
+ *
+ * create 不可用 (老后端不返 allow_create / 运维关掉 / claims 不够) 时, 主区域
+ * 留空或显示 blocked 原因, 次路径回退成"唯一路径".
+ */
+// 后端清洗 return_to 时会保留路径段, 常见就是原 authorize 时传的 /login.
+// 但我们已经在 bind 流程里把登录态写好了, 跳回 /login 会触发 Layout 的
+// "pathname 是 /login 强制显示登录页"守卫, 让用户看到一闪的登录表单 + 二次
+// OidcResume 冗余 poll. 这里把 /login 提到主页. 其它 / 开头的路径保持不变.
+function postLoginReturnTo(raw: string | undefined): string {
+  const value = raw ?? '/'
+  // 仅在精确 /login 与 /login?... 上替换, 不动 /login-history 这种前缀同形路径.
+  if (value === '/login' || value.startsWith('/login?') || value.startsWith('/login/')) {
+    return '/'
+  }
+  return value
+}
+
+// 次入口引导文案. 按 methods[] 实际给的方式拼, 避免写死"密码或短信"误导用户.
+function secondaryHintFor(methods: BindMethod[]): string {
+  const labels: string[] = []
+  if (methods.includes('password')) labels.push('密码')
+  if (methods.includes('sms_otp')) labels.push('短信')
+  if (labels.length === 0) return '已有 Octo 账号，请使用其他方式关联'
+  return `已有 Octo 账号，使用${labels.join('或')}验证关联`
+}
+
+function renderChooseMethod(
+  info: BindInfoResp,
+  busy: boolean,
+  onSelectMethod: (m: BindMethod) => void,
+  onCreate: () => void,
+): JSX.Element {
+  const createState = deriveCreateState(info)
+  const hasVerify = info.methods.length > 0
+  return (
+    <>
+      {createState.kind === 'available' ? (
+        <div className="wk-bind-method-list">
+          <Button
+            theme="solid"
+            type="primary"
+            block
+            size="large"
+            disabled={busy}
+            onClick={onCreate}
+          >
+            使用 SSO 身份创建 Octo 账号
+          </Button>
+        </div>
+      ) : null}
+
+      {createState.kind === 'blocked' ? (
+        <div className="wk-bind-error" data-severity="soft">
+          {createState.reason}
+        </div>
+      ) : null}
+
+      {createState.kind !== 'hidden' && hasVerify ? (
+        <div className="wk-bind-divider" role="separator">
+          <span>或</span>
+        </div>
+      ) : null}
+
+      {hasVerify ? (
+        <>
+          {createState.kind === 'available' ? (
+            <p className="wk-bind-secondary-hint">{secondaryHintFor(info.methods)}</p>
+          ) : null}
+          <div className="wk-bind-method-list">
+            {info.methods.map((m: BindMethod) => (
+              <Button
+                key={m}
+                // create 可用时 verify 降为次要 (light theme), 没 create 时 verify 还是主要.
+                theme={createState.kind === 'available' ? 'light' : 'solid'}
+                type="primary"
+                block
+                size="large"
+                disabled={busy}
+                onClick={() => onSelectMethod(m)}
+              >
+                {m === 'password' ? '使用 Octo 密码验证' : '使用短信验证码验证'}
+              </Button>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+const IdentityBlock = ({ info }: { info: BindInfoResp }) => {
+  return (
+    <div className="wk-bind-identity">
+      <div className="wk-bind-identity-row">
+        <span className="wk-bind-identity-label">SSO 身份</span>
+        <span>{info.name || '—'}</span>
+      </div>
+      {info.masked_email ? (
+        <div className="wk-bind-identity-row">
+          <span className="wk-bind-identity-label">邮箱</span>
+          <span>{info.masked_email}</span>
+        </div>
+      ) : null}
+      {info.masked_phone ? (
+        <div className="wk-bind-identity-row">
+          <span className="wk-bind-identity-label">手机</span>
+          <span>{info.masked_phone}</span>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default BindPage

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
+import { WKApp } from '@octo/base'
 import {
   clearPendingOidcLogin,
   fetchHttpClient,
@@ -258,6 +259,60 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     }
   }
 
+  // PR #72 round-4 (Jerry-Xin): bind success must honour any pendingInviteCode
+  // set by LoginVM.didMount when the user arrived via /login?invite=X. The
+  // legacy LoginVM.loginSuccess routes that through WKApp.endpoints.callOnLogin
+  // → AppLayout.onLogin which handles /space/invite + /space/join + cleanup +
+  // navigation. We can't just call callOnLogin from /oidc/bind directly
+  // because AppLayout.onLogin computes basePath off window.location.pathname,
+  // which would send the user back to /oidc/bind — so we replaceState to '/'
+  // first.
+  //
+  // Validation matches LoginVM and AppLayout: pendingInviteCode must look like
+  // a safe slug. Anything else falls through to the plain returnTo navigation.
+  function finalizeBindSuccess(returnTo: string): void {
+    setStage({ kind: 'success' })
+
+    let pendingInvite: string | null = null
+    try {
+      pendingInvite = localStorage.getItem('pendingInviteCode')
+    } catch {
+      /* localStorage unavailable — treat as no invite */
+    }
+
+    if (pendingInvite && /^[a-zA-Z0-9_-]+$/.test(pendingInvite)) {
+      // Hand off to AppLayout.onLogin. It will:
+      //   1. fetch /space/invite/<code>, then /space/join
+      //   2. clear pendingInviteCode on success
+      //   3. compute basePath from location.pathname → goMain
+      // We replaceState pathname to '/' so basePath resolves to '/' instead of
+      // '/oidc/bind' (which would loop the user back to BindPage).
+      try {
+        window.history.replaceState({}, '', '/')
+      } catch {
+        /* noop: SSR / legacy host */
+      }
+      try {
+        WKApp.endpoints.callOnLogin()
+      } catch (e) {
+        console.warn('callOnLogin error suppressed:', e)
+        // Last-resort fallback so the user isn't stranded on the success stage.
+        window.location.replace('/')
+      }
+      return
+    }
+
+    // No invite — keep the original behaviour: short paint window then navigate
+    // to the originally-requested return_to.
+    window.setTimeout(() => {
+      try {
+        window.location.replace(returnTo)
+      } catch {
+        window.location.href = returnTo
+      }
+    }, 200)
+  }
+
   async function runConfirm(info: BindInfoResp): Promise<void> {
     // Read entryRef and validate the invariants *before* setStage so a stale
     // entryRef can't park the user on the confirming loader with no recovery.
@@ -279,16 +334,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
       // 写完登录态后 token 已无效 (后端 single-use consume), 直接清掉 ref.
       entryRef.current = null
-      setStage({ kind: 'success' })
-      // 200ms gives the success state one paint + a brief Toast visibility window
-      // before the full-page navigation tears down the React tree.
-      window.setTimeout(() => {
-        try {
-          window.location.replace(returnTo)
-        } catch {
-          window.location.href = returnTo
-        }
-      }, 200)
+      finalizeBindSuccess(returnTo)
     } catch (err) {
       // All confirm failures are terminal in errorMessages.ts — the confirming
       // loader has no surface to show an inline error, so handleError will
@@ -314,16 +360,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       applyLoginResp(data, 'oidc-bind-create')
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
       entryRef.current = null
-      setStage({ kind: 'success' })
-      // 200ms gives the success state one paint before the navigation kicks in;
-      // mirrors runConfirm.
-      window.setTimeout(() => {
-        try {
-          window.location.replace(returnTo)
-        } catch {
-          window.location.href = returnTo
-        }
-      }, 200)
+      finalizeBindSuccess(returnTo)
     } catch (err) {
       // create failures are deterministic at bindCreateMax=1 — handleError routes
       // to fatal.

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -259,10 +259,16 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
   }
 
   async function runConfirm(info: BindInfoResp): Promise<void> {
-    setStage({ kind: 'confirming', info })
+    // Read entryRef and validate the invariants *before* setStage so a stale
+    // entryRef can't park the user on the confirming loader with no recovery.
+    // PR #72 review yujiawei P2-2.
     const token = entryRef.current?.token
     const returnTo = postLoginReturnTo(entryRef.current?.returnTo)
-    if (!token) return
+    if (!token) {
+      handleError('confirm', new Error('missing bind token'))
+      return
+    }
+    setStage({ kind: 'confirming', info })
     try {
       const resp = await confirmBind(fetchHttpClient, token, apiOpts())
       // login_resp 是 JSON-encoded string, JSON.parse 后与老 OIDC authstatus.result 同 schema.
@@ -292,10 +298,15 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
   }
 
   async function runCreate(info: BindInfoResp): Promise<void> {
-    setStage({ kind: 'creating', info })
+    // See runConfirm: validate before setStage so a stale entryRef can't park
+    // the user on the creating loader. PR #72 review yujiawei P2-2.
     const token = entryRef.current?.token
     const returnTo = postLoginReturnTo(entryRef.current?.returnTo)
-    if (!token) return
+    if (!token) {
+      handleError('create', new Error('missing bind token'))
+      return
+    }
+    setStage({ kind: 'creating', info })
     try {
       const resp = await createBind(fetchHttpClient, token, apiOpts())
       // 与 confirm 同 schema 同 builder, login_resp 直接 parseLoginResp + applyLoginResp.

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
-import { fetchHttpClient } from '../oidc'
+import { fetchHttpClient, OidcBindHttpError } from '../oidc'
 import { clearPendingOidcLogin } from '../oidc'
 import {
   fetchBindInfo,
@@ -192,6 +192,14 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     }
   }
 
+  // 后端 verify_* 返 409 = "session 已 verified 或更高"; 文档 §3.2 把它定为
+  // "用户已经通过了, 重复 verify 被 CAS 拒". 正确响应是直接 advance 到 confirm,
+  // 而不是给用户看 inline error "请继续完成绑定" — 那个文案承诺了"继续", 但
+  // 之前的实现只 setInlineError, 用户点"验证并绑定"又 409, 死循环. PR #72 W2.
+  function isVerifyAlreadyConsumed(err: unknown): boolean {
+    return err instanceof OidcBindHttpError && err.status === 409
+  }
+
   async function onSubmitPassword(): Promise<void> {
     if (stage.kind !== 'verify_password') return
     if (!identifier || !password) {
@@ -208,6 +216,11 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       setPassword('')
       await runConfirm(stage.info)
     } catch (err) {
+      if (isVerifyAlreadyConsumed(err)) {
+        setPassword('')
+        await runConfirm(stage.info)
+        return
+      }
       handleError('verify_password', err)
     } finally {
       setBusy(false)
@@ -216,8 +229,10 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
 
   async function onSubmitOtp(): Promise<void> {
     if (stage.kind !== 'verify_otp') return
-    if (!otp || otp.length < 4) {
-      setInlineError('请输入验证码')
+    // 后端短信验证码长度固定为 6 位 (BindService.VerifyOTPCheck);
+    // input 的 maxLength={6} 已经卡上限, 这里卡下限避免半截 OTP 提交后被 401.
+    if (!otp || otp.length < 6) {
+      setInlineError('请输入 6 位验证码')
       return
     }
     const token = entryRef.current?.token
@@ -229,6 +244,11 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       setOtp('')
       await runConfirm(stage.info)
     } catch (err) {
+      if (isVerifyAlreadyConsumed(err)) {
+        setOtp('')
+        await runConfirm(stage.info)
+        return
+      }
       handleError('verify_otp_check', err)
     } finally {
       setBusy(false)

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -329,7 +329,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       const resp = await confirmBind(fetchHttpClient, token, apiOpts())
       // login_resp 是 JSON-encoded string, JSON.parse 后与老 OIDC authstatus.result 同 schema.
       const data = parseLoginResp(resp.login_resp)
-      // PR #72 round-5: loginProvider 必须落到真实 IdP id, 下游 NavSettingsPanel /
+      // loginProvider 必须落到真实 IdP id, 下游 NavSettingsPanel /
       // realnameVerifyUrl / login.tsx reset-password 都按 id 在 oidcProviders 里
       // find, 写 'oidc-bind' 这种 synthetic 值会让所有 lookup fails closed.
       // 与 legacy login_vm.loginSuccess(pending.providerId) 对齐, 使用 entry.provider,
@@ -363,7 +363,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       const resp = await createBind(fetchHttpClient, token, apiOpts())
       // 与 confirm 同 schema 同 builder, login_resp 直接 parseLoginResp + applyLoginResp.
       const data = parseLoginResp(resp.login_resp)
-      // PR #72 round-5: 同 runConfirm — loginProvider 必须是真实 IdP id, 不是
+      // 同 runConfirm — loginProvider 必须是真实 IdP id, 不是
       // 'oidc-bind-create' 这种 synthetic 标签. 见 runConfirm 上方注释.
       applyLoginResp(data, entryRef.current?.provider || FALLBACK_PROVIDER_ID)
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
-import { fetchHttpClient, OidcBindHttpError } from '../oidc'
-import { clearPendingOidcLogin } from '../oidc'
+import {
+  clearPendingOidcLogin,
+  fetchHttpClient,
+  OidcBindHttpError,
+} from '../oidc'
 import {
   fetchBindInfo,
   verifyBindPassword,
@@ -271,7 +274,8 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       // 写完登录态后 token 已无效 (后端 single-use consume), 直接清掉 ref.
       entryRef.current = null
       setStage({ kind: 'success' })
-      // 避免短暂的 success 闪屏: 给 200ms 让 Toast 看见再跳.
+      // 200ms gives the success state one paint + a brief Toast visibility window
+      // before the full-page navigation tears down the React tree.
       window.setTimeout(() => {
         try {
           window.location.replace(returnTo)
@@ -280,10 +284,10 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
         }
       }, 200)
     } catch (err) {
+      // All confirm failures are terminal in errorMessages.ts — the confirming
+      // loader has no surface to show an inline error, so handleError will
+      // route to the fatal stage with a "返回登录" CTA.
       handleError('confirm', err)
-      // confirm 失败要回退到能让用户再点 confirm 的 stage; 但 verify 状态后端是
-      // verified, 重新走 verify 会返 409. 最稳是直接落 fatal 让用户重走 OIDC.
-      // 唯一例外: 429 / 503 — 允许再试 confirm. handleError 已经按 terminal 标识区分.
     }
   }
 
@@ -300,6 +304,8 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
       entryRef.current = null
       setStage({ kind: 'success' })
+      // 200ms gives the success state one paint before the navigation kicks in;
+      // mirrors runConfirm.
       window.setTimeout(() => {
         try {
           window.location.replace(returnTo)
@@ -308,8 +314,8 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
         }
       }, 200)
     } catch (err) {
-      // create 端点的失败几乎全部 terminal (bindCreateMax=1; claims/conflict 都是确定性的).
-      // handleError 按 mapBindError 返回的 terminal 标识自动落 fatal vs inline.
+      // create failures are deterministic at bindCreateMax=1 — handleError routes
+      // to fatal.
       handleError('create', err)
     }
   }

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -15,6 +15,7 @@ import {
   createBind,
   parseBindEntryParams,
   clearBindUrl,
+  FALLBACK_PROVIDER_ID,
   type BindEntryParams,
   type BindInfoResp,
   type BindMethod,
@@ -328,7 +329,12 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       const resp = await confirmBind(fetchHttpClient, token, apiOpts())
       // login_resp 是 JSON-encoded string, JSON.parse 后与老 OIDC authstatus.result 同 schema.
       const data = parseLoginResp(resp.login_resp)
-      applyLoginResp(data, 'oidc-bind')
+      // PR #72 round-5: loginProvider 必须落到真实 IdP id, 下游 NavSettingsPanel /
+      // realnameVerifyUrl / login.tsx reset-password 都按 id 在 oidcProviders 里
+      // find, 写 'oidc-bind' 这种 synthetic 值会让所有 lookup fails closed.
+      // 与 legacy login_vm.loginSuccess(pending.providerId) 对齐, 使用 entry.provider,
+      // 缺失时回退 FALLBACK_PROVIDER_ID — resolveProvider() 在 api 层已是同一语义.
+      applyLoginResp(data, entryRef.current?.provider || FALLBACK_PROVIDER_ID)
       // bind 已经把 login 态写入 loginInfo; 同一 tab 上 /login 的 OidcResumeEffect
       // 若读到旧 pending 会再 poll 一次浪费 1-2s. 清掉避免冗余.
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
@@ -357,7 +363,9 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       const resp = await createBind(fetchHttpClient, token, apiOpts())
       // 与 confirm 同 schema 同 builder, login_resp 直接 parseLoginResp + applyLoginResp.
       const data = parseLoginResp(resp.login_resp)
-      applyLoginResp(data, 'oidc-bind-create')
+      // PR #72 round-5: 同 runConfirm — loginProvider 必须是真实 IdP id, 不是
+      // 'oidc-bind-create' 这种 synthetic 标签. 见 runConfirm 上方注释.
+      applyLoginResp(data, entryRef.current?.provider || FALLBACK_PROVIDER_ID)
       try { clearPendingOidcLogin() } catch { /* sessionStorage 不可用时静默 */ }
       entryRef.current = null
       finalizeBindSuccess(returnTo)

--- a/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
@@ -15,13 +15,31 @@ describe('mapBindError', () => {
     expect(mapBindError('confirm', new OidcBindHttpError(410)).terminal).toBe(true)
   })
 
-  it('flags 503/500 as retryable non-terminal', () => {
+  it('flags 503/500 as retryable non-terminal on interactive endpoints', () => {
     const r5 = mapBindError('verify_password', new OidcBindHttpError(503))
     expect(r5.terminal).toBe(false)
     expect(r5.retryable).toBe(true)
-    const r6 = mapBindError('confirm', new OidcBindHttpError(500))
+    const r6 = mapBindError('verify_otp_check', new OidcBindHttpError(500))
     expect(r6.terminal).toBe(false)
     expect(r6.retryable).toBe(true)
+  })
+
+  // PR #72 review B1: confirm/create loader stages don't render inlineError,
+  // so any post-verify failure must be terminal to avoid stranding the user
+  // on an infinite spinner.
+  it('confirm 500/503/429 are terminal (no recovery from confirming stage)', () => {
+    for (const code of [429, 500, 503]) {
+      const r = mapBindError('confirm', new OidcBindHttpError(code))
+      expect(r.terminal).toBe(true)
+      expect(r.message).toMatch(/重新发起 SSO|绑定失败/)
+    }
+  })
+
+  it('create 500/503 are terminal (consistent with create 429)', () => {
+    for (const code of [500, 503]) {
+      const r = mapBindError('create', new OidcBindHttpError(code))
+      expect(r.terminal).toBe(true)
+    }
   })
 
   it('verify_password 401 is non-terminal with password-specific copy', () => {
@@ -46,8 +64,8 @@ describe('mapBindError', () => {
     expect(r.terminal).toBe(false)
   })
 
-  it('429 is non-terminal across endpoints', () => {
-    for (const ep of ['verify_password', 'verify_otp_send', 'verify_otp_check', 'confirm'] as const) {
+  it('429 is non-terminal on verify_* endpoints (user can retry input)', () => {
+    for (const ep of ['verify_password', 'verify_otp_send', 'verify_otp_check'] as const) {
       expect(mapBindError(ep, new OidcBindHttpError(429)).terminal).toBe(false)
     }
   })
@@ -78,8 +96,4 @@ describe('mapBindError', () => {
     expect(r.terminal).toBe(true)
   })
 
-  it('create 503/500 stays retryable', () => {
-    expect(mapBindError('create', new OidcBindHttpError(503)).retryable).toBe(true)
-    expect(mapBindError('create', new OidcBindHttpError(500)).retryable).toBe(true)
-  })
 })

--- a/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
@@ -3,10 +3,30 @@ import { mapBindError } from '../errorMessages'
 import { OidcBindHttpError } from '../../oidc/http'
 
 describe('mapBindError', () => {
-  it('treats non-Http errors as retryable network failure', () => {
+  it('treats non-Http errors as retryable on interactive endpoints', () => {
     const r = mapBindError('info', new Error('socket reset'))
     expect(r.terminal).toBe(false)
-    expect(r.retryable).toBe(true)
+    // (retryable field removed in round 2 — was set but never read)
+  })
+
+  // PR #72 review round 2 (Jerry-Xin): post-verify endpoints cannot show
+  // inlineError, so even non-HTTP failures (timeout, abort, parseLoginResp
+  // throw, applyLoginResp invariant throw) must terminate the flow.
+  it('treats non-Http errors as terminal on confirm/create endpoints', () => {
+    for (const ep of ['confirm', 'create'] as const) {
+      const r = mapBindError(ep, new Error('timeout'))
+      expect(r.terminal).toBe(true)
+      const r2 = mapBindError(ep, new SyntaxError('Unexpected token'))
+      expect(r2.terminal).toBe(true)
+    }
+  })
+
+  // PR #72 review round 2 (yujiawei): confirm 401 was still non-terminal,
+  // same stuck-spinner failure mode as B1 — reclassify as terminal.
+  it('confirm 401 is terminal (was non-terminal in round 1)', () => {
+    const r = mapBindError('confirm', new OidcBindHttpError(401))
+    expect(r.terminal).toBe(true)
+    expect(r.message).toMatch(/重新发起 SSO/)
   })
 
   it('flags 400/410 as terminal on any endpoint', () => {
@@ -18,10 +38,10 @@ describe('mapBindError', () => {
   it('flags 503/500 as retryable non-terminal on interactive endpoints', () => {
     const r5 = mapBindError('verify_password', new OidcBindHttpError(503))
     expect(r5.terminal).toBe(false)
-    expect(r5.retryable).toBe(true)
+    // retryable removed
     const r6 = mapBindError('verify_otp_check', new OidcBindHttpError(500))
     expect(r6.terminal).toBe(false)
-    expect(r6.retryable).toBe(true)
+    // retryable removed
   })
 
   // PR #72 review B1: confirm/create loader stages don't render inlineError,
@@ -59,10 +79,8 @@ describe('mapBindError', () => {
     expect(r.message).toMatch(/已绑定|SSO/)
   })
 
-  it('confirm 401 (not verified) is non-terminal', () => {
-    const r = mapBindError('confirm', new OidcBindHttpError(401))
-    expect(r.terminal).toBe(false)
-  })
+  // Superseded by the new "confirm 401 is terminal" test above (round 2).
+  // Kept here as a documentation breadcrumb of what the prior contract was.
 
   it('429 is non-terminal on verify_* endpoints (user can retry input)', () => {
     for (const ep of ['verify_password', 'verify_otp_send', 'verify_otp_check'] as const) {

--- a/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/errorMessages.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { mapBindError } from '../errorMessages'
+import { OidcBindHttpError } from '../../oidc/http'
+
+describe('mapBindError', () => {
+  it('treats non-Http errors as retryable network failure', () => {
+    const r = mapBindError('info', new Error('socket reset'))
+    expect(r.terminal).toBe(false)
+    expect(r.retryable).toBe(true)
+  })
+
+  it('flags 400/410 as terminal on any endpoint', () => {
+    expect(mapBindError('info', new OidcBindHttpError(400)).terminal).toBe(true)
+    expect(mapBindError('verify_password', new OidcBindHttpError(410)).terminal).toBe(true)
+    expect(mapBindError('confirm', new OidcBindHttpError(410)).terminal).toBe(true)
+  })
+
+  it('flags 503/500 as retryable non-terminal', () => {
+    const r5 = mapBindError('verify_password', new OidcBindHttpError(503))
+    expect(r5.terminal).toBe(false)
+    expect(r5.retryable).toBe(true)
+    const r6 = mapBindError('confirm', new OidcBindHttpError(500))
+    expect(r6.terminal).toBe(false)
+    expect(r6.retryable).toBe(true)
+  })
+
+  it('verify_password 401 is non-terminal with password-specific copy', () => {
+    const r = mapBindError('verify_password', new OidcBindHttpError(401))
+    expect(r.terminal).toBe(false)
+    expect(r.message).toMatch(/密码/)
+  })
+
+  it('verify_otp_check 401 is non-terminal with otp-specific copy', () => {
+    const r = mapBindError('verify_otp_check', new OidcBindHttpError(401))
+    expect(r.message).toMatch(/验证码/)
+  })
+
+  it('confirm 409 is terminal (identity already bound recovery path)', () => {
+    const r = mapBindError('confirm', new OidcBindHttpError(409))
+    expect(r.terminal).toBe(true)
+    expect(r.message).toMatch(/已绑定|SSO/)
+  })
+
+  it('confirm 401 (not verified) is non-terminal', () => {
+    const r = mapBindError('confirm', new OidcBindHttpError(401))
+    expect(r.terminal).toBe(false)
+  })
+
+  it('429 is non-terminal across endpoints', () => {
+    for (const ep of ['verify_password', 'verify_otp_send', 'verify_otp_check', 'confirm'] as const) {
+      expect(mapBindError(ep, new OidcBindHttpError(429)).terminal).toBe(false)
+    }
+  })
+
+  // ---- /bind/create specific (PR#93) -----------------------------------
+  // bindCreateMax=1: 一次失败 token 即不可用, 所有 create 失败都 terminal.
+
+  it('create 429 is terminal (bindCreateMax=1)', () => {
+    const r = mapBindError('create', new OidcBindHttpError(429))
+    expect(r.terminal).toBe(true)
+    expect(r.message).toMatch(/重新发起 SSO/)
+  })
+
+  it('create 409 (any conflict variant) is terminal with manual-resolve hint', () => {
+    const r = mapBindError('create', new OidcBindHttpError(409, 'account conflict needs manual resolution'))
+    expect(r.terminal).toBe(true)
+    expect(r.message).toMatch(/账号信息冲突|联系管理员/)
+  })
+
+  it('create 422 (claims incomplete) is terminal', () => {
+    const r = mapBindError('create', new OidcBindHttpError(422))
+    expect(r.terminal).toBe(true)
+    expect(r.message).toMatch(/信息不完整|无法自助创建/)
+  })
+
+  it('create 401 (issuer removed mid-flight) is terminal', () => {
+    const r = mapBindError('create', new OidcBindHttpError(401))
+    expect(r.terminal).toBe(true)
+  })
+
+  it('create 503/500 stays retryable', () => {
+    expect(mapBindError('create', new OidcBindHttpError(503)).retryable).toBe(true)
+    expect(mapBindError('create', new OidcBindHttpError(500)).retryable).toBe(true)
+  })
+})

--- a/packages/dmworklogin/src/bind/bind.css
+++ b/packages/dmworklogin/src/bind/bind.css
@@ -1,0 +1,241 @@
+/* OIDC 自助绑定页面 — 单卡片居中布局, 风格对齐 login 的浅灰背景但不复用 split-screen.
+   bind 页是一次性流程, 视觉上需要尽量简洁、把用户注意力锁在表单上, 所以不用左侧品牌墙. */
+
+.wk-bind {
+    display: flex;
+    min-height: 100vh;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow-y: auto;
+    justify-content: center;
+    align-items: center;
+    padding: 24px;
+    box-sizing: border-box;
+    background-color: var(--semi-color-bg-1, #f5f6fa);
+
+    /* 复用登录页的品牌色 token, 让 Semi primary 渲成黑色而不是默认蓝.
+       hover / active 颜色与 login.css 一致 (color-mix 已 fallback). */
+    --semi-color-primary: var(--wk-color-theme, #1C1C23);
+    --semi-color-primary-hover: #2A2A33;
+    --semi-color-primary-hover: color-mix(in srgb, var(--wk-color-theme, #1C1C23) 85%, black);
+    --semi-color-primary-active: #151519;
+    --semi-color-primary-active: color-mix(in srgb, var(--wk-color-theme, #1C1C23) 75%, black);
+}
+
+.wk-bind-card {
+    width: 100%;
+    max-width: 440px;
+    background: var(--semi-color-bg-0, #fff);
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+    padding: 32px 36px;
+    box-sizing: border-box;
+}
+
+.wk-bind-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--semi-color-text-0, #1C1C23);
+    margin: 0 0 8px;
+}
+
+.wk-bind-subtitle {
+    font-size: 14px;
+    color: var(--semi-color-text-2, #6B7280);
+    margin: 0 0 24px;
+    line-height: 1.5;
+}
+
+.wk-bind-identity {
+    background: var(--semi-color-fill-0, #F5F6FA);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    font-size: 13px;
+    color: var(--semi-color-text-1, #4B5563);
+}
+
+.wk-bind-identity-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+}
+
+.wk-bind-identity-row + .wk-bind-identity-row {
+    border-top: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.06));
+}
+
+.wk-bind-identity-label {
+    color: var(--semi-color-text-2, #6B7280);
+}
+
+.wk-bind-method-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+/* "或" 分隔条, 把主操作 (Create) 与次操作 (Verify) 视觉切开. 中间一段灰线
+   + 短文字, 比单纯空白更明确"这是另一条路径"而不是"重复选项". */
+.wk-bind-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 8px 0 12px;
+    color: var(--semi-color-text-2, #6B7280);
+    font-size: 12px;
+    line-height: 1;
+}
+.wk-bind-divider::before,
+.wk-bind-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--semi-color-border, rgba(0, 0, 0, 0.08));
+}
+
+.wk-bind-secondary-hint {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--semi-color-text-2, #6B7280);
+    text-align: center;
+}
+
+/* 创建/绑定中的过场 loader. 之前 textAlign center + padding 20px 在大卡片里
+   显得 spinner 飘在上方 ("飞了"). 给一个明确容器: 整块垂直居中, spinner 与
+   文字间距固定, 卡片高度感保持. */
+.wk-bind-loader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 32px 8px;
+    min-height: 160px;
+    text-align: center;
+}
+
+.wk-bind-loader-title {
+    margin-top: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--semi-color-text-0, #1C1C23);
+}
+
+.wk-bind-loader-sub {
+    font-size: 12px;
+    color: var(--semi-color-text-2, #6B7280);
+    line-height: 1.5;
+}
+
+.wk-bind-field {
+    margin-bottom: 16px;
+}
+
+.wk-bind-field label {
+    display: block;
+    font-size: 13px;
+    color: var(--semi-color-text-1, #4B5563);
+    margin-bottom: 6px;
+}
+
+.wk-bind-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.wk-bind-actions > * {
+    flex: 1;
+}
+
+/* 错误提示按严重程度分层:
+   - soft: 401/429/输入错 — 用户可改后重试; 用暖橙色, 视觉重量低
+   - hard: 400/410/409 等 fatal — 必须重走 OIDC; 用 AA 合规深红
+   左 3px 色条强化"这是一段提示而不是装饰", 同时保持 padding-left 给文字呼吸. */
+.wk-bind-error {
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 16px;
+    font-size: 13px;
+    line-height: 1.5;
+    border-left: 3px solid;
+}
+
+.wk-bind-error[data-severity="soft"] {
+    background: #FFF7ED;
+    color: #9A3412;        /* AA 8.0:1 on #FFF7ED */
+    border-left-color: #F97316;
+}
+
+.wk-bind-error[data-severity="hard"] {
+    background: #FEF2F2;
+    color: #991B1B;        /* AA 7.5:1 on #FEF2F2 — 比之前 #DC2626/#FEE2E2 (4.0:1) 通过 */
+    border-left-color: #DC2626;
+}
+
+/* 兼容老调用 (未来若漏写 data-severity 不至于完全无样式) */
+.wk-bind-error:not([data-severity]) {
+    background: #FEF2F2;
+    color: #991B1B;
+    border-left-color: #DC2626;
+}
+
+.wk-bind-footer {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.06));
+    font-size: 12px;
+    color: var(--semi-color-text-2, #6B7280);
+    text-align: center;
+}
+
+.wk-bind-footer a {
+    color: var(--semi-color-link, #3B82F6);
+    text-decoration: none;
+}
+
+.wk-bind-otp-hint {
+    font-size: 12px;
+    color: var(--semi-color-text-2, #6B7280);
+    margin-top: 6px;
+}
+
+/* ============================================================
+   主按钮 hover / active / focus 三态
+   ============================================================
+   黑按钮"按了没"的感知问题: 单纯改色觉察弱; 叠 transform + shadow
+   形成层次. transform 100ms 比 color 160ms 短, 先动再亮, 节律自然.
+   focus-visible 用紫色描边复用登录页品牌渐变端, 键盘可达. */
+.wk-bind .semi-button-primary {
+    transition:
+        background-color 160ms ease,
+        box-shadow 160ms ease,
+        transform 100ms ease;
+}
+.wk-bind .semi-button-primary:hover:not(:disabled):not(.semi-button-loading) {
+    box-shadow: 0 4px 12px rgba(28, 28, 35, 0.18);
+    transform: translateY(-1px);
+}
+.wk-bind .semi-button-primary:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.10);
+}
+.wk-bind .semi-button-primary:focus-visible {
+    outline: 2px solid #7A5CFF;
+    outline-offset: 2px;
+}
+
+/* 次按钮 (返回 / 默认 theme) hover: 仅做边框加深 + 微抬, 不抢主按钮戏 */
+.wk-bind .semi-button:not(.semi-button-primary) {
+    transition: border-color 160ms ease, background-color 160ms ease, transform 100ms ease;
+}
+.wk-bind .semi-button:not(.semi-button-primary):hover:not(:disabled) {
+    transform: translateY(-1px);
+}
+.wk-bind .semi-button:not(.semi-button-primary):active:not(:disabled) {
+    transform: translateY(0);
+}

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -26,6 +26,21 @@ export default class BindModule implements IModule {
     // documented flow.
     if (typeof window !== 'undefined' && window.location.pathname === '/oidc/bind') {
       bindInitialSearch = window.location.search
+      // Scrub the live URL *synchronously* here, before RouteManager's
+      // pageshow handler runs window.history.pushState to add the sid URL on
+      // top. If we wait for BindPage's useEffect, the current entry is
+      // already the sid URL (see Route.tsx push()), and replaceState there
+      // leaves the original `?token=...` entry behind in the Back stack —
+      // pressing Back exposes the bind token via address bar / referrer.
+      // The snapshot above keeps the params available to BindPage via prop,
+      // so wiping window.location.search is safe.
+      try {
+        window.history.replaceState({}, '', window.location.pathname)
+      } catch {
+        /* SSR / legacy host without history API — clearBindUrl in BindPage is
+           still defense-in-depth for the current entry, even if it can't fix
+           the back-stack leak. */
+      }
     }
     WKApp.route.register('/oidc/bind', (): JSX.Element => {
       return <BindPage initialSearch={bindInitialSearch} />

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -16,6 +16,14 @@ export default class BindModule implements IModule {
     return 'BindModule'
   }
   init(): void {
+    // Assumption (PR #72 review yujiawei P2-3): the user arrives at /oidc/bind
+    // via the backend's full-page 302 from the OIDC callback, so init() always
+    // runs while window.location.search still has the bind params. If a future
+    // path ever routes to /oidc/bind via SPA navigation (no full reload), init
+    // won't fire again and the route factory will hand BindPage an empty
+    // snapshot — falling cleanly to the "链接无效" fatal stage rather than
+    // silently picking up stale params. Acceptable trade-off given the
+    // documented flow.
     if (typeof window !== 'undefined' && window.location.pathname === '/oidc/bind') {
       bindInitialSearch = window.location.search
     }

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { WKApp, IModule } from '@octo/base'
+import BindPage from './BindPage'
+
+// 在 module init 时 (startup 同步阶段, 早于 RouteManager 的 pageshow handler)
+// 抓住 location.search 快照. RouteManager 的 pageshow 监听器会 push 一个带
+// sid= 的新 URL, 把 bind 入口参数 (token / authcode / return_to / provider)
+// 一起冲掉; BindPage 再去读 window.location.search 就拿不到了.
+//
+// 这个 snapshot 在 BindModule.init() 调用瞬间 capture, 然后通过 prop 注入,
+// 比 useEffect 里读 window.location.search 更早, 也更确定.
+let bindInitialSearch = ''
+
+export default class BindModule implements IModule {
+  id(): string {
+    return 'BindModule'
+  }
+  init(): void {
+    if (typeof window !== 'undefined' && window.location.pathname === '/oidc/bind') {
+      bindInitialSearch = window.location.search
+    }
+    WKApp.route.register('/oidc/bind', (): JSX.Element => {
+      return <BindPage initialSearch={bindInitialSearch} />
+    })
+  }
+}

--- a/packages/dmworklogin/src/bind/errorMessages.ts
+++ b/packages/dmworklogin/src/bind/errorMessages.ts
@@ -11,8 +11,6 @@ export type BindEndpoint = 'info' | 'verify_password' | 'verify_otp_send' | 'ver
 export interface BindErrorDisplay {
   message: string
   terminal: boolean
-  // 503 / 5xx 时给重试按钮
-  retryable?: boolean
 }
 
 const DEFAULT: BindErrorDisplay = {
@@ -20,13 +18,26 @@ const DEFAULT: BindErrorDisplay = {
   terminal: false,
 }
 
+// confirm / create are post-verify endpoints: the BindPage loader stage cannot
+// surface inlineError. Any failure there (HTTP or non-HTTP — network timeout,
+// fetch abort, parseLoginResp JSON parse, applyLoginResp invariant throw) MUST
+// be terminal to avoid stranding the user on the spinner. PR #72 review round 2.
+function isPostVerifyEndpoint(endpoint: BindEndpoint): boolean {
+  return endpoint === 'confirm' || endpoint === 'create'
+}
+
 export function mapBindError(
   endpoint: BindEndpoint,
   err: unknown,
 ): BindErrorDisplay {
   if (!(err instanceof OidcBindHttpError)) {
-    // 网络层 / 反序列化失败. 不区分端点统一兜底.
-    return { message: '网络异常，请检查后重试', terminal: false, retryable: true }
+    // Non-HTTP failure (network/abort/parse/validate). Interactive endpoints
+    // can keep this retryable since their stage renders inlineError; post-verify
+    // endpoints must terminate so the user gets a "返回登录" CTA.
+    if (isPostVerifyEndpoint(endpoint)) {
+      return { message: '绑定失败，请重新发起 SSO 登录', terminal: true }
+    }
+    return { message: '网络异常，请检查后重试', terminal: false }
   }
   const s = err.status
 
@@ -44,8 +55,8 @@ export function mapBindError(
     || endpoint === 'verify_otp_send' || endpoint === 'verify_otp_check'
   if (fiveXX && isInteractive) {
     return s === 503
-      ? { message: '绑定服务暂不可用，请稍后重试', terminal: false, retryable: true }
-      : { message: '服务异常，请稍后重试', terminal: false, retryable: true }
+      ? { message: '绑定服务暂不可用，请稍后重试', terminal: false }
+      : { message: '服务异常，请稍后重试', terminal: false }
   }
 
   // 端点级语义
@@ -67,16 +78,15 @@ export function mapBindError(
       if (s === 429) return { message: '尝试次数过多，请稍后再试', terminal: false }
       return DEFAULT
     case 'confirm':
-      if (s === 401) return { message: '请先完成身份验证', terminal: false }
-      // 409 在 confirm 端点是 "identity 已绑定" — 实际是恢复路径成功的信号,
-      // 此时该用户的 OIDC autolink 已经能命中, 引导回登录即可.
+      // 409 在 confirm 端点是 "identity 已绑定" — 恢复路径成功的信号, OIDC
+      // autolink 下次会命中, 引导回登录即可.
       if (s === 409) return { message: '该账号已绑定，请返回登录页重新使用 SSO 登录', terminal: true }
-      // confirm 阶段的 429/500/503 都是 post-verify 失败: token 已被 CAS 推到
-      // consuming 中间态, BindPage 的 `confirming` loader 也不会渲染 inlineError.
-      // 必须 terminal 让用户重走 OIDC — PR #72 review B1.
+      // confirm 端点本质 post-verify: BindPage 的 `confirming` loader 不渲染
+      // inlineError. 所有失败 (401 / 429 / 5xx / 未识别) 一律 terminal 让用户
+      // 重走 OIDC — PR #72 review B1 + round 2.
+      if (s === 401) return { message: '请先完成身份验证，请重新发起 SSO 登录', terminal: true }
       if (s === 429) return { message: '尝试次数过多，请重新发起 SSO 登录', terminal: true }
       if (s === 500 || s === 503) return { message: '绑定失败，请重新发起 SSO 登录', terminal: true }
-      // 任何未识别状态也按 terminal — confirming loader 不能吃错误.
       return { message: '绑定失败，请重新发起 SSO 登录', terminal: true }
     case 'create':
       // PR#93: bindCreateMax = 1, 一次失败 token 即不可重用 → 429 必然 terminal.

--- a/packages/dmworklogin/src/bind/errorMessages.ts
+++ b/packages/dmworklogin/src/bind/errorMessages.ts
@@ -33,11 +33,20 @@ export function mapBindError(
   // 跨端点共通: 400/410 一律 terminal — token 没救了.
   if (s === 400) return { message: '链接已失效，请重新发起登录', terminal: true }
   if (s === 410) return { message: '链接已过期，请重新发起登录', terminal: true }
-  if (s === 503) return { message: '绑定服务暂不可用，请稍后重试', terminal: false, retryable: true }
-  if (s === 500) return { message: '服务异常，请稍后重试', terminal: false, retryable: true }
   // 422 仅出现在 /bind/create: SSO claims 缺 verified email/phone — 后端无法构造账号.
   // 是 terminal: 这条 bind_token 上不会"突然有"邮箱/手机, 让用户走联系管理员路径.
   if (s === 422) return { message: 'SSO 身份信息不完整（缺邮箱或手机），无法自助创建账号', terminal: true }
+  // 500/503 不在这里 early-return: 交互端点 (info/verify_*) 还能重试, post-verify
+  // 端点 (confirm/create) 的 loader stage 不渲染 inlineError 必须 terminal —
+  // 见 PR #72 review B1. 下面 switch 按 endpoint 分别处理.
+  const fiveXX = s === 500 || s === 503
+  const isInteractive = endpoint === 'info' || endpoint === 'verify_password'
+    || endpoint === 'verify_otp_send' || endpoint === 'verify_otp_check'
+  if (fiveXX && isInteractive) {
+    return s === 503
+      ? { message: '绑定服务暂不可用，请稍后重试', terminal: false, retryable: true }
+      : { message: '服务异常，请稍后重试', terminal: false, retryable: true }
+  }
 
   // 端点级语义
   switch (endpoint) {
@@ -62,19 +71,23 @@ export function mapBindError(
       // 409 在 confirm 端点是 "identity 已绑定" — 实际是恢复路径成功的信号,
       // 此时该用户的 OIDC autolink 已经能命中, 引导回登录即可.
       if (s === 409) return { message: '该账号已绑定，请返回登录页重新使用 SSO 登录', terminal: true }
-      if (s === 429) return { message: '尝试次数过多，请稍后再试', terminal: false }
-      return DEFAULT
+      // confirm 阶段的 429/500/503 都是 post-verify 失败: token 已被 CAS 推到
+      // consuming 中间态, BindPage 的 `confirming` loader 也不会渲染 inlineError.
+      // 必须 terminal 让用户重走 OIDC — PR #72 review B1.
+      if (s === 429) return { message: '尝试次数过多，请重新发起 SSO 登录', terminal: true }
+      if (s === 500 || s === 503) return { message: '绑定失败，请重新发起 SSO 登录', terminal: true }
+      // 任何未识别状态也按 terminal — confirming loader 不能吃错误.
+      return { message: '绑定失败，请重新发起 SSO 登录', terminal: true }
     case 'create':
       // PR#93: bindCreateMax = 1, 一次失败 token 即不可重用 → 429 必然 terminal.
       if (s === 429) return { message: '已尝试创建账号，请重新发起 SSO 登录', terminal: true }
-      // 409 有两种 sentinel:
-      //   ErrBindStatusConflict — token 已过 issued (并发 verify/create 占用了)
-      //   ErrBindAlreadyBound — (issuer,sub) 唯一键撞了, identity 已存在
-      //   ErrBindCreateConflictNeedManual — claims 命中多个 dmwork 账号, 不能自助创建
-      // 三个对用户的下一步都不同, 但本期统一引导回登录 + 提示联系管理员的 fallback.
-      // 后端 msg 字段会给出区分, 但 UI 不读 msg (反枚举原则), 这里 terminal=true 即可.
+      // 409 有三种 sentinel (ErrBindStatusConflict / ErrBindAlreadyBound /
+      // ErrBindCreateConflictNeedManual), 用户下一步都是回登录, 反枚举原则下
+      // UI 不区分 msg 内容, 一律 terminal.
       if (s === 409) return { message: '账号信息冲突，请联系管理员或返回登录页重试', terminal: true }
       if (s === 401) return { message: '当前 SSO 身份无创建权限', terminal: true }
-      return DEFAULT
+      // create 的 500/503/未识别: 同 confirm 推理, terminal 防 spinner 死锁.
+      if (s === 500 || s === 503) return { message: '创建失败，请重新发起 SSO 登录', terminal: true }
+      return { message: '创建失败，请重新发起 SSO 登录', terminal: true }
   }
 }

--- a/packages/dmworklogin/src/bind/errorMessages.ts
+++ b/packages/dmworklogin/src/bind/errorMessages.ts
@@ -1,0 +1,80 @@
+import { OidcBindHttpError } from '../oidc/http'
+
+// 错误码 → 用户文案映射. 文档表格 §3.1-§3.5 把每个端点的 400/401/409/410/429/500/503
+// 都列了, 这里按端点上下文给出更具体的提示, 而不是一刀切.
+//
+// terminal=true 表示该错误不可在 bind 流程内恢复, UI 必须给"重新走 OIDC 登录"出口;
+// terminal=false 表示用户改输入后可重试.
+
+export type BindEndpoint = 'info' | 'verify_password' | 'verify_otp_send' | 'verify_otp_check' | 'confirm' | 'create'
+
+export interface BindErrorDisplay {
+  message: string
+  terminal: boolean
+  // 503 / 5xx 时给重试按钮
+  retryable?: boolean
+}
+
+const DEFAULT: BindErrorDisplay = {
+  message: '操作失败，请重试',
+  terminal: false,
+}
+
+export function mapBindError(
+  endpoint: BindEndpoint,
+  err: unknown,
+): BindErrorDisplay {
+  if (!(err instanceof OidcBindHttpError)) {
+    // 网络层 / 反序列化失败. 不区分端点统一兜底.
+    return { message: '网络异常，请检查后重试', terminal: false, retryable: true }
+  }
+  const s = err.status
+
+  // 跨端点共通: 400/410 一律 terminal — token 没救了.
+  if (s === 400) return { message: '链接已失效，请重新发起登录', terminal: true }
+  if (s === 410) return { message: '链接已过期，请重新发起登录', terminal: true }
+  if (s === 503) return { message: '绑定服务暂不可用，请稍后重试', terminal: false, retryable: true }
+  if (s === 500) return { message: '服务异常，请稍后重试', terminal: false, retryable: true }
+  // 422 仅出现在 /bind/create: SSO claims 缺 verified email/phone — 后端无法构造账号.
+  // 是 terminal: 这条 bind_token 上不会"突然有"邮箱/手机, 让用户走联系管理员路径.
+  if (s === 422) return { message: 'SSO 身份信息不完整（缺邮箱或手机），无法自助创建账号', terminal: true }
+
+  // 端点级语义
+  switch (endpoint) {
+    case 'info':
+      return DEFAULT
+    case 'verify_password':
+      if (s === 401) return { message: '用户名或密码错误', terminal: false }
+      if (s === 409) return { message: '验证已通过，请继续完成绑定', terminal: false }
+      if (s === 429) return { message: '尝试次数过多，请稍后再试', terminal: false }
+      return DEFAULT
+    case 'verify_otp_send':
+      if (s === 401) return { message: '无法发送验证码，请尝试其他验证方式', terminal: false }
+      if (s === 429) return { message: '发送过于频繁，请稍后再试', terminal: false }
+      return DEFAULT
+    case 'verify_otp_check':
+      if (s === 401) return { message: '验证码错误或已过期', terminal: false }
+      if (s === 409) return { message: '验证已通过，请继续完成绑定', terminal: false }
+      if (s === 429) return { message: '尝试次数过多，请稍后再试', terminal: false }
+      return DEFAULT
+    case 'confirm':
+      if (s === 401) return { message: '请先完成身份验证', terminal: false }
+      // 409 在 confirm 端点是 "identity 已绑定" — 实际是恢复路径成功的信号,
+      // 此时该用户的 OIDC autolink 已经能命中, 引导回登录即可.
+      if (s === 409) return { message: '该账号已绑定，请返回登录页重新使用 SSO 登录', terminal: true }
+      if (s === 429) return { message: '尝试次数过多，请稍后再试', terminal: false }
+      return DEFAULT
+    case 'create':
+      // PR#93: bindCreateMax = 1, 一次失败 token 即不可重用 → 429 必然 terminal.
+      if (s === 429) return { message: '已尝试创建账号，请重新发起 SSO 登录', terminal: true }
+      // 409 有两种 sentinel:
+      //   ErrBindStatusConflict — token 已过 issued (并发 verify/create 占用了)
+      //   ErrBindAlreadyBound — (issuer,sub) 唯一键撞了, identity 已存在
+      //   ErrBindCreateConflictNeedManual — claims 命中多个 dmwork 账号, 不能自助创建
+      // 三个对用户的下一步都不同, 但本期统一引导回登录 + 提示联系管理员的 fallback.
+      // 后端 msg 字段会给出区分, 但 UI 不读 msg (反枚举原则), 这里 terminal=true 即可.
+      if (s === 409) return { message: '账号信息冲突，请联系管理员或返回登录页重试', terminal: true }
+      if (s === 401) return { message: '当前 SSO 身份无创建权限', terminal: true }
+      return DEFAULT
+  }
+}

--- a/packages/dmworklogin/src/index.tsx
+++ b/packages/dmworklogin/src/index.tsx
@@ -1,1 +1,2 @@
-export { default as LoginModule } from "./module" 
+export { default as LoginModule } from "./module"
+export { default as BindModule } from "./bind/bindModule"

--- a/packages/dmworklogin/src/login.css
+++ b/packages/dmworklogin/src/login.css
@@ -239,7 +239,7 @@
 
 .wk-login-content {
     width: 100%;
-    max-width: 360px;
+    max-width: 400px;
 }
 
 /* ---- Logo (inside form panel, mobile fallback) ---- */
@@ -259,17 +259,18 @@
 /* ---- Slogan / panel title ---- */
 .wk-login-content-slogan {
     color: var(--semi-color-text-0, #1a1a2e);
-    font-size: 26px;
+    font-size: 30px;
     font-weight: 700;
-    line-height: 1.3;
-    margin-bottom: 8px;
+    line-height: 1.25;
+    margin-bottom: 10px;
     text-align: left;
+    letter-spacing: -0.01em;
 }
 
 .wk-login-content-slogan-sub {
     color: var(--semi-color-text-2, #8a8fa8);
     font-size: 14px;
-    margin-bottom: 32px;
+    margin-bottom: 28px;
     text-align: left;
 }
 
@@ -937,17 +938,59 @@
     color: #fff;
 }
 
-.wk-login-content-sso-helper {
-    margin-top: 8px;
+/* 主按钮下方注释行: 行为 + IdP 信任锚单行展示, 用 · 分隔.
+   单行密度比两行小灰字叠放更清爽; trust 段单独可 hover 出 tooltip. */
+.wk-login-content-sso-meta {
+    margin-top: 10px;
     text-align: center;
     color: rgba(0, 0, 0, 0.45);
     font-size: 12px;
-    line-height: 1.5;
+    line-height: 1.6;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+.wk-login-content-sso-meta-sep {
+    color: rgba(0, 0, 0, 0.2);
+}
+.wk-login-content-sso-trust {
+    color: rgba(0, 0, 0, 0.45);
+    cursor: help;
+    user-select: none;
+    border-bottom: 1px dotted rgba(0, 0, 0, 0.18);
+    padding-bottom: 1px;
+    transition: color 120ms ease, border-color 120ms ease;
+}
+.wk-login-content-sso-trust:hover {
+    color: rgba(0, 0, 0, 0.75);
+    border-bottom-color: rgba(0, 0, 0, 0.45);
+}
+
+/* 默认折叠态: 单行小字链接, 紧贴信任锚下方, 不被下载按钮夹在中间 (P1 反馈).
+   主按钮 → 引导小字 → 信任锚 → "使用密码登录" → 下载客户端, 自上而下视觉降权. */
+.wk-login-content-legacy-toggle {
+    margin: 16px 0 0;
+    text-align: center;
+    font-size: 13px;
+    color: rgba(0, 0, 0, 0.55);
+}
+.wk-login-content-legacy-toggle a {
+    color: rgba(0, 0, 0, 0.7);
+    cursor: pointer;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+    padding-bottom: 1px;
+    transition: color 120ms ease, border-color 120ms ease;
+}
+.wk-login-content-legacy-toggle a:hover {
+    color: rgba(0, 0, 0, 0.95);
+    border-color: rgba(0, 0, 0, 0.4);
 }
 
 .wk-login-content-legacy-divider {
     position: relative;
-    margin: 40px 0 20px;
+    margin: 32px 0 20px;
     text-align: center;
     color: rgba(0, 0, 0, 0.4);
     font-size: 13px;

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -1,6 +1,7 @@
 import React, { Component, useState, useEffect, useRef } from "react";
 import { Button, Spin, Toast } from '@douyinfe/semi-ui';
-import { IconLock } from '@douyinfe/semi-icons';
+// 不引入特定渠道 icon (Mail / Phone 都不准确, Aegis 同时支持邮箱和手机号).
+// 主按钮纯文字, 避免锁定到任意一种登录方式让用户产生 "我没邮箱不能登" 的误判.
 import './login.css'
 import { QRCodeSVG } from 'qrcode.react';
 import { WKApp, Provider } from "@octo/base"
@@ -36,7 +37,15 @@ const OidcResumeEffect: React.FC<{ vm: LoginVM }> = ({ vm }) => {
         })()
         return () => {
             unmounted = true
-            vm.cancelOidcLogin()
+            // 不在 cleanup 里调 vm.cancelOidcLogin(): React 18 StrictMode 在 dev
+            // 下会 mount → cleanup → mount, 这里清掉 sessionStorage 的 pending +
+            // abort 会让第二次 mount 拿不到 pending, 整个 SSO 落地直接哑火.
+            //
+            // 真正需要取消的两条路径都被保留:
+            //   1) 用户点 OidcResumingOverlay 的"取消"按钮 → 直接调 cancelOidcLogin
+            //   2) 用户离开 /login (真正的 unmount, 比如关页面/导航走) → 浏览器
+            //      会自动中断 in-flight fetch, JS 上下文销毁, poll 自然停
+            // 5min TTL 是兜底, 不会无限循环.
         }
     }, [vm])
     return null
@@ -61,6 +70,92 @@ const OidcResumingOverlay: React.FC<{ vm: LoginVM }> = ({ vm }) => {
     )
 }
 
+
+// 本地密码登录区域. SSO 启用时这一段默认折叠 (P0 反馈): 外部用户大多
+// 没有 Octo 本地账号, 默认显示 SSO 主按钮 + 一行"使用密码登录"链接, 比
+// 把表单常态展开干净.
+//
+// 触发自动展开的两种情况:
+//   1) 用户主动点击 "使用密码登录" 链接
+//   2) 用户尝试登录失败 (vm.loginAttemptFailed) — 此时多半已经把账号密码
+//      填进去, 不能在失败一刻反过来把表单收起
+//
+// 折叠/展开切换是纯 UI 状态, 与 LoginVM 业务无关, 用本地 useState 持有.
+const LegacyPasswordSection: React.FC<{
+    vm: LoginVM
+    startSsoLogin: () => void
+    handleLogin: () => void
+}> = ({ vm, startSsoLogin, handleLogin }) => {
+    const [expanded, setExpanded] = useState(false)
+    const open = expanded || vm.loginAttemptFailed
+
+    if (!open) {
+        return (
+            <div className="wk-login-content-legacy-toggle">
+                <a onClick={() => setExpanded(true)}>使用密码登录</a>
+            </div>
+        )
+    }
+    return (
+        <>
+            <div className="wk-login-content-legacy-divider">
+                <span>或使用密码登录</span>
+            </div>
+            <div className="wk-login-content-legacy-form">
+                <input
+                    type="text"
+                    name="username"
+                    autoComplete="username"
+                    placeholder="邮箱"
+                    onChange={(v) => { vm.username = v.target.value }}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}
+                />
+                <input
+                    type="password"
+                    name="password"
+                    autoComplete="current-password"
+                    placeholder="密码"
+                    onChange={(v) => { vm.password = v.target.value }}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}
+                />
+                <div className="wk-login-content-form-buttons">
+                    <Button
+                        loading={vm.loginLoading}
+                        className="wk-login-content-form-ok"
+                        type="primary"
+                        theme="solid"
+                        onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
+                        onClick={handleLogin}
+                    >
+                        登录
+                    </Button>
+                </div>
+                {vm.loginAttemptFailed && (
+                    <div className="wk-login-content-form-error-cta">
+                        登录不上或还是新用户？请
+                        <a onClick={(e) => { e.preventDefault(); startSsoLogin() }}>
+                            登录 / 注册
+                        </a>
+                    </div>
+                )}
+                <div className="wk-login-content-form-others">
+                    <div
+                        className="wk-login-content-form-scanlogin"
+                        onClick={() => { vm.loginType = LoginType.qrcode }}
+                    >
+                        扫码登录
+                    </div>
+                    <div
+                        className="wk-login-content-form-switch"
+                        onClick={() => { vm.loginType = LoginType.forgetPassword }}
+                    >
+                        忘记密码
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}
 
 // Android APK 下载按钮：动态从接口获取最新下载链接
 const AndroidDownloadButton: React.FC = () => {
@@ -261,27 +356,8 @@ class Login extends Component<any, LoginState> {
                             连接人与 AI，让协作更高效。<br />
                             支持 Web、Mac、Windows、Linux 全平台。
                         </div>
-                        <div className="wk-login-brand-features">
-                            <div className="wk-login-brand-feature">
-                                <div className="wk-login-brand-feature-icon">
-                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.9)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><path d="M12 8v4l3 3" /></svg>
-                                </div>
-                                <div className="wk-login-brand-feature-text">内置 AI，智能回复与自动化</div>
-                            </div>
-                            <div className="wk-login-brand-feature">
-                                <div className="wk-login-brand-feature-icon">
-                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.9)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
-                                </div>
-                                <div className="wk-login-brand-feature-text">端到端加密，数据安全可控</div>
-                            </div>
-                            <div className="wk-login-brand-feature">
-                                <div className="wk-login-brand-feature-icon">
-                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.9)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
-                                </div>
-                                <div className="wk-login-brand-feature-text">实时消息，毫秒级响应</div>
-                            </div>
-                        </div>
-
+                        {/* 3 个功能点已下线 (P1 反馈): 登录页不是营销页, 把 hero 留给左侧
+                            chat 卡片预览即可. */}
                     </div>{/* end brand-inner */}
 
                     {/* Chat bubble decoration - absolute bottom */}
@@ -330,13 +406,18 @@ class Login extends Component<any, LoginState> {
                         )}
                         <div className="wk-login-content-phonelogin" style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}>
                             <div className="wk-login-content-slogan">欢迎回来</div>
+                            {/* hero 到 CTA 之间一行过渡. SSO 启用时点明渠道 (手机号或邮箱都行),
+                                避免用户误以为只能用邮箱; 与按钮 "登录 / 注册" 是动作 + 渠道的互补. */}
                             <div className="wk-login-content-slogan-sub">
                                 {ENTERPRISE_SSO_ENABLED && hasSsoProvider
-                                    ? `使用 ${ssoProvider!.name} 登录，已有 ${WKApp.config.appName || 'Octo'} 账号可继续使用`
+                                    ? '使用手机号或邮箱即可登录'
                                     : '登录你的账号以继续'}
                             </div>
                             {ENTERPRISE_SSO_ENABLED && hasSsoProvider ? (
-                                // SSO 启用：OIDC provider 作为主 CTA，本地账号下沉为遗留路径
+                                // SSO 启用：OIDC provider 作为主 CTA. Aegis 等 IdP 品牌名
+                                // 作为信任锚点放在主按钮下面小字 + tooltip, 而不是塞进主
+                                // 按钮文案 — 平衡"外部用户认知零负担"与"老用户/警觉用户能
+                                // 在跳转前预读 IdP 名字防钓鱼"两个诉求.
                                 <div className="wk-login-content-form">
                                     <Button
                                         className="wk-login-content-sso-primary"
@@ -344,48 +425,32 @@ class Login extends Component<any, LoginState> {
                                         disabled={vm.oidcLoading || vm.oidcResuming}
                                         onClick={startSsoLogin}
                                     >
-                                        <IconLock className="wk-login-content-sso-btn-icon" />
-                                        使用 {ssoProvider!.name} 登录或注册
+                                        登录 / 注册
                                     </Button>
-                                    <div className="wk-login-content-sso-helper">
-                                        新用户首次点击将自动创建 {ssoProvider!.name} 账号
+                                    {/* 主按钮下的注释块: helper(行为) + trust(IdP 来源)
+                                        合到同一行用 "·" 分隔, 避免两行小灰字相邻视觉糊成一团.
+                                        鼠标悬停 trust 段弹出 IdP 完整解释 (借浏览器 title). */}
+                                    <div className="wk-login-content-sso-meta">
+                                        <span>已有账号将自动登录，新用户将自动注册</span>
+                                        <span className="wk-login-content-sso-meta-sep">·</span>
+                                        <span
+                                            className="wk-login-content-sso-trust"
+                                            title={`${ssoProvider!.name} 是 Mininglamp 统一身份服务，登录后可在所有 Mininglamp 产品中通用`}
+                                        >
+                                            由 {ssoProvider!.name} 提供
+                                        </span>
                                     </div>
-                                    <div className="wk-login-content-legacy-divider">
-                                        <span>已有 {WKApp.config.appName || 'Octo'} 账号</span>
-                                    </div>
-                                    <div className="wk-login-content-legacy-form">
-                                        <input type="text" name="username" autoComplete="username" placeholder="邮箱 / 用户名" onChange={(v) => {
-                                            vm.username = v.target.value
-                                        }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                        <input type="password" name="password" autoComplete="current-password" placeholder="密码" onChange={(v) => {
-                                            vm.password = v.target.value
-                                        }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                        <div className="wk-login-content-form-buttons">
-                                            <Button loading={vm.loginLoading} className="wk-login-content-form-ok" type='primary' theme='solid'
-                                                onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
-                                                onClick={handleLogin}>登录</Button>
-                                        </div>
-                                        {vm.loginAttemptFailed && (
-                                            <div className="wk-login-content-form-error-cta">
-                                                登录不上？企业账号或新用户请
-                                                <a onClick={(e) => { e.preventDefault(); startSsoLogin() }}>
-                                                    使用 {ssoProvider!.name} 登录或注册
-                                                </a>
-                                            </div>
-                                        )}
-                                        <div className="wk-login-content-form-others">
-                                            <div className="wk-login-content-form-scanlogin" onClick={() => {
-                                                vm.loginType = LoginType.qrcode
-                                            }}>
-                                                扫码登录
-                                            </div>
-                                            <div className="wk-login-content-form-switch" onClick={() => {
-                                                vm.loginType = LoginType.forgetPassword
-                                            }}>
-                                                忘记密码
-                                            </div>
-                                        </div>
-                                    </div>
+                                    {/* TODO(legacy-login-flag): 暂时隐藏本地密码登录入口, 等
+                                        后端 PR 在 /v1/common/appconfig 暴露 legacy_password_login_off
+                                        (或类似字段) 后, 改成读 WKApp.remoteConfig 字段动态切换.
+                                        当前: SSO 启用 + 有 provider 时, 整块隐藏看效果. */}
+                                    {false && (
+                                        <LegacyPasswordSection
+                                            vm={vm}
+                                            startSsoLogin={startSsoLogin}
+                                            handleLogin={handleLogin}
+                                        />
+                                    )}
                                     <div className="wk-login-content-download">
                                         <AndroidDownloadButton />
                                         <IOSDownloadButton />
@@ -394,7 +459,7 @@ class Login extends Component<any, LoginState> {
                             ) : (
                                 // 未启用 SSO：保持原有布局（含本地注册入口）
                                 <div className="wk-login-content-form">
-                                    <input type="text" name="username" autoComplete="username" placeholder="邮箱 / 用户名" onChange={(v) => {
+                                    <input type="text" name="username" autoComplete="username" placeholder="邮箱" onChange={(v) => {
                                         vm.username = v.target.value
                                     }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
                                     <input type="password" name="password" autoComplete="current-password" placeholder="密码" onChange={(v) => {

--- a/packages/dmworklogin/src/loginSession.ts
+++ b/packages/dmworklogin/src/loginSession.ts
@@ -1,0 +1,100 @@
+import { WKApp } from '@octo/base'
+
+// LoginRespJSON 的字段子集. 用 unknown / any 避免对后端 schema 过度约束:
+// 不同登录入口 (password / sms / OIDC autolink / OIDC bind confirm) 走的是同
+// 一份后端 execLogin, 但 dmwork 也有少数实验字段, 这里只校验登录必备的两项.
+export interface LoginRespFields {
+  uid?: unknown
+  token?: unknown
+  app_id?: unknown
+  short_no?: unknown
+  name?: unknown
+  sex?: unknown
+  realname_verified?: unknown
+  real_name?: unknown
+  realname_verified_at?: unknown
+  [k: string]: unknown
+}
+
+/**
+ * applyLoginResp 把后端登录响应映射到 WKApp.loginInfo 并持久化.
+ *
+ * 调用方:
+ *  - LoginVM.loginSuccess (密码 / 短信 / 二维码 / OIDC autolink 短码轮询)
+ *  - BindPage (OIDC bind confirm 成功后, login_resp 经 JSON.parse 后)
+ *
+ * 两条路径走的是后端同一份 execLogin (modules/oidc bind confirm 复用
+ * userSvc.LoginByExternalIdentity → externalLoginExisting), schema 一致.
+ *
+ * 不做的事:
+ *  - 不清表单字段 (那是 LoginVM 自己的事)
+ *  - 不触发任何导航 / callOnLogin / space 检查 (由调用方负责: LoginVM 走
+ *    checkSpaceAndLogin; BindPage 走 navigate(return_to))
+ */
+export function applyLoginResp(data: LoginRespFields, provider: string): void {
+  if (
+    !data ||
+    typeof data.uid !== 'string' ||
+    data.uid === '' ||
+    typeof data.token !== 'string' ||
+    data.token === ''
+  ) {
+    throw new Error('Invalid login response: missing required fields (uid, token)')
+  }
+  const loginInfo = WKApp.loginInfo
+  loginInfo.appID = typeof data.app_id === 'string' ? data.app_id : ''
+  loginInfo.uid = data.uid
+  loginInfo.token = data.token
+  loginInfo.shortNo = typeof data.short_no === 'string' ? data.short_no : ''
+  loginInfo.name = typeof data.name === 'string' ? data.name : ''
+  loginInfo.sex = typeof data.sex === 'number' ? data.sex : 0
+  loginInfo.loginProvider = provider
+
+  // 实名 tri-state: undefined 表示"未知" (老后端字段缺失场景), 不能塌缩为 false.
+  // 原由保留在 login_vm.tsx 旧实现的注释里 (memory 627798ef): 后续 /v1/users/:uid
+  // 刷新会覆盖, undefined 是它的初始读位.
+  const rv = data.realname_verified
+  if (rv === true || rv === 1 || rv === '1' || rv === 'true') {
+    loginInfo.realnameVerified = true
+  } else if (rv === false || rv === 0 || rv === '0' || rv === 'false') {
+    loginInfo.realnameVerified = false
+  } else {
+    loginInfo.realnameVerified = undefined
+  }
+  if (typeof data.real_name === 'string' && data.real_name.length > 0) {
+    loginInfo.realName = data.real_name
+  } else {
+    loginInfo.realName = undefined
+  }
+  const rvAt = data.realname_verified_at
+  if (typeof rvAt === 'number' && rvAt > 0) {
+    loginInfo.realnameVerifiedAt = rvAt
+  } else if (typeof rvAt === 'string' && rvAt !== '') {
+    const n = Number(rvAt)
+    loginInfo.realnameVerifiedAt = Number.isFinite(n) && n > 0 ? n : undefined
+  } else {
+    loginInfo.realnameVerifiedAt = undefined
+  }
+
+  loginInfo.save()
+}
+
+/**
+ * parseLoginResp 把 bind confirm 返回的 JSON-encoded string 解出.
+ *
+ * 与老 OIDC authstatus.result 不同, bind 流程 login_resp 是字符串 (后端用
+ * json.Marshal 后再放进 wrapper) — 详见 oidc-bind-frontend.md §2.3 / §3.5.
+ * 解析失败抛 Error, 让 UI 落 500 文案 (实际只可能发生在后端串错 schema).
+ */
+export function parseLoginResp(raw: string): LoginRespFields {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (e) {
+    throw new Error(`Invalid login_resp: not JSON (${(e as Error).message})`)
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid login_resp: not an object')
+  }
+  return parsed as LoginRespFields
+}

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -1,4 +1,5 @@
 import { WKApp, ProviderListener } from "@octo/base";
+import { applyLoginResp } from "./loginSession";
 import {
     buildAuthorizeURL,
     clearPendingOidcLogin,
@@ -353,59 +354,10 @@ export class LoginVM extends ProviderListener {
     }
 
     loginSuccess(data:any, provider: string = 'local') {
-        if (!data || !data.uid || !data.token) {
-            throw new Error('Invalid login response: missing required fields (uid, token)')
-        }
         this.clearSensitiveFields()
-        const loginInfo = WKApp.loginInfo
-        loginInfo.appID = data.app_id ?? ''
-        loginInfo.uid = data.uid
-        loginInfo.token = data.token
-        loginInfo.shortNo = data.short_no ?? ''
-        loginInfo.name = data.name ?? ''
-        loginInfo.sex = data.sex ?? 0
-        loginInfo.loginProvider = provider
-
-        // 把后端登录 payload 的实名字段映射到 loginInfo（配套
-        // dmworkim `/v1/user/login` & `/v1/user/current` response
-        // 新增 realname_verified / real_name / realname_verified_at）。
-        //
-        // 数据契约：
-        //   - 已实名用户：realname_verified=true, real_name=非空, realname_verified_at=unix秒
-        //   - 未实名用户：realname_verified=false（或字段缺失），real_name 缺失或空
-        //   - 老后端尚未部署：三个字段都 **缺失** → loginInfo 三个字段保持
-        //     undefined（tri-state 的「未知」态），前端继续用 loginInfo.name
-        //     显示，不报错（渐进兼容）。
-        //
-        // 为什么严格 tri-state：字段缺失 (undefined) 必须和 「明确 false」
-        // 区分开，否则老后端场景下会把「状态未知」当作「明确未实名」，
-        // 覆盖掉 MeInfo 页后续 /v1/users/:uid 刷新拿到的实名状态。
-        // 这是 R9 的 Coda 血泪教训（memory 627798ef）：读取
-        // state 字段前必须验证完整写入路径，本次通过登录 payload 直发解决。
-        const rv = data.realname_verified
-        if (rv === true || rv === 1 || rv === "1" || rv === "true") {
-            loginInfo.realnameVerified = true
-        } else if (rv === false || rv === 0 || rv === "0" || rv === "false") {
-            loginInfo.realnameVerified = false
-        } else {
-            loginInfo.realnameVerified = undefined
-        }
-        if (typeof data.real_name === "string" && data.real_name.length > 0) {
-            loginInfo.realName = data.real_name
-        } else {
-            loginInfo.realName = undefined
-        }
-        const rvAt = data.realname_verified_at
-        if (typeof rvAt === "number" && rvAt > 0) {
-            loginInfo.realnameVerifiedAt = rvAt
-        } else if (typeof rvAt === "string" && rvAt !== "") {
-            const n = Number(rvAt)
-            loginInfo.realnameVerifiedAt = Number.isFinite(n) && n > 0 ? n : undefined
-        } else {
-            loginInfo.realnameVerifiedAt = undefined
-        }
-
-        loginInfo.save()
+        // 数据映射 (含实名 tri-state) 与 loginInfo.save() 统一抽到 loginSession.ts
+        // 共享; bind 流程 (BindPage) 复用同一份写入路径, 走的是后端同一份 execLogin.
+        applyLoginResp(data, provider)
 
         // 登录/注册成功后，检查是否有待处理的邀请码（来自邀请链接）
         // 有邀请码：直接 callOnLogin()，邀请码加入逻辑统一由 Layout/onLogin 处理，避免重复执行

--- a/packages/dmworklogin/src/oidc/__tests__/api.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import { fetchAuthcode, fetchAuthStatus } from '../api'
 import type { OidcHttpClient } from '../api'
 
 function makeClient(impl: OidcHttpClient['get']): OidcHttpClient {
-  return { get: impl }
+  return { get: impl, post: vi.fn() }
 }
 
 describe('fetchAuthcode', () => {

--- a/packages/dmworklogin/src/oidc/__tests__/http.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/http.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchHttpClient, OidcBindHttpError } from '../http'
+
+describe('fetchHttpClient', () => {
+  const realFetch = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  it('GET parses JSON on 2xx', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ x: 1 }),
+    }) as never
+    const r = await fetchHttpClient.get<{ x: number }>('/u')
+    expect(r.x).toBe(1)
+  })
+
+  it('GET throws OidcBindHttpError on non-2xx with msg body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => JSON.stringify({ msg: 'rate_limited' }),
+    }) as never
+    try {
+      await fetchHttpClient.get('/u')
+      throw new Error('should not reach')
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcBindHttpError)
+      expect((e as OidcBindHttpError).status).toBe(429)
+      expect((e as OidcBindHttpError).msg).toBe('rate_limited')
+    }
+  })
+
+  it('GET surfaces status when body is not JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'internal error',
+    }) as never
+    try {
+      await fetchHttpClient.get('/u')
+    } catch (e) {
+      expect((e as OidcBindHttpError).status).toBe(500)
+    }
+  })
+
+  it('POST sends Content-Type: application/json with stringified body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    globalThis.fetch = fetchMock as never
+    await fetchHttpClient.post('/u', { a: 1 })
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(init.body).toBe(JSON.stringify({ a: 1 }))
+  })
+
+  it('POST throws OidcBindHttpError on 410 with msg', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 410,
+      text: async () => JSON.stringify({ msg: 'expired' }),
+    }) as never
+    await expect(fetchHttpClient.post('/u', {})).rejects.toMatchObject({
+      name: 'OidcBindHttpError',
+      status: 410,
+      msg: 'expired',
+    })
+  })
+})

--- a/packages/dmworklogin/src/oidc/__tests__/poller.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/poller.test.ts
@@ -19,6 +19,7 @@ function makeClient(
       if (!next) throw new Error('No more queued responses')
       return next as never
     }),
+    post: vi.fn(),
   }
   return { client, calls }
 }
@@ -97,6 +98,7 @@ describe('pollAuthStatus', () => {
         if (!next) throw new Error('exhausted')
         return next as never
       }),
+      post: vi.fn(),
     }
     const result = await pollAuthStatus({
       client,
@@ -114,6 +116,7 @@ describe('pollAuthStatus', () => {
       get: vi.fn(async () => {
         throw new Error('network down')
       }),
+      post: vi.fn(),
     }
     await expect(
       pollAuthStatus({
@@ -143,6 +146,7 @@ describe('pollAuthStatus', () => {
         if (!next) throw new Error('exhausted')
         return next as never
       }),
+      post: vi.fn(),
     }
     const result = await pollAuthStatus({
       client,
@@ -166,6 +170,7 @@ describe('pollAuthStatus', () => {
           )
         }) as never
       }),
+      post: vi.fn(),
     }
     const promise = pollAuthStatus({
       client,
@@ -186,6 +191,7 @@ describe('pollAuthStatus', () => {
       get: vi.fn(async () => {
         throw new DOMException('aborted', 'AbortError')
       }),
+      post: vi.fn(),
     }
     ac.abort()
     await expect(

--- a/packages/dmworklogin/src/oidc/api.ts
+++ b/packages/dmworklogin/src/oidc/api.ts
@@ -21,6 +21,7 @@ export interface OidcRequestInit {
 
 export interface OidcHttpClient {
   get<T>(url: string, init?: OidcRequestInit): Promise<T>
+  post<T>(url: string, body: unknown, init?: OidcRequestInit): Promise<T>
 }
 
 const AUTHCODE_PATH = '/v1/user/thirdlogin/authcode'

--- a/packages/dmworklogin/src/oidc/bind/__tests__/api.test.ts
+++ b/packages/dmworklogin/src/oidc/bind/__tests__/api.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  fetchBindInfo,
+  verifyBindPassword,
+  sendBindOtp,
+  checkBindOtp,
+  confirmBind,
+  createBind,
+  FALLBACK_PROVIDER_ID,
+} from '../api'
+import type { OidcHttpClient } from '../../api'
+
+function makeClient(overrides: Partial<OidcHttpClient> = {}): OidcHttpClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('fetchBindInfo', () => {
+  it('GETs /v1/auth/oidc/<provider>/bind/info?token=', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@example.com',
+      masked_phone: '****5678',
+      name: 'Alice',
+      methods: ['password', 'sms_otp'],
+      support_contact: 's@x.com',
+    })
+    const client = makeClient({ get })
+    const info = await fetchBindInfo(client, 'tok', { provider: 'aegis' })
+    expect(get).toHaveBeenCalledWith(
+      '/v1/auth/oidc/aegis/bind/info?token=tok',
+      { signal: undefined },
+    )
+    expect(info).toEqual({
+      masked_email: 'a***@example.com',
+      masked_phone: '****5678',
+      name: 'Alice',
+      methods: ['password', 'sms_otp'],
+      support_contact: 's@x.com',
+    })
+  })
+
+  it('falls back to aegis when provider missing and fires telemetry', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: '',
+      name: 'X',
+      methods: ['password'],
+    })
+    const client = makeClient({ get })
+    const onProviderFallback = vi.fn()
+    await fetchBindInfo(client, 'tok', { telemetry: { onProviderFallback } })
+    expect(get.mock.calls[0][0]).toContain(`/v1/auth/oidc/${FALLBACK_PROVIDER_ID}/bind/`)
+    expect(onProviderFallback).toHaveBeenCalledWith('missing')
+  })
+
+  it('flags invalid provider via telemetry and still falls back', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: '',
+      name: 'X',
+      methods: [],
+    })
+    const onProviderFallback = vi.fn()
+    await fetchBindInfo(makeClient({ get }), 'tok', {
+      provider: '../evil',
+      telemetry: { onProviderFallback },
+    })
+    expect(get.mock.calls[0][0]).toContain(`/v1/auth/oidc/${FALLBACK_PROVIDER_ID}/bind/`)
+    expect(onProviderFallback).toHaveBeenCalledWith('invalid')
+  })
+
+  it('omits masked_phone when backend omits the field (tri-state)', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@x',
+      name: 'A',
+      methods: ['password'],
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info).not.toHaveProperty('masked_phone')
+  })
+
+  it('treats empty masked_phone as absent', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'e',
+      masked_phone: '',
+      name: 'A',
+      methods: [],
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info).not.toHaveProperty('masked_phone')
+  })
+
+  it('drops unknown methods from the response', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: '',
+      name: 'A',
+      methods: ['password', 'face_id', 'sms_otp', 42],
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info.methods).toEqual(['password', 'sms_otp'])
+  })
+
+  it('rejects malformed response', async () => {
+    const get = vi.fn().mockResolvedValue(null)
+    await expect(
+      fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects when methods is not an array', async () => {
+    const get = vi.fn().mockResolvedValue({ masked_email: '', name: 'A', methods: 'password' })
+    await expect(
+      fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('verifyBindPassword', () => {
+  it('POSTs body { token, identifier, password }', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'verified' })
+    const client = makeClient({ post })
+    const r = await verifyBindPassword(client, 'tok', 'alice', 'pw', { provider: 'aegis' })
+    expect(post).toHaveBeenCalledWith(
+      '/v1/auth/oidc/aegis/bind/verify/password',
+      { token: 'tok', identifier: 'alice', password: 'pw' },
+      { signal: undefined },
+    )
+    expect(r.status).toBe('verified')
+  })
+
+  it('rejects when status != verified', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'pending' })
+    await expect(
+      verifyBindPassword(makeClient({ post }), 't', 'i', 'p', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('sendBindOtp', () => {
+  it('POSTs only { token }', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'sent' })
+    await sendBindOtp(makeClient({ post }), 'tok', { provider: 'aegis' })
+    expect(post).toHaveBeenCalledWith(
+      '/v1/auth/oidc/aegis/bind/verify/otp/send',
+      { token: 'tok' },
+      { signal: undefined },
+    )
+  })
+
+  it('does not include phone in body', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'sent' })
+    await sendBindOtp(makeClient({ post }), 'tok', { provider: 'aegis' })
+    const body = post.mock.calls[0][1]
+    expect(body).toEqual({ token: 'tok' })
+    expect(body).not.toHaveProperty('phone')
+  })
+})
+
+describe('checkBindOtp', () => {
+  it('POSTs { token, code }', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'verified' })
+    await checkBindOtp(makeClient({ post }), 'tok', '123456', { provider: 'aegis' })
+    expect(post).toHaveBeenCalledWith(
+      '/v1/auth/oidc/aegis/bind/verify/otp/check',
+      { token: 'tok', code: '123456' },
+      { signal: undefined },
+    )
+  })
+})
+
+describe('confirmBind', () => {
+  it('POSTs { token } and returns parsed shape', async () => {
+    const post = vi.fn().mockResolvedValue({
+      status: 'ok',
+      login_resp: '{"uid":"u","token":"t"}',
+      uid: 'u',
+    })
+    const r = await confirmBind(makeClient({ post }), 'tok', { provider: 'aegis' })
+    expect(r.uid).toBe('u')
+    expect(typeof r.login_resp).toBe('string')
+  })
+
+  it('rejects when login_resp is missing', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok', uid: 'u' })
+    await expect(
+      confirmBind(makeClient({ post }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects when login_resp is empty', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok', login_resp: '', uid: 'u' })
+    await expect(
+      confirmBind(makeClient({ post }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects when uid is missing', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok', login_resp: '{}' })
+    await expect(
+      confirmBind(makeClient({ post }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects on non-ok status', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'pending', login_resp: 'x', uid: 'u' })
+    await expect(
+      confirmBind(makeClient({ post }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('fetchBindInfo allow_create / create_blocked (PR#93)', () => {
+  it('passes through allow_create=true and create_blocked="" when claims are clean', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@x',
+      name: 'A',
+      methods: [],
+      allow_create: true,
+      create_blocked: '',
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info.allow_create).toBe(true)
+    expect(info.create_blocked).toBe('')
+  })
+
+  it('passes through create_blocked="claims_incomplete"', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: '',
+      name: 'A',
+      methods: [],
+      allow_create: true,
+      create_blocked: 'claims_incomplete',
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info.create_blocked).toBe('claims_incomplete')
+  })
+
+  it('passes through create_blocked="manual_conflict"', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@x',
+      name: 'A',
+      methods: ['password'],
+      allow_create: true,
+      create_blocked: 'manual_conflict',
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info.create_blocked).toBe('manual_conflict')
+  })
+
+  it('downgrades unknown create_blocked values to "" (forward-compat)', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@x',
+      name: 'A',
+      methods: ['password'],
+      allow_create: true,
+      create_blocked: 'future_unknown_reason',
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info.create_blocked).toBe('')
+  })
+
+  it('leaves allow_create undefined when old backend omits the field', async () => {
+    const get = vi.fn().mockResolvedValue({
+      masked_email: 'a***@x',
+      name: 'A',
+      methods: ['password'],
+    })
+    const info = await fetchBindInfo(makeClient({ get }), 'tok', { provider: 'aegis' })
+    expect(info).not.toHaveProperty('allow_create')
+    expect(info).not.toHaveProperty('create_blocked')
+  })
+})
+
+describe('createBind', () => {
+  it('POSTs to /bind/create with { token }', async () => {
+    const post = vi.fn().mockResolvedValue({
+      status: 'ok',
+      login_resp: '{"uid":"u","token":"t"}',
+      uid: 'u-new',
+    })
+    await createBind(makeClient({ post }), 'tok', { provider: 'aegis' })
+    expect(post).toHaveBeenCalledWith(
+      '/v1/auth/oidc/aegis/bind/create',
+      { token: 'tok' },
+      { signal: undefined },
+    )
+  })
+
+  it('returns login_resp + uid', async () => {
+    const post = vi.fn().mockResolvedValue({
+      status: 'ok',
+      login_resp: '{"uid":"u-new","token":"t-new"}',
+      uid: 'u-new',
+    })
+    const r = await createBind(makeClient({ post }), 'tok', { provider: 'aegis' })
+    expect(r.uid).toBe('u-new')
+    expect(r.login_resp).toContain('u-new')
+  })
+
+  it('rejects malformed response (missing login_resp)', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok', uid: 'u' })
+    await expect(
+      createBind(makeClient({ post }), 'tok', { provider: 'aegis' }),
+    ).rejects.toThrow()
+  })
+
+  it('falls back to aegis provider when missing', async () => {
+    const post = vi.fn().mockResolvedValue({
+      status: 'ok',
+      login_resp: '{}',
+      uid: 'u',
+    })
+    await createBind(makeClient({ post }), 'tok')
+    expect(post.mock.calls[0][0]).toContain(`/v1/auth/oidc/${FALLBACK_PROVIDER_ID}/bind/create`)
+  })
+})
+
+describe('token not in logs', () => {
+  it('does not log token to console anywhere in the api layer', async () => {
+    // 防御性测试: 任何 bind api 调用都不应触发 console.log/info/warn/error.
+    // 这是 bind_token-in-URL limitation 缓解的一部分.
+    const spies = ['log', 'info', 'warn', 'error'].map((m) =>
+      vi.spyOn(console, m as 'log').mockImplementation(() => {}),
+    )
+    try {
+      const client = makeClient({
+        get: vi.fn().mockResolvedValue({
+          masked_email: '',
+          name: 'A',
+          methods: [],
+        }),
+        post: vi
+          .fn()
+          .mockResolvedValueOnce({ status: 'verified' }) // verify_password
+          .mockResolvedValueOnce({ status: 'sent' }), // otp/send
+      })
+      await fetchBindInfo(client, 'SECRET-TOK', { provider: 'aegis' })
+      await verifyBindPassword(client, 'SECRET-TOK', 'u', 'p', { provider: 'aegis' })
+      await sendBindOtp(client, 'SECRET-TOK', { provider: 'aegis' })
+      for (const s of spies) {
+        expect(s).not.toHaveBeenCalled()
+      }
+    } finally {
+      spies.forEach((s) => s.mockRestore())
+    }
+  })
+})

--- a/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
+++ b/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  parseBindEntryParams,
+  sanitizeReturnTo,
+  clearBindUrl,
+} from '../url'
+
+describe('parseBindEntryParams', () => {
+  it('parses token / authcode / return_to / provider from query string', () => {
+    const r = parseBindEntryParams('?token=tok123&authcode=ac456&return_to=/home&provider=aegis')
+    expect(r).toEqual({
+      token: 'tok123',
+      authcode: 'ac456',
+      returnTo: '/home',
+      provider: 'aegis',
+    })
+  })
+
+  it('handles missing leading ?', () => {
+    const r = parseBindEntryParams('token=t&authcode=a')
+    expect(r).toEqual({
+      token: 't',
+      authcode: 'a',
+      returnTo: '/',
+    })
+  })
+
+  it('returns null when token missing', () => {
+    expect(parseBindEntryParams('?authcode=a&return_to=/')).toBeNull()
+  })
+
+  it('returns null when authcode missing', () => {
+    expect(parseBindEntryParams('?token=t&return_to=/')).toBeNull()
+  })
+
+  it('falls back return_to to /', () => {
+    const r = parseBindEntryParams('?token=t&authcode=a')
+    expect(r?.returnTo).toBe('/')
+  })
+
+  it('does not include provider key when absent (distinguishable from explicit empty)', () => {
+    const r = parseBindEntryParams('?token=t&authcode=a')
+    expect(r).not.toHaveProperty('provider')
+  })
+
+  it('rejects protocol-relative return_to', () => {
+    const r = parseBindEntryParams('?token=t&authcode=a&return_to=//evil.com/x')
+    expect(r?.returnTo).toBe('/')
+  })
+
+  it('rejects absolute url return_to', () => {
+    const r = parseBindEntryParams('?token=t&authcode=a&return_to=https://evil.com')
+    expect(r?.returnTo).toBe('/')
+  })
+})
+
+describe('sanitizeReturnTo', () => {
+  it('accepts safe relative paths', () => {
+    expect(sanitizeReturnTo('/home')).toBe('/home')
+    expect(sanitizeReturnTo('/contacts/123')).toBe('/contacts/123')
+  })
+
+  it('rejects protocol-relative', () => {
+    expect(sanitizeReturnTo('//evil')).toBe('/')
+  })
+
+  it('rejects javascript:', () => {
+    expect(sanitizeReturnTo('javascript:alert(1)')).toBe('/')
+  })
+
+  it('rejects absolute', () => {
+    expect(sanitizeReturnTo('https://evil')).toBe('/')
+  })
+
+  it('rejects empty', () => {
+    expect(sanitizeReturnTo('')).toBe('/')
+  })
+})
+
+describe('clearBindUrl', () => {
+  it('calls history.replaceState with pathname only', () => {
+    const replaceState = vi.fn()
+    const win = {
+      history: { replaceState } as unknown as History,
+      location: { pathname: '/oidc/bind' } as Location,
+    }
+    clearBindUrl(win)
+    expect(replaceState).toHaveBeenCalledWith({}, '', '/oidc/bind')
+  })
+
+  it('does not throw when history is unavailable', () => {
+    const win = {
+      history: {
+        replaceState: () => {
+          throw new Error('SSR')
+        },
+      } as unknown as History,
+      location: { pathname: '/x' } as Location,
+    }
+    expect(() => clearBindUrl(win)).not.toThrow()
+  })
+})

--- a/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
+++ b/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
@@ -29,8 +29,11 @@ describe('parseBindEntryParams', () => {
     expect(parseBindEntryParams('?authcode=a&return_to=/')).toBeNull()
   })
 
-  it('returns null when authcode missing', () => {
-    expect(parseBindEntryParams('?token=t&return_to=/')).toBeNull()
+  it('accepts entry with token but no authcode (authcode is server-side only, PR #72 review B3)', () => {
+    const r = parseBindEntryParams('?token=t&return_to=/')
+    expect(r).not.toBeNull()
+    expect(r?.token).toBe('t')
+    expect(r?.authcode).toBe('')
   })
 
   it('falls back return_to to /', () => {
@@ -74,6 +77,35 @@ describe('sanitizeReturnTo', () => {
 
   it('rejects empty', () => {
     expect(sanitizeReturnTo('')).toBe('/')
+  })
+
+  // ---- regression: PR #72 Jerry-Xin review — sanitize must reject backslash
+  // variants. Browsers normalise `\` to `/` in URL parsing, so `/\evil.com`
+  // resolves to https://evil.com/ via the URL ctor. Both raw `\` and the
+  // URL-encoded `%5C` / `%5c` must be rejected.
+  it('rejects raw backslash injection', () => {
+    expect(sanitizeReturnTo('/\\evil.com')).toBe('/')
+    expect(sanitizeReturnTo('/\\\\evil.com')).toBe('/')
+    expect(sanitizeReturnTo('\\evil.com')).toBe('/')
+  })
+
+  it('rejects URL-encoded backslash injection', () => {
+    expect(sanitizeReturnTo('/%5Cevil.com')).toBe('/')
+    expect(sanitizeReturnTo('/%5cevil.com')).toBe('/')
+    expect(sanitizeReturnTo('/safe%5Cbut-encoded')).toBe('/')
+  })
+
+  // Defense-in-depth: even if some unicode same-shape char slips past the
+  // string-level checks, the URL ctor cross-origin check catches it.
+  it('rejects URLs whose parsed origin differs from page origin', () => {
+    const pageOrigin = 'http://localhost:3000'
+    // Same as cross-origin via raw backslash but exercised through the URL
+    // ctor branch by mocking the page origin.
+    expect(sanitizeReturnTo('http://evil.com/path', pageOrigin)).toBe('/')
+  })
+
+  it('accepts when parsed origin matches page origin (sanity)', () => {
+    expect(sanitizeReturnTo('/home', 'http://localhost:3000')).toBe('/home')
   })
 })
 

--- a/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
+++ b/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
@@ -110,14 +110,61 @@ describe('sanitizeReturnTo', () => {
 })
 
 describe('clearBindUrl', () => {
-  it('calls history.replaceState with pathname only', () => {
+  function makeWin(pathname: string, search: string) {
     const replaceState = vi.fn()
-    const win = {
-      history: { replaceState } as unknown as History,
-      location: { pathname: '/oidc/bind' } as Location,
+    return {
+      replaceState,
+      win: {
+        history: { replaceState } as unknown as History,
+        location: { pathname, search } as Location,
+      },
     }
+  }
+
+  it('strips bind-flow params (no other query) → bare pathname', () => {
+    const { win, replaceState } = makeWin(
+      '/oidc/bind',
+      '?token=tok&authcode=ac&return_to=/&provider=aegis',
+    )
     clearBindUrl(win)
     expect(replaceState).toHaveBeenCalledWith({}, '', '/oidc/bind')
+  })
+
+  // PR #72 round-3 critical (Jerry-Xin): RouteManager's pageshow handler can
+  // inject ?sid= before BindPage's useEffect runs. The previous clearBindUrl
+  // wiped sid too, routing applyLoginResp().save() to the empty-sid storage
+  // bucket and losing the session on next reload.
+  it('preserves sid alongside bind-param stripping', () => {
+    const { win, replaceState } = makeWin(
+      '/oidc/bind',
+      '?sid=abc123&token=tok&authcode=ac',
+    )
+    clearBindUrl(win)
+    expect(replaceState).toHaveBeenCalledWith({}, '', '/oidc/bind?sid=abc123')
+  })
+
+  it('preserves arbitrary non-bind params (forward-compat)', () => {
+    const { win, replaceState } = makeWin(
+      '/oidc/bind',
+      '?token=tok&debug=1&trace_id=xyz',
+    )
+    clearBindUrl(win)
+    const call = replaceState.mock.calls[0]
+    const newUrl = call[2] as string
+    expect(newUrl.startsWith('/oidc/bind?')).toBe(true)
+    const params = new URLSearchParams(newUrl.split('?')[1])
+    expect(params.has('token')).toBe(false)
+    expect(params.get('debug')).toBe('1')
+    expect(params.get('trace_id')).toBe('xyz')
+  })
+
+  it('no-ops when no bind params present', () => {
+    const { win, replaceState } = makeWin(
+      '/oidc/bind',
+      '?sid=abc',
+    )
+    clearBindUrl(win)
+    expect(replaceState).not.toHaveBeenCalled()
   })
 
   it('does not throw when history is unavailable', () => {

--- a/packages/dmworklogin/src/oidc/bind/api.ts
+++ b/packages/dmworklogin/src/oidc/bind/api.ts
@@ -1,0 +1,217 @@
+import type { OidcHttpClient, OidcRequestInit } from '../api'
+import type {
+  BindInfoResp,
+  BindVerifyResp,
+  BindConfirmResp,
+  BindCreateResp,
+  BindCreateBlocked,
+  BindMethod,
+} from './types'
+
+// 已知 create_blocked 取值. 后端可能将来增加新原因, 这里只把已知项强类型化;
+// 未知值降级为 '' (不显示阻塞文案) 但仍透传给上层做埋点 — 防御性 forward-compat.
+const KNOWN_CREATE_BLOCKED: ReadonlySet<BindCreateBlocked> = new Set([
+  '',
+  'disabled',
+  'claims_incomplete',
+  'manual_conflict',
+  'consumed',
+])
+
+// 与后端 modules/oidc 的 legacyProviderPathID 对齐. 当前端 URL 没带 provider
+// 时 (兼容旧后端 / 漏配) 回退到 aegis. 后端目前同时挂了 cfg.Provider.ID 和
+// aegis 两套路由, 所以回退安全.
+export const FALLBACK_PROVIDER_ID = 'aegis'
+
+// telemetry 钩子: provider 缺失时由调用方上报埋点便于排查.
+// 设计成可注入而非直接调 console / SDK, 让单测能断言 token 不会泄漏到日志.
+export type BindTelemetry = {
+  onProviderFallback?: (reason: 'missing' | 'invalid') => void
+}
+
+function resolveProvider(provider: string | undefined, t?: BindTelemetry): string {
+  if (typeof provider === 'string' && /^[a-z0-9_-]+$/i.test(provider)) {
+    return provider
+  }
+  t?.onProviderFallback?.(provider === undefined ? 'missing' : 'invalid')
+  return FALLBACK_PROVIDER_ID
+}
+
+function pathFor(provider: string, suffix: string): string {
+  return `/v1/auth/oidc/${encodeURIComponent(provider)}/bind/${suffix}`
+}
+
+export interface BindApiOptions extends OidcRequestInit {
+  provider?: string
+  telemetry?: BindTelemetry
+}
+
+export async function fetchBindInfo(
+  client: OidcHttpClient,
+  token: string,
+  opts?: BindApiOptions,
+): Promise<BindInfoResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const qs = new URLSearchParams({ token }).toString()
+  const url = `${pathFor(provider, 'info')}?${qs}`
+  const resp = await client.get<unknown>(url, { signal: opts?.signal })
+  return validateBindInfo(resp)
+}
+
+export async function verifyBindPassword(
+  client: OidcHttpClient,
+  token: string,
+  identifier: string,
+  password: string,
+  opts?: BindApiOptions,
+): Promise<BindVerifyResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const resp = await client.post<unknown>(
+    pathFor(provider, 'verify/password'),
+    { token, identifier, password },
+    { signal: opts?.signal },
+  )
+  return validateVerifyResp(resp, 'verified')
+}
+
+export async function sendBindOtp(
+  client: OidcHttpClient,
+  token: string,
+  opts?: BindApiOptions,
+): Promise<BindVerifyResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const resp = await client.post<unknown>(
+    pathFor(provider, 'verify/otp/send'),
+    { token },
+    { signal: opts?.signal },
+  )
+  return validateVerifyResp(resp, 'sent')
+}
+
+export async function checkBindOtp(
+  client: OidcHttpClient,
+  token: string,
+  code: string,
+  opts?: BindApiOptions,
+): Promise<BindVerifyResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const resp = await client.post<unknown>(
+    pathFor(provider, 'verify/otp/check'),
+    { token, code },
+    { signal: opts?.signal },
+  )
+  return validateVerifyResp(resp, 'verified')
+}
+
+export async function confirmBind(
+  client: OidcHttpClient,
+  token: string,
+  opts?: BindApiOptions,
+): Promise<BindConfirmResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const resp = await client.post<unknown>(
+    pathFor(provider, 'confirm'),
+    { token },
+    { signal: opts?.signal },
+  )
+  return validateConfirmResp(resp)
+}
+
+// POST /bind/create — 自助从 SSO claims 直接创建 Octo 账号 (server PR#93).
+// 响应 shape 与 /bind/confirm 完全一致 (后端复用同一份 LoginRespJSON builder).
+export async function createBind(
+  client: OidcHttpClient,
+  token: string,
+  opts?: BindApiOptions,
+): Promise<BindCreateResp> {
+  const provider = resolveProvider(opts?.provider, opts?.telemetry)
+  const resp = await client.post<unknown>(
+    pathFor(provider, 'create'),
+    { token },
+    { signal: opts?.signal },
+  )
+  // 复用 validateConfirmResp — 两端 schema 同构, 同一份校验避免分叉.
+  return validateConfirmResp(resp) as BindCreateResp
+}
+
+// ---- response validators -------------------------------------------------
+// 强校验外部数据是 system boundary 通用原则; 这里同时把不合规字段早抛, 让
+// UI 不需要处理半成品响应.
+
+const KNOWN_METHODS: ReadonlySet<BindMethod> = new Set(['password', 'sms_otp'])
+
+function validateBindInfo(resp: unknown): BindInfoResp {
+  if (!resp || typeof resp !== 'object') {
+    throw new Error('Invalid bind/info response')
+  }
+  const r = resp as Record<string, unknown>
+  if (typeof r.name !== 'string') {
+    throw new Error('Invalid bind/info: name must be string')
+  }
+  if (typeof r.masked_email !== 'string') {
+    throw new Error('Invalid bind/info: masked_email must be string')
+  }
+  if (!Array.isArray(r.methods)) {
+    throw new Error('Invalid bind/info: methods must be array')
+  }
+  const methods: BindMethod[] = []
+  for (const m of r.methods) {
+    if (typeof m === 'string' && KNOWN_METHODS.has(m as BindMethod)) {
+      methods.push(m as BindMethod)
+    }
+  }
+  const out: BindInfoResp = {
+    masked_email: r.masked_email,
+    name: r.name,
+    methods,
+  }
+  // masked_phone 是 optional, 字段缺失与空串语义不同 (§3.7); 只在确为非空字符串时透传.
+  if (typeof r.masked_phone === 'string' && r.masked_phone !== '') {
+    out.masked_phone = r.masked_phone
+  }
+  if (typeof r.support_contact === 'string' && r.support_contact !== '') {
+    out.support_contact = r.support_contact
+  }
+  // PR#93 扩展字段. 老后端不返时保持 undefined, BindPage 视为"无 create 入口".
+  if (typeof r.allow_create === 'boolean') {
+    out.allow_create = r.allow_create
+  }
+  if (typeof r.create_blocked === 'string') {
+    // 强类型 narrow: 仅放行已知值, 未知值降级为 '' 防 UI 误判.
+    out.create_blocked = KNOWN_CREATE_BLOCKED.has(r.create_blocked as BindCreateBlocked)
+      ? (r.create_blocked as BindCreateBlocked)
+      : ''
+  }
+  return out
+}
+
+function validateVerifyResp(
+  resp: unknown,
+  expected: 'verified' | 'sent',
+): BindVerifyResp {
+  if (!resp || typeof resp !== 'object') {
+    throw new Error('Invalid bind/verify response')
+  }
+  const r = resp as Record<string, unknown>
+  if (r.status !== expected) {
+    throw new Error(`Invalid bind/verify response: status != ${expected}`)
+  }
+  return { status: expected }
+}
+
+function validateConfirmResp(resp: unknown): BindConfirmResp {
+  if (!resp || typeof resp !== 'object') {
+    throw new Error('Invalid bind/confirm response')
+  }
+  const r = resp as Record<string, unknown>
+  if (r.status !== 'ok') {
+    throw new Error('Invalid bind/confirm: status != ok')
+  }
+  if (typeof r.login_resp !== 'string' || r.login_resp === '') {
+    throw new Error('Invalid bind/confirm: login_resp must be non-empty string')
+  }
+  if (typeof r.uid !== 'string' || r.uid === '') {
+    throw new Error('Invalid bind/confirm: uid must be non-empty string')
+  }
+  return { status: 'ok', login_resp: r.login_resp, uid: r.uid }
+}

--- a/packages/dmworklogin/src/oidc/bind/index.ts
+++ b/packages/dmworklogin/src/oidc/bind/index.ts
@@ -1,0 +1,27 @@
+export type {
+  BindMethod,
+  BindInfoResp,
+  BindVerifyResp,
+  BindConfirmResp,
+  BindCreateResp,
+  BindCreateBlocked,
+  BindEntryParams,
+  BindStage,
+} from './types'
+
+export {
+  fetchBindInfo,
+  verifyBindPassword,
+  sendBindOtp,
+  checkBindOtp,
+  confirmBind,
+  createBind,
+  FALLBACK_PROVIDER_ID,
+} from './api'
+export type { BindApiOptions, BindTelemetry } from './api'
+
+export {
+  parseBindEntryParams,
+  sanitizeReturnTo,
+  clearBindUrl,
+} from './url'

--- a/packages/dmworklogin/src/oidc/bind/types.ts
+++ b/packages/dmworklogin/src/oidc/bind/types.ts
@@ -1,0 +1,70 @@
+// 后端 PR#73 (feat/oidc-bind-self-service) 自助绑定流程响应类型.
+// 文档: octo-server docs/octo-aegis/oidc-bind-frontend.md
+
+// 可用的二次验证方法. 来自后端 cfg.Methods ∩ claims 支持:
+// - claims 无 verified phone 时 'sms_otp' 不会出现在 methods[] 里
+export type BindMethod = 'password' | 'sms_otp'
+
+// /bind/info 的 create_blocked 字段取值. 后端永远序列化此字段 (不会 omitempty),
+// 所以 '' 与 'disabled' 语义不同 — 见 server PR#93 的 Info precedence 说明:
+//   disabled > claims_incomplete > manual_conflict > consumed
+// - ''                  → create 可用, UI 显示主按钮可点
+// - 'disabled'          → 运维关掉了开关, UI 完全隐藏 create 入口
+// - 'claims_incomplete' → IdP claims 无 verified email/phone, 无法自助创建
+// - 'manual_conflict'   → claims 命中多个 dmwork 账号, 必须人工合并
+// - 'consumed'          → token 已被 verify 或 create 使用过, 必须重走 OIDC
+export type BindCreateBlocked =
+  | ''
+  | 'disabled'
+  | 'claims_incomplete'
+  | 'manual_conflict'
+  | 'consumed'
+
+export interface BindInfoResp {
+  // claims 无邮箱时为空串. masked_phone 在 claims 无手机号时**字段缺失**,
+  // 不要用 === '' 判断 — 这是文档 §3.7 明确的契约.
+  masked_email: string
+  masked_phone?: string
+  name: string
+  methods: BindMethod[]
+  // 兜底联系方式, env 配置, 可空.
+  support_contact?: string
+  // 后端 PR#93 扩展: 自助创建账号支持. 老后端不返这两个字段时, FE 视为
+  // allow_create=false / create_blocked='' (即不显示 create 按钮, 退回老 UX).
+  allow_create?: boolean
+  create_blocked?: BindCreateBlocked
+}
+
+// /bind/create 响应与 /bind/confirm 同 shape, 单独命名让契约可追溯.
+export interface BindCreateResp {
+  status: 'ok'
+  login_resp: string
+  uid: string
+}
+
+export interface BindVerifyResp {
+  // 'verified' | 'sent'. password/otp_check 返 'verified'; otp_send 返 'sent'.
+  status: 'verified' | 'sent'
+}
+
+export interface BindConfirmResp {
+  status: 'ok'
+  // JSON-encoded string, 必须 JSON.parse 后才能拿到登录 payload (与老 OIDC
+  // authstatus.result 同 schema, 经后端同一份 execLogin 生成).
+  login_resp: string
+  uid: string
+}
+
+// bind 页面三参数, 来自 OIDC callback 302 时挂在 URL 上.
+// token 视为凭据, 等同一次密码登录会话; 见 url.ts 的 token 安全约束.
+export interface BindEntryParams {
+  token: string
+  authcode: string
+  returnTo: string
+  // 从 URL 取的 provider id. 缺失时调用方应回退到 fallback 并埋点.
+  provider?: string
+}
+
+// state machine: issued (URL 入口) → verified (verify 成功) → consumed (confirm 成功).
+// 后端 CAS 不允许回退到 issued; verified 后再调 verify 端点返 409.
+export type BindStage = 'issued' | 'verifying' | 'verified' | 'confirming' | 'consumed'

--- a/packages/dmworklogin/src/oidc/bind/url.ts
+++ b/packages/dmworklogin/src/oidc/bind/url.ts
@@ -3,8 +3,17 @@ import type { BindEntryParams } from './types'
 const DEFAULT_RETURN_TO = '/'
 
 /**
- * parseBindEntryParams 从 location.search 解出 bind 入口三参数.
- * provider 字段是前端契约扩展, 缺失时由调用方回退到 FALLBACK_PROVIDER_ID 并埋点.
+ * parseBindEntryParams 从 location.search 解出 bind 入口参数.
+ *
+ * 必填: token (所有 /bind/* 请求都用它, 视为凭据 — PR#73 §2.1)
+ * 选填:
+ *  - authcode: 原 dmwork 短码. **前端不会发送给任何 /bind/* 端点** — 后端在
+ *    callback 签发 bind_token 时已经在 BindSession state 里记下了 (token → authcode)
+ *    映射, confirm/create 成功时由后端用这个映射回填 ThirdAuthcode[authcode],
+ *    让 A 设备的 thirdlogin/authstatus 轮询能拿到 login_resp (PR#73 §2.3, FR-6.3).
+ *    前端持有它仅用于跨设备调试 traceability — 不验证、不传递、不入 log.
+ *  - return_to: 用户原本想去的页面 (绝对 / 站内相对均会经 sanitizeReturnTo 二次防御).
+ *  - provider: 前端契约扩展. 缺失时由调用方回退 FALLBACK_PROVIDER_ID 并埋点.
  *
  * token 的安全责任在调用方 (BindPage):
  *  - 拿到后立即调 clearBindUrl() 清地址栏
@@ -19,8 +28,9 @@ export function parseBindEntryParams(search: string): BindEntryParams | null {
   const rawReturnTo = params.get('return_to') ?? ''
   const provider = params.get('provider') ?? undefined
 
-  // token 与 authcode 是流程必备; 缺其一直接拒, 由 BindPage 引导重新登录.
-  if (token === '' || authcode === '') return null
+  // 仅 token 是流程必备 — 没 token 就没法发任何 /bind/* 请求.
+  // authcode 缺失也允许进入 bind 页 (前端不需要), 兼容后端将来精简 redirect URL.
+  if (token === '') return null
 
   const returnTo = sanitizeReturnTo(rawReturnTo)
   return provider !== undefined
@@ -29,18 +39,37 @@ export function parseBindEntryParams(search: string): BindEntryParams | null {
 }
 
 /**
- * sanitizeReturnTo 限定 return_to 必须是站内相对路径.
+ * sanitizeReturnTo 限定 return_to 必须是站内相对路径. 双重防御:
  *
- * 后端会先做一次 host 白名单校验, 但前端仍做一道防御:
- *  - 只放行 `/` 开头, 不以 `//` 开头 (防 protocol-relative URL 跳第三方)
- *  - 不允许 javascript:/data: 之类 (URL ctor 也会拒, 但这里更早拒)
+ *  1) 字符级 reject: 任何含反斜杠的输入直接拒. 浏览器 URL 解析会把 `\` 当 `/`,
+ *     所以 `/\evil.com` 进入 new URL() 后 origin 变成 evil.com — 跨域绕过.
+ *     原始 `\` 和 URL-encoded `%5C` / `%5c` 都拒.
+ *  2) 起始字符: 必须 `/` 开头但不能 `//` 开头 (防 protocol-relative).
+ *  3) origin 同源兜底: 用 new URL(value, location.origin) 解出 origin,
+ *     不等于当前页面 origin 一律拒. 防御 (1)(2) 漏掉的奇怪 unicode 同形字符
+ *     / 浏览器规范化怪癖.
+ *
  * 不合规一律落到 DEFAULT_RETURN_TO.
  *
- * 规则与 OidcConfig.ts:isSafeAuthorizePath 同源, 故意复制而非依赖以避免反向依赖.
+ * 同源规则与 OidcConfig.ts:isSafeAuthorizePath 一致, 故意复制而非依赖以避免反向依赖.
  */
-export function sanitizeReturnTo(value: string): string {
+export function sanitizeReturnTo(
+  value: string,
+  // 测试时可注入, 默认 window.location.origin.
+  pageOrigin: string = typeof window !== 'undefined' ? window.location.origin : 'http://localhost',
+): string {
   if (typeof value !== 'string' || value.length < 1) return DEFAULT_RETURN_TO
+  // (1) 反斜杠 / URL-encoded 反斜杠 — 任意位置出现都拒.
+  if (/\\|%5[cC]/.test(value)) return DEFAULT_RETURN_TO
+  // (2) 必须站内相对路径起点.
   if (!value.startsWith('/') || value.startsWith('//')) return DEFAULT_RETURN_TO
+  // (3) URL 解析后 origin 必须等于本页. 解析失败也拒.
+  try {
+    const parsed = new URL(value, pageOrigin)
+    if (parsed.origin !== pageOrigin) return DEFAULT_RETURN_TO
+  } catch {
+    return DEFAULT_RETURN_TO
+  }
   return value
 }
 

--- a/packages/dmworklogin/src/oidc/bind/url.ts
+++ b/packages/dmworklogin/src/oidc/bind/url.ts
@@ -73,28 +73,55 @@ export function sanitizeReturnTo(
   return value
 }
 
+// Query params that carry bind-flow data — only these get stripped by
+// clearBindUrl. Everything else (notably `sid`, which RouteManager injects
+// on pageshow and LoginInfo.getSID() reads back at save() time) is preserved.
+//
+// PR #72 round-3 review (Jerry-Xin): the previous implementation replaced
+// location with bare pathname, wiping sid and routing applyLoginResp().save()
+// to the empty-sid storage bucket — losing the just-created session on the
+// next reload.
+const BIND_QUERY_KEYS: ReadonlySet<string> = new Set([
+  'token',
+  'authcode',
+  'return_to',
+  'provider',
+])
+
 /**
- * clearBindUrl 从地址栏抹掉 bind 入口的 query 段.
+ * clearBindUrl scrubs bind-specific params from the address bar while
+ * preserving everything else (in particular `sid`, which the storage layer
+ * depends on).
  *
- * 目的:
- *  - 浏览器历史不留 token
- *  - 用户截图不暴露 token
- *  - Referer 不带 token 给下一跳
+ * Goals:
+ *  - browser history doesn't retain the token
+ *  - screenshots don't leak the token
+ *  - subsequent Referer headers don't carry the token
+ *  - sid + any other host-level params stay intact so the storage round-trip
+ *    (save → reload → load) reads from the same bucket
  *
- * 如果路由是 hash 模式 (location.pathname 不变, 路由在 location.hash 上),
- * 这里只清 search 段, 不动 hash. WKApp.route 默认是 path 模式; 真用 hash
- * 部署时 hash 里本来就没 token, 不影响.
+ * Hash-mode routing is unaffected: we only edit `location.search`, never
+ * `location.hash`. WKApp.route is path-mode today, so the hash is empty.
  *
- * 测试时可注入 historyApi 替换全局 window.history.
+ * `win` is injectable for tests.
  */
 export function clearBindUrl(
   win: Pick<Window, 'history' | 'location'> = window,
 ): void {
-  // replaceState 在 jsdom / 浏览器都有; 没有的话静默失败 — 这一步是 mitigation
-  // 不是 hard requirement, 不能因为它失败把 bind 流程整个挂掉.
   try {
-    win.history.replaceState({}, '', win.location.pathname)
+    const params = new URLSearchParams(win.location.search)
+    let mutated = false
+    for (const key of BIND_QUERY_KEYS) {
+      if (params.has(key)) {
+        params.delete(key)
+        mutated = true
+      }
+    }
+    if (!mutated) return
+    const remaining = params.toString()
+    const nextUrl = win.location.pathname + (remaining ? `?${remaining}` : '')
+    win.history.replaceState({}, '', nextUrl)
   } catch {
-    /* noop: 老浏览器或 SSR 容器无 history.replaceState */
+    /* noop: SSR / legacy host without history.replaceState */
   }
 }

--- a/packages/dmworklogin/src/oidc/bind/url.ts
+++ b/packages/dmworklogin/src/oidc/bind/url.ts
@@ -1,0 +1,71 @@
+import type { BindEntryParams } from './types'
+
+const DEFAULT_RETURN_TO = '/'
+
+/**
+ * parseBindEntryParams 从 location.search 解出 bind 入口三参数.
+ * provider 字段是前端契约扩展, 缺失时由调用方回退到 FALLBACK_PROVIDER_ID 并埋点.
+ *
+ * token 的安全责任在调用方 (BindPage):
+ *  - 拿到后立即调 clearBindUrl() 清地址栏
+ *  - 不要写入任何 store / log / telemetry
+ *  - 只在 useRef / closure 持有
+ */
+export function parseBindEntryParams(search: string): BindEntryParams | null {
+  const normalized = search.startsWith('?') ? search.slice(1) : search
+  const params = new URLSearchParams(normalized)
+  const token = params.get('token') ?? ''
+  const authcode = params.get('authcode') ?? ''
+  const rawReturnTo = params.get('return_to') ?? ''
+  const provider = params.get('provider') ?? undefined
+
+  // token 与 authcode 是流程必备; 缺其一直接拒, 由 BindPage 引导重新登录.
+  if (token === '' || authcode === '') return null
+
+  const returnTo = sanitizeReturnTo(rawReturnTo)
+  return provider !== undefined
+    ? { token, authcode, returnTo, provider }
+    : { token, authcode, returnTo }
+}
+
+/**
+ * sanitizeReturnTo 限定 return_to 必须是站内相对路径.
+ *
+ * 后端会先做一次 host 白名单校验, 但前端仍做一道防御:
+ *  - 只放行 `/` 开头, 不以 `//` 开头 (防 protocol-relative URL 跳第三方)
+ *  - 不允许 javascript:/data: 之类 (URL ctor 也会拒, 但这里更早拒)
+ * 不合规一律落到 DEFAULT_RETURN_TO.
+ *
+ * 规则与 OidcConfig.ts:isSafeAuthorizePath 同源, 故意复制而非依赖以避免反向依赖.
+ */
+export function sanitizeReturnTo(value: string): string {
+  if (typeof value !== 'string' || value.length < 1) return DEFAULT_RETURN_TO
+  if (!value.startsWith('/') || value.startsWith('//')) return DEFAULT_RETURN_TO
+  return value
+}
+
+/**
+ * clearBindUrl 从地址栏抹掉 bind 入口的 query 段.
+ *
+ * 目的:
+ *  - 浏览器历史不留 token
+ *  - 用户截图不暴露 token
+ *  - Referer 不带 token 给下一跳
+ *
+ * 如果路由是 hash 模式 (location.pathname 不变, 路由在 location.hash 上),
+ * 这里只清 search 段, 不动 hash. WKApp.route 默认是 path 模式; 真用 hash
+ * 部署时 hash 里本来就没 token, 不影响.
+ *
+ * 测试时可注入 historyApi 替换全局 window.history.
+ */
+export function clearBindUrl(
+  win: Pick<Window, 'history' | 'location'> = window,
+): void {
+  // replaceState 在 jsdom / 浏览器都有; 没有的话静默失败 — 这一步是 mitigation
+  // 不是 hard requirement, 不能因为它失败把 bind 流程整个挂掉.
+  try {
+    win.history.replaceState({}, '', win.location.pathname)
+  } catch {
+    /* noop: 老浏览器或 SSR 容器无 history.replaceState */
+  }
+}

--- a/packages/dmworklogin/src/oidc/http.ts
+++ b/packages/dmworklogin/src/oidc/http.ts
@@ -24,6 +24,38 @@ function combineSignals(
 }
 
 /**
+ * OIDC bind 流程要按 HTTP status 分支处理 (400/401/409/410/429/500/503),
+ * 老 fetchHttpClient 把 status 字符串化丢失语义。保留 status + 解析 body.msg
+ * 让上层 UI 可以做错误码→文案映射。
+ */
+export class OidcBindHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly msg?: string,
+  ) {
+    super(msg ? `HTTP ${status}: ${msg}` : `HTTP ${status}`)
+    this.name = 'OidcBindHttpError'
+  }
+}
+
+// 后端约定 4xx/5xx 响应体: {"msg": "<英文短描述>"}.
+// thirdlogin 老端点不遵循此契约, 解析失败时返回 undefined 不抛.
+async function parseErrorMsg(resp: Response): Promise<string | undefined> {
+  const text = await resp.text().catch(() => '')
+  if (!text) return undefined
+  try {
+    const parsed = JSON.parse(text) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const m = (parsed as Record<string, unknown>).msg
+      if (typeof m === 'string' && m !== '') return m
+    }
+  } catch {
+    /* 非 JSON 响应体 */
+  }
+  return text || undefined
+}
+
+/**
  * OIDC endpoints live at absolute paths like `/v1/...` and must bypass the
  * apiClient baseURL (which is `/api/...`). Use the global fetch.
  *
@@ -40,8 +72,28 @@ export const fetchHttpClient: OidcHttpClient = {
       signal,
     })
     if (!resp.ok) {
-      const body = await resp.text().catch(() => '')
-      throw new Error(`HTTP ${resp.status}: ${body || resp.statusText}`)
+      throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
+    }
+    return (await resp.json()) as T
+  },
+  async post<T>(
+    url: string,
+    body: unknown,
+    init?: { signal?: AbortSignal },
+  ): Promise<T> {
+    const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
+    const resp = await fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body ?? {}),
+      signal,
+    })
+    if (!resp.ok) {
+      throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
     }
     return (await resp.json()) as T
   },

--- a/packages/dmworklogin/src/oidc/index.ts
+++ b/packages/dmworklogin/src/oidc/index.ts
@@ -31,4 +31,4 @@ export {
 } from './poller'
 export type { PollAuthStatusOptions } from './poller'
 
-export { fetchHttpClient } from './http'
+export { fetchHttpClient, OidcBindHttpError } from './http'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   timeout: 60000,
   use: {
     headless: true,
-    baseURL: 'https://im-test.xming.ai',
+    baseURL: 'https://im-test.deepminer.com.cn',
   },
 });


### PR DESCRIPTION
## Summary

Frontend implementation for two server-side OIDC bind PRs, plus a login page UX revamp and a fix for a pre-existing StrictMode bug surfaced during integration.

| Server PR | Feature |
|---|---|
| [octo-server#73](https://github.com/Mininglamp-OSS/octo-server/pull/73) | OIDC self-service bind (verify existing Octo account via password / SMS) |
| [octo-server#93](https://github.com/Mininglamp-OSS/octo-server/pull/93) | Self-service account creation (open an Octo account directly from SSO claims) |

## Commits

Original four atomic commits, followed by review-driven fix commits that the diff folds into the same logical changes:

| Commit | Scope |
|---|---|
| `afd07e4c` | feat(oidc): add bind self-service api layer (5 endpoint wrappers, entry-param parsing, URL scrub, provider fallback, typed `BindCreateBlocked`) |
| `2e397150` | feat(oidc): bind page UI + shared `applyLoginResp` session writer |
| `e0f59dc7` | feat(login): login page UX revamp + IdP trust anchor + collapse legacy form + StrictMode OidcResume fix |
| `247852eb` | chore(e2e): Playwright bind suite (Chromium only, workspace-local browser) |
| `3cac5f1d` → `d0561424` | fix(oidc): review-driven hardening (see *Hardened invariants* below) |

## Architecture

`oidc/bind/` — protocol layer (no UI dependency)

- `OidcHttpClient.post` + `OidcBindHttpError` preserve HTTP status + `body.msg` so upper layers branch on 400 / 401 / 409 / 410 / 422 / 429 / 500 / 503
- 5 endpoint wrappers: `fetchBindInfo`, `verifyBindPassword`, `sendBindOtp`, `checkBindOtp`, `confirmBind`, `createBind`
- `resolveProvider()` validates URL `provider` against an allow-shape and falls back to `FALLBACK_PROVIDER_ID` (`'aegis'`) with a telemetry hook
- `BindCreateBlocked` typed union (`'' | 'disabled' | 'claims_incomplete' | 'manual_conflict' | 'consumed'`); unknown values degrade to `''` so old backends don't trigger spurious blocking UI

`loginSession.ts` — shared session writer

- Extracts `applyLoginResp` shared by the legacy `LoginVM` path and the new bind/create path so both session-entry routes write the same fields the same way
- Tri-state realname (`true` / `false` / `undefined` for "unknown")

`bind/BindPage` — UI layer

- State machine: `init → loading_info → choose_method → verify_password|verify_otp → confirming|creating → success|fatal`
- **Bind token strictly in `useRef`** — never in React state, sessionStorage, store, Sentry, or console (PR#73 §2.2 mitigation for the bind_token-in-URL known limitation)
- UX inversion (per PR#93 contract): primary button = Create, secondary = Verify
- `runConfirm` / `runCreate` validate `entryRef` before transitioning to the confirming/creating loader so a stale ref can't park the user on an unrecoverable spinner

## Hardened invariants (review-driven)

These were tightened across the fix commits and now hold as regression-tested invariants:

1. **Token never appears in the Back stack.** `BindModule.init` snapshots `location.search` AND synchronously `history.replaceState`s the bind params off the live URL, before `RouteManager`'s `pageshow` handler runs `pushState`. Without that, the original `?token=…` entry stayed in history under the later `?sid=…` entry, so Back / Referer could expose the token.
2. **`clearBindUrl` preserves `sid`.** Earlier impl wiped the whole search, routing `LoginInfo.save()`'s sid-keyed storage to the empty bucket and losing the session on reload. Now only the bind-specific keys (`token`, `authcode`, `return_to`, `provider`) are stripped.
3. **`loginProvider` persists the real IdP id, not a synthetic label.** Earlier impl wrote `'oidc-bind'` / `'oidc-bind-create'` strings into `WKApp.loginInfo.loginProvider`. Downstream `NavSettingsPanel` / `realnameVerifyUrl` / `login.tsx` reset-password resolve URLs via `providers.find(p => p.id === loginProvider)` — synthetic ids would fail closed and silently break account-center, realname-verify, and reset-password. Now uses `entry.provider || FALLBACK_PROVIDER_ID`, matching `resolveProvider` semantics in the api layer and the legacy `login_vm.loginSuccess(pending.providerId)` contract.
4. **`pendingInviteCode` survives bind/create success.** After applyLoginResp persists the session, `finalizeBindSuccess` hands off to `AppLayout.onLogin` (via `WKApp.endpoints.callOnLogin`) when a validated invite slug is present, so the `/space/invite` → `/space/join` chain runs as if the user had completed legacy login. `history.replaceState('/')` precedes the handoff so `AppLayout` computes `basePath` correctly.
5. **Error terminality is endpoint-aware.** `errorMessages.mapBindError` classifies 401/429/500/503 as retryable on interactive endpoints (verify_*) and terminal on `confirm` / `create` where the confirming loader has no recovery surface. 409 on verify auto-advances to confirm (the token is already verified server-side); 409 on confirm is terminal with the "identity already bound" copy.
6. **`return_to` sanitization rejects open-redirect variants.** Absolute URLs, protocol-relative `//host`, `\\`-escaped paths and `%5C`-encoded variants, and cross-origin URLs all fall back to `'/'`.

## Test plan

- [x] `cd packages/dmworklogin && pnpm test` — vitest **165/165**
- [x] `cd apps/web && pnpm test:e2e:bind` — Playwright **24/24** (~19s, Chromium only)
- [x] Real backend smoke (im-test):
  - [x] OIDC autolink success path unchanged
  - [x] OIDC autolink fail + bind enabled → redirected to `/oidc/bind` with real token / claims; BindPage renders masked email; missing `masked_phone` correctly omitted; `methods=['password']` hides the SMS button
  - [x] verify_password 401 → soft warm-orange inline error, form stays editable
  - [x] `/bind/create` 200 → `applyLoginResp` writes `loginInfo`, navigates to `return_to`
  - [x] After StrictMode fix, `/login` landing successfully polls to status=1 and reaches main app
- [ ] **Not exercised**: full real-IdP end-to-end via option A (requires backend to temporarily set `OCTO_OIDC_BIND_REDIRECT_BASE` to localhost; deferred)
- [ ] **Backend follow-up**: once appconfig exposes `legacy_password_login_off` (or equivalent), swap the hard-hidden `LegacyPasswordSection` in BindPage for a `WKApp.remoteConfig` read; marked with `TODO(legacy-login-flag)`

## Compatibility / rollout

- ✅ Old backend that doesn't return `allow_create` / `create_blocked` → frontend treats it as "no create entry", falls back to verify-only UX. **Fully backward-compatible.**
- ✅ Bind switch OFF / issuer not in allowlist → callback uses the legacy failure path; frontend unchanged
- ⚠️ `apps/web/.env.local` (gitignored) needs `VITE_API_URL` for the dev proxy; `VITE_ENABLE_ENTERPRISE_SSO=true` gates SSO entry visibility

## Out of scope (follow-up)

- `legacy_password_login_off` wire-up (waiting on backend PR)
- Permanent fix for bind_token-in-URL (issue independent confirm secret after verify success; currently mitigated via `replaceState` + no-store, per PR#73 §5)
- Abandon-bind cleanup endpoint (PR#73 §4.5 known follow-up)
- bind.css uses hardcoded colors / Semi overrides; should migrate to project theme tokens
