### PR TITLE
fix: standardize modal spacing

### DIFF
--- a/packages/dmworkbase/package.json
+++ b/packages/dmworkbase/package.json
@@ -7,7 +7,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@douyinfe/semi-icons": "^2.93.0",
-    "@douyinfe/semi-ui": "^2.24.2",
+    "@douyinfe/semi-ui": "^2.93.0",
     "@emotion/react": "^11.14.0",
     "@floating-ui/dom": "^1.7.6",
     "@lottiefiles/lottie-player": "^1.5.5",

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.css
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.css
@@ -1,5 +1,5 @@
-.wk-bot-detail-modal .semi-modal-body {
-    padding: 0 !important;
+.wk-bot-detail-modal .wk-modal-shell {
+    padding: 0;
 }
 .wk-bot-detail-content {
     padding: 24px;

--- a/packages/dmworkbase/src/Components/ClawInfoModal/ClawInfoModal.css
+++ b/packages/dmworkbase/src/Components/ClawInfoModal/ClawInfoModal.css
@@ -1,8 +1,11 @@
 /* ===== ClawInfoModal 龙虾详情弹窗样式 ===== */
 
 /* 弹窗容器 */
-.claw-info-modal .semi-modal-content {
-  padding: 0 !important;
+.claw-info-modal .wk-modal-shell {
+  padding: 0;
+}
+
+.claw-info-modal .wk-modal-content {
   border-radius: 18px;
   overflow: hidden;
 }

--- a/packages/dmworkbase/src/Components/ClawInfoModal/ClawInfoModal.css
+++ b/packages/dmworkbase/src/Components/ClawInfoModal/ClawInfoModal.css
@@ -6,7 +6,7 @@
 }
 
 .claw-info-modal .wk-modal-content {
-  border-radius: 18px;
+  border-radius: var(--wk-r-lg);
   overflow: hidden;
 }
 

--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -891,14 +891,3 @@ body[theme-mode="dark"] .wk-conversationpositionview-item {
     background-color: transparent;
   }
 }
-
-/* 删除确认弹窗 — 清除 Semi body 默认 padding，内容自己控制间距 */
-.wk-delete-confirm-modal .semi-modal-body {
-  padding: 0 !important;
-}
-.wk-delete-confirm-modal .semi-modal-body-wrapper {
-  margin: 0 !important;
-}
-.wk-delete-confirm-modal .semi-modal-content {
-  padding: 0 !important;
-}

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -50,7 +50,7 @@ import WKAvatar from "../WKAvatar";
 import AiBadge from "../AiBadge";
 import { IconClose, IconEdit, IconReply } from "@douyinfe/semi-icons";
 import { Toast, Spin } from "@douyinfe/semi-ui";
-import WKModal from "../WKModal";
+import { wkConfirm } from "../WKModal";
 import { FlameMessageCell } from "../../Messages/Flame";
 import FoldSessionCard, { FoldSessionCardParticipant } from "./FoldSessionCard";
 import { BeatLoader } from "react-spinners";
@@ -282,7 +282,6 @@ const ConversationSelectionStateBridge: React.FC<{
 
 interface ConversationState {
   inputExpanded: boolean;
-  showDeleteConfirm: boolean;
   contextMenuMessageID: string | null;
 }
 
@@ -328,7 +327,6 @@ export class Conversation
     super(props);
     this.state = {
       inputExpanded: false,
-      showDeleteConfirm: false,
       contextMenuMessageID: null as string | null,
     };
     this.onOpenThreadPanel = props.onOpenThreadPanel;
@@ -2026,7 +2024,28 @@ export class Conversation
                         Toast.error(t("base.conversation.selection.selectMessageFirst"));
                         return;
                       }
-                      this.setState({ showDeleteConfirm: true });
+                      wkConfirm({
+                        title: t("base.conversation.deleteConfirm.title"),
+                        content: t("base.conversation.deleteConfirm.content"),
+                        okText: t("base.conversation.deleteConfirm.confirm"),
+                        cancelText: t("base.common.cancel"),
+                        okType: "danger",
+                        onOk: async () => {
+                          const checkedMessagewraps = vm.getCheckedMessages();
+                          const messages = checkedMessagewraps
+                            .map((m) => m.message)
+                            .filter(Boolean);
+                          if (messages.length === 0) return;
+                          try {
+                            await vm.deleteMessages(messages);
+                            vm.editOn = false;
+                            vm.unCheckAllMessages();
+                          } catch (e) {
+                            Toast.error(t("base.conversation.deleteConfirm.failed"));
+                            throw e;
+                          }
+                        },
+                      });
                     }}
                     onAddToMatter={(anchor) => {
                       const checkedMsgs = vm.getCheckedMessages();
@@ -2080,145 +2099,6 @@ export class Conversation
                     }}
                   ></MultiplePanel>
 
