### PR TITLE
feat: add inline archive quick action to active thread list (#286)

### DIFF
--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { ThreadStatus } from "../../../Service/Thread";
+
+// ── Hoisted mock fns shared across module mocks ──
+const hoisted = vi.hoisted(() => ({
+  threadArchive: vi.fn(),
+  threadUnarchive: vi.fn(),
+  threadGet: vi.fn(),
+  threadList: vi.fn(),
+  toastInfo: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastClose: vi.fn(),
+  getSubscribes: vi.fn(),
+}));
+
+vi.mock("../../../App", () => ({
+  __esModule: true,
+  default: {
+    dataSource: {
+      channelDataSource: {
+        threadArchive: hoisted.threadArchive,
+        threadUnarchive: hoisted.threadUnarchive,
+        threadGet: hoisted.threadGet,
+        threadList: hoisted.threadList,
+        channelFiles: vi.fn(),
+      },
+    },
+    loginInfo: { uid: "owner-uid" },
+    shared: { deviceId: "dev-1", currentSpaceId: "space-1" },
+    mittBus: { emit: vi.fn() },
+    endpoints: { showConversation: vi.fn() },
+  },
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    info: hoisted.toastInfo,
+    error: hoisted.toastError,
+    success: hoisted.toastSuccess,
+    close: hoisted.toastClose,
+  },
+  Spin: () => React.createElement("div", { "data-testid": "spin" }),
+  Popover: ({ children }: any) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+  }
+  return {
+    Channel,
+    ChannelTypePerson: 1,
+    ChannelTypeGroup: 2,
+    WKSDK: {
+      shared: () => ({
+        channelManager: {
+          getSubscribes: hoisted.getSubscribes,
+          getChannelInfo: () => null,
+          deleteChannelInfo: vi.fn(),
+          fetchChannelInfo: vi.fn(),
+        },
+      }),
+    },
+  };
+});
+
+// Heavy sub-trees not needed for list-view interaction tests.
+vi.mock("../../Conversation", () => ({ Conversation: () => null }));
+vi.mock("../../FilePreviewPanel/FileListPanel", () => ({ FileListPanel: () => null }));
+vi.mock("../../FilePreviewPanel/FilePreviewHeader", () => ({ __esModule: true, default: () => null }));
+vi.mock("../../FilePreviewPanel/registry", () => ({ fileRendererRegistry: { getRenderer: () => ({ renderer: () => null }) } }));
+vi.mock("../../FilePreviewPanel/renderers/MarkdownRenderer", () => ({ MarkdownRenderer: () => null }));
+vi.mock("../../FilePreviewPanel/renderers/HtmlRenderer", () => ({ HtmlRenderer: () => null }));
+vi.mock("../../FilePreviewPanel/renderers/ImageRenderer", () => ({ ImageRenderer: () => null }));
+vi.mock("../../../Service/SidebarService", () => ({ __esModule: true, default: { sync: vi.fn().mockResolvedValue(null) } }));
+vi.mock("../../../Service/FollowService", () => ({ __esModule: true, default: {} }));
+vi.mock("../../../Service/CategoryService", () => ({ __esModule: true, default: {} }));
+
+import ThreadPanel from "../index";
+
+const ACTIVE_THREAD = {
+  short_id: "t1",
+  group_no: "g1",
+  channel_id: "g1____t1",
+  channel_type: 5,
+  name: "Active Thread",
+  creator_uid: "owner-uid",
+  status: ThreadStatus.Active,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const ARCHIVED_THREAD = {
+  ...ACTIVE_THREAD,
+  short_id: "t2",
+  channel_id: "g1____t2",
+  name: "Archived Thread",
+  status: ThreadStatus.Archived,
+};
+
+function archiveButton(): HTMLElement | null {
+  return document.querySelector(".wk-thread-panel-item-archive-btn");
+}
+
+async function renderPanel(threads: any[], canEdit = true) {
+  hoisted.threadList.mockResolvedValue(threads);
+  // canEditThread: creator_uid === loginInfo.uid ⇒ owner; toggle via creator match.
+  hoisted.getSubscribes.mockReturnValue(
+    canEdit ? [{ uid: "owner-uid", role: 1 /* owner */ }] : []
+  );
+  const props = {
+    groupNo: "g1",
+    thread: null,
+    onClose: vi.fn(),
+    onThreadSelect: vi.fn(),
+  };
+  render(React.createElement(ThreadPanel, props));
+  await waitFor(() =>
+    expect(screen.getByText(threads[0].name)).toBeTruthy()
+  );
+  return props;
+}
+
+async function renderPanelWithUnmount(threads: any[], canEdit = true) {
+  hoisted.threadList.mockResolvedValue(threads);
+  hoisted.getSubscribes.mockReturnValue(
+    canEdit ? [{ uid: "owner-uid", role: 1 /* owner */ }] : []
+  );
+  const result = render(
+    React.createElement(ThreadPanel, {
+      groupNo: "g1",
+      thread: null,
+      onClose: vi.fn(),
+      onThreadSelect: vi.fn(),
+    })
+  );
+  await waitFor(() => expect(screen.getByText(threads[0].name)).toBeTruthy());
+  return result;
+}
+
+beforeEach(() => {
+  Object.values(hoisted).forEach((fn) => fn.mockReset?.());
+  hoisted.toastInfo.mockReturnValue("toast-id-1");
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("ThreadPanel inline archive button", () => {
+  it("点击归档按钮调用 threadArchive 参数正确，并弹出撤销 Toast", async () => {
+    await renderPanel([ACTIVE_THREAD]);
+    const btn = archiveButton();
+    expect(btn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(btn!);
+    });
+
+    expect(hoisted.threadArchive).toHaveBeenCalledWith("g1", "t1");
+    await waitFor(() => expect(hoisted.toastInfo).toHaveBeenCalledTimes(1));
+  });
+
+  it("点击归档不触发整行 handleThreadClick（e.stopPropagation 生效）", async () => {
+    const props = await renderPanel([ACTIVE_THREAD]);
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    // 进入 detail 视图会调用 onThreadSelect(thread)；stopPropagation 后不应触发
+    expect(props.onThreadSelect).not.toHaveBeenCalled();
+  });
+
+  it("归档失败回滚乐观状态并 Toast.error", async () => {
+    hoisted.threadArchive.mockRejectedValue(new Error("boom"));
+    await renderPanel([ACTIVE_THREAD]);
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.toastError).toHaveBeenCalledTimes(1));
+    // 回滚后仍在活跃组，按钮 data-action 仍为 archive
+    expect(archiveButton()?.getAttribute("data-action")).toBe("archive");
+  });
+
+  it("无编辑权限时不渲染归档按钮", async () => {
+    // 非创建者 + 非群主/管理员 ⇒ canEditThread 为 false
+    await renderPanel(
+      [{ ...ACTIVE_THREAD, creator_uid: "someone-else" }],
+      /* canEdit */ false
+    );
+    expect(archiveButton()).toBeNull();
+  });
+
+  it("已归档行点击直接调用 threadUnarchive（无撤销 Toast）", async () => {
+    hoisted.threadList.mockResolvedValue([ARCHIVED_THREAD]);
+    hoisted.getSubscribes.mockReturnValue([{ uid: "owner-uid", role: 1 }]);
+    render(
+      React.createElement(ThreadPanel, {
+        groupNo: "g1",
+        thread: null,
+        onClose: vi.fn(),
+        onThreadSelect: vi.fn(),
+      })
+    );
+    // 已归档分组默认折叠，需先展开
+    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archived"));
+    });
+    await waitFor(() => expect(archiveButton()).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t2");
+    expect(hoisted.toastInfo).not.toHaveBeenCalled();
+  });
+
+  it("点击撤销调用 threadUnarchive 恢复", async () => {
+    await renderPanel([ACTIVE_THREAD]);
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.toastInfo).toHaveBeenCalled());
+
+    // 取出 Toast 自定义 content，点击其中的「撤销」按钮
+    const content = hoisted.toastInfo.mock.calls[0][0].content as React.ReactElement;
+    render(content);
+    const undoBtn = await waitFor(() => {
+      const el = document.querySelector(".wk-thread-archive-undo-btn");
+      if (!el) throw new Error("undo button not rendered yet");
+      return el;
+    });
+    expect(undoBtn).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(undoBtn!);
+    });
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t1");
+    expect(hoisted.toastClose).toHaveBeenCalledWith("toast-id-1");
+  });
+
+  it("超时未点撤销不会调用 threadUnarchive", async () => {
+    await renderPanel([ACTIVE_THREAD]);
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.threadArchive).toHaveBeenCalled());
+    // 不点击撤销：threadUnarchive 永远不应被调用
+    expect(hoisted.threadUnarchive).not.toHaveBeenCalled();
+  });
+
+  it("卸载后点撤销不应再发 threadUnarchive 请求（B1 回归）", async () => {
+    const { unmount } = await renderPanelWithUnmount([ACTIVE_THREAD]);
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.toastInfo).toHaveBeenCalled());
+
+    // 取出撤销 Toast 的 content（渲染在全局 portal，不随面板卸载销毁）
+    const content = hoisted.toastInfo.mock.calls[0][0].content as React.ReactElement;
+    render(content);
+    const undoBtn = await waitFor(() => {
+      const el = document.querySelector(".wk-thread-archive-undo-btn");
+      if (!el) throw new Error("undo button not rendered yet");
+      return el;
+    });
+
+    // 面板卸载：componentWillUnmount 应 Toast.close 撤销 Toast 并清理集合
+    await act(async () => {
+      unmount();
+    });
+    expect(hoisted.toastClose).toHaveBeenCalledWith("toast-id-1");
+
+    // 卸载后点撤销：isUnmounted 短路，不应再发 threadUnarchive
+    await act(async () => {
+      fireEvent.click(undoBtn!);
+    });
+    expect(hoisted.threadUnarchive).not.toHaveBeenCalled();
+  });
+
+  it("连点两次行内归档按钮只发一次 threadArchive（防重复点击闸门）", async () => {
+    // threadArchive 挂起，模拟请求进行中连点：archivingShortIds 闸门应拦住第二次
+    let resolveArchive: () => void = () => {};
+    hoisted.threadArchive.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveArchive = resolve;
+      })
+    );
+    await renderPanel([ACTIVE_THREAD]);
+    const btn = archiveButton();
+    expect(btn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(btn!);
+      fireEvent.click(btn!);
+    });
+
+    expect(hoisted.threadArchive).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveArchive();
+    });
+  });
+});

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
@@ -411,4 +411,91 @@ describe("ThreadPanel inline archive button", () => {
     expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled();
     expect(hoisted.threadList.mock.calls.length).toBe(threadListCallsBefore);
   });
