### PR TITLE
feat: migrate rich text mixed content UI

### DIFF
--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
@@ -22,6 +22,9 @@ import { downloadFile } from "../../Utils/download";
 import { isSafeUrl } from "../../Utils/security";
 import { getExtension } from "../FilePreviewPanel/types";
 import MarkdownContent from "../../Messages/Text/MarkdownContent";
+import { RichTextContent } from "../../Messages/RichText/RichTextContent";
+import { getRichTextBlocksUI } from "../../bridge/message/useRichTextMessageUI";
+import MixedContent from "../../ui/message/MixedContent";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import "yet-another-react-lightbox/styles.css";
@@ -276,6 +279,19 @@ export default class MergeforwardMessageList extends Component<
               previewImageContent: imageContent,
             })
           }
+        />
+      );
+    }
+    if (msg.contentType === MessageContentTypeConst.richText) {
+      const richTextContent = msg.content as RichTextContent;
+      return (
+        <MixedContent
+          blocks={getRichTextBlocksUI(richTextContent.content || [])}
+          onFileDownload={(block) => {
+            if (block.url) {
+              downloadFile(block.url, block.name);
+            }
+          }}
         />
       );
     }

--- a/packages/dmworkbase/src/Messages/MessageCell.tsx
+++ b/packages/dmworkbase/src/Messages/MessageCell.tsx
@@ -1,5 +1,11 @@
 import React, { Component } from "react";
-import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
+import WKSDK, {
+    Channel,
+    ChannelInfo,
+    ChannelInfoListener,
+    ChannelTypeGroup,
+    ChannelTypePerson,
+} from "wukongimjssdk";
 import ConversationContext from "../Components/Conversation/context";
 import { MessageWrap } from "../Service/Model";
 
@@ -21,6 +27,7 @@ export class MessageBaseCell<P extends MessageBaseCellProps = MessageBaseCellPro
 
 export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsImp, S = {}> extends MessageBaseCell<P, S> {
     private _channelInfoListener!: ChannelInfoListener
+    private _subscriberChangeListener?: (channel: Channel) => void
 
     componentDidMount() {
         const { message } = this.props
@@ -74,10 +81,24 @@ export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsIm
                 WKSDK.shared().channelManager.fetchChannelInfo(convChannel)
             }
         }
