### PR TITLE
fix: 含文件附件的 bot 消息不参与折叠分组 (#322)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
@@ -165,7 +165,25 @@ function botMessage(contentType: number, timestamp: number, fromUID: string = "c
 
 const TEXT = 1
 const IMAGE = 2
+const GIF = 3
+const VOICE = 4
+const SMALL_VIDEO = 5
 const FILE = 8
+const RICH_TEXT = 14
+
+function humanMessage(contentType: number, timestamp: number, fromUID: string = "alice") {
+    const messageSeq = seqCounter++
+    return {
+        clientMsgNo: `msg-${messageSeq}`,
+        messageSeq,
+        fromUID,
+        timestamp,
+        contentType,
+        revoke: false,
+        send: false,
+        from: { title: fromUID },
+    } as any
+}
 
 describe("ConversationVM fold session file attachment", () => {
     beforeEach(() => {
@@ -173,31 +191,114 @@ describe("ConversationVM fold session file attachment", () => {
         seqCounter = 1
     })
 
-    it("does not fold a bot image message into a fold session", () => {
+    // --- All excluded content types ---
+
+    it.each([
+        { name: "image", contentType: IMAGE },
+        { name: "gif", contentType: GIF },
+        { name: "smallVideo", contentType: SMALL_VIDEO },
+        { name: "file", contentType: FILE },
+        { name: "richText", contentType: RICH_TEXT },
+    ])("does not fold a bot $name message (contentType=$contentType) into a fold session", ({ contentType }) => {
         const vm = new ConversationVM(channel)
         const messages = [
             botMessage(TEXT, 100),
-            botMessage(IMAGE, 110),
+            botMessage(contentType, 110),
         ]
 
         const items = vm.buildRenderItems(messages)
 
         expect(items.every((item) => item.type === "message")).toBe(true)
-        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, IMAGE])
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, contentType])
     })
 
-    it("does not fold a bot file message into a fold session", () => {
+    // --- Voice should still fold ---
+
+    it("still folds a bot voice message (voice is not a file attachment)", () => {
         const vm = new ConversationVM(channel)
         const messages = [
             botMessage(TEXT, 100),
+            botMessage(VOICE, 110),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.length).toBe(1)
+        expect(items[0].type).toBe("foldSession")
+        expect((items[0] as any).session.count).toBe(2)
+    })
+
+    // --- User-sent file messages are not affected ---
+
+    it("does not affect user-sent file messages (guard is bot-only)", () => {
+        const vm = new ConversationVM(channel)
+        // Human messages are never folded (they flush pending session and render standalone)
+        const messages = [
+            humanMessage(FILE, 100),
+            humanMessage(IMAGE, 110),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.every((item) => item.type === "message")).toBe(true)
+        expect(items.length).toBe(2)
+    })
+
+    // --- Boundary: attachment as first message ---
+
+    it("renders attachment as standalone when it is the first message", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(IMAGE, 100),
+            botMessage(TEXT, 110),
+            botMessage(TEXT, 120),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.length).toBe(2)
+        expect(items[0].type).toBe("message")
+        expect((items[0] as any).message.contentType).toBe(IMAGE)
+        expect(items[1].type).toBe("foldSession")
+        expect((items[1] as any).session.count).toBe(2)
+    })
+
+    // --- Boundary: attachment as last message ---
+
+    it("renders attachment as standalone when it is the last message", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(TEXT, 110),
+            botMessage(FILE, 120),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.length).toBe(2)
+        expect(items[0].type).toBe("foldSession")
+        expect((items[0] as any).session.count).toBe(2)
+        expect(items[1].type).toBe("message")
+        expect((items[1] as any).message.contentType).toBe(FILE)
+    })
+
+    // --- Two adjacent attachments ---
+
+    it("renders two adjacent attachment messages as standalone items", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(IMAGE, 100),
             botMessage(FILE, 110),
         ]
 
         const items = vm.buildRenderItems(messages)
 
-        expect(items.some((item) => item.type === "foldSession")).toBe(false)
-        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, FILE])
+        expect(items.length).toBe(2)
+        expect(items.every((item) => item.type === "message")).toBe(true)
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([IMAGE, FILE])
     })
