### PR TITLE
fix: polish channel search UI details

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
@@ -20,9 +20,6 @@ const figmaMediaThumbs = [
   new URL("./assets/figma-media-08.png", import.meta.url).href,
 ];
 
-const figmaPdfIcon = new URL("./assets/figma-file-pdf.png", import.meta.url)
-  .href;
-const figmaMdIcon = new URL("./assets/figma-file-md.png", import.meta.url).href;
 const figmaInlineImage = new URL(
   "./assets/figma-inline-image-01.png",
   import.meta.url
@@ -128,7 +125,6 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     file: {
       name: "一个名叫哈哈帮的文件.pdf",
       size: 2411724,
-      iconUrl: figmaPdfIcon,
       url: "",
     },
   },
@@ -199,7 +195,6 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     file: {
       name: "文件名称文件名称文件名称.md",
       size: 2411724,
-      iconUrl: figmaMdIcon,
       url: "",
     },
   },

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/fileIcon.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/fileIcon.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { channelSearchFileIconTestUtils } from "../fileIcon";
+
+const { fileNameForIconLookup } = channelSearchFileIconTestUtils;
+
+describe("channel search file icon lookup name", () => {
+  it("keeps the original name when no backend extension is provided", () => {
+    expect(fileNameForIconLookup("report.final")).toBe("report.final");
+  });
+
+  it("keeps the original name when it already ends with the backend extension", () => {
+    expect(fileNameForIconLookup("report.pdf", "pdf")).toBe("report.pdf");
+    expect(fileNameForIconLookup("REPORT.PDF", "pdf")).toBe("REPORT.PDF");
+  });
+
+  it("appends a cleaned backend extension when the name has no extension", () => {
+    expect(fileNameForIconLookup("report", " .pdf ")).toBe("report.pdf");
+  });
+
+  it("prefers backend extension when a dotted name segment is not the file type", () => {
+    expect(fileNameForIconLookup("report.final", "pdf")).toBe(
+      "report.final.pdf"
+    );
+  });
+
+  it("prefers backend extension when the visible name conflicts with it", () => {
+    expect(fileNameForIconLookup("report.doc", "pdf")).toBe("report.doc.pdf");
+  });
+});

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/fileIcon.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/fileIcon.test.ts
@@ -1,29 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { channelSearchFileIconTestUtils } from "../fileIcon";
 
-const { fileNameForIconLookup } = channelSearchFileIconTestUtils;
+const { extensionForIconLookup } = channelSearchFileIconTestUtils;
 
