### PR TITLE
fix: render online badge in compact conversation list (favorites/group tab)

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/onlineBadge.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/onlineBadge.test.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+let ConversationList: typeof import("../index").default;
+let container: HTMLDivElement;
+
+class MockChannel {
+  channelID: string;
+  channelType: number;
+
+  constructor(channelID: string, channelType: number) {
+    this.channelID = channelID;
+    this.channelType = channelType;
+  }
+
+  getChannelKey() {
+    return `${this.channelID}_${this.channelType}`;
+  }
+
+  isEqual(other: { channelID: string; channelType: number }) {
+    return (
+      other?.channelID === this.channelID &&
+      other?.channelType === this.channelType
+    );
+  }
+}
+
+beforeAll(async () => {
+  vi.doMock("wukongimjssdk", () => {
+    const sdk = {
+      shared: () => ({
+        channelManager: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          fetchChannelInfo: vi.fn(),
+          getChannelInfo: vi.fn(),
+        },
+      }),
+    };
+
+    return {
+      default: sdk,
+      WKSDK: sdk,
+      Channel: MockChannel,
+      ChannelTypePerson: 1,
+      ChannelTypeGroup: 2,
+      ReminderType: { ReminderTypeMentionMe: 1 },
+    };
+  });
+
+  vi.doMock("../../WKAvatar", () => ({
+    default: ({ channel }: { channel: { channelID: string } }) => (
+      <div className="wk-avatar" data-channel-id={channel.channelID} />
+    ),
+  }));
+  vi.doMock("../../ContextMenus", () => ({ default: () => null }));
+  vi.doMock("../../AiBadge", () => ({ default: () => null }));
+  vi.doMock("../../Icons/GroupIcon", () => ({ default: () => <span /> }));
+  vi.doMock("../../Icons/ThreadIcon", () => ({ default: () => <span /> }));
+
+  vi.doMock("../../../App", () => ({
+    default: {
+      loginInfo: { uid: "u1" },
+      shared: {
+        currentSpaceId: "space1",
+        getChannelAvatarTag: () => "avatar",
+      },
+      apiClient: { put: vi.fn() },
+      conversationProvider: { deleteConversation: vi.fn() },
+    },
+  }));
+
+  vi.doMock("../../../Service/Const", () => ({
+    ChannelTypeCommunityTopic: 3,
+    EndpointID: {},
+  }));
+  vi.doMock("../../../Service/Thread", () => ({
+    parseThreadChannelId: () => undefined,
+  }));
+  vi.doMock("../../../Service/TypingManager", () => ({
+    TypingManager: {
+      shared: {
+        addTypingListener: vi.fn(),
+        removeTypingListener: vi.fn(),
+        getTyping: () => undefined,
+      },
+    },
+  }));
+  vi.doMock("../../../Service/ChannelSetting", () => ({
+    ChannelSettingManager: {
+      shared: { top: vi.fn(), mute: vi.fn(() => Promise.resolve()) },
+    },
+  }));
+  vi.doMock("../../../Service/Model", () => ({ MessageWrap: class {} }));
+  vi.doMock("../../../Messages/Revoke", () => ({ RevokeCell: { tip: () => "" } }));
+  vi.doMock("../../../Messages/Flame", () => ({
+    FlameMessageCell: { tip: () => "" },
+  }));
+  vi.doMock("../../../Utils/time", () => ({
+    getTimeStringAutoShort2: () => "now",
+  }));
+  vi.doMock("../../../Utils/draftPreview", () => ({
+    formatDraftPreview: (draft: string) => draft,
+  }));
+  vi.doMock("../../WKModal", () => ({ wkConfirm: vi.fn() }));
+  vi.doMock("../../Conversation/vm", () => ({
+    default: { foldSessionPreview: new Map() },
+  }));
+  vi.doMock("../../../i18n", () => ({
+    I18nContext: React.createContext({}),
+    t: (key: string) => key,
+    useI18n: () => ({ t: (key: string) => key }),
+  }));
+  vi.doMock("@douyinfe/semi-ui", () => ({
+    Tag: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  }));
+  vi.doMock("react-spinners", () => ({ BeatLoader: () => null }));
+
+  ConversationList = (await import("../index")).default;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+});
+
+// channelType 1 = person (DM / agent / human). online drives the badge.
+function makeConversation(opts: {
+  id?: string;
+  online: boolean;
+  lastOffline?: number;
+}) {
+  const channel = new MockChannel(opts.id ?? "alice", 1);
+  return {
+    channel,
+    channelInfo: {
+      channel,
+      mute: false,
+      online: opts.online,
+      lastOffline: opts.lastOffline ?? 0,
+      top: false,
+      orgData: { displayName: "Alice" },
+    },
+    unread: 0,
+    isMentionMe: false,
+    simpleReminders: [],
+    remoteExtra: {},
+    timestamp: 1,
+    lastMessage: undefined,
+  };
+}
+
+function render(node: React.ReactElement) {
+  act(() => {
+    ReactDOM.render(node, container);
+  });
+}
+
+describe("online badge in compact (favorites/group) list", () => {
+  it("renders the online badge for an online entry in compact mode", () => {
+    render(
+      <ConversationList
+        compact
+        conversations={[makeConversation({ online: true })] as any}
+      />
+    );
+    const compactItem = container.querySelector(".wk-conv-compact-item");
+    expect(compactItem).not.toBeNull();
+    expect(
+      compactItem?.querySelector(".wk-conv-compact-icon .wk-onlinestatusbadge")
+    ).not.toBeNull();
+  });
+
+  it("does not render the badge for a long-offline entry in compact mode", () => {
+    render(
+      <ConversationList
+        compact
+        conversations={[makeConversation({ online: false, lastOffline: 1 })] as any}
+      />
+    );
+    const compactItem = container.querySelector(".wk-conv-compact-item");
+    expect(compactItem).not.toBeNull();
+    expect(compactItem?.querySelector(".wk-onlinestatusbadge")).toBeNull();
+  });
+
+  it("matches the recent (non-compact) list: same online entry shows a badge in both", () => {
+    const conv = makeConversation({ online: true });
+
+    render(<ConversationList compact conversations={[conv] as any} />);
+    const compactHasBadge = !!container.querySelector(
+      ".wk-conv-compact-item .wk-onlinestatusbadge"
+    );
+
+    render(<ConversationList conversations={[conv] as any} />);
+    const recentHasBadge = !!container.querySelector(
+      ".wk-conversationlist-item-avatar-box .wk-onlinestatusbadge"
+    );
+
+    expect(compactHasBadge).toBe(true);
+    expect(recentHasBadge).toBe(true);
+    expect(compactHasBadge).toBe(recentHasBadge);
+  });
+});

