### PR TITLE
feat(voice): local ASR toggle in VoiceSettingsPanel + fix triple probe

### DIFF
--- a/apps/web/src/__tests__/voiceService.test.ts
+++ b/apps/web/src/__tests__/voiceService.test.ts
@@ -6,6 +6,8 @@ vi.mock("@octo/base/src/Service/APIClient", () => {
         shared: {
             get: vi.fn(),
             post: vi.fn(),
+            put: vi.fn(),
+            delete: vi.fn(),
             config: { apiURL: "" },
         },
     }
@@ -468,6 +470,87 @@ describe("VoiceService", () => {
             expect(r1.context).toBe("Space A 纠错词")
             expect(r2.context).toBe("Space B 纠错词")
             expect(APIClient.shared.get).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe("putLocalConfig", () => {
+        it("should call PUT /voice/local-config with enabled true", async () => {
+            vi.mocked(APIClient.shared.put).mockResolvedValue({ status: 200, msg: "ok" })
+
+            await VoiceService.shared.putLocalConfig({ enabled: true })
+
+            expect(APIClient.shared.put).toHaveBeenCalledWith("/voice/local-config", { enabled: true })
+        })
+
+        it("should call PUT /voice/local-config with enabled false", async () => {
+            vi.mocked(APIClient.shared.put).mockResolvedValue({ status: 200, msg: "ok" })
+
+            await VoiceService.shared.putLocalConfig({ enabled: false })
+
+            expect(APIClient.shared.put).toHaveBeenCalledWith("/voice/local-config", { enabled: false })
+        })
+
+        it("should propagate errors from the API", async () => {
+            vi.mocked(APIClient.shared.put).mockRejectedValue(new Error("Forbidden"))
+
+            await expect(VoiceService.shared.putLocalConfig({ enabled: true })).rejects.toThrow("Forbidden")
+        })
+    })
+
+    describe("getLocalConfig", () => {
+        it("should call GET /voice/local-config and return config", async () => {
+            const mockResp = {
+                status: 200,
+                enabled: true,
+                timeout_ms: 8000,
+                probe_url: "http://localhost:8787/",
+                transcribe_url: "http://localhost:8787/v1/voice/transcribe",
+            }
+            vi.mocked(APIClient.shared.get).mockResolvedValue(mockResp)
+
+            const result = await VoiceService.shared.getLocalConfig()
+
+            expect(APIClient.shared.get).toHaveBeenCalledWith("/voice/local-config")
+            expect(result).toEqual(mockResp)
+        })
+
+        it("should handle null fields from unset config", async () => {
+            const mockResp = {
+                status: 200,
+                enabled: false,
+                timeout_ms: null,
+                probe_url: null,
+                transcribe_url: null,
+            }
+            vi.mocked(APIClient.shared.get).mockResolvedValue(mockResp)
+
+            const result = await VoiceService.shared.getLocalConfig()
+
+            expect(result.timeout_ms).toBeNull()
+            expect(result.probe_url).toBeNull()
+            expect(result.transcribe_url).toBeNull()
+        })
+
+        it("should propagate errors from the API", async () => {
+            vi.mocked(APIClient.shared.get).mockRejectedValue(new Error("Service unavailable"))
+
+            await expect(VoiceService.shared.getLocalConfig()).rejects.toThrow("Service unavailable")
+        })
+    })
+
+    describe("deleteLocalConfig", () => {
+        it("should call DELETE /voice/local-config", async () => {
+            vi.mocked(APIClient.shared.delete).mockResolvedValue({ status: 200, msg: "ok" })
+
+            await VoiceService.shared.deleteLocalConfig()
+
+            expect(APIClient.shared.delete).toHaveBeenCalledWith("/voice/local-config")
+        })
+
+        it("should propagate errors from the API", async () => {
+            vi.mocked(APIClient.shared.delete).mockRejectedValue(new Error("Not found"))
+
+            await expect(VoiceService.shared.deleteLocalConfig()).rejects.toThrow("Not found")
         })
     })
 })

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceInput.ts
@@ -101,14 +101,11 @@ export default function useVoiceInput(
     LocalModelService.shared.loadConfig(localStorage);
     LocalModelService.shared.updateConfig({ enabled: false }, localStorage);
 
-    const LOCAL_DEFAULT_TIMEOUT_MS = 10000;
-
     VoiceService.shared
       .getConfig()
       .then((config: VoiceConfig) => {
         if (cancelled) return;
-        const localAllowed = config.local_enabled === true;
-        setIsVoiceEnabled(config.enabled || localAllowed);
+        setIsVoiceEnabled(config.enabled || config.local_enabled === true);
         backendEnabledRef.current = config.enabled;
         maxFileSizeRef.current = config.max_file_size || 0;
         if (config.max_duration != null) {
@@ -129,24 +126,6 @@ export default function useVoiceInput(
           VoiceFeedback.init(undefined);
         }
 
-        const localTimeout = config.local_timeout_ms ?? LOCAL_DEFAULT_TIMEOUT_MS;
-
-        if (localAllowed) {
-          const updateFields: Partial<LocalModelConfig> = {
-            enabled: true,
-            requestTimeoutMs: localTimeout,
-          };
-          if (config.local_probe_url) {
-            updateFields.probeUrl = config.local_probe_url;
-          }
-          if (config.local_transcribe_url) {
-            updateFields.transcribeUrl = config.local_transcribe_url;
-          }
-          LocalModelService.shared.updateConfig(updateFields, localStorage);
-          LocalModelService.shared.probe().then((available) => {
-            if (!cancelled) setLocalAvailable(available);
-          });
-        }
       })
       .catch(() => {
         if (cancelled) return;
@@ -192,6 +171,44 @@ export default function useVoiceInput(
     return subscribeSpaceFeedback(() => {
       const st = getSharedSpaceFeedbackState();
       voiceFeedbackOnRef.current = (st.spaceSetting?.voice_input_enabled === 1 && st.spaceSetting?.voice_feedback_on === 1) ? 1 : 0;
+    });
+  }, []);
+
+  useEffect(() => {
+    const prevRef = { enabled: false, probeUrl: '', transcribeUrl: '', timeoutMs: 0 };
+    return subscribeSpaceFeedback(() => {
+      const config = getSharedVoiceConfig();
+      if (!config) return;
+
+      const next = {
+        enabled: config.local_enabled === true,
+        probeUrl: config.local_probe_url ?? '',
+        transcribeUrl: config.local_transcribe_url ?? '',
+        timeoutMs: config.local_timeout_ms ?? 10000,
+      };
+
+      const changed = next.enabled !== prevRef.enabled
+        || next.probeUrl !== prevRef.probeUrl
+        || next.transcribeUrl !== prevRef.transcribeUrl
+        || next.timeoutMs !== prevRef.timeoutMs;
+
+      if (!changed) return;
+      Object.assign(prevRef, next);
+
+      // Assumption: fetchAndApplySpaceSetting does not mutate local_* fields.
+      if (next.enabled) {
+        const updateFields: Partial<LocalModelConfig> = {
+          enabled: true,
+          requestTimeoutMs: next.timeoutMs,
+        };
+        if (next.probeUrl) updateFields.probeUrl = next.probeUrl;
+        if (next.transcribeUrl) updateFields.transcribeUrl = next.transcribeUrl;
+        LocalModelService.shared.updateConfig(updateFields, localStorage);
+        LocalModelService.shared.probe().then(setLocalAvailable);
+      } else {
+        LocalModelService.shared.updateConfig({ enabled: false }, localStorage);
+        setLocalAvailable(false);
+      }
     });
   }, []);
 

--- a/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { Switch, Tooltip, Toast } from '@douyinfe/semi-ui';
 import { IconHelpCircle } from '@douyinfe/semi-icons';
 import WKModal from '../WKModal';
@@ -6,9 +6,11 @@ import useSpaceFeedbackSetting, {
   toggleVoiceFeedback,
   acceptVoiceInput,
   disableVoiceInput,
+  setSharedVoiceConfig,
 } from '../MessageInput/useSpaceFeedbackSetting';
 import VoiceFeedbackNotice from '../MessageInput/VoiceFeedbackNotice';
 import WKApp from '../../App';
+import VoiceService from '../../Service/VoiceService';
 
 interface VoiceSettingsPanelProps {
   onClose: () => void;
@@ -25,6 +27,42 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
 
   const privacyUrl = voiceConfig?.feedback_privacy_url;
   const agreementUrl = voiceConfig?.feedback_user_agreement_url;
+
+  const [localEnabled, setLocalEnabled] = useState<boolean>(false);
+  const [localTimeoutMs, setLocalTimeoutMs] = useState<string>('');
+  const [localProbeUrl, setLocalProbeUrl] = useState<string>('');
+  const [localTranscribeUrl, setLocalTranscribeUrl] = useState<string>('');
+  const [localConfigLoaded, setLocalConfigLoaded] = useState(false);
+  const [localSaving, setLocalSaving] = useState(false);
+  const [localDirty, setLocalDirty] = useState(false);
+  const [probeTestStatus, setProbeTestStatus] = useState<'idle' | 'loading' | 'success' | 'fail'>('idle');
+
+  useEffect(() => {
+    if (!isVoiceEnabled || voiceConfig?.local_enabled === undefined) {
+      setLocalConfigLoaded(false);
+      return;
+    }
+
+    let cancelled = false;
+    VoiceService.shared.getLocalConfig().then((cfg) => {
+      if (cancelled) return;
+      setLocalEnabled(cfg.enabled);
+      setLocalTimeoutMs(cfg.timeout_ms != null ? String(cfg.timeout_ms) : '');
+      setLocalProbeUrl(cfg.probe_url ?? '');
+      setLocalTranscribeUrl(cfg.transcribe_url ?? '');
+      setLocalConfigLoaded(true);
+      setLocalDirty(false);
+    }).catch(() => {
+      if (cancelled) return;
+      setLocalEnabled(voiceConfig.local_enabled ?? false);
+      setLocalTimeoutMs(voiceConfig.local_timeout_ms != null ? String(voiceConfig.local_timeout_ms) : '');
+      setLocalProbeUrl(voiceConfig.local_probe_url ?? '');
+      setLocalTranscribeUrl(voiceConfig.local_transcribe_url ?? '');
+      setLocalConfigLoaded(true);
+    });
+
+    return () => { cancelled = true; };
+  }, [isVoiceEnabled, voiceConfig?.local_enabled]);
 
   const handleVoiceToggle = useCallback(async (checked: boolean) => {
     if (loading) return;
@@ -83,6 +121,94 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
     }
   }, [loading, spaceSetting, voiceConfig, updateSetting]);
 
+  const handleLocalToggle = useCallback(async (checked: boolean) => {
+    if (localSaving) return;
+    const prevEnabled = localEnabled;
+
+    setLocalEnabled(checked);
+    setLocalSaving(true);
+
+    try {
+      await VoiceService.shared.putLocalConfig({ enabled: checked });
+      const newConfig = await VoiceService.shared.getConfig();
+      setSharedVoiceConfig(newConfig);
+    } catch {
+      setLocalEnabled(prevEnabled);
+      Toast.error('操作失败，请重试');
+    } finally {
+      setLocalSaving(false);
+    }
+  }, [localSaving, localEnabled]);
+
+  const handleLocalConfigSave = useCallback(async () => {
+    if (localSaving) return;
+    setLocalSaving(true);
+
+    const config: { enabled: boolean; timeout_ms?: number; probe_url?: string; transcribe_url?: string } = {
+      enabled: localEnabled,
+    };
+    const timeoutNum = parseInt(localTimeoutMs, 10);
+    if (!isNaN(timeoutNum) && timeoutNum > 0) {
+      config.timeout_ms = timeoutNum;
+    }
+    if (localProbeUrl.trim()) {
+      config.probe_url = localProbeUrl.trim();
+    }
+    if (localTranscribeUrl.trim()) {
+      config.transcribe_url = localTranscribeUrl.trim();
+    }
+
+    try {
+      await VoiceService.shared.putLocalConfig(config);
+      const newConfig = await VoiceService.shared.getConfig();
+      setSharedVoiceConfig(newConfig);
+      setLocalDirty(false);
+      Toast.success('已保存');
+    } catch {
+      Toast.error('保存失败，请重试');
+    } finally {
+      setLocalSaving(false);
+    }
+  }, [localSaving, localEnabled, localTimeoutMs, localProbeUrl, localTranscribeUrl]);
+
+  const handleLocalConfigReset = useCallback(async () => {
+    if (localSaving) return;
+    setLocalSaving(true);
+
+    try {
+      await VoiceService.shared.deleteLocalConfig();
+      const newConfig = await VoiceService.shared.getConfig();
+      setSharedVoiceConfig(newConfig);
+
+      const cfg = await VoiceService.shared.getLocalConfig();
+      setLocalEnabled(cfg.enabled);
+      setLocalTimeoutMs(cfg.timeout_ms != null ? String(cfg.timeout_ms) : '');
+      setLocalProbeUrl(cfg.probe_url ?? '');
+      setLocalTranscribeUrl(cfg.transcribe_url ?? '');
+      setLocalDirty(false);
+      Toast.success('已恢复默认设置');
+    } catch {
+      Toast.error('操作失败，请重试');
+    } finally {
+      setLocalSaving(false);
+    }
+  }, [localSaving]);
+
+  const handleTestProbe = useCallback(async () => {
+    if (!localProbeUrl.trim() || probeTestStatus === 'loading') return;
+    setProbeTestStatus('loading');
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      await fetch(localProbeUrl.trim(), { signal: controller.signal, redirect: 'manual' });
+      clearTimeout(timer);
+      setProbeTestStatus('success');
+    } catch {
+      setProbeTestStatus('fail');
+    }
+    setTimeout(() => setProbeTestStatus('idle'), 3000);
+  }, [localProbeUrl, probeTestStatus]);
+
   return (
     <WKModal
       visible
@@ -123,6 +249,118 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
               disabled={loading || !apiAvailable}
             />
           </div>
+        )}
+
+        {isVoiceEnabled && voiceConfig?.local_enabled !== undefined && localConfigLoaded && (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                本地语音识别
+                <Tooltip content="开启后，语音识别请求将优先尝试本地部署的 ASR 服务（需本地服务可达）。">
+                  <IconHelpCircle size="small" style={{ color: 'var(--semi-color-text-2)', cursor: 'help' }} />
+                </Tooltip>
+              </span>
+              <Switch
+                size="small"
+                checked={localEnabled}
+                onChange={handleLocalToggle}
+                disabled={loading || localSaving}
+              />
+            </div>
+
+            {localEnabled && (
+              <div style={{
+                display: 'flex', flexDirection: 'column', gap: 12,
+                padding: '12px', marginTop: 4,
+                background: 'var(--semi-color-fill-0)',
+                borderRadius: 6, fontSize: 13,
+              }}>
+                <div>
+                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+                    超时时间 (ms)
+                  </div>
+                  <input
+                    type="number"
+                    value={localTimeoutMs}
+                    placeholder="10000"
+                    onChange={(e) => { setLocalTimeoutMs(e.target.value); setLocalDirty(true); }}
+                    style={{
+                      width: '100%', padding: '6px 8px',
+                      border: '1px solid var(--semi-color-border)',
+                      borderRadius: 4, fontSize: 13,
+                    }}
+                  />
+                </div>
+                <div>
+                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+                    探测地址
+                  </div>
+                  <input
+                    type="url"
+                    value={localProbeUrl}
+                    placeholder="http://localhost:8787/"
+                    onChange={(e) => { setLocalProbeUrl(e.target.value); setLocalDirty(true); }}
+                    style={{
+                      width: '100%', padding: '6px 8px',
+                      border: '1px solid var(--semi-color-border)',
+                      borderRadius: 4, fontSize: 13,
+                    }}
+                  />
+                  <button
+                    onClick={handleTestProbe}
+                    disabled={probeTestStatus === 'loading' || !localProbeUrl.trim()}
+                    style={{ marginLeft: 8, fontSize: 12, padding: '2px 8px', cursor: 'pointer' }}
+                  >
+                    {probeTestStatus === 'idle' && '测试连接'}
+                    {probeTestStatus === 'loading' && '测试中...'}
+                    {probeTestStatus === 'success' && '✅ 连接成功'}
+                    {probeTestStatus === 'fail' && '❌ 连接失败'}
+                  </button>
+                </div>
+                <div>
+                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+                    转写地址
+                  </div>
+                  <input
+                    type="url"
+                    value={localTranscribeUrl}
+                    placeholder="http://localhost:8787/v1/voice/transcribe"
+                    onChange={(e) => { setLocalTranscribeUrl(e.target.value); setLocalDirty(true); }}
+                    style={{
+                      width: '100%', padding: '6px 8px',
+                      border: '1px solid var(--semi-color-border)',
+                      borderRadius: 4, fontSize: 13,
+                    }}
+                  />
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+                  <button
+                    onClick={handleLocalConfigReset}
+                    disabled={localSaving}
+                    style={{
+                      padding: '4px 12px', fontSize: 13, borderRadius: 4,
+                      border: '1px solid var(--semi-color-border)',
+                      background: 'transparent', cursor: 'pointer',
+                    }}
+                  >
+                    恢复默认
+                  </button>
+                  <button
+                    onClick={handleLocalConfigSave}
+                    disabled={localSaving || !localDirty}
+                    style={{
+                      padding: '4px 12px', fontSize: 13, borderRadius: 4,
+                      border: 'none', color: '#fff',
+                      background: localDirty ? 'var(--semi-color-primary)' : 'var(--semi-color-disabled-bg)',
+                      cursor: localDirty ? 'pointer' : 'not-allowed',
+                    }}
+                  >
+                    保存
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
         )}
 
         {(privacyUrl || agreementUrl) && (

--- a/packages/dmworkbase/src/Service/VoiceService.ts
+++ b/packages/dmworkbase/src/Service/VoiceService.ts
@@ -144,6 +144,29 @@ export default class VoiceService {
     return request;
   }
 
+  async putLocalConfig(config: {
+    enabled: boolean;
+    timeout_ms?: number;
+    probe_url?: string;
+    transcribe_url?: string;
+  }): Promise<void> {
+    await APIClient.shared.put("/voice/local-config", config);
+  }
+
+  async getLocalConfig(): Promise<{
+    status: number;
+    enabled: boolean;
+    timeout_ms: number | null;
+    probe_url: string | null;
+    transcribe_url: string | null;
+  }> {
+    return APIClient.shared.get("/voice/local-config");
+  }
+
+  async deleteLocalConfig(): Promise<void> {
+    await APIClient.shared.delete("/voice/local-config");
+  }
+
   clearVoiceContextCache(spaceId?: string): void {
     if (spaceId) {
       this._voiceContextEpoch.set(


### PR DESCRIPTION
## Summary

- Move local ASR toggle into VoiceSettingsPanel (inside Voice Settings modal)
- Toggle only visible when voice transcription is enabled AND local_enabled is defined
- Advanced config: timeout_ms, probe_url, transcribe_url with save/reset
- Add Test Connection button (tests unsaved probe URL with 3s timeout)
- Fix triple probe on load: remove redundant probe from initial useEffect, add diff-guard in subscriber
- Extend VoiceService.putLocalConfig to accept full config object (partial update)

## Changes

- VoiceSettingsPanel.tsx: local ASR section + Test Connection button
- useVoiceInput.ts: remove redundant probe, add prev-vs-next diff guard in subscriber
- VoiceService.ts: extend putLocalConfig signature
- Remove NavLocalASRItem.tsx (replaced by in-panel implementation)

Closes #128