### PR TITLE
feat: include ASR params in uploadLocal feedback metadata

### DIFF
--- a/apps/web/src/__tests__/VoiceFeedback.test.ts
+++ b/apps/web/src/__tests__/VoiceFeedback.test.ts
@@ -233,6 +233,123 @@ describe("VoiceFeedback", () => {
       expect(metadata.utterance_id).toBe("u-scene");
       expect(metadata.source).toBe("local");
     });
+
+    it("includes asrParams fields in local upload metadata", () => {
+      VoiceFeedback.init("https://fb.test");
+      const fb = VoiceFeedback.shared()!;
+      const blob = new Blob(["data"], { type: "audio/webm" });
+
+      fb.onTranscribeResult({
+        utteranceId: "u-params",
+        modelText: "hello",
+        source: "local",
+        audioBlob: blob,
+        scene: "chat",
+        asrParams: {
+          contextText: "ctx",
+          chatContext: "chat-ctx",
+          personalContext: "personal-ctx",
+          memberContext: "member-ctx",
+          mode: "streaming",
+          channelType: 2,
+          model: "v3",
+          allowFeedback: true,
+        },
+      });
+
+      const fetchMock = vi.mocked(fetch);
+      const localCall = fetchMock.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("/local"),
+      );
+      expect(localCall).toBeDefined();
+
+      const formData = localCall![1]!.body as FormData;
+      const metadata = JSON.parse(formData.get("metadata") as string);
+      expect(metadata.context_text).toBe("ctx");
+      expect(metadata.chat_context).toBe("chat-ctx");
+      expect(metadata.personal_context).toBe("personal-ctx");
+      expect(metadata.member_context).toBe("member-ctx");
+      expect(metadata.mode).toBe("streaming");
+      expect(metadata.channel_type).toBe(2);
+      expect(metadata.model).toBe("v3");
+      expect(metadata.allow_feedback).toBe(true);
+    });
+    it("defaults metadata fields when asrParams is undefined", () => {
+      VoiceFeedback.init("https://fb.test");
+      const fb = VoiceFeedback.shared()!;
+      const blob = new Blob(["data"], { type: "audio/webm" });
+
+      fb.onTranscribeResult({
+        utteranceId: "u-no-params",
+        modelText: "hello",
+        source: "local",
+        audioBlob: blob,
+        scene: "chat",
+      });
+
+      const fetchMock = vi.mocked(fetch);
+      const localCall = fetchMock.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("/local"),
+      );
+      expect(localCall).toBeDefined();
+
+      const formData = localCall![1]!.body as FormData;
+      const metadata = JSON.parse(formData.get("metadata") as string);
+      expect(metadata.context_text).toBe("");
+      expect(metadata.chat_context).toBe("");
+      expect(metadata.personal_context).toBe("");
+      expect(metadata.member_context).toBe("");
+      expect(metadata.mode).toBe("");
+      expect(metadata.channel_type).toBe(0);
+      expect(metadata.model).toBe("");
+      expect(metadata.allow_feedback).toBe(false);
+    });
+  });
+
+  describe("uploadFinal payload", () => {
+    it("does not include asrParams fields in final upload", () => {
+      VoiceFeedback.init("https://fb.test");
+      const fb = VoiceFeedback.shared()!;
+
+      fb.onTranscribeResult({
+        utteranceId: "u-final",
+        modelText: "hello",
+        source: "remote",
+        scene: "chat",
+        asrParams: {
+          contextText: "ctx",
+          chatContext: "chat-ctx",
+          personalContext: "personal-ctx",
+          memberContext: "member-ctx",
+          mode: "streaming",
+          channelType: 2,
+          model: "v3",
+          allowFeedback: true,
+        },
+      });
+
+      vi.mocked(fetch).mockClear();
+      fb.submitAll("corrected text");
+
+      const fetchMock = vi.mocked(fetch);
+      const finalCall = fetchMock.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("/final"),
+      );
+      expect(finalCall).toBeDefined();
+
+      const body = JSON.parse(finalCall![1]!.body as string);
+      expect(body.utterance_id).toBe("u-final");
+      expect(body.model_text).toBe("hello");
+      expect(body.user_text).toBe("corrected text");
+      expect(body).not.toHaveProperty("context_text");
+      expect(body).not.toHaveProperty("chat_context");
+      expect(body).not.toHaveProperty("personal_context");
+      expect(body).not.toHaveProperty("member_context");
+      expect(body).not.toHaveProperty("mode");
+      expect(body).not.toHaveProperty("channel_type");
+      expect(body).not.toHaveProperty("model");
+      expect(body).not.toHaveProperty("allow_feedback");
+    });
   });
 
   describe("no-op when disabled", () => {

--- a/apps/web/src/__tests__/useVoiceInput.test.ts
+++ b/apps/web/src/__tests__/useVoiceInput.test.ts
@@ -1,6 +1,11 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
+const { mockOnTranscribeResult, mockLocalTranscribe } = vi.hoisted(() => ({
+  mockOnTranscribeResult: vi.fn(),
+  mockLocalTranscribe: vi.fn(),
+}));
+
 // Mock WKApp
 vi.mock("@octo/base/src/App", () => ({
   default: {
@@ -29,8 +34,46 @@ vi.mock("@octo/base/src/Service/VoiceService", () => {
   };
 });
 
+// Mock VoiceFeedback
+vi.mock("@octo/base/src/Service/VoiceFeedback", () => ({
+  default: {
+    init: vi.fn(),
+    destroy: vi.fn(),
+    shared: () => ({ onTranscribeResult: mockOnTranscribeResult }),
+  },
+}));
+
+// Mock LocalModelService
+vi.mock("@octo/base/src/Service/LocalModelService", () => ({
+  default: {
+    shared: {
+      config: { preferLocal: false, enabled: false },
+      loadConfig: vi.fn(),
+      updateConfig: vi.fn(),
+      probe: vi.fn().mockResolvedValue(false),
+      transcribe: mockLocalTranscribe,
+    },
+  },
+}));
+
+// Mock useSpaceFeedbackSetting helpers
+vi.mock(
+  "@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting",
+  () => ({
+    fetchAndApplySpaceSetting: vi.fn().mockResolvedValue(undefined),
+    resetSharedSpaceSetting: vi.fn(),
+    setSharedVoiceConfig: vi.fn(),
+    getSharedSpaceFeedbackState: () => ({
+      spaceSetting: { voice_feedback_on: 1, voice_feedback_notice_acked: 1 },
+    }),
+    getSharedVoiceConfig: () => null,
+    subscribe: vi.fn(() => vi.fn()),
+  }),
+);
+
 import WKApp from "@octo/base/src/App";
 import VoiceService from "@octo/base/src/Service/VoiceService";
+import LocalModelService from "@octo/base/src/Service/LocalModelService";
 import useVoiceInput from "@octo/base/src/Components/MessageInput/useVoiceInput";
 
 // Mock MediaRecorder
@@ -363,7 +406,8 @@ describe("useVoiceInput - getChatContext", () => {
       undefined,
       "smart",
       true,
-      1
+      1,
+      false
     );
   });
 
@@ -406,7 +450,8 @@ describe("useVoiceInput - getChatContext", () => {
       "聊天成员：Bob",
       "smart",
       true,
-      2
+      2,
+      false
     );
   });
 
@@ -602,7 +647,8 @@ describe("useVoiceInput - personal voice context", () => {
       "聊天成员：Alice,Bob", // memberContext
       "smart", // mode
       true, // skipLocal
-      undefined // channelType
+      undefined, // channelType
+      false // allowFeedback
     );
     expect(getChatContext).toHaveBeenCalled();
   });
@@ -644,7 +690,8 @@ describe("useVoiceInput - personal voice context", () => {
       "聊天成员：Alice,Bob", // memberContext
       "smart", // mode
       true, // skipLocal
-      undefined // channelType
+      undefined, // channelType
+      false // allowFeedback
     );
     expect(getChatContext).toHaveBeenCalled();
   });
@@ -686,7 +733,8 @@ describe("useVoiceInput - personal voice context", () => {
       "聊天成员：Alice", // memberContext
       "smart", // mode
       true, // skipLocal
-      undefined // channelType
+      undefined, // channelType
+      false // allowFeedback
     );
   });
 
