### PR TITLE
fix(space): stop cross-Space groups & threads from leaking into recent tab

### DIFF
--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -187,10 +187,14 @@ export class ChatVM extends ProviderListener {
                         if (sid) {
                             WKApp.shared.channelSpaceMap.set(key, sid)
                         } else if (WKApp.shared.currentSpaceId && !hasSpacePrefix(conversation.channel.channelID)) {
-                            // Fix: fail-open — 新群假定属于当前 Space，先展示
-                            // 建群 API 已带 space_id，channelInfo 异步返回后会补写正确值
-                            // 下次 Space 切换时 requestConversationList() 会用真实缓存重新过滤
-                            WKApp.shared.channelSpaceMap.set(key, WKApp.shared.currentSpaceId)
+                            // 缓存未命中 + channelInfo 同步取不到 space_id：暂存到 pending,
+                            // 等 channelInfoListener 拿到真实 space_id 后再决定是否加入
+                            // (与 update 分支一致)。旧 fail-open 兜底会把他 Space 群假定为
+                            // 当前 Space 写入缓存,后续 channelInfo 若不带 space_id (跨 Space
+                            // 场景常见) 纠正路径不触发,conv 持久卡在列表。
+                            this._pendingSpaceConversations.set(key, conversation)
+                            WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
+                            return
                         }
                     }
                 }

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -289,7 +289,13 @@ export class ChatVM extends ProviderListener {
                     this._pendingSpaceConversations.delete(key)
                 }
                 const conv = pendingConv || WKSDK.shared().conversationManager.findConversation(channelInfo.channel)
