### PR TITLE
fix(app): remove deprecated friend apply reddot

### DIFF
--- a/apps/web/src/App/friendApplyReddotCleanup.ts
+++ b/apps/web/src/App/friendApplyReddotCleanup.ts
@@ -1,0 +1,37 @@
+export type FriendApplyReddotCleanupDeps = {
+  isLoggedIn: () => boolean;
+  getUid: () => string;
+  clearReddot: () => Promise<void>;
+  emitUnreadCount: (count: number) => void;
+  setUnreadCount: (uid: string, count: string) => void;
+  refreshMenus: () => void;
+  warn: (message: string, error: unknown) => void;
+};
+
+const cleanedUids = new Set<string>();
+
+export async function clearDeprecatedFriendApplyReddotOnce(
+  deps: FriendApplyReddotCleanupDeps
+): Promise<boolean> {
+  const uid = deps.getUid();
+  if (!deps.isLoggedIn() || !uid || cleanedUids.has(uid)) {
+    return false;
+  }
+
+  cleanedUids.add(uid);
+
+  try {
+    await deps.clearReddot();
+    deps.emitUnreadCount(0);
+    deps.setUnreadCount(uid, "0");
+    deps.refreshMenus();
+  } catch (error) {
+    deps.warn('Failed to clear friend apply count:', error);
+  }
+
+  return true;
+}
+
+export function resetDeprecatedFriendApplyReddotCleanupForTest() {
+  cleanedUids.clear();
+}