+
+    // --- Original structural tests ---
 
     it("breaks a fold group when an image sits between bot text messages", () => {
         const vm = new ConversationVM(channel)
@@ -209,7 +310,6 @@ describe("ConversationVM fold session file attachment", () => {
 
         const items = vm.buildRenderItems(messages)
 
-        // image breaks the run, so the two single texts never form a group of 2
         expect(items.length).toBe(3)
         expect(items.every((item) => item.type === "message")).toBe(true)
         expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, IMAGE, TEXT])

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const BOT_UIDS = new Set(["claude", "jojo"])
+
+vi.mock("wukongimjssdk", () => {
+    class Channel {
+        channelID: string
+        channelType: number
+        constructor(id: string, type: number) {
+            this.channelID = id
+            this.channelType = type
+        }
+        isEqual(other: any) {
+            return this.channelID === other.channelID && this.channelType === other.channelType
+        }
+        getChannelKey() {
+            return `${this.channelID}-${this.channelType}`
+        }
+    }
+
+    return {
+        Channel,
+        ChannelTypeGroup: 2,
+        ChannelTypePerson: 1,
+        ChannelTypeCommunityTopic: 6,
+        ConversationAction: { update: "update" },
+        MessageStatus: { Wait: 0, Normal: 1, Fail: 2 },
+        MessageContentType: { text: 1 },
+        WKSDK: {
+            shared: () => ({
+                channelManager: {
+                    getChannelInfo: (channel: any) => {
+                        if (BOT_UIDS.has(channel.channelID)) {
+                            return { orgData: { robot: 1 } }
+                        }
+                        return undefined
+                    },
+                    getSubscribes: () => [],
+                    addSubscriberChangeListener: () => {},
+                    removeSubscriberChangeListener: () => {},
+                    syncSubscribes: () => Promise.resolve(),
+                    subscribeCacheMap: new Map(),
+                    notifySubscribeChangeListeners: () => {},
+                },
+                conversationManager: {
+                    findConversation: () => null,
+                    notifyConversationListeners: () => {},
+                    addConversationListener: () => {},
+                    removeConversationListener: () => {},
+                },
+                chatManager: {
+                    sendingQueues: new Map(),
+                    addMessageListener: () => {},
+                    removeMessageListener: () => {},
+                    addCMDListener: () => {},
+                    removeCMDListener: () => {},
+                    addMessageStatusListener: () => {},
+                    removeMessageStatusListener: () => {},
+                },
+                connectManager: {
+                    addConnectStatusListener: () => {},
+                    removeConnectStatusListener: () => {},
+                },
+            }),
+        },
+        Message: class {},
+        MessageContent: class {},
+        Subscriber: class {},
+        Conversation: class {},
+        MessageExtra: class {},
+        CMDContent: class {},
+        PullMode: {},
+        ChannelInfo: class {},
+        ChannelInfoListener: class {},
+        ConversationListener: class {},
+        ConnectStatus: {},
+        ConnectStatusListener: class {},
+        MessageListener: class {},
+        MessageStatusListener: class {},
+        SendackPacket: class {},
+        Setting: class {},
+        SystemContent: class {},
+    }
+})
+
+vi.mock("../../../App", () => ({
+    default: {
+        loginInfo: { uid: "me" },
+        dataSource: { channelDataSource: { subscribers: () => Promise.resolve([]) } },
+        mittBus: { on: () => {}, off: () => {} },
+        conversationProvider: { markConversationUnread: () => Promise.resolve() },
+        shared: { currentSpaceId: "", notifyMessageDeleteListener: () => {} },
+    },
+}))
+
+vi.mock("../../../Service/DataSource/DataProvider", () => ({
+    SyncMessageOptions: class {},
+}))
+vi.mock("../../../Service/Model", () => ({ MessageWrap: class {} }))
+vi.mock("../../../Service/Provider", () => ({
+    ProviderListener: class {
+        callback?: Function
+        notifyListener(done?: Function) { this.callback?.(); done?.() }
+        listen(f: Function) { this.callback = f }
+        clearListeners() { this.callback = undefined }
+        didMount() {}
+        didUnMount() {}
+    },
+}))
+vi.mock("react-scroll", () => ({ animateScroll: { scrollToBottom: () => {} }, scroller: { scrollTo: () => {} } }))
+vi.mock("../../../Service/Const", () => ({
+    EndpointID: {},
+    MessageContentTypeConst: {
+        historySplit: -3,
+        typing: -2,
+        time: -1,
+        image: 2,
+        gif: 3,
+        voice: 4,
+        smallVideo: 5,
+        file: 8,
+        richText: 14,
+        rtcData: 9994,
+    },
+    OrderFactor: 10000,
+    ChannelTypeCommunityTopic: 6,
+}))
+vi.mock("moment", () => ({ default: () => ({ format: () => "" }) }))
+vi.mock("../../../Messages/Time", () => ({ TimeContent: class {} }))
+vi.mock("../../../Messages/HistorySplit", () => ({ HistorySplitContent: class {} }))
+vi.mock("../../../Messages/Mergeforward", () => ({ default: class {} }))
+vi.mock("../../../Service/TypingManager", () => ({
+    TypingListener: class {},
+    TypingManager: { shared: { addTypingListener: () => {}, removeTypingListener: () => {} } },
+}))
+vi.mock("../../../Service/ProhibitwordsService", () => ({ ProhibitwordsService: { shared: { filter: (text: string) => text, getProhibitwords: () => [] } } }))
+vi.mock("../../../Service/SpaceService", () => ({ SYSTEM_BOTS: new Set() }))
+vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
+vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: (opts: any) => opts.messages }))
+vi.mock("../historyScroll", () => ({ getPulldownRestoredScrollTop: () => 0, getRestoredAnchorScrollTop: () => 0 }))
+vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+vi.mock("../sendContentProxy", () => ({ wrapSendContentForInjection: (content: any) => content }))
+vi.mock("../../../Service/messageSelection", () => ({ isMessageSelectable: () => true }))
+
+import ConversationVM from "../vm"
+import { Channel } from "wukongimjssdk"
+
+const channel = new Channel("g1", 2)
+
+let seqCounter = 1
+
+function botMessage(contentType: number, timestamp: number, fromUID: string = "claude") {
+    const messageSeq = seqCounter++
+    return {
+        clientMsgNo: `msg-${messageSeq}`,
+        messageSeq,
+        fromUID,
+        timestamp,
+        contentType,
+        revoke: false,
+        send: false,
+        from: { title: fromUID },
+    } as any
+}
+
+const TEXT = 1
+const IMAGE = 2
+const FILE = 8
+
+describe("ConversationVM fold session file attachment", () => {
+    beforeEach(() => {
+        ConversationVM.sendQueue.clear()
+        seqCounter = 1
+    })
+
+    it("does not fold a bot image message into a fold session", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(IMAGE, 110),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.every((item) => item.type === "message")).toBe(true)
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, IMAGE])
+    })
+
+    it("does not fold a bot file message into a fold session", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(FILE, 110),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.some((item) => item.type === "foldSession")).toBe(false)
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, FILE])
+    })
+
+    it("breaks a fold group when an image sits between bot text messages", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(IMAGE, 110),
+            botMessage(TEXT, 120),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        // image breaks the run, so the two single texts never form a group of 2
+        expect(items.length).toBe(3)
+        expect(items.every((item) => item.type === "message")).toBe(true)
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([TEXT, IMAGE, TEXT])
+    })
+
+    it("renders foldSession + standalone image + foldSession for two text runs around an image", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(TEXT, 110),
+            botMessage(IMAGE, 120),
+            botMessage(TEXT, 130),
+            botMessage(TEXT, 140),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.length).toBe(3)
+        expect(items[0].type).toBe("foldSession")
+        expect((items[0] as any).session.count).toBe(2)
+        expect(items[1].type).toBe("message")
+        expect((items[1] as any).message.contentType).toBe(IMAGE)
+        expect(items[2].type).toBe("foldSession")
+        expect((items[2] as any).session.count).toBe(2)
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -289,6 +289,22 @@ export default class ConversationVM extends ProviderListener {
         return channelInfo?.orgData?.robot === 1
     }
 
