### PR TITLE
fix: unify thread archive action visibility across entries (#283)

### DIFF
--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -16,7 +16,8 @@ import { X, Plus, ChevronDown, ArrowLeft, MoreHorizontal, Star } from "lucide-re
 import ThreadIcon from "../Icons/ThreadIcon";
 import classNames from "classnames";
 import { Conversation } from "../Conversation";
-import { ChannelTypeCommunityTopic, GroupRole } from "../../Service/Const";
+import { ChannelTypeCommunityTopic } from "../../Service/Const";
+import { canManageThread } from "../../Service/threadPermission";
 import { ErrorBoundary } from "../ErrorBoundary";
 import WKApp from "../../App";
 import { formatRelativeTime } from "../../Utils/time";
@@ -581,14 +582,7 @@ export default class ThreadPanel extends Component<
 
   private canEditThread(thread: Thread): boolean {
     if (!this.props.groupNo) return false;
-    const isCreator = thread.creator_uid === WKApp.loginInfo.uid;
-    const groupChannel = new Channel(this.props.groupNo, ChannelTypeGroup);
-    const subscribers =
-      WKSDK.shared().channelManager.getSubscribes(groupChannel);
-    const me = subscribers?.find((s) => s.uid === WKApp.loginInfo.uid);
-    const isManagerOrOwner =
-      me?.role === GroupRole.owner || me?.role === GroupRole.manager;
-    return isCreator || isManagerOrOwner;
+    return canManageThread(thread, this.props.groupNo);
   }
 
   private handleEditThread = () => {

--- a/packages/dmworkbase/src/Service/__tests__/threadArchiveAction.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadArchiveAction.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// 内存版父群成员缓存，测试通过它驱动 getSubscribes 返回值
+const subscribesByKey = new Map<string, Array<{ uid: string; role: number }>>();
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+    getChannelKey() {
+      return `${this.channelID}-${this.channelType}`;
+    }
+  },
+  ChannelTypeGroup: 2,
+  WKSDK: {
+    shared: () => ({
+      channelManager: {
+        getSubscribes: (channel: { getChannelKey: () => string }) =>
+          subscribesByKey.get(channel.getChannelKey()),
+      },
+    }),
+  },
+}));
+
+vi.mock("../../App", () => ({
+  default: {
+    loginInfo: { uid: "me" },
+  },
+}));
+
+import {
+  canArchiveThread,
+  shouldShowThreadArchiveAction,
+} from "../threadPermission";
+import { GroupRole } from "../Const";
+import { ThreadStatus } from "../Thread";
+
+const GROUP_NO = "g1";
+const GROUP_KEY = `${GROUP_NO}-2`;
+
+function setGroupMembers(members: Array<{ uid: string; role: number }>) {
+  subscribesByKey.set(GROUP_KEY, members);
+}
+
+/**
+ * 入口 B（ThreadPanel）的归档可见性参照实现：
+ * canEditThread 调用 canManageThread（角色核心），状态判断在渲染处。
+ * 这里复刻其归档项实际可见性，用于一致性回归断言。
+ */
+function entryBArchiveVisibility(thread: {
+  creator_uid?: string;
+  status?: number;
+}): boolean {
+  // canManageThread 经由 canArchiveThread（无 fallback）等价表达
+  const canManage = canArchiveThread({ thread, groupNo: GROUP_NO });
+  const statusOk =
+    thread.status === ThreadStatus.Active ||
+    thread.status === ThreadStatus.Archived;
+  return canManage && statusOk;
+}
+
+describe("thread.actions archive visibility (entry A)", () => {
+  beforeEach(() => {
+    subscribesByKey.clear();
+  });
+
+  it("shows archive action for a non-creator group owner on an Active thread", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(
+      shouldShowThreadArchiveAction({
+        thread: { creator_uid: "other", status: ThreadStatus.Active },
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: false,
+      })
+    ).toBe(true);
+  });
+
+  it("shows unarchive action for a non-creator group owner on an Archived thread", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(
+      shouldShowThreadArchiveAction({
+        thread: { creator_uid: "other", status: ThreadStatus.Archived },
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: false,
+      })
+    ).toBe(true);
+  });
+
+  it("hides archive action for an ordinary parent-group member", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.normal }]);
+    expect(
+      shouldShowThreadArchiveAction({
+        thread: { creator_uid: "other", status: ThreadStatus.Active },
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: false,
+      })
+    ).toBe(false);
+  });
+
+  it("does not throw when orgData.thread is missing", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(() =>
+      shouldShowThreadArchiveAction({
+        thread: undefined,
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: false,
+      })
+    ).not.toThrow();
+    // 无 thread → 无状态 → 不渲染
+    expect(
+      shouldShowThreadArchiveAction({
+        thread: undefined,
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: false,
+      })
+    ).toBe(false);
+  });
+
+  it("honors the isManagerOrCreatorOfMe fallback when true", () => {
+    // 父群缓存为空、非创建者，但兜底为 true → 放行
+    expect(
+      shouldShowThreadArchiveAction({
+        thread: { creator_uid: "other", status: ThreadStatus.Active },
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: true,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("entry A / entry B archive visibility consistency (issue #283)", () => {
+  beforeEach(() => {
+    subscribesByKey.clear();
+  });
+
+  const roles = [
+    { label: "creator", creator_uid: "me", members: [] as Array<{ uid: string; role: number }> },
+    {
+      label: "non-creator owner",
+      creator_uid: "other",
+      members: [{ uid: "me", role: GroupRole.owner }],
+    },
+    {
+      label: "non-creator manager",
+      creator_uid: "other",
+      members: [{ uid: "me", role: GroupRole.manager }],
+    },
+    {
+      label: "ordinary member",
+      creator_uid: "other",
+      members: [{ uid: "me", role: GroupRole.normal }],
+    },
+    {
+      label: "empty member cache",
+      creator_uid: "other",
+      members: [] as Array<{ uid: string; role: number }>,
+    },
+  ];
+
+  const statuses = [
+    { label: "Active", status: ThreadStatus.Active },
+    { label: "Archived", status: ThreadStatus.Archived },
+    { label: "Deleted", status: ThreadStatus.Deleted },
+  ];
+
+  for (const role of roles) {
+    for (const st of statuses) {
+      it(`matches for ${role.label} + ${st.label}`, () => {
+        if (role.members.length > 0) {
+          setGroupMembers(role.members);
+        }
+        const thread = { creator_uid: role.creator_uid, status: st.status };
+
+        // 入口 A：不依赖子区缓存兜底（fallback=false），纯父群口径
+        const entryA = shouldShowThreadArchiveAction({
+          thread,
+          groupNo: GROUP_NO,
+          isManagerOrCreatorOfMeFallback: false,
+        });
+        const entryB = entryBArchiveVisibility(thread);
+
+        expect(entryA).toBe(entryB);
+      });
+    }
+  }
+});

--- a/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// 内存版父群成员缓存，测试通过它驱动 getSubscribes 返回值
+const subscribesByKey = new Map<string, Array<{ uid: string; role: number }>>();
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+    getChannelKey() {
+      return `${this.channelID}-${this.channelType}`;
+    }
+  },
+  ChannelTypeGroup: 2,
+  WKSDK: {
+    shared: () => ({
+      channelManager: {
+        getSubscribes: (channel: { getChannelKey: () => string }) =>
+          subscribesByKey.get(channel.getChannelKey()),
+      },
+    }),
+  },
+}));
+
+vi.mock("../../App", () => ({
+  default: {
+    loginInfo: { uid: "me" },
+  },
+}));
+
+import { canManageThread } from "../threadPermission";
+import { GroupRole } from "../Const";
+
+const GROUP_NO = "g1";
+const GROUP_KEY = `${GROUP_NO}-2`;
+
+function setGroupMembers(members: Array<{ uid: string; role: number }>) {
+  subscribesByKey.set(GROUP_KEY, members);
+}
+
+describe("canManageThread", () => {
+  beforeEach(() => {
+    subscribesByKey.clear();
+  });
+
+  it("returns false when thread is missing", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(canManageThread(null, GROUP_NO)).toBe(false);
+    expect(canManageThread(undefined, GROUP_NO)).toBe(false);
+  });
+
+  it("returns true for the thread creator", () => {
+    // 即便父群没有成员缓存，创建者也成立
+    expect(canManageThread({ creator_uid: "me" }, GROUP_NO)).toBe(true);
+  });
+
+  it("returns true for parent-group owner who is not the creator", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      true
+    );
+  });
+
+  it("returns true for parent-group manager who is not the creator", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.manager }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      true
+    );
+  });
+
+  it("returns false for an ordinary parent-group member", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.normal }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      false
+    );
+  });
+
+  it("returns false (and does not throw) when the member cache is empty", () => {
+    // 父群成员缓存从未同步：getSubscribes 返回 undefined
+    expect(() =>
+      canManageThread({ creator_uid: "someone-else" }, GROUP_NO)
+    ).not.toThrow();
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      false
+    );
+  });
+
+  it("returns false when groupNo is empty for a non-creator", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, "")).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Service/threadPermission.ts
+++ b/packages/dmworkbase/src/Service/threadPermission.ts
@@ -1,0 +1,75 @@
+import { Channel, ChannelTypeGroup, WKSDK } from "wukongimjssdk";
+import { GroupRole } from "./Const";
+import { ThreadStatus } from "./Thread";
+import WKApp from "../App";
+
+/**
+ * 子区「角色/权限」统一判定：当前登录用户是否可以管理（含归档/取消归档）该子区。
+ *
+ * 归档入口在两处出现，必须共用同一份口径，否则会像 issue #283 一样出现一处可见、
+ * 一处不可见的撕裂：
+ *   - 入口 A：ChannelSetting 的 thread.actions（module.tsx）
+ *   - 入口 B：ThreadPanel 右上角「…」菜单（ThreadPanel/canEditThread）
+ *
+ * 关键点：角色必须从【父群】成员列表解析，而不是子区频道自身的成员缓存。
+ * 子区频道成员从未被同步，读取子区缓存会让非创建者的群主/管理员恒为 false。
+ *
+ * @param thread  子区数据（至少含 creator_uid）。为空返回 false。
+ * @param groupNo 父群 group_no。
+ */
+export function canManageThread(
+  thread: { creator_uid?: string } | null | undefined,
+  groupNo: string
+): boolean {
+  if (!thread) {
+    return false;
+  }
+  if (thread.creator_uid && thread.creator_uid === WKApp.loginInfo.uid) {
+    return true;
+  }
+  if (!groupNo) {
+    return false;
+  }
+  const groupChannel = new Channel(groupNo, ChannelTypeGroup);
+  const subscribers = WKSDK.shared().channelManager.getSubscribes(groupChannel);
+  const me = subscribers?.find((s) => s.uid === WKApp.loginInfo.uid);
+  return me?.role === GroupRole.owner || me?.role === GroupRole.manager;
+}
+
+/**
+ * ChannelSetting「子区管理」入口（module.tsx 的 thread.actions，即 issue #283 的
+ * 缺陷入口 A）的归档可见性判定。
+ *
+ * 角色/权限核心走 {@link canManageThread}（父群口径，与 ThreadPanel 完全一致），
+ * 另保留 isManagerOrCreatorOfMeFallback 作为兜底：它来自子区频道成员缓存，正常
+ * 情况下不可靠（恒 false），但若后端/缓存确实给出 true 则直接放行，不回退权限。
+ */
+export function canArchiveThread(args: {
+  thread: { creator_uid?: string } | null | undefined;
+  groupNo: string | undefined;
+  isManagerOrCreatorOfMeFallback?: boolean;
+}): boolean {
+  if (args.isManagerOrCreatorOfMeFallback) {
+    return true;
+  }
+  return canManageThread(args.thread, args.groupNo ?? "");
+}
+
+/**
+ * 入口 A（thread.actions）归档/取消归档菜单项是否应渲染：
+ * 既要有权限（canArchiveThread），状态又必须是 Active 或 Archived。
+ * 抽成纯函数以便与入口 B 做「一致性回归」断言。
+ */
+export function shouldShowThreadArchiveAction(args: {
+  thread: { creator_uid?: string; status?: number } | null | undefined;
+  groupNo: string | undefined;
+  isManagerOrCreatorOfMeFallback?: boolean;
+}): boolean {
+  const status = args.thread?.status;
+  const isActive = status === ThreadStatus.Active;
+  const isArchived = status === ThreadStatus.Archived;
+  if (!isActive && !isArchived) {
+    return false;
+  }
+  return canArchiveThread(args);
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -111,6 +111,7 @@ import {
 import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
+import { shouldShowThreadArchiveAction } from "./Service/threadPermission";
 import { canShowRevokeMenu } from "./Service/revokePermission";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
@@ -2194,13 +2195,22 @@ export default class BaseModule implements IModule {
         }
         const threadInfo = parseThreadChannelId(channel.channelID);
         const thread = data.channelInfo?.orgData?.thread as any;
-        const isCreator = thread?.creator_uid === WKApp.loginInfo.uid;
-        const canArchive = isCreator || data.isManagerOrCreatorOfMe;
+        // 角色/权限判定统一走 shouldShowThreadArchiveAction（内部调用
+        // canArchiveThread → canManageThread，从【父群】成员列表解析
+        // owner/manager，与 ThreadPanel.canEditThread 完全一致，见 issue #283），
+        // 并统一「状态须为 Active/Archived」的门槛，避免与入口 B 产生平行副本。
+        // data.isManagerOrCreatorOfMe 读的是子区频道自身成员缓存，从未同步，
+        // 非创建者的群主/管理员恒为 false，仅作兜底。
+        const showArchiveAction = shouldShowThreadArchiveAction({
+          thread,
+          groupNo: threadInfo?.groupNo,
+          isManagerOrCreatorOfMeFallback: data.isManagerOrCreatorOfMe,
+        });
+        // isArchived 用于决定显示「归档」还是「取消归档」文案。
         const isArchived = thread?.status === ThreadStatus.Archived;
-        const isActive = thread?.status === ThreadStatus.Active;
         const rows = new Array<Row>();
 
-        if (threadInfo && canArchive && (isActive || isArchived)) {
+        if (threadInfo && showArchiveAction) {
           rows.push(
             new Row({
               cell: ListItemButton,


### PR DESCRIPTION
Closes #283.

## Problem
The thread "..." menu's "归档子区 (Archive thread)" action showed inconsistently depending on the entry point:
- Entry A (left thread list / channel info → ChannelSetting `thread.actions`): archive action missing for group owner/manager who is not the thread creator.
- Entry B (in-group thread entry → ThreadPanel "..." menu): archive action visible.

## Root cause
The two entries resolved the "am I owner/manager" role from different data sources:
- Entry B (`ThreadPanel.canEditThread`) correctly read the role from the **parent group** member list.
- Entry A (`module.tsx` `thread.actions`) relied on `data.isManagerOrCreatorOfMe`, which reads the **thread channel's** own subscriber cache. Thread-channel members are never synced, so for a non-creator owner/manager this was always `false`, filtering out the archive action.

## Fix
- Add shared pure helpers in `packages/dmworkbase/src/Service/threadPermission.ts` (`canManageThread` / `canArchiveThread` / `shouldShowThreadArchiveAction`) that resolve the role from the parent group member list.
- Entry A (`module.tsx`) now gates the archive/unarchive action via `shouldShowThreadArchiveAction`, no longer depending on the always-empty thread-channel subscriber cache (kept only as an OR fallback).
- Entry B (`ThreadPanel.canEditThread`) now calls the same shared helper, so both entries share one source of truth.

## Tests
- New unit tests for the permission helpers and Entry A action rows (27 cases), including an entry-consistency regression that asserts the archive visibility matches between the two entries.
- Related package tests pass.

## Verification
- Local docker build + container recreate (`octo-web:local`) verified the change is included in the built bundle and the service serves normally.