### PR TITLE
feat(webhook): display short /v1/webhooks alias for push URLs

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookUrlModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookUrlModal.test.tsx
@@ -103,6 +103,16 @@ const groupContaining = (selector: string): HTMLElement => {
 };
 
 describe('WebhookUrlModal renderExample branch mapping', () => {
+  it('renders the short /v1/webhooks alias (not canonical /incoming-webhooks) for the push address (#452)', async () => {
+    await render();
+    const addr = container.querySelector(
+      '.wk-webhook-url__row .wk-webhook-url__value'
+    );
+    // 后端返回 canonical /v1/incoming-webhooks/...，展示层应改写成更短的等价别名。
+    expect(addr?.textContent).toContain('/api/v1/webhooks/iwh_test/tok');
+    expect(container.textContent).not.toContain('/incoming-webhooks/');
+  });
+
   it('shows only native/wecom by default; github is folded behind the toggle', async () => {
     await render();
     // 默认展开的只有 native / wecom 两组；github 收进「更多适配器」折叠区。

--- a/packages/dmworkbase/src/Service/IncomingWebhook.ts
+++ b/packages/dmworkbase/src/Service/IncomingWebhook.ts
@@ -262,6 +262,41 @@ export function buildIncomingWebhookUrl(
     return `${abs.origin}${basePath}${rel}`;
 }
 
+/**
+ * canonical 推送路径里的「入站 webhook」段。服务端 publicURL/publicURLs 始终广告这一形态
+ * —— octo-server #456 刻意保持向后兼容，不在响应里返回短别名。
+ */
+const CANONICAL_WEBHOOK_SEGMENT = "/v1/incoming-webhooks/";
+/**
+ * 等价的短别名段（octo-server #455/#456）：`/v1/webhooks/{id}/{token}[/adapter]` 与 canonical
+ * 共用同一套 handler / 中间件链 / 限流桶，access-log token 脱敏也对两个前缀做了 parity。
+ */
+const SHORT_WEBHOOK_SEGMENT = "/v1/webhooks/";
+
+/**
+ * 把 canonical 推送地址改写成更短的 `/v1/webhooks` 别名，用于推送地址弹窗的展示 / 复制
+ * （octo-web #452）。仅替换首个 `/v1/incoming-webhooks/` 段，webhook_id / token / 适配器
+ * 后缀 / query 一律原样保留。
+ *
+ * - 幂等且前向兼容：地址已是 `/v1/webhooks/` 形态、或根本不含 canonical 段时原样返回——
+ *   将来后端若直接返回短别名也不会被二次改写（正好覆盖 issue 里「if/when the backend
+ *   returns it」）。
+ * - 只匹配 `/v1/incoming-webhooks/` 这一精确前缀，不会误伤管理面
+ *   `/v1/groups/{group_no}/incoming-webhooks`（其 `incoming-webhooks` 前不是 `/v1/`）。
+ * - 纯字符串改写，相对路径（`/v1/...`）与绝对地址（`https://host/api/v1/...`）皆可用：
+ *   用 indexOf 定位、只替换一次，避免误伤路径里其它同名子串。
+ */
+export function toShortWebhookAlias(url: string): string {
+    if (!url) return url;
+    const idx = url.indexOf(CANONICAL_WEBHOOK_SEGMENT);
+    if (idx < 0) return url;
+    return (
+        url.slice(0, idx) +
+        SHORT_WEBHOOK_SEGMENT +
+        url.slice(idx + CANONICAL_WEBHOOK_SEGMENT.length)
+    );
+}
+
 /** 一次性推送地址弹窗里的一行（一个适配器） */
 export interface WebhookUrlRow {
     key: "native" | "github" | "wecom" | "gitlab" | "feishu" | "multica";
@@ -276,6 +311,11 @@ export interface WebhookUrlRow {
  * 决策点：native 适配器优先用 `urls.native`，回退到顶层 `url`（旧契约只给 `url`）；
  * 其余适配器（github / gitlab / wecom / feishu / multica）仅在响应提供对应
  * `urls.*` 时出现；最终过滤掉空地址，故老后端不返回的适配器自动不展示。
+ *
+ * 展示偏好（octo-web #452 / octo-server #456）：后端返回的仍是 canonical
+ * `/v1/incoming-webhooks/...`，这里统一经 {@link toShortWebhookAlias} 改写成更短的等价
+ * 别名 `/v1/webhooks/...` 再展示 / 复制。两条路径服务端完全等价（同 handler / 中间件 /
+ * 限流，日志 token 脱敏亦 parity），故纯属展示层变更，不改请求契约。
  */
 export function buildWebhookUrlRows(
     resp: Pick<IncomingWebhookCreateResp, "url" | "urls">,
@@ -283,15 +323,18 @@ export function buildWebhookUrlRows(
     origin: string
 ): WebhookUrlRow[] {
     const abs = (rel?: string): string =>
-        rel ? buildIncomingWebhookUrl(rel, apiURL || "/", origin) : "";
-    return [
+        rel ? buildIncomingWebhookUrl(toShortWebhookAlias(rel), apiURL || "/", origin) : "";
+    // 显式标注元素类型：让各 key 字面量被钉到 WebhookUrlRow["key"] 联合（否则数组字面量里
+    // key 会被拓宽成 string，filter 后整体不可赋值给 WebhookUrlRow[]）。
+    const rows: WebhookUrlRow[] = [
         { key: "native", labelKey: "channelWebhook.url.native", url: abs(resp.urls?.native || resp.url) },
         { key: "github", labelKey: "channelWebhook.url.github", url: abs(resp.urls?.github) },
         { key: "gitlab", labelKey: "channelWebhook.url.gitlab", url: abs(resp.urls?.gitlab) },
         { key: "wecom", labelKey: "channelWebhook.url.wecom", url: abs(resp.urls?.wecom) },
         { key: "feishu", labelKey: "channelWebhook.url.feishu", url: abs(resp.urls?.feishu) },
         { key: "multica", labelKey: "channelWebhook.url.multica", url: abs(resp.urls?.multica) },
-    ].filter((row) => !!row.url);
+    ];
+    return rows.filter((row) => !!row.url);
 }
 
 /** push 消息 payload 里的发送者展示身份（DeliveredMessagePayload.from） */

--- a/packages/dmworkbase/src/Service/__tests__/IncomingWebhook.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/IncomingWebhook.test.ts
@@ -11,6 +11,7 @@ import {
     isFlagOn,
     isIncomingWebhookSender,
     normalizeMentionUids,
+    toShortWebhookAlias,
     validateMentionUids,
     webhookFromOfMessage,
 } from "../IncomingWebhook";
@@ -64,6 +65,50 @@ describe("buildIncomingWebhookUrl", () => {
         expect(buildIncomingWebhookUrl(`${rel}/wecom`, "/api/v1/", "https://h.e")).toBe(
             "https://h.e/api/v1/incoming-webhooks/iwh_abc/token123/wecom"
         );
+    });
+});
+
+describe("toShortWebhookAlias (#452)", () => {
+    it("canonical 相对路径 → 短别名，webhook_id/token 保留", () => {
+        expect(toShortWebhookAlias("/v1/incoming-webhooks/iwh_a/tok")).toBe(
+            "/v1/webhooks/iwh_a/tok"
+        );
+    });
+
+    it("适配器后缀完整保留", () => {
+        expect(toShortWebhookAlias("/v1/incoming-webhooks/iwh_a/tok/github")).toBe(
+            "/v1/webhooks/iwh_a/tok/github"
+        );
+    });
+
+    it("query 串完整保留", () => {
+        expect(toShortWebhookAlias("/v1/incoming-webhooks/iwh_a/tok?foo=bar")).toBe(
+            "/v1/webhooks/iwh_a/tok?foo=bar"
+        );
+    });
+
+    it("绝对地址里的 canonical 段也被改写（仅换一次）", () => {
+        expect(
+            toShortWebhookAlias("https://h.e/api/v1/incoming-webhooks/iwh_a/tok")
+        ).toBe("https://h.e/api/v1/webhooks/iwh_a/tok");
+    });
+
+    it("幂等：已是短别名 → 原样返回（前向兼容后端将来直接返回别名）", () => {
+        const short = "/v1/webhooks/iwh_a/tok";
+        expect(toShortWebhookAlias(short)).toBe(short);
+    });
+
+    it("不含 canonical 段 → 原样返回", () => {
+        expect(toShortWebhookAlias("/v1/message/send")).toBe("/v1/message/send");
+    });
+
+    it("不误伤管理面 /v1/groups/{group_no}/incoming-webhooks（前缀不同）", () => {
+        const mgmt = "/v1/groups/g_1/incoming-webhooks";
+        expect(toShortWebhookAlias(mgmt)).toBe(mgmt);
+    });
+
+    it("空串 → 空串", () => {
+        expect(toShortWebhookAlias("")).toBe("");
     });
 });
 
@@ -348,7 +393,9 @@ describe("buildWebhookUrlRows", () => {
     const origin = "https://host.example";
     const full = (rel: string) => `https://host.example/api/v1${rel}`;
 
-    it("三个适配器 URL 齐全 → 三行，标签 key 正确", () => {
+    // 后端返回的仍是 canonical /v1/incoming-webhooks/...（#456 保持向后兼容），
+    // 展示层统一改写成更短的等价别名 /v1/webhooks/...（#452）。
+    it("三个适配器 URL 齐全 → 三行，标签 key 正确，展示为短别名（#452）", () => {
         const rows = buildWebhookUrlRows(
             {
                 url: "/v1/incoming-webhooks/iwh_a/t",
@@ -362,13 +409,13 @@ describe("buildWebhookUrlRows", () => {
             origin
         );
         expect(rows).toEqual([
-            { key: "native", labelKey: "channelWebhook.url.native", url: full("/incoming-webhooks/iwh_a/t") },
-            { key: "github", labelKey: "channelWebhook.url.github", url: full("/incoming-webhooks/iwh_a/t/github") },
-            { key: "wecom", labelKey: "channelWebhook.url.wecom", url: full("/incoming-webhooks/iwh_a/t/wecom") },
+            { key: "native", labelKey: "channelWebhook.url.native", url: full("/webhooks/iwh_a/t") },
+            { key: "github", labelKey: "channelWebhook.url.github", url: full("/webhooks/iwh_a/t/github") },
+            { key: "wecom", labelKey: "channelWebhook.url.wecom", url: full("/webhooks/iwh_a/t/wecom") },
         ]);
     });
 
-    it("旧契约只给顶层 url（无 urls）→ native 回退到 url，github/wecom 过滤掉", () => {
+    it("旧契约只给顶层 url（无 urls）→ native 回退到 url 并改写为短别名，github/wecom 过滤掉", () => {
         const rows = buildWebhookUrlRows(
             { url: "/v1/incoming-webhooks/iwh_a/t" },
             apiURL,
@@ -378,7 +425,7 @@ describe("buildWebhookUrlRows", () => {
         expect(rows[0]).toEqual({
             key: "native",
             labelKey: "channelWebhook.url.native",
-            url: full("/incoming-webhooks/iwh_a/t"),
+            url: full("/webhooks/iwh_a/t"),
         });
     });
 


### PR DESCRIPTION
## Summary

Frontend follow-up to #452 (depends on octo-server #456, merged). The push-address modal now displays the shorter `/v1/webhooks/{id}/{token}[/adapter]` alias instead of the canonical `/v1/incoming-webhooks/...` form.

octo-server #456 added the `/v1/webhooks` alias for all 6 push forms (native + github / wecom / gitlab / feishu / multica) behind the **identical** handler chain, middleware, rate-limit buckets and access-log token scrubbing — but deliberately keeps `publicURL` / `publicURLs` advertising the canonical form. So the `urls` map returned to the frontend is still canonical; preferring the alias is a pure display-layer rewrite on the client.

## Changes

**`Service/IncomingWebhook.ts`**
- New pure fn `toShortWebhookAlias(url)`: rewrites the first `/v1/incoming-webhooks/` segment to `/v1/webhooks/`, preserving webhook_id / token / adapter suffix / query. It is **idempotent and forward-compatible** (no-op when the URL is already short or has no canonical segment, so it stays correct if the backend ever returns the alias directly), and matches only the exact prefix so the management route `/v1/groups/{group_no}/incoming-webhooks` is never touched.
- `buildWebhookUrlRows` applies it to every adapter row, so the address box, curl examples and per-adapter Payload URLs all show the short form. **Display-only** — the request contract is unchanged (both paths are server-equivalent, with token-scrub parity per #456).
- Annotated the `rows` array as `WebhookUrlRow[]` to pin the `key` literals (removes a `tsc` literal-widening error).

## Test plan

- [x] `vitest` (dmworkbase) — +9 new cases (8 for `toShortWebhookAlias` + 1 modal short-alias assertion), all green. Verified against the pristine tree: **0 new failures** — the repo's 31 pre-existing failures are a `react@17` / `react-dom@18` version mismatch unrelated to this change (pass count 973 → 982 = exactly +9 new).
- [x] `tsc --noEmit` — 0 errors in the touched files.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ErYhTkgsGRqnmqC9TJjtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014ErYhTkgsGRqnmqC9TJjtZ)_