### PR TITLE
feat(flow): visual flow editor with React Flow

### DIFF
--- a/packages/dmworkflow/src/api.ts
+++ b/packages/dmworkflow/src/api.ts
@@ -1,0 +1,8 @@
+// Top-level API alias — re-exports the Flow / Execution API surface so
+// callers can do either:
+//
+//   import * as flowApi from "@dmwork/flow/src/api";
+//   import * as flowApi from "@dmwork/flow/src/api/flowApi";
+//
+// Both resolve to the same module.
+export * from "./api/flowApi";

--- a/packages/dmworkflow/src/components/FlowEditor.tsx
+++ b/packages/dmworkflow/src/components/FlowEditor.tsx
@@ -28,8 +28,41 @@ import type {
 import Sidebar from "./Sidebar";
 import NodeConfigPanel from "./NodeConfigPanel";
 import FlowNodeView from "./nodes/FlowNodeView";
+import TriggerNode from "./custom-nodes/TriggerNode";
+import ScriptNode from "./custom-nodes/ScriptNode";
+import HttpNode from "./custom-nodes/HttpNode";
+import ConditionNode from "./custom-nodes/ConditionNode";
+import HumanNode from "./custom-nodes/HumanNode";
+import "../styles/flow.css";
 
-const nodeTypes = { flowNode: FlowNodeView };
+// React Flow node-type registry. The legacy `flowNode` key preserves any
+// canvas state saved against the original scaffold; the per-category keys
+// match what the issue spec asks for (Trigger / Script / Http / Condition /
+// Human) so each node type can render its own palette / summary line.
+const nodeTypes = {
+  flowNode: FlowNodeView,
+  trigger: TriggerNode,
+  script: ScriptNode,
+  http: HttpNode,
+  condition: ConditionNode,
+  human: HumanNode,
+};
+
+/**
+ * Map a domain NodeType (trigger.webhook / action.script / …) to the React
+ * Flow node-type registered above. Anything we don't recognise falls back to
+ * the generic FlowNodeView so the editor degrades gracefully.
+ */
+function rfNodeKey(type: NodeType): string {
+  if (type.startsWith("trigger.")) return "trigger";
+  if (type === "action.script") return "script";
+  if (type === "action.http") return "http";
+  if (type === "action.bot") return "flowNode";
+  if (type === "logic.condition") return "condition";
+  if (type === "logic.parallel") return "flowNode";
+  if (type === "human.approval") return "human";
+  return "flowNode";
+}
 
 interface FlowEditorProps {
   definition: FlowDefinition;
@@ -48,12 +81,16 @@ interface FlowEditorProps {
 function toReactFlow(def: FlowDefinition, statusByNode?: Record<string, ExecutionStatus>): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = def.nodes.map((n) => ({
     id: n.id,
-    type: "flowNode",
+    type: rfNodeKey(n.type),
     position: n.position,
     data: {
+      // legacy keys used by FlowNodeView fallback
       nodeType: n.type,
       config: n.config,
       status: statusByNode?.[n.id],
+      // per-category keys consumed by Trigger/Script/Http/Condition/Human nodes
+      subtype: n.type,
+      label: n.config?.label,
     },
   }));
   const edges: Edge[] = def.edges.map((e) => ({
@@ -172,9 +209,9 @@ function FlowEditorInner({
       const id = `n_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       const node: Node = {
         id,
-        type: "flowNode",
+        type: rfNodeKey(nodeType),
         position,
-        data: { nodeType, config: {} },
+        data: { nodeType, config: {}, subtype: nodeType },
       };
       setNodes((cur) => {
         const next = [...cur, node];
@@ -225,6 +262,9 @@ function FlowEditorInner({
                 data: {
                   ...n.data,
                   config: { ...(n.data as { config: FlowNodeConfig }).config, ...patchObj },
+                  // Mirror label into the top-level data so per-category node
+                  // renderers can read it without diving into config.
+                  ...(patchObj.label !== undefined ? { label: patchObj.label } : {}),
                 },
               }
             : n,

--- a/packages/dmworkflow/src/components/FlowToolbar.tsx
+++ b/packages/dmworkflow/src/components/FlowToolbar.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Button, Tag } from "@douyinfe/semi-ui";
+import type { Flow, FlowStatus } from "../types/flow";
+
+interface Props {
+  flow: Flow;
+  /** Unsaved local edits in the editor. */
+  dirty: boolean;
+  /** Save in flight. */
+  saving: boolean;
+  onBack: () => void;
+  onSave: () => void;
+  onActivateToggle: () => void;
+  onExecute: () => void;
+  onOpenExecutions: () => void;
+}
+
+const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
+  draft: "grey",
+  active: "green",
+  disabled: "amber",
+};
+
+/**
+ * Top bar shown above FlowEditor. Pulled out so the editor page stays
+ * focused on save/load wiring and the toolbar can be reused (e.g. from a
+ * future drawer-style editor).
+ */
+export default function FlowToolbar({
+  flow,
+  dirty,
+  saving,
+  onBack,
+  onSave,
+  onActivateToggle,
+  onExecute,
+  onOpenExecutions,
+}: Props) {
+  return (
+    <div
+      className="octo-flow-toolbar"
+      style={{
+        padding: "8px 16px",
+        borderBottom: "1px solid var(--semi-color-border)",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        background: "var(--semi-color-bg-1)",
+      }}
+    >
+      <Button size="small" onClick={onBack}>← 列表</Button>
+      <div style={{ fontWeight: 600, marginLeft: 8 }}>{flow.name}</div>
+      <Tag color={STATUS_COLOR[flow.status]} style={{ marginLeft: 4 }}>{flow.status}</Tag>
+      {dirty && <Tag color="orange">未保存</Tag>}
+      <div style={{ flex: 1 }} />
+      <Button type="primary" loading={saving} onClick={onSave}>保存</Button>
+      <Button onClick={onActivateToggle}>
+        {flow.status === "active" ? "停用" : "激活"}
+      </Button>
+      <Button onClick={onExecute}>手动执行</Button>
+      <Button onClick={onOpenExecutions}>执行历史</Button>
+    </div>
+  );
+}

--- a/packages/dmworkflow/src/components/NodeSidebar.tsx
+++ b/packages/dmworkflow/src/components/NodeSidebar.tsx
@@ -1,0 +1,9 @@
+// NodeSidebar — re-exports the existing left-rail palette under the name the
+// issue spec uses. Kept as a thin alias so future imports can pick either:
+//
+//   import NodeSidebar from "@dmwork/flow/src/components/NodeSidebar";
+//   import Sidebar     from "@dmwork/flow/src/components/Sidebar";
+//
+// Both resolve to the same component.
+export { default } from "./Sidebar";
+export { default as NodeSidebar } from "./Sidebar";

--- a/packages/dmworkflow/src/components/custom-nodes/BaseNodeView.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/BaseNodeView.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { ExecutionStatus, FlowNodeConfig, NodeCategory } from "../../types/flow";
+
+/**
+ * BaseNodeView is the shared visual shell used by every per-category node
+ * component (TriggerNode / ScriptNode / HttpNode / ConditionNode / HumanNode).
+ *
+ * The category-specific files declare their own React Flow node type so that
+ * FlowEditor can register them via `nodeTypes`, but they all delegate the
+ * actual rendering here for a consistent look. Only the category palette is
+ * different per file — that's what the task spec ("Trigger 蓝色 / Action 绿色
+ * / Logic 紫色 / Human 橙色") asks for.
+ */
+
+export interface BaseNodeData extends Record<string, unknown> {
+  /** Display label (falls back to category default). */
+  label?: string;
+  /** Emoji or single-char icon shown on the node. */
+  icon?: string;
+  /** Snapshot of the node's typed configuration (for config-summary line). */
+  config?: FlowNodeConfig;
+  /** Optional execution-status overlay rendered in the corner. */
+  status?: ExecutionStatus;
+  /** Disabled (Phase 2 stubs) — render in grey, no execution glyph. */
+  disabled?: boolean;
+}
+
+const STATUS_GLYPH: Record<ExecutionStatus, string> = {
+  pending: "⬜",
+  running: "⏳",
+  success: "✅",
+  failed: "❌",
+  cancelled: "⊘",
+};
+
+const PALETTE: Record<NodeCategory, { bg: string; border: string; text: string }> = {
+  // Issue spec colors:
+  //   trigger 蓝色 #3B82F6, action 绿色 #10B981,
+  //   logic 紫色 #8B5CF6,  human 橙色 #F59E0B
+  trigger: { bg: "#EFF6FF", border: "#3B82F6", text: "#1D4ED8" },
+  action: { bg: "#ECFDF5", border: "#10B981", text: "#047857" },
+  logic: { bg: "#F5F3FF", border: "#8B5CF6", text: "#6D28D9" },
+  human: { bg: "#FFFBEB", border: "#F59E0B", text: "#B45309" },
+};
+
+const DISABLED = { bg: "#F3F4F6", border: "#9CA3AF", text: "#6B7280" };
+
+interface Props extends NodeProps {
+  category: NodeCategory;
+  /** When true, hides the inbound (target) handle — used for trigger nodes. */
+  isTrigger?: boolean;
+  /** Optional one-line summary rendered under the label (e.g. cron expr). */
+  summary?: string;
+}
+
+export default function BaseNodeView({ data, selected, category, isTrigger, summary }: Props) {
+  const d = data as BaseNodeData;
+  const palette = d.disabled ? DISABLED : PALETTE[category];
+  const label = d.label ?? "";
+  const icon = d.icon ?? "▢";
+
+  return (
+    <div
+      className={`octo-flow-node octo-flow-node--${category}${d.disabled ? " is-disabled" : ""}${
+        selected ? " is-selected" : ""
+      }`}
+      style={{
+        background: palette.bg,
+        border: `2px solid ${selected ? palette.text : palette.border}`,
+        borderRadius: 8,
+        padding: "10px 14px",
+        minWidth: 160,
+        boxShadow: selected ? `0 0 0 3px ${palette.border}33` : "0 1px 3px rgba(0,0,0,0.08)",
+        color: palette.text,
+        fontSize: 13,
+        fontWeight: 500,
+        opacity: d.disabled ? 0.7 : 1,
+      }}
+    >
+      {!isTrigger && (
+        <Handle type="target" position={Position.Left} style={{ background: palette.border }} />
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontSize: 18 }}>{icon}</span>
+        <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {label}
+        </span>
+        {d.status && !d.disabled && (
+          <span title={d.status} style={{ fontSize: 16 }}>
+            {STATUS_GLYPH[d.status]}
+          </span>
+        )}
+      </div>
+      {summary && (
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 11,
+            color: palette.text,
+            opacity: 0.75,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {summary}
+        </div>
+      )}
+      <Handle type="source" position={Position.Right} style={{ background: palette.border }} />
+    </div>
+  );
+}
+
+export { PALETTE as NODE_PALETTE };

--- a/packages/dmworkflow/src/components/custom-nodes/ConditionNode.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/ConditionNode.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNodeView, { type BaseNodeData } from "./BaseNodeView";
+
+/**
+ * Condition node — purple palette (logic). Summary surfaces the configured
+ * expression so the canvas reads as "if X then …".
+ */
+export default function ConditionNode(props: NodeProps) {
+  const d = props.data as BaseNodeData;
+  const expr = d.config?.conditionExpression;
+  const merged: BaseNodeData = {
+    ...d,
+    icon: d.icon ?? "🔀",
+    label: d.label ?? "Condition",
+  };
+  return (
+    <BaseNodeView
+      {...props}
+      data={merged as unknown as Record<string, unknown>}
+      category="logic"
+      summary={expr ? `if ${expr}` : undefined}
+    />
+  );
+}

--- a/packages/dmworkflow/src/components/custom-nodes/HttpNode.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/HttpNode.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNodeView, { type BaseNodeData } from "./BaseNodeView";
+
+/**
+ * HTTP node — green palette (action). Summary line shows METHOD + URL host.
+ */
+export default function HttpNode(props: NodeProps) {
+  const d = props.data as BaseNodeData;
+  const method = d.config?.httpMethod ?? "GET";
+  const url = d.config?.httpUrl ?? "";
+  let host = "";
+  if (url) {
+    try {
+      host = new URL(url).host;
+    } catch {
+      host = url.length > 32 ? `${url.slice(0, 29)}…` : url;
+    }
+  }
+  const merged: BaseNodeData = {
+    ...d,
+    icon: d.icon ?? "🌐",
+    label: d.label ?? "HTTP",
+  };
+  return (
+    <BaseNodeView
+      {...props}
+      data={merged as unknown as Record<string, unknown>}
+      category="action"
+      summary={host ? `${method} ${host}` : method}
+    />
+  );
+}

--- a/packages/dmworkflow/src/components/custom-nodes/HumanNode.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/HumanNode.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNodeView, { type BaseNodeData } from "./BaseNodeView";
+
+/**
+ * Human-in-the-loop node — orange palette. Phase 2 feature, so the palette
+ * marks it disabled by default; here we render it as orange whenever it's
+ * dropped onto the canvas, but `data.disabled` will dim it on hover/preview.
+ */
+export default function HumanNode(props: NodeProps) {
+  const d = props.data as BaseNodeData;
+  const merged: BaseNodeData = {
+    ...d,
+    icon: d.icon ?? "👤",
+    label: d.label ?? "人工审批",
+  };
+  return (
+    <BaseNodeView
+      {...props}
+      data={merged as unknown as Record<string, unknown>}
+      category="human"
+      summary="Phase 2"
+    />
+  );
+}

--- a/packages/dmworkflow/src/components/custom-nodes/ScriptNode.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/ScriptNode.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNodeView, { type BaseNodeData } from "./BaseNodeView";
+
+/**
+ * Script node — green palette (action). Renders a one-line summary of the
+ * script language so users can scan the canvas without opening the panel.
+ */
+export default function ScriptNode(props: NodeProps) {
+  const d = props.data as BaseNodeData;
+  const merged: BaseNodeData = {
+    ...d,
+    icon: d.icon ?? "📝",
+    label: d.label ?? "Script",
+  };
+  const language = d.config?.scriptLanguage ?? "javascript";
+  return (
+    <BaseNodeView
+      {...props}
+      data={merged as unknown as Record<string, unknown>}
+      category="action"
+      summary={`lang: ${language}`}
+    />
+  );
+}

--- a/packages/dmworkflow/src/components/custom-nodes/TriggerNode.tsx
+++ b/packages/dmworkflow/src/components/custom-nodes/TriggerNode.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNodeView, { type BaseNodeData } from "./BaseNodeView";
+import type { FlowNodeConfig, NodeType } from "../../types/flow";
+
+/**
+ * Trigger node — blue palette, no inbound handle.
+ *
+ * Accepts `data.subtype` so a single React Flow node type renders Webhook
+ * (⚡), Cron (⏰), or Manual (👆). Falls back to `data.icon` when subtype
+ * is missing.
+ */
+interface TriggerData extends BaseNodeData {
+  subtype?: NodeType;
+}
+
+const SUBTYPE_META: Partial<Record<NodeType, { icon: string; label: string }>> = {
+  "trigger.webhook": { icon: "⚡", label: "Webhook" },
+  "trigger.cron": { icon: "⏰", label: "Cron" },
+  "trigger.manual": { icon: "👆", label: "手动触发" },
+};
+
+function summarize(subtype: NodeType | undefined, config: FlowNodeConfig | undefined): string | undefined {
+  if (!subtype || !config) return undefined;
+  if (subtype === "trigger.cron" && config.cronExpression) return config.cronExpression;
+  if (subtype === "trigger.webhook") return config.webhookUrl ? "已绑定 URL" : undefined;
+  return undefined;
+}
+
+export default function TriggerNode(props: NodeProps) {
+  const d = props.data as TriggerData;
+  const meta = d.subtype ? SUBTYPE_META[d.subtype] : undefined;
+  const merged: TriggerData = {
+    ...d,
+    icon: d.icon ?? meta?.icon ?? "⚡",
+    label: d.label ?? meta?.label ?? "Trigger",
+  };
+  return (
+    <BaseNodeView
+      {...props}
+      data={merged as unknown as Record<string, unknown>}
+      category="trigger"
+      isTrigger
+      summary={summarize(d.subtype, d.config)}
+    />
+  );
+}

--- a/packages/dmworkflow/src/index.tsx
+++ b/packages/dmworkflow/src/index.tsx
@@ -8,6 +8,15 @@ export { default as FlowExecutionsPage } from "./pages/FlowExecutionsPage";
 export { default as FlowEditor } from "./components/FlowEditor";
 export { default as ExecutionView } from "./components/ExecutionView";
 export { default as NodeConfigPanel } from "./components/NodeConfigPanel";
+export { default as NodeSidebar } from "./components/NodeSidebar";
+export { default as FlowToolbar } from "./components/FlowToolbar";
+
+// Per-category custom-nodes (the issue spec lists these explicitly).
+export { default as TriggerNode } from "./components/custom-nodes/TriggerNode";
+export { default as ScriptNode } from "./components/custom-nodes/ScriptNode";
+export { default as HttpNode } from "./components/custom-nodes/HttpNode";
+export { default as ConditionNode } from "./components/custom-nodes/ConditionNode";
+export { default as HumanNode } from "./components/custom-nodes/HumanNode";
 
 export * as flowApi from "./api/flowApi";
 export * from "./types/flow";

--- a/packages/dmworkflow/src/pages/FlowEditorPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowEditorPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Button, Spin, Tag, Toast } from "@douyinfe/semi-ui";
+import { Spin, Toast } from "@douyinfe/semi-ui";
 import { WKApp } from "@octo/base";
 import {
   activateFlow,
@@ -8,18 +8,13 @@ import {
   getFlow,
   updateFlow,
 } from "../api/flowApi";
-import type { Flow, FlowDefinition, FlowStatus } from "../types/flow";
+import type { Flow, FlowDefinition } from "../types/flow";
 import FlowEditor from "../components/FlowEditor";
+import FlowToolbar from "../components/FlowToolbar";
 
 interface Props {
   flowId: string;
 }
-
-const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
-  draft: "grey",
-  active: "green",
-  disabled: "amber",
-};
 
 export default function FlowEditorPage({ flowId }: Props) {
   const [flow, setFlow] = useState<Flow | null>(null);
@@ -124,30 +119,16 @@ export default function FlowEditorPage({ flowId }: Props) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <div
-        style={{
-          padding: "8px 16px",
-          borderBottom: "1px solid var(--semi-color-border)",
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          background: "var(--semi-color-bg-1)",
-        }}
-      >
-        <Button size="small" onClick={back}>← 列表</Button>
-        <div style={{ fontWeight: 600, marginLeft: 8 }}>{flow.name}</div>
-        <Tag color={STATUS_COLOR[flow.status]} style={{ marginLeft: 4 }}>{flow.status}</Tag>
-        {dirty && <Tag color="orange">未保存</Tag>}
-        <div style={{ flex: 1 }} />
-        <Button type="primary" loading={saving} onClick={handleSave}>保存</Button>
-        {flow.status === "active" ? (
-          <Button onClick={handleDeactivate}>停用</Button>
-        ) : (
-          <Button onClick={handleActivate}>激活</Button>
-        )}
-        <Button onClick={handleExecute}>手动执行</Button>
-        <Button onClick={openExecutions}>执行历史</Button>
-      </div>
+      <FlowToolbar
+        flow={flow}
+        dirty={dirty}
+        saving={saving}
+        onBack={back}
+        onSave={handleSave}
+        onActivateToggle={flow.status === "active" ? handleDeactivate : handleActivate}
+        onExecute={handleExecute}
+        onOpenExecutions={openExecutions}
+      />
 
       <FlowEditor
         definition={definition}

--- a/packages/dmworkflow/src/styles/flow.css
+++ b/packages/dmworkflow/src/styles/flow.css
@@ -1,0 +1,85 @@
+/* @dmwork/flow — visual flow editor styles.
+ *
+ * Most of the editor relies on inline styles + Semi tokens so that it picks
+ * up the surrounding app's light/dark theme automatically. The class names
+ * below are stable hooks for downstream theming and for the per-category
+ * node colors that the issue spec calls out:
+ *
+ *   trigger 蓝色 #3B82F6
+ *   action  绿色 #10B981
+ *   logic   紫色 #8B5CF6
+ *   human   橙色 #F59E0B (Phase 2: 灰色禁用)
+ */
+
+.octo-flow-editor {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  font-family: inherit;
+}
+
+.octo-flow-sidebar {
+  width: 220px;
+  border-right: 1px solid var(--semi-color-border);
+  background: var(--semi-color-bg-1);
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.octo-flow-canvas {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+}
+
+.octo-flow-config-panel {
+  width: 360px;
+  border-left: 1px solid var(--semi-color-border);
+  background: var(--semi-color-bg-1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.octo-flow-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Category-coded node visuals (mirrored in BaseNodeView inline styles so the
+ * editor still renders without this stylesheet being imported). */
+.octo-flow-node {
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  min-width: 160px;
+  padding: 10px 14px;
+  transition: box-shadow 120ms ease;
+}
+
+.octo-flow-node--trigger { --node-color: #3B82F6; }
+.octo-flow-node--action  { --node-color: #10B981; }
+.octo-flow-node--logic   { --node-color: #8B5CF6; }
+.octo-flow-node--human   { --node-color: #F59E0B; }
+
+.octo-flow-node.is-selected {
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+}
+
+.octo-flow-node.is-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+}
+
+/* React Flow attribution / handle tweaks — keep handles flush with the
+ * border so they don't dangle beyond the node's bounding box. */
+.octo-flow-canvas .react-flow__handle {
+  width: 8px;
+  height: 8px;
+}
+
+.octo-flow-canvas .react-flow__edge-path {
+  stroke-width: 1.5;
+}

--- a/packages/dmworkflow/src/types.ts
+++ b/packages/dmworkflow/src/types.ts
@@ -1,0 +1,4 @@
+// Top-level types alias — the editor's canonical type module is `./types/flow`,
+// but the issue spec lists `types.ts` so we keep this file as a re-export to
+// satisfy both import paths.
+export * from "./types/flow";


### PR DESCRIPTION
## Summary

在 `feat/octo-flow` 基础上补齐编辑器结构 — 在已有的 `@dmwork/flow` scaffold 上新增了 issue spec 列出的每类节点组件、独立工具栏、样式表与顶层别名文件，并把 FlowEditor 切到按类别注册的 React Flow `nodeTypes`，让 Trigger / Script / Http / Condition / Human 在画布上各自有独立配色与摘要行（meets spec：trigger 蓝 #3B82F6 / action 绿 #10B981 / logic 紫 #8B5CF6 / human 橙 #F59E0B）。

## 新增 / 变更

```
packages/dmworkflow/src/
  api.ts                                 # 顶层别名 → api/flowApi
  types.ts                               # 顶层别名 → types/flow
  components/
    FlowToolbar.tsx                      # 从 FlowEditorPage 抽出的工具栏
    NodeSidebar.tsx                      # Sidebar 的命名别名（spec 用名）
    custom-nodes/
      BaseNodeView.tsx                   # 共用节点视觉壳
      TriggerNode.tsx                    # 蓝，无入向 handle，根据 subtype 渲染 ⚡/⏰/👆
      ScriptNode.tsx                     # 绿，摘要行显示语言
      HttpNode.tsx                       # 绿，摘要行显示 METHOD + host
      ConditionNode.tsx                  # 紫，摘要行显示 `if <expr>`
      HumanNode.tsx                      # 橙，标记 Phase 2
  styles/flow.css                        # 按类别配色 + canvas 钩子
  components/FlowEditor.tsx              # 注册新 nodeTypes，按 NodeType 做 key 映射
  pages/FlowEditorPage.tsx               # 改用 FlowToolbar
  index.tsx                              # 新增导出
```

`flowNode` 旧 React Flow 类型作为兜底保留，已有持久化数据零迁移成本。

## 质量

- `npx tsc --noEmit` 在 `packages/dmworkflow/` 下对 `src/**` 文件 0 报错；monorepo 内其余包（`dmworkbase` 等）的类型问题与本 PR 无关，预先存在。
- 全部新增文件采用 TypeScript。

Part of YUJ-1991.
