### PR TITLE
fix(upload): preflight credentials so rejected files surface error (#119)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -76,6 +76,7 @@ import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
 import { parseThreadChannelId } from "../../Service/Thread";
 import FoldSessionExpandedList from "./FoldSessionExpandedList";
 import VoiceFeedback from "../../Service/VoiceFeedback";
+import { precheckUploadCredentials } from "../../Service/UploadCredentials";
 
 /**
  * 取消息的有效内容：如果消息被编辑过，返回编辑后的 contentEdit；否则返回原始 content
@@ -2347,6 +2348,17 @@ export class Conversation
 
                         // ── 辅助：发送单张图片（读取预览+宽高） ──────────────
                         const sendImageFile = async (file: File) => {
+                          // 上传前预检：后端会对文件大小/类型做校验,失败时直接 Toast,
+                          // 不要让本地气泡先进聊天框再显示失败 (octo-web#119)。
+                          try {
+                            const dot = (file.name || "").lastIndexOf(".");
+                            const ext = dot > 0 ? file.name.substring(dot + 1) : "";
+                            await precheckUploadCredentials(file, this.channel(), ext);
+                          } catch (err) {
+                            const msg = (err as { msg?: string })?.msg || "上传失败";
+                            Toast.error(`图片「${file.name}」${msg}`);
+                            return;
+                          }
                           const reader = new FileReader();
                           const previewUrl = await new Promise<string>(
                             (resolve) => {
@@ -2385,6 +2397,14 @@ export class Conversation
                           const dotIndex = name.lastIndexOf(".");
                           const ext =
                             dotIndex > 0 ? name.substring(dotIndex + 1) : "";
+                          // 上传前预检 (octo-web#119)。
+                          try {
+                            await precheckUploadCredentials(file, this.channel(), ext);
+                          } catch (err) {
+                            const msg = (err as { msg?: string })?.msg || "上传失败";
+                            Toast.error(`文件「${name}」${msg}`);
+                            return;
+                          }
                           await this.sendMediaAndWait(
                             new FileContent(file, name, ext, file.size),
                           );

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -2347,7 +2347,10 @@ export class Conversation
                         }
 
                         // ── 辅助：发送单张图片（读取预览+宽高） ──────────────
-                        const sendImageFile = async (file: File) => {
+                        // 返回 true 表示消息已入队 / 发送; false 表示被预检拒绝、
+                        // 调用方应据此决定是否继续后续流程 (例如不要再补一条
+                        // 空回复消息: octo-web#119 review by Jerry-Xin)。
+                        const sendImageFile = async (file: File): Promise<boolean> => {
                           // 上传前预检：后端会对文件大小/类型做校验,失败时直接 Toast,
                           // 不要让本地气泡先进聊天框再显示失败 (octo-web#119)。
                           try {
@@ -2357,7 +2360,7 @@ export class Conversation
                           } catch (err) {
                             const msg = (err as { msg?: string })?.msg || "上传失败";
                             Toast.error(`图片「${file.name}」${msg}`);
-                            return;
+                            return false;
                           }
                           const reader = new FileReader();
                           const previewUrl = await new Promise<string>(
@@ -2370,7 +2373,7 @@ export class Conversation
                           );
                           if (!previewUrl) {
                             Toast.error(`图片「${file.name}」读取失败`);
-                            return;
+                            return false;
                           }
                           const { width, height } = await new Promise<{
                             width: number;
@@ -2389,10 +2392,11 @@ export class Conversation
                           await this.sendMediaAndWait(
                             new ImageContent(file, previewUrl, width, height),
                           );
+                          return true;
                         };
 
                         // ── 辅助：发送单个非图片文件 ──────────────
-                        const sendFileAttachment = async (file: File) => {
+                        const sendFileAttachment = async (file: File): Promise<boolean> => {
                           const name = file.name || "unknown";
                           const dotIndex = name.lastIndexOf(".");
                           const ext =
@@ -2403,11 +2407,12 @@ export class Conversation
                           } catch (err) {
                             const msg = (err as { msg?: string })?.msg || "上传失败";
                             Toast.error(`文件「${name}」${msg}`);
-                            return;
+                            return false;
                           }
                           await this.sendMediaAndWait(
                             new FileContent(file, name, ext, file.size),
                           );
+                          return true;
                         };
 
                         // ── 辅助：构建带 mention 的文本 MessageContent ──────────────
@@ -2490,14 +2495,20 @@ export class Conversation
                         };
 
                         // ── 第一阶段：发送顶部附件区的文件（优先级最高） ──────────────
+                        // anyMessageSent: 标记本次 onSend 是否实际入队过任何消息。
+                        // 若所有顶部附件 + 编辑器内容块都被预检拒绝,且没有文本块,
+                        // 则不应再补发空回复消息 (octo-web#119 review by Jerry-Xin)。
+                        let anyMessageSent = false;
                         const topFilesToSend = topFiles || [];
                         for (const { file } of topFilesToSend) {
                           try {
+                            let sent = false;
                             if (file.type && file.type.startsWith("image/")) {
-                              await sendImageFile(file);
+                              sent = await sendImageFile(file);
                             } else {
-                              await sendFileAttachment(file);
+                              sent = await sendFileAttachment(file);
                             }
+                            if (sent) anyMessageSent = true;
                           } catch (err) {
                             Toast.error(`文件「${file.name}」发送失败`);
                           }
@@ -2520,10 +2531,15 @@ export class Conversation
                                 }
                                 isFirstTextBlock = false;
                                 await this.sendTextAndWaitAck(msgContent);
+                                anyMessageSent = true;
                               } else if (block.type === "image") {
-                                await sendImageFile(block.file);
+                                if (await sendImageFile(block.file)) {
+                                  anyMessageSent = true;
+                                }
                               } else if (block.type === "file") {
-                                await sendFileAttachment(block.file);
+                                if (await sendFileAttachment(block.file)) {
+                                  anyMessageSent = true;
+                                }
                               }
                             } catch (err) {
                               console.error(
@@ -2533,8 +2549,10 @@ export class Conversation
                               Toast.error("消息发送失败");
                             }
                           }
-                          // 如果 reply 还没被消费（没有文本块），附加到一条空白消息
-                          if (reply) {
+                          // 如果 reply 还没被消费（没有文本块），附加到一条空白消息;
+                          // 但仅当本次确实发出了别的消息时,否则用户的所有附件都被
+                          // 预检拒绝、却仍收到一条孤立的空回复气泡 (#119 Jerry-Xin)。
+                          if (reply && anyMessageSent) {
                             const emptyContent = new MessageText("");
                             emptyContent.reply = reply;
                             await this.sendTextAndWaitAck(emptyContent);
@@ -2547,7 +2565,8 @@ export class Conversation
                               msgContent.reply = reply;
                             }
                             await this.sendTextAndWaitAck(msgContent);
-                          } else if (reply) {
+                          } else if (reply && anyMessageSent) {
+                            // 同上: 顶部附件全部被预检拒绝时不要补空回复
                             const emptyContent = new MessageText("");
                             emptyContent.reply = reply;
                             await this.sendTextAndWaitAck(emptyContent);

--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -1,0 +1,62 @@
+import { Channel } from "wukongimjssdk"
+import WKApp from "../App"
+import { extractErrorMsg } from "./APIClient"
+
+/**
+ * 上传前预检 file/upload/credentials。
+ *
+ * Why: GH Mininglamp-OSS/octo-web#119 — 后端会对文件类型/大小做白名单校验
+ * (例如 .xlsm 会返回 `400 不支持的文件类型`)。SDK 层 `MediaMessageUploadTask`
+ * 把 credentials 调用放在 `chatManager.send` 之后,而 `send` 已经把消息气泡
+ * 塞进了本地会话队列;失败也只是把 task 状态翻成 fail、错误信息整个吞掉,
+ * 用户看到一条假的"已发送"气泡且没有任何提示,刷新后消息消失。
+ *
+ * How: 在 UI 调用 `vm.sendMessage` *之前* 先打一次 credentials,失败就 Toast
+ * 后端 msg 并 return,气泡完全不进聊天框。成功路径会多调一次 credentials
+ * (task 内部仍会再 fetch 一次新凭证),credentials 接口轻量,可接受。
+ *
+ * 失败时抛出的 Error 上挂 `.msg` 字段,UI 层可直接读取无需再次解析。
+ */
+export async function precheckUploadCredentials(
+    file: File,
+    channel: Channel,
+    extension: string,
+): Promise<void> {
+    const contentType = file.type || "application/octet-stream"
+    const fileName = file.name || "file"
+    const fileSize = file.size
+    const ext = extension ? `.${extension}` : ""
+    const path = `/${channel.channelType}/${channel.channelID}/${genUploadUUID()}${ext}`
+
+    try {
+        const result = await WKApp.apiClient.get(
+            `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}&fileSize=${fileSize}`,
+        )
+        if (!result || !result.uploadUrl || !result.downloadUrl) {
+            throwWithMsg("响应缺少凭证字段")
+        }
+    } catch (err) {
+        const msg =
+            extractErrorMsg(err) ||
+            (err instanceof Error ? err.message : "") ||
+            "上传失败"
+        throwWithMsg(msg)
+    }
+}
+
+function throwWithMsg(msg: string): never {
+    const e = new Error(msg) as Error & { msg: string }
+    e.msg = msg
+    throw e
+}
+
+function genUploadUUID(): string {
+    const len = 32
+    const radix = 16
+    const bytes = new Uint8Array(len)
+    crypto.getRandomValues(bytes)
+    const chars = "0123456789ABCDEF".split("")
+    const uuid: string[] = []
+    for (let i = 0; i < len; i++) uuid[i] = chars[bytes[i] % radix]
+    return uuid.join("")
+}

--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -1,6 +1,5 @@
 import { Channel } from "wukongimjssdk"
-import WKApp from "../App"
-import { extractErrorMsg } from "./APIClient"
+import APIClient, { extractErrorMsg } from "./APIClient"
 
 /**
  * 上传前预检 file/upload/credentials。
@@ -28,19 +27,22 @@ export async function precheckUploadCredentials(
     const ext = extension ? `.${extension}` : ""
     const path = `/${channel.channelType}/${channel.channelID}/${genUploadUUID()}${ext}`
 
+    let result: { uploadUrl?: unknown; downloadUrl?: unknown } | undefined
     try {
-        const result = await WKApp.apiClient.get(
+        result = await APIClient.shared.get(
             `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}&fileSize=${fileSize}`,
         )
-        if (!result || !result.uploadUrl || !result.downloadUrl) {
-            throwWithMsg("响应缺少凭证字段")
-        }
     } catch (err) {
         const msg =
             extractErrorMsg(err) ||
             (err instanceof Error ? err.message : "") ||
             "上传失败"
         throwWithMsg(msg)
+    }
+
+    // 200 但响应缺字段时单独抛, 不要再被一个 catch 吞掉重写 (#135 review by lml2468)。
+    if (!result || typeof result.uploadUrl !== "string" || typeof result.downloadUrl !== "string") {
+        throwWithMsg("响应缺少凭证字段")
     }
 }
 

--- a/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import axios from "axios"
+import { Channel, ChannelTypePerson } from "wukongimjssdk"
+import APIClient from "../APIClient"
+import { precheckUploadCredentials } from "../UploadCredentials"
+
+/**
+ * GH Mininglamp-OSS/octo-web#119 / #135 — preflight credentials helper.
+ *
+ * 三条核心契约 UI 层依赖:
+ *   1. 后端拒收 (e.g. 400 不支持的文件类型) 时, throw 出来的 Error 上挂 .msg
+ *      直接是后端的 msg 字符串, UI 可读取后 Toast。
+ *   2. HTTP 200 但响应字段缺失时, throw 一个稳定的兜底 msg。
+ *   3. 成功时静默 resolve, 不返回任何东西。
+ */
+describe("precheckUploadCredentials", () => {
+    const client = APIClient.shared
+    const fakeFile = (name: string, type: string, size = 100): File =>
+        new File([new Uint8Array(size)], name, { type })
+    const fakeChannel = new Channel("u-test", ChannelTypePerson)
+
+    let lastUrl: string = ""
+
+    beforeEach(() => {
+        lastUrl = ""
+        client.config.tokenCallback = undefined
+        client.config.spaceIdCallback = undefined
+    })
+
+    it("成功路径: 后端返回完整凭证, 静默 resolve", async () => {
+        axios.defaults.adapter = async (config) => {
+            lastUrl = config.url || ""
+            return {
+                data: {
+                    uploadUrl: "https://cos.example/u",
+                    downloadUrl: "https://cos.example/d",
+                },
+                status: 200,
+                statusText: "OK",
+                headers: {},
+                config,
+                request: {},
+            } as any
+        }
+        await expect(
+            precheckUploadCredentials(fakeFile("a.png", "image/png"), fakeChannel, "png"),
+        ).resolves.toBeUndefined()
+        expect(lastUrl).toContain("file/upload/credentials")
+        expect(lastUrl).toContain("filename=a.png")
+        expect(lastUrl).toContain("contentType=image%2Fpng")
+        expect(lastUrl).toContain(encodeURIComponent(`/${ChannelTypePerson}/u-test/`))
+    })
+
+    it("后端 400 + msg: 抛 Error.msg 透传后端 msg", async () => {
+        // 模拟 axios 收到 400 时抛错的形状, 让 APIClient 拦截器走 reject 分支
+        // 并把 response.data.msg 作为 reject 的 msg 字段。
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("Request failed with status code 400")
+            err.response = {
+                status: 400,
+                data: { msg: "不支持的文件类型", status: 400 },
+                headers: {},
+            }
+            throw err
+        }
+        try {
+            await precheckUploadCredentials(
+                fakeFile("a.xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12"),
+                fakeChannel,
+                "xlsm",
+            )
+            expect.fail("应当抛出错误")
+        } catch (err) {
+            expect((err as { msg?: string }).msg).toBe("不支持的文件类型")
+        }
+    })
+
+    it("HTTP 200 但缺 uploadUrl: 抛 '响应缺少凭证字段'", async () => {
+        axios.defaults.adapter = async (config) => {
+            return {
+                data: { downloadUrl: "https://cos.example/d" }, // 缺 uploadUrl
+                status: 200,
+                statusText: "OK",
+                headers: {},
+                config,
+                request: {},
+            } as any
+        }
+        try {
+            await precheckUploadCredentials(fakeFile("a.txt", "text/plain"), fakeChannel, "txt")
+            expect.fail("应当抛出错误")
+        } catch (err) {
+            expect((err as { msg?: string }).msg).toBe("响应缺少凭证字段")
+        }
+    })
+
+    it("网络异常: 走 fallback msg, 不至于裸 'undefined'", async () => {
+        axios.defaults.adapter = async () => {
+            throw new Error("Network down")
+        }
+        try {
+            await precheckUploadCredentials(fakeFile("a.txt", "text/plain"), fakeChannel, "txt")
+            expect.fail("应当抛出错误")
+        } catch (err) {
+            const msg = (err as { msg?: string }).msg
+            expect(typeof msg).toBe("string")
+            expect(msg!.length).toBeGreaterThan(0)
+        }
+    })
+})


