### PR TITLE
feat(sticker): render lottieSticker via MessageRow

### DIFF
--- a/packages/dmworkbase/src/Messages/LottieSticker/__tests__/LottieSticker.test.ts
+++ b/packages/dmworkbase/src/Messages/LottieSticker/__tests__/LottieSticker.test.ts
@@ -1,18 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-
-vi.mock('wukongimjssdk', () => ({
-  MessageContent: class {},
-}))
-
-vi.mock('react', async () => await vi.importActual('react'))
-vi.mock('@lottiefiles/lottie-player/dist/tgs-player', () => ({}))
-vi.mock('../../../App', () => ({ default: { dataSource: { commonDataSource: { getImageURL: (u: string) => u } } } }))
-vi.mock('../../../Service/Const', () => ({ MessageContentTypeConst: { lottieSticker: 12 } }))
-vi.mock('../../Base', () => ({ default: () => null }))
-vi.mock('../../MessageCell', () => ({ MessageCell: class {} }))
-vi.mock('../../../i18n', () => ({ t: (k: string) => k }))
-
-import { isBitmapStickerFormat } from '../index'
+import { describe, it, expect } from 'vitest'
+import { isBitmapStickerFormat } from '../format'
 
 // 贴纸的 format 字段是在历史发送之后才引入的：早期贴纸消息没有 format，解码默认空串，
 // 本质是 Lottie(.tgs)。位图分流只能识别已知位图格式，其余(空/未知/tgs)必须 fall back

--- a/packages/dmworkbase/src/Messages/LottieSticker/format.ts
+++ b/packages/dmworkbase/src/Messages/LottieSticker/format.ts
@@ -1,0 +1,9 @@
+// LottieSticker/lottieEmojiSticker 的位图 vs Lottie 分流判定。
+// 历史贴纸消息在 `format` 字段引入前就已发送，decodeJSON 默认 ""；
+// 因此空/未知/tgs 全部 fail-safe 到 tgs-player，只有已知位图格式才走 <img>。
+// PR#496 review 血泪：把 .tgs 喂进 <img> 会导致历史聊天中所有贴纸裂图。
+const BITMAP_STICKER_FORMATS = new Set(['gif', 'png', 'jpg', 'jpeg', 'webp'])
+
+export function isBitmapStickerFormat(format: string | undefined | null): boolean {
+  return BITMAP_STICKER_FORMATS.has((format || '').toLowerCase())
+}

--- a/packages/dmworkbase/src/Messages/LottieSticker/index.css
+++ b/packages/dmworkbase/src/Messages/LottieSticker/index.css
@@ -1,0 +1,15 @@
+/* Sticker 消息体（lottieSticker / lottieEmojiSticker）
+ * 走 MessageRow 路径，body 内不带气泡背景，与旧 hiddeBubble 视觉一致。
+ * 尺寸保留原有 208px，避免和历史贴图观感差异过大。 */
+.wk-sticker-body {
+  display: inline-flex;
+  padding: 2px 0;
+}
+
+.wk-sticker-media {
+  display: block;
+  width: auto;
+  height: 208px;
+  max-width: 208px;
+  object-fit: contain;
+}

--- a/packages/dmworkbase/src/Messages/LottieSticker/index.tsx
+++ b/packages/dmworkbase/src/Messages/LottieSticker/index.tsx
@@ -1,12 +1,18 @@
 import { MessageContent } from "wukongimjssdk"
 import React from "react"
-import WKApp from "../../App"
 import { MessageContentTypeConst } from "../../Service/Const"
-import MessageBase from "../Base"
 import { MessageCell } from "../MessageCell"
-import "@lottiefiles/lottie-player/dist/tgs-player";
+import "@lottiefiles/lottie-player/dist/tgs-player"
 import { t } from "../../i18n"
+import MessageRow from "../../ui/message/MessageRow"
+import { getStickerMessageUI } from "../../bridge/message/useStickerMessageUI"
+import { isMessageSelectable } from "../../Service/messageSelection"
+import { isBitmapStickerFormat } from "./format"
+import "./index.css"
 
