### PR TITLE
fix: forwarding to a thread silently fails from the forward dialog

### DIFF
--- a/apps/web/src/__tests__/forwardModalChatType.test.ts
+++ b/apps/web/src/__tests__/forwardModalChatType.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { Channel } from "wukongimjssdk";
+
+// Import the source file directly to avoid pulling the full @octo/base barrel
+// (which loads lottie-web and other browser-only deps). Mirrors the approach in
+// threadGroupMd.test.ts.
+import { chatTypeToChannelType } from "../../../../packages/dmworkbase/src/Components/ForwardModal/chatTypeToChannelType";
+import { candidateToForwardItem } from "../../../../packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem";
+
+const ChannelTypePerson = 1;
+const ChannelTypeGroup = 2;
+const ChannelTypeCommunityTopic = 5;
+
+describe("ForwardModal: chatTypeToChannelType", () => {
+  it("maps thread -> ChannelTypeCommunityTopic (5)", () => {
+    expect(chatTypeToChannelType("thread")).toBe(ChannelTypeCommunityTopic);
+  });
+
+  it("maps direct -> ChannelTypePerson (1)", () => {
+    expect(chatTypeToChannelType("direct")).toBe(ChannelTypePerson);
+  });
+
+  it("maps group -> ChannelTypeGroup (2)", () => {
+    expect(chatTypeToChannelType("group")).toBe(ChannelTypeGroup);
+  });
+
+  it("maps unknown / undefined -> ChannelTypeGroup (2)", () => {
+    expect(chatTypeToChannelType("something-else")).toBe(ChannelTypeGroup);
+    expect(chatTypeToChannelType(undefined)).toBe(ChannelTypeGroup);
+  });
+});
+
+describe("ForwardModal: search candidate -> Channel construction (#273)", () => {
+  // Reproduces the search-result mapping in useForwardModal: a selected thread
+  // must become Channel(groupNo____shortId, 5), NOT Channel(..., 2). The old
+  // "non-direct => group" logic produced type=2 and the backend silently
+  // dropped the forwarded message.
+  function buildChannel(candidate: { chat_id: string; chat_type: string }): Channel {
+    return new Channel(candidate.chat_id, chatTypeToChannelType(candidate.chat_type));
+  }
+
+  it("builds a CommunityTopic channel for a thread candidate, keeping the full groupNo____shortId id", () => {
+    const channel = buildChannel({
+      chat_id: "grp001____tid001",
+      chat_type: "thread",
+    });
+    expect(channel.channelType).toBe(ChannelTypeCommunityTopic);
+    expect(channel.channelID).toBe("grp001____tid001");
+  });
+
+  it("builds a Person channel for a direct candidate", () => {
+    const channel = buildChannel({ chat_id: "u123", chat_type: "direct" });
+    expect(channel.channelType).toBe(ChannelTypePerson);
+    expect(channel.channelID).toBe("u123");
+  });
+
+  it("builds a Group channel for a group candidate", () => {
+    const channel = buildChannel({ chat_id: "grp001", chat_type: "group" });
+    expect(channel.channelType).toBe(ChannelTypeGroup);
+    expect(channel.channelID).toBe("grp001");
+  });
+});
+
+describe("ForwardModal: candidateToForwardItem (#273)", () => {
+  // No local channelInfo cache in tests; inject a stub so the pure function
+  // never touches WKSDK.
+  const noCache = (_ch: Channel) => undefined;
+
+  it("prefers parent_group_no for a thread's parentChannelID", () => {
+    const item = candidateToForwardItem(
+      { chat_id: "grp001____tid001", chat_type: "thread", parent_group_no: "grpX" },
+      noCache,
+    );
+    expect(item.parentChannelID).toBe("grpX");
+  });
+
+  it("treats numeric parent_group_no 0 as a valid parent (not falsy fallback)", () => {
+    const item = candidateToForwardItem(
+      { chat_id: "0____tid001", chat_type: "thread", parent_group_no: 0 },
+      noCache,
+    );
+    expect(item.parentChannelID).toBe("0");
+  });
+
+  it("converts a numeric parent_group_no to String", () => {
+    const item = candidateToForwardItem(
+      { chat_id: "grp001____tid001", chat_type: "thread", parent_group_no: 12345 },
+      noCache,
+    );
+    expect(item.parentChannelID).toBe("12345");
+    expect(typeof item.parentChannelID).toBe("string");
+  });
+
+  it("falls back to parseThreadChannelId(chat_id).groupNo when parent_group_no is missing", () => {
+    const item = candidateToForwardItem(
+      { chat_id: "grpFallback____tid001", chat_type: "thread" },
+      noCache,
+    );
+    expect(item.parentChannelID).toBe("grpFallback");
+  });
+
+  it("treats null parent_group_no like missing and uses the parsed fallback", () => {
+    const item = candidateToForwardItem(
+      { chat_id: "grpFallback____tid001", chat_type: "thread", parent_group_no: null },
+      noCache,
+    );
+    expect(item.parentChannelID).toBe("grpFallback");
+  });
+
+  it("returns undefined parentChannelID (without throwing) when chat_id has no separator", () => {
+    let item: ReturnType<typeof candidateToForwardItem> | undefined;
+    expect(() => {
+      item = candidateToForwardItem(
+        { chat_id: "no-separator-id", chat_type: "thread" },
+        noCache,
+      );
+    }).not.toThrow();
+    expect(item?.parentChannelID).toBeUndefined();
+  });
+
+  it("computes isThread from chat_type", () => {
+    expect(
+      candidateToForwardItem({ chat_id: "grp001____t", chat_type: "thread" }, noCache).isThread,
+    ).toBe(true);
+    expect(
+      candidateToForwardItem({ chat_id: "grp001", chat_type: "group" }, noCache).isThread,
+    ).toBe(false);
+    expect(
+      candidateToForwardItem({ chat_id: "u1", chat_type: "direct" }, noCache).isThread,
+    ).toBe(false);
+  });
+
+  it("never sets parentChannelID for non-thread candidates", () => {
+    const group = candidateToForwardItem(
+      { chat_id: "grp001____x", chat_type: "group" },
+      noCache,
+    );
+    expect(group.parentChannelID).toBeUndefined();
+    const direct = candidateToForwardItem(
+      { chat_id: "u1____x", chat_type: "direct" },
+      noCache,
+    );
+    expect(direct.parentChannelID).toBeUndefined();
+  });
+
+  it("maps channelType for direct / group / thread candidates", () => {
+    expect(
+      candidateToForwardItem({ chat_id: "u1", chat_type: "direct" }, noCache).channelType,
+    ).toBe(ChannelTypePerson);
+    expect(
+      candidateToForwardItem({ chat_id: "grp001", chat_type: "group" }, noCache).channelType,
+    ).toBe(ChannelTypeGroup);
+    expect(
+      candidateToForwardItem({ chat_id: "grp001____t", chat_type: "thread" }, noCache).channelType,
+    ).toBe(ChannelTypeCommunityTopic);
+  });
+
+  it("falls back to chat_id for displayName when name is absent", () => {
+    expect(
+      candidateToForwardItem({ chat_id: "grp001", chat_type: "group" }, noCache).displayName,
+    ).toBe("grp001");
+    expect(
+      candidateToForwardItem(
+        { chat_id: "grp001", chat_type: "group", name: "Team" },
+        noCache,
+      ).displayName,
+    ).toBe("Team");
+  });
+
+  it("inherits isExternal from cached channelInfo only for groups", () => {
+    const externalCache = (_ch: Channel) =>
+      ({ orgData: { is_external_group: 1 } } as any);
+    expect(
+      candidateToForwardItem(
+        { chat_id: "grp001", chat_type: "group" },
+        externalCache,
+      ).isExternal,
+    ).toBe(true);
+    // A thread with the same cached flag must NOT be marked external.
+    expect(
+      candidateToForwardItem(
+        { chat_id: "grp001____t", chat_type: "thread" },
+        externalCache,
+      ).isExternal,
+    ).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -450,13 +450,77 @@ export class Conversation
     return message;
   }
 
+  // 统一上报转发结果。区分「全部失败」与「部分失败（带计数）」，全部成功不提示。
+  private showForwardResult(failed: number, total: number): void {
+    if (failed <= 0) {
+      return;
+    }
+    if (failed >= total) {
+      Toast.error(t("base.conversation.forward.allFailed"));
+    } else {
+      Toast.error(
+        t("base.conversation.forward.partialFailed", {
+          values: { failed, total },
+        }),
+      );
+    }
+  }
+
   fowardMessageUI(message: Message): void {
-    WKApp.shared.baseContext.showConversationSelect((channels: Channel[]) => {
-      const cloneContent = getEffectiveContent(message);
-      for (const channel of channels) {
-        this.sendMessage(cloneContent, channel);
+    WKApp.shared.baseContext.showConversationSelect(async (channels: Channel[]) => {
+      // getEffectiveContent 放在最外层 try：它同步抛错也不会逃逸成 unhandled
+      // rejection（此回调是 async）。
+      try {
+        const cloneContent = getEffectiveContent(message);
+        // 并发投递，单目标失败不影响其余（目标上限已放宽到 30，串行会线性放大耗时）。
+        // 用 Promise.all + 每个任务 .catch 兜底（语义等价 Promise.allSettled，但本
+        // 包 tsconfig target=es2019 没有 allSettled 类型，手写更稳）。
+        //
+        // 加固边界（#273）：此处捕获的是「内容构造 / 编码 / 同步 send 调用」异常；
+        // WKSDK.chatManager.send() 是本地乐观语义——packet 入队后立即 resolve，真正
+        // 的投递失败在 ack 阶段异步回调（notifyMessageStatusListeners），不会在这里
+        // 被 catch 到。hook ack 超出本次修复范围。
+        const failed = await this.forwardToChannels(
+          channels,
+          () => cloneContent,
+        );
+        this.showForwardResult(failed, channels.length);
+      } catch (e) {
+        console.error("[forward] build content failed", e);
+        Toast.error(t("base.conversation.forward.allFailed"));
       }
     });
+  }
+
+  // 把同一 content 并发转发到多个目标，返回失败目标数。getContent 每个目标调用
+  // 一次（merge / 多消息场景按需返回不同 content）。单目标失败被隔离、计数，不影响
+  // 其余目标。见 fowardMessageUI 处关于 send() 乐观语义与捕获边界的说明。
+  private async forwardToChannels(
+    channels: Channel[],
+    getContent: (channel: Channel) => MessageContent,
+  ): Promise<number> {
+    type SendOutcome = { ok: true } | { ok: false; channelID: string; reason: unknown };
+    const outcomes = await Promise.all(
+      channels.map((channel): Promise<SendOutcome> =>
+        this.sendMessage(getContent(channel), channel)
+          .then((): SendOutcome => ({ ok: true }))
+          .catch(
+            (reason: unknown): SendOutcome => ({
+              ok: false,
+              channelID: channel.channelID,
+              reason,
+            }),
+          ),
+      ),
+    );
+    let failed = 0;
+    for (const o of outcomes) {
+      if (!o.ok) {
+        failed++;
+        console.error("[forward] send failed", o.channelID, o.reason);
+      }
+    }
+    return failed;
   }
   openThreadPanel(threadChannelId: string, threadName: string): void {
     this.onOpenThreadPanel?.(threadChannelId, threadName);
@@ -2445,14 +2509,57 @@ export class Conversation
                         return;
                       }
                       WKApp.shared.baseContext.showConversationSelect(
-                        (channels: Channel[]) => {
-                          for (const message of messages) {
-                            const cloneContent = getEffectiveContent(
-                              message.message
-                            );
-                            for (const channel of channels) {
-                              this.sendMessage(cloneContent, channel);
+                        async (channels: Channel[]) => {
+                          try {
+                            // 每条选中消息 × 每个目标，全部并发投递（详见
+                            // forwardToChannels / fowardMessageUI 处关于 send()
+                            // 乐观语义的说明）。getEffectiveContent 同步抛错会被
+                            // 最外层 try 兜住。
+                            const tasks: {
+                              content: MessageContent;
+                              channel: Channel;
+                            }[] = [];
+                            for (const message of messages) {
+                              const cloneContent = getEffectiveContent(
+                                message.message,
+                              );
+                              for (const channel of channels) {
+                                tasks.push({ content: cloneContent, channel });
+                              }
                             }
+                            type SendOutcome =
+                              | { ok: true }
+                              | { ok: false; channelID: string; reason: unknown };
+                            const outcomes = await Promise.all(
+                              tasks.map((task): Promise<SendOutcome> =>
+                                this.sendMessage(task.content, task.channel)
+                                  .then((): SendOutcome => ({ ok: true }))
+                                  .catch(
+                                    (reason: unknown): SendOutcome => ({
+                                      ok: false,
+                                      channelID: task.channel.channelID,
+                                      reason,
+                                    }),
+                                  ),
+                              ),
+                            );
+                            let failed = 0;
+                            for (const o of outcomes) {
+                              if (!o.ok) {
+                                failed++;
+                                console.error(
+                                  "[forward] send failed",
+                                  o.channelID,
+                                  o.reason,
+                                );
+                              }
+                            }
+                            this.showForwardResult(failed, tasks.length);
+                          } catch (e) {
+                            console.error("[forward] build content failed", e);
+                            Toast.error(
+                              t("base.conversation.forward.allFailed"),
+                            );
                           }
                           vm.editOn = false;
                           vm.unCheckAllMessages();
@@ -2468,8 +2575,26 @@ export class Conversation
                         return;
                       }
                       WKApp.shared.baseContext.showConversationSelect(
-                        (channels: Channel[]) => {
-                          vm.sendMergeforward(channels);
+                        async (channels: Channel[]) => {
+                          // 最外层 try：sendMergeforward 的同步前置段
+                          // （getCheckedMessages().map / getChannelInfo /
+                          // new MergeforwardContent）在 await 之前，若抛错会让此
+                          // async 回调 reject 成 unhandled rejection，且清理逻辑
+                          // 不执行、UI 卡在多选态。与 onForward / fowardMessageUI
+                          // 两处路径对称兜底（#273）。
+                          try {
+                            const { failed, total } =
+                              await vm.sendMergeforward(channels);
+                            this.showForwardResult(failed, total);
+                          } catch (e) {
+                            console.error(
+                              "[merge-forward] build content failed",
+                              e,
+                            );
+                            Toast.error(
+                              t("base.conversation.forward.allFailed"),
+                            );
+                          }
                           vm.editOn = false;
                           vm.unCheckAllMessages();
                         }

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -575,7 +575,11 @@ export default class ConversationVM extends ProviderListener {
         })
     }
 
-    sendMergeforward(toChannels: Channel[]) {
+    // 返回 { failed, total }：failed 为转发失败的目标数，total 为目标总数。
+    // 单个目标失败不中断其余目标（并发投递，互相隔离）。
+    // 注意：sendMessage→WKSDK.chatManager.send() 是本地乐观语义，入队即 resolve，
+    // 真正投递失败在 ack 阶段异步回调，不在此 catch 覆盖范围内（#273 已知边界）。
+    async sendMergeforward(toChannels: Channel[]): Promise<{ failed: number; total: number }> {
         let users = new Array<any>();
 
         let checkedMessages = this.getCheckedMessages().map((messageWrap: MessageWrap) => {
@@ -597,11 +601,29 @@ export default class ConversationVM extends ProviderListener {
                 users.push({ uid: message.fromUID, name: channelInfo?.title })
             }
         }
+        const total = toChannels?.length ?? 0
+        let failed = 0
         if (toChannels && toChannels.length > 0) {
-            for (const destChannel of toChannels) {
-                this.sendMessage(new MergeforwardContent(this.channel.channelType, users, checkedMessages), destChannel)
+            const content = new MergeforwardContent(this.channel.channelType, users, checkedMessages)
+            // 并发投递 + 每个任务 .catch 兜底（语义等价 Promise.allSettled，但本包
+            // tsconfig target=es2019 没有 allSettled 类型，手写更稳）。单目标失败
+            // 被隔离、计数，不影响其余。
+            type SendOutcome = { ok: true } | { ok: false; channelID: string; reason: unknown }
+            const outcomes = await Promise.all(
+                toChannels.map((destChannel): Promise<SendOutcome> =>
+                    this.sendMessage(content, destChannel)
+                        .then((): SendOutcome => ({ ok: true }))
+                        .catch((reason: unknown): SendOutcome => ({ ok: false, channelID: destChannel.channelID, reason }))
+                )
+            )
+            for (const o of outcomes) {
+                if (!o.ok) {
+                    failed++
+                    console.error("[merge-forward] send failed", o.channelID, o.reason)
+                }
             }
         }
+        return { failed, total }
     }
 
     // 删除消息

--- a/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
@@ -1,0 +1,53 @@
+import { WKSDK, Channel, ChannelInfo, ChannelTypeGroup } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../../Service/Const"
+import { parseThreadChannelId } from "../../Service/Thread"
+import { chatTypeToChannelType } from "./chatTypeToChannelType"
+import type { ForwardItem } from "./ForwardModal"
+
+/** searchChatCandidates 后端返回的单条候选（只取本模块用到的字段）。 */
+export interface SearchChatCandidate {
+  chat_id: string
+  chat_type?: string
+  name?: string
+  /** 子区父群号；可能是数字(含 0) 或字符串，缺失时为 null/undefined。 */
+  parent_group_no?: string | number | null
+}
+
+/**
+ * 把后端 searchChatCandidates 的单条候选映射成列表用的 ForwardItem。
+ *
+ * 抽成纯函数便于单测（见 forwardModalChatType.test.ts）：唯一的外部依赖
+ * （读本地缓存的 channelInfo 以继承外部群标记）通过 getCachedChannelInfo
+ * 注入，省略时不读缓存。
+ *
+ * parentChannelID 仅子区(thread)有意义：优先用后端 parent_group_no（注意
+ * 数字 0 也是合法父群号，必须 `!= null` 判断而非 falsy 判断），缺失时再从
+ * channelID(groupNo____shortId) 兜底解析；chat_id 不含分隔符时 parse 返回
+ * null → parentChannelID 为 undefined（不抛错）。
+ */
+export function candidateToForwardItem(
+  candidate: SearchChatCandidate,
+  getCachedChannelInfo: (channel: Channel) => ChannelInfo | undefined = (ch) =>
+    WKSDK.shared().channelManager.getChannelInfo(ch),
+): ForwardItem {
+  const chType = chatTypeToChannelType(candidate.chat_type)
+  const ch = new Channel(candidate.chat_id, chType)
+  const cachedInfo = getCachedChannelInfo(ch)
+  const isExternal =
+    chType === ChannelTypeGroup && cachedInfo?.orgData?.is_external_group === 1
+  const isThread = chType === ChannelTypeCommunityTopic
+  const parentChannelID = isThread
+    ? candidate.parent_group_no != null
+      ? String(candidate.parent_group_no)
+      : parseThreadChannelId(candidate.chat_id)?.groupNo
+    : undefined
+  return {
+    channelID: candidate.chat_id,
+    channelType: chType,
+    displayName: candidate.name || candidate.chat_id,
+    isAI: false,
+    isThread,
+    parentChannelID,
+    isExternal,
+  }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/chatTypeToChannelType.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/chatTypeToChannelType.ts
@@ -1,0 +1,24 @@
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../../Service/Const"
+
+/**
+ * 把后端 searchChatCandidates 返回的 chat_type 映射成 wukongimjssdk 的 channelType。
+ *
+ *   - "direct" → ChannelTypePerson (1)
+ *   - "thread" → ChannelTypeCommunityTopic (5)
+ *   - 其它(group/未知) → ChannelTypeGroup (2)
+ *
+ * 之前这里写成「非 direct 一律当群」，子区会被构造成 ChannelTypeGroup，channelID
+ * 带四下划线 (groupNo____shortId)、channelType 错成 2，后端按 (type=2, 四下划线 id)
+ * 找不到频道 → 消息被丢弃但前端本地回显成功，造成子区→子区转发静默失败 (#273)。
+ */
+export function chatTypeToChannelType(chatType: string | undefined): number {
+  switch (chatType) {
+    case "direct":
+      return ChannelTypePerson
+    case "thread":
+      return ChannelTypeCommunityTopic
+    default:
+      return ChannelTypeGroup
+  }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -7,6 +7,8 @@ import { filterArchivedThreads } from "../ConversationListGrouped/archivedThread
 import { debounce } from "../../Utils/rateLimit"
 import WKApp from "../../App"
 import { ForwardItem } from "./ForwardModal"
+import { candidateToForwardItem } from "./candidateToForwardItem"
+import { chatTypeToChannelType } from "./chatTypeToChannelType"
 
 function channelInfoToForwardItem(channelInfo: ChannelInfo): ForwardItem {
   return {
@@ -347,22 +349,10 @@ export function useForwardModal(
         if (reqId !== searchRequestRef.current) return
         const arr = Array.isArray(candidates) ? candidates : []
         const groups: ForwardItem[] = arr.map((c: any) => {
-          const chType = c.chat_type === "direct" ? 1 : ChannelTypeGroup
-          const ch = new Channel(c.chat_id, chType)
+          // 保留 channelMapRef 副作用：confirm 时按 channelID 取回 Channel 引用。
+          const ch = new Channel(c.chat_id, chatTypeToChannelType(c.chat_type))
           channelMapRef.current.set(c.chat_id, ch)
-          // 若本地已缓存 channelInfo，尝试继承外部群标记
-          const cachedInfo = WKSDK.shared().channelManager.getChannelInfo(ch)
-          const isExternal =
-            chType === ChannelTypeGroup &&
-            cachedInfo?.orgData?.is_external_group === 1
-          return {
-            channelID: c.chat_id,
-            channelType: chType,
-            displayName: c.name || c.chat_id,
-            isAI: false,
-            isThread: false,
-            isExternal,
-          } as ForwardItem
+          return candidateToForwardItem(c)
         })
         setSearchGroupItems(groups)
       })

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -166,6 +166,8 @@
   "conversation.foldSession.collapsedParticipants": "{{name}} and {{count}} others",
   "conversation.foldSession.collapseDiscussions": "Collapse {{count}} discussions",
   "conversation.foldSession.expandDiscussions": "Expand {{count}} discussions",
+  "conversation.forward.allFailed": "Failed to forward",
+  "conversation.forward.partialFailed": "{{failed}} of {{total}} failed to forward",
   "conversation.message.sendFailed": "Failed to send message",
   "conversation.multiplePanel.cancelSelection": "Cancel selection",
   "conversation.multiplePanel.createMatter": "Create task",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -166,6 +166,8 @@
   "conversation.foldSession.collapsedParticipants": "{{name}}等{{count}}人",
   "conversation.foldSession.collapseDiscussions": "收起{{count}}条讨论",
   "conversation.foldSession.expandDiscussions": "展开{{count}}条讨论",
+  "conversation.forward.allFailed": "转发失败",
+  "conversation.forward.partialFailed": "{{total}} 个会话中有 {{failed}} 个转发失败",
   "conversation.message.sendFailed": "消息发送失败",
   "conversation.multiplePanel.cancelSelection": "取消多选",
   "conversation.multiplePanel.createMatter": "创建新事项",


### PR DESCRIPTION
## Summary
Fixes silent failure when forwarding a message to a thread (sub-channel) selected from the forward dialog: the forward appeared to do nothing — no error, message never arrived in the target thread.

## Problem
When the forward target was a thread, the dialog built the target with the wrong channel type, so the server could not resolve it and silently dropped the forward. There was no error shown to the user.

## Fix
- Map each candidate's chat type to the correct channel type (direct / thread / group) instead of treating every non-direct target as a plain group.
- For thread targets, carry the parent group reference so the server can resolve the destination correctly.
- Make the forward send concurrent and isolate per-target failures, surfacing a toast on failure so a bad target no longer fails silently.

## Tests
- `forwardModalChatType.test.ts`: 18/18 passing (pure-function coverage for chat-type mapping and candidate construction).

## Related issues
Fixes #273
