### PR TITLE
feat(octo-web): send RichText=14 mixed text+image + SmartCreateModal digest (Phase 1)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -71,6 +71,13 @@ import {
   resolveSafeFileUrl,
 } from "../../Messages/File";
 import { ImageContent } from "../../Messages/Image";
+import {
+  RichTextBlock,
+  createRichTextContent,
+  makeTextBlock,
+  makeImageBlock,
+} from "../../Messages/RichText/RichTextContent";
+import { isSafeUrl } from "../../Utils/security";
 import { downloadFile } from "../../Utils/download";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
@@ -84,7 +91,7 @@ import {
 import { parseThreadChannelId } from "../../Service/Thread";
 import FoldSessionExpandedList from "./FoldSessionExpandedList";
 import VoiceFeedback from "../../Service/VoiceFeedback";
-import { precheckUploadCredentials } from "../../Service/UploadCredentials";
+import { precheckUploadCredentials, uploadChatMedia } from "../../Service/UploadCredentials";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext, t } from "../../i18n";
 
@@ -683,6 +690,119 @@ export class Conversation
     }
 
     return promise;
+  }
+
+  /**
+   * 图文混排发送：把编辑器里穿插的 text / image 块聚合成单条 RichText(=14) 消息。
+   *
+   * 仅在「同时含文本和图片、且无非图片文件块」时触发（见 onSend）。纯文本仍走
+   * 文本消息(type=1)、纯图片仍走 ImageContent(type=2)，避免回退已落地的发送路径。
+   *
+   * - blocks schema 复用 #218 接收侧 RichTextContent 同一份定义（makeTextBlock /
+   *   makeImageBlock），wire-format 与 octo-lib 权威 schema byte-match。
+   * - 图片先 uploadChatMedia 拿 downloadUrl，再 isSafeUrl(http/https) 校验（与接收侧
+   *   对称，防 javascript:/data:/file: 注入）；单张图片上传失败/URL 不安全则 Toast 跳过该图。
+   * - plain 由 createRichTextContent 本地占位，server #232 Finalize 重算覆盖。
+   * - mention：合并各文本块的 all/uids/humans/ais 到顶层，保证群里 @人/@所有AI 通知不丢
+   *   （vm.sendMessage 读 content.mention.humans/ais 注入）。
+   *
+   * 返回 true 表示消息已入队。
+   */
+  private async sendRichTextMixed(
+    editorBlocks: EditorContentBlock[],
+    reply?: Reply,
+  ): Promise<boolean> {
+    const channel = this.channel();
+    const contentBlocks: RichTextBlock[] = [];
+
+    // 合并 mention（跨多个文本块）。
+    let mentionAll = false;
+    const mentionUids = new Set<string>();
+    let mentionHumans = false;
+    let mentionAis = false;
+
+    for (const block of editorBlocks) {
+      if (block.type === "text") {
+        if (block.text) {
+          contentBlocks.push(makeTextBlock(block.text));
+        }
+        const m = block.mention;
+        if (m) {
+          if (m.all) mentionAll = true;
+          if (m.humans) mentionHumans = true;
+          if (m.ais) mentionAis = true;
+          m.uids?.forEach((uid) => mentionUids.add(uid));
+        }
+      } else if (block.type === "image") {
+        const file = block.file;
+        const dot = (file.name || "").lastIndexOf(".");
+        const ext = dot > 0 ? file.name.substring(dot + 1) : "";
+        let url: string;
+        try {
+          url = await uploadChatMedia(file, channel, ext);
+        } catch (err) {
+          const msg =
+            (err as { msg?: string })?.msg ||
+            t("base.conversation.upload.failed");
+          Toast.error(
+            t("base.conversation.upload.imageFailed", {
+              values: { name: file.name, message: msg },
+            }),
+          );
+          continue;
+        }
+        // 安全：发送前图片 URL 走 isSafeUrl(http/https only)，与接收侧对称。
+        if (!isSafeUrl(url)) {
+          Toast.error(
+            t("base.conversation.upload.imageFailed", {
+              values: {
+                name: file.name,
+                message: t("base.conversation.upload.failed"),
+              },
+            }),
+          );
+          continue;
+        }
+        const { width, height } = await new Promise<{
+          width: number;
+          height: number;
+        }>((resolve) => {
+          const img = new Image();
+          img.onload = () =>
+            resolve({ width: img.naturalWidth, height: img.naturalHeight });
+          img.onerror = () => resolve({ width: 0, height: 0 });
+          img.src = url;
+        });
+        contentBlocks.push(
+          makeImageBlock({
+            url,
+            width,
+            height,
+            size: file.size,
+            name: file.name || undefined,
+          }),
+        );
+      }
+      // file 块在 onSend 已被排除在图文混排路径之外
+    }
+
+    if (contentBlocks.length === 0) {
+      return false;
+    }
+
+    const content = createRichTextContent(contentBlocks);
+    if (reply) {
+      content.reply = reply;
+    }
+    if (mentionAll || mentionUids.size > 0 || mentionHumans || mentionAis) {
+      const mn = new Mention();
+      mn.all = mentionAll;
+      if (mentionUids.size > 0) mn.uids = Array.from(mentionUids);
+      if (mentionHumans) (mn as any).humans = 1;
+      if (mentionAis) (mn as any).ais = 1;
+      content.mention = mn;
+    }
+    return this.sendTextAndWaitAck(content);
   }
 
   scrollToBottom(animate?: boolean): void {
@@ -2541,6 +2661,40 @@ export class Conversation
 
                         // ── 第二阶段：按编辑器文档顺序发送内容块（文本段和粘贴图片交替） ──
                         if (editorBlocks && editorBlocks.length > 0) {
+                          // 图文混排：同时含文本和图片、且无非图片文件块时，聚合成单条
+                          // RichText(=14) 消息（而非拆成多条独立消息）。含 file 块或
+                          // 纯文本/纯图片时仍走下方逐块发送路径，不回退已落地逻辑。
+                          const hasText = editorBlocks.some(
+                            (b) => b.type === "text" && b.text.trim() !== "",
+                          );
+                          const hasImage = editorBlocks.some(
+                            (b) => b.type === "image",
+                          );
+                          const hasFile = editorBlocks.some(
+                            (b) => b.type === "file",
+                          );
+                          if (hasText && hasImage && !hasFile) {
+                            try {
+                              if (await this.sendRichTextMixed(editorBlocks, reply)) {
+                                anyMessageSent = true;
+                              }
+                              reply = undefined;
+                            } catch (err) {
+                              console.error(
+                                "[Conversation] richtext mixed send failed:",
+                                err,
+                              );
+                              Toast.error(t("base.conversation.message.sendFailed"));
+                            }
+                            if (anyMessageSent) {
+                              await this.clearDraftAfterSend(
+                                sendDraftGeneration,
+                                remoteDraftAtSend,
+                              );
+                            }
+                            this.props.onMessageSent?.();
+                            return;
+                          }
                           let isFirstTextBlock = true;
                           for (const block of editorBlocks) {
                             try {

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -43,6 +43,7 @@ import MessageInput, {
   MessageInputContext,
   EditorContentBlock,
 } from "../MessageInput";
+import { SendResultDetail } from "../MessageInput/sendFlow";
 import { BotCommand } from "../SlashCommandMenu";
 import ContextMenus, { ContextMenusContext } from "../ContextMenus";
 import classNames from "classnames";
@@ -2476,7 +2477,7 @@ export class Conversation
                         _attachments?: { id: string; file: File }[],
                         topFiles?: { id: string; file: File }[],
                         editorBlocks?: EditorContentBlock[],
-                      ): Promise<boolean> => {
+                      ): Promise<boolean | SendResultDetail> => {
                         // 返回值告诉 MessageInput 是否清空编辑器/附件：
                         //   true  → 发送成功(或已消费)，清空草稿+附件；
                         //   false → 发送失败，保留编辑器内容+图片引用供重试。
@@ -2681,8 +2682,12 @@ export class Conversation
                         // 若所有顶部附件 + 编辑器内容块都被预检拒绝,且没有文本块,
                         // 则不应再补发空回复消息 (octo-web#119 review by Jerry-Xin)。
                         let anyMessageSent = false;
+                        // 记录实际发出的顶部附件 id：失败时让 MessageInput 仅
+                        // 清掉这些已发文件、保留编辑器草稿，重试不会重复发送
+                        // (octo-web#227 Jerry-Xin non-blocking)。
+                        const consumedTopIds: string[] = [];
                         const topFilesToSend = topFiles || [];
-                        for (const { file } of topFilesToSend) {
+                        for (const { id, file } of topFilesToSend) {
                           try {
                             let sent = false;
                             if (file.type && file.type.startsWith("image/")) {
@@ -2690,7 +2695,10 @@ export class Conversation
                             } else {
                               sent = await sendFileAttachment(file);
                             }
-                            if (sent) anyMessageSent = true;
+                            if (sent) {
+                              anyMessageSent = true;
+                              consumedTopIds.push(id);
+                            }
                           } catch (err) {
                             Toast.error(t("base.conversation.upload.fileSendFailed", {
                               values: { name: file.name },
@@ -2742,10 +2750,17 @@ export class Conversation
                               );
                             }
                             this.props.onMessageSent?.();
-                            // 返回 mixedSent：失败时 (false) MessageInput 保留编辑器
-                            // 文本+图片引用与预览 URL，用户可直接重试整条消息
-                            // (octo-web#227 Jerry-Xin P1)。
-                            return mixedSent;
+                            // 返回 snapshot-aware 结果 (octo-web#227 Jerry-Xin
+                            // 第二轮)：
+                            //   • editorConsumed=mixedSent：混排失败时保留编辑器
+                            //     文本+图片，用户可整条重试；
+                            //   • consumedTopIds：本次已发出的顶部附件 id。即使
+                            //     混排失败，这些文件也已发出，让 MessageInput 只
+                            //     清掉它们、不随编辑器草稿一起保留，避免重试重复。
+                            return {
+                              editorConsumed: mixedSent,
+                              consumedTopIds,
+                            };
                           }
                           let isFirstTextBlock = true;
                           for (const block of editorBlocks) {

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -2476,7 +2476,12 @@ export class Conversation
                         _attachments?: { id: string; file: File }[],
                         topFiles?: { id: string; file: File }[],
                         editorBlocks?: EditorContentBlock[],
-                      ) => {
+                      ): Promise<boolean> => {
+                        // 返回值告诉 MessageInput 是否清空编辑器/附件：
+                        //   true  → 发送成功(或已消费)，清空草稿+附件；
+                        //   false → 发送失败，保留编辑器内容+图片引用供重试。
+                        // 关键：混排 (text+image) 上传失败时必须返回 false，否则
+                        // 用户整条消息会被同步清空丢失 (octo-web#227 Jerry-Xin P1)。
                         const sendDraftGeneration = this.draftSaveGeneration;
                         const remoteDraftAtSend =
                           this.vm.currentConversation?.remoteExtra?.draft || "";
@@ -2498,7 +2503,8 @@ export class Conversation
                               JSON.stringify(json),
                             );
                             vm.currentReplyMessage = undefined;
-                            return;
+                            // 编辑消息已提交，编辑器应清空。
+                            return true;
                           }
                           reply = new Reply();
                           reply.messageID = vm.currentReplyMessage.messageID;
@@ -2736,7 +2742,10 @@ export class Conversation
                               );
                             }
                             this.props.onMessageSent?.();
-                            return;
+                            // 返回 mixedSent：失败时 (false) MessageInput 保留编辑器
+                            // 文本+图片引用与预览 URL，用户可直接重试整条消息
+                            // (octo-web#227 Jerry-Xin P1)。
+                            return mixedSent;
                           }
                           let isFirstTextBlock = true;
                           for (const block of editorBlocks) {
@@ -2804,6 +2813,10 @@ export class Conversation
                           );
                         }
                         this.props.onMessageSent?.();
+                        // 与 clearDraftAfterSend 同口径：只有确实发出消息时才让
+                        // MessageInput 清空编辑器；全部失败/被预检拒绝时返回 false
+                        // 保留草稿可重试。
+                        return anyMessageSent;
                       }}
                     ></MessageInput>
                   </div>

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -2707,8 +2707,13 @@ export class Conversation
                             (b) => b.type === "file",
                           );
                           if (hasText && hasImage && !hasFile) {
+                            // 单独跟踪图文混排是否成功：图片准备失败时 sendRichTextMixed
+                            // 抛错，此时即便此前顶部附件已发(anyMessageSent=true)，也不能
+                            // 清空编辑器草稿——草稿里的文本+图片整条都没发出，须保留可重试。
+                            let mixedSent = false;
                             try {
                               if (await this.sendRichTextMixed(editorBlocks, reply)) {
+                                mixedSent = true;
                                 anyMessageSent = true;
                               }
                               reply = undefined;
@@ -2718,12 +2723,13 @@ export class Conversation
                                 err,
                               );
                               // 图片准备失败已在 sendRichTextMixed 内 Toast 具体原因，
-                              // 不再重复弹通用错误（草稿因 anyMessageSent=false 自动保留可重试）。
+                              // 不再重复弹通用错误。
                               if (!(err as { toasted?: boolean })?.toasted) {
                                 Toast.error(t("base.conversation.message.sendFailed"));
                               }
                             }