+// 权威定义在 ./format.ts，此处 re-export 保持外部 import 兼容
+// （EmojiToolbar 等消费方从 "../../Messages/LottieSticker" 引入）。
+export { isBitmapStickerFormat }
 
 
 export class LottieSticker extends MessageContent {
@@ -15,57 +21,69 @@ export class LottieSticker extends MessageContent {
     placeholder!: string
     format!: string
     decodeJSON(content: any) {
-        this.url = content["url"] || ""
-        this.category = content["category"] || ""
-        this.placeholder = content["placeholder"] || ""
-        this.format = content["format"] || ""
+        // 与 GifContent 对齐：防上游 double-stringify。空对象 fallback 保留默认空串。
+        if (typeof content === "string") {
+            try {
+                content = JSON.parse(content)
+            } catch {
+                content = {}
+            }
+        }
+        this.url = content?.["url"] || ""
+        this.category = content?.["category"] || ""
+        this.placeholder = content?.["placeholder"] || ""
+        this.format = content?.["format"] || ""
     }
     get conversationDigest() {
-
         return t("base.message.digest.sticker")
     }
     encodeJSON() {
-        
-        return {url:this.url||"",category:this.category||"",placeholder:this.placeholder||"",format:this.format||""}
+        return { url: this.url || "", category: this.category || "", placeholder: this.placeholder || "", format: this.format || "" }
     }
     get contentType() {
         return MessageContentTypeConst.lottieSticker
     }
-    
 }
 
 
 declare global {
     namespace JSX {
         interface IntrinsicElements {
-            "tgs-player": any;
+            "tgs-player": any
         }
     }
 }
 
-// 已知位图贴纸格式 → 用 <img>；其余(含空/未知/tgs)一律走 <tgs-player>。历史贴纸
-// 消息在 format 字段出现前发送，format 解码默认空串，本质是 Lottie，必须 fail-safe
-// 到 tgs-player —— 否则会把 .tgs 喂进 <img>，历史聊天里的贴纸全裂(PR#496 review)。
-const BITMAP_STICKER_FORMATS = new Set(["gif", "png", "jpg", "jpeg", "webp"])
-export function isBitmapStickerFormat(format: string | undefined | null): boolean {
-    return BITMAP_STICKER_FORMATS.has((format || "").toLowerCase())
-}
 
+// 贴图消息不走 MessageBase 的气泡路径，而是与 image/file/video 一致地走
+// MessageRow（bridge），保证发送人名字/头像/时间/实名徽章样式与普通消息统一。
+// body 按 isBitmap 分流：png/gif/jpg/jpeg/webp 走 <img>，其余走 tgs-player。
 export class LottieStickerCell extends MessageCell {
 
-
     render() {
-
         const { message, context } = this.props
-        const content = message.content as LottieSticker
-        const url = WKApp.dataSource.commonDataSource.getImageURL(content.url)
-        const isBitmap = isBitmapStickerFormat(content.format)
-        return <MessageBase hiddeBubble={true} message={message} context={context} >
-            {
-                isBitmap
-                    ? <img src={url} style={{ height: "208px", maxWidth: "208px", objectFit: "contain" }} alt="" />
-                    : <tgs-player style={{ width: "auto", height: "208px" }} autoplay loop mode="normal" src={url}></tgs-player>
-            }
-        </MessageBase>
+        const ui = getStickerMessageUI(message)
+        const selectionMode = context.editOn()
+        const selectable = isMessageSelectable(message)
+        return (
+            <MessageRow
+                {...ui.row}
+                onContextMenu={(event) => context.showContextMenus(message.message, event)}
+                isActive={context.isContextMenuOpen(message.message)}
+                selectionMode={selectionMode}
+                showCheckbox={selectionMode && selectable}
+                isSelected={selectable && !!message.checked}
+                onSelect={selectable ? (checked) => context.checkeMessage(message.message, checked) : undefined}
+                onAvatarClick={(e) => context.onTapAvatar(message.fromUID, e)}
+                onSenderNameClick={() => context.showUser(message.fromUID)}
+            >
+                <div className="wk-sticker-body">
+                    {ui.isBitmap
+                        ? <img className="wk-sticker-media" src={ui.url} alt="" />
+                        : <tgs-player class="wk-sticker-media" autoplay loop mode="normal" src={ui.url}></tgs-player>
+                    }
+                </div>
+            </MessageRow>
+        )
     }
 }

--- a/packages/dmworkbase/src/bridge/message/useStickerMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useStickerMessageUI.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import WKApp from '../../App'
+import { MessageWrap } from '../../Service/Model'
+import { getMessageRow } from './useMessageRow'
+import { isBitmapStickerFormat } from '../../Messages/LottieSticker/format'
+
+export interface StickerMessageUI {
+  row: ReturnType<typeof getMessageRow>
+  url: string
+  format: string
+  category: string
+  placeholder: string
+  isBitmap: boolean
+}
+
+// 拉平 lottieSticker/lottieEmojiSticker 消息内容到 MessageRow 所需 UI 数据。
+// - `row` 复用与 image/file/video 相同的 getMessageRow → head/头像/时间/徽章
+//   全走同一份 MessageRow 布局，避免旧 MessageBase 路径样式漂移。
+// - `isBitmap` 沿用 fail-safe 判定：未知/空/tgs 走 tgs-player，
+//   png/gif/jpg/jpeg/webp 走 <img>（PR#496 review）。
+export function getStickerMessageUI(message: MessageWrap): StickerMessageUI {
+  const rowProps = getMessageRow(message)
+  const content = message.content as any
+  const rawUrl: string = content?.url || ''
+  const format: string = content?.format || ''
+  const category: string = content?.category || ''
+  const placeholder: string = content?.placeholder || ''
+  const resolvedUrl = rawUrl
+    ? WKApp.dataSource.commonDataSource.getImageURL(rawUrl)
+    : ''
+  return {
+    row: rowProps,
+    url: resolvedUrl,
+    format,
+    category,
+    placeholder,
+    isBitmap: isBitmapStickerFormat(format),
+  }
+}
+
+export function useStickerMessageUI(message: MessageWrap): StickerMessageUI {
+  return useMemo(() => getStickerMessageUI(message), [message])
+}


### PR DESCRIPTION
## Summary

- Move `LottieStickerCell` off the legacy `MessageBase{hiddeBubble}` path and render through the shared `MessageRow` used by image / file / video, so the sender header (avatar / name / timestamp / realname badge / @SpaceName / bot / webhook badges) matches ordinary messages one-to-one. Same-person continuation now merges the header consistently with image / file, instead of the previous ad-hoc block.
- Harden `LottieSticker.decodeJSON` with the same double-stringify defence and optional-chain access as `GifContent`, so an upstream re-stringify no longer wipes `url` / `format`.
- Extract `isBitmapStickerFormat` into `Messages/LottieSticker/format.ts` (re-exported from `index.tsx` for existing `EmojiToolbar` consumers) so the bridge helper can share it without a circular import.

### File map

- new: `packages/dmworkbase/src/bridge/message/useStickerMessageUI.ts` — parallels `useImageMessageUI.ts`; returns `{ row, url, format, category, placeholder, isBitmap }`.
- new: `packages/dmworkbase/src/Messages/LottieSticker/format.ts` — canonical `isBitmapStickerFormat` implementation.
- change: `packages/dmworkbase/src/Messages/LottieSticker/index.tsx` — `LottieStickerCell` now renders `<MessageRow>` with selection / contextMenu / avatarClick / senderNameClick wired the same way as `ImageCell`. `decodeJSON` hardened.
- change: `packages/dmworkbase/src/Messages/LottieSticker/index.css` — `.wk-sticker-body` / `.wk-sticker-media`, keeps the original 208px sizing, no bubble background.
- change: `packages/dmworkbase/src/Messages/LottieSticker/__tests__/LottieSticker.test.ts` — imports `isBitmapStickerFormat` from `../format`, drops mocks that are no longer needed.

## Test plan

- [x] `vitest run src/Messages/LottieSticker/__tests__` — 4 passed
- [x] `tsc --noEmit -p .` — no new error classes introduced (only pre-existing monorepo-wide `react` type / `props` errors that reproduce on `origin/main`)
- [x] Local dev server against `im-test.deepminer.com.cn`: visually verified in a real conversation that a sticker message's avatar / name / timestamp now match text messages, and that same-person continuation merges the header the same way image / file do.
- [ ] Reviewer: try a mixed thread with text + image + sticker from the same sender, check header merging feels identical.
- [ ] Reviewer: send an old-format sticker (no `format` field) and confirm it still falls back to `<tgs-player>` (fail-safe from PR#496 review).