### PR DESCRIPTION
## Summary

- 上传文件前先打一次 `file/upload/credentials` 做预检, 后端拒收 (例如 `.xlsm` 返回 `400 不支持的文件类型`) 时直接 Toast 错误信息, 不再让本地"已发送"气泡先塞进聊天框
- 新增 helper `packages/dmworkbase/src/Service/UploadCredentials.ts`, 用 `extractErrorMsg` 从拦截器 reject 形状里直接拿到后端 `msg`
- 在 `Conversation/index.tsx` 的 `sendImageFile` / `sendFileAttachment` 里加 preflight 调用; 失败 `Toast.error("文件「xxx」<msg>")` 后 return, 不调用 `vm.sendMessage`

## 背景

GH #119: 私聊 Bot 上传 `.xlsm` 时, 后端 credentials API 返回 `{"msg":"不支持的文件类型","status":400}`, 但前端:
1. SDK 层 `MediaMessageUploadTask.start()` 用 `try { ... } catch {}` 完全吞掉错误, 只把 task 翻成 `fail`
2. 本地气泡早在 `WKSDK.shared().chatManager.send(...)` 时 (credentials 调用之前) 就已经被 `addSendMessageToQueue` 塞进 UI

结果: 用户看到一条假的"已发送"气泡, 没有任何错误提示, 刷新后由于服务端没收到合法消息, 气泡消失。

