### PR TITLE
fix(frontend): dedup re-sent snapshot blocks after mid-flight draft change #240

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -15,6 +15,13 @@
  *   editor only if it still holds exactly what was sent, and remove only the
  *   top attachments that were actually consumed.
  *
+ * Round 3 — sent snapshot lingered and was RE-SENT (dedup, Jerry-Xin record):
+ *   The round-2 guard left the already-sent blocks in the live doc alongside
+ *   the new draft, so the next send re-sent them (a duplicate). The fix
+ *   subtracts the sent snapshot from the live document (`removeSentSnapshot` /
+ *   `removeSentEditorContent`), keeping only what the user typed during the
+ *   window, and releases the consumed pasted-image File refs / preview URLs.
+ *
  * The contract these tests lock in:
  *   - send resolves false  → editor preserved; no top attachment removed.
  *   - send throws          → same as false.
@@ -28,25 +35,39 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { runSendWithCleanup, SendCleanup } from "../sendFlow";
+import {
+  runSendWithCleanup,
+  removeSentSnapshot,
+  SendCleanup,
+  EditorJSONNode,
+} from "../sendFlow";
 
 interface RecordingCleanup extends SendCleanup {
   calls: string[];
   removedIds: string[];
   editorUnchanged: boolean;
+  sentContentRemoved: boolean;
 }
 
