### PR TITLE
fix(chat): trust backend recent conversations

### DIFF
--- a/packages/dmworkbase/src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx
@@ -1,0 +1,147 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+let ChatConversationList: typeof import("../index").default
+let container: HTMLDivElement
+
+beforeAll(async () => {
+    vi.doMock("wukongimjssdk", () => ({
+        Channel: class {
+            channelID: string
+            channelType: number
+
+            constructor(channelID: string, channelType: number) {
+                this.channelID = channelID
+                this.channelType = channelType
+            }
+        },
+        ChannelTypeGroup: 2,
+        ChannelTypePerson: 1,
+        WKSDK: {
+            shared: () => ({
+                channelManager: {
+                    getChannelInfo: () => undefined,
+                },
+            }),
+        },
+    }))
+
+    vi.doMock("../../../App", () => ({
+        default: {
+            endpoints: {},
+        },
+    }))
+
+    vi.doMock("../../../Hooks/useCategoryList", () => ({
+        useCategoryList: () => ({
+            categories: [],
+            isLoading: false,
+            error: null,
+            reload: vi.fn(),
+            createCategory: vi.fn(),
+            renameCategory: vi.fn(),
+            deleteCategory: vi.fn(),
+            sortCategories: vi.fn(),
+            moveGroupToCategory: vi.fn(),
+        }),
+    }))
+
+    vi.doMock("../../../Hooks/useFollowSidebar", () => ({
+        useFollowSidebarContext: () => ({
+            dmsByCategory: new Map(),
+            threadsByCategory: new Map(),
+            itemsByCategory: new Map(),
+            followedGroupNos: new Set(),
+            followedKeys: new Set(),
+            versionRef: { current: 0 },
+            bumpVersion: vi.fn(),
+            applyOptimisticSort: vi.fn(),
+            isLoading: false,
+            error: null,
+            reload: vi.fn(),
+        }),
+    }))
+
+    vi.doMock("../../../Service/FollowService", () => ({
+        default: {},
+    }))
+
+    vi.doMock("../../../Service/Thread", () => ({
+        isEffectivelyMuted: () => false,
+        parseThreadChannelId: () => undefined,
+    }))
+
+    vi.doMock("../../../i18n", () => ({
+        useI18n: () => ({ t: (key: string) => key }),
+    }))
+
+    vi.doMock("../../ConversationListGrouped", () => ({
+        default: () => null,
+        isValidCategoryItem: () => true,
+    }))
+
+    vi.doMock("../../CreateCategoryModal", () => ({
+        default: () => null,
+    }))
+
+    vi.doMock("../../ConversationList", () => ({
+        default: ({ conversations }: { conversations: Array<any> }) => (
+            <div data-testid="conversation-list">
+                {conversations.map((conv) => (
+                    <span key={conv.channel.channelID}>{conv.channel.channelID}</span>
+                ))}
+            </div>
+        ),
+    }))
+
+    ChatConversationList = (await import("../index")).default
+})
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+})
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+})
+
+function makeGroupConversation(id: string, timestamp: number) {
+    return {
+        channel: {
+            channelID: id,
+            channelType: 2,
+        },
+        timestamp,
+        unread: 0,
+    }
+}
+
+describe("ChatConversationList", () => {
+    it("passes stale group conversations through to the recent list", () => {
+        const staleGroup = makeGroupConversation("stale-group", 1)
+        const recentGroup = makeGroupConversation("recent-group", Math.floor(Date.now() / 1000))
+
+        act(() => {
+            ReactDOM.render(
+                <ChatConversationList
+                    conversations={[staleGroup, recentGroup] as any}
+                    filter="all"
+                    onConversationClick={() => {}}
+                    onClearMessages={() => {}}
+                    onThreadOverflowClick={() => {}}
+                />,
+                container
+            )
+        })
+
+        expect(container.textContent).toContain("stale-group")
+        expect(container.textContent).toContain("recent-group")
+    })
+})

--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -6,7 +6,7 @@
  * - 其他 filter：渲染 ConversationList，右键群聊有「移到分组」子菜单
  * - CreateCategoryModal 在此层管理，不依赖子组件挂载
  */
-import React, { useState, useMemo } from "react"
+import React, { useState } from "react"
 import { Channel, ChannelTypeGroup, ChannelTypePerson, WKSDK } from "wukongimjssdk"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import WKApp from "../../App"
@@ -21,18 +21,6 @@ import ConversationListGrouped, { ValidCategoryItem, isValidCategoryItem } from 
 import CreateCategoryModal from "../CreateCategoryModal"
 import { ContextMenusData } from "../ContextMenus"
 import { useI18n } from "../../i18n"
