### PR TITLE
fix: auto-follow new thread when parent channel is followed

### DIFF
--- a/packages/dmworkbase/src/Components/ThreadCreate/__tests__/ThreadCreate.followOnCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreate/__tests__/ThreadCreate.followOnCreate.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mock fns shared across module mocks ──
+const hoisted = vi.hoisted(() => ({
+  threadCreate: vi.fn(),
+  followThread: vi.fn(),
+  sidebarSync: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastWarning: vi.fn(),
+  emit: vi.fn(),
+}));
+
+vi.mock("../../../App", () => ({
+  __esModule: true,
+  default: {
+    dataSource: {
+      channelDataSource: { threadCreate: hoisted.threadCreate },
+    },
+    shared: { deviceId: "dev-1" },
+    mittBus: { emit: hoisted.emit },
+  },
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    success: hoisted.toastSuccess,
+    error: hoisted.toastError,
+    warning: hoisted.toastWarning,
+  },
+}));
+
+vi.mock("../../../Service/FollowService", () => ({
+  __esModule: true,
+  default: { followThread: hoisted.followThread },
+}));
+
+vi.mock("../../../Service/SidebarService", () => ({
+  __esModule: true,
+  default: { sync: hoisted.sidebarSync },
+  SidebarTargetType: { DM: 1, CHANNEL: 2, THREAD: 5 },
+}));
+
+import { ThreadCreate } from "../index";
+
+const CREATED = { channel_id: "g1____t1", short_id: "t1", group_no: "g1" };
+
+// 直接实例化类组件并驱动 handleSubmit（避免 monorepo 内多 React 副本导致的
+// testing-library DOM 渲染落空问题；本测试聚焦 threadCreate → 自动关注 的接线）。
+function makeInstance(props: any) {
+  const inst: any = new (ThreadCreate as any)(props);
+  inst.state = { name: "新子区", loading: false };
+  inst.setState = (patch: any) => {
+    const next = typeof patch === "function" ? patch(inst.state) : patch;
+    inst.state = { ...inst.state, ...next };
+  };
+  return inst;
+}
+
+describe("ThreadCreate auto-follow on create (GH#292)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.threadCreate.mockResolvedValue(CREATED);
+  });
+
+  it("父群已关注 → followThread 被调一次，入参 thread_channel_id 正确", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "g1", is_followed: true }],
+    });
+    const onSuccess = vi.fn();
+    const inst = makeInstance({ groupNo: "g1", onSuccess });
+    await inst.handleSubmit();
+
+    expect(hoisted.threadCreate).toHaveBeenCalledWith("g1", "新子区", undefined);
+    expect(hoisted.followThread).toHaveBeenCalledTimes(1);
+    expect(hoisted.followThread).toHaveBeenCalledWith({ thread_channel_id: "g1____t1" });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("父群未关注 → followThread 不被调，创建反馈仍触发", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "other", is_followed: true }],
+    });
+    const onSuccess = vi.fn();
+    const inst = makeInstance({ groupNo: "g1", onSuccess });
+    await inst.handleSubmit();
+
+    expect(hoisted.followThread).not.toHaveBeenCalled();
+    expect(hoisted.toastSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
@@ -3,6 +3,7 @@ import { Toast } from "@douyinfe/semi-ui"
 import { X } from "lucide-react"
 import ThreadIcon from "../Icons/ThreadIcon"
 import WKApp from "../../App"
+import { maybeFollowNewThread } from "../../Utils/followNewThread"
 import { I18nContext, t } from "../../i18n"
 import "./index.css"
 
@@ -57,11 +58,12 @@ export class ThreadCreate extends Component<ThreadCreateProps, ThreadCreateState
     this.setState({ loading: true })
 
     try {
-      await WKApp.dataSource.channelDataSource.threadCreate(
+      const created = await WKApp.dataSource.channelDataSource.threadCreate(
         groupNo,
         name.trim(),
         sourceMessageId
       )
+      await maybeFollowNewThread(groupNo, created)
       Toast.success(t("base.threadCreate.success"))
       onSuccess?.()
     } catch (err: unknown) {

--- a/packages/dmworkbase/src/Components/ThreadCreateModal/__tests__/ThreadCreateModal.followOnCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreateModal/__tests__/ThreadCreateModal.followOnCreate.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  threadCreate: vi.fn(),
+  followThread: vi.fn(),
+  sidebarSync: vi.fn(),
+  emit: vi.fn(),
+}));
+
+vi.mock("../../../App", () => ({
+  __esModule: true,
+  default: {
+    dataSource: {
+      channelDataSource: { threadCreate: hoisted.threadCreate },
+    },
+    shared: { deviceId: "dev-1" },
+    mittBus: { emit: hoisted.emit },
+  },
+}));
+
+vi.mock("../../VoiceInputButton", () => ({ __esModule: true, default: () => null }));
+
+// i18n 静态 import @douyinfe/semi-ui → lottie-web，需要 canvas，jsdom 没有，stub 掉。
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn(), close: vi.fn() },
+  ConfigProvider: ({ children }: any) => children,
+  LocaleProvider: ({ children }: any) => children,
+}));
+
+vi.mock("../../../Service/FollowService", () => ({
+  __esModule: true,
+  default: { followThread: hoisted.followThread },
+}));
+
+vi.mock("../../../Service/SidebarService", () => ({
+  __esModule: true,
+  default: { sync: hoisted.sidebarSync },
+  SidebarTargetType: { DM: 1, CHANNEL: 2, THREAD: 5 },
+}));
+
+import ThreadCreateModal from "../index";
+
+const CREATED = { channel_id: "g1____t1", short_id: "t1", group_no: "g1" };
+
+// 直接实例化类组件并驱动 handleSubmit（见 ThreadCreate 测试同理说明）。
+function makeInstance(props: any) {
+  const inst: any = new (ThreadCreateModal as any)(props);
+  inst.state = { name: "新子区", loading: false, error: null };
+  inst.setState = (patch: any) => {
+    const next = typeof patch === "function" ? patch(inst.state) : patch;
+    inst.state = { ...inst.state, ...next };
+  };
+  return inst;
+}
+
+describe("ThreadCreateModal auto-follow on create (GH#292)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.threadCreate.mockResolvedValue(CREATED);
+  });
+
+  it("父群已关注 → followThread 被调一次，入参 thread_channel_id 正确", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "g1", is_followed: true }],
+    });
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    const inst = makeInstance({ visible: true, groupNo: "g1", onSuccess, onClose });
+    await inst.handleSubmit();
+
+    expect(hoisted.threadCreate).toHaveBeenCalledWith("g1", "新子区", undefined);
+    expect(hoisted.followThread).toHaveBeenCalledTimes(1);
+    expect(hoisted.followThread).toHaveBeenCalledWith({ thread_channel_id: "g1____t1" });
+    expect(onSuccess).toHaveBeenCalledWith("t1");
+  });
+
+  it("父群未关注 → followThread 不被调，创建反馈仍触发", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "other", is_followed: true }],
+    });
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    const inst = makeInstance({ visible: true, groupNo: "g1", onSuccess, onClose });
+    await inst.handleSubmit();
+
+    expect(hoisted.followThread).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith("t1");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/ThreadCreateModal/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreateModal/index.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react"
 import ThreadIcon from "../Icons/ThreadIcon"
 import classNames from "classnames"
 import WKApp from "../../App"
