### PR TITLE
修复群聊 AI 备注名不立即生效

### DIFF
--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -19,7 +19,10 @@ import {
 import { IConversationProvider } from "../../Service/DataSource/DataProvider";
 import WKApp from "../../App";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
-import { subscriberDisplayName } from "../../Utils/displayName";
+import {
+  personalRemarkDisplayName,
+  subscriberDisplayName,
+} from "../../Utils/displayName";
 import { shouldShowRealnameBadge } from "../../Utils/realnameBadge";
 import { css } from "@emotion/react";
 // import ClockLoader from "react-spinners/ClockLoader";
@@ -346,13 +349,19 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     //   即可拿到。规则改动请同步 bridge/message/useMessageRow.ts。
     const isOwnMessageName =
       message.fromUID && message.fromUID === WKApp.loginInfo.uid;
+    // 个人备注来自 sender 的 Person channelInfo。群消息虽然主路径读 subscriber，
+    // 但个人备注必须优先于群成员名，才能在 friend/remark 保存并刷新
+    // Person channelInfo 后立即反映到聊天框。
+    const personalRemarkName = personalRemarkDisplayName(channelInfo);
     const displayName = isOwnMessageName
       ? WKApp.loginInfo.selfDisplayName() ||
+        personalRemarkName ||
         groupMemberName ||
         channelInfo?.orgData?.displayName ||
         channelInfo?.title ||
         ""
-      : groupMemberName ||
+      : personalRemarkName ||
+        groupMemberName ||
         channelInfo?.orgData?.displayName ||
         channelInfo?.title ||
         "";

--- a/packages/dmworkbase/src/Utils/__tests__/displayName.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/displayName.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
     displayName,
     isRealnameVerified,
+    personalRemarkDisplayName,
     subscriberDisplayName,
 } from "../displayName"
 
@@ -121,5 +122,42 @@ describe("subscriberDisplayName — 字符串归一化透传 (E1)", () => {
             },
         }
         expect(subscriberDisplayName(sub)).toBe("alice_nick")
+    })
+})
+
+describe("personalRemarkDisplayName — Person channelInfo 个人备注", () => {
+    it("存在个人备注时返回 orgData.displayName", () => {
+        expect(
+            personalRemarkDisplayName({
+                title: "bot_name",
+                orgData: {
+                    remark: "Bot Alias",
+                    displayName: "Bot Alias",
+                },
+            })
+        ).toBe("Bot Alias")
+    })
+
+    it("displayName 缺失时回退到 remark", () => {
+        expect(
+            personalRemarkDisplayName({
+                title: "bot_name",
+                orgData: {
+                    remark: "Bot Alias",
+                },
+            })
+        ).toBe("Bot Alias")
+    })
+
+    it("个人备注为空时返回空串，不用 displayName/title 抢占群成员名", () => {
+        expect(
+            personalRemarkDisplayName({
+                title: "bot_name",
+                orgData: {
+                    remark: "",
+                    displayName: "Real Bot Name",
+                },
+            })
+        ).toBe("")
     })
 })

--- a/packages/dmworkbase/src/Utils/displayName.ts
+++ b/packages/dmworkbase/src/Utils/displayName.ts
@@ -98,3 +98,27 @@ export function subscriberDisplayName(sub: SubscriberLike | null | undefined): s
         realname_verified: sub.orgData?.realname_verified,
     });
 }
+
+export interface PersonalRemarkChannelInfoLike {
+    title?: string | null;
+    orgData?: {
+        displayName?: string | null;
+        remark?: string | null;
+    } | null;
+}
+
+/**
+ * 从 Person ChannelInfo 中提取“个人备注”展示名。
+ *
+ * 群消息默认优先读 subscriber，避免群内陌生成员频繁单查 Person
+ * channelInfo；但当用户已经给对方设置了个人备注时，个人备注应覆盖群成员名。
+ */
+export function personalRemarkDisplayName(
+    channelInfo: PersonalRemarkChannelInfoLike | null | undefined
+): string {
+    const remark = channelInfo?.orgData?.remark;
+    if (typeof remark !== "string" || remark.trim() === "") {
+        return "";
+    }
+    return channelInfo?.orgData?.displayName || remark;
+}

--- a/packages/dmworkbase/src/bridge/message/__tests__/useMessageRow.realname.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/useMessageRow.realname.test.ts
@@ -234,6 +234,52 @@ describe("getMessageRow — realname badge branch logic", () => {
         expect(row.isRealnameVerified).toBe(false)
     })
 
