### PR TITLE
fix(#203): sync sidebar snapshot on conversation unread change

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1407,7 +1407,7 @@ export default class ConversationVM extends ProviderListener {
     }
 
     // 刷新新消息数量
-    refreshNewMsgCount() {
+    async refreshNewMsgCount() {
 
         const oldUnreadCount = this.unreadCount
         if (this.browseToMessageSeq == 0) {

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1429,15 +1429,28 @@ export default class ConversationVM extends ProviderListener {
             if (conversation) {
                 conversation.unread = this.unreadCount
             }
-            // 先同步未读清零到服务端，再通知监听者（#203）。
-            // 顺序很重要：会话列表 / 关注 tab 的 sidebar-reload 由 ConversationAction.update
-            // 触发并立即拉 /sidebar/sync，若先 notify 后 mark，sidebar 同步可能跑在
-            // 清未读持久化之前，拿到旧的未读快照。
-            if (this.unreadCount === 0 && oldUnreadCount > 0) {
-                WKApp.conversationProvider.markConversationUnread(this.channel, 0)
+            // 未读清零时：先持久化到服务端，成功后再通知监听者 + 刷新 sidebar 快照（#203）。
+            // markConversationUnread 是异步 HTTP PUT，必须 await 确保 /sidebar/sync 读到
+            // 的是已持久化的状态，而不是旧快照。
+            const shouldClear = this.unreadCount === 0 && oldUnreadCount > 0
+            if (shouldClear) {
+                try {
+                    await WKApp.conversationProvider.markConversationUnread(this.channel, 0)
+                } catch (_e) {
+                    // 清未读失败时仍通知本地 UI（unread 已归零），
+                    // 避免阻塞 UI 更新，但跳过 sidebar 刷新——服务端还是旧状态，
+                    // 此时 sync 拉回来的快照仍是旧值，刷新没有意义。
+                }
             }
             if (conversation) {
                 WKSDK.shared().conversationManager.notifyConversationListeners(conversation, ConversationAction.update)
+            }
+            // 仅未读清零且服务端确认后刷新 sidebar：按 schema `sidebar/sync` 拿到最新 follow 快照，
+            // 关注 tab 中 sidebar-only 项的角标才能归零。未读增量（新消息到达）不需要 refresh。
+            // 触发点选在 ConversationVM 而非 ChatVM，因为只有这里有权威的 oldUnreadCount，
+            // SDK 在 notify 前已原地修改 Conversation 对象，ChatVM 无法检测 delta。
+            if (shouldClear) {
+                WKApp.mittBus.emit("sidebar-reload" as any)
             }
         }
 

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1428,11 +1428,16 @@ export default class ConversationVM extends ProviderListener {
             const conversation = WKSDK.shared().conversationManager.findConversation(this.channel)
             if (conversation) {
                 conversation.unread = this.unreadCount
-                WKSDK.shared().conversationManager.notifyConversationListeners(conversation, ConversationAction.update)
             }
-            // 未读数变为0时立即同步到服务端，防止会话列表同步时拿到旧的未读数
+            // 先同步未读清零到服务端，再通知监听者（#203）。
+            // 顺序很重要：会话列表 / 关注 tab 的 sidebar-reload 由 ConversationAction.update
+            // 触发并立即拉 /sidebar/sync，若先 notify 后 mark，sidebar 同步可能跑在
+            // 清未读持久化之前，拿到旧的未读快照。
             if (this.unreadCount === 0 && oldUnreadCount > 0) {
                 WKApp.conversationProvider.markConversationUnread(this.channel, 0)
+            }
+            if (conversation) {
+                WKSDK.shared().conversationManager.notifyConversationListeners(conversation, ConversationAction.update)
             }
         }
 

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1432,23 +1432,23 @@ export default class ConversationVM extends ProviderListener {
             // 未读清零时：先持久化到服务端，成功后再通知监听者 + 刷新 sidebar 快照（#203）。
             // markConversationUnread 是异步 HTTP PUT，必须 await 确保 /sidebar/sync 读到
             // 的是已持久化的状态，而不是旧快照。
-            const shouldClear = this.unreadCount === 0 && oldUnreadCount > 0
+            let shouldClear = this.unreadCount === 0 && oldUnreadCount > 0
+            // 先通知本地监听者：conversation.unread 已归零，让会话列表 UI 立即反映，
+            // 不等待网络请求。sidebar-reload 才需要等服务端确认后再触发（#203）。
+            if (conversation) {
+                WKSDK.shared().conversationManager.notifyConversationListeners(conversation, ConversationAction.update)
+            }
             if (shouldClear) {
                 try {
                     await WKApp.conversationProvider.markConversationUnread(this.channel, 0)
                 } catch (_e) {
-                    // 清未读失败时仍通知本地 UI（unread 已归零），
-                    // 避免阻塞 UI 更新，但跳过 sidebar 刷新——服务端还是旧状态，
-                    // 此时 sync 拉回来的快照仍是旧值，刷新没有意义。
+                    // 清未读失败时跳过 sidebar 刷新——服务端还是旧状态，
+                    // sync 拉回来的快照仍是旧值，刷新没有意义。
+                    shouldClear = false
                 }
             }
-            if (conversation) {
-                WKSDK.shared().conversationManager.notifyConversationListeners(conversation, ConversationAction.update)
-            }
-            // 仅未读清零且服务端确认后刷新 sidebar：按 schema `sidebar/sync` 拿到最新 follow 快照，
-            // 关注 tab 中 sidebar-only 项的角标才能归零。未读增量（新消息到达）不需要 refresh。
-            // 触发点选在 ConversationVM 而非 ChatVM，因为只有这里有权威的 oldUnreadCount，
-            // SDK 在 notify 前已原地修改 Conversation 对象，ChatVM 无法检测 delta。
+            // 仅未读清零且服务端确认后刷新 sidebar：按 schema sidebar/sync 拿到最新 follow 快照，
+            // 关注 tab 中 sidebar-only 项的角标才能归零。
             if (shouldClear) {
                 WKApp.mittBus.emit("sidebar-reload" as any)
             }

--- a/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
+++ b/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
@@ -7,6 +7,7 @@ const hoisted = vi.hoisted(() => {
     const state = {
         listener: undefined as undefined | ((conversation: any, action: any) => void),
         threadCreatedListener: undefined as undefined | ((event: any) => void),
+        sidebarReloadListener: undefined as undefined | ((event: any) => void),
     }
     const sync = vi.fn()
     const addConversationListener = vi.fn((listener: (conversation: any, action: any) => void) => {
@@ -37,11 +38,15 @@ const hoisted = vi.hoisted(() => {
                 on: vi.fn((event: string, listener: (event: any) => void) => {
                     if (event === "wk:thread-created") {
                         state.threadCreatedListener = listener
+                    } else if (event === "sidebar-reload") {
+                        state.sidebarReloadListener = listener
                     }
                 }),
                 off: vi.fn((event: string, listener: (event: any) => void) => {
                     if (event === "wk:thread-created" && state.threadCreatedListener === listener) {
                         state.threadCreatedListener = undefined
+                    } else if (event === "sidebar-reload" && state.sidebarReloadListener === listener) {
+                        state.sidebarReloadListener = undefined
                     }
                 }),
             },
@@ -118,6 +123,7 @@ describe("useFollowSidebar", () => {
         vi.useFakeTimers()
         hoisted.state.listener = undefined
         hoisted.state.threadCreatedListener = undefined
+        hoisted.state.sidebarReloadListener = undefined
         hoisted.sync.mockReset()
         hoisted.addConversationListener.mockClear()
         hoisted.removeConversationListener.mockClear()
@@ -207,5 +213,39 @@ describe("useFollowSidebar", () => {
 
         expect(hoisted.sync).toHaveBeenCalledTimes(2)
         expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(true)
+    })
+
+    it("refreshes the followed sidebar snapshot silently on sidebar-reload (unread badge sync, #203)", async () => {
+        let latest: ReturnType<typeof useFollowSidebar> | undefined
+        const groupItemUnread = { ...groupItem, unread: 1 }
+        const groupItemRead = { ...groupItem, unread: 0 }
+        hoisted.sync
+            .mockResolvedValueOnce({ items: [groupItemUnread], follow_version: 1, version: 1 })
+            .mockResolvedValueOnce({ items: [groupItemRead], follow_version: 2, version: 2 })
+
+        await act(async () => {
+            ReactDOM.render(<Probe onValue={(value) => { latest = value }} />, container)
+            await flushMicrotasks()
+        })
+
+        // 初次加载后拿到的是带未读的快照
+        expect(hoisted.sync).toHaveBeenCalledTimes(1)
+        expect(latest?.items.find((it) => it.target_id === "group-a")?.unread).toBe(1)
+        expect(hoisted.fakeWKApp.mittBus.on).toHaveBeenCalledWith(
+            "sidebar-reload",
+            expect.any(Function)
+        )
+
+        // 触发 sidebar-reload：应静默重新 /sidebar/sync，且不进入 loading 态（不闪烁）
+        await act(async () => {
+            hoisted.state.sidebarReloadListener?.(undefined)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(2)
+        // reload 全程 isLoading 保持 false（silent 模式），避免关注 tab 列表 remount
+        expect(latest?.isLoading).toBe(false)
+        // 拿到最新已读快照，关注 tab 角标可归零
+        expect(latest?.items.find((it) => it.target_id === "group-a")?.unread).toBe(0)
     })
 })

--- a/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
+++ b/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
@@ -119,9 +119,10 @@ export function useFollowSidebar(): UseFollowSidebarResult {
         load()
     }, [load])
 
-    // 外部触发重载（如 ThreadPanel 关注子区后）
+    // 外部触发重载（如 ThreadPanel 关注子区后、会话未读数变化后 #203）
+    // 使用 silent 模式：不翻转 isLoading，避免关注 tab 列表 remount 闪烁 / 丢失滚动位置
     useEffect(() => {
-        const handler = () => load()
+        const handler = () => load({ silent: true })
         WKApp.mittBus.on("sidebar-reload" as any, handler)
         return () => { WKApp.mittBus.off("sidebar-reload" as any, handler) }
     }, [load])

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -262,6 +262,8 @@ export class ChatVM extends ProviderListener {
                 }
                 if (shouldSkipPersonConversationForSpace(conversation)) return
                 const existConversation = this.findConversation(conversation.channel)
+                // 捕获更新前的未读数，用于判断未读是否真正发生变化（#203）
+                const prevUnread = existConversation?.conversation.unread ?? 0
                 if (existConversation) {
                     existConversation.conversation = conversation
                     // WS 更新后有条件清除 spaceLastMessage (#783)
@@ -286,8 +288,12 @@ export class ChatVM extends ProviderListener {
                         this.keepPosition(conversationY)
                     }
                 })
-                // 会话未读数变化后刷新 sidebar 快照，保证关注 tab 角标与最新状态同步（#203）
-                WKApp.mittBus.emit("sidebar-reload" as any)
+                // 仅在未读数真正变化时刷新 sidebar 快照，保证关注 tab 中「不在 IM 缓存里」的
+                // sidebar-only 关注项角标也能同步归零（#203）。非未读变化（新消息预览、撤回、
+                // 草稿清除等）不触发，避免活跃会话每条消息都打一次 /sidebar/sync。
+                if (conversation.unread !== prevUnread) {
+                    WKApp.mittBus.emit("sidebar-reload" as any)
+                }
             } else if (action === ConversationAction.remove) {
                 this.removeConversation(conversation.channel)
             }

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -286,6 +286,8 @@ export class ChatVM extends ProviderListener {
                         this.keepPosition(conversationY)
                     }
                 })
+                // 会话未读数变化后刷新 sidebar 快照，保证关注 tab 角标与最新状态同步（#203）
+                WKApp.mittBus.emit("sidebar-reload" as any)
             } else if (action === ConversationAction.remove) {
                 this.removeConversation(conversation.channel)
             }

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -262,8 +262,6 @@ export class ChatVM extends ProviderListener {
                 }
                 if (shouldSkipPersonConversationForSpace(conversation)) return
                 const existConversation = this.findConversation(conversation.channel)
-                // 捕获更新前的未读数，用于判断未读是否真正发生变化（#203）
-                const prevUnread = existConversation?.conversation.unread ?? 0
                 if (existConversation) {
                     existConversation.conversation = conversation
                     // WS 更新后有条件清除 spaceLastMessage (#783)
@@ -288,12 +286,6 @@ export class ChatVM extends ProviderListener {
                         this.keepPosition(conversationY)
                     }
                 })
-                // 仅在未读数真正变化时刷新 sidebar 快照，保证关注 tab 中「不在 IM 缓存里」的
-                // sidebar-only 关注项角标也能同步归零（#203）。非未读变化（新消息预览、撤回、
-                // 草稿清除等）不触发，避免活跃会话每条消息都打一次 /sidebar/sync。
-                if (conversation.unread !== prevUnread) {
-                    WKApp.mittBus.emit("sidebar-reload" as any)
-                }
             } else if (action === ConversationAction.remove) {
                 this.removeConversation(conversation.channel)
             }


### PR DESCRIPTION
Closes #203

## 问题
两个未读角标 bug：
1. 关注 tab 角标永不消失（sidebar 快照 stale）
2. 最近 tab 角标刷新后重现（会话未读数变化后 sidebar 未同步）

## 根因
SidebarTabBarWithBadges 的 followUnread 计算依赖 /sidebar/sync 快照中的 items。
当用户打开会话、未读归零后，SDK 触发 ConversationAction.update，
ChatVM 重新渲染，但 sidebar 快照不变——关注 tab 中对应 item 的 it.unread
仍是旧值，角标无法归零。

## 修复
在 ChatVM.conversationListener 的 update 分支里，会话未读数变化后
emit sidebar-reload 事件，触发 useFollowSidebar 重新 /sidebar/sync，
拿到最新的未读数值，关注 tab 角标与实时状态同步。

## 改动
- packages/dmworkbase/src/Pages/Chat/vm.ts: +2 行