### PR TITLE
fix(login): add APIClient request timeout to stop login page infinite spinner

### DIFF
--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -48,6 +48,21 @@ export class APIClientConfig {
     }
 }
 
+/**
+ * 默认请求超时（毫秒）。
+ *
+ * 在此之前 axios 没有任何超时配置 —— 一旦后端/网关迟迟不返回（连接 hang、
+ * 网关 504 前的长挂起、移动弱网），`user/login`、`user/loginuuid`、`space/my`
+ * 这些请求的 Promise 永远不 settle，于是 LoginVM.loginLoading 一直停在 true，
+ * 登录按钮 / 二维码就「一直转圈」无法恢复（YUJ-2628）。
+ *
+ * 给一个全局兜底超时，请求超时后会被 response 拦截器 normalizeApiError 归类成
+ * 可读 msg 并 reject，前端的 .catch / finally 才能复位 loading 状态并提示重试。
+ * 文件上传等长耗时请求走的是直接的 `axios.post/put`（带各自的 timeout），
+ * 不经过这里的 get/post/put/delete 封装，所以不受影响。
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 20_000
+
 export default class APIClient {
     private constructor() {
         this.initAxios()
@@ -58,6 +73,9 @@ export default class APIClient {
 
     initAxios() {
         const self = this
+        // 全局默认超时兜底，避免请求永久挂起导致登录页一直转圈（YUJ-2628）。
+        // 单个请求仍可通过 config.timeout 覆盖（如上传走更长的超时）。
+        axios.defaults.timeout = DEFAULT_REQUEST_TIMEOUT_MS
         axios.interceptors.request.use(function (config) {
             config.headers = config.headers || {};
             config.headers["Accept-Language"] = buildAcceptLanguage();

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.test.ts
@@ -85,3 +85,16 @@ describe("APIClient request interceptor — X-Space-Id (GH #1038)", () => {
         expect(captured.headers["X-Space-Id"]).toBe("space-gamma")
     })
 })
+
+/**
+ * YUJ-2628 — 登录页一直转圈的根因：APIClient 没有任何请求超时。
+ * 请求永久挂起时 LoginVM.loginLoading 停在 true，按钮一直转圈无法恢复。
+ * 这里验证全局默认 timeout 已配置（超时/网络错误的归类见 apiError.test.ts）。
+ */
+describe("APIClient request timeout (YUJ-2628)", () => {
+    it("注册了全局默认超时（不再永久挂起）", () => {
+        // 触发单例构造 → initAxios 设置 axios.defaults.timeout
+        expect(APIClient.shared).toBeTruthy()
+        expect(axios.defaults.timeout).toBeGreaterThan(0)
+    })
+})

--- a/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
@@ -148,4 +148,28 @@ describe("normalizeApiError", () => {
     expect(normalizeApiError({ httpStatus: 404, data: {} }).message).toBe("请求地址没有找到（404）");
     expect(normalizeApiError({ httpStatus: 418, data: {} }).message).toBe("未知错误");
   });
+
+  // YUJ-2628 — 无响应错误（请求超时/网络中断）必须归类成可读提示，
+  // 否则登录页 hang 住后用户只看到「未知错误」。
+  it("classifies axios timeout (ECONNABORTED) as timeout message", () => {
+    const raw: any = new Error("timeout of 20000ms exceeded");
+    raw.code = "ECONNABORTED";
+    expect(normalizeApiError({ raw }).message).toBe("请求超时，请检查网络后重试");
+  });
+
+  it("classifies timeout by message even without code", () => {
+    const raw: any = new Error("timeout exceeded");
+    expect(normalizeApiError({ raw }).message).toBe("请求超时，请检查网络后重试");
+  });
+
+  it("classifies axios network error (ERR_NETWORK) as network message", () => {
+    const raw: any = new Error("Network Error");
+    raw.code = "ERR_NETWORK";
+    expect(normalizeApiError({ raw }).message).toBe("网络异常，请检查网络后重试");
+  });
+
+  it("does not misclassify a normal HTTP error as timeout/network", () => {
+    const raw: any = new Error("Request failed with status code 500");
+    expect(normalizeApiError({ httpStatus: 500, data: {}, raw }).message).toBe("未知错误");
+  });
 });

