### PR TITLE
feat(persona): v2 — list toggle + persona_prompt textarea + edit form reuse (#73)

### DIFF
--- a/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
@@ -52,10 +52,25 @@ interface PersonaEditProps {
 
 interface PersonaEditState {
     confirmDelete: boolean
+    /**
+     * v2 (octo-web#73)：表单本地状态。用 props.grant 做初值；用户在 textarea 里编辑
+     * 时只更新 state，直到点「保存」才 PUT —— 避免每次 onChange 都打一次后端。
+     * `active` 也走同样的本地态：用户切 toggle 后立即提交（active 是单一布尔，没有
+     * 「半成品」状态需要先暂存），但保存按钮也允许把当前未保存的 prompt 与 active
+     * 一次提交，便于「改 prompt 顺手切 active」的常见路径。
+     */
+    prompt: string
+    active: boolean
+    saving: boolean
 }
 
 export default class PersonaEdit extends Component<PersonaEditProps, PersonaEditState> {
-    state: PersonaEditState = { confirmDelete: false }
+    state: PersonaEditState = {
+        confirmDelete: false,
+        prompt: this.props.grant.persona_prompt || "",
+        active: !!this.props.grant.active,
+        saving: false,
+    }
     private confirmTimer?: ReturnType<typeof setTimeout>
 
     componentWillUnmount() {
@@ -86,6 +101,27 @@ export default class PersonaEdit extends Component<PersonaEditProps, PersonaEdit
         })
     }
 
+    /**
+     * v2 (octo-web#73)：一次 PUT 提交 persona_prompt + active。
+     * 成功后调父级 onChange 让 PersonaSettingsVM 重拉列表 —— 后端在 active=true 时会
+     * mutex 其它 grant 的 active=false，本地这里看不见别人状态变化，必须 reload。
+     */
+    private handleSave = (vm: PersonaEditVM) => {
+        if (this.state.saving) return
+        this.setState({ saving: true })
+        void vm
+            .savePersonaForm(this.state.prompt, this.state.active)
+            .then((ok) => {
+                if (ok) {
+                    Toast.success("已保存")
+                    if (this.props.onChange) this.props.onChange()
+                }
+            })
+            .finally(() => {
+                this.setState({ saving: false })
+            })
+    }
+
     render(): ReactNode {
         const { grant } = this.props
         return (
@@ -108,13 +144,64 @@ export default class PersonaEdit extends Component<PersonaEditProps, PersonaEdit
                     const removeLabel = globalOn ? "恢复代答" : "停止代答"
                     return (
                         <div className="wk-persona-edit">
-                            {/* 基础信息 */}
+                            {/* 基础信息 + v2 表单（octo-web#73）：
+                                bot 名（只读）+ persona_prompt（可编辑）+ active toggle + 保存
+                                布局复用 Create 表单视觉风格，让用户在两条路径上拿到一致的填写体验。 */}
                             <div className="wk-persona-edit-section">
                                 <div className="wk-persona-edit-row">
                                     <div className="wk-persona-edit-row-title">关联 Bot</div>
-                                    <div className="wk-persona-edit-row-value">
+                                    <div
+                                        className="wk-persona-edit-row-value"
+                                        data-testid="persona-edit-bot-name"
+                                    >
                                         {vm.grant.grantee_bot_name || vm.grant.grantee_bot_uid}
                                     </div>
+                                </div>
+                                {/*
+                                 * persona_prompt textarea：纵向占整行，与「关联 Bot」/「启用」
+                                 * 的「左标题右值」横排不同，所以单独一个 column-row。
+                                 * 用原生 textarea 与 PersonaCreate 保持一致（避免引入额外 Semi 组件
+                                 * mock 噪音；Semi TextArea 在 RoutePage 容器里也偶发样式 portal 问题）。
+                                 */}
+                                <div className="wk-persona-edit-row wk-persona-edit-row-column">
+                                    <div className="wk-persona-edit-row-title">回复风格 prompt</div>
+                                    <textarea
+                                        className="wk-persona-edit-prompt"
+                                        placeholder="设置分身的回复风格，如：用简洁专业的语气回复"
+                                        value={this.state.prompt}
+                                        onChange={(e) =>
+                                            this.setState({ prompt: e.target.value })
+                                        }
+                                        rows={4}
+                                        data-testid="persona-edit-prompt"
+                                    />
+                                </div>
+                                <div className="wk-persona-edit-row">
+                                    <div className="wk-persona-edit-row-title">启用此分身</div>
+                                    <div className="wk-persona-edit-row-control">
+                                        {/*
+                                         * v2 (octo-web#73)：active 是 mutex 字段，后端在 PUT
+                                         * {active:true} 时会自动把同一用户其它 grant 的 active
+                                         * 置 false。前端只 toggle 自己的状态，剩下的依赖
+                                         * onChange → 父级 reload 把整列表拉回来对齐。
+                                         */}
+                                        <Switch
+                                            checked={this.state.active}
+                                            onChange={(v: boolean) =>
+                                                this.setState({ active: !!v })
+                                            }
+                                        />
+                                    </div>
+                                </div>
+                                <div className="wk-persona-edit-row">
+                                    <button
+                                        className="wk-persona-edit-save-btn"
+                                        disabled={this.state.saving}
+                                        onClick={() => this.handleSave(vm)}
+                                        data-testid="persona-edit-save"
+                                    >
+                                        {this.state.saving ? "保存中..." : "保存"}
+                                    </button>
                                 </div>
                                 <div className="wk-persona-edit-row">
                                     <div className="wk-persona-edit-row-title">模式</div>

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
@@ -29,7 +29,8 @@ const hoisted = vi.hoisted(() => {
     const put = vi.fn()
     const toastError = vi.fn()
     const toastWarning = vi.fn()
-    return { get, post, del, put, toastError, toastWarning }
+    const toastSuccess = vi.fn()
+    return { get, post, del, put, toastError, toastWarning, toastSuccess }
 })
 
 vi.mock("../../../App", () => ({
@@ -57,6 +58,7 @@ vi.mock("@douyinfe/semi-ui", () => ({
     Toast: {
         error: hoisted.toastError,
         warning: hoisted.toastWarning,
+        success: hoisted.toastSuccess,
     },
 }))
 
@@ -89,6 +91,7 @@ beforeEach(() => {
     hoisted.put.mockReset()
     hoisted.toastError.mockReset()
     hoisted.toastWarning.mockReset()
+    hoisted.toastSuccess.mockReset()
 })
 
 afterEach(() => {
@@ -269,5 +272,130 @@ describe("PersonaEdit — remove action wiring (R4 P1 regression guard)", () => 
             "已排除的会话 (0)",
         )
         expect(screen.getByText(/暂无排除的会话/)).toBeInTheDocument()
+    })
+})
+
+/**
+ * v2 (octo-web#73) PersonaEdit form 测试 ——「reuse create form」：
+ *   - 关联 Bot 名只读展示
+ *   - persona_prompt textarea 用 grant.persona_prompt 预填
+ *   - 启用 toggle 用 grant.active 预填
+ *   - 「保存」按钮 → PUT 把 prompt + active 一并提交（savePersonaForm）
+ *   - 保存成功后调 onChange，让父级列表 reload 抓后端 mutex 之后的最新状态
+ *
+ * 这一组直接对应 issue task 3。textarea 用原生 <textarea>，所以无需额外 mock
+ * Semi TextArea —— fireEvent.change 即可触发 onChange。
+ */
+describe("PersonaEdit — v2 (octo-web#73) form (bot read-only + prompt + active)", () => {
+    it("pre-fills bot name + persona_prompt + active toggle from grant", async () => {
+        hoisted.get.mockResolvedValueOnce([])
+        render(
+            <PersonaEdit
+                grant={baseGrant({
+                    grantee_bot_name: "Demo Bot",
+                    persona_prompt: "已设置的风格",
+                    active: true,
+                })}
+                onDeleted={() => {}}
+            />,
+        )
+        await waitForScopesLoaded()
+        expect(screen.getByTestId("persona-edit-bot-name")).toHaveTextContent("Demo Bot")
+        const textarea = screen.getByTestId("persona-edit-prompt") as HTMLTextAreaElement
+        expect(textarea.value).toBe("已设置的风格")
+        // 第一个 Switch 是 v2 form 的「启用此分身」，第二个是旧 global toggle。
+        // 我们 stub Switch 渲染成 checkbox，所以两个都能查到 — 用顺序断言 v2 在前。
+        const switches = screen.getAllByTestId("persona-edit-global-switch")
+        expect(switches.length).toBeGreaterThanOrEqual(2)
+        expect((switches[0] as HTMLInputElement).checked).toBe(true)
+    })
+
+    it("falls back to bot uid when grantee_bot_name is missing (task 4 regression guard)", async () => {
+        hoisted.get.mockResolvedValueOnce([])
+        render(
+            <PersonaEdit
+                grant={baseGrant({
+                    grantee_bot_name: undefined,
+                    grantee_bot_uid: "27qFHDRBCJQ2c868c93_bot",
+                })}
+                onDeleted={() => {}}
+            />,
+        )
+        await waitForScopesLoaded()
+        expect(screen.getByTestId("persona-edit-bot-name")).toHaveTextContent(
+            "27qFHDRBCJQ2c868c93_bot",
+        )
+    })
+
+    it("uses the v2 textarea placeholder verbatim (issue body fixes the wording)", async () => {
+        hoisted.get.mockResolvedValueOnce([])
+        render(
+            <PersonaEdit
+                grant={baseGrant({ persona_prompt: "" })}
+                onDeleted={() => {}}
+            />,
+        )
+        await waitForScopesLoaded()
+        const textarea = screen.getByTestId("persona-edit-prompt")
+        // placeholder 文案直接来自 issue body — 不要再改，否则与 PersonaCreate 那条
+        // 视觉一致性就破了。
+        expect(textarea).toHaveAttribute(
+            "placeholder",
+            "设置分身的回复风格，如：用简洁专业的语气回复",
+        )
+    })
+
+    it("save button → PUT /v1/obo/grants/:id with persona_prompt + active in one call", async () => {
+        hoisted.get.mockResolvedValueOnce([])
+        hoisted.put.mockResolvedValueOnce({})
+        const onChange = vi.fn()
+        render(
+            <PersonaEdit
+                grant={baseGrant({ persona_prompt: "", active: false })}
+                onDeleted={() => {}}
+                onChange={onChange}
+            />,
+        )
+        await waitForScopesLoaded()
+
+        // 模拟用户编辑 textarea + 切换 active toggle
+        const textarea = screen.getByTestId("persona-edit-prompt") as HTMLTextAreaElement
+        fireEvent.change(textarea, { target: { value: "新的简洁风格" } })
+        const v2Switch = screen.getAllByTestId("persona-edit-global-switch")[0] as HTMLInputElement
+        fireEvent.click(v2Switch)
+
+        // 点保存
+        fireEvent.click(screen.getByTestId("persona-edit-save"))
+
+        await waitFor(() =>
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", {
+                persona_prompt: "新的简洁风格",
+                active: true,
+            }),
+        )
+        // onChange 被调以提示父级 reload（mutex 影响其它行）
+        await waitFor(() => expect(onChange).toHaveBeenCalled())
+    })
+
+    it("save with cleared prompt sends empty string (user explicitly removed prompt)", async () => {
+        // 关键边界：与 create 的「空串过滤」相反，编辑里清空是合法语义。
+        hoisted.get.mockResolvedValueOnce([])
+        hoisted.put.mockResolvedValueOnce({})
+        render(
+            <PersonaEdit
+                grant={baseGrant({ persona_prompt: "old prompt", active: true })}
+                onDeleted={() => {}}
+            />,
+        )
+        await waitForScopesLoaded()
+        const textarea = screen.getByTestId("persona-edit-prompt") as HTMLTextAreaElement
+        fireEvent.change(textarea, { target: { value: "" } })
+        fireEvent.click(screen.getByTestId("persona-edit-save"))
+        await waitFor(() =>
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", {
+                persona_prompt: "",
+                active: true,
+            }),
+        )
     })
 })

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaSettings.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaSettings.test.tsx
@@ -19,7 +19,7 @@
 
 import React from "react"
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 const hoisted = vi.hoisted(() => {
@@ -48,6 +48,16 @@ vi.mock("../../../App", () => ({
 vi.mock("@douyinfe/semi-ui", () => ({
     Button: (props: any) =>
         React.createElement("button", { ...props, "data-testid": props["data-testid"] || "btn" }, props.children),
+    // v2 (octo-web#73)：PersonaCard 现在内嵌 Switch 用作 active toggle。
+    // 与 PersonaEdit.test 同款最小 stub —— 直接渲染原生 checkbox，
+    // 避免拉起 Semi 主题 / portal 层，同时让测试能用 fireEvent.click 触发 onChange。
+    Switch: (props: any) =>
+        React.createElement("input", {
+            type: "checkbox",
+            checked: !!props.checked,
+            onChange: (e: any) => props.onChange && props.onChange(e.target.checked),
+            "data-testid": props["data-testid"] || "persona-list-switch",
+        }),
     Toast: {
         error: hoisted.toastError,
         warning: hoisted.toastWarning,
@@ -131,5 +141,148 @@ describe("PersonaSettings list — BUG-1 regression (YUJ-1341)", () => {
         // Allow any pending microtasks to flush
         await Promise.resolve()
         expect(hoisted.get.mock.calls.length).toBe(calls)
+    })
+})
+
+/**
+ * v2 (octo-web#73) PersonaCard active toggle 测试。
+ *
+ * 任务 1（issue body）：「列表行加 toggle，开启时调后端 mutex（关其它），active
+ * 卡片高亮，其余 dimmed」。这一组测试覆盖：
+ *   - 列表渲染时每行确实出现 Switch（用 data-testid 锁定）
+ *   - 点击开 → PUT /v1/obo/grants/:id {active:true}（后端处理 mutex，前端只发 1 个请求）
+ *   - active 卡片有 .wk-persona-card-active class，非 active 在「有人 active」时 dimmed
+ *   - 点 toggle 不会冒泡触发卡片 onClick（不应跳进 PersonaEdit）—— 这是 UX 关键路径
+ *   - 全部 inactive 时不 dim 任何卡片（dim 只在「有 active」时生效，否则会让空列表看上去全是禁用）
+ *
+ * Bot name 显示（任务 4）：grant.grantee_bot_name 应出现在 Card 上；这条已被
+ * 「renders the grant card when API returns one grant」覆盖（断言 "James Persona"）。
+ * 这里再加一条独立断言保证 v2 改造没回归。
+ */
+describe("PersonaSettings list — v2 (octo-web#73) active toggle + visual states", () => {
+    it("renders a toggle on each persona row", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 1, grantee_bot_name: "Alpha" }),
+            sampleGrant({ id: 2, grantee_bot_name: "Beta", active: false }),
+        ])
+        render(<PersonaSettings />)
+        // 两张卡片 → 两个 toggle 容器
+        expect(await screen.findByTestId("persona-card-toggle-1")).toBeInTheDocument()
+        expect(screen.getByTestId("persona-card-toggle-2")).toBeInTheDocument()
+    })
+
+    it("toggling an inactive row → PUT /obo/grants/:id {active:true} (backend handles mutex)", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 7, grantee_bot_name: "Gamma", active: false }),
+        ])
+        // updateGrant → put then reload
+        hoisted.put.mockResolvedValueOnce({})
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 7, grantee_bot_name: "Gamma", active: true }),
+        ])
+
+        render(<PersonaSettings />)
+        const toggleWrap = await screen.findByTestId("persona-card-toggle-7")
+        const cb = toggleWrap.querySelector('input[type="checkbox"]') as HTMLInputElement
+        expect(cb).toBeTruthy()
+        expect(cb.checked).toBe(false)
+
+        fireEvent.click(cb)
+
+        // 关键合约：前端只 PUT {active:true}，**不**预先 PATCH 其它 grant 的 active=false。
+        // 后端 (octo-server#108) 自行处理 mutex。
+        await waitFor(() =>
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/7", { active: true }),
+        )
+        // 前端没多发别的 PUT
+        expect(hoisted.put).toHaveBeenCalledTimes(1)
+    })
+
+    it("toggling an active row off → PUT {active:false}", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 9, grantee_bot_name: "Delta", active: true }),
+        ])
+        hoisted.put.mockResolvedValueOnce({})
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 9, grantee_bot_name: "Delta", active: false }),
+        ])
+        render(<PersonaSettings />)
+        const cb = (await screen.findByTestId("persona-card-toggle-9")).querySelector(
+            'input[type="checkbox"]',
+        ) as HTMLInputElement
+        expect(cb.checked).toBe(true)
+        fireEvent.click(cb)
+        await waitFor(() =>
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/9", { active: false }),
+        )
+    })
+
+    it("active card gets .wk-persona-card-active; non-active siblings get .wk-persona-card-dimmed", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 1, grantee_bot_name: "Alpha", active: true }),
+            sampleGrant({ id: 2, grantee_bot_name: "Beta", active: false }),
+            sampleGrant({ id: 3, grantee_bot_name: "Gamma", active: false }),
+        ])
+        render(<PersonaSettings />)
+        const cardActive = await screen.findByTestId("persona-card-1")
+        expect(cardActive.className).toContain("wk-persona-card-active")
+        expect(cardActive.className).not.toContain("wk-persona-card-dimmed")
+
+        const cardDimmed = screen.getByTestId("persona-card-2")
+        expect(cardDimmed.className).toContain("wk-persona-card-dimmed")
+        expect(cardDimmed.className).not.toContain("wk-persona-card-active")
+
+        expect(screen.getByTestId("persona-card-3").className).toContain(
+            "wk-persona-card-dimmed",
+        )
+    })
+
+    it("when no row is active, none are dimmed (avoids the 'everything looks disabled' trap)", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 1, grantee_bot_name: "Alpha", active: false }),
+            sampleGrant({ id: 2, grantee_bot_name: "Beta", active: false }),
+        ])
+        render(<PersonaSettings />)
+        await screen.findByTestId("persona-card-1")
+        expect(screen.getByTestId("persona-card-1").className).not.toContain(
+            "wk-persona-card-dimmed",
+        )
+        expect(screen.getByTestId("persona-card-2").className).not.toContain(
+            "wk-persona-card-dimmed",
+        )
+    })
+
+    it("clicking the toggle does NOT bubble up to open PersonaEdit (UX guard)", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 5, grantee_bot_name: "Echo", active: false }),
+        ])
+        hoisted.put.mockResolvedValueOnce({})
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({ id: 5, grantee_bot_name: "Echo", active: true }),
+        ])
+        render(<PersonaSettings />)
+        const toggleWrap = await screen.findByTestId("persona-card-toggle-5")
+        const cb = toggleWrap.querySelector('input[type="checkbox"]') as HTMLInputElement
+        fireEvent.click(cb)
+        await waitFor(() => expect(hoisted.put).toHaveBeenCalled())
+        // PersonaEdit 的「关联 Bot」标签是它独有的，如果它被 push 进了 route stack
+        // 应该会出现在 DOM 里。Bot 名 "Echo" 在卡片里也存在但「关联 Bot」label 只在 Edit 出现。
+        expect(screen.queryByText("关联 Bot")).not.toBeInTheDocument()
+    })
+
+    it("persists grantee_bot_name on the card (task 4 — PR#70 regression guard)", async () => {
+        hoisted.get.mockResolvedValueOnce([
+            sampleGrant({
+                id: 1,
+                grantee_bot_uid: "27qFHDRBCJQ2c868c93_bot",
+                grantee_bot_name: "James Persona",
+            }),
+        ])
+        render(<PersonaSettings />)
+        // 必须落 grantee_bot_name 而不是 uid；uid 不应该被人看见。
+        expect(await screen.findByText("James Persona")).toBeInTheDocument()
+        expect(
+            screen.queryByText("27qFHDRBCJQ2c868c93_bot", { exact: false }),
+        ).not.toBeInTheDocument()
     })
 })

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
@@ -170,6 +170,37 @@ describe("PersonaSettingsVM.createGrant", () => {
         await vm.createGrant("b1")
         expect(vm.myBots).toEqual([])
     })
