### PR TITLE
fix: escape backslash before pipe in markdown cell output

### DIFF
--- a/scripts/i18n-scan.mjs
+++ b/scripts/i18n-scan.mjs
@@ -34,6 +34,10 @@ function normalizeText(value) {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function escapeMarkdownCell(text) {
+  return text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
 function hasCjk(value) {
   return cjkPattern.test(value);
 }
@@ -607,7 +611,7 @@ function renderMarkdownReport(candidates, summary) {
     }, {});
 
   const sampleRows = candidates.slice(0, 200).map((candidate) => (
-    `| \`${candidate.file}:${candidate.line}\` | ${candidate.kind} | ${candidate.confidence} | \`${candidate.suggestedKey}\` | ${candidate.text.replace(/\|/g, "\\|")} |`
+    `| \`${candidate.file}:${candidate.line}\` | ${candidate.kind} | ${candidate.confidence} | \`${candidate.suggestedKey}\` | ${escapeMarkdownCell(candidate.text)} |`
   ));
 
   return `${[
@@ -663,7 +667,7 @@ function renderLocaleReport(report) {
       : issue.message || (issue.examples?.length
           ? issue.examples.map((example) => `${example.file}:${example.line}`).join(", ")
           : "");
-    return `| ${issue.type} | ${issue.locale || ""} | \`${key}\` | \`${location}\` | ${details.replace(/\|/g, "\\|")} |`;
+    return `| ${issue.type} | ${issue.locale || ""} | \`${key}\` | \`${location}\` | ${escapeMarkdownCell(details)} |`;
   });
 
   return `${[


### PR DESCRIPTION
## Summary

Fix incomplete string sanitization in `scripts/i18n-scan.mjs` (CodeQL alerts #9 and #10).

## Problem

Two places escape pipe characters `|` for Markdown table cells but do not first escape backslashes. If input contains `\|`, the replacement produces `\\|` which Markdown parses as an escaped backslash + a cell boundary, breaking the table structure.

## Fix

Extract a shared `escapeMarkdownCell()` helper that escapes backslashes **before** pipes:

```javascript
function escapeMarkdownCell(text) {
  return text.replace(/\\\\/g, "\\\\\\\\").replace(/\\|/g, "\\\\|");
}
```

Applied at both call sites (L610, L666).

## Verification

- `node --check scripts/i18n-scan.mjs` passes (no syntax errors)
- CodeQL should auto-close #9 and #10 on merge

Fixes CodeQL #9, #10 (js/incomplete-sanitization, CWE-20/CWE-80/CWE-116)