+
+  it("撤销请求在途时卸载：resolve 后不再刷新 / loadThreads（撤销在途竞态回归）", async () => {
+    let resolveUnarchive: () => void = () => {};
+    hoisted.threadUnarchive.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveUnarchive = resolve;
+      })
+    );
+    const { unmount } = await renderPanelWithUnmount([ACTIVE_THREAD]);
+
+    // 归档创建撤销 Toast
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.toastInfo).toHaveBeenCalled());
+
+    // 取出撤销 Toast 的 content 并点击「撤销」，threadUnarchive 进入在途状态
+    const content = hoisted.toastInfo.mock.calls[0][0].content as React.ReactElement;
+    render(content);
+    const undoBtn = await waitFor(() => {
+      const el = document.querySelector(".wk-thread-archive-undo-btn");
+      if (!el) throw new Error("undo button not rendered yet");
+      return el;
+    });
+    const threadListCallsBefore = hoisted.threadList.mock.calls.length;
+    await act(async () => {
+      fireEvent.click(undoBtn!);
+    });
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t1");
+
+    // 记录基线：归档成功路径已调用过 refreshThreadChannelInfo，只观察卸载后是否再次调用
+    const deleteCallsBefore = hoisted.deleteChannelInfo.mock.calls.length;
+    const fetchCallsBefore = hoisted.fetchChannelInfo.mock.calls.length;
+
+    // 撤销请求 resolve 前卸载面板
+    await act(async () => {
+      unmount();
+    });
+
+    // resolve 在途请求：isUnmounted 短路，不应 refreshThreadChannelInfo / loadThreads
+    await act(async () => {
+      resolveUnarchive();
+    });
+    expect(hoisted.deleteChannelInfo.mock.calls.length).toBe(deleteCallsBefore);
+    expect(hoisted.fetchChannelInfo.mock.calls.length).toBe(fetchCallsBefore);
+    expect(hoisted.threadList.mock.calls.length).toBe(threadListCallsBefore);
+  });
+
+  it("撤销请求在途时卸载：reject 后不再 Toast.error（撤销在途 reject 竞态回归）", async () => {
+    let rejectUnarchive: (e: Error) => void = () => {};
+    hoisted.threadUnarchive.mockReturnValue(
+      new Promise<void>((_resolve, reject) => {
+        rejectUnarchive = reject;
+      })
+    );
+    const { unmount } = await renderPanelWithUnmount([ACTIVE_THREAD]);
+
+    // 归档创建撤销 Toast
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    await waitFor(() => expect(hoisted.toastInfo).toHaveBeenCalled());
+
+    // 取出撤销 Toast 的 content 并点击「撤销」，threadUnarchive 进入在途状态
+    const content = hoisted.toastInfo.mock.calls[0][0].content as React.ReactElement;
+    render(content);
+    const undoBtn = await waitFor(() => {
+      const el = document.querySelector(".wk-thread-archive-undo-btn");
+      if (!el) throw new Error("undo button not rendered yet");
+      return el;
+    });
+    await act(async () => {
+      fireEvent.click(undoBtn!);
+    });
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t1");
+
+    // 撤销请求 reject 前卸载面板
+    await act(async () => {
+      unmount();
+    });
+
+    // reject 在途请求：catch 块开头 isUnmounted 短路，不应 Toast.error
+    await act(async () => {
+      rejectUnarchive(new Error("boom"));
+    });
+    expect(hoisted.toastError).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
@@ -15,6 +15,8 @@ const hoisted = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastClose: vi.fn(),
   getSubscribes: vi.fn(),
+  deleteChannelInfo: vi.fn(),
+  fetchChannelInfo: vi.fn(),
 }));
 
 vi.mock("../../../App", () => ({
@@ -65,8 +67,8 @@ vi.mock("wukongimjssdk", () => {
         channelManager: {
           getSubscribes: hoisted.getSubscribes,
           getChannelInfo: () => null,
-          deleteChannelInfo: vi.fn(),
-          fetchChannelInfo: vi.fn(),
+          deleteChannelInfo: hoisted.deleteChannelInfo,
+          fetchChannelInfo: hoisted.fetchChannelInfo,
         },
       }),
     },
@@ -310,5 +312,103 @@ describe("ThreadPanel inline archive button", () => {
     await act(async () => {
       resolveArchive();
     });
+  });
+
+  it("归档请求在途时卸载：resolve 后不再建撤销 Toast / 刷新（在途竞态回归）", async () => {
+    let resolveArchive: () => void = () => {};
+    hoisted.threadArchive.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveArchive = resolve;
+      })
+    );
+    const { unmount } = await renderPanelWithUnmount([ACTIVE_THREAD]);
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    expect(hoisted.threadArchive).toHaveBeenCalledTimes(1);
+
+    // 请求 resolve 前卸载面板
+    await act(async () => {
+      unmount();
+    });
+
+    // 现在 resolve 在途请求：isUnmounted 短路，不应再建撤销 Toast 或刷新频道信息
+    await act(async () => {
+      resolveArchive();
+    });
+    expect(hoisted.toastInfo).not.toHaveBeenCalled();
+    expect(hoisted.deleteChannelInfo).not.toHaveBeenCalled();
+    expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled();
+  });
+
+  it("归档请求在途时卸载：reject 后不再回滚乐观状态（在途 reject 竞态回归）", async () => {
+    let rejectArchive: (e: Error) => void = () => {};
+    hoisted.threadArchive.mockReturnValue(
+      new Promise<void>((_resolve, reject) => {
+        rejectArchive = reject;
+      })
+    );
+    const { unmount } = await renderPanelWithUnmount([ACTIVE_THREAD]);
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    expect(hoisted.threadArchive).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      unmount();
+    });
+
+    // reject 在途请求：catch 块开头 isUnmounted 短路，不应回滚（setThreadStatusOptimistic）
+    // 也不应 Toast.error。
+    await act(async () => {
+      rejectArchive(new Error("boom"));
+    });
+    expect(hoisted.toastError).not.toHaveBeenCalled();
+  });
+
+  it("取消归档请求在途时卸载：resolve 后不再刷新 / loadThreads（在途竞态回归）", async () => {
+    let resolveUnarchive: () => void = () => {};
+    hoisted.threadUnarchive.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveUnarchive = resolve;
+      })
+    );
+    hoisted.threadList.mockResolvedValue([ARCHIVED_THREAD]);
+    hoisted.getSubscribes.mockReturnValue([{ uid: "owner-uid", role: 1 }]);
+    const { unmount } = render(
+      React.createElement(ThreadPanel, {
+        groupNo: "g1",
+        thread: null,
+        onClose: vi.fn(),
+        onThreadSelect: vi.fn(),
+      })
+    );
+    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archived"));
+    });
+    await waitFor(() => expect(archiveButton()).toBeTruthy());
+
+    // 初次列表加载已调用过 threadList，记录基线后只观察卸载后是否再次调用
+    const threadListCallsBefore = hoisted.threadList.mock.calls.length;
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t2");
+
+    await act(async () => {
+      unmount();
+    });
+
+    // resolve 在途请求：isUnmounted 短路，不应 refreshThreadChannelInfo / loadThreads
+    await act(async () => {
+      resolveUnarchive();
+    });
+    expect(hoisted.deleteChannelInfo).not.toHaveBeenCalled();
+    expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled();
+    expect(hoisted.threadList.mock.calls.length).toBe(threadListCallsBefore);
   });
 });

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/archiveActions.test.ts
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/archiveActions.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveArchiveAction,
+  shouldShowArchiveButton,
+} from "../archiveActions";
+import { Thread, ThreadStatus } from "../../../Service/Thread";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    short_id: "t1",
+    group_no: "g1",
+    channel_id: "g1____t1",
+    channel_type: 5,
+    name: "Thread 1",
+    creator_uid: "u1",
+    status: ThreadStatus.Active,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+describe("deriveArchiveAction", () => {
+  it("活跃子区推导为归档动作", () => {
+    expect(deriveArchiveAction(makeThread({ status: ThreadStatus.Active }))).toBe(
+      "archive"
+    );
+  });
+
+  it("已归档子区推导为取消归档动作", () => {
+    expect(
+      deriveArchiveAction(makeThread({ status: ThreadStatus.Archived }))
+    ).toBe("unarchive");
+  });
+
+  it("已删除子区无可执行动作", () => {
+    expect(
+      deriveArchiveAction(makeThread({ status: ThreadStatus.Deleted }))
+    ).toBeNull();
+  });
+});
+
+describe("shouldShowArchiveButton", () => {
+  it("有权限且状态可操作时显示", () => {
+    expect(
+      shouldShowArchiveButton(makeThread({ status: ThreadStatus.Active }), true)
+    ).toBe(true);
+    expect(
+      shouldShowArchiveButton(
+        makeThread({ status: ThreadStatus.Archived }),
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("无权限时不显示", () => {
+    expect(
+      shouldShowArchiveButton(makeThread({ status: ThreadStatus.Active }), false)
+    ).toBe(false);
+  });
+
+  it("有权限但状态不可操作（已删除）时不显示", () => {
+    expect(
+      shouldShowArchiveButton(makeThread({ status: ThreadStatus.Deleted }), true)
+    ).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Components/ThreadPanel/archiveActions.ts
+++ b/packages/dmworkbase/src/Components/ThreadPanel/archiveActions.ts
@@ -1,0 +1,27 @@
+import { Thread, ThreadStatus } from "../../Service/Thread";
+
+/** 行内归档按钮要执行的目标动作（由子区当前状态推导） */
+export type ArchiveAction = "archive" | "unarchive";
+
+/**
+ * 由 thread.status 推导行内按钮点击后应执行的动作。
+ * 活跃 → 归档；已归档 → 取消归档；其它状态（如已删除）→ null（不可操作）。
+ * 抽成纯函数便于单测，并让活跃组 / 已归档组复用同一行组件时按状态区分图标与 title。
+ */
+export function deriveArchiveAction(thread: Thread): ArchiveAction | null {
+  if (thread.status === ThreadStatus.Active) return "archive";
+  if (thread.status === ThreadStatus.Archived) return "unarchive";
+  return null;
+}
+
+/**
+ * 是否渲染行内归档按钮。
+ * 需同时满足：有编辑权限（与详情菜单一致，无权限不显示）且能推导出有效动作。
+ * 抽成纯函数便于单测。
+ */
+export function shouldShowArchiveButton(
+  thread: Thread,
+  canEdit: boolean
+): boolean {
+  return canEdit && deriveArchiveAction(thread) !== null;
+}

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.css
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.css
@@ -502,25 +502,31 @@ body[theme-mode="dark"] .wk-thread-panel {
 }
 
 .wk-thread-panel-item-archive-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: none;
-  border: none;
-  padding: 2px;
+  gap: 3px;
+  background: var(--semi-color-fill-0);
+  border: 1px solid var(--wk-border-default);
+  padding: 2px 8px;
   cursor: pointer;
-  border-radius: 4px;
-  opacity: 0;
-  transition: opacity 0.15s;
+  border-radius: var(--wk-r-full);
+  color: var(--wk-text-secondary);
+  font-size: 12px;
   line-height: 1;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.wk-thread-panel-item:hover .wk-thread-panel-item-archive-btn {
-  opacity: 1;
+.wk-thread-panel-item-archive-btn-label {
+  font-size: 12px;
 }
 
 .wk-thread-panel-item-archive-btn:hover {
   background: var(--semi-color-fill-1);
+  border-color: var(--wk-border-glow);
+  color: var(--wk-text-primary);
 }
 
 .wk-thread-archive-undo-toast {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.css
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.css
@@ -501,6 +501,47 @@ body[theme-mode="dark"] .wk-thread-panel {
   background: var(--semi-color-fill-1);
 }
 
+.wk-thread-panel-item-archive-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  line-height: 1;
+}
+
+.wk-thread-panel-item:hover .wk-thread-panel-item-archive-btn {
+  opacity: 1;
+}
+
+.wk-thread-panel-item-archive-btn:hover {
+  background: var(--semi-color-fill-1);
+}
+
+.wk-thread-archive-undo-toast {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+}
+
+.wk-thread-archive-undo-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--semi-color-primary);
+}
+
+.wk-thread-archive-undo-btn:hover {
+  text-decoration: underline;
+}
+
 .wk-thread-panel-item-title {
   display: flex;
   align-items: center;

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -1476,9 +1476,12 @@ export default class ThreadPanel extends Component<
         groupNo,
         thread.short_id
       );
+      // 卸载后短路：避免对已卸载组件 setState 并刷新列表。
+      if (this.isUnmounted) return;
       this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
       await this.loadThreads();
     } catch {
+      if (this.isUnmounted) return;
       this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Archived);
       Toast.error(t("base.module.thread.unarchiveFailedRetry"));
     } finally {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -1384,12 +1384,15 @@ export default class ThreadPanel extends Component<
         groupNo,
         thread.short_id
       );
+      // 卸载后短路：撤销 Toast 渲染在全局 portal，卸载后再创建会绕过 cleanup。
+      if (this.isUnmounted) return;
       this.refreshThreadChannelInfo({
         ...thread,
         status: ThreadStatus.Archived,
       });
       this.showArchiveUndoToast(groupNo, thread);
     } catch {
+      if (this.isUnmounted) return;
       // 失败回滚乐观状态
       this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Active);
       Toast.error(t("base.module.thread.archiveFailedRetry"));
@@ -1407,10 +1410,13 @@ export default class ThreadPanel extends Component<
         groupNo,
         thread.short_id
       );
+      // 卸载后短路：避免对已卸载组件 setState 并刷新列表。
+      if (this.isUnmounted) return;
       Toast.success(t("base.module.thread.unarchiveSuccess"));
       this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
       await this.loadThreads();
     } catch {
+      if (this.isUnmounted) return;
       this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Archived);
       Toast.error(t("base.module.thread.unarchiveFailedRetry"));
     } finally {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -1500,10 +1500,11 @@ export default class ThreadPanel extends Component<
         onClick={(e) => this.handleInlineArchiveToggle(thread, e)}
       >
         {archiving ? (
-          <Archive size={15} color="var(--semi-color-text-2)" />
+          <Archive size={13} />
         ) : (
-          <ArchiveRestore size={15} color="var(--semi-color-text-2)" />
+          <ArchiveRestore size={13} />
         )}
+        <span className="wk-thread-panel-item-archive-btn-label">{label}</span>
       </button>
     );
   }

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -12,7 +12,16 @@ import {
   buildThreadChannelId,
 } from "../../Service/Thread";
 import { ThreadPanelVM, ThreadPanelState } from "./vm";
