### PR TITLE
fix: support archived threads in smart summary selector, exclude from forward targets (#346)

### DIFF
--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+/**
+ * 转发目标排除归档子区（issue #346 需求 2）。
+ *
+ * useForwardModal.rebuildConvItems 在构建子区来源时复用侧栏的 fail-open
+ * helper filterArchivedThreads：
+ *   - 明确 status=Archived(2) 的子区 → 不出现在转发目标
+ *   - 活跃(1) / status 未知（channelInfo 未加载）的子区 → 保留（fail-open）
+ *   - 群聊/私聊不受影响
+ *
+ * 这里 mock 掉 WKSDK / WKApp 的数据源，但使用真实的 archivedThreads.ts，
+ * 守护「归档子区冒出来当转发目标」的回归。
+ *
+ * 渲染采用与 useFollowSidebar.test.tsx 一致的 React 17 legacy
+ * ReactDOM.render + Probe 模式，避免依赖 @testing-library/react。
+ */
+
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+import { ThreadStatus } from "../../../Service/Thread"
+
+const CT_GROUP = 2
+
+const hoisted = vi.hoisted(() => {
+    return {
+        conversations: [] as any[],
+        getChannelInfo: vi.fn(() => undefined),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        fetchChannelInfo: vi.fn(),
+        groupSaveList: vi.fn(async () => []),
+        searchFriends: vi.fn(async () => []),
+        mittOn: vi.fn(),
+        mittOff: vi.fn(),
+    }
+})
+
+// 真实 ConversationWrap 依赖完整 SDK；这里用最小透传桩，只暴露
+// channel / channelInfo / timestamp，足够 rebuildConvItems 与 filterArchivedThreads 使用。
+vi.mock("../../../Service/Model", () => ({
+    ConversationWrap: class {
+        conversation: any
+        constructor(conversation: any) {
+            this.conversation = conversation
+        }
+        get channel() {
+            return this.conversation.channel
+        }
+        get channelInfo() {
+            return this.conversation.channelInfo
+        }
+        get timestamp() {
+            return this.conversation.timestamp ?? 0
+        }
+    },
+}))
+
+vi.mock("wukongimjssdk", () => {
+    class Channel {
+        channelID: string
+        channelType: number
+        constructor(channelID: string, channelType: number) {
+            this.channelID = channelID
+            this.channelType = channelType
+        }
+    }
+    return {
+        __esModule: true,
+        WKSDK: {
+            shared: () => ({
+                conversationManager: { conversations: hoisted.conversations },
+                channelManager: {
+                    getChannelInfo: hoisted.getChannelInfo,
+                    addListener: hoisted.addListener,
+                    removeListener: hoisted.removeListener,
+                    fetchChannelInfo: hoisted.fetchChannelInfo,
+                },
+            }),
+        },
+        Channel,
+        ChannelInfo: class {},
+        ChannelTypeGroup: 2,
+    }
+})
+
+vi.mock("../../../Service/SpaceService", () => ({
+    shouldSkipChannelForSpace: () => false,
+    shouldSkipPersonConversationForSpace: () => false,
+}))
+
+vi.mock("../../../Utils/rateLimit", () => ({
+    debounce: (fn: any) => {
+        const wrapped = (...args: any[]) => fn(...args)
+        wrapped.cancel = () => {}
+        return wrapped
+    },
+}))
+
+vi.mock("../../../App", () => ({
+    default: {
+        shared: { currentSpaceId: undefined },
+        dataSource: {
+            channelDataSource: { groupSaveList: hoisted.groupSaveList },
+            commonDataSource: { searchFriends: hoisted.searchFriends },
+        },
+        mittBus: { on: hoisted.mittOn, off: hoisted.mittOff },
+        searchChatCandidates: undefined,
+    },
+}))
+
+import { useForwardModal } from "../useForwardModal"
+
+function makeConv(channelID: string, channelType: number, displayName: string, opts: {
+    parentGroupNo?: string
+    threadStatus?: number
+    noChannelInfo?: boolean
+    timestamp?: number
+} = {}) {
+    if (opts.noChannelInfo) {
+        return { channel: { channelID, channelType }, channelInfo: undefined, timestamp: opts.timestamp ?? 0 }
+    }
+    const orgData: any = { displayName }
+    if (opts.parentGroupNo) orgData.parentGroupNo = opts.parentGroupNo
+    if (opts.threadStatus !== undefined) orgData.thread = { status: opts.threadStatus }
+    return {
+        channel: { channelID, channelType },
+        channelInfo: { orgData },
+        timestamp: opts.timestamp ?? 0,
+    }
+}
+
+function Probe({ onValue }: { onValue: (value: ReturnType<typeof useForwardModal>) => void }) {
+    const value = useForwardModal()
+    onValue(value)
+    return null
+}
+
+async function flushMicrotasks() {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+}
+
+async function renderForward() {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: ReturnType<typeof useForwardModal> | undefined
+    await act(async () => {
+        ReactDOM.render(<Probe onValue={(value) => { latest = value }} />, container)
+        await flushMicrotasks()
+    })
+    return {
+        get current() {
+            return latest!
+        },
+        unmount() {
+            act(() => {
+                ReactDOM.unmountComponentAtNode(container)
+            })
+            container.remove()
+        },
+    }
+}
+
+describe("useForwardModal — archived threads excluded from forward targets", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        hoisted.getChannelInfo.mockReturnValue(undefined)
+        hoisted.groupSaveList.mockResolvedValue([])
+        hoisted.searchFriends.mockResolvedValue([])
+    })
+
+    afterEach(() => {
+        hoisted.conversations = []
+    })
+
+    it("excludes archived(status=2) threads, keeps active(1), unknown-status, and groups (fail-open)", async () => {
+        hoisted.conversations = [
+            makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 }),
+            makeConv("t-active", ChannelTypeCommunityTopic, "Active Thread", {
+                parentGroupNo: "g1", threadStatus: ThreadStatus.Active, timestamp: 90,
+            }),
+            makeConv("t-archived", ChannelTypeCommunityTopic, "Archived Thread", {
+                parentGroupNo: "g1", threadStatus: ThreadStatus.Archived, timestamp: 80,
+            }),
+            makeConv("t-unknown", ChannelTypeCommunityTopic, "Unknown Thread", {
+                parentGroupNo: "g1", timestamp: 70, // no thread.status → fail-open keep
+            }),
+        ]
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g1")
+        expect(ids).toContain("t-active")
+        expect(ids).toContain("t-unknown")
+        expect(ids).not.toContain("t-archived")
+
+        view.unmount()
+    })
+
+    it("keeps a thread whose channelInfo has not loaded yet (status unknown → fail-open)", async () => {
+        hoisted.conversations = [
+            makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 }),
+            makeConv("t-noinfo", ChannelTypeCommunityTopic, "", { noChannelInfo: true, timestamp: 60 }),
+        ]
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("t-noinfo")
+
+        view.unmount()
+    })
+
+    it("does not filter groups or direct conversations", async () => {
+        hoisted.conversations = [
+            makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 }),
+            makeConv("g2", CT_GROUP, "Group 2", { timestamp: 95 }),
+        ]
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g1")
+        expect(ids).toContain("g2")
+
+        view.unmount()
+    })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -3,6 +3,7 @@ import { WKSDK, Channel, ChannelInfo, ChannelInfoListener, ChannelTypeGroup } fr
 import { ConversationWrap } from "../../Service/Model"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import { shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace } from "../../Service/SpaceService"
