### PR TITLE
feat(runtimes): gate Create Bot until a runtime is online

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -170,12 +170,14 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   }, []);
 
   useImperativeHandle(ref, () => ({
-    openCreate: () => {
+    openCreate: async () => {
       // 刷新弹窗用的 runtime 缓存再开 —— hidden 的 BotsTab 不轮询 (见下方 polling
       // effect),runtimes 只在 mount / 切 space 时拉过。用户「先装运行时→等菜单变
       // 可点→点创建」时,本缓存仍是装之前的(无/离线)数据,弹窗 runtime 选择器为空
-      // 导致建不了 bot。openCreate 主动重拉,与 RuntimesPage 的 gating 数据对齐。
-      loadRuntimes();
+      // 导致建不了 bot。await 后再开,确保弹窗一上来就是刷新后的列表,不会先用旧
+      // (尤其首屏空)缓存渲染再跳变(codex code-review C1)。loadRuntimes 内有
+      // try/catch + epoch guard,不会 reject、不会跨 space 回填。
+      await loadRuntimes();
       setModalOpen(true);
     },
     openBot: (id: number) => {

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -182,12 +182,12 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
       // effect),runtimes 只在 mount / 切 space 时拉过。用户「先装运行时→等菜单变
       // 可点→点创建」时,本缓存仍是装之前的(无/离线)数据,弹窗 runtime 选择器为空
       // 导致建不了 bot。await 后再开,确保弹窗一上来就是刷新后的列表,不会先用旧
-      // (尤其首屏空)缓存渲染再跳变(codex code-review C1)。loadRuntimes 内有
+      // (尤其首屏空)缓存渲染再跳变。loadRuntimes 内有
       // try/catch + epoch guard,不会 reject、不会跨 space 回填。
       const epoch = spaceEpochRef.current;
       await loadRuntimes();
       // await 期间可能切了 space (onSpaceChanged 已 setModalOpen(false))——epoch 变了
-      // 就别在新 space 里用旧调用重开弹窗 (cc+codex round 8 一致)。
+      // 就别在新 space 里用旧调用重开弹窗。
       if (epoch !== spaceEpochRef.current) return;
       setModalOpen(true);
     },

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -75,6 +75,11 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   // space 的请求覆盖新 space 的 setRuntimes/setBots.
   const spaceEpochRef = useRef(0);
 
+  // 同 space 内的请求序号 (跟 RuntimesPage.loadData 的 loadSeq 同模式)。
+  // loadRuntimes 可能被 mount / space-change / openCreate 并发触发,fetch 响应
+  // 顺序不保证;只让最新一次请求 setRuntimes,防早发晚归的请求覆盖成旧列表。
+  const loadRuntimesSeqRef = useRef(0);
+
   // When a parent calls openBot(id) before the bots list has loaded, we
   // stash the id here and let a [bots]-watching effect apply it once the
   // list arrives. Without this, jumping in from a Runtime detail page on
@@ -98,6 +103,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
   // mittBus 监听 space-changed (跟 RuntimesPage 同源信号), 命中时重拉.
   const loadRuntimes = useCallback(async () => {
     const epoch = spaceEpochRef.current;
+    const seq = ++loadRuntimesSeqRef.current;
     const spaceId = (WKApp as any)?.shared?.currentSpaceId ?? '';
     const sessionToken = (WKApp as any)?.loginInfo?.token ?? '';
     // 合并 plan 决策一+二 Phase 3A: fleet 切到 AuthMiddleware 接 session
@@ -110,7 +116,8 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
         headers,
       });
       const env = await res.json();
-      if (epoch !== spaceEpochRef.current) return; // stale
+      // stale: 切了 space (epoch) 或被更新的 loadRuntimes 请求超越 (seq) 都丢弃
+      if (epoch !== spaceEpochRef.current || seq !== loadRuntimesSeqRef.current) return;
       const list = (env?.data?.runtimes ?? env?.runtimes ?? []) as any[];
       setRuntimes(list.map(r => ({
         id: r.id,
@@ -121,7 +128,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
         status: r.status || 'unknown',
       })));
     } catch {
-      if (epoch === spaceEpochRef.current) setRuntimes([]);
+      if (epoch === spaceEpochRef.current && seq === loadRuntimesSeqRef.current) setRuntimes([]);
     }
   }, []);
 

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -31,7 +31,7 @@ interface RuntimeListEntry {
 // Level-3 空态 CTA ("在此创建") 已随 "没 bot 不可展开" 改动移除, 唯一
 // caller 消失 (死链路清理). 将来有 runtime 行创建入口再加回.
 export interface BotsTabHandle {
-  openCreate: () => void;
+  openCreate: () => void | Promise<void>;
   openBot: (id: number) => void;
 }
 
@@ -177,7 +177,11 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
       // 导致建不了 bot。await 后再开,确保弹窗一上来就是刷新后的列表,不会先用旧
       // (尤其首屏空)缓存渲染再跳变(codex code-review C1)。loadRuntimes 内有
       // try/catch + epoch guard,不会 reject、不会跨 space 回填。
+      const epoch = spaceEpochRef.current;
       await loadRuntimes();
+      // await 期间可能切了 space (onSpaceChanged 已 setModalOpen(false))——epoch 变了
+      // 就别在新 space 里用旧调用重开弹窗 (cc+codex round 8 一致)。
+      if (epoch !== spaceEpochRef.current) return;
       setModalOpen(true);
     },
     openBot: (id: number) => {

--- a/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/BotsTab.tsx
@@ -171,6 +171,11 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
 
   useImperativeHandle(ref, () => ({
     openCreate: () => {
+      // 刷新弹窗用的 runtime 缓存再开 —— hidden 的 BotsTab 不轮询 (见下方 polling
+      // effect),runtimes 只在 mount / 切 space 时拉过。用户「先装运行时→等菜单变
+      // 可点→点创建」时,本缓存仍是装之前的(无/离线)数据,弹窗 runtime 选择器为空
+      // 导致建不了 bot。openCreate 主动重拉,与 RuntimesPage 的 gating 数据对齐。
+      loadRuntimes();
       setModalOpen(true);
     },
     openBot: (id: number) => {
@@ -187,7 +192,7 @@ export const BotsTab = forwardRef<BotsTabHandle, BotsTabProps>(function BotsTab(
         refresh();
       }
     },
-  }), [bots, selectBot, refresh]);
+  }), [bots, selectBot, refresh, loadRuntimes]);
 
   // Apply any parked openBot request once the bots list (or a refresh)
   // delivers the matching entry. Cleared regardless of match — a missing