+    it("GH#326: 群消息存在个人备注时，senderName 优先使用 Person channelInfo 备注", () => {
+        mockState.subscribesByChannel.set("g_remark", [
+            {
+                uid: "u_bot",
+                name: "Bot Original",
+                remark: "Group Bot Name",
+            },
+        ])
+        mockState.channelInfoByUID.set("u_bot", {
+            channel: new Channel("u_bot", ChannelTypePerson),
+            title: "Bot Original",
+            orgData: {
+                remark: "Personal Bot Alias",
+                displayName: "Personal Bot Alias",
+                robot: 1,
+            },
+        })
+        const row = getMessageRow(
+            makeGroupMessage({ fromUID: "u_bot", groupID: "g_remark" })
+        )
+        expect(row.senderName).toBe("Personal Bot Alias")
+    })
+
+    it("GH#326: 个人备注为空时仍回退到群成员名，避免 Person displayName 抢占群昵称", () => {
+        mockState.subscribesByChannel.set("g_no_remark", [
+            {
+                uid: "u_bot",
+                name: "Bot Original",
+                remark: "Group Bot Name",
+            },
+        ])
+        mockState.channelInfoByUID.set("u_bot", {
+            channel: new Channel("u_bot", ChannelTypePerson),
+            title: "Bot Original",
+            orgData: {
+                remark: "",
+                displayName: "Bot Real Name",
+                robot: 1,
+            },
+        })
+        const row = getMessageRow(
+            makeGroupMessage({ fromUID: "u_bot", groupID: "g_no_remark" })
+        )
+        expect(row.senderName).toBe("Group Bot Name")
+    })
+
     // ---------------------------------------------------------------------
     // 自己看自己的消息也显示实名徽章
     //

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -1,14 +1,15 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson, ChannelTypeGroup } from 'wukongimjssdk'
+import WKSDK, { Channel, ChannelTypePerson, ChannelTypeGroup } from 'wukongimjssdk'
+import type { ChannelInfo, ChannelInfoListener } from 'wukongimjssdk'
 import WKApp from '../../App'
-import { MessageWrap } from '../../Service/Model'
-import { MessageRowUIProps } from './types'
+import type { MessageWrap } from '../../Service/Model'
+import type { MessageRowUIProps } from './types'
 import { resolveExternalForViewer } from '../../Utils/externalViewer'
-import { subscriberDisplayName } from '../../Utils/displayName'
+import { personalRemarkDisplayName, subscriberDisplayName } from '../../Utils/displayName'
 import { shouldShowRealnameBadge } from '../../Utils/realnameBadge'
 import moment from 'moment'
 import { isMessageContinuation } from '../../Service/messageContinuity'
-import { t } from '../../i18n'
+import { t } from '../../i18n/instance'
 
 export interface MessageRowSelectionState {
   /** 当前会话是否处于多选模式（不可选消息也需要知道，用于禁用行内操作） */
@@ -131,6 +132,10 @@ export function getMessageRow(
   // 单次群成员查找，同时拿到 memberName 和 member 对象，
   // 避免重复 .find()。
   const { member: groupMember, memberName: groupMemberName } = getGroupMemberInfo(message)
+  // 个人备注来自 sender 的 Person channelInfo。群消息虽然主路径读 subscriber，
+  // 但用户手动设置的个人备注必须优先于群成员名，否则 friend/remark 保存后
+  // fetchChannelInfo 已刷新也会被 subscriber.name 挡住。
+  const personalRemarkName = personalRemarkDisplayName(channelInfo)
 
   // Epic dmwork-web#1169 Phase A: 发送者实名徽章。
   // 优先群成员 orgData（群消息命中率最高），回落 Person channelInfo.orgData
@@ -205,9 +210,10 @@ export function getMessageRow(
     // payload 下发的 loginInfo 是可靠源。规则改动同步 Messages/Base/index.tsx。
     senderName: isOwnMessage
       ? WKApp.loginInfo.selfDisplayName() ||
+        personalRemarkName ||
         groupMemberName ||
         getSenderName(channelInfo, message.fromUID)
-      : groupMemberName || getSenderName(channelInfo, message.fromUID),
+      : personalRemarkName || groupMemberName || getSenderName(channelInfo, message.fromUID),
     isBot: channelInfo?.orgData?.robot === 1,
     timestamp,
     timeOnly,


### PR DESCRIPTION
## Summary
- prefer sender Person channelInfo personal remark over group subscriber name in both message rendering paths
- keep group member name fallback when personal remark is empty
- add focused coverage for personal remark priority and fallback behavior

Closes #326

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Utils/__tests__/displayName.test.ts packages/dmworkbase/src/bridge/message/__tests__/useMessageRow.realname.test.ts
- pnpm i18n:check
- pnpm build
- pnpm lint
- pnpm lint:wkmodal