### PR TITLE
feat: chat-window smart summary UI with i18n

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -19,6 +19,8 @@ export type MittEvents = {
   "wk:toggle-matter-panel": { channelId: string; channelType: number };
   /** v0.7 Matter 详情面板切换（跟子区/文件预览/任务列表可并存） */
   "wk:toggle-matter-detail-panel": { channelId: string; channelType: number };
+  "wk:toggle-summary-panel": { channelId: string; channelType: number; summaryPanelView: 'history' | 'new'; forceOpen?: boolean };
+  "wk:open-summary-modal": { channelId: string; channelType: number };
   /** 打开多选→添加到事项的弹出菜单（由 dmworktodo 模块接管渲染） */
   "wk:open-matter-link-menu": { anchor: HTMLElement; channelId: string; channelType: number; messages?: Array<{ messageSeq?: number; messageID?: string; fromUID?: string; fromUName?: string; content?: string; timestamp?: number; attachments?: any[] }> };
   "wk:switch-sidebar-tab": string;

--- a/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
@@ -11,6 +11,10 @@ import {
     THREAD_MAX_WIDTH,
     THREAD_DEFAULT_WIDTH,
     THREAD_STORAGE_KEY,
+    SUMMARY_MIN_WIDTH,
+    SUMMARY_MAX_WIDTH,
+    SUMMARY_DEFAULT_WIDTH,
+    SUMMARY_STORAGE_KEY,
     getMaxLeftWidth,
     clampWidth,
     restoreWidth,
@@ -18,6 +22,9 @@ import {
     clampThreadWidth,
     restoreThreadWidth,
     persistThreadWidth,
+    clampSummaryWidth,
+    restoreSummaryWidth,
+    persistSummaryWidth,
 } from '../layoutWidth'
 
 describe('layoutWidth', () => {
@@ -121,6 +128,60 @@ describe('layoutWidth', () => {
             it('returns default for out-of-range stored values', () => {
                 localStorage.setItem(THREAD_STORAGE_KEY, '9999')
                 expect(restoreThreadWidth()).toBe(THREAD_DEFAULT_WIDTH)
+            })
+        })
+    })
+
+    describe('summary panel', () => {
+        describe('clampSummaryWidth', () => {
+            it('clamps below minimum', () => {
+                expect(clampSummaryWidth(100, 1200, 300)).toBe(SUMMARY_MIN_WIDTH)
+            })
+
+            it('passes through valid values', () => {
+                expect(clampSummaryWidth(500, 1600, 300)).toBe(500)
+            })
+
+            it('caps at SUMMARY_MAX_WIDTH even if 50% would be higher', () => {
+                // window=4000, left=300 → available=3700 → 50%=1850 > 720
+                expect(clampSummaryWidth(1000, 4000, 300)).toBe(SUMMARY_MAX_WIDTH)
+            })
+
+            it('limits to 50% of available space (window - left panel)', () => {
+                // window=1200, left=300 → available=900 → max=450
+                expect(clampSummaryWidth(700, 1200, 300)).toBe(450)
+            })
+
+            it('never goes below SUMMARY_MIN_WIDTH even on tiny screens', () => {
+                // window=600, left=300 → available=300 → 50%=150 < 320
+                expect(clampSummaryWidth(400, 600, 300)).toBe(SUMMARY_MIN_WIDTH)
+            })
+        })
+
+        describe('restoreSummaryWidth / persistSummaryWidth', () => {
+            beforeEach(() => {
+                localStorage.clear()
+            })
+
+            it('returns default when nothing stored', () => {
+                expect(restoreSummaryWidth()).toBe(SUMMARY_DEFAULT_WIDTH)
+            })
+
+            it('restores a previously persisted value', () => {
+                persistSummaryWidth(500)
+                expect(restoreSummaryWidth()).toBe(500)
+            })
+
+            it('returns default for out-of-range stored values', () => {
+                localStorage.setItem(SUMMARY_STORAGE_KEY, '9999')
+                expect(restoreSummaryWidth()).toBe(SUMMARY_DEFAULT_WIDTH)
+            })
+
+            it('does not collide with the thread panel storage key', () => {
+                persistSummaryWidth(500)
+                persistThreadWidth(700)
+                expect(restoreSummaryWidth()).toBe(500)
+                expect(restoreThreadWidth()).toBe(700)
             })
         })
     })

--- a/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
@@ -20,6 +20,14 @@ export const THREAD_MAX_WIDTH = 1600  // effective max is clamped by screen rati
 export const THREAD_DEFAULT_WIDTH = 432
 export const THREAD_STORAGE_KEY = 'wk-thread-panel-width'
 
+// ── Right panel (smart summary panel) ──
+// Independent constants + storage key so the summary panel width never
+// collides with the thread panel's (THREAD_MIN_WIDTH=432 > summary default 360).
+export const SUMMARY_MIN_WIDTH = 320
+export const SUMMARY_MAX_WIDTH = 720
+export const SUMMARY_DEFAULT_WIDTH = 360
+export const SUMMARY_STORAGE_KEY = 'wk-summary-panel-width'
+
 /**
  * Generic clamp utility: min(maxWidth, containerWidth * ratio), floored to minWidth.
  */
@@ -75,6 +83,35 @@ export function restoreThreadWidth(): number {
 
 export function persistThreadWidth(width: number): void {
     persistStoredWidth(THREAD_STORAGE_KEY, width)
+}
+
+// ── Right (summary) panel helpers ──
+
+/**
+ * Summary panel max width based on available space (window - left panel).
+ * Like the thread panel, the chat area keeps at least 50% of available space.
+ *
+ * @param windowWidth - Total window width
+ * @param leftPanelWidth - Left conversation list width (default 300px)
+ * @returns Maximum allowed summary panel width
+ */
+export function getMaxSummaryWidth(windowWidth: number, leftPanelWidth = SPLITTER_DEFAULT_WIDTH): number {
+    const availableSpace = windowWidth - leftPanelWidth
+    const dynamicMax = Math.floor(availableSpace * 0.5)
+    return Math.max(SUMMARY_MIN_WIDTH, Math.min(SUMMARY_MAX_WIDTH, dynamicMax))
+}
+
+export function clampSummaryWidth(width: number, windowWidth: number, leftPanelWidth = SPLITTER_DEFAULT_WIDTH): number {
+    const max = getMaxSummaryWidth(windowWidth, leftPanelWidth)
+    return Math.max(SUMMARY_MIN_WIDTH, Math.min(max, width))
+}
+
+export function restoreSummaryWidth(): number {
+    return restoreStoredWidth(SUMMARY_STORAGE_KEY, SUMMARY_MIN_WIDTH, SUMMARY_MAX_WIDTH, SUMMARY_DEFAULT_WIDTH)
+}
+
+export function persistSummaryWidth(width: number): void {
+    persistStoredWidth(SUMMARY_STORAGE_KEY, width)
 }
 
 // ── Shared localStorage helpers ──

--- a/packages/dmworkbase/src/EndpointCommon.tsx
+++ b/packages/dmworkbase/src/EndpointCommon.tsx
@@ -348,6 +348,31 @@ export class EndpointCommon {
     );
   }
 
+  chatSummaryPanel(
+    channel: Channel,
+    onClose: () => void,
+  ): JSX.Element | undefined {
+    return EndpointManager.shared.invoke(EndpointCategory.chatSummaryPanel, {
+      channel,
+      onClose,
+    });
+  }
+
+  registerChatSummaryPanel(
+    sid: string,
+    callback: (param: any) => JSX.Element | undefined
+  ) {
+    EndpointManager.shared.setMethod(
+      EndpointCategory.chatSummaryPanel,
+      (param) => {
+        return callback(param);
+      },
+      {
+        category: EndpointCategory.chatSummaryPanel,
+      }
+    );
+  }
+
   callOnLogin() {
     [...this._onLogins].forEach(fn => fn());
   }

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -848,3 +848,39 @@ body[theme-mode="dark"] .wk-chat-popover {
     var(--wk-width-matter-detail-panel) + var(--wk-width-thread-panel)
   );
 }
+
+/* ============================================
+   智能总结面板
+   ============================================ */
+:root {
+  --wk-width-summary-panel: 360px;
+}
+
+.wk-summary-panel {
+  pointer-events: auto;
+  width: var(--wk-width-summary-panel);
+  height: 100%;
+  position: absolute;
+  z-index: 100;
+  top: 0;
+  right: 0;
+  border-left: 1px solid var(--wk-border-default);
+  background-color: var(--wk-bg-surface);
+  box-shadow: var(--wk-shadow-md);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  /* 容器查询上下文：详情按面板自身宽度自适应（与视口解耦，拖宽后仍生效） */
+  container-type: inline-size;
+  container-name: wk-summary;
+}
+
+.wk-chat-content-right.wk-chat-summary-panel-open .wk-chat-content-chat {
+  width: calc(100% - var(--wk-width-summary-panel));
+}
+
+/* 总结面板打开时，设置面板贴在总结面板左侧（对齐子区/事项让位行为，避免被遮挡） */
+.wk-chat-content-right.wk-chat-summary-panel-open.wk-chat-channelsetting-open
+  .wk-chat-channelsetting {
+  right: var(--wk-width-summary-panel);
+}

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -199,6 +199,10 @@ export interface ChatContentPageState {
    * 没来过子区的情况下让 ← 把用户带到子区列表会很突兀。
    */
   previewHadThreadShell: boolean;
+  /** 智能总结面板是否显示 */
+  showSummaryPanel: boolean;
+  /** 总结面板初始视图 */
+  summaryPanelView: 'history' | 'new';
 }
 export class ChatContentPage extends Component<
   ChatContentPageProps,
@@ -225,6 +229,8 @@ export class ChatContentPage extends Component<
       showMatterDetailPanel: false,
       previewReturnMatterId: null,
       previewHadThreadShell: false,
+      showSummaryPanel: false,
+      summaryPanelView: 'new',
     };
   }
 
@@ -289,6 +295,7 @@ export class ChatContentPage extends Component<
       showMatterDetailPanel: fromMatter
         ? this.state.showMatterDetailPanel
         : false,
+      showSummaryPanel: false,
       activePreviewMessageId: file.messageId || null, // 保存激活的消息 ID
       previewReturnMatterId: file.originMatterId || null,
       // 仅当预览触发前用户已经在子区面板里 (showThreadPanel 已经是 true)
@@ -351,6 +358,7 @@ export class ChatContentPage extends Component<
           activePreviewMessageId: null,
           showMatterPanel: false, // 关闭事项列表面板
           showMatterDetailPanel: false, // 关闭事项详情面板
+          showSummaryPanel: false,
         });
       }
     };
@@ -386,6 +394,7 @@ export class ChatContentPage extends Component<
           activePreviewMessageId: opening
             ? null
             : prevState.activePreviewMessageId,
+          showSummaryPanel: opening ? false : prevState.showSummaryPanel,
         };
       });
     };
@@ -412,6 +421,7 @@ export class ChatContentPage extends Component<
           activeThread: null,
           previewFile: null,
           activePreviewMessageId: null,
+          showSummaryPanel: false,
         };
       });
     };
@@ -419,6 +429,29 @@ export class ChatContentPage extends Component<
       "wk:toggle-matter-detail-panel",
       this._onToggleMatterDetailPanel,
     );
+
+    this._onToggleSummaryPanel = (data) => {
+      if (
+        data.channelId !== channel.channelID ||
+        data.channelType !== channel.channelType
+      )
+        return;
+      this.setState((prevState) => {
+        // forceOpen：始终打开（用于聊天内创建总结后展示），不做 toggle 关闭
+        const opening = data.forceOpen ? true : !prevState.showSummaryPanel;
+        return {
+          showSummaryPanel: opening,
+          summaryPanelView: opening ? data.summaryPanelView : prevState.summaryPanelView,
+          showMatterPanel: opening ? false : prevState.showMatterPanel,
+          showMatterDetailPanel: opening ? false : prevState.showMatterDetailPanel,
+          showThreadPanel: opening ? false : prevState.showThreadPanel,
+          activeThread: opening ? null : prevState.activeThread,
+          previewFile: opening ? null : prevState.previewFile,
+          activePreviewMessageId: opening ? null : prevState.activePreviewMessageId,
+        };
+      });
+    };
+    WKApp.mittBus.on("wk:toggle-summary-panel", this._onToggleSummaryPanel);
 
     // 检查是否需要自动打开子区面板（查看全部子区）
     if (WKApp.shared.pendingThreadPanel === channel.channelID) {
@@ -429,6 +462,7 @@ export class ChatContentPage extends Component<
         activePreviewMessageId: null,
         showMatterPanel: false, // 互斥
         showMatterDetailPanel: false, // 互斥
+        showSummaryPanel: false,
       });
       WKApp.shared.pendingThreadPanel = undefined;
     }
@@ -453,6 +487,7 @@ export class ChatContentPage extends Component<
         activePreviewMessageId: pending.messageId || null,
         showMatterPanel: false, // 互斥
         showMatterDetailPanel: false, // 互斥
+        showSummaryPanel: false,
       });
     }
 
@@ -489,6 +524,7 @@ export class ChatContentPage extends Component<
           activePreviewMessageId: null,
           showMatterPanel: false, // 互斥
           showMatterDetailPanel: false, // 互斥
+          showSummaryPanel: false,
         });
         return;
       }
@@ -513,6 +549,7 @@ export class ChatContentPage extends Component<
           activePreviewMessageId: pending.messageId || null,
           showMatterPanel: false, // 互斥
           showMatterDetailPanel: false, // 互斥
+          showSummaryPanel: false,
         });
         return;
       }
@@ -551,6 +588,12 @@ export class ChatContentPage extends Component<
     channelId: string;
     channelType: number;
   }) => void;
+  private _onToggleSummaryPanel?: (data: {
+    channelId: string;
+    channelType: number;
+    summaryPanelView: 'history' | 'new';
+    forceOpen?: boolean;
+  }) => void;
 
   componentWillUnmount() {
     WKApp.mittBus.off("wk:file-preview", this._onFilePreview);
@@ -568,6 +611,9 @@ export class ChatContentPage extends Component<
         "wk:toggle-matter-detail-panel",
         this._onToggleMatterDetailPanel,
       );
+    }
+    if (this._onToggleSummaryPanel) {
+      WKApp.mittBus.off("wk:toggle-summary-panel", this._onToggleSummaryPanel);
     }
     WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
   }
@@ -667,6 +713,8 @@ export class ChatContentPage extends Component<
       previewFile,
       showMatterPanel,
       showMatterDetailPanel,
+      showSummaryPanel,
+      summaryPanelView,
     } = this.state;
     // 子区页面不显示讨论串按钮
     const isThreadChannel = channel.channelType === ChannelTypeCommunityTopic;
@@ -684,6 +732,7 @@ export class ChatContentPage extends Component<
             ? "wk-chat-threadpanel-open"
             : "",
           showMatterDetailPanel ? "wk-chat-matter-detail-panel-open" : "",
+          showSummaryPanel ? "wk-chat-summary-panel-open" : "",
         )}
       >
         <div
@@ -846,6 +895,7 @@ export class ChatContentPage extends Component<
                                 showThreadPanel: !isThreadListVisible,
                                 showMatterPanel: false, // 与事项列表面板互斥
                                 showMatterDetailPanel: false, // 与事项详情面板互斥
+                                showSummaryPanel: false,
                                 activeThread: null,
                                 previewFile: null, // 关闭文件预览（互斥）
                                 activePreviewMessageId: null,
@@ -911,6 +961,7 @@ export class ChatContentPage extends Component<
                       showThreadPanel: true,
                       showMatterPanel: false, // 与事项列表面板互斥
                       showMatterDetailPanel: false, // 与事项详情面板互斥
+                      showSummaryPanel: false,
                       previewFile: null, // 关闭文件预览（互斥）
                       activePreviewMessageId: null,
                       activeThread: buildThreadStub(
@@ -1059,6 +1110,15 @@ export class ChatContentPage extends Component<
           >
             {WKApp.endpoints.chatMatterDetailPanel(channel, () =>
               this.setState({ showMatterDetailPanel: false }),
+            )}
+          </div>
+        )}
+
+        {showSummaryPanel && (
+          <div className="wk-summary-panel">
+            {WKApp.endpoints.chatSummaryPanel(
+              channel,
+              () => this.setState({ showSummaryPanel: false }),
             )}
           </div>
         )}

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -27,6 +27,7 @@ export class EndpointCategory {
   static organizationalLayer = "organizationalLayer" // 组织架构弹框
   static chatMatterPanel = "chatMatterPanel" // 事项面板
   static chatMatterDetailPanel = "chatMatterDetailPanel" // 事项详情面板 (v0.7)
+  static chatSummaryPanel = "chatSummaryPanel"
 }
 
 

--- a/packages/dmworksummary/src/__tests__/notifyChatSummaryCreated.test.ts
+++ b/packages/dmworksummary/src/__tests__/notifyChatSummaryCreated.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockEmit = vi.fn();
+const mockSwitchToMenuById = vi.fn();
+const mockOpenSummaryDetail = vi.fn();
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: {
+            mittBus: { on: vi.fn(), off: vi.fn(), emit: (...args: any[]) => mockEmit(...args) },
+            switchToMenuById: (...args: any[]) => mockSwitchToMenuById(...args),
+            openSummaryDetail: (...args: any[]) => mockOpenSummaryDetail(...args),
+        },
+    };
+});
+
+import { notifyChatSummaryCreated } from '../utils/chatSummaryActions';
+
+describe('notifyChatSummaryCreated (chat-context summary create)', () => {
+    const channel = { channelID: 'ch1', channelType: 2 };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('opens the chat side summary panel via mittBus without switching the main tab', () => {
+        notifyChatSummaryCreated(channel);
+
+        // BUG 1: must NOT force-switch to the 智能总结 main tab
+        expect(mockSwitchToMenuById).not.toHaveBeenCalled();
+        expect(mockOpenSummaryDetail).not.toHaveBeenCalled();
+
+        // Stays in chat: opens/refreshes the side panel idempotently
+        expect(mockEmit).toHaveBeenCalledWith('wk:toggle-summary-panel', {
+            channelId: 'ch1',
+            channelType: 2,
+            summaryPanelView: 'history',
+            forceOpen: true,
+        });
+    });
+});

--- a/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
@@ -1,24 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockRequestUse, mockResponseUse } = vi.hoisted(() => ({
-  mockRequestUse: vi.fn(),
-  mockResponseUse: vi.fn(),
+const { mockGet, mockPost, mockRequestUse, mockResponseUse } = vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockPost: vi.fn(),
+    mockRequestUse: vi.fn(),
+    mockResponseUse: vi.fn(),
 }));
 
 vi.mock('axios', () => ({
-  default: {
-    create: () => ({
-      get: vi.fn(),
-      post: vi.fn(),
-      put: vi.fn(),
-      delete: vi.fn(),
-      interceptors: {
-        request: { use: mockRequestUse },
-        response: { use: mockResponseUse },
-      },
-    }),
-  },
+    default: {
+        create: () => ({
+            get: mockGet,
+            post: mockPost,
+            put: vi.fn(),
+            delete: vi.fn(),
+            interceptors: {
+                request: { use: mockRequestUse },
+                response: { use: mockResponseUse },
+            },
+        }),
+    },
 }));
