### PR TITLE
fix(message): linkify rich text previews

### DIFF
--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -14,6 +14,7 @@ import "katex/dist/katex.min.css";
 import "./markdown.css";
 import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
+import { linkifySafeUrls } from "../../Utils/linkify";
 import { downloadFile } from "../../Utils/download";
 import { t } from "../../i18n";
 import { getMentionRenderState } from "./mentionRenderState";
@@ -168,6 +169,21 @@ const plainRehypePlugins: any[] = [[rehypeSanitize, sanitizeSchema]];
  */
 function escapeMarkdown(raw: string): string {
   return raw.replace(/[\\`*_{}[\]()#+\-.!>|~]/g, "\\$&");
+}
+
+function escapeMarkdownLinkDestination(href: string): string {
+  return href.replace(/\\/g, "%5C").replace(/>/g, "%3E");
+}
+
+function escapeMarkdownPreservingSafeLinks(raw: string): string {
+  return linkifySafeUrls(raw)
+    .map((segment) => {
+      if (segment.type === "text") return escapeMarkdown(segment.content);
+      return `[${escapeMarkdown(
+        segment.text
+      )}](<${escapeMarkdownLinkDestination(segment.href)}>)`;
+    })
+    .join("");
 }
 
 /**
@@ -394,7 +410,10 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   enableMarkdown = true,
 }) => {
   const normalized = useMemo(
-    () => (enableMarkdown ? normalizeContent(content) : escapeMarkdown(content)),
+    () =>
+      enableMarkdown
+        ? normalizeContent(content)
+        : escapeMarkdownPreservingSafeLinks(content),
     [content, enableMarkdown]
   );
 

--- a/packages/dmworkbase/src/Utils/__tests__/linkify.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/linkify.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { linkifySafeUrls } from "../linkify";
+
+describe("linkifySafeUrls", () => {
+  it("extracts http URL links and preserves surrounding text", () => {
+    expect(
+      linkifySafeUrls(
+        "文字 @哈 https://github.com/Mininglamp-OSS/octo-web/issues/355 测试测试"
+      )
+    ).toEqual([
+      { type: "text", content: "文字 @哈 " },
+      {
+        type: "link",
+        text: "https://github.com/Mininglamp-OSS/octo-web/issues/355",
+        href: "https://github.com/Mininglamp-OSS/octo-web/issues/355",
+      },
+      { type: "text", content: " 测试测试" },
+    ]);
+  });
+
+  it("normalizes www links to https hrefs", () => {
+    expect(linkifySafeUrls("官网 www.example.com")).toEqual([
+      { type: "text", content: "官网 " },
+      {
+        type: "link",
+        text: "www.example.com",
+        href: "https://www.example.com",
+      },
+    ]);
+  });
+
+  it("keeps trailing punctuation outside the link", () => {
+    expect(linkifySafeUrls("看这里 https://example.com/docs。")).toEqual([
+      { type: "text", content: "看这里 " },
+      {
+        type: "link",
+        text: "https://example.com/docs",
+        href: "https://example.com/docs",
+      },
+      { type: "text", content: "。" },
+    ]);
+  });
+});

--- a/packages/dmworkbase/src/Utils/linkify.ts
+++ b/packages/dmworkbase/src/Utils/linkify.ts
@@ -1,0 +1,76 @@
+import { isSafeUrl } from "./security";
+
+export type SafeUrlTextSegment =
+  | { type: "text"; content: string }
+  | { type: "link"; text: string; href: string };
+
+const safeUrlPattern = /((?:https?:\/\/|www\.)[^\s<>"']+)/gi;
+const trailingUrlPunctuation = new Set([
+  ".",
+  ",",
+  "!",
+  "?",
+  ";",
+  ":",
+  ")",
+  "]",
+  "}",
+  "。",
+  "，",
+  "！",
+  "？",
+  "；",
+  "：",
+  "）",
+  "】",
+  "』",
+]);
+
+function splitTrailingPunctuation(value: string) {
+  let end = value.length;
+  while (end > 0 && trailingUrlPunctuation.has(value[end - 1])) {
+    end -= 1;
+  }
+  return {
+    linkText: value.slice(0, end),
+    trailingText: value.slice(end),
+  };
+}
+
+function toSafeHref(linkText: string) {
+  const href = linkText.toLowerCase().startsWith("www.")
+    ? `https://${linkText}`
+    : linkText;
+  return isSafeUrl(href) ? href : "";
+}
+
+export function linkifySafeUrls(text: string): SafeUrlTextSegment[] {
+  const segments: SafeUrlTextSegment[] = [];
+  let lastIndex = 0;
+  safeUrlPattern.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = safeUrlPattern.exec(text)) !== null) {
+    const rawUrl = match[0];
+    const index = match.index;
+    const { linkText, trailingText } = splitTrailingPunctuation(rawUrl);
+    const href = toSafeHref(linkText);
+
+    if (!href) continue;
+
+    if (index > lastIndex) {
+      segments.push({ type: "text", content: text.slice(lastIndex, index) });
+    }
+    segments.push({ type: "link", text: linkText, href });
+    if (trailingText) {
+      segments.push({ type: "text", content: trailingText });
+    }
+    lastIndex = index + rawUrl.length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", content: text.slice(lastIndex) });
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", content: text }];
+}

--- a/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx
@@ -37,6 +37,20 @@ export const TextAndImages: Story = {
   },
 };
 
