### PR TITLE
fix: 调整最近会话未读数字展示位置

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -14,29 +14,29 @@ import {
 let ConversationList: typeof import("../index").default;
 let container: HTMLDivElement;
 
+class MockChannel {
+  channelID: string;
+  channelType: number;
+
+  constructor(channelID: string, channelType: number) {
+    this.channelID = channelID;
+    this.channelType = channelType;
+  }
+
+  getChannelKey() {
+    return `${this.channelID}_${this.channelType}`;
+  }
+
+  isEqual(other: { channelID: string; channelType: number }) {
+    return (
+      other?.channelID === this.channelID &&
+      other?.channelType === this.channelType
+    );
+  }
+}
+
 beforeAll(async () => {
   vi.doMock("wukongimjssdk", () => {
-    class Channel {
-      channelID: string;
-      channelType: number;
-
-      constructor(channelID: string, channelType: number) {
-        this.channelID = channelID;
-        this.channelType = channelType;
-      }
-
-      getChannelKey() {
-        return `${this.channelID}_${this.channelType}`;
-      }
-
-      isEqual(other: Channel) {
-        return (
-          other?.channelID === this.channelID &&
-          other?.channelType === this.channelType
-        );
-      }
-    }
-
     const sdk = {
       shared: () => ({
         channelManager: {
@@ -51,7 +51,7 @@ beforeAll(async () => {
     return {
       default: sdk,
       WKSDK: sdk,
-      Channel,
+      Channel: MockChannel,
       ChannelTypePerson: 1,
       ChannelTypeGroup: 2,
       ReminderType: {
@@ -185,13 +185,7 @@ afterEach(() => {
 });
 
 function makeChannel(channelID: string, channelType = 1) {
-  return {
-    channelID,
-    channelType,
-    getChannelKey: () => `${channelID}_${channelType}`,
-    isEqual: (other: { channelID: string; channelType: number }) =>
-      other?.channelID === channelID && other?.channelType === channelType,
-  };
+  return new MockChannel(channelID, channelType);
 }
 
 function makeConversation(options: {
@@ -272,5 +266,44 @@ describe("ConversationList unread indicators", () => {
     expect(
       indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
     ).toBe("14");
+  });
+
+  it("renders mention and muted unread count together", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={
+            [makeConversation({ unread: 5, mention: true, mute: true })] as any
+          }
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
+    expect(
+      indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
+    ).toBe("5");
+  });
+
+  it("does not render indicators when there is no unread count or mention", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[makeConversation({ unread: 0 })] as any}
+        />,
+        container
+      );
+    });
+
+    expect(
+      container.querySelector(".wk-conversationlist-item-indicators")
+    ).toBeNull();
   });
 });

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -1,0 +1,276 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+let ConversationList: typeof import("../index").default;
+let container: HTMLDivElement;
+
+beforeAll(async () => {
+  vi.doMock("wukongimjssdk", () => {
+    class Channel {
+      channelID: string;
+      channelType: number;
+
+      constructor(channelID: string, channelType: number) {
+        this.channelID = channelID;
+        this.channelType = channelType;
+      }
+
+      getChannelKey() {
+        return `${this.channelID}_${this.channelType}`;
+      }
+
+      isEqual(other: Channel) {
+        return (
+          other?.channelID === this.channelID &&
+          other?.channelType === this.channelType
+        );
+      }
+    }
+
+    const sdk = {
+      shared: () => ({
+        channelManager: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          fetchChannelInfo: vi.fn(),
+          getChannelInfo: vi.fn(),
+        },
+      }),
+    };
+
+    return {
+      default: sdk,
+      WKSDK: sdk,
+      Channel,
+      ChannelTypePerson: 1,
+      ChannelTypeGroup: 2,
+      ReminderType: {
+        ReminderTypeMentionMe: 1,
+      },
+    };
+  });
+
+  vi.doMock("../../WKAvatar", () => ({
+    default: ({ channel }: { channel: { channelID: string } }) => (
+      <div className="wk-avatar" data-channel-id={channel.channelID} />
+    ),
+  }));
+
+  vi.doMock("../../ContextMenus", () => ({
+    default: () => null,
+  }));
+
+  vi.doMock("../../AiBadge", () => ({
+    default: () => null,
+  }));
+
+  vi.doMock("../../Icons/GroupIcon", () => ({
+    default: () => <span />,
+  }));
+
+  vi.doMock("../../Icons/ThreadIcon", () => ({
+    default: () => <span />,
+  }));
+
+  vi.doMock("../../../App", () => ({
+    default: {
+      loginInfo: { uid: "u1" },
+      shared: {
+        currentSpaceId: "space1",
+        getChannelAvatarTag: () => "avatar",
+      },
+      apiClient: { put: vi.fn() },
+      conversationProvider: { deleteConversation: vi.fn() },
+    },
+  }));
+
+  vi.doMock("../../../Service/Const", () => ({
+    ChannelTypeCommunityTopic: 3,
+    EndpointID: {},
+  }));
+
+  vi.doMock("../../../Service/Thread", () => ({
+    parseThreadChannelId: () => undefined,
+  }));
+
+  vi.doMock("../../../Service/TypingManager", () => ({
+    TypingManager: {
+      shared: {
+        addTypingListener: vi.fn(),
+        removeTypingListener: vi.fn(),
+        getTyping: () => undefined,
+      },
+    },
+  }));
+
+  vi.doMock("../../../Service/ChannelSetting", () => ({
+    ChannelSettingManager: {
+      shared: {
+        top: vi.fn(),
+        mute: vi.fn(() => Promise.resolve()),
+      },
+    },
+  }));
+
+  vi.doMock("../../../Service/Model", () => ({
+    MessageWrap: class {},
+  }));
+
+  vi.doMock("../../../Messages/Revoke", () => ({
+    RevokeCell: { tip: () => "" },
+  }));
+
+  vi.doMock("../../../Messages/Flame", () => ({
+    FlameMessageCell: { tip: () => "" },
+  }));
+
+  vi.doMock("../../../Utils/time", () => ({
+    getTimeStringAutoShort2: () => "刚刚",
+  }));
+
+  vi.doMock("../../../Utils/draftPreview", () => ({
+    formatDraftPreview: (draft: string) => draft,
+  }));
+
+  vi.doMock("../../WKModal", () => ({
+    wkConfirm: vi.fn(),
+  }));
+
+  vi.doMock("../../Conversation/vm", () => ({
+    default: {
+      foldSessionPreview: new Map(),
+    },
+  }));
+
+  vi.doMock("../../../i18n", () => ({
+    I18nContext: React.createContext({}),
+    t: (key: string) => key,
+    useI18n: () => ({ t: (key: string) => key }),
+  }));
+
+  vi.doMock("@douyinfe/semi-ui", () => ({
+    Tag: ({ children }: { children: React.ReactNode }) => (
+      <span>{children}</span>
+    ),
+  }));
+
+  vi.doMock("react-spinners", () => ({
+    BeatLoader: () => null,
+  }));
+
+  ConversationList = (await import("../index")).default;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+});
+
+function makeChannel(channelID: string, channelType = 1) {
+  return {
+    channelID,
+    channelType,
+    getChannelKey: () => `${channelID}_${channelType}`,
+    isEqual: (other: { channelID: string; channelType: number }) =>
+      other?.channelID === channelID && other?.channelType === channelType,
+  };
+}
+
+function makeConversation(options: {
+  unread: number;
+  mention?: boolean;
+  mute?: boolean;
+}) {
+  const channel = makeChannel("alice");
+  return {
+    channel,
+    channelInfo: {
+      channel,
+      mute: options.mute,
+      online: false,
+      lastOffline: 0,
+      top: false,
+      orgData: {
+        displayName: "Alice",
+      },
+    },
+    unread: options.unread,
+    isMentionMe: !!options.mention,
+    simpleReminders: [],
+    remoteExtra: {},
+    timestamp: 1,
+    lastMessage: undefined,
+  };
+}
+
+describe("ConversationList unread indicators", () => {
+  it("renders unread count under the time instead of on the avatar", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={
+            [makeConversation({ unread: 3, mention: true })] as any
+          }
+        />,
+        container
+      );
+    });
+
+    const avatarBox = container.querySelector(
+      ".wk-conversationlist-item-avatar-box"
+    );
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+
+    expect(avatarBox?.querySelector(".wk-conv-unread-num")).toBeNull();
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
+    expect(indicators?.querySelector(".wk-conv-unread-num")?.textContent).toBe(
+      "3"
+    );
+  });
+
+  it("renders muted unread count under the time instead of on the avatar", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[makeConversation({ unread: 14, mute: true })] as any}
+        />,
+        container
+      );
+    });
+
+    const avatarBox = container.querySelector(
+      ".wk-conversationlist-item-avatar-box"
+    );
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+
+    expect(avatarBox?.querySelector(".wk-conv-unread-num")).toBeNull();
+    expect(container.querySelector(".wk-conv-count-hint")).toBeNull();
+    expect(
+      indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
+    ).toBe("14");
+  });
+});