+
+import { getTopicTemplates, getTemplates } from '../summaryApi';
 
 describe('summaryApi interceptors', () => {
   it('injects language, token, and space headers', async () => {
@@ -34,4 +38,101 @@ describe('summaryApi interceptors', () => {
     expect(result.headers['token']).toBe('test-token-abc');
     expect(result.headers['X-Space-Id']).toBe('space-123');
   });
+});
+
+describe('summaryApi', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('getTopicTemplates', () => {
+        it('unwraps {templates: [...]} correctly', async () => {
+            const templates = [
+                { id: 'project_progress', label: '汇总项目进展', icon: 'FileText', description: 'desc', type: 'parameterized', pattern: '总结 {project_name} 的项目进展', placeholders: [{ key: 'project_name', label: '输入项目名称', position: [3, 9] }] },
+                { id: 'weekly_report', label: '总结团队周报', icon: 'Calendar', description: 'desc2', type: 'fixed', pattern: '总结每周的工作周报' },
+            ];
+            mockGet.mockResolvedValue({ data: { data: { templates } } });
+
+            const result = await getTopicTemplates();
+
+            expect(result).toEqual(templates);
+        });
+
+        it('returns empty array when templates is missing', async () => {
+            mockGet.mockResolvedValue({ data: { data: {} } });
+
+            const result = await getTopicTemplates();
+
+            expect(result).toEqual([]);
+        });
+
+        it('returns empty array when data is null', async () => {
+            mockGet.mockResolvedValue({ data: { data: null } });
+
+            const result = await getTopicTemplates();
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getTemplates', () => {
+        it('maps TopicTemplate fields to SummaryTemplate format', async () => {
+            const templates = [
+                { id: 'project_progress', label: '汇总项目进展', icon: 'FileText', description: '与团队一起总结', type: 'parameterized', pattern: '总结 {project_name} 的项目进展' },
+                { id: 'weekly_report', label: '总结团队周报', icon: 'Calendar', description: '总结每周工作', type: 'fixed', pattern: '总结每周的工作周报' },
+            ];
+            mockGet.mockResolvedValue({ data: { data: { templates } } });
+
+            const result = await getTemplates();
+
+            expect(result).toEqual([
+                { template_id: 'project_progress', name: '汇总项目进展', description: '与团队一起总结', default_mode: 1, default_time_range_type: 1 },
+                { template_id: 'weekly_report', name: '总结团队周报', description: '总结每周工作', default_mode: 1, default_time_range_type: 1 },
+            ]);
+        });
+
+        it('returns empty array when templates is missing', async () => {
+            mockGet.mockResolvedValue({ data: { data: {} } });
+
+            const result = await getTemplates();
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('extractErrorMessage', () => {
+        it('reads response.data.message from backend envelope', async () => {
+            mockGet.mockRejectedValue({
+                response: { data: { message: 'Insufficient permissions' } },
+            });
+
+            await expect(getTopicTemplates()).rejects.toThrow('Insufficient permissions');
+        });
+
+        it('falls back to err.message when response.data.message is absent', async () => {
+            mockGet.mockRejectedValue(new Error('Network Error'));
+
+            await expect(getTopicTemplates()).rejects.toThrow('Network Error');
+        });
+
+        it('falls back to "Request failed" for non-Error rejections', async () => {
+            mockGet.mockRejectedValue('string error');
+
+            await expect(getTopicTemplates()).rejects.toThrow('Request failed');
+        });
+
+        it('truncates long error messages to 200 chars', async () => {
+            const longMsg = 'x'.repeat(300);
+            mockGet.mockRejectedValue({
+                response: { data: { message: longMsg } },
+            });
+
+            try {
+                await getTopicTemplates();
+            } catch (err: any) {
+                expect(err.message).toHaveLength(201);
+                expect(err.message.endsWith('…')).toBe(true);
+            }
+        });
+    });
 });

--- a/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
 
 const { mockGet, mockPost, mockRequestUse, mockResponseUse } = vi.hoisted(() => ({
     mockGet: vi.fn(),
@@ -19,10 +20,11 @@ vi.mock('axios', () => ({
                 response: { use: mockResponseUse },
             },
         }),
+        isCancel: (err: unknown) => !!(err as { __CANCEL__?: boolean })?.__CANCEL__,
     },
 }));
 
-import { getTopicTemplates, getTemplates } from '../summaryApi';
+import { getTopicTemplates, getTemplates, listSummaries } from '../summaryApi';
 
 describe('summaryApi interceptors', () => {
   it('injects language, token, and space headers', async () => {
@@ -133,6 +135,32 @@ describe('summaryApi', () => {
                 expect(err.message).toHaveLength(201);
                 expect(err.message.endsWith('…')).toBe(true);
             }
+        });
+    });
+
+    describe('cancellation', () => {
+        it('rethrows the original cancel error so axios.isCancel still detects it', async () => {
+            const cancelErr = { __CANCEL__: true, message: 'canceled' };
+            mockGet.mockRejectedValue(cancelErr);
+
+            await expect(
+                listSummaries({ origin_channel_id: 'ch1', page: 1, page_size: 1 }),
+            ).rejects.toBe(cancelErr);
+
+            // The thrown value preserves cancellation identity (not wrapped in a new Error).
+            try {
+                await listSummaries({ origin_channel_id: 'ch1', page: 1, page_size: 1 });
+            } catch (err) {
+                expect(axios.isCancel(err)).toBe(true);
+            }
+        });
+
+        it('still wraps non-cancel errors in a plain Error', async () => {
+            mockGet.mockRejectedValue(new Error('Network Error'));
+
+            await expect(
+                listSummaries({ origin_channel_id: 'ch1', page: 1, page_size: 1 }),
+            ).rejects.toThrow('Network Error');
         });
     });
 });

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { WKApp, buildAcceptLanguage } from '@octo/base';
 import type {
     ApiResponse,
@@ -18,8 +18,10 @@ import type {
     SourceItem,
     SummaryDetail,
     SummaryTemplate,
+    TopicTemplate,
     UpdateScheduleParams,
 } from '../types/summary';
+import { SummaryMode } from '../types/summary';
 
 const summaryAxios = axios.create({ baseURL: '' });
 
@@ -50,16 +52,16 @@ summaryAxios.interceptors.response.use(
 const BASE = '/summary/api/v1';
 
 function extractErrorMessage(err: unknown): string {
-    const axiosErr = err as { response?: { data?: { error?: { message?: string } } } };
-    const msg = axiosErr?.response?.data?.error?.message;
+    const axiosErr = err as { response?: { data?: { message?: string } } };
+    const msg = axiosErr?.response?.data?.message;
     const raw = msg || (err instanceof Error ? err.message : 'Request failed');
     return raw.length > 200 ? raw.slice(0, 200) + '…' : raw;
 }
 
 // Backend wraps responses in {code, message, data} envelope — unwrap .data
-async function get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+async function get<T>(path: string, params?: Record<string, unknown>, config?: AxiosRequestConfig): Promise<T> {
     try {
-        const resp = await summaryAxios.get(`${BASE}${path}`, { params });
+        const resp = await summaryAxios.get(`${BASE}${path}`, { params, ...config });
         return resp.data?.data ?? resp.data;
     } catch (err) {
         throw new Error(extractErrorMessage(err));
@@ -99,8 +101,11 @@ export async function createSummary(params: CreateSummaryParams): Promise<{ task
     return post('/summaries', params);
 }
 
-export async function listSummaries(params: ListSummariesParams): Promise<ListSummariesResponse> {
-    return get('/summaries', params as Record<string, unknown>);
+export async function listSummaries(
+    params: ListSummariesParams,
+    config?: { signal?: AbortSignal },
+): Promise<ListSummariesResponse> {
+    return get('/summaries', params as Record<string, unknown>, config);
 }
 
 export async function getSummaryDetail(taskId: number): Promise<SummaryDetail> {
@@ -194,8 +199,19 @@ export async function getParticipants(taskId: number): Promise<Participant[]> {
 }
 
 export async function getTemplates(): Promise<SummaryTemplate[]> {
-    const data = await get<SummaryTemplate[]>('/summary-templates');
-    return data || [];
+    const data = await get<{ templates: TopicTemplate[] }>('/summary-templates');
+    return (data?.templates || []).map(t => ({
+        template_id: t.id,
+        name: t.label,
+        description: t.description,
+        default_mode: SummaryMode.BY_GROUP,
+        default_time_range_type: 1 as const,
+    }));
+}
+
+export async function getTopicTemplates(): Promise<TopicTemplate[]> {
+    const data = await get<{ templates: TopicTemplate[] }>('/summary-templates');
+    return data?.templates || [];
 }
 
 export async function inferScope(topic: string): Promise<InferResult> {

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -64,6 +64,8 @@ async function get<T>(path: string, params?: Record<string, unknown>, config?: A
         const resp = await summaryAxios.get(`${BASE}${path}`, { params, ...config });
         return resp.data?.data ?? resp.data;
     } catch (err) {
+        // Preserve cancellation identity so callers can use axios.isCancel(err)
+        if (axios.isCancel(err)) throw err;
         throw new Error(extractErrorMessage(err));
     }
 }
@@ -73,6 +75,7 @@ async function post<T>(path: string, data?: unknown): Promise<T> {
         const resp = await summaryAxios.post(`${BASE}${path}`, data);
         return resp.data?.data ?? resp.data;
     } catch (err) {
+        if (axios.isCancel(err)) throw err;
         throw new Error(extractErrorMessage(err));
     }
 }
@@ -82,6 +85,7 @@ async function put<T>(path: string, data?: unknown): Promise<T> {
         const resp = await summaryAxios.put(`${BASE}${path}`, data);
         return resp.data?.data ?? resp.data;
     } catch (err) {
+        if (axios.isCancel(err)) throw err;
         throw new Error(extractErrorMessage(err));
     }
 }
@@ -91,6 +95,7 @@ async function del<T>(path: string): Promise<T> {
         const resp = await summaryAxios.delete(`${BASE}${path}`);
         return resp.data?.data ?? resp.data;
     } catch (err) {
+        if (axios.isCancel(err)) throw err;
         throw new Error(extractErrorMessage(err));
     }
 }
@@ -133,6 +138,8 @@ export async function editSummary(
         });
         return resp.data?.data ?? resp.data;
     } catch (err: unknown) {
+        // Preserve cancellation identity so callers can use axios.isCancel(err)
+        if (axios.isCancel(err)) throw err;
         const axiosErr = err as { response?: { status?: number; data?: { error?: { message?: string } } } };
         const status = axiosErr?.response?.status;
         const msg = extractErrorMessage(err);

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import axios from 'axios';
+import { Toast } from '@douyinfe/semi-ui';
 import { I18nContext } from '@octo/base';
 import * as summaryApi from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
 import { TaskStatus } from '../types/summary';
-import TaskStatusBadge from './TaskStatusBadge';
+import SummaryCard from './SummaryCard';
 
 interface ChatSummaryHistoryProps {
     channel: { channelID: string; channelType: number };
@@ -147,9 +148,18 @@ export default class ChatSummaryHistory extends Component<
         }
     }
 
-    private formatTime(dateStr: string): string {
-        return this.context.format.time(dateStr, { hour: '2-digit', minute: '2-digit' });
-    }
+    private handleDelete = async (taskId: number) => {
+        try {
+            await summaryApi.deleteSummary(taskId);
+            // Reuse the existing event mechanism so this list refreshes itself.
+            window.dispatchEvent(new CustomEvent('chat-summary-deleted', {
+                detail: { channelId: this.props.channel.channelID },
+            }));
+        } catch {
+            // Surface the failure; the item stays in the list if deletion fails.
+            Toast.error(this.context.t('summary.common.deleteFailed'));
+        }
+    };
 
     render() {
         const { onCreateNew, onViewDetail } = this.props;
@@ -157,7 +167,7 @@ export default class ChatSummaryHistory extends Component<
         const { t } = this.context;
 
         return (
-            <div style={{ padding: '16px', height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <div className="chat-summary-history" style={{ padding: '16px', height: '100%', display: 'flex', flexDirection: 'column' }}>
                 <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 16, color: 'var(--wk-text-primary, #1C1F23)' }}>
                     {t('summary.chatSummary.panelTitle')}
                 </div>
@@ -198,60 +208,12 @@ export default class ChatSummaryHistory extends Component<
                 ) : (
                     <div style={{ flex: 1, overflowY: 'auto' }}>
                         {items.map((item) => (
-                            <div
+                            <SummaryCard
                                 key={item.task_id}
-                                onClick={() => onViewDetail(item.task_id)}
-                                style={{
-                                    padding: '12px',
-                                    border: '1px solid var(--wk-border-default, #E5E6EB)',
-                                    borderRadius: 8,
-                                    marginBottom: 8,
-                                    cursor: 'pointer',
-                                    transition: 'background-color 0.15s',
-                                }}
-                                onMouseEnter={(e) => {
-                                    e.currentTarget.style.backgroundColor = 'var(--wk-bg-hover, #F5F6F7)';
-                                }}
-                                onMouseLeave={(e) => {
-                                    e.currentTarget.style.backgroundColor = '';
-                                }}
-                            >
-                                <div style={{
-                                    fontSize: 14,
-                                    fontWeight: 500,
-                                    color: 'var(--wk-text-primary, #1C1F23)',
-                                    marginBottom: 6,
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                }}>
-                                    {item.title}
-                                </div>
-                                <div style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    fontSize: 12,
-                                    color: 'var(--wk-text-tertiary, #8F959E)',
-                                }}>
-                                    <span>
-                                        {item.sources?.length
-                                            ? t('summary.chatSummary.creatorWithSources', {
-                                                values: {
-                                                    name: item.creator_name || t('summary.common.unknown'),
-                                                    count: item.sources.length,
-                                                },
-                                            })
-                                            : t('summary.summaryCard.createdBy', {
-                                                values: { name: item.creator_name || t('summary.common.unknown') },
-                                            })}
-                                    </span>
-                                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                                        <TaskStatusBadge status={item.status} />
-                                        {this.formatTime(item.created_at)}
-                                    </span>
-                                </div>
-                            </div>
+                                task={item}
+                                onClick={onViewDetail}
+                                onDelete={this.handleDelete}
+                            />
                         ))}
                     </div>
                 )}

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -1,0 +1,261 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import { I18nContext } from '@octo/base';
+import * as summaryApi from '../api/summaryApi';
+import type { SummaryListItem } from '../types/summary';
+import { TaskStatus } from '../types/summary';
+import TaskStatusBadge from './TaskStatusBadge';
+
+interface ChatSummaryHistoryProps {
+    channel: { channelID: string; channelType: number };
+    onCreateNew: () => void;
+    onViewDetail: (taskId: number) => void;
+    paused?: boolean;
+}
+
+interface ChatSummaryHistoryState {
+    items: SummaryListItem[];
+    loading: boolean;
+}
+
+export default class ChatSummaryHistory extends Component<
+    ChatSummaryHistoryProps,
+    ChatSummaryHistoryState
+> {
+    static contextType = I18nContext;
+    declare context: React.ContextType<typeof I18nContext>;
+
+    private abortController: AbortController | null = null;
+    private pollTimer: ReturnType<typeof setInterval> | null = null;
+    private isPolling = false;
+
+    constructor(props: ChatSummaryHistoryProps) {
+        super(props);
+        this.state = { items: [], loading: true };
+    }
+
+    componentDidMount() {
+        void this.loadHistory();
+        window.addEventListener('chat-summary-created', this.handleChange as EventListener);
+        window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
+    }
+
+    componentWillUnmount() {
+        this.abortController?.abort();
+        this.stopPoll();
+        window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
+        window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
+    }
+
+    componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
+        if (prevProps.paused !== this.props.paused) {
+            if (this.props.paused) {
+                // 详情打开时暂停列表轮询，避免对同一任务重复请求状态
+                this.stopPoll();
+            } else {
+                // 返回列表后刷新一次以同步详情期间的状态变化，并恢复轮询
+                void this.loadHistory();
+            }
+        }
+    }
+
+    private getActiveTaskIds(): number[] {
+        return this.state.items
+            .filter(item =>
+                item.status === TaskStatus.PENDING ||
+                item.status === TaskStatus.WAITING_CONFIRM ||
+                item.status === TaskStatus.PROCESSING
+            )
+            .map(item => item.task_id);
+    }
+
+    private maybeStartPoll() {
+        this.stopPoll();
+        if (this.props.paused) return;
+        if (this.getActiveTaskIds().length === 0) return;
+        this.pollTimer = setInterval(() => {
+            const ids = this.getActiveTaskIds();
+            if (ids.length === 0) {
+                this.stopPoll();
+                return;
+            }
+            void this.doPoll(ids);
+        }, 5000);
+    }
+
+    private stopPoll() {
+        if (this.pollTimer !== null) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+        }
+    }
+
+    private async doPoll(taskIds: number[]) {
+        if (this.isPolling) return;
+        this.isPolling = true;
+        try {
+            const updates = await summaryApi.batchStatus(taskIds);
+            const updateMap = new Map(updates.map(u => [u.id, u]));
+            let changed = false;
+            const newItems = this.state.items.map(item => {
+                const update = updateMap.get(item.task_id);
+                if (update && update.status !== item.status) {
+                    changed = true;
+                    return { ...item, status: update.status };
+                }
+                return item;
+            });
+            if (changed) {
+                this.setState({ items: newItems }, () => this.maybeStartPoll());
+            }
+        } catch {
+            // ignore
+        } finally {
+            this.isPolling = false;
+        }
+    }
+
+    private handleChange = (e: CustomEvent<{ channelId: string }>) => {
+        if (e.detail?.channelId === this.props.channel.channelID) {
+            void this.loadHistory();
+        }
+    };
+
+    private async loadHistory() {
+        this.abortController?.abort();
+        const controller = new AbortController();
+        this.abortController = controller;
+
+        try {
+            const res = await summaryApi.listSummaries(
+                {
+                    origin_channel_id: this.props.channel.channelID,
+                    page: 1,
+                    page_size: 50,
+                    sort_by: 'created_at',
+                    sort_order: 'desc',
+                },
+                { signal: controller.signal },
+            );
+            if (!controller.signal.aborted) {
+                this.setState({ items: res.items || [], loading: false }, () => this.maybeStartPoll());
+            }
+        } catch (err: unknown) {
+            if (!axios.isCancel(err)) {
+                this.setState({ loading: false });
+            }
+        }
+    }
+
+    private formatTime(dateStr: string): string {
+        return this.context.format.time(dateStr, { hour: '2-digit', minute: '2-digit' });
+    }
+
+    render() {
+        const { onCreateNew, onViewDetail } = this.props;
+        const { items, loading } = this.state;
+        const { t } = this.context;
+
+        return (
+            <div style={{ padding: '16px', height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 16, color: 'var(--wk-text-primary, #1C1F23)' }}>
+                    {t('summary.chatSummary.panelTitle')}
+                </div>
+
+                <div
+                    onClick={onCreateNew}
+                    style={{
+                        padding: '14px',
+                        border: '1px dashed var(--wk-border-default, #E5E6EB)',
+                        borderRadius: 8,
+                        textAlign: 'center',
+                        cursor: 'pointer',
+                        marginBottom: 12,
+                        color: 'var(--wk-text-secondary, #646A73)',
+                        fontSize: 14,
+                        transition: 'border-color 0.15s, background-color 0.15s',
+                    }}
+                    onMouseEnter={(e) => {
+                        e.currentTarget.style.borderStyle = 'solid';
+                        e.currentTarget.style.backgroundColor = '#F0F7FF';
+                    }}
+                    onMouseLeave={(e) => {
+                        e.currentTarget.style.borderStyle = 'dashed';
+                        e.currentTarget.style.backgroundColor = '';
+                    }}
+                >
+                    + {t('summary.chatSummary.createNew')}
+                </div>
+
+                {loading ? (
+                    <div style={{ textAlign: 'center', color: 'var(--wk-text-tertiary, #8F959E)', paddingTop: 40 }}>
+                        {t('summary.common.loading')}
+                    </div>
+                ) : items.length === 0 ? (
+                    <div style={{ textAlign: 'center', color: 'var(--wk-text-tertiary, #8F959E)', paddingTop: 40 }}>
+                        {t('summary.list.emptyTitle')}
+                    </div>
+                ) : (
+                    <div style={{ flex: 1, overflowY: 'auto' }}>
+                        {items.map((item) => (
+                            <div
+                                key={item.task_id}
+                                onClick={() => onViewDetail(item.task_id)}
+                                style={{
+                                    padding: '12px',
+                                    border: '1px solid var(--wk-border-default, #E5E6EB)',
+                                    borderRadius: 8,
+                                    marginBottom: 8,
+                                    cursor: 'pointer',
+                                    transition: 'background-color 0.15s',
+                                }}
+                                onMouseEnter={(e) => {
+                                    e.currentTarget.style.backgroundColor = 'var(--wk-bg-hover, #F5F6F7)';
+                                }}
+                                onMouseLeave={(e) => {
+                                    e.currentTarget.style.backgroundColor = '';
+                                }}
+                            >
+                                <div style={{
+                                    fontSize: 14,
+                                    fontWeight: 500,
+                                    color: 'var(--wk-text-primary, #1C1F23)',
+                                    marginBottom: 6,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}>
+                                    {item.title}
+                                </div>
+                                <div style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'space-between',
+                                    fontSize: 12,
+                                    color: 'var(--wk-text-tertiary, #8F959E)',
+                                }}>
+                                    <span>
+                                        {item.sources?.length
+                                            ? t('summary.chatSummary.creatorWithSources', {
+                                                values: {
+                                                    name: item.creator_name || t('summary.common.unknown'),
+                                                    count: item.sources.length,
+                                                },
+                                            })
+                                            : t('summary.summaryCard.createdBy', {
+                                                values: { name: item.creator_name || t('summary.common.unknown') },
+                                            })}
+                                    </span>
+                                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                                        <TaskStatusBadge status={item.status} />
+                                        {this.formatTime(item.created_at)}
+                                    </span>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    }
+}

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.css
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.css
@@ -1,0 +1,93 @@
+.chat-summary-new-modal .semi-modal-header {
+    display: none;
+}
+
+.chat-summary-modal-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.chat-summary-modal-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--wk-text-primary, #1C1F23);
+}
+
+.chat-summary-modal-ai-badge {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background-color: var(--wk-color-primary, #3370FF);
+    color: #fff;
+}
+
+.chat-summary-modal-desc {
+    font-size: 13px;
+    color: var(--wk-text-tertiary, #8F959E);
+    line-height: 20px;
+    margin-bottom: 16px;
+}
+
+.chat-summary-modal-input-area {
+    border: 1px solid var(--wk-border-default, #E5E6EB);
+    border-radius: 8px;
+    margin-bottom: 16px;
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.chat-summary-modal-input-area:focus-within {
+    border-color: var(--wk-color-primary, #3370FF);
+}
+
+.chat-summary-modal-input {
+    width: 100%;
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    border: none;
+    border-radius: 0;
+    outline: none;
+    background-color: transparent;
+    color: var(--wk-text-primary, #1C1F23);
+    box-sizing: border-box;
+    flex: 1;
+    min-height: 40px;
+    resize: none;
+}
+
+.chat-summary-modal-chat-section {
+    margin-bottom: 16px;
+}
+
+.chat-summary-modal-chat-tags {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.chat-summary-modal-templates-label {
+    font-size: 13px;
+    color: var(--wk-text-secondary, #646A73);
+    margin-bottom: 12px;
+    padding: 0 12px;
+}
+
+.chat-summary-modal-templates {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 0 12px 12px;
+}
+
+.chat-summary-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: 100%;
+}

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -1,0 +1,290 @@
+import React, { Component, createRef } from 'react';
+import { Modal, Toast, Tag, Button } from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+import { WKApp, I18nContext } from '@octo/base';
+import type { TopicTemplate, ChatCandidate } from '../types/summary';
+import { SourceType } from '../types/summary';
+import { getSourceType } from '../utils/channelType';
+import { channelToChatCandidate } from '../utils/channelConvert';
+import { resolveTemplate, computeTemplateSelection, type ResolvableTemplate } from '../utils/templateResolver';
+import * as summaryApi from '../api/summaryApi';
+import { getTopicTemplates } from '../api/summaryApi';
+import { TOPIC_TEMPLATES } from '../constants/templates';
+import TemplateCard from './TemplateCard';
+import ChatSelectorModal from './ChatSelectorModal';
+import './ChatSummaryNewModal.css';
+
+interface ChatSummaryNewModalProps {
+    visible: boolean;
+    channel: { channelID: string; channelType: number };
+    onClose: () => void;
+    onSubmit: (taskId: number) => void;
+}
+
+interface ChatSummaryNewModalState {
+    topic: string;
+    templates: ResolvableTemplate[];
+    selectedChats: ChatCandidate[];
+    showChatSelector: boolean;
+    submitting: boolean;
+    templatePlaceholderRange: [number, number] | null;
+}
+
+export default class ChatSummaryNewModal extends Component<
+    ChatSummaryNewModalProps,
+    ChatSummaryNewModalState
+> {
+    static contextType = I18nContext;
+    declare context: React.ContextType<typeof I18nContext>;
+
+    private inputRef = createRef<HTMLTextAreaElement>();
+
+    constructor(props: ChatSummaryNewModalProps) {
+        super(props);
+        this.state = {
+            topic: '',
+            templates: TOPIC_TEMPLATES,
+            selectedChats: [],
+            showChatSelector: false,
+            submitting: false,
+            templatePlaceholderRange: null,
+        };
+    }
+
+    componentDidMount() {
+        if (this.props.visible) {
+            const defaultChat = channelToChatCandidate(this.props.channel);
+            this.setState({ selectedChats: [defaultChat] });
+            void this.loadTemplates();
+        }
+    }
+
+    componentDidUpdate(prevProps: ChatSummaryNewModalProps) {
+        if (this.props.visible && !prevProps.visible) {
+            const defaultChat = channelToChatCandidate(this.props.channel);
+            this.setState({
+                topic: '',
+                selectedChats: [defaultChat],
+                showChatSelector: false,
+                submitting: false,
+                templatePlaceholderRange: null,
+            });
+            void this.loadTemplates();
+        }
+    }
+
+    private async loadTemplates() {
+        try {
+            const templates = await getTopicTemplates();
+            if (templates.length > 0) {
+                this.setState({ templates });
+            }
+        } catch {
+            // fallback to constants already in state
+        }
+    }
+
+    private handleTemplateClick = (template: TopicTemplate) => {
+        const { text, range } = computeTemplateSelection(template);
+
+        if (range) {
+            const [start, end] = range;
+            this.setState({ topic: text, templatePlaceholderRange: [start, end] });
+
+            setTimeout(() => {
+                const input = this.inputRef.current;
+                if (!input) return;
+                input.focus();
+                input.setSelectionRange(start, end);
+            }, 0);
+        } else {
+            this.setState({ topic: text, templatePlaceholderRange: null });
+
+            setTimeout(() => {
+                this.inputRef.current?.focus();
+            }, 0);
+        }
+    };
+
+    private handleInputFocus = () => {
+        const { templatePlaceholderRange, topic } = this.state;
+        if (!templatePlaceholderRange) return;
+        const [start, end] = templatePlaceholderRange;
+        const newTopic = topic.substring(0, start) + topic.substring(end);
+        this.setState({ topic: newTopic, templatePlaceholderRange: null }, () => {
+            this.inputRef.current?.setSelectionRange(start, start);
+        });
+    };
+
+    private handleSubmit = async () => {
+        const { topic, selectedChats } = this.state;
+        const { channel, onSubmit } = this.props;
+
+        if (!topic.trim()) return;
+
+        const sourceType = getSourceType(channel);
+        if (sourceType === null) return;
+
+        this.setState({ submitting: true });
+        try {
+            const sources = selectedChats.length > 0
+                ? selectedChats.map((c) => ({
+                    source_type: (c.chat_type === 'group'
+                        ? SourceType.GROUP_CHAT
+                        : c.chat_type === 'thread'
+                        ? SourceType.THREAD
+                        : SourceType.DIRECT_MESSAGE),
+                    source_id: c.chat_id,
+                    source_name: c.name,
+                }))
+                : [{
+                    source_type: sourceType as 1 | 2 | 3,
+                    source_id: channel.channelID,
+                }];
+
+            const res = await summaryApi.createSummary({
+                topic: topic.trim(),
+                origin_channel_id: channel.channelID,
+                origin_channel_type: sourceType,
+                sources,
+            });
+            window.dispatchEvent(
+                new CustomEvent('chat-summary-created', {
+                    detail: { taskId: res.task_id, channelId: channel.channelID },
+                }),
+            );
+            onSubmit(res.task_id);
+        } catch (err: unknown) {
+            const msg = err instanceof Error
+                ? err.message
+                : this.context.t('summary.common.createFailedRetry');
+            Toast.error(msg);
+        } finally {
+            this.setState({ submitting: false });
+        }
+    };
+
+    private handleRemoveChat = (chatId: string) => {
+        this.setState((prev) => ({
+            selectedChats: prev.selectedChats.filter((c) => c.chat_id !== chatId),
+        }));
+    };
+
+    render() {
+        const { visible, onClose } = this.props;
+        const { topic, templates, selectedChats, showChatSelector, submitting } = this.state;
+        const { t } = this.context;
+        // 模板在 render() 用当前 locale 解析，切语言即时刷新（不在 state 烘焙）。
+        const resolvedTemplates = templates.map((tpl) => resolveTemplate(tpl, t));
+
+        const footer = (
+            <div className="chat-summary-modal-footer">
+                <Button
+                    theme="solid"
+                    size="default"
+                    loading={submitting}
+                    disabled={!topic.trim() || submitting}
+                    onClick={() => void this.handleSubmit()}
+                >
+                    {submitting ? t('summary.create.submitting') : t('summary.create.start')}
+                </Button>
+            </div>
+        );
+
+        return (
+            <>
+                <Modal
+                    visible={visible}
+                    onCancel={onClose}
+                    footer={footer}
+                    width={640}
+                    closable
+                    title={null}
+                    bodyStyle={{ padding: '24px 24px 0' }}
+                    className="chat-summary-new-modal"
+                >
+                    <div className="chat-summary-modal-header">
+                        <span className="chat-summary-modal-title">{t('summary.create.title')}</span>
+                        <span className="chat-summary-modal-ai-badge">AI+</span>
+                    </div>
+                    <div className="chat-summary-modal-desc">
+                        {t('summary.create.desc')}
+                    </div>
+
+                    <div className="chat-summary-modal-input-area">
+                        <textarea
+                            ref={this.inputRef}
+                            className="chat-summary-modal-input"
+                            placeholder={t('summary.create.topicPlaceholderInChat')}
+                            value={topic}
+                            onChange={(e) => this.setState({ topic: e.target.value, templatePlaceholderRange: null })}
+                            onFocus={this.handleInputFocus}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey && !submitting) {
+                                    e.preventDefault();
+                                    void this.handleSubmit();
+                                }
+                            }}
+                        />
+                        {!topic.trim() && (
+                            <>
+                                <div className="chat-summary-modal-templates-label">{t('summary.create.templatesTitle')}</div>
+                                <div className="chat-summary-modal-templates">
+                                    {resolvedTemplates.map((tpl) => (
+                                        <TemplateCard
+                                            key={tpl.id}
+                                            template={tpl}
+                                            onClick={this.handleTemplateClick}
+                                        />
+                                    ))}
+                                </div>
+                            </>
+                        )}
+                    </div>
+
+                    <div className="chat-summary-modal-chat-section">
+                        <Button
+                            theme="borderless"
+                            icon={<IconPlus />}
+                            size="small"
+                            onClick={() => this.setState({ showChatSelector: true })}
+                            style={{
+                                color: selectedChats.length > 0
+                                    ? 'var(--wk-color-primary, #3370FF)'
+                                    : undefined,
+                            }}
+                        >
+                            {selectedChats.length > 0
+                                ? t('summary.create.selectedChats', { values: { count: selectedChats.length } })
+                                : t('summary.create.selectChat')}
+                        </Button>
+                        {selectedChats.length > 0 && (
+                            <div className="chat-summary-modal-chat-tags">
+                                {selectedChats.map((c) => (
+                                    <Tag
+                                        key={c.chat_id}
+                                        closable
+                                        onClose={() => this.handleRemoveChat(c.chat_id)}
+                                        style={{ marginRight: 6, marginBottom: 4 }}
+                                    >
+                                        {c.name}
+                                    </Tag>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </Modal>
+
+                <ChatSelectorModal
+                    visible={showChatSelector}
+                    selected={selectedChats}
+                    onConfirm={(chats) =>
+                        this.setState({ selectedChats: chats, showChatSelector: false })
+                    }
+                    onCancel={() => this.setState({ showChatSelector: false })}
+                    maxSelect={10}
+                />
+            </>
+        );
+    }
+}

--- a/packages/dmworksummary/src/components/ChatSummaryPanel.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryPanel.tsx
@@ -1,0 +1,213 @@
+import React, { Component } from 'react';
+import { WKApp, I18nContext } from '@octo/base';
+import {
+    SUMMARY_DEFAULT_WIDTH,
+    clampSummaryWidth,
+    restoreSummaryWidth,
+    persistSummaryWidth,
+} from '@octo/base/src/Components/WKLayout/layoutWidth';
+import { X, ChevronLeft } from 'lucide-react';
+import ChatSummaryHistory from './ChatSummaryHistory';
+import SummaryDetailPage from '../pages/SummaryDetailPage';
+
+interface ChatSummaryPanelProps {
+    visible: boolean;
+    channel: { channelID: string; channelType: number };
+    onClose: () => void;
+}
+
+interface ChatSummaryPanelState {
+    view: 'list' | 'detail';
+    selectedTaskId: number | null;
+    isDragging: boolean;
+}
+
+export default class ChatSummaryPanel extends Component<
+    ChatSummaryPanelProps,
+    ChatSummaryPanelState
+> {
+    static contextType = I18nContext;
+    declare context: React.ContextType<typeof I18nContext>;
+
+    private rootRef = React.createRef<HTMLDivElement>();
+    private dragStartX = 0;
+    private dragStartWidth = 0;
+    private lastPanelWidth = clampSummaryWidth(restoreSummaryWidth(), window.innerWidth);
+
+    constructor(props: ChatSummaryPanelProps) {
+        super(props);
+        this.state = { view: 'list', selectedTaskId: null, isDragging: false };
+    }
+
+    componentDidMount() {
+        // 还原持久化宽度：写容器 width + 祖先 CSS 变量（挤压聊天区）
+        this.applyWidth(this.lastPanelWidth);
+    }
+
+    componentWillUnmount() {
+        // 兜底解绑，避免拖动中卸载导致的内存泄漏
+        document.removeEventListener('mousemove', this.onDragMove);
+        document.removeEventListener('mouseup', this.onDragEnd);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+    }
+
+    componentDidUpdate(prevProps: ChatSummaryPanelProps) {
+        const prev = prevProps.channel;
+        const next = this.props.channel;
+        if (
+            prev.channelID !== next.channelID ||
+            prev.channelType !== next.channelType
+        ) {
+            // 切换会话时回到列表视图，避免残留上个会话的详情
+            this.setState({ view: 'list', selectedTaskId: null });
+        }
+    }
+
+    // ── Splitter drag ──
+    private applyWidth(width: number) {
+        const root = this.rootRef.current;
+        if (!root) return;
+        const panel = root.closest('.wk-summary-panel') as HTMLElement | null;
+        if (panel) {
+            panel.style.width = width + 'px';
+        }
+        // CSS 变量要设在祖先 .wk-chat-content-right 上，兄弟节点
+        // .wk-chat-content-chat 才能 var() 拿到，触发宽度挤压
+        const ancestor = root.closest('.wk-chat-content-right') as HTMLElement | null;
+        if (ancestor) {
+            ancestor.style.setProperty('--wk-width-summary-panel', width + 'px');
+        }
+    }
+
+    private onDragStart = (e: React.MouseEvent) => {
+        e.preventDefault();
+        this.dragStartX = e.clientX;
+        this.dragStartWidth = this.lastPanelWidth;
+        this.setState({ isDragging: true });
+        document.addEventListener('mousemove', this.onDragMove);
+        document.addEventListener('mouseup', this.onDragEnd);
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+    };
+
+    private onDragMove = (e: MouseEvent) => {
+        // 面板在右侧，左边缘拖动：向左拖（clientX 变小）应变宽
+        const delta = this.dragStartX - e.clientX;
+        const newWidth = clampSummaryWidth(this.dragStartWidth + delta, window.innerWidth);
+        this.lastPanelWidth = newWidth;
+        // 直接改 style / CSS 变量，不走 setState，避免拖动卡顿
+        this.applyWidth(newWidth);
+    };
+
+    private onDragEnd = () => {
+        document.removeEventListener('mousemove', this.onDragMove);
+        document.removeEventListener('mouseup', this.onDragEnd);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        this.setState({ isDragging: false });
+        persistSummaryWidth(this.lastPanelWidth);
+    };
+
+    private handleResetWidth = () => {
+        this.lastPanelWidth = SUMMARY_DEFAULT_WIDTH;
+        this.applyWidth(SUMMARY_DEFAULT_WIDTH);
+        persistSummaryWidth(SUMMARY_DEFAULT_WIDTH);
+    };
+
+    private handleCreateNew = () => {
+        const { channel } = this.props;
+        WKApp.mittBus.emit('wk:open-summary-modal', {
+            channelId: channel.channelID,
+            channelType: channel.channelType,
+        });
+    };
+
+    private handleViewDetail = (taskId: number) => {
+        this.setState({ view: 'detail', selectedTaskId: taskId });
+    };
+
+    private handleBack = () => {
+        this.setState({ view: 'list' });
+    };
+
+    render() {
+        const { channel, onClose } = this.props;
+        const { view, selectedTaskId, isDragging } = this.state;
+        const { t } = this.context;
+        const isDetail = view === 'detail' && selectedTaskId != null;
+
+        return (
+            <div ref={this.rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                {/* 左边缘分隔条：拖动调宽，双击重置默认宽度（复用 thread 面板样式） */}
+                <div
+                    className={`wk-thread-panel-splitter${isDragging ? ' wk-thread-panel-splitter-active' : ''}`}
+                    onMouseDown={this.onDragStart}
+                    onDoubleClick={this.handleResetWidth}
+                >
+                    <div className="wk-thread-panel-splitter-line" />
+                </div>
+
+                {/* 列表视图：常驻挂载，详情时隐藏以保留滚动位置 */}
+                <div
+                    style={{
+                        display: isDetail ? 'none' : 'flex',
+                        flex: 1,
+                        minHeight: 0,
+                        flexDirection: 'column',
+                    }}
+                >
+                    <div style={{
+                        display: 'flex',
+                        justifyContent: 'flex-end',
+                        padding: '8px 8px 0',
+                    }}>
+                        <button
+                            onClick={onClose}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                cursor: 'pointer',
+                                padding: 4,
+                                color: 'var(--wk-text-secondary, #646A73)',
+                                display: 'flex',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <X size={18} />
+                        </button>
+                    </div>
+
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={this.handleCreateNew}
+                        onViewDetail={this.handleViewDetail}
+                        paused={isDetail}
+                    />
+                </div>
+
+                {/* 详情视图：复用整页 SummaryDetailPage，外层加面板级返回栏 */}
+                {isDetail && (
+                    <div className="wk-summary-panel-detail">
+                        <div className="wk-summary-panel-detail-back">
+                            <button
+                                type="button"
+                                className="wk-summary-panel-detail-back-btn"
+                                onClick={this.handleBack}
+                            >
+                                <ChevronLeft size={18} />
+                                <span>{t('summary.chatSummary.back')}</span>
+                            </button>
+                        </div>
+                        <div className="wk-summary-panel-detail-body">
+                            <SummaryDetailPage taskId={selectedTaskId} />
+                        </div>
+                    </div>
+                )}
+
+                {/* 拖动遮罩：避免内部内容/选区抢鼠标 */}
+                {isDragging && <div className="wk-thread-panel-drag-overlay" />}
+            </div>
+        );
+    }
+}

--- a/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
@@ -1,0 +1,125 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import { WKApp, I18nContext } from '@octo/base';
+import { Sparkle } from 'lucide-react';
+import * as summaryApi from '../api/summaryApi';
+
+interface ChatSummaryStarButtonProps {
+    channel: { channelID: string; channelType: number };
+}
+
+interface ChatSummaryStarButtonState {
+    hasSummaries: boolean;
+    loaded: boolean;
+}
+
+export default class ChatSummaryStarButton extends Component<
+    ChatSummaryStarButtonProps,
+    ChatSummaryStarButtonState
+> {
+    static contextType = I18nContext;
+    declare context: React.ContextType<typeof I18nContext>;
+
+    private abortController: AbortController | null = null;
+
+    constructor(props: ChatSummaryStarButtonProps) {
+        super(props);
+        this.state = { hasSummaries: false, loaded: false };
+    }
+
+    componentDidUpdate(prevProps: ChatSummaryStarButtonProps) {
+        if (prevProps.channel.channelID !== this.props.channel.channelID) {
+            this.abortController?.abort();
+            this.setState({ hasSummaries: false, loaded: false });
+        }
+    }
+
+    componentDidMount() {
+        window.addEventListener('chat-summary-created', this.handleSummaryCreated as EventListener);
+        window.addEventListener('chat-summary-deleted', this.handleSummaryDeleted as EventListener);
+    }
+
+    componentWillUnmount() {
+        this.abortController?.abort();
+        window.removeEventListener('chat-summary-created', this.handleSummaryCreated as EventListener);
+        window.removeEventListener('chat-summary-deleted', this.handleSummaryDeleted as EventListener);
+    }
+
+    private handleSummaryCreated = (e: CustomEvent<{ channelId: string }>) => {
+        if (e.detail?.channelId === this.props.channel.channelID) {
+            this.setState({ hasSummaries: true, loaded: true });
+        }
+    };
+
+    private handleSummaryDeleted = (e: CustomEvent<{ channelId: string }>) => {
+        if (e.detail?.channelId === this.props.channel.channelID) {
+            void this.fetchSummaryCount();
+        }
+    };
+
+    private async fetchSummaryCount(): Promise<boolean> {
+        this.abortController?.abort();
+        const controller = new AbortController();
+        this.abortController = controller;
+
+        try {
+            const res = await summaryApi.listSummaries(
+                { origin_channel_id: this.props.channel.channelID, page: 1, page_size: 1 },
+                { signal: controller.signal },
+            );
+            if (!controller.signal.aborted) {
+                const hasSummaries = res.total > 0;
+                this.setState({ hasSummaries, loaded: true });
+                return hasSummaries;
+            }
+            return false;
+        } catch (err: unknown) {
+            if (!axios.isCancel(err)) {
+                // non-cancel error, silent
+            }
+            return false;
+        }
+    }
+
+    private handleClick = async () => {
+        const { channel } = this.props;
+        let hasSummaries = this.state.hasSummaries;
+
+        if (!this.state.loaded) {
+            hasSummaries = await this.fetchSummaryCount();
+        }
+
+        if (hasSummaries) {
+            WKApp.mittBus.emit('wk:toggle-summary-panel', {
+                channelId: channel.channelID,
+                channelType: channel.channelType,
+                summaryPanelView: 'history',
+            });
+        } else {
+            WKApp.mittBus.emit('wk:open-summary-modal', {
+                channelId: channel.channelID,
+                channelType: channel.channelType,
+            });
+        }
+    };
+
+    render() {
+        const { t } = this.context;
+        return (
+            <div
+                onClick={(e) => {
+                    e.stopPropagation();
+                    void this.handleClick();
+                }}
+                style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}
+                title={t('summary.chatSummary.starTooltip')}
+            >
+                <Sparkle
+                    size={20}
+                    fill="none"
+                    color="currentColor"
+                />
+            </div>
+        );
+    }
+}

--- a/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import axios from 'axios';
+import { Toast } from '@douyinfe/semi-ui';
 import { WKApp, I18nContext } from '@octo/base';
 import { Sparkle } from 'lucide-react';
 import * as summaryApi from '../api/summaryApi';
@@ -57,7 +58,14 @@ export default class ChatSummaryStarButton extends Component<
         }
     };
 
-    private async fetchSummaryCount(): Promise<boolean> {
+    // Three outcomes are distinguished so the caller never confuses a load
+    // failure with "no summaries":
+    //   { state: 'ok', hasSummaries } — genuine result (total resolved)
+    //   { state: 'cancelled' }        — superseded/aborted request, ignore
+    //   { state: 'failed' }           — network/server error, surface to user
+    private async fetchSummaryCount(): Promise<
+        { state: 'ok'; hasSummaries: boolean } | { state: 'cancelled' } | { state: 'failed' }
+    > {
         this.abortController?.abort();
         const controller = new AbortController();
         this.abortController = controller;
@@ -67,28 +75,46 @@ export default class ChatSummaryStarButton extends Component<
                 { origin_channel_id: this.props.channel.channelID, page: 1, page_size: 1 },
                 { signal: controller.signal },
             );
-            if (!controller.signal.aborted) {
-                const hasSummaries = res.total > 0;
-                this.setState({ hasSummaries, loaded: true });
-                return hasSummaries;
+            if (controller.signal.aborted) {
+                return { state: 'cancelled' };
             }
-            return false;
+            const hasSummaries = res.total > 0;
+            this.setState({ hasSummaries, loaded: true });
+            return { state: 'ok', hasSummaries };
         } catch (err: unknown) {
-            if (!axios.isCancel(err)) {
-                // non-cancel error, silent
+            // Cancellation identity is preserved by the api layer (see summaryApi get helper).
+            if (axios.isCancel(err) || controller.signal.aborted) {
+                return { state: 'cancelled' };
             }
-            return false;
+            // Genuine load failure: cannot assert "no summaries".
+            return { state: 'failed' };
         }
     }
 
     private handleClick = async () => {
-        const { channel } = this.props;
-        let hasSummaries = this.state.hasSummaries;
-
-        if (!this.state.loaded) {
-            hasSummaries = await this.fetchSummaryCount();
+        if (this.state.loaded) {
+            this.emitForHasSummaries(this.state.hasSummaries);
+            return;
         }
 
+        const result = await this.fetchSummaryCount();
+
+        // Cancelled (superseded by a newer request): do nothing.
+        if (result.state === 'cancelled') {
+            return;
+        }
+        // Load failed: surface an error and do NOT route the user into the
+        // create flow, which would risk creating a duplicate summary.
+        if (result.state === 'failed') {
+            Toast.error(this.context.t('summary.common.loadingFailed'));
+            return;
+        }
+
+        this.emitForHasSummaries(result.hasSummaries);
+    };
+
+    private emitForHasSummaries(hasSummaries: boolean) {
+        const { channel } = this.props;
         if (hasSummaries) {
             WKApp.mittBus.emit('wk:toggle-summary-panel', {
                 channelId: channel.channelID,
@@ -101,7 +127,7 @@ export default class ChatSummaryStarButton extends Component<
                 channelType: channel.channelType,
             });
         }
-    };
+    }
 
     render() {
         const { t } = this.context;

--- a/packages/dmworksummary/src/components/TemplateCard.tsx
+++ b/packages/dmworksummary/src/components/TemplateCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { FileText, ListChecks, Calendar, MessageSquare } from 'lucide-react';
+import type { TopicTemplate } from '../types/summary';
+
+const ICON_MAP: Record<string, React.FC<{ size?: number }>> = {
+    FileText,
+    ListChecks,
+    Calendar,
+    MessageSquare,
+};
+
+interface TemplateCardProps {
+    template: TopicTemplate;
+    onClick: (template: TopicTemplate) => void;
+}
+
+const TemplateCard: React.FC<TemplateCardProps> = ({ template, onClick }) => {
+    const IconComponent = ICON_MAP[template.icon];
+
+    return (
+        <div
+            className="chat-summary-template-card"
+            onClick={() => onClick(template)}
+            style={{
+                flex: '1 1 0',
+                minWidth: 0,
+                padding: '12px',
+                border: '1px solid var(--wk-border-default, #E5E6EB)',
+                borderRadius: 8,
+                cursor: 'pointer',
+                backgroundColor: 'var(--wk-bg-surface, #fff)',
+                transition: 'background-color 0.15s, border-color 0.15s',
+            }}
+            onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = '#F0F7FF';
+                e.currentTarget.style.borderColor = 'var(--wk-color-primary, #3370FF)';
+            }}
+            onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--wk-bg-surface, #fff)';
+                e.currentTarget.style.borderColor = 'var(--wk-border-default, #E5E6EB)';
+            }}
+        >
+            <div style={{ marginBottom: 8, color: 'var(--wk-text-secondary, #646A73)' }}>
+                {IconComponent ? <IconComponent size={20} /> : null}
+            </div>
+            <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4, color: 'var(--wk-text-primary, #1C1F23)' }}>
+                {template.label}
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--wk-text-tertiary, #8F959E)', lineHeight: '16px' }}>
+                {template.description}
+            </div>
+        </div>
+    );
+};
+
+export default TemplateCard;

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -1,0 +1,327 @@
+import React from 'react';
+import { render as rtlRender, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ChatSummaryHistory from '../ChatSummaryHistory';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: { mittBus: { emit: vi.fn() } },
+    };
+});
+
+const mockListSummaries = vi.fn();
+const mockBatchStatus = vi.fn();
+
+vi.mock('../../api/summaryApi', () => ({
+    listSummaries: (...args: any[]) => mockListSummaries(...args),
+    batchStatus: (...args: any[]) => mockBatchStatus(...args),
+}));
+
+vi.mock('../../utils/summaryHelpers', () => ({
+    getStatusLabel: (status: number) => {
+        const labels: Record<number, string> = { 0: '待处理', 1: '待确认', 2: '进行中', 3: '已完成', 4: '失败', 5: '已取消' };
+        return labels[status] ?? '未知';
+    },
+    getStatusColor: (status: number) => {
+        const colors: Record<number, string> = { 0: 'grey', 1: 'amber', 2: 'blue', 3: 'green', 4: 'red', 5: 'grey' };
+        return colors[status] ?? 'grey';
+    },
+}));
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Tag: ({ children, color, size }: any) => (
+        <span data-testid="status-tag" data-color={color} data-size={size}>{children}</span>
+    ),
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+    return {
+        task_id: 1,
+        task_no: 'T001',
+        title: '测试总结',
+        summary_mode: 1,
+        status: 3,
+        trigger_type: 1,
+        time_range_start: '2026-01-01T00:00:00Z',
+        time_range_end: '2026-01-02T00:00:00Z',
+        sources: [{ source_type: 1, source_id: 's1' }],
+        total_msg_count: 10,
+        creator_name: '张三',
+        origin_channel_id: 'ch1',
+        origin_channel_type: 2,
+        created_at: '2026-01-01T09:30:00Z',
+        completed_at: '2026-01-01T10:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('ChatSummaryHistory', () => {
+    const channel = { channelID: 'ch1', channelType: 2 };
+    const onCreateNew = vi.fn();
+    const onViewDetail = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders status badge for each item', async () => {
+        mockListSummaries.mockResolvedValue({
+            items: [
+                makeItem({ task_id: 1, status: 3, title: '已完成任务' }),
+                makeItem({ task_id: 2, status: 2, title: '进行中任务' }),
+            ],
+        });
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        const tags = screen.getAllByTestId('status-tag');
+        expect(tags).toHaveLength(2);
+        expect(tags[0]).toHaveTextContent('已完成');
+        expect(tags[0].dataset.color).toBe('green');
+        expect(tags[1]).toHaveTextContent('进行中');
+        expect(tags[1].dataset.color).toBe('blue');
+    });
+
+    it('renders creator, source count, and time alongside badge', async () => {
+        mockListSummaries.mockResolvedValue({
+            items: [makeItem({ creator_name: '李四', sources: [{ source_type: 1, source_id: 's1' }, { source_type: 1, source_id: 's2' }] })],
+        });
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        expect(screen.getByText(/李四 发起/)).toBeInTheDocument();
+        expect(screen.getByText(/2 个来源/)).toBeInTheDocument();
+        expect(screen.getByTestId('status-tag')).toBeInTheDocument();
+    });
+
+    it('does not poll when all items are completed', async () => {
+        mockListSummaries.mockResolvedValue({
+            items: [makeItem({ task_id: 1, status: 3 })],
+        });
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        expect(mockBatchStatus).not.toHaveBeenCalled();
+    });
+
+    describe('polling', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('starts polling when items have active status', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 3, progress: 100, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            expect(screen.getByTestId('status-tag')).toHaveTextContent('进行中');
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            expect(mockBatchStatus).toHaveBeenCalledWith([1]);
+            expect(screen.getByTestId('status-tag')).toHaveTextContent('已完成');
+        });
+
+        it('stops polling after status transitions to terminal', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 0 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 3, progress: 100, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            expect(mockBatchStatus).toHaveBeenCalledTimes(1);
+            mockBatchStatus.mockClear();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('does not start polling when mounted with paused=true', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                        paused
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('stops polling when paused flips to true and resumes when it flips back', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            let rerender: (ui: React.ReactElement) => void;
+            await act(async () => {
+                const result = render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                        paused={false}
+                    />,
+                );
+                rerender = result.rerender;
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalled();
+
+            // 进入详情：暂停轮询
+            await act(async () => {
+                rerender!(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                        paused
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            mockBatchStatus.mockClear();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(15000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+
+            // 返回列表：刷新一次并恢复轮询
+            mockListSummaries.mockClear();
+            await act(async () => {
+                rerender!(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                        paused={false}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(mockListSummaries).toHaveBeenCalled();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalled();
+        });
+
+        it('cleans up poll timer on unmount', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            let unmount: () => void;
+            await act(async () => {
+                const result = render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                unmount = result.unmount;
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            act(() => unmount!());
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -13,10 +13,13 @@ vi.mock('@octo/base', async () => {
 
 const mockListSummaries = vi.fn();
 const mockBatchStatus = vi.fn();
+const mockDeleteSummary = vi.fn();
+const mockToastError = vi.fn();
 
 vi.mock('../../api/summaryApi', () => ({
     listSummaries: (...args: any[]) => mockListSummaries(...args),
     batchStatus: (...args: any[]) => mockBatchStatus(...args),
+    deleteSummary: (...args: any[]) => mockDeleteSummary(...args),
 }));
 
 vi.mock('../../utils/summaryHelpers', () => ({
@@ -31,9 +34,26 @@ vi.mock('../../utils/summaryHelpers', () => ({
 }));
 
 vi.mock('@douyinfe/semi-ui', () => ({
+    Toast: { error: (...args: any[]) => mockToastError(...args) },
     Tag: ({ children, color, size }: any) => (
         <span data-testid="status-tag" data-color={color} data-size={size}>{children}</span>
     ),
+    Tooltip: ({ children }: any) => <>{children}</>,
+    Button: ({ icon, onClick }: any) => (
+        <button data-testid="delete-btn" onClick={onClick}>{icon}</button>
+    ),
+    Popconfirm: ({ children, onConfirm }: any) => (
+        <span
+            data-testid="popconfirm"
+            onClick={() => onConfirm({ stopPropagation: () => {} })}
+        >
+            {children}
+        </span>
+    ),
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconDelete: () => <svg data-testid="delete-icon" />,
 }));
 
 function render(ui: React.ReactElement, options?: any) {
@@ -101,9 +121,9 @@ describe('ChatSummaryHistory', () => {
         expect(tags[1].dataset.color).toBe('blue');
     });
 
-    it('renders creator, source count, and time alongside badge', async () => {
+    it('renders title, creator, date, and status via SummaryCard', async () => {
         mockListSummaries.mockResolvedValue({
-            items: [makeItem({ creator_name: '李四', sources: [{ source_type: 1, source_id: 's1' }, { source_type: 1, source_id: 's2' }] })],
+            items: [makeItem({ title: '已完成任务', creator_name: '李四', created_at: '2026-01-01T09:30:00Z' })],
         });
 
         await act(async () => {
@@ -117,9 +137,91 @@ describe('ChatSummaryHistory', () => {
             await flushPromises();
         });
 
+        expect(screen.getByText('已完成任务')).toBeInTheDocument();
+        // Subtitle matches the tab: "{name} 发起" with no source count.
         expect(screen.getByText(/李四 发起/)).toBeInTheDocument();
-        expect(screen.getByText(/2 个来源/)).toBeInTheDocument();
+        expect(screen.queryByText(/个来源/)).not.toBeInTheDocument();
+        // Date is the YYYY-MM-DD prefix, not an HH:MM time.
+        expect(screen.getByText('2026-01-01')).toBeInTheDocument();
         expect(screen.getByTestId('status-tag')).toBeInTheDocument();
+    });
+
+    it('falls back to task_no when title is empty', async () => {
+        mockListSummaries.mockResolvedValue({
+            items: [makeItem({ title: '', task_no: 'T999' })],
+        });
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        expect(screen.getByText('T999')).toBeInTheDocument();
+    });
+
+    it('deletes a summary and refreshes the list via chat-summary-deleted event', async () => {
+        mockListSummaries.mockResolvedValue({ items: [makeItem({ task_id: 7 })] });
+        mockDeleteSummary.mockResolvedValue(undefined);
+        const onDeleted = vi.fn();
+        window.addEventListener('chat-summary-deleted', onDeleted as EventListener);
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        await act(async () => {
+            screen.getByTestId('popconfirm').click();
+            await flushPromises();
+        });
+
+        expect(mockDeleteSummary).toHaveBeenCalledWith(7);
+        expect(onDeleted).toHaveBeenCalled();
+        const event = onDeleted.mock.calls[0][0] as CustomEvent;
+        expect(event.detail).toEqual({ channelId: 'ch1' });
+
+        window.removeEventListener('chat-summary-deleted', onDeleted as EventListener);
+    });
+
+    it('shows a toast and keeps the item when delete fails', async () => {
+        mockListSummaries.mockResolvedValue({ items: [makeItem({ task_id: 7 })] });
+        mockDeleteSummary.mockRejectedValue(new Error('boom'));
+        const onDeleted = vi.fn();
+        window.addEventListener('chat-summary-deleted', onDeleted as EventListener);
+
+        await act(async () => {
+            render(
+                <ChatSummaryHistory
+                    channel={channel}
+                    onCreateNew={onCreateNew}
+                    onViewDetail={onViewDetail}
+                />,
+            );
+            await flushPromises();
+        });
+
+        await act(async () => {
+            screen.getByTestId('popconfirm').click();
+            await flushPromises();
+        });
+
+        expect(mockDeleteSummary).toHaveBeenCalledWith(7);
+        expect(mockToastError).toHaveBeenCalledWith('删除失败');
+        expect(onDeleted).not.toHaveBeenCalled();
+
+        window.removeEventListener('chat-summary-deleted', onDeleted as EventListener);
     });
 
     it('does not poll when all items are completed', async () => {

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { render as rtlRender, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatSummaryNewModal from '../ChatSummaryNewModal';
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Modal: ({ children, visible, footer, onCancel }: any) =>
+        visible ? (
+            <div data-testid="modal">
+                <div data-testid="modal-body">{children}</div>
+                <div data-testid="modal-footer">{footer}</div>
+            </div>
+        ) : null,
+    Toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+    Tag: ({ children, closable, onClose }: any) => (
+        <span data-testid="tag">
+            {children}
+            {closable && <button data-testid="tag-close" onClick={onClose}>x</button>}
+        </span>
+    ),
+    Button: ({ children, onClick, disabled, loading, theme, icon, ...rest }: any) => (
+        <button onClick={onClick} disabled={disabled} data-loading={loading} data-theme={theme} {...rest}>
+            {icon}{children}
+        </button>
+    ),
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconPlus: () => <span data-testid="icon-plus" />,
+}));
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: { mittBus: { emit: vi.fn() } },
+    };
+});
+
+vi.mock('../../utils/channelConvert', () => ({
+    channelToChatCandidate: (ch: any) => ({
+        chat_id: ch.channelID,
+        chat_type: 'group',
+        name: 'Test Chat',
+        member_count: null,
+    }),
+}));
+
+vi.mock('../../utils/channelType', () => ({
+    getSourceType: () => 1,
+}));
+
+vi.mock('../../api/summaryApi', () => ({
+    getTopicTemplates: vi.fn().mockResolvedValue([]),
+    createSummary: vi.fn().mockResolvedValue({ task_id: 1 }),
+}));
+
+vi.mock('../TemplateCard', () => ({
+    default: ({ template, onClick }: any) => (
+        <div data-testid={`template-${template.id}`} onClick={() => onClick(template)}>
+            {template.label}
+        </div>
+    ),
+}));
+
+vi.mock('../ChatSelectorModal', () => ({
+    default: () => null,
+}));
+
+vi.mock('../../constants/templates', () => ({
+    TOPIC_TEMPLATES: [
+        { id: 'project_progress', label: '汇总项目进展', icon: 'FileText', description: '总结进展', type: 'parameterized', pattern: '总结 {project_name} 的项目进展', placeholders: [{ key: 'project_name', label: '输入项目名称', position: [3, 9] }] },
+        { id: 'weekly_report', label: '总结团队周报', icon: 'Calendar', description: '总结工作', type: 'fixed', pattern: '总结每周的工作周报' },
+        { id: 'chat_content', label: '总结聊天内容', icon: 'MessageSquare', description: '总结聊天', type: 'fixed', pattern: '总结本群中的关键内容' },
+    ],
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('ChatSummaryNewModal', () => {
+    const defaultProps = {
+        visible: true,
+        channel: { channelID: 'ch1', channelType: 2 },
+        onClose: vi.fn(),
+        onSubmit: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows updated description text', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        expect(screen.getByText('邀请同事一起总结信息，并根据聊天等内容自动总结')).toBeInTheDocument();
+    });
+
+    it('does not contain old description text', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        expect(screen.queryByText('邀请同事一起汇总信息，并根据聊天、文档、会议和邮件等自动总结。')).not.toBeInTheDocument();
+    });
+
+    it('shows templates when input is empty', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        expect(screen.getByText('试试总结')).toBeInTheDocument();
+        expect(screen.getByTestId('template-weekly_report')).toBeInTheDocument();
+        expect(screen.getByTestId('template-chat_content')).toBeInTheDocument();
+    });
+
+    it('hides templates when input has content', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题');
+        fireEvent.change(input, { target: { value: '测试主题' } });
+
+        expect(screen.queryByText('试试总结')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('template-weekly_report')).not.toBeInTheDocument();
+    });
+
+    it('shows templates again when input is cleared', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题');
+        fireEvent.change(input, { target: { value: '测试' } });
+        expect(screen.queryByText('试试总结')).not.toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: '' } });
+        expect(screen.getByText('试试总结')).toBeInTheDocument();
+        expect(screen.getByTestId('template-weekly_report')).toBeInTheDocument();
+    });
+
+    it('renders templates inside the unified input-area container', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const body = screen.getByTestId('modal-body');
+        const inputArea = body.querySelector('.chat-summary-modal-input-area');
+        expect(inputArea).toBeInTheDocument();
+
+        const input = inputArea!.querySelector('.chat-summary-modal-input');
+        expect(input).toBeInTheDocument();
+
+        const templatesLabel = inputArea!.querySelector('.chat-summary-modal-templates-label');
+        expect(templatesLabel).toBeInTheDocument();
+        expect(templatesLabel!.textContent).toBe('试试总结');
+
+        const templatesContainer = inputArea!.querySelector('.chat-summary-modal-templates');
+        expect(templatesContainer).toBeInTheDocument();
+    });
+
+    it('renders templates before chat selector in DOM order', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const body = screen.getByTestId('modal-body');
+        const html = body.innerHTML;
+        const templatesIdx = html.indexOf('template-weekly_report');
+        const chatSelectorIdx = html.indexOf('chat-summary-modal-chat-section');
+        expect(templatesIdx).toBeGreaterThan(-1);
+        expect(chatSelectorIdx).toBeGreaterThan(-1);
+        expect(templatesIdx).toBeLessThan(chatSelectorIdx);
+    });
+
+    it('input-area keeps its structure when templates are hidden', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const body = screen.getByTestId('modal-body');
+        const inputArea = body.querySelector('.chat-summary-modal-input-area');
+        expect(inputArea).toBeInTheDocument();
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题');
+        fireEvent.change(input, { target: { value: '测试' } });
+
+        expect(inputArea!.querySelector('.chat-summary-modal-input')).toBeInTheDocument();
+        expect(inputArea!.querySelector('.chat-summary-modal-templates')).not.toBeInTheDocument();
+    });
+
+    it('parameterized template click sets value with placeholder, then focus removes placeholder text', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const templateCard = screen.getByTestId('template-project_progress');
+        fireEvent.click(templateCard);
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题') as HTMLTextAreaElement;
+        expect(input.value).toBe('总结 输入项目名称 的项目进展');
+
+        await act(async () => {
+            await flushPromises();
+        });
+
+        expect(input.value).toBe('总结  的项目进展');
+    });
+
+    it('fixed template click does not set placeholder range', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const templateCard = screen.getByTestId('template-weekly_report');
+        await act(async () => {
+            fireEvent.click(templateCard);
+            await flushPromises();
+        });
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题') as HTMLTextAreaElement;
+        expect(input.value).toBe('总结每周的工作周报');
+
+        await act(async () => {
+            fireEvent.focus(input);
+            await flushPromises();
+        });
+
+        expect(input.value).toBe('总结每周的工作周报');
+    });
+
+    it('onChange clears placeholder range so subsequent focus does not remove text', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const templateCard = screen.getByTestId('template-project_progress');
+        await act(async () => {
+            fireEvent.click(templateCard);
+            await flushPromises();
+        });
+
+        const input = screen.getByPlaceholderText('输入聊天内你想总结的主题') as HTMLTextAreaElement;
+        fireEvent.change(input, { target: { value: '总结 我的项目 的项目进展' } });
+
+        await act(async () => {
+            fireEvent.focus(input);
+            await flushPromises();
+        });
+
+        expect(input.value).toBe('总结 我的项目 的项目进展');
+    });
+
+    it('footer only contains the submit button', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const footer = screen.getByTestId('modal-footer');
+        expect(footer.textContent).toContain('开始总结');
+        expect(footer.textContent).not.toContain('添加成员');
+        expect(footer.textContent).not.toContain('定时更新');
+        expect(footer.textContent).not.toContain('总结并发到聊天');
+    });
+
+    it('submit button is disabled when input is empty', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        const footer = screen.getByTestId('modal-footer');
+        const submitBtn = footer.querySelector('button');
+        expect(submitBtn).toBeDisabled();
+    });
+
+    it('does not render when not visible', () => {
+        render(<ChatSummaryNewModal {...defaultProps} visible={false} />);
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryPanel.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryPanel.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatSummaryPanel from '../ChatSummaryPanel';
+
+const mockEmit = vi.fn();
+const mockOpenSummaryDetail = vi.fn();
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: {
+            mittBus: { emit: (...args: any[]) => mockEmit(...args) },
+            openSummaryDetail: (...args: any[]) => mockOpenSummaryDetail(...args),
+        },
+    };
+});
+
+vi.mock('lucide-react', () => ({
+    X: () => <svg data-testid="close-icon" />,
+    ChevronLeft: () => <svg data-testid="back-icon" />,
+}));
+
+// 列表组件：暴露一个点击入口触发 onViewDetail，并标记自身是否挂载
+let viewDetailCb: ((taskId: number) => void) | null = null;
+vi.mock('../ChatSummaryHistory', () => ({
+    default: (props: any) => {
+        viewDetailCb = props.onViewDetail;
+        return (
+            <div data-testid="summary-history" data-paused={String(!!props.paused)}>
+                <button onClick={() => props.onViewDetail(42)}>open-detail</button>
+                <button onClick={() => props.onCreateNew()}>create-new</button>
+            </div>
+        );
+    },
+}));
+
+// 详情组件：仅记录收到的 taskId
+vi.mock('../../pages/SummaryDetailPage', () => ({
+    default: (props: any) => (
+        <div data-testid="summary-detail" data-task-id={String(props.taskId)} />
+    ),
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+describe('ChatSummaryPanel', () => {
+    const channel = { channelID: 'ch1', channelType: 2 };
+    const onClose = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        viewDetailCb = null;
+    });
+
+    it('renders the list view by default', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        expect(screen.getByTestId('summary-history')).toBeInTheDocument();
+        expect(screen.queryByTestId('summary-detail')).not.toBeInTheDocument();
+    });
+
+    it('switches to detail view in-panel without closing or routing away', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+
+        fireEvent.click(screen.getByText('open-detail'));
+
+        const detail = screen.getByTestId('summary-detail');
+        expect(detail).toBeInTheDocument();
+        expect(detail.dataset.taskId).toBe('42');
+        // 关键：不关闭侧边栏、不走整页路由
+        expect(onClose).not.toHaveBeenCalled();
+        expect(mockOpenSummaryDetail).not.toHaveBeenCalled();
+    });
+
+    it('keeps the list mounted (hidden) while detail is open to preserve scroll', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        fireEvent.click(screen.getByText('open-detail'));
+
+        // 列表常驻挂载，仅隐藏
+        expect(screen.getByTestId('summary-history')).toBeInTheDocument();
+        expect(screen.getByTestId('summary-detail')).toBeInTheDocument();
+    });
+
+    it('pauses list polling while detail is open', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        expect(screen.getByTestId('summary-history').dataset.paused).toBe('false');
+
+        fireEvent.click(screen.getByText('open-detail'));
+        expect(screen.getByTestId('summary-history').dataset.paused).toBe('true');
+    });
+
+    it('returns to the list view via the back button', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        fireEvent.click(screen.getByText('open-detail'));
+        expect(screen.getByTestId('summary-detail')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('返回'));
+
+        expect(screen.queryByTestId('summary-detail')).not.toBeInTheDocument();
+        expect(screen.getByTestId('summary-history').dataset.paused).toBe('false');
+    });
+
+    it('resets to the list view when the channel changes', () => {
+        const { rerender } = render(
+            <ChatSummaryPanel visible channel={channel} onClose={onClose} />,
+        );
+        fireEvent.click(screen.getByText('open-detail'));
+        expect(screen.getByTestId('summary-detail')).toBeInTheDocument();
+
+        rerender(
+            <ChatSummaryPanel
+                visible
+                channel={{ channelID: 'ch2', channelType: 2 }}
+                onClose={onClose}
+            />,
+        );
+
+        expect(screen.queryByTestId('summary-detail')).not.toBeInTheDocument();
+        expect(screen.getByTestId('summary-history')).toBeInTheDocument();
+    });
+
+    it('closes the panel via the close button in list view', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        fireEvent.click(screen.getByTestId('close-icon').closest('button')!);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits open-summary-modal when creating a new summary', () => {
+        render(<ChatSummaryPanel visible channel={channel} onClose={onClose} />);
+        fireEvent.click(screen.getByText('create-new'));
+        expect(mockEmit).toHaveBeenCalledWith('wk:open-summary-modal', {
+            channelId: 'ch1',
+            channelType: 2,
+        });
+    });
+
+    describe('resizable splitter', () => {
+        beforeEach(() => {
+            localStorage.clear();
+            // 宽屏，保证 400px 不被 50% 可用空间约束 clamp 掉
+            Object.defineProperty(window, 'innerWidth', {
+                value: 1600,
+                configurable: true,
+                writable: true,
+            });
+        });
+
+        it('renders a drag splitter on the left edge', () => {
+            const { container } = render(
+                <ChatSummaryPanel visible channel={channel} onClose={onClose} />,
+            );
+            expect(
+                container.querySelector('.wk-thread-panel-splitter'),
+            ).toBeInTheDocument();
+        });
+
+        it('persists the new width to its own storage key after a drag', () => {
+            const { container } = render(
+                <ChatSummaryPanel visible channel={channel} onClose={onClose} />,
+            );
+            const splitter = container.querySelector(
+                '.wk-thread-panel-splitter',
+            ) as HTMLElement;
+
+            // 起点 360（默认），向左拖 40px → 宽度变 400
+            fireEvent.mouseDown(splitter, { clientX: 1000 });
+            fireEvent.mouseMove(document, { clientX: 960 });
+            fireEvent.mouseUp(document);
+
+            expect(localStorage.getItem('wk-summary-panel-width')).toBe('400');
+            // 不污染 thread 面板宽度
+            expect(localStorage.getItem('wk-thread-panel-width')).toBeNull();
+        });
+
+        it('shows the drag overlay while dragging and removes it after', () => {
+            const { container } = render(
+                <ChatSummaryPanel visible channel={channel} onClose={onClose} />,
+            );
+            const splitter = container.querySelector(
+                '.wk-thread-panel-splitter',
+            ) as HTMLElement;
+
+            fireEvent.mouseDown(splitter, { clientX: 1000 });
+            fireEvent.mouseMove(document, { clientX: 960 });
+            expect(
+                container.querySelector('.wk-thread-panel-drag-overlay'),
+            ).toBeInTheDocument();
+
+            fireEvent.mouseUp(document);
+            expect(
+                container.querySelector('.wk-thread-panel-drag-overlay'),
+            ).not.toBeInTheDocument();
+        });
+
+        it('resets to the default width on double-click', () => {
+            const { container } = render(
+                <ChatSummaryPanel visible channel={channel} onClose={onClose} />,
+            );
+            const splitter = container.querySelector(
+                '.wk-thread-panel-splitter',
+            ) as HTMLElement;
+
+            fireEvent.mouseDown(splitter, { clientX: 1000 });
+            fireEvent.mouseMove(document, { clientX: 960 });
+            fireEvent.mouseUp(document);
+            expect(localStorage.getItem('wk-summary-panel-width')).toBe('400');
+
+            fireEvent.doubleClick(splitter);
+            expect(localStorage.getItem('wk-summary-panel-width')).toBe('360');
+        });
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryStarButton.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryStarButton.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render as rtlRender, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatSummaryStarButton from '../ChatSummaryStarButton';
+
+const mockEmit = vi.fn();
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: { mittBus: { emit: (...args: any[]) => mockEmit(...args) } },
+    };
+});
+
+const mockListSummaries = vi.fn();
+
+vi.mock('../../api/summaryApi', () => ({
+    listSummaries: (...args: any[]) => mockListSummaries(...args),
+}));
+
+vi.mock('lucide-react', () => ({
+    Sparkle: (props: any) => (
+        <svg data-testid="sparkle-icon" data-fill={props.fill} data-color={props.color} />
+    ),
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('ChatSummaryStarButton', () => {
+    const channel = { channelID: 'ch1', channelType: 2 };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders with default icon color', () => {
+        render(<ChatSummaryStarButton channel={channel} />);
+        const icon = screen.getByTestId('sparkle-icon');
+        expect(icon.dataset.fill).toBe('none');
+        expect(icon.dataset.color).toBe('currentColor');
+    });
+
+    it('icon stays default color even when hasSummaries is true', async () => {
+        render(<ChatSummaryStarButton channel={channel} />);
+
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent('chat-summary-created', {
+                    detail: { channelId: 'ch1' },
+                }),
+            );
+        });
+
+        const icon = screen.getByTestId('sparkle-icon');
+        expect(icon.dataset.fill).toBe('none');
+        expect(icon.dataset.color).toBe('currentColor');
+    });
+
+    it('opens summary modal when no summaries exist', async () => {
+        mockListSummaries.mockResolvedValue({ total: 0 });
+        render(<ChatSummaryStarButton channel={channel} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTitle('智能总结'));
+            await flushPromises();
+        });
+
+        expect(mockEmit).toHaveBeenCalledWith('wk:open-summary-modal', {
+            channelId: 'ch1',
+            channelType: 2,
+        });
+    });
+
+    it('opens summary panel when summaries exist', async () => {
+        render(<ChatSummaryStarButton channel={channel} />);
+
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent('chat-summary-created', {
+                    detail: { channelId: 'ch1' },
+                }),
+            );
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTitle('智能总结'));
+            await flushPromises();
+        });
+
+        expect(mockEmit).toHaveBeenCalledWith('wk:toggle-summary-panel', {
+            channelId: 'ch1',
+            channelType: 2,
+            summaryPanelView: 'history',
+        });
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryStarButton.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryStarButton.test.tsx
@@ -13,6 +13,18 @@ vi.mock('@octo/base', async () => {
     };
 });
 
+const mockToastError = vi.fn();
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Toast: { error: (...args: any[]) => mockToastError(...args) },
+}));
+
+const mockIsCancel = vi.fn(() => false);
+
+vi.mock('axios', () => ({
+    default: { isCancel: (...args: any[]) => mockIsCancel(...args) },
+}));
+
 const mockListSummaries = vi.fn();
 
 vi.mock('../../api/summaryApi', () => ({
@@ -38,6 +50,7 @@ describe('ChatSummaryStarButton', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockIsCancel.mockReturnValue(false);
     });
 
     it('renders with default icon color', () => {
@@ -76,6 +89,38 @@ describe('ChatSummaryStarButton', () => {
             channelId: 'ch1',
             channelType: 2,
         });
+    });
+
+    it('does NOT open create modal when count query fails', async () => {
+        mockListSummaries.mockRejectedValue(new Error('500'));
+        render(<ChatSummaryStarButton channel={channel} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTitle('智能总结'));
+            await flushPromises();
+        });
+
+        // Load failure must not be treated as "no summaries".
+        expect(mockEmit).not.toHaveBeenCalledWith('wk:open-summary-modal', expect.anything());
+        expect(mockEmit).not.toHaveBeenCalledWith('wk:toggle-summary-panel', expect.anything());
+        // An error is surfaced to the user instead.
+        expect(mockToastError).toHaveBeenCalledWith('加载失败');
+    });
+
+    it('ignores a cancelled count query (no modal, no toast)', async () => {
+        const cancelErr = { __CANCEL__: true };
+        mockIsCancel.mockImplementation((e: unknown) => e === cancelErr);
+        mockListSummaries.mockRejectedValue(cancelErr);
+        render(<ChatSummaryStarButton channel={channel} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTitle('智能总结'));
+            await flushPromises();
+        });
+
+        expect(mockEmit).not.toHaveBeenCalledWith('wk:open-summary-modal', expect.anything());
+        expect(mockEmit).not.toHaveBeenCalledWith('wk:toggle-summary-panel', expect.anything());
+        expect(mockToastError).not.toHaveBeenCalled();
     });
 
     it('opens summary panel when summaries exist', async () => {

--- a/packages/dmworksummary/src/constants/templates.ts
+++ b/packages/dmworksummary/src/constants/templates.ts
@@ -1,0 +1,47 @@
+import type { LocalTopicTemplate } from '../types/summary';
+
+/**
+ * 前端离线兜底模板：存 i18n key（去 `summary.` 前缀），由 resolveTemplate 在
+ * render() 期按当前 locale 解析为明文，保证切语言即时刷新。
+ * key 层故意与后端模板 `id` 对齐（snake_case），便于按 id 拼接。
+ */
+export const TOPIC_TEMPLATES: LocalTopicTemplate[] = [
+    {
+        id: 'project_progress',
+        icon: 'FileText',
+        type: 'parameterized',
+        labelKey: 'templates.project_progress.label',
+        descriptionKey: 'templates.project_progress.description',
+        patternKey: 'templates.project_progress.pattern',
+        placeholders: [
+            { key: 'project_name', labelKey: 'templates.project_progress.placeholder', position: [3, 9] },
+        ],
+    },
+    {
+        id: 'task_tracking',
+        icon: 'ListChecks',
+        type: 'parameterized',
+        labelKey: 'templates.task_tracking.label',
+        descriptionKey: 'templates.task_tracking.description',
+        patternKey: 'templates.task_tracking.pattern',
+        placeholders: [
+            { key: 'task_name', labelKey: 'templates.task_tracking.placeholder', position: [3, 9] },
+        ],
+    },
+    {
+        id: 'weekly_report',
+        icon: 'Calendar',
+        type: 'fixed',
+        labelKey: 'templates.weekly_report.label',
+        descriptionKey: 'templates.weekly_report.description',
+        patternKey: 'templates.weekly_report.pattern',
+    },
+    {
+        id: 'chat_content',
+        icon: 'MessageSquare',
+        type: 'fixed',
+        labelKey: 'templates.chat_content.label',
+        descriptionKey: 'templates.chat_content.description',
+        patternKey: 'templates.chat_content.pattern',
+    },
+];

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -144,8 +144,7 @@
     "panelTitle": "Summaries in this chat",
     "createNew": "New summary",
     "back": "Back",
-    "starTooltip": "AI Summary",
-    "creatorWithSources": "Created by {{name}} · {{count}} sources"
+    "starTooltip": "AI Summary"
   },
   "templates": {
     "project_progress": {

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -4,8 +4,10 @@
     "cancel": "Cancel",
     "confirm": "OK",
     "createFailed": "Failed to create",
+    "createFailedRetry": "Failed to create. Please try again.",
     "deleteFailed": "Failed to delete",
     "edit": "Edit",
+    "loading": "Loading...",
     "loadingFailed": "Failed to load",
     "operationFailed": "Operation failed",
     "retry": "Retry",
@@ -126,15 +128,48 @@
     "title": "AI Summary",
     "desc": "Invite teammates to summarize information together, with automatic summaries from chats and related content.",
     "topicPlaceholder": "Enter a topic, for example: summarize this week's project progress, organize customer feedback...",
+    "topicPlaceholderInChat": "Enter a topic to summarize in this chat",
+    "templatesTitle": "Try summarizing",
+    "submitting": "Summarizing...",
     "scheduleFailed": "Summary was created, but scheduled updates failed",
     "success": "Summary task created",
     "selectChat": "Select chats",
     "selectedChats": "{{count}} chats selected",
     "start": "Start summary",
-    "templatesTitle": "Try these summary templates",
     "scheduleDaily": "Daily {{time}}",
     "scheduleWeekly": "Every {{day}} {{time}}",
     "scheduleMonthly": "Monthly on day {{day}} {{time}}"
+  },
+  "chatSummary": {
+    "panelTitle": "Summaries in this chat",
+    "createNew": "New summary",
+    "back": "Back",
+    "starTooltip": "AI Summary",
+    "creatorWithSources": "Created by {{name}} · {{count}} sources"
+  },
+  "templates": {
+    "project_progress": {
+      "label": "Summarize project progress",
+      "description": "Summarize progress with your team",
+      "pattern": "Summarize the progress of {project_name}",
+      "placeholder": "Enter project name"
+    },
+    "task_tracking": {
+      "label": "Track task progress",
+      "description": "Invite colleagues to summarize task status",
+      "pattern": "Summarize the status of {task_name}",
+      "placeholder": "Enter task name"
+    },
+    "weekly_report": {
+      "label": "Summarize team weekly report",
+      "description": "Summarize the team's weekly work",
+      "pattern": "Summarize the weekly work report"
+    },
+    "chat_content": {
+      "label": "Summarize chat content",
+      "description": "Summarize what's happening in a chat",
+      "pattern": "Summarize key content in this chat"
+    }
   },
   "chatSelector": {
     "title": "Select chats",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -144,8 +144,7 @@
     "panelTitle": "聊天内的智能总结",
     "createNew": "新建总结",
     "back": "返回",
-    "starTooltip": "智能总结",
-    "creatorWithSources": "{{name}} 发起 · {{count}} 个来源"
+    "starTooltip": "智能总结"
   },
   "templates": {
     "project_progress": {

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -4,8 +4,10 @@
     "cancel": "取消",
     "confirm": "确定",
     "createFailed": "创建失败",
+    "createFailedRetry": "创建失败，请稍后重试",
     "deleteFailed": "删除失败",
     "edit": "编辑",
+    "loading": "加载中...",
     "loadingFailed": "加载失败",
     "operationFailed": "操作失败",
     "retry": "重试",
@@ -126,15 +128,48 @@
     "title": "智能总结",
     "desc": "邀请同事一起总结信息，并根据聊天等内容自动总结",
     "topicPlaceholder": "输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点...",
+    "topicPlaceholderInChat": "输入聊天内你想总结的主题",
+    "templatesTitle": "试试总结",
+    "submitting": "总结中...",
     "scheduleFailed": "总结已创建，但定时更新配置失败",
     "success": "总结任务已创建",
     "selectChat": "选择聊天",
     "selectedChats": "已选 {{count}} 个聊天",
     "start": "开始总结",
-    "templatesTitle": "试试这些总结模板",
     "scheduleDaily": "按天 {{time}}",
     "scheduleWeekly": "每{{day}} {{time}}",
     "scheduleMonthly": "每月{{day}}日 {{time}}"
+  },
+  "chatSummary": {
+    "panelTitle": "聊天内的智能总结",
+    "createNew": "新建总结",
+    "back": "返回",
+    "starTooltip": "智能总结",
+    "creatorWithSources": "{{name}} 发起 · {{count}} 个来源"
+  },
+  "templates": {
+    "project_progress": {
+      "label": "汇总项目进展",
+      "description": "与团队成员一起总结进展",
+      "pattern": "总结 {project_name} 的项目进展",
+      "placeholder": "输入项目名称"
+    },
+    "task_tracking": {
+      "label": "跟踪任务进度",
+      "description": "邀请同事汇总任务完成情况",
+      "pattern": "总结 {task_name} 的完成情况",
+      "placeholder": "输入任务名称"
+    },
+    "weekly_report": {
+      "label": "总结团队周报",
+      "description": "总结团队成员每周的工作",
+      "pattern": "总结每周的工作周报"
+    },
+    "chat_content": {
+      "label": "总结聊天内容",
+      "description": "总结指定聊天中的事情进展",
+      "pattern": "总结本群中的关键内容"
+    }
   },
   "chatSelector": {
     "title": "选择聊天",

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -190,6 +190,13 @@
     font-weight: 500;
 }
 
+/* Sidebar reuses SummaryCard in a narrow column: tighten spacing without dropping fields. */
+.chat-summary-history .summary-card {
+    padding: 12px;
+    border-radius: 8px;
+    margin-bottom: 8px;
+}
+
 /* ========== Create Page ========== */
 .summary-create-header {
     display: flex;

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -1222,9 +1222,12 @@
 
 .summary-workbench-input-area {
     border: 1px solid var(--semi-color-border);
-    border-radius: 12px;
+    border-radius: 8px;
     overflow: hidden;
     margin-bottom: 16px;
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
     background: var(--semi-color-fill-0);
     box-shadow: none;
     transition: border-color 0.2s;
@@ -1233,6 +1236,10 @@
 .summary-workbench-input-area:focus-within {
     border-color: var(--semi-color-primary);
     box-shadow: none;
+}
+
+.summary-workbench-input-area > div:first-child {
+    position: relative;
 }
 
 .summary-workbench-input-area .semi-input-textarea-wrapper {
@@ -1250,10 +1257,17 @@
     background: transparent;
     padding: 12px 16px;
     font-family: inherit;
-    font-size: 15px;
-    line-height: 1.6;
+    font-size: 14px;
+    line-height: 20px;
+    min-height: 40px;
+    max-height: 160px;
+    overflow-y: auto;
     color: var(--semi-color-text-0);
     box-sizing: border-box;
+}
+
+.summary-workbench-textarea::placeholder {
+    color: #999;
 }
 
 .summary-workbench-actions {
@@ -1261,7 +1275,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 10px 16px;
-    border-top: 1px solid var(--semi-color-border);
+    margin-top: auto;
     background: var(--semi-color-fill-0);
 }
 
@@ -1285,64 +1299,18 @@
     flex-wrap: wrap;
 }
 
-.summary-workbench-templates {
-    margin-top: 32px;
-}
-
-.summary-workbench-templates-title {
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--semi-color-text-1);
-    margin-bottom: 16px;
-}
-
-.summary-workbench-template-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-}
-
-.summary-workbench-template-card {
-    display: flex;
-    flex-direction: column;
-    padding: 16px;
-    border: 1px solid var(--semi-color-border);
-    border-radius: 12px;
-    cursor: pointer;
-    background: transparent;
-    transition: all 0.2s;
-    box-shadow: none;
-}
-
-.summary-workbench-template-card:hover {
-    border-color: var(--semi-color-primary);
-    background: var(--semi-color-primary-light-default);
-    box-shadow: none;
-    transform: translateY(-1px);
-}
-
-.summary-workbench-template-card.selected {
-    border-color: var(--semi-color-primary);
-    background: var(--semi-color-primary-light-default);
-    box-shadow: 0 0 0 2px var(--semi-color-primary-light-hover);
-}
-
-.summary-template-card-icon {
-    font-size: 24px;
-    margin-bottom: 8px;
-}
-
-.summary-template-card-title {
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--semi-color-text-0);
-    margin-bottom: 6px;
-}
-
-.summary-template-card-desc {
+.summary-workbench-templates-label {
     font-size: 13px;
-    color: var(--semi-color-text-2);
-    line-height: 1.5;
+    color: var(--semi-color-text-1);
+    margin-bottom: 12px;
+    padding: 0 16px;
+}
+
+.summary-workbench-templates {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 0 16px 12px;
 }
 
 /* ========== Mobile Responsive ========== */
@@ -1446,4 +1414,178 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 500;
+}
+
+/* ========== 侧边栏内详情视图（列表 ↔ 详情 二级导航） ========== */
+.wk-summary-panel-detail {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.wk-summary-panel-detail-back {
+    flex-shrink: 0;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--semi-color-border);
+}
+
+.wk-summary-panel-detail-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px 6px;
+    font-size: 14px;
+    color: var(--semi-color-text-1);
+    border-radius: 6px;
+    transition: background-color 0.15s;
+}
+
+.wk-summary-panel-detail-back-btn:hover {
+    background-color: var(--semi-color-fill-0);
+}
+
+.wk-summary-panel-detail-body {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   侧边栏内详情：按「面板自身宽度」自适应（容器查询），分窄/中/宽三档。
+   旧的视口媒体查询与侧边栏宽度解耦，拖宽后会误触发/失效，故改用
+   @container wk-summary（容器上下文定义在 .wk-summary-panel）。
+   ────────────────────────────────────────────────────────────────── */
+
+/* A. 全宽通用（所有档位都生效）：去掉整页 max-width、长串溢出兜底、按钮换行 */
+.wk-summary-panel-detail .summary-detail-content-inner,
+.wk-summary-panel-detail .summary-detail-header-inner {
+    max-width: 100%;
+}
+
+.wk-summary-panel-detail .summary-detail-header-actions {
+    flex-wrap: wrap;
+}
+
+/* flex 子项默认 min-width:auto 会被长内容撑破，统一兜底 */
+.wk-summary-panel-detail .summary-detail-result-content,
+.wk-summary-panel-detail .summary-detail-content-box,
+.wk-summary-panel-detail .summary-detail-personal-content,
+.wk-summary-panel-detail .summary-detail-result,
+.wk-summary-panel-detail .summary-detail-personal,
+.wk-summary-panel-detail .summary-detail-team,
+.wk-summary-panel-detail .summary-detail-members {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+/* B. 静态 fallback（容器查询不支持的老 WebView）：等同窄档基本收敛 */
+.wk-summary-panel-detail .summary-detail-header-inner {
+    padding: 12px 16px 10px;
+    gap: 8px;
+}
+
+.wk-summary-panel-detail .summary-detail-title {
+    font-size: 17px;
+}
+
+.wk-summary-panel-detail .summary-detail-content-inner {
+    padding: 12px 16px;
+}
+
+/* C. 窄档（面板 ≤ 420px）：纵向堆叠、单列、小字、padding 收敛 */
+@container wk-summary (max-width: 420px) {
+    .wk-summary-panel-detail .summary-detail-content-inner {
+        padding: 12px 14px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-header-inner {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+        padding: 12px 14px 8px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-title {
+        font-size: 16px;
+        line-height: 1.4;
+    }
+
+    /* header 按钮窄屏铺满，避免互相挤压 */
+    .wk-summary-panel-detail .summary-detail-header-actions {
+        gap: 6px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-processing,
+    .wk-summary-panel-detail .summary-detail-failed,
+    .wk-summary-panel-detail .summary-detail-cancelled,
+    .wk-summary-panel-detail .summary-detail-waiting {
+        padding: 32px 16px;
+        margin: 16px 0;
+    }
+
+    .wk-summary-panel-detail .summary-detail-result {
+        padding: 16px 14px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-personal,
+    .wk-summary-panel-detail .summary-detail-team,
+    .wk-summary-panel-detail .summary-detail-members {
+        padding: 16px 14px;
+    }
+
+    /* 两端对齐在窄屏会相撞，改为换行 */
+    .wk-summary-panel-detail .summary-detail-result-header,
+    .wk-summary-panel-detail .summary-detail-result-footer,
+    .wk-summary-panel-detail .summary-detail-section-header {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    /* mode-cards / 网格在窄屏强制单列 */
+    .wk-summary-panel-detail .summary-mode-cards {
+        flex-direction: column;
+    }
+}
+
+/* D. 中档（420 < 面板 ≤ 600px）：恢复横向 header、标题中等字号 */
+@container wk-summary (min-width: 421px) {
+    .wk-summary-panel-detail .summary-detail-title {
+        font-size: 19px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-header-inner {
+        padding: 14px 18px 12px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-content-inner {
+        padding: 16px 18px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-result {
+        padding: 20px 18px;
+    }
+}
+
+/* E. 宽档（面板 > 600px）：接近整页观感 */
+@container wk-summary (min-width: 601px) {
+    .wk-summary-panel-detail .summary-detail-title {
+        font-size: 22px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-header-inner {
+        padding: 18px 24px 16px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-content-inner {
+        padding: 20px 24px;
+    }
+
+    .wk-summary-panel-detail .summary-detail-result {
+        padding: 24px;
+    }
 }

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -1,12 +1,18 @@
-import React from "react";
-import type { IModule } from "@octo/base/src/Service/Module";
-import { i18n, WKApp } from "@octo/base";
+import React, { useState, useEffect } from "react";
+import ReactDOM from "react-dom/client";
+import type { IModule } from "@octo/base";
+import { i18n, I18nProvider, WKApp } from "@octo/base";
 import SummaryListPage from "./pages/SummaryListPage";
 import SummaryCreatePage from "./pages/SummaryCreatePage";
 import SummaryDetailPage from "./pages/SummaryDetailPage";
 import SummaryConfirmPage from "./pages/SummaryConfirmPage";
 import ScheduleListPage from "./pages/ScheduleListPage";
 import { getChatCandidates } from "./api/summaryApi";
+import { notifyChatSummaryCreated } from "./utils/chatSummaryActions";
+import { isSupportedChannelType } from "./utils/channelType";
+import ChatSummaryStarButton from "./components/ChatSummaryStarButton";
+import ChatSummaryPanel from "./components/ChatSummaryPanel";
+import ChatSummaryNewModal from "./components/ChatSummaryNewModal";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 import "./index.css";
@@ -60,6 +66,30 @@ export class SummaryModule implements IModule {
         WKApp.searchChatCandidates = async (params) => {
             return getChatCandidates(params);
         };
+
+        mountGlobalSummaryModal();
+
+        // ═══ Chat window integration ═══
+
+        WKApp.endpoints.registerChannelHeaderRightItem(
+            "channelheader.summary",
+            ({ channel }) => {
+                if (!isSupportedChannelType(channel)) return undefined;
+                return <ChatSummaryStarButton channel={channel} />;
+            },
+            5100,
+        );
+
+        WKApp.endpoints.registerChatSummaryPanel(
+            "chatsummarypanel",
+            ({ channel, onClose }) => (
+                <ChatSummaryPanel
+                    visible={true}
+                    channel={channel}
+                    onClose={onClose}
+                />
+            ),
+        );
     }
 }
 
@@ -69,5 +99,65 @@ if (import.meta.hot) {
             WKApp.mittBus.off('space-changed', _spaceChangedHandler);
             _spaceChangedHandler = null;
         }
+        _globalSummaryModalRoot?.unmount();
+        _globalSummaryModalRoot = null;
+        const el = document.getElementById("summary-global-modal-root");
+        if (el) el.remove();
+        _globalSummaryModalMounted = false;
     });
+}
+
+let _globalSummaryModalMounted = false;
+let _globalSummaryModalRoot: ReturnType<typeof ReactDOM.createRoot> | null = null;
+
+function mountGlobalSummaryModal() {
+    if (_globalSummaryModalMounted) return;
+    _globalSummaryModalMounted = true;
+    const container = document.createElement("div");
+    container.id = "summary-global-modal-root";
+    document.body.appendChild(container);
+    _globalSummaryModalRoot = ReactDOM.createRoot(container);
+    // 独立 root 不在主应用 <I18nProvider> 子树内，须自行包裹，
+    // 否则全局弹窗运行时切语言不会刷新（拿到的是 I18nContext 默认值）。
+    _globalSummaryModalRoot.render(
+        <I18nProvider>
+            <GlobalSummaryModal />
+        </I18nProvider>,
+    );
+}
+
+/**
+ * 聊天上下文里创建总结成功后的收尾动作（实现见 utils/chatSummaryActions，
+ * 拆分到独立文件以便单测不必经过引入 react-dom/client 的本模块）。
+ */
+function GlobalSummaryModal() {
+    const [open, setOpen] = useState(false);
+    const [channel, setChannel] = useState<{ channelID: string; channelType: number } | null>(null);
+
+    useEffect(() => {
+        const handler = (data: { channelId: string; channelType: number }) => {
+            setChannel({ channelID: data.channelId, channelType: data.channelType });
+            setOpen(true);
+        };
+        WKApp.mittBus.on("wk:open-summary-modal", handler);
+        return () => {
+            WKApp.mittBus.off("wk:open-summary-modal", handler);
+        };
+    }, []);
+
+    if (!open || !channel) return null;
+
+    return (
+        <ChatSummaryNewModal
+            visible={open}
+            channel={channel}
+            onClose={() => setOpen(false)}
+            onSubmit={() => {
+                setOpen(false);
+                // 聊天上下文：不切换主 Tab（不调用 openSummaryDetail），
+                // 改为在聊天侧栏内打开/刷新「智能总结」面板展示新建的总结。
+                notifyChatSummaryCreated(channel);
+            }}
+        />
+    );
 }

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -12,19 +12,23 @@ import WKApp from "@octo/base/src/App";
 import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
+import { getTopicTemplates } from "../api/summaryApi";
 import SummaryDetailPage from "./SummaryDetailPage";
 import ChatSelectorModal from "../components/ChatSelectorModal";
 import MemberSelectorModal from "../components/MemberSelectorModal";
 import ScheduleConfigModal from "../components/ScheduleConfigModal";
+import TemplateCard from "../components/TemplateCard";
+import { TOPIC_TEMPLATES } from "../constants/templates";
 import type {
-    SummaryTemplate,
     CreateSummaryParams,
     ChatCandidate,
     MemberCandidate,
     ScheduleConfig,
+    TopicTemplate,
 } from "../types/summary";
 import { SummaryMode, SourceType } from "../types/summary";
 import { getWeekdayName, scheduleToCron } from "../utils/summaryHelpers";
+import { resolveTemplate, computeTemplateSelection, type ResolvableTemplate } from "../utils/templateResolver";
 
 const { Text } = Typography;
 
@@ -34,8 +38,8 @@ interface SummaryCreatePageProps {
 
 interface SummaryCreatePageState {
     topic: string;
-    templates: SummaryTemplate[];
-    selectedTemplateId: string;
+    templates: ResolvableTemplate[];
+    templatePlaceholderRange: [number, number] | null;
     selectedChats: ChatCandidate[];
     selectedMembers: MemberCandidate[];
     scheduleConfig: ScheduleConfig | null;
@@ -46,13 +50,6 @@ interface SummaryCreatePageState {
     error: string | null;
 }
 
-const TEMPLATE_ICONS: Record<string, string> = {
-    project: "📋",
-    tasks: "☰",
-    weekly: "📅",
-    docs: "📄",
-};
-
 export default class SummaryCreatePage extends Component<SummaryCreatePageProps, SummaryCreatePageState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
@@ -61,8 +58,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     state: SummaryCreatePageState = {
         topic: "",
-        templates: [],
-        selectedTemplateId: "",
+        templates: TOPIC_TEMPLATES,
+        templatePlaceholderRange: null,
         selectedChats: [],
         selectedMembers: [],
         scheduleConfig: null,
@@ -74,23 +71,57 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     };
 
     componentDidMount() {
-        this.loadTemplates();
+        void this.loadTemplates();
     }
 
-    async loadTemplates() {
+    private async loadTemplates() {
         try {
-            const templates = await api.getTemplates();
-            this.setState({ templates });
+            const templates = await getTopicTemplates();
+            if (templates.length > 0) {
+                this.setState({ templates });
+            }
         } catch {
-            // non-critical
+            // fallback to constants already in state
         }
     }
 
-    handleTemplateClick = (tpl: SummaryTemplate) => {
-        this.setState({
-            selectedTemplateId: tpl.template_id,
-            topic: this.state.topic || tpl.name,
+    private handleTemplateClick = (template: TopicTemplate) => {
+        const { text, range } = computeTemplateSelection(template);
+
+        if (range) {
+            const [start, end] = range;
+            this.setState({ topic: text, templatePlaceholderRange: [start, end] }, this.autoResizeTextarea);
+
+            setTimeout(() => {
+                const input = this.textareaRef.current;
+                if (!input) return;
+                input.focus();
+                input.setSelectionRange(start, end);
+            }, 0);
+        } else {
+            this.setState({ topic: text, templatePlaceholderRange: null }, this.autoResizeTextarea);
+
+            setTimeout(() => {
+                this.textareaRef.current?.focus();
+            }, 0);
+        }
+    };
+
+    private handleInputFocus = () => {
+        const { templatePlaceholderRange, topic } = this.state;
+        if (!templatePlaceholderRange) return;
+        const [start, end] = templatePlaceholderRange;
+        const newTopic = topic.substring(0, start) + topic.substring(end);
+        this.setState({ topic: newTopic, templatePlaceholderRange: null }, () => {
+            this.textareaRef.current?.setSelectionRange(start, start);
         });
+    };
+
+    autoResizeTextarea = () => {
+        const el = this.textareaRef.current;
+        if (!el) return;
+        el.style.height = "auto";
+        el.style.height = `${el.scrollHeight}px`;
     };
 
     getScheduleLabel(cfg: ScheduleConfig): string {
@@ -113,19 +144,19 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     handleVoiceTranscribed = (text: string, mode: ReplaceMode, savedRange?: SelectionRange) => {
         if (mode === "all") {
-            this.setState({ topic: text.slice(0, 1000) });
+            this.setState({ topic: text.slice(0, 1000) }, this.autoResizeTextarea);
         } else if (mode === "selection" && savedRange) {
             // Note: savedRange indices are from recording start; assumes input is read-only during recording
             this.setState((prev) => {
                 const updated = prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to);
                 return { topic: updated.slice(0, 1000) };
-            });
+            }, this.autoResizeTextarea);
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.topic.length;
                 const updated = prev.topic.slice(0, pos) + text + prev.topic.slice(pos);
                 return { topic: updated.slice(0, 1000) };
-            });
+            }, this.autoResizeTextarea);
         }
     };
 
@@ -190,12 +221,15 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     render() {
         const {
-            topic, templates, selectedTemplateId,
+            topic,
+            templates,
             selectedChats, selectedMembers, scheduleConfig,
             showChatSelector, showMemberSelector, showScheduleConfig,
             submitting, error,
         } = this.state;
         const { t: translate } = this.context;
+        // 模板在 render() 用当前 locale 解析，切语言即时刷新（不在 state 烘焙）。
+        const resolvedTemplates = templates.map((tpl) => resolveTemplate(tpl, translate));
 
         return (
             <div className="summary-workbench">
@@ -217,9 +251,13 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             ref={this.textareaRef}
                             className="summary-workbench-textarea"
                             value={topic}
-                            onChange={(e) => this.setState({ topic: e.target.value.slice(0, 1000) })}
+                            onChange={(e) => {
+                                this.setState({ topic: e.target.value.slice(0, 1000), templatePlaceholderRange: null });
+                                this.autoResizeTextarea();
+                            }}
+                            onFocus={this.handleInputFocus}
                             placeholder={translate("summary.create.topicPlaceholder")}
-                            rows={4}
+                            rows={1}
                             maxLength={1000}
                         />
                         <VoiceInputButton
@@ -232,9 +270,25 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         />
                     </div>
                     {topic.length >= 1000 && (
-                        <div style={{ color: "var(--semi-color-warning)", fontSize: 12, marginTop: 4, padding: "0 12px 8px" }}>
+                        <div style={{ color: "var(--semi-color-warning)", fontSize: 12, marginTop: 4, padding: "0 16px 8px" }}>
                             {translate("summary.common.charLimitReached", { values: { count: 1000 } })}
                         </div>
+                    )}
+
+                    {/* Templates (nested inside the input panel, like the modal) */}
+                    {!topic.trim() && (
+                        <>
+                            <div className="summary-workbench-templates-label">{translate("summary.create.templatesTitle")}</div>
+                            <div className="summary-workbench-templates">
+                                {resolvedTemplates.map((tpl) => (
+                                    <TemplateCard
+                                        key={tpl.id}
+                                        template={tpl}
+                                        onClick={this.handleTemplateClick}
+                                    />
+                                ))}
+                            </div>
+                        </>
                     )}
 
                     {/* Action bar */}
@@ -307,28 +361,6 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                     <Text type="danger" style={{ display: "block", marginTop: 8 }}>
                         {error}
                     </Text>
-                )}
-
-                {/* Template cards */}
-                {templates.length > 0 && (
-                    <div className="summary-workbench-templates">
-                        <div className="summary-workbench-templates-title">{translate("summary.create.templatesTitle")}</div>
-                        <div className="summary-workbench-template-grid">
-                            {templates.map((tpl) => (
-                                <div
-                                    key={tpl.template_id}
-                                    className={`summary-workbench-template-card${selectedTemplateId === tpl.template_id ? " selected" : ""}`}
-                                    onClick={() => this.handleTemplateClick(tpl)}
-                                >
-                                    <div className="summary-template-card-icon">
-                                        {TEMPLATE_ICONS[tpl.template_id] || "📝"}
-                                    </div>
-                                    <div className="summary-template-card-title">{tpl.name}</div>
-                                    <div className="summary-template-card-desc">{tpl.description}</div>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
                 )}
 
                 {/* Modals */}

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render as rtlRender, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SummaryCreatePage from '../SummaryCreatePage';
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: ({ children, onClick, disabled, loading, theme, icon, ...rest }: any) => (
+        <button onClick={onClick} disabled={disabled} data-loading={loading} data-theme={theme} {...rest}>
+            {icon}{children}
+        </button>
+    ),
+    Toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+    Typography: { Text: ({ children }: any) => <span>{children}</span> },
+    Tag: ({ children }: any) => <span data-testid="tag">{children}</span>,
+    Avatar: ({ children }: any) => <span data-testid="avatar">{children}</span>,
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconPlus: () => <span data-testid="icon-plus" />,
+}));
+
+vi.mock('../../api/summaryApi', () => ({
+    createSummary: vi.fn().mockResolvedValue({ task_id: 1 }),
+    createSchedule: vi.fn().mockResolvedValue({}),
+    getTopicTemplates: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../SummaryDetailPage', () => ({ default: () => null }));
+vi.mock('../../components/ChatSelectorModal', () => ({ default: () => null }));
+vi.mock('../../components/MemberSelectorModal', () => ({ default: () => null }));
+vi.mock('../../components/ScheduleConfigModal', () => ({ default: () => null }));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('SummaryCreatePage templates', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the four fallback template cards when topic is empty', async () => {
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        expect(screen.getByText('试试总结')).toBeInTheDocument();
+        expect(screen.getByText('汇总项目进展')).toBeInTheDocument();
+        expect(screen.getByText('跟踪任务进度')).toBeInTheDocument();
+        expect(screen.getByText('总结团队周报')).toBeInTheDocument();
+        expect(screen.getByText('总结聊天内容')).toBeInTheDocument();
+    });
+
+    it('hides templates once the topic has content', async () => {
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        const textarea = document.querySelector('.summary-workbench-textarea') as HTMLTextAreaElement;
+        await act(async () => {
+            fireEvent.change(textarea, { target: { value: '总结本周进展' } });
+        });
+
+        expect(screen.queryByText('试试总结')).not.toBeInTheDocument();
+        expect(screen.queryByText('汇总项目进展')).not.toBeInTheDocument();
+    });
+
+    it('fills the topic from a fixed template on click', async () => {
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('总结团队周报'));
+        });
+
+        const textarea = document.querySelector('.summary-workbench-textarea') as HTMLTextAreaElement;
+        expect(textarea.value).toBe('总结每周的工作周报');
+        // templates hidden after selection
+        expect(screen.queryByText('试试总结')).not.toBeInTheDocument();
+    });
+
+    it('fills the topic frame from a parameterized template', async () => {
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('汇总项目进展'));
+        });
+
+        const textarea = document.querySelector('.summary-workbench-textarea') as HTMLTextAreaElement;
+        // The auto-focus clears the selected placeholder, leaving the pattern frame.
+        expect(textarea.value).toContain('的项目进展');
+        expect(textarea.value.startsWith('总结')).toBe(true);
+    });
+});

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -126,6 +126,8 @@ export interface SummaryListItem {
     participants?: Participant[];
     total_msg_count: number;
     creator_name?: string;
+    origin_channel_id: string;
+    origin_channel_type: number;
     created_at: string;
     completed_at: string | null;
 }
@@ -145,6 +147,8 @@ export interface SummaryDetail {
     result: SummaryResult | null;
     error_message: string | null;
     schedule_id?: number;
+    origin_channel_id: string;
+    origin_channel_type: number;
     created_at: string;
     updated_at: string;
     result_id?: number;
@@ -158,12 +162,14 @@ export interface SummaryDetail {
 /** 创建请求 */
 export interface CreateSummaryParams {
     topic: string;
-    title: string;
+    title?: string;
     summary_mode?: SummaryModeType;
     time_range?: TimeRange;
     sources?: SourceItem[];
     participants?: { user_id: string }[];
     confirm_timeout_hours?: number;
+    origin_channel_id?: string;
+    origin_channel_type?: number;
 }
 
 /** 列表查询参数 */
@@ -178,14 +184,13 @@ export interface ListSummariesParams {
     created_before?: string;
     trigger_type?: number;
     keyword?: string;
+    origin_channel_id?: string;
 }
 
 /** 列表响应 */
 export interface ListSummariesResponse {
     items: SummaryListItem[];
     total: number;
-    page: number;
-    page_size: number;
 }
 
 /** 定时配置 */
@@ -281,4 +286,43 @@ export interface ScheduleConfig {
     dayOfWeek?: number;   // 1=Mon, 2=Tue, ..., 7=Sun (ISO weekday)
     dayOfMonth?: number;  // 1..28
     time: string;         // "HH:MM"
+}
+
+/** 主题模板占位符 */
+export interface TopicTemplatePlaceholder {
+    key: string;
+    label: string;
+    position?: [number, number];
+}
+
+/** 主题模板 */
+export interface TopicTemplate {
+    id: string;
+    label: string;
+    icon: string;
+    description: string;
+    type: 'fixed' | 'parameterized';
+    pattern: string;
+    placeholders?: TopicTemplatePlaceholder[];
+}
+
+/** 前端兜底主题模板占位符（存 i18n key，渲染期解析为明文） */
+export interface LocalTopicTemplatePlaceholder {
+    key: string;
+    labelKey: string;
+    position?: [number, number];
+}
+
+/**
+ * 前端离线兜底模板：字段存 i18n key 而非明文，进组件后由 resolveTemplate
+ * 在 render() 期用当前 locale 解析为明文 TopicTemplate，保证切语言即时刷新。
+ */
+export interface LocalTopicTemplate {
+    id: string;
+    icon: string;
+    type: 'fixed' | 'parameterized';
+    labelKey: string;
+    descriptionKey: string;
+    patternKey: string;
+    placeholders?: LocalTopicTemplatePlaceholder[];
 }

--- a/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@octo/base', () => ({
+    ChannelTypeCommunityTopic: 5,
+    parseThreadChannelId: (channelId: string) => {
+        const parts = channelId.split('____');
+        if (parts.length !== 2) return null;
+        return { groupNo: parts[0], shortId: parts[1] };
+    },
+}));
+
+vi.mock('wukongimjssdk', () => {
+    const Channel = class {
+        channelID: string;
+        channelType: number;
+        constructor(id: string, type: number) {
+            this.channelID = id;
+            this.channelType = type;
+        }
+    };
+    return {
+        default: {
+            shared: () => ({
+                channelManager: {
+                    getChannelInfo: (ch: any) => {
+                        if (ch.channelID === 'unknown-channel') return null;
+                        return { title: `Name of ${ch.channelID}`, orgData: { member_count: 10 } };
+                    },
+                },
+            }),
+        },
+        Channel,
+        ChannelTypeGroup: 2,
+        ChannelTypePerson: 1,
+    };
+});
+
+import { channelToChatCandidate } from '../channelConvert';
+
+describe('channelToChatCandidate', () => {
+    it('converts a group channel', () => {
+        const result = channelToChatCandidate({ channelID: 'group1', channelType: 2 });
+        expect(result).toEqual({
+            chat_id: 'group1',
+            chat_type: 'group',
+            name: 'Name of group1',
+            member_count: 10,
+        });
+    });
+
+    it('converts a person channel to direct', () => {
+        const result = channelToChatCandidate({ channelID: 'user1', channelType: 1 });
+        expect(result).toEqual({
+            chat_id: 'user1',
+            chat_type: 'direct',
+            name: 'Name of user1',
+            member_count: 10,
+        });
+    });
+
+    it('converts a community topic channel to thread', () => {
+        const result = channelToChatCandidate({ channelID: 'topic1', channelType: 5 });
+        expect(result).toEqual({
+            chat_id: 'topic1',
+            chat_type: 'thread',
+            name: 'Name of topic1',
+            member_count: 10,
+        });
+    });
+
+    it('detects thread from channelID with ____ separator', () => {
+        const result = channelToChatCandidate({ channelID: 'group1____thread1', channelType: 2 });
+        expect(result.chat_type).toBe('thread');
+    });
+
+    it('falls back to channelID when channelInfo is null', () => {
+        const result = channelToChatCandidate({ channelID: 'unknown-channel', channelType: 2 });
+        expect(result.name).toBe('unknown-channel');
+        expect(result.member_count).toBeNull();
+    });
+
+    it('defaults unknown channelType to group', () => {
+        const result = channelToChatCandidate({ channelID: 'ch1', channelType: 99 });
+        expect(result.chat_type).toBe('group');
+    });
+});

--- a/packages/dmworksummary/src/utils/__tests__/channelType.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/channelType.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@octo/base', () => ({
+    ChannelTypeCommunityTopic: 5,
+    parseThreadChannelId: (channelId: string) => {
+        const parts = channelId.split('____');
+        if (parts.length !== 2) return null;
+        return { groupNo: parts[0], shortId: parts[1] };
+    },
+    WKApp: {
+        loginInfo: { token: 'test-token', uid: 'test-uid' },
+        shared: { currentSpaceId: 'space-123', logout: () => {} },
+    },
+}));
+
+vi.mock('wukongimjssdk', () => ({
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+}));
+
+import { isSupportedChannelType, getSourceType } from '../channelType';
+
+describe('channelType utils', () => {
+    describe('isSupportedChannelType', () => {
+        it('returns true for channelType 1 (Person)', () => {
+            expect(isSupportedChannelType({ channelType: 1 })).toBe(true);
+        });
+
+        it('returns true for channelType 2 (Group)', () => {
+            expect(isSupportedChannelType({ channelType: 2 })).toBe(true);
+        });
+
+        it('returns true for channelType 5 (CommunityTopic)', () => {
+            expect(isSupportedChannelType({ channelType: 5 })).toBe(true);
+        });
+
+        it('returns false for channelType 3 (CustomerService)', () => {
+            expect(isSupportedChannelType({ channelType: 3 })).toBe(false);
+        });
+
+        it('returns false for channelType 4', () => {
+            expect(isSupportedChannelType({ channelType: 4 })).toBe(false);
+        });
+
+        it('returns false for channelType 99', () => {
+            expect(isSupportedChannelType({ channelType: 99 })).toBe(false);
+        });
+    });
+
+    describe('getSourceType', () => {
+        it('maps channelType=2 (Group) to GROUP_CHAT (1)', () => {
+            expect(getSourceType({ channelType: 2, channelID: 'group123' })).toBe(1);
+        });
+
+        it('maps channelType=1 (Person) to DIRECT_MESSAGE (3)', () => {
+            expect(getSourceType({ channelType: 1, channelID: 'user456' })).toBe(3);
+        });
+
+        it('maps channelType=5 (CommunityTopic) to THREAD (2)', () => {
+            expect(getSourceType({ channelType: 5, channelID: 'topic789' })).toBe(2);
+        });
+
+        it('maps channelID with ____ separator to THREAD (2) regardless of channelType', () => {
+            expect(getSourceType({ channelType: 2, channelID: 'group1____thread1' })).toBe(2);
+        });
+
+        it('returns null for unsupported channelType 99', () => {
+            expect(getSourceType({ channelType: 99, channelID: 'unknown' })).toBeNull();
+        });
+    });
+});