-                            if (anyMessageSent) {
+                            // 仅当图文混排本身发出时才清草稿；失败则保留编辑器内容可重试。
+                            if (mixedSent) {
                               await this.clearDraftAfterSend(
                                 sendDraftGeneration,
                                 remoteDraftAtSend,

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -190,6 +190,35 @@ function guessFileNameFromUrl(url: string, fallback: string): string {
 }
 
 /**
+ * 从本地图片文件读取像素尺寸（用 FileReader → Image，绝不依赖远端 URL）。
+ *
+ * Why: RichText image block 的 width/height 是 schema 必填>0（供端上占位排版）。
+ * 若从刚上传的 downloadUrl 读尺寸，CDN read-after-write 延迟可能让 Image 读到 0×0，
+ * 注入非法块。纯图片发送路径(sendImageFile)本就从本地文件量尺寸，这里保持一致。
+ */
+function readLocalImageSize(
+  file: File,
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const dataUrl = reader.result as string;
+      if (!dataUrl) {
+        resolve({ width: 0, height: 0 });
+        return;
+      }
+      const img = new Image();
+      img.onload = () =>
+        resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      img.onerror = () => resolve({ width: 0, height: 0 });
+      img.src = dataUrl;
+    };
+    reader.onerror = () => resolve({ width: 0, height: 0 });
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
  * 从 WuKongIM Message 对象解析发送人的展示名。
  *
  * WuKongIM SDK 的 Message 只带 fromUID, 不带 fromName; name 必须前端自己解析。
@@ -700,13 +729,17 @@ export class Conversation
    *
    * - blocks schema 复用 #218 接收侧 RichTextContent 同一份定义（makeTextBlock /
    *   makeImageBlock），wire-format 与 octo-lib 权威 schema byte-match。
-   * - 图片先 uploadChatMedia 拿 downloadUrl，再 isSafeUrl(http/https) 校验（与接收侧
-   *   对称，防 javascript:/data:/file: 注入）；单张图片上传失败/URL 不安全则 Toast 跳过该图。
+   * - 原子性：单条 RichText 是一个整体，任一图片上传失败 / URL 不安全 / 本地尺寸读取
+   *   失败 → 整条消息发送中止（抛错），调用方不清草稿、用户可重试，绝不静默丢图。
+   * - 图片尺寸取**本地文件**（与纯图片路径一致），不依赖刚上传的 downloadUrl，避免
+   *   CDN read-after-write 延迟导致 width/height=0 违反 image schema 必填>0。
+   * - 上传成功后图片 URL 走 isSafeUrl(http/https only)（与接收侧对称，防 javascript:/
+   *   data:/file: 注入）。
    * - plain 由 createRichTextContent 本地占位，server #232 Finalize 重算覆盖。
    * - mention：合并各文本块的 all/uids/humans/ais 到顶层，保证群里 @人/@所有AI 通知不丢
    *   （vm.sendMessage 读 content.mention.humans/ais 注入）。
    *
-   * 返回 true 表示消息已入队。
+   * 返回 true 表示消息已入队；任一图片块准备失败则抛错（已 Toast 具体原因）。
    */
   private async sendRichTextMixed(
     editorBlocks: EditorContentBlock[],
@@ -720,6 +753,21 @@ export class Conversation
     const mentionUids = new Set<string>();
     let mentionHumans = false;
     let mentionAis = false;
+
+    // 单张图片准备失败 → Toast 具体原因后抛错，让整条消息原子失败（草稿保留可重试）。
+    const failImage = (file: File, message: string): never => {
+      Toast.error(
+        t("base.conversation.upload.imageFailed", {
+          values: { name: file.name, message },
+        }),
+      );
+      const e = new Error(
+        `richtext mixed image prepare failed: ${file.name}`,
+      ) as Error & { toasted?: boolean };
+      // 标记已 Toast，调用方 catch 不再重复弹通用错误。
+      e.toasted = true;
+      throw e;
+    };
 
     for (const block of editorBlocks) {
       if (block.type === "text") {
@@ -735,6 +783,14 @@ export class Conversation
         }
       } else if (block.type === "image") {
         const file = block.file;
+        // 1. 先从本地文件读尺寸（schema 必填>0，且不受 CDN 延迟影响）。
+        const { width, height } = await readLocalImageSize(file);
+        if (width <= 0 || height <= 0) {
+          failImage(file, t("base.conversation.upload.imageReadFailed", {
+            values: { name: file.name },
+          }));
+        }
+        // 2. 上传拿 downloadUrl。
         const dot = (file.name || "").lastIndexOf(".");
         const ext = dot > 0 ? file.name.substring(dot + 1) : "";
         let url: string;
@@ -744,38 +800,15 @@ export class Conversation
           const msg =
             (err as { msg?: string })?.msg ||
             t("base.conversation.upload.failed");
-          Toast.error(
-            t("base.conversation.upload.imageFailed", {
-              values: { name: file.name, message: msg },
-            }),
-          );
-          continue;
+          failImage(file, msg);
         }
-        // 安全：发送前图片 URL 走 isSafeUrl(http/https only)，与接收侧对称。
-        if (!isSafeUrl(url)) {
-          Toast.error(
-            t("base.conversation.upload.imageFailed", {
-              values: {
-                name: file.name,
-                message: t("base.conversation.upload.failed"),
-              },
-            }),
-          );
-          continue;
+        // 3. 安全：发送前图片 URL 走 isSafeUrl(http/https only)，与接收侧对称。
+        if (!isSafeUrl(url!)) {
+          failImage(file, t("base.conversation.upload.failed"));
         }
-        const { width, height } = await new Promise<{
-          width: number;
-          height: number;
-        }>((resolve) => {
-          const img = new Image();
-          img.onload = () =>
-            resolve({ width: img.naturalWidth, height: img.naturalHeight });
-          img.onerror = () => resolve({ width: 0, height: 0 });
-          img.src = url;
-        });
         contentBlocks.push(
           makeImageBlock({
-            url,
+            url: url!,
             width,
             height,
             size: file.size,
@@ -2684,7 +2717,11 @@ export class Conversation
                                 "[Conversation] richtext mixed send failed:",
                                 err,
                               );
-                              Toast.error(t("base.conversation.message.sendFailed"));
+                              // 图片准备失败已在 sendRichTextMixed 内 Toast 具体原因，
+                              // 不再重复弹通用错误（草稿因 anyMessageSent=false 自动保留可重试）。
+                              if (!(err as { toasted?: boolean })?.toasted) {
+                                Toast.error(t("base.conversation.message.sendFailed"));
+                              }
                             }
                             if (anyMessageSent) {
                               await this.clearDraftAfterSend(

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -1,51 +1,73 @@
 /**
- * Regression tests for the mixed text+image send-failure data-loss bug
- * (octo-web#227, Jerry-Xin P1).
+ * Regression tests for the two send-side data-loss bugs (octo-web#227).
  *
- * The bug: MessageInput cleared the editor / deleted pasted-image File refs /
- * revoked preview URLs synchronously, BEFORE the awaited async send (mixed
- * RichText) could report failure. A failed image upload therefore destroyed
- * the user's whole text+image compose with no message and nothing to retry.
+ * Round 1 — mixed text+image send failure wiped the draft:
+ *   MessageInput cleared the editor / deleted pasted-image File refs / revoked
+ *   preview URLs synchronously, BEFORE the awaited async send (mixed RichText)
+ *   could report failure. A failed image upload therefore destroyed the user's
+ *   whole text+image compose with no message and nothing to retry.
+ *
+ * Round 2 — await-cleanup race wiped the NEXT draft (Jerry-Xin P1):
+ *   Once the send was awaited, the editor stayed editable during the wait. If
+ *   the user finished one message and started typing the next while upload/ack
+ *   was still pending, the older send's success cleared the live (newer) editor
+ *   and top-attachment list. The cleanup must be snapshot-aware: clear the
+ *   editor only if it still holds exactly what was sent, and remove only the
+ *   top attachments that were actually consumed.
  *
  * The contract these tests lock in:
- *   - send resolves false  → NO cleanup runs; editor draft + image refs +
- *                            preview URLs survive for retry.
- *   - send throws          → same as false (preserve draft).
- *   - send resolves true    → cleanup runs (success path unchanged).
- *   - send resolves void    → treated as success (back-compat with legacy
- *                            void-returning onSend callers).
+ *   - send resolves false  → editor preserved; no top attachment removed.
+ *   - send throws          → same as false.
+ *   - send resolves true / void → success; consumed top ids = all; editor
+ *     cleared IFF unchanged.
+ *   - send resolves a detail object → partial: editor cleared per
+ *     editorConsumed, top attachments removed per consumedTopIds.
+ *   - editor changed during await → editor NEVER cleared (round-2 fix), even on
+ *     success; consumed top attachments are still removed by id.
  *   - cleanup never runs before the send settles (ordering guarantee).
  */
 
 import { describe, it, expect, vi } from "vitest";
 import { runSendWithCleanup, SendCleanup } from "../sendFlow";
 
-function makeCleanup(): SendCleanup & { calls: string[] } {
-  const calls: string[] = [];
-  return {
-    calls,
-    deleteAttachmentRefs: vi.fn(() => calls.push("deleteAttachmentRefs")),
-    revokePreviewUrls: vi.fn(() => calls.push("revokePreviewUrls")),
-    clearTopAttachments: vi.fn(() => calls.push("clearTopAttachments")),
-    clearEditor: vi.fn(() => calls.push("clearEditor")),
-    collapseExpanded: vi.fn(() => calls.push("collapseExpanded")),
-  };
+interface RecordingCleanup extends SendCleanup {
+  calls: string[];
+  removedIds: string[];
+  editorUnchanged: boolean;
 }
 
-describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#227)", () => {
-  it("does NOT clear editor / delete image refs / revoke URLs when send resolves false", async () => {
+function makeCleanup(opts?: { editorUnchanged?: boolean }): RecordingCleanup {
+  const calls: string[] = [];
+  const removedIds: string[] = [];
+  const state = {
+    calls,
+    removedIds,
+    editorUnchanged: opts?.editorUnchanged ?? true,
+    isEditorUnchanged: vi.fn(() => state.editorUnchanged),
+    deleteEditorAttachmentRefs: vi.fn(() => calls.push("deleteEditorAttachmentRefs")),
+    revokeEditorPreviewUrls: vi.fn(() => calls.push("revokeEditorPreviewUrls")),
+    clearEditor: vi.fn(() => calls.push("clearEditor")),
+    removeTopAttachments: vi.fn((ids: string[]) => {
+      calls.push("removeTopAttachments");
+      removedIds.push(...ids);
+    }),
+    collapseExpanded: vi.fn(() => calls.push("collapseExpanded")),
+  };
+  return state as unknown as RecordingCleanup;
+}
+
+describe("runSendWithCleanup — round 1: mixed send failure preserves draft", () => {
+  it("does NOT clear editor / refs / urls and removes no top attachment when send resolves false", async () => {
     const cleanup = makeCleanup();
-    // mixed text+image send fails (e.g. image upload / read failure)
     const send = vi.fn().mockResolvedValue(false);
 
-    const ok = await runSendWithCleanup(send, cleanup);
+    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
 
     expect(ok).toBe(false);
-    // The whole compose state must survive so the user can retry.
-    expect(cleanup.deleteAttachmentRefs).not.toHaveBeenCalled();
-    expect(cleanup.revokePreviewUrls).not.toHaveBeenCalled();
-    expect(cleanup.clearTopAttachments).not.toHaveBeenCalled();
     expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
+    expect(cleanup.removeTopAttachments).not.toHaveBeenCalled();
     expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
     expect(cleanup.calls).toEqual([]);
   });
@@ -54,22 +76,23 @@ describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#22
     const cleanup = makeCleanup();
     const send = vi.fn().mockRejectedValue(new Error("upload failed"));
 
-    const ok = await runSendWithCleanup(send, cleanup);
+    const ok = await runSendWithCleanup(send, ["t1"], cleanup);
 
     expect(ok).toBe(false);
     expect(cleanup.calls).toEqual([]);
   });
 
-  it("clears compose state when send succeeds (resolves true)", async () => {
+  it("clears compose state and removes all top attachments when send resolves true", async () => {
     const cleanup = makeCleanup();
     const send = vi.fn().mockResolvedValue(true);
 
-    const ok = await runSendWithCleanup(send, cleanup);
+    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
 
     expect(ok).toBe(true);
-    expect(cleanup.deleteAttachmentRefs).toHaveBeenCalledTimes(1);
-    expect(cleanup.revokePreviewUrls).toHaveBeenCalledTimes(1);
-    expect(cleanup.clearTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+    expect(cleanup.deleteEditorAttachmentRefs).toHaveBeenCalledTimes(1);
+    expect(cleanup.revokeEditorPreviewUrls).toHaveBeenCalledTimes(1);
     expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
     expect(cleanup.collapseExpanded).toHaveBeenCalledTimes(1);
   });
@@ -78,10 +101,11 @@ describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#22
     const cleanup = makeCleanup();
     const send = vi.fn().mockResolvedValue(undefined);
 
-    const ok = await runSendWithCleanup(send, cleanup);
+    const ok = await runSendWithCleanup(send, ["t1"], cleanup);
 
     expect(ok).toBe(true);
     expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1"]);
   });
 
   it("treats a synchronous void return as success", async () => {
@@ -90,7 +114,7 @@ describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#22
       /* legacy void onSend */
     });
 
-    const ok = await runSendWithCleanup(send, cleanup);
+    const ok = await runSendWithCleanup(send, [], cleanup);
 
     expect(ok).toBe(true);
     expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
@@ -106,17 +130,119 @@ describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#22
         }),
     );
 
-    const p = runSendWithCleanup(send, cleanup);
+    const p = runSendWithCleanup(send, ["t1"], cleanup);
 
-    // Send is still in flight (upload pending) — nothing must be cleared yet.
     await Promise.resolve();
     expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.removeTopAttachments).not.toHaveBeenCalled();
 
     resolveSend(true);
     await p;
 
-    // Only after the send resolves successfully does cleanup happen.
     expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the NEXT draft", () => {
+  it("does NOT clear the editor when the user started a new draft during the await, even on success", async () => {
+    // editor changed during the await → isEditorUnchanged() returns false.
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    // Send still reported success...
+    expect(ok).toBe(true);
+    // ...but the live (newer) editor draft must survive untouched.
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
+    expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
+  });
+
+  it("still removes consumed top attachments by id even when the editor changed mid-flight", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    // Consumed top attachments are id-scoped, so removing them never touches a
+    // newly queued attachment — safe regardless of editor changes.
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+    // Editor itself preserved.
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+
+  it("clears the editor on success when it still holds exactly what was sent", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: true });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, [], cleanup);
+
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it("pure-text send: a new draft typed during ack wait is not wiped by the old send", async () => {
+    // Pure text now also awaits sendTextAndWaitAck; simulate ack landing after
+    // the user started a new line.
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    let resolveSend!: (v: boolean) => void;
+    const send = vi.fn(
+      () => new Promise<boolean>((res) => (resolveSend = res)),
+    );
+
+    const p = runSendWithCleanup(send, [], cleanup);
+    // user types the next message while ack is pending → editor now differs.
+    resolveSend(true);
+    const ok = await p;
+
+    expect(ok).toBe(true);
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSendWithCleanup — partial result (top attachments sent, editor failed)", () => {
+  it("preserves the editor but drops only the consumed top attachments (no retry duplication)", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: true });
+    // Top attachments t1,t2 were sent first; the mixed editor send then failed.
+    const send = vi
+      .fn()
+      .mockResolvedValue({ editorConsumed: false, consumedTopIds: ["t1", "t2"] });
+
+    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    // editorConsumed=false → return false so MessageInput keeps the editor.
+    expect(ok).toBe(false);
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    // But the already-sent top attachments are removed so retry won't resend.
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+  });
+
+  it("detail with editorConsumed=true clears editor and removes the listed top ids", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: true });
+    const send = vi
+      .fn()
+      .mockResolvedValue({ editorConsumed: true, consumedTopIds: ["t1"] });
+
+    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    // Only the explicitly-consumed id is removed, not the whole allTopIds list.
+    expect(cleanup.removedIds).toEqual(["t1"]);
+  });
+
+  it("detail editorConsumed=true with no consumedTopIds falls back to all top ids", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: true });
+    const send = vi.fn().mockResolvedValue({ editorConsumed: true });
+
+    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for the mixed text+image send-failure data-loss bug
+ * (octo-web#227, Jerry-Xin P1).
+ *
+ * The bug: MessageInput cleared the editor / deleted pasted-image File refs /
+ * revoked preview URLs synchronously, BEFORE the awaited async send (mixed
+ * RichText) could report failure. A failed image upload therefore destroyed
+ * the user's whole text+image compose with no message and nothing to retry.
+ *
+ * The contract these tests lock in:
+ *   - send resolves false  → NO cleanup runs; editor draft + image refs +
+ *                            preview URLs survive for retry.
+ *   - send throws          → same as false (preserve draft).
+ *   - send resolves true    → cleanup runs (success path unchanged).
+ *   - send resolves void    → treated as success (back-compat with legacy
+ *                            void-returning onSend callers).
+ *   - cleanup never runs before the send settles (ordering guarantee).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { runSendWithCleanup, SendCleanup } from "../sendFlow";
+
+function makeCleanup(): SendCleanup & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    deleteAttachmentRefs: vi.fn(() => calls.push("deleteAttachmentRefs")),
+    revokePreviewUrls: vi.fn(() => calls.push("revokePreviewUrls")),
+    clearTopAttachments: vi.fn(() => calls.push("clearTopAttachments")),
+    clearEditor: vi.fn(() => calls.push("clearEditor")),
+    collapseExpanded: vi.fn(() => calls.push("collapseExpanded")),
+  };
+}
+
+describe("runSendWithCleanup — mixed send failure preserves draft (octo-web#227)", () => {
+  it("does NOT clear editor / delete image refs / revoke URLs when send resolves false", async () => {
+    const cleanup = makeCleanup();
+    // mixed text+image send fails (e.g. image upload / read failure)
+    const send = vi.fn().mockResolvedValue(false);
+
+    const ok = await runSendWithCleanup(send, cleanup);
+
+    expect(ok).toBe(false);
+    // The whole compose state must survive so the user can retry.
+    expect(cleanup.deleteAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.revokePreviewUrls).not.toHaveBeenCalled();
+    expect(cleanup.clearTopAttachments).not.toHaveBeenCalled();
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
+    expect(cleanup.calls).toEqual([]);
+  });
+
+  it("preserves draft when send throws (image prepare/upload error)", async () => {
+    const cleanup = makeCleanup();
+    const send = vi.fn().mockRejectedValue(new Error("upload failed"));
+
+    const ok = await runSendWithCleanup(send, cleanup);
+
+    expect(ok).toBe(false);
+    expect(cleanup.calls).toEqual([]);
+  });
+
+  it("clears compose state when send succeeds (resolves true)", async () => {
+    const cleanup = makeCleanup();
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.deleteAttachmentRefs).toHaveBeenCalledTimes(1);
+    expect(cleanup.revokePreviewUrls).toHaveBeenCalledTimes(1);
+    expect(cleanup.clearTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    expect(cleanup.collapseExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats void/undefined return as success (back-compat with legacy onSend)", async () => {
+    const cleanup = makeCleanup();
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    const ok = await runSendWithCleanup(send, cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a synchronous void return as success", async () => {
+    const cleanup = makeCleanup();
+    const send = vi.fn(() => {
+      /* legacy void onSend */
+    });
+
+    const ok = await runSendWithCleanup(send, cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it("never runs cleanup before the async send settles (ordering guarantee)", async () => {
+    const cleanup = makeCleanup();
+    let resolveSend!: (v: boolean) => void;
+    const send = vi.fn(
+      () =>
+        new Promise<boolean>((res) => {
+          resolveSend = res;
+        }),
+    );
+
+    const p = runSendWithCleanup(send, cleanup);
+
+    // Send is still in flight (upload pending) — nothing must be cleared yet.
+    await Promise.resolve();
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.deleteAttachmentRefs).not.toHaveBeenCalled();
+
+    resolveSend(true);
+    await p;
+
+    // Only after the send resolves successfully does cleanup happen.
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -33,6 +33,7 @@ import {
   videoPlayIcon,
 } from "./AttachmentNode";
 import { t as translate, useI18n } from "../../i18n";
+import { runSendWithCleanup } from "./sendFlow";
 
 const MAX_MESSAGE_LENGTH = 5000;
 
@@ -174,6 +175,13 @@ export interface AttachmentFile {
 
 interface MessageInputProps {
   context: ConversationContext;
+  /**
+   * 发送回调。返回值决定是否清空编辑器/附件：
+   *   - resolve `true`（或 `undefined`/`void`，向后兼容）→ 视为发送成功，清空草稿与附件；
+   *   - resolve `false` → 视为发送失败/未发送，保留编辑器内容、附件引用与预览 URL 以便重试。
+   * 必须在 send 内被 `await`，否则同步清理会先于异步发送结果丢掉混排草稿
+   * (octo-web#227 review by Jerry-Xin)。
+   */
   onSend?: (
     text: string,
     mention?: MentionModel,
@@ -182,7 +190,7 @@ interface MessageInputProps {
     topFiles?: AttachmentFile[],
     /** 编辑器中按文档顺序排列的内容块（文本段和粘贴图片交替） */
     editorBlocks?: EditorContentBlock[]
-  ) => void;
+  ) => void | boolean | Promise<void | boolean>;
   members?: Array<Subscriber>;
   onInputRef?: any;
   onInsertText?: (fnc: OnInsertFnc) => void;
@@ -612,7 +620,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
   const isDirectChannelRef = useRef(
     props.context.channel().channelType === ChannelTypePerson,
   );
-  const sendRef = useRef<(() => void) | null>(null);
+  const sendRef = useRef<(() => void | Promise<void>) | null>(null);
+  // 发送进行中标志：onSend 现在被 await，发送窗口内防止重复触发 (octo-web#227)。
+  const sendingRef = useRef(false);
   const mentionActiveRef = useRef(false);
   const botCommandsRef = useRef(props.botCommands);
   // editorHandleKeyDownRef 持有最新的键盘处理函数，通过 useEffect 更新
@@ -1011,8 +1021,11 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     [editor]
   );
 
-  const send = useCallback(() => {
+  const send = useCallback(async () => {
     if (!editor) return;
+    // 重入保护：onSend 现在被 await，发送期间可能再次触发 Enter/快捷键，
+    // 避免同一份草稿被发送两次 (octo-web#227)。
+    if (sendingRef.current) return;
 
     const text = editor.getText();
     if (text.length > MAX_MESSAGE_LENGTH) {
@@ -1046,45 +1059,68 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     const hasText = text.trim() !== "";
     const hasAttachments = allAttachments.length > 0;
 
-    if (props.onSend && (hasText || hasAttachments)) {
-      // 从编辑器提取带格式的文本（包含 @[uid:name] 格式的 mention）
-      const formattedText = extractMentionsFromEditor(editor);
-      const { content, mention } = formatMentionTextV2(formattedText);
-
-      // 提取编辑器中有序内容块（文本段和粘贴图片按文档顺序交替）
-      const orderedBlocks = extractOrderedBlocks(editor, attachmentFilesRef.current);
-
-      props.onSend(
-        content,
-        mention,
-        allAttachments.length > 0 ? allAttachments : undefined,
-        topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
-        orderedBlocks.length > 0 ? orderedBlocks : undefined
-      );
+    // 没有 onSend 或没有任何内容时无需发送，直接退出（不清空，保持现状）。
+    if (!props.onSend || (!hasText && !hasAttachments)) {
+      return;
     }
 
-    // 清理编辑器附件文件引用和图片预览 URL
-    attachmentAttrs.forEach((attr) => {
-      attachmentFilesRef.current.delete(attr.id);
-      // 释放图片预览 URL，避免内存泄漏
-      if (attr.previewUrl) {
-        URL.revokeObjectURL(attr.previewUrl);
-      }
-    });
+    // 从编辑器提取带格式的文本（包含 @[uid:name] 格式的 mention）
+    const formattedText = extractMentionsFromEditor(editor);
+    const { content, mention } = formatMentionTextV2(formattedText);
 
-    // 清理顶部附件区
-    topAttachments.forEach((item) => {
-      if (item.previewUrl) {
-        URL.revokeObjectURL(item.previewUrl);
-      }
-    });
-    setTopAttachments([]);
+    // 提取编辑器中有序内容块（文本段和粘贴图片按文档顺序交替）
+    const orderedBlocks = extractOrderedBlocks(editor, attachmentFilesRef.current);
 
-    editor.commands.clearContent();
-
-    if (expanded) {
-      setExpanded(false);
-      props.onExpandChange?.(false);
+    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1)：
+    // 必须 await onSend 的结果，且仅在发送成功 (true / void) 后才清空编辑器、
+    // 删除附件引用、revoke 预览 URL。否则混排 (text+image) 上传失败时，
+    // 同步清理会先于异步发送结果执行，导致用户已编辑的整条消息（文本+图片）
+    // 全部丢失、无草稿可重试。失败 (false) 时保留全部 compose 状态。
+    // 编排逻辑抽到纯函数 runSendWithCleanup，便于单测覆盖失败保留草稿场景。
+    const topItemsAtSend = topAttachments;
+    sendingRef.current = true;
+    try {
+      await runSendWithCleanup(
+        () =>
+          props.onSend!(
+            content,
+            mention,
+            allAttachments.length > 0 ? allAttachments : undefined,
+            topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
+            orderedBlocks.length > 0 ? orderedBlocks : undefined
+          ),
+        {
+          deleteAttachmentRefs: () => {
+            attachmentAttrs.forEach((attr) => {
+              attachmentFilesRef.current.delete(attr.id);
+            });
+          },
+          revokePreviewUrls: () => {
+            // 编辑器内粘贴图片的预览 URL
+            attachmentAttrs.forEach((attr) => {
+              if (attr.previewUrl) {
+                URL.revokeObjectURL(attr.previewUrl);
+              }
+            });
+            // 顶部附件区的预览 URL
+            topItemsAtSend.forEach((item) => {
+              if (item.previewUrl) {
+                URL.revokeObjectURL(item.previewUrl);
+              }
+            });
+          },
+          clearTopAttachments: () => setTopAttachments([]),
+          clearEditor: () => editor.commands.clearContent(),
+          collapseExpanded: () => {
+            if (expanded) {
+              setExpanded(false);
+              props.onExpandChange?.(false);
+            }
+          },
+        }
+      );
+    } finally {
+      sendingRef.current = false;
     }
   }, [editor, expanded, topAttachments, props.onSend, props.onExpandChange, t]);
 

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -33,7 +33,7 @@ import {
   videoPlayIcon,
 } from "./AttachmentNode";
 import { t as translate, useI18n } from "../../i18n";
-import { runSendWithCleanup } from "./sendFlow";
+import { runSendWithCleanup, SendResultDetail } from "./sendFlow";
 
 const MAX_MESSAGE_LENGTH = 5000;
 
@@ -177,10 +177,16 @@ interface MessageInputProps {
   context: ConversationContext;
   /**
    * 发送回调。返回值决定是否清空编辑器/附件：
-   *   - resolve `true`（或 `undefined`/`void`，向后兼容）→ 视为发送成功，清空草稿与附件；
-   *   - resolve `false` → 视为发送失败/未发送，保留编辑器内容、附件引用与预览 URL 以便重试。
-   * 必须在 send 内被 `await`，否则同步清理会先于异步发送结果丢掉混排草稿
-   * (octo-web#227 review by Jerry-Xin)。
+   *   - resolve `true`（或 `undefined`/`void`，向后兼容）→ 发送成功，清空编辑器
+   *     草稿与全部本次附件；
+   *   - resolve `false` → 发送失败/未发送，保留编辑器内容、附件引用与预览 URL；
+   *   - resolve `{ editorConsumed, consumedTopIds }` → 部分成功：可表达「顶部
+   *     附件已发出但编辑器混排失败需保留」，仅清掉已消费的 top 附件，避免重试
+   *     重复发送 (octo-web#227 Jerry-Xin non-blocking)。
+   * 必须在 send 内被 `await`，否则同步清理会先于异步发送结果丢掉混排草稿。
+   * 注意 (第二轮 octo-web#227)：清理是 snapshot-aware 的——onSend 返回成功后，
+   * 仅当编辑器内容仍等于发送时的快照才会清空；用户在 await 期间输入的新草稿
+   * 不会被旧 send 误删。
    */
   onSend?: (
     text: string,
@@ -190,7 +196,7 @@ interface MessageInputProps {
     topFiles?: AttachmentFile[],
     /** 编辑器中按文档顺序排列的内容块（文本段和粘贴图片交替） */
     editorBlocks?: EditorContentBlock[]
-  ) => void | boolean | Promise<void | boolean>;
+  ) => void | boolean | SendResultDetail | Promise<void | boolean | SendResultDetail>;
   members?: Array<Subscriber>;
   onInputRef?: any;
   onInsertText?: (fnc: OnInsertFnc) => void;
@@ -1071,13 +1077,22 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 提取编辑器中有序内容块（文本段和粘贴图片按文档顺序交替）
     const orderedBlocks = extractOrderedBlocks(editor, attachmentFilesRef.current);
 
-    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1)：
-    // 必须 await onSend 的结果，且仅在发送成功 (true / void) 后才清空编辑器、
-    // 删除附件引用、revoke 预览 URL。否则混排 (text+image) 上传失败时，
-    // 同步清理会先于异步发送结果执行，导致用户已编辑的整条消息（文本+图片）
-    // 全部丢失、无草稿可重试。失败 (false) 时保留全部 compose 状态。
-    // 编排逻辑抽到纯函数 runSendWithCleanup，便于单测覆盖失败保留草稿场景。
+    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1 第二轮)：
+    // round 1 已把同步清理改成「await onSend、仅成功才清」，避免混排上传失败
+    // 丢整条草稿。但 await 期间编辑器仍可编辑，onSend 可能耗时数秒（上传图片 +
+    // 等 ack），用户趁发送 pending 时打的下一条草稿，会被上一条 send 成功后的
+    // 清理误删。本轮改为 snapshot-aware：
+    //   • 发送前对编辑器文档拍 JSON 快照 (editorSnapshot)；成功回来时只有当
+    //     编辑器内容仍 === 快照（用户没开始新草稿）才 clearContent，否则保留。
+    //   • 顶部附件按本次实际消费的 id 精确移除，绝不 setTopAttachments([])
+    //     全清，等待期间新加的附件因此不丢。
+    //   • onSend 可返回 { editorConsumed, consumedTopIds } 表达「顶部附件已发、
+    //     但编辑器混排失败」，让已发文件不被重试重复 (Jerry-Xin non-blocking)。
+    // 编排逻辑在纯函数 runSendWithCleanup，便于单测覆盖各竞态场景。
+    const editorSnapshot = JSON.stringify(editor.getJSON());
+    const consumedAttachmentAttrs = attachmentAttrs;
     const topItemsAtSend = topAttachments;
+    const allTopIds = topItemsAtSend.map((item) => item.id);
     sendingRef.current = true;
     try {
       await runSendWithCleanup(
@@ -1089,28 +1104,36 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
             orderedBlocks.length > 0 ? orderedBlocks : undefined
           ),
+        allTopIds,
         {
-          deleteAttachmentRefs: () => {
-            attachmentAttrs.forEach((attr) => {
+          isEditorUnchanged: () =>
+            JSON.stringify(editor.getJSON()) === editorSnapshot,
+          deleteEditorAttachmentRefs: () => {
+            consumedAttachmentAttrs.forEach((attr) => {
               attachmentFilesRef.current.delete(attr.id);
             });
           },
-          revokePreviewUrls: () => {
-            // 编辑器内粘贴图片的预览 URL
-            attachmentAttrs.forEach((attr) => {
+          revokeEditorPreviewUrls: () => {
+            consumedAttachmentAttrs.forEach((attr) => {
               if (attr.previewUrl) {
                 URL.revokeObjectURL(attr.previewUrl);
               }
             });
-            // 顶部附件区的预览 URL
-            topItemsAtSend.forEach((item) => {
-              if (item.previewUrl) {
+          },
+          clearEditor: () => editor.commands.clearContent(),
+          removeTopAttachments: (ids: string[]) => {
+            const idSet = new Set(ids);
+            // 先 revoke 被消费项的预览 URL（避免内存泄漏），用拍快照时的列表
+            // 取 previewUrl，再按 id 过滤当前 state——保留等待期间新加的附件。
+            topItemsAtSend.forEach((item: TopAttachmentItem) => {
+              if (idSet.has(item.id) && item.previewUrl) {
                 URL.revokeObjectURL(item.previewUrl);
               }
             });
+            setTopAttachments((prev: TopAttachmentItem[]) =>
+              prev.filter((a: TopAttachmentItem) => !idSet.has(a.id))
+            );
           },
-          clearTopAttachments: () => setTopAttachments([]),
-          clearEditor: () => editor.commands.clearContent(),
           collapseExpanded: () => {
             if (expanded) {
               setExpanded(false);

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -24,6 +24,11 @@
  *    the user's newer draft is left untouched. Top attachments are removed by
  *    the specific ids that were consumed, never with a blanket reset, so items
  *    queued during the wait survive.
+ *    Residual follow-up: when the editor changed mid-flight we leave the live
+ *    doc untouched, so the already-sent snapshot blocks stay alongside the new
+ *    draft and could be re-sent on the next send (duplicate). Accepted over the
+ *    worse "draft wiped" failure; a precise per-range removal is deferred — see
+ *    the `!isEditorUnchanged()` branch below.
  *
  * `onSend` return-value contract (back-compatible):
  *   - `undefined` / `void` → success: editor consumed, all consumed top
@@ -136,9 +141,19 @@ export async function runSendWithCleanup(
   }
 
   if (!cleanup.isEditorUnchanged()) {
-    // The user started a new draft while the older send was in flight. Never
-    // wipe it — the snapshot content left behind is harmless and gets cleared
-    // on the next send. This is the core round-2 fix.
+    // The user started a new draft while the older send was in flight. We must
+    // NOT clear the editor — doing so would wipe the newly typed draft (the
+    // round-2 data-loss bug). We deliberately leave the live document as-is.
+    //
+    // Known residual edge case (octo-web#227, tracked as a follow-up): the live
+    // editor now holds [already-sent snapshot blocks] + [new draft]. The
+    // already-sent blocks are NOT auto-removed here, so if the user presses send
+    // again those blocks are re-sent → a duplicate of the previous message. The
+    // message was delivered and the leftover content is visible to the user, so
+    // per the team's severity call this is accepted for now over the worse
+    // "draft wiped" failure. A precise fix (remove only the submitted snapshot
+    // range from the live doc, mirroring the by-id removeTopAttachments path)
+    // is deferred to a dedicated PR with its own ProseMirror-position tests.
     return true;
   }
 

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -1,75 +1,150 @@
 /**
  * Send-flow orchestration helper (octo-web#227, Jerry-Xin P1).
  *
- * Background — the data-loss bug this fixes:
- *   `MessageInput.send()` used to call `props.onSend(...)` (typed `=> void`,
- *   never awaited) and then, in the *same synchronous frame*, unconditionally
- *   cleared the editor, deleted pasted-image `File` refs, revoked preview URLs
- *   and cleared the top-attachment area. For the mixed text+image RichText
- *   path, `onSend` is async and awaits an upload before it can fail — so the
- *   compose state was already destroyed before the failure was known. A single
- *   failed image upload therefore wiped the user's whole text+image draft with
- *   no message sent and nothing to retry from.
+ * Background — two data-loss bugs this guards against:
  *
- * The fix: make the contract awaitable and run compose cleanup ONLY after a
- * successful send. This helper centralizes that ordering so it can be unit
- * tested without mounting the full editor.
+ * 1. (round 1) `MessageInput.send()` used to call `props.onSend(...)` (typed
+ *    `=> void`, never awaited) and then, in the *same synchronous frame*,
+ *    unconditionally cleared the editor, deleted pasted-image `File` refs,
+ *    revoked preview URLs and cleared the top-attachment area. For the mixed
+ *    text+image RichText path `onSend` is async and only fails after an upload,
+ *    so the compose state was destroyed before the failure was known — one
+ *    failed upload wiped the whole draft with nothing to retry.
+ *    Fix: make the contract awaitable and clean up ONLY after a successful send.
+ *
+ * 2. (round 2 — this file's reason for being snapshot-aware) Once the send was
+ *    awaited, the editor stayed editable during the wait. `Conversation.onSend`
+ *    can take seconds (image upload + message ack). If the user finished one
+ *    message and started typing the next while the first was still pending, the
+ *    successful completion of the *older* send cleared the *current* (newer)
+ *    editor document and top-attachment list — wiping the new draft. Pure text
+ *    is affected too, because the callback now awaits `sendTextAndWaitAck`.
+ *    Fix: cleanup is snapshot-aware. The editor is only cleared if it still
+ *    holds exactly the content that was sent (`isEditorUnchanged`); otherwise
+ *    the user's newer draft is left untouched. Top attachments are removed by
+ *    the specific ids that were consumed, never with a blanket reset, so items
+ *    queued during the wait survive.
  *
  * `onSend` return-value contract (back-compatible):
- *   - `undefined` / `void` → treated as success (legacy callers that return
- *     nothing keep clearing the editor as before);
- *   - `true`               → success → clear compose state;
- *   - `false`              → failure / nothing sent → PRESERVE compose state
- *     (editor content, attachment refs, preview URLs) so the user can retry;
- *   - throws               → treated as failure → preserve compose state.
+ *   - `undefined` / `void` → success: editor consumed, all consumed top
+ *     attachments cleared (legacy void-returning callers keep working);
+ *   - `true`               → success: same as void;
+ *   - `false`              → failure / nothing sent: PRESERVE everything so the
+ *     user can retry;
+ *   - `{ editorConsumed, consumedTopIds }` → partial result. Lets a caller say
+ *     "the editor compose failed and must be preserved, but these top
+ *     attachments were already sent — drop just those so a retry does not
+ *     duplicate them" (octo-web#227 non-blocking note by Jerry-Xin);
+ *   - throws               → treated as failure → preserve everything.
  */
 
-/** Side-effecting cleanup steps, all run together only on a successful send. */
+/** Partial send outcome — see contract above. */
+export interface SendResultDetail {
+  /** Whether the editor compose (text + pasted images / ordered blocks) was
+   *  sent. `true` → the editor may be cleared; `false` → preserve it. */
+  editorConsumed: boolean;
+  /** Ids of top attachments that were actually sent. Only these are removed
+   *  from the top-attachment area. Omit to derive from `editorConsumed`. */
+  consumedTopIds?: string[];
+}
+
+export type SendResult = void | boolean | SendResultDetail;
+
+/** Snapshot-aware cleanup steps, run after the send settles. */
 export interface SendCleanup {
-  /** Delete in-memory pasted-image File refs keyed in the editor. */
-  deleteAttachmentRefs: () => void;
-  /** Revoke object URLs created for image previews (avoid memory leaks). */
-  revokePreviewUrls: () => void;
-  /** Clear the top attachment area state. */
-  clearTopAttachments: () => void;
+  /**
+   * True iff the editor still holds exactly the document that was sent, i.e. the
+   * user has NOT started a new draft during the await. Editor-scoped cleanup is
+   * skipped when this returns false so a newer draft is never wiped by an older
+   * send.
+   */
+  isEditorUnchanged: () => boolean;
+  /** Delete in-memory pasted-image File refs consumed by this send. */
+  deleteEditorAttachmentRefs: () => void;
+  /** Revoke object URLs for the editor's pasted-image previews. */
+  revokeEditorPreviewUrls: () => void;
   /** Clear the editor document. */
   clearEditor: () => void;
-  /** Optional: collapse the expanded composer after sending. */
+  /**
+   * Remove the given top attachments (by id) and revoke their preview URLs.
+   * Id-scoped so attachments queued during the await are preserved.
+   */
+  removeTopAttachments: (ids: string[]) => void;
+  /** Optional: collapse the expanded composer (only when the editor is cleared). */
   collapseExpanded?: () => void;
 }
 
-export type SendResult = void | boolean;
+/** Normalize the loose `SendResult` union into an explicit decision. */
+function normalizeResult(
+  result: SendResult,
+  allTopIds: string[],
+): { editorConsumed: boolean; consumedTopIds: string[] } {
+  if (result === false) {
+    return { editorConsumed: false, consumedTopIds: [] };
+  }
+  if (result === true || result == null) {
+    // void / undefined / true → full success.
+    return { editorConsumed: true, consumedTopIds: allTopIds };
+  }
+  // Detailed partial result.
+  return {
+    editorConsumed: result.editorConsumed,
+    consumedTopIds:
+      result.consumedTopIds ?? (result.editorConsumed ? allTopIds : []),
+  };
+}
 
 /**
- * Await `send()` and, only if it succeeded, perform compose-state cleanup.
+ * Await `send()` and apply snapshot-aware compose cleanup.
  *
- * @returns `true` if the send succeeded and cleanup ran; `false` if the send
- *   reported failure (or threw) and the compose state was deliberately
- *   preserved for retry.
+ * - Consumed top attachments are removed by id (safe even if the user queued
+ *   more during the wait).
+ * - The editor is cleared only if its compose was consumed AND it still holds
+ *   exactly what was sent; if the user typed a new draft meanwhile it is left
+ *   intact.
+ *
+ * @param allTopIds Ids of every top attachment handed to this send attempt;
+ *   used to expand a `true`/`void` result into "all consumed".
+ * @returns `true` if the editor compose was consumed (and cleanup considered
+ *   clearing it); `false` if the editor compose was preserved for retry.
  */
 export async function runSendWithCleanup(
   send: () => SendResult | Promise<SendResult>,
+  allTopIds: string[],
   cleanup: SendCleanup,
 ): Promise<boolean> {
-  let succeeded = true;
+  let decision: { editorConsumed: boolean; consumedTopIds: string[] };
   try {
-    const result = await send();
-    // Only an explicit `false` means "not sent"; void/undefined stays success.
-    succeeded = result !== false;
+    decision = normalizeResult(await send(), allTopIds);
   } catch (err) {
     // onSend should surface its own error toast; we just preserve the draft.
     console.error("[MessageInput] send failed, preserving draft", err);
-    succeeded = false;
+    decision = { editorConsumed: false, consumedTopIds: [] };
   }
 
-  if (!succeeded) {
-    // Failure → keep editor content, attachment refs and preview URLs intact.
+  // Top attachments: drop only the ones actually sent. Always safe — id-scoped,
+  // so anything queued during the await stays. This runs even when the editor
+  // compose failed, so a retry of the editor does not re-send these files
+  // (octo-web#227 non-blocking note).
+  if (decision.consumedTopIds.length > 0) {
+    cleanup.removeTopAttachments(decision.consumedTopIds);
+  }
+
+  if (!decision.editorConsumed) {
+    // Editor compose not sent → keep its content, refs and preview URLs.
     return false;
   }
 
-  cleanup.deleteAttachmentRefs();
-  cleanup.revokePreviewUrls();
-  cleanup.clearTopAttachments();
+  if (!cleanup.isEditorUnchanged()) {
+    // The user started a new draft while the older send was in flight. Never
+    // wipe it — the snapshot content left behind is harmless and gets cleared
+    // on the next send. This is the core round-2 fix.
+    return true;
+  }
+
+  // Editor still holds exactly what was sent → safe to clear it.
+  cleanup.deleteEditorAttachmentRefs();
+  cleanup.revokeEditorPreviewUrls();
   cleanup.clearEditor();
   cleanup.collapseExpanded?.();
   return true;

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -1,0 +1,76 @@
+/**
+ * Send-flow orchestration helper (octo-web#227, Jerry-Xin P1).
+ *
+ * Background — the data-loss bug this fixes:
+ *   `MessageInput.send()` used to call `props.onSend(...)` (typed `=> void`,
+ *   never awaited) and then, in the *same synchronous frame*, unconditionally
+ *   cleared the editor, deleted pasted-image `File` refs, revoked preview URLs
+ *   and cleared the top-attachment area. For the mixed text+image RichText
+ *   path, `onSend` is async and awaits an upload before it can fail — so the
+ *   compose state was already destroyed before the failure was known. A single
+ *   failed image upload therefore wiped the user's whole text+image draft with
+ *   no message sent and nothing to retry from.
+ *
+ * The fix: make the contract awaitable and run compose cleanup ONLY after a
+ * successful send. This helper centralizes that ordering so it can be unit
+ * tested without mounting the full editor.
+ *
+ * `onSend` return-value contract (back-compatible):
+ *   - `undefined` / `void` → treated as success (legacy callers that return
+ *     nothing keep clearing the editor as before);
+ *   - `true`               → success → clear compose state;
+ *   - `false`              → failure / nothing sent → PRESERVE compose state
+ *     (editor content, attachment refs, preview URLs) so the user can retry;
+ *   - throws               → treated as failure → preserve compose state.
+ */
+
+/** Side-effecting cleanup steps, all run together only on a successful send. */
+export interface SendCleanup {
+  /** Delete in-memory pasted-image File refs keyed in the editor. */
+  deleteAttachmentRefs: () => void;
+  /** Revoke object URLs created for image previews (avoid memory leaks). */
+  revokePreviewUrls: () => void;
+  /** Clear the top attachment area state. */
+  clearTopAttachments: () => void;
+  /** Clear the editor document. */
+  clearEditor: () => void;
+  /** Optional: collapse the expanded composer after sending. */
+  collapseExpanded?: () => void;
+}
+
+export type SendResult = void | boolean;
+
+/**
+ * Await `send()` and, only if it succeeded, perform compose-state cleanup.
+ *
+ * @returns `true` if the send succeeded and cleanup ran; `false` if the send
+ *   reported failure (or threw) and the compose state was deliberately
+ *   preserved for retry.
+ */
+export async function runSendWithCleanup(
+  send: () => SendResult | Promise<SendResult>,
+  cleanup: SendCleanup,
+): Promise<boolean> {
+  let succeeded = true;
+  try {
+    const result = await send();
+    // Only an explicit `false` means "not sent"; void/undefined stays success.
+    succeeded = result !== false;
+  } catch (err) {
+    // onSend should surface its own error toast; we just preserve the draft.
+    console.error("[MessageInput] send failed, preserving draft", err);
+    succeeded = false;
+  }
+
+  if (!succeeded) {
+    // Failure → keep editor content, attachment refs and preview URLs intact.
+    return false;
+  }
+
+  cleanup.deleteAttachmentRefs();
+  cleanup.revokePreviewUrls();
+  cleanup.clearTopAttachments();
+  cleanup.clearEditor();
+  cleanup.collapseExpanded?.();
+  return true;
+}

--- a/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
+++ b/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
@@ -49,8 +49,50 @@ export function buildRichTextPlain(content: RichTextBlock[]): string {
     return out
 }
 
+/** 构造一个 text block（发送侧，与接收侧 schema 对齐）。 */
+export function makeTextBlock(text: string): RichTextBlock {
+    return { type: RichTextBlockType.text, text }
+}
+
 /**
- * RichText(=14) 图文混排消息正文（Phase 1：仅接收渲染）。
+ * 构造一个 image block（发送侧，与接收侧 schema + octo-lib 权威 schema 对齐）。
+ * url/width/height 必填（contract §image 必填 >0，供端上占位排版）；size/name 仅在有值时带上，
+ * 避免往 wire 注入 0/空 字段污染 byte-match。
+ */
+export function makeImageBlock(opts: {
+    url: string
+    width: number
+    height: number
+    size?: number
+    name?: string
+}): RichTextBlock {
+    const blk: RichTextBlock = {
+        type: RichTextBlockType.image,
+        url: opts.url,
+        width: opts.width,
+        height: opts.height,
+    }
+    if (opts.size && opts.size > 0) blk.size = opts.size
+    if (opts.name) blk.name = opts.name
+    return blk
+}
+
+/**
+ * 构造一个可发送的 RichText(=14) 正文（发送侧入口，与接收侧 decodeJSON 共用同一份 schema）。
+ *
+ * plain 字段：本地按 buildRichTextPlain 填一份占位（image→RichTextImagePlaceholder），
+ * 仅用于本地回显 / 离线兜底；**server #232 Finalize 会重算覆盖**，web 不是 plain 权威源。
+ * 占位符 token 复用 RichTextImagePlaceholder（wire-format 不可本地化），与接收侧严格对称。
+ */
+export function createRichTextContent(content: RichTextBlock[]): RichTextContent {
+    const c = new RichTextContent()
+    c.content = content
+    c.plain = buildRichTextPlain(content)
+    return c
+}
+
+/**
+ * RichText(=14) 图文混排消息正文（接收渲染 + 发送构造共用同一份 schema）。
  *
  * payload 结构（见 octo-lib common/richtext.go）：
  *   { type: 14, content: [ {type:"text",text} | {type:"image",url,width,height} ], plain }
@@ -89,7 +131,9 @@ export class RichTextContent extends MessageContent {
     }
 
     encodeJSON(): any {
-        // Phase 1 仅接收渲染，发送端留后续单；此处保留可往返编码以防转发等路径复用。
+        // 发送侧序列化 content blocks + 本地 plain 占位（server #232 Finalize 重算覆盖）。
+        // SDK MessageContent.encode() 会注入 type=14；JSON.stringify 自动丢弃 undefined 字段，
+        // 保证 wire-format 与 octo-lib 权威 schema byte-match。
         return { content: this.content, plain: this.plain }
     }
 

--- a/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
+++ b/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
@@ -25,6 +25,9 @@ import {
   RichTextContent,
   buildRichTextPlain,
   RichTextImagePlaceholder,
+  makeTextBlock,
+  makeImageBlock,
+  createRichTextContent,
 } from "../RichTextContent";
 
 describe("buildRichTextPlain", () => {
@@ -89,5 +92,66 @@ describe("RichTextContent.decodeJSON", () => {
     c.decodeJSON({ type: 14, content: [] });
     expect(c.plain).toBe("");
     expect(c.conversationDigest).toBe("[富文本]");
+  });
+});
+
+describe("发送侧 block 构造（与接收侧 schema 对称）", () => {
+  it("makeTextBlock 产出 text block", () => {
+    expect(makeTextBlock("hi")).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("makeImageBlock 必填 url/width/height，size/name 仅在有值时带上", () => {
+    expect(
+      makeImageBlock({ url: "https://x/a.png", width: 10, height: 20 }),
+    ).toEqual({ type: "image", url: "https://x/a.png", width: 10, height: 20 });
+
+    expect(
+      makeImageBlock({
+        url: "https://x/a.png",
+        width: 10,
+        height: 20,
+        size: 123,
+        name: "a.png",
+      }),
+    ).toEqual({
+      type: "image",
+      url: "https://x/a.png",
+      width: 10,
+      height: 20,
+      size: 123,
+      name: "a.png",
+    });
+
+    // size=0 不应注入 wire（防 byte-match 污染）
+    expect(
+      makeImageBlock({ url: "https://x/a.png", width: 1, height: 1, size: 0 }),
+    ).not.toHaveProperty("size");
+  });
+
+  it("createRichTextContent 本地填 plain 占位（image→占位符），与 buildRichTextPlain 对称", () => {
+    const blocks = [
+      makeTextBlock("看图："),
+      makeImageBlock({ url: "https://x/a.png", width: 10, height: 20 }),
+    ];
+    const c = createRichTextContent(blocks);
+    expect(c.content).toBe(blocks);
+    expect(c.plain).toBe(`看图：${RichTextImagePlaceholder}`);
+  });
+
+  it("encodeJSON↔decodeJSON 往返：发送构造的 payload 可被接收侧解析回同一 blocks", () => {
+    const sent = createRichTextContent([
+      makeTextBlock("hello"),
+      makeImageBlock({ url: "https://x/a.png", width: 10, height: 20 }),
+    ]);
+    const wire = sent.encodeJSON();
+    const received = new RichTextContent();
+    received.decodeJSON(wire);
+    expect(received.content[0]).toMatchObject({ type: "text", text: "hello" });
+    expect(received.content[1]).toMatchObject({
+      type: "image",
+      url: "https://x/a.png",
+      width: 10,
+      height: 20,
+    });
   });
 });

--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -1,6 +1,14 @@
 import { Channel } from "wukongimjssdk"
+import axios from "axios"
 import APIClient, { extractErrorMsg } from "./APIClient"
 import { t } from "../i18n"
+
+interface UploadCredentials {
+    uploadUrl: string
+    downloadUrl: string
+    contentType: string
+    contentDisposition?: string
+}
 
 /**
  * 上传前预检 file/upload/credentials。
@@ -51,6 +59,69 @@ function throwWithMsg(msg: string): never {
     const e = new Error(msg) as Error & { msg: string }
     e.msg = msg
     throw e
+}
+
+/**
+ * 上传一个聊天文件并返回最终 downloadUrl。
+ *
+ * Why: 图文混排 RichText(=14) 发送侧需要在「构造单条 payload」之前先把每张图片
+ * 上传拿到 url（与逐条 ImageContent 发送不同——后者由 SDK MediaMessageUploadTask
+ * 在发送时上传）。直接复用 SDK 的 task 拿不到 url 再聚合，故抽出独立直传。
+ *
+ * How: 与 `dmworkdatasource` 的 `MediaMessageUploadTask` 完全同一套两步：
+ *   1. GET file/upload/credentials（同一接口、同一 query 形状）拿预签名直传凭证；
+ *   2. axios.put(uploadUrl, file) 直传，成功返回 downloadUrl。
+ *
+ * 失败抛出的 Error 上挂 `.msg`，UI 层可直接 Toast，无需再解析。
+ */
+export async function uploadChatMedia(
+    file: File,
+    channel: Channel,
+    extension: string,
+): Promise<string> {
+    const contentType = file.type || "application/octet-stream"
+    const fileName = file.name || "file"
+    const fileSize = file.size
+    const ext = extension ? `.${extension}` : ""
+    const path = `/${channel.channelType}/${channel.channelID}/${genUploadUUID()}${ext}`
+
+    let credentials: UploadCredentials | undefined
+    try {
+        credentials = await APIClient.shared.get<UploadCredentials>(
+            `file/upload/credentials?path=${encodeURIComponent(path)}&type=chat&filename=${encodeURIComponent(fileName)}&contentType=${encodeURIComponent(contentType)}&fileSize=${fileSize}`,
+        )
+    } catch (err) {
+        const msg =
+            extractErrorMsg(err) ||
+            (err instanceof Error ? err.message : "") ||
+            t("base.uploadCredentials.failed")
+        throwWithMsg(msg)
+    }
+
+    if (!credentials || typeof credentials.uploadUrl !== "string" || typeof credentials.downloadUrl !== "string") {
+        throwWithMsg(t("base.uploadCredentials.missingFields"))
+    }
+
+    // 动态超时：每 MB 预留 10 秒，最低 2 分钟兜底（对齐 MediaMessageUploadTask）。
+    const fileSizeMB = file.size / (1024 * 1024)
+    const timeoutMs = Math.max(2 * 60 * 1000, fileSizeMB * 10 * 1000)
+    const headers: Record<string, string> = { "Content-Type": credentials.contentType }
+    if (credentials.contentDisposition) {
+        headers["Content-Disposition"] = credentials.contentDisposition
+    }
+
+    try {
+        const resp = await axios.put(credentials.uploadUrl, file, { headers, timeout: timeoutMs })
+        if (!(resp.status >= 200 && resp.status < 300)) {
+            throwWithMsg(t("base.conversation.upload.failed"))
+        }
+    } catch (err) {
+        if (err && typeof err === "object" && "msg" in err) throw err
+        const msg = (err instanceof Error ? err.message : "") || t("base.conversation.upload.failed")
+        throwWithMsg(msg)
+    }
+
+    return credentials.downloadUrl
 }
 
 function genUploadUUID(): string {


### PR DESCRIPTION
## What

Web **send-side** for 图文混排 RichText(=14), Phase 1 (text + image mixed). Receive-side (octo-web #218) and server-authoritative plain (octo-server #232) are already merged; this completes the loop with the send path.

## Changes

1. **Aggregate into a single RichText=14 message** (`Conversation/index.tsx`): when the editor holds **both** text and image blocks **and no non-image file blocks**, `sendRichTextMixed` builds one `type=14` payload (ordered `content` blocks = interleave order) instead of emitting separate text/image messages. Pure text (`type=1`), pure image (`type=2`), and any path containing file blocks are **untouched** — no regression to existing send logic.
2. **Reuse the receive-side schema, no fork** (`RichTextContent.ts`): `makeTextBlock` / `makeImageBlock` / `createRichTextContent` live in the *same* file #218 decodes from. wire-format byte-matches the octo-lib authoritative schema. Round-trip `encodeJSON`↔`decodeJSON` covered by a new test.
3. **plain stays non-authoritative**: client fills a local placeholder via `buildRichTextPlain` (image → `RichTextImagePlaceholder`, a wire token — **not** localized); server #232 `Finalize` recomputes and overwrites. Web is not the plain source of truth.
4. **Security (symmetric with receive side)**: each image URL is uploaded then validated with `isSafeUrl` (http/https only) before going into a block — blocks `javascript:`/`data:`/`file:` injection. Unsafe or failed-upload images are skipped with a Toast.
5. **`uploadChatMedia`** (`UploadCredentials.ts`): same `file/upload/credentials` endpoint + direct PUT as the SDK `MediaMessageUploadTask`, exposed so the aggregator can resolve image URLs *before* constructing one payload (the SDK task only uploads at per-message send time).
6. **mention merge**: `all`/`uids`/`humans`/`ais` from the text blocks are merged onto the single message so group @-notifications (incl. @所有AI) are not lost (`vm.sendMessage` reads `content.mention`).

**SmartCreateModal digest**: already reuses `m.content?.conversationDigest`, which polymorphically returns `RichTextContent.plain` (the #218 3-level fallback) for `type=14`. No duplicate digest extraction exists or was added — task 2 satisfied by reuse.

## Symmetry check (grep all RichText payload entry points)

Construction + parsing + plain builder + image placeholder + URL guard all funnel through the single `Messages/RichText/RichTextContent.ts` + `Utils/security.isSafeUrl`. No second/divergent implementation.

## Out of scope (locked for Phase 1)

Rich-text formatting (bold/headings/etc.) — Phase 1 is plain text + image only. No changes to other repos; no rollback of #218 / #232.

## 审查状态

- **改动规模**: +336 / -3, 4 文件
- **/review**: PASS ✅ (self-audit)
  - Surgical: every changed line traces to the send-path / digest / security asks. Existing pure-text and pure-image paths untouched.
  - Trust boundary: image URLs `isSafeUrl`-gated before wire; plain treated as non-authoritative (server overwrites).
  - No SQL / no LLM trust changes.
- **/codex**: 待 ReviewBot 独立 codex-review

## 验证

- `pnpm build` ✅ (turbo: web + extension, 2/2)
- `pnpm lint` ✅
- `pnpm i18n:check` ✅ (0 candidates, locale keys healthy)
- RichText 单测 ✅ 10/10（含 4 个新发送侧用例：block 构造 / size=0 不注入 / plain 占位 / encode↔decode 往返）
- 全量 dmworkbase 套件：482→**486** passing，新增失败 **0**（16 文件/31 用例的 pre-existing 失败为 canvas/lottie jsdom native-dep import 错误，base SHA b1bb31df 同样失败，与本改动无关）

Fixes #221
