### PR TITLE
fix: align AI assistant history timestamps

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionExpandedList.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionExpandedList.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import classNames from "classnames";
-import moment from "moment";
 import { Message } from "wukongimjssdk";
 import { MessageWrap } from "../../Service/Model";
 import Checkbox from "../Checkbox";
 import { isMessageSelectable } from "../../Service/messageSelection";
+import { formatMessageTimestamp } from "../../Utils/time";
 
 interface FoldSessionExpandedListProps {
   messages: MessageWrap[];
@@ -30,7 +30,7 @@ const FoldSessionExpandedList: React.FC<FoldSessionExpandedListProps> = ({
     <>
       {messages.map((message) => {
         const senderName = message.from?.title || message.fromUID;
-        const timeStr = moment(message.timestamp * 1000).format("HH:mm");
+        const timeStr = formatMessageTimestamp(message.timestamp);
         const selectable = isMessageSelectable(message);
         return (
           <div

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -19,7 +19,6 @@ import {
 } from "wukongimjssdk";
 import React, { Component, HTMLProps } from "react";
 
-import moment from "moment";
 import Provider from "../../Service/Provider";
 import ConversationVM from "./vm";
 import "./index.css";
@@ -80,6 +79,7 @@ import {
   makeTextBlock,
   makeImageBlock,
 } from "../../Messages/RichText/RichTextContent";
+import { formatMessageTimestamp } from "../../Utils/time";
 import { isSafeUrl } from "../../Utils/security";
 import { downloadFile } from "../../Utils/download";
 import Lightbox from "yet-another-react-lightbox";
@@ -1751,7 +1751,7 @@ export class Conversation
                 <span className="wk-fold-session-tag">{tagLabel}</span>
               </div>
               <span className="wk-fold-session-time">
-                {moment(session.lastMessage.timestamp * 1000).format("HH:mm")}
+                {formatMessageTimestamp(session.lastMessage.timestamp)}
               </span>
               <button
                 type="button"
@@ -1811,9 +1811,7 @@ export class Conversation
               highlightSummary={session.highlightSummary}
               summaryId={summaryId}
               summarySender={summarySender}
-              summaryTime={moment(summaryMessage.timestamp * 1000).format(
-                "HH:mm"
-              )}
+              summaryTime={formatMessageTimestamp(summaryMessage.timestamp)}
               summaryContent={this.renderFoldSessionSummary(summaryMessage)}
               expandedContent={this.renderFoldSessionExpandedList(
                 session.expandedMessages

--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -33,13 +33,13 @@ import WKAvatar from "../../Components/WKAvatar";
 import AiBadge from "../../Components/AiBadge";
 import RealnameVerifiedBadge from "../../Components/RealnameVerifiedBadge";
 import { getTitleColor } from "./head";
-import moment from "moment";
 import ThreadIndicator, {
   ThreadIndicatorData,
 } from "../../Components/ThreadIndicator";
 import { isMessageContinuation } from "../../Service/messageContinuity";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext } from "../../i18n";
+import { formatMessageTimestamp } from "../../Utils/time";
 
 interface MessageBaseProps extends HTMLProps<any> {
   message: MessageWrap;
@@ -374,7 +374,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     const isAi = this.isAiMessage();
     const showHead = this.needHead();
     const showAvatar = this.needAvatar();
-    const timeStr = moment(message.timestamp * 1000).format("HH:mm");
+    const timeStr = formatMessageTimestamp(message.timestamp);
     const selectionMode = context.editOn();
     const selectable = isMessageSelectable(message);
 

--- a/packages/dmworkbase/src/Messages/Base/tail.tsx
+++ b/packages/dmworkbase/src/Messages/Base/tail.tsx
@@ -1,9 +1,9 @@
 import { MessageStatus } from "wukongimjssdk";
-import moment from "moment";
 import React from "react";
 import { Component, CSSProperties } from "react";
 import { MessageWrap } from "../../Service/Model";
 import { I18nContext } from "../../i18n";
+import { formatMessageTimestamp } from "../../Utils/time";
 
 interface MessageTrailProps {
     message: MessageWrap
@@ -37,7 +37,7 @@ export default class MessageTrail extends Component<MessageTrailProps> {
         const { message,timeStyle,statusStyle } = this.props
         return <span className="messageMeta">
             {message.remoteExtra?.isEdit?<span className="messageTime">{this.context.t("base.message.edited")}</span>:null}
-            <span className="messageTime" style={timeStyle}> {moment(message.timestamp * 1000).format('HH:mm')}</span>
+            <span className="messageTime" style={timeStyle}> {formatMessageTimestamp(message.timestamp)}</span>
            {message.send?<span className="messageStatus" style={statusStyle}>  {this.getMessageStatusIcon()}</span>:null}
         </span>
     }

--- a/packages/dmworkbase/src/Utils/__tests__/time.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/time.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { formatMessageTimestamp } from "../time"
+
+describe("formatMessageTimestamp", () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("shows only HH:mm for messages from today", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 8, 12, 0, 0))
+
+        const timestamp = new Date(2026, 5, 8, 8, 20, 0).getTime() / 1000
+
+        expect(formatMessageTimestamp(timestamp)).toBe("08:20")
+    })
+
+    it("shows MM-DD HH:mm for older same-year history messages", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 8, 12, 0, 0))
+
+        const timestamp = new Date(2026, 4, 12, 8, 20, 0).getTime() / 1000
+
+        expect(formatMessageTimestamp(timestamp)).toBe("05-12 08:20")
+    })
+
+    it("shows YYYY-MM-DD HH:mm for cross-year history messages", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 8, 12, 0, 0))
+
+        const timestamp = new Date(2025, 11, 31, 23, 59, 0).getTime()
+
+        expect(formatMessageTimestamp(timestamp)).toBe("2025-12-31 23:59")
+    })
+})

