### PR TITLE
feat(octo-web): 接收渲染 RichText=14 图文混排 (Phase 1)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -15,6 +15,10 @@
     {
       "path": "packages/dmworkbase/src/Utils/mentionRender.ts",
       "reason": "Mention broadcast token helpers for @所有人/@所有AI. These literals are protocol/display tokens inserted into message content and covered by mention tests, not translatable UI copy in this pass."
+    },
+    {
+      "path": "packages/dmworkbase/src/Messages/RichText/RichTextContent.ts",
+      "reason": "RichText(=14) plain-generation image placeholder. This [图片] literal is a cross-platform wire-format token that must byte-match octo-lib RichTextImagePlaceholder (common/richtext.go) so server/mobile/web produce identical plain text; it is protocol data, not translatable UI copy."
     }
   ]
 }

--- a/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
+++ b/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
@@ -1,0 +1,116 @@
+import { MessageContent } from "wukongimjssdk"
+import { MessageContentTypeConst } from "../../Service/Const"
+import { t } from "../../i18n"
+
+/** RichText(=14) 图文混排 block 类型常量（与 octo-lib common/richtext.go 对齐）。 */
+export const RichTextBlockType = {
+    text: "text",
+    image: "image",
+} as const
+
+/** plain 生成时 image block 注入的占位符（与 octo-lib RichTextImagePlaceholder 对齐）。 */
+export const RichTextImagePlaceholder = "[图片]"
+
+/**
+ * RichText(=14) content 数组中的单个 block。
+ * 字段命名与 server payload（snake_case 兼容）保持一致：
+ *   - text  块：type="text"，text 为纯文本（MVP 不渲染 markdown）；
+ *   - image 块：type="image"，url 为图片引用地址，width/height 供占位排版。
+ */
+export interface RichTextBlock {
+    type: string
+    /** text block 文本内容。 */
+    text?: string
+    /** image block 图片地址（scheme allowlist 仅 http/https）。 */
+    url?: string
+    width?: number
+    height?: number
+    size?: number
+    name?: string
+}
+
+/**
+ * 遍历 content blocks 生成纯文本（与 octo-lib BuildRichTextPlain 对齐）：
+ *   - text  block 取 text；
+ *   - image block 注入占位符；
+ *   - 未知 type 前向兼容：有 text 则取 text，否则跳过。
+ */
+export function buildRichTextPlain(content: RichTextBlock[]): string {
+    let out = ""
+    for (const blk of content) {
+        if (blk.type === RichTextBlockType.image) {
+            out += RichTextImagePlaceholder
+        } else if (blk.type === RichTextBlockType.text) {
+            out += blk.text || ""
+        } else if (blk.text) {
+            out += blk.text
+        }
+    }
+    return out
+}
+
+/**
+ * RichText(=14) 图文混排消息正文（Phase 1：仅接收渲染）。
+ *
+ * payload 结构（见 octo-lib common/richtext.go）：
+ *   { type: 14, content: [ {type:"text",text} | {type:"image",url,width,height} ], plain }
+ *   - content 为有序数组，顺序即图文穿插顺序；
+ *   - plain 为冗余纯文本，server 权威生成，供复制 / 引用预览 / 搜索复用。
+ *
+ * 向后兼容：老 payload content 可能是纯字符串，归一为单个 text block。
+ */
+export class RichTextContent extends MessageContent {
+    content: RichTextBlock[] = []
+    plain = ""
+
+    decodeJSON(content: any) {
+        const raw = content?.content
+        if (Array.isArray(raw)) {
+            this.content = raw.map((blk: any) => ({
+                type: blk?.type,
+                text: blk?.text,
+                url: blk?.url,
+                width: blk?.width,
+                height: blk?.height,
+                size: blk?.size,
+                name: blk?.name,
+            }))
+        } else if (typeof raw === "string") {
+            // 兼容老版本 content 为纯字符串：归一为单个 text block。
+            this.content = raw ? [{ type: RichTextBlockType.text, text: raw }] : []
+        } else {
+            this.content = []
+        }
+        this.plain = typeof content?.plain === "string" ? content.plain : ""
+        // plain 缺失时（老 payload 或字符串 content）现场回填，保证复制/引用预览不丢字。
+        if (this.plain.trim() === "") {
+            this.plain = buildRichTextPlain(this.content)
+        }
+    }
+
+    encodeJSON(): any {
+        // Phase 1 仅接收渲染，发送端留后续单；此处保留可往返编码以防转发等路径复用。
+        return { content: this.content, plain: this.plain }
+    }
+
+    get contentType() {
+        return MessageContentTypeConst.richText
+    }
+
+    /**
+     * 引用预览 / 会话摘要文本：优先 server 生成的 plain，回退现场遍历 blocks，
+     * 都为空再回退到静态「富文本消息」（与旧端 UnknownContent 行为一致）。
+     */
+    get conversationDigest() {
+        if (this.plain.trim() !== "") {
+            return this.plain
+        }
+        const plain = buildRichTextPlain(this.content)
+        if (plain !== "") {
+            return plain
+        }
+        return t("base.message.digest.richText")
+    }
+}
+
+export default RichTextContent

