### PR TITLE
fix: render channel search snippet emojis

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
@@ -66,7 +66,7 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     senderUid: "liubo",
     timestamp: toSeconds("2026-06-03T15:06:00+08:00"),
     kind: "text",
-    text: "哈哈哈哈哈哈有趣有趣",
+    text: "哈哈哈哈[有品位]有趣有趣",
   },
   {
     id: "msg-2",

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/snippetContent.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/snippetContent.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../App", () => ({
+  default: {
+    emojiService: {
+      emojiRegExp: () => /\[有品位\]|\[OK\]/,
+      getImage: (key: string) => {
+        if (key === "[有品位]") return "./emoji/custom_taste.png";
+        if (key === "[OK]") return "./emoji/ok.png";
+        return "";
+      },
+    },
+  },
+}));
+
+import ChannelSearchSnippetContent, {
+  buildChannelSearchSnippetTokens,
+  parseChannelSearchSnippetHighlights,
+} from "../snippetContent";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+function renderSnippet(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(element, container);
+  });
+  return container;
+}
+
+describe("ChannelSearchSnippetContent", () => {
+  it("converts backend mark tags into highlight ranges without rendering html", () => {
+    const parsed = parseChannelSearchSnippetHighlights(
+      "你好<mark>搜索</mark><b>结果</b>",
+      "nope"
+    );
+
+    expect(parsed).toEqual({
+      text: "你好搜索<b>结果</b>",
+      ranges: [{ start: 2, end: 4 }],
+    });
+  });
+
+  it("renders a whole custom emoji when mark splits the emoji key", () => {
+    const parsed = parseChannelSearchSnippetHighlights(
+      "这个[有<mark>品</mark>位]不错",
+      "品"
+    );
+    const tokens = buildChannelSearchSnippetTokens(
+      parsed.text,
+      parsed.ranges,
+      (key) => (key === "[有品位]" ? "./emoji/custom_taste.png" : ""),
+      /\[有品位\]/
+    );
+
+    expect(tokens).toEqual([
+      { type: "text", text: "这个", highlighted: false },
+      {
+        type: "emoji",
+        key: "[有品位]",
+        url: "./emoji/custom_taste.png",
+        highlighted: true,
+      },
+      { type: "text", text: "不错", highlighted: false },
+    ]);
+  });
+
+  it("highlights a custom emoji when keyword matches inside the emoji key", () => {
+    const parsed = parseChannelSearchSnippetHighlights("这个[有品位]不错", "品");
+    const tokens = buildChannelSearchSnippetTokens(
+      parsed.text,
+      parsed.ranges,
+      (key) => (key === "[有品位]" ? "./emoji/custom_taste.png" : ""),
+      /\[有品位\]/
+    );
+
+    expect(tokens[1]).toMatchObject({
+      type: "emoji",
+      key: "[有品位]",
+      highlighted: true,
+    });
+  });
+
+  it("accepts global emoji regexes from custom emoji services", () => {
+    const parsed = parseChannelSearchSnippetHighlights("[OK][OK]", "");
+    const tokens = buildChannelSearchSnippetTokens(
+      parsed.text,
+      parsed.ranges,
+      (key) => (key === "[OK]" ? "./emoji/ok.png" : ""),
+      /\[OK\]/g
+    );
+
+    expect(tokens).toEqual([
+      {
+        type: "emoji",
+        key: "[OK]",
+        url: "./emoji/ok.png",
+        highlighted: false,
+      },
+      {
+        type: "emoji",
+        key: "[OK]",
+        url: "./emoji/ok.png",
+        highlighted: false,
+      },
+    ]);
+  });
+
+  it("renders only emoji images and keeps unrelated html as text", () => {
+    const root = renderSnippet(
+      <ChannelSearchSnippetContent
+        text={'hello <img src="x"> [OK]'}
+        keyword="hello"
+      />
+    );
+
+    expect(root.textContent).toContain('<img src="x">');
+    expect(root.querySelectorAll("img")).toHaveLength(1);
+    expect(root.querySelector("img")?.getAttribute("alt")).toBe("[OK]");
+    expect(root.querySelector("mark")?.textContent).toBe("hello");
+  });
+});

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -264,6 +264,30 @@
   color: inherit;
 }
 
