### PR TITLE
fix(channel-webhook): ignore IME composition Enter in webhook name input

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -323,7 +323,11 @@ export default function WebhookEditModal({
                         placeholder={t("base.channelWebhook.form.namePlaceholder")}
                         onChange={(e) => setName(e.target.value)}
                         onKeyDown={(e) => {
-                            if (e.key === "Enter") void handleSubmit();
+                            // 排除输入法组字回车（中文拼音等选词/上屏），仅非组字状态
+                            // 的回车才提交，避免误触发创建（#500）。
+                            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                                void handleSubmit();
+                            }
                         }}
                     />
                     {!isManager && (

--- a/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
@@ -249,3 +249,37 @@ describe('WebhookEditModal mention_uids picker', () => {
     expect(hoisted.update).not.toHaveBeenCalled();
   });
 });
+
+describe('WebhookEditModal name input Enter / IME composition (#500)', () => {
+  const nameInput = (): HTMLInputElement =>
+    container.querySelectorAll<HTMLInputElement>('.wk-webhook-form__input')[0];
+
+  const pressEnter = (isComposing: boolean): void => {
+    act(() => {
+      nameInput().dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          isComposing,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+  };
+
+  it('does NOT submit when Enter fires during IME composition (选词/上屏)', async () => {
+    await render({});
+    // 中文拼音等输入法组字过程中的回车仅用于上屏候选，不应触发创建。
+    pressEnter(true);
+    await flush();
+    expect(hoisted.create).not.toHaveBeenCalled();
+  });
+
+  it('submits when Enter fires outside composition', async () => {
+    await render({});
+    // 非组字状态下的回车仍应正常提交创建（名称可留空，服务端自动命名）。
+    pressEnter(false);
+    await flush();
+    expect(hoisted.create).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The "new webhook" modal (channel settings → incoming webhook → **新建 Webhook**) submitted the form on **any** `Enter` keydown in the name input — including the `Enter` used to confirm an IME (e.g. Chinese Pinyin) composition candidate. A user typing a name with an IME would press `Enter` to commit a candidate and instead fire the create request mid-input, unable to keep typing.

## Root cause

`packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx`, name input `onKeyDown`:

```tsx
if (e.key === "Enter") void handleSubmit();
```

The handler did not exclude the IME composition state. During composition (选词/上屏), the `Enter` keydown also fires, but `e.nativeEvent.isComposing === true` at that moment; the code treated this "composition Enter" as a submit.

## Fix

Guard the submit with `!e.nativeEvent.isComposing`, so only a non-composing `Enter` submits — matching MDN's recommended IME-aware input handling and the composition handling already used elsewhere in the app (ChannelSearch / GlobalSearch). Degrades safely on engines without `isComposing` (`!undefined === true` → original behavior).

## Reproduction (before)

1. Open a group → channel settings → 群消息推送 → 新建 Webhook.
2. Focus the name input, simulating an IME candidate-confirm `Enter` (`isComposing = true`).
3. Observed: a `POST .../incoming-webhooks` create request fires (form submitted mid-composition).

## Verification (after)

Verified in the real dev stack (Chromium) by dispatching the exact same events and watching network:

| Scenario | Before | After |
| --- | --- | --- |
| Composition `Enter` (`isComposing=true`) | `POST /incoming-webhooks` ×1 | **0 requests**, modal stays open ✓ |
| Plain `Enter` (`isComposing=false`) | — | **1 request**, submits normally ✓ (control) |

## Tests

Added two cases to `WebhookEditModal.test.tsx`:
- composition `Enter` does **not** call create;
- plain `Enter` still calls create once (control).

Full `dmworkbase` suite: no new failures introduced (pre-existing baseline failures are unrelated jsdom/localStorage env issues, identical count with and without this change).

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)