### PR TITLE
feat(message-input): emoji prefix autocomplete in composer

### DIFF
--- a/apps/web/src/__tests__/emojiSuggestion.test.ts
+++ b/apps/web/src/__tests__/emojiSuggestion.test.ts
@@ -52,6 +52,28 @@ describe('matchEmojiPrefix — prefix matching (v1)', () => {
     expect(matchEmojiPrefix('我要完成使命')).toBeNull()
   })
 
+  it('does NOT co-fire inside an @ mention / slash context: 「@使命」「/使命」→ null', () => {
+    // 中文串紧邻的前一字符是其它 suggestion 触发符时不触发，避免与 mention /
+    // slash 候选同时弹出抢键盘。
+    expect(matchEmojiPrefix('@使命')).toBeNull()
+    expect(matchEmojiPrefix('/使命')).toBeNull()
+    // 句中的 @：前一字符仍是 @ → 不触发
+    expect(matchEmojiPrefix('hi @使命')).toBeNull()
+  })
+
+  it('does NOT trigger right after a bracket: 「[使命」→ null', () => {
+    // [ 是表情 key 起始符，替换 query 后会残留前导 [，故守卫掉。
+    expect(matchEmojiPrefix('[使命')).toBeNull()
+  })
+
+  it('still triggers after a non-reserved boundary char: 「[尚方宝剑]崇尚」→ 崇尚', () => {
+    // ] 不是保留前导符，紧随其后的连续中文应正常联想。
+    const r = matchEmojiPrefix('[尚方宝剑]崇尚')
+    expect(r).not.toBeNull()
+    expect(r!.query).toBe('崇尚')
+    expect(r!.items.map((e) => e.key)).toContain('[崇尚行动]')
+  })
+
   it('prefers the longest matching prefix: 「使命必」→ 使命必', () => {
     const r = matchEmojiPrefix('使命必')
     expect(r).not.toBeNull()

--- a/apps/web/src/__tests__/emojiSuggestion.test.ts
+++ b/apps/web/src/__tests__/emojiSuggestion.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCustomEmojiItems,
+  buildEmojiSuggestItems,
+  matchEmojiPrefix,
+  MIN_QUERY_LEN,
+} from '../../../../packages/dmworkbase/src/Utils/emojiSuggestion'
+
+/**
+ * 表情前缀联想核心逻辑测试。依赖真实 DefaultEmojiService 单例中的 4 个
+ * 中文 key 自定义表情：[使命必达] [崇尚行动] [有品位] [尚方宝剑]。
+ */
+
+describe('getCustomEmojiItems', () => {
+  it('only returns custom (bracketed Chinese) emojis, not Unicode emojis', () => {
+    const items = getCustomEmojiItems()
+    expect(items.length).toBe(4)
+    const keys = items.map((e) => e.key)
+    // 仅断言集合相等，不约束顺序（getAllEmoji 的返回顺序不是契约）
+    expect(new Set(keys)).toEqual(
+      new Set(['[使命必达]', '[崇尚行动]', '[有品位]', '[尚方宝剑]']),
+    )
+  })
+
+  it('strips brackets into label and carries an image path', () => {
+    const mission = getCustomEmojiItems().find((e) => e.key === '[使命必达]')
+    expect(mission).toBeDefined()
+    expect(mission!.label).toBe('使命必达')
+    expect(mission!.image).toContain('custom_mission')
+  })
+})
+
+describe('matchEmojiPrefix — prefix matching (v1)', () => {
+  it('matches a prefix: 「使命」→ [使命必达]', () => {
+    const r = matchEmojiPrefix('使命')
+    expect(r).not.toBeNull()
+    expect(r!.query).toBe('使命')
+    expect(r!.items.map((e) => e.key)).toContain('[使命必达]')
+  })
+
+  it('does NOT match a mid-string substring: 「必达」→ null', () => {
+    expect(matchEmojiPrefix('必达')).toBeNull()
+  })
+
+  it('does NOT trigger on a single character: 「使」→ null', () => {
+    expect(matchEmojiPrefix('使')).toBeNull()
+  })
+
+  it('does NOT trigger when the name is embedded in a phrase: 「我要完成使命」→ null', () => {
+    // 词边界规则：光标前最长连续中文整段须是表情名前缀。「我要完成使命」整段
+    // 不是任何表情名前缀 → 不触发，与「公司的使命是」「使命是xxx」一致，避免句中误弹。
+    expect(matchEmojiPrefix('我要完成使命')).toBeNull()
+  })
+
+  it('prefers the longest matching prefix: 「使命必」→ 使命必', () => {
+    const r = matchEmojiPrefix('使命必')
+    expect(r).not.toBeNull()
+    expect(r!.query).toBe('使命必')
+    expect(r!.items.map((e) => e.key)).toEqual(['[使命必达]'])
+  })
+
+  it('matches other custom emojis: 「尚方」→ [尚方宝剑], 「崇尚」→ [崇尚行动]', () => {
+    expect(matchEmojiPrefix('尚方')!.items.map((e) => e.key)).toContain(
+      '[尚方宝剑]',
+    )
+    expect(matchEmojiPrefix('崇尚')!.items.map((e) => e.key)).toContain(
+      '[崇尚行动]',
+    )
+  })
+
+  it('returns null for non-matching latin / unicode input', () => {
+    expect(matchEmojiPrefix('hello')).toBeNull()
+    expect(matchEmojiPrefix('😀😀')).toBeNull()
+  })
+
+  it('returns null for empty / too-short input', () => {
+    expect(matchEmojiPrefix('')).toBeNull()
+    expect('使'.length).toBeLessThan(MIN_QUERY_LEN)
+  })
+})
+
+describe('buildEmojiSuggestItems', () => {
+  it('prefix-filters custom emojis by query', () => {
+    expect(buildEmojiSuggestItems('使命').map((e) => e.key)).toEqual([
+      '[使命必达]',
+    ])
+  })
+
+  it('returns empty for query shorter than min length', () => {
+    expect(buildEmojiSuggestItems('使')).toEqual([])
+    expect(buildEmojiSuggestItems('')).toEqual([])
+  })
+
+  it('returns empty for a non-prefix substring', () => {
+    expect(buildEmojiSuggestItems('必达')).toEqual([])
+  })
+})

--- a/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.css
+++ b/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.css
@@ -1,0 +1,54 @@
+/* 表情联想候选条：输入法风格的横向排列，刻意区别于 @ 提及的竖向成员列表。 */
+.emoji-suggestion-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 2px;
+  background-color: var(--wk-color-item);
+  box-shadow: var(--wk-shadow-md);
+  border-radius: 8px;
+  padding: 4px;
+  max-width: 360px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overflow-anchor: none;
+}
+
+.emoji-suggestion-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s, transform 0.12s ease;
+  flex-shrink: 0;
+}
+
+/* hover 与键盘选中（含联想弹出的默认项）：浅灰底高亮 + 轻微放大 */
+.emoji-suggestion-bar.emoji-suggestion-bar--mouse .emoji-suggestion-cell:hover,
+.emoji-suggestion-bar.emoji-suggestion-bar--keyboard .emoji-suggestion-cell.is-selected {
+  background-color: var(--semi-color-fill-1);
+  transform: scale(1.06);
+}
+
+.emoji-suggestion-bar.emoji-suggestion-bar--mouse .emoji-suggestion-cell:hover .emoji-suggestion-name,
+.emoji-suggestion-bar.emoji-suggestion-bar--keyboard .emoji-suggestion-cell.is-selected .emoji-suggestion-name {
+  color: var(--semi-color-text-0, var(--wk-text-primary));
+}
+
+.emoji-suggestion-icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.emoji-suggestion-name {
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+  color: var(--wk-text-secondary, var(--semi-color-text-2));
+}