--- a/packages/dmworkbase/src/Pages/Runtimes/botGating.test.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botGating.test.ts
@@ -6,12 +6,15 @@ describe("canCreateBot", () => {
         expect(canCreateBot([])).toBe(false)
     })
     it("returns false when every runtime is offline", () => {
-        expect(canCreateBot([{ status: "offline" }, { status: "offline" }])).toBe(false)
+        expect(canCreateBot([{ status: "offline", provider: "claude" }, { status: "offline", provider: "openclaw" }])).toBe(false)
     })
-    it("returns true when at least one runtime is online", () => {
-        expect(canCreateBot([{ status: "offline" }, { status: "online" }])).toBe(true)
+    it("returns true when a supported runtime is online", () => {
+        expect(canCreateBot([{ status: "offline", provider: "claude" }, { status: "online", provider: "openclaw" }])).toBe(true)
+    })
+    it("returns false when the only online runtime is an unsupported kind", () => {
+        expect(canCreateBot([{ status: "online", provider: "codex" }])).toBe(false)
     })
     it("treats only the exact string 'online' as online", () => {
-        expect(canCreateBot([{ status: "Online" }, { status: "" }])).toBe(false)
+        expect(canCreateBot([{ status: "Online", provider: "claude" }, { status: "", provider: "claude" }])).toBe(false)
     })
 })

--- a/packages/dmworkbase/src/Pages/Runtimes/botGating.test.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botGating.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest"
+import { canCreateBot } from "./botGating"
+
+describe("canCreateBot", () => {
+    it("returns false for an empty list", () => {
+        expect(canCreateBot([])).toBe(false)
+    })
+    it("returns false when every runtime is offline", () => {
+        expect(canCreateBot([{ status: "offline" }, { status: "offline" }])).toBe(false)
+    })
+    it("returns true when at least one runtime is online", () => {
+        expect(canCreateBot([{ status: "offline" }, { status: "online" }])).toBe(true)
+    })
+    it("treats only the exact string 'online' as online", () => {
+        expect(canCreateBot([{ status: "Online" }, { status: "" }])).toBe(false)
+    })
+})

--- a/packages/dmworkbase/src/Pages/Runtimes/botGating.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botGating.ts
@@ -1,7 +1,12 @@
+// 受支持的运行时类型 —— 与 botsApi.SUPPORTED_RUNTIME_KINDS 一致(内联于此让本
+// 模块零依赖、可被纯单测安全 import;botsApi 因 import App/i18n 带重副作用不宜引入)。
+const SUPPORTED_RUNTIME_KINDS = ["openclaw", "claude"]
+
 /**
- * 当前 space 是否存在至少一个在线运行时 —— 决定能否创建 Bot。
- * 仅精确匹配 "online";其它(含 "offline"、空、大小写变体)均视为不可创建。
+ * 当前 space 是否存在至少一个「在线且受支持」的运行时 —— 决定能否创建 Bot。
+ * 与 CreateBotModal 的提交条件(supported && status==="online")对齐:只有在线且
+ * 类型受支持的运行时才能真正建 bot,否则菜单亮了点开弹窗也无可选项、是死胡同。
  */