+import { filterArchivedThreads } from "../ConversationListGrouped/archivedThreads"
 import { debounce } from "../../Utils/rateLimit"
 import WKApp from "../../App"
 import { ForwardItem } from "./ForwardModal"
@@ -150,10 +151,15 @@ export function useForwardModal(
       }
     }
 
+    // 转发目标永不包含已归档子区：复用侧栏的 fail-open helper
+    // （仅过滤明确 status=Archived 的子区，status 未知/未加载的子区保留）。
+    // 仅作用于子区来源，不触碰群聊/私聊。
+    const visibleThreadWraps = filterArchivedThreads(threadWraps)
+
     // 按 parentGroupNo 建 Map
     const threadsByParent = new Map<string, ConversationWrap[]>()
     const orphanThreads: ConversationWrap[] = []
-    for (const tw of threadWraps) {
+    for (const tw of visibleThreadWraps) {
       const parentGroupNoRaw = tw.channelInfo?.orgData?.parentGroupNo
       const parentGroupNo = parentGroupNoRaw != null ? String(parentGroupNoRaw) : undefined
       if (parentGroupNo) {

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -254,7 +254,7 @@ export async function toggleSchedule(scheduleId: number, isActive: boolean): Pro
 
 // ─── Candidate Selection ───────────────────────────────
 
-export async function getChatCandidates(params?: { keyword?: string; chat_type?: string }): Promise<ChatCandidate[]> {
+export async function getChatCandidates(params?: { keyword?: string; chat_type?: string; include_archived?: boolean }): Promise<ChatCandidate[]> {
     const data = await get<ChatCandidate[]>('/summary-chat-candidates', params as Record<string, unknown>);
     return data || [];
 }

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -42,28 +42,33 @@ export default class ChatSelectorModal extends Component<Props, State> {
         includeArchived: false,
     };
 
+    private reqSeq = 0;
+
     componentDidUpdate(prevProps: Props) {
         if (this.props.visible && !prevProps.visible) {
             this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "all", includeArchived: false });
-            this.loadCandidates();
+            this.loadCandidates(false);
         }
     }
 
-    async loadCandidates() {
+    async loadCandidates(includeArchivedOverride?: boolean) {
+        const includeArchived = includeArchivedOverride ?? this.state.includeArchived;
+        const seq = ++this.reqSeq;
         this.setState({ loading: true });
         try {
-            const params = this.state.includeArchived ? { include_archived: true } : {};
+            const params = includeArchived ? { include_archived: true } : {};
             const candidates = await api.getChatCandidates(params);
+            if (seq !== this.reqSeq) return;
             this.setState({ candidates, loading: false });
         } catch {
+            if (seq !== this.reqSeq) return;
             this.setState({ loading: false });
         }
     }
 
     handleIncludeArchivedChange = (checked: boolean) => {
-        this.setState({ includeArchived: checked }, () => {
-            this.loadCandidates();
-        });
+        this.setState({ includeArchived: checked });
+        this.loadCandidates(checked);
     };
 
     handleKeywordChange = (val: string) => {
@@ -271,6 +276,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
                         checked={includeArchived}
                         onChange={this.handleIncludeArchivedChange}
                         size="small"
+                        aria-label={t("summary.chatSelector.includeArchived")}
                     />
                     <span style={{ fontSize: 13 }}>{t("summary.chatSelector.includeArchived")}</span>
                     <span style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Modal, Input, Tabs, TabPane, Checkbox, Button, Spin, Empty, Tag } from "@douyinfe/semi-ui";
+import { Modal, Input, Tabs, TabPane, Checkbox, Button, Spin, Empty, Tag, Switch } from "@douyinfe/semi-ui";
 import { IconSearch } from "@douyinfe/semi-icons";
 import { I18nContext } from "@octo/base";
 import type { ChatCandidate } from "../types/summary";
@@ -21,6 +21,7 @@ interface State {
     candidates: ChatCandidate[];
     loading: boolean;
     localSelected: ChatCandidate[];
+    includeArchived: boolean;
 }
 
 interface DisplayEntry {
@@ -38,11 +39,12 @@ export default class ChatSelectorModal extends Component<Props, State> {
         candidates: [],
         loading: false,
         localSelected: [],
+        includeArchived: false,
     };
 
     componentDidUpdate(prevProps: Props) {
         if (this.props.visible && !prevProps.visible) {
-            this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "all" });
+            this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "all", includeArchived: false });
             this.loadCandidates();
         }
     }
