### PR TITLE
fix(group): add all selected bots as admins instead of only the first

### DIFF
--- a/packages/dmworkbase/src/Components/GroupManagement/__tests__/botAdmins.test.ts
+++ b/packages/dmworkbase/src/Components/GroupManagement/__tests__/botAdmins.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { submitBotAdmins } from "../botAdmins";
+
+describe("submitBotAdmins", () => {
+  it("calls setBotAdmin once per selected uid (N=3) with the exact selected set", async () => {
+    const setBotAdmin = vi.fn().mockResolvedValue(undefined);
+    const uids = ["bot-a", "bot-b", "bot-c"];
+
+    const result = await submitBotAdmins(uids, setBotAdmin);
+
+    // 调用恰好 3 次
+    expect(setBotAdmin).toHaveBeenCalledTimes(3);
+    // 参数集合 == 选中集合（顺序无关）
+    const calledUids = setBotAdmin.mock.calls.map((c) => c[0]);
+    expect(new Set(calledUids)).toEqual(new Set(uids));
+    expect(result.succeeded).toEqual(uids);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("submits remaining uids when one rejects and reports the failed uid(s)", async () => {
+    const setBotAdmin = vi.fn((uid: string) =>
+      uid === "bot-b"
+        ? Promise.reject({ msg: "boom" })
+        : Promise.resolve()
+    );
+    const uids = ["bot-a", "bot-b", "bot-c"];
+
+    const result = await submitBotAdmins(uids, setBotAdmin);
+
+    // 全部 3 个都被尝试提交（第 2 个失败不阻断其余）
+    expect(setBotAdmin).toHaveBeenCalledTimes(3);
+    expect(result.succeeded).toEqual(["bot-a", "bot-c"]);
+    // 失败 uid 被收集（含原因），不静默吞掉
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].uid).toBe("bot-b");
+    expect((result.failed[0].reason as any)?.msg).toBe("boom");
+    expect(result.failed.map((f) => f.uid)).toContain("bot-b");
+  });
+
+  it("collects every failure when all reject", async () => {
+    const setBotAdmin = vi.fn().mockRejectedValue({ msg: "down" });
+    const uids = ["bot-a", "bot-b"];
+
+    const result = await submitBotAdmins(uids, setBotAdmin);
+
+    expect(setBotAdmin).toHaveBeenCalledTimes(2);
+    expect(result.succeeded).toEqual([]);
+    expect(result.failed.map((f) => f.uid)).toEqual(["bot-a", "bot-b"]);
+  });
+});

--- a/packages/dmworkbase/src/Components/GroupManagement/botAdmins.ts
+++ b/packages/dmworkbase/src/Components/GroupManagement/botAdmins.ts
@@ -1,0 +1,34 @@
+// 批量添加 Bot 管理员的提交逻辑，单独抽出便于单测。
+//
+// 背景：后端只有单 uid 端点 `PUT /:group_no/bot_admin/:uid`，无批量端点。
+// 「添加 Bot 管理员」对话框是真多选，因此对每个选中 uid 各发一次 PUT，
+// 用 Promise.allSettled 收集结果，部分失败时明确返回失败 uid 列表，
+// 不静默吞掉（旧实现只取 selectedItems[0] 提交一个）。
+export interface BotAdminSubmitResult {
+  // 成功提交的 uid（按输入顺序）
+  succeeded: string[];
+  // 失败的 uid 及其原因（按输入顺序）
+  failed: { uid: string; reason: unknown }[];
+}
+
+// 对每个 uid 调一次 setBotAdmin，并发提交、独立收集成败。
+// setBotAdmin 已柯里化为只接收 uid，channel 由调用方闭包注入，
+// 这样本函数与具体 DataSource / channel 解耦，纯逻辑可测。
+export async function submitBotAdmins(
+  uids: string[],
+  setBotAdmin: (uid: string) => Promise<void>
+): Promise<BotAdminSubmitResult> {
+  const results = await Promise.allSettled(
+    uids.map((uid) => setBotAdmin(uid))
+  );
+  const succeeded: string[] = [];
+  const failed: { uid: string; reason: unknown }[] = [];
+  results.forEach((r, i) => {
+    if (r.status === "fulfilled") {
+      succeeded.push(uids[i]);
+    } else {
+      failed.push({ uid: uids[i], reason: r.reason });
+    }
+  });
+  return { succeeded, failed };
+}

