### PR TITLE
feat(runtime-ui): UI/UX polish — 术语统一 + 详情页信息密度 + 空态 CTA

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -25,14 +25,29 @@ interface RuntimeListEntry {
 // invoked when the user clicks a bot row inside a Runtime's detail page —
 // the parent switches the active tab to "bots" and then asks us to
 // surface that bot's detail panel.
+//
+// UI/UX review #375 follow-up (P1-4 空态 CTA): openCreate 加可选
+// preselectRuntimeId — 用户在左树 Level-3 看到"暂无 Bot"按钮直接打开
+// modal 时, modal 跳过 firstReady 自动选, 直接定位到目标 runtime + 它
+// 的 device, 用户只填名字按确认.
 export interface BotsTabHandle {
-  openCreate: () => void;
+  openCreate: (opts?: { preselectRuntimeId?: number }) => void;
   openBot: (id: number) => void;
 }
 
 // PR-2: cc-channel-octo (claude) adapter 已落地 (吕思佳 daemon-cli #34) +
 // 本机 ~/.cc-channel-octo 已切本地 server, 开放 claude 创建. codex/hermes
 // adapter 仍在收尾 (codex skeleton, hermes 未跑通), 暂不开放.
+//
+// UI/UX review #375 follow-up: claude 跟 openclaw 走两条不同的执行路径:
+//   - openclaw → 经 daemon adapter Provision (internal/adapter/openclaw.go)
+//   - claude   → 不经 daemon adapter Provision. cc-channel-octo 是用户自
+//                己起的独立 gateway 进程 (从 /v1/runtime-onboarding 拿命令
+//                启动), 它注册自己的 IM bot_uid 接 WS 收消息, 直接调
+//                Claude SDK. daemon-cli internal/adapter/claude.go 的
+//                ErrUnsupported skeleton 在这条路径上不会被踩到 — 创建
+//                claude bot 时 fleet 不派 provision 给 daemon, 派给
+//                cc-channel-octo gateway. 已 e2e 验过.
 const SUPPORTED_KINDS: RuntimeKind[] = ['openclaw', 'claude'];
 
 export interface BotsTabProps {
@@ -54,6 +69,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [runtimes, setRuntimes] = useState<RuntimeListEntry[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
+  const [preselectRuntimeId, setPreselectRuntimeId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
 
   // C10 in-flight guard: spaceEpoch 每次 space-changed 自增, refresh /
@@ -156,7 +172,10 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   }, []);
 
   useImperativeHandle(ref, () => ({
-    openCreate: () => setModalOpen(true),
+    openCreate: (opts) => {
+      setPreselectRuntimeId(opts?.preselectRuntimeId ?? null);
+      setModalOpen(true);
+    },
     openBot: (id: number) => {
       const found = bots.find(b => b.id === id);
       if (found) {
@@ -245,7 +264,12 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
       <CreateBotModal
         visible={modalOpen}
         runtimes={modalRuntimes}
-        onClose={() => setModalOpen(false)}
+        preselectRuntimeId={preselectRuntimeId}
+        onClose={() => {
+          setModalOpen(false);
+          // 关闭时清掉 preselect, 下次没传时不残留
+          setPreselectRuntimeId(null);
+        }}
         onCreated={handleCreated}
       />
     </div>

--- a/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Modal, Toast } from '@douyinfe/semi-ui';
-import { createBot, RuntimeKind } from './botsApi';
+import { createBot, providerLabels, RuntimeKind } from './botsApi';
 
 // CreateBotModal — 2-step device-first selector.
 //
@@ -25,6 +25,11 @@ interface RuntimeOption {
 interface Props {
   visible: boolean;
   runtimes: RuntimeOption[];
+  // UI/UX review #375 follow-up (P1-4 空态 CTA): 父侧 (RuntimesPage 通过
+  // BotsTab.openCreate({preselectRuntimeId})) 指定一个 runtime, modal 打开
+  // 时跳过 firstReady 自动选, 直接定位到目标 runtime + 它的 device. 用户
+  // 在左树某个空 runtime 下点"在此创建"时省去重选 device + runtime 两步.
+  preselectRuntimeId?: number | null;
   onClose: () => void;
   onCreated: (botId: number) => void;
 }
@@ -76,7 +81,7 @@ function groupByDevice(runtimes: RuntimeOption[]): DeviceGroup[] {
   });
 }
 
-export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props) {
+export function CreateBotModal({ visible, runtimes, preselectRuntimeId, onClose, onCreated }: Props) {
   const [name, setName] = useState('');
   const [deviceKey, setDeviceKey] = useState<string | null>(null);
   const [runtimeId, setRuntimeId] = useState<number | null>(null);
@@ -84,12 +89,37 @@ export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props)
 
   const groups = useMemo(() => groupByDevice(runtimes), [runtimes]);
 
-  // Reset state on open. Auto-select the first device that has a
-  // supported online runtime, and that runtime as the default.
+  // Reset state on open.
+  // 优先级:
+  //   (1) 父侧传 preselectRuntimeId → 定位到该 runtime + 它的 device
+  //       (空态 CTA 入口: 用户在左树 Level-3 某个空 runtime 下点"在此创建")
+  //   (2) 否则走 firstReady (有 supported+online runtime 的第一个 device)
+  //   (3) 否则随便选第一个 device, runtime 留空
   useEffect(() => {
     if (!visible) return;
     setName('');
     setBusy(false);
+    if (preselectRuntimeId != null) {
+      const targetGroup = groups.find(g => g.runtimes.some(r => r.id === preselectRuntimeId));
+      if (targetGroup) {
+        setDeviceKey(targetGroup.key);
+        // R1-2 (cc+codex review #PR-3): 校验 target runtime 是否
+        // supported+online. 是 → 预选; 否 → 走 firstReady 同款逻辑选该
+        // device 第一个可用 runtime, 避免出现 "选中态 + radio disabled +
+        // 创建按钮灰" 的矛盾死胡同 (空态 CTA 在 offline / unsupported
+        // runtime 下也会出现, 不能信任 preselect 一定可用).
+        const target = targetGroup.runtimes.find(r => r.id === preselectRuntimeId);
+        if (target && target.supported && target.status === 'online') {
+          setRuntimeId(preselectRuntimeId);
+        } else {
+          const fallback = targetGroup.runtimes.find(r => r.supported && r.status === 'online');
+          setRuntimeId(fallback?.id ?? null);
+        }
+        return;
+      }
+      // preselect runtime 不在 groups 里 (e.g. 数据未同步) — 静默 fallback
+      // 到 firstReady, 不让用户卡在错误的 modal 状态.
+    }
     const firstReady = groups.find(g => g.hasSupportedOnline);
     if (firstReady) {
       setDeviceKey(firstReady.key);
@@ -103,7 +133,7 @@ export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props)
       setDeviceKey(null);
       setRuntimeId(null);
     }
-  }, [visible, groups]);
+  }, [visible, groups, preselectRuntimeId]);
 
   const activeGroup = useMemo(
     () => groups.find(g => g.key === deviceKey) ?? null,
@@ -229,7 +259,7 @@ export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props)
                       onChange={() => enabled && setRuntimeId(r.id)}
                       disabled={!enabled}
                     />
-                    <span className="wk-rt-cb__rt-kind">{r.kind}</span>
+                    <span className="wk-rt-cb__rt-kind">{providerLabels[r.kind] ?? r.kind}</span>
                     <span className="wk-rt-cb__rt-status" data-status={isOnline ? 'online' : 'offline'}>
                       {isOnline ? '在线' : '离线'}
                     </span>

--- a/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botsApi.ts
@@ -5,6 +5,19 @@ import WKApp from '../../App';
 
 export type RuntimeKind = 'openclaw' | 'claude' | 'codex' | 'hermes';
 
+// providerLabels: runtime kind 的用户可读名. 单源 export 让所有渲染入口
+// (左树 device 行 / RuntimeDetail / CreateBotModal kind 列表) 显示
+// 完全一致, 不再 "kind 列表用裸 'claude' / detail 显示 'Claude Code'" 漂移.
+//
+// 'Claude' 不加 'Code' 后缀 — caster review 决策, 跟其他 kind (Codex /
+// OpenClaw / Hermes) 简洁度对齐.
+export const providerLabels: Record<string, string> = {
+  claude:   'Claude',
+  codex:    'Codex',
+  openclaw: 'OpenClaw',
+  hermes:   'Hermes',
+};
+
 export interface Bot {
   id: number;
   space_id: string;

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -2024,6 +2024,28 @@
   padding: 6px 12px;
   font-size: 11px;
   color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.wk-rt-bot-empty__cta {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.wk-rt-bot-empty__cta:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.wk-rt-bot-empty__cta:focus-visible {
+  outline: none;
+  border-color: var(--accent);
 }
 
 /* runtime arrow inherits the existing wk-rt-expand-arrow style; no new

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -5,7 +5,7 @@ import WKApp from "../../App"
 import WKAvatar from "../../Components/WKAvatar"
 import { BotsTab, type BotsTabHandle } from "./BotsTab"
 import { CreateRuntimeModal } from "./CreateRuntimeModal"
-import { Bot, botStatusLabel, listBots } from "./botsApi"
+import { Bot, botStatusLabel, listBots, providerLabels } from "./botsApi"
 import "./index.css"
 
 interface AgentRuntime {
@@ -71,16 +71,49 @@ const providerColors: Record<string, string> = {
     hermes: "#4B5563",
 }
 
-const providerLabels: Record<string, string> = {
-    claude: "Claude Code",
-    codex: "Codex",
-    openclaw: "OpenClaw",
-    hermes: "Hermes",
-}
+// providerLabels 已抽到 botsApi.ts (单源 export), CreateBotModal 也共用同
+// 一份, 避免 "kind 列表用裸 'claude' / detail 显示 'Claude Code'" 三层
+// 概念名漂移. (UI/UX review #375 follow-up: P0-1 术语统一)
 
 function parseMetadata(raw: string): Record<string, unknown> | null {
     if (!raw) return null
     try { return JSON.parse(raw) } catch { return null }
+}
+
+// humanizeLastSeen: ISO 时间戳 -> "刚刚" / "X 分钟前" / "X 小时前" / "X 天前".
+// 用于 DeviceDetail "最近活跃" 字段.
+//
+// ⚠️ 时区前提: fleet 写 last_seen_at 用 MySQL NOW(), 字符串 'YYYY-MM-DD HH:MM:SS'
+// 不带 timezone marker. 前端 + 'Z' 按 UTC 解析 — 这要求 **server tz = UTC**
+// (testenv-mysql container 默认 UTC, 已 verify NOW()===UTC_TIMESTAMP()).
+// 若 prod mysql 配本地时区, last_seen_at 写的是本地时间, 前端按 UTC 解析
+// 会偏 (e.g. UTC+8 sever 写 20:00, 前端按 20:00Z 解析 → 算成本地 28:00 即
+// 第二天 04:00 → diff 是负值 → 显示"刚刚"但其实显示永远卡在"刚刚").
+//
+// TODO(PR-N): 让 fleet/server 返 RFC3339 with timezone (e.g. 2026-06-12T04:11:31Z)
+// 而非 naive 'YYYY-MM-DD HH:MM:SS', 前端就不需要假设. 当前 docker testenv +
+// k8s prod 都配 UTC 是项目约定.
+function humanizeAge(epochMs: number): string {
+    if (!epochMs) return "—"
+    const diff = Date.now() - epochMs
+    if (diff < 60_000)     return "刚刚"
+    if (diff < 3_600_000)  return `${Math.floor(diff / 60_000)} 分钟前`
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`
+    return `${Math.floor(diff / 86_400_000)} 天前`
+}
+
+// 取 device 下所有 runtime 的 max last_seen_at, 返 epoch ms (无则 0).
+// 4 个 runtime 跑同一 daemon 同一 heartbeatLoop, 4 个 last_seen_at 几乎同步,
+// 取 max 等价 daemon 整体最后心跳时间. 直接返 epoch 让 caller 自己决定渲染
+// (避免 string ↔ epoch 来回往返).
+function deviceLastSeenMs(group: DeviceGroup): number {
+    let max = 0
+    for (const r of group.runtimes) {
+        if (!r.last_seen_at) continue
+        const ts = new Date(r.last_seen_at.replace(" ", "T") + "Z").getTime()
+        if (!isNaN(ts) && ts > max) max = ts
+    }
+    return max
 }
 
 function groupByDevice(runtimes: AgentRuntime[]): DeviceGroup[] {
@@ -319,6 +352,24 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                         <label>Daemon ID</label>
                         <span className="wk-rt-mono">{group.daemonId}</span>
                     </div>
+                    {(() => {
+                        // 最近活跃: humanize 该 device 下所有 runtime 的
+                        // max last_seen_at. 4 个 runtime 走同一 daemon
+                        // 同一 heartbeatLoop, 实务上 4 个值几乎同步. daemon
+                        // 在跑 → "刚刚"; daemon 挂 → 反映挂多久了.
+                        // title 走本地时区 (toLocaleString) 让 hover 看到的精确
+                        // 时间符合用户本地预期.
+                        const ms = deviceLastSeenMs(group)
+                        if (!ms) return null
+                        return (
+                            <div className="wk-rt-field">
+                                <label>最近活跃</label>
+                                <span title={new Date(ms).toLocaleString()}>
+                                    {humanizeAge(ms)}
+                                </span>
+                            </div>
+                        )
+                    })()}
                     <div className="wk-rt-field">
                         <label>Server Ping</label>
                         <span className="wk-rt-ping-result" onClick={this.handlePing}>
@@ -801,6 +852,12 @@ interface RuntimeDetailProps {
     componentActiveUpgrade?: ActiveUpgrade
     onDelete: (id: number) => void
     onAgentsChanged?: () => void
+    // UI/UX review #375 follow-up (P1-3): RuntimeDetail 详情页信息密度
+    // 低 (只 Runtime Mode / Provider / Version / Octo Plugin). 父侧
+    // RuntimesPage 持有 botsByRuntime cache, 把"已绑定 Bot 数" prop 注入
+    // 让 detail 页有 runtime-级别的真实信息 (跟 last_seen_at 那种 daemon-
+    // 级别冗余的不同).
+    botCount?: number
 }
 
 type PluginUpgradeStatus = "idle" | "pending" | "dispatched" | "installing" | "completed" | "failed" | "timeout"
@@ -966,7 +1023,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                     <RuntimeDetail
                                         runtime={updated}
                                         versionHints={hints}
+                                        pluginActiveUpgrade={this.props.pluginActiveUpgrade}
+                                        componentActiveUpgrade={this.props.componentActiveUpgrade}
                                         onDelete={this.props.onDelete}
+                                        botCount={this.props.botCount}
                                     />
                                 )
                             }
@@ -1068,7 +1128,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                     <RuntimeDetail
                                         runtime={updated}
                                         versionHints={hints}
+                                        pluginActiveUpgrade={this.props.pluginActiveUpgrade}
+                                        componentActiveUpgrade={this.props.componentActiveUpgrade}
                                         onDelete={this.props.onDelete}
+                                        botCount={this.props.botCount}
                                     />
                                 )
                             }
@@ -1150,6 +1213,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     <div className="wk-rt-field">
                         <label>Provider</label>
                         <span>{providerLabels[rt.provider] || rt.provider}</span>
+                    </div>
+                    <div className="wk-rt-field">
+                        <label>已绑定 Bot</label>
+                        <span>{this.props.botCount ?? 0} 个</span>
                     </div>
                     {/* PR-2: 探活由 device row 绿点 + daemon heartbeat
                         体现; runtime 级 last_seen_at / device_name /
@@ -1268,7 +1335,12 @@ function BotRow({ bot, onOpen }: BotRowProps) {
                 {isOnline && <span className="wk-rt-online-dot" title="Online" />}
             </div>
             <span className="wk-rt-bot-name">{bot.name}</span>
-            <span className="wk-rt-bot-status">{botStatusLabel(bot.status)}</span>
+            {/* P0-1 follow-up (UI/UX review): bot.status==='active' 时
+                头像绿点已经表达"在线", 不再显示"在线"文字避免重复 — 仅
+                非 active 状态显示 (配置中/失败/草稿/已归档 是有信息量的). */}
+            {bot.status !== "active" && (
+                <span className="wk-rt-bot-status">{botStatusLabel(bot.status)}</span>
+            )}
         </div>
     )
 }
@@ -1527,6 +1599,19 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 const loading = new Set(prev.botsLoading)
                 loading.delete(runtimeId)
                 return { botsByRuntime: next, botsLoading: loading }
+            }, () => {
+                // R1-3 fix (cc + codex review #PR-3): RuntimeDetail 经
+                // routeRight.replaceToRoot 命令式渲染, 不在 React tree 内
+                // 接收新 props. cache miss 后这里的 setState 只刷新左树
+                // botsByRuntime cache, 已 mount 的 RuntimeDetail 不会自动
+                // 拿到新 botCount. 所以 setState 完成后, 若当前右侧 detail
+                // 正指向该 runtimeId, 重新调 showAgentDetail 把带新
+                // botCount 的 RuntimeDetail replaceToRoot 推过去.
+                if (isStale()) return
+                if (this.state.selectedId === runtimeId) {
+                    const rt = this.state.runtimes.find(r => r.id === runtimeId)
+                    if (rt) this.showAgentDetail(rt)
+                }
             })
         } catch (e) {
             this.setState((prev) => {
@@ -1556,12 +1641,22 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         this.selectedDaemonId = undefined
         const pluginUpgrade = this.state.activeUpgrades[`${rt.id}:octo`]
         const componentUpgrade = this.state.activeUpgrades[`${rt.id}:${rt.provider}`]
+        // botCount 先用 botsByRuntime cache 当前值 (miss 时为 0). cache miss
+        // 时触发一次 refreshRuntimeBots, 它的 setState callback 会在数据
+        // 回来后 re-replaceToRoot 注入正确 botCount (见 refreshRuntimeBots
+        // 注释) — RuntimeDetail 走命令式 routeRight 渲染不在 React tree
+        // 内, 不会自动收到新 props 必须命令式 re-replace.
+        const cachedBots = this.state.botsByRuntime.get(rt.id)
+        if (cachedBots === undefined && !this.state.botsLoading.has(rt.id)) {
+            this.refreshRuntimeBots(rt.id)
+        }
         WKApp.routeRight.replaceToRoot(
             <RuntimeDetail
                 runtime={rt}
                 versionHints={this.state.versionHints}
                 pluginActiveUpgrade={pluginUpgrade}
                 componentActiveUpgrade={componentUpgrade}
+                botCount={cachedBots?.length ?? 0}
                 onDelete={() => {
                     this.setState({ selectedId: null })
                     WKApp.routeRight.popToRoot()
@@ -1575,7 +1670,15 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     render() {
         const { runtimes, selectedId, loading, expandedDevices, createMenuOpen, runtimeModalOpen } = this.state
         const groups = groupByDevice(runtimes)
-        const totalOnline = runtimes.filter(r => r.status === "online").length
+        // P1 follow-up (UI/UX review): "M online" 含义重定义 — 不再是
+        // runtime.status='online' 的 runtime 数 (实务上一个 daemon 4 个
+        // runtime 几乎同时上下线, 单算 runtime 在线粒度太细). 现在表达
+        // "活着的 daemon 下提供的 runtime 总数" — daemon 活 (任一 runtime
+        // 在线) 就把它的 4 个 runtime 全计入. 跟左树展开后看到的"槽位"
+        // 数对得上.
+        const totalOnline = groups
+            .filter(g => g.onlineCount > 0)
+            .reduce((sum, g) => sum + g.runtimes.length, 0)
 
         return (
             <div className="wk-rt-list">
@@ -1690,8 +1793,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                     >
                                         <div className="wk-rt-device-name">{group.deviceName}</div>
                                         <div className="wk-rt-device-sub">
-                                            {group.runtimes.length} agent{group.runtimes.length !== 1 ? "s" : ""}
-                                                                                    </div>
+                                            {group.runtimes.length} 个运行时
+                                        </div>
                                     </div>
                                     <div className={`wk-rt-status-dot ${anyOnline ? "online" : "offline"}`} />
                                 </div>
@@ -1745,7 +1848,17 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                                         <div className="wk-rt-bot-empty">加载中…</div>
                                                     )}
                                                     {!botsLoading && bots.length === 0 && (
-                                                        <div className="wk-rt-bot-empty">该运行时下暂无智能体</div>
+                                                        <div className="wk-rt-bot-empty">
+                                                            <span>该运行时下暂无 Bot</span>
+                                                            <button
+                                                                type="button"
+                                                                className="wk-rt-bot-empty__cta"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    this.botsTabRef.current?.openCreate({ preselectRuntimeId: rt.id })
+                                                                }}
+                                                            >+ 在此创建</button>
+                                                        </div>
                                                     )}
                                                     {bots.map((b) => (
                                                         <BotRow

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -96,10 +96,11 @@ function parseMetadata(raw: string): Record<string, unknown> | null {
 function humanizeAge(epochMs: number): string {
     if (!epochMs) return "—"
     const diff = Date.now() - epochMs
-    if (diff < 60_000)     return "刚刚"
-    if (diff < 3_600_000)  return `${Math.floor(diff / 60_000)} 分钟前`
-    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`
-    return `${Math.floor(diff / 86_400_000)} 天前`
+    if (diff < 0)          return "—"
+    if (diff < 60_000)     return "Just now"
+    if (diff < 3_600_000)  return `${Math.floor(diff / 60_000)} min ago`
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} hr ago`
+    return `${Math.floor(diff / 86_400_000)} day${Math.floor(diff / 86_400_000) === 1 ? "" : "s"} ago`
 }
 
 // 取 device 下所有 runtime 的 max last_seen_at, 返 epoch ms (无则 0).
@@ -308,7 +309,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                         <span>{group.deviceName}</span>
                     </div>
                     <div className="wk-rt-field">
-                        <label>Agents</label>
+                        <label>Runtimes</label>
                         <span>{group.runtimes.length}</span>
                     </div>
                     {(group.osName || group.arch) && (
@@ -363,7 +364,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                         if (!ms) return null
                         return (
                             <div className="wk-rt-field">
-                                <label>最近活跃</label>
+                                <label>Last Active</label>
                                 <span title={new Date(ms).toLocaleString()}>
                                     {humanizeAge(ms)}
                                 </span>
@@ -1215,8 +1216,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                         <span>{providerLabels[rt.provider] || rt.provider}</span>
                     </div>
                     <div className="wk-rt-field">
-                        <label>已绑定 Bot</label>
-                        <span>{this.props.botCount ?? 0} 个</span>
+                        <label>Bots</label>
+                        <span>{this.props.botCount ?? 0}</span>
                     </div>
                     {/* PR-2: 探活由 device row 绿点 + daemon heartbeat
                         体现; runtime 级 last_seen_at / device_name /


### PR DESCRIPTION
## Summary

PR-2 #375 已 merged. 本 PR 基于 UI/UX 走查报告 + caster 决策做 **8 项打磨**, P0 + P1 + 顺手 P2 都收, P2 cosmetic 推 PR-N.

## P0

| # | 项 | 文件 | 说明 |
|---|---|---|---|
| 1 | "X agents" → "X 个运行时" | `index.tsx` device row | 之前写 "agents" 实际是 runtime 数, 用户会以为有 N 个 bot 其实是 0 bot N runtime |
| 2 | providerLabels 抽 `botsApi.ts`, claude→"Claude" 不带 Code | `botsApi.ts` / `index.tsx` / `CreateBotModal.tsx` | 三处入口共用单源, 避免 "kind 列表用裸 'claude' / detail 显示 'Claude Code'" 三层概念名漂移 |
| 3 | SUPPORTED_KINDS 注释 claude 走 cc-channel-octo | `BotsTab.tsx` | 防下次 reviewer 看 \`internal/adapter/claude.go\` skeleton ErrUnsupported 又质疑 UI 开放但执行不通 |

## P1

| # | 项 | 说明 |
|---|---|---|
| 4 | RuntimeDetail 加"已绑定 Bot" | prop 注入 (RuntimesPage botsByRuntime cache); cache miss 触发 refreshRuntimeBots, setState callback 内若当前 detail 正指向该 runtime 重 replaceToRoot 注入新 botCount — RuntimeDetail 走命令式 routeRight 渲染不在 React tree 内必须命令式 re-replace |
| 5 | DeviceDetail 加"最近活跃" humanize | "刚刚 / X 分钟前 / X 小时前 / X 天前", 取 device 下 runtime max last_seen_at (4 个 runtime 几乎同步, max 等价 daemon 整体最后心跳). 时区前提: server tz=UTC (testenv-mysql 已 verify NOW()===UTC_TIMESTAMP()), 注释说明前提 + TODO(PR-N) 后端返 RFC3339 |
| 6 | 空态 CTA "+ 在此创建" | 跨 BotsTabHandle.openCreate(opts) + BotsTab preselectRuntimeId state + CreateBotModal preselect prop. useEffect 优先级: preselect > firstReady > groups[0]; preselect target 不可用时 fallback 到该 device 内 supported+online 第一个 (锁定 targetGroup, 不跳别 device) |
| 7 | totalOnline 含义重定义 | \`runtimes.filter(status==="online").length\` → \`groups.filter(onlineCount>0).reduce(...g.runtimes.length,0)\` (活 daemon 下 runtime 总数, 跟左树展开数对得上) |
| 8 | BotRow status==='active' 时不显示"在线"文字 | 头像绿点已表达, 避免重复; 非 active 状态 (配置中/失败/草稿) 保留文字 |

## P2 顺手 (cc review round 2)

- 两处 \`RuntimeDetail\` self-replaceToRoot 补 \`pluginActiveUpgrade\` / \`componentActiveUpgrade\` props 透传, 避免升级态丢失
- \`showAgentDetail\` 旧失实注释清掉 (跟 \`refreshRuntimeBots\` 新注释打脸)

## P3 推 PR-N

- totalOnline 变量名/文案 \"X online\" 含 offline 槽位有歧义 (caster 既定决策, 接受)
- a11y N1 二级动作 nested onClick keyboard 不可达 / N2 Space keyup
- per-row 2s timer 不抽全局 listener
- useChannelOnline 两份复制
- CreateRuntimeModal stale fetch race
- listBots 全量 per-expand
- bot saga / cross-tier deprovision

## Test plan

- [x] cc reviewer (Claude Code) 2 轮 review, round 2 verdict=approve-with-nits, 0 P0/P1
- [x] codex reviewer 2 轮 review, round 2 verdict=approved, 0 finding
- [x] \`pnpm tsc --noEmit\` 0 真实 ts 错误
- [x] \`stylelint:ci\` 整文件 0 报错
- [x] 死循环 verify (cc round 2 confirmed): cache hit 终止递归, selectedId guard 跨 runtime 切换安全
- [x] 时区 verify: \`docker exec testenv-mysql NOW()===UTC_TIMESTAMP()\` 验 server tz=UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)