### PR TITLE
fix: show raw HTML in messages

### DIFF
--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -148,10 +148,35 @@ const mathRehypePlugins: any[] = [
 ];
 
 /** 基础 remark 插件（不含 math） */
-const baseRemarkPlugins: any[] = [remarkGfm, remarkBreaks];
+const baseRemarkPlugins: any[] = [
+  rawHtmlAsTextPlugin,
+  remarkGfm,
+  remarkBreaks,
+];
 
 /** 含 math 的 remark 插件 */
-const mathRemarkPlugins: any[] = [remarkGfm, remarkBreaks, remarkMath];
+const mathRemarkPlugins: any[] = [
+  rawHtmlAsTextPlugin,
+  remarkGfm,
+  remarkBreaks,
+  remarkMath,
+];
+
+function rawHtmlAsTextPlugin() {
+  return (tree: any) => {
+    const visit = (node: any) => {
+      if (!node || !Array.isArray(node.children)) return;
+      node.children = node.children.map((child: any) => {
+        if (child?.type === "html") {
+          return { type: "text", value: child.value || "" };
+        }
+        visit(child);
+        return child;
+      });
+    };
+    visit(tree);
+  };
+}
 
 /**
  * 纯文本模式（enableMarkdown=false）插件：

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
@@ -81,3 +81,23 @@ describe("MarkdownContent — broadcast mention (@所有人) 高亮渲染 (GH#29
     expect(entities).toContain("@张三");
   });
 });
+
+describe("MarkdownContent — raw HTML displays as text", () => {
+  it("renders pasted HTML source instead of dropping the tag", () => {
+    const root = renderContent(
+      <MarkdownContent content={'<button class="x">Octo 登录</button>'} />
+    );
+
+    expect(root.querySelector("button")).toBeNull();
+    expect(root.textContent).toBe('<button class="x">Octo 登录</button>');
+  });
+
+  it("keeps empty HTML tags visible", () => {
+    const root = renderContent(
+      <MarkdownContent content={'<button class="x"></button>'} />
+    );
+
+    expect(root.querySelector("button")).toBeNull();
+    expect(root.textContent).toBe('<button class="x"></button>');
+  });
+});


### PR DESCRIPTION
## Summary
- render raw HTML markdown nodes as text so pasted HTML source is visible in chat messages
- keep sanitizer in place so user HTML is not executed/rendered
- add regression coverage for button HTML with and without text

Closes #442

## Test
- pnpm --dir packages/dmworkbase exec vitest run src/Messages/Text/__tests__/MarkdownContentMention.test.tsx