### PR TITLE
fix: keep thread unread off parent recent rows

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -168,6 +168,15 @@ describe("ConversationVM message ordering", () => {
         sdkState.sendingQueues.clear()
     })
 
+    it("uses a unique message container id for each instance", () => {
+        const first = new ConversationVM(channel)
+        const second = new ConversationVM(channel)
+
+        expect(first.messageContainerId).toMatch(/^viewport-\d+$/)
+        expect(second.messageContainerId).toMatch(/^viewport-\d+$/)
+        expect(first.messageContainerId).not.toBe(second.messageContainerId)
+    })
+
     it("sorts no-seq messages with invalid order after sequenced messages", () => {
         const vm = new ConversationVM(channel)
         const seq2 = wrap({ clientMsgNo: "seq2", messageSeq: 2, timestamp: 200 })

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -70,6 +70,8 @@ const PendingMessageOrderBase = Number.MAX_SAFE_INTEGER / 2
 
 export default class ConversationVM extends ProviderListener {
 
+    private static nextMessageContainerSeq = 0
+
     loading: boolean = false // 消息是否加载中
     channel: Channel
     channelInfo?: ChannelInfo // 当前会话的频道详情
@@ -87,7 +89,7 @@ export default class ConversationVM extends ProviderListener {
     pullupHasMore: boolean = false // 上拉是否有更多
     pulldownFinished: boolean = false // 下拉完成
     pendingMessages: MessageWrap[] = [] // 缓冲区：pullupHasMore 期间收到的实时消息
-    messageContainerId = "viewport" // 消息容器的ID
+    messageContainerId = `viewport-${ConversationVM.nextMessageContainerSeq++}` // 消息容器的ID
     static sendQueue: Map<string, Array<MessageWrap>> = new Map() // 发送队列
     static foldSessionPreview: Map<string, { participants: string[], count: number }> = new Map() // 会话列表折叠预览缓存
     private _needSetUnread: boolean = false // 是否需要设置未读数量

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { collapsedThreadUnread } from "../unread"
+
+const thread = (
+  unread: number,
+  mute?: number | null
+) => ({
+  unread,
+  channelInfo: {
+    orgData: {
+      thread: {
+        mute,
+      },
+    },
+  },
+})
+
+describe("collapsedThreadUnread", () => {
+  it("does not fold thread unread into parent rows when disabled", () => {
+    expect(collapsedThreadUnread([thread(3), thread(2)], false, false)).toBe(0)
+  })
+
+  it("sums unmuted collapsed thread unread when enabled", () => {
+    expect(collapsedThreadUnread([thread(3), thread(2, 0)], false, true)).toBe(5)
+  })
+
+  it("excludes explicitly muted threads", () => {
+    expect(collapsedThreadUnread([thread(3), thread(2, 1)], false, true)).toBe(3)
+  })
+
+  it("inherits parent mute only when the thread has no explicit setting", () => {
+    expect(collapsedThreadUnread([thread(3), thread(2, 0)], true, true)).toBe(2)
+  })
+})

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -38,6 +38,7 @@ import ConversationVM from "../Conversation/vm";
 import { I18nContext, t, useI18n } from "../../i18n";
 import { formatDraftPreview } from "../../Utils/draftPreview";
 import { wkConfirm } from "../WKModal";
+import { collapsedThreadUnread } from "./unread";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
 // ── CompactGroupItem：群聊 Tab 紧凑 item，支持拖拽 ──────────────────────
@@ -679,9 +680,9 @@ export default class ConversationList extends Component<
     const { locatingUnreadKey, locatingUnreadPulse } = this.state;
     const typing = TypingManager.shared.getTyping(conversationWrap.channel);
     const selected = select && select.isEqual(conversationWrap.channel);
-    // 父群下的子区折叠到 thread-overflow（默认不展开），父群 badge 必须把
-    // 折叠中的子区未读一起显示，否则会出现「角标显示 N 但列表里看不到任何未读」。
-    // 已展开时 threadUnread 由调用处传 0，自然只显示父群自身。
+    // compact mode nests collapsed threads under the parent group, so the
+    // parent item receives the collapsed unread count. Recent mode renders
+    // threads as independent rows and must keep parent unread independent.
     const totalUnread = conversationWrap.unread + threadUnread;
     const hasMention = conversationWrap.isMentionMe && totalUnread > 0;
     const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
@@ -1217,16 +1218,10 @@ export default class ConversationList extends Component<
         if (!hasThreads) return 0;
         if (this._isThreadExpanded(conv.channel.channelID)) return 0;
         const threads = threadsByParent.get(conv.channel.channelID) ?? [];
-        // 子区有独立免打扰设置，汇总时过滤掉已开启免打扰的子区未读
-        return threads.reduce((sum, t) => {
-          // 对齐 effectiveMute 逻辑：显式设置看自身，未设置继承父群
-          const rawMute = (t.channelInfo?.orgData?.thread as any)?.mute as number | null | undefined
-          const parentInfo = WKSDK.shared().channelManager.getChannelInfo(
-            new Channel(conv.channel.channelID, ChannelTypeGroup)
-          )
-          const tMute = rawMute != null ? rawMute === 1 : !!(parentInfo?.mute)
-          return sum + (tMute ? 0 : t.unread)
-        }, 0);
+        const parentInfo = WKSDK.shared().channelManager.getChannelInfo(
+          new Channel(conv.channel.channelID, ChannelTypeGroup)
+        );
+        return collapsedThreadUnread(threads, !!parentInfo?.mute, !!compact);
       })();
       return this.conversationItem(conv, hasThreads, threadUnread);
     };

--- a/packages/dmworkbase/src/Components/ConversationList/unread.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/unread.ts
@@ -1,0 +1,31 @@
+interface ThreadUnreadSource {
+  unread?: number
+  channelInfo?: {
+    orgData?: {
+      thread?: {
+        mute?: number | null
+      }
+    }
+  }
+}
+
+export function isThreadUnreadMuted(
+  thread: ThreadUnreadSource,
+  parentMuted: boolean
+): boolean {
+  const rawMute = thread.channelInfo?.orgData?.thread?.mute
+  return rawMute != null ? rawMute === 1 : parentMuted
+}
+
+export function collapsedThreadUnread(
+  threads: ThreadUnreadSource[],
+  parentMuted: boolean,
+  includeCollapsedThreadUnread: boolean
+): number {
+  if (!includeCollapsedThreadUnread) return 0
+
+  return threads.reduce((sum, thread) => {
+    if (isThreadUnreadMuted(thread, parentMuted)) return sum
+    return sum + (thread.unread || 0)
+  }, 0)
+}


### PR DESCRIPTION
## Summary
- stop folding child thread unread into parent group rows in the recent conversation list
- preserve collapsed thread unread aggregation for compact/follow views where threads are nested under the parent
- give each ConversationVM instance a unique message container id so parent group and thread panel read-state DOM queries do not collide

## Tests
- pnpm vitest run packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts

Note: pnpm --filter @octo/base exec tsc --noEmit still fails on existing third-party/Semi, React type, Storybook moduleResolution, and test global type errors unrelated to this change.