--- a/packages/dmworksummary/src/utils/__tests__/templateResolver.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/templateResolver.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTemplate, computeTemplateSelection } from '../templateResolver';
+import { TOPIC_TEMPLATES } from '../../constants/templates';
+import type { TopicTemplate } from '../../types/summary';
+
+// 读 zh-CN 资源的简易 t（与 dmworkBase mock 行为一致）：把 `summary.<path>` 映射到明文。
+import zhCN from '../../i18n/zh-CN.json';
+import enUS from '../../i18n/en-US.json';
+
+type MessageNode = string | { [key: string]: MessageNode };
+
+function flatten(messages: Record<string, MessageNode>, prefix = ''): Record<string, string> {
+    return Object.entries(messages).reduce<Record<string, string>>((acc, [key, value]) => {
+        const nextKey = prefix ? `${prefix}.${key}` : key;
+        if (typeof value === 'string') acc[nextKey] = value;
+        else Object.assign(acc, flatten(value, nextKey));
+        return acc;
+    }, {});
+}
+
+function makeT(locale: 'zh-CN' | 'en-US') {
+    const source = locale === 'zh-CN' ? zhCN : enUS;
+    const messages = Object.entries(flatten(source as Record<string, MessageNode>)).reduce<Record<string, string>>(
+        (acc, [key, value]) => {
+            acc[`summary.${key}`] = value;
+            return acc;
+        },
+        {},
+    );
+    return (key: string, options?: { values?: Record<string, unknown>; defaultValue?: string }) =>
+        messages[key] ?? options?.defaultValue ?? key;
+}
+
+describe('resolveTemplate', () => {
+    it('resolves every built-in template id to non-key cleartext (zh-CN)', () => {
+        const t = makeT('zh-CN');
+        for (const tpl of TOPIC_TEMPLATES) {
+            const resolved = resolveTemplate(tpl, t);
+            // 解析结果必须是明文，而非回显 key（拼接 key 不被 i18n:check 收集，这里兜底）。
+            expect(resolved.label.startsWith('templates.')).toBe(false);
+            expect(resolved.label).not.toContain('.label');
+            expect(resolved.description).not.toContain('.description');
+            expect(resolved.pattern).not.toContain('.pattern');
+            for (const ph of resolved.placeholders ?? []) {
+                expect(ph.label).not.toContain('.placeholder');
+            }
+        }
+    });
+
+    it('resolves to localized English text (en-US)', () => {
+        const t = makeT('en-US');
+        const project = resolveTemplate(
+            TOPIC_TEMPLATES.find((x) => x.id === 'project_progress')!,
+            t,
+        );
+        expect(project.label).toBe('Summarize project progress');
+        expect(project.pattern).toBe('Summarize the progress of {project_name}');
+        expect(project.placeholders?.[0].label).toBe('Enter project name');
+    });
+
+    it('passes through already-cleartext backend templates unchanged', () => {
+        const backend: TopicTemplate = {
+            id: 'project_progress',
+            label: '后端明文标题',
+            icon: 'FileText',
+            description: '后端明文描述',
+            type: 'parameterized',
+            pattern: '总结 {project_name} 的项目进展',
+            placeholders: [{ key: 'project_name', label: '项目', position: [3, 9] }],
+        };
+        const resolved = resolveTemplate(backend, makeT('en-US'));
+        expect(resolved).toBe(backend);
+    });
+});
+
+describe('computeTemplateSelection', () => {
+    it('locates the placeholder token in the zh-CN pattern → [3, 9]', () => {
+        const t = makeT('zh-CN');
+        const resolved = resolveTemplate(
+            TOPIC_TEMPLATES.find((x) => x.id === 'project_progress')!,
+            t,
+        );
+        const { text, range } = computeTemplateSelection(resolved);
+        expect(text).toBe('总结 输入项目名称 的项目进展');
+        expect(range).toEqual([3, 9]);
+    });
+
+    it('locates the placeholder token in the en-US pattern → [26, 44]', () => {
+        const t = makeT('en-US');
+        const resolved = resolveTemplate(
+            TOPIC_TEMPLATES.find((x) => x.id === 'project_progress')!,
+            t,
+        );
+        const { text, range } = computeTemplateSelection(resolved);
+        expect(text).toBe('Summarize the progress of Enter project name');
+        expect(range).toEqual([26, 44]);
+    });
+
+    it('returns null range for fixed templates and replaces no token', () => {
+        const t = makeT('zh-CN');
+        const resolved = resolveTemplate(
+            TOPIC_TEMPLATES.find((x) => x.id === 'weekly_report')!,
+            t,
+        );
+        const { text, range } = computeTemplateSelection(resolved);
+        expect(text).toBe('总结每周的工作周报');
+        expect(range).toBeNull();
+    });
+
+    it('replaces all placeholder tokens (no residual {key}) for multi-placeholder patterns', () => {
+        const multi: TopicTemplate = {
+            id: 'multi',
+            label: 'x',
+            icon: 'FileText',
+            description: 'x',
+            type: 'parameterized',
+            pattern: '{a} 和 {b}',
+            placeholders: [
+                { key: 'a', label: 'AA' },
+                { key: 'b', label: 'BB' },
+            ],
+        };
+        const { text, range } = computeTemplateSelection(multi);
+        expect(text).toBe('AA 和 BB');
+        expect(range).toEqual([0, 2]);
+    });
+});

