### PR TITLE
fix: count channel search sender filters separately

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
@@ -297,7 +297,7 @@ export const FilterApplied: Story = {
     if (
       canvasElement
         .querySelector(".wk-channel-search-filter-trigger")
-        ?.textContent?.trim() !== "筛选3"
+        ?.textContent?.trim() !== "筛选8"
     ) {
       throw new Error(
         "Expected filter trigger to show selected condition count"

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/filterState.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/filterState.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { activeChannelSearchFilterCount } from "../filterState";
+
+describe("channel search filter state", () => {
+  it("counts each selected sender as an individual active filter", () => {
+    expect(
+      activeChannelSearchFilterCount({
+        senderUids: ["u1", "u2", "u3"],
+        sort: "time_desc",
+      })
+    ).toBe(3);
+  });
+
+  it("counts sender, sort, and date filters together", () => {
+    expect(
+      activeChannelSearchFilterCount({
+        senderUids: ["u1", "u2"],
+        sort: "time_asc",
+        startAt: 1767225600,
+        endAt: 1767830399,
+      })
+    ).toBe(4);
+  });
+});

--- a/packages/dmworkbase/src/Components/ChannelSearch/filterState.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/filterState.ts
@@ -1,0 +1,9 @@
+import type { ChannelSearchFilters } from "./types";
+
+export function activeChannelSearchFilterCount(filters: ChannelSearchFilters) {
+  return (
+    filters.senderUids.length +
+    (filters.sort !== "time_desc" ? 1 : 0) +
+    (filters.datePreset || filters.startAt || filters.endAt ? 1 : 0)
+  );
+}

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -36,6 +36,7 @@ import {
   formatForwardInnerMessage,
   getForwardInnerMessageHiddenCount,
 } from "./forwardInnerMessage";
+import { activeChannelSearchFilterCount } from "./filterState";
 import {
   canLocateChannelSearchItem,
   resolveChannelSearchLocateTarget,
@@ -91,14 +92,6 @@ function resolveSender(
   getSender: GetChannelSearchSender
 ): ChannelSearchSender {
   return item.sender || getSender(item.senderUid);
-}
-
-function activeFilterCount(filters: ChannelSearchFilters) {
-  return (
-    (filters.senderUids.length > 0 ? 1 : 0) +
-    (filters.sort !== "time_desc" ? 1 : 0) +
-    (filters.datePreset || filters.startAt || filters.endAt ? 1 : 0)
-  );
 }
 
 function startOfDay(date: Date) {
@@ -1309,7 +1302,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
-  const filterCount = activeFilterCount(filters);
+  const filterCount = activeChannelSearchFilterCount(filters);
   const keywordRuneCount = countChannelSearchKeywordRunes(keyword);
   const keywordAtLimit =
     !isComposing && keywordRuneCount >= CHANNEL_SEARCH_KEYWORD_MAX_RUNES;


### PR DESCRIPTION
## Summary
- count each selected sender as a separate ChannelSearch filter condition
- move filter-count calculation into a tested helper
- update the ChannelSearch Storybook filter-count expectation

## Test
- pnpm --filter @octo/base exec vitest run src/Components/ChannelSearch/__tests__