### PR TITLE
feat(summary): support scheduled updates when creating from sidebar quick-create modal (#398)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -299,9 +299,6 @@ export default class ChatSummaryNewModal extends Component<
                                 ? t('summary.create.selectedChats', { values: { count: selectedChats.length } })
                                 : t('summary.create.selectChat')}
                         </Button>
-                        <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--semi-color-text-2)' }}>
-                            {t('summary.create.archivedNotice')}
-                        </span>
                         <Button
                             theme="borderless"
                             icon={<IconClock />}
@@ -316,6 +313,9 @@ export default class ChatSummaryNewModal extends Component<
                                 ? this.getScheduleLabel(scheduleConfig)
                                 : t('summary.schedule.config.title')}
                         </Button>
+                        <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--semi-color-text-2)' }}>
+                            {t('summary.create.archivedNotice')}
+                        </span>
                         {selectedChats.length > 0 && (
                             <div className="chat-summary-modal-chat-tags">
                                 {selectedChats.map((c) => (

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -1,18 +1,20 @@
 import React, { Component, createRef } from 'react';
 import { Modal, Toast, Tag, Button } from '@douyinfe/semi-ui';
-import { IconPlus } from '@douyinfe/semi-icons';
+import { IconPlus, IconClock } from '@douyinfe/semi-icons';
 import { WKApp, I18nContext } from '@octo/base';
-import type { TopicTemplate, ChatCandidate } from '../types/summary';
-import { SourceType } from '../types/summary';
+import type { TopicTemplate, ChatCandidate, ScheduleConfig } from '../types/summary';
+import { SourceType, SummaryMode } from '../types/summary';
 import { getSourceType } from '../utils/channelType';
 import { channelToChatCandidate } from '../utils/channelConvert';
 import { resolveTemplate, computeTemplateSelection, type ResolvableTemplate } from '../utils/templateResolver';
+import { describeSchedule, scheduleToParams } from '../utils/summaryHelpers';
 import * as summaryApi from '../api/summaryApi';
 import { getTopicTemplates } from '../api/summaryApi';
 import { TOPIC_TEMPLATES } from '../constants/templates';
 import { MAX_CHAT_SELECT } from '../constants/limits';
 import TemplateCard from './TemplateCard';
 import ChatSelectorModal from './ChatSelectorModal';
+import ScheduleConfigModal from './ScheduleConfigModal';
 import './ChatSummaryNewModal.css';
 
 interface ChatSummaryNewModalProps {
@@ -29,6 +31,8 @@ interface ChatSummaryNewModalState {
     showChatSelector: boolean;
     submitting: boolean;
     templatePlaceholderRange: [number, number] | null;
+    scheduleConfig: ScheduleConfig | null;
+    showScheduleConfig: boolean;
 }
 
 export default class ChatSummaryNewModal extends Component<
@@ -49,6 +53,8 @@ export default class ChatSummaryNewModal extends Component<
             showChatSelector: false,
             submitting: false,
             templatePlaceholderRange: null,
+            scheduleConfig: null,
+            showScheduleConfig: false,
         };
     }
 
@@ -69,6 +75,8 @@ export default class ChatSummaryNewModal extends Component<
                 showChatSelector: false,
                 submitting: false,
                 templatePlaceholderRange: null,
+                scheduleConfig: null,
+                showScheduleConfig: false,
             });
             void this.loadTemplates();
         }
@@ -117,8 +125,13 @@ export default class ChatSummaryNewModal extends Component<
         });
     };
 
+    private getScheduleLabel(cfg: ScheduleConfig): string {
+        const { cron_expr, interval_days, interval_months, run_time, day_of_week, day_of_month } = scheduleToParams(cfg);
+        return describeSchedule(cron_expr, interval_days, interval_months, run_time, day_of_week, day_of_month);
+    }
+
     private handleSubmit = async () => {
-        const { topic, selectedChats } = this.state;
+        const { topic, selectedChats, scheduleConfig } = this.state;
         const { channel, onSubmit } = this.props;
 
         if (!topic.trim()) return;
@@ -150,6 +163,32 @@ export default class ChatSummaryNewModal extends Component<
                 origin_channel_type: sourceType,
                 sources,
             });
