### PR TITLE
feat(auth): decisions 1+2 — web verify + daemon api_key direct

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -55,8 +55,11 @@ export const BotsTab = forwardRef<BotsTabHandle>(function BotsTab(_props, ref) {
     // token, 直接带 `token:` header 调 (跟 matter user-auth 一致).
     (async () => {
       try {
+        const headers: Record<string, string> = {};
+        if (sessionToken) headers.token = sessionToken;
+        if (spaceId) headers['X-Space-Id'] = spaceId;
         const res = await fetch('/api/v1/runtimes?space_id=' + encodeURIComponent(spaceId), {
-          headers: sessionToken ? { token: sessionToken } : {},
+          headers,
         });
         const env = await res.json();
         const list = (env?.data?.runtimes ?? env?.runtimes ?? []) as any[];

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -51,18 +51,12 @@ export const BotsTab = forwardRef<BotsTabHandle>(function BotsTab(_props, ref) {
   useEffect(() => {
     const spaceId = (WKApp as any)?.shared?.currentSpaceId ?? '';
     const sessionToken = (WKApp as any)?.loginInfo?.token ?? '';
-    // PR-A.2: /api/v1/runtimes is served by fleet which requires JWT.
-    // Exchange session for JWT first, then fetch.
+    // 合并 plan 决策一+二 Phase 3A: fleet 切到 AuthMiddleware 接 session
+    // token, 直接带 `token:` header 调 (跟 matter user-auth 一致).
     (async () => {
       try {
-        const tokRes = await fetch('/api/v1/auth/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ session_token: sessionToken, space_id: spaceId }),
-        });
-        const tok = (await tokRes.json())?.token;
         const res = await fetch('/api/v1/runtimes?space_id=' + encodeURIComponent(spaceId), {
-          headers: tok ? { Authorization: 'Bearer ' + tok } : {},
+          headers: sessionToken ? { token: sessionToken } : {},
         });
         const env = await res.json();
         const list = (env?.data?.runtimes ?? env?.runtimes ?? []) as any[];

--- a/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
@@ -41,40 +41,13 @@ export interface BotFeedItem {
 
 const base = '/api'; // vite proxy strips /api → /v1; /api/v1/runtimes goes to fleet :8092
 
-// PR-A.2: fleet expects JWT (Bearer) instead of session token. Cache the
-// JWT in-module; mirror the same pattern APIClient.getFleetJWT() uses.
-// Kept here (rather than calling into APIClient) because botsApi.ts has
-// always used raw fetch — letting it stay independent keeps the surface
-// area contained.
-let _jwt: { token: string; expiresAt: number } | null = null;
-
-async function getFleetJWT(): Promise<string> {
-  if (_jwt && _jwt.expiresAt > Date.now() + 60_000) return _jwt.token;
-  const sessionToken = (WKApp as any)?.loginInfo?.token;
-  if (!sessionToken) return '';
-  const spaceId = (WKApp as any)?.shared?.currentSpaceId || '';
-  try {
-    const res = await fetch('/api/v1/auth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_token: sessionToken, space_id: spaceId }),
-    });
-    if (!res.ok) return '';
-    const j = await res.json();
-    const tok = j?.token || j?.data?.token;
-    const expiresIn = j?.expires_in || j?.data?.expires_in || 1800;
-    if (!tok) return '';
-    _jwt = { token: tok, expiresAt: Date.now() + Number(expiresIn) * 1000 };
-    return tok;
-  } catch {
-    return '';
-  }
-}
-
+// 合并 plan 决策一+二 Phase 3A: fleet 已切到 AuthMiddleware 接 session token
+// 直接 (跟 matter user-auth 一致), 不再换 JWT。authHeaders 注入 token: +
+// X-Space-Id, 跟 axios 全局 interceptor 行为对齐。
 async function authHeaders(): Promise<Record<string, string>> {
   const h: Record<string, string> = {};
-  const jwt = await getFleetJWT();
-  if (jwt) h.Authorization = 'Bearer ' + jwt;
+  const sessionToken = (WKApp as any)?.loginInfo?.token;
+  if (sessionToken) h.token = sessionToken;
   const spaceId = (WKApp as any)?.shared?.currentSpaceId;
   if (spaceId) h['X-Space-Id'] = spaceId;
   return h;

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -56,50 +56,9 @@ export default class APIClient {
     public config = new APIClientConfig()
     public logoutCallback?:()=>void
 
-    // PR-A.2: per-process JWT cache for fleet routes. Acquired on demand
-    // by exchanging the session token at POST /v1/auth/token. We use raw
-    // fetch (not axios) for that exchange to avoid recursing through our
-    // own request interceptor.
-    private _jwt: { token: string; expiresAt: number } | null = null
-
-    private static FLEET_URL_RE = /\/runtimes(\/|$|\?)|\/daemon(\/|$|\?)/
-
-    /**
-     * Returns a daemon-or-web-scope JWT acceptable to octo-fleet. Cached
-     * in-memory; refreshed when within 60s of expiry. Returns "" if no
-     * session token is configured (caller should let the request 401).
-     */
-    private async getFleetJWT(): Promise<string> {
-        if (this._jwt && this._jwt.expiresAt > Date.now() + 60_000) {
-            return this._jwt.token
-        }
-        const sessionToken = this.config.tokenCallback?.()
-        if (!sessionToken) return ""
-        const spaceId = this.config.spaceIdCallback?.() || ""
-        try {
-            const res = await fetch("/api/v1/auth/token", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ session_token: sessionToken, space_id: spaceId }),
-            })
-            if (!res.ok) {
-                // Don't cache failure — next call retries.
-                return ""
-            }
-            const j = await res.json()
-            const tok = j?.token || j?.data?.token
-            const expiresIn = j?.expires_in || j?.data?.expires_in || 1800
-            if (!tok) return ""
-            this._jwt = { token: tok, expiresAt: Date.now() + Number(expiresIn) * 1000 }
-            return tok
-        } catch {
-            return ""
-        }
-    }
-
     initAxios() {
         const self = this
-        axios.interceptors.request.use(async function (config) {
+        axios.interceptors.request.use(function (config) {
             config.headers = config.headers || {};
             config.headers["Accept-Language"] = buildAcceptLanguage();
             let token:string | undefined
@@ -116,20 +75,9 @@ export default class APIClient {
                     config.headers!["X-Space-Id"] = spaceId;
                 }
             }
-            // PR-A.2: fleet endpoints (under /runtimes or /daemon) require
-            // a server-issued JWT in Authorization. Keep the existing
-            // `token` header too — server's session AuthMiddleware ignores
-            // Authorization and JWT middleware ignores `token`, so the
-            // dual-header request works against either backend.
-            const url = config.url || ""
-            const baseURL = config.baseURL || ""
-            const fullPath = url.startsWith("http") ? url : baseURL + url
-            if (APIClient.FLEET_URL_RE.test(fullPath)) {
-                const jwt = await self.getFleetJWT()
-                if (jwt) {
-                    config.headers!["Authorization"] = "Bearer " + jwt
-                }
-            }
+            // 合并 plan 决策一+二 Phase 3A: fleet/matter 已切到 AuthMiddleware,
+            // 接受 token: <session> 跟 server 一致, 不再换 JWT。删 getFleetJWT
+            // + FLEET_URL_RE 后 interceptor 走单一 session token 路径。
             return config;
         });
 


### PR DESCRIPTION
## ⚠️ Reviewer 请先读架构 doc, 再 review 代码

避免直接 nitpick 实现细节而错过架构层决策的 context (e.g. 为啥 AU5 删了但 issue #75 没修).

## 1. 背景 + Phase 拆解

合并 plan: **决策一** (web 验证改造 — 浏览器改回带 session token, 不再换 JWT) + **决策二** (daemon api_key 直连 — daemon 不再换 JWT, 直接持 api_key 调 fleet/matter, 由它们调 server verify-api-key 验证).

5 个 Phase:

| Phase | 内容 | 涉及 repo |
|---|---|---|
| 1 | server `POST /v1/auth/verify-api-key` endpoint | server |
| 2 | matter middleware 扩三协议 (session+bot_token+api_key) + fleet 抄 | matter + fleet |
| 3A | web 客户端切回 session token | web |
| 3B | daemon 改 api_key 直连 + 业务 SQL 加 owner_uid 过滤 | daemon-cli + fleet + matter |
| 4 | 清理 (JWT/AU5/DualAuth/JWKS) + 配置改名 + 单测补 | 全 5 repo |

会议依据: 鉴权架构讨论会议结论 2026-06-05 决策一+决策二.

## 2. 本 repo 改动 (2 commit, 按时间顺序)

```
a1de53e3 fix(runtimes): BotsTab raw fetch must pass X-Space-Id header
b4c73aca refactor(auth): drop web JWT exchange, use session token directly
```

## 3. 配套 PR (cross-link)

- octo-server: Mininglamp-OSS/octo-server#290
- octo-matter: Mininglamp-OSS/octo-matter#78
- octo-fleet: Mininglamp-OSS/octo-fleet#24
- octo-daemon-cli: Mininglamp-OSS/octo-daemon-cli#26
- octo-web (本 PR)

跟 daemon 独立, 任何顺序 merge 都行.

## 4. 本 repo review 重点

### Phase 3A: 浏览器切回 session token (不再换 JWT)

- `APIClient.ts`: 删 `_jwt` cache + `FLEET_URL_RE` regex + `getFleetJWT()` 整段 (~50 行)
- 删 axios interceptor 里 fleet URL 注入 Bearer JWT 整块, 所有请求统一带 `token:` + `X-Space-Id`
- async function → function (没有 await 了)
- `botsApi.ts`: 删模块级 `_jwt` + `getFleetJWT()` (~30 行), `authHeaders()` 返 `token:` + `X-Space-Id`
- `BotsTab.tsx`: 删 `fetch('/api/v1/auth/token')` 调用, 直接调 `/api/v1/runtimes` 带 `token:` header

### hotfix: BotsTab raw fetch 漏带 X-Space-Id header

Phase 3A 改时 `BotsTab.tsx` 用 raw fetch (不走 axios), 漏带 `X-Space-Id` → 创建 bot modal 没 runtime 可选 (fleet 403).

修法: raw fetch 显式加 X-Space-Id header.

## 5. 重要决策 — issue #75 推迟到决策四

(本 PR 不涉及.)

## 6. e2e 验证

- 本地 web 登录正常, runtime 列表显示 4 个 online (claude/codex/hermes/openclaw)
- create bot modal 能选 runtime
- `npm run build` clean (✓ built in 1.74s)
