### PR TITLE
feat(web): render message reactions in chat (#111)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/reactionMerge.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/reactionMerge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { applyRemoteReactions } from "../reactionMerge"
+
+// 模拟本地消息（只关心 message.reactions 这一结构面）
+const local = (reactions: unknown[] = []) => ({ message: { reactions } })
+
+describe("applyRemoteReactions", () => {
+    it("returns false and touches nothing when remote is empty", () => {
+        const resolve = () => { throw new Error("should not be called") }
+        expect(applyRemoteReactions([], resolve)).toBe(false)
+    })
+
+    it("overwrites reactions on a matched local message and returns true", () => {
+        const m1 = local([{ emoji: "old" }])
+        const store: Record<string, ReturnType<typeof local>> = { msg1: m1 }
+        const changed = applyRemoteReactions(
+            [{ messageID: "msg1", reactions: [{ emoji: "👍", count: 1 }] }],
+            (id) => store[id],
+        )
+        expect(changed).toBe(true)
+        expect(m1.message.reactions).toEqual([{ emoji: "👍", count: 1 }])
+    })
+
+    it("normalizes missing remote reactions to [] (clears stale)", () => {
+        const m1 = local([{ emoji: "stale" }])
+        const changed = applyRemoteReactions(
+            [{ messageID: "msg1" }],            // reactions undefined → 清空
+            () => m1,
+        )
+        expect(changed).toBe(true)
+        expect(m1.message.reactions).toEqual([])
+    })
+
+    it("skips remote messages not present in the current page (no false create)", () => {
+        const changed = applyRemoteReactions(
+            [{ messageID: "not-on-page", reactions: [{ emoji: "👍" }] }],
+            () => undefined,                    // 本地找不到
+        )
+        expect(changed).toBe(false)
+    })
+
+    it("updates only matched messages in a mixed batch", () => {
+        const m1 = local([])
+        const store: Record<string, ReturnType<typeof local>> = { msg1: m1 }
+        const changed = applyRemoteReactions(
+            [
+                { messageID: "msg1", reactions: [{ emoji: "❤️" }] },
+                { messageID: "msg-absent", reactions: [{ emoji: "👍" }] },
+            ],
+            (id) => store[id],
+        )
+        expect(changed).toBe(true)
+        expect(m1.message.reactions).toEqual([{ emoji: "❤️" }])
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/reactionMerge.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/reactionMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { applyRemoteReactions } from "../reactionMerge"
+import { applyRemoteReactions, refreshReactionsCore } from "../reactionMerge"
 
 // 模拟本地消息（只关心 message.reactions 这一结构面）
 const local = (reactions: unknown[] = []) => ({ message: { reactions } })
@@ -51,5 +51,40 @@ describe("applyRemoteReactions", () => {
         )
         expect(changed).toBe(true)
         expect(m1.message.reactions).toEqual([{ emoji: "❤️" }])
+    })
+})
+
+describe("refreshReactionsCore", () => {
+    it("merges fetched reactions and returns changed", async () => {
+        const m1 = local([])
+        const changed = await refreshReactionsCore(
+            async () => [{ messageID: "msg1", reactions: [{ emoji: "👍" }] }],
+            () => m1,
+            () => { throw new Error("onError should not be called on success") },
+        )
+        expect(changed).toBe(true)
+        expect(m1.message.reactions).toEqual([{ emoji: "👍" }])
+    })
+
+    it("returns false on empty/undefined fetch without calling onError", async () => {
+        const onErr = (_e: unknown) => { throw new Error("onError should not be called") }
+        expect(await refreshReactionsCore(async () => [], () => undefined, onErr)).toBe(false)
+        expect(await refreshReactionsCore(async () => undefined, () => undefined, onErr)).toBe(false)
+    })
+
+    // Failure path: a sync rejection must be caught (reported via onError) and
+    // must NOT propagate — a passive reaction refresh failing cannot be allowed
+    // to crash the syncMessageReaction CMD handler, and there is no user-facing
+    // error.
+    it("swallows a sync failure: reports via onError, returns false, does not throw", async () => {
+        let reported: unknown = null
+        const boom = new Error("sync failed")
+        const changed = await refreshReactionsCore(
+            async () => { throw boom },
+            () => { throw new Error("resolveLocal must not run when fetch fails") },
+            (err) => { reported = err },
+        )
+        expect(changed).toBe(false)
+        expect(reported).toBe(boom)
     })
 })

--- a/packages/dmworkbase/src/Components/Conversation/reactionMerge.ts
+++ b/packages/dmworkbase/src/Components/Conversation/reactionMerge.ts
@@ -32,3 +32,28 @@ export function applyRemoteReactions(
     }
     return changed
 }
+
+/**
+ * 取数 + 合并 + 错误处理的纯 core，供 ConversationVM.refreshReactions 委托。
+ * syncMessages / resolveLocal 由调用方注入（生产里是 WKApp 同步 + VM 查找），
+ * 失败路径在此收口：reaction 刷新是被动的非关键更新，一次同步失败**不得**冒泡
+ * 打断 CMD handler，也不该弹用户可见错误——故 catch 后经 onError 记录并返回
+ * false（无变更），而非抛出。
+ * @returns 是否有本地消息被更新（调用方据此决定 notifyListener）。
+ */
+export async function refreshReactionsCore(
+    syncMessages: () => Promise<RemoteReactionSource[] | undefined>,
+    resolveLocal: (messageID: string) => ReactionTarget | undefined,
+    onError: (err: unknown) => void,
+): Promise<boolean> {
+    try {
+        const remote = await syncMessages()
+        if (!remote || remote.length === 0) {
+            return false
+        }
+        return applyRemoteReactions(remote, resolveLocal)
+    } catch (err) {
+        onError(err)
+        return false
+    }
+}

--- a/packages/dmworkbase/src/Components/Conversation/reactionMerge.ts
+++ b/packages/dmworkbase/src/Components/Conversation/reactionMerge.ts
@@ -1,0 +1,34 @@
+// reactionMerge —— syncMessageReaction CMD 不带 message_id，所以 refreshReactions
+// 重拉本频道最近一页消息后，按 messageID 把远端 reactions 合并进已渲染的本地消息。
+// 这段「按 id 匹配 + 覆盖 reactions + 是否有变更」的逻辑抽成纯函数，便于单测：
+// resolveLocal 注入本地查找（生产里是 ConversationVM.findMessageWithMessageID），
+// 不在当前页的远端消息找不到本地对应项 → 跳过，不误建。
+
+interface ReactionTarget {
+    message: { reactions: unknown[] }
+}
+
+interface RemoteReactionSource {
+    messageID: string
+    reactions?: unknown[]
+}
+
+/**
+ * 把 remoteMessages 的 reactions 合并进本地消息。
+ * @returns 是否有任一本地消息被更新（决定要不要 notifyListener 重渲染）。
+ */
+export function applyRemoteReactions(
+    remoteMessages: RemoteReactionSource[],
+    resolveLocal: (messageID: string) => ReactionTarget | undefined,
+): boolean {
+    let changed = false
+    for (const remote of remoteMessages) {
+        const existing = resolveLocal(remote.messageID)
+        if (existing) {
+            // 覆盖式写入：远端是该消息 reactions 的权威全量（Convert.toReactions 已聚合）。
+            existing.message.reactions = remote.reactions || []
+            changed = true
+        }
+    }
+    return changed
+}

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1340,6 +1340,13 @@ export default class ConversationVM extends ProviderListener {
     // 刷新消息表情回应：收到 syncMessageReaction CMD 后重新拉取本频道最近一页
     // 消息（reactions 由 Convert.toMessage 聚合带出），把新的 reactions 合并进
     // 已渲染的对应 message，再重渲染。CMD 不带 message_id，所以按页 diff 合并。
+    //
+    // 已知限制（平台级，非本改动引入）：CMDSyncMessageReaction 全平台都不带
+    // message_id（user 端 addOrCancelReaction 与 bot 端同款），所以这里只能重拉
+    // 最新一页。对一条**已加载但不在最新页**的历史消息加/删 reaction，当前列表
+    // 不会实时更新，直到用户翻页/重载。user 表情有完全相同的限制。彻底修复需让
+    // CMD 携带 message_id 后做 targeted refresh（user+bot+web 同步改），属独立
+    // follow-up，不在本轮 reactions 范围内。
     async refreshReactions() {
         const opts = new SyncMessageOptions()
         opts.limit = WKApp.config.pageSizeOfMessage

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -2,7 +2,7 @@ import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK
 import WKApp from "../../App";
 import { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
 import { MessageWrap } from "../../Service/Model";
-import { applyRemoteReactions } from "./reactionMerge";
+import { refreshReactionsCore } from "./reactionMerge";
 import { ProviderListener } from "../../Service/Provider";
 import { isConversationDisbanded } from "../../Utils/groupDisband";
 import { animateScroll, scroller } from 'react-scroll';
@@ -913,9 +913,9 @@ export default class ConversationVM extends ProviderListener {
                 // 一页消息（reactions 由 Convert.toMessage 聚合带出），把新的
                 // reactions 合并进已渲染的对应 message，再重渲染。
                 if (message.channel.isEqual(this.channel)) {
-                    this.refreshReactions().catch((err) => {
-                        console.error('[ConversationVM] refreshReactions failed:', err)
-                    })
+                    // refreshReactionsCore swallows failures (logs, returns
+                    // false), so this never rejects — fire and forget.
+                    void this.refreshReactions()
                 }
             }
         }
@@ -1352,13 +1352,10 @@ export default class ConversationVM extends ProviderListener {
         opts.limit = WKApp.config.pageSizeOfMessage
         opts.startMessageSeq = 0
         opts.pullMode = PullMode.Down
-        const remoteMessages = await WKApp.conversationProvider.syncMessages(this.channel, opts)
-        if (!remoteMessages || remoteMessages.length === 0) {
-            return
-        }
-        let changed = applyRemoteReactions(
-            remoteMessages,
+        const changed = await refreshReactionsCore(
+            () => WKApp.conversationProvider.syncMessages(this.channel, opts),
             (messageID) => this.findMessageWithMessageID(messageID),
+            (err) => console.error('[ConversationVM] refreshReactions failed:', err),
         )
         if (changed) {
             this.notifyListener()

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -906,6 +906,16 @@ export default class ConversationVM extends ProviderListener {
                     })
                 }
 
+            } else if (cmdContent.cmd === 'syncMessageReaction') { // 同步消息表情回应
+                // 服务端的 reaction CMD 只携带 channel（不含 message_id/emoji），
+                // 与 user 端 addOrCancelReaction 一致。收到后重新拉取本频道最近
+                // 一页消息（reactions 由 Convert.toMessage 聚合带出），把新的
+                // reactions 合并进已渲染的对应 message，再重渲染。
+                if (message.channel.isEqual(this.channel)) {
+                    this.refreshReactions().catch((err) => {
+                        console.error('[ConversationVM] refreshReactions failed:', err)
+                    })
+                }
             }
         }
         WKSDK.shared().chatManager.addCMDListener(this.cmdListener)
@@ -1324,6 +1334,31 @@ export default class ConversationVM extends ProviderListener {
         }
         this.notifyListener()
 
+    }
+
+    // 刷新消息表情回应：收到 syncMessageReaction CMD 后重新拉取本频道最近一页
+    // 消息（reactions 由 Convert.toMessage 聚合带出），把新的 reactions 合并进
+    // 已渲染的对应 message，再重渲染。CMD 不带 message_id，所以按页 diff 合并。
+    async refreshReactions() {
+        const opts = new SyncMessageOptions()
+        opts.limit = WKApp.config.pageSizeOfMessage
+        opts.startMessageSeq = 0
+        opts.pullMode = PullMode.Down
+        const remoteMessages = await WKApp.conversationProvider.syncMessages(this.channel, opts)
+        if (!remoteMessages || remoteMessages.length === 0) {
+            return
+        }
+        let changed = false
+        for (const remote of remoteMessages) {
+            const existing = this.findMessageWithMessageID(remote.messageID)
+            if (existing) {
+                existing.message.reactions = remote.reactions || []
+                changed = true
+            }
+        }
+        if (changed) {
+            this.notifyListener()
+        }
     }
 
     // 修改被回复的消息体

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -2,6 +2,7 @@ import { Channel, ChannelTypeGroup, ChannelTypePerson, ConversationAction, WKSDK
 import WKApp from "../../App";
 import { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
 import { MessageWrap } from "../../Service/Model";
+import { applyRemoteReactions } from "./reactionMerge";
 import { ProviderListener } from "../../Service/Provider";
 import { isConversationDisbanded } from "../../Utils/groupDisband";
 import { animateScroll, scroller } from 'react-scroll';
@@ -1348,14 +1349,10 @@ export default class ConversationVM extends ProviderListener {
         if (!remoteMessages || remoteMessages.length === 0) {
             return
         }
-        let changed = false
-        for (const remote of remoteMessages) {
-            const existing = this.findMessageWithMessageID(remote.messageID)
-            if (existing) {
-                existing.message.reactions = remote.reactions || []
-                changed = true
-            }
-        }
+        let changed = applyRemoteReactions(
+            remoteMessages,
+            (messageID) => this.findMessageWithMessageID(messageID),
+        )
         if (changed) {
             this.notifyListener()
         }

--- a/packages/dmworkbase/src/Messages/Base/index.css
+++ b/packages/dmworkbase/src/Messages/Base/index.css
@@ -552,3 +552,31 @@ body[theme-mode=dark] .wk-message-base-bubble-box.recv .wk-message-base-bubble  
   background: #1C1C23;
   border-color: #1C1C23;
 }
+
+/* 消息表情回应（reactions）——气泡下方的表情 chip 行 */
+.wk-message-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.wk-message-reaction-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 7px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  font-size: 13px;
+  line-height: 18px;
+  cursor: default;
+  user-select: none;
+}
+.wk-message-reaction-emoji {
+  font-size: 14px;
+}
+.wk-message-reaction-count {
+  font-size: 12px;
+  color: #666;
+}

--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -314,6 +314,35 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     }
   }
 
