### PR TITLE
fix: integrate ChatSummaryHistory into heartbeat protocol (#334)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryHistory.tsx
@@ -29,6 +29,8 @@ export default class ChatSummaryHistory extends Component<
     private abortController: AbortController | null = null;
     private pollTimer: ReturnType<typeof setInterval> | null = null;
     private isPolling = false;
+    private heartbeatCoveredTaskIds: Set<number> = new Set();
+    private lastHeartbeatTime = 0;
 
     constructor(props: ChatSummaryHistoryProps) {
         super(props);
@@ -39,6 +41,7 @@ export default class ChatSummaryHistory extends Component<
         void this.loadHistory();
         window.addEventListener('chat-summary-created', this.handleChange as EventListener);
         window.addEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.addEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
     }
 
     componentWillUnmount() {
@@ -46,6 +49,7 @@ export default class ChatSummaryHistory extends Component<
         this.stopPoll();
         window.removeEventListener('chat-summary-created', this.handleChange as EventListener);
         window.removeEventListener('chat-summary-deleted', this.handleChange as EventListener);
+        window.removeEventListener('summary-batch-heartbeat', this.handleBatchHeartbeat as EventListener);
     }
 
     componentDidUpdate(prevProps: ChatSummaryHistoryProps) {
@@ -80,6 +84,15 @@ export default class ChatSummaryHistory extends Component<
                 this.stopPoll();
                 return;
             }
+            // Skip this poll cycle when another heartbeat-aware poller (e.g.
+            // SummaryListPage) recently covered all our active taskIds (issue #334).
+            if (
+                this.lastHeartbeatTime > 0 &&
+                Date.now() - this.lastHeartbeatTime < 10000 &&
+                ids.every(id => this.heartbeatCoveredTaskIds.has(id))
+            ) {
+                return;
+            }
             void this.doPoll(ids);
         }, 5000);
     }
@@ -96,6 +109,9 @@ export default class ChatSummaryHistory extends Component<
         this.isPolling = true;
         try {
             const updates = await summaryApi.batchStatus(taskIds);
+            // Broadcast heartbeat so SummaryDetailPage (and other heartbeat-aware
+            // pollers) can suppress their own redundant polling for these taskIds.
+            window.dispatchEvent(new CustomEvent('summary-batch-heartbeat', { detail: { taskIds } }));
             const updateMap = new Map(updates.map(u => [u.id, u]));
             let changed = false;
             const newItems = this.state.items.map(item => {
@@ -120,6 +136,19 @@ export default class ChatSummaryHistory extends Component<
         if (e.detail?.channelId === this.props.channel.channelID) {
             void this.loadHistory();
         }
+    };
+
+    /**
+     * Heartbeat coordination (issue #334): when another poller (e.g.
+     * SummaryListPage) broadcasts that it is covering certain taskIds, record
+     * them and the timestamp so our timer loop can skip redundant polls while
+     * the heartbeat remains fresh (< 10 s old).
+     */
+    private handleBatchHeartbeat = (event: Event) => {
+        const taskIds: number[] | undefined = (event as CustomEvent).detail?.taskIds;
+        if (!taskIds || taskIds.length === 0) return;
+        this.heartbeatCoveredTaskIds = new Set(taskIds);
+        this.lastHeartbeatTime = Date.now();
     };
 
     private async loadHistory() {

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx
@@ -250,6 +250,7 @@ describe('ChatSummaryHistory', () => {
     describe('polling', () => {
         beforeEach(() => {
             vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
         });
 
         afterEach(() => {
@@ -428,6 +429,154 @@ describe('ChatSummaryHistory', () => {
             });
 
             expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('dispatches summary-batch-heartbeat after a successful poll', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 42, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 42, status: 2, progress: 50, updated_at: '' }]);
+
+            const dispatched: CustomEvent[] = [];
+            const listener = (e: Event) => dispatched.push(e as CustomEvent);
+            window.addEventListener('summary-batch-heartbeat', listener);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            expect(mockBatchStatus).toHaveBeenCalledWith([42]);
+            const heartbeat = dispatched.find(e => e.detail?.taskIds?.includes(42));
+            expect(heartbeat).toBeDefined();
+            expect(heartbeat!.detail.taskIds).toEqual([42]);
+
+            window.removeEventListener('summary-batch-heartbeat', listener);
+        });
+
+        it('skips poll when heartbeat covers all active taskIds', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 10, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 10, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Let the first poll fire so we know batchStatus works
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalledTimes(1);
+            mockBatchStatus.mockClear();
+
+            // Simulate SummaryListPage broadcasting a heartbeat covering taskId 10
+            act(() => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [10] } }),
+                );
+            });
+
+            // Advance within the heartbeat freshness window — sidebar should NOT call batchStatus
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(8000);
+            });
+
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+        });
+
+        it('resumes poll when no new heartbeat arrives after a skipped cycle', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [makeItem({ task_id: 10, status: 2 })],
+            });
+            mockBatchStatus.mockResolvedValue([{ id: 10, status: 2, progress: 50, updated_at: '' }]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Send a heartbeat — next poll cycle should be skipped
+            act(() => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [10] } }),
+                );
+            });
+
+            mockBatchStatus.mockClear();
+
+            // First poll cycle after heartbeat: suppressed
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).not.toHaveBeenCalled();
+
+            // No new heartbeat sent — next cycle resumes polling
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+            expect(mockBatchStatus).toHaveBeenCalled();
+        });
+
+        it('does not skip poll when heartbeat only partially covers active taskIds', async () => {
+            mockListSummaries.mockResolvedValue({
+                items: [
+                    makeItem({ task_id: 10, status: 2 }),
+                    makeItem({ task_id: 20, status: 2 }),
+                ],
+            });
+            mockBatchStatus.mockResolvedValue([]);
+
+            await act(async () => {
+                render(
+                    <ChatSummaryHistory
+                        channel={channel}
+                        onCreateNew={onCreateNew}
+                        onViewDetail={onViewDetail}
+                    />,
+                );
+                await vi.advanceTimersByTimeAsync(0);
+            });
+
+            // Heartbeat only covers taskId 10, not 20
+            act(() => {
+                window.dispatchEvent(
+                    new CustomEvent('summary-batch-heartbeat', { detail: { taskIds: [10] } }),
+                );
+            });
+
+            mockBatchStatus.mockClear();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(5000);
+            });
+
+            // Should still poll because taskId 20 is not covered
+            expect(mockBatchStatus).toHaveBeenCalledWith([10, 20]);
         });
     });
 });


