### PR TITLE
fix(device): generalize stale device_id recovery into APIClient interceptor (closes #76, #270)

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -910,7 +910,7 @@ export default class WKApp extends ProviderListener {
     // Plan F Task 9 hardening: clearLocalLoginState performs raw
     // localStorage/sessionStorage writes (via StorageService) that throw in
     // Safari private mode, on QuotaExceededError, or under SecurityError.
-    // Without the try/finally, a throw here would leave loggingOut=true
+    // Without the try/catch, a throw here would leave loggingOut=true
     // forever AND skip the reload — every subsequent logout attempt
     // short-circuits and the user is permanently wedged. The reload must
     // happen regardless so the next bootstrap can detect the broken auth

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -861,6 +861,15 @@ export default class WKApp extends ProviderListener {
         // messages then build clientMsgNo as "<uuid>_0_3" instead of
         // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
         // which breaks per-device message dedup and cross-device tracking.
+        if (err?.code !== "err.server.user.device_not_found") {
+          // Non-stale device errors fall through to existing handling paths
+          // (auth interceptor / silent failure). Log once for observability
+          // so future regressions on this endpoint are not hidden.
+          console.warn(
+            "[App.startMain] /user/devices fetch failed (non-stale):",
+            { status: err?.status, code: err?.code, msg: err?.msg },
+          );
+        }
         handleDeviceFetchError(err, {
           removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
           resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -907,7 +907,19 @@ export default class WKApp extends ProviderListener {
     // a real page reload resets the flag.
     if (this.loggingOut) return;
     this.loggingOut = true;
-    this.clearLocalLoginState();
+    // Plan F Task 9 hardening: clearLocalLoginState performs raw
+    // localStorage/sessionStorage writes (via StorageService) that throw in
+    // Safari private mode, on QuotaExceededError, or under SecurityError.
+    // Without the try/finally, a throw here would leave loggingOut=true
+    // forever AND skip the reload — every subsequent logout attempt
+    // short-circuits and the user is permanently wedged. The reload must
+    // happen regardless so the next bootstrap can detect the broken auth
+    // state and route to login.
+    try {
+      this.clearLocalLoginState();
+    } catch (e) {
+      console.warn("[WKApp.logout] clearLocalLoginState threw, reloading anyway", e);
+    }
     window.location.reload();
   }
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -630,6 +630,7 @@ export default class WKApp extends ProviderListener {
 
   private wsaddrs = new Array<string>(); // ws的连接地址
   private addrUsed = false; // 地址是否被使用
+  private loggingOut = false; // Plan F: in-flight guard for logout() to short-circuit concurrent reload attempts from racing callbacks (auth-expired + stale-device). One-way per session — reset only by the actual page reload.
 
   isPC = false; // 是否是PC端
   deviceId: string = ""; // 设备ID
@@ -898,6 +899,14 @@ export default class WKApp extends ProviderListener {
 
   // 登出
   logout() {
+    // Plan F bundled fix #1: in-flight guard. Multiple concurrent API
+    // errors (e.g., auth-expired + stale-device, or N parallel stale
+    // responses) can call logout() in rapid succession before the page
+    // actually unloads. Without this guard, clearLocalLoginState() runs N
+    // times. Idempotent in practice but wasteful and noisy. One-way: only
+    // a real page reload resets the flag.
+    if (this.loggingOut) return;
+    this.loggingOut = true;
     this.clearLocalLoginState();
     window.location.reload();
   }

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -117,7 +117,6 @@ import {
   requestOidcLogout,
   safeEndSessionUrl,
 } from "./Service/oidcLogout";
-import { handleDeviceFetchError } from "./Service/deviceFailure";
 import type { APIClientRejectedError } from "./Service/APIClient";
 
 export enum ThemeMode {
@@ -854,27 +853,18 @@ export default class WKApp extends ProviderListener {
         }
       })
       .catch((err: APIClientRejectedError) => {
-        // octo-web#76: server may forget our device (after data reset, manual
-        // device-table cleanup, sessionStorage copied from another env, etc.).
-        // Without this handler the device fetch silently fails, leaving
-        // WKSDK.config.clientMsgDeviceId at its default 0; subsequent outbound
-        // messages then build clientMsgNo as "<uuid>_0_3" instead of
-        // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
-        // which breaks per-device message dedup and cross-device tracking.
+        // Plan F: stale device recovery is handled centrally by the
+        // APIClient staleLocalResourceCallback (see module.tsx). This catch
+        // only exists to (a) consume the promise rejection so it doesn't
+        // surface as Uncaught and (b) keep observability of non-stale
+        // failures of this endpoint. The recovery side-effect has already
+        // fired by the time this runs (interceptor → callback → handler).
         if (err?.code !== "err.server.user.device_not_found") {
-          // Non-stale device errors fall through to existing handling paths
-          // (auth interceptor / silent failure). Log once for observability
-          // so future regressions on this endpoint are not hidden.
           console.warn(
             "[App.startMain] /user/devices fetch failed (non-stale):",
             { status: err?.status, code: err?.code, msg: err?.msg },
           );
         }
-        handleDeviceFetchError(err, {
-          removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
-          resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
-          triggerLogout: () => WKApp.shared.logout(),
-        });
       });
   }
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -117,6 +117,8 @@ import {
   requestOidcLogout,
   safeEndSessionUrl,
 } from "./Service/oidcLogout";
+import { handleDeviceFetchError } from "./Service/deviceFailure";
+import type { APIClientRejectedError } from "./Service/APIClient";
 
 export enum ThemeMode {
   light,
@@ -850,6 +852,20 @@ export default class WKApp extends ProviderListener {
         if (res.id) {
           WKSDK.shared().config.clientMsgDeviceId = res.id;
         }
+      })
+      .catch((err: APIClientRejectedError) => {
+        // octo-web#76: server may forget our device (after data reset, manual
+        // device-table cleanup, sessionStorage copied from another env, etc.).
+        // Without this handler the device fetch silently fails, leaving
+        // WKSDK.config.clientMsgDeviceId at its default 0; subsequent outbound
+        // messages then build clientMsgNo as "<uuid>_0_3" instead of
+        // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
+        // which breaks per-device message dedup and cross-device tracking.
+        handleDeviceFetchError(err, {
+          removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
+          resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
+          triggerLogout: () => WKApp.shared.logout(),
+        });
       });
   }
 

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { buildAcceptLanguage } from "./apiLanguage";
-import { isAuthExpiredApiError, normalizeApiError, NormalizedApiError } from "./apiError";
+import { isAuthExpiredApiError, isStaleLocalResourceApiError, normalizeApiError, NormalizedApiError } from "./apiError";
 
 export interface APIClientRejectedError {
     error: unknown;
@@ -55,6 +55,7 @@ export default class APIClient {
     public static shared = new APIClient()
     public config = new APIClientConfig()
     public logoutCallback?:()=>void
+    public staleLocalResourceCallback?:(code: string)=>void
 
     initAxios() {
         const self = this
@@ -88,8 +89,18 @@ export default class APIClient {
                 httpStatus: error?.response?.status,
                 raw: error,
             });
+            // Plan F: classification is mutually exclusive. else if (not two
+            // independent ifs) ensures a single error response triggers at
+            // most one recovery callback, even if a future code lands in both
+            // sets by mistake.
             if (isAuthExpiredApiError(normalized) && self.logoutCallback) {
                 self.logoutCallback()
+            } else if (
+                isStaleLocalResourceApiError(normalized) &&
+                self.staleLocalResourceCallback &&
+                normalized.code
+            ) {
+                self.staleLocalResourceCallback(normalized.code)
             }
             const rejected: APIClientRejectedError = {
                 error: error,

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.error.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.error.test.ts
@@ -13,6 +13,7 @@ describe("APIClient backend i18n contract", () => {
         client.config.tokenCallback = undefined
         client.config.spaceIdCallback = undefined
         client.logoutCallback = undefined
+        client.staleLocalResourceCallback = undefined
     })
 
     it("adds Accept-Language without trusted backend-only i18n headers", async () => {

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -156,6 +156,7 @@ describe("APIClient stale local resource interceptor", () => {
             throw err
         }
         await client.get("/v1/user/devices/probe").catch(() => {})
-        expect(staleFn).toHaveBeenCalledExactlyOnceWith("err.server.user.device_not_found")
+        expect(staleFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
     })
 })

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import axios from "axios"
+import APIClient from "../APIClient"
+
+describe("APIClient stale local resource interceptor", () => {
+    const client = APIClient.shared
+    let logoutFn: ReturnType<typeof vi.fn>
+    let staleFn: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        logoutFn = vi.fn()
+        staleFn = vi.fn()
+        client.logoutCallback = logoutFn
+        client.staleLocalResourceCallback = staleFn
+        client.config.tokenCallback = undefined
+        client.config.spaceIdCallback = undefined
+    })
+
+    it("device_not_found code triggers staleLocalResourceCallback once, NOT logoutCallback", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "未查询到该设备。",
+                    },
+                    msg: "未查询到该设备。",
+                    status: 400,
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/v1/user/devices/x")).rejects.toMatchObject({
+            code: "err.server.user.device_not_found",
+        })
+        expect(staleFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
+        expect(logoutFn).not.toHaveBeenCalled()
+    })
+})

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -41,4 +41,121 @@ describe("APIClient stale local resource interceptor", () => {
         expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
         expect(logoutFn).not.toHaveBeenCalled()
     })
+
+    it("auth-expired (token_expired) still triggers logoutCallback only", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.shared.auth.token_expired",
+                        http_status: 401,
+                        message: "expired",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/anything")).rejects.toMatchObject({
+            code: "err.shared.auth.token_expired",
+        })
+        expect(logoutFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).not.toHaveBeenCalled()
+    })
+
+    it("login_device_expired (cousin code, HTTP 401) routes via auth-expired path, not stale path", async () => {
+        // Server emits this for the device-lock SMS-verify flow when the Redis
+        // login-device cache expired. It's a 401 — auth-expired classifier
+        // catches it via httpStatus fallback. Verifies the two device-related
+        // server codes don't accidentally both go through stale path.
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("401")
+            err.response = {
+                status: 401,
+                data: {
+                    error: {
+                        code: "err.server.user.login_device_expired",
+                        http_status: 401,
+                        message: "登录设备已过期",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/anything")).rejects.toMatchObject({})
+        expect(logoutFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).not.toHaveBeenCalled()
+    })
+
+    it("concurrent stale device responses each invoke callback (re-entry expected; mitigation lives in WKApp.logout)", async () => {
+        let n = 0
+        axios.defaults.adapter = async () => {
+            n++
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "x",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        const p1 = client.get("/a").catch(() => {})
+        const p2 = client.get("/b").catch(() => {})
+        await Promise.all([p1, p2])
+        expect(n).toBe(2)
+        expect(staleFn).toHaveBeenCalledTimes(2)
+    })
+
+    it("unrelated 404 codes do NOT trigger staleLocalResourceCallback", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("404")
+            err.response = {
+                status: 404,
+                data: {
+                    error: {
+                        code: "err.server.user.not_found",
+                        http_status: 404,
+                        message: "no such user",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/v1/users/missing")).rejects.toMatchObject({})
+        expect(staleFn).not.toHaveBeenCalled()
+        expect(logoutFn).not.toHaveBeenCalled()
+    })
+
+    it("interceptor still fires callback even if normalized.code is captured from envelope", async () => {
+        // Defensive: confirm the callback receives the actual code string,
+        // not undefined / a fallback. This guards against future refactors
+        // of normalizeApiError that might drop the code field.
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "msg",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await client.get("/v1/user/devices/probe").catch(() => {})
+        expect(staleFn).toHaveBeenCalledExactlyOnceWith("err.server.user.device_not_found")
+    })
 })

--- a/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
@@ -4,6 +4,7 @@ import {
   isForbiddenApiError,
   isInternalApiError,
   isRateLimitedApiError,
+  isStaleLocalResourceApiError,
   normalizeApiError,
 } from "../apiError";
 import { i18n } from "../../i18n/instance";
@@ -149,3 +150,25 @@ describe("normalizeApiError", () => {
     expect(normalizeApiError({ httpStatus: 418, data: {} }).message).toBe("未知错误");
   });
 });
+
+describe("isStaleLocalResourceApiError", () => {
+  it("returns true for err.server.user.device_not_found regardless of httpStatus", () => {
+    // Real server response shape: HTTP 400 but body.http_status=404; only the code is stable.
+    expect(
+      isStaleLocalResourceApiError({ code: "err.server.user.device_not_found" })
+    ).toBe(true)
+  })
+
+  it("returns false for unrelated codes", () => {
+    expect(
+      isStaleLocalResourceApiError({ code: "err.shared.auth.token_expired" })
+    ).toBe(false)
+    expect(
+      isStaleLocalResourceApiError({ code: "err.server.user.not_found" })
+    ).toBe(false)
+  })
+
+  it("returns false when code is undefined", () => {
+    expect(isStaleLocalResourceApiError({ code: undefined })).toBe(false)
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -17,11 +17,11 @@ function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientReje
 }
 
 describe('handleDeviceFetchError', () => {
-  it('on 400 with err.server.user.device_not_found, invokes all three handlers', () => {
+  it('on err.server.user.device_not_found code (production status 404), invokes all three handlers', () => {
     const removeDeviceId = vi.fn()
     const resetInMemoryDeviceId = vi.fn()
     const triggerLogout = vi.fn()
-    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+    const err = makeRejected({ status: 404, code: 'err.server.user.device_not_found' })
 
     handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
 
@@ -67,5 +67,21 @@ describe('handleDeviceFetchError', () => {
     expect(removeDeviceId).not.toHaveBeenCalled()
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
+  })
+
+  it('on the device_not_found code regardless of status field value, still triggers', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    // Defensive: even if the backend ever flips its inconsistent http_status
+    // field to something else (e.g. 400 matching the real HTTP status), the
+    // code-only gate must still trigger.
+    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).toHaveBeenCalledTimes(1)
+    expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
+    expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -1,0 +1,32 @@
+// packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { handleDeviceFetchError } from '../deviceFailure'
+import type { APIClientRejectedError } from '../APIClient'
+
+function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientRejectedError {
+  return {
+    error: new Error('stub'),
+    msg: '',
+    status: undefined as any,
+    code: '',
+    details: undefined,
+    backendMessage: undefined,
+    normalized: undefined as any,
+    ...overrides,
+  } as APIClientRejectedError
+}
+
+describe('handleDeviceFetchError', () => {
+  it('on 400 with err.server.user.device_not_found, invokes all three handlers', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).toHaveBeenCalledTimes(1)
+    expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
+    expect(triggerLogout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -29,4 +29,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
     expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
+
+  it('on 401 (auth expired), does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 401, code: 'err.shared.auth.token_missing' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -83,4 +83,22 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
     expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
+
+  it('invokes handlers in storage-clear-before-logout order (reload depends on this)', () => {
+    // Order matters: removeDeviceId MUST run before triggerLogout, because
+    // triggerLogout fires window.location.reload(), and the post-reload
+    // App.startup → getDeviceIdFromStorage() only regenerates a fresh UUID
+    // when sessionStorage.deviceId is null/"". If logout fired first and the
+    // reload raced ahead before removeDeviceId completed, the stale UUID
+    // would be re-used and the loop would not break.
+    const calls: string[] = []
+    const removeDeviceId = vi.fn(() => { calls.push('removeDeviceId') })
+    const resetInMemoryDeviceId = vi.fn(() => { calls.push('resetInMemoryDeviceId') })
+    const triggerLogout = vi.fn(() => { calls.push('triggerLogout') })
+    const err = makeRejected({ code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(calls).toEqual(['removeDeviceId', 'resetInMemoryDeviceId', 'triggerLogout'])
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -7,13 +7,12 @@ function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientReje
   return {
     error: new Error('stub'),
     msg: '',
-    status: undefined as any,
     code: '',
     details: undefined,
     backendMessage: undefined,
-    normalized: undefined as any,
+    normalized: { message: '', raw: undefined },
     ...overrides,
-  } as APIClientRejectedError
+  }
 }
 
 describe('handleDeviceFetchError', () => {
@@ -47,7 +46,7 @@ describe('handleDeviceFetchError', () => {
     const removeDeviceId = vi.fn()
     const resetInMemoryDeviceId = vi.fn()
     const triggerLogout = vi.fn()
-    const err = makeRejected({ status: undefined as any, code: '' })
+    const err = makeRejected({ code: '' })
 
     handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
 

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -55,4 +55,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
   })
+
+  it('on 400 with a different error code, does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 400, code: 'err.shared.request.invalid' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -42,4 +42,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
   })
+
+  it('on network error (no response, status undefined), does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: undefined as any, code: '' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/apiError.ts
+++ b/packages/dmworkbase/src/Service/apiError.ts
@@ -30,6 +30,17 @@ const rateLimitedCodes = new Set([
   "err.shared.rate.limited",
 ]);
 
+// Plan F: stale local resource codes. Server emits one such code per cached
+// client-side ID it no longer recognizes (e.g., the deviceId UUID in
+// localStorage when the server-side device row was removed). Code-only
+// matching: server returns HTTP 400 with body.http_status=404 for
+// device_not_found, so neither HTTP status nor body http_status is the
+// stable contract — the string code is. Future siblings (e.g., space.not_found)
+// can be added to this set without touching the interceptor.
+const staleLocalResourceCodes = new Set([
+  "err.server.user.device_not_found",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -77,6 +88,10 @@ export function isForbiddenApiError(error: Pick<NormalizedApiError, "code" | "ht
 
 export function isRateLimitedApiError(error: Pick<NormalizedApiError, "code" | "httpStatus">): boolean {
   return Boolean(error.code && rateLimitedCodes.has(error.code)) || error.httpStatus === 429;
+}
+
+export function isStaleLocalResourceApiError(error: Pick<NormalizedApiError, "code">): boolean {
+  return Boolean(error.code && staleLocalResourceCodes.has(error.code));
 }
 
 export function isInternalApiError(error: Pick<NormalizedApiError, "code" | "httpStatus">): boolean {

--- a/packages/dmworkbase/src/Service/deviceFailure.ts
+++ b/packages/dmworkbase/src/Service/deviceFailure.ts
@@ -10,7 +10,10 @@ export interface DeviceFailureHandlers {
  * Classify a rejected device-fetch error and invoke recovery handlers if it
  * represents a stale device_id (server doesn't recognize it).
  *
- * Trigger condition: HTTP 400 + backend code 'err.server.user.device_not_found'.
+ * Trigger condition: backend code 'err.server.user.device_not_found'.
+ * (HTTP status not checked — APIClient.normalizeApiError exposes
+ * body.error.http_status, not the real HTTP status code, and the two diverge
+ * for this endpoint. Code-only gating is more robust.)
  * All other errors (auth, network, 5xx) are intentionally ignored — they have
  * their own handling paths (auth interceptor / silent failure).
  *
@@ -20,7 +23,11 @@ export function handleDeviceFetchError(
   err: APIClientRejectedError,
   handlers: DeviceFailureHandlers,
 ): void {
-  if (err.status === 400 && err.code === 'err.server.user.device_not_found') {
+  // Gate by code only. The HTTP status line is 400 Bad Request, but
+  // APIClient.normalizeApiError reads the body's inconsistent `http_status`
+  // field (=404) into err.status, not the actual HTTP status code. The code
+  // string is the stable backend contract — that's what we match on.
+  if (err.code === 'err.server.user.device_not_found') {
     handlers.removeDeviceId()
     handlers.resetInMemoryDeviceId()
     handlers.triggerLogout()

--- a/packages/dmworkbase/src/Service/deviceFailure.ts
+++ b/packages/dmworkbase/src/Service/deviceFailure.ts
@@ -1,0 +1,28 @@
+import type { APIClientRejectedError } from './APIClient'
+
+export interface DeviceFailureHandlers {
+  removeDeviceId: () => void
+  resetInMemoryDeviceId: () => void
+  triggerLogout: () => void
+}
+
+/**
+ * Classify a rejected device-fetch error and invoke recovery handlers if it
+ * represents a stale device_id (server doesn't recognize it).
+ *
+ * Trigger condition: HTTP 400 + backend code 'err.server.user.device_not_found'.
+ * All other errors (auth, network, 5xx) are intentionally ignored — they have
+ * their own handling paths (auth interceptor / silent failure).
+ *
+ * See octo-web#76.
+ */
+export function handleDeviceFetchError(
+  err: APIClientRejectedError,
+  handlers: DeviceFailureHandlers,
+): void {
+  if (err.status === 400 && err.code === 'err.server.user.device_not_found') {
+    handlers.removeDeviceId()
+    handlers.resetInMemoryDeviceId()
+    handlers.triggerLogout()
+  }
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -86,6 +86,8 @@ import { UserInfoRouteData } from "./Components/UserInfo/vm";
 import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
 import APIClient from "./Service/APIClient";
+import StorageService from "./Service/StorageService";
+import { handleDeviceFetchError } from "./Service/deviceFailure";
 import { patchSdkDecodeForExternalFields } from "./Service/Convert";
 import { isMessageSelectable } from "./Service/messageSelection";
 import ConversationVM from "./Components/Conversation/vm";
@@ -203,6 +205,25 @@ export default class BaseModule implements IModule {
 
     APIClient.shared.logoutCallback = () => {
       WKApp.shared.logout();
+    };
+
+    // Plan F: generic stale-local-resource recovery dispatcher. First
+    // customer is the device_not_found code (octo-web#270 / #76). Future
+    // siblings (e.g., err.server.space.not_found for stale currentSpaceId)
+    // can be added to the staleLocalResourceCodes set in apiError.ts and
+    // routed here without touching the interceptor or business catch sites.
+    APIClient.shared.staleLocalResourceCallback = (code: string) => {
+      if (code === "err.server.user.device_not_found") {
+        handleDeviceFetchError(
+          { code } as any,
+          {
+            removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
+            resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
+            triggerLogout: () => WKApp.shared.logout(),
+          }
+        );
+      }
+      // Future siblings (space.not_found, etc.) add their else-if branches here.
     };
 
     WKApp.endpointManager.setMethod(


### PR DESCRIPTION
## Summary

Resolves stale `deviceId` causing both `Uncaught (in promise)` noise (#270) and WebSocket reconnect issues (#76) by promoting the per-call-site catch into a shared `APIClient` interceptor that classifies any registered stale-resource code and dispatches to resource-specific recovery handlers.

**Design rationale:** the same pattern applies to `currentSpaceId` (6 `localStorage.setItem` sites, `err.server.space.not_found` code already defined server-side) and any future client-cached server ID. The interceptor + classifier pattern mirrors the existing `isAuthExpiredApiError` + `logoutCallback` design — new stale codes plug in via a single-line set entry + dispatcher branch, **with zero changes** to call sites or the interceptor itself.

## Scope

This PR ships in two layers:

**Layer 1 (original #76 fix, already on branch):** classifier `handleDeviceFetchError` + `App.startMain` catch handler. Resolves the immediate stale-device symptoms via per-site catch.

**Layer 2 (Plan F generalization):** lifts that classifier into a generic `APIClient` interceptor pattern (`isStaleLocalResourceApiError` + `staleLocalResourceCallback`). Simplifies `App.startMain` catch to observability-only. Adds two bundled risk fixes:

- **Risk fix #1:** in-flight guard for `WKApp.shared.logout()` so concurrent stale/auth responses don't trigger N parallel reloads
- **Risk fix #2:** `beforeEach` reset of the new callback field in `APIClient.error.test.ts` to prevent cross-test pollution

Spec doc included: `docs/superpowers/specs/2026-06-05-plan-f-stale-resource-interceptor-design.md`.

## Files changed

```
 docs/superpowers/specs/...-plan-f-stale-resource-interceptor-design.md  | +140
 packages/dmworkbase/src/App.tsx                                          |  +36 / -2
 packages/dmworkbase/src/Service/APIClient.ts                             |  +13 / -1
 packages/dmworkbase/src/Service/apiError.ts                              |  +15
 packages/dmworkbase/src/Service/deviceFailure.ts                         |  +35   (NEW)
 packages/dmworkbase/src/module.tsx                                       |  +21
 packages/dmworkbase/src/Service/__tests__/APIClient.error.test.ts        |  +1
 packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts| +161   (NEW)
 packages/dmworkbase/src/Service/__tests__/apiError.test.ts               |  +23
 packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts          | +104   (NEW)
 ---
 10 files changed, 549 insertions(+), 2 deletions(-)
```

**No server changes.** Works against the existing octo-server contract.

## Test plan

- [ ] Unit tests: `cd packages/dmworkbase && pnpm test` → 35 tests across 5 files all pass
- [ ] Lint: `pnpm lint` clean on the touched files
- [ ] Manual end-to-end (against local octo-server):
  - [ ] Fresh login → success path of `GET /v1/user/devices/{deviceId}` works (no console error)
  - [ ] Delete device on server via `DELETE /v1/user/devices/{deviceId}` → refresh browser → user lands on login page
  - [ ] Console shows the `console.warn` from `App.startMain` for non-stale errors but **no `Uncaught (in promise)`** for the stale-device case
  - [ ] No infinite WebSocket reconnect loop
  - [ ] `localStorage` fully cleared after stale-trigger logout
- [ ] Cross-check: original happy-path flows (login, refresh-with-valid-token, normal logout) unchanged

The end-to-end manual scenario was reproduced and verified against a local `octo-server` during development.

## Risks & mitigations

| Risk | Mitigation |
|---|---|
| Concurrent stale/auth responses cause parallel `WKApp.logout()` calls | In-flight guard (Risk fix #1) |
| Storage throw in Safari private mode / `QuotaExceededError` leaves user wedged | `try/catch` around `clearLocalLoginState` ensures `window.location.reload()` always runs |
| Generic naming tempts adding unrelated codes to the set | Comment explicitly defines invariant: "client cached an ID the server no longer recognizes, recovery requires session reset"; non-fitting codes belong in business catch sites |
| Phase 2 (server expands stale-check to other endpoints) could cause silent logout from background sync | Out of scope. Verified Phase 1 trigger surface is exactly 1 endpoint (`api_device.go:24`), called only from `startMain` which runs only at login/refresh — user is never mid-edit. Decision documented in spec §6. |

## Roll-back plan

Each task is its own commit (rebased linear, 20 total). Revert specific layers if needed:
- Revert Plan F (Layer 2) only: `git revert <plan-f-head>..<plan-f-base>` — preserves original #76 fix
- Revert everything: `git revert <branch-head>..<pre-#76-base>`

## Follow-ups (not in this PR)

1. **`currentSpaceId` as second customer**: same pattern, ~5-line addition to `staleLocalResourceCodes` set + dispatcher else-if (needs corresponding recovery handler)
2. **`{ code } as any` cleanup**: type-widening `handleDeviceFetchError`'s param from `APIClientRejectedError` to `Pick<APIClientRejectedError, 'code'>` eliminates the cast without behavior change (final reviewer flagged as low-priority)
3. **Server-side Phase 2**: optionally extend `device_not_found` to all auth-required endpoints via middleware (zero frontend change needed once it lands)

Closes #76
Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
