### PR TITLE
fix(i18n): sync Semi locale with app language

### DIFF
--- a/docs/i18n-agent-guide.md
+++ b/docs/i18n-agent-guide.md
@@ -75,6 +75,8 @@ format.dateTime(createdAt);
 format.relativeTime(updatedAt);
 ```
 
+Semi UI component chrome is also locale-sensitive. The app-level `I18nProvider` owns the Semi `ConfigProvider` / `LocaleProvider` bridge, so do not set Semi locale per DatePicker, Pagination, Modal, or Select unless a component has a specific product reason. Component props that are still product copy, such as labels, placeholders, tooltips, and aria labels, must continue to use `t()`.
+
 ## Key Naming
 
 Use stable semantic keys, not source-language sentence keys.

--- a/packages/dmworkbase/src/i18n/I18nProvider.tsx
+++ b/packages/dmworkbase/src/i18n/I18nProvider.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, ReactNode, useEffect, useMemo, useState } from "react";
+import { ConfigProvider, LocaleProvider } from "@douyinfe/semi-ui";
 import { createI18nFormatter } from "./format";
 import { i18n } from "./instance";
+import { getSemiDirection, getSemiLocale } from "./semiLocale";
 import { Locale } from "./types";
 
 export interface I18nContextValue {
@@ -32,10 +34,16 @@ export function I18nProvider({ children }: I18nProviderProps) {
     setLocale: (nextLocale) => i18n.setLocale(nextLocale),
     t: i18n.t.bind(i18n),
   }), [locale]);
+  const semiLocale = getSemiLocale(locale);
+  const semiDirection = getSemiDirection(locale);
 
   return (
-    <I18nContext.Provider value={value}>
-      {children}
-    </I18nContext.Provider>
+    <ConfigProvider locale={semiLocale} direction={semiDirection}>
+      <LocaleProvider locale={semiLocale}>
+        <I18nContext.Provider value={value}>
+          {children}
+        </I18nContext.Provider>
+      </LocaleProvider>
+    </ConfigProvider>
   );
 }

--- a/packages/dmworkbase/src/i18n/I18nService.ts
+++ b/packages/dmworkbase/src/i18n/I18nService.ts
@@ -1,4 +1,5 @@
 import { detectLocale, localeStorageKey } from "./detectLocale";
+import { getTextDirection } from "./direction";
 import { createI18nFormatter, I18nFormatter } from "./format";
 import {
   defaultLocale,
@@ -10,7 +11,6 @@ import {
   NamespaceResources,
   normalizeLocale,
   supportedLocales,
-  TextDirection,
   TranslateOptions,
 } from "./types";
 
@@ -50,8 +50,6 @@ function interpolate(template: string, values?: TranslateOptions["values"]) {
   });
 }
 
-const rtlLocales = new Set<Locale>();
-
 function createEmptyMessages(): Record<Locale, FlatMessages> {
   return supportedLocales.reduce(
     (acc, locale) => {
@@ -62,14 +60,10 @@ function createEmptyMessages(): Record<Locale, FlatMessages> {
   );
 }
 
-function getDirection(locale: Locale): TextDirection {
-  return rtlLocales.has(locale) ? "rtl" : "ltr";
-}
-
 function applyDocumentLocale(locale: Locale) {
   if (typeof document === "undefined") return;
   document.documentElement.lang = locale;
-  document.documentElement.dir = getDirection(locale);
+  document.documentElement.dir = getTextDirection(locale);
 }
 
 export class I18nService {

--- a/packages/dmworkbase/src/i18n/__tests__/semiLocale.test.ts
+++ b/packages/dmworkbase/src/i18n/__tests__/semiLocale.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getSemiDirection, getSemiLocale } from "../semiLocale";
+
+describe("semiLocale", () => {
+  it("maps app locales to Semi locale packages", () => {
+    expect(getSemiLocale("zh-CN").code).toBe("zh-CN");
+    expect(getSemiLocale("zh-CN").DatePicker.placeholder.date).toBe("请选择日期");
+    expect(getSemiLocale("en-US").code).toBe("en-US");
+    expect(getSemiLocale("en-US").DatePicker.placeholder.date).toBe("Select date");
+  });
+
+  it("uses the shared text direction mapping", () => {
+    expect(getSemiDirection("zh-CN")).toBe("ltr");
+    expect(getSemiDirection("en-US")).toBe("ltr");
+  });
+});

--- a/packages/dmworkbase/src/i18n/direction.ts
+++ b/packages/dmworkbase/src/i18n/direction.ts
@@ -1,0 +1,7 @@
+import { Locale, TextDirection } from "./types";
+
+const rtlLocales = new Set<Locale>();
+
+export function getTextDirection(locale: Locale): TextDirection {
+  return rtlLocales.has(locale) ? "rtl" : "ltr";
+}

--- a/packages/dmworkbase/src/i18n/index.ts
+++ b/packages/dmworkbase/src/i18n/index.ts
@@ -1,4 +1,5 @@
 export * from "./detectLocale";
+export * from "./direction";
 export * from "./format";
 export * from "./I18nProvider";
 export * from "./I18nService";

--- a/packages/dmworkbase/src/i18n/semiLocale.ts
+++ b/packages/dmworkbase/src/i18n/semiLocale.ts
@@ -1,0 +1,18 @@
+import enUS from "@douyinfe/semi-ui/lib/es/locale/source/en_US";
+import zhCN from "@douyinfe/semi-ui/lib/es/locale/source/zh_CN";
+import type { Locale as SemiLocale } from "@douyinfe/semi-ui/lib/es/locale/interface";
+import { getTextDirection } from "./direction";
+import { Locale } from "./types";
+
+export const semiLocales: Record<Locale, SemiLocale> = {
+  "zh-CN": zhCN,
+  "en-US": enUS,
+};
+
+export function getSemiLocale(locale: Locale) {
+  return semiLocales[locale];
+}
+
+export function getSemiDirection(locale: Locale) {
+  return getTextDirection(locale);
+}

--- a/packages/dmworktodo/src/i18n/en-US.json
+++ b/packages/dmworktodo/src/i18n/en-US.json
@@ -110,6 +110,7 @@
   },
   "field": {
     "assignee": "Assignee",
+    "deadline": "Deadline",
     "goal": "Main goal",
     "goalPlaceholder": "Enter the main goal",
     "title": "Task name"

--- a/packages/dmworktodo/src/i18n/zh-CN.json
+++ b/packages/dmworktodo/src/i18n/zh-CN.json
@@ -110,6 +110,7 @@
   },
   "field": {
     "assignee": "负责人",
+    "deadline": "截止日期",
     "goal": "主要目标",
     "goalPlaceholder": "请输入主要目标",
     "title": "事项名称"

--- a/packages/dmworktodo/src/pages/MatterPage.css
+++ b/packages/dmworktodo/src/pages/MatterPage.css
@@ -88,11 +88,15 @@
   margin: 0 var(--wk-sp-3) var(--wk-sp-2);
   background: var(--wk-brand-tint-04);
   border-radius: var(--wk-r-full);
+  min-height: 44px;
+  box-sizing: border-box;
 }
 
 .wk-mp-page-sidebar__tab {
-  flex: 1;
-  padding: 2px var(--wk-sp-2);
+  flex: 1 1 0;
+  min-width: 0;
+  height: 36px;
+  padding: 2px var(--wk-sp-1);
   border: none;
   background: transparent;
   color: var(--wk-icon-muted);
@@ -101,10 +105,14 @@
   line-height: 16px;
   cursor: pointer;
   border-radius: var(--wk-r-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   transition:
     color var(--wk-dur-fast),
     background var(--wk-dur-fast);
+  white-space: normal;
 }
 
 .wk-mp-page-sidebar__tab:hover {
@@ -370,4 +378,3 @@
   position: relative;
   display: inline-flex;
 }
-

--- a/packages/dmworktodo/src/ui/CreateTaskModal/index.tsx
+++ b/packages/dmworktodo/src/ui/CreateTaskModal/index.tsx
@@ -275,7 +275,7 @@ export default function CreateTaskModal({
           {/* Deadline */}
           <div className="wk-create-task-modal__field">
             <label className="wk-create-task-modal__label">
-              Deadline<span className="wk-create-task-modal__required">*</span>
+              {t("todo.field.deadline")}<span className="wk-create-task-modal__required">*</span>
             </label>
             <DatePicker
               className="wk-create-task-modal__datepicker"

--- a/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
+++ b/packages/dmworktodo/src/ui/SmartCreateModal/index.tsx
@@ -317,7 +317,7 @@ export default function SmartCreateModal({
               {/* Deadline */}
               <div className="wk-smart-create-modal__field">
                 <label className="wk-smart-create-modal__label">
-                  Deadline<span className="wk-smart-create-modal__req">*</span>
+                  {t("todo.field.deadline")}<span className="wk-smart-create-modal__req">*</span>
                 </label>
                 <DatePicker
                   className="wk-smart-create-modal__datepicker"


### PR DESCRIPTION
## Summary

- Sync Semi UI locale/direction with the app i18n provider for component chrome such as DatePicker.
- Localize remaining task deadline labels in create task modals.
- Stabilize task sidebar tab sizing in English so all segments share the same selected-state footprint.
- Document the Semi locale bridge for future i18n work.

## Validation

- pnpm i18n:check
- pnpm exec vitest run packages/dmworkbase/src/i18n/__tests__/detectLocale.test.ts packages/dmworkbase/src/i18n/__tests__/I18nService.test.ts packages/dmworkbase/src/i18n/__tests__/semiLocale.test.ts
- pnpm --filter @octo/web build
- Browser verified DatePicker chrome switches between English and Chinese.

Closes #147