### PR TITLE
fix(thread): allow parent-group owner/admin to rename subgroup (#394)

### DIFF
--- a/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/threadPermission.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../App", () => ({
   },
 }));
 
-import { canManageThread } from "../threadPermission";
+import { canManageThread, canEditThreadName, canArchiveThread } from "../threadPermission";
 import { GroupRole } from "../Const";
 
 const GROUP_NO = "g1";
@@ -92,5 +92,87 @@ describe("canManageThread", () => {
   it("returns false when groupNo is empty for a non-creator", () => {
     setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
     expect(canManageThread({ creator_uid: "someone-else" }, "")).toBe(false);
+  });
+});
+
+// issue #394：子区设置页「改名」入口的权限回归。旧代码用恒为 false 的
+// isManagerOrCreatorOfMe 判定，导致非创建者的父群群主/管理员被前端拦截。
+describe("canEditThreadName (issue #394)", () => {
+  beforeEach(() => {
+    subscribesByKey.clear();
+  });
+
+  it("allows the thread creator (even with empty parent-group cache)", () => {
+    expect(
+      canEditThreadName({ thread: { creator_uid: "me" }, groupNo: GROUP_NO })
+    ).toBe(true);
+  });
+
+  it("allows a non-creator parent-group owner — the issue #394 fix", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.owner }]);
+    expect(
+      canEditThreadName({
+        thread: { creator_uid: "someone-else" },
+        groupNo: GROUP_NO,
+      })
+    ).toBe(true);
+  });
+
+  it("allows a non-creator parent-group manager", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.manager }]);
+    expect(
+      canEditThreadName({
+        thread: { creator_uid: "someone-else" },
+        groupNo: GROUP_NO,
+      })
+    ).toBe(true);
+  });
+
+  it("denies an ordinary parent-group member", () => {
+    setGroupMembers([{ uid: "me", role: GroupRole.normal }]);
+    expect(
+      canEditThreadName({
+        thread: { creator_uid: "someone-else" },
+        groupNo: GROUP_NO,
+      })
+    ).toBe(false);
+  });
+
+  it("honors the isManagerOrCreatorOfMe fallback when the backend does set it", () => {
+    // 父群缓存为空时，若子区频道缓存意外给出 true，仍放行（与 canArchiveThread 一致）
+    expect(
+      canEditThreadName({
+        thread: { creator_uid: "someone-else" },
+        groupNo: GROUP_NO,
+        isManagerOrCreatorOfMeFallback: true,
+      })
+    ).toBe(true);
+  });
+
+  // 一致性回归：改名入口（A）与归档入口共用父群口径，二者权限判定必须始终一致，
+  // 避免再次出现「一处能改、一处不能」的撕裂（issue #283 / #394）。
+  it("stays consistent with canArchiveThread across the role/fallback matrix", () => {
+    const roles = [
+      GroupRole.owner,
+      GroupRole.manager,
+      GroupRole.normal,
+      undefined,
+    ];
+    for (const role of roles) {
+      for (const fallback of [true, false, undefined]) {
+        for (const creator of ["me", "someone-else"]) {
+          subscribesByKey.clear();
+          if (role !== undefined) {
+            setGroupMembers([{ uid: "me", role }]);
+          }
+          const args = {
+            thread: { creator_uid: creator },
+            groupNo: GROUP_NO,
+            isManagerOrCreatorOfMeFallback: fallback,
+          };
+          expect(canEditThreadName(args)).toBe(canArchiveThread(args));
+        }
+      }
+    }
   });
 });

