### PR TITLE
feat(docs): standalone document page for shared /d/:docId links

### DIFF
--- a/apps/web/e2e/standalone-doc.config.ts
+++ b/apps/web/e2e/standalone-doc.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Standalone doc page (`/d/:docId`) clean cold-load e2e — octo-web #512 / XIN-294.
+//
+// Same shape as bind.config.ts: the root playwright.config.ts targets the shared
+// im-test.deepminer.com.cn env, but this suite must exhaust the boundary status codes
+// (200/401/403/404/409) and the anonymous / malformed-id branches, so it starts a local Vite
+// dev server and mocks the backend with page.route(). That is the whole point of the tester's
+// finding — the clean cold-load (a shared link opened in a fresh tab, NO in-app sid route) must
+// stand on its own, and only a real browser hitting `/d/:docId` directly proves it.
+export default defineConfig({
+  testDir: '.',
+  testMatch: /standalone-doc\.spec\.ts$/,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    // The clean cold-load must never touch real network; page.route intercepts everything.
+    serviceWorkers: 'block',
+    trace: 'on-first-retry',
+  },
+
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+
+  webServer: {
+    command: 'pnpm dev',
+    cwd: '.',
+    url: 'http://localhost:3000',
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/apps/web/e2e/standalone-doc.spec.ts
+++ b/apps/web/e2e/standalone-doc.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+/**
+ * Standalone doc page (`/d/:docId`) — clean cold-load end-to-end (octo-web #512 / XIN-294).
+ *
+ * The tester's real-machine run (XIN-293) passed every AC reached via the in-app sid route but
+ * failed 6 on a clean cold-load (a shared link opened in a fresh tab, no `?sid=`): the direct path
+ * was not self-sufficient. These specs drive a REAL browser straight at `/d/:docId` with the
+ * backend mocked per status code, so the clean path is exercised without any in-app navigation —
+ * exactly the scenario the 447 green component unit tests never covered.
+ *
+ * Auth model under test: a signed-in user's session lives under a `token{sid}` bucket in
+ * localStorage; a fresh-tab deep-link URL has no `?sid=`, so the app must recover that session
+ * from storage (AC-3). A genuinely anonymous visitor must fall through to the login screen so the
+ * post-login bounce returns them to the doc (AC-11).
+ */
+
+const SID = 'S_e2e'
+const USER_TOKEN = 'tok-user-e2e'
+
+/** Silence unrelated boot traffic and default every backend call to an innocuous 200 {}. */
+async function stubBackend(page: Page): Promise<void> {
+  await page.route('**/api/v1/common/**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ oidc_providers: [] }),
+    }),
+  )
+  await page.route('**/api/v1/**', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+}
+
+/** Route the per-doc preflight (GET /api/v1/docs/:id) to a specific status/body. */
+async function routeDocPreflight(
+  page: Page,
+  docId: string,
+  status: number,
+  body: object = {},
+): Promise<{ tokenHeaderOf: () => string | undefined }> {
+  let seenToken: string | undefined
+  await page.route(`**/api/v1/docs/${docId}`, (route: Route) => {
+    seenToken = route.request().headers()['token']
+    route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) })
+  })
+  return { tokenHeaderOf: () => seenToken }
+}
+
+/** Seed a signed-in session under a sid bucket, as if the user logged in earlier in another tab. */
+async function seedSignedInSession(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([sid, token]) => {
+      try {
+        localStorage.clear()
+        sessionStorage.clear()
+        localStorage.setItem('token' + sid, token)
+        localStorage.setItem('uid' + sid, 'u_e2e')
+        localStorage.setItem('name' + sid, 'E2E User')
+      } catch {
+        /* noop */
+      }
+    },
+    [SID, USER_TOKEN],
+  )
+}
+
+/** Clear all storage → a genuinely anonymous visitor. */
+async function seedAnonymous(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.clear()
+      sessionStorage.clear()
+    } catch {
+      /* noop */
+    }
+  })
+}
+
+test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', () => {
+  test('AC-3: a signed-in user opening a clean link authenticates the preflight (no 401 wall)', async ({
+    page,
+  }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    const probe = await routeDocPreflight(page, 'd_ok', 200, {
+      docId: 'd_ok',
+      title: 'Shared Doc',
+      ownerId: 'u_e2e',
+      role: 'admin',
+    })
+
+    // Fresh-tab deep link: NO ?sid= in the URL.
+    await page.goto('/d/d_ok')
+
+    // The recovered session token rides the preflight — not an anonymous 401-bound request.
+    await expect.poll(() => probe.tokenHeaderOf()).toBe(USER_TOKEN)
+    // The clean path did NOT dead-end on the sign-in terminal.
+    await expect(page.locator('.octo-terminal-msg')).toHaveCount(0)
+  })
+
+  test('AC-7: a 403 renders the access-denied terminal with a Back control, editor not mounted', async ({
+    page,
+  }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    await routeDocPreflight(page, 'd_forbidden', 403)
+
+    await page.goto('/d/d_forbidden')
+
+    await expect(page.locator('.octo-terminal')).toBeVisible()
+    await expect(page.locator('.octo-terminal-msg')).toHaveText(/no longer have access|无权访问/)
+    await expect(page.locator('.octo-doc-back')).toBeVisible()
+    await expect(page.locator('.octo-doc--editor')).toHaveCount(0)
+  })
+
+  test('AC-12: an archived doc (409) renders the locked terminal', async ({ page }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    await routeDocPreflight(page, 'd_archived', 409)
+
+    await page.goto('/d/d_archived')
+
+    await expect(page.locator('.octo-terminal')).toBeVisible()
+    await expect(page.locator('.octo-terminal-msg')).toHaveText(/locked or archived|锁定或归档/)
+    await expect(page.locator('.octo-doc--editor')).toHaveCount(0)
+  })
+
+  test('AC-10/9: a 404 renders the not-found terminal', async ({ page }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    await routeDocPreflight(page, 'd_missing', 404)
+
+    await page.goto('/d/d_missing')
+
+    await expect(page.locator('.octo-terminal')).toBeVisible()
+    await expect(page.locator('.octo-terminal-msg')).toHaveText(/does not exist|不存在/)
+  })
+
+  test('AC-9: a malformed id (`/d/` empty) renders not-found without any preflight, never the shell', async ({
+    page,
+  }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    let preflightCalls = 0
+    await page.route('**/api/v1/docs/**', (route: Route) => {
+      preflightCalls += 1
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    // `/d/` with no id is still the standalone namespace — must be intercepted, not shelled.
+    await page.goto('/d/')
+
+    await expect(page.locator('.octo-terminal')).toBeVisible()
+    await expect(page.locator('.octo-terminal-msg')).toHaveText(/does not exist|不存在/)
+    // The app shell (NavRail) must NOT appear.
+    await expect(page.locator('.wk-nav-rail, .octo-nav-rail')).toHaveCount(0)
+    expect(preflightCalls).toBe(0)
+  })
+
+  test('AC-11: an anonymous visitor is sent to the login screen (so post-login bounces back)', async ({
+    page,
+  }) => {
+    await seedAnonymous(page)
+    await stubBackend(page)
+    // Even if a preflight were issued it would 401; the point is the app renders login, not a
+    // standalone dead-end.
+    await routeDocPreflight(page, 'd_shared', 401)
+
+    await page.goto('/d/d_shared')
+
+    // The login screen renders in place (pathname stays /d/d_shared → onLogin bounces back).
+    await expect(page.locator('[class^="wk-login"], [class*=" wk-login"]').first()).toBeVisible()
+    await expect(page.locator('.octo-doc-standalone')).toHaveCount(0)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,8 @@
     "test": "vitest run",
     "test:e2e:bind": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test -c e2e/bind.config.ts",
     "test:e2e:bind:install": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium",
+    "test:e2e:standalone": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test -c e2e/standalone-doc.config.ts",
+    "test:e2e:standalone:install": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium",
     "test:arch-builds": "./scripts/test-arch-builds.sh",
     "debug:build-structure": "./scripts/debug-build-structure.sh",
     "test:arch-specific": "./scripts/test-arch-specific-builds.sh",

--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -5,7 +5,10 @@ import {
   findUniqueStoredSession,
   findSidForToken,
   adoptStoredSession,
+  sidsForToken,
+  clearSessionsWithToken,
   type StorageLike,
+  type WritableStorageLike,
   type SessionSink,
 } from '../recoverSession'
 
@@ -112,6 +115,20 @@ function storageOver(store: Map<string, string>): StorageLike {
     },
     key: (i: number) => Array.from(store.keys())[i] ?? null,
     getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+  }
+}
+
+/** A writable Storage-like view over a Map (adds removeItem) for the expired-session clear. */
+function writableStorageOver(store: Map<string, string>): WritableStorageLike {
+  return {
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
   }
 }
 
@@ -381,5 +398,132 @@ describe('multi-session deep-link login round trip — the /d/:docId loop is bro
     reloaded.load()
     expect(reloaded.token).toBe('tok-current') // hit — authenticated, no recovery, no loop
     expect(reloaded.uid).toBe('u_cur')
+  })
+})
+
+describe('sidsForToken — buckets holding the current (expired) token, matched by value (XIN-408)', () => {
+  it('lists every sid whose token bucket holds the given token, empty-sid reported as ""', () => {
+    // The cold-load recover-then-persist case: the same expired token lives in the empty-sid bucket
+    // AND its original sid-keyed bucket. Both must be named so a clear tears down both copies.
+    const store = storageOver(
+      new Map([
+        ['token', 'expired-tok'],
+        ['uid', 'u_e'],
+        ['tokenabc', 'expired-tok'],
+        ['uidabc', 'u_e'],
+        ['tokenxyz', 'other-valid-tok'],
+        ['uidxyz', 'u_v'],
+      ]),
+    )
+    expect(sidsForToken(store, 'expired-tok').sort()).toEqual(['', 'abc'])
+    // A different, still-valid session (different token value) is never listed.
+    expect(sidsForToken(store, 'other-valid-tok')).toEqual(['xyz'])
+  })
+
+  it('matches nothing for an empty token and never treats tokenCallback as a bucket', () => {
+    const store = storageOver(new Map([['tokenCallback', 'expired-tok'], ['tokenA', 'expired-tok']]))
+    expect(sidsForToken(store, '')).toEqual([])
+    expect(sidsForToken(store, 'expired-tok')).toEqual(['A']) // tokenCallback excluded
+  })
+})
+
+describe('clearSessionsWithToken — clears only the expired session, never a valid one (XIN-408)', () => {
+  it('removes every bucket holding the expired token across both stores, leaving valid sessions intact', () => {
+    // Model the cross-tab mirror: cross-tab keys live in BOTH sessionStorage and localStorage.
+    const session = new Map<string, string>([
+      ['token', 'expired-tok'], // empty-sid mirror written by the recover-then-persist path
+      ['uid', 'u_e'],
+      ['name', 'Expired'],
+      ['tokenabc', 'expired-tok'], // the original sid-keyed bucket the token was recovered from
+      ['uidabc', 'u_e'],
+      ['nameabc', 'Expired'],
+      ['tokenGOOD', 'valid-tok'], // a DIFFERENT, still-valid session — must survive
+      ['uidGOOD', 'u_v'],
+      ['nameGOOD', 'Valid'],
+    ])
+    const local = new Map(session) // same key set mirrored across tabs
+
+    clearSessionsWithToken('expired-tok', writableStorageOver(session), writableStorageOver(local))
+
+    for (const store of [session, local]) {
+      // Every copy of the expired session is gone…
+      expect(store.get('token')).toBeUndefined()
+      expect(store.get('tokenabc')).toBeUndefined()
+      expect(store.get('uidabc')).toBeUndefined()
+      expect(store.get('nameabc')).toBeUndefined()
+      // …but the unrelated valid session is untouched.
+      expect(store.get('tokenGOOD')).toBe('valid-tok')
+      expect(store.get('uidGOOD')).toBe('u_v')
+    }
+  })
+
+  it('is a no-op for an empty token (nothing to match)', () => {
+    const store = new Map<string, string>([['tokenA', 'tok-a'], ['uidA', 'u_a']])
+    clearSessionsWithToken('', writableStorageOver(store))
+    expect(store.get('tokenA')).toBe('tok-a')
+  })
+})
+
+describe('expired-token deep-link login round trip — the /d/:docId dead-end is cleared (XIN-408)', () => {
+  // Byte-trace on head de0b8d82: a signed-in user whose session has EXPIRED opens a shared
+  // /d/:docId in a fresh tab (no ?sid=). Layout recovers the sole stored session from `token{sid'}`,
+  // persists it into the empty-sid bucket, and mounts the page with a non-empty-but-stale token. The
+  // preflight 401s → the OLD code rendered a terminal with no login entry, and clearing only the
+  // current (empty) sid left `token{sid'}` behind, so a reload just re-recovered the dead session:
+  // a dead-end / re-mount loop. Modeling the storage shows the fix (clear by token value) breaks it.
+  function coldLoadWithRecoveredExpiredSession() {
+    // Post-recover-then-persist state: the expired token sits in BOTH the empty-sid bucket and the
+    // original sid-keyed bucket it was recovered from.
+    return new Map<string, string>([
+      ['token', 'expired-tok'],
+      ['uid', 'u_e'],
+      ['name', 'Expired'],
+      ['tokenabc', 'expired-tok'],
+      ['uidabc', 'u_e'],
+      ['nameabc', 'Expired'],
+    ])
+  }
+
+  it('OLD behavior (clear only the current empty-sid bucket) loops: the sid-keyed copy is re-recovered', () => {
+    const store = coldLoadWithRecoveredExpiredSession()
+    // The pre-fix clear was sid-scoped to the URL (empty sid here): only the empty-sid bucket goes.
+    for (const prefix of ['token', 'uid', 'name']) store.delete(prefix + '')
+    // A no-sid reload's recovery scans localStorage — and still finds the unique sid-keyed bucket…
+    expect(findUniqueStoredSession(storageOver(store))).toEqual({
+      token: 'expired-tok',
+      uid: 'u_e',
+      name: 'Expired',
+    })
+    // …so it re-adopts the SAME expired session → the page re-mounts → 401 again → the dead-end loops.
+  })
+
+  it('FIX (clear by token value across stores) resolves: no bucket survives → falls through to login', () => {
+    const store = coldLoadWithRecoveredExpiredSession()
+    clearSessionsWithToken('expired-tok', writableStorageOver(store))
+    // Nothing recoverable remains, so the reloaded standalone branch sees `!token` and renders the
+    // real login screen. The stashed return target then bounces the user back to the doc post-login.
+    expect(findUniqueStoredSession(storageOver(store))).toBeNull()
+    expect(findStoredSession(storageOver(store))).toBeNull()
+    const reloaded = new FakeLoginInfo(store, '')
+    reloaded.load()
+    expect(reloaded.token).toBe('') // → login screen, not the dead terminal
+  })
+
+  it('a multi-session user keeps their OTHER valid session when the expired one is cleared', () => {
+    // Expired session in its own bucket + a second, still-valid session. Clearing the expired token
+    // must not disturb the valid one (XIN-392: never touch a valid session).
+    const store = new Map<string, string>([
+      ['tokenexp', 'expired-tok'],
+      ['uidexp', 'u_e'],
+      ['tokenok', 'valid-tok'],
+      ['uidok', 'u_v'],
+      ['nameok', 'Valid'],
+    ])
+    clearSessionsWithToken('expired-tok', writableStorageOver(store))
+    expect(findSidForToken(storageOver(store), 'valid-tok')).toBe('ok')
+    const stillThere = new FakeLoginInfo(store, 'ok')
+    stillThere.load()
+    expect(stillThere.token).toBe('valid-tok')
+    expect(stillThere.uid).toBe('u_v')
   })
 })

--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { findStoredSession, type StorageLike } from '../recoverSession'
+
+/** Minimal in-memory Storage-like bag (insertion-ordered) for the scan. */
+function makeStorage(entries: Record<string, string>): StorageLike {
+  const keys = Object.keys(entries)
+  return {
+    length: keys.length,
+    key: (i: number) => keys[i] ?? null,
+    getItem: (k: string) => (k in entries ? entries[k] : null),
+  }
+}
+
+describe('findStoredSession — clean cold-load session recovery (AC-3)', () => {
+  it('recovers a sid-keyed session opened in a fresh tab with no ?sid= in the URL', () => {
+    // The signed-in user logged in under sid "abc"; a shared /d/:docId link opened in a new tab
+    // has no ?sid=, so the sid-keyed load() found nothing. The scan adopts the stored session.
+    const storage = makeStorage({
+      tokenabc: 'octo-session-xyz',
+      uidabc: 'u_42',
+      nameabc: 'Ada',
+      currentSpaceId: 's_1',
+    })
+    expect(findStoredSession(storage)).toEqual({
+      token: 'octo-session-xyz',
+      uid: 'u_42',
+      name: 'Ada',
+    })
+  })
+
+  it('recovers the empty-sid session stored under a plain-sid bucket (token"")', () => {
+    // A login with no ?sid= persists under token"" → key is exactly "token", which load() already
+    // handled; so it is intentionally skipped. A user with only that key is considered loaded by
+    // load(), not recovered here → null.
+    const storage = makeStorage({ token: 'bare', uid: 'u_bare' })
+    expect(findStoredSession(storage)).toBeNull()
+  })
+
+  it('returns null for a genuinely anonymous visitor (no token bucket) → login redirect (AC-11)', () => {
+    const storage = makeStorage({ currentSpaceId: 's_1', locale: 'en-US' })
+    expect(findStoredSession(storage)).toBeNull()
+  })
+
+  it('never mistakes the tokenCallback config key for a session', () => {
+    const storage = makeStorage({ tokenCallback: 'not-a-token' })
+    expect(findStoredSession(storage)).toBeNull()
+  })
+
+  it('tolerates a token bucket missing its sibling uid/name', () => {
+    const storage = makeStorage({ tokenS9: 'tok' })
+    expect(findStoredSession(storage)).toEqual({ token: 'tok', uid: '', name: '' })
+  })
+
+  it('skips an empty token value and keeps scanning for a real one', () => {
+    const storage = makeStorage({
+      tokenEmpty: '',
+      tokenReal: 'real-tok',
+      uidReal: 'u_real',
+      nameReal: 'Real',
+    })
+    expect(findStoredSession(storage)).toEqual({
+      token: 'real-tok',
+      uid: 'u_real',
+      name: 'Real',
+    })
+  })
+})

--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { findStoredSession, type StorageLike } from '../recoverSession'
+import { findStoredSession, adoptStoredSession, type StorageLike, type SessionSink } from '../recoverSession'
 
 /** Minimal in-memory Storage-like bag (insertion-ordered) for the scan. */
 function makeStorage(entries: Record<string, string>): StorageLike {
@@ -63,5 +63,111 @@ describe('findStoredSession — clean cold-load session recovery (AC-3)', () => 
       uid: 'u_real',
       name: 'Real',
     })
+  })
+})
+
+/**
+ * Faithful stand-in for `@octo/base`'s `LoginInfo`, reduced to the sid-keyed session slots this
+ * flow touches. It reproduces the real class's storage contract exactly:
+ *   - save()  writes `token{sid}` / `uid{sid}` / `name{sid}` for the CURRENT sid
+ *   - load()  reads those same sid-keyed keys back
+ *   - getSID() returns whatever `?sid=` the current URL carries ('' when none)
+ * so the recover → Back → reload round trip can be exercised without booting the real host. The
+ * only behaviour under test is `adoptStoredSession`; this double is just the persistence surface.
+ */
+class FakeLoginInfo implements SessionSink {
+  token?: string
+  uid?: string
+  name?: string
+  constructor(
+    private store: Map<string, string>,
+    /** Mutable to model navigating between a `?sid=`-bearing URL and a clean one. */
+    public sid: string,
+  ) {}
+  save(): void {
+    this.store.set('token' + this.sid, this.token ?? '')
+    this.store.set('uid' + this.sid, this.uid ?? '')
+    this.store.set('name' + this.sid, this.name ?? '')
+  }
+  load(): void {
+    this.token = this.store.get('token' + this.sid) || ''
+    this.uid = this.store.get('uid' + this.sid) || ''
+    this.name = this.store.get('name' + this.sid) || ''
+  }
+}
+
+/** A real Storage-like view over a Map so the same backing store drives both scan and save/load. */
+function storageOver(store: Map<string, string>): StorageLike {
+  return {
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+  }
+}
+
+describe('adoptStoredSession — Back keeps an already-signed-in user logged in (standalone AC)', () => {
+  it('persists the recovered session so a subsequent no-sid load stays authenticated', () => {
+    // A user signed in under sid "abc"; their session lives in the sid-keyed bucket. They open a
+    // shared /d/:docId link in a fresh tab with NO ?sid=, so the clean-tab login slot (empty sid)
+    // is empty.
+    const store = new Map<string, string>([
+      ['tokenabc', 'octo-session-xyz'],
+      ['uidabc', 'u_42'],
+      ['nameabc', 'Ada'],
+    ])
+
+    // Cold-load of /d/:docId — the URL has no ?sid=, so getSID() === '' and load() reads nothing.
+    const onDeepLink = new FakeLoginInfo(store, '')
+    onDeepLink.load()
+    expect(onDeepLink.token).toBe('') // sid-keyed load misses the clean tab → would 401 without recovery
+
+    const adopted = adoptStoredSession(onDeepLink, storageOver(store))
+    expect(adopted).toBe(true)
+    expect(onDeepLink.token).toBe('octo-session-xyz')
+
+    // Back → /docs is also a no-sid navigation → a full reload boots a fresh login-info that
+    // load()s the EMPTY-sid slot. Because adoptStoredSession persisted into that slot, the reloaded
+    // session is authenticated and the user is NOT bounced to the login wall.
+    const afterBackReload = new FakeLoginInfo(store, '')
+    afterBackReload.load()
+    expect(afterBackReload.token).toBe('octo-session-xyz')
+    expect(afterBackReload.uid).toBe('u_42')
+    expect(afterBackReload.name).toBe('Ada')
+  })
+
+  it('RED without the persist: recovering in memory only leaves the Back reload logged out', () => {
+    // Documents the pre-fix behaviour: adopting the session in memory but NOT saving it leaves the
+    // empty-sid slot empty, so the Back → /docs reload reads nothing and bounces to login.
+    const store = new Map<string, string>([
+      ['tokenabc', 'octo-session-xyz'],
+      ['uidabc', 'u_42'],
+      ['nameabc', 'Ada'],
+    ])
+    const onDeepLink = new FakeLoginInfo(store, '')
+    const session = findStoredSession(storageOver(store))!
+    onDeepLink.token = session.token // in-memory only — the old code path, no save()
+    onDeepLink.uid = session.uid
+    onDeepLink.name = session.name
+
+    const afterBackReload = new FakeLoginInfo(store, '')
+    afterBackReload.load()
+    expect(afterBackReload.token).toBe('') // empty-sid slot never written → logged out on reload
+  })
+
+  it('is a no-op when a token is already loaded (does not clobber the active session)', () => {
+    const store = new Map<string, string>([['tokenabc', 'other']])
+    const info = new FakeLoginInfo(store, '')
+    info.token = 'already-here'
+    expect(adoptStoredSession(info, storageOver(store))).toBe(false)
+    expect(info.token).toBe('already-here')
+  })
+
+  it('is a no-op for a genuinely anonymous visitor (no stored session)', () => {
+    const store = new Map<string, string>([['currentSpaceId', 's_1']])
+    const info = new FakeLoginInfo(store, '')
+    expect(adoptStoredSession(info, storageOver(store))).toBe(false)
+    expect(info.token).toBeUndefined()
   })
 })

--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -3,6 +3,7 @@ import {
   findStoredSession,
   findStoredSessions,
   findUniqueStoredSession,
+  findSidForToken,
   adoptStoredSession,
   type StorageLike,
   type SessionSink,
@@ -295,5 +296,90 @@ describe('adoptStoredSession — invite branch keeps its original non-persistent
     expect(invite.token).toBe('tok-a') // first-wins, in memory, exactly as before
     // …and it is still not persisted.
     expect(new Map(store).get('token')).toBeUndefined()
+  })
+})
+
+describe('findSidForToken — sid of the CURRENT session bucket, never a guess (XIN-398)', () => {
+  it('returns the sid whose token bucket holds the current token, among several sessions', () => {
+    // A multi-session device: findUniqueStoredSession would refuse to pick (ambiguous), but the
+    // current identity is KNOWN by its token — so we can name its own sid without guessing.
+    const store = storageOver(
+      new Map([
+        ['tokenA', 'tok-a'],
+        ['uidA', 'u_a'],
+        ['tokenB', 'tok-b'],
+        ['uidB', 'u_b'],
+        ['tokenfresh6', 'tok-current'],
+        ['uidfresh6', 'u_cur'],
+      ]),
+    )
+    expect(findSidForToken(store, 'tok-current')).toBe('fresh6')
+    expect(findSidForToken(store, 'tok-a')).toBe('A')
+  })
+
+  it('returns null when the current session lives only in the empty-sid (bare token) bucket', () => {
+    // A no-sid reload already reads the bare `token` bucket, so no `?sid=` needs to be carried and
+    // the bare key is intentionally not treated as a sid-keyed bucket.
+    const store = storageOver(new Map([['token', 'bare-tok'], ['uid', 'u_bare']]))
+    expect(findSidForToken(store, 'bare-tok')).toBeNull()
+  })
+
+  it('returns null for an empty token, an unmatched token, and never matches tokenCallback', () => {
+    const store = storageOver(
+      new Map([['tokenX', 'tok-x'], ['tokenCallback', 'tok-current']]),
+    )
+    expect(findSidForToken(store, '')).toBeNull()
+    expect(findSidForToken(store, 'no-such-token')).toBeNull()
+    // The config key `tokenCallback` must never be reported as a session bucket even if its value
+    // happens to equal the current token.
+    expect(findSidForToken(store, 'tok-current')).toBeNull()
+  })
+})
+
+describe('multi-session deep-link login round trip — the /d/:docId loop is broken by carrying sid (XIN-398)', () => {
+  // Byte-level regression the reviewers reproduced on head ce328eea: an anonymous multi-session
+  // user opens a shared /d/:docId, signs in (the fresh session lands in its own `token{sid}`
+  // bucket), and goMain reloads /d/:docId. Modeling the reload's sid-keyed load() + the strict
+  // XIN-392 P1-2 recovery shows the fix flips this from a login loop to a resolved session.
+  function deviceWithThreeSessions() {
+    // Two pre-existing sessions on the device + the just-authenticated one.
+    return new Map<string, string>([
+      ['tokenA', 'tok-a'],
+      ['uidA', 'u_a'],
+      ['tokenB', 'tok-b'],
+      ['uidB', 'u_b'],
+      ['tokenfresh6', 'tok-current'],
+      ['uidfresh6', 'u_cur'],
+    ])
+  }
+
+  it('OLD behavior (no sid carried) loops: reload misses + recovery refuses to guess → stuck', () => {
+    const store = deviceWithThreeSessions()
+    // goMain reloaded /d/:docId with NO sid: the reloaded page's sid-keyed load() reads the
+    // empty-sid bucket, which is empty.
+    const reloaded = new FakeLoginInfo(store, '')
+    reloaded.load()
+    expect(reloaded.token).toBe('') // load() misses — the fresh session lives under `tokenfresh6`
+
+    // The standalone branch then tries recovery with persist:true. With three sessions stored the
+    // ambiguity gate refuses to adopt one (never pins a guessed identity), so the visitor falls
+    // through to the login screen again → the loop.
+    const adopted = adoptStoredSession(reloaded, storageOver(store), { persist: true })
+    expect(adopted).toBe(false)
+    expect(reloaded.token).toBe('') // still unauthenticated → back to login
+  })
+
+  it('FIX (carry the current session sid) resolves: reload hits the right bucket directly', () => {
+    const store = deviceWithThreeSessions()
+    // goMain looks up the current (in-memory) token's own bucket sid and hands it to the reload.
+    const currentToken = 'tok-current'
+    const sid = findSidForToken(storageOver(store), currentToken)
+    expect(sid).toBe('fresh6')
+
+    // The reloaded /d/:docId?sid=fresh6 now runs a sid-keyed load() against that exact bucket…
+    const reloaded = new FakeLoginInfo(store, sid ?? '')
+    reloaded.load()
+    expect(reloaded.token).toBe('tok-current') // hit — authenticated, no recovery, no loop
+    expect(reloaded.uid).toBe('u_cur')
   })
 })

