### PR TITLE
fix(global-search): close search modal when bot detail sends message

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tab-contacts.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tab-contacts.test.tsx
@@ -152,4 +152,28 @@ describe("TabContacts #397 close outer GlobalSearch on bot send", () => {
         expect(onClick).toHaveBeenCalledTimes(1);
         expect(onClose).not.toHaveBeenCalled();
     });
+
+    it("bot path without onClose prop: send message still navigates and does not throw", () => {
+        // Guards the optional-chaining `this.props.onClose?.()`: callers that
+        // omit onClose (e.g. Contacts/Subscribers) must not crash on bot send.
+        mocks.isBot.mockReturnValue(true);
+        const onClick = vi.fn();
+
+        // No onClose passed.
+        renderTab({ onClick });
+
+        act(() => {
+            fireEvent.click(friendItem());
+        });
+        const sendBtn = container.querySelector(
+            '[data-testid="bot-send"]'
+        ) as HTMLElement;
+        expect(() => {
+            act(() => {
+                fireEvent.click(sendBtn);
+            });
+        }).not.toThrow();
+
+        expect(mocks.showConversation).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tab-contacts.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tab-contacts.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { fireEvent } from "@testing-library/dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    isBot: vi.fn(),
+    showConversation: vi.fn(),
+}));
+
+// Render every data item directly — no viewport virtualization.
+vi.mock("react-virtuoso", () => ({
+    Virtuoso: ({ data, itemContent }: any) => (
+        <div data-testid="virtuoso">
+            {(data ?? []).map((item: any, i: number) => (
+                <div key={i}>{itemContent(i, item)}</div>
+            ))}
+        </div>
+    ),
+}));
+
+// BotDetailModal exposes a "发送消息" button (when visible) that fires onChat.
+vi.mock("../../BotDetailModal", () => ({
+    default: ({ visible, onChat }: any) =>
+        visible ? (
+            <button data-testid="bot-send" onClick={() => onChat({})}>
+                发送消息
+            </button>
+        ) : null,
+}));
+
+// isBot is imported from ../WKAvatar in tab-contacts.tsx; keep WKAvatar/AiBadge light.
+vi.mock("../../WKAvatar", () => ({
+    isBot: mocks.isBot,
+    default: () => <div data-testid="wk-avatar" />,
+}));
+
+vi.mock("../../AiBadge", () => ({
+    default: () => <span data-testid="ai-badge">AI</span>,
+}));
+
+vi.mock("../../../App", () => ({
+    default: {
+        endpoints: {
+            showConversation: mocks.showConversation,
+        },
+        shared: {
+            avatarUser: vi.fn(() => "avatar.png"),
+        },
+    },
+}));
+
+vi.mock("wukongimjssdk", () => {
+    class Channel {
+        channelID: string;
+        channelType: number;
+        constructor(channelID: string, channelType: number) {
+            this.channelID = channelID;
+            this.channelType = channelType;
+        }
+    }
+    return {
+        default: {
+            shared: () => ({
+                channelManager: {
+                    addListener: vi.fn(),
+                    removeListener: vi.fn(),
+                    getChannelInfo: vi.fn(() => undefined),
+                    fetchChannelInfo: vi.fn(),
+                },
+            }),
+        },
+        Channel,
+        ChannelTypePerson: 1,
+    };
+});
+
+import TabContacts from "../tab-contacts";
+
+const FRIEND = { channel_id: "bot-1", channel_name: "Bot One" };
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+});
+
+function renderTab(props: any) {
+    act(() => {
+        ReactDOM.render(<TabContacts friends={[FRIEND]} {...props} />, container);
+    });
+}
+
+function friendItem(): HTMLElement {
+    // ItemContacts renders the name via dangerouslySetInnerHTML; find by text.
+    const el = Array.from(container.querySelectorAll(".wk-item-contacts")).find(
+        (node) => node.textContent?.includes("Bot One")
+    );
+    return el as HTMLElement;
+}
+
+describe("TabContacts #397 close outer GlobalSearch on bot send", () => {
+    it("bot path: send message calls showConversation and onClose, not onClick", () => {
+        mocks.isBot.mockReturnValue(true);
+        const onClick = vi.fn();
+        const onClose = vi.fn();
+
+        renderTab({ onClick, onClose });
+
+        // Click the friend item -> opens the bot detail card.
+        act(() => {
+            fireEvent.click(friendItem());
+        });
+        // Trigger the card's "发送消息".
+        const sendBtn = container.querySelector(
+            '[data-testid="bot-send"]'
+        ) as HTMLElement;
+        act(() => {
+            fireEvent.click(sendBtn);
+        });
+
+        expect(mocks.showConversation).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("normal contact path: click calls onClick once and never onClose", () => {
+        mocks.isBot.mockReturnValue(false);
+        const onClick = vi.fn();
+        const onClose = vi.fn();
+
+        renderTab({ onClick, onClose });
+
+        act(() => {
+            fireEvent.click(friendItem());
+        });
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/index.tsx
@@ -15,6 +15,8 @@ interface GlobalSearchProps {
     channel?: Channel; // 查询指定频道的聊天记录
     // item点击事件，传递item和type，type为contacts、group、message,file
     onClick?: (item: any, type: string) => void;
+    // #397: 关闭外层搜索框（透传给 TabContacts）
+    onClose?: () => void;
 }
 
 export default class GlobalSearch extends Component<GlobalSearchProps> {
@@ -61,6 +63,7 @@ export default class GlobalSearch extends Component<GlobalSearchProps> {
                     friends={vm.searchResult?.friends}
                     keyword={vm.keyword}
                     onClick={onClickOf("contacts")}
+                    onClose={this.props.onClose}
                 />
             </div>
             <div style={panelStyle("groups")}>

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
@@ -14,6 +14,8 @@ interface TabContactsProps {
     keyword?: string;
     friends?: any[];
     onClick?: (item: any) => void;
+    // #397: 关闭外层 GlobalSearch 搜索框（Bot 经名片发消息后；普通联系人由 onClick 链路负责关闭）
+    onClose?: () => void;
 }
 
 interface TabContactsState {
@@ -145,6 +147,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
                 onChat={(channel) => {
                     WKApp.endpoints.showConversation(channel);
                     this.setState({ botDetailVisible: false });
+                    this.props.onClose?.(); // #397: 关名片后再关闭外层搜索框
                 }}
             />
         </div>

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1538,6 +1538,9 @@ export default class ChatPage extends Component<any, ChatPageState> {
                           vm.showGlobalSearch = false;
                         });
                       }}
+                      onClose={() => {
+                        vm.showGlobalSearch = false;
+                      }}
                     />
                   </ErrorBoundary>
                 </div>

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1262,6 +1262,10 @@ export default class ChatPage extends Component<any, ChatPageState> {
           // filter 用于 ConversationList
           // follow Tab 用 group（分组视图），recent Tab 用 all（所有会话混合）
           const filter: ConvFilter = activeTab === "follow" ? "group" : "all";
+          // #397: 关闭全局搜索弹窗的统一语义（onCancel / 选中项点击 / bot 发消息后均复用）
+          const closeSearch = () => {
+            vm.showGlobalSearch = false;
+          };
           return (
             <div className="wk-chat">
               <div
@@ -1526,21 +1530,15 @@ export default class ChatPage extends Component<any, ChatPageState> {
               <WKModal
                 size="full"
                 visible={vm.showGlobalSearch}
-                onCancel={() => {
-                  vm.showGlobalSearch = false;
-                }}
+                onCancel={closeSearch}
               >
                 <div style={{ marginTop: "30px" }}>
                   <ErrorBoundary moduleName={t("base.chatPage.searchModuleName")}>
                     <GlobalSearch
                       onClick={(item, type: string) => {
-                        void handleGlobalSearchClick(item, type, () => {
-                          vm.showGlobalSearch = false;
-                        });
+                        void handleGlobalSearchClick(item, type, closeSearch);
                       }}
-                      onClose={() => {
-                        vm.showGlobalSearch = false;
-                      }}
+                      onClose={closeSearch}
                     />
                   </ErrorBoundary>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #397 — when selecting a Bot via the contact search box and clicking **Send Message** (发送消息) in the bot detail card, the app navigated to the conversation but the outer GlobalSearch modal stayed open.

## Root Cause

Normal contacts close the outer search modal through `onClick` → `handleGlobalSearchClick(..., () => vm.showGlobalSearch = false)`. The Bot path in `tab-contacts.tsx` calls `setState({ botDetailVisible: true })` and then **returns early**, bypassing `onClick` entirely. The bot detail card's `onChat` callback only closed the card itself (`botDetailVisible: false`), never the outer GlobalSearch modal — so the search box remained open after entering the chat.

## Fix

Thread an optional `onClose` callback through `Chat/index.tsx → GlobalSearch → TabContacts`, and invoke it in the bot `onChat` callback after navigating and closing the card. The change is purely additive (optional prop): the other five `BotDetailModal` callers are unaffected, and the normal-contact close path is unchanged.

## Changes

- `GlobalSearch/tab-contacts.tsx` — add `onClose?: () => void`; call `this.props.onClose?.()` in the bot `onChat` callback
- `GlobalSearch/index.tsx` — add `onClose?` prop; forward it to `<TabContacts>`
- `Pages/Chat/index.tsx` — pass `onClose={() => { vm.showGlobalSearch = false }}` to `<GlobalSearch>`
- `GlobalSearch/__tests__/tab-contacts.test.tsx` — new unit test

## Unit Tests

`tab-contacts.test.tsx` — 2/2 passing:
- Bot path: send message → `showConversation` and `onClose` each called once, `onClick` not called
- Normal-contact path: click → `onClick` called once, `onClose` never called

## Real-Environment Reproduction & Verification

Performed in a local full-stack dev environment (octo-server + octo-web running this branch), logged in as a real user whose contact list includes a BotFather-created bot. The exact issue steps were executed in the browser; modal state was captured via DOM assertions (count of `[role="dialog"]` nodes and whether the GlobalSearch dialog — the one containing the 联系人/群组/文件 tabs — is present).

**Steps:** open contact search box → click the bot result → bot detail card opens → click "Send Message".

**Before the fix (bug reproduced) — DOM state right after clicking Send Message:**
```json
{ "dialogCount": 1, "globalSearchStillOpen": true, "botCardStillOpen": false, "enteredChat": false }
```
→ Bot card closed, but the GlobalSearch modal stayed open (1 stray dialog). Bug confirmed.

**After the fix — same steps, same assertion:**
```json
{ "dialogCount": 0, "globalSearchStillOpen": false, "botCardStillOpen": false, "enteredChat": true }
```
→ Both dialogs closed and the conversation opened. Bug resolved.

**Regression control — normal contact via search (must still close), after the fix:**
```json
{ "dialogCount": 0, "globalSearchStillOpen": false }
```
→ Normal-contact path still closes the search modal correctly; not broken by this change.

The bug was reproduced first, then verified fixed using the **same steps**, plus the normal-contact path was confirmed unaffected.

- [x] Unit tests added
- [x] Manually verified in a real dev environment (reproduce → fix → regression control)
- [ ] Docs: not applicable — behavior-only fix (close a modal on bot-chat navigation); no user-facing docs, API, or UI copy changed

## Checklist

- [x] Read CONTRIBUTING.md
- [x] PR description in English
- [x] Added tests
- [x] Followed Conventional Commits
