### PR TITLE
fix: restore conversation scroll anchors

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/historyScroll.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/historyScroll.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { getPulldownRestoredScrollTop, shouldPulldownOnWheel, TOP_HISTORY_TRIGGER_OFFSET } from "../historyScroll"
+import {
+    getPulldownRestoredScrollTop,
+    getRestoredAnchorScrollTop,
+    getScrollAnchorOffsetY,
+    shouldPulldownOnWheel,
+    TOP_HISTORY_TRIGGER_OFFSET,
+} from "../historyScroll"
 
 describe("getPulldownRestoredScrollTop", () => {
     it("keeps the visible anchor stable by restoring the scroll height delta", () => {
@@ -16,6 +22,29 @@ describe("getPulldownRestoredScrollTop", () => {
             previousScrollTop: 0,
             nextScrollHeight: 1000,
         })).toBe(0)
+    })
+})
+
+describe("message anchor scroll restore", () => {
+    it("stores the viewport offset from the first visible message anchor", () => {
+        expect(getScrollAnchorOffsetY({
+            scrollTop: 260,
+            anchorOffsetTop: 220,
+        })).toBe(40)
+    })
+
+    it("does not store a negative anchor offset", () => {
+        expect(getScrollAnchorOffsetY({
+            scrollTop: 180,
+            anchorOffsetTop: 220,
+        })).toBe(0)
+    })
+
+    it("restores scrollTop from the message anchor and stored offset", () => {
+        expect(getRestoredAnchorScrollTop({
+            anchorOffsetTop: 500,
+            keepOffsetY: 35,
+        })).toBe(535)
     })
 })
 

--- a/packages/dmworkbase/src/Components/Conversation/historyScroll.ts
+++ b/packages/dmworkbase/src/Components/Conversation/historyScroll.ts
@@ -6,9 +6,29 @@ export interface PulldownScrollRestoreInput {
     nextScrollHeight: number
 }
 
+export interface ScrollAnchorOffsetInput {
+    scrollTop: number
+    anchorOffsetTop: number
+}
+
+export interface AnchorScrollRestoreInput {
+    anchorOffsetTop: number
+    keepOffsetY: number
+}
+
 export function getPulldownRestoredScrollTop(input: PulldownScrollRestoreInput): number {
     const nextScrollTop = input.previousScrollTop + (input.nextScrollHeight - input.previousScrollHeight)
     return nextScrollTop < 0 ? 0 : nextScrollTop
+}
+
+export function getScrollAnchorOffsetY(input: ScrollAnchorOffsetInput): number {
+    const offsetY = input.scrollTop - input.anchorOffsetTop
+    return offsetY < 0 ? 0 : offsetY
+}
+
+export function getRestoredAnchorScrollTop(input: AnchorScrollRestoreInput): number {
+    const scrollTop = input.anchorOffsetTop + input.keepOffsetY
+    return scrollTop < 0 ? 0 : scrollTop
 }
 
 export function shouldPulldownOnWheel(deltaY: number, scrollTop: number, isFullScreen: boolean): boolean {

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -61,6 +61,7 @@ import {
   isFoldSessionSummaryMessage,
 } from "./foldSessionSummary";
 import {
+  getScrollAnchorOffsetY,
   shouldPulldownOnWheel,
   TOP_HISTORY_TRIGGER_OFFSET,
 } from "./historyScroll";
@@ -1234,24 +1235,47 @@ export class Conversation
   }
 
   updateConversationExtra(draft: string) {
+    const viewport = document.getElementById(this.vm.messageContainerId);
     const conversationLastMessageSeq = this.vm.conversationLastMessageSeq();
-    const lastVisiableMessage = this.lastVisiableMessage(null);
+    const lastVisiableMessage = this.visiblePersistentMessage(viewport, true);
     let keepMessageSeq = 0;
+    let keepOffsetY = 0;
     if (
+      conversationLastMessageSeq > 0 &&
       lastVisiableMessage &&
       lastVisiableMessage.messageSeq >= conversationLastMessageSeq
     ) {
       keepMessageSeq = 0;
     } else {
-      const firstVisiableMessage = this.firstVisiableMessage(null);
+      const firstVisiableMessage = this.visiblePersistentMessage(
+        viewport,
+        false,
+      );
+      const firstVisibleElement = firstVisiableMessage
+        ? this.getMessageElement(firstVisiableMessage)
+        : null;
       keepMessageSeq = firstVisiableMessage?.messageSeq || 0;
+      keepOffsetY =
+        viewport && firstVisibleElement
+          ? getScrollAnchorOffsetY({
+              scrollTop: viewport.scrollTop,
+              anchorOffsetTop: firstVisibleElement.offsetTop,
+            })
+          : 0;
+    }
+
+    const remoteExtra = this.vm.currentConversation?.remoteExtra;
+    if (remoteExtra) {
+      remoteExtra.keepMessageSeq = keepMessageSeq;
+      remoteExtra.keepOffsetY = keepOffsetY;
+      remoteExtra.draft = draft || "";
     }
 
     return WKApp.dataSource.channelDataSource.conversationExtraUpdate({
       channel: this.vm.channel,
       browseTo: 0,
       keepMessageSeq: keepMessageSeq,
-      keepOffsetY: 0,
+      keepOffsetY,
       draft,
       version: 0,
     });
@@ -2016,6 +2040,46 @@ export class Conversation
       }
     }
   }
