### PR TITLE
fix(persona): PersonaCreate subscribes to VM notifyListener fan-out

### DIFF
--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * PersonaCreate notifyListener fan-out regression (octo-web#95 / YUJ-1772).
+ *
+ * Bug repro:
+ *   - PersonaCreate is pushed via routeContext.push(<PersonaCreate vm={vm} />).
+ *   - Provider's setState → re-runs the render prop, but the pushed JSX is
+ *     already captured by WKViewQueue's state and is NOT re-created.
+ *   - vm.loadMyBots() finishes, sets vm.myBots, calls notifyListener() — but
+ *     PersonaCreate has no subscription path, so its DOM stays on
+ *     "暂无可关联的 Bot" forever.
+ *
+ * Fix being verified here: PersonaCreate calls vm.addListener(forceUpdate) in
+ * a useEffect, opting back into the VM update stream via the new fan-out
+ * channel on ProviderListener (see ../../../Service/Provider.tsx).
+ *
+ * Why we don't use @testing-library/react:
+ *   This monorepo's dmworkbase package is React 17, but the installed RTL
+ *   transitively pulls in react-dom@18 (root devDep). Mounting a function
+ *   component with hooks via RTL's render() crashes with
+ *   "Invalid hook call" — see the same workaround in createRouteStack.test.
+ *   We use ReactDOM.render legacy + react-dom/test-utils.act, which targets
+ *   the same React 17 instance the component imports and lets useEffect run.
+ */
+
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const hoisted = vi.hoisted(() => {
+    const get = vi.fn()
+    const post = vi.fn()
+    const del = vi.fn()
+    const put = vi.fn()
+    const toastError = vi.fn()
+    const toastWarning = vi.fn()
+    return { get, post, del, put, toastError, toastWarning }
+})
+
+vi.mock("../../../App", () => ({
+    default: {
+        apiClient: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+        shared: { currentSpaceId: "" },
+        loginInfo: { uid: "" },
+    },
+    __esModule: true,
+}))
+
+vi.mock("@douyinfe/semi-ui", () => ({
+    Toast: {
+        error: hoisted.toastError,
+        warning: hoisted.toastWarning,
+    },
+    // PersonaCreate uses native <textarea>/<button>; nothing else from Semi
+    // is reached on this render path, so a single Toast stub is enough.
+}))
+
+import { PersonaCreate, PersonaSettingsVM } from "../index"
+
+let container: HTMLDivElement
+
+beforeEach(() => {
+    hoisted.get.mockReset()
+    hoisted.post.mockReset()
+    hoisted.del.mockReset()
+    hoisted.put.mockReset()
+    hoisted.toastError.mockReset()
+    hoisted.toastWarning.mockReset()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+})
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+    vi.restoreAllMocks()
+})
+
+/**
+ * Helper: yield to microtasks so Promise.then/await chains in the VM's
+ * loadMyBots resolve, then re-render with `act` so React flushes effects.
+ */
+const flush = async (): Promise<void> => {
+    await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+    })
+}
+
+describe("PersonaCreate — notifyListener fan-out (octo-web#95)", () => {
+    it("re-renders the bot list once loadMyBots resolves (was stuck on '暂无')", async () => {
+        // VM hits /robot/my_bots and /robot/space_bots (leading slash) for the
+        // picker, and obo/grants (no leading slash) for the dedupe set. Match
+        // both spellings just in case.
+        hoisted.get.mockImplementation((url: string) => {
+            if (url === "/robot/my_bots" || url === "robot/my_bots") {
+                return Promise.resolve([{ uid: "bot-x", name: "Picker Bot X" }])
+            }
+            if (url === "/robot/space_bots" || url === "robot/space_bots") {
+                return Promise.resolve([])
+            }
+            if (url === "obo/grants") return Promise.resolve([])
+            return Promise.resolve([])
+        })
+
+        const vm = new PersonaSettingsVM()
+
+        await act(async () => {
+            ReactDOM.render(
+                <PersonaCreate
+                    vm={vm}
+                    onCreated={async () => {
+                        /* not exercised */
+                    }}
+                />,
+                container,
+            )
+        })
+
+        // First paint: loadMyBots is in flight → "加载中..." or initial empty.
+        // We don't pin the exact label here because both states are valid
+        // before the fan-out fires; the contract is that AFTER fan-out the
+        // bot row is visible. Pre-fix, that never happened.
+        await flush()
+        await flush()
+
+        // Bot row must be in the DOM now.
+        const row = container.querySelector('[data-testid="persona-create-bot-bot-x"]')
+        expect(row).toBeTruthy()
+        expect(row?.textContent).toContain("Picker Bot X")
+        // The empty-state must be gone.
+        expect(container.textContent || "").not.toMatch(/暂无可关联的 Bot/)
+    })
+
+    it("clean unsubscribe — VM still functions after PersonaCreate unmounts", async () => {
+        hoisted.get.mockImplementation((url: string) => {
+            if (url === "/robot/my_bots" || url === "robot/my_bots") {
+                return Promise.resolve([])
+            }
+            if (url === "/robot/space_bots" || url === "robot/space_bots") {
+                return Promise.resolve([])
+            }
+            if (url === "obo/grants") return Promise.resolve([])
+            return Promise.resolve([])
+        })
+        const vm = new PersonaSettingsVM()
+
+        await act(async () => {
+            ReactDOM.render(
+                <PersonaCreate vm={vm} onCreated={async () => {}} />,
+                container,
+            )
+        })
+        await flush()
+
+        // Unmount.
+        act(() => {
+            ReactDOM.unmountComponentAtNode(container)
+        })
+
+        // notifyListener must not throw after the subscriber detaches —
+        // the unsubscribe path on useEffect cleanup is the contract that
+        // makes this safe even when other Provider listeners are still
+        // active.
+        expect(() => vm.notifyListener()).not.toThrow()
+    })
+
+    it("hides bots that already have a grant (dedupe runs through the rendered tree)", async () => {
+        hoisted.get.mockImplementation((url: string) => {
+            if (url === "obo/grants") {
+                return Promise.resolve([
+                    {
+                        id: 1,
+                        grantor_uid: "me",
+                        grantee_bot_uid: "bot-x",
+                        grantee_bot_name: "Bot X",
+                        mode: "auto",
+                        global_enabled: true,
+                        active: true,
+                    },
+                ])
+            }
+            if (url === "/robot/my_bots" || url === "robot/my_bots") {
+                return Promise.resolve([
+                    { uid: "bot-x", name: "Bot X" },
+                    { uid: "bot-y", name: "Bot Y" },
+                ])
+            }
+            if (url === "/robot/space_bots" || url === "robot/space_bots") {
+                return Promise.resolve([])
+            }
+            return Promise.resolve([])
+        })
+
+        const vm = new PersonaSettingsVM()
+        // loadGrants must run first so the dedupe set is populated when
+        // loadMyBots filters.
+        await vm.loadGrants()
+
+        await act(async () => {
+            ReactDOM.render(
+                <PersonaCreate vm={vm} onCreated={async () => {}} />,
+                container,
+            )
+        })
+        await flush()
+        await flush()
+
+        // Bot Y is showable; Bot X must be filtered out (already granted).
+        expect(
+            container.querySelector('[data-testid="persona-create-bot-bot-y"]'),
+        ).toBeTruthy()
+        expect(
+            container.querySelector('[data-testid="persona-create-bot-bot-x"]'),
+        ).toBeNull()
+    })
+})

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
@@ -352,6 +352,24 @@ function PersonaCreate(props: {
     const [selectedUid, setSelectedUid] = React.useState<string>("")
     const [prompt, setPrompt] = React.useState<string>("")
     const [submitting, setSubmitting] = React.useState<boolean>(false)
+    // 让 VM 的 notifyListener 能驱动本组件重渲染（octo-web#95）。
+    //
+    // 历史背景：`PersonaCreate` 通过父级 `routeContext.push()` 推入 RoutePage 的
+    // WKViewQueue，于是它虽然在 `<Provider>` 的 React 子树里、但 JSX 已经被 WKViewQueue
+    // 捕获到自己的 state 里 —— Provider 在 `notifyListener` 时只 `setState({})` 触发
+    // 自身 render prop 重跑，并不会把新的 props 透传到已经被 WKViewQueue 缓存的
+    // `<PersonaCreate>` 节点。结果 `vm.loadMyBots()` 完成后 `vm.myBots` 已经填好，
+    // 但本组件不会重新读取 vm 上的字段，UI 永远卡在「暂无可关联的 Bot」空态。
+    //
+    // 修法：用 `ProviderListener.addListener` 这条 fan-out 通道（PR 同改 Provider.tsx）
+    // 显式订阅 VM 变化，命中时 `forceUpdate` 重读 `vm.myBots / vm.myBotsLoading`。
+    // 与 Provider 自带的 `listen()` 单插槽不冲突 —— Provider 走 callback，本组件走
+    // Set<listener> 旁路，互不覆盖。
+    const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0)
+    React.useEffect(() => {
+        const unsubscribe = vm.addListener(() => forceUpdate())
+        return unsubscribe
+    }, [vm])
     // 第一次渲染时触发 loadMyBots（避免在 vm 构造里副作用）
     React.useEffect(() => {
         if (vm.myBots.length === 0 && !vm.myBotsLoading) {
@@ -431,4 +449,9 @@ function PersonaCreate(props: {
 
 // 重导出，方便测试和外部引用
 export { PersonaSettings }
+// PersonaCreate 单独导出供测试使用（octo-web#95 fan-out 回归测试需要直接挂载它，
+// 走完整的 routeContext.push 链路在 dmworkbase 这套 React 17 + RTL/react-dom 18
+// 混搭环境里会触发 invalid hook call —— 详见 PersonaSettings/__tests__/createRouteStack.test
+// 顶部注释解释了为什么这里要降级到 ReactDOM legacy render）。
+export { PersonaCreate }
 export { PersonaSettingsVM, PersonaEditVM, hasAnyActiveGrant, refreshActiveGrantCache, clearPersonaActiveCache } from "./vm"

--- a/packages/dmworkbase/src/Service/Provider.tsx
+++ b/packages/dmworkbase/src/Service/Provider.tsx
@@ -10,13 +10,62 @@ export interface IProviderListener {
 
 export class ProviderListener implements IProviderListener {
     callback?:(ck?:()=>void)=>void
+    /**
+     * Ad-hoc fan-out subscribers. The `callback` slot above is owned exclusively
+     * by the Provider component (it overwrites whatever was there on mount), so
+     * any view that lives outside the Provider's own subtree — e.g. children
+     * pushed onto a RoutePage / WKViewQueue via `routeContext.push()` — cannot
+     * use `listen()` to react to `notifyListener()`. Those views register here
+     * via `addListener` and unregister on unmount.
+     *
+     * Why this exists (octo-web#95): `PersonaCreate` is a function component
+     * pushed via `routeContext.push(<PersonaCreate vm={vm} />)`. WKViewQueue
+     * captures that JSX in its own state, so the Provider's `setState({})` on
+     * `notifyListener` does not bubble fresh props down to it; the bot list
+     * stayed stuck on "暂无可关联的 Bot" forever even after `loadMyBots()`
+     * resolved. Subscribing through `addListener` gives those rogue subtrees
+     * a way to opt back into the VM update stream.
+     */
+    private listeners: Set<() => void> = new Set()
+
     notifyListener(stateCallback?:()=>void): void {
         if(this.callback) {
             this.callback(stateCallback)
         }
+        if (this.listeners.size > 0) {
+            // Snapshot first so a subscriber that synchronously unsubscribes
+            // (e.g. unmounts during the callback) doesn't mutate the Set we
+            // are iterating.
+            for (const fn of Array.from(this.listeners)) {
+                try {
+                    fn()
+                } catch (e) {
+                    // A misbehaving subscriber must not break sibling subscribers
+                    // or the legacy Provider callback path. Surface for debug.
+                    // eslint-disable-next-line no-console
+                    console.warn("[ProviderListener] subscriber threw", e)
+                }
+            }
+        }
     }
     listen(f: (ck?:()=>void) => void): void {
        this.callback = f
+    }
+
+    /**
+     * Subscribe to `notifyListener()` fan-out. Returns an unsubscribe handle
+     * suitable for use as a `useEffect` cleanup. Safe to add the same `fn`
+     * twice — Set semantics dedupe.
+     */
+    addListener(fn: () => void): () => void {
+        this.listeners.add(fn)
+        return () => {
+            this.listeners.delete(fn)
+        }
+    }
+
+    removeListener(fn: () => void): void {
+        this.listeners.delete(fn)
     }
 
     didMount() {
@@ -25,10 +74,14 @@ export class ProviderListener implements IProviderListener {
 
     clearListeners(): void {
         this.callback = undefined
+        // Drop ad-hoc subscribers too: `clearListeners` is called from
+        // `Provider.componentWillUnmount`, at which point the VM is on its way
+        // out and any surviving subscriber is by definition stale.
+        this.listeners.clear()
     }
 
     didUnMount(): void {
-        
+
     }
 
 }

--- a/packages/dmworkbase/src/Service/__tests__/ProviderListener.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/ProviderListener.test.ts
@@ -1,0 +1,128 @@
+/**
+ * ProviderListener fan-out subscriber regression test (octo-web#95 / YUJ-1772).
+ *
+ * Background — bug fixed by this test's companion change:
+ *   `PersonaCreate` is a function component pushed into a RoutePage via
+ *   `routeContext.push()`. RoutePage stashes the JSX inside `WKViewQueue`'s
+ *   own state, so when the parent `<Provider>` re-renders on
+ *   `vm.notifyListener()` the pushed view does *not* re-render — it has been
+ *   captured by WKViewQueue's state and is only re-rendered when WKViewQueue
+ *   itself gets new children, which Provider can't trigger.
+ *
+ *   `Provider.componentDidMount` claims the *single* `callback` slot on the
+ *   VM via `listen()`, so any other view that wanted to observe
+ *   `notifyListener()` would either overwrite Provider's callback (breaking
+ *   the list page) or be silently ignored.
+ *
+ *   `addListener(fn)` opens a side-channel: a `Set` of subscribers that
+ *   `notifyListener()` fans out to *in addition to* the legacy callback.
+ *
+ * What this test pins down:
+ *   1. `addListener` returns an unsubscribe handle that actually unhooks.
+ *   2. `notifyListener()` invokes BOTH the legacy `callback` (set by `listen`)
+ *      AND every active subscriber — order independent, but both must fire.
+ *   3. A subscriber that throws does not break sibling subscribers or the
+ *      legacy callback (so a buggy view can't take down PersonaListBody).
+ *   4. `clearListeners()` drops both the callback slot and the subscriber Set,
+ *      matching `Provider.componentWillUnmount` semantics.
+ *   5. A subscriber that synchronously unsubscribes during fan-out does not
+ *      crash iteration (Set-snapshot guarantee).
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { ProviderListener } from "../Provider"
+
+describe("ProviderListener.addListener — octo-web#95 fan-out", () => {
+    it("fires registered subscribers on notifyListener()", () => {
+        const vm = new ProviderListener()
+        const sub = vi.fn()
+        vm.addListener(sub)
+        vm.notifyListener()
+        expect(sub).toHaveBeenCalledTimes(1)
+    })
+
+    it("fires alongside the legacy listen() callback (does not replace it)", () => {
+        const vm = new ProviderListener()
+        const legacy = vi.fn()
+        const sub = vi.fn()
+        vm.listen(legacy)
+        vm.addListener(sub)
+        vm.notifyListener()
+        expect(legacy).toHaveBeenCalledTimes(1)
+        expect(sub).toHaveBeenCalledTimes(1)
+    })
+
+    it("returns an unsubscribe handle that detaches the subscriber", () => {
+        const vm = new ProviderListener()
+        const sub = vi.fn()
+        const unsubscribe = vm.addListener(sub)
+        vm.notifyListener()
+        expect(sub).toHaveBeenCalledTimes(1)
+        unsubscribe()
+        vm.notifyListener()
+        // No additional call after unsubscribe.
+        expect(sub).toHaveBeenCalledTimes(1)
+    })
+
+    it("removeListener also detaches", () => {
+        const vm = new ProviderListener()
+        const sub = vi.fn()
+        vm.addListener(sub)
+        vm.removeListener(sub)
+        vm.notifyListener()
+        expect(sub).not.toHaveBeenCalled()
+    })
+
+    it("isolates a throwing subscriber from siblings and from the legacy callback", () => {
+        const vm = new ProviderListener()
+        const legacy = vi.fn()
+        const ok = vi.fn()
+        const boom = vi.fn(() => {
+            throw new Error("subscriber blew up")
+        })
+        vm.listen(legacy)
+        vm.addListener(boom)
+        vm.addListener(ok)
+
+        // Should not throw out of notifyListener.
+        expect(() => vm.notifyListener()).not.toThrow()
+        expect(legacy).toHaveBeenCalledTimes(1)
+        expect(ok).toHaveBeenCalledTimes(1)
+        expect(boom).toHaveBeenCalledTimes(1)
+    })
+
+    it("clearListeners() drops both the callback and the subscriber Set", () => {
+        const vm = new ProviderListener()
+        const legacy = vi.fn()
+        const sub = vi.fn()
+        vm.listen(legacy)
+        vm.addListener(sub)
+        vm.clearListeners()
+        vm.notifyListener()
+        expect(legacy).not.toHaveBeenCalled()
+        expect(sub).not.toHaveBeenCalled()
+    })
+
+    it("tolerates a subscriber that synchronously unsubscribes during fan-out", () => {
+        // Snapshot semantics: notifyListener iterates a copy of the Set so a
+        // subscriber removing itself (or a sibling) mid-loop doesn't crash.
+        const vm = new ProviderListener()
+        const order: string[] = []
+        const a = (): void => {
+            order.push("a")
+            vm.removeListener(a)
+        }
+        const b = (): void => {
+            order.push("b")
+        }
+        vm.addListener(a)
+        vm.addListener(b)
+        expect(() => vm.notifyListener()).not.toThrow()
+        expect(order).toEqual(["a", "b"])
+
+        // a unsubscribed itself; only b should fire next time.
+        order.length = 0
+        vm.notifyListener()
+        expect(order).toEqual(["b"])
+    })
+})


### PR DESCRIPTION
## Summary

`PersonaCreate` is a function component pushed via `routeContext.push(<PersonaCreate vm={vm} />)`. The JSX is captured inside `WKViewQueue`'s own state, so when the parent `<Provider>` re-renders on `vm.notifyListener()` the already-captured node is NOT re-rendered. After `loadMyBots()` resolved and populated `vm.myBots`, the picker stayed stuck on **"暂无可关联的 Bot"** forever even when bots existed.

## Root cause

`Provider.componentDidMount` claims the single `callback` slot on the VM via `listen()`. Any view that lives outside Provider's direct React subtree had no way to react to `notifyListener()` without overwriting Provider's callback (which would break the list page).

## Fix

Two coordinated changes:

1. **`ProviderListener` fan-out channel** (`packages/dmworkbase/src/Service/Provider.tsx`):
   - New `addListener(fn) → unsubscribe` and `removeListener(fn)` API backed by a `Set`.
   - `notifyListener()` invokes the legacy `callback` slot **and** every active subscriber.
   - Buggy subscriber is isolated (try/catch); cannot take down `Provider` or siblings.
   - `clearListeners()` (called from `Provider.componentWillUnmount`) drops both the legacy callback and the subscriber Set.
   - Snapshot iteration so a subscriber that synchronously unsubscribes mid-fan-out doesn't crash the loop.

2. **`PersonaCreate` subscribes** (`packages/dmworkbase/src/Components/PersonaSettings/index.tsx`):
   - `useEffect` registers `vm.addListener(forceUpdate)` and returns the unsubscribe handle as cleanup.
   - `vm` as the effect dep so re-keying VMs (unlikely but possible) re-binds correctly.

## Tests

- `Service/__tests__/ProviderListener.test.ts` — pins the fan-out contract: subscriber + legacy callback both fire, unsubscribe detaches, throws are isolated, `clearListeners()` drops both, mid-iteration unsubscribe is safe.
- `Components/PersonaSettings/__tests__/PersonaCreate.test.tsx` — mounts `PersonaCreate` via `ReactDOM` legacy render (React 17 + react-dom 18 RTL mismatch makes hooks crash under RTL — same workaround as `createRouteStack.test`). Verifies the picker renders the bot row after `loadMyBots` resolves, dedupes already-granted bots from the picker, and unsubscribes cleanly on unmount.

Manually verified that without the `addListener` subscription the new component test fails (bot row never appears, dedupe never observed) and passes once the subscription is restored.

The pre-existing `vm.test.ts > toggleGlobal` failure (boolean vs `1` in PUT body) is on `main` at base SHA and not in scope here (禁改 vm logic).

## What did NOT change

- `vm.loadMyBots` / `vm.loadGrants` logic
- API endpoints / payloads
- `PersonaEdit` component

Fixes #95
