### PR TITLE
feat: navigate recent tab to unread conversation

### DIFF
--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -7,13 +7,13 @@
  * - CreateCategoryModal 在此层管理，不依赖子组件挂载
  */
 import React, { useState, useMemo } from "react"
-import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+import { Channel, ChannelTypeGroup, ChannelTypePerson, WKSDK } from "wukongimjssdk"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import WKApp from "../../App"
 import { useCategoryList } from "../../Hooks/useCategoryList"
 import { useFollowSidebarContext } from "../../Hooks/useFollowSidebar"
 import FollowService from "../../Service/FollowService"
-import { parseThreadChannelId } from "../../Service/Thread"
+import { isEffectivelyMuted, parseThreadChannelId } from "../../Service/Thread"
 import { ConversationWrap } from "../../Service/Model"
 import { ConvFilter } from "../ConversationList"
 import ConversationList from "../ConversationList"
@@ -34,6 +34,26 @@ export function isVisibleInRecentTab(conv: ConversationWrap, now: number = Date.
     return (now - conv.timestamp * 1000) < RECENT_INACTIVE_THRESHOLD_MS
 }
 
+export function isMutedForRecentConversation(conv: ConversationWrap): boolean {
+    const isThread = conv.channel.channelType === ChannelTypeCommunityTopic
+    let parentChannelInfo: any | undefined
+    if (isThread) {
+        const parentGroupNo =
+            (conv.channelInfo?.orgData?.parentGroupNo as string | undefined) ||
+            parseThreadChannelId(conv.channel.channelID)?.groupNo
+        if (parentGroupNo) {
+            parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+                new Channel(parentGroupNo, ChannelTypeGroup)
+            )
+        }
+    }
+    return isEffectivelyMuted({
+        isThread,
+        channelInfo: conv.channelInfo,
+        parentChannelInfo,
+    })
+}
+
 export interface ChatConversationListProps {
     conversations: ConversationWrap[]
     filter: ConvFilter
@@ -47,6 +67,8 @@ export interface ChatConversationListProps {
     onOpenCreateCategoryRef?: React.MutableRefObject<(() => void) | null>
     /** 群聊创建成功后回调，用于刷新会话列表 */
     onGroupCreated?: () => void
+    /** 递增 token：变化时最近列表滚到第一条可导航未读 */
+    scrollToUnreadToken?: number
 }
 
 // 「+ 新建分组」入口在三个右键场景共用同一个 modal。建分类成功后,要把当时
@@ -72,6 +94,7 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
     onThreadOverflowClick,
     onOpenCreateCategoryRef,
     onGroupCreated,
+    scrollToUnreadToken,
 }) => {
     const { t } = useI18n()
     const {
@@ -209,6 +232,16 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
         const now = Date.now()
         return conversations.filter(conv => isVisibleInRecentTab(conv, now))
     }, [conversations, hideInactiveGroups])
+
+    const shouldScrollToRecentUnreadTarget = React.useCallback(
+        (conv: ConversationWrap) => {
+            if (filter === 'group') return false
+            if (conv.unread <= 0) return false
+            if (hideInactiveGroups && !isVisibleInRecentTab(conv)) return false
+            return !isMutedForRecentConversation(conv)
+        },
+        [filter, hideInactiveGroups]
+    )
 
     // 按 conv.channelType 把会话归入指定分类。三种 channel 走三套写操作:
     // - 子区:父群先 refollow + moveCategory,再 followThread(子区不能脱离父群单独分组)
@@ -418,6 +451,8 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                     onClearMessages={onClearMessages}
                     onThreadOverflowClick={onThreadOverflowClick}
                     extraContextMenus={buildExtraMenus}
+                    scrollToUnreadToken={scrollToUnreadToken}
+                    shouldScrollToUnreadTarget={shouldScrollToRecentUnreadTarget}
                 />
             )}
 

--- a/packages/dmworkbase/src/Components/ConversationList/index.css
+++ b/packages/dmworkbase/src/Components/ConversationList/index.css
@@ -219,6 +219,59 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   box-sizing: border-box;
 }
 
