### PR TITLE
feat: send summary notify tip to groups when smart summary completes

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1812,6 +1812,7 @@ export class Conversation
     const isSystemMessage =
       message.revoke ||
       message.contentType === MessageContentTypeConst.screenshot ||
+      message.contentType === MessageContentTypeConst.summaryNotify ||
       (message.contentType >= 1000 &&
         message.contentType <= 2000 &&
         message.contentType !== MessageContentTypeConst.threadCreated);

--- a/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
@@ -1,0 +1,58 @@
+import { Channel, ChannelTypePerson, WKSDK, MessageContent } from "wukongimjssdk";
+import React from "react";
+import WKApp from "../../App";
+import { MessageContentTypeConst } from "../../Service/Const";
+import { MessageCell } from "../MessageCell";
+import { t } from "../../i18n";
+
+
+export class SummaryNotifyContent extends MessageContent {
+    fromUID!: string
+    fromName!: string
+
+
+    get tip() {
+        let name = ""
+        if (this.fromUID === WKApp.loginInfo.uid) {
+            name = t("base.message.summaryNotify.you")
+        } else {
+            let channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(this.fromUID, ChannelTypePerson))
+            if (channelInfo) {
+                name = channelInfo?.orgData?.displayName
+            } else {
+                name = this.fromName
+            }
+        }
+        return t("base.message.summaryNotify.text", { values: { name } })
+    }
+
+    encodeJSON(): Record<string, any> {
+        return {
+            type: this.contentType,
+            from_uid: this.fromUID,
+            from_name: this.fromName,
+        }
+    }
+
+    decodeJSON(content: any): void {
+        this.fromUID = content["from_uid"]
+        this.fromName = content["from_name"]
+    }
+
+    get contentType() {
+        return MessageContentTypeConst.summaryNotify
+    }
+
+    get conversationDigest() {
+        return this.tip
+    }
+
+}
+
+export class SummaryNotifyCell extends MessageCell {
+    render() {
+        const { message } = this.props
+        let content = message.content as SummaryNotifyContent
+        return <div className="wk-message-system">{content.tip}</div>
+    }
+}

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -67,6 +67,7 @@ export class MessageContentTypeConst {
   static newGroupOwner: number = 1008 // 新的管理员
   static approveGroupMember: number = 1009 // 审批群成员
   static screenshot:number = 20 // 截屏消息
+  static summaryNotify:number = 21 // 总结通知
 
   // 音频通话消息号段 9900 - 9999
   static rtcResult:number = 9989 // 音视频通话结果

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -727,6 +727,8 @@
   "message.mergeForward.chatRecord": "Chat history",
   "message.screenshot.text": "{{name}} took a screenshot in the chat",
   "message.screenshot.you": "You",
+  "message.summaryNotify.text": "{{name}} summarized the chat",
+  "message.summaryNotify.you": "You",
   "message.signal.unavailable": "This message uses end-to-end encryption and cannot be decrypted on web. View it on mobile.",
   "message.unknown.unsupportedWithType": "[This message cannot be viewed here. Open it on mobile for details ({{type}})]",
   "message.unsupport.tip": "[Received a message type not supported on web. View it on mobile.]",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -728,6 +728,8 @@
   "message.mergeForward.chatRecord": "聊天记录",
   "message.screenshot.text": "{{name}}在聊天中截屏了",
   "message.screenshot.you": "你",
+  "message.summaryNotify.text": "{{name}}总结了群聊内容",
+  "message.summaryNotify.you": "你",
   "message.signal.unavailable": "此消息已采用端对端加密，web端无法解密，请在手机端查看",
   "message.unknown.unsupportedWithType": "[此消息不支持查看，请至手机端查看详情({{type}})]",
   "message.unsupport.tip": "[收到一条网页版暂不支持的消息类型，请在手机上查看]",

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -48,6 +48,8 @@ export * from "./Messages/Base"
 
 export * from "./Messages/MessageCell"
 
+export * from "./Messages/SummaryNotify"
+
 export * from "./Service/Section";
 export * from "./Components/ListItem";
 

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -91,6 +91,7 @@ import { isMessageSelectable } from "./Service/messageSelection";
 import ConversationVM from "./Components/Conversation/vm";
 import { ChannelAvatar } from "./Components/ChannelAvatar";
 import { ScreenshotCell, ScreenshotContent } from "./Messages/Screenshot";
+import { SummaryNotifyCell, SummaryNotifyContent } from "./Messages/SummaryNotify";
 import FileToolbar from "./Components/FileToolbar";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { SubscriberList } from "./Components/Subscribers/list";
@@ -248,6 +249,8 @@ export default class BaseModule implements IModule {
             return LocationCell;
           case MessageContentTypeConst.screenshot:
             return ScreenshotCell;
+          case MessageContentTypeConst.summaryNotify:
+            return SummaryNotifyCell;
           case MessageContentType.signalMessage: // 端对端加密错误消息
           case MessageContentTypeConst.approveGroupMember: // 审批群成员
             return ApproveGroupMemberCell;
@@ -305,6 +308,10 @@ export default class BaseModule implements IModule {
     WKSDK.shared().register(
       MessageContentTypeConst.screenshot,
       () => new ScreenshotContent()
+    );
+    WKSDK.shared().register(
+      MessageContentTypeConst.summaryNotify,
+      () => new SummaryNotifyContent()
     );
     // 加入组织
     WKSDK.shared().register(

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -4,7 +4,8 @@ import { Toast } from '@douyinfe/semi-ui';
 import { I18nContext } from '@octo/base';
 import * as summaryApi from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
-import { TaskStatus } from '../types/summary';
+import { TaskStatus, SourceType } from '../types/summary';
+import { sendSummaryNotifyTip } from '../utils/sendSummaryNotifyTip';
 import SummaryCard from './SummaryCard';
 
 interface ChatSummaryHistoryProps {
@@ -29,6 +30,7 @@ export default class ChatSummaryHistory extends Component<
     private abortController: AbortController | null = null;
     private pollTimer: ReturnType<typeof setInterval> | null = null;
     private isPolling = false;
+    private notifiedTaskIds = new Set<number>();
 
     constructor(props: ChatSummaryHistoryProps) {
         super(props);
@@ -98,16 +100,32 @@ export default class ChatSummaryHistory extends Component<
             const updates = await summaryApi.batchStatus(taskIds);
             const updateMap = new Map(updates.map(u => [u.id, u]));
             let changed = false;
+            const completedTaskIds: number[] = [];
             const newItems = this.state.items.map(item => {
                 const update = updateMap.get(item.task_id);
                 if (update && update.status !== item.status) {
                     changed = true;
+                    if (update.status === TaskStatus.COMPLETED && !this.notifiedTaskIds.has(item.task_id)) {
+                        completedTaskIds.push(item.task_id);
+                    }
                     return { ...item, status: update.status };
                 }
                 return item;
             });
             if (changed) {
                 this.setState({ items: newItems }, () => this.maybeStartPoll());
+            }
+            // Send summary notify tips for newly completed tasks
+            for (const taskId of completedTaskIds) {
+                this.notifiedTaskIds.add(taskId);
+                try {
+                    const detail = await summaryApi.getSummaryDetail(taskId);
+                    if (detail.sources?.length > 0) {
+                        sendSummaryNotifyTip(detail.sources);
+                    }
+                } catch {
+                    // best-effort
+                }
             }
         } catch {
             // ignore

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -12,6 +12,7 @@ import { Channel, ChannelTypeGroup, ChannelTypePerson, MessageText, WKSDK } from
 import { I18nContext, t } from "@octo/base";
 import WKApp from "@octo/base/src/App";
 import { splitSummaryText } from "../utils/splitMessage";
+import { sendSummaryNotifyTip } from "../utils/sendSummaryNotifyTip";
 import SummaryConfirmPage from "./SummaryConfirmPage";
 import * as api from "../api/summaryApi";
 import OverflowTooltip from "../components/OverflowTooltip";
@@ -91,6 +92,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     private listPageActive = false;
     private lastEventTime = 0;
     private isPersonalPolling = false;
+    private hasSentNotifyTip = false;
 
     componentDidMount() {
         window.addEventListener("summary-status-change", this.handleStatusChangeEvent);
@@ -104,6 +106,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         const currentTaskId = this.taskId;
         if (prevTaskId !== currentTaskId && currentTaskId != null) {
             this.listPageActive = false;
+            this.hasSentNotifyTip = false;
             this.clearAllTimers();
             this.loadDetail();
         }
@@ -277,6 +280,10 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         this.loadMembers();
                     }
                 }
+                if (newStatus === TaskStatus.COMPLETED && !this.hasSentNotifyTip) {
+                    this.hasSentNotifyTip = true;
+                    sendSummaryNotifyTip(detail.sources);
+                }
             }
         } catch {
             // ignore
@@ -342,6 +349,10 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         if (detail.schedule_id && detail.schedule_id > 0) {
                             this.loadSchedule(detail.schedule_id);
                         }
+                    }
+                    if (newStatus === TaskStatus.COMPLETED && !this.hasSentNotifyTip) {
+                        this.hasSentNotifyTip = true;
+                        sendSummaryNotifyTip(detail.sources);
                     }
                 } catch {
                     // Don't advance lastKnownStatus — retry on next tick

--- a/packages/dmworksummary/src/utils/__tests__/sendSummaryNotifyTip.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/sendSummaryNotifyTip.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('wukongimjssdk', () => ({
+    Channel: class {
+        channelID: string;
+        channelType: number;
+        constructor(id: string, type: number) {
+            this.channelID = id;
+            this.channelType = type;
+        }
+    },
+    ChannelTypeGroup: 2,
+    WKSDK: {
+        shared: () => ({
+            chatManager: { send: mockSend },
+        }),
+    },
+}));
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        ChannelTypeCommunityTopic: 5,
+        SummaryNotifyContent: class {
+            fromUID = '';
+            fromName = '';
+            get contentType() { return 21; }
+            encodeJSON() {
+                return { type: 21, from_uid: this.fromUID, from_name: this.fromName };
+            }
+        },
+        WKApp: {
+            ...(actual as any).WKApp,
+            loginInfo: { uid: 'user_001', name: 'Test User', token: 'test-token' },
+        },
+    };
+});
+
+import { sendSummaryNotifyTip } from '../sendSummaryNotifyTip';
+
+describe('sendSummaryNotifyTip', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('sends tip to group sources', async () => {
+        await sendSummaryNotifyTip([
+            { source_type: 1, source_id: 'group_abc' },
+        ]);
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const [msg, channel] = mockSend.mock.calls[0];
+        expect(msg.fromUID).toBe('user_001');
+        expect(msg.fromName).toBe('Test User');
+        expect(channel.channelID).toBe('group_abc');
+        expect(channel.channelType).toBe(2); // ChannelTypeGroup
+    });
+
+    it('sends tip to thread sources', async () => {
+        await sendSummaryNotifyTip([
+            { source_type: 2, source_id: 'group_abc____thread_123' },
+        ]);
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const [, channel] = mockSend.mock.calls[0];
+        expect(channel.channelID).toBe('group_abc____thread_123');
+        expect(channel.channelType).toBe(5); // ChannelTypeCommunityTopic
+    });
+
+    it('skips DM sources', async () => {
+        await sendSummaryNotifyTip([
+            { source_type: 3, source_id: 'user_xyz' },
+        ]);
+
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple sources', async () => {
+        await sendSummaryNotifyTip([
+            { source_type: 1, source_id: 'group_1' },
+            { source_type: 1, source_id: 'group_2' },
+            { source_type: 3, source_id: 'dm_skip' },
+            { source_type: 2, source_id: 'group_3____thread_1' },
+        ]);
+
+        expect(mockSend).toHaveBeenCalledTimes(3);
+    });
+
+    it('does nothing for empty sources', async () => {
+        await sendSummaryNotifyTip([]);
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('silently ignores send errors', async () => {
+        mockSend.mockRejectedValueOnce(new Error('network error'));
+
+        await expect(
+            sendSummaryNotifyTip([{ source_type: 1, source_id: 'group_abc' }])
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/dmworksummary/src/utils/sendSummaryNotifyTip.ts
+++ b/packages/dmworksummary/src/utils/sendSummaryNotifyTip.ts
@@ -1,0 +1,46 @@
+import { Channel, ChannelTypeGroup, WKSDK } from 'wukongimjssdk';
+import { ChannelTypeCommunityTopic, WKApp, SummaryNotifyContent } from '@octo/base';
+import type { SourceItem } from '../types/summary';
+import { SourceType } from '../types/summary';
+
+/**
+ * Send a "XXX summarized the chat" tip message to each source group/thread.
+ *
+ * Modeled after the screenshot notification (contentType=20):
+ * - Client constructs a SummaryNotifyContent (contentType=21) with from_uid/from_name
+ * - Sends directly via WuKongIM SDK to each source channel
+ * - Renders as a grey system tip in the chat
+ *
+ * Only group and thread sources receive the notification (DMs are skipped).
+ * Errors are silently ignored — the tip is best-effort.
+ */
+export async function sendSummaryNotifyTip(sources: SourceItem[]): Promise<void> {
+    if (!sources || sources.length === 0) return;
+
+    const uid = WKApp.loginInfo.uid;
+    const name = WKApp.loginInfo.name || '';
+
+    for (const source of sources) {
+        try {
+            let channel: Channel | null = null;
+
+            if (source.source_type === SourceType.GROUP_CHAT) {
+                channel = new Channel(source.source_id, ChannelTypeGroup);
+            } else if (source.source_type === SourceType.THREAD) {
+                // Thread channels use ChannelTypeCommunityTopic (5)
+                channel = new Channel(source.source_id, ChannelTypeCommunityTopic);
+            }
+            // Skip DM sources — no need to notify yourself
+
+            if (!channel) continue;
+
+            const msg = new SummaryNotifyContent();
+            msg.fromUID = uid;
+            msg.fromName = name;
+
+            await WKSDK.shared().chatManager.send(msg, channel);
+        } catch {
+            // Best-effort: don't block on notification failures
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When a user completes a smart summary, a tip message (grey system text) is sent to each summarized group/thread, notifying other members:

> **吴明辉 总结了群聊内容**

This mirrors the screenshot notification pattern — the client sends a tip directly via WuKongIM SDK, no backend changes needed.

Closes #289

## Changes

### New: `SummaryNotifyContent` (contentType=21)

`packages/dmworkbase/src/Messages/SummaryNotify/index.tsx`

Modeled after `ScreenshotContent` (type=20):
- Decodes/encodes `from_uid` and `from_name`
- Renders as `wk-message-system` (grey centered text)
- i18n: `"吴明辉 总结了群聊内容"` / `"Test User summarized the chat"`

### New: `sendSummaryNotifyTip()` utility

`packages/dmworksummary/src/utils/sendSummaryNotifyTip.ts`

- Iterates `sources[]` from the summary task
- Sends tip to group (ChannelTypeGroup=2) and thread (ChannelTypeCommunityTopic=5) sources
- Skips DM sources (no need to notify yourself)
- Best-effort: errors are silently ignored

### Integration points

| Location | When |
|---|---|
| `SummaryDetailPage` | WS event or fallback poll detects status → COMPLETED |
| `ChatSummaryHistory` | Batch poll detects status → COMPLETED (chat-window flow) |

Both use dedup flags (`hasSentNotifyTip` / `notifiedTaskIds`) to ensure tips are sent exactly once per task.

### Registration

- `Const.ts`: `summaryNotify = 21`
- `module.tsx`: Cell renderer + SDK content decoder registered
- `Conversation/index.tsx`: Treated as system message (no bubble, no avatar)
- `index.tsx`: Exported from `@octo/base`

## Testing

6 unit tests added and passing:
- ✅ Sends tip to group sources
- ✅ Sends tip to thread sources
- ✅ Skips DM sources
- ✅ Handles multiple sources (3 groups + 1 DM skip)
- ✅ Does nothing for empty sources
- ✅ Silently ignores send errors

Full `dmworksummary` test suite: **140/140 tests passing**.

## Not included

- ❌ iOS/Android rendering (separate PRs needed for `octo-ios` / `octo-android`)
- ❌ Group-level notification toggle (not needed for v1)
- ❌ Summary content in the notification (only notifies the action)