### PR TITLE
fix: stabilize local message send ordering

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const sdkState = vi.hoisted(() => ({
+    sendingQueues: new Map<number, unknown>(),
+}))
+
+vi.mock("wukongimjssdk", () => {
+    class Channel {
+        channelID: string
+        channelType: number
+        constructor(id: string, type: number) {
+            this.channelID = id
+            this.channelType = type
+        }
+        isEqual(other: any) {
+            return this.channelID === other.channelID && this.channelType === other.channelType
+        }
+        getChannelKey() {
+            return `${this.channelID}-${this.channelType}`
+        }
+    }
+
+    return {
+        Channel,
+        ChannelTypeGroup: 2,
+        ChannelTypePerson: 1,
+        ChannelTypeCommunityTopic: 6,
+        ConversationAction: { update: "update" },
+        MessageStatus: { Wait: 0, Normal: 1, Fail: 2 },
+        MessageContentType: { text: 1 },
+        WKSDK: {
+            shared: () => ({
+                channelManager: {
+                    getSubscribes: () => [],
+                    addSubscriberChangeListener: () => {},
+                    removeSubscriberChangeListener: () => {},
+                    syncSubscribes: () => Promise.resolve(),
+                    subscribeCacheMap: new Map(),
+                    notifySubscribeChangeListeners: () => {},
+                },
+                conversationManager: {
+                    findConversation: () => null,
+                    notifyConversationListeners: () => {},
+                    addConversationListener: () => {},
+                    removeConversationListener: () => {},
+                },
+                chatManager: {
+                    sendingQueues: sdkState.sendingQueues,
+                    addMessageListener: () => {},
+                    removeMessageListener: () => {},
+                    addCMDListener: () => {},
+                    removeCMDListener: () => {},
+                    addMessageStatusListener: () => {},
+                    removeMessageStatusListener: () => {},
+                },
+                connectManager: {
+                    addConnectStatusListener: () => {},
+                    removeConnectStatusListener: () => {},
+                },
+            }),
+        },
+        Message: class {},
+        MessageContent: class {},
+        Subscriber: class {},
+        Conversation: class {},
+        MessageExtra: class {},
+        CMDContent: class {},
+        PullMode: {},
+        ChannelInfo: class {},
+        ChannelInfoListener: class {},
+        ConversationListener: class {},
+        ConnectStatus: {},
+        ConnectStatusListener: class {},
+        MessageListener: class {},
+        MessageStatusListener: class {},
+        SendackPacket: class {},
+        Setting: class {},
+        SystemContent: class {},
+    }
+})
+
+vi.mock("../../../App", () => ({
+    default: {
+        loginInfo: { uid: "me" },
+        dataSource: { channelDataSource: { subscribers: () => Promise.resolve([]) } },
+        mittBus: { on: () => {}, off: () => {} },
+        conversationProvider: { markConversationUnread: () => Promise.resolve() },
+        shared: { currentSpaceId: "", notifyMessageDeleteListener: () => {} },
+    },
+}))
+
+vi.mock("../../../Service/DataSource/DataProvider", () => ({
+    SyncMessageOptions: class {},
+}))
+vi.mock("../../../Service/Model", () => ({ MessageWrap: class {} }))
+vi.mock("../../../Service/Provider", () => ({
+    ProviderListener: class {
+        callback?: Function
+        notifyListener(done?: Function) { this.callback?.(); done?.() }
+        listen(f: Function) { this.callback = f }
+        clearListeners() { this.callback = undefined }
+        didMount() {}
+        didUnMount() {}
+    },
+}))
+vi.mock("react-scroll", () => ({ animateScroll: { scrollToBottom: () => {} }, scroller: { scrollTo: () => {} } }))
+vi.mock("../../../Service/Const", () => ({
+    EndpointID: {},
+    MessageContentTypeConst: { time: 1001, historySplit: 1002, rtcData: 1003 },
+    OrderFactor: 10000,
+    ChannelTypeCommunityTopic: 6,
+}))
+vi.mock("moment", () => ({ default: () => ({ format: () => "" }) }))
+vi.mock("../../../Messages/Time", () => ({ TimeContent: class {} }))
+vi.mock("../../../Messages/HistorySplit", () => ({ HistorySplitContent: class {} }))
+vi.mock("../../../Messages/Mergeforward", () => ({ default: class {} }))
+vi.mock("../../../Service/TypingManager", () => ({
+    TypingListener: class {},
+    TypingManager: { shared: { addTypingListener: () => {}, removeTypingListener: () => {} } },
+}))
+vi.mock("../../../Service/ProhibitwordsService", () => ({ ProhibitwordsService: { shared: { filter: (text: string) => text, getProhibitwords: () => [] } } }))
+vi.mock("../../../Service/SpaceService", () => ({ SYSTEM_BOTS: new Set() }))
+vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
+vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
+vi.mock("../historyScroll", () => ({ getPulldownRestoredScrollTop: () => 0 }))
+vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+vi.mock("../sendContentProxy", () => ({ wrapSendContentForInjection: (content: any) => content }))
+vi.mock("../../../Service/messageSelection", () => ({ isMessageSelectable: () => true }))
+
+import ConversationVM from "../vm"
+import { Channel, MessageStatus } from "wukongimjssdk"
+
+const channel = new Channel("g1", 2)
+
+function wrap(overrides: Record<string, any>) {
+    const message: any = {
+        channel,
+        clientSeq: overrides.clientSeq || 0,
+        clientMsgNo: overrides.clientMsgNo || "",
+        messageSeq: overrides.messageSeq || 0,
+        messageID: overrides.messageID || "",
+        timestamp: overrides.timestamp || 0,
+        status: overrides.status ?? MessageStatus.Normal,
+        fromUID: overrides.fromUID || "me",
+        remoteExtra: {},
+    }
+    const result: any = {
+        message,
+        order: overrides.order ?? (message.messageSeq > 0 ? message.messageSeq * 10000 : 0),
+        get clientSeq() { return message.clientSeq },
+        get clientMsgNo() { return message.clientMsgNo },
+        get messageSeq() { return message.messageSeq },
+        get messageID() { return message.messageID },
+        get timestamp() { return message.timestamp },
+        get fromUID() { return message.fromUID },
+        get channel() { return message.channel },
+        get status() { return message.status },
+        set status(value: number) { message.status = value },
+        get send() { return message.fromUID === "me" },
+        reasonCode: 0,
+    }
+    return result
+}
+
+describe("ConversationVM message ordering", () => {
+    beforeEach(() => {
+        ConversationVM.sendQueue.clear()
+        sdkState.sendingQueues.clear()
+    })
+
+    it("sorts no-seq messages with invalid order after sequenced messages", () => {
+        const vm = new ConversationVM(channel)
+        const seq2 = wrap({ clientMsgNo: "seq2", messageSeq: 2, timestamp: 200 })
+        const stale = wrap({ clientMsgNo: "stale", order: Number.NaN, timestamp: 100 })
+        const seq1 = wrap({ clientMsgNo: "seq1", messageSeq: 1, timestamp: 150 })
+
+        expect(vm.sortMessages([seq2, stale, seq1]).map((m: any) => m.clientMsgNo)).toEqual([
+            "seq1",
+            "seq2",
+            "stale",
+        ])
+    })
+
+    it("fills a finite temporary order even when the current max message has invalid order", () => {
+        const vm = new ConversationVM(channel)
+        vm.messagesOfOrigin = [
+            wrap({ clientMsgNo: "seq1", messageSeq: 1, timestamp: 100 }),
+            wrap({ clientMsgNo: "stale", order: Number.NaN, timestamp: 200 }),
+        ]
+        const next = wrap({ clientMsgNo: "next", order: Number.NaN, timestamp: 300 })
+
+        vm.fillOrder(next)
+
+        expect(Number.isFinite(next.order)).toBe(true)
+    })
+
+    it("reorders and refreshes origin messages after a successful send ack", () => {
+        const vm = new ConversationVM(channel)
+        const seq100 = wrap({ clientMsgNo: "seq100", messageSeq: 100, timestamp: 100 })
+        const pending = wrap({ clientSeq: 7, clientMsgNo: "pending", order: 1000001, timestamp: 300, status: MessageStatus.Wait })
+        const seq101 = wrap({ clientMsgNo: "seq101", messageSeq: 101, timestamp: 200 })
+        const queued = wrap({ clientSeq: 7, clientMsgNo: "pending", order: Number.NaN, timestamp: 300, status: MessageStatus.Wait })
+        vm.messagesOfOrigin = [seq100, pending, seq101]
+        vm.messages = [seq100, pending, seq101]
+        ConversationVM.sendQueue.set(channel.getChannelKey(), [queued])
+        const refreshMessages = vi.spyOn(vm, "refreshMessages").mockImplementation(() => {})
+
+        vm.updateMessageStatusBySendAck({
+            clientSeq: 7,
+            messageID: "m102",
+            messageSeq: 102,
+            reasonCode: 1,
+        } as any)
+
+        expect(pending.messageSeq).toBe(102)
+        expect(pending.order).toBe(1020000)
+        expect(queued.order).toBe(1020000)
+        expect(pending.status).toBe(MessageStatus.Normal)
+        expect(ConversationVM.sendQueue.get(channel.getChannelKey())).toEqual([])
+        expect(vm.messagesOfOrigin.map((m: any) => m.clientMsgNo)).toEqual(["seq100", "seq101", "pending"])
+        expect(refreshMessages).toHaveBeenCalledTimes(1)
+    })
+
+    it("drops stale wait messages from sendQueue when SDK is no longer sending them", () => {
+        const vm = new ConversationVM(channel)
+        const stale = wrap({ clientSeq: 7, clientMsgNo: "stale", timestamp: 100, status: MessageStatus.Wait })
+        const active = wrap({ clientSeq: 8, clientMsgNo: "active", timestamp: 200, status: MessageStatus.Wait })
+        ConversationVM.sendQueue.set(channel.getChannelKey(), [stale, active])
+        sdkState.sendingQueues.set(8, {})
+
+        const sendingMessages = vm.getSendingMessages(channel)
+
+        expect(sendingMessages.map((m: any) => m.clientMsgNo)).toEqual(["active"])
+        expect(ConversationVM.sendQueue.get(channel.getChannelKey())?.map((m: any) => m.clientMsgNo)).toEqual(["active"])
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -66,6 +66,8 @@ export interface ConversationRenderFoldSessionItem {
 
 export type ConversationRenderItem = ConversationRenderMessageItem | ConversationRenderFoldSessionItem
 
+const PendingMessageOrderBase = Number.MAX_SAFE_INTEGER / 2
+
 export default class ConversationVM extends ProviderListener {
 
     loading: boolean = false // 消息是否加载中
@@ -665,6 +667,70 @@ export default class ConversationVM extends ProviderListener {
         }
     }
 
+    private static getSdkSendingQueues(): Map<number, unknown> | undefined {
+        const chatManager = WKSDK.shared().chatManager as unknown as { sendingQueues?: Map<number, unknown> }
+        return chatManager.sendingQueues
+    }
+
+    private static shouldKeepSendingMessage(message: MessageWrap, sdkSendingQueues?: Map<number, unknown>): boolean {
+        if (message.messageSeq && message.messageSeq > 0) {
+            return false
+        }
+        if (message.status === MessageStatus.Fail) {
+            return true
+        }
+        if (message.status !== MessageStatus.Wait) {
+            return false
+        }
+        if (!message.clientSeq || message.clientSeq <= 0 || !sdkSendingQueues) {
+            return true
+        }
+        return sdkSendingQueues.has(message.clientSeq)
+    }
+
+    private reconcileSendingMessages(channel: Channel): MessageWrap[] {
+        const channelKey = channel.getChannelKey()
+        const sendingMessages = ConversationVM.sendQueue.get(channelKey)
+        if (!sendingMessages || sendingMessages.length === 0) {
+            return []
+        }
+
+        const sdkSendingQueues = ConversationVM.getSdkSendingQueues()
+        const nextSendingMessages = sendingMessages.filter((message) => {
+            return ConversationVM.shouldKeepSendingMessage(message, sdkSendingQueues)
+        })
+
+        if (nextSendingMessages.length !== sendingMessages.length) {
+            if (nextSendingMessages.length > 0) {
+                ConversationVM.sendQueue.set(channelKey, nextSendingMessages)
+            } else {
+                ConversationVM.sendQueue.delete(channelKey)
+            }
+        }
+
+        return nextSendingMessages
+    }
+
+    private forEachLocalMessageWithClientSeq(clientSeq: number, handler: (message: MessageWrap) => void) {
+        const visited = new Set<MessageWrap>()
+        const visit = (messages?: MessageWrap[]) => {
+            if (!messages || messages.length === 0) {
+                return
+            }
+            for (const message of messages) {
+                if (message.clientSeq === clientSeq && !visited.has(message)) {
+                    visited.add(message)
+                    handler(message)
+                }
+            }
+        }
+
+        visit(this.messagesOfOrigin)
+        visit(this.pendingMessages)
+        visit(this.messages)
+        visit(ConversationVM.sendQueue.get(this.channel.getChannelKey()))
+    }
+
     // 取消所有消息的选中
     unCheckAllMessages() {
         let hasChange = false
@@ -1136,24 +1202,28 @@ export default class ConversationVM extends ProviderListener {
     updateMessageStatusBySendAck(ackPacket: SendackPacket) {
         const message = this.findMessageWithClientSeq(ackPacket.clientSeq)
         if (message) {
-            message.message.messageID = ackPacket.messageID.toString()
-            message.message.messageSeq = ackPacket.messageSeq
-            if (ackPacket.reasonCode === 1) {
-                // 发送成功后同步更新 order，确保 sortMessages 能正确排序
-                message.order = ackPacket.messageSeq * OrderFactor
-                this.updateLastMessageIfNeed(message)
-                message.status = MessageStatus.Normal
-                this.removeSendingMessageIfNeed(ackPacket.clientSeq, this.channel)
-            } else {
-                message.status = MessageStatus.Fail
-                const sendingMessage = this.getSendingMessageWithClientMsgNo(message.clientMsgNo)
-                if (sendingMessage) {
-                    sendingMessage.reasonCode = ackPacket.reasonCode
-                    this.fillOrder(sendingMessage)
+            const ackOrder = ackPacket.messageSeq * OrderFactor
+            this.forEachLocalMessageWithClientSeq(ackPacket.clientSeq, (localMessage) => {
+                localMessage.message.messageID = ackPacket.messageID.toString()
+                localMessage.message.messageSeq = ackPacket.messageSeq
+                localMessage.reasonCode = ackPacket.reasonCode
+                if (ackPacket.reasonCode === 1) {
+                    localMessage.order = ackOrder
+                    localMessage.status = MessageStatus.Normal
+                } else {
+                    localMessage.status = MessageStatus.Fail
+                    this.fillOrder(localMessage)
                 }
-
+            })
+            if (ackPacket.reasonCode === 1) {
+                // 发送成功后同步更新 order 并重排渲染列表，纠正本地回显阶段的临时位置。
+                message.order = ackOrder
+                this.updateLastMessageIfNeed(message)
+                this.removeSendingMessageIfNeed(ackPacket.clientSeq, this.channel)
+                this.messagesOfOrigin = ConversationVM.deduplicateMessages(this.sortMessages(this.messagesOfOrigin))
+                this.refreshMessages(this.messagesOfOrigin)
+                return
             }
-            message.reasonCode = ackPacket.reasonCode
         }
         this.notifyListener()
     }
@@ -1191,25 +1261,24 @@ export default class ConversationVM extends ProviderListener {
         }
         this.notifyListener()
     }
-    // 通过clientSeq获取消息对象（同时搜索 messages 和 sendQueue，避免 ack 丢失）
+    // 通过clientSeq获取消息对象（同时搜索本地列表/缓冲区/sendQueue，避免 ack 丢失）
     findMessageWithClientSeq(clientSeq: number): MessageWrap | undefined {
-        if (this.messages && this.messages.length > 0) {
-            for (let i = this.messages.length - 1; i >= 0; i--) {
-                const message = this.messages[i]
+        const findIn = (messages?: MessageWrap[]) => {
+            if (!messages || messages.length <= 0) {
+                return
+            }
+            for (let i = messages.length - 1; i >= 0; i--) {
+                const message = messages[i]
                 if (message.clientSeq === clientSeq) {
                     return message
                 }
             }
         }
-        // 消息可能还在 sendQueue 中（尚未通过 appendMessage 合并到 messages）
-        const sending = ConversationVM.sendQueue.get(this.channel.getChannelKey())
-        if (sending && sending.length > 0) {
-            for (let i = sending.length - 1; i >= 0; i--) {
-                if (sending[i].clientSeq === clientSeq) {
-                    return sending[i]
-                }
-            }
-        }
+
+        return findIn(this.messages)
+            || findIn(this.messagesOfOrigin)
+            || findIn(this.pendingMessages)
+            || findIn(ConversationVM.sendQueue.get(this.channel.getChannelKey()))
     }
 
     // 通过clientMsgNo获取消息对象
@@ -1516,9 +1585,33 @@ export default class ConversationVM extends ProviderListener {
             this.ensureBotChannelInfos()
         })
     }
+    private getMessageSortOrder(message: MessageWrap): number {
+        if (message.messageSeq && message.messageSeq > 0) {
+            return message.messageSeq * OrderFactor
+        }
+        if (Number.isFinite(message.order) && message.order > 0) {
+            return message.order
+        }
+        const timestamp = Number.isFinite(message.timestamp) && message.timestamp > 0 ? message.timestamp : 0
+        const clientSeq = Number.isFinite(message.clientSeq) && message.clientSeq > 0 ? message.clientSeq : 0
+        return PendingMessageOrderBase + timestamp * 1000 + clientSeq
+    }
+
     sortMessages(messages: MessageWrap[]) {
         return messages.sort((a, b) => {
-            return a.order - b.order
+            const orderDiff = this.getMessageSortOrder(a) - this.getMessageSortOrder(b)
+            if (orderDiff !== 0) {
+                return orderDiff
+            }
+            const timestampDiff = (a.timestamp || 0) - (b.timestamp || 0)
+            if (timestampDiff !== 0) {
+                return timestampDiff
+            }
+            const clientSeqDiff = (a.clientSeq || 0) - (b.clientSeq || 0)
+            if (clientSeqDiff !== 0) {
+                return clientSeqDiff
+            }
+            return (a.clientMsgNo || "").localeCompare(b.clientMsgNo || "")
         })
     }
 
@@ -1718,8 +1811,13 @@ export default class ConversationVM extends ProviderListener {
     // 获取当前消息列表的最小序列号的消息
     getMessageMax(): MessageWrap | undefined {
         if (this.messagesOfOrigin && this.messagesOfOrigin.length > 0) {
-            let lastMsg = this.messagesOfOrigin[this.messagesOfOrigin.length - 1];
-            return lastMsg;
+            let maxMessage = this.messagesOfOrigin[0]
+            for (const message of this.messagesOfOrigin) {
+                if (this.getMessageSortOrder(message) > this.getMessageSortOrder(maxMessage)) {
+                    maxMessage = message
+                }
+            }
+            return maxMessage
         }
     }
 
@@ -1825,9 +1923,7 @@ export default class ConversationVM extends ProviderListener {
 
     // 获取当前发送中的消息
     getSendingMessages(channel: Channel) {
-        let channelKey = channel.getChannelKey();
-        let sending = ConversationVM.sendQueue.get(channelKey);
-        return sending || [];
+        return this.reconcileSendingMessages(channel)
     }
     // 获取当前发送中的消息
     getSendingMessageWithClientMsgNo(clientMsgNo: string) {
@@ -1883,6 +1979,7 @@ export default class ConversationVM extends ProviderListener {
         // bubble 丢外部来源标识。已有值不覆盖、失败静默。
         applyMsgLevelExternalFieldsWithFallback(message, undefined)
         const messageWrap = new MessageWrap(message)
+        this.fillOrder(messageWrap)
 
         this.addSendMessageToQueue(messageWrap)
         return message
@@ -1899,13 +1996,13 @@ export default class ConversationVM extends ProviderListener {
         if (maxMessage) {
             if (message.clientMsgNo === maxMessage.clientMsgNo) {
                 if (maxMessage.preMessage) {
-                    message.order = maxMessage.preMessage.order + 1
+                    message.order = this.getMessageSortOrder(maxMessage.preMessage) + 1
                 } else {
                     message.order = OrderFactor + 1
                 }
 
             } else {
-                message.order = maxMessage.order + 1
+                message.order = this.getMessageSortOrder(maxMessage) + 1
             }
 
         } else {

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -213,7 +213,7 @@ export class MessageWrap {
     public locateRemind?: boolean // 定位到消息后是否需要提醒
     constructor(message: Message) {
         this.message = message
-        this.order = message.messageSeq * OrderFactor
+        this.order = message.messageSeq > 0 ? message.messageSeq * OrderFactor : 0
     }
     private _parts?: Array<Part>
 


### PR DESCRIPTION
## Summary
- Re-sort and refresh chat messages after successful send ACK so local echo messages move to their server-sequenced position.
- Update all local copies of the same `clientSeq` across `messagesOfOrigin`, `pendingMessages`, render messages, and business `sendQueue`.
- Reconcile `ConversationVM.sendQueue` with WukongIM SDK `sendingQueues` before restoring local sending messages, preventing stale Wait messages from re-entering the latest sync window.
- Add stable fallback ordering for no-seq local messages to avoid `NaN` comparator behavior.

## Problem
WukongIM SDK guarantees SendPacket retry and ACK notification, but octo-web also keeps a business-level `ConversationVM.sendQueue` for local Wait bubbles. If ACK handling is missed or only one `MessageWrap` copy is updated, stale no-seq Wait messages can be merged back with remote sync results and appear in the wrong position inside the chat window.

## Tests
- `pnpm exec vitest run packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts --config packages/dmworkbase/vitest.config.ts`

Closes #233