### PR TITLE
feat(login): SSO panel redesign per Figma + theme-token compliance

### DIFF
--- a/packages/dmworklogin/src/login.css
+++ b/packages/dmworklogin/src/login.css
@@ -12,6 +12,18 @@
     --semi-color-primary-active: #151519;
     --semi-color-primary-active: color-mix(in srgb, var(--wk-color-theme, #1C1C23) 75%, black);
 
+    /* SSO accent surface derives from brand theme; override
+       --wk-sso-accent at deploy time if SSO CTA needs to diverge from
+       --wk-color-theme. Translucent variants use color-mix so they
+       track the configured brand color in custom / dark themes. */
+    --wk-sso-accent: var(--wk-color-theme, #5b5be5);
+    --wk-sso-accent-soft: color-mix(in srgb, var(--wk-sso-accent) 80%, white);
+    --wk-sso-accent-strong: color-mix(in srgb, var(--wk-sso-accent) 85%, black);
+    --wk-sso-accent-shadow: color-mix(in srgb, var(--wk-sso-accent) 32%, transparent);
+    --wk-sso-accent-shadow-hover: color-mix(in srgb, var(--wk-sso-accent) 42%, transparent);
+    --wk-sso-accent-translucent: color-mix(in srgb, var(--wk-sso-accent) 45%, transparent);
+    --wk-sso-accent-dot-ring: color-mix(in srgb, var(--wk-sso-accent) 18%, transparent);
+
     display: flex;
     min-height: 100vh;
     width: 100%;
@@ -226,7 +238,7 @@
     justify-content: center;
     background: var(--semi-color-bg-0, #fff);
     box-sizing: border-box;
-    padding: 40px 48px;
+    padding: 72px 48px 64px;
     overflow-y: auto;
 }
 
@@ -237,9 +249,54 @@
     min-height: 0;
 }
 
+/* ---- Panel breadcrumb (top-left small label) ---- */
+.wk-login-panel-breadcrumb {
+    position: absolute;
+    top: 28px;
+    left: 48px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--semi-color-text-2, #8a8fa8);
+    user-select: none;
+}
+.wk-login-panel-breadcrumb-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--wk-sso-accent);
+    box-shadow: 0 0 0 3px var(--wk-sso-accent-dot-ring);
+}
+
+/* ---- Panel footer (bottom-center copyright + legal) ---- */
+.wk-login-panel-footer {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--semi-color-text-2, #9aa0b6);
+}
+.wk-login-panel-footer a {
+    color: var(--semi-color-text-2, #9aa0b6);
+    text-decoration: none;
+    transition: color 120ms ease;
+}
+.wk-login-panel-footer a:hover {
+    color: var(--wk-sso-accent);
+}
+.wk-login-panel-footer-sep {
+    color: rgba(0, 0, 0, 0.15);
+}
+
 .wk-login-content {
     width: 100%;
-    max-width: 400px;
+    max-width: 520px;
 }
 
 /* ---- Logo (inside form panel, mobile fallback) ---- */
@@ -710,6 +767,27 @@
     line-height: 1.6;
 }
 
