### PR TITLE
fix(thread): allow parent-group owner/admin to rename threads from channel settings

### DIFF
--- a/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
@@ -98,8 +98,9 @@ describe("canManageThread", () => {
 // issue #394：子区设置页「改名」入口此前用 data.isManagerOrCreatorOfMe（读子区频道
 // 成员缓存，从未同步、恒 false），把非创建者的父群群主/管理员误拦在前端、不发请求。
 // 修复后改名入口（module.tsx）改调 canRenameThread —— 与归档入口同口径。
-// 这里直接测 module.tsx 实际调用的 canRenameThread（而非底层 canManageThread），
-// 并断言「改名口径 == canManageThread 父群口径」，锁住此入口、防止再次回退。
+// 这里覆盖 canRenameThread 自身的契约（创建者 / 父群群主 / 管理员 / 普通成员 /
+// undefined groupNo）。注意：本组用例并不证明 module.tsx 仍在调用 canRenameThread；
+// 那部分由 module.tsx:2222 的静态 import 与类型检查保障，不在测试范围内。
 describe("canRenameThread (thread rename gate, issue #394)", () => {
   beforeEach(() => {
     subscribesByKey.clear();
@@ -135,32 +136,6 @@ describe("canRenameThread (thread rename gate, issue #394)", () => {
     setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
     expect(canRenameThread({ creator_uid: "someone-else" }, undefined)).toBe(
       false
-    );
-  });
-
-  it("matches canManageThread (parent-group gate) across all role tiers", () => {
-    // 一致性回归：改名入口必须与归档/管理口径完全一致。若 module.tsx 改名 gate
-    // 漂移回 data.isManagerOrCreatorOfMe（子区缓存口径），canRenameThread 仍会与
-    // canManageThread 对齐，本断言保证两者不会分叉。
-    const tiers: Array<Array<{ uid: string; role: number }>> = [
-      [],
-      [{ uid: "me", role: GroupRole.owner }],
-      [{ uid: "me", role: GroupRole.manager }],
-      [{ uid: "me", role: GroupRole.normal }],
-    ];
-    const thread = { creator_uid: "someone-else" };
-    for (const members of tiers) {
-      subscribesByKey.clear();
-      if (members.length > 0) {
-        setGroupMembers(members);
-      }
-      expect(canRenameThread(thread, GROUP_NO)).toBe(
-        canManageThread(thread, GROUP_NO)
-      );
-    }
-    // 创建者快路径同样应一致
-    expect(canRenameThread({ creator_uid: "me" }, GROUP_NO)).toBe(
-      canManageThread({ creator_uid: "me" }, GROUP_NO)
     );
   });
 });

--- a/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../App", () => ({
   },
 }));
 
-import { canManageThread } from "../threadPermission";
+import { canManageThread, canRenameThread } from "../threadPermission";
 import { GroupRole } from "../Const";
 
 const GROUP_NO = "g1";