-export function canCreateBot(runtimes: { status: string }[]): boolean {
-    return runtimes.some((r) => r.status === "online")
+export function canCreateBot(runtimes: { status: string; provider: string }[]): boolean {
+    return runtimes.some((r) => r.status === "online" && SUPPORTED_RUNTIME_KINDS.includes(r.provider))
 }

--- a/packages/dmworkbase/src/Pages/Runtimes/botGating.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/botGating.ts
@@ -1,0 +1,7 @@
+/**
+ * 当前 space 是否存在至少一个在线运行时 —— 决定能否创建 Bot。
+ * 仅精确匹配 "online";其它(含 "offline"、空、大小写变体)均视为不可创建。
+ */
+export function canCreateBot(runtimes: { status: string }[]): boolean {
+    return runtimes.some((r) => r.status === "online")
+}

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1720,6 +1720,13 @@
   line-height: 1.3;
   color: var(--text-tertiary);
 }
+.wk-rt-create-menu-item--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.wk-rt-create-menu-item--disabled:hover {
+  background: transparent;
+}
 
 /* ──────────────────────────────────────────────────────────────────
    CreateBotModal — device-first 2-step picker.

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1727,6 +1727,11 @@
 .wk-rt-create-menu-item--disabled:hover {
   background: transparent;
 }
+/* 禁用项仍可聚焦 (aria-disabled),保留 box-shadow 焦点环但去掉 hover 背景,
+   免得看起来像可激活态 (Octo-Q review P2)。 */
+.wk-rt-create-menu-item--disabled:focus-visible {
+  background: transparent;
+}
 
 /* ──────────────────────────────────────────────────────────────────
    CreateBotModal — device-first 2-step picker.

--- a/packages/dmworkbase/src/Pages/Runtimes/index.css
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.css
@@ -1728,7 +1728,7 @@
   background: transparent;
 }
 /* 禁用项仍可聚焦 (aria-disabled),保留 box-shadow 焦点环但去掉 hover 背景,
-   免得看起来像可激活态 (Octo-Q review P2)。 */
+   免得看起来像可激活态。 */
 .wk-rt-create-menu-item--disabled:focus-visible {
   background: transparent;
 }

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -1587,7 +1587,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
             // 切 space 即清空 runtime 视图 —— 否则旧 space 的 runtimes 会残留到新 space
             // 首次 loadData 返回前;若该 loadData 失败 (catch 仅复位 loading=false 不清
             // runtimes),`canBot=!loading && canCreateBot(runtimes)` 会用旧 space 的在线
-            // 运行时误启用「创建 Bot」(codex code-review C1)。清空后失败也回落到禁用。
+            // 运行时误启用「创建 Bot」。清空后失败也回落到禁用。
             runtimes: [],
             versionHints: {},
             daemonVersionHints: {},
@@ -2017,7 +2017,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         // gating「创建 Bot」: 仅当本 space 已加载完成(非 loading)且有 ≥1 在线运行时才允许。
         // 切 space 时 handleSpaceChanged 已清空 runtimes:[];!loading 为兜底 —— 覆盖加载
         // 窗口期,以及 loadData 失败(catch 仅复位 loading=false、runtimes 保持 [])的场景,