--- a/packages/dmworkbase/src/Service/apiError.ts
+++ b/packages/dmworkbase/src/Service/apiError.ts
@@ -87,6 +87,27 @@ export function normalizeApiError(input: NormalizeApiErrorInput): NormalizedApiE
   const data = input.data;
   const raw = input.raw ?? data;
 
+  // 无响应错误（请求超时 / 网络中断）：axios reject 时没有 response，因此
+  // data 和 httpStatus 都缺失，错误信息挂在 raw 上（code=ECONNABORTED/
+  // ERR_NETWORK，message 含 "timeout"）。必须在这里显式归类，否则会落到最后
+  // 的「未知错误」分支 —— 而真正的影响是：登录请求永久挂起 + 这个兜底超时
+  // 触发后，用户只看到「未知错误」，不知道是网络问题（YUJ-2628：登录页一直
+  // 转圈的根因是 APIClient 此前根本没有超时，请求 hang 住 loginLoading 不复位）。
+  if (input.httpStatus === undefined && !isRecord(data)) {
+    const rawRecord = isRecord(raw) ? raw : undefined;
+    const code = asNonEmptyString(rawRecord?.code);
+    const message = asNonEmptyString(rawRecord?.message);
+    const isTimeout = code === "ECONNABORTED" || /timeout/i.test(message ?? "");
+    const isNetwork = code === "ERR_NETWORK" || /network\s*error/i.test(message ?? "");
+    if (isTimeout || isNetwork) {
+      return {
+        code,
+        raw,
+        message: isTimeout ? t("base.api.error.timeout") : t("base.api.error.network"),
+      };
+    }
+  }
+
   if (isV2ErrorEnvelope(data)) {
     const envelope = data.error;
     const code = asNonEmptyString(envelope.code);

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -756,6 +756,8 @@
   "api.error.sessionExpired": "Session expired. Please log in again.",
   "api.error.forbidden": "Permission denied",
   "api.error.rateLimited": "Too many requests. Please try again later.",
+  "api.error.timeout": "Request timed out. Please check your network and retry.",
+  "api.error.network": "Network error. Please check your network and retry.",
   "api.error.unknown": "Unknown error",
   "aiTag.assistant": "AI assistant",
   "aiTag.collaboration": "AI collaboration",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -757,6 +757,8 @@
   "api.error.sessionExpired": "登录已过期，请重新登录",
   "api.error.forbidden": "没有权限",
   "api.error.rateLimited": "请求过于频繁，请稍后再试",
+  "api.error.timeout": "请求超时，请检查网络后重试",
+  "api.error.network": "网络异常，请检查网络后重试",
   "api.error.unknown": "未知错误",
   "aiTag.assistant": "AI助手",
   "aiTag.collaboration": "AI协作",


### PR DESCRIPTION
## 问题
登录页「一直转圈」无法恢复（YUJ-2628，群里反馈、紧急）。

## 根因
`packages/dmworkbase/src/Service/APIClient.ts` 里的 axios 客户端**没有任何请求超时**。一旦后端/网关迟迟不返回（连接 hang、网关 504 前的长挂起、移动弱网），`user/login` / `user/loginuuid` / `space/my` 这些请求的 Promise 永远不会 settle，于是 `LoginVM.loginLoading` 一直停在 `true`，登录按钮和二维码就一直转圈，且没有任何路径能复位。

OIDC 流程之前单独加过 10s 超时（#1061），但主登录路径走的普通 axios 没有兜底超时。

## 改动
- 给 axios 配置 20s 全局默认超时。上传等长耗时请求走的是直接的 `axios.post/put`（各自带 timeout），不经过 APIClient 的 get/post/put/delete 封装，因此不受影响。
- 在 `normalizeApiError` 里把「无响应」错误（超时 `ECONNABORTED` / 网络中断 `ERR_NETWORK`）归类成本地化提示（新增 i18n key `api.error.timeout` / `api.error.network`，中英文都加），这样请求超时被 reject 后前端 `.catch/finally` 能复位 loading 并提示用户重试，而不是落到「未知错误」。

## 测试
- `apiError.test.ts`：新增超时 / 网络错误归类用例 + 不误判普通 HTTP 错误的回归守卫。
- `APIClient.test.ts`：断言全局默认 timeout 已配置。
- dmworkbase Service + i18n 全套测试通过（132 passed；唯一失败的 UploadCredentials.test.ts 是 lottie-web/jsdom 预存在的导入问题，与本改动无关，clean tree 上同样失败）。

Closes #2628