### PR TITLE
fix: eliminate duplicate batch-status polling from sidebar (#334)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -29,6 +29,11 @@ export default class ChatSummaryHistory extends Component<
     private abortController: AbortController | null = null;
     private pollTimer: ReturnType<typeof setInterval> | null = null;
     private isPolling = false;
+    // GH #334: heartbeat coordination with SummaryListPage.
+    // When the main summary list is already polling the same taskIds,
+    // suppress this sidebar poll to avoid duplicate batch-status requests.
+    private lastHeartbeatAt = 0;
+    private heartbeatTaskIds: Set<number> = new Set();
 
     constructor(props: ChatSummaryHistoryProps) {
         super(props);
@@ -39,6 +44,7 @@ export default class ChatSummaryHistory extends Component<
         void this.loadHistory();
         window.addEventListener('chat-summary-created', this.handleChange as EventListener);
         window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.addEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat);
     }
 
     componentWillUnmount() {
@@ -46,6 +52,7 @@ export default class ChatSummaryHistory extends Component<
         this.stopPoll();
         window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
         window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.removeEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat);
     }
 
     componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
@@ -93,9 +100,22 @@ export default class ChatSummaryHistory extends Component<
 
     private async doPoll(taskIds: number[]) {
         if (this.isPolling) return;
+        // GH #334: skip poll when another poller (SummaryListPage) already covers
+        // the same taskIds via the heartbeat protocol. Heartbeat expires after 15s
+        // of silence — if the main list unmounts or stops polling, sidebar resumes.
+        if (
+            this.heartbeatTaskIds.size > 0 &&
+            taskIds.some(id => this.heartbeatTaskIds.has(id)) &&
+            Date.now() - this.lastHeartbeatAt < 15000
+        ) {
+            return;
+        }
         this.isPolling = true;
         try {
             const updates = await summaryApi.batchStatus(taskIds);
+            // GH #334: emit heartbeat so SummaryDetailPage can suppress its
+            // fallback poll when the sidebar is actively covering these taskIds.
+            window.dispatchEvent(new CustomEvent('summary-batch-heartbeat', { detail: { taskIds } }));
             const updateMap = new Map(updates.map(u => [u.id, u]));
             let changed = false;
             const newItems = this.state.items.map(item => {
@@ -115,6 +135,15 @@ export default class ChatSummaryHistory extends Component<
             this.isPolling = false;
         }
     }
+
+    // GH #334: heartbeat listener — SummaryListPage emits this after each of its
+    // polls. Record the covered taskIds + timestamp so doPoll can dedup.
+    private handleBatchHeartbeat = (event: Event) => {
+        const detail = (event as CustomEvent).detail;
+        if (!detail?.taskIds) return;
+        this.heartbeatTaskIds = new Set(detail.taskIds as number[]);
+        this.lastHeartbeatAt = Date.now();
+    };
 
     private handleChange = (e: CustomEvent<{ channelId: string }>) => {
         if (e.detail?.channelId === this.props.channel.channelID) {

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -429,5 +429,111 @@ describe('ChatSummaryHistory', () => {
 
             expect(mockBatchStatus).not.toHaveBeenCalled();
         });
+
+        // GH #334: ChatSummaryHistory must honour summary-batch-heartbeat from
+        // SummaryListPage — when the main list already polls the same taskIds,
+        // the sidebar poll is redundant and must be suppressed.
+        it('suppresses its own batch-status poll when summary-batch-heartbeat covers the same taskIds', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 42, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 42, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Simulate SummaryListPage emitting a heartbeat that covers task 42
+            // (the same taskId the sidebar would poll).
+            window.dispatchEvent(
+                new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [42] } }),
+            );
+
+            mockBatchStatus.mockClear();
+
+            // Advance past the 5s poll interval — sidebar must NOT call batchStatus
+            // because the heartbeat signals the main list already covers task 42.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        // GH #334: when a heartbeat fires with non-overlapping taskIds, the
+        // sidebar should NOT be suppressed (its taskIds are independent).
+        it('continues polling when heartbeat covers different taskIds', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 42, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 42, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Heartbeat covers a DIFFERENT taskId — sidebar poll must not be suppressed.
+            window.dispatchEvent(
+                new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [999] } }),
+            );
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            expect(mockBatchStatus).toHaveBeenCalledWith([42]);
+        });
+
+        it('dispatches summary-batch-heartbeat after its own poll so SummaryDetailPage can suppress fallback', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 7, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 7, status: 2, progress: 30, updated_at: '' }]);
+
+            const heartbeatListener = vi.fn();
+            window.addEventListener('summary-batch-heartbeat', heartbeatListener);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            heartbeatListener.mockClear();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            // Sidebar poll happened
+            expect(mockBatchStatus).toHaveBeenCalledWith([7]);
+
+            // Sidebar should have dispatched a heartbeat covering task 7
+            const heartbeatCalls = heartbeatListener.mock.calls.filter(
+                (c) => (c[0] as CustomEvent).detail?.taskIds?.includes(7),
+            );
+            expect(heartbeatCalls.length).toBeGreaterThanOrEqual(1);
+
+            window.removeEventListener('summary-batch-heartbeat', heartbeatListener);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fixes duplicate `POST /summaries/batch-status` polling when the sidebar smart summary panel and main summary tab are both visible.

## Root Cause

`ChatSummaryHistory` (sidebar) ran its own 5s `setInterval` → `batchStatus()` independently of the `summary-batch-heartbeat` coordination protocol used between `SummaryListPage` and `SummaryDetailPage`. When both the tab and sidebar were showing, two separate pollers hit the same batch-status endpoint for overlapping taskIds at different cadences (2s + 5s).

## Fix

Brings `ChatSummaryHistory` into the existing heartbeat protocol:

1. **Listener**: On receiving `summary-batch-heartbeat` from `SummaryListPage`, record the covered taskIds + timestamp. Skip sidebar poll when the same taskIds are already being polled and the heartbeat is fresh (< 15s).

2. **Dispatcher**: After each successful sidebar poll, dispatch `summary-batch-heartbeat` so `SummaryDetailPage`'s fallback poller can also be suppressed.

3. **15s expiry**: If no heartbeats arrive for 15s (e.g., main list unmounted or stopped polling), the sidebar resumes its own polling — a safety net against over-suppression.

## Changes

| File | Change |
|---|---|
| `ChatSummaryHistory.tsx` | Added heartbeat listener + dispatch + 15s expiry guard (~20 lines) |
| `ChatSummaryHistory.test.tsx` | 3 new tests: heartbeat suppression, heartbeat dispatch, non-overlapping IDs don't suppress |

## Test Plan

- [x] New test: heartbeat with overlapping taskIds suppresses sidebar poll
- [x] New test: sidebar dispatches heartbeat after its own poll
- [x] New test: heartbeat with non-overlapping taskIds does NOT suppress sidebar poll
- [x] All 14 existing `ChatSummaryHistory` tests still pass
- [ ] Manual verification: open sidebar + tab, confirm single batch-status stream in DevTools Network

Fixes #334