--- a/packages/dmworksummary/src/utils/channelConvert.ts
+++ b/packages/dmworksummary/src/utils/channelConvert.ts
@@ -1,0 +1,34 @@
+import { ChannelTypeCommunityTopic, parseThreadChannelId } from '@octo/base';
+import { ChannelTypeGroup, ChannelTypePerson } from 'wukongimjssdk';
+import WKSDK from 'wukongimjssdk';
+import { Channel } from 'wukongimjssdk';
+import type { ChatCandidate } from '../types/summary';
+
+export function channelToChatCandidate(channel: {
+    channelID: string;
+    channelType: number;
+}): ChatCandidate {
+    const ch = new Channel(channel.channelID, channel.channelType);
+    const info = WKSDK.shared().channelManager.getChannelInfo(ch);
+
+    let chatType: ChatCandidate['chat_type'];
+    if (
+        channel.channelType === ChannelTypeCommunityTopic ||
+        parseThreadChannelId(channel.channelID)
+    ) {
+        chatType = 'thread';
+    } else if (channel.channelType === ChannelTypeGroup) {
+        chatType = 'group';
+    } else if (channel.channelType === ChannelTypePerson) {
+        chatType = 'direct';
+    } else {
+        chatType = 'group';
+    }
+
+    return {
+        chat_id: channel.channelID,
+        chat_type: chatType,
+        name: info?.title || channel.channelID,
+        member_count: (info?.orgData as any)?.member_count ?? null,
+    };
+}

