### PR TITLE
fix(sticker): stop fetching unimplemented sticker category endpoint

### DIFF
--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -111,7 +111,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         this.setState({
             emojis: this.emojiService.getAllEmoji()
         })
-        this.requestStickerCategory()
+        // 贴纸分类依赖后端 /sticker/* 接口，服务端尚未实现（sticker/user/category 返回 404）。
+        // 暂不调用 requestStickerCategory()，避免每次挂载都触发必失败的请求；
+        // 后端实现该端点后，恢复调用即可让贴纸分类 Tab 重新出现。
     }
 
     requestStickerCategory() {


### PR DESCRIPTION
## Problem

`EmojiPanel` fetches sticker categories on every mount (`componentDidMount` → `requestStickerCategory` → `GET sticker/user/category`). The backend has not implemented `/v1/sticker/*`, so this 404s on every input render and spams the network panel:

```
GET /api/v1/sticker/user/category  404 (Not Found)
```

It's functionally harmless (`.catch(() => [])` swallows it), but it's persistent network/console noise.

## Fix

Remove the auto-fetch. Since the endpoint does not exist, there is nothing to fetch — dropping the `componentDidMount` call means zero requests to the unimplemented endpoint.

The sticker picker code is left intact and dormant: the sticker tabs only render once `stickerCategories` is populated, so with no fetch they simply don't appear. Re-enable by calling `requestStickerCategory()` once the backend ships `/sticker/*` — a one-line change, documented in a comment at the removal site.

`LottieSticker` rendering (for incoming sticker messages) is untouched.

## Test plan

- `pnpm --filter @octo/datasource test` → 24 passed (no regressions)
- The change is a pure removal of a network call; the picker UI is conditional on fetched data, so there is no visual regression.

Closes #380