--- a/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.tsx
@@ -1,0 +1,111 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import type { EmojiSuggestItem } from '../../Utils/emojiSuggestion'
+import './EmojiSuggestionList.css'
+
+interface EmojiSuggestionListProps {
+  items: EmojiSuggestItem[]
+  command: (item: EmojiSuggestItem) => void
+}
+
+type InteractionMode = 'keyboard' | 'mouse'
+
+/**
+ * 表情前缀联想候选条。形态为输入法风格的「横向候选条」（一行内横排多个表情
+ * 图标 + 名称），刻意区别于 @ 提及的竖向成员列表。
+ *
+ * 暴露 onKeyDown 供 Tiptap Suggestion 在激活时驱动键盘选择：横向条以左右键
+ * 切换（同时兼容上下键），Enter 选中。鼠标 hover 高亮、点击选中。
+ */
+export default forwardRef((props: EmojiSuggestionListProps, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [interactionMode, setInteractionMode] =
+    useState<InteractionMode>('keyboard')
+  const selectedIndexRef = useRef(0)
+
+  const selectItem = (index: number) => {
+    const item = props.items[index]
+    if (item) {
+      props.command(item)
+    }
+  }
+
+  const moveSelection = (direction: 'prev' | 'next') => {
+    if (!props.items.length) return
+    const len = props.items.length
+    const next =
+      direction === 'prev'
+        ? (selectedIndexRef.current + len - 1) % len
+        : (selectedIndexRef.current + 1) % len
+    selectedIndexRef.current = next
+    setSelectedIndex(next)
+    setInteractionMode('keyboard')
+  }
+
+  useEffect(() => {
+    selectedIndexRef.current = 0
+    setSelectedIndex(0)
+    setInteractionMode('keyboard')
+  }, [props.items])
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+      // 横向候选条：左右键为主，上下键兼容
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        moveSelection('prev')
+        return true
+      }
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        moveSelection('next')
+        return true
+      }
+      if (event.key === 'Enter') {
+        selectItem(selectedIndexRef.current)
+        return true
+      }
+      return false
+    },
+  }))
+
+  if (!props.items.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={`emoji-suggestion-bar emoji-suggestion-bar--${interactionMode}`}
+      role="listbox"
+    >
+      {props.items.map((item, index) => {
+        const isSelected =
+          interactionMode === 'keyboard' && index === selectedIndex
+
+        return (
+          <div
+            className={`emoji-suggestion-cell ${isSelected ? 'is-selected' : ''}`}
+            key={item.key}
+            role="option"
+            aria-selected={isSelected}
+            onMouseEnter={() => {
+              setInteractionMode('mouse')
+              selectedIndexRef.current = index
+            }}
+            onClick={() => selectItem(index)}
+          >
+            <img
+              className="emoji-suggestion-icon"
+              src={item.image}
+              alt={item.label}
+            />
+            <span className="emoji-suggestion-name">{item.label}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+})

--- a/packages/dmworkbase/src/Components/MessageInput/emojiSuggestion.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/emojiSuggestion.tsx
@@ -1,0 +1,158 @@
+import { Extension } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import Suggestion, {
+  SuggestionMatch,
+  SuggestionOptions,
+} from '@tiptap/suggestion'
+import { ReactRenderer } from '@tiptap/react'
+import tippy, { Instance as TippyInstance } from 'tippy.js'
+import EmojiSuggestionList from './EmojiSuggestionList'
+import {
+  buildEmojiSuggestItems,
+  matchEmojiPrefix,
+  EmojiSuggestItem,
+} from '../../Utils/emojiSuggestion'
+
+/**
+ * 表情前缀联想的 Tiptap 扩展，复用 @ 提及同一套 Tiptap Suggestion + tippy 基建。
+ *
+ * 与 mention 的关键差异：
+ * - 无触发字符（char: ''），由自定义 findSuggestionMatch 反向扫描光标前文本做前缀匹配
+ * - 选中后插入的是 emoji.key 纯文本（如 "[使命必达]"），不引入任何自定义 node；
+ *   表情的图片渲染由发送/接收链路的 emojiRegExp 解析完成（本扩展不参与渲染）
+ * - 独立 pluginKey，与 mention(@)/默认 suggestion 并存不冲突
+ */
+
+/** 独立 pluginKey，避免与 mention 及默认 suggestion 冲突 */
+export const emojiSuggestionPluginKey = new PluginKey('emojiSuggestion')
+
+/**
+ * 自定义匹配：取光标前所在文本节点的内容，交给 matchEmojiPrefix 做前缀匹配。
+ * range 覆盖光标前的 query 文字，选中后整体替换为表情 key。
+ * 不依赖 char / allowedPrefixes 等触发符配置。
+ */
+function findEmojiSuggestionMatch(config: { $position: any }): SuggestionMatch {
+  const { $position } = config
+  const nodeBefore = $position.nodeBefore
+  const text: string | false | undefined = nodeBefore?.isText && nodeBefore.text
+
+  if (!text) return null
+
+  const matched = matchEmojiPrefix(text)
+  if (!matched) return null
+
+  // query 是 text 的后缀，range 从「光标 - query 长度」到光标
+  const to = $position.pos
+  const from = to - matched.query.length
+
+  return {
+    range: { from, to },
+    query: matched.query,
+    text: matched.query,
+  }
+}
+
+export function createEmojiSuggestionExtension(
+  onActiveChange?: (active: boolean) => void,
+): Extension {
+  const suggestion: Omit<SuggestionOptions<EmojiSuggestItem>, 'editor'> = {
+    pluginKey: emojiSuggestionPluginKey,
+    char: '',
+    allowSpaces: false,
+    // 关闭「触发符前需空格」限制，否则句中输入不会触发
+    allowedPrefixes: null,
+    findSuggestionMatch: findEmojiSuggestionMatch,
+
+    items: ({ query }) => {
+      // 不在此处用 editor.view.composing 拦截：表情名 query 完全经中文输入法
+      // 上屏，compositionend 派发的插入事务跑到这里时 view.composing 往往仍为
+      // true，会把首次匹配的列表吞成空 → onStart 因 items 为空不建弹窗 → 此后
+      // 无新输入便永久不弹（表现为「粘贴能联想、键入不联想」）。
+      // 组合期 ProseMirror 不向 doc 写入拼音中间态，apply 的 findSuggestionMatch
+      // 拿不到拼音串，去掉此拦截不会引入组合期误触发。
+      return buildEmojiSuggestItems(query)
+    },
+
+    command: ({ editor, range, props }) => {
+      // 把光标前的 query 文字替换为表情 key 纯文本（第一版不追加空格）
+      editor.chain().focus().insertContentAt(range, props.key).run()
+    },
+
+    render: () => {
+      let component: ReactRenderer
+      let popup: TippyInstance[]
+
+      return {
+        onStart: (props: any) => {
+          if (!props.items?.length) return
+
+          onActiveChange?.(true)
+          component = new ReactRenderer(EmojiSuggestionList, {
+            props,
+            editor: props.editor,
+          })
+
+          if (!props.clientRect) return
+
+          popup = tippy('body', {
+            getReferenceClientRect: props.clientRect,
+            appendTo: () => document.body,
+            content: component.element,
+            showOnCreate: true,
+            interactive: true,
+            trigger: 'manual',
+            placement: 'bottom-start',
+          })
+        },
+
+        onUpdate(props: any) {
+          if (!component) return
+
+          component.updateProps(props)
+
+          if (!props.items?.length) {
+            popup?.[0]?.hide()
+            return
+          }
+
+          popup?.[0]?.show()
+
+          if (!props.clientRect) return
+
+          popup[0].setProps({
+            getReferenceClientRect: props.clientRect,
+          })
+        },
+
+        onKeyDown(props: any) {
+          if (!component) return false
+
+          if (props.event.key === 'Escape') {
+            popup?.[0]?.hide()
+            return true
+          }
+
+          return component.ref?.onKeyDown(props)
+        },
+
+        onExit() {
+          onActiveChange?.(false)
+          popup?.[0]?.destroy()
+          component?.destroy()
+        },
+      }
+    },
+  }
+
+  return Extension.create({
+    name: 'emojiSuggestion',
+    addProseMirrorPlugins() {
+      return [
+        Suggestion({
+          editor: this.editor,
+          ...suggestion,
+        }),
+      ]
+    },
+  })
+}

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -11,6 +11,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import TiptapMention from "@tiptap/extension-mention";
 import { createMentionSuggestion } from "./mentionSuggestion";
+import { createEmojiSuggestionExtension } from "./emojiSuggestion";
 import ConversationContext from "../Conversation/context";
 import clazz from "classnames";
 import WKSDK, { Channel, ChannelInfo, ChannelTypePerson, Subscriber } from "wukongimjssdk";
@@ -461,6 +462,8 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
   // 发送进行中标志：onSend 现在被 await，发送窗口内防止重复触发 (octo-web#227)。
   const sendingRef = useRef(false);
   const mentionActiveRef = useRef(false);
+  // 表情前缀联想下拉激活标志，激活时 Enter 用于选中而非发送
+  const emojiSuggestionActiveRef = useRef(false);
   const botCommandsRef = useRef(props.botCommands);
   // editorHandleKeyDownRef 持有最新的键盘处理函数，通过 useEffect 更新
   const editorHandleKeyDownRef = useRef<
@@ -539,6 +542,10 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         renderLabel({ options, node }) {
           return `@${node.attrs.label}`;
         },
+      }),
+      // 表情前缀联想：输入中文片段（如「使命」）联想出自定义表情 [使命必达]
+      createEmojiSuggestionExtension((active) => {
+        emojiSuggestionActiveRef.current = active;
       }),
     ],
     content: "",