-import { X, Plus, ChevronDown, ArrowLeft, MoreHorizontal, Star } from "lucide-react";
+import {
+  X,
+  Plus,
+  ChevronDown,
+  ArrowLeft,
+  MoreHorizontal,
+  Star,
+  Archive,
+  ArchiveRestore,
+} from "lucide-react";
 import ThreadIcon from "../Icons/ThreadIcon";
 import classNames from "classnames";
 import { Conversation } from "../Conversation";
@@ -35,6 +44,11 @@ import { HtmlRenderer } from "../FilePreviewPanel/renderers/HtmlRenderer";
 import { ImageRenderer } from "../FilePreviewPanel/renderers/ImageRenderer";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
+import {
+  ArchiveAction,
+  deriveArchiveAction,
+  shouldShowArchiveButton,
+} from "./archiveActions";
 import {
   SMALL_SCREEN_WIDTH,
   THREAD_DEFAULT_WIDTH,
@@ -141,6 +155,14 @@ export default class ThreadPanel extends Component<
   private cachedLeftPanelWidth = 300; // cached on drag start
   /** 同步标志，防止 loadMore 竞态条件 */
   private _loadingMore = false;
+  /** 行内归档操作进行中的子区集合，防止重复点击 / 撤销窗口竞态 */
+  private archivingShortIds = new Set<string>();
+  /** 撤销 Toast 的自动关闭计时器，按 short_id 记录，卸载时统一清理 */
+  private undoToastTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** 撤销 Toast 的 id，便于点击撤销后主动关闭 */
+  private undoToastIds = new Map<string, string>();
+  /** 组件是否已卸载，撤销 Toast 渲染在全局 portal，卸载后回调需短路 */
+  private isUnmounted = false;
 
   constructor(props: ThreadPanelProps) {
     super(props);
@@ -198,12 +220,21 @@ export default class ThreadPanel extends Component<
   }
 
   componentWillUnmount() {
+    this.isUnmounted = true;
     document.removeEventListener("mousemove", this.onPanelDragMove);
     document.removeEventListener("mouseup", this.onPanelDragEnd);
     if (this.state.isDragging) {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     }
+    // 清理撤销 Toast：撤销 Toast 渲染在 Semi 全局 portal，不随本组件卸载销毁，
+    // 其「撤销」按钮仍持有已卸载实例的 handleUndoArchive。卸载时必须主动关闭
+    // 这些 Toast 并清空计时器与 id 两个集合，避免卸载后点撤销对已卸载组件
+    // setState 并发出无意义请求。
+    this.undoToastIds.forEach((toastId) => Toast.close(toastId));
+    this.undoToastTimers.forEach((timer) => clearTimeout(timer));
+    this.undoToastTimers.clear();
+    this.undoToastIds.clear();
   }
 
   // ── Helper to get left panel width from CSS variable or default ──
@@ -663,15 +694,69 @@ export default class ThreadPanel extends Component<
     }, 100);
   };
 
