### PR TITLE
fix: show all groups and threads in forward picker (cold cache / inactive items)

### DIFF
--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -34,8 +34,14 @@ const hoisted = vi.hoisted(() => {
         fetchChannelInfo: vi.fn(),
         groupSaveList: vi.fn(async () => []),
         searchFriends: vi.fn(async () => []),
-        mittOn: vi.fn(),
+        mittOn: vi.fn((event: string, handler: () => void) => {
+            if (event === "conversation-list-refreshed") hoisted.refreshHandlers.push(handler)
+        }),
         mittOff: vi.fn(),
+        currentSpaceId: "" as string,
+        channelSpaceMap: new Map<string, string>(),
+        channelListeners: [] as Array<(info: any) => void>,
+        refreshHandlers: [] as Array<() => void>,
     }
 })
 
@@ -75,7 +81,10 @@ vi.mock("wukongimjssdk", () => {
                 conversationManager: { conversations: hoisted.conversations },
                 channelManager: {
                     getChannelInfo: hoisted.getChannelInfo,
-                    addListener: hoisted.addListener,
+                    addListener: (fn: any) => {
+                        hoisted.addListener(fn)
+                        hoisted.channelListeners.push(fn)
+                    },
                     removeListener: hoisted.removeListener,
                     fetchChannelInfo: hoisted.fetchChannelInfo,
                 },
@@ -102,7 +111,14 @@ vi.mock("../../../Utils/rateLimit", () => ({
 
 vi.mock("../../../App", () => ({
     default: {
-        shared: { currentSpaceId: undefined },
+        get shared() {
+            return {
+                get currentSpaceId() {
+                    return hoisted.currentSpaceId
+                },
+                channelSpaceMap: hoisted.channelSpaceMap,
+            }
+        },
         dataSource: {
             channelDataSource: { groupSaveList: hoisted.groupSaveList },
             commonDataSource: { searchFriends: hoisted.searchFriends },
@@ -130,6 +146,16 @@ function makeConv(channelID: string, channelType: number, displayName: string, o
         channel: { channelID, channelType },
         channelInfo: { orgData },
         timestamp: opts.timestamp ?? 0,
+    }
+}
+
+function makeGroupInfo(channelID: string, displayName: string, opts: { space_id?: string | null } = {}) {
+    const orgData: any = { displayName }
+    // 字段缺省(undefined) → 不写 space_id；显式 null → 写 null（验证 typeof 非 string 的 fail-open）。
+    if (opts.space_id !== undefined) orgData.space_id = opts.space_id
+    return {
+        channel: { channelID, channelType: CT_GROUP },
+        orgData,
     }
 }
 
@@ -232,3 +258,241 @@ describe("useForwardModal — archived threads excluded from forward targets", (
         view.unmount()
     })
 })
+
+describe("useForwardModal — group/my fallback groups + thread re-homing", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        hoisted.getChannelInfo.mockReturnValue(undefined)
+        hoisted.groupSaveList.mockResolvedValue([])
+        hoisted.searchFriends.mockResolvedValue([])
+        hoisted.currentSpaceId = ""
+        hoisted.channelSpaceMap = new Map()
+        hoisted.channelListeners = []
+        hoisted.refreshHandlers = []
+    })
+
+    afterEach(() => {
+        hoisted.conversations = []
+    })
+
+    it("recents has no group + group/my returns groups → final allItems contains the group", async () => {
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-only", "Group Only")] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-only")
+
+        view.unmount()
+    })
+
+    it("survives a lazy-load channelListener rebuild without dropping the fallback group (double-write race guard)", async () => {
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-lazy", "Group Lazy")] as any)
+
+        const view = await renderForward()
+        expect(view.current.allItems.map((i) => i.channelID)).toContain("g-lazy")
+
+        // 模拟懒加载 channelInfo 到达 → channelListener → rebuildDebounced → rebuild
+        await act(async () => {
+            for (const fn of hoisted.channelListeners) fn({})
+            await flushMicrotasks()
+        })
+
+        expect(view.current.allItems.map((i) => i.channelID)).toContain("g-lazy")
+
+        view.unmount()
+    })
+
+    it("keeps a group whose authoritative space_id matches and re-seeds channelSpaceMap", async () => {
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-match", "Group Match", { space_id: "space-1" }),
+        ] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-match")
+        expect(hoisted.channelSpaceMap.get(`g-match_${CT_GROUP}`)).toBe("space-1")
+
+        view.unmount()
+    })
+
+    it("drops a group whose space_id explicitly belongs to another space", async () => {
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-other", "Group Other", { space_id: "space-2" }),
+        ] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).not.toContain("g-other")
+        expect(hoisted.channelSpaceMap.has(`g-other_${CT_GROUP}`)).toBe(false)
+
+        view.unmount()
+    })
+
+    it("keeps a group with empty-string space_id but does NOT re-seed channelSpaceMap", async () => {
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-empty", "Group Empty", { space_id: "" }),
+        ] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-empty")
+        expect(hoisted.channelSpaceMap.has(`g-empty_${CT_GROUP}`)).toBe(false)
+
+        view.unmount()
+    })
+
+    it("keeps a group missing the space_id field (fail-open)", async () => {
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        // 无 space_id 字段
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-nofield", "Group NoField")] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-nofield")
+        expect(hoisted.channelSpaceMap.has(`g-nofield_${CT_GROUP}`)).toBe(false)
+
+        view.unmount()
+    })
+
+    it("deduplicates a group present in both recents and group/my (appears once)", async () => {
+        hoisted.conversations = [makeConv("g-dup", CT_GROUP, "Group Dup", { timestamp: 100 })]
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-dup", "Group Dup")] as any)
+
+        const view = await renderForward()
+        const occurrences = view.current.allItems.filter((i) => i.channelID === "g-dup")
+
+        expect(occurrences).toHaveLength(1)
+
+        view.unmount()
+    })
+
+    it("re-homes a recents thread under a parent group that only exists in group/my", async () => {
+        hoisted.conversations = [
+            makeConv("t-child", ChannelTypeCommunityTopic, "Child Thread", {
+                parentGroupNo: "g-parent", timestamp: 90,
+            }),
+        ]
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-parent", "Parent Group")] as any)
+
+        const view = await renderForward()
+        const items = view.current.allItems
+
+        const parentIdx = items.findIndex((i) => i.channelID === "g-parent")
+        const childIdx = items.findIndex((i) => i.channelID === "t-child")
+
+        expect(parentIdx).toBeGreaterThanOrEqual(0)
+        expect(childIdx).toBe(parentIdx + 1)
+        expect(items[childIdx].parentChannelID).toBe("g-parent")
+
+        view.unmount()
+    })
+
+    it("falls back to keeping an orphan thread whose parent is in neither recents nor group/my", async () => {
+        hoisted.conversations = [
+            makeConv("t-orphan", ChannelTypeCommunityTopic, "Orphan Thread", {
+                parentGroupNo: "g-missing", timestamp: 90,
+            }),
+        ]
+        hoisted.groupSaveList.mockResolvedValue([])
+
+        const view = await renderForward()
+        const item = view.current.allItems.find((i) => i.channelID === "t-orphan")
+
+        expect(item).toBeTruthy()
+        expect(item!.parentChannelID).toBe("g-missing")
+
+        view.unmount()
+    })
+
+    it("keeps a group with null space_id (fail-open) and does NOT re-seed channelSpaceMap", async () => {
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        // 显式 null：typeof 非 "string"，落入末位 fail-open，且不回种缓存。
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-null", "Group Null", { space_id: null }),
+        ] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-null")
+        expect(hoisted.channelSpaceMap.has(`g-null_${CT_GROUP}`)).toBe(false)
+
+        view.unmount()
+    })
+
+    it("filters an archived child re-homed under a group/my fallback parent (#346 still applies on the new path)", async () => {
+        // 父群仅在 group/my（兜底群），子区在 recents：一个活跃、一个归档。
+        // 组合 extra-group 父群 + archived child，验证归档过滤在兜底路径下仍生效。
+        hoisted.conversations = [
+            makeConv("t-active", ChannelTypeCommunityTopic, "Active Child", {
+                parentGroupNo: "g-fallback", threadStatus: ThreadStatus.Active, timestamp: 90,
+            }),
+            makeConv("t-archived", ChannelTypeCommunityTopic, "Archived Child", {
+                parentGroupNo: "g-fallback", threadStatus: ThreadStatus.Archived, timestamp: 80,
+            }),
+        ]
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-fallback", "Fallback Parent")] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        expect(ids).toContain("g-fallback")
+        expect(ids).toContain("t-active")
+        expect(ids).not.toContain("t-archived")
+
+        view.unmount()
+    })
+
+    it("on Space switch re-entry, the previous Space's fallback group must not flash in the first frame (M1)", async () => {
+        // Space A：兜底群带空串 space_id（fail-open 保留），渲染后进入 extraGroupsRef。
+        hoisted.currentSpaceId = "space-A"
+        hoisted.conversations = []
+        hoisted.groupSaveList.mockResolvedValueOnce([
+            makeGroupInfo("g-A", "Group A", { space_id: "" }),
+        ] as any)
+
+        const view = await renderForward()
+        expect(view.current.allItems.map((i) => i.channelID)).toContain("g-A")
+
+        // 切到 Space B：第二次 groupSaveList 挂起，模拟「B 的结果 resolve 前」的第一帧。
+        let resolveB: (v: any) => void = () => {}
+        hoisted.groupSaveList.mockReturnValueOnce(
+            new Promise((res) => { resolveB = res }) as any
+        )
+        hoisted.currentSpaceId = "space-B"
+
+        // conversation-list-refreshed → load() 重入。
+        await act(async () => {
+            for (const fn of hoisted.refreshHandlers) fn()
+            await flushMicrotasks()
+        })
+
+        // 关键回归断言：B 的 groupSaveList 尚未 resolve，第一帧不得出现 A 的兜底群。
+        // g-A 是空串 space_id，旧逻辑（extraGroupsRef 残留）会在 Space B 下 fail-open 闪现。
+        expect(view.current.allItems.map((i) => i.channelID)).not.toContain("g-A")
+
+        // 收尾：让挂起的 B 完成，避免悬挂 promise。
+        await act(async () => {
+            resolveB([])
+            await flushMicrotasks()
+        })
+
+        view.unmount()
+    })
+})
+