@@ -724,7 +772,8 @@ describe("useVoiceInput - personal voice context", () => {
       "聊天成员：Alice", // memberContext
       "smart", // mode
       true, // skipLocal
-      undefined // channelType
+      undefined, // channelType
+      false // allowFeedback
     );
   });
 
@@ -784,7 +833,8 @@ describe("useVoiceInput - personal voice context", () => {
       undefined, // memberContext (无 getChatContext)
       "smart", // mode
       true, // skipLocal
-      undefined // channelType
+      undefined, // channelType
+      false // allowFeedback
     );
   });
 
@@ -1016,5 +1066,172 @@ describe("useVoiceInput - max duration config", () => {
       await vi.advanceTimersByTimeAsync(1001);
     });
     expect(result.current.isRecording).toBe(false);
+  });
+});
+
+describe("useVoiceInput - notifyFeedback asrParams", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setupMocks();
+    WKApp.shared.currentSpaceId = "test-space-id";
+    vi.mocked(VoiceService.shared.getConfig).mockResolvedValue({
+      enabled: true,
+      max_duration: 60,
+      max_file_size: 3145728,
+      feedback_url: "https://fb.test",
+    } as any);
+    vi.mocked(VoiceService.shared.getVoiceContext).mockResolvedValue({
+      status: 200,
+      has_context: false,
+      context: "",
+      updated_at: "",
+    });
+    mockOnTranscribeResult.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("should NOT pass asrParams for remote-only transcription", async () => {
+    vi.mocked(VoiceService.shared.transcribe).mockResolvedValue({
+      text: "remote text",
+      request_id: "req-1",
+      m: "whisper-1",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscribed: vi.fn() }),
+    );
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      result.current.stopRecordingAndTranscribe();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockOnTranscribeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelText: "remote text",
+        source: "remote",
+        requestId: "req-1",
+      }),
+    );
+    const callArg = mockOnTranscribeResult.mock.calls[0][0];
+    expect(callArg.asrParams).toBeUndefined();
+  });
+
+  it("should NOT pass asrParams when falling back to remote after local failure", async () => {
+    (LocalModelService.shared as any).config = {
+      preferLocal: true,
+      enabled: true,
+    };
+    mockLocalTranscribe.mockResolvedValue(null);
+    vi.mocked(VoiceService.shared.transcribe).mockResolvedValue({
+      text: "fallback text",
+      request_id: "req-2",
+      m: "whisper-1",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscribed: vi.fn() }),
+    );
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      result.current.stopRecordingAndTranscribe();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockOnTranscribeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelText: "fallback text",
+        source: "remote",
+        requestId: "req-2",
+      }),
+    );
+    const callArg = mockOnTranscribeResult.mock.calls[0][0];
+    expect(callArg.asrParams).toBeUndefined();
+
+    (LocalModelService.shared as any).config = {
+      preferLocal: false,
+      enabled: false,
+    };
+  });
+
+  it("should pass asrParams for local transcription", async () => {
+    (LocalModelService.shared as any).config = {
+      preferLocal: true,
+      enabled: true,
+    };
+    mockLocalTranscribe.mockResolvedValue({ text: "local text", m: "v3" });
+
+    const getChatContext = vi.fn().mockReturnValue({
+      chatContext: "chat-ctx",
+      memberContext: "member-ctx",
+      channelType: 2,
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscribed: vi.fn(), getChatContext }),
+    );
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      result.current.stopRecordingAndTranscribe("ctx text");
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockOnTranscribeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelText: "local text",
+        source: "local",
+        asrParams: expect.objectContaining({
+          chatContext: "chat-ctx",
+          memberContext: "member-ctx",
+          channelType: 2,
+          model: "v3",
+        }),
+      }),
+    );
+
+    (LocalModelService.shared as any).config = {
+      preferLocal: false,
+      enabled: false,
+    };
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
@@ -5,7 +5,7 @@ import VoiceService, {
   VoiceContextResponse,
   VoiceMode,
 } from "../../Service/VoiceService";
