### PR TITLE
fix(follow,mergeforward): keep follow tab on create group + restore SDK conv cache after space switch

### DIFF
--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -114,13 +114,25 @@ export class MainPage extends Component<{}, MainPageState> {
     }
 
     handleSpaceSelected = (spaceId: string) => {
+        // 同步更新 currentSpaceId 与持久化，并立刻 emit space-changed，
+        // 避免随后用户立即触发的"合并转发"等动作读到旧的 spaceId
+        // （此前这些更新都放在 getMySpaces().then 内，存在网络 race）。
+        WKApp.shared.currentSpaceId = spaceId;
+        localStorage.setItem("currentSpaceId", spaceId);
+        const existing = this.state.allSpaces.find(s => s.space_id === spaceId);
+        if (existing) {
+            WKApp.mittBus.emit("space-changed", existing);
+        }
+        WKApp.shared.notifyListener();
+
+        // 后台刷新 Space 列表（用户可能新加入/离开 Space），完成后再补一次
+        // 事件给那些以 Space 对象为入参的监听者（首次拿不到 existing 的情况）。
         SpaceService.shared.getMySpaces().then(spaces => {
             this.setState({ allSpaces: spaces, showJoinSpace: false });
-            WKApp.shared.currentSpaceId = spaceId;
-            localStorage.setItem("currentSpaceId", spaceId);
-            const target = spaces.find(s => s.space_id === spaceId);
-            if (target) WKApp.mittBus.emit("space-changed", target);
-            WKApp.shared.notifyListener();
+            if (!existing) {
+                const target = spaces.find(s => s.space_id === spaceId);
+                if (target) WKApp.mittBus.emit("space-changed", target);
+            }
         }).catch(() => {
             Toast.error("刷新 Space 列表失败，请手动刷新");
         });

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -54,6 +54,12 @@ export type MittEvents = {
   'wk:matter-deleted': { matterId: string };
   "summary-space-changed": undefined;
   /**
+   * Chat VM 完成 requestConversationList()（切 Space / 重连后会触发）后广播。
+   * 用于让那些一次性读取 WKSDK.conversationManager.conversations 缓存的消费者
+   * （如合并转发选择器）在缓存被回填后再 load 一次,避免读到清空中间态。
+   */
+  "conversation-list-refreshed": undefined;
+  /**
    * 频道头像发生变化（上传/更新）时广播。订阅者（例如 WKAvatar）可依据 channelID +
    * channelType 匹配后刷新自身缓存的 avatar URL，避免整页刷新。
    */

--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -52,10 +52,14 @@ export interface ChatConversationListProps {
 // 右键的会话(添加到关注)或群(移到分组)一并归入新分类,否则就是 bug:用户
 // 以为操作连贯,实际只建了空分类。modal 是无 conv 上下文的全局组件,通过这
 // 个 state 把上下文从右键现场带到 onConfirm。
-type PendingAction =
+//
+// NewCategoryTarget = 非 null 的 PendingAction;子组件(如 ConversationListGrouped)
+// 通过 onOpenCreateCategory(target?) 把右键现场带过来,顶部 + 入口 target=undefined
+// 即可走"建空分类"的路径。
+export type NewCategoryTarget =
     | { kind: 'followToNewCategory'; conv: ConversationWrap }
     | { kind: 'moveGroupToNewCategory'; groupNo: string }
-    | null
+type PendingAction = NewCategoryTarget | null
 
 const ChatConversationList: React.FC<ChatConversationListProps> = ({
     conversations,
@@ -347,34 +351,8 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
             }
         }
 
-        // 关注 Tab 的群聊显示「移到分组」（保留原有逻辑）
-        if (filter === 'group' && conv.channel.channelType === ChannelTypeGroup && categories.length > 0) {
-            const groupNo = conv.channel.channelID
-            const currentCategoryId = categories.find(
-                cat => (cat.groups || []).some(g => g.group_no === groupNo)
-            )?.category_id
-
-            const moveItems: ContextMenusData[] = categories
-                .filter(cat => !cat.is_default && isValidCategoryItem(cat))
-                .map(cat => ({
-                    title: cat.name,
-                    checked: currentCategoryId === cat.category_id,
-                    onClick: () => handleMoveGroupToCategory(groupNo, cat.category_id),
-                }))
-            moveItems.push({ separator: true } as ContextMenusData)
-            moveItems.push({
-                title: '+ 新建分组',
-                onClick: () => {
-                    setPendingAction({ kind: 'moveGroupToNewCategory', groupNo })
-                    setCreateModalVisible(true)
-                }
-            })
-
-            menus.push({
-                title: '移到分组',
-                children: moveItems
-            })
-        }
+        // filter === 'group'(关注 Tab) 走 ConversationListGrouped 自建右键菜单,
+        // 通过下方 onOpenCreateCategory(target) 把现场带回这里,不在此处处理。
 
         return menus
     }
@@ -402,8 +380,10 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onDeleteCategory={handleDeleteCategory}
                     onSortCategories={sortCategories}
                     onMoveGroupToCategory={handleMoveGroupToCategory}
-                    onOpenCreateCategory={() => {
-                        setPendingAction(null)
+                    onOpenCreateCategory={(target?: NewCategoryTarget) => {
+                        // target 由 ConversationListGrouped 右键"+ 新建分组"传入
+                        // (移到分组 / 添加到关注的分支);顶部 + 按钮不带 target,清空即可。
+                        setPendingAction(target ?? null)
                         setCreateModalVisible(true)
                     }}
                     onStartGroup={() => {

--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -167,6 +167,16 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
 
     const [createModalVisible, setCreateModalVisible] = useState(false)
 
+    // 「+ 新建分组」入口在三个右键场景共用同一个 modal。建分类成功后,要把当时
+    // 右键的会话(添加到关注)或群(移到分组)一并归入新分类,否则就是 bug:用户
+    // 以为操作连贯,实际只建了空分类。modal 是无 conv 上下文的全局组件,通过这
+    // 个 state 把上下文从右键现场带到 onConfirm。
+    type PendingAction =
+        | { kind: 'followToNewCategory'; conv: ConversationWrap }
+        | { kind: 'moveGroupToNewCategory'; groupNo: string }
+        | null
+    const [pendingAction, setPendingAction] = useState<PendingAction>(null)
+
     // 暴露「打开新建分组 Modal」给外层（如顶部 + 按钮）
     React.useEffect(() => {
         if (onOpenCreateCategoryRef) {
@@ -188,6 +198,28 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
         const now = Date.now()
         return conversations.filter(conv => isVisibleInRecentTab(conv, now))
     }, [conversations, hideInactiveGroups])
+
+    // 按 conv.channelType 把会话归入指定分类。三种 channel 走三套写操作:
+    // - 子区:父群先 refollow + moveCategory,再 followThread(子区不能脱离父群单独分组)
+    // - 群:refollow + moveCategory
+    // - DM:followDM 带 category_id 一步到位
+    // "添加到关注 → 已有分组"和"添加到关注 → + 新建分组"两条路径都用这一份。
+    const followConvToCategory = async (conv: ConversationWrap, categoryId: string) => {
+        const channel = conv.channel
+        if (channel.channelType === ChannelTypeCommunityTopic) {
+            const parentGroupNo = conv.channelInfo?.orgData?.parentGroupNo
+                || parseThreadChannelId(channel.channelID)?.groupNo
+            if (!parentGroupNo) throw new Error('无法解析父频道 groupNo')
+            await FollowService.refollowChannel({ group_no: parentGroupNo })
+            await moveGroupToCategory(parentGroupNo, categoryId)
+            await FollowService.followThread({ thread_channel_id: channel.channelID })
+        } else if (channel.channelType === ChannelTypeGroup) {
+            await FollowService.refollowChannel({ group_no: channel.channelID })
+            await moveGroupToCategory(channel.channelID, categoryId)
+        } else if (channel.channelType === ChannelTypePerson) {
+            await FollowService.followDM({ peer_uid: channel.channelID, category_id: categoryId })
+        }
+    }
 
     // 构建额外的右键菜单项
     // - 「移到分组」子菜单（仅关注 Tab 的群聊）
@@ -256,14 +288,8 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                             .map(cat => ({
                                 title: cat.name,
                                 onClick: async () => {
-                                    if (!parentGroupNo) {
-                                        console.error('关注子区失败: 无法解析父频道 groupNo', channel.channelID)
-                                        return
-                                    }
                                     try {
-                                        await FollowService.refollowChannel({ group_no: parentGroupNo })
-                                        await moveGroupToCategory(parentGroupNo, cat.category_id)
-                                        await FollowService.followThread({ thread_channel_id: channel.channelID })
+                                        await followConvToCategory(conv, cat.category_id)
                                         reloadAll()
                                     } catch (err) {
                                         console.error('关注子区失败', err)
@@ -273,7 +299,10 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                         categoryItems.push({ separator: true } as ContextMenusData)
                         categoryItems.push({
                             title: '+ 新建分组',
-                            onClick: () => setCreateModalVisible(true)
+                            onClick: () => {
+                                setPendingAction({ kind: 'followToNewCategory', conv })
+                                setCreateModalVisible(true)
+                            }
                         })
 
                         menus.push({
@@ -289,13 +318,7 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                             title: cat.name,
                             onClick: async () => {
                                 try {
-                                    if (channel.channelType === ChannelTypeGroup) {
-                                        await FollowService.refollowChannel({ group_no: channel.channelID })
-                                        // 移到指定分组
-                                        await moveGroupToCategory(channel.channelID, cat.category_id)
-                                    } else if (channel.channelType === ChannelTypePerson) {
-                                        await FollowService.followDM({ peer_uid: channel.channelID, category_id: cat.category_id })
-                                    }
+                                    await followConvToCategory(conv, cat.category_id)
                                     reloadAll()
                                 } catch (err) {
                                     console.error('添加到关注失败', err)
@@ -305,7 +328,10 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     categoryItems.push({ separator: true } as ContextMenusData)
                     categoryItems.push({
                         title: '+ 新建分组',
-                        onClick: () => setCreateModalVisible(true)
+                        onClick: () => {
+                            setPendingAction({ kind: 'followToNewCategory', conv })
+                            setCreateModalVisible(true)
+                        }
                     })
 
                     menus.push({
@@ -331,7 +357,13 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onClick: () => handleMoveGroupToCategory(groupNo, cat.category_id),
                 }))
             moveItems.push({ separator: true } as ContextMenusData)
-            moveItems.push({ title: '+ 新建分组', onClick: () => setCreateModalVisible(true) })
+            moveItems.push({
+                title: '+ 新建分组',
+                onClick: () => {
+                    setPendingAction({ kind: 'moveGroupToNewCategory', groupNo })
+                    setCreateModalVisible(true)
+                }
+            })
 
             menus.push({
                 title: '移到分组',
@@ -368,8 +400,9 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onOpenCreateCategory={() => setCreateModalVisible(true)}
                     onStartGroup={() => {
                         WKApp.endpoints.organizationalLayer(null, {
+                            keepSidebarTab: true,
                             onSuccess: () => {
-                                reload()
+                                reloadAll()
                                 onGroupCreated?.()
                             }
                         })
@@ -377,8 +410,9 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onCreateGroupInCategory={(categoryId: string) => {
                         WKApp.endpoints.organizationalLayer(null, {
                             defaultCategoryId: categoryId,
+                            keepSidebarTab: true,
                             onSuccess: () => {
-                                reload()
+                                reloadAll()
                                 onGroupCreated?.()
                             }
                         })
@@ -402,10 +436,33 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                 visible={createModalVisible}
                 existingNames={existingCategoryNames}
                 onConfirm={async (name) => {
-                    await createCategory(name)
+                    const action = pendingAction
+                    try {
+                        const created = await createCategory(name)
+                        const newCategoryId = created.category_id
+                        // 顶部 + 按钮入口 action 为 null,只建空分类即可。
+                        if (newCategoryId && action) {
+                            try {
+                                if (action.kind === 'followToNewCategory') {
+                                    await followConvToCategory(action.conv, newCategoryId)
+                                } else if (action.kind === 'moveGroupToNewCategory') {
+                                    await handleMoveGroupToCategory(action.groupNo, newCategoryId)
+                                }
+                            } catch (err) {
+                                // 分类已建出来,不阻塞 modal 关闭;打日志让用户重试关注操作
+                                console.error('归入新分组失败', err)
+                            }
+                        }
+                        reloadAll()
+                    } finally {
+                        setPendingAction(null)
+                        setCreateModalVisible(false)
+                    }
+                }}
+                onCancel={() => {
+                    setPendingAction(null)
                     setCreateModalVisible(false)
                 }}
-                onCancel={() => setCreateModalVisible(false)}
             />
         </>
     )

--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -48,6 +48,15 @@ export interface ChatConversationListProps {
     onGroupCreated?: () => void
 }
 
+// 「+ 新建分组」入口在三个右键场景共用同一个 modal。建分类成功后,要把当时
+// 右键的会话(添加到关注)或群(移到分组)一并归入新分类,否则就是 bug:用户
+// 以为操作连贯,实际只建了空分类。modal 是无 conv 上下文的全局组件,通过这
+// 个 state 把上下文从右键现场带到 onConfirm。
+type PendingAction =
+    | { kind: 'followToNewCategory'; conv: ConversationWrap }
+    | { kind: 'moveGroupToNewCategory'; groupNo: string }
+    | null
+
 const ChatConversationList: React.FC<ChatConversationListProps> = ({
     conversations,
     filter,
@@ -167,20 +176,16 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
 
     const [createModalVisible, setCreateModalVisible] = useState(false)
 
-    // 「+ 新建分组」入口在三个右键场景共用同一个 modal。建分类成功后,要把当时
-    // 右键的会话(添加到关注)或群(移到分组)一并归入新分类,否则就是 bug:用户
-    // 以为操作连贯,实际只建了空分类。modal 是无 conv 上下文的全局组件,通过这
-    // 个 state 把上下文从右键现场带到 onConfirm。
-    type PendingAction =
-        | { kind: 'followToNewCategory'; conv: ConversationWrap }
-        | { kind: 'moveGroupToNewCategory'; groupNo: string }
-        | null
     const [pendingAction, setPendingAction] = useState<PendingAction>(null)
 
-    // 暴露「打开新建分组 Modal」给外层（如顶部 + 按钮）
+    // 暴露「打开新建分组 Modal」给外层（如顶部 + 按钮）。
+    // 顶部入口无右键上下文,必须先清 pendingAction,避免上次右键残留被误归入新分类。
     React.useEffect(() => {
         if (onOpenCreateCategoryRef) {
-            onOpenCreateCategoryRef.current = () => setCreateModalVisible(true)
+            onOpenCreateCategoryRef.current = () => {
+                setPendingAction(null)
+                setCreateModalVisible(true)
+            }
         }
         return () => {
             if (onOpenCreateCategoryRef) {
@@ -397,7 +402,10 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onDeleteCategory={handleDeleteCategory}
                     onSortCategories={sortCategories}
                     onMoveGroupToCategory={handleMoveGroupToCategory}
-                    onOpenCreateCategory={() => setCreateModalVisible(true)}
+                    onOpenCreateCategory={() => {
+                        setPendingAction(null)
+                        setCreateModalVisible(true)
+                    }}
                     onStartGroup={() => {
                         WKApp.endpoints.organizationalLayer(null, {
                             keepSidebarTab: true,
@@ -454,9 +462,14 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                             }
                         }
                         reloadAll()
-                    } finally {
+                        // 只有 createCategory 成功才关 modal。失败时让异常继续上抛,
+                        // 由 CreateCategoryModal 自身 catch 显示"创建失败,请重试"。
                         setPendingAction(null)
                         setCreateModalVisible(false)
+                    } catch (err) {
+                        // 失败也清理右键上下文,避免下次打开时挂着上次的 pending
+                        setPendingAction(null)
+                        throw err
                     }
                 }}
                 onCancel={() => {

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -10,6 +10,7 @@ import { ConversationWrap } from "../../Service/Model"
 import ConversationList from "../ConversationList"
 import ConversationListWithCategory from "../ConversationListWithCategory"
 import ContextMenus, { ContextMenusContext, ContextMenusData } from "../ContextMenus"
+import type { NewCategoryTarget } from "../ChatConversationList"
 import {
     DndContext,
     DragOverlay,
@@ -73,7 +74,11 @@ export interface ConversationListGroupedProps {
     onDeleteCategory: (id: string) => Promise<void> | void
     onSortCategories: (ids: string[]) => Promise<void>
     onMoveGroupToCategory: (groupNo: string, categoryId: string) => Promise<void>
-    onOpenCreateCategory: () => void
+    /**
+     * 打开"新建分组" modal。target 表示当时右键的现场;父层(ChatConversationList)据此
+     * 把分类建出后顺手把右键选中项归入新分类。无 target = 顶部 + 入口/纯建空分类。
+     */
+    onOpenCreateCategory: (target?: NewCategoryTarget) => void
     onStartGroup?: () => void
     onCreateGroupInCategory?: (categoryId: string) => void
     /** 取消关注后的回调（用于刷新列表） */
@@ -372,7 +377,10 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                     onClick: () => onMoveGroupToCategory(groupNo, cat.category_id),
                 }))
             moveToChildren.push({ separator: true } as ContextMenusData)
-            moveToChildren.push({ title: '+ 新建分组', onClick: onOpenCreateCategory })
+            moveToChildren.push({
+                title: '+ 新建分组',
+                onClick: () => onOpenCreateCategory({ kind: 'moveGroupToNewCategory', groupNo }),
+            })
 
             const moveToItem: ContextMenusData = {
                 title: '移到分组',
@@ -410,7 +418,12 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                     },
                 }))
             moveToChildrenDm.push({ separator: true } as ContextMenusData)
-            moveToChildrenDm.push({ title: '+ 新建分组', onClick: onOpenCreateCategory })
+            moveToChildrenDm.push({
+                title: '+ 新建分组',
+                // DM 的"新分组"语义 = 用新分类 followDM,与 followConvToCategory
+                // 对 ChannelTypePerson 分支等价(都走 FollowService.followDM)。
+                onClick: () => onOpenCreateCategory({ kind: 'followToNewCategory', conv }),
+            })
             menus.push({
                 title: '移到分组',
                 icon: "M2 9V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-4 M12 3v5h5 M9 15l3 3 3-3 M12 12v6",

--- a/packages/dmworkbase/src/Components/CreateCategoryModal/index.tsx
+++ b/packages/dmworkbase/src/Components/CreateCategoryModal/index.tsx
@@ -29,7 +29,10 @@ const CreateCategoryModal: React.FC<CreateCategoryModalProps> = ({
         }
     }, [visible])
 
-    const isDuplicate = existingNames.includes(value.trim())
+    // loading 期间(父层 onConfirm 进行中)不参与重复校验:此时分类可能已建成
+    // 并出现在 existingNames 里,但用户输入框里的 value 还没被清空 ——
+    // 否则会让"该分组名已存在"在 modal 关掉前闪一下。
+    const isDuplicate = !loading && existingNames.includes(value.trim())
     const isEmpty = value.trim() === ""
     const isDisabled = isEmpty || isDuplicate || loading
 

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -85,6 +85,10 @@ export function useForwardModal(
   const [loading, setLoading] = useState(true)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchRequestRef = useRef(0)
+  // load() 可能并发(mount 自动触发 + conversation-list-refreshed 又触发一次)。
+  // 用一个单调递增的 generation,await 边界处比对,过期就丢弃 setState,
+  // 避免两次 setConversationItems(prev => [...prev, ...]) 重复 append 同一批群。
+  const loadGenRef = useRef(0)
 
   const setInputValue = useCallback((val: string) => {
     setInputValueState(val)
@@ -180,6 +184,7 @@ export function useForwardModal(
 
   useEffect(() => {
     async function load() {
+      const gen = ++loadGenRef.current
       setLoading(true)
       try {
         // 最近会话：仅构造 wrap，不再对每个 conv 主动 fetchChannelInfo。
@@ -197,6 +202,7 @@ export function useForwardModal(
 
         // 补全：获取用户加入的全部群聊（已支持 space_id 过滤）
         const allGroups = await WKApp.dataSource.channelDataSource.groupSaveList()
+        if (gen !== loadGenRef.current) return // 有更新的 load 在跑,丢弃本次结果
         const existingGroupIDs = new Set<string>()
         for (const wrap of wrapsRef.current) {
           if (wrap.channel.channelType === ChannelTypeGroup) {
@@ -216,6 +222,7 @@ export function useForwardModal(
 
         // 好友
         const friends = (await WKApp.dataSource.commonDataSource.searchFriends("")) ?? []
+        if (gen !== loadGenRef.current) return
         // 按 channelID 去重：Space 模式下后端 space/{id}/members 可能返回同一
         // uid 的多条记录（多角色等），不去重会触发 React duplicate key 警告。
         const seen = new Set<string>()
@@ -229,7 +236,9 @@ export function useForwardModal(
         }
         setFriendItems(fItems)
       } finally {
-        setLoading(false)
+        // 仅最新 generation 收尾 loading,避免老 load 的 setLoading(false)
+        // 把更新的 load 标记成"已完成"。
+        if (gen === loadGenRef.current) setLoading(false)
       }
     }
 

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -241,10 +241,19 @@ export function useForwardModal(
     }
     WKSDK.shared().channelManager.addListener(channelListener)
 
+    // 切 Space 后 conversationManager.conversations 会被先清空再回填,
+    // 如果 modal 在回填前打开,初次 load() 会读到空 cache（缺最近会话/子区）。
+    // 监听 ChatVM 的回填广播,触发后重新 load 一次,保证最终能拿到完整数据。
+    const onConversationListRefreshed = () => {
+      load()
+    }
+    WKApp.mittBus.on('conversation-list-refreshed', onConversationListRefreshed)
+
     load()
 
     return () => {
       WKSDK.shared().channelManager.removeListener(channelListener)
+      WKApp.mittBus.off('conversation-list-refreshed', onConversationListRefreshed)
       rebuildDebounced.cancel()
     }
   }, [rebuildConvItems])

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -216,10 +216,17 @@ export function useForwardModal(
 
         // 好友
         const friends = (await WKApp.dataSource.commonDataSource.searchFriends("")) ?? []
-        const fItems = friends.map((info: ChannelInfo) => {
-          channelMapRef.current.set(info.channel.channelID, info.channel)
-          return channelInfoToForwardItem(info)
-        })
+        // 按 channelID 去重：Space 模式下后端 space/{id}/members 可能返回同一
+        // uid 的多条记录（多角色等），不去重会触发 React duplicate key 警告。
+        const seen = new Set<string>()
+        const fItems: ForwardItem[] = []
+        for (const info of friends) {
+          const cid = info.channel.channelID
+          if (seen.has(cid)) continue
+          seen.add(cid)
+          channelMapRef.current.set(cid, info.channel)
+          fItems.push(channelInfoToForwardItem(info))
+        }
         setFriendItems(fItems)
       } finally {
         setLoading(false)

--- a/packages/dmworkbase/src/Components/WKBase/index.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/index.tsx
@@ -88,6 +88,7 @@ export interface WKBaseState {
   showBotDetail?: boolean;
   showConversationSelect?: boolean;
   conversationSelectTitle?: string;
+  conversationSelectKey?: number;
   showAlert?: boolean;
   alertContent?: string;
   alertTitle?: string;
@@ -219,11 +220,14 @@ export default class WKBase
     onFinished?: (channels: Channel[]) => void,
     title?: string
   ) {
-    this.setState({
+    this.setState((prev) => ({
       showConversationSelect: true,
       conversationSelectFinished: onFinished,
       conversationSelectTitle: title,
-    });
+      // 每次打开递增 key，强制 ConversationSelect 重新挂载，
+      // 让 useForwardModal 用当前 spaceId 重新拉数据，避免切 Space 后列表陈旧。
+      conversationSelectKey: (prev.conversationSelectKey ?? 0) + 1,
+    }));
   }
 
   hideUserInfo() {
@@ -292,6 +296,7 @@ export default class WKBase
       vercode,
       showConversationSelect,
       conversationSelectTitle,
+      conversationSelectKey,
       conversationSelectFinished,
       onAlertOk,
       alertContent,
@@ -366,6 +371,7 @@ export default class WKBase
           }}
         >
           <ConversationSelect
+            key={conversationSelectKey}
             onFinished={(channels: Channel[]) => {
               this.setState({
                 showConversationSelect: false,

--- a/packages/dmworkbase/src/EndpointCommon.tsx
+++ b/packages/dmworkbase/src/EndpointCommon.tsx
@@ -282,11 +282,12 @@ export class EndpointCommon {
     );
   }
 
-  organizationalLayer(channel: Channel | null, options?: { defaultCategoryId?: string; onSuccess?: () => void }): void {
+  organizationalLayer(channel: Channel | null, options?: { defaultCategoryId?: string; onSuccess?: () => void; keepSidebarTab?: boolean }): void {
     return EndpointManager.shared.invoke(EndpointCategory.organizationalLayer, {
       channel: channel,
       defaultCategoryId: options?.defaultCategoryId,
       onSuccess: options?.onSuccess,
+      keepSidebarTab: options?.keepSidebarTab,
     });
   }
 

--- a/packages/dmworkbase/src/Hooks/useCategoryList.ts
+++ b/packages/dmworkbase/src/Hooks/useCategoryList.ts
@@ -7,7 +7,7 @@ export interface UseCategoryListResult {
     isLoading: boolean
     error: string | null
     reload: () => void
-    createCategory: (name: string) => Promise<void>
+    createCategory: (name: string) => Promise<CategoryItem>
     renameCategory: (categoryId: string, name: string) => Promise<void>
     deleteCategory: (categoryId: string) => Promise<void>
     sortCategories: (categoryIds: string[]) => Promise<void>
@@ -43,8 +43,9 @@ export function useCategoryList(): UseCategoryListResult {
 
     const createCategory = async (name: string) => {
         if (!spaceId) throw new Error("未选中 Space")
-        await CategoryService.create(spaceId, { name })
+        const created = await CategoryService.create(spaceId, { name })
         await load()
+        return created
     }
 
     const renameCategory = async (categoryId: string, name: string) => {

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -441,6 +441,9 @@ export class ChatVM extends ProviderListener {
 
         this.notifyListener()
         WKApp.menus.refresh() // Fix #3: 切换 Space 后刷新 badge
+        // 通知一次性读取 conversationManager.conversations 的消费者（合并转发等）
+        // 缓存已经回填,可以重新 load 了。
+        WKApp.mittBus.emit('conversation-list-refreshed')
     }
 
     async reloadRequestConversationList() {

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -413,8 +413,8 @@ export class ChatVM extends ProviderListener {
         // 先拉取数据，避免清空列表导致 UI 闪烁（fix #266）
         const conversations = await WKSDK.shared().conversationManager.sync({})
 
-        // 拉取成功后再清空+替换（切换 Space 时清空 SDK 内部缓存，避免旧 Space 会话残留）
-        WKSDK.shared().conversationManager.conversations = []
+        // _pendingSpaceConversations 是 ChatVM 自己的延迟队列,跟 SDK cache 无关,
+        // 切 Space 时清掉避免旧 Space 排队中的 incoming 落入新 Space 视图。
         this._pendingSpaceConversations.clear()
 
         const conversationWraps = new Array<ConversationWrap>()

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -418,6 +418,7 @@ export class ChatVM extends ProviderListener {
         this._pendingSpaceConversations.clear()
 
         const conversationWraps = new Array<ConversationWrap>()
+        const filteredForSdk = new Array<Conversation>()
         if (conversations && conversations.length > 0) {
             for (const conversation of conversations) {
                 // Space 过滤：复用共享函数（含 channelSpaceMap 缓存）
@@ -426,8 +427,13 @@ export class ChatVM extends ProviderListener {
                 }
                 if (shouldSkipPersonConversationForSpace(conversation)) continue
                 conversationWraps.push(new ConversationWrap(conversation))
+                filteredForSdk.push(conversation)
             }
         }
+        // 将过滤后的会话回填到 SDK 全局缓存，保证其它读取者（合并转发选择器、
+        // todo 等）在切换 Space 后能立刻读到当前 Space 的最近会话/子区，
+        // 而不是看到上一行被清空的空数组。
+        WKSDK.shared().conversationManager.conversations = filteredForSdk
         this.conversations = conversationWraps
         this.loading = false
 

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -410,8 +410,19 @@ export class ChatVM extends ProviderListener {
         this.loading = true
         this.notifyListener()
 
+        // 快照本次请求对应的 Space,sync 回来后比对 —— 快速 A→B→C 切换时,
+        // B 的回包可能晚于 C 的回包到达;如果直接写入会把 C 的 cache 覆盖成 B 的
+        // (甚至空数组,见 dmworkdatasource/module.ts 的 stale guard)。
+        const requestSpaceId = WKApp.shared.currentSpaceId
+
         // 先拉取数据，避免清空列表导致 UI 闪烁（fix #266）
         const conversations = await WKSDK.shared().conversationManager.sync({})
+
+        // 回来已经不是本次请求对应的 Space —— 当前 Space 自有更新一次 sync,
+        // 直接放弃本次结果。loading 留给新一次 sync 收尾,避免和 loading=false 冲突。
+        if (WKApp.shared.currentSpaceId !== requestSpaceId) {
+            return
+        }
 
         // _pendingSpaceConversations 是 ChatVM 自己的延迟队列,跟 SDK cache 无关,
         // 切 Space 时清掉避免旧 Space 排队中的 incoming 落入新 Space 视图。

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -35,6 +35,7 @@ interface IPorpsOrganizationalGroupNew {
   autoShow?: boolean;
   defaultCategoryId?: string;
   onSuccess?: () => void;
+  keepSidebarTab?: boolean;
 }
 
 interface ISateOrganizationalGroupNew {
@@ -468,7 +469,10 @@ export class OrganizationalGroupNew extends Component<
           { categoryId: this.props.defaultCategoryId }
         )
         if (result?.group_no) {
-          WKApp.endpoints.showConversation(new Channel(result.group_no, ChannelTypeGroup))
+          WKApp.endpoints.showConversation(
+            new Channel(result.group_no, ChannelTypeGroup),
+            this.props.keepSidebarTab ? { fromSidebarList: true } : undefined,
+          )
         }
         this.props.onSuccess?.()
       } catch (error: any) {

--- a/packages/dmworkcontacts/src/module.tsx
+++ b/packages/dmworkcontacts/src/module.tsx
@@ -106,6 +106,7 @@ export default class ContactsModule implements IModule {
         const channel = (param.channel ?? { channelID: "", channelType: 0 }) as any;
         const defaultCategoryId = param.defaultCategoryId as string | undefined;
         const onSuccess = param.onSuccess as (() => void) | undefined;
+        const keepSidebarTab = param.keepSidebarTab as boolean | undefined;
         const div = document.createElement("div");
         document.body.appendChild(div);
 
@@ -122,6 +123,7 @@ export default class ContactsModule implements IModule {
             autoShow={true}
             defaultCategoryId={defaultCategoryId}
             onSuccess={onSuccess}
+            keepSidebarTab={keepSidebarTab}
           />,
           div
         );


### PR DESCRIPTION
## Summary

两个独立 bug，凑在同一个 branch 一起提：

### 1. `fix(mergeforward)` — 切 Space 后合并转发列表缺子区/最近会话
切换 Space 后立即触发"合并转发"，弹出的列表里子区、最近会话、个人聊天会缺失，要刷新页面才正常。

**根因**：`Chat/vm.ts` 的 `requestConversationList()` 在 `sync({})` 完成后又显式 `WKSDK.conversationManager.conversations = []` 清空了 SDK 全局缓存（注释写的是"清空旧 Space 残留"，但 sync 已经替换过了，再清就是把刚拿到的新数据丢掉）。`useForwardModal` 直接读这个缓存，自然拿到空数组。

**修复**：
- `Chat/vm.ts`：sync 完用过滤后的 conversation 回填 SDK 缓存，让合并转发/todo 等读取者切 Space 后能立刻读到当前 Space 的最近会话+子区。
- `WKBase`：给 `<ConversationSelect>` 加 key 计数器，每次 `showConversationSelect()` 自增；Semi `Modal` 默认不卸载子树，没这个 key 的话"在 A 开过弹窗 → 切到 B → 再开"会显示 A 的缓存。
- `useForwardModal`：friends 按 `channelID` 自去重（Space 模式 `space/{id}/members` 可能返回重复 uid，触发 React duplicate-key 警告）。
- `Main/handleSpaceSelected`：把 `currentSpaceId`/`localStorage`/`emit space-changed` 改成同步执行，`getMySpaces()` 仅用于后台刷新 Space 列表 UI；避免用户在网络回包前立即操作时读到旧 spaceId 的 race。

### 2. `fix(follow)` — 关注 Tab 两处建分组相关的 bug
- **右键 → "+ 新建分组"**：之前只是打开 modal 建出空分类，右键选中的会话没被归入新分类。新增 `pendingAction` 把右键现场上下文带到 modal `onConfirm`；抽出 `followConvToCategory` helper 统一三种 channelType（子区/群/DM）的写入。
- **关注 Tab 内"新建群聊"**：建完群 sidebar 跳回最近 Tab、关注列表也没刷新。新增 `organizationalLayer` 的 `keepSidebarTab` 选项，`GroupNew` 透传 `fromSidebarList: true`；建群入口改用 `reloadAll`。

附带：
- `useCategoryList.createCategory` 返回新建的 `CategoryItem`（之前是 void），调用方拿到 `category_id` 才能继续 follow/move。
- `CreateCategoryModal`：`loading` 期间不做重复名校验，否则父层 setState 间隙会让"该分组名已存在"一闪。

## Test plan

- [ ] 切 Space → 立即合并转发：列表展示当前 Space 的最近会话+子区+群+好友，与刷新后一致
- [ ] 在 A 开合并转发 → 关掉 → 切 B → 再开：列表是 B 的数据，不是 A 的缓存
- [ ] 合并转发弹窗第一次点击就能打开，控制台无 React duplicate-key 警告
- [ ] 关注 Tab 右键群/会话/子区 → 移到分组 / 添加到关注 → "+ 新建分组" → 新分类建出来后选中会话被自动归入
- [ ] 顶部 "+ 新建分组" 入口仍正常（建空分类即可）
- [ ] 关注 Tab 内"新建群聊"成功后，sidebar 留在关注 Tab、关注列表和会话列表都刷新