### PR TITLE
fix(extension): 目标选择菜单可搜群/子区——将 searchChatCandidates 注册迁到 DataSourceModule

### DIFF
--- a/packages/dmworkdatasource/src/chatCandidates.ts
+++ b/packages/dmworkdatasource/src/chatCandidates.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { WKApp, buildAcceptLanguage } from "@octo/base";
+
+// 候选会话（群/子区）搜索使用独立的 axios 实例：
+// 该接口走 /summary/api/v1 网关，与 WKApp.apiClient（IM API /v1/）不同，
+// 不能复用 apiClient。这里完整复刻 summary 模块原本的 HTTP 行为（同样的
+// header、base path、401 处理与 envelope 解包），使转发选择器（ForwardModal）
+// 不再隐式依赖 summary 模块。
+const candidatesAxios = axios.create({ baseURL: "" });
+
+candidatesAxios.interceptors.request.use((config) => {
+    config.headers = config.headers ?? {};
+    config.headers["Accept-Language"] = buildAcceptLanguage();
+    const token = WKApp.loginInfo.token;
+    if (token) {
+        config.headers["token"] = token;
+    }
+    const spaceId = WKApp.shared.currentSpaceId;
+    if (spaceId) {
+        config.headers["X-Space-Id"] = spaceId;
+    }
+    return config;
+});
+
+candidatesAxios.interceptors.response.use(
+    (resp) => resp,
+    (err) => {
+        if (err?.response?.status === 401) {
+            WKApp.shared.logout();
+        }
+        return Promise.reject(err);
+    },
+);
+
+const BASE = "/summary/api/v1";
+
+// Backend wraps responses in {code, message, data} envelope — unwrap .data
+export async function getChatCandidates(params?: {
+    keyword?: string;
+    chat_type?: string;
+    space_id?: string;
+}): Promise<any[]> {
+    const resp = await candidatesAxios.get(`${BASE}/summary-chat-candidates`, { params });
+    const data = resp.data?.data ?? resp.data;
+    return data || [];
+}

--- a/packages/dmworkdatasource/src/module.ts
+++ b/packages/dmworkdatasource/src/module.ts
@@ -4,6 +4,7 @@ import { MessageTask } from "wukongimjssdk";
 import { ConversationProvider } from "./conversation";
 import { ChannelDataSource, CommonDataSource } from "./datasource";
 import { MediaMessageUploadTask } from "./task";
+import { getChatCandidates } from "./chatCandidates";
 
 export default class DataSourceModule implements IModule {
     id(): string {
@@ -25,6 +26,13 @@ export default class DataSourceModule implements IModule {
         this.setSyncRemindersCallback() // 同步提醒
         this.setReminderDoneCallback() // 提醒项完成
         this.setMessageReadedCallback() // 消息已读未读
+
+        // 候选会话（群/子区）搜索回调：供 ForwardModal 等 base 组件使用。
+        // 注册在此处而非 summary 模块，保证 web 与浏览器扩展（仅加载 DataSourceModule）
+        // 都能搜索到群/子区，而不仅是联系人。
+        WKApp.searchChatCandidates = async (params) => {
+            return getChatCandidates(params)
+        }
     }
 
     // 从 Space channel_id (s{spaceId}_{uid}) 中提取真实 uid

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -7,7 +7,6 @@ import SummaryCreatePage from "./pages/SummaryCreatePage";
 import SummaryDetailPage from "./pages/SummaryDetailPage";
 import SummaryConfirmPage from "./pages/SummaryConfirmPage";
 import ScheduleListPage from "./pages/ScheduleListPage";
-import { getChatCandidates } from "./api/summaryApi";
 import { notifyChatSummaryCreated } from "./utils/chatSummaryActions";
 import { isSupportedChannelType } from "./utils/channelType";
 import ChatSummaryStarButton from "./components/ChatSummaryStarButton";
@@ -62,10 +61,6 @@ export class SummaryModule implements IModule {
             WKApp.mittBus.emit('summary-space-changed');
         };
         WKApp.mittBus.on('space-changed', _spaceChangedHandler);
-
-        WKApp.searchChatCandidates = async (params) => {
-            return getChatCandidates(params);
-        };
 
         mountGlobalSummaryModal();
 


### PR DESCRIPTION
## 问题

浏览器插件(extension)里使用 CoCraft @ 选中内容后弹出的「选群/选联系人」目标选择菜单（`ForwardModal`），只能搜到联系人(direct)，频道(group)和子区(thread)都搜不到。Web 端正常。

Closes #420

## 根因

`ForwardModal`（`packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts`）的群/子区搜索完全依赖全局回调 `WKApp.searchChatCandidates`，未注册时直接 early-return 空数组。而该回调**只在 `SummaryModule` 里注册**（`packages/dmworksummary/src/module.tsx`）。

- Web 端 `apps/web/src/index.tsx` 注册了 `SummaryModule` → 回调有定义 → 群/子区可搜。
- 插件 sidepanel（`apps/extension/entrypoints/sidepanel/main.tsx`）只注册 Base / DataSource / Login / Contacts，**没有 SummaryModule** → `WKApp.searchChatCandidates === undefined` → 群/子区远程搜索永远空。联系人走另一条本地好友列表路径，所以唯独联系人能显示。

这是一个跨模块依赖断裂：base 组件 `ForwardModal` 隐式依赖由 summary 模块注入的全局回调，宿主装配清单不一致时静默失效。

## 改动（解耦方案）

把 `WKApp.searchChatCandidates` 的注册从 summary 模块移到 `DataSourceModule`（web 与插件都会装配），解除 `ForwardModal` 对 summary 模块的隐式依赖：

1. 新增 `packages/dmworkdatasource/src/chatCandidates.ts` —— 自带独立 axios 实例的候选拉取 helper，完整复刻原 summary 的 HTTP 行为（`/summary/api/v1/summary-chat-candidates` 路径、`token`/`X-Space-Id`/`Accept-Language` 头、401 登出、`{code,message,data}` envelope 解包）。该接口与 `WKApp.apiClient`（IM API `/v1/`）非同一 base，故未复用 apiClient。
2. `packages/dmworkdatasource/src/module.ts` —— 在 `DataSourceModule.init()` 注册 `WKApp.searchChatCandidates`。
3. `packages/dmworksummary/src/module.tsx` —— 删除重复注册与不再使用的 import。`summaryApi.ts` 的 `getChatCandidates` 保留（summary 自己的 ChatSelectorModal 仍在用）。
4. 插件 sidepanel 模块清单未改动——插件本就加载 DataSourceModule。

## 验证

- `pnpm install` 全量装依赖。
- 插件生产构建 `wxt build`：✔ 通过（18.9s）。
- Web 生产构建 `vite build`：✔ 通过（14.05s，仅有与本改动无关的既有第三方 eval / chunk size 警告）。

## 影响面

- 行为变化：插件端 `ForwardModal` 现在能搜到群/子区。
- Web 端行为不变（回调换了注册位置，语义等价）。
- summary 模块自身功能不受影响。
