### PR TITLE
feat(summary): pre-submit personal draft edit entry (OCT-21)

### DIFF
--- a/packages/dmworksummary/src/api/__tests__/personalDraft.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/personalDraft.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// OCT-21 Stage 4 (v2 F1) — personalDraftSummary must NOT reuse the `put` helper,
+// because that helper rethrows `new Error(extractErrorMessage(err))` and drops
+// `response.status`. SummaryEditor.handleSave's 409 branch hard-depends on
+// `error.status === 409`, so the draft API has to attach the HTTP status onto the
+// thrown Error (mirroring editSummary). These tests pin that contract.
+
+const { mockPut } = vi.hoisted(() => ({ mockPut: vi.fn() }));
+
+vi.mock('axios', () => ({
+    default: {
+        create: () => ({
+            get: vi.fn(),
+            post: vi.fn(),
+            put: mockPut,
+            delete: vi.fn(),
+            interceptors: {
+                request: { use: vi.fn() },
+                response: { use: vi.fn() },
+            },
+        }),
+        isCancel: (err: unknown) => !!(err as { __CANCEL__?: boolean })?.__CANCEL__,
+    },
+}));
+
+import { personalDraftSummary } from '../summaryApi';
+
+describe('personalDraftSummary (v2 F1: HTTP status passthrough)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('PUTs to /summaries/:id/personal-draft with {content} and resolves on 200', async () => {
+        mockPut.mockResolvedValueOnce({ data: { data: {} } });
+        await expect(personalDraftSummary(42, 'my draft [1]')).resolves.toBeUndefined();
+        expect(mockPut).toHaveBeenCalledWith(
+            '/summary/api/v1/summaries/42/personal-draft',
+            { content: 'my draft [1]' },
+        );
+    });
+
+    it('attaches error.status = 409 when the backend rejects with HTTP 409 (already submitted)', async () => {
+        mockPut.mockRejectedValueOnce({
+            response: { status: 409, data: { message: '草稿已被提交，请刷新后改走编辑接口' } },
+        });
+        try {
+            await personalDraftSummary(42, 'late draft');
+            throw new Error('expected personalDraftSummary to reject');
+        } catch (err) {
+            const e = err as Error & { status?: number };
+            expect(e.status).toBe(409); // load-bearing: SummaryEditor 409 branch depends on this
+            expect(e.message).toContain('草稿已被提交');
+        }
+    });
+
+    it('passes through other HTTP statuses too (e.g. 500) so callers can branch', async () => {
+        mockPut.mockRejectedValueOnce({
+            response: { status: 500, data: { message: 'internal error' } },
+        });
+        try {
+            await personalDraftSummary(7, 'x');
+            throw new Error('expected reject');
+        } catch (err) {
+            const e = err as Error & { status?: number };
+            expect(e.status).toBe(500);
+        }
+    });
+
+    it('rethrows cancellations preserving axios.isCancel identity', async () => {
+        const cancelErr = { __CANCEL__: true, message: 'canceled' };
+        mockPut.mockRejectedValueOnce(cancelErr);
+        await expect(personalDraftSummary(1, 'x')).rejects.toBe(cancelErr);
+    });
+});

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -177,6 +177,32 @@ export async function personalEditSummary(
     return put(`/summaries/${taskId}/personal-edit`, { content });
 }
 
