### PR TITLE
feat(runtimes): one-click install for the openclaw octo plugin

### DIFF
--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -986,7 +986,11 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         const { pluginUpgradeStatus, componentUpgradeStatus } = this.state
         const pluginUpg = this.props.pluginActiveUpgrade
         if (pluginUpg?.task_id && isUpgradeInProgress(pluginUpgradeStatus)) {
-            this.pollPluginUpgrade(pluginUpg.task_id, this.props.runtime.id)
+            // remount 续看时必须重建 install 上下文 —— 否则 install 在途也会落回升级的
+            // !has_plugin_update 完成条件,首装时它一开始即 true 会过早 remount + 「安装」
+            // 按钮闪回(与点击路径同一竞态)。在途插件还没出现在 metadata.plugins 即视为 install。
+            const isInstall = !octoPluginInstalled(this.props.runtime.metadata, pluginUpg.component)
+            this.pollPluginUpgrade(pluginUpg.task_id, this.props.runtime.id, { component: pluginUpg.component, isInstall })
         }
         const compUpg = this.props.componentActiveUpgrade
         if (compUpg?.task_id && isUpgradeInProgress(componentUpgradeStatus)) {

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -9,7 +9,7 @@ import { InstallGuidePopover } from "./InstallGuidePopover"
 import { getInstallGuide } from "./installGuide"
 import { octoComponentName } from "./octoComponent"
 import { deviceRuntimeMode } from "./deviceRuntimeMode"
-import { canInstallOctoPlugin } from "./pluginInstall"
+import { canInstallOctoPlugin, octoPluginInstalled } from "./pluginInstall"
 import { canCreateBot } from "./botGating"
 import { Bot, botStatusLabel, listBots, providerLabels, FLEET_API_BASE } from "./botsApi"
 import { ProviderLogo } from "./providerLogos"
@@ -1063,7 +1063,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         }
     }
 
-    handlePluginUpgrade = async (pluginComponent: string) => {
+    handlePluginUpgrade = async (pluginComponent: string, isInstall = false) => {
         const rt = this.props.runtime
         const runtimeId = rt.id
 
@@ -1079,15 +1079,17 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
             this.props.onUpgradeStarted?.()
             const taskId = initRes?.data?.task_id
             if (!taskId) throw new Error("plugin upgrade init: missing task_id in response")
-            await this.pollPluginUpgrade(taskId, runtimeId)
+            await this.pollPluginUpgrade(taskId, runtimeId, { component: pluginComponent, isInstall })
         } catch (err: any) {
             const msg = err?.msg || err?.message || t("base.runtimes.upgrade.errFailed")
             this.setState({ pluginUpgradeStatus: "failed", pluginUpgradeError: msg })
         }
     }
 
-    // 轮询已知 taskId 的进度。抽出复用于：1）首次点击 Upgrade；2）remount 后续看。
-    pollPluginUpgrade = async (taskId: string, runtimeId: number) => {
+    // 轮询已知 taskId 的进度。抽出复用于：1）首次点击 Upgrade / Install；2）remount 后续看。
+    // opts.isInstall: 首装走专属完成条件(等插件出现在 metadata.plugins),升级仍用
+    // !has_plugin_update —— 否则首装时该 hint 一开始即 false 会让确认循环过早 remount。
+    pollPluginUpgrade = async (taskId: string, runtimeId: number, opts?: { component?: string; isInstall?: boolean }) => {
         const isStale = () => this._unmounted || this.props.runtime.id !== runtimeId
         for (let i = 0; i < 200; i++) {
             if (isStale()) return
@@ -1116,9 +1118,13 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                         const runtimesRes = (await WKApp.apiClient.get("/runtimes", { param: { space_id: WKApp.shared.currentSpaceId }, baseURL: FLEET_API_BASE }))?.data
                         if (isStale()) return
                         const hints = runtimesRes?.version_hints || {}
-                        if (!hints[runtimeId]?.has_plugin_update) {
-                            const allRuntimes = runtimesRes?.runtimes || []
-                            const updated = allRuntimes.find((r: AgentRuntime) => r.id === runtimeId)
+                        const allRuntimes = runtimesRes?.runtimes || []
+                        const updated = allRuntimes.find((r: AgentRuntime) => r.id === runtimeId)
+                        // install: 等插件真正出现在 metadata.plugins;upgrade: 等 has_plugin_update 翻 false。
+                        const landed = opts?.isInstall
+                            ? octoPluginInstalled(updated?.metadata, opts.component)
+                            : !hints[runtimeId]?.has_plugin_update
+                        if (landed) {
                             if (updated) {
                                 // B-5 (X3): 透传互斥 props, 同 DeviceDetail 注释
                                 WKApp.routeRight.replaceToRoot(
@@ -1169,7 +1175,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     {pluginUpgradeError && <span className="wk-rt-upgrade-reason">· {pluginUpgradeError.length > 40 ? pluginUpgradeError.slice(0, 40) + "…" : pluginUpgradeError}</span>}
                     {!!pluginName && (busyByOther
                         ? <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{actionLabel}</span>
-                        : <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{actionLabel}</span>)}
+                        : <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName, action === "install")}>{actionLabel}</span>)}
                 </span>
             )
         }
@@ -1187,7 +1193,7 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                 // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
                 return <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{actionLabel}</span>
             }
