### PR TITLE
fix(conversation): block folder drop to prevent ghost file messages (#115)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1901,8 +1901,19 @@ export class Conversation
                         onDrop={(event) => {
                           event.preventDefault();
                           this.dragEnd();
+                          const items = Array.from(event.dataTransfer.items);
                           const files = Array.from(event.dataTransfer.files);
                           if (files.length === 0) return;
+                          const hasDirectory = items.length
+                            ? items.some((it) => {
+                                const entry = it.webkitGetAsEntry?.();
+                                return entry ? entry.isDirectory : false;
+                              })
+                            : files.some((f) => f.type === "" && f.size === 0);
+                          if (hasDirectory) {
+                            Toast.error("暂不支持上传文件夹，请选择具体文件");
+                            return;
+                          }
                           const err = this.addPendingAttachments(files);
                           if (err) Toast.error(err);
                         }}


### PR DESCRIPTION
## Summary

- 修复 #115：Web 端拖拽文件夹后 UI 显示「已发送」、但 Bot 读不到、撤回也报错的幽灵消息。
- 根因：浏览器拖拽文件夹时会在 `event.dataTransfer.files` 里塞一个 `type="" / size=0` 的伪 File，旧逻辑直接当附件走上传流程，而后端不支持文件夹，于是消息卡片显示成功但未真正入库。
- 修复：在 `Conversation/index.tsx` 的 `onDrop` 里优先用 `dataTransfer.items[].webkitGetAsEntry().isDirectory` 检测文件夹，兜底用 `type==="" && size===0`，命中则 `Toast.error("暂不支持上传文件夹，请选择具体文件")` 并 return，不进 `addPendingAttachments`。

只动一个文件、新增 11 行；其他入口（粘贴、`<input type="file">`）天然产生不了文件夹，无需改动。

Closes #115

## Test plan

- [ ] `pnpm dev`，进入任意会话
- [ ] 从 Finder/Explorer 拖一个**文件夹**到聊天区 → 红色 Toast「暂不支持上传文件夹，请选择具体文件」，不生成附件卡片，不发送消息
- [ ] 拖单个文件 → 行为与原来一致，正常进入待发送附件
- [ ] 一次拖多个文件 + 一个文件夹 → 整批拒绝，Toast 同上
- [ ] 复制粘贴文件、点上传按钮 → 回归无变化
- [ ] 在 Chrome、Edge、Safari 下分别复测拖拽（`webkitGetAsEntry` 在主流浏览器都已实现，Safari 也支持）