### PR TITLE
fix: create group from private chat add member

### DIFF
--- a/packages/dmworkcontacts/src/Organizational/GroupNew/__tests__/memberUids.test.ts
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/__tests__/memberUids.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildPrivateChatGroupMemberUids } from "../memberUids";
+
+describe("buildPrivateChatGroupMemberUids", () => {
+  it("includes the current user, private chat peer, and selected contacts", () => {
+    expect(
+      buildPrivateChatGroupMemberUids("u_self", "u_peer", ["u_a", "u_b"])
+    ).toEqual(["u_self", "u_peer", "u_a", "u_b"]);
+  });
+
+  it("deduplicates members and omits empty login uid", () => {
+    expect(
+      buildPrivateChatGroupMemberUids("", "u_peer", ["u_peer", "u_a", "u_a"])
+    ).toEqual(["u_peer", "u_a"]);
+  });
+});

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -17,6 +17,7 @@ import WKAvatar from "@octo/base/src/Components/WKAvatar";
 import AiBadge from "@octo/base/src/Components/AiBadge";
 import "./index.css";
 import { SuperGroup } from "@octo/base/src/Utils/const";
+import { buildPrivateChatGroupMemberUids } from "./memberUids";
 
 export enum OrganizationalGroupNewAction {
   createGroup, // 创建群聊
@@ -486,10 +487,26 @@ export class OrganizationalGroupNew extends Component<
     // 添加联系人
     if (this.props.action === OrganizationalGroupNewAction.AddMember) {
       try {
-        await WKApp.dataSource.channelDataSource.addSubscribers(
-          channel,
-          getOptPersonnelData
-        );
+        if (channel.channelType === ChannelTypePerson) {
+          const memberUids = buildPrivateChatGroupMemberUids(
+            WKApp.loginInfo.uid,
+            channel.channelID,
+            getOptPersonnelData
+          );
+          const result = await WKApp.dataSource.channelDataSource.createChannel(
+            memberUids
+          );
+          if (result?.group_no) {
+            WKApp.endpoints.showConversation(
+              new Channel(result.group_no, ChannelTypeGroup)
+            );
+          }
+        } else {
+          await WKApp.dataSource.channelDataSource.addSubscribers(
+            channel,
+            getOptPersonnelData
+          );
+        }
       } catch (error: any) {
         Toast.error(error.msg);
         return

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/memberUids.ts
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/memberUids.ts
@@ -1,0 +1,11 @@
+export function buildPrivateChatGroupMemberUids(
+  loginUid: string | undefined,
+  peerUid: string,
+  selectedUids: string[]
+) {
+  const memberUids = [loginUid, peerUid, ...selectedUids].filter(
+    (uid): uid is string => typeof uid === "string" && uid.length > 0
+  );
+
+  return Array.from(new Set(memberUids));
+}


### PR DESCRIPTION
## Summary
- create a new group when Start Group Chat is triggered from a private chat
- keep existing group AddMember behavior using addSubscribers
- add member UID helper coverage for private-chat group creation

Fixes #51

## Tests
- pnpm exec vitest run packages/dmworkcontacts/src/Organizational/GroupNew/__tests__/memberUids.test.ts --config packages/dmworkcontacts/vitest.config.ts