### PR TITLE
fix(typing): reset typing on foreground/reconnect + refresh conversation on reconnect

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -101,6 +101,7 @@ import { ConnectStatus } from "wukongimjssdk";
 import { WKBaseContext } from "./Components/WKBase";
 import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
+import { TypingManager } from "./Service/TypingManager";
 
 export enum ThemeMode {
   light,
@@ -673,6 +674,12 @@ export default class WKApp extends ProviderListener {
         } else if (reasonCode === 2) {
           // 认证失败！
           WKApp.shared.logout();
+        } else if (status === ConnectStatus.Connected) {
+          // 第二层防御：重连成功后清除所有残留 typing。
+          // SDK 重连只 reSubscribe，不补拉离线消息/CMD，断连期间 bot 回复经
+          // HTTP sync 落库不触发清除路径 → typing 永不清。放全局单例 listener
+          // （生命周期最长），不放 Chat/vm.ts（随页面卸载注销）。
+          TypingManager.shared.resetAll();
         } else if (status === ConnectStatus.Disconnect) {
           if (this.addrUsed && this.wsaddrs.length > 1) {
             const oldwsAddr = this.wsaddrs[0];
@@ -712,7 +719,11 @@ export default class WKApp extends ProviderListener {
       this.refreshRemoteConfigOnForeground();
     };
     document.addEventListener("visibilitychange", () => {
-      if (!document.hidden) refresh();
+      if (!document.hidden) {
+        refresh();
+        // 第一层防御：回前台清除所有残留 typing，对齐 iOS appDidBecomeActive。
+        TypingManager.shared.resetAll();
+      }
     });
     window.addEventListener("focus", refresh);
   }

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1,4 +1,4 @@
-import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK, Message, MessageContent, MessageStatus, Subscriber, Conversation, MessageExtra, CMDContent, PullMode, MessageContentType, ChannelInfo, ChannelInfoListener, ConversationListener } from "wukongimjssdk";
+import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK, Message, MessageContent, MessageStatus, Subscriber, Conversation, MessageExtra, CMDContent, PullMode, MessageContentType, ChannelInfo, ChannelInfoListener, ConversationListener, ConnectStatus, ConnectStatusListener } from "wukongimjssdk";
 import WKApp from "../../App";
 import { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
 import { MessageWrap } from "../../Service/Model";
@@ -91,6 +91,8 @@ export default class ConversationVM extends ProviderListener {
 
     typingListener!: TypingListener // 输入中监听
     messageListener!: MessageListener // 消息监听
+    connectStatusListener!: ConnectStatusListener // 连接状态监听（重连补刷当前会话）
+    private lastReconnectRefreshAt: number = 0 // 重连补刷去抖时间戳
     cmdListener!: MessageListener // cmd消息监听
     messageStatusListener!: MessageStatusListener // 消息状态监听
     conversationListener!: ConversationListener // 会话监听
@@ -855,6 +857,24 @@ export default class ConversationVM extends ProviderListener {
         }
         TypingManager.shared.addTypingListener(this.typingListener)
 
+        // 重连补刷：SDK 重连不补拉离线消息，断连期间当前会话窗口不刷新。
+        // Connected 时补刷首屏。5s 去抖（参考 App.tsx remoteConfig foreground
+        // refresh pattern），避免频繁断连重连重复拉首屏。
+        // ⚠️ 必须在 didUnMount 成对 removeConnectStatusListener，否则页面切换
+        // 累积 listener → 内存泄漏 + 重连时多实例并发拉首屏。
+        this.connectStatusListener = (status: ConnectStatus) => {
+            if (status !== ConnectStatus.Connected) {
+                return
+            }
+            const now = Date.now()
+            if (now - this.lastReconnectRefreshAt < 5000) {
+                return
+            }
+            this.lastReconnectRefreshAt = now
+            this.requestMessagesOfFirstPage(0)
+        }
+        WKSDK.shared().connectManager.addConnectStatusListener(this.connectStatusListener)
+
         const conversation = WKSDK.shared().conversationManager.findConversation(this.channel)
         if (conversation) {
             const unread = conversation.unread
@@ -906,6 +926,7 @@ export default class ConversationVM extends ProviderListener {
         WKSDK.shared().chatManager.removeCMDListener(this.cmdListener)
 
         TypingManager.shared.removeTypingListener(this.typingListener)
+        WKSDK.shared().connectManager.removeConnectStatusListener(this.connectStatusListener)
         WKSDK.shared().conversationManager.removeConversationListener(this.conversationListener)
         WKSDK.shared().channelManager.removeSubscriberChangeListener(this.subscriberChangeListener)
         WKSDK.shared().channelManager.removeListener(this.channelInfoListener)

--- a/packages/dmworkbase/src/Service/TypingManager.tsx
+++ b/packages/dmworkbase/src/Service/TypingManager.tsx
@@ -4,28 +4,34 @@ import { TypingContent } from "../Messages/Typing";
 
 export type TypingListener = (channel: Channel, add: boolean) => void
 
+interface TypingEntry {
+    typing: Typing
+    channel: Channel
+}
+
 export class TypingManager {
-    private typingMap: Map<string, Typing> = new Map()
+    // value 存 { typing, channel }，以便 resetAll 能反查 Channel 广播 notify
+    private typingMap: Map<string, TypingEntry> = new Map()
     private typingListeners: TypingListener[] = new Array<TypingListener>();
 
     private constructor() {
     }
     public static shared = new TypingManager()
 
-  
+
 
     addTyping(channel: Channel, fromUID: string, fromName: string) {
         if(fromUID === WKApp.loginInfo.uid) {
             return
         }
-        const typing = this.typingMap.get(channel.getChannelKey())
-        if (typing) {
-            typing.restart()
+        const entry = this.typingMap.get(channel.getChannelKey())
+        if (entry) {
+            entry.typing.restart()
         } else {
             const newTyping = new Typing(fromUID, fromName, () => {
                 this.removeTyping(channel)
             })
-            this.typingMap.set(channel.getChannelKey(), newTyping)
+            this.typingMap.set(channel.getChannelKey(), { typing: newTyping, channel })
             newTyping.start()
 
             this.notifyTypingListener(channel, true)
@@ -33,10 +39,11 @@ export class TypingManager {
     }
     // 获取输入中的消息（仿造）
     getFakeTypingMessage(channel: Channel) {
-        const typing = this.typingMap.get(channel.getChannelKey())
-        if (!typing) {
+        const entry = this.typingMap.get(channel.getChannelKey())
+        if (!entry) {
             return
         }
+        const { typing } = entry
         const message = new Message()
         message.channel = channel
         message.timestamp = new Date().getTime() / 1000
@@ -49,15 +56,33 @@ export class TypingManager {
         return this.typingMap.has(channel.getChannelKey())
     }
     getTyping(channel: Channel): Typing | undefined {
-        return this.typingMap.get(channel.getChannelKey())
+        return this.typingMap.get(channel.getChannelKey())?.typing
     }
     removeTyping(channel: Channel) {
-        const typing = this.typingMap.get(channel.getChannelKey())
-        if (typing) {
-            typing.stop()
+        const entry = this.typingMap.get(channel.getChannelKey())
+        if (entry) {
+            entry.typing.stop()
         }
         this.typingMap.delete(channel.getChannelKey())
         this.notifyTypingListener(channel, false)
+    }
+
+    // 清除所有会话的 typing：回前台 / 重连后调用，对齐 iOS appDidBecomeActive
+    // 与 Connected 两层防御。先快照 channel 列表再 clear，避免遍历中修改 map。
+    resetAll() {
+        if (this.typingMap.size === 0) {
+            return
+        }
+        const channels: Channel[] = []
+        this.typingMap.forEach((entry) => {
+            entry.typing.stop()
+            channels.push(entry.channel)
+        })
+        this.typingMap.clear()
+        // 聚合 notify：clear 已完成，逐个通知对应会话清除 typing
+        channels.forEach((channel) => {
+            this.notifyTypingListener(channel, false)
+        })
     }
 
     addTypingListener(listener: TypingListener) {

--- a/packages/dmworkbase/src/Service/__tests__/TypingManager.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/TypingManager.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { Channel } from "wukongimjssdk"
+
+// TypingManager imports `../App` (heavy module) only for WKApp.loginInfo.uid.
+// Mock it so the singleton can be exercised in isolation.
+vi.mock("../../App", () => ({
+    default: { loginInfo: { uid: "me" } },
+}))
+
+// `../../Messages/Typing` transitively pulls in lottie/react-spinners (DOM-heavy,
+// crashes under jsdom). resetAll/addTyping don't need the real TypingContent.
+vi.mock("../../Messages/Typing", () => ({
+    TypingContent: class {
+        constructor(public fromUID: string, public fromName: string) {}
+    },
+}))
+
+import { TypingManager } from "../TypingManager"
+
+const ChannelTypePerson = 1
+
+describe("TypingManager.resetAll", () => {
+    beforeEach(() => {
+        // 清掉上一个用例的残留 typing（singleton 跨用例共享）
+        TypingManager.shared.resetAll()
+        vi.useFakeTimers()
+    })
+
+    it("clears every active typing and notifies each affected channel with add=false", () => {
+        const a = new Channel("alice", ChannelTypePerson)
+        const b = new Channel("bob", ChannelTypePerson)
+
+        const events: Array<{ key: string; add: boolean }> = []
+        const listener = (channel: Channel, add: boolean) => {
+            events.push({ key: channel.getChannelKey(), add })
+        }
+        TypingManager.shared.addTypingListener(listener)
+
+        TypingManager.shared.addTyping(a, "u1", "Alice")
+        TypingManager.shared.addTyping(b, "u2", "Bob")
+        expect(TypingManager.shared.hasTyping(a)).toBe(true)
+        expect(TypingManager.shared.hasTyping(b)).toBe(true)
+
+        // 只保留 add 事件后清空，便于断言 reset 的 remove 通知
+        const addEvents = events.filter((e) => e.add)
+        expect(addEvents.length).toBe(2)
+        events.length = 0
+
+        TypingManager.shared.resetAll()
+
+        expect(TypingManager.shared.hasTyping(a)).toBe(false)
+        expect(TypingManager.shared.hasTyping(b)).toBe(false)
+        const removedKeys = events.filter((e) => !e.add).map((e) => e.key).sort()
+        expect(removedKeys).toEqual([a.getChannelKey(), b.getChannelKey()].sort())
+
+        TypingManager.shared.removeTypingListener(listener)
+    })
+
+    it("is a no-op (no notify) when there is no active typing", () => {
+        const listener = vi.fn()
+        TypingManager.shared.addTypingListener(listener)
+        TypingManager.shared.resetAll()
+        expect(listener).not.toHaveBeenCalled()
+        TypingManager.shared.removeTypingListener(listener)
+    })
+
+    it("stops the 8s timer so a cleared typing does not fire a late removal", () => {
+        const a = new Channel("carol", ChannelTypePerson)
+        const listener = vi.fn()
+        TypingManager.shared.addTypingListener(listener)
+
+        TypingManager.shared.addTyping(a, "u3", "Carol")
+        TypingManager.shared.resetAll()
+        listener.mockClear()
+
+        // resetAll 后推进超过 8s，原 timer 不应再触发任何 notify
+        vi.advanceTimersByTime(10_000)
+        expect(listener).not.toHaveBeenCalled()
+
+        TypingManager.shared.removeTypingListener(listener)
+    })
+})


### PR DESCRIPTION
## 问题

octo-web 群聊 typing indicator 在 tab 切后台或 WebSocket 重连后卡死不消失，且当前打开的会话窗口不刷新断连期间的消息。

**根因**：typing 状态进入路径与清除路径不对称。typing 唯一清除点挂在实时 WS push 的全局 `messageListener` 上，而 App 后台/断连期间 bot 真实回复经 HTTP sync 落库，该路径从不触发 `messageListener` → typing 永不清。SDK 重连只 reSubscribe，不补拉离线消息/CMD，导致当前会话窗口也不刷新。三端同构（iOS octo-ios#10 / Android octo-android#17 已合入对应修复）。

## 修复（两层防御，对齐三端）

- **TypingManager**（`Service/TypingManager.tsx`）：`typingMap` value 改为 `{ typing, channel }`，支持 Channel 反查；新增 `resetAll()`——快照所有 channel、stop timer、clear map，再逐个 `notifyTypingListener(channel, false)` 广播清除（先快照后 clear，避免遍历中改 map）。
- **回前台 reset**（`App.tsx` visibilitychange，第一层）：复用既有 handler，`document.hidden===false` 时除原有 `refresh()` 外追加 `TypingManager.shared.resetAll()`。对应 iOS `appDidBecomeActive`。
- **重连 reset**（`App.tsx` 全局 connectStatusListener，第二层）：新增 `ConnectStatus.Connected` 分支调 `resetAll()`。放全局 App 单例（生命周期最长），不放页面 VM。
- **重连补刷当前会话**（`Components/Conversation/vm.ts`）：`didMount` 注册 connectStatusListener，`Connected` 时 `requestMessagesOfFirstPage(0)` 补刷首屏，5s 去抖（参考 remoteConfig foreground refresh pattern）；**`didUnMount` 成对 `removeConnectStatusListener`**，避免页面切换累积 listener → 内存泄漏 + 重连多实例并发拉首屏。

## 测试

- 新增 `Service/__tests__/TypingManager.test.ts`：覆盖 `resetAll()` 清除并广播每个会话、空 map no-op、stop timer 防止延迟触发（3 用例全过）。
- dmworkbase 既有用例不回归（预存在的 jsdom/canvas/lottie 环境失败与本改动无关，本分支失败数较 base 更少）。
- `tsc` 对改动文件零新增类型错误（既有 16 项错误为 base 预存在的 ambient 类型噪声）。

## 验证点

1. 群聊 bot 回复 → 切后台等回复完成 → 切回前台：typing 立即消失，bot 回复显示在当前会话。
2. 断网重连后：typing 不残留，当前会话补刷断连期间消息。
3. 正常前台聊天 typing 显示/消失不受影响。
4. 反复切换会话页面不泄漏 listener（didUnMount 已成对注销）。

Closes #187