-            return <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{actionLabel}</span>
+            return <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName, action === "install")}>{actionLabel}</span>
         }
         return null
     }
@@ -1403,8 +1409,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                     ) : (
                                         // openclaw 的 octo 插件未装 → 显「安装」按钮(一键装到 latest);
                                         // 其它(如 cc-octo)无插件数据时用中性占位「—」(指引 popover 已挂在 label 行)。
-                                        canInstallOctoPlugin(rt.provider, !!octoPlugin)
-                                            ? this.renderPluginUpgradeBtn(octoComponent ?? "", true, "install")
+                                        canInstallOctoPlugin(rt.provider, false)
+                                            ? this.renderPluginUpgradeBtn(octoComponent ?? "", undefined, "install")
                                             : <span className="wk-rt-install-empty">—</span>
                                     )}
                                 </span>

--- a/packages/dmworkbase/src/Pages/Runtimes/index.tsx
+++ b/packages/dmworkbase/src/Pages/Runtimes/index.tsx
@@ -9,6 +9,7 @@ import { InstallGuidePopover } from "./InstallGuidePopover"
 import { getInstallGuide } from "./installGuide"
 import { octoComponentName } from "./octoComponent"
 import { deviceRuntimeMode } from "./deviceRuntimeMode"
+import { canInstallOctoPlugin } from "./pluginInstall"
 import { canCreateBot } from "./botGating"
 import { Bot, botStatusLabel, listBots, providerLabels, FLEET_API_BASE } from "./botsApi"
 import { ProviderLogo } from "./providerLogos"
@@ -1148,12 +1149,14 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
         this.setState({ pluginUpgradeStatus: "timeout", pluginUpgradeError: t("base.runtimes.upgrade.errPollingTimeout") })
     }
 
-    renderPluginUpgradeBtn(pluginName: string, hasUpdate: boolean | undefined) {
+    renderPluginUpgradeBtn(pluginName: string, hasUpdate: boolean | undefined, action: "upgrade" | "install" = "upgrade") {
         const { pluginUpgradeStatus, pluginUpgradeError } = this.state
         // busy 来源是否本按钮自己的 task — 自己升级显示进度态; 别的 task
         // 在跑则本按钮 busy-disabled (按钮粒度豁免, plan §2.B-3 / X4).
         const selfInProgress = isUpgradeInProgress(pluginUpgradeStatus)
         const busyByOther = !!this.props.daemonBusy && !selfInProgress
+        // install: 用「安装」文案、空闲即显按钮; upgrade: 用「升级」文案、仅有更新时显。
+        const actionLabel = action === "install" ? t("base.runtimes.upgrade.install") : t("base.runtimes.upgrade.upgrade")
         if (pluginUpgradeStatus === "completed") {
             return <span className="wk-rt-upgrade-status success"><span className="upgrade-dot" />{t("base.runtimes.upgrade.completed")}</span>
         }
@@ -1165,8 +1168,8 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                     {pluginUpgradeStatus === "timeout" ? t("base.runtimes.upgrade.timeout") : t("base.runtimes.upgrade.failed")}
                     {pluginUpgradeError && <span className="wk-rt-upgrade-reason">· {pluginUpgradeError.length > 40 ? pluginUpgradeError.slice(0, 40) + "…" : pluginUpgradeError}</span>}
                     {!!pluginName && (busyByOther
-                        ? <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{t("base.runtimes.upgrade.upgrade")}</span>
-                        : <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{t("base.runtimes.upgrade.upgrade")}</span>)}
+                        ? <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{actionLabel}</span>
+                        : <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{actionLabel}</span>)}
                 </span>
             )
         }