-import VoiceFeedback from "../../Service/VoiceFeedback";
+import VoiceFeedback, { type AsrParams } from "../../Service/VoiceFeedback";
 import LocalModelService, { LocalModelConfig } from "../../Service/LocalModelService";
 import WKApp from "../../App";
 import { ChatContextResult } from "../Conversation/chatContext";
@@ -316,7 +316,12 @@ export default function useVoiceInput(
         }
 
         setIsTranscribing(true);
-        const notifyFeedback = (text: string, source: "local" | "remote", requestId?: string) => {
+        const notifyFeedback = (
+          text: string,
+          source: "local" | "remote",
+          requestId?: string,
+          asrParams?: AsrParams,
+        ) => {
           if (voiceFeedbackOnRef.current !== 1) return;
           VoiceFeedback.shared()?.onTranscribeResult({
             utteranceId: utteranceIdRef.current,
@@ -325,6 +330,7 @@ export default function useVoiceInput(
             requestId,
             scene,
             audioBlob: source === "local" ? blob : undefined,
+            asrParams,
           });
         };
 
@@ -372,7 +378,16 @@ export default function useVoiceInput(
               );
             if (localResult) {
               if (localResult.text) {
-                notifyFeedback(localResult.text, "local");
+                notifyFeedback(localResult.text, "local", undefined, {
+                  contextText: contextTextRef.current,
+                  chatContext,
+                  personalContext,
+                  memberContext,
+                  mode: recordingModeRef.current,
+                  channelType: chatCtxResult.channelType,
+                  model: localResult.m,
+                  allowFeedback,
+                });
                 if (onTranscribed) onTranscribed(localResult.text);
               }
               return;

--- a/packages/dmworkbase/src/Service/VoiceFeedback.ts
+++ b/packages/dmworkbase/src/Service/VoiceFeedback.ts
@@ -1,3 +1,14 @@
+export interface AsrParams {
+  contextText?: string;
+  chatContext?: string;
+  personalContext?: string;
+  memberContext?: string;
+  mode?: string;
+  channelType?: number;
+  model?: string;
+  allowFeedback?: boolean;
+}
+
 interface PendingUtterance {
   utteranceId: string;
   modelText: string;
@@ -6,6 +17,7 @@ interface PendingUtterance {
   scene?: string;
   audioBlob?: Blob;
   timestamp: number;
+  asrParams?: AsrParams;
 }
 
 export default class VoiceFeedback {
@@ -68,6 +80,7 @@ export default class VoiceFeedback {
     requestId?: string;
     scene?: string;
     audioBlob?: Blob;
+    asrParams?: AsrParams;
   }): void {
     if (this.disabled) return;
 
@@ -104,6 +117,14 @@ export default class VoiceFeedback {
           text: u.modelText,
           source: u.source,
           scene: u.scene || "",
+          context_text: u.asrParams?.contextText || "",
+          chat_context: u.asrParams?.chatContext || "",
+          personal_context: u.asrParams?.personalContext || "",
+          member_context: u.asrParams?.memberContext || "",
+          mode: u.asrParams?.mode || "",
+          channel_type: u.asrParams?.channelType ?? 0,
+          model: u.asrParams?.model || "",
+          allow_feedback: u.asrParams?.allowFeedback ?? false,
         }),
       );
       await fetch(`${this.feedbackUrl}/local`, {


### PR DESCRIPTION
## Summary

Add all ASR request parameters to the `uploadLocal` metadata payload for data collection purposes.

## Changes

- **VoiceFeedback.ts**: Add `AsrParams` interface and include all 8 ASR fields (`context_text`, `chat_context`, `personal_context`, `member_context`, `mode`, `channel_type`, `model`, `allow_feedback`) in `uploadLocal` metadata
- **useVoiceInput.ts**: Pass `asrParams` only from local ASR path; remote paths do not pass it
- **useVoiceInput.test.ts**: Add tests verifying local passes asrParams, remote does not, and default values

## Notes

- Only `uploadLocal` carries ASR params; `uploadFinal` remains unchanged
- Remote ASR paths do not pass `asrParams` (only triggered when `source === 'local' && audioBlob` exists)
- Default values provided for `channel_type` (0) and `allow_feedback` (false) to prevent JSON field omission