--- a/packages/dmworkbase/src/Components/ConversationList/index.css
+++ b/packages/dmworkbase/src/Components/ConversationList/index.css
@@ -191,25 +191,31 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   font-weight: 600;
 }
 
-/* 静音状态：名字 / 预览 / 计数提示降为 icon-muted */
+/* 静音状态：名字 / 预览降为 icon-muted */
 .wk-conversationlist-item-muted .wk-conversationlist-item-name h3,
-.wk-conversationlist-item-muted .wk-conversationlist-item-lastmsg,
-.wk-conversationlist-item-muted .wk-conv-count-hint {
+.wk-conversationlist-item-muted .wk-conversationlist-item-lastmsg {
   color: var(--wk-icon-muted);
 }
 
-/* 头像右上角未读数字 badge（非静音） */
+/* 第二行右侧状态区：对齐在时间下方 */
+.wk-conversationlist-item-indicators {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--wk-sp-1);
+  flex-shrink: 0;
+  margin-left: var(--wk-sp-1);
+  min-height: var(--wk-sp-4);
+}
+
+/* 时间下方未读数字 badge（非静音） */
 .wk-conv-unread-num {
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  min-width: 16px;
-  height: 16px;
+  min-width: var(--wk-sp-4);
+  height: var(--wk-sp-4);
   padding: 0 var(--wk-sp-1);
-  background: var(--wk-color-danger);
-  color: var(--wk-color-white);
-  border: 2px solid var(--wk-bg-base);
-  border-radius: 9px;
+  background: var(--wk-badge-danger-bg);
+  color: var(--wk-badge-danger-text);
+  border-radius: var(--wk-r-full);
   font-size: var(--wk-text-size-tiny);
   font-weight: 600;
   line-height: 1;
@@ -217,6 +223,11 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+}
+
+.wk-conv-unread-num--muted {
+  background: color-mix(in srgb, var(--wk-icon-muted) 14%, transparent);
+  color: var(--wk-icon-muted);
 }
 
 .wk-conv-unread-num--nudge-a {
@@ -272,33 +283,12 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   }
 }
 