-describe("channel search file icon lookup name", () => {
-  it("keeps the original name when no backend extension is provided", () => {
-    expect(fileNameForIconLookup("report.final")).toBe("report.final");
+describe("channel search file icon lookup extension", () => {
+  it("falls back to the visible file name when no backend extension is provided", () => {
+    expect(extensionForIconLookup("report.final")).toBe("final");
   });
 
-  it("keeps the original name when it already ends with the backend extension", () => {
-    expect(fileNameForIconLookup("report.pdf", "pdf")).toBe("report.pdf");
-    expect(fileNameForIconLookup("REPORT.PDF", "pdf")).toBe("REPORT.PDF");
+  it("uses the backend extension when it matches the visible file name", () => {
+    expect(extensionForIconLookup("report.pdf", "pdf")).toBe("pdf");
+    expect(extensionForIconLookup("REPORT.PDF", "pdf")).toBe("pdf");
   });
 
-  it("appends a cleaned backend extension when the name has no extension", () => {
-    expect(fileNameForIconLookup("report", " .pdf ")).toBe("report.pdf");
+  it("cleans the backend extension before lookup", () => {
+    expect(extensionForIconLookup("report", " .pdf ")).toBe("pdf");
   });
 
   it("prefers backend extension when a dotted name segment is not the file type", () => {
-    expect(fileNameForIconLookup("report.final", "pdf")).toBe(
-      "report.final.pdf"
-    );
+    expect(extensionForIconLookup("report.final", "pdf")).toBe("pdf");
   });
 
   it("prefers backend extension when the visible name conflicts with it", () => {
-    expect(fileNameForIconLookup("report.doc", "pdf")).toBe("report.doc.pdf");
+    expect(extensionForIconLookup("report.doc", "pdf")).toBe("pdf");
   });
 });

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  channelSearchPaginationTestUtils,
+  LOAD_MORE_SCROLL_THRESHOLD,
+} from "../pagination";
+
+const { isNearChannelSearchScrollBottom, shouldStopPaginationForCursor } =
+  channelSearchPaginationTestUtils;
+
+function scrollMetrics({
+  clientHeight = 400,
+  scrollHeight = 1000,
+  scrollTop,
+}: {
+  clientHeight?: number;
+  scrollHeight?: number;
+  scrollTop: number;
+}) {
+  return { clientHeight, scrollHeight, scrollTop } as HTMLElement;
+}
+
+describe("channel search scroll pagination helpers", () => {
+  it("triggers pagination when the content is inside the bottom threshold", () => {
+    expect(
+      isNearChannelSearchScrollBottom(
+        scrollMetrics({
+          scrollTop: 1000 - 400 - LOAD_MORE_SCROLL_THRESHOLD,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("does not trigger pagination before the bottom threshold", () => {
+    expect(
+      isNearChannelSearchScrollBottom(
+        scrollMetrics({
+          scrollTop: 1000 - 400 - LOAD_MORE_SCROLL_THRESHOLD - 1,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("stops pagination when the backend repeats the requested cursor", () => {
+    expect(
+      shouldStopPaginationForCursor({
+        hasMore: true,
+        nextCursor: "cursor-2",
+        requestedCursor: "cursor-2",
+      })
+    ).toBe(true);
+  });
+
+  it("continues pagination when the backend advances the cursor", () => {
+    expect(
+      shouldStopPaginationForCursor({
+        hasMore: true,
+        nextCursor: "cursor-3",
+        requestedCursor: "cursor-2",
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
@@ -52,6 +52,15 @@ describe("channel search scroll pagination helpers", () => {
     ).toBe(true);
   });
 
+  it("stops pagination when the backend has more but returns no next cursor", () => {
+    expect(
+      shouldStopPaginationForCursor({
+        hasMore: true,
+        requestedCursor: "cursor-2",
+      })
+    ).toBe(true);
+  });
+
   it("continues pagination when the backend advances the cursor", () => {
     expect(
       shouldStopPaginationForCursor({

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/pagination.test.ts
@@ -6,6 +6,8 @@ import {
 
 const { isNearChannelSearchScrollBottom, shouldStopPaginationForCursor } =
   channelSearchPaginationTestUtils;
+const { shouldPauseAutoPaginationForEmptyPage } =
+  channelSearchPaginationTestUtils;
 
 function scrollMetrics({
   clientHeight = 400,
@@ -56,6 +58,38 @@ describe("channel search scroll pagination helpers", () => {
         hasMore: true,
         nextCursor: "cursor-3",
         requestedCursor: "cursor-2",
+      })
+    ).toBe(false);
+  });
+
+  it("pauses auto pagination when an empty page advances the cursor", () => {
+    expect(
+      shouldPauseAutoPaginationForEmptyPage({
+        hasMore: true,
+        itemCount: 0,
+        nextCursor: "cursor-3",
+        requestedCursor: "cursor-2",
+      })
+    ).toBe(true);
+  });
+
+  it("keeps auto pagination active when a page appends items", () => {
+    expect(
+      shouldPauseAutoPaginationForEmptyPage({
+        hasMore: true,
+        itemCount: 2,
+        nextCursor: "cursor-3",
+        requestedCursor: "cursor-2",
+      })
+    ).toBe(false);
+  });
+
+  it("does not pause the initial empty result page", () => {
+    expect(
+      shouldPauseAutoPaginationForEmptyPage({
+        hasMore: true,
+        itemCount: 0,
+        nextCursor: "cursor-1",
       })
     ).toBe(false);
   });

--- a/packages/dmworkbase/src/Components/ChannelSearch/fileIcon.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/fileIcon.ts
@@ -1,0 +1,26 @@
+function normalizeFileExtension(extension?: string) {
+  return extension?.trim().replace(/^\./, "").toLowerCase() || "";
+}
+
+function getFileNameExtension(fileName: string) {
+  const dotIdx = fileName.lastIndexOf(".");
+  if (dotIdx <= 0 || dotIdx === fileName.length - 1) {
+    return "";
+  }
+  return fileName.slice(dotIdx + 1).toLowerCase();
+}
+
+export function fileNameForIconLookup(fileName: string, extension?: string) {
+  const ext = normalizeFileExtension(extension);
+  if (!ext) {
+    return fileName;
+  }
+  if (getFileNameExtension(fileName) === ext) {
+    return fileName;
+  }
+  return `${fileName}.${ext}`;
+}
+
+export const channelSearchFileIconTestUtils = {
+  fileNameForIconLookup,
+};

--- a/packages/dmworkbase/src/Components/ChannelSearch/fileIcon.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/fileIcon.ts
@@ -1,3 +1,5 @@
+import { getFileIconByExtension } from "../../Utils/fileIcon";
+
 function normalizeFileExtension(extension?: string) {
   return extension?.trim().replace(/^\./, "").toLowerCase() || "";
 }
@@ -10,17 +12,22 @@ function getFileNameExtension(fileName: string) {
   return fileName.slice(dotIdx + 1).toLowerCase();
 }
 
-export function fileNameForIconLookup(fileName: string, extension?: string) {
+export function extensionForIconLookup(fileName: string, extension?: string) {
   const ext = normalizeFileExtension(extension);
   if (!ext) {
-    return fileName;
+    return getFileNameExtension(fileName);
   }
-  if (getFileNameExtension(fileName) === ext) {
-    return fileName;
-  }
-  return `${fileName}.${ext}`;
+  return ext;
+}
+
+export function resolveChannelSearchFileIconSrc(
+  fileName: string,
+  extension?: string
+) {
+  return getFileIconByExtension(extensionForIconLookup(fileName, extension));
 }
 
 export const channelSearchFileIconTestUtils = {
-  fileNameForIconLookup,
+  extensionForIconLookup,
+  resolveChannelSearchFileIconSrc,
 };

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -933,6 +933,10 @@
   font: 400 12px/20px var(--wk-font-sans);
 }
 
+.wk-channel-search-load-more--error {
+  color: var(--wk-color-error);
+}
+
 .wk-channel-search-load-more button {
   border: none;
   padding: 0;

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -23,7 +23,7 @@
   );
   --channel-search-accent: var(--wk-text-accent);
   --channel-search-warning: var(--wk-color-warning);
-  --channel-search-highlight: #f8e6ab;
+  --channel-search-highlight: var(--wk-color-search-highlight);
   --channel-search-shadow: var(--wk-shadow-lg),
     0 0 0 1px var(--wk-border-subtle);
   --channel-search-overlay: color-mix(
@@ -773,8 +773,7 @@
   position: relative;
   width: 16px;
   height: 16px;
-  border: 1px solid
-    color-mix(in srgb, var(--wk-text-primary) 24%, transparent);
+  border: 1px solid color-mix(in srgb, var(--wk-text-primary) 24%, transparent);
   border-radius: 4px;
   flex-shrink: 0;
   background: var(--channel-search-surface);
@@ -878,8 +877,7 @@
 .wk-channel-search-radio-list button span {
   width: 16px;
   height: 16px;
-  border: 1px solid
-    color-mix(in srgb, var(--wk-text-primary) 35%, transparent);
+  border: 1px solid color-mix(in srgb, var(--wk-text-primary) 35%, transparent);
   border-radius: 9999px;
 }
 
@@ -927,8 +925,19 @@
 
 .wk-channel-search-load-more {
   display: flex;
+  align-items: center;
   justify-content: center;
+  gap: 8px;
   padding: 12px 16px 16px;
   color: var(--channel-search-text-tertiary);
   font: 400 12px/20px var(--wk-font-sans);
+}
+
+.wk-channel-search-load-more--error button {
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: var(--channel-search-accent);
+  font: inherit;
+  cursor: pointer;
 }

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -23,7 +23,7 @@
   );
   --channel-search-accent: var(--wk-text-accent);
   --channel-search-warning: var(--wk-color-warning);
-  --channel-search-highlight: var(--wk-color-warning-bg);
+  --channel-search-highlight: #f8e6ab;
   --channel-search-shadow: var(--wk-shadow-lg),
     0 0 0 1px var(--wk-border-subtle);
   --channel-search-overlay: color-mix(
@@ -528,17 +528,9 @@
 }
 
 .wk-channel-search-file-icon img {
-  width: 32px;
-  height: 32px;
-}
-
-.wk-channel-search-file-icon--figma {
-  background: transparent;
-}
-
-.wk-channel-search-file-icon--figma img {
   width: 48px;
   height: 48px;
+  object-fit: contain;
 }
 
 .wk-channel-search-file-body {
@@ -936,5 +928,7 @@
 .wk-channel-search-load-more {
   display: flex;
   justify-content: center;
-  padding: 16px;
+  padding: 12px 16px 16px;
+  color: var(--channel-search-text-tertiary);
+  font: 400 12px/20px var(--wk-font-sans);
 }

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -933,7 +933,7 @@
   font: 400 12px/20px var(--wk-font-sans);
 }
 
-.wk-channel-search-load-more--error button {
+.wk-channel-search-load-more button {
   border: none;
   padding: 0;
   background: transparent;

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -22,15 +22,20 @@ import WKAvatar from "../WKAvatar";
 import WKButton from "../WKButton";
 import IconClick from "../IconClick";
 import ConversationContext from "../Conversation/context";
-import { getFileIcon as getFileIconUrl } from "../MessageInput/AttachmentNode";
+import { getFileIcon } from "../MessageInput/AttachmentNode";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
 import { channelSearchEmptyDataSource } from "./adapter";
 import { shouldRunSearch } from "./apiAdapter";
+import { fileNameForIconLookup } from "./fileIcon";
 import {
   canLocateChannelSearchItem,
   resolveChannelSearchLocateTarget,
 } from "./locate";
+import {
+  isNearChannelSearchScrollBottom,
+  shouldStopPaginationForCursor,
+} from "./pagination";
 import { defaultChannelSearchFilters } from "./types";
 import type {
   ChannelSearchDataSource,
@@ -57,7 +62,6 @@ interface ChannelSearchPanelProps {
 
 const tabs: ChannelSearchTab[] = ["all", "message", "media", "file"];
 const SEARCH_DEBOUNCE_MS = 300;
-const LOAD_MORE_SCROLL_THRESHOLD = 120;
 
 const tabI18nKey: Record<ChannelSearchTab, string> = {
   all: "base.channelSearch.tabs.all",
@@ -146,12 +150,8 @@ function compactFileSize(bytes: number) {
   return `${bytes}B`;
 }
 
-function getFileIconName(fileName: string, extension?: string) {
-  const ext = extension?.replace(/^\./, "").trim();
-  if (!ext || /\.[^.]+$/.test(fileName)) {
-    return fileName;
-  }
-  return `${fileName}.${ext}`;
+function resolveFileIconSrc(fileName: string, extension?: string) {
+  return getFileIcon(fileNameForIconLookup(fileName, extension), "");
 }
 
 function useOutsideDismiss(
@@ -943,10 +943,7 @@ const FileInlineResult = React.memo(function FileInlineResult({
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
   const inlineFileName = fileName.replace(/\.[^.]+$/, "");
-  const fileIconSrc = getFileIconUrl(
-    getFileIconName(fileName, item.file?.extension),
-    ""
-  );
+  const fileIconSrc = resolveFileIconSrc(fileName, item.file?.extension);
 
   return (
     <div className="wk-channel-search-result wk-channel-search-file-inline">
@@ -1051,10 +1048,7 @@ const FileResultItem = React.memo(function FileResultItem({
   const menuRef = useRef<HTMLDivElement>(null);
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
-  const fileIconSrc = getFileIconUrl(
-    getFileIconName(fileName, item.file?.extension),
-    ""
-  );
+  const fileIconSrc = resolveFileIconSrc(fileName, item.file?.extension);
 
   const handleDownload = async () => {
     const url = item.file?.downloadUrl || item.file?.url;
@@ -1197,6 +1191,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const [loadingMore, setLoadingMore] = useState(false);
   const [queryStarted, setQueryStarted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [paginationError, setPaginationError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
   const loadingMoreCursorRef = useRef<string | null>(null);
   const [isComposing, setIsComposing] = useState(false);
@@ -1247,7 +1242,6 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
       if (cursor && loadingMoreCursorRef.current === cursor) {
         return;
       }
-      loadingMoreCursorRef.current = cursor || null;
 
       // Empty-state guard: the keyword-optional `_search`/`_search_all` endpoints
       // reject an empty keyword + empty filter with 400 (validateSearchNotEmpty).
@@ -1257,13 +1251,16 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         return;
       }
 
+      loadingMoreCursorRef.current = cursor || null;
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       setQueryStarted(true);
-      setError(null);
       if (cursor) {
+        setPaginationError(null);
         setLoadingMore(true);
       } else {
+        setError(null);
+        setPaginationError(null);
         setLoading(true);
       }
 
@@ -1278,14 +1275,24 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
           limit: 20,
         });
         if (requestIdRef.current !== requestId) return;
+        const stopPagination = shouldStopPaginationForCursor({
+          hasMore: next.hasMore,
+          nextCursor: next.nextCursor,
+          requestedCursor: cursor,
+        });
         setResponse((prev) => ({
           items: cursor ? [...prev.items, ...next.items] : next.items,
-          nextCursor: next.nextCursor,
-          hasMore: next.hasMore,
+          nextCursor: stopPagination ? undefined : next.nextCursor,
+          hasMore: stopPagination ? false : next.hasMore,
         }));
       } catch (_) {
         if (requestIdRef.current === requestId) {
-          setError(t("base.channelSearch.searchFailed"));
+          const message = t("base.channelSearch.searchFailed");
+          if (cursor) {
+            setPaginationError(message);
+          } else {
+            setError(message);
+          }
         }
       } finally {
         if (requestIdRef.current === requestId) {
@@ -1300,25 +1307,29 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     [activeTab, channel, dataSource, filters, isComposing, keyword, t]
   );
 
-  const loadNextPage = useCallback(() => {
-    if (loading || loadingMore || !response.hasMore || !response.nextCursor) {
-      return;
-    }
-    void runSearch(response.nextCursor);
-  }, [
-    loading,
-    loadingMore,
-    response.hasMore,
-    response.nextCursor,
-    runSearch,
-  ]);
+  const loadNextPage = useCallback(
+    (force = false) => {
+      if (loading || loadingMore || !response.hasMore || !response.nextCursor) {
+        return;
+      }
+      if (paginationError && !force) {
+        return;
+      }
+      void runSearch(response.nextCursor);
+    },
+    [
+      loading,
+      loadingMore,
+      paginationError,
+      response.hasMore,
+      response.nextCursor,
+      runSearch,
+    ]
+  );
 
   const handleContentScroll = useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {
-      const target = event.currentTarget;
-      const distanceToBottom =
-        target.scrollHeight - target.scrollTop - target.clientHeight;
-      if (distanceToBottom <= LOAD_MORE_SCROLL_THRESHOLD) {
+      if (isNearChannelSearchScrollBottom(event.currentTarget)) {
         loadNextPage();
       }
     },
@@ -1332,6 +1343,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     setResponse({ items: [], hasMore: false });
     setLoadingMore(false);
     setError(null);
+    setPaginationError(null);
 
     // No keyword and no effective filter → don't hit the backend (it would 400).
     // Reset to the initial empty-state prompt instead of a spinner.
@@ -1353,9 +1365,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   useEffect(() => {
     const content = contentRef.current;
     if (!content) return;
-    const distanceToBottom =
-      content.scrollHeight - content.scrollTop - content.clientHeight;
-    if (distanceToBottom <= LOAD_MORE_SCROLL_THRESHOLD) {
+    if (isNearChannelSearchScrollBottom(content)) {
       loadNextPage();
     }
   }, [activeTab, loadNextPage, response.items.length]);
@@ -1403,7 +1413,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         </div>
       );
     }
-    if (error) {
+    if (error && response.items.length === 0) {
       return <div className="wk-channel-search-error">{error}</div>;
     }
     if (!queryStarted || response.items.length === 0) {
@@ -1525,6 +1535,14 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         {loadingMore && (
           <div className="wk-channel-search-load-more" role="status">
             {t("base.channelSearch.loading")}
+          </div>
+        )}
+        {paginationError && response.items.length > 0 && (
+          <div className="wk-channel-search-load-more wk-channel-search-load-more--error">
+            <span>{paginationError}</span>
+            <button type="button" onClick={() => loadNextPage(true)}>
+              {t("base.channelSearch.loadMore")}
+            </button>
           </div>
         )}
       </div>

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -22,12 +22,11 @@ import WKAvatar from "../WKAvatar";
 import WKButton from "../WKButton";
 import IconClick from "../IconClick";
 import ConversationContext from "../Conversation/context";
-import { getFileIcon } from "../MessageInput/AttachmentNode";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
 import { channelSearchEmptyDataSource } from "./adapter";
 import { shouldRunSearch } from "./apiAdapter";
-import { fileNameForIconLookup } from "./fileIcon";
+import { resolveChannelSearchFileIconSrc } from "./fileIcon";
 import {
   canLocateChannelSearchItem,
   resolveChannelSearchLocateTarget,
@@ -149,10 +148,6 @@ function compactFileSize(bytes: number) {
     return `${(bytes / 1024).toFixed(1).replace(/\.0$/, "")}KB`;
   }
   return `${bytes}B`;
-}
-
-function resolveFileIconSrc(fileName: string, extension?: string) {
-  return getFileIcon(fileNameForIconLookup(fileName, extension), "");
 }
 
 function useOutsideDismiss(
@@ -944,7 +939,10 @@ const FileInlineResult = React.memo(function FileInlineResult({
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
   const inlineFileName = fileName.replace(/\.[^.]+$/, "");
-  const fileIconSrc = resolveFileIconSrc(fileName, item.file?.extension);
+  const fileIconSrc = resolveChannelSearchFileIconSrc(
+    fileName,
+    item.file?.extension
+  );
 
   return (
     <div className="wk-channel-search-result wk-channel-search-file-inline">
@@ -967,7 +965,7 @@ const FileInlineResult = React.memo(function FileInlineResult({
         </div>
         <div className="wk-channel-search-inline-file-card">
           <div className="wk-channel-search-inline-file-icon">
-            {fileIconSrc && <img src={fileIconSrc} alt="" />}
+            <img src={fileIconSrc} alt="" />
           </div>
           <div className="wk-channel-search-inline-file-body">
             <div className="wk-channel-search-inline-file-name">
@@ -1049,7 +1047,10 @@ const FileResultItem = React.memo(function FileResultItem({
   const menuRef = useRef<HTMLDivElement>(null);
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
-  const fileIconSrc = resolveFileIconSrc(fileName, item.file?.extension);
+  const fileIconSrc = resolveChannelSearchFileIconSrc(
+    fileName,
+    item.file?.extension
+  );
 
   const handleDownload = async () => {
     const url = item.file?.downloadUrl || item.file?.url;
@@ -1196,6 +1197,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const [autoPaginationPaused, setAutoPaginationPaused] = useState(false);
   const requestIdRef = useRef(0);
   const loadingMoreCursorRef = useRef<string | null>(null);
+  const scrollFrameRef = useRef<number | null>(null);
   const [isComposing, setIsComposing] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const filterWrapRef = useRef<HTMLDivElement>(null);
@@ -1338,14 +1340,43 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     ]
   );
 
-  const handleContentScroll = useCallback(
-    (event: React.UIEvent<HTMLDivElement>) => {
-      if (isNearChannelSearchScrollBottom(event.currentTarget)) {
+  const maybeLoadNextPageFromScroll = useCallback(
+    (content: HTMLElement) => {
+      if (isNearChannelSearchScrollBottom(content)) {
         loadNextPage();
       }
     },
     [loadNextPage]
   );
+
+  const handleContentScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const content = event.currentTarget;
+      if (typeof window.requestAnimationFrame !== "function") {
+        maybeLoadNextPageFromScroll(content);
+        return;
+      }
+      if (scrollFrameRef.current !== null) {
+        return;
+      }
+      scrollFrameRef.current = window.requestAnimationFrame(() => {
+        scrollFrameRef.current = null;
+        maybeLoadNextPageFromScroll(content);
+      });
+    },
+    [maybeLoadNextPageFromScroll]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (
+        scrollFrameRef.current !== null &&
+        typeof window.cancelAnimationFrame === "function"
+      ) {
+        window.cancelAnimationFrame(scrollFrameRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (isComposing) return;
@@ -1374,13 +1405,12 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     return () => window.clearTimeout(timer);
   }, [canSearch, isComposing, runSearch]);
 
+  // User scrolls and this first-screen top-up effect share the same load guard.
   useEffect(() => {
     const content = contentRef.current;
     if (!content) return;
-    if (isNearChannelSearchScrollBottom(content)) {
-      loadNextPage();
-    }
-  }, [activeTab, loadNextPage, response.items.length]);
+    maybeLoadNextPageFromScroll(content);
+  }, [activeTab, maybeLoadNextPageFromScroll, response.items.length]);
 
   const handleLocate = useCallback(
     (item: ChannelSearchItem) => {

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -22,7 +22,7 @@ import WKAvatar from "../WKAvatar";
 import WKButton from "../WKButton";
 import IconClick from "../IconClick";
 import ConversationContext from "../Conversation/context";
-import FileHelper from "../../Utils/filehelper";
+import { getFileIcon as getFileIconUrl } from "../MessageInput/AttachmentNode";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
 import { channelSearchEmptyDataSource } from "./adapter";
@@ -57,6 +57,7 @@ interface ChannelSearchPanelProps {
 
 const tabs: ChannelSearchTab[] = ["all", "message", "media", "file"];
 const SEARCH_DEBOUNCE_MS = 300;
+const LOAD_MORE_SCROLL_THRESHOLD = 120;
 
 const tabI18nKey: Record<ChannelSearchTab, string> = {
   all: "base.channelSearch.tabs.all",
@@ -145,12 +146,12 @@ function compactFileSize(bytes: number) {
   return `${bytes}B`;
 }
 
-function assetUrl(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
-  if (value && typeof value === "object" && "default" in value) {
-    return assetUrl((value as { default?: unknown }).default);
+function getFileIconName(fileName: string, extension?: string) {
+  const ext = extension?.replace(/^\./, "").trim();
+  if (!ext || /\.[^.]+$/.test(fileName)) {
+    return fileName;
   }
-  return undefined;
+  return `${fileName}.${ext}`;
 }
 
 function useOutsideDismiss(
@@ -942,8 +943,10 @@ const FileInlineResult = React.memo(function FileInlineResult({
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
   const inlineFileName = fileName.replace(/\.[^.]+$/, "");
-  const fileIconInfo = FileHelper.getFileIconInfo(fileName);
-  const fileIconSrc = item.file?.iconUrl || assetUrl(fileIconInfo?.icon);
+  const fileIconSrc = getFileIconUrl(
+    getFileIconName(fileName, item.file?.extension),
+    ""
+  );
 
   return (
     <div className="wk-channel-search-result wk-channel-search-file-inline">
@@ -1048,9 +1051,10 @@ const FileResultItem = React.memo(function FileResultItem({
   const menuRef = useRef<HTMLDivElement>(null);
   const sender = resolveSender(item, getSender);
   const fileName = item.file?.name || t("base.conversation.file.unknown");
-  const fileIconInfo = FileHelper.getFileIconInfo(fileName);
-  const fileIconSrc = item.file?.iconUrl || assetUrl(fileIconInfo?.icon);
-  const hasFigmaIcon = !!item.file?.iconUrl;
+  const fileIconSrc = getFileIconUrl(
+    getFileIconName(fileName, item.file?.extension),
+    ""
+  );
 
   const handleDownload = async () => {
     const url = item.file?.downloadUrl || item.file?.url;
@@ -1084,18 +1088,8 @@ const FileResultItem = React.memo(function FileResultItem({
         }
       }}
     >
-      <div
-        className={[
-          "wk-channel-search-file-icon",
-          hasFigmaIcon ? "wk-channel-search-file-icon--figma" : "",
-        ]
-          .filter(Boolean)
-          .join(" ")}
-        style={{
-          backgroundColor: hasFigmaIcon ? undefined : fileIconInfo?.color,
-        }}
-      >
-        {fileIconSrc && <img src={fileIconSrc} alt="" />}
+      <div className="wk-channel-search-file-icon">
+        <img src={fileIconSrc} alt="" />
       </div>
       <div className="wk-channel-search-file-body">
         <div className="wk-channel-search-file-name">
@@ -1204,7 +1198,9 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const [queryStarted, setQueryStarted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
+  const loadingMoreCursorRef = useRef<string | null>(null);
   const [isComposing, setIsComposing] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
   const filterCount = activeFilterCount(filters);
@@ -1248,6 +1244,10 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
       if (isComposing) {
         return;
       }
+      if (cursor && loadingMoreCursorRef.current === cursor) {
+        return;
+      }
+      loadingMoreCursorRef.current = cursor || null;
 
       // Empty-state guard: the keyword-optional `_search`/`_search_all` endpoints
       // reject an empty keyword + empty filter with 400 (validateSearchNotEmpty).
@@ -1291,15 +1291,44 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         if (requestIdRef.current === requestId) {
           setLoading(false);
           setLoadingMore(false);
+          if (loadingMoreCursorRef.current === cursor) {
+            loadingMoreCursorRef.current = null;
+          }
         }
       }
     },
     [activeTab, channel, dataSource, filters, isComposing, keyword, t]
   );
 
+  const loadNextPage = useCallback(() => {
+    if (loading || loadingMore || !response.hasMore || !response.nextCursor) {
+      return;
+    }
+    void runSearch(response.nextCursor);
+  }, [
+    loading,
+    loadingMore,
+    response.hasMore,
+    response.nextCursor,
+    runSearch,
+  ]);
+
+  const handleContentScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const distanceToBottom =
+        target.scrollHeight - target.scrollTop - target.clientHeight;
+      if (distanceToBottom <= LOAD_MORE_SCROLL_THRESHOLD) {
+        loadNextPage();
+      }
+    },
+    [loadNextPage]
+  );
+
   useEffect(() => {
     if (isComposing) return;
     requestIdRef.current += 1;
+    loadingMoreCursorRef.current = null;
     setResponse({ items: [], hasMore: false });
     setLoadingMore(false);
     setError(null);
@@ -1320,6 +1349,16 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     }, SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
   }, [canSearch, isComposing, runSearch]);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+    const distanceToBottom =
+      content.scrollHeight - content.scrollTop - content.clientHeight;
+    if (distanceToBottom <= LOAD_MORE_SCROLL_THRESHOLD) {
+      loadNextPage();
+    }
+  }, [activeTab, loadNextPage, response.items.length]);
 
   const handleLocate = useCallback(
     (item: ChannelSearchItem) => {
@@ -1472,23 +1511,20 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         </div>
       </div>
 
-      <div className="wk-channel-search-content">
+      <div
+        className="wk-channel-search-content"
+        ref={contentRef}
+        onScroll={handleContentScroll}
+      >
         {activeTab === "media" && (
           <div className="wk-channel-search-media-tip">
             {t("base.channelSearch.mediaKeywordTip")}
           </div>
         )}
         {renderResults()}
-        {response.hasMore && !loading && (
-          <div className="wk-channel-search-load-more">
-            <WKButton
-              size="sm"
-              variant="secondary"
-              loading={loadingMore}
-              onClick={() => void runSearch(response.nextCursor)}
-            >
-              {t("base.channelSearch.loadMore")}
-            </WKButton>
+        {loadingMore && (
+          <div className="wk-channel-search-load-more" role="status">
+            {t("base.channelSearch.loading")}
           </div>
         )}
       </div>

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -34,6 +34,7 @@ import {
 } from "./locate";
 import {
   isNearChannelSearchScrollBottom,
+  shouldPauseAutoPaginationForEmptyPage,
   shouldStopPaginationForCursor,
 } from "./pagination";
 import { defaultChannelSearchFilters } from "./types";
@@ -1192,6 +1193,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const [queryStarted, setQueryStarted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [paginationError, setPaginationError] = useState<string | null>(null);
+  const [autoPaginationPaused, setAutoPaginationPaused] = useState(false);
   const requestIdRef = useRef(0);
   const loadingMoreCursorRef = useRef<string | null>(null);
   const [isComposing, setIsComposing] = useState(false);
@@ -1261,6 +1263,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
       } else {
         setError(null);
         setPaginationError(null);
+        setAutoPaginationPaused(false);
         setLoading(true);
       }
 
@@ -1280,6 +1283,13 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
           nextCursor: next.nextCursor,
           requestedCursor: cursor,
         });
+        const pauseAutoPagination = shouldPauseAutoPaginationForEmptyPage({
+          hasMore: next.hasMore,
+          itemCount: next.items.length,
+          nextCursor: next.nextCursor,
+          requestedCursor: cursor,
+        });
+        setAutoPaginationPaused(pauseAutoPagination);
         setResponse((prev) => ({
           items: cursor ? [...prev.items, ...next.items] : next.items,
           nextCursor: stopPagination ? undefined : next.nextCursor,
@@ -1312,12 +1322,13 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
       if (loading || loadingMore || !response.hasMore || !response.nextCursor) {
         return;
       }
-      if (paginationError && !force) {
+      if ((paginationError || autoPaginationPaused) && !force) {
         return;
       }
       void runSearch(response.nextCursor);
     },
     [
+      autoPaginationPaused,
       loading,
       loadingMore,
       paginationError,
@@ -1344,6 +1355,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     setLoadingMore(false);
     setError(null);
     setPaginationError(null);
+    setAutoPaginationPaused(false);
 
     // No keyword and no effective filter → don't hit the backend (it would 400).
     // Reset to the initial empty-state prompt instead of a spinner.
@@ -1545,6 +1557,16 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
             </button>
           </div>
         )}
+        {autoPaginationPaused &&
+          !paginationError &&
+          !loadingMore &&
+          response.hasMore && (
+            <div className="wk-channel-search-load-more">
+              <button type="button" onClick={() => loadNextPage(true)}>
+                {t("base.channelSearch.loadMore")}
+              </button>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
@@ -1,0 +1,30 @@
+export const LOAD_MORE_SCROLL_THRESHOLD = 120;
+
+type ScrollMetrics = Pick<
+  HTMLElement,
+  "clientHeight" | "scrollHeight" | "scrollTop"
+>;
+
+export function isNearChannelSearchScrollBottom(element: ScrollMetrics) {
+  return (
+    element.scrollHeight - element.scrollTop - element.clientHeight <=
+    LOAD_MORE_SCROLL_THRESHOLD
+  );
+}
+
+export function shouldStopPaginationForCursor({
+  hasMore,
+  nextCursor,
+  requestedCursor,
+}: {
+  hasMore: boolean;
+  nextCursor?: string;
+  requestedCursor?: string;
+}) {
+  return Boolean(requestedCursor && hasMore && nextCursor === requestedCursor);
+}
+
+export const channelSearchPaginationTestUtils = {
+  isNearChannelSearchScrollBottom,
+  shouldStopPaginationForCursor,
+};

--- a/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
@@ -21,7 +21,11 @@ export function shouldStopPaginationForCursor({
   nextCursor?: string;
   requestedCursor?: string;
 }) {
-  return Boolean(requestedCursor && hasMore && nextCursor === requestedCursor);
+  return Boolean(
+    requestedCursor &&
+      hasMore &&
+      (!nextCursor || nextCursor === requestedCursor)
+  );
 }
 
 export function shouldPauseAutoPaginationForEmptyPage({

--- a/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/pagination.ts
@@ -24,7 +24,28 @@ export function shouldStopPaginationForCursor({
   return Boolean(requestedCursor && hasMore && nextCursor === requestedCursor);
 }
 
+export function shouldPauseAutoPaginationForEmptyPage({
+  hasMore,
+  itemCount,
+  nextCursor,
+  requestedCursor,
+}: {
+  hasMore: boolean;
+  itemCount: number;
+  nextCursor?: string;
+  requestedCursor?: string;
+}) {
+  return Boolean(
+    requestedCursor &&
+      hasMore &&
+      nextCursor &&
+      nextCursor !== requestedCursor &&
+      itemCount === 0
+  );
+}
+
 export const channelSearchPaginationTestUtils = {
   isNearChannelSearchScrollBottom,
+  shouldPauseAutoPaginationForEmptyPage,
   shouldStopPaginationForCursor,
 };

--- a/packages/dmworkbase/src/Components/ChannelSearch/types.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/types.ts
@@ -37,7 +37,6 @@ export interface ChannelSearchFileInfo {
   name: string;
   size: number;
   extension?: string;
-  iconUrl?: string;
   url?: string;
   downloadUrl?: string;
   previewUrl?: string | null;

--- a/packages/dmworkbase/src/Components/MessageInput/AttachmentNode.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/AttachmentNode.tsx
@@ -3,19 +3,11 @@ import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import React from "react";
 import { X } from "lucide-react";
 import { useI18n } from "../../i18n";
-
-// 文件类型图标
-import defaultIcon from "../../assets/files/default.svg";
-import docIcon from "../../assets/files/doc.svg";
-import excelIcon from "../../assets/files/excel.svg";
-import gifIcon from "../../assets/files/gif.svg";
-import pdfIcon from "../../assets/files/pdf.svg";
-import videoIcon from "../../assets/files/video.svg";
-import zipIcon from "../../assets/files/zip.svg";
-import videoPlayIcon from "../../assets/files/video2.svg";
-import htmlIcon from "../../assets/files/html.svg";
-import mdIcon from "../../assets/files/md.svg";
-import txtIcon from "../../assets/files/txt.svg";
+import {
+  formatFileSize,
+  getFileIcon,
+  videoPlayIcon,
+} from "../../Utils/fileIcon";
 
 // 导出图标供外部使用
 export {
@@ -30,7 +22,9 @@ export {
   htmlIcon,
   mdIcon,
   txtIcon,
-};
+  formatFileSize,
+  getFileIcon,
+} from "../../Utils/fileIcon";
 
 export interface AttachmentAttributes {
   id: string;
@@ -53,52 +47,6 @@ function isVideoType(type: string, name: string): boolean {
   const dotIdx = name.lastIndexOf(".");
   const ext = dotIdx > 0 ? name.substring(dotIdx + 1).toLowerCase() : "";
   return ["mp4", "avi", "mov", "mkv", "webm"].includes(ext);
-}
-
-/** 根据文件名和类型获取文件图标（导出供复用） */
-export function getFileIcon(name: string, type: string): string {
-  const dotIdx = name.lastIndexOf(".");
-  const ext = dotIdx > 0 ? name.substring(dotIdx + 1).toLowerCase() : "";
-
-  if (
-    type.startsWith("video/") ||
-    ["mp4", "avi", "mov", "mkv", "webm"].includes(ext)
-  ) {
-    return videoIcon;
-  }
-  if (ext === "gif") {
-    return gifIcon;
-  }
-  if (ext === "pdf") {
-    return pdfIcon;
-  }
-  if (["doc", "docx"].includes(ext)) {
-    return docIcon;
-  }
-  if (["xls", "xlsx"].includes(ext)) {
-    return excelIcon;
-  }
-  if (["zip", "rar", "7z", "tar", "gz"].includes(ext)) {
-    return zipIcon;
-  }
-  if (["html", "htm"].includes(ext)) {
-    return htmlIcon;
-  }
-  if (ext === "md") {
-    return mdIcon;
-  }
-  if (ext === "txt") {
-    return txtIcon;
-  }
-
-  return defaultIcon;
-}
-
-/** 格式化文件大小（导出供复用） */
-export function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 interface AttachmentNodeViewProps {

--- a/packages/dmworkbase/src/Utils/fileIcon.ts
+++ b/packages/dmworkbase/src/Utils/fileIcon.ts
@@ -1,0 +1,84 @@
+// 文件类型图标
+import defaultIcon from "../assets/files/default.svg";
+import docIcon from "../assets/files/doc.svg";
+import excelIcon from "../assets/files/excel.svg";
+import gifIcon from "../assets/files/gif.svg";
+import pdfIcon from "../assets/files/pdf.svg";
+import videoIcon from "../assets/files/video.svg";
+import zipIcon from "../assets/files/zip.svg";
+import videoPlayIcon from "../assets/files/video2.svg";
+import htmlIcon from "../assets/files/html.svg";
+import mdIcon from "../assets/files/md.svg";
+import txtIcon from "../assets/files/txt.svg";
+
+export {
+  defaultIcon,
+  docIcon,
+  excelIcon,
+  gifIcon,
+  pdfIcon,
+  videoIcon,
+  zipIcon,
+  videoPlayIcon,
+  htmlIcon,
+  mdIcon,
+  txtIcon,
+};
+
+function getFileNameExtension(name: string) {
+  const dotIdx = name.lastIndexOf(".");
+  return dotIdx > 0 ? name.substring(dotIdx + 1).toLowerCase() : "";
+}
+
+function normalizeFileExtension(extension?: string) {
+  return extension?.trim().replace(/^\./, "").toLowerCase() || "";
+}
+
+export function getFileIconByExtension(extension?: string, type = "") {
+  const ext = normalizeFileExtension(extension);
+
+  if (
+    type.startsWith("video/") ||
+    ["mp4", "avi", "mov", "mkv", "webm"].includes(ext)
+  ) {
+    return videoIcon;
+  }
+  if (ext === "gif") {
+    return gifIcon;
+  }
+  if (ext === "pdf") {
+    return pdfIcon;
+  }
+  if (["doc", "docx"].includes(ext)) {
+    return docIcon;
+  }
+  if (["xls", "xlsx"].includes(ext)) {
+    return excelIcon;
+  }
+  if (["zip", "rar", "7z", "tar", "gz"].includes(ext)) {
+    return zipIcon;
+  }
+  if (["html", "htm"].includes(ext)) {
+    return htmlIcon;
+  }
+  if (ext === "md") {
+    return mdIcon;
+  }
+  if (ext === "txt") {
+    return txtIcon;
+  }
+
+  return defaultIcon;
+}
+
+/** 根据文件名和类型获取文件图标（导出供复用） */
+export function getFileIcon(name: string, type: string): string {
+  return getFileIconByExtension(getFileNameExtension(name), type);
+}
+
+/** 格式化文件大小（导出供复用） */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -219,6 +219,7 @@
   --wk-color-success-bg: rgba(65, 205, 89, 0.08);
   --wk-color-warning: var(--wk-amber-light); /* Figma: #FC8800 */
   --wk-color-warning-bg: rgba(252, 136, 0, 0.08);
+  --wk-color-search-highlight: #f8e6ab; /* Figma: 搜索命中高亮 */
   --wk-color-error: var(--wk-red-light); /* Figma: #F54A45 */
   --wk-color-error-bg: rgba(245, 74, 69, 0.08);
   --wk-color-info: var(--wk-blue-light); /* Figma: #0077FA */
@@ -304,6 +305,7 @@ body[theme-mode="dark"] {
   --wk-color-success-bg: var(--wk-teal-alpha-10);
   --wk-color-warning: var(--wk-amber-dark);
   --wk-color-warning-bg: rgba(255, 173, 51, 0.1);
+  --wk-color-search-highlight: rgba(248, 230, 171, 0.32);
   --wk-color-error: var(--wk-red-dark);
   --wk-color-error-bg: rgba(255, 92, 114, 0.1);
   --wk-color-info: var(--wk-blue-dark);


### PR DESCRIPTION
### Summary
- replace the manual channel-search load-more button with scroll-triggered pagination
- align search highlight color to Figma #F8E6AB
- render file results with the shared file-type icon helper and clean Storybook mocks

### Validation
- pnpm --filter @octo/base exec vitest run src/Components/ChannelSearch/__tests__
- pnpm --filter @octo/web build