### PR TITLE
fix: prevent malformed text messages from crashing conversation render (#465)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/malformedMessageRender.test.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/malformedMessageRender.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+/**
+ * #465 render-layer regression coverage.
+ *
+ * Unlike messageOrder.test.ts (which mocks both `wukongimjssdk` and
+ * `Service/Model`), this suite uses the REAL SDK and the REAL `MessageWrap`,
+ * so the SDK getters that actually crash the conversation render are exercised
+ * faithfully:
+ *   - `Message.contentType` getter derefs `this.content.contentType`
+ *   - `MessageWrap.flame` getter derefs `this.message.content.contentObj`
+ *   - `MessageWrap.parts` → `parseMention` derefs `this.content.contentType`
+ *
+ * A malformed message (payload.type === text but content failed to decode →
+ * `message.content === undefined`) makes every one of those throw. The fix
+ * normalizes such messages to an empty `MessageText` at a single point in
+ * `ConversationVM.refreshMessages`, before any contentType read, so the
+ * malformed bubble renders as empty instead of taking down the whole list.
+ */
+
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, describe, it, expect, vi } from "vitest"
+import {
+    Channel,
+    ChannelTypeGroup,
+    Message,
+    MessageStatus,
+    MessageText,
+    MessageContentType,
+} from "wukongimjssdk"
+
+// Heavy app/service singletons that ConversationVM and the real MessageWrap
+// pull in. Mirrors messageOrder.test.ts, minus the `wukongimjssdk` and
+// `Service/Model` mocks (we want the real SDK + real MessageWrap here).
+vi.mock("../../../App", () => ({
+    default: {
+        loginInfo: { uid: "me", realnameVerified: false },
+        config: { pageSizeOfMessage: 30 },
+        dataSource: { channelDataSource: { subscribers: () => Promise.resolve([]) } },
+        mittBus: { on: () => {}, off: () => {} },
+        emojiService: { getImage: () => undefined },
+        conversationProvider: {
+            markConversationUnread: () => Promise.resolve(),
+            syncMessages: () => Promise.resolve([]),
+        },
+        shared: {
+            currentSpaceId: "",
+            notifyMessageDeleteListener: () => {},
+            avatarUser: () => "",
+        },
+    },
+}))
+vi.mock("../../../Service/DataSource/DataProvider", () => ({ SyncMessageOptions: class {} }))
+vi.mock("../../../Service/Provider", () => ({
+    ProviderListener: class {
+        callback?: Function
+        notifyListener(done?: Function) { this.callback?.(); done?.() }
+        listen(f: Function) { this.callback = f }
+        clearListeners() { this.callback = undefined }
+        didMount() {}
+        didUnMount() {}
+    },
+}))
+vi.mock("react-scroll", () => ({ animateScroll: { scrollToBottom: () => {} }, scroller: { scrollTo: () => {} } }))
+vi.mock("../../../Messages/Time", () => ({ TimeContent: class {} }))
+vi.mock("../../../Messages/HistorySplit", () => ({ HistorySplitContent: class {} }))
+vi.mock("../../../Messages/Mergeforward", () => ({ default: class {} }))
+vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
+vi.mock("../historyScroll", () => ({
+    getPulldownRestoredScrollTop: () => 0,
+    getRestoredAnchorScrollTop: ({ anchorOffsetTop, keepOffsetY }: any) => anchorOffsetTop + keepOffsetY,
+}))
+vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+vi.mock("../sendContentProxy", () => ({ wrapSendContentForInjection: (content: any) => content }))
+vi.mock("../../../Service/messageSelection", () => ({ isMessageSelectable: () => true }))
+// The i18n barrel transitively pulls in lottie-web, which crashes on import
+// under jsdom (no canvas). Stub it the same way MessageRow.test / MarkdownContent
+// tests do — the render path here only needs `t` to echo keys back.
+vi.mock("../../../i18n", () => ({
+    t: (key: string) => key,
+    useI18n: () => ({ t: (key: string) => key }),
+}))
+// ProhibitwordsService.filter is invoked on the normalized text; keep it faithful
+// to the production behaviour (empty stays empty).
+vi.mock("../../../Service/ProhibitwordsService", () => ({
+    ProhibitwordsService: {
+        shared: { filter: (text: unknown) => (typeof text === "string" ? text : ""), getProhibitwords: () => [] },
+    },
+}))
+
+import ConversationVM from "../vm"
+import { MessageWrap, PartType } from "../../../Service/Model"
+import { getTextMessageUI } from "../../../bridge/message/useTextMessageUI"
+
+const channel = new Channel("g1", ChannelTypeGroup)
+
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+    if (!container) return
+    ReactDOM.unmountComponentAtNode(container)
+    container.remove()
+    container = null
+})
+
+// A real SDK Message whose content failed to decode: `new Message()` without a
+// recvPacket leaves `content` undefined, matching a group text message whose
+// payload was malformed (#465).
+function buildMalformedWrap(): MessageWrap {
+    const message = new Message()
+    message.messageID = "m-malformed"
+    message.messageSeq = 1
+    message.clientMsgNo = "malformed"
+    message.timestamp = 100
+    message.fromUID = "u1"
+    message.channel = channel
+    message.status = MessageStatus.Normal
+    // message.content intentionally left undefined
+    return new MessageWrap(message)
+}
+
+describe("#465 malformed message — real SDK render-layer getters", () => {
+    it("raw malformed wrap crashes on the very getters the render layer reads", () => {
+        const wrap = buildMalformedWrap()
+        // These are the exact deref sites that take down the conversation list.
+        expect(() => wrap.contentType).toThrow()
+        expect(() => wrap.flame).toThrow()
+        expect(() => wrap.parts).toThrow()
+    })
+
+    it("ConversationVM.refreshMessages normalizes it so the getters are safe", () => {
+        const vm = new ConversationVM(channel)
+        const wrap = buildMalformedWrap()
+
+        // Pre-fix this throws inside the sort/dedup pass (Message.contentType
+        // derefs undefined content); post-fix the single-point normalization
+        // runs first and refreshMessages completes.
+        expect(() => vm.refreshMessages([wrap])).not.toThrow()
+
+        // Same wrap, now normalized in place to an empty text message.
+        expect(wrap.content).toBeInstanceOf(MessageText)
+        expect(wrap.contentType).toBe(MessageContentType.text)
+        expect(wrap.flame).toBe(false)
+        expect(wrap.parts.map((p) => p.text).join("")).toBe("")
+        expect(wrap.parts.every((p) => p.type === PartType.text)).toBe(true)
+    })
+})
+
+describe("#465 malformed message — render path", () => {
+    it("getTextMessageUI yields empty content for a normalized malformed message", () => {
+        const vm = new ConversationVM(channel)
+        const wrap = buildMalformedWrap()
+
+        vm.refreshMessages([wrap])
+
+        const ui = getTextMessageUI(wrap)
+        expect(ui.content.content).toBe("")
+        expect(ui.content.mentions).toEqual([])
+        expect(ui.content.emojis).toEqual([])
+    })
+
+    it("rendering the text cell for a normalized malformed message does not throw", () => {
+        const vm = new ConversationVM(channel)
+        const wrap = buildMalformedWrap()
+        vm.refreshMessages([wrap])
+
+        const TextCell: React.FC<{ message: MessageWrap }> = ({ message }) => {
+            const ui = getTextMessageUI(message)
+            return <span data-testid="text-cell">{ui.content.content}</span>
+        }
+
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        expect(() => {
+            act(() => {
+                ReactDOM.render(<TextCell message={wrap} />, container)
+            })
+        }).not.toThrow()
+
+        const cell = container.querySelector('[data-testid="text-cell"]')
+        expect(cell).not.toBeNull()
+        expect(cell?.textContent).toBe("")
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -128,7 +128,7 @@ vi.mock("../../../Service/TypingManager", () => ({
     TypingListener: class {},
     TypingManager: { shared: { addTypingListener: () => {}, removeTypingListener: () => {} } },
 }))
-vi.mock("../../../Service/ProhibitwordsService", () => ({ ProhibitwordsService: { shared: { filter: (text: string) => text, getProhibitwords: () => [] } } }))
+vi.mock("../../../Service/ProhibitwordsService", () => ({ ProhibitwordsService: { shared: { filter: (text: unknown) => (typeof text === "string" && text.length > 0 ? text : ""), getProhibitwords: () => [] } } }))
 vi.mock("../../../Service/SpaceService", () => ({ SYSTEM_BOTS: new Set() }))
 vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
 vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
@@ -156,6 +156,7 @@ function wrap(overrides: Record<string, any>) {
         contentType: overrides.contentType ?? 1,
         status: overrides.status ?? MessageStatus.Normal,
         fromUID: overrides.fromUID || "me",
+        content: overrides.content,
         remoteExtra: {},
     }
     const result: any = {
@@ -171,6 +172,8 @@ function wrap(overrides: Record<string, any>) {
         get contentType() { return message.contentType },
         get status() { return message.status },
         set status(value: number) { message.status = value },
+        get content() { return message.content },
+        set content(value: any) { message.content = value },
         get revoke() { return message.remoteExtra.revoke },
         set revoke(value: boolean) { message.remoteExtra.revoke = value },
         get revoker() { return message.remoteExtra.revoker },
@@ -506,5 +509,44 @@ describe("ConversationVM message ordering", () => {
             expect(vm.renderItems[0].session.userToggled).toBe(true)
             expect(vm.renderItems[0].session.isActive).toBe(true)
         }
+    })
+
+    it("normalizes malformed text messages during refreshMessages without throwing (#465)", () => {
+        const vm = new ConversationVM(channel)
+        // payload.type===1 但 content 缺失：SDK 解出的 content 整体为空
+        const missingContent = wrap({ clientMsgNo: "missing-content", messageSeq: 1, timestamp: 100, contentType: 1 })
+        // payload.type===1 但 content.text 缺失：content 在、text===undefined
+        const undefinedText = wrap({ clientMsgNo: "undefined-text", messageSeq: 2, timestamp: 200, contentType: 1, content: {} })
+
+        expect(() => vm.refreshMessages([missingContent, undefinedText])).not.toThrow()
+        expect(undefinedText.content.text).toBe("")
+    })
+
+    it("appends a new message when origin already holds a malformed text message (#465)", () => {
+        const vm = new ConversationVM(channel)
+        const malformed = wrap({ clientMsgNo: "malformed", messageSeq: 1, timestamp: 100, contentType: 1 })
+        vm.messagesOfOrigin = [malformed]
+        const fresh = wrap({ clientMsgNo: "fresh", messageSeq: 2, timestamp: 200, contentType: 1, content: { text: "hi" }, fromUID: "me" })
+
+        expect(() => vm.appendMessage(fresh)).not.toThrow()
+        expect(vm.messagesOfOrigin.map((m: any) => m.clientMsgNo)).toContain("fresh")
+    })
+
+    it("processes a successful send ack when origin already holds a malformed text message (#465)", () => {
+        const vm = new ConversationVM(channel)
+        const malformed = wrap({ clientMsgNo: "malformed", messageSeq: 1, timestamp: 100, contentType: 1 })
+        const pending = wrap({ clientSeq: 9, clientMsgNo: "pending", order: 1000001, timestamp: 300, status: MessageStatus.Wait, contentType: 1, content: { text: "hi" }, fromUID: "me" })
+        vm.messagesOfOrigin = [malformed, pending]
+        vm.messages = [malformed, pending]
+
+        expect(() => vm.updateMessageStatusBySendAck({
+            clientSeq: 9,
+            messageID: "m102",
+            messageSeq: 102,
+            reasonCode: 1,
+        } as any)).not.toThrow()
+
+        expect(pending.status).toBe(MessageStatus.Normal)
+        expect(vm.messagesOfOrigin.map((m: any) => m.clientMsgNo)).toContain("malformed")
     })
 })

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -67,6 +67,11 @@ vi.mock("wukongimjssdk", () => {
         },
         Message: class {},
         MessageContent: class {},
+        MessageText: class {
+            text: string
+            constructor(text: string) { this.text = text }
+            get contentType() { return 1 }
+        },
         Subscriber: class {},
         Conversation: class {},
         MessageExtra: class {},
@@ -169,7 +174,10 @@ function wrap(overrides: Record<string, any>) {
         get timestamp() { return message.timestamp },
         get fromUID() { return message.fromUID },
         get channel() { return message.channel },
-        get contentType() { return message.contentType },
+        // Faithful to the SDK: Message.contentType derefs `content.contentType`
+        // (see wukongimjssdk Message.prototype.contentType). Reading the raw
+        // field would mask the malformed-content crash this suite guards (#465).
+        get contentType() { return message.content?.contentType ?? message.contentType },
         get status() { return message.status },
         set status(value: number) { message.status = value },
         get content() { return message.content },

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -549,4 +549,15 @@ describe("ConversationVM message ordering", () => {
         expect(pending.status).toBe(MessageStatus.Normal)
         expect(vm.messagesOfOrigin.map((m: any) => m.clientMsgNo)).toContain("malformed")
     })
+
+    it("updates reply content without throwing when messages hold a malformed text message (#465)", () => {
+        const vm = new ConversationVM(channel)
+        // content 整体缺失的畸形文本消息：旧逻辑会在 message.content.reply 处崩溃
+        const malformed = wrap({ clientMsgNo: "malformed", messageSeq: 1, timestamp: 100, contentType: 1 })
+        const replyMsg = wrap({ clientMsgNo: "reply", messageSeq: 2, timestamp: 200, contentType: 1, content: { reply: { messageID: "m1", content: "old" } } })
+        vm.messages = [malformed, replyMsg]
+
+        expect(() => vm.updateReplyMessageContent({ messageID: "m1", contentEdit: "edited" } as any)).not.toThrow()
+        expect(replyMsg.content.reply.content).toBe("edited")
+    })
 })

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1,4 +1,4 @@
-import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK, Message, MessageContent, MessageStatus, Subscriber, Conversation, MessageExtra, CMDContent, PullMode, MessageContentType, ChannelInfo, ChannelInfoListener, ConversationListener, ConnectStatus, ConnectStatusListener } from "wukongimjssdk";
+import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK, Message, MessageContent, MessageStatus, Subscriber, Conversation, MessageExtra, CMDContent, PullMode, MessageContentType, MessageText, ChannelInfo, ChannelInfoListener, ConversationListener, ConnectStatus, ConnectStatusListener } from "wukongimjssdk";
 import WKApp from "../../App";
 import { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
 import { MessageWrap } from "../../Service/Model";
@@ -1865,6 +1865,16 @@ export default class ConversationVM extends ProviderListener {
 
     // 刷新消息列表
     refreshMessages(messages: MessageWrap[], callback?: () => void, options?: { allowFoldAnimation?: boolean }) {
+        // 单点归一（#465）：content 整体缺失的畸形消息（如 payload.type=text 但
+        // 解码失败）会让 SDK 的 Message.contentType getter 以及 MessageWrap 的
+        // flame / parts 解引用 undefined 而崩页，且这一步发生在下面排序 / 去重 /
+        // 渲染读取 contentType 之前。这里在任何 contentType 读取之前补一个空文本
+        // content，让畸形消息渲染成空气泡而非拖垮整个消息列表。
+        for (const m of messages) {
+            if (m.message.content == null) {
+                m.message.content = new MessageText("")
+            }
+        }
         let newMessages = messages
         // 渲染前先按 order（seq）排序，防止延迟推送/重连补推导致消息位置错乱
         newMessages = this.sortMessages(newMessages)

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1874,7 +1874,11 @@ export default class ConversationVM extends ProviderListener {
         for (let i = 0; i < newMessages.length; i++) {
             const message = newMessages[i]
             if (message.contentType === MessageContentType.text) {
-                message.content.text = ProhibitwordsService.shared.filter(message.content.text)
+                // 防御畸形文本消息：content 整体缺失时跳过，避免读取 undefined.text 崩溃（#465）。
+                const content = message.content
+                if (content) {
+                    content.text = ProhibitwordsService.shared.filter(content.text)
+                }
             }
         }
         this.messages = this.genMessageLinkedData(newMessages)

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1318,7 +1318,8 @@ export default class ConversationVM extends ProviderListener {
         }
         for (let i = this.messages.length - 1; i >= 0; i--) {
             const message = this.messages[i]
-            if (message.content.reply === undefined) {
+            // 防御畸形消息：content 可能整体缺失（#465 保留了此类消息），用可选链避免读取 undefined.reply 崩溃。
+            if (message.content?.reply === undefined) {
                 continue
             }
             if (message.content.reply.messageID && message.content.reply.messageID === extra.messageID) {

--- a/packages/dmworkbase/src/Service/ProhibitwordsService.ts
+++ b/packages/dmworkbase/src/Service/ProhibitwordsService.ts
@@ -57,7 +57,12 @@ export class ProhibitwordsService {
         })
         this.sensitiveWordTool.addWords(words)
     }
-    filter(v:string) {
+    filter(v: unknown): string {
+        // 仅对非空字符串调用第三方库；undefined/null/空串/非字符串一律归一为空串，
+        // 避免 sensitive-word-tool 读取 content.length 时崩溃（#465 畸形文本消息）。
+        if (typeof v !== "string" || v.length === 0) {
+            return ""
+        }
         return this.sensitiveWordTool.filter(v)
     }
 }

--- a/packages/dmworkbase/src/Service/__tests__/ProhibitwordsService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/ProhibitwordsService.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest"
+
+// ProhibitwordsService 依赖 App / StorageService，仅为模块加载打桩；
+// filter() 走真实的 sensitive-word-tool，以复现 #465 的崩溃场景。
+vi.mock("../../App", () => ({ default: { apiClient: { get: () => Promise.resolve([]) } } }))
+vi.mock("../StorageService", () => ({ default: { shared: { getItem: () => null, setItem: () => {} } } }))
+
+import { ProhibitwordsService } from "../ProhibitwordsService"
+
+describe("ProhibitwordsService.filter", () => {
+    it("returns an empty string for undefined input", () => {
+        expect(ProhibitwordsService.shared.filter(undefined)).toBe("")
+    })
+
+    it("returns an empty string for null input", () => {
+        expect(ProhibitwordsService.shared.filter(null)).toBe("")
+    })
+
+    it("returns an empty string for non-string input", () => {
+        expect(ProhibitwordsService.shared.filter(123 as unknown as string)).toBe("")
+    })
+
+    it("returns an empty string for an empty string", () => {
+        expect(ProhibitwordsService.shared.filter("")).toBe("")
+    })
+
+    it("passes through a normal string", () => {
+        expect(ProhibitwordsService.shared.filter("hello world")).toBe("hello world")
+    })
+})


### PR DESCRIPTION
Closes #465.

## Problem
In one specific group, the conversation history vanished and messages could not be sent, while other groups worked fine. The console showed:

`TypeError: Cannot read properties of undefined (reading 'length')` in the `filter → refreshMessages → appendMessage / updateMessageStatusBySendAck` chain.

## Root cause
The affected group's history contains a malformed text message: the payload is typed as text (`type === 1`) but the content body is missing, so the decoded `message.content.text` is `undefined`. During render, `ConversationVM.refreshMessages` runs the sensitive-word filter on every text message and called `ProhibitwordsService.filter(undefined)`. `ProhibitwordsService.filter` forwarded the value straight to the third-party `sensitive-word-tool`, which reads `content.length` and threw. This aborted `refreshMessages` before it could assign the rendered list, blanking the whole conversation. Send acks and live-message appends both re-run the same refresh, so every attempt hit the same bad history message and failed.

## Fix
- `ProhibitwordsService.filter` now accepts `unknown`, normalizes any non-string (including `undefined`/`null`/empty string) to `""`, and only invokes the library for real strings. This also hardens the other call sites.
- The text-filter branch in `ConversationVM.refreshMessages` skips entries whose `content` object is missing.
- `ConversationVM.updateReplyMessageContent` uses optional chaining so retained malformed messages no longer crash when a replied-to message is edited (same root cause, different trigger).

## Tests
- New `ProhibitwordsService` unit tests run against the real `sensitive-word-tool` and reproduce the original crash before the fix (`filter(undefined/null/non-string/"")` → `""`, normal strings pass through).
- New `messageOrder` regression tests cover `refreshMessages`, `appendMessage`, `updateMessageStatusBySendAck` and the edited-reply path with a malformed text message present, asserting no throw and correct normalization.
