### PR TITLE
fix: hide archived threads in follow list when expanding group (#285)

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import {
+    isArchivedThreadConversation,
+    filterArchivedThreads,
+    type ArchivableConversation,
+} from "../archivedThreads"
+import { ThreadStatus } from "../../../Service/Thread"
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+
+const CT_GROUP = 2
+
+// 构造一个子区会话存根：channelType=子区，thread.status 可选（undefined 表示未知/未加载）
+function makeThreadConv(channelID: string, status?: number): ArchivableConversation {
+    return {
+        channel: { channelType: ChannelTypeCommunityTopic },
+        channelInfo:
+            status === undefined
+                ? undefined
+                : { orgData: { thread: { status } } },
+    }
+}
+
+function makeGroupConv(): ArchivableConversation {
+    return { channel: { channelType: CT_GROUP } }
+}
+
+describe("isArchivedThreadConversation", () => {
+    it("active 子区(status=1) 不算归档", () => {
+        expect(isArchivedThreadConversation(makeThreadConv("t1", ThreadStatus.Active))).toBe(false)
+    })
+
+    it("archived 子区(status=2) 算归档", () => {
+        expect(isArchivedThreadConversation(makeThreadConv("t2", ThreadStatus.Archived))).toBe(true)
+    })
+
+    it("status 未知/channelInfo 未加载的子区不算归档（fail-open）", () => {
+        expect(isArchivedThreadConversation(makeThreadConv("t3", undefined))).toBe(false)
+    })
+
+    it("非子区类型（群聊）永远不算归档", () => {
+        expect(isArchivedThreadConversation(makeGroupConv())).toBe(false)
+    })
+})
+
+describe("filterArchivedThreads", () => {
+    it("同一父群下 active + archived + unknown：只滤掉归档，保留 active 与 unknown", () => {
+        const active = makeThreadConv("active", ThreadStatus.Active)
+        const archived = makeThreadConv("archived", ThreadStatus.Archived)
+        const unknown = makeThreadConv("unknown", undefined)
+
+        const result = filterArchivedThreads([active, archived, unknown])
+
+        expect(result).toEqual([active, unknown])
+        expect(result).not.toContain(archived)
+    })
+
+    it("不影响非子区会话", () => {
+        const group = makeGroupConv()
+        const archived = makeThreadConv("archived", ThreadStatus.Archived)
+        expect(filterArchivedThreads([group, archived])).toEqual([group])
+    })
+
+    it("空数组返回空数组", () => {
+        expect(filterArchivedThreads([])).toEqual([])
+    })
+})

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
@@ -1,0 +1,39 @@
+import { ChannelTypeCommunityTopic } from "../../Service/Const"
+import { ThreadStatus } from "../../Service/Thread"
+
+/**
+ * 关注 Tab 展开父群子区时，默认隐藏「已归档(archived)」子区。
+ *
+ * 设计原则 fail-open：只有当 conv 是子区且其 thread.status 明确等于
+ * ThreadStatus.Archived 时才算「已归档」。status 未知 / channelInfo 未加载
+ * （如 sidebar-only 子区还没补齐 channelInfo）一律视为可见，避免误隐藏活跃子区。
+ *
+ * 这里读取的归档状态路径与项目内其它处一致：
+ *   conv.channelInfo?.orgData?.thread?.status
+ */
+
+/** conv 上读取归档状态所需的最小结构（便于单测构造，避免依赖完整 ConversationWrap）。 */
+export interface ArchivableConversation {
+    channel: { channelType: number }
+    channelInfo?: {
+        orgData?: {
+            thread?: {
+                status?: number
+            }
+        }
+    }
+}
+
+/** 仅当 conv 是子区类型且其 thread.status 明确为 Archived 时返回 true。 */
+export function isArchivedThreadConversation(conv: ArchivableConversation): boolean {
+    if (conv.channel.channelType !== ChannelTypeCommunityTopic) return false
+    return conv.channelInfo?.orgData?.thread?.status === ThreadStatus.Archived
+}
+
+/**
+ * 过滤掉「明确已归档」的子区，返回 UI 可见的会话数组。
+ * 非子区、status 未知的子区都会保留（fail-open）。
+ */
+export function filterArchivedThreads<T extends ArchivableConversation>(convs: T[]): T[] {
+    return convs.filter(conv => !isArchivedThreadConversation(conv))
+}

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -31,6 +31,7 @@ import {
     isVirtualCategory,
     type ValidCategoryItem,
 } from "./categoriesFallback"
+import { filterArchivedThreads, isArchivedThreadConversation } from "./archivedThreads"
 import { useI18n } from "../../i18n"
 import { wkConfirm } from "../WKModal"
 
@@ -335,6 +336,14 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
         }
     }
 
