### PR TITLE
fix(summary): preserve channel/thread/DM name suffix for scheduled summaries

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -129,6 +129,8 @@ export default class ChatSummaryNewModal extends Component<
         this.setState({ submitting: true });
         try {
             const sources = selectedChats.length > 0
+                // 不传 source_name：让后端按 source_id 现查 IM 库最新群名（带类型后缀），
+                // 与下方 fallback 分支一致，避免把群名冻结进配置。
                 ? selectedChats.map((c) => ({
                     source_type: (c.chat_type === 'group'
                         ? SourceType.GROUP_CHAT
@@ -136,7 +138,6 @@ export default class ChatSummaryNewModal extends Component<
                         ? SourceType.THREAD
                         : SourceType.DIRECT_MESSAGE),
                     source_id: c.chat_id,
-                    source_name: c.name,
                 }))
                 : [{
                     source_type: sourceType as 1 | 2 | 3,

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -165,12 +165,13 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             };
 
             if (selectedChats.length > 0) {
+                // 不传 source_name：让后端按 source_id 现查 IM 库最新群名（带类型后缀）。
+                // 避免把创建那一刻的群名冻结进定时配置，从而群改名后定时仍显示旧名。
                 params.sources = selectedChats.map((c) => ({
                     source_type: c.chat_type === "group" ? SourceType.GROUP_CHAT
                                : c.chat_type === "thread" ? SourceType.THREAD
                                : SourceType.DIRECT_MESSAGE,
                     source_id: c.chat_id,
-                    source_name: c.name,
                 }));
             }
 


### PR DESCRIPTION
## 问题 / Bug

定时任务（scheduled summary）更新后，所选数据源若是**群聊 / 子区 / 私聊**，其名称的**类型后缀会丢失**。

## 根因 / Root cause

创建/编辑总结时，前端把「当下渲染的 `source_name`」一并冻结进了任务配置。后续定时任务再次运行时，沿用的是这个被冻结的旧名称字符串，而该字符串在某些路径下不含类型后缀（群/子区/私聊），导致展示时后缀丢失。

## 修复 / Fix

创建/编辑时不再把前端当下的 `source_name` 冻结进配置，改为只传 `source_type` + `source_id`，让后端按 `source_id` 现查 IM 库的最新名称（自带 群/子区/私聊 类型后缀）。

这样名称始终以 IM 库为准、实时解析，定时任务每次运行都能拿到带正确后缀的最新名称。

## 改动文件 / Changed files

- `packages/dmworksummary/src/components/ChatSummaryNewModal.tsx`
- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx`

(+4 / -2)

## 兼容性 / Notes

- 仅前端改动，去掉冗余的 `source_name` 传参，依赖后端按 `source_id` 解析名称的既有能力。
- 与上游 main 最新提交无文件交集，无冲突。
