### PR TITLE
feat(octo-web): group-level allow no-mention toggle (owner/admin)

### DIFF
--- a/packages/dmworkbase/src/Service/ChannelSetting.ts
+++ b/packages/dmworkbase/src/Service/ChannelSetting.ts
@@ -54,6 +54,11 @@ export class ChannelSettingManager {
         return this._onSetting({ "allow_member_pinned_message": v ? 1 : 0 }, channel)
     }
 
+    // 允许群内 Bot 免@回答（群级总开关，群主/管理员可控）
+    setAllowNoMention(allow: boolean, channel: Channel): Promise<void> {
+        return this._onSetting({ "allow_no_mention": allow ? 1 : 0 }, channel)
+    }
+
     _onSetting(setting: any, channel: Channel): Promise<void> {
         return WKApp.dataSource.channelDataSource.updateSetting(setting, channel).catch((err) => {
             console.error('Setting update failed:', err);

--- a/packages/dmworkbase/src/Service/Convert.ts
+++ b/packages/dmworkbase/src/Service/Convert.ts
@@ -410,6 +410,8 @@ export class Convert {
         channelInfo.orgData.invite = data.invite;
         channelInfo.orgData.forbiddenAddFriend = data.forbidden_add_friend;
         channelInfo.orgData.save = data.save;
+        // 群级「允许免@回答」总开关：老数据无字段时回退 1（允许），零回归。
+        channelInfo.orgData.allow_no_mention = data.allow_no_mention ?? 1;
 
         channelInfo.logo = data.logo
         if (!channelInfo.logo || channelInfo.logo === "") {

--- a/packages/dmworkbase/src/Service/__tests__/channelSettingRows.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/channelSettingRows.test.ts
@@ -1,0 +1,102 @@
+/**
+ * buildAllowNoMentionRow — 群级「允许群内 Bot 免@回答」总开关行单测（YUJ-3088）。
+ *
+ * 覆盖：
+ *   1. 默认态：allow_no_mention 缺省 → checked=true（开）。
+ *   2. allow_no_mention=0 → checked=false（关）。
+ *   3. onCheck：loading 流转（true→false）+ 调 setAllowNoMention(v) + 成功后 refresh()。
+ *   4. onCheck 失败：loading 回 false，不 refresh。
+ *   5. 非管理员（isManagerOrCreator=false）→ 返回 undefined（不渲染）。
+ *   6. 非 group channelType → 返回 undefined（不渲染）。
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+
+const hoisted = vi.hoisted(() => {
+    const setAllowNoMention = vi.fn(() => Promise.resolve())
+    return { setAllowNoMention }
+})
+
+vi.mock("../ChannelSetting", () => ({
+    ChannelSettingManager: {
+        shared: { setAllowNoMention: hoisted.setAllowNoMention },
+    },
+}))
+
+// ListItemSwitch 引入了 semi-ui / css，单测里 stub 成占位即可。
+vi.mock("../../Components/ListItem", () => ({
+    ListItemSwitch: function ListItemSwitch() { return null },
+}))
+
+import { buildAllowNoMentionRow } from "../channelSettingRows"
+
+const groupChannel = new Channel("g1", ChannelTypeGroup)
+const personChannel = new Channel("u1", ChannelTypePerson)
+
+const make = (over: any = {}) =>
+    buildAllowNoMentionRow({
+        channel: groupChannel,
+        channelInfo: { orgData: {} } as any,
+        isManagerOrCreator: true,
+        title: "allow",
+        refresh: vi.fn(),
+        ...over,
+    })
+
+describe("buildAllowNoMentionRow", () => {
+    beforeEach(() => {
+        hoisted.setAllowNoMention.mockReset()
+        hoisted.setAllowNoMention.mockResolvedValue(undefined)
+    })
+
+    it("defaults checked=true when allow_no_mention is absent", () => {
+        const row = make({ channelInfo: { orgData: {} } as any })
+        expect(row).toBeDefined()
+        expect(row!.properties.checked).toBe(true)
+    })
+
+    it("checked=true when allow_no_mention=1", () => {
+        const row = make({ channelInfo: { orgData: { allow_no_mention: 1 } } as any })
+        expect(row!.properties.checked).toBe(true)
+    })
+
+    it("checked=false when allow_no_mention=0", () => {
+        const row = make({ channelInfo: { orgData: { allow_no_mention: 0 } } as any })
+        expect(row!.properties.checked).toBe(false)
+    })
+
+    it("onCheck calls setAllowNoMention, toggles loading, and refreshes on success", async () => {
+        const refresh = vi.fn()
+        const row = make({ refresh })
+        const ctx: any = { loading: false }
+        row!.properties.onCheck(false, ctx)
+        // 立即进入 loading
+        expect(ctx.loading).toBe(true)
+        expect(hoisted.setAllowNoMention).toHaveBeenCalledWith(false, groupChannel)
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(ctx.loading).toBe(false)
+        expect(refresh).toHaveBeenCalledTimes(1)
+    })
+
+    it("onCheck resets loading and skips refresh on failure", async () => {
+        hoisted.setAllowNoMention.mockRejectedValueOnce(new Error("boom"))
+        const refresh = vi.fn()
+        const row = make({ refresh })
+        const ctx: any = { loading: false }
+        row!.properties.onCheck(true, ctx)
+        expect(ctx.loading).toBe(true)
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(ctx.loading).toBe(false)
+        expect(refresh).not.toHaveBeenCalled()
+    })
+
+    it("returns undefined for non-manager members", () => {
+        expect(make({ isManagerOrCreator: false })).toBeUndefined()
+    })
+
+    it("returns undefined for non-group channel types", () => {
+        expect(make({ channel: personChannel })).toBeUndefined()
+    })
+})

--- a/packages/dmworkbase/src/Service/channelSettingRows.ts
+++ b/packages/dmworkbase/src/Service/channelSettingRows.ts
@@ -1,0 +1,55 @@
+import { Channel, ChannelInfo } from "wukongimjssdk"
+import { ChannelTypeGroup } from "wukongimjssdk"
+import { Row } from "./Section"
+import { ListItemSwitch, ListItemSwitchContext } from "../Components/ListItem"
+import { ChannelSettingManager } from "./ChannelSetting"
+
+/**
+ * 群级「允许群内 Bot 免@回答」总开关行（YUJ-3088 / 配套 YUJ-2996）。
+ *
+ * 两轴语义：最终免at = bot主人开了本群免at(no_mention) AND 群管理员允许本群免at(allow_no_mention)。
+ * 本行管的是「群管理员 allow_no_mention 轴」。
+ *
+ * 可见性守卫：
+ *   - 仅 ChannelTypeGroup（排除 CustomerService / CommunityTopic）；
+ *   - 仅群主/管理员（isManagerOrCreator）；普通成员返回 undefined（不渲染）。
+ *
+ * checked：channelInfo.orgData.allow_no_mention !== 0，默认开（缺省=1，零回归）。
+ * onCheck：loading=true → setAllowNoMention → 成功 loading=false + refresh()；失败 loading=false。
+ */
+export function buildAllowNoMentionRow(opts: {
+    channel: Channel
+    channelInfo?: ChannelInfo
+    isManagerOrCreator: boolean
+    title: string
+    refresh: () => void
+}): Row | undefined {
+    const { channel, channelInfo, isManagerOrCreator, title, refresh } = opts
+
+    if (channel.channelType !== ChannelTypeGroup) {
+        return undefined
+    }
+    if (!isManagerOrCreator) {
+        return undefined
+    }
+
+    return new Row({
+        cell: ListItemSwitch,
+        properties: {
+            title,
+            checked: channelInfo?.orgData?.allow_no_mention !== 0,
+            onCheck: (v: boolean, ctx: ListItemSwitchContext) => {
+                ctx.loading = true
+                ChannelSettingManager.shared
+                    .setAllowNoMention(v, channel)
+                    .then(() => {
+                        ctx.loading = false
+                        refresh()
+                    })
+                    .catch(() => {
+                        ctx.loading = false
+                    })
+            },
+        },
+    })
+}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -468,6 +468,7 @@
   "botStore.noDescription": "No description",
   "botStore.pending": "Pending approval",
   "botStore.storeEmpty": "No AI bots available in this Space",
+  "module.channelSettings.allowNoMention": "Allow bots to reply without @",
   "module.channelSettings.clearMessages": "Clear chat history",
   "module.channelSettings.clearMessagesConfirm": "Clear all messages in this conversation?",
   "module.channelSettings.configuredVersion": "Configured v{{version}}",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -469,6 +469,7 @@
   "botStore.noDescription": "暂无简介",
   "botStore.pending": "审批中",
   "botStore.storeEmpty": "当前 Space 暂无可用 AI",
+  "module.channelSettings.allowNoMention": "允许群内 Bot 免@回答",
   "module.channelSettings.clearMessages": "清空聊天记录",
   "module.channelSettings.clearMessagesConfirm": "是否清空此会话的所有消息？",
   "module.channelSettings.configuredVersion": "已配置 v{{version}}",

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -77,6 +77,7 @@ import { LottieSticker, LottieStickerCell } from "./Messages/LottieSticker";
 import { LocationCell, LocationContent } from "./Messages/Location";
 import { Toast, Tag } from "@douyinfe/semi-ui";
 import { ChannelSettingManager } from "./Service/ChannelSetting";
+import { buildAllowNoMentionRow } from "./Service/channelSettingRows";
 import { DefaultEmojiService } from "./Service/EmojiService";
 import IconClick from "./Components/IconClick";
 import EmojiToolbar from "./Components/EmojiToolbar";
@@ -1830,6 +1831,18 @@ export default class BaseModule implements IModule {
               },
             })
           );
+        }
+
+        // 群级「允许群内 Bot 免@回答」总开关：仅群主/管理员可见可控。
+        const allowNoMentionRow = buildAllowNoMentionRow({
+          channel,
+          channelInfo,
+          isManagerOrCreator: data.isManagerOrCreatorOfMe,
+          title: t("base.module.channelSettings.allowNoMention"),
+          refresh: () => data.refresh(),
+        });
+        if (allowNoMentionRow) {
+          rows.push(allowNoMentionRow);
         }
         return new Section({
           rows: rows,

--- a/packages/dmworkdatasource/src/module.ts
+++ b/packages/dmworkdatasource/src/module.ts
@@ -145,6 +145,8 @@ export default class DataSourceModule implements IModule {
                 channelInfo.orgData.invite = data.invite;
                 channelInfo.orgData.forbiddenAddFriend = data.extra?.forbidden_add_friend;
                 channelInfo.orgData.save = data.save;
+                // 群级「允许免@回答」总开关：老数据无字段时回退 1（允许），零回归。
+                channelInfo.orgData.allow_no_mention = (data.allow_no_mention ?? data.extra?.allow_no_mention) ?? 1;
                 channelInfo.orgData.has_group_md = !!(data.has_group_md ?? data.extra?.has_group_md);
                 channelInfo.orgData.group_md_version = data.group_md_version || data.extra?.group_md_version || 0;
                 channelInfo.orgData.group_md_updated_at = data.group_md_updated_at || data.extra?.group_md_updated_at || null;


### PR DESCRIPTION
## What

Adds a group-level **「允许群内 Bot 免@回答」/ "Allow bots to reply without @"** switch to channel settings, controllable only by group owner/managers.

This is the **group admin (`allow_no_mention`) axis** of the two-axis mention-free feature:

```
最终免at = bot主人开了本群免at(no_mention) AND 群管理员允许本群免at(allow_no_mention)
```

The bot-owner `no_mention` axis (BotManage/MentionFreeList) already exists and is untouched. This PR adds the group-admin `allow_no_mention` axis.

## Changes

- **Service**: `ChannelSettingManager.setAllowNoMention(allow, channel)` posts `allow_no_mention` 0/1 via the existing group setting endpoint (server checks owner/admin permission).
- **channelInfo**: `Convert.groupToChannelInfo` + datasource channelInfo builder expose `allow_no_mention`, defaulting to **1 (allowed)** when the field is absent → zero regression for existing groups.
- **UI**: `module.tsx` renders the switch via a new pure helper `buildAllowNoMentionRow`, guarded to `ChannelTypeGroup` and owner/managers only (`isManagerOrCreatorOfMe`). Default checked. `onCheck` mirrors the existing mute/pin pattern (loading→setAllowNoMention→refresh on success / loading reset on failure).
- **i18n**: `module.channelSettings.allowNoMention` for zh-CN / en-US.
- **Tests**: unit tests cover default-checked (absent field), `allow_no_mention=0` off, loading flow + refresh on success, no-refresh on failure, and visibility guards (non-manager hidden, non-group hidden).

## Notes

- Depends on octo-server PR#263 (`allow_no_mention` field + group attr endpoint). UI degrades safely if absent (defaults to allowed).
- Does **not** touch BotManage/MentionFreeList.

Part of YUJ-2996 / closes YUJ-3088.