@@ -1120,6 +1127,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
 
       if (event.key === "Enter" && !event.shiftKey) {
         if (mentionActiveRef.current) return false;
+        if (emojiSuggestionActiveRef.current) return false;
         sendRef.current?.();
         return true;
       }

--- a/packages/dmworkbase/src/Utils/emojiSuggestion.ts
+++ b/packages/dmworkbase/src/Utils/emojiSuggestion.ts
@@ -38,6 +38,12 @@ export const MIN_QUERY_LEN = 2
 const CJK_CHAR = /[一-鿿]/
 
 /**
+ * 中文串前一字符若属于这些「保留前导符」，则不触发表情联想：
+ * @ / 分别是 mention、slash 两套 suggestion 的触发符，[ 是表情 key 起始符。
+ */
+const RESERVED_PREFIX_CHARS = new Set(['@', '/', '['])
+
+/**
  * 取光标前最长的连续中文片段（词边界为任何非中文字符或文本起点）。
  * 例：「[使命必达]崇尚」→「崇尚」；「公司的使命是」→「公司的使命是」；
  * 光标前紧邻字母时返回空串。
@@ -101,6 +107,16 @@ export function matchEmojiPrefix(
   }
   const word = trailingChineseWord(textBeforeCursor)
   if (word.length < MIN_QUERY_LEN) {
+    return null
+  }
+  // 词边界守卫：中文串紧邻的前一字符若是其它 suggestion 的触发符（@ mention、
+  // / slash）或表情 key 起始符 [，则不触发表情联想。否则输入 @使命 / /使命 时
+  // 文本字面仍是 "@使命"（mention/slash 候选未落定成 node），trailingChineseWord
+  // 会取到 "使命" 并与 [使命必达] 同时弹出，造成两个下拉抢箭头/Enter；输入
+  // [使命 时则会在替换 query 后残留前导 [。word 为整段文本时前一字符为 undefined，
+  // 不命中守卫，正常联想。
+  const charBefore = textBeforeCursor[textBeforeCursor.length - word.length - 1]
+  if (charBefore !== undefined && RESERVED_PREFIX_CHARS.has(charBefore)) {
     return null
   }
   const items = getCustomEmojiItems().filter((e) => e.label.startsWith(word))

--- a/packages/dmworkbase/src/Utils/emojiSuggestion.ts
+++ b/packages/dmworkbase/src/Utils/emojiSuggestion.ts
@@ -1,0 +1,111 @@
+import { DefaultEmojiService } from "../Service/EmojiService"
+
+/**
+ * 输入框「表情前缀联想」的核心纯逻辑。
+ *
+ * 匹配规则（词边界 + 整段前缀）：取光标前最长的连续中文片段 W（遇到非中文
+ * 字符——字母/数字/标点/空格/已插入的 `[表情]` 的方括号——即为词边界），
+ * 当 W 长度 >= MIN_QUERY_LEN 且某表情名以 W 开头时触发。
+ *
+ *   「使命」          → W=使命           → 命中 [使命必达]
+ *   「公司的使命是」   → W=公司的使命是    → 非任何表情名前缀 → 不触发
+ *   「使命是xxx」      → 光标前是字母      → W 为空/非前缀     → 不触发
+ *   「[使命必达]崇尚」  → W=崇尚（] 为边界）→ 命中 [崇尚行动]
+ *
+ * 即：只有「从词边界开始、整段连续中文恰好是表情名前缀」才联想；句子中间
+ * 出现表情名二字（如「我要完成使命」）不会误触发。仅对中文 key 的自定义表情
+ * 生效；Unicode emoji（key 为表情符号本身）不参与文字联想。
+ *
+ * 这些函数不依赖 React / Tiptap，便于单测；运行时副作用仅来自 DefaultEmojiService
+ * 单例（emojiMap 运行期不变，因此对自定义表情列表做模块级缓存）。
+ */
+
+export interface EmojiSuggestItem {
+  /** 完整 key，插入输入框的纯文本，如 "[使命必达]" */
+  key: string
+  /** 去掉方括号的显示名，用于匹配与展示，如 "使命必达" */
+  label: string
+  /** 表情图片路径，如 "./emoji/custom_mission.png" */
+  image: string
+}
+
+/** 仅匹配形如 `[中文]` 的自定义表情 key；Unicode emoji 的 key 不会命中 */
+const CUSTOM_KEY_RE = /^\[.+\]$/
+
+/** 触发联想的最小 query 长度（汉字数），单字不触发以压制误弹 */
+export const MIN_QUERY_LEN = 2
+/** 判定「连续中文词」边界用的 CJK 统一汉字区间 */
+const CJK_CHAR = /[一-鿿]/
+
+/**
+ * 取光标前最长的连续中文片段（词边界为任何非中文字符或文本起点）。
+ * 例：「[使命必达]崇尚」→「崇尚」；「公司的使命是」→「公司的使命是」；
+ * 光标前紧邻字母时返回空串。
+ */
+export function trailingChineseWord(text: string): string {
+  let i = text.length
+  while (i > 0 && CJK_CHAR.test(text[i - 1])) {
+    i--
+  }
+  return text.slice(i)
+}
+
+let cachedItems: EmojiSuggestItem[] | null = null
+
+/**
+ * 从 EmojiService 取出所有自定义表情（中文 key），转为联想项。
+ * emojiMap 运行期不变，结果做模块级缓存。
+ */
+export function getCustomEmojiItems(): EmojiSuggestItem[] {
+  if (cachedItems) {
+    return cachedItems
+  }
+  cachedItems = DefaultEmojiService.shared
+    .getAllEmoji()
+    .filter((e) => CUSTOM_KEY_RE.test(e.key))
+    .map((e) => ({
+      key: e.key,
+      label: e.key.slice(1, -1),
+      image: e.image,
+    }))
+  return cachedItems
+}
+
+/** 测试辅助：清除缓存，使下一次 getCustomEmojiItems 重新构建 */
+export function resetEmojiSuggestCache(): void {
+  cachedItems = null
+}
+
+/**
+ * 按 query 做前缀匹配，返回命中的自定义表情列表。
+ * query 为空或长度不足时返回空数组。
+ */
+export function buildEmojiSuggestItems(query: string): EmojiSuggestItem[] {
+  if (!query || query.length < MIN_QUERY_LEN) {
+    return []
+  }
+  return getCustomEmojiItems().filter((e) => e.label.startsWith(query))
+}
+
+/**
+ * 判断光标前文本是否应触发表情联想（词边界 + 整段前缀规则，见文件头注释）。
+ *
+ * @param textBeforeCursor 当前文本节点中、光标之前的文本
+ * @returns 命中时返回 { query, items }，否则返回 null（不弹下拉）
+ */
+export function matchEmojiPrefix(
+  textBeforeCursor: string,
+): { query: string; items: EmojiSuggestItem[] } | null {
+  if (!textBeforeCursor) {
+    return null
+  }
+  const word = trailingChineseWord(textBeforeCursor)
+  if (word.length < MIN_QUERY_LEN) {
+    return null
+  }
+  const items = getCustomEmojiItems().filter((e) => e.label.startsWith(word))
+  if (items.length === 0) {
+    return null
+  }
+  return { query: word, items }
+}


