### PR TITLE
fix(base): recover group creator permissions on half-success create #244

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/__tests__/vm.subscriberFallback.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/__tests__/vm.subscriberFallback.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ChannelSettingVM — subscriberOfMe HTTP 兜底回归门（GH octo-web#244）
+ *
+ * 弱网下群创建「半成功」(群记录已入库但 IM 频道未创建/未同步，详见 octo-server#247)：
+ * 本地 SDK 没有 subscriber 缓存 → reloadSubscribers 读到空 → subscriberOfMe 为
+ * undefined → ChannelSettingRouteData.isManagerOrCreatorOfMe 返回 false →
+ * 群「创建者」被当成非管理员，改名 / 改头像 / 公告全部被拒且无任何提示。
+ *
+ * 修复：当本地缓存拿不到 subscriberOfMe 时，直接走 HTTP
+ * (GET groups/:id/members/:uid，读 DB 而非依赖 IM 频道) 兜底拉取「我」的成员记录，
+ * 用服务端权威 role 回填 subscriberOfMe，恢复创建者的管理权限。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const hoisted = vi.hoisted(() => {
+    const subscriber = vi.fn()
+    const channelManager = {
+        fetchChannelInfo: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addSubscriberChangeListener: vi.fn(),
+        removeSubscriberChangeListener: vi.fn(),
+        getChannelInfo: vi.fn(() => undefined),
+        getSubscribes: vi.fn(() => []), // 本地缓存为空：模拟半成功 / 未同步
+        syncSubscribes: vi.fn(() => Promise.resolve()),
+    }
+    return { subscriber, channelManager }
+})
+
+vi.mock("../../../App", () => ({
+    default: {
+        apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn(), put: vi.fn() },
+        shared: { channelSettings: () => [] },
+        loginInfo: { uid: "alice" },
+        dataSource: { channelDataSource: { subscriber: hoisted.subscriber } },
+    },
+    __esModule: true,
+}))
+
+vi.mock("@douyinfe/semi-ui", () => ({
+    Toast: { error: vi.fn(), warning: vi.fn() },
+}))
+
+vi.mock("wukongimjssdk", () => ({
+    default: { shared: () => ({ channelManager: hoisted.channelManager }) },
+    WKSDK: { shared: () => ({ channelManager: hoisted.channelManager }) },
+    Channel: class {
+        constructor(public channelID: string, public channelType: number) {}
+        isEqual(): boolean {
+            return false
+        }
+    },
+    ChannelInfo: class {},
+    ChannelTypePerson: 1,
+    __esModule: true,
+}))
+
+vi.mock("../../ListItem", () => ({
+    ListItem: () => null,
+    ListItemSwitch: () => null,
+    ListItemIcon: () => null,
+}))
+
+import { ChannelSettingVM } from "../vm"
+import { GroupRole } from "../../../Service/Const"
+
+const ChannelTypeGroup = 2
+
+function makeGroupVM() {
+    const channel: any = { channelID: "grp-halfsuccess", channelType: ChannelTypeGroup, isEqual: () => false }
+    return new ChannelSettingVM(channel)
+}
+
+beforeEach(() => {
+    hoisted.subscriber.mockReset()
+    hoisted.channelManager.getSubscribes.mockReturnValue([])
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe("ChannelSettingVM.ensureSubscriberOfMeFallback — issue 244", () => {
+    it("issue 244: recovers creator permission when local subscriber cache is empty", async () => {
+        // 服务端 DB 里群主记录存在（半成功：群记录已入库），HTTP 兜底能拿到 owner role。
+        hoisted.subscriber.mockResolvedValueOnce({ uid: "alice", role: GroupRole.owner })
+        const vm: any = makeGroupVM()
+
+        // 前置：本地缓存空 → subscriberOfMe 尚未就绪 → 权限判定为 false（bug 现场）。
+        expect(vm.subscriberOfMe).toBeUndefined()
+        expect(vm.routeData.isManagerOrCreatorOfMe).toBe(false)
+
+        await vm.ensureSubscriberOfMeFallback()
+
+        // HTTP 兜底命中，用 uid + channel 精确查询「我」。
+        expect(hoisted.subscriber).toHaveBeenCalledTimes(1)
+        expect(hoisted.subscriber.mock.calls[0][1]).toBe("alice")
+        // 回填后创建者恢复管理权限。
+        expect(vm.subscriberOfMe).toMatchObject({ uid: "alice", role: GroupRole.owner })
+        expect(vm.routeData.subscriberOfMe).toMatchObject({ uid: "alice" })
+        expect(vm.routeData.isManagerOrCreatorOfMe).toBe(true)
+    })
+
+    it("issue 244: no-op when subscriberOfMe already resolved from cache", async () => {
+        const vm: any = makeGroupVM()
+        vm.subscriberOfMe = { uid: "alice", role: GroupRole.owner }
+
+        await vm.ensureSubscriberOfMeFallback()
+
+        // 缓存已就绪 → 不重复打服务端。
+        expect(hoisted.subscriber).not.toHaveBeenCalled()
+    })
+
+    it("issue 244: stays silent (no crash) when server has no membership row", async () => {
+        // 更坏的半成功：连成员记录都没入库 → subscriber() 返回 undefined。
+        hoisted.subscriber.mockResolvedValueOnce(undefined)
+        const vm: any = makeGroupVM()
+
+        await expect(vm.ensureSubscriberOfMeFallback()).resolves.toBeUndefined()
+        expect(vm.subscriberOfMe).toBeUndefined()
+        expect(vm.routeData.isManagerOrCreatorOfMe).toBe(false)
+    })
+
+    it("issue 244: swallows HTTP errors without throwing", async () => {
+        hoisted.subscriber.mockRejectedValueOnce({ status: 500, msg: "boom" })
+        const vm: any = makeGroupVM()
+
+        await expect(vm.ensureSubscriberOfMeFallback()).resolves.toBeUndefined()
+        expect(vm.subscriberOfMe).toBeUndefined()
+    })
+
+    it("issue 244: skips fallback for 1-1 (person) channels", async () => {
+        const channel: any = { channelID: "peer", channelType: 1, isEqual: () => false }
+        const vm: any = new ChannelSettingVM(channel)
+
+        await vm.ensureSubscriberOfMeFallback()
+
+        expect(hoisted.subscriber).not.toHaveBeenCalled()
+    })
+})

--- a/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
@@ -307,7 +307,15 @@ export class ChannelSettingVM extends ProviderListener {
             }
             WKSDK.shared().channelManager.addSubscriberChangeListener(this.subscriberChangeListener)
 
-            // WKSDK.shared().channelManager.syncSubscribes(this.channel)
+            // 强制从服务端同步成员列表（走 HTTP membersync，读 DB 而非依赖 IM 频道）。
+            // 弱网下群创建「半成功」(群记录已入库但 IM 频道未创建/未同步，详见 octo-server#247)
+            // 时，本地 SDK 无 subscriber 缓存，不同步就永远拿不到成员 / subscriberOfMe。
+            // 同步完成会触发 subscriberChangeListener → reloadSubscribers 回填。(GH octo-web#244)
+            void WKSDK.shared().channelManager.syncSubscribes(this.channel)
+
+            // 即便全量 membersync 因增量 version 缓存等原因没回填「我」，也用单条 HTTP 查询
+            // (GET groups/:id/members/:uid) 兜底拉取本人的服务端权威 role，恢复创建者管理权限。
+            void this.ensureSubscriberOfMeFallback()
 
         }
         this.channelInfoListener = (channelInfo:ChannelInfo) => {
@@ -366,6 +374,39 @@ export class ChannelSettingVM extends ProviderListener {
             this.notifyListener()
         }
 
+    }
+
+    /**
+     * subscriberOfMe HTTP 兜底（GH octo-web#244）。
+     *
+     * reloadSubscribers 读的是本地 SDK 缓存；弱网下群创建「半成功」(群记录已入库但
+     * IM 频道未创建/未同步，详见 octo-server#247) 时缓存为空 → subscriberOfMe 为
+     * undefined → ChannelSettingRouteData.isManagerOrCreatorOfMe 返回 false →
+     * 群创建者被当成非管理员，改名/改头像/公告全部被拒且无任何提示。
+     *
+     * 缓存拿不到「我」时，直接走单条 HTTP 查询 (GET groups/:id/members/:uid，读 DB
+     * 而非依赖 IM 频道) 拿服务端权威 role 回填，恢复创建者的管理权限。
+     * subscriber() 对 404 / 不存在返回 undefined；异常一律静默，绝不 crash 设置页。
+     */
+    async ensureSubscriberOfMeFallback(): Promise<void> {
+        if (this.channel.channelType === ChannelTypePerson) return
+        if (this.subscriberOfMe) return // 缓存已就绪，无需兜底
+        const loginUID = WKApp.loginInfo?.uid
+        if (!loginUID) return
+        let me: Subscriber | undefined
+        try {
+            me = await WKApp.dataSource.channelDataSource.subscriber(this.channel, loginUID)
+        } catch (e) {
+            // 弱网 / 无权限 / 服务端错误：保持既有行为静默降级，不打断设置页渲染。
+            console.warn("[ChannelSetting] ensureSubscriberOfMeFallback failed:", e)
+            return
+        }
+        // 兜底期间可能已被 unmount，或全量同步已回填 subscriberOfMe，两种情况都不再覆盖。
+        if (this._disposed || !me || this.subscriberOfMe) return
+        me.channel = this.channel
+        this.subscriberOfMe = me
+        this.routeData.subscriberOfMe = me
+        this.notifyListener()
     }
 
     reloadChannelInfo() {


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #244 — 弱网群创建半成功后侧边栏群设置不可操作

## 1. Executive Summary
- **Bug**: 弱网下群创建「半成功」（群记录入库但 IM 频道未创建/未同步）后，群创建者在侧边栏群设置里改名/改头像/改公告全部被拒且无任何提示。
- **Root Cause**: `ChannelSetting/vm.ts` 未同步成员，`subscriberOfMe` 为 `undefined` → `context.tsx:isManagerOrCreatorOfMe` 返回 `false`，创建者被当成非管理员。
- **Fix Approach**: localized（仅 `ChannelSetting/vm.ts`）
- **Risk Level**: Low
- **PR**: draft（见下方链接）

## 2. Issue Context
- Title: 🐛 [Web] 弱网下群创建半成功后，侧边栏群设置不可操作（改名/改头像/公告均失败）
- Reporter: GitHub issue octo-web#244
- bug-verified by: self（v7.5 无人类 verify gate；代码级复现，见 §3）
- Affected: current `main`；触发条件为弱网 + 服务端半成功（octo-server#247）

## 3. Reproduction
**Environment**: octo-web `main`, Web 端 + 弱网（高延迟/高丢包，如海外漫游）
**Steps**:
1. 弱网下 Web 端创建群聊
2. 服务端半成功（群记录入库但 IM 频道未建，返回 200 + `group_no`）
3. 自动跳转进群，打开右侧群设置
4. 点「群名」→ Toast「仅管理员可修改」（但当前用户就是创建者）；头像/公告同样不可用
**Expected**: 群创建者可正常改名/改头像/改公告
**Actual**: 全部被拒，无错误提示
**Evidence**: 代码路径确认 —
- 权限门 `module.tsx:1611/1650/1691` 读 `data.isManagerOrCreatorOfMe`
- `context.tsx:18` 该 getter 依赖 `subscriberOfMe?.role`
- `vm.ts:310` 原 `syncSubscribes` 被注释掉 → 本地无缓存时 `subscriberOfMe` 恒为 `undefined` → getter 恒 `false`
- 回归测试 `vm.subscriberFallback.test.ts` 在修复前 RED（`isManagerOrCreatorOfMe===false`），修复后 GREEN。

## 4. RCA
**Method**: Fault Tree（多组件失败叠加）
**Analysis**:
- 服务端半成功（octo-server#247，本 issue 根因，服务端侧另行处理）→ IM 频道缺失
- → WKSDK 本地无 subscriber 缓存
- → `ChannelSetting/vm.ts` `reloadSubscribers()` 读到空，且 `syncSubscribes` 被注释、无 HTTP 兜底 → `subscriberOfMe` 保持 `undefined`
- → `isManagerOrCreatorOfMe` 返回 `false`
- → 创建者被当成非管理员，管理操作静默失败

**Root cause**: `packages/dmworkbase/src/Components/ChannelSetting/vm.ts:didMount` — 群设置面板挂载时不做服务端成员兜底，`subscriberOfMe` 在缓存缺失场景恒为空，导致 `context.tsx:isManagerOrCreatorOfMe` 误判。

**Scope note（诚实校准）**: 原 issue 建议修复 #1（`createChannel` 加 timeout）在当前 `main` 已由 `APIClient.ts:DEFAULT_REQUEST_TIMEOUT_MS = 20_000`（YUJ-2628）覆盖，无需重复加。建议 #3 依赖 `channelInfo.orgData.creator` 字段，但 `channels/:uid/:type` 当前不返回该字段（`datasource/module.ts:115-155`），故未按原文实现，改用现有 `subscriber(channel, uid)` 端点做服务端权威兜底，等价且不需服务端改动。

## 5. Fix Description
**Files changed**:
- `packages/dmworkbase/src/Components/ChannelSetting/vm.ts` (+40/-1)
- `packages/dmworkbase/src/Components/ChannelSetting/__tests__/vm.subscriberFallback.test.ts` (new, +160)

**Change summary**: 在 `didMount` 恢复被注释的 `WKSDK.syncSubscribes(this.channel)`（走 HTTP `membersync`，读 DB 而非 IM 频道），并新增 `ensureSubscriberOfMeFallback()`：当本地缓存拿不到「我」时，单条 HTTP 查询 `GET groups/:id/members/:uid` 拉取服务端权威 role 回填 `subscriberOfMe`，恢复创建者管理权限。兜底对 404/异常静默降级，含 `_disposed` unmount 守卫与「已被全量同步回填则不覆盖」双重防呆。

**Does NOT change** (scope 边界):
- 不动服务端半成功事务边界（octo-server#247）
- 不加 `createChannel` timeout（全局 20s 已有）
- 不做「群异常状态 UI + 重试按钮」「网络状态感知预警」（issue 中期项，另开 PR）
- 不改 `GroupNew` 创建后跳转逻辑

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| issue 244: recovers creator permission when local subscriber cache is empty | `vm.subscriberFallback.test.ts` | 缓存空→HTTP 兜底回填 owner→`isManagerOrCreatorOfMe===true` | FAIL | PASS |
| issue 244: no-op when subscriberOfMe already resolved from cache | 同上 | 缓存已就绪不重复请求 | FAIL | PASS |
| issue 244: stays silent when server has no membership row | 同上 | `subscriber()` 返回 undefined 不 crash | FAIL | PASS |
| issue 244: swallows HTTP errors without throwing | 同上 | 服务端 500 静默降级 | FAIL | PASS |
| issue 244: skips fallback for 1-1 (person) channels | 同上 | 单聊不触发兜底 | FAIL | PASS |

## 7. CI Status
- Linter: N/A — 仓库 `pnpm lint` 走 turbo 配置；单文件 `eslint` 直跑报 parser 噪声（现存 persona 测试同样），vm.ts 无新增真实告警。
- Unit: dmworkbase 全量 `1123 pass`，其中 ChannelSetting 目录 `23 pass`（5 新 + 18 既有）。
- Integration: N/A — 前端无独立集成层。
- Coverage delta: N/A（未采集）；新增 5 条针对性用例覆盖兜底全分支。
- **Baseline diff**: 修复前后同套件均 `20 failed files`，失败集合完全一致（PersonaSettings/Claw*/Mergeforward 等既有 jsdom/react 环境失败），**new_failures == 0**，无 ChannelSetting 相关失败。

## 8. Deployment Notes
- Migration required?: no
- Config change?: no
- Feature flag: no（纯前端兜底逻辑，默认生效）
- Compatibility: backward preserved — 正常群（缓存已就绪）走既有路径，兜底仅在缓存缺失时触发；复用既有 `GET groups/:id/members/:uid` 端点，无新增服务端依赖。

## 9. Rollback Plan
**Pattern**: revert
**Steps**:
1. `git revert` 本 PR 两个 commit（test + fix）
2. 重新部署前端
**Detection** (trigger rollback): 群设置面板挂载时成员相关请求错误率异常上升，或出现 `subscriberOfMe` 被错误覆盖导致的权限误判上报。

---
_Generated by frontend-engineer · awaiting review squad (qa+security+code)_
