### PR TITLE
fix: sync sidebar thread list in real time on archive/unarchive (#345)

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
@@ -1,0 +1,260 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { ThreadStatus } from "../../../Service/Thread"
+
+let ConversationListGrouped: typeof import("../index").default
+let container: HTMLDivElement
+
+const ChannelTypeGroup = 2
+const ChannelTypePerson = 1
+const ChannelTypeCommunityTopic = 5
+
+beforeAll(async () => {
+    vi.doMock("wukongimjssdk", () => ({
+        default: {
+            shared: () => ({
+                channelManager: {
+                    getChannelInfo: () => undefined,
+                },
+            }),
+        },
+        Channel: class {
+            channelID: string
+            channelType: number
+            constructor(channelID: string, channelType: number) {
+                this.channelID = channelID
+                this.channelType = channelType
+            }
+        },
+        ChannelTypeGroup,
+        ChannelTypePerson,
+        Conversation: class {},
+        WKSDK: {
+            shared: () => ({
+                channelManager: {
+                    getChannelInfo: () => undefined,
+                },
+            }),
+        },
+    }))
+
+    vi.doMock("../../../Service/Const", () => ({
+        ChannelTypeCommunityTopic,
+    }))
+
+    vi.doMock("../../../Service/Thread", () => ({
+        parseThreadChannelId: (channelId: string) => {
+            const parts = channelId.split("____")
+            return parts.length === 2 ? { groupNo: parts[0], shortId: parts[1] } : null
+        },
+        isEffectivelyMuted: () => false,
+        ThreadStatus: { Active: 1, Archived: 2, Deleted: 3 },
+    }))
+
+    vi.doMock("../../../Service/FollowService", () => ({ default: {} }))
+
+    vi.doMock("../../../Service/SidebarService", () => ({ default: {} }))
+
+    vi.doMock("../../../Service/Model", () => ({
+        ConversationWrap: class {
+            conversation: any
+            constructor(conversation: any) {
+                this.conversation = conversation
+            }
+            get channel() {
+                return this.conversation.channel
+            }
+            get channelInfo() {
+                return this.conversation.channelInfo
+            }
+            get timestamp() {
+                return this.conversation.timestamp
+            }
+            get unread() {
+                return this.conversation.unread
+            }
+            get isMentionMe() {
+                return this.conversation.isMentionMe
+            }
+        },
+    }))
+
+    vi.doMock("../../../i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+    vi.doMock("../../WKModal", () => ({ wkConfirm: vi.fn() }))
+
+    vi.doMock("../../ContextMenus", () => ({
+        __esModule: true,
+        default: () => null,
+    }))
+
+    // DnD 包：直接 passthrough children，避免引入真实拖拽上下文
+    vi.doMock("@dnd-kit/core", () => ({
+        DndContext: ({ children }: any) => <div>{children}</div>,
+        DragOverlay: ({ children }: any) => <div>{children}</div>,
+        PointerSensor: class {},
+        useSensor: () => ({}),
+        useSensors: () => [],
+    }))
+    vi.doMock("@dnd-kit/sortable", () => ({
+        SortableContext: ({ children }: any) => <div>{children}</div>,
+        verticalListSortingStrategy: {},
+        arrayMove: (arr: any[]) => arr,
+    }))
+
+    // ConversationListWithCategory：渲染每个分组的 conversations 节点即可
+    vi.doMock("../../ConversationListWithCategory", () => ({
+        __esModule: true,
+        default: ({ categories = [] }: { categories?: Array<any> }) => (
+            <div data-testid="cat-list">
+                {categories.map((cat) => (
+                    <div key={cat.id} data-testid={`cat-${cat.id}`}>
+                        {cat.conversations}
+                    </div>
+                ))}
+            </div>
+        ),
+    }))
+
+    // ConversationList：把传入的 conversations 的 channelID 平铺渲染，便于断言成员
+    vi.doMock("../../ConversationList", () => ({
+        __esModule: true,
+        default: ({ conversations }: { conversations: Array<any> }) => (
+            <div data-testid="conversation-list">
+                {conversations.map((conv) => (
+                    <span key={conv.channel.channelID} data-cid={conv.channel.channelID}>
+                        {conv.channel.channelID}
+                    </span>
+                ))}
+            </div>
+        ),
+    }))
+
+    ConversationListGrouped = (await import("../index")).default
+})
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+})
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+})
+
+function groupConv(groupNo: string) {
+    return {
+        channel: { channelID: groupNo, channelType: ChannelTypeGroup },
+        channelInfo: { orgData: {} },
+        timestamp: 100,
+        unread: 0,
+        isMentionMe: false,
+    }
+}
+
+function threadConv(channelID: string, parentGroupNo: string, status?: number) {
+    return {
+        channel: { channelID, channelType: ChannelTypeCommunityTopic },
+        channelInfo: {
+            orgData: {
+                parentGroupNo,
+                ...(status === undefined ? {} : { thread: { status } }),
+            },
+        },
+        timestamp: 90,
+        unread: 0,
+        isMentionMe: false,
+    }
+}
+
+function renderGrouped(props: Partial<React.ComponentProps<typeof ConversationListGrouped>>) {
+    const baseProps: any = {
+        conversations: [],
+        onConversationClick: () => {},
+        onClearMessages: () => {},
+        onThreadOverflowClick: () => {},
+        categories: [],
+        isLoading: false,
+        error: null,
+        onRetry: () => {},
+        onRenameCategory: async () => {},
+        onDeleteCategory: () => {},
+        onSortCategories: async () => {},
+        onMoveGroupToCategory: async () => {},
+        onOpenCreateCategory: () => {},
+        ...props,
+    }
+    act(() => {
+        ReactDOM.render(<ConversationListGrouped {...baseProps} />, container)
+    })
+}
+
+describe("ConversationListGrouped — 归档子区过滤 (issue #345)", () => {
+    const categories = [
+        {
+            category_id: "cat-a",
+            name: "Cat A",
+            sort: 0,
+            groups: [{ group_no: "grpA" }],
+            is_default: false,
+        },
+    ]
+
+    it("已归档子区不出现在分组子项，活跃子区与父群仍展示", () => {
+        const conversations = [
+            groupConv("grpA"),
+            threadConv("grpA____tActive", "grpA", ThreadStatus.Active),
+            threadConv("grpA____tArchived", "grpA", ThreadStatus.Archived),
+        ]
+        const itemsByCategory = new Map<string, any[]>([
+            ["cat-a", [{ target_type: 2, target_id: "grpA", category_id: "cat-a", follow_sort: 1 }]],
+        ])
+        const followedKeys = new Set<string>([
+            "5::grpA____tActive",
+            "5::grpA____tArchived",
+        ])
+        const followedGroupNos = new Set<string>(["grpA"])
+
+        renderGrouped({
+            conversations: conversations as any,
+            categories: categories as any,
+            itemsByCategory,
+            followedKeys,
+            followedGroupNos,
+        })
+
+        const text = container.textContent || ""
+        expect(text).toContain("grpA____tActive")
+        expect(text).not.toContain("grpA____tArchived")
+        // 父群本身仍在
+        expect(container.querySelector('[data-cid="grpA"]')).toBeTruthy()
+    })
+
+    it("status 未知(channelInfo 未加载)的子区 fail-open 仍展示", () => {
+        const conversations = [
+            groupConv("grpA"),
+            threadConv("grpA____tUnknown", "grpA", undefined),
+        ]
+        const itemsByCategory = new Map<string, any[]>([
+            ["cat-a", [{ target_type: 2, target_id: "grpA", category_id: "cat-a", follow_sort: 1 }]],
+        ])
+        const followedKeys = new Set<string>(["5::grpA____tUnknown"])
+        const followedGroupNos = new Set<string>(["grpA"])
+
+        renderGrouped({
+            conversations: conversations as any,
+            categories: categories as any,
+            itemsByCategory,
+            followedKeys,
+            followedGroupNos,
+        })
+
+        expect(container.textContent || "").toContain("grpA____tUnknown")
+    })
+})

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/archivedThreads.test.ts
@@ -63,4 +63,19 @@ describe("filterArchivedThreads", () => {
     it("空数组返回空数组", () => {
         expect(filterArchivedThreads([])).toEqual([])
     })
+
+    it("status 从 Active 改为 Archived 后，filterArchivedThreads 结果随之变化（issue #345 判定路径回归）", () => {
+        // 模拟归档前：同父群下两个活跃子区都可见
+        const stable = makeThreadConv("stable", ThreadStatus.Active)
+        const toggling = makeThreadConv("toggling", ThreadStatus.Active)
+        const before = filterArchivedThreads([stable, toggling])
+        expect(before).toEqual([stable, toggling])
+
+        // channelInfo 刷新后拿到权威 status=Archived（live 引用被原地改写）
+        toggling.channelInfo!.orgData!.thread!.status = ThreadStatus.Archived
+        const after = filterArchivedThreads([stable, toggling])
+
+        expect(after).toEqual([stable])
+        expect(after).not.toContain(toggling)
+    })
 })

