### PR TITLE
fix(chat-summary-history): join summary-batch-heartbeat protocol to dedupe polling (#334)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -53,6 +53,8 @@ export default class ChatSummaryHistory extends Component<
         window.addEventListener('chat-summary-created', this.handleChange as EventListener);
         window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
         window.addEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
+        window.addEventListener('summary-status-change', this.handleStatusChangeEvent as EventListener);
+        window.addEventListener('summary-list-unmount', this.handleListUnmount as EventListener);
     }
 
     componentWillUnmount() {
@@ -61,6 +63,8 @@ export default class ChatSummaryHistory extends Component<
         window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
         window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
         window.removeEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
+        window.removeEventListener('summary-status-change', this.handleStatusChangeEvent as EventListener);
+        window.removeEventListener('summary-list-unmount', this.handleListUnmount as EventListener);
     }
 
     componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
@@ -175,6 +179,31 @@ export default class ChatSummaryHistory extends Component<
         if (!containsAllTaskIds(taskIds, this.getActiveTaskIds())) return;
         this.peerActive = true;
         this.lastCoveringEventTime = Date.now();
+    };
+
+    // #334: a peer surfaced a status flip for at least one of our visible
+    // items — refresh from server so the UI shows the new status without
+    // waiting for our own 5s tick. Ignored when the flip is for unrelated
+    // tasks (different channel / different page in SummaryListPage).
+    //
+    // Name choice: `handleStatusChangeEvent` mirrors SummaryDetailPage's
+    // identically-named handler (DetailPage:303) and avoids confusion with
+    // SummaryListPage's `handleStatusChange` (a filter-dropdown callback on
+    // a different class — unrelated despite the bare name).
+    private handleStatusChangeEvent = (event: Event) => {
+        const taskIds: number[] | undefined = (event as CustomEvent).detail?.taskIds;
+        if (!taskIds || taskIds.length === 0) return;
+        const mine = new Set(this.state.items.map(item => item.task_id));
+        const intersects = taskIds.some(id => mine.has(id));
+        if (!intersects) return;
+        void this.loadHistory();
+    };
+
+    // #334: a peer left the heartbeat protocol (e.g. SummaryListPage
+    // unmounted). Clear suppression so the next 5s tick polls — we may
+    // now be the only poller covering our active-task set.
+    private handleListUnmount = () => {
+        this.peerActive = false;
     };
 
     private async loadHistory() {

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -117,10 +117,8 @@ export default class ChatSummaryHistory extends Component<
         this.isPolling = true;
         try {
             const updates = await summaryApi.batchStatus(taskIds);
-            // #334: let peers (SummaryListPage / SummaryDetailPage fallback /
-            // another ChatSummaryHistory instance) skip their next own tick.
-            // Self-echo guard: window.dispatchEvent is synchronous; the flag
-            // suppresses our own handleBatchHeartbeat on the re-entry stack.
+            // #334: let peers skip their next tick. Self-echo guard explained
+            // on handleBatchHeartbeat (sync dispatchEvent re-enters own listener).
             this.isDispatchingOwnHeartbeat = true;
             try {
                 window.dispatchEvent(

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -6,6 +6,7 @@ import * as summaryApi from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
 import { TaskStatus } from '../types/summary';
 import SummaryCard from './SummaryCard';
+import { containsAllTaskIds } from '../utils/heartbeatCoverage';
 
 interface ChatSummaryHistoryProps {
     channel: { channelID: string; channelType: number };
@@ -19,6 +20,12 @@ interface ChatSummaryHistoryState {
     loading: boolean;
 }
 
+// Mirrors SummaryDetailPage's 15s grace window so a heartbeat from any peer
+// (SummaryListPage or another ChatSummaryHistory instance) suppresses our
+// 5s tick for one window. After 15s of silence we treat the peer as gone
+// and resume self-polling on the next tick.
+const COVERING_HEARTBEAT_WINDOW_MS = 15_000;
+
 export default class ChatSummaryHistory extends Component<
     ChatSummaryHistoryProps,
     ChatSummaryHistoryState
@@ -29,6 +36,12 @@ export default class ChatSummaryHistory extends Component<
     private abortController: AbortController | null = null;
     private pollTimer: ReturnType<typeof setInterval> | null = null;
     private isPolling = false;
+    // #334: bring this component into the summary-batch-heartbeat protocol.
+    private peerActive = false;
+    private lastCoveringEventTime = 0;
+    // Set true for the duration of one synchronous window.dispatchEvent call
+    // when WE are the dispatcher, so our own listener can ignore the echo.
+    private isDispatchingOwnHeartbeat = false;
 
     constructor(props: ChatSummaryHistoryProps) {
         super(props);
@@ -39,6 +52,7 @@ export default class ChatSummaryHistory extends Component<
         void this.loadHistory();
         window.addEventListener('chat-summary-created', this.handleChange as EventListener);
         window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.addEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
     }
 
     componentWillUnmount() {
@@ -46,6 +60,7 @@ export default class ChatSummaryHistory extends Component<
         this.stopPoll();
         window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
         window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.removeEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
     }
 
     componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
@@ -78,6 +93,14 @@ export default class ChatSummaryHistory extends Component<
             const ids = this.getActiveTaskIds();
             if (ids.length === 0) {
                 this.stopPoll();
+                return;
+            }
+            // #334: a peer's heartbeat covered our active set within the
+            // freshness window — skip this tick, do NOT stop the timer.
+            if (
+                this.peerActive &&
+                Date.now() - this.lastCoveringEventTime <= COVERING_HEARTBEAT_WINDOW_MS
+            ) {
                 return;
             }
             void this.doPoll(ids);
@@ -120,6 +143,26 @@ export default class ChatSummaryHistory extends Component<
         if (e.detail?.channelId === this.props.channel.channelID) {
             void this.loadHistory();
         }
+    };
+
+    // #334: a covering heartbeat from a peer means we can skip our next own
+    // poll tick. We do NOT stop the timer — the tick callback consults the
+    // flag + freshness window and self-skips. See containsAllTaskIds for the
+    // exact subset semantics.
+    //
+    // Self-echo guard: window.dispatchEvent is synchronous, so our own
+    // dispatch in doPoll re-enters this listener on the same call stack.
+    // Without the guard we would set peerActive=true from our own heartbeat
+    // and starve our own next tick → 5s cadence would silently degrade to
+    // ~15s when we are the sole poller. The isDispatchingOwnHeartbeat flag
+    // is set true in doPoll right before dispatch and cleared immediately
+    // after; we ignore any event observed while it is true.
+    private handleBatchHeartbeat = (event: Event) => {
+        if (this.isDispatchingOwnHeartbeat) return;
+        const taskIds: number[] | undefined = (event as CustomEvent).detail?.taskIds;
+        if (!containsAllTaskIds(taskIds, this.getActiveTaskIds())) return;
+        this.peerActive = true;
+        this.lastCoveringEventTime = Date.now();
     };
 
     private async loadHistory() {

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -191,6 +191,11 @@ export default class ChatSummaryHistory extends Component<
     // SummaryListPage's `handleStatusChange` (a filter-dropdown callback on
     // a different class — unrelated despite the bare name).
     private handleStatusChangeEvent = (event: Event) => {
+        // #334: panel is hidden in detail view — even if a peer's status flip
+        // is for one of our items, the user can't see this list right now.
+        // maybeStartPoll already short-circuits on paused; mirror that here
+        // so we don't waste a network round-trip + setState while invisible.
+        if (this.props.paused) return;
         const taskIds: number[] | undefined = (event as CustomEvent).detail?.taskIds;
         if (!taskIds || taskIds.length === 0) return;
         const mine = new Set(this.state.items.map(item => item.task_id));

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -6,7 +6,7 @@ import * as summaryApi from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
 import { TaskStatus } from '../types/summary';
 import SummaryCard from './SummaryCard';
-import { containsAllTaskIds } from '../utils/heartbeatCoverage';
+import { containsAllTaskIds, COVERING_HEARTBEAT_WINDOW_MS } from '../utils/heartbeatCoverage';
 
 interface ChatSummaryHistoryProps {
     channel: { channelID: string; channelType: number };
@@ -19,12 +19,6 @@ interface ChatSummaryHistoryState {
     items: SummaryListItem[];
     loading: boolean;
 }
-
-// Mirrors SummaryDetailPage's 15s grace window so a heartbeat from any peer
-// (SummaryListPage or another ChatSummaryHistory instance) suppresses our
-// 5s tick for one window. After 15s of silence we treat the peer as gone
-// and resume self-polling on the next tick.
-const COVERING_HEARTBEAT_WINDOW_MS = 15_000;
 
 export default class ChatSummaryHistory extends Component<
     ChatSummaryHistoryProps,

--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -119,6 +119,18 @@ export default class ChatSummaryHistory extends Component<
         this.isPolling = true;
         try {
             const updates = await summaryApi.batchStatus(taskIds);
+            // #334: let peers (SummaryListPage / SummaryDetailPage fallback /
+            // another ChatSummaryHistory instance) skip their next own tick.
+            // Self-echo guard: window.dispatchEvent is synchronous; the flag
+            // suppresses our own handleBatchHeartbeat on the re-entry stack.
+            this.isDispatchingOwnHeartbeat = true;
+            try {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds } }),
+                );
+            } finally {
+                this.isDispatchingOwnHeartbeat = false;
+            }
             const updateMap = new Map(updates.map(u => [u.id, u]));
             let changed = false;
             const newItems = this.state.items.map(item => {

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -426,4 +426,149 @@ describe('ChatSummaryHistory', () => {
             expect(mockBatchStatus).not.toHaveBeenCalled();
         });
     });
+
+    describe('heartbeat coordination (#334)', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('skips the next 5s tick when a covering heartbeat arrives', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1, 2, 3] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('polls again after the 15s freshness window expires', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+
+            // Move past the 15s freshness window from the heartbeat moment.
+            // Heartbeat at T=0; ticks fire at T=5000,10000,15000,20000.
+            // T=15000 delta=15000 is still fresh (<=15000), so the next
+            // unsuppressed tick is at T=20000. Advance to T>=20000 total.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(15500);
+            });
+            expect(mockBatchStatus).toHaveBeenCalled();
+        });
+
+        it('does not skip when the heartbeat is non-covering (partial overlap)', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [
+                    makeItem({ task_id: 1, status: 2 }),
+                    makeItem({ task_id: 2, status: 2, title: 'Second' }),
+                ],
+            });
+            mockBatchStatus.mockResolvedValue([
+                { id: 1, status: 2, progress: 50, updated_at: '' },
+                { id: 2, status: 2, progress: 50, updated_at: '' },
+            ]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledWith([1, 2]);
+        });
+
+        it('does not skip when the heartbeat payload is empty and I have active ids', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledWith([1]);
+        });
+    });
 });

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -744,5 +744,34 @@ describe('ChatSummaryHistory', () => {
             });
             expect(mockBatchStatus).toHaveBeenCalledWith([1]);
         });
