### PR TITLE
fix(mention): pass mentions/emojis through MixedContent for RichText highlight

### DIFF
--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -68,6 +68,7 @@ export class RichTextCell extends MessageCell {
           )}
           <MixedContent
             {...uiProps.content}
+            onMentionClick={(uid) => context.showUser(uid)}
             onFileDownload={(block) => {
               if (block.url) {
                 downloadFile(block.url, block.name);

--- a/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import WKApp from "../../App";
 import type { MessageWrap } from "../../Service/Model";
+import { PartType } from "../../Service/Model";
 import { RichTextBlockType } from "../../Messages/RichText/RichTextContent";
 import type {
   RichTextBlock,
@@ -19,6 +20,8 @@ import type {
 } from "../../ui/message/MixedContent";
 import { getMessageRow } from "./useMessageRow";
 import type { MessageRowSelectionState } from "./useMessageRow";
+import { buildTextMessageMentions } from "./textMessageMentions";
+import type { MentionInfo, EmojiInfo } from "../../Messages/Text/MarkdownContent";
 
 function resolveFileUrl(rawUrl?: string): string {
   if (!rawUrl) return "";
@@ -125,10 +128,30 @@ export function getRichTextMessageUI(
   selection?: MessageRowSelectionState
 ) {
   const content = message.content as RichTextContent;
+  const parts = message.parts || [];
+
+  const mentions: MentionInfo[] = buildTextMessageMentions({
+    parts: parts as any,
+    content: message.content,
+    partMentionType: PartType.mention as unknown as number,
+  }) as MentionInfo[];
+
+  const emojis: EmojiInfo[] = parts
+    .filter((p: any) => p.type === PartType.emoji)
+    .reduce((acc: EmojiInfo[], p: any) => {
+      const url = WKApp.emojiService.getImage(p.text);
+      if (url && !acc.find((e) => e.key === p.text)) {
+        acc.push({ key: p.text, url });
+      }
+      return acc;
+    }, []);
+
   return {
     row: getMessageRow(message, selection),
     content: {
       blocks: getRichTextBlocksUI(content.content || []),
+      mentions,
+      emojis,
     },
   };
 }

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Download } from "lucide-react";
 import MarkdownContent, {
   MarkdownImage,
+  MentionInfo,
+  EmojiInfo,
 } from "../../../Messages/Text/MarkdownContent";
 import "./index.css";
 
@@ -43,6 +45,9 @@ export type MixedContentBlock =
 
 export interface MixedContentProps {
   blocks: MixedContentBlock[];
+  mentions?: MentionInfo[];
+  onMentionClick?: (uid: string) => void;
+  emojis?: EmojiInfo[];
   onFileDownload?: (
     block: Extract<MixedContentBlock, { type: "file" }>
   ) => void;
@@ -50,6 +55,9 @@ export interface MixedContentProps {
 
 export default function MixedContent({
   blocks,
+  mentions,
+  onMentionClick,
+  emojis,
   onFileDownload,
 }: MixedContentProps) {
   return (
@@ -110,7 +118,13 @@ export default function MixedContent({
         }
         return (
           <div key={block.id} className="wk-msg-mixed-text">
-            <MarkdownContent content={block.content} enableMarkdown={false} />
+            <MarkdownContent
+              content={block.content}
+              enableMarkdown={false}
+              mentions={mentions}
+              onMentionClick={onMentionClick}
+              emojis={emojis}
+            />
           </div>
         );
       })}


### PR DESCRIPTION
## Summary

Fix `@所有人` and `@member` mentions not being highlighted in RichText(=14) messages on Web.

Closes #295

## Problem

PR #264 (`feat: migrate rich text mixed content UI`) introduced `MixedContent` as the renderer for RichText messages, but did not forward `mentions` / `emojis` / `onMentionClick` props to `MarkdownContent`. As a result, all mention highlights (including `@所有人`) were silently dropped for any RichText message.

## Changes

**`ui/message/MixedContent/index.tsx`**
- Add `mentions`, `onMentionClick`, `emojis` to `MixedContentProps`
- Forward them to `<MarkdownContent>` in the text block branch

**`bridge/message/useRichTextMessageUI.ts`**
- Build `mentions` via `buildTextMessageMentions` (same logic as text messages)
- Build `emojis` via `WKApp.emojiService` (same logic as text messages)
- Include both in the returned `content` object

**`Messages/RichText/index.tsx`**
- Wire `onMentionClick` to `context.showUser` in `RichTextCell`

## Testing

- `vitest run textMessageMentions.test.ts` — 4/4 passed
- TypeScript: no new errors (all pre-existing)