--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { findStoredSession, adoptStoredSession, type StorageLike, type SessionSink } from '../recoverSession'
+import {
+  findStoredSession,
+  findStoredSessions,
+  findUniqueStoredSession,
+  adoptStoredSession,
+  type StorageLike,
+  type SessionSink,
+} from '../recoverSession'
 
 /** Minimal in-memory Storage-like bag (insertion-ordered) for the scan. */
 function makeStorage(entries: Record<string, string>): StorageLike {
@@ -123,7 +130,7 @@ describe('adoptStoredSession — Back keeps an already-signed-in user logged in 
     onDeepLink.load()
     expect(onDeepLink.token).toBe('') // sid-keyed load misses the clean tab → would 401 without recovery
 
-    const adopted = adoptStoredSession(onDeepLink, storageOver(store))
+    const adopted = adoptStoredSession(onDeepLink, storageOver(store), { persist: true })
     expect(adopted).toBe(true)
     expect(onDeepLink.token).toBe('octo-session-xyz')
 
@@ -169,5 +176,124 @@ describe('adoptStoredSession — Back keeps an already-signed-in user logged in 
     const info = new FakeLoginInfo(store, '')
     expect(adoptStoredSession(info, storageOver(store))).toBe(false)
     expect(info.token).toBeUndefined()
+  })
+})
+
+describe('findStoredSessions / findUniqueStoredSession — ambiguity gate (XIN-392 P1-2)', () => {
+  it('collects every valid token bucket, skipping the bare/callback/empty keys', () => {
+    const storage = makeStorage({
+      token: 'bare', // empty-sid slot load() already read → skipped
+      tokenCallback: 'cfg', // unrelated config key → skipped
+      tokenA: 'tok-a',
+      uidA: 'u_a',
+      nameA: 'Alice',
+      tokenEmpty: '', // empty value → skipped
+      tokenB: 'tok-b',
+      uidB: 'u_b',
+      nameB: 'Bob',
+    })
+    expect(findStoredSessions(storage)).toEqual([
+      { token: 'tok-a', uid: 'u_a', name: 'Alice' },
+      { token: 'tok-b', uid: 'u_b', name: 'Bob' },
+    ])
+  })
+
+  it('returns the single session when storage holds exactly one', () => {
+    const storage = makeStorage({ tokenabc: 'only', uidabc: 'u_1', nameabc: 'Solo' })
+    expect(findUniqueStoredSession(storage)).toEqual({ token: 'only', uid: 'u_1', name: 'Solo' })
+  })
+
+  it('returns null when MORE THAN ONE session bucket is stored (no first-wins guess)', () => {
+    const storage = makeStorage({
+      tokenA: 'tok-a',
+      uidA: 'u_a',
+      tokenB: 'tok-b',
+      uidB: 'u_b',
+    })
+    // findStoredSession still returns the first (invite semantics), but the unique gate refuses.
+    expect(findStoredSession(storage)).toEqual({ token: 'tok-a', uid: 'u_a', name: '' })
+    expect(findUniqueStoredSession(storage)).toBeNull()
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(findUniqueStoredSession(makeStorage({ currentSpaceId: 's_1' }))).toBeNull()
+  })
+})
+
+describe('adoptStoredSession — persist gating never pins a guessed identity (XIN-392 P1-2)', () => {
+  it('with multiple sessions and persist:true, does NOT adopt or persist any identity', () => {
+    // Two signed-in sessions (two token{sid} buckets, different uids). A standalone deep-link with no
+    // ?sid= must not silently pick the first and pin it into the cross-tab empty-sid slot.
+    const store = new Map<string, string>([
+      ['tokenA', 'tok-a'],
+      ['uidA', 'u_a'],
+      ['nameA', 'Alice'],
+      ['tokenB', 'tok-b'],
+      ['uidB', 'u_b'],
+      ['nameB', 'Bob'],
+    ])
+    const onDeepLink = new FakeLoginInfo(store, '')
+    onDeepLink.load()
+
+    expect(adoptStoredSession(onDeepLink, storageOver(store), { persist: true })).toBe(false)
+    expect(onDeepLink.token).toBe('') // in-memory identity untouched → falls through to login
+    // Nothing pinned into the empty-sid slot, so a Back reload does NOT resurrect a guessed identity.
+    const afterBackReload = new FakeLoginInfo(store, '')
+    afterBackReload.load()
+    expect(afterBackReload.token).toBe('')
+    // The original per-sid buckets are left exactly as they were.
+    expect(store.get('tokenA')).toBe('tok-a')
+    expect(store.get('tokenB')).toBe('tok-b')
+  })
+
+  it('with a single session and persist:true, adopts AND persists (XIN-390 Back-keeps-login)', () => {
+    const store = new Map<string, string>([
+      ['tokenabc', 'octo-session-xyz'],
+      ['uidabc', 'u_42'],
+      ['nameabc', 'Ada'],
+    ])
+    const onDeepLink = new FakeLoginInfo(store, '')
+    onDeepLink.load()
+    expect(adoptStoredSession(onDeepLink, storageOver(store), { persist: true })).toBe(true)
+    const afterBackReload = new FakeLoginInfo(store, '')
+    afterBackReload.load()
+    expect(afterBackReload.token).toBe('octo-session-xyz')
+  })
+})
+
+describe('adoptStoredSession — invite branch keeps its original non-persistent semantics (XIN-392 P1-2)', () => {
+  it('persist:false (default) adopts the first session in memory only and never writes storage', () => {
+    // The invite-landing branch has always adopted the first stored session in memory WITHOUT
+    // persisting. Sharing adoptStoredSession must not change that — the empty-sid slot stays empty.
+    const store = new Map<string, string>([
+      ['tokenabc', 'octo-session-xyz'],
+      ['uidabc', 'u_42'],
+      ['nameabc', 'Ada'],
+    ])
+    const invite = new FakeLoginInfo(store, '')
+    invite.load()
+
+    expect(adoptStoredSession(invite, storageOver(store))).toBe(true)
+    expect(invite.token).toBe('octo-session-xyz') // in-memory recovery for the current tab
+
+    // No save(): the empty-sid slot is never written, so a later no-sid reload is NOT persisted.
+    const afterReload = new FakeLoginInfo(store, '')
+    afterReload.load()
+    expect(afterReload.token).toBe('') // invite never pins the recovered session
+  })
+
+  it('persist:false still recovers the FIRST of several sessions (unchanged multi-session behavior)', () => {
+    const store = new Map<string, string>([
+      ['tokenA', 'tok-a'],
+      ['uidA', 'u_a'],
+      ['tokenB', 'tok-b'],
+      ['uidB', 'u_b'],
+    ])
+    const invite = new FakeLoginInfo(store, '')
+    invite.load()
+    expect(adoptStoredSession(invite, storageOver(store))).toBe(true)
+    expect(invite.token).toBe('tok-a') // first-wins, in memory, exactly as before
+    // …and it is still not persisted.
+    expect(new Map(store).get('token')).toBeUndefined()
   })
 })

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -26,19 +26,23 @@ interface AppLayoutState {
  *
  * Both `/d/:docId` (standalone doc, #512) and `?invite=` links can be opened in a fresh tab where
  * the URL has no `sid`, so the sid-keyed `WKApp.loginInfo.load()` reads nothing even when the user
- * is signed in — their token lives under a `token{sid}` key in localStorage. Adopt the first such
+ * is signed in — their token lives under a `token{sid}` key in localStorage. Adopt the stored
  * session (token + uid + name) so the deep-link's authenticated requests succeed instead of
  * returning 401 for everyone. No-op when a token is already present or none is stored (a genuinely
- * anonymous visitor). The scan itself lives in findStoredSession (pure + unit-tested).
+ * anonymous visitor). The scan itself lives in recoverSession.ts (pure + unit-tested).
+ *
+ * `persist` distinguishes the two callers (XIN-392 P1-2):
+ *   - standalone (`persist: true`): also writes the session back to the current empty-sid bucket so
+ *     the page's Back → /docs full reload stays authenticated (XIN-390). Because that write mirrors
+ *     the identity into the cross-tab localStorage whitelist, adoptStoredSession only persists when
+ *     EXACTLY ONE session is stored — a multi-session user's identity is never guessed-and-pinned.
+ *   - invite (`persist: false`): adopts the first stored session IN MEMORY ONLY and never persists,
+ *     which is the invite branch's original pre-#512 behavior (it must not start persisting just
+ *     because both branches now share this helper).
  */
-function recoverOctoSessionFromStorage(): void {
+function recoverOctoSessionFromStorage(persist: boolean): void {
     if (WKApp.loginInfo.token) return;
-    // Adopt AND persist: adoptStoredSession writes the recovered session back to the current
-    // (empty-sid) bucket via loginInfo.save(), so a later no-sid navigation (e.g. the standalone
-    // page's Back → /docs) reloads an authenticated session instead of bouncing to login. The
-    // scan itself lives in findStoredSession (pure + unit-tested); adoptStoredSession is a no-op
-    // when a token is already present or none is stored (a genuinely anonymous visitor).
-    adoptStoredSession(WKApp.loginInfo, localStorage);
+    adoptStoredSession(WKApp.loginInfo, localStorage, { persist });
 }
 
 export default class AppLayout extends Component<{}, AppLayoutState> {
@@ -315,7 +319,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 WKApp.loginInfo.load();
             }
             if (!WKApp.loginInfo.token) {
-                recoverOctoSessionFromStorage();
+                recoverOctoSessionFromStorage(true);
             }
             if (WKApp.loginInfo.token) {
                 const standaloneDocId = parseStandaloneDocId(window.location.pathname);
@@ -340,9 +344,10 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 WKApp.loginInfo.load();
             }
             // 如果 URL 没有 ?sid= 或 sid 不匹配，从 localStorage 恢复已登录会话
-            // （与 /d/:docId 直达同一套 clean 冷加载恢复逻辑）
+            // （与 /d/:docId 直达同一套 clean 冷加载恢复逻辑，但只在内存恢复、不持久化——
+            //   invite 分支原本就不把恢复出来的 session 写回存储，共用 helper 后仍保持该语义，XIN-392 P1-2）
             if (!WKApp.loginInfo.token) {
-                recoverOctoSessionFromStorage();
+                recoverOctoSessionFromStorage(false);
             }
             return <InviteLanding inviteCode={inviteCode} />;
         }

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -14,7 +14,7 @@ import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
 import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
-import { adoptStoredSession, findSidForToken } from "./recoverSession";
+import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -43,6 +43,31 @@ interface AppLayoutState {
 function recoverOctoSessionFromStorage(persist: boolean): void {
     if (WKApp.loginInfo.token) return;
     adoptStoredSession(WKApp.loginInfo, localStorage, { persist });
+}
+
+/**
+ * The standalone `/d/:docId` page reached a 401 while a token WAS loaded — the current session is
+ * expired (XIN-408). Clear that dead session and reload so the standalone branch below re-evaluates,
+ * finds no token, and falls through to the real login screen. The deep-link target was already
+ * stashed (persistStandaloneReturn) by the page, so the existing post-login bounce returns the user
+ * to the document after sign-in — no new return-path plumbing.
+ *
+ * Why clearing by token VALUE, not just `logout()`: `logout()` clears only the CURRENT `?sid=`
+ * bucket, but on a clean cold-load (no `?sid=`) the expired token was recovered from a `token{sid'}`
+ * bucket and mirrored into the empty-sid bucket, so it lives in two places. Clearing every bucket
+ * that holds this exact token (clearSessionsWithToken over both storages) tears down all copies, so
+ * the reload's recovery can't re-adopt it and loop. A DIFFERENT valid session has a different token
+ * and is left untouched (XIN-390/392: 只清当前过期 session，别误清有效 session).
+ */
+function clearExpiredStandaloneSessionAndReload(): void {
+    const expiredToken = WKApp.loginInfo.token || "";
+    // In-memory + current-sid bucket + cross-tab mirror (the sid-scoped part logout() handles).
+    WKApp.loginInfo.logout();
+    // Value-matched sweep for any remaining copies (the cold-load recover-then-persist case).
+    if (expiredToken && typeof window !== "undefined") {
+        clearSessionsWithToken(expiredToken, window.sessionStorage, window.localStorage);
+    }
+    if (typeof window !== "undefined") window.location.reload();
 }
 
 export default class AppLayout extends Component<{}, AppLayoutState> {
@@ -332,7 +357,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             }
             if (WKApp.loginInfo.token) {
                 const standaloneDocId = parseStandaloneDocId(window.location.pathname);
-                return <StandaloneDocPage docId={standaloneDocId} />;
+                return <StandaloneDocPage docId={standaloneDocId} onSessionExpired={clearExpiredStandaloneSessionAndReload} />;
             }
             // Anonymous: stash the exact /d/:docId target so the post-login flow (local OR SSO/OIDC)
             // can bounce the user back to the document instead of the app root, then fall through to

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -13,8 +13,8 @@ import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
-import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn } from "@octo/docs";
-import { adoptStoredSession } from "./recoverSession";
+import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
+import { adoptStoredSession, findSidForToken } from "./recoverSession";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -93,13 +93,22 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 // IdP returnTo lands back on /login) has a stashed standalone target — bounce them
                 // back to that exact document instead of the app root. consumeStandaloneReturn
                 // clears the key and only returns SAFE same-origin relative paths (open-redirect
-                // guard), so a tampered value can never redirect off-origin. No sid is appended: the
-                // reloaded /d/:docId re-establishes the session via recoverOctoSessionFromStorage
-                // (which now persists into the no-sid bucket), and re-appending could double a sid
-                // already present in the stored target.
+                // guard), so a tampered value can never redirect off-origin.
+                //
+                // Carry the just-authenticated session's own sid on the reload (XIN-398): the
+                // stashed target has no `?sid=`, so the reloaded /d/:docId's sid-keyed load() would
+                // read only the empty-sid bucket and — for a multi-session user — fall through to a
+                // recovery that (XIN-392 P1-2) refuses to guess an identity, bouncing them back to
+                // login in a loop. withReturnSid appends the sid of the bucket that already holds the
+                // current token (findSidForToken — the known identity, never a guess), so the reload
+                // hits the right session directly instead of relying on the now-strict recovery. It
+                // no-ops when the target already carries a sid or the session lives in the empty-sid
+                // bucket (where a no-sid reload already resolves it), and the appended target still
+                // passes the isSafeReturnPath / parseStandaloneDocId gates.
                 const standaloneReturn = consumeStandaloneReturn();
                 if (standaloneReturn) {
-                    window.location.assign(standaloneReturn)
+                    const sessionSid = findSidForToken(localStorage, WKApp.loginInfo.token || "");
+                    window.location.assign(withReturnSid(standaloneReturn, sessionSid))
                     return
                 }
                 if ((window as any).__POWERED_EXTENSION__) {

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -13,6 +13,7 @@ import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
+import { StandaloneDocPage, parseStandaloneDocId } from "@octo/docs";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -258,6 +259,22 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             if (bindComponent) {
                 return bindComponent
             }
+        }
+
+        // Standalone document deep-link (`/d/:docId`, octo-web #512): a shareable full-window
+        // doc view that lives OUTSIDE the app shell (no MainPage / NavRail), mounted with the
+        // same early-return interception the `?invite=` landing uses below. Ensure the session
+        // token is loaded first (this branch renders before the Provider), so the page's
+        // GET /docs/{docId} preflight and the collab-token exchange are authenticated; when the
+        // user has no session the preflight returns 401 and StandaloneDocPage shows the sign-in
+        // terminal (and stashes the return target). SPA deep-link serving depends on the nginx
+        // try_files fallback (deployment concern, out of scope for this frontend change).
+        const standaloneDocId = parseStandaloneDocId(window.location.pathname);
+        if (standaloneDocId) {
+            if (!WKApp.loginInfo.token) {
+                WKApp.loginInfo.load();
+            }
+            return <StandaloneDocPage docId={standaloneDocId} />;
         }
 
         // 邀请链接检测

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -13,11 +13,32 @@ import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
-import { StandaloneDocPage, parseStandaloneDocId } from "@octo/docs";
+import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath } from "@octo/docs";
+import { findStoredSession } from "./recoverSession";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
     joinApproval?: { status: JoinApprovalStatus; inviteCode: string };
