### PR TITLE
Fix thread archive state refresh

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -456,6 +456,34 @@ body[theme-mode="dark"] .wk-conversation-content {
   height: 100%;
 }
 
+.wk-conversation-input-notice-wrap {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 16px 6px;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.wk-conversation-input-notice-bubble {
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(28, 28, 35, 0.08);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 14px rgba(28, 28, 35, 0.08);
+  color: var(--wk-status-archived-text, var(--wk-text-secondary));
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+body[theme-mode="dark"] .wk-conversation-input-notice-bubble {
+  background: rgba(38, 38, 42, 0.94);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
 .wk-conversation-chattoolbars {
   height: 100%;
   margin-bottom: 0px;

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -256,6 +256,10 @@ export interface ConversationProps {
     editOn: boolean;
     checkedCount: number;
   }) => void;
+  /** 展示在输入框上方的轻量提示。 */
+  inputNotice?: React.ReactNode;
+  /** 当前会话发送完成后的回调。 */
+  onMessageSent?: () => void;
   /** 当前正在预览的文件消息 ID（用于文件卡片激活态） */
   activePreviewMessageId?: string | null;
 }
@@ -2204,6 +2208,13 @@ export class Conversation
                         : undefined
                     }
                   >
+                    {this.props.inputNotice && (
+                      <div className="wk-conversation-input-notice-wrap">
+                        <div className="wk-conversation-input-notice-bubble">
+                          {this.props.inputNotice}
+                        </div>
+                      </div>
+                    )}
                     <MessageInput
                       botCommands={botCommands}
                       onAddAttachment={(addFn: (files: File[]) => void) => {
@@ -2572,6 +2583,7 @@ export class Conversation
                             await this.sendTextAndWaitAck(emptyContent);
                           }
                         }
+                        this.props.onMessageSent?.();
                       }}
                     ></MessageInput>
                   </div>

--- a/packages/dmworkbase/src/Components/ListItem/index.css
+++ b/packages/dmworkbase/src/Components/ListItem/index.css
@@ -20,6 +20,18 @@ body[theme-mode=dark] .wk-list-item {
     background-color: #eee;
 }
 