-                if (conv && !shouldSkipChannelForSpace(channelInfo.channel)) {
+                // 排空 pending 时必须有 space_id 证据(channelInfo 直接给 OR 已写入
+                // channelSpaceMap)才插入。否则 shouldSkipChannelForSpace 在 group 分支会
+                // 走 SpaceService.tsx:142 fall-through `return false`,跨 Space 群在
+                // channelInfo 不带 space_id 时仍会被插入,等于 pending 队列形同虚设
+                // (PR #105 review by lml2468)。
+                const hasSpaceEvidence = !!sid || WKApp.shared.channelSpaceMap.has(key)
+                if (conv && hasSpaceEvidence && !shouldSkipChannelForSpace(channelInfo.channel)) {
                     const existingInListener = this.findConversation(channelInfo.channel)
                     if (!existingInListener) {
                         this.conversations = [new ConversationWrap(conv), ...this.conversations]

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -1,6 +1,8 @@
 import WKApp from "../App"
 import { ChannelTypePerson, ChannelTypeGroup, Channel, Conversation, Message, WKSDK } from "wukongimjssdk"
 import { hasSpacePrefix } from "./SpacePrefix"
+import { parseThreadChannelId } from "./Thread"
+import { ChannelTypeCommunityTopic } from "./Const"
 
 export type JoinSpaceStatus = "NEED_APPROVAL" | "PENDING"
 
@@ -95,6 +97,7 @@ function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
  * - Person channel（私聊）→ 永远不过滤
  * - 有 Space 前缀（s{spaceId}_）的 channel → 前缀匹配
  * - 群聊（无前缀）→ 查 channelSpaceMap 缓存 → channelInfo.orgData.space_id
+ * - 子区（CommunityTopic）→ 按父群 Space 归属判定；父群 Space 未知时 fail-close
  * - 都未命中 → fail-open（放行，等 channelInfo 回调后再检查）
  *
  * 外部群兼容：当群归属 Space 与当前 Space 不一致时，额外检查自己是否
@@ -137,6 +140,37 @@ export function shouldSkipChannelForSpace(channel: Channel): boolean {
             return true
         }
         // channelInfo 也没有 → fail-open，等 channelInfo 回调后 channelListener 会二次检查
+    }
+
+    // 子区（CommunityTopic）→ Space 归属跟随父群
+    // channelID 形如 {groupNo}____{shortId}，解析出父群 groupNo 后复用群的判定路径
+    // 父群 Space 未知时 fail-close（return true）：跨 Space WS 推子区会一直卡在列表里
+    // （vm.ts 的 ChannelTypeGroup pending 路径不覆盖子区，channelListener 也不修正），
+    // 必须在过滤层兜底。代价是自己 Space 父群刚 cold-start 还没缓存 space_id 时，
+    // 第一次到达的子区会被拒一次；父群随后的 add/update 会写缓存,下一条消息恢复正常。
+    if (channel.channelType === ChannelTypeCommunityTopic) {
+        const parsed = parseThreadChannelId(cid)
+        if (!parsed) return true
+        const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
+        const parent = new Channel(parsed.groupNo, ChannelTypeGroup)
+
+        const cachedSpaceId = WKApp.shared.channelSpaceMap.get(parentKey)
+        if (cachedSpaceId) {
+            if (cachedSpaceId === currentSpaceId) return false
+            if (getMyMembershipSourceSpaceId(parent) === currentSpaceId) return false
+            return true
+        }
+
+        const parentInfo = WKSDK.shared().channelManager.getChannelInfo(parent)
+        const infoSpaceId = parentInfo?.orgData?.space_id
+        if (infoSpaceId) {
+            WKApp.shared.channelSpaceMap.set(parentKey, infoSpaceId)
+            if (infoSpaceId === currentSpaceId) return false
+            if (getMyMembershipSourceSpaceId(parent) === currentSpaceId) return false
+            return true
+        }
+
+        return true
     }
 
     return false

--- a/packages/dmworkbase/src/Service/__tests__/SpaceService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SpaceService.test.ts
@@ -149,6 +149,8 @@ vi.mock("wukongimjssdk", async () => {
 
 import { shouldSkipChannelForSpace } from "../SpaceService"
 import { Channel, ChannelTypeGroup } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../Const"
+import { ThreadChannelIdSeparator } from "../Thread"
 
 const SPACE_A = "a".repeat(32)
 const SPACE_B = "b".repeat(32)
@@ -223,6 +225,87 @@ describe("shouldSkipChannelForSpace — external group", () => {
             { uid: "u_external", orgData: { is_external: 1, source_space_name: "Space B" } },
         ])
         expect(shouldSkipChannelForSpace(ch)).toBe(true)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// shouldSkipChannelForSpace — CommunityTopic (子区) branch (PR #105)
+//
+// Threads inherit their parent group's Space membership. The channelID format
+// is `{groupNo}____{shortId}` (see Thread.ts:40). The new branch parses the
+// parent groupNo, reuses the group's channelSpaceMap / channelInfo lookup,
+// and fail-closes when the parent's Space is unknown — preventing cross-Space
+// thread leaks in the recent tab.
+// ---------------------------------------------------------------------------
+
+function threadCid(groupNo: string, shortId: string) {
+    return `${groupNo}${ThreadChannelIdSeparator}${shortId}`
+}
+
+describe("shouldSkipChannelForSpace — CommunityTopic (thread)", () => {
+    beforeEach(() => {
+        mockState.channelSpaceMap.clear()
+        mockState.subscribesByChannel.clear()
+        mockState.channelInfoByChannel.clear()
+        mockState.currentSpaceId = ""
+        mockState.loginUid = "u_self"
+    })
+
+    it("does NOT skip when parent group is in current Space (cache hit)", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelSpaceMap.set(`g1_${ChannelTypeGroup}`, SPACE_A)
+        const thread = new Channel(threadCid("g1", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(false)
+    })
+
+    it("skips when parent group belongs to another Space (cache hit)", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelSpaceMap.set(`g1_${ChannelTypeGroup}`, SPACE_B)
+        const thread = new Channel(threadCid("g1", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(true)
+    })
+
+    it("falls back to parent channelInfo.orgData.space_id when cache misses", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelInfoByChannel.set("g1", { orgData: { space_id: SPACE_B } })
+        const thread = new Channel(threadCid("g1", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(true)
+    })
+
+    it("writes parent cache when resolving via channelInfo", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelInfoByChannel.set("g1", { orgData: { space_id: SPACE_A } })
+        const thread = new Channel(threadCid("g1", "t1"), ChannelTypeCommunityTopic)
+        shouldSkipChannelForSpace(thread)
+        expect(mockState.channelSpaceMap.get(`g1_${ChannelTypeGroup}`)).toBe(SPACE_A)
+    })
+
+    it("fail-closes (skip) when parent Space is completely unknown — no cache, no channelInfo", () => {
+        mockState.currentSpaceId = SPACE_A
+        const thread = new Channel(threadCid("g_unknown", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(true)
+    })
+
+    it("does NOT skip when I'm an external member of the parent group sourced from currentSpaceId", () => {
+        mockState.currentSpaceId = SPACE_B
+        mockState.channelSpaceMap.set(`g1_${ChannelTypeGroup}`, SPACE_A)
+        mockState.subscribesByChannel.set("g1", [
+            { uid: "u_self", orgData: { is_external: 1, source_space_id: SPACE_B } },
+        ])
+        const thread = new Channel(threadCid("g1", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(false)
+    })
+
+    it("fail-closes on malformed thread channelID (cannot parse parent)", () => {
+        mockState.currentSpaceId = SPACE_A
+        const malformed = new Channel("not_a_thread_id", ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(malformed)).toBe(true)
+    })
+
+    it("does NOT filter when no current Space (Space mode off)", () => {
+        mockState.currentSpaceId = ""
+        const thread = new Channel(threadCid("g_unknown", "t1"), ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(thread)).toBe(false)
     })
 })
 


### PR DESCRIPTION
## Summary

When a user is viewing Space A, WS-pushed conversations from Space B were showing up at the top of A's 最近 tab and persisting there (clickable, never cleared).

Two fail-open paths:

- **Threads (CommunityTopic)** had no Space filter at all. `shouldSkipChannelForSpace` falls through to `return false` for `channelType=5`, and `vm.ts`'s conversationListener / channelListener only branch on `ChannelTypeGroup`. So any thread from any Space WS-pushed straight into the list and never got corrected.
- **Groups** whose `channelSpaceMap` was empty AND whose `channelInfo` had no `space_id` got the cache **poisoned** with `currentSpaceId` (vm.ts:189-194 fail-open), then never corrected because `channelListener` requires `orgData.space_id` to fire `removeConversation`. In cross-Space scenarios the backend often doesn't ship `space_id` for foreign-Space groups, so the conv stuck forever.

### Changes

- **`SpaceService.tsx`** — add a `ChannelTypeCommunityTopic` branch to `shouldSkipChannelForSpace`. Resolves the parent group via `parseThreadChannelId`, reuses the group cache/`channelInfo` lookup (incl. external-member exception via `getMyMembershipSourceSpaceId`), and **fail-closes** when the parent's Space is unknown — matching the user-visible requirement that cross-Space conversations shouldn't appear at all.
- **`vm.ts:189-194`** — replace the fail-open cache writeback with the same `_pendingSpaceConversations` queue the `update` branch already uses. The conv waits in pending; once `channelInfo` arrives, `channelListener` (already in place at vm.ts:275-296) drains it through `shouldSkipChannelForSpace` for a clean Space decision.

### Trade-off

A group/thread in the user's *own* Space whose `channelInfo` hasn't arrived yet will be delayed by one RTT instead of shown immediately. For threads it's only the cold-start case (the parent group's add/update writes the cache; subsequent threads under that parent are instant). Strict isolation wins over the brief delay.

### Not in scope

Private DM filter (`shouldSkipPersonConversationForSpace`) has a similar fail-open when `lastMessage.content.contentObj.space_id` is missing on the WS push. Fixing it cleanly requires the server to always stamp `space_id` on private messages — needs backend coordination, tracked separately.

## Test plan

- [ ] Login → enter Space A → open 最近 tab, record top entries
- [ ] Have another account send a message in a Space B **group**: A's list should NOT update
- [ ] Have another account send a message in a Space B **thread**: A's list should NOT update
- [ ] Switch to Space B: the group/thread appears at top, opens normally
- [ ] Switch back to A: list remains clean
- [ ] Regression: send in own-Space group → instant top
- [ ] Regression: send in own-Space thread (parent already cached) → instant top
- [ ] Regression: create a new group in current Space → appears
- [ ] Regression: private messages behave as before
- [ ] A → B → A switching leaves no residue / duplicates