+  /**
+   * 参数化的归档 / 取消归档执行函数，不依赖当前打开的子区（vmState.thread）。
+   * detail 菜单（确认弹窗后）与未来其它入口都复用这里，避免逻辑重复。
+   *
+   * 副作用链与原实现保持一致：threadArchive/threadUnarchive → threadGet 拿到
+   * 后端权威状态 → Toast 提示 → 仅当更新的是「当前打开的子区」时同步 vmState.thread
+   * 与 onThreadSelect → refreshThreadChannelInfo 清 SDK 缓存 → loadThreads 刷新列表。
+   * 动作由 thread.status 推导，非活跃 / 已归档（如已删除）直接忽略。
+   */
+  private archiveThreadById = async (thread: Thread): Promise<void> => {
+    const { groupNo } = this.props;
+    if (!groupNo) return;
+    const action = deriveArchiveAction(thread);
+    if (!action) return;
+    const archiving = action === "archive";
+
+    if (archiving) {
+      await WKApp.dataSource.channelDataSource.threadArchive(
+        groupNo,
+        thread.short_id
+      );
+    } else {
+      await WKApp.dataSource.channelDataSource.threadUnarchive(
+        groupNo,
+        thread.short_id
+      );
+    }
+
+    const updatedThread = await WKApp.dataSource.channelDataSource.threadGet(
+      groupNo,
+      thread.short_id
+    );
+    Toast.success(
+      archiving
+        ? t("base.module.thread.archiveSuccess")
+        : t("base.module.thread.unarchiveSuccess")
+    );
+    this.setState((prevState) =>
+      prevState.vmState.thread?.short_id === updatedThread.short_id
+        ? {
+            vmState: {
+              ...prevState.vmState,
+              thread: updatedThread,
+            },
+          }
+        : null
+    );
+    if (this.state.vmState.thread?.short_id === updatedThread.short_id) {
+      this.props.onThreadSelect?.(updatedThread);
+    }
+    this.refreshThreadChannelInfo(updatedThread);
+    await this.loadThreads();
+  };
+
   private handleToggleArchiveThread = () => {
     const { vmState } = this.state;
     const { groupNo } = this.props;
     const thread = vmState.thread;
     if (!thread || !groupNo) return;
 
-    const archiving = thread.status === ThreadStatus.Active;
-    const unarchiving = thread.status === ThreadStatus.Archived;
-    if (!archiving && !unarchiving) return;
+    const action = deriveArchiveAction(thread);
+    if (!action) return;
+    const archiving = action === "archive";
 
     this.setState({ showMoreMenu: false });
 
@@ -687,35 +772,7 @@ export default class ThreadPanel extends Component<
           : t("base.module.thread.unarchiveConfirmContent"),
         onOk: async () => {
           try {
-            if (archiving) {
-              await WKApp.dataSource.channelDataSource.threadArchive(
-                groupNo,
-                thread.short_id
-              );
-            } else {
-              await WKApp.dataSource.channelDataSource.threadUnarchive(
-                groupNo,
-                thread.short_id
-              );
-            }
-
-            const updatedThread =
-              await WKApp.dataSource.channelDataSource.threadGet(
-                groupNo,
-                thread.short_id
-              );
-            Toast.success(archiving
-              ? t("base.module.thread.archiveSuccess")
-              : t("base.module.thread.unarchiveSuccess"));
-            this.setState((prevState) => ({
-              vmState: {
-                ...prevState.vmState,
-                thread: updatedThread,
-              },
-            }));
-            this.props.onThreadSelect?.(updatedThread);
-            this.refreshThreadChannelInfo(updatedThread);
-            await this.loadThreads();
+            await this.archiveThreadById(thread);
           } catch {
             Toast.error(archiving
               ? t("base.module.thread.archiveFailedRetry")
@@ -1284,6 +1341,172 @@ export default class ThreadPanel extends Component<
       Toast.error(err?.msg || err?.message || t(wasFollowed ? "base.threadList.unfollowFailed" : "base.threadList.followFailed"));
     }
   };
+
+  /** 撤销 Toast 自动关闭时间（秒），与 setTimeout 清理保持一致 */
+  private static readonly ARCHIVE_UNDO_DURATION_S = 5;
+
+  /** 乐观更新某子区的 status（活跃 ⇄ 已归档），自动在活跃组 / 已归档组间移动 */
+  private setThreadStatusOptimistic(shortId: string, status: number) {
+    this.setState((prev) => ({
+      threads: prev.threads.map((item) =>
+        item.short_id === shortId ? { ...item, status } : item
+      ),
+    }));
+  }
+
+  /**
+   * 行内归档按钮入口（方案 B）。照搬 handleFollow 行内范式：
+   * e.stopPropagation() 阻止冒泡到整行 handleThreadClick + 乐观更新。
+   * 活跃 → 一键归档并弹「撤销」Toast；已归档 → 直接取消归档（无需撤销）。
+   * archivingShortIds 防重复点击与撤销窗口竞态。
+   */
+  private handleInlineArchiveToggle = (thread: Thread, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const { groupNo } = this.props;
+    if (!groupNo) return;
+    const action = deriveArchiveAction(thread);
+    if (!action) return;
+    if (this.archivingShortIds.has(thread.short_id)) return;
+
+    if (action === "archive") {
+      void this.inlineArchive(groupNo, thread);
+    } else {
+      void this.inlineUnarchive(groupNo, thread);
+    }
+  };
+
+  private async inlineArchive(groupNo: string, thread: Thread) {
+    this.archivingShortIds.add(thread.short_id);
+    // 乐观：活跃 → 已归档（自动移到已归档组）
+    this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Archived);
+    try {
+      await WKApp.dataSource.channelDataSource.threadArchive(
+        groupNo,
+        thread.short_id
+      );
+      this.refreshThreadChannelInfo({
+        ...thread,
+        status: ThreadStatus.Archived,
+      });
+      this.showArchiveUndoToast(groupNo, thread);
+    } catch {
+      // 失败回滚乐观状态
+      this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Active);
+      Toast.error(t("base.module.thread.archiveFailedRetry"));
+    } finally {
+      this.archivingShortIds.delete(thread.short_id);
+    }
+  }
+
+  private async inlineUnarchive(groupNo: string, thread: Thread) {
+    this.archivingShortIds.add(thread.short_id);
+    // 乐观：已归档 → 活跃
+    this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Active);
+    try {
+      await WKApp.dataSource.channelDataSource.threadUnarchive(
+        groupNo,
+        thread.short_id
+      );
+      Toast.success(t("base.module.thread.unarchiveSuccess"));
+      this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
+      await this.loadThreads();
+    } catch {
+      this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Archived);
+      Toast.error(t("base.module.thread.unarchiveFailedRetry"));
+    } finally {
+      this.archivingShortIds.delete(thread.short_id);
+    }
+  }
+
+  /** 弹出带「撤销」按钮的自定义 Toast，约 5s 后自动消失 */
+  private showArchiveUndoToast(groupNo: string, thread: Thread) {
+    const duration = ThreadPanel.ARCHIVE_UNDO_DURATION_S;
+    const toastId = Toast.info({
+      duration,
+      content: (
+        <div className="wk-thread-archive-undo-toast">
+          <span>{t("base.module.thread.archiveSuccess")}</span>
+          <button
+            type="button"
+            className="wk-thread-archive-undo-btn"
+            onClick={() => this.handleUndoArchive(groupNo, thread)}
+          >
+            {t("base.module.thread.archiveUndo")}
+          </button>
+        </div>
+      ),
+    });
+    this.undoToastIds.set(thread.short_id, toastId);
+    const timer = setTimeout(() => {
+      this.undoToastTimers.delete(thread.short_id);
+      this.undoToastIds.delete(thread.short_id);
+      // 撤销窗口结束后做一次静默对账：行内归档成功路径只有前端拼的乐观对象，
+      // 后端权威字段（archived_at/updated_at/排序时间等）未刷新。窗口内不立即
+      // loadThreads 以免行抖动；到点后静默刷新与其它路径对齐。卸载后跳过。
+      if (this.isUnmounted) return;
+      void this.loadThreads(true);
+    }, duration * 1000);
+    this.undoToastTimers.set(thread.short_id, timer);
+  }
+
+  /** 点击撤销：关闭 Toast、清理计时器，并取消归档恢复活跃 */
+  private handleUndoArchive = async (groupNo: string, thread: Thread) => {
+    // 撤销 Toast 渲染在全局 portal，本组件卸载后仍可能被点击：短路避免对已卸载
+    // 组件 setState 并发出无意义请求。卸载时已统一 Toast.close，这里兜底。
+    if (this.isUnmounted) return;
+    const toastId = this.undoToastIds.get(thread.short_id);
+    if (toastId) Toast.close(toastId);
+    const timer = this.undoToastTimers.get(thread.short_id);
+    if (timer) clearTimeout(timer);
+    this.undoToastTimers.delete(thread.short_id);
+    this.undoToastIds.delete(thread.short_id);
+
+    if (this.archivingShortIds.has(thread.short_id)) return;
+    this.archivingShortIds.add(thread.short_id);
+    // 乐观恢复活跃
+    this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Active);
+    try {
+      await WKApp.dataSource.channelDataSource.threadUnarchive(
+        groupNo,
+        thread.short_id
+      );
+      this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
+      await this.loadThreads();
+    } catch {
+      this.setThreadStatusOptimistic(thread.short_id, ThreadStatus.Archived);
+      Toast.error(t("base.module.thread.unarchiveFailedRetry"));
+    } finally {
+      this.archivingShortIds.delete(thread.short_id);
+    }
+  };
+
+  /** 行内归档 / 取消归档按钮：无权限或状态不可操作时返回 null */
+  private renderArchiveButton(thread: Thread) {
+    if (!shouldShowArchiveButton(thread, this.canEditThread(thread))) {
+      return null;
+    }
+    const action: ArchiveAction | null = deriveArchiveAction(thread);
+    const archiving = action === "archive";
+    const label = archiving
+      ? t("base.module.thread.archive")
+      : t("base.module.thread.unarchive");
+    return (
+      <button
+        type="button"
+        className="wk-thread-panel-item-archive-btn"
+        data-action={action ?? ""}
+        title={label}
+        aria-label={label}
+        onClick={(e) => this.handleInlineArchiveToggle(thread, e)}
+      >
+        {archiving ? (
+          <Archive size={15} color="var(--semi-color-text-2)" />
+        ) : (
+          <ArchiveRestore size={15} color="var(--semi-color-text-2)" />
+        )}
+      </button>
+    );
+  }
   /**
    * 确保父群已进入关注集合（有关联的 category）。
    * 子区关注依赖父群在 sidebar follow tab 的 follow set 里，
@@ -1338,6 +1561,7 @@ export default class ThreadPanel extends Component<
             <span className="wk-thread-panel-item-name">{thread.name}</span>
           </div>
           <div className="wk-thread-panel-item-header-right">
+            {this.renderArchiveButton(thread)}
             <button
               type="button"
               className="wk-thread-panel-item-follow-btn"

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -521,6 +521,7 @@
   "module.thread.archiveFailedRetry": "Failed to archive. Please try again.",
   "module.thread.archiveOk": "Archive",
   "module.thread.archiveSuccess": "Thread archived",
+  "module.thread.archiveUndo": "Undo",
   "module.thread.fallbackName": "Thread",
   "module.thread.info": "Thread info",
   "module.thread.leave": "Leave thread",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -522,6 +522,7 @@
   "module.thread.archiveFailedRetry": "归档失败，请重试",
   "module.thread.archiveOk": "归档",
   "module.thread.archiveSuccess": "子区已归档",
+  "module.thread.archiveUndo": "撤销",
   "module.thread.fallbackName": "子区",
   "module.thread.info": "子区信息",
   "module.thread.leave": "离开子区",


### PR DESCRIPTION
Closes #286.

## What
Add an inline "Archive" quick action button to each row in the active thread list, so archiving a thread takes one click instead of the previous 4-step path (open thread → top-right "..." → "Archive thread" → confirm).

## How
- Inline archive/unarchive button rendered in each thread row (next to the follow star), reusing the existing `threadArchive` / `threadUnarchive` data-source APIs (no backend change).
- One-click archive with optimistic move into the Archived group, plus a Toast with an "Undo" action (~5s) to safely revert mis-clicks; archived rows show "Unarchive".
- Button is always-visible with an icon + text label for clear discoverability and to avoid accidental archiving.
- Permission reuses existing `canEditThread` (only the thread creator / group owner / admin sees the button); `e.stopPropagation()` prevents the row click from opening the thread.
- Existing detail-view archive logic refactored into a reusable `archiveThreadById` to remove duplication.
- On unmount the pending undo Toast is closed and timers cleared; after the undo window elapses a silent `loadThreads` reconciles authoritative backend state.

## Tests
- New `archiveActions.ts` pure helpers (`deriveArchiveAction` / `shouldShowArchiveButton`) with unit tests.
- Component tests covering: correct archive params, stopPropagation, optimistic rollback on failure, no button without permission, undo calls unarchive, no call when undo not pressed, no setState/request after unmount, and de-duped rapid clicks.
- `i18n:check` and `lint:css` pass; ThreadPanel tests 15/15 green.