### PR TITLE
fix(chat): move mention badge to preview area

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationList/index.css
+++ b/packages/dmworkbase/src/Components/ConversationList/index.css
@@ -354,7 +354,7 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   }
 }
 
-/* @我 mention badge：红底白字小色块，紧跟预览右侧 */
+/* @我 mention badge：第二行右侧，对齐时间区域 */
 .wk-mention {
   font-size: var(--wk-text-size-tiny);
   font-weight: 600;
@@ -363,7 +363,7 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   padding: 0 var(--wk-sp-1);
   border-radius: var(--wk-r-xs);
   flex-shrink: 0;
-  margin-right: var(--wk-sp-1);
+  margin-left: var(--wk-sp-1);
 }
 
 /* 草稿、提醒 */
@@ -589,6 +589,24 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   flex-shrink: 0;
 }
 
+.wk-conv-compact-mention {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 var(--wk-sp-1);
+  border-radius: var(--wk-r-full);
+  background: color-mix(in srgb, var(--wk-color-error) 10%, transparent);
+  color: var(--wk-color-error);
+  font-family: var(--wk-font-sans);
+  font-size: var(--wk-text-size-tiny);
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  user-select: none;
+}
+
 .wk-conv-compact-badge {
   min-width: 16px;
   height: 16px;
@@ -779,24 +797,6 @@ body[theme-mode="dark"] .wk-conv-compact-thread-badge {
   flex-shrink: 0;
   margin-left: var(--wk-sp-0-5);
   opacity: 0.6;
-}
-
-/* @ 未读 mention 徽章（design v3.1：红底白字色块） */
-.wk-mention-badge {
-  background: var(--wk-color-danger);
-  color: var(--wk-color-white);
-  padding: 0 var(--wk-sp-1);
-  height: 14px;
-  border-radius: var(--wk-r-xs);
-  font-size: var(--wk-text-size-tiny);
-  font-weight: 600;
-  font-family: var(--wk-font-sans);
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  user-select: none;
-  margin-left: var(--wk-sp-1);
 }
 
 /* ── 外部群角标 ── */

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -5,6 +5,7 @@ import {
   ChannelInfo,
   ChannelTypePerson,
   ChannelTypeGroup,
+  ReminderType,
 } from "wukongimjssdk";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
@@ -67,6 +68,7 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
 }) => {
   const { t } = useI18n();
   const totalUnread = conversationWrap.unread + threadUnread;
+  const hasMention = conversationWrap.isMentionMe && totalUnread > 0;
   const channelInfo = conversationWrap.channelInfo;
   // channelInfo 未加载时主动拉取，加载完触发 re-render
   React.useEffect(() => {
@@ -176,9 +178,6 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
           />
         )}
       </span>
-      {conversationWrap.isMentionMe && totalUnread > 0 && (
-        <span className="wk-mention-badge">{t("base.conversationList.mentionMe")}</span>
-      )}
       <span className="wk-conv-compact-name">
         {channelInfo?.orgData.displayName ? (
           channelInfo.orgData.displayName
@@ -211,11 +210,18 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
           </svg>
         </span>
       )}
-      {totalUnread > 0 && !effectiveMute && (
+      {(hasMention || (totalUnread > 0 && !effectiveMute)) && (
         <span className="wk-conv-compact-badges">
-          <span className="wk-conv-compact-badge">
-            {totalUnread > 99 ? "99+" : totalUnread}
-          </span>
+          {hasMention && (
+            <span className="wk-conv-compact-mention" aria-hidden="true">
+              {t("base.conversationList.mentionMarker")}
+            </span>
+          )}
+          {totalUnread > 0 && !effectiveMute && (
+            <span className="wk-conv-compact-badge">
+              {totalUnread > 99 ? "99+" : totalUnread}
+            </span>
+          )}
         </span>
       )}
       {hasThreads && (
@@ -669,6 +675,10 @@ export default class ConversationList extends Component<
     // 折叠中的子区未读一起显示，否则会出现「角标显示 N 但列表里看不到任何未读」。
     // 已展开时 threadUnread 由调用处传 0，自然只显示父群自身。
     const totalUnread = conversationWrap.unread + threadUnread;
+    const hasMention = conversationWrap.isMentionMe && totalUnread > 0;
+    const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
+      (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
+    );
     // 子区静音继承父群（与 CompactGroupItem 保持一致）：显式设置看自身，未设置看父群
     const threadRawMute = isThread
       ? ((channelInfo?.orgData?.thread as any)?.mute as number | null | undefined)
@@ -819,18 +829,16 @@ export default class ConversationList extends Component<
                     {t("base.conversationList.draft")}
                   </label>
                 ) : undefined}
-                {conversationWrap.simpleReminders &&
+                {visibleSimpleReminders &&
                 !typing &&
-                conversationWrap.simpleReminders.length > 0
-                  ? conversationWrap.simpleReminders
-                      .filter((r) => r.done === false)
-                      .map((r) => {
-                        return (
-                          <label key={r.reminderID} className="wk-reminder">
-                            {r.text}
-                          </label>
-                        );
-                      })
+                visibleSimpleReminders.length > 0
+                  ? visibleSimpleReminders.map((r) => {
+                      return (
+                        <label key={r.reminderID} className="wk-reminder">
+                          {r.text}
+                        </label>
+                      );
+                    })
                   : undefined}
                 {/* 静音 + 多条未读：预览前置 [N 条] 红字提示（design v3.1 低打扰） */}
                 {effectiveMute && totalUnread > 1 && !typing && (
@@ -844,8 +852,10 @@ export default class ConversationList extends Component<
                   ? this._getTypingUI(conversationWrap)
                   : this.lastContent(conversationWrap)}
               </div>
-              {conversationWrap.isMentionMe && totalUnread > 0 && !effectiveMute && (
-                <span className="wk-mention-badge">{t("base.conversationList.mentionMe")}</span>
+              {hasMention && (
+                <span className="wk-mention" aria-hidden="true">
+                  {t("base.conversationList.mentionMarker")}
+                </span>
               )}
             </div>
           </div>

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -33,7 +33,7 @@
   "conversationList.external": "External",
   "conversationList.externalGroup": "External group",
   "conversationList.justNow": "Just now",
-  "conversationList.mentionMe": "@me",
+  "conversationList.mentionMarker": "@me",
   "conversationList.minutesAgoShort": "{{count}}m",
   "conversationList.toggleThreads": "Expand or collapse threads",
   "conversationList.typing": "typing",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -33,7 +33,7 @@
   "conversationList.external": "外部",
   "conversationList.externalGroup": "外部群",
   "conversationList.justNow": "刚刚",
-  "conversationList.mentionMe": "@我",
+  "conversationList.mentionMarker": "@我",
   "conversationList.minutesAgoShort": "{{count}}分钟",
   "conversationList.toggleThreads": "展开或收起子区",
   "conversationList.typing": "正在输入",


### PR DESCRIPTION
## Summary
- remove the left-side mention badge from regular and compact conversation list items
- stop rendering mentionMe reminders as ordinary preview reminder text, so 「有人@我」 does not remain in the recent tab
- show mention state in the right-side preview/badge area as a compact localized marker (`@我` / `@me`)

## Verification
- pnpm i18n:check
- git diff --check
- pnpm exec stylelint packages/dmworkbase/src/Components/ConversationList/index.css --config stylelint.config.mjs --allow-empty-input (passes with 2 existing warnings in this file)
- pnpm --filter @octo/web build

Closes #306