### PR TITLE
fix: remove residual sent text from input box after send (#458)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -34,15 +34,20 @@ interface RecordingCleanup extends SendCleanup {
   calls: string[];
   removedIds: string[];
   editorUnchanged: boolean;
+  removeSentContentCalled: boolean;
 }
 
-function makeCleanup(opts?: { editorUnchanged?: boolean }): RecordingCleanup {
+function makeCleanup(opts?: {
+  editorUnchanged?: boolean;
+  withRemoveSentContent?: boolean;
+}): RecordingCleanup {
   const calls: string[] = [];
   const removedIds: string[] = [];
   const state = {
     calls,
     removedIds,
     editorUnchanged: opts?.editorUnchanged ?? true,
+    removeSentContentCalled: false,
     isEditorUnchanged: vi.fn(() => state.editorUnchanged),
     deleteEditorAttachmentRefs: vi.fn(() => calls.push("deleteEditorAttachmentRefs")),
     revokeEditorPreviewUrls: vi.fn(() => calls.push("revokeEditorPreviewUrls")),
@@ -52,6 +57,17 @@ function makeCleanup(opts?: { editorUnchanged?: boolean }): RecordingCleanup {
       removedIds.push(...ids);
     }),
     collapseExpanded: vi.fn(() => calls.push("collapseExpanded")),
+    // octo-web#458: only wire removeSentContent when opted in, so we can test
+    // both the new behavior and the backward-compatible fallback.
+    ...(opts?.withRemoveSentContent
+      ? {
+          snapshotContentSize: 5,
+          removeSentContent: vi.fn(() => {
+            state.removeSentContentCalled = true;
+            calls.push("removeSentContent");
+          }),
+        }
+      : {}),
   };
   return state as unknown as RecordingCleanup;
 }
@@ -244,5 +260,95 @@ describe("runSendWithCleanup — partial result (top attachments sent, editor fa
     await runSendWithCleanup(send, ["t1", "t2"], cleanup);
 
     expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("runSendWithCleanup — octo-web#458: partial editor cleanup when draft changed mid-flight", () => {
+  it("calls removeSentContent (not clearEditor) when editor changed AND removeSentContent is provided", async () => {
+    const cleanup = makeCleanup({
+      editorUnchanged: false,
+      withRemoveSentContent: true,
+    });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(true);
+    // Must NOT do a full clear — that would wipe the new draft (round-2 bug).
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    // Must call the surgical removal instead.
+    expect(cleanup.removeSentContentCalled).toBe(true);
+    // Attachment refs / preview URLs should still be cleaned up.
+    expect(cleanup.deleteEditorAttachmentRefs).toHaveBeenCalledTimes(1);
+    expect(cleanup.revokeEditorPreviewUrls).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to leave-as-is when editor changed but removeSentContent is NOT provided (backward compat)", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(true);
+    // Old behavior: no clearEditor, no removeSentContent — just leave the doc.
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call removeSentContent when editor is unchanged (normal full-clear path)", async () => {
+    const cleanup = makeCleanup({
+      editorUnchanged: true,
+      withRemoveSentContent: true,
+    });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, [], cleanup);
+
+    // Normal path: editor still holds exactly what was sent → full clear.
+    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    // removeSentContent must NOT be called — it's only for the changed-editor branch.
+    expect(cleanup.removeSentContentCalled).toBe(false);
+  });
+
+  it("still removes consumed top attachments by id when using removeSentContent path", async () => {
+    const cleanup = makeCleanup({
+      editorUnchanged: false,
+      withRemoveSentContent: true,
+    });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+    expect(cleanup.removeSentContentCalled).toBe(true);
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call removeSentContent when send resolved false (preserve draft for retry)", async () => {
+    const cleanup = makeCleanup({
+      editorUnchanged: false,
+      withRemoveSentContent: true,
+    });
+    const send = vi.fn().mockResolvedValue(false);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(false);
+    // send failed → preserve everything, no cleanup at all.
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.removeSentContentCalled).toBe(false);
+    expect(cleanup.removeTopAttachments).not.toHaveBeenCalled();
+  });
+
+  it("calls collapseExpanded via removeSentContent path when editor changed mid-flight", async () => {
+    const cleanup = makeCleanup({
+      editorUnchanged: false,
+      withRemoveSentContent: true,
+    });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, [], cleanup);
+
+    expect(cleanup.collapseExpanded).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -980,6 +980,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     //     但编辑器混排失败」，让已发文件不被重试重复 (Jerry-Xin non-blocking)。
     // 编排逻辑在纯函数 runSendWithCleanup，便于单测覆盖各竞态场景。
     const editorSnapshot = JSON.stringify(editor.getJSON());
+    // octo-web#458: snapshot content size enables surgical removal of the sent
+    // range when the user typed a new draft mid-flight (editor changed).
+    const snapshotContentSize = editor.state.doc.content.size;
     const consumedAttachmentAttrs = attachmentAttrs;
     const topItemsAtSend = topAttachments;
     const allTopIds = topItemsAtSend.map((item) => item.id);
@@ -1029,6 +1032,24 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
               setExpanded(false);
               props.onExpandChange?.(false);
             }
+          },
+          // octo-web#458: surgical removal of the sent snapshot range when the
+          // editor changed mid-flight. The current doc is structured as
+          // [snapshot content (sent)] [new draft (user-typed during await)].
+          // We delete the snapshot portion (positions 0→snapshotContentSize)
+          // while keeping the new draft intact.
+          snapshotContentSize,
+          removeSentContent: () => {
+            const { state } = editor;
+            const { doc, tr } = state;
+            const currentSize = doc.content.size;
+            // Nothing to remove if doc is exactly the snapshot (shouldn't happen
+            // since isEditorUnchanged() was false, but guard anyway).
+            if (currentSize <= snapshotContentSize) return;
+            // Delete the sent portion at the beginning of the document.
+            // Positions 0→snapshotContentSize cover the original snapshot; the
+            // remaining text (snapshotContentSize→currentSize) is the new draft.
+            editor.view.dispatch(tr.delete(0, snapshotContentSize));
           },
         }
       );

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -24,11 +24,12 @@
  *    the user's newer draft is left untouched. Top attachments are removed by
  *    the specific ids that were consumed, never with a blanket reset, so items
  *    queued during the wait survive.
