### PR TITLE
ci: auto-satisfy code-review check for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-code-review.yml
+++ b/.github/workflows/dependabot-code-review.yml
@@ -1,0 +1,39 @@
+name: Dependabot Code Review Gate
+
+# Dependabot-authored PRs never receive the external `code-review` commit
+# status (the reviewer app skips bot actors), so the `code-review` required
+# status check stays absent and the PRs are permanently BLOCKED even when
+# `Build` is green. This workflow auto-satisfies that one required context for
+# Dependabot bumps ONLY. Human PRs are untouched and still require the real
+# `code-review` status. CI-green policy stands: `Build` is a separate required
+# check and is unaffected by this workflow.
+#
+# Uses pull_request_target (not pull_request) so the job runs with the base
+# repo's token and `statuses: write`; Dependabot's own GITHUB_TOKEN is
+# read-only and cannot post statuses. No PR head code is checked out or
+# executed here, so pull_request_target is safe for this use.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  statuses: write
+
+jobs:
+  satisfy-code-review:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report code-review success for trusted Dependabot bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=success \
+            -f context=code-review \
+            -f description="Auto-satisfied for Dependabot dependency bump (scoped bot bypass)" \
+            -f target_url="${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
## Summary

Dependabot-authored PRs were permanently **BLOCKED**: the `main` ruleset requires the `code-review` status check, but the external reviewer app never posts `code-review` for bot actors, so it stayed absent and the PRs could never go green (despite `Build` passing). No Dependabot PR has ever merged in this repo.

This adds a workflow that auto-satisfies the **`code-review`** required context **for Dependabot PRs only** (option 2 from the issue):

- Trigger: `pull_request_target` (base-repo token has `statuses: write`; Dependabot's own token is read-only and cannot post statuses).
- Guard: `github.event.pull_request.user.login == 'dependabot[bot]'` — strictly scoped to the bot actor.
- Action: posts `code-review = success` on the PR head SHA. No PR head code is checked out or executed.

### Honesty / scope
- Human PRs are untouched — they still require the real `code-review` status from the reviewer app.
- `Build` is a separate required check and is unaffected — **CI-green policy stands** for Dependabot too.

### Note (separate gate)
The `main` ruleset also requires **1 code-owner approving review**, which still blocks Dependabot independently of `code-review`. That is being handled separately (board-confirmed branch-protection change) so Dependabot bumps can flow without manual intervention. This PR fixes the named `code-review` blocker.

Refs OCT-44.