### PR DESCRIPTION
## 根因 / 实现说明

- `ChatSummaryHistory`（侧边栏）的 5s `batchStatus` 轮询完全游离在 `summary-batch-heartbeat` 协调协议之外：既不发送心跳，也不监听心跳。当 `SummaryListPage`（2s）和/或 `SummaryDetailPage`（15s fallback）已经覆盖相同 taskId 时，sidebar 仍在独立发请求，造成重复的 batch-status 调用。

**修复**：把 `ChatSummaryHistory` 接入心跳协议——
1. **dispatch**：每次 `batchStatus` 成功后广播 `summary-batch-heartbeat`（与 `SummaryListPage` 行为一致），让 `SummaryDetailPage` 的 fallback poller 能感知到 sidebar 也在轮询。
2. **listen**：监听 `summary-batch-heartbeat`，当所有活跃 taskId 都已被其他 poller 覆盖且心跳在 10s 内，跳过本周期轮询。心跳过期（≥10s 无新心跳）后自动恢复。

## 改动摘要

- `packages/dmworksummary/src/components/ChatSummaryHistory.tsx`
  - 新增 `heartbeatCoveredTaskIds`、`lastHeartbeatTime` 实例字段
  - `componentDidMount` / `componentWillUnmount` 注册/注销 `summary-batch-heartbeat` 监听
  - `doPoll()` 成功后 dispatch `summary-batch-heartbeat`
  - `maybeStartPoll()` 定时器回调中增加心跳抑制判断

- `packages/dmworksummary/src/components/__tests__/ChatSummaryHistory.test.tsx`
  - 新增 4 个测试：心跳 dispatch、心跳抑制、心跳过期后恢复、部分覆盖不抑制

## 测试

- 新增单元测试 4 项 ✓
- 原有 11 项 polling/render 测试 ✓
- 全部 15 项 `ChatSummaryHistory` 测试通过

## 验证 (baseline diff, charter §6)

- after − baseline = 0 new failures
- 噪音 (两侧都有): ChatSummaryPanel resizable splitter (4 tests, pre-existing localStorage/jsdom 环境问题)

Fixes #334