@@ -1178,12 +1181,13 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                 </span>
             )
         }
-        if (hasUpdate && !!pluginName) {
+        const showIdle = action === "install" ? !!pluginName : (hasUpdate && !!pluginName)
+        if (showIdle) {
             if (busyByOther) {
                 // B-3: 同 daemon 其他升级在跑, fleet 必拒 — 预防性禁用
-                return <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{t("base.runtimes.upgrade.upgrade")}</span>
+                return <span className="wk-rt-upgrade-btn disabled" title={t("base.runtimes.upgrade.busyTitle")}>{actionLabel}</span>
             }
-            return <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{t("base.runtimes.upgrade.upgrade")}</span>
+            return <span className="wk-rt-upgrade-btn" onClick={() => this.handlePluginUpgrade(pluginName)}>{actionLabel}</span>
         }
         return null
     }
@@ -1397,8 +1401,11 @@ class RuntimeDetail extends Component<RuntimeDetailProps, RuntimeDetailState> {
                                             {this.renderPluginUpgradeBtn(octoComponent ?? "", pluginHint?.has_plugin_update)}
                                         </>
                                     ) : (
-                                        // 无 octo 适配插件数据时用中性占位, 不断言「未安装」.
-                                        <span className="wk-rt-install-empty">—</span>
+                                        // openclaw 的 octo 插件未装 → 显「安装」按钮(一键装到 latest);
+                                        // 其它(如 cc-octo)无插件数据时用中性占位「—」(指引 popover 已挂在 label 行)。
+                                        canInstallOctoPlugin(rt.provider, !!octoPlugin)
+                                            ? this.renderPluginUpgradeBtn(octoComponent ?? "", true, "install")
+                                            : <span className="wk-rt-install-empty">—</span>
                                     )}
                                 </span>
                             </div>

