### PR TITLE
fix: stabilize AI streaming message layout

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/foldSessionSummary.ts
+++ b/packages/dmworkbase/src/Components/Conversation/foldSessionSummary.ts
@@ -33,8 +33,10 @@ export function getFoldSessionExpandedMessages(session: FoldSessionExpandedMessa
     if (session.messages.length === 0) {
         return []
     }
-    // 展开时显示所有消息(包括最后一条)
-    return [...session.messages]
+    if (session.typing) {
+        return [...session.messages]
+    }
+    return session.messages.slice(0, -1)
 }
 
 export function isFoldSessionSummaryMessage(session: FoldSessionSummarySource, messageSeq: number): boolean {

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -737,6 +737,7 @@ export default class ConversationVM extends ProviderListener {
                         existMsg.message.streams.sort((a, b) => a.streamSeq - b.streamSeq)
                     }
                     existMsg.message.streamFlag = message.streamFlag
+                    this.rebuildRenderItems()
                     this.notifyListener()
                     return
                 }

--- a/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
@@ -31,6 +31,18 @@ describe("isMessageContinuation", () => {
         )).toBe(false)
     })
 
+    it("does not let temporary typing messages merge with real messages", () => {
+        expect(isMessageContinuation(
+            msg("bot1", 1_000, { contentType: MessageContentTypeConst.typing }),
+            msg("bot1", 1_030),
+        )).toBe(false)
+
+        expect(isMessageContinuation(
+            msg("bot1", 1_000),
+            msg("bot1", 1_030, { contentType: MessageContentTypeConst.typing }),
+        )).toBe(false)
+    })
+
     it("does not continue across different senders", () => {
         expect(isMessageContinuation(msg("u1", 1_000), msg("u2", 1_030))).toBe(false)
     })

--- a/packages/dmworkbase/src/Service/messageContinuity.ts
+++ b/packages/dmworkbase/src/Service/messageContinuity.ts
@@ -20,6 +20,7 @@ function isBoundaryMessage(message: ContinuityMessage): boolean {
     const contentType = contentTypeOf(message)
     return contentType === MessageContentTypeConst.time
         || contentType === MessageContentTypeConst.historySplit
+        || contentType === MessageContentTypeConst.typing
         || !!message.revoke
 }
 


### PR DESCRIPTION
## Summary
- Treat temporary typing messages as message-continuity boundaries so AI streaming replies keep their own avatar/header during live rendering.
- Rebuild conversation render items when streaming chunks are appended to an existing message.
- Avoid duplicating the latest real message in fold-session expanded content when it is already shown as the summary.

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionSummary.test.ts packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts

## Related Issue
- Related to #117