### PR TITLE
feat(sticker): gate custom sticker entry by appconfig flag

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -217,6 +217,14 @@ export class WKRemoteConfig {
    */
   suppressLoginMigrationNotice: boolean = false;
   /**
+   * 自定义贴纸管理入口开关。后端字段 sticker_custom_enabled 为 true 时，前端展示
+   * 「我的贴纸」tab 及上传/删除入口；false 或字段缺失时隐藏。
+   *
+   * 纯 UI 展示开关，不承担鉴权语义: /v1/sticker/user 相关接口的权限/限流/所有权
+   * 校验仍由后端负责，前端不能据此推断用户是否具备上传能力。
+   */
+  stickerCustomEnabled: boolean = false;
+  /**
    * OIDC provider 元数据数组, 由后端 /v1/common/appconfig 的 oidc_providers 字段下发。
    * OIDC 关闭时为空数组。前端不再硬编码具体 IdP, 部署 env 切 provider。
    * 顶层 oidc_account_url / oidc_reset_password_url 是后端兼容老前端用的,新前端只读这里。
@@ -315,6 +323,7 @@ export class WKRemoteConfig {
       const previousMessagesSearchOn = this.messagesSearchOn;
       const previousSuppressLoginMigrationNotice =
         this.suppressLoginMigrationNotice;
+      const previousStickerCustomEnabled = this.stickerCustomEnabled;
       this.requestSuccess = true;
       this.revokeSecond = result["revoke_second"];
       this.threadOn = !!result["thread_on"];
@@ -325,6 +334,9 @@ export class WKRemoteConfig {
       this.suppressLoginMigrationNotice = parseRemoteBool(
         result["suppress_login_migration_notice"]
       );
+      this.stickerCustomEnabled = parseRemoteBool(
+        result["sticker_custom_enabled"]
+      );
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();
@@ -332,7 +344,8 @@ export class WKRemoteConfig {
         previousDisableUserCreateSpace !== this.disableUserCreateSpace ||
         previousMessagesSearchOn !== this.messagesSearchOn ||
         previousSuppressLoginMigrationNotice !==
-          this.suppressLoginMigrationNotice
+          this.suppressLoginMigrationNotice ||
+        previousStickerCustomEnabled !== this.stickerCustomEnabled
       ) {
         this.notifyConfigChangeListeners();
       }

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// 可变 mock state, 让 test 能运行时切换 flag 并手动触发 configChangeListener 回调,
+// 忠实模拟 App.tsx notifyConfigChangeListeners 的真实运行时行为。
+const hoisted = vi.hoisted(() => {
+    const state = {
+        stickerCustomEnabled: true,
+        listener: null as (() => void) | null,
+    };
+    return {
+        state,
+        getAllEmoji: vi.fn().mockReturnValue([]),
+        userStickers: vi.fn().mockResolvedValue({ list: [] }),
+        addConfigChangeListener: vi.fn((cb: () => void) => {
+            state.listener = cb;
+            return () => {
+                if (state.listener === cb) state.listener = null;
+            };
+        }),
+        mittOn: vi.fn(),
+        mittOff: vi.fn(),
+    };
+});
+
+vi.mock("../../../App", () => ({
+    default: {
+        endpointManager: {
+            invoke: () => ({ getAllEmoji: hoisted.getAllEmoji }),
+        },
+        mittBus: { on: hoisted.mittOn, off: hoisted.mittOff },
+        remoteConfig: {
+            // getter: EmojiPanel.render 每次都读最新值, 与真实 WKRemoteConfig 单例语义一致。
+            get stickerCustomEnabled() {
+                return hoisted.state.stickerCustomEnabled;
+            },
+            addConfigChangeListener: hoisted.addConfigChangeListener,
+        },
+        dataSource: {
+            commonDataSource: {
+                userStickers: hoisted.userStickers,
+                getFileURL: (p: string) => p,
+            },
+        },
+    },
+    __esModule: true,
+}));
+
+vi.mock("../../../i18n", () => ({
+    t: (key: string) => key,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+    Toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+        warning: vi.fn(),
+        info: vi.fn(),
+    },
+}));
+
+// LottieSticker 只被 EmojiToolbar (非 EmojiPanel) 用到, 但 index.tsx 顶部 import
+// 拉入的 tgs-player / lottie-web 在 jsdom 下会 crash, 直接 stub。
+vi.mock("../../../Messages/LottieSticker", () => ({
+    LottieSticker: class {},
+    isBitmapStickerFormat: () => true,
+}));
+
+// IconClick 只被 EmojiToolbar 用, EmojiPanel 不渲染它; stub 掉避免副作用。
+vi.mock("../../IconClick", () => ({
+    default: (props: any) =>
+        React.createElement("div", { onClick: props.onClick }),
+}));
+
+// require("./emoji_tab_icon.png") 在 EmojiPanel.render 里被调用, 让 vitest 有静态 stub。
+vi.mock("../emoji_tab_icon.png", () => ({ default: "stub.png" }));
+
+import { EmojiPanel } from "../index";
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+    hoisted.state.stickerCustomEnabled = true;
+    hoisted.state.listener = null;
+    hoisted.addConfigChangeListener.mockClear();
+    hoisted.getAllEmoji.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+});
+
+function render(el: React.ReactElement) {
+    act(() => {
+        ReactDOM.render(el, container);
+    });
+}
+
+function tabs(): Element[] {
+    return Array.from(container.querySelectorAll(".wk-emojipanel-tab-item"));
+}
+
+describe("EmojiPanel sticker gating", () => {
+    it("renders the sticker tab when stickerCustomEnabled is true", () => {
+        hoisted.state.stickerCustomEnabled = true;
+        render(<EmojiPanel />);
+        expect(tabs()).toHaveLength(2);
+    });
+
+    it("hides the sticker tab and all sticker controls when stickerCustomEnabled is false", () => {
+        hoisted.state.stickerCustomEnabled = false;
+        render(<EmojiPanel />);
+        expect(tabs()).toHaveLength(1);
+        expect(container.querySelector(".wk-sticker-add")).toBeNull();
+        expect(container.querySelector(".wk-sticker-item")).toBeNull();
+        expect(container.querySelector(".wk-sticker-empty")).toBeNull();
+    });
+
+    it("falls back to the emoji view when the flag flips false while the panel is on the sticker tab", () => {
+        hoisted.state.stickerCustomEnabled = true;
+        render(<EmojiPanel />);
+
+        const stickerTab = tabs()[1];
+        act(() => {
+            stickerTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        // 前置校验: 切换后确实进入了 sticker 视图, 上传入口渲染出来。
+        expect(container.querySelector(".wk-sticker-add")).not.toBeNull();
+
+        // 模拟后端翻 flag + notifyConfigChangeListeners。
+        hoisted.state.stickerCustomEnabled = false;
+        act(() => {
+            hoisted.state.listener?.();
+        });
+
+        expect(tabs()).toHaveLength(1);
+        expect(container.querySelector(".wk-sticker-add")).toBeNull();
+        expect(container.querySelector(".wk-sticker-item")).toBeNull();
+    });
+
+    it("subscribes on mount and unsubscribes on unmount", () => {
+        hoisted.state.stickerCustomEnabled = true;
+        render(<EmojiPanel />);
+        expect(hoisted.addConfigChangeListener).toHaveBeenCalledTimes(1);
+        expect(hoisted.state.listener).not.toBeNull();
+
+        act(() => {
+            ReactDOM.unmountComponentAtNode(container);
+        });
+        expect(hoisted.state.listener).toBeNull();
+    });
+});

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -16,6 +16,8 @@ const hoisted = vi.hoisted(() => {
         state,
         getAllEmoji: vi.fn().mockReturnValue([]),
         userStickers: vi.fn().mockResolvedValue({ list: [] }),
+        uploadSticker: vi.fn().mockResolvedValue({ path: "sticker-path", format: "png" }),
+        addSticker: vi.fn().mockResolvedValue({}),
         addConfigChangeListener: vi.fn((cb: () => void) => {
             state.listener = cb;
             return () => {
@@ -43,6 +45,8 @@ vi.mock("../../../App", () => ({
         dataSource: {
             commonDataSource: {
                 userStickers: hoisted.userStickers,
+                uploadSticker: hoisted.uploadSticker,
+                addSticker: hoisted.addSticker,
                 getFileURL: (p: string) => p,
             },
         },
@@ -88,6 +92,9 @@ beforeEach(() => {
     hoisted.state.listener = null;
     hoisted.addConfigChangeListener.mockClear();
     hoisted.getAllEmoji.mockClear();
+    hoisted.uploadSticker.mockClear();
+    hoisted.addSticker.mockClear();
+    hoisted.userStickers.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
 });
@@ -157,5 +164,41 @@ describe("EmojiPanel sticker gating", () => {
             ReactDOM.unmountComponentAtNode(container);
         });
         expect(hoisted.state.listener).toBeNull();
+    });
+
+    it("does not upload when the flag flips false between opening the file picker and picking a file", async () => {
+        // 覆盖 review 里 Jerry-Xin 标出的 race window: 「+ 按钮点击 → 用户选文件」之间的异步窗口,
+        // 后端灰度翻掉 stickerCustomEnabled 后, onFileChange 不应再走 uploadSticker/addSticker。
+        hoisted.state.stickerCustomEnabled = true;
+        render(<EmojiPanel />);
+
+        // 切到 sticker tab, 让 file input 及关联 handler 挂上。
+        const stickerTab = tabs()[1];
+        act(() => {
+            stickerTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+        expect(fileInput).not.toBeNull();
+
+        // 模拟浏览器把用户选中的文件塞到 fileInput.files。
+        const file = new File(["hello"], "s.png", { type: "image/png" });
+        Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+
+        // 用户在 file picker 里犹豫的这段时间, 后端灰度关闭了 flag。
+        hoisted.state.stickerCustomEnabled = false;
+        act(() => {
+            hoisted.state.listener?.();
+        });
+
+        // 用户最终确认了选择, onFileChange 触发。
+        await act(async () => {
+            fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+            // 等 microtask 让 async onFileChange 走完 early guard。
+            await Promise.resolve();
+        });
+
+        expect(hoisted.uploadSticker).not.toHaveBeenCalled();
+        expect(hoisted.addSticker).not.toHaveBeenCalled();
     });
 });

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -155,6 +155,8 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     // 故用 isUnmounted 守卫（PR#496 review，参照 ThreadPanel）。
     private isUnmounted = false
     private stickersLoaded = false
+    // 订阅 appconfig 字段变化，让 sticker_custom_enabled 灰度切换后无需刷新前台即可生效。
+    private removeConfigChangeListener?: () => void
 
     constructor(props: any) {
         super(props)
@@ -174,6 +176,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         // 表情清单（服务端内置表情，web#492）异步到达后刷新选择器，否则面板若在
         // load() 完成前挂载，要重开才显示新表情。
         WKApp.mittBus.on("emoji-manifest-updated", this._onEmojiManifestUpdated)
+        this.removeConfigChangeListener = WKApp.remoteConfig.addConfigChangeListener(
+            this._onRemoteConfigChange
+        )
         // 贴纸列表延迟到首次切到「我的贴纸」tab 时再拉（ensureStickersLoaded），
         // 避免每次打开表情面板都打一次 sticker/user 请求（PR#496 review P2-1）。
     }
@@ -181,6 +186,8 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     componentWillUnmount() {
         this.isUnmounted = true
         WKApp.mittBus.off("emoji-manifest-updated", this._onEmojiManifestUpdated)
+        this.removeConfigChangeListener?.()
+        this.removeConfigChangeListener = undefined
     }
 
     private _onEmojiManifestUpdated = () => {
@@ -188,6 +195,15 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
             return
         }
         this.setState({ emojis: this.emojiService.getAllEmoji() })
+    }
+
+    private _onRemoteConfigChange = () => {
+        if (this.isUnmounted) {
+            return
+        }
+        // 开关值直接从 WKApp.remoteConfig 读取, 用 forceUpdate 触发 render 拾取最新值。
+        // 不需要拷贝到 state, 避免 state 与 remoteConfig 双源不一致。
+        this.forceUpdate()
     }
 
     requestStickers(): Promise<void> {
@@ -275,7 +291,11 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     render(): React.ReactNode {
         const { emojis, category, stickers, uploading } = this.state
         const { onEmoji, onSticker } = this.props
-        const isSticker = category === STICKER_CATEGORY
+        // stickerCustomEnabled 关闭时: 隐藏贴纸 tab, 并把 isSticker 强制视为 false, 兜住
+        // 「面板已打开且当前在 sticker tab, 后端灰度关掉开关」的边界——避免 tab 消失但
+        // 内容区仍渲染上传/删除入口。纯 render-time 计算, 不触碰 state。
+        const stickerCustomEnabled = WKApp.remoteConfig.stickerCustomEnabled
+        const isSticker = stickerCustomEnabled && category === STICKER_CATEGORY
         return <div className="wk-emojipanel">
             <div className={classNames("wk-emojipanel-content", isSticker ? "wk-emojipanel-content-sticker" : undefined)}>
                 <ul>
@@ -336,18 +356,20 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
                 }}>
                     <img alt="" src={require("./emoji_tab_icon.png")}></img>
                 </div>
-                <div className={classNames("wk-emojipanel-tab-item", isSticker ? "wk-emojipanel-tab-item-selected" : undefined)} onClick={(e) => {
-                    e.stopPropagation()
-                    this.setState({ category: STICKER_CATEGORY })
-                    this.ensureStickersLoaded()
-                }} title={t("base.sticker.tab")}>
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-                        <rect x="3" y="3" width="18" height="18" rx="5" stroke="currentColor" strokeWidth="1.8" />
-                        <circle cx="9" cy="10" r="1.2" fill="currentColor" />
-                        <circle cx="15" cy="10" r="1.2" fill="currentColor" />
-                        <path d="M8.5 14 a3.5 2.5 0 0 0 7 0" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-                    </svg>
-                </div>
+                {stickerCustomEnabled ? (
+                    <div className={classNames("wk-emojipanel-tab-item", isSticker ? "wk-emojipanel-tab-item-selected" : undefined)} onClick={(e) => {
+                        e.stopPropagation()
+                        this.setState({ category: STICKER_CATEGORY })
+                        this.ensureStickersLoaded()
+                    }} title={t("base.sticker.tab")}>
+                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+                            <rect x="3" y="3" width="18" height="18" rx="5" stroke="currentColor" strokeWidth="1.8" />
+                            <circle cx="9" cy="10" r="1.2" fill="currentColor" />
+                            <circle cx="15" cy="10" r="1.2" fill="currentColor" />
+                            <path d="M8.5 14 a3.5 2.5 0 0 0 7 0" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                        </svg>
+                    </div>
+                ) : undefined}
             </div>
             <input
                 ref={(ref) => { this.fileInput = ref }}

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -238,6 +238,13 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         if (!file) {
             return
         }
+        // "+ 按钮点击 → 用户选文件" 之间的异步窗口内, 后端可能通过 appconfig 灰度把
+        // stickerCustomEnabled 翻 false, 此时贴纸 tab / 上传按钮已从 UI 消失。沿用旧回调
+        // 继续上传会与「入口已下线」的 UX 语义冲突, 也让请求白跑一趟。后端 /v1/sticker/user
+        // 仍是最终守卫, 这里只是配合 UI 门控。
+        if (!WKApp.remoteConfig.stickerCustomEnabled) {
+            return
+        }
         if (!ACCEPTED_STICKER_TYPES.includes(file.type)) {
             Toast.error(t("base.sticker.formatUnsupported"))
             return


### PR DESCRIPTION
## Summary

- Read new backend field `sticker_custom_enabled` from `/v1/common/appconfig` into `WKRemoteConfig`, defaulting to `false` so missing field / failed fetch fails safe (entry hidden).
- Hide the "my stickers" tab and its upload/delete controls in `EmojiPanel` when the flag is disabled.
- Subscribe `EmojiPanel` to `addConfigChangeListener` and `forceUpdate` on change, so backend toggles take effect without a page reload. The `isSticker` derivation ANDs the flag in as well to cover the edge case where the panel is open on the sticker tab when the backend flips the flag.

## Notes

- The flag is a **pure UI switch**. Backend still owns auth, rate limiting and ownership checks on `/v1/sticker/user`; the frontend must not infer capability from it.
- No new dependency, no CSS, no i18n changes.
- `parseRemoteBool` is reused (existing util in `packages/dmworkbase/src/Utils/remoteConfig.ts`), consistent with sibling flags like `disable_user_create_space` and `suppress_login_migration_notice`.

## Test plan

- [ ] Manually verified against `im-test` backend (returns `sticker_custom_enabled: false` today): sticker tab is hidden, only the emoji tab renders.
- [ ] Flip the backend flag to `true` (or mock it): sticker tab and upload/delete controls appear; upload/delete flows unchanged.
- [ ] Runtime toggle: while the emoji panel is open on the sticker tab, backend flips the flag to `false` on next `appconfig` refresh; the sticker tab disappears and the content area falls back to the emoji list (no `setState`-in-render warnings).
- [ ] `appconfig` fetch failure / missing field: entry hidden by default.
- [ ] `pnpm lint` and `pnpm build` locally.