### PR TITLE
fix: show pending state for image sends

### DIFF
--- a/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
@@ -12,6 +12,7 @@ vi.mock('wukongimjssdk', () => ({
   },
   Task: class {},
   TaskStatus: { wait: 0, success: 1, processing: 2, fail: 3, suspend: 4, cancel: 5 },
+  MessageStatus: { Wait: 0, Normal: 1, Fail: 2 },
 }))
 
 vi.mock('react', async () => await vi.importActual('react'))
@@ -26,7 +27,8 @@ vi.mock('../../MessageCell', () => ({
   MessageCell: class {},
 }))
 
-import { ImageContent } from '../index'
+import { ImageContent, getImageTransferState } from '../index'
+import { MessageStatus, TaskStatus } from 'wukongimjssdk'
 
 describe('ImageContent name field', () => {
   it('sets name from file.name in constructor', () => {
@@ -65,5 +67,90 @@ describe('ImageContent name field', () => {
     const content = new ImageContent()
     content.decodeJSON({ width: 100, height: 100, url: 'https://cdn.example.com/photo.jpg' })
     expect(content.name).toBeUndefined()
+  })
+})
+
+describe('getImageTransferState', () => {
+  it('shows sending while message is waiting for ack', () => {
+    expect(getImageTransferState({
+      hasLocalFile: false,
+      hasRemoteUrl: true,
+      fileSize: 0,
+      messageStatus: MessageStatus.Wait,
+      uploadStatus: TaskStatus.success,
+      uploadProgress: 100,
+    })).toEqual({ status: 'sending' })
+  })
+
+  it('keeps local images pending until a remote URL exists', () => {
+    expect(getImageTransferState({
+      hasLocalFile: true,
+      hasRemoteUrl: false,
+      fileSize: 256 * 1024,
+      messageStatus: MessageStatus.Normal,
+      uploadStatus: null,
+      uploadProgress: 0,
+    })).toEqual({ status: 'sending' })
+  })
+
+  it('shows failed state with retry callback when upload fails', () => {
+    const onRetry = vi.fn()
+
+    expect(getImageTransferState({
+      hasLocalFile: true,
+      hasRemoteUrl: false,
+      fileSize: 2 * 1024 * 1024,
+      messageStatus: MessageStatus.Wait,
+      uploadStatus: TaskStatus.fail,
+      uploadProgress: 17,
+      onRetry,
+    })).toEqual({ status: 'failed', onRetry })
+  })
+
+  it('shows failed state when send ack fails after upload', () => {
+    const onRetry = vi.fn()
+
+    expect(getImageTransferState({
+      hasLocalFile: false,
+      hasRemoteUrl: true,
+      fileSize: 0,
+      messageStatus: MessageStatus.Fail,
+      uploadStatus: TaskStatus.success,
+      uploadProgress: 100,
+      onRetry,
+    })).toEqual({ status: 'failed', onRetry })
+  })
+
+  it('uses sending state for small active uploads instead of hiding pending state', () => {
+    expect(getImageTransferState({
+      hasLocalFile: true,
+      hasRemoteUrl: false,
+      fileSize: 128 * 1024,
+      messageStatus: MessageStatus.Wait,
+      uploadStatus: TaskStatus.processing,
+      uploadProgress: 42,
+    })).toEqual({ status: 'sending' })
+  })
+
+  it('uses progress state for large active uploads', () => {
+    expect(getImageTransferState({
+      hasLocalFile: true,
+      hasRemoteUrl: false,
+      fileSize: 2 * 1024 * 1024,
+      messageStatus: MessageStatus.Wait,
+      uploadStatus: TaskStatus.processing,
+      uploadProgress: 42.4,
+    })).toEqual({ status: 'uploading', progress: 42 })
+  })
+
+  it('returns no transfer state after a normal remote image is available', () => {
+    expect(getImageTransferState({
+      hasLocalFile: false,
+      hasRemoteUrl: true,
+      fileSize: 0,
+      messageStatus: MessageStatus.Normal,
+      uploadStatus: TaskStatus.success,
+      uploadProgress: 100,
+    })).toBeUndefined()
   })
 })

--- a/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
@@ -94,7 +94,7 @@ describe('getImageTransferState', () => {
   })
 
   it('shows failed state with retry callback when upload fails', () => {
-    const onRetry = vi.fn()
+    const onUploadRetry = vi.fn()
 
     expect(getImageTransferState({
       hasLocalFile: true,
@@ -103,12 +103,12 @@ describe('getImageTransferState', () => {
       messageStatus: MessageStatus.Wait,
       uploadStatus: TaskStatus.fail,
       uploadProgress: 17,
-      onRetry,
-    })).toEqual({ status: 'failed', onRetry })
+      onUploadRetry,
+    })).toEqual({ status: 'failed', onRetry: onUploadRetry })
   })
 
   it('shows failed state when send ack fails after upload', () => {
-    const onRetry = vi.fn()
+    const onMessageRetry = vi.fn()
 
     expect(getImageTransferState({
       hasLocalFile: false,
@@ -117,8 +117,19 @@ describe('getImageTransferState', () => {
       messageStatus: MessageStatus.Fail,
       uploadStatus: TaskStatus.success,
       uploadProgress: 100,
-      onRetry,
-    })).toEqual({ status: 'failed', onRetry })
+      onMessageRetry,
+    })).toEqual({ status: 'failed', onRetry: onMessageRetry })
+  })
+
+  it('lets an active upload retry override a stale failed message status', () => {
+    expect(getImageTransferState({
+      hasLocalFile: true,
+      hasRemoteUrl: false,
+      fileSize: 2 * 1024 * 1024,
+      messageStatus: MessageStatus.Fail,
+      uploadStatus: TaskStatus.processing,
+      uploadProgress: 31,
+    })).toEqual({ status: 'uploading', progress: 31 })
   })
 
   it('uses sending state for small active uploads instead of hiding pending state', () => {

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -1,4 +1,4 @@
-import { MediaMessageContent, WKSDK, Task, TaskStatus } from "wukongimjssdk"
+import { MediaMessageContent, WKSDK, Task, TaskStatus, MessageStatus } from "wukongimjssdk"
 import React from "react"
 import WKApp from "../../App"
 import { MessageContentTypeConst } from "../../Service/Const"
@@ -12,6 +12,7 @@ import { downloadFile } from "../../Utils/download"
 import MessageRow from "../../ui/message/MessageRow"
 import SingleImage from "../../ui/message/ImageContent/SingleImage"
 import MultiImage from "../../ui/message/ImageContent/MultiImage"
+import type { ImageTransferState } from "../../ui/message/ImageContent/SingleImage"
 import { getImageMessageUI } from "../../bridge/message/useImageMessageUI"
 
 const SMALL_FILE_THRESHOLD = 1024 * 1024 // 1MB 以下不显示进度覆盖层
@@ -74,6 +75,56 @@ interface ImageCellState {
     uploadStatus: TaskStatus | null
 }
 
+export interface ImageTransferInput {
+    hasLocalFile: boolean
+    hasRemoteUrl: boolean
+    fileSize: number
+    messageStatus: MessageStatus
+    uploadStatus: TaskStatus | null
+    uploadProgress: number
+    onRetry?: () => void
+}
+
+function isTaskFailed(uploadStatus: TaskStatus | null) {
+    return uploadStatus === TaskStatus.fail || uploadStatus === TaskStatus.cancel
+}
+
+function isTaskActive(uploadStatus: TaskStatus | null) {
+    return uploadStatus !== null && uploadStatus !== TaskStatus.success && !isTaskFailed(uploadStatus)
+}
+
+export function getImageTransferState({
+    hasLocalFile,
+    hasRemoteUrl,
+    fileSize,
+    messageStatus,
+    uploadStatus,
+    uploadProgress,
+    onRetry,
+}: ImageTransferInput): ImageTransferState | undefined {
+    if (messageStatus === MessageStatus.Fail) {
+        return { status: "failed", onRetry }
+    }
+
+    if (isTaskFailed(uploadStatus)) {
+        return { status: "failed", onRetry }
+    }
+
+    if (isTaskActive(uploadStatus)) {
+        const progress = Math.max(0, Math.min(100, Math.round(uploadProgress)))
+        if (fileSize >= SMALL_FILE_THRESHOLD && progress > 0) {
+            return { status: "uploading", progress }
+        }
+        return { status: "sending" }
+    }
+
+    if (messageStatus === MessageStatus.Wait || (hasLocalFile && !hasRemoteUrl)) {
+        return { status: "sending" }
+    }
+
+    return undefined
+}
+
 /** task 自身支持的重试接口（MediaMessageUploadTask 实现） */
 interface RestartableTask extends Task {
     restart(): Promise<void>;
@@ -100,9 +151,6 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
     componentDidMount() {
         super.componentDidMount()
         const { message } = this.props
-        // 小文件（<1MB）不显示进度，跳过订阅
-        const fileSize = (message.content as any).file?.size ?? 0
-        if (fileSize < SMALL_FILE_THRESHOLD) return
         WKSDK.shared().taskManager.addListener(this._taskListener)
         const found = ((WKSDK.shared().taskManager as any).taskMap as Map<string, Task> | undefined)
             ?.get(message.clientMsgNo) as RestartableTask | undefined
@@ -155,6 +203,14 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
         return <img alt="" src={this.getImageSrc(content)} style={{ borderRadius: '8px', width: scaleSize.width, height: scaleSize.height, maxWidth: '100%' }} />
     }
 
+    private handleRetry = () => {
+        if (!this._task) {
+            Toast.warning('上传任务已失效，请重新发送文件')
+            return
+        }
+        this._task.restart()
+    }
+
     render() {
         const { message, context } = this.props
         const { showPreview, uploadProgress, uploadStatus } = this.state
@@ -164,6 +220,18 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
         const useNewUI = true
         if (useNewUI) {
             const uiProps = getImageMessageUI(message)
+            const hasRemoteUrl = !!(content.url || (content as any).remoteUrl)
+            const fileSize = (content as any).file?.size ?? 0
+            const transferState = getImageTransferState({
+                hasLocalFile: !!(content as any).file,
+                hasRemoteUrl,
+                fileSize,
+                messageStatus: message.status,
+                uploadStatus,
+                uploadProgress,
+                onRetry: this.handleRetry,
+            })
+            const canPreview = !transferState && hasRemoteUrl
             return (
                 <>
                     <MessageRow
@@ -179,6 +247,7 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                         {uiProps.isMulti
                             ? <MultiImage
                                 images={uiProps.images}
+                                transferState={transferState}
                                 onImageClick={(index) => {
                                     // TODO: 多图预览
                                 }}
@@ -186,7 +255,8 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                             : uiProps.singleImage
                                 ? <SingleImage
                                     {...uiProps.singleImage}
-                                    onClick={() => this.setState({ showPreview: true })}
+                                    transferState={transferState}
+                                    onClick={canPreview ? () => this.setState({ showPreview: true }) : undefined}
                                   />
                                 : null
                         }

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -82,7 +82,8 @@ export interface ImageTransferInput {
     messageStatus: MessageStatus
     uploadStatus: TaskStatus | null
     uploadProgress: number
-    onRetry?: () => void
+    onUploadRetry?: () => void
+    onMessageRetry?: () => void
 }
 
 function isTaskFailed(uploadStatus: TaskStatus | null) {
@@ -100,22 +101,23 @@ export function getImageTransferState({
     messageStatus,
     uploadStatus,
     uploadProgress,
-    onRetry,
+    onUploadRetry,
+    onMessageRetry,
 }: ImageTransferInput): ImageTransferState | undefined {
-    if (messageStatus === MessageStatus.Fail) {
-        return { status: "failed", onRetry }
-    }
-
-    if (isTaskFailed(uploadStatus)) {
-        return { status: "failed", onRetry }
-    }
-
     if (isTaskActive(uploadStatus)) {
         const progress = Math.max(0, Math.min(100, Math.round(uploadProgress)))
         if (fileSize >= SMALL_FILE_THRESHOLD && progress > 0) {
             return { status: "uploading", progress }
         }
         return { status: "sending" }
+    }
+
+    if (isTaskFailed(uploadStatus)) {
+        return { status: "failed", onRetry: onUploadRetry }
+    }
+
+    if (messageStatus === MessageStatus.Fail) {
+        return { status: "failed", onRetry: onMessageRetry }
     }
 
     if (messageStatus === MessageStatus.Wait || (hasLocalFile && !hasRemoteUrl)) {
@@ -229,7 +231,8 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                 messageStatus: message.status,
                 uploadStatus,
                 uploadProgress,
-                onRetry: this.handleRetry,
+                onUploadRetry: this.handleRetry,
+                onMessageRetry: () => context.resendMessage(message.message),
             })
             const canPreview = !transferState && hasRemoteUrl
             return (

--- a/packages/dmworkbase/src/ui/message/ImageContent/ImageContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/ImageContent/ImageContent.stories.tsx
@@ -30,6 +30,41 @@ export const SingleDefault: SingleStory = {
   },
 }
 
+export const SingleSending: SingleStory = {
+  args: {
+    src: 'https://picsum.photos/800/600?random=sending',
+    width: 800,
+    height: 600,
+    transferState: {
+      status: 'sending',
+    },
+  },
+}
+
+export const SingleUploading: SingleStory = {
+  args: {
+    src: 'https://picsum.photos/1200/900?random=uploading',
+    width: 1200,
+    height: 900,
+    transferState: {
+      status: 'uploading',
+      progress: 48,
+    },
+  },
+}
+
+export const SingleUploadFailed: SingleStory = {
+  args: {
+    src: 'https://picsum.photos/800/600?random=failed',
+    width: 800,
+    height: 600,
+    transferState: {
+      status: 'failed',
+      onRetry: () => alert('重试上传'),
+    },
+  },
+}
+
 export const SingleLarge: SingleStory = {
   args: {
     src: 'https://picsum.photos/1200/900',
@@ -87,6 +122,16 @@ export const MultiFiveImages: MultiStory = {
   render: () => (
     <MultiImage
       images={mockImages}
+      onImageClick={(i) => alert(`点击第 ${i + 1} 张`)}
+    />
+  ),
+}
+
+export const MultiSending: MultiStory = {
+  render: () => (
+    <MultiImage
+      images={mockImages.slice(0, 3)}
+      transferState={{ status: 'sending' }}
       onImageClick={(i) => alert(`点击第 ${i + 1} 张`)}
     />
   ),

--- a/packages/dmworkbase/src/ui/message/ImageContent/MultiImage.tsx
+++ b/packages/dmworkbase/src/ui/message/ImageContent/MultiImage.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import './index.css'
-import SingleImage from './SingleImage'
+import SingleImage, { ImageTransferState } from './SingleImage'
 
 export interface ImageItem {
   src: string
   width: number
   height: number
+  transferState?: ImageTransferState
 }
 
 export interface MultiImageProps {
@@ -14,6 +15,9 @@ export interface MultiImageProps {
 
   /** 点击图片回调 */
   onImageClick?: (index: number) => void
+
+  /** 多图整体发送/上传状态 */
+  transferState?: ImageTransferState
 }
 
 /**
@@ -28,7 +32,8 @@ export interface MultiImageProps {
  */
 export default function MultiImage({
   images,
-  onImageClick
+  onImageClick,
+  transferState
 }: MultiImageProps) {
   return (
     <div className="wk-msg-multi-image">
@@ -38,6 +43,7 @@ export default function MultiImage({
           src={img.src}
           width={img.width}
           height={img.height}
+          transferState={img.transferState || transferState}
           onClick={() => onImageClick?.(index)}
         />
       ))}

--- a/packages/dmworkbase/src/ui/message/ImageContent/SingleImage.tsx
+++ b/packages/dmworkbase/src/ui/message/ImageContent/SingleImage.tsx
@@ -1,6 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react'
 import './index.css'
 
+export interface ImageTransferState {
+  status: 'sending' | 'uploading' | 'failed'
+  progress?: number
+  onRetry?: () => void
+}
+
 export interface SingleImageProps {
   /** 图片 URL */
   src: string
@@ -13,6 +19,9 @@ export interface SingleImageProps {
   
   /** 点击回调 */
   onClick?: () => void
+
+  /** 图片发送/上传状态 */
+  transferState?: ImageTransferState
 }
 
 const FALLBACK_MAX_WIDTH = 660
@@ -28,9 +37,11 @@ export default function SingleImage({
   width,
   height,
   onClick,
+  transferState,
 }: SingleImageProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [maxWidth, setMaxWidth] = useState(FALLBACK_MAX_WIDTH)
+  const isInteractive = !!onClick && !transferState
 
   useEffect(() => {
     const el = containerRef.current
@@ -62,6 +73,72 @@ export default function SingleImage({
     displayHeight = Math.round(height * ratio)
   }
 
+  const handleRetryKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!transferState?.onRetry) return
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      event.stopPropagation()
+      transferState.onRetry()
+    }
+  }
+
+  const renderTransferOverlay = () => {
+    if (!transferState) return null
+
+    const pct = typeof transferState.progress === 'number'
+      ? Math.max(0, Math.min(100, Math.round(transferState.progress)))
+      : null
+    const showProgress = transferState.status === 'uploading' && pct !== null
+    const label = transferState.status === 'failed'
+      ? '上传失败，点击重试'
+      : transferState.status === 'uploading'
+        ? '上传中'
+        : '发送中'
+
+    if (transferState.status === 'failed') {
+      return (
+        <div
+          className="wk-msg-image-transfer wk-msg-image-transfer--failed"
+          role={transferState.onRetry ? 'button' : undefined}
+          tabIndex={transferState.onRetry ? 0 : undefined}
+          onClick={(event) => {
+            event.stopPropagation()
+            transferState.onRetry?.()
+          }}
+          onKeyDown={handleRetryKeyDown}
+        >
+          <span className="wk-msg-image-transfer-warning" aria-hidden="true">!</span>
+          <span className="wk-msg-image-transfer-label">{label}</span>
+        </div>
+      )
+    }
+
+    return (
+      <div
+        className="wk-msg-image-transfer"
+        aria-live="polite"
+        aria-label={showProgress ? `${label} ${pct}%` : label}
+      >
+        {showProgress ? (
+          <>
+            <div className="wk-msg-image-transfer-progress">
+              <div
+                className="wk-msg-image-transfer-progress-fill"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <span className="wk-msg-image-transfer-label">{pct}%</span>
+          </>
+        ) : (
+          <>
+            <span className="wk-msg-image-transfer-spinner" aria-hidden="true" />
+            <span className="wk-msg-image-transfer-label">{label}</span>
+          </>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div
       ref={containerRef}
@@ -70,9 +147,10 @@ export default function SingleImage({
       <div
         className="wk-msg-single-image"
         style={{ width: displayWidth, height: displayHeight }}
-        onClick={onClick}
-        role={onClick ? 'button' : undefined}
-        tabIndex={onClick ? 0 : undefined}
+        onClick={isInteractive ? onClick : undefined}
+        role={isInteractive ? 'button' : undefined}
+        tabIndex={isInteractive ? 0 : undefined}
+        aria-busy={!!transferState || undefined}
       >
         <img
           src={src}
@@ -80,6 +158,7 @@ export default function SingleImage({
           width={displayWidth}
           height={displayHeight}
         />
+        {renderTransferOverlay()}
       </div>
     </div>
   )

--- a/packages/dmworkbase/src/ui/message/ImageContent/index.css
+++ b/packages/dmworkbase/src/ui/message/ImageContent/index.css
@@ -11,11 +11,16 @@
 .wk-msg-single-image {
   border-radius: var(--wk-r-lg);
   overflow: hidden;
-  cursor: pointer;
+  cursor: default;
   transition: opacity 0.2s;
+  position: relative;
 }
 
-.wk-msg-single-image:hover {
+.wk-msg-single-image[role='button'] {
+  cursor: pointer;
+}
+
+.wk-msg-single-image[role='button']:hover {
   opacity: 0.9;
 }
 
@@ -24,7 +29,75 @@
   width: 100%;
   height: 100%;
   object-fit: contain;
-  background: var(--wk-neutral-100, #F2F3F4);
+  background: var(--wk-bg-elevated);
+}
+
+.wk-msg-image-transfer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--wk-sp-2);
+  background: color-mix(in srgb, var(--wk-text-primary) 52%, transparent);
+  color: var(--wk-text-inverse);
+  font-size: var(--wk-text-size-sm);
+  font-weight: var(--wk-font-medium, 500);
+  text-align: center;
+  pointer-events: auto;
+}
+
+.wk-msg-image-transfer--failed {
+  cursor: pointer;
+}
+
+.wk-msg-image-transfer-progress {
+  width: min(70%, 180px);
+  height: var(--wk-sp-1);
+  border-radius: var(--wk-r-full);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--wk-text-inverse) 28%, transparent);
+}
+
+.wk-msg-image-transfer-progress-fill {
+  height: 100%;
+  border-radius: var(--wk-r-full);
+  background: var(--wk-text-inverse);
+  transition: width 0.2s ease;
+}
+
+.wk-msg-image-transfer-spinner {
+  width: var(--wk-sp-5);
+  height: var(--wk-sp-5);
+  border-radius: var(--wk-r-full);
+  border: var(--wk-sp-0-5) solid color-mix(in srgb, var(--wk-text-inverse) 28%, transparent);
+  border-top-color: var(--wk-text-inverse);
+  animation: wk-msg-image-transfer-spin 0.8s linear infinite;
+}
+
+.wk-msg-image-transfer-warning {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--wk-sp-6);
+  height: var(--wk-sp-6);
+  border-radius: var(--wk-r-full);
+  background: var(--wk-color-error);
+  color: var(--wk-text-inverse);
+  font-size: var(--wk-text-size-lg);
+  font-weight: var(--wk-font-bold, 700);
+  line-height: 1;
+}
+
+.wk-msg-image-transfer-label {
+  line-height: 1.4;
+}
+
+@keyframes wk-msg-image-transfer-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /**
@@ -35,6 +108,6 @@
 .wk-msg-multi-image {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--wk-sp-2);
   max-width: 660px;
 }


### PR DESCRIPTION
## Summary
- show an explicit sending/uploading/failed overlay for image messages while upload or send ack is pending
- wire ImageCell task/message status into the new image UI and keep small images subscribed to upload task changes
- add Storybook states and unit coverage for image transfer state mapping

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts --environment jsdom