### PR TITLE
fix(extension): enable channel/subzone search in sidepanel forward menu (#420)

### DIFF
--- a/apps/extension/entrypoints/sidepanel/main.tsx
+++ b/apps/extension/entrypoints/sidepanel/main.tsx
@@ -12,6 +12,7 @@ import StorageService from '@octo/base/src/Service/StorageService';
 import { LoginModule } from '@octo/login';
 import { DataSourceModule } from '@octo/datasource';
 import { ContactsModule } from '@octo/contacts';
+import { getChatCandidates } from '@dmwork/summary/src/api/summaryApi';
 import { version as pkgVersion } from '../../../web/package.json';
 import { Channel, ChannelTypePerson, WKSDK } from 'wukongimjssdk';
 import App from '../../../web/src/App';
@@ -164,6 +165,12 @@ WKApp.shared.registerModule(new BaseModule());
 WKApp.shared.registerModule(new DataSourceModule());
 WKApp.shared.registerModule(new LoginModule());
 WKApp.shared.registerModule(new ContactsModule());
+
+// 转发目标选择器（ForwardModal/useForwardModal）通过 WKApp.searchChatCandidates
+// 搜索群聊/子区（联系人走 ContactsModule）。Web 端由 SummaryModule 注册该回调，
+// 但侧边面板不挂载完整 Summary 模块（路由/全局弹窗/聊天头部按钮均不需要），
+// 因此这里只补一个等价回调，使转发菜单能搜到 channels/subzones。GH #420。
+WKApp.searchChatCandidates = (params) => getChatCandidates(params);
 
 WKApp.shared.startup();
 void syncExtensionAuthState();

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -15,6 +15,7 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
+    "@dmwork/summary": "workspace:*",
     "@octo/base": "workspace:*",
     "@octo/contacts": "workspace:*",
     "@octo/datasource": "workspace:*",

--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -45,6 +45,9 @@ const hoisted = vi.hoisted(() => {
         // 可配置的 Space 裁决桩：默认全保留(false)。需要模拟「外部成员豁免保留」
         // 与「跨 Space 非外部成员剔除」时，用例按 channel 覆写 mockImplementation。
         shouldSkip: vi.fn((_channel: any) => false),
+        // WKApp.searchChatCandidates 桩：默认 undefined（复刻 #420 修复前侧边面板
+        // 未注册回调的状态）。GH #420 用例按需赋一个返回群/子区/联系人候选的 fn。
+        searchChatCandidates: undefined as undefined | ((params: any) => Promise<any[]>),
     }
 })
 
@@ -96,6 +99,7 @@ vi.mock("wukongimjssdk", () => {
         Channel,
         ChannelInfo: class {},
         ChannelTypeGroup: 2,
+        ChannelTypePerson: 1,
     }
 })
 
@@ -127,7 +131,9 @@ vi.mock("../../../App", () => ({
             commonDataSource: { searchFriends: hoisted.searchFriends },
         },
         mittBus: { on: hoisted.mittOn, off: hoisted.mittOff },
-        searchChatCandidates: undefined,
+        get searchChatCandidates() {
+            return hoisted.searchChatCandidates
+        },
     },
 }))
 
@@ -187,6 +193,7 @@ function resetHoisted() {
     hoisted.channelListeners = []
     hoisted.refreshHandlers = []
     hoisted.conversations = []
+    hoisted.searchChatCandidates = undefined
 }
 
 async function renderForward() {
@@ -553,3 +560,120 @@ describe("useForwardModal — group/my fallback groups + thread re-homing", () =
     })
 })
 
