### PR TITLE
fix(bot): skip empty reply placeholder in message bubbles (#300)

### DIFF
--- a/packages/dmworkbase/src/Messages/RichText/index.tsx
+++ b/packages/dmworkbase/src/Messages/RichText/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import WKApp from "../../App";
 import { getRichTextMessageUI } from "../../bridge/message/useRichTextMessageUI";
-import { isMessageSelectable } from "../../Service/messageSelection";
+import { isMessageSelectable, isMeaningfulReply } from "../../Service/messageSelection";
 import MessageRow from "../../ui/message/MessageRow";
 import MixedContent from "../../ui/message/MixedContent";
 import ReplyBlock from "../../ui/message/ReplyBlock";
@@ -58,7 +58,7 @@ export class RichTextCell extends MessageCell {
         onSenderNameClick={() => context.showUser(message.fromUID)}
       >
         <div className="wk-message-richtext">
-          {content.reply && (
+          {isMeaningfulReply(content.reply) && (
             <ReplyBlock
               fromName={content.reply.fromName || ""}
               digest={content.reply.content?.conversationDigest || ""}

--- a/packages/dmworkbase/src/Messages/Text/index.tsx
+++ b/packages/dmworkbase/src/Messages/Text/index.tsx
@@ -12,7 +12,7 @@ import MessageRow from "../../ui/message/MessageRow"
 import ReplyBlock from "../../ui/message/ReplyBlock";
 import TextContent from "../../ui/message/TextContent";
 import { getTextMessageUI } from "../../bridge/message/useTextMessageUI";
-import { isMessageSelectable } from "../../Service/messageSelection";
+import { isMessageSelectable, isMeaningfulReply } from "../../Service/messageSelection";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import "./index.css"
 
@@ -194,7 +194,7 @@ export class TextCell extends MessageCell {
                     onSenderNameClick={() => context.showUser(message.fromUID)}
                 >
                     <div>
-                        {message?.content?.reply && (
+                        {isMeaningfulReply(message?.content?.reply) && (
                             <ReplyBlock
                                 fromName={message.content.reply.fromName || ''}
                                 digest={message.content.reply.content?.conversationDigest || ''}
@@ -218,7 +218,7 @@ export class TextCell extends MessageCell {
         }}>
 
             {
-                message?.content.reply ? <div className={classNames("wk-message-text-reply",message.send?undefined:"wk-message-text-reply-recv")} onClick={()=>{
+                isMeaningfulReply(message?.content?.reply) ? <div className={classNames("wk-message-text-reply",message.send?undefined:"wk-message-text-reply-recv")} onClick={()=>{
                     context.locateMessage( message?.content.reply.messageSeq)
                 }}>
                     <div className="wk-message-text-reply-author">

--- a/packages/dmworkbase/src/Service/__tests__/messageSelection.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageSelection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { MessageContentType } from "wukongimjssdk"
 import { MessageContentTypeConst } from "../Const"
-import { isMessageSelectable } from "../messageSelection"
+import { isMessageSelectable, isMeaningfulReply } from "../messageSelection"
 
 describe("isMessageSelectable", () => {
   it("allows normal user message types", () => {
@@ -24,5 +24,73 @@ describe("isMessageSelectable", () => {
   it("rejects missing messages defensively", () => {
     expect(isMessageSelectable(undefined)).toBe(false)
     expect(isMessageSelectable({})).toBe(false)
+  })
+})
+
+describe("isMeaningfulReply (#300 — Bot bubble empty reply placeholder)", () => {
+  it("[FIX] rejects null / undefined / non-object", () => {
+    expect(isMeaningfulReply(null)).toBe(false)
+    expect(isMeaningfulReply(undefined)).toBe(false)
+    expect(isMeaningfulReply("not an object")).toBe(false)
+    expect(isMeaningfulReply(42)).toBe(false)
+  })
+
+  it("[FIX] rejects empty reply object (the #300 bug case)", () => {
+    expect(isMeaningfulReply({})).toBe(false)
+  })
+
+  it("[FIX] rejects reply where every meaningful field is empty/zero", () => {
+    expect(
+      isMeaningfulReply({
+        fromName: "",
+        messageSeq: 0,
+        content: { conversationDigest: "" },
+      })
+    ).toBe(false)
+    expect(
+      isMeaningfulReply({
+        fromName: "",
+        messageSeq: 0,
+        content: undefined,
+      })
+    ).toBe(false)
+    expect(
+      isMeaningfulReply({ messageID: "msg_xxx", messageSeq: 0, fromName: "" })
+    ).toBe(false)
+  })
+
+  it("[FIX] accepts reply with non-empty fromName", () => {
+    expect(
+      isMeaningfulReply({ fromName: "Alice", messageSeq: 0 })
+    ).toBe(true)
+  })
+
+  it("[FIX] accepts reply with non-empty digest", () => {
+    expect(
+      isMeaningfulReply({
+        fromName: "",
+        messageSeq: 0,
+        content: { conversationDigest: "Hello world" },
+      })
+    ).toBe(true)
+  })
+
+  it("[FIX] accepts reply with non-zero messageSeq (locate-target available)", () => {
+    expect(
+      isMeaningfulReply({ fromName: "", messageSeq: 42 })
+    ).toBe(true)
+  })
+
+  it("[FIX] accepts SDK-shaped Reply instance with real fields", () => {
+    const sdkReply = {
+      messageID: "msg_real_001",
+      messageSeq: 17,
+      fromUID: "u_alice",
+      fromName: "Alice",
+      content: {
+        conversationDigest: "Original message text",
+      },
+    }
+    expect(isMeaningfulReply(sdkReply)).toBe(true)
   })
 })

--- a/packages/dmworkbase/src/Service/messageSelection.ts
+++ b/packages/dmworkbase/src/Service/messageSelection.ts
@@ -18,3 +18,36 @@ export function isMessageSelectable(message?: SelectableMessageLike | null): boo
   }
   return !UNSELECTABLE_MESSAGE_TYPES.has(message.contentType)
 }
+
+// ── Issue #300 — guard against rendering empty reply placeholders ──
+// Bot reply messages from the server can carry a `reply` field whose
+// content is structurally present but semantically empty (e.g. `reply: {}`
+// or `reply: { from_name: "", message_seq: 0 }`). The SDK's
+// `Reply.decode` silently creates a Reply instance from any truthy
+// payload object, with all fields possibly `undefined` / empty string / 0.
+//
+// Rendering ReplyBlock for such a reply produces a full-width grey
+// rectangle with a 2px left bar that visually mimics a focused input
+// field — see #300 (reporter described it as "extra empty input box").
+//
+// Meaningful = at least one of the three user-visible fields the
+// ReplyBlock surfaces has real content:
+//   - fromName: non-empty string
+//   - content.conversationDigest: non-empty string
+//   - messageSeq: positive integer (locate-target available)
+//
+// Server-side cleanup (Bot framework should not emit empty reply at all)
+// is tracked as a follow-up — not in this PR's scope.
+export function isMeaningfulReply(reply: unknown): boolean {
+  if (!reply || typeof reply !== "object") return false
+  const r = reply as {
+    fromName?: unknown
+    messageSeq?: unknown
+    content?: { conversationDigest?: unknown } | null
+  }
+  if (typeof r.fromName === "string" && r.fromName.length > 0) return true
+  const digest = r.content?.conversationDigest
+  if (typeof digest === "string" && digest.length > 0) return true
+  if (typeof r.messageSeq === "number" && r.messageSeq > 0) return true
+  return false
+}


### PR DESCRIPTION
## Summary

Fixes [#300](https://github.com/Mininglamp-OSS/octo-web/issues/300) — Bot reply messages render a full-width grey rectangle with a 2px left bar in the bubble above the actual text. The reporter described it as "an extra empty input box / cursor"; the real source is an empty `ReplyBlock` placeholder.

Visual evidence (from issue screenshots): the grey rectangle is `wk-reply-block` (`rgba(28,28,35,0.04)` background, 6px radius), the apparent "cursor" is `wk-reply-block__bar` (2px wide, deep-grey left edge).

## Root cause

SDK `wukongimjssdk@1.3.5` `Reply.decode` silently creates a `Reply` instance from any truthy payload object — including `{}` or `{ message_id: "", from_name: "", message_seq: 0 }`. Bot reply messages from the server can carry exactly such a structurally-present-but-semantically-empty `reply` field.

The 3 render callsites (`RichText/index.tsx`, `Text/index.tsx` new-UI, `Text/index.tsx` legacy div) all guard with a bare truthy check (`content.reply &&`), which the empty `Reply` instance passes. The `ReplyBlock` (or legacy reply div) then renders with all its inner spans empty — producing the placeholder rectangle the reporter saw.

## Approach

1. Add `isMeaningfulReply(reply: unknown): boolean` to `Service/messageSelection.ts` (the existing home of `isMessageSelectable` and similar small predicates).
2. Replace the 3 truthy guards with `isMeaningfulReply(...)`. Reply is "meaningful" iff at least one of these user-visible fields has real content:
   - `fromName` — non-empty string
   - `content.conversationDigest` — non-empty string
   - `messageSeq` — positive integer (locate-target available)

Failed check → guard short-circuits → no render. No visual placeholder.

## Files changed

```
packages/dmworkbase/src/Service/messageSelection.ts                | +33
packages/dmworkbase/src/Service/__tests__/messageSelection.test.ts | +70
packages/dmworkbase/src/Messages/RichText/index.tsx                | +2 -2
packages/dmworkbase/src/Messages/Text/index.tsx                    | +3 -3
4 files changed, 107 insertions(+), 6 deletions(-)
```

## Test plan

- [x] **Unit tests** — 7 new cases in `messageSelection.test.ts`:
  - `[FIX]` reject null / undefined / non-object
  - `[FIX]` reject empty `{}` (the exact #300 bug case)
  - `[FIX]` reject all-empty-fields object (3 sub-cases including the SDK-shaped `{ messageID, messageSeq: 0, fromName: "" }`)
  - `[FIX]` accept on non-empty `fromName`
  - `[FIX]` accept on non-empty `content.conversationDigest`
  - `[FIX]` accept on `messageSeq > 0`
  - `[FIX]` accept SDK-shaped real Reply object
  - **11/11 pass** (4 baseline + 7 new)
- [x] **No regression** — full `dmworkbase` suite has same pre-existing failure count as `main`.
- [x] **Lint** — no new errors on touched files.
- [ ] **Manual reproduction**: blocked locally (per @menghao-webtest's earlier comment — can't reproduce reliably without a specific Bot wire payload that emits `reply: {}`). If a reviewer has a Bot that exhibits the bug, the fix can be visually verified: before this PR the bubble shows the grey placeholder; after, the bubble contains only the Bot's text.

## Risks & mitigations

| Risk | Mitigation |
|---|---|
| Helper might reject a legitimate reply we forgot about | The 3 OR conditions cover every field `ReplyBlock` (and the legacy div) actually renders. If a real reply somehow has none of fromName / digest / messageSeq, there is nothing the UI would show anyway — degrading to no-render is correct. |
| Server-side root cause (Bot framework emitting empty reply) is not addressed | Out of #300's reported scope. The helper's comment documents this as a follow-up. Defense-in-depth at the web layer is the safer immediate fix. |
| Latent optional-chain tightening at `Text/index.tsx:221` (`message?.content.reply` → `message?.content?.reply`) was bundled with the guard swap | Strictly null-safer; surfaces here because the existing form would have been a TypeScript-narrow oddity once the new guard expects the optional chain. No behavior change for non-empty replies. |

## Roll-back plan

```bash
# Full revert (3 commits)
git revert 9a1ccdcb 9a054804 74510a71
```

## Related

- Closes #300
- @menghao-webtest's two triage comments on #300 — the hypothesis "empty quote/reference renders placeholder" is the correct one; this PR implements it as the meaningfulness predicate.
- Suggested follow-up (separate issue, not opened by this PR): trace whether the Bot reply payload should carry `reply: {}` at all — likely a server-side cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
