### PR TITLE
feat: preview channel search media results

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
@@ -76,6 +76,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-06-03T15:05:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[0],
+      previewUrl: figmaMediaThumbs[0],
       thumbUrl: figmaMediaThumbs[0],
       inlineThumbUrl: figmaInlineImage,
       tone: "cool",
@@ -89,6 +91,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-06-01T15:04:30+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[5],
+      previewUrl: figmaMediaThumbs[5],
       thumbUrl: figmaMediaThumbs[5],
       tone: "warm",
     },
@@ -189,6 +193,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-06-01T10:24:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[2],
+      previewUrl: figmaMediaThumbs[2],
       thumbUrl: figmaMediaThumbs[2],
       tone: "green",
     },
@@ -227,6 +233,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-05-01T11:18:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[7],
+      previewUrl: figmaMediaThumbs[7],
       thumbUrl: figmaMediaThumbs[7],
       tone: "cool",
     },
@@ -252,6 +260,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-05-12T13:10:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[2],
+      previewUrl: figmaMediaThumbs[2],
       thumbUrl: figmaMediaThumbs[2],
       tone: "green",
     },
@@ -264,6 +274,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-05-06T19:12:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[3],
+      previewUrl: figmaMediaThumbs[3],
       thumbUrl: figmaMediaThumbs[3],
       tone: "purple",
     },
@@ -276,6 +288,8 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     timestamp: toSeconds("2026-04-18T12:00:00+08:00"),
     kind: "image",
     media: {
+      url: figmaMediaThumbs[4],
+      previewUrl: figmaMediaThumbs[4],
       thumbUrl: figmaMediaThumbs[4],
       tone: "warm",
     },

--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
@@ -3,9 +3,13 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { Channel, ChannelTypeGroup } from "wukongimjssdk";
 import { I18nProvider } from "../../i18n";
+import FilePreviewPanel, {
+  FilePreviewInfo,
+  getExtension,
+} from "../FilePreviewPanel";
 import ChannelSearchPanel from "./index";
 import { mockChannelSearchDataSource } from "./ChannelSearch.stories.mock";
-import type { ChannelSearchFilters } from "./types";
+import type { ChannelSearchFilters, ChannelSearchItem } from "./types";
 
 const toSeconds = (value: string) =>
   Math.floor(new Date(value).getTime() / 1000);
@@ -135,6 +139,75 @@ const ChatSearchEntryPreview: React.FC<
   );
 };
 
+const extensionFromUrl = (url: string) => {
+  const path = url.split(/[?#]/)[0] || "";
+  const fileName = path.substring(path.lastIndexOf("/") + 1);
+  return getExtension("", fileName);
+};
+
+const MediaPreviewShell: React.FC<
+  React.ComponentProps<typeof ChannelSearchPanel>
+> = (args) => {
+  const [previewFile, setPreviewFile] = React.useState<FilePreviewInfo | null>(
+    null
+  );
+
+  const handlePreviewMedia = React.useCallback((item: ChannelSearchItem) => {
+    const media = item.media;
+    if (!media) return;
+    const url =
+      media.previewUrl ||
+      media.url ||
+      media.downloadUrl ||
+      (item.kind === "image" ? media.thumbUrl : "");
+    if (!url) return;
+    const extension =
+      extensionFromUrl(url) || (item.kind === "video" ? "mp4" : "jpg");
+    setPreviewFile({
+      url,
+      name: media.name || `${item.kind}-${item.messageSeq}.${extension}`,
+      extension,
+      category: item.kind,
+      posterUrl: media.thumbUrl || media.inlineThumbUrl,
+      width: media.width,
+      height: media.height,
+      duration: media.duration,
+      messageId: item.messageId,
+      messageSeq: item.messageSeq,
+      fromUID: item.senderUid,
+    });
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "100vh",
+        background: "var(--wk-bg-base)",
+      }}
+    >
+      <aside
+        style={{
+          width: 480,
+          height: "100vh",
+          borderRight: "1px solid var(--wk-border-subtle)",
+          background: "var(--wk-bg-surface)",
+        }}
+      >
+        <ChannelSearchPanel {...args} onPreviewMedia={handlePreviewMedia} />
+      </aside>
+      <section style={{ flex: 1, minWidth: 0, height: "100vh" }}>
+        {previewFile && (
+          <FilePreviewPanel
+            file={previewFile}
+            onClose={() => setPreviewFile(null)}
+          />
+        )}
+      </section>
+    </div>
+  );
+};
+
 async function waitForElement<T extends Element>(
   root: HTMLElement,
   selector: string
@@ -185,7 +258,9 @@ export const OpenEmpty: Story = {
     // (the backend rejects it with 400). The panel shows the empty-state prompt.
     await waitForElement(canvasElement, ".wk-channel-search-empty");
     if (canvasElement.querySelector(".wk-channel-search-result")) {
-      throw new Error("Expected empty keyword to render the empty state, not results");
+      throw new Error(
+        "Expected empty keyword to render the empty state, not results"
+      );
     }
   },
 };
@@ -427,6 +502,29 @@ export const MediaFilterOnly: Story = {
     ) {
       throw new Error("Expected media thumbnails to avoid name tooltips");
     }
+  },
+};
+
+export const MediaPreview: Story = {
+  name: "Media preview",
+  parameters: {
+    channelSearchShell: true,
+  },
+  args: {
+    initialState: {
+      activeTab: "media",
+      filters: mediaPreviewFilter,
+    },
+  },
+  render: (args) => <MediaPreviewShell {...args} />,
+  play: async ({ canvasElement }) => {
+    await waitForElement(canvasElement, ".wk-channel-search-media-grid");
+    const previewButton = await waitForElement<HTMLButtonElement>(
+      canvasElement,
+      ".wk-channel-search-media-preview-trigger"
+    );
+    await userEvent.click(previewButton);
+    await waitForElement(canvasElement, ".wk-file-preview-panel");
   },
 };
 

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
@@ -5,6 +5,7 @@ const mockState = vi.hoisted(() => ({
   subscribers: vi.fn(),
   getChannelInfo: vi.fn(),
   getImageURL: vi.fn((path: string) => `/api/v1/${path}`),
+  getFileURL: vi.fn((path: string) => `/files/${path}`),
   parseThreadChannelId: vi.fn(),
 }));
 