--- a/packages/dmworkbase/src/Service/threadPermission.ts
+++ b/packages/dmworkbase/src/Service/threadPermission.ts
@@ -56,6 +56,26 @@ export function canArchiveThread(args: {
 }
 
 /**
+ * ChannelSetting 子区设置页「改名」入口（module.tsx 的 thread.base.info）的权限判定。
+ *
+ * 修复 issue #394：旧代码用恒为 false 的 `data.isManagerOrCreatorOfMe`（子区频道
+ * 成员缓存，从未同步）判定，导致非创建者的父群群主/管理员被前端拦截、根本不
+ * 调用 `threadUpdate`。现统一走父群口径（{@link canManageThread}），与归档入口
+ * （{@link canArchiveThread}）、ThreadPanel 入口 B（canEditThread）完全一致。
+ *
+ * 与 canArchiveThread 同口径（canManageThread || fallback）。差异仅在于改名没有
+ * 「状态须为 Active/Archived」的门槛，故单独成函数，不复用
+ * {@link shouldShowThreadArchiveAction}。
+ */
+export function canEditThreadName(args: {
+  thread: { creator_uid?: string } | null | undefined;
+  groupNo: string | undefined;
+  isManagerOrCreatorOfMeFallback?: boolean;
+}): boolean {
+  return canArchiveThread(args);
+}
+
+/**
  * 入口 A（thread.actions）归档/取消归档菜单项是否应渲染：
  * 既要有权限（canArchiveThread），状态又必须是 Active 或 Archived。
  * 抽成纯函数以便与入口 B 做「一致性回归」断言。

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -114,7 +114,10 @@ import {
 import { SummaryCardContent } from "./Messages/SummaryCard/SummaryCardContent";
 import { SummaryCardCell } from "./Messages/SummaryCard";
 import { parseThreadChannelId, ThreadStatus } from "./Service/Thread";
-import { shouldShowThreadArchiveAction } from "./Service/threadPermission";
+import {
+  canEditThreadName,
+  shouldShowThreadArchiveAction,
+} from "./Service/threadPermission";
 import { runChannelSettingThreadArchive } from "./Service/threadArchiveAction";
 import { canShowRevokeMenu } from "./Service/revokePermission";
 
@@ -2203,11 +2206,17 @@ export default class BaseModule implements IModule {
         const channelInfo = data.channelInfo;
         const threadName = channelInfo?.title;
 
-        // 权限：只有创建者或群管理者可以修改名称
+        // 权限：创建者或【父群】群主/管理员可改名。统一走 canEditThreadName
+        // （父群口径，与归档入口 canArchiveThread、ThreadPanel 入口 B 完全一致，
+        // 见 issue #394 / #283）。旧代码读 data.isManagerOrCreatorOfMe（子区频道成员
+        // 缓存，从未同步、对非创建者群主/管理员恒为 false），导致被前端拦截、根本
+        // 不调用 threadUpdate；现仅作兜底（fallback）。
         const thread = channelInfo?.orgData?.thread as any;
-        const isCreator = thread?.creator_uid === WKApp.loginInfo.uid;
-        const isManagerOrOwner = data.isManagerOrCreatorOfMe;
-        const canEdit = isCreator || isManagerOrOwner;
+        const canEdit = canEditThreadName({
+          thread,
+          groupNo: threadInfo?.groupNo,
+          isManagerOrCreatorOfMeFallback: data.isManagerOrCreatorOfMe,
+        });
         const statusTitle =
           thread?.status === ThreadStatus.Archived
             ? t("base.module.thread.status.archived")


### PR DESCRIPTION
## Summary
Fixes #394. On the subgroup (子区) **ChannelSetting** page, the rename row gated edits on `data.isManagerOrCreatorOfMe`, which reads the **subgroup channel's own** subscriber cache. Thread-channel members are never synced, so for a non-creator **parent-group owner/admin** this was always `false` — the click was blocked client-side and `threadUpdate` was never called. Only the thread creator could rename.

This was the leftover from #314, which migrated only the **archive** action off the always-empty thread-channel cache to the parent-group source of truth (`canManageThread`). The rename row in the same settings page kept the old, broken check.

## Changes
- Add `canEditThreadName` helper in `Service/threadPermission.ts`, resolving owner/manager from the **parent-group** member list (same source as `canArchiveThread` and `ThreadPanel.canEditThread` / entry B). Keeps `isManagerOrCreatorOfMe` only as an OR fallback, consistent with the archive path.
- `module.tsx` thread `base.info` rename row now gates on `canEditThreadName(...)` instead of `isCreator || data.isManagerOrCreatorOfMe`.
- Regression tests in `threadPermission.test.ts`: creator / parent-group owner / manager / ordinary member / fallback, plus a **role×fallback consistency matrix** asserting rename permission stays aligned with `canArchiveThread` (guards against the entry-A/entry-B split recurring, cf. #283/#394).

## Verification
- `@octo/web` production build (CI typecheck gate): green.
- `pnpm i18n:check`, `pnpm lint:wkmodal`: pass.
- `vitest run` for `threadPermission` / archive specs: 37/37 pass (6 new).
- Behavior is now identical between the rename and archive entries on the settings page, and matches ThreadPanel entry B.

## Test plan (manual / QA)
1. User A creates a subgroup; user B is the **parent-group owner** (not the subgroup creator).
2. B opens the subgroup settings page → taps **子区名称 (Thread name)** → edit field opens (previously: blocked toast, no request) → save → `threadUpdate` succeeds, name updates.
3. Ordinary member still sees the "only creator or manager" toast.
4. Regression: archive/unarchive visibility unchanged on the same page.

Part of OCT-5 golden-path work (OCT-11).