### PR TITLE
refactor(runtimes): bot feed direct to matter, drop fleet proxy hop

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -132,9 +132,9 @@ export default defineConfig(({ mode }) => {
             : undefined,
         },
         // PR-A.2: runtime/bot endpoints moved to octo-fleet :8092.
-        // Must come before the general /api/ catch-all. Endpoints like
-        // /api/v1/runtimes/bots/:id/feed are also served from fleet
-        // (fleet internally proxies to octo-matter).
+        // Must come before the general /api/ catch-all.
+        // Note: bot feed (/bots/:uid/feed) is served directly by matter
+        // via the /matter/api/v1 proxy rule above — no fleet proxy.
         "/api/v1/runtimes": {
           target: env.VITE_FLEET_API_URL || "http://127.0.0.1:8092",
           changeOrigin: true,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,13 @@ set -eu
 : "${SUMMARY_API_URL:=}"
 export SUMMARY_API_URL
 
-envsubst '${API_URL} ${SUMMARY_API_URL}' < /nginx.conf.template > /etc/nginx/conf.d/default.conf
+# Same pattern for MATTER_API_URL — the /matter/ location 503-falls-back
+# when blank. Set MATTER_API_URL=http://octo-matter:8080 in the compose
+# stack to enable the bot feed / matter direct path.
+: "${MATTER_API_URL:=}"
+export MATTER_API_URL
+
+envsubst '${API_URL} ${SUMMARY_API_URL} ${MATTER_API_URL}' < /nginx.conf.template > /etc/nginx/conf.d/default.conf
 
 
 exec "$@"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -18,6 +18,7 @@ server {
         # these at container start; leaving an env blank yields an empty
         # string that the corresponding location block tests for.
         set $summary_api_url "${SUMMARY_API_URL}";
+        set $matter_api_url "${MATTER_API_URL}";
 
         # Security headers
         # Prevent clickjacking attacks
@@ -71,6 +72,28 @@ server {
             proxy_pass  ${API_URL}/;
             client_max_body_size 1000m;
             client_body_buffer_size 500m;
+        }
+
+        # octo-matter API — bot feed (/matter/api/v1/bots/:uid/feed) is
+        # called directly from the browser (was previously proxied by fleet);
+        # dmworktodo also targets /matter/api/v1/matters/* via the same prefix.
+        # Set MATTER_API_URL (e.g. http://octo-matter:8080) at container start;
+        # blank yields a 503 so missing matter does not break nginx startup.
+        location /matter/api/v1/ {
+            default_type application/json;
+            if ($matter_api_url = "") {
+                return 503 '{"status":503,"msg":"matter API is not configured"}';
+            }
+            resolver 127.0.0.11 ipv6=off valid=30s;
+            # Same variable-in-proxy_pass caveat as /summary/: rewrite to the
+            # upstream URI first, then proxy_pass without a URI.
+            rewrite ^/matter/api/v1/(.*)$ /api/v1/$1 break;
+            proxy_pass  $matter_api_url;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            client_max_body_size 100m;
         }
 
         # OIDC SSO endpoints (authcode/authstatus/authorize/callback).

--- a/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
@@ -165,12 +165,12 @@ function FeedTab({ bot }: { bot: Bot }) {
   const [items, setItems] = useState<BotFeedItem[] | null>(null);
   const load = useCallback(async () => {
     try {
-      const data = await getBotFeed(bot.id, 50);
+      const data = await getBotFeed(bot.bot_uid, 50);
       setItems(data);
     } catch {
       setItems([]);
     }
-  }, [bot.id]);
+  }, [bot.bot_uid]);
   useEffect(() => { load(); }, [load]);
   useEffect(() => {
     const t = window.setInterval(load, 3000);
@@ -257,10 +257,10 @@ function FeedTab({ bot }: { bot: Bot }) {
 function TasksTab({ bot }: { bot: Bot }) {
   const [items, setItems] = useState<BotFeedItem[] | null>(null);
   useEffect(() => {
-    getBotFeed(bot.id, 100)
+    getBotFeed(bot.bot_uid, 100)
       .then(data => setItems(data.filter(i => i.kind === 'activity' && i.action?.startsWith('agent_task'))))
       .catch(() => setItems([]));
-  }, [bot.id]);
+  }, [bot.bot_uid]);
   if (items === null) return <div className="wk-bd-empty">加载中…</div>;
   if (items.length === 0) return (
     <section className="wk-bd-section wk-bd-section--card">

--- a/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
@@ -176,12 +176,22 @@ export async function archiveBot(id: number): Promise<void> {
   if (!res.ok) throw new Error(`archiveBot: ${res.status}`);
 }
 
-export async function getBotFeed(id: number, limit = 50): Promise<BotFeedItem[]> {
-  const res = await fetch(`${base}/v1/runtimes/bots/${id}/feed?limit=${limit}`, { headers: await authHeaders() });
+export async function getBotFeed(botUid: string, limit = 50): Promise<BotFeedItem[]> {
+  // Skip the round-trip for draft/provisioning bots where bot_uid is empty —
+  // matter would 404 and FeedTab polls every 3s, so silent empty is correct.
+  if (!botUid) return [];
+  // Direct to matter (was: fleet /v1/runtimes/bots/:id/feed proxy → matter).
+  // matter user-auth expects session `token:` header, not the fleet Bearer JWT,
+  // and the new endpoint is space-agnostic (ownership checked via related_uids),
+  // so X-Space-Id is omitted.
+  const sessionToken = (WKApp as any)?.loginInfo?.token || '';
+  const res = await fetch(`/matter/api/v1/bots/${encodeURIComponent(botUid)}/feed?limit=${limit}`, {
+    headers: sessionToken ? { token: sessionToken } : {},
+  });
   if (!res.ok) throw new Error(`getBotFeed: ${res.status}`);
   const env = await res.json();
   const payload = unwrap<{ items?: BotFeedItem[] }>(env);
-  // server may return {items: []} or just the array
+  // matter may return {items: []} or just the array
   if (Array.isArray(payload)) return payload as any as BotFeedItem[];
   return (payload as any)?.items ?? [];
 }


### PR DESCRIPTION
## Summary

Bot detail view's "动态" + "Tasks" tabs now call matter directly at `/matter/api/v1/bots/:bot_uid/feed` instead of the fleet-proxied `/api/v1/runtimes/bots/:id/feed`. One less hop, no shared secret on this path.

Part of a 3-repo refactor — **merge AFTER** the matter PR, **BEFORE** the fleet PR:
1. octo-matter PR — adds the new endpoint (must merge first)
2. **octo-web** (this PR) — switches URL
3. octo-fleet PR — drops the proxy (must merge last)

## Changes

- `botsApi.ts`:
  - `getBotFeed(id: number)` → `getBotFeed(botUid: string)`
  - URL → `/matter/api/v1/bots/:uid/feed`
  - Auth → `token: <session>` (matter user-auth) instead of `Authorization: Bearer <fleet-JWT>`
  - Empty `bot_uid` short-circuits to `[]` so draft/provisioning bots don't 404-loop on the 3s feed poll
- `BotDetailPanel.tsx`: 2 callsites pass `bot.bot_uid` instead of `bot.id`
- `nginx.conf.template`: add `/matter/api/v1/` location with `MATTER_API_URL` env (blank → 503, same pattern as `/summary/`) so the standalone web image is self-sufficient
- `vite.config.ts`: comment refresh (no behavior change)

## Test plan

- [x] Local e2e: FeedTab `/feed?limit=50` and TasksTab `/feed?limit=100` both 200, served by matter
- [x] Network panel shows requests on `/matter/api/v1/...`, headers include `token: <session>`
- [x] Old `/api/v1/runtimes/bots/:id/feed` no longer called
- [ ] Production with `MATTER_API_URL` unset returns 503 (graceful, not 5xx crash)