+.wk-list-item-static {
+    cursor: default;
+}
+
+.wk-list-item-static:hover {
+    background-color: white;
+}
+
+body[theme-mode=dark] .wk-list-item-static:hover {
+    background-color: var(--wk-color-secondary-2);
+}
+
 
 .wk-list-item-ripple {
     position: relative;

--- a/packages/dmworkbase/src/Components/ListItem/index.tsx
+++ b/packages/dmworkbase/src/Components/ListItem/index.tsx
@@ -7,16 +7,17 @@ export interface ListItemProps {
     style: CSSProperties
     title: string
     subTitle?: React.ReactNode
-    onClick: () => void
+    onClick?: () => void
 }
 
 export class ListItem extends Component<ListItemProps>{
 
     render() {
         const { style, title, subTitle, onClick } = this.props
+        const clickable = typeof onClick === "function"
         const titleAttr = typeof subTitle === "string" ? subTitle : undefined
-        return <div className="wk-list-item wk-list-item-ripple" style={style} title={titleAttr} onClick={() => {
-            if (onClick) {
+        return <div className={`wk-list-item ${clickable ? "wk-list-item-ripple" : "wk-list-item-static"}`} style={style} title={titleAttr} onClick={() => {
+            if (clickable) {
                 onClick()
             }
         }}>

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -40,6 +40,10 @@ import {
 } from "../WKLayout/layoutWidth";
 import "./index.css";
 
+// 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
+// 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
+const THREAD_REACTIVATE_REFRESH_DELAYS_MS = [0, 300, 800, 1500];
+
 /** API 返回的文件数据结构 */
 interface ChannelFileResponse {
   message_id: string | number;
@@ -58,7 +62,7 @@ export interface ThreadPanelProps {
   groupNo?: string;
   thread?: Thread | null;
   onClose: () => void;
-  onThreadSelect?: (thread: Thread) => void;
+  onThreadSelect?: (thread: Thread | null) => void;
   onCreateThread?: () => void;
   /** 文件预览信息，传入时渲染文件预览内容而非子区内容 */
   filePreview?: FilePreviewInfo | null;
@@ -270,13 +274,31 @@ export default class ThreadPanel extends Component<
   componentDidUpdate(prevProps: ThreadPanelProps) {
     // 纯文件预览模式时跳过子区相关逻辑
     if (this.props.groupNo) {
-      if (this.props.thread !== prevProps.thread) {
+      const prevThreadShortId = prevProps.thread?.short_id;
+      const currentThreadShortId = this.props.thread?.short_id;
+      if (currentThreadShortId !== prevThreadShortId) {
         if (this.props.thread) {
           this.setState({ view: "detail" });
           this.initVM(this.props.thread.short_id);
         } else {
           this.setState({ view: "list" });
         }
+      } else if (this.props.thread !== prevProps.thread && this.props.thread) {
+        // 同一个子区的状态同步只合并数据，不能重新 initVM。
+        // 否则发送消息后父级传回新 thread 对象会重建右侧面板，造成二次刷新体感。
+        const nextThread = this.props.thread;
+        this.setState((prevState) => ({
+          vmState:
+            prevState.vmState.thread?.short_id === nextThread.short_id
+              ? {
+                  ...prevState.vmState,
+                  thread: {
+                    ...prevState.vmState.thread,
+                    ...nextThread,
+                  },
+                }
+              : prevState.vmState,
+        }));
       }
       if (this.props.groupNo !== prevProps.groupNo) {
         this.loadThreads();
@@ -433,17 +455,38 @@ export default class ThreadPanel extends Component<
         {
           page_index: 1,
           page_size: 100,
+          status: "all",
         }
       );
-      // 按活跃时间倒序排序
-      threads.sort(
-        (a, b) =>
-          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-      );
-      this.setState({ threads, threadsLoading: false });
+      threads.sort((a, b) => this.threadSortTime(b) - this.threadSortTime(a));
+      this.setState((prevState) => {
+        const currentThread = prevState.vmState.thread;
+        const refreshedCurrentThread = currentThread
+          ? threads.find((item) => item.short_id === currentThread.short_id)
+          : undefined;
+        return {
+          threads,
+          threadsLoading: false,
+          vmState: currentThread && refreshedCurrentThread
+            ? {
+                ...prevState.vmState,
+                thread: {
+                  ...currentThread,
+                  ...refreshedCurrentThread,
+                },
+              }
+            : prevState.vmState,
+        };
+      });
     } catch {
       this.setState({ threadsLoading: false });
     }
+  }
+
+  private threadSortTime(thread: Thread): number {
+    const raw = thread.last_message_at || thread.updated_at || thread.created_at;
+    const time = raw ? new Date(raw).getTime() : 0;
+    return Number.isFinite(time) ? time : 0;
   }
 
   private handleThreadClick = (thread: Thread) => {
@@ -465,7 +508,18 @@ export default class ThreadPanel extends Component<
   };
 
   private handleBackToList = () => {
-    this.setState({ view: "list" });
+    this.setState((prevState) => ({
+      view: "list",
+      showMoreMenu: false,
+      vmState: {
+        ...prevState.vmState,
+        thread: null,
+        loading: false,
+        error: null,
+      },
+    }));
+    this.props.onThreadSelect?.(null);
+    this.loadThreads();
   };
 
   private handleOpenFullView = () => {
@@ -486,6 +540,7 @@ export default class ThreadPanel extends Component<
   };
 
   private canEditThread(thread: Thread): boolean {
+    if (!this.props.groupNo) return false;
     const isCreator = thread.creator_uid === WKApp.loginInfo.uid;
     const groupChannel = new Channel(this.props.groupNo, ChannelTypeGroup);
     const subscribers =
@@ -498,8 +553,9 @@ export default class ThreadPanel extends Component<
 
   private handleEditThread = () => {
     const { vmState } = this.state;
+    const { groupNo } = this.props;
     const thread = vmState.thread;
-    if (!thread) return;
+    if (!thread || !groupNo) return;
     this.setState({ showMoreMenu: false });
 
     // 延迟弹窗，等 Popover 完全关闭后再触发，避免 Modal 被 Popover 关闭事件误关
@@ -540,7 +596,7 @@ export default class ThreadPanel extends Component<
           }
           try {
             await WKApp.dataSource.channelDataSource.threadUpdate(
-              this.props.groupNo,
+              groupNo,
               thread.short_id,
               { name: newName.trim() }
             );
@@ -556,12 +612,10 @@ export default class ThreadPanel extends Component<
             });
 
             // 清除 SDK 缓存，刷新 Chat header 展示的子区名称
-            const threadChannel = new Channel(
-              buildThreadChannelId(this.props.groupNo, thread.short_id),
-              ChannelTypeCommunityTopic
-            );
-            WKSDK.shared().channelManager.deleteChannelInfo(threadChannel);
-            WKSDK.shared().channelManager.fetchChannelInfo(threadChannel);
+            this.refreshThreadChannelInfo({
+              ...thread,
+              name: newName.trim(),
+            });
           } catch {
             Toast.error("保存失败，请重试");
           }
@@ -570,10 +624,170 @@ export default class ThreadPanel extends Component<
     }, 100);
   };
 
+  private handleToggleArchiveThread = () => {
+    const { vmState } = this.state;
+    const { groupNo } = this.props;
+    const thread = vmState.thread;
+    if (!thread || !groupNo) return;
+
+    const archiving = thread.status === ThreadStatus.Active;
+    const unarchiving = thread.status === ThreadStatus.Archived;
+    if (!archiving && !unarchiving) return;
+
+    this.setState({ showMoreMenu: false });
+
+    setTimeout(() => {
+      Modal.confirm({
+        title: archiving
+          ? `归档子区「${thread.name}」？`
+          : `取消归档「${thread.name}」？`,
+        icon: null,
+        okText: archiving ? "归档" : "取消归档",
+        cancelText: "取消",
+        content: archiving
+          ? "归档后会从活跃子区列表移到已归档分组。"
+          : "取消归档后会回到活跃子区列表。",
+        onOk: async () => {
+          try {
+            if (archiving) {
+              await WKApp.dataSource.channelDataSource.threadArchive(
+                groupNo,
+                thread.short_id
+              );
+            } else {
+              await WKApp.dataSource.channelDataSource.threadUnarchive(
+                groupNo,
+                thread.short_id
+              );
+            }
+
+            const updatedThread =
+              await WKApp.dataSource.channelDataSource.threadGet(
+                groupNo,
+                thread.short_id
+              );
+            Toast.success(archiving ? "子区已归档" : "已取消归档");
+            this.setState((prevState) => ({
+              vmState: {
+                ...prevState.vmState,
+                thread: updatedThread,
+              },
+            }));
+            this.props.onThreadSelect?.(updatedThread);
+            this.refreshThreadChannelInfo(updatedThread);
+            await this.loadThreads();
+          } catch {
+            Toast.error(archiving ? "归档失败，请重试" : "取消归档失败，请重试");
+          }
+        },
+      });
+    }, 100);
+  };
+
+  private handleThreadMessageSent = async () => {
+    const { groupNo } = this.props;
+    const thread = this.state.vmState.thread;
+    if (!groupNo || !thread) return;
+
+    if (thread.status !== ThreadStatus.Archived) return;
+
+    void this.reconcileThreadAfterMessageSent(groupNo, thread);
+  };
+
+  private async reconcileThreadAfterMessageSent(
+    groupNo: string,
+    thread: Thread
+  ) {
+    try {
+      const updatedThread = await this.fetchThreadAfterMessageSent(
+        groupNo,
+        thread
+      );
+      if (this.state.vmState.thread?.short_id !== thread.short_id) {
+        return;
+      }
+
+      const currentThread = this.state.vmState.thread;
+      if (!currentThread || updatedThread.status === currentThread.status) {
+        return;
+      }
+      if (updatedThread.status === ThreadStatus.Archived) {
+        return;
+      }
+
+      // 不做乐观更新：只有后端确认子区已恢复活跃后，才切换提示和菜单状态。
+      this.applyThreadUpdate(updatedThread);
+      this.refreshThreadChannelInfo(updatedThread);
+    } catch {
+      // Message sending already succeeded. Keep the archived UI until a
+      // backend-backed refresh confirms the state change.
+    }
+  }
+
+  private async fetchThreadAfterMessageSent(
+    groupNo: string,
+    thread: Thread
+  ): Promise<Thread> {
+    let lastThread = thread;
+
+    for (const delay of THREAD_REACTIVATE_REFRESH_DELAYS_MS) {
+      if (delay > 0) {
+        await this.sleep(delay);
+      }
+
+      const updatedThread = await WKApp.dataSource.channelDataSource.threadGet(
+        groupNo,
+        thread.short_id
+      );
+      lastThread = updatedThread;
+      if (
+        thread.status !== ThreadStatus.Archived ||
+        updatedThread.status !== ThreadStatus.Archived
+      ) {
+        break;
+      }
+    }
+
+    return lastThread;
+  }
+
+  private applyThreadUpdate(thread: Thread) {
+    this.setState((prevState) => ({
+      threads: prevState.threads
+        .map((item) => (item.short_id === thread.short_id ? thread : item))
+        .sort((a, b) => this.threadSortTime(b) - this.threadSortTime(a)),
+      vmState: {
+        ...prevState.vmState,
+        thread:
+          prevState.vmState.thread?.short_id === thread.short_id
+            ? thread
+            : prevState.vmState.thread,
+      },
+    }));
+    this.props.onThreadSelect?.(thread);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+  }
+
+  private refreshThreadChannelInfo(thread: Thread) {
+    const channelID =
+      thread.channel_id ||
+      (this.props.groupNo
+        ? buildThreadChannelId(this.props.groupNo, thread.short_id)
+        : "");
+    if (!channelID) return;
+    const threadChannel = new Channel(channelID, ChannelTypeCommunityTopic);
+    WKSDK.shared().channelManager.deleteChannelInfo(threadChannel);
+    WKSDK.shared().channelManager.fetchChannelInfo(threadChannel);
+  }
+
   private handleDeleteThread = () => {
     const { vmState } = this.state;
+    const { groupNo } = this.props;
     const thread = vmState.thread;
-    if (!thread) return;
+    if (!thread || !groupNo) return;
     this.setState({ showMoreMenu: false });
 
     setTimeout(() => {
@@ -587,12 +801,11 @@ export default class ThreadPanel extends Component<
         onOk: async () => {
           try {
             await WKApp.dataSource.channelDataSource.threadDelete(
-              this.props.groupNo,
+              groupNo,
               thread.short_id
             );
             Toast.success("子区已删除");
             this.handleBackToList();
-            this.loadThreads();
           } catch {
             Toast.error("删除失败，请重试");
           }
@@ -607,6 +820,7 @@ export default class ThreadPanel extends Component<
       onCreateThread();
       return;
     }
+    if (!groupNo) return;
 
     let threadName = "";
     Modal.confirm({
@@ -845,12 +1059,30 @@ export default class ThreadPanel extends Component<
                     </div>
                   )}
                   {vmState.thread && this.canEditThread(vmState.thread) && (
-                    <div
-                      className="wk-thread-more-menu-item"
-                      onClick={this.handleEditThread}
-                    >
-                      编辑子区名称
-                    </div>
+                    <>
+                      <div
+                        className="wk-thread-more-menu-item"
+                        onClick={this.handleEditThread}
+                      >
+                        编辑子区名称
+                      </div>
+                      {vmState.thread.status === ThreadStatus.Active && (
+                        <div
+                          className="wk-thread-more-menu-item"
+                          onClick={this.handleToggleArchiveThread}
+                        >
+                          归档子区
+                        </div>
+                      )}
+                      {vmState.thread.status === ThreadStatus.Archived && (
+                        <div
+                          className="wk-thread-more-menu-item"
+                          onClick={this.handleToggleArchiveThread}
+                        >
+                          取消归档
+                        </div>
+                      )}
+                    </>
                   )}
                   <div
                     className="wk-thread-more-menu-item wk-thread-more-menu-item-danger"
@@ -1043,6 +1275,12 @@ export default class ThreadPanel extends Component<
             key={thread.channel_id}
             channel={threadChannel}
             shouldShowHistorySplit={false}
+            inputNotice={
+              thread.status === ThreadStatus.Archived
+                ? "该子区已归档。发送消息后，子区会恢复为活跃状态。"
+                : undefined
+            }
+            onMessageSent={this.handleThreadMessageSent}
           />
         </ErrorBoundary>
       </div>

--- a/packages/dmworkbase/src/Components/ThreadPanel/vm.ts
+++ b/packages/dmworkbase/src/Components/ThreadPanel/vm.ts
@@ -47,12 +47,10 @@ export class ThreadPanelVM {
   async load() {
     this.setState({ loading: true, error: null })
     try {
-      // 获取 thread 详情
-      const threads = await WKApp.dataSource.channelDataSource.threadList(this.groupNo, {
-        page_index: 1,
-        page_size: 100
-      })
-      const thread = threads.find(t => t.short_id === this.threadShortId) || null
+      const thread = await WKApp.dataSource.channelDataSource.threadGet(
+        this.groupNo,
+        this.threadShortId
+      )
       this.setState({ loading: false, thread })
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "加载失败"

--- a/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
+++ b/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
@@ -81,7 +81,7 @@ export class ThreadCreatedCell extends MessageCell {
           Toast.warning("该子区已删除")
           return
         }
-        // 归档状态允许进入查看，但会在聊天界面禁用发送
+        // 归档状态允许进入查看；是否自动恢复活跃由后端发送链路处理。
       } catch (err: any) {
         Toast.warning("该子区已删除或不存在")
         return

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -41,6 +41,7 @@ import NavSignalBadge from "../../Components/NavRail/NavSignalBadge";
 import ThreadPanel from "../../Components/ThreadPanel";
 import {
   Thread,
+  ThreadStatus,
   parseThreadChannelId,
   buildThreadStub,
   isEffectivelyMuted,
@@ -50,6 +51,10 @@ import FilePreviewPanel, {
 } from "../../Components/FilePreviewPanel";
 import { FollowSidebarProvider, useFollowSidebarContext } from "../../Hooks/useFollowSidebar";
 import { SidebarTargetType } from "../../Service/SidebarService";
+
+// 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
+// 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
+const THREAD_REACTIVATE_REFRESH_DELAYS_MS = [0, 300, 800, 1500];
 
 interface SidebarTabBarWithBadgesProps {
   conversations: ConversationWrap[];
@@ -515,6 +520,90 @@ export class ChatContentPage extends Component<
     WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
   }
 
+  private getThreadStatus(channelInfo?: ChannelInfo | null) {
+    return (channelInfo?.orgData?.thread as any)?.status as
+      | ThreadStatus
+      | undefined;
+  }
+
+  private handleConversationMessageSent = () => {
+    const { channel } = this.props;
+    if (channel.channelType !== ChannelTypeCommunityTopic) return;
+
+    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    if (this.getThreadStatus(channelInfo) !== ThreadStatus.Archived) return;
+
+    const threadInfo = parseThreadChannelId(channel.channelID);
+    if (threadInfo) {
+      void this.reconcileConversationThreadAfterMessageSent(
+        threadInfo.groupNo,
+        threadInfo.shortId,
+        channel,
+      );
+    }
+  };
+
+  private async reconcileConversationThreadAfterMessageSent(
+    groupNo: string,
+    shortId: string,
+    channel: Channel,
+  ) {
+    try {
+      const updatedThread = await this.fetchThreadAfterMessageSent(
+        groupNo,
+        shortId,
+      );
+      if (!this.props.channel.isEqual(channel)) return;
+      if (updatedThread.status === ThreadStatus.Archived) return;
+
+      // 独立子区会话的提示来自 SDK channelInfo。
+      // 只有 threadGet 确认非归档后才刷新 channelInfo，避免 UI 先切活跃再回退。
+      await this.refreshCurrentThreadChannelInfo(channel);
+      if (!this.props.channel.isEqual(channel)) return;
+
+      this.setState({});
+    } catch {
+      // Message sending already succeeded. Leave the archived prompt visible
+      // until a backend-backed channel-info refresh confirms the state change.
+    }
+  }
+
+  private async fetchThreadAfterMessageSent(
+    groupNo: string,
+    shortId: string,
+  ): Promise<Thread> {
+    let lastThread: Thread | null = null;
+
+    for (const delay of THREAD_REACTIVATE_REFRESH_DELAYS_MS) {
+      if (delay > 0) {
+        await this.sleep(delay);
+      }
+
+      const updatedThread = await WKApp.dataSource.channelDataSource.threadGet(
+        groupNo,
+        shortId,
+      );
+      lastThread = updatedThread;
+      if (updatedThread.status !== ThreadStatus.Archived) {
+        break;
+      }
+    }
+
+    if (!lastThread) {
+      throw new Error("thread status refresh failed");
+    }
+    return lastThread;
+  }
+
+  private async refreshCurrentThreadChannelInfo(channel: Channel) {
+    WKSDK.shared().channelManager.deleteChannelInfo(channel);
+    await WKSDK.shared().channelManager.fetchChannelInfo(channel);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+  }
+
   render(): React.ReactNode {
     const { channel, initLocateMessageSeq } = this.props;
     const {
@@ -533,6 +622,7 @@ export class ChatContentPage extends Component<
     if (!channelInfo) {
       WKSDK.shared().channelManager.fetchChannelInfo(channel);
     }
+    const threadStatus = this.getThreadStatus(channelInfo);
     return (
       <div
         className={classNames(
@@ -786,6 +876,12 @@ export class ChatContentPage extends Component<
                 }
                 channel={channel}
                 activePreviewMessageId={this.state.activePreviewMessageId}
+                inputNotice={
+                  isThreadChannel && threadStatus === ThreadStatus.Archived
+                    ? "该子区已归档。发送消息后，子区会恢复为活跃状态。"
+                    : undefined
+                }
+                onMessageSent={this.handleConversationMessageSent}
               ></Conversation>
             </ErrorBoundary>
           </div>

--- a/packages/dmworkbase/src/Service/DataSource/DataSource.ts
+++ b/packages/dmworkbase/src/Service/DataSource/DataSource.ts
@@ -1,5 +1,6 @@
 import { Channel, ChannelInfo, ConversationExtra, Message, Subscriber } from "wukongimjssdk";
 import { APIResp } from "../APIClient";
+import type { Thread, ThreadListStatus } from "../Thread";
 
 export type ContactsChangeListener = () => void;
 
@@ -318,7 +319,19 @@ export interface IChannelDataSource {
     deleteThreadMd(groupNo: string, shortId: string): Promise<void>
 
     // 子区信息
+    threadList(groupNo: string, req?: {
+        page_index?: number
+        page_size?: number
+        status?: ThreadListStatus
+    }): Promise<Thread[]>
+    threadCreate(groupNo: string, name: string, sourceMessageId?: number): Promise<Thread>
+    threadGet(groupNo: string, shortId: string): Promise<Thread>
+    threadArchive(groupNo: string, shortId: string): Promise<void>
+    threadUnarchive(groupNo: string, shortId: string): Promise<void>
+    threadDelete(groupNo: string, shortId: string): Promise<void>
     threadUpdate(groupNo: string, shortId: string, data: { name: string }): Promise<void>
+    threadJoin(shortId: string): Promise<void>
+    threadLeave(shortId: string): Promise<void>
 
     setBotAdmin(channel: Channel, uid: string): Promise<void>
     removeBotAdmin(channel: Channel, uid: string): Promise<void>

--- a/packages/dmworkbase/src/Service/Thread.ts
+++ b/packages/dmworkbase/src/Service/Thread.ts
@@ -37,6 +37,8 @@ export enum ThreadStatus {
   Deleted = 3,
 }
 
+export type ThreadListStatus = "active" | "archived" | "all"
+
 export const ThreadChannelIdSeparator = '____'
 
 export function parseThreadChannelId(channelId: string): { groupNo: string; shortId: string } | null {

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -106,7 +106,7 @@ import {
 } from "./Messages/ThreadCreated";
 import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
-import { parseThreadChannelId } from "./Service/Thread";
+import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
 function fallbackCopy(text: string) {
@@ -1903,6 +1903,18 @@ export default class BaseModule implements IModule {
         const isCreator = thread?.creator_uid === WKApp.loginInfo.uid;
         const isManagerOrOwner = data.isManagerOrCreatorOfMe;
         const canEdit = isCreator || isManagerOrOwner;
+        const statusTitle =
+          thread?.status === ThreadStatus.Archived
+            ? "已归档"
+            : thread?.status === ThreadStatus.Deleted
+              ? "已删除"
+              : "活跃中";
+        const statusColor =
+          thread?.status === ThreadStatus.Archived
+            ? "grey"
+            : thread?.status === ThreadStatus.Deleted
+              ? "red"
+              : "green";
 
         const rows = new Array<Row>();
         rows.push(
@@ -1945,6 +1957,19 @@ export default class BaseModule implements IModule {
             },
           })
         );
+        rows.push(
+          new Row({
+            cell: ListItem,
+            properties: {
+              title: "子区状态",
+              subTitle: (
+                <Tag color={statusColor} size="small">
+                  {statusTitle}
+                </Tag>
+              ),
+            },
+          })
+        );
         if (threadInfo) {
           const groupChannel = new Channel(
             threadInfo.groupNo,
@@ -1958,9 +1983,10 @@ export default class BaseModule implements IModule {
           const groupName = groupInfo?.title || threadInfo.groupNo;
           rows.push(
             new Row({
-              cell: ListItemButton,
+              cell: ListItem,
               properties: {
-                title: `返回群聊「${groupName}」`,
+                title: "所属群聊",
+                subTitle: groupName,
                 onClick: () => {
                   WKApp.endpoints.showConversation(groupChannel);
                 },
@@ -1969,6 +1995,7 @@ export default class BaseModule implements IModule {
           );
         }
         return new Section({
+          title: "子区信息",
           rows: rows,
         });
       },
@@ -2044,7 +2071,6 @@ export default class BaseModule implements IModule {
 
     // 子区设置说明：
     // - 消息免打扰/聊天置顶：子区继承父群组设置，暂不支持单独配置
-    // - 清空聊天记录/归档：子区管理由父群组统一处理，暂不开放
     // - 成员管理：子区成员通过加入/离开操作，不支持手动添加
     WKApp.shared.channelSettingRegister(
       "thread.actions",
@@ -2055,33 +2081,99 @@ export default class BaseModule implements IModule {
           return undefined;
         }
         const threadInfo = parseThreadChannelId(channel.channelID);
-        return new Section({
-          rows: [
+        const thread = data.channelInfo?.orgData?.thread as any;
+        const isCreator = thread?.creator_uid === WKApp.loginInfo.uid;
+        const canArchive = isCreator || data.isManagerOrCreatorOfMe;
+        const isArchived = thread?.status === ThreadStatus.Archived;
+        const isActive = thread?.status === ThreadStatus.Active;
+        const rows = new Array<Row>();
+
+        if (threadInfo && canArchive && (isActive || isArchived)) {
+          rows.push(
             new Row({
               cell: ListItemButton,
               properties: {
-                title: "离开子区",
-                type: ListItemButtonType.warn,
+                title: isArchived ? "取消归档" : "归档子区",
+                type: ListItemButtonType.default,
                 onClick: () => {
-                  WKApp.shared.baseContext.showAlert({
-                    content: "确定要离开此子区吗？",
+                  Modal.confirm({
+                    title: isArchived
+                      ? `取消归档「${thread?.name || data.channelInfo?.title || "子区"}」？`
+                      : `归档子区「${thread?.name || data.channelInfo?.title || "子区"}」？`,
+                    icon: null,
+                    okText: isArchived ? "取消归档" : "归档",
+                    cancelText: "取消",
+                    content: isArchived
+                      ? "取消归档后会回到活跃子区列表。"
+                      : "归档后会从活跃子区列表移到已归档分组。",
                     onOk: async () => {
-                      if (threadInfo) {
-                        await WKApp.apiClient
-                          .post(`threads/${threadInfo.shortId}/leave`)
-                          .catch((err: any) => {
-                            Toast.error(err.msg || "离开失败");
-                          });
-                        WKApp.conversationProvider.deleteConversation(
-                          data.channel
+                      try {
+                        if (isArchived) {
+                          await WKApp.dataSource.channelDataSource.threadUnarchive(
+                            threadInfo.groupNo,
+                            threadInfo.shortId
+                          );
+                        } else {
+                          await WKApp.dataSource.channelDataSource.threadArchive(
+                            threadInfo.groupNo,
+                            threadInfo.shortId
+                          );
+                        }
+                        Toast.success(
+                          isArchived ? "已取消归档" : "子区已归档"
+                        );
+                        WKSDK.shared().channelManager.deleteChannelInfo(
+                          channel
+                        );
+                        await WKSDK.shared().channelManager.fetchChannelInfo(
+                          channel
+                        );
+                        data.refresh();
+                      } catch (err: any) {
+                        Toast.error(
+                          err?.msg ||
+                            (isArchived
+                              ? "取消归档失败，请重试"
+                              : "归档失败，请重试")
                         );
                       }
                     },
                   });
                 },
               },
-            }),
-          ],
+            })
+          );
+        }
+
+        rows.push(
+          new Row({
+            cell: ListItemButton,
+            properties: {
+              title: "离开子区",
+              type: ListItemButtonType.warn,
+              onClick: () => {
+                WKApp.shared.baseContext.showAlert({
+                  content: "确定要离开此子区吗？",
+                  onOk: async () => {
+                    if (threadInfo) {
+                      await WKApp.apiClient
+                        .post(`threads/${threadInfo.shortId}/leave`)
+                        .catch((err: any) => {
+                          Toast.error(err.msg || "离开失败");
+                        });
+                      WKApp.conversationProvider.deleteConversation(
+                        data.channel
+                      );
+                    }
+                  },
+                });
+              },
+            },
+          })
+        );
+        return new Section({
+          title: "子区管理",
+          rows,
         });
       },
       90000

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -1,4 +1,4 @@
-import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId } from "@octo/base";
+import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ThreadListStatus, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId } from "@octo/base";
 import { Channel, ChannelInfo, ChannelTypeGroup, ChannelTypePerson, WKSDK, Message, MessageContentType,ConversationExtra,Subscriber } from "wukongimjssdk";
 
 const MAX_GROUP_LIST_LIMIT = 100000;
@@ -204,10 +204,14 @@ export class ChannelDataSource implements IChannelDataSource {
     async threadList(groupNo: string, req?: {
         page_index?: number
         page_size?: number
+        status?: ThreadListStatus
     }): Promise<Thread[]> {
         const resp = await WKApp.apiClient.get(`groups/${groupNo}/threads`, {
             param: req
         })
+        if (Array.isArray(resp)) {
+            return resp.map((item: any) => this.toThread(item, groupNo))
+        }
         if (!resp || !resp.list || !Array.isArray(resp.list)) {
             return []
         }
@@ -230,6 +234,10 @@ export class ChannelDataSource implements IChannelDataSource {
 
     async threadArchive(groupNo: string, shortId: string): Promise<void> {
         return WKApp.apiClient.post(`groups/${groupNo}/threads/${shortId}/archive`)
+    }
+
+    async threadUnarchive(groupNo: string, shortId: string): Promise<void> {
+        return WKApp.apiClient.post(`groups/${groupNo}/threads/${shortId}/unarchive`)
     }
 
     async threadDelete(groupNo: string, shortId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Refresh archived thread state from the backend after sending messages in both side-panel and standalone thread conversations.
- Keep the thread panel from remounting when the same thread receives updated status data.
- Add archive/unarchive entry points in thread settings and include archived threads in the thread panel list/detail flow.
- Show a lightweight archived-thread notice above the message input.

## Root Cause
Sending a message to an archived thread reactivates the thread on the backend, but the frontend was not consistently reconciling that backend state across the side-panel and standalone thread surfaces. The side-panel also reinitialized its view when the parent passed a new thread object for the same `short_id`, causing a visible secondary refresh.

## Validation
- `git diff --check`
- `pnpm --filter @octo/web build`
- Manual browser checks for archived-thread message sending in both standalone thread conversations and the right-side thread panel.