+// OCT-21（提交前编辑）/ v2 F1：提交前编辑「自己的个人报告」草稿。
+// 后端按 (task_id, user_id=自己) 定位，只能改自己；不写 edited_at、不 revive、
+// 不触发团队重算。仅当 worker_status===2 && submitted_at IS NULL 时允许；
+// 已提交后请改用 personalEditSummary（后端会重算团队）。
+// 不复用 put helper（理由同 editSummary，见 line 146-168 注释）：
+// SummaryEditor.handleSave 的 409 分支硬依赖 error.status === 409，
+// put helper 的 catch 把 axios error 转成 new Error(extractErrorMessage(err))，
+// 丢失 response.status -> 409 分支永远不触发，编辑器无法关闭。
+export async function personalDraftSummary(
+    taskId: number,
+    content: string,
+): Promise<void> {
+    try {
+        await summaryAxios.put(`${BASE}/summaries/${taskId}/personal-draft`, { content });
+    } catch (err: unknown) {
+        // Preserve cancellation identity so callers can use axios.isCancel(err)
+        if (axios.isCancel(err)) throw err;
+        const axiosErr = err as { response?: { status?: number } };
+        const status = axiosErr?.response?.status;
+        const msg = extractErrorMessage(err);
+        const error = new Error(msg) as Error & { status?: number };
+        if (status) error.status = status;
+        throw error;
+    }
+}
+
 // need7：creator 添加新成员。body={user_ids:[...]}（以后端 addMembersReq.UserIDs
 // 为准，见 octo-smart-summary/internal/api/handler/personal.go AddMembers）。
 // 新成员以「待确认」(Pending) 进入成员状态列表，等其自己 Accept 才生成个人+并入团队。

