### PR TITLE
fix(flow): open editor and executions via routeRight, not WKApp.route

### DIFF
--- a/packages/dmworkflow/src/pages/FlowListPage.tsx
+++ b/packages/dmworkflow/src/pages/FlowListPage.tsx
@@ -10,6 +10,8 @@ import {
   listFlows,
 } from "../api/flowApi";
 import type { ExecutionStatus, Flow, FlowStatus } from "../types/flow";
+import FlowEditorPage from "./FlowEditorPage";
+import FlowExecutionsPage from "./FlowExecutionsPage";
 
 const STATUS_COLOR: Record<FlowStatus, "grey" | "green" | "amber"> = {
   draft: "grey",
@@ -44,12 +46,18 @@ export default function FlowListPage() {
     load();
   }, [load]);
 
+  // 注意：列表页 (`/flow`) 由模块菜单 onPress 通过 `WKApp.routeRight.replaceToRoot`
+  // 挂在右侧主区域，下面的子页面也必须通过同一个 routeRight 推进，否则 `WKApp.route.push`
+  // 仅会调用 `restContent`，没有任何 listener 把它渲染出来 → 点击列表项无反应
+  // (YUJ-2070, Bug 2)。统一沿用 SummaryListPage 的 popToRoot + push 范式。
   const openEditor = (id: string) => {
-    WKApp.route.push("/flow/edit", { flowId: id });
+    WKApp.routeRight.popToRoot();
+    WKApp.routeRight.push(<FlowEditorPage flowId={id} />);
   };
 
   const openExecutions = (id: string) => {
-    WKApp.route.push("/flow/executions", { flowId: id });
+    WKApp.routeRight.popToRoot();
+    WKApp.routeRight.push(<FlowExecutionsPage flowId={id} />);
   };
 
   const handleCreate = async () => {


### PR DESCRIPTION
## Why

Bug 2 in YUJ-2070: clicking a row in the Flow list page does nothing — no orchestrator opens.

## Root cause

The Flow nav menu mounts `FlowListPage` on `routeRight` via `replaceToRoot`, but row clicks called `WKApp.route.push("/flow/edit", { flowId })`. `route.push` only invokes `WKApp.shared.restContent`, which sets `this.content` and notifies generic listeners — nothing in the actual layout subscribes to that field, so the click was a silent no-op.

## Fix

Switch `openEditor` and `openExecutions` to the `routeRight` pattern already used by `SummaryListPage`: `popToRoot` then `push` the page component directly. Same pattern keeps the back button on the route header working (back pops the editor and reveals the list).

The name column already had `onClick=openEditor` wired up, so both the link in the name column and the 编辑 button now correctly open the orchestrator.

No type / lint issues introduced. Verified via code review against `SummaryListPage` / `SummaryDetailPage` / `Service/Route.tsx` semantics — coda will deploy and screenshot end-to-end.

Part of YUJ-2070.