+.wk-channel-search-highlight--emoji {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: -4px;
+  line-height: 1;
+}
+
+.wk-channel-search-snippet-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  vertical-align: -4px;
+  line-height: 1;
+}
+
+.wk-channel-search-snippet-emoji img {
+  display: block;
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
 .wk-channel-search-match-reason {
   color: var(--channel-search-text-secondary);
   font: 400 14px/20px var(--wk-font-sans);

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -46,6 +46,7 @@ import {
   shouldPauseAutoPaginationForEmptyPage,
   shouldStopPaginationForCursor,
 } from "./pagination";
+import ChannelSearchSnippetContent from "./snippetContent";
 import { defaultChannelSearchFilters } from "./types";
 import type {
   ChannelSearchDataSource,
@@ -189,71 +190,6 @@ function useOutsideDismiss(
     };
   }, [getContainers, onDismiss, open, shouldIgnoreTarget]);
 }
-
-const HighlightText = React.memo(function HighlightText({
-  text = "",
-  keyword,
-}: {
-  text?: string;
-  keyword: string;
-}) {
-  const content = useMemo(() => {
-    if (/<\/?mark>/i.test(text)) {
-      const parts: React.ReactNode[] = [];
-      const pattern = /<mark>(.*?)<\/mark>/gi;
-      let cursor = 0;
-      let match: RegExpExecArray | null;
-      while ((match = pattern.exec(text))) {
-        if (match.index > cursor) {
-          parts.push(text.slice(cursor, match.index));
-        }
-        parts.push(
-          <mark
-            key={`${match.index}-${pattern.lastIndex}`}
-            className="wk-channel-search-highlight"
-          >
-            {match[1]}
-          </mark>
-        );
-        cursor = pattern.lastIndex;
-      }
-      if (cursor < text.length) {
-        parts.push(text.slice(cursor));
-      }
-      return parts;
-    }
-
-    const needle = keyword.trim();
-    if (!needle) return text;
-
-    const lowerText = text.toLowerCase();
-    const lowerNeedle = needle.toLowerCase();
-    const parts: React.ReactNode[] = [];
-    let cursor = 0;
-    let index = lowerText.indexOf(lowerNeedle);
-
-    while (index !== -1) {
-      if (index > cursor) {
-        parts.push(text.slice(cursor, index));
-      }
-      const end = index + needle.length;
-      parts.push(
-        <mark key={`${index}-${end}`} className="wk-channel-search-highlight">
-          {text.slice(index, end)}
-        </mark>
-      );
-      cursor = end;
-      index = lowerText.indexOf(lowerNeedle, cursor);
-    }
-
-    if (cursor < text.length) {
-      parts.push(text.slice(cursor));
-    }
-    return parts;
-  }, [keyword, text]);
-
-  return <>{content}</>;
-});
 
 const SenderAvatar: React.FC<{
   uid: string;
@@ -832,11 +768,14 @@ const MessageResultItem = React.memo(function MessageResultItem({
         {isForward ? (
           <>
             <div className="wk-channel-search-match-reason">
-              <HighlightText text={forwardMatchReason} keyword={keyword} />
+              <ChannelSearchSnippetContent
+                text={forwardMatchReason}
+                keyword={keyword}
+              />
             </div>
             <div className="wk-channel-search-forward-card">
               <div className="wk-channel-search-forward-title">
-                <HighlightText
+                <ChannelSearchSnippetContent
                   text={
                     item.forward?.title ||
                     t("base.channelSearch.forward.defaultTitle")
@@ -849,7 +788,7 @@ const MessageResultItem = React.memo(function MessageResultItem({
                   key={`${message.messageId || "inner"}-${index}`}
                   className="wk-channel-search-forward-snippet"
                 >
-                  <HighlightText
+                  <ChannelSearchSnippetContent
                     text={formatForwardInnerMessage(message, getSender, t)}
                     keyword={keyword}
                   />
@@ -868,7 +807,10 @@ const MessageResultItem = React.memo(function MessageResultItem({
                     key={snippet}
                     className="wk-channel-search-forward-snippet"
                   >
-                    <HighlightText text={snippet} keyword={keyword} />
+                    <ChannelSearchSnippetContent
+                      text={snippet}
+                      keyword={keyword}
+                    />
                   </div>
                 ))}
               {visibleForwardInnerMessages.length === 0 &&
@@ -884,7 +826,7 @@ const MessageResultItem = React.memo(function MessageResultItem({
           </>
         ) : (
           <div className="wk-channel-search-result-text">
-            <HighlightText text={item.text} keyword={keyword} />
+            <ChannelSearchSnippetContent text={item.text} keyword={keyword} />
           </div>
         )}
       </div>
@@ -965,7 +907,10 @@ const MediaInlineResult = React.memo(function MediaInlineResult({
           </span>
         </div>
         <div className="wk-channel-search-match-reason">
-          <HighlightText text={item.matchReason} keyword={keyword} />
+          <ChannelSearchSnippetContent
+            text={item.matchReason}
+            keyword={keyword}
+          />
         </div>
         <MediaThumb item={item} onLocate={onLocate} compact />
       </div>
@@ -1065,7 +1010,10 @@ const FileInlineResult = React.memo(function FileInlineResult({
           </div>
           <div className="wk-channel-search-inline-file-body">
             <div className="wk-channel-search-inline-file-name">
-              <HighlightText text={inlineFileName} keyword={keyword} />
+              <ChannelSearchSnippetContent
+                text={inlineFileName}
+                keyword={keyword}
+              />
             </div>
             <div className="wk-channel-search-inline-file-size">
               {compactFileSize(item.file?.size || 0)}
@@ -1185,7 +1133,7 @@ const FileResultItem = React.memo(function FileResultItem({
       </div>
       <div className="wk-channel-search-file-body">
         <div className="wk-channel-search-file-name">
-          <HighlightText text={fileName} keyword={keyword} />
+          <ChannelSearchSnippetContent text={fileName} keyword={keyword} />
         </div>
         <div className="wk-channel-search-file-meta">
           <span>{sender.name}</span>

--- a/packages/dmworkbase/src/Components/ChannelSearch/snippetContent.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/snippetContent.tsx
@@ -1,0 +1,282 @@
+import React, { useMemo } from "react";
+import WKApp from "../../App";
+
+type HighlightRange = {
+  start: number;
+  end: number;
+};
+
+export type ChannelSearchSnippetToken =
+  | {
+      type: "text";
+      text: string;
+      highlighted: boolean;
+    }
+  | {
+      type: "emoji";
+      key: string;
+      url: string;
+      highlighted: boolean;
+    };
+
+export function parseChannelSearchSnippetHighlights(
+  text = "",
+  keyword = ""
+) {
+  const markPattern = /<mark>([\s\S]*?)<\/mark>/gi;
+  const ranges: HighlightRange[] = [];
+  const parts: string[] = [];
+  let cursor = 0;
+  let plainLength = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = markPattern.exec(text))) {
+    if (match.index > cursor) {
+      const plainText = text.slice(cursor, match.index);
+      parts.push(plainText);
+      plainLength += plainText.length;
+    }
+
+    const markedText = match[1];
+    const start = plainLength;
+    parts.push(markedText);
+    plainLength += markedText.length;
+    ranges.push({ start, end: start + markedText.length });
+    cursor = markPattern.lastIndex;
+  }
+
+  if (ranges.length > 0) {
+    if (cursor < text.length) {
+      parts.push(text.slice(cursor));
+    }
+    return {
+      text: parts.join(""),
+      ranges: mergeHighlightRanges(ranges),
+    };
+  }
+
+  const needle = keyword.trim();
+  if (!needle) {
+    return { text, ranges };
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  let index = lowerText.indexOf(lowerNeedle);
+  while (index !== -1) {
+    ranges.push({ start: index, end: index + needle.length });
+    index = lowerText.indexOf(lowerNeedle, index + needle.length);
+  }
+
+  return {
+    text,
+    ranges: mergeHighlightRanges(ranges),
+  };
+}
+
+function mergeHighlightRanges(ranges: HighlightRange[]) {
+  const sorted = ranges
+    .filter((range) => range.end > range.start)
+    .sort((a, b) => a.start - b.start);
+  const merged: HighlightRange[] = [];
+
+  for (const range of sorted) {
+    const prev = merged[merged.length - 1];
+    if (prev && range.start <= prev.end) {
+      prev.end = Math.max(prev.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+
+  return merged;
+}
+
+function rangeIntersectsHighlight(
+  start: number,
+  end: number,
+  ranges: HighlightRange[]
+) {
+  return ranges.some((range) => start < range.end && end > range.start);
+}
+
+function pushToken(
+  tokens: ChannelSearchSnippetToken[],
+  token: ChannelSearchSnippetToken
+) {
+  const prev = tokens[tokens.length - 1];
+  if (
+    token.type === "text" &&
+    prev?.type === "text" &&
+    prev.highlighted === token.highlighted
+  ) {
+    prev.text += token.text;
+    return;
+  }
+  tokens.push(token);
+}
+
+function pushTextTokens(
+  tokens: ChannelSearchSnippetToken[],
+  text: string,
+  start: number,
+  end: number,
+  ranges: HighlightRange[]
+) {
+  let cursor = start;
+
+  for (const range of ranges) {
+    if (range.end <= cursor) continue;
+    if (range.start >= end) break;
+
+    const highlightStart = Math.max(range.start, cursor);
+    const highlightEnd = Math.min(range.end, end);
+
+    if (highlightStart > cursor) {
+      pushToken(tokens, {
+        type: "text",
+        text: text.slice(cursor, highlightStart),
+        highlighted: false,
+      });
+    }
+
+    if (highlightEnd > highlightStart) {
+      pushToken(tokens, {
+        type: "text",
+        text: text.slice(highlightStart, highlightEnd),
+        highlighted: true,
+      });
+    }
+    cursor = highlightEnd;
+  }
+
+  if (cursor < end) {
+    pushToken(tokens, {
+      type: "text",
+      text: text.slice(cursor, end),
+      highlighted: false,
+    });
+  }
+}
+
+function toSearchableEmojiRegExp(emojiRegExp: RegExp) {
+  const flags = emojiRegExp.flags.replace(/[gy]/g, "");
+  return new RegExp(emojiRegExp.source, flags);
+}
+
+export function buildChannelSearchSnippetTokens(
+  text: string,
+  ranges: HighlightRange[],
+  resolveEmojiUrl: (key: string) => string,
+  emojiRegExp?: RegExp
+) {
+  const tokens: ChannelSearchSnippetToken[] = [];
+  if (!text) return tokens;
+  if (!emojiRegExp) {
+    pushTextTokens(tokens, text, 0, text.length, ranges);
+    return tokens;
+  }
+
+  let cursor = 0;
+  let rest = text;
+  const searchableEmojiRegExp = toSearchableEmojiRegExp(emojiRegExp);
+
+  while (rest.length > 0) {
+    const match = rest.match(searchableEmojiRegExp);
+    const matchIndex = match?.index;
+    const matchedText = match?.[0];
+
+    if (
+      matchIndex === undefined ||
+      !matchedText ||
+      matchedText.length === 0
+    ) {
+      break;
+    }
+
+    const start = cursor + matchIndex;
+    const end = start + matchedText.length;
+    if (start > cursor) {
+      pushTextTokens(tokens, text, cursor, start, ranges);
+    }
+
+    const emojiUrl = resolveEmojiUrl(matchedText);
+    if (emojiUrl) {
+      pushToken(tokens, {
+        type: "emoji",
+        key: matchedText,
+        url: emojiUrl,
+        highlighted: rangeIntersectsHighlight(start, end, ranges),
+      });
+    } else {
+      pushTextTokens(tokens, text, start, end, ranges);
+    }
+
+    cursor = end;
+    rest = text.slice(cursor);
+  }
+
+  if (cursor < text.length) {
+    pushTextTokens(tokens, text, cursor, text.length, ranges);
+  }
+
+  return tokens;
+}
+
+type ChannelSearchSnippetContentProps = {
+  text?: string;
+  keyword: string;
+};
+
+const ChannelSearchSnippetContent = React.memo(
+  function ChannelSearchSnippetContent({
+    text = "",
+    keyword,
+  }: ChannelSearchSnippetContentProps) {
+    const tokens = useMemo(() => {
+      const parsed = parseChannelSearchSnippetHighlights(text, keyword);
+      return buildChannelSearchSnippetTokens(
+        parsed.text,
+        parsed.ranges,
+        (key) => WKApp.emojiService.getImage(key),
+        WKApp.emojiService.emojiRegExp()
+      );
+    }, [keyword, text]);
+
+    return (
+      <>
+        {tokens.map((token, index) => {
+          if (token.type === "emoji") {
+            const emoji = (
+              <span className="wk-channel-search-snippet-emoji">
+                <img alt={token.key} src={token.url} />
+              </span>
+            );
+            if (!token.highlighted) {
+              return React.cloneElement(emoji, { key: index });
+            }
+            return (
+              <mark
+                key={index}
+                className="wk-channel-search-highlight wk-channel-search-highlight--emoji"
+              >
+                {emoji}
+              </mark>
+            );
+          }
+
+          if (!token.highlighted) {
+            return <React.Fragment key={index}>{token.text}</React.Fragment>;
+          }
+          return (
+            <mark key={index} className="wk-channel-search-highlight">
+              {token.text}
+            </mark>
+          );
+        })}
+      </>
+    );
+  }
+);
+
+export default ChannelSearchSnippetContent;


### PR DESCRIPTION
## Summary
- render channel search snippets with a dedicated inline renderer instead of full markdown parsing
- support backend <mark> highlights together with custom emoji images
- keep non-mark HTML-like content as plain text and add focused coverage for snippet rendering

## Test
- pnpm --filter @octo/base exec vitest run src/Components/ChannelSearch/__tests__
- pnpm --filter @octo/web build