### PR TITLE
fix(summary): hide stale loading card and fix empty overflow tooltip / broken hover

### DIFF
--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/ExcelRenderer.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/ExcelRenderer.tsx
@@ -141,9 +141,10 @@ function SheetTable({ sheetData }: { sheetData: SheetData }) {
   const { t } = useI18n();
 
   const renderCellContent = (value: unknown): string => {
-    if (value === null || value === undefined) return "-";
+    if (value === null || value === undefined || value === "") return "-";
     if (typeof value === "object") return JSON.stringify(value);
-    return String(value);
+    const str = String(value);
+    return str.trim() === "" ? "-" : str;
   };
 
   if (!data || data.length === 0) {

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/JsonlRenderer.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/JsonlRenderer.tsx
@@ -78,9 +78,10 @@ const JsonlRenderer: React.FC<JsonlRendererProps> = ({ file, onError }) => {
 
   // 渲染单元格内容
   const renderCellContent = (value: unknown): string => {
-    if (value === null || value === undefined) return "-";
+    if (value === null || value === undefined || value === "") return "-";
     if (typeof value === "object") return JSON.stringify(value);
-    return String(value);
+    const str = String(value);
+    return str.trim() === "" ? "-" : str;
   };
 
   // 复用 CodeRendererBase 处理边界状态（too-large / loading / error）

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/TooltipCell.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/TooltipCell.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, memo } from "react";
+import React, { useRef, useState, useEffect, useCallback, memo } from "react";
 import { Tooltip } from "@douyinfe/semi-ui";
 import "./TooltipCell.css";
 
@@ -14,6 +14,13 @@ interface TooltipCellProps {
 export const TooltipCell = memo(function TooltipCell({ content }: TooltipCellProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  // 内容是否非空（排除 null/undefined 以及空白字符串）
+  const hasContent =
+    content !== null &&
+    content !== undefined &&
+    !(typeof content === "string" && content.trim() === "");
 
   useEffect(() => {
     const checkTruncation = () => {
@@ -27,18 +34,39 @@ export const TooltipCell = memo(function TooltipCell({ content }: TooltipCellPro
     return () => window.removeEventListener("resize", checkTruncation);
   }, [content]);
 
+  // NOTE: 这里刻意使用 trigger="custom" 而非 trigger="hover"。
+  // hover 模式下 semi 会用内部状态挂载浮层，绕过受控的 visible，
+  // 当内容为空时会出现一个空的深色气泡（"乌云"）。改为受控后，
+  // 仅当元素确实溢出且有内容时才显示浮层。
+  const handleMouseEnter = useCallback(() => {
+    const el = ref.current;
+    if (el && el.scrollWidth > el.clientWidth && hasContent) {
+      setVisible(true);
+    }
+  }, [hasContent]);
+
+  const handleMouseLeave = useCallback(() => {
+    setVisible(false);
+  }, []);
+
   const cellContent = (
-    <div ref={ref} className="wk-excel-tooltip-cell">
+    <div
+      ref={ref}
+      className="wk-excel-tooltip-cell"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {content}
     </div>
   );
 
-  if (!isTruncated) {
+  // 未截断或无内容时，直接返回裸单元格，不挂载 Tooltip，杜绝空气泡
+  if (!isTruncated || !hasContent) {
     return cellContent;
   }
 
   return (
-    <Tooltip content={content} position="top" showArrow>
+    <Tooltip content={content} position="top" trigger="custom" visible={visible} showArrow>
       {cellContent}
     </Tooltip>
   );

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/__tests__/json-utils.test.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/__tests__/json-utils.test.ts
@@ -151,6 +151,11 @@ describe("renderCellContent", () => {
     expect(renderCellContent(undefined)).toBe("-");
   });
 
+  it("should return dash for empty or whitespace-only strings", () => {
+    expect(renderCellContent("")).toBe("-");
+    expect(renderCellContent("   ")).toBe("-");
+  });
+
   it("should stringify objects", () => {
     expect(renderCellContent({ a: 1 })).toBe('{"a":1}');
   });
@@ -182,6 +187,11 @@ describe("extractColumns", () => {
   it("should set title equal to key", () => {
     const columns = extractColumns([{ myKey: 1 }]);
     expect(columns[0]).toEqual({ key: "myKey", title: "myKey" });
+  });
+
+  it("should fall back to dash title for empty-string keys", () => {
+    const columns = extractColumns([{ "": 1 }]);
+    expect(columns[0]).toEqual({ key: "", title: "-" });
   });
 });
 

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/json-utils.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/json-utils.ts
@@ -168,13 +168,14 @@ export function formatJsonl(content: string): string {
  * 渲染单元格内容
  */
 export function renderCellContent(value: unknown): string {
-  if (value === null || value === undefined) {
+  if (value === null || value === undefined || value === "") {
     return "-";
   }
   if (typeof value === "object") {
     return JSON.stringify(value);
   }
-  return String(value);
+  const str = String(value);
+  return str.trim() === "" ? "-" : str;
 }
 
 /**
@@ -190,7 +191,7 @@ export function extractColumns(data: Record<string, unknown>[]): ColumnConfig[] 
     }
   });
 
-  return Array.from(allKeys).map((key) => ({ key, title: key }));
+  return Array.from(allKeys).map((key) => ({ key, title: key || "-" }));
 }
 
 /**

--- a/packages/dmworksummary/src/components/OverflowTooltip.test.tsx
+++ b/packages/dmworksummary/src/components/OverflowTooltip.test.tsx
@@ -4,9 +4,10 @@ import { vi } from "vitest";
 import OverflowTooltip from "./OverflowTooltip";
 
 // Mock semi Tooltip: render content only when `visible` is true. The real
-// component now drives visibility via its own onMouseEnter/onMouseLeave on the
-// wrapped child (trigger="custom"), so the mock must render `children` as-is and
-// let those handlers flow through.
+// component drives visibility via its own onMouseEnter/onMouseLeave on the
+// wrapped child (trigger="custom") and supplies a stable `content` from the
+// `title` prop, so the mock renders `children` as-is and lets those handlers
+// flow through.
 vi.mock("@douyinfe/semi-ui", () => ({
     Tooltip: ({ children, content, visible, trigger }: any) => (
         <div data-testid="tooltip-wrapper" data-visible={visible} data-trigger={trigger}>
@@ -27,7 +28,7 @@ function mockOverflow(el: HTMLElement, overflowing: boolean) {
 
 describe("OverflowTooltip", () => {
     it("does not show tooltip when text is not overflowing", () => {
-        render(<OverflowTooltip>Short text</OverflowTooltip>);
+        render(<OverflowTooltip title="Short text">Short text</OverflowTooltip>);
 
         const container = screen.getByText("Short text");
         mockOverflow(container, false);
@@ -38,9 +39,10 @@ describe("OverflowTooltip", () => {
     });
 
     it("shows tooltip when text is overflowing", () => {
-        render(<OverflowTooltip>This is a very long text that overflows</OverflowTooltip>);
+        const text = "This is a very long text that overflows";
+        render(<OverflowTooltip title={text}>{text}</OverflowTooltip>);
 
-        const container = screen.getByText("This is a very long text that overflows");
+        const container = screen.getByText(text);
         mockOverflow(container, true);
 
         fireEvent.mouseEnter(container);
@@ -48,8 +50,19 @@ describe("OverflowTooltip", () => {
         expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
     });
 
+    it("uses the title prop as the tooltip content", () => {
+        render(<OverflowTooltip title="Full title text">Truncated…</OverflowTooltip>);
+
+        const container = screen.getByText("Truncated…");
+        mockOverflow(container, true);
+
+        fireEvent.mouseEnter(container);
+
+        expect(screen.getByTestId("tooltip-content")).toHaveTextContent("Full title text");
+    });
+
     it("hides tooltip on mouse leave", () => {
-        render(<OverflowTooltip>Overflowing text</OverflowTooltip>);
+        render(<OverflowTooltip title="Overflowing text">Overflowing text</OverflowTooltip>);
 
         const container = screen.getByText("Overflowing text");
         mockOverflow(container, true);
@@ -62,7 +75,7 @@ describe("OverflowTooltip", () => {
     });
 
     it("renders correct element type when as prop is provided", () => {
-        render(<OverflowTooltip as="span">Content</OverflowTooltip>);
+        render(<OverflowTooltip as="span" title="Content">Content</OverflowTooltip>);
 
         const el = screen.getByText("Content");
         expect(el.tagName).toBe("SPAN");
@@ -70,7 +83,7 @@ describe("OverflowTooltip", () => {
 
     it("passes className and style correctly", () => {
         render(
-            <OverflowTooltip className="custom-class" style={{ color: "red" }}>
+            <OverflowTooltip className="custom-class" style={{ color: "red" }} title="Styled content">
                 Styled content
             </OverflowTooltip>
         );
@@ -81,22 +94,18 @@ describe("OverflowTooltip", () => {
     });
 
     it("uses a fully controlled (custom) trigger so semi never self-mounts an overlay", () => {
-        render(<OverflowTooltip>Text</OverflowTooltip>);
+        render(<OverflowTooltip title="Text">Text</OverflowTooltip>);
 
         const wrapper = screen.getByTestId("tooltip-wrapper");
         expect(wrapper).toHaveAttribute("data-trigger", "custom");
     });
 
-    it("does not show an empty tooltip bubble when text content is blank", () => {
-        render(<OverflowTooltip>{"   "}</OverflowTooltip>);
+    it("keeps the overlay closed until the title actually overflows", () => {
+        render(<OverflowTooltip title="Some title">Some title</OverflowTooltip>);
 
         const wrapper = screen.getByTestId("tooltip-wrapper");
-        const container = wrapper.lastElementChild as HTMLElement;
-        mockOverflow(container, true);
-
-        fireEvent.mouseEnter(container);
-
-        // Blank/whitespace text must never open an (empty) tooltip overlay.
+        // Before any hover, visibility is driven solely by `visible` (false).
+        expect(wrapper).toHaveAttribute("data-visible", "false");
         expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
     });
 });

--- a/packages/dmworksummary/src/components/OverflowTooltip.test.tsx
+++ b/packages/dmworksummary/src/components/OverflowTooltip.test.tsx
@@ -3,17 +3,15 @@ import { render as rtlRender, screen, fireEvent } from "@testing-library/react";
 import { vi } from "vitest";
 import OverflowTooltip from "./OverflowTooltip";
 
+// Mock semi Tooltip: render content only when `visible` is true. The real
+// component now drives visibility via its own onMouseEnter/onMouseLeave on the
+// wrapped child (trigger="custom"), so the mock must render `children` as-is and
+// let those handlers flow through.
 vi.mock("@douyinfe/semi-ui", () => ({
-    Tooltip: ({ children, content, visible, onVisibleChange, trigger }: any) => (
+    Tooltip: ({ children, content, visible, trigger }: any) => (
         <div data-testid="tooltip-wrapper" data-visible={visible} data-trigger={trigger}>
             {visible && <div data-testid="tooltip-content">{content}</div>}
-            <div
-                data-testid="tooltip-trigger"
-                onMouseEnter={() => onVisibleChange?.(true)}
-                onMouseLeave={() => onVisibleChange?.(false)}
-            >
-                {children}
-            </div>
+            {children}
         </div>
     ),
 }));
@@ -34,7 +32,7 @@ describe("OverflowTooltip", () => {
         const container = screen.getByText("Short text");
         mockOverflow(container, false);
 
-        fireEvent.mouseEnter(screen.getByTestId("tooltip-trigger"));
+        fireEvent.mouseEnter(container);
 
         expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
     });
@@ -45,7 +43,7 @@ describe("OverflowTooltip", () => {
         const container = screen.getByText("This is a very long text that overflows");
         mockOverflow(container, true);
 
-        fireEvent.mouseEnter(screen.getByTestId("tooltip-trigger"));
+        fireEvent.mouseEnter(container);
 
         expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
     });
@@ -56,10 +54,10 @@ describe("OverflowTooltip", () => {
         const container = screen.getByText("Overflowing text");
         mockOverflow(container, true);
 
-        fireEvent.mouseEnter(screen.getByTestId("tooltip-trigger"));
+        fireEvent.mouseEnter(container);
         expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
 
-        fireEvent.mouseLeave(screen.getByTestId("tooltip-trigger"));
+        fireEvent.mouseLeave(container);
         expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
     });
 
@@ -82,10 +80,23 @@ describe("OverflowTooltip", () => {
         expect(el).toHaveStyle("color: rgb(255, 0, 0); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;");
     });
 
-    it("uses hover trigger for selectable tooltip text", () => {
+    it("uses a fully controlled (custom) trigger so semi never self-mounts an overlay", () => {
         render(<OverflowTooltip>Text</OverflowTooltip>);
 
         const wrapper = screen.getByTestId("tooltip-wrapper");
-        expect(wrapper).toHaveAttribute("data-trigger", "hover");
+        expect(wrapper).toHaveAttribute("data-trigger", "custom");
+    });
+
+    it("does not show an empty tooltip bubble when text content is blank", () => {
+        render(<OverflowTooltip>{"   "}</OverflowTooltip>);
+
+        const wrapper = screen.getByTestId("tooltip-wrapper");
+        const container = wrapper.lastElementChild as HTMLElement;
+        mockOverflow(container, true);
+
+        fireEvent.mouseEnter(container);
+
+        // Blank/whitespace text must never open an (empty) tooltip overlay.
+        expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
     });
 });

--- a/packages/dmworksummary/src/components/OverflowTooltip.tsx
+++ b/packages/dmworksummary/src/components/OverflowTooltip.tsx
@@ -6,27 +6,24 @@ interface OverflowTooltipProps {
     className?: string;
     style?: React.CSSProperties;
     as?: React.ElementType;
+    title?: string;
 }
 
-const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, style, as: Component = "div" }) => {
+const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, style, as: Component = "div", title }) => {
     const containerRef = useRef<HTMLElement>(null);
     const [visible, setVisible] = useState(false);
-    const [content, setContent] = useState("");
 
     // NOTE: we intentionally use trigger="custom" instead of trigger="hover".
     // With trigger="hover", semi binds its own mouseenter/focus handlers that mount
-    // the overlay from internal state (empty content on first hover) and bypass the
-    // controlled `visible` prop, producing an empty dark bubble. trigger="custom"
-    // makes visibility depend solely on `visible`, so the overlay only ever mounts
-    // when the title is truly overflowing and the text is non-empty.
+    // the overlay from internal state and bypass the controlled `visible` prop. The
+    // content is now a stable, caller-supplied `title` string (not deferred state),
+    // so the overlay never mounts with empty content and never produces a stray empty
+    // dark bubble. Visibility depends solely on `visible`, which we flip on only when
+    // the title is actually overflowing.
     const handleMouseEnter = useCallback(() => {
         const el = containerRef.current;
         if (el && el.scrollWidth > el.clientWidth) {
-            const text = el.textContent ?? "";
-            if (text.trim()) {
-                setContent(text);
-                setVisible(true);
-            }
+            setVisible(true);
         }
     }, []);
 
@@ -36,10 +33,10 @@ const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, 
 
     return (
         <Tooltip
-            content={content}
+            content={title ?? ""}
             position="bottom"
             trigger="custom"
-            visible={visible && content.length > 0}
+            visible={visible}
         >
             <Component
                 ref={containerRef}

--- a/packages/dmworksummary/src/components/OverflowTooltip.tsx
+++ b/packages/dmworksummary/src/components/OverflowTooltip.tsx
@@ -11,30 +11,42 @@ interface OverflowTooltipProps {
 const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, style, as: Component = "div" }) => {
     const containerRef = useRef<HTMLElement>(null);
     const [visible, setVisible] = useState(false);
+    const [content, setContent] = useState("");
 
-    const handleVisibleChange = useCallback((newVisible: boolean) => {
-        if (newVisible) {
-            const el = containerRef.current;
-            if (el && el.scrollWidth > el.clientWidth) {
+    // NOTE: we intentionally use trigger="custom" instead of trigger="hover".
+    // With trigger="hover", semi binds its own mouseenter/focus handlers that mount
+    // the overlay from internal state (empty content on first hover) and bypass the
+    // controlled `visible` prop, producing an empty dark bubble. trigger="custom"
+    // makes visibility depend solely on `visible`, so the overlay only ever mounts
+    // when the title is truly overflowing and the text is non-empty.
+    const handleMouseEnter = useCallback(() => {
+        const el = containerRef.current;
+        if (el && el.scrollWidth > el.clientWidth) {
+            const text = el.textContent ?? "";
+            if (text.trim()) {
+                setContent(text);
                 setVisible(true);
             }
-        } else {
-            setVisible(false);
         }
+    }, []);
+
+    const handleMouseLeave = useCallback(() => {
+        setVisible(false);
     }, []);
 
     return (
         <Tooltip
-            content={containerRef.current?.textContent ?? ""}
+            content={content}
             position="bottom"
-            trigger="hover"
-            visible={visible}
-            onVisibleChange={handleVisibleChange}
+            trigger="custom"
+            visible={visible && content.length > 0}
         >
             <Component
                 ref={containerRef}
                 className={className}
                 style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", ...style }}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
             >
                 {children}
             </Component>

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -25,7 +25,7 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, onClick, onDelete, onRe
     return (
         <div className="summary-card" onClick={() => onClick(task.task_id)}>
             <div className="summary-card-header">
-                <OverflowTooltip className="summary-card-title">
+                <OverflowTooltip className="summary-card-title" title={task.title || task.task_no}>
                     {task.title || task.task_no}
                 </OverflowTooltip>
                 <TaskStatusBadge status={task.status} />

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -840,7 +840,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         return (
             <div className="summary-detail-header">
                 <div className="summary-detail-header-inner">
-                    <OverflowTooltip as="h2" className="summary-detail-title">
+                    <OverflowTooltip as="h2" className="summary-detail-title" title={detail?.title || t("summary.detail.defaultTitle")}>
                         {detail?.title || t("summary.detail.defaultTitle")}
                     </OverflowTooltip>
                     <div className="summary-detail-header-actions">

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -534,6 +534,20 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         }
     };
 
+    /**
+     * Whether the personal summary content is already visible in BY_PERSON mode.
+     * Mirrors the content-display predicate in renderPersonalSummary (shows when content is non-empty),
+     * so the global "generating" card and the personal summary are guaranteed to be mutually exclusive
+     * regardless of worker_status value/type/timing.
+     */
+    private get personalReady(): boolean {
+        const { detail, personalResult } = this.state;
+        return (
+            detail?.summary_mode === SummaryMode.BY_PERSON &&
+            !!personalResult?.content?.trim()
+        );
+    }
+
     renderProcessing() {
         const { t } = this.context;
         return (
@@ -957,6 +971,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                 )}
 
                                 {(detail.status === TaskStatus.PENDING || detail.status === TaskStatus.PROCESSING) &&
+                                    !this.personalReady &&
                                     this.renderProcessing()
                                 }
 
@@ -985,8 +1000,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                         </Button>
                                     </div>
                                 )}
-                                {/* 单人 WaitingConfirm 状态显示生成中 */}
-                                {detail.status === TaskStatus.WAITING_CONFIRM && this.state.members.length <= 1 && (
+                                {/* 单人 WaitingConfirm 状态显示生成中（个人总结已出则不再显示 loading） */}
+                                {detail.status === TaskStatus.WAITING_CONFIRM && this.state.members.length <= 1 && !this.personalReady && (
                                     this.renderProcessing()
                                 )}
 


### PR DESCRIPTION
## Summary

Fixes two issues in the personal summary panel:

1. **Loading card lingers** – the "generating" loading card now hides as soon as the personal summary is visible.
2. **Empty dark tooltip bubble + broken hover** – the overflow tooltip used deferred state with a double visibility gate, which produced a stray empty black bubble on first hover and could silently break hover entirely.

## Changes

- `OverflowTooltip` now uses stable, caller-supplied `title` content instead of deferred `content` state, with a single `visible` gate. This mirrors the working pattern already used in the contacts sidebar (`trigger="custom"` + static non-empty content), so the overlay never mounts with empty content (no stray bubble) and hover visibility is fully controlled.
- Call sites (`SummaryCard`, `SummaryDetailPage`) pass the title text explicitly.
- Updated `OverflowTooltip` tests to the new title-driven API.

## Testing

- dmworksummary package tests pass (65 tests, including 8 OverflowTooltip tests).
- Verified locally: the empty dark bubble is gone and hover works on overflowing titles.

Closes #305
