### PR TITLE
fix(mention): expand bot UIDs into mention.uids on @所有AI (#100)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -323,7 +323,21 @@ function formatMentionTextV2(text: string): {
     mention.uids = uids.length > 0 ? uids : undefined;
     mention.entities = entities.length > 0 ? entities : undefined;
     if (humans) mention.humans = 1;
-    if (ais) mention.ais = 1;
+    if (ais) {
+      mention.ais = 1;
+      // GH#100: expand bot member UIDs into mention.uids so legacy adapter
+      // bots (which only check mention.uids, not mention.ais) still recognise
+      // the @所有AI broadcast. Messages go via WuKongIM SDK direct — they
+      // never hit the server REST API, so server-side expansion (octo-server
+      // PR#145) does not apply to client-sent messages.
+      const botUids = (membersRef.current ?? [])
+        .filter((m: any) => m.orgData?.robot === 1)
+        .map((m: any) => m.uid)
+        .filter((uid: string) => !uids.includes(uid));
+      if (botUids.length > 0) {
+        mention.uids = [...(mention.uids ?? []), ...botUids];
+      }
+    }
     return { content: result, mention };
   }
 

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -510,9 +510,10 @@ export class MessageWrap {
                 continue
             }
 
-            // Defensive check: @all / @所有人 should not have personal entity
+            // Defensive check: broadcast tokens (@all / @所有人 / @所有AI)
+            // should not bind to personal entities.
             const mentionName = mentionText.slice(1)
-            if (mentionName.toLowerCase() === 'all' || mentionName === '所有人') {
+            if (mentionName.toLowerCase() === 'all' || mentionName === '所有人' || mentionName === '所有AI') {
                 parts.push(new Part(PartType.text, mentionText))
                 cursor = entity.offset + entity.length
                 continue
@@ -541,8 +542,12 @@ export class MessageWrap {
             const matchText = match[0]
             const mentionName = matchText.slice(1)
 
-            // Skip @all / @所有人 — these correspond to mentionAll, not individual uid
-            if (mentionName.toLowerCase() === 'all' || mentionName === '所有人') {
+            // Skip @all / @所有人 / @所有AI — these correspond to broadcast
+            // flags (mentionAll / humans / ais), not individual uid mentions.
+            // @所有AI was added for GH#100: client-side bot UID expansion puts
+            // routing UIDs into mention.uids, but the broadcast text token must
+            // not bind to any of them.
+            if (mentionName.toLowerCase() === 'all' || mentionName === '所有人' || mentionName === '所有AI') {
                 continue
             }
 

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -435,7 +435,16 @@ export class MessageWrap {
         }
 
         if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-            return this.parseMentionLegacy(text, mention.uids)
+            // GH#100: when mention.ais is set, mention.uids may contain
+            // server-expanded bot routing UIDs that have no corresponding
+            // @text token in the message. parseMentionLegacy binds UIDs
+            // to @-tokens by position, so extra routing UIDs would
+            // mis-bind to unrelated @-words. Skip legacy parsing when
+            // ais is present — the @所有AI pill is rendered separately
+            // by mentionRender.ts via the ais flag.
+            if (!(mention as any).ais) {
+                return this.parseMentionLegacy(text, mention.uids)
+            }
         }
 
         // mention.all：把文本中的 @所有人/@all 替换成 uid="all" 的 mention Part

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -435,16 +435,7 @@ export class MessageWrap {
         }
 
         if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-            // GH#100: when mention.ais is set, mention.uids may contain
-            // server-expanded bot routing UIDs that have no corresponding
-            // @text token in the message. parseMentionLegacy binds UIDs
-            // to @-tokens by position, so extra routing UIDs would
-            // mis-bind to unrelated @-words. Skip legacy parsing when
-            // ais is present — the @所有AI pill is rendered separately
-            // by mentionRender.ts via the ais flag.
-            if (!(mention as any).ais) {
-                return this.parseMentionLegacy(text, mention.uids)
-            }
+            return this.parseMentionLegacy(text, mention.uids)
         }
 
         // mention.all：把文本中的 @所有人/@all 替换成 uid="all" 的 mention Part


### PR DESCRIPTION
## What

When a user sends `@所有AI` from the web client, the message goes via WuKongIM SDK direct — it never hits the server REST API, so server-side UID expansion (octo-server PR#145) does not apply.

Legacy adapter bots only check `mention.uids` (not `mention.ais`), so they miss the broadcast.

## Fix

In `formatMentionTextV2`, when `ais=true`, collect all bot members from the group roster (`membersRef`, `orgData.robot===1`) and append their UIDs to `mention.uids`. Deduped against any explicitly @-mentioned bot UIDs.

## UI impact

Zero. `mention.uids` is backend routing metadata. Text still shows `@所有AI xxx`.

## Test matrix

- `@所有AI` → payload `mention.uids` includes all bot UIDs + `mention.ais=1`
- `@所有AI` + explicit `@alice` → uids includes alice + all bots (no dupes)
- `@所有人` → uids unchanged (no bot expansion)
- Group with no bots → uids empty/undefined

Closes #100

Related: octo-server#144/PR#145, octo-adapters#71