### PR TITLE
fix: complete OIDC logout flow

### DIFF
--- a/apps/web/src/Components/JoinSpacePage/index.tsx
+++ b/apps/web/src/Components/JoinSpacePage/index.tsx
@@ -115,7 +115,7 @@ export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {
         : ACCENT;
 
     const handleLogout = () => {
-        WKApp.shared.logout();
+        void WKApp.shared.logoutUserInitiated();
     };
 
     return (

--- a/apps/web/src/Components/SpaceGate/index.tsx
+++ b/apps/web/src/Components/SpaceGate/index.tsx
@@ -120,7 +120,7 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
     };
 
     logout = () => {
-        WKApp.shared.logout();
+        void WKApp.shared.logoutUserInitiated();
     };
 
     render() {

--- a/apps/web/src/__tests__/disableUserCreateSpace.test.ts
+++ b/apps/web/src/__tests__/disableUserCreateSpace.test.ts
@@ -59,7 +59,7 @@ describe("disable_user_create_space web integration", () => {
     const zh = JSON.parse(readRepoFile("apps/web/src/i18n/zh-CN.json"));
     const en = JSON.parse(readRepoFile("apps/web/src/i18n/en-US.json"));
 
-    expect(source).toContain("WKApp.shared.logout()");
+    expect(source).toContain("WKApp.shared.logoutUserInitiated()");
     expect(source).toContain('t("app.spaceGate.logout")');
     expect(zh["spaceGate.logout"]).toBe("退出登录");
     expect(en["spaceGate.logout"]).toBe("Log out");
@@ -80,7 +80,7 @@ describe("disable_user_create_space web integration", () => {
     const zh = JSON.parse(readRepoFile("apps/web/src/i18n/zh-CN.json"));
     const en = JSON.parse(readRepoFile("apps/web/src/i18n/en-US.json"));
 
-    expect(source).toContain("WKApp.shared.logout()");
+    expect(source).toContain("WKApp.shared.logoutUserInitiated()");
     expect(source).toContain('t("app.joinSpace.logout")');
     expect(zh["joinSpace.logout"]).toBe("退出登录");
     expect(en["joinSpace.logout"]).toBe("Log out");

--- a/apps/web/src/__tests__/oidcLogoutWiring.test.ts
+++ b/apps/web/src/__tests__/oidcLogoutWiring.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+describe("OIDC logout wiring", () => {
+  it("runs post-logout cleanup before loading cached login state", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+    const cleanupIdx = source.indexOf("consumeOidcPostLogoutCleanup()");
+    const loadIdx = source.indexOf("WKApp.loginInfo.load(); // 加载登录信息");
+
+    expect(cleanupIdx).toBeGreaterThanOrEqual(0);
+    expect(loadIdx).toBeGreaterThanOrEqual(0);
+    expect(cleanupIdx).toBeLessThan(loadIdx);
+  });
+
+  it("uses backend-issued end_session_url for user-initiated settings logout", () => {
+    const appSource = readRepoFile("packages/dmworkbase/src/App.tsx");
+    const navSource = readRepoFile("packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx");
+    const spaceGateSource = readRepoFile("apps/web/src/Components/SpaceGate/index.tsx");
+    const joinSpaceSource = readRepoFile("apps/web/src/Components/JoinSpacePage/index.tsx");
+
+    expect(navSource).toContain("logoutUserInitiated");
+    expect(spaceGateSource).toContain("logoutUserInitiated");
+    expect(joinSpaceSource).toContain("logoutUserInitiated");
+    expect(appSource).toContain("requestOidcLogout(providerId, token)");
+    expect(appSource).toContain("safeEndSessionUrl(resp.end_session_url)");
+    expect(appSource).toContain("window.location.href = endSessionUrl");
+  });
+
+  it("clears local auth state before redirecting to the IdP logout URL", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+    const redirectBlockIdx = source.indexOf("if (endSessionUrl) {");
+    const clearIdx = source.indexOf("this.clearLocalLoginState();", redirectBlockIdx);
+    const markIdx = source.indexOf("markOidcPostLogoutCleanup();", redirectBlockIdx);
+    const redirectIdx = source.indexOf("window.location.href = endSessionUrl", redirectBlockIdx);
+
+    expect(redirectBlockIdx).toBeGreaterThanOrEqual(0);
+    expect(clearIdx).toBeGreaterThan(redirectBlockIdx);
+    expect(markIdx).toBeGreaterThan(clearIdx);
+    expect(redirectIdx).toBeGreaterThan(markIdx);
+  });
+});

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -8,6 +8,8 @@ interface ImportMetaEnv {
   // Enables the enterprise SSO entry (OIDC) on the login page.
   // Open-source builds leave this unset to keep the entry hidden.
   readonly VITE_ENABLE_ENTERPRISE_SSO?: string
+  // Dev-only override for OIDC logout callback when using a remote backend from localhost.
+  readonly VITE_OIDC_POST_LOGOUT_REDIRECT_URI?: string
 }
 
 interface ImportMeta {

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -108,6 +108,15 @@ import { WKBaseContext } from "./Components/WKBase";
 import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
+import {
+  clearAuthStorage,
+  consumeOidcPostLogoutCleanup,
+  isOidcLoginProvider,
+  markOidcPostLogoutCleanup,
+  overridePostLogoutRedirectUri,
+  requestOidcLogout,
+  safeEndSessionUrl,
+} from "./Service/oidcLogout";
 
 export enum ThemeMode {
   light,
@@ -425,6 +434,10 @@ export class LoginInfo {
    * load 加载登录信息
    */
   public load() {
+    if (consumeOidcPostLogoutCleanup()) {
+      this.logout();
+      clearAuthStorage();
+    }
     this.uid = this.getStorageItemForSID("uid") || "";
     this.shortNo = this.getStorageItemForSID("short_no") || "";
     this.token = this.getStorageItemForSID("token") || "";
@@ -482,6 +495,11 @@ export class LoginInfo {
     this.token = undefined;
     this.appID = "";
     this.role = "";
+    this.uid = "";
+    this.shortNo = "";
+    this.name = "";
+    this.isWork = false;
+    this.sex = 0;
     this.loginProvider = undefined;
     this.removeStorageItemForSID("token");
     this.removeStorageItemForSID("app_id");
@@ -637,6 +655,9 @@ export default class WKApp extends ProviderListener {
 
   // app启动
   startup() {
+    if (consumeOidcPostLogoutCleanup()) {
+      this.clearLocalLoginState();
+    }
     WKApp.loginInfo.load(); // 加载登录信息
 
     // 是否是PC端
@@ -851,15 +872,46 @@ export default class WKApp extends ProviderListener {
   isLogined() {
     return WKApp.loginInfo.isLogined();
   }
-  // 登出
-  logout() {
+  private clearLocalLoginState() {
     WKApp.loginInfo.logout();
-    localStorage.removeItem("currentSpaceId");
+    clearAuthStorage();
     this.currentSpaceId = "";
     this.channelSpaceMap.clear();
     this.channelMySourceSpaceMap.clear();
     this.spaceChecked = false;
+  }
+
+  // 登出
+  logout() {
+    this.clearLocalLoginState();
     window.location.reload();
+  }
+
+  async logoutUserInitiated() {
+    const providerId = WKApp.loginInfo.loginProvider;
+    const token = WKApp.loginInfo.token || "";
+    if (isOidcLoginProvider(providerId) && token) {
+      try {
+        const resp = await requestOidcLogout(providerId, token);
+        const rawEndSessionUrl = safeEndSessionUrl(resp.end_session_url);
+        const endSessionUrl =
+          rawEndSessionUrl && import.meta.env.DEV
+            ? overridePostLogoutRedirectUri(
+                rawEndSessionUrl,
+                import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI
+              )
+            : rawEndSessionUrl;
+        if (endSessionUrl) {
+          this.clearLocalLoginState();
+          markOidcPostLogoutCleanup();
+          window.location.href = endSessionUrl;
+          return;
+        }
+      } catch (e) {
+        console.warn("OIDC logout failed, falling back to local logout", e);
+      }
+    }
+    this.logout();
   }
 
   avatarChannel(channel: Channel) {

--- a/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
@@ -179,7 +179,7 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                     <NavVoiceSettingsItem />
                     <li onClick={() => {
                         onToggleSetting();
-                        WKApp.shared.logout();
+                        void WKApp.shared.logoutUserInitiated();
                     }}>
                         {t("base.navRail.settingsPanel.logout")}
                     </li>

--- a/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildOidcLogoutPath,
+  clearAuthStorage,
+  consumeOidcPostLogoutCleanup,
+  isOidcLoginProvider,
+  markOidcPostLogoutCleanup,
+  overridePostLogoutRedirectUri,
+  requestOidcLogout,
+  safeEndSessionUrl,
+} from "../oidcLogout";
+
+describe("oidcLogout helpers", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it("identifies OIDC providers and excludes local or empty providers", () => {
+    expect(isOidcLoginProvider("aegis")).toBe(true);
+    expect(isOidcLoginProvider("local")).toBe(false);
+    expect(isOidcLoginProvider("")).toBe(false);
+    expect(isOidcLoginProvider(undefined)).toBe(false);
+  });
+
+  it("builds the backend logout path with an encoded provider id", () => {
+    expect(buildOidcLogoutPath("aegis")).toBe("/v1/auth/oidc/aegis/logout");
+    expect(buildOidcLogoutPath("corp/sso")).toBe(
+      "/v1/auth/oidc/corp%2Fsso/logout"
+    );
+  });
+
+  it("posts the Octo token to backend logout and parses end_session_url", async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: 200,
+            end_session_url:
+              "https://accounts.example.com/end_session?id_token_hint=jwt",
+          }),
+          { status: 200 }
+        )
+    );
+
+    const resp = await requestOidcLogout(
+      "aegis",
+      "octo-token",
+      fetcher as typeof fetch
+    );
+
+    expect(fetcher).toHaveBeenCalledWith("/v1/auth/oidc/aegis/logout", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+        token: "octo-token",
+      },
+    });
+    expect(resp.end_session_url).toBe(
+      "https://accounts.example.com/end_session?id_token_hint=jwt"
+    );
+  });
+
+  it("rejects failed backend logout responses", async () => {
+    const fetcher = vi.fn(
+      async () => new Response("login required", { status: 401 })
+    );
+    await expect(
+      requestOidcLogout("aegis", "bad-token", fetcher as typeof fetch)
+    ).rejects.toThrow("OIDC logout failed: HTTP 401");
+  });
+
+  it("only accepts absolute http(s) end_session URLs", () => {
+    expect(
+      safeEndSessionUrl("https://accounts.example.com/end_session")
+    ).toBeTruthy();
+    expect(safeEndSessionUrl("http://localhost:8080/end_session")).toBeTruthy();
+    expect(safeEndSessionUrl("/end_session")).toBeUndefined();
+    expect(safeEndSessionUrl("javascript:alert(1)")).toBeUndefined();
+    expect(safeEndSessionUrl("data:text/html,bye")).toBeUndefined();
+    expect(safeEndSessionUrl(undefined)).toBeUndefined();
+  });
+
+  it("can override post_logout_redirect_uri for local development", () => {
+    const rewritten = overridePostLogoutRedirectUri(
+      "https://accounts.example.com/end_session?id_token_hint=jwt&post_logout_redirect_uri=https%3A%2F%2Ftest.example.com%2Flogin",
+      "http://localhost:3000/login"
+    );
+
+    const parsed = new URL(rewritten);
+    expect(parsed.origin).toBe("https://accounts.example.com");
+    expect(parsed.searchParams.get("id_token_hint")).toBe("jwt");
+    expect(parsed.searchParams.get("post_logout_redirect_uri")).toBe(
+      "http://localhost:3000/login"
+    );
+  });
+
+  it("ignores unsafe post_logout_redirect_uri overrides", () => {
+    const endSessionUrl =
+      "https://accounts.example.com/end_session?id_token_hint=jwt";
+    expect(
+      overridePostLogoutRedirectUri(endSessionUrl, "javascript:alert(1)")
+    ).toBe(endSessionUrl);
+    expect(overridePostLogoutRedirectUri(endSessionUrl, "/login")).toBe(
+      endSessionUrl
+    );
+  });
+
+  it("marks post-logout cleanup and consumes it once", () => {
+    expect(markOidcPostLogoutCleanup()).toBe(true);
+    expect(consumeOidcPostLogoutCleanup()).toBe(true);
+    expect(consumeOidcPostLogoutCleanup()).toBe(false);
+  });
+
+  it("clears auth-related storage in both sessionStorage and localStorage", () => {
+    sessionStorage.setItem("tokenabc", "t");
+    sessionStorage.setItem("uidabc", "u");
+    sessionStorage.setItem("login_providerabc", "aegis");
+    sessionStorage.setItem("realname_verifiedabc", "1");
+    sessionStorage.setItem("pending_oidc_login", "{}");
+    sessionStorage.setItem("theme-mode", "dark");
+    localStorage.setItem("tokenabc", "t");
+    localStorage.setItem("currentSpaceId", "s1");
+    localStorage.setItem("i18n_lang", "zh-CN");
+
+    clearAuthStorage();
+
+    expect(sessionStorage.getItem("tokenabc")).toBeNull();
+    expect(sessionStorage.getItem("uidabc")).toBeNull();
+    expect(sessionStorage.getItem("login_providerabc")).toBeNull();
+    expect(sessionStorage.getItem("realname_verifiedabc")).toBeNull();
+    expect(sessionStorage.getItem("pending_oidc_login")).toBeNull();
+    expect(localStorage.getItem("tokenabc")).toBeNull();
+    expect(localStorage.getItem("currentSpaceId")).toBeNull();
+    expect(sessionStorage.getItem("theme-mode")).toBe("dark");
+    expect(localStorage.getItem("i18n_lang")).toBe("zh-CN");
+  });
+});

--- a/packages/dmworkbase/src/Service/oidcLogout.ts
+++ b/packages/dmworkbase/src/Service/oidcLogout.ts
@@ -1,0 +1,138 @@
+export const OIDC_POST_LOGOUT_CLEANUP_KEY = "octo_oidc_post_logout_cleanup";
+
+const AUTH_STORAGE_PREFIXES = [
+  "token",
+  "uid",
+  "short_no",
+  "app_id",
+  "name",
+  "role",
+  "is_work",
+  "sex",
+  "login_provider",
+  "realname_verified",
+  "real_name",
+  "realname_verified_at",
+];
+
+const AUTH_STORAGE_KEYS = ["currentSpaceId", "pending_oidc_login"];
+
+export interface OidcLogoutResponse {
+  status?: number;
+  end_session_url?: unknown;
+  [key: string]: unknown;
+}
+
+export function isOidcLoginProvider(providerId: unknown): providerId is string {
+  return (
+    typeof providerId === "string" &&
+    providerId !== "" &&
+    providerId !== "local"
+  );
+}
+
+export function buildOidcLogoutPath(providerId: string): string {
+  return `/v1/auth/oidc/${encodeURIComponent(providerId)}/logout`;
+}
+
+export function safeEndSessionUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || value === "") return undefined;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return value;
+    }
+  } catch {
+    /* invalid URL */
+  }
+  return undefined;
+}
+
+export function overridePostLogoutRedirectUri(
+  endSessionUrl: string,
+  redirectUri: unknown
+): string {
+  const safeRedirectUri = safeEndSessionUrl(redirectUri);
+  if (!safeRedirectUri) return endSessionUrl;
+  try {
+    const parsed = new URL(endSessionUrl);
+    parsed.searchParams.set("post_logout_redirect_uri", safeRedirectUri);
+    return parsed.toString();
+  } catch {
+    return endSessionUrl;
+  }
+}
+
+export async function requestOidcLogout(
+  providerId: string,
+  token: string,
+  fetcher: typeof fetch = fetch
+): Promise<OidcLogoutResponse> {
+  const resp = await fetcher(buildOidcLogoutPath(providerId), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+      token,
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`OIDC logout failed: HTTP ${resp.status}`);
+  }
+  if (resp.status === 204) return {};
+  const text = await resp.text();
+  if (!text) return {};
+  return JSON.parse(text) as OidcLogoutResponse;
+}
+
+export function markOidcPostLogoutCleanup(): boolean {
+  try {
+    sessionStorage.setItem(OIDC_POST_LOGOUT_CLEANUP_KEY, "1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function consumeOidcPostLogoutCleanup(): boolean {
+  try {
+    const marked = sessionStorage.getItem(OIDC_POST_LOGOUT_CLEANUP_KEY) === "1";
+    if (marked) {
+      sessionStorage.removeItem(OIDC_POST_LOGOUT_CLEANUP_KEY);
+    }
+    return marked;
+  } catch {
+    return false;
+  }
+}
+
+function removeMatchingStorage(store: Storage | undefined): void {
+  if (!store) return;
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i);
+      if (!key) continue;
+      if (
+        AUTH_STORAGE_KEYS.includes(key) ||
+        AUTH_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
+      ) {
+        keys.push(key);
+      }
+    }
+    for (const key of keys) {
+      store.removeItem(key);
+    }
+  } catch {
+    /* storage may be unavailable in private mode */
+  }
+}
+
+export function clearAuthStorage(): void {
+  removeMatchingStorage(
+    typeof sessionStorage === "undefined" ? undefined : sessionStorage
+  );
+  removeMatchingStorage(
+    typeof localStorage === "undefined" ? undefined : localStorage
+  );
+}


### PR DESCRIPTION
## Summary
- call backend OIDC logout for user-initiated logout and redirect to the returned end_session_url
- clear cached auth state after IdP post-logout return, including sid-scoped storage
- add a dev-only localhost post_logout_redirect_uri override and regression tests

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts --config packages/dmworkbase/vitest.config.ts
- cd apps/web && pnpm exec vitest run src/__tests__/oidcLogoutWiring.test.ts src/__tests__/disableUserCreateSpace.test.ts --config vitest.config.ts

Closes #184