### PR TITLE
fix(login): breathe out the non-SSO panel layout

### DIFF
--- a/packages/dmworklogin/src/login.css
+++ b/packages/dmworklogin/src/login.css
@@ -389,7 +389,8 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    margin-top: 20px;
+    margin-top: 24px;
+    margin-bottom: 8px;
     gap: 0;
     width: 100%;
 }

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -512,6 +512,12 @@ class Login extends Component<any, LoginState> {
                                             忘记密码
                                         </div>
                                     </div>
+                                    {/* 与 SSO 分支一致: 下载入口前一条带文案的分隔线,
+                                        把"主登录区"和"也提供移动版"次级 CTA 分开,
+                                        避免按钮区 → 链接行 → 下载按钮 全部贴在一起. */}
+                                    <div className="wk-login-content-download-divider">
+                                        <span>也可下载移动版</span>
+                                    </div>
                                     <div className="wk-login-content-download">
                                         <AndroidDownloadButton />
                                         <IOSDownloadButton />


### PR DESCRIPTION
## Summary

The non-SSO (password) login flow looked too cramped after the SSO redesign landed: the action-link row (`扫码登录 | 没有账号？注册 | 忘记密码`) was hugging the primary login button and the Android / iOS download pills stacked directly underneath with no separator. This PR brings the legacy flow back in line with the SSO branch.

- Mirror the SSO branch by inserting the `也可下载移动版` divider before the download buttons so the secondary CTA gets its own visual zone.
- Bump `.wk-login-content-form-others` `margin-top` 20 → 24 and add a new 8px `margin-bottom` so the link row breathes between the login button and the divider.

No functional changes; affects only the right panel rendered when `VITE_ENABLE_ENTERPRISE_SSO` is unset / false.

## Test plan

- [ ] Verify with `VITE_ENABLE_ENTERPRISE_SSO` unset: link row + download section has clear spacing, divider reads `也可下载移动版`, download buttons unchanged.
- [ ] Verify with `VITE_ENABLE_ENTERPRISE_SSO=true`: SSO panel unchanged (regression check).
- [ ] Verify on `<= 768px` viewport: link row wraps gracefully, footer / breadcrumb still in-flow.