+
+    // v2 (octo-web#73): personaPrompt argument hits POST body when non-empty;
+    // empty / whitespace input is filtered so it doesn't overwrite the server's
+    // NULL default (fan-out logic distinguishes "" from NULL when assembling
+    // the system prompt).
+    it("sends persona_prompt in POST body when provided (v2 octo-web#73)", async () => {
+        const created = { id: 8, grantor_uid: "u1", grantee_bot_uid: "b1", mode: "auto", global_enabled: false, active: false }
+        hoisted.post.mockResolvedValueOnce(created)
+        hoisted.get.mockResolvedValueOnce([created])
+        const vm = new PersonaSettingsVM()
+        await vm.createGrant("b1", "用简洁专业的语气回复")
+        expect(hoisted.post).toHaveBeenCalledWith("obo/grants", {
+            grantee_bot_uid: "b1",
+            mode: "auto",
+            global_enabled: false,
+            persona_prompt: "用简洁专业的语气回复",
+        })
+    })
+
+    it("trims persona_prompt and omits when blank (v2 octo-web#73)", async () => {
+        // 用户没填 prompt → 不要把 "" 提交进 body 把后端 NULL 覆盖成 ''。
+        hoisted.post.mockResolvedValueOnce({})
+        hoisted.get.mockResolvedValueOnce([])
+        const vm = new PersonaSettingsVM()
+        await vm.createGrant("b1", "   ")
+        expect(hoisted.post).toHaveBeenCalledWith("obo/grants", {
+            grantee_bot_uid: "b1",
+            mode: "auto",
+            global_enabled: false,
+        })
+    })
 })
 
 describe("PersonaSettingsVM.deleteGrant / updateGrant", () => {
@@ -190,6 +221,22 @@ describe("PersonaSettingsVM.deleteGrant / updateGrant", () => {
         const ok = await vm.updateGrant(42, { global_enabled: true })
         expect(ok).toBe(true)
         expect(hoisted.put).toHaveBeenCalledWith("obo/grants/42", { global_enabled: true })
+    })
+
+    // v2 (octo-web#73): updateGrant now accepts `active` so PersonaCard toggle
+    // can flip it; backend (octo-server#108) performs mutual exclusion across
+    // the user's grants — the frontend just sends one PUT.
+    it("update accepts {active:true} and reloads list (backend handles mutex)", async () => {
+        hoisted.put.mockResolvedValueOnce({})
+        hoisted.get.mockResolvedValueOnce([
+            { id: 42, grantor_uid: "u1", grantee_bot_uid: "b1", mode: "auto", global_enabled: false, active: true },
+        ])
+        const vm = new PersonaSettingsVM()
+        const ok = await vm.updateGrant(42, { active: true })
+        expect(ok).toBe(true)
+        expect(hoisted.put).toHaveBeenCalledWith("obo/grants/42", { active: true })
+        // 必须 reload，因为后端 mutex 把别的 grant 改成 inactive 了，前端这里看不见。
+        expect(hoisted.get).toHaveBeenCalledWith("obo/grants")
     })
 
     it("delete returns false and toasts on error", async () => {
@@ -259,6 +306,58 @@ describe("PersonaEditVM", () => {
         const ok = await vm.deleteGrant()
         expect(ok).toBe(true)
         expect(hoisted.del).toHaveBeenCalledWith("obo/grants/99")
+    })
+
+    // v2 (octo-web#73): savePersonaForm puts persona_prompt + active in one round-trip
+    // and updates local grant optimistically. This is the primary write path for the
+    // PersonaEdit form's "保存" button.
+    describe("savePersonaForm (v2 octo-web#73)", () => {
+        it("PUTs persona_prompt + active together and updates local grant", async () => {
+            hoisted.put.mockResolvedValueOnce({})
+            const vm = new PersonaEditVM(grant)
+            const ok = await vm.savePersonaForm("用简洁专业的语气回复", true)
+            expect(ok).toBe(true)
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", {
+                persona_prompt: "用简洁专业的语气回复",
+                active: true,
+            })
+            // 本地乐观更新：避免 UI 还显示旧值等到 reload。
+            expect(vm.grant.persona_prompt).toBe("用简洁专业的语气回复")
+            expect(vm.grant.active).toBe(true)
+        })
+
+        it("allows empty string prompt (user explicitly clearing previously set prompt)", async () => {
+            // 边界：编辑场景下空串不应被过滤 —— 用户的真实意图就是「清掉之前写的 prompt」。
+            // 这与 createGrant 的策略相反（创建时空串意味着「我还没填」→ 过滤）。
+            hoisted.put.mockResolvedValueOnce({})
+            const vm = new PersonaEditVM({ ...grant, persona_prompt: "old style" })
+            const ok = await vm.savePersonaForm("", false)
+            expect(ok).toBe(true)
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", {
+                persona_prompt: "",
+                active: false,
+            })
+            expect(vm.grant.persona_prompt).toBe("")
+            expect(vm.grant.active).toBe(false)
+        })
+
+        it("omits active when not provided (prompt-only save)", async () => {
+            hoisted.put.mockResolvedValueOnce({})
+            const vm = new PersonaEditVM(grant)
+            await vm.savePersonaForm("hello")
+            expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", {
+                persona_prompt: "hello",
+            })
+            expect(vm.grant.active).toBe(grant.active) // unchanged
+        })
+
+        it("returns false + toasts on failure", async () => {
+            hoisted.put.mockRejectedValueOnce({ status: 500, msg: "save boom" })
+            const vm = new PersonaEditVM(grant)
+            const ok = await vm.savePersonaForm("x", true)
+            expect(ok).toBe(false)
+            expect(hoisted.toastError).toHaveBeenCalledWith("save boom")
+        })
     })
 })
 

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.css
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.css
@@ -150,6 +150,44 @@
     color: var(--wk-color-danger);
 }
 
