### PR TITLE
fix(contacts): allow search results to scroll

### DIFF
--- a/packages/dmworkcontacts/src/Contacts/index.css
+++ b/packages/dmworkcontacts/src/Contacts/index.css
@@ -30,6 +30,7 @@
     border-radius: var(--wk-r-md);
     cursor: pointer;
     transition: opacity var(--wk-dur-fast) var(--wk-ease);
+    flex-shrink: 0;
 }
 
 .wk-contacts-botfather-banner:hover {
@@ -68,6 +69,7 @@
    ============================================================ */
 .wk-contacts-search {
     padding: var(--wk-sp-2) var(--wk-sp-3);
+    flex-shrink: 0;
 }
 
 .wk-contacts-search-input {
@@ -121,6 +123,9 @@
    搜索结果
    ============================================================ */
 .wk-contacts-search-results {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
     padding: var(--wk-sp-1) 0;
 }
 


### PR DESCRIPTION
## Summary
- Make the contacts search results area fill remaining vertical space
- Add internal scrolling for long search result lists
- Keep the banner and search input from shrinking in the contacts flex layout

## Verification
- git diff --check
- pnpm exec stylelint packages/dmworkcontacts/src/Contacts/index.css --config stylelint.config.mjs --allow-empty-input (0 errors; existing warnings only)

Fixes #197