+import { maybeFollowNewThread } from "../../Utils/followNewThread"
 import VoiceInputButton from "../VoiceInputButton"
 import { I18nContext, t } from "../../i18n"
 import "./index.css"
@@ -77,6 +78,7 @@ export default class ThreadCreateModal extends Component<
         trimmedName,
         sourceMessageId
       )
+      await maybeFollowNewThread(groupNo, result)
       this.setState({ loading: false })
       onSuccess?.(result.short_id)
       onClose()

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.followOnCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.followOnCreate.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  threadCreate: vi.fn(),
+  followThread: vi.fn(),
+  sidebarSync: vi.fn(),
+  emit: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  wkConfirm: vi.fn(),
+  loadThreads: vi.fn(),
+}));
+
+vi.mock("../../../App", () => ({
+  __esModule: true,
+  default: {
+    dataSource: {
+      channelDataSource: { threadCreate: hoisted.threadCreate },
+    },
+    loginInfo: { uid: "owner-uid" },
+    shared: { deviceId: "dev-1", currentSpaceId: "space-1" },
+    mittBus: { emit: hoisted.emit },
+    endpoints: { showConversation: vi.fn() },
+  },
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: { success: hoisted.toastSuccess, error: hoisted.toastError, info: vi.fn(), close: vi.fn() },
+  Spin: () => null,
+  Popover: ({ children }: any) => children,
+}));
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string; channelType: number;
+    constructor(id: string, type: number) { this.channelID = id; this.channelType = type; }
+  }
+  return {
+    Channel, ChannelTypePerson: 1, ChannelTypeGroup: 2,
+    WKSDK: { shared: () => ({ channelManager: {} }) },
+  };
+});
+
+vi.mock("../../Conversation", () => ({ Conversation: () => null }));
+vi.mock("../../FilePreviewPanel/FileListPanel", () => ({ FileListPanel: () => null }));
+vi.mock("../../FilePreviewPanel/FilePreviewHeader", () => ({ __esModule: true, default: () => null }));
+vi.mock("../../FilePreviewPanel/registry", () => ({ fileRendererRegistry: { getRenderer: () => ({ renderer: () => null }) } }));
+vi.mock("../../FilePreviewPanel/renderers/MarkdownRenderer", () => ({ MarkdownRenderer: () => null }));
+vi.mock("../../FilePreviewPanel/renderers/HtmlRenderer", () => ({ HtmlRenderer: () => null }));
+vi.mock("../../FilePreviewPanel/renderers/ImageRenderer", () => ({ ImageRenderer: () => null }));
+vi.mock("../../../Service/CategoryService", () => ({ __esModule: true, default: {} }));
+vi.mock("../../WKModal", () => ({ wkConfirm: hoisted.wkConfirm }));
+
+vi.mock("../../../Service/FollowService", () => ({
+  __esModule: true,
+  default: { followThread: hoisted.followThread },
+}));
+vi.mock("../../../Service/SidebarService", () => ({
+  __esModule: true,
+  default: { sync: hoisted.sidebarSync },
+  SidebarTargetType: { DM: 1, CHANNEL: 2, THREAD: 5 },
+}));
+
+import ThreadPanel from "../index";
+
+const CREATED = { channel_id: "g1____t1", short_id: "t1", group_no: "g1" };
+
+// 在 React 元素树里找到 <input> 并取其 onChange（handleCreateThread 用闭包变量
+// 记录子区名）。避免 monorepo 多 React 副本导致的 DOM 渲染落空。
+function findInputOnChange(node: any): ((e: any) => void) | null {
+  if (!node || typeof node !== "object") return null;
+  if (node.type === "input" && node.props?.onChange) return node.props.onChange;
+  const children = node.props?.children;
+  const arr = Array.isArray(children) ? children : [children];
+  for (const c of arr) {
+    const found = findInputOnChange(c);
+    if (found) return found;
+  }
+  return null;
+}
+
+// 直接实例化 ThreadPanel 并调用 handleCreateThread（私有方法，通过实例访问），
+// 通过 mock 的 wkConfirm 捕获弹窗配置，填名后调用 onOk 驱动创建+自动关注链路。
+async function runCreateFlow(threadName = "新子区") {
+  const inst: any = new (ThreadPanel as any)({
+    groupNo: "g1", thread: null, onClose: vi.fn(), onThreadSelect: vi.fn(),
+  });
+  inst.loadThreads = hoisted.loadThreads;
+  inst.handleCreateThread();
+
+  expect(hoisted.wkConfirm).toHaveBeenCalledTimes(1);
+  const config = hoisted.wkConfirm.mock.calls[0][0] as any;
+  const onChange = findInputOnChange(config.content);
+  expect(onChange).toBeTypeOf("function");
+  onChange!({ target: { value: threadName } });
+  await config.onOk();
+}
+
+describe("ThreadPanel handleCreateThread auto-follow (GH#292)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.threadCreate.mockResolvedValue(CREATED);
+  });
+
+  it("父群已关注 → followThread 被调一次，入参 thread_channel_id 正确", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "g1", is_followed: true }],
+    });
+    await runCreateFlow();
+
+    expect(hoisted.threadCreate).toHaveBeenCalledWith("g1", "新子区");
+    expect(hoisted.followThread).toHaveBeenCalledTimes(1);
+    expect(hoisted.followThread).toHaveBeenCalledWith({ thread_channel_id: "g1____t1" });
+    expect(hoisted.loadThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it("父群未关注 → followThread 不被调，创建反馈仍触发", async () => {
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [{ target_type: 2, target_id: "other", is_followed: true }],
+    });
+    await runCreateFlow();
+
+    expect(hoisted.threadCreate).toHaveBeenCalledWith("g1", "新子区");
+    expect(hoisted.followThread).not.toHaveBeenCalled();
+    expect(hoisted.toastSuccess).toHaveBeenCalledTimes(1);
+    expect(hoisted.loadThreads).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -30,6 +30,7 @@ import { canManageThread } from "../../Service/threadPermission";
 import { ErrorBoundary } from "../ErrorBoundary";
 import WKApp from "../../App";
 import { formatRelativeTime } from "../../Utils/time";
+import { maybeFollowNewThread } from "../../Utils/followNewThread";
 import FollowService from "../../Service/FollowService";
 import SidebarService from "../../Service/SidebarService";
 import CategoryService from "../../Service/CategoryService";
@@ -975,10 +976,11 @@ export default class ThreadPanel extends Component<
           return;
         }
         try {
-          await WKApp.dataSource.channelDataSource.threadCreate(
+          const created = await WKApp.dataSource.channelDataSource.threadCreate(
             groupNo,
             threadName.trim()
           );
+          await maybeFollowNewThread(groupNo, created);
           Toast.success(t("base.module.createThread.success"));
           this.loadThreads();
         } catch (err: unknown) {

--- a/packages/dmworkbase/src/Utils/followNewThread.ts
+++ b/packages/dmworkbase/src/Utils/followNewThread.ts
@@ -1,0 +1,36 @@
+import WKApp from "../App"
+import FollowService from "../Service/FollowService"
+import SidebarService, { SidebarTargetType } from "../Service/SidebarService"
+import { Thread } from "../Service/Thread"
+
+/**
+ * 手建子区后，若父群已关注则自动关注新子区（best-effort）。
+ *
+ * 后端 `auto_follow_threads` fanout 只对 bot 创建的子区生效且是最终一致，
+ * 前端手建入口不能依赖它（GH#292）。这里在 threadCreate 成功后补一次关注：
+ * 仅当父群已关注（权威源是 sidebar follow 快照，而非 channelInfo.orgData.is_followed）
+ * 才关注新子区，语义对齐 issue 期望。
+ *
+ * 失败不抛出、不阻塞创建反馈。
+ */
+export async function maybeFollowNewThread(
+  groupNo: string,
+  thread: Thread
+): Promise<void> {
+  try {
+    const resp = await SidebarService.sync({
+      tab: "follow",
+      device_uuid: WKApp.shared.deviceId,
+    })
+    const parentFollowed = (resp.items ?? []).some(
+      (it) => it.target_type === SidebarTargetType.CHANNEL && it.target_id === groupNo
+    )
+    if (parentFollowed) {
+      await FollowService.followThread({ thread_channel_id: thread.channel_id })
+      // 让 follow 侧栏刷新，新子区即时进关注 tab
+      WKApp.mittBus.emit("sidebar-reload" as any)
+    }
+  } catch (err) {
+    console.warn("[maybeFollowNewThread] auto-follow new thread failed", err)
+  }
+}


### PR DESCRIPTION
## What

Web users creating a thread under an **already-followed** channel didn't get the new thread auto-followed — it only showed up in the **Recent** tab and needed a manual right-click → follow. Bot-created threads already land in Follow because the backend `auto_follow_threads` fanout handles them, but that fanout is bot-only and eventually consistent, so the web manual-create paths can't rely on it.

## How

New best-effort helper `Utils/followNewThread.ts` → `maybeFollowNewThread(groupNo, thread)`:
- After `threadCreate` succeeds, reads the sidebar follow snapshot (`SidebarService.sync({ tab: "follow" })`).
- Parent-channel follow state comes from that snapshot (`target_type === 2 && target_id === groupNo`), **not** from `channelInfo.orgData.is_followed` (commented as unreliable).
- Only when the parent is already followed: `FollowService.followThread({ thread_channel_id: thread.channel_id })`, then `emit("sidebar-reload")` so the new thread shows in the Follow tab immediately.
- Wrapped in try/catch — failures never block the create feedback.

Wired symmetrically into all three manual create entry points:
- `Components/ThreadCreate/index.tsx`
- `Components/ThreadCreateModal/index.tsx`
- `Components/ThreadPanel/index.tsx` (inline `wkConfirm` create)

No schema/API changes. Backend fanout untouched.

## Tests

- `[api]` 6 new Vitest cases (2 per entry point), symmetric:
  - parent followed → `followThread` called exactly once with `{ thread_channel_id: "g1____t1" }`
  - parent not followed → `followThread` not called, create feedback still fires
- Existing `ThreadPanel.archive.test.tsx` (16) still green.

A `[browser]` smoke check (create a thread under a followed channel → it appears in the Follow tab ≤2s, persists after refresh) is left for post-merge regression.

Fixes #292
<!-- sprint-retrigger 074934 -->