--- a/packages/dmworkbase/src/Components/GroupManagement/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/index.tsx
@@ -14,6 +14,7 @@ import {
   shouldApplyFetchResult,
   shouldListenerApply,
 } from "./allowNoMention";
+import { submitBotAdmins } from "./botAdmins";
 import "./index.css";
 
 export interface GroupManagementProps {
@@ -268,17 +269,31 @@ export class GroupManagement extends Component<
             Toast.warning(t("base.groupManagement.selectBot"));
             return;
           }
-          const uid = selectedItems[0].uid;
-          try {
-            await WKApp.dataSource.channelDataSource.setBotAdmin(
-              channel,
-              uid
-            );
-            Toast.success(t("base.groupManagement.added"));
+          // 后端无批量端点，对每个选中 bot 各发一次 PUT；先快照选中 uid，
+          // 避免提交期间 onSelect 回调改写 selectedItems 造成竞态。
+          const uids = selectedItems.map((item) => item.uid);
+          const { succeeded, failed } = await submitBotAdmins(uids, (uid) =>
+            WKApp.dataSource.channelDataSource.setBotAdmin(channel, uid)
+          );
+          if (succeeded.length > 0) {
+            // 只要有成功的就刷新列表并关闭对话框。
             context.pop();
             this.loadMembers();
-          } catch (err: any) {
-            Toast.error(err?.msg || t("base.groupManagement.operationFailed"));
+          }
+          if (failed.length === 0) {
+            Toast.success(t("base.groupManagement.added"));
+          } else if (succeeded.length === 0) {
+            const firstReason = failed[0].reason as any;
+            Toast.error(
+              firstReason?.msg || t("base.groupManagement.operationFailed")
+            );
+          } else {
+            // 部分失败：明确列出失败的 uid，不静默吞掉。
+            Toast.error(
+              t("base.groupManagement.operationFailed") +
+                ` (${failed.length}/${uids.length}): ` +
+                failed.map((f) => f.uid).join(", ")
+            );
           }
         },
       })

--- a/packages/dmworkbase/tsconfig.json
+++ b/packages/dmworkbase/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../packages/tsconfig/react-library.json",
+  "compilerOptions": {
+    "lib": ["es2020", "dom", "dom.iterable"]
+  },
   "include": ["src"],
   "exclude": ["dist", "build", "node_modules"]
 }


### PR DESCRIPTION
## Problem

In the **Add Bot Administrator** dialog (`GroupManagement`), the subscriber list allows multi-select, but the submit handler only read `selectedItems[0].uid` and issued a single `setBotAdmin` PUT. Every other selected bot was silently dropped, so picking N bots only ever added one.

## Fix

- Extract the submit logic into a small, testable pure function `submitBotAdmins(uids, setBotAdmin)` that calls the single-uid endpoint once per selected bot via `Promise.allSettled`, collecting successes and failures independently (the backend only exposes the single-uid `PUT /:group_no/bot_admin/:uid` endpoint, so a per-uid loop is the right shape — no backend change needed).
- Snapshot the selected uids before awaiting, so a late `onSelect` callback can't mutate the set mid-submit.
- On partial failure, the toast now **lists the failed uids** instead of swallowing them; full failure keeps the dialog open and surfaces the backend error message; full success closes and refreshes as before.
- `Promise.allSettled` needs the `es2020` lib, added to the package `tsconfig.json`.

## Tests

New unit tests in `GroupManagement/__tests__/botAdmins.test.ts`:
- N=3 selected → `setBotAdmin` called exactly 3 times, arg set == selected set
- 2nd uid rejects → other 2 still submitted, failed uid reported
- all reject → every failure collected

```
cd packages/dmworkbase && pnpm exec vitest run src/Components/GroupManagement/__tests__/
```
→ all passed.

## Relationship to #365

#365 is already open against this issue with the same core approach (per-uid loop + `Promise.allSettled` + the es2020 tsconfig bump), and credit to that author for landing on the right shape. This PR builds on that direction and additionally (a) extracts the logic into a pure, unit-tested function and (b) makes partial failures list the specific failed uids rather than only a count, addressing the testability/error-reporting gaps. Happy to consolidate into whichever PR maintainers prefer.

Fixes #364
