### PR TITLE
fix: polish channel search locate and keyword limit

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
@@ -89,7 +89,9 @@ const {
   secondsToDateOnly,
   sentAtToSeconds,
   toRequestBody,
+  countChannelSearchKeywordRunes,
   shouldRunSearch,
+  truncateChannelSearchKeyword,
 } = channelSearchApiAdapterTestUtils;
 
 function baseQuery(tab: ChannelSearchQuery["tab"]): ChannelSearchQuery {
@@ -141,6 +143,24 @@ describe("channel search API adapter request construction", () => {
     expect(
       toRequestBody({ ...baseQuery("file"), keyword: "   " })
     ).not.toHaveProperty("keyword");
+  });
+
+  it("limits keywords to 64 unicode code points before sending", () => {
+    const keyword = `${"中".repeat(64)}尾`;
+    const emojiKeyword = `${"😀".repeat(64)}tail`;
+
+    expect(countChannelSearchKeywordRunes(emojiKeyword)).toBe(68);
+    expect(
+      countChannelSearchKeywordRunes(truncateChannelSearchKeyword(emojiKeyword))
+    ).toBe(64);
+    expect(toRequestBody({ ...baseQuery("message"), keyword })).toMatchObject({
+      keyword: "中".repeat(64),
+    });
+    expect(
+      toRequestBody({ ...baseQuery("file"), keyword: emojiKeyword })
+    ).toMatchObject({
+      keyword: "😀".repeat(64),
+    });
   });
 
   it("converts filters, pagination, and local day boundaries into request body", () => {

--- a/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
@@ -93,6 +93,17 @@ type CombinedSearchHit = {
 };
 
 const PAGE_SIZE_SENDERS = 50;
+export const CHANNEL_SEARCH_KEYWORD_MAX_RUNES = 64;
+
+export function countChannelSearchKeywordRunes(keyword: string) {
+  return Array.from(keyword).length;
+}
+
+export function truncateChannelSearchKeyword(keyword: string) {
+  return Array.from(keyword)
+    .slice(0, CHANNEL_SEARCH_KEYWORD_MAX_RUNES)
+    .join("");
+}
 
 function searchEndpoint(tab: ChannelSearchTab) {
   if (tab === "all") return "messages/_search_all";
@@ -193,7 +204,7 @@ function toRequestBody(query: ChannelSearchQuery) {
     cursor: query.cursor || "",
   };
 
-  const keyword = query.keyword.trim();
+  const keyword = truncateChannelSearchKeyword(query.keyword.trim());
   if (query.tab === "all" || query.tab === "message") {
     body.keyword = keyword;
   } else if (query.tab === "file" && keyword) {
@@ -467,8 +478,10 @@ export const channelSearchApiAdapterTestUtils = {
   monthBucketFromSentAt,
   normalizeItems,
   cleanFilters,
+  countChannelSearchKeywordRunes,
   hasEffectiveFilters,
   shouldRunSearch,
+  truncateChannelSearchKeyword,
   toRequestBody,
   mapMessageHit,
   mapFileHit,

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -31,6 +31,8 @@
     var(--wk-text-primary) 35%,
     transparent
   );
+  --channel-search-locate-bg: rgba(28, 28, 35, 0.4);
+  --channel-search-locate-bg-hover: rgba(28, 28, 35, 0.6);
   --channel-search-inverse: var(--wk-neutral-0);
 
   display: flex;
@@ -78,6 +80,13 @@
 
 .wk-channel-search-input-wrap input::placeholder {
   color: var(--channel-search-text-placeholder);
+}
+
+.wk-channel-search-keyword-limit {
+  flex-shrink: 0;
+  color: var(--channel-search-warning);
+  font: 400 12px/18px var(--wk-font-sans);
+  white-space: nowrap;
 }
 
 .wk-channel-search-tabs-row {
@@ -438,19 +447,33 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
   opacity: 0;
   border: none;
   border-radius: 9999px;
-  background: var(--channel-search-surface);
-  color: var(--channel-search-text-primary);
+  background: var(--channel-search-locate-bg);
+  color: var(--channel-search-inverse);
   cursor: pointer;
-  transition: opacity var(--wk-dur-fast) var(--wk-ease);
+  transition:
+    background var(--wk-dur-fast) var(--wk-ease),
+    opacity var(--wk-dur-fast) var(--wk-ease);
 }
 
-.wk-channel-search-media-thumb:hover .wk-channel-search-media-locate {
+.wk-channel-search-media-locate:hover,
+.wk-channel-search-media-locate:focus-visible {
+  background: var(--channel-search-locate-bg-hover);
+}
+
+.wk-channel-search-media-thumb:hover .wk-channel-search-media-locate,
+.wk-channel-search-media-locate:focus-visible {
   opacity: 1;
+}
+
+.wk-channel-search-locate-icon {
+  display: block;
+  flex-shrink: 0;
 }
 
 .wk-channel-search-file-result {

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -5,13 +5,12 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { DatePicker, Toast } from "@douyinfe/semi-ui";
+import { DatePicker, Toast, Tooltip } from "@douyinfe/semi-ui";
 import {
   CalendarDays,
   ChevronDown,
   Download,
   Filter,
-  LocateFixed,
   MoreHorizontal,
   Play,
   X,
@@ -25,7 +24,12 @@ import ConversationContext from "../Conversation/context";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
 import { channelSearchEmptyDataSource } from "./adapter";
-import { shouldRunSearch } from "./apiAdapter";
+import {
+  CHANNEL_SEARCH_KEYWORD_MAX_RUNES,
+  countChannelSearchKeywordRunes,
+  shouldRunSearch,
+  truncateChannelSearchKeyword,
+} from "./apiAdapter";
 import { resolveChannelSearchFileIconSrc } from "./fileIcon";
 import {
   canLocateChannelSearchItem,
@@ -722,6 +726,66 @@ type ResultItemProps = {
   onLocate: (item: ChannelSearchItem) => void;
 };
 
+type LocateToChatIconProps = {
+  size?: number;
+};
+
+const LocateToChatIcon = React.memo(function LocateToChatIcon({
+  size = 16,
+}: LocateToChatIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className="wk-channel-search-locate-icon"
+      fill="none"
+      focusable="false"
+      height={size}
+      viewBox="0 0 16 16"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M14.3333 1.66675H3.66658V3.00008H12.9999V13.0001H3.66659V14.3334H14.3333V1.66675Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+      <path
+        d="M6.88572 11.496L5.94291 10.5532L7.82889 8.66726L1.39062 8.66726L1.39062 7.33393L7.82817 7.33393L5.94291 5.44867L6.88572 4.50586L10.3808 8.00095L6.88572 11.496Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+});
+
+type LocateIconButtonProps = {
+  className: string;
+  iconSize?: number;
+  onClick: () => void;
+};
+
+const LocateIconButton = React.memo(function LocateIconButton({
+  className,
+  iconSize,
+  onClick,
+}: LocateIconButtonProps) {
+  const { t } = useI18n();
+  const label = t("base.channelSearch.locateToChatPosition");
+
+  return (
+    <Tooltip content={label} position="top">
+      <button
+        aria-label={label}
+        className={className}
+        type="button"
+        onClick={onClick}
+      >
+        <LocateToChatIcon size={iconSize} />
+      </button>
+    </Tooltip>
+  );
+});
+
 const MessageResultItem = React.memo(function MessageResultItem({
   item,
   keyword,
@@ -917,13 +981,11 @@ const MediaThumb = React.memo(function MediaThumb({
         </div>
       )}
       {canLocateChannelSearchItem(item) && (
-        <button
+        <LocateIconButton
           className="wk-channel-search-media-locate"
-          type="button"
+          iconSize={16}
           onClick={() => onLocate(item)}
-        >
-          <LocateFixed size={16} />
-        </button>
+        />
       )}
     </div>
   );
@@ -1128,7 +1190,7 @@ const FileResultItem = React.memo(function FileResultItem({
                   onLocate(item);
                 }}
               >
-                <LocateFixed size={14} />
+                <LocateToChatIcon size={14} />
                 {t("base.channelSearch.locateToChatPosition")}
               </button>
             )}
@@ -1176,7 +1238,9 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   onStateChange,
 }) => {
   const { t } = useI18n();
-  const [keyword, setKeyword] = useState(initialState?.keyword || "");
+  const [keyword, setKeyword] = useState(() =>
+    truncateChannelSearchKeyword(initialState?.keyword || "")
+  );
   const [activeTab, setActiveTab] = useState<ChannelSearchTab>(
     initialState?.activeTab || "all"
   );
@@ -1198,11 +1262,16 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const requestIdRef = useRef(0);
   const loadingMoreCursorRef = useRef<string | null>(null);
   const scrollFrameRef = useRef<number | null>(null);
+  const keywordLimitToastShownRef = useRef(false);
+  const isComposingRef = useRef(false);
   const [isComposing, setIsComposing] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
   const filterCount = activeFilterCount(filters);
+  const keywordRuneCount = countChannelSearchKeywordRunes(keyword);
+  const keywordAtLimit =
+    !isComposing && keywordRuneCount >= CHANNEL_SEARCH_KEYWORD_MAX_RUNES;
   const canSearch = shouldRunSearch({ keyword, filters, tab: activeTab });
   const getSender = useCallback(
     (uid: string) => dataSource.getSender(uid),
@@ -1215,6 +1284,27 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const closeFilterPopover = useCallback(() => {
     setFilterOpen(false);
   }, []);
+  const updateKeyword = useCallback(
+    (value: string) => {
+      const runeCount = countChannelSearchKeywordRunes(value);
+      const exceedsLimit = runeCount > CHANNEL_SEARCH_KEYWORD_MAX_RUNES;
+
+      if (exceedsLimit && !keywordLimitToastShownRef.current) {
+        Toast.warning(
+          t("base.channelSearch.keywordLimitToast", {
+            values: { count: CHANNEL_SEARCH_KEYWORD_MAX_RUNES },
+          })
+        );
+        keywordLimitToastShownRef.current = true;
+      }
+      if (!exceedsLimit && runeCount < CHANNEL_SEARCH_KEYWORD_MAX_RUNES) {
+        keywordLimitToastShownRef.current = false;
+      }
+
+      setKeyword(truncateChannelSearchKeyword(value));
+    },
+    [t]
+  );
   const shouldKeepSemiPopupOpen = useCallback((target: Node) => {
     return (
       target instanceof Element &&
@@ -1511,17 +1601,35 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
             placeholder={t("base.channelSearch.placeholder")}
             autoFocus
             onCompositionStart={() => {
+              isComposingRef.current = true;
               setIsComposing(true);
             }}
             onCompositionEnd={(event) => {
+              isComposingRef.current = false;
               setIsComposing(false);
-              setKeyword(event.currentTarget.value);
+              updateKeyword(event.currentTarget.value);
             }}
             onChange={(event) => {
-              setKeyword(event.currentTarget.value);
+              const nextKeyword = event.currentTarget.value;
+              if (isComposingRef.current) {
+                setKeyword(nextKeyword);
+                return;
+              }
+              updateKeyword(nextKeyword);
             }}
           />
         </div>
+        {keywordAtLimit && (
+          <div
+            className="wk-channel-search-keyword-limit"
+            role="status"
+            aria-live="polite"
+          >
+            {t("base.channelSearch.keywordLimitHint", {
+              values: { count: CHANNEL_SEARCH_KEYWORD_MAX_RUNES },
+            })}
+          </div>
+        )}
         <IconClick
           size="sm"
           icon={<X size={18} />}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -73,6 +73,8 @@
   "channelSearch.filter.today": "Today",
   "channelSearch.forward.childCount": "{{count}} chat messages",
   "channelSearch.forward.defaultTitle": "Chat history",
+  "channelSearch.keywordLimitHint": "Up to {{count}} characters",
+  "channelSearch.keywordLimitToast": "Search keywords can be up to {{count}} characters.",
   "channelSearch.loadMore": "Load more",
   "channelSearch.loading": "Searching...",
   "channelSearch.locateToChat": "Locate in chat",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -73,6 +73,8 @@
   "channelSearch.filter.today": "今天",
   "channelSearch.forward.childCount": "共 {{count}} 条聊天记录",
   "channelSearch.forward.defaultTitle": "聊天记录",
+  "channelSearch.keywordLimitHint": "最多 {{count}} 字符",
+  "channelSearch.keywordLimitToast": "搜索关键词最多输入 {{count}} 个字符",
   "channelSearch.loadMore": "加载更多",
   "channelSearch.loading": "搜索中...",
   "channelSearch.locateToChat": "点击定位到聊天",


### PR DESCRIPTION
## Summary
- Align channel search locate icons and tooltip with the Figma design
- Add a 64 unicode-rune keyword limit with visible warning and hint
- Keep keyword truncation IME-safe and guard request payloads with adapter tests

## Tests
- pnpm --filter @octo/base exec vitest run src/Components/ChannelSearch/__tests__
- pnpm lint:css:ci
- pnpm --filter @octo/web build