--- a/packages/dmworksummary/src/utils/channelType.ts
+++ b/packages/dmworksummary/src/utils/channelType.ts
@@ -1,0 +1,22 @@
+import { ChannelTypeCommunityTopic, parseThreadChannelId } from '@octo/base';
+import { ChannelTypeGroup, ChannelTypePerson } from 'wukongimjssdk';
+import { SourceType } from '../types/summary';
+
+export function isSupportedChannelType(channel: { channelType: number }): boolean {
+    return channel.channelType === ChannelTypePerson
+        || channel.channelType === ChannelTypeGroup
+        || channel.channelType === ChannelTypeCommunityTopic;
+}
+
+export function getSourceType(channel: { channelType: number; channelID: string }): number | null {
+    if (channel.channelType === ChannelTypeCommunityTopic || parseThreadChannelId(channel.channelID)) {
+        return SourceType.THREAD;
+    }
+    if (channel.channelType === ChannelTypeGroup) {
+        return SourceType.GROUP_CHAT;
+    }
+    if (channel.channelType === ChannelTypePerson) {
+        return SourceType.DIRECT_MESSAGE;
+    }
+    return null;
+}

--- a/packages/dmworksummary/src/utils/chatSummaryActions.ts
+++ b/packages/dmworksummary/src/utils/chatSummaryActions.ts
@@ -1,0 +1,21 @@
+import { WKApp } from '@octo/base';
+
+/**
+ * 聊天上下文里创建总结成功后的收尾动作。
+ *
+ * 关键点：聊天侧栏创建总结后**不应**调用 `WKApp.openSummaryDetail`——后者会无条件
+ * `switchToMenuById("summary")`，把用户从聊天踢到「智能总结」主 Tab。这里改为只在
+ * 聊天侧栏内打开/刷新「智能总结」面板。`forceOpen` 保证面板已打开时不会被 toggle 关闭；
+ * 新任务由 ChatSummaryNewModal 派发的 window 'chat-summary-created' 事件驱动列表刷新。
+ */
+export function notifyChatSummaryCreated(channel: {
+    channelID: string;
+    channelType: number;
+}): void {
+    WKApp.mittBus.emit('wk:toggle-summary-panel', {
+        channelId: channel.channelID,
+        channelType: channel.channelType,
+        summaryPanelView: 'history',
+        forceOpen: true,
+    });
+}

