### PR TITLE
fix(flow): render editor in right pane, keep list compact on left

### DIFF
--- a/packages/dmworkflow/src/module.tsx
+++ b/packages/dmworkflow/src/module.tsx
@@ -6,18 +6,15 @@ import FlowEditorPage from "./pages/FlowEditorPage";
 import FlowExecutionsPage from "./pages/FlowExecutionsPage";
 
 /**
- * The WKApp router is a flat path → component map (see Service/Route.tsx).
- * It does not natively support `/flow/:id` style segment matching, so we
- * follow the existing module convention (e.g. SummaryModule registering
- * `/summary/detail` with a `taskId` param) and expose:
+ * octo-web is a three-pane shell: NavRail | left panel (~300 px) | right panel
+ * (the wide main area). Anything registered through `WKApp.route.register(...)`
+ * is rendered by `MainContentLeft` inside the narrow left panel — that fits
+ * list views (chats, contacts, summary list) but does NOT fit the Flow editor
+ * canvas.
  *
- *   /flow            — list page
- *   /flow/edit       — editor (param: { flowId })
- *   /flow/executions — execution history (param: { flowId })
- *   /flow/execution  — single-execution detail (param: { flowId, executionId })
- *
- * Cross-page navigation goes through WKApp.route.push(path, param). The
- * `:id` semantics from the issue spec are preserved as param keys.
+ * Following the SummaryModule pattern, we only register the list page on the
+ * left, and push the editor / execution-history pages to the right pane via
+ * `WKApp.routeRight.*`. This keeps the React Flow canvas full-width.
  */
 function FlowIcon({ active }: { active?: boolean }) {
   const color = active ? "var(--wk-brand-primary, #7C5CFC)" : "currentColor";
@@ -32,48 +29,63 @@ function FlowIcon({ active }: { active?: boolean }) {
   );
 }
 
+// ─── Right-pane navigation helpers ────────────────────────────────────────
+// Centralised so list / editor / executions pages all push to the same stack
+// with identical onBack semantics. Exposed on WKApp so external entries (e.g.
+// notifications, deeplinks) can drop straight into the editor.
+
+function openFlowEditor(flowId: string): void {
+  WKApp.switchToMenuById?.("flow");
+  WKApp.routeRight.replaceToRoot(
+    <FlowEditorPage
+      flowId={flowId}
+      onBack={() => WKApp.routeRight.popToRoot()}
+      onOpenExecutions={(id, executionId) => openFlowExecutions(id, executionId)}
+    />,
+  );
+}
+
+function openFlowExecutions(flowId: string, executionId?: string | null): void {
+  WKApp.switchToMenuById?.("flow");
+  WKApp.routeRight.push(
+    <FlowExecutionsPage
+      flowId={flowId}
+      executionId={executionId ?? null}
+      onBack={() => WKApp.routeRight.pop()}
+      onClose={() => WKApp.routeRight.popToRoot()}
+    />,
+  );
+}
+
+// Re-export so other modules can import without reaching into module internals.
+(WKApp as any).openFlowEditor = openFlowEditor;
+(WKApp as any).openFlowExecutions = openFlowExecutions;
+
 export class FlowModule implements IModule {
   id(): string {
     return "FlowModule";
   }
 
   init(): void {
-    WKApp.route.register("/flow", () => <FlowListPage />);
-
-    WKApp.route.register("/flow/edit", (param: { flowId?: string } | undefined) => {
-      const flowId = param?.flowId ?? "";
-      return <FlowEditorPage flowId={flowId} />;
-    });
-
-    WKApp.route.register("/flow/executions", (param: { flowId?: string; executionId?: string } | undefined) => {
-      return (
-        <FlowExecutionsPage
-          flowId={param?.flowId ?? ""}
-          executionId={param?.executionId ?? null}
-        />
-      );
-    });
-
-    WKApp.route.register("/flow/execution", (param: { flowId?: string; executionId?: string } | undefined) => {
-      return (
-        <FlowExecutionsPage
-          flowId={param?.flowId ?? ""}
-          executionId={param?.executionId ?? null}
-        />
-      );
-    });
+    // Only the list lives on the left. The editor / executions pages are
+    // pushed to the right pane via the helpers above so they get the full
+    // canvas width that React Flow needs.
+    WKApp.route.register("/flow", () => (
+      <FlowListPage
+        onOpenEditor={openFlowEditor}
+        onOpenExecutions={(id) => openFlowExecutions(id)}
+      />
+    ));
 
     // Top-level nav entry, weight chosen to sit after summary (5000).
-    WKApp.menus.register("flow", (_ctx) => {
-      const m = new Menus("flow", "/flow", "Flow", <FlowIcon />, <FlowIcon />);
-      m.onPress = () => {
-        WKApp.routeLeft.popToRoot();
-        const page = WKApp.route.get("/flow");
-        if (page && React.isValidElement(page)) {
-          WKApp.routeRight.replaceToRoot(page);
-        }
-      };
-      return m;
-    }, 6000);
+    // No onPress override — the default in MainPage.onMenuClick already does
+    // `routeLeft.popToRoot() + routeRight.popToRoot()`, which is exactly what
+    // we want: show the list on the left and clear any stale editor on the
+    // right.
+    WKApp.menus.register(
+      "flow",
+      (_ctx) => new Menus("flow", "/flow", "Flow", <FlowIcon />, <FlowIcon />),
+      6000,
+    );
   }
 }

