### PR TITLE
fix(persona): bot picker — filter myBotsRaw by creator_uid

### DIFF
--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
@@ -46,7 +46,9 @@ vi.mock("../../../App", () => ({
             put: hoisted.put,
         },
         shared: { currentSpaceId: "" },
-        loginInfo: { uid: "" },
+        // #111 (YUJ-1964): loadMyBots filters my_bots by creator_uid===loginInfo.uid;
+        // give a stable uid so mocked bots flagged with creator_uid: "me" pass through.
+        loginInfo: { uid: "me" },
     },
     __esModule: true,
 }))
@@ -101,7 +103,7 @@ describe("PersonaCreate — notifyListener fan-out (octo-web#95)", () => {
         // both spellings just in case.
         hoisted.get.mockImplementation((url: string) => {
             if (url === "/robot/my_bots" || url === "robot/my_bots") {
-                return Promise.resolve([{ uid: "bot-x", name: "Picker Bot X" }])
+                return Promise.resolve([{ uid: "bot-x", name: "Picker Bot X", creator_uid: "me" }])
             }
             if (url === "/robot/space_bots" || url === "robot/space_bots") {
                 return Promise.resolve([])
@@ -189,8 +191,8 @@ describe("PersonaCreate — notifyListener fan-out (octo-web#95)", () => {
             }
             if (url === "/robot/my_bots" || url === "robot/my_bots") {
                 return Promise.resolve([
-                    { uid: "bot-x", name: "Bot X" },
-                    { uid: "bot-y", name: "Bot Y" },
+                    { uid: "bot-x", name: "Bot X", creator_uid: "me" },
+                    { uid: "bot-y", name: "Bot Y", creator_uid: "me" },
                 ])
             }
             if (url === "/robot/space_bots" || url === "robot/space_bots") {

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
@@ -361,7 +361,7 @@ describe("PersonaEditVM", () => {
     })
 })
 
-describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + owned space_bots", () => {
+describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444) + #111 (YUJ-1964): merges owned my_bots + owned space_bots", () => {
     // 拿到模块默认导出的 mock，方便测试动态改 currentSpaceId / loginInfo.uid。
     // 在所有 mock 注册之后再 import，保证拿到 vi.mock 注入的对象（不是真实 App）。
     const getApp = async () => (await import("../../../App")).default as any
@@ -374,8 +374,12 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
 
     it("space_id absent: only calls /robot/my_bots, no /robot/space_bots", async () => {
         // 模拟用户未进入任何 space —— 老路径：只问 my_bots。
+        // 注意：自 #111 (YUJ-1964) 起 my_bots 也按 creator_uid 过滤，所以需要先登入。
+        const App = await getApp()
+        App.loginInfo.uid = "alice"
+
         hoisted.get.mockResolvedValueOnce([
-            { uid: "b1", name: "Bot 1" },
+            { uid: "b1", name: "Bot 1", creator_uid: "alice" },
         ])
         const vm = new PersonaSettingsVM()
         await vm.loadMyBots()
@@ -389,9 +393,11 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         App.shared.currentSpaceId = "spaceA"
         App.loginInfo.uid = "alice"
 
-        // my_bots 命中：用户已加好友的 bot
+        // my_bots 命中：用户已加好友的 bot（含 alice 创建 + 别人创建）。
+        // #111 (YUJ-1964): 别人创建的（friend_other）必须被过滤掉。
         hoisted.get.mockResolvedValueOnce([
-            { uid: "friend_bot", name: "FriendBot" },
+            { uid: "friend_bot", name: "FriendBot", creator_uid: "alice" },
+            { uid: "friend_other", name: "FriendOther", creator_uid: "bob" },
         ])
         // space_bots 命中：包含 alice 创建的 + 别人创建的；只有 alice 创建的应进入 picker
         hoisted.get.mockResolvedValueOnce([
@@ -406,8 +412,31 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         expect(hoisted.get).toHaveBeenCalledWith("/robot/space_bots", { param: { space_id: "spaceA" } })
 
         const uids = vm.myBots.map((b) => b.uid).sort()
-        // friend_bot 来自 my_bots; owned_bot 来自 space_bots(creator=alice); other_bot 被过滤掉
+        // friend_bot 来自 my_bots (creator=alice); owned_bot 来自 space_bots (creator=alice);
+        // friend_other / other_bot 都被 creator_uid 过滤掉。
         expect(uids).toEqual(["friend_bot", "owned_bot"])
+    })
+
+    it("#111 (YUJ-1964): filters my_bots entries NOT created by current user", async () => {
+        // 复现 bug：用户加了好友的 bot（创建者是别人）不应出现在「新建分身」picker。
+        // 老实现把整个 my_bots 列表灌进 picker，导致用户能选到别人的 bot 当作分身。
+        const App = await getApp()
+        App.shared.currentSpaceId = "spaceA"
+        App.loginInfo.uid = "alice"
+
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "mine_friend", name: "MineFriend", creator_uid: "alice" },
+            { uid: "bob_bot", name: "BobBot", creator_uid: "bob" },
+            { uid: "carol_bot", name: "CarolBot", creator_uid: "carol" },
+            { uid: "legacy_no_creator", name: "LegacyNoCreator" }, // 兜底：缺 creator_uid 视为非自有
+        ])
+        hoisted.get.mockResolvedValueOnce([]) // space_bots 此处无关
+
+        const vm = new PersonaSettingsVM()
+        await vm.loadMyBots()
+
+        // 只有 mine_friend (creator=alice) 通过；别人创建的 + 缺字段的全部剔除。
+        expect(vm.myBots.map((b) => b.uid)).toEqual(["mine_friend"])
     })
 
     it("filters out bots already granted to a persona", async () => {
@@ -416,8 +445,8 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         App.loginInfo.uid = "alice"
 
         hoisted.get.mockResolvedValueOnce([
-            { uid: "b1", name: "Bot 1" },
-            { uid: "b2", name: "Bot 2" },
+            { uid: "b1", name: "Bot 1", creator_uid: "alice" },
+            { uid: "b2", name: "Bot 2", creator_uid: "alice" },
         ])
         hoisted.get.mockResolvedValueOnce([
             { uid: "b3", name: "Bot 3", creator_uid: "alice" },
@@ -437,9 +466,9 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         App.shared.currentSpaceId = "spaceA"
         App.loginInfo.uid = "alice"
 
-        // 同一个 bot 同时在 my_bots（已加好友）和 space_bots（alice 创建）出现 —— 必须去重。
+        // 同一个 bot 同时在 my_bots（alice 创建 + 已加好友）和 space_bots（alice 创建）出现 —— 必须去重。
         hoisted.get.mockResolvedValueOnce([
-            { uid: "shared_bot", name: "Shared (from my_bots)" },
+            { uid: "shared_bot", name: "Shared (from my_bots)", creator_uid: "alice" },
         ])
         hoisted.get.mockResolvedValueOnce([
             { uid: "shared_bot", name: "Shared (from space_bots)", creator_uid: "alice" },
@@ -469,13 +498,13 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         expect(vm.myBots.map((b) => b.uid)).toEqual(["owned_only"])
     })
 
-    it("space_bots fails: still returns my_bots", async () => {
+    it("space_bots fails: still returns owned my_bots", async () => {
         const App = await getApp()
         App.shared.currentSpaceId = "spaceA"
         App.loginInfo.uid = "alice"
 
         hoisted.get.mockResolvedValueOnce([
-            { uid: "friend_only", name: "FriendOnly" },
+            { uid: "friend_only", name: "FriendOnly", creator_uid: "alice" },
         ])
         hoisted.get.mockRejectedValueOnce({ status: 500, msg: "space_bots boom" })
 
@@ -506,14 +535,16 @@ describe("PersonaSettingsVM.loadMyBots — Bug 3 (YUJ-1444): merges my_bots + ow
         App.shared.currentSpaceId = "spaceA"
         App.loginInfo.uid = ""
 
-        hoisted.get.mockResolvedValueOnce([])
+        hoisted.get.mockResolvedValueOnce([
+            { uid: "friend_bot", name: "FriendBot", creator_uid: "alice" },
+        ])
         hoisted.get.mockResolvedValueOnce([
             { uid: "owned_bot", name: "OwnedBot", creator_uid: "alice" },
         ])
 
         const vm = new PersonaSettingsVM()
         await vm.loadMyBots()
-        // creator_uid 过滤无法判断「是不是我」→ 整段 ownedSpaceBots 留空，picker 空态。
+        // creator_uid 过滤无法判断「是不是我」→ 两端的 owned 集合都留空，picker 空态。
         expect(vm.myBots).toEqual([])
     })
 })

--- a/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
@@ -68,8 +68,8 @@ export interface OboScope {
 /**
  * MyBot — 用于「新建分身」时选择关联 bot 的下拉数据源。
  *
- * 数据来源（YUJ-1444, 2026-05-20 后）：
- *   - `/robot/my_bots`     —— 当前用户已加好友的 bot（含 botfather 撮合的 + 自动加好友的）
+ * 数据来源（YUJ-1444, 2026-05-20 后；#111/YUJ-1964, 2026-05-25 收紧）：
+ *   - `/robot/my_bots`     —— 当前用户已加好友的 bot（仅取 creator_uid===me 的「我创建的」）
  *   - `/robot/space_bots`  —— 当前 space 的 bot（仅取 creator_uid===me 的「我创建的」）
  * 两端结果按 uid 合并去重，再剔除已经绑定 grant 的 uid。详见 loadMyBots()。
  */
@@ -182,6 +182,12 @@ export class PersonaSettingsVM extends ProviderListener {
      *   (b) 用户创建但未加好友（im-test 常见情况）→ 通过 space_bots + creator_uid
      *       兜底进入 picker
      *
+     * BUG (octo-web#111 / YUJ-1964, 2026-05-25)：上面 (a) 的「旧路径不变」会把
+     * `/robot/my_bots` 里**别人创建的**好友 bot（botfather 撮合后双向加好友的、
+     * 别人发的 bot 名片接受了的）也灌进 picker，让用户能把别人的 bot 错绑成自己
+     * 的分身。修复：对 `myBotsRaw` 也加 `creator_uid === myUid` 过滤，与
+     * space_bots 同款门槛——picker 永远只列「我创建的 bot」。
+     *
      * 错误降级：任一端点失败都用空数组兜底；两端都失败时 myBots=[]，UI 仍正确显示
      * 「暂无可关联的 Bot」。不对单独失败弹 Toast —— 这是「设置子页」，picker 空时
      * 用户能从文案得知，比 Toast 干扰更小；同时打 console.warn 便于线上排查。
@@ -219,6 +225,18 @@ export class PersonaSettingsVM extends ProviderListener {
             const myBotsRaw: any[] = Array.isArray(myRes) ? myRes : []
             const spaceBotsRaw: any[] = Array.isArray(spaceRes) ? spaceRes : []
 
+            // BUG (octo-web#111, YUJ-1964)：`/robot/my_bots` 返回当前用户**已加好友**
+            // 的所有 bot —— 包含别人创建的 bot（被 botfather 撮合自动加好友），
+            // 不只是「我创建的」。picker 必须只显示当前用户自己创建的 bot，否则
+            // 用户会误绑定别人的 bot 当作自己的分身。
+            // 修复：与 space_bots 同样按 `creator_uid === myUid` 过滤。后端已返回
+            // creator_uid 字段（与 BotStore.BotInfo 命名一致），不需要改后端。
+            const ownedMyBots = myUid
+                ? myBotsRaw.filter(
+                      (b) => b && typeof b === "object" && (b as any).creator_uid === myUid,
+                  )
+                : []
+
             // space_bots 包含整个 space 的 bot：只取「当前用户创建的」，避免把别人的
             // bot 列出来让用户误绑定。creator_uid 字段命名与 BotStore.BotInfo 一致。
             const ownedSpaceBots = myUid
@@ -229,7 +247,7 @@ export class PersonaSettingsVM extends ProviderListener {
 
             // 合并 + 去重（按 uid，先到先得；my_bots 优先因为已加好友的元数据更完整）。
             const merged = new Map<string, MyBot>()
-            for (const b of [...myBotsRaw, ...ownedSpaceBots]) {
+            for (const b of [...ownedMyBots, ...ownedSpaceBots]) {
                 if (!b || typeof b !== "object") continue
                 const uid = (b as any).uid
                 if (!uid || merged.has(uid)) continue


### PR DESCRIPTION
## Why
Bot picker (新建分身 → bot picker) listed bots created by other users that the current user had merely befriended (e.g. botfather match-ups, accepted bot business cards). Users could mistakenly bind someone else's bot as their own persona.

## What
`loadMyBots()` merged two sources:
1. `/robot/my_bots` — every befriended bot, **no creator filter** ❌
2. `/robot/space_bots` — already filtered by `creator_uid === myUid` ✅

Apply the same `creator_uid === myUid` guard to `myBotsRaw` that already exists for `spaceBotsRaw`. Backend already returns `creator_uid` on `/robot/my_bots` — no server change needed.

## Tests
- `vm.test.ts`: existing fixtures get `creator_uid: "alice"` so they pass the new filter; new regression test mixes alice/bob/carol bots in `my_bots` and asserts only alice's survive.
- `PersonaCreate.test.tsx`: `loginInfo.uid = "me"` and bot fixtures carry `creator_uid: "me"`.
- All 39 `loadMyBots`-related tests pass (1 unrelated pre-existing failure in `toggleGlobal` baseline, untouched).

Closes #111