### PR TITLE
feat(runtime-ui): runtime 页 UI/UX 打磨(术语统一 + 待上线占位 + 头部对齐设计系统)

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
@@ -6,6 +6,19 @@ import { Bot, BotFeedItem, getBotFeed } from './botsApi';
 
 type DetailTab = 'info' | 'feed' | 'tasks' | 'skills';
 
+// matter (任务/数据面) 本期未上线 —— 依赖 matter 的「动态」「任务记录」两个
+// tab 改为「待上线」占位 (同时停掉 FeedTab/TasksTab 对 matter feed 的 3s 轮询).
+// matter 上线后把 MATTER_ENABLED 置 true 即恢复真实内容.
+const MATTER_ENABLED = false;
+// 每个 tab 是否已就绪: false → 展示「待上线」占位 + tab 角标.
+// Skills 是独立的待开发功能, 跟 matter 无关.
+const TAB_READY: Record<DetailTab, boolean> = {
+  info: true,
+  feed: MATTER_ENABLED,
+  tasks: MATTER_ENABLED,
+  skills: false,
+};
+
 // PR-2: bot 在线信号 = WuKongIM channel.online (跟主 IM 私聊里 bot 头像
 // 旁边那个绿点同源). 不是 fleet bot.status / runtime.status —— 那俩是
 // fleet 内部状态机, 跟 IM 实际能否通讯无直接关系.
@@ -90,7 +103,7 @@ export function BotDetailPanel({ bot }: { bot: Bot }) {
       </header>
 
       {/* ── Tabs ──────────────────────────────────────────── */}
-      <nav className="wk-bd-tabs" role="tablist" aria-label="智能体详情切换">
+      <nav className="wk-bd-tabs" role="tablist" aria-label="Bot 详情切换">
         {(['info','feed','tasks','skills'] as DetailTab[]).map(t => (
           <button
             key={t}
@@ -101,6 +114,7 @@ export function BotDetailPanel({ bot }: { bot: Bot }) {
             onClick={() => setTab(t)}
           >
             {t === 'info' ? '基本信息' : t === 'feed' ? '动态' : t === 'tasks' ? 'Tasks' : 'Skills'}
+            {!TAB_READY[t] && <span className="wk-bd-tab__soon">待上线</span>}
           </button>
         ))}
       </nav>
@@ -108,9 +122,9 @@ export function BotDetailPanel({ bot }: { bot: Bot }) {
       {/* ── Body ──────────────────────────────────────────── */}
       <div className="wk-bd-body">
         {tab === 'info' && <InfoTab bot={bot} />}
-        {tab === 'feed' && <FeedTab bot={bot} />}
-        {tab === 'tasks' && <TasksTab bot={bot} />}
-        {tab === 'skills' && <SkillsTab />}
+        {tab === 'feed' && (TAB_READY.feed ? <FeedTab bot={bot} /> : <ComingSoon title="动态" />)}
+        {tab === 'tasks' && (TAB_READY.tasks ? <TasksTab bot={bot} /> : <ComingSoon title="任务记录" />)}
+        {tab === 'skills' && (TAB_READY.skills ? <SkillsTab /> : <ComingSoon title="Skills" />)}
       </div>
     </div>
   );
@@ -309,7 +323,7 @@ function TasksTab({ bot }: { bot: Bot }) {
   if (items.length === 0) return (
     <section className="wk-bd-section wk-bd-section--card">
       <h3 className="wk-bd-section__title">任务记录</h3>
-      <div className="wk-bd-empty wk-bd-empty--inline">还没有任务记录 — 在事项里 @ 此智能体即可派任务</div>
+      <div className="wk-bd-empty wk-bd-empty--inline">还没有任务记录 — 在事项里 @ 此 Bot 即可派任务</div>
     </section>
   );
   return (
@@ -348,6 +362,16 @@ function SkillsTab() {
     <section className="wk-bd-section wk-bd-section--card">
       <h3 className="wk-bd-section__title">Skills</h3>
       <div className="wk-bd-empty wk-bd-empty--inline">Skills 配置（占位 — 下个迭代）</div>
+    </section>
+  );
+}
+
+// 「待上线」占位 — 用于本期未开放的 tab (动态/任务记录依赖 matter; Skills 待开发).
+function ComingSoon({ title }: { title: string }) {
+  return (
+    <section className="wk-bd-section wk-bd-section--card">
+      <h3 className="wk-bd-section__title">{title}</h3>
+      <div className="wk-bd-empty wk-bd-empty--inline">该功能开发中，即将上线，敬请期待</div>
     </section>
   );
 }

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -242,7 +242,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
     <div className="wk-rt-bots-list" style={props.hidden ? { display: 'none' } : undefined}>
       {loading && bots.length === 0 && <div className="wk-rt-bots__empty">加载中…</div>}
       {!loading && bots.length === 0 && (
-        <div className="wk-rt-bots__empty">还没有智能体，点右上角 + 新建</div>
+        <div className="wk-rt-bots__empty">还没有 Bot，点右上角 + 新建</div>
       )}
       <ul className="wk-rt-bots__items">
         {bots.map(b => (

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1000,7 +1000,7 @@
  * is the only divider; section subheader takes over below.
  */
 .wk-rt-pageheader {
-  padding: 12px 16px 0;
+  padding: 14px 16px;
   background: var(--bg-primary);
   border-bottom: 1px solid var(--border-light);
 }

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1031,7 +1031,7 @@
 
 /* Toolbar row above the list — minimal, only carries the create CTA
  * and an inline count. No section title — the page tab already says
- * "Bot", so a "智能体" heading here would be duplicative. */
+ * "Bot", so a duplicate "Bot" heading here would be redundant. */
 .wk-rt-bots__item {
   padding: 10px 14px;
   border-bottom: 1px solid var(--border-light);
@@ -1230,6 +1230,18 @@
   color: var(--text-primary);
   border-bottom-color: var(--text-primary);
   font-weight: 600;
+}
+/* 「待上线」角标 — 标注本期未开放的 tab (动态/Tasks/Skills) */
+.wk-bd-tab__soon {
+  margin-left: 5px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 16px;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  border-radius: 4px;
+  vertical-align: middle;
 }
 
 /* ── Body / section cards ── */

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1005,16 +1005,28 @@
   border-bottom: 1px solid var(--border-light);
 }
 
-/* Meta info (count / status summary) sits at the trailing edge of the
- * tab row — keeps page metadata visible without a second header line. */
+/* Meta info (count / online status) sits at the trailing edge of the
+ * header, next to the create button — mirrors the conversation list's
+ * "ping" chip. Online count leads, with a status dot for quick scanning. */
 .wk-rt-pageheader__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   margin-left: auto;
-  align-self: center;
-  padding-bottom: 4px;       /* visually align with active tab baseline */
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--wk-text-tertiary);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+.wk-rt-meta-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--wk-icon-muted);
+  flex-shrink: 0;
+}
+.wk-rt-meta-dot.is-online {
+  background: var(--wk-color-success);
 }
 
 /* Primary action button hosted in the page header (Bot tab uses it for
@@ -1628,37 +1640,37 @@
    page. */
 .wk-rt-pagetitle {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
+  align-items: center;
+  gap: 8px;
   width: 100%;
 }
 .wk-rt-pagetitle-text {
   margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.4;
+  font-size: var(--wk-text-size-xl);
+  font-weight: var(--wk-font-semibold);
+  line-height: 24px;
+  color: var(--wk-text-primary);
 }
 .wk-rt-create-wrap {
   position: relative;
-  margin-left: auto;
 }
 .wk-rt-create-btn {
-  border: 1px solid var(--border-color);
-  background: transparent;
-  color: var(--text-primary);
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--wk-icon-muted);
+  cursor: pointer;
+  border-radius: var(--wk-r-sm);
+  transition: color var(--wk-dur-fast), background var(--wk-dur-fast);
 }
 .wk-rt-create-btn:hover {
-  background: var(--bg-hover);
+  background: var(--wk-bg-item-hover);
+  color: var(--wk-text-primary);
 }
 .wk-rt-create-btn:focus-visible {
   outline: 2px solid var(--accent);

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -1250,7 +1250,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     })()}
                 </div>
 