+.wk-conv-unread-num--nudge-a {
+  animation: wk-conv-unread-num-nudge-a 560ms ease;
+}
+
+.wk-conv-unread-num--nudge-b {
+  animation: wk-conv-unread-num-nudge-b 560ms ease;
+}
+
+@keyframes wk-conv-unread-num-nudge-a {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-2px);
+  }
+  40% {
+    transform: translateX(2px);
+  }
+  60% {
+    transform: translateX(-1px);
+  }
+  80% {
+    transform: translateX(1px);
+  }
+}
+
+@keyframes wk-conv-unread-num-nudge-b {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-2px);
+  }
+  40% {
+    transform: translateX(2px);
+  }
+  60% {
+    transform: translateX(-1px);
+  }
+  80% {
+    transform: translateX(1px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-conv-unread-num--nudge-a,
+  .wk-conv-unread-num--nudge-b {
+    animation: none;
+  }
+}
+
 /* 头像右上角小红点（静音 + 有未读，低打扰提示） */
 .wk-conv-unread-dot {
   position: absolute;

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -272,6 +272,8 @@ export interface ConversationListState {
   selectConversationWrap?: ConversationWrap;
   /** compact 模式：已展开全部子区的父群聊 ID 集合（点击 +N 后加入） */
   expandedGroupIds: Set<string>;
+  locatingUnreadKey?: string;
+  locatingUnreadPulse: number;
 }
 
 export default class ConversationList extends Component<
@@ -288,6 +290,7 @@ export default class ConversationList extends Component<
   private itemRefs = new Map<string, HTMLDivElement>();
   private lastRenderableItems: ConversationWrap[] = [];
   private scrollFrame: number | null = null;
+  private unreadNudgeTimer: number | null = null;
   private _storageKey(): string {
     const uid = WKApp.loginInfo?.uid || 'unknown';
     const spaceId = WKApp.shared?.currentSpaceId || 'default';
@@ -306,7 +309,11 @@ export default class ConversationList extends Component<
     } catch {
       restoredIds = new Set();
     }
-    this.state = { expandedGroupIds: restoredIds };
+    this.state = {
+      expandedGroupIds: restoredIds,
+      locatingUnreadKey: undefined,
+      locatingUnreadPulse: 0,
+    };
   }
 
   componentDidMount() {
@@ -338,6 +345,14 @@ export default class ConversationList extends Component<
     ) {
       window.cancelAnimationFrame(this.scrollFrame);
       this.scrollFrame = null;
+    }
+    if (
+      this.unreadNudgeTimer !== null &&
+      typeof window !== "undefined" &&
+      typeof window.clearTimeout === "function"
+    ) {
+      window.clearTimeout(this.unreadNudgeTimer);
+      this.unreadNudgeTimer = null;
     }
     WKSDK.shared().channelManager.removeListener(this.channelListener);
     TypingManager.shared.removeTypingListener(this.typingListener);
@@ -396,6 +411,36 @@ export default class ConversationList extends Component<
     } else {
       root.scrollTop = targetTop;
     }
+
+    this.nudgeUnreadBadge(target.channel.getChannelKey());
+  }
+
+  private nudgeUnreadBadge(channelKey: string) {
+    if (
+      this.unreadNudgeTimer !== null &&
+      typeof window !== "undefined" &&
+      typeof window.clearTimeout === "function"
+    ) {
+      window.clearTimeout(this.unreadNudgeTimer);
+      this.unreadNudgeTimer = null;
+    }
+
+    this.setState((state) => ({
+      locatingUnreadKey: channelKey,
+      locatingUnreadPulse: state.locatingUnreadPulse + 1,
+    }));
+
+    if (
+      typeof window === "undefined" ||
+      typeof window.setTimeout !== "function"
+    ) {
+      return;
+    }
+
+    this.unreadNudgeTimer = window.setTimeout(() => {
+      this.unreadNudgeTimer = null;
+      this.setState({ locatingUnreadKey: undefined });
+    }, 700);
   }
 
   _handleScroll = () => {
@@ -617,6 +662,7 @@ export default class ConversationList extends Component<
     }
 
     const { select, onClick } = this.props;
+    const { locatingUnreadKey, locatingUnreadPulse } = this.state;
     const typing = TypingManager.shared.getTyping(conversationWrap.channel);
     const selected = select && select.isEqual(conversationWrap.channel);
     // 父群下的子区折叠到 thread-overflow（默认不展开），父群 badge 必须把
@@ -636,6 +682,12 @@ export default class ConversationList extends Component<
     // 不再套 .wk-conversationlist-item-thread（避免缩进 + 树形连接线视觉嵌套）。
     const avatarChannel = isThread && parentChannel ? parentChannel : conversationWrap.channel;
     const isDM = avatarChannel.channelType === ChannelTypePerson;