--- a/packages/dmworkbase/src/Components/ThreadList/vm.ts
+++ b/packages/dmworkbase/src/Components/ThreadList/vm.ts
@@ -1,4 +1,5 @@
-import { Thread } from "../../Service/Thread"
+import { Thread, ThreadStatus, buildThreadChannelId } from "../../Service/Thread"
+import { syncThreadArchiveState } from "../../Service/threadArchiveSync"
 import WKApp from "../../App"
 import { t } from "../../i18n"
 
@@ -45,9 +46,18 @@ export class ThreadListVM {
     }
   }
 
+  // 第四个归档入口（issue #345）。当前未接 UI：ThreadList 组件只渲染活跃子区、
+  // 没有归档按钮调用本方法，属死代码。仍与另外三个入口（ThreadPanel 行内 / 详情菜单、
+  // ChannelSetting thread.actions）一样收口到 syncThreadArchiveState，以权威 Archived
+  // 状态写回 channelInfo 缓存并 emit("sidebar-reload")，避免将来接 UI 时再次漏掉左侧
+  // sidebar 同步。
   async archive(shortId: string) {
     try {
       await WKApp.dataSource.channelDataSource.threadArchive(this.groupNo, shortId)
+      syncThreadArchiveState(
+        buildThreadChannelId(this.groupNo, shortId),
+        ThreadStatus.Archived
+      )
       await this.load()
     } catch (err: any) {
       throw new Error(err?.msg || t("base.module.thread.archiveFailedRetry"))

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
@@ -17,6 +17,10 @@ const hoisted = vi.hoisted(() => ({
   getSubscribes: vi.fn(),
   deleteChannelInfo: vi.fn(),
   fetchChannelInfo: vi.fn(),
+  getChannelInfo: vi.fn(),
+  setChannleInfoForCache: vi.fn(),
+  notifyListeners: vi.fn(),
+  emit: vi.fn(),
 }));
 
 vi.mock("../../../App", () => ({
@@ -33,7 +37,7 @@ vi.mock("../../../App", () => ({
     },
     loginInfo: { uid: "owner-uid" },
     shared: { deviceId: "dev-1", currentSpaceId: "space-1" },
-    mittBus: { emit: vi.fn() },
+    mittBus: { emit: hoisted.emit },
     endpoints: { showConversation: vi.fn() },
   },
 }));
@@ -66,9 +70,11 @@ vi.mock("wukongimjssdk", () => {
       shared: () => ({
         channelManager: {
           getSubscribes: hoisted.getSubscribes,
-          getChannelInfo: () => null,
+          getChannelInfo: hoisted.getChannelInfo,
           deleteChannelInfo: hoisted.deleteChannelInfo,
           fetchChannelInfo: hoisted.fetchChannelInfo,
+          setChannleInfoForCache: hoisted.setChannleInfoForCache,
+          notifyListeners: hoisted.notifyListeners,
         },
       }),
     },
@@ -497,5 +503,71 @@ describe("ThreadPanel inline archive button", () => {
       rejectUnarchive(new Error("boom"));
     });
     expect(hoisted.toastError).not.toHaveBeenCalled();
+  });
+});
+
+// 入口对齐回归（issue #345）：行内归档 / 取消归档成功分支都经共享同步函数
+// syncThreadArchiveState 触发。新实现用调用方传入的权威 status 直接写回 channelInfo
+// 缓存（setChannleInfoForCache + notifyListeners），再 emit("sidebar-reload")，
+// 不再绕异步 fetchChannelInfo，避免被在途旧请求覆盖（B1 去重竞态）。
+describe("ThreadPanel inline archive sidebar sync (issue #345)", () => {
+  it("行内归档成功后写回权威 Archived 状态并 emit('sidebar-reload')", async () => {
+    // 提供 live channelInfo，验证权威 status 原地写回
+    const channelInfo: any = {
+      channel: { channelID: "g1____t1", channelType: 5 },
+      orgData: { thread: { status: ThreadStatus.Active } },
+    };
+    hoisted.getChannelInfo.mockReturnValue(channelInfo);
+
+    await renderPanel([ACTIVE_THREAD]);
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+
+    await waitFor(() => expect(hoisted.threadArchive).toHaveBeenCalledWith("g1", "t1"));
+    await waitFor(() =>
+      expect(hoisted.emit).toHaveBeenCalledWith("sidebar-reload")
+    );
+    // 权威 status 写回缓存并通知监听器
+    expect(channelInfo.orgData.thread.status).toBe(ThreadStatus.Archived);
+    expect(hoisted.setChannleInfoForCache).toHaveBeenCalledWith(channelInfo);
+    expect(hoisted.notifyListeners).toHaveBeenCalledWith(channelInfo);
+    // 不再绕异步 fetchChannelInfo（避免被在途旧请求覆盖）
+    expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled();
+  });
+
+  it("已归档行点击取消归档成功后写回 Active 并 emit('sidebar-reload')", async () => {
+    const channelInfo: any = {
+      channel: { channelID: "g1____t2", channelType: 5 },
+      orgData: { thread: { status: ThreadStatus.Archived } },
+    };
+    hoisted.getChannelInfo.mockReturnValue(channelInfo);
+
+    hoisted.threadList.mockResolvedValue([ARCHIVED_THREAD]);
+    hoisted.getSubscribes.mockReturnValue([{ uid: "owner-uid", role: 1 }]);
+    render(
+      React.createElement(ThreadPanel, {
+        groupNo: "g1",
+        thread: null,
+        onClose: vi.fn(),
+        onThreadSelect: vi.fn(),
+      })
+    );
+    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archived"));
+    });
+    await waitFor(() => expect(archiveButton()).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(archiveButton()!);
+    });
+
+    await waitFor(() => expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t2"));
+    await waitFor(() =>
+      expect(hoisted.emit).toHaveBeenCalledWith("sidebar-reload")
+    );
+    expect(channelInfo.orgData.thread.status).toBe(ThreadStatus.Active);
   });
 });

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -33,6 +33,7 @@ import { formatRelativeTime } from "../../Utils/time";
 import FollowService from "../../Service/FollowService";
 import SidebarService from "../../Service/SidebarService";
 import CategoryService from "../../Service/CategoryService";
