### PR TITLE
fix(channel-webhook): drop stale member name-prefix hint

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -111,8 +111,7 @@ function readGroupMemberOptions(channel: Channel): MentionMemberOption[] {
 /**
  * 新建 / 编辑 webhook 弹窗。
  *
- * - 名称可留空：服务端自动命名 `Webhook-<id 后缀>`；
- *   普通成员自定义名称时服务端会强制加 `Webhook-` 前缀，表单下方有提示。
+ * - 名称可留空：服务端自动命名 `Webhook-<id 后缀>`；成员/管理员均可自定义任意名称。
  * - 头像仅管理员可设（URL 形式）；空值不随请求发送。
  */
 export default function WebhookEditModal({
@@ -330,11 +329,6 @@ export default function WebhookEditModal({
                             }
                         }}
                     />
-                    {!isManager && (
-                        <div className="wk-webhook-form__hint">
-                            {t("base.channelWebhook.form.memberPrefixHint")}
-                        </div>
-                    )}
                 </div>
                 {isManager && (
                     <div className="wk-webhook-form__field">

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -529,7 +529,6 @@
   "channelWebhook.form.editTitle": "Edit webhook",
   "channelWebhook.form.name": "Name",
   "channelWebhook.form.namePlaceholder": "Leave empty to auto-generate",
-  "channelWebhook.form.memberPrefixHint": "Webhooks created by regular members are automatically prefixed with Webhook-",
   "channelWebhook.form.avatar": "Avatar URL",
   "channelWebhook.form.avatarPlaceholder": "https://example.com/avatar.png",
   "channelWebhook.form.avatarHint": "Optional. Shown as the sender avatar of webhook messages",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -529,7 +529,6 @@
   "channelWebhook.form.editTitle": "编辑 Webhook",
   "channelWebhook.form.name": "名称",
   "channelWebhook.form.namePlaceholder": "留空将自动命名",
-  "channelWebhook.form.memberPrefixHint": "普通成员创建的 Webhook 名称会自动加上 Webhook- 前缀",
   "channelWebhook.form.avatar": "头像 URL",
   "channelWebhook.form.avatarPlaceholder": "https://example.com/avatar.png",
   "channelWebhook.form.avatarHint": "可选，作为该 Webhook 消息的发送者头像",


### PR DESCRIPTION
## Summary

`octo-server` (Mininglamp-OSS/octo-server#526) removed the forced `Webhook-` name prefix it used to prepend to non-admin members' incoming-webhook names. This follows up on the frontend: removes the now-inaccurate hint text shown under the name field in the webhook create/edit modal for non-admin users, and its now-unused i18n key.

## Related Issue

None (paired with Mininglamp-OSS/octo-server#526).

## Changes

- `packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx`: removed the `!isManager` hint block ("Webhooks created by regular members are automatically prefixed with Webhook-") below the name input, and updated the component doc comment that described the old forced-prefix behavior.
- `packages/dmworkbase/src/i18n/locales/en-US.json` / `zh-CN.json`: removed the now-unused `channelWebhook.form.memberPrefixHint` key from both locales (verified key sets stay identical between the two files).

No behavior change beyond removing the hint — the frontend never enforced the prefix itself, it only echoed whatever name the server returned, so this is a pure copy/dead-code removal.

## Testing

- [ ] Unit tests added/updated
- [x] Manually verified

No test assertions referenced the removed hint or i18n key (verified via repo-wide grep). Verified both edited locale JSON files still parse and stay key-parallel. **Could not run `pnpm lint` / `pnpm test`** — `pnpm install` failed in this sandbox (the configured `registry.npmmirror.com` returned 403 through the sandbox's proxy, and overriding to the public registry was blocked by the environment's policy as an unauthorized registry bypass). The diff is JSX/JSON-only with no logic change; recommend running `pnpm lint` and `cd apps/web && pnpm test` before merge.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes — N/A: pure dead-code/copy removal, no new logic to cover; verified no existing test references the removed hint/key
- [x] Updated documentation
- [ ] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy — could not run the tool (see Testing); manually confirmed both locale JSON files parse and stay key-parallel as a substitute
- [x] Followed commit message conventions (Conventional Commits)


---
_Generated by [Claude Code](https://claude.ai/code/session_016Tvp1R2hBrba4T2nozUdbM)_