### PR TITLE
fix(message-input): hide broadcast mentions in direct chats

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -388,6 +388,20 @@ export class Conversation
       this.reply(messageWrap.message, 1);
     }
   }
+
+  private addReplyMention(fromUID: string): void {
+    if (
+      this.props.channel.channelType === ChannelTypePerson ||
+      fromUID === WKApp.loginInfo.uid
+    ) {
+      return;
+    }
+    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      new Channel(fromUID, ChannelTypePerson),
+    );
+    this._messageInputContext?.addMention(fromUID, channelInfo?.title || "");
+  }
+
   replyToFileMessage(info: {
     messageId: string;
     messageSeq: number;
@@ -418,17 +432,7 @@ export class Conversation
     fakeMessage.channel = channel;
     fakeMessage.content = new MessageText(info.conversationDigest);
 
-    // 添加 @提及（如果不是自己发的消息）
-    if (info.fromUID !== WKApp.loginInfo.uid) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
-        new Channel(info.fromUID, ChannelTypePerson),
-      );
-      let name = "";
-      if (channelInfo) {
-        name = channelInfo.title;
-      }
-      this._messageInputContext?.addMention(info.fromUID, name);
-    }
+    this.addReplyMention(info.fromUID);
 
     // 设置回复状态
     this.vm.currentHandlerType = 1;
@@ -752,16 +756,7 @@ export class Conversation
 
   // 回复消息
   reply(message: Message, handlerType: number): void {
-    if (message.fromUID !== WKApp.loginInfo.uid) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
-        new Channel(message.fromUID, ChannelTypePerson),
-      );
-      let name = "";
-      if (channelInfo) {
-        name = channelInfo.title;
-      }
-      this._messageInputContext?.addMention(message.fromUID, name);
-    }
+    this.addReplyMention(message.fromUID);
     if (handlerType === 2) {
       let content = message.remoteExtra?.isEdit
         ? message.remoteExtra?.contentEdit?.conversationDigest

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -609,6 +609,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
   }, [props.members]);
 
   const localMembersRef = useRef(props.members);
+  const isDirectChannelRef = useRef(
+    props.context.channel().channelType === ChannelTypePerson,
+  );
   const sendRef = useRef<(() => void) | null>(null);
   const mentionActiveRef = useRef(false);
   const botCommandsRef = useRef(props.botCommands);
@@ -619,6 +622,8 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
 
   // 更新模块级别的 membersRef
   membersRef = localMembersRef;
+  isDirectChannelRef.current =
+    props.context.channel().channelType === ChannelTypePerson;
 
   // 更新 membersRef
   useEffect(() => {
@@ -674,6 +679,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
                   sourceSpaceNameLegacy: member.orgData?.source_space_name,
                 }),
               stickyIcon: mentionAllIcon,
+              includeBroadcastMentions: !isDirectChannelRef.current,
             });
           },
           (active) => {

--- a/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMentionDropdownItems,
+  MENTION_UID_AIS,
+  MENTION_UID_HUMANS,
+} from "../mentionRender";
+
+const members = [
+  { uid: "u1", name: "Alice" },
+  { uid: "bot1", name: "BuildBot", orgData: { robot: 1 } },
+];
+
+const baseArgs = {
+  members,
+  iconResolver: () => "",
+  externalResolver: () => ({ isExternal: false, sourceSpaceName: "" }),
+  stickyIcon: "",
+};
+
+describe("buildMentionDropdownItems", () => {
+  it("prepends broadcast mentions for an empty group query", () => {
+    const items = buildMentionDropdownItems({
+      ...baseArgs,
+      query: "",
+    });
+
+    expect(items.map((item) => item.uid)).toEqual([
+      MENTION_UID_HUMANS,
+      MENTION_UID_AIS,
+      "u1",
+      "bot1",
+    ]);
+  });
+
+  it("omits broadcast mentions when disabled for direct chats", () => {
+    const items = buildMentionDropdownItems({
+      ...baseArgs,
+      query: "",
+      includeBroadcastMentions: false,
+    });
+
+    expect(items.map((item) => item.uid)).toEqual(["u1", "bot1"]);
+  });
+
+  it("keeps broadcast mentions hidden while filtering members", () => {
+    const items = buildMentionDropdownItems({
+      ...baseArgs,
+      query: "Ali",
+    });
+
+    expect(items.map((item) => item.uid)).toEqual(["u1"]);
+  });
+});

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -142,6 +142,8 @@ export interface MentionDropdownItem {
  * dropdown shows only matching members, so `MentionList`'s default
  * `selectedIndex = 0` correctly lands on the first member match and
  * Enter inserts the typed member instead of broadcasting to everyone.
+ * Callers can set `includeBroadcastMentions=false` for direct chats,
+ * where broadcasting to everyone or all AIs does not make sense.
  *
  * `iconResolver` and `externalResolver` are injected so callers can
  * pass the production avatar lookup / external-space resolver, while
@@ -168,12 +170,20 @@ export function buildMentionDropdownItems<
     sourceSpaceName: string;
   };
   stickyIcon: string;
+  includeBroadcastMentions?: boolean;
 }): MentionDropdownItem[] {
-  const { query, members, iconResolver, externalResolver, stickyIcon } = args;
+  const {
+    query,
+    members,
+    iconResolver,
+    externalResolver,
+    stickyIcon,
+    includeBroadcastMentions = true,
+  } = args;
 
   const trimmedQuery = (query ?? "").trim();
   const stickyTop: MentionDropdownItem[] =
-    trimmedQuery.length === 0
+    includeBroadcastMentions && trimmedQuery.length === 0
       ? [
           {
             uid: MENTION_UID_HUMANS,


### PR DESCRIPTION
## Summary
- hide @所有人/@所有AI sticky mention suggestions in direct chats
- skip automatic reply mentions in direct chats, including file preview replies
- add focused coverage for broadcast mention dropdown behavior

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/subscribersReady.test.ts packages/dmworkbase/src/Components/MessageInput/__tests__/useSpaceFeedbackSetting.test.ts
- git diff --check
- pnpm --filter @octo/web build

Fixes #212