### PR TITLE
feat(runtimes): localize detail labels, device-level runtime mode, header cleanup

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotDetailPanel.tsx
@@ -138,7 +138,7 @@ function InfoTab({ bot }: { bot: Bot }) {
       <h3 className="wk-bd-section__title">配置</h3>
       <dl className="wk-bd-props">
         {/* PR-2: 删 #runtime_id (dev 级 PK, 用户用不到), 只留 kind. */}
-        <PropRow label="Runtime" value={<span className="wk-bd-mono">{bot.runtime_kind}</span>} />
+        <PropRow label="运行时" value={<span className="wk-bd-mono">{bot.runtime_kind}</span>} />
         <PropRow label="所有者" value={<OwnerLabel ownerUid={bot.owner_uid} />} />
         <PropRow label="状态" value={<span className="wk-bd-mono">{bot.status}</span>} />
         {/* PR-2: 删 Workspace 字段 — dev 级实现细节, 用户不需要管. */}

--- a/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/CreateBotModal.tsx
@@ -252,12 +252,6 @@ export function CreateBotModal({ visible, runtimes, onClose, onCreated }: Props)
             </div>
           )}
         </div>
-
-        {selectedRuntime?.supported && selectedRuntime.kind === 'openclaw' && (
-          <div className="wk-rt-cb__hint">
-            openclaw workspace 名将自动派生
-          </div>
-        )}
       </div>
     </Modal>
   );

--- a/packages/dmworkbase/src/Pages/Runtimes/deviceRuntimeMode.test.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/deviceRuntimeMode.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { deviceRuntimeMode } from "./deviceRuntimeMode"
+
+// 构造最小入参 —— deviceRuntimeMode 只读 group.runtimes[].runtime_mode。
+function group(modes: Array<string | null | undefined>): { runtimes: Array<{ runtime_mode?: string | null }> } {
+    return { runtimes: modes.map((m) => ({ runtime_mode: m })) }
+}
+
+describe("deviceRuntimeMode — device 级 runtime_mode 去重", () => {
+    it("0 个 runtime → 未知", () => {
+        expect(deviceRuntimeMode(group([]))).toBe("未知")
+    })
+
+    it("全空字符串 runtime_mode(去重后无有效值)→ 未知", () => {
+        expect(deviceRuntimeMode(group(["", ""]))).toBe("未知")
+    })
+
+    it("1 个 runtime → 返回该值", () => {
+        expect(deviceRuntimeMode(group(["local"]))).toBe("local")
+    })
+
+    it("多个 runtime 同一 mode(去重后 1 个)→ 返回该值", () => {
+        expect(deviceRuntimeMode(group(["local", "local", "local"]))).toBe("local")
+    })
+
+    it("多个 runtime 不同 mode(去重后 >1)→ 混合", () => {
+        expect(deviceRuntimeMode(group(["local", "remote"]))).toBe("混合")
+    })
+
+    it("混入空值后仍有 1 个有效唯一值 → 返回该有效值(空值不算独立 mode)", () => {
+        expect(deviceRuntimeMode(group(["local", "", "local"]))).toBe("local")
+    })
+
+    it("多有效值 + 空值混合(去重后 >1)→ 混合", () => {
+        expect(deviceRuntimeMode(group(["local", "", "remote"]))).toBe("混合")
+    })
+
+    it("null runtime_mode 视为无效值 → 未知", () => {
+        expect(deviceRuntimeMode(group([null]))).toBe("未知")
+    })
+
+    it("undefined runtime_mode 视为无效值 → 未知", () => {
+        expect(deviceRuntimeMode(group([undefined]))).toBe("未知")
+    })
+
+    it("有效值混入 null / undefined → 返回该有效值", () => {
+        expect(deviceRuntimeMode(group(["local", null, undefined]))).toBe("local")
+    })
+})

