### PR TITLE
fix(conversation): show last message of fold session when expanded

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionSummary.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionSummary.test.ts
@@ -71,25 +71,18 @@ describe("getFoldSessionSummaryState", () => {
 })
 
 describe("getFoldSessionExpandedMessages", () => {
-    it("excludes the last real message when there is no typing summary", () => {
+    it("includes all real messages so the expanded list matches the fold count", () => {
         const messages = [
             makeMessage("msg-1", "claude", 1),
             makeMessage("msg-2", "jojo", 2),
             makeMessage("msg-3", "claude", 3),
         ]
 
-        expect(getFoldSessionExpandedMessages({ messages })).toEqual(messages.slice(0, 2))
+        expect(getFoldSessionExpandedMessages({ messages })).toEqual(messages)
     })
 
-    it("keeps all real messages in the expanded list when typing occupies the summary slot", () => {
-        const messages = [
-            makeMessage("msg-1", "claude", 1),
-            makeMessage("msg-2", "jojo", 2),
-            makeMessage("msg-3", "claude", 3),
-        ]
-        const typingMessage = makeMessage("typing-claude", "claude", 0)
-
-        expect(getFoldSessionExpandedMessages({ messages, typing: typingMessage })).toEqual(messages)
+    it("returns an empty list when there are no messages", () => {
+        expect(getFoldSessionExpandedMessages({ messages: [] })).toEqual([])
     })
 })
 

--- a/packages/dmworkbase/src/Components/Conversation/foldSessionSummary.ts
+++ b/packages/dmworkbase/src/Components/Conversation/foldSessionSummary.ts
@@ -9,7 +9,6 @@ export interface FoldSessionSummarySource {
 
 export interface FoldSessionExpandedMessagesSource {
     messages: MessageWrap[]
-    typing?: MessageWrap
 }
 
 export interface FoldSessionSummaryState {
@@ -30,13 +29,9 @@ export function getFoldSessionSummaryState(session: FoldSessionSummarySource): F
 }
 
 export function getFoldSessionExpandedMessages(session: FoldSessionExpandedMessagesSource): MessageWrap[] {
-    if (session.messages.length === 0) {
-        return []
-    }
-    if (session.typing) {
-        return [...session.messages]
-    }
-    return session.messages.slice(0, -1)
+    // 展开时 CSS 会隐藏 summary（FoldSessionCard/index.css 中 .expanded-show ~ .summary-show {display:none}），
+    // 所以最后一条必须留在 expanded 列表里，否则会从 UI 上消失。
+    return [...session.messages]
 }
 
 export function isFoldSessionSummaryMessage(session: FoldSessionSummarySource, messageSeq: number): boolean {

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -422,7 +422,6 @@ export default class ConversationVM extends ProviderListener {
                 lastItem.session.typing = typingMessage
                 lastItem.session.expandedMessages = getFoldSessionExpandedMessages({
                     messages: lastItem.session.messages,
-                    typing: typingMessage,
                 })
             } else {
                 renderItems.push({ type: "message", message: typingMessage })


### PR DESCRIPTION
标题：


fix(conversation): show last message of fold session when expanded
正文：


## Summary
- AI 折叠会话展开后，最后一条消息会从列表里消失（最容易被注意到的是"文件"最后一条 —— 折叠态显示 `[文件]`，展开后文件卡片不见）
- 根因：`getFoldSessionExpandedMessages` 故意 `slice(0, -1)` 排除最后一条（假设由 summary 显示），但 #941 重构时新增了 CSS 规则展开时隐藏 summary，两端没对齐导致最后一条被双重隐藏
- 修复：让 `getFoldSessionExpandedMessages` 始终返回全部消息，CSS 隐藏 summary 的逻辑保留；加注释防止后人再次"优化"成 slice

## 影响范围
不只是文件 —— 任何类型的"最后一条"消息（文件/图片/文本）在展开后都会消失，只是文件/图片最直观。

## Test plan
- 单测：`foldSessionSummary` 8 用例通过，Conversation 模块 40 用例全过
- 本地复现群聊 AI 折叠场景：折叠态预览 `[文件]` → 展开后文件卡片正确显示
- 切换折叠/展开多次，无重复或丢失
- typing（AI 协作中）场景下折叠卡片行为保持不变