+/**
+ * GH #420 / OCT-34 回归守护：转发目标选择器搜索群聊/子区。
+ *
+ * 根因：群/子区结果来自 WKApp.searchChatCandidates。Web 端由 SummaryModule
+ * 注册该回调，但扩展侧边面板从未挂载它 → 回调为 undefined → useForwardModal
+ * 的搜索 effect 清空群/子区结果，搜索只剩联系人。修复在侧边面板入口注册了一个
+ * 等价回调。这里直接驱动 useForwardModal 的「已注册 searchChatCandidates」路径
+ * （此前 App mock 恒为 undefined，从未覆盖），守护：
+ *   - 搜到频道(group) / 子区(thread)，命中子区时父群被带出；
+ *   - 联系人(direct)候选不被丢失（无回归）；
+ *   - 非默认 Space 下，currentSpaceId 作为 space_id 透传给回调（Space 作用域）。
+ *
+ * keyword 经 setInputValue 的 300ms debounce 才生效，故用 fake timers 推进。
+ */
+describe("useForwardModal — registered searchChatCandidates surfaces channels & subzones (GH #420)", () => {
+    beforeEach(() => {
+        resetHoisted()
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    // 群「Engineering」、子区「Daily Standup」(父群=g-eng)、联系人「Alice」。
+    const candidates = [
+        { chat_id: "g-eng", chat_type: "group", name: "Engineering", member_count: 12 },
+        { chat_id: "t-standup", chat_type: "thread", name: "Daily Standup", parent_group_no: "g-eng" },
+        { chat_id: "d-alice", chat_type: "direct", name: "Alice", member_count: null },
+    ]
+
+    async function search(view: Awaited<ReturnType<typeof renderForward>>, kw: string) {
+        await act(async () => {
+            view.current.setInputValue(kw)
+            await vi.advanceTimersByTimeAsync(350) // 越过 300ms debounce → setKeyword
+            await flushMicrotasks() // searchChatCandidates(...).then(setSearchGroupItems)
+            await flushMicrotasks()
+        })
+    }
+
+    it("surfaces a channel(group) result when searching its name", async () => {
+        hoisted.searchChatCandidates = vi.fn(async () => candidates)
+        const view = await renderForward()
+
+        await search(view, "engineering")
+        const found = view.current.items.find((i) => i.channelID === "g-eng")
+
+        expect(found).toBeTruthy()
+        expect(found!.isThread).toBe(false)
+        expect(found!.displayName).toBe("Engineering")
+
+        view.unmount()
+    })
+
+    it("surfaces a subzone(thread) result AND brings out its parent group (方案 A)", async () => {
+        hoisted.searchChatCandidates = vi.fn(async () => candidates)
+        const view = await renderForward()
+
+        await search(view, "standup")
+        const ids = view.current.items.map((i) => i.channelID)
+        const thread = view.current.items.find((i) => i.channelID === "t-standup")
+
+        // 命中子区本身
+        expect(ids).toContain("t-standup")
+        expect(thread!.isThread).toBe(true)
+        expect(thread!.parentChannelID).toBe("g-eng")
+        // 父群被带出（即使父群名未命中关键字）
+        expect(ids).toContain("g-eng")
+
+        view.unmount()
+    })
+
+    it("still surfaces a contact(direct) result (no regression)", async () => {
+        hoisted.searchChatCandidates = vi.fn(async () => candidates)
+        const view = await renderForward()
+
+        await search(view, "alice")
+        const found = view.current.items.find((i) => i.channelID === "d-alice")
+
+        expect(found).toBeTruthy()
+        expect(found!.isThread).toBe(false)
+        expect(found!.displayName).toBe("Alice")
+
+        view.unmount()
+    })
+
+    it("forwards currentSpaceId as space_id to searchChatCandidates under a non-default Space", async () => {
+        hoisted.currentSpaceId = "space-非默认"
+        const spy = vi.fn(async () => candidates)
+        hoisted.searchChatCandidates = spy
+        const view = await renderForward()
+
+        await search(view, "engineering")
+
+        expect(spy).toHaveBeenCalled()
+        const arg = spy.mock.calls[spy.mock.calls.length - 1][0]
+        expect(arg.keyword).toBe("engineering")
+        expect(arg.space_id).toBe("space-非默认")
+
+        view.unmount()
+    })
+
+    it("clears group/thread results when searchChatCandidates is unregistered (pre-fix sidepanel state)", async () => {
+        // 复刻修复前：回调未注册 → 群/子区结果应为空（只可能剩本地会话/联系人，
+        // 本用例无本地数据 → items 不含群/子区候选）。
+        hoisted.searchChatCandidates = undefined
+        const view = await renderForward()
+
+        await search(view, "engineering")
+        const ids = view.current.items.map((i) => i.channelID)
+
+        expect(ids).not.toContain("g-eng")
+        expect(ids).not.toContain("t-standup")
+
+        view.unmount()
+    })
+})

--- a/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
@@ -42,6 +42,48 @@ describe('summaryApi interceptors', () => {
   });
 });
 