--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -42,6 +42,9 @@ const hoisted = vi.hoisted(() => {
         channelSpaceMap: new Map<string, string>(),
         channelListeners: [] as Array<(info: any) => void>,
         refreshHandlers: [] as Array<() => void>,
+        // 可配置的 Space 裁决桩：默认全保留(false)。需要模拟「外部成员豁免保留」
+        // 与「跨 Space 非外部成员剔除」时，用例按 channel 覆写 mockImplementation。
+        shouldSkip: vi.fn((_channel: any) => false),
     }
 })
 
@@ -97,7 +100,7 @@ vi.mock("wukongimjssdk", () => {
 })
 
 vi.mock("../../../Service/SpaceService", () => ({
-    shouldSkipChannelForSpace: () => false,
+    shouldSkipChannelForSpace: (channel: any) => hoisted.shouldSkip(channel),
     shouldSkipPersonConversationForSpace: () => false,
 }))
 
@@ -171,6 +174,21 @@ async function flushMicrotasks() {
     await Promise.resolve()
 }
 
+// 用例隔离：重置所有 hoisted 共享状态（mock 返回值 + Space/缓存/监听器集合），
+// 保证两个 describe 的每个用例都从干净 hoisted 状态起步，避免跨用例串扰。
+function resetHoisted() {
+    vi.clearAllMocks()
+    hoisted.getChannelInfo.mockReturnValue(undefined)
+    hoisted.groupSaveList.mockResolvedValue([])
+    hoisted.searchFriends.mockResolvedValue([])
+    hoisted.shouldSkip.mockImplementation(() => false)
+    hoisted.currentSpaceId = ""
+    hoisted.channelSpaceMap = new Map()
+    hoisted.channelListeners = []
+    hoisted.refreshHandlers = []
+    hoisted.conversations = []
+}
+
 async function renderForward() {
     const container = document.createElement("div")
     document.body.appendChild(container)
@@ -194,10 +212,7 @@ async function renderForward() {
 
 describe("useForwardModal — archived threads excluded from forward targets", () => {
     beforeEach(() => {
-        vi.clearAllMocks()
-        hoisted.getChannelInfo.mockReturnValue(undefined)
-        hoisted.groupSaveList.mockResolvedValue([])
-        hoisted.searchFriends.mockResolvedValue([])
+        resetHoisted()
     })
 
     afterEach(() => {
@@ -261,14 +276,7 @@ describe("useForwardModal — archived threads excluded from forward targets", (
 
 describe("useForwardModal — group/my fallback groups + thread re-homing", () => {
     beforeEach(() => {
-        vi.clearAllMocks()
-        hoisted.getChannelInfo.mockReturnValue(undefined)
-        hoisted.groupSaveList.mockResolvedValue([])
-        hoisted.searchFriends.mockResolvedValue([])
-        hoisted.currentSpaceId = ""
-        hoisted.channelSpaceMap = new Map()
-        hoisted.channelListeners = []
-        hoisted.refreshHandlers = []
+        resetHoisted()
     })
 
     afterEach(() => {
@@ -321,9 +329,11 @@ describe("useForwardModal — group/my fallback groups + thread re-homing", () =
         view.unmount()
     })
 
-    it("drops a group whose space_id explicitly belongs to another space", async () => {
+    it("drops a cross-space group when shouldSkipChannelForSpace rejects it (non-external member), but still re-seeds its real space_id", async () => {
         hoisted.currentSpaceId = "space-1"
         hoisted.conversations = []
+        // 非外部成员：权威裁决剔除（source_space_id 不匹配 → shouldSkip 返回 true）。
+        hoisted.shouldSkip.mockImplementation((ch: any) => ch?.channelID === "g-other")
         hoisted.groupSaveList.mockResolvedValue([
             makeGroupInfo("g-other", "Group Other", { space_id: "space-2" }),
         ] as any)
@@ -332,7 +342,30 @@ describe("useForwardModal — group/my fallback groups + thread re-homing", () =
         const ids = view.current.allItems.map((i) => i.channelID)
 
         expect(ids).not.toContain("g-other")
-        expect(hoisted.channelSpaceMap.has(`g-other_${CT_GROUP}`)).toBe(false)
+        // Plan A：跨 Space 分支无条件回种群真实归属（与权威 channelInfo 命中时一致），
+        // 即便最终被剔除，缓存里存的也是该群真实 space_id（非污染）。
+        expect(hoisted.channelSpaceMap.get(`g-other_${CT_GROUP}`)).toBe("space-2")
+
+        view.unmount()
+    })
+
+    it("keeps a cross-space external group exempted by source_space_id and re-seeds its real space_id", async () => {
+        // currentSpaceId=space-1，群 orgData.space_id=space-2，但我以 space-1 身份外部加入
+        // （source_space_id=space-1）→ 权威 shouldSkipChannelForSpace 豁免保留（返回 false）。
+        hoisted.currentSpaceId = "space-1"
+        hoisted.conversations = []
+        hoisted.shouldSkip.mockImplementation(() => false)
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-external", "External Group", { space_id: "space-2" }),
+        ] as any)
+
+        const view = await renderForward()
+        const ids = view.current.allItems.map((i) => i.channelID)
+
+        // 回归 #366 Blocker：外部群必须出现在转发框（兜底路径不得错误剔除）。
+        expect(ids).toContain("g-external")
+        // 回种群真实归属 space-2。
+        expect(hoisted.channelSpaceMap.get(`g-external_${CT_GROUP}`)).toBe("space-2")
 
         view.unmount()
     })
@@ -368,35 +401,59 @@ describe("useForwardModal — group/my fallback groups + thread re-homing", () =
         view.unmount()
     })
 
-    it("deduplicates a group present in both recents and group/my (appears once)", async () => {
-        hoisted.conversations = [makeConv("g-dup", CT_GROUP, "Group Dup", { timestamp: 100 })]
-        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-dup", "Group Dup")] as any)
+    it("deduplicates a group present in both recents and group/my, keeping the recents version", async () => {
+        // 给两份设可区分 displayName：recents 版 vs group/my 版。
+        // 去重逻辑：recents 群先入 seenGroupIDs，兜底群 continue 跳过 → 应保留 recents 版。
+        hoisted.conversations = [makeConv("g-dup", CT_GROUP, "Group Dup Recents", { timestamp: 100 })]
+        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-dup", "Group Dup Fallback")] as any)
 
         const view = await renderForward()
         const occurrences = view.current.allItems.filter((i) => i.channelID === "g-dup")
 
         expect(occurrences).toHaveLength(1)
+        // 锁定「recents 优先」语义：保留的必须是 recents 版本，而非兜底版本。
+        expect(occurrences[0].displayName).toBe("Group Dup Recents")
 
         view.unmount()
     })
 
-    it("re-homes a recents thread under a parent group that only exists in group/my", async () => {
+    it("re-homes a recents thread within its group/my parent's segment while an orphan thread stays in the tail", async () => {
+        // 区分两条路径：
+        //  - t-child 的父群 g-parent 仅在 group/my（兜底群），子区在 recents → 走挂回循环，
+        //    应紧跟父群、落在父群与下一个兜底群 g-second 之间。
+        //  - t-orphan 的父群 g-missing 既不在 recents 也不在 group/my → 真孤儿，落在末尾段。
+        // 第二个兜底群 g-second 作为分界：若删掉挂回循环，t-child 会落到末尾的
+        // threadsByParent 兜底段，排到 g-second 之后，下面的 childIdx < secondIdx 断言即失败。
         hoisted.conversations = [
             makeConv("t-child", ChannelTypeCommunityTopic, "Child Thread", {
                 parentGroupNo: "g-parent", timestamp: 90,
             }),
+            makeConv("t-orphan", ChannelTypeCommunityTopic, "Orphan Thread", {
+                parentGroupNo: "g-missing", timestamp: 80,
+            }),
         ]
-        hoisted.groupSaveList.mockResolvedValue([makeGroupInfo("g-parent", "Parent Group")] as any)
+        hoisted.groupSaveList.mockResolvedValue([
+            makeGroupInfo("g-parent", "Parent Group"),
+            makeGroupInfo("g-second", "Second Group"),
+        ] as any)
 
         const view = await renderForward()
         const items = view.current.allItems
 
         const parentIdx = items.findIndex((i) => i.channelID === "g-parent")
         const childIdx = items.findIndex((i) => i.channelID === "t-child")
+        const secondIdx = items.findIndex((i) => i.channelID === "g-second")
+        const orphanIdx = items.findIndex((i) => i.channelID === "t-orphan")
 
         expect(parentIdx).toBeGreaterThanOrEqual(0)
-        expect(childIdx).toBe(parentIdx + 1)
+        expect(secondIdx).toBeGreaterThanOrEqual(0)
+        // 真子区紧跟父群、归在父群段内（在下一个兜底群之前）——删除挂回循环则此断言失败。
+        expect(childIdx).toBeGreaterThan(parentIdx)
+        expect(childIdx).toBeLessThan(secondIdx)
         expect(items[childIdx].parentChannelID).toBe("g-parent")
+        // 孤儿子区在末尾段：排在所有兜底群之后，且 parentChannelID 仍正确。
+        expect(orphanIdx).toBeGreaterThan(secondIdx)
+        expect(items[orphanIdx].parentChannelID).toBe("g-missing")
 
         view.unmount()
     })

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -173,8 +173,14 @@ export function useForwardModal(
             // key 格式与 shouldSkipChannelForSpace 一致。
             WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
           } else if (groupSpaceId !== "") {
-            // 明确跨 Space → 剔除。
-            continue
+            // 跨 Space：先用 group/my 行自带的权威 space_id 回种 channelSpaceMap
+            // （回种群真实归属，与 shouldSkipChannelForSpace 命中 channelInfo 时
+            // 无条件回填的语义一致），再交给 shouldSkipChannelForSpace 统一裁决
+            // （它内部含 source_space_id 外部成员豁免）。豁免逻辑只活在
+            // SpaceService，不在此复制。先回种再调用不会短路——缓存命中分支读到
+            // 回种的跨 Space 值后仍会执行 source_space_id 豁免检查。
+            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
+            if (shouldSkipChannelForSpace(groupInfo.channel)) continue
           }
           // 空串 ""：group/my 已带 param.space_id 背书，保留但绝不回种缓存（空串污染）。
         }

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -112,6 +112,12 @@ export function useForwardModal(
   // 保存原始 wraps 引用，供 channelInfoListener 触发后重新构建
   const wrapsRef = useRef<ConversationWrap[]>([])
 
+  // group/my 兜底群（recents 里缺席的群只在旁路返回，SDK 不建 conversation）。
+  // 由 load() 在 gen 守卫通过后写入，rebuildConvItems 每次执行都消费它并与
+  // recents 群合并，从而成为 conversationItems 的唯一写入路径，避免懒加载
+  // channelInfo 到达后 rebuild 全量覆盖把兜底群冲掉的双写竞态。
+  const extraGroupsRef = useRef<ChannelInfo[]>([])
+
   // 懒加载：记录已发起 fetchChannelInfo 的 channelID，避免重复请求
   const fetchedRef = useRef<Set<string>>(new Set())
 
@@ -135,20 +141,51 @@ export function useForwardModal(
     const groupWraps: ConversationWrap[] = []
     const threadWraps: ConversationWrap[] = []
     const spaceId = WKApp.shared.currentSpaceId
+    // 已并入的群 ID（recents 群 + extraGroups 群），用于去重与子区挂回。
+    const seenGroupIDs = new Set<string>()
     for (const wrap of wrapsRef.current) {
-      if (spaceId && wrap.channel.channelType === ChannelTypeGroup) {
-        const groupSpaceId = wrap.channelInfo?.orgData?.space_id
-        // 严格模式：没有 space_id 或不匹配当前 Space 的群聊都跳过
-        if (!groupSpaceId || groupSpaceId !== spaceId) {
-          continue
-        }
-      }
       channelMapRef.current.set(wrap.channel.channelID, wrap.channel)
       if (wrap.channel.channelType === ChannelTypeCommunityTopic) {
         threadWraps.push(wrap)
       } else {
+        // recents 群：load() 入口的 shouldSkipChannelForSpace 已做权威 Space
+        // 把关（channelSpaceMap → channelInfo → fail-closed），此处不再二次过滤。
         groupWraps.push(wrap)
+        if (wrap.channel.channelType === ChannelTypeGroup) {
+          seenGroupIDs.add(wrap.channel.channelID)
+        }
       }
+    }
+
+    // group/my 兜底群：用群条目自带的权威 space_id（来自 group/my 行）按来源分流。
+    const extraGroupItems: ForwardItem[] = []
+    for (const groupInfo of extraGroupsRef.current) {
+      const channelID = groupInfo.channel.channelID
+      // 去重：仅当不在已并入的 recents 群集合时才并入（避免 React duplicate key）。
+      if (seenGroupIDs.has(channelID)) continue
+
+      if (spaceId) {
+        const groupSpaceId = groupInfo.orgData?.space_id
+        if (typeof groupSpaceId === "string") {
+          if (groupSpaceId === spaceId) {
+            // 权威命中：用 group/my 行自带的权威 space_id 回灌 channelSpaceMap
+            // （隐藏副作用：让后续 shouldSkipChannelForSpace 走缓存命中分支）。
+            // key 格式与 shouldSkipChannelForSpace 一致。
+            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
+          } else if (groupSpaceId !== "") {
+            // 明确跨 Space → 剔除。
+            continue
+          }
+          // 空串 ""：group/my 已带 param.space_id 背书，保留但绝不回种缓存（空串污染）。
+        }
+        // groupSpaceId 字段缺失(undefined) 或为 null（typeof 非 "string"）
+        // → 末位 fail-open 保留，且不回种 channelSpaceMap。
+      }
+      // currentSpaceId 为空（无 Space 模式）→ 不做 Space 过滤，全保留。
+
+      channelMapRef.current.set(channelID, groupInfo.channel)
+      seenGroupIDs.add(channelID)
+      extraGroupItems.push(channelInfoToForwardItem(groupInfo))
     }
 
     // 转发目标永不包含已归档子区：复用侧栏的 fail-open helper
@@ -179,8 +216,26 @@ export function useForwardModal(
       for (const tw of children) {
         items.push(conversationWrapToForwardItem(tw, gw.channel.channelID))
       }
+      // 已挂回的子区从 Map 移除，避免后续兜底重复追加。
+      threadsByParent.delete(gw.channel.channelID)
     }
-    // 找不到父群的孤儿子区追加到末尾
+    // group/my 兜底群追加在 recents 群之后；其子区（仅来自 recents）挂回父群。
+    for (const item of extraGroupItems) {
+      items.push(item)
+      const children = threadsByParent.get(item.channelID) || []
+      for (const tw of children) {
+        items.push(conversationWrapToForwardItem(tw, item.channelID))
+      }
+      threadsByParent.delete(item.channelID)
+    }
+    // 兜底：有 parentGroupNo 但父群既不在 recents 也不在 group/my 的子区，
+    // 作为独立项追加到末尾（带 parentChannelID），避免父群确实缺席时被静默丢弃。
+    for (const [parentGroupNo, children] of threadsByParent) {
+      for (const tw of children) {
+        items.push(conversationWrapToForwardItem(tw, parentGroupNo))
+      }
+    }
+    // 找不到父群的孤儿子区（无 parentGroupNo）追加到末尾
     for (const ow of orphanThreads) {
       items.push(conversationWrapToForwardItem(ow))
     }
@@ -191,6 +246,10 @@ export function useForwardModal(
   useEffect(() => {
     async function load() {
       const gen = ++loadGenRef.current
+      // 重入/切 Space 时先清空上一轮兜底群，避免第一帧 rebuild 用旧 Space 的
+      // group/my 兜底群产出（空串/字段缺失分支会 fail-open 让旧 Space 群闪现）。
+      // 代价仅冷启动第一帧不显示兜底群（本就冷状态，无损）。
+      extraGroupsRef.current = []
       setLoading(true)
       try {
         // 最近会话：仅构造 wrap，不再对每个 conv 主动 fetchChannelInfo。
@@ -206,25 +265,13 @@ export function useForwardModal(
         wrapsRef.current = sortConversations(wraps)
         rebuildConvItems()
 
-        // 补全：获取用户加入的全部群聊（已支持 space_id 过滤）
+        // 补全：获取用户加入的全部群聊（已支持 space_id 过滤）。
+        // 不再直接 setConversationItems 第二次写入，而是存入 extraGroupsRef 并
+        // 触发一次 rebuildConvItems，让其与 recents 群合并产出，杜绝双写竞态。
         const allGroups = await WKApp.dataSource.channelDataSource.groupSaveList()
         if (gen !== loadGenRef.current) return // 有更新的 load 在跑,丢弃本次结果
-        const existingGroupIDs = new Set<string>()
-        for (const wrap of wrapsRef.current) {
-          if (wrap.channel.channelType === ChannelTypeGroup) {
-            existingGroupIDs.add(wrap.channel.channelID)
-          }
-        }
-        const extraGroupItems: ForwardItem[] = []
-        for (const groupInfo of allGroups) {
-          if (!existingGroupIDs.has(groupInfo.channel.channelID)) {
-            channelMapRef.current.set(groupInfo.channel.channelID, groupInfo.channel)
-            extraGroupItems.push(channelInfoToForwardItem(groupInfo))
-          }
-        }
-        if (extraGroupItems.length > 0) {
-          setConversationItems((prev: ForwardItem[]) => [...prev, ...extraGroupItems])
-        }
+        extraGroupsRef.current = allGroups
+        rebuildConvItems()
 
         // 好友
         const friends = (await WKApp.dataSource.commonDataSource.searchFriends("")) ?? []


### PR DESCRIPTION
## Summary
Fixes the Web forward dialog so that all groups the user belongs to, and threads that exist, are reliably listed as forward targets — including on a cold cache and for threads/groups without recent activity.

## Problem
When opening the forward picker:
- Some groups the user belongs to were missing right after launch (cold cache / no recent activity).
- Threads that exist inside a group did not show up if they had not been recently active, so users could not forward to them — with no error shown (silent failure).

## Fix
- Build the conversation/thread list from a single, stable data source so late-arriving data can no longer overwrite already-listed groups.
- Feed the authoritative group fallback source into the list build so groups remain present regardless of load timing.
- Use the authoritative per-group space scoping (no fail-open guessing) so groups are filtered correctly without cross-space leakage, including the empty-space-id edge case.
- Re-attach threads to their parent group and keep an orphan fallback so threads are not dropped.

## Tests
- `useForwardModal.test.tsx`: 15/15 passing, including a regression guard for the late-data race.

## Related issues
Fixes #366