@@ -97,34 +97,70 @@ describe("canManageThread", () => {
 
 // issue #394：子区设置页「改名」入口此前用 data.isManagerOrCreatorOfMe（读子区频道
 // 成员缓存，从未同步、恒 false），把非创建者的父群群主/管理员误拦在前端、不发请求。
-// 修复后改名复用 canManageThread，与归档入口同口径。下面锁定该口径，防止再次回退。
-describe("thread rename permission gate (issue #394)", () => {
+// 修复后改名入口（module.tsx）改调 canRenameThread —— 与归档入口同口径。
+// 这里直接测 module.tsx 实际调用的 canRenameThread（而非底层 canManageThread），
+// 并断言「改名口径 == canManageThread 父群口径」，锁住此入口、防止再次回退。
+describe("canRenameThread (thread rename gate, issue #394)", () => {
   beforeEach(() => {
     subscribesByKey.clear();
   });
 
   it("allows the thread creator to rename", () => {
-    expect(canManageThread({ creator_uid: "me" }, GROUP_NO)).toBe(true);
+    expect(canRenameThread({ creator_uid: "me" }, GROUP_NO)).toBe(true);
   });
 
   it("allows a non-creator parent-group owner to rename", () => {
     setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
-    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+    expect(canRenameThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
       true
     );
   });
 
   it("allows a non-creator parent-group manager to rename", () => {
     setGroupMembers([{ uid: "me", role: GroupRole.manager }]);
-    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+    expect(canRenameThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
       true
     );
   });
 
   it("blocks an ordinary parent-group member from renaming", () => {
     setGroupMembers([{ uid: "me", role: GroupRole.normal }]);
-    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+    expect(canRenameThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
       false
+    );
+  });
+
+  it("fails closed when groupNo is undefined for a non-creator", () => {
+    // module.tsx 传入的是 threadInfo?.groupNo，可能为 undefined
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(canRenameThread({ creator_uid: "someone-else" }, undefined)).toBe(
+      false
+    );
+  });
+
+  it("matches canManageThread (parent-group gate) across all role tiers", () => {
+    // 一致性回归：改名入口必须与归档/管理口径完全一致。若 module.tsx 改名 gate
+    // 漂移回 data.isManagerOrCreatorOfMe（子区缓存口径），canRenameThread 仍会与
+    // canManageThread 对齐，本断言保证两者不会分叉。
+    const tiers: Array<Array<{ uid: string; role: number }>> = [
+      [],
+      [{ uid: "me", role: GroupRole.owner }],
+      [{ uid: "me", role: GroupRole.manager }],
+      [{ uid: "me", role: GroupRole.normal }],
+    ];
+    const thread = { creator_uid: "someone-else" };
+    for (const members of tiers) {
+      subscribesByKey.clear();
+      if (members.length > 0) {
+        setGroupMembers(members);
+      }
+      expect(canRenameThread(thread, GROUP_NO)).toBe(
+        canManageThread(thread, GROUP_NO)
+      );
+    }
+    // 创建者快路径同样应一致
+    expect(canRenameThread({ creator_uid: "me" }, GROUP_NO)).toBe(
+      canManageThread({ creator_uid: "me" }, GROUP_NO)
     );
   });
 });

--- a/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
@@ -94,3 +94,37 @@ describe("canManageThread", () => {
     expect(canManageThread({ creator_uid: "someone-else" }, "")).toBe(false);
   });
 });
+
+// issue #394：子区设置页「改名」入口此前用 data.isManagerOrCreatorOfMe（读子区频道
+// 成员缓存，从未同步、恒 false），把非创建者的父群群主/管理员误拦在前端、不发请求。
+// 修复后改名复用 canManageThread，与归档入口同口径。下面锁定该口径，防止再次回退。
+describe("thread rename permission gate (issue #394)", () => {
+  beforeEach(() => {
+    subscribesByKey.clear();
+  });
+
+  it("allows the thread creator to rename", () => {
+    expect(canManageThread({ creator_uid: "me" }, GROUP_NO)).toBe(true);
+  });
+
+  it("allows a non-creator parent-group owner to rename", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      true
+    );
+  });
+
+  it("allows a non-creator parent-group manager to rename", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.manager }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      true
+    );
+  });
+
+  it("blocks an ordinary parent-group member from renaming", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.normal }]);
+    expect(canManageThread({ creator_uid: "someone-else" }, GROUP_NO)).toBe(
+      false
+    );
+  });
+});

