### PR TITLE
feat: use reset endpoint instead of delete for restoring defaults

### DIFF
--- a/apps/web/src/__tests__/voiceService.test.ts
+++ b/apps/web/src/__tests__/voiceService.test.ts
@@ -553,4 +553,28 @@ describe("VoiceService", () => {
             await expect(VoiceService.shared.deleteLocalConfig()).rejects.toThrow("Not found")
         })
     })
+
+    describe("resetLocalConfig", () => {
+        it("should call POST /voice/local-config/reset with enabled true", async () => {
+            vi.mocked(APIClient.shared.post).mockResolvedValue({ status: 200, msg: "ok" })
+
+            await VoiceService.shared.resetLocalConfig({ enabled: true })
+
+            expect(APIClient.shared.post).toHaveBeenCalledWith("/voice/local-config/reset", { enabled: true })
+        })
+
+        it("should call POST /voice/local-config/reset with enabled false", async () => {
+            vi.mocked(APIClient.shared.post).mockResolvedValue({ status: 200, msg: "ok" })
+
+            await VoiceService.shared.resetLocalConfig({ enabled: false })
+
+            expect(APIClient.shared.post).toHaveBeenCalledWith("/voice/local-config/reset", { enabled: false })
+        })
+
+        it("should propagate errors from the API", async () => {
+            vi.mocked(APIClient.shared.post).mockRejectedValue(new Error("Server error"))
+
+            await expect(VoiceService.shared.resetLocalConfig({ enabled: true })).rejects.toThrow("Server error")
+        })
+    })
 })

--- a/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
@@ -178,7 +178,7 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
     setLocalSaving(true);
 
     try {
-      await VoiceService.shared.deleteLocalConfig();
+      await VoiceService.shared.resetLocalConfig({ enabled: localEnabled });
       const newConfig = await VoiceService.shared.getConfig();
       setSharedVoiceConfig(newConfig);
 
@@ -194,7 +194,8 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
     } finally {
       setLocalSaving(false);
     }
-  }, [localSaving, t]);
+  }, [localSaving, localEnabled, t]);
+
 
   const handleTestProbe = useCallback(async () => {
     if (!localProbeUrl.trim() || probeTestStatus === 'loading') return;

--- a/packages/dmworkbase/src/Service/VoiceService.ts
+++ b/packages/dmworkbase/src/Service/VoiceService.ts
@@ -167,6 +167,10 @@ export default class VoiceService {
     await APIClient.shared.delete("/voice/local-config");
   }
 
+  async resetLocalConfig(config: { enabled: boolean }): Promise<void> {
+    await APIClient.shared.post("/voice/local-config/reset", config);
+  }
+
   clearVoiceContextCache(spaceId?: string): void {
     if (spaceId) {
       this._voiceContextEpoch.set(


### PR DESCRIPTION
Change the 'Restore Defaults' button behavior from DELETE to POST /reset.

- Calls `VoiceService.resetLocalConfig({enabled})` instead of `deleteLocalConfig()`
- Preserves current enabled state when resetting other fields
- Clearer semantic: reset to defaults ≠ delete config entirely


Closes #159