@@ -50,12 +52,19 @@ export default class ChatSelectorModal extends Component<Props, State> {
     async loadCandidates() {
         this.setState({ loading: true });
         try {
-            const candidates = await api.getChatCandidates({});
+            const params = this.state.includeArchived ? { include_archived: true } : {};
+            const candidates = await api.getChatCandidates(params);
             this.setState({ candidates, loading: false });
         } catch {
             this.setState({ loading: false });
         }
     }
+
+    handleIncludeArchivedChange = (checked: boolean) => {
+        this.setState({ includeArchived: checked }, () => {
+            this.loadCandidates();
+        });
+    };
 
     handleKeywordChange = (val: string) => {
         this.setState({ keyword: val });
@@ -192,6 +201,11 @@ export default class ChatSelectorModal extends Component<Props, State> {
                         {item.chat_type === "direct" && item.is_bot && (
                             <span style={{ marginLeft: 4 }}><AiBadge size="small" /></span>
                         )}
+                        {item.is_archived && (
+                            <Tag size="small" color="grey" style={{ marginLeft: 6 }}>
+                                {t("summary.chatSelector.archivedTag")}
+                            </Tag>
+                        )}
                     </div>
                     {item.member_count !== null && (
                         <div style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>
@@ -214,7 +228,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     render() {
         const { visible, onCancel, maxSelect = MAX_CHAT_SELECT } = this.props;
-        const { keyword, activeTab, loading, localSelected } = this.state;
+        const { keyword, activeTab, loading, localSelected, includeArchived } = this.state;
         const { t } = this.context;
         const displayList = this.getDisplayList();
 
@@ -252,6 +266,17 @@ export default class ChatSelectorModal extends Component<Props, State> {
                     <TabPane tab={t("summary.source.groupChat")} itemKey="group" />
                     <TabPane tab={t("summary.source.directMessage")} itemKey="direct" />
                 </Tabs>
+                <div style={{ display: "flex", alignItems: "center", padding: "8px 0", gap: 8 }}>
+                    <Switch
+                        checked={includeArchived}
+                        onChange={this.handleIncludeArchivedChange}
+                        size="small"
+                    />
+                    <span style={{ fontSize: 13 }}>{t("summary.chatSelector.includeArchived")}</span>
+                    <span style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>
+                        {t("summary.chatSelector.includeArchivedHelper")}
+                    </span>
+                </div>
                 <div style={{ minHeight: 240, maxHeight: 360, overflowY: "auto" }}>
                     {loading ? (
                         <div style={{ textAlign: "center", paddingTop: 60 }}><Spin /></div>

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -259,6 +259,9 @@ export default class ChatSummaryNewModal extends Component<
                                 ? t('summary.create.selectedChats', { values: { count: selectedChats.length } })
                                 : t('summary.create.selectChat')}
                         </Button>
+                        <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--semi-color-text-2)' }}>
+                            {t('summary.create.archivedNotice')}
+                        </span>
                         {selectedChats.length > 0 && (
                             <div className="chat-summary-modal-chat-tags">
                                 {selectedChats.map((c) => (

--- a/packages/dmworksummary/src/components/__tests__/ChatSelectorModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSelectorModal.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render as rtlRender, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatSelectorModal from '../ChatSelectorModal';
+import type { ChatCandidate } from '../../types/summary';
+
+const mockGetChatCandidates = vi.fn();
+
+vi.mock('../../api/summaryApi', () => ({
+    getChatCandidates: (...args: any[]) => mockGetChatCandidates(...args),
+}));
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return actual;
+});
+
+vi.mock('@octo/base/src/Components/AiBadge', () => ({
+    default: () => <span data-testid="ai-badge" />,
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconSearch: () => <span data-testid="icon-search" />,
+}));
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Modal: ({ children, visible, footer }: any) =>
+        visible ? (
+            <div data-testid="modal">
+                <div data-testid="modal-body">{children}</div>
+                <div data-testid="modal-footer">{footer}</div>
+            </div>
+        ) : null,
+    Input: ({ value, onChange, placeholder }: any) => (
+        <input
+            data-testid="search-input"
+            value={value}
+            placeholder={placeholder}
+            onChange={(e: any) => onChange(e.target.value)}
+        />
+    ),
+    Tabs: ({ children }: any) => <div data-testid="tabs">{children}</div>,
+    TabPane: ({ tab }: any) => <span>{tab}</span>,
+    Checkbox: ({ checked, disabled }: any) => (
+        <input type="checkbox" readOnly checked={!!checked} disabled={disabled} />
+    ),
+    Switch: ({ checked, onChange }: any) => (
+        <input
+            type="checkbox"
+            data-testid="include-archived-switch"
+            checked={!!checked}
+            onChange={(e: any) => onChange(e.target.checked)}
+        />
+    ),
+    Button: ({ children, onClick, disabled }: any) => (
+        <button onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+    Spin: () => <div data-testid="spinner">loading</div>,
+    Empty: ({ description }: any) => <div data-testid="empty">{description}</div>,
+    Tag: ({ children }: any) => <span data-testid="tag">{children}</span>,
+}));
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const ACTIVE_THREAD: ChatCandidate = {
+    chat_id: 't-active',
+    chat_type: 'thread',
+    name: 'Active Thread',
+    member_count: 3,
+    is_archived: false,
+};
+
+const ARCHIVED_THREAD: ChatCandidate = {
+    chat_id: 't-archived',
+    chat_type: 'thread',
+    name: 'Archived Thread',
+    member_count: 2,
+    is_archived: true,
+};
+
+const baseProps = {
+    selected: [],
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+};
+
+// The modal loads candidates on a visible false→true transition
+// (componentDidUpdate), so we mount closed then re-render open.
+async function open(initialCandidates: ChatCandidate[]) {
+    mockGetChatCandidates.mockResolvedValue(initialCandidates);
+    let utils: ReturnType<typeof rtlRender>;
+    await act(async () => {
+        utils = rtlRender(<ChatSelectorModal {...baseProps} visible={false} />, { legacyRoot: true });
+    });
+    await act(async () => {
+        utils!.rerender(<ChatSelectorModal {...baseProps} visible={true} />);
+        await flushPromises();
+    });
+    return utils!;
+}
+
+describe('ChatSelectorModal — include-archived toggle', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('fetches candidates without include_archived when toggle is off (default)', async () => {
+        await open([ACTIVE_THREAD]);
+
+        expect(mockGetChatCandidates).toHaveBeenCalledTimes(1);
+        const firstCallArg = mockGetChatCandidates.mock.calls[0][0];
+        expect(firstCallArg?.include_archived).toBeFalsy();
+    });
+
+    it('shows the include-archived label and helper text', async () => {
+        const utils = await open([ACTIVE_THREAD]);
+
+        expect(utils.getByText('包含已归档子区')).toBeInTheDocument();
+        expect(utils.getByText('默认不含已归档子区，开启后可选择归档子区')).toBeInTheDocument();
+    });
+
+    it('re-fetches with include_archived=true and renders an Archived tag when toggled on', async () => {
+        const utils = await open([ACTIVE_THREAD]);
+
+        // archived row absent before opting in
+        expect(utils.queryByText('Archived Thread')).not.toBeInTheDocument();
+
+        // backend returns the archived thread once the flag is set
+        mockGetChatCandidates.mockResolvedValueOnce([ACTIVE_THREAD, ARCHIVED_THREAD]);
+
+        const toggle = utils.getByTestId('include-archived-switch');
+        await act(async () => {
+            fireEvent.click(toggle);
+            await flushPromises();
+        });
+
+        expect(mockGetChatCandidates).toHaveBeenCalledTimes(2);
+        expect(mockGetChatCandidates.mock.calls[1][0]).toEqual({ include_archived: true });
+
+        expect(utils.getByText('Archived Thread')).toBeInTheDocument();
+        const tags = utils.getAllByTestId('tag').map((el) => el.textContent);
+        expect(tags).toContain('已归档');
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSelectorModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSelectorModal.test.tsx
@@ -143,4 +143,78 @@ describe('ChatSelectorModal — include-archived toggle', () => {
         const tags = utils.getAllByTestId('tag').map((el) => el.textContent);
         expect(tags).toContain('已归档');
     });
+
+    it('resets the toggle and fetches without include_archived on reopen after archived was on', async () => {
+        const utils = await open([ACTIVE_THREAD]);
+
+        // opt in to archived
+        mockGetChatCandidates.mockResolvedValueOnce([ACTIVE_THREAD, ARCHIVED_THREAD]);
+        const toggle = utils.getByTestId('include-archived-switch');
+        await act(async () => {
+            fireEvent.click(toggle);
+            await flushPromises();
+        });
+        expect(mockGetChatCandidates.mock.calls[1][0]).toEqual({ include_archived: true });
+
+        // close the modal (the instance is never unmounted; parent drives `visible`)
+        await act(async () => {
+            utils.rerender(<ChatSelectorModal {...baseProps} visible={false} />);
+            await flushPromises();
+        });
+
+        // reopen — the first fetch must NOT carry the archived flag despite the
+        // prior toggle, because setState is async and we pass the value explicitly.
+        mockGetChatCandidates.mockResolvedValueOnce([ACTIVE_THREAD]);
+        await act(async () => {
+            utils.rerender(<ChatSelectorModal {...baseProps} visible={true} />);
+            await flushPromises();
+        });
+
+        expect(mockGetChatCandidates).toHaveBeenCalledTimes(3);
+        const reopenArg = mockGetChatCandidates.mock.calls[2][0];
+        expect(reopenArg?.include_archived).toBeFalsy();
+
+        // and the Switch renders OFF
+        expect((utils.getByTestId('include-archived-switch') as HTMLInputElement).checked).toBe(false);
+    });
+
+    it('drops a stale response when an earlier request resolves after a later one', async () => {
+        // First load (open) resolves immediately with the active thread.
+        const utils = await open([ACTIVE_THREAD]);
+
+        // Set up two overlapping loads with manually controlled resolution.
+        let resolveFirst!: (v: ChatCandidate[]) => void;
+        let resolveSecond!: (v: ChatCandidate[]) => void;
+        const firstPromise = new Promise<ChatCandidate[]>((r) => { resolveFirst = r; });
+        const secondPromise = new Promise<ChatCandidate[]>((r) => { resolveSecond = r; });
+
+        mockGetChatCandidates.mockReturnValueOnce(firstPromise);
+        mockGetChatCandidates.mockReturnValueOnce(secondPromise);
+
+        const toggle = utils.getByTestId('include-archived-switch');
+
+        // Kick off the first overlapping load (archived ON) — does not resolve yet.
+        await act(async () => {
+            fireEvent.click(toggle);
+        });
+        // Kick off the second overlapping load (archived OFF) — does not resolve yet.
+        await act(async () => {
+            fireEvent.click(toggle);
+        });
+
+        // The LATER request resolves first...
+        await act(async () => {
+            resolveSecond([ACTIVE_THREAD]);
+            await flushPromises();
+        });
+        // ...then the EARLIER (stale) request resolves last with different data.
+        await act(async () => {
+            resolveFirst([ACTIVE_THREAD, ARCHIVED_THREAD]);
+            await flushPromises();
+        });
+
+        // Final state must reflect the LATER request, not the stale earlier one.
+        expect(utils.queryByText('Archived Thread')).not.toBeInTheDocument();
+        expect(utils.getByText('Active Thread')).toBeInTheDocument();
+    });
 });

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -138,7 +138,8 @@
     "start": "Start summary",
     "scheduleDaily": "Daily {{time}}",
     "scheduleWeekly": "Every {{day}} {{time}}",
-    "scheduleMonthly": "Monthly on day {{day}} {{time}}"
+    "scheduleMonthly": "Monthly on day {{day}} {{time}}",
+    "archivedNotice": "Active threads are summarized by default; archived threads are excluded"
   },
   "chatSummary": {
     "panelTitle": "Summaries in this chat",
@@ -174,7 +175,10 @@
     "title": "Select chats",
     "searchPlaceholder": "Search groups or contacts",
     "all": "All",
-    "noData": "No data"
+    "noData": "No data",
+    "includeArchived": "Include archived threads",
+    "includeArchivedHelper": "Archived threads are excluded by default; enable to select them",
+    "archivedTag": "Archived"
   },
   "memberSelector": {
     "title": "Add members",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -138,7 +138,8 @@
     "start": "开始总结",
     "scheduleDaily": "按天 {{time}}",
     "scheduleWeekly": "每{{day}} {{time}}",
-    "scheduleMonthly": "每月{{day}}日 {{time}}"
+    "scheduleMonthly": "每月{{day}}日 {{time}}",
+    "archivedNotice": "默认总结活跃子区，不含已归档子区"
   },
   "chatSummary": {
     "panelTitle": "聊天内的智能总结",
@@ -174,7 +175,10 @@
     "title": "选择聊天",
     "searchPlaceholder": "搜索群聊或联系人",
     "all": "全部",
-    "noData": "暂无数据"
+    "noData": "暂无数据",
+    "includeArchived": "包含已归档子区",
+    "includeArchivedHelper": "默认不含已归档子区，开启后可选择归档子区",
+    "archivedTag": "已归档"
   },
   "memberSelector": {
     "title": "添加成员",

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -307,6 +307,9 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     ? translate("summary.create.selectedChats", { values: { count: selectedChats.length } })
                                     : translate("summary.create.selectChat")}
                             </Button>
+                            <span style={{ marginLeft: 8, fontSize: 12, color: "var(--semi-color-text-2)" }}>
+                                {translate("summary.create.archivedNotice")}
+                            </span>
                         </div>
 
                         <Button

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -270,6 +270,8 @@ export interface ChatCandidate {
     member_count: number | null;
     parent_group_no?: string;
     is_bot?: boolean;
+    /** 是否为已归档子区（status=2）；群聊/私聊恒为 false */
+    is_archived?: boolean;
 }
 
 /** 成员候选项（添加成员弹窗用） */

--- a/packages/dmworksummary/vitest.config.ts
+++ b/packages/dmworksummary/vitest.config.ts
@@ -3,6 +3,17 @@ import path from 'path';
 
 const root = path.resolve(__dirname, '../..');
 const pnpm = path.resolve(root, 'node_modules/.pnpm');
+// @testing-library/react renders via react-dom/client (React 18+). The pnpm
+// store links it against react-dom@17 (which has no client.js), so render/hook
+// tests can only resolve through these aliases. Pin react/react-dom to 18 and
+// @testing-library/react to its react-18-linked variant; tests opt back into
+// legacy rendering via { legacyRoot: true }.
+const react18 = path.resolve(pnpm, 'react@18.3.1/node_modules/react');
+const reactDom18 = path.resolve(pnpm, 'react-dom@18.3.1_react@18.3.1/node_modules/react-dom');
+const testingLibraryReact = path.resolve(
+  pnpm,
+  '@testing-library+react@14.3.1_@types+react@18.3.28_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@testing-library/react',
+);
 
 export default defineConfig({
   test: {
@@ -22,9 +33,11 @@ export default defineConfig({
       { find: /^@octo\/base\/src\/App$/, replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
       { find: /^@octo\/base\/src\/Components\/WKLayout\/layoutWidth$/, replacement: path.resolve(root, 'packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts') },
       { find: '@octo/base', replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
-      { find: /^react-dom\/(.*)/, replacement: path.resolve(pnpm, 'react-dom@17.0.2_react@17.0.2/node_modules/react-dom') + '/$1' },
-      { find: /^react-dom$/, replacement: path.resolve(pnpm, 'react-dom@17.0.2_react@17.0.2/node_modules/react-dom') },
-      { find: /^react$/, replacement: path.resolve(pnpm, 'react@17.0.2/node_modules/react') },
+      { find: /^@testing-library\/react$/, replacement: testingLibraryReact },
+      { find: /^react-dom\/(.*)/, replacement: reactDom18 + '/$1' },
+      { find: /^react-dom$/, replacement: reactDom18 },
+      { find: /^react\/(.*)/, replacement: react18 + '/$1' },
+      { find: /^react$/, replacement: react18 },
     ],
   },
 });


### PR DESCRIPTION
Closes #346. Backend counterpart: Mininglamp-OSS/octo-smart-summary#78 (PR Mininglamp-OSS/octo-smart-summary#80).

## Summary

Smart summary could only see non-archived threads. This change lets users opt in to selecting archived threads in the summary chat/thread selector (default hidden, behind a toggle), distinguishes them with a tag, adds user-facing notices, and excludes archived threads from forward targets.

## Changes

- `types/summary.ts`: add `is_archived?: boolean` to `ChatCandidate`.
- `api/summaryApi.ts`: `getChatCandidates` accepts `include_archived?: boolean`, passed through to the request.
- `components/ChatSelectorModal.tsx`: add an "include archived threads" toggle (default off; resets on modal reopen); re-fetches candidates when toggled; renders an "archived" tag on archived thread rows.
- `components/ChatSummaryNewModal.tsx` and `pages/SummaryCreatePage.tsx`: static notice that default summaries cover active threads and exclude archived.
- `Components/ForwardModal/useForwardModal.ts`: reuse the existing `filterArchivedThreads` helper to exclude archived threads from forward targets (thread source only; groups/directs untouched; fail-open for unknown status).
- i18n: new keys added to both `zh-CN.json` and `en-US.json`.

## Default behavior

Archived threads remain excluded by default (opt-in to include) for summary; forward targets always exclude archived threads.

## Tests

- `ChatSelectorModal.test.tsx`: toggle off does not request include_archived; toggle on requests `include_archived=true` and renders the archived tag.
- `useForwardModal.test.tsx`: archived threads are excluded from forward targets; active and unknown-status threads remain.

Also repairs the package vitest config (react 17 -> 18 aliases) so render-based component tests resolve `react-dom/client`.

## Coordination

Must ship together with octo-smart-summary#78 — the toggle reveals archived threads only when the backend returns them, and selecting one requires the backend pipeline change to avoid an empty summary.