--- a/packages/dmworkbase/src/Service/threadPermission.ts
+++ b/packages/dmworkbase/src/Service/threadPermission.ts
@@ -37,6 +37,24 @@ export function canManageThread(
 }
 
 /**
+ * 子区设置页「改名」入口（module.tsx 的 thread.base.info）的权限判定。
+ *
+ * 与归档入口（{@link shouldShowThreadArchiveAction}）共享同一份父群口径
+ * {@link canManageThread}：创建者 / 父群群主 / 父群管理员可改名。改名不像归档那样
+ * 有状态门槛（Active/Archived），所以这里不做 status 过滤。
+ *
+ * 之所以抽成独立纯函数（而非在 module.tsx 内联判断），是为了让改名 gate 可被单测
+ * 直接锁定，避免再次回退到 data.isManagerOrCreatorOfMe —— 它读子区频道成员缓存，
+ * 从未同步、对非创建者的群主/管理员恒为 false，会在前端误拦他们（见 issue #394）。
+ */
+export function canRenameThread(
+  thread: { creator_uid?: string } | null | undefined,
+  groupNo: string | undefined
+): boolean {
+  return canManageThread(thread, groupNo ?? "");
+}
+
+/**
  * ChannelSetting「子区管理」入口（module.tsx 的 thread.actions，即 issue #283 的
  * 缺陷入口 A）的归档可见性判定。
  *

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -115,7 +115,10 @@ import {
 import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
-import { shouldShowThreadArchiveAction } from "./Service/threadPermission";
+import {
+  shouldShowThreadArchiveAction,
+  canManageThread,
+} from "./Service/threadPermission";
 import { runChannelSettingThreadArchive } from "./Service/threadArchiveAction";
 import { canShowRevokeMenu } from "./Service/revokePermission";
 
@@ -2211,11 +2214,12 @@ export default class BaseModule implements IModule {
         const channelInfo = data.channelInfo;
         const threadName = channelInfo?.title;
 
-        // 权限：只有创建者或群管理者可以修改名称
+        // 权限：创建者 / 父群群主 / 父群管理员可改名。必须走 canManageThread
+        // （父群成员口径），与归档入口保持一致；data.isManagerOrCreatorOfMe 读的是
+        // 子区频道成员缓存，从未同步，对非创建者的群主/管理员恒为 false，会误拦他们
+        // （见 issue #394：#314 统一归档可见性时遗漏了此改名入口）。
         const thread = channelInfo?.orgData?.thread as any;
-        const isCreator = thread?.creator_uid === WKApp.loginInfo.uid;
-        const isManagerOrOwner = data.isManagerOrCreatorOfMe;
-        const canEdit = isCreator || isManagerOrOwner;
+        const canEdit = canManageThread(thread, threadInfo?.groupNo ?? "");
         const statusTitle =
           thread?.status === ThreadStatus.Archived
             ? t("base.module.thread.status.archived")

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -117,7 +117,7 @@ import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
 import {
   shouldShowThreadArchiveAction,
-  canManageThread,
+  canRenameThread,
 } from "./Service/threadPermission";
 import { runChannelSettingThreadArchive } from "./Service/threadArchiveAction";
 import { canShowRevokeMenu } from "./Service/revokePermission";
@@ -2214,12 +2214,12 @@ export default class BaseModule implements IModule {
         const channelInfo = data.channelInfo;
         const threadName = channelInfo?.title;
 
-        // 权限：创建者 / 父群群主 / 父群管理员可改名。必须走 canManageThread
+        // 权限：创建者 / 父群群主 / 父群管理员可改名。必须走 canRenameThread
         // （父群成员口径），与归档入口保持一致；data.isManagerOrCreatorOfMe 读的是
         // 子区频道成员缓存，从未同步，对非创建者的群主/管理员恒为 false，会误拦他们
         // （见 issue #394：#314 统一归档可见性时遗漏了此改名入口）。
         const thread = channelInfo?.orgData?.thread as any;
-        const canEdit = canManageThread(thread, threadInfo?.groupNo ?? "");
+        const canEdit = canRenameThread(thread, threadInfo?.groupNo);
         const statusTitle =
           thread?.status === ThreadStatus.Archived
             ? t("base.module.thread.status.archived")

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -2217,7 +2217,7 @@ export default class BaseModule implements IModule {
         // 权限：创建者 / 父群群主 / 父群管理员可改名。必须走 canRenameThread
         // （父群成员口径），与归档入口保持一致；data.isManagerOrCreatorOfMe 读的是
         // 子区频道成员缓存，从未同步，对非创建者的群主/管理员恒为 false，会误拦他们
-        // （见 issue #394：#314 统一归档可见性时遗漏了此改名入口）。
+        // （见 issue #394：#283 统一归档可见性时遗漏了此改名入口）。
         const thread = channelInfo?.orgData?.thread as any;
         const canEdit = canRenameThread(thread, threadInfo?.groupNo);
         const statusTitle =


### PR DESCRIPTION
## Problem

Parent-group owners/admins (who are not the thread creator) cannot rename a thread from the **thread settings page (ChannelSetting)**. The click is blocked client-side with a "only creator or manager can edit" toast, and the `threadUpdate` backend API is never called. Only the thread creator can rename.

## Root cause

The rename entry gated on `data.isManagerOrCreatorOfMe`, which reads `subscriberOfMe.role` from the **thread channel's own** member cache (`ChannelTypeCommunityTopic`). That cache is never synced, so the value is **always false** for non-creator parent-group owners/managers — they get blocked at the front end.

PR #314 already migrated the **archive** action on the same settings page from `isManagerOrCreatorOfMe` to the parent-group-scoped `canManageThread`, but the **rename** row's onClick gate was left on the old, unreliable check. This PR fixes that omission.

## Change

- `packages/dmworkbase/src/module.tsx`: switch the rename gate to `canManageThread(thread, threadInfo?.groupNo ?? "")`, matching the archive entry. Remove the now-dead `isCreator` / `isManagerOrOwner` locals.
- `packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts`: add a regression suite pinning the rename gate across all role tiers (creator / parent-group owner / parent-group manager → allowed; ordinary member → blocked).

The creator fast-path is preserved: `canManageThread` checks `creator_uid` first and does not depend on any member cache, so creators keep working even if the parent-group member list is not yet synced.

## Test plan

- `vitest run` on `threadPermission.test.ts` + `threadArchiveAction.test.ts` → 31 passed (incl. 4 new rename-gate cases).
- tsc: no new type errors on changed lines.
- eslint: no leftover unused vars from the removed locals; new import is used.

Manual verification (recommended before release):
- [ ] As a parent-group owner who did NOT create the thread: open the thread settings page → tap the name → can edit and save.
- [ ] As a parent-group admin (manager): same as above.
- [ ] As the thread creator: rename still works.
- [ ] As an ordinary member: rename is blocked.

## Scope notes

- **Archive** is already correct via #314 (unchanged here).
- **Delete** is intentionally out of scope: the `ThreadList` delete gate is dead code (tracked in #282); the `ThreadPanel` "…" menu delete item currently has no client-side gate (over-permissive, opposite direction) — see #394 secondary notes.
- **Open question**: whether bot admins carry `GroupRole.manager` in the parent-group member list (which `canManageThread` would then allow) needs backend member-data confirmation; not verifiable from the front end.

Closes #394