+    // 渲染用的可见子区 map：在全量 followedChildThreadsByParent 基础上过滤掉「明确已归档」
+    // 的子区（fail-open：status 未知/未加载的子区仍显示）。全量 map 继续用于拖拽排序的
+    // sort payload，避免隐藏归档子区导致后端 follow_sort 被意外改动。
+    const visibleChildThreadsByParent = new Map<string, ConversationWrap[]>()
+    for (const [parentGroupNo, threads] of followedChildThreadsByParent) {
+        visibleChildThreadsByParent.set(parentGroupNo, filterArchivedThreads(threads))
+    }
+
     // 构建右键菜单：取消关注 + 移出分组（有分组时，一级直接点击）+ 移到分组（一级，展开二级子菜单）
     const buildExtraContextMenus = (conv: ConversationWrap | undefined): ContextMenusData[] => {
         if (!conv) return []
@@ -498,7 +507,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
             const withThreads: ConversationWrap[] = []
             for (const conv of catConvs) {
                 withThreads.push(conv)
-                const threads = [...(threadConvsByParent.get(conv.channel.channelID) || [])]
+                const threads = filterArchivedThreads([...(threadConvsByParent.get(conv.channel.channelID) || [])])
                     .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
                 withThreads.push(...threads)
             }
@@ -523,7 +532,8 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                     catConvs.push(groupConvMap.get(it.target_id) || synthesizeFromItem(it))
                     // 父群下挂已关注子区：来源已合并 IM 缓存（按 followedKeys 过滤）+ sidebar
                     // 自带的 target_type=5 with parent_channel_id（含 IM 没缓存的关注子区）。
-                    const childThreads = (followedChildThreadsByParent.get(it.target_id) || [])
+                    // 渲染用可见 map（已过滤明确归档子区）；全量 map 仅用于拖拽 sort payload。
+                    const childThreads = (visibleChildThreadsByParent.get(it.target_id) || [])
                         .slice()
                         .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
                     for (const t of childThreads) {
@@ -534,7 +544,11 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                         }
                     }
                 } else if (it.target_type === 5) {
-                    catConvs.push(threadConvByChannel.get(it.target_id) || synthesizeFromItem(it))
+                    const threadConv = threadConvByChannel.get(it.target_id) || synthesizeFromItem(it)
+                    // standalone 子区：明确归档的不在关注列表渲染（ThreadPanel 仍可查看/重新激活）。
+                    if (!isArchivedThreadConversation(threadConv)) {
+                        catConvs.push(threadConv)
+                    }
                 }
             }
         } else {
@@ -547,14 +561,16 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                 const groupConv = groupConvMap.get(g.group_no)
                 if (groupConv) {
                     catConvs.push(groupConv)
-                    const threads = threadConvsByParent.get(g.group_no) || []
+                    const threads = filterArchivedThreads(threadConvsByParent.get(g.group_no) || [])
                     catConvs.push(...threads)
                 }
             }
             const dmItems = dmsByCategory?.get(sidebarKey) || []
             const threadItems = threadsByCategory?.get(sidebarKey) || []
             const dmConvsInCat = dmItems.map(it => dmConvMap.get(it.target_id) || synthesizeFromItem(it))
-            const standaloneThreadConvs = threadItems.map(it => threadConvByChannel.get(it.target_id) || synthesizeFromItem(it))
+            const standaloneThreadConvs = filterArchivedThreads(
+                threadItems.map(it => threadConvByChannel.get(it.target_id) || synthesizeFromItem(it))
+            )
             const seenChannelIds = new Set(catConvs.map(c => c.channel.channelID))
             const dedupedThreads = standaloneThreadConvs.filter(c => !seenChannelIds.has(c.channel.channelID))
             catConvs.push(...dmConvsInCat, ...dedupedThreads)

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -5,6 +5,7 @@ import ConversationList, {
 } from "../../Components/ConversationList";
 import SidebarTabBar, { SidebarTab } from "../../Components/SidebarTabBar";
 import ConversationListGrouped from "../../Components/ConversationListGrouped";
+import { isArchivedThreadConversation } from "../../Components/ConversationListGrouped/archivedThreads";
 import ChatConversationList, {
   isMutedForRecentConversation,
   isVisibleInRecentTab,
@@ -130,6 +131,16 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
           c.channel.channelType === channelType && c.channel.channelID === it.target_id,
         )
       : undefined;
+    // 与展开列表的展示层过滤一致：明确已归档的子区已从列表隐藏，未读也不计入
+    // 角标，否则会出现「红点 N 但列表里看不到对应未读」。fail-open：status 未知 /
+    // liveConv 不存在（sidebar-only 子区，无 channelInfo）仍按原逻辑累加，不漏算。
+    if (
+      it.target_type === SidebarTargetType.THREAD &&
+      liveConv &&
+      isArchivedThreadConversation(liveConv)
+    ) {
+      return sum;
+    }
     const unread = liveConv ? (liveConv.unread || 0) : (it.unread || 0);
     return sum + unread;
   }, 0);


### PR DESCRIPTION
Closes #285

## What

关注列表展开群聊子区时，默认隐藏「已归档」子区，只展示活跃子区，避免子区多的群把列表撑得过长。已归档子区仍可通过群聊右上角「子区」入口查看 / 重新激活（行为不变）。

## Changes

- 新增 `ConversationListGrouped/archivedThreads.ts`：纯函数 `isArchivedThreadConversation` / `filterArchivedThreads`，仅当子区 `thread.status === Archived` 才判定为归档；status 未知 / channelInfo 未加载时 fail-open 默认显示，避免误隐藏活跃子区。
- `ConversationListGrouped/index.tsx`：渲染用过滤后的可见子区；拖拽排序 payload 仍使用全量子区集合，归档隐藏不影响后端 `follow_sort`。
- `Pages/Chat/index.tsx`：关注 Tab 未读角标对明确归档子区跳过累加，保持「角标数 = 列表可见未读」一致。

## Scope / Non-goals

- 纯前端展示层过滤，不改任何接口、不改后端。
- 右上角 `ThreadPanel`（`status: "all"`）不受影响，归档子区照常可查看 / 重新激活。
- 「最近」Tab 不受影响。

## Tests

- 新增 `archivedThreads.test.ts`：覆盖 active 保留 / archived 滤除 / status 未知 fail-open 保留 / 非子区不受影响等用例，全部通过。
- 包内回归测试无新增失败。
