### PR TITLE
feat(flow): parallel exec view + webhook/cron UI + new-flow templates

### DIFF
--- a/packages/dmworkflow/src/api/flowApi.ts
+++ b/packages/dmworkflow/src/api/flowApi.ts
@@ -115,3 +115,27 @@ export async function getExecution(executionId: string): Promise<FlowExecution> 
 export async function cancelExecution(executionId: string): Promise<void> {
   await flowAxios.post(`${apiBase()}/executions/${executionId}/cancel`);
 }
+
+export interface WebhookInfo {
+  url: string;
+  /** Optional configured signature header; the raw secret is never returned. */
+  signatureHeader?: string;
+}
+
+/**
+ * Fetch the canonical webhook URL minted by the server. We prefer this over
+ * deriving the URL from the apiBase locally because the server may publish a
+ * different host (e.g. webhook ingress vs. API ingress) and may include a
+ * token segment in the path.
+ */
+export async function getWebhookUrl(flowId: string): Promise<WebhookInfo> {
+  const resp = await flowAxios.get(`${apiBase()}/flows/${flowId}/webhook`);
+  const body = unwrap<Partial<WebhookInfo> | string>(resp.data);
+  if (typeof body === "string") {
+    return { url: body };
+  }
+  return {
+    url: body.url ?? "",
+    signatureHeader: body.signatureHeader,
+  };
+}

--- a/packages/dmworkflow/src/components/FlowEditor.tsx
+++ b/packages/dmworkflow/src/components/FlowEditor.tsx
@@ -28,6 +28,7 @@ import type {
 import Sidebar from "./Sidebar";
 import NodeConfigPanel from "./NodeConfigPanel";
 import FlowNodeView from "./nodes/FlowNodeView";
+import { buildLayeredLayout, isParallelSiblingEdge } from "../utils/flowLayout";
 
 const nodeTypes = { flowNode: FlowNodeView };
 
@@ -45,8 +46,21 @@ interface FlowEditorProps {
   webhookUrl?: string;
 }
 
-function toReactFlow(def: FlowDefinition, statusByNode?: Record<string, ExecutionStatus>): { nodes: Node[]; edges: Edge[] } {
-  const nodes: Node[] = def.nodes.map((n) => ({
+function toReactFlow(
+  def: FlowDefinition,
+  statusByNode?: Record<string, ExecutionStatus>,
+  layered?: boolean,
+): { nodes: Node[]; edges: Edge[] } {
+  // Read-only execution view applies a layered layout so parallel siblings
+  // render side-by-side and a dashed sibling edge surfaces the same-layer
+  // relationship explicitly. Editing mode keeps user-placed positions.
+  const source: FlowDefinition = layered
+    ? (() => {
+        const { nodes: ln, edges: le } = buildLayeredLayout(def);
+        return { nodes: ln, edges: le };
+      })()
+    : def;
+  const nodes: Node[] = source.nodes.map((n) => ({
     id: n.id,
     type: "flowNode",
     position: n.position,
@@ -55,13 +69,31 @@ function toReactFlow(def: FlowDefinition, statusByNode?: Record<string, Executio
       config: n.config,
       status: statusByNode?.[n.id],
     },
+    draggable: !layered,
   }));
-  const edges: Edge[] = def.edges.map((e) => ({
-    id: e.id,
-    source: e.source,
-    target: e.target,
-    label: e.label ?? e.branch,
-  }));
+  const edges: Edge[] = source.edges.map((e) => {
+    const isSibling = isParallelSiblingEdge(e.id);
+    return {
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      label: isSibling ? undefined : e.label ?? e.branch,
+      // Dashed, animation-free, lower contrast — visually distinct from real
+      // data-flow edges so users don't mistake them for actual control flow.
+      animated: false,
+      type: isSibling ? "straight" : undefined,
+      style: isSibling
+        ? {
+            stroke: "var(--semi-color-text-2, #86909C)",
+            strokeDasharray: "4 4",
+            strokeWidth: 1,
+            opacity: 0.7,
+          }
+        : undefined,
+      data: isSibling ? { parallelSibling: true } : undefined,
+      selectable: !isSibling,
+    } as Edge;
+  });
   return { nodes, edges };
 }
 
@@ -73,13 +105,17 @@ function fromReactFlow(nodes: Node[], edges: Edge[]): FlowDefinition {
       position: n.position,
       config: (n.data as { config: FlowNodeConfig }).config ?? {},
     })),
-    edges: edges.map((e) => ({
-      id: e.id,
-      source: e.source,
-      target: e.target,
-      label: typeof e.label === "string" ? e.label : undefined,
-      branch: typeof e.label === "string" ? e.label : undefined,
-    })),
+    edges: edges
+      // Synthetic sibling edges are layout-only — never persist them back
+      // into the user-authored definition.
+      .filter((e) => !isParallelSiblingEdge(e.id))
+      .map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        label: typeof e.label === "string" ? e.label : undefined,
+        branch: typeof e.label === "string" ? e.label : undefined,
+      })),
   };
 }
 
