### PR TITLE
fix: auto-follow thread on create when parent channel is followed

### DIFF
--- a/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
+++ b/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
@@ -3,6 +3,7 @@ import WKSDK, { ConversationAction, type Conversation, type ConversationListener
 import WKApp from "../App"
 import { t } from "../i18n"
 import { ChannelTypeCommunityTopic } from "../Service/Const"
+import FollowService from "../Service/FollowService"
 import SidebarService, { SidebarItem } from "../Service/SidebarService"
 import { buildThreadChannelId, parseThreadChannelId } from "../Service/Thread"
 
@@ -201,6 +202,21 @@ export function useFollowSidebar(): UseFollowSidebarResult {
             const threadChannelId = event.threadChannelId
                 || event.thread?.channel_id
                 || (event.shortId ? buildThreadChannelId(event.groupNo, event.shortId) : undefined)
+
+            // Auto-follow the newly created thread when its parent channel
+            // is already followed.  This covers all create entry points
+            // (ThreadCreate, ThreadCreateModal, ThreadPanel) without each
+            // needing access to follow state.  Best-effort: failure is
+            // logged but does not affect the create UX.
+            if (threadChannelId && followedGroupNosRef.current.has(event.groupNo)) {
+                const threadKey = `${ChannelTypeCommunityTopic}::${threadChannelId}`
+                if (!followedKeysRef.current.has(threadKey)) {
+                    FollowService.followThread({ thread_channel_id: threadChannelId })
+                        .then(() => load({ silent: true }))
+                        .catch((err) => console.warn("[useFollowSidebar] auto-follow thread failed (non-fatal)", err))
+                }
+            }
+
             scheduleThreadReload(threadChannelId)
         }
 


### PR DESCRIPTION
## Summary

When a user creates a new thread via the Web UI under a **followed** channel, the thread now appears in the follow tab automatically — instead of only showing up in the "recent" tab and requiring manual right-click → "add to follow".

Closes #292

## Root Cause

None of the three create entry points (`ThreadCreate`, `ThreadCreateModal`, `ThreadPanel`) called `FollowService.followThread()` after `threadCreate()`. The backend `auto_follow_threads` fanout mechanism exists but has edge cases (ext row not yet materialized, best-effort semantics) that make it unreliable as the sole path for the creator.

## v2 Changes (addressing review feedback)

**Moved auto-follow from `datasource.threadCreate()` to `useFollowSidebar`'s existing `wk:thread-created` listener**, addressing the P1 concern from both reviewers:

- ✅ **Conditional on parent being followed**: checks `followedGroupNosRef.current.has(event.groupNo)` before calling `followThread` — will NOT silently re-follow an explicitly-unfollowed parent channel
- ✅ **Dedup**: checks `followedKeysRef.current.has(threadKey)` to skip if already followed
- ✅ **Single point of change**: covers all three UI entry points without each needing access to follow state
- ✅ **Authoritative follow state**: `useFollowSidebar` holds `followedGroupNosRef` / `followedKeysRef` — the sidebar's own state, not the unreliable `channelInfo.orgData.is_followed`
- ✅ **Fire-and-forget with logging**: failure is `console.warn`'d, not swallowed silently
- ✅ **Sidebar reload uses existing pattern**: `load({ silent: true })` avoids flicker

### Why `useFollowSidebar` and not the datasource or UI components?

- `datasource.ts` (`dmworkdatasource` package) cannot import `FollowService` (cross-package) and has no access to follow state
- The three UI components are class components without access to `FollowSidebarContext`
- `useFollowSidebar` already listens for `wk:thread-created` and is the single source of truth for follow state

## Files Changed

- `packages/dmworkbase/src/Hooks/useFollowSidebar.ts` — 16 lines added in `wk:thread-created` listener

## Testing

| Scenario | Expected | Verified |
|---|---|---|
| Create thread under **followed** parent | Thread appears in follow tab | ✅ |
| Create thread under **unfollowed** parent | Thread appears in recent tab only, parent NOT re-followed | ✅ |
| `/follow/thread` API fails | Create succeeds, warning logged | ✅ |
| Thread already followed (e.g. via backend fanout) | No duplicate follow call | ✅ |