+// The summary service lives at <origin>/summary/api/v1. On Web, apiClient.apiURL
+// is relative ("/api/v1/") so same-origin requests work with an empty baseURL.
+// In the extension/Electron the page origin is chrome-extension:// / app://, so
+// the request must target the API origin derived from apiClient.config.apiURL.
+// GH #420 — sidepanel forward menu could not search channels/subzones.
+describe('summaryApi baseURL resolution (GH #420)', () => {
+  async function getRequestInterceptor(apiClient: unknown) {
+    vi.resetModules();
+    mockRequestUse.mockClear();
+    // Mutate the WKApp instance from the post-reset module graph — the same one
+    // summaryApi will import — so the interceptor reads this apiClient at call time.
+    const { default: freshWKApp } = await import('@octo/base');
+    (freshWKApp as any).apiClient = apiClient;
+    await import('../summaryApi');
+    return mockRequestUse.mock.calls[0]?.[0];
+  }
+
+  it('uses the API origin when apiClient.apiURL is absolute (extension/Electron)', async () => {
+    const interceptor = await getRequestInterceptor({ config: { apiURL: 'https://api.example.com/api/v1/' } });
+
+    const result = interceptor({ headers: {} } as any);
+
+    expect(result.baseURL).toBe('https://api.example.com');
+  });
+
+  it('stays same-origin (empty baseURL) when apiClient.apiURL is relative (Web)', async () => {
+    const interceptor = await getRequestInterceptor({ config: { apiURL: '/api/v1/' } });
+
+    const result = interceptor({ headers: {} } as any);
+
+    expect(result.baseURL).toBe('');
+  });
+
+  it('stays same-origin when apiClient.config is absent', async () => {
+    const interceptor = await getRequestInterceptor({});
+
+    const result = interceptor({ headers: {} } as any);
+
+    expect(result.baseURL).toBe('');
+  });
+});
+
 describe('summaryApi', () => {
     beforeEach(() => {
         vi.clearAllMocks();

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -25,7 +25,25 @@ import { SummaryMode } from '../types/summary';
 
 const summaryAxios = axios.create({ baseURL: '' });
 
+// The summary service is mounted at <origin>/summary/api/v1 (nginx proxies it).
+// On Web, apiClient.apiURL is relative ("/api/v1/"), so same-origin requests
+// resolve correctly with an empty baseURL. In the browser extension (and
+// Electron) the page origin is chrome-extension://… / app://…, so a relative
+// "/summary/api/v1/…" request never reaches the backend; derive the API origin
+// from apiClient.config.apiURL in those runtimes. GH #420.
+function resolveSummaryBaseURL(): string {
+    const apiURL = WKApp.apiClient?.config?.apiURL;
+    if (!apiURL) return '';
+    try {
+        return new URL(apiURL).origin;
+    } catch {
+        // Relative apiURL (Web) has no parsable origin → stay same-origin.
+        return '';
+    }
+}
+
 summaryAxios.interceptors.request.use((config) => {
+    config.baseURL = resolveSummaryBaseURL();
     config.headers = config.headers ?? {};
     config.headers['Accept-Language'] = buildAcceptLanguage();
     const token = WKApp.loginInfo.token;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
 
   apps/extension:
     dependencies:
+      '@dmwork/summary':
+        specifier: workspace:*
+        version: link:../../packages/dmworksummary
       '@douyinfe/semi-icons':
         specifier: ^2.93.0
         version: 2.93.0(react@18.3.1)
@@ -13114,7 +13117,7 @@ snapshots:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -13173,7 +13176,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 7.32.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.11
@@ -13192,6 +13195,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
@@ -13200,7 +13213,7 @@ snapshots:
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13229,7 +13242,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13240,7 +13253,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13252,7 +13265,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
Closes #420

## Summary
Fixes octo-web #420 — in the browser extension **sidepanel**, the `@`-content forward target picker (`ForwardModal` / `useForwardModal`) could only find **contacts**; **channels** (group) and **subzones** (thread) returned nothing. Same menu works on Web.

### Root cause
Group/thread results come from `WKApp.searchChatCandidates`. On Web that callback is registered by `SummaryModule`. The sidepanel entry (`apps/extension/entrypoints/sidepanel/main.tsx`) never mounts `SummaryModule`, so `WKApp.searchChatCandidates` was `undefined` and `useForwardModal` cleared group/thread results.

A second, deeper issue: even once the callback is registered, `getChatCandidates` uses its own `summaryAxios` with a **relative** `baseURL` (`/summary/api/v1/...`). On Web that resolves via the same-origin nginx/Vite proxy, but in the extension the page origin is `chrome-extension://…`, so the request never reaches the backend.

### Changes
- **Register a sidepanel-safe `WKApp.searchChatCandidates`** via `getChatCandidates`, matching the Web entry — without pulling the full Summary module's routes / global modal / chat-header UI into the lightweight sidepanel.
- **Resolve the summary API origin in non-same-origin runtimes** (extension/Electron): derive the origin from `WKApp.apiClient.config.apiURL`. Web keeps the relative same-origin behavior (no change).
- **Tests**: add `summaryApi` baseURL-resolution tests (absolute → origin; relative → same-origin; missing config → same-origin).

### Verification
- `dmworksummary` vitest: 17/17 pass in `summaryApi.test.ts` (incl. 3 new); full suite shows no new failures vs. baseline (pre-existing react 17/18 render-test failures are unrelated).
- `wxt build` (chrome-mv3) succeeds; bundled sidepanel chunk contains both the `searchChatCandidates` registration and the `summary-chat-candidates` call.
- Not yet verified live in a loaded extension against a logged-in session — see test plan below.

## Test plan (QA — extension sidepanel, env: im-test-xming)
- [ ] Load the built extension, open the sidepanel, log in.
- [ ] In a chat, trigger `@`-content forward; open the forward target picker.
- [ ] Search a term matching a **channel (group)** → it appears.
- [ ] Search a term matching a **subzone (thread)** → it appears (parent group surfaced per existing behavior).
- [ ] Search a **contact** → still appears (no regression).
- [ ] Confirm forwarding to a channel and to a subzone both deliver correctly.
- [ ] Repeat under a non-default Space to confirm `space_id` scoping (X-Space-Id header) works.
