### PR TITLE
fix: refresh followed sidebar after thread creation

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -9,6 +9,12 @@ export type MittEvents = {
     groupNo: string;
     thread: import("./Service/Thread").Thread | null;
   };
+  "wk:thread-created": {
+    groupNo: string;
+    threadChannelId: string;
+    shortId?: string;
+    thread?: import("./Service/Thread").Thread;
+  };
   "wk:close-thread-panel": undefined;
   "wk:toggle-matter-panel": { channelId: string; channelType: number };
   /** v0.7 Matter 详情面板切换（跟子区/文件预览/任务列表可并存） */

--- a/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
+++ b/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
@@ -1,0 +1,211 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const hoisted = vi.hoisted(() => {
+    const state = {
+        listener: undefined as undefined | ((conversation: any, action: any) => void),
+        threadCreatedListener: undefined as undefined | ((event: any) => void),
+    }
+    const sync = vi.fn()
+    const addConversationListener = vi.fn((listener: (conversation: any, action: any) => void) => {
+        state.listener = listener
+    })
+    const removeConversationListener = vi.fn((listener: (conversation: any, action: any) => void) => {
+        if (state.listener === listener) {
+            state.listener = undefined
+        }
+    })
+    const ConversationAction = {
+        add: 1,
+        update: 2,
+        remove: 3,
+    }
+    return {
+        state,
+        sync,
+        addConversationListener,
+        removeConversationListener,
+        ConversationAction,
+        fakeWKApp: {
+            shared: {
+                currentSpaceId: "space-1",
+                deviceId: "device-1",
+            },
+            mittBus: {
+                on: vi.fn((event: string, listener: (event: any) => void) => {
+                    if (event === "wk:thread-created") {
+                        state.threadCreatedListener = listener
+                    }
+                }),
+                off: vi.fn((event: string, listener: (event: any) => void) => {
+                    if (event === "wk:thread-created" && state.threadCreatedListener === listener) {
+                        state.threadCreatedListener = undefined
+                    }
+                }),
+            },
+        },
+    }
+})
+
+vi.mock("wukongimjssdk", () => ({
+    default: {
+        shared: () => ({
+            conversationManager: {
+                addConversationListener: hoisted.addConversationListener,
+                removeConversationListener: hoisted.removeConversationListener,
+            },
+        }),
+    },
+    ConversationAction: hoisted.ConversationAction,
+    __esModule: true,
+}))
+
+vi.mock("../../App", () => ({ default: hoisted.fakeWKApp }))
+vi.mock("../../i18n", () => ({ t: (key: string) => key }))
+vi.mock("../../Service/SidebarService", () => ({
+    default: {
+        sync: hoisted.sync,
+    },
+}))
+
+import { ConversationAction } from "wukongimjssdk"
+import { useFollowSidebar } from "../useFollowSidebar"
+
+const groupItem = {
+    target_type: 2,
+    target_id: "group-a",
+    channel_type: 2,
+    channel_id: "group-a",
+    timestamp: 10,
+    unread: 0,
+    is_pinned: false,
+    is_followed: true,
+    category_id: "cat-a",
+    follow_sort: 1,
+}
+
+const threadItem = {
+    target_type: 5,
+    target_id: "group-a____thread-1",
+    channel_type: 5,
+    channel_id: "group-a____thread-1",
+    timestamp: 11,
+    unread: 1,
+    is_pinned: false,
+    is_followed: true,
+    category_id: "cat-a",
+    follow_sort: 2,
+    parent_channel_id: "group-a",
+}
+
+function Probe({ onValue }: { onValue: (value: ReturnType<typeof useFollowSidebar>) => void }) {
+    const value = useFollowSidebar()
+    onValue(value)
+    return null
+}
+
+async function flushMicrotasks() {
+    await Promise.resolve()
+    await Promise.resolve()
+}
+
+describe("useFollowSidebar", () => {
+    let container: HTMLDivElement
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        hoisted.state.listener = undefined
+        hoisted.state.threadCreatedListener = undefined
+        hoisted.sync.mockReset()
+        hoisted.addConversationListener.mockClear()
+        hoisted.removeConversationListener.mockClear()
+        hoisted.fakeWKApp.mittBus.on.mockClear()
+        hoisted.fakeWKApp.mittBus.off.mockClear()
+        container = document.createElement("div")
+        document.body.appendChild(container)
+    })
+
+    afterEach(() => {
+        act(() => {
+            ReactDOM.unmountComponentAtNode(container)
+        })
+        container.remove()
+        vi.useRealTimers()
+    })
+
+    it("refreshes the followed sidebar when a new thread conversation arrives under a followed group", async () => {
+        let latest: ReturnType<typeof useFollowSidebar> | undefined
+        hoisted.sync
+            .mockResolvedValueOnce({ items: [groupItem], follow_version: 1, version: 1 })
+            .mockResolvedValueOnce({ items: [groupItem, threadItem], follow_version: 2, version: 2 })
+
+        await act(async () => {
+            ReactDOM.render(<Probe onValue={(value) => { latest = value }} />, container)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(1)
+        expect(latest?.followedGroupNos.has("group-a")).toBe(true)
+        expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(false)
+        expect(hoisted.addConversationListener).toHaveBeenCalledTimes(1)
+
+        act(() => {
+            hoisted.state.listener?.({
+                channel: {
+                    channelID: "group-a____thread-1",
+                    channelType: 5,
+                },
+            }, ConversationAction.add)
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            vi.advanceTimersByTime(300)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(2)
+        expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(true)
+        expect(latest?.itemsByCategory.get("cat-a")?.map((it) => it.target_id))
+            .toEqual(["group-a", "group-a____thread-1"])
+    })
+
+    it("refreshes the followed sidebar when a thread is created under a followed group", async () => {
+        let latest: ReturnType<typeof useFollowSidebar> | undefined
+        hoisted.sync
+            .mockResolvedValueOnce({ items: [groupItem], follow_version: 1, version: 1 })
+            .mockResolvedValueOnce({ items: [groupItem, threadItem], follow_version: 2, version: 2 })
+
+        await act(async () => {
+            ReactDOM.render(<Probe onValue={(value) => { latest = value }} />, container)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.fakeWKApp.mittBus.on).toHaveBeenCalledWith(
+            "wk:thread-created",
+            expect.any(Function)
+        )
+        expect(latest?.followedGroupNos.has("group-a")).toBe(true)
+
+        act(() => {
+            hoisted.state.threadCreatedListener?.({
+                groupNo: "group-a",
+                threadChannelId: "group-a____thread-1",
+                shortId: "thread-1",
+            })
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            vi.advanceTimersByTime(300)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(2)
+        expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(true)
+    })
+})

--- a/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
+++ b/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
@@ -1,7 +1,10 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import WKSDK, { ConversationAction, type Conversation, type ConversationListener } from "wukongimjssdk"
 import WKApp from "../App"
 import { t } from "../i18n"
+import { ChannelTypeCommunityTopic } from "../Service/Const"
 import SidebarService, { SidebarItem } from "../Service/SidebarService"
+import { buildThreadChannelId, parseThreadChannelId } from "../Service/Thread"
 
 export interface UseFollowSidebarResult {
     /** 已关注的 sidebar items（target_type 全集，is_followed=true 由后端保证） */
@@ -37,6 +40,29 @@ export interface UseFollowSidebarResult {
 }
 
 const NULL_CATEGORY = ""
+const THREAD_SIDEBAR_RELOAD_DELAYS_MS = [300, 1000, 2000]
+type LoadOptions = { silent?: boolean }
+
+export function shouldReloadFollowSidebarForThreadConversation(args: {
+    conversation?: Conversation | null
+    action: ConversationAction
+    followedKeys: Set<string>
+    followedGroupNos: Set<string>
+    requestedThreadIds: Set<string>
+}): boolean {
+    const { conversation, action, followedKeys, followedGroupNos, requestedThreadIds } = args
+    if (action !== ConversationAction.add && action !== ConversationAction.update) return false
+    const channel = conversation?.channel
+    if (!channel || channel.channelType !== ChannelTypeCommunityTopic) return false
+    if (!channel.channelID || requestedThreadIds.has(channel.channelID)) return false
+
+    const threadKey = `${ChannelTypeCommunityTopic}::${channel.channelID}`
+    if (followedKeys.has(threadKey)) return false
+
+    const parentGroupNo = conversation?.channelInfo?.orgData?.parentGroupNo
+        || parseThreadChannelId(channel.channelID)?.groupNo
+    return !!parentGroupNo && followedGroupNos.has(parentGroupNo)
+}
 
 /**
  * 拉取关注 tab 的 sidebar items，并按 category_id 分桶。
@@ -57,11 +83,18 @@ export function useFollowSidebar(): UseFollowSidebarResult {
     // 与 followVersion state 同步的 ref：消费者通过 ref 读到的永远是最新值，
     // 不受 React 渲染节奏 / useCallback 闭包过期影响。
     const versionRef = useRef<number>(0)
+    const followedKeysRef = useRef<Set<string>>(new Set())
+    const followedGroupNosRef = useRef<Set<string>>(new Set())
+    const requestedThreadReloadsRef = useRef<Set<string>>(new Set())
+    const threadReloadTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
 
-    const load = useCallback(async () => {
+    const load = useCallback(async (options: LoadOptions = {}) => {
         if (!spaceId) return
-        setIsLoading(true)
-        setError(null)
+        const silent = options.silent === true
+        if (!silent) {
+            setIsLoading(true)
+            setError(null)
+        }
         try {
             const resp = await SidebarService.sync({
                 tab: "follow",
@@ -72,15 +105,106 @@ export function useFollowSidebar(): UseFollowSidebarResult {
             setFollowVersion(v)
             versionRef.current = v
         } catch (e: any) {
-            setError(e?.message || t("base.followSidebar.loadFailed"))
+            if (!silent) {
+                setError(e?.message || t("base.followSidebar.loadFailed"))
+            }
         } finally {
-            setIsLoading(false)
+            if (!silent) {
+                setIsLoading(false)
+            }
         }
     }, [spaceId])
 
     useEffect(() => {
         load()
     }, [load])
+
+    useEffect(() => {
+        requestedThreadReloadsRef.current.clear()
+        for (const timer of threadReloadTimersRef.current) {
+            clearTimeout(timer)
+        }
+        threadReloadTimersRef.current.clear()
+    }, [spaceId])
+
+    const scheduleThreadReload = useCallback((threadChannelId?: string | null) => {
+        if (!threadChannelId) return
+
+        const threadKey = `${ChannelTypeCommunityTopic}::${threadChannelId}`
+        if (followedKeysRef.current.has(threadKey)) return
+        if (requestedThreadReloadsRef.current.has(threadChannelId)) return
+
+        requestedThreadReloadsRef.current.add(threadChannelId)
+        THREAD_SIDEBAR_RELOAD_DELAYS_MS.forEach((delay, index) => {
+            const timer = setTimeout(() => {
+                threadReloadTimersRef.current.delete(timer)
+                if (followedKeysRef.current.has(threadKey)) {
+                    requestedThreadReloadsRef.current.delete(threadChannelId)
+                    return
+                }
+
+                void load({ silent: true }).finally(() => {
+                    if (index === THREAD_SIDEBAR_RELOAD_DELAYS_MS.length - 1) {
+                        requestedThreadReloadsRef.current.delete(threadChannelId)
+                    }
+                })
+            }, delay)
+            threadReloadTimersRef.current.add(timer)
+        })
+    }, [load])
+
+    useEffect(() => {
+        const conversationManager = WKSDK.shared().conversationManager
+        if (!conversationManager?.addConversationListener) return
+
+        const listener: ConversationListener = (conversation: Conversation, action: ConversationAction) => {
+            if (!shouldReloadFollowSidebarForThreadConversation({
+                conversation,
+                action,
+                followedKeys: followedKeysRef.current,
+                followedGroupNos: followedGroupNosRef.current,
+                requestedThreadIds: requestedThreadReloadsRef.current,
+            })) {
+                return
+            }
+
+            scheduleThreadReload(conversation.channel.channelID)
+        }
+
+        conversationManager.addConversationListener(listener)
+        return () => {
+            conversationManager.removeConversationListener?.(listener)
+            for (const timer of threadReloadTimersRef.current) {
+                clearTimeout(timer)
+            }
+            threadReloadTimersRef.current.clear()
+        }
+    }, [scheduleThreadReload])
+
+    useEffect(() => {
+        const listener = (event: {
+            groupNo: string
+            threadChannelId: string
+            shortId?: string
+            thread?: { channel_id?: string }
+        }) => {
+            if (!event?.groupNo) return
+
+            const threadChannelId = event.threadChannelId
+                || event.thread?.channel_id
+                || (event.shortId ? buildThreadChannelId(event.groupNo, event.shortId) : undefined)
+            scheduleThreadReload(threadChannelId)
+        }
+
+        WKApp.mittBus.on("wk:thread-created", listener)
+        return () => {
+            WKApp.mittBus.off("wk:thread-created", listener)
+            for (const timer of threadReloadTimersRef.current) {
+                clearTimeout(timer)
+            }
+            threadReloadTimersRef.current.clear()
+        }
+    }, [scheduleThreadReload])
 
     // sort 成功后调，乐观自增 ref，避免连续拖拽用旧版本号触发 CAS conflict
     const bumpVersion = useCallback(() => {
@@ -141,6 +265,8 @@ export function useFollowSidebar(): UseFollowSidebarResult {
             followedGroupNos.add(it.target_id)
         }
     }
+    followedKeysRef.current = followedKeys
+    followedGroupNosRef.current = followedGroupNos
     // 每个 category 内按 follow_sort ASC 排，覆盖 sidebar 响应里的 pinned DESC 拆段。
     // PM #337 spec 是用户主导的统一排序，pinned 只是标记不影响位置 —— 后端响应仍按
     // (pinned DESC, follow_sort ASC) 多键排，前端这里按 follow_sort 一锤定音。

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -872,6 +872,13 @@ export default class BaseModule implements IModule {
                   );
                   Toast.success(t("base.module.createThread.success"));
                   if (resp && resp.channel_id) {
+                    WKApp.mittBus.emit("wk:thread-created", {
+                      groupNo: message.channel.channelID,
+                      shortId:
+                        resp.short_id ||
+                        parseThreadChannelId(resp.channel_id)?.shortId,
+                      threadChannelId: resp.channel_id,
+                    });
                     const channel = new Channel(
                       resp.channel_id,
                       ChannelTypeCommunityTopic

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -224,7 +224,14 @@ export class ChannelDataSource implements IChannelDataSource {
             body.source_message_id = sourceMessageId
         }
         const resp = await WKApp.apiClient.post(`groups/${groupNo}/threads`, body)
-        return this.toThread(resp, groupNo)
+        const thread = this.toThread(resp, groupNo)
+        WKApp.mittBus.emit("wk:thread-created", {
+            groupNo,
+            shortId: thread.short_id,
+            threadChannelId: thread.channel_id,
+            thread,
+        })
+        return thread
     }
 
     async threadGet(groupNo: string, shortId: string): Promise<Thread> {


### PR DESCRIPTION
## Summary
- emit a thread-created domain event after successful thread creation
- refresh the followed sidebar from /sidebar/sync with short silent retries
- keep SDK conversation updates as a fallback trigger

## Tests
- pnpm --filter @octo/base exec vitest run src/Hooks/__tests__/useFollowSidebar.test.tsx src/Pages/Chat/__tests__/vm.sortConversations.test.ts

Fixes #127