--- a/packages/dmworksummary/src/utils/templateResolver.ts
+++ b/packages/dmworksummary/src/utils/templateResolver.ts
@@ -1,0 +1,73 @@
+import type {
+    LocalTopicTemplate,
+    TopicTemplate,
+    TopicTemplatePlaceholder,
+} from '../types/summary';
+
+type TranslateFn = (key: string, options?: { values?: Record<string, unknown>; defaultValue?: string }) => string;
+
+/** 解析期接受两态：前端兜底 LocalTopicTemplate（含 *Key）或后端明文 TopicTemplate。 */
+export type ResolvableTemplate = LocalTopicTemplate | TopicTemplate;
+
+/** 以 `labelKey` 是否存在判别是否为前端兜底（需解析 i18n key）类型。 */
+function isLocalTemplate(template: ResolvableTemplate): template is LocalTopicTemplate {
+    return typeof (template as LocalTopicTemplate).labelKey === 'string';
+}
+
+/**
+ * 把模板解析为已本地化的明文 TopicTemplate。
+ * - LocalTopicTemplate（含 *Key）：用 `summary.` 前缀的 key 经 `t` 解析为明文。
+ * - 已是明文 TopicTemplate（无 *Key，来自后端或测试 inline mock）：原样透传。
+ *
+ * render() 里对 state 中的模板统一过一遍即可，调用方无需先分流。
+ */
+export function resolveTemplate(template: ResolvableTemplate, t: TranslateFn): TopicTemplate {
+    if (!isLocalTemplate(template)) {
+        return template;
+    }
+    const placeholders: TopicTemplatePlaceholder[] | undefined = template.placeholders?.map((ph) => ({
+        key: ph.key,
+        label: t(`summary.${ph.labelKey}`),
+        position: ph.position,
+    }));
+    return {
+        id: template.id,
+        icon: template.icon,
+        type: template.type,
+        label: t(`summary.${template.labelKey}`),
+        description: t(`summary.${template.descriptionKey}`),
+        pattern: t(`summary.${template.patternKey}`),
+        placeholders,
+    };
+}
+
+/**
+ * 基于已本地化的明文模板，生成填入输入框的文本与首个 placeholder 选区。
+ * - text：把全部 placeholder 的 `{key}` token 依次替换成对应 label（与原 applyTemplate 一致），
+ *   避免多 placeholder 模板残留未替换 token。
+ * - range：在本地化 pattern 中定位首个 placeholder 的 token，得到 [tokenStart, tokenStart+label.length]；
+ *   token 找不到时回退到 placeholder.position（后端老数据兜底），仍无则 null。
+ */
+export function computeTemplateSelection(template: TopicTemplate): {
+    text: string;
+    range: [number, number] | null;
+} {
+    const pattern = template.pattern;
+    const placeholders = template.placeholders ?? [];
+
+    let text = pattern;
+    for (const ph of placeholders) {
+        text = text.replace(`{${ph.key}}`, ph.label);
+    }
+
+    if (template.type !== 'parameterized' || placeholders.length === 0) {
+        return { text, range: null };
+    }
+
+    const first = placeholders[0];
+    const tokenStart = pattern.indexOf(`{${first.key}}`);
+    if (tokenStart !== -1) {
+        return { text, range: [tokenStart, tokenStart + first.label.length] };
+    }
+    return { text, range: first.position ?? null };
+}

