### PR TITLE
fix: use setActivatorNodeRef to isolate drag activation on handle, re…

### DIFF
--- a/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
+++ b/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
@@ -18,7 +18,9 @@ export interface CategoryHeaderProps {
     onRenameConfirm?: (newName: string) => void
     onRenameCancel?: () => void
     // 拖拽 handle props（由 useSortable 传入）
-    dragHandleProps?: React.HTMLAttributes<HTMLSpanElement>
+    dragHandleRef?: React.RefCallback<HTMLElement>
+    dragHandleAttributes?: React.HTMLAttributes<HTMLSpanElement>
+    dragHandleListeners?: Record<string, React.EventHandler<any>>
 }
 
 const CategoryHeader: React.FC<CategoryHeaderProps> = ({
@@ -34,7 +36,9 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({
     isEditing,
     onRenameConfirm,
     onRenameCancel,
-    dragHandleProps,
+    dragHandleRef,
+    dragHandleAttributes,
+    dragHandleListeners,
 }) => {
     const { t } = useI18n()
     const inputRef = useRef<HTMLInputElement>(null)
@@ -126,11 +130,13 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({
             onClick={onToggle}
             onContextMenu={onContextMenu}
         >
-            {/* 拖拽 handle（由父组件传入 useSortable listeners） */}
-            {dragHandleProps && (
+            {/* 拖拽 handle（由父组件传入 useSortable setActivatorNodeRef + attributes/listeners） */}
+            {dragHandleRef && (
                 <span
+                    ref={dragHandleRef}
                     className="wk-category-header__drag-handle"
-                    {...dragHandleProps}
+                    {...dragHandleAttributes}
+                    {...dragHandleListeners}
                     onClick={e => e.stopPropagation()}
                 >
                     <svg width="10" height="14" viewBox="0 0 10 14" fill="none">

--- a/packages/dmworkbase/src/Components/CategorySection/index.tsx
+++ b/packages/dmworkbase/src/Components/CategorySection/index.tsx
@@ -43,6 +43,7 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
         attributes,
         listeners,
         setNodeRef,
+        setActivatorNodeRef,
         transform,
         transition,
         isDragging,
@@ -61,7 +62,7 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
         <div
             ref={setNodeRef}
             style={style}
-            className={`wk-category-section${isOver ? ' wk-category-section--drop-over' : ''}`}
+            className={`wk-category-section${isOver ? ' wk-category-section--drop-over' : ''}${isDragging ? ' wk-category-section--dragging' : ''}`}
         >
             <CategoryHeader
                 name={category.name}
@@ -76,7 +77,9 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
                 isEditing={isEditing}
                 onRenameConfirm={onRenameConfirm}
                 onRenameCancel={onRenameCancel}
-                dragHandleProps={{ ...attributes, ...listeners }}
+                dragHandleRef={setActivatorNodeRef}
+                dragHandleAttributes={attributes}
+                dragHandleListeners={listeners}
             />
             <div
                 className={`wk-category-section__content ${


### PR DESCRIPTION
## 问题
关注 Tab 中 CategorySection 的折叠点击被 dnd-kit 拦截，`onToggle` 无法触发。

根因：`useSortable` 的 `setNodeRef` 绑在 outer div 上，dnd-kit 将整个 div 作为 activator，点击 header 任意位置都被 dnd-kit 捕获，折叠事件被吃掉。

## 修复
使用 `setActivatorNodeRef` 将 drag activator 限定在拖拽 handle（六点图标）上：

- `setNodeRef` → 留在 outer div（碰撞检测不变）
- `setActivatorNodeRef` → handle span（只有拖拽图标触发排序）
- `attributes`（role/tabIndex/aria-*）→ outer div（a11y 正确）
- `listeners`（onPointerDown/onKeyDown）→ handle span

## 与 PR #312 的区别
| | #312 | 本 PR |
|---|---|---|
| setNodeRef | ❌ 移到 handle（碰撞检测失效） | ✅ 留在 div |
| 激活 | span 触发 | ✅ setActivatorNodeRef 精确限定 |
| 拖拽排序 | ❌ 碰撞区变小 | ✅ 完整 div |
| 折叠 | ✅ | ✅ |

## 改动
- `CategorySection/index.tsx`: 拆 `dragHandleProps` → `dragHandleRef` + `dragHandleListeners`；`attributes` 归还 outer div
- `CategoryHeader/index.tsx`: 对应更新 props 类型和渲染