+    const unreadNudgeClass =
+      locatingUnreadKey === conversationWrap.channel.getChannelKey()
+        ? locatingUnreadPulse % 2 === 0
+          ? "wk-conv-unread-num--nudge-a"
+          : "wk-conv-unread-num--nudge-b"
+        : undefined;
     return (
       <div
         ref={(node) => this.setConversationItemRef(conversationWrap, node)}
@@ -677,7 +729,12 @@ export default class ConversationList extends Component<
                 ></OnlineStatusBadge>
               ) : undefined}
               {totalUnread > 0 && !effectiveMute && (
-                <span className="wk-conv-unread-num">
+                <span
+                  className={classNames(
+                    "wk-conv-unread-num",
+                    unreadNudgeClass
+                  )}
+                >
                   {totalUnread > 99 ? "99+" : totalUnread}
                 </span>
               )}

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -262,6 +262,10 @@ export interface ConversationListProps {
    *  pin 与拖拽语义冲突（pin 会强制顶到分组顶端覆盖手动顺序），所以在关注 tab 移除 pin 入口。
    *  最近 tab 仍保留 pin。 */
   hidePin?: boolean;
+  /** 递增 token：变化时滚到第一条 shouldScrollToUnreadTarget 命中的会话 */
+  scrollToUnreadToken?: number;
+  /** 外部提供导航目标口径，避免列表层重复理解具体业务规则 */
+  shouldScrollToUnreadTarget?: (conversation: ConversationWrap) => boolean;
 }
 
 export interface ConversationListState {
@@ -280,6 +284,10 @@ export default class ConversationList extends Component<
   channelListener!: ChannelInfoListener;
   contextMenusContext!: ContextMenusContext;
   typingListener!: TypingListener;
+  private listRef = React.createRef<HTMLDivElement>();
+  private itemRefs = new Map<string, HTMLDivElement>();
+  private lastRenderableItems: ConversationWrap[] = [];
+  private scrollFrame: number | null = null;
   private _storageKey(): string {
     const uid = WKApp.loginInfo?.uid || 'unknown';
     const spaceId = WKApp.shared?.currentSpaceId || 'default';
@@ -313,9 +321,81 @@ export default class ConversationList extends Component<
     TypingManager.shared.addTypingListener(this.typingListener);
   }
 
+  componentDidUpdate(prevProps: ConversationListProps) {
+    if (
+      this.props.scrollToUnreadToken !== undefined &&
+      this.props.scrollToUnreadToken !== prevProps.scrollToUnreadToken
+    ) {
+      this.scheduleScrollToFirstUnreadTarget();
+    }
+  }
+
   componentWillUnmount() {
+    if (
+      this.scrollFrame !== null &&
+      typeof window !== "undefined" &&
+      typeof window.cancelAnimationFrame === "function"
+    ) {
+      window.cancelAnimationFrame(this.scrollFrame);
+      this.scrollFrame = null;
+    }
     WKSDK.shared().channelManager.removeListener(this.channelListener);
     TypingManager.shared.removeTypingListener(this.typingListener);
+  }
+
+  private setConversationItemRef(
+    conversationWrap: ConversationWrap,
+    node: HTMLDivElement | null
+  ) {
+    const key = conversationWrap.channel.getChannelKey();
+    if (node) {
+      this.itemRefs.set(key, node);
+    } else {
+      this.itemRefs.delete(key);
+    }
+  }
+
+  private scheduleScrollToFirstUnreadTarget() {
+    if (
+      typeof window === "undefined" ||
+      typeof window.requestAnimationFrame !== "function"
+    ) {
+      this.scrollToFirstUnreadTarget();
+      return;
+    }
+
+    if (this.scrollFrame !== null) {
+      window.cancelAnimationFrame(this.scrollFrame);
+    }
+    this.scrollFrame = window.requestAnimationFrame(() => {
+      this.scrollFrame = null;
+      this.scrollToFirstUnreadTarget();
+    });
+  }
+
+  private scrollToFirstUnreadTarget() {
+    const root = this.listRef.current;
+    const shouldTarget = this.props.shouldScrollToUnreadTarget;
+    if (!root || !shouldTarget) return;
+
+    const target = this.lastRenderableItems.find((conv) => shouldTarget(conv));
+    if (!target) return;
+
+    const node = this.itemRefs.get(target.channel.getChannelKey());
+    if (!node) return;
+
+    const rootRect = root.getBoundingClientRect();
+    const nodeRect = node.getBoundingClientRect();
+    const targetTop = Math.max(0, root.scrollTop + nodeRect.top - rootRect.top);
+
+    if (typeof root.scrollTo === "function") {
+      root.scrollTo({
+        top: targetTop,
+        behavior: "smooth",
+      });
+    } else {
+      root.scrollTop = targetTop;
+    }
   }
 
   _handleScroll = () => {
@@ -558,6 +638,7 @@ export default class ConversationList extends Component<
     const isDM = avatarChannel.channelType === ChannelTypePerson;
     return (
       <div
+        ref={(node) => this.setConversationItemRef(conversationWrap, node)}
         key={conversationWrap.channel.getChannelKey()}
         onClick={() => {
           if (onClick) {
@@ -984,6 +1065,9 @@ export default class ConversationList extends Component<
 
     const { onThreadOverflowClick } = this.props;
     const { expandedGroupIds } = this.state;
+    this.lastRenderableItems = [...finalPinned, ...finalRecent].filter(
+      (item): item is ConversationWrap => !("type" in item)
+    );
 
     const renderItem = (
       item:
@@ -1055,6 +1139,7 @@ export default class ConversationList extends Component<
 
     return (
       <div
+        ref={this.listRef}
         id="wk-conversationlist"
         className="wk-conversationlist"
         onScroll={this._handleScroll}

--- a/packages/dmworkbase/src/Components/SidebarTabBar/SidebarTabBar.stories.tsx
+++ b/packages/dmworkbase/src/Components/SidebarTabBar/SidebarTabBar.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof SidebarTabBar> = {
 - \`followUnread\`：关注未读总数
 - \`recentUnread\`：最近未读总数
 - \`onTabChange\`：切换回调
+- \`onActiveTabClick\`：点击当前已激活 Tab 时触发
 
 **States：**
 - 关注激活
@@ -136,5 +137,34 @@ export const TabSwitch: Story = {
     // 再点回关注
     await userEvent.click(btns[0])
     expect(btns[0].className).toContain('active')
+  },
+}
+
+export const ActiveTabClick: Story = {
+  name: '点击已激活 Tab',
+  render: () => {
+    const [activeClicks, setActiveClicks] = useState<SidebarTab[]>([])
+    return (
+      <div>
+        <SidebarTabBar
+          activeTab="recent"
+          followUnread={0}
+          recentUnread={3}
+          onTabChange={() => {}}
+          onActiveTabClick={(tab) => setActiveClicks((items) => [...items, tab])}
+        />
+        <div data-testid="active-clicks">{activeClicks.join(',')}</div>
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const btns = canvas.getAllByRole('button')
+
+    await userEvent.click(btns[1])
+    expect(canvas.getByTestId('active-clicks').textContent).toBe('recent')
+
+    await userEvent.click(canvas.getByText('3'))
+    expect(canvas.getByTestId('active-clicks').textContent).toBe('recent,recent')
   },
 }

--- a/packages/dmworkbase/src/Components/SidebarTabBar/__tests__/SidebarTabBar.test.tsx
+++ b/packages/dmworkbase/src/Components/SidebarTabBar/__tests__/SidebarTabBar.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let SidebarTabBar: typeof import('../index').default
+let container: HTMLDivElement
+
+beforeAll(async () => {
+  vi.doMock('../../../i18n', () => ({
+    useI18n: () => ({ t: (key: string) => key }),
+  }))
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    fillRect: vi.fn(),
+    fillStyle: '',
+  })) as any
+  SidebarTabBar = (await import('../index')).default
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container)
+  })
+  container.remove()
+})
+
+describe('SidebarTabBar', () => {
+  it('calls onTabChange when clicking an inactive tab', () => {
+    const onTabChange = vi.fn()
+    const onActiveTabClick = vi.fn()
+
+    act(() => {
+      ReactDOM.render(
+        <SidebarTabBar
+          activeTab="follow"
+          followUnread={0}
+          recentUnread={3}
+          onTabChange={onTabChange}
+          onActiveTabClick={onActiveTabClick}
+        />,
+        container
+      )
+    })
+
+    act(() => {
+      container.querySelectorAll('button')[1].click()
+    })
+
+    expect(onTabChange).toHaveBeenCalledWith('recent')
+    expect(onActiveTabClick).not.toHaveBeenCalled()
+  })
+
+  it('calls onActiveTabClick when clicking the active tab', () => {
+    const onTabChange = vi.fn()
+    const onActiveTabClick = vi.fn()
+
+    act(() => {
+      ReactDOM.render(
+        <SidebarTabBar
+          activeTab="recent"
+          followUnread={0}
+          recentUnread={3}
+          onTabChange={onTabChange}
+          onActiveTabClick={onActiveTabClick}
+        />,
+        container
+      )
+    })
+
+    act(() => {
+      container.querySelectorAll('button')[1].click()
+    })
+
+    expect(onActiveTabClick).toHaveBeenCalledWith('recent')
+    expect(onTabChange).not.toHaveBeenCalled()
+  })
+
+  it('treats clicking the unread badge as clicking the active tab', () => {
+    const onActiveTabClick = vi.fn()
+
+    act(() => {
+      ReactDOM.render(
+        <SidebarTabBar
+          activeTab="recent"
+          followUnread={0}
+          recentUnread={3}
+          onTabChange={() => {}}
+          onActiveTabClick={onActiveTabClick}
+        />,
+        container
+      )
+    })
+
+    const badge = Array.from(
+      container.querySelectorAll('.wk-sidebar-tabbar__badge')
+    ).find((el) => el.textContent === '3') as HTMLElement
+    act(() => {
+      badge.click()
+    })
+
+    expect(onActiveTabClick).toHaveBeenCalledWith('recent')
+  })
+})

--- a/packages/dmworkbase/src/Components/SidebarTabBar/index.tsx
+++ b/packages/dmworkbase/src/Components/SidebarTabBar/index.tsx
@@ -9,6 +9,7 @@ export interface SidebarTabBarProps {
     followUnread: number
     recentUnread: number
     onTabChange: (tab: SidebarTab) => void
+    onActiveTabClick?: (tab: SidebarTab) => void
 }
 
 const SidebarTabBar: React.FC<SidebarTabBarProps> = ({
@@ -16,14 +17,23 @@ const SidebarTabBar: React.FC<SidebarTabBarProps> = ({
     followUnread,
     recentUnread,
     onTabChange,
+    onActiveTabClick,
 }) => {
     const { t } = useI18n()
+    const handleTabClick = (tab: SidebarTab) => {
+        if (activeTab === tab) {
+            onActiveTabClick?.(tab)
+            return
+        }
+        onTabChange(tab)
+    }
+
     return (
         <div className="wk-sidebar-tabbar">
             <div className="wk-sidebar-tabbar__container">
                 <button
                     className={`wk-sidebar-tabbar__btn ${activeTab === 'follow' ? 'wk-sidebar-tabbar__btn--active' : ''}`}
-                    onClick={() => onTabChange('follow')}
+                    onClick={() => handleTabClick('follow')}
                 >
                     <span className="wk-sidebar-tabbar__label">{t("base.sidebarTabBar.follow")}</span>
                     {followUnread > 0 && (
@@ -34,7 +44,7 @@ const SidebarTabBar: React.FC<SidebarTabBarProps> = ({
                 </button>
                 <button
                     className={`wk-sidebar-tabbar__btn ${activeTab === 'recent' ? 'wk-sidebar-tabbar__btn--active' : ''}`}
-                    onClick={() => onTabChange('recent')}
+                    onClick={() => handleTabClick('recent')}
                 >
                     <span className="wk-sidebar-tabbar__label">{t("base.sidebarTabBar.recent")}</span>
                     {recentUnread > 0 && (

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -5,7 +5,10 @@ import ConversationList, {
 } from "../../Components/ConversationList";
 import SidebarTabBar, { SidebarTab } from "../../Components/SidebarTabBar";
 import ConversationListGrouped from "../../Components/ConversationListGrouped";
-import ChatConversationList, { isVisibleInRecentTab } from "../../Components/ChatConversationList";
+import ChatConversationList, {
+  isMutedForRecentConversation,
+  isVisibleInRecentTab,
+} from "../../Components/ChatConversationList";
 import Provider from "../../Service/Provider";
 import { ErrorBoundary } from "../../Components/ErrorBoundary";
 
@@ -61,6 +64,7 @@ interface SidebarTabBarWithBadgesProps {
   conversations: ConversationWrap[];
   activeTab: SidebarTab;
   onTabChange: (tab: SidebarTab) => void;
+  onRecentUnreadNavigate?: () => void;
 }
 
 /**
@@ -79,6 +83,7 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
   conversations,
   activeTab,
   onTabChange,
+  onRecentUnreadNavigate,
 }) => {
   const { items } = useFollowSidebarContext();
 
@@ -110,22 +115,6 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
     return isEffectivelyMuted({ isThread, channelInfo: info, parentChannelInfo });
   };
 
-  const isConversationMuted = (c: ConversationWrap): boolean => {
-    const isThread = c.channel.channelType === ChannelTypeCommunityTopic;
-    let parentChannelInfo: any | undefined;
-    if (isThread) {
-      const parentGroupNo =
-        (c.channelInfo?.orgData?.parentGroupNo as string | undefined) ||
-        parseThreadChannelId(c.channel.channelID)?.groupNo;
-      if (parentGroupNo) {
-        parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
-          new Channel(parentGroupNo, ChannelTypeGroup),
-        );
-      }
-    }
-    return isEffectivelyMuted({ isThread, channelInfo: c.channelInfo, parentChannelInfo });
-  };
-
   // sidebar items 是 /sidebar/sync 的快照，IM 缓存里 conv 才是 reactive 的。
   // IM 缓存有这条会话就用 live unread；没有（sidebar-only 关注，从未聊过）才
   // fallback sidebar 的 unread 快照——这样新消息一来 badge 即刻同步，sidebar-
@@ -150,7 +139,7 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
       // 与 ChatConversationList 的 hideInactiveGroups 渲染过滤一致：3 天不活跃的群
       // 不算入 badge，否则会出现「红点 N 但列表里看不到对应未读」。
       if (!isVisibleInRecentTab(c)) return sum;
-      if (isConversationMuted(c)) return sum;
+      if (isMutedForRecentConversation(c)) return sum;
       return sum + (c.unread || 0);
     },
     0,
@@ -162,6 +151,11 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
       followUnread={followUnread}
       recentUnread={recentUnread}
       onTabChange={onTabChange}
+      onActiveTabClick={(tab) => {
+        if (tab === "recent" && activeTab === "recent" && recentUnread > 0) {
+          onRecentUnreadNavigate?.();
+        }
+      }}
     />
   );
 };
@@ -1084,6 +1078,7 @@ interface ChatPageState {
   activeTab: SidebarTab;
   currentSpaceName: string;
   pendingConfirm: null | { onOk: () => void }; // 附件切换确认弹窗
+  recentUnreadJumpToken: number;
 }
 
 export default class ChatPage extends Component<any, ChatPageState> {
@@ -1101,6 +1096,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
       activeTab: getSavedTab(),
       currentSpaceName: WKApp.config.appName,
       pendingConfirm: null,
+      recentUnreadJumpToken: 0,
     };
   }
 
@@ -1109,6 +1105,12 @@ export default class ChatPage extends Component<any, ChatPageState> {
       localStorage.setItem(SIDEBAR_TAB_KEY, tab);
     } catch {}
     this.setState({ activeTab: tab });
+  };
+
+  _handleRecentUnreadNavigate = () => {
+    this.setState((state) => ({
+      recentUnreadJumpToken: state.recentUnreadJumpToken + 1,
+    }));
   };
 
   private _onSpaceChanged?: (space: any) => void;
@@ -1178,7 +1180,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
           return this.vm;
         }}
         render={(vm: ChatVM) => {
-          const { activeTab } = this.state;
+          const { activeTab, recentUnreadJumpToken } = this.state;
           // filter 用于 ConversationList
           // follow Tab 用 group（分组视图），recent Tab 用 all（所有会话混合）
           const filter: ConvFilter = activeTab === "follow" ? "group" : "all";
@@ -1280,6 +1282,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
                     conversations={vm.conversations}
                     activeTab={activeTab}
                     onTabChange={this._handleTabChange}
+                    onRecentUnreadNavigate={this._handleRecentUnreadNavigate}
                   />
                   <div className="wk-chat-conversation-list">
                     {vm.loading ? (
@@ -1349,6 +1352,11 @@ export default class ChatPage extends Component<any, ChatPageState> {
                           filter={filter}
                           hideInactiveGroups={activeTab === "recent"}
                           select={WKApp.shared.openChannel}
+                          scrollToUnreadToken={
+                            activeTab === "recent"
+                              ? recentUnreadJumpToken
+                              : undefined
+                          }
                           onOpenCreateCategoryRef={this.openCreateCategoryRef}
                           onGroupCreated={() =>
                             vm.reloadRequestConversationList()


### PR DESCRIPTION
## Summary
- add active Recent tab click handling to jump to the first visible unread conversation
- keep Recent unread badge and navigation target sharing visibility/mute rules
- add unread badge nudge feedback when the target is already visible or after scrolling

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/SidebarTabBar/__tests__/SidebarTabBar.test.tsx --config packages/dmworkbase/vitest.config.ts
- pnpm --filter @octo/web build