### PR TITLE
fix(frontend): await device fetch before connectIM to close clientMsgDeviceId=0 race #256

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -875,28 +875,32 @@ export default class WKApp extends ProviderListener {
     }
   }
 
-  startMain() {
+  async startMain() {
+    // 先解析真实 deviceId 再连接 IM：connectIM 会立刻打开 WuKongIM WebSocket，
+    // 若在 /user/devices 返回前发送消息，clientMsgNo 会用 SDK 默认值 0 拼成
+    // "<uuid>_0_3"，破坏下游按设备去重 (#256)。这里 await 消除该竞态窗口。
+    try {
+      const res = await WKApp.apiClient.get(
+        `/user/devices/${WKApp.shared.deviceId}`
+      );
+      if (res?.id) {
+        WKSDK.shared().config.clientMsgDeviceId = res.id;
+      }
+    } catch (err: any) {
+      // 设备记录不存在（status===400）或其它读取失败时，仅记录告警以消除
+      // unhandled promise rejection；不写 clientMsgDeviceId，保持原值降级运行。
+      // 服务端暂无设备注册端点，此处不做注册，仅兜底。降级仍需连接 IM (#255)，
+      // 因此不 return——设备读取失败不应阻断 IM 上线。
+      const notFound = err?.status === 400;
+      console.warn(
+        `[startMain] fetch device record failed${notFound ? " (device not found)" : ""}`,
+        { deviceId: WKApp.shared.deviceId, status: err?.status, code: err?.code }
+      );
+    }
+
     this.connectIM();
     WKApp.dataSource.contactsSync(); // 同步通讯录
     ProhibitwordsService.shared.sync(); // 同步敏感词
-
-    WKApp.apiClient
-      .get(`/user/devices/${WKApp.shared.deviceId}`)
-      .then((res) => {
-        if (res.id) {
-          WKSDK.shared().config.clientMsgDeviceId = res.id;
-        }
-      })
-      .catch((err) => {
-        // 设备记录不存在（status===400）或其它读取失败时，仅记录告警以消除
-        // unhandled promise rejection；不写 clientMsgDeviceId，保持原值降级运行。
-        // 服务端暂无设备注册端点，此处不做注册，仅兜底。
-        const notFound = err?.status === 400;
-        console.warn(
-          `[startMain] fetch device record failed${notFound ? " (device not found)" : ""}`,
-          { deviceId: WKApp.shared.deviceId, status: err?.status, code: err?.code }
-        );
-      });
   }
 
   connectIM() {

--- a/packages/dmworkbase/src/__tests__/App.startMain.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.startMain.test.ts
@@ -136,4 +136,60 @@ describe("[api] WKApp.startMain device record fetch", () => {
     expect(contactsSyncSpy).toHaveBeenCalledTimes(1);
     expect(prohibitSyncSpy).toHaveBeenCalledTimes(1);
   });
+
+  // ── #256 regression: eliminate the clientMsgDeviceId=0 race window ──
+  // Before the fix connectIM() fired synchronously, before the async
+  // /user/devices fetch resolved, so the WS opened while clientMsgDeviceId was
+  // still the SDK default (0). Outbound messages built in that gap got
+  // clientMsgNo = "<uuid>_0_3", corrupting per-device dedup. startMain must now
+  // resolve the real deviceId BEFORE connecting.
+  it("[repro] happy path: writes clientMsgDeviceId BEFORE connectIM (no deviceId=0 window)", async () => {
+    hoisted.wkConfig.clientMsgDeviceId = 0 as any; // SDK default before fetch
+    getSpy.mockReturnValue(Promise.resolve({ id: "srv-dev-1" }) as any);
+
+    let deviceIdAtConnect: unknown = "CONNECT_NOT_CALLED";
+    connectIMSpy.mockImplementation(() => {
+      deviceIdAtConnect = hoisted.wkConfig.clientMsgDeviceId;
+    });
+
+    await WKApp.shared.startMain();
+    await flush();
+
+    // Before fix: connectIM ran with the default 0. After fix: real id is set first.
+    expect(deviceIdAtConnect).toBe("srv-dev-1");
+    expect(connectIMSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("[repro] device fetch failure: still connects (degraded), and only after the fetch settles — never before", async () => {
+    hoisted.wkConfig.clientMsgDeviceId = 0 as any;
+    getSpy.mockReturnValue(
+      Promise.reject({ status: 400, code: "bad_request" }) as any
+    );
+
+    let getResolved = false;
+    getSpy.mockImplementation(
+      () =>
+        new Promise((_, reject) =>
+          setTimeout(() => {
+            getResolved = true;
+            reject({ status: 400, code: "bad_request" });
+          }, 0)
+        ) as any
+    );
+
+    let connectSeenAfterFetch = false;
+    connectIMSpy.mockImplementation(() => {
+      connectSeenAfterFetch = getResolved;
+    });
+
+    await WKApp.shared.startMain();
+    await flush();
+
+    // Graceful degradation (#255): still connect on failure...
+    expect(connectIMSpy).toHaveBeenCalledTimes(1);
+    // ...but only once the fetch has settled, so we never open the WS with a
+    // half-known deviceId.
+    expect(connectSeenAfterFetch).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes #256

## Problem

`WKApp.startMain()` called `connectIM()` **synchronously first**, then fired the async `GET /user/devices/:id` fetch that sets `WKSDK.config.clientMsgDeviceId`. During the fetch window (~50–200ms) the WuKongIM WebSocket was already open while `clientMsgDeviceId` was still the SDK default `0`, so any outbound message built in that gap got `clientMsgNo = "<uuid>_0_3"` — corrupting per-device dedup / cross-device tracking downstream. Silent (no UI symptom, no console error).

## Fix (Option A — reorder)

`startMain` now `await`s the device fetch and sets `clientMsgDeviceId` **before** `connectIM()`, eliminating the `deviceId=0` window entirely.

Crucially, PR #255's graceful-degradation behavior is preserved: on device-fetch failure (e.g. 400 stale device) we still `warn` and **still connect** in degraded mode — the fetch failure does not block IM. (The issue's Option A pseudocode had `return` on catch; that would regress #255 and its tests, so it was intentionally not adopted.)

Trade-off: WS connect now waits one `/user/devices` roundtrip — the documented, accepted latency cost of Option A.

## Tests

`packages/dmworkbase/src/__tests__/App.startMain.test.ts` — 3 existing tests still pass; 2 new `[repro]` regression tests added:
- happy path: `clientMsgDeviceId` is the server value **at the moment `connectIM` fires** (was `0` before fix)
- fetch-failure: still connects (degraded), but only **after** the fetch settles

Both new tests **fail on `main`**, pass after the fix. Full `@octo/base` suite shows no new failures vs. baseline (pre-existing unrelated failures unchanged).

## Scope

Frontend only — `packages/dmworkbase/src/App.tsx`. Options B (backend register endpoint) and C (SDK-level guard) from the issue are out of scope.
