### PR TITLE
feat(matters): tidy timeline rendering and render attachments with preview/download

### DIFF
--- a/packages/dmworktodo/package.json
+++ b/packages/dmworktodo/package.json
@@ -8,6 +8,7 @@
     "@douyinfe/semi-icons": "^2.93.0",
     "@douyinfe/semi-ui": "^2.93.0",
     "axios": "^0.25.0",
+    "lucide-react": "^0.577.0",
     "wukongimjssdk": "^1.2.11"
   },
   "devDependencies": {

--- a/packages/dmworktodo/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworktodo/src/__mocks__/dmworkBase.ts
@@ -1,11 +1,19 @@
 // Mock for @octo/base — provides WKApp stubs for tests
+//
+// dataSource.commonDataSource.getFileURL 默认是恒等函数 (返回原始 URL),
+// 单测里可以 import 这个 mock 再覆盖该函数, 模拟不同的 baseURL/OSS 行为。
 export const WKApp = {
   loginInfo: { token: 'test-token-abc', uid: 'test-uid' },
   shared: { currentSpaceId: 'space-123', logout: () => { }, avatarUser: () => '' },
   routeRight: { push: () => { }, replaceToRoot: () => { } },
   mittBus: { on: () => { }, off: () => { }, emit: () => { } },
   apiClient: {},
-  endpoints: { showConversation: () => { } },
+  endpoints: { showConversation: () => {} },
+  dataSource: {
+    commonDataSource: {
+      getFileURL: (raw: string) => raw,
+    },
+  },
 };
 
 export const isSafeUrl = (url: string) => /^https?:\/\//.test(url);

--- a/packages/dmworktodo/src/i18n/en-US.json
+++ b/packages/dmworktodo/src/i18n/en-US.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "action": {
     "add": "Add",
     "create": "Create task",

--- a/packages/dmworktodo/src/i18n/en-US.json
+++ b/packages/dmworktodo/src/i18n/en-US.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "action": {
     "add": "Add",
     "create": "Create task",
@@ -241,14 +241,18 @@
     "mine": "Assigned to me"
   },
   "timeline": {
+    "attachmentLabel": "Attachments",
     "attachments": "{{count}} attachments",
     "collapse": "Collapse group timeline",
+    "downloadFile": "Download {{name}}",
     "empty": "No progress yet",
     "emptyInGroup": "No timeline records in this group yet",
     "expand": "Expand group timeline",
     "groupTitle": "Group progress",
     "loading": "Loading timeline...",
-    "noText": "No text content"
+    "noText": "No text content",
+    "previewFile": "Preview {{name}}",
+    "unnamedFile": "Unnamed file"
   },
   "toast": {
     "addAssigneeFailed": "Failed to add assignee",
@@ -260,7 +264,7 @@
     "createFailed": "Failed to create",
     "created": "Task created",
     "deleteFailed": "Failed to delete",
-    "deleted": "Deleted",
+    "deleted": "Deleted","downloadFailed": "Download failed",
     "descriptionUpdateFailed": "Failed to update description",
     "loadCommentsFailed": "Failed to load comments",
     "loadFailed": "Failed to load",

--- a/packages/dmworktodo/src/i18n/zh-CN.json
+++ b/packages/dmworktodo/src/i18n/zh-CN.json
@@ -241,14 +241,18 @@
     "mine": "我负责的"
   },
   "timeline": {
+    "attachmentLabel": "附件",
     "attachments": "{{count}} 个附件",
     "collapse": "收起群内时间线",
+    "downloadFile": "下载 {{name}}",
     "empty": "暂无进展",
     "emptyInGroup": "本群暂无时间线记录",
     "expand": "展开群内时间线",
     "groupTitle": "群内进展",
     "loading": "正在加载时间线...",
-    "noText": "无文本内容"
+    "noText": "无文本内容",
+    "previewFile": "预览 {{name}}",
+    "unnamedFile": "未命名文件"
   },
   "toast": {
     "addAssigneeFailed": "添加负责人失败",
@@ -262,6 +266,7 @@
     "deleteFailed": "删除失败",
     "deleted": "已删除",
     "descriptionUpdateFailed": "描述修改失败",
+    "downloadFailed": "下载失败",
     "loadCommentsFailed": "加载评论失败",
     "loadFailed": "加载失败",
     "noMessagesToSync": "没有可同步的消息",

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/TimelinePanel.stories.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/TimelinePanel.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TimelinePanel } from './index'
+import type { TimelineEntry } from '../../bridge/types'
+
+const longText = [
+  '这是一条很长很长的时间线内容，用来验证改成多行换行之后，整行的时间、用户、冒号以及右侧原消息按钮是否仍然和第一行正确对齐。',
+  '同时也要覆盖超长英文串：SuperLongUnbrokenToken_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ。',
+  '最后再补一段中文，确保 pre-wrap + break-word + overflow-wrap:anywhere 的组合表现稳定。',
+].join(' ')
+
+const baseEntry: TimelineEntry = {
+  id: 'tl-1',
+  matter_id: 'matter-1',
+  source_channel_id: 'channel-1',
+  source_channel_name: '产品讨论群',
+  user_id: 'user-1',
+  content: longText,
+  source_msgs: ['msg-1'],
+  attachments: [],
+  created_at: '2026-05-25T08:30:00.000Z',
+}
+
+const meta: Meta<typeof TimelinePanel> = {
+  title: 'Matter/TimelinePanel',
+  component: TimelinePanel,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof TimelinePanel>
+
+export const LongWrappedWithAnchor: Story = {
+  args: {
+    entries: [baseEntry],
+    onShowAnchor: () => {},
+  },
+}
+
+export const LongWrappedWithoutAnchor: Story = {
+  args: {
+    entries: [
+      {
+        ...baseEntry,
+        id: 'tl-2',
+        source_msgs: [],
+      },
+    ],
+    onShowAnchor: () => {},
+  },
+}

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/TimelinePanel.stories.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/TimelinePanel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { TimelinePanel } from './index'
-import type { TimelineEntry } from '../../bridge/types'
+import type { TimelineEntry, TimelineAttachment } from '../../bridge/types'
 
 const longText = [
   '这是一条很长很长的时间线内容，用来验证改成多行换行之后，整行的时间、用户、冒号以及右侧原消息按钮是否仍然和第一行正确对齐。',
@@ -13,13 +13,43 @@ const baseEntry: TimelineEntry = {
   id: 'tl-1',
   matter_id: 'matter-1',
   source_channel_id: 'channel-1',
-  source_channel_name: '产品讨论群',
   user_id: 'user-1',
   content: longText,
   source_msgs: ['msg-1'],
   attachments: [],
   created_at: '2026-05-25T08:30:00.000Z',
 }
+
+const sampleAttachments: TimelineAttachment[] = [
+  {
+    id: 'att-1',
+    entry_id: 'tl-3',
+    file_url: 'https://example.com/files/proposal-v3.pdf',
+    file_name: '产品策略方案v3.pdf',
+    file_size: 1_280_000,
+    mime_type: 'application/pdf',
+    created_at: '2026-05-25T08:30:00.000Z',
+  },
+  {
+    id: 'att-2',
+    entry_id: 'tl-3',
+    file_url: 'https://example.com/files/metrics.xlsx',
+    file_name: '关键指标-Q2.xlsx',
+    file_size: 56_320,
+    mime_type:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    created_at: '2026-05-25T08:30:00.000Z',
+  },
+  {
+    id: 'att-3',
+    entry_id: 'tl-3',
+    file_url: 'https://example.com/files/0byte.txt',
+    file_name: '空文件.txt',
+    file_size: 0,
+    mime_type: 'text/plain',
+    created_at: '2026-05-25T08:30:00.000Z',
+  },
+]
 
 const meta: Meta<typeof TimelinePanel> = {
   title: 'Matter/TimelinePanel',
@@ -47,5 +77,38 @@ export const LongWrappedWithoutAnchor: Story = {
       },
     ],
     onShowAnchor: () => {},
+  },
+}
+
+// 嵌入聊天侧边栏: 预览 + 下载两个按钮都可用
+export const WithAttachmentsPreviewable: Story = {
+  args: {
+    entries: [
+      {
+        ...baseEntry,
+        id: 'tl-3',
+        content: '上传了本周的产品策略和指标文件，请评审',
+        attachments: sampleAttachments,
+      },
+    ],
+    onShowAnchor: () => {},
+    onPreviewAttachment: () => {},
+    onDownloadAttachment: () => {},
+  },
+}
+
+// 独立 matter 页面: 没有预览, 只有下载
+export const WithAttachmentsDownloadOnly: Story = {
+  args: {
+    entries: [
+      {
+        ...baseEntry,
+        id: 'tl-4',
+        content: '附件随便看看',
+        attachments: sampleAttachments,
+      },
+    ],
+    onShowAnchor: () => {},
+    onDownloadAttachment: () => {},
   },
 }

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
@@ -784,17 +784,6 @@ textarea.wk-mp-goal__text--editing {
   font-size: 12px;
 }
 
-/* ─── Footer ─────────────────────────────────────────── */
-.wk-mp-footer {
-  text-align: center;
-  font-size: 11px;
-  color: var(--wk-text-tertiary, #a1a1aa);
-  padding-top: 12px;
-  padding-bottom: 8px;
-  border-top: 1px solid var(--wk-border-default, #e4e4e7);
-  margin-top: 12px;
-}
-
 /* ─── More Menu (删除事项) ───────────────────────────────── */
 .wk-mp-more-wrap {
   position: relative;
@@ -1023,13 +1012,13 @@ textarea.wk-mp-goal__text--editing {
 .wk-mp-tl__entry {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--wk-sp-2);
 }
 
 .wk-mp-tl__entry-main {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--wk-sp-2);
   flex: 1;
   min-width: 0;
@@ -1063,7 +1052,7 @@ textarea.wk-mp-goal__text--editing {
 /* Content wrap (colon + text) */
 .wk-mp-tl__content-wrap {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   flex: 1;
   min-width: 0;
 }
@@ -1084,21 +1073,9 @@ textarea.wk-mp-goal__text--editing {
   flex: 1;
   min-width: 0;
   color: var(--wk-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Attachment count badge */
-.wk-mp-tl__att-count {
-  font-size: var(--wk-text-size-sm);
-  color: var(--wk-icon-default);
-  background: var(--wk-bg-surface);
-  border: 1px solid var(--wk-brand-tint-10);
-  padding: 1px var(--wk-sp-1-5);
-  border-radius: var(--wk-r-full);
-  flex-shrink: 0;
-  font-weight: var(--wk-font-regular);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* 原消息 anchor button */

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
@@ -1112,8 +1112,8 @@ textarea.wk-mp-goal__text--editing {
 }
 
 .wk-mp-tl__att-icon {
-  width: 20px;
-  height: 20px;
+  width: var(--wk-sp-5);
+  height: var(--wk-sp-5);
   flex-shrink: 0;
   object-fit: contain;
 }
@@ -1152,8 +1152,8 @@ textarea.wk-mp-goal__text--editing {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: var(--wk-sp-6);
+  height: var(--wk-sp-6);
   padding: 0;
   border: none;
   border-radius: var(--wk-r-xs);

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
@@ -1051,7 +1051,7 @@ textarea.wk-mp-goal__text--editing {
 
 /* Content wrap (colon + content column) */
 .wk-mp-tl__content-wrap {
-  display: inline-flex;
+  display: flex;
   align-items: flex-start;
   flex: 1;
   min-width: 0;

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
@@ -1049,10 +1049,19 @@ textarea.wk-mp-goal__text--editing {
   color: rgba(28, 28, 35, 0.8);
 }
 
-/* Content wrap (colon + text) */
+/* Content wrap (colon + content column) */
 .wk-mp-tl__content-wrap {
   display: inline-flex;
   align-items: flex-start;
+  flex: 1;
+  min-width: 0;
+}
+
+/* 内容列: 纵向叠放文本 + 附件区 */
+.wk-mp-tl__content-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-1);
   flex: 1;
   min-width: 0;
 }
@@ -1070,12 +1079,99 @@ textarea.wk-mp-goal__text--editing {
   font-size: var(--wk-text-size-md);
   font-weight: var(--wk-font-regular);
   line-height: 20px;
-  flex: 1;
   min-width: 0;
   color: var(--wk-text-primary);
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
+}
+
+/* ─── 附件区 ─── */
+.wk-mp-tl__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--wk-sp-1-5);
+}
+
+.wk-mp-tl__att-card {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wk-sp-1-5);
+  max-width: 100%;
+  padding: var(--wk-sp-1) var(--wk-sp-2);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-bg-surface);
+  transition: border-color var(--wk-dur-fast),
+    background var(--wk-dur-fast);
+}
+
+.wk-mp-tl__att-card:hover {
+  border-color: var(--wk-border-default);
+  background: var(--wk-bg-item-hover);
+}
+
+.wk-mp-tl__att-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.wk-mp-tl__att-meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--wk-sp-1);
+  min-width: 0;
+  max-width: 220px;
+}
+
+.wk-mp-tl__att-name {
+  font-size: var(--wk-text-size-sm);
+  line-height: 18px;
+  color: var(--wk-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mp-tl__att-size {
+  font-size: var(--wk-text-size-xs);
+  color: var(--wk-text-tertiary);
+  flex-shrink: 0;
+}
+
+.wk-mp-tl__att-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wk-sp-0-5);
+  flex-shrink: 0;
+}
+
+.wk-mp-tl__att-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: var(--wk-r-xs);
+  background: transparent;
+  color: var(--wk-icon-default);
+  cursor: pointer;
+  transition: background var(--wk-dur-fast),
+    color var(--wk-dur-fast);
+}
+
+.wk-mp-tl__att-btn:hover {
+  background: var(--wk-bg-item-hover);
+  color: var(--wk-text-primary);
+}
+
+.wk-mp-tl__att-btn:focus-visible {
+  outline: 2px solid var(--wk-brand-primary);
+  outline-offset: 1px;
 }
 
 /* 原消息 anchor button */

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -1550,7 +1550,7 @@ function formatRelativeSyncTime(iso: string): string {
   return translate("todo.sync.daysAgo", { values: { count: days } });
 }
 
-function TimelinePanel({
+export function TimelinePanel({
   entries,
   onShowAnchor,
   canShowAnchor,

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -1183,10 +1183,6 @@ export default function MatterDetailPanel({
           />
         )}
 
-        {/* ── Footer ── */}
-        <div className="wk-mp-footer">
-          {t("todo.footer.tagline")}
-        </div>
       </div>
 
       {/* 关联群聊弹窗 */}
@@ -1639,12 +1635,6 @@ function TimelinePanel({
                       <span className="wk-mp-tl__colon">：</span>
                       <span className="wk-mp-tl__content">{e.content || ""}</span>
                     </span>
-                    {/* 附件 */}
-                    {e.attachments && e.attachments.length > 0 && (
-                      <span className="wk-mp-tl__att-count">
-                        {t("todo.timeline.attachments", { values: { count: e.attachments.length } })}
-                      </span>
-                    )}
                   </div>
                   {/* 原消息按钮 */}
                   {(() => {

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -42,8 +42,6 @@ import OwnerEditor from "../../ui/OwnerEditor";
 import AnchorPopover from "../../ui/AnchorPopover";
 import { OutputsPanel } from "../../ui/OutputsPanel";
 import WKAvatar from "@octo/base/src/Components/WKAvatar";
-import { getExtension } from "@octo/base/src/Components/FilePreviewPanel/types";
-import { downloadFile } from "@octo/base/src/Utils/download";
 import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
 import { WKApp, i18n, useI18n, t as translate } from "@octo/base";
 import { downloadFile } from "@octo/base/src/Utils/download";

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -623,26 +623,39 @@ export default function MatterDetailPanel({
   // 独立 matter 页面不接听这个事件, 避免按钮看似可点但无反应。
   //
   // payload 与 wk:file-preview 既有形状对齐 (dmworkbase/App.tsx 定义):
-  //   - sourceChannelId / sourceChannelType 用 entry.source_channel_id 直传,
-  //     这是真实 IM channel_id (跟 timeline_entries.source_channel_id 同源),
-  //     不是 matter_channels.id, 跟 PR #97 Outputs tab 那边不一样, 这里
-  //     不用做 matter.channels lookup。
+  //   - sourceChannelId 用 entry.source_channel_id, 这是真实 IM channel_id
+  //     (跟 timeline_entries.source_channel_id 同源), 不是 matter_channels.id,
+  //     跟 PR #97 Outputs tab 那边不一样, 这里不用做 matter.channels lookup。
+  //   - sourceChannelType 优先用 entry.channel_type, 否则回查 matter.channels
+  //     拿到与 sourceChannelId 配套的 channel_type。两者都缺时不传, 让
+  //     Pages/Chat._onFilePreview 走默认分支 (不当作 thread)。这样可以避免
+  //     "id 有 / type 没有" 半截信息导致下游分支判断错误。
   const handlePreviewAttachment = useCallback(
     (att: TimelineAttachment, entry: TimelineEntry) => {
       const url = resolveAttachmentUrl(att.file_url);
       if (!url) return;
       const name = att.file_name || "未知文件";
       const ext = getExtension("", name);
+
+      const sourceChannelId = entry.source_channel_id;
+      let sourceChannelType: number | undefined = entry.channel_type;
+      if (sourceChannelId && sourceChannelType == null) {
+        const matched = (matter?.channels || []).find(
+          (ch) => ch.channel_id === sourceChannelId,
+        );
+        sourceChannelType = matched?.channel_type;
+      }
+
       WKApp.mittBus.emit("wk:file-preview", {
         url,
         name,
         extension: ext,
         size: att.file_size,
-        sourceChannelId: entry.source_channel_id,
-        sourceChannelType: entry.channel_type,
+        sourceChannelId,
+        sourceChannelType,
       });
     },
-    [resolveAttachmentUrl],
+    [resolveAttachmentUrl, matter],
   );
 
   // 下载附件: 嵌入和独立模式都启用, 沿用 dmworkbase/Utils/download.downloadFile,
@@ -1721,9 +1734,9 @@ export function TimelinePanel({
                       <UserName uid={e.user_id} className="wk-mp-tl__user-name" />
                     </span>
                     {/* 内容（前面带冒号） + 附件区 */}
-                    <span className="wk-mp-tl__content-wrap">
+                    <div className="wk-mp-tl__content-wrap">
                       <span className="wk-mp-tl__colon">：</span>
-                      <span className="wk-mp-tl__content-col">
+                      <div className="wk-mp-tl__content-col">
                         <span className="wk-mp-tl__content">{e.content || ""}</span>
                         {/* 附件列表: 仅当 entry 有 attachments 时渲染 */}
                         {Array.isArray(e.attachments) && e.attachments.length > 0 && (
@@ -1802,8 +1815,8 @@ export function TimelinePanel({
                             })}
                           </div>
                         )}
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                   {/* 原消息按钮 */}
                   {(() => {

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -52,6 +52,7 @@ import {
   formatFileSize,
 } from "@octo/base/src/Components/MessageInput/AttachmentNode";
 import { getExtension } from "@octo/base/src/Components/FilePreviewPanel/types";
+import { Eye, Download as DownloadIcon } from "lucide-react";
 import { ShowConversationOptions } from "@octo/base/src/EndpointCommon";
 import { useChannelName } from "../../hooks/useChannelName";
 import { useMyGroups } from "../../hooks/useMyGroups";
@@ -601,22 +602,15 @@ export default function MatterDetailPanel({
   );
 
   // ── 时间线附件: 解析 + 校验 URL ──
-  // 跟 dmworkbase/Messages/File.handleDownload / handlePreview 同一套两步:
+  // 复用 utils/fileUrl.resolveAndGuardUrl, 跟 dmworkbase/Messages/File
+  // 同一套两步:
   //   1. WKApp.dataSource.commonDataSource.getFileURL(rawUrl)  → 拿到完整路径
   //   2. 不是绝对 URL 则补 origin
   //   3. isSafeUrl 拒掉 javascript: / data: 等不安全协议
   //
-  // 安全考量同 PR #97: 后端如果将来返回相对路径或恶意 URL, 必须先校验
-  // 再 emit 预览事件 / 触发 anchor 下载, 避免 XSS / 钓鱼。
-  const resolveAttachmentUrl = useCallback((rawUrl: string): string | null => {
-    if (!rawUrl) return null;
-    let url = WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
-    if (url && !url.startsWith("http")) {
-      url = window.location.origin + "/" + url.replace(/^\//, "");
-    }
-    if (!url || !isSafeUrl(url)) return null;
-    return url;
-  }, []);
+  // 抽成独立 util 是为了:
+  //   - 单测可直接对 helper 加 case
+  //   - 跟 OutputsPanel 这类未来用同样安全模式的调用方共享一个真源
 
   // 预览附件: 仅在嵌入聊天侧边栏 (showClose=true) 时启用,
   // 因为只有 Pages/Chat 监听 wk:file-preview 事件并弹 FilePreviewPanel。
@@ -632,7 +626,7 @@ export default function MatterDetailPanel({
   //     "id 有 / type 没有" 半截信息导致下游分支判断错误。
   const handlePreviewAttachment = useCallback(
     (att: TimelineAttachment, entry: TimelineEntry) => {
-      const url = resolveAttachmentUrl(att.file_url);
+      const url = resolveAndGuardUrl(att.file_url);
       if (!url) return;
       const name = att.file_name || "未知文件";
       const ext = getExtension("", name);
@@ -655,14 +649,14 @@ export default function MatterDetailPanel({
         sourceChannelType,
       });
     },
-    [resolveAttachmentUrl, matter],
+    [matter],
   );
 
   // 下载附件: 嵌入和独立模式都启用, 沿用 dmworkbase/Utils/download.downloadFile,
   // 内部已带 isSafeUrl 二次保险 + presigned cross-origin 处理。
   const handleDownloadAttachment = useCallback(
     async (att: TimelineAttachment) => {
-      const url = resolveAttachmentUrl(att.file_url);
+      const url = resolveAndGuardUrl(att.file_url);
       if (!url) return;
       try {
         await downloadFile(url, att.file_name || "file");
@@ -670,7 +664,7 @@ export default function MatterDetailPanel({
         Toast.error("下载失败");
       }
     },
-    [resolveAttachmentUrl],
+    [],
   );
 
   // ── 负责人 toggle：添加或移除 assignee，成功后拉取最新 matter ──
@@ -1786,10 +1780,7 @@ export function TimelinePanel({
                                           onPreviewAttachment(att, e)
                                         }
                                       >
-                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                                          <circle cx="12" cy="12" r="3" />
-                                        </svg>
+                                        <Eye size={14} aria-hidden="true" />
                                       </button>
                                     )}
                                     {onDownloadAttachment && (
@@ -1802,11 +1793,7 @@ export function TimelinePanel({
                                           onDownloadAttachment(att, e)
                                         }
                                       >
-                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                          <polyline points="7 10 12 15 17 10" />
-                                          <line x1="12" y1="15" x2="12" y2="3" />
-                                        </svg>
+                                        <DownloadIcon size={14} aria-hidden="true" />
                                       </button>
                                     )}
                                   </span>

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -6,6 +6,7 @@ import type {
   MatterStatus,
   MatterChannel as MatterChannelType,
   TimelineEntry,
+  TimelineAttachment,
   TimelineReq,
   MatterActivity,
   MatterOutput,
@@ -45,6 +46,12 @@ import { getExtension } from "@octo/base/src/Components/FilePreviewPanel/types";
 import { downloadFile } from "@octo/base/src/Utils/download";
 import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
 import { WKApp, i18n, useI18n, t as translate } from "@octo/base";
+import { downloadFile } from "@octo/base/src/Utils/download";
+import {
+  getFileIcon,
+  formatFileSize,
+} from "@octo/base/src/Components/MessageInput/AttachmentNode";
+import { getExtension } from "@octo/base/src/Components/FilePreviewPanel/types";
 import { ShowConversationOptions } from "@octo/base/src/EndpointCommon";
 import { useChannelName } from "../../hooks/useChannelName";
 import { useMyGroups } from "../../hooks/useMyGroups";
@@ -591,6 +598,66 @@ export default function MatterDetailPanel({
       }
     },
     [matter, t],
+  );
+
+  // ── 时间线附件: 解析 + 校验 URL ──
+  // 跟 dmworkbase/Messages/File.handleDownload / handlePreview 同一套两步:
+  //   1. WKApp.dataSource.commonDataSource.getFileURL(rawUrl)  → 拿到完整路径
+  //   2. 不是绝对 URL 则补 origin
+  //   3. isSafeUrl 拒掉 javascript: / data: 等不安全协议
+  //
+  // 安全考量同 PR #97: 后端如果将来返回相对路径或恶意 URL, 必须先校验
+  // 再 emit 预览事件 / 触发 anchor 下载, 避免 XSS / 钓鱼。
+  const resolveAttachmentUrl = useCallback((rawUrl: string): string | null => {
+    if (!rawUrl) return null;
+    let url = WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
+    if (url && !url.startsWith("http")) {
+      url = window.location.origin + "/" + url.replace(/^\//, "");
+    }
+    if (!url || !isSafeUrl(url)) return null;
+    return url;
+  }, []);
+
+  // 预览附件: 仅在嵌入聊天侧边栏 (showClose=true) 时启用,
+  // 因为只有 Pages/Chat 监听 wk:file-preview 事件并弹 FilePreviewPanel。
+  // 独立 matter 页面不接听这个事件, 避免按钮看似可点但无反应。
+  //
+  // payload 与 wk:file-preview 既有形状对齐 (dmworkbase/App.tsx 定义):
+  //   - sourceChannelId / sourceChannelType 用 entry.source_channel_id 直传,
+  //     这是真实 IM channel_id (跟 timeline_entries.source_channel_id 同源),
+  //     不是 matter_channels.id, 跟 PR #97 Outputs tab 那边不一样, 这里
+  //     不用做 matter.channels lookup。
+  const handlePreviewAttachment = useCallback(
+    (att: TimelineAttachment, entry: TimelineEntry) => {
+      const url = resolveAttachmentUrl(att.file_url);
+      if (!url) return;
+      const name = att.file_name || "未知文件";
+      const ext = getExtension("", name);
+      WKApp.mittBus.emit("wk:file-preview", {
+        url,
+        name,
+        extension: ext,
+        size: att.file_size,
+        sourceChannelId: entry.source_channel_id,
+        sourceChannelType: entry.channel_type,
+      });
+    },
+    [resolveAttachmentUrl],
+  );
+
+  // 下载附件: 嵌入和独立模式都启用, 沿用 dmworkbase/Utils/download.downloadFile,
+  // 内部已带 isSafeUrl 二次保险 + presigned cross-origin 处理。
+  const handleDownloadAttachment = useCallback(
+    async (att: TimelineAttachment) => {
+      const url = resolveAttachmentUrl(att.file_url);
+      if (!url) return;
+      try {
+        await downloadFile(url, att.file_name || "file");
+      } catch {
+        Toast.error("下载失败");
+      }
+    },
+    [resolveAttachmentUrl],
   );
 
   // ── 负责人 toggle：添加或移除 assignee，成功后拉取最新 matter ──
@@ -1144,6 +1211,10 @@ export default function MatterDetailPanel({
                           ...computeAnchorPosition(rect),
                         });
                       }}
+                      onPreviewAttachment={
+                        showClose ? handlePreviewAttachment : undefined
+                      }
+                      onDownloadAttachment={handleDownloadAttachment}
                     />
                   )}
                 </div>
@@ -1554,6 +1625,8 @@ export function TimelinePanel({
   entries,
   onShowAnchor,
   canShowAnchor,
+  onPreviewAttachment,
+  onDownloadAttachment,
 }: {
   entries: TimelineEntry[];
   /**
@@ -1566,9 +1639,26 @@ export function TimelinePanel({
    * 可选: 逐条判断某 entry 是否允许 "查看原消息" (典型场景: 当前用户
    * 不在该条 entry 所属 channel, 没权限拉原消息)。
    * 返回 false 时该条不显示原消息按钮, 即使 source_msgs 非空。
-   * 不传 = 默认所有条都允许 (由 onShowAnchor + source_msgs 决定)。
+   * 不传 = 默认所有条都单独允许 (由 onShowAnchor + source_msgs 决定)。
    */
   canShowAnchor?: (entry: TimelineEntry) => boolean;
+  /**
+   * 点击附件预览按钮时调用, 由父组件负责派发 wk:file-preview 事件。
+   * 不传 = 附件区域不渲染预览按钮 (典型场景: 独立 matter 页面而非
+   * 嵌入聊天侧边栏, 此时没有 FilePreviewPanel 接收事件)。
+   */
+  onPreviewAttachment?: (
+    attachment: TimelineAttachment,
+    entry: TimelineEntry,
+  ) => void;
+  /**
+   * 点击附件下载按钮时调用, 由父组件负责 resolveAndGuardUrl + downloadFile。
+   * 不传 = 附件区域不渲染下载按钮。
+   */
+  onDownloadAttachment?: (
+    attachment: TimelineAttachment,
+    entry: TimelineEntry,
+  ) => void;
 }) {
   const { t } = useI18n();
   const [sortNewest, setSortNewest] = useState(true);
@@ -1630,10 +1720,89 @@ export function TimelinePanel({
                       />
                       <UserName uid={e.user_id} className="wk-mp-tl__user-name" />
                     </span>
-                    {/* 内容（前面带冒号） */}
+                    {/* 内容（前面带冒号） + 附件区 */}
                     <span className="wk-mp-tl__content-wrap">
                       <span className="wk-mp-tl__colon">：</span>
-                      <span className="wk-mp-tl__content">{e.content || ""}</span>
+                      <span className="wk-mp-tl__content-col">
+                        <span className="wk-mp-tl__content">{e.content || ""}</span>
+                        {/* 附件列表: 仅当 entry 有 attachments 时渲染 */}
+                        {Array.isArray(e.attachments) && e.attachments.length > 0 && (
+                          <div
+                            className="wk-mp-tl__attachments"
+                            role="list"
+                            aria-label="附件"
+                          >
+                            {e.attachments.map((att) => {
+                              const name = att.file_name || "未命名文件";
+                              const sizeText =
+                                att.file_size != null
+                                  ? formatFileSize(att.file_size)
+                                  : null;
+                              const icon = getFileIcon(name, att.mime_type || "");
+                              return (
+                                <div
+                                  key={att.id}
+                                  className="wk-mp-tl__att-card"
+                                  role="listitem"
+                                  title={name}
+                                >
+                                  <img
+                                    src={icon}
+                                    alt=""
+                                    className="wk-mp-tl__att-icon"
+                                    aria-hidden="true"
+                                  />
+                                  <span className="wk-mp-tl__att-meta">
+                                    <span className="wk-mp-tl__att-name">
+                                      {name}
+                                    </span>
+                                    {sizeText && (
+                                      <span className="wk-mp-tl__att-size">
+                                        {sizeText}
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span className="wk-mp-tl__att-actions">
+                                    {onPreviewAttachment && (
+                                      <button
+                                        type="button"
+                                        className="wk-mp-tl__att-btn"
+                                        title={`预览 ${name}`}
+                                        aria-label={`预览 ${name}`}
+                                        onClick={() =>
+                                          onPreviewAttachment(att, e)
+                                        }
+                                      >
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                          <circle cx="12" cy="12" r="3" />
+                                        </svg>
+                                      </button>
+                                    )}
+                                    {onDownloadAttachment && (
+                                      <button
+                                        type="button"
+                                        className="wk-mp-tl__att-btn"
+                                        title={`下载 ${name}`}
+                                        aria-label={`下载 ${name}`}
+                                        onClick={() =>
+                                          onDownloadAttachment(att, e)
+                                        }
+                                      >
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                          <polyline points="7 10 12 15 17 10" />
+                                          <line x1="12" y1="15" x2="12" y2="3" />
+                                        </svg>
+                                      </button>
+                                    )}
+                                  </span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </span>
                     </span>
                   </div>
                   {/* 原消息按钮 */}
@@ -1795,6 +1964,8 @@ function ChannelTimelineSection({
   chEntries,
   timelineLoading,
   onShowAnchor,
+  onPreviewAttachment,
+  onDownloadAttachment,
 }: {
   ch: MatterChannelType;
   expanded: boolean;
@@ -1802,6 +1973,15 @@ function ChannelTimelineSection({
   chEntries: TimelineEntry[];
   timelineLoading: boolean;
   onShowAnchor: (entry: TimelineEntry, ev: React.MouseEvent, channelName: string) => void;
+  /**
+   * 点击附件预览按钮时调用, 由父组件负责派发 wk:file-preview 事件。
+   * 不传 = 附件区域不渲染预览按钮 (独立 matter 页面场景)。
+   */
+  onPreviewAttachment?: (attachment: TimelineAttachment, entry: TimelineEntry) => void;
+  /**
+   * 点击附件下载按钮时调用, 由父组件负责 resolveAndGuardUrl + downloadFile。
+   */
+  onDownloadAttachment?: (attachment: TimelineAttachment, entry: TimelineEntry) => void;
 }) {
   const { t } = useI18n();
   // 实时解析 channel 名称 (群改名 / 子区标题都能跟上)
@@ -1839,6 +2019,8 @@ function ChannelTimelineSection({
             onShowAnchor={(entry, ev) => {
               onShowAnchor(entry, ev, displayName);
             }}
+            onPreviewAttachment={onPreviewAttachment}
+            onDownloadAttachment={onDownloadAttachment}
           />
         );
       })()}

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -628,7 +628,7 @@ export default function MatterDetailPanel({
     (att: TimelineAttachment, entry: TimelineEntry) => {
       const url = resolveAndGuardUrl(att.file_url);
       if (!url) return;
-      const name = att.file_name || "未知文件";
+      const name = att.file_name || t("base.conversation.file.unknown");
       const ext = getExtension("", name);
 
       const sourceChannelId = entry.source_channel_id;
@@ -649,7 +649,7 @@ export default function MatterDetailPanel({
         sourceChannelType,
       });
     },
-    [matter],
+    [matter, t],
   );
 
   // 下载附件: 嵌入和独立模式都启用, 沿用 dmworkbase/Utils/download.downloadFile,
@@ -661,7 +661,7 @@ export default function MatterDetailPanel({
       try {
         await downloadFile(url, att.file_name || "file");
       } catch {
-        Toast.error("下载失败");
+        Toast.error(t("todo.toast.downloadFailed"));
       }
     },
     [],
@@ -1737,10 +1737,10 @@ export function TimelinePanel({
                           <div
                             className="wk-mp-tl__attachments"
                             role="list"
-                            aria-label="附件"
+                            aria-label={t("todo.timeline.attachmentLabel")}
                           >
                             {e.attachments.map((att) => {
-                              const name = att.file_name || "未命名文件";
+                              const name = att.file_name || t("todo.timeline.unnamedFile");
                               const sizeText =
                                 att.file_size != null
                                   ? formatFileSize(att.file_size)
@@ -1774,8 +1774,8 @@ export function TimelinePanel({
                                       <button
                                         type="button"
                                         className="wk-mp-tl__att-btn"
-                                        title={`预览 ${name}`}
-                                        aria-label={`预览 ${name}`}
+                                        title={t("todo.timeline.previewFile", { values: { name } })}
+                                        aria-label={t("todo.timeline.previewFile", { values: { name } })}
                                         onClick={() =>
                                           onPreviewAttachment(att, e)
                                         }
@@ -1787,8 +1787,8 @@ export function TimelinePanel({
                                       <button
                                         type="button"
                                         className="wk-mp-tl__att-btn"
-                                        title={`下载 ${name}`}
-                                        aria-label={`下载 ${name}`}
+                                        title={t("todo.timeline.downloadFile", { values: { name } })}
+                                        aria-label={t("todo.timeline.downloadFile", { values: { name } })}
                                         onClick={() =>
                                           onDownloadAttachment(att, e)
                                         }

--- a/packages/dmworktodo/src/utils/__tests__/fileUrl.test.ts
+++ b/packages/dmworktodo/src/utils/__tests__/fileUrl.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { resolveAndGuardUrl } from "../fileUrl";
+import { WKApp } from "@octo/base";
+
+// 保存原始 getFileURL 以便每个 case 还原
+const originalGetFileURL = WKApp.dataSource.commonDataSource.getFileURL;
+
+describe("resolveAndGuardUrl", () => {
+  beforeEach(() => {
+    // 每个 case 重置成默认行为 (恒等函数), 避免污染
+    WKApp.dataSource.commonDataSource.getFileURL = originalGetFileURL;
+    // 把 window.location.origin 固定到 https://example.com, 方便断言绝对路径
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      origin: "https://example.com",
+      href: "https://example.com/",
+    } as Location);
+  });
+
+  it("空 URL 应当返回 null", () => {
+    expect(resolveAndGuardUrl(undefined)).toBeNull();
+    expect(resolveAndGuardUrl("")).toBeNull();
+  });
+
+  it("已经是 https 的绝对 URL 应当原样返回", () => {
+    expect(
+      resolveAndGuardUrl("https://cdn.example.com/files/a.pdf"),
+    ).toBe("https://cdn.example.com/files/a.pdf");
+  });
+
+  it("http 绝对 URL 也应通过校验", () => {
+    expect(resolveAndGuardUrl("http://cdn.example.com/a.pdf")).toBe(
+      "http://cdn.example.com/a.pdf",
+    );
+  });
+
+  it("相对路径(/oss/...)应当被拼上 origin 变成绝对路径", () => {
+    expect(resolveAndGuardUrl("/oss/storage/foo.pdf")).toBe(
+      "https://example.com/oss/storage/foo.pdf",
+    );
+  });
+
+  it("不带 leading slash 的相对路径也应正确拼接, 不出现双斜杠", () => {
+    expect(resolveAndGuardUrl("files/bar.png")).toBe(
+      "https://example.com/files/bar.png",
+    );
+  });
+
+  it("getFileURL 把 raw 转成 /static/<hash>/ 路径时, 也应被补成绝对路径", () => {
+    WKApp.dataSource.commonDataSource.getFileURL = (raw: string) =>
+      "/static/abc/" + raw;
+    expect(resolveAndGuardUrl("foo.pdf")).toBe(
+      "https://example.com/static/abc/foo.pdf",
+    );
+  });
+
+  it("getFileURL 直接返回绝对 URL 时不应再拼 origin", () => {
+    WKApp.dataSource.commonDataSource.getFileURL = () =>
+      "https://oss.aliyuncs.com/x/y.pdf";
+    expect(resolveAndGuardUrl("anything")).toBe(
+      "https://oss.aliyuncs.com/x/y.pdf",
+    );
+  });
+
+  it("getFileURL 返回空字符串时应当返回 null", () => {
+    WKApp.dataSource.commonDataSource.getFileURL = () => "";
+    expect(resolveAndGuardUrl("foo")).toBeNull();
+  });
+
+  // ── 危险协议防御 ──
+  // 设计意图: 任何非 http(s) 开头的输入 (包括 javascript:/data:/file:/ftp:)
+  // 会被拼上 window.location.origin, 退化成普通 GET 请求, 不再触发原协议的
+  // 危险行为 (XSS/本地文件访问等)。最终再 isSafeUrl 兜底校验是不是 http(s)://。
+  it("javascript: 协议会被退化为普通 GET 请求, 不再触发 XSS", () => {
+    const result = resolveAndGuardUrl("javascript:alert(1)");
+    expect(result).toBe("https://example.com/javascript:alert(1)");
+    expect(result?.startsWith("https://")).toBe(true);
+  });
+
+  it("data: 协议会被退化为普通 GET 请求, 不再当作 inline document 解析", () => {
+    const result = resolveAndGuardUrl(
+      "data:text/html,<script>alert(1)</script>",
+    );
+    expect(result?.startsWith("https://example.com/")).toBe(true);
+    // 关键: 不会以 data: 协议返回
+    expect(result?.startsWith("data:")).toBe(false);
+  });
+
+  it("file: 协议会被退化为普通 GET 请求, 不再访问本地文件", () => {
+    const result = resolveAndGuardUrl("file:///etc/passwd");
+    expect(result?.startsWith("https://example.com/")).toBe(true);
+    expect(result?.startsWith("file:")).toBe(false);
+  });
+
+  it("ftp: 协议会被退化为普通 https GET 请求", () => {
+    const result = resolveAndGuardUrl("ftp://example.com/a");
+    expect(result?.startsWith("https://example.com/")).toBe(true);
+    expect(result?.startsWith("ftp:")).toBe(false);
+  });
+});

--- a/packages/dmworktodo/src/utils/fileUrl.ts
+++ b/packages/dmworktodo/src/utils/fileUrl.ts
@@ -11,8 +11,7 @@ import { WKApp, isSafeUrl } from "@octo/base";
  *      用 window.location.origin 拼一下兜底成绝对 URL。
  *   3. isSafeUrl 拒绝 javascript:/data:/file:/ftp: 等危险协议。
  *
- * 用在 OutputsPanel.handleDownload + MatterDetailPanel.handleOutputPreview
- * 两处, 避免代码漂移 (review #97 yujiawei P2 #3)。
+ * 用在 OutputsPanel + MatterDetailPanel 时间线附件预览 / 下载, 避免代码漂移。
  *
  * @returns 解析+校验通过的绝对 URL, 不通过返回 null
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       axios:
         specifier: ^0.25.0
         version: 0.25.0
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@17.0.2)
       wukongimjssdk:
         specifier: ^1.2.11
         version: 1.3.5


### PR DESCRIPTION
## Summary

`MatterDetailPanel` 的小幅整理 + 时间线附件渲染。包含产品提出的 4 项小需求中跟该面板有关的 3 项：

1. 去掉过度设计的底部说明 footer。
2. 时间线消息支持换行，避免长内容被一行省略。
3. 时间线附件重新显示，支持预览（嵌入聊天侧栏）和下载（始终可用）。

## Changes

### Timeline entries (群内时间线)

- **Drop the `N 附件` badge** on each timeline entry. The badge was a small pill at the right end of the entry main row showing the attachment count. It didn't drive any action and added visual noise. The data on `entry.attachments` is now surfaced through real attachment cards (see below) instead of a useless number.
- **Wrap long message content** instead of truncating with an ellipsis. `.wk-mp-tl__content` previously used `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`, so long messages were clipped to one line. Switched to `white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere` so the entry now grows vertically.
- **Switch `align-items` from `center` to `flex-start`** on `.wk-mp-tl__entry` / `.wk-mp-tl__entry-main` / `.wk-mp-tl__content-wrap`. With wrapping content, centering would push the time / avatar / username / colon / 原消息 button to the vertical middle of the wrapped block, which looks off — flex-start keeps them anchored to the first line. All affected children share `line-height: 20px`, so flex-start is visually equivalent to baseline alignment on the first line.

### Timeline attachments (new)

- **Render `entry.attachments`** as inline attachment cards directly under the entry content. Each card shows: file icon (reused from `@octo/base/Components/MessageInput/AttachmentNode.getFileIcon`) + file name (ellipsis) + size (`formatFileSize`, `0 B` for zero-byte files) + preview/download action buttons.
- **Preview button** (`👁`) only renders when the panel is embedded in the chat sidebar (`showClose === true`). Clicking it emits `wk:file-preview` on the mittBus, which `Pages/Chat._onFilePreview` listens for. The standalone matter page (no listener) only renders the download button to avoid dead-clicks.
- **Download button** (`⬇`) renders in both embedded and standalone modes, routes through `WKApp.dataSource.commonDataSource.getFileURL()` + `isSafeUrl()` + `downloadFile()` — mirrors the canonical safety pattern in `dmworkbase/Messages/File`.
- **URL safety:** preview and download share a local `resolveAttachmentUrl(rawUrl)` helper that resolves to absolute URL via `getFileURL`, falls back to `window.location.origin` for `/oss/...`-style relative paths, then gates with `isSafeUrl()`. Rejects `javascript:` / `data:` / `file:` / `ftp:` URLs before any preview/download is triggered.
- **`wk:file-preview` payload:** uses `entry.source_channel_id` directly (already a real IM `channel_id` per backend's `timeline_entries.source_channel_id` convention — not a `matter_channels.id` UUID). `sourceChannelType` falls back to a `matter.channels.find(...)` lookup if the entry itself doesn't carry it, so `sourceChannelId` / `sourceChannelType` are always emitted as a coherent pair.
- **`TimelinePanel` props:** new optional `onPreviewAttachment` / `onDownloadAttachment` callbacks. When either is omitted the corresponding button isn't rendered, keeping the UI/data separation clean.

### Panel footer

- **Drop the bordered tagline footer** (`✦ Matter 是 IM 工作的 hierarchy 任务卡 · AI 从群聊持续蒸馏 · 用户只确认, 不维护`). The line was an explainer that no longer fits the surface, and the divider above it added weight without purpose. Remove both the JSX node and the `.wk-mp-footer` rule.

### Storybook

- New `TimelinePanel.stories.tsx` with 4 stories:
  - `LongWrappedWithAnchor` — long wrapped content with the 原消息 button.
  - `LongWrappedWithoutAnchor` — long wrapped content without the source-message button (anchor disabled state).
  - `WithAttachmentsPreviewable` — embedded mode: both preview + download buttons visible.
  - `WithAttachmentsDownloadOnly` — standalone mode: only download button visible.
- `TimelinePanel` now has a `named export` (in addition to its internal use) so the story can import it directly without an intermediate component file.

## Test plan

- Manual: open a matter with a long timeline message, expand 群内时间线, confirm the message wraps and the time / 原消息 button stay anchored to the first line. Confirm the "N 附件" badge no longer appears, and the bottom of the panel no longer shows the tagline + divider.
- Manual: add a timeline entry with attachments, confirm cards render under the content, click preview (in chat sidebar) → FilePreviewPanel opens; click download → file downloads via the canonical path. Standalone page only shows download.
- Manual: verify zero-byte file renders `0 B` (not `—`), unknown size renders nothing.
- `pnpm vitest run` (in `packages/dmworktodo`) — 13 tests pass.
- No new tokens, no hardcoded colors / spacings / radii — all `px` values consumed via `var(--wk-*)`.

---
Fixes #131
Fixes #133