### PR TITLE
fix(web): add logout path to no-space pages

### DIFF
--- a/apps/web/src/Components/JoinSpacePage/index.css
+++ b/apps/web/src/Components/JoinSpacePage/index.css
@@ -86,6 +86,46 @@
     margin-top: 16px;
 }
 
+.wk-join-space-logout {
+    margin-top: var(--wk-sp-5);
+}
+
+.wk-join-space-logout-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wk-sp-1);
+    min-height: 30px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-base);
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: color 0.15s ease;
+}
+
+.wk-join-space-logout-btn:hover {
+    color: var(--wk-brand-primary);
+}
+
+.wk-join-space-logout-btn:hover span {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.wk-join-space-logout-btn:focus-visible {
+    outline: 2px solid var(--wk-brand-primary-ring);
+    outline-offset: 2px;
+    border-radius: var(--wk-r-xs);
+}
+
+.wk-join-space-logout-btn svg {
+    flex: 0 0 auto;
+}
+
 /* Primary 按钮颜色统一 */
 .wk-join-space-btn.semi-button-primary {
     background-color: var(--wk-color-primary, #1C1C23) !important;

--- a/apps/web/src/Components/JoinSpacePage/index.tsx
+++ b/apps/web/src/Components/JoinSpacePage/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { SpaceCreate, WKApp, toJoinApprovalStatus, useI18n } from "@octo/base";
 import { SpaceService } from "@octo/base";
 import { Button, Input, Toast } from "@douyinfe/semi-ui";
+import { LogOut } from "lucide-react";
 import "./index.css";
 
 type View = "home" | "join" | "join-confirm";
@@ -113,6 +114,10 @@ export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
         ? colors[inviteInfo.space_name.charCodeAt(0) % colors.length]
         : ACCENT;
 
+    const handleLogout = () => {
+        WKApp.shared.logout();
+    };
+
     return (
         <div className="wk-join-space">
             <div className="wk-join-space-card">
@@ -216,6 +221,12 @@ export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
                         </button>
                     </>
                 )}
+                <div className="wk-join-space-logout">
+                    <button type="button" className="wk-join-space-logout-btn" onClick={handleLogout}>
+                        <LogOut size={14} aria-hidden="true" />
+                        <span>{t("app.joinSpace.logout")}</span>
+                    </button>
+                </div>
             </div>
             <SpaceCreate
                 visible={canCreateSpace && showCreate}

--- a/apps/web/src/Components/SpaceGate/index.css
+++ b/apps/web/src/Components/SpaceGate/index.css
@@ -1,0 +1,39 @@
+.wk-spacegate-logout {
+    margin-top: var(--wk-sp-5);
+}
+
+.wk-spacegate-logout-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wk-sp-1);
+    min-height: 30px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-base);
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: color 0.15s ease;
+}
+
+.wk-spacegate-logout-btn:hover {
+    color: var(--wk-brand-primary);
+}
+
+.wk-spacegate-logout-btn:hover span {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.wk-spacegate-logout-btn:focus-visible {
+    outline: 2px solid var(--wk-brand-primary-ring);
+    outline-offset: 2px;
+    border-radius: var(--wk-r-xs);
+}
+
+.wk-spacegate-logout-btn svg {
+    flex: 0 0 auto;
+}

--- a/apps/web/src/Components/SpaceGate/index.tsx
+++ b/apps/web/src/Components/SpaceGate/index.tsx
@@ -3,6 +3,8 @@ import { I18nContext, WKApp, t } from "@octo/base";
 import { SpaceService } from "@octo/base";
 import { Input, Button, Toast, Spin } from "@douyinfe/semi-ui";
 import { SpaceCreate } from "@octo/base";
+import { LogOut } from "lucide-react";
+import "./index.css";
 
 interface SpaceGateState {
     loading: boolean;
@@ -117,6 +119,10 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
         }
     };
 
+    logout = () => {
+        WKApp.shared.logout();
+    };
+
     render() {
         const { loading, noSpace, inviteCode, joining, showCreate, showInviteInput } = this.state;
         const { t } = this.context;
@@ -178,6 +184,12 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
                             </Button>
                         </div>
                     )}
+                    <div className="wk-spacegate-logout">
+                        <button type="button" className="wk-spacegate-logout-btn" onClick={this.logout}>
+                            <LogOut size={14} aria-hidden="true" />
+                            <span>{t("app.spaceGate.logout")}</span>
+                        </button>
+                    </div>
                 </div>
 
                 <SpaceCreate