+
+        // class + MessageRow 渲染路径依赖 group subscribers 解析群昵称/实名标。
+        // 群成员列表异步到达时需要主动刷新，对齐旧 MessageBase 行为。
+        if (message.channel?.channelType === ChannelTypeGroup) {
+            this._subscriberChangeListener = (channel: Channel) => {
+                if (message.channel?.isEqual(channel)) {
+                    this.setState({})
+                }
+            }
+            WKSDK.shared().channelManager.addSubscriberChangeListener(this._subscriberChangeListener)
+        }
     }
 
     componentWillUnmount() {
         WKSDK.shared().channelManager.removeListener(this._channelInfoListener)
+        if (this._subscriberChangeListener) {
+            WKSDK.shared().channelManager.removeSubscriberChangeListener(this._subscriberChangeListener)
+        }
     }
 
     render() {

--- a/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
+++ b/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
@@ -119,7 +119,6 @@ export function createRichTextContent(
 export class RichTextContent extends MessageContent {
   content: RichTextBlock[] = [];
   plain = "";
-  reply?: any;
 
   decodeJSON(content: any) {
     const raw = content?.content;

--- a/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
+++ b/packages/dmworkbase/src/Messages/RichText/RichTextContent.ts
@@ -1,57 +1,69 @@
-import { MessageContent } from "wukongimjssdk"
-import { MessageContentTypeConst } from "../../Service/Const"
-import { t } from "../../i18n"
+import { MessageContent } from "wukongimjssdk";
+import { MessageContentTypeConst } from "../../Service/Const";
+import { t } from "../../i18n";
 
 /** RichText(=14) 图文混排 block 类型常量（与 octo-lib common/richtext.go 对齐）。 */
 export const RichTextBlockType = {
-    text: "text",
-    image: "image",
-} as const
+  text: "text",
+  image: "image",
+  file: "file",
+} as const;
 
 /** plain 生成时 image block 注入的占位符（与 octo-lib RichTextImagePlaceholder 对齐）。 */
-export const RichTextImagePlaceholder = "[图片]"
+export const RichTextImagePlaceholder = "[图片]";
+/** plain 生成时 file block 注入的占位符。仅用于前端前向兼容展示，发送侧暂不构造 file block。 */
+export const RichTextFilePlaceholder = "[文件]";
 
 /**
  * RichText(=14) content 数组中的单个 block。
  * 字段命名与 server payload（snake_case 兼容）保持一致：
  *   - text  块：type="text"，text 为纯文本（MVP 不渲染 markdown）；
  *   - image 块：type="image"，url 为图片引用地址，width/height 供占位排版。
+ *   - file  块：type="file"，当前仅做前向兼容接收渲染，发送侧待 octo-lib/backend 契约支持后打开。
  */
 export interface RichTextBlock {
-    type: string
-    /** text block 文本内容。 */
-    text?: string
-    /** image block 图片地址（scheme allowlist 仅 http/https）。 */
-    url?: string
-    width?: number
-    height?: number
-    size?: number
-    name?: string
+  type: string;
+  /** text block 文本内容。 */
+  text?: string;
+  /** image block 图片地址（scheme allowlist 仅 http/https）。 */
+  url?: string;
+  width?: number;
+  height?: number;
+  size?: number;
+  name?: string;
+  extension?: string;
+  mime?: string;
+  caption?: string;
 }
 
 /**
  * 遍历 content blocks 生成纯文本（与 octo-lib BuildRichTextPlain 对齐）：
  *   - text  block 取 text；
  *   - image block 注入占位符；
+ *   - file  block 注入占位符 + 文件名；
  *   - 未知 type 前向兼容：有 text 则取 text，否则跳过。
  */
 export function buildRichTextPlain(content: RichTextBlock[]): string {
-    let out = ""
-    for (const blk of content) {
-        if (blk.type === RichTextBlockType.image) {
-            out += RichTextImagePlaceholder
-        } else if (blk.type === RichTextBlockType.text) {
-            out += blk.text || ""
-        } else if (blk.text) {
-            out += blk.text
-        }
+  let out = "";
+  for (const blk of content) {
+    if (blk.type === RichTextBlockType.image) {
+      out += RichTextImagePlaceholder;
+    } else if (blk.type === RichTextBlockType.file) {
+      out += blk.name
+        ? `${RichTextFilePlaceholder} ${blk.name}`
+        : RichTextFilePlaceholder;
+    } else if (blk.type === RichTextBlockType.text) {
+      out += blk.text || "";
+    } else if (blk.text) {
+      out += blk.text;
     }
-    return out
+  }
+  return out;
 }
 
 /** 构造一个 text block（发送侧，与接收侧 schema 对齐）。 */
 export function makeTextBlock(text: string): RichTextBlock {
-    return { type: RichTextBlockType.text, text }
+  return { type: RichTextBlockType.text, text };
 }
 
 /**
@@ -60,21 +72,21 @@ export function makeTextBlock(text: string): RichTextBlock {
  * 避免往 wire 注入 0/空 字段污染 byte-match。
  */
 export function makeImageBlock(opts: {
-    url: string
-    width: number
-    height: number
-    size?: number
-    name?: string
+  url: string;
+  width: number;
+  height: number;
+  size?: number;
+  name?: string;
 }): RichTextBlock {
-    const blk: RichTextBlock = {
-        type: RichTextBlockType.image,
-        url: opts.url,
-        width: opts.width,
-        height: opts.height,
-    }
-    if (opts.size && opts.size > 0) blk.size = opts.size
-    if (opts.name) blk.name = opts.name
-    return blk
+  const blk: RichTextBlock = {
+    type: RichTextBlockType.image,
+    url: opts.url,
+    width: opts.width,
+    height: opts.height,
+  };
+  if (opts.size && opts.size > 0) blk.size = opts.size;
+  if (opts.name) blk.name = opts.name;
+  return blk;
 }
 
 /**
@@ -84,11 +96,13 @@ export function makeImageBlock(opts: {
  * 仅用于本地回显 / 离线兜底；**server #232 Finalize 会重算覆盖**，web 不是 plain 权威源。
  * 占位符 token 复用 RichTextImagePlaceholder（wire-format 不可本地化），与接收侧严格对称。
  */
-export function createRichTextContent(content: RichTextBlock[]): RichTextContent {
-    const c = new RichTextContent()
-    c.content = content
-    c.plain = buildRichTextPlain(content)
-    return c
+export function createRichTextContent(
+  content: RichTextBlock[]
+): RichTextContent {
+  const c = new RichTextContent();
+  c.content = content;
+  c.plain = buildRichTextPlain(content);
+  return c;
 }
 
 /**
@@ -98,63 +112,68 @@ export function createRichTextContent(content: RichTextBlock[]): RichTextContent
  *   { type: 14, content: [ {type:"text",text} | {type:"image",url,width,height} ], plain }
  *   - content 为有序数组，顺序即图文穿插顺序；
  *   - plain 为冗余纯文本，server 权威生成，供复制 / 引用预览 / 搜索复用。
+ *   - file block 字段仅用于前端前向兼容展示；当前发送侧不会构造 file block。
  *
  * 向后兼容：老 payload content 可能是纯字符串，归一为单个 text block。
  */
 export class RichTextContent extends MessageContent {
-    content: RichTextBlock[] = []
-    plain = ""
+  content: RichTextBlock[] = [];
+  plain = "";
+  reply?: any;
 
-    decodeJSON(content: any) {
-        const raw = content?.content
-        if (Array.isArray(raw)) {
-            this.content = raw.map((blk: any) => ({
-                type: blk?.type,
-                text: blk?.text,
-                url: blk?.url,
-                width: blk?.width,
-                height: blk?.height,
-                size: blk?.size,
-                name: blk?.name,
-            }))
-        } else if (typeof raw === "string") {
-            // 兼容老版本 content 为纯字符串：归一为单个 text block。
-            this.content = raw ? [{ type: RichTextBlockType.text, text: raw }] : []
-        } else {
-            this.content = []
-        }
-        this.plain = typeof content?.plain === "string" ? content.plain : ""
-        // plain 缺失时（老 payload 或字符串 content）现场回填，保证复制/引用预览不丢字。
-        if (this.plain.trim() === "") {
-            this.plain = buildRichTextPlain(this.content)
-        }
+  decodeJSON(content: any) {
+    const raw = content?.content;
+    if (Array.isArray(raw)) {
+      this.content = raw.map((blk: any) => ({
+        type: blk?.type,
+        text: blk?.text,
+        url: blk?.url,
+        width: blk?.width,
+        height: blk?.height,
+        size: blk?.size,
+        name: blk?.name,
+        extension: blk?.extension,
+        mime: blk?.mime,
+        caption: blk?.caption,
+      }));
+    } else if (typeof raw === "string") {
+      // 兼容老版本 content 为纯字符串：归一为单个 text block。
+      this.content = raw ? [{ type: RichTextBlockType.text, text: raw }] : [];
+    } else {
+      this.content = [];
     }
+    this.plain = typeof content?.plain === "string" ? content.plain : "";
+    // plain 缺失时（老 payload 或字符串 content）现场回填，保证复制/引用预览不丢字。
+    if (this.plain.trim() === "") {
+      this.plain = buildRichTextPlain(this.content);
+    }
+  }
 
-    encodeJSON(): any {
-        // 发送侧序列化 content blocks + 本地 plain 占位（server #232 Finalize 重算覆盖）。
-        // SDK MessageContent.encode() 会注入 type=14；JSON.stringify 自动丢弃 undefined 字段，
-        // 保证 wire-format 与 octo-lib 权威 schema byte-match。
-        return { content: this.content, plain: this.plain }
-    }
+  encodeJSON(): any {
+    // 发送侧序列化 content blocks + 本地 plain 占位（server #232 Finalize 重算覆盖）。
+    // SDK MessageContent.encode() 会注入 type=14；JSON.stringify 自动丢弃 undefined 字段，
+    // 保证 wire-format 与 octo-lib 权威 schema byte-match。
+    return { content: this.content, plain: this.plain };
+  }
 
-    get contentType() {
-        return MessageContentTypeConst.richText
-    }
+  get contentType() {
+    return MessageContentTypeConst.richText;
+  }
 
-    /**
-     * 引用预览 / 会话摘要文本：优先 server 生成的 plain，回退现场遍历 blocks，
-     * 都为空再回退到静态「富文本消息」（与旧端 UnknownContent 行为一致）。
-     */
-    get conversationDigest() {
-        if (this.plain.trim() !== "") {
-            return this.plain
-        }
-        const plain = buildRichTextPlain(this.content)
-        if (plain !== "") {
-            return plain
-        }
-        return t("base.message.digest.richText")
+  /**
+   * 引用预览 / 会话摘要文本：优先 server 生成的 plain，回退现场遍历 blocks，
+   * 都为空再回退到静态「富文本消息」（与旧端 UnknownContent 行为一致）。
+   */
+  get conversationDigest() {
+    if (this.plain.trim() !== "") {
+      return this.plain;
     }
+    const plain = buildRichTextPlain(this.content);
+    if (plain !== "") {
+      return plain;
+    }
+    return t("base.message.digest.richText");
+  }
 }
 
-export default RichTextContent
+export default RichTextContent;

--- a/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
+++ b/packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../../i18n", () => ({
 import {
   RichTextContent,
   buildRichTextPlain,
+  RichTextFilePlaceholder,
   RichTextImagePlaceholder,
   makeTextBlock,
   makeImageBlock,
@@ -40,12 +41,22 @@ describe("buildRichTextPlain", () => {
     expect(plain).toBe(`看图：${RichTextImagePlaceholder} 完成`);
   });
 
+  it("file block 前向兼容：plain 注入文件占位符和文件名", () => {
+    const plain = buildRichTextPlain([
+      { type: "text", text: "参考：" },
+      {
+        type: "file",
+        name: "需求说明.pdf",
+        url: "https://x/a.pdf",
+        size: 1024,
+      },
+    ]);
+    expect(plain).toBe(`参考：${RichTextFilePlaceholder} 需求说明.pdf`);
+  });
+
   it("未知 type 有 text 则取 text，否则跳过", () => {
     expect(
-      buildRichTextPlain([
-        { type: "future", text: "hi" },
-        { type: "future" },
-      ])
+      buildRichTextPlain([{ type: "future", text: "hi" }, { type: "future" }])
     ).toBe("hi");
   });
 });
@@ -80,6 +91,36 @@ describe("RichTextContent.decodeJSON", () => {
     expect(c.conversationDigest).toBe(`a${RichTextImagePlaceholder}`);
   });
 
+  it("前向兼容：解析 file block 需要的展示字段", () => {
+    const c = new RichTextContent();
+    c.decodeJSON({
+      type: 14,
+      content: [
+        {
+          type: "file",
+          url: "https://x/a.pdf",
+          name: "需求说明.pdf",
+          extension: "pdf",
+          size: 2048,
+          mime: "application/pdf",
+          caption: "正文里的文件",
+        },
+      ],
+    });
+    expect(c.content[0]).toMatchObject({
+      type: "file",
+      url: "https://x/a.pdf",
+      name: "需求说明.pdf",
+      extension: "pdf",
+      size: 2048,
+      mime: "application/pdf",
+      caption: "正文里的文件",
+    });
+    expect(c.conversationDigest).toBe(
+      `${RichTextFilePlaceholder} 需求说明.pdf`
+    );
+  });
+
   it("向后兼容：content 为纯字符串归一为单个 text block", () => {
     const c = new RichTextContent();
     c.decodeJSON({ type: 14, content: "legacy text" });
@@ -102,7 +143,7 @@ describe("发送侧 block 构造（与接收侧 schema 对称）", () => {
 
   it("makeImageBlock 必填 url/width/height，size/name 仅在有值时带上", () => {
     expect(
-      makeImageBlock({ url: "https://x/a.png", width: 10, height: 20 }),
+      makeImageBlock({ url: "https://x/a.png", width: 10, height: 20 })
     ).toEqual({ type: "image", url: "https://x/a.png", width: 10, height: 20 });
 
     expect(
@@ -112,7 +153,7 @@ describe("发送侧 block 构造（与接收侧 schema 对称）", () => {
         height: 20,
         size: 123,
         name: "a.png",
-      }),
+      })
     ).toEqual({
       type: "image",
       url: "https://x/a.png",
@@ -124,7 +165,7 @@ describe("发送侧 block 构造（与接收侧 schema 对称）", () => {
 
     // size=0 不应注入 wire（防 byte-match 污染）
     expect(
-      makeImageBlock({ url: "https://x/a.png", width: 1, height: 1, size: 0 }),
+      makeImageBlock({ url: "https://x/a.png", width: 1, height: 1, size: 0 })
     ).not.toHaveProperty("size");
   });
 

--- a/packages/dmworkbase/src/Messages/RichText/index.css
+++ b/packages/dmworkbase/src/Messages/RichText/index.css
@@ -4,15 +4,6 @@
 .wk-message-richtext {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--wk-sp-1-5);
   word-break: break-word;
-}
-
-/* 相邻文本块视觉上连续，去掉块间多余间距 */
-.wk-message-richtext-text + .wk-message-richtext-text {
-  margin-top: -4px;
-}
-
-.wk-message-richtext-image {
-  display: flex;
 }

--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -1,66 +1,83 @@
-import React from "react"
-import MessageBase from "../Base"
-import MessageTrail from "../Base/tail"
-import { MessageCell } from "../MessageCell"
-import MarkdownContent, { MarkdownImage } from "../Text/MarkdownContent"
-import { RichTextBlock, RichTextBlockType, RichTextContent } from "./RichTextContent"
-import "./index.css"
+import React from "react";
+import WKApp from "../../App";
+import { getRichTextMessageUI } from "../../bridge/message/useRichTextMessageUI";
+import { isMessageSelectable } from "../../Service/messageSelection";
+import MessageRow from "../../ui/message/MessageRow";
+import MixedContent from "../../ui/message/MixedContent";
+import ReplyBlock from "../../ui/message/ReplyBlock";
+import { downloadFile } from "../../Utils/download";
+import { resolveExternalForViewer } from "../../Utils/externalViewer";
+import { MessageCell } from "../MessageCell";
+import { RichTextContent } from "./RichTextContent";
+import "./index.css";
 
-export { RichTextContent } from "./RichTextContent"
+export { RichTextContent } from "./RichTextContent";
+
+function resolveReplySourceSpaceName(reply: any): string {
+  if (!reply) return "";
+  const { isExternal, sourceSpaceName } = resolveExternalForViewer({
+    homeSpaceId: reply.from_home_space_id as string | undefined,
+    homeSpaceName: reply.from_home_space_name as string | undefined,
+    isExternalLegacy:
+      reply.from_is_external === 1 || reply.from_is_external === true ? 1 : 0,
+    sourceSpaceNameLegacy: reply.from_source_space_name as string | undefined,
+    viewerSpaceId: WKApp.shared.currentSpaceId,
+  });
+  return isExternal && sourceSpaceName ? sourceSpaceName : "";
+}
 
 /**
- * RichText(=14) 图文混排消息（Phase 1：仅接收渲染）。
+ * RichText(=14) 图文混排消息。
  *
- * 按 content blocks 数组顺序穿插渲染：
- *   - text  block：复用 MarkdownContent 管线，但 MVP 锁纯文本（enableMarkdown=false），
- *     避免 web 渲 markdown 而移动端不渲的跨端不一致；
- *   - image block：复用 MarkdownImage（Lightbox 大图预览 + url 安全校验）。
+ * 展示层接入新 MessageRow / bridge / ui/message 体系；发送协议仍保持现状：
+ * 当前只发送 text + image RichText，file block 仅作为未来协议的前向兼容渲染。
  *
  * 老端 fallback：未注册 type=14 的旧端落 UnknownCell（已有），本端注册后正常渲染。
  */
 export class RichTextCell extends MessageCell {
-    render() {
-        const { message, context } = this.props
-        const content = message.content as RichTextContent
-        const blocks: RichTextBlock[] = content.content || []
+  render() {
+    const { message, context } = this.props;
+    const content = message.content as RichTextContent;
+    const selectionMode = context.editOn();
+    const selectable = isMessageSelectable(message);
+    const uiProps = getRichTextMessageUI(message, {
+      selectionMode,
+      showCheckbox: selectionMode && selectable,
+      isSelected: selectable && !!message.checked,
+      onSelect: selectable
+        ? (selected) => context.checkeMessage(message.message, selected)
+        : undefined,
+    });
 
-        return (
-            <MessageBase message={message} context={context}>
-                <div className="wk-message-richtext">
-                    {blocks.map((blk, i) => {
-                        if (blk.type === RichTextBlockType.image) {
-                            return (
-                                <div
-                                    key={`${message.clientMsgNo}-rt-img-${i}`}
-                                    className="wk-message-richtext-image"
-                                >
-                                    <MarkdownImage src={blk.url} alt={blk.name} />
-                                </div>
-                            )
-                        }
-                        // text block（含未知 type 的前向兼容：有 text 则按文本渲染）
-                        const text = blk.text || ""
-                        if (text === "") {
-                            return null
-                        }
-                        return (
-                            <div
-                                key={`${message.clientMsgNo}-rt-text-${i}`}
-                                className="wk-message-richtext-text"
-                            >
-                                <MarkdownContent
-                                    content={text}
-                                    isSend={message.send}
-                                    enableMarkdown={false}
-                                />
-                            </div>
-                        )
-                    })}
-                    <MessageTrail message={message} />
-                </div>
-            </MessageBase>
-        )
-    }
+    return (
+      <MessageRow
+        {...uiProps.row}
+        onContextMenu={(event) => context.showContextMenus(message, event)}
+        isActive={context.isContextMenuOpen(message.message)}
+        onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
+        onSenderNameClick={() => context.showUser(message.fromUID)}
+      >
+        <div className="wk-message-richtext">
+          {content.reply && (
+            <ReplyBlock
+              fromName={content.reply.fromName || ""}
+              digest={content.reply.content?.conversationDigest || ""}
+              sourceSpaceName={resolveReplySourceSpaceName(content.reply)}
+              onClick={() => context.locateMessage(content.reply.messageSeq)}
+            />
+          )}
+          <MixedContent
+            {...uiProps.content}
+            onFileDownload={(block) => {
+              if (block.url) {
+                downloadFile(block.url, block.name);
+              }
+            }}
+          />
+        </div>
+      </MessageRow>
+    );
+  }
 }
 
-export default RichTextCell
+export default RichTextCell;

--- a/packages/dmworkbase/src/Messages/__tests__/MessageCell.test.ts
+++ b/packages/dmworkbase/src/Messages/__tests__/MessageCell.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const channelManager = vi.hoisted(() => ({
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addSubscriberChangeListener: vi.fn(),
+  removeSubscriberChangeListener: vi.fn(),
+  getChannelInfo: vi.fn(),
+  fetchChannelInfo: vi.fn(),
+}));
+
+vi.mock("wukongimjssdk", () => {
+  const ChannelTypePerson = 1;
+  const ChannelTypeGroup = 2;
+  class Channel {
+    channelID: string;
+    channelType: number;
+
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+
+    isEqual(other?: Channel) {
+      return (
+        !!other &&
+        this.channelID === other.channelID &&
+        this.channelType === other.channelType
+      );
+    }
+  }
+  const sdk = { shared: () => ({ channelManager }) };
+  return {
+    default: sdk,
+    WKSDK: sdk,
+    Channel,
+    ChannelTypePerson,
+    ChannelTypeGroup,
+  };
+});
+
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import { MessageCell } from "../MessageCell";
+
+function createCell(channelID = "group-1") {
+  const message = {
+    fromUID: "user-1",
+    channel: new Channel(channelID, ChannelTypeGroup),
+  };
+  const cell = new MessageCell({ message, context: {} } as any);
+  cell.setState = vi.fn() as any;
+  return cell;
+}
+
+describe("MessageCell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    channelManager.getChannelInfo.mockReturnValue(undefined);
+  });
+
+  it("subscribes group member changes and re-renders matching group messages", () => {
+    const cell = createCell();
+
+    cell.componentDidMount();
+
+    const listener = channelManager.addSubscriberChangeListener.mock
+      .calls[0][0] as (channel: Channel) => void;
+    listener(new Channel("other-group", ChannelTypeGroup));
+    expect(cell.setState).not.toHaveBeenCalled();
+
+    listener(new Channel("group-1", ChannelTypeGroup));
+    expect(cell.setState).toHaveBeenCalledWith({});
+
+    cell.componentWillUnmount();
+    expect(channelManager.removeSubscriberChangeListener).toHaveBeenCalledWith(
+      listener
+    );
+  });
+});

--- a/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
@@ -13,7 +13,10 @@ import {
 } from "../../Messages/File";
 import { t } from "../../i18n";
 import { isSafeUrl } from "../../Utils/security";
-import type { MixedContentBlock } from "../../ui/message/MixedContent";
+import type {
+  MixedContentBlock,
+  MixedContentFileTone,
+} from "../../ui/message/MixedContent";
 import { getMessageRow } from "./useMessageRow";
 import type { MessageRowSelectionState } from "./useMessageRow";
 
@@ -26,6 +29,50 @@ function resolveFileUrl(rawUrl?: string): string {
     fileUrl = `${window.location.origin}/${fileUrl.replace(/^\//, "")}`;
   }
   return isSafeUrl(fileUrl) ? fileUrl : "";
+}
+
+function getFileIconTone(extension: string): MixedContentFileTone {
+  switch (extension) {
+    case "pdf":
+      return "pdf";
+    case "doc":
+    case "docx":
+      return "doc";
+    case "xls":
+    case "xlsx":
+      return "sheet";
+    case "ppt":
+    case "pptx":
+      return "slide";
+    case "zip":
+    case "rar":
+    case "7z":
+    case "tar":
+    case "gz":
+      return "archive";
+    case "mp3":
+    case "wav":
+    case "flac":
+    case "aac":
+      return "audio";
+    case "mp4":
+    case "avi":
+    case "mov":
+    case "mkv":
+      return "video";
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+    case "bmp":
+    case "webp":
+      return "image";
+    case "txt":
+    case "md":
+      return "text";
+    default:
+      return "default";
+  }
 }
 
 export function getRichTextBlocksUI(
@@ -53,7 +100,7 @@ export function getRichTextBlocksUI(
         name: block.name || t("base.messageFile.unknownFile"),
         size: formatFileSize(block.size || 0),
         extension: extension.toUpperCase(),
-        iconColor: iconInfo.color,
+        iconTone: getFileIconTone(extension),
         iconLabel: iconInfo.label,
         url: resolveFileUrl(block.url),
         caption: block.caption,

--- a/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
@@ -1,0 +1,91 @@
+import { useMemo } from "react";
+import WKApp from "../../App";
+import type { MessageWrap } from "../../Service/Model";
+import { RichTextBlockType } from "../../Messages/RichText/RichTextContent";
+import type {
+  RichTextBlock,
+  RichTextContent,
+} from "../../Messages/RichText/RichTextContent";
+import {
+  formatFileSize,
+  getExtension,
+  getFileIconInfo,
+} from "../../Messages/File";
+import { t } from "../../i18n";
+import { isSafeUrl } from "../../Utils/security";
+import type { MixedContentBlock } from "../../ui/message/MixedContent";
+import { getMessageRow } from "./useMessageRow";
+import type { MessageRowSelectionState } from "./useMessageRow";
+
+function resolveFileUrl(rawUrl?: string): string {
+  if (!rawUrl) return "";
+  let fileUrl = WKApp.dataSource.commonDataSource.getFileURL(rawUrl);
+  if (!fileUrl) return "";
+  if (!fileUrl.startsWith("http")) {
+    if (typeof window === "undefined") return "";
+    fileUrl = `${window.location.origin}/${fileUrl.replace(/^\//, "")}`;
+  }
+  return isSafeUrl(fileUrl) ? fileUrl : "";
+}
+
+export function getRichTextBlocksUI(
+  blocks: RichTextBlock[]
+): MixedContentBlock[] {
+  return blocks.reduce<MixedContentBlock[]>((acc, block, index) => {
+    const id = `richtext-${index}`;
+    if (block.type === RichTextBlockType.image) {
+      if (!block.url) return acc;
+      acc.push({
+        id,
+        type: "image",
+        src: block.url,
+        alt: block.name,
+      });
+      return acc;
+    }
+
+    if (block.type === RichTextBlockType.file) {
+      const extension = getExtension(block.extension || "", block.name);
+      const iconInfo = getFileIconInfo(extension, block.name);
+      acc.push({
+        id,
+        type: "file",
+        name: block.name || t("base.messageFile.unknownFile"),
+        size: formatFileSize(block.size || 0),
+        extension: extension.toUpperCase(),
+        iconColor: iconInfo.color,
+        iconLabel: iconInfo.label,
+        url: resolveFileUrl(block.url),
+        caption: block.caption,
+      });
+      return acc;
+    }
+
+    const text = block.text || "";
+    if (block.type === RichTextBlockType.text || text) {
+      acc.push({
+        id,
+        type: "text",
+        content: text,
+      });
+    }
+    return acc;
+  }, []);
+}
+
+export function getRichTextMessageUI(
+  message: MessageWrap,
+  selection?: MessageRowSelectionState
+) {
+  const content = message.content as RichTextContent;
+  return {
+    row: getMessageRow(message, selection),
+    content: {
+      blocks: getRichTextBlocksUI(content.content || []),
+    },
+  };
+}
+
+export function useRichTextMessageUI(message: MessageWrap) {
+  return useMemo(() => getRichTextMessageUI(message), [message]);
+}

--- a/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import MixedContent from "./index";
 
 const meta: Meta<typeof MixedContent> = {

--- a/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof MixedContent> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: "720px", padding: "20px" }}>
+      <div style={{ maxWidth: "720px", padding: "var(--wk-sp-5)" }}>
         <Story />
       </div>
     ),

--- a/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import MixedContent from "./index";
+
+const meta: Meta<typeof MixedContent> = {
+  title: "ui/message/MixedContent",
+  component: MixedContent,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: "720px", padding: "20px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MixedContent>;
+
+export const TextAndImages: Story = {
+  args: {
+    blocks: [
+      { id: "t1", type: "text", content: "这是一条按顺序渲染的图文混排消息。" },
+      {
+        id: "i1",
+        type: "image",
+        src: "https://picsum.photos/900/520?random=richtext-1",
+        alt: "preview",
+      },
+      {
+        id: "t2",
+        type: "text",
+        content: "图片之后继续显示正文，保持在同一条消息里。",
+      },
+    ],
+  },
+};
+
+export const TextAndFile: Story = {
+  args: {
+    blocks: [
+      {
+        id: "t1",
+        type: "text",
+        content: "这个 story 用来预览未来 file block 的展示。",
+      },
+      {
+        id: "f1",
+        type: "file",
+        name: "产品需求说明.pdf",
+        size: "2.4 MB",
+        extension: "PDF",
+        iconLabel: "PDF",
+        url: "https://example.com/product.pdf",
+      },
+      {
+        id: "t2",
+        type: "text",
+        content: "发送协议未打开前，文件仍会拆成独立消息发送。",
+      },
+    ],
+    onFileDownload: () => alert("下载文件"),
+  },
+};

--- a/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../Messages/Text/MarkdownContent", () => ({
+  default: ({ content }: { content: string }) => <span>{content}</span>,
+  MarkdownImage: ({ src, alt }: { src: string; alt?: string }) => (
+    <img src={src} alt={alt || ""} />
+  ),
+}));
+
+import MixedContent from "../index";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+function renderMixed(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(element, container);
+  });
+  return container;
+}
+
+describe("MixedContent", () => {
+  it("按块渲染文本、图片和文件卡片", () => {
+    const root = renderMixed(
+      <MixedContent
+        blocks={[
+          { id: "t1", type: "text", content: "看这个" },
+          { id: "i1", type: "image", src: "https://x/a.png", alt: "截图" },
+          {
+            id: "f1",
+            type: "file",
+            name: "需求说明.pdf",
+            size: "2.0 KB",
+            extension: "PDF",
+            iconLabel: "PDF",
+            url: "https://x/a.pdf",
+          },
+        ]}
+      />
+    );
+
+    expect(root.textContent).toContain("看这个");
+    expect(root.querySelector('img[alt="截图"]')?.getAttribute("src")).toBe(
+      "https://x/a.png"
+    );
+    expect(root.textContent).toContain("需求说明.pdf");
+    expect(root.textContent).toContain("2.0 KB");
+  });
+
+  it("点击文件下载按钮时回调 file block", () => {
+    const onFileDownload = vi.fn();
+    const root = renderMixed(
+      <MixedContent
+        blocks={[
+          {
+            id: "f1",
+            type: "file",
+            name: "需求说明.pdf",
+            size: "2.0 KB",
+            extension: "PDF",
+            iconLabel: "PDF",
+            url: "https://x/a.pdf",
+          },
+        ]}
+        onFileDownload={onFileDownload}
+      />
+    );
+
+    const button = root.querySelector("button");
+    expect(button).not.toBeNull();
+    act(() => {
+      button?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+    expect(onFileDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "f1", type: "file" })
+    );
+  });
+});

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.css
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.css
@@ -33,6 +33,8 @@
 }
 
 .wk-msg-mixed-file-icon {
+  --wk-msg-mixed-file-icon-bg: var(--wk-brand-primary);
+
   width: 40px;
   height: 40px;
   flex: 0 0 40px;
@@ -40,10 +42,40 @@
   align-items: center;
   justify-content: center;
   border-radius: var(--wk-r-sm);
-  background: var(--wk-brand-primary);
+  background: var(--wk-msg-mixed-file-icon-bg);
   color: var(--wk-text-on-brand);
   font: var(--wk-text-tiny);
   letter-spacing: 0;
+}
+
+.wk-msg-mixed-file-icon-pdf {
+  --wk-msg-mixed-file-icon-bg: var(--wk-color-error);
+}
+
+.wk-msg-mixed-file-icon-doc {
+  --wk-msg-mixed-file-icon-bg: var(--wk-color-info);
+}
+
+.wk-msg-mixed-file-icon-sheet {
+  --wk-msg-mixed-file-icon-bg: var(--wk-color-success);
+}
+
+.wk-msg-mixed-file-icon-slide,
+.wk-msg-mixed-file-icon-archive {
+  --wk-msg-mixed-file-icon-bg: var(--wk-color-warning);
+}
+
+.wk-msg-mixed-file-icon-audio,
+.wk-msg-mixed-file-icon-video {
+  --wk-msg-mixed-file-icon-bg: var(--wk-text-accent);
+}
+
+.wk-msg-mixed-file-icon-image {
+  --wk-msg-mixed-file-icon-bg: var(--wk-color-info);
+}
+
+.wk-msg-mixed-file-icon-text {
+  --wk-msg-mixed-file-icon-bg: var(--wk-text-tertiary);
 }
 
 .wk-msg-mixed-file-info {

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.css
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.css
@@ -1,0 +1,100 @@
+.wk-msg-mixed-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-1-5);
+  max-width: min(100%, 680px);
+  word-break: break-word;
+}
+
+.wk-msg-mixed-text {
+  font: var(--wk-text-body);
+  color: var(--wk-text-primary);
+}
+
+.wk-msg-mixed-text + .wk-msg-mixed-text {
+  margin-top: calc(var(--wk-sp-1) * -1);
+}
+
+.wk-msg-mixed-image {
+  display: flex;
+  max-width: 100%;
+}
+
+.wk-msg-mixed-file {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  width: min(100%, 300px);
+  box-sizing: border-box;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-elevated);
+}
+
+.wk-msg-mixed-file-icon {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-brand-primary);
+  color: var(--wk-text-on-brand);
+  font: var(--wk-text-tiny);
+  letter-spacing: 0;
+}
+
+.wk-msg-mixed-file-info {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-1);
+}
+
+.wk-msg-mixed-file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--wk-text-body-medium);
+  color: var(--wk-text-primary);
+}
+
+.wk-msg-mixed-file-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  overflow: hidden;
+  white-space: nowrap;
+  font: var(--wk-text-caption);
+  color: var(--wk-text-tertiary);
+}
+
+.wk-msg-mixed-file-caption {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--wk-text-caption);
+  color: var(--wk-text-secondary);
+}
+
+.wk-msg-mixed-file-download {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  color: var(--wk-brand-primary);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.wk-msg-mixed-file-download:hover {
+  background: var(--wk-brand-tint-08);
+}

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -5,6 +5,18 @@ import MarkdownContent, {
 } from "../../../Messages/Text/MarkdownContent";
 import "./index.css";
 
+export type MixedContentFileTone =
+  | "default"
+  | "pdf"
+  | "doc"
+  | "sheet"
+  | "slide"
+  | "archive"
+  | "audio"
+  | "video"
+  | "image"
+  | "text";
+
 export type MixedContentBlock =
   | {
       type: "text";
@@ -23,7 +35,7 @@ export type MixedContentBlock =
       name: string;
       size: string;
       extension: string;
-      iconColor?: string;
+      iconTone?: MixedContentFileTone;
       iconLabel: string;
       url?: string;
       caption?: string;
@@ -53,15 +65,11 @@ export default function MixedContent({
 
         if (block.type === "file") {
           const canDownload = !!block.url && !!onFileDownload;
+          const iconTone = block.iconTone || "default";
           return (
             <div key={block.id} className="wk-msg-mixed-file">
               <div
-                className="wk-msg-mixed-file-icon"
-                style={
-                  block.iconColor
-                    ? { backgroundColor: block.iconColor }
-                    : undefined
-                }
+                className={`wk-msg-mixed-file-icon wk-msg-mixed-file-icon-${iconTone}`}
                 aria-hidden="true"
               >
                 {block.iconLabel}

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Download } from "lucide-react";
+import MarkdownContent, {
+  MarkdownImage,
+} from "../../../Messages/Text/MarkdownContent";
+import "./index.css";
+
+export type MixedContentBlock =
+  | {
+      type: "text";
+      id: string;
+      content: string;
+    }
+  | {
+      type: "image";
+      id: string;
+      src: string;
+      alt?: string;
+    }
+  | {
+      type: "file";
+      id: string;
+      name: string;
+      size: string;
+      extension: string;
+      iconColor?: string;
+      iconLabel: string;
+      url?: string;
+      caption?: string;
+    };
+
+export interface MixedContentProps {
+  blocks: MixedContentBlock[];
+  onFileDownload?: (
+    block: Extract<MixedContentBlock, { type: "file" }>
+  ) => void;
+}
+
+export default function MixedContent({
+  blocks,
+  onFileDownload,
+}: MixedContentProps) {
+  return (
+    <div className="wk-msg-mixed-content">
+      {blocks.map((block) => {
+        if (block.type === "image") {
+          return (
+            <div key={block.id} className="wk-msg-mixed-image">
+              <MarkdownImage src={block.src} alt={block.alt} />
+            </div>
+          );
+        }
+
+        if (block.type === "file") {
+          const canDownload = !!block.url && !!onFileDownload;
+          return (
+            <div key={block.id} className="wk-msg-mixed-file">
+              <div
+                className="wk-msg-mixed-file-icon"
+                style={
+                  block.iconColor
+                    ? { backgroundColor: block.iconColor }
+                    : undefined
+                }
+                aria-hidden="true"
+              >
+                {block.iconLabel}
+              </div>
+              <div className="wk-msg-mixed-file-info">
+                <div className="wk-msg-mixed-file-name" title={block.name}>
+                  {block.name}
+                </div>
+                <div className="wk-msg-mixed-file-meta">
+                  <span>{block.size}</span>
+                  {block.extension && <span>{block.extension}</span>}
+                </div>
+                {block.caption && (
+                  <div className="wk-msg-mixed-file-caption">
+                    {block.caption}
+                  </div>
+                )}
+              </div>
+              {canDownload && (
+                <button
+                  type="button"
+                  className="wk-msg-mixed-file-download"
+                  aria-label={block.name}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onFileDownload?.(block);
+                  }}
+                >
+                  <Download size={16} strokeWidth={2} />
+                </button>
+              )}
+            </div>
+          );
+        }
+
+        if (!block.content) {
+          return null;
+        }
+        return (
+          <div key={block.id} className="wk-msg-mixed-text">
+            <MarkdownContent content={block.content} enableMarkdown={false} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/dmworkbase/src/ui/message/TextContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.tsx
@@ -1,37 +1,43 @@
-import React from 'react'
-import MarkdownContent, { type MentionInfo, type EmojiInfo } from '../../../Messages/Text/MarkdownContent'
-import './index.css'
+import React from "react";
+import MarkdownContent, {
+  type MentionInfo,
+  type EmojiInfo,
+} from "../../../Messages/Text/MarkdownContent";
+import "./index.css";
 
 export interface TextContentProps {
   /** 消息文本内容（支持 Markdown） */
-  content: string
+  content: string;
 
   /** @ 提及列表 */
-  mentions?: MentionInfo[]
+  mentions?: MentionInfo[];
 
   /** Emoji 列表 */
-  emojis?: EmojiInfo[]
+  emojis?: EmojiInfo[];
 
   /** 是否为大表情（单个自定义 emoji，230×230） */
-  isLargeEmoji?: boolean
+  isLargeEmoji?: boolean;
 
   /** 是否为流式消息（正在流式输出中） */
-  isStreaming?: boolean
+  isStreaming?: boolean;
 
   /** 点击 @ 提及回调 */
-  onMentionClick?: (uid: string) => void
+  onMentionClick?: (uid: string) => void;
+
+  /** 是否启用 Markdown 语法渲染，默认 true */
+  enableMarkdown?: boolean;
 }
 
 /**
  * 文本消息内容组件
- * 
+ *
  * @description 渲染消息文本，支持 Markdown、@ 提及、Emoji
- * 
+ *
  * @ 提及三等级（Figma 318:12716）：
  * - 交互实体：紫色文字 + 浅紫背景胶囊（type=entity）
  * - 强调色：纯紫色文字（@所有人）
  * - 降级：同正文色（未解析的 @）
- * 
+ *
  * 大表情：
  * - 单个自定义 emoji 时，显示为 160×160
  */
@@ -41,20 +47,16 @@ export default function TextContent({
   emojis = [],
   isLargeEmoji = false,
   isStreaming = false,
-  onMentionClick
+  onMentionClick,
+  enableMarkdown = true,
 }: TextContentProps) {
   // 大表情：单独渲染
   if (isLargeEmoji && emojis.length === 1) {
     return (
       <div className="wk-msg-text-large-emoji">
-        <img
-          src={emojis[0].url}
-          alt={emojis[0].key}
-          width={230}
-          height={230}
-        />
+        <img src={emojis[0].url} alt={emojis[0].key} width={230} height={230} />
       </div>
-    )
+    );
   }
 
   // 普通文本：复用现有 MarkdownContent 组件
@@ -67,7 +69,8 @@ export default function TextContent({
         mentions={mentions}
         onMentionClick={onMentionClick}
         emojis={emojis}
+        enableMarkdown={enableMarkdown}
       />
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- migrate RichText rendering to MessageRow + bridge + ui/message MixedContent
- add forward-compatible RichText file block display support without enabling file-block sending
- render RichText blocks inside merge-forward detail previews

## Tests
- git diff --check
- ./packages/dmworkbase/node_modules/.bin/vitest run packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx --config packages/dmworkbase/vitest.config.ts