### PR TITLE
docs(contributing): add PR-review SLA + reconcile review policy; CODEOWNERS path routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,10 @@
 * @Mininglamp-OSS/maintainers @Mininglamp-OSS/web-maintainers
 
 # Web/desktop application code and shared packages
-/apps/      @Mininglamp-OSS/web-maintainers
-/packages/  @Mininglamp-OSS/web-maintainers
+# @maintainers is listed first so these paths always resolve to a valid code
+# owner even if @web-maintainers lacks repo access/visibility on octo-web.
+/apps/      @Mininglamp-OSS/maintainers @Mininglamp-OSS/web-maintainers
+/packages/  @Mininglamp-OSS/maintainers @Mininglamp-OSS/web-maintainers
 
 # CI, automation, and repo governance — keep these with core maintainers
 /.github/   @Mininglamp-OSS/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,16 @@
-# CODEOWNERS — unified team ownership
+# CODEOWNERS — automatic review routing
+# Order matters: the LAST matching pattern wins for a given path.
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Code-owner review is required on `main` (see branch ruleset), so every path
+# below must resolve to at least one team that can approve PRs.
 
+# Default owners for everything in the repo
 * @Mininglamp-OSS/maintainers @Mininglamp-OSS/web-maintainers
+
+# Web/desktop application code and shared packages
+/apps/      @Mininglamp-OSS/web-maintainers
+/packages/  @Mininglamp-OSS/web-maintainers
+
+# CI, automation, and repo governance — keep these with core maintainers
+/.github/   @Mininglamp-OSS/maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,21 @@ Thanks for your interest in contributing to OCTO! 🐙 We welcome contributions 
 ## Development Workflow
 
 - All changes go through a Pull Request.
-- PRs must pass CI before merging.
-- PRs require at least one approving review from a maintainer.
-- We use squash-merge to keep history clean.
+- PRs must pass CI before merging (the `Build` and `code-review` checks are required).
+- PRs require approving reviews from maintainers before merging; review routing is automatic via [`.github/CODEOWNERS`](.github/CODEOWNERS).
+- Keep your branch up to date with `main` — stale branches may miss required CI checks and need a rebase before they can merge.
+- We use squash-merge with a linear history to keep the log clean.
+
+## Review SLA
+
+We aim to give every PR a fast first response so contributing here stays low-friction:
+
+- **First review within 3 business days** of a PR being opened (or updated out of draft).
+- If a PR needs changes, maintainers leave concrete, actionable feedback rather than a bare rejection.
+- If a PR is superseded or out of scope, maintainers close it with a short, polite explanation.
+- A PR with no maintainer response after 3 business days is fair game to ping in the thread or in [Discussions](https://github.com/orgs/Mininglamp-OSS/discussions) — a nudge is welcome, not noise.
+
+Maintainers: keep no open PR older than ~14 days without a first review. Triage oldest-first.
 
 ## Commit Messages
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -14,9 +14,21 @@
 ## 研发流程
 
 - 所有修改必须经过 Pull Request
-- PR 必须通过 CI 才能合并
-- PR 需至少 1 位 maintainer approve
-- 使用 squash merge 保持历史清爽
+- PR 必须通过 CI 才能合并（`Build` 与 `code-review` 为必需检查）
+- 合并前需要 maintainer 的 approve；评审分派通过 [`.github/CODEOWNERS`](.github/CODEOWNERS) 自动完成
+- 保持分支与 `main` 同步 —— 过旧的分支可能缺少必需的 CI 检查，合并前需要 rebase
+- 使用 squash merge 并保持线性历史，让提交记录保持清爽
+
+## 评审 SLA
+
+我们希望每个 PR 都能尽快得到首次回应，让贡献保持低门槛：
+
+- **首次评审在 3 个工作日内**完成（以 PR 创建、或从草稿转为正式的时间计）。
+- 若 PR 需要修改，maintainer 会给出具体、可执行的反馈，而不是简单驳回。
+- 若 PR 已被取代或超出范围，maintainer 会礼貌地说明原因并关闭。
+- 若 3 个工作日内仍无 maintainer 回应，欢迎在评论区或 [Discussions](https://github.com/orgs/Mininglamp-OSS/discussions) 中 ping 一下 —— 这是被鼓励的，不是打扰。
+
+Maintainer：不要让任何 PR 超过约 14 天仍未完成首次评审，按最旧优先的顺序处理。
 
 ## Commit 规范
 


### PR DESCRIPTION
## What

- **PR-review SLA** — documents a **first review within 3 business days** target in `CONTRIBUTING.md` and `CONTRIBUTING.zh.md`, plus the "no open PR older than ~14 days unreviewed" maintainer rule.
- **Reconciles CONTRIBUTING with the real `main` ruleset** — the doc previously said "at least one approving review"; the branch actually requires the `Build` + `code-review` checks and maintainer approvals, with squash + linear history. Added a note that stale branches need a rebase to pick up required CI.
- **CODEOWNERS path routing** — keeps the catch-all and adds explicit owners for `apps/`, `packages/`, and `.github/` so review routing is automatic. Uses only existing teams (`@Mininglamp-OSS/maintainers`, `@Mininglamp-OSS/web-maintainers`) since code-owner review is enforced on `main`.

## Why

Part of OCT-13 (contributor-experience / PR-review cadence). First-PR time is the OSS growth lever; a written SLA + automatic routing makes the review loop predictable for contributors.

## Notes

- Docs + config only — no app code changes.
- This PR is itself subject to the 3-approval `main` ruleset, so it needs maintainer reviews to merge.

Co-Authored-By: Paperclip <noreply@paperclip.ing>