--- a/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
+++ b/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+
+// MessageContent base from the SDK only needs to be a constructable class for
+// RichTextContent to extend; the digest fallback uses i18n t().
+vi.mock("wukongimjssdk", () => ({
+  MessageContent: class {
+    contentObj: any;
+    contentType!: number;
+    decodeJSON(_: any): void {}
+    encodeJSON(): any {
+      return {};
+    }
+    get conversationDigest() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../../../i18n", () => ({
+  // 静态兜底文案：与 message.digest.richText 对应
+  t: () => "[富文本]",
+}));
+
+import {
+  RichTextContent,
+  buildRichTextPlain,
+  RichTextImagePlaceholder,
+} from "../RichTextContent";
+
+describe("buildRichTextPlain", () => {
+  it("拼接 text，image 注入占位符，保留顺序", () => {
+    const plain = buildRichTextPlain([
+      { type: "text", text: "看图：" },
+      { type: "image", url: "https://x/a.png" },
+      { type: "text", text: " 完成" },
+    ]);
+    expect(plain).toBe(`看图：${RichTextImagePlaceholder} 完成`);
+  });
+
+  it("未知 type 有 text 则取 text，否则跳过", () => {
+    expect(
+      buildRichTextPlain([
+        { type: "future", text: "hi" },
+        { type: "future" },
+      ])
+    ).toBe("hi");
+  });
+});
+
+describe("RichTextContent.decodeJSON", () => {
+  it("解析 blocks 数组并优先用 server plain", () => {
+    const c = new RichTextContent();
+    c.decodeJSON({
+      type: 14,
+      content: [
+        { type: "text", text: "hello" },
+        { type: "image", url: "https://x/a.png", width: 10, height: 20 },
+      ],
+      plain: "hello[图片]",
+    });
+    expect(c.content).toHaveLength(2);
+    expect(c.content[1].url).toBe("https://x/a.png");
+    expect(c.plain).toBe("hello[图片]");
+    expect(c.conversationDigest).toBe("hello[图片]");
+  });
+
+  it("plain 缺失时现场遍历 blocks 回填（不丢字）", () => {
+    const c = new RichTextContent();
+    c.decodeJSON({
+      type: 14,
+      content: [
+        { type: "text", text: "a" },
+        { type: "image", url: "https://x/a.png" },
+      ],
+    });
+    expect(c.plain).toBe(`a${RichTextImagePlaceholder}`);
+    expect(c.conversationDigest).toBe(`a${RichTextImagePlaceholder}`);
+  });
+
+  it("向后兼容：content 为纯字符串归一为单个 text block", () => {
+    const c = new RichTextContent();
+    c.decodeJSON({ type: 14, content: "legacy text" });
+    expect(c.content).toEqual([{ type: "text", text: "legacy text" }]);
+    expect(c.plain).toBe("legacy text");
+  });
+
+  it("空内容回退到静态摘要文案", () => {
+    const c = new RichTextContent();
+    c.decodeJSON({ type: 14, content: [] });
+    expect(c.plain).toBe("");
+    expect(c.conversationDigest).toBe("[富文本]");
+  });
+});

--- a/packages/dmworkbase/src/Messages/RichText/index.css
+++ b/packages/dmworkbase/src/Messages/RichText/index.css
@@ -1,0 +1,18 @@
+/* ──────────────────────────────────────────────────────────────
+   RichText(=14) 图文混排消息：按 blocks 顺序穿插文本/图片
+   ────────────────────────────────────────────────────────────── */
+.wk-message-richtext {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  word-break: break-word;
+}
+
+/* 相邻文本块视觉上连续，去掉块间多余间距 */
+.wk-message-richtext-text + .wk-message-richtext-text {
+  margin-top: -4px;
+}
+
+.wk-message-richtext-image {
+  display: flex;
+}

--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -1,0 +1,66 @@
+import React from "react"
+import MessageBase from "../Base"
+import MessageTrail from "../Base/tail"
+import { MessageCell } from "../MessageCell"
+import MarkdownContent, { MarkdownImage } from "../Text/MarkdownContent"
+import { RichTextBlock, RichTextBlockType, RichTextContent } from "./RichTextContent"
+import "./index.css"
+
+export { RichTextContent } from "./RichTextContent"
+
+/**
+ * RichText(=14) 图文混排消息（Phase 1：仅接收渲染）。
+ *
+ * 按 content blocks 数组顺序穿插渲染：
+ *   - text  block：复用 MarkdownContent 管线，但 MVP 锁纯文本（enableMarkdown=false），
+ *     避免 web 渲 markdown 而移动端不渲的跨端不一致；
+ *   - image block：复用 MarkdownImage（Lightbox 大图预览 + url 安全校验）。
+ *
+ * 老端 fallback：未注册 type=14 的旧端落 UnknownCell（已有），本端注册后正常渲染。
+ */
+export class RichTextCell extends MessageCell {
+    render() {
+        const { message, context } = this.props
+        const content = message.content as RichTextContent
+        const blocks: RichTextBlock[] = content.content || []
+
+        return (
+            <MessageBase message={message} context={context}>
+                <div className="wk-message-richtext">
+                    {blocks.map((blk, i) => {
+                        if (blk.type === RichTextBlockType.image) {
+                            return (
+                                <div
+                                    key={`${message.clientMsgNo}-rt-img-${i}`}
+                                    className="wk-message-richtext-image"
+                                >
+                                    <MarkdownImage src={blk.url} alt={blk.name} />
+                                </div>
+                            )
+                        }
+                        // text block（含未知 type 的前向兼容：有 text 则按文本渲染）
+                        const text = blk.text || ""
+                        if (text === "") {
+                            return null
+                        }
+                        return (
+                            <div
+                                key={`${message.clientMsgNo}-rt-text-${i}`}
+                                className="wk-message-richtext-text"
+                            >
+                                <MarkdownContent
+                                    content={text}
+                                    isSend={message.send}
+                                    enableMarkdown={false}
+                                />
+                            </div>
+                        )
+                    })}
+                    <MessageTrail message={message} />
+                </div>
+            </MessageBase>
+        )
+    }
+}
+
+export default RichTextCell

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -6,9 +6,15 @@ import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import Lightbox from "yet-another-react-lightbox";
+import Download from "yet-another-react-lightbox/plugins/download";
+import "yet-another-react-lightbox/styles.css";
 import "highlight.js/styles/github-dark.css";
 import "katex/dist/katex.min.css";
 import "./markdown.css";
+import WKApp from "../../App";
+import { isSafeUrl } from "../../Utils/security";
+import { downloadFile } from "../../Utils/download";
 
 export interface MentionInfo {
   name: string; // "@张三"（含@符号）
@@ -29,6 +35,12 @@ interface MarkdownContentProps {
   emojis?: EmojiInfo[];
   /** 是否启用数学公式渲染（KaTeX），默认 false */
   enableMath?: boolean;
+  /**
+   * 是否启用 Markdown 语法渲染，默认 true。
+   * RichText(=14) MVP 锁纯文本：传 false 时按纯文本渲染（保留换行/链接/emoji/mention），
+   * 不解析标题/列表/表格/代码块等 markdown 语法，避免 web 渲 markdown 而移动端不渲的跨端不一致。
+   */
+  enableMarkdown?: boolean;
 }
 
 /**
@@ -139,6 +151,24 @@ const baseRemarkPlugins: any[] = [remarkGfm, remarkBreaks];
 const mathRemarkPlugins: any[] = [remarkGfm, remarkBreaks, remarkMath];
 
 /**
+ * 纯文本模式（enableMarkdown=false）插件：
+ *   - remark 只保留 remarkBreaks（换行转 <br>），不启用 gfm，避免 markdown 语法解析；
+ *   - rehype 只保留 sanitize 兜底清洗。
+ * 配合 escapeMarkdown 转义，最终按纯文本渲染（与移动端「不渲 markdown」对齐）。
+ */
+const plainRemarkPlugins: any[] = [remarkBreaks];
+const plainRehypePlugins: any[] = [[rehypeSanitize, sanitizeSchema]];
+
+/**
+ * 转义 markdown 语法字符，使内容按纯文本渲染：
+ * 反斜杠转义后 react-markdown 渲染时会还原为原字符（不显示反斜杠），
+ * 从而禁用标题/加粗/列表/代码块/表格/链接等一切 markdown 语法。
+ */
+function escapeMarkdown(raw: string): string {
+  return raw.replace(/[\\`*_{}[\]()#+\-.!>|~]/g, "\\$&");
+}
+
+/**
  * 预处理 Markdown 内容：
  * 把独占一行的 --- / === 补充前后空行，避免被解析成 setext 标题（h2/h1）。
  * 跳过 fenced code block（```...```）内的内容，避免误处理 YAML 等代码中的分隔线。
@@ -235,6 +265,57 @@ const baseComponents: any = {
       <pre {...props}>{children}</pre>
     </div>
   ),
+  img: ({ src, alt }: any) => <MarkdownImage src={src} alt={alt} />,
+};
+
+/**
+ * Markdown / RichText 正文内联图片：
+ *  - url 安全校验（仅 http/https，挡 data:/javascript:/file: 等），不安全则降级为文本占位；
+ *  - 点击打开 Lightbox 大图预览（与 ImageCell 行为一致，带下载）；
+ *  - src 经 datasource 处理，与其它图片渲染路径补全 base URL 保持一致。
+ */
+const MarkdownImage: React.FC<{ src?: string; alt?: string }> = ({
+  src,
+  alt,
+}) => {
+  const [open, setOpen] = useState(false);
+  if (!src) return null;
+  // 经 datasource 解析（补全 base URL / 相对路径改写），与 ImageCell 一致。
+  const resolved = WKApp.dataSource.commonDataSource.getImageURL(src);
+  // 安全校验：解析后必须是 http/https 绝对地址，否则降级为纯文本占位，绝不渲染。
+  if (!isSafeUrl(resolved)) {
+    return <span className="wk-markdown-img-unsafe">{alt || "[图片]"}</span>;
+  }
+  return (
+    <>
+      <img
+        className="wk-markdown-img"
+        src={resolved}
+        alt={alt || ""}
+        loading="lazy"
+        onClick={() => setOpen(true)}
+      />
+      <Lightbox
+        open={open}
+        close={() => setOpen(false)}
+        slides={[{ src: resolved, alt: alt || "" }]}
+        plugins={[Download]}
+        download={{
+          download: ({ slide }) => {
+            if (slide?.src) {
+              downloadFile(slide.src, alt || "image.png");
+            }
+          },
+        }}
+        carousel={{ finite: true }}
+        controller={{ closeOnBackdropClick: true }}
+        render={{
+          buttonPrev: () => null,
+          buttonNext: () => null,
+        }}
+      />
+    </>
+  );
 };
 
 /**
@@ -309,8 +390,12 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   onMentionClick,
   emojis = [],
   enableMath = false,
+  enableMarkdown = true,
 }) => {
-  const normalized = useMemo(() => normalizeContent(content), [content]);
+  const normalized = useMemo(
+    () => (enableMarkdown ? normalizeContent(content) : escapeMarkdown(content)),
+    [content, enableMarkdown]
+  );
 
   // Stabilize mentions/emojis references: only swap when actual content changes.
   // Parent re-renders triggered by scroll events create new array instances with
@@ -379,9 +464,17 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
     isSend,
   ]);
 
-  // 根据是否启用数学公式选择插件
-  const remarkPlugins = enableMath ? mathRemarkPlugins : baseRemarkPlugins;
-  const rehypePlugins = enableMath ? mathRehypePlugins : baseRehypePlugins;
+  // 根据是否启用数学公式 / markdown 选择插件
+  const remarkPlugins = !enableMarkdown
+    ? plainRemarkPlugins
+    : enableMath
+    ? mathRemarkPlugins
+    : baseRemarkPlugins;
+  const rehypePlugins = !enableMarkdown
+    ? plainRehypePlugins
+    : enableMath
+    ? mathRehypePlugins
+    : baseRehypePlugins;
 
   return (
     <div
@@ -401,4 +494,5 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   );
 };
 
+export { MarkdownImage };
 export default MarkdownContent;

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -15,6 +15,7 @@ import "./markdown.css";
 import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
 import { downloadFile } from "../../Utils/download";
+import { t } from "../../i18n";
 
 export interface MentionInfo {
   name: string; // "@张三"（含@符号）
@@ -284,7 +285,11 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string }> = ({
   const resolved = WKApp.dataSource.commonDataSource.getImageURL(src);
   // 安全校验：解析后必须是 http/https 绝对地址，否则降级为纯文本占位，绝不渲染。
   if (!isSafeUrl(resolved)) {
-    return <span className="wk-markdown-img-unsafe">{alt || "[图片]"}</span>;
+    return (
+      <span className="wk-markdown-img-unsafe">
+        {alt || t("base.message.digest.image")}
+      </span>
+    );
   }
   return (
     <>

--- a/packages/dmworkbase/src/Messages/Text/markdown.css
+++ b/packages/dmworkbase/src/Messages/Text/markdown.css
@@ -189,6 +189,19 @@
   border-radius: var(--wk-r-sm);
 }
 
+/* RichText / Markdown 内联图片：可点击放大 */
+.wk-markdown-img {
+  max-width: 100%;
+  max-height: 320px;
+  border-radius: var(--wk-r-sm);
+  cursor: zoom-in;
+}
+
+/* url 安全校验未通过的图片占位（降级为文本，绝不渲染图片） */
+.wk-markdown-img-unsafe {
+  color: var(--wk-text-secondary);
+}
+
 /* ── @mention（消息气泡内的 mention span）── */
 .wk-message-mention {
   display: inline;

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -58,6 +58,7 @@ export class MessageContentTypeConst {
   static mergeForward: number = 11 // 合并转发
   static lottieSticker: number = 12 // lottie贴图
   static lottieEmojiSticker: number = 13 // lottie emoji 贴图
+  static richText: number = 14 // 富文本（图文混排）
   static joinOrganization: number = 16 // 加入组织
   static addMembers: number = 1002 // 添加群成员
   static removeMembers: number = 1003 // 删除群成员

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -685,6 +685,7 @@
   "message.digest.image": "[Image]",
   "message.digest.joinOrganization": "[Organization invite]",
   "message.digest.location": "[Location]",
+  "message.digest.richText": "[Rich text]",
   "message.digest.sticker": "[Sticker]",
   "message.digest.summaryCard": "[Smart summary]",
   "message.digest.voice": "[Voice]",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -686,6 +686,7 @@
   "message.digest.image": "[图片]",
   "message.digest.joinOrganization": "[邀请加入组织]",
   "message.digest.location": "[位置]",
+  "message.digest.richText": "[富文本]",
   "message.digest.sticker": "[贴图]",
   "message.digest.summaryCard": "[智能总结]",
   "message.digest.voice": "[语音]",

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -49,6 +49,7 @@ import {
 } from "./Messages/SignalMessage/signalmessage";
 import { SystemCell } from "./Messages/System";
 import { TextCell } from "./Messages/Text";
+import { RichTextCell, RichTextContent } from "./Messages/RichText";
 import { TimeCell } from "./Messages/Time";
 import { UnknownCell } from "./Messages/Unknown";
 import { UnsupportCell, UnsupportContent } from "./Messages/Unsupport";
@@ -214,6 +215,8 @@ export default class BaseModule implements IModule {
         switch (contentType) {
           case MessageContentType.text: // 文本消息
             return TextCell;
+          case MessageContentTypeConst.richText: // 富文本（图文混排）
+            return RichTextCell;
           case MessageContentType.image: // 图片消息
             return ImageCell;
           case MessageContentTypeConst.card: // 名片
@@ -315,6 +318,12 @@ export default class BaseModule implements IModule {
     );
     // 智能总结卡片
     WKSDK.shared().register(15, () => new SummaryCardContent());
+
+    // 富文本（图文混排）
+    WKSDK.shared().register(
+      MessageContentTypeConst.richText,
+      () => new RichTextContent()
+    );
 
     // 未知消息
     WKApp.messageManager.registerCell(
@@ -703,7 +712,10 @@ export default class BaseModule implements IModule {
     WKApp.endpoints.registerMessageContextMenus(
       "contextmenus.copy",
       (message, context) => {
-        if (message.contentType !== MessageContentType.text) {
+        const isText = message.contentType === MessageContentType.text;
+        const isRichText =
+          message.contentType === MessageContentTypeConst.richText;
+        if (!isText && !isRichText) {
           return null;
         }
 
@@ -711,8 +723,12 @@ export default class BaseModule implements IModule {
           title: t("base.module.contextMenus.copy"),
           onClick: () => {
             const selectedText = context.getCachedSelectedText?.();
-            const textToCopy =
-              selectedText || (message.content as MessageText).text || "";
+            // RichText(=14)：取顶层 plain（server 权威纯文本），避免对 content
+            // blocks 数组 stringify 丢字；text 消息走 content.text。
+            const fullText = isRichText
+              ? (message.content as RichTextContent).plain || ""
+              : (message.content as MessageText).text || "";
+            const textToCopy = selectedText || fullText;
             if (navigator.clipboard?.writeText) {
               navigator.clipboard.writeText(textToCopy).catch(() => {
                 // navigator.clipboard 失败时降级到 execCommand


### PR DESCRIPTION
## What

Web 接收渲染 RichText=14 图文混排（Phase 1，只做接收渲染）。RichText=14 此前在 web 两个注册表均无实现，收到落 UnknownCell。本 PR 在 octo-web 注册并渲染该类型。

Schema 对齐 octo-lib `common/richtext.go`：`{ type:14, content:[blocks], plain }`，`content` 为有序数组（顺序即图文穿插顺序），`plain` 为 server 权威纯文本。

## Changes

1. **双注册表加 type=14**（`module.tsx`）：`type→Cell`（RichTextCell）+ `type→Content model`（RichTextContent）。
2. **新增 RichTextCell**：按 `content` blocks 数组顺序穿插渲染 text / image 块。
3. **text 块**复用 `MarkdownContent` 管线，但 MVP 锁纯文本：新增 `enableMarkdown` prop，对 14 传 `false`（转义 markdown 语法字符 + 去 gfm/highlight/math），避免 web 渲 markdown 而移动端不渲的跨端不一致；保留换行/链接/emoji/mention。
4. **image 块**：给 `MarkdownContent` `baseComponents` 补 `img` 组件（`MarkdownImage`）—— 接 Lightbox 大图预览 + url 安全校验（`isSafeUrl`，仅 http/https；不安全降级为文本占位，绝不渲染）。此前 baseComponents 只覆盖 a/pre。
5. **复制取顶层 plain**：copy 菜单对 14 取 `content.plain`（server 权威纯文本），不再对 content blocks 数组 stringify 丢字。
6. **引用预览**：14 的 `conversationDigest` 从 `plain` 取，回退现场遍历 blocks，再回退静态「富文本消息」。
7. **老端 fallback 不崩**：未注册 14 的旧端仍落 UnknownCell（已有）。
8. i18n 补 `message.digest.richText`（zh/en）。

## 不在本单（留后续，依赖 server plain 链路）

- 发送端 Tiptap 聚合单 payload
- SmartCreateModal 抽 digest

## 验证

- `pnpm build` ✅（apps/web + extension turbo build 全绿）
- `pnpm lint` ✅
- 新增单测 `RichTextContent.test.ts` 6 个用例全绿（decode / plain 回填 / 字符串兼容 / 空内容 fallback）
- base 包测试套件：本改动 +6 通过、0 新增失败（既有 31 失败为不相关组件，clean base 同样存在）

## 审查状态

- 改动规模：+~260 行, 10 文件（含新增 cell/model/test/css）
- /review: PASS ✅（critical pass：Enum & Value Completeness 已审 sibling handlers；URL trust boundary：图片 url 经 isSafeUrl 校验）
- /codex: 另派 ReviewBot 独立 codex-review

Fixes #217

## Codex review

独立 codex-review 提了 1 个 P1：新增的两处硬编码中文 `[图片]` 会让 CI 的 `pnpm i18n:check` 失败。已修复：
- `MarkdownImage` 不安全 url 兜底文案改走 `base.message.digest.image`；
- `RichTextContent.ts` 的 `[图片]` 是必须与 octo-lib `RichTextImagePlaceholder` 字节对齐的跨端 wire-format token（协议数据，非 UI 文案），按 EmojiService/mentionRender 先例加入 `.i18n/scan-config.json` 白名单。
- `pnpm i18n:check` 现已通过 ✅