- *    Residual follow-up: when the editor changed mid-flight we leave the live
- *    doc untouched, so the already-sent snapshot blocks stay alongside the new
- *    draft and could be re-sent on the next send (duplicate). Accepted over the
- *    worse "draft wiped" failure; a precise per-range removal is deferred — see
- *    the `!isEditorUnchanged()` branch below.
+ *    Residual follow-up (octo-web#458, now fixed): when the editor changed
+ *    mid-flight we used to leave the live doc untouched, so the already-sent
+ *    snapshot blocks stayed alongside the new draft. The fix: a
+ *    `removeSentContent` callback surgically removes the submitted snapshot
+ *    range while preserving the new draft — opt-in via `SendCleanup`, backward
+ *    compatible with callers that don't provide it.
  *
  * `onSend` return-value contract (back-compatible):
  *   - `undefined` / `void` → success: editor consumed, all consumed top
@@ -77,6 +78,22 @@ export interface SendCleanup {
   removeTopAttachments: (ids: string[]) => void;
   /** Optional: collapse the expanded composer (only when the editor is cleared). */
   collapseExpanded?: () => void;
+
+  // ── octo-web#458: partial editor cleanup when draft changed mid-flight ──
+  //
+  // When the editor content changed during the send await, the old behavior
+  // left the entire live doc untouched — including the already-sent content.
+  // The fix: remove only the submitted snapshot range from the editor while
+  // preserving the newly typed draft. Both fields are optional for backward
+  // compatibility; when absent the old "leave as-is" behavior applies.
+
+  /** Number of content-size units (ProseMirror `content.size`) in the snapshot
+   *  document that was passed to `onSend`. Used to compute the deletion range
+   *  when removing the sent portion from the live doc. */
+  snapshotContentSize?: number;
+  /** Remove the already-sent snapshot range from the live editor document,
+   *  preserving any content the user typed after the snapshot. */
+  removeSentContent?: () => void;
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -143,17 +160,21 @@ export async function runSendWithCleanup(
   if (!cleanup.isEditorUnchanged()) {
     // The user started a new draft while the older send was in flight. We must
     // NOT clear the editor — doing so would wipe the newly typed draft (the
-    // round-2 data-loss bug). We deliberately leave the live document as-is.
+    // round-2 data-loss bug).
     //
-    // Known residual edge case (octo-web#227, tracked as a follow-up): the live
-    // editor now holds [already-sent snapshot blocks] + [new draft]. The
-    // already-sent blocks are NOT auto-removed here, so if the user presses send
-    // again those blocks are re-sent → a duplicate of the previous message. The
-    // message was delivered and the leftover content is visible to the user, so
-    // per the team's severity call this is accepted for now over the worse
-    // "draft wiped" failure. A precise fix (remove only the submitted snapshot
-    // range from the live doc, mirroring the by-id removeTopAttachments path)
-    // is deferred to a dedicated PR with its own ProseMirror-position tests.
+    // octo-web#458 fix: when the caller provided `removeSentContent`, surgically
+    // remove only the already-sent snapshot range from the editor, preserving
+    // the new draft. This eliminates the "sent text lingers in the input box"
+    // residual without re-introducing the round-2 data loss.
+    //
+    // When `removeSentContent` is not provided (older callers), fall back to
+    // the original "leave as-is" behavior.
+    if (cleanup.removeSentContent) {
+      cleanup.removeSentContent();
+      cleanup.deleteEditorAttachmentRefs();
+      cleanup.revokeEditorPreviewUrls();
+      cleanup.collapseExpanded?.();
+    }
     return true;
   }
 


### PR DESCRIPTION
## Root Cause

When the user typed a new draft while the previous send was still in flight (slow upload / ack latency), the `!isEditorUnchanged()` branch in `runSendWithCleanup` deliberately left the entire live doc untouched to avoid wiping the new draft — but the already-sent text portion was never surgically removed. This is the known residual of the #227 round-2 snapshot-aware cleanup.

The fix direction was identified in [MrAladdin's root-cause analysis](https://github.com/Mininglamp-OSS/octo-web/issues/458#issuecomment-4808039009): remove only the submitted snapshot range while preserving the new draft.

## Fix

Extend `SendCleanup` with two optional, backward-compatible fields:
- `snapshotContentSize`: ProseMirror `content.size` of the snapshot taken at send time
- `removeSentContent()`: callback that surgically deletes positions `0→snapshotContentSize` from the live editor, preserving any content the user typed after the snapshot

The caller (`MessageInput/index.tsx`) now:
1. Captures `snapshotContentSize` from `editor.state.doc.content.size` before the send
2. Implements `removeSentContent` via a ProseMirror `tr.delete(0, snapshotContentSize)` — removes the old sent portion, keeps the new draft

When the editor changed mid-flight and `removeSentContent` is provided, `runSendWithCleanup` calls it (plus attachment ref/URL cleanup) instead of leaving the doc untouched.

## Backward Compatibility

- Both new fields are optional on `SendCleanup`
- Callers that don't provide `removeSentContent` get the original "leave as-is" behavior
- All 13 existing test contracts remain green
- 6 new tests cover the partial-removal path

## Test Coverage

New test describe block: `runSendWithCleanup — octo-web#458: partial editor cleanup when draft changed mid-flight`

| Test | What it verifies |
|---|---|
| `calls removeSentContent (not clearEditor) when editor changed AND removeSentContent is provided` | New path: surgical removal, no full clear |
| `falls back to leave-as-is when editor changed but removeSentContent is NOT provided` | Backward compat for older callers |
| `does NOT call removeSentContent when editor is unchanged (normal full-clear path)` | Normal path unaffected |
| `still removes consumed top attachments by id when using removeSentContent path` | Top attachments still handled correctly |
| `does NOT call removeSentContent when send resolved false (preserve draft for retry)` | Send failure → preserve everything |
| `calls collapseExpanded via removeSentContent path when editor changed mid-flight` | Collapse still works in new path |

## Files Changed

- `packages/dmworkbase/src/Components/MessageInput/sendFlow.ts` — interface + logic
- `packages/dmworkbase/src/Components/MessageInput/index.tsx` — caller integration
- `packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts` — 6 new tests

Fixes #458