+export const MentionAndLink: Story = {
+  args: {
+    blocks: [
+      {
+        id: "t1",
+        type: "text",
+        content:
+          "文字\n@哈 https://github.com/Mininglamp-OSS/octo-web/issues/355\n测试测试",
+        mentions: [{ name: "@哈", uid: "ha" }],
+      },
+    ],
+  },
+};
+
 export const TextAndFile: Story = {
   args: {
     blocks: [

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/ReplyBlock.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/ReplyBlock.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import ReplyBlock from "./index";
 
@@ -53,5 +53,13 @@ export const LongSpaceName: Story = {
       "This is a very long quoted digest that should be truncated after one line",
     sourceSpaceName:
       "A very very long external workspace name for truncation demo",
+  },
+};
+
+/** 摘要中的链接：高亮并可点击，不影响点击引用块定位原消息 */
+export const LinkDigest: Story = {
+  args: {
+    fromName: "沈鑫",
+    digest: "图文混排摘要 https://example.com/docs 后面还有文字",
   },
 };

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/__tests__/ReplyBlock.test.tsx
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/__tests__/ReplyBlock.test.tsx
@@ -1,7 +1,27 @@
-import React from "react"
-import { renderToStaticMarkup } from "react-dom/server"
-import { describe, it, expect } from "vitest"
-import ReplyBlock from "../index"
+import React from "react";
+import ReactDOM from "react-dom";
+import { renderToStaticMarkup } from "react-dom/server";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ReplyBlock from "../index";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+function renderBlock(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(element, container);
+  });
+  return container;
+}
 
 /**
  * dmwork-web#1069 round 3 — UI consumer-side coverage.
@@ -17,50 +37,103 @@ import ReplyBlock from "../index"
  * 一旦 UI 退回仅读 fromName 就会红。
  */
 describe("ReplyBlock — external source space suffix", () => {
-    it("renders only the nickname when sourceSpaceName is absent", () => {
-        const html = renderToStaticMarkup(
-            <ReplyBlock fromName="嘉伟qq" digest="hello" />
-        )
-        expect(html).toContain("嘉伟qq")
-        expect(html).toContain("hello")
-        expect(html).not.toContain("@")
-        expect(html).not.toMatch(/wk-reply-block__space/)
-    })
+  it("renders only the nickname when sourceSpaceName is absent", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock fromName="嘉伟qq" digest="hello" />
+    );
+    expect(html).toContain("嘉伟qq");
+    expect(html).toContain("hello");
+    expect(html).not.toContain("@");
+    expect(html).not.toMatch(/wk-reply-block__space/);
+  });
 
