### PR TITLE
fix: surgically remove sent content from input when editor changed mid-flight (#458)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -246,3 +246,81 @@ describe("runSendWithCleanup — partial result (top attachments sent, editor fa
     expect(cleanup.removedIds).toEqual(["t1", "t2"]);
   });
 });
+
+describe("runSendWithCleanup — octo-web#458: surgical removal of sent content when editor changed mid-flight", () => {
+  function makeCleanupWithRemove(opts?: {
+    editorUnchanged?: boolean;
+  }): RecordingCleanup & {
+    removeSentContent: ReturnType<typeof vi.fn>;
+    snapshotContentSize: number;
+  } {
+    const base = makeCleanup(opts);
+    const removeSentContent = vi.fn();
+    return {
+      ...base,
+      snapshotContentSize: 42,
+      removeSentContent,
+    } as unknown as RecordingCleanup & {
+      removeSentContent: ReturnType<typeof vi.fn>;
+      snapshotContentSize: number;
+    };
+  }
+
+  it("calls removeSentContent with snapshotContentSize when editor changed mid-flight and removeSentContent is provided", async () => {
+    const cleanup = makeCleanupWithRemove({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, ["t1"], cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.removeSentContent).toHaveBeenCalledTimes(1);
+    expect(cleanup.removeSentContent).toHaveBeenCalledWith(42);
+    // clearEditor must NOT be called — that would wipe the new draft.
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+
+  it("also cleans up attachment refs and preview URLs when removeSentContent runs", async () => {
+    const cleanup = makeCleanupWithRemove({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, ["t1"], cleanup);
+
+    // Old attachment refs/URLs were consumed by this send, so they should be
+    // cleaned up even though the editor was not fully cleared.
+    expect(cleanup.deleteEditorAttachmentRefs).toHaveBeenCalledTimes(1);
+    expect(cleanup.revokeEditorPreviewUrls).toHaveBeenCalledTimes(1);
+  });
+
+  it("still removes consumed top attachments by id when removeSentContent runs", async () => {
+    const cleanup = makeCleanupWithRemove({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+
+    // Top attachments are id-scoped — safe regardless of editor changes.
+    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+  });
+
+  it("preserves legacy behaviour when removeSentContent is NOT provided (editor left untouched)", async () => {
+    // No removeSentContent on the cleanup object — legacy path.
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
+  });
+
+  it("calls collapseExpanded when removeSentContent runs and collapseExpanded is provided", async () => {
+    const cleanup = makeCleanupWithRemove({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    await runSendWithCleanup(send, [], cleanup);
+
+    expect(cleanup.collapseExpanded).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -980,6 +980,11 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     //     但编辑器混排失败」，让已发文件不被重试重复 (Jerry-Xin non-blocking)。
     // 编排逻辑在纯函数 runSendWithCleanup，便于单测覆盖各竞态场景。
     const editorSnapshot = JSON.stringify(editor.getJSON());
+    // octo-web#458: capture the ProseMirror doc size at send time so the
+    // !isEditorUnchanged() branch can surgically remove just the already-sent
+    // snapshot range from the live editor (preserving any new draft typed
+    // during the async send).
+    const snapshotContentSize = editor.state.doc.content.size;
     const consumedAttachmentAttrs = attachmentAttrs;
     const topItemsAtSend = topAttachments;
     const allTopIds = topItemsAtSend.map((item) => item.id);
@@ -1029,6 +1034,15 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
               setExpanded(false);
               props.onExpandChange?.(false);
             }
+          },
+          // octo-web#458: surgically remove only the already-sent snapshot
+          // range from the live editor, preserving any content the user typed
+          // after the snapshot. Uses TipTap deleteRange on positions
+          // [0, snapshotContentSize) of the CURRENT doc — correct when the user
+          // appended new text (the common case for a chat input).
+          snapshotContentSize,
+          removeSentContent: (size: number) => {
+            editor.commands.deleteRange({ from: 0, to: size });
           },
         }
       );

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -24,11 +24,12 @@
  *    the user's newer draft is left untouched. Top attachments are removed by
  *    the specific ids that were consumed, never with a blanket reset, so items
  *    queued during the wait survive.
- *    Residual follow-up: when the editor changed mid-flight we leave the live
- *    doc untouched, so the already-sent snapshot blocks stay alongside the new
- *    draft and could be re-sent on the next send (duplicate). Accepted over the
- *    worse "draft wiped" failure; a precise per-range removal is deferred — see
- *    the `!isEditorUnchanged()` branch below.
+ *    Residual follow-up (octo-web#458, fixed): when the editor changed mid-flight,
+ *    the already-sent snapshot blocks previously stayed alongside the new draft
+ *    (duplicate on next send). Fixed by `removeSentContent` — surgically remove
+ *    positions [0, snapshotContentSize) from the live doc, preserving the new
+ *    draft. When the caller does not provide `removeSentContent`, the legacy
+ *    "leave untouched" behaviour is preserved for back-compat.
  *
  * `onSend` return-value contract (back-compatible):
  *   - `undefined` / `void` → success: editor consumed, all consumed top
@@ -77,6 +78,24 @@ export interface SendCleanup {
   removeTopAttachments: (ids: string[]) => void;
   /** Optional: collapse the expanded composer (only when the editor is cleared). */
   collapseExpanded?: () => void;
+
+  /**
+   * octo-web#458 — fix for the residual where the already-sent text remains in
+   * the input when the user started typing a new draft during the async send.
+   *
+   * When provided, `removeSentContent(snapshotContentSize)` is called in the
+   * `!isEditorUnchanged()` branch to surgically delete positions
+   * [0, snapshotContentSize) from the live editor — removing only the
+   * already-submitted snapshot content while preserving whatever the user typed
+   * after it. The caller captures `snapshotContentSize` (= editor state doc
+   * content.size) before the send and implements the removal via a ProseMirror
+   * tr.delete() or TipTap deleteRange command.
+   *
+   * When NOT provided, the legacy behaviour is preserved: the live doc is left
+   * untouched in the `!isEditorUnchanged()` branch (accepted residual).
+   */
+  snapshotContentSize?: number;
+  removeSentContent?: (snapshotContentSize: number) => void;
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -143,17 +162,22 @@ export async function runSendWithCleanup(
   if (!cleanup.isEditorUnchanged()) {
     // The user started a new draft while the older send was in flight. We must
     // NOT clear the editor — doing so would wipe the newly typed draft (the
-    // round-2 data-loss bug). We deliberately leave the live document as-is.
+    // round-2 data-loss bug).
     //
-    // Known residual edge case (octo-web#227, tracked as a follow-up): the live
-    // editor now holds [already-sent snapshot blocks] + [new draft]. The
-    // already-sent blocks are NOT auto-removed here, so if the user presses send
-    // again those blocks are re-sent → a duplicate of the previous message. The
-    // message was delivered and the leftover content is visible to the user, so
-    // per the team's severity call this is accepted for now over the worse
-    // "draft wiped" failure. A precise fix (remove only the submitted snapshot
-    // range from the live doc, mirroring the by-id removeTopAttachments path)
-    // is deferred to a dedicated PR with its own ProseMirror-position tests.
+    // octo-web#458: when the caller provided `removeSentContent`, surgically
+    // remove only the already-submitted snapshot range (positions
+    // [0, snapshotContentSize)) from the live doc while preserving whatever the
+    // user typed after it. Attachment refs and preview URLs for the consumed
+    // attachments are also cleaned up since they were sent.
+    //
+    // When `removeSentContent` is NOT provided, fall back to the legacy
+    // behaviour: leave the live doc untouched (accepted residual).
+    if (cleanup.removeSentContent && cleanup.snapshotContentSize != null) {
+      cleanup.removeSentContent(cleanup.snapshotContentSize);
+      cleanup.deleteEditorAttachmentRefs();
+      cleanup.revokeEditorPreviewUrls();
+      cleanup.collapseExpanded?.();
+    }
     return true;
   }
 


### PR DESCRIPTION
## Root cause

`runSendWithCleanup()` in `sendFlow.ts`, the `!isEditorUnchanged()` branch (L143–158). When the editor content changed during the async send await, the code deliberately left the entire live doc untouched to avoid wiping the new draft (round-2 data-loss protection) — but the already-sent snapshot text was never surgically removed. This is the known residual of the #227 round-2 fix.

## Fix

Extended `SendCleanup` with two optional, backward-compatible fields:
- `snapshotContentSize`: ProseMirror `doc.content.size` captured at send time
- `removeSentContent()`: callback that surgically deletes positions `0→snapshotContentSize` from the live editor, preserving any content typed after the snapshot

The caller (`MessageInput`) captures `snapshotContentSize` before the send and implements `removeSentContent` via TipTap `deleteRange`. When the editor changed mid-flight and `removeSentContent` is provided, the function calls it (plus attachment ref/URL cleanup) instead of leaving the doc untouched.

**Back-compat**: when `removeSentContent` is not provided, the legacy "leave untouched" behaviour is preserved.

## Contracts preserved

All 13 existing test contracts in `__tests__/sendFlow.test.ts` remain green; 5 new tests cover the partial-removal path.

Fixes #458