### PR TITLE
fix(summary): integrate sidebar into heartbeat protocol to eliminate duplicate polling (#334)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -29,6 +29,14 @@ export default class ChatSummaryHistory extends Component<
     private abortController: AbortController | null = null;
     private pollTimer: ReturnType<typeof setInterval> | null = null;
     private isPolling = false;
+    /**
+     * Fix #334: Track whether SummaryListPage is actively polling the same task IDs.
+     * When the main summary list is running batch-status polls, the sidebar skips
+     * its own redundant polling and relies on summary-status-change events instead.
+     * Reset when SummaryListPage unmounts (summary-list-unmount event) so sidebar
+     * resumes polling when the main list is no longer active.
+     */
+    private listPageActive_ = false;
 
     constructor(props: ChatSummaryHistoryProps) {
         super(props);
@@ -39,6 +47,10 @@ export default class ChatSummaryHistory extends Component<
         void this.loadHistory();
         window.addEventListener('chat-summary-created', this.handleChange as EventListener);
         window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        // Fix #334: Coordinate with SummaryListPage polling to avoid duplicate batch-status calls.
+        window.addEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat_ as EventListener);
+        window.addEventListener('summary-status-change', this.handleStatusChange_ as EventListener);
+        window.addEventListener('summary-list-unmount', this.handleListPageUnmount_ as EventListener);
     }
 
     componentWillUnmount() {
@@ -46,6 +58,9 @@ export default class ChatSummaryHistory extends Component<
         this.stopPoll();
         window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
         window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.removeEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat_ as EventListener);
+        window.removeEventListener('summary-status-change', this.handleStatusChange_ as EventListener);
+        window.removeEventListener('summary-list-unmount', this.handleListPageUnmount_ as EventListener);
     }
 
     componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
@@ -74,12 +89,18 @@ export default class ChatSummaryHistory extends Component<
         this.stopPoll();
         if (this.props.paused) return;
         if (this.getActiveTaskIds().length === 0) return;
+        // Fix #334: Don't start polling when SummaryListPage is actively doing it.
+        // The list page dispatches summary-list-unmount on cleanup, which resets
+        // listPageActive_ so polling can resume.
+        if (this.listPageActive_) return;
         this.pollTimer = setInterval(() => {
             const ids = this.getActiveTaskIds();
             if (ids.length === 0) {
                 this.stopPoll();
                 return;
             }
+            // Fix #334: Skip this tick if list page is still active.
+            if (this.listPageActive_) return;
             void this.doPoll(ids);
         }, 5000);
     }
@@ -159,6 +180,44 @@ export default class ChatSummaryHistory extends Component<
             // Surface the failure; the item stays in the list if deletion fails.
             Toast.error(this.context.t('summary.common.deleteFailed'));
         }
+    };
+
+    /**
+     * Fix #334: When SummaryListPage sends a heartbeat for task IDs we're also tracking,
+     * suppress our own redundant polling. We receive status updates via
+     * summary-status-change events dispatched by the list page instead.
+     */
+    private handleBatchHeartbeat_ = (e: Event) => {
+        const taskIds: number[] | undefined = (e as CustomEvent).detail?.taskIds;
+        if (!taskIds) return;
+        const myIds = this.getActiveTaskIds();
+        const overlap = taskIds.some(id => myIds.includes(id));
+        if (!overlap) return;
+        this.listPageActive_ = true;
+        this.stopPoll();
+    };
+
+    /**
+     * Fix #334: When SummaryListPage unmounts (user navigates away from main summary
+     * tab), reset the active flag and resume polling if we have active tasks.
+     */
+    private handleListPageUnmount_ = () => {
+        this.listPageActive_ = false;
+        this.maybeStartPoll();
+    };
+
+    /**
+     * Fix #334: When SummaryListPage detects a status change for tasks we're tracking,
+     * reload our history to reflect the updated statuses without making our own
+     * batch-status API call.
+     */
+    private handleStatusChange_ = (e: Event) => {
+        const taskIds: number[] | undefined = (e as CustomEvent).detail?.taskIds;
+        if (!taskIds) return;
+        const myIds = this.state.items.map(item => item.task_id);
+        const overlap = taskIds.some(id => myIds.includes(id));
+        if (!overlap) return;
+        void this.loadHistory();
     };
 
     render() {

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -429,5 +429,105 @@ describe('ChatSummaryHistory', () => {
 
             expect(mockBatchStatus).not.toHaveBeenCalled();
         });
+
+        it('skips polling when summary-batch-heartbeat arrives for overlapping task IDs', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Simulate SummaryListPage sending a heartbeat for our task ID
+            window.dispatchEvent(
+                new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1] } }),
+            );
+
+            mockBatchStatus.mockClear();
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+
+            // Sidebar should NOT poll because heartbeat indicates list page is active
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('resumes polling after summary-list-unmount resets active flag', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 1, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Send heartbeat → sidebar stops polling
+            window.dispatchEvent(
+                new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [1] } }),
+            );
+
+            mockBatchStatus.mockClear();
+
+            // Sidebar should NOT poll while list page is active
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+
+            // List page unmounts → sidebar should resume polling
+            window.dispatchEvent(new CustomEvent('summary-list-unmount'));
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(6000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalled();
+        });
+
+        it('reloads history on summary-status-change for overlapping task IDs', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 1, status: 2 })],
+            });
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            mockListSummaries.mockClear();
+
+            // Simulate SummaryListPage detecting a status change for our task
+            await act(async () => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-status-change', { detail: { taskIds: [1] } }),
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Sidebar should reload its history to reflect the change
+            expect(mockListSummaries).toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
<!-- multica:verify v1 -->

## Summary

Fix #334 — `ChatSummaryHistory` (sidebar) ran its own 5s polling → `batchStatus()` completely outside the `summary-batch-heartbeat` coordination protocol. When sidebar and main summary tab were both visible, they independently polled overlapping task batches, causing redundant API calls.

## Root cause

- `SummaryListPage.tsx:152` dispatches `summary-batch-heartbeat` every poll ✅
- `SummaryDetailPage.tsx:137` listens to `summary-batch-heartbeat` ✅
- `ChatSummaryHistory.tsx` — neither sends nor receives ❌ (completely outside coordination)

## Fix

Integrate `ChatSummaryHistory` into the existing heartbeat protocol:

1. **Listen to `summary-batch-heartbeat`** from `SummaryListPage` — when task IDs overlap, set `listPageActive_ = true` and stop own polling
2. **Listen to `summary-status-change`** from `SummaryListPage` — when changed task IDs overlap, reload history via `listSummaries()` (no duplicate batch-status call)
3. **Listen to `summary-list-unmount`** — `SummaryListPage` already dispatches this on `componentWillUnmount`; use it to reset `listPageActive_` and resume polling

Design decision: event-driven coordination (no `Date.now()` timeout). The sidebar's poll state is a pure function of list page lifecycle events — simpler, deterministic, fully testable with fake timers.

## Changes

| File | Change |
|---|---|
| `ChatSummaryHistory.tsx` | Add 3 event listeners, `listPageActive_` flag, suppress/resume logic |
| `ChatSummaryHistory.test.tsx` | Add 3 tests: heartbeat suppression, unmount resume, status-change reload |

## Verification

- [x] All 14 tests in `ChatSummaryHistory.test.tsx` pass (11 existing + 3 new)
- [x] `SummaryListPage` and `SummaryDetailPage` heartbeat logic unchanged
- [x] Sidebar falls back to independent polling when list page is not mounted (no regression)

Fixes #334