### PR TITLE
feat: render rich channel search results

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts
@@ -69,6 +69,45 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
     text: "哈哈哈哈[有品位]有趣有趣",
   },
   {
+    id: "msg-richtext-1",
+    messageId: "m-61020",
+    messageSeq: 61020,
+    senderUid: "liubo",
+    timestamp: toSeconds("2026-06-03T15:05:30+08:00"),
+    kind: "text",
+    text: "哈哈，图文混排里有两张图和一个文件",
+    matchReason: "<mark>哈哈</mark>，图文混排里有两张图和一个文件",
+    richText: {
+      plain: "哈哈，图文混排里有两张图和一个文件[图片]继续补充[图片][文件] 需求.md",
+      content: [
+        { type: "text", text: "哈哈，图文混排里有两张图和一个文件" },
+        {
+          type: "image",
+          url: figmaMediaThumbs[2],
+          width: 1200,
+          height: 800,
+          name: "design-a.png",
+        },
+        { type: "text", text: "继续补充" },
+        {
+          type: "image",
+          url: figmaMediaThumbs[3],
+          width: 960,
+          height: 1280,
+          name: "design-b.png",
+        },
+        {
+          type: "file",
+          url: "files/richtext/spec.md",
+          name: "需求.md",
+          extension: "md",
+          size: 14230,
+          caption: "富文本里的文件",
+        },
+      ],
+    },
+  },
+  {
     id: "msg-2",
     messageId: "m-61002",
     messageSeq: 61002,
@@ -297,7 +336,7 @@ export const mockChannelSearchItems: ChannelSearchItem[] = [
 ];
 
 const tabKinds: Record<ChannelSearchTab, ChannelSearchItem["kind"][]> = {
-  all: ["text", "file", "merge_forward"],
+  all: ["text", "file", "merge_forward", "image", "video"],
   message: ["text", "merge_forward"],
   media: ["image", "video"],
   file: ["file"],
@@ -310,10 +349,11 @@ const containsKeyword = (value: string | undefined, keyword: string) => {
 
 const itemMatchesKeyword = (item: ChannelSearchItem, keyword: string) => {
   if (!keyword.trim()) return true;
-  if (item.kind === "image" || item.kind === "video") return true;
+  if (item.kind === "image" || item.kind === "video") return false;
   return [
     item.text,
     item.matchReason,
+    item.richText?.plain,
     item.file?.name,
     item.forward?.title,
     ...(item.forward?.snippets || []),

--- a/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.tsx
@@ -255,7 +255,7 @@ export const OpenEmpty: Story = {
   name: "Open empty (no request)",
   play: async ({ canvasElement }) => {
     // Empty keyword + no filter on the default "all" tab must NOT fire a request
-    // (the backend rejects it with 400). The panel shows the empty-state prompt.
+    // until the backend explicitly supports all/message browse mode.
     await waitForElement(canvasElement, ".wk-channel-search-empty");
     if (canvasElement.querySelector(".wk-channel-search-result")) {
       throw new Error(

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/apiAdapter.test.ts
@@ -85,6 +85,7 @@ import type { ChannelSearchQuery } from "../types";
 const {
   mapFileHit,
   mapMediaHit,
+  mapCombinedHit,
   mapMessageHit,
   normalizeItems,
   searchEndpoint,
@@ -202,7 +203,7 @@ describe("channel search API adapter request construction", () => {
 describe("channel search empty-state guard", () => {
   const noFilters = { senderUids: [], sort: "time_desc" as const };
 
-  it("does not run all/message tabs with empty keyword and no filters (would 400)", () => {
+  it("does not run all/message tabs with empty keyword and no filters", () => {
     expect(
       shouldRunSearch({ keyword: "   ", filters: noFilters, tab: "all" })
     ).toBe(false);
@@ -436,6 +437,144 @@ describe("channel search API adapter response mapping", () => {
           },
         ],
         childCount: 2,
+      },
+    });
+  });
+
+  it("maps message-kind image and video hits from search_all browse mode", () => {
+    const image = mapMessageHit(
+      {
+        message_id: "m-image",
+        message_seq: 41,
+        message_kind: "image",
+        snippet: "野餐合影",
+        thumb_url: "images/a.jpg",
+        width: 1080,
+        height: 720,
+        sender_id: "u1",
+        sent_at: "2026-01-02T00:00:00Z",
+      },
+      baseQuery("all")
+    );
+    const video = mapMessageHit(
+      {
+        message_id: "m-video",
+        message_seq: 42,
+        message_kind: "video",
+        thumb_url: "videos/a-cover.jpg",
+        width: 1280,
+        height: 720,
+        duration_ms: 42000,
+        sender_id: "u2",
+        sent_at: "2026-01-02T00:00:00Z",
+      },
+      baseQuery("all")
+    );
+
+    expect(image).toMatchObject({
+      kind: "image",
+      text: "野餐合影",
+      matchReason: "野餐合影",
+      media: {
+        url: "/api/v1/images/a.jpg",
+        previewUrl: "/api/v1/images/a.jpg",
+        thumbUrl: "/api/v1/images/a.jpg",
+        width: 1080,
+        height: 720,
+      },
+    });
+    expect(video).toMatchObject({
+      kind: "video",
+      media: {
+        thumbUrl: "/api/v1/videos/a-cover.jpg",
+        width: 1280,
+        height: 720,
+        duration: 42,
+      },
+    });
+    expect(video.media?.url).toBeUndefined();
+    expect(video.media?.previewUrl).toBeUndefined();
+  });
+
+  it("maps search_all message result media through the combined dispatcher", () => {
+    expect(
+      mapCombinedHit(
+        {
+          result_type: "message",
+          sorted_at: "2026-01-03T00:00:00Z",
+          message: {
+            message_id: "m-image",
+            message_seq: 41,
+            message_kind: "image",
+            thumb_url: "images/a.jpg",
+            sender_id: "u1",
+            sent_at: "2026-01-02T00:00:00Z",
+          },
+        },
+        baseQuery("all")
+      )
+    ).toMatchObject({
+      kind: "image",
+      timestamp: 1767398400,
+      media: {
+        thumbUrl: "/api/v1/images/a.jpg",
+      },
+    });
+  });
+
+  it("keeps rich_text detail on text hits for structured rendering", () => {
+    const item = mapMessageHit(
+      {
+        message_id: "m-richtext",
+        message_seq: 43,
+        message_kind: "text",
+        snippet: "命中的<mark>哈哈</mark>片段",
+        sender_id: "u1",
+        sent_at: "2026-01-02T00:00:00Z",
+        rich_text: {
+          plain: "命中的哈哈片段[图片][文件] 需求.md",
+          content: [
+            { type: "text", text: "命中的哈哈片段" },
+            {
+              type: "image",
+              url: "images/rich.png",
+              width: 800,
+              height: 600,
+            },
+            {
+              type: "file",
+              url: "files/spec.md",
+              name: "需求.md",
+              extension: "md",
+              size: 2048,
+            },
+          ],
+          mention: {
+            entities: [{ uid: "u1", offset: 0, length: 3 }],
+            all: 1,
+            humans: 1,
+          },
+        },
+      },
+      baseQuery("message")
+    );
+
+    expect(item).toMatchObject({
+      kind: "text",
+      text: "命中的<mark>哈哈</mark>片段",
+      matchReason: "命中的<mark>哈哈</mark>片段",
+      richText: {
+        plain: "命中的哈哈片段[图片][文件] 需求.md",
+        content: [
+          { type: "text", text: "命中的哈哈片段" },
+          { type: "image", url: "images/rich.png" },
+          { type: "file", name: "需求.md", extension: "md" },
+        ],
+        mention: {
+          entities: [{ uid: "u1", offset: 0, length: 3 }],
+          all: 1,
+          humans: 1,
+        },
       },
     });
   });

--- a/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts
@@ -16,6 +16,8 @@ import type {
   ChannelSearchMediaInfo,
   ChannelSearchQuery,
   ChannelSearchResponse,
+  ChannelSearchRichTextInfo,
+  ChannelSearchRichTextMention,
   ChannelSearchSender,
   ChannelSearchTab,
 } from "./types";
@@ -33,7 +35,7 @@ type SearchEnvelope<T> = {
 type MessageSearchHit = {
   message_id?: string;
   message_seq?: number;
-  message_kind?: "text" | "forward" | "quote";
+  message_kind?: "text" | "forward" | "quote" | "image" | "video";
   snippet?: string;
   sender_id?: string;
   sender_name?: string;
@@ -51,6 +53,11 @@ type MessageSearchHit = {
   inner_messages?: ForwardInnerMessageHit[];
   channel_id?: string;
   channel_type?: number;
+  thumb_url?: string;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+  rich_text?: RichTextSearchHit;
 };
 
 type ForwardInnerMessageHit = {
@@ -60,6 +67,36 @@ type ForwardInnerMessageHit = {
   sender_id?: string;
   sender_name?: string;
   sent_at?: string;
+};
+
+type RichTextSearchBlock = {
+  type?: string;
+  text?: string;
+  url?: string;
+  width?: number;
+  height?: number;
+  size?: number;
+  name?: string;
+  extension?: string;
+  mime?: string;
+  caption?: string;
+};
+
+type RichTextSearchMentionEntity = {
+  uid?: string;
+  offset?: number;
+  length?: number;
+};
+
+type RichTextSearchHit = {
+  content?: RichTextSearchBlock[];
+  plain?: string;
+  mention?: {
+    entities?: RichTextSearchMentionEntity[];
+    all?: number;
+    humans?: number;
+    ais?: number;
+  };
 };
 
 type MediaSearchHit = {
@@ -223,14 +260,8 @@ function hasEffectiveFilters(filters: ChannelSearchFilters) {
   return Object.keys(cleanFilters(filters)).length > 0;
 }
 
-// Decide whether a search request should actually be sent. Only the keyword-
-// optional endpoints `_search` (message tab) and `_search_all` (all tab) carry
-// the backend empty-search guard (validateSearchNotEmpty): with an empty keyword
-// AND no effective filter they fail-fast with 400. Mirror that guard here so an
-// empty panel never fires a request that is guaranteed to 400 — it falls back to
-// the empty-state view instead. The media (`_search_media`) and file
-// (`_search_files`) tabs have no such backend guard and legitimately browse
-// without a keyword, so they always run.
+// Only send empty-keyword requests to all/message tabs when a real filter is
+// present. Media/file tabs support browse mode directly.
 export function shouldRunSearch(
   query: Pick<ChannelSearchQuery, "keyword" | "filters" | "tab">
 ) {
@@ -299,6 +330,109 @@ function mapForwardInnerMessage(
   };
 }
 
+function normalizeRichTextMention(
+  mention?: RichTextSearchHit["mention"]
+): ChannelSearchRichTextMention | undefined {
+  if (!mention) return undefined;
+  const entities = Array.isArray(mention.entities)
+    ? mention.entities
+        .filter(
+          (entity): entity is Required<RichTextSearchMentionEntity> =>
+            typeof entity?.uid === "string" &&
+            Number.isFinite(entity.offset) &&
+            Number.isFinite(entity.length) &&
+            (entity.offset || 0) >= 0 &&
+            (entity.length || 0) > 0
+        )
+        .map((entity) => ({
+          uid: entity.uid,
+          offset: entity.offset,
+          length: entity.length,
+        }))
+    : undefined;
+
+  return {
+    entities,
+    all: mention.all,
+    humans: mention.humans,
+    ais: mention.ais,
+  };
+}
+
+function normalizeRichText(
+  richText?: RichTextSearchHit
+): ChannelSearchRichTextInfo | undefined {
+  if (!richText) return undefined;
+  const content = Array.isArray(richText.content)
+    ? richText.content
+        .filter(
+          (block): block is RichTextSearchBlock & { type: string } =>
+            typeof block?.type === "string" && block.type.length > 0
+        )
+        .map((block) => ({
+          type: block.type,
+          text: block.text,
+          url: block.url,
+          width: block.width,
+          height: block.height,
+          size: block.size,
+          name: block.name,
+          extension: block.extension,
+          mime: block.mime,
+          caption: block.caption,
+        }))
+    : [];
+
+  if (content.length === 0 && !richText.plain) {
+    return undefined;
+  }
+
+  return {
+    content,
+    plain: richText.plain,
+    mention: normalizeRichTextMention(richText.mention),
+  };
+}
+
+function mapMessageMediaHit(
+  hit: MessageSearchHit,
+  query: ChannelSearchQuery,
+  mediaKind: "image" | "video"
+): ChannelSearchItem {
+  const sender = senderFromHit(hit);
+  const hitChannel = channelFromHit(hit, query);
+  const sentAt = hit.sent_at || "";
+  const thumbUrl = normalizeImageUrl(hit.thumb_url);
+  const media: ChannelSearchMediaInfo = {
+    url: mediaKind === "image" ? thumbUrl : undefined,
+    previewUrl: mediaKind === "image" ? thumbUrl : undefined,
+    thumbUrl,
+    duration:
+      typeof hit.duration_ms === "number"
+        ? Math.round(hit.duration_ms / 1000)
+        : undefined,
+    width: hit.width,
+    height: hit.height,
+    monthBucket: monthBucketFromSentAt(sentAt),
+    tone: mediaKind === "video" ? "purple" : "cool",
+  };
+
+  return {
+    id: hit.message_id || `${hit.message_seq || 0}`,
+    messageId: hit.message_id || "",
+    messageSeq: hit.message_seq || 0,
+    channelId: hitChannel.channelId,
+    channelType: hitChannel.channelType,
+    senderUid: sender.uid,
+    sender,
+    timestamp: sentAtToSeconds(sentAt),
+    kind: mediaKind,
+    text: hit.snippet || "",
+    matchReason: hit.snippet,
+    media,
+  };
+}
+
 function mapMessageHit(
   hit: MessageSearchHit,
   query: ChannelSearchQuery
@@ -307,12 +441,18 @@ function mapMessageHit(
   const hitChannel = channelFromHit(hit, query);
   const sentAt = hit.sent_at || "";
   const messageKind = hit.message_kind || "text";
+  if (messageKind === "image" || messageKind === "video") {
+    return mapMessageMediaHit(hit, query, messageKind);
+  }
+
+  const richText = normalizeRichText(hit.rich_text);
   const kind =
     messageKind === "forward"
       ? "merge_forward"
       : messageKind === "quote"
       ? "quote"
       : "text";
+  const text = hit.snippet || richText?.plain || "";
 
   return {
     id: hit.message_id || `${hit.message_seq || 0}`,
@@ -324,8 +464,9 @@ function mapMessageHit(
     sender,
     timestamp: sentAtToSeconds(sentAt),
     kind,
-    text: hit.snippet || "",
-    matchReason: hit.snippet,
+    text,
+    matchReason: hit.snippet || richText?.plain,
+    richText,
     forward:
       messageKind === "forward"
         ? {
@@ -567,6 +708,8 @@ export const channelSearchApiAdapterTestUtils = {
   truncateChannelSearchKeyword,
   toRequestBody,
   mapForwardInnerMessage,
+  normalizeRichText,
+  mapMessageMediaHit,
   mapMessageHit,
   mapFileHit,
   mapMediaHit,

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -257,6 +257,38 @@
   word-break: break-word;
 }
 
+.wk-channel-search-richtext-preview {
+  max-width: 315px;
+  margin-top: 2px;
+}
+
+.wk-channel-search-richtext-preview .wk-msg-mixed-content {
+  gap: 4px;
+  max-width: 100%;
+}
+
+.wk-channel-search-richtext-preview .wk-msg-mixed-text {
+  color: var(--channel-search-text-primary);
+  font: 400 14px/20px var(--wk-font-sans);
+}
+
+.wk-channel-search-richtext-preview .wk-msg-mixed-image {
+  max-width: 180px;
+}
+
+.wk-channel-search-richtext-preview .wk-markdown-img {
+  display: block;
+  max-width: 180px;
+  max-height: 120px;
+  object-fit: contain;
+  background: var(--channel-search-elevated);
+}
+
+.wk-channel-search-richtext-preview .wk-msg-mixed-file {
+  width: min(100%, 315px);
+  padding: 8px;
+}
+
 .wk-channel-search-highlight {
   padding: 0;
   border-radius: 0;

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.tsx
@@ -23,6 +23,9 @@ import IconClick from "../IconClick";
 import ConversationContext from "../Conversation/context";
 import { downloadFile } from "../../Utils/download";
 import { useI18n } from "../../i18n";
+import { getRichTextBlocksUI } from "../../bridge/message/useRichTextMessageUI";
+import MixedContent from "../../ui/message/MixedContent";
+import type { MixedContentBlock } from "../../ui/message/MixedContent";
 import { channelSearchEmptyDataSource } from "./adapter";
 import {
   CHANNEL_SEARCH_KEYWORD_MAX_RUNES,
@@ -722,6 +725,66 @@ const LocateIconButton = React.memo(function LocateIconButton({
   );
 });
 
+const RichTextResultContent = React.memo(function RichTextResultContent({
+  item,
+  keyword,
+}: {
+  item: ChannelSearchItem;
+  keyword: string;
+}) {
+  const { t } = useI18n();
+  const richText = item.richText;
+  const blocks = useMemo(() => {
+    return getRichTextBlocksUI(richText?.content || [], {
+      entities: richText?.mention?.entities || [],
+      syntheticMentions: [],
+    });
+  }, [richText]);
+  const showMatchReason =
+    !!keyword.trim() &&
+    !!item.matchReason &&
+    item.matchReason !== richText?.plain;
+
+  const handleFileDownload = useCallback(
+    async (block: Extract<MixedContentBlock, { type: "file" }>) => {
+      if (!block.url) {
+        Toast.warning(t("base.channelSearch.downloadUnavailable"));
+        return;
+      }
+      try {
+        await downloadFile(block.url, block.name);
+      } catch (_) {
+        Toast.error(t("base.channelSearch.downloadFailed"));
+      }
+    },
+    [t]
+  );
+
+  if (blocks.length === 0) {
+    return (
+      <div className="wk-channel-search-result-text">
+        <ChannelSearchSnippetContent text={item.text} keyword={keyword} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {showMatchReason && (
+        <div className="wk-channel-search-match-reason">
+          <ChannelSearchSnippetContent
+            text={item.matchReason}
+            keyword={keyword}
+          />
+        </div>
+      )}
+      <div className="wk-channel-search-richtext-preview">
+        <MixedContent blocks={blocks} onFileDownload={handleFileDownload} />
+      </div>
+    </>
+  );
+});
+
 const MessageResultItem = React.memo(function MessageResultItem({
   item,
   keyword,
@@ -827,9 +890,7 @@ const MessageResultItem = React.memo(function MessageResultItem({
             </div>
           </>
         ) : (
-          <div className="wk-channel-search-result-text">
-            <ChannelSearchSnippetContent text={item.text} keyword={keyword} />
-          </div>
+          <RichTextResultContent item={item} keyword={keyword} />
         )}
       </div>
       {canLocateChannelSearchItem(item) && (
@@ -955,6 +1016,14 @@ const MediaThumb = React.memo(function MediaThumb({
     ? item.media?.inlineThumbUrl || item.media?.thumbUrl
     : item.media?.thumbUrl;
   const previewLabel = t("base.filePreview.preview");
+  const canPreviewMedia =
+    !!onPreviewMedia &&
+    !!(
+      item.media?.previewUrl ||
+      item.media?.url ||
+      item.media?.downloadUrl ||
+      (item.kind === "image" && item.media?.thumbUrl)
+    );
 
   return (
     <div
@@ -962,7 +1031,7 @@ const MediaThumb = React.memo(function MediaThumb({
         "wk-channel-search-media-thumb",
         `wk-channel-search-media-thumb--${item.media?.tone || "warm"}`,
         thumbUrl ? "wk-channel-search-media-thumb--image" : "",
-        onPreviewMedia ? "wk-channel-search-media-thumb--previewable" : "",
+        canPreviewMedia ? "wk-channel-search-media-thumb--previewable" : "",
         compact ? "wk-channel-search-media-thumb--compact" : "",
       ]
         .filter(Boolean)
@@ -976,7 +1045,7 @@ const MediaThumb = React.memo(function MediaThumb({
           src={thumbUrl}
         />
       )}
-      {onPreviewMedia && (
+      {canPreviewMedia && (
         <button
           aria-label={previewLabel}
           className="wk-channel-search-media-preview-trigger"
@@ -1358,10 +1427,8 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
         return;
       }
 
-      // Empty-state guard: the keyword-optional `_search`/`_search_all` endpoints
-      // reject an empty keyword + empty filter with 400 (validateSearchNotEmpty).
-      // Don't fire it — show the empty-state view. Media/file tabs are exempt
-      // (they browse without a keyword), which shouldRunSearch encodes.
+      // Empty all/message searches are only sent once keyword or filters exist.
+      // Media/file tabs browse without a keyword, which shouldRunSearch encodes.
       if (!shouldRunSearch({ keyword, filters, tab: activeTab })) {
         return;
       }
@@ -1499,8 +1566,8 @@ const ChannelSearchPanel: React.FC<ChannelSearchPanelProps> = ({
     setPaginationError(null);
     setAutoPaginationPaused(false);
 
-    // No keyword and no effective filter → don't hit the backend (it would 400).
-    // Reset to the initial empty-state prompt instead of a spinner.
+    // Keep the initial prompt until an all/message search has a keyword or a
+    // real filter. Media/file tabs can browse immediately.
     if (!canSearch) {
       setQueryStarted(false);
       setLoading(false);

--- a/packages/dmworkbase/src/Components/ChannelSearch/types.ts
+++ b/packages/dmworkbase/src/Components/ChannelSearch/types.ts
@@ -1,3 +1,5 @@
+import type { RichTextBlock } from "../../Messages/RichText/RichTextContent";
+
 export type ChannelSearchTab = "all" | "message" | "media" | "file";
 
 export type ChannelSearchItemKind =
@@ -72,6 +74,25 @@ export interface ChannelSearchForwardInfo {
   childCount?: number;
 }
 
+export interface ChannelSearchRichTextMentionEntity {
+  uid: string;
+  offset: number;
+  length: number;
+}
+
+export interface ChannelSearchRichTextMention {
+  entities?: ChannelSearchRichTextMentionEntity[];
+  all?: number;
+  humans?: number;
+  ais?: number;
+}
+
+export interface ChannelSearchRichTextInfo {
+  content: RichTextBlock[];
+  plain?: string;
+  mention?: ChannelSearchRichTextMention;
+}
+
 export interface ChannelSearchItem {
   id: string;
   messageId: string;
@@ -87,6 +108,7 @@ export interface ChannelSearchItem {
   file?: ChannelSearchFileInfo;
   media?: ChannelSearchMediaInfo;
   forward?: ChannelSearchForwardInfo;
+  richText?: ChannelSearchRichTextInfo;
 }
 
 export interface ChannelSearchResponse {


### PR DESCRIPTION
## Summary
- render channel search rich_text results with existing rich text mixed-content components
- map _search_all message-kind image/video hits into media search result cards
- keep all/message empty-keyword guard conservative until backend supports browse mode

## Tests
- cd packages/dmworkbase && ./node_modules/.bin/vitest run src/Components/ChannelSearch/__tests__/apiAdapter.test.ts src/Components/ChannelSearch/__tests__/snippetContent.test.tsx