-/* 头像右上角小红点（静音 + 有未读，低打扰提示） */
-.wk-conv-unread-dot {
-  position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 9px;
-  height: 9px;
-  border-radius: var(--wk-r-circle);
-  background: var(--wk-color-danger);
-  border: 2px solid var(--wk-bg-base);
-  box-sizing: border-box;
-}
-
 /* name 行内的免打扰小图标 */
 .wk-conv-mute-icon {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
   color: var(--wk-icon-muted);
-}
-
-/* 静音 + 多条未读：[N 条] 红字提示前置预览 */
-.wk-conv-count-hint {
-  color: var(--wk-color-danger);
-  font-weight: 500;
-  margin-right: var(--wk-sp-1);
-  flex-shrink: 0;
 }
 
 /* AI 协作中预览 */
@@ -363,7 +353,6 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   padding: 0 var(--wk-sp-1);
   border-radius: var(--wk-r-xs);
   flex-shrink: 0;
-  margin-left: var(--wk-sp-1);
 }
 
 /* 草稿、提醒 */

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -747,19 +747,6 @@ export default class ConversationList extends Component<
                   tip={this.getOnlineTip(channelInfo)}
                 ></OnlineStatusBadge>
               ) : undefined}
-              {totalUnread > 0 && !effectiveMute && (
-                <span
-                  className={classNames(
-                    "wk-conv-unread-num",
-                    unreadNudgeClass
-                  )}
-                >
-                  {totalUnread > 99 ? "99+" : totalUnread}
-                </span>
-              )}
-              {totalUnread > 0 && effectiveMute && (
-                <span className="wk-conv-unread-dot" />
-              )}
             </div>
           </div>
           <div className="wk-conversationlist-item-right">