--- a/packages/dmworksummary/src/components/SummaryEditor.tsx
+++ b/packages/dmworksummary/src/components/SummaryEditor.tsx
@@ -16,8 +16,11 @@ interface SummaryEditorProps {
      *  - "team"（默认）：编辑团队/个人总结结果，走 PUT /summaries/:id/edit（editSummary）。
      *  - "personal"（need3/6）：编辑「自己的个人报告」，走 PUT /summaries/:id/personal-edit
      *    （personalEditSummary），成功后后端自动触发团队重算。
+     *  - "personal_draft"（OCT-21）：提交前编辑「自己的个人报告」草稿，走
+     *    PUT /summaries/:id/personal-draft（personalDraftSummary）。**不**触发团队
+     *    重算、**不**写 edited_at。仅当 worker_status===2 && submitted_at IS NULL 时允许。
      */
-    mode?: "team" | "personal";
+    mode?: "team" | "personal" | "personal_draft";
 }
 
 interface SummaryEditorState {
@@ -76,7 +79,10 @@ export default class SummaryEditor extends Component<SummaryEditorProps, Summary
 
         this.setState({ saving: true });
         try {
-            if (mode === "personal") {
+            if (mode === "personal_draft") {
+                // OCT-21：提交前编辑自己的草稿（只能改自己），不触发团队重算、不写 edited_at。
+                await api.personalDraftSummary(taskId, content);
+            } else if (mode === "personal") {
                 // need3/6：编辑自己的个人报告（只能改自己），后端会自动触发团队重算。
                 // F2：personal-edit 只传 content，不带 base_result_id。
                 await api.personalEditSummary(taskId, content);
@@ -88,7 +94,12 @@ export default class SummaryEditor extends Component<SummaryEditorProps, Summary
         } catch (err: unknown) {
             const error = err as Error & { status?: number };
             if (error.status === 409) {
-                Toast.warning(t("summary.editor.contentUpdated"));
+                // v2 GLM-F4：409 文案按 mode 分发。personal_draft 走「该总结已提交，已为你刷新」，
+                // 其余 mode 沿用旧文案「内容已更新，请刷新」。
+                const conflictKey = mode === "personal_draft"
+                    ? "summary.editor.draftAlreadySubmitted"
+                    : "summary.editor.contentUpdated";
+                Toast.warning(t(conflictKey));
                 onSave();
             } else {
                 Toast.error(error.message || t("summary.editor.saveFailed"));

--- a/packages/dmworksummary/src/components/__tests__/SummaryEditor.personalDraft.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryEditor.personalDraft.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// OCT-21 Stage 4 (v2 GLM-F4 + F1 wiring) — SummaryEditor.handleSave in
+// mode="personal_draft":
+//   - success path  -> calls api.personalDraftSummary(taskId, content) + onSave()
+//   - 409 conflict   -> calls onSave() and shows the NEW i18n toast key
+//                       "summary.editor.draftAlreadySubmitted" (NOT the generic
+//                       "summary.editor.contentUpdated" used by other modes).
+//
+// @octo/base is aliased to the dmworkBase mock by vitest.config.ts, so `t`/`Toast`
+// context resolve. The mock t(key) returns the key string for un-mapped summary
+// keys, so asserting the Toast was called with the key proves the per-mode i18n
+// dispatch picked the right key.
+
+const Toast = vi.hoisted(() => ({
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+}));
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Toast,
+    Button: ({ children, onClick, disabled }: any) => (
+        <button onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+}));
+
+vi.mock('@octo/base/src/Components/VoiceInputButton', () => ({
+    default: () => null,
+}));
+
+const api = vi.hoisted(() => ({
+    personalDraftSummary: vi.fn(),
+    personalEditSummary: vi.fn(),
+    editSummary: vi.fn(),
+}));
+vi.mock('../../api/summaryApi', () => api);
+
+import SummaryEditor from '../SummaryEditor';
+
+function renderEditor(onSave: () => void, mode: 'team' | 'personal' | 'personal_draft' = 'personal_draft') {
+    render(
+        <SummaryEditor
+            taskId={42}
+            baseResultId={0}
+            initialContent="orig"
+            onSave={onSave}
+            onCancel={() => {}}
+            mode={mode}
+        />,
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // content !== initialContent -> hasChanges true -> Save enabled.
+    fireEvent.change(textarea, { target: { value: 'my draft body [1]' } });
+    const saveBtn = screen.getByText('保存').closest('button') as HTMLButtonElement;
+    return { textarea, saveBtn };
+}
+
+describe('SummaryEditor mode="personal_draft" (v2 GLM-F4 + F1 wiring)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('success path routes to personalDraftSummary, then onSave + success toast', async () => {
+        api.personalDraftSummary.mockResolvedValue(undefined);
+        const onSave = vi.fn();
+        const { saveBtn } = renderEditor(onSave);
+        expect(saveBtn.disabled).toBe(false);
+
+        fireEvent.click(saveBtn);
+
+        await waitFor(() => {
+            expect(api.personalDraftSummary).toHaveBeenCalledWith(42, 'my draft body [1]');
+        });
+        expect(api.personalEditSummary).not.toHaveBeenCalled();
+        expect(api.editSummary).not.toHaveBeenCalled();
+        await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+        // dmworkBase mock t() resolves the real zh-CN string, so assert the
+        // translation (saveSuccess -> "保存成功").
+        expect(Toast.success).toHaveBeenCalledWith('保存成功');
+    });
+
+    it('409 conflict closes editor (onSave) and shows the draftAlreadySubmitted toast key', async () => {
+        const conflict = new Error('已提交') as Error & { status?: number };
+        conflict.status = 409;
+        api.personalDraftSummary.mockRejectedValue(conflict);
+        const onSave = vi.fn();
+        const { saveBtn } = renderEditor(onSave);
+
+        fireEvent.click(saveBtn);
+
+        // GLM-F4: draft mode picks the NEW key draftAlreadySubmitted
+        // ("该总结已提交，已为你刷新"), NOT the generic contentUpdated
+        // ("内容已更新，请刷新"). The mock t() resolves real zh-CN strings.
+        await waitFor(() => {
+            expect(Toast.warning).toHaveBeenCalledWith('该总结已提交，已为你刷新');
+        });
+        expect(Toast.warning).not.toHaveBeenCalledWith('内容已更新，请刷新');
+        await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+        expect(Toast.error).not.toHaveBeenCalled();
+    });
+
+    it('non-409 error keeps editor open (no onSave) and shows an error toast', async () => {
+        const boom = new Error('boom') as Error & { status?: number };
+        boom.status = 500;
+        api.personalDraftSummary.mockRejectedValue(boom);
+        const onSave = vi.fn();
+        const { saveBtn } = renderEditor(onSave);
+
+        fireEvent.click(saveBtn);
+
+        await waitFor(() => {
+            expect(Toast.error).toHaveBeenCalled();
+        });
+        expect(onSave).not.toHaveBeenCalled();
+        expect(Toast.warning).not.toHaveBeenCalled();
+    });
+});

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -370,6 +370,7 @@
   "editor": {
     "saveSuccess": "Saved",
     "contentUpdated": "Content has changed. Please refresh.",
+    "draftAlreadySubmitted": "This summary was already submitted; the page has been refreshed.",
     "saveFailed": "Failed to save. Please retry.",
     "placeholder": "Edit summary content..."
   },

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -370,6 +370,7 @@
   "editor": {
     "saveSuccess": "保存成功",
     "contentUpdated": "内容已更新，请刷新",
+    "draftAlreadySubmitted": "该总结已提交，已为你刷新",
     "saveFailed": "保存失败，请重试",
     "placeholder": "编辑总结内容..."
   },

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -68,6 +68,8 @@ interface SummaryDetailPageState {
     editingPersonalReport: boolean;
     /** need4：行内编辑「团队总结」中（仅 creator）。 */
     editingTeamSummary: boolean;
+    /** OCT-21：提交前编辑「我自己的个人报告」草稿中（行内编辑器接管「我（未提交）」行）。 */
+    editingMyDraft: boolean;
     /** need7：成员选择器弹窗显隐。 */
     showAddMember: boolean;
     /** need7：添加成员提交中。 */
@@ -104,6 +106,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         isEditing: false,
         editingPersonalReport: false,
         editingTeamSummary: false,
+        editingMyDraft: false,
         showAddMember: false,
         addingMember: false,
         showMatterPicker: false,
@@ -186,6 +189,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             error: null,
             editingTeamSummary: false,
             editingPersonalReport: false,
+            editingMyDraft: false,
             isEditing: false,
             personalResult: null,
             members: [],
@@ -1073,10 +1077,11 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      */
     // 共享门控：是否应展示「我的提交」入口（顶部卡片 + 参与者报告区行 复用）。
     shouldShowMySubmit(): boolean {
-        const { personalResult, members, isEditing, editingPersonalReport, editingTeamSummary } = this.state;
+        const { personalResult, members, isEditing, editingPersonalReport, editingTeamSummary, editingMyDraft } = this.state;
         if (!this.isMultiCollab()) return false;
         // F2：任一编辑态下隐藏提交入口，避免与编辑器并存、提交触发团队聚合与编辑冲突。
-        if (isEditing || editingPersonalReport || editingTeamSummary) return false;
+        // OCT-21：草稿编辑态（editingMyDraft）也走同款互斥，整行（含「提交给全部」按钮）让位给草稿编辑器分支。
+        if (isEditing || editingPersonalReport || editingTeamSummary || editingMyDraft) return false;
         if (personalResult?.worker_status !== 2) return false;
         if (personalResult.submitted_at) return false;
         if (members.length <= 1) return false;
@@ -1316,7 +1321,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     renderParticipantReports() {
-        const { members, membersLoading, expandedReports, editingPersonalReport, detail } = this.state;
+        const { members, membersLoading, expandedReports, editingPersonalReport, detail, personalResult, editingMyDraft } = this.state;
         const { t } = this.context;
         // 如果只有 1 个人（creator 自己），不显示参与者报告区块
         if (membersLoading || members.length <= 1) return null;
@@ -1338,7 +1343,19 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         // 也不该以“等待提交”的被动 pending 行呈现。这里显式渲染“我（未提交）+ 提交按钮”的主入口行（renderMyPendingSubmitRow），
         // 并从 generic pending 里排掉我那条，避免重复。不展开我的总结正文 → 不违反 need1。
         const showMyPending = this.shouldShowMySubmit();
-        const pendingOthers = showMyPending ? pending.filter((m) => m.user_id !== myUid) : pending;
+        // OCT-21 / GLM-F3：草稿编辑态独立守卫（与 shouldShowMySubmit 的前置条件等价，
+        // 但不再依赖「无任何编辑态」——本身就是编辑态）。补 isMultiCollab() 纵深防御。
+        const showMyDraftEditing =
+            editingMyDraft &&
+            this.isMultiCollab() &&
+            personalResult?.worker_status === 2 &&
+            !personalResult?.submitted_at &&
+            members.length > 1;
+        // v2 F2：只要 renderMyPendingSubmitRow 会渲染「我」（无论草稿编辑态或常规态），
+        // 都必须从 pendingOthers 里排掉「我」，避免双份渲染。
+        const pendingOthers = (showMyPending || showMyDraftEditing)
+            ? pending.filter((m) => m.user_id !== myUid)
+            : pending;
         // need3：自己那条的「编辑」按钮 gate=can_edit_personal。
         const canEditPersonal = !!detail?.permissions?.can_edit_personal;
         return (
@@ -1433,6 +1450,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     );
                 })}
                 {showMyPending && this.renderMyPendingSubmitRow()}
+                {showMyDraftEditing && this.renderMyPendingSubmitRow()}
                 {pendingOthers.map((m) => (
                     <div key={m.user_id} className="summary-detail-participant-report-pending">
                         <IconClock style={{ fontSize: 14 }} />
@@ -1468,9 +1486,31 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      */
     renderMyPendingSubmitRow() {
         const { t } = this.context;
-        const { personalResult } = this.state;
+        const { personalResult, editingMyDraft, detail } = this.state;
         const myContent = personalResult?.content || "";
         const myCitations = personalResult?.citations || [];
+        // OCT-21：草稿编辑态——整行让位给 SummaryEditor (mode=personal_draft)，
+        // 「提交给全部」按钮在编辑态下不可见（与既有「team / personal 编辑」体验一致）。
+        if (editingMyDraft && detail) {
+            return (
+                <div
+                    key="__my_pending_submit_editing__"
+                    className="summary-detail-participant-report-item summary-detail-my-pending-row"
+                >
+                    <div className="summary-detail-participant-report-header">
+                        <span>{t("summary.detail.mySubmitRowName")}</span>
+                    </div>
+                    <SummaryEditor
+                        mode="personal_draft"
+                        taskId={detail.task_id}
+                        baseResultId={detail.result_id ?? 0}
+                        initialContent={myContent}
+                        onSave={this.handleEditMyDraftSave}
+                        onCancel={this.handleEditMyDraftCancel}
+                    />
+                </div>
+            );
+        }
         return (
             <div
                 key="__my_pending_submit__"
@@ -1478,10 +1518,20 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             >
                 <div className="summary-detail-participant-report-header">
                     <span>{t("summary.detail.mySubmitRowName")}</span>
+                    {/* OCT-21：提交前编辑入口。文案复用 summary.common.edit；按钮放在「提交给全部」左侧。 */}
+                    <Button
+                        size="small"
+                        theme="borderless"
+                        icon={<IconEdit />}
+                        style={{ marginLeft: "auto" }}
+                        onClick={this.handleStartEditMyDraft}
+                    >
+                        {t("summary.common.edit")}
+                    </Button>
                     <Button
                         size="small"
                         theme="solid"
-                        style={{ marginLeft: "auto" }}
+                        style={{ marginLeft: 8 }}
                         onClick={this.handleSubmitPersonal}
                     >
                         {t("summary.detail.submitToAll")}
@@ -1498,7 +1548,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
 
     handleStartEdit = () => {
         // F1：进入单人个人总结编辑时互斥关闭另两个编辑态。
-        this.setState({ isEditing: true, editingTeamSummary: false, editingPersonalReport: false });
+        // OCT-21：同时关闭草稿编辑态（纵深防御）。
+        this.setState({ isEditing: true, editingTeamSummary: false, editingPersonalReport: false, editingMyDraft: false });
     };
 
     handleEditSave = () => {
@@ -1513,7 +1564,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     // need3：进入/退出「自己的个人报告」行内编辑。保存走 personal-edit（后端自动重算团队）。
     handleStartEditPersonalReport = () => {
         // F1：互斥——只留 editingPersonalReport，关闭团队/单人编辑态。
-        this.setState({ editingPersonalReport: true, editingTeamSummary: false, isEditing: false });
+        // OCT-21：同时关闭草稿编辑态。
+        this.setState({ editingPersonalReport: true, editingTeamSummary: false, isEditing: false, editingMyDraft: false });
     };
     handleEditPersonalReportSave = () => {
         this.setState({ editingPersonalReport: false });
@@ -1527,7 +1579,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     // need4：进入/退出「团队总结」行内编辑（仅 creator）。保存走既有 PUT /summaries/:id/edit。
     handleStartEditTeam = () => {
         // F1：互斥——只留 editingTeamSummary，关闭个人/单人编辑态。
-        this.setState({ editingTeamSummary: true, editingPersonalReport: false, isEditing: false });
+        // OCT-21：同时关闭草稿编辑态。
+        this.setState({ editingTeamSummary: true, editingPersonalReport: false, isEditing: false, editingMyDraft: false });
     };
     handleEditTeamSave = () => {
         this.setState({ editingTeamSummary: false });
@@ -1535,6 +1588,29 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
     handleEditTeamCancel = () => {
         this.setState({ editingTeamSummary: false });
+    };
+
+    // OCT-21：提交前编辑「我自己」的个人报告草稿。三件套与 handleStartEditPersonalReport 对齐。
+    handleStartEditMyDraft = () => {
+        // 互斥：只留 editingMyDraft，关闭其他三种编辑态。
+        this.setState({
+            editingMyDraft: true,
+            isEditing: false,
+            editingPersonalReport: false,
+            editingTeamSummary: false,
+        });
+    };
+    handleEditMyDraftSave = () => {
+        // v2 F3：保存后统一走 loadDetail()——不是 loadPersonalResult。
+        // 理由：草稿保存遇 409（已被并发 submit 抢先）会让 personalResult.submitted_at 变非空，
+        // 但 members 中的「我」仍是 pending，只刷 personalResult 会让分桶视图错乱。
+        // loadDetail 一把全刷（task/members/personal/schedule），保证分桶绝对一致；
+        // 草稿成功路径不重算团队，loadDetail 也不会触发新的 LLM 调用，开销可接受。
+        this.setState({ editingMyDraft: false });
+        this.loadDetail();
+    };
+    handleEditMyDraftCancel = () => {
+        this.setState({ editingMyDraft: false });
     };
 
     // need7：creator 添加新成员。选定后调 POST /members，成功 loadDetail 刷新（新成员 Pending）。
@@ -1565,9 +1641,10 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     renderScheduleButton() {
-        const { detail, scheduleItem, scheduleLoading, isEditing, editingTeamSummary, editingPersonalReport } = this.state;
+        const { detail, scheduleItem, scheduleLoading, isEditing, editingTeamSummary, editingPersonalReport, editingMyDraft } = this.state;
         const { t } = this.context;
-        if (!detail?.permissions?.can_schedule || isEditing || editingTeamSummary || editingPersonalReport) return null;
+        // OCT-21 / GPT-S1：草稿编辑态也隐藏 schedule 按钮，与其它编辑态保持一致约束。
+        if (!detail?.permissions?.can_schedule || isEditing || editingTeamSummary || editingPersonalReport || editingMyDraft) return null;
 
         // 任务3：hasSchedule 仅在存在且 is_active 时为 true。
         // 停用后文案回到「设置定时更新」。


### PR DESCRIPTION
## What

前端「提交前个人草稿编辑」入口（OCT-21），对接后端 `PUT /api/v1/summaries/:id/personal-draft`（PR Mininglamp-OSS/octo-smart-summary#125）。

BY_PERSON 任务在提交前，用户可在 SummaryEditor 里编辑自己的个人总结草稿并保存，不触发 meta_summary、不改已发布结果。

## Changes

- `SummaryEditor.tsx`：扩展 mode，新增提交前草稿编辑态
- `SummaryDetailPage.tsx`：接入草稿编辑入口
- `summaryApi.ts`：新增 personalDraft 保存 API（对应后端 PUT 端点，含 40001/40005/40008/40009/40010/40016 错误码分发）
- i18n（zh-CN / en-US）：草稿编辑相关文案
- 测试：`personalDraft.test.ts` + `SummaryEditor.personalDraft.test.tsx`

## Test

前端组件测 + API 测已入库并通过；docker 本地前后端 fork 镜像端到端 BY_PERSON 回归（OCT-40）已验证。

## Related

Closes #497
后端：Mininglamp-OSS/octo-smart-summary#125
