### PR TITLE
ci: Phase 1 test quality — add reusable Node quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,15 @@ jobs:
         run: pnpm build
       - name: Lint
         run: pnpm lint
+
+  quality:
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
+    name: Quality
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-node-quality.yml@main
+    with:
+      package-manager: pnpm
+      node-version: '20'
+      has-tests: false


### PR DESCRIPTION
## Summary

Phase 1 test quality CI upgrade for octo-web.

### Changes

- **New `quality` job**: Calls `Mininglamp-OSS/.github/.github/workflows/reusable-node-quality.yml@main`
  - `typecheck`: `tsc --noEmit`
  - `lint`: `pnpm lint`
  - `build`: `pnpm build`
  - `has-tests: false` — no Vitest tests yet (Phase 2+)

### What's NOT changed
- Existing `build` job preserved (build + lint + i18n:check)
- `changes` preflight job unchanged
- Trigger conditions unchanged

### Dependencies
- Requires `Mininglamp-OSS/.github` PR #55 to be merged first (reusable workflow)

### Checklist
- [x] Reusable node quality workflow integration
- [x] has-tests set to false (Phase 2+)
- [x] Existing jobs preserved
- [x] YAML validated