### PR TITLE
fix: remove deleted thread conversations locally

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -15,6 +15,11 @@ export type MittEvents = {
     shortId?: string;
     thread?: import("./Service/Thread").Thread;
   };
+  "wk:thread-deleted": {
+    groupNo: string;
+    threadChannelId: string;
+    shortId?: string;
+  };
   "wk:close-thread-panel": undefined;
   "wk:toggle-matter-panel": { channelId: string; channelType: number };
   /** v0.7 Matter 详情面板切换（跟子区/文件预览/任务列表可并存） */

--- a/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
+++ b/packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx
@@ -7,6 +7,7 @@ const hoisted = vi.hoisted(() => {
     const state = {
         listener: undefined as undefined | ((conversation: any, action: any) => void),
         threadCreatedListener: undefined as undefined | ((event: any) => void),
+        threadDeletedListener: undefined as undefined | ((event: any) => void),
         sidebarReloadListener: undefined as undefined | ((event: any) => void),
     }
     const sync = vi.fn()
@@ -38,6 +39,8 @@ const hoisted = vi.hoisted(() => {
                 on: vi.fn((event: string, listener: (event: any) => void) => {
                     if (event === "wk:thread-created") {
                         state.threadCreatedListener = listener
+                    } else if (event === "wk:thread-deleted") {
+                        state.threadDeletedListener = listener
                     } else if (event === "sidebar-reload") {
                         state.sidebarReloadListener = listener
                     }
@@ -45,6 +48,8 @@ const hoisted = vi.hoisted(() => {
                 off: vi.fn((event: string, listener: (event: any) => void) => {
                     if (event === "wk:thread-created" && state.threadCreatedListener === listener) {
                         state.threadCreatedListener = undefined
+                    } else if (event === "wk:thread-deleted" && state.threadDeletedListener === listener) {
+                        state.threadDeletedListener = undefined
                     } else if (event === "sidebar-reload" && state.sidebarReloadListener === listener) {
                         state.sidebarReloadListener = undefined
                     }
@@ -123,6 +128,7 @@ describe("useFollowSidebar", () => {
         vi.useFakeTimers()
         hoisted.state.listener = undefined
         hoisted.state.threadCreatedListener = undefined
+        hoisted.state.threadDeletedListener = undefined
         hoisted.state.sidebarReloadListener = undefined
         hoisted.sync.mockReset()
         hoisted.addConversationListener.mockClear()
@@ -247,5 +253,37 @@ describe("useFollowSidebar", () => {
         expect(latest?.isLoading).toBe(false)
         // 拿到最新已读快照，关注 tab 角标可归零
         expect(latest?.items.find((it) => it.target_id === "group-a")?.unread).toBe(0)
+    })
+
+    it("refreshes the followed sidebar when a thread is deleted", async () => {
+        let latest: ReturnType<typeof useFollowSidebar> | undefined
+        hoisted.sync
+            .mockResolvedValueOnce({ items: [groupItem, threadItem], follow_version: 1, version: 1 })
+            .mockResolvedValueOnce({ items: [groupItem], follow_version: 2, version: 2 })
+
+        await act(async () => {
+            ReactDOM.render(<Probe onValue={(value) => { latest = value }} />, container)
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.fakeWKApp.mittBus.on).toHaveBeenCalledWith(
+            "wk:thread-deleted",
+            expect.any(Function)
+        )
+        expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(true)
+
+        await act(async () => {
+            hoisted.state.threadDeletedListener?.({
+                groupNo: "group-a",
+                threadChannelId: "group-a____thread-1",
+                shortId: "thread-1",
+            })
+            await flushMicrotasks()
+        })
+
+        expect(hoisted.sync).toHaveBeenCalledTimes(2)
+        expect(latest?.followedKeys.has("5::group-a____thread-1")).toBe(false)
+        expect(latest?.itemsByCategory.get("cat-a")?.map((it) => it.target_id))
+            .toEqual(["group-a"])
     })
 })

--- a/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
+++ b/packages/dmworkbase/src/Hooks/useFollowSidebar.ts
@@ -213,6 +213,14 @@ export function useFollowSidebar(): UseFollowSidebarResult {
             threadReloadTimersRef.current.clear()
         }
     }, [scheduleThreadReload])
+
+    useEffect(() => {
+        const listener = () => load({ silent: true })
+        WKApp.mittBus.on("wk:thread-deleted", listener)
+        return () => {
+            WKApp.mittBus.off("wk:thread-deleted", listener)
+        }
+    }, [load])
     // sort 成功后调，乐观自增 ref，避免连续拖拽用旧版本号触发 CAS conflict
     const bumpVersion = useCallback(() => {
         versionRef.current = versionRef.current + 1

--- a/packages/dmworkdatasource/src/datasource.test.ts
+++ b/packages/dmworkdatasource/src/datasource.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const hoisted = vi.hoisted(() => {
+    const apiDelete = vi.fn()
+    const mittEmit = vi.fn()
+    const deleteChannelInfo = vi.fn()
+    const removeConversation = vi.fn()
+    return {
+        apiDelete,
+        mittEmit,
+        deleteChannelInfo,
+        removeConversation,
+        mockWKApp: {
+            apiClient: {
+                delete: apiDelete,
+            },
+            mittBus: {
+                emit: mittEmit,
+            },
+            shared: {
+                currentSpaceId: "",
+                avatarUser: vi.fn(),
+                avatarChannel: vi.fn(),
+            },
+        },
+    }
+})
+
+vi.mock("@octo/base", () => ({
+    ChannelQrcodeResp: class {},
+    ChannelTypeCommunityTopic: 5,
+    Contacts: class {},
+    GroupRole: {},
+    RequestConfig: class {},
+    WKApp: hoisted.mockWKApp,
+    buildThreadChannelId: (groupNo: string, shortId: string) => `${groupNo}____${shortId}`,
+    hasSpacePrefix: vi.fn(() => false),
+    parseThreadChannelId: vi.fn(() => null),
+}))
+
+vi.mock("wukongimjssdk", () => ({
+    Channel: class {
+        channelID: string
+        channelType: number
+
+        constructor(channelID: string, channelType: number) {
+            this.channelID = channelID
+            this.channelType = channelType
+        }
+    },
+    ChannelInfo: class {},
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    ConversationExtra: class {},
+    Message: class {},
+    MessageContentType: {},
+    Subscriber: class {},
+    WKSDK: {
+        shared: () => ({
+            channelManager: {
+                deleteChannelInfo: hoisted.deleteChannelInfo,
+            },
+            conversationManager: {
+                removeConversation: hoisted.removeConversation,
+            },
+        }),
+    },
+}))
+
+import { ChannelDataSource } from "./datasource"
+
+describe("ChannelDataSource.threadDelete", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        hoisted.apiDelete.mockResolvedValue(undefined)
+    })
+
+    it("removes the deleted thread conversation from local realtime state", async () => {
+        await new ChannelDataSource().threadDelete("group-a", "thread-1")
+
+        expect(hoisted.apiDelete).toHaveBeenCalledWith("groups/group-a/threads/thread-1")
+        const deletedChannel = expect.objectContaining({
+            channelID: "group-a____thread-1",
+            channelType: 5,
+        })
+        expect(hoisted.deleteChannelInfo).toHaveBeenCalledWith(deletedChannel)
+        expect(hoisted.removeConversation).toHaveBeenCalledWith(deletedChannel)
+        expect(hoisted.mittEmit).toHaveBeenCalledWith("wk:thread-deleted", {
+            groupNo: "group-a",
+            shortId: "thread-1",
+            threadChannelId: "group-a____thread-1",
+        })
+    })
+})

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -278,7 +278,16 @@ export class ChannelDataSource implements IChannelDataSource {
     }
 
     async threadDelete(groupNo: string, shortId: string): Promise<void> {
-        return WKApp.apiClient.delete(`groups/${groupNo}/threads/${shortId}`)
+        await WKApp.apiClient.delete(`groups/${groupNo}/threads/${shortId}`)
+        const threadChannelId = buildThreadChannelId(groupNo, shortId)
+        const threadChannel = new Channel(threadChannelId, ChannelTypeCommunityTopic)
+        WKSDK.shared().channelManager.deleteChannelInfo(threadChannel)
+        WKSDK.shared().conversationManager.removeConversation(threadChannel)
+        WKApp.mittBus.emit("wk:thread-deleted", {
+            groupNo,
+            shortId,
+            threadChannelId,
+        })
     }
 
     async threadUpdate(groupNo: string, shortId: string, data: { name: string }): Promise<void> {


### PR DESCRIPTION
## Summary
- remove deleted thread channel info and SDK conversation cache after the delete API succeeds
- emit `wk:thread-deleted` so the follow sidebar silently reloads and drops deleted thread items without a page refresh
- add regression coverage for datasource delete side effects and follow sidebar reload

Fixes #280

## Tests
- `pnpm vitest run --environment jsdom packages/dmworkdatasource/src/datasource.test.ts packages/dmworkbase/src/Hooks/__tests__/useFollowSidebar.test.tsx`
- `pnpm --filter @octo/datasource test`
- `pnpm --filter @octo/web build` (passes; existing VITE_API_URL / eval / chunk-size warnings remain)