--- a/packages/dmworkbase/src/Pages/Runtimes/deviceRuntimeMode.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/deviceRuntimeMode.ts
@@ -1,0 +1,17 @@
+// 取 device 下所有 runtime 的 runtime_mode 去重结果(device 级展示):
+//   - 0 个有效值 → "未知"
+//   - 1 个唯一值 → 该值
+//   - >1 个唯一值 → "混合"(混合部署 / 脏数据,不取 runtimes[0] 静默误显示)
+// 空字符串 / null / undefined 的 runtime_mode 视为无效值,不计入去重集合。
+//
+// 独立无副作用文件:index.tsx 与单测都从这里 import,避免把页面模块的
+// 顶层副作用(WKApp / Semi / CSS / BotsTab 等)拉进 vitest。
+export function deviceRuntimeMode(group: { runtimes: Array<{ runtime_mode?: string | null }> }): string {
+    const modes = new Set<string>()
+    for (const r of group.runtimes) {
+        if (r.runtime_mode) modes.add(r.runtime_mode)
+    }
+    if (modes.size === 0) return "未知"
+    if (modes.size === 1) return modes.values().next().value as string
+    return "混合"
+}

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -996,20 +996,6 @@
   border-bottom: 1px solid var(--border-light);
 }
 
-/* Meta info (count / online status) sits at the trailing edge of the
- * header, next to the create button — mirrors the conversation list's
- * "ping" chip. Online count leads, with a status dot for quick scanning. */
-.wk-rt-pageheader__meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  margin-left: auto;
-  font-size: 12px;
-  color: var(--wk-text-tertiary);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
 /* Primary action button hosted in the page header (Bot tab uses it for
  * "+ 新建"). Style mirrors .wk-rt-upgrade-btn — light grey on hairline
  * border — so it reads as a secondary chrome control, not a hero CTA. */