+/*
+ * v2 (octo-web#73) PersonaCard active toggle 容器。Semi <Switch> 在裸 flex 子项
+ * 位置同样会被父行的 flex 算法压扁（与 PersonaEdit row-control 同样根因），
+ * 这里给它一个固定 container：
+ *   - flex-shrink: 0 锁定容器不被 .wk-persona-card-info 的 flex:1 抢占；
+ *   - 阻断 pointer cursor 继承（外层卡片有 cursor: pointer），让 Switch
+ *     视觉上明确是「可点的开关」而非「卡片本身」；
+ *   - 自身的 click 在 JSX 里 stopPropagation，不会触发卡片 onClick → 跳进 Edit。
+ */
+.wk-persona-card-toggle {
+    flex: 0 0 auto;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    margin-left: var(--wk-sp-3);
+    min-width: 44px;
+    cursor: default;
+    overflow: visible;
+}
+
+/*
+ * v2: active 卡片高亮（左侧描边 + 略微凸起），其余 dimmed 卡片降低 opacity。
+ * 这是「同一时刻只有一个生效」mutex 语义最直观的视觉映射 —— 用户一眼能看出
+ * 「现在是哪个分身在替我回」。
+ */
+.wk-persona-card-active {
+    border-color: var(--wk-brand-primary);
+    box-shadow: 0 0 0 1px var(--wk-brand-primary) inset;
+}
+
+.wk-persona-card-dimmed {
+    opacity: 0.55;
+}
+
+.wk-persona-card-dimmed:hover {
+    opacity: 0.85;
+}
+
 .wk-persona-empty {
     padding: var(--wk-sp-8) 0;
     text-align: center;
@@ -293,6 +331,64 @@
     overflow: visible;
 }
 
