### PR TITLE
fix(mention): protect all-ai routing uids

### DIFF
--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -247,6 +247,7 @@ function parseMention(
         subscriberUserUids?: string[];
         channelInfoBotUids?: string[];
         channelInfoUserUids?: string[];
+        channelInfoUnknownUids?: string[];
     }
 ): Part[] {
     if (!mention) {
@@ -263,20 +264,26 @@ function parseMention(
         const subscriberUserUids = new Set(mention.subscriberUserUids ?? mention.userUids ?? []);
         const channelInfoBotUids = new Set(mention.channelInfoBotUids ?? mention.botUids ?? []);
         const channelInfoUserUids = new Set(mention.channelInfoUserUids ?? mention.userUids ?? []);
+        const channelInfoUnknownUids = new Set(mention.channelInfoUnknownUids ?? []);
         const legacyUids = mention.ais
             ? (() => {
                 let trailingBotCount = 0;
                 for (let idx = mention.uids!.length - 1; idx >= 0; idx--) {
                     const uid = mention.uids![idx];
-                    const state = subscriberBotUids.has(uid)
+                    const subscriberState = subscriberBotUids.has(uid)
                         ? 'bot'
                         : subscriberUserUids.has(uid)
                             ? 'user'
-                            : channelInfoBotUids.has(uid)
-                                ? 'bot'
-                                : channelInfoUserUids.has(uid)
-                                    ? 'user'
-                                    : 'unknown';
+                            : undefined;
+                    const state = subscriberState ?? (
+                        channelInfoBotUids.has(uid)
+                            ? 'bot'
+                            : channelInfoUserUids.has(uid)
+                                ? 'user'
+                                : channelInfoUnknownUids.has(uid)
+                                    ? 'unknown'
+                                    : 'unknown'
+                    );
                     if (state === 'bot') {
                         trailingBotCount++;
                         continue;
@@ -756,6 +763,34 @@ describe('parseMention dispatcher (v2 priority + v1 fallback)', () => {
             uids: ['uid_alice', 'bot_a', 'bot_b'],
             subscriberBotUids: ['bot_b'],
             userUids: ['uid_alice'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.text, '@Alice @所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should fallback when a subscriber record exists but lacks robot metadata', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a', 'bot_b'],
+            subscriberBotUids: ['bot_b'],
+            channelInfoBotUids: ['bot_a', 'bot_b'],
+            channelInfoUserUids: ['uid_alice'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.mention, '@Alice', { uid: 'uid_alice' }),
+            new Part(PartType.text, ' @所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should fail closed when subscriber and channelInfo records lack robot metadata', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a'],
+            channelInfoUnknownUids: ['bot_a'],
+            channelInfoUserUids: ['uid_alice'],
         });
 
         expect(parts).toEqual([

--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -12,6 +12,7 @@ import {
     buildMessageMentions as productionBuildMessageMentions,
     readMentionFlags,
     buildMentionDropdownItems,
+    MENTION_UID_LEGACY_ALL,
     MENTION_UID_HUMANS,
     MENTION_UID_AIS,
     MENTION_LABEL_HUMANS,
@@ -170,11 +171,10 @@ function parseMentionWithEntities(
             continue;
         }
 
-        const mentionName = mentionText.slice(1);
         if (
-            mentionName.toLowerCase() === 'all' ||
-            mentionName === MENTION_LABEL_HUMANS ||
-            mentionName === MENTION_LABEL_AIS
+            entity.uid === MENTION_UID_LEGACY_ALL ||
+            entity.uid === MENTION_UID_HUMANS ||
+            entity.uid === MENTION_UID_AIS
         ) {
             parts.push(new Part(PartType.text, mentionText));
             cursor = entity.offset + entity.length;
@@ -258,7 +258,7 @@ function parseMention(
             break;
         }
         const legacyUids = mention.ais
-            ? mention.uids.slice(0, Math.max(0, mention.uids.length - trailingBotCount))
+            ? mention.uids.slice(0, trailingBotCount > 0 ? Math.max(0, mention.uids.length - trailingBotCount) : 0)
             : mention.uids;
         return parseMentionLegacy(text, legacyUids);
     }
@@ -532,6 +532,14 @@ describe('parseMentionWithEntities', () => {
         expect(result![0].data.uid).toBe('uid_alice');
         expect(result![2].data.uid).toBe('uid_bob');
     });
+
+    it('should bind a real member entity even when its label is reserved text', () => {
+        const text = '@所有AI 请看下';
+        const entities = [{ uid: 'real_member_uid', offset: 0, length: 5 }];
+        const parts = parseMentionWithEntities(text, entities);
+
+        expect(parts![0]).toEqual(new Part(PartType.mention, '@所有AI', { uid: 'real_member_uid' }));
+    });
 });
 
 describe('parseMentionLegacy', () => {
@@ -653,6 +661,17 @@ describe('parseMention dispatcher (v2 priority + v1 fallback)', () => {
             ais: 1,
             uids: ['bot_a'],
             botUids: ['bot_a'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.text, '@所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should fail closed when @所有AI legacy routing uids have no bot metadata', () => {
+        const parts = parseMention('@所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['bot_a'],
         });
 
         expect(parts).toEqual([

--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -243,6 +243,10 @@ function parseMention(
         ais?: number;
         botUids?: string[];
         userUids?: string[];
+        subscriberBotUids?: string[];
+        subscriberUserUids?: string[];
+        channelInfoBotUids?: string[];
+        channelInfoUserUids?: string[];
     }
 ): Part[] {
     if (!mention) {
@@ -255,18 +259,29 @@ function parseMention(
     }
 
     if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-        const botUids = new Set(mention.botUids ?? []);
-        const userUids = new Set(mention.userUids ?? []);
+        const subscriberBotUids = new Set(mention.subscriberBotUids ?? mention.botUids ?? []);
+        const subscriberUserUids = new Set(mention.subscriberUserUids ?? mention.userUids ?? []);
+        const channelInfoBotUids = new Set(mention.channelInfoBotUids ?? mention.botUids ?? []);
+        const channelInfoUserUids = new Set(mention.channelInfoUserUids ?? mention.userUids ?? []);
         const legacyUids = mention.ais
             ? (() => {
                 let trailingBotCount = 0;
                 for (let idx = mention.uids!.length - 1; idx >= 0; idx--) {
                     const uid = mention.uids![idx];
-                    if (botUids.has(uid)) {
+                    const state = subscriberBotUids.has(uid)
+                        ? 'bot'
+                        : subscriberUserUids.has(uid)
+                            ? 'user'
+                            : channelInfoBotUids.has(uid)
+                                ? 'bot'
+                                : channelInfoUserUids.has(uid)
+                                    ? 'user'
+                                    : 'unknown';
+                    if (state === 'bot') {
                         trailingBotCount++;
                         continue;
                     }
-                    if (userUids.has(uid)) {
+                    if (state === 'user') {
                         return mention.uids!.slice(0, mention.uids!.length - trailingBotCount);
                     }
                     return [];
@@ -720,11 +735,26 @@ describe('parseMention dispatcher (v2 priority + v1 fallback)', () => {
         ]);
     });
 
+    it('should fallback from partial subscriber metadata to channelInfo for each trailing bot', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a', 'bot_b'],
+            subscriberBotUids: ['bot_b'],
+            channelInfoBotUids: ['bot_a', 'bot_b'],
+            channelInfoUserUids: ['uid_alice'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.mention, '@Alice', { uid: 'uid_alice' }),
+            new Part(PartType.text, ' @所有AI 测试 @ops'),
+        ]);
+    });
+
     it('should fail closed when a trailing all-ai uid cannot be classified', () => {
         const parts = parseMention('@Alice @所有AI 测试 @ops', {
             ais: 1,
             uids: ['uid_alice', 'bot_a', 'bot_b'],
-            botUids: ['bot_b'],
+            subscriberBotUids: ['bot_b'],
             userUids: ['uid_alice'],
         });
 

--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -51,6 +51,8 @@ class MentionModel {
     all: boolean = false
     uids?: Array<string>
     entities?: MentionEntity[]
+    humans?: number
+    ais?: number
 }
 
 // ─── Extracted functions (mirroring production code) ─────────────
@@ -64,6 +66,8 @@ function formatMentionTextV2(text: string): {
     let result = '';
     let cursor = 0;
     let all = false;
+    let humans = false;
+    let ais = false;
 
     const placeholderPattern = /@\[([^:\]]+):([^\]]+)\]/g;
     let match;
@@ -78,6 +82,17 @@ function formatMentionTextV2(text: string): {
             all = true;
             const atName = `@${name}`;
             result += atName;
+        } else if (uid === MENTION_UID_HUMANS) {
+            humans = true;
+            const atName = `@${MENTION_LABEL_HUMANS}`;
+            result += atName;
+        } else if (uid === MENTION_UID_AIS) {
+            ais = true;
+            const atName = `@${MENTION_LABEL_AIS}`;
+            const offset = result.length;
+            result += atName;
+
+            entities.push({ uid, offset, length: atName.length });
         } else {
             const atName = `@${name}`;
             const offset = result.length;
@@ -92,20 +107,17 @@ function formatMentionTextV2(text: string): {
 
     result += text.substring(cursor);
 
-    if (all) {
+    if (all || humans || ais || entities.length > 0) {
         const mention = new MentionModel();
-        mention.all = true;
+        mention.all = all;
+        mention.uids = uids.length > 0 ? uids : undefined;
+        mention.entities = entities.length > 0 ? entities : undefined;
+        if (humans) mention.humans = 1;
+        if (ais) mention.ais = 1;
         return { content: result, mention };
     }
 
-    if (entities.length === 0) {
-        return { content: result, mention: undefined };
-    }
-
-    const mention = new MentionModel();
-    mention.uids = uids;
-    mention.entities = entities;
-    return { content: result, mention };
+    return { content: result, mention: undefined };
 }
 
 function parseMentionWithEntities(
@@ -153,6 +165,17 @@ function parseMentionWithEntities(
         const mentionText = text.substring(entity.offset, entity.offset + entity.length);
 
         if (!mentionText.startsWith('@')) {
+            parts.push(new Part(PartType.text, mentionText));
+            cursor = entity.offset + entity.length;
+            continue;
+        }
+
+        const mentionName = mentionText.slice(1);
+        if (
+            mentionName.toLowerCase() === 'all' ||
+            mentionName === MENTION_LABEL_HUMANS ||
+            mentionName === MENTION_LABEL_AIS
+        ) {
             parts.push(new Part(PartType.text, mentionText));
             cursor = entity.offset + entity.length;
             continue;
@@ -213,7 +236,7 @@ function parseMentionLegacy(text: string, uids: string[]): Part[] {
 
 function parseMention(
     text: string,
-    mention?: { uids?: string[]; entities?: any[]; all?: boolean }
+    mention?: { uids?: string[]; entities?: any[]; all?: boolean; ais?: number; botUids?: string[] }
 ): Part[] {
     if (!mention) {
         return [new Part(PartType.text, text)];
@@ -225,7 +248,19 @@ function parseMention(
     }
 
     if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-        return parseMentionLegacy(text, mention.uids);
+        let trailingBotCount = 0;
+        const botUids = new Set(mention.botUids ?? []);
+        for (let idx = mention.uids.length - 1; idx >= 0; idx--) {
+            if (botUids.has(mention.uids[idx])) {
+                trailingBotCount++;
+                continue;
+            }
+            break;
+        }
+        const legacyUids = mention.ais
+            ? mention.uids.slice(0, Math.max(0, mention.uids.length - trailingBotCount))
+            : mention.uids;
+        return parseMentionLegacy(text, legacyUids);
     }
 
     return [new Part(PartType.text, text)];
@@ -278,6 +313,18 @@ describe('formatMentionTextV2', () => {
         expect(result.content).toBe('大家注意 @所有人 ');
         expect(result.mention?.all).toBe(true);
         expect(result.mention?.entities).toBeUndefined();
+    });
+
+    it('should mark @所有AI with a sentinel entity', () => {
+        const input = '@[-3:所有AI] ping @ops';
+        const result = formatMentionTextV2(input);
+
+        expect(result.content).toBe('@所有AI ping @ops');
+        expect(result.mention?.ais).toBe(1);
+        expect(result.mention?.uids).toBeUndefined();
+        expect(result.mention?.entities).toEqual([
+            { uid: MENTION_UID_AIS, offset: 0, length: 5 },
+        ]);
     });
 
     it('should return undefined mention when no mentions', () => {
@@ -587,6 +634,43 @@ describe('parseMention dispatcher (v2 priority + v1 fallback)', () => {
 
         const mentionPart = parts.find((p) => p.type === PartType.mention);
         expect(mentionPart?.data?.uid).toBe('uid_bob');
+    });
+
+    it('should not bind routing uids to raw @text when @所有AI has an entity', () => {
+        const parts = parseMention('@所有AI ping @ops', {
+            uids: ['bot_a'],
+            entities: [{ uid: MENTION_UID_AIS, offset: 0, length: 5 }],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.text, '@所有AI'),
+            new Part(PartType.text, ' ping @ops'),
+        ]);
+    });
+
+    it('should not bind mobile @所有AI routing uids to raw @text without entities', () => {
+        const parts = parseMention('@所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['bot_a'],
+            botUids: ['bot_a'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.text, '@所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should keep real uid mentions before @所有AI routing uids in legacy payloads', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a'],
+            botUids: ['bot_a'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.mention, '@Alice', { uid: 'uid_alice' }),
+            new Part(PartType.text, ' @所有AI 测试 @ops'),
+        ]);
     });
 
     it('should return plain text when no mention', () => {

--- a/apps/web/src/__tests__/mentionRefactor.test.ts
+++ b/apps/web/src/__tests__/mentionRefactor.test.ts
@@ -236,7 +236,14 @@ function parseMentionLegacy(text: string, uids: string[]): Part[] {
 
 function parseMention(
     text: string,
-    mention?: { uids?: string[]; entities?: any[]; all?: boolean; ais?: number; botUids?: string[] }
+    mention?: {
+        uids?: string[];
+        entities?: any[];
+        all?: boolean;
+        ais?: number;
+        botUids?: string[];
+        userUids?: string[];
+    }
 ): Part[] {
     if (!mention) {
         return [new Part(PartType.text, text)];
@@ -248,24 +255,30 @@ function parseMention(
     }
 
     if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-        let trailingBotCount = 0;
         const botUids = new Set(mention.botUids ?? []);
-        for (let idx = mention.uids.length - 1; idx >= 0; idx--) {
-            if (botUids.has(mention.uids[idx])) {
-                trailingBotCount++;
-                continue;
-            }
-            break;
-        }
+        const userUids = new Set(mention.userUids ?? []);
         const legacyUids = mention.ais
-            ? mention.uids.slice(0, trailingBotCount > 0 ? Math.max(0, mention.uids.length - trailingBotCount) : 0)
+            ? (() => {
+                let trailingBotCount = 0;
+                for (let idx = mention.uids!.length - 1; idx >= 0; idx--) {
+                    const uid = mention.uids![idx];
+                    if (botUids.has(uid)) {
+                        trailingBotCount++;
+                        continue;
+                    }
+                    if (userUids.has(uid)) {
+                        return mention.uids!.slice(0, mention.uids!.length - trailingBotCount);
+                    }
+                    return [];
+                }
+                return [];
+            })()
             : mention.uids;
         return parseMentionLegacy(text, legacyUids);
     }
 
     return [new Part(PartType.text, text)];
 }
-
 // ═════════════════════════════════════════════════════════════════
 // Tests
 // ═════════════════════════════════════════════════════════════════
@@ -684,11 +697,39 @@ describe('parseMention dispatcher (v2 priority + v1 fallback)', () => {
             ais: 1,
             uids: ['uid_alice', 'bot_a'],
             botUids: ['bot_a'],
+            userUids: ['uid_alice'],
         });
 
         expect(parts).toEqual([
             new Part(PartType.mention, '@Alice', { uid: 'uid_alice' }),
             new Part(PartType.text, ' @所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should check each trailing routing uid before keeping legacy mentions', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a', 'bot_b'],
+            botUids: ['bot_a', 'bot_b'],
+            userUids: ['uid_alice'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.mention, '@Alice', { uid: 'uid_alice' }),
+            new Part(PartType.text, ' @所有AI 测试 @ops'),
+        ]);
+    });
+
+    it('should fail closed when a trailing all-ai uid cannot be classified', () => {
+        const parts = parseMention('@Alice @所有AI 测试 @ops', {
+            ais: 1,
+            uids: ['uid_alice', 'bot_a', 'bot_b'],
+            botUids: ['bot_b'],
+            userUids: ['uid_alice'],
+        });
+
+        expect(parts).toEqual([
+            new Part(PartType.text, '@Alice @所有AI 测试 @ops'),
         ]);
     });
 

--- a/apps/web/src/__tests__/voiceMention.test.ts
+++ b/apps/web/src/__tests__/voiceMention.test.ts
@@ -134,7 +134,10 @@ function formatMentionTextV2(text: string): {
             result += `@${MENTION_LABEL_HUMANS}`;
         } else if (uid === MENTION_UID_AIS) {
             ais = true;
-            result += `@${MENTION_LABEL_AIS}`;
+            const atName = `@${MENTION_LABEL_AIS}`;
+            const offset = result.length;
+            result += atName;
+            entities.push({ uid, offset, length: atName.length });
         } else {
             const atName = `@${name}`;
             const offset = result.length;
@@ -471,6 +474,9 @@ describe('voice mention end-to-end', () => {
         expect(mention?.ais).toBe(1)
         expect(mention?.all).toBe(false)
         expect(mention?.humans).toBeUndefined()
+        expect(mention?.entities).toEqual([
+            { uid: MENTION_UID_AIS, offset: 0, length: 5 },
+        ])
     })
 
     it('unmatched @mention should pass through as plain text', () => {

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts
@@ -56,6 +56,25 @@ describe("wrapSendContentForInjection", () => {
         expect(wrapped.contentObj.mention.ais).toBe(1)
     })
 
+    it("preserves mention.entities in the wire payload when SDK encode overwrites mention", () => {
+        const msg = new MessageText("@所有AI ping @ops")
+        const mn = new Mention()
+        ;(mn as any).ais = 1
+        ;(mn as any).entities = [{ uid: "-3", offset: 0, length: 5 }]
+        mn.uids = ["bot_a"]
+        msg.mention = mn
+
+        const wrapped = wrapSendContentForInjection(msg, { mentionAis: true })
+
+        const wire = decodeWire(wrapped)
+        expect(wire.mention.uids).toEqual(["bot_a"])
+        expect(wire.mention.ais).toBe(1)
+        expect(wire.mention.entities).toEqual([{ uid: "-3", offset: 0, length: 5 }])
+        expect(wrapped.contentObj.mention.entities).toEqual([
+            { uid: "-3", offset: 0, length: 5 },
+        ])
+    })
+
     it("injects mention.humans=1 (@所有人 three-state path)", () => {
         const msg = new MessageText("@所有人 ping")
         const mn = new Mention()

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -739,7 +739,9 @@ export class Conversation
    *   data:/file: 注入）。
    * - plain 由 createRichTextContent 本地占位，server #232 Finalize 重算覆盖。
    * - mention：合并各文本块的 all/uids/humans/ais 到顶层，保证群里 @人/@所有AI 通知不丢
-   *   （vm.sendMessage 读 content.mention.humans/ais 注入）。
+   *   （vm.sendMessage 读 content.mention.humans/ais 注入）。这里不合并
+   *   entities：富文本发送的是 blocks，entity offset 需要映射到最终 plain 文本，
+   *   当前由接收侧 ais legacy fail-closed 兜底，避免 routing UID 误绑裸 @text。
    *
    * 返回 true 表示消息已入队；任一图片块准备失败则抛错（已 Toast 具体原因）。
    */

--- a/packages/dmworkbase/src/Components/Conversation/sendContentProxy.ts
+++ b/packages/dmworkbase/src/Components/Conversation/sendContentProxy.ts
@@ -9,7 +9,7 @@
  *   1. **space_id**（仅 DM / ChannelTypePerson）—— `filterPersonMessagesBySpace`
  *      (#784) 依赖。BotFather 等 Bot 用此判断用户当前 Space。
  *
- *   2. **mention.humans / mention.ais**（任意 channel）——
+ *   2. **mention.humans / mention.ais / mention.entities**（任意 channel）——
  *      `wukongimjssdk@1.3.5` 的 `MessageContent.encode()` 写 mention 时
  *      只取 `this.mention.all` / `this.mention.uids`，**整段覆盖**
  *      `contentObj.mention`：
@@ -25,9 +25,9 @@
  *      }
  *      ```
  *
- *      所以仅靠 `encodeJSON` 注入 `mention.humans|ais` 不够—— SDK encode 后
- *      仍会被覆盖。必须在 `encode()` 的 wire bytes 出炉后做 post-process
- *      （decode-modify-encode）才能保住三态字段。
+ *      所以仅靠 `encodeJSON` 注入 `mention.humans|ais|entities` 不够——
+ *      SDK encode 后仍会被覆盖。必须在 `encode()` 的 wire bytes 出炉后做
+ *      post-process（decode-modify-encode）才能保住这些字段。
  *
  *      群聊里发 "@所有AI" 时若不修复，server 端收不到 `mention.ais=1`，
  *      AI bot 不响应。参考 octo-web#62 / YUJ-1378。
@@ -79,7 +79,16 @@ export function wrapSendContentForInjection(
     const injectSpaceId = !!injection.spaceId
     const injectMentionHumans = !!injection.mentionHumans
     const injectMentionAis = !!injection.mentionAis
-    const injectMention = injectMentionHumans || injectMentionAis
+    const mentionAny = (content as any).mention
+    const mentionEntities =
+        Array.isArray(mentionAny?.entities) && mentionAny.entities.length > 0
+            ? mentionAny.entities
+            : Array.isArray((content as any).contentObj?.mention?.entities) &&
+                (content as any).contentObj.mention.entities.length > 0
+              ? (content as any).contentObj.mention.entities
+              : undefined
+    const injectMentionEntities = !!mentionEntities
+    const injectMention = injectMentionHumans || injectMentionAis || injectMentionEntities
     if (!injectSpaceId && !injectMention) {
         return content
     }
@@ -100,6 +109,7 @@ export function wrapSendContentForInjection(
         // 不同入口的输出一致。
         if (injectMention) {
             if (!obj.mention) obj.mention = {}
+            if (injectMentionEntities) obj.mention.entities = mentionEntities
             if (injectMentionHumans) obj.mention.humans = 1
             if (injectMentionAis) obj.mention.ais = 1
         }
@@ -154,6 +164,7 @@ export function wrapSendContentForInjection(
                 const str = new TextDecoder().decode(bytes)
                 const obj = JSON.parse(str)
                 if (!obj.mention) obj.mention = {}
+                if (injectMentionEntities) obj.mention.entities = mentionEntities
                 if (injectMentionHumans) obj.mention.humans = 1
                 if (injectMentionAis) obj.mention.ais = 1
                 bytes = new TextEncoder().encode(JSON.stringify(obj))
@@ -178,6 +189,7 @@ export function wrapSendContentForInjection(
     }
     if (injectMention) {
         mergedObj.mention = { ...(mergedObj.mention || {}) }
+        if (injectMentionEntities) mergedObj.mention.entities = mentionEntities
         if (injectMentionHumans) mergedObj.mention.humans = 1
         if (injectMentionAis) mergedObj.mention.ais = 1
     }

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -289,9 +289,18 @@ function formatMentionTextV2(text: string): {
       humans = true;
       result += `@${MENTION_LABEL_HUMANS}`;
     } else if (uid === MENTION_UID_AIS) {
-      // 新的三态：ais=1，文本插入 @所有AI，不进 entities 列表
+      // 新的三态：ais=1。这里也为 @所有AI 写入 sentinel entity：
+      // bot routing UIDs 会放进 mention.uids，entity 能让接收端走精确解析路径，
+      // 避免这些 routing UID 被 legacy parser 误绑到其它裸写的 @xxx 文本。
       ais = true;
-      result += `@${MENTION_LABEL_AIS}`;
+      const atName = `@${MENTION_LABEL_AIS}`;
+      const offset = result.length;
+      entities.push({
+        uid,
+        offset,
+        length: atName.length,
+      });
+      result += atName;
     } else {
       // 普通成员：以最新的 member.name 优先（avoid stale display label），fallback to label。
       const atName = membersRef.current?.find((m) => m.uid === uid)?.name

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -426,7 +426,12 @@ export class MessageWrap {
         }
 
         if (mention.uids && Array.isArray(mention.uids) && mention.uids.length > 0) {
-            return this.parseMentionLegacy(text, mention.uids)
+            const mentionAny = mention as any
+            const hasAisBroadcast = !!(mentionAny.ais || this.content.contentObj?.mention?.ais)
+            const legacyUids = hasAisBroadcast
+                ? mention.uids.slice(0, this.getLegacyMentionUidLimitForAis(mention.uids))
+                : mention.uids
+            return this.parseMentionLegacy(text, legacyUids)
         }
 
         // mention.all：把文本中的 @所有人/@all 替换成 uid="all" 的 mention Part
@@ -567,6 +572,58 @@ export class MessageWrap {
         }
 
         return parts
+    }
+
+    private getLegacyMentionUidLimitForAis(uids: string[]): number {
+        const routingUidCount = this.getAisRoutingUidCount(uids)
+        return Math.max(0, uids.length - routingUidCount)
+    }
+
+    private getAisRoutingUidCount(uids: string[]): number {
+        const uidSet = new Set(uids)
+
+        try {
+            const subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel) || []
+            const botUidSet = new Set(subscribers
+                .filter((sub: any) =>
+                    sub &&
+                    uidSet.has(sub.uid) &&
+                    sub.orgData?.robot === 1
+                )
+                .map((sub: any) => sub.uid)
+            )
+            let trailingBotCount = 0
+            for (let idx = uids.length - 1; idx >= 0; idx--) {
+                if (botUidSet.has(uids[idx])) {
+                    trailingBotCount++
+                    continue
+                }
+                break
+            }
+            if (trailingBotCount > 0) {
+                return trailingBotCount
+            }
+        } catch {
+            // Fall through to per-uid channelInfo lookup.
+        }
+
+        let trailingBotCount = 0
+        for (let idx = uids.length - 1; idx >= 0; idx--) {
+            try {
+                const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uids[idx], ChannelTypePerson))
+                if (
+                    uidSet.has(uids[idx]) &&
+                    info?.orgData?.robot === 1
+                ) {
+                    trailingBotCount++
+                    continue
+                }
+            } catch {
+                // Treat unknown uid as non-routing; do not trim beyond it.
+            }
+            break
+        }
+        return trailingBotCount
     }
     // 解析emoji
     parseEmoji(parts: Array<Part>): Array<Part> {

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -12,6 +12,8 @@ import {
     MENTION_UID_AIS,
     MENTION_UID_HUMANS,
     MENTION_UID_LEGACY_ALL,
+    mentionUidStateFromRobot,
+    type MentionUidState,
 } from "../Utils/mentionRender"
 
 export class ConversationWrap {
@@ -608,14 +610,17 @@ export class MessageWrap {
         return 0
     }
 
-    private getSubscriberMentionUidState(uids: string[]): Map<string, "bot" | "user"> {
-        const state = new Map<string, "bot" | "user">()
+    private getSubscriberMentionUidState(uids: string[]): Map<string, MentionUidState> {
+        const state = new Map<string, MentionUidState>()
         const uidSet = new Set(uids)
         try {
             const subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel) || []
             for (const sub of subscribers as any[]) {
                 if (sub?.uid && uidSet.has(sub.uid)) {
-                    state.set(sub.uid, sub.orgData?.robot === 1 ? "bot" : "user")
+                    const uidState = mentionUidStateFromRobot(sub.orgData?.robot)
+                    if (uidState !== "unknown") {
+                        state.set(sub.uid, uidState)
+                    }
                 }
             }
         } catch {
@@ -624,11 +629,11 @@ export class MessageWrap {
         return state
     }
 
-    private getChannelInfoMentionUidState(uid: string): "bot" | "user" | "unknown" {
+    private getChannelInfoMentionUidState(uid: string): MentionUidState {
         try {
             const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson))
             if (!info) return "unknown"
-            return info.orgData?.robot === 1 ? "bot" : "user"
+            return mentionUidStateFromRobot(info.orgData?.robot)
         } catch {
             return "unknown"
         }

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -6,7 +6,13 @@ import { DefaultEmojiService } from "./EmojiService"
 import { TypingManager } from "./TypingManager"
 import { getSpaceFilteredLastMessage, SYSTEM_BOTS } from "./SpaceService"
 import { isMessageContinuation } from "./messageContinuity"
-import { MENTION_LABEL_AIS, MENTION_LABEL_HUMANS } from "../Utils/mentionRender"
+import {
+    MENTION_LABEL_AIS,
+    MENTION_LABEL_HUMANS,
+    MENTION_UID_AIS,
+    MENTION_UID_HUMANS,
+    MENTION_UID_LEGACY_ALL,
+} from "../Utils/mentionRender"
 
 export class ConversationWrap {
     conversation: Conversation
@@ -506,10 +512,13 @@ export class MessageWrap {
                 continue
             }
 
-            // Defensive check: broadcast tokens (@all / @所有人 / @所有AI)
-            // should not bind to personal entities.
-            const mentionName = mentionText.slice(1)
-            if (mentionName.toLowerCase() === 'all' || mentionName === MENTION_LABEL_HUMANS || mentionName === MENTION_LABEL_AIS) {
+            // Broadcast entities use sentinel uids. Do not suppress by visible
+            // label alone: a real member can be named "所有AI" / "所有人".
+            if (
+                entity.uid === MENTION_UID_LEGACY_ALL ||
+                entity.uid === MENTION_UID_HUMANS ||
+                entity.uid === MENTION_UID_AIS
+            ) {
                 parts.push(new Part(PartType.text, mentionText))
                 cursor = entity.offset + entity.length
                 continue
@@ -576,6 +585,9 @@ export class MessageWrap {
 
     private getLegacyMentionUidLimitForAis(uids: string[]): number {
         const routingUidCount = this.getAisRoutingUidCount(uids)
+        if (routingUidCount === 0) {
+            return 0
+        }
         return Math.max(0, uids.length - routingUidCount)
     }
 

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -584,58 +584,54 @@ export class MessageWrap {
     }
 
     private getLegacyMentionUidLimitForAis(uids: string[]): number {
-        const routingUidCount = this.getAisRoutingUidCount(uids)
-        if (routingUidCount === 0) {
+        const subscriberState = this.getSubscriberMentionUidState(uids)
+        let trailingBotCount = 0
+
+        for (let idx = uids.length - 1; idx >= 0; idx--) {
+            const uid = uids[idx]
+            const state = subscriberState.get(uid) ?? this.getChannelInfoMentionUidState(uid)
+
+            if (state === "bot") {
+                trailingBotCount++
+                continue
+            }
+            if (state === "user") {
+                return uids.length - trailingBotCount
+            }
+
+            // Unknown metadata means we cannot separate real direct mentions
+            // from all-AI routing UIDs. Fail closed rather than binding a
+            // routing UID to unrelated raw @text.
             return 0
         }
-        return Math.max(0, uids.length - routingUidCount)
+
+        return 0
     }
 
-    private getAisRoutingUidCount(uids: string[]): number {
+    private getSubscriberMentionUidState(uids: string[]): Map<string, "bot" | "user"> {
+        const state = new Map<string, "bot" | "user">()
         const uidSet = new Set(uids)
-
         try {
             const subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel) || []
-            const botUidSet = new Set(subscribers
-                .filter((sub: any) =>
-                    sub &&
-                    uidSet.has(sub.uid) &&
-                    sub.orgData?.robot === 1
-                )
-                .map((sub: any) => sub.uid)
-            )
-            let trailingBotCount = 0
-            for (let idx = uids.length - 1; idx >= 0; idx--) {
-                if (botUidSet.has(uids[idx])) {
-                    trailingBotCount++
-                    continue
+            for (const sub of subscribers as any[]) {
+                if (sub?.uid && uidSet.has(sub.uid)) {
+                    state.set(sub.uid, sub.orgData?.robot === 1 ? "bot" : "user")
                 }
-                break
-            }
-            if (trailingBotCount > 0) {
-                return trailingBotCount
             }
         } catch {
-            // Fall through to per-uid channelInfo lookup.
+            // Fall through with whatever state was collected before failure.
         }
+        return state
+    }
 
-        let trailingBotCount = 0
-        for (let idx = uids.length - 1; idx >= 0; idx--) {
-            try {
-                const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uids[idx], ChannelTypePerson))
-                if (
-                    uidSet.has(uids[idx]) &&
-                    info?.orgData?.robot === 1
-                ) {
-                    trailingBotCount++
-                    continue
-                }
-            } catch {
-                // Treat unknown uid as non-routing; do not trim beyond it.
-            }
-            break
+    private getChannelInfoMentionUidState(uid: string): "bot" | "user" | "unknown" {
+        try {
+            const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson))
+            if (!info) return "unknown"
+            return info.orgData?.robot === 1 ? "bot" : "user"
+        } catch {
+            return "unknown"
         }
-        return trailingBotCount
     }
     // 解析emoji
     parseEmoji(parts: Array<Part>): Array<Part> {

--- a/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
@@ -3,6 +3,7 @@ import {
   buildMentionDropdownItems,
   MENTION_UID_AIS,
   MENTION_UID_HUMANS,
+  mentionUidStateFromRobot,
 } from "../mentionRender";
 
 const members = [
@@ -49,5 +50,19 @@ describe("buildMentionDropdownItems", () => {
     });
 
     expect(items.map((item) => item.uid)).toEqual(["u1"]);
+  });
+});
+
+describe("mentionUidStateFromRobot", () => {
+  it("classifies only explicit robot metadata as bot or user", () => {
+    expect(mentionUidStateFromRobot(1)).toBe("bot");
+    expect(mentionUidStateFromRobot(0)).toBe("user");
+  });
+
+  it("treats missing or malformed robot metadata as unknown", () => {
+    expect(mentionUidStateFromRobot(undefined)).toBe("unknown");
+    expect(mentionUidStateFromRobot(null)).toBe("unknown");
+    expect(mentionUidStateFromRobot("1")).toBe("unknown");
+    expect(mentionUidStateFromRobot(true)).toBe("unknown");
   });
 });

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -117,6 +117,14 @@ export const MENTION_UID_AIS = "-3";
 export const MENTION_LABEL_HUMANS = "所有人";
 export const MENTION_LABEL_AIS = "所有AI";
 
+export type MentionUidState = "bot" | "user" | "unknown";
+
+export function mentionUidStateFromRobot(robot: unknown): MentionUidState {
+  if (robot === 1) return "bot";
+  if (robot === 0) return "user";
+  return "unknown";
+}
+
 /**
  * Dropdown item shape returned by the @-mention suggestion factory.
  * Exported so unit tests can assert the exact selection order and


### PR DESCRIPTION
## Summary
- generate a sentinel entity for `@所有AI` when Web sends all-AI mentions
- preserve `mention.entities` in the send payload after WKSDK rewrites `mention`
- guard the render-side legacy parser for mobile/old-client messages that have `mention.ais + uids + no entities`, so routing bot UIDs are not bound to raw `@ops` text

## Tests
- `pnpm --dir apps/web exec vitest run src/__tests__/mentionRefactor.test.ts src/__tests__/voiceMention.test.ts`
- `pnpm exec vitest run packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts`
- `git diff --check`

Fixes #103
