### PR TITLE
Fix rich text mixed message clipboard round trip

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/richTextMixedSend.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/richTextMixedSend.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRichTextMixedCandidate,
+  isImageFileForRichTextMixed,
+} from "../richTextMixedSend";
+
+function file(name: string, type = ""): File {
+  return new File(["x"], name, { type });
+}
+
+describe("buildRichTextMixedCandidate", () => {
+  it("mixes upload-button image attachments with editor text into one RichText payload", () => {
+    const candidate = buildRichTextMixedCandidate(
+      [{ id: "img1", file: file("a.png", "image/png") }],
+      [{ type: "text", text: "@Alice 看一下" }]
+    );
+
+    expect(candidate?.topImageIds).toEqual(["img1"]);
+    expect(candidate?.blocks).toEqual([
+      expect.objectContaining({ id: "img1", type: "image" }),
+      { type: "text", text: "@Alice 看一下" },
+    ]);
+  });
+
+  it("keeps pasted image plus text eligible for RichText", () => {
+    const image = file("paste.png", "image/png");
+    const candidate = buildRichTextMixedCandidate(
+      [],
+      [
+        { type: "text", text: "看图" },
+        { type: "image", id: "p1", file: image },
+      ]
+    );
+
+    expect(candidate?.topImageIds).toEqual([]);
+    expect(candidate?.blocks).toHaveLength(2);
+  });
+
+  it("does not aggregate when any non-image top attachment is present", () => {
+    const candidate = buildRichTextMixedCandidate(
+      [
+        { id: "img1", file: file("a.png", "image/png") },
+        { id: "pdf1", file: file("a.pdf", "application/pdf") },
+      ],
+      [{ type: "text", text: "看附件" }]
+    );
+
+    expect(candidate).toBeNull();
+  });
+
+  it("recognizes image files by extension when MIME is missing", () => {
+    expect(isImageFileForRichTextMixed(file("screenshot.webp"))).toBe(true);
+    expect(isImageFileForRichTextMixed(file("notes.txt"))).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -2566,9 +2566,22 @@ export class Conversation
                     )}
                     <MessageInput
                       botCommands={botCommands}
-                      onAddAttachment={(addFn: (files: File[]) => void) => {
+                      onAddAttachment={(
+                        addFn: (
+                          files: File[],
+                          source?: "paste" | "upload"
+                        ) => void
+                      ) => {
                         // 存储 addAttachment 方法，供外部调用
                         this._addAttachmentFn = addFn;
+                      }}
+                      onAddPendingAttachments={(files, source) => {
+                        const err = this.addPendingAttachments(files, source);
+                        if (err) {
+                          Toast.error(err);
+                          return false;
+                        }
+                        return true;
                       }}
                       members={this.vm.subscribers.filter(
                         (s) => s.uid !== WKApp.loginInfo.uid

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -75,6 +75,7 @@ import {
 import { ImageContent } from "../../Messages/Image";
 import {
   RichTextBlock,
+  RichTextImagePlaceholder,
   createRichTextContent,
   makeTextBlock,
   makeImageBlock,
@@ -93,9 +94,16 @@ import {
 import { parseThreadChannelId } from "../../Service/Thread";
 import FoldSessionExpandedList from "./FoldSessionExpandedList";
 import VoiceFeedback from "../../Service/VoiceFeedback";
-import { precheckUploadCredentials, uploadChatMedia } from "../../Service/UploadCredentials";
+import {
+  precheckUploadCredentials,
+  uploadChatMedia,
+} from "../../Service/UploadCredentials";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext, t } from "../../i18n";
+import {
+  buildRichTextMixedCandidate,
+  isImageFileForRichTextMixed,
+} from "./richTextMixedSend";
 
 /**
  * 取消息的有效内容：如果消息被编辑过，返回编辑后的 contentEdit；否则返回原始 content
@@ -123,12 +131,13 @@ function getEffectiveContent(message: Message): MessageContent {
  * (后端 json binding 接受空数组)。
  */
 function extractMessageAttachments(
-  m: Message | undefined | null,
+  m: Message | undefined | null
 ): { file_name: string; file_url: string }[] {
   if (!m || !m.content) return [];
   const contentType = (m.content as { contentType?: number }).contentType;
   const anyContent = m.content as Record<string, unknown>;
-  const url = typeof anyContent.url === "string" ? (anyContent.url as string) : "";
+  const url =
+    typeof anyContent.url === "string" ? (anyContent.url as string) : "";
   // remoteUrl 是 MediaMessageContent 在 decode 后设置的真实 CDN URL, 优先用
   const remoteUrl =
     typeof anyContent.remoteUrl === "string"
@@ -154,7 +163,8 @@ function extractMessageAttachments(
       // 图片一般没 name, 用 URL 末尾的文件名, 失败就合成 image.jpg
       return [
         {
-          file_name: explicitName || guessFileNameFromUrl(effectiveUrl, "image.jpg"),
+          file_name:
+            explicitName || guessFileNameFromUrl(effectiveUrl, "image.jpg"),
           file_url: effectiveUrl,
         },
       ];
@@ -199,7 +209,7 @@ function guessFileNameFromUrl(url: string, fallback: string): string {
  * 注入非法块。纯图片发送路径(sendImageFile)本就从本地文件量尺寸，这里保持一致。
  */
 function readLocalImageSize(
-  file: File,
+  file: File
 ): Promise<{ width: number; height: number }> {
   return new Promise((resolve) => {
     const reader = new FileReader();
@@ -218,6 +228,28 @@ function readLocalImageSize(
     reader.onerror = () => resolve({ width: 0, height: 0 });
     reader.readAsDataURL(file);
   });
+}
+
+function offsetMentionEntities(
+  entities: Array<{ uid: string; offset: number; length: number }> | undefined,
+  baseOffset: number
+): Array<{ uid: string; offset: number; length: number }> {
+  if (!Array.isArray(entities)) return [];
+  return entities
+    .filter(
+      (entity) =>
+        entity &&
+        typeof entity.uid === "string" &&
+        Number.isFinite(entity.offset) &&
+        Number.isFinite(entity.length) &&
+        entity.offset >= 0 &&
+        entity.length > 0
+    )
+    .map((entity) => ({
+      uid: entity.uid,
+      offset: baseOffset + entity.offset,
+      length: entity.length,
+    }));
 }
 
 /**
@@ -245,7 +277,12 @@ function resolveFromUName(m: Message | undefined | null): string {
     const ch = m.channel;
     if (ch && ch.channelType === ChannelTypeGroup) {
       const subs = WKSDK.shared().channelManager.getSubscribes(ch) as
-        | { uid?: string; name?: string; remark?: string; orgData?: Record<string, unknown> }[]
+        | {
+            uid?: string;
+            name?: string;
+            remark?: string;
+            orgData?: Record<string, unknown>;
+          }[]
         | null
         | undefined;
       const member = subs?.find((s) => s && s.uid === fromUID);
@@ -260,8 +297,9 @@ function resolveFromUName(m: Message | undefined | null): string {
 
   // 2. Person channelInfo 兜底
   try {
-    const info = WKSDK.shared()
-      .channelManager.getChannelInfo(new Channel(fromUID, ChannelTypePerson));
+    const info = WKSDK.shared().channelManager.getChannelInfo(
+      new Channel(fromUID, ChannelTypePerson)
+    );
     if (info?.title) return info.title;
   } catch {
     // ignore
@@ -272,7 +310,7 @@ function resolveFromUName(m: Message | undefined | null): string {
 
 const foldSessionAvatarIcon = new URL(
   "./fold-session-avatar.svg",
-  import.meta.url,
+  import.meta.url
 ).href;
 
 const FoldImage: React.FC<{ src: string }> = ({ src }) => {
@@ -363,11 +401,11 @@ export class Conversation
   private latestSavedDraft = "";
   private _addAttachmentFn?: (
     files: File[],
-    source?: "paste" | "upload",
+    source?: "paste" | "upload"
   ) => void;
   private onOpenThreadPanel?: (
     threadChannelId: string,
-    threadName: string,
+    threadName: string
   ) => void;
 
   constructor(props: any) {
@@ -401,7 +439,7 @@ export class Conversation
 
   async sendMessage(
     content: MessageContent,
-    channel?: Channel,
+    channel?: Channel
   ): Promise<Message> {
     // const { channel } = this.props
     let c = channel;
@@ -441,7 +479,7 @@ export class Conversation
       return;
     }
     const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
-      new Channel(fromUID, ChannelTypePerson),
+      new Channel(fromUID, ChannelTypePerson)
     );
     this._messageInputContext?.addMention(fromUID, channelInfo?.title || "");
   }
@@ -488,7 +526,7 @@ export class Conversation
     await this.vm.deleteMessagesFromLocal([message]);
     const newMessage = await this.vm.sendMessage(
       message.content,
-      message.channel,
+      message.channel
     );
     return newMessage;
   }
@@ -500,7 +538,7 @@ export class Conversation
    */
   private async sendMediaAndWait(
     content: MessageContent,
-    channel?: Channel,
+    channel?: Channel
   ): Promise<boolean> {
     // 非媒体消息（或无文件需上传）无需等待上传，直接发送并等 ack
     if (
@@ -603,7 +641,7 @@ export class Conversation
       const taskResult = taskStatusWaitResult(
         task?.status,
         TaskStatus.success,
-        TaskStatus.fail,
+        TaskStatus.fail
       );
       if (taskResult === false) {
         done(false);
@@ -630,7 +668,7 @@ export class Conversation
       const statusResult = messageStatusWaitResult(
         message.status,
         MessageStatus.Normal,
-        MessageStatus.Fail,
+        MessageStatus.Fail
       );
       if (!settled && statusResult === false) {
         done(false);
@@ -652,7 +690,7 @@ export class Conversation
    */
   private async sendTextAndWaitAck(
     content: MessageContent,
-    channel?: Channel,
+    channel?: Channel
   ): Promise<boolean> {
     const TIMEOUT = 10_000;
     let settled = false;
@@ -713,7 +751,7 @@ export class Conversation
       const statusResult = messageStatusWaitResult(
         message.status,
         MessageStatus.Normal,
-        MessageStatus.Fail,
+        MessageStatus.Fail
       );
       if (!settled && statusResult !== undefined) {
         done(statusResult);
@@ -738,16 +776,15 @@ export class Conversation
    * - 上传成功后图片 URL 走 isSafeUrl(http/https only)（与接收侧对称，防 javascript:/
    *   data:/file: 注入）。
    * - plain 由 createRichTextContent 本地占位，server #232 Finalize 重算覆盖。
-   * - mention：合并各文本块的 all/uids/humans/ais 到顶层，保证群里 @人/@所有AI 通知不丢
-   *   （vm.sendMessage 读 content.mention.humans/ais 注入）。这里不合并
-   *   entities：富文本发送的是 blocks，entity offset 需要映射到最终 plain 文本，
-   *   当前由接收侧 ais legacy fail-closed 兜底，避免 routing UID 误绑裸 @text。
+   * - mention：合并各文本块的 all/uids/humans/ais/entities 到顶层。entities
+   *   的 offset 映射到最终 plain 文本（image block 计为 "[图片]"），让接收端
+   *   RichText 文本块可以复用普通文本的 mention 高亮/点击逻辑。
    *
    * 返回 true 表示消息已入队；任一图片块准备失败则抛错（已 Toast 具体原因）。
    */
   private async sendRichTextMixed(
     editorBlocks: EditorContentBlock[],
-    reply?: Reply,
+    reply?: Reply
   ): Promise<boolean> {
     const channel = this.channel();
     const contentBlocks: RichTextBlock[] = [];
@@ -757,16 +794,22 @@ export class Conversation
     const mentionUids = new Set<string>();
     let mentionHumans = false;
     let mentionAis = false;
+    const mentionEntities: Array<{
+      uid: string;
+      offset: number;
+      length: number;
+    }> = [];
+    let plainOffset = 0;
 
     // 单张图片准备失败 → Toast 具体原因后抛错，让整条消息原子失败（草稿保留可重试）。
     const failImage = (file: File, message: string): never => {
       Toast.error(
         t("base.conversation.upload.imageFailed", {
           values: { name: file.name, message },
-        }),
+        })
       );
       const e = new Error(
-        `richtext mixed image prepare failed: ${file.name}`,
+        `richtext mixed image prepare failed: ${file.name}`
       ) as Error & { toasted?: boolean };
       // 标记已 Toast，调用方 catch 不再重复弹通用错误。
       e.toasted = true;
@@ -784,15 +827,22 @@ export class Conversation
           if (m.humans) mentionHumans = true;
           if (m.ais) mentionAis = true;
           m.uids?.forEach((uid) => mentionUids.add(uid));
+          mentionEntities.push(
+            ...offsetMentionEntities(m.entities, plainOffset)
+          );
         }
+        plainOffset += block.text.length;
       } else if (block.type === "image") {
         const file = block.file;
         // 1. 先从本地文件读尺寸（schema 必填>0，且不受 CDN 延迟影响）。
         const { width, height } = await readLocalImageSize(file);
         if (width <= 0 || height <= 0) {
-          failImage(file, t("base.conversation.upload.imageReadFailed", {
-            values: { name: file.name },
-          }));
+          failImage(
+            file,
+            t("base.conversation.upload.imageReadFailed", {
+              values: { name: file.name },
+            })
+          );
         }
         // 2. 上传拿 downloadUrl。
         const dot = (file.name || "").lastIndexOf(".");
@@ -817,8 +867,9 @@ export class Conversation
             height,
             size: file.size,
             name: file.name || undefined,
-          }),
+          })
         );
+        plainOffset += RichTextImagePlaceholder.length;
       }
       // file 块在 onSend 已被排除在图文混排路径之外
     }
@@ -831,12 +882,19 @@ export class Conversation
     if (reply) {
       content.reply = reply;
     }
-    if (mentionAll || mentionUids.size > 0 || mentionHumans || mentionAis) {
+    if (
+      mentionAll ||
+      mentionUids.size > 0 ||
+      mentionHumans ||
+      mentionAis ||
+      mentionEntities.length > 0
+    ) {
       const mn = new Mention();
       mn.all = mentionAll;
       if (mentionUids.size > 0) mn.uids = Array.from(mentionUids);
       if (mentionHumans) (mn as any).humans = 1;
       if (mentionAis) (mn as any).ais = 1;
+      if (mentionEntities.length > 0) (mn as any).entities = mentionEntities;
       content.mention = mn;
     }
     return this.sendTextAndWaitAck(content);
@@ -869,7 +927,11 @@ export class Conversation
   }
   setEditOn(edit: boolean): void {
     this.vm.editOn = edit;
-    if (this.vm.selectMessage && edit && isMessageSelectable(this.vm.selectMessage)) {
+    if (
+      this.vm.selectMessage &&
+      edit &&
+      isMessageSelectable(this.vm.selectMessage)
+    ) {
       this.vm.checkedMessage(this.vm.selectMessage, true);
     }
   }
@@ -893,14 +955,14 @@ export class Conversation
     messageSeq: number,
     channelID: String,
     channelType: number,
-    content: String,
+    content: String
   ): Promise<void> {
     return this.vm.editMessage(
       messageID,
       messageSeq,
       channelID,
       channelType,
-      content,
+      content
     );
   }
   onTapAvatar(uid: string, event: React.MouseEvent<Element, MouseEvent>): void {
@@ -916,7 +978,7 @@ export class Conversation
       if (foldSession) {
         const isSummaryMessage = isFoldSessionSummaryMessage(
           foldSession,
-          messageSeq,
+          messageSeq
         );
         if (isSummaryMessage) {
           this.vm.highlightFoldSessionSummary(foldSession.sessionId, () => {
@@ -932,7 +994,7 @@ export class Conversation
             messageWrap.locateRemind = true;
             this.vm.scrollToMessage(messageWrap);
             this.vm.notifyListener();
-          },
+          }
         );
         return;
       }
@@ -990,7 +1052,7 @@ export class Conversation
 
   addPendingAttachments(
     files: File[],
-    source: "paste" | "upload" = "upload",
+    source: "paste" | "upload" = "upload"
   ): string | null {
     const BLOCKED_EXTENSIONS = [
       "exe",
@@ -1118,8 +1180,7 @@ export class Conversation
         : undefined;
     if (foldSession?.isExpanded) {
       return foldSession.expandedMessages.some(
-        (expandedMessage) =>
-          expandedMessage.clientMsgNo === message.clientMsgNo,
+        (expandedMessage) => expandedMessage.clientMsgNo === message.clientMsgNo
       );
     }
     for (const item of this.vm.renderItems) {
@@ -1129,7 +1190,7 @@ export class Conversation
       if (
         item.session.expandedMessages.some(
           (expandedMessage) =>
-            expandedMessage.clientMsgNo === message.clientMsgNo,
+            expandedMessage.clientMsgNo === message.clientMsgNo
         )
       ) {
         return true;
@@ -1177,7 +1238,7 @@ export class Conversation
     };
     WKApp.mittBus.on(
       "wk:matter-created-from-input",
-      this._matterSendMessageHandler,
+      this._matterSendMessageHandler
     );
 
     this._exitMultipleModeHandler = () => {
@@ -1202,7 +1263,7 @@ export class Conversation
     if (this._matterSendMessageHandler) {
       WKApp.mittBus.off(
         "wk:matter-created-from-input",
-        this._matterSendMessageHandler,
+        this._matterSendMessageHandler
       );
       this._matterSendMessageHandler = undefined;
     }
@@ -1272,7 +1333,7 @@ export class Conversation
     } else {
       const firstVisiableMessage = this.visiblePersistentMessage(
         viewport,
-        false,
+        false
       );
       const firstVisibleElement = firstVisiableMessage
         ? this.getMessageElement(firstVisiableMessage)
@@ -1306,16 +1367,18 @@ export class Conversation
 
   async clearDraftAfterSend(
     sendDraftGeneration: number,
-    remoteDraftAtSend: string,
+    remoteDraftAtSend: string
   ) {
     const remoteExtra = this.vm.currentConversation?.remoteExtra;
-    if (!shouldClearDraftAfterSend({
-      liveDraft: this.messageInputContext()?.text() || "",
-      remoteDraft: remoteExtra?.draft || "",
-      remoteDraftAtSend,
-      draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
-      latestSavedDraft: this.latestSavedDraft,
-    })) {
+    if (
+      !shouldClearDraftAfterSend({
+        liveDraft: this.messageInputContext()?.text() || "",
+        remoteDraft: remoteExtra?.draft || "",
+        remoteDraftAtSend,
+        draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
+        latestSavedDraft: this.latestSavedDraft,
+      })
+    ) {
       return;
     }
 
@@ -1330,7 +1393,7 @@ export class Conversation
     if (this.vm.currentConversation) {
       WKSDK.shared().conversationManager.notifyConversationListeners(
         this.vm.currentConversation,
-        ConversationAction.update,
+        ConversationAction.update
       );
     }
   }
@@ -1382,7 +1445,7 @@ export class Conversation
     return buildMentionRenderInfo(
       message.parts as any,
       flags,
-      PartType.mention as unknown as number,
+      PartType.mention as unknown as number
     ) as MentionInfo[];
   }
 
@@ -1593,7 +1656,7 @@ export class Conversation
             style={{ width: "100%", height: "100%" }}
           />
         ),
-      }),
+      })
     );
     const { showSummary, summaryId, summaryMessage } =
       getFoldSessionSummaryState(session);
@@ -1619,9 +1682,12 @@ export class Conversation
     let participantNameDisplay: React.ReactNode;
     if (shouldCollapse) {
       // 折叠模式: 显示第一个名字 + "等X人"
-      const collapsedText = t("base.conversation.foldSession.collapsedParticipants", {
-        values: { name: participants[0].name, count: participants.length },
-      });
+      const collapsedText = t(
+        "base.conversation.foldSession.collapsedParticipants",
+        {
+          values: { name: participants[0].name, count: participants.length },
+        }
+      );
       participantNameDisplay = (
         <span className="wk-fold-session-participants-collapsed">
           <span className="wk-fold-session-participant-name wk-fold-session-participant-name-ai">
@@ -1663,7 +1729,7 @@ export class Conversation
         className={classNames(
           "wk-message-item",
           "wk-message-item-fold-session",
-          last ? "wk-message-item-last" : undefined,
+          last ? "wk-message-item-last" : undefined
         )}
       >
         <div className="wk-message-item-fold-session-shell">
@@ -1746,11 +1812,11 @@ export class Conversation
               summaryId={summaryId}
               summarySender={summarySender}
               summaryTime={moment(summaryMessage.timestamp * 1000).format(
-                "HH:mm",
+                "HH:mm"
               )}
               summaryContent={this.renderFoldSessionSummary(summaryMessage)}
               expandedContent={this.renderFoldSessionExpandedList(
-                session.expandedMessages,
+                session.expandedMessages
               )}
               onToggle={() => {
                 this.vm.toggleFoldSession(session.sessionId);
@@ -1830,7 +1896,7 @@ export class Conversation
           extraClassName,
           last ? "wk-message-item-last" : undefined,
           message.locateRemind ? "wk-message-item-reminder" : undefined,
-          isSystemMessage ? "wk-message-item-system" : undefined,
+          isSystemMessage ? "wk-message-item-system" : undefined
         )}
       >
         {MessageCell ? (
@@ -1873,7 +1939,7 @@ export class Conversation
     }
     if (this.vm.lastMessage) {
       this.vm.lastLocalMessageElement = this.getMessageElement(
-        this.vm.lastMessage,
+        this.vm.lastMessage
       ); // 最新消息
       if (this.vm.lastLocalMessageElement) {
         // 如果有最新消息的dom则判断是否在可见范围内
@@ -1903,7 +1969,7 @@ export class Conversation
       shouldPulldownOnWheel(
         e.deltaY,
         viewport.scrollTop,
-        this.isFullScreen(viewport),
+        this.isFullScreen(viewport)
       )
     ) {
       this.vm.pulldownMessages();
@@ -1939,7 +2005,7 @@ export class Conversation
       }
       WKSDK.shared().receiptManager.addReceiptMessages(
         this.channel(),
-        unreadMessages,
+        unreadMessages
       );
     }
   }
@@ -2064,10 +2130,7 @@ export class Conversation
     }
   }
 
-  private visiblePersistentMessage(
-    vp: HTMLElement | null,
-    fromEnd: boolean,
-  ) {
+  private visiblePersistentMessage(vp: HTMLElement | null, fromEnd: boolean) {
     if (!this.vm.messages || this.vm.messages.length === 0) {
       return;
     }
@@ -2257,7 +2320,7 @@ export class Conversation
                   vm.fileDragEnter ? "wk-conversation-dragover" : undefined,
                   vm.currentReplyMessage
                     ? "wk-conversation-hasreply"
-                    : undefined,
+                    : undefined
                 )}
                 style={{
                   background: chatBg
@@ -2308,7 +2371,7 @@ export class Conversation
                       showScrollToBottom={vm.showScrollToBottomBtn || false}
                       unreadCount={vm.unreadCount}
                       reminders={vm.currentConversation?.reminders?.filter(
-                        (r) => !r.done,
+                        (r) => !r.done
                       )}
                     ></ConversationPositionView>
                   </div>
@@ -2330,9 +2393,7 @@ export class Conversation
                 <div
                   className={classNames(
                     "wk-conversation-multiplepanel",
-                    vm.editOn
-                      ? "wk-conversation-multiplepanel-show"
-                      : undefined,
+                    vm.editOn ? "wk-conversation-multiplepanel-show" : undefined
                   )}
                 >
                   <MultiplePanel
@@ -2343,14 +2404,16 @@ export class Conversation
                     onForward={() => {
                       const messages = vm.getCheckedMessages();
                       if (!messages || messages.length === 0) {
-                        Toast.error(t("base.conversation.selection.selectMessageFirst"));
+                        Toast.error(
+                          t("base.conversation.selection.selectMessageFirst")
+                        );
                         return;
                       }
                       WKApp.shared.baseContext.showConversationSelect(
                         (channels: Channel[]) => {
                           for (const message of messages) {
                             const cloneContent = getEffectiveContent(
-                              message.message,
+                              message.message
                             );
                             for (const channel of channels) {
                               this.sendMessage(cloneContent, channel);
@@ -2358,13 +2421,15 @@ export class Conversation
                           }
                           vm.editOn = false;
                           vm.unCheckAllMessages();
-                        },
+                        }
                       );
                     }}
                     onMergeForward={() => {
                       const checkedMsgs = vm.getCheckedMessages();
                       if (!checkedMsgs || checkedMsgs.length === 0) {
-                        Toast.error(t("base.conversation.selection.selectMessageFirst"));
+                        Toast.error(
+                          t("base.conversation.selection.selectMessageFirst")
+                        );
                         return;
                       }
                       WKApp.shared.baseContext.showConversationSelect(
@@ -2372,13 +2437,15 @@ export class Conversation
                           vm.sendMergeforward(channels);
                           vm.editOn = false;
                           vm.unCheckAllMessages();
-                        },
+                        }
                       );
                     }}
                     onDelete={() => {
                       const checkedMsgs = vm.getCheckedMessages();
                       if (!checkedMsgs || checkedMsgs.length === 0) {
-                        Toast.error(t("base.conversation.selection.selectMessageFirst"));
+                        Toast.error(
+                          t("base.conversation.selection.selectMessageFirst")
+                        );
                         return;
                       }
                       wkConfirm({
@@ -2398,7 +2465,9 @@ export class Conversation
                             vm.editOn = false;
                             vm.unCheckAllMessages();
                           } catch (e) {
-                            Toast.error(t("base.conversation.deleteConfirm.failed"));
+                            Toast.error(
+                              t("base.conversation.deleteConfirm.failed")
+                            );
                             throw e;
                           }
                         },
@@ -2407,7 +2476,9 @@ export class Conversation
                     onAddToMatter={(anchor) => {
                       const checkedMsgs = vm.getCheckedMessages();
                       if (!checkedMsgs || checkedMsgs.length === 0) {
-                        Toast.error(t("base.conversation.selection.selectMessageFirst"));
+                        Toast.error(
+                          t("base.conversation.selection.selectMessageFirst")
+                        );
                         return;
                       }
                       // 传 channel 信息给 MatterLinkMenu，用于按 channel 查询关联的 Matter
@@ -2433,7 +2504,9 @@ export class Conversation
                     onCreateMatter={() => {
                       const checkedMsgs = vm.getCheckedMessages();
                       if (!checkedMsgs || checkedMsgs.length === 0) {
-                        Toast.error(t("base.conversation.selection.selectMessageFirst"));
+                        Toast.error(
+                          t("base.conversation.selection.selectMessageFirst")
+                        );
                         return;
                       }
                       const ch = this.props.channel;
@@ -2455,7 +2528,6 @@ export class Conversation
                       });
                     }}
                   ></MultiplePanel>
-
                 </div>
                 <div
                   className="wk-conversation-footer"
@@ -2463,13 +2535,13 @@ export class Conversation
                     vm.editOn
                       ? { display: "none" }
                       : this.state.inputExpanded
-                        ? {
-                            flex: 1,
-                            minHeight: 0,
-                            overflow: "hidden",
-                            paddingTop: "var(--wk-sp-2)",
-                          }
-                        : undefined
+                      ? {
+                          flex: 1,
+                          minHeight: 0,
+                          overflow: "hidden",
+                          paddingTop: "var(--wk-sp-2)",
+                        }
+                      : undefined
                   }
                 >
                   <div
@@ -2499,7 +2571,7 @@ export class Conversation
                         this._addAttachmentFn = addFn;
                       }}
                       members={this.vm.subscribers.filter(
-                        (s) => s.uid !== WKApp.loginInfo.uid,
+                        (s) => s.uid !== WKApp.loginInfo.uid
                       )}
                       topView={
                         vm.currentReplyMessage ? (
@@ -2557,17 +2629,21 @@ export class Conversation
                         const { channel } = this.props;
                         await this.vm.ensureSubscribersLoaded();
 
-                        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+                        const channelInfo =
+                          WKSDK.shared().channelManager.getChannelInfo(channel);
                         let groupName: string | undefined;
                         let threadName: string | undefined;
 
                         if (channel.channelType === ChannelTypeCommunityTopic) {
                           threadName = channelInfo?.title;
-                          const parsed = parseThreadChannelId(channel.channelID);
+                          const parsed = parseThreadChannelId(
+                            channel.channelID
+                          );
                           if (parsed) {
-                            const parentInfo = WKSDK.shared().channelManager.getChannelInfo(
-                              new Channel(parsed.groupNo, ChannelTypeGroup)
-                            );
+                            const parentInfo =
+                              WKSDK.shared().channelManager.getChannelInfo(
+                                new Channel(parsed.groupNo, ChannelTypeGroup)
+                              );
                             groupName = parentInfo?.title;
                           }
                         } else if (channel.channelType === ChannelTypeGroup) {
@@ -2582,7 +2658,7 @@ export class Conversation
                           channelInfo:
                             channel.channelType === ChannelTypePerson
                               ? (WKSDK.shared().channelManager.getChannelInfo(
-                                  channel,
+                                  channel
                                 ) as ChatContextChannelInfo | null)
                               : undefined,
                           groupName,
@@ -2594,7 +2670,7 @@ export class Conversation
                         mention?: MentionModel,
                         _attachments?: { id: string; file: File }[],
                         topFiles?: { id: string; file: File }[],
-                        editorBlocks?: EditorContentBlock[],
+                        editorBlocks?: EditorContentBlock[]
                       ): Promise<boolean | SendResultDetail> => {
                         // 返回值告诉 MessageInput 是否清空编辑器/附件：
                         //   true  → 发送成功(或已消费)，清空草稿+附件；
@@ -2619,7 +2695,7 @@ export class Conversation
                               vm.currentReplyMessage.messageSeq,
                               vm.currentReplyMessage.channel.channelID,
                               vm.currentReplyMessage.channel.channelType,
-                              JSON.stringify(json),
+                              JSON.stringify(json)
                             );
                             vm.currentReplyMessage = undefined;
                             // 编辑消息已提交，编辑器应清空。
@@ -2633,8 +2709,8 @@ export class Conversation
                             WKSDK.shared().channelManager.getChannelInfo(
                               new Channel(
                                 vm.currentReplyMessage.fromUID,
-                                ChannelTypePerson,
-                              ),
+                                ChannelTypePerson
+                              )
                             );
                           if (channelInfo) {
                             reply.fromName = channelInfo.title;
@@ -2647,18 +2723,29 @@ export class Conversation
                         // 返回 true 表示消息已入队 / 发送; false 表示被预检拒绝、
                         // 调用方应据此决定是否继续后续流程 (例如不要再补一条
                         // 空回复消息: octo-web#119 review by Jerry-Xin)。
-                        const sendImageFile = async (file: File): Promise<boolean> => {
+                        const sendImageFile = async (
+                          file: File
+                        ): Promise<boolean> => {
                           // 上传前预检：后端会对文件大小/类型做校验,失败时直接 Toast,
                           // 不要让本地气泡先进聊天框再显示失败 (octo-web#119)。
                           try {
                             const dot = (file.name || "").lastIndexOf(".");
-                            const ext = dot > 0 ? file.name.substring(dot + 1) : "";
-                            await precheckUploadCredentials(file, this.channel(), ext);
+                            const ext =
+                              dot > 0 ? file.name.substring(dot + 1) : "";
+                            await precheckUploadCredentials(
+                              file,
+                              this.channel(),
+                              ext
+                            );
                           } catch (err) {
-                            const msg = (err as { msg?: string })?.msg || t("base.conversation.upload.failed");
-                            Toast.error(t("base.conversation.upload.imageFailed", {
-                              values: { name: file.name, message: msg },
-                            }));
+                            const msg =
+                              (err as { msg?: string })?.msg ||
+                              t("base.conversation.upload.failed");
+                            Toast.error(
+                              t("base.conversation.upload.imageFailed", {
+                                values: { name: file.name, message: msg },
+                              })
+                            );
                             return false;
                           }
                           const reader = new FileReader();
@@ -2668,12 +2755,14 @@ export class Conversation
                                 resolve(reader.result as string);
                               reader.onerror = () => resolve("");
                               reader.readAsDataURL(file);
-                            },
+                            }
                           );
                           if (!previewUrl) {
-                            Toast.error(t("base.conversation.upload.imageReadFailed", {
-                              values: { name: file.name },
-                            }));
+                            Toast.error(
+                              t("base.conversation.upload.imageReadFailed", {
+                                values: { name: file.name },
+                              })
+                            );
                             return false;
                           }
                           const { width, height } = await new Promise<{
@@ -2691,35 +2780,45 @@ export class Conversation
                             img.src = previewUrl;
                           });
                           return this.sendMediaAndWait(
-                            new ImageContent(file, previewUrl, width, height),
+                            new ImageContent(file, previewUrl, width, height)
                           );
                         };
 
                         // ── 辅助：发送单个非图片文件 ──────────────
-                        const sendFileAttachment = async (file: File): Promise<boolean> => {
+                        const sendFileAttachment = async (
+                          file: File
+                        ): Promise<boolean> => {
                           const name = file.name || "unknown";
                           const dotIndex = name.lastIndexOf(".");
                           const ext =
                             dotIndex > 0 ? name.substring(dotIndex + 1) : "";
                           // 上传前预检 (octo-web#119)。
                           try {
-                            await precheckUploadCredentials(file, this.channel(), ext);
+                            await precheckUploadCredentials(
+                              file,
+                              this.channel(),
+                              ext
+                            );
                           } catch (err) {
-                            const msg = (err as { msg?: string })?.msg || t("base.conversation.upload.failed");
-                            Toast.error(t("base.conversation.upload.fileFailed", {
-                              values: { name, message: msg },
-                            }));
+                            const msg =
+                              (err as { msg?: string })?.msg ||
+                              t("base.conversation.upload.failed");
+                            Toast.error(
+                              t("base.conversation.upload.fileFailed", {
+                                values: { name, message: msg },
+                              })
+                            );
                             return false;
                           }
                           return this.sendMediaAndWait(
-                            new FileContent(file, name, ext, file.size),
+                            new FileContent(file, name, ext, file.size)
                           );
                         };
 
                         // ── 辅助：构建带 mention 的文本 MessageContent ──────────────
                         const buildTextContent = (
                           blockText: string,
-                          blockMention?: MentionModel,
+                          blockMention?: MentionModel
                         ) => {
                           const msgContent = new MessageText(blockText);
                           if (blockMention) {
@@ -2741,8 +2840,9 @@ export class Conversation
                             const hasEntities =
                               blockMention.entities &&
                               blockMention.entities.length > 0;
-                            const hasThreeState =
-                              !!(blockMention.humans || blockMention.ais);
+                            const hasThreeState = !!(
+                              blockMention.humans || blockMention.ais
+                            );
 
                             if (hasEntities || hasThreeState) {
                               const entities = blockMention.entities;
@@ -2780,12 +2880,12 @@ export class Conversation
                                     obj.mention.ais = blockMention.ais;
                                   }
                                   return new TextEncoder().encode(
-                                    JSON.stringify(obj),
+                                    JSON.stringify(obj)
                                   );
                                 } catch (e) {
                                   console.warn(
                                     "[Mention] encode override failed",
-                                    e,
+                                    e
                                   );
                                   return originalEncode();
                                 }
@@ -2805,10 +2905,54 @@ export class Conversation
                         // (octo-web#227 Jerry-Xin non-blocking)。
                         const consumedTopIds: string[] = [];
                         const topFilesToSend = topFiles || [];
+                        const mixedCandidate = buildRichTextMixedCandidate(
+                          topFilesToSend,
+                          editorBlocks
+                        );
+                        if (mixedCandidate) {
+                          let mixedSent = false;
+                          try {
+                            if (
+                              await this.sendRichTextMixed(
+                                mixedCandidate.blocks as EditorContentBlock[],
+                                reply
+                              )
+                            ) {
+                              mixedSent = true;
+                              anyMessageSent = true;
+                              consumedTopIds.push(
+                                ...mixedCandidate.topImageIds
+                              );
+                            }
+                            reply = undefined;
+                          } catch (err) {
+                            console.error(
+                              "[Conversation] richtext mixed send failed:",
+                              err
+                            );
+                            if (!(err as { toasted?: boolean })?.toasted) {
+                              Toast.error(
+                                t("base.conversation.message.sendFailed")
+                              );
+                            }
+                          }
+                          if (mixedSent) {
+                            await this.clearDraftAfterSend(
+                              sendDraftGeneration,
+                              remoteDraftAtSend
+                            );
+                          }
+                          this.props.onMessageSent?.();
+                          return {
+                            editorConsumed: mixedSent,
+                            consumedTopIds,
+                          };
+                        }
+
                         for (const { id, file } of topFilesToSend) {
                           try {
                             let sent = false;
-                            if (file.type && file.type.startsWith("image/")) {
+                            if (isImageFileForRichTextMixed(file)) {
                               sent = await sendImageFile(file);
                             } else {
                               sent = await sendFileAttachment(file);
@@ -2818,9 +2962,11 @@ export class Conversation
                               consumedTopIds.push(id);
                             }
                           } catch (err) {
-                            Toast.error(t("base.conversation.upload.fileSendFailed", {
-                              values: { name: file.name },
-                            }));
+                            Toast.error(
+                              t("base.conversation.upload.fileSendFailed", {
+                                values: { name: file.name },
+                              })
+                            );
                           }
                         }
 
@@ -2830,13 +2976,13 @@ export class Conversation
                           // RichText(=14) 消息（而非拆成多条独立消息）。含 file 块或
                           // 纯文本/纯图片时仍走下方逐块发送路径，不回退已落地逻辑。
                           const hasText = editorBlocks.some(
-                            (b) => b.type === "text" && b.text.trim() !== "",
+                            (b) => b.type === "text" && b.text.trim() !== ""
                           );
                           const hasImage = editorBlocks.some(
-                            (b) => b.type === "image",
+                            (b) => b.type === "image"
                           );
                           const hasFile = editorBlocks.some(
-                            (b) => b.type === "file",
+                            (b) => b.type === "file"
                           );
                           if (hasText && hasImage && !hasFile) {
                             // 单独跟踪图文混排是否成功：图片准备失败时 sendRichTextMixed
@@ -2844,7 +2990,12 @@ export class Conversation
                             // 清空编辑器草稿——草稿里的文本+图片整条都没发出，须保留可重试。
                             let mixedSent = false;
                             try {
-                              if (await this.sendRichTextMixed(editorBlocks, reply)) {
+                              if (
+                                await this.sendRichTextMixed(
+                                  editorBlocks,
+                                  reply
+                                )
+                              ) {
                                 mixedSent = true;
                                 anyMessageSent = true;
                               }
@@ -2852,19 +3003,21 @@ export class Conversation
                             } catch (err) {
                               console.error(
                                 "[Conversation] richtext mixed send failed:",
-                                err,
+                                err
                               );
                               // 图片准备失败已在 sendRichTextMixed 内 Toast 具体原因，
                               // 不再重复弹通用错误。
                               if (!(err as { toasted?: boolean })?.toasted) {
-                                Toast.error(t("base.conversation.message.sendFailed"));
+                                Toast.error(
+                                  t("base.conversation.message.sendFailed")
+                                );
                               }
                             }
                             // 仅当图文混排本身发出时才清草稿；失败则保留编辑器内容可重试。
                             if (mixedSent) {
                               await this.clearDraftAfterSend(
                                 sendDraftGeneration,
-                                remoteDraftAtSend,
+                                remoteDraftAtSend
                               );
                             }
                             this.props.onMessageSent?.();
@@ -2886,7 +3039,7 @@ export class Conversation
                               if (block.type === "text") {
                                 const msgContent = buildTextContent(
                                   block.text,
-                                  block.mention,
+                                  block.mention
                                 );
                                 // 第一个文本块携带 reply 信息
                                 if (reply && isFirstTextBlock) {
@@ -2909,9 +3062,11 @@ export class Conversation
                             } catch (err) {
                               console.error(
                                 "[Conversation] editorBlock send failed:",
-                                err,
+                                err
                               );
-                              Toast.error(t("base.conversation.message.sendFailed"));
+                              Toast.error(
+                                t("base.conversation.message.sendFailed")
+                              );
                             }
                           }
                           // 如果 reply 还没被消费（没有文本块），附加到一条空白消息;
@@ -2942,7 +3097,7 @@ export class Conversation
                         if (anyMessageSent) {
                           await this.clearDraftAfterSend(
                             sendDraftGeneration,
-                            remoteDraftAtSend,
+                            remoteDraftAtSend
                           );
                         }
                         this.props.onMessageSent?.();
@@ -2992,14 +3147,14 @@ export class Conversation
                       }
                       const channel = new Channel(
                         this.vm.selectUID,
-                        ChannelTypePerson,
+                        ChannelTypePerson
                       );
                       const channelInfo =
                         WKSDK.shared().channelManager.getChannelInfo(channel);
 
                       this.messageInputContext()?.addMention(
                         this.vm.selectUID,
-                        channelInfo?.title || "",
+                        channelInfo?.title || ""
                       );
                     },
                   },
@@ -3014,7 +3169,7 @@ export class Conversation
                       if (this.vm.channel.channelType === ChannelTypeGroup) {
                         fromChannel = this.vm.channel;
                         const subscriber = this.vm.subscriberWithUID(
-                          this.vm.selectUID,
+                          this.vm.selectUID
                         );
                         if (subscriber?.orgData?.vercode) {
                           vercode = subscriber?.orgData?.vercode;
@@ -3023,7 +3178,7 @@ export class Conversation
                       WKApp.shared.baseContext.showUserInfo(
                         this.vm.selectUID,
                         fromChannel,
-                        vercode,
+                        vercode
                       );
                     },
                   },
@@ -3116,7 +3271,7 @@ class ConversationPositionView extends Component<
                   <div
                     className={classNames(
                       "wk-conversationpositionview-item",
-                      "wk-reveale",
+                      "wk-reveale"
                     )}
                     onClick={async () => {
                       if (onReminder) {
@@ -3156,7 +3311,7 @@ class ConversationPositionView extends Component<
             <div
               className={classNames(
                 "wk-conversationpositionview-item",
-                showScrollToBottom ? "wk-reveale" : undefined,
+                showScrollToBottom ? "wk-reveale" : undefined
               )}
               onClick={async () => {
                 if (onScrollToBottom) {
@@ -3199,7 +3354,7 @@ class ReplyView extends Component<ReplyViewProps> {
   render(): React.ReactNode {
     const { message, onClose, vm } = this.props;
     const fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
-      new Channel(message.fromUID, ChannelTypePerson),
+      new Channel(message.fromUID, ChannelTypePerson)
     );
     const isEdit = vm.currentHandlerType === 2;
     const label = isEdit

--- a/packages/dmworkbase/src/Components/Conversation/richTextMixedSend.ts
+++ b/packages/dmworkbase/src/Components/Conversation/richTextMixedSend.ts
@@ -1,0 +1,74 @@
+export type RichTextMixedEditorBlock =
+  | { type: "text"; text: string; mention?: unknown }
+  | { type: "image"; id: string; file: File }
+  | { type: "file"; id: string; file: File };
+
+export interface RichTextMixedAttachment {
+  id: string;
+  file: File;
+}
+
+export interface RichTextMixedCandidate {
+  blocks: RichTextMixedEditorBlock[];
+  topImageIds: string[];
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+]);
+
+export function isImageFileForRichTextMixed(file: Pick<File, "type" | "name">) {
+  if (file.type?.startsWith("image/")) return true;
+  const ext = file.name.split(".").pop()?.toLowerCase() || "";
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Decide whether the current compose payload should become one RichText(=14)
+ * message. Upload-button images live in the top attachment area, while pasted
+ * images live inside editorBlocks; both must count as image blocks.
+ */
+export function buildRichTextMixedCandidate(
+  topFiles: RichTextMixedAttachment[],
+  editorBlocks?: RichTextMixedEditorBlock[]
+): RichTextMixedCandidate | null {
+  const blocks = editorBlocks || [];
+  if (blocks.length === 0) return null;
+
+  const topImages = topFiles.filter(({ file }) =>
+    isImageFileForRichTextMixed(file)
+  );
+  const hasTopNonImage = topImages.length !== topFiles.length;
+  if (hasTopNonImage) return null;
+
+  const hasText = blocks.some(
+    (block) => block.type === "text" && block.text.trim() !== ""
+  );
+  const hasEditorImage = blocks.some((block) => block.type === "image");
+  const hasEditorFile = blocks.some((block) => block.type === "file");
+  if (
+    !hasText ||
+    hasEditorFile ||
+    (!hasEditorImage && topImages.length === 0)
+  ) {
+    return null;
+  }
+
+  return {
+    blocks: [
+      ...topImages.map<RichTextMixedEditorBlock>(({ id, file }) => ({
+        type: "image",
+        id,
+        file,
+      })),
+      ...blocks,
+    ],
+    topImageIds: topImages.map(({ id }) => id),
+  };
+}

--- a/packages/dmworkbase/src/Components/FileToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/FileToolbar/index.tsx
@@ -25,6 +25,7 @@ export default class FileToolbar extends Component<FileToolbarProps> {
     // 通过比较焦点所在的 .wk-messageinput-box 和当前 toolbar 所在的 .wk-messageinput-box
     // 确保只有焦点所在的输入框响应粘贴，避免重复上传。
     this.pasteListen = (event: ClipboardEvent) => {
+      if (event.defaultPrevented) return;
       const activeBox = document.activeElement?.closest?.(
         ".wk-messageinput-box"
       );

--- a/packages/dmworkbase/src/Components/ImageToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/ImageToolbar/index.tsx
@@ -24,6 +24,7 @@ export default class ImageToolbar extends Component<ImageToolbarProps> {
         // 通过比较焦点所在的 .wk-messageinput-box 和当前 toolbar 所在的 .wk-messageinput-box
         // 确保只有焦点所在的输入框响应粘贴，避免重复上传。
         this.pasteListen = (event: any) => {
+            if (event.defaultPrevented) return
             const activeBox = document.activeElement?.closest?.('.wk-messageinput-box')
             const myBox = this.containerRef.current?.closest?.('.wk-messageinput-box')
             if (!activeBox || !myBox || activeBox !== myBox) return

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -120,7 +120,7 @@ describe("richTextPaste", () => {
     expect(file?.type).toBe("image/png");
   });
 
-  it("keeps same-origin credentials for pasted images on same-origin deployments", async () => {
+  it("omits credentials for same-origin pasted images by default", async () => {
     const blob = new Blob(["image"], { type: "image/png" });
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -140,7 +140,7 @@ describe("richTextPaste", () => {
 
     expect(fetch).toHaveBeenCalledWith(url, {
       mode: "cors",
-      credentials: "same-origin",
+      credentials: "omit",
     });
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../App", () => ({
 import {
   buildInlineContentForRichTextPaste,
   imageBlockToPasteFile,
+  MAX_PASTE_IMAGE_BYTES,
   restoreOctoRichTextClipboardToEditor,
 } from "../richTextPaste";
 
@@ -44,6 +45,17 @@ function fakeEditor() {
         }),
       }),
     },
+  };
+}
+
+function mockImageResponse(blob: Blob, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    headers: new Headers({
+      "Content-Type": blob.type || "image/png",
+      ...headers,
+    }),
+    blob: vi.fn().mockResolvedValue(blob),
   };
 }
 
@@ -95,12 +107,32 @@ describe("richTextPaste", () => {
     ]);
   });
 
+  it("falls back to the image placeholder when the validated attachment path rejects the file", async () => {
+    const { editor, insertContent } = fakeEditor();
+    const imageFile = new File(["image"], "a.png", { type: "image/png" });
+    const addAttachment = vi.fn().mockResolvedValue(false);
+
+    await restoreOctoRichTextClipboardToEditor(
+      {
+        version: 1,
+        blocks: [{ type: "image", url: "https://cdn.example.com/a.png" }],
+      },
+      editor,
+      addAttachment,
+      {
+        imageBlockToFile: vi.fn().mockResolvedValue(imageFile),
+      }
+    );
+
+    expect(addAttachment).toHaveBeenCalledWith([imageFile], "paste");
+    expect(insertContent).toHaveBeenCalledWith([
+      { type: "text", text: "[图片]" },
+    ]);
+  });
+
   it("fetches pasted images without credentials for wildcard CORS CDNs", async () => {
     const blob = new Blob(["image"], { type: "image/png" });
-    const fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(blob),
-    });
+    const fetch = vi.fn().mockResolvedValue(mockImageResponse(blob));
     vi.stubGlobal("fetch", fetch);
 
     const file = await imageBlockToPasteFile(
@@ -122,10 +154,7 @@ describe("richTextPaste", () => {
 
   it("omits credentials for same-origin pasted images by default", async () => {
     const blob = new Blob(["image"], { type: "image/png" });
-    const fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(blob),
-    });
+    const fetch = vi.fn().mockResolvedValue(mockImageResponse(blob));
     vi.stubGlobal("fetch", fetch);
 
     const url = `${window.location.origin}/assets/a.png`;
@@ -142,5 +171,60 @@ describe("richTextPaste", () => {
       mode: "cors",
       credentials: "omit",
     });
+  });
+
+  it("rejects pasted images whose Content-Length exceeds the fetch cap", async () => {
+    const blob = new Blob(["image"], { type: "image/png" });
+    const response = mockImageResponse(blob, {
+      "Content-Length": String(MAX_PASTE_IMAGE_BYTES + 1),
+    });
+    const fetch = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetch);
+
+    const file = await imageBlockToPasteFile(
+      {
+        type: "image",
+        url: "https://cdn.example.com/huge.png",
+        name: "huge.png",
+      },
+      (url) => url
+    );
+
+    expect(file).toBeNull();
+    expect(response.blob).not.toHaveBeenCalled();
+  });
+
+  it("rejects pasted images whose blob size exceeds the fetch cap", async () => {
+    const blob = { size: MAX_PASTE_IMAGE_BYTES + 1, type: "image/png" } as Blob;
+    const fetch = vi.fn().mockResolvedValue(mockImageResponse(blob));
+    vi.stubGlobal("fetch", fetch);
+
+    const file = await imageBlockToPasteFile(
+      {
+        type: "image",
+        url: "https://cdn.example.com/huge.png",
+        name: "huge.png",
+      },
+      (url) => url
+    );
+
+    expect(file).toBeNull();
+  });
+
+  it("rejects fetched clipboard blobs that are not images", async () => {
+    const blob = new Blob(["html"], { type: "text/html" });
+    const fetch = vi.fn().mockResolvedValue(mockImageResponse(blob));
+    vi.stubGlobal("fetch", fetch);
+
+    const file = await imageBlockToPasteFile(
+      {
+        type: "image",
+        url: "https://cdn.example.com/not-image",
+        name: "not-image.html",
+      },
+      (url) => url
+    );
+
+    expect(file).toBeNull();
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("wukongimjssdk", () => ({
   MessageContent: class {
@@ -29,6 +29,7 @@ vi.mock("../../../App", () => ({
 
 import {
   buildInlineContentForRichTextPaste,
+  imageBlockToPasteFile,
   restoreOctoRichTextClipboardToEditor,
 } from "../richTextPaste";
 
@@ -47,6 +48,10 @@ function fakeEditor() {
 }
 
 describe("richTextPaste", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("builds inline content with mention nodes and hard breaks", () => {
     expect(
       buildInlineContentForRichTextPaste("hi @Alice\nnext", [
@@ -88,5 +93,30 @@ describe("richTextPaste", () => {
     expect(insertContent).toHaveBeenNthCalledWith(2, [
       { type: "text", text: "after" },
     ]);
+  });
+
+  it("fetches pasted images without credentials for wildcard CORS CDNs", async () => {
+    const blob = new Blob(["image"], { type: "image/png" });
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(blob),
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const file = await imageBlockToPasteFile(
+      {
+        type: "image",
+        url: "https://cdn.example.com/a.png",
+        name: "a.png",
+      },
+      (url) => url
+    );
+
+    expect(fetch).toHaveBeenCalledWith("https://cdn.example.com/a.png", {
+      mode: "cors",
+      credentials: "omit",
+    });
+    expect(file?.name).toBe("a.png");
+    expect(file?.type).toBe("image/png");
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -119,4 +119,28 @@ describe("richTextPaste", () => {
     expect(file?.name).toBe("a.png");
     expect(file?.type).toBe("image/png");
   });
+
+  it("keeps same-origin credentials for pasted images on same-origin deployments", async () => {
+    const blob = new Blob(["image"], { type: "image/png" });
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(blob),
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const url = `${window.location.origin}/assets/a.png`;
+    await imageBlockToPasteFile(
+      {
+        type: "image",
+        url,
+        name: "a.png",
+      },
+      (url) => url
+    );
+
+    expect(fetch).toHaveBeenCalledWith(url, {
+      mode: "cors",
+      credentials: "same-origin",
+    });
+  });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("wukongimjssdk", () => ({
+  MessageContent: class {
+    contentObj: any;
+    contentType!: number;
+  },
+}));
+
+vi.mock("../../../Service/Const", () => ({
+  MessageContentTypeConst: { richText: 14 },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: {
+      commonDataSource: {
+        getImageURL: (url: string) => url,
+      },
+    },
+  },
+}));
+
+import {
+  buildInlineContentForRichTextPaste,
+  restoreOctoRichTextClipboardToEditor,
+} from "../richTextPaste";
+
+function fakeEditor() {
+  const insertContent = vi.fn(() => ({ run: vi.fn() }));
+  return {
+    insertContent,
+    editor: {
+      chain: () => ({
+        focus: () => ({
+          insertContent,
+        }),
+      }),
+    },
+  };
+}
+
+describe("richTextPaste", () => {
+  it("builds inline content with mention nodes and hard breaks", () => {
+    expect(
+      buildInlineContentForRichTextPaste("hi @Alice\nnext", [
+        { uid: "alice", offset: 3, length: "@Alice".length },
+      ])
+    ).toEqual([
+      { type: "text", text: "hi " },
+      { type: "mention", attrs: { id: "alice", label: "Alice" } },
+      { type: "hardBreak" },
+      { type: "text", text: "next" },
+    ]);
+  });
+
+  it("restores text and image blocks through the existing pasted attachment path", async () => {
+    const { editor, insertContent } = fakeEditor();
+    const imageFile = new File(["image"], "a.png", { type: "image/png" });
+    const addAttachment = vi.fn().mockResolvedValue(undefined);
+
+    await restoreOctoRichTextClipboardToEditor(
+      {
+        version: 1,
+        blocks: [
+          { type: "text", text: "before" },
+          { type: "image", url: "https://cdn.example.com/a.png" },
+          { type: "text", text: "after" },
+        ],
+      },
+      editor,
+      addAttachment,
+      {
+        imageBlockToFile: vi.fn().mockResolvedValue(imageFile),
+      }
+    );
+
+    expect(insertContent).toHaveBeenNthCalledWith(1, [
+      { type: "text", text: "before" },
+    ]);
+    expect(addAttachment).toHaveBeenCalledWith([imageFile], "paste");
+    expect(insertContent).toHaveBeenNthCalledWith(2, [
+      { type: "text", text: "after" },
+    ]);
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -209,6 +209,10 @@ interface MessageInputProps {
   onAddAttachment?: (
     fnc: (files: File[], source?: "paste" | "upload") => void
   ) => void;
+  onAddPendingAttachments?: (
+    files: File[],
+    source?: "paste" | "upload"
+  ) => boolean | Promise<boolean>;
   hideMention?: boolean;
   toolbar?: JSX.Element;
   /** Extra action nodes rendered inside the actionbox, before voice input */
@@ -897,15 +901,22 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
 
       event.preventDefault();
       const beforePasteContent = JSON.stringify(editor.getJSON());
-      restoreOctoRichTextClipboardToEditor(payload, editor, addAttachment, {
-        imageBlockToFile: (block) =>
-          imageBlockToPasteFile(
-            block,
-            WKApp.dataSource.commonDataSource.getImageURL.bind(
-              WKApp.dataSource.commonDataSource
-            )
-          ),
-      }).catch(() => {
+      const addRichTextPasteAttachment =
+        props.onAddPendingAttachments || addAttachment;
+      restoreOctoRichTextClipboardToEditor(
+        payload,
+        editor,
+        addRichTextPasteAttachment,
+        {
+          imageBlockToFile: (block) =>
+            imageBlockToPasteFile(
+              block,
+              WKApp.dataSource.commonDataSource.getImageURL.bind(
+                WKApp.dataSource.commonDataSource
+              )
+            ),
+        }
+      ).catch(() => {
         if (
           payload.plain &&
           JSON.stringify(editor.getJSON()) === beforePasteContent
@@ -915,7 +926,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
       });
       return true;
     };
-  }, [addAttachment, editor]);
+  }, [addAttachment, editor, props.onAddPendingAttachments]);
 
   // 移除顶部附件区的附件
   const removeTopAttachment = useCallback((id: string) => {

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -34,6 +34,11 @@ import {
 } from "./AttachmentNode";
 import { t as translate, useI18n } from "../../i18n";
 import { runSendWithCleanup, SendResultDetail } from "./sendFlow";
+import { extractOctoRichTextClipboardPayloadFromHtml } from "../../Utils/richTextClipboard";
+import {
+  imageBlockToPasteFile,
+  restoreOctoRichTextClipboardToEditor,
+} from "./richTextPaste";
 
 const MAX_MESSAGE_LENGTH = 5000;
 
@@ -644,6 +649,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
   const editorHandleKeyDownRef = useRef<
     ((view: any, event: KeyboardEvent) => boolean) | null
   >(null);
+  const editorHandlePasteRef = useRef<
+    ((view: any, event: ClipboardEvent) => boolean) | null
+  >(null);
 
   // 更新模块级别的 membersRef
   membersRef = localMembersRef;
@@ -721,6 +729,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
       // ProseMirror 级别的键盘处理，在所有 keymap 之前执行
       handleKeyDown: (_view, event) => {
         return editorHandleKeyDownRef.current?.(_view, event) ?? false;
+      },
+      handlePaste: (_view, event) => {
+        return editorHandlePasteRef.current?.(_view, event) ?? false;
       },
     },
     onUpdate: ({ editor }) => {
@@ -875,6 +886,36 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     },
     [editor]
   );
+
+  useEffect(() => {
+    editorHandlePasteRef.current = (_view: any, event: ClipboardEvent) => {
+      if (!editor || !event.clipboardData) return false;
+      const payload = extractOctoRichTextClipboardPayloadFromHtml(
+        event.clipboardData.getData("text/html")
+      );
+      if (!payload) return false;
+
+      event.preventDefault();
+      const beforePasteContent = JSON.stringify(editor.getJSON());
+      restoreOctoRichTextClipboardToEditor(payload, editor, addAttachment, {
+        imageBlockToFile: (block) =>
+          imageBlockToPasteFile(
+            block,
+            WKApp.dataSource.commonDataSource.getImageURL.bind(
+              WKApp.dataSource.commonDataSource
+            )
+          ),
+      }).catch(() => {
+        if (
+          payload.plain &&
+          JSON.stringify(editor.getJSON()) === beforePasteContent
+        ) {
+          editor.commands.insertContent(payload.plain);
+        }
+      });
+      return true;
+    };
+  }, [addAttachment, editor]);
 
   // 移除顶部附件区的附件
   const removeTopAttachment = useCallback((id: string) => {

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -19,11 +19,16 @@ type EditorLike = {
   };
 };
 
-type AddAttachment = (files: File[], source: "paste") => void | Promise<void>;
+type AddAttachment = (
+  files: File[],
+  source: "paste"
+) => boolean | void | Promise<boolean | void>;
 type GetImageUrl = (
   url: string,
   opts?: { width: number; height: number }
 ) => string;
+
+export const MAX_PASTE_IMAGE_BYTES = 20 * 1024 * 1024;
 
 export interface RestoreOctoRichTextPasteDeps {
   imageBlockToFile?: (
@@ -93,6 +98,57 @@ function safeImageFileName(name?: string, mime?: string): string {
   return raw || fallback;
 }
 
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const size = Number(value);
+  return Number.isFinite(size) && size >= 0 ? size : null;
+}
+
+function normalizeMime(value: string | null | undefined): string {
+  return (value || "").split(";")[0].trim().toLowerCase();
+}
+
+async function responseToCappedImageBlob(
+  response: Response
+): Promise<Blob | null> {
+  const contentLength = parseContentLength(
+    response.headers.get("Content-Length")
+  );
+  if (contentLength !== null && contentLength > MAX_PASTE_IMAGE_BYTES) {
+    return null;
+  }
+
+  const contentType = normalizeMime(response.headers.get("Content-Type"));
+
+  if (response.body?.getReader) {
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        received += value.byteLength;
+        if (received > MAX_PASTE_IMAGE_BYTES) {
+          await reader.cancel();
+          return null;
+        }
+        chunks.push(value);
+      }
+    } catch {
+      return null;
+    }
+    return new Blob(chunks, { type: contentType });
+  }
+
+  const blob = await response.blob();
+  if (blob.size > MAX_PASTE_IMAGE_BYTES) {
+    return null;
+  }
+  return blob;
+}
+
 export async function imageBlockToPasteFile(
   block: Extract<OctoRichTextClipboardBlock, { type: "image" }>,
   getImageURL: GetImageUrl
@@ -112,8 +168,12 @@ export async function imageBlockToPasteFile(
       credentials: "omit",
     });
     if (!response.ok) return null;
-    const blob = await response.blob();
-    const type = blob.type || block.mime || "image/png";
+    const blob = await responseToCappedImageBlob(response);
+    if (!blob) return null;
+    const type = normalizeMime(
+      blob.type || response.headers.get("Content-Type")
+    );
+    if (!type.startsWith("image/")) return null;
     return new File([blob], safeImageFileName(block.name, type), {
       type,
       lastModified: Date.now(),
@@ -144,7 +204,11 @@ export async function restoreOctoRichTextClipboardToEditor(
     if (block.type === "image") {
       const file = await resolveImageFile(block);
       if (file) {
-        await addAttachment([file], "paste");
+        const accepted = await addAttachment([file], "paste");
+        if (accepted !== false) continue;
+        insertInlineContent(editor, [
+          { type: "text", text: RichTextImagePlaceholder },
+        ]);
       } else {
         insertInlineContent(editor, [
           { type: "text", text: RichTextImagePlaceholder },

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -93,17 +93,6 @@ function safeImageFileName(name?: string, mime?: string): string {
   return raw || fallback;
 }
 
-function getPasteImageFetchCredentials(src: string): RequestCredentials {
-  if (typeof window === "undefined") return "omit";
-  try {
-    return new URL(src, window.location.href).origin === window.location.origin
-      ? "same-origin"
-      : "omit";
-  } catch {
-    return "omit";
-  }
-}
-
 export async function imageBlockToPasteFile(
   block: Extract<OctoRichTextClipboardBlock, { type: "image" }>,
   getImageURL: GetImageUrl
@@ -117,7 +106,10 @@ export async function imageBlockToPasteFile(
   try {
     const response = await fetch(src, {
       mode: "cors",
-      credentials: getPasteImageFetchCredentials(src),
+      // Clipboard payloads are user-controlled HTML. Do not attach cookies when
+      // fetching image blocks; add an explicit allowlist if private same-origin
+      // image endpoints need to be restored in the future.
+      credentials: "omit",
     });
     if (!response.ok) return null;
     const blob = await response.blob();

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -106,7 +106,7 @@ export async function imageBlockToPasteFile(
   try {
     const response = await fetch(src, {
       mode: "cors",
-      credentials: "include",
+      credentials: "omit",
     });
     if (!response.ok) return null;
     const blob = await response.blob();

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -1,0 +1,160 @@
+import {
+  RichTextFilePlaceholder,
+  RichTextImagePlaceholder,
+} from "../../Messages/RichText/RichTextContent";
+import type {
+  OctoRichTextClipboardBlock,
+  OctoRichTextClipboardMention,
+  OctoRichTextClipboardPayload,
+} from "../../Utils/richTextClipboard";
+import { isSafeUrl } from "../../Utils/security";
+
+type EditorLike = {
+  chain: () => {
+    focus: () => {
+      insertContent: (content: any) => {
+        run: () => void;
+      };
+    };
+  };
+};
+
+type AddAttachment = (files: File[], source: "paste") => void | Promise<void>;
+type GetImageUrl = (
+  url: string,
+  opts?: { width: number; height: number }
+) => string;
+
+export interface RestoreOctoRichTextPasteDeps {
+  imageBlockToFile?: (
+    block: Extract<OctoRichTextClipboardBlock, { type: "image" }>
+  ) => Promise<File | null>;
+}
+
+function appendPlainText(nodes: any[], text: string) {
+  if (!text) return;
+  const lines = text.split("\n");
+  lines.forEach((line, index) => {
+    if (line) {
+      nodes.push({ type: "text", text: line });
+    }
+    if (index < lines.length - 1) {
+      nodes.push({ type: "hardBreak" });
+    }
+  });
+}
+
+export function buildInlineContentForRichTextPaste(
+  text: string,
+  mentions?: OctoRichTextClipboardMention[]
+): any[] {
+  const nodes: any[] = [];
+  const sortedMentions = (mentions || [])
+    .filter(
+      (mention) =>
+        mention.offset >= 0 &&
+        mention.length > 0 &&
+        mention.offset + mention.length <= text.length
+    )
+    .sort((a, b) => a.offset - b.offset);
+
+  let cursor = 0;
+  for (const mention of sortedMentions) {
+    if (mention.offset < cursor) continue;
+    appendPlainText(nodes, text.slice(cursor, mention.offset));
+    const name = text.slice(mention.offset, mention.offset + mention.length);
+    if (name.startsWith("@")) {
+      nodes.push({
+        type: "mention",
+        attrs: {
+          id: mention.uid,
+          label: name.slice(1),
+        },
+      });
+    } else {
+      appendPlainText(nodes, name);
+    }
+    cursor = mention.offset + mention.length;
+  }
+
+  appendPlainText(nodes, text.slice(cursor));
+  return nodes;
+}
+
+function insertInlineContent(editor: EditorLike, content: any[]) {
+  if (content.length === 0) return;
+  editor.chain().focus().insertContent(content).run();
+}
+
+function safeImageFileName(name?: string, mime?: string): string {
+  const fallbackExt = mime?.split("/").pop() || "png";
+  const fallback = `image.${fallbackExt}`;
+  const raw = (name || fallback).replace(/[\\/:*?"<>|]+/g, "_").slice(0, 120);
+  return raw || fallback;
+}
+
+export async function imageBlockToPasteFile(
+  block: Extract<OctoRichTextClipboardBlock, { type: "image" }>,
+  getImageURL: GetImageUrl
+): Promise<File | null> {
+  const src = getImageURL(block.url, {
+    width: block.width || 0,
+    height: block.height || 0,
+  });
+  if (!isSafeUrl(src)) return null;
+
+  try {
+    const response = await fetch(src, {
+      mode: "cors",
+      credentials: "include",
+    });
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    const type = blob.type || block.mime || "image/png";
+    return new File([blob], safeImageFileName(block.name, type), {
+      type,
+      lastModified: Date.now(),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function restoreOctoRichTextClipboardToEditor(
+  payload: OctoRichTextClipboardPayload,
+  editor: EditorLike,
+  addAttachment: AddAttachment,
+  deps: RestoreOctoRichTextPasteDeps = {}
+): Promise<void> {
+  const resolveImageFile =
+    deps.imageBlockToFile || (() => Promise.resolve(null));
+
+  for (const block of payload.blocks) {
+    if (block.type === "text") {
+      insertInlineContent(
+        editor,
+        buildInlineContentForRichTextPaste(block.text, block.mentions)
+      );
+      continue;
+    }
+
+    if (block.type === "image") {
+      const file = await resolveImageFile(block);
+      if (file) {
+        await addAttachment([file], "paste");
+      } else {
+        insertInlineContent(editor, [
+          { type: "text", text: RichTextImagePlaceholder },
+        ]);
+      }
+      continue;
+    }
+
+    if (block.type === "file") {
+      const label = block.name
+        ? `${RichTextFilePlaceholder} ${block.name}`
+        : RichTextFilePlaceholder;
+      insertInlineContent(editor, [{ type: "text", text: label }]);
+    }
+  }
+}

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -93,6 +93,17 @@ function safeImageFileName(name?: string, mime?: string): string {
   return raw || fallback;
 }
 
+function getPasteImageFetchCredentials(src: string): RequestCredentials {
+  if (typeof window === "undefined") return "omit";
+  try {
+    return new URL(src, window.location.href).origin === window.location.origin
+      ? "same-origin"
+      : "omit";
+  } catch {
+    return "omit";
+  }
+}
+
 export async function imageBlockToPasteFile(
   block: Extract<OctoRichTextClipboardBlock, { type: "image" }>,
   getImageURL: GetImageUrl
@@ -106,7 +117,7 @@ export async function imageBlockToPasteFile(
   try {
     const response = await fetch(src, {
       mode: "cors",
-      credentials: "omit",
+      credentials: getPasteImageFetchCredentials(src),
     });
     if (!response.ok) return null;
     const blob = await response.blob();

--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -68,6 +68,7 @@ export class RichTextCell extends MessageCell {
           )}
           <MixedContent
             {...uiProps.content}
+            onMentionClick={(uid) => context.showUser(uid)}
             onFileDownload={(block) => {
               if (block.url) {
                 downloadFile(block.url, block.name);

--- a/packages/dmworkbase/src/Service/EmojiService.ts
+++ b/packages/dmworkbase/src/Service/EmojiService.ts
@@ -13,6 +13,7 @@ export class Emoji {
 export interface EmojiService {
     getImage(name: string): string
     getAllEmoji(): Array<Emoji>
+    emojiRegExp(): RegExp
 }
 
 export class DefaultEmojiService implements EmojiService {

--- a/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
@@ -6,7 +6,10 @@ import {
   RichTextContent,
   RichTextImagePlaceholder,
 } from "../../Messages/RichText/RichTextContent";
-import { extractOctoRichTextClipboardPayloadFromHtml } from "../richTextClipboard";
+import {
+  encodeOctoRichTextClipboardPayload,
+  extractOctoRichTextClipboardPayloadFromHtml,
+} from "../richTextClipboard";
 
 vi.mock("wukongimjssdk", () => ({
   MessageContent: class {
@@ -165,5 +168,42 @@ describe("copyRichTextToClipboard", () => {
       },
       { type: "text", text: "after" },
     ]);
+  });
+
+  it("extracts the marker without parsing clipboard html as DOM", () => {
+    const encoded = encodeOctoRichTextClipboardPayload({
+      version: 1,
+      blocks: [{ type: "text", text: "safe" }],
+      plain: "safe",
+    });
+    const originalDOMParser = (globalThis as any).DOMParser;
+    Object.defineProperty(globalThis, "DOMParser", {
+      configurable: true,
+      value: class {
+        parseFromString() {
+          throw new Error("should not parse clipboard html");
+        }
+      },
+    });
+
+    try {
+      const payload = extractOctoRichTextClipboardPayloadFromHtml(
+        `<img src=x onerror=alert(1)><span data-octo-richtext="${encoded}"></span>`
+      );
+      expect(payload?.blocks).toEqual([{ type: "text", text: "safe" }]);
+    } finally {
+      Object.defineProperty(globalThis, "DOMParser", {
+        configurable: true,
+        value: originalDOMParser,
+      });
+    }
+  });
+
+  it("rejects non-base64url marker attributes", () => {
+    expect(
+      extractOctoRichTextClipboardPayloadFromHtml(
+        `<span data-octo-richtext="<img src=x onerror=alert(1)>"></span>`
+      )
+    ).toBeNull();
   });
 });

--- a/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
@@ -43,6 +43,7 @@ class MockClipboardItem {
 describe("copyRichTextToClipboard", () => {
   beforeEach(() => {
     (globalThis as any).ClipboardItem = MockClipboardItem;
+    (document as any).execCommand = undefined;
   });
 
   it("writes text/html plus text/plain so images survive rich paste", async () => {
@@ -102,5 +103,67 @@ describe("copyRichTextToClipboard", () => {
     await expect(item.items["text/plain"].text()).resolves.toBe(
       "看图：[图片] @Alice"
     );
+  });
+
+  it("falls back to execCommand with text/html when ClipboardItem write fails", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+
+    const copied: Record<string, string> = {};
+    (document as any).execCommand = vi.fn((command: string) => {
+      if (command !== "copy") return false;
+      const event = new Event("copy", {
+        bubbles: true,
+        cancelable: true,
+      }) as ClipboardEvent;
+      Object.defineProperty(event, "clipboardData", {
+        value: {
+          setData: (type: string, value: string) => {
+            copied[type] = value;
+          },
+        },
+      });
+      document.dispatchEvent(event);
+      return true;
+    });
+
+    const content = new RichTextContent();
+    content.content = [
+      { type: "text", text: "before" },
+      {
+        type: "image",
+        url: "https://cdn.example.com/a.png",
+        width: 10,
+        height: 20,
+        name: "a.png",
+      },
+      { type: "text", text: "after" },
+    ];
+    content.plain = "before[图片]after";
+
+    await expect(copyRichTextToClipboard(content)).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalled();
+    expect(copied["text/html"]).toContain("data-octo-richtext");
+    expect(copied["text/html"]).toContain(
+      '<img src="https://cdn.example.com/a.png" alt="a.png" />'
+    );
+    expect(copied["text/plain"]).toBe("before[图片]after");
+    expect(
+      extractOctoRichTextClipboardPayloadFromHtml(copied["text/html"])?.blocks
+    ).toEqual([
+      { type: "text", text: "before" },
+      {
+        type: "image",
+        url: "https://cdn.example.com/a.png",
+        width: 10,
+        height: 20,
+        name: "a.png",
+      },
+      { type: "text", text: "after" },
+    ]);
   });
 });

--- a/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
@@ -2,7 +2,11 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { copyRichTextToClipboard } from "../clipboard";
-import { RichTextContent } from "../../Messages/RichText/RichTextContent";
+import {
+  RichTextContent,
+  RichTextImagePlaceholder,
+} from "../../Messages/RichText/RichTextContent";
+import { extractOctoRichTextClipboardPayloadFromHtml } from "../richTextClipboard";
 
 vi.mock("wukongimjssdk", () => ({
   MessageContent: class {
@@ -61,6 +65,15 @@ describe("copyRichTextToClipboard", () => {
       { type: "text", text: " @Alice" },
     ];
     content.plain = "看图：[图片] @Alice";
+    (content as any).mention = {
+      entities: [
+        {
+          uid: "alice",
+          offset: "看图：".length + RichTextImagePlaceholder.length + 1,
+          length: "@Alice".length,
+        },
+      ],
+    };
 
     await expect(copyRichTextToClipboard(content)).resolves.toBe(true);
 
@@ -69,6 +82,23 @@ describe("copyRichTextToClipboard", () => {
     await expect(item.items["text/html"].text()).resolves.toContain(
       '<img src="https://cdn.example.com/a.png" alt="a.png" />'
     );
+    const html = await item.items["text/html"].text();
+    const payload = extractOctoRichTextClipboardPayloadFromHtml(html);
+    expect(payload?.blocks).toEqual([
+      { type: "text", text: "看图：" },
+      {
+        type: "image",
+        url: "https://cdn.example.com/a.png",
+        width: 10,
+        height: 20,
+        name: "a.png",
+      },
+      {
+        type: "text",
+        text: " @Alice",
+        mentions: [{ uid: "alice", offset: 1, length: "@Alice".length }],
+      },
+    ]);
     await expect(item.items["text/plain"].text()).resolves.toBe(
       "看图：[图片] @Alice"
     );

--- a/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { copyRichTextToClipboard } from "../clipboard";
+import { RichTextContent } from "../../Messages/RichText/RichTextContent";
+
+vi.mock("wukongimjssdk", () => ({
+  MessageContent: class {
+    contentObj: any;
+    contentType!: number;
+  },
+}));
+
+vi.mock("../../Service/Const", () => ({
+  MessageContentTypeConst: { richText: 14 },
+}));
+
+vi.mock("../../i18n", () => ({
+  t: () => "",
+}));
+
+vi.mock("../../App", () => ({
+  default: {
+    dataSource: {
+      commonDataSource: {
+        getImageURL: (url: string) => url,
+      },
+    },
+  },
+}));
+
+class MockClipboardItem {
+  items: Record<string, Blob>;
+  constructor(items: Record<string, Blob>) {
+    this.items = items;
+  }
+}
+
+describe("copyRichTextToClipboard", () => {
+  beforeEach(() => {
+    (globalThis as any).ClipboardItem = MockClipboardItem;
+  });
+
+  it("writes text/html plus text/plain so images survive rich paste", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+
+    const content = new RichTextContent();
+    content.content = [
+      { type: "text", text: "看图：" },
+      {
+        type: "image",
+        url: "https://cdn.example.com/a.png",
+        width: 10,
+        height: 20,
+        name: "a.png",
+      },
+      { type: "text", text: " @Alice" },
+    ];
+    content.plain = "看图：[图片] @Alice";
+
+    await expect(copyRichTextToClipboard(content)).resolves.toBe(true);
+
+    const item = write.mock.calls[0][0][0] as MockClipboardItem;
+    expect(Object.keys(item.items).sort()).toEqual(["text/html", "text/plain"]);
+    await expect(item.items["text/html"].text()).resolves.toContain(
+      '<img src="https://cdn.example.com/a.png" alt="a.png" />'
+    );
+    await expect(item.items["text/plain"].text()).resolves.toBe(
+      "看图：[图片] @Alice"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Utils/clipboard.ts
+++ b/packages/dmworkbase/src/Utils/clipboard.ts
@@ -79,16 +79,72 @@ function buildRichTextHtml(content: RichTextContent): string {
   return `<div ${OCTO_RICHTEXT_CLIPBOARD_ATTR}="${payload}">${body}</div>`;
 }
 
+function copyHtmlToClipboard(html: string, plain: string): boolean {
+  if (
+    typeof document === "undefined" ||
+    typeof document.execCommand !== "function"
+  ) {
+    return false;
+  }
+
+  let container: HTMLDivElement | null = null;
+  const selection =
+    typeof window !== "undefined" ? window.getSelection?.() : null;
+  const previousRanges: Range[] = [];
+  if (selection) {
+    for (let i = 0; i < selection.rangeCount; i += 1) {
+      previousRanges.push(selection.getRangeAt(i).cloneRange());
+    }
+  }
+
+  const handleCopy = (event: ClipboardEvent) => {
+    if (!event.clipboardData) return;
+    event.preventDefault();
+    event.clipboardData.setData("text/html", html);
+    event.clipboardData.setData("text/plain", plain);
+  };
+
+  try {
+    container = document.createElement("div");
+    container.setAttribute("aria-hidden", "true");
+    container.style.position = "fixed";
+    container.style.top = "0";
+    container.style.left = "0";
+    container.style.opacity = "0";
+    container.style.pointerEvents = "none";
+    container.contentEditable = "true";
+    container.innerHTML = html;
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.selectNodeContents(container);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    document.addEventListener("copy", handleCopy);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.removeEventListener("copy", handleCopy);
+    selection?.removeAllRanges();
+    previousRanges.forEach((range) => selection?.addRange(range));
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  }
+}
+
 export async function copyRichTextToClipboard(
   content: RichTextContent
 ): Promise<boolean> {
   const plain = content.plain || buildRichTextPlain(content.content || []);
+  const html = buildRichTextHtml(content);
   const canWriteRich =
     !!navigator.clipboard?.write && typeof ClipboardItem !== "undefined";
 
   if (canWriteRich) {
     try {
-      const html = buildRichTextHtml(content);
       await navigator.clipboard.write([
         new ClipboardItem({
           "text/html": new Blob([html], { type: "text/html" }),
@@ -99,6 +155,10 @@ export async function copyRichTextToClipboard(
     } catch {
       // fall through to plain-text fallback
     }
+  }
+
+  if (copyHtmlToClipboard(html, plain)) {
+    return true;
   }
 
   return copyToClipboard(plain);

--- a/packages/dmworkbase/src/Utils/clipboard.ts
+++ b/packages/dmworkbase/src/Utils/clipboard.ts
@@ -1,4 +1,13 @@
 import { t } from "../i18n";
+import WKApp from "../App";
+import {
+  buildRichTextPlain,
+  RichTextBlockType,
+  RichTextContent,
+  RichTextFilePlaceholder,
+  RichTextImagePlaceholder,
+} from "../Messages/RichText/RichTextContent";
+import { isSafeUrl } from "./security";
 
 /**
  * 复制图片到剪贴板。
@@ -11,108 +20,184 @@ import { t } from "../i18n";
  * 5. 不支持时抛出带用户可读文案的 Error，调用方负责 Toast 展示
  */
 export async function copyImageToClipboard(src: string): Promise<void> {
-    if (!navigator.clipboard?.write) {
-        throw new Error(t('base.clipboard.imageUnsupported'))
-    }
+  if (!navigator.clipboard?.write) {
+    throw new Error(t("base.clipboard.imageUnsupported"));
+  }
 
-    const pngBlob = await loadImageAndConvertToPng(src)
-    await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': pngBlob })
-    ])
+  const pngBlob = await loadImageAndConvertToPng(src);
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": pngBlob }),
+  ]);
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function richTextBlockToHtml(
+  block: RichTextContent["content"][number]
+): string {
+  if (block.type === RichTextBlockType.image) {
+    if (!block.url) return escapeHtml(RichTextImagePlaceholder);
+    const src = WKApp.dataSource.commonDataSource.getImageURL(block.url, {
+      width: block.width || 0,
+      height: block.height || 0,
+    });
+    if (!isSafeUrl(src)) {
+      return escapeHtml(RichTextImagePlaceholder);
+    }
+    const alt = escapeHtml(block.name || RichTextImagePlaceholder);
+    return `<img src="${escapeHtml(src)}" alt="${alt}" />`;
+  }
+
+  if (block.type === RichTextBlockType.file) {
+    const label = block.name
+      ? `${RichTextFilePlaceholder} ${block.name}`
+      : RichTextFilePlaceholder;
+    return escapeHtml(label);
+  }
+
+  return escapeHtml(block.text || "").replace(/\n/g, "<br>");
+}
+
+function buildRichTextHtml(content: RichTextContent): string {
+  const blocks = content.content || [];
+  const body = blocks.map(richTextBlockToHtml).join("");
+  return `<div>${body}</div>`;
+}
+
+export async function copyRichTextToClipboard(
+  content: RichTextContent
+): Promise<boolean> {
+  const plain = content.plain || buildRichTextPlain(content.content || []);
+  const canWriteRich =
+    !!navigator.clipboard?.write && typeof ClipboardItem !== "undefined";
+
+  if (canWriteRich) {
+    try {
+      const html = buildRichTextHtml(content);
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([html], { type: "text/html" }),
+          "text/plain": new Blob([plain], { type: "text/plain" }),
+        }),
+      ]);
+      return true;
+    } catch {
+      // fall through to plain-text fallback
+    }
+  }
+
+  return copyToClipboard(plain);
 }
 
 /** 将已加载的 HTMLImageElement 绘制到 canvas 并转为 PNG Blob。
  *  超过 16MP 时等比缩放，避免内存峰值。
  */
 function drawImageToBlob(img: HTMLImageElement): Promise<Blob> {
-    const MAX_PIXELS = 16 * 1024 * 1024
-    const naturalPixels = img.naturalWidth * img.naturalHeight
-    let drawWidth = img.naturalWidth
-    let drawHeight = img.naturalHeight
-    if (naturalPixels > MAX_PIXELS) {
-        const scale = Math.sqrt(MAX_PIXELS / naturalPixels)
-        drawWidth = Math.floor(img.naturalWidth * scale)
-        drawHeight = Math.floor(img.naturalHeight * scale)
-    }
-    const canvas = document.createElement('canvas')
-    canvas.width = drawWidth
-    canvas.height = drawHeight
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return Promise.reject(new Error(t('base.clipboard.canvasUnavailable')))
-    ctx.drawImage(img, 0, 0, drawWidth, drawHeight)
-    return new Promise((resolve, reject) => {
-        canvas.toBlob(b => b ? resolve(b) : reject(new Error(t('base.clipboard.imageConvertFailed'))), 'image/png')
-    })
+  const MAX_PIXELS = 16 * 1024 * 1024;
+  const naturalPixels = img.naturalWidth * img.naturalHeight;
+  let drawWidth = img.naturalWidth;
+  let drawHeight = img.naturalHeight;
+  if (naturalPixels > MAX_PIXELS) {
+    const scale = Math.sqrt(MAX_PIXELS / naturalPixels);
+    drawWidth = Math.floor(img.naturalWidth * scale);
+    drawHeight = Math.floor(img.naturalHeight * scale);
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = drawWidth;
+  canvas.height = drawHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx)
+    return Promise.reject(new Error(t("base.clipboard.canvasUnavailable")));
+  ctx.drawImage(img, 0, 0, drawWidth, drawHeight);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) =>
+        b
+          ? resolve(b)
+          : reject(new Error(t("base.clipboard.imageConvertFailed"))),
+      "image/png"
+    );
+  });
 }
 
 function loadImageAndConvertToPng(src: string): Promise<Blob> {
-    return new Promise((resolve, reject) => {
-        const img = new Image()
-        img.crossOrigin = 'anonymous'  // 避免 canvas 被污染（需服务端返回 CORS 头）
-        img.onload = () => drawImageToBlob(img).then(resolve).catch(reject)
-        img.onerror = () => {
-            // crossOrigin 加载失败时降级 fetch 重试（处理网络瞬时失败）
-            fallbackFetchAndConvert(src).then(resolve).catch(reject)
-        }
-        img.src = src
-    })
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous"; // 避免 canvas 被污染（需服务端返回 CORS 头）
+    img.onload = () => drawImageToBlob(img).then(resolve).catch(reject);
+    img.onerror = () => {
+      // crossOrigin 加载失败时降级 fetch 重试（处理网络瞬时失败）
+      fallbackFetchAndConvert(src).then(resolve).catch(reject);
+    };
+    img.src = src;
+  });
 }
 
 async function fallbackFetchAndConvert(src: string): Promise<Blob> {
-    const resp = await fetch(src, { mode: 'cors' })
-    if (!resp.ok) throw new Error(t('base.clipboard.imageLoadFailed'))
-    const blob = await resp.blob()
-    // fallback 路径需将文件全量 fetch 到内存，额外限制 5MB 防止内存峰值
-    // 主路径通过 <img> 加载无此限制（浏览器自行管理解码内存）
-    if (blob.size > 5 * 1024 * 1024) {
-        throw new Error(t('base.clipboard.imageTooLarge'))
-    }
-    return new Promise((resolve, reject) => {
-        const url = URL.createObjectURL(blob)
-        const img = new Image()
-        img.onload = () => {
-            URL.revokeObjectURL(url)
-            drawImageToBlob(img).then(resolve).catch(reject)
-        }
-        img.onerror = () => { URL.revokeObjectURL(url); reject(new Error(t('base.clipboard.imageDecodeFailed'))) }
-        img.src = url
-    })
+  const resp = await fetch(src, { mode: "cors" });
+  if (!resp.ok) throw new Error(t("base.clipboard.imageLoadFailed"));
+  const blob = await resp.blob();
+  // fallback 路径需将文件全量 fetch 到内存，额外限制 5MB 防止内存峰值
+  // 主路径通过 <img> 加载无此限制（浏览器自行管理解码内存）
+  if (blob.size > 5 * 1024 * 1024) {
+    throw new Error(t("base.clipboard.imageTooLarge"));
+  }
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      drawImageToBlob(img).then(resolve).catch(reject);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error(t("base.clipboard.imageDecodeFailed")));
+    };
+    img.src = url;
+  });
 }
 
 // 复制文本到剪贴板。优先使用 navigator.clipboard，不可用时降级到 textarea + execCommand("copy")，
 // 适配 iOS Safari、非 HTTPS 等不支持 Clipboard API 的环境。返回是否复制成功。
 export async function copyToClipboard(text: string): Promise<boolean> {
-    if (navigator.clipboard?.writeText) {
-        try {
-            await navigator.clipboard.writeText(text);
-            return true;
-        } catch {
-            // fall through to fallback
-        }
-    }
-
-    let textarea: HTMLTextAreaElement | null = null;
+  if (navigator.clipboard?.writeText) {
     try {
-        textarea = document.createElement("textarea");
-        textarea.value = text;
-        // iOS Safari 需要 readOnly + 非负 fontSize 才不会触发键盘和缩放
-        textarea.readOnly = true;
-        textarea.style.position = "fixed";
-        textarea.style.top = "0";
-        textarea.style.left = "0";
-        textarea.style.opacity = "0";
-        textarea.style.fontSize = "16px";
-        document.body.appendChild(textarea);
-        textarea.focus();
-        textarea.select();
-        // iOS Safari：select() 不一定生效，再调一次 setSelectionRange 兜底
-        textarea.setSelectionRange(0, text.length);
-        return document.execCommand("copy");
+      await navigator.clipboard.writeText(text);
+      return true;
     } catch {
-        return false;
-    } finally {
-        if (textarea && textarea.parentNode) {
-            textarea.parentNode.removeChild(textarea);
-        }
+      // fall through to fallback
     }
+  }
+
+  let textarea: HTMLTextAreaElement | null = null;
+  try {
+    textarea = document.createElement("textarea");
+    textarea.value = text;
+    // iOS Safari 需要 readOnly + 非负 fontSize 才不会触发键盘和缩放
+    textarea.readOnly = true;
+    textarea.style.position = "fixed";
+    textarea.style.top = "0";
+    textarea.style.left = "0";
+    textarea.style.opacity = "0";
+    textarea.style.fontSize = "16px";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    // iOS Safari：select() 不一定生效，再调一次 setSelectionRange 兜底
+    textarea.setSelectionRange(0, text.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    if (textarea && textarea.parentNode) {
+      textarea.parentNode.removeChild(textarea);
+    }
+  }
 }

--- a/packages/dmworkbase/src/Utils/clipboard.ts
+++ b/packages/dmworkbase/src/Utils/clipboard.ts
@@ -7,6 +7,11 @@ import {
   RichTextFilePlaceholder,
   RichTextImagePlaceholder,
 } from "../Messages/RichText/RichTextContent";
+import {
+  buildOctoRichTextClipboardPayload,
+  encodeOctoRichTextClipboardPayload,
+  OCTO_RICHTEXT_CLIPBOARD_ATTR,
+} from "./richTextClipboard";
 import { isSafeUrl } from "./security";
 
 /**
@@ -68,7 +73,10 @@ function richTextBlockToHtml(
 function buildRichTextHtml(content: RichTextContent): string {
   const blocks = content.content || [];
   const body = blocks.map(richTextBlockToHtml).join("");
-  return `<div>${body}</div>`;
+  const payload = encodeOctoRichTextClipboardPayload(
+    buildOctoRichTextClipboardPayload(content)
+  );
+  return `<div ${OCTO_RICHTEXT_CLIPBOARD_ATTR}="${payload}">${body}</div>`;
 }
 
 export async function copyRichTextToClipboard(

--- a/packages/dmworkbase/src/Utils/richTextClipboard.ts
+++ b/packages/dmworkbase/src/Utils/richTextClipboard.ts
@@ -282,12 +282,20 @@ export function decodeOctoRichTextClipboardPayload(
   }
 }
 
+const octoRichTextAttrPattern =
+  /(?:^|[\s<])data-octo-richtext\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i;
+const base64UrlPattern = /^[A-Za-z0-9_-]+$/;
+
+function extractOctoRichTextMarker(html: string): string {
+  const match = html.match(octoRichTextAttrPattern);
+  const encoded = match?.[1] || match?.[2] || match?.[3] || "";
+  if (!encoded || !base64UrlPattern.test(encoded)) return "";
+  return encoded;
+}
+
 export function extractOctoRichTextClipboardPayloadFromHtml(
   html: string
 ): OctoRichTextClipboardPayload | null {
-  if (!html || typeof DOMParser === "undefined") return null;
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const marker = doc.querySelector(`[${OCTO_RICHTEXT_CLIPBOARD_ATTR}]`);
-  const encoded = marker?.getAttribute(OCTO_RICHTEXT_CLIPBOARD_ATTR) || "";
-  return decodeOctoRichTextClipboardPayload(encoded);
+  if (!html) return null;
+  return decodeOctoRichTextClipboardPayload(extractOctoRichTextMarker(html));
 }

--- a/packages/dmworkbase/src/Utils/richTextClipboard.ts
+++ b/packages/dmworkbase/src/Utils/richTextClipboard.ts
@@ -1,0 +1,293 @@
+import {
+  RichTextBlock,
+  RichTextBlockType,
+  RichTextContent,
+  RichTextFilePlaceholder,
+  RichTextImagePlaceholder,
+} from "../Messages/RichText/RichTextContent";
+
+export const OCTO_RICHTEXT_CLIPBOARD_ATTR = "data-octo-richtext";
+
+export interface OctoRichTextClipboardMention {
+  uid: string;
+  offset: number;
+  length: number;
+}
+
+export type OctoRichTextClipboardBlock =
+  | {
+      type: "text";
+      text: string;
+      mentions?: OctoRichTextClipboardMention[];
+    }
+  | {
+      type: "image";
+      url: string;
+      width?: number;
+      height?: number;
+      size?: number;
+      name?: string;
+      mime?: string;
+    }
+  | {
+      type: "file";
+      name?: string;
+    };
+
+export interface OctoRichTextClipboardPayload {
+  version: 1;
+  blocks: OctoRichTextClipboardBlock[];
+  plain?: string;
+}
+
+interface RichTextMentionEntity {
+  uid: string;
+  offset: number;
+  length: number;
+}
+
+const MAX_BLOCKS = 100;
+const MAX_TEXT_LENGTH = 20_000;
+const MAX_IMAGES = 20;
+const MAX_IMAGE_URL_LENGTH = 4096;
+const MAX_ENCODED_PAYLOAD_LENGTH = 256_000;
+
+function getMentionEntities(content: RichTextContent): RichTextMentionEntity[] {
+  const mentionAny = (content as any).mention;
+  const contentObjMention = (content as any).contentObj?.mention;
+  const entities = Array.isArray(mentionAny?.entities)
+    ? mentionAny.entities
+    : Array.isArray(contentObjMention?.entities)
+    ? contentObjMention.entities
+    : [];
+
+  return entities.filter(
+    (entity: any): entity is RichTextMentionEntity =>
+      entity &&
+      typeof entity.uid === "string" &&
+      Number.isFinite(entity.offset) &&
+      Number.isFinite(entity.length) &&
+      entity.offset >= 0 &&
+      entity.length > 0
+  );
+}
+
+function getBlockPlainLength(block: RichTextBlock): number {
+  if (block.type === RichTextBlockType.image) {
+    return RichTextImagePlaceholder.length;
+  }
+  if (block.type === RichTextBlockType.file) {
+    return block.name
+      ? `${RichTextFilePlaceholder} ${block.name}`.length
+      : RichTextFilePlaceholder.length;
+  }
+  return (block.text || "").length;
+}
+
+function getTextBlockMentions(
+  text: string,
+  plainOffset: number,
+  entities: RichTextMentionEntity[]
+): OctoRichTextClipboardMention[] {
+  const end = plainOffset + text.length;
+  return entities
+    .filter(
+      (entity) =>
+        entity.offset >= plainOffset && entity.offset + entity.length <= end
+    )
+    .map((entity) => ({
+      uid: entity.uid,
+      offset: entity.offset - plainOffset,
+      length: entity.length,
+    }));
+}
+
+export function buildOctoRichTextClipboardPayload(
+  content: RichTextContent
+): OctoRichTextClipboardPayload {
+  const entities = getMentionEntities(content);
+  let plainOffset = 0;
+  const blocks: OctoRichTextClipboardBlock[] = [];
+
+  for (const block of content.content || []) {
+    if (blocks.length >= MAX_BLOCKS) break;
+
+    if (block.type === RichTextBlockType.image && block.url) {
+      blocks.push({
+        type: "image",
+        url: block.url,
+        width: block.width,
+        height: block.height,
+        size: block.size,
+        name: block.name,
+        mime: block.mime,
+      });
+      plainOffset += getBlockPlainLength(block);
+      continue;
+    }
+
+    if (block.type === RichTextBlockType.file) {
+      blocks.push({ type: "file", name: block.name });
+      plainOffset += getBlockPlainLength(block);
+      continue;
+    }
+
+    const text = block.text || "";
+    if (block.type === RichTextBlockType.text || text) {
+      const mentions = getTextBlockMentions(text, plainOffset, entities);
+      blocks.push({
+        type: "text",
+        text,
+        mentions: mentions.length > 0 ? mentions : undefined,
+      });
+    }
+    plainOffset += getBlockPlainLength(block);
+  }
+
+  return {
+    version: 1,
+    blocks,
+    plain: content.plain || undefined,
+  };
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "="
+  );
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export function encodeOctoRichTextClipboardPayload(
+  payload: OctoRichTextClipboardPayload
+): string {
+  return encodeBase64Url(JSON.stringify(payload));
+}
+
+function normalizeMention(
+  mention: any,
+  textLength: number
+): OctoRichTextClipboardMention | null {
+  if (
+    !mention ||
+    typeof mention.uid !== "string" ||
+    !Number.isFinite(mention.offset) ||
+    !Number.isFinite(mention.length)
+  ) {
+    return null;
+  }
+  const offset = Math.floor(mention.offset);
+  const length = Math.floor(mention.length);
+  if (offset < 0 || length <= 0 || offset + length > textLength) {
+    return null;
+  }
+  return { uid: mention.uid, offset, length };
+}
+
+function normalizePayload(raw: any): OctoRichTextClipboardPayload | null {
+  if (!raw || raw.version !== 1 || !Array.isArray(raw.blocks)) {
+    return null;
+  }
+
+  let totalTextLength = 0;
+  let imageCount = 0;
+  const blocks: OctoRichTextClipboardBlock[] = [];
+
+  for (const block of raw.blocks.slice(0, MAX_BLOCKS)) {
+    if (!block || typeof block.type !== "string") continue;
+
+    if (block.type === "text") {
+      const text = typeof block.text === "string" ? block.text : "";
+      if (!text) continue;
+      const remaining = MAX_TEXT_LENGTH - totalTextLength;
+      if (remaining <= 0) break;
+      const safeText = text.slice(0, remaining);
+      totalTextLength += safeText.length;
+      const mentions = Array.isArray(block.mentions)
+        ? block.mentions
+            .map((mention: any) => normalizeMention(mention, safeText.length))
+            .filter(
+              (
+                mention: OctoRichTextClipboardMention | null
+              ): mention is OctoRichTextClipboardMention => mention !== null
+            )
+        : [];
+      blocks.push({
+        type: "text",
+        text: safeText,
+        mentions: mentions.length > 0 ? mentions : undefined,
+      });
+      continue;
+    }
+
+    if (block.type === "image") {
+      if (imageCount >= MAX_IMAGES || typeof block.url !== "string") continue;
+      const url = block.url.slice(0, MAX_IMAGE_URL_LENGTH);
+      if (!url) continue;
+      imageCount += 1;
+      blocks.push({
+        type: "image",
+        url,
+        width: Number.isFinite(block.width) ? block.width : undefined,
+        height: Number.isFinite(block.height) ? block.height : undefined,
+        size: Number.isFinite(block.size) ? block.size : undefined,
+        name: typeof block.name === "string" ? block.name : undefined,
+        mime: typeof block.mime === "string" ? block.mime : undefined,
+      });
+      continue;
+    }
+
+    if (block.type === "file") {
+      blocks.push({
+        type: "file",
+        name: typeof block.name === "string" ? block.name : undefined,
+      });
+    }
+  }
+
+  return {
+    version: 1,
+    blocks,
+    plain: typeof raw.plain === "string" ? raw.plain : undefined,
+  };
+}
+
+export function decodeOctoRichTextClipboardPayload(
+  encoded: string
+): OctoRichTextClipboardPayload | null {
+  if (!encoded || encoded.length > MAX_ENCODED_PAYLOAD_LENGTH) return null;
+  try {
+    return normalizePayload(JSON.parse(decodeBase64Url(encoded)));
+  } catch {
+    return null;
+  }
+}
+
+export function extractOctoRichTextClipboardPayloadFromHtml(
+  html: string
+): OctoRichTextClipboardPayload | null {
+  if (!html || typeof DOMParser === "undefined") return null;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const marker = doc.querySelector(`[${OCTO_RICHTEXT_CLIPBOARD_ATTR}]`);
+  const encoded = marker?.getAttribute(OCTO_RICHTEXT_CLIPBOARD_ATTR) || "";
+  return decodeOctoRichTextClipboardPayload(encoded);
+}

--- a/packages/dmworkbase/src/bridge/message/__tests__/useRichTextMessageUI.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/useRichTextMessageUI.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { RichTextImagePlaceholder } from "../../../Messages/RichText/RichTextContent";
+import { getRichTextBlocksUI } from "../useRichTextMessageUI";
+
+vi.mock("wukongimjssdk", () => ({
+  MessageContent: class {
+    contentObj: any;
+    contentType!: number;
+  },
+}));
+
+vi.mock("../../../Service/Const", () => ({
+  MessageContentTypeConst: { richText: 14 },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: {
+      commonDataSource: {
+        getFileURL: (url: string) => url,
+        getImageURL: (url: string) => url,
+      },
+    },
+    emojiService: {
+      emojiRegExp: () => /\[OK\]/,
+      getImage: (key: string) => (key === "[OK]" ? "emoji://ok" : ""),
+    },
+  },
+}));
+
+vi.mock("../../../Messages/File", () => ({
+  formatFileSize: (bytes: number) => `${bytes} B`,
+  getExtension: (extension?: string, name?: string) =>
+    extension || name?.split(".").pop() || "",
+  getFileIconInfo: (extension: string) => ({
+    color: "#999",
+    label: extension.toUpperCase() || "FILE",
+  }),
+}));
+
+vi.mock("../useMessageRow", () => ({
+  getMessageRow: () => ({}),
+  useMessageRow: () => ({}),
+}));
+
+describe("getRichTextBlocksUI", () => {
+  it("maps global mention entity offsets back to individual text blocks", () => {
+    const firstText = "hi @Alice";
+    const secondText = " @Bob [OK]";
+    const secondOffset = firstText.length + RichTextImagePlaceholder.length;
+
+    const blocks = getRichTextBlocksUI(
+      [
+        { type: "text", text: firstText },
+        { type: "image", url: "https://x/a.png" },
+        { type: "text", text: secondText },
+      ],
+      {
+        entities: [
+          { uid: "alice", offset: 3, length: "@Alice".length },
+          { uid: "bob", offset: secondOffset + 1, length: "@Bob".length },
+        ],
+        syntheticMentions: [{ name: "@所有人", uid: "all" }],
+      }
+    );
+
+    expect(blocks[0]).toMatchObject({
+      type: "text",
+      mentions: [
+        { name: "@Alice", uid: "alice" },
+        { name: "@所有人", uid: "all" },
+      ],
+    });
+    expect(blocks[2]).toMatchObject({
+      type: "text",
+      mentions: [
+        { name: "@Bob", uid: "bob" },
+        { name: "@所有人", uid: "all" },
+      ],
+      emojis: [{ key: "[OK]", url: "emoji://ok" }],
+    });
+  });
+});

--- a/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useRichTextMessageUI.ts
@@ -1,11 +1,19 @@
 import { useMemo } from "react";
 import WKApp from "../../App";
 import type { MessageWrap } from "../../Service/Model";
-import { RichTextBlockType } from "../../Messages/RichText/RichTextContent";
+import {
+  RichTextBlockType,
+  RichTextFilePlaceholder,
+  RichTextImagePlaceholder,
+} from "../../Messages/RichText/RichTextContent";
 import type {
   RichTextBlock,
   RichTextContent,
 } from "../../Messages/RichText/RichTextContent";
+import type {
+  EmojiInfo,
+  MentionInfo,
+} from "../../Messages/Text/MarkdownContent";
 import {
   formatFileSize,
   getExtension,
@@ -13,6 +21,13 @@ import {
 } from "../../Messages/File";
 import { t } from "../../i18n";
 import { isSafeUrl } from "../../Utils/security";
+import {
+  buildMessageMentions,
+  MENTION_UID_AIS,
+  MENTION_UID_HUMANS,
+  MENTION_UID_LEGACY_ALL,
+  readMentionFlags,
+} from "../../Utils/mentionRender";
 import type {
   MixedContentBlock,
   MixedContentFileTone,
@@ -75,19 +90,127 @@ function getFileIconTone(extension: string): MixedContentFileTone {
   }
 }
 
+interface RichTextMentionEntity {
+  uid: string;
+  offset: number;
+  length: number;
+}
+
+interface RichTextTextRenderContext {
+  entities: RichTextMentionEntity[];
+  syntheticMentions: MentionInfo[];
+}
+
+function getRichTextMentionEntities(
+  content: RichTextContent
+): RichTextMentionEntity[] {
+  const mentionAny = (content as any).mention;
+  const contentObjMention = (content as any).contentObj?.mention;
+  const entities = Array.isArray(mentionAny?.entities)
+    ? mentionAny.entities
+    : Array.isArray(contentObjMention?.entities)
+    ? contentObjMention.entities
+    : [];
+  return entities.filter(
+    (entity: any): entity is RichTextMentionEntity =>
+      entity &&
+      typeof entity.uid === "string" &&
+      Number.isFinite(entity.offset) &&
+      Number.isFinite(entity.length) &&
+      entity.offset >= 0 &&
+      entity.length > 0
+  );
+}
+
+function getRichTextSyntheticMentions(content: RichTextContent): MentionInfo[] {
+  return buildMessageMentions(
+    [],
+    readMentionFlags(content),
+    -1
+  ) as MentionInfo[];
+}
+
+function getTextBlockMentions(
+  text: string,
+  plainOffset: number,
+  context?: RichTextTextRenderContext
+): MentionInfo[] {
+  if (!context) return [];
+  const end = plainOffset + text.length;
+  const entityMentions = context.entities
+    .filter(
+      (entity) =>
+        entity.offset >= plainOffset &&
+        entity.offset + entity.length <= end &&
+        entity.uid !== MENTION_UID_LEGACY_ALL &&
+        entity.uid !== MENTION_UID_HUMANS &&
+        entity.uid !== MENTION_UID_AIS
+    )
+    .map((entity) => {
+      const localOffset = entity.offset - plainOffset;
+      return {
+        name: text.slice(localOffset, localOffset + entity.length),
+        uid: entity.uid,
+      };
+    })
+    .filter((mention) => mention.name.startsWith("@"));
+
+  const mentions = [...entityMentions];
+  const seen = new Set(mentions.map((mention) => mention.name));
+  for (const synthetic of context.syntheticMentions) {
+    if (!seen.has(synthetic.name)) {
+      mentions.push(synthetic);
+      seen.add(synthetic.name);
+    }
+  }
+  return mentions;
+}
+
+function getTextBlockEmojis(text: string): EmojiInfo[] {
+  const emojis: EmojiInfo[] = [];
+  let rest = text;
+  while (rest.length > 0) {
+    const match = rest.match(WKApp.emojiService.emojiRegExp());
+    if (!match || match.index === undefined || match.index < 0) break;
+    const key = match[0];
+    const url = WKApp.emojiService.getImage(key);
+    if (url && !emojis.find((emoji) => emoji.key === key)) {
+      emojis.push({ key, url });
+    }
+    rest = rest.slice(match.index + key.length);
+  }
+  return emojis;
+}
+
+function getBlockPlainLength(block: RichTextBlock): number {
+  if (block.type === RichTextBlockType.image) {
+    return RichTextImagePlaceholder.length;
+  }
+  if (block.type === RichTextBlockType.file) {
+    return block.name
+      ? `${RichTextFilePlaceholder} ${block.name}`.length
+      : RichTextFilePlaceholder.length;
+  }
+  return (block.text || "").length;
+}
+
 export function getRichTextBlocksUI(
-  blocks: RichTextBlock[]
+  blocks: RichTextBlock[],
+  textContext?: RichTextTextRenderContext
 ): MixedContentBlock[] {
+  let plainOffset = 0;
   return blocks.reduce<MixedContentBlock[]>((acc, block, index) => {
     const id = `richtext-${index}`;
     if (block.type === RichTextBlockType.image) {
-      if (!block.url) return acc;
-      acc.push({
-        id,
-        type: "image",
-        src: block.url,
-        alt: block.name,
-      });
+      if (block.url) {
+        acc.push({
+          id,
+          type: "image",
+          src: block.url,
+          alt: block.name,
+        });
+      }
+      plainOffset += getBlockPlainLength(block);
       return acc;
     }
 
@@ -105,6 +228,7 @@ export function getRichTextBlocksUI(
         url: resolveFileUrl(block.url),
         caption: block.caption,
       });
+      plainOffset += getBlockPlainLength(block);
       return acc;
     }
 
@@ -114,8 +238,11 @@ export function getRichTextBlocksUI(
         id,
         type: "text",
         content: text,
+        mentions: getTextBlockMentions(text, plainOffset, textContext),
+        emojis: getTextBlockEmojis(text),
       });
     }
+    plainOffset += getBlockPlainLength(block);
     return acc;
   }, []);
 }
@@ -128,7 +255,10 @@ export function getRichTextMessageUI(
   return {
     row: getMessageRow(message, selection),
     content: {
-      blocks: getRichTextBlocksUI(content.content || []),
+      blocks: getRichTextBlocksUI(content.content || [], {
+        entities: getRichTextMentionEntities(content),
+        syntheticMentions: getRichTextSyntheticMentions(content),
+      }),
     },
   };
 }

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -101,7 +101,10 @@ import { handleGlobalSearchClick } from "./Pages/Chat/vm";
 import { ApproveGroupMemberCell } from "./Messages/ApproveGroupMember";
 import { notificationUtil } from "./Utils/NotificationUtil";
 import { resolveExternalForViewer } from "./Utils/externalViewer";
-import { copyImageToClipboard } from "./Utils/clipboard";
+import {
+  copyImageToClipboard,
+  copyRichTextToClipboard,
+} from "./Utils/clipboard";
 import { shouldSkipMessageForSpace } from "./Service/SpaceService";
 import { t } from "./i18n";
 import {
@@ -135,14 +138,18 @@ function findSubscriber(channel: Channel, uid: string): Subscriber | undefined {
     | Subscriber[]
     | null
     | undefined;
-  return subscribers?.find((subscriber) => subscriber && subscriber.uid === uid);
+  return subscribers?.find(
+    (subscriber) => subscriber && subscriber.uid === uid
+  );
 }
 
 function mergeSubscriberIntoCache(channel: Channel, subscriber: Subscriber) {
   const channelManager = WKSDK.shared().channelManager;
   const cached = (channelManager.getSubscribes(channel) || []) as Subscriber[];
   const nextSubscribers = [...cached];
-  const index = nextSubscribers.findIndex((item) => item.uid === subscriber.uid);
+  const index = nextSubscribers.findIndex(
+    (item) => item.uid === subscriber.uid
+  );
   subscriber.channel = channel;
 
   if (index >= 0) {
@@ -154,7 +161,10 @@ function mergeSubscriberIntoCache(channel: Channel, subscriber: Subscriber) {
     nextSubscribers.push(subscriber);
   }
 
-  channelManager.subscribeCacheMap.set(channel.getChannelKey(), nextSubscribers);
+  channelManager.subscribeCacheMap.set(
+    channel.getChannelKey(),
+    nextSubscribers
+  );
   channelManager.notifySubscribeChangeListeners(channel);
 }
 
@@ -630,12 +640,16 @@ export default class BaseModule implements IModule {
     }
 
     // 已屏蔽（免打扰）的 channel 不播提示音、不发通知
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(message.channel);
+    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      message.channel
+    );
     if (channelInfo?.mute) {
       return false;
     }
     // 子区消息：额外检查父群聊 mute
-    const parentGroupNo = channelInfo?.orgData?.parentGroupNo as string | undefined;
+    const parentGroupNo = channelInfo?.orgData?.parentGroupNo as
+      | string
+      | undefined;
     if (parentGroupNo) {
       const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
         new Channel(parentGroupNo, ChannelTypeGroup)
@@ -729,6 +743,14 @@ export default class BaseModule implements IModule {
               ? (message.content as RichTextContent).plain || ""
               : (message.content as MessageText).text || "";
             const textToCopy = selectedText || fullText;
+            if (isRichText && !selectedText) {
+              copyRichTextToClipboard(message.content as RichTextContent).catch(
+                () => {
+                  fallbackCopy(textToCopy);
+                }
+              );
+              return;
+            }
             if (navigator.clipboard?.writeText) {
               navigator.clipboard.writeText(textToCopy).catch(() => {
                 // navigator.clipboard 失败时降级到 execCommand
@@ -754,14 +776,23 @@ export default class BaseModule implements IModule {
         const rawSrc = content.url || content.remoteUrl || "";
         if (!rawSrc) return null;
         // 经过 datasource URL 处理，与渲染路径保持一致（补全 base URL、路径改写等）
-        const src = WKApp.dataSource.commonDataSource.getImageURL(rawSrc, { width: content.width || 0, height: content.height || 0 });
+        const src = WKApp.dataSource.commonDataSource.getImageURL(rawSrc, {
+          width: content.width || 0,
+          height: content.height || 0,
+        });
 
         return {
           title: t("base.module.contextMenus.copyImage"),
           onClick: () => {
             copyImageToClipboard(src)
-              .then(() => Toast.success(t("base.module.contextMenus.copyImageSuccess")))
-              .catch((err: Error) => Toast.warning(err.message || t("base.module.contextMenus.copyFailed")));
+              .then(() =>
+                Toast.success(t("base.module.contextMenus.copyImageSuccess"))
+              )
+              .catch((err: Error) =>
+                Toast.warning(
+                  err.message || t("base.module.contextMenus.copyFailed")
+                )
+              );
           },
         };
       },
@@ -1043,7 +1074,9 @@ export default class BaseModule implements IModule {
             const inviteChannelInfo =
               WKSDK.shared().channelManager.getChannelInfo(inviterChannel);
             if (inviteChannelInfo) {
-              joinDesc += t("base.module.userInfo.invitedBy", { values: { name: inviteChannelInfo.title } });
+              joinDesc += t("base.module.userInfo.invitedBy", {
+                values: { name: inviteChannelInfo.title },
+              });
             } else {
               WKSDK.shared().channelManager.fetchChannelInfo(inviterChannel);
             }
@@ -1256,9 +1289,8 @@ export default class BaseModule implements IModule {
         if (relation !== UserRelation.friend) {
           return;
         }
-        const sourceDesc = (channelInfo?.orgData?.source_desc as
-          | string
-          | undefined) || "";
+        const sourceDesc =
+          (channelInfo?.orgData?.source_desc as string | undefined) || "";
         if (!sourceDesc || sourceDesc.trim() === "") {
           return;
         }
@@ -1517,7 +1549,9 @@ export default class BaseModule implements IModule {
               subTitle: groupNameSubTitle,
               onClick: () => {
                 if (!data.isManagerOrCreatorOfMe) {
-                  Toast.warning(t("base.module.channelSettings.groupNameOnlyManager"));
+                  Toast.warning(
+                    t("base.module.channelSettings.groupNameOnlyManager")
+                  );
                   return;
                 }
                 this.inputEditPush(
@@ -1595,7 +1629,9 @@ export default class BaseModule implements IModule {
               subTitle: channelInfo?.orgData?.notice,
               onClick: () => {
                 if (!data.isManagerOrCreatorOfMe) {
-                  Toast.warning(t("base.module.channelSettings.groupNoticeOnlyManager"));
+                  Toast.warning(
+                    t("base.module.channelSettings.groupNoticeOnlyManager")
+                  );
                   return;
                 }
                 this.inputEditPush(
@@ -1626,7 +1662,9 @@ export default class BaseModule implements IModule {
               properties: {
                 title: "GROUP.md",
                 subTitle: hasGroupMd
-                  ? t("base.module.channelSettings.configuredVersion", { values: { version: mdVersion } })
+                  ? t("base.module.channelSettings.configuredVersion", {
+                      values: { version: mdVersion },
+                    })
                   : t("base.module.channelSettings.notConfigured"),
                 onClick: () => {
                   // Fall back to role check: creator (role=1) or manager (role=2) can edit GROUP.md
@@ -1940,7 +1978,9 @@ export default class BaseModule implements IModule {
                 type: ListItemButtonType.warn,
                 onClick: () => {
                   WKApp.shared.baseContext.showAlert({
-                    content: t("base.module.channelSettings.clearMessagesConfirm"),
+                    content: t(
+                      "base.module.channelSettings.clearMessagesConfirm"
+                    ),
                     onOk: async () => {
                       const conversation =
                         WKSDK.shared().conversationManager.findConversation(
@@ -1969,7 +2009,9 @@ export default class BaseModule implements IModule {
                 type: ListItemButtonType.warn,
                 onClick: () => {
                   WKApp.shared.baseContext.showAlert({
-                    content: t("base.module.channelSettings.deleteAndExitConfirm"),
+                    content: t(
+                      "base.module.channelSettings.deleteAndExitConfirm"
+                    ),
                     onOk: async () => {
                       WKApp.dataSource.channelDataSource
                         .exitChannel(data.channel)
@@ -2017,14 +2059,14 @@ export default class BaseModule implements IModule {
           thread?.status === ThreadStatus.Archived
             ? t("base.module.thread.status.archived")
             : thread?.status === ThreadStatus.Deleted
-              ? t("base.module.thread.status.deleted")
-              : t("base.module.thread.status.active");
+            ? t("base.module.thread.status.deleted")
+            : t("base.module.thread.status.active");
         const statusColor =
           thread?.status === ThreadStatus.Archived
             ? "grey"
             : thread?.status === ThreadStatus.Deleted
-              ? "red"
-              : "green";
+            ? "red"
+            : "green";
 
         const rows = new Array<Row>();
         rows.push(
@@ -2036,7 +2078,9 @@ export default class BaseModule implements IModule {
               onClick: () => {
                 if (!threadInfo) return;
                 if (!canEdit) {
-                  Toast.warning(t("base.module.thread.nameOnlyCreatorOrManager"));
+                  Toast.warning(
+                    t("base.module.thread.nameOnlyCreatorOrManager")
+                  );
                   return;
                 }
                 this.inputEditPush(
@@ -2050,7 +2094,9 @@ export default class BaseModule implements IModule {
                         { name: value }
                       );
                     } catch (err: any) {
-                      Toast.error(err?.msg || t("base.module.thread.saveFailedRetry"));
+                      Toast.error(
+                        err?.msg || t("base.module.thread.saveFailedRetry")
+                      );
                       return; // 失败时 inputEditPush 正常关闭，不刷新缓存
                     }
                     // 清除缓存后重新拉取，拿到新数据再刷新 UI
@@ -2137,7 +2183,9 @@ export default class BaseModule implements IModule {
               properties: {
                 title: "GROUP.md",
                 subTitle: hasThreadMd
-                  ? t("base.module.channelSettings.configuredVersion", { values: { version: mdVersion } })
+                  ? t("base.module.channelSettings.configuredVersion", {
+                      values: { version: mdVersion },
+                    })
                   : t("base.module.channelSettings.notConfigured"),
                 onClick: () => {
                   // 延迟获取最新数据
@@ -2210,11 +2258,18 @@ export default class BaseModule implements IModule {
                   : t("base.module.thread.archive"),
                 type: ListItemButtonType.default,
                 onClick: () => {
-                  const threadDisplayName = thread?.name || data.channelInfo?.title || t("base.module.thread.fallbackName");
+                  const threadDisplayName =
+                    thread?.name ||
+                    data.channelInfo?.title ||
+                    t("base.module.thread.fallbackName");
                   wkConfirm({
                     title: isArchived
-                      ? t("base.module.thread.unarchiveConfirmTitle", { values: { name: threadDisplayName } })
-                      : t("base.module.thread.archiveConfirmTitle", { values: { name: threadDisplayName } }),
+                      ? t("base.module.thread.unarchiveConfirmTitle", {
+                          values: { name: threadDisplayName },
+                        })
+                      : t("base.module.thread.archiveConfirmTitle", {
+                          values: { name: threadDisplayName },
+                        }),
                     okText: isArchived
                       ? t("base.module.thread.unarchive")
                       : t("base.module.thread.archiveOk"),
@@ -2265,8 +2320,8 @@ export default class BaseModule implements IModule {
 
         rows.push(
           new Row({
-              cell: ListItemButton,
-              properties: {
+            cell: ListItemButton,
+            properties: {
               title: t("base.module.thread.leave"),
               type: ListItemButtonType.warn,
               onClick: () => {
@@ -2277,7 +2332,9 @@ export default class BaseModule implements IModule {
                       await WKApp.apiClient
                         .post(`threads/${threadInfo.shortId}/leave`)
                         .catch((err: any) => {
-                          Toast.error(err.msg || t("base.module.thread.leaveFailed"));
+                          Toast.error(
+                            err.msg || t("base.module.thread.leaveFailed")
+                          );
                         });
                       WKApp.conversationProvider.deleteConversation(
                         data.channel

--- a/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
@@ -115,7 +115,7 @@ describe("MixedContent", () => {
     );
   });
 
-  it("文本块透传 mention、emoji 和点击回调", () => {
+  it("文本块关闭 markdown 解析但保留 mention、emoji 和点击回调", () => {
     const onMentionClick = vi.fn();
     const root = renderMixed(
       <MixedContent
@@ -135,7 +135,7 @@ describe("MixedContent", () => {
     const text = root.querySelector(".wk-msg-mixed-text span");
     expect(text?.getAttribute("data-mentions")).toContain("alice");
     expect(text?.getAttribute("data-emojis")).toContain("emoji://ok");
-    expect(text?.getAttribute("data-enable-markdown")).toBe("true");
+    expect(text?.getAttribute("data-enable-markdown")).toBe("false");
     act(() => {
       text?.dispatchEvent(
         new MouseEvent("click", { bubbles: true, cancelable: true })

--- a/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx
@@ -5,8 +5,32 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../../TextContent", () => ({
+  default: ({
+    content,
+    mentions = [],
+    emojis = [],
+    onMentionClick,
+    enableMarkdown,
+  }: {
+    content: string;
+    mentions?: Array<{ name: string; uid: string }>;
+    emojis?: Array<{ key: string; url: string }>;
+    onMentionClick?: (uid: string) => void;
+    enableMarkdown?: boolean;
+  }) => (
+    <span
+      data-mentions={JSON.stringify(mentions)}
+      data-emojis={JSON.stringify(emojis)}
+      data-enable-markdown={String(enableMarkdown)}
+      onClick={() => mentions[0]?.uid && onMentionClick?.(mentions[0].uid)}
+    >
+      {content}
+    </span>
+  ),
+}));
+
 vi.mock("../../../../Messages/Text/MarkdownContent", () => ({
-  default: ({ content }: { content: string }) => <span>{content}</span>,
   MarkdownImage: ({ src, alt }: { src: string; alt?: string }) => (
     <img src={src} alt={alt || ""} />
   ),
@@ -89,5 +113,34 @@ describe("MixedContent", () => {
     expect(onFileDownload).toHaveBeenCalledWith(
       expect.objectContaining({ id: "f1", type: "file" })
     );
+  });
+
+  it("文本块透传 mention、emoji 和点击回调", () => {
+    const onMentionClick = vi.fn();
+    const root = renderMixed(
+      <MixedContent
+        blocks={[
+          {
+            id: "t1",
+            type: "text",
+            content: "@Alice [OK]",
+            mentions: [{ name: "@Alice", uid: "alice" }],
+            emojis: [{ key: "[OK]", url: "emoji://ok" }],
+          },
+        ]}
+        onMentionClick={onMentionClick}
+      />
+    );
+
+    const text = root.querySelector(".wk-msg-mixed-text span");
+    expect(text?.getAttribute("data-mentions")).toContain("alice");
+    expect(text?.getAttribute("data-emojis")).toContain("emoji://ok");
+    expect(text?.getAttribute("data-enable-markdown")).toBe("true");
+    act(() => {
+      text?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+    expect(onMentionClick).toHaveBeenCalledWith("alice");
   });
 });

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -122,7 +122,7 @@ export default function MixedContent({
               mentions={block.mentions || []}
               emojis={block.emojis || []}
               onMentionClick={onMentionClick}
-              enableMarkdown={true}
+              enableMarkdown={false}
             />
           </div>
         );

--- a/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Download } from "lucide-react";
-import MarkdownContent, {
-  MarkdownImage,
+import { MarkdownImage } from "../../../Messages/Text/MarkdownContent";
+import type {
+  EmojiInfo,
+  MentionInfo,
 } from "../../../Messages/Text/MarkdownContent";
+import TextContent from "../TextContent";
 import "./index.css";
 
 export type MixedContentFileTone =
@@ -22,6 +25,8 @@ export type MixedContentBlock =
       type: "text";
       id: string;
       content: string;
+      mentions?: MentionInfo[];
+      emojis?: EmojiInfo[];
     }
   | {
       type: "image";
@@ -43,6 +48,7 @@ export type MixedContentBlock =
 
 export interface MixedContentProps {
   blocks: MixedContentBlock[];
+  onMentionClick?: (uid: string) => void;
   onFileDownload?: (
     block: Extract<MixedContentBlock, { type: "file" }>
   ) => void;
@@ -50,6 +56,7 @@ export interface MixedContentProps {
 
 export default function MixedContent({
   blocks,
+  onMentionClick,
   onFileDownload,
 }: MixedContentProps) {
   return (
@@ -110,7 +117,13 @@ export default function MixedContent({
         }
         return (
           <div key={block.id} className="wk-msg-mixed-text">
-            <MarkdownContent content={block.content} enableMarkdown={false} />
+            <TextContent
+              content={block.content}
+              mentions={block.mentions || []}
+              emojis={block.emojis || []}
+              onMentionClick={onMentionClick}
+              enableMarkdown={true}
+            />
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- send mixed image/text editor content as one RichText message and render RichText text blocks through the normal text UI
- copy RichText messages with a platform marker in text/html plus text/plain fallback
- restore platform RichText clipboard payloads into the editor, using existing pasted attachment handling for images
- omit credentials when fetching clipboard image blocks to support wildcard CORS CDNs and avoid attaching cookies to user-controlled clipboard URLs

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Utils/__tests__/clipboardRichText.test.ts packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/richTextMixedSend.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/sendContentProxy.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/copySelection.test.ts packages/dmworkbase/src/bridge/message/__tests__/useRichTextMessageUI.test.ts packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts packages/dmworkbase/src/ui/message/MixedContent/__tests__/MixedContent.test.tsx packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts packages/dmworkbase/src/Messages/RichText/__tests__/RichTextContent.test.ts
- pnpm --filter @octo/web build

Fixes Mininglamp-OSS/octo-web#319