### PR TITLE
fix(channel-search): don't fire _search/_search_all on empty input

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
@@ -179,13 +179,13 @@ export const Default: Story = {
 };
 
 export const OpenEmpty: Story = {
-  name: "Open default results",
+  name: "Open empty (no request)",
   play: async ({ canvasElement }) => {
-    await waitForElement(canvasElement, ".wk-channel-search-result-list");
-    if (
-      canvasElement.querySelectorAll(".wk-channel-search-result").length === 0
-    ) {
-      throw new Error("Expected empty keyword to browse default results");
+    // Empty keyword + no filter on the default "all" tab must NOT fire a request
+    // (the backend rejects it with 400). The panel shows the empty-state prompt.
+    await waitForElement(canvasElement, ".wk-channel-search-empty");
+    if (canvasElement.querySelector(".wk-channel-search-result")) {
+      throw new Error("Expected empty keyword to render the empty state, not results");
     }
   },
 };

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
@@ -89,6 +89,7 @@ const {
   secondsToDateOnly,
   sentAtToSeconds,
   toRequestBody,
+  shouldRunSearch,
 } = channelSearchApiAdapterTestUtils;
 
 function baseQuery(tab: ChannelSearchQuery["tab"]): ChannelSearchQuery {
@@ -173,6 +174,65 @@ describe("channel search API adapter request construction", () => {
       page_size: 30,
       cursor: "next-cursor",
     });
+  });
+});
+
+describe("channel search empty-state guard", () => {
+  const noFilters = { senderUids: [], sort: "time_desc" as const };
+
+  it("does not run all/message tabs with empty keyword and no filters (would 400)", () => {
+    expect(
+      shouldRunSearch({ keyword: "   ", filters: noFilters, tab: "all" })
+    ).toBe(false);
+    expect(
+      shouldRunSearch({ keyword: "", filters: noFilters, tab: "message" })
+    ).toBe(false);
+  });
+
+  it("runs all/message tabs once a keyword is present", () => {
+    expect(
+      shouldRunSearch({ keyword: "  hello  ", filters: noFilters, tab: "all" })
+    ).toBe(true);
+    expect(
+      shouldRunSearch({ keyword: "hi", filters: noFilters, tab: "message" })
+    ).toBe(true);
+  });
+
+  it("runs all/message tabs with a filter-only query (no keyword)", () => {
+    expect(
+      shouldRunSearch({
+        keyword: "",
+        filters: { senderUids: ["u1"], sort: "time_desc" },
+        tab: "all",
+      })
+    ).toBe(true);
+    const startAt = Math.floor(new Date(2026, 0, 5).getTime() / 1000);
+    expect(
+      shouldRunSearch({
+        keyword: "",
+        filters: { senderUids: [], sort: "time_desc", startAt },
+        tab: "message",
+      })
+    ).toBe(true);
+  });
+
+  it("treats a sort-only change as not searchable (sort is not an effective filter)", () => {
+    expect(
+      shouldRunSearch({
+        keyword: "",
+        filters: { senderUids: [], sort: "time_asc" },
+        tab: "all",
+      })
+    ).toBe(false);
+  });
+
+  it("always runs media and file tabs even with empty keyword and no filters", () => {
+    expect(
+      shouldRunSearch({ keyword: "", filters: noFilters, tab: "media" })
+    ).toBe(true);
+    expect(
+      shouldRunSearch({ keyword: "", filters: noFilters, tab: "file" })
+    ).toBe(true);
   });
 });
 

--- a/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
@@ -162,6 +162,27 @@ function cleanFilters(filters: ChannelSearchFilters) {
   return next;
 }
 