+  renderReactions() {
+    const { message } = this.props;
+    const reactions = (message as any)?.reactions as
+      | Array<{ emoji: string; count: number; users?: Array<{ uid: string; name: string }> }>
+      | undefined;
+    if (!reactions || reactions.length === 0) {
+      return null;
+    }
+    return (
+      <div className="wk-message-reactions">
+        {reactions.map((r) => {
+          const names = (r.users || []).map((u) => u?.name).filter(Boolean).join("、");
+          return (
+            <span
+              key={r.emoji}
+              className="wk-message-reaction-chip"
+              title={names}
+            >
+              <span className="wk-message-reaction-emoji">{r.emoji}</span>
+              {r.count > 1 && (
+                <span className="wk-message-reaction-count">{r.count}</span>
+              )}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
   render() {
     const { message, context, hiddeBubble, bubbleStyle } = this.props;
     const hasContinue = this.isContinue();
@@ -606,6 +635,11 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
                   )}
                 </div>
               </div>
+
+              {/* 消息表情回应（reactions）。数据由 Convert.toMessage 从
+                  /message/channel/sync 聚合进 message.reactions（SDK 自身不填充）。
+                  CMDSyncMessageReaction 触发重新拉取后这里随之更新。 */}
+              {this.renderReactions()}
 
               {/* Thread 指示条 */}
               {this.props.threadInfo && (

--- a/packages/dmworkbase/src/Service/Convert.ts
+++ b/packages/dmworkbase/src/Service/Convert.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { Setting } from "wukongimjssdk";
-import { WKSDK, ChannelInfo, Channel, Conversation, Message, MessageStatus, ChannelTypePerson, ChannelTypeGroup,ConversationExtra,Reminder, MessageExtra, Reply } from "wukongimjssdk";
+import { WKSDK, ChannelInfo, Channel, Conversation, Message, MessageStatus, ChannelTypePerson, ChannelTypeGroup,ConversationExtra,Reminder, MessageExtra, Reply, Reaction } from "wukongimjssdk";
 import { displayName as resolveDisplayName } from "../Utils/displayName";
 
 
@@ -280,7 +280,16 @@ export class Convert {
             const messageExtra = msgMap["message_extra"]
            message.remoteExtra = this.toMessageExtra(messageExtra)
         }
-        
+
+        // 消息表情回应（reactions）。服务端 /message/channel/sync 按「每个
+        // actor 一条」返回 {seq,uid,name,emoji,is_deleted}，而 SDK 的 Reaction
+        // 是「按 emoji 聚合」的 {seq,count,emoji,users[]}。这里做过滤 + 聚合：
+        // 跳过已撤回（is_deleted=1）的条目，按 emoji 分组，count = 人数，
+        // users 保留 uid/name 便于 hover 展示是谁回应的。wukongimjssdk 1.3.5
+        // 只声明了 Message.reactions 字段、并不在 sync 解析里填充它，所以由本
+        // 转换层补上，否则前端永远拿不到 reaction 数据（机器人/用户都一样）。
+        message.reactions = this.toReactions(msgMap["reactions"])
+
         message.clientSeq = msgMap["client_seq"]
         message.channel = new Channel(msgMap['channel_id'], msgMap['channel_type']);
         message.messageSeq = msgMap["message_seq"]
@@ -310,6 +319,41 @@ export class Convert {
         applyMsgLevelExternalFieldsWithFallback(message, msgMap)
 
         return message
+    }
+
+    static toReactions(rawList: any): Reaction[] {
+        if (!Array.isArray(rawList) || rawList.length === 0) {
+            return []
+        }
+        // 按 emoji 聚合：服务端是「每个 actor 一条」，SDK 要「每个 emoji 一组」。
+        // 跳过 is_deleted=1（已撤回）；同一 emoji 的 seq 取该组最大值（最近一次
+        // 变更），count = 人数，users 保留 {uid,name} 供 hover 显示是谁回应的。
+        const groups = new Map<string, Reaction>()
+        for (const item of rawList) {
+            if (!item || item["is_deleted"] === 1) {
+                continue
+            }
+            const emoji = item["emoji"]
+            if (!emoji) {
+                continue
+            }
+            const seq = Number(item["seq"]) || 0
+            let group = groups.get(emoji)
+            if (!group) {
+                group = new Reaction()
+                group.emoji = emoji
+                group.count = 0
+                group.users = []
+                group.seq = String(seq)
+                groups.set(emoji, group)
+            }
+            group.count += 1
+            group.users.push({ uid: item["uid"], name: item["name"] })
+            if (seq > Number(group.seq)) {
+                group.seq = String(seq)
+            }
+        }
+        return Array.from(groups.values())
     }
 
     static toMessageExtra(msgExtraMap: any) :MessageExtra {

--- a/packages/dmworkbase/src/Service/__tests__/Convert.reactions.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Convert.reactions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { Convert } from "../Convert"
+
+// 服务端 /message/channel/sync 的 reactions 是「每个 actor 一条」
+// {seq,uid,name,emoji,is_deleted}；Convert.toReactions 负责过滤已撤回 +
+// 按 emoji 聚合成 SDK 的 {seq,count,emoji,users[]}。这些断言锁住聚合契约，
+// 防止后续改动悄悄破坏前端拿到的 reaction 形状。
+const row = (over: Record<string, unknown> = {}) => ({
+    seq: 1,
+    uid: "u1",
+    name: "n1",
+    emoji: "👍",
+    is_deleted: 0,
+    ...over,
+})
+
+describe("Convert.toReactions", () => {
+    it("returns [] for non-array / empty input", () => {
+        expect(Convert.toReactions(undefined)).toEqual([])
+        expect(Convert.toReactions(null)).toEqual([])
+        expect(Convert.toReactions("nope")).toEqual([])
+        expect(Convert.toReactions([])).toEqual([])
+    })
+
+    it("aggregates a single actor into one emoji group", () => {
+        const out = Convert.toReactions([row({ uid: "u1", name: "n1", emoji: "👍", seq: 5 })])
+        expect(out).toHaveLength(1)
+        expect(out[0].emoji).toBe("👍")
+        expect(out[0].count).toBe(1)
+        expect(out[0].users).toEqual([{ uid: "u1", name: "n1" }])
+        // seq 以字符串形式带出（SDK Reaction.seq:string）
+        expect(out[0].seq).toBe("5")
+    })
+
+    it("aggregates multiple actors of the same emoji: count = 人数, users 全保留", () => {
+        const out = Convert.toReactions([
+            row({ uid: "u1", name: "n1", emoji: "👍", seq: 3 }),
+            row({ uid: "u2", name: "n2", emoji: "👍", seq: 7 }),
+            row({ uid: "u3", name: "n3", emoji: "👍", seq: 4 }),
+        ])
+        expect(out).toHaveLength(1)
+        expect(out[0].count).toBe(3)
+        expect(out[0].users).toEqual([
+            { uid: "u1", name: "n1" },
+            { uid: "u2", name: "n2" },
+            { uid: "u3", name: "n3" },
+        ])
+        // 同组 seq 取最大值（最近一次变更），与顺序无关
+        expect(out[0].seq).toBe("7")
+    })
+
+    it("splits different emojis into separate groups (insertion order)", () => {
+        const out = Convert.toReactions([
+            row({ emoji: "👍", uid: "u1" }),
+            row({ emoji: "❤️", uid: "u2" }),
+            row({ emoji: "👍", uid: "u3" }),
+        ])
+        expect(out.map((r) => r.emoji)).toEqual(["👍", "❤️"])
+        const thumbs = out.find((r) => r.emoji === "👍")!
+        const heart = out.find((r) => r.emoji === "❤️")!
+        expect(thumbs.count).toBe(2)
+        expect(heart.count).toBe(1)
+    })
+
+    it("skips撤回 (is_deleted=1) entries", () => {
+        const out = Convert.toReactions([
+            row({ uid: "u1", emoji: "👍", is_deleted: 0 }),
+            row({ uid: "u2", emoji: "👍", is_deleted: 1 }),
+        ])
+        expect(out).toHaveLength(1)
+        expect(out[0].count).toBe(1)
+        expect(out[0].users).toEqual([{ uid: "u1", name: "n1" }])
+    })
+
+    it("returns [] when every entry is撤回", () => {
+        const out = Convert.toReactions([
+            row({ emoji: "👍", is_deleted: 1 }),
+            row({ emoji: "❤️", is_deleted: 1 }),
+        ])
+        expect(out).toEqual([])
+    })
+
+    it("skips malformed entries (null / missing emoji)", () => {
+        const out = Convert.toReactions([
+            null,
+            row({ emoji: "" }),
+            row({ emoji: undefined }),
+            row({ emoji: "👍", uid: "u9", name: "n9" }),
+        ])
+        expect(out).toHaveLength(1)
+        expect(out[0].emoji).toBe("👍")
+        expect(out[0].users).toEqual([{ uid: "u9", name: "n9" }])
+    })
+
+    it("coerces missing/NaN seq to 0", () => {
+        const out = Convert.toReactions([row({ emoji: "👍", seq: undefined })])
+        expect(out[0].seq).toBe("0")
+    })
+})

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -124,6 +124,7 @@ export function getMessageRow(
       isExternal: false,
       isRealnameVerified: false,
       onSelect: selection?.onSelect,
+      reactions: (message as any).reactions,
     }
   }
 
@@ -260,6 +261,7 @@ export function getMessageRow(
     onSelect: selection?.onSelect,
     onAvatarClick,
     onSenderNameClick,
+    reactions: (message as any).reactions,
   }
 }
 

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -210,3 +210,31 @@
   background: #1C1C23;
   border-color: #1C1C23;
 }
+
+/* 消息表情回应（reactions）——消息体下方的表情 chip 行 */
+.wk-msg-row-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.wk-msg-row-reaction-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 8px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  font-size: 13px;
+  line-height: 18px;
+  cursor: default;
+  user-select: none;
+}
+.wk-msg-row-reaction-emoji {
+  font-size: 14px;
+}
+.wk-msg-row-reaction-count {
+  font-size: 12px;
+  color: #888;
+}

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
@@ -59,10 +59,16 @@ export interface MessageRowProps {
   
   /** 选择状态变化回调 */
   onSelect?: (selected: boolean) => void
-  
+
   /** 消息内容（子组件） */
   children: React.ReactNode
-  
+
+  /**
+   * 消息表情回应（reactions），已按 emoji 聚合。bridge 层从
+   * message.reactions（由 Convert.toMessage 解析填充）提取。为空 / undefined
+   * 时不渲染回应行。
+   */
+  reactions?: Array<{ emoji: string; count: number; users?: Array<{ uid: string; name: string }> }>
   /** 是否显示多选 Checkbox */
   showCheckbox?: boolean
 
@@ -120,6 +126,7 @@ export default function MessageRow({
   isRealnameVerified,
   onSelect,
   children,
+  reactions,
   showCheckbox = false,
   selectionMode = false,
   onContextMenu,
@@ -249,6 +256,24 @@ export default function MessageRow({
         <div className="wk-msg-row-body">
           {children}
         </div>
+
+        {/* 消息表情回应（reactions）。数据由 Convert.toMessage 聚合进
+            message.reactions，bridge useMessageRow 透传到这里。 */}
+        {reactions && reactions.length > 0 && (
+          <div className="wk-msg-row-reactions">
+            {reactions.map((r) => {
+              const names = (r.users || []).map((u) => u?.name).filter(Boolean).join('、')
+              return (
+                <span key={r.emoji} className="wk-msg-row-reaction-chip" title={names}>
+                  <span className="wk-msg-row-reaction-emoji">{r.emoji}</span>
+                  {r.count > 1 && (
+                    <span className="wk-msg-row-reaction-count">{r.count}</span>
+                  )}
+                </span>
+              )
+            })}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Render message reactions in chat (frontend of the three-end #111 reactions feature).

## Related Issue

#111

## Changes

- `Convert.toReactions`: aggregate the server's per-actor rows `{seq, uid, name, emoji, is_deleted}` into per-emoji groups `{seq, count, emoji, users[]}` — skip `is_deleted`, count = number of actors, seq = max within the group.
- `MessageRow` (and the legacy Base bubble) render a reaction chip row under the message body; `useMessageRow` forwards the data.
- `ConversationVM` handles the `syncMessageReaction` CMD by re-pulling the latest page and merging fresh reactions by message id. The fetch + merge + error-handling is extracted into a pure `reactionMerge.ts` seam (match/overwrite/changed-gate; a sync failure is caught and non-fatal) so it is unit-testable without instantiating the VM.
- Documented a known platform-level limitation (not introduced here): `CMDSyncMessageReaction` carries no message_id, so a reaction on an already-loaded but off-latest-page message does not live-update until reload (user reactions share this). Proper fix is a separate follow-up.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

`vitest` — `Convert.reactions` (aggregation / is_deleted filter / max-seq / malformed), `reactionMerge` (merge + swallowed-failure path), `MessageRow`: all pass. Three-end e2e verified (bot reaction → chip rendered in chat).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran \`pnpm i18n:check\` or confirmed the change does not affect UI copy
- [x] Followed commit message conventions (Conventional Commits)

> Draft: reactions is a three-end feature — ships with octo-server (endpoint) + openclaw-channel-octo (react action). Reaction chips show emoji + count only; no new translatable UI copy.