-    it("renders the `@SpaceName` suffix when sourceSpaceName is non-empty (dmwork-web#1069)", () => {
-        const html = renderToStaticMarkup(
-            <ReplyBlock
-                fromName="嘉伟qq"
-                digest="hello"
-                sourceSpaceName="测试空间1"
-            />
-        )
-        expect(html).toContain("嘉伟qq")
-        // 关键断言：外部成员后缀必须出现在渲染产物里；如果回归到仅读 fromName
-        // 则下面任一断言都会 fail。
-        expect(html).toContain("@测试空间1")
-        expect(html).toMatch(/wk-reply-block__space/)
-        // title 属性给长文本的 hover 显示
-        expect(html).toMatch(/title="@测试空间1"/)
-    })
+  it("renders the `@SpaceName` suffix when sourceSpaceName is non-empty (dmwork-web#1069)", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock
+        fromName="嘉伟qq"
+        digest="hello"
+        sourceSpaceName="测试空间1"
+      />
+    );
+    expect(html).toContain("嘉伟qq");
+    // 关键断言：外部成员后缀必须出现在渲染产物里；如果回归到仅读 fromName
+    // 则下面任一断言都会 fail。
+    expect(html).toContain("@测试空间1");
+    expect(html).toMatch(/wk-reply-block__space/);
+    // title 属性给长文本的 hover 显示
+    expect(html).toMatch(/title="@测试空间1"/);
+  });
 
-    it("treats empty/whitespace-safe values the same as absent", () => {
-        const html = renderToStaticMarkup(
-            <ReplyBlock fromName="嘉伟qq" digest="hello" sourceSpaceName="" />
-        )
-        expect(html).not.toMatch(/wk-reply-block__space/)
-    })
+  it("treats empty/whitespace-safe values the same as absent", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock fromName="嘉伟qq" digest="hello" sourceSpaceName="" />
+    );
+    expect(html).not.toMatch(/wk-reply-block__space/);
+  });
 