+function hasEffectiveFilters(filters: ChannelSearchFilters) {
+  return Object.keys(cleanFilters(filters)).length > 0;
+}
+
+// Decide whether a search request should actually be sent. Only the keyword-
+// optional endpoints `_search` (message tab) and `_search_all` (all tab) carry
+// the backend empty-search guard (validateSearchNotEmpty): with an empty keyword
+// AND no effective filter they fail-fast with 400. Mirror that guard here so an
+// empty panel never fires a request that is guaranteed to 400 — it falls back to
+// the empty-state view instead. The media (`_search_media`) and file
+// (`_search_files`) tabs have no such backend guard and legitimately browse
+// without a keyword, so they always run.
+export function shouldRunSearch(
+  query: Pick<ChannelSearchQuery, "keyword" | "filters" | "tab">
+) {
+  if (query.tab !== "all" && query.tab !== "message") {
+    return true;
+  }
+  return query.keyword.trim().length > 0 || hasEffectiveFilters(query.filters);
+}
+
 function toRequestBody(query: ChannelSearchQuery) {
   const body: Record<string, unknown> = {
     channel_type: query.channelType,
@@ -446,6 +467,8 @@ export const channelSearchApiAdapterTestUtils = {
   monthBucketFromSentAt,
   normalizeItems,
   cleanFilters,
+  hasEffectiveFilters,
+  shouldRunSearch,
   toRequestBody,
   mapMessageHit,
   mapFileHit,

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -26,6 +26,7 @@ import FileHelper from "../../Utils/filehelper";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
 import { channelSearchEmptyDataSource } from "./adapter";
+import { shouldRunSearch } from "./apiAdapter";
 import {
   canLocateChannelSearchItem,
   resolveChannelSearchLocateTarget,
@@ -1207,6 +1208,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
   const filterCount = activeFilterCount(filters);
+  const canSearch = shouldRunSearch({ keyword, filters, tab: activeTab });
   const getSender = useCallback(
     (uid: string) => dataSource.getSender(uid),
     [dataSource]
@@ -1244,6 +1246,14 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const runSearch = useCallback(
     async (cursor?: string) => {
       if (isComposing) {
+        return;
+      }
+
+      // Empty-state guard: the keyword-optional `_search`/`_search_all` endpoints
+      // reject an empty keyword + empty filter with 400 (validateSearchNotEmpty).
+      // Don't fire it — show the empty-state view. Media/file tabs are exempt
+      // (they browse without a keyword), which shouldRunSearch encodes.
+      if (!shouldRunSearch({ keyword, filters, tab: activeTab })) {
         return;
       }
 
@@ -1290,17 +1300,26 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   useEffect(() => {
     if (isComposing) return;
     requestIdRef.current += 1;
-    setQueryStarted(true);
     setResponse({ items: [], hasMore: false });
-    setLoading(true);
     setLoadingMore(false);
     setError(null);
+
+    // No keyword and no effective filter → don't hit the backend (it would 400).
+    // Reset to the initial empty-state prompt instead of a spinner.
+    if (!canSearch) {
+      setQueryStarted(false);
+      setLoading(false);
+      return;
+    }
+
+    setQueryStarted(true);
+    setLoading(true);
 
     const timer = window.setTimeout(() => {
       void runSearch();
     }, SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
-  }, [isComposing, runSearch]);
+  }, [canSearch, isComposing, runSearch]);
 
   const handleLocate = useCallback(
     (item: ChannelSearchItem) => {


### PR DESCRIPTION
## Problem

Opening the channel search panel fired a keyword-less `_search_all` request immediately. The `_search` / `_search_all` endpoints reject an empty keyword with no effective filter (server-side `validateSearchNotEmpty`) with **HTTP 400**, so simply opening the panel produced a 400 in the Network panel every time. The UI masked it by also calling other endpoints, but the failed request was real.

## Fix

Add a client-side guard (`shouldRunSearch`) that mirrors the backend's exact scope:

- **all / message tabs** only fire when there is a trimmed keyword **OR** at least one effective filter (sender / date range). Empty input falls back to the existing empty-state prompt without firing a request.
- **media / file tabs** have no backend empty-search guard and legitimately browse without a keyword, so they always run (unchanged).

The guard short-circuits in both the debounce effect (so an empty panel resets to the empty-state view instead of a spinner) and at the `runSearch` entry (defense in depth + load-more path).

## Behavior

- Open panel (empty keyword) → no `_search`/`_search_all` request, empty-state prompt shown.
- Type a keyword → `_search_all` fires and renders results.
- Clear the keyword → back to the no-request empty state.
- Filter-only (sender / date, no keyword) → request fires normally.
- Media / file tabs → unaffected, browse without a keyword as before.

## Tests

- Adapter tests cover empty / keyword / filter-only / sort-only / media-file paths.
- `OpenEmpty` story updated to assert the no-request empty-state behavior.
- `pnpm vitest run src/Components/ChannelSearch` → 23 passed.