### PR TITLE
feat(runtime-ui): upgrade mutex UX, auto-refresh upgrade status & tree simplification

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -26,12 +26,11 @@ interface RuntimeListEntry {
 // the parent switches the active tab to "bots" and then asks us to
 // surface that bot's detail panel.
 //
-// UI/UX review #375 follow-up (P1-4 空态 CTA): openCreate 加可选
-// preselectRuntimeId — 用户在左树 Level-3 看到"暂无 Bot"按钮直接打开
-// modal 时, modal 跳过 firstReady 自动选, 直接定位到目标 runtime + 它
-// 的 device, 用户只填名字按确认.
+// caster 2026-06-12: openCreate 的 preselectRuntimeId 参数删 — 左树
+// Level-3 空态 CTA ("在此创建") 已随 "没 bot 不可展开" 改动移除, 唯一
+// caller 消失 (codex R3-2 死链路清理). 将来有 runtime 行创建入口再加回.
 export interface BotsTabHandle {
-  openCreate: (opts?: { preselectRuntimeId?: number }) => void;
+  openCreate: () => void;
   openBot: (id: number) => void;
 }
 
@@ -69,7 +68,6 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [runtimes, setRuntimes] = useState<RuntimeListEntry[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
-  const [preselectRuntimeId, setPreselectRuntimeId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
 
   // C10 in-flight guard: spaceEpoch 每次 space-changed 自增, refresh /
@@ -172,8 +170,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   }, []);
 
   useImperativeHandle(ref, () => ({
-    openCreate: (opts) => {
-      setPreselectRuntimeId(opts?.preselectRuntimeId ?? null);
+    openCreate: () => {
       setModalOpen(true);
     },
     openBot: (id: number) => {
@@ -264,12 +261,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
       <CreateBotModal
         visible={modalOpen}
         runtimes={modalRuntimes}
-        preselectRuntimeId={preselectRuntimeId}
-        onClose={() => {
-          setModalOpen(false);
-          // 关闭时清掉 preselect, 下次没传时不残留
-          setPreselectRuntimeId(null);
-        }}
+        onClose={() => setModalOpen(false)}
         onCreated={handleCreated}
       />
     </div>

--- a/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
@@ -25,11 +25,10 @@ interface RuntimeOption {
 interface Props {
   visible: boolean;
   runtimes: RuntimeOption[];
-  // UI/UX review #375 follow-up (P1-4 空态 CTA): 父侧 (RuntimesPage 通过
-  // BotsTab.openCreate({preselectRuntimeId})) 指定一个 runtime, modal 打开
-  // 时跳过 firstReady 自动选, 直接定位到目标 runtime + 它的 device. 用户
-  // 在左树某个空 runtime 下点"在此创建"时省去重选 device + runtime 两步.
-  preselectRuntimeId?: number | null;
+  // caster 2026-06-12 (codex R3-2): preselectRuntimeId prop 删 — 左树
+  // Level-3 空态 CTA (唯一 caller) 已随 "没 bot 不可展开" 改动移除.
+  // 将来 runtime 行加创建入口时从 git history 取回 (含 R1-2 的
+  // supported+online 校验逻辑).
   onClose: () => void;
   onCreated: (botId: number) => void;
 }
@@ -81,7 +80,7 @@ function groupByDevice(runtimes: RuntimeOption[]): DeviceGroup[] {
   });
 }
 
-export function CreateBotModal({ visible, runtimes, preselectRuntimeId, onClose, onCreated }: Props) {
+export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props) {
   const [name, setName] = useState('');
   const [deviceKey, setDeviceKey] = useState<string | null>(null);
   const [runtimeId, setRuntimeId] = useState<number | null>(null);
@@ -91,35 +90,13 @@ export function CreateBotModal({ visible, runtimes, preselectRuntimeId, onClose,
 
   // Reset state on open.
   // 优先级:
-  //   (1) 父侧传 preselectRuntimeId → 定位到该 runtime + 它的 device
-  //       (空态 CTA 入口: 用户在左树 Level-3 某个空 runtime 下点"在此创建")
-  //   (2) 否则走 firstReady (有 supported+online runtime 的第一个 device)
-  //   (3) 否则随便选第一个 device, runtime 留空
+  //   (1) firstReady (有 supported+online runtime 的第一个 device)
+  //   (2) 否则随便选第一个 device, runtime 留空
+  // (preselectRuntimeId 分支已删 — codex R3-2 死链路, 见 Props 注释)
   useEffect(() => {
     if (!visible) return;
     setName('');
     setBusy(false);
-    if (preselectRuntimeId != null) {
-      const targetGroup = groups.find(g => g.runtimes.some(r => r.id === preselectRuntimeId));
-      if (targetGroup) {
-        setDeviceKey(targetGroup.key);
-        // R1-2 (cc+codex review #PR-3): 校验 target runtime 是否
-        // supported+online. 是 → 预选; 否 → 走 firstReady 同款逻辑选该
-        // device 第一个可用 runtime, 避免出现 "选中态 + radio disabled +
-        // 创建按钮灰" 的矛盾死胡同 (空态 CTA 在 offline / unsupported
-        // runtime 下也会出现, 不能信任 preselect 一定可用).
-        const target = targetGroup.runtimes.find(r => r.id === preselectRuntimeId);
-        if (target && target.supported && target.status === 'online') {
-          setRuntimeId(preselectRuntimeId);
-        } else {
-          const fallback = targetGroup.runtimes.find(r => r.supported && r.status === 'online');
-          setRuntimeId(fallback?.id ?? null);
-        }
-        return;
-      }
-      // preselect runtime 不在 groups 里 (e.g. 数据未同步) — 静默 fallback
-      // 到 firstReady, 不让用户卡在错误的 modal 状态.
-    }
     const firstReady = groups.find(g => g.hasSupportedOnline);
     if (firstReady) {
       setDeviceKey(firstReady.key);
@@ -133,7 +110,7 @@ export function CreateBotModal({ visible, runtimes, preselectRuntimeId, onClose,
       setDeviceKey(null);
       setRuntimeId(null);
     }
-  }, [visible, groups, preselectRuntimeId]);
+  }, [visible, groups]);
 
   const activeGroup = useMemo(
     () => groups.find(g => g.key === deviceKey) ?? null,

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -2053,6 +2053,13 @@
 }
 /* .wk-rt-bot-empty + __cta 已删 (caster 2026-06-12): Level-3 空态文案
    "该运行时下暂无 Bot + 在此创建" 移除, 没 bot 的 runtime 直接不可展开 */
+/* 水合前回退懒加载路径的加载指示 (codex R3-3) */
+.wk-rt-bot-loading {
+  margin-left: 36px;
+  padding: 6px 12px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
 
 /* runtime arrow inherits the existing wk-rt-expand-arrow style; no new
    class needed. The agent-row's onClick now triggers toggleRuntime, but

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -290,6 +290,12 @@
     transform: rotate(90deg);
 }
 
+/* 没 bot 的 runtime 行不可展开 — 不渲染箭头, 占位保持缩进对齐
+   (caster 2026-06-12, 同步删除 Level-3 空态文案 + 在此创建 CTA) */
+.wk-rt-expand-arrow.placeholder {
+    visibility: hidden;
+}
+
 .wk-rt-device-icon {
     width: 32px;
     height: 32px;
@@ -322,11 +328,8 @@
     white-space: nowrap;
 }
 
-.wk-rt-device-sub {
-    font-size: 11px;
-    color: var(--text-tertiary);
-    margin-top: 1px;
-}
+/* .wk-rt-device-sub 已删 (caster 2026-06-12): device 行 "N 个运行时"
+   副标题移除, 顶栏 "N devices · M runtimes" 已有该信息 */
 
 /* ── Agent Row (Level 2) ── */
 .wk-rt-agent-row {
@@ -611,6 +614,21 @@
 }
 .wk-rt-upgrade-status.error .upgrade-dot {
     background: var(--wk-color-error);
+}
+/* A-1 (升级互斥 UX): Failed 旁内联展示 error_msg (截断 40 字符, title 放
+   全文) — 原来藏 hover title, 互斥拒绝看起来像升级真坏了 */
+.wk-rt-upgrade-reason {
+    color: var(--wk-color-error);
+    opacity: 0.85;
+    font-weight: 400;
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+/* A-2: Failed 态旁的 Retry 按钮间距 */
+.wk-rt-upgrade-status.error .wk-rt-upgrade-btn {
+    margin-left: 6px;
 }
 @keyframes upgradeDotPulse {
     0%, 100% { opacity: 1; transform: scale(1); }
@@ -1017,16 +1035,6 @@
   color: var(--wk-text-tertiary);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-}
-.wk-rt-meta-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--wk-icon-muted);
-  flex-shrink: 0;
-}
-.wk-rt-meta-dot.is-online {
-  background: var(--wk-color-success);
 }
 
 /* Primary action button hosted in the page header (Bot tab uses it for
@@ -2043,34 +2051,8 @@
   font-size: 11px;
   color: var(--text-tertiary);
 }
-.wk-rt-bot-empty {
-  margin-left: 36px;
-  padding: 6px 12px;
-  font-size: 11px;
-  color: var(--text-tertiary);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.wk-rt-bot-empty__cta {
-  appearance: none;
-  background: transparent;
-  border: 1px solid var(--border-color);
-  color: var(--text-secondary);
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
-}
-.wk-rt-bot-empty__cta:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-.wk-rt-bot-empty__cta:focus-visible {
-  outline: none;
-  border-color: var(--accent);
-}
+/* .wk-rt-bot-empty + __cta 已删 (caster 2026-06-12): Level-3 空态文案
+   "该运行时下暂无 Bot + 在此创建" 移除, 没 bot 的 runtime 直接不可展开 */
 
 /* runtime arrow inherits the existing wk-rt-expand-arrow style; no new
    class needed. The agent-row's onClick now triggers toggleRuntime, but

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -186,6 +186,19 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
         return `${WKApp.shared.currentSpaceId}:${this.props.group.daemonId}`
     }
 
+    componentDidMount() {
+        // R4-3 (cc) / R3-5 (codex), round 4 双方同抓: DeviceDetail 跟
+        // RuntimeDetail 893 行同款 remount 续看 — replaceToRoot remount 后
+        // 原 handleUpgrade 轮询协程死 (isStale), 新实例若初始 state 是
+        // in-progress 必须续看, 否则 upgradeStatus 冻结在 remount 时刻值,
+        // 3s 自适应轮询带来的新 prop 也救不了 (此前 componentDidUpdate 只
+        // 在 daemonId 变化时重读).
+        const upg = this.props.activeUpgrade
+        if (upg?.task_id && isUpgradeInProgress(this.state.upgradeStatus)) {
+            this.resumeUpgradePoll(upg.task_id)
+        }
+    }
+
     componentDidUpdate(prevProps: DeviceDetailProps) {
         if (prevProps.group.daemonId !== this.props.group.daemonId) {
             const cached = this.props.pingCache.get(this.cacheKey)
@@ -196,6 +209,20 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                 ? { pingStatus: cached.status, pingMs: cached.ms, upgradeStatus: upgStatus, upgradeError: upgError }
                 : { pingStatus: "idle", pingMs: 0, upgradeStatus: upgStatus, upgradeError: upgError }
             )
+            return
+        }
+        // R4-3/R3-5: 同 daemon 下 activeUpgrade prop 变化 → state 跟进
+        // (RuntimeDetail syncUpgradeStateFromProp 同款语义): 页面级轮询
+        // (15s/3s) 经 B-4 re-replaceToRoot 推新 prop, React 原地复用实例
+        // 时走这里. prop 消失 (任务终态出 active_upgrades) 时若本地还是
+        // in-progress 复位 idle — 让 detect 上报后的终态能落地.
+        const prevUpg = prevProps.activeUpgrade
+        const currUpg = this.props.activeUpgrade
+        if (prevUpg?.status === currUpg?.status && prevUpg?.error_msg === currUpg?.error_msg) return
+        if (currUpg) {
+            this.setState({ upgradeStatus: currUpg.status as any, upgradeError: currUpg.error_msg || "" })
+        } else if (isUpgradeInProgress(this.state.upgradeStatus)) {
+            this.setState({ upgradeStatus: "idle", upgradeError: "" })
         }
     }
 
@@ -233,13 +260,25 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
     handleUpgrade = async () => {
         this.setState({ upgradeStatus: "pending", upgradeError: "" })
         const daemonId = this.props.group.daemonId
-        const isStale = () => this._unmounted || this.props.group.daemonId !== daemonId
         try {
             const initRes = await WKApp.apiClient.post("/runtimes/upgrade", { daemon_id: daemonId, space_id: WKApp.shared.currentSpaceId })
             const taskId = initRes.task_id
             // C-1: task 已创建, 立即让父层重拉 active_upgrades, 其他 detail
             // 的 daemonBusy ~1s 内生效 (不等 15s 轮询).
             this.props.onUpgradeStarted?.()
+            await this.resumeUpgradePoll(taskId)
+        } catch (err: any) {
+            this.setState({ upgradeStatus: "failed", upgradeError: err?.msg || err?.message || "upgrade failed" })
+        }
+    }
+
+    // 轮询已知 taskId 的进度. 抽出复用 (R4-3/R3-5 round 4): 1) handleUpgrade
+    // 首次点击; 2) componentDidMount remount 续看 — 跟 RuntimeDetail
+    // pollPluginUpgrade/pollComponentUpgrade 同款双入口模式.
+    resumeUpgradePoll = async (taskId: string) => {
+        const daemonId = this.props.group.daemonId
+        const isStale = () => this._unmounted || this.props.group.daemonId !== daemonId
+        try {
             for (let i = 0; i < 60; i++) {
                 if (isStale()) return
                 await new Promise(r => setTimeout(r, 2000))
@@ -295,7 +334,11 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
             }
             this.setState({ upgradeStatus: "timeout", upgradeError: "polling timeout" })
         } catch (err: any) {
-            this.setState({ upgradeStatus: "failed", upgradeError: err?.msg || err?.message || "upgrade failed" })
+            // resumeUpgradePoll 自身的网络/解析异常: 不标 failed (任务可能
+            // 还在跑), 留给页面级轮询兜底纠正.
+            if (!isStale()) {
+                this.setState({ upgradeError: err?.msg || err?.message || "" })
+            }
         }
     }
 
@@ -1544,6 +1587,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
             botsLoading: new Set(),
             botsHydrated: false,
         })
+        // R4-2: 新 space 的首次全量 bot 拉取不受旧 space 节流时间戳约束
+        this.lastAllBotsAt = 0
         WKApp.routeRight.popToRoot()
         this.loadData()
     }
@@ -1754,14 +1799,19 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     // 更早起飞的全量覆盖, 新 bot 左树短暂消失). botsSeq 模块级序号统一
     // 两路: 任一新请求起飞使旧响应作废.
     private botsSeq = 0
+    // R4-2 (cc + codex round 4): refreshAllBots 自带 15s 节流 — 升级期间
+    // loadData 降到 3s 档时, bot 数据跟升级无关, 不该连带 5 倍 listBots.
+    private lastAllBotsAt = 0
 
-    refreshAllBots = async () => {
+    refreshAllBots = async (force = false) => {
+        if (!force && Date.now() - this.lastAllBotsAt < POLL_IDLE_MS) return
         const epoch = this.spaceEpoch
         const seq = ++this.botsSeq
         const isStale = () => this.spaceEpoch !== epoch || seq !== this.botsSeq
         try {
             const all = await listBots()
             if (isStale()) return
+            this.lastAllBotsAt = Date.now()
             this.setState((prev) => {
                 if (isStale()) return null
                 const next = new Map<number, Bot[]>()
@@ -1835,6 +1885,22 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 loading.delete(runtimeId)
                 return { botsLoading: loading }
             })
+        } finally {
+            // R4-1 (cc + codex round 4 同抓): 本请求被 botsSeq 作废 (更新
+            // 的 refreshAllBots / 别的单 key 请求起飞) 时, 上面所有
+            // setState 都被 isStale 挡住 — botsLoading 里的标记没人清,
+            // 若接班的全量请求恰好失败, "加载中…" 挂死且 needFirstLoad
+            // 被 botsLoading.has 抑制无法重试. epoch 没变 (同 space) 时
+            // 兜底清掉本 runtime 的 loading 标记 (幂等, 接班请求成功路径
+            // 也会清). epoch 变了不管 — handleSpaceChanged 整体重置.
+            if (this.spaceEpoch === epoch && seq !== this.botsSeq) {
+                this.setState((prev) => {
+                    if (this.spaceEpoch !== epoch || !prev.botsLoading.has(runtimeId)) return null
+                    const loading = new Set(prev.botsLoading)
+                    loading.delete(runtimeId)
+                    return { botsLoading: loading }
+                })
+            }
         }
     }
 

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -363,7 +363,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                                                 {upgradeStatus === "timeout" ? "Timeout" : "Failed"}
                                                 {upgradeError && <span className="wk-rt-upgrade-reason">· {upgradeError.length > 40 ? upgradeError.slice(0, 40) + "…" : upgradeError}</span>}
                                                 {!isWindows && (busyByOther
-                                                    ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                                                    ? <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
                                                     : <span className="wk-rt-upgrade-btn" onClick={this.handleUpgrade}>Upgrade</span>)}
                                             </span>
                                         )
@@ -376,7 +376,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                                     }
                                     if (busyByOther) {
                                         // B-3: 同 daemon 其他升级在跑, 点了 fleet 必拒 — 预防性禁用
-                                        return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                                        return <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
                                     }
                                     if (!anyOnline) return null
                                     return <span className="wk-rt-upgrade-btn" onClick={this.handleUpgrade}>Upgrade</span>
@@ -918,6 +918,10 @@ function isUpgradeInProgress(status: string): boolean {
     return UPGRADE_IN_PROGRESS_STATUSES.has(status)
 }
 
+// busy-disabled title 单源 (6 个按钮共用). 英文 — detail 面板 label 已统一
+// 全英文 (cc R3-4: 同面板 Windows disabled title 也是英文, 语言保持一致).
+const UPGRADE_BUSY_TITLE = "Another upgrade is in progress on this device, please wait"
+
 // 允许远程升级的 provider（和服务端 providerComponents / daemon componentUpgradeSpecs 保持一致）
 const COMPONENT_UPGRADE_ENABLED = new Set<string>(["claude", "codex", "hermes", "openclaw"])
 
@@ -1123,7 +1127,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     {pluginUpgradeStatus === "timeout" ? "Timeout" : "Failed"}
                     {pluginUpgradeError && <span className="wk-rt-upgrade-reason">· {pluginUpgradeError.length > 40 ? pluginUpgradeError.slice(0, 40) + "…" : pluginUpgradeError}</span>}
                     {pluginName === "octo" && (busyByOther
-                        ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                        ? <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
                         : <span className="wk-rt-upgrade-btn" onClick={this.handlePluginUpgrade}>Upgrade</span>)}
                 </span>
             )
@@ -1139,7 +1143,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         if (hasUpdate && pluginName === "octo") {
             if (busyByOther) {
                 // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
-                return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                return <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
             }
             return <span className="wk-rt-upgrade-btn" onClick={this.handlePluginUpgrade}>Upgrade</span>
         }
@@ -1248,7 +1252,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     {componentUpgradeStatus === "timeout" ? "Timeout" : "Failed"}
                     {componentUpgradeError && <span className="wk-rt-upgrade-reason">· {componentUpgradeError.length > 40 ? componentUpgradeError.slice(0, 40) + "…" : componentUpgradeError}</span>}
                     {busyByOther
-                        ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                        ? <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
                         : <span className="wk-rt-upgrade-btn" onClick={this.handleComponentUpgrade}>Upgrade</span>}
                 </span>
             )
@@ -1264,7 +1268,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         if (hasUpdate) {
             if (busyByOther) {
                 // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
-                return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                return <span className="wk-rt-upgrade-btn disabled" title={UPGRADE_BUSY_TITLE}>Upgrade</span>
             }
             return <span className="wk-rt-upgrade-btn" onClick={this.handleComponentUpgrade}>Upgrade</span>
         }
@@ -1446,6 +1450,11 @@ interface RuntimesPageState extends RuntimesState {
     expandedRuntimes: Set<number>
     botsByRuntime: Map<number, Bot[]>
     botsLoading: Set<number>
+    // codex R3-3: botsByRuntime 首次水合标记. 没水合前 (首屏 loadData →
+    // refreshAllBots 在飞) 不能把所有 runtime 按 "0 bot" 渲染成不可展开 —
+    // 回退到旧的 "可展开 + 展开时懒加载" 行为, 水合后才用 "没 bot 不可
+    // 展开" 新逻辑.
+    botsHydrated: boolean
 }
 
 export default class RuntimesPage extends Component<{}, RuntimesPageState> {
@@ -1471,6 +1480,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         expandedRuntimes: new Set<number>(),
         botsByRuntime: new Map<number, Bot[]>(),
         botsLoading: new Set<number>(),
+        botsHydrated: false,
     }
 
     private pollTimer?: ReturnType<typeof setInterval>
@@ -1518,6 +1528,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
             expandedRuntimes: new Set(),
             botsByRuntime: new Map(),
             botsLoading: new Set(),
+            botsHydrated: false,
         })
         WKApp.routeRight.popToRoot()
         this.loadData()
@@ -1645,10 +1656,14 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
             if (isStale()) return
             if (!silent) this.setState({ loading: false })
         } finally {
-            // X7: non-silent 请求被后发 silent 请求淘汰 (isStale 早退) 时,
-            // 没人翻回 loading=false 会卡屏 Loading. 兜底: 本请求是
-            // non-silent 且 loading 仍真 (后续成功响应没翻掉) 时翻 false.
-            if (!silent && this.state.loading) this.setState({ loading: false })
+            // X7 + cc R3-3: loading 兜底归"最新请求"管 — seq 不是最新说明
+            // 有更新的请求在飞, 它的成功/finally 路径会收尾, 本请求不动
+            // (防旧 non-silent 把新 non-silent 刚设的 loading 提前翻掉).
+            // seq 是最新且 loading 还挂着 (e.g. non-silent 被 silent 抢先
+            // 淘汰后 silent 失败) 才兜底翻 false.
+            if (seq === this.loadSeq && this.state.loading) {
+                this.setState({ loading: false })
+            }
         }
     }
 
@@ -1694,9 +1709,18 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     // listBots() 本来就一次返回全 space 的 bot (refreshRuntimeBots 是客户
     // 端过滤), 这里批量按 runtime_id 分组回填 botsByRuntime. 由 loadData
     // 每 15s 调用 — 也顺带让 Level-3 bot 行保持新鲜 (别处创建的 bot 会出现).
+    //
+    // R3 review (cc R3-2 / codex R3-1): refreshAllBots 整 Map 替换跟
+    // refreshRuntimeBots 单 key 合并是双路并发写 — 旧全量响应晚到会覆盖
+    // 新单 key 结果 (e.g. 刚创建 bot 后 handleBotCreated 的单 key 刷新被
+    // 更早起飞的全量覆盖, 新 bot 左树短暂消失). botsSeq 模块级序号统一
+    // 两路: 任一新请求起飞使旧响应作废.
+    private botsSeq = 0
+
     refreshAllBots = async () => {
         const epoch = this.spaceEpoch
-        const isStale = () => this.spaceEpoch !== epoch
+        const seq = ++this.botsSeq
+        const isStale = () => this.spaceEpoch !== epoch || seq !== this.botsSeq
         try {
             const all = await listBots()
             if (isStale()) return
@@ -1713,18 +1737,25 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 for (const rt of prev.runtimes) {
                     if (!next.has(rt.id)) next.set(rt.id, [])
                 }
-                return { botsByRuntime: next }
+                // codex R3-3: 首屏 botsByRuntime 未水合前不能按 "0 bot" 渲染
+                // (所有 runtime 都没箭头, 数据回来箭头才冒出来). hydrated
+                // 标记让 render 在水合前回退到 "可展开 + 懒加载" 旧行为.
+                return { botsByRuntime: next, botsHydrated: true }
             })
         } catch {
-            // 静默: 保留旧 cache, 下轮 15s 再试
+            // 静默: 保留旧 cache (botsHydrated 不动 — 首次失败时维持
+            // 未水合的可展开回退, 不会把全树误判成无 bot), 下轮 15s 再试
         }
     }
 
     refreshRuntimeBots = async (runtimeId: number) => {
         // C9 in-flight guard: 进 epoch 闭包, 响应回来时若 epoch 变过
         // (期间切了 space) 就丢弃, 防旧 space 数据回填.
+        // R3-2/R3-1: botsSeq 跟 refreshAllBots 共用 — 单 key 刷新起飞也
+        // 使在飞的全量响应作废 (双路写 botsByRuntime 的最新 wins).
         const epoch = this.spaceEpoch
-        const isStale = () => this.spaceEpoch !== epoch
+        const seq = ++this.botsSeq
+        const isStale = () => this.spaceEpoch !== epoch || seq !== this.botsSeq
         this.setState((prev) => {
             if (isStale()) return null
             const loading = new Set(prev.botsLoading)
@@ -1965,16 +1996,25 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                     // "该运行时下暂无 Bot + 在此创建" 空态 (创建入口顶栏 +
                                     // 已有). botsByRuntime 由 loadData → refreshAllBots 批量
                                     // 预填 (15s), 不再依赖展开时懒加载.
+                                    //
+                                    // codex R3-3: 首屏水合前 (refreshAllBots 还没回来)
+                                    // botsByRuntime 全空, 不能按 "0 bot" 把全树渲染成不可
+                                    // 展开 — 回退旧 "可展开 + 懒加载" 行为, 水合后才启用
+                                    // 新逻辑. 失败时 botsHydrated 维持 false 同样回退.
                                     const bots = this.state.botsByRuntime.get(rt.id) || []
-                                    const expandable = bots.length > 0
+                                    const expandable = !this.state.botsHydrated || bots.length > 0
                                     const rtExpanded = expandable && this.state.expandedRuntimes.has(rt.id)
+                                    const botsLoading = this.state.botsLoading.has(rt.id)
                                     return (
                                         <div key={rt.id} className="wk-rt-rt-block">
                                             <div
                                                 className={`wk-rt-agent-row ${selectedId === rt.id ? "selected" : ""}`}
-                                                role="button"
-                                                tabIndex={0}
-                                                aria-expanded={rtExpanded}
+                                                // cc R3-5 (a11y): 不可展开行不再播报成可操作的
+                                                // 折叠按钮 — role/tabIndex/aria-expanded 仅在
+                                                // expandable 时给 (此页 a11y 之前 C6 专门修过).
+                                                role={expandable ? "button" : undefined}
+                                                tabIndex={expandable ? 0 : undefined}
+                                                aria-expanded={expandable ? rtExpanded : undefined}
                                                 onClick={() => { if (expandable) this.toggleRuntime(rt.id) }}
                                                 onKeyDown={(e) => {
                                                     if (e.key === "Enter" || e.key === " ") {
@@ -2009,9 +2049,13 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                             </div>
 
                                             {/* Level 3: Bots under this runtime (没 bot 不可展开,
-                                                空态文案 + 在此创建 CTA 已删 — caster 2026-06-12) */}
+                                                空态文案 + 在此创建 CTA 已删 — caster 2026-06-12.
+                                                水合前回退懒加载, 保留加载中指示) */}
                                             {rtExpanded && (
                                                 <div className="wk-rt-bot-rows">
+                                                    {botsLoading && bots.length === 0 && (
+                                                        <div className="wk-rt-bot-loading">加载中…</div>
+                                                    )}
                                                     {bots.map((b) => (
                                                         <BotRow
                                                             key={b.id}

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -155,6 +155,9 @@ interface DeviceDetailProps {
     pingCache: PingCache
     daemonVersionHint?: { has_update?: boolean; latest_version?: string; current?: string }
     activeUpgrade?: ActiveUpgrade
+    // 升级互斥 UX: 同 RuntimeDetailProps.daemonBusy / onUpgradeStarted.
+    daemonBusy?: boolean
+    onUpgradeStarted?: () => void
 }
 
 interface DeviceDetailState {
@@ -234,6 +237,9 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
         try {
             const initRes = await WKApp.apiClient.post("/runtimes/upgrade", { daemon_id: daemonId, space_id: WKApp.shared.currentSpaceId })
             const taskId = initRes.task_id
+            // C-1: task 已创建, 立即让父层重拉 active_upgrades, 其他 detail
+            // 的 daemonBusy ~1s 内生效 (不等 15s 轮询).
+            this.props.onUpgradeStarted?.()
             for (let i = 0; i < 60; i++) {
                 if (isStale()) return
                 await new Promise(r => setTimeout(r, 2000))
@@ -258,8 +264,19 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                                 const groups = groupByDevice(allRuntimes)
                                 const updated = groups.find((g: DeviceGroup) => g.daemonId === daemonId)
                                 if (updated) {
+                                    // B-5 (X3): 自我重渲染同样透传 daemonBusy /
+                                    // onUpgradeStarted, 否则这条路径 remount 的
+                                    // detail 丢互斥 props. 注: 此刻本 daemon 升级
+                                    // 刚完成, busy 取自己 props 当前值 (15s 轮询
+                                    // 链路会在下轮带来准确值).
                                     WKApp.routeRight.replaceToRoot(
-                                        <DeviceDetail group={updated} pingCache={this.props.pingCache} daemonVersionHint={hints[daemonId]} />
+                                        <DeviceDetail
+                                            group={updated}
+                                            pingCache={this.props.pingCache}
+                                            daemonVersionHint={hints[daemonId]}
+                                            daemonBusy={this.props.daemonBusy}
+                                            onUpgradeStarted={this.props.onUpgradeStarted}
+                                        />
                                     )
                                 }
                                 return
@@ -329,19 +346,37 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                                 {this.props.daemonVersionHint?.has_update && (() => {
                                     const isWindows = group.osName?.toLowerCase() === "windows"
                                     const { upgradeStatus, upgradeError } = this.state
-                                    const inProgress = upgradeStatus !== "idle" && upgradeStatus !== "completed" && upgradeStatus !== "failed" && upgradeStatus !== "timeout"
+                                    const inProgress = isUpgradeInProgress(upgradeStatus)
+                                    // busy 且不是自己在升级 → 其他升级在跑, fleet 会拒
+                                    const busyByOther = !!this.props.daemonBusy && !inProgress
 
                                     if (upgradeStatus === "completed") {
                                         return <span className="wk-rt-upgrade-status success"><span className="upgrade-dot" />Upgraded</span>
                                     }
                                     if (upgradeStatus === "failed" || upgradeStatus === "timeout") {
-                                        return <span className="wk-rt-upgrade-status error" title={upgradeError}><span className="upgrade-dot" />Failed</span>
+                                        // A-1: error_msg 内联展示 (原来藏 hover title 像升级真坏了);
+                                        // A-2: 旁挂 Retry, busy 时禁用 (P7/X6 — 互斥拒后 daemon
+                                        // 仍忙, Retry 可点必再撞墙).
+                                        return (
+                                            <span className="wk-rt-upgrade-status error" title={upgradeError}>
+                                                <span className="upgrade-dot" />
+                                                {upgradeStatus === "timeout" ? "Timeout" : "Failed"}
+                                                {upgradeError && <span className="wk-rt-upgrade-reason">· {upgradeError.length > 40 ? upgradeError.slice(0, 40) + "…" : upgradeError}</span>}
+                                                {!isWindows && (busyByOther
+                                                    ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                                                    : <span className="wk-rt-upgrade-btn" onClick={this.handleUpgrade}>Upgrade</span>)}
+                                            </span>
+                                        )
                                     }
                                     if (inProgress) {
                                         return <span className="wk-rt-upgrade-status progress"><span className="upgrade-dot" />{upgradeStatus}...</span>
                                     }
                                     if (isWindows) {
                                         return <span className="wk-rt-upgrade-btn disabled" title="Windows remote upgrade is not supported yet">Upgrade</span>
+                                    }
+                                    if (busyByOther) {
+                                        // B-3: 同 daemon 其他升级在跑, 点了 fleet 必拒 — 预防性禁用
+                                        return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
                                     }
                                     if (!anyOnline) return null
                                     return <span className="wk-rt-upgrade-btn" onClick={this.handleUpgrade}>Upgrade</span>
@@ -853,6 +888,14 @@ interface RuntimeDetailProps {
     componentActiveUpgrade?: ActiveUpgrade
     onDelete: (id: number) => void
     onAgentsChanged?: () => void
+    // 升级互斥 UX (plan-upgrade-mutex-ux §2.B): 该 runtime 所属 daemon 是否
+    // 有任一 in-progress 升级 task (无论 component). fleet insertUpgradeTask
+    // 同 daemon 互斥 (upgrade.go:359), busy 时其他 Upgrade 按钮必失败 —
+    // 禁用 + title 预防, 替代点了才报错.
+    daemonBusy?: boolean
+    // §2.C: POST /runtimes/upgrade 成功后通知父层立即 silent loadData,
+    // 让其他已打开 detail 的 daemonBusy 在 ~1s 内更新 (不等 15s 轮询).
+    onUpgradeStarted?: () => void
     // UI/UX review #375 follow-up (P1-3): RuntimeDetail 详情页信息密度
     // 低 (只 Runtime Mode / Provider / Version / Octo Plugin). 父侧
     // RuntimesPage 持有 botsByRuntime cache, 把"已绑定 Bot 数" prop 注入
@@ -861,7 +904,19 @@ interface RuntimeDetailProps {
     botCount?: number
 }
 
-type PluginUpgradeStatus = "idle" | "pending" | "dispatched" | "installing" | "completed" | "failed" | "timeout"
+type PluginUpgradeStatus = "idle" | "pending" | "dispatched" | "downloading" | "installing" | "restarting" | "completed" | "failed" | "timeout"
+
+// in-progress 状态全集 — 必须跟 fleet upgrade.go:401 互斥判定集合严格一致
+// (5 态). web 早期只枚举 pending/dispatched/installing 三态, 漏 downloading/
+// restarting — daemon 升级走 downloading→installing→restarting, 漏态期间
+// busyDaemons 误判不忙 (plan-upgrade-mutex-ux P2).
+const UPGRADE_IN_PROGRESS_STATUSES = new Set<string>([
+    "pending", "dispatched", "downloading", "installing", "restarting",
+])
+
+function isUpgradeInProgress(status: string): boolean {
+    return UPGRADE_IN_PROGRESS_STATUSES.has(status)
+}
 
 // 允许远程升级的 provider（和服务端 providerComponents / daemon componentUpgradeSpecs 保持一致）
 const COMPONENT_UPGRADE_ENABLED = new Set<string>(["claude", "codex", "hermes", "openclaw"])
@@ -897,11 +952,11 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         // 停留在 installing/dispatched 永不更新，用户要切页面才能跳出。
         const { pluginUpgradeStatus, componentUpgradeStatus } = this.state
         const pluginUpg = this.props.pluginActiveUpgrade
-        if (pluginUpg?.task_id && (pluginUpgradeStatus === "pending" || pluginUpgradeStatus === "dispatched" || pluginUpgradeStatus === "installing")) {
+        if (pluginUpg?.task_id && isUpgradeInProgress(pluginUpgradeStatus)) {
             this.pollPluginUpgrade(pluginUpg.task_id, this.props.runtime.id)
         }
         const compUpg = this.props.componentActiveUpgrade
-        if (compUpg?.task_id && (componentUpgradeStatus === "pending" || componentUpgradeStatus === "dispatched" || componentUpgradeStatus === "installing")) {
+        if (compUpg?.task_id && isUpgradeInProgress(componentUpgradeStatus)) {
             this.pollComponentUpgrade(compUpg.task_id, this.props.runtime.id)
         }
     }
@@ -983,6 +1038,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                 space_id: WKApp.shared.currentSpaceId,
                 component: "octo",
             })
+            // C-1: 立即让父层重拉 active_upgrades (见 RuntimeDetailProps 注释)
+            this.props.onUpgradeStarted?.()
             await this.pollPluginUpgrade(initRes.task_id, runtimeId)
         } catch (err: any) {
             const msg = err?.msg || err?.message || "upgrade failed"
@@ -1020,6 +1077,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                             const allRuntimes = runtimesRes?.runtimes || []
                             const updated = allRuntimes.find((r: AgentRuntime) => r.id === runtimeId)
                             if (updated) {
+                                // B-5 (X3): 透传互斥 props, 同 DeviceDetail 注释
                                 WKApp.routeRight.replaceToRoot(
                                     <RuntimeDetail
                                         runtime={updated}
@@ -1028,6 +1086,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                         componentActiveUpgrade={this.props.componentActiveUpgrade}
                                         onDelete={this.props.onDelete}
                                         botCount={this.props.botCount}
+                                        daemonBusy={this.props.daemonBusy}
+                                        onUpgradeStarted={this.props.onUpgradeStarted}
                                     />
                                 )
                             }
@@ -1048,14 +1108,23 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
 
     renderPluginUpgradeBtn(pluginName: string, hasUpdate: boolean | undefined) {
         const { pluginUpgradeStatus, pluginUpgradeError } = this.state
+        // busy 来源是否本按钮自己的 task — 自己升级显示进度态; 别的 task
+        // 在跑则本按钮 busy-disabled (按钮粒度豁免, plan §2.B-3 / X4).
+        const selfInProgress = isUpgradeInProgress(pluginUpgradeStatus)
+        const busyByOther = !!this.props.daemonBusy && !selfInProgress
         if (pluginUpgradeStatus === "completed") {
             return <span className="wk-rt-upgrade-status success"><span className="upgrade-dot" />Completed</span>
         }
         if (pluginUpgradeStatus === "failed" || pluginUpgradeStatus === "timeout") {
+            // A-1 错误内联 + A-2 Retry (busy 时禁用 — P7/X6)
             return (
                 <span className="wk-rt-upgrade-status error" title={pluginUpgradeError}>
                     <span className="upgrade-dot" />
                     {pluginUpgradeStatus === "timeout" ? "Timeout" : "Failed"}
+                    {pluginUpgradeError && <span className="wk-rt-upgrade-reason">· {pluginUpgradeError.length > 40 ? pluginUpgradeError.slice(0, 40) + "…" : pluginUpgradeError}</span>}
+                    {pluginName === "octo" && (busyByOther
+                        ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                        : <span className="wk-rt-upgrade-btn" onClick={this.handlePluginUpgrade}>Upgrade</span>)}
                 </span>
             )
         }
@@ -1068,6 +1137,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             )
         }
         if (hasUpdate && pluginName === "octo") {
+            if (busyByOther) {
+                // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
+                return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+            }
             return <span className="wk-rt-upgrade-btn" onClick={this.handlePluginUpgrade}>Upgrade</span>
         }
         return null
@@ -1088,6 +1161,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                 space_id: WKApp.shared.currentSpaceId,
                 component,
             })
+            // C-1: 立即让父层重拉 active_upgrades (见 RuntimeDetailProps 注释)
+            this.props.onUpgradeStarted?.()
             await this.pollComponentUpgrade(initRes.task_id, runtimeId)
         } catch (err: any) {
             const msg = err?.msg || err?.message || "upgrade failed"
@@ -1125,6 +1200,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                             const allRuntimes = runtimesRes?.runtimes || []
                             const updated = allRuntimes.find((r: AgentRuntime) => r.id === runtimeId)
                             if (updated) {
+                                // B-5 (X3): 透传互斥 props, 同 DeviceDetail 注释
                                 WKApp.routeRight.replaceToRoot(
                                     <RuntimeDetail
                                         runtime={updated}
@@ -1133,6 +1209,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                         componentActiveUpgrade={this.props.componentActiveUpgrade}
                                         onDelete={this.props.onDelete}
                                         botCount={this.props.botCount}
+                                        daemonBusy={this.props.daemonBusy}
+                                        onUpgradeStarted={this.props.onUpgradeStarted}
                                     />
                                 )
                             }
@@ -1156,14 +1234,22 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         if (!COMPONENT_UPGRADE_ENABLED.has(rt.provider)) return null
 
         const { componentUpgradeStatus, componentUpgradeError } = this.state
+        // 同 renderPluginUpgradeBtn: 按钮粒度豁免 (plan §2.B-3 / X4)
+        const selfInProgress = isUpgradeInProgress(componentUpgradeStatus)
+        const busyByOther = !!this.props.daemonBusy && !selfInProgress
         if (componentUpgradeStatus === "completed") {
             return <span className="wk-rt-upgrade-status success"><span className="upgrade-dot" />Completed</span>
         }
         if (componentUpgradeStatus === "failed" || componentUpgradeStatus === "timeout") {
+            // A-1 错误内联 + A-2 Retry (busy 时禁用 — P7/X6)
             return (
                 <span className="wk-rt-upgrade-status error" title={componentUpgradeError}>
                     <span className="upgrade-dot" />
                     {componentUpgradeStatus === "timeout" ? "Timeout" : "Failed"}
+                    {componentUpgradeError && <span className="wk-rt-upgrade-reason">· {componentUpgradeError.length > 40 ? componentUpgradeError.slice(0, 40) + "…" : componentUpgradeError}</span>}
+                    {busyByOther
+                        ? <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+                        : <span className="wk-rt-upgrade-btn" onClick={this.handleComponentUpgrade}>Upgrade</span>}
                 </span>
             )
         }
@@ -1176,6 +1262,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             )
         }
         if (hasUpdate) {
+            if (busyByOther) {
+                // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
+                return <span className="wk-rt-upgrade-btn disabled" title="同设备已有升级进行中, 请稍候">Upgrade</span>
+            }
             return <span className="wk-rt-upgrade-btn" onClick={this.handleComponentUpgrade}>Upgrade</span>
         }
         return null
@@ -1457,12 +1547,21 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         document.removeEventListener("keydown", this.handleGlobalKeyDown)
     }
 
+    // C-2 (plan-upgrade-mutex-ux X1): 同 space 请求序号. onUpgradeStarted
+    // 立即 loadData 跟 15s 定时轮询并发时, 旧响应晚到会覆盖新 activeUpgrades
+    // (busyDaemons 短暂清空 → 按钮闪烁可点). 序号比 epoch 细一级: epoch
+    // 隔离跨 space, seq 隔离同 space 多请求.
+    private loadSeq = 0
+
     async loadData(silent = false) {
         // C9 in-flight guard: 切 space 时 epoch++, 旧 space 在飞的
         // /runtimes 响应回来时若 epoch 变了就丢弃, 防旧 space runtimes /
         // versionHints / activeUpgrades 回填到新 space.
+        // C-2: seq 一并入 isStale 闭包, 覆盖全部三个检查点 (await 后 /
+        // setState updater 内 / setState callback 内).
         const epoch = this.spaceEpoch
-        const isStale = () => this.spaceEpoch !== epoch
+        const seq = ++this.loadSeq
+        const isStale = () => this.spaceEpoch !== epoch || seq !== this.loadSeq
         if (!silent) this.setState({ loading: true })
         try {
             const spaceId = WKApp.shared.currentSpaceId
@@ -1511,6 +1610,9 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 },
                 () => {
                     if (isStale()) return
+                    // 左树 Level-3 需要每个 runtime 的 bot 数判断"能否展开"
+                    // (没 bot 不可展开) — 批量回填 botsByRuntime.
+                    this.refreshAllBots()
                     // 放 callback 里：保证 showAgentDetail / showDeviceDetail 里读到的
                     // this.state.activeUpgrades 是本轮刚拉到的，而不是 setState 之前的快照
                     if (silent && WKApp.route.currentPath === "/runtimes") {
@@ -1522,7 +1624,14 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                 this.setState({ selectedId: null })
                                 WKApp.routeRight.popToRoot()
                             }
-                        } else if (this.selectedDaemonId && activeUpgrades[`${this.selectedDaemonId}:octo-daemon`]) {
+                        } else if (this.selectedDaemonId) {
+                            // B-4 (P1/X2): 原条件还要求 activeUpgrades 里有
+                            // `${daemonId}:octo-daemon` — 只覆盖 daemon 自身
+                            // 升级, component/plugin 升级引起的 daemonBusy
+                            // 变化 (出现和消失两个方向) 推不到已打开的
+                            // DeviceDetail. 放宽为打开着就重渲染, 跟上面
+                            // RuntimeDetail 分支对齐. replaceToRoot 幂等,
+                            // 15s 一次成本可忽略.
                             const groups = groupByDevice(runtimes)
                             const updated = groups.find(g => g.daemonId === this.selectedDaemonId)
                             if (updated) {
@@ -1535,6 +1644,11 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         } catch {
             if (isStale()) return
             if (!silent) this.setState({ loading: false })
+        } finally {
+            // X7: non-silent 请求被后发 silent 请求淘汰 (isStale 早退) 时,
+            // 没人翻回 loading=false 会卡屏 Loading. 兜底: 本请求是
+            // non-silent 且 loading 仍真 (后续成功响应没翻掉) 时翻 false.
+            if (!silent && this.state.loading) this.setState({ loading: false })
         }
     }
 
@@ -1573,6 +1687,37 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         }, () => {
             if (needFirstLoad) this.refreshRuntimeBots(runtimeId)
         })
+    }
+
+    // caster 2026-06-12: 左树 Level-3 空态简化 — "没 bot 的 runtime 不能
+    // 展开" 需要预先知道每个 runtime 的 bot 数 (原来是展开时懒加载).
+    // listBots() 本来就一次返回全 space 的 bot (refreshRuntimeBots 是客户
+    // 端过滤), 这里批量按 runtime_id 分组回填 botsByRuntime. 由 loadData
+    // 每 15s 调用 — 也顺带让 Level-3 bot 行保持新鲜 (别处创建的 bot 会出现).
+    refreshAllBots = async () => {
+        const epoch = this.spaceEpoch
+        const isStale = () => this.spaceEpoch !== epoch
+        try {
+            const all = await listBots()
+            if (isStale()) return
+            this.setState((prev) => {
+                if (isStale()) return null
+                const next = new Map<number, Bot[]>()
+                for (const b of all) {
+                    const arr = next.get(b.runtime_id)
+                    if (arr) arr.push(b)
+                    else next.set(b.runtime_id, [b])
+                }
+                // 没 bot 的 runtime 也写空数组 — 区分 "已加载, 0 个" 跟
+                // "没加载过" (后者不再出现, 但 Map.get undefined 兜底仍在).
+                for (const rt of prev.runtimes) {
+                    if (!next.has(rt.id)) next.set(rt.id, [])
+                }
+                return { botsByRuntime: next }
+            })
+        } catch {
+            // 静默: 保留旧 cache, 下轮 15s 再试
+        }
     }
 
     refreshRuntimeBots = async (runtimeId: number) => {
@@ -1624,6 +1769,21 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         }
     }
 
+    // B-1/B-2 (plan-upgrade-mutex-ux): 该 daemon 是否有任一 in-progress
+    // 升级 task (无论 component). 集合语义跟 fleet insertUpgradeTask 互斥
+    // 判定一致 — busy 时同 daemon 其他 Upgrade 必被 fleet 拒.
+    private isDaemonBusy = (daemonId: string): boolean => {
+        return Object.values(this.state.activeUpgrades).some(
+            u => u.daemon_id === daemonId && isUpgradeInProgress(u.status)
+        )
+    }
+
+    // C-1: detail 页 POST /runtimes/upgrade 成功后立即 silent 重拉, 让
+    // busyDaemons ~1s 内更新到所有打开的 detail (不等 15s 轮询). silent
+    // 必须 true — loadData 的 re-replaceToRoot callback 只在 silent 分支
+    // 执行, false 还会闪 loading.
+    private handleUpgradeStarted = () => { this.loadData(true) }
+
     showDeviceDetail = (group: DeviceGroup) => {
         this.setState({ selectedId: null })
         this.selectedDaemonId = group.daemonId
@@ -1633,6 +1793,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 pingCache={this.pingCache}
                 daemonVersionHint={this.state.daemonVersionHints[group.daemonId]}
                 activeUpgrade={this.state.activeUpgrades[`${group.daemonId}:octo-daemon`]}
+                daemonBusy={this.isDaemonBusy(group.daemonId)}
+                onUpgradeStarted={this.handleUpgradeStarted}
             />
         )
     }
@@ -1658,6 +1820,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 pluginActiveUpgrade={pluginUpgrade}
                 componentActiveUpgrade={componentUpgrade}
                 botCount={cachedBots?.length ?? 0}
+                daemonBusy={this.isDaemonBusy(rt.daemon_id)}
+                onUpgradeStarted={this.handleUpgradeStarted}
                 onDelete={() => {
                     this.setState({ selectedId: null })
                     WKApp.routeRight.popToRoot()
@@ -1672,14 +1836,10 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         const { runtimes, selectedId, loading, expandedDevices, createMenuOpen, runtimeModalOpen } = this.state
         const groups = groupByDevice(runtimes)
         // P1 follow-up (UI/UX review): "M online" 含义重定义 — 不再是
-        // runtime.status='online' 的 runtime 数 (实务上一个 daemon 4 个
-        // runtime 几乎同时上下线, 单算 runtime 在线粒度太细). 现在表达
-        // "活着的 daemon 下提供的 runtime 总数" — daemon 活 (任一 runtime
-        // 在线) 就把它的 4 个 runtime 全计入. 跟左树展开后看到的"槽位"
-        // 数对得上.
-        const totalOnline = groups
-            .filter(g => g.onlineCount > 0)
-            .reduce((sum, g) => sum + g.runtimes.length, 0)
+        // 顶部计数纯报"装置-运行时"槽位规模, 不报死活. 单 runtime 死活
+        // 由 DeviceDetail 右上角 "X/Y Online" 表达; 顶栏只回答 "我有几个
+        // device, 加起来几个 runtime", 跟左树展开后的总条数一致.
+        const totalRuntimes = groups.reduce((sum, g) => sum + g.runtimes.length, 0)
 
         return (
             <div className="wk-rt-list">
@@ -1693,8 +1853,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                     <div className="wk-rt-pagetitle">
                         <h2 className="wk-rt-pagetitle-text">运行时</h2>
                         <span className="wk-rt-pageheader__meta" aria-live="polite">
-                            <span className={`wk-rt-meta-dot${totalOnline > 0 ? " is-online" : ""}`} aria-hidden="true" />
-                            {totalOnline} online · {groups.length} device{groups.length !== 1 ? "s" : ""}
+                            {groups.length} device{groups.length !== 1 ? "s" : ""} · {totalRuntimes} runtime{totalRuntimes !== 1 ? "s" : ""}
                         </span>
                         <div className="wk-rt-create-wrap">
                             <button
@@ -1793,19 +1952,22 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                         className="wk-rt-device-info"
                                         onClick={(e) => { e.stopPropagation(); this.showDeviceDetail(group) }}
                                     >
+                                        {/* caster 2026-06-12: 删 "N 个运行时" 副标题 — 顶栏已有
+                                            "N devices · M runtimes" 计数, device 行重复显示噪音 */}
                                         <div className="wk-rt-device-name">{group.deviceName}</div>
-                                        <div className="wk-rt-device-sub">
-                                            {group.runtimes.length} 个运行时
-                                        </div>
                                     </div>
                                     <div className={`wk-rt-status-dot ${anyOnline ? "online" : "offline"}`} />
                                 </div>
 
                                 {/* Level 2: Agents (runtime kind) */}
                                 {expanded && group.runtimes.map((rt) => {
-                                    const rtExpanded = this.state.expandedRuntimes.has(rt.id)
+                                    // caster 2026-06-12: 没 bot 的 runtime 不可展开 — 删掉
+                                    // "该运行时下暂无 Bot + 在此创建" 空态 (创建入口顶栏 +
+                                    // 已有). botsByRuntime 由 loadData → refreshAllBots 批量
+                                    // 预填 (15s), 不再依赖展开时懒加载.
                                     const bots = this.state.botsByRuntime.get(rt.id) || []
-                                    const botsLoading = this.state.botsLoading.has(rt.id)
+                                    const expandable = bots.length > 0
+                                    const rtExpanded = expandable && this.state.expandedRuntimes.has(rt.id)
                                     return (
                                         <div key={rt.id} className="wk-rt-rt-block">
                                             <div
@@ -1813,15 +1975,18 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                                 role="button"
                                                 tabIndex={0}
                                                 aria-expanded={rtExpanded}
-                                                onClick={() => this.toggleRuntime(rt.id)}
+                                                onClick={() => { if (expandable) this.toggleRuntime(rt.id) }}
                                                 onKeyDown={(e) => {
                                                     if (e.key === "Enter" || e.key === " ") {
                                                         e.preventDefault()
-                                                        this.toggleRuntime(rt.id)
+                                                        if (expandable) this.toggleRuntime(rt.id)
                                                     }
                                                 }}
                                             >
-                                                <span className={`wk-rt-expand-arrow ${rtExpanded ? "expanded" : ""}`}>&#9654;</span>
+                                                {/* 没 bot 时不渲染箭头, 占位保持缩进对齐 */}
+                                                {expandable
+                                                    ? <span className={`wk-rt-expand-arrow ${rtExpanded ? "expanded" : ""}`}>&#9654;</span>
+                                                    : <span className="wk-rt-expand-arrow placeholder" aria-hidden="true" />}
                                                 <div
                                                     className="wk-rt-provider-icon small"
                                                     style={{ background: providerColors[rt.provider] || "#6B7280" }}
@@ -1843,25 +2008,10 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                                     探活. caster 拍的去重. */}
                                             </div>
 
-                                            {/* Level 3: Bots under this runtime */}
+                                            {/* Level 3: Bots under this runtime (没 bot 不可展开,
+                                                空态文案 + 在此创建 CTA 已删 — caster 2026-06-12) */}
                                             {rtExpanded && (
                                                 <div className="wk-rt-bot-rows">
-                                                    {botsLoading && bots.length === 0 && (
-                                                        <div className="wk-rt-bot-empty">加载中…</div>
-                                                    )}
-                                                    {!botsLoading && bots.length === 0 && (
-                                                        <div className="wk-rt-bot-empty">
-                                                            <span>该运行时下暂无 Bot</span>
-                                                            <button
-                                                                type="button"
-                                                                className="wk-rt-bot-empty__cta"
-                                                                onClick={(e) => {
-                                                                    e.stopPropagation()
-                                                                    this.botsTabRef.current?.openCreate({ preselectRuntimeId: rt.id })
-                                                                }}
-                                                            >+ 在此创建</button>
-                                                        </div>
-                                                    )}
                                                     {bots.map((b) => (
                                                         <BotRow
                                                             key={b.id}

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -278,68 +278,67 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
     resumeUpgradePoll = async (taskId: string) => {
         const daemonId = this.props.group.daemonId
         const isStale = () => this._unmounted || this.props.group.daemonId !== daemonId
-        try {
-            for (let i = 0; i < 60; i++) {
-                if (isStale()) return
+        for (let i = 0; i < 60; i++) {
+            if (isStale()) return
+            await new Promise(r => setTimeout(r, 2000))
+            if (isStale()) return
+            let res: any
+            try {
+                // R5-2: 单次容错 — 跟 RuntimeDetail pollPluginUpgrade 对齐,
+                // 瞬时网络抖动 continue 重试而不是终止整条轮询协程.
+                res = await WKApp.apiClient.get(`/runtimes/upgrade/${taskId}`)
+            } catch {
+                continue
+            }
+            if (isStale()) return
+            this.setState({ upgradeStatus: res.status })
+            if (res.status === "completed") {
+                this.setState({ upgradeStatus: "completed" })
+                // 方案 3 (升级状态不刷新修复): 原 8s 固定等待砍到 2s —
+                // 后面的确认循环本身已有 2s×10 重试, 足够覆盖 daemon
+                // detect 上报延迟, 固定 8s 只是让 UI 终态白等.
                 await new Promise(r => setTimeout(r, 2000))
                 if (isStale()) return
-                const res = await WKApp.apiClient.get(`/runtimes/upgrade/${taskId}`)
-                if (isStale()) return
-                this.setState({ upgradeStatus: res.status })
-                if (res.status === "completed") {
-                    this.setState({ upgradeStatus: "completed" })
-                    // 方案 3 (升级状态不刷新修复): 原 8s 固定等待砍到 2s —
-                    // 后面的确认循环本身已有 2s×10 重试, 足够覆盖 daemon
-                    // detect 上报延迟, 固定 8s 只是让 UI 终态白等.
+                for (let j = 0; j < 10; j++) {
+                    if (isStale()) return
                     await new Promise(r => setTimeout(r, 2000))
                     if (isStale()) return
-                    for (let j = 0; j < 10; j++) {
+                    try {
+                        const runtimesRes = await WKApp.apiClient.get("/runtimes", { param: { space_id: WKApp.shared.currentSpaceId } })
                         if (isStale()) return
-                        await new Promise(r => setTimeout(r, 2000))
-                        if (isStale()) return
-                        try {
-                            const runtimesRes = await WKApp.apiClient.get("/runtimes", { param: { space_id: WKApp.shared.currentSpaceId } })
-                            if (isStale()) return
-                            const hints = runtimesRes?.daemon_version_hints || {}
-                            if (!hints[daemonId]?.has_update) {
-                                const allRuntimes = runtimesRes?.runtimes || []
-                                const groups = groupByDevice(allRuntimes)
-                                const updated = groups.find((g: DeviceGroup) => g.daemonId === daemonId)
-                                if (updated) {
-                                    // B-5 (X3): 自我重渲染同样透传 daemonBusy /
-                                    // onUpgradeStarted, 否则这条路径 remount 的
-                                    // detail 丢互斥 props. 注: 此刻本 daemon 升级
-                                    // 刚完成, busy 取自己 props 当前值 (15s 轮询
-                                    // 链路会在下轮带来准确值).
-                                    WKApp.routeRight.replaceToRoot(
-                                        <DeviceDetail
-                                            group={updated}
-                                            pingCache={this.props.pingCache}
-                                            daemonVersionHint={hints[daemonId]}
-                                            daemonBusy={this.props.daemonBusy}
-                                            onUpgradeStarted={this.props.onUpgradeStarted}
-                                        />
-                                    )
-                                }
-                                return
+                        const hints = runtimesRes?.daemon_version_hints || {}
+                        if (!hints[daemonId]?.has_update) {
+                            const allRuntimes = runtimesRes?.runtimes || []
+                            const groups = groupByDevice(allRuntimes)
+                            const updated = groups.find((g: DeviceGroup) => g.daemonId === daemonId)
+                            if (updated) {
+                                // B-5 (X3): 自我重渲染同样透传 daemonBusy /
+                                // onUpgradeStarted, 否则这条路径 remount 的
+                                // detail 丢互斥 props. 注: 此刻本 daemon 升级
+                                // 刚完成, busy 取自己 props 当前值 (15s 轮询
+                                // 链路会在下轮带来准确值).
+                                WKApp.routeRight.replaceToRoot(
+                                    <DeviceDetail
+                                        group={updated}
+                                        pingCache={this.props.pingCache}
+                                        daemonVersionHint={hints[daemonId]}
+                                        daemonBusy={this.props.daemonBusy}
+                                        onUpgradeStarted={this.props.onUpgradeStarted}
+                                    />
+                                )
                             }
-                        } catch {}
-                    }
-                    return
+                            return
+                        }
+                    } catch {}
                 }
-                if (res.status === "failed" || res.status === "timeout") {
-                    this.setState({ upgradeError: res.error_msg || res.status })
-                    return
-                }
+                return
             }
-            this.setState({ upgradeStatus: "timeout", upgradeError: "polling timeout" })
-        } catch (err: any) {
-            // resumeUpgradePoll 自身的网络/解析异常: 不标 failed (任务可能
-            // 还在跑), 留给页面级轮询兜底纠正.
-            if (!isStale()) {
-                this.setState({ upgradeError: err?.msg || err?.message || "" })
+            if (res.status === "failed" || res.status === "timeout") {
+                this.setState({ upgradeError: res.error_msg || res.status })
+                return
             }
         }
+        this.setState({ upgradeStatus: "timeout", upgradeError: "polling timeout" })
     }
 
     render() {
@@ -1799,12 +1798,14 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     // 更早起飞的全量覆盖, 新 bot 左树短暂消失). botsSeq 模块级序号统一
     // 两路: 任一新请求起飞使旧响应作废.
     private botsSeq = 0
-    // R4-2 (cc + codex round 4): refreshAllBots 自带 15s 节流 — 升级期间
+    // R4-2 (cc + codex round 4): refreshAllBots 自带节流 — 升级期间
     // loadData 降到 3s 档时, bot 数据跟升级无关, 不该连带 5 倍 listBots.
+    // R5-1: 阈值取 0.8× 轮询间隔 (12s) 而不是打平 15s — 打平时 15s tick
+    // 到达常差几十 ms 不满阈值被跳过, 空闲态退化成 ~30s 隔轮生效.
     private lastAllBotsAt = 0
 
-    refreshAllBots = async (force = false) => {
-        if (!force && Date.now() - this.lastAllBotsAt < POLL_IDLE_MS) return
+    refreshAllBots = async () => {
+        if (Date.now() - this.lastAllBotsAt < POLL_IDLE_MS * 0.8) return
         const epoch = this.spaceEpoch
         const seq = ++this.botsSeq
         const isStale = () => this.spaceEpoch !== epoch || seq !== this.botsSeq

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -249,7 +249,10 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                 this.setState({ upgradeStatus: res.status })
                 if (res.status === "completed") {
                     this.setState({ upgradeStatus: "completed" })
-                    await new Promise(r => setTimeout(r, 8000))
+                    // 方案 3 (升级状态不刷新修复): 原 8s 固定等待砍到 2s —
+                    // 后面的确认循环本身已有 2s×10 重试, 足够覆盖 daemon
+                    // detect 上报延迟, 固定 8s 只是让 UI 终态白等.
+                    await new Promise(r => setTimeout(r, 2000))
                     if (isStale()) return
                     for (let j = 0; j < 10; j++) {
                         if (isStale()) return
@@ -922,6 +925,11 @@ function isUpgradeInProgress(status: string): boolean {
 // 全英文 (cc R3-4: 同面板 Windows disabled title 也是英文, 语言保持一致).
 const UPGRADE_BUSY_TITLE = "Another upgrade is in progress on this device, please wait"
 
+// 页面级轮询两档间隔: 空闲 15s; 有 in-progress 升级任务时 3s (升级状态
+// 不刷新修复方案 2 — 详见 RuntimesPage.adjustPollInterval 注释).
+const POLL_IDLE_MS = 15000
+const POLL_UPGRADE_MS = 3000
+
 // 允许远程升级的 provider（和服务端 providerComponents / daemon componentUpgradeSpecs 保持一致）
 const COMPONENT_UPGRADE_ENABLED = new Set<string>(["claude", "codex", "hermes", "openclaw"])
 
@@ -1067,7 +1075,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             if (isStale()) return
             this.setState({ pluginUpgradeStatus: res.status, pluginUpgradeError: res.error_msg || "" })
             if (res.status === "completed") {
-                await new Promise(r => setTimeout(r, 8000))
+                // 方案 3 (升级状态不刷新修复): 原 8s 固定等待砍到 2s — 后面的确认
+                // 循环本身已有 2s×10 重试, 足够覆盖 daemon detect 上报延迟,
+                // 固定 8s 只是让 UI 终态白等.
+                await new Promise(r => setTimeout(r, 2000))
                 if (isStale()) return
                 for (let j = 0; j < 10; j++) {
                     if (isStale()) return
@@ -1190,7 +1201,10 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             this.setState({ componentUpgradeStatus: res.status, componentUpgradeError: res.error_msg || "" })
             if (res.status === "completed") {
                 // 服务端关单（register 匹配新版本）后再刷一次 runtimes 拿最新 version_hints
-                await new Promise(r => setTimeout(r, 8000))
+                // 方案 3 (升级状态不刷新修复): 原 8s 固定等待砍到 2s — 后面的确认
+                // 循环本身已有 2s×10 重试, 足够覆盖 daemon detect 上报延迟,
+                // 固定 8s 只是让 UI 终态白等.
+                await new Promise(r => setTimeout(r, 2000))
                 if (isStale()) return
                 for (let j = 0; j < 10; j++) {
                     if (isStale()) return
@@ -1547,7 +1561,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
 
     componentDidMount() {
         this.loadData()
-        this.pollTimer = setInterval(() => this.loadData(true), 15000)
+        this.startPollTimer(POLL_IDLE_MS)
         WKApp.mittBus.on("space-changed", this.handleSpaceChanged)
         document.addEventListener("keydown", this.handleGlobalKeyDown)
     }
@@ -1556,6 +1570,28 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         if (this.pollTimer) clearInterval(this.pollTimer)
         WKApp.mittBus.off("space-changed", this.handleSpaceChanged)
         document.removeEventListener("keydown", this.handleGlobalKeyDown)
+    }
+
+    // 升级期间临时加速兜底轮询 (runtime页升级状态不刷新 修复方案 2):
+    // pollPluginUpgrade/pollComponentUpgrade 协程寄生在 detail 组件实例上
+    // (isStale = unmounted || runtime.id 变), 分钟级升级期间用户切走节点
+    // 协程就死 — 只剩页面级轮询兜底. 15s 间隔让"升级完成→页面终态"最坏
+    // ~20s+, 体感是"一直不刷新". 有 in-progress 升级任务时把页面级轮询
+    // 降到 3s, 全部终态后恢复 15s — 兜底不再依赖组件实例协程死活.
+    // 间隔切换只在档位翻转时重建 timer (防每 tick 重建).
+    private currentPollMs = POLL_IDLE_MS
+
+    private startPollTimer(ms: number) {
+        if (this.pollTimer) clearInterval(this.pollTimer)
+        this.currentPollMs = ms
+        this.pollTimer = setInterval(() => this.loadData(true), ms)
+    }
+
+    private adjustPollInterval() {
+        const anyInProgress = Object.values(this.state.activeUpgrades)
+            .some(u => isUpgradeInProgress(u.status))
+        const want = anyInProgress ? POLL_UPGRADE_MS : POLL_IDLE_MS
+        if (want !== this.currentPollMs) this.startPollTimer(want)
     }
 
     // C-2 (plan-upgrade-mutex-ux X1): 同 space 请求序号. onUpgradeStarted
@@ -1624,6 +1660,8 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                     // 左树 Level-3 需要每个 runtime 的 bot 数判断"能否展开"
                     // (没 bot 不可展开) — 批量回填 botsByRuntime.
                     this.refreshAllBots()
+                    // 升级期间临时加速轮询 (15s ↔ 3s 两档, 见 adjustPollInterval)
+                    this.adjustPollInterval()
                     // 放 callback 里：保证 showAgentDetail / showDeviceDetail 里读到的
                     // this.state.activeUpgrades 是本轮刚拉到的，而不是 setState 之前的快照
                     if (silent && WKApp.route.currentPath === "/runtimes") {


### PR DESCRIPTION
## 背景 (3 个 caster 实测问题)

1. **连点两个 Upgrade 红 Failed 误导**: fleet 同 daemon 升级互斥 (`upgrade.go:359`, v3.3.1 §C.3 per-tenant 并发预算) 拒绝第二个请求, web 只渲染红 "Failed", error_msg 藏 hover title — 看起来像升级真坏了, 且本地 failed 态永不清除 (task 不进 active_upgrades, syncUpgradeStateFromProp 双 undefined early-return)
2. **升级完成页面卡 installing 不自动刷新**: 升级轮询协程寄生 detail 组件实例, 分钟级升级期间切走节点协程即死, 只剩 15s 兜底; completed 后还有固定 8s 白等
3. **左树信息冗余**: device 行 "N 个运行时" 副标题与顶栏计数重复; 空 runtime 的 "暂无 Bot + 在此创建" 空态噪音

## 改动 (web-only, 不动 fleet 互斥)

### A. Failed 态修复
- error_msg 内联展示 (截断 40 字符 + title 全文), 不再藏 hover
- failed/timeout 旁保留 Retry 按钮; **Retry 同样套 busy 规则** (daemonBusy 时禁用, 防互斥拒后立刻再撞墙)

### B. busyDaemons 预防性禁用
- `UPGRADE_IN_PROGRESS_STATUSES` 用 fleet 互斥判定全集 5 态 (补 web 原 3 态缺 downloading/restarting 的缺口)
- RuntimeDetail/DeviceDetail 加 `daemonBusy` prop; 豁免按**按钮粒度** (自己的 task 显示进度态, 其他同 daemon 按钮禁用 + title)
- 已打开 DeviceDetail 的 re-render 条件放宽 (原只覆盖 daemon 自身升级, component/plugin 升级的 busy 变化推不到)
- 3 处升级轮询自我 replaceToRoot 补透传互斥 props

### C. 即时同步
- POST 成功后 `onUpgradeStarted` → 父层立即 silent loadData, 其他 detail busy ~1s 生效
- `loadSeq` 请求序号并入 isStale 闭包 (三检查点), 防旧响应覆盖新 busyDaemons

### 升级状态自动刷新 (问题 2)
- **自适应轮询**: activeUpgrades 有 in-progress 时页面级轮询 15s→3s, 全终态恢复 — 兜底不再依赖组件实例协程死活
- completed 后固定 8s 等待砍 2s (3 处)
- DeviceDetail 补 RuntimeDetail 同款 prop→state 同步 + remount 续看 (daemon 升级路径同病同治)

### 左树简化 (问题 3)
- 删 device 行 "N 个运行时" 副标题
- 删 Level-3 空态文案 + CTA; 没 bot 的 runtime 不可展开 (无箭头); botsByRuntime 由 loadData 批量预填 (15s 节流), 含首屏水合回退防全树闪烁

## Review 轨迹

本地 cc + codex 双 reviewer **5 轮** (同 session 累积): plan 2 轮 (P1-P9 / X1-X7, 含 2 个 blocker) → 代码 3 轮 (R3/R4/R5 系, 含 2 个 blocker) → **双方最终 verdict pass, 无 pre-push blocker**。中途 reviewer 抓到的关键问题: DeviceDetail prop 推送链路断 (critical) / Retry 不套 busy 再撞墙 / botsSeq 双路写竞态 / botsLoading 泄漏 / 首屏水合闪烁。

## 实测 (2026-06-12 本地)

- 并发互斥: 点 codex 升级 → hermes/daemon Upgrade 灰不可点 (hover 英文提示) → codex completed (13s) → 按钮**自动**恢复 → 点 hermes → 45s 完成 — 全程无手动刷新, fleet 两 task 串行 completed, binary 实测 codex 0.139.0 + hermes 0.16.0 ✓
- 左树: 无 bot runtime 无箭头不可展开; 有 bot 正常展开

## 已知限制 (记 backlog)

- fleet `active_upgrades` 查询 Load err 被吞 → web 误判不 busy (退化回旧行为, 非新风险) — fleet 侧修复
- 跨 owner 同 daemon 并发升级理论可撞 (fleet 按 owner_uid 隔离是 §C.3 有意设计, 产品化再议)
- 升级轮询页面级 tracker (方案 1 根治) — 自适应轮询已覆盖主场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)