### PR TITLE
fix(summary): strip client source_name from scheduled-summary submit (detail page + schedule form)

### DIFF
--- a/packages/dmworksummary/src/components/ScheduleForm.tsx
+++ b/packages/dmworksummary/src/components/ScheduleForm.tsx
@@ -101,6 +101,14 @@ const ScheduleForm: React.FC<ScheduleFormProps> = ({
         const day_of_week = unit === "week" ? dayOfWeek || 0 : 0;
         const day_of_month = unit === "month" ? dayOfMonth || 0 : 0;
 
+        // 强剥 source_name：与即时总结路一致，提交时不带 name，
+        // 让后端按 source_id 现查 IM 库最新群名（带类型后缀）。
+        // 这样定时管理 UI 也不会把原始 group_no/thread id 当名写进库。
+        const cleanSources = sources.map(({ source_type, source_id }) => ({
+            source_type,
+            source_id,
+        }));
+
         onSubmit({
             title: title.trim(),
             summary_mode: summaryMode,
@@ -111,7 +119,7 @@ const ScheduleForm: React.FC<ScheduleFormProps> = ({
             day_of_month,
             run_time,
             time_range_type: timeRangeType,
-            sources,
+            sources: cleanSources,
         });
     }, [title, summaryMode, unit, every, runTime, dayOfWeek, dayOfMonth, timeRangeType, sources, onSubmit]);
 

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -530,7 +530,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     day_of_month,
                     run_time,
                     time_range_type: 2,
-                    sources: detail.sources,
+                    // 强剥 source_name：与即时总结/ScheduleForm 一致，提交时只带
+                    // {source_type, source_id}，让后端按 source_id 现查 IM 库权威群名
+                    // （带类型后缀）。避免详情页把 detail.sources 里的客户端名
+                    // （未命名来源会退化成原始 group_no/thread id）写进定时配置。
+                    sources: detail.sources.map(({ source_type, source_id }) => ({
+                        source_type,
+                        source_id,
+                    })),
                     scope: 'task',
                     task_id: detail.task_id,
                 });


### PR DESCRIPTION
## 背景

定时总结提交时，前端会把客户端的 `source_name` 一起传给后端落库。对于**未命名来源（尤其子区 thread）**，`source_name` 会退化成原始 `groupNo____shortId`（把来源 id 当成名字），写进 schedule 的 `source_config`。

## 改动

把所有「定时总结提交入口」的 sources 在提交前剥成 `{ source_type, source_id }`，与即时总结路径对齐，让后端按 `source_id` 现查 IM 库的权威名称（带类型后缀）。

涉及两处入口：
- `ScheduleForm.tsx`：onSubmit 前剥离 `source_name`（覆盖 ScheduleListPage 的创建/编辑两条路）。
- `SummaryDetailPage.tsx`：详情页「为无定时总结新建定时」的 `createSchedule`，sources 同样剥离。

即时总结（`SummaryCreatePage`）本就只传 `{source_type, source_id}`，无需改动。

## 为什么这样改

后端 worker 出活时（`buildScheduledTaskSources` / `syncScheduledTaskSources`）本就**无条件**调用 `ResolveSourceNameWithType(source_id, source_type, imDB)` 重新解析、绝不信任客户端 `source_name`，并有测试 `TestBuildScheduledTaskSources_IgnoresConfigSourceName` 背书。

因此本前端改动的价值是：**让 schedule 的 `source_config` 配置快照也干净、统一所有提交入口**，杜绝最后一个仍提交 `source_name` 的路径。属于 backend-authoritative naming 的前端收尾。

## 测试 / 验证
- `tsc` 类型检查：本次改动文件无错（detail.sources/sources 元素均为 `SourceItem`，含 `source_type`/`source_id`）。
- code review：APPROVE（无 blocking）。

## 关联
Closes Mininglamp-OSS/octo-smart-summary#93 — Summary list API does not distinguish thread vs group source (source_name shows parent group name, missing source_type).

> 注：跨仓库引用，GitHub 不会自动关闭该后端 issue；需后端改动一并完成后手动关闭。
