### PR TITLE
feat: support disabling user space creation

### DIFF
--- a/apps/web/src/Components/JoinSpacePage/index.tsx
+++ b/apps/web/src/Components/JoinSpacePage/index.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { WKApp, toJoinApprovalStatus, useI18n } from "@octo/base";
+import React, { useEffect, useState } from "react";
+import { SpaceCreate, WKApp, toJoinApprovalStatus, useI18n } from "@octo/base";
 import { SpaceService } from "@octo/base";
 import { Button, Input, Toast } from "@douyinfe/semi-ui";
 import "./index.css";
@@ -22,18 +22,32 @@ interface JoinSpacePageProps {
 const ACCENT = "var(--wk-color-primary, #1C1C23)";
 
 const setCurrentSpace = (spaceId: string) => {
-    if (spaceId) localStorage.setItem("currentSpaceId", spaceId);
+    if (!spaceId) return;
+    WKApp.shared.currentSpaceId = spaceId;
+    localStorage.setItem("currentSpaceId", spaceId);
 };
 
 export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
     const { t } = useI18n();
     const [view, setView] = useState<View>("home");
+    const [showCreate, setShowCreate] = useState(false);
+    const [, setRemoteConfigVersion] = useState(0);
+    const canCreateSpace = !WKApp.remoteConfig.disableUserCreateSpace;
 
     // --- 加入 Space ---
     const [inviteCode, setInviteCode] = useState("");
     const [inviteInfo, setInviteInfo] = useState<InviteInfo | null>(null);
     const [verifyLoading, setVerifyLoading] = useState(false);
     const [joinLoading, setJoinLoading] = useState(false);
+
+    useEffect(() => {
+        return WKApp.remoteConfig.addConfigChangeListener(() => {
+            if (WKApp.remoteConfig.disableUserCreateSpace) {
+                setShowCreate(false);
+            }
+            setRemoteConfigVersion((v) => v + 1);
+        });
+    }, []);
 
     /** 验证邀请码，展示 Space 信息 */
     const handleVerifyCode = async () => {
@@ -119,6 +133,16 @@ export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
                             >
                                 📩 {t("app.joinSpace.inputInviteJoin")}
                             </Button>
+                            {canCreateSpace && (
+                                <Button
+                                    type="secondary"
+                                    size="large"
+                                    className="wk-join-space-btn"
+                                    onClick={() => setShowCreate(true)}
+                                >
+                                    ✨ {t("app.spaceGate.createTeam")}
+                                </Button>
+                            )}
                         </div>
                     </>
                 )}
@@ -193,6 +217,15 @@ export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
                     </>
                 )}
             </div>
+            <SpaceCreate
+                visible={canCreateSpace && showCreate}
+                onClose={() => setShowCreate(false)}
+                onSuccess={(spaceId) => {
+                    setCurrentSpace(spaceId);
+                    setShowCreate(false);
+                    onSuccess();
+                }}
+            />
         </div>
     );
 }

--- a/apps/web/src/Components/SpaceGate/index.tsx
+++ b/apps/web/src/Components/SpaceGate/index.tsx
@@ -29,9 +29,18 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
     private _enterTimer: ReturnType<typeof setTimeout> | null = null;
     private _isEntering = false;
     private _isMounted = false;
