### PR TITLE
Fix message grouping for same-sender messages after long gaps

### DIFF
--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -34,6 +34,7 @@ import moment from "moment";
 import ThreadIndicator, {
   ThreadIndicatorData,
 } from "../../Components/ThreadIndicator";
+import { isMessageContinuation } from "../../Service/messageContinuity";
 
 interface MessageBaseProps extends HTMLProps<any> {
   message: MessageWrap;
@@ -142,12 +143,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
       return false;
     }
     const { message } = this.props;
-    if (message.preMessage) {
-      if (message.fromUID === message.preMessage.fromUID) {
-        return true;
-      }
-    }
-    return false;
+    return isMessageContinuation(message.preMessage, message);
   }
 
   getMessageStyle(hasContinue: boolean, message: MessageWrap) {
@@ -167,18 +163,12 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
       messageStyle.marginBottom = "0px";
       messageStyle.marginRight = "0px";
     }
-    if (message.preMessage && message.preMessage.fromUID !== message.fromUID) {
-      if (
-        message.nextMessage &&
-        message.nextMessage.fromUID === message.fromUID
-      ) {
+    if (!hasContinue) {
+      if (isMessageContinuation(message, message.nextMessage)) {
         messageStyle.marginBottom = "0px";
       }
     }
-    if (
-      message.nextMessage &&
-      message.nextMessage.fromUID !== message.fromUID
-    ) {
+    if (!isMessageContinuation(message, message.nextMessage)) {
       messageStyle.marginBottom = "15px";
     }
     return messageStyle;
@@ -190,15 +180,13 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     }
     if (
       hasContinue &&
-      message.nextMessage &&
-      message.nextMessage.fromUID === message.fromUID
+      isMessageContinuation(message, message.nextMessage)
     ) {
       return "8px 20px 20px 8px";
     }
     if (
       hasContinue &&
-      message.nextMessage &&
-      message.nextMessage.fromUID !== message.fromUID
+      !isMessageContinuation(message, message.nextMessage)
     ) {
       return "8px 20px 20px 8px";
     }

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -5,6 +5,7 @@ import { MessageContentTypeConst, MessageReasonCode, OrderFactor } from "./Const
 import { DefaultEmojiService } from "./EmojiService"
 import { TypingManager } from "./TypingManager"
 import { getSpaceFilteredLastMessage, SYSTEM_BOTS } from "./SpaceService"
+import { isMessageContinuation } from "./messageContinuity"
 
 export class ConversationWrap {
     conversation: Conversation
@@ -362,39 +363,28 @@ export class MessageWrap {
 
     public get bubblePosition(): BubblePosition {
 
-        if (!this.preIsSamePerson && this.nextIsSamePerson) {
+        if (!this.isContinueFromPrevious && this.isContinueToNext) {
             return BubblePosition.first
         }
-        if (this.preIsSamePerson && this.nextIsSamePerson) {
+        if (this.isContinueFromPrevious && this.isContinueToNext) {
             return BubblePosition.middle
         }
 
-        if (this.preIsSamePerson && !this.nextIsSamePerson) {
+        if (this.isContinueFromPrevious && !this.isContinueToNext) {
             return BubblePosition.last
         }
-        if (!this.preIsSamePerson && !this.nextIsSamePerson) {
+        if (!this.isContinueFromPrevious && !this.isContinueToNext) {
             return BubblePosition.single
         }
         return BubblePosition.unknown
     }
 
-    private get preIsSamePerson(): boolean {
-        if (this.preMessage?.content.contentType === MessageContentTypeConst.time) {
-            return false
-        }
-        if (this.preMessage?.revoke) {
-            return false
-        }
-        return this.preMessage?.fromUID === this.fromUID
+    public get isContinueFromPrevious(): boolean {
+        return isMessageContinuation(this.preMessage, this)
     }
-    private get nextIsSamePerson(): boolean {
-        if (this.nextMessage?.content.contentType === MessageContentTypeConst.time) {
-            return false
-        }
-        if (this.nextMessage?.revoke) {
-            return false
-        }
-        return this.nextMessage?.fromUID === this.fromUID
+
+    public get isContinueToNext(): boolean {
+        return isMessageContinuation(this, this.nextMessage)
     }
 
     // 解析@

--- a/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { MessageContentTypeConst } from "../Const"
+import { MESSAGE_CONTINUATION_MAX_GAP_SEC, isMessageContinuation } from "../messageContinuity"
+
+const msg = (fromUID: string, timestamp: number, extra: Record<string, unknown> = {}) => ({
+    fromUID,
+    timestamp,
+    contentType: 1,
+    ...extra,
+})
+
+describe("isMessageContinuation", () => {
+    it("continues messages from the same sender within 10 minutes", () => {
+        expect(isMessageContinuation(
+            msg("u1", 1_000),
+            msg("u1", 1_000 + MESSAGE_CONTINUATION_MAX_GAP_SEC - 1),
+        )).toBe(true)
+    })
+
+    it("breaks same-sender groups at 10 minutes", () => {
+        expect(isMessageContinuation(
+            msg("u1", 1_000),
+            msg("u1", 1_000 + MESSAGE_CONTINUATION_MAX_GAP_SEC),
+        )).toBe(false)
+    })
+
+    it("breaks same-sender groups when the previous item is a local separator", () => {
+        expect(isMessageContinuation(
+            msg("u1", 1_000, { contentType: MessageContentTypeConst.time }),
+            msg("u1", 1_030),
+        )).toBe(false)
+    })
+
+    it("does not continue across different senders", () => {
+        expect(isMessageContinuation(msg("u1", 1_000), msg("u2", 1_030))).toBe(false)
+    })
+})

--- a/packages/dmworkbase/src/Service/messageContinuity.ts
+++ b/packages/dmworkbase/src/Service/messageContinuity.ts
@@ -1,0 +1,45 @@
+import { MessageContentTypeConst } from "./Const"
+
+export const MESSAGE_CONTINUATION_MAX_GAP_SEC = 10 * 60
+
+interface ContinuityMessage {
+    fromUID?: string
+    timestamp?: number
+    revoke?: boolean
+    contentType?: number
+    content?: {
+        contentType?: number
+    }
+}
+
+function contentTypeOf(message: ContinuityMessage): number | undefined {
+    return message.contentType ?? message.content?.contentType
+}
+
+function isBoundaryMessage(message: ContinuityMessage): boolean {
+    const contentType = contentTypeOf(message)
+    return contentType === MessageContentTypeConst.time
+        || contentType === MessageContentTypeConst.historySplit
+        || !!message.revoke
+}
+
+export function isMessageContinuation(previous?: ContinuityMessage, current?: ContinuityMessage): boolean {
+    if (!previous || !current) {
+        return false
+    }
+    if (isBoundaryMessage(previous) || isBoundaryMessage(current)) {
+        return false
+    }
+    if (!previous.fromUID || previous.fromUID !== current.fromUID) {
+        return false
+    }
+    const previousTimestamp = previous.timestamp
+    const currentTimestamp = current.timestamp
+    if (typeof previousTimestamp !== "number" || typeof currentTimestamp !== "number") {
+        return true
+    }
+    if (!Number.isFinite(previousTimestamp) || !Number.isFinite(currentTimestamp)) {
+        return true
+    }
+    return Math.abs(currentTimestamp - previousTimestamp) < MESSAGE_CONTINUATION_MAX_GAP_SEC
+}

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -2,12 +2,12 @@ import React, { useCallback, useEffect, useState } from 'react'
 import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson, ChannelTypeGroup } from 'wukongimjssdk'
 import WKApp from '../../App'
 import { MessageWrap } from '../../Service/Model'
-import { MessageContentTypeConst } from '../../Service/Const'
 import { MessageRowUIProps } from './types'
 import { resolveExternalForViewer } from '../../Utils/externalViewer'
 import { subscriberDisplayName } from '../../Utils/displayName'
 import { shouldShowRealnameBadge } from '../../Utils/realnameBadge'
 import moment from 'moment'
+import { isMessageContinuation } from '../../Service/messageContinuity'
 
 export interface MessageRowSelectionState {
   /** 是否处于多选模式（来自 context.editOn()） */
@@ -82,11 +82,7 @@ export function getMessageRow(
 
   // 判断是否为连续消息（对齐 Model.tsx preIsSamePerson 逻辑）
   // 时间分隔符或撤回消息之后不算连续
-  const pre = message.preMessage
-  const isContinue = !!pre
-    && pre.content?.contentType !== MessageContentTypeConst.time
-    && !pre.revoke
-    && pre.fromUID === message.fromUID
+  const isContinue = isMessageContinuation(message.preMessage, message)
 
   // 格式化时间戳
   const timestamp = formatTimestamp(message.timestamp)


### PR DESCRIPTION
## Summary

- Add a shared message-continuation helper with a 10-minute grouping threshold.
- Use the shared rule for legacy message bubbles, `MessageWrap` bubble positions, and bridge message rows.
- Add unit coverage for same-sender grouping boundaries.

Fixes #113

## Validation

- `pnpm exec vitest run packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts packages/dmworkbase/src/bridge/message/__tests__/useMessageRow.realname.test.ts`
- `git diff --check`
- Manually verified same-sender message grouping before and after the 10-minute threshold.