### PR TITLE
fix(ai-chat): preview files in folded sessions instead of downloading

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -68,10 +68,10 @@ import {
   formatFileSize,
   getFileIconInfo,
   getExtension,
+  resolveSafeFileUrl,
 } from "../../Messages/File";
 import { ImageContent } from "../../Messages/Image";
 import { downloadFile } from "../../Utils/download";
-import { isSafeUrl } from "../../Utils/security";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
@@ -1203,20 +1203,12 @@ export class Conversation
     if (message.contentType === MessageContentTypeConst.file) {
       const content = message.content as FileContent;
       const iconInfo = getFileIconInfo(content.extension, content.name);
-      const resolveFileUrl = () => {
-        const rawUrl = content.url || content.remoteUrl || "";
-        if (!rawUrl) return "";
-        const fileUrl =
-          WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
-        if (!fileUrl || !isSafeUrl(fileUrl)) return "";
-        return fileUrl;
-      };
       return (
         <div
           className="wk-fold-file"
           title={t("base.messageFile.preview")}
           onClick={() => {
-            const fileUrl = resolveFileUrl();
+            const fileUrl = resolveSafeFileUrl(content);
             if (!fileUrl) return;
             WKApp.mittBus.emit("wk:file-preview", {
               url: fileUrl,
@@ -1251,7 +1243,7 @@ export class Conversation
             title={t("base.conversation.file.download")}
             onClick={async (e) => {
               e.stopPropagation();
-              const fileUrl = resolveFileUrl();
+              const fileUrl = resolveSafeFileUrl(content);
               if (!fileUrl) return;
               await downloadFile(fileUrl, content.name || "file");
             }}

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -67,9 +67,11 @@ import {
   FileContent,
   formatFileSize,
   getFileIconInfo,
+  getExtension,
 } from "../../Messages/File";
 import { ImageContent } from "../../Messages/Image";
 import { downloadFile } from "../../Utils/download";
+import { isSafeUrl } from "../../Utils/security";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
@@ -1201,16 +1203,33 @@ export class Conversation
     if (message.contentType === MessageContentTypeConst.file) {
       const content = message.content as FileContent;
       const iconInfo = getFileIconInfo(content.extension, content.name);
+      const resolveFileUrl = () => {
+        const rawUrl = content.url || content.remoteUrl || "";
+        if (!rawUrl) return "";
+        const fileUrl =
+          WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
+        if (!fileUrl || !isSafeUrl(fileUrl)) return "";
+        return fileUrl;
+      };
       return (
         <div
           className="wk-fold-file"
-          onClick={async () => {
-            const rawUrl = content.url || content.remoteUrl || "";
-            if (!rawUrl) return;
-            const fileUrl =
-              WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
+          title={t("base.messageFile.preview")}
+          onClick={() => {
+            const fileUrl = resolveFileUrl();
             if (!fileUrl) return;
-            await downloadFile(fileUrl, content.name || "file");
+            WKApp.mittBus.emit("wk:file-preview", {
+              url: fileUrl,
+              name: content.name || t("base.messageFile.unknownFile"),
+              extension: getExtension(content.extension, content.name),
+              size: content.size,
+              sourceChannelId: message.channel.channelID,
+              sourceChannelType: message.channel.channelType,
+              messageId: message.messageID,
+              messageSeq: message.messageSeq,
+              fromUID: message.fromUID,
+              conversationDigest: content.conversationDigest,
+            });
           }}
         >
           <div
@@ -1227,7 +1246,16 @@ export class Conversation
               {formatFileSize(content.size)}
             </div>
           </div>
-          <div className="wk-fold-file-dl" title={t("base.conversation.file.download")}>
+          <div
+            className="wk-fold-file-dl"
+            title={t("base.conversation.file.download")}
+            onClick={async (e) => {
+              e.stopPropagation();
+              const fileUrl = resolveFileUrl();
+              if (!fileUrl) return;
+              await downloadFile(fileUrl, content.name || "file");
+            }}
+          >
             <svg
               viewBox="0 0 24 24"
               width="14"

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -296,6 +296,20 @@ export function getExtension(extension: string, name?: string): string {
   return "";
 }
 
+// 解析 FileContent 的可用下载 URL: 拼接 baseURL + 相对路径绝对化 + 安全校验。
+// 任一环节失败返回 ""，方便调用方一次性判断。生产环境 apiURL 是 /api/v1/，
+// 直接喂给 isSafeUrl 会被 new URL() 拒掉，必须先绝对化。
+export function resolveSafeFileUrl(content: FileContent): string {
+  const rawUrl = content.url || content.remoteUrl || "";
+  if (!rawUrl) return "";
+  let fileUrl = WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
+  if (!fileUrl) return "";
+  if (!fileUrl.startsWith("http")) {
+    fileUrl = window.location.origin + "/" + fileUrl.replace(/^\//, "");
+  }
+  return isSafeUrl(fileUrl) ? fileUrl : "";
+}
+
 function isPreviewable(extension: string, name?: string): boolean {
   const ext = getExtension(extension, name);
   return [

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -275,7 +275,7 @@ function FileTypeIcon({
   );
 }
 
-function getExtension(extension: string, name?: string): string {
+export function getExtension(extension: string, name?: string): string {
   // 优先从文件名后缀提取: 服务端返回的 extension 字段不可靠 (可能为空、
   // 或是 "file" 等占位值, 见 issue #143), 用文件名后缀更稳妥。
   //


### PR DESCRIPTION
标题

fix(ai-chat): preview files in folded AI sessions instead of downloading

Summary

AI 助手折叠会话里点击文件附件之前会直接下载，没有预览
卡片整体 click 改为发出 wk:file-preview mittBus 事件，复用 FilePreviewPanel，行为与普通文件消息一致
右侧下载小图标单独绑 click + stopPropagation，保留显式下载入口
URL 经 isSafeUrl 校验后再发预览/下载

Test plan

 AI 助手协作折叠后展开，里面包含文件消息
 点击文件卡片主体 → 打开 FilePreviewPanel，支持的格式正常渲染，不支持的格式给出提示
 点击右侧下载小图标 → 仅触发下载，不打开预览面板
 预览面板内下载/打开新窗口/关闭按钮正常
 非折叠区的普通文件消息预览/下载无回归