-    it("keeps digest visible alongside the suffix", () => {
-        const html = renderToStaticMarkup(
-            <ReplyBlock
-                fromName="Alice"
-                digest="This is the quoted content"
-                sourceSpaceName="ExampleCorp"
-            />
-        )
-        expect(html).toContain("Alice")
-        expect(html).toContain("This is the quoted content")
-        expect(html).toContain("@ExampleCorp")
-    })
-})
+  it("keeps digest visible alongside the suffix", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock
+        fromName="Alice"
+        digest="This is the quoted content"
+        sourceSpaceName="ExampleCorp"
+      />
+    );
+    expect(html).toContain("Alice");
+    expect(html).toContain("This is the quoted content");
+    expect(html).toContain("@ExampleCorp");
+  });
+});
+
+describe("ReplyBlock — digest links", () => {
+  it("renders safe URL text as a clickable link", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock fromName="Alice" digest="请看 https://example.com/docs。" />
+    );
+
+    expect(html).toContain('class="wk-reply-block__digest-link"');
+    expect(html).toContain('href="https://example.com/docs"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain("https://example.com/docs");
+    expect(html).toContain("。");
+  });
+
+  it("normalizes www links to safe https hrefs", () => {
+    const html = renderToStaticMarkup(
+      <ReplyBlock fromName="Alice" digest="官网 www.example.com" />
+    );
+
+    expect(html).toContain('href="https://www.example.com"');
+    expect(html).toContain(">www.example.com</a>");
+  });
+
+  it("does not trigger reply-block navigation when clicking a digest link", () => {
+    const onClick = vi.fn();
+    const root = renderBlock(
+      <ReplyBlock
+        fromName="Alice"
+        digest="请看 https://example.com/docs"
+        onClick={onClick}
+      />
+    );
+
+    const link = root.querySelector(".wk-reply-block__digest-link");
+    expect(link).not.toBeNull();
+    act(() => {
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+    expect(onClick).not.toHaveBeenCalled();
+
+    act(() => {
+      root
+        .querySelector(".wk-reply-block")
+        ?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true })
+        );
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
@@ -19,7 +19,7 @@
 .wk-reply-block__bar {
   width: 2px;
   border-radius: 1px;
-  background: rgba(28, 28, 35, 0.40);
+  background: rgba(28, 28, 35, 0.4);
   flex-shrink: 0;
   align-self: stretch;
   min-height: 18px;
@@ -45,7 +45,7 @@
 .wk-reply-block__name {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.60);
+  color: rgba(28, 28, 35, 0.6);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
@@ -69,9 +69,19 @@
 .wk-reply-block__digest {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.60);
+  color: rgba(28, 28, 35, 0.6);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.wk-reply-block__digest-link {
+  color: var(--wk-text-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.wk-reply-block__digest-link:hover {
+  opacity: 0.8;
 }

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/index.tsx
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/index.tsx
@@ -1,20 +1,39 @@
-import React from 'react'
-import './index.css'
+import React from "react";
+import { linkifySafeUrls } from "../../../Utils/linkify";
+import "./index.css";
 
 export interface ReplyBlockProps {
   /** 被引用消息的发送者名字 */
-  fromName: string
+  fromName: string;
   /** 引用内容摘要 */
-  digest: string
+  digest: string;
   /**
    * 被引用消息发送者的来源 Space 名称（相对当前查看 Space 解析后）。
    * 非空时，在昵称后以 `@{sourceSpaceName}` 形式内联展示，匹配消息头
    * 「@SpaceName」后缀（企微风格，dmwork-web#1069）。
    * 调用方负责调用 `resolveExternalForViewer`，避免把 WKApp 副作用引入纯 UI 组件。
    */
-  sourceSpaceName?: string
+  sourceSpaceName?: string;
   /** 点击跳转到原消息 */
-  onClick?: () => void
+  onClick?: () => void;
+}
+
+function renderDigest(digest: string) {
+  return linkifySafeUrls(digest).map((segment, index) => {
+    if (segment.type === "text") return segment.content;
+    return (
+      <a
+        key={`${index}-${segment.text}`}
+        className="wk-reply-block__digest-link"
+        href={segment.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {segment.text}
+      </a>
+    );
+  });
 }
 
 /**
@@ -34,7 +53,7 @@ export default function ReplyBlock({
   onClick,
 }: ReplyBlockProps) {
   const hasSpaceSuffix =
-    typeof sourceSpaceName === 'string' && sourceSpaceName.length > 0
+    typeof sourceSpaceName === "string" && sourceSpaceName.length > 0;
   return (
     <div className="wk-reply-block" onClick={onClick}>
       <div className="wk-reply-block__bar" />
@@ -50,8 +69,8 @@ export default function ReplyBlock({
             </span>
           )}
         </span>
-        <span className="wk-reply-block__digest">{digest}</span>
+        <span className="wk-reply-block__digest">{renderDigest(digest)}</span>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add a shared safe URL linkifier for message previews and plain text rendering
- keep RichText/MixedContent plain-text mode while preserving clickable http(s)/www links
- update ReplyBlock to reuse the same linkifier and stop link clicks from triggering reply navigation

Fixes #355

## Test
- pnpm --filter @octo/base exec vitest run src/Utils/__tests__/linkify.test.ts src/ui/message/ReplyBlock/__tests__/ReplyBlock.test.tsx
- pnpm exec prettier --check packages/dmworkbase/src/Utils/linkify.ts packages/dmworkbase/src/Utils/__tests__/linkify.test.ts packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx packages/dmworkbase/src/ui/message/ReplyBlock/index.tsx packages/dmworkbase/src/ui/message/ReplyBlock/__tests__/ReplyBlock.test.tsx packages/dmworkbase/src/ui/message/ReplyBlock/ReplyBlock.stories.tsx packages/dmworkbase/src/ui/message/MixedContent/MixedContent.stories.tsx packages/dmworkbase/src/ui/message/ReplyBlock/index.css