### PR TITLE
fix: unify message multiselect behavior

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.tsx
@@ -163,7 +163,14 @@ const FoldSessionCard: React.FC<FoldSessionCardProps> = ({
             highlightSummary && "wk-fold-session-card-summary-highlight"
           )}
           onAnimationEnd={onSummaryAnimationEnd}
-          onContextMenu={selectionMode ? undefined : onSummaryContextMenu}
+          onContextMenu={
+            selectionMode
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              : onSummaryContextMenu
+          }
         >
           <div
             className={classNames(
@@ -210,8 +217,7 @@ const FoldSessionCard: React.FC<FoldSessionCardProps> = ({
             <div
               className="wk-fold-session-card-summary-main"
               style={{
-                pointerEvents:
-                  selectionMode && summarySelectable ? "none" : undefined,
+                pointerEvents: selectionMode ? "none" : undefined,
               }}
             >
               {/* 折叠状态显示完整消息:姓名tag + 时间 + 内容 */}

--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionExpandedList.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionExpandedList.tsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import { Message } from "wukongimjssdk";
 import { MessageWrap } from "../../Service/Model";
 import Checkbox from "../Checkbox";
+import { isMessageSelectable } from "../../Service/messageSelection";
 
 interface FoldSessionExpandedListProps {
   messages: MessageWrap[];
@@ -30,19 +31,22 @@ const FoldSessionExpandedList: React.FC<FoldSessionExpandedListProps> = ({
       {messages.map((message) => {
         const senderName = message.from?.title || message.fromUID;
         const timeStr = moment(message.timestamp * 1000).format("HH:mm");
+        const selectable = isMessageSelectable(message);
         return (
           <div
             key={message.clientMsgNo}
             className={classNames(
               "wk-fold-msg",
               editMode && "wk-fold-msg-check-open",
-              message.checked && "wk-fold-msg-selected"
+              selectable && message.checked && "wk-fold-msg-selected"
             )}
             data-testid={`fold-msg-${message.clientMsgNo}`}
             onClick={
               editMode
                 ? () => {
-                    onToggleSelect(message.message, !message.checked);
+                    if (selectable) {
+                      onToggleSelect(message.message, !message.checked);
+                    }
                   }
                 : undefined
             }
@@ -54,7 +58,7 @@ const FoldSessionExpandedList: React.FC<FoldSessionExpandedListProps> = ({
               onMessageContextMenu(message.message, event);
             }}
           >
-            {editMode ? (
+            {editMode && selectable ? (
               <div
                 className="wk-fold-msg-check"
                 onClick={(event) => {

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -79,6 +79,7 @@ import { parseThreadChannelId } from "../../Service/Thread";
 import FoldSessionExpandedList from "./FoldSessionExpandedList";
 import VoiceFeedback from "../../Service/VoiceFeedback";
 import { precheckUploadCredentials } from "../../Service/UploadCredentials";
+import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext, t } from "../../i18n";
 
 /**
@@ -656,7 +657,7 @@ export class Conversation
   }
   setEditOn(edit: boolean): void {
     this.vm.editOn = edit;
-    if (this.vm.selectMessage && edit) {
+    if (this.vm.selectMessage && edit && isMessageSelectable(this.vm.selectMessage)) {
       this.vm.checkedMessage(this.vm.selectMessage, true);
     }
   }
@@ -1313,8 +1314,7 @@ export class Conversation
     const { showSummary, summaryId, summaryMessage } =
       getFoldSessionSummaryState(session);
     const summarySelectable =
-      showSummary &&
-      summaryMessage.contentType !== MessageContentTypeConst.typing;
+      showSummary && isMessageSelectable(summaryMessage);
     const typingSender =
       summaryMessage.contentType === MessageContentTypeConst.typing
         ? (summaryMessage.content as { fromName?: string })?.fromName

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -20,6 +20,7 @@ import { getFoldSessionExpandedMessages } from "./foldSessionSummary";
 import { getPulldownRestoredScrollTop } from "./historyScroll";
 import { applyMsgLevelExternalFieldsWithFallback } from "../../Service/Convert";
 import { wrapSendContentForInjection } from "./sendContentProxy";
+import { isMessageSelectable } from "../../Service/messageSelection";
 
 export interface FoldSessionParticipant {
     uid: string
@@ -240,6 +241,9 @@ export default class ConversationVM extends ProviderListener {
 
     // 选中消息
     checkedMessage(message: Message, checked: boolean): void {
+        if (checked && !isMessageSelectable(message)) {
+            return
+        }
         let messageWrap = this.findMessageWithClientMsgNo(message.clientMsgNo)
         if (!messageWrap) {
             return
@@ -251,7 +255,7 @@ export default class ConversationVM extends ProviderListener {
     // 获取被选中的消息列表
     getCheckedMessages() {
         return this.messages.filter((m) => {
-            return m.checked
+            return m.checked && isMessageSelectable(m)
         })
     }
 

--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -35,6 +35,7 @@ import ThreadIndicator, {
   ThreadIndicatorData,
 } from "../../Components/ThreadIndicator";
 import { isMessageContinuation } from "../../Service/messageContinuity";
+import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext } from "../../i18n";
 
 interface MessageBaseProps extends HTMLProps<any> {
@@ -365,6 +366,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     const showHead = this.needHead();
     const showAvatar = this.needAvatar();
     const timeStr = moment(message.timestamp * 1000).format("HH:mm");
+    const selectionMode = context.editOn();
+    const selectable = isMessageSelectable(message);
 
     // 外部群成员来源标记：按当前查看 Space 相对渲染。
     // 优先读 msg-level 新字段 from_home_space_id / from_home_space_name；
@@ -440,22 +443,24 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
       <div
         className={classNames(
           "wk-message-base",
-          context.editOn() ? "wk-message-base-check-open" : undefined
+          selectionMode && selectable ? "wk-message-base-check-open" : undefined
         )}
         onClick={
-          context.editOn()
-            ? (event) => {
-                context.checkeMessage(message.message, !message.checked);
+          selectionMode
+            ? () => {
+                if (selectable) {
+                  context.checkeMessage(message.message, !message.checked);
+                }
               }
             : undefined
         }
       >
-        {context.editOn() ? (
+        {selectionMode && selectable ? (
           <div
             className="wk-message-base-checkBox"
             style={{ marginBottom: messageStyle.marginBottom }}
           >
-            <Checkbox checked={message.checked} />
+            <Checkbox checked={selectable && message.checked} />
           </div>
         ) : null}
         <div
@@ -466,7 +471,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
         >
           <div
             className={"wk-message-base-box"}
-            style={{ pointerEvents: context.editOn() ? "none" : undefined }}
+            style={{ pointerEvents: selectionMode ? "none" : undefined }}
           >
             {message.send && message.status === MessageStatus.Fail ? (
               <Popconfirm

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -11,6 +11,7 @@ import WKModal from "../../Components/WKModal";
 import MarkdownContent from "../Text/MarkdownContent";
 import MessageRow from "../../ui/message/MessageRow";
 import { getFileMessageUI } from "../../bridge/message/useFileMessageUI";
+import { isMessageSelectable } from "../../Service/messageSelection";
 import { isSafeUrl } from "../../Utils/security";
 import { I18nContext } from "../../i18n";
 
@@ -608,6 +609,8 @@ export class FileCell extends MessageCell<any, FileCellState> {
     }
 
     const uiProps = getFileMessageUI(message);
+    const selectionMode = context.editOn();
+    const selectable = isMessageSelectable(message);
     // 检查是否为当前正在预览的文件
     const isActive =
       context.getActivePreviewMessageId?.() === message.messageID;
@@ -618,10 +621,12 @@ export class FileCell extends MessageCell<any, FileCellState> {
           {...uiProps.row}
           onContextMenu={(event) => context.showContextMenus(message, event)}
           isActive={context.isContextMenuOpen(message.message)}
-          showCheckbox={context.editOn()}
-          isSelected={!!message.checked}
-          onSelect={(selected) =>
-            context.checkeMessage(message.message, selected)
+          selectionMode={selectionMode}
+          showCheckbox={selectionMode && selectable}
+          isSelected={selectable && !!message.checked}
+          onSelect={selectable
+            ? (selected) => context.checkeMessage(message.message, selected)
+            : undefined
           }
           onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
           onSenderNameClick={() => context.showUser(message.fromUID)}

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -14,6 +14,7 @@ import SingleImage from "../../ui/message/ImageContent/SingleImage"
 import MultiImage from "../../ui/message/ImageContent/MultiImage"
 import type { ImageTransferState } from "../../ui/message/ImageContent/SingleImage"
 import { getImageMessageUI } from "../../bridge/message/useImageMessageUI"
+import { isMessageSelectable } from "../../Service/messageSelection"
 import { t } from "../../i18n"
 
 const SMALL_FILE_THRESHOLD = 1024 * 1024 // 1MB 以下不显示进度覆盖层
@@ -235,16 +236,20 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                 onUploadRetry: this.handleRetry,
                 onMessageRetry: () => context.resendMessage(message.message),
             })
+            const selectionMode = context.editOn()
+            const selectable = isMessageSelectable(message)
             const canPreview = !transferState && hasRemoteUrl
+            const canOpenPreview = canPreview && !selectionMode
             return (
                 <>
                     <MessageRow
                         {...uiProps.row}
                         onContextMenu={(event) => context.showContextMenus(message, event)}
                         isActive={context.isContextMenuOpen(message.message)}
-                        showCheckbox={context.editOn()}
-                        isSelected={!!message.checked}
-                        onSelect={(selected) => context.checkeMessage(message.message, selected)}
+                        selectionMode={selectionMode}
+                        showCheckbox={selectionMode && selectable}
+                        isSelected={selectable && !!message.checked}
+                        onSelect={selectable ? (selected) => context.checkeMessage(message.message, selected) : undefined}
                         onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
                         onSenderNameClick={() => context.showUser(message.fromUID)}
                     >
@@ -252,15 +257,15 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                             ? <MultiImage
                                 images={uiProps.images}
                                 transferState={transferState}
-                                onImageClick={(index) => {
+                                onImageClick={canOpenPreview ? (index) => {
                                     // TODO: 多图预览
-                                }}
+                                } : undefined}
                               />
                             : uiProps.singleImage
                                 ? <SingleImage
                                     {...uiProps.singleImage}
                                     transferState={transferState}
-                                    onClick={canPreview ? () => this.setState({ showPreview: true }) : undefined}
+                                    onClick={canOpenPreview ? () => this.setState({ showPreview: true }) : undefined}
                                   />
                                 : null
                         }

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
@@ -14,6 +14,7 @@ import React from "react";
 import MergeforwardMessageList from "../../Components/MergeforwardMessageList";
 import { MessageContentTypeConst } from "../../Service/Const";
 import { applyMsgLevelExternalFields } from "../../Service/Convert";
+import { isMessageSelectable } from "../../Service/messageSelection";
 import MessageBase from "../Base";
 import MessageTrail from "../Base/tail";
 import { MessageCell } from "../MessageCell";
@@ -304,11 +305,15 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
 
     // 新 UI 实现
     if (useNewUI) {
+      const selectionMode = context.editOn();
+      const selectable = isMessageSelectable(message);
       const uiProps = getMergeforwardMessageUI(message, {
-        showCheckbox: context.editOn(),
-        isSelected: !!message.checked,
-        onSelect: (selected) =>
-          context.checkeMessage(message.message, selected),
+        selectionMode,
+        showCheckbox: selectionMode && selectable,
+        isSelected: selectable && !!message.checked,
+        onSelect: selectable
+          ? (selected) => context.checkeMessage(message.message, selected)
+          : undefined,
       });
       return (
         <>
@@ -316,11 +321,6 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
             {...uiProps.row}
             onContextMenu={(event) => context.showContextMenus(message, event)}
             isActive={context.isContextMenuOpen(message.message)}
-            onClick={
-              context.editOn()
-                ? () => context.checkeMessage(message.message, !message.checked)
-                : undefined
-            }
             onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
             onSenderNameClick={() => context.showUser(message.fromUID)}
           >

--- a/packages/dmworkbase/src/Messages/Text/index.tsx
+++ b/packages/dmworkbase/src/Messages/Text/index.tsx
@@ -12,6 +12,7 @@ import MessageRow from "../../ui/message/MessageRow"
 import ReplyBlock from "../../ui/message/ReplyBlock";
 import TextContent from "../../ui/message/TextContent";
 import { getTextMessageUI } from "../../bridge/message/useTextMessageUI";
+import { isMessageSelectable } from "../../Service/messageSelection";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import "./index.css"
 
@@ -175,10 +176,13 @@ export class TextCell extends MessageCell {
 
         // 新 UI 实现
         if (useNewUI) {
+            const selectionMode = context.editOn()
+            const selectable = isMessageSelectable(message)
             const uiProps = getTextMessageUI(message, {
-                showCheckbox: context.editOn(),
-                isSelected: !!message.checked,
-                onSelect: (selected) => context.checkeMessage(message.message, selected),
+                selectionMode,
+                showCheckbox: selectionMode && selectable,
+                isSelected: selectable && !!message.checked,
+                onSelect: selectable ? (selected) => context.checkeMessage(message.message, selected) : undefined,
             })
 
             return (
@@ -186,7 +190,6 @@ export class TextCell extends MessageCell {
                     {...uiProps.row}
                     onContextMenu={(event) => context.showContextMenus(message, event)}
                     isActive={context.isContextMenuOpen(message.message)}
-                    onClick={context.editOn() ? () => context.checkeMessage(message.message, !message.checked) : undefined}
                     onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
                     onSenderNameClick={() => context.showUser(message.fromUID)}
                 >

--- a/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
+++ b/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
@@ -102,7 +102,7 @@ export class ThreadCreatedCell extends MessageCell {
   }
 
   render() {
-    const { message } = this.props
+    const { message, context } = this.props
     const content = message.content as ThreadCreatedContent
     const messageCount = content.message_count || 0
     const timeStr = content.last_message
@@ -132,10 +132,11 @@ export class ThreadCreatedCell extends MessageCell {
     return (
       <MessageRow 
         {...rowProps}
-        onContextMenu={(event) => this.props.context.showContextMenus(message, event)}
-        isActive={this.props.context.isContextMenuOpen(message.message)}
-        onAvatarClick={(e) => this.props.context.onTapAvatar(content.from_uid || message.fromUID, e)}
-        onSenderNameClick={() => this.props.context.showUser(content.from_uid || message.fromUID)}
+        selectionMode={context.editOn()}
+        onContextMenu={(event) => context.showContextMenus(message, event)}
+        isActive={context.isContextMenuOpen(message.message)}
+        onAvatarClick={(e) => context.onTapAvatar(content.from_uid || message.fromUID, e)}
+        onSenderNameClick={() => context.showUser(content.from_uid || message.fromUID)}
       >
         <div className="wk-thread-created-card" onClick={this.handleClick}>
         {/* 消息正文预览 */}

--- a/packages/dmworkbase/src/Messages/Video/index.tsx
+++ b/packages/dmworkbase/src/Messages/Video/index.tsx
@@ -7,6 +7,7 @@ import { MessageCell } from "../MessageCell";
 import MessageRow from "../../ui/message/MessageRow";
 import VideoContentUI from "../../ui/message/VideoContent"
 import { getMessageRow } from "../../bridge/message/useMessageRow"
+import { isMessageSelectable } from "../../Service/messageSelection"
 import { I18nContext, t } from "../../i18n"
 import "./index.css"
 
@@ -140,6 +141,8 @@ export class VideoCell extends MessageCell<any, VideoCellState> {
         const useNewUI = true
         if (useNewUI) {
             const rowProps = getMessageRow(message)
+            const selectionMode = context.editOn()
+            const selectable = isMessageSelectable(message)
             const src = WKApp.dataSource.commonDataSource.getFileURL(content.url)
             const coverSrc = WKApp.dataSource.commonDataSource.getImageURL(content.cover)
             const isUploading =
@@ -154,9 +157,10 @@ export class VideoCell extends MessageCell<any, VideoCellState> {
                     {...rowProps}
                     onContextMenu={(event) => context.showContextMenus(message, event)}
                     isActive={context.isContextMenuOpen(message.message)}
-                    showCheckbox={context.editOn()}
-                    isSelected={!!message.checked}
-                    onSelect={(selected) => context.checkeMessage(message.message, selected)}
+                    selectionMode={selectionMode}
+                    showCheckbox={selectionMode && selectable}
+                    isSelected={selectable && !!message.checked}
+                    onSelect={selectable ? (selected) => context.checkeMessage(message.message, selected) : undefined}
                     onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
                     onSenderNameClick={() => context.showUser(message.fromUID)}
                 >

--- a/packages/dmworkbase/src/Service/__tests__/messageSelection.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageSelection.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { MessageContentType } from "wukongimjssdk"
+import { MessageContentTypeConst } from "../Const"
+import { isMessageSelectable } from "../messageSelection"
+
+describe("isMessageSelectable", () => {
+  it("allows normal user message types", () => {
+    expect(isMessageSelectable({ contentType: MessageContentType.text })).toBe(true)
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.image })).toBe(true)
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.file })).toBe(true)
+  })
+
+  it("rejects non-selectable timeline and thread-created message types", () => {
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.time })).toBe(false)
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.historySplit })).toBe(false)
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.typing })).toBe(false)
+    expect(isMessageSelectable({ contentType: MessageContentTypeConst.threadCreated })).toBe(false)
+  })
+
+  it("rejects missing messages defensively", () => {
+    expect(isMessageSelectable(undefined)).toBe(false)
+    expect(isMessageSelectable({})).toBe(false)
+  })
+})

--- a/packages/dmworkbase/src/Service/messageSelection.ts
+++ b/packages/dmworkbase/src/Service/messageSelection.ts
@@ -1,0 +1,19 @@
+import { MessageContentTypeConst } from "./Const"
+
+export interface SelectableMessageLike {
+  contentType?: number
+}
+
+const UNSELECTABLE_MESSAGE_TYPES = new Set<number>([
+  MessageContentTypeConst.time,
+  MessageContentTypeConst.historySplit,
+  MessageContentTypeConst.typing,
+  MessageContentTypeConst.threadCreated,
+])
+
+export function isMessageSelectable(message?: SelectableMessageLike | null): boolean {
+  if (!message || typeof message.contentType !== "number") {
+    return false
+  }
+  return !UNSELECTABLE_MESSAGE_TYPES.has(message.contentType)
+}

--- a/packages/dmworkbase/src/bridge/message/types.ts
+++ b/packages/dmworkbase/src/bridge/message/types.ts
@@ -45,8 +45,11 @@ export interface MessageRowUIProps {
   /** 选择状态变化回调 */
   onSelect?: (selected: boolean) => void
 
-  /** 是否显示多选 Checkbox（多选模式时为 true） */
+  /** 当前消息是否显示多选 Checkbox */
   showCheckbox?: boolean
+
+  /** 当前是否处于多选模式（当前消息不可选时也可为 true） */
+  selectionMode?: boolean
 
   /** 头像点击回调（私聊场景：点头像打开私聊） */
   onAvatarClick?: (e: React.MouseEvent) => void

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -11,7 +11,9 @@ import { isMessageContinuation } from '../../Service/messageContinuity'
 import { t } from '../../i18n'
 
 export interface MessageRowSelectionState {
-  /** 是否处于多选模式（来自 context.editOn()） */
+  /** 当前会话是否处于多选模式（不可选消息也需要知道，用于禁用行内操作） */
+  selectionMode?: boolean
+  /** 当前消息是否显示多选 Checkbox */
   showCheckbox: boolean
   /** 当前消息是否被选中（来自 message.checked） */
   isSelected: boolean
@@ -194,6 +196,7 @@ export function getMessageRow(
     isContinue,
     isSelected: selection?.isSelected ?? false,
     showCheckbox: selection?.showCheckbox ?? false,
+    selectionMode: selection?.selectionMode ?? selection?.showCheckbox ?? false,
     showAvatar: !isContinue,
     avatarUrl: WKApp.shared.avatarUser(message.fromUID),
     // self 气泡名字走 loginInfo.selfDisplayName() —— 已实名时

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -85,6 +85,7 @@ import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
 import APIClient from "./Service/APIClient";
 import { patchSdkDecodeForExternalFields } from "./Service/Convert";
+import { isMessageSelectable } from "./Service/messageSelection";
 import ConversationVM from "./Components/Conversation/vm";
 import { ChannelAvatar } from "./Components/ChannelAvatar";
 import { ScreenshotCell, ScreenshotContent } from "./Messages/Screenshot";
@@ -723,6 +724,9 @@ export default class BaseModule implements IModule {
     WKApp.endpoints.registerMessageContextMenus(
       "contextmenus.muli",
       (message, context) => {
+        if (!isMessageSelectable(message)) {
+          return null;
+        }
         return {
           title: t("base.module.contextMenus.multiSelect"),
           onClick: () => {

--- a/packages/dmworkbase/src/ui/message/ImageContent/MultiImage.tsx
+++ b/packages/dmworkbase/src/ui/message/ImageContent/MultiImage.tsx
@@ -44,7 +44,7 @@ export default function MultiImage({
           width={img.width}
           height={img.height}
           transferState={img.transferState || transferState}
-          onClick={() => onImageClick?.(index)}
+          onClick={onImageClick ? () => onImageClick(index) : undefined}
         />
       ))}
     </div>

--- a/packages/dmworkbase/src/ui/message/Message/index.tsx
+++ b/packages/dmworkbase/src/ui/message/Message/index.tsx
@@ -75,6 +75,7 @@ export default function Message({
     <MessageRow
       {...row}
       isSelected={isSelected}
+      selectionMode={selectionMode}
       showCheckbox={selectionMode}
       onSelect={onSelect}
     >

--- a/packages/dmworkbase/src/ui/message/MessageRow/__tests__/MessageRow.test.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/__tests__/MessageRow.test.tsx
@@ -1,7 +1,175 @@
+// @vitest-environment jsdom
+
 import React from "react"
+import ReactDOM from "react-dom"
 import { renderToStaticMarkup } from "react-dom/server"
-import { describe, it, expect } from "vitest"
+import { act } from "react-dom/test-utils"
+import { afterEach, describe, it, expect, vi } from "vitest"
+
+vi.mock("../../../../i18n", () => ({
+    useI18n: () => ({
+        t: (key: string) => {
+            const messages: Record<string, string> = {
+                "base.message.avatar.alt": "Avatar",
+                "base.message.edited": "已编辑",
+                "base.realnameVerified.title": "已完成实名认证",
+                "base.realnameVerified.label": "已实名",
+            }
+            return messages[key] ?? key
+        },
+    }),
+}))
+
 import MessageRow from "../index"
+
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+    if (!container) return
+    ReactDOM.unmountComponentAtNode(container)
+    container.remove()
+    container = null
+})
+
+function renderRow(element: React.ReactElement) {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    act(() => {
+        ReactDOM.render(element, container)
+    })
+    return container
+}
+
+function dispatchMouseEvent(element: Element, type: string) {
+    const event = new MouseEvent(type, { bubbles: true, cancelable: true })
+    act(() => {
+        element.dispatchEvent(event)
+    })
+    return event
+}
+
+describe("MessageRow — selection mode interactions", () => {
+    const baseProps = {
+        isSend: false,
+        isContinue: false,
+        isSelected: false,
+        showAvatar: true,
+        avatarUrl: "https://example.test/avatar.png",
+        senderName: "yujiawei",
+        timestamp: "10:30",
+    }
+
+    it("turns row clicks into selection and suppresses row-specific actions while selecting", () => {
+        const onSelect = vi.fn()
+        const onClick = vi.fn()
+        const onContextMenu = vi.fn()
+        const onAvatarClick = vi.fn()
+        const onSenderNameClick = vi.fn()
+
+        const root = renderRow(
+            <MessageRow
+                {...baseProps}
+                showCheckbox={true}
+                onSelect={onSelect}
+                onClick={onClick}
+                onContextMenu={onContextMenu}
+                onAvatarClick={onAvatarClick}
+                onSenderNameClick={onSenderNameClick}
+            >
+                <button type="button">open</button>
+            </MessageRow>
+        )
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "click")
+        expect(onSelect).toHaveBeenLastCalledWith(true)
+        expect(onClick).not.toHaveBeenCalled()
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-avatar")!, "click")
+        expect(onAvatarClick).not.toHaveBeenCalled()
+        expect(onSelect).toHaveBeenCalledTimes(2)
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row-sender")!, "click")
+        expect(onSenderNameClick).not.toHaveBeenCalled()
+        expect(onSelect).toHaveBeenCalledTimes(3)
+
+        const contextMenuEvent = dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "contextmenu")
+        expect(onContextMenu).not.toHaveBeenCalled()
+        expect(contextMenuEvent.defaultPrevented).toBe(true)
+    })
+
+    it("suppresses row-specific actions for unselectable rows while selection mode is active", () => {
+        const onSelect = vi.fn()
+        const onClick = vi.fn()
+        const onContextMenu = vi.fn()
+        const onAvatarClick = vi.fn()
+        const onSenderNameClick = vi.fn()
+
+        const root = renderRow(
+            <MessageRow
+                {...baseProps}
+                selectionMode={true}
+                showCheckbox={false}
+                onSelect={onSelect}
+                onClick={onClick}
+                onContextMenu={onContextMenu}
+                onAvatarClick={onAvatarClick}
+                onSenderNameClick={onSenderNameClick}
+            >
+                <button type="button">open</button>
+            </MessageRow>
+        )
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "click")
+        expect(onSelect).not.toHaveBeenCalled()
+        expect(onClick).not.toHaveBeenCalled()
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-avatar")!, "click")
+        expect(onAvatarClick).not.toHaveBeenCalled()
+        expect(onSelect).not.toHaveBeenCalled()
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row-sender")!, "click")
+        expect(onSenderNameClick).not.toHaveBeenCalled()
+        expect(onSelect).not.toHaveBeenCalled()
+
+        const contextMenuEvent = dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "contextmenu")
+        expect(onContextMenu).not.toHaveBeenCalled()
+        expect(contextMenuEvent.defaultPrevented).toBe(true)
+    })
+
+    it("keeps row-specific actions available outside selection mode", () => {
+        const onSelect = vi.fn()
+        const onClick = vi.fn()
+        const onContextMenu = vi.fn()
+        const onAvatarClick = vi.fn()
+        const onSenderNameClick = vi.fn()
+
+        const root = renderRow(
+            <MessageRow
+                {...baseProps}
+                onSelect={onSelect}
+                onClick={onClick}
+                onContextMenu={onContextMenu}
+                onAvatarClick={onAvatarClick}
+                onSenderNameClick={onSenderNameClick}
+            >
+                <button type="button">open</button>
+            </MessageRow>
+        )
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "click")
+        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(onSelect).not.toHaveBeenCalled()
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-avatar")!, "click")
+        expect(onAvatarClick).toHaveBeenCalledTimes(1)
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row-sender")!, "click")
+        expect(onSenderNameClick).toHaveBeenCalledTimes(1)
+
+        dispatchMouseEvent(root.querySelector(".wk-msg-row")!, "contextmenu")
+        expect(onContextMenu).toHaveBeenCalledTimes(1)
+    })
+})
 
 /**
  * 老组件 `wk-msg-row-header` 补齐 @SpaceName 渲染。

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -189,6 +189,10 @@
   cursor: pointer;
 }
 
+.wk-msg-row--selection-mode .wk-msg-row-content {
+  pointer-events: none;
+}
+
 .wk-msg-row-checkbox-inner {
   width: 18px;
   height: 18px;

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
@@ -64,6 +64,9 @@ export interface MessageRowProps {
   
   /** 是否显示多选 Checkbox */
   showCheckbox?: boolean
+
+  /** 会话是否处于多选模式（即使当前消息不可选） */
+  selectionMode?: boolean
   
   /** 右键菜单事件 */
   onContextMenu?: (event: React.MouseEvent) => void
@@ -113,6 +116,7 @@ export default function MessageRow({
   onSelect,
   children,
   showCheckbox = false,
+  selectionMode = false,
   onContextMenu,
   onClick,
   isActive,
@@ -120,6 +124,27 @@ export default function MessageRow({
   onSenderNameClick,
 }: MessageRowProps) {
   const { t } = useI18n()
+  const isSelecting = selectionMode || showCheckbox
+  const handleRowClick = isSelecting || onClick
+    ? () => {
+        if (isSelecting) {
+          if (showCheckbox) {
+            onSelect?.(!isSelected)
+          }
+          return
+        }
+        onClick?.()
+      }
+    : undefined
+  const handleContextMenu = (event: React.MouseEvent) => {
+    if (isSelecting) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+    onContextMenu?.(event)
+  }
+
   return (
     <div
       className={classNames(
@@ -128,10 +153,11 @@ export default function MessageRow({
         isContinue && 'wk-msg-row--continue',
         isSelected && 'wk-msg-row--selected',
         showCheckbox && 'wk-msg-row--selecting',
+        isSelecting && 'wk-msg-row--selection-mode',
         isActive && 'wk-msg-row--active',
       )}
-      onContextMenu={onContextMenu}
-      onClick={onClick}
+      onContextMenu={handleContextMenu}
+      onClick={handleRowClick}
     >
       {/* 多选 Checkbox */}
       {showCheckbox && (
@@ -164,7 +190,7 @@ export default function MessageRow({
             isOnline={isOnline}
             showOnlineDot
             alt={senderName}
-            onClick={onAvatarClick}
+            onClick={isSelecting ? undefined : onAvatarClick}
           />
         )}
         {/* 连续消息：头像占位,hover 时显示时间戳 */}
@@ -183,8 +209,8 @@ export default function MessageRow({
           <div className="wk-msg-row-header">
             <span
               className="wk-msg-row-sender"
-              style={{ cursor: onSenderNameClick ? 'pointer' : undefined }}
-              onClick={onSenderNameClick}
+              style={{ cursor: !isSelecting && onSenderNameClick ? 'pointer' : undefined }}
+              onClick={isSelecting ? undefined : onSenderNameClick}
             >{senderName}</span>
             {/* Epic dmwork-web#1169 Phase A: 实名徽章紧贴作者名右侧，
                 只 variant="icon" 迷你形态，已实名才渲染。*/}


### PR DESCRIPTION
## Summary
- add a shared message selectability guard for multi-select behavior
- suppress row-level actions while multi-select mode is active, including image preview and thread-created interactions
- prevent non-selectable message types from entering selection via UI, context menu, or VM state

Fixes #155

## Test
- pnpm --dir packages/dmworkbase exec vitest run src/ui/message/MessageRow/__tests__/MessageRow.test.tsx src/Messages/Image/__tests__/ImageContent.test.ts src/Service/__tests__/messageSelection.test.ts --config vitest.config.ts
- git diff --check HEAD