@@ -95,7 +131,12 @@ function FlowEditorInner({
   const { screenToFlowPosition } = useReactFlow();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const initial = useMemo(() => toReactFlow(definition, statusByNode), [definition, statusByNode]);
+  const initial = useMemo(
+    () => toReactFlow(definition, statusByNode, readOnly),
+    // intentional: layout reflows on read-only toggle and definition change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [definition, readOnly],
+  );
   const [nodes, setNodes] = useState<Node[]>(initial.nodes);
   const [edges, setEdges] = useState<Edge[]>(initial.edges);
   const [selectedId, setSelectedId] = useState<string | null>(controlledSelected ?? null);
@@ -107,7 +148,7 @@ function FlowEditorInner({
   const lastUpstreamRef = useRef(definition);
   if (lastUpstreamRef.current !== definition) {
     lastUpstreamRef.current = definition;
-    const next = toReactFlow(definition, statusByNode);
+    const next = toReactFlow(definition, statusByNode, readOnly);
     setNodes(next.nodes);
     setEdges(next.edges);
   }

--- a/packages/dmworkflow/src/components/configs/CronConfig.tsx
+++ b/packages/dmworkflow/src/components/configs/CronConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Input } from "@douyinfe/semi-ui";
+import { Button, Input } from "@douyinfe/semi-ui";
 import type { FlowNodeConfig } from "../../types/flow";
 import { previewNextCronRuns } from "../../utils/cronPreview";
 
@@ -7,6 +7,22 @@ interface Props {
   config: FlowNodeConfig;
   onChange: (patch: Partial<FlowNodeConfig>) => void;
 }
+
+interface CronTemplate {
+  label: string;
+  expression: string;
+  hint: string;
+}
+
+// 5-field expressions: more universally portable than 6-field. The preview
+// utility internally fills seconds=0 when only 5 fields are supplied so the
+// "下次执行" timestamp is correct either way.
+const CRON_TEMPLATES: CronTemplate[] = [
+  { label: "每分钟", expression: "* * * * *", hint: "每 60 秒触发一次" },
+  { label: "每小时", expression: "0 * * * *", hint: "每小时整点触发" },
+  { label: "每天", expression: "0 9 * * *", hint: "每天 09:00 触发" },
+  { label: "每周", expression: "0 9 * * 1", hint: "每周一 09:00 触发" },
+];
 
 export default function CronConfig({ config, onChange }: Props) {
   const expr = config.cronExpression ?? "";
@@ -16,6 +32,27 @@ export default function CronConfig({ config, onChange }: Props) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <div style={{ fontSize: 12, marginBottom: 4 }}>常用模板</div>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {CRON_TEMPLATES.map((tpl) => {
+            const active = expr.trim() === tpl.expression;
+            return (
+              <Button
+                key={tpl.label}
+                size="small"
+                theme={active ? "solid" : "light"}
+                type={active ? "primary" : "tertiary"}
+                onClick={() => onChange({ cronExpression: tpl.expression })}
+                title={`${tpl.expression} — ${tpl.hint}`}
+              >
+                {tpl.label}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+
       <div>
         <div style={{ fontSize: 12, marginBottom: 4 }}>Cron 表达式</div>
         <Input

--- a/packages/dmworkflow/src/components/nodes/FlowNodeView.tsx
+++ b/packages/dmworkflow/src/components/nodes/FlowNodeView.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import type { FlowNodeConfig, NodeType } from "../../types/flow";
+import type { ExecutionStatus, FlowNodeConfig, NodeType } from "../../types/flow";
 import { CATEGORY_COLORS, catalogFor } from "../../utils/nodeCatalog";
 
 interface FlowNodeData extends Record<string, unknown> {
   nodeType: NodeType;
   config: FlowNodeConfig;
   /** Optional runtime status overlay (used by ExecutionView). */
-  status?: "pending" | "running" | "success" | "failed" | "cancelled";
+  status?: ExecutionStatus;
 }
 
-const STATUS_GLYPH: Record<NonNullable<FlowNodeData["status"]>, string> = {
+const STATUS_GLYPH: Record<ExecutionStatus, string> = {
   pending: "⬜",
   running: "⏳",
   success: "✅",
@@ -19,14 +19,34 @@ const STATUS_GLYPH: Record<NonNullable<FlowNodeData["status"]>, string> = {
 };
 
 /**
- * Single canvas node renderer. Layout is the same for every category — the
- * category-specific affordances are color + icon + (optional) status glyph.
+ * Color map mandated by the Phase 2 spec:
+ *   success = green, failed = red, running = blue, pending = grey.
+ * `cancelled` re-uses the grey palette but with an amber accent so users can
+ * tell it apart from "never ran".
+ */
+export const STATUS_COLORS: Record<
+  ExecutionStatus,
+  { bg: string; border: string; text: string }
+> = {
+  pending: { bg: "#F2F3F5", border: "#A4ABB3", text: "#4E5969" },
+  running: { bg: "#E6F2FF", border: "#2E7DFC", text: "#1257B8" },
+  success: { bg: "#E6F7EA", border: "#3FB964", text: "#1F8A45" },
+  failed: { bg: "#FDECEE", border: "#F5363C", text: "#B81C20" },
+  cancelled: { bg: "#FFF5E6", border: "#D89614", text: "#9A5A00" },
+};
+
+/**
+ * Single canvas node renderer. In the editor view we color the node by its
+ * category; in the read-only execution view (when `data.status` is set) we
+ * override with a status-driven palette so success/failed/running/pending is
+ * legible at a glance.
  */
 export default function FlowNodeView({ data, selected }: NodeProps) {
   const d = data as unknown as FlowNodeData;
   const entry = catalogFor(d.nodeType);
   const category = entry?.category ?? "action";
-  const color = CATEGORY_COLORS[category];
+  const baseColor = CATEGORY_COLORS[category];
+  const palette = d.status ? STATUS_COLORS[d.status] : baseColor;
   const label = d.config?.label || entry?.label || d.nodeType;
 
   // Triggers have no inbound handle; everything else has both.
@@ -35,19 +55,19 @@ export default function FlowNodeView({ data, selected }: NodeProps) {
   return (
     <div
       style={{
-        background: color.bg,
-        border: `2px solid ${selected ? color.text : color.border}`,
+        background: palette.bg,
+        border: `2px solid ${selected ? palette.text : palette.border}`,
         borderRadius: 8,
         padding: "10px 14px",
         minWidth: 160,
-        boxShadow: selected ? `0 0 0 3px ${color.border}33` : "0 1px 3px rgba(0,0,0,0.08)",
-        color: color.text,
+        boxShadow: selected ? `0 0 0 3px ${palette.border}33` : "0 1px 3px rgba(0,0,0,0.08)",
+        color: palette.text,
         fontSize: 13,
         fontWeight: 500,
         position: "relative",
       }}
     >
-      {!isTrigger && <Handle type="target" position={Position.Left} style={{ background: color.border }} />}
+      {!isTrigger && <Handle type="target" position={Position.Left} style={{ background: palette.border }} />}
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <span style={{ fontSize: 18 }}>{entry?.icon ?? "▢"}</span>
         <span style={{ flex: 1 }}>{label}</span>
@@ -57,7 +77,7 @@ export default function FlowNodeView({ data, selected }: NodeProps) {
           </span>
         )}
       </div>
-      <Handle type="source" position={Position.Right} style={{ background: color.border }} />
+      <Handle type="source" position={Position.Right} style={{ background: palette.border }} />
     </div>
   );
 }

--- a/packages/dmworkflow/src/pages/FlowEditorPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowEditorPage.tsx
@@ -6,6 +6,7 @@ import {
   deactivateFlow,
   executeFlow,
   getFlow,
+  getWebhookUrl,
   updateFlow,
 } from "../api/flowApi";
 import type { Flow, FlowDefinition, FlowStatus } from "../types/flow";
@@ -27,6 +28,7 @@ export default function FlowEditorPage({ flowId }: Props) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [serverWebhookUrl, setServerWebhookUrl] = useState<string | null>(null);
   const definitionRef = useRef(definition);
   definitionRef.current = definition;
 
@@ -43,6 +45,23 @@ export default function FlowEditorPage({ flowId }: Props) {
       .catch((e) => Toast.error(`加载失败：${(e as Error).message}`))
       .finally(() => {
         if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [flowId]);
+
+  // Best-effort fetch the canonical webhook URL from the server. Failure is
+  // non-fatal — we fall back to a locally-derived URL so the copy button
+  // still works during local dev.
+  useEffect(() => {
+    let cancelled = false;
+    getWebhookUrl(flowId)
+      .then((info) => {
+        if (!cancelled && info.url) setServerWebhookUrl(info.url);
+      })
+      .catch(() => {
+        // silently ignore; fallback URL is computed below
       });
     return () => {
       cancelled = true;
@@ -117,10 +136,13 @@ export default function FlowEditorPage({ flowId }: Props) {
     );
   }
 
-  // Webhook URL is conventionally exposed under /api/v1/flows/:id/webhook —
-  // we hand it to the trigger-webhook config form for display.
+  // Webhook URL prefers the server-issued value (POST /v1/flows/:id/webhook
+  // is the runtime ingest path; GET returns the canonical URL). When the
+  // server hasn't yet exposed it (or in offline dev) we fall back to the
+  // locally-computed URL so the copy button still does something useful.
   const apiBase = (WKApp.apiClient.config.apiURL || "/api/v1/").replace(/\/$/, "");
-  const webhookUrl = `${window.location.origin}${apiBase}/flows/${flow.id}/webhook`;
+  const fallbackWebhookUrl = `${window.location.origin}${apiBase}/flows/${flow.id}/webhook`;
+  const webhookUrl = serverWebhookUrl || fallbackWebhookUrl;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>

--- a/packages/dmworkflow/src/pages/FlowListPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowListPage.tsx
@@ -10,6 +10,7 @@ import {
   listFlows,
 } from "../api/flowApi";
 import type { ExecutionStatus, Flow, FlowStatus } from "../types/flow";
+import { FLOW_TEMPLATES, findTemplate } from "../utils/flowTemplates";
 
 const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
   draft: "grey",
@@ -31,6 +32,7 @@ export default function FlowListPage() {
   const [creating, setCreating] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [draftName, setDraftName] = useState("");
+  const [draftTemplateId, setDraftTemplateId] = useState<string>("blank");
 
   const load = useCallback(() => {
     setLoading(true);
@@ -52,20 +54,29 @@ export default function FlowListPage() {
     WKApp.route.push("/flow/executions", { flowId: id });
   };
 
+  const openCreate = () => {
+    setDraftName("");
+    setDraftTemplateId("blank");
+    setCreateOpen(true);
+  };
+
   const handleCreate = async () => {
     const name = draftName.trim();
     if (!name) {
       Toast.warning("请输入 Flow 名称");
       return;
     }
+    const template = findTemplate(draftTemplateId) ?? findTemplate("blank")!;
     setCreating(true);
     try {
       const flow = await createFlow({
         name,
-        definition: { nodes: [], edges: [] },
+        description: template.id === "blank" ? undefined : `From template: ${template.label}`,
+        definition: template.build(),
       });
       setCreateOpen(false);
       setDraftName("");
+      setDraftTemplateId("blank");
       openEditor(flow.id);
     } catch (e) {
       Toast.error(`创建失败：${(e as Error).message}`);
@@ -99,7 +110,7 @@ export default function FlowListPage() {
       <div style={{ display: "flex", alignItems: "center", marginBottom: 12 }}>
         <div style={{ fontSize: 18, fontWeight: 600, flex: 1 }}>Octo Flow</div>
         <Button icon={<IconRefresh />} onClick={load} style={{ marginRight: 8 }}>刷新</Button>
-        <Button type="primary" icon={<IconPlus />} onClick={() => setCreateOpen(true)}>
+        <Button type="primary" icon={<IconPlus />} onClick={openCreate}>
           新建 Flow
         </Button>
       </div>
@@ -170,9 +181,60 @@ export default function FlowListPage() {
         onOk={handleCreate}
         confirmLoading={creating}
         okText="创建"
+        width={520}
       >
         <div style={{ fontSize: 12, marginBottom: 4 }}>名称</div>
         <Input value={draftName} onChange={setDraftName} placeholder="my-first-flow" />
+
+        <div style={{ fontSize: 12, marginTop: 16, marginBottom: 6 }}>模板</div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {FLOW_TEMPLATES.map((tpl) => {
+            const active = tpl.id === draftTemplateId;
+            return (
+              <div
+                key={tpl.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => setDraftTemplateId(tpl.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setDraftTemplateId(tpl.id);
+                  }
+                }}
+                style={{
+                  cursor: "pointer",
+                  padding: "10px 12px",
+                  border: `1px solid ${active ? "var(--semi-color-primary)" : "var(--semi-color-border)"}`,
+                  borderRadius: 6,
+                  background: active ? "var(--semi-color-primary-light-default)" : "transparent",
+                  outline: "none",
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 10,
+                }}
+              >
+                <div
+                  style={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: "50%",
+                    border: `2px solid ${active ? "var(--semi-color-primary)" : "var(--semi-color-border)"}`,
+                    background: active ? "var(--semi-color-primary)" : "transparent",
+                    flexShrink: 0,
+                    marginTop: 3,
+                  }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 500, fontSize: 13 }}>{tpl.label}</div>
+                  <div style={{ fontSize: 12, color: "var(--semi-color-text-2)", marginTop: 2 }}>
+                    {tpl.description}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </Modal>
     </div>
   );

--- a/packages/dmworkflow/src/utils/__tests__/flowLayout.test.ts
+++ b/packages/dmworkflow/src/utils/__tests__/flowLayout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildLayeredLayout, isParallelSiblingEdge } from "../flowLayout";
+import type { FlowDefinition } from "../../types/flow";
+
+const action = (id: string) => ({
+  id,
+  type: "action.script" as const,
+  position: { x: 0, y: 0 },
+  config: {},
+});
+
+describe("buildLayeredLayout", () => {
+  it("returns empty result for empty definition", () => {
+    const out = buildLayeredLayout({ nodes: [], edges: [] });
+    expect(out.nodes).toEqual([]);
+    expect(out.edges).toEqual([]);
+  });
+
+  it("places same-layer parallel siblings in different rows and emits a dashed edge", () => {
+    const def: FlowDefinition = {
+      nodes: [
+        { ...action("t"), type: "trigger.manual" },
+        action("a"),
+        action("b"),
+      ],
+      edges: [
+        { id: "e1", source: "t", target: "a" },
+        { id: "e2", source: "t", target: "b" },
+      ],
+    };
+    const out = buildLayeredLayout(def);
+    expect(out.layers).toEqual({ t: 0, a: 1, b: 1 });
+    const a = out.nodes.find((n) => n.id === "a")!;
+    const b = out.nodes.find((n) => n.id === "b")!;
+    // Same column, different rows.
+    expect(a.position.x).toBe(b.position.x);
+    expect(a.position.y).not.toBe(b.position.y);
+    const sibling = out.edges.filter((e) => isParallelSiblingEdge(e.id));
+    expect(sibling).toHaveLength(1);
+    expect(sibling[0]).toMatchObject({ source: "a", target: "b" });
+  });
+
+  it("does not connect same-layer nodes that don't share a parent", () => {
+    const def: FlowDefinition = {
+      nodes: [action("a"), action("b")],
+      edges: [],
+    };
+    const out = buildLayeredLayout(def);
+    const sibling = out.edges.filter((e) => isParallelSiblingEdge(e.id));
+    expect(sibling).toHaveLength(0);
+  });
+
+  it("diamond: layer of a node = max layer of its parents + 1", () => {
+    const def: FlowDefinition = {
+      nodes: [
+        { ...action("t"), type: "trigger.manual" },
+        action("a"),
+        action("b"),
+        action("s"),
+      ],
+      edges: [
+        { id: "e1", source: "t", target: "a" },
+        { id: "e2", source: "t", target: "b" },
+        { id: "e3", source: "a", target: "s" },
+        { id: "e4", source: "b", target: "s" },
+      ],
+    };
+    const out = buildLayeredLayout(def);
+    expect(out.layers.s).toBe(2);
+    expect(out.layers.a).toBe(1);
+    expect(out.layers.b).toBe(1);
+  });
+});

--- a/packages/dmworkflow/src/utils/flowLayout.ts
+++ b/packages/dmworkflow/src/utils/flowLayout.ts
@@ -1,0 +1,154 @@
+// Layered layout for ExecutionView: arranges nodes left-to-right by topological
+// depth so same-layer (parallel) nodes render side-by-side, and emits dashed
+// "sibling" edges between nodes that share a layer + at least one upstream
+// parent — which is the precise definition of "parallel" in our DAG.
+//
+// Pure utility, no React. Heavy logic kept here so FlowEditor stays
+// rendering-focused.
+
+import type { FlowDefinition, FlowEdge, FlowNode } from "../types/flow";
+
+const COLUMN_X = 240;
+const ROW_Y = 110;
+const ORIGIN_X = 80;
+const ORIGIN_Y = 40;
+
+export const PARALLEL_EDGE_PREFIX = "__parallel__";
+
+/** Returns true if the synthetic edge id was emitted by buildLayeredLayout. */
+export function isParallelSiblingEdge(edgeId: string): boolean {
+  return edgeId.startsWith(PARALLEL_EDGE_PREFIX);
+}
+
+interface LayoutResult {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  /** node-id → 0-based layer index. Useful for tests & debugging. */
+  layers: Record<string, number>;
+}
+
+/**
+ * Compute layered positions and synthetic sibling edges for a flow definition.
+ * The original `position` of each node is replaced; original edges are
+ * preserved verbatim.
+ */
+export function buildLayeredLayout(def: FlowDefinition): LayoutResult {
+  const nodes = def.nodes;
+  const edges = def.edges;
+  if (nodes.length === 0) {
+    return { nodes: [], edges: [], layers: {} };
+  }
+
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const adjOut = new Map<string, string[]>();
+  const adjIn = new Map<string, string[]>();
+  for (const n of nodes) {
+    adjOut.set(n.id, []);
+    adjIn.set(n.id, []);
+  }
+  for (const e of edges) {
+    if (!byId.has(e.source) || !byId.has(e.target)) continue;
+    adjOut.get(e.source)!.push(e.target);
+    adjIn.get(e.target)!.push(e.source);
+  }
+
+  // Layer assignment: a node sits one layer past its deepest predecessor.
+  // Cycles are tolerated (we cap iterations); any node we can't reach gets
+  // layer 0 so it still renders.
+  const layer: Record<string, number> = {};
+  const seedRoots: string[] = nodes.filter((n) => (adjIn.get(n.id) ?? []).length === 0).map((n) => n.id);
+  const queue: string[] = [];
+  for (const id of seedRoots) {
+    layer[id] = 0;
+    queue.push(id);
+  }
+  // Fallback: if the graph has no source (every node in a cycle), seed all
+  // nodes at layer 0.
+  if (queue.length === 0) {
+    for (const n of nodes) {
+      layer[n.id] = 0;
+      queue.push(n.id);
+    }
+  }
+  const safetyLimit = nodes.length * 8;
+  let iterations = 0;
+  while (queue.length > 0 && iterations < safetyLimit) {
+    iterations += 1;
+    const cur = queue.shift()!;
+    const curLayer = layer[cur] ?? 0;
+    for (const next of adjOut.get(cur) ?? []) {
+      const nextLayer = curLayer + 1;
+      if (layer[next] === undefined || layer[next] < nextLayer) {
+        layer[next] = nextLayer;
+        queue.push(next);
+      }
+    }
+  }
+  for (const n of nodes) {
+    if (layer[n.id] === undefined) layer[n.id] = 0;
+  }
+
+  // Group by layer and assign deterministic vertical slots. Sort within a
+  // layer by (parent layer-row, then original id) so a parent's children stay
+  // visually close to it.
+  const layerToIds = new Map<number, string[]>();
+  for (const n of nodes) {
+    const l = layer[n.id];
+    if (!layerToIds.has(l)) layerToIds.set(l, []);
+    layerToIds.get(l)!.push(n.id);
+  }
+  const sortedLayers = Array.from(layerToIds.keys()).sort((a, b) => a - b);
+  const slot: Record<string, number> = {};
+  for (const l of sortedLayers) {
+    const ids = layerToIds.get(l)!;
+    ids.sort((a, b) => {
+      const pa = (adjIn.get(a) ?? [])[0];
+      const pb = (adjIn.get(b) ?? [])[0];
+      const sa = pa !== undefined ? slot[pa] ?? 0 : 0;
+      const sb = pb !== undefined ? slot[pb] ?? 0 : 0;
+      if (sa !== sb) return sa - sb;
+      return a.localeCompare(b);
+    });
+    ids.forEach((id, idx) => {
+      slot[id] = idx;
+    });
+  }
+
+  const positionedNodes: FlowNode[] = nodes.map((n) => ({
+    ...n,
+    position: {
+      x: ORIGIN_X + (layer[n.id] ?? 0) * COLUMN_X,
+      y: ORIGIN_Y + (slot[n.id] ?? 0) * ROW_Y,
+    },
+  }));
+
+  // Sibling/parallel edges: two nodes are "parallel siblings" when they sit
+  // on the same layer AND share at least one upstream parent. We connect
+  // adjacent ones (ordered by slot) with a dashed edge so the layered
+  // relationship is visually obvious in the read-only view.
+  const siblingEdges: FlowEdge[] = [];
+  for (const l of sortedLayers) {
+    if (l === 0) continue;
+    const ids = layerToIds.get(l)!;
+    if (ids.length < 2) continue;
+    for (let i = 0; i + 1 < ids.length; i += 1) {
+      const a = ids[i];
+      const b = ids[i + 1];
+      const parentsA = new Set(adjIn.get(a) ?? []);
+      const parentsB = adjIn.get(b) ?? [];
+      const sharesParent = parentsB.some((p) => parentsA.has(p));
+      if (!sharesParent) continue;
+      siblingEdges.push({
+        id: `${PARALLEL_EDGE_PREFIX}${a}__${b}`,
+        source: a,
+        target: b,
+      });
+    }
+  }
+
+  return {
+    nodes: positionedNodes,
+    edges: [...edges, ...siblingEdges],
+    layers: layer,
+  };
+}

--- a/packages/dmworkflow/src/utils/flowTemplates.ts
+++ b/packages/dmworkflow/src/utils/flowTemplates.ts
@@ -1,0 +1,174 @@
+// Flow templates surfaced in the "新建 Flow" dialog. Templates are pure
+// frontend data (no backend API) — selecting one stamps a starter
+// FlowDefinition the user can edit immediately.
+
+import type { FlowDefinition, FlowNode, FlowEdge, NodeType } from "../types/flow";
+
+export interface FlowTemplate {
+  id: string;
+  label: string;
+  description: string;
+  /** Builds a fresh definition with deterministic-but-unique node ids. */
+  build: () => FlowDefinition;
+}
+
+let counter = 0;
+function uid(prefix: string): string {
+  counter += 1;
+  return `${prefix}_${Date.now().toString(36)}_${counter.toString(36)}`;
+}
+
+function n(type: NodeType, x: number, y: number, config: FlowNode["config"] = {}): FlowNode {
+  return { id: uid("n"), type, position: { x, y }, config };
+}
+
+function e(source: string, target: string, label?: string): FlowEdge {
+  const branch = label;
+  return { id: uid("e"), source, target, label, branch };
+}
+
+const PR_REVIEW_SCRIPT = `// Parse the GitHub webhook payload into a normalized PR descriptor.
+// \`input\` is whatever the webhook delivered (already JSON-parsed).
+const pr = input?.pull_request ?? {};
+return {
+  owner: input?.repository?.owner?.login,
+  repo: input?.repository?.name,
+  number: pr.number,
+  title: pr.title,
+  body: pr.body ?? "",
+  head: pr.head?.sha,
+  diff_url: pr.diff_url,
+};
+`;
+
+const SIMPLE_HTTP_SCRIPT = `// Build the HTTP payload for the next node.
+return {
+  greeting: "hello",
+  ts: Date.now(),
+};
+`;
+
+export const FLOW_TEMPLATES: FlowTemplate[] = [
+  {
+    id: "blank",
+    label: "空白 Flow",
+    description: "不预置任何节点，从零开始拖拽。",
+    build: () => ({ nodes: [], edges: [] }),
+  },
+  {
+    id: "simple-http",
+    label: "简单 HTTP 调用",
+    description: "Script 生成 payload → HTTP 节点发出请求。",
+    build: () => {
+      const script = n("action.script", 80, 80, {
+        label: "Build payload",
+        scriptLanguage: "javascript",
+        scriptCode: SIMPLE_HTTP_SCRIPT,
+      });
+      const http = n("action.http", 360, 80, {
+        label: "Send request",
+        httpMethod: "POST",
+        httpUrl: "https://example.com/api/echo",
+        httpHeaders: [{ key: "Content-Type", value: "application/json" }],
+        httpBody: '{"hello":"world"}',
+      });
+      return {
+        nodes: [script, http],
+        edges: [e(script.id, http.id)],
+      };
+    },
+  },
+  {
+    id: "condition",
+    label: "条件分支",
+    description: "Script → 条件节点 → 分别走两条 HTTP 分支。",
+    build: () => {
+      const script = n("action.script", 80, 120, {
+        label: "Compute branch",
+        scriptLanguage: "javascript",
+        scriptCode: `// Return any value the condition node can evaluate against.\nreturn { kind: input?.kind ?? "a" };\n`,
+      });
+      const cond = n("logic.condition", 360, 120, {
+        label: "Route by kind",
+        conditionExpression: "input.kind",
+        conditionBranches: [
+          { value: "a", label: "Branch A" },
+          { value: "b", label: "Branch B" },
+        ],
+      });
+      const httpA = n("action.http", 640, 40, {
+        label: "Branch A",
+        httpMethod: "POST",
+        httpUrl: "https://example.com/branch-a",
+      });
+      const httpB = n("action.http", 640, 200, {
+        label: "Branch B",
+        httpMethod: "POST",
+        httpUrl: "https://example.com/branch-b",
+      });
+      return {
+        nodes: [script, cond, httpA, httpB],
+        edges: [
+          e(script.id, cond.id),
+          e(cond.id, httpA.id, "a"),
+          e(cond.id, httpB.id, "b"),
+        ],
+      };
+    },
+  },
+  {
+    id: "pr-review",
+    label: "PR Review",
+    description: "Webhook 触发 → 解析 PR → 调 review API → 条件 → 发 comment。",
+    build: () => {
+      const trigger = n("trigger.webhook", 60, 120, {
+        label: "GitHub webhook",
+        signatureAlgo: "hmac-sha256",
+        signatureHeader: "X-Hub-Signature-256",
+      });
+      const parse = n("action.script", 320, 120, {
+        label: "Parse PR",
+        scriptLanguage: "javascript",
+        scriptCode: PR_REVIEW_SCRIPT,
+      });
+      const review = n("action.http", 580, 120, {
+        label: "Call review API",
+        httpMethod: "POST",
+        httpUrl: "https://im-lab.xming.ai/v1/review",
+        httpHeaders: [{ key: "Content-Type", value: "application/json" }],
+        httpBody: '{"owner":"{{ steps.parse.owner }}","repo":"{{ steps.parse.repo }}","number":{{ steps.parse.number }}}',
+      });
+      const cond = n("logic.condition", 840, 120, {
+        label: "Has findings?",
+        conditionExpression: "input.findings && input.findings.length > 0",
+        conditionBranches: [
+          { value: "true", label: "comment" },
+          { value: "false", label: "skip" },
+        ],
+      });
+      const comment = n("action.http", 1100, 60, {
+        label: "Post comment",
+        httpMethod: "POST",
+        httpUrl: "https://api.github.com/repos/{{ steps.parse.owner }}/{{ steps.parse.repo }}/issues/{{ steps.parse.number }}/comments",
+        httpHeaders: [
+          { key: "Authorization", value: "Bearer {{ secrets.GITHUB_TOKEN }}" },
+          { key: "Accept", value: "application/vnd.github+json" },
+        ],
+        httpBody: '{"body":"{{ steps.review.summary }}"}',
+      });
+      return {
+        nodes: [trigger, parse, review, cond, comment],
+        edges: [
+          e(trigger.id, parse.id),
+          e(parse.id, review.id),
+          e(review.id, cond.id),
+          e(cond.id, comment.id, "true"),
+        ],
+      };
+    },
+  },
+];
+
+export function findTemplate(id: string): FlowTemplate | undefined {
+  return FLOW_TEMPLATES.find((t) => t.id === id);
+}


### PR DESCRIPTION
Closes [YUJ-2061](mention://issue/61f6b5b5-3b9f-4768-9eb1-dec6922eabe0)

Phase 2 frontend adaptation for the parallel/webhook/cron backend that just shipped to `im-lab.xming.ai`.

## ExecutionView — parallel visualization
- **New `flowLayout` util** — BFS-based topological layering. Same-layer nodes (= parallel siblings sharing an upstream parent) are stacked side-by-side, and an extra dashed sibling edge is emitted so the layered relationship is obvious in the read-only execution view.
- **FlowEditor** switches to layered layout in \`readOnly\` mode (used by ExecutionView) while keeping user-placed positions intact in the editor mode.
- **FlowNodeView** gets a per-status palette per the spec:
  - \`success\` = green, \`failed\` = red, \`running\` = blue, \`pending\` = grey
  - \`cancelled\` keeps an amber accent so it's distinguishable from pending.

## Trigger configuration
- **Webhook** — \`WebhookConfig\` already had the copy button + URL display; the editor page now fetches the canonical URL from \`GET /v1/flows/:id/webhook\` (new \`getWebhookUrl\` API helper) and falls back to a locally-derived URL when the API isn't available.
- **Cron** — \`CronConfig\` grows quick-template buttons (\"每分钟 / 每小时 / 每天 / 每周\") that populate a 5-field expression. The existing live \`下次执行\` preview confirms the result.

## New-flow template picker
- The \"新建 Flow\" modal is now a name input + card-style template list:
  - 空白 Flow
  - 简单 HTTP 调用 (\`script → http\`)
  - 条件分支 (\`script → condition → (a:http, b:http)\`)
  - PR Review (\`webhook → script → http(review) → condition → http(comment)\`)
- Templates are pure frontend (\`utils/flowTemplates.ts\`) — no backend dependency. Each \`build()\` returns a fresh definition with unique node ids so the same template can be stamped multiple times.

## Tests
- vitest unit tests for the layered-layout invariants (\`packages/dmworkflow/src/utils/__tests__/flowLayout.test.ts\`).