+}
+
+/**
+ * Recover an octo session for a clean deep-link that carries no `?sid=` in the URL.
+ *
+ * Both `/d/:docId` (standalone doc, #512) and `?invite=` links can be opened in a fresh tab where
+ * the URL has no `sid`, so the sid-keyed `WKApp.loginInfo.load()` reads nothing even when the user
+ * is signed in — their token lives under a `token{sid}` key in localStorage. Adopt the first such
+ * session (token + uid + name) so the deep-link's authenticated requests succeed instead of
+ * returning 401 for everyone. No-op when a token is already present or none is stored (a genuinely
+ * anonymous visitor). The scan itself lives in findStoredSession (pure + unit-tested).
+ */
+function recoverOctoSessionFromStorage(): void {
+    if (WKApp.loginInfo.token) return;
+    const session = findStoredSession(localStorage);
+    if (session) {
+        WKApp.loginInfo.token = session.token;
+        WKApp.loginInfo.uid = session.uid;
+        WKApp.loginInfo.name = session.name;
+    }
 }
 
 export default class AppLayout extends Component<{}, AppLayoutState> {
@@ -263,18 +284,31 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
 
         // Standalone document deep-link (`/d/:docId`, octo-web #512): a shareable full-window
         // doc view that lives OUTSIDE the app shell (no MainPage / NavRail), mounted with the
-        // same early-return interception the `?invite=` landing uses below. Ensure the session
-        // token is loaded first (this branch renders before the Provider), so the page's
-        // GET /docs/{docId} preflight and the collab-token exchange are authenticated; when the
-        // user has no session the preflight returns 401 and StandaloneDocPage shows the sign-in
-        // terminal (and stashes the return target). SPA deep-link serving depends on the nginx
-        // try_files fallback (deployment concern, out of scope for this frontend change).
-        const standaloneDocId = parseStandaloneDocId(window.location.pathname);
-        if (standaloneDocId) {
+        // same early-return interception the `?invite=` landing uses below. We claim the whole
+        // `/d` namespace (not just well-formed ids) so a malformed/empty id renders the
+        // standalone not-found terminal instead of silently falling through to the shell (AC-9).
+        //
+        // Auth: this branch renders before the Provider, so ensure the octo session is loaded
+        // for the page's GET /docs/{docId} preflight + collab-token exchange. A clean cold-load
+        // in a fresh tab carries no `?sid=`, so load() (sid-keyed) misses even a signed-in user's
+        // token — recover it from localStorage the way the invite branch does (AC-3). When the
+        // visitor is genuinely anonymous, fall through to the login screen rendered IN PLACE: the
+        // pathname stays `/d/:docId`, so onLogin derives basePath from it and bounces the user
+        // straight back to the doc (now with `?sid=`) after sign-in — the deep-link resumes
+        // instead of dead-ending (AC-11). SPA deep-link serving depends on the nginx try_files
+        // fallback (deployment concern, out of scope for this frontend change).
+        if (isStandaloneDocPath(window.location.pathname)) {
             if (!WKApp.loginInfo.token) {
                 WKApp.loginInfo.load();
             }
-            return <StandaloneDocPage docId={standaloneDocId} />;
+            if (!WKApp.loginInfo.token) {
+                recoverOctoSessionFromStorage();
+            }
+            if (WKApp.loginInfo.token) {
+                const standaloneDocId = parseStandaloneDocId(window.location.pathname);
+                return <StandaloneDocPage docId={standaloneDocId} />;
+            }
+            // Anonymous: fall through to the login screen (below) without navigating away.
         }
 
         // 邀请链接检测
@@ -286,22 +320,10 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             if (!WKApp.loginInfo.token) {
                 WKApp.loginInfo.load();
             }
-            // 如果 URL 没有 ?sid= 或 sid 不匹配，尝试从 localStorage 找正确的 token
+            // 如果 URL 没有 ?sid= 或 sid 不匹配，从 localStorage 恢复已登录会话
+            // （与 /d/:docId 直达同一套 clean 冷加载恢复逻辑）
             if (!WKApp.loginInfo.token) {
-                for (let i = 0; i < localStorage.length; i++) {
-                    const key = localStorage.key(i);
-                    if (key && key.startsWith("token") && key !== "token") {
-                        const val = localStorage.getItem(key);
-                        if (val) {
-                            // 直接设置 token 和相关信息，不重定向
-                            const sid = key.substring(5);
-                            WKApp.loginInfo.token = val;
-                            WKApp.loginInfo.uid = localStorage.getItem("uid" + sid) || "";
-                            WKApp.loginInfo.name = localStorage.getItem("name" + sid) || "";
-                            break;
-                        }
-                    }
-                }
+                recoverOctoSessionFromStorage();
             }
             return <InviteLanding inviteCode={inviteCode} />;
         }

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -13,8 +13,8 @@ import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
-import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath } from "@octo/docs";
-import { findStoredSession } from "./recoverSession";
+import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn } from "@octo/docs";
+import { adoptStoredSession } from "./recoverSession";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -33,12 +33,12 @@ interface AppLayoutState {
  */
 function recoverOctoSessionFromStorage(): void {
     if (WKApp.loginInfo.token) return;
-    const session = findStoredSession(localStorage);
-    if (session) {
-        WKApp.loginInfo.token = session.token;
-        WKApp.loginInfo.uid = session.uid;
-        WKApp.loginInfo.name = session.name;
-    }
+    // Adopt AND persist: adoptStoredSession writes the recovered session back to the current
+    // (empty-sid) bucket via loginInfo.save(), so a later no-sid navigation (e.g. the standalone
+    // page's Back → /docs) reloads an authenticated session instead of bouncing to login. The
+    // scan itself lives in findStoredSession (pure + unit-tested); adoptStoredSession is a no-op
+    // when a token is already present or none is stored (a genuinely anonymous visitor).
+    adoptStoredSession(WKApp.loginInfo, localStorage);
 }
 
 export default class AppLayout extends Component<{}, AppLayoutState> {
@@ -85,6 +85,19 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const sidParam = existingSid ? `?sid=${existingSid}` : ""
 
             const goMain = () => {
+                // A user who signed in from a shared /d/:docId link (local OR SSO/OIDC, where the
+                // IdP returnTo lands back on /login) has a stashed standalone target — bounce them
+                // back to that exact document instead of the app root. consumeStandaloneReturn
+                // clears the key and only returns SAFE same-origin relative paths (open-redirect
+                // guard), so a tampered value can never redirect off-origin. No sid is appended: the
+                // reloaded /d/:docId re-establishes the session via recoverOctoSessionFromStorage
+                // (which now persists into the no-sid bucket), and re-appending could double a sid
+                // already present in the stored target.
+                const standaloneReturn = consumeStandaloneReturn();
+                if (standaloneReturn) {
+                    window.location.assign(standaloneReturn)
+                    return
+                }
                 if ((window as any).__POWERED_EXTENSION__) {
                     window.location.reload()
                     return
@@ -308,6 +321,12 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 const standaloneDocId = parseStandaloneDocId(window.location.pathname);
                 return <StandaloneDocPage docId={standaloneDocId} />;
             }
+            // Anonymous: stash the exact /d/:docId target so the post-login flow (local OR SSO/OIDC)
+            // can bounce the user back to the document instead of the app root, then fall through to
+            // the login screen (below) without navigating away. The standalone page itself only
+            // mounts once a token exists, so the anonymous path is the ONLY place this key gets
+            // written for a first-time visitor — onLogin consumes it via consumeStandaloneReturn.
+            persistStandaloneReturn();
             // Anonymous: fall through to the login screen (below) without navigating away.
         }
 

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -29,20 +29,63 @@ export type StorageLike = Pick<Storage, 'length' | 'key' | 'getItem'>
  * unrelated `tokenCallback` config key. Returns the token plus its sibling uid/name so the caller
  * can populate `loginInfo` exactly as a normal load would.
  */
-export function findStoredSession(storage: StorageLike): RecoveredSession | null {
-  for (let i = 0; i < storage.length; i++) {
-    const key = storage.key(i)
+export function findStoredSession(store: StorageLike): RecoveredSession | null {
+  // NB: the parameter is `store`, not `storage`. Under apps/extension's WXT build, a bare
+  // `storage` identifier is auto-imported from `wxt/utils/storage`, which Rolldown then fails to
+  // resolve in this shared web file (`pnpm build` exit 1). Keep the name off that registered token.
+  for (let i = 0; i < store.length; i++) {
+    const key = store.key(i)
     if (key && key.startsWith('token') && key !== 'token' && key !== 'tokenCallback') {
-      const val = storage.getItem(key)
+      const val = store.getItem(key)
       if (val) {
         const sid = key.substring(5) // "token".length === 5
         return {
           token: val,
-          uid: storage.getItem('uid' + sid) || '',
-          name: storage.getItem('name' + sid) || '',
+          uid: store.getItem('uid' + sid) || '',
+          name: store.getItem('name' + sid) || '',
         }
       }
     }
   }
   return null
+}
+
+/**
+ * The subset of `WKApp.loginInfo` the adoption path writes. Kept structural (not the concrete
+ * `LoginInfo` class from `@octo/base`) so this stays a pure, host-free unit.
+ */
+export interface SessionSink {
+  token?: string
+  uid?: string
+  name?: string
+  /** Persist the current fields to storage (sid-keyed, exactly as `LoginInfo.save()` does). */
+  save: () => void
+}
+
+/**
+ * Adopt a stored octo session into `sink` for a clean deep-link cold-load, then PERSIST it.
+ *
+ * Recovery alone (writing the in-memory `token`/`uid`/`name` fields) is not enough: the sid-keyed
+ * bucket the session came from is `token{sid}`, but a clean deep-link (`/d/:docId` with no `?sid=`)
+ * and the `/docs` list it Backs into both read the empty-sid bucket (`token`). So after the user
+ * hits Back, the full-reload `loginInfo.load()` reads the empty-sid slot, finds nothing, and bounces
+ * an already-signed-in user to the login wall. Calling `sink.save()` here writes the adopted session
+ * into the *current* (empty-sid, since the URL has no `?sid=`) bucket, so the subsequent no-sid
+ * navigation reloads an authenticated session instead. Without this save the Back-keeps-login AC
+ * fails; with it, the session survives the reload.
+ *
+ * No-op (returns false) when a token is already loaded or none is stored — a genuinely anonymous
+ * visitor is left untouched to fall through to the login screen.
+ */
+export function adoptStoredSession(sink: SessionSink, store: StorageLike): boolean {
+  if (sink.token) return false
+  const session = findStoredSession(store)
+  if (!session) return false
+  sink.token = session.token
+  sink.uid = session.uid
+  sink.name = session.name
+  // Persist to the current sid bucket so a later same-tab navigation that also lacks `?sid=`
+  // (e.g. Back → /docs) reloads this session rather than an empty one.
+  sink.save()
+  return true
 }

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -1,0 +1,48 @@
+// Clean deep-link session recovery (octo-web #512).
+//
+// Standalone doc links (`/d/:docId`) and invite links (`?invite=`) are routinely opened in a
+// fresh tab whose URL carries no `?sid=`. The app persists each session under a sid-keyed
+// `token{sid}` bucket in localStorage, so the sid-keyed `WKApp.loginInfo.load()` reads nothing on
+// such a cold-load even though the user is signed in — every request then 401s. This mirrors the
+// recovery the invite-landing path has always done: scan localStorage for the first stored
+// session and adopt it, so the deep-link authenticates against the real session instead of
+// bouncing to a sign-in wall (AC-3).
+//
+// Kept as a pure function over a Storage-like object (not reading the WKApp singleton) so the
+// scan logic is unit-testable without a live host.
+
+/** A session recovered from a `token{sid}` bucket. */
+export interface RecoveredSession {
+  token: string
+  uid: string
+  name: string
+}
+
+/** The subset of the Web Storage API the scan needs. */
+export type StorageLike = Pick<Storage, 'length' | 'key' | 'getItem'>
+
+/**
+ * Find the first stored octo session in a Storage-like bag, or null when none is present.
+ *
+ * Session buckets are keyed `token{sid}` (with sibling `uid{sid}` / `name{sid}`). The bare
+ * `token` key is skipped — it is the empty-sid slot `loginInfo.load()` already read — as is the
+ * unrelated `tokenCallback` config key. Returns the token plus its sibling uid/name so the caller
+ * can populate `loginInfo` exactly as a normal load would.
+ */
+export function findStoredSession(storage: StorageLike): RecoveredSession | null {
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i)
+    if (key && key.startsWith('token') && key !== 'token' && key !== 'tokenCallback') {
+      const val = storage.getItem(key)
+      if (val) {
+        const sid = key.substring(5) // "token".length === 5
+        return {
+          token: val,
+          uid: storage.getItem('uid' + sid) || '',
+          name: storage.getItem('name' + sid) || '',
+        }
+      }
+    }
+  }
+  return null
+}

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -64,6 +64,29 @@ export function findStoredSession(store: StorageLike): RecoveredSession | null {
 }
 
 /**
+ * The sid of the stored `token{sid}` bucket whose token equals `token`, or null when none matches.
+ *
+ * Used by the post-login standalone return path to hand the reloaded `/d/:docId` an explicit
+ * `?sid=` that its sid-keyed `load()` will hit directly — instead of leaning on the multi-session
+ * recovery, which now (XIN-392 P1-2) refuses to guess an identity when several sessions are stored
+ * and would otherwise bounce a multi-session user into a login loop. Unlike findUniqueStoredSession
+ * this makes NO guess: it matches the CURRENT authenticated identity by its own token and returns
+ * that session's own sid, so it is safe even with several sessions stored — we carry a known sid,
+ * we never pin an arbitrary one. Returns null when the current session lives only in the empty-sid
+ * (`token`) bucket, where a no-sid reload already reads it and no `?sid=` is needed.
+ */
+export function findSidForToken(store: StorageLike, token: string): string | null {
+  if (!token) return null
+  for (let i = 0; i < store.length; i++) {
+    const key = store.key(i)
+    if (key && key.startsWith('token') && key !== 'token' && key !== 'tokenCallback') {
+      if (store.getItem(key) === token) return key.substring(5) // "token".length === 5
+    }
+  }
+  return null
+}
+
+/**
  * The single UNAMBIGUOUS stored session, or null when storage holds zero or MORE THAN ONE session
  * bucket.
  *

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -22,32 +22,62 @@ export interface RecoveredSession {
 export type StorageLike = Pick<Storage, 'length' | 'key' | 'getItem'>
 
 /**
- * Find the first stored octo session in a Storage-like bag, or null when none is present.
+ * Collect EVERY stored octo session in a Storage-like bag, in iteration order.
  *
- * Session buckets are keyed `token{sid}` (with sibling `uid{sid}` / `name{sid}`). The bare
- * `token` key is skipped — it is the empty-sid slot `loginInfo.load()` already read — as is the
- * unrelated `tokenCallback` config key. Returns the token plus its sibling uid/name so the caller
- * can populate `loginInfo` exactly as a normal load would.
+ * Session buckets are keyed `token{sid}` (with sibling `uid{sid}` / `name{sid}`). The bare `token`
+ * key is skipped — it is the empty-sid slot `loginInfo.load()` already read — as is the unrelated
+ * `tokenCallback` config key, and empty-valued token buckets. Used by both the "first wins" invite
+ * recovery (findStoredSession) and the "exactly one" standalone recovery (findUniqueStoredSession).
  */
-export function findStoredSession(store: StorageLike): RecoveredSession | null {
+export function findStoredSessions(store: StorageLike): RecoveredSession[] {
   // NB: the parameter is `store`, not `storage`. Under apps/extension's WXT build, a bare
   // `storage` identifier is auto-imported from `wxt/utils/storage`, which Rolldown then fails to
   // resolve in this shared web file (`pnpm build` exit 1). Keep the name off that registered token.
+  const sessions: RecoveredSession[] = []
   for (let i = 0; i < store.length; i++) {
     const key = store.key(i)
     if (key && key.startsWith('token') && key !== 'token' && key !== 'tokenCallback') {
       const val = store.getItem(key)
       if (val) {
         const sid = key.substring(5) // "token".length === 5
-        return {
+        sessions.push({
           token: val,
           uid: store.getItem('uid' + sid) || '',
           name: store.getItem('name' + sid) || '',
-        }
+        })
       }
     }
   }
-  return null
+  return sessions
+}
+
+/**
+ * Find the FIRST stored octo session in a Storage-like bag, or null when none is present.
+ *
+ * Returns the token plus its sibling uid/name so the caller can populate `loginInfo` exactly as a
+ * normal load would. "First wins" is the invite-landing branch's original recovery semantics — it
+ * adopts this in memory only (never persisted), so a stale storage-iteration order can at worst make
+ * the current tab authenticate as one of the user's own sessions, never pinned anywhere.
+ */
+export function findStoredSession(store: StorageLike): RecoveredSession | null {
+  return findStoredSessions(store)[0] ?? null
+}
+
+/**
+ * The single UNAMBIGUOUS stored session, or null when storage holds zero or MORE THAN ONE session
+ * bucket.
+ *
+ * This is the gate for the standalone branch, which PERSISTS what it adopts (see adoptStoredSession).
+ * "First wins" is fine for in-memory-only invite recovery, but persisting a first-of-several guess
+ * would pin one arbitrary identity into the cross-tab `token` slot (StorageService mirrors it into
+ * the cross-tab localStorage whitelist) — a multi-session user could be silently bound to, and stuck
+ * across tabs on, the wrong session. Requiring exactly one bucket means we only ever persist when
+ * there is no guess to make; with several, the caller falls through to the login screen instead
+ * (XIN-392 P1-2).
+ */
+export function findUniqueStoredSession(store: StorageLike): RecoveredSession | null {
+  const sessions = findStoredSessions(store)
+  return sessions.length === 1 ? sessions[0] : null
 }
 
 /**
@@ -62,30 +92,57 @@ export interface SessionSink {
   save: () => void
 }
 
+/** Options controlling how a recovered session is adopted. */
+export interface AdoptOptions {
+  /**
+   * Persist the adopted session back to the current (sid-keyed) bucket via `sink.save()`.
+   *
+   * When true (the standalone `/d/:docId` branch): a later no-sid navigation — the standalone page's
+   * Back → /docs full reload — reads the empty-sid slot; persisting into it there keeps an
+   * already-signed-in user logged in across that reload (XIN-390 Back-keeps-login). But `save()` also
+   * mirrors token/uid/name into the cross-tab localStorage whitelist (StorageService), so it is only
+   * safe when the stored session is UNAMBIGUOUS. Persisting therefore requires EXACTLY ONE stored
+   * session (findUniqueStoredSession); with zero or several this is a no-op (returns false) and the
+   * visitor falls through to login rather than having a guessed identity pinned across tabs (XIN-392).
+   *
+   * When false (the DEFAULT — the invite-landing branch): adopt the first stored session IN MEMORY
+   * ONLY and never call `save()`. This is the invite branch's original, pre-#512 recovery behavior;
+   * it must not start persisting just because it now shares this helper.
+   */
+  persist?: boolean
+}
+
 /**
- * Adopt a stored octo session into `sink` for a clean deep-link cold-load, then PERSIST it.
+ * Adopt a stored octo session into `sink` for a clean deep-link cold-load.
  *
- * Recovery alone (writing the in-memory `token`/`uid`/`name` fields) is not enough: the sid-keyed
- * bucket the session came from is `token{sid}`, but a clean deep-link (`/d/:docId` with no `?sid=`)
- * and the `/docs` list it Backs into both read the empty-sid bucket (`token`). So after the user
- * hits Back, the full-reload `loginInfo.load()` reads the empty-sid slot, finds nothing, and bounces
- * an already-signed-in user to the login wall. Calling `sink.save()` here writes the adopted session
- * into the *current* (empty-sid, since the URL has no `?sid=`) bucket, so the subsequent no-sid
- * navigation reloads an authenticated session instead. Without this save the Back-keeps-login AC
- * fails; with it, the session survives the reload.
+ * By default (invite branch) this writes only the in-memory `token`/`uid`/`name` fields, adopting the
+ * FIRST stored session and persisting nothing — the pre-#512 invite semantics. Pass `{ persist: true }`
+ * (standalone branch) to also `sink.save()` the adopted session so a subsequent no-sid reload stays
+ * authenticated (XIN-390) — but persistence only happens when EXACTLY ONE session is stored, so a
+ * multi-session user's identity is never guessed-and-pinned across tabs (XIN-392).
  *
- * No-op (returns false) when a token is already loaded or none is stored — a genuinely anonymous
- * visitor is left untouched to fall through to the login screen.
+ * No-op (returns false) when a token is already loaded, when none is stored, or when persistence is
+ * requested but the stored session is ambiguous — a genuinely anonymous (or ambiguous) visitor is
+ * left untouched to fall through to the login screen.
  */
-export function adoptStoredSession(sink: SessionSink, store: StorageLike): boolean {
+export function adoptStoredSession(
+  sink: SessionSink,
+  store: StorageLike,
+  options: AdoptOptions = {},
+): boolean {
   if (sink.token) return false
-  const session = findStoredSession(store)
+  const { persist = false } = options
+  // Persisting demands an unambiguous session (never pin a guess cross-tab); in-memory-only
+  // recovery keeps the original "first wins" behavior.
+  const session = persist ? findUniqueStoredSession(store) : findStoredSession(store)
   if (!session) return false
   sink.token = session.token
   sink.uid = session.uid
   sink.name = session.name
-  // Persist to the current sid bucket so a later same-tab navigation that also lacks `?sid=`
-  // (e.g. Back → /docs) reloads this session rather than an empty one.
-  sink.save()
+  if (persist) {
+    // Persist to the current sid bucket so a later same-tab navigation that also lacks `?sid=`
+    // (e.g. Back → /docs) reloads this session rather than an empty one.
+    sink.save()
+  }
   return true
 }

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -21,6 +21,30 @@ export interface RecoveredSession {
 /** The subset of the Web Storage API the scan needs. */
 export type StorageLike = Pick<Storage, 'length' | 'key' | 'getItem'>
 
+/** A Storage-like bag that also supports removal (for clearing an expired session). */
+export type WritableStorageLike = StorageLike & Pick<Storage, 'removeItem'>
+
+/**
+ * Session key prefixes a single login bucket occupies, keyed `<prefix><sid>`. This is the union of
+ * the cross-tab whitelist StorageService mirrors into localStorage and the extra keys
+ * `LoginInfo.logout()` clears, so removing all of them for a given sid tears down the whole bucket —
+ * exactly the set logout() would clear, but for a sid we name explicitly rather than the URL's.
+ */
+const SESSION_KEY_PREFIXES = [
+  'token',
+  'uid',
+  'short_no',
+  'app_id',
+  'name',
+  'role',
+  'is_work',
+  'sex',
+  'login_provider',
+  'realname_verified',
+  'real_name',
+  'realname_verified_at',
+] as const
+
 /**
  * Collect EVERY stored octo session in a Storage-like bag, in iteration order.
  *
@@ -168,4 +192,52 @@ export function adoptStoredSession(
     sink.save()
   }
   return true
+}
+
+/**
+ * The sids of every stored bucket whose `token{sid}` value equals `token`. The bare `token` bucket
+ * (empty sid) is reported as ''. Matching by VALUE, not by sid, is the whole point: it names ONLY
+ * the session that carries this exact token, so a caller clearing an expired session never touches a
+ * DIFFERENT, still-valid session (whose token differs). `tokenCallback` (a config key) is never
+ * treated as a session bucket, and an empty `token` argument matches nothing.
+ *
+ * Used by clearSessionsWithToken to tear down an expired standalone session across BOTH the empty-sid
+ * bucket and any sid-keyed bucket that holds the same dead token (the cold-load recover-then-persist
+ * case mirrors it into two places), so a post-clear reload's recovery can't resurrect it (XIN-408).
+ */
+export function sidsForToken(store: StorageLike, token: string): string[] {
+  const sids: string[] = []
+  if (!token) return sids
+  for (let i = 0; i < store.length; i++) {
+    const key = store.key(i)
+    if (key && key.startsWith('token') && key !== 'tokenCallback' && store.getItem(key) === token) {
+      sids.push(key === 'token' ? '' : key.substring(5)) // "token".length === 5
+    }
+  }
+  return sids
+}
+
+/**
+ * Remove every stored session whose token value equals `token` from the given store(s), clearing all
+ * of that bucket's sid-keyed sibling keys (uid/name/…). Pass BOTH sessionStorage and localStorage so
+ * the cross-tab mirror StorageService writes is fully torn down — otherwise a reload's
+ * StorageService-backed `load()` (sessionStorage first, then localStorage) or the localStorage
+ * recovery scan could still find the dead session and re-adopt it, looping the user back to the
+ * expired terminal (XIN-408).
+ *
+ * Because buckets are matched by the (expired) token's VALUE, a different valid session — different
+ * token — is never cleared. This is the "只清当前过期 session，别误清有效 session" guarantee. No-op for
+ * an empty token.
+ */
+export function clearSessionsWithToken(token: string, ...stores: WritableStorageLike[]): void {
+  if (!token) return
+  const sids = new Set<string>()
+  for (const store of stores) {
+    for (const sid of sidsForToken(store, token)) sids.add(sid)
+  }
+  for (const store of stores) {
+    for (const sid of sids) {
+      for (const prefix of SESSION_KEY_PREFIXES) store.removeItem(prefix + sid)
+    }
+  }
 }

--- a/apps/web/src/__tests__/docsOn.test.ts
+++ b/apps/web/src/__tests__/docsOn.test.ts
@@ -26,9 +26,11 @@ describe("docs_on appconfig web integration", () => {
   it("wires docsOn into WKRemoteConfig from appconfig, defaulting to false", () => {
     const source = readRepoFile("packages/dmworkbase/src/App.tsx");
 
-    // Fail-safe default: hidden until docs-backend is deployed and ops flips docs_on.
+    // Fail-safe default on the field; on appconfig, fall back to true when the backend
+    // omits docs_on (temp for test env until backend docs_on lands).
     expect(source).toContain("docsOn: boolean = false");
-    expect(source).toContain('this.docsOn = parseRemoteBool(result["docs_on"])');
+    expect(source).toContain('result["docs_on"] === undefined');
+    expect(source).toContain('parseRemoteBool(result["docs_on"])');
     // docsOn must participate in change detection so the NavRail refreshes on toggle.
     expect(source).toContain("previousDocsOn");
     expect(source).toContain("previousDocsOn !== this.docsOn");

--- a/apps/web/src/__tests__/docsOn.test.ts
+++ b/apps/web/src/__tests__/docsOn.test.ts
@@ -26,11 +26,9 @@ describe("docs_on appconfig web integration", () => {
   it("wires docsOn into WKRemoteConfig from appconfig, defaulting to false", () => {
     const source = readRepoFile("packages/dmworkbase/src/App.tsx");
 
-    // Fail-safe default on the field; on appconfig, fall back to true when the backend
-    // omits docs_on (temp for test env until backend docs_on lands).
+    // Fail-safe default: hidden until docs-backend is deployed and ops flips docs_on.
     expect(source).toContain("docsOn: boolean = false");
-    expect(source).toContain('result["docs_on"] === undefined');
-    expect(source).toContain('parseRemoteBool(result["docs_on"])');
+    expect(source).toContain('this.docsOn = parseRemoteBool(result["docs_on"])');
     // docsOn must participate in change detection so the NavRail refreshes on toggle.
     expect(source).toContain("previousDocsOn");
     expect(source).toContain("previousDocsOn !== this.docsOn");

--- a/apps/web/src/__tests__/layoutPendingInviteToast.test.ts
+++ b/apps/web/src/__tests__/layoutPendingInviteToast.test.ts
@@ -26,7 +26,7 @@ describe('Layout.onLogin — pendingInviteCode path shares joinSuccessNotice', (
 
     it('imports computeAndSaveJoinSuccess from @octo/base', () => {
         expect(layout).toMatch(/computeAndSaveJoinSuccess/);
-        expect(layout).toMatch(/from\s+["']@dmwork\/base["']/);
+        expect(layout).toMatch(/from\s+["']@octo\/base["']/);
     });
 
     it('snapshots prevCurrentSpaceId before calling /space/join', () => {

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -27,12 +27,13 @@ describe('Layout — standalone /d/:docId clean cold-load path', () => {
   })
 
   it('recovers a stored session before rendering so a clean cold-load authenticates (AC-3)', () => {
-    expect(layout).toMatch(/recoverOctoSessionFromStorage\(\)/)
+    // Standalone persists the recovered session (Back-keeps-login), so it passes persist:true.
+    expect(layout).toMatch(/recoverOctoSessionFromStorage\(true\)/)
     // Inside the namespace branch, recovery must run before the page renders. Search from the
     // branch start so the helper's top-of-file definition doesn't skew the ordering.
     const nsIdx = layout.search(/isStandaloneDocPath\(\s*window\.location\.pathname\s*\)/)
     expect(nsIdx).toBeGreaterThan(0)
-    const recoverIdx = layout.indexOf('recoverOctoSessionFromStorage()', nsIdx)
+    const recoverIdx = layout.indexOf('recoverOctoSessionFromStorage(true)', nsIdx)
     const renderIdx = layout.indexOf('<StandaloneDocPage', nsIdx)
     expect(recoverIdx).toBeGreaterThan(nsIdx)
     expect(renderIdx).toBeGreaterThan(recoverIdx)
@@ -49,6 +50,9 @@ describe('Layout — standalone /d/:docId clean cold-load path', () => {
     // Both deep-link branches now call the shared helper; the old inline localStorage loop in the
     // invite branch must be gone.
     expect(layout).not.toMatch(/for\s*\(\s*let\s+i\s*=\s*0;\s*i\s*<\s*localStorage\.length/)
-    expect(layout.match(/recoverOctoSessionFromStorage\(\)/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(layout.match(/recoverOctoSessionFromStorage\(/g)?.length).toBeGreaterThanOrEqual(2)
+    // XIN-392 P1-2: the invite branch recovers in memory only (persist:false), so it keeps its
+    // original non-persistent semantics rather than pinning a session cross-tab like standalone.
+    expect(layout).toMatch(/recoverOctoSessionFromStorage\(false\)/)
   })
 })

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -1,0 +1,54 @@
+/**
+ * octo-web #512 — clean cold-load main path for the standalone doc page (`/d/:docId`).
+ *
+ * The tester's real-machine run (XIN-293) failed 6 ACs that all traced to the clean/direct
+ * cold-load path never being self-sufficient: it only worked via the in-app sid route. These
+ * guards lock the Layout wiring that makes the clean path stand on its own, following the
+ * source-grep convention the Layout already uses (layoutPendingInviteToast.test.ts) since the
+ * component pulls in Tauri / MainPage and can't be cheaply rendered in jsdom. Behavioral coverage
+ * of the pieces lives in recoverSession.test.ts (recovery scan), the @octo/docs unit tests
+ * (namespace + not-found), and the standalone-doc Playwright e2e (real browser cold-load).
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+describe('Layout — standalone /d/:docId clean cold-load path', () => {
+  let layout: string
+
+  beforeAll(() => {
+    layout = fs.readFileSync(path.join(__dirname, '../Layout/index.tsx'), 'utf-8')
+  })
+
+  it('claims the whole /d namespace so malformed ids are intercepted, not shelled (AC-9)', () => {
+    expect(layout).toMatch(/isStandaloneDocPath\(\s*window\.location\.pathname\s*\)/)
+    // The old guard keyed off a well-formed id only (`if (standaloneDocId)`); ensure we no longer
+    // gate the interception on a truthy parsed id.
+    expect(layout).not.toMatch(/if\s*\(\s*standaloneDocId\s*\)/)
+  })
+
+  it('recovers a stored session before rendering so a clean cold-load authenticates (AC-3)', () => {
+    expect(layout).toMatch(/recoverOctoSessionFromStorage\(\)/)
+    // Inside the namespace branch, recovery must run before the page renders. Search from the
+    // branch start so the helper's top-of-file definition doesn't skew the ordering.
+    const nsIdx = layout.search(/isStandaloneDocPath\(\s*window\.location\.pathname\s*\)/)
+    expect(nsIdx).toBeGreaterThan(0)
+    const recoverIdx = layout.indexOf('recoverOctoSessionFromStorage()', nsIdx)
+    const renderIdx = layout.indexOf('<StandaloneDocPage', nsIdx)
+    expect(recoverIdx).toBeGreaterThan(nsIdx)
+    expect(renderIdx).toBeGreaterThan(recoverIdx)
+  })
+
+  it('renders the standalone page only when a token is present (else falls through to login, AC-11)', () => {
+    // The page is returned inside `if (WKApp.loginInfo.token)`; an anonymous visitor falls through
+    // to the Provider/login branch rendered in place (pathname stays /d/:docId → onLogin bounces
+    // back after sign-in).
+    expect(layout).toMatch(/if\s*\(\s*WKApp\.loginInfo\.token\s*\)\s*\{[\s\S]*?<StandaloneDocPage/)
+  })
+
+  it('shares the same recovery with the invite-landing branch (no duplicated scan loop)', () => {
+    // Both deep-link branches now call the shared helper; the old inline localStorage loop in the
+    // invite branch must be gone.
+    expect(layout).not.toMatch(/for\s*\(\s*let\s+i\s*=\s*0;\s*i\s*<\s*localStorage\.length/)
+    expect(layout.match(/recoverOctoSessionFromStorage\(\)/g)?.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -55,4 +55,19 @@ describe('Layout — standalone /d/:docId clean cold-load path', () => {
     // original non-persistent semantics rather than pinning a session cross-tab like standalone.
     expect(layout).toMatch(/recoverOctoSessionFromStorage\(false\)/)
   })
+
+  it('hands an expired-session 401 back to a clear-and-reload handler, not the dead terminal (XIN-408)', () => {
+    // The page mounts only with a token present, so a preflight 401 means the loaded session is
+    // expired. Layout wires onSessionExpired so the page can delegate the dead-end fix (clear the
+    // stale session + reload → falls through to the login screen) instead of rendering a terminal
+    // with no way to re-authenticate.
+    expect(layout).toMatch(/<StandaloneDocPage[\s\S]*?onSessionExpired=\{clearExpiredStandaloneSessionAndReload\}/)
+    // The handler clears the CURRENT session (logout) AND sweeps every bucket holding the expired
+    // token by value (clearSessionsWithToken), so the cold-load recover-then-persist copy can't be
+    // re-recovered into a loop — while a different valid session (different token) is left intact.
+    expect(layout).toMatch(/function\s+clearExpiredStandaloneSessionAndReload/)
+    expect(layout).toMatch(/WKApp\.loginInfo\.logout\(\)/)
+    expect(layout).toMatch(/clearSessionsWithToken\(/)
+    expect(layout).toMatch(/window\.location\.reload\(\)/)
+  })
 })

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -352,7 +352,11 @@ export class WKRemoteConfig {
       this.stickerCustomEnabled = parseRemoteBool(
         result["sticker_custom_enabled"]
       );
-      this.docsOn = parseRemoteBool(result["docs_on"]);
+      // temp: default docsOn=true for test env until backend docs_on lands
+      this.docsOn =
+        result["docs_on"] === undefined
+          ? true
+          : parseRemoteBool(result["docs_on"]);
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -352,11 +352,7 @@ export class WKRemoteConfig {
       this.stickerCustomEnabled = parseRemoteBool(
         result["sticker_custom_enabled"]
       );
-      // temp: default docsOn=true for test env until backend docs_on lands
-      this.docsOn =
-        result["docs_on"] === undefined
-          ? true
-          : parseRemoteBool(result["docs_on"]);
+      this.docsOn = parseRemoteBool(result["docs_on"]);
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -89,7 +89,11 @@ export default class APIClient {
             // 统一注入 X-Space-Id header（GH Mininglamp-OSS/octo-web#1038）。
             // 仅当回调返回非空字符串时写入，避免把 "" 作为合法 space_id 传给后端。
             // 与 URL query 里的 space_id= 拼接共存，后端按优先级双读，前端渐进迁移。
-            if (self.config.spaceIdCallback) {
+            // 合并策略：per-request 显式头优先。若调用方已通过 config.headers 显式带上
+            // X-Space-Id（如 standalone /d/:docId 冷启动 preflight），拦截器不覆盖它；
+            // 仅在显式头缺省时用 currentSpaceId 兜底注入。这样显式头与拦截器头永远一致
+            // （显式为准/拦截器兜底），不会互相冲突。
+            if (self.config.spaceIdCallback && !config.headers!["X-Space-Id"]) {
                 const spaceId = self.config.spaceIdCallback()
                 if (spaceId && spaceId !== "") {
                     config.headers!["X-Space-Id"] = spaceId;
@@ -124,22 +128,27 @@ export default class APIClient {
 
      get<T>(path: string, config?: RequestConfig) {
        return this.wrapResult<T>(axios.get(path, {
-        params: config?.param
+        params: config?.param,
+        headers: config?.headers,
     }), config)
     }
     post(path: string, data?: any, config?: RequestConfig) {
-        return this.wrapResult(axios.post(path, data, {}), config)
+        return this.wrapResult(axios.post(path, data, {
+            headers: config?.headers,
+        }), config)
     }
 
     put(path: string, data?: any, config?: RequestConfig) {
         return this.wrapResult(axios.put(path, data, {
             params: config?.param,
+            headers: config?.headers,
         }), config)
     }
 
     patch(path: string, data?: any, config?: RequestConfig) {
         return this.wrapResult(axios.patch(path, data, {
             params: config?.param,
+            headers: config?.headers,
         }), config)
     }
 
@@ -147,6 +156,7 @@ export default class APIClient {
         return this.wrapResult(axios.delete(path, {
             params: config?.param,
             data: config?.data,
+            headers: config?.headers,
         }), config)
     }
 
@@ -185,6 +195,13 @@ export class RequestConfig {
     param?: any
     data?:any
     resp?: () => APIResp
+    /**
+     * 逐请求显式 HTTP 头，转发给 axios 并由其合并进最终请求头。用于让 per-request 头
+     * （如 standalone /d/:docId preflight 的 X-Space-Id）真正上 wire。合并策略见
+     * initAxios 的请求拦截器：显式头优先，拦截器仅在对应头缺省时兜底注入。不传则完全
+     * 保持既有无显式头行为。
+     */
+    headers?: Record<string, string>
 }
 
 export interface APIResp {

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Real header-forwarding path for APIClient (XIN-424).
+//
+// Regression guard for the "explicit X-Space-Id was dead code" bug: the standalone /d/:docId
+// preflight passes an explicit `X-Space-Id` header via config.headers, but APIClient.get/post/
+// put/delete used to forward only params/baseURL to axios and silently drop config.headers, so
+// the header never reached the wire (the seam-level MockApiClient recorded the config and looked
+// green while production dropped it). These tests mock the axios module and assert the header
+// really lands in the axios call, plus that the request interceptor's merge lets an explicit
+// per-request X-Space-Id win over the interceptor's currentSpaceId fallback.
+
+const { getMock, postMock, putMock, patchMock, deleteMock, holder } = vi.hoisted(() => ({
+  getMock: vi.fn(() => Promise.resolve({ data: {} })),
+  postMock: vi.fn(() => Promise.resolve({ data: {} })),
+  putMock: vi.fn(() => Promise.resolve({ data: {} })),
+  patchMock: vi.fn(() => Promise.resolve({ data: {} })),
+  deleteMock: vi.fn(() => Promise.resolve({ data: {} })),
+  holder: { requestInterceptor: null as null | ((config: any) => any) },
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    defaults: {} as Record<string, unknown>,
+    interceptors: {
+      request: {
+        use: vi.fn((fn: (config: any) => any) => {
+          holder.requestInterceptor = fn;
+        }),
+      },
+      response: { use: vi.fn() },
+    },
+    get: getMock,
+    post: postMock,
+    put: putMock,
+    patch: patchMock,
+    delete: deleteMock,
+  },
+}));
+
+import APIClient from "../APIClient";
+
+const client = APIClient.shared;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  client.config.spaceIdCallback = undefined;
+  client.config.tokenCallback = undefined;
+});
+
+describe("APIClient forwards config.headers to axios (explicit X-Space-Id reaches the wire)", () => {
+  it("get() forwards config.headers", async () => {
+    await client.get("/docs/d1", { headers: { "X-Space-Id": "sp1" } });
+    expect(getMock).toHaveBeenCalledWith(
+      "/docs/d1",
+      expect.objectContaining({ headers: { "X-Space-Id": "sp1" } }),
+    );
+  });
+
+  it("post() forwards config.headers", async () => {
+    await client.post("/docs", { title: "t" }, { headers: { "X-Space-Id": "sp2" } });
+    expect(postMock).toHaveBeenCalledWith(
+      "/docs",
+      { title: "t" },
+      expect.objectContaining({ headers: { "X-Space-Id": "sp2" } }),
+    );
+  });
+
+  it("put() forwards config.headers", async () => {
+    await client.put("/docs/d1", { title: "t" }, { headers: { "X-Space-Id": "sp3" } });
+    expect(putMock).toHaveBeenCalledWith(
+      "/docs/d1",
+      { title: "t" },
+      expect.objectContaining({ headers: { "X-Space-Id": "sp3" } }),
+    );
+  });
+
+  it("patch() forwards config.headers", async () => {
+    await client.patch("/docs/d1", { title: "t" }, { headers: { "X-Space-Id": "sp4" } });
+    expect(patchMock).toHaveBeenCalledWith(
+      "/docs/d1",
+      { title: "t" },
+      expect.objectContaining({ headers: { "X-Space-Id": "sp4" } }),
+    );
+  });
+
+  it("delete() forwards config.headers", async () => {
+    await client.delete("/docs/d1", { headers: { "X-Space-Id": "sp5" } });
+    expect(deleteMock).toHaveBeenCalledWith(
+      "/docs/d1",
+      expect.objectContaining({ headers: { "X-Space-Id": "sp5" } }),
+    );
+  });
+
+  it("omits headers (undefined) when the caller passes none — unchanged behavior", async () => {
+    await client.get("/docs/d1", { param: { a: 1 } });
+    const [, cfg] = getMock.mock.calls.at(-1)!;
+    expect((cfg as { headers?: unknown }).headers).toBeUndefined();
+    expect((cfg as { params?: unknown }).params).toEqual({ a: 1 });
+  });
+});
+
+describe("request interceptor X-Space-Id merge (explicit header wins, interceptor is fallback)", () => {
+  it("does NOT overwrite an explicit per-request X-Space-Id with the interceptor's space", () => {
+    client.config.spaceIdCallback = () => "interceptor-space";
+    const out = holder.requestInterceptor!({ headers: { "X-Space-Id": "explicit-space" } });
+    expect(out.headers["X-Space-Id"]).toBe("explicit-space");
+  });
+
+  it("injects the interceptor's space when no explicit header is present (unchanged fallback)", () => {
+    client.config.spaceIdCallback = () => "interceptor-space";
+    const out = holder.requestInterceptor!({ headers: {} });
+    expect(out.headers["X-Space-Id"]).toBe("interceptor-space");
+  });
+
+  it("injects nothing when the interceptor space is empty (cold standalone deep link)", () => {
+    client.config.spaceIdCallback = () => "";
+    const out = holder.requestInterceptor!({ headers: {} });
+    expect(out.headers["X-Space-Id"]).toBeUndefined();
+  });
+});

--- a/packages/docs/src/collab/useCollabEditor.test.ts
+++ b/packages/docs/src/collab/useCollabEditor.test.ts
@@ -18,6 +18,11 @@ describe('terminalForCreateError — collab-token failure -> terminal state', ()
   it('maps 423 to locked', () => {
     expect(terminalForCreateError({ response: { status: 423 } })).toBe('locked')
   })
+  it('maps 409 to locked (archived — the standalone GET preflight signal, #512 AC-12)', () => {
+    // The per-doc GET preflight returns 409 for an archived doc; the collab-token path never
+    // reports archived, so 409 must resolve to the same 'locked' terminal screen as 423.
+    expect(terminalForCreateError({ response: { status: 409 } })).toBe('locked')
+  })
   it('falls back to not-found for network/unknown errors', () => {
     expect(terminalForCreateError(new Error('Network Error'))).toBe('not-found')
     expect(terminalForCreateError(undefined)).toBe('not-found')

--- a/packages/docs/src/collab/useCollabEditor.ts
+++ b/packages/docs/src/collab/useCollabEditor.ts
@@ -22,8 +22,11 @@ const registry = new Map<string, RegistryEntry>()
  * Map a collab-token issuance failure (the awaited step in CollabEditor.create) to a terminal
  * state, so a failed editor bootstrap shows a clear reason instead of an infinite
  * "Loading document…" spinner. Unknown/networkless errors fall back to 'not-found'.
+ *
+ * Never returns 'none' (every branch is a concrete terminal reason), so the return type excludes
+ * it — callers such as the standalone page can feed the result straight into the terminal screen.
  */
-export function terminalForCreateError(err: unknown): TerminalState['kind'] {
+export function terminalForCreateError(err: unknown): Exclude<TerminalState['kind'], 'none'> {
   const status = (err as { response?: { status?: number } })?.response?.status
   switch (status) {
     case 403:
@@ -32,6 +35,12 @@ export function terminalForCreateError(err: unknown): TerminalState['kind'] {
       return 'not-found'
     case 401:
       return 'login'
+    // 423 Locked and 409 Conflict both mean the document is not editable right now: 423 is the
+    // WebSocket/collab-token lock signal, 409 is the archived signal surfaced by the per-doc GET
+    // preflight (backend returns 409 for an archived doc; the collab-token path never reports it).
+    // Both map to the same terminal 'locked' screen so the standalone page can flag an archived
+    // doc without a WS round-trip.
+    case 409:
     case 423:
       return 'locked'
     default:

--- a/packages/docs/src/editor/DocMoreMenu.test.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.test.tsx
@@ -51,6 +51,25 @@ describe('DocMoreMenu', () => {
     expect(screen.queryByText('Delete document')).toBeNull()
   })
 
+  it('renders neutral rows top-to-bottom in the given order (first item is the first row)', () => {
+    // Locks the ordering the standalone page relies on: a lead row (e.g. Copy link) prepended by
+    // the host lands as the FIRST menu row (AC-2).
+    render(
+      <DocMoreMenu
+        creatorName="Alice"
+        items={[
+          { key: 'copy-link', label: 'Copy link', icon: null, onClick: vi.fn() },
+          ...items,
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    const labels = Array.from(document.querySelectorAll('.octo-doc-more-label')).map(
+      (n) => n.textContent,
+    )
+    expect(labels).toEqual(['Copy link', 'Open in new page', 'Version history'])
+  })
+
   it('closes on an outside pointer-down', () => {
     render(
       <div>

--- a/packages/docs/src/editor/DocMoreMenu.test.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { DocMoreMenu, formatCreatedDate, type DocMoreMenuItem } from './DocMoreMenu.tsx'
+
+afterEach(cleanup)
+
+describe('formatCreatedDate', () => {
+  it('slices an ISO-8601 timestamp lexically (no timezone drift)', () => {
+    expect(formatCreatedDate('2026-07-02T23:59:00Z')).toBe('2026-07-02')
+    expect(formatCreatedDate('2026-01-05')).toBe('2026-01-05')
+  })
+  it('returns null for missing / unparseable input', () => {
+    expect(formatCreatedDate(undefined)).toBeNull()
+    expect(formatCreatedDate('')).toBeNull()
+    expect(formatCreatedDate('not-a-date')).toBeNull()
+  })
+})
+
+describe('DocMoreMenu', () => {
+  const items: DocMoreMenuItem[] = [
+    { key: 'a', label: 'Open in new page', icon: null, onClick: vi.fn() },
+    { key: 'b', label: 'Version history', icon: null, onClick: vi.fn() },
+  ]
+
+  it('is closed by default and toggles open on the ≡ trigger', () => {
+    render(<DocMoreMenu creatorName="Alice" createdAt="2026-07-02T10:00:00Z" items={items} />)
+    expect(screen.queryByText('Version history')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    expect(screen.getByText('Version history')).toBeTruthy()
+    // Head shows creator + created-on line.
+    expect(screen.getByText('Alice')).toBeTruthy()
+    expect(screen.getByText(/2026-07-02/)).toBeTruthy()
+  })
+
+  it('renders the danger item with the is-danger class and fires its handler', () => {
+    const onDelete = vi.fn()
+    const danger: DocMoreMenuItem = {
+      key: 'del',
+      label: 'Delete document',
+      icon: null,
+      danger: true,
+      onClick: onDelete,
+    }
+    render(<DocMoreMenu creatorName="Bob" items={items} dangerItem={danger} />)
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    const row = screen.getByText('Delete document').closest('button')!
+    expect(row.className).toContain('is-danger')
+    fireEvent.click(row)
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    // Selecting an item closes the menu.
+    expect(screen.queryByText('Delete document')).toBeNull()
+  })
+
+  it('closes on an outside pointer-down', () => {
+    render(
+      <div>
+        <span data-testid="outside">outside</span>
+        <DocMoreMenu creatorName="Bob" items={items} />
+      </div>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    expect(screen.getByText('Version history')).toBeTruthy()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByText('Version history')).toBeNull()
+  })
+
+  it('drops the created-on row when the timestamp is absent', () => {
+    render(<DocMoreMenu creatorName="Bob" items={items} />)
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    expect(screen.queryByText(/docs\.moreMenu\.createdPrefix/)).toBeNull()
+  })
+})

--- a/packages/docs/src/editor/DocMoreMenu.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { t } from '../octoweb/index.ts'
+
+/**
+ * A single row in the header "more" (≡) dropdown. `danger` paints the row red (delete);
+ * `disabled` greys it and blocks the click (e.g. export while a previous export is in flight).
+ */
+export interface DocMoreMenuItem {
+  key: string
+  label: string
+  icon: ReactNode
+  onClick: () => void
+  danger?: boolean
+  disabled?: boolean
+}
+
+export interface DocMoreMenuProps {
+  /** Resolved creator display name. The parent handles the resolution + fallback (short uid). */
+  creatorName: string
+  /** Creation timestamp (RFC3339). Rendered as "Created on YYYY-MM-DD"; omitted when absent/invalid. */
+  createdAt?: string
+  /** Neutral action rows, rendered top-to-bottom in the given order. */
+  items: DocMoreMenuItem[]
+  /**
+   * The destructive row (delete). Rendered LAST, below a dedicated separator + extra spacing so it
+   * sits apart from the neutral actions and is hard to mis-click. Omitted when the viewer can't delete.
+   */
+  dangerItem?: DocMoreMenuItem
+}
+
+/**
+ * Format an RFC3339 / ISO-8601 timestamp as `YYYY-MM-DD`. A leading `YYYY-MM-DD` is sliced
+ * lexically so the displayed calendar date matches the stored date exactly — no timezone drift
+ * from `Date` parsing. Anything else falls back to a parsed local date; unparseable input yields
+ * null so the caller drops the row instead of showing "Invalid Date".
+ */
+export function formatCreatedDate(raw?: string): string | null {
+  if (!raw) return null
+  const iso = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw)
+  if (iso) return `${iso[1]}-${iso[2]}-${iso[3]}`
+  const d = new Date(raw)
+  if (Number.isNaN(d.getTime())) return null
+  const y = d.getFullYear()
+  const mo = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${mo}-${da}`
+}
+
+/** First visible character of the creator name, uppercased, for the fallback avatar bubble. */
+function avatarInitial(name: string): string {
+  const c = name.trim().charAt(0)
+  return c ? c.toUpperCase() : '?'
+}
+
+/** ≡ trigger glyph — three horizontal lines, 20×20, 1.5 stroke (Jeff's spec). */
+function HamburgerIcon() {
+  return (
+    <svg className="octo-doc-more-glyph" viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+      <path d="M4 6h12M4 10h12M4 14h12" />
+    </svg>
+  )
+}
+
+/** Base 20×20 line-icon wrapper for the menu rows (stroke inherits currentColor). */
+function RowIcon({ children }: { children: ReactNode }) {
+  return (
+    <svg className="octo-doc-more-rowicon" viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+      {children}
+    </svg>
+  )
+}
+
+/** ↗ open in a new page. */
+export const OpenNewPageIcon = (
+  <RowIcon>
+    <path d="M8 4H5.5A1.5 1.5 0 0 0 4 5.5v9A1.5 1.5 0 0 0 5.5 16h9a1.5 1.5 0 0 0 1.5-1.5V12" />
+    <path d="M11 4h5v5M16 4l-7 7" />
+  </RowIcon>
+)
+
+/** 🕐 version history (clock). */
+export const HistoryIcon = (
+  <RowIcon>
+    <circle cx="10" cy="10" r="6.5" />
+    <path d="M10 6.5V10l2.5 1.5" />
+  </RowIcon>
+)
+
+/** ⬇ export / download. */
+export const ExportIcon = (
+  <RowIcon>
+    <path d="M10 3.5v9M6.5 9l3.5 3.5L13.5 9" />
+    <path d="M4.5 15.5h11" />
+  </RowIcon>
+)
+
+/** 🗑 delete (trash). */
+export const DeleteIcon = (
+  <RowIcon>
+    <path d="M4.5 6h11M8 6V4.5h4V6M6 6l.7 9.5A1 1 0 0 0 7.7 16.5h4.6a1 1 0 0 0 1-.99L14 6" />
+    <path d="M8.5 8.5v5M11.5 8.5v5" />
+  </RowIcon>
+)
+
+function MenuRow({ item, onSelect }: { item: DocMoreMenuItem; onSelect: () => void }) {
+  return (
+    <li role="none">
+      <button
+        type="button"
+        role="menuitem"
+        className={item.danger ? 'octo-doc-more-item is-danger' : 'octo-doc-more-item'}
+        disabled={item.disabled}
+        onClick={() => {
+          onSelect()
+          item.onClick()
+        }}
+      >
+        <span className="octo-doc-more-icon">{item.icon}</span>
+        <span className="octo-doc-more-label">{item.label}</span>
+      </button>
+    </li>
+  )
+}
+
+/**
+ * Header "more" (≡) dropdown for the document editor. Collapses the low-frequency title-bar
+ * actions (open in new page / version history / export / delete) behind a single ≡ affordance at
+ * the far right of the header, and shows a light info head (creator + created date) above them.
+ *
+ * Self-contained plain-React popover (no antd, no portal): a relatively-positioned wrapper anchors
+ * an absolutely-positioned panel below the trigger. Closes on outside pointer-down and on Escape.
+ */
+export function DocMoreMenu({ creatorName, createdAt, items, dangerItem }: DocMoreMenuProps) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const close = () => setOpen(false)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown, true)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown, true)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const createdOn = formatCreatedDate(createdAt)
+
+  return (
+    <div className="octo-doc-more" ref={wrapRef}>
+      <button
+        type="button"
+        className={open ? 'octo-doc-more-btn is-active' : 'octo-doc-more-btn'}
+        title={t('docs.toolbar.more')}
+        aria-label={t('docs.toolbar.more')}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <HamburgerIcon />
+      </button>
+      {open && (
+        <div className="octo-doc-more-panel" role="menu">
+          <div className="octo-doc-more-head">
+            <div className="octo-doc-more-creator">
+              <span className="octo-doc-more-avatar" aria-hidden="true">
+                {avatarInitial(creatorName)}
+              </span>
+              <span className="octo-doc-more-name" title={creatorName}>
+                {creatorName}
+              </span>
+            </div>
+            {createdOn && (
+              <div className="octo-doc-more-created">
+                {t('docs.moreMenu.createdPrefix')} {createdOn}
+              </div>
+            )}
+          </div>
+          <ul className="octo-doc-more-list">
+            {items.map((item) => (
+              <MenuRow key={item.key} item={item} onSelect={close} />
+            ))}
+          </ul>
+          {dangerItem && (
+            <>
+              <div className="octo-doc-more-sep" />
+              <ul className="octo-doc-more-list octo-doc-more-danger-group">
+                <MenuRow item={dangerItem} onSelect={close} />
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/docs/src/editor/DocMoreMenu.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.tsx
@@ -78,6 +78,14 @@ export const OpenNewPageIcon = (
   </RowIcon>
 )
 
+/** 🔗 copy link (chain). */
+export const LinkIcon = (
+  <RowIcon>
+    <path d="M8.5 11.5a3 3 0 0 0 4.24 0l2-2a3 3 0 0 0-4.24-4.24l-1 1" />
+    <path d="M11.5 8.5a3 3 0 0 0-4.24 0l-2 2a3 3 0 0 0 4.24 4.24l1-1" />
+  </RowIcon>
+)
+
 /** 🕐 version history (clock). */
 export const HistoryIcon = (
   <RowIcon>

--- a/packages/docs/src/editor/DocTerminal.tsx
+++ b/packages/docs/src/editor/DocTerminal.tsx
@@ -1,0 +1,53 @@
+// Terminal (dead-end) screen for a document that can't be opened: access revoked, not found,
+// locked/archived, session expired, or deleted-under-you. Extracted so BOTH the in-shell editor
+// (EditorShell, when the collab bootstrap fails) and the standalone deep-link page
+// (StandaloneDocPage, from its GET preflight) render the SAME markup + message for a given kind —
+// one source of truth for the boundary states (AC-7 / AC-10 / AC-11 / AC-12).
+
+import type { ReactElement } from 'react'
+import { t } from '../octoweb/index.ts'
+import type { TerminalState } from '../collab/createCollabEditor.ts'
+
+/** Non-'none' terminal kinds. */
+export type TerminalKind = Exclude<TerminalState['kind'], 'none'>
+
+/** i18n key for each terminal kind's user-facing message. */
+const MESSAGE_KEYS: Record<TerminalKind, string> = {
+  forbidden: 'docs.error.permission.forbidden',
+  'not-found': 'docs.error.permission.notFound',
+  locked: 'docs.error.permission.locked',
+  login: 'docs.error.permission.login',
+  deleted: 'docs.error.permission.deleted',
+}
+
+/** Resolve the i18n message key for a terminal kind (exported for tests / reuse). */
+export function terminalMessageKey(kind: TerminalKind): string {
+  return MESSAGE_KEYS[kind]
+}
+
+/**
+ * The terminal block: a title, the reason message, and — when a handler is provided — a single
+ * "back to all documents" control. Nothing else (no Share, no Request access) per the locked
+ * scope. `onBack` is optional so the in-shell path (list always resident) can omit it.
+ */
+export function DocTerminal({
+  title,
+  kind,
+  onBack,
+}: {
+  title: string
+  kind: TerminalKind
+  onBack?: () => void
+}): ReactElement {
+  return (
+    <div className="octo-doc octo-terminal">
+      {onBack && (
+        <button type="button" className="octo-doc-back" onClick={onBack}>
+          ← {t('docs.list.back')}
+        </button>
+      )}
+      <h2>{title}</h2>
+      <p className="octo-terminal-msg">{t(MESSAGE_KEYS[kind])}</p>
+    </div>
+  )
+}

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -123,7 +123,9 @@ describe('EditorShell — export filename uses the live title, not the stale pro
     // The header shows the fetched (live) title once the mount fetch resolves.
     await waitFor(() => expect(screen.getByText('Live Title')).toBeTruthy())
 
-    fireEvent.click(screen.getByTitle('docs.toolbar.exportMarkdown'))
+    // Export moved into the header ≡ "more" menu: open it, then trigger the export row.
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.exportMarkdown'))
 
     await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(createdAnchors.length).toBeGreaterThan(0))
@@ -151,9 +153,11 @@ describe('EditorShell — header injection props (#512 AC-8)', () => {
     render(<EditorShell {...baseProps} />)
     // No header back button when onBack is omitted.
     expect(screen.queryByTitle('docs.list.back')).toBeNull()
-    // The built-in header controls still render (in-shell path intact).
-    expect(screen.getByTitle('docs.toolbar.exportMarkdown')).toBeTruthy()
-    expect(screen.getByTitle('docs.toolbar.history')).toBeTruthy()
+    // The low-frequency controls now live behind the ≡ "more" menu, not as resident buttons.
+    expect(screen.getByTitle('docs.toolbar.more')).toBeTruthy()
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    expect(screen.getByText('docs.toolbar.exportMarkdown')).toBeTruthy()
+    expect(screen.getByText('docs.toolbar.history')).toBeTruthy()
   })
 
   it('standalone: renders the injected headerRight content alongside the built-in controls', () => {
@@ -168,7 +172,77 @@ describe('EditorShell — header injection props (#512 AC-8)', () => {
     expect(screen.getByText('INJECTED_ACTIONS')).toBeTruthy()
     // ...the back control shows when onBack is provided...
     expect(screen.getByTitle('docs.list.back')).toBeTruthy()
-    // ...and the built-in controls are still present (parity preserved).
-    expect(screen.getByTitle('docs.toolbar.exportMarkdown')).toBeTruthy()
+    // ...and the built-in controls are still reachable via the ≡ menu (parity preserved).
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    expect(screen.getByText('docs.toolbar.exportMarkdown')).toBeTruthy()
+  })
+})
+
+// #512 title-bar tidy-up: the header ≡ "more" menu collapses the low-frequency actions behind one
+// affordance, with a creator + created-on head. role is 'admin' (see the useCollabEditor mock), so
+// the destructive delete row is present.
+describe('EditorShell — header "more" (≡) menu', () => {
+  const baseProps = {
+    docId: 'd_1',
+    title: 'Doc',
+    space: 's_1',
+    folder: 'f_1',
+    doc: 'd_1',
+    uid: 'u_self',
+    user: { id: 'u_self', name: 'Self' },
+  }
+
+  it('collapses history / export / delete behind ≡; delete is a danger row, pinned last', () => {
+    render(<EditorShell {...baseProps} />)
+    // Closed by default: no rows visible.
+    expect(screen.queryByText('docs.toolbar.exportMarkdown')).toBeNull()
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+
+    const historyRow = screen.getByText('docs.toolbar.history').closest('button')!
+    const exportRow = screen.getByText('docs.toolbar.exportMarkdown').closest('button')!
+    const deleteRow = screen.getByText('docs.doc.deleteEntry').closest('button')!
+    expect(historyRow).toBeTruthy()
+    expect(exportRow).toBeTruthy()
+    // Delete is the danger row.
+    expect(deleteRow.className).toContain('is-danger')
+    // Order: history precedes export precedes delete in the DOM.
+    expect(historyRow.compareDocumentPosition(exportRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(exportRow.compareDocumentPosition(deleteRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('shows the "open in new page" row (first) only when onOpenInNewPage is wired', () => {
+    const onOpenInNewPage = vi.fn()
+    const { rerender } = render(<EditorShell {...baseProps} />)
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    // In-shell handler absent → no open-in-new-page row.
+    expect(screen.queryByText('docs.standalone.openInNewPage')).toBeNull()
+
+    // Wire the handler; the menu stays open across the rerender and now shows the row first.
+    rerender(<EditorShell {...baseProps} onOpenInNewPage={onOpenInNewPage} />)
+    const openRow = screen.getByText('docs.standalone.openInNewPage')
+    fireEvent.click(openRow)
+    expect(onOpenInNewPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the creator + created-on head from the doc meta', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_1') {
+        return {
+          data: { docId: 'd_1', title: 'Doc', ownerId: 'u_owner', createdAt: '2026-07-02T14:00:45Z' },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url === '/users/u_owner') {
+        return { data: { name: 'Alice' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<EditorShell {...baseProps} />)
+    // Wait for the owner-name resolution to land, then open the menu.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(true))
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    await waitFor(() => expect(screen.getByText('Alice')).toBeTruthy())
+    // Created-on line uses the lexical YYYY-MM-DD slice (no timezone drift).
+    expect(screen.getByText(/2026-07-02/)).toBeTruthy()
   })
 })

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -134,7 +134,7 @@ describe('EditorShell — export filename uses the live title, not the stale pro
 })
 
 // #512 AC-8 non-regression: the standalone deep-link page reuses EditorShell and injects a Back
-// control (onBack) + "Copy link" / "Open in App" (headerRight). The IN-SHELL path passes neither,
+// control (onBack) + "Copy link" (headerRight). The IN-SHELL path passes neither,
 // and must be completely unaffected by the new props.
 describe('EditorShell — header injection props (#512 AC-8)', () => {
   const baseProps = {

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -132,3 +132,43 @@ describe('EditorShell — export filename uses the live title, not the stale pro
     expect(a.download).not.toBe('Stale Prop Title.md')
   })
 })
+
+// #512 AC-8 non-regression: the standalone deep-link page reuses EditorShell and injects a Back
+// control (onBack) + "Copy link" / "Open in App" (headerRight). The IN-SHELL path passes neither,
+// and must be completely unaffected by the new props.
+describe('EditorShell — header injection props (#512 AC-8)', () => {
+  const baseProps = {
+    docId: 'd_1',
+    title: 'Doc',
+    space: 's_1',
+    folder: 'f_1',
+    doc: 'd_1',
+    uid: 'u_self',
+    user: { id: 'u_self', name: 'Self' },
+  }
+
+  it('in-shell (no onBack / no headerRight): renders no header back control, header unchanged', () => {
+    render(<EditorShell {...baseProps} />)
+    // No header back button when onBack is omitted.
+    expect(screen.queryByTitle('docs.list.back')).toBeNull()
+    // The built-in header controls still render (in-shell path intact).
+    expect(screen.getByTitle('docs.toolbar.exportMarkdown')).toBeTruthy()
+    expect(screen.getByTitle('docs.toolbar.history')).toBeTruthy()
+  })
+
+  it('standalone: renders the injected headerRight content alongside the built-in controls', () => {
+    render(
+      <EditorShell
+        {...baseProps}
+        onBack={() => {}}
+        headerRight={<button type="button">INJECTED_ACTIONS</button>}
+      />,
+    )
+    // The injected standalone chrome appears...
+    expect(screen.getByText('INJECTED_ACTIONS')).toBeTruthy()
+    // ...the back control shows when onBack is provided...
+    expect(screen.getByTitle('docs.list.back')).toBeTruthy()
+    // ...and the built-in controls are still present (parity preserved).
+    expect(screen.getByTitle('docs.toolbar.exportMarkdown')).toBeTruthy()
+  })
+})

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -46,7 +46,13 @@ vi.mock('../comments/useDocComments.ts', () => ({
   useDocComments: () => ({ threads: [], createRoot: vi.fn() }),
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
-vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+// useMemberNames drives the creator-name resolution's PRIMARY source (the space-member map). Kept
+// as an overridable hoisted spy so a test can seed the map with the owner (XIN-392 P2-1) and assert
+// the standalone nickname-only path bypasses it. Defaults to an empty map, reset in beforeEach.
+const { useMemberNamesMock } = vi.hoisted(() => ({
+  useMemberNamesMock: vi.fn(() => new Map<string, string>()),
+}))
+vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: useMemberNamesMock }))
 vi.mock('./useDocDelete.ts', () => ({
   useDocDelete: () => ({
     confirming: false,
@@ -68,6 +74,8 @@ beforeEach(() => {
   wk = createMockWKApp()
   setWKApp(wk)
   exportSpy.mockClear()
+  useMemberNamesMock.mockReset()
+  useMemberNamesMock.mockReturnValue(new Map<string, string>())
   fakeEditor.storage.octoCommentHighlight = {}
   // jsdom has no object-URL impl; the export handler creates + revokes one.
   ;(URL as unknown as { createObjectURL: () => string }).createObjectURL = () => 'blob:mock'
@@ -244,5 +252,48 @@ describe('EditorShell — header "more" (≡) menu', () => {
     await waitFor(() => expect(screen.getByText('Alice')).toBeTruthy())
     // Created-on line uses the lexical YYYY-MM-DD slice (no timezone drift).
     expect(screen.getByText(/2026-07-02/)).toBeTruthy()
+  })
+
+  it('P2-1: standalone (creatorNicknameOnly) SKIPS the member map even when it holds a real name', async () => {
+    // Simulate the future backend that fills the space-member display name with a VERIFIED real
+    // name. On the externally shared standalone surface this must never reach a link holder — the
+    // creator name has to resolve through the nickname-only getUserName path, not the member map.
+    useMemberNamesMock.mockReturnValue(new Map([['u_owner', 'Real Legal Name']]))
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_1') {
+        return { data: { docId: 'd_1', title: 'Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      if (method === 'get' && url === '/users/u_owner') {
+        // Nickname-only fetch: real_name present but must be ignored (preferRealName:false).
+        return { data: { name: 'Nick', real_name: 'Real Legal Name' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<EditorShell {...baseProps} creatorNicknameOnly />)
+    // The nickname-only resolver is called despite the member map already holding a name.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(true))
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    await waitFor(() => expect(screen.getByText('Nick')).toBeTruthy())
+    // The verified real name from the member map never surfaces on the shared surface.
+    expect(screen.queryByText('Real Legal Name')).toBeNull()
+  })
+
+  it('P2-1: in-shell (creatorNicknameOnly unset) still uses the member map first, no /users fetch', async () => {
+    // Unchanged in-shell behavior: the already-loaded member map is the free primary source, so the
+    // creator name comes straight from it and getUserName is never called.
+    useMemberNamesMock.mockReturnValue(new Map([['u_owner', 'Member Name']]))
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_1') {
+        return { data: { docId: 'd_1', title: 'Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<EditorShell {...baseProps} />)
+    // Wait for the doc meta (ownerId) to land so the creator effect has run.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/d_1')).toBe(true))
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    await waitFor(() => expect(screen.getByText('Member Name')).toBeTruthy())
+    // Member map hit → the /users/:uid fallback is never reached in-shell.
+    expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(false)
   })
 })

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -46,7 +46,7 @@ export interface EditorShellProps extends CollabEditorOptions {
   onDeleted?: (docId: string) => void
   /**
    * Extra controls injected into the header's right-hand cluster (e.g. the standalone deep-link
-   * page's "Copy link" + "Open in App"). Optional: when omitted, the in-shell header renders
+   * page's "Copy link"). Optional: when omitted, the in-shell header renders
    * exactly as before — no wrapper, no empty node — so the in-shell path is byte-for-byte
    * unchanged (AC-8 non-regression). Rendered ahead of the built-in history/comments/… buttons.
    */

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -302,14 +302,26 @@ export function EditorShell(props: EditorShellProps) {
   const [creatorName, setCreatorName] = useState<string | undefined>(undefined)
   useEffect(() => {
     if (!ownerId) return
-    const fromMembers = names.get(ownerId)
-    if (fromMembers && fromMembers !== ownerId) {
-      setCreatorName(fromMembers)
-      return
+    // In-shell (creatorNicknameOnly unset): prefer the already-loaded space-member map — free, and
+    // the same source the presence caret + member panel use.
+    //
+    // On the standalone (externally shared) surface (creatorNicknameOnly), SKIP the member-map
+    // primary source entirely (XIN-392 P2-1). Gating only the getUserName fallback on
+    // creatorNicknameOnly (as before) left the member map as an ungated primary source that leaks a
+    // real name the moment the backend fills member display names with verified names — the
+    // no-leak-today guarantee rests on the implicit "member name is never a real name" contract.
+    // A link holder must never see the creator's verified name, so resolve nickname-only regardless
+    // of what the member map holds.
+    if (!creatorNicknameOnly) {
+      const fromMembers = names.get(ownerId)
+      if (fromMembers && fromMembers !== ownerId) {
+        setCreatorName(fromMembers)
+        return
+      }
     }
     let cancelled = false
-    // On the standalone (externally shared) surface, resolve the nickname only — never leak the
-    // creator's verified real name to a link holder. In-shell keeps the real-name preference.
+    // In-shell resolves the verified real name (falling back to nickname); the standalone surface
+    // forces nickname-only and never requests real_name.
     getUserName(ownerId, { preferRealName: !creatorNicknameOnly })
       .then((name) => {
         if (!cancelled && name) setCreatorName(name)

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -67,6 +67,13 @@ export interface EditorShellProps extends CollabEditorOptions {
    * doesn't render there.
    */
   onOpenInNewPage?: () => void
+  /**
+   * Extra rows prepended to the TOP of the header's ≡ "more" menu (in the given order), before the
+   * built-in open-in-new-page / history / export rows. Opt-in: when omitted the menu renders exactly
+   * as before, so the in-shell path is unchanged (AC-4 non-regression). The standalone page uses this
+   * to pin its "Copy link" action as the first menu item, having dropped its resident header button.
+   */
+  moreMenuLeadItems?: DocMoreMenuItem[]
 }
 
 /**
@@ -238,7 +245,7 @@ function DocTitle({
 
 /** Page shell (frontend-design §3.1): title / toolbar / content / presence + right-side drawer. */
 export function EditorShell(props: EditorShellProps) {
-  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, onOpenInNewPage, ...collabOpts } =
+  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, onOpenInNewPage, moreMenuLeadItems, ...collabOpts } =
     props
   const docId = props.docId
   const { instance, ready, role, connState, terminal } = useCollabEditor(collabOpts)
@@ -414,11 +421,14 @@ export function EditorShell(props: EditorShellProps) {
   const editor = instance.editor
   const manage = role ? canManage(role) : false
 
-  // "More" (≡) menu contents. Order is fixed per spec: open-in-new-page → version history →
-  // export, with delete pinned last (below a separator) as the destructive row. The open-in-new-
-  // page row only appears when the host wired the handler (in-shell path), never on the standalone
-  // page itself.
+  // "More" (≡) menu contents. Order is fixed per spec: [caller-provided lead rows] → open-in-new-
+  // page → version history → export, with delete pinned last (below a separator) as the destructive
+  // row. Lead rows come from the host (e.g. the standalone page's "Copy link"); they sit at the very
+  // top so a standalone page — which never wires open-in-new-page — shows Copy link as the first row.
+  // The open-in-new-page row only appears when the host wired the handler (in-shell path), never on
+  // the standalone page itself.
   const moreItems: DocMoreMenuItem[] = []
+  if (moreMenuLeadItems?.length) moreItems.push(...moreMenuLeadItems)
   if (onOpenInNewPage) {
     moreItems.push({
       key: 'open-new-page',

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -17,9 +17,10 @@ import { useMemberNames } from '../members/useMemberNames.ts'
 import { exportDocToMarkdown, type MdNode } from '../export/markdown.ts'
 import { emojiGlyph } from './emoji.ts'
 import { colorFromId } from '../awareness/presence.ts'
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
 import { t } from '../octoweb/index.ts'
 import { getDoc, updateDocTitle } from '../pages/docsApi.ts'
+import { DocTerminal } from './DocTerminal.tsx'
 import './styles.css'
 
 /** Which right-side drawer panel is open (mutually exclusive); null = drawer closed. */
@@ -43,6 +44,13 @@ export interface EditorShellProps extends CollabEditorOptions {
    * to its own return-to-list handler (onExit ?? onBack).
    */
   onDeleted?: (docId: string) => void
+  /**
+   * Extra controls injected into the header's right-hand cluster (e.g. the standalone deep-link
+   * page's "Copy link" + "Open in App"). Optional: when omitted, the in-shell header renders
+   * exactly as before — no wrapper, no empty node — so the in-shell path is byte-for-byte
+   * unchanged (AC-8 non-regression). Rendered ahead of the built-in history/comments/… buttons.
+   */
+  headerRight?: ReactNode
 }
 
 /**
@@ -214,7 +222,7 @@ function DocTitle({
 
 /** Page shell (frontend-design §3.1): title / toolbar / content / presence + right-side drawer. */
 export function EditorShell(props: EditorShellProps) {
-  const { title, onBack, onExit, onTitleSaved, onDeleted, ...collabOpts } = props
+  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, ...collabOpts } = props
   const docId = props.docId
   const { instance, ready, role, connState, terminal } = useCollabEditor(collabOpts)
   // The live document title, lifted out of DocTitle so the export filename uses the current
@@ -344,24 +352,7 @@ export function EditorShell(props: EditorShellProps) {
   const closePanel = useCallback(() => setActivePanel(null), [])
 
   if (terminal.kind !== 'none') {
-    const messages: Record<string, string> = {
-      forbidden: t('docs.error.permission.forbidden'),
-      'not-found': t('docs.error.permission.notFound'),
-      locked: t('docs.error.permission.locked'),
-      login: t('docs.error.permission.login'),
-      deleted: t('docs.error.permission.deleted'),
-    }
-    return (
-      <div className="octo-doc octo-terminal">
-        {onBack && (
-          <button type="button" className="octo-doc-back" onClick={onBack}>
-            ← {t('docs.list.back')}
-          </button>
-        )}
-        <h2>{title}</h2>
-        <p className="octo-terminal-msg">{messages[terminal.kind]}</p>
-      </div>
-    )
+    return <DocTerminal title={title} kind={terminal.kind} onBack={onBack} />
   }
 
   if (!instance) {
@@ -399,6 +390,7 @@ export function EditorShell(props: EditorShellProps) {
           onTitleLoaded={setCurrentTitle}
         />
         <div className="octo-doc-header-right">
+          {headerRight}
           <PresenceBar provider={instance.provider} connState={connState} synced={ready} />
           {/* History is reader+ (everyone with access), unlike admin-only Members. */}
           <button

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -74,6 +74,14 @@ export interface EditorShellProps extends CollabEditorOptions {
    * to pin its "Copy link" action as the first menu item, having dropped its resident header button.
    */
   moreMenuLeadItems?: DocMoreMenuItem[]
+  /**
+   * When true, resolve the creator display name from the NICKNAME only, never the verified
+   * `real_name`. Opt-in: defaults to false so the in-shell editor keeps preferring the real name
+   * (AC non-regression). The standalone `/d/:docId` page sets this because it is an externally
+   * shareable surface — showing the creator's legal name to any link holder is a privacy leak
+   * (boss decision).
+   */
+  creatorNicknameOnly?: boolean
 }
 
 /**
@@ -245,7 +253,7 @@ function DocTitle({
 
 /** Page shell (frontend-design §3.1): title / toolbar / content / presence + right-side drawer. */
 export function EditorShell(props: EditorShellProps) {
-  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, onOpenInNewPage, moreMenuLeadItems, ...collabOpts } =
+  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, onOpenInNewPage, moreMenuLeadItems, creatorNicknameOnly, ...collabOpts } =
     props
   const docId = props.docId
   const { instance, ready, role, connState, terminal } = useCollabEditor(collabOpts)
@@ -300,7 +308,9 @@ export function EditorShell(props: EditorShellProps) {
       return
     }
     let cancelled = false
-    getUserName(ownerId)
+    // On the standalone (externally shared) surface, resolve the nickname only — never leak the
+    // creator's verified real name to a link holder. In-shell keeps the real-name preference.
+    getUserName(ownerId, { preferRealName: !creatorNicknameOnly })
       .then((name) => {
         if (!cancelled && name) setCreatorName(name)
       })
@@ -310,7 +320,7 @@ export function EditorShell(props: EditorShellProps) {
     return () => {
       cancelled = true
     }
-  }, [ownerId, names])
+  }, [ownerId, names, creatorNicknameOnly])
 
   // C4 (#5): reset the drawer whenever the document changes. The shell is keyed by docId in
   // DocsHome (so it already remounts), but this makes the reset explicit and robust if the key

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -19,8 +19,16 @@ import { emojiGlyph } from './emoji.ts'
 import { colorFromId } from '../awareness/presence.ts'
 import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
 import { t } from '../octoweb/index.ts'
-import { getDoc, updateDocTitle } from '../pages/docsApi.ts'
+import { getDoc, getUserName, updateDocTitle } from '../pages/docsApi.ts'
 import { DocTerminal } from './DocTerminal.tsx'
+import {
+  DocMoreMenu,
+  OpenNewPageIcon,
+  HistoryIcon,
+  ExportIcon,
+  DeleteIcon,
+  type DocMoreMenuItem,
+} from './DocMoreMenu.tsx'
 import './styles.css'
 
 /** Which right-side drawer panel is open (mutually exclusive); null = drawer closed. */
@@ -48,9 +56,17 @@ export interface EditorShellProps extends CollabEditorOptions {
    * Extra controls injected into the header's right-hand cluster (e.g. the standalone deep-link
    * page's "Copy link"). Optional: when omitted, the in-shell header renders
    * exactly as before — no wrapper, no empty node — so the in-shell path is byte-for-byte
-   * unchanged (AC-8 non-regression). Rendered ahead of the built-in history/comments/… buttons.
+   * unchanged (AC-8 non-regression). Rendered ahead of the built-in comments/members/… cluster.
    */
   headerRight?: ReactNode
+  /**
+   * "Open in new page" handler (in-shell only). When provided, the header's ≡ "more" menu shows an
+   * "Open in new page" row that opens the shareable standalone `/d/:docId` link — the same action
+   * the old resident purple button performed. Omitted on the standalone page itself (there is no
+   * "open in a new page" from a page that already IS the standalone view), so the row simply
+   * doesn't render there.
+   */
+  onOpenInNewPage?: () => void
 }
 
 /**
@@ -222,7 +238,8 @@ function DocTitle({
 
 /** Page shell (frontend-design §3.1): title / toolbar / content / presence + right-side drawer. */
 export function EditorShell(props: EditorShellProps) {
-  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, ...collabOpts } = props
+  const { title, onBack, onExit, onTitleSaved, onDeleted, headerRight, onOpenInNewPage, ...collabOpts } =
+    props
   const docId = props.docId
   const { instance, ready, role, connState, terminal } = useCollabEditor(collabOpts)
   // The live document title, lifted out of DocTitle so the export filename uses the current
@@ -238,14 +255,19 @@ export function EditorShell(props: EditorShellProps) {
   // this the panel falls back to a role heuristic that never matches a fresh doc, so the badge
   // never shows. Resilient: stays null if the meta lacks ownerId.
   const [ownerId, setOwnerId] = useState<string | undefined>(undefined)
+  // Creation timestamp (RFC3339) for the "more" menu head's "Created on" line. Fetched from the
+  // same per-doc GET as ownerId; stays undefined (row hidden) when the backend omits it.
+  const [createdAt, setCreatedAt] = useState<string | undefined>(undefined)
   useEffect(() => {
     let cancelled = false
     getDoc(docId)
       .then((meta) => {
-        if (!cancelled && typeof meta?.ownerId === 'string' && meta.ownerId) setOwnerId(meta.ownerId)
+        if (cancelled) return
+        if (typeof meta?.ownerId === 'string' && meta.ownerId) setOwnerId(meta.ownerId)
+        if (typeof meta?.createdAt === 'string' && meta.createdAt) setCreatedAt(meta.createdAt)
       })
       .catch(() => {
-        /* non-fatal: owner badge just won't show */
+        /* non-fatal: owner badge + created-on row just won't show */
       })
     return () => {
       cancelled = true
@@ -256,6 +278,32 @@ export function EditorShell(props: EditorShellProps) {
   // the presence avatar initial and the collaboration caret label show the name, not the uid.
   // The editor is created with the best-known name; this updates it when the member list lands.
   const names = useMemberNames(props.space)
+
+  // Creator display name for the "more" menu head. The doc's ownerId (boss-decided creator
+  // semantics) is resolved to a human name: first from the already-loaded space-member map (free,
+  // same source the presence caret + member panel use), then — for an owner who isn't in that map
+  // — via GET /users/:uid. Resilient: any failure leaves it undefined and the menu falls back to a
+  // short uid, so the header can never crash on a missing/failed name lookup.
+  const [creatorName, setCreatorName] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (!ownerId) return
+    const fromMembers = names.get(ownerId)
+    if (fromMembers && fromMembers !== ownerId) {
+      setCreatorName(fromMembers)
+      return
+    }
+    let cancelled = false
+    getUserName(ownerId)
+      .then((name) => {
+        if (!cancelled && name) setCreatorName(name)
+      })
+      .catch(() => {
+        /* keep the uid fallback */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [ownerId, names])
 
   // C4 (#5): reset the drawer whenever the document changes. The shell is keyed by docId in
   // DocsHome (so it already remounts), but this makes the reset explicit and robust if the key
@@ -366,6 +414,47 @@ export function EditorShell(props: EditorShellProps) {
   const editor = instance.editor
   const manage = role ? canManage(role) : false
 
+  // "More" (≡) menu contents. Order is fixed per spec: open-in-new-page → version history →
+  // export, with delete pinned last (below a separator) as the destructive row. The open-in-new-
+  // page row only appears when the host wired the handler (in-shell path), never on the standalone
+  // page itself.
+  const moreItems: DocMoreMenuItem[] = []
+  if (onOpenInNewPage) {
+    moreItems.push({
+      key: 'open-new-page',
+      label: t('docs.standalone.openInNewPage'),
+      icon: OpenNewPageIcon,
+      onClick: onOpenInNewPage,
+    })
+  }
+  moreItems.push(
+    {
+      key: 'history',
+      label: t('docs.toolbar.history'),
+      icon: HistoryIcon,
+      onClick: () => togglePanel('history'),
+    },
+    {
+      key: 'export',
+      label: t('docs.toolbar.exportMarkdown'),
+      icon: ExportIcon,
+      disabled: exporting,
+      onClick: () => void onExportMarkdown(),
+    },
+  )
+  const deleteItem: DocMoreMenuItem | undefined = manage
+    ? {
+        key: 'delete',
+        label: t('docs.doc.deleteEntry'),
+        icon: DeleteIcon,
+        danger: true,
+        onClick: del.requestDelete,
+      }
+    : undefined
+  // Creator name with fallback: resolved name → short uid → placeholder. Never blank, never crashes.
+  const creatorDisplay =
+    creatorName || (ownerId ? ownerId.slice(0, 8) : t('docs.moreMenu.unknownCreator'))
+
   return (
     <div className="octo-doc octo-doc--editor octo-theme">
       <header className="octo-doc-header">
@@ -392,16 +481,6 @@ export function EditorShell(props: EditorShellProps) {
         <div className="octo-doc-header-right">
           {headerRight}
           <PresenceBar provider={instance.provider} connState={connState} synced={ready} />
-          {/* History is reader+ (everyone with access), unlike admin-only Members. */}
-          <button
-            type="button"
-            className={activePanel === 'history' ? 'octo-tb-btn is-active' : 'octo-tb-btn'}
-            title={t('docs.toolbar.history')}
-            aria-pressed={activePanel === 'history'}
-            onClick={() => togglePanel('history')}
-          >
-            🕐 {t('docs.toolbar.history')}
-          </button>
           {/* Comments are reader+ (everyone with access — "can see → can comment"). */}
           <button
             type="button"
@@ -411,16 +490,6 @@ export function EditorShell(props: EditorShellProps) {
             onClick={() => togglePanel('comments')}
           >
             💬 {t('docs.toolbar.comments')}
-          </button>
-          {/* Export the document as a Markdown file (reader+ — anyone who can view can export). */}
-          <button
-            type="button"
-            className="octo-tb-btn"
-            title={t('docs.toolbar.exportMarkdown')}
-            disabled={exporting}
-            onClick={() => void onExportMarkdown()}
-          >
-            ⬇ {t('docs.toolbar.exportMarkdown')}
           </button>
           {manage && (
             <button
@@ -432,17 +501,14 @@ export function EditorShell(props: EditorShellProps) {
               {t('docs.toolbar.members')}
             </button>
           )}
-          {/* Delete entry (Problem 4) — owner/admin only; moved here from the list row. */}
-          {manage && (
-            <button
-              type="button"
-              className="octo-tb-btn octo-doc-delete-btn"
-              title={t('docs.doc.deleteEntry')}
-              onClick={del.requestDelete}
-            >
-              🗑 {t('docs.doc.deleteEntry')}
-            </button>
-          )}
+          {/* Low-frequency actions (open in new page / version history / export / delete) collapse
+              into a single ≡ "more" menu pinned to the far right, with a creator + created-on head. */}
+          <DocMoreMenu
+            creatorName={creatorDisplay}
+            createdAt={createdAt}
+            items={moreItems}
+            dangerItem={deleteItem}
+          />
         </div>
       </header>
 

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2462,22 +2462,9 @@
   min-height: 0;
 }
 
-/* Standalone-injected header actions (Copy link), sitting ahead of the built-in
-   history/comments/export cluster in .octo-doc-header-right. */
-.octo-doc-standalone-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.octo-doc-copy-link {
-  white-space: nowrap;
-}
-
 /* Responsive, 3 tiers (prototype v2):
    ≥1024  — full labels everywhere (default).
-   768–1024 — the built-in secondary buttons collapse to their icons to reclaim width; the
-              standalone Copy link keeps its label.
+   768–1024 — the built-in secondary buttons collapse to their icons to reclaim width.
    <1024  — the header may wrap and the toolbar scrolls horizontally rather than overflowing;
             the prose column stays full-width and the title never collapses to zero width.
    Back is never hidden. */

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2296,3 +2296,65 @@
   font-size: 12px;
   color: var(--octo-text-secondary, #86909c);
 }
+
+/* ── Standalone document page (octo-web #512) ────────────────────────────────
+   The full-window view a shared `/d/:docId` link opens, outside the app shell / NavRail.
+   The wrapper owns the viewport; the inner EditorShell (.octo-doc--editor) fills it, so the
+   layout matches the in-shell full-width pane. */
+.octo-doc-standalone {
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--octo-bg, #fff);
+  display: flex;
+  flex-direction: column;
+}
+.octo-doc-standalone > .octo-doc {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Standalone-injected header actions (Copy link + Open in App), sitting ahead of the built-in
+   history/comments/export cluster in .octo-doc-header-right. */
+.octo-doc-standalone-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* "Open in App" is the primary call to action (#1664ff), matching the prototype. */
+.octo-doc-open-in-app {
+  background: var(--octo-active-fg, #1664ff);
+  color: #fff;
+  border-color: var(--octo-active-fg, #1664ff);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.octo-doc-open-in-app:hover {
+  background: #0f52d9;
+  border-color: #0f52d9;
+  color: #fff;
+}
+.octo-doc-copy-link {
+  white-space: nowrap;
+}
+
+/* Responsive, 3 tiers (prototype v2):
+   ≥1024  — full labels everywhere (default).
+   768–1024 — the built-in secondary buttons collapse to their icons to reclaim width; the
+              standalone Copy link / Open in App keep their labels.
+   <1024  — the header may wrap and the toolbar scrolls horizontally rather than overflowing;
+            the prose column stays full-width and the title never collapses to zero width.
+   Back and Open in App are never hidden. */
+@media (max-width: 1024px) {
+  .octo-doc-standalone .octo-doc-header {
+    flex-wrap: wrap;
+  }
+  .octo-doc-standalone .octo-doc-title {
+    min-width: 8ch;
+  }
+  .octo-doc-standalone .octo-toolbar {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+}

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2314,7 +2314,7 @@
   min-height: 0;
 }
 
-/* Standalone-injected header actions (Copy link + Open in App), sitting ahead of the built-in
+/* Standalone-injected header actions (Copy link), sitting ahead of the built-in
    history/comments/export cluster in .octo-doc-header-right. */
 .octo-doc-standalone-actions {
   display: flex;
@@ -2322,19 +2322,6 @@
   gap: 8px;
 }
 
-/* "Open in App" is the primary call to action (#1664ff), matching the prototype. */
-.octo-doc-open-in-app {
-  background: var(--octo-active-fg, #1664ff);
-  color: #fff;
-  border-color: var(--octo-active-fg, #1664ff);
-  font-weight: 500;
-  white-space: nowrap;
-}
-.octo-doc-open-in-app:hover {
-  background: #0f52d9;
-  border-color: #0f52d9;
-  color: #fff;
-}
 .octo-doc-copy-link {
   white-space: nowrap;
 }
@@ -2342,10 +2329,10 @@
 /* Responsive, 3 tiers (prototype v2):
    ≥1024  — full labels everywhere (default).
    768–1024 — the built-in secondary buttons collapse to their icons to reclaim width; the
-              standalone Copy link / Open in App keep their labels.
+              standalone Copy link keeps its label.
    <1024  — the header may wrap and the toolbar scrolls horizontally rather than overflowing;
             the prose column stays full-width and the title never collapses to zero width.
-   Back and Open in App are never hidden. */
+   Back is never hidden. */
 @media (max-width: 1024px) {
   .octo-doc-standalone .octo-doc-header {
     flex-wrap: wrap;

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2462,6 +2462,24 @@
   min-height: 0;
 }
 
+/* Menu-external "Link copied" toast (octo-web #512 return-fix). Fixed, document-external overlay so
+   it stays visible after the ≡ "more" menu closes on selection — mirrors the image upload
+   status/error toast style (fixed, centered near the bottom, accent fill, soft shadow). */
+.octo-doc-standalone-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--octo-accent);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  z-index: 1000;
+  pointer-events: none;
+}
+
 /* Responsive, 3 tiers (prototype v2):
    ≥1024  — full labels everywhere (default).
    768–1024 — the built-in secondary buttons collapse to their icons to reclaim width.

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1220,18 +1220,166 @@
   background: #d64545;
 }
 
-/* Editor delete entry (Problem 4): danger-tinted header button + a confirm card that
-   sits just under the header instead of floating in a list row. */
-.octo-doc-delete-btn {
-  color: #eb5757;
-}
-.octo-doc-delete-btn:hover {
-  background: rgba(235, 87, 87, 0.1);
-}
+/* Editor delete entry (Problem 4): the delete action now lives inside the header ≡ "more" menu
+   (danger row, see .octo-doc-more-item.is-danger below). The confirm card still sits just under
+   the header instead of floating in a list row. */
 .octo-doc-delete-confirm {
   margin: 8px 0 0;
   max-width: 420px;
 }
+
+/* Header "more" (≡) menu (#512 title-bar tidy-up). A relatively-positioned anchor holds the ≡
+   trigger and an absolutely-positioned dropdown so the panel opens flush under the icon at the
+   far right of the header. */
+.octo-doc-more {
+  position: relative;
+  flex: 0 0 auto;
+}
+/* 32×32 hit area, 20×20 glyph; hover tint + rounded corners per Jeff's spec. */
+.octo-doc-more-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #646a73;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.octo-doc-more-btn:hover {
+  background: #f2f3f5;
+}
+.octo-doc-more-btn.is-active {
+  background: #f2f3f5;
+  color: #1f2329;
+}
+.octo-doc-more-glyph {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+/* Dropdown panel: 248px, 8px radius, soft shadow, white — anchored top-right under the trigger. */
+.octo-doc-more-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  width: 248px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 6px 0;
+  overflow: hidden;
+}
+/* Info head: light-grey band with the creator (avatar + name) and the created-on line. */
+.octo-doc-more-head {
+  background: #f7f8fa;
+  padding: 16px;
+  margin: -6px 0 6px;
+}
+.octo-doc-more-creator {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.octo-doc-more-avatar {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #e8eaf0;
+  color: #646a73;
+  font-size: 13px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+}
+.octo-doc-more-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2329;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.octo-doc-more-created {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #8a919e;
+}
+.octo-doc-more-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+/* 40px rows: 20px icon + 12px gap + 14px label, hover tint. */
+.octo-doc-more-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  border: none;
+  background: transparent;
+  color: #1f2329;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+.octo-doc-more-item:hover {
+  background: #f2f3f5;
+}
+.octo-doc-more-item:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.octo-doc-more-item:disabled:hover {
+  background: transparent;
+}
+.octo-doc-more-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: #646a73;
+}
+.octo-doc-more-rowicon {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.octo-doc-more-label {
+  flex: 1;
+  min-width: 0;
+}
+/* Delete row: red icon + label, softer red hover; separated + set 4px lower to prevent mis-clicks. */
+.octo-doc-more-sep {
+  height: 1px;
+  background: #eff0f1;
+  margin: 4px 0;
+}
+.octo-doc-more-danger-group {
+  padding-top: 4px;
+}
+.octo-doc-more-item.is-danger {
+  color: #f5222d;
+}
+.octo-doc-more-item.is-danger .octo-doc-more-icon {
+  color: #f5222d;
+}
+.octo-doc-more-item.is-danger:hover {
+  background: #fef0f0;
+}
+
 
 /* Version history (feature #4 §1) */
 .octo-version-panel {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -74,9 +74,10 @@
     "undo": "Undo",
     "redo": "Redo",
     "codeLanguageAuto": "auto",
-    "history": "History",
+    "history": "Version history",
     "comments": "Comments",
     "members": "Members",
+    "more": "More",
     "exportMarkdown": "Export as Markdown",
     "exportError": "Couldn't export this document. Please try again.",
     "exportSignedLinkNotice": "Note: images and attachments are signed links and may expire. Once expired, reopen the source document to fetch them again, or download them manually."
@@ -283,6 +284,10 @@
     "copyLink": "Copy link",
     "linkCopied": "Link copied",
     "openInNewPage": "Open in new page"
+  },
+  "moreMenu": {
+    "createdPrefix": "Created on",
+    "unknownCreator": "Unknown creator"
   },
   "error": {
     "permission": {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -282,7 +282,6 @@
   "standalone": {
     "copyLink": "Copy link",
     "linkCopied": "Link copied",
-    "openInApp": "Open in App",
     "openInNewPage": "Open in new page"
   },
   "error": {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -282,7 +282,8 @@
   "standalone": {
     "copyLink": "Copy link",
     "linkCopied": "Link copied",
-    "openInApp": "Open in App"
+    "openInApp": "Open in App",
+    "openInNewPage": "Open in new page"
   },
   "error": {
     "permission": {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -279,6 +279,11 @@
     "invalidUrl": "Please enter a valid http/https URL.",
     "failed": "Could not fetch link details."
   },
+  "standalone": {
+    "copyLink": "Copy link",
+    "linkCopied": "Link copied",
+    "openInApp": "Open in App"
+  },
   "error": {
     "permission": {
       "forbidden": "You no longer have access to this document.",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -282,7 +282,8 @@
   "standalone": {
     "copyLink": "复制链接",
     "linkCopied": "链接已复制",
-    "openInApp": "在应用中打开"
+    "openInApp": "在应用中打开",
+    "openInNewPage": "在新页面打开"
   },
   "error": {
     "permission": {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -74,9 +74,10 @@
     "undo": "撤销",
     "redo": "重做",
     "codeLanguageAuto": "自动",
-    "history": "历史",
+    "history": "历史版本",
     "comments": "评论",
     "members": "成员",
+    "more": "更多",
     "exportMarkdown": "导出为 Markdown",
     "exportError": "导出文档失败，请重试。",
     "exportSignedLinkNotice": "注意：图片/附件为签名链接，可能过期；过期后请回原文档重新获取或手动下载。"
@@ -283,6 +284,10 @@
     "copyLink": "复制链接",
     "linkCopied": "链接已复制",
     "openInNewPage": "在新页面打开"
+  },
+  "moreMenu": {
+    "createdPrefix": "创建于",
+    "unknownCreator": "未知创建者"
   },
   "error": {
     "permission": {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -279,6 +279,11 @@
     "invalidUrl": "请输入有效的 http/https 链接。",
     "failed": "无法获取链接信息。"
   },
+  "standalone": {
+    "copyLink": "复制链接",
+    "linkCopied": "链接已复制",
+    "openInApp": "在应用中打开"
+  },
   "error": {
     "permission": {
       "forbidden": "你已无权访问该文档。",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -282,7 +282,6 @@
   "standalone": {
     "copyLink": "复制链接",
     "linkCopied": "链接已复制",
-    "openInApp": "在应用中打开",
     "openInNewPage": "在新页面打开"
   },
   "error": {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -6,7 +6,7 @@
 
 export { DocsModule } from './module.tsx'
 export { EditorShell } from './editor/EditorShell.tsx'
-export { StandaloneDocPage, parseStandaloneDocId } from './pages/StandaloneDocPage.tsx'
+export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath } from './pages/StandaloneDocPage.tsx'
 export { buildDocumentName, parseDocumentName } from './documentName/index.ts'
 export { COLLAB_FIELD, SCHEMA_VERSION } from './schema/index.ts'
 export type { Role } from './auth/roles.ts'

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -6,7 +6,7 @@
 
 export { DocsModule } from './module.tsx'
 export { EditorShell } from './editor/EditorShell.tsx'
-export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath } from './pages/StandaloneDocPage.tsx'
+export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn } from './pages/StandaloneDocPage.tsx'
 export { buildDocumentName, parseDocumentName } from './documentName/index.ts'
 export { COLLAB_FIELD, SCHEMA_VERSION } from './schema/index.ts'
 export type { Role } from './auth/roles.ts'

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -6,6 +6,7 @@
 
 export { DocsModule } from './module.tsx'
 export { EditorShell } from './editor/EditorShell.tsx'
+export { StandaloneDocPage, parseStandaloneDocId } from './pages/StandaloneDocPage.tsx'
 export { buildDocumentName, parseDocumentName } from './documentName/index.ts'
 export { COLLAB_FIELD, SCHEMA_VERSION } from './schema/index.ts'
 export type { Role } from './auth/roles.ts'

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -6,7 +6,7 @@
 
 export { DocsModule } from './module.tsx'
 export { EditorShell } from './editor/EditorShell.tsx'
-export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn } from './pages/StandaloneDocPage.tsx'
+export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from './pages/StandaloneDocPage.tsx'
 export { buildDocumentName, parseDocumentName } from './documentName/index.ts'
 export { COLLAB_FIELD, SCHEMA_VERSION } from './schema/index.ts'
 export type { Role } from './auth/roles.ts'

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -28,8 +28,8 @@ type Responder = (
 export class MockApiClient implements APIClient {
   /** Test hook: set a responder to control returned data / thrown errors. */
   responder: Responder | null = null
-  /** Recorded calls for assertions. */
-  calls: Array<{ method: string; url: string; body?: unknown }> = []
+  /** Recorded calls for assertions (includes per-request `config` so tests can assert headers). */
+  calls: Array<{ method: string; url: string; body?: unknown; config?: ApiRequestConfig }> = []
 
   private async dispatch(
     method: 'get' | 'post' | 'put' | 'patch' | 'delete',
@@ -37,7 +37,7 @@ export class MockApiClient implements APIClient {
     body: unknown,
     config?: ApiRequestConfig,
   ): Promise<ApiResponse> {
-    this.calls.push({ method, url, body })
+    this.calls.push({ method, url, body, config })
     if (!this.responder) {
       return { data: {}, status: 200 }
     }

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -40,6 +40,16 @@ export interface ApiRequestConfig {
    * back instead of parsed JSON (feature #4 §7). Defaults to axios' `'json'`.
    */
   responseType?: 'json' | 'arraybuffer'
+  /**
+   * Per-request headers, merged over the global request interceptor's headers by axios
+   * (request-config headers win). The standalone `/d/:docId` preflight uses this to carry an
+   * explicit `X-Space-Id`: it mounts via the Layout early-return, before the app shell restores
+   * `currentSpaceId`, so the global `spaceIdCallback` interceptor reads an empty space and injects
+   * no `X-Space-Id` — the backend's by-space middleware then rejects the bare `getDoc` (400
+   * space_required / 404 space mismatch). Passing the space here makes the preflight the source of
+   * truth for its own space header. In-shell callers omit this and keep relying on the interceptor.
+   */
+  headers?: Record<string, string>
 }
 
 /**

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -9,10 +9,20 @@ import { resolveDocTarget, clearDocTarget, DocsHome } from './DocsHome.tsx'
 // render tests exercise target-resolution / navigation without mounting the real editor.
 // The marker surfaces the docId it was addressed with and the onBack affordance.
 vi.mock('../editor/EditorShell.tsx', () => ({
-  EditorShell: (props: { docId: string; onBack?: () => void; headerRight?: React.ReactNode }) => (
+  EditorShell: (props: {
+    docId: string
+    onBack?: () => void
+    headerRight?: React.ReactNode
+    onOpenInNewPage?: () => void
+  }) => (
     <div data-testid="editor-shell">
       <span data-testid="editor-doc">{props.docId}</span>
       <div data-testid="editor-header-right">{props.headerRight}</div>
+      {props.onOpenInNewPage && (
+        <button type="button" data-testid="editor-open-new-page" onClick={props.onOpenInNewPage}>
+          docs.standalone.openInNewPage
+        </button>
+      )}
       {props.onBack && (
         <button type="button" data-testid="editor-back" onClick={props.onBack}>
           back
@@ -245,10 +255,9 @@ describe('DocsHome navigation (split-pane)', () => {
     await waitFor(() => expect(screen.getByText('Doc A')).toBeTruthy())
     fireEvent.click(screen.getByText('Doc A'))
 
-    // The entry is injected into the editor header (headerRight), not the list row.
-    const right = screen.getByTestId('editor-header-right')
-    expect(right.textContent).toContain('docs.standalone.openInNewPage')
-    const entry = screen.getByText(/docs\.standalone\.openInNewPage/)
+    // The entry is wired into the editor via onOpenInNewPage (it now lives in the header ≡ menu,
+    // no longer a resident headerRight button).
+    const entry = screen.getByTestId('editor-open-new-page')
     fireEvent.click(entry)
 
     // It opens the clean standalone deep-link in a new tab — no in-app navigation.

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -265,6 +265,44 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
+  it('AC-1 (XIN-420): a multi-session user opens the standalone link carrying the current session sid', async () => {
+    const openSpy = vi.fn()
+    Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
+    // Multi-session in-shell URL: the host's RouteManager re-push collapses the docs route to
+    // `/docs?sid=…`, so the active session's sid rides on window.location. Give the stub a real
+    // origin too — withReturnSid rebuilds the target against it.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { origin: 'https://app.example.com', search: '?sid=s_active', assign: assignSpy },
+    })
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return {
+          data: {
+            total: 1,
+            items: [{ docId: 'd_a', title: 'Doc A', ownerId: 'u_self', role: 'admin' }],
+          },
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('Doc A')).toBeTruthy())
+    fireEvent.click(screen.getByText('Doc A'))
+    fireEvent.click(screen.getByTestId('editor-open-new-page'))
+
+    // The new tab must carry the active sid so its sid-keyed load() hits the right bucket. Without
+    // it a multi-session user's new tab reads the empty-sid bucket, misses, and (since XIN-392's
+    // strict findUniqueStoredSession refuses to guess) bounces to login instead of the document.
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a?sid=s_active', '_blank', 'noopener,noreferrer')
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
   it('mounts the editor inline from a persisted target on first paint (deep-link / refresh)', async () => {
     window.sessionStorage.setItem(
       TARGET_KEY,

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
 import { resolveDocTarget, clearDocTarget, DocsHome } from './DocsHome.tsx'
@@ -8,9 +9,10 @@ import { resolveDocTarget, clearDocTarget, DocsHome } from './DocsHome.tsx'
 // render tests exercise target-resolution / navigation without mounting the real editor.
 // The marker surfaces the docId it was addressed with and the onBack affordance.
 vi.mock('../editor/EditorShell.tsx', () => ({
-  EditorShell: (props: { docId: string; onBack?: () => void }) => (
+  EditorShell: (props: { docId: string; onBack?: () => void; headerRight?: React.ReactNode }) => (
     <div data-testid="editor-shell">
       <span data-testid="editor-doc">{props.docId}</span>
+      <div data-testid="editor-header-right">{props.headerRight}</div>
       {props.onBack && (
         <button type="button" data-testid="editor-back" onClick={props.onBack}>
           back
@@ -219,6 +221,39 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(JSON.parse(window.sessionStorage.getItem(TARGET_KEY)!)).toMatchObject({ doc: 'd_a' })
     expect(assignSpy).not.toHaveBeenCalled()
     expect(String(replaceStateSpy.mock.calls.at(-1)![2])).toContain('doc=d_a')
+  })
+
+  it('AC-1: the open doc exposes an "Open in new page" entry that opens the /d/:docId standalone link', async () => {
+    const openSpy = vi.fn()
+    Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return {
+          data: {
+            total: 1,
+            items: [{ docId: 'd_a', title: 'Doc A', ownerId: 'u_self', role: 'admin' }],
+          },
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('Doc A')).toBeTruthy())
+    fireEvent.click(screen.getByText('Doc A'))
+
+    // The entry is injected into the editor header (headerRight), not the list row.
+    const right = screen.getByTestId('editor-header-right')
+    expect(right.textContent).toContain('docs.standalone.openInNewPage')
+    const entry = screen.getByText(/docs\.standalone\.openInNewPage/)
+    fireEvent.click(entry)
+
+    // It opens the clean standalone deep-link in a new tab — no in-app navigation.
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
+    expect(assignSpy).not.toHaveBeenCalled()
   })
 
   it('mounts the editor inline from a persisted target on first paint (deep-link / refresh)', async () => {

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -436,16 +436,7 @@ export function DocsHome() {
         onExit={backToList}
         onTitleSaved={onTitleSaved}
         onDeleted={onDocDeleted}
-        headerRight={
-          <button
-            type="button"
-            className="octo-tb-btn octo-doc-open-new-page"
-            title={t('docs.standalone.openInNewPage')}
-            onClick={() => onOpenInNewPage(docId)}
-          >
-            ⧉ {t('docs.standalone.openInNewPage')}
-          </button>
-        }
+        onOpenInNewPage={() => onOpenInNewPage(docId)}
       />
     ),
     [uid, space, folder, names, onTitleSaved, backToList, onDocDeleted, onOpenInNewPage],

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -4,6 +4,7 @@ import { EditorShell } from '../editor/EditorShell.tsx'
 import '../editor/styles.css'
 import { DEFAULT_DOC_SPACE, DEFAULT_DOC_FOLDER, DEFAULT_DOC_ID } from '../config.ts'
 import { listDocs, createDoc, type DocListItem } from './docsApi.ts'
+import { withReturnSid } from './StandaloneDocPage.tsx'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { formatRelative, formatAbsolute } from '../versions/format.ts'
 
@@ -410,9 +411,20 @@ export function DocsHome() {
   // "Open in new page" (AC-1): open the current doc as a standalone full-window `/d/:docId` link
   // in a new browser tab — the clean, shareable cold-load entry that lives outside the app shell.
   // The id only ever contains documentName-safe chars, so the built path stays a valid /d/ route.
+  //
+  // Carry the current session's sid (XIN-420, same gap the XIN-398 post-login return path fixed):
+  // the host's RouteManager re-push collapses the in-shell docs route to `/docs?sid=…`, so a
+  // multi-session user's active sid rides on window.location. Route it through withReturnSid
+  // (query-only, percent-encoded, safe-path re-checked) so the new tab's sid-keyed load() hits the
+  // right bucket instead of missing the empty-sid bucket and — since XIN-392's strict
+  // findUniqueStoredSession refuses to guess an identity — bouncing to login. An empty sid (single
+  // / empty-sid session, no ambiguity) makes withReturnSid a no-op: the plain /d/:docId cold-load
+  // recovers on its own, so we never append a meaningless `?sid=`.
   const onOpenInNewPage = useCallback((id: string) => {
     if (typeof window !== 'undefined') {
-      window.open(`/d/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
+      const sid = new URLSearchParams(window.location.search).get('sid')
+      const target = withReturnSid(`/d/${encodeURIComponent(id)}`, sid)
+      window.open(target, '_blank', 'noopener,noreferrer')
     }
   }, [])
 

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -407,6 +407,15 @@ export function DocsHome() {
     [selectedDocId, backToList],
   )
 
+  // "Open in new page" (AC-1): open the current doc as a standalone full-window `/d/:docId` link
+  // in a new browser tab — the clean, shareable cold-load entry that lives outside the app shell.
+  // The id only ever contains documentName-safe chars, so the built path stays a valid /d/ route.
+  const onOpenInNewPage = useCallback((id: string) => {
+    if (typeof window !== 'undefined') {
+      window.open(`/d/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
+    }
+  }, [])
+
   // Build the editor element. `onBack` (header "← back" control) is passed ONLY on the inline
   // standalone/test path; in the routeRight production path the left list is always resident, so
   // the header back button is redundant and omitted (#2). `onExit` (= backToList) is ALWAYS
@@ -427,9 +436,19 @@ export function DocsHome() {
         onExit={backToList}
         onTitleSaved={onTitleSaved}
         onDeleted={onDocDeleted}
+        headerRight={
+          <button
+            type="button"
+            className="octo-tb-btn octo-doc-open-new-page"
+            title={t('docs.standalone.openInNewPage')}
+            onClick={() => onOpenInNewPage(docId)}
+          >
+            ⧉ {t('docs.standalone.openInNewPage')}
+          </button>
+        }
       />
     ),
-    [uid, space, folder, names, onTitleSaved, backToList, onDocDeleted],
+    [uid, space, folder, names, onTitleSaved, backToList, onDocDeleted, onOpenInNewPage],
   )
 
   const openDoc = useCallback(

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -8,7 +8,7 @@ import { createMockWKApp } from '../octoweb/mock.ts'
 // AC-12 acceptance: the standalone page's boundary states are driven entirely by the GET
 // /api/v1/docs/{docId} PREFLIGHT, so they must render WITHOUT ever mounting Tiptap/Yjs/
 // Hocuspocus — i.e. with NO WebSocket dependency. The marker echoes the docId it was addressed
-// with and renders whatever headerRight (Copy link / Open in App) the page injected.
+// with and renders whatever headerRight (Copy link) the page injected.
 vi.mock('../editor/EditorShell.tsx', () => ({
   EditorShell: (props: { docId: string; onBack?: () => void; headerRight?: ReactNode }) => (
     <div data-testid="editor-shell">
@@ -175,7 +175,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(wk.apiClient.calls.some((c) => c.url.startsWith('/docs/'))).toBe(false)
   })
 
-  it('mounts the editor with Copy link + Open in App injected when the preflight succeeds', async () => {
+  it('mounts the editor with Copy link injected (no "Open in App") when the preflight succeeds', async () => {
     wk.apiClient.responder = (method, url) => {
       if (method === 'get' && url === '/docs/d_ok') {
         return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
@@ -190,6 +190,8 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // The standalone chrome is injected via EditorShell's headerRight prop.
     const right = screen.getByTestId('editor-header-right')
     expect(right.textContent).toContain('docs.standalone.copyLink')
-    expect(right.textContent).toContain('docs.standalone.openInApp')
+    // The reverse "Open in App" exit was removed (boss change): standalone links are opened from
+    // an external chat, not from inside the shell, so there is nothing to return to.
+    expect(right.textContent).not.toContain('docs.standalone.openInApp')
   })
 })

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -47,6 +47,7 @@ import {
   standaloneFallbackSpace,
   persistStandaloneReturn,
   consumeStandaloneReturn,
+  withReturnSid,
   STANDALONE_RETURN_KEY,
 } from './StandaloneDocPage.tsx'
 
@@ -387,6 +388,50 @@ describe('standalone return target — open-redirect-safe post-login bounce (blo
     )
     // The stashed target is a safe relative path that the post-login flow can bounce back to.
     expect(consumeStandaloneReturn()).toBe('/d/d_locked_out')
+  })
+})
+
+describe('withReturnSid — carry the current session sid on the post-login /d/:docId reload (XIN-398)', () => {
+  it('appends the sid to a sid-less standalone target so the reload hits the sid-keyed bucket', () => {
+    // The stashed return target has no ?sid=; carrying the just-authenticated session's own sid
+    // lets the reloaded /d/:docId resolve the right session directly instead of relying on the
+    // now-strict multi-session recovery (which would loop back to login).
+    expect(withReturnSid('/d/d_abc', 'fresh6')).toBe('/d/d_abc?sid=fresh6')
+    expect(withReturnSid('/d/d_abc/', 'fresh6')).toBe('/d/d_abc/?sid=fresh6')
+  })
+
+  it('leaves a target that already carries a sid untouched (no doubling)', () => {
+    expect(withReturnSid('/d/d_abc?sid=already', 'fresh6')).toBe('/d/d_abc?sid=already')
+  })
+
+  it('is a no-op when there is no sid to carry (session in the empty-sid bucket)', () => {
+    expect(withReturnSid('/d/d_abc', null)).toBe('/d/d_abc')
+    expect(withReturnSid('/d/d_abc', undefined)).toBe('/d/d_abc')
+    expect(withReturnSid('/d/d_abc', '')).toBe('/d/d_abc')
+  })
+
+  it('percent-encodes the sid so it cannot smuggle a second query, path, or host (XIN-392 safety)', () => {
+    // A sid can only ever come from our own localStorage keys, but encode defensively regardless:
+    // the value must land as a single, inert query parameter, never a new path/host/query segment.
+    expect(withReturnSid('/d/d_abc', 'a&foo=bar')).toBe('/d/d_abc?sid=a%26foo%3Dbar')
+    expect(withReturnSid('/d/d_abc', 'x#frag')).toBe('/d/d_abc?sid=x%23frag')
+    expect(withReturnSid('/d/d_abc', '/evil')).toBe('/d/d_abc?sid=%2Fevil')
+    // The pathname is unchanged, so the result still resolves to the same /d/:docId and stays safe.
+    for (const sid of ['a&foo=bar', 'x#frag', '/evil']) {
+      const out = withReturnSid('/d/d_abc', sid)
+      expect(parseStandaloneDocId(new URL(out, window.location.origin).pathname)).toBe('d_abc')
+    }
+  })
+
+  it('preserves the XIN-392 gates end to end: consume → withReturnSid stays a safe /d/:docId link', () => {
+    window.sessionStorage.setItem(STANDALONE_RETURN_KEY, '/d/d_deep')
+    const consumed = consumeStandaloneReturn()
+    expect(consumed).toBe('/d/d_deep')
+    const target = withReturnSid(consumed!, 'sid42')
+    expect(target).toBe('/d/d_deep?sid=sid42')
+    // Re-stashing the sid-bearing target still passes every consume-side gate.
+    window.sessionStorage.setItem(STANDALONE_RETURN_KEY, target)
+    expect(consumeStandaloneReturn()).toBe('/d/d_deep?sid=sid42')
   })
 })
 

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -230,4 +230,40 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
     expect(writeText).toHaveBeenCalledWith(window.location.href)
   })
+
+  it('AC-6: after copying, a menu-external "Link copied" toast appears (visible even though the menu row closes)', async () => {
+    // Reviewer's blocker (XIN-386): the old in-row "Link copied" label was dead — selecting the row
+    // closes the ≡ menu, so the panel that hosted the label unmounts and the user never sees it.
+    // The fix moves the confirmation to a page-level, menu-external toast. This test locks that in:
+    // the toast is rendered OUTSIDE the (here-mocked) EditorShell/menu, and it never rode on the row.
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('lead-copy-link')).toBeTruthy())
+    // No toast before the action.
+    expect(screen.queryByText('docs.standalone.linkCopied')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('lead-copy-link'))
+
+    // The toast becomes visible after the copy resolves — proving the confirmation survives the
+    // menu closing (the menu row itself is mocked away here, yet the toast still shows).
+    const toast = await screen.findByText('docs.standalone.linkCopied')
+    expect(toast).toBeTruthy()
+    expect(toast.getAttribute('role')).toBe('status')
+    // The toast is document-external / menu-external: it is NOT inside the ≡ menu lead-row subtree.
+    expect(screen.getByTestId('editor-more-lead').contains(toast)).toBe(false)
+
+    // The dead in-row "copied" label is gone: the menu row label stays the action name, never flips.
+    expect(screen.getByTestId('lead-copy-link').textContent).toContain('docs.standalone.copyLink')
+    expect(screen.getByTestId('lead-copy-link').textContent).not.toContain('docs.standalone.linkCopied')
+  })
 })

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -343,12 +343,33 @@ describe('standalone return target — open-redirect-safe post-login bounce (blo
       'd/relative', // not rooted at /
       '', // empty
       '/', // bare root carries no doc target
+      // XIN-392 P1-1: control chars smuggled after the first `/`. The old byte-check saw only
+      // path[0]/path[1] and missed the `//host` the WHATWG URL parser normalizes these into.
+      '/\n/evil.example.com', // newline → normalizes to scheme-relative //evil
+      '/\t/evil.example.com', // tab → same
+      '/\r/evil.example.com', // CR → same
+      '/d/\td_abc', // control char even inside an otherwise /d/ path
+      // XIN-392 P2-2: same-origin but NOT a standalone doc page — must not be a post-login bounce
+      // target (a tampered value can't steer the user to another app page after sign-in).
+      '/settings',
+      '/oidc/bind',
+      '/docs?doc=x',
+      '/d', // namespace root, not a concrete /d/:docId
+      '/d/', // empty id
+      '/d/a:b', // malformed id (parseStandaloneDocId → null)
     ]
     for (const bad of hostile) {
       window.sessionStorage.setItem(STANDALONE_RETURN_KEY, bad)
       expect(consumeStandaloneReturn()).toBeNull()
       // Even a rejected value is cleared, so it can't leak into a subsequent login.
       expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBeNull()
+    }
+  })
+
+  it('accepts a safe same-origin /d/:docId target (with and without a query string)', () => {
+    for (const good of ['/d/d_abc', '/d/d_abc/', '/d/DOC-9_x?sid=xyz']) {
+      window.sessionStorage.setItem(STANDALONE_RETURN_KEY, good)
+      expect(consumeStandaloneReturn()).toBe(good)
     }
   })
 

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -261,7 +261,12 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(lead.textContent).not.toContain('docs.standalone.openInApp')
   })
 
-  it('AC-3: clicking the Copy link menu row copies the current URL to the clipboard', async () => {
+  it('AC-3: clicking the Copy link menu row copies the CANONICAL /d/:docId link, stripping ?sid', async () => {
+    // Copy-link must NOT leak the sharer's session: the live URL can carry `?sid=` (added when the
+    // doc is opened in a new page / returned to post-login). The copied value is the clean canonical
+    // link (origin + pathname), with the whole query stripped, so a shared link never carries the
+    // sharer's sid.
+    window.history.pushState({}, '', '/d/d_ok?sid=sharer-secret')
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
 
@@ -278,7 +283,11 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     fireEvent.click(screen.getByTestId('lead-copy-link'))
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
-    expect(writeText).toHaveBeenCalledWith(window.location.href)
+    const copied = writeText.mock.calls[0][0] as string
+    expect(copied).toBe(`${window.location.origin}/d/d_ok`)
+    // The sharer's sid never rides along on the shared link.
+    expect(copied).not.toContain('sid')
+    expect(copied).not.toContain('?')
   })
 
   it('AC-6: after copying, a menu-external "Link copied" toast appears (visible even though the menu row closes)', async () => {
@@ -367,7 +376,10 @@ describe('StandaloneDocPage — cold-start preflight carries X-Space-Id from the
     // interceptor injects NO X-Space-Id. The backend's by-space middleware then rejects the bare
     // preflight (400 space_required / 404 space mismatch) and the page shows the not-found terminal.
     // The fix resolves the space from the SAME cached localStorage key the room addressing uses and
-    // passes it as an explicit header on the preflight. This assertion FAILS on the old bare getDoc.
+    // passes it as an explicit header on the preflight. This asserts the DOCS-SIDE contract (the page
+    // puts the resolved space into the preflight config header); the real wire-level forwarding — host
+    // APIClient forwarding config.headers to axios, which was the XIN-424 fake-green — is covered by
+    // packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts.
     window.localStorage.setItem('currentSpaceId', 'space-abc')
     expect(wk.shared.currentSpaceId).toBeFalsy() // shell has not restored the live space yet
 

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -346,6 +346,74 @@ describe('StandaloneDocPage — cold-start addressing uses the cached space, not
   })
 })
 
+describe('StandaloneDocPage — cold-start preflight carries X-Space-Id from the cached space (by-space isolation)', () => {
+  it('sends GET /docs/:id with header X-Space-Id = cached currentSpaceId even though wk.shared.currentSpaceId is empty', async () => {
+    // Root cause: the standalone page mounts via the Layout early-return, BEFORE the app shell
+    // restores currentSpaceId, so wk.shared.currentSpaceId is empty and the global spaceIdCallback
+    // interceptor injects NO X-Space-Id. The backend's by-space middleware then rejects the bare
+    // preflight (400 space_required / 404 space mismatch) and the page shows the not-found terminal.
+    // The fix resolves the space from the SAME cached localStorage key the room addressing uses and
+    // passes it as an explicit header on the preflight. This assertion FAILS on the old bare getDoc.
+    window.localStorage.setItem('currentSpaceId', 'space-abc')
+    expect(wk.shared.currentSpaceId).toBeFalsy() // shell has not restored the live space yet
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
+    expect(preflight).toBeTruthy()
+    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-abc')
+    // Consistency: the room the editor joins uses the same resolved space as the preflight header.
+    expect(screen.getByTestId('editor-space').textContent).toBe('space-abc')
+  })
+
+  it('seeds the empty live currentSpaceId from the cached value at standalone mount (defense in depth)', async () => {
+    // The primary fix is the explicit header, but the page also restores wk.shared.currentSpaceId
+    // from the cached key when empty, so any in-shell-shared logic the EditorShell touches sees it.
+    window.localStorage.setItem('currentSpaceId', 'space-abc')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    expect(wk.shared.currentSpaceId).toBe('space-abc')
+  })
+
+  it('never overwrites a real live currentSpaceId with the cached value', async () => {
+    // In-shell (or any mount where the live space is already set) must be unaffected: the guarded
+    // restore only fills an EMPTY space, so a real current space is preserved and the preflight
+    // header/room follow the live space, not the stale cached one.
+    window.localStorage.setItem('currentSpaceId', 'space-cached')
+    wk.shared.currentSpaceId = 'space-live'
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    expect(wk.shared.currentSpaceId).toBe('space-live')
+    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
+    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-live')
+    expect(screen.getByTestId('editor-space').textContent).toBe('space-live')
+  })
+})
+
 describe('standalone return target — open-redirect-safe post-login bounce (blocker 4)', () => {
   it('round-trips a safe same-origin /d/:docId target through persist → consume', () => {
     window.history.pushState({}, '', '/d/d_abc?sid=xyz')

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -21,6 +21,13 @@ vi.mock('../editor/EditorShell.tsx', () => ({
       <span data-testid="editor-doc">{props.docId}</span>
       <span data-testid="editor-space">{props.space}</span>
       <span data-testid="editor-creator-nickname-only">{String(!!props.creatorNicknameOnly)}</span>
+      {/* The shared EditorShell renders its header "← back" control iff it receives onBack; expose
+          that here so a test can assert the standalone editor view no longer offers it (XIN-416). */}
+      {props.onBack && (
+        <button data-testid="editor-back" onClick={props.onBack}>
+          back
+        </button>
+      )}
       <ul data-testid="editor-more-lead">
         {(props.moreMenuLeadItems ?? []).map((it) => (
           <li key={it.key}>
@@ -231,6 +238,13 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
     await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
     expect(screen.getByTestId('editor-doc').textContent).toBe('d_ok')
+
+    // XIN-416 (boss real-device acceptance): the standalone editor view no longer shows a
+    // "← 全部文档" return link. A standalone `/d/:docId` share page is a pure, self-contained
+    // surface with no "back to all documents" entry, so the page passes NO onBack to the shared
+    // EditorShell and the header renders no back control. (In-shell EditorShell, which still gets
+    // onBack from DocsHome, is unaffected — verified separately in EditorShell.test.tsx.)
+    expect(screen.queryByTestId('editor-back')).toBeNull()
 
     // AC-2: Copy link is collapsed into the header ≡ "more" menu as its first (top) row — the
     // page injects it via EditorShell's moreMenuLeadItems, not a resident title-bar button.

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -10,9 +10,17 @@ import type { DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
 // Hocuspocus — i.e. with NO WebSocket dependency. The marker echoes the docId it was addressed
 // with and renders the ≡ "more" menu lead rows (Copy link) the page injected as clickable buttons.
 vi.mock('../editor/EditorShell.tsx', () => ({
-  EditorShell: (props: { docId: string; onBack?: () => void; moreMenuLeadItems?: DocMoreMenuItem[] }) => (
+  EditorShell: (props: {
+    docId: string
+    space?: string
+    onBack?: () => void
+    moreMenuLeadItems?: DocMoreMenuItem[]
+    creatorNicknameOnly?: boolean
+  }) => (
     <div data-testid="editor-shell">
       <span data-testid="editor-doc">{props.docId}</span>
+      <span data-testid="editor-space">{props.space}</span>
+      <span data-testid="editor-creator-nickname-only">{String(!!props.creatorNicknameOnly)}</span>
       <ul data-testid="editor-more-lead">
         {(props.moreMenuLeadItems ?? []).map((it) => (
           <li key={it.key}>
@@ -36,6 +44,9 @@ import {
   StandaloneDocPage,
   parseStandaloneDocId,
   isStandaloneDocPath,
+  standaloneFallbackSpace,
+  persistStandaloneReturn,
+  consumeStandaloneReturn,
   STANDALONE_RETURN_KEY,
 } from './StandaloneDocPage.tsx'
 
@@ -48,6 +59,7 @@ let wk: ReturnType<typeof createMockWKApp>
 
 beforeEach(() => {
   window.sessionStorage.clear()
+  window.localStorage.clear()
   wk = createMockWKApp()
   setWKApp(wk)
 })
@@ -56,6 +68,7 @@ afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
   window.sessionStorage.clear()
+  window.localStorage.clear()
 })
 
 describe('parseStandaloneDocId', () => {
@@ -265,5 +278,111 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // The dead in-row "copied" label is gone: the menu row label stays the action name, never flips.
     expect(screen.getByTestId('lead-copy-link').textContent).toContain('docs.standalone.copyLink')
     expect(screen.getByTestId('lead-copy-link').textContent).not.toContain('docs.standalone.linkCopied')
+  })
+})
+
+describe('standaloneFallbackSpace — cold-start cross-space addressing (blocker 3)', () => {
+  it('prefers the live currentSpaceId when the shell has one', () => {
+    window.localStorage.setItem('currentSpaceId', 's_cached')
+    expect(standaloneFallbackSpace('s_live')).toBe('s_live')
+  })
+
+  it('falls back to the cached localStorage currentSpaceId when the shell has none', () => {
+    // The standalone page mounts via the Layout early-return, BEFORE the shell restores
+    // currentSpaceId — so wk.shared.currentSpaceId is empty on a cold cross-space deep link. The
+    // cached key is the user's real last space; using it avoids addressing the wrong room.
+    window.localStorage.setItem('currentSpaceId', 's_cached')
+    expect(standaloneFallbackSpace('')).toBe('s_cached')
+    expect(standaloneFallbackSpace(undefined)).toBe('s_cached')
+  })
+
+  it('falls back to the deploy default only when neither is available', () => {
+    expect(standaloneFallbackSpace('')).toBe('demo') // DEFAULT_DOC_SPACE
+  })
+})
+
+describe('StandaloneDocPage — cold-start addressing uses the cached space, not the deploy default (blocker 3)', () => {
+  it('addresses the EditorShell to the cached currentSpaceId when the preflight carries no documentName', async () => {
+    // Repro: 200 preflight WITHOUT documentName + a cached currentSpaceId in localStorage. Before
+    // the fix the page addressed DEFAULT_DOC_SPACE ("demo"), mounting the editor against the wrong
+    // room. It must instead use the cached space so the shared doc opens in the right space.
+    window.localStorage.setItem('currentSpaceId', 's_real')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        // No documentName in the payload → the addressing memo hits the fallback branch.
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    expect(screen.getByTestId('editor-space').textContent).toBe('s_real')
+    expect(screen.getByTestId('editor-space').textContent).not.toBe('demo')
+  })
+})
+
+describe('standalone return target — open-redirect-safe post-login bounce (blocker 4)', () => {
+  it('round-trips a safe same-origin /d/:docId target through persist → consume', () => {
+    window.history.pushState({}, '', '/d/d_abc?sid=xyz')
+    persistStandaloneReturn()
+    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBe('/d/d_abc?sid=xyz')
+    expect(consumeStandaloneReturn()).toBe('/d/d_abc?sid=xyz')
+    // Consumed once — the key is cleared so a later unrelated login can't inherit a stale target.
+    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBeNull()
+    expect(consumeStandaloneReturn()).toBeNull()
+  })
+
+  it('rejects open-redirect payloads and still clears the key', () => {
+    const hostile = [
+      '//evil.example.com', // scheme-relative → off-origin
+      '/\\evil.example.com', // backslash-smuggled → some browsers normalize to //evil
+      'https://evil.example.com/d/x', // absolute URL
+      'javascript:alert(1)', // script payload
+      'd/relative', // not rooted at /
+      '', // empty
+      '/', // bare root carries no doc target
+    ]
+    for (const bad of hostile) {
+      window.sessionStorage.setItem(STANDALONE_RETURN_KEY, bad)
+      expect(consumeStandaloneReturn()).toBeNull()
+      // Even a rejected value is cleared, so it can't leak into a subsequent login.
+      expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBeNull()
+    }
+  })
+
+  it('AC-11 anonymous entry: the sign-in terminal stashes a safe, consumable return target', async () => {
+    window.history.pushState({}, '', '/d/d_locked_out')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_locked_out') throw { response: { status: 401 } }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_locked_out" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.login')).toBeTruthy(),
+    )
+    // The stashed target is a safe relative path that the post-login flow can bounce back to.
+    expect(consumeStandaloneReturn()).toBe('/d/d_locked_out')
+  })
+})
+
+describe('StandaloneDocPage — creator name is nickname-only on the shared surface (blocker 5)', () => {
+  it('tells the EditorShell to resolve the creator from the nickname, never the verified real name', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    // The standalone page is an externally shareable surface: it must NOT expose the creator's
+    // verified real_name to a link holder. It flags the shell to use the nickname only.
+    expect(screen.getByTestId('editor-creator-nickname-only').textContent).toBe('true')
   })
 })

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -1,19 +1,27 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
+import type { DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
 
 // Replace the heavy collaborative editor with a lightweight marker. This is the crux of the
 // AC-12 acceptance: the standalone page's boundary states are driven entirely by the GET
 // /api/v1/docs/{docId} PREFLIGHT, so they must render WITHOUT ever mounting Tiptap/Yjs/
 // Hocuspocus — i.e. with NO WebSocket dependency. The marker echoes the docId it was addressed
-// with and renders whatever headerRight (Copy link) the page injected.
+// with and renders the ≡ "more" menu lead rows (Copy link) the page injected as clickable buttons.
 vi.mock('../editor/EditorShell.tsx', () => ({
-  EditorShell: (props: { docId: string; onBack?: () => void; headerRight?: ReactNode }) => (
+  EditorShell: (props: { docId: string; onBack?: () => void; moreMenuLeadItems?: DocMoreMenuItem[] }) => (
     <div data-testid="editor-shell">
       <span data-testid="editor-doc">{props.docId}</span>
-      <div data-testid="editor-header-right">{props.headerRight}</div>
+      <ul data-testid="editor-more-lead">
+        {(props.moreMenuLeadItems ?? []).map((it) => (
+          <li key={it.key}>
+            <button data-testid={`lead-${it.key}`} onClick={it.onClick}>
+              {it.label}
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   ),
 }))
@@ -175,7 +183,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(wk.apiClient.calls.some((c) => c.url.startsWith('/docs/'))).toBe(false)
   })
 
-  it('mounts the editor with Copy link injected (no "Open in App") when the preflight succeeds', async () => {
+  it('mounts the editor with Copy link pinned as the first ≡ menu row (no resident button, no "Open in App")', async () => {
     wk.apiClient.responder = (method, url) => {
       if (method === 'get' && url === '/docs/d_ok') {
         return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
@@ -187,11 +195,39 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
     await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
     expect(screen.getByTestId('editor-doc').textContent).toBe('d_ok')
-    // The standalone chrome is injected via EditorShell's headerRight prop.
-    const right = screen.getByTestId('editor-header-right')
-    expect(right.textContent).toContain('docs.standalone.copyLink')
+
+    // AC-2: Copy link is collapsed into the header ≡ "more" menu as its first (top) row — the
+    // page injects it via EditorShell's moreMenuLeadItems, not a resident title-bar button.
+    const lead = screen.getByTestId('editor-more-lead')
+    const rows = lead.querySelectorAll('button')
+    expect(rows.length).toBe(1)
+    expect(rows[0].getAttribute('data-testid')).toBe('lead-copy-link')
+    expect(rows[0].textContent).toContain('docs.standalone.copyLink')
+
+    // AC-1: no resident "Copy link" button remains in the standalone chrome.
+    expect(screen.queryByText('docs.standalone.copyLink', { selector: '.octo-doc-copy-link' })).toBeNull()
     // The reverse "Open in App" exit was removed (boss change): standalone links are opened from
     // an external chat, not from inside the shell, so there is nothing to return to.
-    expect(right.textContent).not.toContain('docs.standalone.openInApp')
+    expect(lead.textContent).not.toContain('docs.standalone.openInApp')
+  })
+
+  it('AC-3: clicking the Copy link menu row copies the current URL to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('lead-copy-link')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('lead-copy-link'))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText).toHaveBeenCalledWith(window.location.href)
   })
 })

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../members/useMemberNames.ts', () => ({
 import {
   StandaloneDocPage,
   parseStandaloneDocId,
+  isStandaloneDocPath,
   STANDALONE_RETURN_KEY,
 } from './StandaloneDocPage.tsx'
 
@@ -65,6 +66,29 @@ describe('parseStandaloneDocId', () => {
     expect(parseStandaloneDocId('/d/a:b')).toBeNull()
     // Only a top-level /d/ path, not a nested one.
     expect(parseStandaloneDocId('/x/d/abc')).toBeNull()
+  })
+})
+
+describe('isStandaloneDocPath', () => {
+  it('claims the whole /d namespace so malformed ids are still intercepted (AC-9)', () => {
+    // Well-formed links.
+    expect(isStandaloneDocPath('/d/d_abc123')).toBe(true)
+    expect(isStandaloneDocPath('/d/d_abc123/')).toBe(true)
+    // Malformed / empty ids: still in the namespace → intercepted → not-found terminal, NOT the
+    // app shell.
+    expect(isStandaloneDocPath('/d/')).toBe(true)
+    expect(isStandaloneDocPath('/d')).toBe(true)
+    expect(isStandaloneDocPath('/d/a:b')).toBe(true)
+  })
+  it('does not claim unrelated paths', () => {
+    expect(isStandaloneDocPath('/docs')).toBe(false)
+    expect(isStandaloneDocPath('/docs?doc=x')).toBe(false)
+    expect(isStandaloneDocPath('/')).toBe(false)
+    // A nested /d/ is not the top-level standalone namespace.
+    expect(isStandaloneDocPath('/x/d/abc')).toBe(false)
+    // A different top-level segment that merely starts with "d".
+    expect(isStandaloneDocPath('/docs/d/abc')).toBe(false)
+    expect(isStandaloneDocPath('/download')).toBe(false)
   })
 })
 
@@ -131,6 +155,24 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // The link is stashed so the post-login flow can bounce the user back to the doc.
     expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).not.toBeNull()
     expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
+  it('AC-9: a null docId (malformed /d/ link) renders not-found without any preflight', async () => {
+    // The host Layout claims the whole /d namespace and passes null here for a malformed/empty id
+    // (`/d/`, `/d/a:b`). The page must render the not-found terminal — NOT fall through to the app
+    // shell — and must issue NO preflight (there is nothing valid to fetch).
+    wk.apiClient.responder = (method, url) => {
+      throw new Error(`unexpected request ${method} ${url}`)
+    }
+
+    render(<StandaloneDocPage docId={null} />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy(),
+    )
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+    // No GET /docs/... preflight was attempted for a malformed id.
+    expect(wk.apiClient.calls.some((c) => c.url.startsWith('/docs/'))).toBe(false)
   })
 
   it('mounts the editor with Copy link + Open in App injected when the preflight succeeds', async () => {

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -179,6 +179,28 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(screen.queryByTestId('editor-shell')).toBeNull()
   })
 
+  it('XIN-408: a GET 401 with an onSessionExpired handler hands off (clears session + reloads) instead of dead-ending on the terminal', async () => {
+    // The page only mounts when a token IS present (Layout gate). A 401 here therefore means the
+    // loaded session is EXPIRED — the old behavior rendered the "session expired" terminal with only
+    // a Back control and no way to re-authenticate, a dead end. When the host wires onSessionExpired,
+    // the page must stash the return target and delegate to it (the host clears the dead session and
+    // reloads into the real login screen) rather than rendering the terminal.
+    const onSessionExpired = vi.fn()
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_expired') throw apiError(401)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_expired" onSessionExpired={onSessionExpired} />)
+
+    await waitFor(() => expect(onSessionExpired).toHaveBeenCalledTimes(1))
+    // The deep-link target is stashed so the post-login flow can bounce the user back to the doc.
+    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).not.toBeNull()
+    // No dead-end terminal, no editor: the host is navigating to the login screen.
+    expect(screen.queryByText('docs.error.permission.login')).toBeNull()
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
   it('AC-9: a null docId (malformed /d/ link) renders not-found without any preflight', async () => {
     // The host Layout claims the whole /d namespace and passes null here for a malformed/empty id
     // (`/d/`, `/d/a:b`). The page must render the not-found terminal — NOT fall through to the app

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// Replace the heavy collaborative editor with a lightweight marker. This is the crux of the
+// AC-12 acceptance: the standalone page's boundary states are driven entirely by the GET
+// /api/v1/docs/{docId} PREFLIGHT, so they must render WITHOUT ever mounting Tiptap/Yjs/
+// Hocuspocus — i.e. with NO WebSocket dependency. The marker echoes the docId it was addressed
+// with and renders whatever headerRight (Copy link / Open in App) the page injected.
+vi.mock('../editor/EditorShell.tsx', () => ({
+  EditorShell: (props: { docId: string; onBack?: () => void; headerRight?: ReactNode }) => (
+    <div data-testid="editor-shell">
+      <span data-testid="editor-doc">{props.docId}</span>
+      <div data-testid="editor-header-right">{props.headerRight}</div>
+    </div>
+  ),
+}))
+
+// useMemberNames pages the space-member seam; stub it to a stable empty map so these tests stay
+// focused on the preflight gate and chrome.
+vi.mock('../members/useMemberNames.ts', () => ({
+  useMemberNames: () => new Map<string, string>(),
+}))
+
+import {
+  StandaloneDocPage,
+  parseStandaloneDocId,
+  STANDALONE_RETURN_KEY,
+} from './StandaloneDocPage.tsx'
+
+/** Axios-style rejection shape the docs error handlers read (`err.response.status`). */
+function apiError(status: number) {
+  return { response: { status } }
+}
+
+let wk: ReturnType<typeof createMockWKApp>
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  wk = createMockWKApp()
+  setWKApp(wk)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  window.sessionStorage.clear()
+})
+
+describe('parseStandaloneDocId', () => {
+  it('extracts the docId from /d/:docId (with or without a trailing slash)', () => {
+    expect(parseStandaloneDocId('/d/d_abc123')).toBe('d_abc123')
+    expect(parseStandaloneDocId('/d/d_abc123/')).toBe('d_abc123')
+    expect(parseStandaloneDocId('/d/DOC-9_x')).toBe('DOC-9_x')
+  })
+  it('returns null for non-standalone paths', () => {
+    expect(parseStandaloneDocId('/docs')).toBeNull()
+    expect(parseStandaloneDocId('/docs?doc=x')).toBeNull()
+    expect(parseStandaloneDocId('/d/')).toBeNull()
+    expect(parseStandaloneDocId('/d')).toBeNull()
+    expect(parseStandaloneDocId('/')).toBeNull()
+    // A ':' would forge a second documentName segment — reject it.
+    expect(parseStandaloneDocId('/d/a:b')).toBeNull()
+    // Only a top-level /d/ path, not a nested one.
+    expect(parseStandaloneDocId('/x/d/abc')).toBeNull()
+  })
+})
+
+describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () => {
+  it('AC-12: a GET 409 (archived) renders the locked terminal and never mounts the editor', async () => {
+    // Deterministic: the api.responder THROWS 409 for the per-doc GET. The page maps that to the
+    // 'locked' terminal via terminalForCreateError, with only a Back control — no collab editor,
+    // hence no WebSocket, is mounted.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_locked') throw apiError(409)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_locked" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.locked')).toBeTruthy(),
+    )
+    // The editor (and its WS transport) is never mounted on the archived path.
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+    // Only a Back affordance is offered (no Share / Request access).
+    expect(screen.getByText(/docs\.list\.back/)).toBeTruthy()
+  })
+
+  it('AC-7: a GET 403 renders the access-denied terminal, editor not mounted', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_forbidden') throw apiError(403)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_forbidden" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.forbidden')).toBeTruthy(),
+    )
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
+  it('AC-10: a GET 404 renders the not-found terminal, editor not mounted', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_missing') throw apiError(404)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_missing" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy(),
+    )
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
+  it('AC-11: a GET 401 renders the sign-in terminal and stashes the return target', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_locked_out') throw apiError(401)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_locked_out" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('docs.error.permission.login')).toBeTruthy(),
+    )
+    // The link is stashed so the post-login flow can bounce the user back to the doc.
+    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).not.toBeNull()
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
+  it('mounts the editor with Copy link + Open in App injected when the preflight succeeds', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    expect(screen.getByTestId('editor-doc').textContent).toBe('d_ok')
+    // The standalone chrome is injected via EditorShell's headerRight prop.
+    const right = screen.getByTestId('editor-header-right')
+    expect(right.textContent).toContain('docs.standalone.copyLink')
+    expect(right.textContent).toContain('docs.standalone.openInApp')
+  })
+})

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -242,6 +242,30 @@ export function StandaloneDocPage({
   const [copied, setCopied] = useState(false)
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Resolve the standalone space ONCE, from the SAME source the room-addressing fallback uses
+  // (standaloneFallbackSpace: live currentSpaceId → cached localStorage → deploy default). Both the
+  // preflight's explicit X-Space-Id header and the EditorShell room fallback read this one value, so
+  // preflight and room can never address different spaces (the bug: a bare preflight got 400/404 and
+  // fell to the not-found terminal even for the user's own last space).
+  const preflightSpace = standaloneFallbackSpace(wk.shared?.currentSpaceId)
+
+  // Defense in depth (does NOT gate the primary fix above): the standalone page mounts via the
+  // Layout early-return, before the app shell restores currentSpaceId from localStorage, so any
+  // in-shell-shared logic the EditorShell touches would see an empty space. If — and only if — the
+  // live space is empty and a cached value exists, seed it from the same cached key. Never overwrite
+  // a real current space, so in-shell mounts (where it is already set) are unaffected.
+  useEffect(() => {
+    const shared = wk.shared
+    if (!shared || shared.currentSpaceId) return
+    if (typeof window === 'undefined') return
+    try {
+      const cached = window.localStorage.getItem('currentSpaceId')
+      if (cached) shared.currentSpaceId = cached
+    } catch {
+      // localStorage unavailable: the explicit preflight header (primary fix) still carries the space.
+    }
+  }, [wk.shared])
+
   useEffect(() => {
     let cancelled = false
     // AC-9: a `/d/` link with a missing or malformed id. The Layout still routes it here (the
@@ -252,7 +276,9 @@ export function StandaloneDocPage({
       return
     }
     setPhase({ status: 'loading' })
-    getDoc(docId)
+    // Carry an explicit X-Space-Id on the preflight (docsApi getDoc): on a cold standalone deep link
+    // the global interceptor's space is empty, so this resolved space is the header's only source.
+    getDoc(docId, { spaceId: preflightSpace })
       .then((meta) => {
         if (!cancelled) setPhase({ status: 'ready', meta })
       })
@@ -279,7 +305,7 @@ export function StandaloneDocPage({
     return () => {
       cancelled = true
     }
-  }, [docId, onSessionExpired])
+  }, [docId, onSessionExpired, preflightSpace])
 
   useEffect(
     () => () => {
@@ -312,9 +338,10 @@ export function StandaloneDocPage({
 
   // Resolve display names for the doc's space so the presence caret shows a real name (parity
   // with the in-shell path). Space comes from the preflight documentName when available, else the
-  // caller's current space. Derived from `phase` so it re-resolves once the doc meta lands.
+  // SAME resolved `preflightSpace` the preflight header used — so the room the editor joins matches
+  // the space the preflight was authorized against. Derived from `phase` so it re-resolves once the
+  // doc meta lands.
   const addressing = useMemo(() => {
-    const fallbackSpace = standaloneFallbackSpace(wk.shared?.currentSpaceId)
     if (phase.status === 'ready' && phase.meta.documentName) {
       try {
         const parsed = parseDocumentName(phase.meta.documentName)
@@ -325,8 +352,8 @@ export function StandaloneDocPage({
         // Malformed documentName from the backend: fall back to the caller's space + default folder.
       }
     }
-    return { space: fallbackSpace, folder: DEFAULT_DOC_FOLDER, doc: docId ?? '' }
-  }, [phase, wk.shared, docId])
+    return { space: preflightSpace, folder: DEFAULT_DOC_FOLDER, doc: docId ?? '' }
+  }, [phase, preflightSpace, docId])
 
   const names = useMemberNames(addressing.space)
 

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -48,7 +48,7 @@ export function isStandaloneDocPath(pathname: string): boolean {
 }
 
 /** Persist the current location so the post-login flow can bounce the user back to the doc link. */
-function persistStandaloneReturn(): void {
+export function persistStandaloneReturn(): void {
   if (typeof window === 'undefined') return
   try {
     window.sessionStorage.setItem(
@@ -61,6 +61,44 @@ function persistStandaloneReturn(): void {
   }
 }
 
+/**
+ * Whether a stashed return target is a SAFE same-origin relative path.
+ *
+ * Open-redirect guard: only accept a path that begins with a single `/` and is not a
+ * scheme-relative (`//host`) or backslash-smuggled (`/\host`, which some browsers normalize to
+ * `//host`) URL. This rejects absolute URLs (`https://evil`), scheme-relative URLs, and
+ * `javascript:`/`data:` payloads, so a tampered sessionStorage value can never bounce the user to
+ * an attacker origin after login.
+ */
+function isSafeReturnPath(path: string | null): path is string {
+  return (
+    typeof path === 'string' &&
+    path.length > 1 &&
+    path[0] === '/' &&
+    path[1] !== '/' &&
+    path[1] !== '\\'
+  )
+}
+
+/**
+ * Read and CLEAR the stashed standalone return target, returning it only when it is a safe
+ * same-origin relative path (see isSafeReturnPath). The post-login flow calls this to bounce a
+ * user who signed in from a `/d/:docId` link back to that exact document instead of the app root
+ * (AC-11). Always clears the key (even on an unsafe/absent value) so a stale target can't leak into
+ * a later, unrelated login. Returns null when nothing safe is stashed.
+ */
+export function consumeStandaloneReturn(): string | null {
+  if (typeof window === 'undefined') return null
+  let raw: string | null = null
+  try {
+    raw = window.sessionStorage.getItem(STANDALONE_RETURN_KEY)
+    window.sessionStorage.removeItem(STANDALONE_RETURN_KEY)
+  } catch {
+    return null
+  }
+  return isSafeReturnPath(raw) ? raw : null
+}
+
 /** Preserve the octo session id (`?sid=`) across an in-app navigation when present. */
 function withSid(path: string): string {
   if (typeof window === 'undefined') return path
@@ -71,6 +109,31 @@ function withSid(path: string): string {
   } catch {
     return path
   }
+}
+
+/**
+ * Resolve the fallback space for the standalone editor when the preflight carries no
+ * documentName to address from.
+ *
+ * The standalone page mounts via the host Layout's EARLY RETURN — before the app-shell logic that
+ * restores `currentSpaceId` from localStorage runs (Layout's Provider branch / Main's space
+ * bootstrap are both skipped). So on a cold-start cross-space deep link, `wk.shared.currentSpaceId`
+ * is still empty and falling straight to DEFAULT_DOC_SPACE would mount the EditorShell against the
+ * wrong room (`octo:<DEFAULT_DOC_SPACE>:f_default:docId`) → not-found / wrong document. Read the
+ * cached `currentSpaceId` localStorage key (the same key the shell persists) as the middle
+ * fallback so the shared link addresses the user's real last space, not the deploy default.
+ */
+export function standaloneFallbackSpace(currentSpaceId: string | undefined): string {
+  if (currentSpaceId) return currentSpaceId
+  if (typeof window !== 'undefined') {
+    try {
+      const cached = window.localStorage.getItem('currentSpaceId')
+      if (cached) return cached
+    } catch {
+      // localStorage unavailable (private mode / disabled): fall back to the deploy default below.
+    }
+  }
+  return DEFAULT_DOC_SPACE
 }
 
 type Phase =
@@ -169,7 +232,7 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
   // with the in-shell path). Space comes from the preflight documentName when available, else the
   // caller's current space. Derived from `phase` so it re-resolves once the doc meta lands.
   const addressing = useMemo(() => {
-    const fallbackSpace = wk.shared?.currentSpaceId || DEFAULT_DOC_SPACE
+    const fallbackSpace = standaloneFallbackSpace(wk.shared?.currentSpaceId)
     if (phase.status === 'ready' && phase.meta.documentName) {
       try {
         const parsed = parseDocumentName(phase.meta.documentName)
@@ -231,6 +294,7 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
         user={{ id: uid, name: names.get(uid) || uid }}
         onBack={onBack}
         moreMenuLeadItems={moreMenuLeadItems}
+        creatorNicknameOnly
       />
       {/* Menu-external "Link copied" toast. Lives outside EditorShell (and thus outside the ≡ menu
           panel that unmounts on selection), so the confirmation stays visible after the menu closes.

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -80,7 +80,9 @@ type Phase =
 /**
  * Standalone document page (octo-web #512) — the full-window view a shared `/d/:docId` link opens,
  * outside the app shell / NavRail. It reuses the in-shell EditorShell for collaboration parity
- * (AC-5/6) and only adds the standalone chrome: a Back control, "Copy link", and "Open in App".
+ * (AC-5/6) and only adds the standalone chrome: a Back control and "Copy link". Sharing a link is
+ * the whole point of a standalone view, so there is no "back into the app" action — users arrive
+ * here from an external chat link, not from inside the shell.
  *
  * A GET /api/v1/docs/{docId} preflight runs BEFORE the collaborative editor mounts. This is the
  * single deterministic gate for every boundary state, and it needs no WebSocket:
@@ -152,14 +154,6 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
     }
   }, [])
 
-  // "Open in App": jump into the in-shell docs experience for this doc (list + NavRail), reusing
-  // the existing `/docs?doc=` deep-link the in-shell path already understands.
-  const onOpenInApp = useCallback(() => {
-    if (typeof window !== 'undefined' && docId) {
-      window.location.assign(withSid(`/docs?doc=${encodeURIComponent(docId)}`))
-    }
-  }, [docId])
-
   // Resolve display names for the doc's space so the presence caret shows a real name (parity
   // with the in-shell path). Space comes from the preflight documentName when available, else the
   // caller's current space. Derived from `phase` so it re-resolves once the doc meta lands.
@@ -208,13 +202,6 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
         onClick={() => void onCopyLink()}
       >
         🔗 {copied ? t('docs.standalone.linkCopied') : t('docs.standalone.copyLink')}
-      </button>
-      <button
-        type="button"
-        className="octo-tb-btn octo-doc-open-in-app"
-        onClick={onOpenInApp}
-      >
-        {t('docs.standalone.openInApp')}
       </button>
     </div>
   )

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -221,7 +221,21 @@ type Phase =
  * (`/d/`, `/d/a:b`) arrives here as null and short-circuits to the not-found terminal instead of
  * falling through to the app shell (AC-9).
  */
-export function StandaloneDocPage({ docId }: { docId: string | null }): ReactElement {
+export function StandaloneDocPage({
+  docId,
+  onSessionExpired,
+}: {
+  docId: string | null
+  /**
+   * Called when the preflight returns 401 while a token WAS loaded — i.e. the current session is
+   * expired (XIN-408). The page mounts only when `WKApp.loginInfo.token` is truthy (host Layout
+   * gate), so a 401 here can only mean the loaded token is stale, not that the visitor is anonymous.
+   * The host clears the dead session and reloads so the standalone branch falls through to the real
+   * login screen — the stashed return target then bounces the user back to this doc after sign-in.
+   * When omitted (defensive / non-host callers), the page falls back to the login terminal.
+   */
+  onSessionExpired?: () => void
+}): ReactElement {
   const wk = getWKApp()
   const uid = wk.loginInfo?.uid ?? ''
   const [phase, setPhase] = useState<Phase>({ status: 'loading' })
@@ -245,14 +259,27 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
       .catch((err: unknown) => {
         if (cancelled) return
         const kind = terminalForCreateError(err)
-        // Session expired / not signed in: stash the link so login can return here (AC-11).
-        if (kind === 'login') persistStandaloneReturn()
+        if (kind === 'login') {
+          // The page only mounts with a token present (Layout gate), so a 401 means the loaded
+          // session is EXPIRED, not that the visitor is anonymous. Stash the deep-link target, then
+          // hand off to the host to clear the dead session and reload into the real login screen —
+          // instead of rendering a terminal with no way to re-authenticate (XIN-408 dead-end).
+          persistStandaloneReturn()
+          if (onSessionExpired) {
+            onSessionExpired()
+            // Do not setPhase: the host is navigating away (reload) to the login screen.
+            return
+          }
+          // No handler wired (defensive): fall back to the login terminal below.
+          setPhase({ status: 'terminal', kind })
+          return
+        }
         setPhase({ status: 'terminal', kind })
       })
     return () => {
       cancelled = true
     }
-  }, [docId])
+  }, [docId, onSessionExpired])
 
   useEffect(
     () => () => {

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { getWKApp, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
+import { LinkIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
 import { getDoc, type DocMeta } from './docsApi.ts'
 import { parseDocumentName } from '../documentName/index.ts'
@@ -83,6 +84,10 @@ type Phase =
  * (AC-5/6) and only adds the standalone chrome: a Back control and "Copy link". Sharing a link is
  * the whole point of a standalone view, so there is no "back into the app" action — users arrive
  * here from an external chat link, not from inside the shell.
+ *
+ * "Copy link" is collapsed into the header's ≡ "more" menu (as its top row) rather than sitting as a
+ * resident title-bar button, keeping the standalone header as trim as the in-shell one. The clipboard
+ * behaviour is unchanged — only its position moved.
  *
  * A GET /api/v1/docs/{docId} preflight runs BEFORE the collaborative editor mounts. This is the
  * single deterministic gate for every boundary state, and it needs no WebSocket:
@@ -194,17 +199,17 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
   // In the ready phase the addressed id is guaranteed non-null (a null id short-circuits to the
   // not-found terminal above); prefer the id echoed by the preflight, falling back to it.
   const editorDocId = meta.docId || (docId as string)
-  const headerRight = (
-    <div className="octo-doc-standalone-actions">
-      <button
-        type="button"
-        className="octo-tb-btn octo-doc-copy-link"
-        onClick={() => void onCopyLink()}
-      >
-        🔗 {copied ? t('docs.standalone.linkCopied') : t('docs.standalone.copyLink')}
-      </button>
-    </div>
-  )
+  // "Copy link" as the first row of the header ≡ "more" menu (it used to be a resident title-bar
+  // button). The label carries the same transient "Link copied" feedback the button had, driven by
+  // the unchanged onCopyLink clipboard logic below.
+  const moreMenuLeadItems: DocMoreMenuItem[] = [
+    {
+      key: 'copy-link',
+      label: copied ? t('docs.standalone.linkCopied') : t('docs.standalone.copyLink'),
+      icon: LinkIcon,
+      onClick: () => void onCopyLink(),
+    },
+  ]
 
   return (
     <div className="octo-doc-standalone">
@@ -218,7 +223,7 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
         doc={addressing.doc}
         user={{ id: uid, name: names.get(uid) || uid }}
         onBack={onBack}
-        headerRight={headerRight}
+        moreMenuLeadItems={moreMenuLeadItems}
       />
     </div>
   )

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -252,11 +252,19 @@ export function StandaloneDocPage({
   // fell to the not-found terminal even for the user's own last space).
   const preflightSpace = standaloneFallbackSpace(wk.shared?.currentSpaceId)
 
-  // Defense in depth (does NOT gate the primary fix above): the standalone page mounts via the
-  // Layout early-return, before the app shell restores currentSpaceId from localStorage, so any
-  // in-shell-shared logic the EditorShell touches would see an empty space. If — and only if — the
-  // live space is empty and a cached value exists, seed it from the same cached key. Never overwrite
-  // a real current space, so in-shell mounts (where it is already set) are unaffected.
+  // Genuine defense in depth (second, independent path — NOT the only working one): the standalone
+  // page mounts via the Layout early-return, before the app shell restores currentSpaceId from
+  // localStorage, so any in-shell-shared logic the EditorShell touches would see an empty space. If —
+  // and only if — the live space is empty and a cached value exists, seed it from the same cached key.
+  // Never overwrite a real current space, so in-shell mounts (where it is already set) are unaffected.
+  //
+  // Both paths now really carry the space to the backend: the preflight's EXPLICIT X-Space-Id header
+  // (primary — APIClient forwards config.headers since XIN-424, so it truly reaches the wire) AND this
+  // seeding, which repopulates currentSpaceId so the global request interceptor injects X-Space-Id on
+  // every OTHER request the shell fires. Before XIN-424 the explicit header was silently dropped by
+  // APIClient, so this seeding was in fact the ONLY thing that made same-space docs open; with the
+  // header fixed the two are now independent, mutually-reinforcing paths (explicit header wins per
+  // request; interceptor is the fallback), which is what real defense in depth means.
   useEffect(() => {
     const shared = wk.shared
     if (!shared || shared.currentSpaceId) return
@@ -330,7 +338,14 @@ export function StandaloneDocPage({
   const onCopyLink = useCallback(async () => {
     if (typeof window === 'undefined') return
     try {
-      await navigator.clipboard?.writeText(window.location.href)
+      // Copy the CANONICAL share link — origin + `/d/:docId` only — never the live URL. The current
+      // address may carry session-scoped query params (notably `?sid=`, added when opening a doc in a
+      // new page / returning post-login), and copying window.location.href would leak the sharer's own
+      // session id into the shared link. Strip the whole query (and any hash) so what is shared is the
+      // clean document link every recipient should get; the recipient's own session resolves normally.
+      const here = new URL(window.location.href)
+      const canonical = here.origin + here.pathname
+      await navigator.clipboard?.writeText(canonical)
       // Drive the menu-external "Link copied" toast (below). The menu closes on selection, so this
       // confirmation must live outside the (now-unmounted) menu panel — hence page-level state, not
       // a menu-row label. Auto-dismiss after a short interval.

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import { getWKApp, t } from '../octoweb/index.ts'
+import { EditorShell } from '../editor/EditorShell.tsx'
+import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
+import { terminalForCreateError } from '../collab/useCollabEditor.ts'
+import { getDoc, type DocMeta } from './docsApi.ts'
+import { parseDocumentName } from '../documentName/index.ts'
+import { DEFAULT_DOC_SPACE, DEFAULT_DOC_FOLDER } from '../config.ts'
+import { useMemberNames } from '../members/useMemberNames.ts'
+import '../editor/styles.css'
+
+/**
+ * sessionStorage key holding the full standalone target (`/d/:docId` path + query) captured
+ * when the page hits a 401. After the user signs in, the login flow can read this and return
+ * them to the exact document link they opened (AC-11). Distinct from DocsHome's
+ * `octo.docs.target` (which stores `{space, folder, doc}` for the in-shell list), so the two
+ * never clobber each other.
+ */
+export const STANDALONE_RETURN_KEY = 'octo.docs.standaloneReturn'
+
+/** `/d/:docId` — docId is a single documentName segment (A-Z a-z 0-9 _ -), optional trailing slash. */
+const STANDALONE_PATH = /^\/d\/([A-Za-z0-9_-]+)\/?$/
+
+/**
+ * Extract the docId from a standalone document path (`/d/:docId`), or null when the path is not
+ * a standalone doc link. Exported so the host Layout can decide whether to short-circuit into the
+ * standalone page (mirroring the existing `?invite=` interception) and so it is unit-testable.
+ */
+export function parseStandaloneDocId(pathname: string): string | null {
+  if (typeof pathname !== 'string') return null
+  const m = STANDALONE_PATH.exec(pathname)
+  return m ? m[1] : null
+}
+
+/** Persist the current location so the post-login flow can bounce the user back to the doc link. */
+function persistStandaloneReturn(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      STANDALONE_RETURN_KEY,
+      window.location.pathname + window.location.search,
+    )
+  } catch {
+    // sessionStorage unavailable (private mode / disabled): the deep-link still works on a fresh
+    // open; we just can't auto-return after login.
+  }
+}
+
+/** Preserve the octo session id (`?sid=`) across an in-app navigation when present. */
+function withSid(path: string): string {
+  if (typeof window === 'undefined') return path
+  try {
+    const sid = new URLSearchParams(window.location.search).get('sid')
+    if (!sid) return path
+    return path + (path.includes('?') ? '&' : '?') + `sid=${encodeURIComponent(sid)}`
+  } catch {
+    return path
+  }
+}
+
+type Phase =
+  | { status: 'loading' }
+  | { status: 'ready'; meta: DocMeta }
+  | { status: 'terminal'; kind: TerminalKind }
+
+/**
+ * Standalone document page (octo-web #512) — the full-window view a shared `/d/:docId` link opens,
+ * outside the app shell / NavRail. It reuses the in-shell EditorShell for collaboration parity
+ * (AC-5/6) and only adds the standalone chrome: a Back control, "Copy link", and "Open in App".
+ *
+ * A GET /api/v1/docs/{docId} preflight runs BEFORE the collaborative editor mounts. This is the
+ * single deterministic gate for every boundary state, and it needs no WebSocket:
+ *   - 200          -> mount the editor.
+ *   - 403 forbidden (AC-7), 404 not-found (AC-10), 401 login (AC-11), 409 locked/archived (AC-12)
+ *     -> render the matching terminal screen (Back only). 409 is the archived signal the
+ *     collab-token path never reports, which is exactly why the preflight exists.
+ */
+export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
+  const wk = getWKApp()
+  const uid = wk.loginInfo?.uid ?? ''
+  const [phase, setPhase] = useState<Phase>({ status: 'loading' })
+  const [copied, setCopied] = useState(false)
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setPhase({ status: 'loading' })
+    getDoc(docId)
+      .then((meta) => {
+        if (!cancelled) setPhase({ status: 'ready', meta })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const kind = terminalForCreateError(err)
+        // Session expired / not signed in: stash the link so login can return here (AC-11).
+        if (kind === 'login') persistStandaloneReturn()
+        setPhase({ status: 'terminal', kind })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [docId])
+
+  useEffect(
+    () => () => {
+      if (copiedTimer.current) clearTimeout(copiedTimer.current)
+    },
+    [],
+  )
+
+  // Back / return-to-list: from a full-window standalone view there is no resident list to fall
+  // back to, so route to the in-shell docs home (the natural "all documents" destination).
+  const onBack = useCallback(() => {
+    if (typeof window !== 'undefined') window.location.assign(withSid('/docs'))
+  }, [])
+
+  const onCopyLink = useCallback(async () => {
+    if (typeof window === 'undefined') return
+    try {
+      await navigator.clipboard?.writeText(window.location.href)
+      setCopied(true)
+      if (copiedTimer.current) clearTimeout(copiedTimer.current)
+      copiedTimer.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard blocked (permissions / insecure context): silently no-op; the URL bar still
+      // carries the shareable link.
+    }
+  }, [])
+
+  // "Open in App": jump into the in-shell docs experience for this doc (list + NavRail), reusing
+  // the existing `/docs?doc=` deep-link the in-shell path already understands.
+  const onOpenInApp = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.location.assign(withSid(`/docs?doc=${encodeURIComponent(docId)}`))
+    }
+  }, [docId])
+
+  // Resolve display names for the doc's space so the presence caret shows a real name (parity
+  // with the in-shell path). Space comes from the preflight documentName when available, else the
+  // caller's current space. Derived from `phase` so it re-resolves once the doc meta lands.
+  const addressing = useMemo(() => {
+    const fallbackSpace = wk.shared?.currentSpaceId || DEFAULT_DOC_SPACE
+    if (phase.status === 'ready' && phase.meta.documentName) {
+      try {
+        const parsed = parseDocumentName(phase.meta.documentName)
+        if (parsed.kind === 'document') {
+          return { space: parsed.space, folder: parsed.folder, doc: parsed.doc }
+        }
+      } catch {
+        // Malformed documentName from the backend: fall back to the caller's space + default folder.
+      }
+    }
+    return { space: fallbackSpace, folder: DEFAULT_DOC_FOLDER, doc: docId }
+  }, [phase, wk.shared, docId])
+
+  const names = useMemberNames(addressing.space)
+
+  if (phase.status === 'loading') {
+    return (
+      <div className="octo-doc octo-doc-standalone">
+        <p className="octo-loading">{t('docs.state.loading')}</p>
+      </div>
+    )
+  }
+
+  if (phase.status === 'terminal') {
+    return (
+      <div className="octo-doc-standalone">
+        <DocTerminal title={t('docs.state.untitled')} kind={phase.kind} onBack={onBack} />
+      </div>
+    )
+  }
+
+  const meta = phase.meta
+  const headerRight = (
+    <div className="octo-doc-standalone-actions">
+      <button
+        type="button"
+        className="octo-tb-btn octo-doc-copy-link"
+        onClick={() => void onCopyLink()}
+      >
+        🔗 {copied ? t('docs.standalone.linkCopied') : t('docs.standalone.copyLink')}
+      </button>
+      <button
+        type="button"
+        className="octo-tb-btn octo-doc-open-in-app"
+        onClick={onOpenInApp}
+      >
+        {t('docs.standalone.openInApp')}
+      </button>
+    </div>
+  )
+
+  return (
+    <div className="octo-doc-standalone">
+      <EditorShell
+        key={docId}
+        docId={docId}
+        title={meta.title || t('docs.state.untitled')}
+        uid={uid}
+        space={addressing.space}
+        folder={addressing.folder}
+        doc={addressing.doc}
+        user={{ id: uid, name: names.get(uid) || uid }}
+        onBack={onBack}
+        headerRight={headerRight}
+      />
+    </div>
+  )
+}

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -62,22 +62,45 @@ export function persistStandaloneReturn(): void {
 }
 
 /**
- * Whether a stashed return target is a SAFE same-origin relative path.
+ * Whether a stashed return target is a SAFE same-origin link that lands on a standalone doc page.
  *
- * Open-redirect guard: only accept a path that begins with a single `/` and is not a
- * scheme-relative (`//host`) or backslash-smuggled (`/\host`, which some browsers normalize to
- * `//host`) URL. This rejects absolute URLs (`https://evil`), scheme-relative URLs, and
- * `javascript:`/`data:` payloads, so a tampered sessionStorage value can never bounce the user to
- * an attacker origin after login.
+ * Open-redirect guard (hardened, XIN-392). The value lives in sessionStorage, so it is
+ * attacker-influenceable, and it is later fed to `window.location.assign` — it must clear three
+ * gates, in order:
+ *
+ *   1. No control characters. The WHATWG URL parser SILENTLY STRIPS tab / newline / CR mid-string,
+ *      so a value like `/` + "\n" + `/evil.example.com` parses to the scheme-relative
+ *      `//evil.example.com` and the browser then normalizes it off-origin. The old byte-level check
+ *      (only path[0]/path[1]) never saw the smuggled `//host` because the control char sat between
+ *      them. Rejecting any C0 control char (and DEL) up front closes that whole class of bypass
+ *      before parsing can mask it.
+ *   2. Same origin. Resolve against the current origin and require `url.origin === origin`. This
+ *      rejects absolute (`https://evil`), scheme-relative (`//host`), and backslash-smuggled
+ *      (`/\host`) targets structurally, instead of hand-checking leading characters.
+ *   3. Standalone-doc target only (P2-2). Even a same-origin path must resolve to `/d/:docId`
+ *      (`parseStandaloneDocId(url.pathname) !== null`), so a tampered value can't bounce the user to
+ *      another same-origin page (`/settings`, `/oidc/bind`, …) after login — the post-login return
+ *      is scoped to the standalone document the user actually opened.
  */
 function isSafeReturnPath(path: string | null): path is string {
-  return (
-    typeof path === 'string' &&
-    path.length > 1 &&
-    path[0] === '/' &&
-    path[1] !== '/' &&
-    path[1] !== '\\'
-  )
+  if (typeof path !== 'string' || path.length === 0) return false
+  // A return target must be a rooted absolute path. Rejecting relative values (`d/relative`) up
+  // front stops them from resolving against whatever the current document URL happens to be when
+  // window.location.assign runs (e.g. `/login/` → `/login/d/relative`) instead of a clean `/d/:id`.
+  if (path[0] !== '/') return false
+  // Reject ANY control character before parsing — see gate 1 above.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(path)) return false
+  if (typeof window === 'undefined') return false
+  const origin = window.location.origin
+  let url: URL
+  try {
+    url = new URL(path, origin)
+  } catch {
+    return false
+  }
+  if (url.origin !== origin) return false
+  return parseStandaloneDocId(url.pathname) !== null
 }
 
 /**

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -122,6 +122,38 @@ export function consumeStandaloneReturn(): string | null {
   return isSafeReturnPath(raw) ? raw : null
 }
 
+/**
+ * Attach an octo session id to a consumed standalone return target when it carries none.
+ *
+ * Why (XIN-398): after the user signs in from a `/d/:docId` deep link, goMain reloads that exact
+ * path. With no `?sid=`, the reloaded page's sid-keyed `load()` reads the empty-sid bucket only, so
+ * a multi-session user (several stored `token{sid}` buckets) falls to `recoverOctoSessionFromStorage`
+ * — which since XIN-392 P1-2 refuses to guess an identity when the choice is ambiguous, bouncing the
+ * user straight back to login: a loop. Carrying the just-authenticated session's OWN sid on the
+ * reload lets its sid-keyed `load()` hit the right bucket directly, so the loop never forms. This is
+ * the known current identity's sid, not a guess among several — it does NOT reintroduce the pre-P1-2
+ * "persist a guessed session" behavior.
+ *
+ * Security (XIN-392 P1-1/P2-2 must survive): `target` has already cleared isSafeReturnPath in
+ * consumeStandaloneReturn (same-origin, control-char-free, resolves to `/d/:docId`). We only ADD a
+ * query param, which cannot change the pathname, and the sid is percent-encoded by URLSearchParams so
+ * it can never smuggle a second path/host/query. As defense in depth the rebuilt value is re-run
+ * through isSafeReturnPath; anything unexpected falls back to the untouched target. A target that
+ * already carries a sid is returned unchanged (the stored link may include one).
+ */
+export function withReturnSid(target: string, sid: string | null | undefined): string {
+  if (!sid || typeof window === 'undefined') return target
+  try {
+    const url = new URL(target, window.location.origin)
+    if (url.searchParams.has('sid')) return target
+    url.searchParams.set('sid', sid)
+    const rebuilt = url.pathname + url.search
+    return isSafeReturnPath(rebuilt) ? rebuilt : target
+  } catch {
+    return target
+  }
+}
+
 /** Preserve the octo session id (`?sid=`) across an in-app navigation when present. */
 function withSid(path: string): string {
   if (typeof window === 'undefined') return path

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -199,9 +199,12 @@ type Phase =
 /**
  * Standalone document page (octo-web #512) — the full-window view a shared `/d/:docId` link opens,
  * outside the app shell / NavRail. It reuses the in-shell EditorShell for collaboration parity
- * (AC-5/6) and only adds the standalone chrome: a Back control and "Copy link". Sharing a link is
- * the whole point of a standalone view, so there is no "back into the app" action — users arrive
- * here from an external chat link, not from inside the shell.
+ * (AC-5/6) and only adds the standalone chrome: "Copy link". Sharing a link is the whole point of a
+ * standalone view, so the loaded editor offers no "back to all documents" return link (XIN-416, boss
+ * real-device acceptance) — users arrive here from an external chat link, not from inside the shell,
+ * and a pure share page needs no entry back into the doc list. The page therefore passes NO onBack to
+ * EditorShell; the preflight error terminals (below) keep their own Back affordance as an escape
+ * hatch out of a not-found / forbidden / locked dead end.
  *
  * "Copy link" is collapsed into the header's ≡ "more" menu (as its top row) rather than sitting as a
  * resident title-bar button, keeping the standalone header as trim as the in-shell one. The clipboard
@@ -314,8 +317,12 @@ export function StandaloneDocPage({
     [],
   )
 
-  // Back / return-to-list: from a full-window standalone view there is no resident list to fall
-  // back to, so route to the in-shell docs home (the natural "all documents" destination).
+  // Back / return-to-list handler for the preflight ERROR terminals only (not-found / forbidden /
+  // locked / login). The loaded editor view intentionally has no back link (XIN-416); this remains
+  // wired to DocTerminal so a user who lands on a dead-end error screen still has an escape hatch to
+  // the in-shell docs home. From a full-window standalone view there is no resident list to fall
+  // back to, so route to the in-shell docs home (the natural "all documents" destination), carrying
+  // the session sid when present.
   const onBack = useCallback(() => {
     if (typeof window !== 'undefined') window.location.assign(withSid('/docs'))
   }, [])
@@ -401,7 +408,6 @@ export function StandaloneDocPage({
         folder={addressing.folder}
         doc={addressing.doc}
         user={{ id: uid, name: names.get(uid) || uid }}
-        onBack={onBack}
         moreMenuLeadItems={moreMenuLeadItems}
         creatorNicknameOnly
       />

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -21,6 +21,9 @@ export const STANDALONE_RETURN_KEY = 'octo.docs.standaloneReturn'
 /** `/d/:docId` — docId is a single documentName segment (A-Z a-z 0-9 _ -), optional trailing slash. */
 const STANDALONE_PATH = /^\/d\/([A-Za-z0-9_-]+)\/?$/
 
+/** The standalone-doc URL namespace: `/d`, `/d/`, or `/d/<anything>` (top-level only). */
+const STANDALONE_NAMESPACE = /^\/d(?:\/|$)/
+
 /**
  * Extract the docId from a standalone document path (`/d/:docId`), or null when the path is not
  * a standalone doc link. Exported so the host Layout can decide whether to short-circuit into the
@@ -30,6 +33,17 @@ export function parseStandaloneDocId(pathname: string): string | null {
   if (typeof pathname !== 'string') return null
   const m = STANDALONE_PATH.exec(pathname)
   return m ? m[1] : null
+}
+
+/**
+ * Whether `pathname` lives in the standalone-doc namespace (`/d`, `/d/`, `/d/<id>`), regardless of
+ * whether the id is valid. The host Layout intercepts the whole namespace — not just well-formed
+ * ids — so a malformed or empty id (`/d/`, `/d/a:b`) renders the standalone not-found terminal
+ * instead of silently falling through to the app shell (AC-9). Pair with parseStandaloneDocId,
+ * which returns the id (or null when malformed) once the namespace has been claimed.
+ */
+export function isStandaloneDocPath(pathname: string): boolean {
+  return typeof pathname === 'string' && STANDALONE_NAMESPACE.test(pathname)
 }
 
 /** Persist the current location so the post-login flow can bounce the user back to the doc link. */
@@ -74,8 +88,12 @@ type Phase =
  *   - 403 forbidden (AC-7), 404 not-found (AC-10), 401 login (AC-11), 409 locked/archived (AC-12)
  *     -> render the matching terminal screen (Back only). 409 is the archived signal the
  *     collab-token path never reports, which is exactly why the preflight exists.
+ *
+ * `docId` is nullable: the host Layout claims the whole `/d` namespace, so a malformed / empty id
+ * (`/d/`, `/d/a:b`) arrives here as null and short-circuits to the not-found terminal instead of
+ * falling through to the app shell (AC-9).
  */
-export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
+export function StandaloneDocPage({ docId }: { docId: string | null }): ReactElement {
   const wk = getWKApp()
   const uid = wk.loginInfo?.uid ?? ''
   const [phase, setPhase] = useState<Phase>({ status: 'loading' })
@@ -84,6 +102,13 @@ export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
 
   useEffect(() => {
     let cancelled = false
+    // AC-9: a `/d/` link with a missing or malformed id. The Layout still routes it here (the
+    // namespace is claimed) so we render the not-found terminal rather than the app shell. No
+    // preflight — there is nothing valid to fetch.
+    if (!docId) {
+      setPhase({ status: 'terminal', kind: 'not-found' })
+      return
+    }
     setPhase({ status: 'loading' })
     getDoc(docId)
       .then((meta) => {
@@ -130,7 +155,7 @@ export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
   // "Open in App": jump into the in-shell docs experience for this doc (list + NavRail), reusing
   // the existing `/docs?doc=` deep-link the in-shell path already understands.
   const onOpenInApp = useCallback(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && docId) {
       window.location.assign(withSid(`/docs?doc=${encodeURIComponent(docId)}`))
     }
   }, [docId])
@@ -150,7 +175,7 @@ export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
         // Malformed documentName from the backend: fall back to the caller's space + default folder.
       }
     }
-    return { space: fallbackSpace, folder: DEFAULT_DOC_FOLDER, doc: docId }
+    return { space: fallbackSpace, folder: DEFAULT_DOC_FOLDER, doc: docId ?? '' }
   }, [phase, wk.shared, docId])
 
   const names = useMemberNames(addressing.space)
@@ -172,6 +197,9 @@ export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
   }
 
   const meta = phase.meta
+  // In the ready phase the addressed id is guaranteed non-null (a null id short-circuits to the
+  // not-found terminal above); prefer the id echoed by the preflight, falling back to it.
+  const editorDocId = meta.docId || (docId as string)
   const headerRight = (
     <div className="octo-doc-standalone-actions">
       <button
@@ -194,8 +222,8 @@ export function StandaloneDocPage({ docId }: { docId: string }): ReactElement {
   return (
     <div className="octo-doc-standalone">
       <EditorShell
-        key={docId}
-        docId={docId}
+        key={editorDocId}
+        docId={editorDocId}
         title={meta.title || t('docs.state.untitled')}
         uid={uid}
         space={addressing.space}

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -87,7 +87,10 @@ type Phase =
  *
  * "Copy link" is collapsed into the header's ≡ "more" menu (as its top row) rather than sitting as a
  * resident title-bar button, keeping the standalone header as trim as the in-shell one. The clipboard
- * behaviour is unchanged — only its position moved.
+ * behaviour is unchanged — only its position moved. Because selecting a menu row closes the menu (the
+ * panel unmounts), the "Link copied" confirmation cannot live inside the row; it surfaces as a brief
+ * menu-external toast rendered by this page instead (reusing the docs package's document-external
+ * transient-toast convention, the same fixed overlay style as the image upload status/error toasts).
  *
  * A GET /api/v1/docs/{docId} preflight runs BEFORE the collaborative editor mounts. This is the
  * single deterministic gate for every boundary state, and it needs no WebSocket:
@@ -150,6 +153,9 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
     if (typeof window === 'undefined') return
     try {
       await navigator.clipboard?.writeText(window.location.href)
+      // Drive the menu-external "Link copied" toast (below). The menu closes on selection, so this
+      // confirmation must live outside the (now-unmounted) menu panel — hence page-level state, not
+      // a menu-row label. Auto-dismiss after a short interval.
       setCopied(true)
       if (copiedTimer.current) clearTimeout(copiedTimer.current)
       copiedTimer.current = setTimeout(() => setCopied(false), 2000)
@@ -200,12 +206,13 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
   // not-found terminal above); prefer the id echoed by the preflight, falling back to it.
   const editorDocId = meta.docId || (docId as string)
   // "Copy link" as the first row of the header ≡ "more" menu (it used to be a resident title-bar
-  // button). The label carries the same transient "Link copied" feedback the button had, driven by
-  // the unchanged onCopyLink clipboard logic below.
+  // button). Selecting the row closes the menu, so the "Link copied" confirmation can't ride on the
+  // row label (the panel unmounts); the label is always the action name and the success feedback is
+  // shown by the menu-external toast below, driven by the unchanged onCopyLink clipboard logic.
   const moreMenuLeadItems: DocMoreMenuItem[] = [
     {
       key: 'copy-link',
-      label: copied ? t('docs.standalone.linkCopied') : t('docs.standalone.copyLink'),
+      label: t('docs.standalone.copyLink'),
       icon: LinkIcon,
       onClick: () => void onCopyLink(),
     },
@@ -225,6 +232,15 @@ export function StandaloneDocPage({ docId }: { docId: string | null }): ReactEle
         onBack={onBack}
         moreMenuLeadItems={moreMenuLeadItems}
       />
+      {/* Menu-external "Link copied" toast. Lives outside EditorShell (and thus outside the ≡ menu
+          panel that unmounts on selection), so the confirmation stays visible after the menu closes.
+          Fixed overlay, auto-dismissed via the copied timer; matches the docs document-external toast
+          style. role="status" + aria-live announces it to assistive tech without stealing focus. */}
+      {copied && (
+        <div className="octo-doc-standalone-toast" role="status" aria-live="polite">
+          {t('docs.standalone.linkCopied')}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -89,6 +89,11 @@ describe('docs list/create API (bare-relative /docs)', () => {
   })
 
   it('carries an explicit X-Space-Id header when getDoc is given a spaceId (standalone by-space preflight)', async () => {
+    // Scope: this asserts the DOCS-SIDE contract — getDoc puts the explicit header into the request
+    // config. That the header then really reaches the wire (host APIClient forwards config.headers to
+    // axios, and the interceptor lets the explicit header win) is covered by the host unit test at
+    // packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts. Both halves are needed:
+    // the mock seam here cannot prove the real host forwards headers (that was the XIN-424 fake-green).
     api.responder = () => ({ data: { docId: 'd_real', title: 'Real Title' }, status: 200 })
     await getDoc('d_real', { spaceId: 'space-abc' })
     const call = api.calls.at(-1)!

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -5,6 +5,7 @@ import {
   listDocs,
   createDoc,
   getDoc,
+  getUserName,
   updateDocTitle,
   deleteDoc,
   classifyDeleteStatus,
@@ -122,5 +123,30 @@ describe('classifyDeleteStatus / deleteErrorKey', () => {
     expect(deleteErrorKey('forbidden')).toBe('docs.doc.deleteForbidden')
     expect(deleteErrorKey('archived')).toBe('docs.doc.deleteArchived')
     expect(deleteErrorKey('failed')).toBe('docs.doc.deleteFailed')
+  })
+})
+
+describe('getUserName — creator name resolution + standalone privacy (blocker 5)', () => {
+  it('prefers the verified real_name by default (in-shell editor, unchanged behavior)', async () => {
+    api.responder = () => ({ data: { name: 'ada_nick', real_name: 'Ada Lovelace' }, status: 200 })
+    expect(await getUserName('u_owner')).toBe('Ada Lovelace')
+  })
+
+  it('returns the nickname only when preferRealName is false (standalone shared surface)', async () => {
+    // Privacy: a /d/:docId link holder must never see the creator's verified legal name.
+    api.responder = () => ({ data: { name: 'ada_nick', real_name: 'Ada Lovelace' }, status: 200 })
+    expect(await getUserName('u_owner', { preferRealName: false })).toBe('ada_nick')
+  })
+
+  it('falls back to the nickname when no real_name exists, in both modes', async () => {
+    api.responder = () => ({ data: { name: 'ada_nick' }, status: 200 })
+    expect(await getUserName('u_owner')).toBe('ada_nick')
+    expect(await getUserName('u_owner', { preferRealName: false })).toBe('ada_nick')
+  })
+
+  it('returns undefined when no usable name is present (menu falls back to a short uid)', async () => {
+    api.responder = () => ({ data: {}, status: 200 })
+    expect(await getUserName('u_owner')).toBeUndefined()
+    expect(await getUserName('u_owner', { preferRealName: false })).toBeUndefined()
   })
 })

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -79,6 +79,30 @@ describe('docs list/create API (bare-relative /docs)', () => {
     expect(call.url).toBe('/docs/d_real')
   })
 
+  it('sends NO explicit X-Space-Id header for the in-shell getDoc (no spaceId) — the global interceptor still handles it', async () => {
+    api.responder = () => ({ data: { docId: 'd_real', title: 'Real Title' }, status: 200 })
+    await getDoc('d_real')
+    const call = api.calls.at(-1)!
+    // Unchanged behavior: no per-request config header — the global spaceIdCallback interceptor
+    // injects X-Space-Id from the live currentSpaceId, exactly as before.
+    expect(call.config?.headers?.['X-Space-Id']).toBeUndefined()
+  })
+
+  it('carries an explicit X-Space-Id header when getDoc is given a spaceId (standalone by-space preflight)', async () => {
+    api.responder = () => ({ data: { docId: 'd_real', title: 'Real Title' }, status: 200 })
+    await getDoc('d_real', { spaceId: 'space-abc' })
+    const call = api.calls.at(-1)!
+    expect(call.url).toBe('/docs/d_real')
+    expect(call.config?.headers?.['X-Space-Id']).toBe('space-abc')
+  })
+
+  it('does not add a header for an empty spaceId (falls back to interceptor behavior)', async () => {
+    api.responder = () => ({ data: { docId: 'd_real', title: 'Real Title' }, status: 200 })
+    await getDoc('d_real', { spaceId: '' })
+    const call = api.calls.at(-1)!
+    expect(call.config?.headers?.['X-Space-Id']).toBeUndefined()
+  })
+
   it('renames a doc via PATCH /docs/{docId} with {title}', async () => {
     api.responder = () => ({
       data: { docId: 'd_real', title: 'New Name' },

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -69,6 +69,12 @@ export interface DocMeta {
   role?: Role
   updatedAt?: string
   /**
+   * Creation timestamp (RFC3339), returned by the per-doc GET. Consumed by the header "more"
+   * menu to show a "Created on YYYY-MM-DD" line. Optional / forward-compatible: when the backend
+   * omits it the menu simply drops the created-on row rather than showing a broken date.
+   */
+  createdAt?: string
+  /**
    * Canonical collab document key `octo:{space}:{folder}:{doc}` (see documentName/index.ts).
    * Returned by the per-doc GET so a standalone deep-link (`/d/:docId`), which knows only the
    * docId and not the owning space/folder, can address collaboration exactly instead of guessing.
@@ -87,6 +93,20 @@ export interface DocMeta {
 export async function getDoc(docId: string): Promise<DocMeta> {
   const { data } = await apiClient().get<DocMeta>(`/docs/${docId}`)
   return data
+}
+
+/**
+ * GET /api/v1/users/{uid} — resolve a uid to a human display name. Used by the header "more" menu
+ * to render the document creator (the doc's ownerId) as a name instead of a raw uid. The host user
+ * payload carries `name` (nickname) and, when the user is verified, `real_name`; we prefer the
+ * verified real name and fall back to the nickname. Resilient by contract: it returns `undefined`
+ * (never throws for the caller's happy path only — callers still wrap it) when no usable name is
+ * present, so the menu can fall back to a short uid / placeholder without crashing.
+ */
+export async function getUserName(uid: string): Promise<string | undefined> {
+  const { data } = await apiClient().get<{ name?: string; real_name?: string }>(`/users/${uid}`)
+  const name = (data?.real_name || data?.name || '').trim()
+  return name || undefined
 }
 
 /**

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -89,9 +89,20 @@ export interface DocMeta {
  * Used to render the real title in the editor header instead of a hardcoded
  * placeholder. Resilient: callers fall back to a passed-in title if this throws
  * (e.g. the backend has no per-doc GET in a given environment).
+ *
+ * `opts.spaceId` (standalone by-space need): the backend gates `/docs/:docId` behind a by-space
+ * middleware — a request with no `X-Space-Id` header is rejected (400 space_required) and a header
+ * that does not match the doc's space returns 404. In-shell callers omit `opts` and rely on the
+ * global request interceptor (spaceIdCallback → WKApp.shared.currentSpaceId) to inject the header.
+ * The standalone `/d/:docId` page mounts before that space is restored, so the interceptor injects
+ * nothing; it passes the resolved space here to carry an explicit `X-Space-Id` on the preflight,
+ * which axios merges over (and thus wins against) the interceptor's absent header. A non-empty
+ * `opts.spaceId` is the only trigger — omitting it preserves the exact prior no-header behavior.
  */
-export async function getDoc(docId: string): Promise<DocMeta> {
-  const { data } = await apiClient().get<DocMeta>(`/docs/${docId}`)
+export async function getDoc(docId: string, opts?: { spaceId?: string }): Promise<DocMeta> {
+  const config =
+    opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined
+  const { data } = await apiClient().get<DocMeta>(`/docs/${docId}`, config)
   return data
 }
 

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -68,6 +68,14 @@ export interface DocMeta {
   ownerId?: string
   role?: Role
   updatedAt?: string
+  /**
+   * Canonical collab document key `octo:{space}:{folder}:{doc}` (see documentName/index.ts).
+   * Returned by the per-doc GET so a standalone deep-link (`/d/:docId`), which knows only the
+   * docId and not the owning space/folder, can address collaboration exactly instead of guessing.
+   * Optional / forward-compatible: when the backend omits it, callers fall back to the caller's
+   * current space + default folder (same addressing the in-shell list uses).
+   */
+  documentName?: string
 }
 
 /**

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -98,14 +98,24 @@ export async function getDoc(docId: string): Promise<DocMeta> {
 /**
  * GET /api/v1/users/{uid} — resolve a uid to a human display name. Used by the header "more" menu
  * to render the document creator (the doc's ownerId) as a name instead of a raw uid. The host user
- * payload carries `name` (nickname) and, when the user is verified, `real_name`; we prefer the
- * verified real name and fall back to the nickname. Resilient by contract: it returns `undefined`
- * (never throws for the caller's happy path only — callers still wrap it) when no usable name is
- * present, so the menu can fall back to a short uid / placeholder without crashing.
+ * payload carries `name` (nickname) and, when the user is verified, `real_name`.
+ *
+ * By default (in-shell editor) we prefer the verified real name and fall back to the nickname.
+ * Pass `{ preferRealName: false }` to force the NICKNAME only and never expose `real_name` — the
+ * standalone `/d/:docId` page uses this because it is an externally shareable surface: anyone with
+ * the link would otherwise see the creator's verified legal name (privacy leak, boss decision).
+ *
+ * Resilient by contract: it returns `undefined` when no usable name is present, so the menu can
+ * fall back to a short uid / placeholder without crashing.
  */
-export async function getUserName(uid: string): Promise<string | undefined> {
+export async function getUserName(
+  uid: string,
+  opts: { preferRealName?: boolean } = {},
+): Promise<string | undefined> {
+  const { preferRealName = true } = opts
   const { data } = await apiClient().get<{ name?: string; real_name?: string }>(`/users/${uid}`)
-  const name = (data?.real_name || data?.name || '').trim()
+  const resolved = preferRealName ? data?.real_name || data?.name : data?.name
+  const name = (resolved || '').trim()
   return name || undefined
 }
 


### PR DESCRIPTION
## What & why

Adds a standalone document page so a shared `/d/:docId` link opens the document in a full-window view, outside the app shell (no NavRail). It reuses `EditorShell` for full collaboration parity and only layers on the standalone chrome: a Back control, **Copy link**, and **Open in App**.

Implements the approved design for octo-web #512 (standalone doc page). Pure frontend — no backend changes.

## How it works

- **Mount / routing.** `apps/web/src/Layout` intercepts `/d/:docId` in `render()` using the same early-return pattern as the existing `?invite=` landing, mounting `StandaloneDocPage` and skipping `MainPage`/`NavRail`. (Mounting via the Layout early-branch rather than a `WKApp.route` registration is deliberate: the host route manager is menu-driven, so a menu-less route never activates — the early-branch is the mechanism the `?invite=` deep-link already relies on.)
- **Single deterministic gate.** Before the collaborative editor mounts, the page runs a `GET /api/v1/docs/{docId}` preflight. This resolves every boundary state with **no WebSocket dependency**:
  - `200` → mount the editor.
  - `403` → access-denied (Back only).
  - `404` → not-found.
  - `401` → sign-in screen; the target link is stashed in `sessionStorage` so the post-login flow can return the user to the doc.
  - `409` → locked/archived. This is the archived signal the collab-token path never reports, which is exactly why the preflight exists.
- **`EditorShell` gains an optional `headerRight` prop.** When it (and `onBack`) are omitted, the in-shell header renders exactly as before — the in-shell path is unchanged.
- **`terminalForCreateError` maps `409` to `locked`** alongside `423`.
- The terminal (dead-end) screen is extracted into a shared `DocTerminal`, so the in-shell editor and the standalone page render identical boundary states from one source of truth.
- `GET /docs/{docId}` may now return an optional `documentName`; when present the page addresses collaboration exactly (parses `octo:{space}:{folder}:{doc}`), otherwise it falls back to the caller's current space + default folder — same addressing the in-shell list uses. The field is optional and forward-compatible; no backend change is required for this PR.

## Tests

`cd packages/docs && pnpm test` — 447 passing (10 new).

- `terminalForCreateError`: `409 → locked`.
- `StandaloneDocPage`: `409` renders the locked terminal and **never mounts the editor** (deterministic, driven by the api responder, no WS); plus the full `403`/`404`/`401` preflight set, and the successful-mount + injected Copy link / Open in App path.
- `EditorShell`: in-shell non-regression (no Back control and header unchanged when `onBack`/`headerRight` are absent), and the injected-chrome path when they are provided.
- `parseStandaloneDocId`: path matching / rejection.

The new `409`, `headerRight`, and preflight assertions were confirmed failing on the pre-change tree before the implementation landed.

## Dependency (out of scope here)

Cold-loading a `/d/:docId` link directly requires the SPA fallback (`try_files`) in the nginx config so the deep-link path serves `index.html`. That is a deployment change and is **not** included in this PR (backend/nginx untouched).

Closes #512