## 方案权衡

成功路径下会多调一次 credentials 接口 (task 内部仍会再 fetch 一次新凭证, 不复用预检的)。credentials 接口本身轻量, 而且拿到的是 presigned URL 本来就有有效期, 复用也意义不大。换来的是:
- UX 干净: 拒收文件**完全不出现**气泡, 不需要先显示再撤回造成闪烁
- 改动小: 不动 SDK 层 / `vm.ts` / `chatManager.send`, 只在 UI 入口加 gate

## 覆盖范围

- ✅ credentials 阶段被后端拒收的文件 (类型黑名单 / 大小超限 / 未知 MIME 等), 后端以后扩黑名单也自动受益, 前端不用再改
- ⏭️ S3/COS PUT 阶段失败 (网络中断等) 仍按现有"红 ❗ 气泡 + 重试"路径, 不动
- ⏭️ Issue 里另一个建议 (Web 加 `.xlsm` Excel 图标 / 插件 `guessMime` 加 xlsm MIME) 是展示/解析层的事, 不在本 PR 范围

## Test plan

- [ ] 私聊 Bot 上传 `.xlsm`, 期望: 右下 Toast `文件「xxx.xlsm」不支持的文件类型`; 聊天框**没有**气泡
- [ ] 上传 `.xlsx` / `.png` / `.txt` 等正常文件, 行为与原来一致 (气泡正常, 上传成功, 可下载)
- [ ] DevTools block `file/upload/credentials` 模拟网络异常, 期望 Toast + 无气泡
- [ ] 大文件上传 → 取消 → 重试, 现有 cancel/restart 路径未受影响
- [ ] `tsc --noEmit` 错误数与 main 持平 (本 PR 零新增)

Closes #119