--- a/packages/dmworkbase/src/Utils/__tests__/time.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/time.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { i18n } from "../../i18n/instance"
 import { formatMessageTimestamp } from "../time"
 
 describe("formatMessageTimestamp", () => {
     afterEach(() => {
         vi.useRealTimers()
+        i18n.setLocale("zh-CN", { notify: false, persist: false })
     })
 
     it("shows only HH:mm for messages from today", () => {
@@ -22,6 +24,26 @@ describe("formatMessageTimestamp", () => {
         const timestamp = new Date(2026, 4, 12, 8, 20, 0).getTime() / 1000
 
         expect(formatMessageTimestamp(timestamp)).toBe("05-12 08:20")
+    })
+
+    it("shows localized weekday for recent same-week history messages", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 8, 12, 0, 0))
+        i18n.setLocale("zh-CN", { notify: false, persist: false })
+
+        const timestamp = new Date(2026, 5, 2, 15, 20, 0).getTime() / 1000
+
+        expect(formatMessageTimestamp(timestamp)).toBe("周二 15:20")
+    })
+
+    it("shows English weekday when locale is en-US", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date(2026, 5, 8, 12, 0, 0))
+        i18n.setLocale("en-US", { notify: false, persist: false })
+
+        const timestamp = new Date(2026, 5, 2, 15, 20, 0).getTime() / 1000
+
+        expect(formatMessageTimestamp(timestamp)).toBe("Tue 15:20")
     })
 
     it("shows YYYY-MM-DD HH:mm for cross-year history messages", () => {

--- a/packages/dmworkbase/src/Utils/time.ts
+++ b/packages/dmworkbase/src/Utils/time.ts
@@ -1,4 +1,5 @@
-import { i18n, t } from "../i18n";
+import moment from "moment";
+import { i18n, t } from "../i18n/instance";
 
 /**
 * 对Date的扩展，将 Date 转化为指定格式的String。
@@ -139,6 +140,42 @@ export function getTimeStringAutoShort2(timestamp:number, mustIncludeTime:boolea
 export function dateFormat(date:Date, fmt:string) {
 
     return _formatDate(date,fmt)
+}
+
+/**
+ * 格式化聊天消息行时间。
+ *
+ * 对齐新 MessageRow 现有规则：
+ * - 今天：HH:mm
+ * - 昨天：昨天 HH:mm
+ * - 一周内：周X HH:mm
+ * - 今年：MM-DD HH:mm
+ * - 跨年：YYYY-MM-DD HH:mm
+ */
+export function formatMessageTimestamp(timestamp: number): string {
+    const ms = timestamp < 10000000000 ? timestamp * 1000 : timestamp
+    const now = Date.now()
+    const diff = now - ms
+
+    if (diff < 86400 * 1000 && moment(ms).isSame(moment(), "day")) {
+        return moment(ms).format("HH:mm")
+    }
+
+    if (diff < 86400 * 2000 && moment(ms).isSame(moment().subtract(1, "day"), "day")) {
+        return t("base.time.yesterdayWithTime", {
+            values: { time: moment(ms).format("HH:mm") },
+        })
+    }
+
+    if (diff < 86400 * 7000) {
+        return moment(ms).format("ddd HH:mm")
+    }
+
+    if (moment(ms).isSame(moment(), "year")) {
+        return moment(ms).format("MM-DD HH:mm")
+    }
+
+    return moment(ms).format("YYYY-MM-DD HH:mm")
 }
 
 export function formatRelativeTime(dateStr?: string): string {

--- a/packages/dmworkbase/src/Utils/time.ts
+++ b/packages/dmworkbase/src/Utils/time.ts
@@ -45,6 +45,10 @@ function formatWeekday(date: Date) {
     return new Intl.DateTimeFormat(i18n.getLocale(), { weekday: "long" }).format(date);
 }
 
+function formatShortWeekday(date: Date) {
+    return new Intl.DateTimeFormat(i18n.getLocale(), { weekday: "short" }).format(date);
+}
+
 /**
 * 仿照微信中的消息时间显示逻辑，将时间戳（单位：毫秒）转换为友好的显示格式.
 *
@@ -168,7 +172,7 @@ export function formatMessageTimestamp(timestamp: number): string {
     }
 
     if (diff < 86400 * 7000) {
-        return moment(ms).format("ddd HH:mm")
+        return `${formatShortWeekday(new Date(ms))} ${moment(ms).format("HH:mm")}`
     }
 
     if (moment(ms).isSame(moment(), "year")) {

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -9,7 +9,7 @@ import { personalRemarkDisplayName, subscriberDisplayName } from '../../Utils/di
 import { shouldShowRealnameBadge } from '../../Utils/realnameBadge'
 import moment from 'moment'
 import { isMessageContinuation } from '../../Service/messageContinuity'
-import { t } from '../../i18n/instance'
+import { formatMessageTimestamp } from '../../Utils/time'
 
 export interface MessageRowSelectionState {
   /** 当前会话是否处于多选模式（不可选消息也需要知道，用于禁用行内操作） */
@@ -89,7 +89,7 @@ export function getMessageRow(
   const isContinue = isMessageContinuation(message.preMessage, message)
 
   // 格式化时间戳
-  const timestamp = formatTimestamp(message.timestamp)
+  const timestamp = formatMessageTimestamp(message.timestamp)
   const timeOnly = formatTimeOnly(message.timestamp)
 
   // 把 uid 绑定到回调
@@ -330,41 +330,4 @@ export function useMessageRow(
 function formatTimeOnly(timestamp: number): string {
   const ms = timestamp < 10000000000 ? timestamp * 1000 : timestamp
   return moment(ms).format('HH:mm')
-}
-
-/**
- * 格式化时间戳
- * 
- * @param timestamp - 时间戳（秒或毫秒）
- * @returns 格式化后的时间字符串
- */
-function formatTimestamp(timestamp: number): string {
-  const ms = timestamp < 10000000000 ? timestamp * 1000 : timestamp
-  const now = Date.now()
-  const diff = now - ms
-  
-  // 今天：显示 HH:mm
-  if (diff < 86400 * 1000 && moment(ms).isSame(moment(), 'day')) {
-    return moment(ms).format('HH:mm')
-  }
-  
-  // 昨天：显示 "昨天 HH:mm"
-  if (diff < 86400 * 2000 && moment(ms).isSame(moment().subtract(1, 'day'), 'day')) {
-    return t('base.time.yesterdayWithTime', {
-      values: { time: moment(ms).format('HH:mm') },
-    })
-  }
-  
-  // 一周内：显示 "周X HH:mm"
-  if (diff < 86400 * 7000) {
-    return moment(ms).format('ddd HH:mm')
-  }
-  
-  // 今年：显示 "MM-DD HH:mm"
-  if (moment(ms).isSame(moment(), 'year')) {
-    return moment(ms).format('MM-DD HH:mm')
-  }
-  
-  // 跨年：显示 "YYYY-MM-DD HH:mm"
-  return moment(ms).format('YYYY-MM-DD HH:mm')
 }


### PR DESCRIPTION
## Summary
- move the existing MessageRow timestamp rules into a shared `formatMessageTimestamp` helper
- reuse that helper in legacy MessageBase AI panel footer and MessageTrail
- add coverage for today, same-year history, and cross-year message timestamp formatting

Fixes #301

## Tests
- `pnpm exec vitest run --config packages/dmworkbase/vitest.config.ts packages/dmworkbase/src/Utils/__tests__/time.test.ts packages/dmworkbase/src/bridge/message/__tests__/useMessageRow.realname.test.ts`
- `pnpm i18n:check`
- `git diff --check`

## Notes
- `pnpm exec tsc -p packages/dmworkbase/tsconfig.json --noEmit` was also attempted, but the repository currently fails before this change on existing broad type issues in Semi source typings, Storybook type resolution, and existing dmworkbase files.