### PR TITLE
feat(runtimes): refresh on tab focus + readable upgrade stage labels

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -408,7 +408,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                                         )
                                     }
                                     if (inProgress) {
-                                        return <span className="wk-rt-upgrade-status progress"><span className="upgrade-dot" />{upgradeStatus}...</span>
+                                        return <span className="wk-rt-upgrade-status progress"><span className="upgrade-dot" />{upgradeStageLabel(upgradeStatus)}…</span>
                                     }
                                     if (isWindows) {
                                         return <span className="wk-rt-upgrade-btn disabled" title="Windows remote upgrade is not supported yet">Upgrade</span>
@@ -956,6 +956,22 @@ function isUpgradeInProgress(status: string): boolean {
     return UPGRADE_IN_PROGRESS_STATUSES.has(status)
 }
 
+// 升级 in-progress 阶段的展示文案 (单源, 3 处升级按钮共用). 英文 — 跟
+// detail 面板 label 一致. daemon 逐阶段上报 (downloading→installing→
+// restarting), 自适应轮询 3s 拉到变化, 这里把原始 status 映射成可读阶段
+// 让用户看到"在动、在哪一步", 而非一个静态 installing. 终态
+// (completed/failed/timeout) 由各 renderer 自己处理, 不走这里.
+function upgradeStageLabel(status: string): string {
+    switch (status) {
+        case "pending":
+        case "dispatched":  return "Queued"
+        case "downloading": return "Downloading"
+        case "installing":  return "Installing"
+        case "restarting":  return "Restarting"
+        default:            return status
+    }
+}
+
 // busy-disabled title 单源 (6 个按钮共用). 英文 — detail 面板 label 已统一
 // 全英文 (同面板 Windows disabled title 也是英文, 语言保持一致).
 const UPGRADE_BUSY_TITLE = "Another upgrade is in progress on this device, please wait"
@@ -1182,7 +1198,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             return (
                 <span className="wk-rt-upgrade-status progress">
                     <span className="upgrade-dot" />
-                    {pluginUpgradeStatus}
+                    {upgradeStageLabel(pluginUpgradeStatus)}…
                 </span>
             )
         }
@@ -1310,7 +1326,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             return (
                 <span className="wk-rt-upgrade-status progress">
                     <span className="upgrade-dot" />
-                    {componentUpgradeStatus}
+                    {upgradeStageLabel(componentUpgradeStatus)}…
                 </span>
             )
         }
@@ -1593,17 +1609,34 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         }
     }
 
+    // 页面重新可见 / 窗口聚焦时立即拉一次最新 — 自适应轮询管页面内,
+    // 管不到"用户切走 tab 期间不看、切回看到旧帧"这个盲区. visibilitychange
+    // 与 focus 同一次切回会双触发, 且 focus 在页面内点击也乱触发, 故 1.5s
+    // 节流去重 (loadData 的 loadSeq 再兜竞态). silent 不闪 loading.
+    private lastVisRefresh = 0
+    private onVisible = () => {
+        if (document.visibilityState !== "visible") return
+        const now = Date.now()
+        if (now - this.lastVisRefresh < 1500) return
+        this.lastVisRefresh = now
+        this.loadData(true)
+    }
+
     componentDidMount() {
         this.loadData()
         this.startPollTimer(POLL_IDLE_MS)
         WKApp.mittBus.on("space-changed", this.handleSpaceChanged)
         document.addEventListener("keydown", this.handleGlobalKeyDown)
+        document.addEventListener("visibilitychange", this.onVisible)
+        window.addEventListener("focus", this.onVisible)
     }
 
     componentWillUnmount() {
         if (this.pollTimer) clearInterval(this.pollTimer)
         WKApp.mittBus.off("space-changed", this.handleSpaceChanged)
         document.removeEventListener("keydown", this.handleGlobalKeyDown)
+        document.removeEventListener("visibilitychange", this.onVisible)
+        window.removeEventListener("focus", this.onVisible)
     }
 
     // 升级期间临时加速兜底轮询 (runtime页升级状态不刷新 修复方案 2):

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -961,6 +961,8 @@ function isUpgradeInProgress(status: string): boolean {
 // restarting), 自适应轮询 3s 拉到变化, 这里把原始 status 映射成可读阶段
 // 让用户看到"在动、在哪一步", 而非一个静态 installing. 终态
 // (completed/failed/timeout) 由各 renderer 自己处理, 不走这里.
+// ⚠️ 新增 in-progress 状态时同步 UPGRADE_IN_PROGRESS_STATUSES + 这里,
+// 否则漏的态走 default 显示原始 snake_case (不崩, 但用户看着别扭).
 function upgradeStageLabel(status: string): string {
     switch (status) {
         case "pending":
@@ -1619,7 +1621,12 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         const now = Date.now()
         if (now - this.lastVisRefresh < 1500) return
         this.lastVisRefresh = now
-        this.loadData(true)
+        void this.loadData(true)
+        // 重置 pollTimer 对齐到"刚刷过"的点: tab 切后台时 setInterval 可能被
+        // 浏览器节流堆积, 切回时补跑的 poll 若紧随本次 loadData 启动会递增
+        // loadSeq 把这次"切回刷新"的响应判 stale (轻则延迟、重则该 poll 失败
+        // 时本次切回不落数据). 重置后下一轮 poll 从现在起算, 不抢这次刷新.
+        this.startPollTimer(this.currentPollMs)
     }
 
     componentDidMount() {


### PR DESCRIPTION
runtime 页**感知层**体验提升,纯前端、零后端依赖(用 fleet 已返回字段)。改 `Pages/Runtimes/index.tsx`。

## 改动

### 1. 切回 tab / 窗口聚焦立即刷新
自适应轮询(15s↔3s)管页面内,管不到"用户切走 tab 期间不看、切回看到旧帧"这个盲区。监听 `visibilitychange` + `focus`,页面变可见时 `loadData(true)`:
- 两事件同次切回会双触发、`focus` 页面内点击也乱触发 → **1.5s 节流**去重(`loadData` 的 `loadSeq` 再兜竞态)
- 刷新后**重置 pollTimer**:tab 切后台时 `setInterval` 被浏览器节流堆积,切回补跑的 poll 若紧随本次 loadData 会递增 loadSeq 把"切回刷新"判 stale —— 重置后下一轮 poll 从刷新点起算,不抢这次刷新
- `silent` 不闪 loading

### 2. 升级 in-progress 阶段文案可读化
daemon 逐阶段上报(downloading→installing→restarting),自适应轮询 3s 拉到变化,但原来显示原始 status(静态 installing 像卡死)。加单源 `upgradeStageLabel`:`Queued / Downloading / Installing / Restarting`(英文,跟 detail 面板 label 一致),3 处升级按钮(daemon / plugin / component)共用,让用户看到"在动、在哪一步"。终态(completed/failed/timeout)渲染逻辑不动。

砍掉精确计时器(唯一沾后端的点)。

## 说明
- 全程复用现有机制(loadSeq/spaceEpoch 防竞态、自适应轮询、设计系统变量)
- 本 PR 不引入新硬编码中文;runtime 目录的 i18n 国际化是基线历史项,计划随 runtime 合 main 时统一处理,不在本 PR 范围
- esbuild 语法过

## backlog(本次未做,按需)
- 页头手动刷新按钮 / runtime last-seen 相对时间(有了切回刷新后边际收益降)