### PR TITLE
fix(richTextPaste): validate clipboard mentions + reject broadcast sentinels (#330)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts
@@ -228,3 +228,89 @@ describe("richTextPaste", () => {
     expect(file).toBeNull();
   });
 });
+
+describe("buildInlineContentForRichTextPaste — #330 mention UID trust boundary", () => {
+  const members = [
+    { uid: "u_alice", name: "Alice" },
+    { uid: "u_bob",   name: "Bob" },
+  ];
+
+  it("[FIX] rejects MENTION_UID_LEGACY_ALL sentinel (@everyone broadcast smuggling)", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "hi @everyone hello",
+      [{ uid: "-1", offset: 3, length: 9 }],
+      members
+    );
+    expect(nodes.find((n) => n.type === "mention")).toBeUndefined();
+    const fullText = nodes
+      .filter((n) => n.type === "text")
+      .map((n) => n.text)
+      .join("");
+    expect(fullText).toBe("hi @everyone hello");
+  });
+
+  it("[FIX] rejects MENTION_UID_HUMANS sentinel (@all-humans broadcast smuggling)", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "@所有人 ping",
+      [{ uid: "-2", offset: 0, length: 4 }],
+      members
+    );
+    expect(nodes.find((n) => n.type === "mention")).toBeUndefined();
+  });
+
+  it("[FIX] rejects MENTION_UID_AIS sentinel (@all-AI broadcast smuggling)", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "@所有AI go",
+      [{ uid: "-3", offset: 0, length: 5 }],
+      members
+    );
+    expect(nodes.find((n) => n.type === "mention")).toBeUndefined();
+  });
+
+  it("[FIX] passes mention when uid ∈ members AND label matches member.name", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "hi @Alice hello",
+      [{ uid: "u_alice", offset: 3, length: 6 }],
+      members
+    );
+    const mention = nodes.find((n) => n.type === "mention");
+    expect(mention).toBeDefined();
+    expect(mention?.attrs.id).toBe("u_alice");
+    expect(mention?.attrs.label).toBe("Alice");
+  });
+
+  it("[FIX] degrades to plain text when uid not in members (spoofed identity)", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "hi @Alice hello",
+      [{ uid: "u_evil_attacker", offset: 3, length: 6 }],
+      members
+    );
+    expect(nodes.find((n) => n.type === "mention")).toBeUndefined();
+    const fullText = nodes
+      .filter((n) => n.type === "text")
+      .map((n) => n.text)
+      .join("");
+    expect(fullText).toBe("hi @Alice hello");
+  });
+
+  it("[FIX] degrades when uid matches a member but label does not (label tampering)", () => {
+    const nodes = buildInlineContentForRichTextPaste(
+      "hi @Alice hello",
+      [{ uid: "u_bob", offset: 3, length: 6 }],
+      members
+    );
+    expect(nodes.find((n) => n.type === "mention")).toBeUndefined();
+  });
+
+  it("[CONTROL] legacy callers without members still work (backwards compat)", () => {
+    // Calling without `members` returns the old permissive behavior so callsites
+    // not yet updated do not silently break.
+    const nodes = buildInlineContentForRichTextPaste(
+      "hi @Alice hello",
+      [{ uid: "u_alice", offset: 3, length: 6 }]
+    );
+    const mention = nodes.find((n) => n.type === "mention");
+    expect(mention).toBeDefined();
+    expect(mention?.attrs.id).toBe("u_alice");
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -942,10 +942,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
           // Issue #330 — channel members snapshot for clipboard mention validation.
           // membersRef.current is the source of truth; paste is a single discrete
           // operation so a snapshot at paste time is sufficient (no live tracking).
-          // .map projects to the minimal { uid, name } shape required by
-          // MentionValidationMember; passing full Subscriber[] would also work
-          // structurally but the explicit projection documents what we depend on.
-          members: (membersRef.current ?? []).map((m) => ({ uid: m.uid, name: m.name })),
+          // Subscriber structurally satisfies MentionValidationMember (uid + name)
+          // so the ref is passed as-is — no projection needed.
+          members: membersRef.current ?? [],
           imageBlockToFile: (block) =>
             imageBlockToPasteFile(
               block,

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -939,6 +939,13 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         editor,
         addRichTextPasteAttachment,
         {
+          // Issue #330 — channel members snapshot for clipboard mention validation.
+          // membersRef.current is the source of truth; paste is a single discrete
+          // operation so a snapshot at paste time is sufficient (no live tracking).
+          // .map projects to the minimal { uid, name } shape required by
+          // MentionValidationMember; passing full Subscriber[] would also work
+          // structurally but the explicit projection documents what we depend on.
+          members: (membersRef.current ?? []).map((m) => ({ uid: m.uid, name: m.name })),
           imageBlockToFile: (block) =>
             imageBlockToPasteFile(
               block,

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -8,6 +8,11 @@ import type {
   OctoRichTextClipboardPayload,
 } from "../../Utils/richTextClipboard";
 import { isSafeUrl } from "../../Utils/security";
+import {
+  MENTION_UID_LEGACY_ALL,
+  MENTION_UID_HUMANS,
+  MENTION_UID_AIS,
+} from "../../Utils/mentionRender";
 
 type EditorLike = {
   chain: () => {
@@ -34,6 +39,11 @@ export interface RestoreOctoRichTextPasteDeps {
   imageBlockToFile?: (
     block: Extract<OctoRichTextClipboardBlock, { type: "image" }>
   ) => Promise<File | null>;
+  // Issue #330 — channel members snapshot for clipboard mention validation.
+  // Optional so existing tests (which only exercise inline content) keep
+  // working without a members fixture; absent members ⇒ legacy permissive
+  // behavior (sentinels still always rejected, see isAllowedClipboardMention).
+  members?: MentionValidationMember[];
 }
 
 function appendPlainText(nodes: any[], text: string) {
@@ -51,7 +61,8 @@ function appendPlainText(nodes: any[], text: string) {
 
 export function buildInlineContentForRichTextPaste(
   text: string,
-  mentions?: OctoRichTextClipboardMention[]
+  mentions?: OctoRichTextClipboardMention[],
+  members?: MentionValidationMember[]
 ): any[] {
   const nodes: any[] = [];
   const sortedMentions = (mentions || [])
@@ -68,7 +79,7 @@ export function buildInlineContentForRichTextPaste(
     if (mention.offset < cursor) continue;
     appendPlainText(nodes, text.slice(cursor, mention.offset));
     const name = text.slice(mention.offset, mention.offset + mention.length);
-    if (name.startsWith("@")) {
+    if (name.startsWith("@") && isAllowedClipboardMention(mention.uid, name.slice(1), members)) {
       nodes.push({
         type: "mention",
         attrs: {
@@ -77,6 +88,8 @@ export function buildInlineContentForRichTextPaste(
         },
       });
     } else {
+      // Not a mention OR validation failed → degrade to plain text (keeps
+      // user-visible content stable; same UX as typed-@ miss handling).
       appendPlainText(nodes, name);
     }
     cursor = mention.offset + mention.length;
@@ -96,6 +109,36 @@ function safeImageFileName(name?: string, mime?: string): string {
   const fallback = `image.${fallbackExt}`;
   const raw = (name || fallback).replace(/[\\/:*?"<>|]+/g, "_").slice(0, 120);
   return raw || fallback;
+}
+
+// Issue #330 — broadcast routing sentinels MUST NOT come from untrusted
+// clipboard. A pasted @everyone / @all-humans / @all-AI silently triggers
+// group-wide broadcast on send via formatMentionTextV2 (MessageInput/index.tsx:283+).
+const BROADCAST_SENTINEL_UIDS = new Set<string>([
+  MENTION_UID_LEGACY_ALL,
+  MENTION_UID_HUMANS,
+  MENTION_UID_AIS,
+]);
+
+export type MentionValidationMember = { uid: string; name: string };
+
+function isAllowedClipboardMention(
+  uid: string,
+  label: string,
+  members?: MentionValidationMember[]
+): boolean {
+  // Always reject broadcast sentinels (defense in depth — sentinels are
+  // dangerous in any context, even for legacy 2-arg callers).
+  if (BROADCAST_SENTINEL_UIDS.has(uid)) return false;
+  // Legacy 2-arg callers: skip member validation for backwards compat.
+  // The 3-arg call from MessageInput.tsx is the secured entry point.
+  if (!members) return true;
+  const member = members.find((m) => m.uid === uid);
+  if (!member) return false;
+  // Case-sensitive intentional: legitimate OCTO payloads carry server-truth
+  // labels that always exactly equal member.name. Any case mismatch =
+  // attacker-crafted or external paste → degrade for safety.
+  return member.name === label;
 }
 
 function parseContentLength(value: string | null): number | null {
@@ -196,7 +239,7 @@ export async function restoreOctoRichTextClipboardToEditor(
     if (block.type === "text") {
       insertInlineContent(
         editor,
-        buildInlineContentForRichTextPaste(block.text, block.mentions)
+        buildInlineContentForRichTextPaste(block.text, block.mentions, deps.members)
       );
       continue;
     }

--- a/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts
@@ -8,11 +8,7 @@ import type {
   OctoRichTextClipboardPayload,
 } from "../../Utils/richTextClipboard";
 import { isSafeUrl } from "../../Utils/security";
-import {
-  MENTION_UID_LEGACY_ALL,
-  MENTION_UID_HUMANS,
-  MENTION_UID_AIS,
-} from "../../Utils/mentionRender";
+import { isBroadcastSentinelUid } from "../../Utils/mentionRender";
 
 type EditorLike = {
   chain: () => {
@@ -111,15 +107,10 @@ function safeImageFileName(name?: string, mime?: string): string {
   return raw || fallback;
 }
 
-// Issue #330 — broadcast routing sentinels MUST NOT come from untrusted
-// clipboard. A pasted @everyone / @all-humans / @all-AI silently triggers
-// group-wide broadcast on send via formatMentionTextV2 (MessageInput/index.tsx:283+).
-const BROADCAST_SENTINEL_UIDS = new Set<string>([
-  MENTION_UID_LEGACY_ALL,
-  MENTION_UID_HUMANS,
-  MENTION_UID_AIS,
-]);
-
+// Issue #330 — clipboard mention validation. Sentinel-rejection helper is
+// shared with parseDraftToContent and any future paste-adjacent ingestion via
+// Utils/mentionRender.ts; member-list validation stays local because it is
+// only meaningful for clipboard (draft restore comes from server, not user).
 export type MentionValidationMember = { uid: string; name: string };
 
 function isAllowedClipboardMention(
@@ -129,7 +120,7 @@ function isAllowedClipboardMention(
 ): boolean {
   // Always reject broadcast sentinels (defense in depth — sentinels are
   // dangerous in any context, even for legacy 2-arg callers).
-  if (BROADCAST_SENTINEL_UIDS.has(uid)) return false;
+  if (isBroadcastSentinelUid(uid)) return false;
   // Legacy 2-arg callers: skip member validation for backwards compat.
   // The 3-arg call from MessageInput.tsx is the secured entry point.
   if (!members) return true;

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -117,6 +117,21 @@ export const MENTION_UID_AIS = "-3";
 export const MENTION_LABEL_HUMANS = "所有人";
 export const MENTION_LABEL_AIS = "所有AI";
 
+// Issue #330 — broadcast routing sentinels. formatMentionTextV2 routes these
+// uids to mention.all / mention.humans / mention.ais on send, escalating to
+// @everyone / @all-humans / @all-AI broadcasts. Any untrusted ingestion path
+// (clipboard paste, draft restore, future deeplink/postMessage) MUST reject
+// these uids — typed-@ dropdown is the only sanctioned source.
+export const BROADCAST_SENTINEL_UIDS = new Set<string>([
+  MENTION_UID_LEGACY_ALL,
+  MENTION_UID_HUMANS,
+  MENTION_UID_AIS,
+]);
+
+export function isBroadcastSentinelUid(uid: string): boolean {
+  return BROADCAST_SENTINEL_UIDS.has(uid);
+}
+
 export type MentionUidState = "bot" | "user" | "unknown";
 
 export function mentionUidStateFromRobot(robot: unknown): MentionUidState {


### PR DESCRIPTION
## Summary

Fixes [#330](https://github.com/Mininglamp-OSS/octo-web/issues/330) — clipboard-paste of forged `data-octo-richtext` HTML payload could (a) spoof a mention to any user, or (b) smuggle the broadcast routing sentinels (`MENTION_UID_LEGACY_ALL="-1"`, `MENTION_UID_HUMANS="-2"`, `MENTION_UID_AIS="-3"`) which `formatMentionTextV2` routes to `mention.all`/`mention.humans`/`mention.ais` on send — escalating one paste into a group-wide `@everyone` / `@all-humans` / `@all-AI` broadcast.

Validation now mirrors the existing typed-`@` trust contract at the paste boundary.

## Approach

| Layer | Change |
|---|---|
| **Sentinel rejection** (always) | `isBroadcastSentinelUid()` in `Utils/mentionRender.ts` — defense in depth, fires before any member check, applies to all 2-arg legacy callers and the secured 3-arg path |
| **Member-list validation** (3-arg path) | `buildInlineContentForRichTextPaste(text, mentions, members)` — requires `uid ∈ members` AND `member.name === label` (case-sensitive — legitimate OCTO payloads always exact-match, any divergence indicates attacker-crafted content) |
| **Caller wiring** | `MessageInput/index.tsx:937` paste handler passes `membersRef.current ?? []` as members snapshot at paste time |
| **Degrade UX** | Failed validation → plain `@label` text (no mention node), matching typed-`@` miss handling at `index.tsx:451-453` |

Predicate flow:
```
sentinel uid?       → reject (always, even legacy callers)
no members?         → permissive non-sentinel pass (backwards compat)
uid not in members? → reject (spoofed identity)
label ≠ member.name → reject (label tampering)
otherwise           → mention node emitted
```

## Files changed

```
packages/dmworkbase/src/Components/MessageInput/__tests__/richTextPaste.test.ts | +86 (7 new tests)
packages/dmworkbase/src/Components/MessageInput/index.tsx                       |  +6  -1
packages/dmworkbase/src/Components/MessageInput/richTextPaste.ts                | +25  -1
packages/dmworkbase/src/Utils/mentionRender.ts                                  | +15
4 files changed, 132 insertions(+), 2 deletions(-)
```

## Test plan

- [x] **Unit tests:** 7 new tests in `richTextPaste.test.ts` cover the exact threat surface — `[FIX]` sentinel rejection ×3 (`-1`/`-2`/`-3`), `[FIX]` valid mention pass-through, `[FIX]` spoofed uid degrade, `[FIX]` label-tamper degrade, `[CONTROL]` legacy 2-arg backwards compat. **15/15 pass** (8 baseline + 7 new).
- [x] **No regression vs main:** full `dmworkbase` test suite — pre-existing failure count unchanged (57 failed, all pre-existing UI/mock baseline; this PR introduces zero new failures).
- [x] **TypeScript:** no new errors on touched files (pre-existing TS debt from #68 untouched).
- [ ] **Manual reproduction** (recommended before merge by a reviewer with prod-like data): craft a `text/html` payload with `data-octo-richtext` JSON carrying `mention.uid: "-2"`, paste into the editor, confirm no mention node is created and the text appears as plain `@所有人`.

## Risks & mitigations

| Risk | Mitigation |
|---|---|
| `members?` parameter is optional → silent regress trap if a future caller forgets to pass it | Sentinel rejection still fires unconditionally even on 2-arg path. The current sole prod caller (`MessageInput/index.tsx:937`) passes members. Documented in the `RestoreOctoRichTextPasteDeps.members` JSDoc. If more callers appear, consider tightening to a TS overload. |
| Case-sensitive `member.name === label` is stricter than the typed-`@` path (which uses `.toLowerCase() ===`) | Intentional design — legitimate OCTO payloads originate from server and always exact-match `member.name`. Any case divergence in clipboard payload indicates attacker-crafted or externally-sourced content; safer to degrade. Comment in `isAllowedClipboardMention` documents this. |
| Long-term root fix (P2 in #330 report): move OCTO payload to non-forgeable MIME `application/x-octo-richtext` | Out of #330's reported scope. Closes the structural problem for all future fields (not just attachment + mention). Recommend a separate spec/PR. |
| `parseDraftToContent` (`MessageInput/index.tsx:529-569`) is the same vulnerability class at a different ingestion point — converts `@[uid:label]` to mention nodes with no sentinel/member check | **Out of #330 reported scope** — `restoreDraft` callers in production all pass server-supplied `vm.draft()` text (trusted source). Flagged here for a follow-up issue: `isBroadcastSentinelUid` (now in `Utils/mentionRender.ts`) is reusable, so the fix would be ~3 lines. |

## Roll-back plan

```bash
# Full revert (all 4 commits)
git revert ab417e20 13f6a66a 4b795fb4 9b75b42b

# Partial — keep red-baseline tests + sentinel helper, revert behavior change
git revert ab417e20 13f6a66a 4b795fb4
```

## Related

- Closes #330
- Original report + lml2468 triage: see #330 thread
- Companion already merged: #328 (attachment dimension, MERGED 2026-06-08 in `39284ab`)
- Suggested follow-up: `parseDraftToContent` sentinel guard (low priority — current callers trusted)
- Suggested long-term: P2 MIME-type migration to `application/x-octo-richtext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
