### PR TITLE
fix(#308): treat screenshot as boundary message in messageContinuity

### DIFF
--- a/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
@@ -46,4 +46,19 @@ describe("isMessageContinuation", () => {
     it("does not continue across different senders", () => {
         expect(isMessageContinuation(msg("u1", 1_000), msg("u2", 1_030))).toBe(false)
     })
+
+    it("breaks on screenshot system message (same fromUID should not hide avatar)", () => {
+        // 截屏消息虽然 fromUID 与下一条相同，但它是居中胶囊/system tag，
+        // 应该打断连续性，确保下一条正常显示头像（#308）
+        expect(isMessageContinuation(
+            msg("u1", 1_000, { contentType: MessageContentTypeConst.screenshot }),
+            msg("u1", 1_030),
+        )).toBe(false)
+
+        // 前一条正常消息接入截屏也打断
+        expect(isMessageContinuation(
+            msg("u1", 1_000),
+            msg("u1", 1_030, { contentType: MessageContentTypeConst.screenshot }),
+        )).toBe(false)
+    })
 })

--- a/packages/dmworkbase/src/Service/messageContinuity.ts
+++ b/packages/dmworkbase/src/Service/messageContinuity.ts
@@ -21,6 +21,7 @@ function isBoundaryMessage(message: ContinuityMessage): boolean {
     return contentType === MessageContentTypeConst.time
         || contentType === MessageContentTypeConst.historySplit
         || contentType === MessageContentTypeConst.typing
+        || contentType === MessageContentTypeConst.screenshot
         || !!message.revoke
 }
 


### PR DESCRIPTION
Closes #308

## 问题
截屏消息（contentType=20）不被 `isBoundaryMessage()` 视为边界消息。
复现场景：
```
消息A (张三 fromUID="zhangsan")
截屏消息 (张三截屏 → fromUID="zhangsan", contentType=20)
消息B (张三 fromUID="zhangsan")
```
计算消息B连续性时 `isBoundaryMessage(previous)` 返回 false →
`previous.fromUID === current.fromUID` → true → 头像被隐藏。

## 修复
在 `isBoundaryMessage()` 中新增 `MessageContentTypeConst.screenshot`，
与 `time`/`historySplit`/`typing` 一样作为边界打断连续性。

## 改动
- `Service/messageContinuity.ts`: +1 行
- `Service/__tests__/messageContinuity.test.ts`: +15 行（双向覆盖：截屏作为 previous / 截屏作为 current）