### PR TITLE
fix: handle weak-network group creation failure — add timeout, restore syncSubscribes, fallback permission check

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/context.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSetting/context.tsx
@@ -15,7 +15,19 @@ export class ChannelSettingRouteData {
 
      // 我是否是管理者或创建者
      get isManagerOrCreatorOfMe() {
-        return  this.subscriberOfMe?.role === GroupRole.manager || this.subscriberOfMe?.role === GroupRole.owner
+        if (this.subscriberOfMe?.role === GroupRole.manager || this.subscriberOfMe?.role === GroupRole.owner) {
+            return true
+        }
+        // Fallback: if subscriber data is unavailable (e.g. IM channel not yet created
+        // after weak-network group creation), check role from channelInfo.orgData which
+        // is populated from the server-side GroupResp.
+        if (!this.subscriberOfMe && this.channelInfo?.orgData?.role != null) {
+            const role = this.channelInfo.orgData.role as number
+            if (role === GroupRole.owner || role === GroupRole.manager) {
+                return true
+            }
+        }
+        return false
      }
 
 }

--- a/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
@@ -307,7 +307,7 @@ export class ChannelSettingVM extends ProviderListener {
             }
             WKSDK.shared().channelManager.addSubscriberChangeListener(this.subscriberChangeListener)
 
-            // WKSDK.shared().channelManager.syncSubscribes(this.channel)
+            WKSDK.shared().channelManager.syncSubscribes(this.channel)
 
         }
         this.channelInfoListener = (channelInfo:ChannelInfo) => {

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -106,16 +106,20 @@ export default class APIClient {
 
      get<T>(path: string, config?: RequestConfig) {
        return this.wrapResult<T>(axios.get(path, {
-        params: config?.param
+        params: config?.param,
+        timeout: config?.timeout,
     }), config)
     }
     post(path: string, data?: any, config?: RequestConfig) {
-        return this.wrapResult(axios.post(path, data, {}), config)
+        return this.wrapResult(axios.post(path, data, {
+            timeout: config?.timeout,
+        }), config)
     }
 
     put(path: string, data?: any, config?: RequestConfig) {
         return this.wrapResult(axios.put(path, data, {
             params: config?.param,
+            timeout: config?.timeout,
         }), config)
     }
 
@@ -123,6 +127,7 @@ export default class APIClient {
         return this.wrapResult(axios.delete(path, {
             params: config?.param,
             data: config?.data,
+            timeout: config?.timeout,
         }), config)
     }
 
@@ -161,6 +166,7 @@ export class RequestConfig {
     param?: any
     data?:any
     resp?: () => APIResp
+    timeout?: number
 }
 
 export interface APIResp {

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -67,7 +67,7 @@ export class ChannelDataSource implements IChannelDataSource {
         if (options?.categoryId) {
             body.category_id = options.categoryId
         }
-        return WKApp.apiClient.post(`group/create`, body);
+        return WKApp.apiClient.post(`group/create`, body, { timeout: 15000 });
     }
     async groupSaveList(): Promise<ChannelInfo[]> {
         const param: any = { "limit": MAX_GROUP_LIST_LIMIT }


### PR DESCRIPTION
## Problem

Fixes #244 — Under weak network conditions, group creation can "half-succeed": the DMWork group is created on the server but the WuKongIM channel creation times out or fails. This leaves the sidebar group settings inoperable because:

1. The `group/create` API call has no timeout, so it can hang indefinitely
2. `syncSubscribes` was commented out, so subscriber data (including the current user's role) is never fetched on mount
3. `isManagerOrCreatorOfMe` relies solely on `subscriberOfMe` which is null when subscriber sync fails

## Changes

### 1. Add 15s timeout to `createChannel` (`datasource.ts` + `APIClient.ts`)

- Extended `RequestConfig` with an optional `timeout` field
- Wired `timeout` through all `APIClient` methods (get/post/put/delete) to axios
- Set `{ timeout: 15000 }` on the `group/create` call so the client gets a clear timeout error instead of hanging

### 2. Restore `syncSubscribes` (`ChannelSetting/vm.ts`)

- Uncommented `WKSDK.shared().channelManager.syncSubscribes(this.channel)` in `didMount()`
- This ensures subscriber data is fetched when entering channel settings, critical when the IM channel exists but local subscriber cache is empty

### 3. Fallback permission check (`ChannelSetting/context.tsx`)

- When `subscriberOfMe` is null (subscriber sync failed or IM channel not yet created), falls back to checking the `role` field from `channelInfo.orgData` (populated from server-side `GroupResp`)
- The server's `GroupResp.Role` field (1=creator, 2=manager) matches `GroupRole.owner`/`GroupRole.manager` constants
- This ensures the group creator can still access management functions even without subscriber data

## Related

- Server-side fix: octo-server#247
- Issue: #244

## Testing

1. Simulate weak network (e.g. throttle to 2G in DevTools)
2. Create a new group
3. If creation half-succeeds (group appears but IM channel fails), open group settings
4. Verify: settings panel is operable, creator has management permissions
5. Normal network: verify no regression — group creation and settings work as before