+    // 是否为带附件的消息（图片/GIF/小视频/文件/富文本）。
+    // 这类消息是用户需要直接看到的交付物，不应被折叠进 FoldSessionCard。
+    // 注意：语音（voice=4）可以折叠，故不在此列。
+    private hasFileAttachment(message: MessageWrap): boolean {
+        switch (message.contentType) {
+            case MessageContentTypeConst.image:
+            case MessageContentTypeConst.gif:
+            case MessageContentTypeConst.smallVideo:
+            case MessageContentTypeConst.file:
+            case MessageContentTypeConst.richText:
+                return true
+            default:
+                return false
+        }
+    }
+
     getSessionParticipants(messages: MessageWrap[]): FoldSessionParticipant[] {
         const participants = new Array<FoldSessionParticipant>()
         const seenUIDs = new Set<string>()
@@ -388,6 +404,13 @@ export default class ConversationVM extends ProviderListener {
 
         for (const message of sourceMessages) {
             if (this.isBotMessage(message)) {
+                // 带附件的 bot 消息作为折叠分组的边界：先 flush 当前分组，再独立渲染，
+                // 保证图片/文件等交付物始终可见，无需展开折叠卡片。
+                if (this.hasFileAttachment(message)) {
+                    flushPendingSession(false)
+                    renderItems.push({ type: "message", message })
+                    continue
+                }
                 if (pendingSessionMessages.length > 0) {
                     const previousMessage = pendingSessionMessages[pendingSessionMessages.length - 1]
                     if (message.timestamp - previousMessage.timestamp < 120) {


### PR DESCRIPTION
## 问题

龙虾连续输出多条消息时，Web 端将所有消息折叠进 FoldSessionCard。含文件附件的消息（图片、PPT、PDF 等交付物）也被折叠，用户无法感知到有文件产出。

Closes #322

## 修改

在 `ConversationVM.buildRenderItems()` 中，含文件附件（image/gif/video/file/richText）的 bot 消息不再参与折叠分组：

- 新增 `hasFileAttachment()` 方法，判断消息是否包含文件类内容
- 含附件的 bot 消息作为折叠分组的边界：先 flush 当前分组，再作为独立消息渲染
- 纯文字的中间过程消息仍正常折叠

**示例：** bot 发送 [文字, 文字, 图片, 文字, 文字] → 渲染为 [折叠卡片(2条文字)] + [图片(始终可见)] + [折叠卡片(2条文字)]

## 测试

- 新增 4 个单元测试覆盖各种场景
- 已有 foldSessionSummary 测试全部通过（无 regression）