### PR TITLE
fix: suppress native context menu while custom menu open

### DIFF
--- a/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import ContextMenus, { ContextMenusContext } from "../index"
+
+let container: HTMLDivElement
+let originalRequestAnimationFrame: typeof requestAnimationFrame | undefined
+let originalCancelAnimationFrame: typeof cancelAnimationFrame | undefined
+
+beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+
+    const runFrame = (callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+    }
+    const cancelFrame = vi.fn()
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+        configurable: true,
+        value: runFrame,
+    })
+    Object.defineProperty(window, "requestAnimationFrame", {
+        configurable: true,
+        value: runFrame,
+    })
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+        configurable: true,
+        value: cancelFrame,
+    })
+    Object.defineProperty(window, "cancelAnimationFrame", {
+        configurable: true,
+        value: cancelFrame,
+    })
+})
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+
+    restoreAnimationFrame("requestAnimationFrame", originalRequestAnimationFrame)
+    restoreAnimationFrame("cancelAnimationFrame", originalCancelAnimationFrame)
+})
+
+function restoreAnimationFrame(
+    key: "requestAnimationFrame" | "cancelAnimationFrame",
+    original: typeof requestAnimationFrame | typeof cancelAnimationFrame | undefined
+) {
+    if (original) {
+        Object.defineProperty(globalThis, key, {
+            configurable: true,
+            value: original,
+        })
+        Object.defineProperty(window, key, {
+            configurable: true,
+            value: original,
+        })
+    } else {
+        delete (globalThis as any)[key]
+        delete (window as any)[key]
+    }
+}
+
+function dispatchContextMenu(element: Element) {
+    const event = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 120,
+        clientY: 80,
+    })
+    act(() => {
+        element.dispatchEvent(event)
+    })
+    return event
+}
+
+function renderContextMenus(onHide = vi.fn()) {
+    let context: ContextMenusContext | null = null
+
+    act(() => {
+        ReactDOM.render(
+            <div>
+                <button
+                    type="button"
+                    className="trigger"
+                    onContextMenu={(event) => context?.show(event)}
+                >
+                    open
+                </button>
+                <ContextMenus
+                    onContext={(nextContext) => {
+                        context = nextContext
+                    }}
+                    onHide={onHide}
+                    menus={[{ title: "Copy", onClick: vi.fn() }]}
+                />
+            </div>,
+            container
+        )
+    })
+
+    const trigger = container.querySelector(".trigger")!
+    const openEvent = dispatchContextMenu(trigger)
+    expect(openEvent.defaultPrevented).toBe(true)
+    expect(context?.isShow()).toBe(true)
+
+    return { context, onHide }
+}
+
+describe("ContextMenus native contextmenu suppression", () => {
+    it("closes the open menu and suppresses the browser menu on mask right-click", () => {
+        const { context, onHide } = renderContextMenus()
+        const mask = container.querySelector(".wk-contextmenus-mask")!
+
+        const event = dispatchContextMenu(mask)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(context?.isShow()).toBe(false)
+        expect(onHide).toHaveBeenCalledTimes(1)
+    })
+
+    it("suppresses the browser menu on the custom menu without hiding it", () => {
+        const { context, onHide } = renderContextMenus()
+        const menu = container.querySelector(".wk-contextmenus")!
+
+        const event = dispatchContextMenu(menu)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(context?.isShow()).toBe(true)
+        expect(onHide).not.toHaveBeenCalled()
+    })
+
+    it("guards document-level contextmenu events only while a menu is open", () => {
+        const { context } = renderContextMenus()
+
+        const guardedEvent = dispatchContextMenu(document.body)
+
+        expect(guardedEvent.defaultPrevented).toBe(true)
+        expect(context?.isShow()).toBe(true)
+
+        act(() => {
+            context?.hide()
+        })
+
+        const unguardedEvent = dispatchContextMenu(document.body)
+        expect(unguardedEvent.defaultPrevented).toBe(false)
+    })
+})