-        // 防旧 space 在线运行时短暂误启用(codex code-review C1)。
+        // 防旧 space 在线运行时短暂误启用。
         const canBot = !loading && canCreateBot(runtimes)
 
         return (

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -9,6 +9,7 @@ import { InstallGuidePopover } from "./InstallGuidePopover"
 import { getInstallGuide } from "./installGuide"
 import { octoComponentName } from "./octoComponent"
 import { deviceRuntimeMode } from "./deviceRuntimeMode"
+import { canCreateBot } from "./botGating"
 import { Bot, botStatusLabel, listBots, providerLabels } from "./botsApi"
 import { ProviderLogo } from "./providerLogos"
 import { i18n, t } from "../../i18n"
@@ -1570,6 +1571,14 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
         // refreshRuntimeBots 触发.
         this.setState({
             selectedId: null,
+            // 切 space 即清空 runtime 视图 —— 否则旧 space 的 runtimes 会残留到新 space
+            // 首次 loadData 返回前;若该 loadData 失败 (catch 仅复位 loading=false 不清
+            // runtimes),`canBot=!loading && canCreateBot(runtimes)` 会用旧 space 的在线
+            // 运行时误启用「创建 Bot」(codex code-review C1)。清空后失败也回落到禁用。
+            runtimes: [],
+            versionHints: {},
+            daemonVersionHints: {},
+            activeUpgrades: {},
             expandedDevices: new Set(),
             expandedRuntimes: new Set(),
             botsByRuntime: new Map(),
@@ -1992,6 +2001,11 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
     render() {
         const { runtimes, selectedId, loading, expandedDevices, createMenuOpen, runtimeModalOpen } = this.state
         const groups = groupByDevice(runtimes)
+        // gating「创建 Bot」: 仅当本 space 已加载完成(非 loading)且有 ≥1 在线运行时才允许。
+        // 切 space 时 handleSpaceChanged 已清空 runtimes:[];!loading 为兜底 —— 覆盖加载
+        // 窗口期,以及 loadData 失败(catch 仅复位 loading=false、runtimes 保持 [])的场景,
+        // 防旧 space 在线运行时短暂误启用(codex code-review C1)。
+        const canBot = !loading && canCreateBot(runtimes)
 
         return (
             <div className="wk-rt-list">
@@ -2042,8 +2056,13 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                         <button
                                             type="button"
                                             role="menuitem"
-                                            className="wk-rt-create-menu-item"
-                                            onClick={() => this.setState({ createMenuOpen: false }, () => this.botsTabRef.current?.openCreate())}
+                                            className={`wk-rt-create-menu-item${canBot ? "" : " wk-rt-create-menu-item--disabled"}`}
+                                            aria-disabled={!canBot}
+                                            title={canBot ? undefined : t("base.runtimes.create.createBotDisabledHint")}
+                                            onClick={() => {
+                                                if (!canBot) return
+                                                this.setState({ createMenuOpen: false }, () => this.botsTabRef.current?.openCreate())
+                                            }}
                                         >
                                             <span className="wk-rt-create-menu-icon" aria-hidden="true">
                                                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -2056,7 +2075,7 @@ export default class RuntimesPage extends Component<{}, RuntimesPageState> {
                                             </span>
                                             <span className="wk-rt-create-menu-text">
                                                 <span className="wk-rt-create-menu-title">{t("base.runtimes.create.createBot")}</span>
-                                                <span className="wk-rt-create-menu-desc">{t("base.runtimes.create.createBotDesc")}</span>
+                                                <span className="wk-rt-create-menu-desc">{canBot ? t("base.runtimes.create.createBotDesc") : t("base.runtimes.create.createBotDisabledHint")}</span>
                                             </span>
                                         </button>
                                     </div>

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1160,6 +1160,7 @@
   "runtimes.create.createRuntimeDesc": "Connect a daemon on a new device",
   "runtimes.create.createBot": "Create Bot",
   "runtimes.create.createBotDesc": "Start a bot on an existing runtime",
+  "runtimes.create.createBotDisabledHint": "Install and bring a runtime online first",
   "runtimes.create.createFirst": "Click \"+ New Agent\" (top right) to create your first",
   "runtimes.agentModal.titleAddBot": "Add Bot to {{agent}}",
   "runtimes.agentModal.titleCreateAgent": "Create New Agent",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1160,6 +1160,7 @@
   "runtimes.create.createRuntimeDesc": "在新设备上接入 daemon",
   "runtimes.create.createBot": "创建 Bot",
   "runtimes.create.createBotDesc": "基于已有 runtime 起一个 Bot",
+  "runtimes.create.createBotDisabledHint": "需先安装并上线运行时",
   "runtimes.create.createFirst": "点击右上「+ 新建 Agent」创建第一个",
   "runtimes.agentModal.titleAddBot": "给 {{agent}} 添加 Bot",
   "runtimes.agentModal.titleCreateAgent": "创建新 Agent",


### PR DESCRIPTION
## Summary

In the Runtimes page, disable the **Create Bot** entry when the current space has no online runtime, with an inline hint, so users install and bring up a runtime before creating a bot (instead of skipping straight to bot creation).

## Changes

- Add `canCreateBot(runtimes)` pure helper + unit tests — `true` iff some runtime has `status === "online"`.
- Gate the "Create Bot" menu item: `canBot = !loading && canCreateBot(runtimes)`. When not allowed: `aria-disabled` + a `title` hint + greyed style, and `onClick` early-returns (WAI-ARIA menu pattern keeps the item focusable rather than using the native `disabled` attribute).
- Clear `runtimes` and its derived hints/upgrades on space switch, so a stale previous-space runtime cannot briefly re-enable the entry — including the case where the new space's reload fails.
- i18n: add `runtimes.create.createBotDisabledHint` to both `zh-CN` and `en-US`.

## Test plan

- `cd packages/dmworkbase && pnpm exec vitest run botGating` — 4 cases: empty list / all offline / at least one online / only exact `"online"` counts.
- Manual: with an online runtime the entry is enabled; with no online runtime it is greyed with the hint "Install and bring a runtime online first" and does nothing on click.

## Notes

- Pure-frontend change; no API or backend changes.