+
+            // 若配置了定时：仿完整页，在 scope='task' 下由后端在一个事务里原子完成
+            // 「建定时 + 绑定到 task_id」。总结本身已创建成功，定时失败仅提示不阻断。
+            if (scheduleConfig !== null) {
+                const { cron_expr, interval_days, interval_months, day_of_week, day_of_month, run_time } = scheduleToParams(scheduleConfig);
+                try {
+                    await summaryApi.createSchedule({
+                        title: topic.trim(),
+                        summary_mode: SummaryMode.BY_PERSON,
+                        cron_expr,
+                        interval_days,
+                        interval_months,
+                        day_of_week,
+                        day_of_month,
+                        run_time,
+                        time_range_type: 2,
+                        sources,
+                        scope: 'task',
+                        task_id: res.task_id,
+                    });
+                } catch (scheduleErr: any) {
+                    // 与完整页 SummaryCreatePage 对齐：优先透出后端 message，回落 i18n 文案。
+                    Toast.error(scheduleErr?.message || this.context.t('summary.create.scheduleFailed'));
+                }
+            }
+
             window.dispatchEvent(
                 new CustomEvent('chat-summary-created', {
                     detail: { taskId: res.task_id, channelId: channel.channelID },
@@ -174,7 +213,7 @@ export default class ChatSummaryNewModal extends Component<
 
     render() {
         const { visible, onClose } = this.props;
-        const { topic, templates, selectedChats, showChatSelector, submitting } = this.state;
+        const { topic, templates, selectedChats, showChatSelector, submitting, scheduleConfig, showScheduleConfig } = this.state;
         const { t } = this.context;
         // 模板在 render() 用当前 locale 解析，切语言即时刷新（不在 state 烘焙）。
         const resolvedTemplates = templates.map((tpl) => resolveTemplate(tpl, t));
@@ -263,6 +302,20 @@ export default class ChatSummaryNewModal extends Component<
                         <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--semi-color-text-2)' }}>
                             {t('summary.create.archivedNotice')}
                         </span>
+                        <Button
+                            theme="borderless"
+                            icon={<IconClock />}
+                            size="small"
+                            onClick={() => this.setState({ showScheduleConfig: true })}
+                            style={{
+                                marginLeft: 8,
+                                color: scheduleConfig ? 'var(--wk-color-primary, #3370FF)' : undefined,
+                            }}
+                        >
+                            {scheduleConfig
+                                ? this.getScheduleLabel(scheduleConfig)
+                                : t('summary.schedule.config.title')}
+                        </Button>
                         {selectedChats.length > 0 && (
                             <div className="chat-summary-modal-chat-tags">
                                 {selectedChats.map((c) => (
@@ -288,6 +341,13 @@ export default class ChatSummaryNewModal extends Component<
                         this.setState({ selectedChats: chats, showChatSelector: false })
                     }
                     onCancel={() => this.setState({ showChatSelector: false })}
+                />
+
+                <ScheduleConfigModal
+                    visible={showScheduleConfig}
+                    value={scheduleConfig ?? { unit: 'week', every: 1, time: '09:00' }}
+                    onConfirm={(cfg) => this.setState({ scheduleConfig: cfg, showScheduleConfig: false })}
+                    onCancel={() => this.setState({ showScheduleConfig: false })}
                 />
             </>
         );

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.schedule.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.schedule.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ChatSummaryNewModal 间接 import 的链路里含 wukongimjssdk / semi-ui，
+// 在测试环境会拉起无关重依赖，这里与 SummaryCreatePage.schedule.test 一致地 mock 掉。
+vi.mock('wukongimjssdk', () => ({
+    Channel: class {},
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    MessageText: class {},
+    WKSDK: { shared: () => ({ chatManager: { send: vi.fn() } }) },
+}));
+vi.mock('@douyinfe/semi-ui', () => {
+    const Passthrough = ({ children }: any) => children ?? null;
+    return {
+        Modal: Passthrough,
+        Button: Passthrough,
+        Tag: Passthrough,
+        Toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    };
+});
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconPlus: () => null,
+    IconClock: () => null,
+}));
+
+// 与现有 ChatSummaryNewModal.test.tsx 一致：mock 掉 channelType，绕过 @octo/base 的
+// parseThreadChannelId（依赖 wukongimjssdk 运行时），单测只关心 schedule 绑定逻辑。
+vi.mock('../../utils/channelType', () => ({
+    getSourceType: () => 2,
+}));
+
+import * as summaryApi from '../../api/summaryApi';
+import ChatSummaryNewModal from '../ChatSummaryNewModal';
+
+// 回归测试：聊天框右上角入口的「新建智能总结」弹窗，配置了定时后必须仿照完整页，
+// 用「一步式」createSchedule —— 参数直接带 scope='task' + task_id，由后端在一个
+// 事务里原子完成「建定时 + 绑定 summary_task.schedule_id」。
+vi.mock('../../api/summaryApi');
+
+describe('ChatSummaryNewModal — schedule binding on create', () => {
+    const channel = { channelID: 'g123', channelType: 2 };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    function makeModal(scheduleConfig: any) {
+        const onSubmit = vi.fn();
+        const modal = new ChatSummaryNewModal({
+            visible: true,
+            channel,
+            onClose: vi.fn(),
+            onSubmit,
+        });
+        (modal as any).context = { t: (k: string) => k };
+        (modal as any).setState = function (this: any, patch: any) {
+            this.state = { ...this.state, ...(typeof patch === 'function' ? patch(this.state) : patch) };
+        };
+        modal.state = {
+            ...(modal.state as any),
+            topic: '群聊总结',
+            selectedChats: [],
+            scheduleConfig,
+            submitting: false,
+        } as any;
+        return { modal, onSubmit };
+    }
+
+    it('one-step createSchedule with scope=task + task_id when schedule configured', async () => {
+        const TASK_ID = 9001;
+        vi.mocked(summaryApi.createSummary).mockResolvedValue({ task_id: TASK_ID } as any);
+        vi.mocked(summaryApi.createSchedule).mockResolvedValue({ schedule_id: 5 } as any);
+
+        const { modal, onSubmit } = makeModal({ unit: 'week', every: 1, time: '09:00' });
+        await (modal as any).handleSubmit();
+
+        expect(summaryApi.createSummary).toHaveBeenCalledTimes(1);
+        expect(summaryApi.createSchedule).toHaveBeenCalledTimes(1);
+        expect(summaryApi.createSchedule).toHaveBeenCalledWith(
+            expect.objectContaining({ scope: 'task', task_id: TASK_ID }),
+        );
+        // 成功后仍回调 onSubmit，照常进入详情。
+        expect(onSubmit).toHaveBeenCalledWith(TASK_ID);
+    });
+
+    it('does not call createSchedule when no schedule configured', async () => {
+        vi.mocked(summaryApi.createSummary).mockResolvedValue({ task_id: 1 } as any);
+
+        const { modal } = makeModal(null);
+        await (modal as any).handleSubmit();
+
+        expect(summaryApi.createSummary).toHaveBeenCalledTimes(1);
+        expect(summaryApi.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('on schedule create failure (Error):透出后端 message, 主流程不阻断 onSubmit 仍调用', async () => {
+        const TASK_ID = 9002;
+        vi.mocked(summaryApi.createSummary).mockResolvedValue({ task_id: TASK_ID } as any);
+        vi.mocked(summaryApi.createSchedule).mockRejectedValue(new Error('一对一约束'));
+
+        const { Toast } = await import('@douyinfe/semi-ui');
+        const { modal, onSubmit } = makeModal({ unit: 'week', every: 1, time: '09:00' });
+        await (modal as any).handleSubmit();
+
+        expect(Toast.error).toHaveBeenCalledWith('一对一约束');
+        // 总结本身已创建成功，不因定时失败而阻断主流程。
+        expect(onSubmit).toHaveBeenCalledWith(TASK_ID);
+    });
+
+    it('on schedule create failure (无 message): 回落到 i18n scheduleFailed 文案', async () => {
+        const TASK_ID = 9003;
+        vi.mocked(summaryApi.createSummary).mockResolvedValue({ task_id: TASK_ID } as any);
+        // 后端抛出非标准 Error（无 message），应回落 i18n key。
+        vi.mocked(summaryApi.createSchedule).mockRejectedValue({});
+
+        const { Toast } = await import('@douyinfe/semi-ui');
+        const { modal, onSubmit } = makeModal({ unit: 'week', every: 1, time: '09:00' });
+        await (modal as any).handleSubmit();
+
+        // context.t 在测试里被注入为 (k) => k，故回落值即 key 本身。
+        expect(Toast.error).toHaveBeenCalledWith('summary.create.scheduleFailed');
+        expect(onSubmit).toHaveBeenCalledWith(TASK_ID);
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -68,6 +68,10 @@ vi.mock('../ChatSelectorModal', () => ({
     default: () => null,
 }));
 
+vi.mock('../ScheduleConfigModal', () => ({
+    default: () => null,
+}));
+
 vi.mock('../../constants/templates', () => ({
     TOPIC_TEMPLATES: [
         { id: 'project_progress', label: '汇总项目进展', icon: 'FileText', description: '总结进展', type: 'parameterized', pattern: '总结 {project_name} 的项目进展', placeholders: [{ key: 'project_name', label: '输入项目名称', position: [3, 9] }] },


### PR DESCRIPTION
## 关联 issue

Closes #398

## 本 PR 解决什么

侧边栏「智能总结」**新建任务时缺少定时/周期执行入口** —— 右上角快捷新建弹窗（ChatSummaryNewModal）此前只能立即生成总结，无法像完整创建页那样配置定时更新。本 PR 为该弹窗补齐定时配置能力。

## 改动

仿照完整创建页 SummaryCreatePage 的定时交互：

- 新建弹窗新增「定时更新」入口按钮，复用既有 `ScheduleConfigModal`
- 创建总结成功后，若配置了定时，则以 `scope='task'` + `task_id` 一步式调用 `createSchedule`，由后端在一个事务里原子完成「建定时 + 绑定到 task」
- 定时失败仅 Toast 提示、不阻断总结主流程（与完整页一致）；失败文案优先后端 message，回落 i18n
- 「定时更新」按钮置于「默认总结活跃子区，不含已归档子区」说明文案**之前**
- 复用既有 i18n key，无新增文案
- 纯前端改动；后端 `createSchedule` API 已就绪

## 关于 issue 中「已完成的总结无法设置定时」的说明（澄清，无需改动）

issue 描述里提到「已完成任务也无法设置为定时重复执行」——**这一点与现状不符**。

**已完成的总结详情页（SummaryDetailPage）原本就有「设置定时更新」入口**（`openScheduleModal`，文案 i18n `summary.detail.setSchedule`="设置定时更新"），可直接把已完成总结转为定时任务。该能力一直存在，**本 PR 不涉及、也无需修改这部分**。

因此本 PR 聚焦并仅修复 issue 的真实缺口：**新建任务时的定时入口缺失**。

## 测试

- 新增 `ChatSummaryNewModal.schedule.test.tsx`：覆盖 配置定时 / 未配置 / 失败(Error) / 失败(无 message 回落 i18n) 四条路径
- 现有弹窗测试补 mock `ScheduleConfigModal` 子组件隔离
- `@dmwork/summary` 包测试全过

## 范围说明

后端通知/触发机制在 octo-smart-summary#96 跟踪，不在本 PR 范围。