+/*
+ * v2 (octo-web#73)：persona_prompt textarea 行用 column 布局而不是 row 默认的
+ * 「左标题右值」横排，因为 textarea 高度大于一行，横排会挤压标题宽度。
+ * 行内仍保留 padding 与 border-bottom 节奏，只是把 flex-direction 翻成 column。
+ */
+.wk-persona-edit-row-column {
+    flex-direction: column;
+    align-items: stretch;
+    /* min-height 给 textarea + 标题留出垂直呼吸空间，覆盖默认 56px */
+    min-height: auto;
+    gap: var(--wk-sp-2);
+    padding-top: var(--wk-sp-3);
+    padding-bottom: var(--wk-sp-3);
+}
+
+.wk-persona-edit-prompt {
+    width: 100%;
+    box-sizing: border-box;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    border-radius: var(--wk-r-sm);
+    border: 1px solid var(--wk-border-default);
+    background: var(--wk-bg-base);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-base);
+    font-family: inherit;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 80px;
+}
+
+.wk-persona-edit-prompt:focus {
+    outline: none;
+    border-color: var(--wk-brand-primary);
+}
+
+.wk-persona-edit-save-btn {
+    flex: 1;
+    width: 100%;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-brand-primary);
+    color: var(--wk-text-on-brand);
+    font-size: var(--wk-text-size-md);
+    font-weight: var(--wk-font-medium);
+    border: none;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.wk-persona-edit-save-btn:hover {
+    opacity: 0.9;
+}
+
+.wk-persona-edit-save-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .wk-persona-edit-scope-list {
     display: flex;
     flex-direction: column;
@@ -358,6 +454,53 @@
 }
 
 .wk-persona-create-row:hover {
+    border-color: var(--wk-brand-primary);
+}
+
+/*
+ * v2 (octo-web#73)：PersonaCreate 改成「选 bot → 展开 prompt 表单 → 提交」两步流程。
+ * 选中的 bot 行用边框 + 浅色背景标识，与未选中行视觉区分清晰；下方表单区域留出
+ * 间距承接 prompt textarea + 提交按钮。
+ */
+.wk-persona-create-row-selected {
+    border-color: var(--wk-brand-primary);
+    background: var(--wk-brand-tint-08);
+}
+
+.wk-persona-create-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wk-sp-2);
+    margin-top: var(--wk-sp-2);
+    padding: var(--wk-sp-3);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-bg-surface);
+    border: 1px solid var(--wk-border-default);
+}
+
+.wk-persona-create-form-label {
+    font-size: var(--wk-text-size-sm);
+    color: var(--wk-text-secondary);
+    font-weight: var(--wk-font-medium);
+}
+
+.wk-persona-create-prompt {
+    width: 100%;
+    box-sizing: border-box;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    border-radius: var(--wk-r-sm);
+    border: 1px solid var(--wk-border-default);
+    background: var(--wk-bg-base);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-base);
+    font-family: inherit;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 80px;
+}
+
+.wk-persona-create-prompt:focus {
+    outline: none;
     border-color: var(--wk-brand-primary);
 }
 

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode } from "react"
 import RouteContext from "../../Service/Context"
 import Provider, { IProviderListener } from "../../Service/Provider"