--- a/packages/dmworkbase/src/Components/ConversationList/index.css
+++ b/packages/dmworkbase/src/Components/ConversationList/index.css
@@ -529,6 +529,16 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   border: 1px solid var(--wk-color-white);
 }
 
+/* compact 列表头像更小（22x22 vs 最近列表 32x32），在线圆点等比缩小并贴右下角，
+ * 与左上角未读红点错开、不撑乱紧凑排版。复用 .wk-onlinestatusbadge 同色同形。 */
+.wk-conv-compact-icon .wk-onlinestatusbadge {
+  width: 7px;
+  height: 7px;
+  right: -1px;
+  bottom: -1px;
+  border-width: 1.5px;
+}
+
 .wk-conv-compact-name {
   flex: 1;
   font-size: var(--wk-text-size-base);

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -41,6 +41,42 @@ import { wkConfirm } from "../WKModal";
 import { collapsedThreadUnread } from "./unread";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
+// ── 在线态判定/渲染 helper ──────────────────────────────────────────────
+// 最近列表（非 compact）与关注/收藏列表（compact 的 CompactGroupItem）共用同一份
+// 判定与 tip 文案，保证两处在线圆点的数据源、阈值、文案完全一致，避免逻辑复制漂移。
+
+// 是否需要显示在线状态：在线，或离线时间在 1 小时内
+export function needShowOnlineStatus(channelInfo?: ChannelInfo): boolean {
+  if (!channelInfo) {
+    return false;
+  }
+  if (channelInfo.online) {
+    return true;
+  }
+  const nowTime = new Date().getTime() / 1000;
+  const btwTime = nowTime - channelInfo.lastOffline;
+  if (btwTime > 0 && btwTime < 60 * 60) {
+    // 小于1小时才显示
+    return true;
+  }
+  return false;
+}
+
+// 离线 tip 文案（在线时返回 undefined，badge 退化为纯绿点）
+export function getOnlineTip(channelInfo: ChannelInfo): string | undefined {
+  if (channelInfo.online) {
+    return undefined;
+  }
+  const nowTime = new Date().getTime() / 1000;
+  const btwTime = nowTime - channelInfo.lastOffline;
+  if (btwTime < 60) {
+    return t("base.conversationList.justNow");
+  }
+  return t("base.conversationList.minutesAgoShort", {
+    values: { count: (btwTime / 60).toFixed(0) },
+  });
+}
+
 // ── CompactGroupItem：群聊 Tab 紧凑 item，支持拖拽 ──────────────────────
 interface CompactGroupItemProps {
   conversationWrap: ConversationWrap;
@@ -178,6 +214,9 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
             channel={conversationWrap.channel}
           />
         )}
