### PR TITLE
fix(space): prefill channelSpaceMap from conversation sync (#107)

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -556,6 +556,10 @@ export default class WKApp extends ProviderListener {
   deviceId: string = ""; // 设备ID
   currentSpaceId: string = ""; // 当前选中的 Space ID
   channelSpaceMap: Map<string, string> = new Map(); // channelID_channelType → spaceID 缓存
+  // channelID_channelType → my source_space_id 缓存（仅在我作为外部成员加入该群时有值）
+  // 由 conversation sync 响应（octo-server PR#154 起携带 my_source_space_id）预填，
+  // 用于在 subscriber.orgData 未加载完成时避免 shouldSkipChannelForSpace 误过滤外部群。
+  channelMySourceSpaceMap: Map<string, string> = new Map();
   spaceChecked: boolean = false; // Space 检查是否完成
   deviceName: string = ""; // 设备名称
   deviceModel: string = ""; // 设备型号
@@ -751,6 +755,8 @@ export default class WKApp extends ProviderListener {
     WKApp.loginInfo.logout();
     localStorage.removeItem("currentSpaceId");
     this.currentSpaceId = "";
+    this.channelSpaceMap.clear();
+    this.channelMySourceSpaceMap.clear();
     this.spaceChecked = false;
     window.location.reload();
   }

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -184,13 +184,18 @@ export class ChatVM extends ProviderListener {
                         const info = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
                         const sid = info?.orgData?.space_id
                             || conversation.channelInfo?.orgData?.space_id
+                            || (conversation as any).extra?.spaceId
                         if (sid) {
                             WKApp.shared.channelSpaceMap.set(key, sid)
                         } else if (WKApp.shared.currentSpaceId && !hasSpacePrefix(conversation.channel.channelID)) {
-                            // Fix: fail-open — 新群假定属于当前 Space，先展示
-                            // 建群 API 已带 space_id，channelInfo 异步返回后会补写正确值
-                            // 下次 Space 切换时 requestConversationList() 会用真实缓存重新过滤
-                            WKApp.shared.channelSpaceMap.set(key, WKApp.shared.currentSpaceId)
+                            // Fix #107: 改为 fail-closed —— 不再假定新群属于当前 Space。
+                            // sync 响应已携带 space_id 时上面就命中了；缓存仍未命中
+                            // 说明这是 WS 推送的全新群，channelInfo 尚未到达。
+                            // 与 update handler 一致：暂存到待定队列，等 channelInfoListener
+                            // 回调拿到权威 space_id 后再二次检查并展示。
+                            this._pendingSpaceConversations.set(key, conversation)
+                            WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
+                            return
                         }
                     }
                 }
@@ -406,6 +411,31 @@ export class ChatVM extends ProviderListener {
         return sortAfter
     }
 
+    // 从 conversation sync 响应预填 channelSpaceMap / channelMySourceSpaceMap。
+    // octo-server PR#154+ 起 sync 会话条目携带 resolved space_id（群表权威值）和
+    // my_source_space_id（外部群成员的 source Space）。在过滤前预填两张缓存表，
+    // 可消除实时 WebSocket 消息到达时的 fail-open 竞态窗口。
+    // 字段缺失（老后端）时跳过，老路不受影响。
+    private prefillSpaceMapsFromSync(conversations: Conversation[]) {
+        for (const conv of conversations) {
+            if (conv.channel?.channelType !== ChannelTypeGroup) continue
+            const cid = conv.channel.channelID
+            if (!cid) continue
+            const key = `${cid}_${conv.channel.channelType}`
+            const extra: any = conv.extra
+            const sid = extra?.spaceId
+                || (conv as any).channelInfo?.orgData?.space_id
+                || WKSDK.shared().channelManager.getChannelInfo(conv.channel)?.orgData?.space_id
+            if (sid && !WKApp.shared.channelSpaceMap.has(key)) {
+                WKApp.shared.channelSpaceMap.set(key, sid)
+            }
+            const mySrc = extra?.mySourceSpaceId
+            if (mySrc) {
+                WKApp.shared.channelMySourceSpaceMap.set(key, mySrc)
+            }
+        }
+    }
+
     async requestConversationList() {
         this.loading = true
         this.notifyListener()
@@ -427,6 +457,13 @@ export class ChatVM extends ProviderListener {
         // _pendingSpaceConversations 是 ChatVM 自己的延迟队列,跟 SDK cache 无关,
         // 切 Space 时清掉避免旧 Space 排队中的 incoming 落入新 Space 视图。
         this._pendingSpaceConversations.clear()
+
+        // 在做 Space 过滤前，先把 sync 响应携带的 space_id / my_source_space_id
+        // 写入缓存。这样 shouldSkipChannelForSpace 命中率最大化，下游实时消息
+        // 也能立即用到，避免 fail-open 误展示其他 Space 的群。
+        if (conversations && conversations.length > 0) {
+            this.prefillSpaceMapsFromSync(conversations)
+        }
 
         const conversationWraps = new Array<ConversationWrap>()
         const filteredForSdk = new Array<Conversation>()
@@ -460,6 +497,11 @@ export class ChatVM extends ProviderListener {
     async reloadRequestConversationList() {
         const conversationWraps = new Array<ConversationWrap>()
         const conversations = await WKSDK.shared().conversationManager.sync({})
+        // 先按 sync 响应预填 channelSpaceMap / channelMySourceSpaceMap
+        // 再做 Space 过滤，避免老缓存缺失时落到 fail-closed 默认值。
+        if (conversations && conversations.length > 0) {
+            this.prefillSpaceMapsFromSync(conversations)
+        }
         if (conversations && conversations.length > 0) {
             for (const conversation of conversations) {
                 // Space 过滤：复用共享函数（含 channelSpaceMap 缓存）

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -9,7 +9,8 @@ import { ProviderListener } from "../../Service/Provider";
 import { animateScroll, scroller } from 'react-scroll';
 import { ProhibitwordsService } from "../../Service/ProhibitwordsService";
 import { shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace, hasSpacePrefix } from "../../Service/SpaceService";
-import { EndpointID } from "../../Service/Const";
+import { ChannelTypeCommunityTopic, EndpointID } from "../../Service/Const";
+import { parseThreadChannelId } from "../../Service/Thread";
 import { ShowConversationOptions } from "../../EndpointCommon";
 import { Space, SpaceService } from "../../Service/SpaceService";
 import { isSafeUrl } from "../../Utils/security";
@@ -198,6 +199,22 @@ export class ChatVM extends ProviderListener {
                             return
                         }
                     }
+                } else if (conversation.channel.channelType === ChannelTypeCommunityTopic) {
+                    // 子区跟父群走：父群缓存未命中时拉父群 channelInfo。
+                    // 这里 fail-open（不 return / 不 pending）—— shouldSkipChannelForSpace
+                    // 对子区分支父群缓存未命中时返回 false，子区会照常进入列表，
+                    // 避免回归 fail-closed 永久隐藏。父群 channelInfo 到达后，
+                    // channelListener 会在 removeParentAndThreads 路径里把不属于
+                    // 当前 Space 的父群+其所有子区一并移除。
+                    const parsed = parseThreadChannelId(conversation.channel.channelID)
+                    if (parsed) {
+                        const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
+                        if (!WKApp.shared.channelSpaceMap.has(parentKey) && WKApp.shared.currentSpaceId) {
+                            WKSDK.shared().channelManager.fetchChannelInfo(
+                                new Channel(parsed.groupNo, ChannelTypeGroup),
+                            )
+                        }
+                    }
                 }
                 // Space 过滤：只添加属于当前 Space 的会话
                 if (shouldSkipChannelForSpace(conversation.channel)) {
@@ -223,6 +240,20 @@ export class ChatVM extends ProviderListener {
                         this._pendingSpaceConversations.set(key, conversation)
                         WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
                         return // 等待 channelInfoListener 回调处理
+                    }
+                } else if (conversation.channel.channelType === ChannelTypeCommunityTopic) {
+                    // 子区更新：父群缓存未命中时拉父群 channelInfo，不要把子区
+                    // 丢进父群 pending（pending 用父群 key 是为新群补回，对子区
+                    // update 没用），fail-open 让 shouldSkip 兜底（父群无缓存
+                    // 时返回 false，子区照常更新）。
+                    const parsed = parseThreadChannelId(conversation.channel.channelID)
+                    if (parsed) {
+                        const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
+                        if (!WKApp.shared.channelSpaceMap.has(parentKey) && WKApp.shared.currentSpaceId) {
+                            WKSDK.shared().channelManager.fetchChannelInfo(
+                                new Channel(parsed.groupNo, ChannelTypeGroup),
+                            )
+                        }
                     }
                 }
                 // Space 过滤：忽略不属于当前 Space 的会话更新
@@ -266,9 +297,10 @@ export class ChatVM extends ProviderListener {
             if (channelInfo.channel?.channelType === ChannelTypeGroup && channelInfo.orgData?.space_id) {
                 const key = `${channelInfo.channel.channelID}_${channelInfo.channel.channelType}`
                 WKApp.shared.channelSpaceMap.set(key, channelInfo.orgData.space_id)
-                // 如果该群不属于当前 Space，移除会话
+                // 如果该群不属于当前 Space，移除会话（包括所有挂在该父群下的子区）
                 if (shouldSkipChannelForSpace(channelInfo.channel)) {
                     this.removeConversation(channelInfo.channel)
+                    this.removeThreadsOfParent(channelInfo.channel.channelID)
                     return
                 }
             }
@@ -361,6 +393,27 @@ export class ChatVM extends ProviderListener {
         }
     }
 
+    /**
+     * 移除挂在指定父群下的所有 CommunityTopic（子区）会话。
+     * 当父群 channelInfo 到达且发现父群不属于当前 Space 时调用，
+     * 否则子区会以 fail-open 的姿态滞留在列表里。
+     */
+    removeThreadsOfParent(parentGroupNo: string) {
+        if (!this.conversations || this.conversations.length === 0) return
+        let mutated = false
+        this.conversations = this.conversations.filter((wrap) => {
+            const ch = wrap.channel
+            if (ch?.channelType !== ChannelTypeCommunityTopic) return true
+            const parsed = parseThreadChannelId(ch.channelID)
+            if (parsed?.groupNo === parentGroupNo) {
+                mutated = true
+                return false
+            }
+            return true
+        })
+        if (mutated) this.notifyListener()
+    }
+
     async clearMessages(channel: Channel) {
 
         const conversationWrap = this.findConversation(channel)
@@ -416,22 +469,48 @@ export class ChatVM extends ProviderListener {
     // my_source_space_id（外部群成员的 source Space）。在过滤前预填两张缓存表，
     // 可消除实时 WebSocket 消息到达时的 fail-open 竞态窗口。
     // 字段缺失（老后端）时跳过，老路不受影响。
+    //
+    // CommunityTopic（子区）也会出现在 sync 列表里。子区跟父群走，所以这里把子区
+    // 携带的 space_id 写入“父群 key”：`${groupNo}_${ChannelTypeGroup}`，前提是
+    // 父群 key 尚未被写入（不覆盖父群自身条目带来的权威值）。
     private prefillSpaceMapsFromSync(conversations: Conversation[]) {
         for (const conv of conversations) {
-            if (conv.channel?.channelType !== ChannelTypeGroup) continue
-            const cid = conv.channel.channelID
-            if (!cid) continue
-            const key = `${cid}_${conv.channel.channelType}`
-            const extra: any = conv.extra
-            const sid = extra?.spaceId
-                || (conv as any).channelInfo?.orgData?.space_id
-                || WKSDK.shared().channelManager.getChannelInfo(conv.channel)?.orgData?.space_id
-            if (sid && !WKApp.shared.channelSpaceMap.has(key)) {
-                WKApp.shared.channelSpaceMap.set(key, sid)
+            const ch = conv.channel
+            if (!ch?.channelID) continue
+
+            if (ch.channelType === ChannelTypeGroup) {
+                const cid = ch.channelID
+                const key = `${cid}_${ch.channelType}`
+                const extra: any = conv.extra
+                const sid = extra?.spaceId
+                    || (conv as any).channelInfo?.orgData?.space_id
+                    || WKSDK.shared().channelManager.getChannelInfo(ch)?.orgData?.space_id
+                if (sid && !WKApp.shared.channelSpaceMap.has(key)) {
+                    WKApp.shared.channelSpaceMap.set(key, sid)
+                }
+                const mySrc = extra?.mySourceSpaceId
+                if (mySrc) {
+                    WKApp.shared.channelMySourceSpaceMap.set(key, mySrc)
+                }
+                continue
             }
-            const mySrc = extra?.mySourceSpaceId
-            if (mySrc) {
-                WKApp.shared.channelMySourceSpaceMap.set(key, mySrc)
+
+            if (ch.channelType === ChannelTypeCommunityTopic) {
+                const parsed = parseThreadChannelId(ch.channelID)
+                if (!parsed) continue
+                const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
+                const extra: any = conv.extra
+                const sid = extra?.spaceId
+                    || (conv as any).channelInfo?.orgData?.space_id
+                // 子区条目只能补写父群 key（不覆盖：父群自有 sync 条目优先）
+                if (sid && !WKApp.shared.channelSpaceMap.has(parentKey)) {
+                    WKApp.shared.channelSpaceMap.set(parentKey, sid)
+                }
+                const mySrc = extra?.mySourceSpaceId
+                if (mySrc && !WKApp.shared.channelMySourceSpaceMap.has(parentKey)) {
+                    WKApp.shared.channelMySourceSpaceMap.set(parentKey, mySrc)
+                }
+                continue
             }
         }
     }

--- a/packages/dmworkbase/src/Service/Convert.ts
+++ b/packages/dmworkbase/src/Service/Convert.ts
@@ -210,6 +210,16 @@ export class Convert {
         conversation.extra.top = conversationMap["stick"]
         conversation.extra.categoryId = conversationMap["category_id"] ?? null
         conversation.extra.categorySort = conversationMap["category_sort"] ?? 0
+        // octo-server PR#154+：透传群表权威 space_id 与外部成员自己的 source space。
+        // 用于 ChatVM 在 sync 处理时预填 WKApp.shared.channelSpaceMap /
+        // channelMySourceSpaceMap，消除实时 WS 消息到达时的 fail-open 竞态窗口。
+        // 老后端没有该字段时为空，走原有 channelInfo.orgData / subscriber 路径。
+        if (typeof conversationMap["space_id"] === "string" && conversationMap["space_id"]) {
+            conversation.extra.spaceId = conversationMap["space_id"]
+        }
+        if (typeof conversationMap["my_source_space_id"] === "string" && conversationMap["my_source_space_id"]) {
+            conversation.extra.mySourceSpaceId = conversationMap["my_source_space_id"]
+        }
         // 后端返回的 per-Space 字段
         if (conversationMap["space_unread"] !== undefined && conversationMap["space_unread"] !== null) {
             conversation.extra.spaceUnread = conversationMap["space_unread"]

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -73,11 +73,19 @@ export function getSpaceFilteredLastMessage(conversation: Conversation): Message
  *     在"群不在当前 Space"分支虽然比较等价，但字段语义交叉容易误用；
  *     与后端 DB 列名对齐使用 source_space_id 更直观。
  *
- * 依赖 channelManager 的订阅者缓存（getSubscribes）：
- *   - 未缓存或未找到自己 → 返回 undefined（调用方应退化到原有判定）
- *   - source_space_id 为空串（内部成员或历史数据）→ 返回 undefined
+ * 数据源优先级：
+ *   1) WKApp.shared.channelMySourceSpaceMap —— octo-server PR#154+ 由
+ *      conversation sync 响应的 my_source_space_id 字段预填，权威且即时。
+ *   2) channelManager 的订阅者缓存（getSubscribes）—— 老后端或缓存预热前兜底。
+ *      未缓存或未找到自己 → 返回 undefined（调用方应退化到原有判定）。
  */
 function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
+    if (!channel?.channelID) return undefined
+    // 优先读 channelMySourceSpaceMap（由 conversation sync 预填，无须等 subscribers 拉取）
+    const key = `${channel.channelID}_${channel.channelType}`
+    const cached = WKApp.shared.channelMySourceSpaceMap.get(key)
+    if (cached) return cached
+
     const myUid = WKApp.loginInfo?.uid
     if (!myUid) return undefined
     const subs = WKSDK.shared().channelManager.getSubscribes(channel)
@@ -85,7 +93,11 @@ function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
     const mine = subs.find((s: any) => s?.uid === myUid) as any
     if (!mine) return undefined
     const sourceId = mine.orgData?.source_space_id
-    if (typeof sourceId === "string" && sourceId.length > 0) return sourceId
+    if (typeof sourceId === "string" && sourceId.length > 0) {
+        // 回填 map，避免每次都走 subscribers 数组扫描
+        WKApp.shared.channelMySourceSpaceMap.set(key, sourceId)
+        return sourceId
+    }
     return undefined
 }
 
@@ -95,7 +107,15 @@ function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
  * - Person channel（私聊）→ 永远不过滤
  * - 有 Space 前缀（s{spaceId}_）的 channel → 前缀匹配
  * - 群聊（无前缀）→ 查 channelSpaceMap 缓存 → channelInfo.orgData.space_id
- * - 都未命中 → fail-open（放行，等 channelInfo 回调后再检查）
+ * - 都未命中 → fail-closed（先跳过；channelInfo 回调拿到权威 space_id 后
+ *              channelListener 会二次检查并补回）。
+ *
+ * GH octo-web#107: 由 fail-open 改为 fail-closed。fail-open 会让实时 WS
+ * 推送的、归属其他 Space 的群短暂出现在当前 Space 视图（即使 channelInfo 后续
+ * 把它移除）。新策略下，octo-server PR#154+ 的 conversation sync 已经在
+ * channelSpaceMap / channelMySourceSpaceMap 里预填了权威值，命中率覆盖
+ * 绝大多数场景；只有真正全新的 WS 推送会暂时被过滤，等 channelInfo 到达
+ * 后通过 channelListener 的待定队列恢复显示。
  *
  * 外部群兼容：当群归属 Space 与当前 Space 不一致时，额外检查自己是否
  * 以"当前 Space"身份加入了该群（subscriber.orgData.source_space_id === currentSpaceId）。
@@ -136,10 +156,13 @@ export function shouldSkipChannelForSpace(channel: Channel): boolean {
             if (getMyMembershipSourceSpaceId(channel) === currentSpaceId) return false
             return true
         }
-        // channelInfo 也没有 → fail-open，等 channelInfo 回调后 channelListener 会二次检查
+        // channelInfo 也没有 → fail-closed：暂时跳过。channelListener 拿到
+        // 权威 space_id 后会通过 _pendingSpaceConversations 把会话补回展示。
+        return true
     }
 
-    return false
+    // 非 Person / 非 Group 频道 → fail-closed，避免泄漏。
+    return true
 }
 
 /**

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -1,6 +1,8 @@
 import WKApp from "../App"
 import { ChannelTypePerson, ChannelTypeGroup, Channel, Conversation, Message, WKSDK } from "wukongimjssdk"
 import { hasSpacePrefix } from "./SpacePrefix"
+import { ChannelTypeCommunityTopic } from "./Const"
+import { parseThreadChannelId } from "./Thread"
 
 export type JoinSpaceStatus = "NEED_APPROVAL" | "PENDING"
 
@@ -109,13 +111,16 @@ function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
  * - 群聊（无前缀）→ 查 channelSpaceMap 缓存 → channelInfo.orgData.space_id
  * - 都未命中 → fail-closed（先跳过；channelInfo 回调拿到权威 space_id 后
  *              channelListener 会二次检查并补回）。
+ * - CommunityTopic（子区）→ 跟父群走（用父群 channelSpaceMap 缓存）。
+ *              父群缓存未命中 → fail-open（子区不能 fail-closed，否则永久隐藏）。
  *
- * GH octo-web#107: 由 fail-open 改为 fail-closed。fail-open 会让实时 WS
- * 推送的、归属其他 Space 的群短暂出现在当前 Space 视图（即使 channelInfo 后续
- * 把它移除）。新策略下，octo-server PR#154+ 的 conversation sync 已经在
- * channelSpaceMap / channelMySourceSpaceMap 里预填了权威值，命中率覆盖
- * 绝大多数场景；只有真正全新的 WS 推送会暂时被过滤，等 channelInfo 到达
- * 后通过 channelListener 的待定队列恢复显示。
+ * GH octo-web#107: 由 fail-open 改为 fail-closed（仅 Group 类型）。fail-open
+ * 会让实时 WS 推送的、归属其他 Space 的群短暂出现在当前 Space 视图（即使
+ * channelInfo 后续把它移除）。新策略下，octo-server PR#154+ 的 conversation
+ * sync 已经在 channelSpaceMap / channelMySourceSpaceMap 里预填了权威值，命中率
+ * 覆盖绝大多数场景；只有真正全新的 WS 推送会暂时被过滤，等 channelInfo 到达
+ * 后通过 channelListener 的待定队列恢复显示。Person / CommunityTopic 保持
+ * fail-open（私聊从来不过滤；子区不能在父群尚未确权时永久消失）。
  *
  * 外部群兼容：当群归属 Space 与当前 Space 不一致时，额外检查自己是否
  * 以"当前 Space"身份加入了该群（subscriber.orgData.source_space_id === currentSpaceId）。
@@ -161,7 +166,40 @@ export function shouldSkipChannelForSpace(channel: Channel): boolean {
         return true
     }
 
-    // 非 Person / 非 Group 频道 → fail-closed，避免泄漏。
+    // 子区（CommunityTopic）→ 跟父群走，fail-open。
+    // channelID 形如 `${groupNo}____${shortId}`，父群的 channelSpaceMap key
+    // 是 `${groupNo}_${ChannelTypeGroup}`。
+    // - 父群缓存命中 → 跟父群结论（父群在当前 Space → 子区也在）
+    // - 父群缓存未命中 → fail-open（return false），与改造前一致：子区
+    //   永远跟父群展示，避免 fail-closed 永久隐藏子区会话/通知。
+    if (channel.channelType === ChannelTypeCommunityTopic) {
+        const parsed = parseThreadChannelId(cid)
+        if (!parsed) return false
+        const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
+        const parentSpaceId = WKApp.shared.channelSpaceMap.get(parentKey)
+        if (parentSpaceId) {
+            if (parentSpaceId === currentSpaceId) return false
+            // 父群归属其他 Space：检查我是否以当前 Space 身份加入父群（外部成员）
+            const parentChannel = new Channel(parsed.groupNo, ChannelTypeGroup)
+            if (getMyMembershipSourceSpaceId(parentChannel) === currentSpaceId) return false
+            return true
+        }
+        // 父群 channelInfo 兜底
+        const parentChannel = new Channel(parsed.groupNo, ChannelTypeGroup)
+        const parentInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+        const parentInfoSpaceId = parentInfo?.orgData?.space_id
+        if (parentInfoSpaceId) {
+            WKApp.shared.channelSpaceMap.set(parentKey, parentInfoSpaceId)
+            if (parentInfoSpaceId === currentSpaceId) return false
+            if (getMyMembershipSourceSpaceId(parentChannel) === currentSpaceId) return false
+            return true
+        }
+        // 父群缓存 / channelInfo 都没有 → fail-open（子区跟父群，
+        // 父群 channelInfo 到达后由 channelListener 二次纠正）。
+        return false
+    }
+
+    // 非 Person / 非 Group / 非 CommunityTopic 频道 → fail-closed，避免泄漏。
     return true
 }
 

--- a/packages/dmworkbase/src/Service/__tests__/SpaceService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SpaceService.test.ts
@@ -102,6 +102,7 @@ describe("shouldSkipChannelForSpace prefix logic", () => {
 
 const mockState = vi.hoisted(() => ({
     channelSpaceMap: new Map<string, string>(),
+    channelMySourceSpaceMap: new Map<string, string>(),
     subscribesByChannel: new Map<string, any[]>(),
     channelInfoByChannel: new Map<string, any>(),
     currentSpaceId: "",
@@ -118,6 +119,7 @@ vi.mock("../../App", () => ({
                 mockState.currentSpaceId = v
             },
             channelSpaceMap: mockState.channelSpaceMap,
+            channelMySourceSpaceMap: mockState.channelMySourceSpaceMap,
         },
         loginInfo: {
             get uid() {
@@ -149,6 +151,7 @@ vi.mock("wukongimjssdk", async () => {
 
 import { shouldSkipChannelForSpace } from "../SpaceService"
 import { Channel, ChannelTypeGroup } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../Const"
 
 const SPACE_A = "a".repeat(32)
 const SPACE_B = "b".repeat(32)
@@ -156,6 +159,7 @@ const SPACE_B = "b".repeat(32)
 describe("shouldSkipChannelForSpace — external group", () => {
     beforeEach(() => {
         mockState.channelSpaceMap.clear()
+        mockState.channelMySourceSpaceMap.clear()
         mockState.subscribesByChannel.clear()
         mockState.channelInfoByChannel.clear()
         mockState.currentSpaceId = ""
@@ -226,3 +230,84 @@ describe("shouldSkipChannelForSpace — external group", () => {
     })
 })
 
+
+// ---------------------------------------------------------------------------
+// shouldSkipChannelForSpace — CommunityTopic (子区) follows parent group
+//
+// CommunityTopic threads have no own space_id; their visibility must mirror
+// the parent group. channelID is `${groupNo}____${shortId}`. The parent
+// group's channelSpaceMap entry under key `${groupNo}_${ChannelTypeGroup}`
+// is the source of truth.
+//
+// Failure mode being protected against (PR#108 round-2 regression): when
+// shouldSkipChannelForSpace was tightened to fail-closed for "non-Person /
+// non-Group" channels, threads were dropped permanently because they fell
+// through to the trailing `return true`.
+// ---------------------------------------------------------------------------
+describe("shouldSkipChannelForSpace — CommunityTopic (thread)", () => {
+    const GROUP_NO = "f0894a5e0c664126b8fbd81ac12583d6"
+    const SHORT_ID = "2054883151922073600"
+    const THREAD_CID = `${GROUP_NO}____${SHORT_ID}`
+
+    beforeEach(() => {
+        mockState.channelSpaceMap.clear()
+        mockState.channelMySourceSpaceMap.clear()
+        mockState.subscribesByChannel.clear()
+        mockState.channelInfoByChannel.clear()
+        mockState.currentSpaceId = ""
+        mockState.loginUid = "u_self"
+    })
+
+    it("does NOT skip a thread when parent group's channelSpaceMap matches currentSpaceId", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelSpaceMap.set(`${GROUP_NO}_${ChannelTypeGroup}`, SPACE_A)
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+
+    it("skips a thread when parent group's channelSpaceMap belongs to another Space", () => {
+        mockState.currentSpaceId = SPACE_B
+        mockState.channelSpaceMap.set(`${GROUP_NO}_${ChannelTypeGroup}`, SPACE_A)
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(true)
+    })
+
+    it("does NOT skip a thread when I am an external member of the parent sourced from currentSpaceId", () => {
+        mockState.currentSpaceId = SPACE_B
+        mockState.channelSpaceMap.set(`${GROUP_NO}_${ChannelTypeGroup}`, SPACE_A)
+        // External member view: my source_space_id matches the current Space
+        mockState.channelMySourceSpaceMap.set(`${GROUP_NO}_${ChannelTypeGroup}`, SPACE_B)
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+
+    it("FALLS BACK to channelInfo when parent's channelSpaceMap is missing", () => {
+        mockState.currentSpaceId = SPACE_A
+        mockState.channelInfoByChannel.set(GROUP_NO, { orgData: { space_id: SPACE_A } })
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+
+    it("FAIL-OPEN: does NOT skip when parent has no cache and no channelInfo (regression guard for PR#108)", () => {
+        // Critical: prevents the round-2 regression where threads were
+        // permanently hidden by the fail-closed trailing return.
+        mockState.currentSpaceId = SPACE_A
+        // No parent cache, no parent channelInfo
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+
+    it("returns false (not skipped) for malformed thread channelID without separator", () => {
+        // Defensive: parseThreadChannelId returns null → fail-open.
+        mockState.currentSpaceId = SPACE_A
+        const ch = new Channel("not_a_thread_id", ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+
+    it("does not filter when there is no currentSpaceId (Space mode off)", () => {
+        mockState.currentSpaceId = ""
+        mockState.channelSpaceMap.set(`${GROUP_NO}_${ChannelTypeGroup}`, SPACE_A)
+        const ch = new Channel(THREAD_CID, ChannelTypeCommunityTopic)
+        expect(shouldSkipChannelForSpace(ch)).toBe(false)
+    })
+})

--- a/packages/dmworkdatasource/src/module.ts
+++ b/packages/dmworkdatasource/src/module.ts
@@ -299,11 +299,18 @@ export default class DataSourceModule implements IModule {
                 resp.conversations.forEach((conversationMap: any) => {
                     let model = Convert.toConversation(conversationMap);
                     conversations.push(model);
-                    // 填充 channelSpaceMap 缓存
+                    // 填充 channelSpaceMap / channelMySourceSpaceMap 缓存
+                    // octo-server PR#154+ 在 conversation sync 响应里携带 resolved space_id
+                    // （群表权威值）和 my_source_space_id（外部成员的 source Space）。
+                    // 老后端字段为空时跳过，仍走 channelInfo.orgData / subscriber 兜底。
+                    const key = `${conversationMap["channel_id"]}_${conversationMap["channel_type"]}`
                     const sid = conversationMap["space_id"]
                     if (sid) {
-                        const key = `${conversationMap["channel_id"]}_${conversationMap["channel_type"]}`
                         WKApp.shared.channelSpaceMap.set(key, sid)
+                    }
+                    const mySrc = conversationMap["my_source_space_id"]
+                    if (mySrc) {
+                        WKApp.shared.channelMySourceSpaceMap.set(key, mySrc)
                     }
                 });
                 const users = resp.users


### PR DESCRIPTION
## Summary

octo-server PR#154 makes the conversation sync response carry `space_id` (resolved from the group row) and `my_source_space_id` (my source Space when joined as an external member). This PR consumes those fields on the web client so that Space filtering is deterministic before any realtime WS push lands — closing the fail-open race window described in #107.

## Changes

- **`Service/Convert.ts`** — pass `space_id` / `my_source_space_id` through to `conversation.extra.spaceId` / `mySourceSpaceId`. omitempty-friendly: missing fields are no-ops.
- **`dmworkdatasource/module.ts`** — `setSyncConversationsCallback` also prefills the new `channelMySourceSpaceMap` next to the existing `channelSpaceMap` write.
- **`App.tsx`** — add `WKApp.shared.channelMySourceSpaceMap: Map<string, string>` and clear both maps on `logout()`.
- **`Pages/Chat/vm.ts`**
  - new helper `prefillSpaceMapsFromSync()` runs in both `requestConversationList()` and `reloadRequestConversationList()` **before** any `shouldSkipChannelForSpace` check, so the cache covers all sync-known groups instantly.
  - `ConversationAction.add` no longer fail-opens by assuming the current Space. On cache miss it now mirrors the update path: enqueue into `_pendingSpaceConversations` and `fetchChannelInfo`, then let `channelInfoListener` re-show the conversation once the authoritative `space_id` arrives.
- **`Service/SpaceService.tsx`**
  - `shouldSkipChannelForSpace()` final fallback flips from `return false` (fail-open) to `return true` (fail-closed). The sync prefill + the pending-queue recovery in `channelInfoListener` keep visible behavior unchanged for normal traffic while removing the cross-Space leak window for brand-new WS pushes.
  - `getMyMembershipSourceSpaceId()` reads `channelMySourceSpaceMap` first, so external-group recognition no longer waits for subscriber list hydration.

## Backward compatibility

The new server fields are `omitempty`. When absent (server PR#154 not yet deployed) the existing `channelInfo.orgData.space_id` / subscriber `source_space_id` paths are unchanged and `shouldSkipChannelForSpace` still hits the cached `channelInfo.orgData` branch before falling through. Nothing breaks for old backends.

## Test

- Verify `channelSpaceMap` is populated on Space switch / cold load before any conversation is rendered.
- Verify `ConversationAction.add` for an unknown group no longer pre-shows in the wrong Space; it appears after `channelInfo` returns.
- Verify behavior unchanged when the backend omits `space_id` / `my_source_space_id`.

Fixes https://github.com/Mininglamp-OSS/octo-web/issues/107