--- a/apps/web/src/__tests__/disableUserCreateSpace.test.ts
+++ b/apps/web/src/__tests__/disableUserCreateSpace.test.ts
@@ -54,6 +54,17 @@ describe("disable_user_create_space web integration", () => {
     expect(source).toMatch(/visible=\{canCreateSpace\s*&&\s*showCreate\}/);
   });
 
+  it("keeps a logout path on the no-space welcome page", () => {
+    const source = readRepoFile("apps/web/src/Components/SpaceGate/index.tsx");
+    const zh = JSON.parse(readRepoFile("apps/web/src/i18n/zh-CN.json"));
+    const en = JSON.parse(readRepoFile("apps/web/src/i18n/en-US.json"));
+
+    expect(source).toContain("WKApp.shared.logout()");
+    expect(source).toContain('t("app.spaceGate.logout")');
+    expect(zh["spaceGate.logout"]).toBe("退出登录");
+    expect(en["spaceGate.logout"]).toBe("Log out");
+  });
+
   it("shows create-space in the no-space join page only when enabled", () => {
     const source = readRepoFile("apps/web/src/Components/JoinSpacePage/index.tsx");
 
@@ -62,6 +73,17 @@ describe("disable_user_create_space web integration", () => {
     expect(source).toContain("addConfigChangeListener");
     expect(source).toMatch(/\{canCreateSpace\s*&&\s*\(/);
     expect(source).toMatch(/visible=\{canCreateSpace\s*&&\s*showCreate\}/);
+  });
+
+  it("keeps a logout path on the no-space join page", () => {
+    const source = readRepoFile("apps/web/src/Components/JoinSpacePage/index.tsx");
+    const zh = JSON.parse(readRepoFile("apps/web/src/i18n/zh-CN.json"));
+    const en = JSON.parse(readRepoFile("apps/web/src/i18n/en-US.json"));
+
+    expect(source).toContain("WKApp.shared.logout()");
+    expect(source).toContain('t("app.joinSpace.logout")');
+    expect(zh["joinSpace.logout"]).toBe("退出登录");
+    expect(en["joinSpace.logout"]).toBe("Log out");
   });
 
   it("shows create-space in the nav space switcher only when enabled", () => {

--- a/apps/web/src/i18n/en-US.json
+++ b/apps/web/src/i18n/en-US.json
@@ -46,6 +46,7 @@
   "joinSpace.inviteInvalidOrExpired": "The invite code is invalid or expired.",
   "joinSpace.joinFailedRetry": "Failed to join. Please try again.",
   "joinSpace.joinedSpace": "Joined {{spaceName}}",
+  "joinSpace.logout": "Log out",
   "joinSpace.memberCountWithLimit": "{{count}} / {{max}} people",
   "joinSpace.reenterInvite": "Re-enter invite code",
   "joinSpace.serverTerms.alreadyMember": "已是成员",
@@ -83,6 +84,7 @@
   "spaceGate.join": "Join",
   "spaceGate.joinByInvite": "Join team with invite code",
   "spaceGate.joinedSpace": "Joined Space",
+  "spaceGate.logout": "Log out",
   "spaceGate.subtitle": "Join a team or create a new workspace",
   "spaceGate.welcome": "Welcome to {{appName}}!",
   "toast.realnameVerified": "Real-name verification completed"

--- a/apps/web/src/i18n/zh-CN.json
+++ b/apps/web/src/i18n/zh-CN.json
@@ -46,6 +46,7 @@
   "joinSpace.inviteInvalidOrExpired": "邀请码无效或已过期",
   "joinSpace.joinFailedRetry": "加入失败，请重试",
   "joinSpace.joinedSpace": "已加入 {{spaceName}}",
+  "joinSpace.logout": "退出登录",
   "joinSpace.memberCountWithLimit": "{{count}} / {{max}} 人",
   "joinSpace.reenterInvite": "重新输入邀请码",
   "joinSpace.serverTerms.alreadyMember": "已是成员",
@@ -83,6 +84,7 @@
   "spaceGate.join": "加入",
   "spaceGate.joinByInvite": "输入邀请码加入团队",
   "spaceGate.joinedSpace": "已加入 Space",
+  "spaceGate.logout": "退出登录",
   "spaceGate.subtitle": "加入团队或创建新的工作空间",
   "spaceGate.welcome": "欢迎使用 {{appName}}！",
   "toast.realnameVerified": "实名认证已完成"


### PR DESCRIPTION
## Summary
- add a logout escape path to the no-space JoinSpacePage overlay
- add the same logout path to the direct SpaceGate no-space fallback
- style the logout action as a lightweight link button and add zh-CN/en-US copy

Closes #191

## Tests
- pnpm exec vitest run apps/web/src/__tests__/disableUserCreateSpace.test.ts
- pnpm i18n:check
- git diff --check
- pnpm --filter @octo/web build