+        {!isThread && channelInfo && needShowOnlineStatus(channelInfo) ? (
+          <OnlineStatusBadge tip={getOnlineTip(channelInfo)}></OnlineStatusBadge>
+        ) : undefined}
       </span>
       <span className="wk-conv-compact-name">
         {channelInfo?.orgData.displayName ? (
@@ -575,32 +614,12 @@ export default class ConversationList extends Component<
   }
 
   getOnlineTip(channelInfo: ChannelInfo) {
-    if (channelInfo.online) {
-      return undefined;
-    }
-    const nowTime = new Date().getTime() / 1000;
-    const btwTime = nowTime - channelInfo.lastOffline;
-    if (btwTime < 60) {
-      return t("base.conversationList.justNow");
-    }
-    return t("base.conversationList.minutesAgoShort", { values: { count: (btwTime / 60).toFixed(0) } });
+    return getOnlineTip(channelInfo);
   }
 
   // 是否需要显示在线状态
   needShowOnlineStatus(channelInfo?: ChannelInfo) {
-    if (!channelInfo) {
-      return false;
-    }
-    if (channelInfo.online) {
-      return true;
-    }
-    const nowTime = new Date().getTime() / 1000;
-    const btwTime = nowTime - channelInfo.lastOffline;
-    if (btwTime > 0 && btwTime < 60 * 60) {
-      // 小于1小时才显示
-      return true;
-    }
-    return false;
+    return needShowOnlineStatus(channelInfo);
   }
 
   conversationItem(


### PR DESCRIPTION
## Problem

The favorites/group tab (`filter=group`) forces the conversation list into compact mode, which renders `CompactGroupItem`. That component never read `channelInfo.online` nor rendered `OnlineStatusBadge`, so the online dot was missing for **every** entry there (both agents and humans), while the recent (non-compact) list rendered it correctly. Same channel, two render paths, inconsistent result.

Fixes #444.

## Change

- Extract the existing `needShowOnlineStatus` / `getOnlineTip` helpers from the class component to module scope, so the recent list and the compact list share a single source of truth (no duplicated online-state logic to drift).
- Render `OnlineStatusBadge` inside `CompactGroupItem` from the same `channelInfo.online` data source, guarded the same way (`!isThread && needShowOnlineStatus(channelInfo)`).
- Add a compact-scoped style: the dot is sized down to match the smaller 22px avatar (vs 32px in the recent list) and sits bottom-right so it does not collide with the top-left unread marker.

No backend change. The compact list now reads the exact same `channelInfo.online` (channels fetch + `onlineStatus` CMD live push) as the recent list, so the dot follows real-time online/offline changes identically.

## Verification

- New unit test (`onlineBadge.test.tsx`) renders the real `ConversationList` and asserts: the badge appears for an online entry in compact mode, is absent when long-offline, and is present in both compact and recent paths for the same channel.
- Browser render with the production CSS: online entries show a green dot at the avatar's bottom-right; it coexists cleanly with the unread red dot; offline entries show nothing; the dot matches the recent list's form. Layout is unaffected.
- Existing ConversationList / ConversationListGrouped suites pass.

## Screenshot

Compact (favorites/group) online vs online+unread vs offline, plus the recent-list reference — all consistent:

| State | Online dot |
| --- | --- |
| Compact, online | bottom-right green dot |
| Compact, online + unread | green dot bottom-right, red unread dot top-left (no overlap) |
| Compact, offline | none |
| Recent (reference), online | bottom-right green dot, same form |
