### PR TITLE
ci: set fail-on-vuln false on scheduled OSV scan

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -22,6 +22,7 @@ jobs:
       scan-args: |-
         -r
         ./
+      fail-on-vuln: false
 
   scan-pr:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Add `fail-on-vuln: false` to the `scan-scheduled` OSV job.

## Why

Without this, every push to main and every weekly scheduled run fails
on pre-existing vulnerabilities — creating permanent red CI unrelated
to the change being pushed.

With `fail-on-vuln: false`, results are still uploaded to the Security
tab (SARIF) for tracking, but don't block the workflow. PR scans still
block new vulnerabilities (default `fail-on-vuln: true`).