--- a/apps/web/src/App/friendApplyReddotCleanup.ts
+++ b/apps/web/src/App/friendApplyReddotCleanup.ts
@@ -10,6 +10,19 @@ export type FriendApplyReddotCleanupDeps = {
 
 const cleanedUids = new Set<string>();
 
+/**
+ * Clears the deprecated friendApply reddot once for each logged-in uid.
+ *
+ * The friendApply badge UI is removed, but old server/storage reddot state can
+ * still exist for returning users. The module-level Set keeps this migration
+ * idempotent across React re-renders, StrictMode duplicate effects, and
+ * concurrent calls.
+ *
+ * @returns true when this call attempted cleanup for the uid; false when it was
+ * skipped because the user is logged out, uid is empty, or cleanup was already
+ * attempted for this uid. DELETE failures are warned and swallowed, so true does
+ * not mean the server cleanup succeeded.
+ */
 export async function clearDeprecatedFriendApplyReddotOnce(
   deps: FriendApplyReddotCleanupDeps
 ): Promise<boolean> {

--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -10,6 +10,7 @@ import { ChatIcon } from '../Components/Icons/ChatIcon';
 import { ContactsIcon } from '../Components/Icons/ContactsIcon';
 import { SummaryIcon } from '../Components/Icons/SummaryIcon';
 import { Toast } from '@douyinfe/semi-ui';
+import { clearDeprecatedFriendApplyReddotOnce } from './friendApplyReddotCleanup';
 
 let _summaryBadgeCount = 0;
 let _badgeListenerSetup = false;
@@ -45,11 +46,40 @@ function useRealnameVerifiedLandingHandler() {
 }
 
 function App() {
-  registerMenus()
   useRealnameVerifiedLandingHandler()
+  useDeprecatedFriendApplyReddotCleanup()
+  registerMenus()
   return (
     <AppLayout />
   );
+}
+
+function useDeprecatedFriendApplyReddotCleanup() {
+  const isLogined = WKApp.loginInfo.isLogined()
+  const uid = WKApp.loginInfo.uid
+
+  useEffect(() => {
+    if (!isLogined || !uid) {
+      return
+    }
+    void clearDeprecatedFriendApplyReddotOnce({
+      isLoggedIn: () => WKApp.loginInfo.isLogined(),
+      getUid: () => WKApp.loginInfo.uid,
+      clearReddot: () => WKApp.apiClient.delete(`/user/reddot/friendApply`),
+      emitUnreadCount: (count) => {
+        WKApp.mittBus.emit('friend-applys-unread-count', count)
+      },
+      setUnreadCount: (currentUid, count) => {
+        WKApp.loginInfo.setStorageItem(`${currentUid}-friend-applys-unread-count`, count)
+      },
+      refreshMenus: () => {
+        WKApp.menus.refresh()
+      },
+      warn: (message, error) => {
+        console.warn(message, error)
+      },
+    })
+  }, [isLogined, uid])
 }
 
 async function registerMenus() {
@@ -107,16 +137,6 @@ async function registerMenus() {
 
     return m
   }, 1000)
-
-  if (WKApp.loginInfo.isLogined()) {
-    WKApp.apiClient.delete(`/user/reddot/friendApply`).then(() => {
-      WKApp.mittBus.emit('friend-applys-unread-count', 0)
-      WKApp.loginInfo.setStorageItem(`${WKApp.loginInfo.uid}-friend-applys-unread-count`, "0")
-      WKApp.menus.refresh();
-    }).catch(error => {
-      console.warn('Failed to clear friend apply count:', error);
-    });
-  }
 
   WKApp.menus.register("contacts", (param) => {
     const m = new Menus("contacts", "/contacts", t("app.nav.contacts"), <ContactsIcon />, <ContactsIcon />)

--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -109,18 +109,17 @@ async function registerMenus() {
   }, 1000)
 
   if (WKApp.loginInfo.isLogined()) {
-    WKApp.apiClient.get(`/user/reddot/friendApply`).then(res => {
-      WKApp.mittBus.emit('friend-applys-unread-count', res.count)
-      WKApp.loginInfo.setStorageItem(`${WKApp.loginInfo.uid}-friend-applys-unread-count`, res.count)
+    WKApp.apiClient.delete(`/user/reddot/friendApply`).then(() => {
+      WKApp.mittBus.emit('friend-applys-unread-count', 0)
+      WKApp.loginInfo.setStorageItem(`${WKApp.loginInfo.uid}-friend-applys-unread-count`, "0")
       WKApp.menus.refresh();
     }).catch(error => {
-      console.warn('Failed to fetch friend apply count:', error);
+      console.warn('Failed to clear friend apply count:', error);
     });
   }
 
   WKApp.menus.register("contacts", (param) => {
     const m = new Menus("contacts", "/contacts", t("app.nav.contacts"), <ContactsIcon />, <ContactsIcon />)
-    m.badge = WKApp.shared.getFriendApplysUnreadCount();
     return m
   }, 4000)
 

--- a/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
+++ b/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
@@ -21,6 +21,7 @@ describe('friendApply reddot cleanup', () => {
         let isLoggedIn = true;
         let currentUid = uid;
         let shouldReject = false;
+        let clearReddotImpl: (() => Promise<void>) | undefined;
 
         return {
             deps: {
@@ -31,6 +32,7 @@ describe('friendApply reddot cleanup', () => {
                     if (shouldReject) {
                         throw new Error('API Error');
                     }
+                    await clearReddotImpl?.();
                 },
                 emitUnreadCount: (count: number) => {
                     friendApplyCount = count;
@@ -63,16 +65,14 @@ describe('friendApply reddot cleanup', () => {
             rejectNextCalls: () => {
                 shouldReject = true;
             },
+            setClearReddotImpl: (impl: () => Promise<void>) => {
+                clearReddotImpl = impl;
+            },
         };
     }
 
     beforeEach(() => {
         resetDeprecatedFriendApplyReddotCleanupForTest();
-    });
-
-    it('should have zero count initially', () => {
-        const manager = createCleanupDeps();
-        expect(manager.getCount()).toBe(0);
     });
 
     it('should not clear when user is not logged in', async () => {
@@ -108,6 +108,25 @@ describe('friendApply reddot cleanup', () => {
 
         expect(firstStarted).toBe(true);
         expect(secondStarted).toBe(false);
+        expect(manager.getApiCalled()).toBe(1);
+    });
+
+    it('should only clear once for concurrent same-user calls', async () => {
+        const manager = createCleanupDeps(5);
+        let releaseClear!: () => void;
+        const clearStarted = new Promise<void>((resolve) => {
+            releaseClear = resolve;
+        });
+        manager.setClearReddotImpl(() => clearStarted);
+
+        const firstCall = clearDeprecatedFriendApplyReddotOnce(manager.deps);
+        const secondCall = clearDeprecatedFriendApplyReddotOnce(manager.deps);
+
+        releaseClear();
+        const results = await Promise.all([firstCall, secondCall]);
+
+        expect(results).toContain(true);
+        expect(results).toContain(false);
         expect(manager.getApiCalled()).toBe(1);
     });
 

--- a/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
+++ b/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
@@ -1,13 +1,13 @@
 import { vi } from 'vitest'
 /**
  * Unit tests for friendApply API error handling in App/index.tsx
- * Tests that the API call properly handles errors with .catch() (fix for issue #324)
+ * Tests that the startup cleanup call properly handles errors with .catch()
  */
 
 describe('friendApply API error handling', () => {
-    // Simulates the friendApply fetch logic with error handling
-    function createFriendApplyManager() {
-        let friendApplyCount = 0;
+    // Simulates the friendApply reddot cleanup logic with error handling
+    function createFriendApplyManager(initialCount = 0) {
+        let friendApplyCount = initialCount;
         let errorLogged: unknown = null;
         let menusRefreshed = false;
         let storageUpdated = false;
@@ -26,9 +26,9 @@ describe('friendApply API error handling', () => {
                 storageUpdated = false;
                 eventEmitted = false;
             },
-            // Simulates the fixed friendApply fetch with .catch()
-            async fetchFriendApplyCount(
-                apiCall: () => Promise<{ count: number }>,
+            // Simulates the fixed friendApply cleanup with .catch()
+            async clearFriendApplyCount(
+                apiCall: () => Promise<void>,
                 isLoggedIn: boolean
             ) {
                 if (!isLoggedIn) {
@@ -36,15 +36,15 @@ describe('friendApply API error handling', () => {
                 }
 
                 await apiCall()
-                    .then(res => {
-                        friendApplyCount = res.count;
+                    .then(() => {
+                        friendApplyCount = 0;
                         eventEmitted = true;
                         storageUpdated = true;
                         menusRefreshed = true;
                     })
                     .catch(error => {
                         errorLogged = error;
-                        console.warn('Failed to fetch friend apply count:', error);
+                        console.warn('Failed to clear friend apply count:', error);
                     });
             },
         };
@@ -55,27 +55,27 @@ describe('friendApply API error handling', () => {
         expect(manager.getCount()).toBe(0);
     });
 
-    it('should not fetch when user is not logged in', async () => {
-        const manager = createFriendApplyManager();
+    it('should not clear when user is not logged in', async () => {
+        const manager = createFriendApplyManager(5);
         let apiCalled = false;
 
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             apiCalled = true;
-            return { count: 5 };
+            return;
         }, false);
 
         expect(apiCalled).toBe(false);
-        expect(manager.getCount()).toBe(0);
+        expect(manager.getCount()).toBe(5);
     });
 
-    it('should update count on successful API call', async () => {
-        const manager = createFriendApplyManager();
+    it('should clear count on successful API call', async () => {
+        const manager = createFriendApplyManager(5);
 
-        await manager.fetchFriendApplyCount(async () => {
-            return { count: 5 };
+        await manager.clearFriendApplyCount(async () => {
+            return;
         }, true);
 
-        expect(manager.getCount()).toBe(5);
+        expect(manager.getCount()).toBe(0);
         expect(manager.getError()).toBeNull();
         expect(manager.isEventEmitted()).toBe(true);
         expect(manager.isStorageUpdated()).toBe(true);
@@ -83,15 +83,15 @@ describe('friendApply API error handling', () => {
     });
 
     it('should catch error and not crash when API call fails', async () => {
-        const manager = createFriendApplyManager();
+        const manager = createFriendApplyManager(5);
         const testError = new Error('Network error');
 
         // This should NOT throw - the error should be caught
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             throw testError;
         }, true);
 
-        expect(manager.getCount()).toBe(0);
+        expect(manager.getCount()).toBe(5);
         expect(manager.getError()).toBe(testError);
         expect(manager.isEventEmitted()).toBe(false);
         expect(manager.isStorageUpdated()).toBe(false);
@@ -103,18 +103,18 @@ describe('friendApply API error handling', () => {
         const consoleSpy = vi.spyOn(console, 'warn').mockImplementation();
 
         const testError = new Error('API Error');
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             throw testError;
         }, true);
 
-        expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch friend apply count:', testError);
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to clear friend apply count:', testError);
         consoleSpy.mockRestore();
     });
 
     it('should handle server error gracefully', async () => {
         const manager = createFriendApplyManager();
 
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             throw new Error('500 Internal Server Error');
         }, true);
 
@@ -125,7 +125,7 @@ describe('friendApply API error handling', () => {
     it('should handle timeout error gracefully', async () => {
         const manager = createFriendApplyManager();
 
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             throw new Error('Request timeout');
         }, true);
 
@@ -137,7 +137,7 @@ describe('friendApply API error handling', () => {
         const manager = createFriendApplyManager();
 
         // First call fails
-        await manager.fetchFriendApplyCount(async () => {
+        await manager.clearFriendApplyCount(async () => {
             throw new Error('First failure');
         }, true);
 
@@ -146,11 +146,11 @@ describe('friendApply API error handling', () => {
         manager.reset();
 
         // Second call succeeds
-        await manager.fetchFriendApplyCount(async () => {
-            return { count: 3 };
+        await manager.clearFriendApplyCount(async () => {
+            return;
         }, true);
 
-        expect(manager.getCount()).toBe(3);
+        expect(manager.getCount()).toBe(0);
         expect(manager.getError()).toBeNull();
     });
 });

--- a/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
+++ b/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
@@ -1,80 +1,98 @@
-import { vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    clearDeprecatedFriendApplyReddotOnce,
+    resetDeprecatedFriendApplyReddotCleanupForTest,
+} from '../App/friendApplyReddotCleanup'
+
 /**
- * Unit tests for friendApply API error handling in App/index.tsx
- * Tests that the startup cleanup call properly handles errors with .catch()
+ * Unit tests for friendApply reddot cleanup in App/index.tsx.
+ * The cleanup is guarded so React re-renders / StrictMode duplicate effects
+ * cannot repeatedly issue DELETE /user/reddot/friendApply for the same user.
  */
 
-describe('friendApply API error handling', () => {
-    // Simulates the friendApply reddot cleanup logic with error handling
-    function createFriendApplyManager(initialCount = 0) {
+describe('friendApply reddot cleanup', () => {
+    function createCleanupDeps(initialCount = 0, uid = 'user-1') {
         let friendApplyCount = initialCount;
         let errorLogged: unknown = null;
+        let apiCalled = 0;
         let menusRefreshed = false;
         let storageUpdated = false;
         let eventEmitted = false;
+        let isLoggedIn = true;
+        let currentUid = uid;
+        let shouldReject = false;
 
         return {
+            deps: {
+                isLoggedIn: () => isLoggedIn,
+                getUid: () => currentUid,
+                clearReddot: async () => {
+                    apiCalled++;
+                    if (shouldReject) {
+                        throw new Error('API Error');
+                    }
+                },
+                emitUnreadCount: (count: number) => {
+                    friendApplyCount = count;
+                    eventEmitted = true;
+                },
+                setUnreadCount: (_uid: string, count: string) => {
+                    friendApplyCount = Number(count);
+                    storageUpdated = true;
+                },
+                refreshMenus: () => {
+                    menusRefreshed = true;
+                },
+                warn: (_message: string, error: unknown) => {
+                    errorLogged = error;
+                    console.warn('Failed to clear friend apply count:', error);
+                },
+            },
             getCount: () => friendApplyCount,
             getError: () => errorLogged,
+            getApiCalled: () => apiCalled,
             isMenusRefreshed: () => menusRefreshed,
             isStorageUpdated: () => storageUpdated,
             isEventEmitted: () => eventEmitted,
-            reset: () => {
-                friendApplyCount = 0;
-                errorLogged = null;
-                menusRefreshed = false;
-                storageUpdated = false;
-                eventEmitted = false;
+            setLoggedIn: (value: boolean) => {
+                isLoggedIn = value;
             },
-            // Simulates the fixed friendApply cleanup with .catch()
-            async clearFriendApplyCount(
-                apiCall: () => Promise<void>,
-                isLoggedIn: boolean
-            ) {
-                if (!isLoggedIn) {
-                    return;
-                }
-
-                await apiCall()
-                    .then(() => {
-                        friendApplyCount = 0;
-                        eventEmitted = true;
-                        storageUpdated = true;
-                        menusRefreshed = true;
-                    })
-                    .catch(error => {
-                        errorLogged = error;
-                        console.warn('Failed to clear friend apply count:', error);
-                    });
+            setUid: (value: string) => {
+                currentUid = value;
+            },
+            rejectNextCalls: () => {
+                shouldReject = true;
             },
         };
     }
 
+    beforeEach(() => {
+        resetDeprecatedFriendApplyReddotCleanupForTest();
+    });
+
     it('should have zero count initially', () => {
-        const manager = createFriendApplyManager();
+        const manager = createCleanupDeps();
         expect(manager.getCount()).toBe(0);
     });
 
     it('should not clear when user is not logged in', async () => {
-        const manager = createFriendApplyManager(5);
-        let apiCalled = false;
+        const manager = createCleanupDeps(5);
+        manager.setLoggedIn(false);
 
-        await manager.clearFriendApplyCount(async () => {
-            apiCalled = true;
-            return;
-        }, false);
+        const started = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
 
-        expect(apiCalled).toBe(false);
+        expect(started).toBe(false);
+        expect(manager.getApiCalled()).toBe(0);
         expect(manager.getCount()).toBe(5);
     });
 
     it('should clear count on successful API call', async () => {
-        const manager = createFriendApplyManager(5);
+        const manager = createCleanupDeps(5);
 
-        await manager.clearFriendApplyCount(async () => {
-            return;
-        }, true);
+        const started = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
 
+        expect(started).toBe(true);
+        expect(manager.getApiCalled()).toBe(1);
         expect(manager.getCount()).toBe(0);
         expect(manager.getError()).toBeNull();
         expect(manager.isEventEmitted()).toBe(true);
@@ -82,75 +100,63 @@ describe('friendApply API error handling', () => {
         expect(manager.isMenusRefreshed()).toBe(true);
     });
 
+    it('should only clear once for the same logged-in user', async () => {
+        const manager = createCleanupDeps(5);
+
+        const firstStarted = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+        const secondStarted = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+
+        expect(firstStarted).toBe(true);
+        expect(secondStarted).toBe(false);
+        expect(manager.getApiCalled()).toBe(1);
+    });
+
+    it('should clear once for each logged-in user', async () => {
+        const manager = createCleanupDeps(5, 'user-1');
+
+        await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+        manager.setUid('user-2');
+        const secondUserStarted = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+
+        expect(secondUserStarted).toBe(true);
+        expect(manager.getApiCalled()).toBe(2);
+    });
+
     it('should catch error and not crash when API call fails', async () => {
-        const manager = createFriendApplyManager(5);
-        const testError = new Error('Network error');
+        const manager = createCleanupDeps(5);
+        manager.rejectNextCalls();
 
-        // This should NOT throw - the error should be caught
-        await manager.clearFriendApplyCount(async () => {
-            throw testError;
-        }, true);
+        const started = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
 
+        expect(started).toBe(true);
+        expect(manager.getApiCalled()).toBe(1);
         expect(manager.getCount()).toBe(5);
-        expect(manager.getError()).toBe(testError);
+        expect(manager.getError()).toBeInstanceOf(Error);
         expect(manager.isEventEmitted()).toBe(false);
         expect(manager.isStorageUpdated()).toBe(false);
         expect(manager.isMenusRefreshed()).toBe(false);
     });
 
     it('should log warning when API call fails', async () => {
-        const manager = createFriendApplyManager();
+        const manager = createCleanupDeps();
+        manager.rejectNextCalls();
         const consoleSpy = vi.spyOn(console, 'warn').mockImplementation();
 
-        const testError = new Error('API Error');
-        await manager.clearFriendApplyCount(async () => {
-            throw testError;
-        }, true);
+        await clearDeprecatedFriendApplyReddotOnce(manager.deps);
 
-        expect(consoleSpy).toHaveBeenCalledWith('Failed to clear friend apply count:', testError);
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to clear friend apply count:', expect.any(Error));
         consoleSpy.mockRestore();
     });
 
-    it('should handle server error gracefully', async () => {
-        const manager = createFriendApplyManager();
+    it('should not retry the same user after failure', async () => {
+        const manager = createCleanupDeps(5);
+        manager.rejectNextCalls();
 
-        await manager.clearFriendApplyCount(async () => {
-            throw new Error('500 Internal Server Error');
-        }, true);
+        const firstStarted = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+        const secondStarted = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
 
-        expect(manager.getCount()).toBe(0);
-        expect(manager.getError()).toBeInstanceOf(Error);
-    });
-
-    it('should handle timeout error gracefully', async () => {
-        const manager = createFriendApplyManager();
-
-        await manager.clearFriendApplyCount(async () => {
-            throw new Error('Request timeout');
-        }, true);
-
-        expect(manager.getCount()).toBe(0);
-        expect(manager.getError()?.toString()).toContain('timeout');
-    });
-
-    it('should allow retry after failure', async () => {
-        const manager = createFriendApplyManager();
-
-        // First call fails
-        await manager.clearFriendApplyCount(async () => {
-            throw new Error('First failure');
-        }, true);
-
-        expect(manager.getError()).toBeTruthy();
-
-        manager.reset();
-
-        // Second call succeeds
-        await manager.clearFriendApplyCount(async () => {
-            return;
-        }, true);
-
-        expect(manager.getCount()).toBe(0);
-        expect(manager.getError()).toBeNull();
+        expect(firstStarted).toBe(true);
+        expect(secondStarted).toBe(false);
+        expect(manager.getApiCalled()).toBe(1);
     });
 });

--- a/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
+++ b/apps/web/src/__tests__/friendApplyErrorHandling.test.ts
@@ -86,6 +86,17 @@ describe('friendApply reddot cleanup', () => {
         expect(manager.getCount()).toBe(5);
     });
 
+    it('should not clear when logged-in user has no uid', async () => {
+        const manager = createCleanupDeps(5);
+        manager.setUid('');
+
+        const started = await clearDeprecatedFriendApplyReddotOnce(manager.deps);
+
+        expect(started).toBe(false);
+        expect(manager.getApiCalled()).toBe(0);
+        expect(manager.getCount()).toBe(5);
+    });
+
     it('should clear count on successful API call', async () => {
         const manager = createCleanupDeps(5);
 

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -436,7 +436,6 @@ export default class BaseModule implements IModule {
         friendApply.unread = true;
         friendApply.createdAt = message.timestamp;
         WKApp.shared.addFriendApply(friendApply);
-        WKApp.shared.setFriendApplysUnreadCount();
         this.tipsAudio();
       } else if (cmdContent.cmd === "friendAccept") {
         // 接受好友申请

--- a/packages/dmworkcontacts/src/module.tsx
+++ b/packages/dmworkcontacts/src/module.tsx
@@ -41,7 +41,6 @@ export default class ContactsModule implements IModule {
     WKApp.endpoints.registerContactsHeader("friends.new", (param: any) => {
       return (
         <IconListItem
-          badge={ WKApp.shared.getFriendApplysUnreadCount() }
           title={t("contacts.header.newFriends")}
           icon={require("./assets/friend_new.png")}
           backgroudColor={"var(--wk-color-secondary)"}


### PR DESCRIPTION
## Summary
- Clear legacy friendApply reddot state on login instead of reading and showing the stale count
- Remove the Contacts nav badge sourced from the deprecated friendApply flow
- Update friendApply error-handling tests for the cleanup path

Fixes #429

## Tests
- pnpm --dir apps/web exec vitest run src/__tests__/friendApplyErrorHandling.test.ts
- git diff --check
- pnpm --dir apps/web build

Note: `pnpm --dir apps/web exec tsc -p tsconfig.json --noEmit --pretty false` still reports existing repo-wide type errors unrelated to this change.