### PR DESCRIPTION
## Summary

Adds input-side autocomplete for custom (bracketed Chinese) emojis in the message composer. Typing a Chinese prefix such as `使命` pops a horizontal candidate bar suggesting `[使命必达]`; selecting it inserts the plain emoji key, which the existing send/receive pipeline renders into the image.

## What changed

- **New Tiptap suggestion extension** (`emojiSuggestion.tsx`): no trigger char; a custom `findSuggestionMatch` does a **word-boundary prefix** match (longest trailing run of Chinese chars must be a prefix of an emoji name). Uses an **independent `pluginKey`** so it coexists with the existing `@` mention and `/` slash suggestions.
- **Match logic** (`Utils/emojiSuggestion.ts`): only custom bracketed-Chinese emojis participate (Unicode emojis do not); min query length 2; sentence-embedded names do not trigger (`公司的使命是`, `我要完成使命` → no match).
- **Candidate bar UI** (`EmojiSuggestionList.tsx` + `.css`): input-method-style horizontal bar (distinct from the vertical `@` member list), keyboard ← → (↑ ↓ compatible) + Enter, light-grey hover/selected highlight with a subtle `scale(1.06)`.
- **Insert path**: selecting inserts plain `[使命必达]` text — no custom node/entity, image rendering reuses the existing `emojiRegExp` pipeline unchanged.
- **Enter coexistence** (`index.tsx`): suppress send while the suggestion is active, mirroring `mentionActiveRef`.
- **IME fix**: the suggestion items callback no longer drops results while `editor.view.composing` is true — that gate swallowed the first match on `compositionend` and made typed (vs pasted) Chinese never trigger.

## Test plan

- [x] Unit tests for match logic — **13/13 passing** (`apps/web/src/__tests__/emojiSuggestion.test.ts`): prefix match, longest prefix, min-length, sentence-embedded non-trigger, non-Chinese/Unicode rejection, custom-set membership.
- [x] Dev server HMR — compiles without error.
- [ ] **Browser manual check (reviewer)**: typing `使命` via Chinese IME pops the bar (the IME `compositionend` timing can only be verified in a real browser); arrow/Enter selection; hover/selected highlight + scale; Enter selects (does not send) while active.
- [ ] `pnpm lint` not run locally — relying on CI.

## Notes

- No backend / protocol / render-pipeline changes.
- Currently 4 custom emojis qualify (`[使命必达] [崇尚行动] [有品位] [尚方宝剑]`); the feature scales automatically as the custom set grows.