+import { syncThreadArchiveState } from "../../Service/threadArchiveSync";
 import { FilePreviewInfo } from "../FilePreviewPanel/types";
 import { fileRendererRegistry } from "../FilePreviewPanel/registry";
 import { getExtension } from "../FilePreviewPanel/types";
@@ -738,7 +739,7 @@ export default class ThreadPanel extends Component<
     if (this.state.vmState.thread?.short_id === updatedThread.short_id) {
       this.props.onThreadSelect?.(updatedThread);
     }
-    this.refreshThreadChannelInfo(updatedThread);
+    this.syncThreadArchiveToSidebar(updatedThread);
     await this.loadThreads();
   };
 
@@ -874,6 +875,23 @@ export default class ThreadPanel extends Component<
     const threadChannel = new Channel(channelID, ChannelTypeCommunityTopic);
     WKSDK.shared().channelManager.deleteChannelInfo(threadChannel);
     WKSDK.shared().channelManager.fetchChannelInfo(threadChannel);
+  }
+
+  /**
+   * 归档 / 取消归档成功后同步左侧 sidebar（issue #345）。收口到共享的
+   * syncThreadArchiveState：用调用方传入的权威 thread.status 直接写回 channelInfo
+   * 缓存并 notifyListeners，再 emit("sidebar-reload")。传权威 status 而非绕异步
+   * fetchChannelInfo，避免被归档前在途的旧请求覆盖（B1 去重竞态）。
+   * 各入口在调用前已把 thread.status 设为操作后的权威值。
+   */
+  private syncThreadArchiveToSidebar(thread: Thread) {
+    const channelID =
+      thread.channel_id ||
+      (this.props.groupNo
+        ? buildThreadChannelId(this.props.groupNo, thread.short_id)
+        : "");
+    if (!channelID) return;
+    syncThreadArchiveState(channelID, thread.status);
   }
 
   private handleDeleteThread = () => {
@@ -1380,7 +1398,7 @@ export default class ThreadPanel extends Component<
       );
       // 卸载后短路：撤销 Toast 渲染在全局 portal，卸载后再创建会绕过 cleanup。
       if (this.isUnmounted) return;