@@ -849,21 +836,28 @@ export default class ConversationList extends Component<
                       );
                     })
                   : undefined}
-                {/* 静音 + 多条未读：预览前置 [N 条] 红字提示（design v3.1 低打扰） */}
-                {effectiveMute && totalUnread > 1 && !typing && (
-                  <span className="wk-conv-count-hint">
-                    {t("base.conversationList.unreadCountHint", {
-                      values: { count: totalUnread > 99 ? "99+" : totalUnread },
-                    })}
-                  </span>
-                )}
                 {typing
                   ? this._getTypingUI(conversationWrap)
                   : this.lastContent(conversationWrap)}
               </div>
-              {hasMention && (
-                <span className="wk-mention" aria-hidden="true">
-                  {t("base.conversationList.mentionMarker")}
+              {(hasMention || totalUnread > 0) && (
+                <span className="wk-conversationlist-item-indicators">
+                  {hasMention && (
+                    <span className="wk-mention" aria-hidden="true">
+                      {t("base.conversationList.mentionMarker")}
+                    </span>
+                  )}
+                  {totalUnread > 0 && (
+                    <span
+                      className={classNames(
+                        "wk-conv-unread-num",
+                        effectiveMute ? "wk-conv-unread-num--muted" : undefined,
+                        unreadNudgeClass
+                      )}
+                    >
+                      {totalUnread > 99 ? "99+" : totalUnread}
+                    </span>
+                  )}
                 </span>
               )}
             </div>

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -38,7 +38,6 @@
   "conversationList.minutesAgoShort": "{{count}}m",
   "conversationList.toggleThreads": "Expand or collapse threads",
   "conversationList.typing": "typing",
-  "conversationList.unreadCountHint": "[{{count}}]",
   "chatPage.archivedThreadNotice": "This thread is archived. Sending a message will restore it to active status.",
   "chatPage.channelSettings": "Channel settings",
   "chatPage.chatModuleName": "Chat",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -38,7 +38,6 @@
   "conversationList.minutesAgoShort": "{{count}}分钟",
   "conversationList.toggleThreads": "展开或收起子区",
   "conversationList.typing": "正在输入",
-  "conversationList.unreadCountHint": "[{{count}} 条]",
   "chatPage.archivedThreadNotice": "该子区已归档。发送消息后，子区会恢复为活跃状态。",
   "chatPage.channelSettings": "频道设置",
   "chatPage.chatModuleName": "聊天",


### PR DESCRIPTION
## Summary
- move recent conversation unread badges from avatar overlay to the area under the timestamp
- show muted conversations with a gray unread count instead of a dot
- add regression coverage for unread indicator placement

## Tests
- pnpm exec vitest run packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx --config packages/dmworkbase/vitest.config.ts
- pnpm --dir apps/web build