@@ -1634,6 +1620,10 @@
 }
 .wk-rt-create-wrap {
   position: relative;
+  /* 把 + 推到顶栏最右(原由已删的 .wk-rt-pageheader__meta 的 margin-left:auto
+     承担)。这样创建下拉(.wk-rt-create-menu right:0)从右缘往左展开,落在可见
+     内容区,而不是贴标题左侧、被左侧栏裁掉。 */
+  margin-left: auto;
 }
 .wk-rt-create-btn {
   display: inline-flex;

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -5,6 +5,7 @@ import WKApp from "../../App"
 import WKAvatar from "../../Components/WKAvatar"
 import { BotsTab, type BotsTabHandle } from "./BotsTab"
 import { CreateRuntimeModal } from "./CreateRuntimeModal"
+import { deviceRuntimeMode } from "./deviceRuntimeMode"
 import { Bot, botStatusLabel, listBots, providerLabels } from "./botsApi"
 import { ProviderLogo } from "./providerLogos"
 import "./index.css"
@@ -321,6 +322,10 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                     <div className="wk-rt-field">
                         <label>Runtimes</label>
                         <span>{group.runtimes.length}</span>
+                    </div>
+                    <div className="wk-rt-field">
+                        <label>运行模式</label>
+                        <span>{deviceRuntimeMode(group)}</span>
                     </div>
                     {(group.osName || group.arch) && (
                         <div className="wk-rt-field">
@@ -1309,10 +1314,6 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                 </div>
 
                 <div className="wk-rt-detail-grid wk-rt-detail-grid--single">
-                    <div className="wk-rt-field">
-                        <label>Runtime Mode</label>
-                        <span>{rt.runtime_mode}</span>
-                    </div>
                     <div className="wk-rt-field">
                         <label>Provider</label>
                         <span>{providerLabels[rt.provider] || rt.provider}</span>

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -1942,11 +1942,6 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     render() {
         const { runtimes, selectedId, loading, expandedDevices, createMenuOpen, runtimeModalOpen } = this.state
         const groups = groupByDevice(runtimes)
-        // "M online" 含义重定义 — 不再是
-        // 顶部计数纯报"装置-运行时"槽位规模, 不报死活. 单 runtime 死活
-        // 由 DeviceDetail 右上角 "X/Y Online" 表达; 顶栏只回答 "我有几个
-        // device, 加起来几个 runtime", 跟左树展开后的总条数一致.
-        const totalRuntimes = groups.reduce((sum, g) => sum + g.runtimes.length, 0)
 
         return (
             <div className="wk-rt-list">
@@ -1959,9 +1954,6 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                 <div className="wk-rt-pageheader">
                     <div className="wk-rt-pagetitle">
                         <h2 className="wk-rt-pagetitle-text">运行时</h2>
-                        <span className="wk-rt-pageheader__meta" aria-live="polite">
-                            {groups.length} device{groups.length !== 1 ? "s" : ""} · {totalRuntimes} runtime{totalRuntimes !== 1 ? "s" : ""}
-                        </span>
                         <div className="wk-rt-create-wrap">
                             <button
                                 ref={this.createBtnRef}

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -316,11 +316,11 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
 
                 <div className="wk-rt-detail-grid">
                     <div className="wk-rt-field">
-                        <label>Device Name</label>
+                        <label>设备名称</label>
                         <span>{group.deviceName}</span>
                     </div>
                     <div className="wk-rt-field">
-                        <label>Runtimes</label>
+                        <label>运行时</label>
                         <span>{group.runtimes.length}</span>
                     </div>
                     <div className="wk-rt-field">
@@ -329,13 +329,13 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                     </div>
                     {(group.osName || group.arch) && (
                         <div className="wk-rt-field">
-                            <label>OS / Arch</label>
+                            <label>系统 / 架构</label>
                             <span>{[group.osName, group.arch].filter(Boolean).join(" ")}</span>
                         </div>
                     )}
                     {group.cliVersion && (
                         <div className="wk-rt-field">
-                            <label>Daemon Version</label>
+                            <label>Daemon 版本</label>
                             <span className="wk-rt-mono">
                                 {group.cliVersion}
                                 {this.props.daemonVersionHint?.has_update && (
@@ -383,7 +383,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                         </div>
                     )}
                     <div className="wk-rt-field">
-                        <label>Daemon ID</label>
+                        <label>设备 ID</label>
                         <span className="wk-rt-mono">{group.daemonId}</span>
                     </div>
                     {(() => {
@@ -397,7 +397,7 @@ class DeviceDetail extends Component<DeviceDetailProps, DeviceDetailState> {
                         if (!ms) return null
                         return (
                             <div className="wk-rt-field">
-                                <label>Last Active</label>
+                                <label>最近活跃</label>
                                 <span title={new Date(ms).toLocaleString()}>
                                     {humanizeAge(ms)}
                                 </span>
@@ -1315,18 +1315,18 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
 
                 <div className="wk-rt-detail-grid wk-rt-detail-grid--single">
                     <div className="wk-rt-field">
-                        <label>Provider</label>
+                        <label>提供方</label>
                         <span>{providerLabels[rt.provider] || rt.provider}</span>
                     </div>
                     <div className="wk-rt-field">
-                        <label>Bots</label>
+                        <label>Bot 数量</label>
                         <span>{this.props.botCount ?? 0}</span>
                     </div>
                     {/* PR-2: 探活由 device row 绿点 + daemon heartbeat
                         体现; runtime 级 last_seen_at / device_name /
                         daemon_id 都是 dev 调试字段, 用户不需要看到, 全删. */}
                     <div className="wk-rt-field">
-                        <label>Version</label>
+                        <label>版本</label>
                         <span className="wk-rt-mono">
                             {rt.version || "N/A"}
                             {this.props.versionHints[rt.id]?.has_update && (
@@ -1340,7 +1340,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                         const pluginHint = this.props.versionHints[rt.id]
                         return octoPlugin ? (
                             <div className="wk-rt-field">
-                                <label>Octo Plugin</label>
+                                <label>Octo 插件</label>
                                 <span className="wk-rt-mono">
                                     {octoPlugin.version}
                                     {pluginHint?.plugin_has_update && (
@@ -1358,8 +1358,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     的"创建 Bot"重复. caster 拍的去重. */}
 
                 <div className="wk-rt-detail-footer">
-                    <span>Created: {rt.created_at}</span>
-                    <span>Updated: {rt.updated_at}</span>
+                    <span>创建于:{rt.created_at}</span>
+                    <span>更新于:{rt.updated_at}</span>
                 </div>
                 {deleting && <div className="wk-rt-deleting-overlay">Deleting...</div>}
             </div>

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -92,10 +92,10 @@ function humanizeAge(epochMs: number): string {
     if (!epochMs) return "—"
     const diff = Date.now() - epochMs
     if (diff < 0)          return "—"
-    if (diff < 60_000)     return "Just now"
-    if (diff < 3_600_000)  return `${Math.floor(diff / 60_000)} min ago`
-    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} hr ago`
-    return `${Math.floor(diff / 86_400_000)} day${Math.floor(diff / 86_400_000) === 1 ? "" : "s"} ago`
+    if (diff < 60_000)     return "刚刚"
+    if (diff < 3_600_000)  return `${Math.floor(diff / 60_000)} 分钟前`
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`
+    return `${Math.floor(diff / 86_400_000)} 天前`
 }
 
 // 取 device 下所有 runtime 的 max last_seen_at, 返 epoch ms (无则 0).
@@ -1340,7 +1340,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                         const pluginHint = this.props.versionHints[rt.id]
                         return octoPlugin ? (
                             <div className="wk-rt-field">
-                                <label>Octo 插件</label>
+                                <label>Octo 插件版本</label>
                                 <span className="wk-rt-mono">
                                     {octoPlugin.version}
                                     {pluginHint?.plugin_has_update && (


### PR DESCRIPTION
## Summary

Chapter 3 of the runtime UI work: localize the Runtimes detail panel, move Runtime Mode to the device level, and clean up the page header. Builds on chapters 1–2 (already merged).

> Note: per-commit messages are in Chinese; this repo squash-merges, so the squash commit takes this (English, Conventional Commits) PR title.

## Related Issue

No tracking issue. Follows the provider-registry (#400) and server-ping-removal (#401) PRs.

## Changes

- Header: remove the English "N devices · M runtimes" count; restore the create (+) button to the right edge (its right-push was lost when the count span was removed) so the create dropdown opens into the visible area instead of being clipped by the sidebar; drop the now-dead count CSS.
- Runtime Mode shown at the **device** level via a `deviceRuntimeMode(group)` helper (dedup across the device's runtimes → "未知" / the value / "混合"; never silently picks runtimes[0]). `created_at` / `updated_at` stay at runtime level.
- Localize detail-panel labels to Chinese; unify `Octo 插件` → `Octo 插件版本` (parallel with `Daemon 版本`); localize the Last Active relative-time strings (刚刚 / X 分钟前 / X 小时前 / X 天前).
- Remove the "openclaw workspace 名将自动派生" hint from Create Bot.

## Testing

- `pnpm lint` green; `deviceRuntimeMode` unit test 10/10.
- Manually verified on the local dev server: labels localized, no count text, + button on the right with dropdown fully visible, runtime mode at device level.
- [x] Unit tests added/updated (deviceRuntimeMode)
- [x] Manually verified

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes (deviceRuntimeMode)
- [x] Updated documentation (in-code comments)
- [x] Ran \`pnpm i18n:check\` or confirmed the change does not affect UI copy (labels localized in-place; no new i18n keys introduced — consistent with the page's existing hardcoded-string style)
- [x] Followed commit message conventions (squash commit uses this Conventional-Commits PR title)