-      this.refreshThreadChannelInfo({
+      this.syncThreadArchiveToSidebar({
         ...thread,
         status: ThreadStatus.Archived,
       });
@@ -1407,7 +1425,7 @@ export default class ThreadPanel extends Component<
       // 卸载后短路：避免对已卸载组件 setState 并刷新列表。
       if (this.isUnmounted) return;
       Toast.success(t("base.module.thread.unarchiveSuccess"));
-      this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
+      this.syncThreadArchiveToSidebar({ ...thread, status: ThreadStatus.Active });
       await this.loadThreads();
     } catch {
       if (this.isUnmounted) return;
@@ -1472,7 +1490,7 @@ export default class ThreadPanel extends Component<
       );
       // 卸载后短路：避免对已卸载组件 setState 并刷新列表。
       if (this.isUnmounted) return;
-      this.refreshThreadChannelInfo({ ...thread, status: ThreadStatus.Active });
+      this.syncThreadArchiveToSidebar({ ...thread, status: ThreadStatus.Active });
       await this.loadThreads();
     } catch {
       if (this.isUnmounted) return;

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest"
+
+// 捕获 ChatVM.channelListener（didMount 里通过 channelManager.addListener 注册）。
+const hoisted = vi.hoisted(() => ({
+    channelListener: undefined as undefined | ((channelInfo: any) => void),
+}))
+
+vi.mock("wukongimjssdk", () => ({
+    default: {
+        shared: () => ({
+            conversationManager: {
+                conversations: [],
+                addConversationListener: () => {},
+                removeConversationListener: () => {},
+                findConversation: () => undefined,
+                sync: () => Promise.resolve([]),
+            },
+            connectManager: {
+                status: 0,
+                addConnectStatusListener: () => {},
+                removeConnectStatusListener: () => {},
+            },
+            channelManager: {
+                getChannelInfo: () => undefined,
+                fetchChannelInfo: () => {},
+                deleteChannelInfo: () => {},
+                addListener: (listener: (channelInfo: any) => void) => {
+                    hoisted.channelListener = listener
+                },
+                removeListener: () => {},
+            },
+        }),
+    },
+    Channel: class {
+        channelID: string
+        channelType: number
+
+        constructor(channelID: string, channelType: number) {
+            this.channelID = channelID
+            this.channelType = channelType
+        }
+
+        isEqual(other: any) {
+            return this.channelID === other.channelID && this.channelType === other.channelType
+        }
+
+        getChannelKey() {
+            return `${this.channelID}-${this.channelType}`
+        }
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    Conversation: class {},
+    ConversationAction: {},
+    ConnectStatus: { Connected: 1, Disconnect: 0 },
+    Message: class {},
+    MessageContent: class {},
+    MessageContentType: { text: 1 },
+}))
+
+vi.mock("react-scroll", () => ({
+    animateScroll: { scrollTo: () => {} },
+    scroller: {},
+}))
+
+vi.mock("../../../App", () => ({
+    default: {
+        shared: {
+            currentSpaceId: "",
+            channelSpaceMap: new Map(),
+            channelMySourceSpaceMap: new Map(),
+            openChannel: undefined,
+            addMessageDeleteListener: () => {},
+            removeMessageDeleteListener: () => {},
+            notifyListener: () => {},
+        },
+        config: { appName: "Octo" },
+        mittBus: { emit: () => {}, on: () => {}, off: () => {} },
+        menus: { refresh: () => {} },
+        routeRight: { popToRoot: () => {} },
+        endpointManager: { invoke: () => {} },
+        conversationProvider: { clearConversationMessages: () => Promise.resolve() },
+        apiClient: { get: () => Promise.resolve({}) },
+        endpoints: { showConversation: () => {} },
+    },
+}))
+
+vi.mock("../../../Service/Model", () => ({
+    ConversationWrap: class {
+        conversation: any
+
+        constructor(conversation: any) {
+            this.conversation = conversation
+        }
+
+        get channel() {
+            return this.conversation.channel
+        }
+
+        get timestamp() {
+            return this.conversation.timestamp
+        }
+
+        get extra() {
+            if (!this.conversation.extra) this.conversation.extra = {}
+            return this.conversation.extra
+        }
+    },
+}))
+
+vi.mock("../../../Service/ProhibitwordsService", () => ({
+    ProhibitwordsService: { shared: { filter: (text: string) => text } },
+}))
+
+vi.mock("../../../Service/SpaceService", () => ({
+    SpaceService: { shared: { getMembers: () => Promise.resolve([]) } },
+    shouldSkipChannelForSpace: () => false,
+    shouldSkipPersonConversationForSpace: () => false,
+    hasSpacePrefix: () => false,
+}))
+
+vi.mock("../../../Service/Thread", () => ({
+    parseThreadChannelId: () => undefined,
+}))
+
+vi.mock("../../../EndpointCommon", () => ({
+    ShowConversationOptions: class {},
+}))
+
+vi.mock("../../../Utils/security", () => ({
+    isSafeUrl: () => true,
+}))
+
+vi.mock("../../../Utils/download", () => ({
+    downloadFile: () => Promise.resolve(),
+}))
+
+import { ChatVM } from "../vm"
+
+// 真实 Const 值：子区频道 channelType = 5
+const ChannelTypeCommunityTopic = 5
+const ChannelTypeGroup = 2
+
+function mountVM(): ChatVM {
+    const vm = new ChatVM()
+    vm.didMount()
+    return vm
+}
+
+describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", () => {
+    it("收到子区 channelInfo 变化时调用 notifyListener（即便子区不在 conversations）", () => {
+        const vm = mountVM()
+        const notifySpy = vi.spyOn(vm, "notifyListener")
+        expect(hoisted.channelListener).toBeTypeOf("function")
+
+        // 子区不在 vm.conversations（sidebar-only 关注场景）
+        hoisted.channelListener!({
+            channel: { channelID: "g1____t1", channelType: ChannelTypeCommunityTopic },
+        })
+
+        expect(notifySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("子区在 conversations 中时也 notifyListener（既有 top 分支）", () => {
+        const vm = mountVM()
+        const threadChannel = {
+            channelID: "g1____t2",
+            channelType: ChannelTypeCommunityTopic,
+            isEqual: (other: any) =>
+                other?.channelID === "g1____t2" && other?.channelType === ChannelTypeCommunityTopic,
+        }
+        vm.conversations = [
+            {
+                channel: threadChannel,
+                extra: {},
+            } as any,
+        ]
+        const notifySpy = vi.spyOn(vm, "notifyListener")
+
+        hoisted.channelListener!({
+            channel: threadChannel,
+            top: 0,
+        })
+
+        expect(notifySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("非子区且不在 conversations 的群 channelInfo 不会走子区分支", () => {
+        const vm = mountVM()
+        const notifySpy = vi.spyOn(vm, "notifyListener")
+
+        // 群聊且无 space_id、不在 conversations、无 pending → 不应进入子区 notify 分支
+        hoisted.channelListener!({
+            channel: { channelID: "g-unknown", channelType: ChannelTypeGroup },
+        })
+
+        expect(notifySpy).not.toHaveBeenCalled()
+    })
+
+    it("同一子区 status 未变化时仅首次 notifyListener（N2 收敛重渲染）", () => {
+        const vm = mountVM()
+        const notifySpy = vi.spyOn(vm, "notifyListener")
+        const channel = { channelID: "g1____t3", channelType: ChannelTypeCommunityTopic }
+
+        // 首次出现：notify
+        hoisted.channelListener!({ channel, orgData: { thread: { status: 1 } } })
+        // status 未变化（仍为 1，仅其它字段刷新）：跳过 notify
+        hoisted.channelListener!({ channel, orgData: { thread: { status: 1 } } })
+        expect(notifySpy).toHaveBeenCalledTimes(1)
+
+        // status 变化（1 → 2 归档）：再次 notify
+        hoisted.channelListener!({ channel, orgData: { thread: { status: 2 } } })
+        expect(notifySpy).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -36,6 +36,9 @@ export class ChatVM extends ProviderListener {
     private _showSpaceCreate = false // 是否显示创建 Space 弹窗
     private _spaceMemberUids: Set<string> = new Set() // 当前 space 的成员 uid 集合
     private _pendingSpaceConversations: Map<string, Conversation> = new Map() // 等待 channelInfo 的新群会话
+    // 子区(CommunityTopic) sidebar-only 关注项的最近一次 thread.status 快照，按 channelID。
+    // 仅用于 channelListener 里收敛重渲染：status 未变化时跳过 notifyListener（N2）。
+    private _lastThreadStatusByChannel: Map<string, number | undefined> = new Map()
 
     set showAddPopover(v: boolean) {
         this._showAddPopover = v
@@ -309,6 +312,22 @@ export class ChatVM extends ProviderListener {
                 conversation.extra.top = channelInfo.top ? 1 : 0
                 this.sortConversations()
                 this.notifyListener()
+            } else if (channelInfo.channel.channelType === ChannelTypeCommunityTopic) {
+                // 子区(CommunityTopic) channelInfo 到达：sidebar 关注 tab 里大量子区是
+                // sidebar-only 关注（synthesizeFromItem 合成、不在最近列表），findConversation
+                // 返回 undefined。归档/取消归档后三入口都会把权威 thread.status 写回
+                // channelInfo 缓存并 notifyListeners，让关注 tab 的 filterArchivedThreads
+                // 重新计算，否则列表不实时同步（issue #345）。
+                // N2：仅在 thread.status 真正变化（含首次出现）时 notifyListener，
+                // 避免与归档无关的 channelInfo 刷新（名称/未读等）放大重渲染。
+                const channelID = channelInfo.channel.channelID
+                const nextStatus = (channelInfo as any).orgData?.thread?.status as number | undefined
+                const prevTracked = this._lastThreadStatusByChannel.has(channelID)
+                const prevStatus = this._lastThreadStatusByChannel.get(channelID)
+                if (!prevTracked || prevStatus !== nextStatus) {
+                    this._lastThreadStatusByChannel.set(channelID, nextStatus)
+                    this.notifyListener()
+                }
             } else if (channelInfo.channel.channelType === ChannelTypeGroup) {
                 // 新群 channelInfo 异步返回：用真实 space_id 纠正 fail-open 假定值 + 补插遗漏的会话
                 const key = `${channelInfo.channel.channelID}_${channelInfo.channel.channelType}`

--- a/packages/dmworkbase/src/Service/__tests__/runChannelSettingThreadArchive.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/runChannelSettingThreadArchive.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks shared across module mocks ──
+const hoisted = vi.hoisted(() => ({
+  threadArchive: vi.fn(),
+  threadUnarchive: vi.fn(),
+  toastSuccess: vi.fn(),
+  syncThreadArchiveState: vi.fn(),
+}));
+
+vi.mock("../../App", () => ({
+  __esModule: true,
+  default: {
+    dataSource: {
+      channelDataSource: {
+        threadArchive: hoisted.threadArchive,
+        threadUnarchive: hoisted.threadUnarchive,
+      },
+    },
+  },
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: { success: hoisted.toastSuccess },
+}));
+
+vi.mock("../threadArchiveSync", () => ({
+  syncThreadArchiveState: hoisted.syncThreadArchiveState,
+}));
+
+vi.mock("../../i18n", () => ({ t: (key: string) => key }));
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+  },
+}));
+
+import { Channel } from "wukongimjssdk";
+import { runChannelSettingThreadArchive } from "../threadArchiveAction";
+import { ThreadStatus } from "../Thread";
+
+const ChannelTypeCommunityTopic = 5;
+
+beforeEach(() => {
+  hoisted.threadArchive.mockReset().mockResolvedValue(undefined);
+  hoisted.threadUnarchive.mockReset().mockResolvedValue(undefined);
+  hoisted.toastSuccess.mockReset();
+  hoisted.syncThreadArchiveState.mockReset();
+});
+
+describe("runChannelSettingThreadArchive (issue #345 入口3 onOk)", () => {
+  const channel = new Channel("g1____t1", ChannelTypeCommunityTopic);
+
+  it("归档成功：调用 threadArchive，并以权威 Archived 走 syncThreadArchiveState", async () => {
+    await runChannelSettingThreadArchive({
+      channel,
+      groupNo: "g1",
+      shortId: "t1",
+      isArchived: false,
+    });
+
+    expect(hoisted.threadArchive).toHaveBeenCalledWith("g1", "t1");
+    expect(hoisted.threadUnarchive).not.toHaveBeenCalled();
+    expect(hoisted.toastSuccess).toHaveBeenCalledWith(
+      "base.module.thread.archiveSuccess"
+    );
+    expect(hoisted.syncThreadArchiveState).toHaveBeenCalledWith(
+      channel,
+      ThreadStatus.Archived
+    );
+  });
+
+  it("取消归档成功：调用 threadUnarchive，并以权威 Active 走 syncThreadArchiveState", async () => {
+    await runChannelSettingThreadArchive({
+      channel,
+      groupNo: "g1",
+      shortId: "t1",
+      isArchived: true,
+    });
+
+    expect(hoisted.threadUnarchive).toHaveBeenCalledWith("g1", "t1");
+    expect(hoisted.threadArchive).not.toHaveBeenCalled();
+    expect(hoisted.toastSuccess).toHaveBeenCalledWith(
+      "base.module.thread.unarchiveSuccess"
+    );
+    expect(hoisted.syncThreadArchiveState).toHaveBeenCalledWith(
+      channel,
+      ThreadStatus.Active
+    );
+  });
+
+  it("接口失败时向上抛出，不 Toast.success、不同步 sidebar", async () => {
+    hoisted.threadArchive.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      runChannelSettingThreadArchive({
+        channel,
+        groupNo: "g1",
+        shortId: "t1",
+        isArchived: false,
+      })
+    ).rejects.toThrow("boom");
+
+    expect(hoisted.toastSuccess).not.toHaveBeenCalled();
+    expect(hoisted.syncThreadArchiveState).not.toHaveBeenCalled();
+  });
+
+  it("非子区类型的 channel 也按 CommunityTopic 重建后再同步", async () => {
+    const groupChannel = new Channel("g1____t1", 2 /* group */);
+
+    await runChannelSettingThreadArchive({
+      channel: groupChannel,
+      groupNo: "g1",
+      shortId: "t1",
+      isArchived: false,
+    });
+
+    const passed = hoisted.syncThreadArchiveState.mock.calls[0][0] as Channel;
+    expect(passed.channelType).toBe(ChannelTypeCommunityTopic);
+    expect(passed.channelID).toBe("g1____t1");
+  });
+});

--- a/packages/dmworkbase/src/Service/__tests__/threadArchiveSync.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadArchiveSync.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks shared across module mocks ──
+const hoisted = vi.hoisted(() => ({
+  getChannelInfo: vi.fn(),
+  setChannleInfoForCache: vi.fn(),
+  notifyListeners: vi.fn(),
+  emit: vi.fn(),
+}));
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+  }
+  return {
+    Channel,
+    WKSDK: {
+      shared: () => ({
+        channelManager: {
+          getChannelInfo: hoisted.getChannelInfo,
+          setChannleInfoForCache: hoisted.setChannleInfoForCache,
+          notifyListeners: hoisted.notifyListeners,
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../App", () => ({
+  __esModule: true,
+  default: {
+    mittBus: { emit: hoisted.emit },
+  },
+}));
+
+import { Channel } from "wukongimjssdk";
+import { syncThreadArchiveState } from "../threadArchiveSync";
+import { ThreadStatus } from "../Thread";
+
+const THREAD_CHANNEL_ID = "g1____t1";
+const ChannelTypeCommunityTopic = 5;
+
+beforeEach(() => {
+  hoisted.getChannelInfo.mockReset().mockReturnValue(undefined);
+  hoisted.setChannleInfoForCache.mockReset();
+  hoisted.notifyListeners.mockReset();
+  hoisted.emit.mockReset();
+});
+
+describe("syncThreadArchiveState", () => {
+  it("有 live channelInfo 时：原地写回权威 status → setCache → notifyListeners → emit", () => {
+    const channelInfo: any = {
+      channel: { channelID: THREAD_CHANNEL_ID, channelType: ChannelTypeCommunityTopic },
+      title: "Thread 1",
+      orgData: { thread: { status: ThreadStatus.Active }, displayName: "Thread 1" },
+    };
+    hoisted.getChannelInfo.mockReturnValue(channelInfo);
+
+    syncThreadArchiveState(THREAD_CHANNEL_ID, ThreadStatus.Archived);
+
+    // 权威 status 写回，且保留其它字段（title/displayName）
+    expect(channelInfo.orgData.thread.status).toBe(ThreadStatus.Archived);
+    expect(channelInfo.title).toBe("Thread 1");
+    expect(channelInfo.orgData.displayName).toBe("Thread 1");
+    expect(hoisted.setChannleInfoForCache).toHaveBeenCalledWith(channelInfo);
+    expect(hoisted.notifyListeners).toHaveBeenCalledWith(channelInfo);
+    expect(hoisted.emit).toHaveBeenCalledWith("sidebar-reload");
+  });
+
+  it("取消归档：写回 Active", () => {
+    const channelInfo: any = {
+      channel: { channelID: THREAD_CHANNEL_ID, channelType: ChannelTypeCommunityTopic },
+      orgData: { thread: { status: ThreadStatus.Archived } },
+    };
+    hoisted.getChannelInfo.mockReturnValue(channelInfo);
+
+    syncThreadArchiveState(THREAD_CHANNEL_ID, ThreadStatus.Active);
+
+    expect(channelInfo.orgData.thread.status).toBe(ThreadStatus.Active);
+    expect(hoisted.notifyListeners).toHaveBeenCalledWith(channelInfo);
+  });
+
+  it("channelInfo.orgData 缺失时补建 orgData.thread 再写回", () => {
+    const channelInfo: any = {
+      channel: { channelID: THREAD_CHANNEL_ID, channelType: ChannelTypeCommunityTopic },
+    };
+    hoisted.getChannelInfo.mockReturnValue(channelInfo);
+
+    syncThreadArchiveState(THREAD_CHANNEL_ID, ThreadStatus.Archived);
+
+    expect(channelInfo.orgData.thread.status).toBe(ThreadStatus.Archived);
+    expect(hoisted.setChannleInfoForCache).toHaveBeenCalledWith(channelInfo);
+  });
+
+  it("没有 live channelInfo（sidebar-only 子区）：不伪造缓存，仍 emit 兜底", () => {
+    hoisted.getChannelInfo.mockReturnValue(undefined);
+
+    syncThreadArchiveState(THREAD_CHANNEL_ID, ThreadStatus.Archived);
+
+    expect(hoisted.setChannleInfoForCache).not.toHaveBeenCalled();
+    expect(hoisted.notifyListeners).not.toHaveBeenCalled();
+    expect(hoisted.emit).toHaveBeenCalledWith("sidebar-reload");
+  });
+
+  it("接受 channelID 字符串时按 CommunityTopic 构造频道", () => {
+    syncThreadArchiveState(THREAD_CHANNEL_ID, ThreadStatus.Archived);
+
+    const passed = hoisted.getChannelInfo.mock.calls[0][0] as Channel;
+    expect(passed.channelID).toBe(THREAD_CHANNEL_ID);
+    expect(passed.channelType).toBe(ChannelTypeCommunityTopic);
+  });
+
+  it("接受已构造好的 Channel 时直接复用该对象", () => {
+    const channel = new Channel(THREAD_CHANNEL_ID, ChannelTypeCommunityTopic);
+    syncThreadArchiveState(channel, ThreadStatus.Archived);
+
+    expect(hoisted.getChannelInfo).toHaveBeenCalledWith(channel);
+  });
+
+  it("channelID 为空时短路，不触发任何同步副作用", () => {
+    syncThreadArchiveState("", ThreadStatus.Archived);
+
+    expect(hoisted.getChannelInfo).not.toHaveBeenCalled();
+    expect(hoisted.setChannleInfoForCache).not.toHaveBeenCalled();
+    expect(hoisted.notifyListeners).not.toHaveBeenCalled();
+    expect(hoisted.emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkbase/src/Service/threadArchiveAction.ts
+++ b/packages/dmworkbase/src/Service/threadArchiveAction.ts
@@ -1,0 +1,54 @@
+import { Channel } from "wukongimjssdk";
+import { Toast } from "@douyinfe/semi-ui";
+import WKApp from "../App";
+import { ChannelTypeCommunityTopic } from "./Const";
+import { ThreadStatus } from "./Thread";
+import { syncThreadArchiveState } from "./threadArchiveSync";
+import { t } from "../i18n";
+
+/**
+ * ChannelSetting「thread.actions」归档 / 取消归档入口（issue #345，入口 3）的成功流程。
+ *
+ * 抽成独立函数有两个目的：
+ *   1. module.tsx 的 onOk 是内联闭包，整文件依赖图过重（lottie/tiptap/howler 等）无法
+ *      在单测里直接 import 驱动；抽出来后可对「成功分支调用 syncThreadArchiveState 并
+ *      emit('sidebar-reload')」做回归测试。
+ *   2. 与 ThreadPanel 各入口保持同一套副作用顺序：先打归档/取消归档接口，成功后
+ *      Toast 提示，再用操作后的【权威 status】走 syncThreadArchiveState 同步左侧
+ *      sidebar（直接写回 channelInfo 缓存，避免被在途旧 fetch 覆盖，见 B1 去重竞态）。
+ *
+ * 失败时向上抛出，由调用方 catch 弹错误提示（保留各入口自己的文案）。
+ *
+ * @param isArchived 操作【前】子区是否已归档。true → 执行取消归档（权威状态变 Active）；
+ *                   false → 执行归档（权威状态变 Archived）。
+ */
+export async function runChannelSettingThreadArchive(params: {
+  channel: Channel;
+  groupNo: string;
+  shortId: string;
+  isArchived: boolean;
+}): Promise<void> {
+  const { channel, groupNo, shortId, isArchived } = params;
+
+  if (isArchived) {
+    await WKApp.dataSource.channelDataSource.threadUnarchive(groupNo, shortId);
+  } else {
+    await WKApp.dataSource.channelDataSource.threadArchive(groupNo, shortId);
+  }
+
+  Toast.success(
+    isArchived
+      ? t("base.module.thread.unarchiveSuccess")
+      : t("base.module.thread.archiveSuccess")
+  );
+
+  // 权威状态与操作前相反：原已归档 → Active；原活跃 → Archived。
+  const threadChannel =
+    channel.channelType === ChannelTypeCommunityTopic
+      ? channel
+      : new Channel(channel.channelID, ChannelTypeCommunityTopic);
+  syncThreadArchiveState(
+    threadChannel,
+    isArchived ? ThreadStatus.Active : ThreadStatus.Archived
+  );
+}

--- a/packages/dmworkbase/src/Service/threadArchiveSync.ts
+++ b/packages/dmworkbase/src/Service/threadArchiveSync.ts
@@ -1,0 +1,60 @@
+import { Channel, WKSDK } from "wukongimjssdk";
+import WKApp from "../App";
+import { ChannelTypeCommunityTopic } from "./Const";
+import { ThreadStatus } from "./Thread";
+
+/**
+ * 子区归档 / 取消归档后的左侧 sidebar 同步收口（issue #345）。
+ *
+ * 三个归档入口（ThreadPanel 行内、ThreadPanel 详情菜单、ChannelSetting thread.actions）
+ * 此前各自 deleteChannelInfo + fetchChannelInfo，只刷新自己那一层局部状态，没有任何一个
+ * 把刷新推给「持有 conversations、负责过滤归档子区」的 ChatVM sidebar 子树，导致归档后
+ * 左侧列表不实时同步。
+ *
+ * 【B1 去重竞态】SDK ChannelManager.fetchChannelInfo 有 requestQueueMap 去重：同
+ * channelKey 已有在途请求时直接 return 不重拉；而 deleteChannelInfo 只清
+ * channelInfocacheMap、不清 requestQueueMap。归档瞬间若有归档前发起的旧
+ * fetchChannelInfo（携旧 Active 状态）在途，原实现的 deleteChannelInfo +
+ * fetchChannelInfo 就退化成 no-op，随后旧请求 resolve 把 Active 写回缓存并
+ * notifyListeners，导致归档子区不被隐藏，复发 #345。
+ *
+ * 因此这里不再绕异步 fetchChannelInfo，而是由调用方传入权威 status
+ * （archive=Archived / unarchive=Active）。职责按序为：
+ *   1. setChannleInfoForCache：把权威 thread.status 直接写回 channelInfo 缓存
+ *      （在既有 channelInfo 上原地更新 orgData.thread.status，保留 title/logo 等）。
+ *      没有 live channelInfo 时（sidebar-only 关注子区，合成项）跳过——它本就没有
+ *      可被旧请求覆盖的缓存，filterArchivedThreads 对 status 未知的子区 fail-open。
+ *   2. notifyListeners：触发 ChannelManager 的 channelInfoListener →
+ *      ChatVM.channelListener，配合 vm.ts 对 CommunityTopic 的 notifyListener 让
+ *      sidebar 重新过滤归档子区。
+ *   3. emit("sidebar-reload")：让 useFollowSidebar 重新拉 /sidebar/sync，覆盖
+ *      sidebar-only 关注子区（合成项，IM SDK 无 live channelInfo）的场景。
+ *
+ * 入参可传 channelID 字符串或已构造好的 Channel；只要能定位到子区频道即可。
+ */
+export function syncThreadArchiveState(
+  threadChannel: Channel | string,
+  status: ThreadStatus
+): void {
+  const channel =
+    typeof threadChannel === "string"
+      ? new Channel(threadChannel, ChannelTypeCommunityTopic)
+      : threadChannel;
+  if (!channel.channelID) return;
+
+  const channelManager = WKSDK.shared().channelManager;
+  // 权威写回：在既有 channelInfo 上原地更新 thread.status，避免被归档前发起、
+  // 在途的旧 fetchChannelInfo（携 Active）覆盖。没有 live channelInfo 时不伪造
+  // 缓存（会丢 title/logo 等），交由下面的 sidebar-reload 兜底。
+  const channelInfo = channelManager.getChannelInfo(channel);
+  if (channelInfo) {
+    const orgData = (channelInfo.orgData = channelInfo.orgData || {});
+    orgData.thread = { ...(orgData.thread || {}), status };
+    channelManager.setChannleInfoForCache(channelInfo);
+    channelManager.notifyListeners(channelInfo);
+  }
+
+  // sidebar-reload 是 sidebar-only 关注子区的唯一兜底，无论有无 live channelInfo
+  // 都要 emit。
+  WKApp.mittBus.emit("sidebar-reload" as any);
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -115,6 +115,7 @@ import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
 import { shouldShowThreadArchiveAction } from "./Service/threadPermission";
+import { runChannelSettingThreadArchive } from "./Service/threadArchiveAction";
 import { canShowRevokeMenu } from "./Service/revokePermission";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
@@ -2289,28 +2290,16 @@ export default class BaseModule implements IModule {
                       : t("base.module.thread.archiveConfirmContent"),
                     onOk: async () => {
                       try {
-                        if (isArchived) {
-                          await WKApp.dataSource.channelDataSource.threadUnarchive(
-                            threadInfo.groupNo,
-                            threadInfo.shortId
-                          );
-                        } else {
-                          await WKApp.dataSource.channelDataSource.threadArchive(
-                            threadInfo.groupNo,
-                            threadInfo.shortId
-                          );
-                        }
-                        Toast.success(
-                          isArchived
-                            ? t("base.module.thread.unarchiveSuccess")
-                            : t("base.module.thread.archiveSuccess")
-                        );
-                        WKSDK.shared().channelManager.deleteChannelInfo(
-                          channel
-                        );
-                        await WKSDK.shared().channelManager.fetchChannelInfo(
-                          channel
-                        );
+                        // 收口到共享 helper：打接口 → Toast → 用操作后的权威 status
+                        // 走 syncThreadArchiveState 同步左侧 sidebar（issue #345）。
+                        // 权威状态写回 channelInfo 缓存，避免被在途旧 fetch 覆盖
+                        // （B1 去重竞态）。data.refresh() 仍保留，刷新面板本身。
+                        await runChannelSettingThreadArchive({
+                          channel,
+                          groupNo: threadInfo.groupNo,
+                          shortId: threadInfo.shortId,
+                          isArchived,
+                        });
                         data.refresh();
                       } catch (err: any) {
                         Toast.error(


### PR DESCRIPTION
Closes #345.

## Problem
Archiving or unarchiving a thread did not update the left sidebar list in real time. All three trigger entry points were affected:
1. Click a thread in the left list → archive/unarchive from the top-right
2. Inline archive/unarchive in the in-group thread list row
3. Open a thread from the in-group right sidebar → archive/unarchive from the top-right

## Root cause
Each entry point correctly updated the backend status and the thread `channelInfo` cache, but there was no reliable signal to re-render the sidebar subtree that owns the conversations and runs the archived-thread filtering. The bridge `ChatVM.channelListener` did not handle thread (`ChannelTypeCommunityTopic`) channels: for sidebar-only followed threads `findConversation` returns `undefined`, and the `else` branch only handled `ChannelTypeGroup`, so it returned silently without notifying listeners.

## Fix
- New shared `syncThreadArchiveState(channel, status)`: updates the authoritative `thread.status` in place on the live `channelInfo`, writes it back to the cache and notifies listeners, then emits `sidebar-reload` to cover sidebar-only followed threads. This avoids the in-flight `fetchChannelInfo` dedup race (a stale in-flight request could otherwise write the old status back).
- `ChatVM.channelListener` now handles `ChannelTypeCommunityTopic` channels and notifies listeners (only when `thread.status` actually changes) so the followed tab re-runs the archived filter.
- All entry points routed through the shared sync helper, passing the correct authoritative status (archive → Archived, unarchive → Active). Inline archive keeps its optimistic update + 5s undo.

## Tests
- Added unit/component tests for the shared sync helper, the channel listener thread branch, the channel-setting entry helper, and archived filtering.
- Updated existing archive/filter tests.
- All related tests pass; production build succeeds.