### PR TITLE
fix: CategorySection 折叠点击被 dnd-kit 拦截

### DIFF
--- a/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
+++ b/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
@@ -2,6 +2,10 @@ import React, { useRef, useEffect } from "react"
 import { useI18n } from "../../i18n"
 import "./index.css"
 
+export interface DragHandleProps extends React.HTMLAttributes<HTMLSpanElement> {
+    ref?: React.Ref<HTMLSpanElement>
+}
+
 export interface CategoryHeaderProps {
     name: string
     groupCount?: number
@@ -17,8 +21,8 @@ export interface CategoryHeaderProps {
     isEditing?: boolean
     onRenameConfirm?: (newName: string) => void
     onRenameCancel?: () => void
-    // 拖拽 handle props（由 useSortable 传入）
-    dragHandleProps?: React.HTMLAttributes<HTMLSpanElement>
+    // 拖拽 handle props（由 useSortable 传入，包含 ref）
+    dragHandleProps?: DragHandleProps
 }
 
 const CategoryHeader: React.FC<CategoryHeaderProps> = ({
@@ -126,10 +130,11 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({
             onClick={onToggle}
             onContextMenu={onContextMenu}
         >
-            {/* 拖拽 handle（由父组件传入 useSortable listeners） */}
+            {/* 拖拽 handle（由父组件传入 useSortable ref + listeners） */}
             {dragHandleProps && (
                 <span
                     className="wk-category-header__drag-handle"
+                    ref={dragHandleProps.ref}
                     {...dragHandleProps}
                     onClick={e => e.stopPropagation()}
                 >

--- a/packages/dmworkbase/src/Components/CategorySection/index.tsx
+++ b/packages/dmworkbase/src/Components/CategorySection/index.tsx
@@ -26,6 +26,10 @@ export interface CategorySectionProps {
     draggable?: boolean
 }
 
+export interface DragHandleProps extends React.HTMLAttributes<HTMLSpanElement> {
+    ref?: React.Ref<HTMLSpanElement>
+}
+
 const CategorySectionInner: React.FC<CategorySectionProps> = ({
     category,
     isCollapsed,
@@ -39,6 +43,7 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
 }) => {
     const { t } = useI18n()
     // useSortable：分组整体排序（同时作为 droppable，接受 group item 的 drop）
+    // 注意：setNodeRef 移到拖拽 handle 上，避免整个 section 拦截 pointer 事件导致折叠点击失效
     const {
         attributes,
         listeners,
@@ -57,11 +62,17 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
 
     const isEmpty = category.isEmpty ?? (!children || (Array.isArray(children) && children.length === 0))
 
+    // 把 setNodeRef 和 listeners 都绑到拖拽 handle 上，header 其他区域可正常响应点击
+    const dragHandleProps: DragHandleProps = {
+        ref: setNodeRef,
+        ...attributes,
+        ...listeners,
+    }
+
     return (
         <div
-            ref={setNodeRef}
             style={style}
-            className={`wk-category-section${isOver ? ' wk-category-section--drop-over' : ''}`}
+            className={`wk-category-section${isOver ? ' wk-category-section--drop-over' : ''}${isDragging ? ' wk-category-section--dragging' : ''}`}
         >
             <CategoryHeader
                 name={category.name}
@@ -76,7 +87,7 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
                 isEditing={isEditing}
                 onRenameConfirm={onRenameConfirm}
                 onRenameCancel={onRenameCancel}
-                dragHandleProps={{ ...attributes, ...listeners }}
+                dragHandleProps={dragHandleProps}
             />
             <div
                 className={`wk-category-section__content ${


### PR DESCRIPTION
## 问题

`CategorySection` 的折叠功能点击失效。

**原因分析**：
- `useSortable` 的 `setNodeRef` 绑定在整个 section div 上
- dnd-kit 的 `PointerSensor` 在该区域捕获所有 pointer 事件
- 点击 header 触发折叠时，click 事件被 dnd-kit 拦截
- 导致 `onToggle` 无法正常触发

## 修复方案

**方案 A（本 PR 采用）**：把 `setNodeRef` 从 section div 移到拖拽 handle（六点图标）上。

**改动点**：
1. `CategorySectionInner`：不再在外层 div 绑定 `ref={setNodeRef}`，改为把 `setNodeRef` 通过 `dragHandleProps.ref` 传给 `CategoryHeader`
2. `CategoryHeader`：在拖拽 handle span 上绑定 `ref={dragHandleProps.ref}`

**效果**：
- dnd-kit 只监听拖拽把手，不拦截 header 其他区域的点击
- 折叠/展开正常工作
- 拖拽排序仍然有效（通过专用 handle 触发）

## 测试

- [x] 构建通过
- [ ] 点击分类 header 可正常折叠/展开
- [ ] 拖拽分类 handle 可正常排序