### PR TITLE
fix(runtimes): npm daemon install hint + onboarding contract comment

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/CreateRuntimeModal.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/CreateRuntimeModal.tsx
@@ -12,7 +12,7 @@ import WKApp from '../../App';
 //     api_key, space_id,
 //     server_url, fleet_url, matter_url,
 //     commands: { install, start },
-//     env_vars: { OCTO_SERVER_URL, OCTO_FLEET_URL, OCTO_MATTER_URL }
+//     env_vars: { OCTO_SERVER_URL, OCTO_FLEET_URL }
 //   }
 
 interface OnboardingResp {

--- a/packages/dmworkbase/src/Pages/Runtimes/CreateRuntimeModal.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/CreateRuntimeModal.tsx
@@ -92,7 +92,7 @@ export function CreateRuntimeModal({ visible, onClose }: Props) {
           <>
             <Section
               title="① 安装"
-              hint="Go ≥ 1.21 环境"
+              hint="Node.js ≥ 18"
               cmd={data.commands.install}
               onCopy={() => copy(data.commands.install, '安装命令')}
             />


### PR DESCRIPTION
## What

Front-end side of the npm-daemon onboarding change (server PR:
Mininglamp-OSS/octo-server#373).

- **Install hint** in `CreateRuntimeModal`: `Go ≥ 1.21 环境` → `Node.js ≥ 18`
  (matches the npm-distributed `@mininglamp-oss/octo-daemon`, `engines: node >= 18`).
- **Contract comment**: drop `OCTO_MATTER_URL` from the documented `env_vars` shape
  so the comment matches what the server now returns. The top-level `matter_url`
  field is unchanged (still documented + typed).

## Notes

No rendered behavior change beyond the hint text; the modal already only displays
the `install` / `start` command strings. `matter_url` remains in the `OnboardingResp`
type for forward-compat (server keeps emitting it).