### PR TITLE
Fix app bot nav icon color

### DIFF
--- a/packages/dmworkappbot/src/module.tsx
+++ b/packages/dmworkappbot/src/module.tsx
@@ -1,37 +1,79 @@
-import React from "react"
-import { IModule, WKApp, Menus } from "@octo/base"
-import AppBotPage from "./AppBotPage"
+import React from "react";
+import { IModule, WKApp, Menus } from "@octo/base";
+import AppBotPage from "./AppBotPage";
 
 const AppBotIcon: React.FC<{ active?: boolean }> = ({ active }) => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="3" y="3" width="8" height="8" rx="2" stroke={active ? "#5b6abf" : "#999"} strokeWidth={active ? "2" : "1.5"} fill={active ? "#5b6abf" : "none"} />
-    <rect x="13" y="3" width="8" height="8" rx="2" stroke={active ? "#5b6abf" : "#999"} strokeWidth={active ? "2" : "1.5"} fill={active ? "#5b6abf" : "none"} />
-    <rect x="3" y="13" width="8" height="8" rx="2" stroke={active ? "#5b6abf" : "#999"} strokeWidth={active ? "2" : "1.5"} fill={active ? "#5b6abf" : "none"} />
-    <rect x="13" y="13" width="8" height="8" rx="2" stroke={active ? "#5b6abf" : "#999"} strokeWidth={active ? "2" : "1.5"} fill={active ? "#5b6abf" : "none"} />
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      x="3"
+      y="3"
+      width="8"
+      height="8"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={active ? "2" : "1.5"}
+      fill={active ? "currentColor" : "none"}
+    />
+    <rect
+      x="13"
+      y="3"
+      width="8"
+      height="8"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={active ? "2" : "1.5"}
+      fill={active ? "currentColor" : "none"}
+    />
+    <rect
+      x="3"
+      y="13"
+      width="8"
+      height="8"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={active ? "2" : "1.5"}
+      fill={active ? "currentColor" : "none"}
+    />
+    <rect
+      x="13"
+      y="13"
+      width="8"
+      height="8"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={active ? "2" : "1.5"}
+      fill={active ? "currentColor" : "none"}
+    />
   </svg>
-)
+);
 
 /** Guard against double-init (HMR in dev or future module lifecycle changes). */
-let _initialized = false
+let _initialized = false;
 
 // Reset on HMR: tear down old listeners, reset init guard.
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    _initialized = false
-  })
+    _initialized = false;
+  });
 }
 
 export default class AppBotModule implements IModule {
   id(): string {
-    return "AppBotModule"
+    return "AppBotModule";
   }
 
   init(): void {
-    if (_initialized) return
-    _initialized = true
+    if (_initialized) return;
+    _initialized = true;
 
     // Register route
-    WKApp.route.register("/appbot", () => <AppBotPage />)
+    WKApp.route.register("/appbot", () => <AppBotPage />);
 
     // Register NavRail menu item (sort=6000, at the bottom)
     WKApp.menus.register(
@@ -42,11 +84,11 @@ export default class AppBotModule implements IModule {
           "/appbot",
           "应用",
           <AppBotIcon />,
-          <AppBotIcon active />,
-        )
-        return m
+          <AppBotIcon active />
+        );
+        return m;
       },
-      6000,
-    )
+      6000
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Update the App Bot nav icon to use `currentColor` instead of hardcoded blue/gray values.
- Let the selected App Bot nav icon inherit the NavRail active theme color.

## Root Cause
The App Bot icon hardcoded `#5b6abf` for its active state, bypassing the NavRail theme tokens.

## Validation
- Ran `pnpm exec prettier --check packages/dmworkappbot/src/module.tsx`.
- Verified in the local browser preview that the App nav icon no longer renders blue when selected.