-                {/* PR-2: 删 BotsSection (智能体列表 + 新建按钮) — 跟左侧
+                {/* PR-2: 删 BotsSection (Bot 列表 + 新建按钮) — 跟左侧
                     树 Level 3 的 bot rows 重复, "新建" 也跟顶部 + popover
                     的"创建 Bot"重复. caster 拍的去重. */}
 

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -1693,7 +1693,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                     <div className="wk-rt-pagetitle">
                         <h2 className="wk-rt-pagetitle-text">运行时</h2>
                         <span className="wk-rt-pageheader__meta" aria-live="polite">
-                            {groups.length} device{groups.length !== 1 ? "s" : ""} · {totalOnline} online
+                            <span className={`wk-rt-meta-dot${totalOnline > 0 ? " is-online" : ""}`} aria-hidden="true" />
+                            {totalOnline} online · {groups.length} device{groups.length !== 1 ? "s" : ""}
                         </span>
                         <div className="wk-rt-create-wrap">
                             <button
@@ -1704,7 +1705,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                 aria-expanded={createMenuOpen}
                                 aria-label="新建"
                                 onClick={() => this.setState({ createMenuOpen: !createMenuOpen })}
-                            >+</button>
+                            ><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 2.67v10.66M2.67 8h10.66" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" /></svg></button>
                             {createMenuOpen && (
                                 <>
                                     <div


### PR DESCRIPTION
## 概述
`/runtimes` 运行时页的一组 UI/UX 打磨，合入 `feat/agent-runtime`。

## 改动
- **标签英文化 + 概念对齐**：DeviceDetail / RuntimeDetail 字段统一，device / runtime / Bot 概念对齐。
- **术语统一**：残留「智能体」全部改为「Bot」（列表空态 / Tasks 空态 / aria-label / 注释）。
- **动态 / Tasks / Skills → 「待上线」占位**：本期 matter（任务/数据面）未上线，三个 tab 改为「待上线」角标 + 占位；用 `MATTER_ENABLED` 单点开关控制，matter 上线翻 `true` 即恢复真实内容。顺带停掉了 FeedTab 对未上线 matter 的 3s 轮询。
- **头部间距**：`+` 按钮不再贴住底部分隔线。
- **头部对齐设计系统**：`+` 按钮改为无框 lucide plus 图标（与事项 / 会话列表头一致），迁移到 `--wk-*` 语义 token，在线状态用 `--wk-color-success` 绿点编码。

## CI 说明
- ⚠️ `i18n:check` 预期 red：仓库既有问题（`.i18n` baseline 自 #157 起为空，`feat/agent-runtime` 本身这步也是 red），**非本 PR 引入**。i18n rebaseline 按团队决定走单独 PR。

## 测试
- 本地 dev 浏览器走查：头部 / tab 占位 / 术语 / 在线绿点 均确认。
- 生产构建走 `vite build`（不做 tsc 类型检查）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)