### PR TITLE
fix: hide archived threads on first thread-list expand without flicker (#340)

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
@@ -3,6 +3,7 @@ import {
     isArchivedThreadConversation,
     filterArchivedThreads,
     type ArchivableConversation,
+    type ThreadSidebarStatusMap,
 } from "../archivedThreads"
 import { ThreadStatus } from "../../../Service/Thread"
 import { ChannelTypeCommunityTopic } from "../../../Service/Const"
@@ -12,7 +13,7 @@ const CT_GROUP = 2
 // 构造一个子区会话存根：channelType=子区，thread.status 可选（undefined 表示未知/未加载）
 function makeThreadConv(channelID: string, status?: number): ArchivableConversation {
     return {
-        channel: { channelType: ChannelTypeCommunityTopic },
+        channel: { channelType: ChannelTypeCommunityTopic, channelID },
         channelInfo:
             status === undefined
                 ? undefined
@@ -21,7 +22,7 @@ function makeThreadConv(channelID: string, status?: number): ArchivableConversat
 }
 
 function makeGroupConv(): ArchivableConversation {
-    return { channel: { channelType: CT_GROUP } }
+    return { channel: { channelType: CT_GROUP, channelID: "g1" } }
 }
 
 describe("isArchivedThreadConversation", () => {
@@ -62,5 +63,95 @@ describe("filterArchivedThreads", () => {
 
     it("空数组返回空数组", () => {
         expect(filterArchivedThreads([])).toEqual([])
+    })
+})
+
+describe("sidebar status map（issue #340 抗抖动）", () => {
+    const ARCHIVED = ThreadStatus.Archived // 2
+    const ACTIVE = ThreadStatus.Active // 1
+
+    it("sidebar status=2 + channelInfo 缺失 => 首帧即过滤掉（核心回归：无闪烁）", () => {
+        const conv = makeThreadConv("t-archived", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-archived", ARCHIVED]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(true)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([])
+    })
+
+    it("sidebar status=1 + channelInfo 缺失 => 可见", () => {
+        const conv = makeThreadConv("t-active", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-active", ACTIVE]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(false)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([conv])
+    })
+
+    it("sidebar status 缺失 + channelInfo 缺失 => fail-open 可见（向后兼容）", () => {
+        const conv = makeThreadConv("t-unknown", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map() // 没有该 channelID
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(false)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([conv])
+    })
+
+    it("sidebar status 缺失 + channelInfo status=Archived => 过滤掉（既有行为）", () => {
+        const conv = makeThreadConv("t-ci-archived", ThreadStatus.Archived)
+        const statusMap: ThreadSidebarStatusMap = new Map()
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(true)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([])
+    })
+
+    it("sidebar status=1 但 channelInfo 后续解析为 Archived => channelInfo 权威，隐藏", () => {
+        // channelInfo 已加载即为权威信号；它说归档就隐藏，盖过过期的 sidebar=Active。
+        const conv = makeThreadConv("t-late-archived", ThreadStatus.Archived)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-late-archived", ACTIVE]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(true)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([])
+    })
+
+    it("sidebar status=2(过期) 但 channelInfo=Active(刚取消归档) => channelInfo 权威，可见（#340 回归）", () => {
+        // 取消归档只刷新 channelInfo 不发 sidebar-reload，sidebar 仍过期为 Archived；
+        // channelInfo 已加载为 Active 应权威胜出，子区立即重现，不必等下次 sidebar/sync。
+        const conv = makeThreadConv("t-just-unarchived", ThreadStatus.Active)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-just-unarchived", ARCHIVED]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(false)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([conv])
+    })
+
+    it("sidebar status=2 + channelInfo 未知 => 隐藏（冷启动消抖动）", () => {
+        const conv = makeThreadConv("t-cold", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-cold", ARCHIVED]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(true)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([])
+    })
+
+    it("sidebar status=1 + channelInfo=Archived => channelInfo 权威，隐藏", () => {
+        const conv = makeThreadConv("t-ci-auth", ThreadStatus.Archived)
+        const statusMap: ThreadSidebarStatusMap = new Map([["t-ci-auth", ACTIVE]])
+        expect(isArchivedThreadConversation(conv, statusMap)).toBe(true)
+        expect(filterArchivedThreads([conv], statusMap)).toEqual([])
+    })
+
+    it("不传 statusMap（undefined）=> 行为与今天完全一致", () => {
+        const archivedViaCi = makeThreadConv("a", ThreadStatus.Archived)
+        const active = makeThreadConv("b", ThreadStatus.Active)
+        const unknown = makeThreadConv("c", undefined)
+        expect(filterArchivedThreads([archivedViaCi, active, unknown])).toEqual([active, unknown])
+    })
+
+    it("空 statusMap => 退化为仅看 channelInfo（向后兼容）", () => {
+        const archivedViaCi = makeThreadConv("a", ThreadStatus.Archived)
+        const active = makeThreadConv("b", ThreadStatus.Active)
+        const unknown = makeThreadConv("c", undefined)
+        const empty: ThreadSidebarStatusMap = new Map()
+        expect(filterArchivedThreads([archivedViaCi, active, unknown], empty)).toEqual([active, unknown])
+    })
+
+    it("同父群下混合：sidebar 标归档的隐藏，sidebar active / 未知的保留", () => {
+        const a = makeThreadConv("sb-archived", undefined)
+        const b = makeThreadConv("sb-active", undefined)
+        const c = makeThreadConv("sb-unknown", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map([
+            ["sb-archived", ARCHIVED],
+            ["sb-active", ACTIVE],
+        ])
+        expect(filterArchivedThreads([a, b, c], statusMap)).toEqual([b, c])
     })
 })

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
     isArchivedThreadConversation,
+    isThreadArchivedForBadge,
     filterArchivedThreads,
     type ArchivableConversation,
     type ThreadSidebarStatusMap,
@@ -153,5 +154,43 @@ describe("sidebar status map（issue #340 抗抖动）", () => {
             ["sb-active", ACTIVE],
         ])
         expect(filterArchivedThreads([a, b, c], statusMap)).toEqual([b, c])
+    })
+})
+
+describe("isThreadArchivedForBadge", () => {
+    const ARCHIVED = ThreadStatus.Archived // 2
+    const ACTIVE = ThreadStatus.Active // 1
+
+    it("BUG 用例：sidebar-only 已归档子区(liveConv 缺失，statusMap=Archived) => true（未读不计入角标）", () => {
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>([["t1", ARCHIVED]])
+        expect(isThreadArchivedForBadge(undefined, "t1", statusMap)).toBe(true)
+    })
+
+    it("对照：sidebar-only 活跃子区(liveConv 缺失，statusMap=Active) => false（未读计入角标）", () => {
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>([["t2", ACTIVE]])
+        expect(isThreadArchivedForBadge(undefined, "t2", statusMap)).toBe(false)
+    })
+
+    it("sidebar-only 子区且 statusMap 无该项(未知) => false（fail-open，计入角标）", () => {
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>()
+        expect(isThreadArchivedForBadge(undefined, "t3", statusMap)).toBe(false)
+    })
+
+    it("liveConv 存在且 channelInfo 归档(status=2) => true", () => {
+        const conv = makeThreadConv("t4", ThreadStatus.Archived)
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>()
+        expect(isThreadArchivedForBadge(conv, "t4", statusMap)).toBe(true)
+    })
+
+    it("liveConv 存在且 channelInfo 活跃(status=1) => false", () => {
+        const conv = makeThreadConv("t5", ThreadStatus.Active)
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>()
+        expect(isThreadArchivedForBadge(conv, "t5", statusMap)).toBe(false)
+    })
+
+    it("liveConv 存在、channelInfo 未知但 statusMap=Archived => true（委托给 isArchivedThreadConversation 回退）", () => {
+        const conv = makeThreadConv("t6", undefined)
+        const statusMap: ThreadSidebarStatusMap = new Map<string, number | undefined>([["t6", ARCHIVED]])
+        expect(isThreadArchivedForBadge(conv, "t6", statusMap)).toBe(true)
     })
 })

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
@@ -73,6 +73,27 @@ export function isArchivedThreadConversation(
 }
 
 /**
+ * 角标(follow badge)专用：按 sidebar item + 可选 liveConv 判定子区是否「已归档」。
+ *
+ * 与列表展示层保持一致：
+ *   - liveConv 存在 → 走 isArchivedThreadConversation（channelInfo 优先，回退 statusMap）。
+ *   - liveConv 缺失（sidebar-only 关注，从未聊过、IM 缓存无 conv）→ 回退查
+ *     sidebar statusMap，sidebar=Archived 即判定归档。
+ * 这样 sidebar-only 的已归档关注子区不会把 it.unread 误计入角标，
+ * 避免「红点 N 但列表里看不到对应未读」的角标/列表 desync。
+ */
+export function isThreadArchivedForBadge(
+    liveConv: ArchivableConversation | undefined,
+    targetId: string,
+    statusMap: ThreadSidebarStatusMap,
+): boolean {
+    if (liveConv) {
+        return isArchivedThreadConversation(liveConv, statusMap)
+    }
+    return statusMap.get(targetId) === ThreadStatus.Archived
+}
+
+/**
  * 过滤掉「明确已归档」的子区，返回 UI 可见的会话数组。
  * 非子区、两路状态都未知的子区都会保留（fail-open）。
  *

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/archivedThreads.ts
@@ -4,17 +4,28 @@ import { ThreadStatus } from "../../Service/Thread"
 /**
  * 关注 Tab 展开父群子区时，默认隐藏「已归档(archived)」子区。
  *
- * 设计原则 fail-open：只有当 conv 是子区且其 thread.status 明确等于
- * ThreadStatus.Archived 时才算「已归档」。status 未知 / channelInfo 未加载
- * （如 sidebar-only 子区还没补齐 channelInfo）一律视为可见，避免误隐藏活跃子区。
+ * 归档信号有两路来源，但二者并非对等取「或」，而是分主次：
+ *   1. live channelInfo：conv.channelInfo?.orgData?.thread?.status，IM 实时补齐。
+ *      它反映子区当前最新状态（归档/取消归档都会即时刷新 channelInfo），
+ *      因此一旦加载（status 已知）即为权威信号。
+ *   2. sidebar status：/sidebar/sync 在子区项(target_type=5)上直接带 status
+ *      (1=active, 2=archived)。冷启动刷新后第一帧即可拿到，无需等 channelInfo，
+ *      用作 channelInfo 尚未补齐时的「冷启动快路径」，从源头消除
+ *      「归档子区先闪一下再消失」的抖动。但它仅在 /sidebar/sync 时整体刷新，
+ *      取消归档等操作只刷新 channelInfo 而不发 sidebar-reload，故可能短暂过期。
  *
- * 这里读取的归档状态路径与项目内其它处一致：
- *   conv.channelInfo?.orgData?.thread?.status
+ * 精确取舍：
+ *   - channelInfo status 已知（已加载）：以它为准——
+ *     channelInfo=Active 覆盖过期的 sidebar=Archived（刚取消归档立即重现）；
+ *     channelInfo=Archived 即使 sidebar=Active 也隐藏。
+ *   - channelInfo status 未知（未加载）：回退看 sidebar status，
+ *     sidebar=Archived 在首帧即隐藏（消除冷启动抖动）。
+ *   - 两路都未知：fail-open，视为可见，避免误隐藏活跃子区。
  */
 
 /** conv 上读取归档状态所需的最小结构（便于单测构造，避免依赖完整 ConversationWrap）。 */
 export interface ArchivableConversation {
-    channel: { channelType: number }
+    channel: { channelType: number; channelID: string }
     channelInfo?: {
         orgData?: {
             thread?: {
@@ -24,16 +35,52 @@ export interface ArchivableConversation {
     }
 }
 
-/** 仅当 conv 是子区类型且其 thread.status 明确为 Archived 时返回 true。 */
-export function isArchivedThreadConversation(conv: ArchivableConversation): boolean {
+/**
+ * 子区 channelID → sidebar status 映射（来自 /sidebar/sync）。
+ * 值语义同 ThreadStatus：1=active, 2=archived；缺失=未知（回退 channelInfo）。
+ */
+export type ThreadSidebarStatusMap = Map<string, number | undefined>
+
+/**
+ * 仅当 conv 是子区类型且判定为「已归档」时返回 true。
+ *
+ * 优先级：live channelInfo 已知则以它为准（权威）；未知时回退 sidebar status
+ * （冷启动快路径）；两路都未知则 fail-open（可见）。
+ *
+ * @param statusMap 可选；channelID → sidebar status。仅在 channelInfo 尚未加载时
+ *                  作为回退使用；不传 / 命中不到时退化为仅看 channelInfo（旧行为）。
+ */
+export function isArchivedThreadConversation(
+    conv: ArchivableConversation,
+    statusMap?: ThreadSidebarStatusMap,
+): boolean {
     if (conv.channel.channelType !== ChannelTypeCommunityTopic) return false
-    return conv.channelInfo?.orgData?.thread?.status === ThreadStatus.Archived
+
+    // 1) live channelInfo 已知 → 权威信号
+    const channelInfoStatus = conv.channelInfo?.orgData?.thread?.status
+    if (channelInfoStatus !== undefined) {
+        return channelInfoStatus === ThreadStatus.Archived
+    }
+
+    // 2) channelInfo 未知 → 回退 sidebar status（冷启动快路径）
+    const sidebarStatus = statusMap?.get(conv.channel.channelID)
+    if (sidebarStatus !== undefined) {
+        return sidebarStatus === ThreadStatus.Archived
+    }
+
+    // 3) 两路都未知 → fail-open（可见）
+    return false
 }
 
 /**
  * 过滤掉「明确已归档」的子区，返回 UI 可见的会话数组。
- * 非子区、status 未知的子区都会保留（fail-open）。
+ * 非子区、两路状态都未知的子区都会保留（fail-open）。
+ *
+ * @param statusMap 可选 sidebar status 映射；不传时行为与旧版完全一致。
  */
-export function filterArchivedThreads<T extends ArchivableConversation>(convs: T[]): T[] {
-    return convs.filter(conv => !isArchivedThreadConversation(conv))
+export function filterArchivedThreads<T extends ArchivableConversation>(
+    convs: T[],
+    statusMap?: ThreadSidebarStatusMap,
+): T[] {
+    return convs.filter(conv => !isArchivedThreadConversation(conv, statusMap))
 }

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -31,7 +31,7 @@ import {
     isVirtualCategory,
     type ValidCategoryItem,
 } from "./categoriesFallback"
-import { filterArchivedThreads, isArchivedThreadConversation } from "./archivedThreads"
+import { filterArchivedThreads, isArchivedThreadConversation, type ThreadSidebarStatusMap } from "./archivedThreads"
 import { useI18n } from "../../i18n"
 import { wkConfirm } from "../WKModal"
 
@@ -310,6 +310,21 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
         return new ConversationWrap(conv)
     }
 
+    // 子区 channelID → sidebar status（来自 /sidebar/sync 的 target_type=5 项）。
+    // 这是 archived 过滤的「第一路」信号：冷启动刷新后第一帧即可用，无需等 channelInfo
+    // 异步补齐，从源头消除归档子区「先闪一下再消失」的抖动（issue #340）。
+    // 缺失 status 字段（旧后端）的子区不写入，filterArchivedThreads 据此回退到 channelInfo。
+    const threadSidebarStatus: ThreadSidebarStatusMap = new Map()
+    if (itemsByCategory) {
+        for (const list of itemsByCategory.values()) {
+            for (const it of list) {
+                if (it.target_type !== 5) continue
+                if (it.status == null) continue
+                threadSidebarStatus.set(it.target_id, it.status)
+            }
+        }
+    }
+
     // 父群下「已关注子区」统一来源：合并 IM 缓存（按 followedKeys 过滤掉缓存里仍活跃
     // 但 sidebar 已 unfollow 的）+ sidebar 自己列出的 target_type=5 项（含 IM 没缓存的，
     // 通过 parent_channel_id 反挂父群）。渲染嵌套和拖父群 sort payload 共用，避免出现
@@ -341,7 +356,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
     // sort payload，避免隐藏归档子区导致后端 follow_sort 被意外改动。
     const visibleChildThreadsByParent = new Map<string, ConversationWrap[]>()
     for (const [parentGroupNo, threads] of followedChildThreadsByParent) {
-        visibleChildThreadsByParent.set(parentGroupNo, filterArchivedThreads(threads))
+        visibleChildThreadsByParent.set(parentGroupNo, filterArchivedThreads(threads, threadSidebarStatus))
     }
 
     // 构建右键菜单：取消关注 + 移出分组（有分组时，一级直接点击）+ 移到分组（一级，展开二级子菜单）
@@ -507,7 +522,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
             const withThreads: ConversationWrap[] = []
             for (const conv of catConvs) {
                 withThreads.push(conv)
-                const threads = filterArchivedThreads([...(threadConvsByParent.get(conv.channel.channelID) || [])])
+                const threads = filterArchivedThreads([...(threadConvsByParent.get(conv.channel.channelID) || [])], threadSidebarStatus)
                     .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
                 withThreads.push(...threads)
             }
@@ -546,7 +561,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                 } else if (it.target_type === 5) {
                     const threadConv = threadConvByChannel.get(it.target_id) || synthesizeFromItem(it)
                     // standalone 子区：明确归档的不在关注列表渲染（ThreadPanel 仍可查看/重新激活）。
-                    if (!isArchivedThreadConversation(threadConv)) {
+                    if (!isArchivedThreadConversation(threadConv, threadSidebarStatus)) {
                         catConvs.push(threadConv)
                     }
                 }
@@ -561,7 +576,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                 const groupConv = groupConvMap.get(g.group_no)
                 if (groupConv) {
                     catConvs.push(groupConv)
-                    const threads = filterArchivedThreads(threadConvsByParent.get(g.group_no) || [])
+                    const threads = filterArchivedThreads(threadConvsByParent.get(g.group_no) || [], threadSidebarStatus)
                     catConvs.push(...threads)
                 }
             }
@@ -569,7 +584,8 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
             const threadItems = threadsByCategory?.get(sidebarKey) || []
             const dmConvsInCat = dmItems.map(it => dmConvMap.get(it.target_id) || synthesizeFromItem(it))
             const standaloneThreadConvs = filterArchivedThreads(
-                threadItems.map(it => threadConvByChannel.get(it.target_id) || synthesizeFromItem(it))
+                threadItems.map(it => threadConvByChannel.get(it.target_id) || synthesizeFromItem(it)),
+                threadSidebarStatus,
             )
             const seenChannelIds = new Set(catConvs.map(c => c.channel.channelID))
             const dedupedThreads = standaloneThreadConvs.filter(c => !seenChannelIds.has(c.channel.channelID))

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -5,7 +5,7 @@ import ConversationList, {
 } from "../../Components/ConversationList";
 import SidebarTabBar, { SidebarTab } from "../../Components/SidebarTabBar";
 import ConversationListGrouped from "../../Components/ConversationListGrouped";
-import { isArchivedThreadConversation, type ThreadSidebarStatusMap } from "../../Components/ConversationListGrouped/archivedThreads";
+import { isThreadArchivedForBadge, type ThreadSidebarStatusMap } from "../../Components/ConversationListGrouped/archivedThreads";
 import ChatConversationList, {
   isMutedForRecentConversation,
 } from "../../Components/ChatConversationList";
@@ -140,14 +140,14 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
         )
       : undefined;
     // 与展开列表的展示层过滤一致：明确已归档的子区已从列表隐藏，未读也不计入
-    // 角标，否则会出现「红点 N 但列表里看不到对应未读」。角标这里同样先看 sidebar
-    // status（冷启动快路径），再回退 channelInfo，与列表的冷启动隐藏逻辑对齐。
-    // fail-open：status 未知 / liveConv 不存在（sidebar-only 子区，无 channelInfo）
-    // 仍按原逻辑累加，不漏算。
+    // 角标，否则会出现「红点 N 但列表里看不到对应未读」。
+    //   - liveConv 存在：走 channelInfo 优先（回退 sidebar statusMap）判归档；
+    //   - liveConv 缺失（sidebar-only 关注，从未聊过、无 channelInfo）：回退 sidebar
+    //     statusMap，sidebar=Archived 即隐藏，与列表的冷启动隐藏对齐。
+    // fail-open：status 未知（既非 archived，也无 liveConv channelInfo）仍累加，不漏算。
     if (
       it.target_type === SidebarTargetType.THREAD &&
-      liveConv &&
-      isArchivedThreadConversation(liveConv, threadSidebarStatus)
+      isThreadArchivedForBadge(liveConv, it.target_id, threadSidebarStatus)
     ) {
       return sum;
     }

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -5,7 +5,7 @@ import ConversationList, {
 } from "../../Components/ConversationList";
 import SidebarTabBar, { SidebarTab } from "../../Components/SidebarTabBar";
 import ConversationListGrouped from "../../Components/ConversationListGrouped";
-import { isArchivedThreadConversation } from "../../Components/ConversationListGrouped/archivedThreads";
+import { isArchivedThreadConversation, type ThreadSidebarStatusMap } from "../../Components/ConversationListGrouped/archivedThreads";
 import ChatConversationList, {
   isMutedForRecentConversation,
 } from "../../Components/ChatConversationList";
@@ -119,6 +119,15 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
   // IM 缓存有这条会话就用 live unread；没有（sidebar-only 关注，从未聊过）才
   // fallback sidebar 的 unread 快照——这样新消息一来 badge 即刻同步，sidebar-
   // only 关注又不会被漏算。
+  // 子区 channelID → sidebar status（来自 /sidebar/sync 的 target_type=5 项）。
+  // 与展开列表(ConversationListGrouped)用同一路信号：冷启动刷新后第一帧即可用，
+  // 无需等 channelInfo 异步补齐。下方角标过滤据此与列表的冷启动隐藏保持一致。
+  const threadSidebarStatus: ThreadSidebarStatusMap = new Map();
+  for (const it of items) {
+    if (it.target_type !== SidebarTargetType.THREAD) continue;
+    if (it.status == null) continue;
+    threadSidebarStatus.set(it.target_id, it.status);
+  }
   const followUnread = items.reduce((sum, it) => {
     if (isItemMuted(it)) return sum;
     let channelType: number | null = null;
@@ -131,12 +140,14 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
         )
       : undefined;
     // 与展开列表的展示层过滤一致：明确已归档的子区已从列表隐藏，未读也不计入
-    // 角标，否则会出现「红点 N 但列表里看不到对应未读」。fail-open：status 未知 /
-    // liveConv 不存在（sidebar-only 子区，无 channelInfo）仍按原逻辑累加，不漏算。
+    // 角标，否则会出现「红点 N 但列表里看不到对应未读」。角标这里同样先看 sidebar
+    // status（冷启动快路径），再回退 channelInfo，与列表的冷启动隐藏逻辑对齐。
+    // fail-open：status 未知 / liveConv 不存在（sidebar-only 子区，无 channelInfo）
+    // 仍按原逻辑累加，不漏算。
     if (
       it.target_type === SidebarTargetType.THREAD &&
       liveConv &&
-      isArchivedThreadConversation(liveConv)
+      isArchivedThreadConversation(liveConv, threadSidebarStatus)
     ) {
       return sum;
     }

--- a/packages/dmworkbase/src/Service/SidebarService.ts
+++ b/packages/dmworkbase/src/Service/SidebarService.ts
@@ -25,6 +25,9 @@ export interface SidebarItem {
     follow_sort?: number
     /** 子区携带，指向父群 channelID */
     parent_channel_id?: string
+    /** 仅子区(target_type=5)携带：1=active, 2=archived。
+     *  缺失=状态未知（旧后端 / 非子区），消费方应回退到 channelInfo。 */
+    status?: number
 }
 
 export interface SidebarSyncReq {


### PR DESCRIPTION
Closes #340.

## Problem

In the followed (关注) group list, after a page refresh, the first time a group's thread list renders, archived threads briefly flash on screen (or stay visible until another thread is clicked), then collapse to show only active threads.

## Root cause

The follow-tab archived filter (`filterArchivedThreads` / `isArchivedThreadConversation` in `ConversationListGrouped/archivedThreads.ts`) reads thread status from `channelInfo.orgData.thread.status` and is intentionally fail-open (unknown status → visible). On a cold cache after refresh, `channelInfo` for thread rows is not loaded yet, so archived threads pass the filter and render; only after `fetchChannelInfo` resolves does a re-render drop them. Hence the flicker / "stays until interaction".

## Fix

`/sidebar/sync` now returns a `status` field on thread items (`target_type=5`): `1=active`, `2=archived` (absence = unknown). The follow-tab list uses this sidebar status to filter archived threads synchronously, with no dependency on `channelInfo` load timing.

Precedence in `isArchivedThreadConversation`:
1. If live `channelInfo` thread status is known → authoritative (so a freshly-unarchived thread whose `channelInfo` refreshed to active reappears immediately, overriding a stale sidebar snapshot).
2. Else if the sidebar status map has the thread → use sidebar status (kills the cold-start flicker on first paint).
3. Else → fail-open (visible), preserving the existing contract so genuinely-unknown active threads are never wrongly hidden.

The follow-tab unread badge counter is updated to consult the same sidebar status, keeping the badge consistent with the list during the cold-start window.

## Changes

- `Service/SidebarService.ts` — add optional `status` to `SidebarItem` (thread items only).
- `Components/ConversationListGrouped/archivedThreads.ts` — status-aware filter with the precedence above; helper signatures stay backward-compatible (optional `statusMap`).
- `Components/ConversationListGrouped/index.tsx` — build a channelID→status map from sidebar items and pass it to all filter call sites.
- `Pages/Chat/index.tsx` — follow-tab unread badge uses the same sidebar status.
- `Components/ConversationListGrouped/__tests__/archivedThreads.test.ts` — added cases: cold-start sidebar=archived hidden, sidebar=active visible, stale sidebar=archived + fresh channelInfo=active visible, channelInfo authoritative, fail-open back-compat.

Depends on the backend change that adds `status` to thread items in `/sidebar/sync`.

## Testing

- Unit: `archivedThreads.test.ts` — all pass (18/18).
- Build: full web app build passes.
- End-to-end (local deploy, real backend + frontend): with a user following 3 active + 27 archived child threads under one group, after a hard refresh the expanded follow list shows only the 3 active threads; archived threads never appear at any frame (82 DOM samples over 3.5s), and stay hidden across collapse/re-expand and interactions.
