### PR TITLE
fix(group-md): render escaped newlines as markdown

### DIFF
--- a/packages/dmworkbase/src/Components/GroupMdEditor/__tests__/GroupMdEditor.test.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/__tests__/GroupMdEditor.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  GroupMdEditor,
+  normalizeGroupMdContent,
+} from "../index";
+
+const hoisted = vi.hoisted(() => ({
+  getGroupMd: vi.fn(),
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: {
+      channelDataSource: {
+        getGroupMd: hoisted.getGroupMd,
+      },
+    },
+  },
+  __esModule: true,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: ({ children, ...props }: any) =>
+    React.createElement("button", props, children),
+  TextArea: ({ value, onChange, placeholder }: any) =>
+    React.createElement("textarea", {
+      value,
+      placeholder,
+      onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+        onChange?.(event.target.value),
+    }),
+  Spin: () => React.createElement("div", { "data-testid": "spin" }),
+  Toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../../../Messages/Text/MarkdownContent", () => ({
+  default: ({ content }: { content: string }) => {
+    const lines = content.split("\n");
+    return React.createElement(
+      "div",
+      { "data-testid": "markdown-content" },
+      lines.map((line, index) =>
+        React.createElement("p", { key: index }, line)
+      )
+    );
+  },
+  __esModule: true,
+}));
+
+beforeEach(() => {
+  hoisted.getGroupMd.mockReset();
+});
+
+describe("normalizeGroupMdContent", () => {
+  it("turns escaped LF into real line breaks", () => {
+    expect(normalizeGroupMdContent("# Title\\n\\n- item")).toBe(
+      "# Title\n\n- item"
+    );
+  });
+
+  it("turns escaped CRLF into real line breaks", () => {
+    expect(normalizeGroupMdContent("# Title\\r\\n\\r\\n- item")).toBe(
+      "# Title\n\n- item"
+    );
+  });
+
+  it("keeps normal Markdown unchanged", () => {
+    const content = "# Title\n\n- item";
+    expect(normalizeGroupMdContent(content)).toBe(content);
+  });
+
+  it("does not aggressively unescape mixed multiline content", () => {
+    const content = "# Title\nliteral \\n example";
+    expect(normalizeGroupMdContent(content)).toBe(content);
+  });
+});
+
+describe("GroupMdEditor preview", () => {
+  it("normalizes escaped newlines before rendering Markdown preview", async () => {
+    hoisted.getGroupMd.mockResolvedValueOnce({
+      content: "# Title\\n\\n- item",
+      version: 2,
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    render(<GroupMdEditor channel={channel} canEdit={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-content")).toHaveTextContent(
+        "# Title- item"
+      );
+    });
+    expect(screen.queryByText(/\\n/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.css
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 16px;
+  padding: var(--wk-sp-4);
 }
 
 .wk-groupmd-loading {
@@ -16,35 +16,35 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--wk-sp-2);
 }
 
 .wk-groupmd-tabs {
   display: flex;
-  gap: 4px;
+  gap: var(--wk-sp-1);
 }
 
 .wk-groupmd-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--wk-sp-2);
 }
 
 .wk-groupmd-bytecount {
-  font-size: 12px;
-  color: var(--wk-color-text-secondary, #999);
-  margin-bottom: 8px;
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-text-secondary);
+  margin-bottom: var(--wk-sp-2);
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--wk-sp-3);
 }
 
 .wk-groupmd-bytecount-over {
-  color: var(--wk-color-danger, #f5222d);
+  color: var(--wk-color-danger);
 }
 
 .wk-groupmd-version {
-  font-size: 11px;
-  color: var(--wk-color-text-tertiary, #bbb);
+  font-size: var(--wk-text-size-xs);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-groupmd-edit-area {
@@ -58,20 +58,16 @@
 }
 
 .wk-groupmd-preview-content {
-  white-space: pre-wrap;
   word-break: break-word;
-  font-family: monospace;
-  font-size: 14px;
-  line-height: 1.6;
   margin: 0;
-  padding: 12px;
-  background: var(--wk-color-bg-secondary, #f5f5f5);
-  border-radius: 6px;
+  padding: var(--wk-sp-3);
+  background: var(--wk-bg-surface);
+  border-radius: var(--wk-r-sm);
 }
 
 .wk-groupmd-empty {
-  color: var(--wk-color-text-secondary, #999);
+  color: var(--wk-text-secondary);
   text-align: center;
-  padding: 40px 0;
-  font-size: 14px;
+  padding: var(--wk-sp-10) 0;
+  font-size: var(--wk-text-size-md);
 }

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -7,6 +7,7 @@ import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
 import { I18nContext } from "../../i18n";
 import { wkConfirm } from "../WKModal";
+import MarkdownContent from "../../Messages/Text/MarkdownContent";
 import "./index.css";
 
 export interface GroupMdEditorProps {
@@ -27,6 +28,17 @@ const MAX_BYTES = 10240;
 
 function getByteLength(str: string): number {
   return new TextEncoder().encode(str).length;
+}
+
+export function normalizeGroupMdContent(content: string): string {
+  if (
+    !content ||
+    content.includes("\n") ||
+    (!content.includes("\\n") && !content.includes("\\r\\n"))
+  ) {
+    return content;
+  }
+  return content.replace(/\\r\\n/g, "\n").replace(/\\n/g, "\n");
 }
 
 export class GroupMdEditor extends Component<
@@ -78,9 +90,10 @@ export class GroupMdEditor extends Component<
           this.props.channel
         );
       }
+      const content = normalizeGroupMdContent(resp?.content || "");
       this.setState({
-        content: resp?.content || "",
-        originalContent: resp?.content || "",
+        content,
+        originalContent: content,
         version: resp?.version || 0,
         loading: false,
       });
@@ -247,7 +260,9 @@ export class GroupMdEditor extends Component<
         ) : (
           <div className="wk-groupmd-preview">
             {content ? (
-              <pre className="wk-groupmd-preview-content">{content}</pre>
+              <div className="wk-groupmd-preview-content">
+                <MarkdownContent content={content} enableMath />
+              </div>
             ) : (
               <div className="wk-groupmd-empty">{t("base.groupMd.empty")}</div>
             )}


### PR DESCRIPTION
## Summary
- normalize escaped GROUP.md line endings returned as literal \n / \r\n before storing editor state
- render GROUP.md preview with the existing MarkdownContent renderer instead of a plain pre block
- add GroupMdEditor regression coverage for escaped-newline preview content

Fixes #252

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/GroupMdEditor
- pnpm i18n:check
- git diff --check

## Notes
- This makes Web tolerate already-stored escaped GROUP.md content. The cross-platform tracking issue still suggests storage/write-path cleanup may be needed separately.