### PR TITLE
feat(summary): scheduled summary deletion confirmation for one-to-many

### DIFF
--- a/packages/dmworksummary/src/components/SummaryCard.test.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SummaryCard from './SummaryCard';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../__mocks__/dmworkBase');
+    return { ...actual };
+});
+
+// Popconfirm 暴露 content，便于断言不同分支下的删除确认文案。
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: ({ icon, onClick }: any) => (
+        <button data-testid="delete-btn" onClick={onClick}>{icon}</button>
+    ),
+    Popconfirm: ({ children, content }: any) => (
+        <span data-testid="popconfirm">
+            <span data-testid="popconfirm-content">{content}</span>
+            {children}
+        </span>
+    ),
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconDelete: () => <svg data-testid="delete-icon" />,
+}));
+
+vi.mock('./TaskStatusBadge', () => ({
+    default: () => <span data-testid="status-badge" />,
+}));
+
+vi.mock('./OverflowTooltip', () => ({
+    default: ({ children }: any) => <span>{children}</span>,
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+    return {
+        task_id: 1,
+        task_no: 'T001',
+        title: '测试总结',
+        summary_mode: 1,
+        status: 3,
+        trigger_type: 1,
+        time_range_start: '2026-01-01T00:00:00Z',
+        time_range_end: '2026-01-02T00:00:00Z',
+        sources: [{ source_type: 1, source_id: 's1' }],
+        total_msg_count: 10,
+        creator_name: '张三',
+        origin_channel_id: 'ch1',
+        origin_channel_type: 2,
+        created_at: '2026-01-01T09:30:00Z',
+        completed_at: '2026-01-01T10:00:00Z',
+        ...overrides,
+    };
+}
+
+const noop = () => {};
+
+describe('SummaryCard isScheduledTask', () => {
+    it('schedule_id > 0 时使用定时删除确认文案', () => {
+        render(
+            <SummaryCard
+                task={makeItem({ title: '定时总结', schedule_id: 5, trigger_type: 1 }) as any}
+                onClick={noop}
+                onDelete={noop}
+            />,
+        );
+
+        const content = screen.getByTestId('popconfirm-content');
+        expect(content).toHaveTextContent('是定时更新的总结');
+        expect(content).not.toHaveTextContent('历史版本也将一并清除');
+    });
+
+    it('trigger_type === 2 且无 schedule_id 时走兜底定时分支', () => {
+        render(
+            <SummaryCard
+                task={makeItem({ title: '调度生成总结', schedule_id: undefined, trigger_type: 2 }) as any}
+                onClick={noop}
+                onDelete={noop}
+            />,
+        );
+
+        const content = screen.getByTestId('popconfirm-content');
+        expect(content).toHaveTextContent('是定时更新的总结');
+    });
+
+    it('普通手动任务使用普通删除确认文案', () => {
+        render(
+            <SummaryCard
+                task={makeItem({ title: '手动总结', schedule_id: undefined, trigger_type: 1 }) as any}
+                onClick={noop}
+                onDelete={noop}
+            />,
+        );
+
+        const content = screen.getByTestId('popconfirm-content');
+        expect(content).toHaveTextContent('历史版本也将一并清除');
+        expect(content).not.toHaveTextContent('是定时更新的总结');
+    });
+});

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -22,6 +22,12 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, onClick, onDelete, onRe
     const isMultiParticipant = (task.participants?.length ?? 0) > 1;
     const isPendingInvite = isMultiParticipant && myParticipant != null && myParticipant.status === ParticipantStatus.PENDING;
 
+    // 是否定时任务：以「是否绑定了定时配置(schedule_id)」为准，而非 trigger_type。
+    // 给一个手动任务加上定时更新后、在定时器首次执行前，原任务 trigger_type 仍为
+    // MANUAL(1)，只看 trigger_type 会漏掉「未执行过的定时任务」。trigger_type===2
+    // 作为兜底（来自调度器生成的任务）。
+    const isScheduledTask = (task.schedule_id != null && task.schedule_id > 0) || task.trigger_type === 2;
+
     return (
         <div className="summary-card" onClick={() => onClick(task.task_id)}>
             <div className="summary-card-header">
@@ -59,7 +65,11 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, onClick, onDelete, onRe
                 <span className="summary-card-date">{task.created_at?.substring(0, 10) || ''}</span>
                 <Popconfirm
                     title={t("summary.summaryCard.deleteTitle")}
-                    content={t("summary.summaryCard.deleteContent", { values: { title: task.title || task.task_no } })}
+                    content={
+                        isScheduledTask
+                            ? t("summary.summaryCard.deleteScheduledContent", { values: { title: task.title || task.task_no } })
+                            : t("summary.summaryCard.deleteContent", { values: { title: task.title || task.task_no } })
+                    }
                     onConfirm={(e) => {
                         e?.stopPropagation();
                         onDelete(task.task_id);

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -4,7 +4,7 @@ import { IconDelete } from "@douyinfe/semi-icons";
 import { useI18n } from "@octo/base";
 import WKApp from "@octo/base/src/App";
 import type { SummaryListItem } from "../types/summary";
-import { ParticipantStatus } from "../types/summary";
+import { ParticipantStatus, TriggerType } from "../types/summary";
 import TaskStatusBadge from "./TaskStatusBadge";
 import OverflowTooltip from "./OverflowTooltip";
 
@@ -22,11 +22,9 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, onClick, onDelete, onRe
     const isMultiParticipant = (task.participants?.length ?? 0) > 1;
     const isPendingInvite = isMultiParticipant && myParticipant != null && myParticipant.status === ParticipantStatus.PENDING;
 
-    // 是否定时任务：以「是否绑定了定时配置(schedule_id)」为准，而非 trigger_type。
-    // 给一个手动任务加上定时更新后、在定时器首次执行前，原任务 trigger_type 仍为
-    // MANUAL(1)，只看 trigger_type 会漏掉「未执行过的定时任务」。trigger_type===2
-    // 作为兜底（来自调度器生成的任务）。
-    const isScheduledTask = (task.schedule_id != null && task.schedule_id > 0) || task.trigger_type === 2;
+    // 是否定时任务：以 schedule_id 为准，trigger_type===SCHEDULED 作兜底，
+    // 以覆盖「绑定了定时但尚未执行过」的任务。
+    const isScheduledTask = (task.schedule_id != null && task.schedule_id > 0) || task.trigger_type === TriggerType.SCHEDULED;
 
     return (
         <div className="summary-card" onClick={() => onClick(task.task_id)}>

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -329,7 +329,8 @@
   "summaryCard": {
     "createdBy": "Created by {{name}}",
     "deleteTitle": "Confirm deletion",
-    "deleteContent": "Delete \"{{title}}\"? Historical versions will also be removed."
+    "deleteContent": "Delete \"{{title}}\"? Historical versions will also be removed.",
+    "deleteScheduledContent": "\"{{title}}\" is a scheduled summary. Deleting it will stop the scheduled updates and remove all of its history. Delete it?"
   },
   "editor": {
     "saveSuccess": "Saved",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -329,7 +329,8 @@
   "summaryCard": {
     "createdBy": "{{name}} 发起",
     "deleteTitle": "确认删除",
-    "deleteContent": "确定要删除「{{title}}」吗？删除后历史版本也将一并清除。"
+    "deleteContent": "确定要删除「{{title}}」吗？删除后历史版本也将一并清除。",
+    "deleteScheduledContent": "「{{title}}」是定时更新的总结。删除后将停止定时更新，并移除该总结的全部历史记录，确定删除吗？"
   },
   "editor": {
     "saveSuccess": "保存成功",

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -120,6 +120,8 @@ export interface SummaryListItem {
     summary_mode: SummaryModeType;
     status: TaskStatusType;
     trigger_type: number;
+    /** 绑定的定时配置 id。存在即表示该总结是定时任务（无论是否已执行过）。 */
+    schedule_id?: number | null;
     time_range_start: string;
     time_range_end: string;
     sources: SourceItem[];

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -148,7 +148,7 @@ export interface SummaryDetail {
     participants: Participant[];
     result: SummaryResult | null;
     error_message: string | null;
-    schedule_id?: number;
+    schedule_id?: number | null;
     origin_channel_id: string;
     origin_channel_type: number;
     created_at: string;


### PR DESCRIPTION
## 背景
配合后端 `schedule` 一对多改造（octo-smart-summary #86）：删除「定时类」总结时，弹窗需明确告知将停止定时更新并移除全部历史。

## 改动
- **SummaryCard**：以是否绑定 `schedule_id` 判定是否定时任务（`trigger_type === 2` 作兜底）。原因：手动任务加定时后、定时器首次执行前 `trigger_type` 仍为 MANUAL(1)，只看 `trigger_type` 会漏判未执行过的定时任务。定时类删除使用 `deleteScheduledContent` 文案，手动类沿用原 `deleteContent`。
- **i18n(zh/en)**：新增 `summaryCard.deleteScheduledContent`。
- **types**：`SummaryListItem` 补 `schedule_id?: number | null` 字段。

## 验证
- `turbo build --filter=@octo/web` 通过，vitest 全部用例通过。
- 本地重建 octo-web 镜像并重启容器，`localhost:3000` HTTP 200。