+    private _unsubscribeRemoteConfig?: () => void;
 
     componentDidMount() {
         this._isMounted = true;
+        this._unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
+            if (!this._isMounted) return;
+            if (WKApp.remoteConfig.disableUserCreateSpace && this.state.showCreate) {
+                this.setState({ showCreate: false });
+                return;
+            }
+            this.forceUpdate();
+        });
         const cached = localStorage.getItem("currentSpaceId");
         if (cached) {
             this.enterSpace(cached);
@@ -42,6 +51,7 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
 
     componentWillUnmount() {
         this._isMounted = false;
+        this._unsubscribeRemoteConfig?.();
         if (this._enterTimer) {
             clearTimeout(this._enterTimer);
             this._enterTimer = null;
@@ -110,6 +120,7 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
     render() {
         const { loading, noSpace, inviteCode, joining, showCreate, showInviteInput } = this.state;
         const { t } = this.context;
+        const canCreateSpace = !WKApp.remoteConfig.disableUserCreateSpace;
 
         if (loading && !noSpace) {
             return (
@@ -140,10 +151,12 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
                                 onClick={() => this.setState({ showInviteInput: true })}>
                                 📩 {t("app.spaceGate.joinByInvite")}
                             </Button>
-                            <Button type="secondary" size="large" style={{ width: "100%", height: 44 }}
-                                onClick={() => this.setState({ showCreate: true })}>
-                                ✨ {t("app.spaceGate.createTeam")}
-                            </Button>
+                            {canCreateSpace && (
+                                <Button type="secondary" size="large" style={{ width: "100%", height: 44 }}
+                                    onClick={() => this.setState({ showCreate: true })}>
+                                    ✨ {t("app.spaceGate.createTeam")}
+                                </Button>
+                            )}
                         </div>
                     ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -168,7 +181,7 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
                 </div>
 
                 <SpaceCreate
-                    visible={showCreate}
+                    visible={canCreateSpace && showCreate}
                     onClose={() => this.setState({ showCreate: false })}
                     onSuccess={(_spaceId) => this.checkSpaces()}
                 />

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -4,7 +4,7 @@ import "./index.css"
 import MainVM from "./vm";
 import { EmptyStateIllustration } from "./EmptyStateIllustration";
 import { Space, SpaceService } from "@octo/base";
-import { JoinSpaceModalConnected, NavRail, MeInfo } from "@octo/base";
+import { JoinSpaceModalConnected, NavRail, MeInfo, SpaceCreate } from "@octo/base";
 import { consumeJoinSuccessNotice, showJoinSuccessToast } from "@octo/base";
 import { Toast } from "@douyinfe/semi-ui";
 
@@ -37,6 +37,7 @@ export class MainContentLeft extends Component<MainContentLeftProps> {
 interface MainPageState {
     allSpaces: Space[];
     showJoinSpace: boolean;
+    showCreateSpace: boolean;
     showMeInfo: boolean;
 }
 
@@ -46,13 +47,23 @@ export class MainPage extends Component<{}, MainPageState> {
         this.state = {
             allSpaces: [],
             showJoinSpace: false,
+            showCreateSpace: false,
             showMeInfo: false,
         };
     }
 
+    private unsubscribeRemoteConfig?: () => void;
+
     componentDidMount() {
         // 注册菜单刷新回调，触发父组件 re-render（原 TabNormalScreen componentDidMount 里的逻辑）
         WKApp.menus.setRefresh = () => { this.forceUpdate(); };
+        this.unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
+            if (WKApp.remoteConfig.disableUserCreateSpace && this.state.showCreateSpace) {
+                this.setState({ showCreateSpace: false });
+                return;
+            }
+            this.forceUpdate();
+        });
 
         SpaceService.shared.getMySpaces().then(spaces => {
             this.setState({ allSpaces: spaces });
@@ -80,6 +91,7 @@ export class MainPage extends Component<{}, MainPageState> {
     componentWillUnmount() {
         // 清理菜单刷新回调，避免组件卸载后触发 forceUpdate
         WKApp.menus.setRefresh = undefined;
+        this.unsubscribeRemoteConfig?.();
     }
 
     /**
@@ -156,7 +168,7 @@ export class MainPage extends Component<{}, MainPageState> {
     };
 
     render() {
-        const { allSpaces, showJoinSpace, showMeInfo } = this.state;
+        const { allSpaces, showJoinSpace, showCreateSpace, showMeInfo } = this.state;
         // 客户端 UI 可见性控制：仅在用户拥有任一 Space 的 owner/admin 角色时显示入口；
         // 真正的接口鉴权由 admin SPA 后端负责。allSpaces 来自登录后刷新，角色变更需重新加载。
         const canManageSpace = allSpaces.some(s => s.role === 1 || s.role === 2);
@@ -175,6 +187,7 @@ export class MainPage extends Component<{}, MainPageState> {
                                     currentSpaceId={currentSpaceId}
                                     onSpaceSelect={this.handleSpaceSelected}
                                     onJoinSpace={() => this.setState({ showJoinSpace: true })}
+                                    onCreateSpace={() => this.setState({ showCreateSpace: true })}
                                     canManageSpace={canManageSpace}
                                     // 菜单
                                     menusList={vm.menusList}
@@ -270,6 +283,11 @@ export class MainPage extends Component<{}, MainPageState> {
                         <JoinSpaceModalConnected
                             visible={showJoinSpace}
                             onClose={() => this.setState({ showJoinSpace: false })}
+                            onSuccess={this.handleSpaceSelected}
+                        />
+                        <SpaceCreate
+                            visible={!WKApp.remoteConfig.disableUserCreateSpace && showCreateSpace}
+                            onClose={() => this.setState({ showCreateSpace: false })}
                             onSuccess={this.handleSpaceSelected}
                         />
                     </>

--- a/apps/web/src/__tests__/disableUserCreateSpace.test.ts
+++ b/apps/web/src/__tests__/disableUserCreateSpace.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseRemoteBool } from "../../../../packages/dmworkbase/src/Utils/remoteConfig";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+describe("disable_user_create_space web integration", () => {
+  it.each([
+    [0, false],
+    ["0", false],
+    [undefined, false],
+    [1, true],
+    ["1", true],
+    [true, true],
+    ["true", true],
+    ["false", false],
+  ])("parses appconfig value %s as disabled=%s", (value, expected) => {
+    expect(parseRemoteBool(value)).toBe(expected);
+  });
+
+  it("reads disable_user_create_space from appconfig and refreshes on foreground", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+
+    expect(source).toContain("disableUserCreateSpace: boolean = false");
+    expect(source).toContain('result["disable_user_create_space"]');
+    expect(source).toContain("parseRemoteBool");
+    expect(source).toContain("addConfigChangeListener");
+    expect(source).toContain('document.addEventListener("visibilitychange"');
+    expect(source).toContain('window.addEventListener("focus"');
+  });
+
+  it("hides the SpaceList create-space action behind remote config", () => {
+    const source = readRepoFile(
+      "packages/dmworkbase/src/Components/SpaceList/index.tsx"
+    );
+
+    expect(source).toContain("WKApp.remoteConfig.disableUserCreateSpace");
+    expect(source).toContain("addConfigChangeListener");
+    expect(source).toMatch(/\{canCreateSpace\s*&&\s*\(/);
+    expect(source).toContain('variant="create"');
+  });
+
+  it("hides the no-space create-team button and modal behind remote config", () => {
+    const source = readRepoFile("apps/web/src/Components/SpaceGate/index.tsx");
+
+    expect(source).toContain("WKApp.remoteConfig.disableUserCreateSpace");
+    expect(source).toContain("addConfigChangeListener");
+    expect(source).toMatch(/\{canCreateSpace\s*&&\s*\(/);
+    expect(source).toMatch(/visible=\{canCreateSpace\s*&&\s*showCreate\}/);
+  });
+
+  it("shows create-space in the no-space join page only when enabled", () => {
+    const source = readRepoFile("apps/web/src/Components/JoinSpacePage/index.tsx");
+
+    expect(source).toContain("SpaceCreate");
+    expect(source).toContain("WKApp.remoteConfig.disableUserCreateSpace");
+    expect(source).toContain("addConfigChangeListener");
+    expect(source).toMatch(/\{canCreateSpace\s*&&\s*\(/);
+    expect(source).toMatch(/visible=\{canCreateSpace\s*&&\s*showCreate\}/);
+  });
+
+  it("shows create-space in the nav space switcher only when enabled", () => {
+    const switcherSource = readRepoFile(
+      "packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx"
+    );
+    const mainSource = readRepoFile("apps/web/src/Pages/Main/index.tsx");
+
+    expect(switcherSource).toContain("WKApp.remoteConfig.disableUserCreateSpace");
+    expect(switcherSource).toContain("addConfigChangeListener");
+    expect(switcherSource).toContain("onCreateSpace");
+    expect(switcherSource).toContain("IconCreateSpace");
+    expect(mainSource).toContain("showCreateSpace");
+    expect(mainSource).toContain("<SpaceCreate");
+  });
+
+  it("guards the chat create-space modal against stale triggers", () => {
+    const source = readRepoFile("packages/dmworkbase/src/Pages/Chat/index.tsx");
+
+    expect(source).toContain("WKApp.remoteConfig.disableUserCreateSpace");
+    expect(source).toContain("addConfigChangeListener");
+    expect(source).toMatch(
+      /!\s*WKApp\.remoteConfig\.disableUserCreateSpace\s*&&\s*\(/
+    );
+    expect(source).toContain("<SpaceCreate");
+  });
+});

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -142,6 +142,7 @@ import {
   parseOidcProviders,
   type OidcProviderConfig,
 } from "./Service/OidcConfig";
+import { parseRemoteBool } from "./Utils/remoteConfig";
 export {
   sanitizeHttpUrl,
   parseOidcProviders,
@@ -151,6 +152,7 @@ export type { OidcProviderConfig } from "./Service/OidcConfig";
 export class WKRemoteConfig {
   revokeSecond: number = 2 * 60; // 撤回时间
   threadOn: boolean = false; // 子区功能开关，默认关闭
+  disableUserCreateSpace: boolean = false; // 是否关闭普通用户创建 Space 入口
   /**
    * OIDC provider 元数据数组, 由后端 /v1/common/appconfig 的 oidc_providers 字段下发。
    * OIDC 关闭时为空数组。前端不再硬编码具体 IdP, 部署 env 切 provider。
@@ -164,6 +166,7 @@ export class WKRemoteConfig {
   // 而其内容(SSO 按钮文案/可见性)依赖 appconfig 字段的组件去 re-render。
   // 不在每次失败重试上 fire, 避免重复刷新。
   private listeners: Array<() => void> = [];
+  private configChangeListeners: Array<() => void> = [];
 
   /**
    * addListener 订阅 appconfig **首次** 加载完成事件——只 fire 一次 (后续重连/手动 refetch 不再触发)。
@@ -204,6 +207,25 @@ export class WKRemoteConfig {
     }
   }
 
+  addConfigChangeListener(cb: () => void): () => void {
+    this.configChangeListeners.push(cb);
+    return () => {
+      const i = this.configChangeListeners.indexOf(cb);
+      if (i >= 0) this.configChangeListeners.splice(i, 1);
+    };
+  }
+
+  private notifyConfigChangeListeners() {
+    const snapshot = [...this.configChangeListeners];
+    for (const cb of snapshot) {
+      try {
+        cb();
+      } catch (e) {
+        console.error("[WKRemoteConfig] config change listener threw", e);
+      }
+    }
+  }
+
   async startRequestConfig() {
     // 吃掉 requestConfig 的 reject: 否则 await 直接抛出, 后面的 retry 分支根本到不了——
     // 网络错误下指数退避就成了死代码。requestSuccess 在出错时保持 false, retry 分支负责重排。
@@ -226,12 +248,19 @@ export class WKRemoteConfig {
   requestConfig() {
     return WKApp.apiClient.get("common/appconfig").then((result) => {
       const wasSuccessful = this.requestSuccess;
+      const previousDisableUserCreateSpace = this.disableUserCreateSpace;
       this.requestSuccess = true;
       this.revokeSecond = result["revoke_second"];
       this.threadOn = !!result["thread_on"];
+      this.disableUserCreateSpace = parseRemoteBool(
+        result["disable_user_create_space"]
+      );
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();
+      if (previousDisableUserCreateSpace !== this.disableUserCreateSpace) {
+        this.notifyConfigChangeListeners();
+      }
     });
   }
 }
@@ -564,6 +593,8 @@ export default class WKApp extends ProviderListener {
   spaceChecked: boolean = false; // Space 检查是否完成
   deviceName: string = ""; // 设备名称
   deviceModel: string = ""; // 设备型号
+  private remoteConfigForegroundRefreshStarted: boolean = false;
+  private lastRemoteConfigForegroundRefreshAt: number = 0;
 
   set notificationIsClose(v: boolean) {
     this._notificationIsClose = v;
@@ -641,6 +672,35 @@ export default class WKApp extends ProviderListener {
     }
 
     WKApp.remoteConfig.startRequestConfig();
+    this.setupRemoteConfigForegroundRefresh();
+  }
+
+  private setupRemoteConfigForegroundRefresh() {
+    if (
+      this.remoteConfigForegroundRefreshStarted ||
+      typeof window === "undefined" ||
+      typeof document === "undefined"
+    ) {
+      return;
+    }
+    this.remoteConfigForegroundRefreshStarted = true;
+
+    const refresh = () => {
+      this.refreshRemoteConfigOnForeground();
+    };
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) refresh();
+    });
+    window.addEventListener("focus", refresh);
+  }
+
+  private refreshRemoteConfigOnForeground() {
+    const now = Date.now();
+    if (now - this.lastRemoteConfigForegroundRefreshAt < 5000) return;
+    this.lastRemoteConfigForegroundRefreshAt = now;
+    WKApp.remoteConfig.requestConfig().catch((e) => {
+      console.warn("[WKRemoteConfig] foreground refresh failed", e);
+    });
   }
 
   getDeviceIdFromStorage() {

--- a/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
@@ -16,6 +16,7 @@ export interface NavBottomProps {
     currentSpaceId?: string;
     onSpaceSelect: (spaceId: string) => void;
     onJoinSpace?: () => void;
+    onCreateSpace?: () => void;
 }
 
 interface NavBottomState {
@@ -43,7 +44,7 @@ export default class NavBottom extends Component<NavBottomProps, NavBottomState>
     }
 
     render() {
-        const { onSettingsClick, hasNewVersion, onDismissNewVersion, spaces, currentSpaceId, onSpaceSelect, onJoinSpace } = this.props;
+        const { onSettingsClick, hasNewVersion, onDismissNewVersion, spaces, currentSpaceId, onSpaceSelect, onJoinSpace, onCreateSpace } = this.props;
         const { bubbleVisible } = this.state;
 
         return (
@@ -107,6 +108,7 @@ export default class NavBottom extends Component<NavBottomProps, NavBottomState>
                     currentSpaceId={currentSpaceId}
                     onSpaceSelect={onSpaceSelect}
                     onJoinSpace={onJoinSpace}
+                    onCreateSpace={onCreateSpace}
                 />
             </div>
         );

--- a/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
@@ -3,6 +3,7 @@ import { Space } from "wukongimjssdk";
 import SpaceItem from "../SpaceItem";
 import ActionListItem from "../ActionListItem";
 import { I18nContext } from "../../i18n";
+import WKApp from "../../App";
 
 function IconBuilding() {
     return (
@@ -12,13 +13,14 @@ function IconBuilding() {
     );
 }
 
-import { IconJoinSpace, IconChevronRight } from "./icons";
+import { IconCreateSpace, IconJoinSpace, IconChevronRight } from "./icons";
 
 export interface NavSpaceSwitcherProps {
     spaces: Space[];
     currentSpaceId?: string;
     onSpaceSelect: (spaceId: string) => void;
     onJoinSpace?: () => void;
+    onCreateSpace?: () => void;
 }
 
 interface NavSpaceSwitcherState {
@@ -31,6 +33,7 @@ interface NavSpaceSwitcherState {
 export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, NavSpaceSwitcherState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
+    private unsubscribeRemoteConfig?: () => void;
 
     constructor(props: NavSpaceSwitcherProps) {
         super(props);
@@ -39,10 +42,14 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
 
     componentDidMount() {
         document.addEventListener("keydown", this.handleKeyDown);
+        this.unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
+            this.forceUpdate();
+        });
     }
 
     componentWillUnmount() {
         document.removeEventListener("keydown", this.handleKeyDown);
+        this.unsubscribeRemoteConfig?.();
     }
 
     private handleKeyDown = (e: KeyboardEvent) => {
@@ -60,10 +67,11 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
     };
 
     render() {
-        const { spaces, currentSpaceId, onSpaceSelect, onJoinSpace } = this.props;
+        const { spaces, currentSpaceId, onSpaceSelect, onJoinSpace, onCreateSpace } = this.props;
         const { open } = this.state;
         const { t } = this.context;
         const current = spaces.find(s => s.space_id === currentSpaceId);
+        const canCreateSpace = !!onCreateSpace && !WKApp.remoteConfig.disableUserCreateSpace;
 
         return (
             <div className="wk-navrail__switcher">
@@ -111,17 +119,28 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
                                 ))}
                             </div>
                             {/* 固定底部操作区 */}
-                            {onJoinSpace && (
+                            {(onJoinSpace || canCreateSpace) && (
                                 <>
                                     <div className="wk-navrail__dropdown-divider" />
                                     <div className="wk-navrail__dropdown-actions">
-                                        <ActionListItem
-                                            icon={<IconJoinSpace />}
-                                            label={t("base.navRail.spaceSwitcher.joinNewSpace")}
-                                            compact
-                                            trailing={<IconChevronRight />}
-                                            onClick={() => { this.handleClose(); onJoinSpace(); }}
-                                        />
+                                        {onJoinSpace && (
+                                            <ActionListItem
+                                                icon={<IconJoinSpace />}
+                                                label={t("base.navRail.spaceSwitcher.joinNewSpace")}
+                                                compact
+                                                trailing={<IconChevronRight />}
+                                                onClick={() => { this.handleClose(); onJoinSpace(); }}
+                                            />
+                                        )}
+                                        {canCreateSpace && (
+                                            <ActionListItem
+                                                icon={<IconCreateSpace />}
+                                                label={t("base.spaceList.createSpace")}
+                                                compact
+                                                trailing={<IconChevronRight />}
+                                                onClick={() => { this.handleClose(); onCreateSpace?.(); }}
+                                            />
+                                        )}
                                     </div>
                                 </>
                             )}

--- a/packages/dmworkbase/src/Components/NavRail/icons.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/icons.tsx
@@ -12,6 +12,17 @@ export function IconJoinSpace() {
     );
 }
 
+/** 创建 Space — plus icon */
+export function IconCreateSpace() {
+    return (
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none"
+            stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+    );
+}
+
 /** Figma: filled/arrow/chevron_right 16x16 */
 export function IconChevronRight() {
     return (
@@ -21,4 +32,3 @@ export function IconChevronRight() {
         </svg>
     );
 }
-

--- a/packages/dmworkbase/src/Components/NavRail/index.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/index.tsx
@@ -38,6 +38,7 @@ export interface NavRailVMProps {
     currentSpaceId?: string;
     onSpaceSelect: (spaceId: string) => void;
     onJoinSpace?: () => void;
+    onCreateSpace?: () => void;
     /** 是否在设置菜单中显示「空间管理」入口（仅 owner/admin 可见） */
     canManageSpace?: boolean;
     /** 用户关闭版本更新气泡时的回调 */
@@ -72,6 +73,7 @@ export default class NavRail extends Component<NavRailProps> {
             currentSpaceId,
             onSpaceSelect,
             onJoinSpace,
+            onCreateSpace,
             canManageSpace = false,
         } = this.props;
 
@@ -121,6 +123,7 @@ export default class NavRail extends Component<NavRailProps> {
                         currentSpaceId={currentSpaceId}
                         onSpaceSelect={onSpaceSelect}
                         onJoinSpace={onJoinSpace}
+                        onCreateSpace={onCreateSpace}
                     />
                 </nav>
 

--- a/packages/dmworkbase/src/Components/SpaceList/index.tsx
+++ b/packages/dmworkbase/src/Components/SpaceList/index.tsx
@@ -3,6 +3,7 @@ import { IconPlus, IconSearch, IconLink } from "@douyinfe/semi-icons";
 import { Spin, Toast, Tooltip } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
 import { Space, SpaceService } from "../../Service/SpaceService";
+import WKApp from "../../App";
 import SpaceItem from "../SpaceItem";
 import ActionListItem from "../ActionListItem";
 import JoinSpaceModalConnected from "../JoinSpaceModal/JoinSpaceModalConnected";
@@ -31,6 +32,7 @@ interface SpaceListState {
 export default class SpaceList extends Component<SpaceListProps, SpaceListState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
+    private unsubscribeRemoteConfig?: () => void;
 
     constructor(props: SpaceListProps) {
         super(props);
@@ -47,6 +49,13 @@ export default class SpaceList extends Component<SpaceListProps, SpaceListState>
 
     componentDidMount() {
         this.loadSpaces();
+        this.unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
+            this.forceUpdate();
+        });
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeRemoteConfig?.();
     }
 
     loadSpaces = async (): Promise<Space[]> => {
@@ -102,6 +111,7 @@ export default class SpaceList extends Component<SpaceListProps, SpaceListState>
         const selectedSpace = spaces.find(s => s.space_id === selectedSpaceId);
         const headerLabel = selectedSpace ? selectedSpace.name : "Space";
         const handleJoinEntry = onJoinClick ?? (() => this.setState({ showJoinModal: true }));
+        const canCreateSpace = !WKApp.remoteConfig.disableUserCreateSpace;
         const { t } = this.context;
 
         return (
@@ -190,13 +200,15 @@ export default class SpaceList extends Component<SpaceListProps, SpaceListState>
                         variant="join"
                         onClick={handleJoinEntry}
                     />
-                    <ActionListItem
-                        icon={<IconPlus />}
-                        label={t("base.spaceList.createSpace")}
-                        desc={t("base.spaceList.createSpaceDesc")}
-                        variant="create"
-                        onClick={onCreateClick}
-                    />
+                    {canCreateSpace && (
+                        <ActionListItem
+                            icon={<IconPlus />}
+                            label={t("base.spaceList.createSpace")}
+                            desc={t("base.spaceList.createSpaceDesc")}
+                            variant="create"
+                            onClick={onCreateClick}
+                        />
+                    )}
                 </div>
             </div>
         );

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1049,6 +1049,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
 
   private _onSpaceChanged?: (space: any) => void;
   private _onSwitchTab?: (tab: string) => void;
+  private _unsubscribeRemoteConfig?: () => void;
 
   componentDidMount() {
     // 监听 space-changed，同步 spacename 到 state
@@ -1072,6 +1073,14 @@ export default class ChatPage extends Component<any, ChatPageState> {
     };
     WKApp.mittBus.on("wk:switch-sidebar-tab", this._onSwitchTab);
 
+    this._unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
+      if (WKApp.remoteConfig.disableUserCreateSpace && this.vm?.showSpaceCreate) {
+        this.vm.showSpaceCreate = false;
+      } else {
+        this.forceUpdate();
+      }
+    });
+
     // 初始化：主动拉当前 Space 名称（首次渲染时 space-changed 还没触发）
     const currentSpaceId = WKApp.shared.currentSpaceId;
     if (currentSpaceId) {
@@ -1094,6 +1103,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
     if (this._onSwitchTab) {
       WKApp.mittBus.off("wk:switch-sidebar-tab", this._onSwitchTab);
     }
+    this._unsubscribeRemoteConfig?.();
   }
 
   render(): ReactNode {
@@ -1355,15 +1365,17 @@ export default class ChatPage extends Component<any, ChatPageState> {
                   </FollowSidebarProvider>
                 </div>
               </div>
-              <SpaceCreate
-                visible={vm.showSpaceCreate}
-                onClose={() => {
-                  vm.showSpaceCreate = false;
-                }}
-                onSuccess={() => {
-                  this.spaceListRef?.loadSpaces();
-                }}
-              />
+              {!WKApp.remoteConfig.disableUserCreateSpace && (
+                <SpaceCreate
+                  visible={vm.showSpaceCreate}
+                  onClose={() => {
+                    vm.showSpaceCreate = false;
+                  }}
+                  onSuccess={() => {
+                    this.spaceListRef?.loadSpaces();
+                  }}
+                />
+              )}
               <WKModal
                 size="full"
                 visible={vm.showGlobalSearch}

--- a/packages/dmworkbase/src/Utils/remoteConfig.ts
+++ b/packages/dmworkbase/src/Utils/remoteConfig.ts
@@ -1,0 +1,8 @@
+export function parseRemoteBool(value: unknown): boolean {
+  if (value === true || value === 1) return true;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "1" || normalized === "true";
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- Read `disable_user_create_space` from `GET /v1/common/appconfig` and treat `0` / missing as enabled, `1` as disabled.
- Hide user-facing create-space entries across no-space onboarding, SpaceList, NavRail space switcher, and Chat modal triggers.
- Refresh appconfig on foreground/focus and re-render subscribed UI when the setting changes.

## Tests

- `pnpm --filter @octo/web exec vitest run src/__tests__/disableUserCreateSpace.test.ts`
- `pnpm --filter @octo/web build`
