### PR TITLE
feat(summary): ChatSelector tabs 改为「关注/最近/全部群聊/全部私聊」

### DIFF
--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -68,6 +68,7 @@ export class RichTextCell extends MessageCell {
           )}
           <MixedContent
             {...uiProps.content}
+            onMentionClick={(uid) => context.showUser(uid)}
             onFileDownload={(block) => {
               if (block.url) {
                 downloadFile(block.url, block.name);

--- a/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import WKApp from "../../App";
 import type { MessageWrap } from "../../Service/Model";
+import { PartType } from "../../Service/Model";
 import { RichTextBlockType } from "../../Messages/RichText/RichTextContent";
 import type {
   RichTextBlock,
@@ -19,6 +20,8 @@ import type {
 } from "../../ui/message/MixedContent";
 import { getMessageRow } from "./useMessageRow";
 import type { MessageRowSelectionState } from "./useMessageRow";
+import { buildTextMessageMentions } from "./textMessageMentions";
+import type { MentionInfo, EmojiInfo } from "../../Messages/Text/MarkdownContent";
 
 function resolveFileUrl(rawUrl?: string): string {
   if (!rawUrl) return "";
@@ -125,10 +128,30 @@ export function getRichTextMessageUI(
   selection?: MessageRowSelectionState
 ) {
   const content = message.content as RichTextContent;
+  const parts = message.parts || [];
+
+  const mentions: MentionInfo[] = buildTextMessageMentions({
+    parts: parts as any,
+    content: message.content,
+    partMentionType: PartType.mention as unknown as number,
+  }) as MentionInfo[];
+
+  const emojis: EmojiInfo[] = parts
+    .filter((p: any) => p.type === PartType.emoji)
+    .reduce((acc: EmojiInfo[], p: any) => {
+      const url = WKApp.emojiService.getImage(p.text);
+      if (url && !acc.find((e) => e.key === p.text)) {
+        acc.push({ key: p.text, url });
+      }
+      return acc;
+    }, []);
+
   return {
     row: getMessageRow(message, selection),
     content: {
       blocks: getRichTextBlocksUI(content.content || []),
+      mentions,
+      emojis,
     },
   };
 }

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Download } from "lucide-react";
 import MarkdownContent, {
   MarkdownImage,
+  MentionInfo,
+  EmojiInfo,
 } from "../../../Messages/Text/MarkdownContent";
 import "./index.css";
 
@@ -43,6 +45,9 @@ export type MixedContentBlock =
 
 export interface MixedContentProps {
   blocks: MixedContentBlock[];
+  mentions?: MentionInfo[];
+  onMentionClick?: (uid: string) => void;
+  emojis?: EmojiInfo[];
   onFileDownload?: (
     block: Extract<MixedContentBlock, { type: "file" }>
   ) => void;
@@ -50,6 +55,9 @@ export interface MixedContentProps {
 
 export default function MixedContent({
   blocks,
+  mentions,
+  onMentionClick,
+  emojis,
   onFileDownload,
 }: MixedContentProps) {
   return (
@@ -110,7 +118,13 @@ export default function MixedContent({
         }
         return (
           <div key={block.id} className="wk-msg-mixed-text">
-            <MarkdownContent content={block.content} enableMarkdown={false} />
+            <MarkdownContent
+              content={block.content}
+              enableMarkdown={false}
+              mentions={mentions}
+              onMentionClick={onMentionClick}
+              emojis={emojis}
+            />
           </div>
         );
       })}

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -254,7 +254,7 @@ export async function toggleSchedule(scheduleId: number, isActive: boolean): Pro
 
 // ─── Candidate Selection ───────────────────────────────
 
-export async function getChatCandidates(params?: { keyword?: string; chat_type?: string }): Promise<ChatCandidate[]> {
+export async function getChatCandidates(params?: { keyword?: string; chat_type?: string; filter?: string }): Promise<ChatCandidate[]> {
     const data = await get<ChatCandidate[]>('/summary-chat-candidates', params as Record<string, unknown>);
     return data || [];
 }

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 interface State {
     keyword: string;
-    activeTab: "all" | "group" | "direct";
+    activeTab: "followed" | "recent" | "group" | "direct";
     candidates: ChatCandidate[];
     loading: boolean;
     localSelected: ChatCandidate[];
@@ -34,7 +34,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     state: State = {
         keyword: "",
-        activeTab: "all",
+        activeTab: "followed",
         candidates: [],
         loading: false,
         localSelected: [],
@@ -42,15 +42,19 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     componentDidUpdate(prevProps: Props) {
         if (this.props.visible && !prevProps.visible) {
-            this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "all" });
-            this.loadCandidates();
+            this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "followed" });
+            this.loadCandidates("followed");
         }
     }
 
-    async loadCandidates() {
+    async loadCandidates(filter?: string) {
         this.setState({ loading: true });
         try {
-            const candidates = await api.getChatCandidates({});
+            const params: Record<string, string> = {};
+            if (filter === "followed" || filter === "recent") {
+                params.filter = filter;
+            }
+            const candidates = await api.getChatCandidates(params);
             this.setState({ candidates, loading: false });
         } catch {
             this.setState({ loading: false });
@@ -62,7 +66,14 @@ export default class ChatSelectorModal extends Component<Props, State> {
     };
 
     handleTabChange = (tab: string) => {
-        this.setState({ activeTab: tab as State["activeTab"] });
+        const activeTab = tab as State["activeTab"];
+        this.setState({ activeTab });
+        // Reload candidates with the appropriate filter for followed/recent tabs
+        if (activeTab === "followed" || activeTab === "recent") {
+            this.loadCandidates(activeTab);
+        } else {
+            this.loadCandidates();
+        }
     };
 
     handleToggle = (item: ChatCandidate) => {
@@ -85,6 +96,8 @@ export default class ChatSelectorModal extends Component<Props, State> {
         const { candidates, activeTab, keyword } = this.state;
         const kw = keyword.trim().toLowerCase();
 
+        // For "followed" and "recent" tabs, backend already filters.
+        // Apply local chat_type filter only for "group" and "direct" tabs.
         if (activeTab === "direct") {
             return candidates
                 .filter((c) => c.chat_type === "direct")
@@ -92,9 +105,12 @@ export default class ChatSelectorModal extends Component<Props, State> {
                 .map((c) => ({ item: c, indent: false }));
         }
 
+        // For "group" tab, filter to groups+threads only.
+        // For "followed" and "recent", show everything the backend returned.
+        const showAll = activeTab === "followed" || activeTab === "recent";
         const groups = candidates.filter((c) => c.chat_type === "group");
         const threads = candidates.filter((c) => c.chat_type === "thread");
-        const directs = activeTab === "all" ? candidates.filter((c) => c.chat_type === "direct") : [];
+        const directs = showAll ? candidates.filter((c) => c.chat_type === "direct") : [];
 
         const groupIds = new Set(groups.map((g) => g.chat_id));
         const threadsByParent = new Map<string, ChatCandidate[]>();
@@ -248,9 +264,10 @@ export default class ChatSelectorModal extends Component<Props, State> {
                     style={{ marginBottom: 12 }}
                 />
                 <Tabs activeKey={activeTab} onChange={this.handleTabChange} size="small">
-                    <TabPane tab={t("summary.chatSelector.all")} itemKey="all" />
-                    <TabPane tab={t("summary.source.groupChat")} itemKey="group" />
-                    <TabPane tab={t("summary.source.directMessage")} itemKey="direct" />
+                    <TabPane tab={t("summary.chatSelector.followed")} itemKey="followed" />
+                    <TabPane tab={t("summary.chatSelector.recent")} itemKey="recent" />
+                    <TabPane tab={t("summary.chatSelector.allGroups")} itemKey="group" />
+                    <TabPane tab={t("summary.chatSelector.allDirects")} itemKey="direct" />
                 </Tabs>
                 <div style={{ minHeight: 240, maxHeight: 360, overflowY: "auto" }}>
                     {loading ? (

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -173,6 +173,10 @@
   "chatSelector": {
     "title": "Select chats",
     "searchPlaceholder": "Search groups or contacts",
+    "followed": "Followed",
+    "recent": "Recent",
+    "allGroups": "All Groups",
+    "allDirects": "All DMs",
     "all": "All",
     "noData": "No data"
   },

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -173,6 +173,10 @@
   "chatSelector": {
     "title": "选择聊天",
     "searchPlaceholder": "搜索群聊或联系人",
+    "followed": "关注",
+    "recent": "最近",
+    "allGroups": "全部群聊",
+    "allDirects": "全部私聊",
     "all": "全部",
     "noData": "暂无数据"
   },

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -270,6 +270,8 @@ export interface ChatCandidate {
     member_count: number | null;
     parent_group_no?: string;
     is_bot?: boolean;
+    is_followed?: boolean;
+    last_active_at?: string;
 }
 
 /** 成员候选项（添加成员弹窗用） */


### PR DESCRIPTION
## Summary

智能总结群选择弹窗的 tab 从「全部/群聊/私聊」改为「关注/最近/全部群聊/全部私聊」，默认选中「关注」。

## Changes

**`packages/dmworksummary/src/components/ChatSelectorModal.tsx`**
- Tab 从 `all | group | direct` 改为 `followed | recent | group | direct`
- 默认 activeTab 从 `"all"` 改为 `"followed"`
- 切换 tab 时按 filter 值重新请求后端
- 「关注」和「最近」tab 展示后端过滤后的全部类型（群+子区+私聊混排）
- 「全部群聊」和「全部私聊」保持原有前端过滤逻辑

**`packages/dmworksummary/src/api/summaryApi.ts`**
- `getChatCandidates` 参数增加 `filter?: string`

**`packages/dmworksummary/src/types/summary.ts`**
- `ChatCandidate` 接口新增 `is_followed?: boolean` 和 `last_active_at?: string`

**`packages/dmworksummary/src/i18n/zh-CN.json` + `en-US.json`**
- 新增 i18n key：`chatSelector.followed`、`chatSelector.recent`、`chatSelector.allGroups`、`chatSelector.allDirects`
- 保留 `chatSelector.all` 向后兼容

## Related

- Closes Mininglamp-OSS/octo-web#297
- Backend: Mininglamp-OSS/octo-smart-summary#66 / PR Mininglamp-OSS/octo-smart-summary#67