-                  <WKModal
-                    visible={!!this.state.showDeleteConfirm}
-                    footer={null}
-                    options={{ closable: false }}
-                    className="wk-delete-confirm-modal"
-                    onCancel={() => this.setState({ showDeleteConfirm: false })}
-                  >
-                    {/* 整体自定义，对齐 Figma 387-63814 */}
-                    <div style={{ padding: "24px 24px 20px" }}>
-                      {/* Header */}
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "space-between",
-                          marginBottom: 12,
-                        }}
-                      >
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 8,
-                          }}
-                        >
-                          <svg
-                            width="22"
-                            height="22"
-                            viewBox="0 0 22 22"
-                            fill="none"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 2L20.66 18H1.34L11 2Z"
-                              fill="#FF8C00"
-                            />
-                            <path
-                              d="M11 9V13"
-                              stroke="white"
-                              strokeWidth="1.6"
-                              strokeLinecap="round"
-                            />
-                            <circle cx="11" cy="15.5" r="0.85" fill="white" />
-                          </svg>
-                          <span
-                            style={{
-                              fontSize: 16,
-                              fontWeight: 600,
-                              color: "#1C1C23",
-                            }}
-                          >
-                            {t("base.conversation.deleteConfirm.title")}
-                          </span>
-                        </div>
-                        <button
-                          onClick={() =>
-                            this.setState({ showDeleteConfirm: false })
-                          }
-                          style={{
-                            background: "none",
-                            border: "none",
-                            cursor: "pointer",
-                            padding: 4,
-                            color: "rgba(28,28,35,0.4)",
-                            fontSize: 18,
-                            lineHeight: 1,
-                          }}
-                        >
-                          ×
-                        </button>
-                      </div>
-                      {/* Content */}
-                      <p
-                        style={{
-                          margin: "0 0 24px",
-                          color: "rgba(28,28,35,0.6)",
-                          fontSize: 14,
-                          lineHeight: "22px",
-                        }}
-                      >
-                        {t("base.conversation.deleteConfirm.content")}
-                      </p>
-                      {/* Footer */}
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "flex-end",
-                          gap: 8,
-                        }}
-                      >
-                        <button
-                          onClick={() =>
-                            this.setState({ showDeleteConfirm: false })
-                          }
-                          style={{
-                            padding: "7px 20px",
-                            borderRadius: 999,
-                            border: "1px solid rgba(28,28,35,0.15)",
-                            background: "#fff",
-                            color: "rgba(28,28,35,0.8)",
-                            fontSize: 14,
-                            cursor: "pointer",
-                            fontWeight: 500,
-                          }}
-                        >
-                          {t("base.common.cancel")}
-                        </button>
-                        <button
-                          onClick={async () => {
-                            const checkedMessagewraps = vm.getCheckedMessages();
-                            const messages = checkedMessagewraps
-                              .map((m) => m.message)
-                              .filter(Boolean);
-                            this.setState({ showDeleteConfirm: false });
-                            if (messages.length === 0) return;
-                            try {
-                              await vm.deleteMessages(messages);
-                              vm.editOn = false;
-                              vm.unCheckAllMessages();
-                            } catch (e) {
-                              Toast.error(t("base.conversation.deleteConfirm.failed"));
-                            }
-                          }}
-                          style={{
-                            padding: "7px 20px",
-                            borderRadius: 999,
-                            border: "none",
-                            background: "#FF4D4F",
-                            color: "#fff",
-                            fontSize: 14,
-                            cursor: "pointer",
-                            fontWeight: 500,
-                          }}
-                        >
-                          {t("base.conversation.deleteConfirm.confirm")}
-                        </button>
-                      </div>
-                    </div>
-                  </WKModal>
                 </div>
                 <div
                   className="wk-conversation-footer"

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -9,7 +9,7 @@ import {
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
 import React, { Component } from "react";
-import { Modal, Tag } from "@douyinfe/semi-ui";
+import { Tag } from "@douyinfe/semi-ui";
 import { ConversationWrap, MessageWrap } from "../../Service/Model";
 import { getTimeStringAutoShort2 } from "../../Utils/time";
 import classNames from "classnames";
@@ -35,6 +35,7 @@ import WKAvatar from "../WKAvatar";
 import AiBadge from "../AiBadge";
 import ConversationVM from "../Conversation/vm";
 import { I18nContext, t, useI18n } from "../../i18n";
+import { wkConfirm } from "../WKModal";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
 // ── CompactGroupItem：群聊 Tab 紧凑 item，支持拖拽 ──────────────────────
@@ -1097,7 +1098,7 @@ export default class ConversationList extends Component<
                 icon: "M18 6 6 18 M6 6l12 12",
                 onClick: () => {
                   if (!channel) return;
-                  Modal.confirm({
+                  wkConfirm({
                     title: t("base.conversationList.confirm.closeTitle"),
                     content: t("base.conversationList.confirm.closeContent"),
                     okText: t("base.common.ok"),
@@ -1190,7 +1191,7 @@ export default class ConversationList extends Component<
                 danger: true,
                 onClick: () => {
                   if (!channel) return;
-                  Modal.confirm({
+                  wkConfirm({
                     title: t("base.conversationList.confirm.clearTitle"),
                     content: t("base.conversationList.confirm.clearContent"),
                     okText: t("base.common.ok"),
@@ -1208,7 +1209,7 @@ export default class ConversationList extends Component<
                 danger: true,
                 onClick: () => {
                   if (!channel) return;
-                  Modal.confirm({
+                  wkConfirm({
                     title: t("base.conversationList.confirm.closeAndClearTitle"),
                     content:
                       t("base.conversationList.confirm.closeAndClearContent"),

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useEffect } from "react"
-import { Modal } from "@douyinfe/semi-ui"
 import { flushSync } from "react-dom"
 import WKSDK, { ChannelTypeGroup, ChannelTypePerson, Channel, Conversation } from "wukongimjssdk"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
@@ -33,6 +32,7 @@ import {
     type ValidCategoryItem,
 } from "./categoriesFallback"
 import { useI18n } from "../../i18n"
+import { wkConfirm } from "../WKModal"
 
 // 兜底相关 helper 迁移至 ./categoriesFallback 独立模块，便于无依赖地单元测试。
 // 这里保留 re-export 以保持对外 API 不变（ConversationList.tsx / storybook 可直接从本模块引用）。
@@ -655,7 +655,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                 icon: "M3 6h18 M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6 M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2",
                 danger: true,
                 onClick: () => {
-                    Modal.confirm({
+                    wkConfirm({
                         title: t("base.chatSidebar.confirm.deleteCategoryTitle"),
                         content: t("base.chatSidebar.confirm.deleteCategoryContent", {
                             values: { name: cat.name },

--- a/packages/dmworkbase/src/Components/GroupCard/index.css
+++ b/packages/dmworkbase/src/Components/GroupCard/index.css
@@ -1,5 +1,5 @@
-.wk-group-card-modal .semi-modal-body {
-    padding: 0 !important;
+.wk-group-card-modal .wk-modal-shell {
+    padding: 0;
 }
 .wk-group-card-content {
     padding: 24px;

--- a/packages/dmworkbase/src/Components/GroupManagement/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Button, Spin, Tag, Modal, Toast } from "@douyinfe/semi-ui";
+import { Button, Spin, Tag, Toast } from "@douyinfe/semi-ui";
 import { Channel, Subscriber } from "wukongimjssdk";
 import WKApp from "../../App";
 import WKAvatar from "../WKAvatar";
@@ -7,6 +7,7 @@ import { SubscriberList } from "../Subscribers/list";
 import RouteContext, { RouteContextConfig } from "../../Service/Context";
 import { GroupRole } from "../../Service/Const";
 import { I18nContext, t } from "../../i18n";
+import { wkConfirm } from "../WKModal";
 import "./index.css";
 
 export interface GroupManagementProps {
@@ -75,7 +76,7 @@ export class GroupManagement extends Component<
 
   handleRemoveManager = (subscriber: Subscriber) => {
     const { channel } = this.props;
-    Modal.confirm({
+    wkConfirm({
       title: t("base.groupManagement.removeManagerTitle"),
       content: t("base.groupManagement.removeManagerContent", {
         values: { name: subscriber.remark || subscriber.name },
@@ -98,7 +99,7 @@ export class GroupManagement extends Component<
 
   handleRemoveBotAdmin = (subscriber: Subscriber) => {
     const { channel } = this.props;
-    Modal.confirm({
+    wkConfirm({
       title: t("base.groupManagement.removeBotAdminTitle"),
       content: t("base.groupManagement.removeBotAdminContent", {
         values: { name: subscriber.remark || subscriber.name },

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -1,11 +1,12 @@
 import React, { Component } from "react";
-import { Button, TextArea, Spin, Modal } from "@douyinfe/semi-ui";
+import { Button, TextArea, Spin } from "@douyinfe/semi-ui";
 import { Toast } from "@douyinfe/semi-ui";
 import { Channel } from "wukongimjssdk";
 import WKApp from "../../App";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
 import { I18nContext } from "../../i18n";
+import { wkConfirm } from "../WKModal";
 import "./index.css";
 
 export interface GroupMdEditorProps {
@@ -130,7 +131,7 @@ export class GroupMdEditor extends Component<
   };
 
   handleDelete = () => {
-    Modal.confirm({
+    wkConfirm({
       title: this.context.t("base.groupMd.deleteTitle"),
       content: this.context.t("base.groupMd.deleteContent"),
       onOk: async () => {

--- a/packages/dmworkbase/src/Components/MessageInput/VoiceFeedbackNotice.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/VoiceFeedbackNotice.tsx
@@ -61,7 +61,7 @@ export default function VoiceFeedbackNotice({
       onCancel={onCancel}
       options={{ closeOnEsc: true, maskClosable: false }}
       footer={
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div className="wk-modal-footer-fill" style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <div style={{ borderTop: "1px solid var(--semi-color-border)", margin: 0 }} />
           <Checkbox
             checked={feedbackChecked}

--- a/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.css
+++ b/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.css
@@ -1,0 +1,114 @@
+.wk-voice-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-3);
+}
+
+.wk-voice-settings__notice {
+  color: var(--wk-color-warning);
+  font-size: var(--wk-text-size-base);
+  line-height: var(--wk-leading-normal);
+}
+
+.wk-voice-settings__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--wk-sp-4);
+  min-height: var(--wk-sp-6);
+}
+
+.wk-voice-settings__row--primary {
+  min-height: var(--wk-sp-6);
+}
+
+.wk-voice-settings__row--primary .wk-voice-settings__label {
+  font-size: var(--wk-text-size-xl);
+  font-weight: var(--wk-font-medium);
+}
+
+.wk-voice-settings__label {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: var(--wk-sp-1);
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-md);
+  line-height: var(--wk-leading-snug);
+}
+
+.wk-voice-settings__help {
+  flex-shrink: 0;
+  color: var(--wk-text-tertiary);
+  cursor: help;
+}
+
+.wk-voice-settings__local-config {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-3);
+  margin-top: var(--wk-sp-1);
+  padding: var(--wk-sp-3);
+  background: var(--wk-bg-elevated);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-sm);
+  font-size: var(--wk-text-size-base);
+}
+
+.wk-voice-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-1);
+}
+
+.wk-voice-settings__field-label {
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-base);
+  line-height: var(--wk-leading-normal);
+}
+
+.wk-voice-settings__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--wk-sp-1-5) var(--wk-sp-2);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  font: var(--wk-text-body);
+  outline: none;
+}
+
+.wk-voice-settings__input:focus {
+  border-color: var(--wk-brand-primary);
+  box-shadow: 0 0 0 2px var(--wk-border-glow);
+}
+
+.wk-voice-settings__test-btn {
+  align-self: flex-start;
+}
+
+.wk-voice-settings__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--wk-sp-2);
+  margin-top: var(--wk-sp-1);
+}
+
+.wk-voice-settings__links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-2);
+  margin-top: var(--wk-sp-2);
+}
+
+.wk-voice-settings__link {
+  color: var(--wk-text-accent);
+  font-size: var(--wk-text-size-base);
+  line-height: var(--wk-leading-normal);
+  text-decoration: none;
+}
+
+.wk-voice-settings__link:hover {
+  text-decoration: underline;
+}

--- a/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/VoiceSettingsPanel.tsx
@@ -12,6 +12,8 @@ import VoiceFeedbackNotice from '../MessageInput/VoiceFeedbackNotice';
 import WKApp from '../../App';
 import VoiceService from '../../Service/VoiceService';
 import { useI18n } from '../../i18n';
+import WKButton from '../WKButton';
+import './VoiceSettingsPanel.css';
 
 interface VoiceSettingsPanelProps {
   onClose: () => void;
@@ -215,20 +217,21 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
   return (
     <WKModal
       visible
-      title={t('base.navRail.voiceSettings.title')}
+      title={null}
       onCancel={onClose}
-      options={{ closeOnEsc: true, maskClosable: true }}
+      options={{ closeOnEsc: true, maskClosable: true, closable: false }}
       footer={null}
+      className="wk-voice-settings-modal"
     >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div className="wk-voice-settings">
         {loaded && !apiAvailable && (
-          <div style={{ color: 'var(--semi-color-warning)', fontSize: 13 }}>
+          <div className="wk-voice-settings__notice">
             {t('base.navRail.voiceSettings.serviceUnavailable')}
           </div>
         )}
 
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <span>{t('base.navRail.voiceSettings.transcription')}</span>
+        <div className="wk-voice-settings__row wk-voice-settings__row--primary">
+          <span className="wk-voice-settings__label">{t('base.navRail.voiceSettings.transcription')}</span>
           <Switch
             size="small"
             checked={isVoiceEnabled}
@@ -238,11 +241,11 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
         </div>
 
         {isVoiceEnabled && voiceConfig?.feedback_url && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <div className="wk-voice-settings__row">
+            <span className="wk-voice-settings__label">
               {t('base.navRail.voiceSettings.feedback')}
               <Tooltip content={t('base.navRail.voiceSettings.feedbackTooltip')}>
-                <IconHelpCircle size="small" style={{ color: 'var(--semi-color-text-2)', cursor: 'help' }} />
+                <IconHelpCircle className="wk-voice-settings__help" size="small" />
               </Tooltip>
             </span>
             <Switch
@@ -256,11 +259,11 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
 
         {isVoiceEnabled && voiceConfig?.local_enabled !== undefined && localConfigLoaded && (
           <>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <div className="wk-voice-settings__row">
+              <span className="wk-voice-settings__label">
                 {t('base.navRail.voiceSettings.localTranscription')}
                 <Tooltip content={t('base.navRail.voiceSettings.localTranscriptionTooltip')}>
-                  <IconHelpCircle size="small" style={{ color: 'var(--semi-color-text-2)', cursor: 'help' }} />
+                  <IconHelpCircle className="wk-voice-settings__help" size="small" />
                 </Tooltip>
               </span>
               <Switch
@@ -272,94 +275,72 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
             </div>
 
             {localEnabled && (
-              <div style={{
-                display: 'flex', flexDirection: 'column', gap: 12,
-                padding: '12px', marginTop: 4,
-                background: 'var(--semi-color-fill-0)',
-                borderRadius: 6, fontSize: 13,
-              }}>
-                <div>
-                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+              <div className="wk-voice-settings__local-config">
+                <div className="wk-voice-settings__field">
+                  <label className="wk-voice-settings__field-label">
                     {t('base.navRail.voiceSettings.localTimeoutMs')}
-                  </div>
+                  </label>
                   <input
                     type="number"
                     value={localTimeoutMs}
                     placeholder="10000"
                     onChange={(e) => { setLocalTimeoutMs(e.target.value); setLocalDirty(true); }}
-                    style={{
-                      width: '100%', padding: '6px 8px',
-                      border: '1px solid var(--semi-color-border)',
-                      borderRadius: 4, fontSize: 13,
-                    }}
+                    className="wk-voice-settings__input"
                   />
                 </div>
-                <div>
-                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+                <div className="wk-voice-settings__field">
+                  <label className="wk-voice-settings__field-label">
                     {t('base.navRail.voiceSettings.localProbeUrl')}
-                  </div>
+                  </label>
                   <input
                     type="url"
                     value={localProbeUrl}
                     placeholder="http://localhost:8787/"
                     onChange={(e) => { setLocalProbeUrl(e.target.value); setLocalDirty(true); }}
-                    style={{
-                      width: '100%', padding: '6px 8px',
-                      border: '1px solid var(--semi-color-border)',
-                      borderRadius: 4, fontSize: 13,
-                    }}
+                    className="wk-voice-settings__input"
                   />
-                  <button
+                  <WKButton
+                    size="sm"
+                    variant="secondary"
                     onClick={handleTestProbe}
                     disabled={probeTestStatus === 'loading' || !localProbeUrl.trim()}
-                    style={{ marginLeft: 8, fontSize: 12, padding: '2px 8px', cursor: 'pointer' }}
+                    className="wk-voice-settings__test-btn"
                   >
                     {probeTestStatus === 'idle' && t('base.navRail.voiceSettings.testConnection')}
                     {probeTestStatus === 'loading' && t('base.navRail.voiceSettings.testingConnection')}
                     {probeTestStatus === 'success' && t('base.navRail.voiceSettings.connectionSuccess')}
                     {probeTestStatus === 'fail' && t('base.navRail.voiceSettings.connectionFailed')}
-                  </button>
+                  </WKButton>
                 </div>
-                <div>
-                  <div style={{ marginBottom: 4, color: 'var(--semi-color-text-2)' }}>
+                <div className="wk-voice-settings__field">
+                  <label className="wk-voice-settings__field-label">
                     {t('base.navRail.voiceSettings.localTranscribeUrl')}
-                  </div>
+                  </label>
                   <input
                     type="url"
                     value={localTranscribeUrl}
                     placeholder="http://localhost:8787/v1/voice/transcribe"
                     onChange={(e) => { setLocalTranscribeUrl(e.target.value); setLocalDirty(true); }}
-                    style={{
-                      width: '100%', padding: '6px 8px',
-                      border: '1px solid var(--semi-color-border)',
-                      borderRadius: 4, fontSize: 13,
-                    }}
+                    className="wk-voice-settings__input"
                   />
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
-                  <button
+                <div className="wk-voice-settings__actions">
+                  <WKButton
+                    size="sm"
+                    variant="secondary"
                     onClick={handleLocalConfigReset}
                     disabled={localSaving}
-                    style={{
-                      padding: '4px 12px', fontSize: 13, borderRadius: 4,
-                      border: '1px solid var(--semi-color-border)',
-                      background: 'transparent', cursor: 'pointer',
-                    }}
                   >
                     {t('base.navRail.voiceSettings.restoreDefaults')}
-                  </button>
-                  <button
+                  </WKButton>
+                  <WKButton
+                    size="sm"
+                    variant="primary"
                     onClick={handleLocalConfigSave}
                     disabled={localSaving || !localDirty}
-                    style={{
-                      padding: '4px 12px', fontSize: 13, borderRadius: 4,
-                      border: 'none', color: '#fff',
-                      background: localDirty ? 'var(--semi-color-primary)' : 'var(--semi-color-disabled-bg)',
-                      cursor: localDirty ? 'pointer' : 'not-allowed',
-                    }}
                   >
                     {t('base.navRail.voiceSettings.save')}
-                  </button>
+                  </WKButton>
                 </div>
               </div>
             )}
@@ -367,13 +348,13 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
         )}
 
         {(privacyUrl || agreementUrl) && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+          <div className="wk-voice-settings__links">
             {privacyUrl && (
               <a
                 href={privacyUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ color: 'var(--semi-color-link)', fontSize: 13 }}
+                className="wk-voice-settings__link"
               >
                 {t('base.navRail.voiceSettings.privacyPolicy')}
               </a>
@@ -383,7 +364,7 @@ export default function VoiceSettingsPanel({ onClose }: VoiceSettingsPanelProps)
                 href={agreementUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ color: 'var(--semi-color-link)', fontSize: 13 }}
+                className="wk-voice-settings__link"
               >
                 {t('base.navRail.voiceSettings.userAgreement')}
               </a>

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/VoiceSettingsPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/VoiceSettingsPanel.test.tsx
@@ -137,9 +137,10 @@ const renderPanel = async (onClose = vi.fn()) => {
 };
 
 describe('VoiceSettingsPanel', () => {
-  it('renders modal with title 语音设置', async () => {
+  it('renders voice transcription as the primary row instead of a modal header', async () => {
     await renderPanel();
-    expect(container.querySelector('[data-testid="modal-title"]')?.textContent).toBe('语音设置');
+    expect(container.querySelector('[data-testid="modal-title"]')?.textContent).toBe('');
+    expect(container.querySelector('.wk-voice-settings__row--primary')?.textContent).toContain('语音转写');
   });
 
   it('shows voice transcription label', async () => {

--- a/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
-import { Input, TextArea, Toast, Modal, Button } from "@douyinfe/semi-ui";
+import { Input, TextArea, Toast, Button } from "@douyinfe/semi-ui";
 import { IconCopy, IconLink } from "@douyinfe/semi-icons";
 import { Space, SpaceService } from "../../Service/SpaceService";
 import { I18nContext, t } from "../../i18n";
+import { wkConfirm } from "../WKModal";
 import "./index.css";
 
 export interface SpaceSettingsProps {
@@ -57,7 +58,7 @@ export default class SpaceSettings extends Component<SpaceSettingsProps, SpaceSe
     };
 
     handleLeave = () => {
-        Modal.confirm({
+        wkConfirm({
             title: t("base.spaceSettings.leaveTitle"),
             content: t("base.spaceSettings.leaveContent"),
             okText: t("base.common.ok"),
@@ -76,7 +77,7 @@ export default class SpaceSettings extends Component<SpaceSettingsProps, SpaceSe
     };
 
     handleDisband = () => {
-        Modal.confirm({
+        wkConfirm({
             title: t("base.spaceSettings.disbandTitle"),
             content: t("base.spaceSettings.disbandContent"),
             okType: "danger",

--- a/packages/dmworkbase/src/Components/ThreadList/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadList/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { Button, Spin, Modal, Toast, Tooltip } from "@douyinfe/semi-ui"
+import { Button, Spin, Toast, Tooltip } from "@douyinfe/semi-ui"
 import { Channel } from "wukongimjssdk"
 import { UserPlus, LogOut, Trash2 } from "lucide-react"
 import { Thread, ThreadStatus } from "../../Service/Thread"
@@ -9,6 +9,7 @@ import RouteContext from "../../Service/Context"
 import { ThreadListVM, ThreadListState } from "./vm"
 import { ThreadCreate } from "../ThreadCreate"
 import { I18nContext, t } from "../../i18n"
+import { wkConfirm } from "../WKModal"
 import "./index.css"
 
 export interface ThreadListProps {
@@ -62,7 +63,7 @@ export class ThreadList extends Component<ThreadListProps, ThreadListState> {
 
   handleDelete = (thread: Thread, e: React.MouseEvent) => {
     e.stopPropagation()
-    Modal.confirm({
+    wkConfirm({
       title: t("base.threadPanel.delete"),
       content: t("base.threadList.deleteConfirm", { values: { name: thread.name } }),
       okType: "danger",
@@ -89,7 +90,7 @@ export class ThreadList extends Component<ThreadListProps, ThreadListState> {
 
   handleLeave = (thread: Thread, e: React.MouseEvent) => {
     e.stopPropagation()
-    Modal.confirm({
+    wkConfirm({
       title: t("base.module.thread.leave"),
       content: t("base.threadList.leaveConfirm", { values: { name: thread.name } }),
       onOk: async () => {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -5,7 +5,7 @@ import {
   ChannelTypeGroup,
   WKSDK,
 } from "wukongimjssdk";
-import { Modal, Toast, Spin, Popover } from "@douyinfe/semi-ui";
+import { Toast, Spin, Popover } from "@douyinfe/semi-ui";
 import {
   Thread,
   ThreadStatus,
@@ -31,6 +31,7 @@ import { MarkdownRenderer } from "../FilePreviewPanel/renderers/MarkdownRenderer
 import { HtmlRenderer } from "../FilePreviewPanel/renderers/HtmlRenderer";
 import { ImageRenderer } from "../FilePreviewPanel/renderers/ImageRenderer";
 import { I18nContext, t } from "../../i18n";
+import { wkConfirm } from "../WKModal";
 import {
   SMALL_SCREEN_WIDTH,
   THREAD_DEFAULT_WIDTH,
@@ -574,9 +575,8 @@ export default class ThreadPanel extends Component<
     // 延迟弹窗，等 Popover 完全关闭后再触发，避免 Modal 被 Popover 关闭事件误关
     setTimeout(() => {
       let newName = thread.name;
-      Modal.confirm({
+      wkConfirm({
         title: t("base.threadPanel.editNameTitle"),
-        icon: null,
         okText: t("base.threadPanel.save"),
         cancelText: t("base.common.cancel"),
         content: (
@@ -650,11 +650,10 @@ export default class ThreadPanel extends Component<
     this.setState({ showMoreMenu: false });
 
     setTimeout(() => {
-      Modal.confirm({
+      wkConfirm({
         title: archiving
           ? t("base.module.thread.archiveConfirmTitle", { values: { name: thread.name } })
           : t("base.module.thread.unarchiveConfirmTitle", { values: { name: thread.name } }),
-        icon: null,
         okText: archiving ? t("base.module.thread.archiveOk") : t("base.module.thread.unarchive"),
         cancelText: t("base.common.cancel"),
         content: archiving
@@ -808,9 +807,8 @@ export default class ThreadPanel extends Component<
     this.setState({ showMoreMenu: false });
 
     setTimeout(() => {
-      Modal.confirm({
+      wkConfirm({
         title: t("base.threadPanel.deleteConfirmTitle", { values: { name: thread.name } }),
-        icon: null,
         okText: t("base.threadPanel.delete"),
         okType: "danger",
         cancelText: t("base.common.cancel"),
@@ -840,9 +838,8 @@ export default class ThreadPanel extends Component<
     if (!groupNo) return;
 
     let threadName = "";
-    Modal.confirm({
+    wkConfirm({
       title: t("base.module.createThread.title"),
-      icon: null,
       okText: t("base.module.createThread.ok"),
       cancelText: t("base.common.cancel"),
       content: (

--- a/packages/dmworkbase/src/Components/WKBase/index.css
+++ b/packages/dmworkbase/src/Components/WKBase/index.css
@@ -19,11 +19,6 @@
   height: 420px;
 }
 
-/* 转发弹窗宽度 */
-.wk-base-modal-forward .wk-modal-content {
-  width: 625px;
-}
-
 .wk-base-modal-forward .wk-modal-body {
   height: 560px;
   overflow: hidden;

--- a/packages/dmworkbase/src/Components/WKBase/index.css
+++ b/packages/dmworkbase/src/Components/WKBase/index.css
@@ -3,45 +3,28 @@
   height: 100%;
 }
 
-.wk-base-modal .semi-modal-content {
-  border: none !important;
-  padding: 0px !important;
+.wk-base-modal .wk-modal-shell {
+  padding: 0;
 }
 
-.wk-base-modal .semi-modal-close {
-  display: none;
-}
-
-.wk-base-modal .semi-modal-body-wrapper {
-  margin: 0px;
-}
-
-.wk-base-modal-userinfo .semi-modal-body {
+.wk-base-modal-userinfo .wk-modal-body {
   height: 500px;
 }
 
 /* 加入组织 */
-.wk-base-modal-join-org .semi-modal-content {
-  border: none !important;
-  padding: 12px !important;
+.wk-base-modal-join-org .wk-modal-shell {
+  padding: var(--wk-sp-3);
 }
-.wk-base-modal-join-org .semi-modal-header {
-  margin: 12px !important;
-}
-.wk-base-modal-join-org .semi-modal-body-wrapper {
-  margin: 0px;
-}
-.wk-base-modal-join-org .semi-modal-body {
+.wk-base-modal-join-org .wk-modal-body {
   height: 420px;
 }
 
 /* 转发弹窗宽度 */
-.wk-base-modal-forward .semi-modal-content {
-  width: 625px !important;
+.wk-base-modal-forward .wk-modal-content {
+  width: 625px;
 }
 
-.wk-base-modal-forward .semi-modal-body {
-  padding: 0 !important;
+.wk-base-modal-forward .wk-modal-body {
   height: 560px;
   overflow: hidden;
 }

--- a/packages/dmworkbase/src/Components/WKBase/index.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/index.tsx
@@ -367,7 +367,8 @@ export default class WKBase
         <WKModal
           className="wk-base-modal wk-base-modal-forward"
           visible={showConversationSelect}
-          options={{ mask: false, width: 625 }}
+          width={625}
+          options={{ mask: false }}
           onCancel={() => {
             this.setState({
               showConversationSelect: false,
@@ -405,7 +406,7 @@ export default class WKBase
             },
           }}
         >
-          {alertContent}
+          <p className="wk-modal-confirm-text">{alertContent}</p>
         </WKModal>
         <Modal
           closable={this.state.globalModalOptions?.closable}

--- a/packages/dmworkbase/src/Components/WKModal/confirm.tsx
+++ b/packages/dmworkbase/src/Components/WKModal/confirm.tsx
@@ -4,7 +4,19 @@ import type { ModalReactProps } from '@douyinfe/semi-ui/modal'
 import { t } from '../../i18n'
 import WKButton from '../WKButton'
 
-export type WKConfirmProps = Omit<ModalReactProps, 'className' | 'icon'> & {
+type WKConfirmPending = 'ok' | 'cancel' | null
+
+export type WKConfirmProps = Omit<
+  ModalReactProps,
+  | 'cancelButtonProps'
+  | 'cancelLoading'
+  | 'className'
+  | 'confirmLoading'
+  | 'footer'
+  | 'hasCancel'
+  | 'icon'
+  | 'okButtonProps'
+> & {
   className?: string
 }
 
@@ -14,24 +26,30 @@ export function wkConfirm(props: WKConfirmProps) {
   const resolvedCancelText = cancelText ?? t('base.common.cancel')
   let modalRef: ReturnType<typeof Modal.confirm>
 
-  const closeAfter = (result: void | Promise<unknown>) => {
-    if (result && typeof (result as Promise<unknown>).then === 'function') {
-      void (result as Promise<unknown>).then(() => modalRef?.destroy())
-      return
+  const renderContent = (pending: WKConfirmPending = null) => {
+    const updatePending = (nextPending: WKConfirmPending) => {
+      modalRef?.update({
+        content: renderContent(nextPending),
+      } as WKConfirmProps)
     }
-    modalRef?.destroy()
-  }
 
-  modalRef = Modal.confirm({
-    ...rest,
-    icon: null,
-    className: ['wk-modal', 'wk-modal-confirm', className].filter(Boolean).join(' '),
-    modalContentClass: 'wk-modal-content',
-    title: null,
-    header: null,
-    footer: null,
-    onCancel,
-    content: (
+    const runAction = (action: 'ok' | 'cancel', event: React.MouseEvent<HTMLButtonElement>) => {
+      if (pending) return
+      const callback = action === 'ok' ? onOk : onCancel
+      const result = callback?.(event)
+
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        updatePending(action)
+        void (result as Promise<unknown>)
+          .then(() => modalRef?.destroy())
+          .catch(() => updatePending(null))
+        return
+      }
+
+      modalRef?.destroy()
+    }
+
+    return (
       <div className="wk-modal-confirm-shell">
         {props.title !== null && props.title !== undefined && (
           <div className="wk-modal-title wk-modal-confirm-title">{props.title}</div>
@@ -46,19 +64,35 @@ export function wkConfirm(props: WKConfirmProps) {
         <div className="wk-modal-footer wk-modal-confirm-footer">
           <WKButton
             variant="secondary"
-            onClick={(event) => closeAfter(onCancel?.(event) as void | Promise<unknown>)}
+            disabled={pending !== null}
+            loading={pending === 'cancel'}
+            onClick={(event) => runAction('cancel', event)}
           >
             {resolvedCancelText}
           </WKButton>
           <WKButton
             variant={okType === 'danger' ? 'danger' : 'primary'}
-            onClick={(event) => closeAfter(onOk?.(event) as void | Promise<unknown>)}
+            disabled={pending !== null}
+            loading={pending === 'ok'}
+            onClick={(event) => runAction('ok', event)}
           >
             {resolvedOkText}
           </WKButton>
         </div>
       </div>
-    ),
+    )
+  }
+
+  modalRef = Modal.confirm({
+    ...rest,
+    icon: null,
+    className: ['wk-modal', 'wk-modal-confirm', className].filter(Boolean).join(' '),
+    modalContentClass: 'wk-modal-content',
+    title: null,
+    header: null,
+    footer: null,
+    onCancel,
+    content: renderContent(),
   })
 
   return modalRef

--- a/packages/dmworkbase/src/Components/WKModal/confirm.tsx
+++ b/packages/dmworkbase/src/Components/WKModal/confirm.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Modal } from '@douyinfe/semi-ui'
+import type { ModalReactProps } from '@douyinfe/semi-ui/modal'
+import { t } from '../../i18n'
+import WKButton from '../WKButton'
+
+export type WKConfirmProps = Omit<ModalReactProps, 'className' | 'icon'> & {
+  className?: string
+}
+
+export function wkConfirm(props: WKConfirmProps) {
+  const { className, okText, cancelText, okType, onOk, onCancel, ...rest } = props
+  const resolvedOkText = okText ?? t('base.common.ok')
+  const resolvedCancelText = cancelText ?? t('base.common.cancel')
+  let modalRef: ReturnType<typeof Modal.confirm>
+
+  const closeAfter = (result: void | Promise<unknown>) => {
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+      void (result as Promise<unknown>).then(() => modalRef?.destroy())
+      return
+    }
+    modalRef?.destroy()
+  }
+
+  modalRef = Modal.confirm({
+    ...rest,
+    icon: null,
+    className: ['wk-modal', 'wk-modal-confirm', className].filter(Boolean).join(' '),
+    modalContentClass: 'wk-modal-content',
+    title: null,
+    header: null,
+    footer: null,
+    onCancel,
+    content: (
+      <div className="wk-modal-confirm-shell">
+        {props.title !== null && props.title !== undefined && (
+          <div className="wk-modal-title wk-modal-confirm-title">{props.title}</div>
+        )}
+        <div className="wk-modal-confirm-body">
+          {typeof props.content === 'string' ? (
+            <p className="wk-modal-confirm-text">{props.content}</p>
+          ) : (
+            props.content
+          )}
+        </div>
+        <div className="wk-modal-footer wk-modal-confirm-footer">
+          <WKButton
+            variant="secondary"
+            onClick={(event) => closeAfter(onCancel?.(event) as void | Promise<unknown>)}
+          >
+            {resolvedCancelText}
+          </WKButton>
+          <WKButton
+            variant={okType === 'danger' ? 'danger' : 'primary'}
+            onClick={(event) => closeAfter(onOk?.(event) as void | Promise<unknown>)}
+          >
+            {resolvedOkText}
+          </WKButton>
+        </div>
+      </div>
+    ),
+  })
+
+  return modalRef
+}

--- a/packages/dmworkbase/src/Components/WKModal/confirm.tsx
+++ b/packages/dmworkbase/src/Components/WKModal/confirm.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Modal } from '@douyinfe/semi-ui'
-import type { ModalReactProps } from '@douyinfe/semi-ui/modal'
+import type { ConfirmProps, ModalReactProps } from '@douyinfe/semi-ui/modal'
 import { t } from '../../i18n'
 import WKButton from '../WKButton'
 
@@ -28,9 +28,11 @@ export function wkConfirm(props: WKConfirmProps) {
 
   const renderContent = (pending: WKConfirmPending = null) => {
     const updatePending = (nextPending: WKConfirmPending) => {
-      modalRef?.update({
+      const updateConfig: ConfirmProps = {
+        type: 'confirm',
         content: renderContent(nextPending),
-      } as WKConfirmProps)
+      }
+      modalRef?.update(updateConfig)
     }
 
     const runAction = (action: 'ok' | 'cancel', event: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/dmworkbase/src/Components/WKModal/index.css
+++ b/packages/dmworkbase/src/Components/WKModal/index.css
@@ -11,6 +11,39 @@
   --semi-color-bg-1: var(--wk-bg-base);
   --semi-font-size-header-2: var(--wk-text-size-xl);
   --semi-color-text-0: var(--wk-text-primary);
+  --semi-color-bg-2: var(--wk-bg-surface);
+  --semi-color-overlay-bg: var(--wk-brand-tint-35);
+  --semi-shadow-elevated: var(--wk-shadow-lg);
+}
+
+.wk-modal-content {
+  padding: 0;
+}
+
+.wk-modal-shell,
+.wk-modal-confirm-shell {
+  box-sizing: border-box;
+  padding: var(--wk-sp-6);
+}
+
+.wk-modal-title {
+  margin: 0 0 var(--wk-sp-4);
+  padding-right: var(--wk-sp-8);
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-xl);
+  font-weight: var(--wk-font-semibold);
+  line-height: var(--wk-leading-snug);
+}
+
+.wk-modal-body {
+  box-sizing: border-box;
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-md);
+  line-height: var(--wk-leading-normal);
+}
+
+.wk-modal-body:empty {
+  display: none;
 }
 
 /* footer 按钮行 */
@@ -18,14 +51,37 @@
   display: flex;
   justify-content: flex-end;
   gap: var(--wk-sp-2);
-  padding: var(--wk-sp-4) var(--wk-sp-6) var(--wk-sp-6);
+  align-items: center;
+  min-height: var(--wk-sp-8);
+  margin-top: var(--wk-sp-6);
+}
+
+.wk-modal-confirm-footer {
+  margin-top: var(--wk-sp-5);
+}
+
+.wk-modal-confirm-title {
+  margin-bottom: var(--wk-sp-2);
+}
+
+.wk-modal-confirm-body {
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-md);
+  line-height: var(--wk-leading-normal);
+}
+
+.wk-modal-confirm-text {
+  margin: 0;
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-md);
+  line-height: var(--wk-leading-normal);
 }
 
 /* 自定义关闭按钮（用于 title=null 时） */
 .wk-modal-custom-close-btn {
   position: absolute;
-  top: var(--wk-sp-6);
-  right: var(--wk-sp-6);
+  top: var(--wk-sp-4);
+  right: var(--wk-sp-4);
   z-index: 10;
   display: flex;
   align-items: center;

--- a/packages/dmworkbase/src/Components/WKModal/index.css
+++ b/packages/dmworkbase/src/Components/WKModal/index.css
@@ -56,6 +56,10 @@
   margin-top: var(--wk-sp-6);
 }
 
+.wk-modal-footer > .wk-modal-footer-fill {
+  width: 100%;
+}
+
 .wk-modal-confirm-footer {
   margin-top: var(--wk-sp-5);
 }

--- a/packages/dmworkbase/src/Components/WKModal/index.tsx
+++ b/packages/dmworkbase/src/Components/WKModal/index.tsx
@@ -69,7 +69,11 @@ function resolveFooter(
 ): React.ReactNode {
   // 显式传了 footer JSX（包括空字符串等 falsy 要排除，但 null 表示"不渲染"）
   if (footer !== undefined) {
-    return footer === null ? null : footer
+    return footer === null ? null : (
+      <div className="wk-modal-footer">
+        {footer}
+      </div>
+    )
   }
   if (footerConfig?.onOk) {
     const { okText = t('base.common.ok'), cancelText = t('base.common.cancel'), isOkLoading, isDanger, onOk } = footerConfig

--- a/packages/dmworkbase/src/Components/WKModal/index.tsx
+++ b/packages/dmworkbase/src/Components/WKModal/index.tsx
@@ -4,6 +4,8 @@ import { IconClose } from '@douyinfe/semi-icons'
 import WKButton from '../WKButton'
 import { t } from '../../i18n'
 import './index.css'
+export { wkConfirm } from './confirm'
+export type { WKConfirmProps } from './confirm'
 
 export type WKModalSize = 'md' | 'lg' | 'full'
 // md = 400px（默认，覆盖原 380/400/420）
@@ -114,37 +116,40 @@ const WKModal: React.FC<WKModalProps> = ({
 
   const cls = ['wk-modal', className].filter(Boolean).join(' ')
 
-  // 当 title=null 且 closable=true 时，需要自定义关闭按钮
-  // 因为 Semi Modal 的关闭按钮依赖 header，title=null 时 header 不渲染导致按钮位置错位
-  const needCustomCloseBtn = title === null && closable
-
   return (
     <Modal
       visible={visible}
       onCancel={onCancel}
-      title={customHeader ? undefined : title}
-      header={customHeader}
+      title={null}
+      header={null}
       width={width}
-      footer={resolvedFooter}
-      closable={needCustomCloseBtn ? false : closable} // 自定义关闭按钮时禁用 Semi 默认按钮
+      footer={null}
+      closable={false}
       maskClosable={maskClosable}
       mask={mask}
       closeOnEsc={closeOnEsc}
       centered
       className={cls}
+      modalContentClass="wk-modal-content"
       style={style}
-      bodyStyle={bodyStyle}
     >
-      {needCustomCloseBtn && (
-        <button
-          className="wk-modal-custom-close-btn"
-          onClick={onCancel}
-          aria-label={t('base.common.close')}
-        >
-          <IconClose />
-        </button>
-      )}
-      {children}
+      <div className="wk-modal-shell">
+        {closable && (
+          <button
+            className="wk-modal-custom-close-btn"
+            onClick={onCancel}
+            aria-label={t('base.common.close')}
+          >
+            <IconClose />
+          </button>
+        )}
+        {customHeader}
+        {!customHeader && title !== null && title !== undefined && (
+          <div className="wk-modal-title">{title}</div>
+        )}
+        <div className="wk-modal-body" style={bodyStyle}>{children}</div>
+        {resolvedFooter}
+      </div>
     </Modal>
   )
 }

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1464,41 +1464,18 @@ export default class ChatPage extends Component<any, ChatPageState> {
               <WKModal
                 visible={!!this.state.pendingConfirm}
                 title={t("base.chatPage.unsentAttachmentTitle")}
-                footer={
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "flex-end",
-                      gap: "var(--wk-sp-2)",
-                    }}
-                  >
-                    <WKButton
-                      variant="secondary"
-                      onClick={() => this.setState({ pendingConfirm: null })}
-                    >
-                      {t("base.common.cancel")}
-                    </WKButton>
-                    <WKButton
-                      variant="primary"
-                      onClick={() => {
-                        this.state.pendingConfirm?.onOk();
-                        this.setState({ pendingConfirm: null });
-                      }}
-                    >
-                      {t("base.chatPage.continueSwitch")}
-                    </WKButton>
-                  </div>
-                }
+                footerConfig={{
+                  cancelText: t("base.common.cancel"),
+                  okText: t("base.chatPage.continueSwitch"),
+                  onOk: () => {
+                    this.state.pendingConfirm?.onOk();
+                    this.setState({ pendingConfirm: null });
+                  },
+                }}
                 onCancel={() => this.setState({ pendingConfirm: null })}
                 options={{ closable: false }}
               >
-                <p
-                  style={{
-                    margin: 0,
-                    color: "var(--wk-text-secondary)",
-                    fontSize: "var(--wk-text-size-md)",
-                  }}
-                >
+                <p className="wk-modal-confirm-text">
                   {t("base.chatPage.unsentAttachmentContent")}
                 </p>
               </WKModal>

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -74,12 +74,13 @@ import { VideoCell, VideoContent } from "./Messages/Video";
 import { TypingCell } from "./Messages/Typing";
 import { LottieSticker, LottieStickerCell } from "./Messages/LottieSticker";
 import { LocationCell, LocationContent } from "./Messages/Location";
-import { Toast, Modal, Tag } from "@douyinfe/semi-ui";
+import { Toast, Tag } from "@douyinfe/semi-ui";
 import { ChannelSettingManager } from "./Service/ChannelSetting";
 import { DefaultEmojiService } from "./Service/EmojiService";
 import IconClick from "./Components/IconClick";
 import EmojiToolbar from "./Components/EmojiToolbar";
 import MergeforwardContent, { MergeforwardCell } from "./Messages/Mergeforward";
+import { wkConfirm } from "./Components/WKModal";
 import { UserInfoRouteData } from "./Components/UserInfo/vm";
 import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
@@ -814,9 +815,8 @@ export default class BaseModule implements IModule {
               message.content?.conversationDigest || ""
             ).slice(0, 20);
             let threadName = defaultName;
-            Modal.confirm({
+            wkConfirm({
               title: t("base.module.createThread.title"),
-              icon: null,
               okText: t("base.module.createThread.ok"),
               cancelText: t("base.common.cancel"),
               content: (
@@ -2107,11 +2107,10 @@ export default class BaseModule implements IModule {
                 type: ListItemButtonType.default,
                 onClick: () => {
                   const threadDisplayName = thread?.name || data.channelInfo?.title || t("base.module.thread.fallbackName");
-                  Modal.confirm({
+                  wkConfirm({
                     title: isArchived
                       ? t("base.module.thread.unarchiveConfirmTitle", { values: { name: threadDisplayName } })
                       : t("base.module.thread.archiveConfirmTitle", { values: { name: threadDisplayName } }),
-                    icon: null,
                     okText: isArchived
                       ? t("base.module.thread.unarchive")
                       : t("base.module.thread.archiveOk"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,7 +345,7 @@ importers:
         specifier: ^2.93.0
         version: 2.93.0(react@17.0.2)
       '@douyinfe/semi-ui':
-        specifier: ^2.24.2
+        specifier: ^2.93.0
         version: 2.93.0(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@emotion/react':
         specifier: ^11.14.0


### PR DESCRIPTION
## Summary
- centralize WKModal shell/title/body/footer spacing so common dialogs no longer rely on Semi default modal margins
- add wkConfirm and migrate confirm dialogs to the shared modal button/footer layout
- clean up voice settings modal internals while leaving container spacing to WKModal
- update edge-to-edge modal overrides to target WKModal shell classes instead of Semi internals

Closes #185

## Verification
- pnpm --filter @octo/base exec vitest run src/Components/NavRail/__tests__/VoiceSettingsPanel.test.tsx
- git diff --check
- pnpm build