+
+        it('does not fetch on summary-status-change while paused', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                        paused
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            mockListSummaries.mockClear();
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-status-change', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            expect(mockListSummaries).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -570,5 +570,79 @@ describe('ChatSummaryHistory', () => {
             });
             expect(mockBatchStatus).toHaveBeenCalledWith([1]);
         });
+
+        it('dispatches a covering heartbeat with our own active ids after a successful poll', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [
+                    makeItem({ task_id: 7, status: 2 }),
+                    makeItem({ task_id: 9, status: 0, title: 'Pending' }),
+                ],
+            });
+            mockBatchStatus.mockResolvedValue([
+                { id: 7, status: 2, progress: 30, updated_at: '' },
+                { id: 9, status: 0, progress: 0, updated_at: '' },
+            ]);
+            const onHeartbeat = vi.fn();
+            window.addEventListener('summary-batch-heartbeat', onHeartbeat as EventListener);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            const calls = onHeartbeat.mock.calls.filter(([e]) => (e as CustomEvent).detail);
+            expect(calls.length).toBeGreaterThanOrEqual(1);
+            const lastDetail = (calls[calls.length - 1][0] as CustomEvent).detail as { taskIds: number[] };
+            expect(lastDetail.taskIds).toEqual(expect.arrayContaining([7, 9]));
+
+            window.removeEventListener('summary-batch-heartbeat', onHeartbeat as EventListener);
+        });
+
+        it('does not self-suppress: solo polling stays at 5s cadence (self-echo guard)', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // First tick: dispatches a heartbeat. Without the self-echo guard,
+            // peerActive would flip true here and starve the second tick.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledTimes(1);
+
+            // Second tick: must still fire (no peer was ever broadcasting).
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledTimes(2);
+
+            // Third tick for good measure — still steady 5s cadence.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledTimes(3);
+        });
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -85,6 +85,26 @@ function makeItem(overrides: Record<string, unknown> = {}) {
     };
 }
 
