### PR TITLE
chore(docs): drop collab WS legacy env fallback + Dockerfile build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ WORKDIR /app
 RUN npm install -g pnpm@10
 COPY . .
 RUN git config --global url."https://github.com/".insteadOf "git+ssh://git@github.com/" && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-ARG VITE_COLLAB_WS_ENDPOINT
-ENV VITE_COLLAB_WS_ENDPOINT=${VITE_COLLAB_WS_ENDPOINT}
 ARG VITE_DOCS_DEFAULT_SPACE
 ENV VITE_DOCS_DEFAULT_SPACE=${VITE_DOCS_DEFAULT_SPACE}
 ARG VITE_DOCS_DEFAULT_FOLDER

--- a/packages/docs/src/collab/createCollabEditor.ts
+++ b/packages/docs/src/collab/createCollabEditor.ts
@@ -87,8 +87,8 @@ export class CollabEditor {
       : new IndexeddbPersistence(this.cacheKeyStr, this.ydoc)
 
     // 3) provider — connect:false; we set initial editable then connect.
-    // WS origin is resolved from the collab-token response (backend-driven), with a legacy
-    // build-time env fallback — see resolveCollabWsUrl / create().
+    // WS origin is resolved from the collab-token response (backend-driven) — see
+    // resolveCollabWsUrl / create().
     this.provider = new HocuspocusProvider({
       url: wsUrl,
       name: this.documentName,
@@ -181,8 +181,9 @@ export class CollabEditor {
   static async create(opts: CollabEditorOptions): Promise<CollabEditor> {
     const documentName = buildDocumentName(opts.space, opts.folder, opts.doc)
     const entry = await getCollabTokenEntry(documentName)
-    // The collab-token response is the single source of truth for the WS origin too: prefer the
-    // backend-issued `collabWsUrl`, falling back to the legacy build-time env when absent.
+    // The collab-token response is the single source of truth for the WS origin: the
+    // backend-issued `collabWsUrl` is required. resolveCollabWsUrl throws when it is absent, so a
+    // misconfigured backend fails loudly here instead of silently connecting to a placeholder.
     const wsUrl = resolveCollabWsUrl(entry.collabWsUrl)
     return new CollabEditor(opts, entry.role, entry.permission_epoch, wsUrl)
   }

--- a/packages/docs/src/config.test.ts
+++ b/packages/docs/src/config.test.ts
@@ -1,22 +1,23 @@
 import { describe, it, expect } from 'vitest'
 import { resolveCollabWsUrl } from './config.ts'
 
-// The build-time env (VITE_COLLAB_WS_ENDPOINT) is unset under vitest, so the legacy fallback
-// resolves to the placeholder default. These tests pin the resolution PRIORITY, not the exact
-// placeholder value: backend-issued URL wins; a missing/blank one falls back to the env value.
+// The collab WS origin is delivered solely at runtime via the collab-token response
+// (`collabWsUrl`). The legacy build-time env fallback (VITE_COLLAB_WS_ENDPOINT) has been removed,
+// so a missing/blank URL must fail loudly instead of resolving to a placeholder.
 describe('resolveCollabWsUrl', () => {
-  const ENV_FALLBACK = resolveCollabWsUrl(undefined)
-
-  it('prefers the backend-issued collabWsUrl', () => {
+  it('returns the backend-issued collabWsUrl (trimmed)', () => {
     expect(resolveCollabWsUrl('wss://collab.prod.example.com')).toBe('wss://collab.prod.example.com')
+    expect(resolveCollabWsUrl('  wss://collab.prod.example.com  ')).toBe(
+      'wss://collab.prod.example.com',
+    )
   })
 
-  it('falls back to the build-time env when the backend omits collabWsUrl', () => {
-    expect(resolveCollabWsUrl(undefined)).toBe(ENV_FALLBACK)
+  it('throws when the backend omits collabWsUrl', () => {
+    expect(() => resolveCollabWsUrl(undefined)).toThrow(/collabWsUrl/)
   })
 
-  it('treats an empty or whitespace collabWsUrl as unset and falls back', () => {
-    expect(resolveCollabWsUrl('')).toBe(ENV_FALLBACK)
-    expect(resolveCollabWsUrl('   ')).toBe(ENV_FALLBACK)
+  it('throws when collabWsUrl is empty or whitespace-only', () => {
+    expect(() => resolveCollabWsUrl('')).toThrow(/collabWsUrl/)
+    expect(() => resolveCollabWsUrl('   ')).toThrow(/collabWsUrl/)
   })
 })

--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -20,29 +20,25 @@ function envOr(value: unknown, fallback: string): string {
 }
 
 /**
- * Legacy build-time Hocuspocus WebSocket endpoint.
- *
- * The WS origin is now delivered at runtime via the collab-token response (`collabWsUrl`,
- * backend XIN-211). This build-time value is retained only as a smooth-rollout fallback for
- * deployments whose backend does not yet emit `collabWsUrl` (or has it unconfigured); it — and
- * the Dockerfile build-arg feeding it — is removed in a later cleanup issue once the runtime
- * path is validated end-to-end. Do not add new readers of this constant.
- */
-const WS_ENDPOINT_ENV_FALLBACK = envOr(
-  import.meta.env?.VITE_COLLAB_WS_ENDPOINT,
-  'wss://collab.octo.example.com',
-)
-
-/**
  * Resolve the Hocuspocus WebSocket endpoint.
  *
- * Prefers the absolute `collabWsUrl` handed down by the backend collab-token response. When the
- * backend omits it (unconfigured, or an older backend that predates the contract), fall back to
- * the legacy build-time env so existing deployments keep connecting. `envOr` also treats an
- * empty/whitespace value as "unset", so a stray empty string never wins over the fallback.
+ * The WS origin is delivered at runtime via the collab-token response (`collabWsUrl`, backend
+ * XIN-211) and is now the ONLY source — the legacy build-time env fallback
+ * (`VITE_COLLAB_WS_ENDPOINT`) has been removed. When the backend omits `collabWsUrl` (or sends a
+ * blank/whitespace value) we throw so the caller fails loudly instead of silently connecting to a
+ * placeholder origin. A missing WS URL is a backend misconfiguration and must be surfaced, not
+ * masked.
  */
 export function resolveCollabWsUrl(collabWsUrl?: string): string {
-  return envOr(collabWsUrl, WS_ENDPOINT_ENV_FALLBACK)
+  const url = typeof collabWsUrl === 'string' ? collabWsUrl.trim() : ''
+  if (url.length === 0) {
+    throw new Error(
+      'collab-token response is missing `collabWsUrl`: the backend did not deliver a collab ' +
+        'WebSocket origin. There is no build-time fallback; the backend must emit an absolute ' +
+        'WS URL. Check the docs collab-token endpoint configuration.',
+    )
+  }
+  return url
 }
 
 /** Refresh collab token when it is within this window of expiry. */


### PR DESCRIPTION
## What

Removes the transitional build-time env fallback for the collab WebSocket origin. The origin is now delivered exclusively at runtime via the collab-token response (`collabWsUrl`, backend XIN-211).

## Changes

- **`packages/docs/src/config.ts`**: drop `WS_ENDPOINT_ENV_FALLBACK` and the `VITE_COLLAB_WS_ENDPOINT` reader. `resolveCollabWsUrl` now **throws** when the backend omits `collabWsUrl` (or sends a blank/whitespace value) instead of silently falling back to a placeholder origin.
- **`packages/docs/src/collab/createCollabEditor.ts`**: the throw propagates through `CollabEditor.create`; `useCollabEditor` already maps a create failure to a terminal state, so a misconfigured backend fails loudly (editor blocked, error logged) rather than connecting to a dead placeholder. Comments updated.
- **`Dockerfile`**: remove the `VITE_COLLAB_WS_ENDPOINT` `ARG`/`ENV` build-arg.
- **`packages/docs/src/config.test.ts`**: assert the new throw-on-missing behaviour (backend URL wins & is trimmed; missing/blank throws).
- `main.tsx` dev mock keeps `collabWsUrl` (dev still needs it).

## Acceptance

- No legacy env fallback path or placeholder remains; when the backend does not deliver `collabWsUrl`, the frontend errors/blocks instead of silently using a placeholder.
- Local verification: `pnpm i18n:check` green, `@octo/web` production build green, `@octo/docs` tests green (437 passed). The two pre-existing `@octo/docs` typecheck errors (`dmworkbase/i18n/format.ts`, `members/sort.ts`) are present on base `66ecb56` and unrelated to this change.

Draft for review.
