### PR TITLE
fix: unify avatar radius

### DIFF
--- a/packages/dmworkappbot/src/AppBotPage.css
+++ b/packages/dmworkappbot/src/AppBotPage.css
@@ -77,7 +77,7 @@
 .appbot-list-avatar {
   width: 40px;
   height: 40px;
-  border-radius: 10px;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -93,7 +93,7 @@
 }
 
 .appbot-list-avatar .wk-avatar {
-  border-radius: var(--wk-r-sm, 10px);
+  border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .appbot-list-info {
@@ -174,7 +174,7 @@
 .appbot-chat-header-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.css
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.css
@@ -108,7 +108,7 @@
 .wk-bot-detail-avatar--preview {
     width: 64px;
     height: 64px;
-    border-radius: var(--wk-r-sm, 8px);
+    border-radius: var(--wk-avatar-radius, 50%);
     overflow: hidden;
     cursor: zoom-in;
 }
@@ -117,13 +117,13 @@
 .wk-bot-detail-avatar--preview img {
     width: 64px;
     height: 64px;
-    border-radius: var(--wk-r-sm, 8px);
+    border-radius: var(--wk-avatar-radius, 50%);
     object-fit: cover;
 }
 .wk-bot-detail-avatar-overlay {
     position: absolute;
     inset: 0;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
     background: rgba(0, 0, 0, 0.45);
     color: #fff;
     font-size: 20px;
@@ -142,12 +142,12 @@
 .wk-bot-detail-avatar--owner:focus-visible {
     outline: 2px solid var(--wk-border-glow);
     outline-offset: 2px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 .wk-bot-detail-avatar-loading {
     position: absolute;
     inset: 0;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
     background: rgba(255, 255, 255, 0.6);
     display: flex;
     align-items: center;

--- a/packages/dmworkbase/src/Components/ChannelQRCode/index.css
+++ b/packages/dmworkbase/src/Components/ChannelQRCode/index.css
@@ -25,7 +25,7 @@
 .wk-channelqrcode-info-avatar img {
     width: 60px;
     height: 60px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-channelqrcode-qrcode {

--- a/packages/dmworkbase/src/Components/ChannelSearch/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSearch/index.css
@@ -825,7 +825,7 @@
   display: block;
   width: 20px;
   height: 20px;
-  border-radius: 9999px;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
   object-fit: cover;
 }

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -104,7 +104,7 @@
 .wk-channelsetting-avatar img {
     width: 100%;
     object-fit: cover;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-channelsetting-name {

--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
@@ -59,7 +59,7 @@
   width: 24px;
   height: 24px;
   margin-right: -6px;
-  border-radius: var(--wk-r-sm);
+  border-radius: var(--wk-avatar-radius, 50%);
   border: 2px solid var(--wk-ai-panel-bg);
   overflow: hidden;
   background: var(--wk-bg-elevated);

--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -182,7 +182,7 @@ body[theme-mode="dark"] .wk-conversation-content {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
-  border-radius: 4px;
+  border-radius: var(--wk-avatar-radius, 50%);
   overflow: hidden;
 }
 

--- a/packages/dmworkbase/src/Components/ConversationList/index.css
+++ b/packages/dmworkbase/src/Components/ConversationList/index.css
@@ -109,14 +109,11 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   height: 32px;
 }
 
-/* design v3.1：群组/子区头像 32x32 + 6px 圆角；DM 维持圆形 */
+/* Avatar shape is unified; identity is shown by badges/metadata, not corners. */
 .wk-conversationlist-item-avatar-box .wk-avatar {
   width: 32px;
   height: 32px;
-  border-radius: var(--wk-r-sm);
-}
-.wk-conversationlist-item-dm .wk-conversationlist-item-avatar-box .wk-avatar {
-  border-radius: var(--wk-r-circle);
+  border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-conversationlist-item-right-first-line {
@@ -506,14 +503,11 @@ body[theme-mode="dark"] .wk-conversationlist:hover::-webkit-scrollbar-thumb {
   position: relative;
 }
 
-/* design v3.1：群组头像 22x22 + 5px 圆角，DM 维持圆形（由 WKAvatar 自身样式决定） */
+/* Compact avatars keep their size but share the global circular shape. */
 .wk-conv-compact-icon .wk-avatar {
   width: 22px;
   height: 22px;
-  border-radius: 5px;
-}
-.wk-conv-compact-icon .wk-avatar:not(.wk-avatar-group) {
-  border-radius: var(--wk-r-circle);
+  border-radius: var(--wk-avatar-radius, 50%);
 }
 
 /* Figma: emoji/icon 左上角 6x6 红色小圆点（有未读消息时显示） */

--- a/packages/dmworkbase/src/Components/GroupCard/index.css
+++ b/packages/dmworkbase/src/Components/GroupCard/index.css
@@ -13,7 +13,7 @@
 .wk-group-card-header .wk-avatar {
     width: 64px;
     height: 64px;
-    border-radius: var(--wk-r-md, 10px);
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 .wk-group-card-name {
     font-size: 18px;

--- a/packages/dmworkbase/src/Components/IndexTable/index.css
+++ b/packages/dmworkbase/src/Components/IndexTable/index.css
@@ -29,7 +29,7 @@ body[theme-mode=dark] .wk-indextable-item {
 .wk-indextable-item-avatar img {
     width: 50px;
     height: 50px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-indextable-item-name {
@@ -121,7 +121,7 @@ body[theme-mode=dark] .wk-indextable-search-input input {
 }
 
 .wk-indextable-search .wk-indextable-select-user img{
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-indextable-contacts {

--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/index.css
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/index.css
@@ -31,7 +31,7 @@
 .wk-mergeforwardmessagelist-content-msg-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
   overflow: hidden;
 }

--- a/packages/dmworkbase/src/Components/NavRail/index.css
+++ b/packages/dmworkbase/src/Components/NavRail/index.css
@@ -34,7 +34,7 @@
 .wk-navrail__user-avatar {
     width: 40px;
     height: 40px;
-    border-radius: var(--wk-r-circle, 50%);
+    border-radius: var(--wk-avatar-radius, 50%);
     background: var(--wk-bg-elevated);
     border: none;
     cursor: pointer;
@@ -511,7 +511,7 @@
 .wk-navrail__avatar {
     width: 30px;
     height: 30px;
-    border-radius: var(--wk-r-circle, 50%);
+    border-radius: var(--wk-avatar-radius, 50%);
     background: var(--wk-bg-elevated) center/cover no-repeat;
     border: none;
     cursor: pointer;

--- a/packages/dmworkbase/src/Components/QRCodeMy/index.css
+++ b/packages/dmworkbase/src/Components/QRCodeMy/index.css
@@ -42,7 +42,7 @@ body[theme-mode=dark] .wk-qrcodemy-content-qrcodeinfo {
 .wk-qrcodemy-content-userinfo-avatar img{
     width: 50px;
     height: 50px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-qrcodemy-content-qrcode {

--- a/packages/dmworkbase/src/Components/SmallTableEdit/index.css
+++ b/packages/dmworkbase/src/Components/SmallTableEdit/index.css
@@ -22,7 +22,7 @@
 .wk-smalltableedit-content-item-avatar img {
     width: 32px;
     height: 32px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-smalltableedit-content-item-name {

--- a/packages/dmworkbase/src/Components/SpaceMembers/index.css
+++ b/packages/dmworkbase/src/Components/SpaceMembers/index.css
@@ -90,7 +90,7 @@ body[theme-mode=dark] .wk-spacemembers-item:hover {
 .wk-spacemembers-item-avatar {
     width: 36px;
     height: 36px;
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
     object-fit: cover;
 }
 

--- a/packages/dmworkbase/src/Components/Subscribers/index.css
+++ b/packages/dmworkbase/src/Components/Subscribers/index.css
@@ -28,7 +28,7 @@
 .wk-subscribers-item-avatar-wrap img {
     width: 50px;
     height: 50px;
-    border-radius: 40%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-subscribers-item-name {

--- a/packages/dmworkbase/src/Components/ThreadIndicator/index.css
+++ b/packages/dmworkbase/src/Components/ThreadIndicator/index.css
@@ -53,7 +53,7 @@
 .wk-thread-indicator-avatar {
   width: 18px;
   height: 18px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   border: 1.5px solid var(--wk-bg-surface);
   margin-left: -6px;
   object-fit: cover;

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.css
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.css
@@ -106,7 +106,7 @@ body[theme-mode="dark"] .wk-thread-panel {
 .wk-thread-panel-parent-avatar {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-thread-panel-parent-name {
@@ -142,7 +142,7 @@ body[theme-mode="dark"] .wk-thread-panel {
 .wk-thread-panel-reply-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 

--- a/packages/dmworkbase/src/Components/UserInfo/index.css
+++ b/packages/dmworkbase/src/Components/UserInfo/index.css
@@ -42,7 +42,7 @@ body[theme-mode=dark]  .wk-userInfo-footer {
 
 .wk-userinfo-user-avatar {
     margin-left: 20px;
-    border-radius: 40%;
+    border-radius: var(--wk-avatar-radius, 50%);
     background-color: var(--wk-color-item);
     width: 54px;
     height: 54px;
@@ -54,7 +54,7 @@ body[theme-mode=dark]  .wk-userInfo-footer {
 .wk-userinfo-user-avatar  img{
     width: 50px;
     height: 50px;
-    border-radius: 40%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-userinfo-user-info-name {

--- a/packages/dmworkbase/src/Components/WKAvatar/index.css
+++ b/packages/dmworkbase/src/Components/WKAvatar/index.css
@@ -1,17 +1,16 @@
 .wk-avatar {
     width: 40px;
     height: 40px;
-    border-radius: 50%; /* default: human */
+    border-radius: var(--wk-avatar-radius, 50%);
     object-fit: cover;
     transition: border-radius 150ms ease;
 }
 
-/* AI Bot — 圆角矩形 */
+/* Identity classes are kept for metadata hooks; shape stays unified. */
 .wk-avatar.wk-avatar-ai {
-    border-radius: var(--wk-r-sm);
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
-/* 群组 — 中等圆角 */
 .wk-avatar.wk-avatar-group {
-    border-radius: var(--wk-r-md);
+    border-radius: var(--wk-avatar-radius, 50%);
 }

--- a/packages/dmworkbase/src/Components/WKAvatarUploadPreview/index.css
+++ b/packages/dmworkbase/src/Components/WKAvatarUploadPreview/index.css
@@ -13,9 +13,9 @@
 }
 
 .wk-avatar-upload-preview__image--circle {
-    border-radius: 50%;
+    border-radius: var(--wk-avatar-radius, 50%);
 }
 
 .wk-avatar-upload-preview__image--bot {
-    border-radius: var(--wk-r-sm, 8px);
+    border-radius: var(--wk-avatar-radius, 50%);
 }

--- a/packages/dmworkbase/src/Messages/Card/index.tsx
+++ b/packages/dmworkbase/src/Messages/Card/index.tsx
@@ -73,7 +73,7 @@ export class CardCell extends MessageCell<MessageBaseCellProps, CardCellState> {
                         WKApp.shared.baseContext.showUserInfo(content.uid,context.channel(),content.vercode)
                     }}>
                         <div>
-                            <img src={WKApp.shared.avatarUser(content.uid)} style={{ width: "64px", height: "64px", borderRadius: "50%" }} alt="" />
+                            <img src={WKApp.shared.avatarUser(content.uid)} style={{ width: "64px", height: "64px", borderRadius: "var(--wk-avatar-radius, 50%)" }} alt="" />
                         </div>
                         <div className="wk-message-card-content-name">
                             {content.name}

--- a/packages/dmworkbase/src/Messages/JoinOrganization/index.tsx
+++ b/packages/dmworkbase/src/Messages/JoinOrganization/index.tsx
@@ -50,7 +50,7 @@ export class JoinOrganizationCell extends MessageCell {
             <div>
               <img
                 src={WKApp.shared.avatarOrg(content.org_id)}
-                style={{ width: "64px", height: "64px", borderRadius: "50%" }}
+                style={{ width: "64px", height: "64px", borderRadius: "var(--wk-avatar-radius, 50%)" }}
                 alt=""
               />
             </div>

--- a/packages/dmworkbase/src/Messages/Text/index.tsx
+++ b/packages/dmworkbase/src/Messages/Text/index.tsx
@@ -223,7 +223,7 @@ export class TextCell extends MessageCell {
                 }}>
                     <div className="wk-message-text-reply-author">
                         <div className="wk-message-text-reply-authoravatar">
-                            <img alt="" src={WKApp.shared.avatarUser(message.content.reply.fromUID)} style={{ width: "12px", height: "12px",borderRadius:"50%" }} />
+                            <img alt="" src={WKApp.shared.avatarUser(message.content.reply.fromUID)} style={{ width: "12px", height: "12px",borderRadius:"var(--wk-avatar-radius, 50%)" }} />
                         </div>
                         <div className="wk-message-text-reply-authorname">
                             {message.content.reply.fromName}

--- a/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
+++ b/packages/dmworkbase/src/Messages/ThreadCreated/index.tsx
@@ -162,7 +162,7 @@ export class ThreadCreatedCell extends MessageCell {
                     width: 16,
                     height: 16,
                     fontSize: 8,
-                    borderRadius: '50%',
+                    borderRadius: 'var(--wk-avatar-radius, 50%)',
                     marginLeft: idx > 0 ? -8 : 0,
                     border: '1.5px solid rgba(255,255,255,1)',
                     flexShrink: 0,

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -371,7 +371,7 @@
 .wk-chat-conversation-header-channel-avatar img {
   width: 28px;
   height: 28px;
-  border-radius: 100px;
+  border-radius: var(--wk-avatar-radius, 50%);
 }
 
 /* 群聊 header 的频道 icon（Figma: 16x16） */

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1065,7 +1065,7 @@ export class ChatContentPage extends Component<
                             style={{
                               width: 28,
                               height: 28,
-                              borderRadius: "50%",
+                              borderRadius: "var(--wk-avatar-radius, 50%)",
                               flexShrink: 0,
                             }}
                           />

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -1594,7 +1594,7 @@ export default class BaseModule implements IModule {
               title: t("base.module.channelSettings.groupAvatar"),
               icon: (
                 <img
-                  style={{ width: "24px", height: "24px", borderRadius: "50%" }}
+                  style={{ width: "24px", height: "24px", borderRadius: "var(--wk-avatar-radius, 50%)" }}
                   src={WKApp.shared.avatarChannel(channel)}
                   alt=""
                 />

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -160,6 +160,7 @@
   --wk-r-xl: 20px;
   --wk-r-full: 9999px;
   --wk-r-circle: 50%; /* circle — for avatars; distinct from --wk-r-full (9999px pill shape) */
+  --wk-avatar-radius: var(--wk-r-circle);
 
   /* ── Animation ── */
   --wk-ease: cubic-bezier(0.16, 1, 0.3, 1);

--- a/packages/dmworkbase/src/ui/AIMessageCard/index.css
+++ b/packages/dmworkbase/src/ui/AIMessageCard/index.css
@@ -48,7 +48,7 @@
 .wk-ai-message-card__avatar {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   border: 2px solid #FFFFFF;
   object-fit: cover;
 }
@@ -137,7 +137,7 @@
 .wk-ai-message-card__tooltip-item img {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   object-fit: cover;
 }
 

--- a/packages/dmworkbase/src/ui/message/Avatar/index.css
+++ b/packages/dmworkbase/src/ui/message/Avatar/index.css
@@ -11,7 +11,7 @@
 .wk-msg-avatar-img {
   width: 100%;
   height: 100%;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   object-fit: cover;
 }
 

--- a/packages/dmworkbase/src/ui/message/SystemTag/index.css
+++ b/packages/dmworkbase/src/ui/message/SystemTag/index.css
@@ -20,7 +20,7 @@
 .wk-msg-system-tag-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   object-fit: cover;
 }
 

--- a/packages/dmworkbase/src/ui/message/ThreadBadge/index.css
+++ b/packages/dmworkbase/src/ui/message/ThreadBadge/index.css
@@ -60,7 +60,7 @@
 .wk-msg-thread-badge-avatar {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   border: 1px solid var(--wk-bg-surface);
   object-fit: cover;
   margin-left: -4px;
@@ -80,7 +80,7 @@
   width: 16px;
   height: 16px;
   margin-left: -4px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   background-color: var(--wk-bg-surface-secondary);
   border: 1px solid var(--wk-bg-surface);
   font-size: 10px;

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.css
@@ -459,7 +459,7 @@ textarea.wk-mp-goal__text--editing {
 .wk-mp-people__item .wk-avatar {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: block;
   flex-shrink: 0;
 }
@@ -484,14 +484,14 @@ textarea.wk-mp-goal__text--editing {
   display: inline-flex;
   align-items: center;
   border: 1.5px solid var(--wk-bg-surface);
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 
 .wk-mp-people__avatar-wrap .wk-avatar {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: block;
 }
 
@@ -1474,7 +1474,7 @@ textarea.wk-mp-goal__text--editing {
 .wk-mp-activity__actor .wk-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 

--- a/packages/dmworktodo/src/ui/AnchorPopover/index.css
+++ b/packages/dmworktodo/src/ui/AnchorPopover/index.css
@@ -143,7 +143,7 @@
 .wk-anchor-pop__msg-avatar .wk-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: block;
 }
 

--- a/packages/dmworktodo/src/ui/AssigneeEditor/index.css
+++ b/packages/dmworktodo/src/ui/AssigneeEditor/index.css
@@ -154,7 +154,7 @@
 .wk-assignee-search__avatar {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   object-fit: cover;
   flex-shrink: 0;
 }

--- a/packages/dmworktodo/src/ui/DetailPanel/index.css
+++ b/packages/dmworktodo/src/ui/DetailPanel/index.css
@@ -420,7 +420,7 @@
 .wk-matter-detail__comment-avatar {
   width: 32px;
   height: 32px;
-  border-radius: var(--wk-r-lg);
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 

--- a/packages/dmworktodo/src/ui/LinkChannelsModal/LinkChannelsModal.css
+++ b/packages/dmworktodo/src/ui/LinkChannelsModal/LinkChannelsModal.css
@@ -248,7 +248,7 @@
 .wk-lcm__item-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   background: var(--wk-brand-tint-06);
   flex-shrink: 0;
 }

--- a/packages/dmworktodo/src/ui/LinkChannelsModal/index.tsx
+++ b/packages/dmworktodo/src/ui/LinkChannelsModal/index.tsx
@@ -321,7 +321,7 @@ export default function LinkChannelsModal({
                         </span>
                         <WKAvatar
                           channel={avatarChannel}
-                          style={{ width: 32, height: 32, borderRadius: '50%' }}
+                          style={{ width: 32, height: 32, borderRadius: 'var(--wk-avatar-radius, 50%)' }}
                         />
                         <span className="wk-lcm__item-info">
                           <span className="wk-lcm__item-name">
@@ -373,7 +373,7 @@ export default function LinkChannelsModal({
                 <div key={c.channelId} className="wk-lcm__selected-item">
                   <WKAvatar
                     channel={avatarChannel}
-                    style={{ width: 32, height: 32, borderRadius: '50%' }}
+                    style={{ width: 32, height: 32, borderRadius: 'var(--wk-avatar-radius, 50%)' }}
                   />
                   <span className="wk-lcm__item-info">
                     <span className="wk-lcm__item-name">

--- a/packages/dmworktodo/src/ui/MemberPicker/index.css
+++ b/packages/dmworktodo/src/ui/MemberPicker/index.css
@@ -157,7 +157,7 @@
 .wk-member-picker__option-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   overflow: hidden;
   flex-shrink: 0;
   background: var(--wk-bg-base, #f0f0f0);

--- a/packages/dmworktodo/src/ui/MemberPicker/index.tsx
+++ b/packages/dmworktodo/src/ui/MemberPicker/index.tsx
@@ -54,11 +54,11 @@ function MemberTag({
         <img
           src={avatarUrl}
           alt=""
-          style={{ width: 16, height: 16, borderRadius: '50%', objectFit: 'cover', position: 'absolute', top: 0, left: 0 }}
+          style={{ width: 16, height: 16, borderRadius: 'var(--wk-avatar-radius, 50%)', objectFit: 'cover', position: 'absolute', top: 0, left: 0 }}
           onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
         />
         <span style={{
-          width: 16, height: 16, borderRadius: '50%', background: bgColor,
+          width: 16, height: 16, borderRadius: 'var(--wk-avatar-radius, 50%)', background: bgColor,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           fontSize: '9px', fontWeight: 700, color: '#fff',
         }}>{initial}</span>

--- a/packages/dmworktodo/src/ui/OutputsPanel/index.css
+++ b/packages/dmworktodo/src/ui/OutputsPanel/index.css
@@ -215,7 +215,7 @@
   flex-shrink: 0;
   width: 20px;
   height: 20px;
-  border-radius: var(--wk-r-circle);
+  border-radius: var(--wk-avatar-radius, 50%);
   overflow: hidden;
 }
 
@@ -223,7 +223,7 @@
   flex-shrink: 0;
   width: 20px;
   height: 20px;
-  border-radius: var(--wk-r-circle);
+  border-radius: var(--wk-avatar-radius, 50%);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/dmworktodo/src/ui/OwnerEditor/index.css
+++ b/packages/dmworktodo/src/ui/OwnerEditor/index.css
@@ -64,14 +64,14 @@
   display: inline-flex;
   align-items: center;
   border: 1.5px solid var(--wk-bg-surface, #fff);
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 
 .wk-owner-editor__avatar-wrap .wk-avatar {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   display: block;
 }
 
@@ -185,7 +185,7 @@
 .wk-owner-editor__option .wk-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
+  border-radius: var(--wk-avatar-radius, 50%);
   flex-shrink: 0;
 }
 

--- a/packages/dmworktodo/src/ui/TodoCard/index.tsx
+++ b/packages/dmworktodo/src/ui/TodoCard/index.tsx
@@ -121,7 +121,7 @@ export default function MatterCard({
             <div className="wk-matter-card__user">
               <WKAvatar
                 channel={new Channel(creatorUid, ChannelTypePerson)}
-                style={{ width: 16, height: 16, borderRadius: '50%' }}
+                style={{ width: 16, height: 16, borderRadius: 'var(--wk-avatar-radius, 50%)' }}
               />
               {creatorName && <span className="wk-matter-card__user-name">{creatorName}</span>}
             </div>
@@ -136,7 +136,7 @@ export default function MatterCard({
                   <WKAvatar
                     key={uid}
                     channel={new Channel(uid, ChannelTypePerson)}
-                    style={{ width: 16, height: 16, borderRadius: '50%' }}
+                    style={{ width: 16, height: 16, borderRadius: 'var(--wk-avatar-radius, 50%)' }}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Summary: Unifies real avatar border radius through --wk-avatar-radius and removes person/bot/group shape overrides while leaving Space/BotStore/Persona icon tiles unchanged. Tests: git diff --check; focused stylelint on changed CSS via existing node_modules (0 errors; pre-existing color warnings only).