### PR TITLE
ci(check-sprint): mark sprint check non-blocking (continue-on-error)

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -16,6 +16,11 @@ permissions: {}
 
 jobs:
   check-sprint:
+    # Non-blocking: sprint hygiene is an internal tracking aid, not a merge gate.
+    # External/contributor PRs routinely lack a sprint-linked issue, so a failure
+    # here must not paint the PR red or imply the change is unmergeable.
+    # (check-sprint is intentionally NOT a required status check on `main`.)
+    continue-on-error: true
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@v1
     with:
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -16,11 +16,14 @@ permissions: {}
 
 jobs:
   check-sprint:
-    # Non-blocking: sprint hygiene is an internal tracking aid, not a merge gate.
-    # External/contributor PRs routinely lack a sprint-linked issue, so a failure
-    # here must not paint the PR red or imply the change is unmergeable.
-    # (check-sprint is intentionally NOT a required status check on `main`.)
-    continue-on-error: true
+    # Non-blocking for external contributors: sprint hygiene is an internal
+    # tracking aid, not a merge gate, and is NOT a required status check on
+    # `main`. Fork PRs (outside contributors) are never on the Octo Board, so
+    # the check can only ever fail for them — a red ✗ on a first-time
+    # contributor's PR is pure noise and hurts the OSS first-PR experience.
+    # Skip it for cross-repo (fork) PRs; keep it for internal same-repo
+    # branches where maintainers own sprint assignment.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@v1
     with:
       pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What
Skip the `check-sprint` job for **fork (cross-repo) PRs** via an `if:` guard.

## Why
`check-sprint` is non-required sprint-tracking. Outside contributors' PRs are never on the Octo Board, so the check can only ever fail for them — a red ✗ on a first-time contributor's PR is pure noise and hurts the OSS first-PR experience (the OCT-13 contributor-experience lens).

## Fix history
The first attempt used `continue-on-error: true`, but actionlint correctly rejects it: that key is not allowed on a job that calls a reusable workflow (only `name, uses, with, secrets, needs, if, permissions`). Replaced with an `if:` guard (valid on reusable callers).

## Behavior
- **Fork PRs:** `check-sprint` is skipped (neutral, not red).
- **Internal same-repo PRs:** unchanged — still runs, maintainers own sprint assignment.
- Not a required check either way.

Co-Authored-By: Paperclip <noreply@paperclip.ing>