### PR TITLE
feat: raise chat selection limit from 10 to 30

### DIFF
--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -5,6 +5,7 @@ import { I18nContext } from "@octo/base";
 import type { ChatCandidate } from "../types/summary";
 import * as api from "../api/summaryApi";
 import AiBadge from "@octo/base/src/Components/AiBadge";
+import { MAX_CHAT_SELECT } from "../constants/limits";
 
 interface Props {
     visible: boolean;
@@ -21,8 +22,6 @@ interface State {
     loading: boolean;
     localSelected: ChatCandidate[];
 }
-
-const MAX_SELECT = 30;
 
 interface DisplayEntry {
     item: ChatCandidate;
@@ -68,7 +67,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     handleToggle = (item: ChatCandidate) => {
         const { localSelected } = this.state;
-        const maxSelect = this.props.maxSelect ?? MAX_SELECT;
+        const maxSelect = this.props.maxSelect ?? MAX_CHAT_SELECT;
         const existing = localSelected.find((s) => s.chat_id === item.chat_id);
         if (existing) {
             this.setState({ localSelected: localSelected.filter((s) => s.chat_id !== item.chat_id) });
@@ -167,7 +166,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     renderItem = (entry: DisplayEntry) => {
         const { localSelected } = this.state;
-        const maxSelect = this.props.maxSelect ?? MAX_SELECT;
+        const maxSelect = this.props.maxSelect ?? MAX_CHAT_SELECT;
         const { item, indent } = entry;
         const { t } = this.context;
         const checked = !!localSelected.find((s) => s.chat_id === item.chat_id);
@@ -214,7 +213,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
     };
 
     render() {
-        const { visible, onCancel, maxSelect = MAX_SELECT } = this.props;
+        const { visible, onCancel, maxSelect = MAX_CHAT_SELECT } = this.props;
         const { keyword, activeTab, loading, localSelected } = this.state;
         const { t } = this.context;
         const displayList = this.getDisplayList();

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -22,7 +22,7 @@ interface State {
     localSelected: ChatCandidate[];
 }
 
-const MAX_SELECT = 10;
+const MAX_SELECT = 30;
 
 interface DisplayEntry {
     item: ChatCandidate;

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -282,7 +282,6 @@ export default class ChatSummaryNewModal extends Component<
                         this.setState({ selectedChats: chats, showChatSelector: false })
                     }
                     onCancel={() => this.setState({ showChatSelector: false })}
-                    maxSelect={10}
                 />
             </>
         );

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -10,6 +10,7 @@ import { resolveTemplate, computeTemplateSelection, type ResolvableTemplate } fr
 import * as summaryApi from '../api/summaryApi';
 import { getTopicTemplates } from '../api/summaryApi';
 import { TOPIC_TEMPLATES } from '../constants/templates';
+import { MAX_CHAT_SELECT } from '../constants/limits';
 import TemplateCard from './TemplateCard';
 import ChatSelectorModal from './ChatSelectorModal';
 import './ChatSummaryNewModal.css';
@@ -278,6 +279,7 @@ export default class ChatSummaryNewModal extends Component<
                 <ChatSelectorModal
                     visible={showChatSelector}
                     selected={selectedChats}
+                    maxSelect={MAX_CHAT_SELECT}
                     onConfirm={(chats) =>
                         this.setState({ selectedChats: chats, showChatSelector: false })
                     }

--- a/packages/dmworksummary/src/constants/limits.ts
+++ b/packages/dmworksummary/src/constants/limits.ts
@@ -1,0 +1,2 @@
+/** Max number of chats a user can select as sources for a summary. */
+export const MAX_CHAT_SELECT = 30;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -19,6 +19,7 @@ import MemberSelectorModal from "../components/MemberSelectorModal";
 import ScheduleConfigModal from "../components/ScheduleConfigModal";
 import TemplateCard from "../components/TemplateCard";
 import { TOPIC_TEMPLATES } from "../constants/templates";
+import { MAX_CHAT_SELECT } from "../constants/limits";
 import type {
     CreateSummaryParams,
     ChatCandidate,
@@ -367,6 +368,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 <ChatSelectorModal
                     visible={showChatSelector}
                     selected={selectedChats}
+                    maxSelect={MAX_CHAT_SELECT}
                     onConfirm={(chats) => this.setState({ selectedChats: chats, showChatSelector: false })}
                     onCancel={() => this.setState({ showChatSelector: false })}
                 />

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -369,7 +369,6 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                     selected={selectedChats}
                     onConfirm={(chats) => this.setState({ selectedChats: chats, showChatSelector: false })}
                     onCancel={() => this.setState({ showChatSelector: false })}
-                    maxSelect={10}
                 />
                 <MemberSelectorModal
                     visible={showMemberSelector}


### PR DESCRIPTION
## What
Raise the maximum number of selectable chats (information sources) in the smart-summary chat selector from **10** to **30**.

## Why
The previous cap of 10 chats was too low for users who need to summarize across more conversations. The limit is enforced on both frontend and backend; this PR covers the frontend half (backend: Mininglamp-OSS/octo-smart-summary#64).

## Changes
- `packages/dmworksummary/src/components/ChatSelectorModal.tsx`
  - Raise the default selection cap `MAX_SELECT` from `10` to `30`.
  - All dependent logic (selection guard, disabled-checkbox state, header count display) derives from `maxSelect` which falls back to `MAX_SELECT`, so it picks up the new default automatically.
  - The optional `maxSelect` prop override is preserved.

## Testing
- Constant change; dependent UI logic verified to reference `maxSelect`.

Closes #284
