### PR TITLE
fix(summary-list-page): silent-reload full list on terminal status transition (#290)

### DIFF
--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -89,8 +89,16 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
         window.removeEventListener("summary-task-regenerated", this.handleTaskRegenerated_);
     }
 
-    async loadData() {
-        this.setState({ loading: true, error: null });
+    async loadData(opts?: { silent?: boolean }) {
+        if (!opts?.silent) {
+            this.setState({ loading: true, error: null });
+        } else {
+            // #290: silent reload skips the loading=true flicker (render
+            // replaces the entire list with a Spin when loading is true).
+            // Still clear error so a stale banner does not persist past a
+            // successful background refresh.
+            this.setState({ error: null });
+        }
         try {
             const { page, pageSize, statusFilter, keyword } = this.state;
             const params: ListSummariesParams = {
@@ -163,10 +171,29 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
                 return item;
             });
             if (changed) {
-                this.setState({ items: newItems }, () => {
-                    this.maybeStartBatchPoll();
-                    this.emitBadgeUpdate();
+                // #290: terminal transitions expose fields batchStatus does not
+                // return (title, completed_at, result preview) and may surface
+                // tasks created after the original loadData snapshot. Silent
+                // reload avoids the Spin flicker that a plain loadData() would
+                // cause (render is replacement, not overlay). Intermediate
+                // transitions (e.g. PENDING -> PROCESSING) keep the existing
+                // in-place setState path — no new fields to fetch.
+                const hasTerminal = changedIds.some(taskId => {
+                    const update = updateMap.get(taskId);
+                    return update && (
+                        update.status === TaskStatus.COMPLETED ||
+                        update.status === TaskStatus.FAILED ||
+                        update.status === TaskStatus.CANCELLED
+                    );
                 });
+                if (hasTerminal) {
+                    void this.loadData({ silent: true });
+                } else {
+                    this.setState({ items: newItems }, () => {
+                        this.maybeStartBatchPoll();
+                        this.emitBadgeUpdate();
+                    });
+                }
                 window.dispatchEvent(new CustomEvent("summary-status-change", { detail: { taskIds: changedIds } }));
             }
         } catch {

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
@@ -60,7 +60,6 @@ vi.mock('@douyinfe/semi-ui', () => ({
     Tooltip: ({ children }: any) => <>{children}</>,
 }));
 
-(vi.mocked as any) ?? null;
 // Select.Option child stub
 import * as Semi from '@douyinfe/semi-ui';
 (Semi as any).Select.Option = ({ children, value }: any) => <option value={String(value)}>{children}</option>;

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
@@ -111,11 +111,18 @@ describe('SummaryListPage — terminal reload (#290)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
+        // Default for the badge endpoint (page_size=1) and any unqueued main-list call.
+        mockListSummaries.mockResolvedValue({ items: [], total: 0 });
     });
 
     afterEach(() => {
         vi.useRealTimers();
     });
+
+    // emitBadgeUpdate also calls listSummaries (with page_size=1) — filter those
+    // out when asserting how many times the main list endpoint was hit.
+    const mainListCalls = () =>
+        mockListSummaries.mock.calls.filter(c => c[0]?.page_size !== 1);
 
     it('[FIX] silent loadData call does NOT set loading=true', async () => {
         mockListSummaries.mockResolvedValue({ items: [], total: 0 });
@@ -182,7 +189,7 @@ describe('SummaryListPage — terminal reload (#290)', () => {
         });
 
         // First fetch already happened on mount. Reset for clear assertion.
-        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+        expect(mainListCalls()).toHaveLength(1);
 
         // Set up: batch returns task as COMPLETED. Next listSummaries returns updated title.
         mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: 3, progress: 100, updated_at: '' }]);
@@ -198,7 +205,7 @@ describe('SummaryListPage — terminal reload (#290)', () => {
 
         expect(mockBatchStatus).toHaveBeenCalledWith([1]);
         // listSummaries should be called a second time (the silent reload).
-        expect(mockListSummaries).toHaveBeenCalledTimes(2);
+        expect(mainListCalls()).toHaveLength(2);
     });
 
     it('[FIX] doBatchPoll does NOT silent reload on intermediate (PENDING -> PROCESSING)', async () => {
@@ -211,7 +218,7 @@ describe('SummaryListPage — terminal reload (#290)', () => {
             render(<SummaryListPage />);
             await vi.advanceTimersByTimeAsync(0);
         });
-        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+        expect(mainListCalls()).toHaveLength(1);
 
         mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: 2, progress: 30, updated_at: '' }]);
         await act(async () => {
@@ -220,7 +227,7 @@ describe('SummaryListPage — terminal reload (#290)', () => {
 
         expect(mockBatchStatus).toHaveBeenCalledWith([1]);
         // listSummaries should NOT be called again — in-place setState path only.
-        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+        expect(mainListCalls()).toHaveLength(1);
     });
 
     it('[FIX] doBatchPoll triggers silent reload on FAILED and CANCELLED too', async () => {
@@ -248,7 +255,7 @@ describe('SummaryListPage — terminal reload (#290)', () => {
                 await vi.advanceTimersByTimeAsync(2000);
             });
 
-            expect(mockListSummaries).toHaveBeenCalledTimes(2);
+            expect(mainListCalls()).toHaveLength(2);
 
             await act(async () => { unmountFn?.(); });
         }

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import { render as rtlRender, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import SummaryListPage from '../SummaryListPage';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        WKApp: {
+            mittBus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+            routeRight: { popToRoot: vi.fn(), push: vi.fn() },
+        },
+    };
+});
+
+const mockListSummaries = vi.fn();
+const mockBatchStatus = vi.fn();
+const mockDeleteSummary = vi.fn();
+
+vi.mock('../../api/summaryApi', () => ({
+    listSummaries: (...args: any[]) => mockListSummaries(...args),
+    batchStatus: (...args: any[]) => mockBatchStatus(...args),
+    deleteSummary: (...args: any[]) => mockDeleteSummary(...args),
+    respondToTask: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../components/SummaryCard', () => ({
+    default: ({ task }: any) => (
+        <div data-testid="summary-card" data-status={task.status} data-title={task.title}>
+            {task.title}
+        </div>
+    ),
+}));
+
+vi.mock('../SummaryDetailPage', () => ({ default: () => null }));
+vi.mock('../SummaryCreatePage', () => ({ default: () => null }));
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: ({ children, onClick, icon, ...rest }: any) => (
+        <button onClick={onClick} {...rest}>{icon}{children}</button>
+    ),
+    Input: ({ value, onChange, placeholder }: any) => (
+        <input
+            data-testid="search-input"
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+        />
+    ),
+    Select: ({ children, value, onChange }: any) => (
+        <select data-testid="status-filter" value={value} onChange={(e) => onChange(e.target.value)}>
+            {children}
+        </select>
+    ),
+    Spin: ({ size }: any) => <div data-testid="spin" data-size={size} />,
+    Pagination: () => <div data-testid="pagination" />,
+    Toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+    Banner: ({ description }: any) => <div data-testid="banner">{description}</div>,
+    Tooltip: ({ children }: any) => <>{children}</>,
+}));
+
+(vi.mocked as any) ?? null;
+// Select.Option child stub
+import * as Semi from '@douyinfe/semi-ui';
+(Semi as any).Select.Option = ({ children, value }: any) => <option value={String(value)}>{children}</option>;
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconSearch: () => <span data-testid="icon-search" />,
+    IconPlus: () => <span data-testid="icon-plus" />,
+    IconRefresh: () => <span data-testid="icon-refresh" />,
+}));
+
+vi.mock('../../utils/summaryHelpers', () => ({
+    getStatusLabel: (s: number) => {
+        const labels: Record<number, string> = { 0: '待处理', 1: '待确认', 2: '进行中', 3: '已完成', 4: '失败', 5: '已取消' };
+        return labels[s] ?? '未知';
+    },
+}));
+
+function render(ui: React.ReactElement, options?: any) {
+    return rtlRender(ui, { legacyRoot: true, ...options });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+    return {
+        task_id: 1,
+        task_no: 'T001',
+        title: '原始标题',
+        summary_mode: 1,
+        status: 2,
+        trigger_type: 1,
+        time_range_start: '2026-01-01T00:00:00Z',
+        time_range_end: '2026-01-02T00:00:00Z',
+        sources: [],
+        total_msg_count: 0,
+        creator_name: 'TestUser',
+        origin_channel_id: 'ch1',
+        origin_channel_type: 2,
+        created_at: '2026-01-01T09:30:00Z',
+        completed_at: null,
+        ...overrides,
+    };
+}
+
+describe('SummaryListPage — terminal reload (#290)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('[FIX] silent loadData call does NOT set loading=true', async () => {
+        mockListSummaries.mockResolvedValue({ items: [], total: 0 });
+
+        let instance: any;
+        await act(async () => {
+            const { container } = render(<SummaryListPage ref={(r: any) => { instance = r; }} />);
+            container; // silence linter
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        const states: boolean[] = [];
+        const origSetState = instance.setState.bind(instance);
+        instance.setState = (patch: any, cb?: any) => {
+            if (typeof patch === 'object' && patch && 'loading' in patch) {
+                states.push(patch.loading);
+            }
+            return origSetState(patch, cb);
+        };
+
+        mockListSummaries.mockResolvedValue({ items: [makeItem({ status: 3 })], total: 1 });
+        await act(async () => {
+            await instance.loadData({ silent: true });
+        });
+
+        expect(states).not.toContain(true);
+    });
+
+    it('[FIX] non-silent loadData (default) still sets loading=true', async () => {
+        mockListSummaries.mockResolvedValue({ items: [], total: 0 });
+
+        let instance: any;
+        await act(async () => {
+            render(<SummaryListPage ref={(r: any) => { instance = r; }} />);
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        const states: boolean[] = [];
+        const origSetState = instance.setState.bind(instance);
+        instance.setState = (patch: any, cb?: any) => {
+            if (typeof patch === 'object' && patch && 'loading' in patch) {
+                states.push(patch.loading);
+            }
+            return origSetState(patch, cb);
+        };
+
+        mockListSummaries.mockResolvedValue({ items: [makeItem({ status: 3 })], total: 1 });
+        await act(async () => {
+            await instance.loadData();
+        });
+
+        expect(states).toContain(true);
+    });
+
+    it('[FIX] doBatchPoll triggers silent reload when a task transitions to COMPLETED', async () => {
+        mockListSummaries.mockResolvedValueOnce({
+            items: [makeItem({ task_id: 1, status: 2, title: 'original title' })],
+            total: 1,
+        });
+
+        await act(async () => {
+            render(<SummaryListPage />);
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        // First fetch already happened on mount. Reset for clear assertion.
+        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+
+        // Set up: batch returns task as COMPLETED. Next listSummaries returns updated title.
+        mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: 3, progress: 100, updated_at: '' }]);
+        mockListSummaries.mockResolvedValueOnce({
+            items: [makeItem({ task_id: 1, status: 3, title: 'POST-completion title' })],
+            total: 1,
+        });
+
+        // Advance 2s → batch poll fires → detects terminal → triggers silent reload.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+
+        expect(mockBatchStatus).toHaveBeenCalledWith([1]);
+        // listSummaries should be called a second time (the silent reload).
+        expect(mockListSummaries).toHaveBeenCalledTimes(2);
+    });
+
+    it('[FIX] doBatchPoll does NOT silent reload on intermediate (PENDING -> PROCESSING)', async () => {
+        mockListSummaries.mockResolvedValueOnce({
+            items: [makeItem({ task_id: 1, status: 0 })],
+            total: 1,
+        });
+
+        await act(async () => {
+            render(<SummaryListPage />);
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+
+        mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: 2, progress: 30, updated_at: '' }]);
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+
+        expect(mockBatchStatus).toHaveBeenCalledWith([1]);
+        // listSummaries should NOT be called again — in-place setState path only.
+        expect(mockListSummaries).toHaveBeenCalledTimes(1);
+    });
+
+    it('[FIX] doBatchPoll triggers silent reload on FAILED and CANCELLED too', async () => {
+        for (const terminalStatus of [4, 5]) {
+            vi.clearAllMocks();
+            mockListSummaries.mockResolvedValueOnce({
+                items: [makeItem({ task_id: 1, status: 2 })],
+                total: 1,
+            });
+
+            let unmountFn: (() => void) | undefined;
+            await act(async () => {
+                const { unmount } = render(<SummaryListPage />);
+                unmountFn = unmount;
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: terminalStatus, progress: 100, updated_at: '' }]);
+            mockListSummaries.mockResolvedValueOnce({
+                items: [makeItem({ task_id: 1, status: terminalStatus })],
+                total: 1,
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(2000);
+            });
+
+            expect(mockListSummaries).toHaveBeenCalledTimes(2);
+
+            await act(async () => { unmountFn?.(); });
+        }
+    });
+
+    it('[FIX] summary-status-change event is dispatched on both terminal and intermediate transitions', async () => {
+        const onStatusChange = vi.fn();
+        window.addEventListener('summary-status-change', onStatusChange as EventListener);
+
+        // intermediate
+        mockListSummaries.mockResolvedValueOnce({
+            items: [makeItem({ task_id: 1, status: 0 })],
+            total: 1,
+        });
+        let unmount1: (() => void) | undefined;
+        await act(async () => {
+            const r = render(<SummaryListPage />);
+            unmount1 = r.unmount;
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        mockBatchStatus.mockResolvedValueOnce([{ id: 1, status: 2, progress: 30, updated_at: '' }]);
+        await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+        expect(onStatusChange).toHaveBeenCalledTimes(1);
+        await act(async () => { unmount1?.(); });
+
+        // terminal
+        vi.clearAllMocks();
+        onStatusChange.mockClear();
+        mockListSummaries.mockResolvedValueOnce({
+            items: [makeItem({ task_id: 2, status: 2 })],
+            total: 1,
+        });
+        let unmount2: (() => void) | undefined;
+        await act(async () => {
+            const r = render(<SummaryListPage />);
+            unmount2 = r.unmount;
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        mockBatchStatus.mockResolvedValueOnce([{ id: 2, status: 3, progress: 100, updated_at: '' }]);
+        mockListSummaries.mockResolvedValueOnce({ items: [], total: 0 });
+        await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+        expect(onStatusChange).toHaveBeenCalledTimes(1);
+        await act(async () => { unmount2?.(); });
+
+        window.removeEventListener('summary-status-change', onStatusChange as EventListener);
+    });
+});


### PR DESCRIPTION
# Summary

Fixes [#290](https://github.com/Mininglamp-OSS/octo-web/issues/290) — Smart Summary tab's left list does not auto-refresh when a task completes; the user has to click the refresh button or switch tabs to see the post-completion title, completed_at, result preview, or any tasks created since the last load.

Reporter `pkuWMH` gave a complete root-cause analysis + suggested fix; reproduced independently by `zqxxxxx` ("已复现"). This PR implements `pkuWMH`'s direction with one refinement (`silent` option) added during design to avoid a render-flicker regression that the naive fix would have introduced.

# Root Cause

`SummaryListPage.doBatchPoll` (`packages/dmworksummary/src/pages/SummaryListPage.tsx:147-177`) polls `batchStatus(taskIds)` every 2 s. The endpoint returns only `{ id, status, progress, updated_at }` — NOT title, NOT completed_at, NOT result preview.

When a task transitions to a terminal state (COMPLETED / FAILED / CANCELLED), `doBatchPoll` only updates the `status` field in-place via `state.items.map(item => ({ ...item, status: update.status }))`. The other fields stay at the snapshot the original `loadData()` captured. Two user-visible consequences:

1. The task card title remains the auto-generated topic placeholder — never replaced by the final summary title.
2. Tasks created elsewhere (e.g. via the chat sidebar's "+" entry, or by another user in the same Space) AFTER the initial `loadData` snapshot never appear in the list — `doBatchPoll` only polls the IDs `loadData` already enumerated.

# Approach

Branch `doBatchPoll` on terminal-vs-intermediate transitions:

- **Terminal** (`COMPLETED` / `FAILED` / `CANCELLED`): `void this.loadData({ silent: true })` — refresh the full list from server, picking up the new title, completed_at, result preview, and any new tasks.
- **Intermediate** (e.g. `PENDING` → `PROCESSING`): keep the existing in-place setState path — no new fields to fetch, no round-trip needed.

The `summary-status-change` event still fires on both branches, so the listeners added in [PR #371](https://github.com/Mininglamp-OSS/octo-web/pull/371) (`ChatSummaryHistory` + `SummaryDetailPage`) react identically.

## Why a `silent` option (NOT in the reporter's analysis — caught during design)

`loadData()` currently starts with `this.setState({ loading: true, error: null })`. The render path is **replacement, not overlay**:

```tsx
{loading && (
    <div className="summary-list-loading">
        <Spin size="large" />
    </div>
)}
{!loading && items.length > 0 && (... actual list ...)}
```

A naive terminal-triggered `this.loadData()` would flash the **entire list to a centered Spin spinner** for the duration of the round-trip, then bring it back — arguably worse UX than the stale-data bug we're fixing.

Fix: add an opt-in `{ silent: true }` option that skips the `loading: true` setState while still clearing `error: null`. The 7 existing callsites (componentDidMount, handlePageChange, handleStatusChange, handleKeywordChange's debounce, handleDelete, handleCreate, handleNavMenuActivated_, handleSpaceChanged_, handleTaskRegenerated_, refresh button, retry banner) call `loadData()` with no argument and keep their spin (user-initiated actions; spin is correct feedback).

# Files Changed

```
packages/dmworksummary/src/pages/SummaryListPage.tsx                    | +32 -5
packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx    | +304
2 files changed, 336 insertions(+), 5 deletions(-)
```

Commits:

```
85b9b966 test(summary-list-page): remove dead vi.mocked expression (#290 /simplify cleanup)
85288577 fix(summary-list-page): silent-reload full list on terminal status transition (#290)
0fae835f test(summary-list-page): add #290 terminal reload tests (failing baseline)
```

# Test Plan

## Unit tests (6/6 pass)

New `packages/dmworksummary/src/pages/__tests__/SummaryListPage.test.tsx`:

- `silent loadData call does NOT set loading=true` — direct unit test on the option.
- `non-silent loadData (default) still sets loading=true` — regression guard for 7 existing callsites.
- `doBatchPoll triggers silent reload when a task transitions to COMPLETED` — fake-time 2 s advance, assert `mainListCalls()` counts increase (helper filters out the badge-endpoint call which `emitBadgeUpdate` triggers as a side effect).
- `doBatchPoll does NOT silent reload on intermediate (PENDING → PROCESSING)` — assert `mainListCalls()` stays at 1.
- `doBatchPoll triggers silent reload on FAILED and CANCELLED too` — parameterized over both terminal codes.
- `summary-status-change event is dispatched on both terminal and intermediate transitions` — protocol invariant preserved.

Full `dmworksummary` suite: **187 total / 183 pass / 4 pre-existing fail** (no delta from `main` baseline; the 4 failures live in an unrelated `Object.defineProperty(window, 'innerWidth', ...)` test file).

## Real-browser runtime verification (per `[[reference_octo_runtime_test_fixtures]]`)

Setup: `source ~/.config/octo-dev/test-users.env` + INSERT a `PROCESSING` task with a distinguishable initial title.

### PRE-FIX (file reverted to `origin/main`)

| Step | Action | DB | Web list |
|---|---|---|---|
| 1 | INSERT task as PROCESSING | `status=2`, title=`[REPRO] #290 INITIAL title - before terminal` | `生成中` + initial title |
| 2 | `UPDATE status=3, title='POST-COMPLETION title'` | `status=3`, new title | `已完成` ✓ (status flipped via in-place setState) BUT title **stays `[REPRO] #290 INITIAL title - before terminal`** ❌ |

Reproduces the bug pkuWMH and zqxxxxx reported, 1:1.

### POST-FIX (this PR's code applied)

| Step | Action | DB | Web list |
|---|---|---|---|
| 1 | INSERT task as PROCESSING | `status=2`, title=`[POST-FIX] #290 RESET initial title - before terminal` | `生成中` + initial title |
| 2 | `UPDATE status=3, title='POST-COMPLETION title - MUST APPEAR after silent reload'` | `status=3`, new title | `已完成` ✓ AND title **updates to `POST-COMPLETION title - MUST APPEAR after silent reload`** ✅ |

### XHR-timeline evidence(`XMLHttpRequest.prototype` hook over the transition window)

```
T=0.0s   batch-status   (PROCESSING → 2)
T=2.0s   batch-status
T=4.0s   batch-status
T=6.0s   batch-status
T=8.0s   batch-status
T=10.020s batch-status   ← returns COMPLETED (terminal detected)
T=10.030s main-list      ← void this.loadData({silent:true}) fires within 10 ms
T=10.047s badge-list     ← silent reload's success callback → emitBadgeUpdate
```

The 10 ms gap between batch-status (terminal) and main-list (silent reload) confirms the new branch fires synchronously off the polling tick. No `loading: true` flicker observed in the DOM during the transition.

# Risks & Mitigations

| Risk | Mitigation |
|---|---|
| Race: silent reload arrives during in-flight prior silent reload | React batches the resulting setStates; one extra network call is acceptable (terminal events are rare). No state corruption. |
| `error: null` cleared even on silent path | Intentional — a fresh successful refresh should not leave a stale error banner. Mirrors non-silent behavior. |
| Silent reload's success callback re-runs `maybeStartBatchPoll` + `emitBadgeUpdate` | This is the existing `loadData` callback contract; no change. The doBatchPoll terminal branch deliberately does NOT re-invoke them. |
| `emitBadgeUpdate` issues a second `listSummaries` call (page_size=1) | Pre-existing behavior; tests use a `mainListCalls()` helper that filters by params shape. Not introduced by this PR. |
| Static analysis missed a callsite of `loadData` that breaks under the new signature | Optional param is fully backward-compatible (`opts?: { silent?: boolean }` → `loadData()` works as before). Verified by grep + test passes. |
| Approach C (`#370` singleton service) would absorb this cleanly | Out of scope — `#370` is tracked separately. This PR keeps the existing per-component-poller architecture untouched and only refines `loadData`. |

# Out-of-scope Follow-ups (each tracked separately)

- `handleNavMenuActivated_` (and other tab-activation reloads) should also use the silent path for consistent UX — separate cleanup.
- Render redesign to overlay-style spin (`{loading && <Spin overlay />}`) — bigger UX proposal.
- Extract `isTerminalStatus(status)` helper to `summaryHelpers.ts` (the 3-OR triple now appears at 3 sites: this PR's `hasTerminal` + `SummaryDetailPage.tsx:322,384`) — defer to the broader status-predicate consolidation already mentioned in `#370`'s notes.
- Singleton `summaryPollingService` — tracked as **#370**.

# Rollback

```bash
git revert 85b9b966 85288577 0fae835f
```

(All 3 commits are independent of other branches.)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
