### PR TITLE
fix(contextmenu): 群聊右键菜单撤回按钮根据角色权限隐藏

### DIFF
--- a/packages/dmworkbase/src/Service/DataSource/DataSource.ts
+++ b/packages/dmworkbase/src/Service/DataSource/DataSource.ts
@@ -237,6 +237,13 @@ export interface IChannelDataSource {
     }): Promise<Subscriber[]>
 
     /**
+     * 按 UID 精确获取单个订阅者
+     * @param channel
+     * @param uid 订阅者 UID
+     */
+    subscriber(channel: Channel, uid: string): Promise<Subscriber | undefined>
+
+    /**
      * 更新频道设置
      * @param setting 
      * @param channel 

--- a/packages/dmworkbase/src/Service/__tests__/revokePermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/revokePermission.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+import { ChannelTypeCommunityTopic, GroupRole } from "../Const";
+import { canShowRevokeMenu } from "../revokePermission";
+
+const base = {
+  messageID: "msg-1",
+  messageTimestamp: 1000,
+  nowSeconds: 1100,
+  revokeSecond: 120,
+};
+
+describe("canShowRevokeMenu", () => {
+  it("rejects messages without a server id", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        messageID: "",
+        messageSend: true,
+      })
+    ).toBe(false);
+  });
+
+  it("allows bot owners to revoke their own bot messages without the time window", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        isBotOwner: true,
+        messageSend: false,
+        messageTimestamp: 1,
+      })
+    ).toBe(true);
+  });
+
+  it("allows own messages inside the revoke window and hides expired own messages", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypePerson,
+        messageSend: true,
+      })
+    ).toBe(true);
+
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypePerson,
+        messageSend: true,
+        messageTimestamp: 900,
+      })
+    ).toBe(false);
+  });
+
+  it("hides other people's direct messages", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypePerson,
+        messageSend: false,
+      })
+    ).toBe(false);
+  });
+
+  it("allows group owners to revoke anyone's messages", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: false,
+        myRole: GroupRole.owner,
+      })
+    ).toBe(true);
+  });
+
+  it("allows group managers to revoke normal members, but not owners or managers", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: false,
+        myRole: GroupRole.manager,
+        targetRole: GroupRole.normal,
+      })
+    ).toBe(true);
+
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: false,
+        myRole: GroupRole.manager,
+        targetRole: GroupRole.manager,
+      })
+    ).toBe(false);
+
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: false,
+        myRole: GroupRole.manager,
+        targetRole: GroupRole.owner,
+      })
+    ).toBe(false);
+  });
+
+  it("hides manager revoke when the sender role is unknown", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: false,
+        myRole: GroupRole.manager,
+      })
+    ).toBe(false);
+  });
+
+  it("applies the same role matrix to thread channels", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeCommunityTopic,
+        messageSend: false,
+        myRole: GroupRole.manager,
+        targetRole: GroupRole.normal,
+      })
+    ).toBe(true);
+
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeCommunityTopic,
+        messageSend: false,
+        myRole: GroupRole.normal,
+        targetRole: GroupRole.normal,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps manager's own messages time-limited in group channels", () => {
+    expect(
+      canShowRevokeMenu({
+        ...base,
+        channelType: ChannelTypeGroup,
+        messageSend: true,
+        myRole: GroupRole.manager,
+        messageTimestamp: 900,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Service/revokePermission.ts
+++ b/packages/dmworkbase/src/Service/revokePermission.ts
@@ -1,0 +1,71 @@
+import { ChannelTypeCommunityTopic, GroupRole } from "./Const";
+import { ChannelTypeGroup } from "wukongimjssdk";
+
+export interface RevokeMenuPermissionInput {
+  messageID?: string;
+  channelType?: number;
+  messageSend?: boolean;
+  messageTimestamp?: number;
+  revokeSecond?: number;
+  nowSeconds?: number;
+  isBotOwner?: boolean;
+  myRole?: number;
+  targetRole?: number;
+}
+
+export function isWithinRevokeWindow(input: {
+  messageTimestamp?: number;
+  revokeSecond?: number;
+  nowSeconds?: number;
+}): boolean {
+  const revokeSecond = input.revokeSecond ?? 0;
+  if (revokeSecond <= 0) {
+    return true;
+  }
+  const messageTimestamp = input.messageTimestamp ?? 0;
+  const nowSeconds = input.nowSeconds ?? Date.now() / 1000;
+  return nowSeconds - messageTimestamp <= revokeSecond;
+}
+
+export function canShowRevokeMenu(input: RevokeMenuPermissionInput): boolean {
+  if (!input.messageID) {
+    return false;
+  }
+
+  if (input.isBotOwner) {
+    return true;
+  }
+
+  const isGroupLike =
+    input.channelType === ChannelTypeGroup ||
+    input.channelType === ChannelTypeCommunityTopic;
+
+  if (isGroupLike) {
+    if (input.myRole === GroupRole.owner) {
+      return true;
+    }
+
+    if (input.myRole === GroupRole.manager) {
+      if (input.messageSend) {
+        return isWithinRevokeWindow(input);
+      }
+
+      if (input.targetRole == null) {
+        return false;
+      }
+
+      return (
+        input.targetRole !== GroupRole.owner &&
+        input.targetRole !== GroupRole.manager
+      );
+    }
+
+    if (!input.messageSend) {
+      return false;
+    }
+  } else if (!input.messageSend) {
+    return false;
+  }
+
+  return isWithinRevokeWindow(input);
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -168,15 +168,10 @@ function warmRevokeTargetRole(channel: Channel, uid: string) {
 
   pendingRevokeRoleFetches.add(requestKey);
   WKApp.dataSource.channelDataSource
-    .subscribers(channel, {
-      keyword: uid,
-      limit: 20,
-      page: 1,
-    })
-    .then((subscribers) => {
-      const matched = subscribers?.find((subscriber) => subscriber.uid === uid);
-      if (matched) {
-        mergeSubscriberIntoCache(channel, matched);
+    .subscriber(channel, uid)
+    .then((subscriber) => {
+      if (subscriber) {
+        mergeSubscriberIntoCache(channel, subscriber);
       }
     })
     .catch(() => {

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -109,6 +109,7 @@ import {
 import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
+import { canShowRevokeMenu } from "./Service/revokePermission";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
 function fallbackCopy(text: string) {
@@ -739,9 +740,14 @@ export default class BaseModule implements IModule {
     WKApp.endpoints.registerMessageContextMenus(
       "contextmenus.revoke",
       (message, context) => {
-        if (message.messageID === "") {
-          return null;
-        }
+        const makeRevokeAction = () => ({
+          title: t("base.module.contextMenus.revoke"),
+          onClick: () => {
+            context.revokeMessage(message).catch((err) => {
+              Toast.error(err.msg);
+            });
+          },
+        });
 
         // Bot 创建者可撤回自己创建的 Bot 发送的消息（与群管理员同等待遇，
         // 不受 message.send 和 24h 时间窗口限制，与后端行为一致）
@@ -756,132 +762,54 @@ export default class BaseModule implements IModule {
           }
         }
 
-        // 自己创建的 Bot 发的消息 → 显示（无时间限制）
-        if (isBotOwner) {
-          return {
-            title: t("base.module.contextMenus.revoke"),
-            onClick: () => {
-              context.revokeMessage(message).catch((err) => {
-                Toast.error(err.msg);
-              });
-            },
-          };
-        }
-
         // 群聊和子区的撤回权限判断
         const channelType = message.channel.channelType;
         const isGroup = channelType === ChannelTypeGroup;
         const isThread = channelType === ChannelTypeCommunityTopic;
+        const threadInfo = isThread
+          ? parseThreadChannelId(message.channel.channelID)
+          : null;
+        const roleChannel =
+          isThread && threadInfo
+            ? new Channel(threadInfo.groupNo, ChannelTypeGroup)
+            : message.channel;
+        let myRole: number | undefined;
+        let targetRole: number | undefined;
 
         if (isGroup || isThread) {
           // 获取当前用户在群/子区父群中的角色
-          let myRole: number | undefined;
-          if (isGroup) {
-            const sub = WKSDK.shared().channelManager.getSubscribeOfMe(
-              message.channel
+          const sub =
+            WKSDK.shared().channelManager.getSubscribeOfMe(roleChannel);
+          myRole = sub?.role;
+
+          // 管理员撤回别人消息时必须确认发送者不是群主/管理员；角色未知时默认隐藏。
+          if (myRole === GroupRole.manager && !message.send) {
+            const subs = WKSDK.shared().channelManager.getSubscribes(
+              roleChannel
+            ) as any[] | null | undefined;
+            const targetMember = subs?.find(
+              (s: any) => s && s.uid === message.fromUID
             );
-            myRole = sub?.role;
-          } else if (isThread) {
-            // 子区：沿用父群角色判断
-            const parsed = parseThreadChannelId(message.channel.channelID);
-            if (parsed) {
-              const parentChannel = new Channel(parsed.groupNo, ChannelTypeGroup);
-              const sub = WKSDK.shared().channelManager.getSubscribeOfMe(parentChannel);
-              myRole = sub?.role;
-            }
-          }
-
-          const isOwner = myRole === GroupRole.owner;
-          const isManager = myRole === GroupRole.manager;
-
-          // 群主可以撤回任何人的消息（除了自己的也走此分支）
-          if (isOwner) {
-            return {
-              title: t("base.module.contextMenus.revoke"),
-              onClick: () => {
-                context.revokeMessage(message).catch((err) => {
-                  Toast.error(err.msg);
-                });
-              },
-            };
-          }
-
-          // 管理员可以撤回普通成员的消息，但不能撤回其他管理员或群主的消息
-          if (isManager) {
-            // 先判断是否是自己发的消息
-            if (message.send) {
-              // 自己发的消息需要判断时间限制
-              let revokeSecond = WKApp.remoteConfig.revokeSecond;
-              if (revokeSecond > 0) {
-                const messageTime = new Date().getTime() / 1000 - message.timestamp;
-                if (messageTime > revokeSecond) {
-                  return null;
-                }
-              }
-              return {
-                title: t("base.module.contextMenus.revoke"),
-                onClick: () => {
-                  context.revokeMessage(message).catch((err) => {
-                    Toast.error(err.msg);
-                  });
-                },
-              };
-            }
-
-            // 检查消息发送者的角色
-            const targetChannel = isGroup ? message.channel : (
-              parseThreadChannelId(message.channel.channelID)
-                ? new Channel(parseThreadChannelId(message.channel.channelID)!.groupNo, ChannelTypeGroup)
-                : message.channel
-            );
-            const subs = WKSDK.shared().channelManager.getSubscribes(targetChannel) as any[] | null | undefined;
-            const targetMember = subs?.find((s: any) => s && s.uid === message.fromUID);
-            const targetRole = targetMember?.role;
-
-            // 管理员只能撤回普通成员的消息
-            if (targetRole === GroupRole.owner || targetRole === GroupRole.manager) {
-              return null;
-            }
-
-            // 可以撤回普通成员的消息（无时间限制）
-            return {
-              title: t("base.module.contextMenus.revoke"),
-              onClick: () => {
-                context.revokeMessage(message).catch((err) => {
-                  Toast.error(err.msg);
-                });
-              },
-            };
-          }
-
-          // 普通成员只能撤回自己的消息
-          if (!message.send) {
-            return null;
+            targetRole = targetMember?.role;
           }
         }
 
-        // 私聊或其他场景：只能撤回自己的消息
-        if (!message.send) {
+        const canShow = canShowRevokeMenu({
+          messageID: message.messageID,
+          channelType,
+          messageSend: message.send,
+          messageTimestamp: message.timestamp,
+          revokeSecond: WKApp.remoteConfig.revokeSecond,
+          isBotOwner,
+          myRole,
+          targetRole,
+        });
+
+        if (!canShow) {
           return null;
         }
 
-        // 自己发的消息：检查时间限制
-        let revokeSecond = WKApp.remoteConfig.revokeSecond;
-        if (revokeSecond > 0) {
-          const messageTime = new Date().getTime() / 1000 - message.timestamp;
-          if (messageTime > revokeSecond) {
-            return null;
-          }
-        }
-
-        return {
-          title: t("base.module.contextMenus.revoke"),
-          onClick: () => {
-            context.revokeMessage(message).catch((err) => {
-              Toast.error(err.msg);
-            });
-          },
-        };
+        return makeRevokeAction();
       },
       4000
     );

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -743,19 +743,6 @@ export default class BaseModule implements IModule {
           return null;
         }
 
-        let isManager = false;
-        if (message.channel.channelType === ChannelTypeGroup) {
-          const sub = WKSDK.shared().channelManager.getSubscribeOfMe(
-            message.channel
-          );
-          if (
-            sub?.role === GroupRole.manager ||
-            sub?.role === GroupRole.owner
-          ) {
-            isManager = true;
-          }
-        }
-
         // Bot 创建者可撤回自己创建的 Bot 发送的消息（与群管理员同等待遇，
         // 不受 message.send 和 24h 时间窗口限制，与后端行为一致）
         let isBotOwner = false;
@@ -769,19 +756,124 @@ export default class BaseModule implements IModule {
           }
         }
 
-        if (!isManager && !isBotOwner) {
+        // 自己创建的 Bot 发的消息 → 显示（无时间限制）
+        if (isBotOwner) {
+          return {
+            title: t("base.module.contextMenus.revoke"),
+            onClick: () => {
+              context.revokeMessage(message).catch((err) => {
+                Toast.error(err.msg);
+              });
+            },
+          };
+        }
+
+        // 群聊和子区的撤回权限判断
+        const channelType = message.channel.channelType;
+        const isGroup = channelType === ChannelTypeGroup;
+        const isThread = channelType === ChannelTypeCommunityTopic;
+
+        if (isGroup || isThread) {
+          // 获取当前用户在群/子区父群中的角色
+          let myRole: number | undefined;
+          if (isGroup) {
+            const sub = WKSDK.shared().channelManager.getSubscribeOfMe(
+              message.channel
+            );
+            myRole = sub?.role;
+          } else if (isThread) {
+            // 子区：沿用父群角色判断
+            const parsed = parseThreadChannelId(message.channel.channelID);
+            if (parsed) {
+              const parentChannel = new Channel(parsed.groupNo, ChannelTypeGroup);
+              const sub = WKSDK.shared().channelManager.getSubscribeOfMe(parentChannel);
+              myRole = sub?.role;
+            }
+          }
+
+          const isOwner = myRole === GroupRole.owner;
+          const isManager = myRole === GroupRole.manager;
+
+          // 群主可以撤回任何人的消息（除了自己的也走此分支）
+          if (isOwner) {
+            return {
+              title: t("base.module.contextMenus.revoke"),
+              onClick: () => {
+                context.revokeMessage(message).catch((err) => {
+                  Toast.error(err.msg);
+                });
+              },
+            };
+          }
+
+          // 管理员可以撤回普通成员的消息，但不能撤回其他管理员或群主的消息
+          if (isManager) {
+            // 先判断是否是自己发的消息
+            if (message.send) {
+              // 自己发的消息需要判断时间限制
+              let revokeSecond = WKApp.remoteConfig.revokeSecond;
+              if (revokeSecond > 0) {
+                const messageTime = new Date().getTime() / 1000 - message.timestamp;
+                if (messageTime > revokeSecond) {
+                  return null;
+                }
+              }
+              return {
+                title: t("base.module.contextMenus.revoke"),
+                onClick: () => {
+                  context.revokeMessage(message).catch((err) => {
+                    Toast.error(err.msg);
+                  });
+                },
+              };
+            }
+
+            // 检查消息发送者的角色
+            const targetChannel = isGroup ? message.channel : (
+              parseThreadChannelId(message.channel.channelID)
+                ? new Channel(parseThreadChannelId(message.channel.channelID)!.groupNo, ChannelTypeGroup)
+                : message.channel
+            );
+            const subs = WKSDK.shared().channelManager.getSubscribes(targetChannel) as any[] | null | undefined;
+            const targetMember = subs?.find((s: any) => s && s.uid === message.fromUID);
+            const targetRole = targetMember?.role;
+
+            // 管理员只能撤回普通成员的消息
+            if (targetRole === GroupRole.owner || targetRole === GroupRole.manager) {
+              return null;
+            }
+
+            // 可以撤回普通成员的消息（无时间限制）
+            return {
+              title: t("base.module.contextMenus.revoke"),
+              onClick: () => {
+                context.revokeMessage(message).catch((err) => {
+                  Toast.error(err.msg);
+                });
+              },
+            };
+          }
+
+          // 普通成员只能撤回自己的消息
           if (!message.send) {
             return null;
           }
-          let revokeSecond = WKApp.remoteConfig.revokeSecond;
-          if (revokeSecond > 0) {
-            const messageTime = new Date().getTime() / 1000 - message.timestamp;
-            if (messageTime > revokeSecond) {
-              //  超过两分钟则不显示撤回
-              return null;
-            }
+        }
+
+        // 私聊或其他场景：只能撤回自己的消息
+        if (!message.send) {
+          return null;
+        }
+
+        // 自己发的消息：检查时间限制
+        let revokeSecond = WKApp.remoteConfig.revokeSecond;
+        if (revokeSecond > 0) {
+          const messageTime = new Date().getTime() / 1000 - message.timestamp;
+          if (messageTime > revokeSecond) {
+            return null;
           }
         }
+
         return {
           title: t("base.module.contextMenus.revoke"),
           onClick: () => {

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -126,6 +126,67 @@ function fallbackCopy(text: string) {
   }
 }
 
+const pendingRevokeRoleFetches = new Set<string>();
+
+function findSubscriber(channel: Channel, uid: string): Subscriber | undefined {
+  const subscribers = WKSDK.shared().channelManager.getSubscribes(channel) as
+    | Subscriber[]
+    | null
+    | undefined;
+  return subscribers?.find((subscriber) => subscriber && subscriber.uid === uid);
+}
+
+function mergeSubscriberIntoCache(channel: Channel, subscriber: Subscriber) {
+  const channelManager = WKSDK.shared().channelManager;
+  const cached = (channelManager.getSubscribes(channel) || []) as Subscriber[];
+  const nextSubscribers = [...cached];
+  const index = nextSubscribers.findIndex((item) => item.uid === subscriber.uid);
+  subscriber.channel = channel;
+
+  if (index >= 0) {
+    nextSubscribers[index] = {
+      ...nextSubscribers[index],
+      ...subscriber,
+    };
+  } else {
+    nextSubscribers.push(subscriber);
+  }
+
+  channelManager.subscribeCacheMap.set(channel.getChannelKey(), nextSubscribers);
+  channelManager.notifySubscribeChangeListeners(channel);
+}
+
+function warmRevokeTargetRole(channel: Channel, uid: string) {
+  if (findSubscriber(channel, uid)) {
+    return;
+  }
+
+  const requestKey = `${channel.getChannelKey()}:${uid}`;
+  if (pendingRevokeRoleFetches.has(requestKey)) {
+    return;
+  }
+
+  pendingRevokeRoleFetches.add(requestKey);
+  WKApp.dataSource.channelDataSource
+    .subscribers(channel, {
+      keyword: uid,
+      limit: 20,
+      page: 1,
+    })
+    .then((subscribers) => {
+      const matched = subscribers?.find((subscriber) => subscriber.uid === uid);
+      if (matched) {
+        mergeSubscriberIntoCache(channel, matched);
+      }
+    })
+    .catch(() => {
+      // Permission remains fail-closed when the sender role cannot be resolved.
+    })
+    .finally(() => {
+      pendingRevokeRoleFetches.delete(requestKey);
+    });
+}
+
 export default class BaseModule implements IModule {
   messageTone?: Howl;
 
@@ -784,13 +845,11 @@ export default class BaseModule implements IModule {
 
           // 管理员撤回别人消息时必须确认发送者不是群主/管理员；角色未知时默认隐藏。
           if (myRole === GroupRole.manager && !message.send) {
-            const subs = WKSDK.shared().channelManager.getSubscribes(
-              roleChannel
-            ) as any[] | null | undefined;
-            const targetMember = subs?.find(
-              (s: any) => s && s.uid === message.fromUID
-            );
+            const targetMember = findSubscriber(roleChannel, message.fromUID);
             targetRole = targetMember?.role;
+            if (targetRole == null) {
+              warmRevokeTargetRole(roleChannel, message.fromUID);
+            }
           }
         }
 

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -4,6 +4,38 @@ import { Channel, ChannelInfo, ChannelTypeGroup, ChannelTypePerson, WKSDK, Messa
 const MAX_GROUP_LIST_LIMIT = 100000;
 const MAX_FAVORITES_PAGE_SIZE = 10000;
 
+interface GroupMemberMap {
+    uid: string;
+    name?: string;
+    remark?: string;
+    role?: number;
+    version?: number;
+    is_deleted?: number;
+    status?: number;
+    bot_admin?: number;
+    [key: string]: unknown;
+}
+
+interface GroupMemberLookupResp {
+    exists?: boolean;
+    member?: GroupMemberMap;
+}
+
+function toSubscriber(memberMap: GroupMemberMap): Subscriber {
+    const member = new Subscriber();
+    member.uid = memberMap.uid;
+    member.name = memberMap.name;
+    member.remark = memberMap.remark;
+    member.role = memberMap.role;
+    member.version = memberMap.version;
+    member.isDeleted = memberMap.is_deleted;
+    member.status = memberMap.status;
+    member.orgData = memberMap
+    member.orgData.bot_admin = memberMap.bot_admin || 0;
+    member.avatar = WKApp.shared.avatarUser(member.uid)
+    return member
+}
+
 export class ChannelDataSource implements IChannelDataSource {
 
     async exitChannel(channel: Channel): Promise<void> {
@@ -94,21 +126,19 @@ export class ChannelDataSource implements IChannelDataSource {
         if (resp) {
             for (let i = 0; i < resp.length; i++) {
                 let memberMap = resp[i];
-                let member = new Subscriber();
-                member.uid = memberMap.uid;
-                member.name = memberMap.name;
-                member.remark = memberMap.remark;
-                member.role = memberMap.role;
-                member.version = memberMap.version;
-                member.isDeleted = memberMap.is_deleted;
-                member.status = memberMap.status;
-                member.orgData = memberMap
-                member.orgData.bot_admin = memberMap.bot_admin || 0;
-                member.avatar = WKApp.shared.avatarUser(member.uid)
-                members.push(member);
+                members.push(toSubscriber(memberMap));
             }
         }
         return members
+    }
+
+    async subscriber(channel: Channel, uid: string): Promise<Subscriber | undefined> {
+        const resp: GroupMemberLookupResp | undefined = await WKApp.apiClient.get(`groups/${channel.channelID}/members/${uid}`)
+        const memberMap = resp?.member
+        if (!resp?.exists || !memberMap) {
+            return undefined
+        }
+        return toSubscriber(memberMap)
     }
 
     updateField(channel: Channel, field: string, value: string): Promise<void> {


### PR DESCRIPTION
## 问题
群聊中，普通成员右键别人的消息也显示了「撤回」按钮，点击后才提示没有权限。应在前端直接根据角色权限隐藏。

## 修改内容
修改 `packages/dmworkbase/src/module.tsx` 中 `contextmenus.revoke` 的显示逻辑：

### 群聊（Channel）
- ✅ 自己发的消息 → 显示（有时间限制）
- ✅ 自己创建的 Bot 发的消息 → 显示（无时间限制）
- ✅ 群主对任何人的消息 → 显示
- ✅ 管理员对普通成员的消息 → 显示
- ✅ 管理员对其他管理员/群主的消息 → 隐藏
- ✅ 普通成员对别人的消息 → 隐藏

### 子区（Thread）
- ✅ 沿用群聊逻辑（基于父群角色判断）

Closes #205