+// Reduce per-test boilerplate: most tests render with the same channel and
+// callbacks, then await one fake-timer tick for the initial loadHistory
+// effect. Tests that need custom mockListSummaries setup still call it before
+// invoking mountHistory.
+async function mountHistory(props: { paused?: boolean } = {}) {
+    let result: ReturnType<typeof render> | undefined;
+    await act(async () => {
+        result = render(
+            <ChatSummaryHistory
+                channel={{ channelID: 'ch1', channelType: 2 }}
+                onCreateNew={vi.fn()}
+                onViewDetail={vi.fn()}
+                paused={props.paused}
+            />,
+        );
+        await vi.advanceTimersByTimeAsync(0);
+    });
+    return result!;
+}
+
 describe('ChatSummaryHistory', () => {
     const channel = { channelID: 'ch1', channelType: 2 };
     const onCreateNew = vi.fn();
@@ -442,16 +462,7 @@ describe('ChatSummaryHistory', () => {
             });
             mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
 
-            await act(async () => {
-                render(
-                    <ChatSummaryHistory
-                        channel={channel}
-                        onCreateNew={onCreateNew}
-                        onViewDetail={onViewDetail}
-                    />,
-                );
-                await vi.advanceTimersByTimeAsync(0);
-            });
+            await mountHistory();
 
             await act(async () => {
                 window.dispatchEvent(
@@ -472,16 +483,7 @@ describe('ChatSummaryHistory', () => {
             });
             mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
 
-            await act(async () => {
-                render(
-                    <ChatSummaryHistory
-                        channel={channel}
-                        onCreateNew={onCreateNew}
-                        onViewDetail={onViewDetail}
-                    />,
-                );
-                await vi.advanceTimersByTimeAsync(0);
-            });
+            await mountHistory();
 
             await act(async () => {
                 window.dispatchEvent(
@@ -517,16 +519,7 @@ describe('ChatSummaryHistory', () => {
                 { id: 2, status: 2, progress: 50, updated_at: '' },
             ]);
 
-            await act(async () => {
-                render(
-                    <ChatSummaryHistory
-                        channel={channel}
-                        onCreateNew={onCreateNew}
-                        onViewDetail={onViewDetail}
-                    />,
-                );
-                await vi.advanceTimersByTimeAsync(0);
-            });
+            await mountHistory();
 
             await act(async () => {
                 window.dispatchEvent(
@@ -547,16 +540,7 @@ describe('ChatSummaryHistory', () => {
             });
             mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
 
-            await act(async () => {
-                render(
-                    <ChatSummaryHistory
-                        channel={channel}
-                        onCreateNew={onCreateNew}
-                        onViewDetail={onViewDetail}
-                    />,
-                );
-                await vi.advanceTimersByTimeAsync(0);
-            });
+            await mountHistory();
 
             await act(async () => {
                 window.dispatchEvent(
@@ -750,17 +734,7 @@ describe('ChatSummaryHistory', () => {
                 items: [makeItem({ task_id: 1, status: 2 })],
             });
 
-            await act(async () => {
-                render(
-                    <ChatSummaryHistory
-                        channel={channel}
-                        onCreateNew={onCreateNew}
-                        onViewDetail={onViewDetail}
-                        paused
-                    />,
-                );
-                await vi.advanceTimersByTimeAsync(0);
-            });
+            await mountHistory({ paused: true });
 
             mockListSummaries.mockClear();
 

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -644,5 +644,105 @@ describe('ChatSummaryHistory', () => {
             });
             expect(mockBatchStatus).toHaveBeenCalledTimes(3);
         });
+
+        it('refreshes history when summary-status-change intersects current items', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            mockListSummaries.mockClear();
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 3 })],
+            });
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-status-change', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            expect(mockListSummaries).toHaveBeenCalled();
+        });
+
+        it('ignores summary-status-change when taskIds do not intersect current items', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            mockListSummaries.mockClear();
+
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-status-change', { detail: { taskIds: [99] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            expect(mockListSummaries).not.toHaveBeenCalled();
+        });
+
+        it('clears suppression on summary-list-unmount so the next tick polls', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Establish suppression first.
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+
+            // Peer goes away.
+            await act(async () => {
+                window.dispatchEvent(new CustomEvent('summary-list-unmount'));
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledWith([1]);
+        });
     });
 });

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -16,6 +16,7 @@ import WKApp from "@octo/base/src/App";
 import { splitSummaryText } from "../utils/splitMessage";
 import SummaryConfirmPage from "./SummaryConfirmPage";
 import * as api from "../api/summaryApi";
+import { COVERING_HEARTBEAT_WINDOW_MS } from "../utils/heartbeatCoverage";
 import OverflowTooltip from "../components/OverflowTooltip";
 import type {
     SummaryDetail,
@@ -349,7 +350,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     private startFallbackPoll() {
         if (this.fallbackPollTimer || this.fallbackStartTimeout) return;
 
-        if (this.listPageActive && Date.now() - this.lastEventTime > 15000) {
+        if (this.listPageActive && Date.now() - this.lastEventTime > COVERING_HEARTBEAT_WINDOW_MS) {
             this.listPageActive = false;
         }
         if (this.listPageActive) return;

--- a/packages/dmworksummary/src/utils/__tests__/heartbeatCoverage.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/heartbeatCoverage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { containsAllTaskIds } from "../heartbeatCoverage"
+
+describe("containsAllTaskIds", () => {
+    it("returns true when payload is a strict superset of my active ids", () => {
+        expect(containsAllTaskIds([1, 2, 3, 4], [1, 2])).toBe(true)
+    })
+
+    it("returns true when payload equals my active ids", () => {
+        expect(containsAllTaskIds([1, 2], [1, 2])).toBe(true)
+    })
+
+    it("returns false when payload covers only some of my active ids", () => {
+        expect(containsAllTaskIds([1, 2], [1, 2, 3])).toBe(false)
+    })
+
+    it("returns false when payload is disjoint from my active ids", () => {
+        expect(containsAllTaskIds([99, 100], [1, 2])).toBe(false)
+    })
+
+    it("returns true when I have no active ids (nothing to cover)", () => {
+        expect(containsAllTaskIds([1, 2, 3], [])).toBe(true)
+        expect(containsAllTaskIds([], [])).toBe(true)
+        expect(containsAllTaskIds(undefined, [])).toBe(true)
+    })
+
+    it("returns false when I have active ids but payload is empty or undefined", () => {
+        expect(containsAllTaskIds([], [1])).toBe(false)
+        expect(containsAllTaskIds(undefined, [1])).toBe(false)
+    })
+
+    it("treats payload as a Set so lookup is O(1) even for large my-id arrays", () => {
+        const big = Array.from({ length: 5000 }, (_, i) => i)
+        const mine = Array.from({ length: 100 }, (_, i) => i * 47).filter(x => x < 5000)
+        expect(containsAllTaskIds(big, mine)).toBe(true)
+    })
+})

--- a/packages/dmworksummary/src/utils/heartbeatCoverage.ts
+++ b/packages/dmworksummary/src/utils/heartbeatCoverage.ts
@@ -19,3 +19,13 @@ export function containsAllTaskIds(
     }
     return true
 }
+
+// Freshness window for the summary-batch-heartbeat protocol. A peer
+// broadcast is treated as covering only while `Date.now() - lastEventTime
+// <= COVERING_HEARTBEAT_WINDOW_MS`. Beyond it, the broadcaster is treated
+// as gone and the listener resumes self-polling.
+//
+// Shared between SummaryDetailPage (the original 15s grace window) and
+// ChatSummaryHistory (#334), so all protocol participants tune the same
+// window in one place.
+export const COVERING_HEARTBEAT_WINDOW_MS = 15_000;

--- a/packages/dmworksummary/src/utils/heartbeatCoverage.ts
+++ b/packages/dmworksummary/src/utils/heartbeatCoverage.ts
@@ -1,0 +1,21 @@
+// Subset check used by every consumer of the `summary-batch-heartbeat` event:
+// a heartbeat from another poller is "covering" only when every task id we
+// currently care about is included in the broadcast's payload. Partial-overlap
+// payloads MUST NOT suppress our own polling, or the uncovered ids would
+// never get a status update.
+//
+// Empty `myActiveIds` is trivially covered (nothing to ask about), which
+// matches the behavior on the dispatcher side: we don't even start a poll
+// tick when our active set is empty.
+export function containsAllTaskIds(
+    payloadIds: number[] | undefined,
+    myActiveIds: number[],
+): boolean {
+    if (myActiveIds.length === 0) return true
+    if (!payloadIds || payloadIds.length === 0) return false
+    const payload = new Set(payloadIds)
+    for (const id of myActiveIds) {
+        if (!payload.has(id)) return false
+    }
+    return true
+}


### PR DESCRIPTION
# Summary

Fixes [#334](https://github.com/Mininglamp-OSS/octo-web/issues/334) — `POST /summary/api/v1/summaries/batch-status` is hit redundantly when the conversation sidebar's summary history is shown after the standalone Smart Summary tab has been visited. The reporter (jeff-wilson2010) traced the root cause to **three independent pollers running with no cross-coordination**; the maintainer triage (lml2468) confirmed the diagnosis and recommended #2 minimal patch — this PR — with #1 root-fix as a follow-up (now filed as [#370](https://github.com/Mininglamp-OSS/octo-web/issues/370)).

# Root Cause (verified)

The codebase already has a 3-event `window.dispatchEvent` heartbeat protocol coordinating `SummaryListPage` (dispatcher) and `SummaryDetailPage` (listener):

- `summary-batch-heartbeat` — `SummaryListPage:152` dispatches per poll; `SummaryDetailPage:120` listens → stops 15s fallback.
- `summary-status-change` — same, dispatched on status change → reload detail.
- `summary-list-unmount` — `SummaryListPage:84` on cleanup → restart fallback if needed.

`ChatSummaryHistory` (sidebar 5s poller) is **completely outside this protocol**:

```
$ grep -rn 'summary-batch-heartbeat' packages/ apps/
packages/dmworksummary/src/pages/SummaryDetailPage.tsx:120: addEventListener
packages/dmworksummary/src/pages/SummaryListPage.tsx:152:   dispatchEvent
```

When the user has visited the Smart Summary tab once, `Main` keeps `SummaryListPage` mounted under `display:none` and its 2 s timer continues polling. Opening the sidebar starts `ChatSummaryHistory`'s 5 s timer on the same `taskIds`. The two are mutually unaware — same task IDs hit at both 2 s and 5 s cadence.

# Approach (Minimal — Approach A per spec)

Bring `ChatSummaryHistory` into the existing 3-event protocol:

1. **Listener**: on `summary-batch-heartbeat`, if payload's `taskIds` ⊇ our active set (subset check), set `peerActive=true` with a 15 s freshness window. The 5 s tick consults this flag and skips a tick without stopping the timer.
2. **Dispatcher**: after a successful own poll, broadcast `summary-batch-heartbeat` with our `taskIds`, so peers can defer to us symmetrically.
3. **`summary-status-change`** listener refreshes `loadHistory()` when payload `taskIds` intersects current items; ignored otherwise.
4. **`summary-list-unmount`** listener clears `peerActive` so the next tick polls.
5. **Self-echo guard**: `window.dispatchEvent` is synchronous, so our own dispatch re-enters our own listener. A transient `isDispatchingOwnHeartbeat` flag in `doPoll` (set true before dispatch, cleared in `finally`) suppresses the re-entry — without it, solo polling silently degrades from 5 s → ~15 s (caught in Phase 3.5 adversarial verify before any code was written).

**Subset semantics** (in `containsAllTaskIds` helper): we skip ONLY when every one of our active IDs is in the heartbeat payload. Partial-overlap payloads must not suppress, or the uncovered IDs would never get a status update.

**Existing coordination preserved**: `ChatSummaryHistory.paused` prop (sibling coordination within the same `ChatSummaryPanel`), `chat-summary-created` / `chat-summary-deleted` handlers, all existing pre-existing tests — untouched.

# Files Changed

```
 docs/superpowers/specs/2026-06-10-issue-334-summary-batch-status-coordination-design.md | +264
 packages/dmworksummary/src/components/ChatSummaryHistory.tsx                            |  +89
 packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx             | +348
 packages/dmworksummary/src/pages/SummaryDetailPage.tsx                                  |   +1  -2
 packages/dmworksummary/src/utils/heartbeatCoverage.ts                                   |  +27
 packages/dmworksummary/src/utils/__tests__/heartbeatCoverage.test.ts                    |  +37
 6 files changed, 766 insertions(+), 2 deletions(-)
```

Commit history (9 commits, fix → refactor cleanup):

```
d83c617c test(chat-summary-history): extract mountHistory helper (#334)
9eb00b00 refactor(chat-summary-history): dedupe self-echo guard comment (#334)
bba604d2 refactor(summary): share COVERING_HEARTBEAT_WINDOW_MS across heartbeat consumers (#334)
aa8f12ad fix(chat-summary-history): skip status-change refresh while paused (#334)
fb5b0958 fix(chat-summary-history): listen for summary-status-change and summary-list-unmount (#334)
afda5a31 fix(chat-summary-history): dispatch summary-batch-heartbeat after own poll (#334)
b3053db3 fix(chat-summary-history): join summary-batch-heartbeat protocol as listener (#334)
658d6030 fix(summary): add containsAllTaskIds heartbeat-coverage helper (#334)
9ddebcd7 docs(superpowers): add #334 design spec + implementation plan
```

# Test Plan

## Unit tests

- [x] `containsAllTaskIds` helper — 7/7 pass (covers superset, equal, partial-overlap, disjoint, empty-active triplet, empty/undefined-payload-with-active, large-payload O(1) lookup).
- [x] `ChatSummaryHistory` heartbeat coordination — 9 new cases:
  - Listener: covering heartbeat suppresses next tick
  - Listener: polls again after 15 s freshness expires
  - Listener: non-covering (partial-overlap) heartbeat does not suppress
  - Listener: empty heartbeat with active items does not suppress
  - Dispatcher: own poll broadcasts heartbeat with our active IDs
  - **Self-echo guard regression**: solo polling stays at 5 s cadence across 3 consecutive ticks (would fail at "called 2 times" without guard)
  - `summary-status-change` refreshes when payload intersects
  - `summary-status-change` ignored when no intersection
  - `summary-list-unmount` clears suppression
  - (also `does not fetch on summary-status-change while paused` from quality-reviewer follow-up)
- [x] Full `dmworksummary` suite: **198 total / 194 pass / 4 pre-existing failures** (no delta from `main` baseline — failures live in an unrelated `Object.defineProperty(window, 'innerWidth', ...)` test file).

## Real-browser runtime verification

Local dev (`octo-dev` script), setup:

1. Registered `test_user_a` + `test_user_b`, made them mutual friends via DB, created Space `TestSpace334`, created Group `TestGroup334` (members: both users), and INSERT'd one summary task with `status=WAITING_CONFIRM` (long-lived active state — `worker` doesn't process it without user confirmation, so the polling window is bounded only by `confirm_deadline`).
2. Logged in as `test_user_a` → visited Smart Summary tab (mounts `SummaryListPage`, starts 2 s poll) → switched back to chat → opened `TestGroup334` → opened sidebar 智能总结 panel (mounts `ChatSummaryHistory`, would start 5 s poll).
3. Installed an `XMLHttpRequest.prototype.open/send` hook in the page console to count `/summaries/batch-status` requests over a 60 s window.

| Scenario | Requests / 60 s (extrapolated from sample) | Cadence distribution |
|---|---|---|
| **PRE-FIX** (`git checkout origin/main -- ChatSummaryHistory.tsx`) | **~42** | 51 requests in 73 s: 29 ~2s intervals + 14 <1s intervals (the 2s and 5s streams interleaving) + 7 other |
| **POST-FIX** (this PR) | **~30** | 38 requests in 75 s: all intervals 1924–2005 ms — pure 2 s stream, ChatSummaryHistory's 5 s tick **fully suppressed** by SummaryListPage's heartbeat |
| **Delta** | **−12 req / 60 s (~28% reduction)** | 0 requests at the 5 s cadence, confirming the listener's subset-and-freshness check works |

The 60s post-fix figure (~30) exactly matches the theoretical SummaryListPage-only cadence (60 / 2 = 30 ticks). The pre-fix figure (~42) matches the theoretical sum (30 + 12 = 42, where 12 = 60/5).

**No regression scenarios** (also verified in unit tests):

- History alone, no peer broadcasting → keeps its 5 s cadence (self-echo guard regression test).
- `paused === true` while a status-change event arrives → no fetch (covered by `does not fetch on summary-status-change while paused`).
- `summary-list-unmount` arrives → next 5s tick polls normally (covered).

## Code review

- [x] `superpowers:subagent-driven-development` per task: implementer → spec reviewer → code-quality reviewer (5 tasks total, all pass).
- [x] `/simplify` 4 reviewers (reuse / simplification / efficiency / altitude) in parallel; applied:
  - **F2/F6** — exported `COVERING_HEARTBEAT_WINDOW_MS` from `utils/heartbeatCoverage.ts` and replaced `SummaryDetailPage`'s inline `15000` literal so the protocol's freshness window lives in one place.
  - **F3** — extracted `mountHistory()` test helper to dedupe `render + advanceTimers` boilerplate across the new heartbeat tests.
  - **F5** — collapsed duplicate self-echo guard comment in `doPoll` to a one-line reference to the authoritative explanation on `handleBatchHeartbeat`.
  - **F1 / F7 / F8** deferred to follow-up issues (Approach C #370 absorbs F7/F8; `canCancel`/`isInFlight` consolidation belongs to its own cleanup).

# Adversarial Verification (Phase 3.5)

Before any subagent dispatch, ran a plan-stage adversarial check (Critical Rule 5 Layer 1) — caught one would-have-shipped regression:

> **V8 — self-echo loop**: dispatcher's own `window.dispatchEvent` re-enters its own listener on the same call stack; listener flips `peerActive=true` from our own broadcast; next 5 s tick gets suppressed; we never re-dispatch (no peer was ever broadcasting); freshness window expires at 15 s → solo polling cadence silently degrades from 5 s to ~15 s.

Fix patched into plan + added a dedicated regression test (`does not self-suppress: solo polling stays at 5s cadence`) **before** any implementation work — see commit `afda5a31`'s tests and the `isDispatchingOwnHeartbeat` field in `b3053db3`.

# Risks & Mitigations

| Risk | Mitigation |
|---|---|
| Subset check correctness on large payloads | `containsAllTaskIds` uses a `Set` for O(1) payload lookup; tested at scale (5000 elements). |
| `paused` + listener interaction (setState while invisible) | `paused` guard added at top of `handleStatusChangeEvent` (commit `aa8f12ad`); `handleBatchHeartbeat` only flips instance fields, never setState. |
| Stale heartbeat after channel switch | The freshness check is re-evaluated every tick with the current `getActiveTaskIds()`; a no-longer-covering peer stops being suppressive within at most 15 s. |
| `window.dispatchEvent` is synchronous (self-echo) | `isDispatchingOwnHeartbeat` flag in `doPoll` (try/finally) — listener returns early during own dispatch. Tested. |
| Tests miss something unit can't see (the #256 Task E lesson) | Real-browser pre/post-fix run completed; numbers above. |
| Approach C (singleton service) is the right altitude | Out of scope for this minimal patch; filed as **[#370](https://github.com/Mininglamp-OSS/octo-web/issues/370)**. The self-echo guard added here makes the case for Approach C concrete and citable. |

# Out-of-scope Follow-ups (each tracked separately)

- **[#370](https://github.com/Mininglamp-OSS/octo-web/issues/370)** — extract `summaryPollingService` singleton (Approach C / "proper root fix" per maintainer triage).
- **Cadence unification** (2 s / 5 s / 15 s). Folds naturally into #370.
- **`isInFlight(status)` predicate** — the `PENDING || WAITING_CONFIRM || PROCESSING` triple is inlined in 4 sites across this package (`SummaryListPage.tsx:117-123`, `:132-138`, `SummaryDetailPage.tsx:182-184`, and the new `ChatSummaryHistory.tsx:63-71`); consolidating via the existing `canCancel()` helper or a new alias is a separate clean-up. (Out of scope to avoid scope-creep beyond #334.)

# Rollback

```bash
git revert d83c617c 9eb00b00 bba604d2 aa8f12ad fb5b0958 afda5a31 b3053db3 658d6030
# Spec doc (9ddebcd7) is harmless prose; can be kept or reverted independently.
```

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
