### PR TITLE
fix(mention): sync group subscribers after local add/remove #514

### DIFF
--- a/packages/dmworkbase/src/Utils/__tests__/subscriberSync.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/subscriberSync.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const channelManager = vi.hoisted(() => ({
+  syncSubscribes: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("wukongimjssdk", () => {
+  const ChannelTypeGroup = 2;
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+    getChannelKey() {
+      return `${this.channelID}-${this.channelType}`;
+    }
+  }
+  const sdk = { shared: () => ({ channelManager }) };
+  return { default: sdk, WKSDK: sdk, Channel, ChannelTypeGroup };
+});
+
+import { syncSubscribersAfterMembershipChange } from "../subscriberSync";
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+
+describe("subscriberSync", () => {
+  beforeEach(() => {
+    channelManager.syncSubscribes.mockClear();
+  });
+
+  it("issue 514: syncs subscribers after a local membership change so the mention list refreshes without a page reload", async () => {
+    const channel = new Channel("group1", ChannelTypeGroup);
+
+    await syncSubscribersAfterMembershipChange(channel);
+
+    // addSubscribers/removeSubscribers only mutate the server; the local cache
+    // and subscriber-change listeners (which feed the @mention candidate list)
+    // are only refreshed by channelManager.syncSubscribes.
+    expect(channelManager.syncSubscribes).toHaveBeenCalledTimes(1);
+    expect(channelManager.syncSubscribes).toHaveBeenCalledWith(channel);
+  });
+
+  it("issue 514: swallows sync errors so the settings action still completes", async () => {
+    channelManager.syncSubscribes.mockImplementationOnce(() =>
+      Promise.reject(new Error("network"))
+    );
+    const channel = new Channel("group1", ChannelTypeGroup);
+
+    await expect(
+      syncSubscribersAfterMembershipChange(channel)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/dmworkbase/src/Utils/subscriberSync.ts
+++ b/packages/dmworkbase/src/Utils/subscriberSync.ts
@@ -1,0 +1,28 @@
+import { Channel, WKSDK } from "wukongimjssdk";
+
+/**
+ * 本地添加/移除群成员成功后，主动同步订阅者列表 (octo-web#514)。
+ *
+ * `channelDataSource.addSubscribers` / `removeSubscribers` 只把变更写到服务端，
+ * **不会**刷新 SDK 的本地成员缓存，也不会触发 `SubscriberChangeListener`。
+ * 消费方（如 Conversation VM，其监听器为 MessageInput 的 @mention 候选列表供数）
+ * 因此拿不到更新，直到用户刷新页面才会从 version 0 全量重拉。
+ *
+ * `channelManager.syncSubscribes` 会按 version 拉取增量成员（新增成员被并入缓存，
+ * 被移除成员带 `is_deleted` 回来并被 `getSubscribes` 过滤掉），随后
+ * `notifySubscribeChangeListeners`，让候选列表立即刷新——无需刷新页面。
+ *
+ * 与已有的服务端推送路径（CMD `memberUpdate`、`addMembers`/`removeMembers`
+ * 系统消息）走同一个 `syncSubscribes` 入口，保持行为一致。
+ *
+ * 同步失败不应中断设置面板的收尾流程，故吞掉异常。
+ */
+export function syncSubscribersAfterMembershipChange(
+  channel: Channel
+): Promise<void> {
+  return Promise.resolve(
+    WKSDK.shared().channelManager.syncSubscribes(channel)
+  )
+    .then(() => undefined)
+    .catch(() => undefined);
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -102,6 +102,7 @@ import { ApproveGroupMemberCell } from "./Messages/ApproveGroupMember";
 import { notificationUtil } from "./Utils/NotificationUtil";
 import { resolveExternalForViewer } from "./Utils/externalViewer";
 import { isGroupDisbanded, isChannelDisbanded, isConversationDisbanded } from "./Utils/groupDisband";
+import { syncSubscribersAfterMembershipChange } from "./Utils/subscriberSync";
 import {
   copyImageToClipboard,
   copyRichTextToClipboard,
@@ -1521,6 +1522,8 @@ export default class BaseModule implements IModule {
                             return item.id;
                           })
                         );
+                        // 本地拉人只写服务端，主动同步以刷新 @mention 候选列表 (octo-web#514)
+                        await syncSubscribersAfterMembershipChange(channel);
                         context.pop();
                       }
                       addFinishButtonContext.loading(false);
@@ -1556,6 +1559,8 @@ export default class BaseModule implements IModule {
                         )
                         .then(() => {
                           removeFinishButtonContext.loading(false);
+                          // 本地移除成员只写服务端，主动同步以刷新 @mention 候选列表 (octo-web#514)
+                          void syncSubscribersAfterMembershipChange(channel);
                           context.pop();
                         })
                         .catch((err) => {


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #514 — PR (draft)

## 1. Executive Summary
- **Bug**: In a web group chat, the @mention candidate list does not reflect members added/removed by the current user until the page is refreshed.
- **Root Cause**: `module.tsx` group-settings add/remove handlers call `channelDataSource.addSubscribers` / `removeSubscribers` (server-only) but never `channelManager.syncSubscribes`, so the local subscriber cache and `SubscriberChangeListener` are never refreshed for the operator.
- **Fix Approach**: minimal (localized)
- **Risk Level**: Low
- **PR**: draft

## 2. Issue Context
- Title: Web group chat: @mention member list does not update after adding/removing members until page refresh
- Reporter: octo-web#514
- bug-verified by: self (v7.5 — no human gate; dispatched by triager)
- Affected: web client, group chat @mention input

## 3. Reproduction
**Environment**: octo-web (React monorepo), web client, group chat.
**Steps**:
1. Open a group chat in the web client.
2. Add a new member (or remove an existing one) via group settings → members.
3. Without refreshing, type `@` in the message input to trigger the mention list.
4. Observe the candidate list.

**Expected**: candidate list reflects current membership immediately.
**Actual**: candidate list shows old membership; only updates after a page refresh.
**Evidence**: The mention items are sourced from `MessageInput` → `localMembersRef` ← `props.members` ← `ConversationVM.subscribers`, which is only updated by its `subscriberChangeListener`. That listener fires exclusively from `channelManager.syncSubscribes` → `notifySubscribeChangeListeners`. The local add/remove flow never calls `syncSubscribes`, so no notification is emitted to the operator; a page reload works only because a fresh load re-syncs from `version 0`.

## 4. RCA
**Method**: 5 Whys
**Analysis**:
1. Why is the mention list stale? → `ConversationVM.subscribers` isn't updated after the change.
2. Why not? → its `subscriberChangeListener` never fires.
3. Why not? → the listener only fires from `channelManager.notifySubscribeChangeListeners`, called inside `syncSubscribes`.
4. Why isn't `syncSubscribes` called? → the local add/remove handlers in `module.tsx` only call `addSubscribers` / `removeSubscribers` (server-side writes) and then `context.pop()`; server-push paths (`memberUpdate` CMD, add/remove system messages) do call `syncSubscribes`, but the operator's own action does not, and those pushes are not relied upon locally.
5. Why does refresh fix it? → a fresh conversation load re-syncs subscribers from `version 0`, rebuilding the cache without the removed member / with the added one.

**Root cause**: `packages/dmworkbase/src/module.tsx` — the `onFinish` handlers for the members "add" and "remove" settings actions omit a subscriber sync after the mutation succeeds.

## 5. Fix Description
**Files changed**:
- `packages/dmworkbase/src/Utils/subscriberSync.ts` (new, +28) — `syncSubscribersAfterMembershipChange(channel)` helper that delegates to `channelManager.syncSubscribes` and swallows errors.
- `packages/dmworkbase/src/module.tsx` (+5) — call the helper after `addSubscribers` and after `removeSubscribers` succeed.
- `packages/dmworkbase/src/Utils/__tests__/subscriberSync.test.ts` (new, +54) — regression tests.

**Change summary**: After a local membership mutation succeeds, trigger `syncSubscribes(channel)` — the same delta-sync entry point already used by the `memberUpdate` CMD and the `addMembers`/`removeMembers` system-message handlers. It merges added members into the SDK cache and marks removed members `is_deleted` (which `getSubscribes` filters out), then notifies `SubscriberChangeListener`s. That propagates through `ConversationVM.reloadSubscribers` → `notifyListener` → re-render → `MessageInput` `localMembersRef`, so the @mention list is fresh without a reload.

**Does NOT change** (scope boundary): the mention rendering/parse pipeline, the sync provider callback, super-group paging, or the 1-1 "create channel" branch of the add action.

## 6. Regression Tests
| Test | File | Purpose | Before | After |
|---|---|---|---|---|
| issue 514: syncs subscribers after a local membership change… | `Utils/__tests__/subscriberSync.test.ts` | asserts `syncSubscribes(channel)` is invoked | FAIL (module missing) | PASS |
| issue 514: swallows sync errors so the settings action still completes | `Utils/__tests__/subscriberSync.test.ts` | error isolation | FAIL (module missing) | PASS |

## 7. CI Status
- Linter: N/A — `dmworkbase` has no package `lint` script and the root ESLint config is commented out; nothing to run for these files.
- Unit (vitest, `packages/dmworkbase`): baseline `67 failed / 1118 passed` (133 files) → after `67 failed / 1120 passed` (134 files).
- **new failures: 0** — the 67 pre-existing failures are an environmental React 17/18 renderer mismatch (`Invalid hook call`), identical file set before and after (`diff` clean).
- Integration: N/A — change is unit-level.
- Coverage delta: +2 passing tests for the new helper.

## 8. Deployment Notes
- Migration required?: no
- Config change?: no
- Feature flag: no
- Compatibility: backward compatible; only adds a sync call already used elsewhere in the same module.

## 9. Rollback Plan
**Pattern**: revert
**Steps**:
1. `git revert` the fix commit (or drop the two `syncSubscribersAfterMembershipChange` call sites).
2. Behavior returns to prior state (mention list stale until refresh).
**Detection** (trigger rollback): reports of duplicate/incorrect member sync, or an increase in `groups/{id}/membersync` request errors after add/remove.

---

**Verification block (baseline diff)**
```
baseline failures: 67 (pre-existing, React 17/18 renderer mismatch — env)
after failures: 67 (same file set; diff clean)
new failures: 0
repro subscriberSync.test.ts: GREEN (2/2)
```

_Generated by backend-engineer · awaiting review squad (qa+security+code)_