-function makeCleanup(opts?: { editorUnchanged?: boolean }): RecordingCleanup {
+function makeCleanup(opts?: {
+  editorUnchanged?: boolean;
+  sentContentRemoved?: boolean;
+}): RecordingCleanup {
   const calls: string[] = [];
   const removedIds: string[] = [];
   const state = {
     calls,
     removedIds,
     editorUnchanged: opts?.editorUnchanged ?? true,
+    sentContentRemoved: opts?.sentContentRemoved ?? true,
     isEditorUnchanged: vi.fn(() => state.editorUnchanged),
     deleteEditorAttachmentRefs: vi.fn(() => calls.push("deleteEditorAttachmentRefs")),
     revokeEditorPreviewUrls: vi.fn(() => calls.push("revokeEditorPreviewUrls")),
     clearEditor: vi.fn(() => calls.push("clearEditor")),
+    removeSentEditorContent: vi.fn(() => {
+      calls.push("removeSentEditorContent");
+      return state.sentContentRemoved;
+    }),
     removeTopAttachments: vi.fn((ids: string[]) => {
       calls.push("removeTopAttachments");
       removedIds.push(...ids);
@@ -146,7 +167,7 @@ describe("runSendWithCleanup — round 1: mixed send failure preserves draft", (
 });
 
 describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the NEXT draft", () => {
-  it("does NOT clear the editor when the user started a new draft during the await, even on success", async () => {
+  it("does NOT clear the whole editor when the user started a new draft during the await, even on success", async () => {
     // editor changed during the await → isEditorUnchanged() returns false.
     const cleanup = makeCleanup({ editorUnchanged: false });
     const send = vi.fn().mockResolvedValue(true);
@@ -155,10 +176,10 @@ describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the N
 
     // Send still reported success...
     expect(ok).toBe(true);
-    // ...but the live (newer) editor draft must survive untouched.
+    // ...and the whole-editor clear (which would wipe the newer draft) is never
+    // used; only the targeted dedup removal runs.
     expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
-    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
+    expect(cleanup.removeSentEditorContent).toHaveBeenCalledTimes(1);
     expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
   });
 
@@ -172,7 +193,7 @@ describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the N
     // newly queued attachment — safe regardless of editor changes.
     expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
     expect(cleanup.removedIds).toEqual(["t1", "t2"]);
-    // Editor itself preserved.
+    // Whole-editor clear is never used in the changed-editor path.
     expect(cleanup.clearEditor).not.toHaveBeenCalled();
   });
 
@@ -183,6 +204,8 @@ describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the N
     await runSendWithCleanup(send, [], cleanup);
 
     expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    // Targeted dedup is only for the changed-editor path.
+    expect(cleanup.removeSentEditorContent).not.toHaveBeenCalled();
   });
 
   it("pure-text send: a new draft typed during ack wait is not wiped by the old send", async () => {
@@ -201,6 +224,178 @@ describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the N
 
     expect(ok).toBe(true);
     expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSendWithCleanup — round 3: dedup removes the already-sent snapshot from the live editor", () => {
+  it("on success with a changed editor, subtracts the sent snapshot so it is not re-sent", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: false, sentContentRemoved: true });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(true);
+    // The targeted dedup removal runs (instead of a blanket clear)...
+    expect(cleanup.removeSentEditorContent).toHaveBeenCalledTimes(1);
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+    // ...and because it cleanly removed the sent content, the consumed
+    // pasted-image File refs / preview URLs are released (no re-send, no leak).
+    expect(cleanup.deleteEditorAttachmentRefs).toHaveBeenCalledTimes(1);
+    expect(cleanup.revokeEditorPreviewUrls).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT release editor refs when the sent content could not be cleanly separated", async () => {
+    // User edited inside the sent region → removeSentEditorContent returns false.
+    const cleanup = makeCleanup({ editorUnchanged: false, sentContentRemoved: false });
+    const send = vi.fn().mockResolvedValue(true);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(true);
+    expect(cleanup.removeSentEditorContent).toHaveBeenCalledTimes(1);
+    // Live draft preserved untouched; refs NOT released (rare fallback).
+    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
+    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
+    expect(cleanup.clearEditor).not.toHaveBeenCalled();
+  });
+
+  it("dedup does not run on send failure (editor preserved entirely for retry)", async () => {
+    const cleanup = makeCleanup({ editorUnchanged: false });
+    const send = vi.fn().mockResolvedValue(false);
+
+    const ok = await runSendWithCleanup(send, [], cleanup);
+
+    expect(ok).toBe(false);
+    expect(cleanup.removeSentEditorContent).not.toHaveBeenCalled();
+    expect(cleanup.calls).toEqual([]);
+  });
+});
+
+describe("removeSentSnapshot — pure snapshot subtraction (round 3 core)", () => {
+  const doc = (...content: EditorJSONNode[]): EditorJSONNode => ({
+    type: "doc",
+    content,
+  });
+  const para = (...inline: EditorJSONNode[]): EditorJSONNode => ({
+    type: "paragraph",
+    content: inline,
+  });
+  const text = (t: string): EditorJSONNode => ({ type: "text", text: t });
+  const img = (id: string): EditorJSONNode => ({
+    type: "attachment",
+    attrs: { id },
+  });
+
+  it("drops a clean leading block prefix, keeping new paragraphs typed during the wait", () => {
+    const sent = doc(para(text("hello")));
+    const live = doc(para(text("hello")), para(text("the next message")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toEqual(doc(para(text("the next message"))));
+  });
+
+  it("returns an empty content array when nothing new survives (whole-editor clear case)", () => {
+    const sent = doc(para(text("hello")));
+    const live = doc(para(text("hello")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).not.toBeNull();
+    expect(remaining!.content).toEqual([]);
+  });
+
+  it("strips the sent inline prefix when the user appended text to the last sent block", () => {
+    const sent = doc(para(text("hello")));
+    const live = doc(para(text("hello world")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toEqual(doc(para(text(" world"))));
+  });
+
+  it("drops a sent image block but keeps the new draft (no image re-send)", () => {
+    const sent = doc(para(text("look"), img("a1")));
+    const live = doc(para(text("look"), img("a1")), para(text("new line")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toEqual(doc(para(text("new line"))));
+  });
+
+  it("returns null when the user edited inside the sent region (not safely separable)", () => {
+    const sent = doc(para(text("hello")));
+    // user changed the sent text itself — cannot cleanly separate.
+    const live = doc(para(text("hXllo there")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toBeNull();
+  });
+
+  it("preserves a new attachment pasted into the boundary block during the window", () => {
+    const sent = doc(para(text("hi")));
+    const live = doc(para(text("hi"), img("new1")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toEqual(doc(para(img("new1"))));
+  });
+
+  it("returns null when an EARLIER sent block diverged (later sent blocks must not linger and re-send)", () => {
+    // Two sent blocks; user edited the FIRST one. If we stripped at block 0 we'd
+    // leave sent block 1 ("world") in the editor → it would be re-sent.
+    const sent = doc(para(text("hello")), para(text("world")));
+    const live = doc(para(text("hello!!!")), para(text("world")), para(text("new")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toBeNull();
+  });
+
+  it("subtracts cleanly when only the LAST sent block was appended to", () => {
+    const sent = doc(para(text("hello")), para(text("world")));
+    const live = doc(para(text("hello")), para(text("world and more")));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toEqual(doc(para(text(" and more"))));
+  });
+
+  it("does NOT wipe a same-type leaf block whose attrs differ (e.g. a different boundary image)", () => {
+    // Boundary block is an atom/leaf-like node with no inline children; the live
+    // one has different attrs. Must not be silently dropped.
+    const sentImg = (id: string): EditorJSONNode => ({
+      type: "image",
+      attrs: { src: id },
+    });
+    const sent = doc(sentImg("old"));
+    const live = doc(sentImg("brand-new"));
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toBeNull();
+  });
+
+  it("does NOT rewrite a boundary block whose own attrs the user changed", () => {
+    // Same type + same leading inline run, but the block-level attrs differ
+    // (e.g. paragraph turned into a different alignment). Must bail.
+    const sentBlock: EditorJSONNode = {
+      type: "paragraph",
+      attrs: { align: "left" },
+      content: [text("hello")],
+    };
+    const liveBlock: EditorJSONNode = {
+      type: "paragraph",
+      attrs: { align: "center" },
+      content: [text("hello world")],
+    };
+    const sent = doc(sentBlock);
+    const live = doc(liveBlock);
+
+    const remaining = removeSentSnapshot(sent, live);
+
+    expect(remaining).toBeNull();
   });
 });
 

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -40,7 +40,11 @@ import {
   videoPlayIcon,
 } from "./AttachmentNode";
 import { t as translate, useI18n } from "../../i18n";
-import { runSendWithCleanup, SendResultDetail } from "./sendFlow";
+import {
+  runSendWithCleanup,
+  removeSentSnapshot,
+  SendResultDetail,
+} from "./sendFlow";
 import { extractOctoRichTextClipboardPayloadFromHtml } from "../../Utils/richTextClipboard";
 import {
   imageBlockToPasteFile,
@@ -85,6 +89,22 @@ function extractAttachmentsFromEditor(
 
   traverse(json);
   return attachments;
+}
+
+/**
+ * Collect every attachment node id present in a ProseMirror/TipTap JSON doc
+ * into `out`. Used by the round-3 dedup path to learn which consumed attachment
+ * ids survive into the post-subtraction draft, so their File refs / preview
+ * URLs are not released out from under the remaining draft.
+ */
+function collectAttachmentIds(node: any, out: Set<string>): void {
+  if (!node) return;
+  if (node.type === "attachment" && node.attrs?.id) {
+    out.add(node.attrs.id as string);
+  }
+  if (Array.isArray(node.content)) {
+    node.content.forEach((child: any) => collectAttachmentIds(child, out));
+  }
 }
 
 /**
@@ -974,22 +994,31 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 提取编辑器中有序内容块（文本段和粘贴图片按文档顺序交替）
     const orderedBlocks = extractOrderedBlocks(editor, attachmentFilesRef.current);
 
-    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1 第二轮)：
+    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1 第二/三轮)：
     // round 1 已把同步清理改成「await onSend、仅成功才清」，避免混排上传失败
     // 丢整条草稿。但 await 期间编辑器仍可编辑，onSend 可能耗时数秒（上传图片 +
     // 等 ack），用户趁发送 pending 时打的下一条草稿，会被上一条 send 成功后的
     // 清理误删。本轮改为 snapshot-aware：
-    //   • 发送前对编辑器文档拍 JSON 快照 (editorSnapshot)；成功回来时只有当
-    //     编辑器内容仍 === 快照（用户没开始新草稿）才 clearContent，否则保留。
+    //   • 发送前对编辑器文档拍 JSON 快照 (editorSnapshot)；成功回来时若编辑器
+    //     内容仍 === 快照（用户没开始新草稿）则整段 clearContent。
+    //   • round 3 去重：若编辑器已变（用户打了新草稿），不再原样保留——那样会把
+    //     已发送的快照块连同新草稿在下次 send 重发（重复消息）。改为从 live 文档
+    //     里减去已发送的快照，只留窗口期新打的内容 (removeSentEditorContent)，
+    //     并释放被消费的图片 File / 预览 URL，避免重发与 blob 泄漏。
     //   • 顶部附件按本次实际消费的 id 精确移除，绝不 setTopAttachments([])
     //     全清，等待期间新加的附件因此不丢。
     //   • onSend 可返回 { editorConsumed, consumedTopIds } 表达「顶部附件已发、
     //     但编辑器混排失败」，让已发文件不被重试重复 (Jerry-Xin non-blocking)。
     // 编排逻辑在纯函数 runSendWithCleanup，便于单测覆盖各竞态场景。
-    const editorSnapshot = JSON.stringify(editor.getJSON());
+    const editorSnapshotJSON = editor.getJSON();
+    const editorSnapshot = JSON.stringify(editorSnapshotJSON);
     const consumedAttachmentAttrs = attachmentAttrs;
     const topItemsAtSend = topAttachments;
     const allTopIds = topItemsAtSend.map((item) => item.id);
+    // Attachment ids that survive into the post-dedup draft; their File refs /
+    // preview URLs must NOT be released even though their id was "consumed"
+    // (e.g. an in-editor attachment duplicated during the in-flight window).
+    const survivingAttachmentIds = new Set<string>();
     sendingRef.current = true;
     try {
       await runSendWithCleanup(
@@ -1007,17 +1036,53 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             JSON.stringify(editor.getJSON()) === editorSnapshot,
           deleteEditorAttachmentRefs: () => {
             consumedAttachmentAttrs.forEach((attr) => {
+              // Don't drop a File ref that the surviving (post-dedup) draft
+              // still references, e.g. the user duplicated an in-editor
+              // attachment with the same id during the in-flight window.
+              if (survivingAttachmentIds.has(attr.id)) return;
               attachmentFilesRef.current.delete(attr.id);
             });
           },
           revokeEditorPreviewUrls: () => {
             consumedAttachmentAttrs.forEach((attr) => {
+              if (survivingAttachmentIds.has(attr.id)) return;
               if (attr.previewUrl) {
                 URL.revokeObjectURL(attr.previewUrl);
               }
             });
           },
           clearEditor: () => editor.commands.clearContent(),
+          removeSentEditorContent: () => {
+            // round-3 dedup: the editor changed mid-flight but the send
+            // succeeded. Subtract the sent snapshot from the live doc, keeping
+            // only what the user typed during the in-flight window, so the
+            // already-sent blocks are not re-sent on the next send.
+            const live = editor.getJSON();
+            const remaining = removeSentSnapshot(
+              editorSnapshotJSON as any,
+              live as any
+            );
+            if (remaining === null) {
+              // Sent content edited inside the live doc → not safely separable;
+              // preserve the live draft untouched (rare fallback).
+              return false;
+            }
+            const content = Array.isArray(remaining.content)
+              ? remaining.content
+              : [];
+            // Record attachment ids that survive into the remaining draft so we
+            // do NOT release their File refs / preview URLs below (the surviving
+            // draft still needs them; e.g. an attachment duplicated during the
+            // in-flight window shares a consumed id).
+            collectAttachmentIds(remaining, survivingAttachmentIds);
+            if (content.length === 0) {
+              // Everything sent, nothing new survived → clear the editor.
+              editor.commands.clearContent();
+            } else {
+              editor.commands.setContent(remaining as any);
+            }
+            return true;
+          },
           removeTopAttachments: (ids: string[]) => {
             const idSet = new Set(ids);
             // 先 revoke 被消费项的预览 URL（避免内存泄漏），用拍快照时的列表

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -19,16 +19,22 @@
  *    successful completion of the *older* send cleared the *current* (newer)
  *    editor document and top-attachment list — wiping the new draft. Pure text
  *    is affected too, because the callback now awaits `sendTextAndWaitAck`.
- *    Fix: cleanup is snapshot-aware. The editor is only cleared if it still
- *    holds exactly the content that was sent (`isEditorUnchanged`); otherwise
- *    the user's newer draft is left untouched. Top attachments are removed by
- *    the specific ids that were consumed, never with a blanket reset, so items
- *    queued during the wait survive.
- *    Residual follow-up: when the editor changed mid-flight we leave the live
- *    doc untouched, so the already-sent snapshot blocks stay alongside the new
- *    draft and could be re-sent on the next send (duplicate). Accepted over the
- *    worse "draft wiped" failure; a precise per-range removal is deferred — see
- *    the `!isEditorUnchanged()` branch below.
+ *    Fix: cleanup is snapshot-aware. The editor is only cleared wholesale if it
+ *    still holds exactly the content that was sent (`isEditorUnchanged`). Top
+ *    attachments are removed by the specific ids that were consumed, never with
+ *    a blanket reset, so items queued during the wait survive.
+ *
+ * 3. (round 3 — dedup) When the editor changed mid-flight we used to leave the
+ *    live doc untouched, so the already-sent snapshot blocks stayed alongside
+ *    the new draft and were *re-sent* on the next send (a duplicate message —
+ *    NOT "harmlessly cleared"). Fix: on success with a changed editor we now
+ *    subtract the sent snapshot from the live document and keep only what the
+ *    user typed during the window (`removeSentEditorContent`, backed by the
+ *    pure `removeSentSnapshot` helper below). This mirrors the by-id
+ *    `removeTopAttachments` approach: the sent attachment nodes are dropped by
+ *    id and the consumed File refs / preview URLs are released, so neither the
+ *    images nor the text are re-sent and there is no blob leak. The new draft
+ *    (including any attachment pasted during the window) is preserved.
  *
  * `onSend` return-value contract (back-compatible):
  *   - `undefined` / `void` → success: editor consumed, all consumed top
@@ -71,12 +77,178 @@ export interface SendCleanup {
   /** Clear the editor document. */
   clearEditor: () => void;
   /**
+   * Round-3 dedup: the editor changed mid-flight but the send succeeded, so the
+   * live doc holds [already-sent snapshot] + [new draft]. Subtract the sent
+   * snapshot from the live document, leaving only what the user typed during
+   * the in-flight window, so the sent blocks are NOT re-sent on the next send.
+   * Returns `true` if the sent content was removed (the caller may then release
+   * the consumed File refs / preview URLs); `false` if the sent content could
+   * not be cleanly separated from the new draft (user edited inside the sent
+   * region) and the live doc was left intact to avoid wiping the draft.
+   */
+  removeSentEditorContent: () => boolean;
+  /**
    * Remove the given top attachments (by id) and revoke their preview URLs.
    * Id-scoped so attachments queued during the await are preserved.
    */
   removeTopAttachments: (ids: string[]) => void;
   /** Optional: collapse the expanded composer (only when the editor is cleared). */
   collapseExpanded?: () => void;
+}
+
+/** Minimal shape of a TipTap/ProseMirror JSON node (doc, block, or inline). */
+export interface EditorJSONNode {
+  type: string;
+  text?: string;
+  content?: EditorJSONNode[];
+  [key: string]: unknown;
+}
+
+/** Structural equality for JSON nodes (order-sensitive, like the snapshot). */
+function nodesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function isEmptyInline(content: EditorJSONNode[]): boolean {
+  return content.every(
+    (n) => n.type === "text" && (n.text ?? "") === "",
+  );
+}
+
+/**
+ * Strip the leading inline run of `sent` from the matching `live` block.
+ *
+ * Handles the realistic "typed more right after pressing send" flow where the
+ * user appended text/inline nodes to the *last sent block* without starting a
+ * new paragraph. Returns the block holding only the appended suffix, or `null`
+ * if the two blocks cannot be cleanly separated, i.e.:
+ *   - different node types;
+ *   - either side is a leaf/atom node (no inline children) — a same-type leaf
+ *     with different attrs/marks must NOT be silently dropped;
+ *   - `live` does not begin with the full `sent` inline run (the user edited
+ *     inside the sent content rather than appending after it).
+ */
+function stripInlinePrefix(
+  sent: EditorJSONNode,
+  live: EditorJSONNode,
+): EditorJSONNode | null {
+  if (sent.type !== live.type) return null;
+  // Leaf/atom blocks (no inline children) are not separable by prefix; they are
+  // only ever removable via full structural equality, which the caller already
+  // checked (and which failed, since we are here). Bail rather than risk wiping
+  // a same-type-but-different live node.
+  if (!Array.isArray(sent.content) || !Array.isArray(live.content)) return null;
+  // The block wrapper (attrs / marks — everything except `content`) must match,
+  // or we would silently rewrite a block whose own attributes the user changed.
+  if (!nodesEqual({ ...sent, content: [] }, { ...live, content: [] })) {
+    return null;
+  }
+  const si = sent.content;
+  const li = live.content;
+  if (li.length < si.length) return null;
+
+  for (let i = 0; i < si.length; i++) {
+    if (nodesEqual(si[i], li[i])) continue;
+
+    // Only the last sent inline node may match partially, and only when both
+    // are text nodes with identical marks/attrs and live text starts with sent.
+    const isLastSent = i === si.length - 1;
+    const sNode = si[i];
+    const lNode = li[i];
+    if (
+      isLastSent &&
+      sNode.type === "text" &&
+      lNode.type === "text" &&
+      typeof sNode.text === "string" &&
+      typeof lNode.text === "string" &&
+      lNode.text.startsWith(sNode.text) &&
+      nodesEqual({ ...sNode, text: "" }, { ...lNode, text: "" })
+    ) {
+      const suffixText = lNode.text.slice(sNode.text.length);
+      const remaining: EditorJSONNode[] = [
+        ...(suffixText ? [{ ...lNode, text: suffixText }] : []),
+        ...li.slice(i + 1),
+      ];
+      return { ...live, content: remaining };
+    }
+    return null;
+  }
+
+  return { ...live, content: li.slice(si.length) };
+}
+
+/**
+ * Pure snapshot subtraction (round-3 dedup core).
+ *
+ * Given the document that was `sent` and the current `live` document, return a
+ * new document holding only the content the user added *after* the sent
+ * snapshot, so the sent blocks are never re-sent. Mirrors the by-id
+ * `removeTopAttachments` idea at the editor-document level:
+ *
+ *  - sent content is a clean leading run of top-level blocks → drop those
+ *    blocks, keep the rest (new paragraphs typed during the wait survive);
+ *  - the user appended inline content to the *last* sent block → strip the sent
+ *    inline prefix from that block, keep the appended suffix + later blocks;
+ *  - the user edited *inside* the sent region (an earlier sent block diverged,
+ *    or the boundary block is not a clean append) so it cannot be cleanly
+ *    separated → return `null` (caller preserves the live doc rather than risk
+ *    wiping the new draft, or — worse — leaving a later sent block to re-send).
+ *
+ * The returned doc may have an empty `content` array (everything sent, nothing
+ * new) — the caller should treat that as "clear the editor".
+ *
+ * Known limits (content-equality is structural, not transaction-based — these
+ * are bounded residuals, NOT the duplicate-on-every-retype bug this fixes):
+ *  - If an *earlier* sent block was edited but a *later* sent block still
+ *    matches verbatim, we return `null` and preserve the whole live doc to
+ *    avoid wiping the new draft. That later block can still be re-sent on the
+ *    next send. Preferring "no wipe" over "no duplicate" here is the team's
+ *    accepted severity call; fully closing it needs ProseMirror step/version
+ *    tracking (a dedicated follow-up).
+ *  - If the user select-all-replaces the draft with brand-new text that happens
+ *    to *begin with the exact sent string*, we treat the shared run as the sent
+ *    prefix and strip it. This requires the new draft to coincidentally share
+ *    the old prefix within the 1–5s in-flight window — rare, and the dropped
+ *    text is the same characters the user just sent.
+ */
+export function removeSentSnapshot(
+  sent: EditorJSONNode,
+  live: EditorJSONNode,
+): EditorJSONNode | null {
+  const sb = Array.isArray(sent.content) ? sent.content : [];
+  const lb = Array.isArray(live.content) ? live.content : [];
+
+  // Longest common prefix of top-level blocks.
+  let k = 0;
+  while (k < sb.length && k < lb.length && nodesEqual(sb[k], lb[k])) k++;
+
+  // All sent blocks matched as a clean block prefix → drop them.
+  if (k === sb.length) {
+    return { ...live, content: lb.slice(k) };
+  }
+
+  // Otherwise some sent block diverged at index k. We can only recover the
+  // "appended to the end of the sent content" case: that requires the diverged
+  // block to be the LAST sent block (k === sb.length - 1). If an EARLIER sent
+  // block diverged, later sent blocks (sb[k+1..]) would remain in the live doc
+  // and be re-sent — so we must bail and preserve the live doc untouched.
+  if (k === sb.length - 1 && k < lb.length) {
+    const stripped = stripInlinePrefix(sb[k], lb[k]);
+    if (stripped !== null) {
+      const strippedInline = Array.isArray(stripped.content)
+        ? stripped.content
+        : [];
+      const head =
+        strippedInline.length === 0 || isEmptyInline(strippedInline)
+          ? []
+          : [stripped];
+      return { ...live, content: [...head, ...lb.slice(k + 1)] };
+    }
+  }
+
+  // Sent content is interleaved/edited inside the live doc — not safely
+  // separable. Preserve everything (caller keeps the live doc untouched).
+  return null;
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -142,18 +314,24 @@ export async function runSendWithCleanup(
 
   if (!cleanup.isEditorUnchanged()) {
     // The user started a new draft while the older send was in flight. We must
-    // NOT clear the editor — doing so would wipe the newly typed draft (the
-    // round-2 data-loss bug). We deliberately leave the live document as-is.
+    // NOT clear the whole editor — that would wipe the newly typed draft (the
+    // round-2 data-loss bug).
     //
-    // Known residual edge case (octo-web#227, tracked as a follow-up): the live
-    // editor now holds [already-sent snapshot blocks] + [new draft]. The
-    // already-sent blocks are NOT auto-removed here, so if the user presses send
-    // again those blocks are re-sent → a duplicate of the previous message. The
-    // message was delivered and the leftover content is visible to the user, so
-    // per the team's severity call this is accepted for now over the worse
-    // "draft wiped" failure. A precise fix (remove only the submitted snapshot
-    // range from the live doc, mirroring the by-id removeTopAttachments path)
-    // is deferred to a dedicated PR with its own ProseMirror-position tests.
+    // Round-3 dedup: but we also must not leave the already-sent snapshot blocks
+    // in the live doc, or the *next* send would re-send them (a duplicate — the
+    // bug the corrected comment above describes). Subtract the sent snapshot
+    // from the live document, keeping only what the user typed during the
+    // window. `removeSentEditorContent` returns true when it cleanly removed the
+    // sent content; only then do we release the consumed pasted-image File refs
+    // and preview URLs (so neither images nor text are re-sent, and there is no
+    // blob leak). If it returns false (the user edited inside the sent region so
+    // it cannot be separated), we preserve the live doc untouched — the old
+    // accepted tradeoff, now confined to that rare case.
+    const removed = cleanup.removeSentEditorContent();
+    if (removed) {
+      cleanup.deleteEditorAttachmentRefs();
+      cleanup.revokeEditorPreviewUrls();
+    }
     return true;
   }
 


### PR DESCRIPTION
<!-- multica:bug-fix-report v1 -->

# Bug Fix — Issue #240 — PR #533

## 1. Executive Summary
- **Bug**: After a send succeeds while the user is typing a new draft during the in-flight upload/ack window, the already-sent snapshot blocks are left in the live editor and get **re-sent on the next send → duplicate message**.
- **Root Cause**: `sendFlow.ts:runSendWithCleanup` — the `!isEditorUnchanged()` branch deliberately left the live document untouched (round-2 "never wipe the newer draft" guard), so the sent blocks lingered and were re-submitted.
- **Fix Approach**: localized — new pure `removeSentSnapshot()` subtraction helper + `SendCleanup.removeSentEditorContent()` wiring; no refactor of the surrounding send path.
- **Risk Level**: Low
- **PR**: #533 draft

## 2. Issue Context
- Title: fix(octo-web): dedup re-sent snapshot blocks after mid-flight draft change (#227 follow-up)
- Reporter: issue-triager (migrated tracker OCTO-1927 / GitHub octo-web#240)
- bug-verified by: self (reproduced via the round-3 regression suite; direct-dispatch, no human verify gate for `type:bug`)
- Affected: `main`, `packages/dmworkbase` MessageInput send flow. Follow-up to #221 / #227 (merged).

## 3. Reproduction
**Environment**: octo-web monorepo (`main`), Node v26, pnpm 10, Vitest 4.
**Steps**:
1. Compose a message (text and/or pasted image) and press send.
2. While `onSend` is still in flight (image upload + ack, ~1–5s), type a **new** draft into the still-editable editor.
3. The older send resolves successfully.
4. Press send again.

**Expected**: Only the new draft typed during the window is sent.
**Actual**: The already-sent snapshot blocks are still present in the live editor alongside the new draft, so they are **re-sent** → the previous message is duplicated.
**Evidence**: Encoded as the round-3 regression `describe` block in `sendFlow.test.ts` ("dedup removes the already-sent snapshot from the live editor"). Against pre-fix `sendFlow.ts` the `!isEditorUnchanged()` branch returned `true` without removing the sent content, and `removeSentSnapshot` / `removeSentEditorContent` did not exist — so these tests are RED (unresolvable symbol / no dedup) before the fix and GREEN after.

## 4. RCA
**Method**: 5 Whys
**Analysis**:
1. Why a duplicate message? → The next send re-submitted blocks that were already sent.
2. Why were they re-submitted? → They were still in the live editor document.
3. Why still there? → After a successful send with a mid-flight edit, cleanup took the `!isEditorUnchanged()` branch, which left the live doc untouched.
4. Why leave it untouched? → The round-2 guard traded "draft wiped" for "old content retained" to avoid wiping the user's newer draft; precise per-range removal was explicitly deferred.
5. Why was precise removal not done then? → It needs snapshot subtraction with ProseMirror-shape edge-case handling; deferred to this dedicated PR.
**Root cause**: `sendFlow.ts:runSendWithCleanup` had no mechanism to subtract the sent snapshot from a mid-flight-edited live document; the deferred branch left sent blocks in place.

## 5. Fix Description
**Files changed**:
- `packages/dmworkbase/src/Components/MessageInput/sendFlow.ts` (+220/-…): new pure `removeSentSnapshot(sent, live)` + `stripInlinePrefix` helpers; new `SendCleanup.removeSentEditorContent()` contract; `runSendWithCleanup` now subtracts the snapshot on the changed-editor success path and releases consumed File refs / preview URLs only on clean removal.
- `packages/dmworkbase/src/Components/MessageInput/index.tsx` (+75/-…): wires `removeSentEditorContent` into the live TipTap editor via `editor.commands.setContent`/`clearContent`; new `collectAttachmentIds` records ids surviving into the post-subtraction draft so their `File`/preview URLs are not released out from under the remaining draft.
- `packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts` (+209/-…): 12 → 26 tests.

**Change summary**: On a successful send where the user edited the editor mid-flight, subtract the sent JSON snapshot from the live document, keeping only what the user typed during the window. Clean leading block prefixes are dropped; an append to the *last* sent block strips just the sent inline prefix; anything ambiguous (edit inside the sent region, an earlier sent block diverged, leaf/attr divergence) bails to `null` and preserves the live draft untouched. Consumed pasted-image `File` refs and preview URLs are released only after a clean removal.

**Does NOT change** (scope boundary): the round-1 (await-before-clear) and round-2 (never-wipe-newer-draft) guards; the top-attachment by-id removal path; the `onSend` return-value contract; any non-MessageInput code.

## 6. Regression Tests
| Test (describe → it) | File | Purpose | Before | After |
|---|---|---|---|---|
| round 3: subtracts the sent snapshot so it is not re-sent | `sendFlow.test.ts` | Core dedup on changed-editor success | FAIL (no dedup / symbol missing) | PASS |
| round 3: does NOT release editor refs when content not cleanly separable | `sendFlow.test.ts` | Fail-safe preserve path | FAIL | PASS |
| round 3: dedup does not run on send failure | `sendFlow.test.ts` | Failure preserves editor entirely | FAIL | PASS |
| removeSentSnapshot: drops clean leading block prefix | `sendFlow.test.ts` | Pure subtraction happy path | FAIL | PASS |
| removeSentSnapshot: strips inline prefix on last-block append | `sendFlow.test.ts` | Append-after-send case | FAIL | PASS |
| removeSentSnapshot: null on edit-inside / earlier-block / leaf-attr divergence | `sendFlow.test.ts` | No-wipe safety bails | FAIL | PASS |

Full file: 26/26 pass. (Rounds 1 & 2 retained.)

## 7. CI Status
- Linter: N/A — `@octo/base` (dmworkbase) exposes no `lint`/typecheck task (build is Vite; only `test: vitest run`). `git diff --check main...HEAD` clean.
- Unit: `sendFlow.test.ts` 26 pass, 0 fail.
- Baseline diff (full `dmworkbase` suite): baseline (main) 19 failing files / 57 tests; after (this branch) identical 19 files / 57 tests. **new_failures = 0.** The pre-existing failures are an environment `react@17.0.2` vs `react-dom@18.3.1` hook-dispatcher mismatch, unrelated to this change (no MessageInput/sendFlow file among them).
- Integration: N/A — pure-helper + mocked-cleanup coverage per existing pattern.
- Coverage delta: +14 tests in `sendFlow.test.ts`.

## 8. Deployment Notes
- Migration required?: no
- Config change?: no
- Feature flag: no — behavior-narrowing bug fix on an existing path; strictly better than the prior duplicate-on-every-retype behavior.
- Compatibility: backward-compatible; `onSend` contract unchanged, `SendCleanup` gains one method implemented at the single call site.

## 9. Rollback Plan
**Pattern**: revert (single squashed commit; isolated to MessageInput send flow).
**Steps**: 1. `git revert` the merge commit / PR. 2. Redeploy. Reverting restores the prior accepted "leave live doc untouched" behavior (duplicate-on-retype, no wipe).
**Detection** (trigger rollback): user reports of dropped/altered drafts after send, or a spike in send-flow errors in the MessageInput path.

---

### Provenance & known limits
This PR recovers the fully code-approved work from **PR #238** (approved by yujiawei and Jerry-Xin at head `63460a7`), which was auto-closed for inactivity after a non-code CI gate (`check-sprint`: the linked issue had no Sprint assigned) — not for any code defect. Cherry-picked onto current `main`; `index.tsx` was reconciled against main's later refactor (import block + preserved send-cleanup wiring), `sendFlow.ts` and tests applied clean.

Two bounded residuals remain (documented in the `removeSentSnapshot` docstring, both strictly safer — they err toward "no wipe", never re-send-on-every-retype): (1) an edited *earlier* block with a still-matching *later* sent block preserves the draft but can re-send that later block; (2) a select-all-replace whose new text coincidentally begins with the exact sent string is treated as an append. Fully closing both needs ProseMirror step/version tracking — a separate follow-up. Reviewer non-blocking notes on the prior PR (fileless-attachment phantom, whitespace-only residual, `nodesEqual` order-sensitivity) are pre-existing / non-regressions, also follow-up material.

**Note for review squad:** the prior close was caused by a missing Sprint on the linked issue (`check-sprint` gate). Please ensure a Sprint is assigned so CI can go green this time.

---
_Generated by frontend-engineer · awaiting review squad (qa+security+code)_