--- a/packages/dmworksummary/vitest.config.ts
+++ b/packages/dmworksummary/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       { find: /^@octo\/base\/src\/EndpointCommon$/, replacement: path.resolve(__dirname, 'src/__mocks__/EndpointCommon.ts') },
       { find: /^@octo\/base\/src\/Service\/Const$/, replacement: path.resolve(__dirname, 'src/__mocks__/Const.ts') },
       { find: /^@octo\/base\/src\/App$/, replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
+      { find: /^@octo\/base\/src\/Components\/WKLayout\/layoutWidth$/, replacement: path.resolve(root, 'packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts') },
       { find: '@octo/base', replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
       { find: /^react-dom\/(.*)/, replacement: path.resolve(pnpm, 'react-dom@17.0.2_react@17.0.2/node_modules/react-dom') + '/$1' },
       { find: /^react-dom$/, replacement: path.resolve(pnpm, 'react-dom@17.0.2_react@17.0.2/node_modules/react-dom') },


### PR DESCRIPTION
Closes #129

## Summary

Adds the chat-window smart summary feature to octo-web: a new `dmworksummary` module (types, API client, utilities, UI components), in-sidebar list/detail navigation, a resizable panel with container-query detail layout, full i18n (en-US / zh-CN), and chat-window integration. Backend counterpart: Mininglamp-OSS/octo-smart-summary#61.

## Review feedback — status & clarifications

We went through every point raised in review. Some were real and are now fixed; several were investigated against the actual code (frontend + backend) and turned out to be non-issues or based on a misreading. Details below so they don't get re-filed.

### Fixed

- **Star button treats query failure as "no summaries" (P1).** `fetchSummaryCount` used to swallow non-cancel errors and return `false`, so a network/server failure routed the user into creating a duplicate summary. Now it distinguishes `ok` / `cancelled` / `failed`: a failed count query shows an error toast and does **not** open the create modal; the create flow only triggers on a genuine `total === 0`.
- **Request cancellation swallowed by the API wrapper.** `summaryApi` helpers re-wrapped every axios error in a new `Error`, erasing the cancellation identity so callers could not use `axios.isCancel`. The helpers now rethrow the original error on cancellation; only genuine errors are wrapped. (This also underpins the star-button fix.)

### Not a defect / clarification (please read before re-raising)

- **"Stale summaries on channel switch."** Not reproducible on the normal path. `ChatContentPage` is rendered with `key={channel.getChannelKey()}` (see `EndpointCommon`), so switching conversations unmounts and remounts the whole subtree — including `ChatSummaryPanel` / `ChatSummaryHistory` — which re-runs `loadHistory()`. The panel does not persist across channel switches, so `componentDidUpdate` not comparing `channelID` does not cause stale data. (A defensive in-component channel check is a reasonable hardening follow-up, but it is not a live bug.)

- **"`origin_channel_type` sends the wrong value — should be `channel.channelType`."** This recommendation is inverted and would introduce a bug. `getSourceType()` returns the **SourceType** enum (group=1 / thread=2 / DM=3), which is exactly the value space the backend expects for `origin_channel_type` (`OriginChannelGroup=1` / `Thread=2` / `DM=3`). The raw WK `channel.channelType` uses a **different** space (person=1 / group=2 / thread=5). Sending `channel.channelType` would mis-map DMs as groups and send `5` for threads, which exceeds the backend's `[1,3]` validation and returns HTTP 400 for thread-created summaries. The numeric value sent today is correct. We have only renamed/commented for clarity and added a mapping unit test; the wire value is unchanged on purpose.

- **"Missing `title` in chat-created payload."** Not a defect. The backend `CreateSummary` handler derives the title from `topic` when `title` is empty (`title := req.Title; if title == "" { title = req.Topic }`), and `title` is optional in the contract. Chat-created summaries get a correct title. (We can mirror `SummaryCreatePage` and send `title` for consistency as a trivial follow-up, but it is not required for correctness.)

- **"List/count queries should also filter by `origin_channel_type`."** The current backend `ListSummaries` filters only by `origin_channel_id` and does not accept `origin_channel_type`, so adding the parameter on the frontend now would be inert (silently ignored) and create the false impression that type-scoped filtering is in effect. The correct sequence is: add `origin_channel_type` support in the backend first, then pass it from the frontend. Tracked as a backend follow-up; not changed in this PR to avoid a misleading no-op.

### Non-blocking follow-ups (acknowledged, deferred)

- Cancellation edge already addressed by the `summaryApi` fix above.
- Hardcoded hover colors → design tokens.
- `summaryPanelView` dead state (written, not consumed) → remove or wire through.
- Storybook stories for the new components.
- `clampSummaryWidth` uses the default left-panel width instead of the live resizable width (off by up to ~70px).
- `getTemplates` no longer has a caller in this package → remove in a follow-up.
- Deploy ordering: chat-scoping relies on backend #61 — merge/deploy backend first or together.

### Investigated and confirmed NOT issues

- `editSummary` error type annotation is already correct for the field actually read.
- Parameterized-template focus/selection logic behaves as intended (covered by tests).

## Testing

- `dmworksummary` unit tests pass (incl. new negative-path tests for the star button and cancellation preservation).
- Production Vite build passes.

