### PR TITLE
fix(message): highlight broadcast mentions

### DIFF
--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -680,7 +680,7 @@ describe('end-to-end: formatMentionTextV2 -> parseMentionWithEntities', () => {
 // Mirrors the production logic in:
 //   - packages/dmworkbase/src/Components/Conversation/index.tsx
 //     ::getMessageMentions  (synthesizes @所有人 / @所有AI MentionInfo entries
-//     so MarkdownContent applies the existing mention-highlight class)
+//     so MarkdownContent applies the existing member mention pill style)
 //
 // Matrix:
 //   humans=1                       → highlight @所有人
@@ -735,8 +735,8 @@ describe('render matrix: three-state mention highlight (GH#58)', () => {
         const names = mentions.map((m) => m.name)
         expect(names).toContain('@所有人')
         expect(names).not.toContain('@所有AI')
-        // All synthesized highlights reuse the existing "@member" highlight
-        // pathway by setting uid='all' (mention-highlight class).
+        // All synthesized highlights reuse the existing "@member" visual
+        // pathway by setting uid='all' while staying non-clickable.
         expect(mentions.every((m) => m.uid === 'all')).toBe(true)
         // sanity: the literal "@所有人" text exists in the message body so
         // MarkdownContent will actually match it.

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1156,8 +1156,8 @@ export class Conversation
   getMessageMentions(message: MessageWrap): MentionInfo[] {
     // ── 三态 mention 高亮（render matrix） ───────────────────────────
     // 在普通 @member 的 Parts 之外，额外注入以下三个虚拟 highlight token，
-    // 让 MarkdownContent 用现有 @member 高亮样式（uid='all' → mention-highlight）
-    // 标亮文本中的 "@所有人" / "@所有AI":
+    // 让 MarkdownContent 用现有 @member 胶囊样式标亮文本中的
+    // "@所有人" / "@所有AI"（uid='all' 仍表示不可点击）:
     //   - mention.humans=1  → "@所有人"
     //   - mention.ais=1     → "@所有AI"
     //   - mention.humans=1 + mention.ais=1 → 两者都高亮

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -16,6 +16,7 @@ import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
 import { downloadFile } from "../../Utils/download";
 import { t } from "../../i18n";
+import { getMentionRenderState } from "./mentionRenderState";
 
 export interface MentionInfo {
   name: string; // "@张三"（含@符号）
@@ -340,20 +341,15 @@ function processTextChildren(
       if (segments.length === 1 && segments[0].type === "text") return child;
       return segments.map((seg, i) => {
         if (seg.type === "mention") {
-          // 根据 uid 判断 mention 等级
-          let mentionClass = "mention-fallback"; // 默认降级态
-          if (seg.uid === "all" || seg.uid === "channel") {
-            mentionClass = "mention-highlight"; // @所有人/@频道
-          } else if (seg.uid && seg.uid !== "") {
-            mentionClass = "mention-entity"; // 普通用户
-          }
-          const isAll = seg.uid === "all" || seg.uid === "channel";
+          const mentionState = getMentionRenderState(seg.uid);
           return (
             <span
               key={i}
-              className={mentionClass}
+              className={mentionState.className}
               onClick={
-                isAll ? undefined : () => seg.uid && onMentionClick?.(seg.uid)
+                mentionState.interactive
+                  ? () => seg.uid && onMentionClick?.(seg.uid)
+                  : undefined
               }
             >
               {seg.name}

--- a/packages/dmworkbase/src/Messages/Text/__tests__/mentionRenderState.test.ts
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/mentionRenderState.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { getMentionRenderState } from "../mentionRenderState"
+
+describe("getMentionRenderState", () => {
+    it("renders broadcast mentions like ordinary member mentions without enabling clicks", () => {
+        expect(getMentionRenderState("all")).toEqual({
+            className: "mention-entity",
+            interactive: false,
+        })
+    })
+
+    it("keeps ordinary member mentions interactive", () => {
+        expect(getMentionRenderState("uid_chen")).toEqual({
+            className: "mention-entity",
+            interactive: true,
+        })
+    })
+
+    it("keeps channel and fallback mention states distinct", () => {
+        expect(getMentionRenderState("channel")).toEqual({
+            className: "mention-highlight",
+            interactive: false,
+        })
+        expect(getMentionRenderState("")).toEqual({
+            className: "mention-fallback",
+            interactive: false,
+        })
+    })
+})

--- a/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
+++ b/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
@@ -1,0 +1,22 @@
+export type MentionClassName =
+  | "mention-fallback"
+  | "mention-highlight"
+  | "mention-entity";
+
+export interface MentionRenderState {
+  className: MentionClassName;
+  interactive: boolean;
+}
+
+export function getMentionRenderState(uid?: string): MentionRenderState {
+  if (uid === "all") {
+    return { className: "mention-entity", interactive: false };
+  }
+  if (uid === "channel") {
+    return { className: "mention-highlight", interactive: false };
+  }
+  if (uid) {
+    return { className: "mention-entity", interactive: true };
+  }
+  return { className: "mention-fallback", interactive: false };
+}

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -33,8 +33,8 @@ export interface MentionRenderFlags {
  * Build the render-time MentionInfo[] for a message: combine ordinary
  * `@member` parts with synthetic `@所有人` / `@所有AI` entries derived
  * from the three-state mention flags. Synthetic entries reuse the
- * `uid: "all"` sentinel so MarkdownContent applies the same
- * `mention-highlight` class.
+ * `uid: "all"` sentinel so MarkdownContent can keep them non-clickable
+ * while applying the same visual style as ordinary member mentions.
  *
  * Dedup is by visible name — if the conversation already contains a
  * literal `@所有人` member part (rare; admins can rename members), the

--- a/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { buildTextMessageMentions } from "../textMessageMentions"
+
+const PART_TYPE_MENTION = 2
+
+describe("buildTextMessageMentions", () => {
+    it("synthesizes broadcast mentions for @所有人 and @所有AI flags", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "@所有人 @所有AI 请同步",
+                mention: { humans: 1, ais: 1 },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([
+            { name: "@所有人", uid: "all" },
+            { name: "@所有AI", uid: "all" },
+        ])
+    })
+
+    it("keeps member mentions while adding synthetic @所有AI", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [
+                {
+                    type: PART_TYPE_MENTION,
+                    text: "@陈皮皮",
+                    data: { uid: "uid_chen" },
+                },
+            ],
+            content: {
+                text: "@陈皮皮 @所有AI 看一下",
+                mention: { ais: 1 },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([
+            { name: "@陈皮皮", uid: "uid_chen" },
+            { name: "@所有AI", uid: "all" },
+        ])
+    })
+
+    it("uses edited content flags before original mention flags", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "@所有人 原消息",
+                mention: { humans: 1 },
+            },
+            editContent: {
+                text: "@所有AI 编辑后",
+                mention: { ais: 1 },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([{ name: "@所有AI", uid: "all" }])
+    })
+
+    it("falls back to contentObj.mention when SDK mention lacks three-state fields", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "@所有AI 请处理",
+                contentObj: { mention: { ais: 1 } },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([{ name: "@所有AI", uid: "all" }])
+    })
+})

--- a/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
+++ b/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
@@ -1,0 +1,18 @@
+import {
+  buildMessageMentions,
+  readMentionFlags,
+  type MentionRenderInfo,
+  type MentionRenderPart,
+} from "../../Utils/mentionRender";
+
+export function buildTextMessageMentions(args: {
+  parts: MentionRenderPart[];
+  content: unknown;
+  editContent?: unknown;
+  partMentionType: number;
+}): MentionRenderInfo[] {
+  const flags =
+    readMentionFlags(args.editContent) ?? readMentionFlags(args.content);
+
+  return buildMessageMentions(args.parts, flags, args.partMentionType);
+}

--- a/packages/dmworkbase/src/bridge/message/useTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useTextMessageUI.ts
@@ -1,13 +1,37 @@
 import { useMemo } from "react";
 import WKApp from "../../App";
-import { MessageWrap, Part, PartType } from "../../Service/Model";
-import { TextContentUIProps } from "./types";
-import { MentionInfo, EmojiInfo } from "../../Messages/Text/MarkdownContent";
+import type { MessageWrap, Part } from "../../Service/Model";
+import { PartType } from "../../Service/Model";
+import type { TextContentUIProps } from "./types";
+import type { MentionInfo, EmojiInfo } from "../../Messages/Text/MarkdownContent";
+import { buildTextMessageMentions } from "./textMessageMentions";
 import {
   useMessageRow,
   getMessageRow,
   MessageRowSelectionState,
 } from "./useMessageRow";
+
+function getEffectiveContent(message: MessageWrap): unknown {
+  const remoteExtra = message.remoteExtra ?? (message.message as any)?.remoteExtra;
+  return remoteExtra?.isEdit && remoteExtra?.contentEdit
+    ? remoteExtra.contentEdit
+    : message.content;
+}
+
+function getRenderMentions(message: MessageWrap, parts: Part[]): MentionInfo[] {
+  const remoteExtra = message.remoteExtra ?? (message.message as any)?.remoteExtra;
+  const editContent =
+    remoteExtra?.isEdit && remoteExtra?.contentEdit
+      ? remoteExtra.contentEdit
+      : undefined;
+
+  return buildTextMessageMentions({
+    parts: parts as any,
+    content: message.content,
+    editContent,
+    partMentionType: PartType.mention as unknown as number,
+  }) as MentionInfo[];
+}
 
 /**
  * getTextMessageUI - 纯函数版本
@@ -41,13 +65,7 @@ export function getTextMessageUI(
 
   const parts = message.parts || [];
 
-  // 提取 @ 提及列表
-  const mentions: MentionInfo[] = parts
-    .filter((p: Part) => p.type === PartType.mention && p.data?.uid)
-    .map((p: Part) => ({
-      name: p.text,
-      uid: p.data.uid,
-    }));
+  const mentions = getRenderMentions(message, parts);
 
   // 提取 emoji 列表（过滤掉无效 URL）
   const emojis: EmojiInfo[] = parts
@@ -70,12 +88,7 @@ export function getTextMessageUI(
     emojis[0].url.includes("/emoji/custom_");
 
   // 获取纯文本内容（优先使用编辑后的内容）
-  const rawContent = message.content as any;
-  const remoteExtra = (message.message as any)?.remoteExtra;
-  const effectiveContent =
-    remoteExtra?.isEdit && remoteExtra?.contentEdit
-      ? (remoteExtra.contentEdit as any)
-      : rawContent;
+  const effectiveContent = getEffectiveContent(message) as any;
   const plainText =
     effectiveContent?.text || parts.map((p: Part) => p.text).join("") || "";
 
@@ -105,13 +118,7 @@ export function useTextMessageUI(message: MessageWrap) {
   const contentProps = useMemo((): TextContentUIProps => {
     const parts = message.parts || [];
 
-    // 提取 @ 提及列表
-    const mentions: MentionInfo[] = parts
-      .filter((p: Part) => p.type === PartType.mention && p.data?.uid)
-      .map((p: Part) => ({
-        name: p.text,
-        uid: p.data.uid,
-      }));
+    const mentions = getRenderMentions(message, parts);
 
     // 提取 emoji 列表（过滤掉无效 URL）
     const emojis: EmojiInfo[] = parts
@@ -134,12 +141,7 @@ export function useTextMessageUI(message: MessageWrap) {
       emojis[0].url.includes("/emoji/custom_");
 
     // 获取纯文本内容（优先使用编辑后的内容）
-    const rawContent = message.content as any;
-    const remoteExtra = (message.message as any)?.remoteExtra;
-    const effectiveContent =
-      remoteExtra?.isEdit && remoteExtra?.contentEdit
-        ? (remoteExtra.contentEdit as any)
-        : rawContent;
+    const effectiveContent = getEffectiveContent(message) as any;
     const plainText =
       effectiveContent?.text || parts.map((p: Part) => p.text).join("") || "";
 

--- a/packages/dmworkbase/src/ui/message/TextContent/TextContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/TextContent/TextContent.stories.tsx
@@ -139,7 +139,7 @@ export const MentionLevels: Story = {
       
       <div>
         <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
-          强调色（纯紫色文字）
+          广播 mention（同普通 @ 用户视觉，不可点击）
         </p>
         <TextContent
           content="看一下 @所有人"


### PR DESCRIPTION
## Summary
- Reuse the three-state mention render helper in the text-message bridge path.
- Synthesize render mentions for `@所有人` / `@所有AI` so MarkdownContent applies the existing highlight style in the current message UI.
- Add a lightweight regression test for broadcast mention synthesis, member coexistence, edited content precedence, and contentObj fallback.

Fixes #231

## Tests
- `pnpm --filter @octo/base exec vitest run src/bridge/message/__tests__/textMessageMentions.test.ts src/Utils/__tests__/mentionRender.test.ts`
- `pnpm --filter @octo/web exec vitest run --config vitest.config.ts src/__tests__/mentionRefactor.test.ts`