-
-/** 最近 Tab 3 天不活跃过滤阈值。tab 角标和列表必须共用同一阈值。 */
-export const RECENT_INACTIVE_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000
-
-/**
- * 最近 Tab 是否可见：群聊超过 3 天无消息隐藏；私聊 / 子区 不过滤。
- * tab 角标计算和列表渲染必须用同一函数，否则角标 N 但列表看不到的情况就会出现。
- */
-export function isVisibleInRecentTab(conv: ConversationWrap, now: number = Date.now()): boolean {
-    if (conv.channel.channelType !== ChannelTypeGroup) return true
-    return (now - conv.timestamp * 1000) < RECENT_INACTIVE_THRESHOLD_MS
-}
 
 export function isMutedForRecentConversation(conv: ConversationWrap): boolean {
     const isThread = conv.channel.channelType === ChannelTypeCommunityTopic
@@ -57,8 +45,6 @@ export function isMutedForRecentConversation(conv: ConversationWrap): boolean {
 export interface ChatConversationListProps {
     conversations: ConversationWrap[]
     filter: ConvFilter
-    /** 是否隐藏 3 天不活跃的群聊（最近 Tab 使用） */
-    hideInactiveGroups?: boolean
     select?: Channel
     onConversationClick: (conv: ConversationWrap) => void
     onClearMessages: (channel: Channel) => void
@@ -87,7 +73,6 @@ type PendingAction = NewCategoryTarget | null
 const ChatConversationList: React.FC<ChatConversationListProps> = ({
     conversations,
     filter,
-    hideInactiveGroups = false,
     select,
     onConversationClick,
     onClearMessages,
@@ -225,22 +210,13 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
 
     const existingCategoryNames = categories.map(c => c.name)
 
-    // 最近 Tab 3 天不活跃群聊隐藏逻辑：列表渲染、tab 角标、其它复用方都必须共用一套
-    // 判定，否则会出现「badge 显示 N 但列表里看不到对应未读」。
-    const filteredConversations = useMemo(() => {
-        if (!hideInactiveGroups) return conversations
-        const now = Date.now()
-        return conversations.filter(conv => isVisibleInRecentTab(conv, now))
-    }, [conversations, hideInactiveGroups])
-
     const shouldScrollToRecentUnreadTarget = React.useCallback(
         (conv: ConversationWrap) => {
             if (filter === 'group') return false
             if (conv.unread <= 0) return false
-            if (hideInactiveGroups && !isVisibleInRecentTab(conv)) return false
             return !isMutedForRecentConversation(conv)
         },
-        [filter, hideInactiveGroups]
+        [filter]
     )
 
     // 按 conv.channelType 把会话归入指定分类。三种 channel 走三套写操作:
@@ -396,7 +372,7 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
         <>
             {filter === 'group' ? (
                 <ConversationListGrouped
-                    conversations={filteredConversations}
+                    conversations={conversations}
                     select={select}
                     onConversationClick={onConversationClick}
                     onClearMessages={onClearMessages}
@@ -444,7 +420,7 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                 />
             ) : (
                 <ConversationList
-                    conversations={filteredConversations}
+                    conversations={conversations}
                     select={select}
                     filter={filter}
                     onClick={onConversationClick}

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -7,7 +7,6 @@ import SidebarTabBar, { SidebarTab } from "../../Components/SidebarTabBar";
 import ConversationListGrouped from "../../Components/ConversationListGrouped";
 import ChatConversationList, {
   isMutedForRecentConversation,
-  isVisibleInRecentTab,
 } from "../../Components/ChatConversationList";
 import Provider from "../../Service/Provider";
 import { ErrorBoundary } from "../../Components/ErrorBoundary";
@@ -136,9 +135,6 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
 
   const recentUnread = conversations.reduce(
     (sum: number, c: ConversationWrap) => {
-      // 与 ChatConversationList 的 hideInactiveGroups 渲染过滤一致：3 天不活跃的群
-      // 不算入 badge，否则会出现「红点 N 但列表里看不到对应未读」。
-      if (!isVisibleInRecentTab(c)) return sum;
       if (isMutedForRecentConversation(c)) return sum;
       return sum + (c.unread || 0);
     },
@@ -1350,9 +1346,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
                         <Spin style={{ marginTop: "20px" }} />
                       </div>
                     ) : activeTab === "recent" &&
-                      vm.filteredConversations.every(
-                        (c: ConversationWrap) => !isVisibleInRecentTab(c),
-                      ) ? (
+                      vm.filteredConversations.length === 0 ? (
                       <div className="wk-chat-empty-guide">
                         <div style={{ fontSize: 28, marginBottom: 12 }}>💬</div>
                         <div
@@ -1410,7 +1404,6 @@ export default class ChatPage extends Component<any, ChatPageState> {
                         <ChatConversationList
                           conversations={vm.filteredConversations}
                           filter={filter}
-                          hideInactiveGroups={activeTab === "recent"}
                           select={WKApp.shared.openChannel}
                           scrollToUnreadToken={
                             activeTab === "recent"


### PR DESCRIPTION
## Summary
- Remove the frontend hardcoded 3-day inactive group filter from the recent tab.
- Keep recent unread count, empty state, and unread navigation aligned with backend-returned conversations.
- Add a regression test that stale group conversations are still passed through to the recent list.

## Tests
- pnpm --filter @octo/base exec vitest run src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx
- pnpm --filter @octo/base exec vitest run src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx src/Components/SidebarTabBar/__tests__/SidebarTabBar.test.tsx
- pnpm --filter @octo/base exec vitest run src/Pages/Chat/__tests__/vm.sortConversations.test.ts

## Notes
- pnpm --filter @octo/base exec tsc --noEmit -p tsconfig.json currently fails on existing repo-wide type issues in Semi/Storybook/Chat types; not specific to this change.

Closes #299