### PR TITLE
fix(smart-summary): exclude declined members from pending in participant reports (#495)

### DIFF
--- a/packages/dmworksummary/src/components/CitationBadge.tsx
+++ b/packages/dmworksummary/src/components/CitationBadge.tsx
@@ -314,6 +314,15 @@ export const TeamCitationBadge: React.FC<TeamCitationBadgeProps> = ({ index, tea
                                 citations={[]}
                                 hidePlainCitations
                             />
+                        ) : member?.status === "declined" ? (
+                            // OCT-15 / upstream #495：纵深防御。正常流程里 declined 成员不会被
+                            // 后端写进 team_citations（GLM 评审结论），但若数据漂移让 popover
+                            // 拿到一个 declined 的 [Pn]，不再误显示「等待提交」。
+                            // 复用已有 i18n key summary.confirmPage.declined（“已拒绝参与” /
+                            // “Participation declined”），不新增翻译。
+                            <div style={{ fontSize: 12, color: '#999' }}>
+                                {t("summary.confirmPage.declined")}
+                            </div>
                         ) : (
                             <div style={{ fontSize: 12, color: '#999' }}>
                                 {t("summary.detail.waitingSubmit", { values: { name: citation.user_name } })}

--- a/packages/dmworksummary/src/components/CitationText.test.tsx
+++ b/packages/dmworksummary/src/components/CitationText.test.tsx
@@ -257,6 +257,31 @@ describe('CitationText — [n] vs [Pn] parsing', () => {
         expect(open[0].textContent).toContain('李四');
     });
 
+    // OCT-16 / upstream #495（纵深防御复核）：dev 在 CitationBadge 给 [Pn] popover 的
+    // memberContent 为空分支加了 declined 兜底——若数据漂移让 popover 拿到一个 declined
+    // 成员，应显示「已拒绝参与」(summary.confirmPage.declined) 而不是「等待提交」。
+    // 这是对 dev「改了 declined 路径」结论的对应单测。
+    it('6b) [Pn] click shows "已拒绝参与" (not waitingSubmit) when matched member is declined with no content', () => {
+        const members: MemberStatus[] = [
+            { user_id: 'u1', user_name: '王五', status: 'declined', submitted_at: null },
+        ];
+        render(
+            <CitationText
+                content="参见 [P1]"
+                citations={[]}
+                teamCitations={[makeTeamCitation({ index: 1, user_id: 'u1', user_name: '王五' })]}
+                members={members}
+            />,
+        );
+        const team = badgeByText('[P1]')!;
+        fireEvent.click(team);
+        const open = screen.queryAllByTestId('popover-content');
+        expect(open.length).toBeGreaterThanOrEqual(1);
+        // declined 成员显示「已拒绝参与」，不显示「等待提交」。
+        expect(open[0].textContent).toContain('已拒绝参与');
+        expect(open[0].textContent).not.toContain('等待提交');
+    });
+
     // m2（隐私兜底，第二轮）：[Pn] 弹窗渲染成员单人报告时，绝不消费 member.citations，
     // 且对 memberContent 清掉 [n] 角标——即便（旧后端/缓存）给 member 带了 citations，
     // 也不能让他人点开看到原始聊天记录。fail-before（CitationBadge 传 member.citations）/

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -1320,9 +1320,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         const { t } = this.context;
         // 如果只有 1 个人（creator 自己），不显示参与者报告区块
         if (membersLoading || members.length <= 1) return null;
+        // OCT-15 / upstream #495：成员按三类语义切分，pending 显式把 declined 排除掉，
+        // 否则被拒绝的成员会一直在「等待提交」里悬挂。declined 单独成集合，下面单独渲染。
         const submitted = members.filter((m) => m.submitted_at && m.content);
-        const pending = members.filter((m) => !m.submitted_at || !m.content);
-        if (submitted.length === 0 && pending.length === 0) return null;
+        const declined = members.filter((m) => m.status === "declined");
+        const pending = members.filter(
+            (m) => m.status !== "declined" && (!m.submitted_at || !m.content)
+        );
+        if (submitted.length === 0 && pending.length === 0 && declined.length === 0) return null;
         const myUid = WKApp.loginInfo.uid;
         // need2（排序）：把「我」那条置顶，其余保持原相对顺序（stable）。
         const submittedSorted = [
@@ -1432,6 +1437,23 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     <div key={m.user_id} className="summary-detail-participant-report-pending">
                         <IconClock style={{ fontSize: 14 }} />
                         <span>{t("summary.detail.waitingSubmit", { values: { name: m.user_name } })}</span>
+                    </div>
+                ))}
+                {/* OCT-15 / upstream #495：declined 成员单独成行，复用 confirmPage.declined（“已拒绝参与” / “Participation declined”）。
+                    沿用 pending 行的容器类名 + 一个 --declined modifier 以便将来定制样式；本次不动 SCSS。 */}
+                {declined.map((m) => (
+                    <div
+                        key={m.user_id}
+                        className="summary-detail-participant-report-pending summary-detail-participant-report-pending--declined"
+                    >
+                        <IconClose style={{ fontSize: 14 }} />
+                        <span>
+                            {m.user_name}
+                            <span style={{ color: "var(--semi-color-text-3)", fontWeight: 400 }}> · </span>
+                            <span style={{ fontSize: 13, color: "var(--semi-color-text-2)", fontWeight: 400 }}>
+                                {t("summary.confirmPage.declined")}
+                            </span>
+                        </span>
                     </div>
                 ))}
             </div>

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.participantReports.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.participantReports.test.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { render as rtlRender } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// OCT-16 / upstream #495 regression: renderParticipantReports() rendering verdict
+// for declined / pending / submitted combinations.
+//
+// Bug: declined members have no submitted_at; the old `pending` filter only looked
+// at "no submitted content", so declined members were misclassified as pending and
+// rendered as "{name} · waiting to submit", contradicting the member-status area's
+// "declined". Fix: pending filter explicitly excludes m.status === "declined";
+// declined members render on their own line as "Participation declined"
+// (summary.confirmPage.declined), and declined is counted in the early-return guard.
+//
+// Strategy: SummaryDetailPage is a class component; renderParticipantReports() reads
+// this.state / this.context. We instantiate directly, inject state/context, render
+// the returned JSX into jsdom, and assert on DOM text. Heavy children (CitationText /
+// SummaryEditor / semi-ui / semi-icons) are mocked to lightweight placeholders so we
+// only observe the three visible outputs we care about: waiting-submit / declined /
+// submitted body.
+
+const I18N = {
+    'summary.detail.participantReports': 'Participant reports',
+    'summary.detail.waitingSubmit': '{{name}} - waiting to submit...',
+    'summary.confirmPage.declined': 'Participation declined',
+    'summary.detail.collapse': 'Collapse',
+    'summary.detail.expandAll': 'Expand all',
+    'summary.detail.editMyReport': 'Edit',
+};
+const t = (key, opts) => {
+    let s = I18N[key] ?? key;
+    const values = opts?.values ?? {};
+    Object.keys(values).forEach((k) => {
+        s = s.replace(`{{${k}}}`, String(values[k]));
+    });
+    return s;
+};
+
+vi.mock('wukongimjssdk', () => ({
+    Channel: class {},
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    MessageText: class {},
+    WKSDK: { shared: () => ({ chatManager: { send: vi.fn() } }) },
+}));
+
+vi.mock('@douyinfe/semi-ui', () => {
+    const Passthrough = ({ children }) => children ?? null;
+    const Typography = Passthrough;
+    Typography.Text = Passthrough;
+    const Dropdown = Passthrough;
+    Dropdown.Menu = Passthrough;
+    Dropdown.Item = Passthrough;
+    return {
+        Button: Passthrough,
+        Typography,
+        Tag: Passthrough,
+        Avatar: Passthrough,
+        Spin: Passthrough,
+        Modal: Passthrough,
+        Banner: Passthrough,
+        Input: Passthrough,
+        Checkbox: Passthrough,
+        Empty: Passthrough,
+        Dropdown,
+        Popover: Passthrough,
+        Toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    };
+});
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconPlus: () => null,
+    IconClock: () => <i data-testid="icon-clock" />,
+    IconArrowLeft: () => null,
+    IconRefresh: () => null,
+    IconDelete: () => null,
+    IconEdit: () => null,
+    IconMore: () => null,
+    IconSend: () => null,
+    IconChevronDown: () => null,
+    IconUser: () => null,
+    IconTick: () => null,
+    IconClose: () => <i data-testid="icon-close" />,
+    IconInfoCircle: () => null,
+    IconHistory: () => null,
+    IconSearch: () => null,
+    IconMinusCircle: () => null,
+    IconExit: () => null,
+}));
+
+vi.mock('../../components/CitationText', () => ({
+    default: ({ content }) => <div data-testid="citation-text">{content}</div>,
+}));
+
+vi.mock('../../components/SummaryEditor', () => ({
+    default: () => <div data-testid="summary-editor" />,
+}));
+
+import SummaryDetailPage from '../SummaryDetailPage';
+
+function makeMember(over) {
+    return {
+        user_name: `user-${over.user_id}`,
+        status: 'pending',
+        submitted_at: null,
+        ...over,
+    };
+}
+
+// Build an instance, inject state/context, render the returned JSX.
+// personalResult omitted by default -> shouldShowMySubmit() returns false.
+function renderReports(members, stateOver = {}) {
+    const page = new SummaryDetailPage({ taskId: 1 });
+    page.context = { t };
+    page.state = {
+        ...page.state,
+        members,
+        membersLoading: false,
+        expandedReports: {},
+        editingPersonalReport: false,
+        personalResult: null,
+        isEditing: false,
+        editingTeamSummary: false,
+        detail: {
+            task_id: 1,
+            summary_mode: 1, // non BY_PERSON -> isMultiCollab()=false -> shouldShowMySubmit()=false
+            permissions: { can_edit_personal: false },
+            ...(stateOver.detail ?? {}),
+        },
+        ...stateOver,
+    };
+    const out = page.renderParticipantReports();
+    if (out === null) return { container: null, isNull: true };
+    const { container } = rtlRender(out);
+    return { container, isNull: false };
+}
+
+describe('SummaryDetailPage.renderParticipantReports - OCT-16 / #495 declined/pending/submitted', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // Scenario 1: single declined, no submitted, no pending.
+    it('1. single declined: shows declined line, not waiting-submit', () => {
+        const { container, isNull } = renderReports([
+            makeMember({ user_id: 'creator', user_name: 'Creator', status: 'submitted', submitted_at: '2026-01-01T00:00:00Z', content: 'my summary' }),
+            makeMember({ user_id: 'u2', user_name: 'Ming', status: 'declined' }),
+        ]);
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('Ming');
+        expect(text).toContain('Participation declined');
+        expect(text).not.toContain('waiting to submit');
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(1);
+        expect(container.querySelectorAll('[data-testid="icon-clock"]').length).toBe(0);
+        expect(container.querySelector('.summary-detail-participant-report-pending--declined')).not.toBeNull();
+    });
+
+    // Scenario 2: single pending (non-declined, no submitted_at). Behavior unchanged.
+    it('2. single pending: shows waiting-submit line, behavior unchanged', () => {
+        const { container, isNull } = renderReports([
+            makeMember({ user_id: 'creator', user_name: 'Creator', status: 'submitted', submitted_at: '2026-01-01T00:00:00Z', content: 'my summary' }),
+            makeMember({ user_id: 'u2', user_name: 'Hong', status: 'pending' }),
+        ]);
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('Hong - waiting to submit...');
+        expect(text).not.toContain('Participation declined');
+        expect(container.querySelectorAll('[data-testid="icon-clock"]').length).toBe(1);
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(0);
+    });
+
+    // Scenario 3: declined + pending mixed. Each on its own line; declined not in pending.
+    it('3. declined + pending mixed: separate lines, declined not mixed into pending', () => {
+        const { container, isNull } = renderReports([
+            makeMember({ user_id: 'creator', user_name: 'Creator', status: 'submitted', submitted_at: '2026-01-01T00:00:00Z', content: 'body' }),
+            makeMember({ user_id: 'u2', user_name: 'Ming', status: 'declined' }),
+            makeMember({ user_id: 'u3', user_name: 'Hong', status: 'pending' }),
+        ]);
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('Hong - waiting to submit...');
+        expect(text).toContain('Ming');
+        expect(text).toContain('Participation declined');
+        expect(text).not.toContain('Ming - waiting to submit');
+        expect(container.querySelectorAll('[data-testid="icon-clock"]').length).toBe(1);
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(1);
+    });
+
+    // Scenario 4: declined + submitted mixed. submitted shows body; declined own line.
+    it('4. declined + submitted mixed: submitted shows body, declined own line', () => {
+        const { container, isNull } = renderReports([
+            makeMember({ user_id: 'u1', user_name: 'Submitter', status: 'submitted', submitted_at: '2026-01-01T00:00:00Z', content: 'this is the submitted summary body' }),
+            makeMember({ user_id: 'u2', user_name: 'Decliner', status: 'declined' }),
+        ]);
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('this is the submitted summary body');
+        expect(text).toContain('Decliner');
+        expect(text).toContain('Participation declined');
+        expect(text).not.toContain('waiting to submit');
+        // submitted row renders an item container (not a pending/declined line);
+        // declined still renders exactly one IconClose line.
+        expect(container.querySelector('.summary-detail-participant-report-item')).not.toBeNull();
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(1);
+    });
+
+    // Scenario 5: only creator (members.length <= 1) -> early return null.
+    it('5. only creator: participant reports not rendered (early return null)', () => {
+        const { isNull } = renderReports([
+            makeMember({ user_id: 'creator', user_name: 'Creator', status: 'submitted', submitted_at: '2026-01-01T00:00:00Z', content: 'body' }),
+        ]);
+        expect(isNull).toBe(true);
+    });
+
+    // Scenario 6: showMyPending branch (self not submitted).
+    // personalResult.worker_status=2 with no submitted_at + BY_PERSON multi-person ->
+    // shouldShowMySubmit()=true. Verify this fix does not affect showMyPending, and
+    // co-existing others' pending / declined still split correctly.
+    it('6. showMyPending branch: self-not-submitted still renders own row, others declined/pending split intact', () => {
+        const { container, isNull } = renderReports(
+            [
+                // "me" = test-uid (WKApp mock loginInfo.uid)
+                makeMember({ user_id: 'test-uid', user_name: 'Me', status: 'pending' }),
+                makeMember({ user_id: 'u2', user_name: 'Hong', status: 'pending' }),
+                makeMember({ user_id: 'u3', user_name: 'Ming', status: 'declined' }),
+            ],
+            {
+                detail: { summary_mode: 2 /* BY_PERSON */, permissions: { can_edit_personal: false } },
+                personalResult: { worker_status: 2, submitted_at: null, content: 'my draft body', citations: [] },
+            },
+        );
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('Hong - waiting to submit...');
+        expect(text).toContain('Participation declined');
+        expect(text).not.toContain('Me - waiting to submit');
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(1);
+    });
+
+    // Scenario 7: all declined (submitted=0 && pending=0); guard counts declined.
+    it('7. all declined: not early-returned by submitted=0 && pending=0, renders declined lines', () => {
+        const { container, isNull } = renderReports([
+            makeMember({ user_id: 'u1', user_name: 'Alpha', status: 'declined' }),
+            makeMember({ user_id: 'u2', user_name: 'Beta', status: 'declined' }),
+        ]);
+        expect(isNull).toBe(false);
+        const text = container.textContent || '';
+        expect(text).toContain('Alpha');
+        expect(text).toContain('Beta');
+        expect(container.querySelectorAll('[data-testid="icon-close"]').length).toBe(2);
+        expect((text.match(/Participation declined/g) || []).length).toBe(2);
+        expect(text).not.toContain('waiting to submit');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #495.

In the BY_PERSON smart-summary detail page, when a participant **rejects** the invitation, the **member status section** correctly shows "已拒绝", but the **participant reports section** still rendered that member as `{name} · 等待提交...` — contradicting their own status and confusing the meeting owner.

Root cause: `SummaryDetailPage.renderParticipantReports()` derived `pending` purely from `submitted_at`/`content` emptiness, with no `status` check; declined members naturally have no `submitted_at` and fell through into the pending list. The same `summary.detail.waitingSubmit` string was used in `CitationBadge`'s team-citation popover, which would mis-label a declined member's empty content the same way.

## Changes

`packages/dmworksummary/src/pages/SummaryDetailPage.tsx` — `renderParticipantReports()` is now an explicit 3-way split (`submitted` / `declined` / `pending`):

```ts
const submitted = members.filter((m) => m.submitted_at && m.content);
const declined  = members.filter((m) => m.status === "declined");
const pending   = members.filter(
    (m) => m.status !== "declined" && (!m.submitted_at || !m.content)
);
if (submitted.length === 0 && pending.length === 0 && declined.length === 0) return null;
```

Declined members render as their own row using the existing icon (`IconClose`, already used by `statusConfig.declined` at the member-status section above) and the existing i18n key `summary.confirmPage.declined` (zh: "已拒绝参与" / en: "Participation declined") — **no new translation strings added**.

`packages/dmworksummary/src/components/CitationBadge.tsx` — `TeamCitationBadge` popover gets a defensive declined-first branch using the `member` already looked up from `memberList` on line 293:

```tsx
{memberContent ? <CitationText ... /> :
  member?.status === "declined" ? <div>{t("summary.confirmPage.declined")}</div> :
  <div>{t("summary.detail.waitingSubmit", { values: { name: citation.user_name } })}</div>}
```

`TeamCitationItem` itself has no `status` field, so the check is done on the looked-up `MemberStatus.status` (string), consistent with the same field's existing use at `SummaryDetailPage.tsx:1265` (`statusConfig[m.status]`) and `:1278` (`m.status === "pending"`). Note: under the normal backend contract a declined member never appears as a citation source (team_citations are generated from submitted personal reports), so this branch is belt-and-suspenders. It's cheap (one ternary, zero new state, zero new i18n) and pins down the symmetry with the `SummaryDetailPage` fix.

## Tests

`packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.participantReports.test.tsx` (new): 7-case matrix for the new split.

| # | Scenario | Assertion |
|---|---|---|
| 1 | Single declined member only | Shows "已拒绝参与" row, no "等待提交" |
| 2 | Single pending (non-declined) | Shows "等待提交" row (regression guard) |
| 3 | declined + pending mixed | Each in its own row, no cross-leak |
| 4 | declined + submitted mixed | Submitted shows full content, declined separate |
| 5 | Only creator (members.length ≤ 1) | Section short-circuits to null (unchanged) |
| 6 | showMyPending + others mixed | Self submit-row preserved; others routed correctly |
| 7 | All members declined | Section still renders the declined list (the early-return guard now also checks `declined.length === 0`) |

`packages/dmworksummary/src/components/CitationText.test.tsx` (extended): one new `TeamCitationBadge` case asserting the new declined-first popover branch shows "已拒绝参与" instead of "等待提交...".

Total: **356 / 356 tests pass under `pnpm --filter './packages/dmworksummary' test`** (previous baseline 348; +8 new). Negative controls were run: removing either fix site (the pending filter or the CitationBadge defense) turns the new assertions red, confirming they actually pin #495.

## Scope / Non-changes

- Frontend display only. Backend `metaCompletionReady` already excludes declined from the roster — untouched.
- No i18n changes (reuses the pre-existing `summary.confirmPage.declined` key, also used by `SummaryConfirmPage.tsx:100`).
- No new components, no drive-by refactor of `renderParticipantReports`'s other branches.
- No SCSS changes; the new row reuses `summary-detail-participant-report-pending` plus a `--declined` modifier so theming can specialise later without blocking this fix.

## Verification

- Local: `make build` (Dockerfile) → `Successfully tagged octoweb:latest`, container serves the new bundle (`HTTP/1.1 200 OK`), production bundle (`assets/index-*.js`) contains all expected fingerprints: `已拒绝参与` (1×), `Participation declined` (1×), `confirmPage.declined` (3×), `--declined` (1×), two minified `status === "declined"` checks (one per fix site).
- Vitest: 356/356 green, no regressions across the dmworksummary package's 24 test files.

Closes #495.