+/* ---- Download section divider ---- */
+.wk-login-content-download-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 36px 0 18px;
+    color: var(--semi-color-text-2, #9aa0b6);
+    font-size: 12px;
+}
+.wk-login-content-download-divider::before,
+.wk-login-content-download-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--semi-color-border, #eef0f5);
+}
+.wk-login-content-download-divider span {
+    flex-shrink: 0;
+    line-height: 1;
+}
+
 /* ---- Download button ---- */
 .wk-login-content-download {
     display: flex;
@@ -718,9 +796,6 @@
     align-items: center;
     gap: 8px;
     text-align: center;
-    margin-top: 32px;
-    padding-top: 20px;
-    border-top: 1px solid var(--semi-color-border, #eef0f5);
 }
 
 .wk-login-download-btn {
@@ -769,6 +844,22 @@
         width: 100% !important;
         min-height: 100vh;
         padding: 40px 24px;
+    }
+
+    /* On narrow viewports we collapse to a single scrollable column.
+       Keeping the footer absolutely positioned means tall flows
+       (register / reset password / QR / SSO + downloads) scroll
+       underneath it. Flip the breadcrumb + footer back into the
+       normal flow so they grow / shrink the panel naturally. */
+    .wk-login-panel-breadcrumb {
+        position: static;
+        justify-content: center;
+        margin-bottom: 16px;
+    }
+
+    .wk-login-panel-footer {
+        position: static;
+        margin-top: 32px;
     }
 
     .wk-login-content-logo {
@@ -914,58 +1005,67 @@
 /* ---- SSO-first layout ---- */
 .wk-login-panel .wk-login-content-sso-primary.semi-button {
     width: 100%;
-    height: 50px;
-    margin-top: 8px;
-    border-radius: 12px;
-    font-size: 16px;
+    height: 56px;
+    margin-top: 16px;
+    border-radius: 14px;
+    font-size: 17px;
     font-weight: 600;
     letter-spacing: 0.3px;
-    border: 1px solid #5b5be5;
-    background: #5b5be5;
-    color: #fff;
-    box-shadow: 0 4px 12px rgba(91, 91, 229, 0.25);
+    border: none;
+    background: linear-gradient(135deg, var(--wk-sso-accent-soft) 0%, var(--wk-sso-accent) 100%);
+    color: var(--semi-color-white, #fff);
+    box-shadow: 0 8px 24px var(--wk-sso-accent-shadow);
     transition: all 0.2s;
 }
 .wk-login-panel .wk-login-content-sso-primary.semi-button:hover,
 .wk-login-panel .wk-login-content-sso-primary.semi-button:focus {
-    background: #4848d4;
-    border-color: #4848d4;
-    box-shadow: 0 6px 16px rgba(91, 91, 229, 0.35);
+    background: linear-gradient(135deg, var(--wk-sso-accent) 0%, var(--wk-sso-accent-strong) 100%);
+    box-shadow: 0 10px 28px var(--wk-sso-accent-shadow-hover);
     transform: translateY(-1px);
 }
 .wk-login-panel .wk-login-content-sso-primary.semi-button .semi-button-content,
 .wk-login-panel .wk-login-content-sso-primary.semi-button span {
-    color: #fff;
+    color: var(--semi-color-white, #fff);
+}
+.wk-login-content-sso-primary-inner {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+.wk-login-content-sso-primary-icon {
+    flex-shrink: 0;
+    color: var(--semi-color-white, #fff);
 }
 
-/* 主按钮下方注释行: 行为 + IdP 信任锚单行展示, 用 · 分隔.
-   单行密度比两行小灰字叠放更清爽; trust 段单独可 hover 出 tooltip. */
+/* 主按钮下方信任锚: 主题色小字 + shield 图标, 强化企业身份信号.
+   IdP 名用 <strong> 加重, 与 "企业级安全" 一起构成 trust 标签. */
 .wk-login-content-sso-meta {
-    margin-top: 10px;
+    margin-top: 14px;
     text-align: center;
-    color: rgba(0, 0, 0, 0.45);
-    font-size: 12px;
+    color: var(--wk-sso-accent);
+    font-size: 13px;
     line-height: 1.6;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-}
-.wk-login-content-sso-meta-sep {
-    color: rgba(0, 0, 0, 0.2);
-}
-.wk-login-content-sso-trust {
-    color: rgba(0, 0, 0, 0.45);
+    gap: 5px;
     cursor: help;
     user-select: none;
-    border-bottom: 1px dotted rgba(0, 0, 0, 0.18);
-    padding-bottom: 1px;
-    transition: color 120ms ease, border-color 120ms ease;
 }
-.wk-login-content-sso-trust:hover {
-    color: rgba(0, 0, 0, 0.75);
-    border-bottom-color: rgba(0, 0, 0, 0.45);
+.wk-login-content-sso-meta-icon {
+    color: var(--wk-sso-accent);
+    flex-shrink: 0;
+    margin-right: 2px;
+}
+.wk-login-content-sso-meta-brand {
+    color: var(--wk-sso-accent);
+    font-weight: 600;
+}
+.wk-login-content-sso-meta-sep {
+    color: var(--wk-sso-accent-translucent);
+    margin: 0 2px;
 }
 
 /* 默认折叠态: 单行小字链接, 紧贴信任锚下方, 不被下载按钮夹在中间 (P1 反馈).

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -392,6 +392,12 @@ class Login extends Component<any, LoginState> {
                 <div className="wk-login-panel">
                     {ENTERPRISE_SSO_ENABLED && <OidcResumeEffect vm={vm} />}
                     {ENTERPRISE_SSO_ENABLED && <OidcResumingOverlay vm={vm} />}
+                    {/* 右上小面包屑: 紫色圆点 + 当前登录目标. 给到达 /login 的人一个
+                        "我在哪 / 这个表单会把我送去哪" 的轻确认, 不抢主标题视觉权重. */}
+                    <div className="wk-login-panel-breadcrumb">
+                        <span className="wk-login-panel-breadcrumb-dot" />
+                        <span>登录到 {WKApp.config.appName || 'Octo'} · Web</span>
+                    </div>
                     <div className="wk-login-content">
                         {/* Mobile logo fallback */}
                         <div className="wk-login-content-logo">
@@ -406,12 +412,17 @@ class Login extends Component<any, LoginState> {
                         )}
                         <div className="wk-login-content-phonelogin" style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}>
                             <div className="wk-login-content-slogan">欢迎回来</div>
-                            {/* hero 到 CTA 之间一行过渡. SSO 启用时点明渠道 (手机号或邮箱都行),
-                                避免用户误以为只能用邮箱; 与按钮 "登录 / 注册" 是动作 + 渠道的互补. */}
+                            {/* hero 到 CTA 之间两行过渡. SSO 启用时显式说明渠道 + 新用户行为,
+                                两行小字避免用户在主按钮前还需要猜 "点了会发生什么". */}
                             <div className="wk-login-content-slogan-sub">
-                                {ENTERPRISE_SSO_ENABLED && hasSsoProvider
-                                    ? '使用手机号或邮箱即可登录'
-                                    : '登录你的账号以继续'}
+                                {ENTERPRISE_SSO_ENABLED && hasSsoProvider ? (
+                                    <>
+                                        <div>使用 {ssoProvider!.name} 安全登录你的 {WKApp.config.appName || 'Octo'} 账号</div>
+                                        <div>新用户首次登录将自动创建账号</div>
+                                    </>
+                                ) : (
+                                    '登录你的账号以继续'
+                                )}
                             </div>
                             {ENTERPRISE_SSO_ENABLED && hasSsoProvider ? (
                                 // SSO 启用：OIDC provider 作为主 CTA. Aegis 等 IdP 品牌名
@@ -425,20 +436,29 @@ class Login extends Component<any, LoginState> {
                                         disabled={vm.oidcLoading || vm.oidcResuming}
                                         onClick={startSsoLogin}
                                     >
-                                        登录 / 注册
-                                    </Button>
-                                    {/* 主按钮下的注释块: helper(行为) + trust(IdP 来源)
-                                        合到同一行用 "·" 分隔, 避免两行小灰字相邻视觉糊成一团.
-                                        鼠标悬停 trust 段弹出 IdP 完整解释 (借浏览器 title). */}
-                                    <div className="wk-login-content-sso-meta">
-                                        <span>已有账号将自动登录，新用户将自动注册</span>
-                                        <span className="wk-login-content-sso-meta-sep">·</span>
-                                        <span
-                                            className="wk-login-content-sso-trust"
-                                            title={`${ssoProvider!.name} 是 Mininglamp 统一身份服务，登录后可在所有 Mininglamp 产品中通用`}
-                                        >
-                                            由 {ssoProvider!.name} 提供
+                                        <span className="wk-login-content-sso-primary-inner">
+                                            <svg className="wk-login-content-sso-primary-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                                <path d="M12 2 4 5v6c0 5 3.5 9.4 8 11 4.5-1.6 8-6 8-11V5l-8-3z" />
+                                                <path d="m9 12 2 2 4-4" />
+                                            </svg>
+                                            <span>使用 {ssoProvider!.name} 登录</span>
                                         </span>
+                                    </Button>
+                                    {/* 主按钮下方信任锚: shield 图标 + "身份认证由 X 提供 · 企业级安全".
+                                        紫色文案 + IdP 名加粗, 强化"这是企业统一身份, 不是普通登录"的
+                                        视觉信号; 鼠标悬停 trust 段弹出 IdP 完整解释 (借浏览器 title). */}
+                                    <div
+                                        className="wk-login-content-sso-meta"
+                                        title={`通过 ${ssoProvider!.name} 进行统一身份认证，登录后可在所有接入的产品中通用`}
+                                    >
+                                        <svg className="wk-login-content-sso-meta-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                            <path d="M12 2 4 5v6c0 5 3.5 9.4 8 11 4.5-1.6 8-6 8-11V5l-8-3z" />
+                                        </svg>
+                                        <span>身份认证由</span>
+                                        <strong className="wk-login-content-sso-meta-brand">{ssoProvider!.name}</strong>
+                                        <span>提供</span>
+                                        <span className="wk-login-content-sso-meta-sep">·</span>
+                                        <span>企业级安全</span>
                                     </div>
                                     {/* TODO(legacy-login-flag): 暂时隐藏本地密码登录入口, 等
                                         后端 PR 在 /v1/common/appconfig 暴露 legacy_password_login_off
@@ -451,6 +471,11 @@ class Login extends Component<any, LoginState> {
                                             handleLogin={handleLogin}
                                         />
                                     )}
+                                    {/* 下载入口前的分隔线: 两侧细线 + 中间文案,
+                                        从"主登录区"过渡到"也提供移动版"的次级 CTA. */}
+                                    <div className="wk-login-content-download-divider">
+                                        <span>也可下载移动版</span>
+                                    </div>
                                     <div className="wk-login-content-download">
                                         <AndroidDownloadButton />
                                         <IOSDownloadButton />
@@ -730,6 +755,10 @@ class Login extends Component<any, LoginState> {
                                 <button onClick={() => { vm.loginType = LoginType.phone }}>使用账号密码登录</button>
                             </div>
                         </div>
+                    </div>
+                    {/* 右下底栏: 版权, 固定在 panel 底部居中. */}
+                    <div className="wk-login-panel-footer">
+                        <span>© {new Date().getFullYear()} {WKApp.config.appName || 'Octo'}</span>
                     </div>
                 </div>{/* end wk-login-panel */}
             </div>


### PR DESCRIPTION
## Summary

- Right-panel SSO login redesign aligned with the Figma spec: two-line subtitle, shield-iconed primary CTA ("Use \<Provider\> to sign in"), and a purple trust line ("Identity verified by \<Provider\> · Enterprise-grade security").
- New top-left breadcrumb ("Sign in to \<App\> · Web") and bottom-center copyright footer. Both flip from `position: absolute` to `static` on `<= 768px` so register / reset / QR / SSO+downloads flows cannot scroll under the footer.
- Download section now sits under a centered "Also available on mobile" divider instead of a plain `border-top`; Android / iOS pill buttons themselves are untouched.
- Content `max-width` 400 → 520 to fix the excessive side whitespace reported on the right panel.

## Theme compliance

The new SSO CTA / trust line / breadcrumb dot / footer-hover all derive from a new `--wk-sso-accent` CSS variable, scoped to `.wk-login` and defaulting to `var(--wk-color-theme, #5b5be5)`. Translucent variants (`--wk-sso-accent-shadow`, `--wk-sso-accent-translucent`, etc.) are derived via `color-mix(... transparent)` so custom-brand and dark-theme deployments still track the configured color. Deployments that need the SSO surface to diverge from the global theme color can override `--wk-sso-accent` directly without touching `login.css`.

## Identity-provider neutrality

The trust-line tooltip used to hard-code "Mininglamp 统一身份服务". It's now phrased generically (`通过 <Provider> 进行统一身份认证…`) so non-Mininglamp deployments (e.g. tests using `Acme SSO`) show correct copy.

## Test plan

- [ ] Verify SSO login page on desktop with `VITE_ENABLE_ENTERPRISE_SSO=true` matches the Figma spec.
- [ ] Verify the page on a narrow viewport (`<= 768px`): breadcrumb + footer in-flow, no overlap with QR / register / reset-password content.
- [ ] Override `--wk-color-theme` (or `--wk-sso-accent`) and confirm the SSO CTA + trust line + breadcrumb dot all follow the new color.
- [ ] Non-SSO flow (`VITE_ENABLE_ENTERPRISE_SSO` unset) still renders the legacy form correctly.