### PR TITLE
fix(message): stop stray stream cursor on settled bot bubbles #300

### DIFF
--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -721,7 +721,15 @@ export class MessageWrap {
 
     // 流式消息是否正在进行中
     public get isStreaming(): boolean {
-        return this.streamOn && this.message.streamFlag !== StreamFlag.END
+        // 仅当 streamFlag 处于「进行中」(START / ING) 时才算正在流式输出。
+        // streamFlag 是直播推流期间由 Conversation VM 从每个 stream 包临时写到
+        // message 上的字段（见 Components/Conversation/vm.ts），并不随历史消息持久化：
+        // 历史消息重新加载后 streamFlag 为 undefined。旧逻辑 `streamFlag !== END`
+        // 会把 undefined 也判成「流式中」，导致每条 Bot 历史回复气泡都残留一个
+        // 闪烁光标（占位气泡看起来像空白输入框，octo-web#300）。改成显式匹配
+        // START / ING 后，历史 / 已结束的流式消息不再被误判为流式中。
+        const flag = this.message.streamFlag
+        return this.streamOn && (flag === StreamFlag.START || flag === StreamFlag.ING)
     }
 
     // 获取流式消息的完整内容（初始内容 + 所有 stream items 的内容拼接）

--- a/packages/dmworkbase/src/Service/__tests__/MessageWrapStreaming.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/MessageWrapStreaming.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+//
+// octo-web#300 regression — Web 端 Bot 消息气泡内多出「空白输入框/光标」。
+//
+// 根因：MessageWrap.isStreaming 旧逻辑为 `streamOn && streamFlag !== END`。
+// streamFlag 只在直播推流期间由 Conversation VM 临时写到 message 上，不随历史
+// 消息持久化——历史消息重载后 streamFlag 为 undefined，`undefined !== END` 恒真，
+// 于是每条已结束 / 历史的流式 Bot 回复都被误判为「流式中」，MarkdownContent
+// 便持续渲染 `.wk-stream-cursor` 闪烁光标（占位气泡看起来像空白输入框）。
+//
+// 修复后：isStreaming 仅在 streamFlag 为 START / ING 时为真。本测试锁定该边界。
+
+import { describe, expect, it, vi } from "vitest";
+import { StreamFlag } from "wukongimjssdk";
+
+// Model.tsx 在模块加载期静态 import 了一批依赖（App / EmojiService / TypingManager
+// / SpaceService 等），其中只有类型 / 方法级引用，isStreaming 本身不依赖它们。
+// 这里给出最小桩，避免拉起整条 App 依赖链。
+vi.mock("../../App", () => ({ default: {} }));
+
+import { MessageWrap } from "../Model";
+
+function wrapStreamMessage(fields: {
+  streamOn?: boolean;
+  streamFlag?: number;
+  text?: string;
+}) {
+  const message: any = {
+    messageSeq: 1,
+    streamOn: fields.streamOn ?? true,
+    streamFlag: fields.streamFlag,
+    content: { text: fields.text ?? "" },
+  };
+  return new MessageWrap(message as any);
+}
+
+describe("MessageWrap.isStreaming — octo-web#300 stray cursor", () => {
+  it("历史/重载消息（streamFlag 缺失）不算流式中，避免残留光标", () => {
+    // 复现场景：streamOn 由持久化的 setting 位得到 → true；streamFlag 未持久化 → undefined。
+    expect(wrapStreamMessage({ streamOn: true, streamFlag: undefined }).isStreaming).toBe(false);
+  });
+
+  it("已结束的流式消息（END）不算流式中", () => {
+    expect(wrapStreamMessage({ streamOn: true, streamFlag: StreamFlag.END }).isStreaming).toBe(false);
+  });
+
+  it("进行中的流式消息（START / ING）仍算流式中", () => {
+    expect(wrapStreamMessage({ streamOn: true, streamFlag: StreamFlag.START }).isStreaming).toBe(true);
+    expect(wrapStreamMessage({ streamOn: true, streamFlag: StreamFlag.ING }).isStreaming).toBe(true);
+  });
+
+  it("非流式消息永远不算流式中", () => {
+    expect(wrapStreamMessage({ streamOn: false, streamFlag: StreamFlag.ING }).isStreaming).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #300 — Web Bot 气泡残留空白输入框/光标

## 1. Executive Summary
- **Bug**: Web 端与 Bot 私聊时，每条 Bot 回复气泡上方多出一个「空白输入框/闪烁光标」占位（芒格、阿基米德等均可复现）。
- **Root Cause**: `MessageWrap.isStreaming`（`packages/dmworkbase/src/Service/Model.tsx`）用 `streamOn && streamFlag !== END` 判定「流式中」；`streamFlag` 只在直播推流期由 Conversation VM 临时写入、不随历史消息持久化，历史消息重载后为 `undefined`，`undefined !== END` 恒真 → 已结束/历史流式消息被误判为流式中，`MarkdownContent` 持续渲染 `.wk-stream-cursor` 闪烁光标。
- **Fix Approach**: minimal（单点收敛 `isStreaming` 语义）
- **Risk Level**: Low
- **PR**: draft（见下方链接）

## 2. Issue Context
- Title: 🐛 [Web] Bot 消息气泡内多出空白输入框
- Reporter: 刘沛（DMWork uid:5ebd42f85c1445c4bbd0c6d677b85056），经 issue-triager 归类 `type:bug / area:frontend / P2`
- bug-verified by: self（本次已用截图 + 浏览器实测复现，v7.5 无人工 gate）
- Affected: Web 端（iOS/Android 无此问题）；所有走流式回复的 Bot 私聊，历史消息尤为明显

## 3. Reproduction
**Environment**: octo-web `main`，Web (Chromium)，`packages/dmworkbase`
**Steps**:
1. Web 打开与 Bot 的私聊；发消息等 Bot 回复。
2. 刷新/重开会话（或查看昨天的历史回复 —— 见截图二 `昨天 23:13`）。
3. 观察 Bot 回复气泡。
**Expected**: 气泡内只显示回复文本。
**Actual**: 文本上方多出一个灰色圆角占位框 + 竖直闪烁光标（形似空白输入框）。
**Evidence**:
- Issue 截图（芒格 / 阿基米德）均为「灰色圆角框内仅一根闪烁竖条」+ 下方回复文本。
- 浏览器实测（Playwright 量测真实 DOM 布局）确认：`MarkdownContent` 在 `isStreaming=true` 且内容为空时，DOM 为 `<div class="wk-markdown"><span class="wk-stream-cursor"></span></div>`，即一根独立竖条光标 —— 与截图完全吻合。

## 4. RCA
**Method**: 5 Whys
**Analysis**:
1. 为何有闪烁竖条？→ `MarkdownContent` 在 `isStreaming` 为真时渲染 `.wk-stream-cursor`（`MarkdownContent.tsx:537`）。
2. 为何已结束的回复 `isStreaming` 仍为真？→ `MessageWrap.isStreaming = streamOn && streamFlag !== END`。
3. 为何 `streamFlag !== END` 恒真？→ 历史/重载消息的 `streamFlag` 为 `undefined`。
4. 为何是 `undefined`？→ `streamFlag` 仅由 `Components/Conversation/vm.ts:872` 在直播推流收到 stream 包时临时写到 message 上，不属于持久化字段；而 `streamOn` 来自持久化的 setting 位，重载后仍为真。
5. 为何移动端无此问题？→ 移动端不依赖该 web 侧临时字段渲染光标。
**Root cause**: `Model.tsx: MessageWrap.isStreaming` 把「`streamFlag` 缺失(undefined)」误当作「流式进行中」。

## 5. Fix Description
**Files changed**:
- `packages/dmworkbase/src/Service/Model.tsx` (+9/-1) —— 收敛 `isStreaming` 判定
- `packages/dmworkbase/src/Service/__tests__/MessageWrapStreaming.test.ts` (+55/-0) —— 回归测试（新增）

**Change summary**: 将 `isStreaming` 由 `streamOn && streamFlag !== END` 改为 `streamOn && (streamFlag === START || streamFlag === ING)`，即仅当存在明确的「进行中」标志时才算流式。直播推流期间 stream 包携带 START/ING → 光标照常显示；结束(END)或历史重载(undefined) → 不再显示光标。这是所有渲染入口（`Messages/Text/index.tsx`、`bridge/message/useTextMessageUI.ts`、`Components/Conversation/index.tsx`）共用的单一真源。

**Does NOT change**（scope 边界）:
- 不改 `MarkdownContent` 渲染逻辑 / 光标 CSS。
- 不改流式内容拼接 `fullStreamContent`。
- 不改 Conversation VM 的推流累积逻辑。

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| 历史/重载消息（streamFlag 缺失）不算流式中 | `MessageWrapStreaming.test.ts` | 锁定根因场景 | FAIL | PASS |
| 已结束(END)不算流式中 | 同上 | END 边界 | PASS | PASS |
| 进行中(START/ING)仍算流式中 | 同上 | 直播不回归 | PASS | PASS |
| 非流式(streamOn=false) 永不流式 | 同上 | 兜底 | PASS | PASS |

（已验证：仅第 1 条在修复前 FAIL、修复后 PASS，其余在两侧均 PASS —— 证明是精确回归。）

## 7. CI Status
- 本地 `vitest run`（packages/dmworkbase）：修复分支 **973 pass / 57 fail**；main 基线 **969 pass / 57 fail**。差异 = 我新增的 4 条测试全部通过。
- Baseline-diff：两侧失败文件集合**完全一致**（PersonaSettings / Claw* / i18n / Mergeforward / oidcLogout 等，均为**既有失败**，与本改动无关），**未引入任何新失败**。
- Linter: 改动为已导入枚举上的单行布尔表达式，符合既有风格；vitest/esbuild 编译两文件均通过。
- Coverage delta: N/A（新增针对性单测）

## 8. Deployment Notes
- Migration required?: no
- Config change?: no
- Feature flag: no
- Compatibility: 向后兼容；纯前端渲染判定收敛，不涉及协议/持久化字段。

## 9. Rollback Plan
**Pattern**: revert（单 commit）
**Steps**: 1. `git revert <sha>` 2. 重新构建部署。
**Detection**（触发回滚）: 若上线后出现「直播流式回复过程中不再显示打字光标」的反馈（说明线上 stream 包未携带 START/ING flag），则回滚并改走「基于 VM 活跃流会话」的判定。

---

### 备注：残留空占位气泡（供 review 参考，非本 PR 范围）
截图显示灰框占位来自一条 `streamOn=true` 且内容为空的历史流式占位消息。本 PR 去掉其闪烁光标（用户明确反馈的「光标/输入框」感知元素即消除）。若该空占位气泡本身（无光标的空灰框）仍被判定为需清理，属服务端是否应下发/前端是否应过滤空流式占位消息的更大范围问题，建议单独跟进，避免在本次最小修复中引入过滤消息列表的高风险改动。

---
_Generated by frontend-engineer · awaiting review squad (qa+security+code)_
