### PR TITLE
fix: stabilize mention suggestion keyboard hover selection

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.css
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.css
@@ -1,9 +1,11 @@
 .mention-list {
+  position: relative;
   background-color: var(--wk-color-item);
   box-shadow: var(--wk-shadow-md);
   border-radius: 4px;
   max-height: 220px;
   overflow-y: auto;
+  overflow-anchor: none;
   padding: 5px 0;
   min-width: 420px;
 }
@@ -17,8 +19,8 @@
   margin-bottom: 10px;
 }
 
-.mention-list-item:hover,
-.mention-list-item.is-selected {
+.mention-list.mention-list--mouse .mention-list-item:hover,
+.mention-list.mention-list--keyboard .mention-list-item.is-selected {
   background-color: var(--wk-color-theme);
   color: var(--wk-text-inverse);
 }
@@ -32,7 +34,7 @@
   margin-left: 6px;
   font-size: 12px;
   font-weight: 400;
-  color: var(--wk-text-secondary, rgba(9, 30, 66, 0.6));
+  color: var(--wk-text-secondary, var(--semi-color-text-2));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -40,8 +42,8 @@
   vertical-align: middle;
 }
 
-.mention-list-item.is-selected .mention-list-item-space,
-.mention-list-item:hover .mention-list-item-space {
+.mention-list.mention-list--keyboard .mention-list-item.is-selected .mention-list-item-space,
+.mention-list.mention-list--mouse .mention-list-item:hover .mention-list-item-space {
   color: var(--wk-text-inverse);
   opacity: 0.8;
 }

--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 import AiBadge from '../AiBadge'
 import { useI18n } from '../../i18n'
 import './MentionList.css'
@@ -22,10 +28,25 @@ interface MentionListProps {
   command: (item: { id: string; label: string }) => void
 }
 
+type InteractionMode = 'keyboard' | 'mouse'
+type KeyboardDirection = 'up' | 'down'
+type PointerPosition = { x: number; y: number }
+
+const SCROLL_EDGE_EPSILON = 1
+const POINTER_MOVE_EPSILON = 1
+
 export default forwardRef((props: MentionListProps, ref) => {
   const { t } = useI18n()
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [interactionMode, setInteractionMode] =
+    useState<InteractionMode>('keyboard')
+  const listRef = useRef<HTMLDivElement | null>(null)
   const itemRefs = useRef<(HTMLDivElement | null)[]>([])
+  const selectedIndexRef = useRef(0)
+  const hoveredIndexRef = useRef<number | null>(null)
+  const interactionModeRef = useRef<InteractionMode>('keyboard')
+  const suppressMouseHoverUntilMoveRef = useRef(false)
+  const lastPointerPositionRef = useRef<PointerPosition | null>(null)
 
   const selectItem = (index: number) => {
     const item = props.items[index]
@@ -37,26 +58,153 @@ export default forwardRef((props: MentionListProps, ref) => {
     }
   }
 
+  const scrollKeyboardItemIntoView = (index: number, direction: KeyboardDirection) => {
+    const list = listRef.current
+    const item = itemRefs.current[index]
+
+    if (!list || !item) return
+
+    const itemTop = item.offsetTop
+    const itemBottom = itemTop + item.offsetHeight
+    const viewTop = list.scrollTop
+    const viewBottom = viewTop + list.clientHeight
+    let nextScrollTop = viewTop
+
+    if (direction === 'up') {
+      if (itemTop < viewTop - SCROLL_EDGE_EPSILON) {
+        nextScrollTop = itemTop
+      }
+    } else if (itemBottom > viewBottom + SCROLL_EDGE_EPSILON) {
+      nextScrollTop = itemBottom - list.clientHeight
+    }
+
+    const maxScrollTop = Math.max(0, list.scrollHeight - list.clientHeight)
+    const clampedScrollTop = Math.min(Math.max(nextScrollTop, 0), maxScrollTop)
+
+    if (Math.abs(clampedScrollTop - viewTop) > SCROLL_EDGE_EPSILON) {
+      list.scrollTop = clampedScrollTop
+    }
+  }
+
+  const scrollWrappedKeyboardItemIntoView = (direction: KeyboardDirection) => {
+    const list = listRef.current
+    if (!list) return
+
+    if (direction === 'up') {
+      list.scrollTop = Math.max(0, list.scrollHeight - list.clientHeight)
+    } else {
+      list.scrollTop = 0
+    }
+  }
+
+  const moveKeyboardSelection = (direction: KeyboardDirection) => {
+    if (!props.items.length) return
+
+    const startingIndex = interactionModeRef.current === 'mouse'
+      ? hoveredIndexRef.current ?? selectedIndexRef.current
+      : selectedIndexRef.current
+    const nextIndex = direction === 'up'
+      ? (startingIndex + props.items.length - 1) % props.items.length
+      : (startingIndex + 1) % props.items.length
+    const wrapped =
+      (direction === 'up' && startingIndex === 0) ||
+      (direction === 'down' && startingIndex === props.items.length - 1)
+
+    if (wrapped) {
+      scrollWrappedKeyboardItemIntoView(direction)
+    } else {
+      scrollKeyboardItemIntoView(nextIndex, direction)
+    }
+    selectedIndexRef.current = nextIndex
+    suppressMouseHoverUntilMoveRef.current = true
+    interactionModeRef.current = 'keyboard'
+    setInteractionMode('keyboard')
+    hoveredIndexRef.current = null
+    setSelectedIndex(nextIndex)
+  }
+
   const upHandler = () => {
-    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length)
+    moveKeyboardSelection('up')
   }
 
   const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length)
+    moveKeyboardSelection('down')
   }
 
   const enterHandler = () => {
-    selectItem(selectedIndex)
+    const commandIndex = interactionModeRef.current === 'mouse'
+      ? hoveredIndexRef.current ?? selectedIndexRef.current
+      : selectedIndexRef.current
+
+    selectedIndexRef.current = commandIndex
+    interactionModeRef.current = 'keyboard'
+    setInteractionMode('keyboard')
+    hoveredIndexRef.current = null
+    selectItem(commandIndex)
   }
 
-  useEffect(() => setSelectedIndex(0), [props.items])
+  const hasNativeMouseMovement = (event: React.MouseEvent<HTMLDivElement>) => {
+    const nativeEvent = event.nativeEvent as MouseEvent
+    return (
+      Math.abs(nativeEvent.movementX || 0) > POINTER_MOVE_EPSILON ||
+      Math.abs(nativeEvent.movementY || 0) > POINTER_MOVE_EPSILON
+    )
+  }
+
+  const hasPointerMoved = (pointerPosition: PointerPosition) => {
+    const lastPointerPosition = lastPointerPositionRef.current
+    if (!lastPointerPosition) return false
+
+    return (
+      Math.abs(pointerPosition.x - lastPointerPosition.x) > POINTER_MOVE_EPSILON ||
+      Math.abs(pointerPosition.y - lastPointerPosition.y) > POINTER_MOVE_EPSILON
+    )
+  }
+
+  const mouseHandler = (index: number, event: React.MouseEvent<HTMLDivElement>) => {
+    const pointerPosition = { x: event.clientX, y: event.clientY }
+    const pointerMoved = hasPointerMoved(pointerPosition)
+
+    if (
+      suppressMouseHoverUntilMoveRef.current &&
+      (event.type !== 'mousemove' || (!hasNativeMouseMovement(event) && !pointerMoved))
+    ) {
+      return
+    }
+
+    suppressMouseHoverUntilMoveRef.current = false
+    lastPointerPositionRef.current = pointerPosition
+    interactionModeRef.current = 'mouse'
+    setInteractionMode((currentMode) =>
+      currentMode === 'mouse' ? currentMode : 'mouse'
+    )
+    hoveredIndexRef.current = index
+  }
+
+  const mouseLeaveHandler = () => {
+    if (interactionModeRef.current !== 'mouse') return
+
+    suppressMouseHoverUntilMoveRef.current = false
+    lastPointerPositionRef.current = null
+    hoveredIndexRef.current = null
+    selectedIndexRef.current = 0
+    interactionModeRef.current = 'keyboard'
+    setSelectedIndex(0)
+    setInteractionMode('keyboard')
+  }
 
   useEffect(() => {
-    itemRefs.current[selectedIndex]?.scrollIntoView({
-      block: 'nearest',
-      behavior: 'smooth',
-    })
-  }, [selectedIndex])
+    selectedIndexRef.current = 0
+    hoveredIndexRef.current = null
+    interactionModeRef.current = 'keyboard'
+    suppressMouseHoverUntilMoveRef.current = false
+    lastPointerPositionRef.current = null
+    setSelectedIndex(0)
+    setInteractionMode('keyboard')
+    if (listRef.current) {
+      listRef.current.scrollTop = 0
+    }
+  }, [props.items])
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }: any) => {
@@ -80,42 +228,60 @@ export default forwardRef((props: MentionListProps, ref) => {
   }))
 
   return (
-    <div className="mention-list" role="listbox">
+    <div
+      ref={listRef}
+      className={`mention-list mention-list--${interactionMode}`}
+      role="listbox"
+      onMouseLeave={mouseLeaveHandler}
+    >
       {props.items.length ? (
-        props.items.map((item, index) => (
-          <div
-            ref={(el) => {
-              itemRefs.current[index] = el
-            }}
-            className={`mention-list-item ${index === selectedIndex ? 'is-selected' : ''}`}
-            key={item.uid || item.id || index}
-            role="option"
-            aria-selected={index === selectedIndex}
-            onClick={() => selectItem(index)}
-          >
-            <div className="wk-messageinput-iconbox">
-              <img
-                className="wk-messageinput-icon"
-                src={item.icon}
-                alt=""
-                style={{ width: '24px', height: '24px', borderRadius: '24px' }}
-              />
+        props.items.map((item, index) => {
+          const isKeyboardSelected =
+            interactionMode === 'keyboard' && index === selectedIndex
+
+          return (
+            <div
+              ref={(el) => {
+                itemRefs.current[index] = el
+              }}
+              className={`mention-list-item ${
+                isKeyboardSelected ? 'is-selected' : ''
+              }`}
+              key={item.uid || item.id || index}
+              role="option"
+              aria-selected={isKeyboardSelected}
+              onMouseEnter={(event) => mouseHandler(index, event)}
+              onMouseMove={(event) => mouseHandler(index, event)}
+              onClick={() => selectItem(index)}
+            >
+              <div className="wk-messageinput-iconbox">
+                <img
+                  className="wk-messageinput-icon"
+                  src={item.icon}
+                  alt=""
+                  style={{
+                    width: '24px',
+                    height: '24px',
+                    borderRadius: '24px',
+                  }}
+                />
+              </div>
+              <div>
+                <strong>{item.name || item.display}</strong>
+                {/* @ 提醒选人弹窗的「@SpaceName」后缀（企微风格） */}
+                {item.sourceSpaceName && (
+                  <span
+                    className="mention-list-item-space"
+                    title={`@${item.sourceSpaceName}`}
+                  >
+                    @{item.sourceSpaceName}
+                  </span>
+                )}
+                {item.isBot && <AiBadge size="small" />}
+              </div>
             </div>
-            <div>
-              <strong>{item.name || item.display}</strong>
-              {/* @ 提醒选人弹窗的「@SpaceName」后缀（企微风格） */}
-              {item.sourceSpaceName && (
-                <span
-                  className="mention-list-item-space"
-                  title={`@${item.sourceSpaceName}`}
-                >
-                  @{item.sourceSpaceName}
-                </span>
-              )}
-              {item.isBot && <AiBadge size="small" />}
-            </div>
-          </div>
-        ))
+          )
+        })
       ) : (
         <div className="mention-list-item">{t("base.mentionList.noMembers")}</div>
       )}

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { fireEvent } from "@testing-library/dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MentionList from "../MentionList";
+
+vi.mock("../../../i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const items = [
+  { uid: "uid-1", name: "Alice", icon: "avatar://alice" },
+  { uid: "uid-2", name: "Bob", icon: "avatar://bob" },
+  { uid: "uid-3", name: "Carol", icon: "avatar://carol" },
+];
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+});
+
+function renderMentionList(command = vi.fn(), nextItems = items) {
+  const ref = React.createRef<any>();
+
+  act(() => {
+    ReactDOM.render(
+      <MentionList ref={ref} items={nextItems} command={command} />,
+      container
+    );
+  });
+
+  return { command, ref };
+}
+
+function listElement() {
+  return container.querySelector(".mention-list") as HTMLElement;
+}
+
+function optionElements() {
+  return Array.from(container.querySelectorAll(".mention-list-item")) as HTMLElement[];
+}
+
+function setListViewport(height: number, scrollTop: number, scrollHeight: number) {
+  const list = listElement();
+  Object.defineProperty(list, "clientHeight", {
+    configurable: true,
+    value: height,
+  });
+  Object.defineProperty(list, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  });
+  list.scrollTop = scrollTop;
+}
+
+function setOptionLayout(index: number, offsetTop: number, offsetHeight: number) {
+  const option = optionElements()[index];
+  Object.defineProperty(option, "offsetTop", {
+    configurable: true,
+    value: offsetTop,
+  });
+  Object.defineProperty(option, "offsetHeight", {
+    configurable: true,
+    value: offsetHeight,
+  });
+}
+
+describe("MentionList interaction mode", () => {
+  it("starts in keyboard mode with the first item selected", () => {
+    renderMentionList();
+
+    const list = listElement();
+    const options = optionElements();
+
+    expect(list.className).toContain("mention-list--keyboard");
+    expect(options[0].className).toContain("is-selected");
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    expect(options[1].className).not.toContain("is-selected");
+  });
+
+  it("switches to mouse mode on pointer movement and uses click for mouse selection", () => {
+    const command = vi.fn();
+    renderMentionList(command);
+    const options = optionElements();
+
+    act(() => {
+      fireEvent.mouseMove(options[1]);
+    });
+
+    expect(listElement().className).toContain("mention-list--mouse");
+    expect(optionElements().some((option) => option.className.includes("is-selected"))).toBe(false);
+    expect(optionElements().map((option) => option.getAttribute("aria-selected"))).toEqual([
+      "false",
+      "false",
+      "false",
+    ]);
+
+    act(() => {
+      fireEvent.click(options[1]);
+    });
+
+    expect(command).toHaveBeenCalledWith({ id: "uid-2", label: "Bob" });
+  });
+
+  it("uses the hovered item as the keyboard starting point", () => {
+    const command = vi.fn();
+    const { ref } = renderMentionList(command);
+    const options = optionElements();
+
+    act(() => {
+      fireEvent.mouseMove(options[1]);
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "Enter" } });
+    });
+
+    expect(command).toHaveBeenCalledWith({ id: "uid-2", label: "Bob" });
+
+    command.mockClear();
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1]);
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "Enter" } });
+    });
+
+    expect(command).toHaveBeenCalledWith({ id: "uid-3", label: "Carol" });
+  });
+
+  it("ignores scroll-induced hover until the pointer really moves", () => {
+    const { ref } = renderMentionList();
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1], { clientX: 12, clientY: 12 });
+    });
+    expect(listElement().className).toContain("mention-list--mouse");
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      fireEvent.mouseEnter(optionElements()[0], { clientX: 12, clientY: 12 });
+      fireEvent.mouseMove(optionElements()[0], { clientX: 12, clientY: 12 });
+    });
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[0], {
+        clientX: 24,
+        clientY: 12,
+      });
+    });
+    expect(listElement().className).toContain("mention-list--mouse");
+    expect(optionElements().some((option) => option.className.includes("is-selected"))).toBe(false);
+  });
+
+  it("uses mouse hover as the keyboard starting point only when switching modes", () => {
+    const { ref } = renderMentionList();
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1], { clientX: 12, clientY: 12 });
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      fireEvent.mouseEnter(optionElements()[1], { clientX: 12, clientY: 12 });
+      fireEvent.mouseMove(optionElements()[1], { clientX: 12, clientY: 12 });
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(optionElements()[1].className).toContain("is-selected");
+  });
+
+  it("keeps keyboard origin after scroll-induced hover before the next key", () => {
+    const { ref } = renderMentionList();
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1], { clientX: 12, clientY: 12 });
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      fireEvent.mouseEnter(optionElements()[0], { clientX: 12, clientY: 12 });
+      fireEvent.mouseMove(optionElements()[0], { clientX: 12, clientY: 12 });
+    });
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(optionElements()[1].className).toContain("is-selected");
+  });
+
+  it("updates the pointer baseline while moving within the same hovered item", () => {
+    const { ref } = renderMentionList();
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1], { clientX: 12, clientY: 12 });
+      fireEvent.mouseMove(optionElements()[1], { clientX: 80, clientY: 12 });
+    });
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      fireEvent.mouseEnter(optionElements()[0], { clientX: 80, clientY: 12 });
+      fireEvent.mouseMove(optionElements()[0], { clientX: 80, clientY: 12 });
+    });
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[2].className).toContain("is-selected");
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(optionElements()[1].className).toContain("is-selected");
+  });
+
+  it("keeps keyboard boundary wrapping", () => {
+    const command = vi.fn();
+    const { ref } = renderMentionList(command);
+
+    setListViewport(40, 0, 60);
+    setOptionLayout(0, 0, 20);
+    setOptionLayout(1, 20, 20);
+    setOptionLayout(2, 40, 20);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(optionElements()[2].className).toContain("is-selected");
+    expect(listElement().scrollTop).toBe(20);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(optionElements()[0].className).toContain("is-selected");
+    expect(listElement().scrollTop).toBe(0);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "Enter" } });
+    });
+    expect(command).toHaveBeenCalledWith({ id: "uid-1", label: "Alice" });
+  });
+
+  it("returns to the first keyboard item after the pointer leaves the list", () => {
+    const command = vi.fn();
+    const { ref } = renderMentionList(command);
+
+    act(() => {
+      fireEvent.mouseMove(optionElements()[1]);
+    });
+    act(() => {
+      fireEvent.mouseOut(listElement(), { relatedTarget: document.body });
+    });
+
+    expect(listElement().className).toContain("mention-list--keyboard");
+    expect(optionElements()[0].className).toContain("is-selected");
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "Enter" } });
+    });
+
+    expect(command).toHaveBeenCalledWith({ id: "uid-1", label: "Alice" });
+  });
+
+  it("aligns keyboard scrolling to the lower or upper viewport edge", () => {
+    const { ref } = renderMentionList();
+
+    setListViewport(40, 0, 60);
+    setOptionLayout(0, 0, 20);
+    setOptionLayout(1, 20, 20);
+    setOptionLayout(2, 40, 20);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(listElement().scrollTop).toBe(0);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowDown" } });
+    });
+    expect(listElement().scrollTop).toBe(20);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(listElement().scrollTop).toBe(20);
+
+    act(() => {
+      ref.current.onKeyDown({ event: { key: "ArrowUp" } });
+    });
+    expect(listElement().scrollTop).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- split @ mention suggestion highlight state between keyboard selection and mouse hover
- keep keyboard navigation anchored after scroll-induced hover events until the pointer really moves
- replace smooth scrollIntoView with deterministic edge-aligned keyboard scrolling while preserving wraparound
- add MentionList interaction-mode regression coverage

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx --config packages/dmworkbase/vitest.config.ts
- (apps/web) pnpm exec vitest run src/__tests__/mentionRefactor.test.ts --config vitest.config.ts
- pnpm exec stylelint packages/dmworkbase/src/Components/MessageInput/MentionList.css --config stylelint.config.mjs