### PR TITLE
fix(chat): reinsert settled no-seq messages by timestamp #275

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -227,16 +227,49 @@ describe("ConversationVM message ordering", () => {
         expect(first.messageContainerId).not.toBe(second.messageContainerId)
     })
 
-    it("sorts no-seq messages with invalid order after sequenced messages", () => {
+    it("keeps in-flight (Wait/Fail) no-seq messages pinned below sequenced messages", () => {
         const vm = new ConversationVM(channel)
         const seq2 = wrap({ clientMsgNo: "seq2", messageSeq: 2, timestamp: 200 })
-        const stale = wrap({ clientMsgNo: "stale", order: Number.NaN, timestamp: 100 })
+        const sending = wrap({ clientMsgNo: "sending", order: Number.NaN, timestamp: 100, status: MessageStatus.Wait })
+        const failed = wrap({ clientMsgNo: "failed", order: Number.NaN, timestamp: 120, status: MessageStatus.Fail })
         const seq1 = wrap({ clientMsgNo: "seq1", messageSeq: 1, timestamp: 150 })
 
-        expect(vm.sortMessages([seq2, stale, seq1]).map((m: any) => m.clientMsgNo)).toEqual([
+        // 在途气泡（Wait/Fail）即便时间戳更早也固定沉底，用户在此查看进度/重试。
+        expect(vm.sortMessages([seq2, sending, seq1, failed]).map((m: any) => m.clientMsgNo)).toEqual([
             "seq1",
             "seq2",
-            "stale",
+            "sending",
+            "failed",
+        ])
+    })
+
+    it("reinserts a settled (Normal) no-seq message at its chronological slot instead of sinking it (#275)", () => {
+        const vm = new ConversationVM(channel)
+        // 复现叶佳/李金龙场景：一条已落定但缺 seq 的旧文件消息（ack 丢失 / sendQueue 残留），
+        // 时间戳早于后续消息，旧逻辑把它按 PendingMessageOrderBase 沉到最底部。
+        const seqEarly = wrap({ clientMsgNo: "seqEarly", messageSeq: 10, timestamp: 100 })
+        const staleFile = wrap({ clientMsgNo: "staleFile", timestamp: 150, status: MessageStatus.Normal })
+        const seqMid = wrap({ clientMsgNo: "seqMid", messageSeq: 11, timestamp: 200 })
+        const seqLate = wrap({ clientMsgNo: "seqLate", messageSeq: 12, timestamp: 300 })
+
+        expect(vm.sortMessages([seqLate, seqEarly, staleFile, seqMid]).map((m: any) => m.clientMsgNo)).toEqual([
+            "seqEarly",
+            "staleFile",
+            "seqMid",
+            "seqLate",
+        ])
+    })
+
+    it("keeps a settled no-seq message that is newer than everything above the sequenced tail (#275)", () => {
+        const vm = new ConversationVM(channel)
+        const seq1 = wrap({ clientMsgNo: "seq1", messageSeq: 1, timestamp: 100 })
+        const seq2 = wrap({ clientMsgNo: "seq2", messageSeq: 2, timestamp: 200 })
+        const lateSettled = wrap({ clientMsgNo: "lateSettled", timestamp: 500, status: MessageStatus.Normal })
+
+        expect(vm.sortMessages([lateSettled, seq2, seq1]).map((m: any) => m.clientMsgNo)).toEqual([
+            "seq1",
+            "seq2",
+            "lateSettled",
         ])
     })
 

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1787,22 +1787,105 @@ export default class ConversationVM extends ProviderListener {
         return PendingMessageOrderBase + timestamp * 1000 + clientSeq
     }
 
+    // 无 seq 且状态为 Wait/Fail 的在途本地气泡（正在发送 / 发送失败）：
+    // 应固定沉在列表底部，用户在此查看进度或重试，不参与时间线回插。
+    private isInFlightLocalMessage(message: MessageWrap): boolean {
+        if (message.messageSeq && message.messageSeq > 0) {
+            return false
+        }
+        if (Number.isFinite(message.order) && message.order > 0) {
+            return false
+        }
+        return message.status === MessageStatus.Wait || message.status === MessageStatus.Fail
+    }
+
+    // 主键排序 + 稳定 tiebreak（timestamp → clientSeq → clientMsgNo）。
+    private compareByOrder = (a: MessageWrap, b: MessageWrap): number => {
+        const orderDiff = this.getMessageSortOrder(a) - this.getMessageSortOrder(b)
+        if (orderDiff !== 0) {
+            return orderDiff
+        }
+        const timestampDiff = (a.timestamp || 0) - (b.timestamp || 0)
+        if (timestampDiff !== 0) {
+            return timestampDiff
+        }
+        const clientSeqDiff = (a.clientSeq || 0) - (b.clientSeq || 0)
+        if (clientSeqDiff !== 0) {
+            return clientSeqDiff
+        }
+        return (a.clientMsgNo || "").localeCompare(b.clientMsgNo || "")
+    }
+
+    private compareByTimestamp = (a: MessageWrap, b: MessageWrap): number => {
+        const timestampDiff = (a.timestamp || 0) - (b.timestamp || 0)
+        if (timestampDiff !== 0) {
+            return timestampDiff
+        }
+        const clientSeqDiff = (a.clientSeq || 0) - (b.clientSeq || 0)
+        if (clientSeqDiff !== 0) {
+            return clientSeqDiff
+        }
+        return (a.clientMsgNo || "").localeCompare(b.clientMsgNo || "")
+    }
+
+    // #275：消息时间顺序错乱 —— 旧消息/文件沉底显示在新消息下方。
+    //
+    // MessageWrap.order 在无 seq 时默认为 0（见 Service/Model.tsx），getMessageSortOrder
+    // 因此把这类消息落到 PendingMessageOrderBase 分支，排到所有已定序消息「之后」——无论
+    // 它的时间戳多早。对真正在途（Wait/Fail）的本地气泡这是期望行为；但一条已落定
+    // (Normal) 却仍缺 seq 的消息（ack 丢失 / 重连补推 / sendQueue 残留副本，见 #242）会
+    // 被永久钉在列表底部，比它更晚的消息反而排在上面，还被算进更晚的日期分隔线，出现
+    // 「昨天的文件沉到今天消息下方且不归位」。
+    //
+    // 修复：把消息分三类以保证结果仍是一个确定的全序：
+    //  - backbone：有 seq（或已通过 fillOrder 拿到 seq 空间内 order）的消息，按 order 排，
+    //    是时间线骨架，排序规则完全不变（保持 #242 的服务器定序语义）；
+    //  - inFlight：无 seq 且 Wait/Fail 的在途气泡，保持沉底；
+    //  - floating：无 seq 但已落定(Normal)的消息，按时间戳插回骨架中的正确时间位置，
+    //    不再无脑沉底。
     sortMessages(messages: MessageWrap[]) {
-        return messages.sort((a, b) => {
-            const orderDiff = this.getMessageSortOrder(a) - this.getMessageSortOrder(b)
-            if (orderDiff !== 0) {
-                return orderDiff
+        const backbone: MessageWrap[] = []
+        const inFlight: MessageWrap[] = []
+        const floating: MessageWrap[] = []
+        for (const message of messages) {
+            if ((message.messageSeq && message.messageSeq > 0) || (Number.isFinite(message.order) && message.order > 0)) {
+                backbone.push(message)
+            } else if (this.isInFlightLocalMessage(message)) {
+                inFlight.push(message)
+            } else {
+                floating.push(message)
             }
-            const timestampDiff = (a.timestamp || 0) - (b.timestamp || 0)
-            if (timestampDiff !== 0) {
-                return timestampDiff
+        }
+
+        // 没有需要回插的落定无 seq 消息时，走原始快速路径（行为完全不变）。
+        if (floating.length === 0) {
+            return messages.sort(this.compareByOrder)
+        }
+
+        backbone.sort(this.compareByOrder)
+        inFlight.sort(this.compareByOrder)
+        floating.sort(this.compareByTimestamp)
+
+        // 按时间戳把 floating 归并进 backbone：插到最后一个 timestamp <= 它的 backbone 之后
+        // （比全部 backbone 都晚的落定消息，排在 backbone 末尾、in-flight 气泡之前）。
+        const merged: MessageWrap[] = []
+        let fi = 0
+        for (const bmsg of backbone) {
+            const bts = bmsg.timestamp || 0
+            while (fi < floating.length && (floating[fi].timestamp || 0) <= bts) {
+                merged.push(floating[fi])
+                fi++
             }
-            const clientSeqDiff = (a.clientSeq || 0) - (b.clientSeq || 0)
-            if (clientSeqDiff !== 0) {
-                return clientSeqDiff
-            }
-            return (a.clientMsgNo || "").localeCompare(b.clientMsgNo || "")
-        })
+            merged.push(bmsg)
+        }
+        while (fi < floating.length) {
+            merged.push(floating[fi])
+            fi++
+        }
+
+        // 原地写回，保持调用方持有的数组引用不变。
+        messages.splice(0, messages.length, ...merged, ...inFlight)
+        return messages
     }
 
     // 按 clientMsgNo 去重，保留最后一次出现（实时消息优先于历史拉取）


### PR DESCRIPTION
## Summary

Fixes #275 — Web chat renders older messages/files **below** newer ones ("沉底"), crossing date separators and never returning to their chronological position. Reported 3+ times over 3 months (孟凡迪 2026-04, 李金龙 2026-05-26, 叶佳 2026-06-03) and linked to dmwork-pool#334 (P0).

## Root cause

`MessageWrap.order` defaults to `0` for any message with `messageSeq === 0` (`Service/Model.tsx:224`). `getMessageSortOrder` therefore routes such messages into the `PendingMessageOrderBase (≈ MAX_SAFE_INTEGER/2)` branch, which sorts them **after every sequenced message regardless of timestamp**.

For a genuinely in-flight bubble (status `Wait`/`Fail`) that "sink to bottom" is correct. But a **settled (`Normal`) message that lingers without a seq** — a lost/late send-ack, a reconnect backfill, or a stale `sendQueue` copy merged back into the window (exactly the class #242 describes: *"stale no-seq … messages can be merged back with remote sync results and appear in the wrong position"*) — gets permanently pinned to the bottom. Because the date/time separators are derived from the sorted order (`insertTimeOrHistorySplit`), the old message then displays under a **newer** date header, matching every report.

## Fix

`sortMessages` now splits messages into three groups so the result is still a deterministic total order:

- **backbone** — messages with a real seq (or an `order` already mapped into seq-space via `fillOrder`). Sorted exactly as before — server-sequenced ordering from #242 is untouched.
- **in-flight** — no-seq `Wait`/`Fail` bubbles. Still pinned to the bottom (send/retry UX preserved).
- **floating** — no-seq `Normal` messages. Merged back into the backbone **by timestamp**, so a delayed/unreconciled message lands at its correct chronological slot instead of sinking.

The seq'd backbone (the 99% path) is byte-for-byte unchanged; only messages the old code couldn't place meaningfully (order `0`/`NaN`) are affected.

## Tests

`packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts`

- **new (#275)** — a settled no-seq message with an older timestamp is reinserted at its chronological slot (fails on old code: message sinks to bottom; passes after fix).
- **new (#275)** — a settled no-seq message newer than the sequenced tail stays above in-flight bubbles.
- **reframed** — in-flight (`Wait`/`Fail`) no-seq messages stay pinned to the bottom even with earlier timestamps.

```
pnpm exec vitest run packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts \
  --config packages/dmworkbase/vitest.config.ts
# 17 passed
```

Full Conversation suite: **122 passed**. The one failing suite (`categoriesFallback.test.ts`) fails identically on a clean baseline — a pre-existing `lottie-web`/canvas env issue, not from this change.

## Reviewer note (please validate against live)

This targets the **no-seq / unreconciled** variant, which is code-confirmed and matches #242's own diagnosis. Please confirm against a live delayed-delivery repro that the sunk messages are indeed no-seq (`messageSeq === 0`, status `Normal`). If any reported case involves a message that carries a **real but larger** seq (server assigns seq at persist-time, so a late-delivered message can out-rank an earlier one), that is a separate seq-vs-time ordering question this PR does not address — flag it and we'll scope a follow-up.

Draft — for review squad (qa + security + code). Do not merge without QA sign-off.
