### PR TITLE
fix(App): eliminate clientMsgDeviceId=0 race via sessionStorage cache (closes #256, depends on #255)

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -910,7 +910,7 @@ export default class WKApp extends ProviderListener {
     // Plan F Task 9 hardening: clearLocalLoginState performs raw
     // localStorage/sessionStorage writes (via StorageService) that throw in
     // Safari private mode, on QuotaExceededError, or under SecurityError.
-    // Without the try/finally, a throw here would leave loggingOut=true
+    // Without the try/catch, a throw here would leave loggingOut=true
     // forever AND skip the reload — every subsequent logout attempt
     // short-circuits and the user is permanently wedged. The reload must
     // happen regardless so the next bootstrap can detect the broken auth

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -861,6 +861,15 @@ export default class WKApp extends ProviderListener {
         // messages then build clientMsgNo as "<uuid>_0_3" instead of
         // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
         // which breaks per-device message dedup and cross-device tracking.
+        if (err?.code !== "err.server.user.device_not_found") {
+          // Non-stale device errors fall through to existing handling paths
+          // (auth interceptor / silent failure). Log once for observability
+          // so future regressions on this endpoint are not hidden.
+          console.warn(
+            "[App.startMain] /user/devices fetch failed (non-stale):",
+            { status: err?.status, code: err?.code, msg: err?.msg },
+          );
+        }
         handleDeviceFetchError(err, {
           removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
           resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -872,6 +872,14 @@ export default class WKApp extends ProviderListener {
     // (Plan F) for stale device; non-stale errors are logged and we proceed
     // with the SDK default clientMsgDeviceId=0 (current pre-#256 behavior).
     await this.awaitDeviceIdOrTimeout(5000);
+    // Task E guard: if the await resolved because Plan F's interceptor fired
+    // (stale device → staleLocalResourceCallback → WKApp.shared.logout()),
+    // `loggingOut` is now true and a reload is pending. Continuing to call
+    // connectIM / contactsSync / prohibitWordsSync here would fire requests
+    // against the just-cleared token (token/uid emptied by clearLocalLoginState),
+    // returning 401 and producing unhandled Uncaught (in promise) noise.
+    // Short-circuit instead — the pending reload will reset the page.
+    if (this.loggingOut) return;
     this.connectIM();
     WKApp.dataSource.contactsSync();
     ProhibitwordsService.shared.sync();

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -907,7 +907,19 @@ export default class WKApp extends ProviderListener {
     // a real page reload resets the flag.
     if (this.loggingOut) return;
     this.loggingOut = true;
-    this.clearLocalLoginState();
+    // Plan F Task 9 hardening: clearLocalLoginState performs raw
+    // localStorage/sessionStorage writes (via StorageService) that throw in
+    // Safari private mode, on QuotaExceededError, or under SecurityError.
+    // Without the try/finally, a throw here would leave loggingOut=true
+    // forever AND skip the reload — every subsequent logout attempt
+    // short-circuits and the user is permanently wedged. The reload must
+    // happen regardless so the next bootstrap can detect the broken auth
+    // state and route to login.
+    try {
+      this.clearLocalLoginState();
+    } catch (e) {
+      console.warn("[WKApp.logout] clearLocalLoginState threw, reloading anyway", e);
+    }
     window.location.reload();
   }
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -630,6 +630,7 @@ export default class WKApp extends ProviderListener {
 
   private wsaddrs = new Array<string>(); // ws的连接地址
   private addrUsed = false; // 地址是否被使用
+  private loggingOut = false; // Plan F: in-flight guard for logout() to short-circuit concurrent reload attempts from racing callbacks (auth-expired + stale-device). One-way per session — reset only by the actual page reload.
 
   isPC = false; // 是否是PC端
   deviceId: string = ""; // 设备ID
@@ -898,6 +899,14 @@ export default class WKApp extends ProviderListener {
 
   // 登出
   logout() {
+    // Plan F bundled fix #1: in-flight guard. Multiple concurrent API
+    // errors (e.g., auth-expired + stale-device, or N parallel stale
+    // responses) can call logout() in rapid succession before the page
+    // actually unloads. Without this guard, clearLocalLoginState() runs N
+    // times. Idempotent in practice but wasteful and noisy. One-way: only
+    // a real page reload resets the flag.
+    if (this.loggingOut) return;
+    this.loggingOut = true;
     this.clearLocalLoginState();
     window.location.reload();
   }

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -106,6 +106,11 @@ import RouteContext from "./Service/Context";
 import { ConnectStatus } from "wukongimjssdk";
 import { WKBaseContext } from "./Components/WKBase";
 import StorageService from "./Service/StorageService";
+import {
+  loadCachedNumericDeviceId,
+  saveNumericDeviceId,
+  clearCachedNumericDeviceId,
+} from "./Service/clientMsgDeviceIdCache";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
 import {
@@ -841,32 +846,113 @@ export default class WKApp extends ProviderListener {
     }
   }
 
-  startMain() {
-    this.connectIM();
-    WKApp.dataSource.contactsSync(); // 同步通讯录
-    ProhibitwordsService.shared.sync(); // 同步敏感词
+  // Issue #256: dual-track to eliminate the clientMsgDeviceId=0 race window.
+  // Cache hit → use cached id, connectIM immediately, refresh in background.
+  // Cache miss → await device fetch with 5s timeout, then connectIM.
+  // Either way, the WS is never opened with clientMsgDeviceId=0 unless the
+  // first-login fetch times out (graceful degradation to current behavior).
+  async startMain() {
+    const cached = loadCachedNumericDeviceId();
 
+    if (cached !== null) {
+      // Fast path: cache hit. Set optimistically, connect, sync in parallel,
+      // then refresh the cache in background to pick up any server-side
+      // changes (rare but possible if device id was reassigned).
+      WKSDK.shared().config.clientMsgDeviceId = cached;
+      this.connectIM();
+      WKApp.dataSource.contactsSync();
+      ProhibitwordsService.shared.sync();
+      this.fetchAndCacheDeviceId();
+      return;
+    }
+
+    // First-login path: no cache. Await device fetch (with 5s timeout
+    // safety net so a hung server can never permanently block WS connect).
+    // Errors are handled centrally by the APIClient staleLocalResourceCallback
+    // (Plan F) for stale device; non-stale errors are logged and we proceed
+    // with the SDK default clientMsgDeviceId=0 (current pre-#256 behavior).
+    await this.awaitDeviceIdOrTimeout(5000);
+    this.connectIM();
+    WKApp.dataSource.contactsSync();
+    ProhibitwordsService.shared.sync();
+  }
+
+  // Background refresh of the cached numeric device id. Fire-and-forget.
+  // Used by the cache-hit path so the cache stays current with the server.
+  //
+  // The .catch is REQUIRED — without it, a rejection from the fetch (or any
+  // error in the .then handler) becomes an Uncaught (in promise), defeating
+  // the purpose of Plan F.
+  //
+  // Risk A guard: if logout fires between dispatch and resolve, skip writes.
+  // Otherwise the .then could repopulate the cache that clearLocalLoginState
+  // just emptied (microscopic race window, but real).
+  private fetchAndCacheDeviceId(): void {
     WKApp.apiClient
       .get(`/user/devices/${WKApp.shared.deviceId}`)
       .then((res) => {
-        if (res.id) {
+        if (this.loggingOut) return;
+        if (res?.id) {
           WKSDK.shared().config.clientMsgDeviceId = res.id;
+          saveNumericDeviceId(res.id);
         }
       })
       .catch((err: APIClientRejectedError) => {
-        // Plan F: stale device recovery is handled centrally by the
-        // APIClient staleLocalResourceCallback (see module.tsx). This catch
-        // only exists to (a) consume the promise rejection so it doesn't
-        // surface as Uncaught and (b) keep observability of non-stale
-        // failures of this endpoint. The recovery side-effect has already
-        // fired by the time this runs (interceptor → callback → handler).
         if (err?.code !== "err.server.user.device_not_found") {
           console.warn(
-            "[App.startMain] /user/devices fetch failed (non-stale):",
+            "[App.startMain] /user/devices background refresh failed (non-stale):",
             { status: err?.status, code: err?.code, msg: err?.msg },
           );
         }
+        // stale device handled centrally by APIClient interceptor (Plan F)
       });
+  }
+
+  // First-login await with timeout. Returns when EITHER the device fetch's
+  // .then-or-.catch chain resolves OR the timer expires — whichever first.
+  //
+  // CRITICAL: fetchPromise has its OWN .catch (chained inline). This makes
+  // fetchPromise never-rejecting, so the only way Promise.race can reject is
+  // via timeoutPromise. Without the inline .catch, a fetch rejection that
+  // arrives AFTER timeout already won would surface as Uncaught (in promise)
+  // — exactly the noise Plan F was designed to eliminate.
+  //
+  // Risk A guard: same as fetchAndCacheDeviceId — skip writes if logout
+  // started between dispatch and resolve.
+  private async awaitDeviceIdOrTimeout(timeoutMs: number): Promise<void> {
+    const fetchPromise = WKApp.apiClient
+      .get(`/user/devices/${WKApp.shared.deviceId}`)
+      .then((res) => {
+        if (this.loggingOut) return;
+        if (res?.id) {
+          WKSDK.shared().config.clientMsgDeviceId = res.id;
+          saveNumericDeviceId(res.id);
+        }
+      })
+      .catch((err: APIClientRejectedError) => {
+        if (err?.code !== "err.server.user.device_not_found") {
+          console.warn(
+            "[App.startMain] first-login /user/devices fetch failed (non-stale):",
+            { status: err?.status, code: err?.code, msg: err?.msg },
+          );
+        }
+        // stale device handled centrally by APIClient interceptor (Plan F)
+      });
+
+    const timeoutPromise = new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error("FIRST_LOGIN_TIMEOUT")), timeoutMs),
+    );
+
+    try {
+      await Promise.race([fetchPromise, timeoutPromise]);
+    } catch (err) {
+      // Only timeout can reach here — fetchPromise is self-handled above.
+      if ((err as Error)?.message === "FIRST_LOGIN_TIMEOUT") {
+        console.warn(
+          `[App.startMain] first-login /user/devices fetch timed out after ${timeoutMs}ms; proceeding with default clientMsgDeviceId. The original fetch is still in flight and will update the cache if it eventually succeeds.`,
+        );
+      }
+    }
   }
 
   connectIM() {

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -977,6 +977,10 @@ export default class WKApp extends ProviderListener {
   private clearLocalLoginState() {
     WKApp.loginInfo.logout();
     clearAuthStorage();
+    // Issue #256: clear the cached numeric device id so a same-tab relogin
+    // or user-switch always re-traverses the first-login flow (correct
+    // numeric id for the new auth session).
+    clearCachedNumericDeviceId();
     this.currentSpaceId = "";
     this.channelSpaceMap.clear();
     this.channelMySourceSpaceMap.clear();

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -117,7 +117,6 @@ import {
   requestOidcLogout,
   safeEndSessionUrl,
 } from "./Service/oidcLogout";
-import { handleDeviceFetchError } from "./Service/deviceFailure";
 import type { APIClientRejectedError } from "./Service/APIClient";
 
 export enum ThemeMode {
@@ -854,27 +853,18 @@ export default class WKApp extends ProviderListener {
         }
       })
       .catch((err: APIClientRejectedError) => {
-        // octo-web#76: server may forget our device (after data reset, manual
-        // device-table cleanup, sessionStorage copied from another env, etc.).
-        // Without this handler the device fetch silently fails, leaving
-        // WKSDK.config.clientMsgDeviceId at its default 0; subsequent outbound
-        // messages then build clientMsgNo as "<uuid>_0_3" instead of
-        // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
-        // which breaks per-device message dedup and cross-device tracking.
+        // Plan F: stale device recovery is handled centrally by the
+        // APIClient staleLocalResourceCallback (see module.tsx). This catch
+        // only exists to (a) consume the promise rejection so it doesn't
+        // surface as Uncaught and (b) keep observability of non-stale
+        // failures of this endpoint. The recovery side-effect has already
+        // fired by the time this runs (interceptor → callback → handler).
         if (err?.code !== "err.server.user.device_not_found") {
-          // Non-stale device errors fall through to existing handling paths
-          // (auth interceptor / silent failure). Log once for observability
-          // so future regressions on this endpoint are not hidden.
           console.warn(
             "[App.startMain] /user/devices fetch failed (non-stale):",
             { status: err?.status, code: err?.code, msg: err?.msg },
           );
         }
-        handleDeviceFetchError(err, {
-          removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
-          resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
-          triggerLogout: () => WKApp.shared.logout(),
-        });
       });
   }
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -117,6 +117,8 @@ import {
   requestOidcLogout,
   safeEndSessionUrl,
 } from "./Service/oidcLogout";
+import { handleDeviceFetchError } from "./Service/deviceFailure";
+import type { APIClientRejectedError } from "./Service/APIClient";
 
 export enum ThemeMode {
   light,
@@ -850,6 +852,20 @@ export default class WKApp extends ProviderListener {
         if (res.id) {
           WKSDK.shared().config.clientMsgDeviceId = res.id;
         }
+      })
+      .catch((err: APIClientRejectedError) => {
+        // octo-web#76: server may forget our device (after data reset, manual
+        // device-table cleanup, sessionStorage copied from another env, etc.).
+        // Without this handler the device fetch silently fails, leaving
+        // WKSDK.config.clientMsgDeviceId at its default 0; subsequent outbound
+        // messages then build clientMsgNo as "<uuid>_0_3" instead of
+        // "<uuid>_<real-device-id>_3" (see wukongimjssdk packet.clientMsgNo),
+        // which breaks per-device message dedup and cross-device tracking.
+        handleDeviceFetchError(err, {
+          removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
+          resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
+          triggerLogout: () => WKApp.shared.logout(),
+        });
       });
   }
 

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { buildAcceptLanguage } from "./apiLanguage";
-import { isAuthExpiredApiError, normalizeApiError, NormalizedApiError } from "./apiError";
+import { isAuthExpiredApiError, isStaleLocalResourceApiError, normalizeApiError, NormalizedApiError } from "./apiError";
 
 export interface APIClientRejectedError {
     error: unknown;
@@ -55,6 +55,7 @@ export default class APIClient {
     public static shared = new APIClient()
     public config = new APIClientConfig()
     public logoutCallback?:()=>void
+    public staleLocalResourceCallback?:(code: string)=>void
 
     initAxios() {
         const self = this
@@ -88,8 +89,18 @@ export default class APIClient {
                 httpStatus: error?.response?.status,
                 raw: error,
             });
+            // Plan F: classification is mutually exclusive. else if (not two
+            // independent ifs) ensures a single error response triggers at
+            // most one recovery callback, even if a future code lands in both
+            // sets by mistake.
             if (isAuthExpiredApiError(normalized) && self.logoutCallback) {
                 self.logoutCallback()
+            } else if (
+                isStaleLocalResourceApiError(normalized) &&
+                self.staleLocalResourceCallback &&
+                normalized.code
+            ) {
+                self.staleLocalResourceCallback(normalized.code)
             }
             const rejected: APIClientRejectedError = {
                 error: error,

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.error.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.error.test.ts
@@ -13,6 +13,7 @@ describe("APIClient backend i18n contract", () => {
         client.config.tokenCallback = undefined
         client.config.spaceIdCallback = undefined
         client.logoutCallback = undefined
+        client.staleLocalResourceCallback = undefined
     })
 
     it("adds Accept-Language without trusted backend-only i18n headers", async () => {

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -156,6 +156,7 @@ describe("APIClient stale local resource interceptor", () => {
             throw err
         }
         await client.get("/v1/user/devices/probe").catch(() => {})
-        expect(staleFn).toHaveBeenCalledExactlyOnceWith("err.server.user.device_not_found")
+        expect(staleFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
     })
 })

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import axios from "axios"
+import APIClient from "../APIClient"
+
+describe("APIClient stale local resource interceptor", () => {
+    const client = APIClient.shared
+    let logoutFn: ReturnType<typeof vi.fn>
+    let staleFn: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        logoutFn = vi.fn()
+        staleFn = vi.fn()
+        client.logoutCallback = logoutFn
+        client.staleLocalResourceCallback = staleFn
+        client.config.tokenCallback = undefined
+        client.config.spaceIdCallback = undefined
+    })
+
+    it("device_not_found code triggers staleLocalResourceCallback once, NOT logoutCallback", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "未查询到该设备。",
+                    },
+                    msg: "未查询到该设备。",
+                    status: 400,
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/v1/user/devices/x")).rejects.toMatchObject({
+            code: "err.server.user.device_not_found",
+        })
+        expect(staleFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
+        expect(logoutFn).not.toHaveBeenCalled()
+    })
+})

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.staleResource.test.ts
@@ -41,4 +41,121 @@ describe("APIClient stale local resource interceptor", () => {
         expect(staleFn).toHaveBeenCalledWith("err.server.user.device_not_found")
         expect(logoutFn).not.toHaveBeenCalled()
     })
+
+    it("auth-expired (token_expired) still triggers logoutCallback only", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.shared.auth.token_expired",
+                        http_status: 401,
+                        message: "expired",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/anything")).rejects.toMatchObject({
+            code: "err.shared.auth.token_expired",
+        })
+        expect(logoutFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).not.toHaveBeenCalled()
+    })
+
+    it("login_device_expired (cousin code, HTTP 401) routes via auth-expired path, not stale path", async () => {
+        // Server emits this for the device-lock SMS-verify flow when the Redis
+        // login-device cache expired. It's a 401 — auth-expired classifier
+        // catches it via httpStatus fallback. Verifies the two device-related
+        // server codes don't accidentally both go through stale path.
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("401")
+            err.response = {
+                status: 401,
+                data: {
+                    error: {
+                        code: "err.server.user.login_device_expired",
+                        http_status: 401,
+                        message: "登录设备已过期",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/anything")).rejects.toMatchObject({})
+        expect(logoutFn).toHaveBeenCalledTimes(1)
+        expect(staleFn).not.toHaveBeenCalled()
+    })
+
+    it("concurrent stale device responses each invoke callback (re-entry expected; mitigation lives in WKApp.logout)", async () => {
+        let n = 0
+        axios.defaults.adapter = async () => {
+            n++
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "x",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        const p1 = client.get("/a").catch(() => {})
+        const p2 = client.get("/b").catch(() => {})
+        await Promise.all([p1, p2])
+        expect(n).toBe(2)
+        expect(staleFn).toHaveBeenCalledTimes(2)
+    })
+
+    it("unrelated 404 codes do NOT trigger staleLocalResourceCallback", async () => {
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("404")
+            err.response = {
+                status: 404,
+                data: {
+                    error: {
+                        code: "err.server.user.not_found",
+                        http_status: 404,
+                        message: "no such user",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await expect(client.get("/v1/users/missing")).rejects.toMatchObject({})
+        expect(staleFn).not.toHaveBeenCalled()
+        expect(logoutFn).not.toHaveBeenCalled()
+    })
+
+    it("interceptor still fires callback even if normalized.code is captured from envelope", async () => {
+        // Defensive: confirm the callback receives the actual code string,
+        // not undefined / a fallback. This guards against future refactors
+        // of normalizeApiError that might drop the code field.
+        axios.defaults.adapter = async () => {
+            const err: any = new Error("400")
+            err.response = {
+                status: 400,
+                data: {
+                    error: {
+                        code: "err.server.user.device_not_found",
+                        http_status: 404,
+                        message: "msg",
+                    },
+                },
+                headers: {},
+            }
+            throw err
+        }
+        await client.get("/v1/user/devices/probe").catch(() => {})
+        expect(staleFn).toHaveBeenCalledExactlyOnceWith("err.server.user.device_not_found")
+    })
 })

--- a/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/apiError.test.ts
@@ -4,6 +4,7 @@ import {
   isForbiddenApiError,
   isInternalApiError,
   isRateLimitedApiError,
+  isStaleLocalResourceApiError,
   normalizeApiError,
 } from "../apiError";
 import { i18n } from "../../i18n/instance";
@@ -149,3 +150,25 @@ describe("normalizeApiError", () => {
     expect(normalizeApiError({ httpStatus: 418, data: {} }).message).toBe("未知错误");
   });
 });
+
+describe("isStaleLocalResourceApiError", () => {
+  it("returns true for err.server.user.device_not_found regardless of httpStatus", () => {
+    // Real server response shape: HTTP 400 but body.http_status=404; only the code is stable.
+    expect(
+      isStaleLocalResourceApiError({ code: "err.server.user.device_not_found" })
+    ).toBe(true)
+  })
+
+  it("returns false for unrelated codes", () => {
+    expect(
+      isStaleLocalResourceApiError({ code: "err.shared.auth.token_expired" })
+    ).toBe(false)
+    expect(
+      isStaleLocalResourceApiError({ code: "err.server.user.not_found" })
+    ).toBe(false)
+  })
+
+  it("returns false when code is undefined", () => {
+    expect(isStaleLocalResourceApiError({ code: undefined })).toBe(false)
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/clientMsgDeviceIdCache.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/clientMsgDeviceIdCache.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  loadCachedNumericDeviceId,
+  saveNumericDeviceId,
+  clearCachedNumericDeviceId,
+  STORAGE_KEY,
+} from "../clientMsgDeviceIdCache"
+import StorageService from "../StorageService"
+
+describe("clientMsgDeviceIdCache", () => {
+  beforeEach(() => {
+    StorageService.shared.removeItem(STORAGE_KEY)
+  })
+
+  describe("loadCachedNumericDeviceId", () => {
+    it("returns the numeric value when storage has a valid positive integer", () => {
+      StorageService.shared.setItem(STORAGE_KEY, "42")
+      expect(loadCachedNumericDeviceId()).toBe(42)
+    })
+
+    it("returns null when storage is empty", () => {
+      expect(loadCachedNumericDeviceId()).toBeNull()
+    })
+
+    it("returns null when storage has a non-numeric string (NaN guard)", () => {
+      StorageService.shared.setItem(STORAGE_KEY, "not-a-number")
+      expect(loadCachedNumericDeviceId()).toBeNull()
+    })
+
+    it("returns null when storage has \"0\" (0 is the SDK default and indicates no real id)", () => {
+      StorageService.shared.setItem(STORAGE_KEY, "0")
+      expect(loadCachedNumericDeviceId()).toBeNull()
+    })
+
+    it("returns null when storage has a negative number", () => {
+      StorageService.shared.setItem(STORAGE_KEY, "-5")
+      expect(loadCachedNumericDeviceId()).toBeNull()
+    })
+  })
+
+  describe("saveNumericDeviceId", () => {
+    it("persists the numeric value as a string", () => {
+      saveNumericDeviceId(123)
+      expect(StorageService.shared.getItem(STORAGE_KEY)).toBe("123")
+    })
+
+    it("does not throw when StorageService.setItem throws (e.g., quota exceeded)", () => {
+      const spy = vi.spyOn(StorageService.shared, "setItem").mockImplementation(() => {
+        throw new Error("QuotaExceededError")
+      })
+      expect(() => saveNumericDeviceId(99)).not.toThrow()
+      spy.mockRestore()
+    })
+
+    it("does NOT persist a non-positive value (defensive; should never be called with 0)", () => {
+      saveNumericDeviceId(0)
+      expect(StorageService.shared.getItem(STORAGE_KEY)).toBeNull()
+      saveNumericDeviceId(-1)
+      expect(StorageService.shared.getItem(STORAGE_KEY)).toBeNull()
+    })
+  })
+
+  describe("clearCachedNumericDeviceId", () => {
+    it("removes the cached value", () => {
+      StorageService.shared.setItem(STORAGE_KEY, "77")
+      clearCachedNumericDeviceId()
+      expect(StorageService.shared.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it("is a no-op when no cached value present", () => {
+      expect(() => clearCachedNumericDeviceId()).not.toThrow()
+    })
+  })
+
+  describe("save → load round-trip", () => {
+    it("round-trips a valid id", () => {
+      saveNumericDeviceId(2024)
+      expect(loadCachedNumericDeviceId()).toBe(2024)
+    })
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -17,11 +17,11 @@ function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientReje
 }
 
 describe('handleDeviceFetchError', () => {
-  it('on 400 with err.server.user.device_not_found, invokes all three handlers', () => {
+  it('on err.server.user.device_not_found code (production status 404), invokes all three handlers', () => {
     const removeDeviceId = vi.fn()
     const resetInMemoryDeviceId = vi.fn()
     const triggerLogout = vi.fn()
-    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+    const err = makeRejected({ status: 404, code: 'err.server.user.device_not_found' })
 
     handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
 
@@ -67,5 +67,21 @@ describe('handleDeviceFetchError', () => {
     expect(removeDeviceId).not.toHaveBeenCalled()
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
+  })
+
+  it('on the device_not_found code regardless of status field value, still triggers', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    // Defensive: even if the backend ever flips its inconsistent http_status
+    // field to something else (e.g. 400 matching the real HTTP status), the
+    // code-only gate must still trigger.
+    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).toHaveBeenCalledTimes(1)
+    expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
+    expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -1,0 +1,32 @@
+// packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { handleDeviceFetchError } from '../deviceFailure'
+import type { APIClientRejectedError } from '../APIClient'
+
+function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientRejectedError {
+  return {
+    error: new Error('stub'),
+    msg: '',
+    status: undefined as any,
+    code: '',
+    details: undefined,
+    backendMessage: undefined,
+    normalized: undefined as any,
+    ...overrides,
+  } as APIClientRejectedError
+}
+
+describe('handleDeviceFetchError', () => {
+  it('on 400 with err.server.user.device_not_found, invokes all three handlers', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 400, code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).toHaveBeenCalledTimes(1)
+    expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
+    expect(triggerLogout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -29,4 +29,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
     expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
+
+  it('on 401 (auth expired), does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 401, code: 'err.shared.auth.token_missing' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -83,4 +83,22 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).toHaveBeenCalledTimes(1)
     expect(triggerLogout).toHaveBeenCalledTimes(1)
   })
+
+  it('invokes handlers in storage-clear-before-logout order (reload depends on this)', () => {
+    // Order matters: removeDeviceId MUST run before triggerLogout, because
+    // triggerLogout fires window.location.reload(), and the post-reload
+    // App.startup → getDeviceIdFromStorage() only regenerates a fresh UUID
+    // when sessionStorage.deviceId is null/"". If logout fired first and the
+    // reload raced ahead before removeDeviceId completed, the stale UUID
+    // would be re-used and the loop would not break.
+    const calls: string[] = []
+    const removeDeviceId = vi.fn(() => { calls.push('removeDeviceId') })
+    const resetInMemoryDeviceId = vi.fn(() => { calls.push('resetInMemoryDeviceId') })
+    const triggerLogout = vi.fn(() => { calls.push('triggerLogout') })
+    const err = makeRejected({ code: 'err.server.user.device_not_found' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(calls).toEqual(['removeDeviceId', 'resetInMemoryDeviceId', 'triggerLogout'])
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -7,13 +7,12 @@ function makeRejected(overrides: Partial<APIClientRejectedError>): APIClientReje
   return {
     error: new Error('stub'),
     msg: '',
-    status: undefined as any,
     code: '',
     details: undefined,
     backendMessage: undefined,
-    normalized: undefined as any,
+    normalized: { message: '', raw: undefined },
     ...overrides,
-  } as APIClientRejectedError
+  }
 }
 
 describe('handleDeviceFetchError', () => {
@@ -47,7 +46,7 @@ describe('handleDeviceFetchError', () => {
     const removeDeviceId = vi.fn()
     const resetInMemoryDeviceId = vi.fn()
     const triggerLogout = vi.fn()
-    const err = makeRejected({ status: undefined as any, code: '' })
+    const err = makeRejected({ code: '' })
 
     handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
 

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -55,4 +55,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
   })
+
+  it('on 400 with a different error code, does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: 400, code: 'err.shared.request.invalid' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/deviceFailure.test.ts
@@ -42,4 +42,17 @@ describe('handleDeviceFetchError', () => {
     expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
     expect(triggerLogout).not.toHaveBeenCalled()
   })
+
+  it('on network error (no response, status undefined), does NOT invoke any handler', () => {
+    const removeDeviceId = vi.fn()
+    const resetInMemoryDeviceId = vi.fn()
+    const triggerLogout = vi.fn()
+    const err = makeRejected({ status: undefined as any, code: '' })
+
+    handleDeviceFetchError(err, { removeDeviceId, resetInMemoryDeviceId, triggerLogout })
+
+    expect(removeDeviceId).not.toHaveBeenCalled()
+    expect(resetInMemoryDeviceId).not.toHaveBeenCalled()
+    expect(triggerLogout).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dmworkbase/src/Service/apiError.ts
+++ b/packages/dmworkbase/src/Service/apiError.ts
@@ -30,6 +30,17 @@ const rateLimitedCodes = new Set([
   "err.shared.rate.limited",
 ]);
 
+// Plan F: stale local resource codes. Server emits one such code per cached
+// client-side ID it no longer recognizes (e.g., the deviceId UUID in
+// localStorage when the server-side device row was removed). Code-only
+// matching: server returns HTTP 400 with body.http_status=404 for
+// device_not_found, so neither HTTP status nor body http_status is the
+// stable contract — the string code is. Future siblings (e.g., space.not_found)
+// can be added to this set without touching the interceptor.
+const staleLocalResourceCodes = new Set([
+  "err.server.user.device_not_found",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -77,6 +88,10 @@ export function isForbiddenApiError(error: Pick<NormalizedApiError, "code" | "ht
 
 export function isRateLimitedApiError(error: Pick<NormalizedApiError, "code" | "httpStatus">): boolean {
   return Boolean(error.code && rateLimitedCodes.has(error.code)) || error.httpStatus === 429;
+}
+
+export function isStaleLocalResourceApiError(error: Pick<NormalizedApiError, "code">): boolean {
+  return Boolean(error.code && staleLocalResourceCodes.has(error.code));
 }
 
 export function isInternalApiError(error: Pick<NormalizedApiError, "code" | "httpStatus">): boolean {

--- a/packages/dmworkbase/src/Service/clientMsgDeviceIdCache.ts
+++ b/packages/dmworkbase/src/Service/clientMsgDeviceIdCache.ts
@@ -1,0 +1,55 @@
+import StorageService from "./StorageService"
+
+// Cache key for the server-issued numeric device id (clientMsgDeviceId).
+// Distinct from "deviceId" which holds the UUID. Backed by sessionStorage
+// (per-tab) via StorageService — same scope as the UUID, so each tab's
+// (UUID, numeric id) pair stays consistent.
+//
+// Exported for tests; do NOT use this key directly from production code —
+// always go through the helpers below.
+export const STORAGE_KEY = "clientMsgDeviceIdNumeric"
+
+/**
+ * Read the cached numeric device id from sessionStorage.
+ *
+ * Returns null when no cache exists, when the stored value is not parseable,
+ * or when the parsed value is not a positive finite integer. Returning null
+ * (not 0) is important: the SDK default `clientMsgDeviceId === 0` means
+ * "no real id" and the caller distinguishes the two states.
+ *
+ * Issue #256: this read happens BEFORE WKSDK.connect() in App.startMain to
+ * eliminate the race window where outbound messages would carry
+ * clientMsgNo = <uuid>_0_3 instead of <uuid>_<real-id>_3.
+ */
+export function loadCachedNumericDeviceId(): number | null {
+  const raw = StorageService.shared.getItem(STORAGE_KEY)
+  if (raw === null || raw === "") return null
+  const n = parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+/**
+ * Persist the numeric device id to sessionStorage. Silently no-ops on
+ * non-positive input (defensive — should never be called with 0; we only
+ * cache the real server-issued id) and on storage write failures (Safari
+ * private mode, QuotaExceededError). A failed save means next session will
+ * fall back to the first-login path — no behavioral regression vs current.
+ */
+export function saveNumericDeviceId(n: number): void {
+  if (!Number.isFinite(n) || n <= 0) return
+  try {
+    StorageService.shared.setItem(STORAGE_KEY, String(n))
+  } catch (e) {
+    console.warn("[clientMsgDeviceIdCache] save failed; cache will be repopulated next session:", e)
+  }
+}
+
+/**
+ * Remove the cached numeric device id. Called from clearLocalLoginState
+ * during logout so the next user (or relogin) on the same tab always
+ * re-traverses the first-login flow (correct numeric id for the new auth).
+ */
+export function clearCachedNumericDeviceId(): void {
+  StorageService.shared.removeItem(STORAGE_KEY)
+}

--- a/packages/dmworkbase/src/Service/deviceFailure.ts
+++ b/packages/dmworkbase/src/Service/deviceFailure.ts
@@ -10,7 +10,10 @@ export interface DeviceFailureHandlers {
  * Classify a rejected device-fetch error and invoke recovery handlers if it
  * represents a stale device_id (server doesn't recognize it).
  *
- * Trigger condition: HTTP 400 + backend code 'err.server.user.device_not_found'.
+ * Trigger condition: backend code 'err.server.user.device_not_found'.
+ * (HTTP status not checked — APIClient.normalizeApiError exposes
+ * body.error.http_status, not the real HTTP status code, and the two diverge
+ * for this endpoint. Code-only gating is more robust.)
  * All other errors (auth, network, 5xx) are intentionally ignored — they have
  * their own handling paths (auth interceptor / silent failure).
  *
@@ -20,7 +23,11 @@ export function handleDeviceFetchError(
   err: APIClientRejectedError,
   handlers: DeviceFailureHandlers,
 ): void {
-  if (err.status === 400 && err.code === 'err.server.user.device_not_found') {
+  // Gate by code only. The HTTP status line is 400 Bad Request, but
+  // APIClient.normalizeApiError reads the body's inconsistent `http_status`
+  // field (=404) into err.status, not the actual HTTP status code. The code
+  // string is the stable backend contract — that's what we match on.
+  if (err.code === 'err.server.user.device_not_found') {
     handlers.removeDeviceId()
     handlers.resetInMemoryDeviceId()
     handlers.triggerLogout()

--- a/packages/dmworkbase/src/Service/deviceFailure.ts
+++ b/packages/dmworkbase/src/Service/deviceFailure.ts
@@ -1,0 +1,28 @@
+import type { APIClientRejectedError } from './APIClient'
+
+export interface DeviceFailureHandlers {
+  removeDeviceId: () => void
+  resetInMemoryDeviceId: () => void
+  triggerLogout: () => void
+}
+
+/**
+ * Classify a rejected device-fetch error and invoke recovery handlers if it
+ * represents a stale device_id (server doesn't recognize it).
+ *
+ * Trigger condition: HTTP 400 + backend code 'err.server.user.device_not_found'.
+ * All other errors (auth, network, 5xx) are intentionally ignored — they have
+ * their own handling paths (auth interceptor / silent failure).
+ *
+ * See octo-web#76.
+ */
+export function handleDeviceFetchError(
+  err: APIClientRejectedError,
+  handlers: DeviceFailureHandlers,
+): void {
+  if (err.status === 400 && err.code === 'err.server.user.device_not_found') {
+    handlers.removeDeviceId()
+    handlers.resetInMemoryDeviceId()
+    handlers.triggerLogout()
+  }
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -86,6 +86,8 @@ import { UserInfoRouteData } from "./Components/UserInfo/vm";
 import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
 import APIClient from "./Service/APIClient";
+import StorageService from "./Service/StorageService";
+import { handleDeviceFetchError } from "./Service/deviceFailure";
 import { patchSdkDecodeForExternalFields } from "./Service/Convert";
 import { isMessageSelectable } from "./Service/messageSelection";
 import ConversationVM from "./Components/Conversation/vm";
@@ -203,6 +205,25 @@ export default class BaseModule implements IModule {
 
     APIClient.shared.logoutCallback = () => {
       WKApp.shared.logout();
+    };
+
+    // Plan F: generic stale-local-resource recovery dispatcher. First
+    // customer is the device_not_found code (octo-web#270 / #76). Future
+    // siblings (e.g., err.server.space.not_found for stale currentSpaceId)
+    // can be added to the staleLocalResourceCodes set in apiError.ts and
+    // routed here without touching the interceptor or business catch sites.
+    APIClient.shared.staleLocalResourceCallback = (code: string) => {
+      if (code === "err.server.user.device_not_found") {
+        handleDeviceFetchError(
+          { code } as any,
+          {
+            removeDeviceId: () => StorageService.shared.removeItem("deviceId"),
+            resetInMemoryDeviceId: () => { WKApp.shared.deviceId = ""; },
+            triggerLogout: () => WKApp.shared.logout(),
+          }
+        );
+      }
+      // Future siblings (space.not_found, etc.) add their else-if branches here.
     };
 
     WKApp.endpointManager.setMethod(


### PR DESCRIPTION
## Summary

Eliminates the `clientMsgDeviceId = 0` race window in `App.startMain`, where outbound `chatManager.send()` messages get `clientMsgNo = <uuid>_0_3` instead of `<uuid>_<real-id>_3` during the ~50-300ms window between `connectIM()` (synchronous WebSocket open) and `/user/devices/{deviceId}` (async numeric id fetch).

**Approach — Option D+ hybrid** (cache + first-login await):

- Persist the numeric device id in sessionStorage after the first successful `/user/devices` response
- On subsequent sessions (refresh / cache-hit): set `WKSDK.config.clientMsgDeviceId` from cache **before** `connectIM()` — **zero latency, zero race**
- On first-login (cache-miss): `await` the device fetch with a 5s timeout safety net before `connectIM()` — ~200ms WS connect delay only for the first session, **zero race**
- Cache cleared on logout via `clearLocalLoginState` so user-switch on the same tab always re-traverses the first-login path correctly

**No server changes. No SDK changes.**

## ⚠️ Depends on #255 (PR-stacking note)

This branch was developed on top of #255 (Plan F stale-resource interceptor). Of the 26 commits in this PR's diff, **22 belong to #255** and **4 belong to #256**.

The 4 new commits:
```
4411d649  fix(App): short-circuit cache-miss path if Plan F triggers logout (#256)
0fdaa32b  fix(App): clear clientMsgDeviceId cache on logout (#256)
1f300888  fix(App): dual-track startMain to eliminate clientMsgDeviceId=0 race (#256)
8f27af44  feat(Service): add clientMsgDeviceIdCache helper for issue #256
```

**Recommended merge order**: merge #255 first; this PR will then auto-rebase to a clean 4-commit diff. Until then, review either by filtering to those 4 SHAs or by waiting for #255 to land.

## Plan F integration

#256 uses Plan F's existing `staleLocalResourceCallback` interceptor for stale-device error recovery (unchanged). The new `await` path in cache-miss explicitly short-circuits via `this.loggingOut` guard after the await — without it, a stale-device-triggered logout would let `connectIM`/`contactsSync`/`prohibitWordsSync` fire against a just-cleared token, causing 401 chains and `Uncaught (in promise)` console noise. **This was a real regression caught by end-to-end browser testing during development**; the guard prevents it.

## Files changed (just the 4 #256 commits)

```
packages/dmworkbase/src/App.tsx                                          | +106 / -12
packages/dmworkbase/src/Service/__tests__/clientMsgDeviceIdCache.test.ts | +81 (NEW)
packages/dmworkbase/src/Service/clientMsgDeviceIdCache.ts                | +55 (NEW)
```

## Race elimination truth table

| Scenario | Before | After D+ hybrid |
|----------|--------|-----------------|
| First-login (no cache) | ~200ms race window | ~200ms WS connect delay, **no race** |
| Refresh logged-in (cache hit) | ~200ms race window | **zero delay, no race** |
| Logout + relogin same tab (cache cleared) | ~200ms race window | Same as first-login |
| New tab (sessionStorage fresh) | ~200ms race window | Same as first-login |

## Test plan

- [ ] Unit tests: `cd packages/dmworkbase && pnpm test` → 46 tests pass (35 Plan F baseline + 11 new `clientMsgDeviceIdCache.test.ts`)
- [ ] Lint clean on touched files
- [ ] Manual E2E (verified locally against local `octo-server` during development):
  - [ ] Fresh user first refresh → WebSocket connects **AFTER** `/user/devices` returns (await path proven; observed t=550ms after t=537ms fetch end)
  - [ ] Subsequent refresh → WebSocket connects **BEFORE** `/user/devices` settles (cache-hit fast path proven; observed t=550.6ms vs t=551.0ms)
  - [ ] Logout → `sessionStorage.clientMsgDeviceIdNumeric` cleared (verified directly)
  - [ ] Plan F stale device path: delete server-side device → refresh → user lands on login page; **no `Uncaught (in promise)` in console** (Task E guard verified working — pre-Task-E had 2× unhandled rejections; post-Task-E has 0)

## Risks & mitigations

| Risk | Mitigation |
|------|-----------|
| First-login fetch hangs → WS never connects | 5s `Promise.race` timeout falls back to current pre-#256 behavior |
| Concurrent stale/auth callbacks racing | Plan F's `loggingOut` guard (already in place from #255) + new outer post-await guard |
| Cache stale after server-side device replacement | Background refresh updates cache; Plan F handles stale-not-found |
| sessionStorage write throw (Safari private mode) | Helper try/catch swallows; cache becomes best-effort |
| Cache-miss await → Plan F logout → post-await side effects (401 noise) | Task E short-circuit `if (this.loggingOut) return;` after await |

## Roll-back plan

Each task is its own commit; revert specific layers if needed:

- Revert Task E only (regression guard): `git revert 4411d649`
- Revert all #256 (keep #255 Plan F): `git revert 4411d649 0fdaa32b 1f300888 8f27af44`

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
