### PR TITLE
fix(datasource): refresh member cache after add/remove subscribers (#514)

### DIFF
--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -120,17 +120,37 @@ export class ChannelDataSource implements IChannelDataSource {
         }
         return channelInfos;
     }
-    removeSubscribers(channel: Channel, uids: string[]): Promise<void> {
-        return WKApp.apiClient.delete(`groups/${channel.channelID}/members`, {
+    async removeSubscribers(channel: Channel, uids: string[]): Promise<void> {
+        await WKApp.apiClient.delete(`groups/${channel.channelID}/members`, {
             data: {
                 members: uids,
             }
         })
+        // Refresh the local member cache so the operator sees the change without a reload.
+        // syncSubscribes fires notifySubscribeChangeListeners -> reloadSubscribers, keeping
+        // the @mention candidate list in sync. A failure here must not fail the remove
+        // itself (members are already removed on the server); worst case degrades back to
+        // needing a manual refresh.
+        try {
+            await WKSDK.shared().channelManager.syncSubscribes(channel)
+        } catch (e) {
+            console.warn("[removeSubscribers] syncSubscribes failed", e)
+        }
     }
-    addSubscribers(channel: Channel, uids: string[]): Promise<void> {
-        return WKApp.apiClient.post(`groups/${channel.channelID}/members`, {
+    async addSubscribers(channel: Channel, uids: string[]): Promise<void> {
+        await WKApp.apiClient.post(`groups/${channel.channelID}/members`, {
             members: uids,
         })
+        // Refresh the local member cache so the operator sees new members without a reload.
+        // syncSubscribes fires notifySubscribeChangeListeners -> reloadSubscribers, keeping
+        // the @mention candidate list in sync. A failure here must not fail the add itself
+        // (members are already added on the server); worst case degrades back to needing a
+        // manual refresh.
+        try {
+            await WKSDK.shared().channelManager.syncSubscribes(channel)
+        } catch (e) {
+            console.warn("[addSubscribers] syncSubscribes failed", e)
+        }
     }
 
     async subscribers(channel: Channel,req:{


### PR DESCRIPTION
## What

Group member add/remove in the web client did not refresh the `@`mention candidate list for the operator who performed the action — removed members stayed in the list and newly added members were missing until a full page reload (F5).

## Why

The `@`mention candidate list reads `ConversationVM.subscribers`, which is only refreshed on channel reopen (F5) or when a `subscriberChangeListener` fires. The `addSubscribers` / `removeSubscribers` datasource methods only issued the HTTP request and the success callback merely closed the panel — the local member cache was never refreshed for the operator's own action.

## How (fix approach B — single convergence point in the datasource layer)

In `packages/dmworkdatasource/src/datasource.ts`, after the members HTTP request succeeds, call `WKSDK.shared().channelManager.syncSubscribes(channel)` for the target group in both `addSubscribers` and `removeSubscribers`.

- `syncSubscribes` internally fires `notifySubscribeChangeListeners` → `ConversationVM.subscriberChangeListener` → `reloadSubscribers`, so the candidate list refreshes live. No extra manual notify is needed.
- This single convergence point covers every UI entry (group settings, contacts `GroupNew`) without touching each call site.
- Removed members are correctly dropped: the backend bumps the member-sync version and returns an `is_deleted` tombstone, which the incremental pull filters out. No frontend or backend change is required for the delete case.
- The refresh is best-effort — a network failure is caught and logged (`console.warn`) so it never rolls back the add/remove itself. Worst case degrades back to the previous need-F5 behavior.

## Testing

- `packages/dmworkdatasource` vitest suite: 41 passed.
- No new type errors introduced in the changed file (verified against baseline).

Closes #514