--- a/packages/dmworkbase/src/Components/ContextMenus/index.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.tsx
@@ -57,6 +57,7 @@ function ArrowIcon() {
 
 export default class ContextMenus extends Component<ContextMenusProps, ContextMenusState> implements ContextMenusContext {
     private static _instances: Set<ContextMenus> = new Set()
+    private static _documentContextMenuGuardAttached = false
     private _rafId?: number
 
     static hideAll() {
@@ -65,6 +66,34 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
                 instance.hide()
             }
         })
+    }
+
+    private static _hasOpenInstance(): boolean {
+        for (const instance of ContextMenus._instances) {
+            if (instance.isShow()) return true
+        }
+        return false
+    }
+
+    private static _handleDocumentContextMenu(event: MouseEvent) {
+        if (!ContextMenus._hasOpenInstance()) {
+            ContextMenus._syncDocumentContextMenuGuard()
+            return
+        }
+        event.preventDefault()
+    }
+
+    private static _syncDocumentContextMenuGuard() {
+        if (typeof document === "undefined") return
+
+        const shouldAttach = ContextMenus._hasOpenInstance()
+        if (shouldAttach && !ContextMenus._documentContextMenuGuardAttached) {
+            document.addEventListener("contextmenu", ContextMenus._handleDocumentContextMenu, true)
+            ContextMenus._documentContextMenuGuardAttached = true
+        } else if (!shouldAttach && ContextMenus._documentContextMenuGuardAttached) {
+            document.removeEventListener("contextmenu", ContextMenus._handleDocumentContextMenu, true)
+            ContextMenus._documentContextMenuGuardAttached = false
+        }
     }
 
     _gHandleClick!: () => void
@@ -87,7 +116,9 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
     }
 
     hide(): void {
-        this.setState({ showContextMenus: false })
+        this.setState({ showContextMenus: false }, () => {
+            ContextMenus._syncDocumentContextMenuGuard()
+        })
         this.props.onHide?.()
     }
 
@@ -133,7 +164,9 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
             // 子菜单宽度估算 160px（min-width），靠近右侧时翻转
             const SUBMENU_W = 160
             const flipSubmenu = (screenW - left - rootW) < SUBMENU_W + MARGIN
-            this.setState({ contextOrigin, showContextMenus: true, flipSubmenu })
+            this.setState({ contextOrigin, showContextMenus: true, flipSubmenu }, () => {
+                ContextMenus._syncDocumentContextMenuGuard()
+            })
         })
     }
 
@@ -149,6 +182,18 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
         if (this._rafId !== undefined) {
             cancelAnimationFrame(this._rafId)
         }
+        ContextMenus._syncDocumentContextMenuGuard()
+    }
+
+    _handleContextMenu(event: React.MouseEvent<HTMLElement>) {
+        event.preventDefault()
+        event.stopPropagation()
+    }
+
+    _handleMaskContextMenu(event: React.MouseEvent<HTMLDivElement>) {
+        event.preventDefault()
+        event.stopPropagation()
+        ContextMenus.hideAll()
     }
 
     _renderItem(m: ContextMenusData, i: number): ReactNode {
@@ -220,6 +265,7 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
                     className={classNames("wk-contextmenus", showContextMenus && "wk-contextmenus-open", flipSubmenu && "wk-contextmenus-flip-submenu")}
                     ref={ref => { this.contextMenusRef = ref }}
                     style={{ transformOrigin: `-3px ${contextOrigin}px` }}
+                    onContextMenuCapture={this._handleContextMenu}
                 >
                     <ul>
                         {menus && menus.map((m, i) => this._renderItem(m, i))}
@@ -229,6 +275,7 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
                     className="wk-contextmenus-mask"
                     style={{ visibility: showContextMenus ? "visible" : "hidden" }}
                     onClick={() => ContextMenus.hideAll()}
+                    onContextMenuCapture={this._handleMaskContextMenu}
                 />
             </>
         )


### PR DESCRIPTION
## Summary
- suppress the browser native context menu while a custom ContextMenus instance is open
- intercept right-clicks on the custom menu and mask, closing the menu on mask right-click
- add jsdom regression coverage for mask, menu root, and document-level fallback behavior

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx packages/dmworkbase/src/ui/message/MessageRow/__tests__/MessageRow.test.tsx --config packages/dmworkbase/vitest.config.ts
- git diff --check

Closes #337