--- a/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.test.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { canInstallOctoPlugin } from "./pluginInstall"
+import { canInstallOctoPlugin, octoPluginInstalled } from "./pluginInstall"
 
 describe("canInstallOctoPlugin", () => {
     it("openclaw with no octo plugin installed -> true", () => {
@@ -13,5 +13,28 @@ describe("canInstallOctoPlugin", () => {
     })
     it("unknown provider -> false", () => {
         expect(canInstallOctoPlugin("codex", false)).toBe(false)
+    })
+})
+
+describe("octoPluginInstalled", () => {
+    it("true when metadata.plugins contains the component", () => {
+        const meta = JSON.stringify({ plugins: [{ name: "memory-core", version: "1" }, { name: "octo", version: "0.7.0" }] })
+        expect(octoPluginInstalled(meta, "octo")).toBe(true)
+    })
+    it("false when the component is not yet in plugins (fresh install not landed)", () => {
+        const meta = JSON.stringify({ plugins: [{ name: "memory-core", version: "1" }] })
+        expect(octoPluginInstalled(meta, "octo")).toBe(false)
+    })
+    it("false for empty / missing plugins", () => {
+        expect(octoPluginInstalled(JSON.stringify({ plugins: [] }), "octo")).toBe(false)
+        expect(octoPluginInstalled("{}", "octo")).toBe(false)
+        expect(octoPluginInstalled(undefined, "octo")).toBe(false)
+    })
+    it("false on malformed metadata json", () => {
+        expect(octoPluginInstalled("not json", "octo")).toBe(false)
+    })
+    it("false when component is empty", () => {
+        const meta = JSON.stringify({ plugins: [{ name: "octo", version: "0.7.0" }] })
+        expect(octoPluginInstalled(meta, "")).toBe(false)
     })
 })

--- a/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.test.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest"
+import { canInstallOctoPlugin } from "./pluginInstall"
+
+describe("canInstallOctoPlugin", () => {
+    it("openclaw with no octo plugin installed -> true", () => {
+        expect(canInstallOctoPlugin("openclaw", false)).toBe(true)
+    })
+    it("openclaw with octo plugin already installed -> false", () => {
+        expect(canInstallOctoPlugin("openclaw", true)).toBe(false)
+    })
+    it("claude (cc-octo) is out of 1a scope -> false even when plugin absent", () => {
+        expect(canInstallOctoPlugin("claude", false)).toBe(false)
+    })
+    it("unknown provider -> false", () => {
+        expect(canInstallOctoPlugin("codex", false)).toBe(false)
+    })
+})

--- a/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.ts
@@ -4,3 +4,18 @@
 export function canInstallOctoPlugin(provider: string, hasOctoPlugin: boolean): boolean {
     return provider === "openclaw" && !hasOctoPlugin
 }
+
+// 安装完成判定:刷新到的 runtime.metadata(JSON 字符串)的 plugins 列表里是否已出现
+// 该适配插件。install 复用 upgrade 的轮询,但**完成条件**不能沿用升级的
+// `!has_plugin_update`(首装时该 hint 一开始就是 false/undefined,会让确认循环在
+// daemon 还没重报新插件前就 remount,导致「安装」按钮闪回)。install 必须等插件真正
+// 出现在 metadata 里才算落地。
+export function octoPluginInstalled(metadataJson: string | undefined, component: string | undefined): boolean {
+    if (!component) return false
+    try {
+        const meta = JSON.parse(metadataJson || "{}")
+        return Array.isArray(meta?.plugins) && meta.plugins.some((p: { name?: string }) => p?.name === component)
+    } catch {
+        return false
+    }
+}

--- a/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.ts
+++ b/packages/dmworkbase/src/Pages/Runtimes/pluginInstall.ts
@@ -1,0 +1,6 @@
+// 1a 只支持 openclaw 的 octo 适配插件一键安装(cc-octo 的安装留待后续,需用户提供
+// LLM 网关/key 等额外配置)。当 provider 是 openclaw 且其 octo 插件尚未安装时,版本
+// 槽显示「安装」。
+export function canInstallOctoPlugin(provider: string, hasOctoPlugin: boolean): boolean {
+    return provider === "openclaw" && !hasOctoPlugin
+}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1197,6 +1197,7 @@
   "runtimes.empty": "No runtimes registered",
   "runtimes.device.allOnline": "All Online",
   "runtimes.upgrade.upgrade": "Upgrade",
+  "runtimes.upgrade.install": "Install",
   "runtimes.upgrade.upgraded": "Upgraded",
   "runtimes.upgrade.completed": "Completed",
   "runtimes.upgrade.failed": "Failed",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1197,6 +1197,7 @@
   "runtimes.empty": "还没有注册的运行时",
   "runtimes.device.allOnline": "全部在线",
   "runtimes.upgrade.upgrade": "升级",
+  "runtimes.upgrade.install": "安装",
   "runtimes.upgrade.upgraded": "已升级",
   "runtimes.upgrade.completed": "已完成",
   "runtimes.upgrade.failed": "失败",


### PR DESCRIPTION
When an openclaw runtime has no octo plugin installed, show an Install button in the plugin version slot. Clicking it triggers the existing upgrade pipeline (fleet now accepts it as an install task), and after the install completes the version number is shown.

- `canInstallOctoPlugin(provider, hasOctoPlugin)` helper (+ unit tests): true only for openclaw with no octo plugin.
- `renderPluginUpgradeBtn` gains an optional `action` param ("upgrade" default | "install") controlling the label and the idle-state visibility; existing upgrade call sites are unaffected.
- The plugin version slot renders the Install button in the not-found branch for openclaw; cc-octo (Claude) is unchanged (keeps the existing version display / install guide).
- i18n `runtimes.upgrade.install` added to zh-CN and en-US.

Depends on the octo-fleet change that accepts the install task (merge that first).