### PR TITLE
chore(ci): activate lint gate — make pnpm lint a real ESLint pass

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,10 @@
-// module.exports = {
-//   root: true,
-//   // This tells ESLint to load the config from the package `eslint-config-custom`
-//   extends: ["custom"],
-//   settings: {
-//     next: {
-//       rootDir: ["apps/*/"],
-//     },
-//   },
-// };
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,8 @@
     "tauri": "tauri",
     "storybook": "storybook dev -p 16006",
     "build-storybook": "storybook build",
-    "test:storybook": "vitest run --config vitest.storybook.config.ts"
+    "test:storybook": "vitest run --config vitest.storybook.config.ts",
+    "lint": "eslint src/ --ext .ts,.tsx --resolve-plugins-relative-to ../.."
   },
   "dependencies": {
     "@dmwork/appbot": "workspace:*",

--- a/apps/web/src/__tests__/NavVoiceFeedbackItem.test.tsx
+++ b/apps/web/src/__tests__/NavVoiceFeedbackItem.test.tsx
@@ -2,6 +2,8 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import React from "react";
 
+import NavVoiceFeedbackItem from "@octo/base/src/Components/NavRail/NavVoiceFeedbackItem";
+
 const mockUseSpaceFeedbackSetting = vi.fn();
 
 vi.mock("@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting", () => ({
@@ -37,8 +39,6 @@ vi.mock("@douyinfe/semi-icons", () => ({
     return React.createElement("span", { "data-testid": "help-icon" });
   },
 }));
-
-import NavVoiceFeedbackItem from "@octo/base/src/Components/NavRail/NavVoiceFeedbackItem";
 
 describe("NavVoiceFeedbackItem", () => {
   beforeEach(() => {

--- a/apps/web/src/__tests__/components/BotManage.test.tsx
+++ b/apps/web/src/__tests__/components/BotManage.test.tsx
@@ -19,6 +19,10 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
+import BotManageMenu from '../../../../../packages/dmworkbase/src/Components/BotManage/BotManageMenu';
+import MentionFreeList from '../../../../../packages/dmworkbase/src/Components/BotManage/MentionFreeList';
+import { MentionFreeVM } from '../../../../../packages/dmworkbase/src/Components/BotManage/vm';
+
 const mocks = vi.hoisted(() => ({
     apiGet: vi.fn(),
     apiPut: vi.fn(),
@@ -89,10 +93,6 @@ vi.mock('../../../../../packages/dmworkbase/src/i18n', async () => {
         useI18n: () => ({ t: translate }),
     };
 });
-
-import BotManageMenu from '../../../../../packages/dmworkbase/src/Components/BotManage/BotManageMenu';
-import MentionFreeList from '../../../../../packages/dmworkbase/src/Components/BotManage/MentionFreeList';
-import { MentionFreeVM } from '../../../../../packages/dmworkbase/src/Components/BotManage/vm';
 
 beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/__tests__/components/SearchResultExternalSuffix.test.tsx
+++ b/apps/web/src/__tests__/components/SearchResultExternalSuffix.test.tsx
@@ -13,6 +13,9 @@
 
 import { vi } from 'vitest';
 
+// 直接引用 resolver 源文件，避免 barrel 把浏览器依赖拉进 jsdom。
+import { resolveExternalForViewer } from '../../../../../packages/dmworkbase/src/Utils/externalViewer';
+
 // hoisted mock：避开 packages/dmworkbase/App 入口的浏览器副作用（lottie/Howler）。
 vi.mock('../../../../../packages/dmworkbase/src/App', () => ({
   default: {
@@ -21,9 +24,6 @@ vi.mock('../../../../../packages/dmworkbase/src/App', () => ({
     },
   },
 }));
-
-// 直接引用 resolver 源文件，避免 barrel 把浏览器依赖拉进 jsdom。
-import { resolveExternalForViewer } from '../../../../../packages/dmworkbase/src/Utils/externalViewer';
 
 // tab-contacts 适配镜像：friend 顶层 / orgData → resolver 入参。
 function computeContactSuffix(friend: any): string {

--- a/apps/web/src/__tests__/components/WKBaseBotProfileRouting.test.tsx
+++ b/apps/web/src/__tests__/components/WKBaseBotProfileRouting.test.tsx
@@ -2,6 +2,38 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import React, { Component } from 'react';
 import { act, render } from '@testing-library/react';
 
+// Import SUT after the mock is declared.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { UserInfoRouter } from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
+import {
+    createUserInfoRouter,
+    UserInfoDispatch,
+} from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
+
+// ---------------------------------------------------------------------------
+// round-4 blocker: external-viewer gate for bot routing.
+//
+// When UserInfoVM.isExternalToViewer would return true for a bot (cross-space
+// external group click), the router MUST demote isBot=false so the caller
+// keeps using the UserInfo path — UserInfo.getBottomPanel then renders the
+// existing "仅可在群内交流" hint. Without this demotion, a bot in an
+// external group would open BotDetailModal (which decides 发送消息 / 添加好友
+// from follow state alone) and bypass the UI guard.
+//
+// Tests below construct UserInfoRouter directly (not via createUserInfoRouter)
+// so a stub ExternalViewerGate can be injected without importing WKApp /
+// resolveExternalForViewer — that dependency chain belongs to WKBase, not
+// this helper. The host component records the last dispatch's isBot flag so
+// we can assert "bot demoted → user route" regardless of rendering details.
+// ---------------------------------------------------------------------------
+
+import {
+    ExternalViewerGate,
+    UserInfoRouter as UserInfoRouterClass,
+    ChannelManagerLike,
+} from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
+import { Channel as ChannelCtor } from 'wukongimjssdk';
+
 /**
  * Integration tests for the production routing + stale-guard used by
  * WKBase.showUserInfo (GH Mininglamp-OSS/octo-web#1112, PR#1113).
@@ -70,14 +102,6 @@ vi.mock('wukongimjssdk', () => {
         ChannelTypePerson: 1,
     };
 });
-
-// Import SUT after the mock is declared.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { UserInfoRouter } from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
-import {
-    createUserInfoRouter,
-    UserInfoDispatch,
-} from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
 
 /**
  * Host component that wires the production router exactly the way WKBase does:
@@ -277,30 +301,6 @@ describe('WKBase.showUserInfo production helper: routing + stale-guard (GH#1112)
         errSpy.mockRestore();
     });
 });
-
-// ---------------------------------------------------------------------------
-// round-4 blocker: external-viewer gate for bot routing.
-//
-// When UserInfoVM.isExternalToViewer would return true for a bot (cross-space
-// external group click), the router MUST demote isBot=false so the caller
-// keeps using the UserInfo path — UserInfo.getBottomPanel then renders the
-// existing "仅可在群内交流" hint. Without this demotion, a bot in an
-// external group would open BotDetailModal (which decides 发送消息 / 添加好友
-// from follow state alone) and bypass the UI guard.
-//
-// Tests below construct UserInfoRouter directly (not via createUserInfoRouter)
-// so a stub ExternalViewerGate can be injected without importing WKApp /
-// resolveExternalForViewer — that dependency chain belongs to WKBase, not
-// this helper. The host component records the last dispatch's isBot flag so
-// we can assert "bot demoted → user route" regardless of rendering details.
-// ---------------------------------------------------------------------------
-
-import {
-    ExternalViewerGate,
-    UserInfoRouter as UserInfoRouterClass,
-    ChannelManagerLike,
-} from '../../../../../packages/dmworkbase/src/Components/WKBase/userInfoRouter';
-import { Channel as ChannelCtor } from 'wukongimjssdk';
 
 interface GatedHostState {
     modal: 'none' | 'bot' | 'user';

--- a/apps/web/src/__tests__/components/WKBaseSUTBotProfileRouting.test.tsx
+++ b/apps/web/src/__tests__/components/WKBaseSUTBotProfileRouting.test.tsx
@@ -2,6 +2,12 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
+// Import the real WKBase after the mocks are hoisted. This must come after
+// every vi.mock() above or the real deps would be evaluated first.
+import WKBase, {
+    WKBaseContext,
+} from '../../../../../packages/dmworkbase/src/Components/WKBase';
+
 /**
  * Round-3 regression tests for PR#1113.
  *
@@ -194,12 +200,6 @@ vi.mock(
         default: () => <div data-testid="conv-select-stub" />,
     }),
 );
-
-// Import the real WKBase after the mocks are hoisted. This must come after
-// every vi.mock() above or the real deps would be evaluated first.
-import WKBase, {
-    WKBaseContext,
-} from '../../../../../packages/dmworkbase/src/Components/WKBase';
 
 // Small harness that hands the WKBase context to the test so it can drive
 // showUserInfo without needing to synthesise click events on stubbed children.

--- a/apps/web/src/__tests__/download.test.ts
+++ b/apps/web/src/__tests__/download.test.ts
@@ -1,6 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { downloadFile, getPresignedDownloadUrl } from '../../../../packages/dmworkbase/src/Utils/download'
 
+import WKApp from '../../../../packages/dmworkbase/src/App'
+
 // Mock WKApp.apiClient
 vi.mock('../../../../packages/dmworkbase/src/App', () => ({
     default: {
@@ -9,8 +11,6 @@ vi.mock('../../../../packages/dmworkbase/src/App', () => ({
         },
     },
 }))
-
-import WKApp from '../../../../packages/dmworkbase/src/App'
 
 // Track anchors created by download functions
 let clickedAnchors: HTMLAnchorElement[] = []

--- a/apps/web/src/__tests__/handleGlobalSearchClickUrlValidation.test.ts
+++ b/apps/web/src/__tests__/handleGlobalSearchClickUrlValidation.test.ts
@@ -2,6 +2,9 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { isSafeUrl } from '../../../../packages/dmworkbase/src/Utils/security';
 
+import { handleGlobalSearchClick } from '../../../../packages/dmworkbase/src/Pages/Chat/vm';
+import { downloadFile } from '../../../../packages/dmworkbase/src/Utils/download';
+
 // Mock downloadFile
 vi.mock('../../../../packages/dmworkbase/src/Utils/download', () => ({
     downloadFile: vi.fn(),
@@ -63,9 +66,6 @@ vi.mock('../../../../packages/dmworkbase/src/Service/Const', () => ({
 vi.mock('../../../../packages/dmworkbase/src/EndpointCommon', () => ({
     ShowConversationOptions: class {},
 }));
-
-import { handleGlobalSearchClick } from '../../../../packages/dmworkbase/src/Pages/Chat/vm';
-import { downloadFile } from '../../../../packages/dmworkbase/src/Utils/download';
 
 describe('handleGlobalSearchClick file download URL validation', () => {
     beforeEach(() => {

--- a/apps/web/src/__tests__/localModelService.test.ts
+++ b/apps/web/src/__tests__/localModelService.test.ts
@@ -1,13 +1,13 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
+import LocalModelService, {
+  normalizeEndpoint,
+} from "@octo/base/src/Service/LocalModelService";
+
 // Must mock VoiceService to avoid importing APIClient transitively
 vi.mock("@octo/base/src/Service/APIClient", () => ({
   default: { shared: { get: vi.fn(), post: vi.fn(), config: { apiURL: "" } } },
 }));
-
-import LocalModelService, {
-  normalizeEndpoint,
-} from "@octo/base/src/Service/LocalModelService";
 
 describe("LocalModelService", () => {
   let service: typeof LocalModelService.shared;

--- a/apps/web/src/__tests__/summaryCreatePageVoice.test.tsx
+++ b/apps/web/src/__tests__/summaryCreatePageVoice.test.tsx
@@ -2,6 +2,8 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import React from "react";
 
+import SummaryCreatePage from "@dmwork/summary/src/pages/SummaryCreatePage";
+
 const mockUseTextareaVoice = vi.fn();
 vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
   default: (opts: unknown) => mockUseTextareaVoice(opts),
@@ -65,8 +67,6 @@ vi.mock("@dmwork/summary/src/components/ScheduleConfigModal", () => ({
 vi.mock("@dmwork/summary/src/utils/summaryHelpers", () => ({
   scheduleToCron: vi.fn(),
 }));
-
-import SummaryCreatePage from "@dmwork/summary/src/pages/SummaryCreatePage";
 
 function createMockReturn(overrides = {}) {
   return {

--- a/apps/web/src/__tests__/useSpaceFeedbackSetting.test.ts
+++ b/apps/web/src/__tests__/useSpaceFeedbackSetting.test.ts
@@ -1,5 +1,15 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
+import WKApp from "@octo/base/src/App";
+import { getSpaceSetting } from "@octo/base/src/Service/SpaceSettingService";
+import {
+  ensureVoiceFeedbackLoaded,
+  fetchAndApplySpaceSetting,
+  getSharedSpaceFeedbackState,
+  resetSharedSpaceSetting,
+  setSharedSpaceSetting,
+} from "@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting";
+
 vi.mock("@octo/base/src/App", () => ({
   default: {
     shared: {
@@ -21,16 +31,6 @@ const mockGetConfig = vi.fn();
 vi.mock("@octo/base/src/Service/VoiceService", () => ({
   default: { shared: { getConfig: () => mockGetConfig() } },
 }));
-
-import WKApp from "@octo/base/src/App";
-import { getSpaceSetting } from "@octo/base/src/Service/SpaceSettingService";
-import {
-  ensureVoiceFeedbackLoaded,
-  fetchAndApplySpaceSetting,
-  getSharedSpaceFeedbackState,
-  resetSharedSpaceSetting,
-  setSharedSpaceSetting,
-} from "@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting";
 
 const mockGetSpaceSetting = vi.mocked(getSpaceSetting);
 

--- a/apps/web/src/__tests__/useTextareaVoice.test.ts
+++ b/apps/web/src/__tests__/useTextareaVoice.test.ts
@@ -3,6 +3,8 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import React from "react";
 
+import useTextareaVoice from "@octo/base/src/Components/VoiceInputButton/useTextareaVoice";
+
 // Mock useVoiceInput hook
 const mockStartRecording = vi.fn();
 const mockStopRecordingAndTranscribe = vi.fn();
@@ -24,8 +26,6 @@ vi.mock("@octo/base/src/Components/MessageInput/useVoiceInput", () => ({
     };
   },
 }));
-
-import useTextareaVoice from "@octo/base/src/Components/VoiceInputButton/useTextareaVoice";
 
 describe("useTextareaVoice", () => {
   beforeEach(() => {

--- a/apps/web/src/__tests__/useVoiceInput.test.ts
+++ b/apps/web/src/__tests__/useVoiceInput.test.ts
@@ -1,6 +1,11 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
+import WKApp from "@octo/base/src/App";
+import VoiceService from "@octo/base/src/Service/VoiceService";
+import LocalModelService from "@octo/base/src/Service/LocalModelService";
+import useVoiceInput from "@octo/base/src/Components/MessageInput/useVoiceInput";
+
 const { mockOnTranscribeResult, mockLocalTranscribe } = vi.hoisted(() => ({
   mockOnTranscribeResult: vi.fn(),
   mockLocalTranscribe: vi.fn(),
@@ -70,11 +75,6 @@ vi.mock(
     subscribe: vi.fn(() => vi.fn()),
   }),
 );
-
-import WKApp from "@octo/base/src/App";
-import VoiceService from "@octo/base/src/Service/VoiceService";
-import LocalModelService from "@octo/base/src/Service/LocalModelService";
-import useVoiceInput from "@octo/base/src/Components/MessageInput/useVoiceInput";
 
 // Mock MediaRecorder
 class MockMediaRecorder {

--- a/apps/web/src/__tests__/voiceInputButton.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButton.test.tsx
@@ -2,6 +2,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import { Toast } from "@douyinfe/semi-ui";
+
 // Mock useTextareaVoice hook
 const mockUseTextareaVoice = vi.fn();
 vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
@@ -60,9 +63,6 @@ vi.mock("@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting", () => 
   getSharedSpaceFeedbackState: () => mockSharedSpaceFeedbackState,
   getSharedVoiceConfig: () => mockVoiceConfig.current,
 }));
-
-import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
-import { Toast } from "@douyinfe/semi-ui";
 
 function createMockReturn(overrides = {}) {
   return {

--- a/apps/web/src/__tests__/voiceInputButtonPositioning.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButtonPositioning.test.tsx
@@ -2,6 +2,8 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import React, { useRef } from "react";
 
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+
 const mockUseTextareaVoice = vi.fn();
 vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
   default: (opts: unknown) => mockUseTextareaVoice(opts),
@@ -22,8 +24,6 @@ vi.mock("@douyinfe/semi-ui", () => ({
     Item: vi.fn(({ children }: any) => children),
   }),
 }));
-
-import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 
 function createMockReturn(overrides = {}) {
   return {

--- a/apps/web/src/__tests__/voiceInputButtonShiftLongPress.test.tsx
+++ b/apps/web/src/__tests__/voiceInputButtonShiftLongPress.test.tsx
@@ -2,6 +2,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import React from "react";
 
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import { Toast } from "@douyinfe/semi-ui";
+
 const mockUseTextareaVoice = vi.fn();
 vi.mock("@octo/base/src/Components/VoiceInputButton/useTextareaVoice", () => ({
   default: (opts: unknown) => mockUseTextareaVoice(opts),
@@ -54,9 +57,6 @@ vi.mock("@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting", () => 
   getSharedSpaceFeedbackState: () => mockSharedSpaceFeedbackState,
   getSharedVoiceConfig: () => mockVoiceConfig.current,
 }));
-
-import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
-import { Toast } from "@douyinfe/semi-ui";
 
 function createMockReturn(overrides = {}) {
   return {

--- a/apps/web/src/__tests__/voiceInputIndicator.test.tsx
+++ b/apps/web/src/__tests__/voiceInputIndicator.test.tsx
@@ -2,6 +2,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
+import VoiceInputIndicator from "@octo/base/src/Components/MessageInput/VoiceInputIndicator";
+import { Toast } from "@douyinfe/semi-ui";
+
 // Mock useVoiceInput hook
 const mockUseVoiceInput = vi.fn();
 vi.mock("@octo/base/src/Components/MessageInput/useVoiceInput", () => ({
@@ -61,9 +64,6 @@ vi.mock("@octo/base/src/Components/MessageInput/useSpaceFeedbackSetting", () => 
   getSharedSpaceFeedbackState: () => mockSharedSpaceFeedbackState,
   getSharedVoiceConfig: () => mockVoiceConfig.current,
 }));
-
-import VoiceInputIndicator from "@octo/base/src/Components/MessageInput/VoiceInputIndicator";
-import { Toast } from "@douyinfe/semi-ui";
 
 // Reset shared feedback state before each test
 beforeEach(() => {

--- a/apps/web/src/__tests__/voiceInputIntegration.test.tsx
+++ b/apps/web/src/__tests__/voiceInputIntegration.test.tsx
@@ -2,6 +2,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
 import React, { useRef, useState } from "react";
 
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode } from "@octo/base/src/Components/VoiceInputButton";
+
 // Mock useVoiceInput
 let capturedOnTranscribed: ((text: string) => void) | undefined;
 let capturedStartRecording: ReturnType<typeof vi.fn>;
@@ -37,9 +40,6 @@ vi.mock("@douyinfe/semi-ui", () => ({
     Item: vi.fn(({ children }: any) => children),
   }),
 }));
-
-import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
-import type { ReplaceMode } from "@octo/base/src/Components/VoiceInputButton";
 
 function TextareaWithVoice() {
   const [value, setValue] = useState("hello world");

--- a/apps/web/src/__tests__/voiceService.test.ts
+++ b/apps/web/src/__tests__/voiceService.test.ts
@@ -1,5 +1,9 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest"
 
+import APIClient from "@octo/base/src/Service/APIClient"
+import VoiceService from "@octo/base/src/Service/VoiceService"
+import LocalModelService from "@octo/base/src/Service/LocalModelService"
+
 // Mock APIClient before importing VoiceService
 vi.mock("@octo/base/src/Service/APIClient", () => {
     const mockAPIClient = {
@@ -30,10 +34,6 @@ vi.mock("@octo/base/src/Service/LocalModelService", () => {
     }
     return { default: mockLocalModelService }
 })
-
-import APIClient from "@octo/base/src/Service/APIClient"
-import VoiceService from "@octo/base/src/Service/VoiceService"
-import LocalModelService from "@octo/base/src/Service/LocalModelService"
 
 describe("VoiceService", () => {
     beforeEach(() => {

--- a/apps/web/src/stories/GroupCategory.stories.tsx
+++ b/apps/web/src/stories/GroupCategory.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Storybook CSF3 render fns use hooks as inline components */
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React, { useState } from 'react'
 import { Button, Input } from '@douyinfe/semi-ui'


### PR DESCRIPTION
Fixes #456 (Phase 1 of 3).

Previously `pnpm lint` ran `turbo run lint` but **no workspace package defined a `lint` script**, so CI reported a false green (0 tasks executed).

## Changes

- **Uncomment root `.eslintrc.js`** — was fully commented out
- **Add `lint` script to `apps/web`** — `eslint src/ --ext .ts,.tsx`
- **Auto-fix 35 violations** — import ordering in test files
- **Disable react-hooks/rules-of-hooks in stories file** — CSF3 render fns are inline components (false positive)

## Result

| Before | After |
|--------|-------|
| `Tasks: 0 successful, 0 total` | `Tasks: 1 successful, 1 total` |
| ESLint never ran | 0 errors, 32 warnings |

## Deferred to follow-up PRs

- Phase 2: typecheck gate (2015 TS errors in apps/web)
- Phase 3: test gate (34/895 tests failing)