--- a/packages/dmworkflow/src/pages/FlowEditorPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowEditorPage.tsx
@@ -10,9 +10,14 @@ import {
 } from "../api/flowApi";
 import type { Flow, FlowDefinition, FlowStatus } from "../types/flow";
 import FlowEditor from "../components/FlowEditor";
+import FlowExecutionsPage from "./FlowExecutionsPage";
 
 interface Props {
   flowId: string;
+  /** Invoked when the user clicks the back button. Defaults to closing the right pane. */
+  onBack?: () => void;
+  /** Invoked to open the executions page for this flow. Defaults to right-pane push. */
+  onOpenExecutions?: (flowId: string, executionId?: string | null) => void;
 }
 
 const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
@@ -21,7 +26,7 @@ const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
   disabled: "amber",
 };
 
-export default function FlowEditorPage({ flowId }: Props) {
+export default function FlowEditorPage({ flowId, onBack, onOpenExecutions }: Props) {
   const [flow, setFlow] = useState<Flow | null>(null);
   const [definition, setDefinition] = useState<FlowDefinition>({ nodes: [], edges: [] });
   const [loading, setLoading] = useState(true);
@@ -96,7 +101,11 @@ export default function FlowEditorPage({ flowId }: Props) {
     try {
       const exec = await executeFlow(flow.id);
       Toast.success("已触发执行");
-      WKApp.route.push("/flow/execution", { flowId: flow.id, executionId: exec.id });
+      if (onOpenExecutions) {
+        onOpenExecutions(flow.id, exec.id);
+      } else {
+        WKApp.routeRight.push(<FlowExecutionsPage flowId={flow.id} executionId={exec.id} />);
+      }
     } catch (e) {
       Toast.error(`触发失败：${(e as Error).message}`);
     }
@@ -104,10 +113,20 @@ export default function FlowEditorPage({ flowId }: Props) {
 
   const openExecutions = () => {
     if (!flow) return;
-    WKApp.route.push("/flow/executions", { flowId: flow.id });
+    if (onOpenExecutions) {
+      onOpenExecutions(flow.id);
+    } else {
+      WKApp.routeRight.push(<FlowExecutionsPage flowId={flow.id} />);
+    }
   };
 
-  const back = () => WKApp.route.push("/flow");
+  const back = () => {
+    if (onBack) {
+      onBack();
+    } else {
+      WKApp.routeRight.popToRoot();
+    }
+  };
 
   if (loading || !flow) {
     return (

--- a/packages/dmworkflow/src/pages/FlowExecutionsPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowExecutionsPage.tsx
@@ -8,9 +8,13 @@ import ExecutionView from "../components/ExecutionView";
 interface Props {
   flowId: string;
   executionId?: string | null;
+  /** Return to the previous right-pane view (typically the editor). Defaults to `routeRight.pop()`. */
+  onBack?: () => void;
+  /** Close the right pane entirely and return to the list. Defaults to `routeRight.popToRoot()`. */
+  onClose?: () => void;
 }
 
-export default function FlowExecutionsPage({ flowId, executionId }: Props) {
+export default function FlowExecutionsPage({ flowId, executionId, onBack, onClose }: Props) {
   const [flow, setFlow] = useState<Flow | null>(null);
   const [loading, setLoading] = useState(true);
   const [active, setActive] = useState<string | null>(executionId ?? null);
@@ -51,10 +55,10 @@ export default function FlowExecutionsPage({ flowId, executionId }: Props) {
           background: "var(--semi-color-bg-1)",
         }}
       >
-        <Button size="small" onClick={() => WKApp.route.push("/flow/edit", { flowId })}>← 编辑器</Button>
+        <Button size="small" onClick={() => (onBack ? onBack() : WKApp.routeRight.pop())}>← 编辑器</Button>
         <div style={{ fontWeight: 600, marginLeft: 8 }}>{flow.name} · 执行历史</div>
         <div style={{ flex: 1 }} />
-        <Button size="small" onClick={() => WKApp.route.push("/flow")}>返回列表</Button>
+        <Button size="small" onClick={() => (onClose ? onClose() : WKApp.routeRight.popToRoot())}>返回列表</Button>
       </div>
       <ExecutionView flow={flow} activeExecutionId={active} onSelectExecution={setActive} />
     </div>

--- a/packages/dmworkflow/src/pages/FlowListPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowListPage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Button, Modal, Popconfirm, Spin, Table, Tag, Toast, Input } from "@douyinfe/semi-ui";
-import { IconPlus, IconRefresh } from "@douyinfe/semi-icons";
-import { WKApp } from "@octo/base";
+import { Button, Dropdown, Empty, Modal, Popconfirm, Spin, Tag, Toast, Input } from "@douyinfe/semi-ui";
+import { IconPlus, IconRefresh, IconMore } from "@douyinfe/semi-icons";
 import {
   activateFlow,
   createFlow,
@@ -25,7 +24,20 @@ const EXEC_COLOR: Record<ExecutionStatus, "grey" | "green" | "red" | "blue" | "o
   cancelled: "orange",
 };
 
-export default function FlowListPage() {
+interface Props {
+  /** Open a flow's editor in the right pane. */
+  onOpenEditor: (flowId: string) => void;
+  /** Open a flow's execution history in the right pane. */
+  onOpenExecutions: (flowId: string) => void;
+}
+
+/**
+ * Octo Flow list — rendered inside the ~300 px left panel. Layout is therefore
+ * compact: a single column of cards, with bulk actions tucked behind a kebab
+ * menu. Editor / executions navigation is delegated to callbacks so this page
+ * does not need to know that they live on the right pane.
+ */
+export default function FlowListPage({ onOpenEditor, onOpenExecutions }: Props) {
   const [flows, setFlows] = useState<Flow[]>([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -44,14 +56,6 @@ export default function FlowListPage() {
     load();
   }, [load]);
 
-  const openEditor = (id: string) => {
-    WKApp.route.push("/flow/edit", { flowId: id });
-  };
-
-  const openExecutions = (id: string) => {
-    WKApp.route.push("/flow/executions", { flowId: id });
-  };
-
   const handleCreate = async () => {
     const name = draftName.trim();
     if (!name) {
@@ -66,7 +70,9 @@ export default function FlowListPage() {
       });
       setCreateOpen(false);
       setDraftName("");
-      openEditor(flow.id);
+      // Optimistically prepend so the user sees it before the next reload.
+      setFlows((cur) => [flow, ...cur]);
+      onOpenEditor(flow.id);
     } catch (e) {
       Toast.error(`创建失败：${(e as Error).message}`);
     } finally {
@@ -94,74 +100,118 @@ export default function FlowListPage() {
     }
   };
 
+  const renderItem = (flow: Flow) => {
+    const lastExec = flow.last_execution_status as ExecutionStatus | null | undefined;
+    return (
+      <div
+        key={flow.id}
+        onClick={() => onOpenEditor(flow.id)}
+        style={{
+          padding: "10px 12px",
+          borderBottom: "1px solid var(--semi-color-border)",
+          cursor: "pointer",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontWeight: 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            title={flow.name}
+          >
+            {flow.name}
+          </div>
+          <Tag size="small" color={STATUS_COLOR[flow.status]}>{flow.status}</Tag>
+          <Dropdown
+            position="bottomRight"
+            trigger="click"
+            render={(
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => onOpenEditor(flow.id)}>编辑</Dropdown.Item>
+                <Dropdown.Item onClick={() => handleActivateToggle(flow)}>
+                  {flow.status === "active" ? "停用" : "激活"}
+                </Dropdown.Item>
+                <Dropdown.Item onClick={() => onOpenExecutions(flow.id)}>执行历史</Dropdown.Item>
+                <Dropdown.Divider />
+                <Popconfirm
+                  title="删除 Flow"
+                  content="确认删除该 Flow？此操作不可恢复。"
+                  onConfirm={() => handleDelete(flow)}
+                >
+                  <Dropdown.Item type="danger">删除</Dropdown.Item>
+                </Popconfirm>
+              </Dropdown.Menu>
+            )}
+          >
+            <Button
+              size="small"
+              theme="borderless"
+              icon={<IconMore />}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </Dropdown>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 12,
+            color: "var(--semi-color-text-2)",
+          }}
+        >
+          {lastExec ? (
+            <Tag size="small" color={EXEC_COLOR[lastExec]}>{lastExec}</Tag>
+          ) : (
+            <span>尚未执行</span>
+          )}
+          <span style={{ flex: 1 }} />
+          <span>{flow.created_at ? new Date(flow.created_at).toLocaleDateString() : ""}</span>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <div style={{ padding: 16, height: "100%", display: "flex", flexDirection: "column", boxSizing: "border-box" }}>
-      <div style={{ display: "flex", alignItems: "center", marginBottom: 12 }}>
-        <div style={{ fontSize: 18, fontWeight: 600, flex: 1 }}>Octo Flow</div>
-        <Button icon={<IconRefresh />} onClick={load} style={{ marginRight: 8 }}>刷新</Button>
-        <Button type="primary" icon={<IconPlus />} onClick={() => setCreateOpen(true)}>
-          新建 Flow
+    <div style={{ height: "100%", display: "flex", flexDirection: "column", boxSizing: "border-box" }}>
+      <div
+        style={{
+          padding: "10px 12px",
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          borderBottom: "1px solid var(--semi-color-border)",
+        }}
+      >
+        <div style={{ fontSize: 16, fontWeight: 600, flex: 1 }}>Octo Flow</div>
+        <Button size="small" icon={<IconRefresh />} onClick={load} aria-label="刷新" />
+        <Button size="small" type="primary" icon={<IconPlus />} onClick={() => setCreateOpen(true)}>
+          新建
         </Button>
       </div>
 
-      {loading ? (
-        <Spin />
-      ) : (
-        <Table
-          dataSource={flows}
-          rowKey="id"
-          pagination={false}
-          empty="暂无 Flow，点击右上角新建"
-          columns={[
-            {
-              title: "名称",
-              dataIndex: "name",
-              render: (name: string, flow: Flow) => (
-                <a onClick={() => openEditor(flow.id)} style={{ cursor: "pointer" }}>{name}</a>
-              ),
-            },
-            {
-              title: "状态",
-              dataIndex: "status",
-              width: 100,
-              render: (status: FlowStatus) => <Tag color={STATUS_COLOR[status]}>{status}</Tag>,
-            },
-            {
-              title: "最近执行",
-              dataIndex: "last_execution_status",
-              width: 140,
-              render: (status: ExecutionStatus | null | undefined) =>
-                status ? <Tag color={EXEC_COLOR[status]}>{status}</Tag> : <span style={{ color: "var(--semi-color-text-2)" }}>—</span>,
-            },
-            {
-              title: "创建时间",
-              dataIndex: "created_at",
-              width: 180,
-              render: (v: string) => (v ? new Date(v).toLocaleString() : "—"),
-            },
-            {
-              title: "操作",
-              width: 280,
-              render: (_: unknown, flow: Flow) => (
-                <div style={{ display: "flex", gap: 6 }}>
-                  <Button size="small" onClick={() => openEditor(flow.id)}>编辑</Button>
-                  <Button size="small" onClick={() => handleActivateToggle(flow)}>
-                    {flow.status === "active" ? "停用" : "激活"}
-                  </Button>
-                  <Button size="small" onClick={() => openExecutions(flow.id)}>执行历史</Button>
-                  <Popconfirm
-                    title="删除 Flow"
-                    content="确认删除该 Flow？此操作不可恢复。"
-                    onConfirm={() => handleDelete(flow)}
-                  >
-                    <Button size="small" type="danger">删除</Button>
-                  </Popconfirm>
-                </div>
-              ),
-            },
-          ]}
-        />
-      )}
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+        {loading ? (
+          <div style={{ padding: 24, textAlign: "center" }}>
+            <Spin />
+          </div>
+        ) : flows.length === 0 ? (
+          <Empty
+            style={{ paddingTop: 40 }}
+            description="暂无 Flow，点击右上角「新建」开始编排。"
+          />
+        ) : (
+          flows.map(renderItem)
+        )}
+      </div>
 
       <Modal
         title="新建 Flow"


### PR DESCRIPTION
Closes [YUJ-2032](https://multica.app/issues/YUJ-2032)

## Problem

`packages/dmworkflow/src/module.tsx` registered `/flow`, `/flow/edit`,
`/flow/executions` and `/flow/execution` all through `WKApp.route.register`,
which means `MainContentLeft` rendered every page — including the React Flow
editor canvas — inside the ~300 px left pane. The list and the editor were
stacked in the same narrow column and the canvas was unusable.

## Fix

Mirror the `SummaryModule` pattern: list on the left, detail/editor on the right.

- **module.tsx**: only `/flow` is registered for the left pane. Editor and
  executions navigation goes through new helpers (`openFlowEditor` /
  `openFlowExecutions`) that call `WKApp.routeRight.replaceToRoot(...)` and
  `WKApp.routeRight.push(...)`. The menu's `onPress` override was dropped —
  the default `onMenuClick` (popToRoot on both panes) is the right behavior.
- **FlowEditorPage**: gains `onBack` / `onOpenExecutions` props. "← 列表"
  closes the right pane via `routeRight.popToRoot()`. Manual execution pushes
  the executions view onto the right stack instead of the left route table.
- **FlowExecutionsPage**: gains `onBack` / `onClose` props. "← 编辑器"
  pops back to the editor on the right stack; "返回列表" pops the right pane
  to root.
- **FlowListPage**: repacked as a single-column card list with a kebab-menu so
  it fits the left pane width — the previous Table had ~860 px of columns
  inside a 300 px container. Click anywhere on a card → opens the editor.

## Verification

- Manual flow: list renders compactly on the left, clicking 编辑/新建 fills
  the full right pane with the React Flow canvas, 执行历史 stacks on top of
  the editor, ← 编辑器 returns to it, 返回列表 clears the right pane.