+
+  private visiblePersistentMessage(
+    vp: HTMLElement | null,
+    fromEnd: boolean,
+  ) {
+    if (!this.vm.messages || this.vm.messages.length === 0) {
+      return;
+    }
+    let viewport = vp;
+    if (!viewport) {
+      viewport = document.getElementById(this.vm.messageContainerId);
+    }
+    if (!viewport) {
+      return;
+    }
+    const targetScrollTop = viewport.scrollTop;
+    const scrollOffsetTop =
+      viewport.scrollHeight - (targetScrollTop + viewport.clientHeight);
+    const start = fromEnd ? this.vm.messages.length - 1 : 0;
+    const end = fromEnd ? -1 : this.vm.messages.length;
+    const step = fromEnd ? -1 : 1;
+    for (let index = start; index !== end; index += step) {
+      const message = this.vm.messages[index];
+      if (!message.messageSeq || message.messageSeq <= 0) {
+        continue;
+      }
+      const element = this.getMessageElement(message);
+      if (!element) {
+        continue;
+      }
+      if (fromEnd) {
+        if (viewport.scrollHeight - element.offsetTop > scrollOffsetTop) {
+          return message;
+        }
+      } else if (element.offsetTop + element.clientHeight > targetScrollTop) {
+        return message;
+      }
+    }
+  }
+
   // 所有可见的消息
   allVisiableMessages(vp: HTMLElement | null): Array<MessageWrap> {
     const visiableMessages = new Array<MessageWrap>();

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -17,7 +17,7 @@ import { SYSTEM_BOTS } from "../../Service/SpaceService";
 import { SuperGroup } from "../../Utils/const";
 import { SystemContent } from "wukongimjssdk";
 import { getFoldSessionExpandedMessages } from "./foldSessionSummary";
-import { getPulldownRestoredScrollTop } from "./historyScroll";
+import { getPulldownRestoredScrollTop, getRestoredAnchorScrollTop } from "./historyScroll";
 import { applyMsgLevelExternalFieldsWithFallback } from "../../Service/Convert";
 import { wrapSendContentForInjection } from "./sendContentProxy";
 import { isMessageSelectable } from "../../Service/messageSelection";
@@ -1481,24 +1481,31 @@ export default class ConversationVM extends ProviderListener {
     requestMessagesOfFirstPage(lcateMessageSeq?: number, stateCallback?: () => void) {
 
         this.initLocateMessageSeq = 0
+        let initLocateOffsetY = 0
         if (lcateMessageSeq === undefined) {
             if (this.currentConversation) {
                 const remoteExtra = this.currentConversation.remoteExtra
+                const savedKeepMessageSeq = Number(remoteExtra.keepMessageSeq || 0)
+                const savedKeepOffsetY = Number(remoteExtra.keepOffsetY || 0)
+                const keepMessageSeq = Number.isFinite(savedKeepMessageSeq) ? savedKeepMessageSeq : 0
+                const keepOffsetY = Number.isFinite(savedKeepOffsetY) ? savedKeepOffsetY : 0
                 if (this.currentConversation.unread > 0) {
-                    if (remoteExtra.keepMessageSeq != 0 && remoteExtra.keepMessageSeq < this.browseToMessageSeq) {
-                        this.initLocateMessageSeq = remoteExtra.keepMessageSeq
+                    if (keepMessageSeq > 0 && keepMessageSeq < this.browseToMessageSeq) {
+                        this.initLocateMessageSeq = keepMessageSeq
+                        initLocateOffsetY = keepOffsetY
                     } else {
                         this.initLocateMessageSeq = this.browseToMessageSeq
                     }
 
                 } else {
-                    this.initLocateMessageSeq = remoteExtra.keepMessageSeq
+                    this.initLocateMessageSeq = keepMessageSeq
+                    initLocateOffsetY = keepMessageSeq > 0 ? keepOffsetY : 0
                 }
             }
         } else {
             this.initLocateMessageSeq = lcateMessageSeq
         }
-        return this.syncMessages(this.initLocateMessageSeq, stateCallback)
+        return this.syncMessages(this.initLocateMessageSeq, stateCallback, initLocateOffsetY)
     }
 
     // 最近会话显示的最后一条消息的messageSeq
@@ -1511,7 +1518,7 @@ export default class ConversationVM extends ProviderListener {
     }
 
     // 同步消息
-    async syncMessages(initMessageSeq?: number, stateCallback?: () => void) {
+    async syncMessages(initMessageSeq?: number, stateCallback?: () => void, locateOffsetY: number = 0) {
         this.loading = true
         this.notifyListener()
 
@@ -1583,7 +1590,7 @@ export default class ConversationVM extends ProviderListener {
             // loading 完成后，主动确保 bot 消息的 channelInfo 已载入
             // 修复：loading 期间 channelInfoListener 会被跳过，导致 AI 标识不显示
             this.ensureBotChannelInfos()
-        })
+        }, locateOffsetY)
     }
     private getMessageSortOrder(message: MessageWrap): number {
         if (message.messageSeq && message.messageSeq > 0) {
@@ -1632,10 +1639,10 @@ export default class ConversationVM extends ProviderListener {
     }
 
     // 刷新消息列表并定位到某条消息
-    refreshAndLocateMessages(messages: MessageWrap[], locateMessage?: MessageWrap, scrollBottom?: boolean, callback?: () => void) {
+    refreshAndLocateMessages(messages: MessageWrap[], locateMessage?: MessageWrap, scrollBottom?: boolean, callback?: () => void, locateOffsetY: number = 0) {
         this.refreshMessages(messages, () => {
             if (locateMessage) {
-                this.scrollToMessage(locateMessage)
+                this.scrollToMessage(locateMessage, locateOffsetY)
             } else if (scrollBottom) {
                 this.scrollToBottom(false)
             }
@@ -1899,12 +1906,50 @@ export default class ConversationVM extends ProviderListener {
             }
         }
     }
+    private messageScrollElement(message: MessageWrap): HTMLElement | null {
+        const element = document.getElementById(message.clientMsgNo)
+        if (element) {
+            return element
+        }
+        if (!message.messageSeq || message.messageSeq <= 0) {
+            return null
+        }
+        const foldSession = this.findFoldSessionByMessageSeq(message.messageSeq)
+        if (!foldSession) {
+            return null
+        }
+        return document.getElementById(foldSession.anchorId)
+    }
+
     // 滚动到指定的消息
-    scrollToMessage(message: MessageWrap) {
+    scrollToMessage(message: MessageWrap, offsetY: number = 0) {
+        const viewport = document.getElementById(this.messageContainerId)
+        const element = this.messageScrollElement(message)
+        const keepOffsetY = Number.isFinite(offsetY) ? Math.max(0, offsetY) : 0
+        if (viewport && element) {
+            viewport.scrollTop = getRestoredAnchorScrollTop({
+                anchorOffsetTop: element.offsetTop,
+                keepOffsetY,
+            })
+            return
+        }
         scroller.scrollTo(message.clientMsgNo, {
             containerId: this.messageContainerId,
             "duration": 0,
         });
+        if (keepOffsetY > 0) {
+            const restoreOffset = () => {
+                const nextViewport = document.getElementById(this.messageContainerId)
+                if (nextViewport) {
+                    nextViewport.scrollTop += keepOffsetY
+                }
+            }
+            if (typeof requestAnimationFrame === "function") {
+                requestAnimationFrame(restoreOffset)
+            } else {
+                setTimeout(restoreOffset, 0)
+            }
+        }
     }
     // 只滚动到底部
     scrollToBottom(animate: boolean) {


### PR DESCRIPTION
Fixes #257.

## Summary
- Save conversation scroll state as a message anchor plus in-message offset instead of relying on a raw container scrollTop.
- Restore from the saved anchor and offset after the initial message page renders, while keeping explicit message navigation at the target message.
- Update the in-memory conversation extra immediately so fast conversation switches read the latest saved position.

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/Conversation/__tests__