+import { Switch } from "@douyinfe/semi-ui"
 import RoutePage from "../RoutePage"
 import { MyBot, OboGrant, PersonaSettingsVM } from "./vm"
 import PersonaEdit from "./PersonaEdit"
@@ -123,8 +124,11 @@ class PersonaListBody extends Component<PersonaListBodyProps> {
         routeContext.push(
             <PersonaCreate
                 vm={vm}
-                onCreated={async (botUid) => {
-                    const grant = await vm.createGrant(botUid)
+                onCreated={async (botUid, personaPrompt) => {
+                    // v2 (octo-web#73): persona_prompt 在创建时一并提交，省去创建后再
+                    // 进 edit 补填的回合数。空串由 vm.createGrant 内部过滤掉，不会污染
+                    // 后端的 NULL 默认。
+                    const grant = await vm.createGrant(botUid, personaPrompt)
                     if (grant) {
                         // 创建后用 replace 一步切到 edit —— 不能用 pop()+push()。
                         // 历史教训 (YUJ-1348, 2026-05-19, Jerry-Xin review on 8145f420)：
@@ -218,24 +222,37 @@ class PersonaListBody extends Component<PersonaListBodyProps> {
 
                 {/* 列表 */}
                 <div className="wk-persona-list">
-                    {vm.grants.map((g) => (
-                        <PersonaCard
-                            key={g.id}
-                            grant={g}
-                            onClick={() => {
-                                routeContext.push(
-                                    <PersonaEdit
-                                        grant={g}
-                                        onDeleted={() => {
-                                            routeContext.pop()
-                                            void vm.loadGrants()
-                                        }}
-                                        onChange={() => void vm.loadGrants()}
-                                    />,
-                                )
-                            }}
-                        />
-                    ))}
+                    {(() => {
+                        // v2 (octo-web#73)：当有任意 grant active=true 时，把非 active 的卡片
+                        // 视觉「dim」（降低不透明度）来强调「正在生效的只有这一个」。这与后端
+                        // mutex（同一用户最多一个 active grant）的产品语义直接对应；用户切换
+                        // 时也能立刻看出新的 active 行是谁。
+                        const anyActive = vm.grants.some((g) => g.active)
+                        return vm.grants.map((g) => (
+                            <PersonaCard
+                                key={g.id}
+                                grant={g}
+                                dimmed={anyActive && !g.active}
+                                onToggle={async (next) => {
+                                    // 后端在 PUT {active: true} 时自动 mutex 其它 grant，
+                                    // updateGrant 已经会 reload 整列表 → 卡片 active 状态自动同步。
+                                    await vm.updateGrant(g.id, { active: next })
+                                }}
+                                onClick={() => {
+                                    routeContext.push(
+                                        <PersonaEdit
+                                            grant={g}
+                                            onDeleted={() => {
+                                                routeContext.pop()
+                                                void vm.loadGrants()
+                                            }}
+                                            onChange={() => void vm.loadGrants()}
+                                        />,
+                                    )
+                                }}
+                            />
+                        ))
+                    })()}
                 </div>
             </div>
         )
@@ -243,17 +260,37 @@ class PersonaListBody extends Component<PersonaListBodyProps> {
 }
 
 /**
- * 卡片复用 BotStore 视觉：渐变头像 + 标题+badge + 副标题 + 状态点。
+ * 卡片复用 BotStore 视觉：渐变头像 + 标题+badge + 副标题 + 右侧 active 开关。
  * 不直接复用 BotStore/index.tsx 的 renderBotCard，是因为它带 BotInfo 专有的
  * `创建者` / `添加状态` 字段，对 persona 场景无意义。
+ *
+ * v2 (octo-web#73)：
+ *   - 右侧改为可点击的 Switch：开 → PUT {active: true}（后端 mutex 关其它），
+ *     关 → PUT {active: false}。开关 click 事件 stopPropagation，避免冒泡触发卡片
+ *     onClick 跳进 PersonaEdit。
+ *   - `dimmed` 由父级根据「列表里是否有任意 active grant」计算；非 active 卡片
+ *     opacity 调低，与 active 卡片形成对比，呼应「同一时刻只有一个生效」。
  */
-function PersonaCard(props: { grant: OboGrant; onClick: () => void }) {
-    const { grant, onClick } = props
+function PersonaCard(props: {
+    grant: OboGrant
+    dimmed?: boolean
+    onClick: () => void
+    onToggle: (next: boolean) => Promise<void> | void
+}) {
+    const { grant, dimmed, onClick, onToggle } = props
     const name = grant.grantee_bot_name || grant.grantee_bot_uid
     const initial = (name || "P").charAt(0).toUpperCase()
-    const enabled = grant.active && grant.global_enabled
+    const cardClass =
+        "wk-persona-card" +
+        (grant.active ? " wk-persona-card-active" : "") +
+        (dimmed ? " wk-persona-card-dimmed" : "")
     return (
-        <div className="wk-persona-card" onClick={onClick}>
+        <div
+            className={cardClass}
+            onClick={onClick}
+            data-testid={`persona-card-${grant.id}`}
+            data-active={grant.active ? "1" : "0"}
+        >
             <div className="wk-persona-card-header">
                 <div className="wk-persona-card-avatar">{initial}</div>
                 <div className="wk-persona-card-info">
@@ -262,28 +299,59 @@ function PersonaCard(props: { grant: OboGrant; onClick: () => void }) {
                         <span className="wk-persona-card-name-badge">分身</span>
                     </div>
                     <div className="wk-persona-card-sub">
-                        模式: {grant.mode === "draft" ? "草稿审批" : "自动回复"}
+                        {grant.persona_prompt && grant.persona_prompt.trim()
+                            ? grant.persona_prompt
+                            : "未设置回复风格"}
                     </div>
                 </div>
-                <span
-                    className={`wk-persona-card-status ${enabled ? "on" : "off"}`}
+                {/*
+                 * 开关容器拦截 click：Semi Switch 的 onChange 会在 input click 之后触发，
+                 * 但 click 还是会冒到外层 .wk-persona-card → onClick 把页面 push 到 Edit。
+                 * 用一个 wrapper stopPropagation，让 toggle 与「点卡片打开编辑」两条交互
+                 * 互不干扰；同时 Switch 的尺寸由 .wk-persona-card-toggle 锁定避免被压缩
+                 * （与 PersonaEdit row-control 同款防御）。
+                 */}
+                <div
+                    className="wk-persona-card-toggle"
+                    onClick={(e) => e.stopPropagation()}
+                    data-testid={`persona-card-toggle-${grant.id}`}
                 >
-                    {enabled ? "● 启用" : "○ 关闭"}
-                </span>
+                    <Switch
+                        checked={!!grant.active}
+                        onChange={(v: boolean) => void onToggle(!!v)}
+                    />
+                </div>
             </div>
         </div>
     )
 }
 
 /**
- * PersonaCreate —— bot 选择子页。从 vm.loadMyBots() 拉可用 bot 列表 + 过滤已绑定。
- * UX 简化：单击 bot 即创建，不再二次确认 —— 错误可在 PersonaEdit 里删除。
+ * PersonaCreate —— bot 选择子页 + persona_prompt 表单（v2, octo-web#73）。
+ *
+ * 交互：
+ *   1. 顶部一份「选择 bot」列表：点击某行 → 选中该 bot（高亮）。
+ *   2. 选中后下方启用 `persona_prompt` textarea + 「创建分身」按钮；用户填好后点
+ *      创建，触发 `onCreated(uid, prompt)`，由父级 `handleCreate` 走 createGrant
+ *      → replace 到 PersonaEdit。
+ *   3. 留空 prompt 也允许提交（创建无风格的 grant，等用户之后再补）。
+ *
+ * 设计取舍：
+ *   - 仍保留「点 bot 即完成选择」的轻量手感，不让 UX 变成「先勾选再提交」两步表单；
+ *     选中后下方表单原地展开。
+ *   - textarea 用原生 `<textarea>`（不依赖 Semi `TextArea`）的两个原因：
+ *     a) 现有 vm.test 已 mock semi-ui，引入更多 Semi 子组件会增加测试 mock 噪音；
+ *     b) 这是设置子页里一段简单的多行输入，原生足够，少一层 Semi 主题/portal 包装
+ *        在 RoutePage 容器里也更稳。
  */
 function PersonaCreate(props: {
     vm: PersonaSettingsVM
-    onCreated: (botUid: string) => void
+    onCreated: (botUid: string, personaPrompt: string) => Promise<void> | void
 }) {
     const { vm, onCreated } = props
+    const [selectedUid, setSelectedUid] = React.useState<string>("")
+    const [prompt, setPrompt] = React.useState<string>("")
+    const [submitting, setSubmitting] = React.useState<boolean>(false)
     // 第一次渲染时触发 loadMyBots（避免在 vm 构造里副作用）
     React.useEffect(() => {
         if (vm.myBots.length === 0 && !vm.myBotsLoading) {
@@ -291,6 +359,7 @@ function PersonaCreate(props: {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
+    const selectedBot = vm.myBots.find((b) => b.uid === selectedUid)
     return (
         <div className="wk-persona-create">
             {vm.myBotsLoading && (
@@ -303,18 +372,59 @@ function PersonaCreate(props: {
                     请先去 AI 广场添加一个 bot
                 </div>
             )}
-            {vm.myBots.map((b: MyBot) => (
-                <div
-                    key={b.uid}
-                    className="wk-persona-create-row"
-                    onClick={() => onCreated(b.uid)}
-                >
-                    <div>
-                        <div className="wk-persona-create-row-name">{b.name}</div>
-                        <div className="wk-persona-create-row-sub">{b.uid}</div>
+            {vm.myBots.map((b: MyBot) => {
+                const active = b.uid === selectedUid
+                return (
+                    <div
+                        key={b.uid}
+                        className={
+                            "wk-persona-create-row" +
+                            (active ? " wk-persona-create-row-selected" : "")
+                        }
+                        onClick={() => setSelectedUid(b.uid)}
+                        data-testid={`persona-create-bot-${b.uid}`}
+                        data-selected={active ? "1" : "0"}
+                    >
+                        <div>
+                            <div className="wk-persona-create-row-name">{b.name}</div>
+                            <div className="wk-persona-create-row-sub">{b.uid}</div>
+                        </div>
                     </div>
+                )
+            })}
+
+            {/* v2 表单：选中 bot 后展开 prompt + 提交按钮 */}
+            {selectedBot && (
+                <div className="wk-persona-create-form">
+                    <div className="wk-persona-create-form-label">
+                        回复风格 prompt（可选）
+                    </div>
+                    <textarea
+                        className="wk-persona-create-prompt"
+                        placeholder="设置分身的回复风格，如：用简洁专业的语气回复"
+                        value={prompt}
+                        onChange={(e) => setPrompt(e.target.value)}
+                        rows={4}
+                        data-testid="persona-create-prompt"
+                    />
+                    <button
+                        className="wk-persona-add-btn"
+                        disabled={submitting}
+                        data-testid="persona-create-submit"
+                        onClick={async () => {
+                            if (submitting) return
+                            setSubmitting(true)
+                            try {
+                                await onCreated(selectedBot.uid, prompt)
+                            } finally {
+                                setSubmitting(false)
+                            }
+                        }}
+                    >
+                        {submitting ? "创建中..." : "创建分身"}
+                    </button>
                 </div>
-            ))}
+            )}
         </div>
     )
 }

--- a/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
@@ -27,6 +27,14 @@ import { extractErrorMsg } from "../../Service/APIClient"
 /**
  * Grant 主实体（grantor_uid 是当前用户自己；grantee_bot_uid 是代理 bot）。
  * mode === "auto" 是 v0 唯一支持的模式，"draft" 字段保留供 v1 草稿审批用。
+ *
+ * v2（octo-web#73 / octo-server#108）新增：
+ *   - `persona_prompt`：用户自定义的回复风格 prompt（中文），由 grantor 在 Create/Edit
+ *     表单里填写，POST/PUT 时携带；后端写入 grant 表 persona_prompt 字段，fan-out 时
+ *     拼到 system prompt 里影响 bot 回答风格。
+ *   - `active`：v1 已有字段，但在 v2 由「列表 toggle」直接驱动 —— 用户在 PersonaList
+ *     点开关 → 后端 mutex 自动把其他 grant 的 active 置为 false（同一用户最多 1 个
+ *     active grant 接管会话）。前端只需 PUT `{active: true|false}`，不必关心互斥逻辑。
  */
 export interface OboGrant {
     id: number
@@ -36,6 +44,11 @@ export interface OboGrant {
     mode: "auto" | "draft"
     global_enabled: boolean
     active: boolean
+    /**
+     * v2：自定义回复风格 prompt。可空（旧 grant 未填写时为 undefined / 空串）。
+     * 前端表单为可选填写，提交时若空则不放进 POST/PUT body（让后端保持 NULL/未改）。
+     */
+    persona_prompt?: string
     created_at?: number
     updated_at?: number
 }
@@ -244,18 +257,29 @@ export class PersonaSettingsVM extends ProviderListener {
      * 创建一个新的 grant（默认 mode=auto, global_enabled=false）。
      * 创建后 caller 应：reload list → push 进 PersonaEdit 让用户继续配 scope。
      *
+     * v2 (octo-web#73)：第二参数 personaPrompt 允许在创建时直接带上用户填写的回复风格。
+     * 留空（未传或空串）时不放进 POST body，等用户在 PersonaEdit 里再补，避免空串覆盖
+     * 后端的 NULL 默认（fan-out 拼 system prompt 时会忽略 NULL 而处理空串）。
+     *
      * Round-2 nit（YUJ-1193 / yujiawei R2）：成功后清空 `myBots` 缓存，
      * 让下一次 PersonaCreate mount 时 useEffect 的 `length === 0` 守卫真的触发
      * `loadMyBots()` 重拉 —— 否则用户「+ 新建分身」→ 选 bot → 创建 → pop →
      * 再「+ 新建分身」会看到刚绑过的 bot 还在 picker 里，导致 duplicate POST。
      */
-    async createGrant(granteeBotUid: string): Promise<OboGrant | undefined> {
+    async createGrant(granteeBotUid: string, personaPrompt?: string): Promise<OboGrant | undefined> {
         try {
-            const res = await WKApp.apiClient.post(`obo/grants`, {
+            // v2 (octo-web#73)：persona_prompt 可选；只有用户实际填写了非空内容时才放进 body，
+            // 否则空串会让后端把 NULL 覆盖成 ''，影响 fan-out 的 system prompt 拼装逻辑。
+            const body: Record<string, any> = {
                 grantee_bot_uid: granteeBotUid,
                 mode: "auto",
                 global_enabled: false,
-            })
+            }
+            const trimmed = (personaPrompt || "").trim()
+            if (trimmed) {
+                body.persona_prompt = trimmed
+            }
+            const res = await WKApp.apiClient.post(`obo/grants`, body)
             await this.loadGrants()
             // 已绑定的 bot 必须从下一次 PersonaCreate 的 picker 中消失：
             // 清缓存让 useEffect 的 length===0 守卫重新触发 loadMyBots()。
@@ -281,8 +305,20 @@ export class PersonaSettingsVM extends ProviderListener {
         }
     }
 
-    /** 切换 global_enabled 或 mode；服务端用 PATCH-like 语义合并。 */
-    async updateGrant(id: number, patch: Partial<Pick<OboGrant, "global_enabled" | "mode">>): Promise<boolean> {
+    /**
+     * 切换 global_enabled / mode / active / persona_prompt；服务端用 PATCH-like 语义合并。
+     *
+     * v2 (octo-web#73)：
+     *   - `active` 字段由列表 toggle 直接驱动。后端在 PUT `{active: true}` 时自动把当前
+     *     用户其它 grant 的 active 置为 false（mutex）——前端不需要预先调一遍 disable，
+     *     成功后 `loadGrants()` 会拉回新状态，UI 自然更新。
+     *   - `persona_prompt` 由 PersonaEdit 表单的「保存」按钮驱动，与 active 可以同一次
+     *     PUT 提交，减少往返。
+     */
+    async updateGrant(
+        id: number,
+        patch: Partial<Pick<OboGrant, "global_enabled" | "mode" | "active" | "persona_prompt">>,
+    ): Promise<boolean> {
         try {
             await WKApp.apiClient.put(`obo/grants/${id}`, patch)
             await this.loadGrants()
@@ -375,6 +411,38 @@ export class PersonaEditVM extends ProviderListener {
             return true
         } catch (e) {
             Toast.error(extractErrorMsg(e) || "切换失败")
+            return false
+        }
+    }
+
+    /**
+     * v2 (octo-web#73)：保存 PersonaEdit 表单 —— 一次 PUT 同时提交 persona_prompt + active。
+     *
+     * 入参语义：
+     *   - personaPrompt：始终发送，允许空串覆盖（用户主动清空 prompt 是合法的「恢复到无风格」操作）。
+     *     这与 createGrant 的「空串不放进 body」策略不同 —— 创建时空串意味着「我还没想好」，
+     *     编辑时空串意味着「我明确要清掉之前写的」。
+     *   - active：可选。提供时会让后端做 mutex（true 时把其它 grant active 置 false）。
+     *
+     * 成功后乐观更新本地 grant；caller 应额外调父级 onChange 让 PersonaSettingsVM.grants
+     * 与服务端重新对齐（后端 mutex 改了别的 grant 我们这里看不见）。
+     */
+    async savePersonaForm(personaPrompt: string, active?: boolean): Promise<boolean> {
+        try {
+            const body: Record<string, any> = { persona_prompt: personaPrompt }
+            if (typeof active === "boolean") {
+                body.active = active
+            }
+            await WKApp.apiClient.put(`obo/grants/${this.grant.id}`, body)
+            this.grant = {
+                ...this.grant,
+                persona_prompt: personaPrompt,
+                ...(typeof active === "boolean" ? { active } : {}),
+            }
+            this.notifyListener()
+            return true
+        } catch (e) {
+            Toast.error(extractErrorMsg(e) || "保存失败")
             return false
         }
     }


### PR DESCRIPTION
Implements OBO persona v2 frontend changes per #73 (server side at Mininglamp-OSS/octo-server#108).

## What changed

### 1. Persona list — active toggle
- Each `PersonaCard` row now shows a Semi `Switch` on the right.
- Toggling fires `PUT /v1/obo/grants/:id` with `{active: true|false}`. The backend (octo-server#108) handles the mutex — frontend never disables siblings explicitly.
- Visual feedback:
  - Active card gets `.wk-persona-card-active` (brand border ring).
  - When *any* card is active, the rest get `.wk-persona-card-dimmed` (opacity ↓). When *no* card is active, none are dimmed — avoids the "everything looks disabled" trap.
- Toggle click is `stopPropagation`'d so it does NOT bubble into "open PersonaEdit".

### 2. PersonaCreate — `persona_prompt` textarea
- Picker now becomes a two-step inline form: pick a bot → form expands underneath with `persona_prompt` textarea + 「创建分身」submit button.
- Placeholder text is the exact string from the issue body: `设置分身的回复风格，如：用简洁专业的语气回复`.
- Empty / whitespace-only prompts are stripped from the POST body so we don't overwrite the server's NULL default (fan-out distinguishes NULL from `""`).
- After submit, the existing `replace()` flow into PersonaEdit is preserved (YUJ-1348 race-free path).

### 3. PersonaEdit — reuse create form
- New v2 form rendered at the top of the existing edit screen:
  - Bot name (read-only, falls back to uid when name missing)
  - `persona_prompt` textarea, pre-filled from `grant.persona_prompt`
  - Active `Switch` toggle, pre-filled from `grant.active`
  - 「保存」button → `savePersonaForm(prompt, active)` calls `PUT /v1/obo/grants/:id` with both fields in one round-trip
- Empty prompt on save is allowed (explicit "clear what I wrote" semantic — distinct from create's "I haven't filled in" semantic).
- On success: toasts 「已保存」 and fires `onChange` so the parent list reloads (backend mutex may have flipped other rows' `active`).
- No new route added — opens via the existing `routeContext.push(<PersonaEdit/>)` (inline page swap inside the same RoutePage stack).
- The pre-existing global toggle / scope list / delete sections are preserved untouched so v1 power-users don't regress.

### 4. Bot name display (task 4)
- `grantee_bot_name` is the rendered label on both PersonaCard and PersonaEdit, with `grantee_bot_uid` only as a fallback. Regression test added: `persists grantee_bot_name on the card (task 4 — PR#70 regression guard)`.

## API consumed (per octo-server#108)

| Endpoint | New fields handled |
|---|---|
| `POST /v1/obo/grants` | sends `persona_prompt` when non-empty |
| `PUT /v1/obo/grants/:id` | sends `persona_prompt` and/or `active`; backend handles mutex |
| `GET /v1/obo/grants` | reads `persona_prompt` and `active` per grant |
| `DELETE /v1/obo/grants/:id` | unchanged |

## Tests

`packages/dmworkbase/src/Components/PersonaSettings/__tests__/`:

- `vm.test.ts` (+4): `createGrant` sends/omits `persona_prompt`; `updateGrant` accepts `{active:true}` and reloads; `savePersonaForm` PUTs prompt+active and updates `grant` locally; empty prompt allowed on save; failure path toasts.
- `PersonaSettings.test.tsx` (+6): Switch renders per row; PUT goes out with right payload (single call, no preemptive siblings); active/dimmed classes; "no active → no dimming"; toggle does NOT open PersonaEdit; bot-name regression guard.
- `PersonaEdit.test.tsx` (+5): form pre-fill (bot/prompt/active); bot-name fallback to uid; placeholder verbatim; save → PUT both fields + onChange fires; empty prompt save sends `""`.

Local results in `packages/dmworkbase`:
- PersonaSettings suite: **66 passed**, 1 pre-existing failure (`toggleGlobal posts PUT` — a unit-test/implementation expectation drift on `main`, present on e861db9c and out of scope here).
- Full repo: 396 passed (was 377 on baseline). No new failures introduced.

## Build

`pnpm build` ✅ passes.

## Out of scope

- Backend code (none changed)
- Router / navigation structure (no new routes)
- OBO fan-out logic
- The v1 global-toggle / per-channel scope / delete UI (preserved as-is)

Fixes #73
