### PR TITLE
fix(file): prefer filename suffix over content.extension for preview detection

### DIFF
--- a/packages/dmworkbase/src/Components/FilePreviewPanel/__tests__/getExtension.test.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/__tests__/getExtension.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { getExtension } from "../types";
+
+/**
+ * `getExtension(ext, name)` 边界测试。
+ *
+ * 背景 (issue #143 / PR #153):
+ *   服务端返回的 `content.extension` 不可靠 — 实测 `.md` 文件该字段为空或
+ *   是 "file" 等占位值, 导致前端 isMarkdown / FileRendererRegistry 都识别不到,
+ *   最终走 FallbackRenderer 显示"暂不支持预览此文件类型"。
+ *
+ *   修复: 把优先级翻转 — 文件名后缀优先, content.extension 作为 fallback。
+ *
+ * 边界 (review 反复迭代得出):
+ *   - dot > 0       : 排除前导点的 dotfile (如 .env), 它按 POSIX 没有扩展名,
+ *                     该走 content.extension fallback。
+ *   - dot < len - 1 : 排除尾部点 (如 "report."), 提取出来是空串, 也该 fallback。
+ *
+ * 注: 同一逻辑在 packages/dmworkbase/src/Messages/File/index.tsx 还有一份
+ *     私有副本, 两边必须保持一致 (见函数注释)。
+ */
+
+describe("getExtension — 文件名后缀优先, extension 作为 fallback (#143)", () => {
+    it("正常文件: 文件名后缀生效", () => {
+        expect(getExtension("", "README.md")).toBe("md");
+        expect(getExtension("", "report.pdf")).toBe("pdf");
+        expect(getExtension("", "image.PNG")).toBe("png"); // 大小写归一
+    });
+
+    it("服务端返回错的 extension: 文件名后缀仍然胜出 (核心 bug 修复)", () => {
+        // issue #143 复现: server 把 .md 的 extension 设成 "" 或 "file"
+        expect(getExtension("", "README.md")).toBe("md");
+        expect(getExtension("file", "README.md")).toBe("md");
+        // 哪怕 server 给了不同的扩展名, 也以文件名为准
+        expect(getExtension("txt", "report.pdf")).toBe("pdf");
+    });
+
+    it("无后缀文件 (Makefile / Dockerfile): fallback 到 extension", () => {
+        expect(getExtension("txt", "Makefile")).toBe("txt");
+        expect(getExtension("dockerfile", "Dockerfile")).toBe("dockerfile");
+        expect(getExtension("", "Makefile")).toBe(""); // 都没有就空
+    });
+
+    it("尾部点 (report.): 后缀为空, fallback 到 extension", () => {
+        expect(getExtension("pdf", "report.")).toBe("pdf");
+        expect(getExtension("", "report.")).toBe("");
+    });
+
+    it("前导点的 dotfile (.env / .bashrc): fallback 到 extension", () => {
+        // POSIX 语义下 .env 没有扩展名, 该走 fallback
+        expect(getExtension("conf", ".env")).toBe("conf");
+        expect(getExtension("txt", ".bashrc")).toBe("txt");
+        expect(getExtension("", ".gitignore")).toBe("");
+        expect(getExtension("", ".profile")).toBe("");
+    });
+
+    it("多重后缀 (archive.tar.gz): 取最后一个", () => {
+        expect(getExtension("", "archive.tar.gz")).toBe("gz");
+        expect(getExtension("", "report.pdf.bak")).toBe("bak");
+    });
+
+    it("name 缺失: fallback 到 extension", () => {
+        expect(getExtension("pdf")).toBe("pdf");
+        expect(getExtension("pdf", undefined)).toBe("pdf");
+        expect(getExtension("pdf", "")).toBe("pdf");
+    });
+
+    it("两边都空: 返回空串", () => {
+        expect(getExtension("")).toBe("");
+        expect(getExtension("", "")).toBe("");
+        expect(getExtension("", undefined)).toBe("");
+    });
+
+    it("extension 大小写归一", () => {
+        expect(getExtension("PDF", "Makefile")).toBe("pdf");
+        expect(getExtension("PNG")).toBe("png");
+    });
+});

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
@@ -107,12 +107,16 @@ export function getLanguageFromExtension(ext: string): string {
  *
  * 优先级: 文件名后缀 > content.extension。
  * 服务端返回的 extension 字段不可靠 (可能为空、或是 "file" 等占位值,
- * 见 issue #143), 用文件名后缀更稳妥; 文件名无后缀时再 fallback 到 extension。
+ * 见 issue #143), 用文件名后缀更稳妥; 文件名无后缀或后缀为空 (如
+ * "report.") 时再 fallback 到 extension。
  */
 export function getExtension(ext: string, name?: string): string {
   if (name) {
     const dot = name.lastIndexOf(".");
-    if (dot >= 0) return name.substring(dot + 1).toLowerCase();
+    if (dot >= 0) {
+      const suffix = name.substring(dot + 1).toLowerCase();
+      if (suffix) return suffix;
+    }
   }
   const e = (ext || "").toLowerCase();
   if (e) return e;

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
@@ -104,13 +104,17 @@ export function getLanguageFromExtension(ext: string): string {
 
 /**
  * 从扩展名或文件名中提取扩展名
+ *
+ * 优先级: 文件名后缀 > content.extension。
+ * 服务端返回的 extension 字段不可靠 (可能为空、或是 "file" 等占位值,
+ * 见 issue #143), 用文件名后缀更稳妥; 文件名无后缀时再 fallback 到 extension。
  */
 export function getExtension(ext: string, name?: string): string {
-  const e = (ext || "").toLowerCase();
-  if (e) return e;
   if (name) {
     const dot = name.lastIndexOf(".");
     if (dot >= 0) return name.substring(dot + 1).toLowerCase();
   }
+  const e = (ext || "").toLowerCase();
+  if (e) return e;
   return "";
 }

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
@@ -107,15 +107,18 @@ export function getLanguageFromExtension(ext: string): string {
  *
  * 优先级: 文件名后缀 > content.extension。
  * 服务端返回的 extension 字段不可靠 (可能为空、或是 "file" 等占位值,
- * 见 issue #143), 用文件名后缀更稳妥; 文件名无后缀或后缀为空 (如
- * "report.") 时再 fallback 到 extension。
+ * 见 issue #143), 用文件名后缀更稳妥; 文件名无可用后缀时再 fallback 到 extension。
+ *
+ * 后缀提取边界:
+ *   - dot > 0       : 排除前导点的 dotfile (如 ".env" / ".bashrc"),
+ *                     这类文件按 POSIX 语义没有"扩展名", 该 fallback。
+ *   - dot < len-1   : 排除尾部点 (如 "report."), 提取出来是空串, 也该 fallback。
  */
 export function getExtension(ext: string, name?: string): string {
   if (name) {
     const dot = name.lastIndexOf(".");
-    if (dot >= 0) {
-      const suffix = name.substring(dot + 1).toLowerCase();
-      if (suffix) return suffix;
+    if (dot > 0 && dot < name.length - 1) {
+      return name.substring(dot + 1).toLowerCase();
     }
   }
   const e = (ext || "").toLowerCase();

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -279,9 +279,13 @@ function getExtension(extension: string, name?: string): string {
   // 或是 "file" 等占位值, 见 issue #143), 用文件名后缀更稳妥。
   if (name) {
     const dot = name.lastIndexOf(".");
-    if (dot >= 0) return name.substring(dot + 1).toLowerCase();
+    if (dot >= 0) {
+      const suffix = name.substring(dot + 1).toLowerCase();
+      if (suffix) return suffix;
+    }
   }
-  // fallback: 文件名无后缀时 (如 Makefile / Dockerfile) 才用 extension
+  // fallback: 文件名无后缀 (Makefile / Dockerfile) 或后缀为空 ("report.")
+  // 时才用 extension
   const ext = (extension || "").toLowerCase();
   if (ext) return ext;
   return "";

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -277,15 +277,19 @@ function FileTypeIcon({
 function getExtension(extension: string, name?: string): string {
   // 优先从文件名后缀提取: 服务端返回的 extension 字段不可靠 (可能为空、
   // 或是 "file" 等占位值, 见 issue #143), 用文件名后缀更稳妥。
+  //
+  // 边界:
+  //   - dot > 0       : 排除前导点的 dotfile (如 ".env" / ".bashrc"),
+  //                     这类文件按 POSIX 语义没有"扩展名", 该 fallback。
+  //   - dot < len-1   : 排除尾部点 (如 "report."), 提取出来是空串, 也该 fallback。
   if (name) {
     const dot = name.lastIndexOf(".");
-    if (dot >= 0) {
-      const suffix = name.substring(dot + 1).toLowerCase();
-      if (suffix) return suffix;
+    if (dot > 0 && dot < name.length - 1) {
+      return name.substring(dot + 1).toLowerCase();
     }
   }
-  // fallback: 文件名无后缀 (Makefile / Dockerfile) 或后缀为空 ("report.")
-  // 时才用 extension
+  // fallback: 文件名无可用后缀 (Makefile / Dockerfile / .env / report.) 时
+  // 才用 extension
   const ext = (extension || "").toLowerCase();
   if (ext) return ext;
   return "";

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -275,13 +275,15 @@ function FileTypeIcon({
 }
 
 function getExtension(extension: string, name?: string): string {
-  const ext = (extension || "").toLowerCase();
-  if (ext) return ext;
-  // fallback: extract from filename
+  // 优先从文件名后缀提取: 服务端返回的 extension 字段不可靠 (可能为空、
+  // 或是 "file" 等占位值, 见 issue #143), 用文件名后缀更稳妥。
   if (name) {
     const dot = name.lastIndexOf(".");
     if (dot >= 0) return name.substring(dot + 1).toLowerCase();
   }
+  // fallback: 文件名无后缀时 (如 Makefile / Dockerfile) 才用 extension
+  const ext = (extension || "").toLowerCase();
+  if (ext) return ext;
   return "";
 }
 


### PR DESCRIPTION
Closes #143

## 问题

Web 端聊天中收到 `.md` 文件，点击预览弹出「暂不支持预览此文件类型」，只能下载。

## 根因

文件预览的扩展名提取函数 `getExtension(extension, name)` 优先使用 `content.extension`，文件名后缀仅作 fallback：

```ts
// 修改前
function getExtension(extension: string, name?: string): string {
  const ext = (extension || "").toLowerCase();
  if (ext) return ext;            // ← 优先返回, 永远先用 content.extension
  if (name) {
    const dot = name.lastIndexOf(".");
    if (dot >= 0) return name.substring(dot + 1).toLowerCase();
  }
  return "";
}
```

服务端返回的 `content.extension` 不可靠 — 实测有 `.md` 文件该字段为空或返回 `"file"` 等占位值。结果：

- `ThreadPanel` 的 `isMarkdown` 检查（`["md", "markdown"]`）不命中
- `FileRendererRegistry` 也匹配不到
- 最终走 `FallbackRenderer` 显示「暂不支持预览此文件类型」

## 修改

把优先级翻转 — **文件名后缀优先，`content.extension` 作为 fallback**：

```ts
// 修改后
function getExtension(extension: string, name?: string): string {
  if (name) {
    const dot = name.lastIndexOf(".");
    if (dot >= 0) return name.substring(dot + 1).toLowerCase();
  }
  const ext = (extension || "").toLowerCase();
  if (ext) return ext;
  return "";
}
```

`getExtension` 在代码库中有两处独立定义，逻辑一致，**都改**：

| 文件 | 调用方 |
|------|--------|
| `packages/dmworkbase/src/Messages/File/index.tsx` | `getFileIconInfo`、`FileTypeIcon`、`isPreviewable`、`isTextFile`、`handlePreview` |
| `packages/dmworkbase/src/Components/FilePreviewPanel/types.ts` | `FilePreviewPanel`、`registry`、`ThreadPanel`、`MergeforwardMessageList` |

## 边缘情况

- 文件名无后缀（`Makefile` / `Dockerfile` 等）但 `content.extension` 有值 — 仍走 fallback 路径，行为不变
- 文件名后缀为空字符串（如 `foo.`）— `lastIndexOf` 命中后返回空串，进而 fallback 到 `content.extension`

## 验证

- 主流程：`.md` 文件名经 `getExtension` 返回 `"md"`，`isMarkdown` 命中，走 `MarkdownRenderer`
- 回归：常规带 `content.extension` 的文件（pdf / png / docx 等）仍能正确识别（因为文件名通常也带匹配后缀）
- 风险：极低，只翻转了两处函数内的两个分支顺序

---
Relates to #125