@@ -57,6 +58,7 @@ vi.mock("../../../App", () => ({
     dataSource: {
       commonDataSource: {
         getImageURL: mockState.getImageURL,
+        getFileURL: mockState.getFileURL,
       },
       channelDataSource: {
         subscribers: mockState.subscribers,
@@ -336,6 +338,44 @@ describe("channel search API adapter response mapping", () => {
       uid: "u1",
       name: "Alice",
       avatarUrl: "/api/v1/users/u1/avatar",
+    });
+  });
+
+  it("maps media preview urls and normalizes thumb paths", () => {
+    const item = mapMediaHit(
+      {
+        message_id: "video-1",
+        message_seq: 33,
+        media_kind: "video",
+        media_url: "videos/video-1.mp4",
+        download_url: "videos/video-1-download.mp4",
+        preview_url: "videos/video-1-preview.mp4",
+        thumb_url: "images/video-1-cover.jpg",
+        duration_ms: 62000,
+        sender_id: "u1",
+        sent_at: "2026-01-02T00:00:00Z",
+      },
+      baseQuery("media")
+    );
+
+    expect(mockState.getFileURL).toHaveBeenCalledWith(
+      "videos/video-1-preview.mp4"
+    );
+    expect(mockState.getFileURL).toHaveBeenCalledWith(
+      "videos/video-1-download.mp4"
+    );
+    expect(mockState.getImageURL).toHaveBeenCalledWith(
+      "images/video-1-cover.jpg"
+    );
+    expect(item).toMatchObject({
+      kind: "video",
+      media: {
+        url: "/files/videos/video-1-preview.mp4",
+        previewUrl: "/files/videos/video-1-preview.mp4",
+        downloadUrl: "/files/videos/video-1-download.mp4",
+        thumbUrl: "/api/v1/images/video-1-cover.jpg",
+        duration: 62,
+      },
     });
   });
 

--- a/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
@@ -66,6 +66,13 @@ type MediaSearchHit = {
   message_id?: string;
   message_seq?: number;
   media_kind?: "image" | "video";
+  url?: string;
+  media_url?: string;
+  file_url?: string;
+  image_url?: string;
+  video_url?: string;
+  download_url?: string;
+  preview_url?: string | null;
   thumb_url?: string;
   duration_ms?: number;
   width?: number;
@@ -147,6 +154,27 @@ function normalizeImageUrl(path?: string) {
   }
   const baseURL = WKApp.apiClient.config.apiURL || "";
   return `${baseURL}${normalizedPath}`;
+}
+
+function normalizeFileUrl(path?: string | null) {
+  if (!path) return undefined;
+  if (/^(https?:|data:|blob:)/i.test(path)) return path;
+  const normalizedPath = path.replace(/^\/+/, "");
+  const commonDataSource = WKApp.dataSource?.commonDataSource;
+  if (commonDataSource?.getFileURL) {
+    return commonDataSource.getFileURL(normalizedPath);
+  }
+  const baseURL = WKApp.apiClient.config.apiURL || "";
+  return `${baseURL}${normalizedPath}`;
+}
+
+function normalizeMediaUrl(
+  path: string | null | undefined,
+  mediaKind?: "image" | "video"
+) {
+  return mediaKind === "image"
+    ? normalizeImageUrl(path || undefined)
+    : normalizeFileUrl(path);
 }
 
 function secondsToDateOnly(seconds?: number) {
@@ -346,13 +374,33 @@ function mapMediaHit(
 ): ChannelSearchItem {
   const sender = senderFromHit(hit);
   const hitChannel = channelFromHit(hit, query);
+  const mediaKind = hit.media_kind || "image";
+  const previewUrl = normalizeMediaUrl(hit.preview_url, mediaKind);
+  const downloadUrl = normalizeFileUrl(hit.download_url);
+  const mediaUrl =
+    previewUrl ||
+    normalizeMediaUrl(
+      hit.media_url ||
+        hit.url ||
+        hit.file_url ||
+        hit.image_url ||
+        hit.video_url,
+      mediaKind
+    ) ||
+    downloadUrl;
   const media: ChannelSearchMediaInfo = {
-    thumbUrl: hit.thumb_url,
-    duration: hit.duration_ms,
+    url: mediaUrl,
+    previewUrl,
+    downloadUrl,
+    thumbUrl: normalizeImageUrl(hit.thumb_url),
+    duration:
+      typeof hit.duration_ms === "number"
+        ? Math.round(hit.duration_ms / 1000)
+        : undefined,
     width: hit.width,
     height: hit.height,
     monthBucket: hit.month_bucket || monthBucketFromSentAt(hit.sent_at),
-    tone: hit.media_kind === "video" ? "purple" : "cool",
+    tone: mediaKind === "video" ? "purple" : "cool",
   };
   return {
     id: hit.message_id || `${hit.message_seq || 0}`,
@@ -363,7 +411,7 @@ function mapMediaHit(
     senderUid: sender.uid,
     sender,
     timestamp: sentAtToSeconds(hit.sent_at),
-    kind: hit.media_kind === "video" ? "video" : "image",
+    kind: mediaKind === "video" ? "video" : "image",
     media,
   };
 }

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -374,6 +374,10 @@
     color-mix(in srgb, var(--wk-text-primary) 20%, transparent);
 }
 
+.wk-channel-search-media-thumb--previewable {
+  cursor: pointer;
+}
+
 .wk-channel-search-media-thumb--compact {
   width: 120px;
   height: 68px;
@@ -423,8 +427,34 @@
 
 .wk-channel-search-media-thumb--image {
   background-color: var(--channel-search-elevated);
-  background-position: center;
-  background-size: cover;
+}
+
+.wk-channel-search-media-thumb-img {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  pointer-events: none;
+  user-select: none;
+}
+
+.wk-channel-search-media-preview-trigger {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.wk-channel-search-media-preview-trigger:focus-visible {
+  outline: 2px solid var(--channel-search-accent);
+  outline-offset: -2px;
 }
 
 .wk-channel-search-media-thumb > span {
@@ -456,18 +486,21 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 2;
   width: 32px;
   height: 32px;
   transform: translate(-50%, -50%);
   border-radius: 9999px;
   background: var(--channel-search-overlay);
   color: var(--channel-search-inverse);
+  pointer-events: none;
 }
 
 .wk-channel-search-media-locate {
   position: absolute;
   top: 4px;
   right: 4px;
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -67,6 +67,7 @@ interface ChannelSearchPanelProps {
   dataSource?: ChannelSearchDataSource;
   onLocateMessage?: (item: ChannelSearchItem) => void;
   onPreviewFile?: (item: ChannelSearchItem) => void;
+  onPreviewMedia?: (item: ChannelSearchItem) => void;
   initialState?: ChannelSearchPanelState;
   onStateChange?: (state: ChannelSearchPanelState) => void;
 }
@@ -658,6 +659,7 @@ type ResultItemProps = {
   keyword: string;
   getSender: GetChannelSearchSender;
   onLocate: (item: ChannelSearchItem) => void;
+  onPreviewMedia?: (item: ChannelSearchItem) => void;
 };
 
 type LocateToChatIconProps = {
@@ -848,6 +850,7 @@ const MixedResultItem = React.memo(function MixedResultItem({
   keyword,
   getSender,
   onLocate,
+  onPreviewMedia,
 }: ResultItemProps) {
   if (item.kind === "file") {
     return (
@@ -866,6 +869,7 @@ const MixedResultItem = React.memo(function MixedResultItem({
         keyword={keyword}
         getSender={getSender}
         onLocate={onLocate}
+        onPreviewMedia={onPreviewMedia}
       />
     );
   }
@@ -884,6 +888,7 @@ const MediaInlineResult = React.memo(function MediaInlineResult({
   keyword,
   getSender,
   onLocate,
+  onPreviewMedia,
 }: ResultItemProps) {
   const { format, t } = useI18n();
   const sender = resolveSender(item, getSender);
@@ -912,7 +917,12 @@ const MediaInlineResult = React.memo(function MediaInlineResult({
             keyword={keyword}
           />
         </div>
-        <MediaThumb item={item} onLocate={onLocate} compact />
+        <MediaThumb
+          item={item}
+          onLocate={onLocate}
+          onPreviewMedia={onPreviewMedia}
+          compact
+        />
       </div>
       {canLocateChannelSearchItem(item) && (
         <button
@@ -930,17 +940,21 @@ const MediaInlineResult = React.memo(function MediaInlineResult({
 type MediaThumbProps = {
   item: ChannelSearchItem;
   onLocate: (item: ChannelSearchItem) => void;
+  onPreviewMedia?: (item: ChannelSearchItem) => void;
   compact?: boolean;
 };
 
 const MediaThumb = React.memo(function MediaThumb({
   item,
   onLocate,
+  onPreviewMedia,
   compact = false,
 }: MediaThumbProps) {
+  const { t } = useI18n();
   const thumbUrl = compact
     ? item.media?.inlineThumbUrl || item.media?.thumbUrl
     : item.media?.thumbUrl;
+  const previewLabel = t("base.filePreview.preview");
 
   return (
     <div
@@ -948,12 +962,29 @@ const MediaThumb = React.memo(function MediaThumb({
         "wk-channel-search-media-thumb",
         `wk-channel-search-media-thumb--${item.media?.tone || "warm"}`,
         thumbUrl ? "wk-channel-search-media-thumb--image" : "",
+        onPreviewMedia ? "wk-channel-search-media-thumb--previewable" : "",
         compact ? "wk-channel-search-media-thumb--compact" : "",
       ]
         .filter(Boolean)
         .join(" ")}
-      style={thumbUrl ? { backgroundImage: `url(${thumbUrl})` } : undefined}
     >
+      {thumbUrl && (
+        <img
+          alt=""
+          className="wk-channel-search-media-thumb-img"
+          draggable={false}
+          src={thumbUrl}
+        />
+      )}
+      {onPreviewMedia && (
+        <button
+          aria-label={previewLabel}
+          className="wk-channel-search-media-preview-trigger"
+          title={previewLabel}
+          type="button"
+          onClick={() => onPreviewMedia(item)}
+        />
+      )}
       {item.kind === "video" && (
         <div className="wk-channel-search-media-play">
           <Play size={18} fill="currentColor" />
@@ -1037,11 +1068,13 @@ const FileInlineResult = React.memo(function FileInlineResult({
 type MediaResultGridProps = {
   items: ChannelSearchItem[];
   onLocate: (item: ChannelSearchItem) => void;
+  onPreviewMedia?: (item: ChannelSearchItem) => void;
 };
 
 const MediaResultGrid = React.memo(function MediaResultGrid({
   items,
   onLocate,
+  onPreviewMedia,
 }: MediaResultGridProps) {
   const grouped = useMemo(() => {
     return items.reduce<Record<string, ChannelSearchItem[]>>((acc, item) => {
@@ -1059,7 +1092,12 @@ const MediaResultGrid = React.memo(function MediaResultGrid({
           <div className="wk-channel-search-media-month">{label}</div>
           <div className="wk-channel-search-media-grid">
             {groupItems.map((item) => (
-              <MediaThumb key={item.id} item={item} onLocate={onLocate} />
+              <MediaThumb
+                key={item.id}
+                item={item}
+                onLocate={onLocate}
+                onPreviewMedia={onPreviewMedia}
+              />
             ))}
           </div>
         </section>
@@ -1216,6 +1254,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
   dataSource = channelSearchEmptyDataSource,
   onLocateMessage,
   onPreviewFile,
+  onPreviewMedia,
   initialState,
   onStateChange,
 }) => {
@@ -1534,7 +1573,13 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
       return <SearchEmpty queryStarted={queryStarted} />;
     }
     if (activeTab === "media") {
-      return <MediaResultGrid items={response.items} onLocate={handleLocate} />;
+      return (
+        <MediaResultGrid
+          items={response.items}
+          onLocate={handleLocate}
+          onPreviewMedia={onPreviewMedia}
+        />
+      );
     }
     if (activeTab === "file") {
       return (
@@ -1563,6 +1608,7 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
             keyword={keyword}
             getSender={getSender}
             onLocate={handleLocate}
+            onPreviewMedia={onPreviewMedia}
           />
         ))}
       </div>

--- a/packages/dmworkbase/src/Components/ChannelSearch/types.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/types.ts
@@ -44,6 +44,9 @@ export interface ChannelSearchFileInfo {
 
 export interface ChannelSearchMediaInfo {
   name?: string;
+  url?: string;
+  downloadUrl?: string;
+  previewUrl?: string | null;
   thumbUrl?: string;
   inlineThumbUrl?: string;
   duration?: number;

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/index.tsx
@@ -12,6 +12,7 @@ import "./index.css";
 const FilePreviewPanel: React.FC<FilePreviewPanelProps> = ({
   file,
   onClose,
+  showOpenExternal = true,
 }) => {
   const { t } = useI18n();
 
@@ -46,13 +47,15 @@ const FilePreviewPanel: React.FC<FilePreviewPanelProps> = ({
           {file.name}
         </div>
         <div className="wk-file-preview-actions">
-          <button
-            className="wk-file-preview-action"
-            title={t("base.filePreview.openInNewWindow")}
-            onClick={handleOpenExternal}
-          >
-            <ExternalLink size={18} />
-          </button>
+          {showOpenExternal && (
+            <button
+              className="wk-file-preview-action"
+              title={t("base.filePreview.openInNewWindow")}
+              onClick={handleOpenExternal}
+            >
+              <ExternalLink size={18} />
+            </button>
+          )}
           <button
             className="wk-file-preview-action"
             title={t("base.filePreview.download")}

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/registry.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/registry.ts
@@ -14,6 +14,7 @@ import ExcelRenderer from "./renderers/ExcelRenderer";
 import JsonRenderer from "./renderers/JsonRenderer";
 import JsonlRenderer from "./renderers/JsonlRenderer";
 import ImageRenderer from "./renderers/ImageRenderer";
+import VideoRenderer from "./renderers/VideoRenderer";
 
 /**
  * 文件渲染器注册表
@@ -21,7 +22,7 @@ import ImageRenderer from "./renderers/ImageRenderer";
  *
  * 注意：以下文件类型明确不支持预览，走 FallbackRenderer：
  * - .docx / .xlsx / .xls / .pptx / .ppt（Office 文档）
- * - 图片、视频、音频（对话流内已渲染，不进入面板）
+ * - 音频（对话流内已渲染，不进入面板）
  */
 class FileRendererRegistry {
   private registry: Map<string, RendererRegistryItem> = new Map();
@@ -38,6 +39,14 @@ class FileRendererRegistry {
       type: "image",
       extensions: ["png", "jpg", "jpeg", "gif", "bmp", "webp", "svg"],
       renderer: ImageRenderer,
+      needsFetch: false,
+    });
+
+    // 视频
+    this.register({
+      type: "video",
+      extensions: ["mp4", "m4v", "mov", "webm", "ogv", "ogg"],
+      renderer: VideoRenderer,
       needsFetch: false,
     });
 

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.css
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.css
@@ -1,0 +1,57 @@
+/* ============================================
+   VideoRenderer - 视频渲染器样式
+   类名前缀: wk-file-preview-video-renderer
+   ============================================ */
+
+.wk-file-preview-video-renderer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: var(--wk-sp-6);
+  box-sizing: border-box;
+  background: var(--wk-bg-base);
+}
+
+.wk-file-preview-video-renderer__video {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: var(--wk-r-md);
+  background: var(--wk-neutral-900);
+}
+
+.wk-file-preview-video-renderer__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  gap: var(--wk-sp-3);
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-md);
+  background: var(--wk-bg-subtle);
+  border-radius: var(--wk-r-md);
+}
+
+.wk-file-preview-video-renderer__error-text {
+  color: var(--wk-text-tertiary);
+}
+
+.wk-file-preview-video-renderer__retry {
+  padding: var(--wk-sp-2) var(--wk-sp-4);
+  border: 1px solid var(--wk-border-default);
+  background: var(--wk-bg-base);
+  color: var(--wk-text-primary);
+  border-radius: var(--wk-r-sm);
+  cursor: pointer;
+  font-size: var(--wk-text-size-sm);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.wk-file-preview-video-renderer__retry:hover {
+  background: var(--wk-bg-hover);
+  border-color: var(--wk-border-strong);
+}

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useState } from "react";
+import { BaseRendererProps } from "../types";
+import { useI18n } from "../../../i18n";
+import "./VideoRenderer.css";
+
+export interface VideoRendererProps extends BaseRendererProps {}
+
+const VideoRenderer: React.FC<VideoRendererProps> = ({ file, onError }) => {
+  const { t } = useI18n();
+  const [hasError, setHasError] = useState(false);
+
+  const handleError = useCallback(() => {
+    setHasError(true);
+    onError?.(t("base.filePreview.video.loadFailed"));
+  }, [onError, t]);
+
+  const handleRetry = useCallback(() => {
+    setHasError(false);
+  }, []);
+
+  if (hasError) {
+    return (
+      <div className="wk-file-preview-video-renderer wk-file-preview-video-renderer--error-state">
+        <div className="wk-file-preview-video-renderer__error">
+          <span className="wk-file-preview-video-renderer__error-text">
+            {t("base.filePreview.video.loadFailed")}
+          </span>
+          <button
+            className="wk-file-preview-video-renderer__retry"
+            onClick={handleRetry}
+          >
+            {t("base.filePreview.retry")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="wk-file-preview-video-renderer">
+      <video
+        key={hasError ? "retry" : file.url}
+        className="wk-file-preview-video-renderer__video"
+        controls
+        onError={handleError}
+        playsInline
+        poster={file.posterUrl}
+        src={file.url}
+      />
+    </div>
+  );
+};
+
+export default VideoRenderer;
+export { VideoRenderer };

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/index.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/index.ts
@@ -5,6 +5,9 @@
 export { default as ImageRenderer } from "./ImageRenderer";
 export type { ImageRendererProps } from "./ImageRenderer";
 
+export { default as VideoRenderer } from "./VideoRenderer";
+export type { VideoRendererProps } from "./VideoRenderer";
+
 export { default as PdfRenderer } from "./PdfRenderer";
 export type { PdfRendererProps } from "./PdfRenderer";
 

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/types.ts
@@ -14,6 +14,14 @@ export interface FilePreviewInfo {
   messageId?: string;
   /** 文件分类（image/video/document/code 等，用于判断文件类型） */
   category?: string;
+  /** 预览封面图（视频等媒体预览使用） */
+  posterUrl?: string;
+  /** 媒体原始宽度 */
+  width?: number;
+  /** 媒体原始高度 */
+  height?: number;
+  /** 媒体时长（秒） */
+  duration?: number;
   /** 消息序号（用于回复功能） */
   messageSeq?: number;
   /** 发送者 UID（用于回复功能） */
@@ -71,6 +79,7 @@ export interface RendererRegistryItem {
 export interface FilePreviewPanelProps {
   file: FilePreviewInfo | null;
   onClose: () => void;
+  showOpenExternal?: boolean;
 }
 
 /** 加载状态 Props */

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -45,6 +45,7 @@ import { FileListPanel } from "../FilePreviewPanel/FileListPanel";
 import { MarkdownRenderer } from "../FilePreviewPanel/renderers/MarkdownRenderer";
 import { HtmlRenderer } from "../FilePreviewPanel/renderers/HtmlRenderer";
 import { ImageRenderer } from "../FilePreviewPanel/renderers/ImageRenderer";
+import { VideoRenderer } from "../FilePreviewPanel/renderers/VideoRenderer";
 import { isChannelSearchEnabled } from "../ChannelSearch/feature";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
@@ -1795,6 +1796,7 @@ export default class ThreadPanel extends Component<
 
     const ext = getExtension(filePreview.extension, filePreview.name);
     const isImage = filePreview.category === "image";
+    const isVideo = filePreview.category === "video";
     const isMarkdown = ["md", "markdown"].includes(ext);
     const isHtml = ["html", "htm"].includes(ext);
 
@@ -1807,6 +1809,14 @@ export default class ThreadPanel extends Component<
       return (
         <div className="wk-thread-panel-file-preview">
           <ImageRenderer file={filePreview} onError={handleError} />
+        </div>
+      );
+    }
+
+    if (isVideo) {
+      return (
+        <div className="wk-thread-panel-file-preview">
+          <VideoRenderer file={filePreview} onError={handleError} />
         </div>
       );
     }

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -570,6 +570,41 @@ body[theme-mode="dark"] .wk-chat-channelsetting {
   margin-right: calc(0px - var(--wk-width-chat-search-panel));
   background-color: var(--wk-bg-surface);
   border-left: 1px solid var(--wk-border-default);
+  overflow: hidden;
+}
+
+.wk-chat-channel-search-stack,
+.wk-chat-channel-search-main,
+.wk-chat-channel-search-preview {
+  width: 100%;
+  height: 100%;
+}
+
+.wk-chat-channel-search-stack {
+  position: relative;
+}
+
+.wk-chat-channel-search-stack--previewing .wk-chat-channel-search-main {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.wk-chat-channel-search-preview {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background-color: var(--wk-bg-surface);
+}
+
+.wk-chat-channel-search-preview .wk-file-preview-panel {
+  position: static;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  margin-right: 0;
+  border-left: 0;
+  box-shadow: none;
+  transition: none;
 }
 
 .wk-chat-content-right.wk-chat-channel-search-open .wk-chat-content-chat {

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -75,6 +75,25 @@ import { I18nContext, t } from "../../i18n";
 // 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
 const THREAD_REACTIVATE_REFRESH_DELAYS_MS = [0, 300, 800, 1500];
 
+function extensionFromUrl(url: string): string {
+  const path = url.split(/[?#]/)[0] || "";
+  const fileName = path.substring(path.lastIndexOf("/") + 1);
+  return getExtension("", fileName);
+}
+
+function fallbackSearchMediaExtension(kind: ChannelSearchItem["kind"]) {
+  return kind === "video" ? "mp4" : "jpg";
+}
+
+function searchMediaPreviewName(
+  item: ChannelSearchItem,
+  extension: string
+): string {
+  const prefix = item.kind === "video" ? "video" : "image";
+  const id = item.messageSeq || item.messageId || "preview";
+  return `${prefix}-${id}.${extension}`;
+}
+
 interface SidebarTabBarWithBadgesProps {
   conversations: ConversationWrap[];
   activeTab: SidebarTab;
@@ -246,6 +265,8 @@ export interface ChatContentPageState {
   summaryPanelView: "history" | "new";
   /** 频道内聊天搜索面板是否显示 */
   showChannelSearch: boolean;
+  /** 频道内搜索面板中的预览文件 */
+  channelSearchPreviewFile: FilePreviewInfo | null;
   /** 当前文件预览关闭后是否需要回到频道内搜索面板 */
   previewReturnChannelSearch: boolean;
 }
@@ -283,6 +304,7 @@ export class ChatContentPage extends Component<
       showChannelSearch:
         !!props.initialShowChannelSearch &&
         isChannelSearchEnabled(props.channel),
+      channelSearchPreviewFile: null,
       previewReturnChannelSearch: false,
     };
   }
@@ -392,8 +414,8 @@ export class ChatContentPage extends Component<
       Toast.warning(t("base.channelSearch.downloadUnavailable"));
       return;
     }
-    this._onFilePreview(
-      {
+    this.setState({
+      channelSearchPreviewFile: {
         url,
         name,
         extension: getExtension(file.extension || "", name),
@@ -404,8 +426,46 @@ export class ChatContentPage extends Component<
         messageSeq: item.messageSeq,
         fromUID: item.senderUid,
       },
-      { returnToChannelSearch: true }
-    );
+    });
+  };
+
+  private _onSearchMediaPreview = (item: ChannelSearchItem) => {
+    const media = item.media;
+    if (!media || (item.kind !== "image" && item.kind !== "video")) return;
+
+    const { channel } = this.props;
+    const url =
+      media.previewUrl ||
+      media.url ||
+      media.downloadUrl ||
+      (item.kind === "image" ? media.thumbUrl : "") ||
+      "";
+    if (!url) {
+      Toast.warning(t("base.channelSearch.downloadUnavailable"));
+      return;
+    }
+
+    const extension =
+      extensionFromUrl(url) || fallbackSearchMediaExtension(item.kind);
+    const name = media.name || searchMediaPreviewName(item, extension);
+
+    this.setState({
+      channelSearchPreviewFile: {
+        url,
+        name,
+        extension,
+        category: item.kind,
+        posterUrl: media.thumbUrl || media.inlineThumbUrl,
+        width: media.width,
+        height: media.height,
+        duration: media.duration,
+        sourceChannelId: item.channelId || channel.channelID,
+        sourceChannelType: item.channelType || channel.channelType,
+        messageId: item.messageId,
+        messageSeq: item.messageSeq,
+        fromUID: item.senderUid,
+      },
+    });
   };
 
   private _onChannelSearchStateChange = (state: ChannelSearchPanelState) => {
@@ -421,6 +481,7 @@ export class ChatContentPage extends Component<
     this._clearChannelSearchState();
     this.setState({
       showChannelSearch: true,
+      channelSearchPreviewFile: null,
       showChannelSetting: false,
       showThreadPanel: false,
       activeThread: null,
@@ -490,6 +551,7 @@ export class ChatContentPage extends Component<
           this._clearChannelSearchState();
           this.setState({
             showChannelSearch: false,
+            channelSearchPreviewFile: null,
             previewReturnChannelSearch: false,
           });
           return;
@@ -513,6 +575,7 @@ export class ChatContentPage extends Component<
           showMatterDetailPanel: false, // 关闭事项详情面板
           showSummaryPanel: false,
           showChannelSearch: false,
+          channelSearchPreviewFile: null,
           previewReturnChannelSearch: false,
         });
       }
@@ -554,6 +617,9 @@ export class ChatContentPage extends Component<
             : prevState.activePreviewMessageId,
           showSummaryPanel: opening ? false : prevState.showSummaryPanel,
           showChannelSearch: opening ? false : prevState.showChannelSearch,
+          channelSearchPreviewFile: opening
+            ? null
+            : prevState.channelSearchPreviewFile,
         };
       });
     };
@@ -583,6 +649,7 @@ export class ChatContentPage extends Component<
           previewReturnChannelSearch: false,
           showSummaryPanel: false,
           showChannelSearch: false,
+          channelSearchPreviewFile: null,
         };
       });
     };
@@ -619,6 +686,9 @@ export class ChatContentPage extends Component<
             ? null
             : prevState.activePreviewMessageId,
           showChannelSearch: opening ? false : prevState.showChannelSearch,
+          channelSearchPreviewFile: opening
+            ? null
+            : prevState.channelSearchPreviewFile,
         };
       });
     };
@@ -636,6 +706,7 @@ export class ChatContentPage extends Component<
         showMatterDetailPanel: false, // 互斥
         showSummaryPanel: false,
         showChannelSearch: false,
+        channelSearchPreviewFile: null,
       });
       WKApp.shared.pendingThreadPanel = undefined;
     }
@@ -662,6 +733,7 @@ export class ChatContentPage extends Component<
         showMatterDetailPanel: false, // 互斥
         showSummaryPanel: false,
         showChannelSearch: false,
+        channelSearchPreviewFile: null,
         previewReturnChannelSearch: false,
       });
     }
@@ -691,6 +763,9 @@ export class ChatContentPage extends Component<
 
     if (channelChanged) {
       this._clearChannelSearchState();
+      if (this.state.channelSearchPreviewFile) {
+        this.setState({ channelSearchPreviewFile: null });
+      }
     }
 
     if (
@@ -705,6 +780,7 @@ export class ChatContentPage extends Component<
       this._clearChannelSearchState();
       this.setState({
         showChannelSearch: false,
+        channelSearchPreviewFile: null,
         previewReturnChannelSearch: false,
       });
     }
@@ -725,6 +801,7 @@ export class ChatContentPage extends Component<
           showMatterDetailPanel: false, // 互斥
           showSummaryPanel: false,
           showChannelSearch: false,
+          channelSearchPreviewFile: null,
         });
         return;
       }
@@ -751,6 +828,7 @@ export class ChatContentPage extends Component<
           showMatterDetailPanel: false, // 互斥
           showSummaryPanel: false,
           showChannelSearch: false,
+          channelSearchPreviewFile: null,
           previewReturnChannelSearch: false,
         });
         return;
@@ -920,6 +998,7 @@ export class ChatContentPage extends Component<
       showSummaryPanel,
       summaryPanelView,
       showChannelSearch,
+      channelSearchPreviewFile,
     } = this.state;
     // 子区页面不显示讨论串按钮
     const isThreadChannel = channel.channelType === ChannelTypeCommunityTopic;
@@ -1103,6 +1182,7 @@ export class ChatContentPage extends Component<
                                 showMatterDetailPanel: false, // 与事项详情面板互斥
                                 showSummaryPanel: false,
                                 showChannelSearch: false,
+                                channelSearchPreviewFile: null,
                                 activeThread: null,
                                 previewFile: null, // 关闭文件预览（互斥）
                                 activePreviewMessageId: null,
@@ -1122,6 +1202,7 @@ export class ChatContentPage extends Component<
                         this.setState({
                           showChannelSetting: !this.state.showChannelSetting,
                           showChannelSearch: false,
+                          channelSearchPreviewFile: null,
                         });
                       }}
                     >
@@ -1171,6 +1252,7 @@ export class ChatContentPage extends Component<
                       showMatterDetailPanel: false, // 与事项详情面板互斥
                       showSummaryPanel: false,
                       showChannelSearch: false,
+                      channelSearchPreviewFile: null,
                       previewFile: null, // 关闭文件预览（互斥）
                       activePreviewMessageId: null,
                       activeThread: buildThreadStub(
@@ -1224,21 +1306,44 @@ export class ChatContentPage extends Component<
         {showChannelSearch && (
           <div className="wk-chat-channel-search-panel">
             <ErrorBoundary moduleName={t("base.chatPage.searchModuleName")}>
-              <ChannelSearchPanel
-                key={channel.getChannelKey()}
-                channel={channel}
-                conversationContext={this.conversationContext}
-                dataSource={this.getChannelSearchDataSource(channel)}
-                onPreviewFile={this._onSearchFilePreview}
-                initialState={this.channelSearchPanelState}
-                onStateChange={this._onChannelSearchStateChange}
-                onClose={() => {
-                  this._clearChannelSearchState();
-                  this.setState({
-                    showChannelSearch: false,
-                  });
-                }}
-              />
+              <div
+                className={classNames(
+                  "wk-chat-channel-search-stack",
+                  channelSearchPreviewFile &&
+                    "wk-chat-channel-search-stack--previewing"
+                )}
+              >
+                <div className="wk-chat-channel-search-main">
+                  <ChannelSearchPanel
+                    key={channel.getChannelKey()}
+                    channel={channel}
+                    conversationContext={this.conversationContext}
+                    dataSource={this.getChannelSearchDataSource(channel)}
+                    onPreviewFile={this._onSearchFilePreview}
+                    onPreviewMedia={this._onSearchMediaPreview}
+                    initialState={this.channelSearchPanelState}
+                    onStateChange={this._onChannelSearchStateChange}
+                    onClose={() => {
+                      this._clearChannelSearchState();
+                      this.setState({
+                        showChannelSearch: false,
+                        channelSearchPreviewFile: null,
+                      });
+                    }}
+                  />
+                </div>
+                {channelSearchPreviewFile && (
+                  <div className="wk-chat-channel-search-preview">
+                    <FilePreviewPanel
+                      file={channelSearchPreviewFile}
+                      showOpenExternal={false}
+                      onClose={() => {
+                        this.setState({ channelSearchPreviewFile: null });
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
             </ErrorBoundary>
           </div>
         )}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -285,6 +285,7 @@
   "filePreview.html.unknownError": "Unknown error",
   "filePreview.html.viewSource": "View source",
   "filePreview.image.loadFailed": "Image failed to load",
+  "filePreview.video.loadFailed": "Video failed to load",
   "filePreview.jsonl.cannotExtractStructure": "Unable to extract a table structure from the JSONL data",
   "filePreview.jsonl.cannotExtractTable": "Unable to extract table data",
   "filePreview.jsonl.code": "Code",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -285,6 +285,7 @@
   "filePreview.html.unknownError": "未知错误",
   "filePreview.html.viewSource": "查看源码",
   "filePreview.image.loadFailed": "图片加载失败",
+  "filePreview.video.loadFailed": "视频加载失败",
   "filePreview.jsonl.cannotExtractStructure": "无法从 JSONL 数据中提取表格结构",
   "filePreview.jsonl.cannotExtractTable": "无法提取表格数据",
   "filePreview.jsonl.code": "代码",


### PR DESCRIPTION
## Summary
- add image/video preview support for channel search results using the existing file preview panel
- keep preview inside the search panel so closing it preserves search results and avoids re-requesting
- map media preview fields, add video rendering, hide external-open for search previews, and keep media thumbnails fully visible in square cells

## Validation
- pnpm --filter @octo/base exec vitest run src/Components/ChannelSearch/__tests__
- pnpm i18n:check
- pnpm --filter ./apps/web build