### PR TITLE
feat(docs): gate Docs entry behind appconfig docs_on flag

### DIFF
--- a/apps/web/src/Pages/Main/menuReconcile.ts
+++ b/apps/web/src/Pages/Main/menuReconcile.ts
@@ -93,3 +93,82 @@ export function reconcileMenuState<M extends MenuLike>(
     activeMenuVanished: true,
   };
 }
+
+// ── Appearance-side reactivation (#536 reviewer follow-up) ──────────────────────────────────
+//
+// The mirror of the disappearance case above. A config-gated menu (docs_on) also affects the
+// *appearance* side: because the menu factory returns `undefined` until appconfig resolves
+// docsOn=true, a hard load / refresh / bookmark / share-link to that menu's route (e.g. `/docs`)
+// finds no matching menu at MainVM.didMount and falls back to chat. When docs_on later resolves,
+// refreshing the NavRail makes the entry appear, but nothing re-selects the route the URL asked
+// for — so the user is stranded on chat until they click the entry manually (a regression the
+// gating introduced; pre-gate the menu was always registered and didMount matched it).
+//
+// Fix: MainVM records the boot route it could not satisfy (`pendingRoutePath`) and, on each
+// appconfig change, asks this helper whether that route's menu has since appeared. Deliberately
+// scoped so it only ever activates the *exact* route the user deep-linked to — never a surprise
+// jump — and MainVM drops the pending path the moment the user navigates anywhere themselves.
+
+export interface PendingActivationInput<M extends MenuLike> {
+  /** The boot route MainVM.didMount could not match to a live menu (else undefined). */
+  pendingRoutePath: string | undefined;
+  /** The live menu list (reflects the post-appconfig gated set). */
+  menusList: M[];
+  /** The currently active menu, if any. */
+  currentMenu: M | undefined;
+  /** Route paths currently kept mounted by the host (display-toggled tabs). */
+  historyRoutePaths: string[];
+}
+
+export interface PendingActivationResult<M extends MenuLike> {
+  /** True when the pending route's menu appeared and is now selected (caller should re-render). */
+  activated: boolean;
+  /** The reconciled active menu (the newly-appeared menu when activated, else unchanged). */
+  currentMenu: M | undefined;
+  /** History list with the newly-activated route ensured (unchanged when not activated). */
+  historyRoutePaths: string[];
+  /**
+   * The still-pending route. Cleared (→ undefined) once the target menu has appeared — whether we
+   * activated it or found it already active — so we do not keep re-checking. Stays set only while
+   * the target menu is still absent (appconfig may not have enabled it yet).
+   */
+  pendingRoutePath: string | undefined;
+}
+
+/**
+ * Resolve a pending deep-link activation against the live menu list. If the pending route's menu
+ * is now present and is not already the active view, select it and add its route to history so
+ * the host renders it. One-shot: the pending path is consumed as soon as the menu exists.
+ */
+export function resolvePendingRouteActivation<M extends MenuLike>(
+  input: PendingActivationInput<M>
+): PendingActivationResult<M> {
+  const { pendingRoutePath, menusList, currentMenu, historyRoutePaths } = input;
+
+  if (!pendingRoutePath) {
+    return { activated: false, currentMenu, historyRoutePaths, pendingRoutePath };
+  }
+
+  const target = menusList.find((m) => m.routePath === pendingRoutePath);
+  if (!target) {
+    // Target menu still not live (e.g. docs_on not yet true) — keep waiting.
+    return { activated: false, currentMenu, historyRoutePaths, pendingRoutePath };
+  }
+
+  // Target menu exists now → the pending deep-link is resolved either way; stop tracking it.
+  if (currentMenu && currentMenu.id === target.id) {
+    // Already the active view (nothing to do, just consume the pending path).
+    return { activated: false, currentMenu, historyRoutePaths, pendingRoutePath: undefined };
+  }
+
+  const nextHistory =
+    historyRoutePaths.indexOf(target.routePath) === -1
+      ? [...historyRoutePaths, target.routePath]
+      : historyRoutePaths;
+  return {
+    activated: true,
+    currentMenu: target,
+    historyRoutePaths: nextHistory,
+    pendingRoutePath: undefined,
+  };
+}

--- a/apps/web/src/Pages/Main/menuReconcile.ts
+++ b/apps/web/src/Pages/Main/menuReconcile.ts
@@ -2,11 +2,15 @@
 // unit-tested without importing the full @octo/base module graph (which pulls heavy component
 // deps into the test environment). MainVM.reconcileActiveMenu delegates here.
 //
-// Rule (#536 reviewer follow-up): when a config-gated menu (e.g. docs_on) is toggled OFF while
-// it is the active view, its NavRail entry leaves `menusList` but the host would keep rendering
-// its route via `historyRoutePaths`. So when the active menu is no longer in the list, drop its
-// route (unmounting the view / tearing down e.g. the docs collab WS) and fall back to the first
-// available menu. One-directional: turning a menu ON never moves the user off their view.
+// Rule (#536 reviewer follow-up): when a config-gated menu (e.g. docs_on) is toggled OFF, its
+// NavRail entry leaves `menusList` but the host would keep rendering its route via
+// `historyRoutePaths` — including background tabs the user isn't currently on (they stay mounted,
+// just `display:none`, see MainContentLeft). So on every reconcile pass we drop ALL routes whose
+// menu is no longer live, not just the active one; if the active menu itself vanished we also
+// fall back to the first available menu. One-directional: turning a menu ON never moves the user
+// off their current view. Dropping a route only unmounts what that route renders directly into
+// `historyRoutePaths` (e.g. the docs list) — see MainVM.reconcileActiveMenu for the additional
+// step needed to release content a route pushed into the shared right-hand pane.
 
 /** Minimal structural shape of a NavRail menu the reconciliation needs. */
 export interface MenuLike {
@@ -24,34 +28,68 @@ export interface ReconcileInput<M extends MenuLike> {
 }
 
 export interface ReconcileResult<M extends MenuLike> {
-  /** True when the active menu was replaced (caller should re-render). */
+  /** True when the active menu or the history list changed (caller should re-render). */
   changed: boolean;
   /** The reconciled active menu (first available when the old one vanished). */
   currentMenu: M | undefined;
-  /** New history list with the vanished route removed and the fallback route ensured. */
+  /** New history list with any gated-off routes removed (fallback route ensured if needed). */
   historyRoutePaths: string[];
+  /** Route paths dropped this pass because their menu is no longer live — the caller should
+   * release any resources those routes may still hold outside `historyRoutePaths` itself (e.g.
+   * a view pushed into a shared side pane), regardless of whether the route was active. */
+  prunedRoutePaths: string[];
+  /**
+   * True only when the *active* menu itself vanished this pass (not merely a hidden/background
+   * tab). `routeRight` is a single stack shared across whatever menu is currently active (chat
+   * pushes its own content there too, see EndpointCommon.tsx) — only the active menu's departure
+   * mirrors what a manual menu switch already clears via `onMenuClick`'s `routeRight.popToRoot()`.
+   * A background tab disappearing must NOT trigger that clear: it was never occupying the
+   * currently-active menu's right pane (leaving a menu via `onMenuClick` already clears
+   * `routeRight`, so a background route can't still own it) and clearing it anyway would destroy
+   * whatever the *actually* active menu (e.g. an open chat conversation) has pushed there.
+   */
+  activeMenuVanished: boolean;
 }
 
 /**
- * Reconcile the active menu against the live menu list. If the active menu is still present (or
- * there is none), returns `changed: false` and the inputs unchanged. If it has disappeared, drops
- * its route from history and falls back to the first available menu.
+ * Reconcile menu state against the live menu list. Drops every history route whose menu has
+ * disappeared (background/hidden tabs included), and — if the active menu itself vanished —
+ * falls back to the first available menu. Returns `changed: false` only when nothing needed
+ * pruning.
  */
 export function reconcileMenuState<M extends MenuLike>(
   input: ReconcileInput<M>
 ): ReconcileResult<M> {
   const { menusList, currentMenu, historyRoutePaths } = input;
+  const liveRoutePaths = new Set(menusList.map((m) => m.routePath));
+  const liveIds = new Set(menusList.map((m) => m.id));
 
-  // No active menu, or it is still present → nothing to reconcile.
-  if (!currentMenu || menusList.some((m) => m.id === currentMenu.id)) {
-    return { changed: false, currentMenu, historyRoutePaths };
+  const prunedRoutePaths = historyRoutePaths.filter((p) => !liveRoutePaths.has(p));
+  const nextHistory = historyRoutePaths.filter((p) => liveRoutePaths.has(p));
+
+  const activeGone = !!currentMenu && !liveIds.has(currentMenu.id);
+  if (!activeGone) {
+    // Active menu (if any) is still present; a hidden background tab may still have been
+    // pruned above, which alone warrants a re-render (its mounted subtree should unmount).
+    return {
+      changed: prunedRoutePaths.length > 0,
+      currentMenu,
+      historyRoutePaths: nextHistory,
+      prunedRoutePaths,
+      activeMenuVanished: false,
+    };
   }
 
-  // Active menu vanished: drop its route so the view unmounts, then fall back to the first menu.
-  const nextHistory = historyRoutePaths.filter((p) => p !== currentMenu.routePath);
+  // Active menu vanished: fall back to the first available menu (route already dropped above).
   const next = menusList.length > 0 ? menusList[0] : undefined;
   if (next && nextHistory.indexOf(next.routePath) === -1) {
     nextHistory.push(next.routePath);
   }
-  return { changed: true, currentMenu: next, historyRoutePaths: nextHistory };
+  return {
+    changed: true,
+    currentMenu: next,
+    historyRoutePaths: nextHistory,
+    prunedRoutePaths,
+    activeMenuVanished: true,
+  };
 }

--- a/apps/web/src/Pages/Main/menuReconcile.ts
+++ b/apps/web/src/Pages/Main/menuReconcile.ts
@@ -1,0 +1,57 @@
+// Pure reconciliation logic for the NavRail active menu, extracted from MainVM so it can be
+// unit-tested without importing the full @octo/base module graph (which pulls heavy component
+// deps into the test environment). MainVM.reconcileActiveMenu delegates here.
+//
+// Rule (#536 reviewer follow-up): when a config-gated menu (e.g. docs_on) is toggled OFF while
+// it is the active view, its NavRail entry leaves `menusList` but the host would keep rendering
+// its route via `historyRoutePaths`. So when the active menu is no longer in the list, drop its
+// route (unmounting the view / tearing down e.g. the docs collab WS) and fall back to the first
+// available menu. One-directional: turning a menu ON never moves the user off their view.
+
+/** Minimal structural shape of a NavRail menu the reconciliation needs. */
+export interface MenuLike {
+  id: string;
+  routePath: string;
+}
+
+export interface ReconcileInput<M extends MenuLike> {
+  /** The live menu list (already reflects the post-toggle gated set). */
+  menusList: M[];
+  /** The currently active menu, if any. */
+  currentMenu: M | undefined;
+  /** Route paths currently kept mounted by the host (display-toggled tabs). */
+  historyRoutePaths: string[];
+}
+
+export interface ReconcileResult<M extends MenuLike> {
+  /** True when the active menu was replaced (caller should re-render). */
+  changed: boolean;
+  /** The reconciled active menu (first available when the old one vanished). */
+  currentMenu: M | undefined;
+  /** New history list with the vanished route removed and the fallback route ensured. */
+  historyRoutePaths: string[];
+}
+
+/**
+ * Reconcile the active menu against the live menu list. If the active menu is still present (or
+ * there is none), returns `changed: false` and the inputs unchanged. If it has disappeared, drops
+ * its route from history and falls back to the first available menu.
+ */
+export function reconcileMenuState<M extends MenuLike>(
+  input: ReconcileInput<M>
+): ReconcileResult<M> {
+  const { menusList, currentMenu, historyRoutePaths } = input;
+
+  // No active menu, or it is still present → nothing to reconcile.
+  if (!currentMenu || menusList.some((m) => m.id === currentMenu.id)) {
+    return { changed: false, currentMenu, historyRoutePaths };
+  }
+
+  // Active menu vanished: drop its route so the view unmounts, then fall back to the first menu.
+  const nextHistory = historyRoutePaths.filter((p) => p !== currentMenu.routePath);
+  const next = menusList.length > 0 ? menusList[0] : undefined;
+  if (next && nextHistory.indexOf(next.routePath) === -1) {
+    nextHistory.push(next.routePath);
+  }
+  return { changed: true, currentMenu: next, historyRoutePaths: nextHistory };
+}

--- a/apps/web/src/Pages/Main/vm.ts
+++ b/apps/web/src/Pages/Main/vm.ts
@@ -1,5 +1,6 @@
 import { WKApp, Menus, ProviderListener, startVersionCheck, t } from "@octo/base";
 import { Toast } from "@douyinfe/semi-ui";
+import { reconcileMenuState } from "./menuReconcile";
 
 export default class MainVM extends ProviderListener {
   private _currentMenus?: Menus;
@@ -55,6 +56,9 @@ export default class MainVM extends ProviderListener {
 
   private ipcListeners: { event: string; handler: (...args: any[]) => void }[] = [];
   private stopVersionCheck?: () => void;
+  // Unsubscribe for the remote-config listener that reconciles the active view when a
+  // config-gated menu (e.g. docs_on) disappears from the NavRail. See reconcileActiveMenu.
+  private _unsubscribeMenuReconcile?: () => void;
 
   didMount(): void {
     let found = false;
@@ -71,6 +75,20 @@ export default class MainVM extends ProviderListener {
     if (!found && this.menusList.length > 0) {
       this.currentMenus = this.menusList[0];
     }
+
+    // Reconcile the active view when a remote-config flag toggles a menu OFF while it is the
+    // active view (e.g. ops flips docs_on=false while a user is on /docs). Without this the
+    // NavRail entry disappears but `currentMenus` still points at the gone menu and
+    // MainContentLeft keeps rendering its route via `historyRoutePaths` — "hide immediately"
+    // would be incomplete (reviewer feedback on #536). `menusList` is read live inside
+    // reconcileActiveMenu, so it reflects the post-toggle set. Only the change listener matters
+    // here: a first-load turn-ON never removes the currently active menu. This benefits every
+    // config-gated menu, not just docs.
+    this._unsubscribeMenuReconcile = WKApp.remoteConfig.addConfigChangeListener(() => {
+      if (this.reconcileActiveMenu()) {
+        this.notifyListener();
+      }
+    });
 
     if ((window as any).__POWERED_ELECTRON__) {
       this.appUpdateInit();
@@ -150,7 +168,37 @@ export default class MainVM extends ProviderListener {
     }
     this.ipcListeners = [];
     this.stopVersionCheck?.();
+    this._unsubscribeMenuReconcile?.();
   }
+
+  /**
+   * Reconcile the active menu against the live menu list. Called on remote-config changes.
+   *
+   * If the currently active menu is no longer present in `menusList` (a config-gated entry such
+   * as docs_on was turned off), drop its cached route from `historyRoutePaths` so the view
+   * actually unmounts (tearing down e.g. the docs collab WebSocket) and fall back to the first
+   * available menu. If the active menu is still present, this is a no-op.
+   *
+   * Deliberately one-directional: turning a menu ON never yanks the user off their current view,
+   * so we only handle disappearance, not appearance (no surprise auto-navigation).
+   *
+   * @returns true if the active menu changed (caller should re-render), false if unchanged.
+   */
+  reconcileActiveMenu(): boolean {
+    const result = reconcileMenuState({
+      menusList: this.menusList,
+      currentMenu: this._currentMenus,
+      historyRoutePaths: this._historyRoutePaths,
+    });
+    if (!result.changed) {
+      return false;
+    }
+    this._currentMenus = result.currentMenu;
+    this._historyRoutePaths = result.historyRoutePaths;
+    WKApp.currentMenuId = result.currentMenu?.id;
+    return true;
+  }
+
   // 标记当前新版本已读，清除红点
   markVersionRead() {
     if (this.lastVersionInfo?.appVersion) {

--- a/apps/web/src/Pages/Main/vm.ts
+++ b/apps/web/src/Pages/Main/vm.ts
@@ -1,6 +1,6 @@
 import { WKApp, Menus, ProviderListener, startVersionCheck, t } from "@octo/base";
 import { Toast } from "@douyinfe/semi-ui";
-import { reconcileMenuState } from "./menuReconcile";
+import { reconcileMenuState, resolvePendingRouteActivation } from "./menuReconcile";
 
 export default class MainVM extends ProviderListener {
   private _currentMenus?: Menus;
@@ -59,12 +59,18 @@ export default class MainVM extends ProviderListener {
   // Unsubscribe for the remote-config listener that reconciles the active view when a
   // config-gated menu (e.g. docs_on) disappears from the NavRail. See reconcileActiveMenu.
   private _unsubscribeMenuReconcile?: () => void;
+  // A boot route (e.g. /docs) that had no matching menu at didMount because a config-gated menu
+  // (docs_on) had not resolved yet. Kept so it can be activated once the menu appears on the
+  // first appconfig load, then cleared. Any explicit user navigation also clears it (see the
+  // currentMenus setter) so a late toggle never yanks the user off a view they chose.
+  private _pendingRouteActivation?: string;
 
   didMount(): void {
     let found = false;
-    if (WKApp.route.currentPath) {
+    const bootPath = WKApp.route.currentPath;
+    if (bootPath) {
       for (const menus of this.menusList) {
-        if (menus.routePath === WKApp.route.currentPath) {
+        if (menus.routePath === bootPath) {
           this.currentMenus = menus;
           found = true;
           break;
@@ -75,17 +81,26 @@ export default class MainVM extends ProviderListener {
     if (!found && this.menusList.length > 0) {
       this.currentMenus = this.menusList[0];
     }
+    // Deep-link deferral (#536 reviewer follow-up): we fell back to chat because the URL's route
+    // matched no live menu. When that route belongs to a config-gated menu still resolving (e.g.
+    // /docs before docs_on arrives), remember it so activatePendingRouteMenu can select it once
+    // the menu appears — otherwise a hard load / refresh / bookmark of /docs stays stuck on chat
+    // in the enabled deployment. Set AFTER the fallback assignment above, whose setter clears it.
+    if (!found && !!bootPath && bootPath !== "/") {
+      this._pendingRouteActivation = bootPath;
+    }
 
-    // Reconcile the active view when a remote-config flag toggles a menu OFF while it is the
-    // active view (e.g. ops flips docs_on=false while a user is on /docs). Without this the
-    // NavRail entry disappears but `currentMenus` still points at the gone menu and
-    // MainContentLeft keeps rendering its route via `historyRoutePaths` — "hide immediately"
-    // would be incomplete (reviewer feedback on #536). `menusList` is read live inside
-    // reconcileActiveMenu, so it reflects the post-toggle set. Only the change listener matters
-    // here: a first-load turn-ON never removes the currently active menu. This benefits every
-    // config-gated menu, not just docs.
+    // React to remote-config changes (e.g. ops flips docs_on) in two directions:
+    //  - disappearance: a menu that was the active view is gated OFF → reconcileActiveMenu drops
+    //    its route + falls back (also tears down its shared-pane view, see reconcileActiveMenu);
+    //  - appearance: a gated menu we deep-linked to at boot turns ON → activatePendingRouteMenu
+    //    selects the route the URL originally asked for.
+    // `menusList` is read live inside both, so it reflects the post-change gated set. This
+    // benefits every config-gated menu, not just docs.
     this._unsubscribeMenuReconcile = WKApp.remoteConfig.addConfigChangeListener(() => {
-      if (this.reconcileActiveMenu()) {
+      const reconciled = this.reconcileActiveMenu();
+      const activated = this.activatePendingRouteMenu();
+      if (reconciled || activated) {
         this.notifyListener();
       }
     });
@@ -214,6 +229,41 @@ export default class MainVM extends ProviderListener {
     return true;
   }
 
+  /**
+   * Activate a route the user deep-linked to at boot but which had no live menu then because a
+   * config-gated menu (e.g. docs_on) was still resolving. Called on remote-config changes.
+   *
+   * If `_pendingRouteActivation` is set and a menu with that routePath is now present, select it
+   * (adding its route to `historyRoutePaths` so MainContentLeft renders it) and clear the pending
+   * path. If the menu is still absent, keep waiting; if it has appeared but is already active,
+   * just clear the pending path. Only ever activates the *exact* route the URL asked for — never
+   * a surprise jump — and the pending path is dropped the moment the user navigates themselves
+   * (see the currentMenus setter), so a late toggle can't move a user off a view they chose.
+   *
+   * @returns true if a menu was activated (caller should re-render), false otherwise.
+   */
+  activatePendingRouteMenu(): boolean {
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: this._pendingRouteActivation,
+      menusList: this.menusList,
+      currentMenu: this._currentMenus,
+      historyRoutePaths: this._historyRoutePaths,
+    });
+    this._pendingRouteActivation = result.pendingRoutePath;
+    if (!result.activated) {
+      return false;
+    }
+    this._currentMenus = result.currentMenu;
+    this._historyRoutePaths = result.historyRoutePaths;
+    WKApp.currentMenuId = result.currentMenu?.id;
+    // NB: unlike onMenuClick we deliberately do NOT WKApp.routeRight.popToRoot() here. The route
+    // being activated (e.g. /docs) mounts fresh and populates the right pane itself via
+    // replaceToRoot on mount; popping first would empty the shared queue and briefly flash the
+    // host's base chat placeholder (the exact race DocsHome is built to avoid). Atomic replace by
+    // the newly-mounted route is cleaner than empty-then-fill.
+    return true;
+  }
+
   // 标记当前新版本已读，清除红点
   markVersionRead() {
     if (this.lastVersionInfo?.appVersion) {
@@ -245,6 +295,11 @@ export default class MainVM extends ProviderListener {
         this._historyRoutePaths.push(menus.routePath);
       }
     }
+    // An explicit menu selection (user click via onMenuClick, or switchToMenuById) cancels any
+    // pending boot-route activation: the user has chosen a view, so a config-gated menu that
+    // resolves later must not yank them off it. didMount sets _pendingRouteActivation only AFTER
+    // its own fallback assignment runs through here, so this does not clobber that.
+    this._pendingRouteActivation = undefined;
     this.notifyListener();
   }
   get settingSelected() {

--- a/apps/web/src/Pages/Main/vm.ts
+++ b/apps/web/src/Pages/Main/vm.ts
@@ -172,17 +172,29 @@ export default class MainVM extends ProviderListener {
   }
 
   /**
-   * Reconcile the active menu against the live menu list. Called on remote-config changes.
+   * Reconcile menu state against the live menu list. Called on remote-config changes.
    *
-   * If the currently active menu is no longer present in `menusList` (a config-gated entry such
-   * as docs_on was turned off), drop its cached route from `historyRoutePaths` so the view
-   * actually unmounts (tearing down e.g. the docs collab WebSocket) and fall back to the first
-   * available menu. If the active menu is still present, this is a no-op.
+   * Drops any `historyRoutePaths` entry whose menu is no longer present (a config-gated entry
+   * such as docs_on was turned off) — including background tabs the user isn't currently on, not
+   * just the active one — so the corresponding view unmounts. If the *active* menu itself
+   * vanished, additionally falls back to the first available menu.
+   *
+   * The *active* menu may have pushed content into the shared right-hand pane
+   * (`WKApp.routeRight`, e.g. the docs collab editor via `routeRight.replaceToRoot`), which is
+   * independent of `historyRoutePaths` and would otherwise keep its WebSocket connected after its
+   * NavRail entry disappears. When the active menu itself vanishes we clear that pane too,
+   * mirroring what a manual menu switch already does for a non-chat menu (see `onMenuClick` in
+   * `Pages/Main/index.tsx`). This must NOT fire just because some hidden/background tab was
+   * pruned — `routeRight` is shared with whatever menu is *currently* active (e.g. chat pushes
+   * its own content there too via EndpointCommon.tsx), so clearing it on every prune would wipe
+   * an unrelated active view (an open chat conversation) whenever some other gated-off
+   * background tab happens to be dropped from history at the same time.
    *
    * Deliberately one-directional: turning a menu ON never yanks the user off their current view,
    * so we only handle disappearance, not appearance (no surprise auto-navigation).
    *
-   * @returns true if the active menu changed (caller should re-render), false if unchanged.
+   * @returns true if the active menu or history changed (caller should re-render), false if
+   * unchanged.
    */
   reconcileActiveMenu(): boolean {
     const result = reconcileMenuState({
@@ -196,6 +208,9 @@ export default class MainVM extends ProviderListener {
     this._currentMenus = result.currentMenu;
     this._historyRoutePaths = result.historyRoutePaths;
     WKApp.currentMenuId = result.currentMenu?.id;
+    if (result.activeMenuVanished) {
+      WKApp.routeRight.popToRoot();
+    }
     return true;
   }
 

--- a/apps/web/src/__tests__/docsOn.test.ts
+++ b/apps/web/src/__tests__/docsOn.test.ts
@@ -40,11 +40,14 @@ describe("docs_on appconfig web integration", () => {
 
     // Menu factory returns the entry only when docsOn is true (else undefined → hidden).
     expect(source).toContain("wk.remoteConfig?.docsOn");
-    // Subscribe to first load AND later changes, refreshing the NavRail each time.
-    expect(source).toContain("wk.remoteConfig?.addListener(refreshMenus)");
-    expect(source).toContain(
-      "wk.remoteConfig?.addConfigChangeListener(refreshMenus)"
-    );
+    // Subscribe to first load AND later changes, refreshing the NavRail each time. (Behavioral
+    // coverage of the gate flip lives in packages/docs/module.test.tsx; these assert the wiring
+    // is present.)
+    expect(source).toContain("rc.addListener(refreshMenus)");
+    expect(source).toContain("rc.addConfigChangeListener(refreshMenus)");
     expect(source).toContain("wk.menus.refresh?.()");
+    // Honor the addListener contract: when appconfig already resolved before init, reflect the
+    // current docs_on immediately instead of waiting on a listener that would never fire (#536).
+    expect(source).toContain("rc.requestSuccess");
   });
 });

--- a/apps/web/src/__tests__/docsOn.test.ts
+++ b/apps/web/src/__tests__/docsOn.test.ts
@@ -1,0 +1,50 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseRemoteBool } from "../../../../packages/dmworkbase/src/Utils/remoteConfig";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+describe("docs_on appconfig web integration", () => {
+  it.each([
+    [0, false],
+    ["0", false],
+    [undefined, false],
+    [1, true],
+    ["1", true],
+    [true, true],
+    ["true", true],
+    ["false", false],
+  ])("parses appconfig docs_on value %s as docsOn=%s", (value, expected) => {
+    expect(parseRemoteBool(value)).toBe(expected);
+  });
+
+  it("wires docsOn into WKRemoteConfig from appconfig, defaulting to false", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+
+    // Fail-safe default: hidden until docs-backend is deployed and ops flips docs_on.
+    expect(source).toContain("docsOn: boolean = false");
+    expect(source).toContain('this.docsOn = parseRemoteBool(result["docs_on"])');
+    // docsOn must participate in change detection so the NavRail refreshes on toggle.
+    expect(source).toContain("previousDocsOn");
+    expect(source).toContain("previousDocsOn !== this.docsOn");
+    expect(source).toContain("notifyConfigChangeListeners");
+  });
+
+  it("gates the Docs NavRail entry on docsOn and refreshes when appconfig arrives", () => {
+    const source = readRepoFile("packages/docs/src/module.tsx");
+
+    // Menu factory returns the entry only when docsOn is true (else undefined → hidden).
+    expect(source).toContain("wk.remoteConfig?.docsOn");
+    // Subscribe to first load AND later changes, refreshing the NavRail each time.
+    expect(source).toContain("wk.remoteConfig?.addListener(refreshMenus)");
+    expect(source).toContain(
+      "wk.remoteConfig?.addConfigChangeListener(refreshMenus)"
+    );
+    expect(source).toContain("wk.menus.refresh?.()");
+  });
+});

--- a/apps/web/src/__tests__/mainMenuReconcile.test.tsx
+++ b/apps/web/src/__tests__/mainMenuReconcile.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { reconcileMenuState, type MenuLike } from "../Pages/Main/menuReconcile";
+
+// Behavioral coverage for the #536 reviewer follow-up (Jerry-Xin + yujiawei): when a
+// remote-config-gated menu (e.g. docs_on) is toggled OFF while it is the active view,
+// reconciliation must drop its cached route (so the view unmounts / collab WS tears down) and
+// fall back to the first available menu — otherwise the NavRail entry disappears but the route
+// keeps rendering via historyRoutePaths. Turning a menu ON must never move the user.
+//
+// Tested against the pure `reconcileMenuState` helper so it needs no @octo/base module graph;
+// MainVM.reconcileActiveMenu is a thin adapter that copies the result onto its private state.
+
+const chat: MenuLike = { id: "chat", routePath: "/chat" };
+const docs: MenuLike = { id: "docs", routePath: "/docs" };
+
+describe("reconcileMenuState — config-gated menu disappearance", () => {
+  it("falls back to the first menu and drops the route when the active menu is gated off", () => {
+    // User is on Docs; docs_on flips false → docs leaves the list.
+    const result = reconcileMenuState({
+      menusList: [chat], // post-toggle: docs gone
+      currentMenu: docs,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.currentMenu?.id).toBe("chat"); // reconciled to first available
+    expect(result.historyRoutePaths).not.toContain("/docs"); // stale route dropped → unmounts
+    expect(result.historyRoutePaths).toContain("/chat");
+  });
+
+  it("is a no-op when the active menu is still present", () => {
+    const result = reconcileMenuState({
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.changed).toBe(false);
+    expect(result.currentMenu?.id).toBe("chat");
+    expect(result.historyRoutePaths).toEqual(["/chat"]);
+  });
+
+  it("does not move the user when a menu is turned ON (one-directional)", () => {
+    // docs just appeared, user is on chat → chat still present → no change.
+    const result = reconcileMenuState({
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.changed).toBe(false);
+    expect(result.currentMenu?.id).toBe("chat");
+  });
+
+  it("handles no active menu gracefully", () => {
+    const result = reconcileMenuState({
+      menusList: [chat],
+      currentMenu: undefined,
+      historyRoutePaths: [],
+    });
+    expect(result.changed).toBe(false);
+    expect(result.currentMenu).toBeUndefined();
+  });
+
+  it("clears the active menu when the list becomes empty", () => {
+    const result = reconcileMenuState({
+      menusList: [],
+      currentMenu: docs,
+      historyRoutePaths: ["/docs"],
+    });
+    expect(result.changed).toBe(true);
+    expect(result.currentMenu).toBeUndefined();
+    expect(result.historyRoutePaths).not.toContain("/docs");
+  });
+});

--- a/apps/web/src/__tests__/mainMenuReconcile.test.tsx
+++ b/apps/web/src/__tests__/mainMenuReconcile.test.tsx
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 import * as path from "path";
 import { describe, it, expect } from "vitest";
-import { reconcileMenuState, type MenuLike } from "../Pages/Main/menuReconcile";
+import {
+  reconcileMenuState,
+  resolvePendingRouteActivation,
+  type MenuLike,
+} from "../Pages/Main/menuReconcile";
 
 const repoRoot = path.resolve(__dirname, "../../../..");
 
@@ -175,5 +179,99 @@ describe("MainVM.reconcileActiveMenu — releases the shared right pane only whe
     const popIdx = source.indexOf("WKApp.routeRight.popToRoot()");
     expect(guardIdx).toBeGreaterThan(-1);
     expect(popIdx).toBeGreaterThan(guardIdx);
+  });
+});
+
+// #536 round-4 reviewer follow-up (yujiawei / OctoBoooot / Jerry-Xin): the gating regressed the
+// APPEARANCE side. Because the docs menu factory returns undefined until docs_on resolves, a hard
+// load / refresh / bookmark / share-link of /docs finds no matching menu at MainVM.didMount and
+// falls back to chat; when docs_on later resolves, the NavRail refresh makes the entry appear but
+// nothing re-selects the deep-linked route, stranding the user on chat. MainVM records the
+// unsatisfied boot route and, on each appconfig change, asks resolvePendingRouteActivation whether
+// that route's menu has since appeared. Tested as a pure helper (no @octo/base graph); MainVM is a
+// thin adapter that copies the result onto its private state and clears the pending path on any
+// explicit user navigation (verified by source assertion below).
+describe("resolvePendingRouteActivation — deep-link appears after appconfig resolves", () => {
+  it("activates the pending route once its menu appears, and clears the pending path", () => {
+    // Booted at /docs, fell back to chat; docs_on now true → docs menu appears.
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: "/docs",
+      menusList: [chat, docs], // docs now live
+      currentMenu: chat, // user still on the fallback
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.activated).toBe(true);
+    expect(result.currentMenu?.id).toBe("docs");
+    expect(result.historyRoutePaths).toEqual(["/chat", "/docs"]); // route added → host renders it
+    expect(result.pendingRoutePath).toBeUndefined(); // consumed
+  });
+
+  it("keeps waiting (no activation) while the pending route's menu is still absent", () => {
+    // docs_on hasn't resolved yet → docs still not in the list.
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: "/docs",
+      menusList: [chat], // docs still gated off
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.activated).toBe(false);
+    expect(result.currentMenu?.id).toBe("chat");
+    expect(result.historyRoutePaths).toEqual(["/chat"]);
+    expect(result.pendingRoutePath).toBe("/docs"); // still pending
+  });
+
+  it("is a no-op with no pending route", () => {
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: undefined,
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.activated).toBe(false);
+    expect(result.pendingRoutePath).toBeUndefined();
+  });
+
+  it("consumes the pending path without moving the user when the menu is already active", () => {
+    // Edge: the deep-linked menu somehow became active already → just drop the pending path.
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: "/docs",
+      menusList: [chat, docs],
+      currentMenu: docs,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+    expect(result.activated).toBe(false);
+    expect(result.currentMenu?.id).toBe("docs");
+    expect(result.pendingRoutePath).toBeUndefined(); // consumed, won't re-check
+  });
+
+  it("does not duplicate the route when it is already in history", () => {
+    const result = resolvePendingRouteActivation({
+      pendingRoutePath: "/docs",
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat", "/docs"], // already present (e.g. visited earlier)
+    });
+    expect(result.activated).toBe(true);
+    expect(result.currentMenu?.id).toBe("docs");
+    expect(result.historyRoutePaths).toEqual(["/chat", "/docs"]); // no duplicate
+  });
+});
+
+describe("MainVM — pending deep-link wiring", () => {
+  it("records the unsatisfied boot route and clears it on explicit navigation", () => {
+    const source = readRepoFile("apps/web/src/Pages/Main/vm.ts");
+    // didMount stashes the boot route when the fallback fired (no menu matched it)...
+    expect(source).toContain("this._pendingRouteActivation = bootPath");
+    // ...and the config-change listener tries to activate it as menus appear.
+    expect(source).toContain("this.activatePendingRouteMenu()");
+    // Any explicit menu selection (the currentMenus setter) must cancel the pending activation so
+    // a late docs_on toggle never yanks a user off a view they chose.
+    expect(source).toContain("this._pendingRouteActivation = undefined");
+    const setterClearIdx = source.indexOf(
+      "this._pendingRouteActivation = undefined"
+    );
+    const setterIdx = source.indexOf("set currentMenus(");
+    expect(setterIdx).toBeGreaterThan(-1);
+    expect(setterClearIdx).toBeGreaterThan(setterIdx);
   });
 });

--- a/apps/web/src/__tests__/mainMenuReconcile.test.tsx
+++ b/apps/web/src/__tests__/mainMenuReconcile.test.tsx
@@ -1,5 +1,13 @@
+import * as fs from "fs";
+import * as path from "path";
 import { describe, it, expect } from "vitest";
 import { reconcileMenuState, type MenuLike } from "../Pages/Main/menuReconcile";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
 
 // Behavioral coverage for the #536 reviewer follow-up (Jerry-Xin + yujiawei): when a
 // remote-config-gated menu (e.g. docs_on) is toggled OFF while it is the active view,
@@ -69,5 +77,103 @@ describe("reconcileMenuState — config-gated menu disappearance", () => {
     expect(result.changed).toBe(true);
     expect(result.currentMenu).toBeUndefined();
     expect(result.historyRoutePaths).not.toContain("/docs");
+  });
+
+  // #536 round-2 reviewer follow-up (yujiawei/OctoBoooot/Jerry-Xin): a menu gated off while the
+  // user is on a *different* tab must still be pruned from history — otherwise the hidden
+  // subtree (and anything it pushed outside historyRoutePaths, e.g. the docs editor in the
+  // shared right pane) lingers forever, since it's no longer reachable from the NavRail.
+  it("drops a gated-off menu's route even when it is not the active tab", () => {
+    // User is on chat; docs was visited earlier (hidden, display:none) and is now gated off.
+    const result = reconcileMenuState({
+      menusList: [chat], // post-toggle: docs gone
+      currentMenu: chat,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+
+    expect(result.changed).toBe(true); // history shrank → caller must re-render
+    expect(result.currentMenu?.id).toBe("chat"); // active tab is untouched
+    expect(result.historyRoutePaths).toEqual(["/chat"]);
+    expect(result.prunedRoutePaths).toEqual(["/docs"]);
+  });
+
+  it("reports no pruned routes when nothing disappeared", () => {
+    const result = reconcileMenuState({
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(result.prunedRoutePaths).toEqual([]);
+  });
+
+  it("reports the vanished route as pruned when the active menu itself disappears", () => {
+    const result = reconcileMenuState({
+      menusList: [chat],
+      currentMenu: docs,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+    expect(result.prunedRoutePaths).toEqual(["/docs"]);
+  });
+
+  // #536 round-4 reviewer follow-up: `activeMenuVanished` is the signal the caller uses to decide
+  // whether to also clear the shared right-hand pane (WKApp.routeRight). It must be true only
+  // when the *active* menu vanished, and false when merely a hidden/background tab was pruned —
+  // otherwise clearing routeRight on every prune would wipe an unrelated active view (e.g. chat
+  // pushes its own content into the same shared pane).
+  it("reports activeMenuVanished=true only when the active menu itself disappeared", () => {
+    const activeGoneResult = reconcileMenuState({
+      menusList: [chat],
+      currentMenu: docs,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+    expect(activeGoneResult.activeMenuVanished).toBe(true);
+
+    const hiddenTabPrunedResult = reconcileMenuState({
+      menusList: [chat], // docs gone, but it wasn't the active menu
+      currentMenu: chat,
+      historyRoutePaths: ["/chat", "/docs"],
+    });
+    expect(hiddenTabPrunedResult.activeMenuVanished).toBe(false);
+    expect(hiddenTabPrunedResult.prunedRoutePaths).toEqual(["/docs"]); // still pruned from history
+
+    const noOpResult = reconcileMenuState({
+      menusList: [chat, docs],
+      currentMenu: chat,
+      historyRoutePaths: ["/chat"],
+    });
+    expect(noOpResult.activeMenuVanished).toBe(false);
+  });
+});
+
+// #536 round-3/4 reviewer follow-up (yujiawei/OctoBoooot/Jerry-Xin, converged after
+// back-and-forth): dropping a route from `historyRoutePaths` only unmounts what that route
+// renders directly there. The docs editor instead lives in the shared right-hand pane
+// (WKApp.routeRight, pushed via `routeRight.replaceToRoot`), which `historyRoutePaths` pruning
+// never touches — so its collab WebSocket kept running after `docs_on` was gated off while docs
+// was the active tab. Fix: MainVM.reconcileActiveMenu additionally clears `WKApp.routeRight`
+// when the active menu itself vanished (mirroring what a manual menu switch already does — see
+// onMenuClick in Pages/Main/index.tsx). Gating on `activeMenuVanished` rather than "any route
+// pruned" matters: routeRight is shared with whatever menu is currently active (e.g. chat pushes
+// its own content there too, see EndpointCommon.tsx), so clearing it whenever some unrelated
+// background tab is pruned would wipe an open chat conversation. Verified here via source
+// assertion (same house style as docsOn.test.ts / disableUserCreateSpace.test.ts) since
+// MainVM.reconcileActiveMenu is a thin adapter over the fully execution-tested
+// `reconcileMenuState` above; a real @octo/base WKApp instance would pull in the full heavy
+// module graph these tests deliberately avoid.
+describe("MainVM.reconcileActiveMenu — releases the shared right pane only when the active menu vanishes", () => {
+  it("gates WKApp.routeRight.popToRoot() on activeMenuVanished, not on any prune", () => {
+    const source = readRepoFile("apps/web/src/Pages/Main/vm.ts");
+
+    expect(source).toContain("result.activeMenuVanished");
+    expect(source).toContain("WKApp.routeRight.popToRoot()");
+    // Must NOT regress to clearing on every prune, which would also wipe an active menu's own
+    // right-pane content (e.g. chat's open conversation) whenever an unrelated background tab
+    // is dropped from history at the same time.
+    expect(source).not.toContain("result.prunedRoutePaths.length > 0");
+
+    const guardIdx = source.indexOf("result.activeMenuVanished");
+    const popIdx = source.indexOf("WKApp.routeRight.popToRoot()");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(popIdx).toBeGreaterThan(guardIdx);
   });
 });

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -227,6 +227,18 @@ export class WKRemoteConfig {
    */
   stickerCustomEnabled: boolean = false;
   /**
+   * Docs 协作文档模块展示开关。后端字段 docs_on 为 true 时，前端在侧边栏 NavRail
+   * 展示 Docs 入口；false 或字段缺失时隐藏。
+   *
+   * 默认 false(fail-safe): docs-backend 是独立服务，其反向代理路由、Hocuspocus
+   * WS(:1234) 暴露、MySQL/Redis/对象存储依赖未就绪前保持隐藏，避免用户点进去卡在
+   * "Loading document…" 或报错。运维在 docs-backend 部署就绪后再下发 docs_on=true。
+   *
+   * 纯 UI 展示开关，不承担鉴权语义: /api/v1/docs 相关接口的权限校验仍由 docs-backend
+   * 负责，前端不能据此推断用户是否具备文档访问能力。
+   */
+  docsOn: boolean = false;
+  /**
    * OIDC provider 元数据数组, 由后端 /v1/common/appconfig 的 oidc_providers 字段下发。
    * OIDC 关闭时为空数组。前端不再硬编码具体 IdP, 部署 env 切 provider。
    * 顶层 oidc_account_url / oidc_reset_password_url 是后端兼容老前端用的,新前端只读这里。
@@ -326,6 +338,7 @@ export class WKRemoteConfig {
       const previousSuppressLoginMigrationNotice =
         this.suppressLoginMigrationNotice;
       const previousStickerCustomEnabled = this.stickerCustomEnabled;
+      const previousDocsOn = this.docsOn;
       this.requestSuccess = true;
       this.revokeSecond = result["revoke_second"];
       this.threadOn = !!result["thread_on"];
@@ -339,6 +352,7 @@ export class WKRemoteConfig {
       this.stickerCustomEnabled = parseRemoteBool(
         result["sticker_custom_enabled"]
       );
+      this.docsOn = parseRemoteBool(result["docs_on"]);
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();
@@ -347,7 +361,8 @@ export class WKRemoteConfig {
         previousMessagesSearchOn !== this.messagesSearchOn ||
         previousSuppressLoginMigrationNotice !==
           this.suppressLoginMigrationNotice ||
-        previousStickerCustomEnabled !== this.stickerCustomEnabled
+        previousStickerCustomEnabled !== this.stickerCustomEnabled ||
+        previousDocsOn !== this.docsOn
       ) {
         this.notifyConfigChangeListeners();
       }

--- a/packages/dmworkbase/src/Service/Menus.ts
+++ b/packages/dmworkbase/src/Service/Menus.ts
@@ -7,7 +7,9 @@ export default class MenusManager {
   }
   setRefresh?:()=>void
   public static shared = new MenusManager()
-  register(sid: string, f: (param:any) => Menus,sort?:number) {
+  // 工厂可返回 undefined 表示「当前不展示该菜单」——invokes() 用 `if (result)` 过滤 falsy，
+  // 配合 refresh() 可实现按 remoteConfig(如 docsOn)运行时显隐,无需 unregister。
+  register(sid: string, f: (param:any) => Menus | undefined,sort?:number) {
     EndpointManager.shared.setMethod(
       `${EndpointID.menusPrefix}${sid}`, (param) => f(param),
       { category: EndpointCategory.menus,sort:sort });

--- a/packages/docs/src/module.test.tsx
+++ b/packages/docs/src/module.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { setWKApp } from './octoweb/index.ts'
-import { createMockWKApp } from './octoweb/mock.ts'
+import { createMockWKApp, MockRemoteConfig } from './octoweb/mock.ts'
 import { DocsModule } from './module.tsx'
 
 // Replace the heavy editor chunk (Tiptap + Yjs + Hocuspocus) with a marker component so the
@@ -58,6 +58,59 @@ describe('DocsModule (octo-web same-origin integration)', () => {
     expect(wk.mockMenus.menus.has('docs')).toBe(true)
     const menu = wk.mockMenus.menus.get('docs')!() as { routePath: string }
     expect(menu.routePath).toBe('/docs')
+  })
+
+  describe('docs_on appconfig gate', () => {
+    it('hides the NavRail entry (factory returns undefined) when docs_on is false', () => {
+      // Default fail-safe: docs-backend may not be deployed yet, so with docs_on=false the
+      // factory returns undefined and MenusManager.invokes() filters it out — no entry shown.
+      const wk = createMockWKApp(undefined, new MockRemoteConfig(false))
+      setWKApp(wk)
+      new DocsModule().init()
+      // The factory IS registered (so it re-evaluates on refresh), but yields nothing now.
+      expect(wk.mockMenus.menus.has('docs')).toBe(true)
+      expect(wk.mockMenus.menus.get('docs')!()).toBeUndefined()
+    })
+
+    it('shows the NavRail entry when docs_on is true', () => {
+      const wk = createMockWKApp(undefined, new MockRemoteConfig(true))
+      setWKApp(wk)
+      new DocsModule().init()
+      const menu = wk.mockMenus.menus.get('docs')!() as { routePath: string } | undefined
+      expect(menu?.routePath).toBe('/docs')
+    })
+
+    it('re-evaluates from hidden to shown when docs_on flips after appconfig arrives', () => {
+      // appconfig is async: at init() docs_on is still false, so the entry is hidden. When the
+      // backend later reports docs_on=true, the module refreshes the NavRail and the factory now
+      // yields the menu. This is the real boot ordering the listeners exist for.
+      const rc = new MockRemoteConfig(false)
+      const wk = createMockWKApp(undefined, rc)
+      setWKApp(wk)
+      new DocsModule().init()
+      expect(wk.mockMenus.menus.get('docs')!()).toBeUndefined()
+
+      // Backend enables docs after deployment is ready → first-load listener fires a refresh.
+      rc.docsOn = true
+      rc.emitLoad()
+      expect(wk.mockMenus.refreshCount).toBeGreaterThan(0)
+      const menu = wk.mockMenus.menus.get('docs')!() as { routePath: string } | undefined
+      expect(menu?.routePath).toBe('/docs')
+    })
+
+    it('refreshes the NavRail on a later appconfig change (docs_on toggled off)', () => {
+      const rc = new MockRemoteConfig(true)
+      const wk = createMockWKApp(undefined, rc)
+      setWKApp(wk)
+      new DocsModule().init()
+      expect((wk.mockMenus.menus.get('docs')!() as { routePath: string }).routePath).toBe('/docs')
+
+      // Ops turns docs off again → change listener refreshes, factory now hides the entry.
+      rc.docsOn = false
+      rc.emitChange()
+      expect(wk.mockMenus.refreshCount).toBeGreaterThan(0)
+      expect(wk.mockMenus.menus.get('docs')!()).toBeUndefined()
+    })
   })
 
   it('returns a STABLE /docs route element across handler invocations', () => {

--- a/packages/docs/src/module.test.tsx
+++ b/packages/docs/src/module.test.tsx
@@ -111,6 +111,41 @@ describe('DocsModule (octo-web same-origin integration)', () => {
       expect(wk.mockMenus.refreshCount).toBeGreaterThan(0)
       expect(wk.mockMenus.menus.get('docs')!()).toBeUndefined()
     })
+
+    it('refreshes immediately when appconfig already resolved before init (#536 P2)', () => {
+      // Registration-order independent: if the docs module initializes AFTER the first appconfig
+      // load resolved, addListener would return a noop (fires only for pre-load subscribers), so
+      // the entry would wait for an unrelated later change. init() must honor requestSuccess and
+      // reflect the current docs_on right away.
+      const rc = new MockRemoteConfig(true)
+      rc.emitLoad() // first appconfig load resolves → requestSuccess=true, before init()
+      expect(rc.requestSuccess).toBe(true)
+      const wk = createMockWKApp(undefined, rc)
+      setWKApp(wk)
+      new DocsModule().init()
+      // Entry reflects docs_on now, without waiting for a further emitLoad/emitChange.
+      expect(wk.mockMenus.refreshCount).toBeGreaterThan(0)
+      expect((wk.mockMenus.menus.get('docs')!() as { routePath: string }).routePath).toBe('/docs')
+    })
+
+    it('does not accumulate duplicate config listeners across repeat init() (#536 P2)', () => {
+      // HMR / re-registration calls init() again on the same instance. The listeners must be
+      // rebound idempotently (old ones dropped first), not stacked — else each appconfig change
+      // fires refreshMenus N times.
+      const rc = new MockRemoteConfig(false)
+      const wk = createMockWKApp(undefined, rc)
+      setWKApp(wk)
+      const mod = new DocsModule()
+      mod.init()
+      mod.init()
+      mod.init()
+      // Exactly one change listener remains regardless of how many times init() ran.
+      expect(rc.changeListenerCount()).toBe(1)
+      const before = wk.mockMenus.refreshCount
+      rc.docsOn = true
+      rc.emitChange()
+      expect(wk.mockMenus.refreshCount).toBe(before + 1) // one refresh, not three
+    })
   })
 
   it('returns a STABLE /docs route element across handler invocations', () => {

--- a/packages/docs/src/module.tsx
+++ b/packages/docs/src/module.tsx
@@ -243,6 +243,12 @@ const docsRouteElement = <DocsRouteElement />
  * BaseModule / LoginModule / ContactsModule.
  */
 export class DocsModule implements IModule {
+  // Unsubscribe fns for the remote-config listeners bound in init(). Stored (rather than
+  // discarded) so a repeat init() on this instance — HMR, re-registration — can drop the old
+  // ones before rebinding instead of accumulating refreshMenus closures on the shared
+  // WKApp.remoteConfig singleton. Mirrors MainVM's _unsubscribeMenuReconcile discipline.
+  private _configUnsubscribers: Array<() => void> = []
+
   id(): string {
     return 'docs'
   }
@@ -289,13 +295,29 @@ export class DocsModule implements IModule {
       4002,
     )
 
-    // appconfig is fetched asynchronously, so at init() docsOn is almost always still the
-    // default false. Subscribe to the FIRST successful load (addListener) and to later CHANGES
-    // (addConfigChangeListener) and refresh the NavRail on each, so the Docs entry appears (or
-    // disappears) the moment docs_on resolves — no unsubscribe needed, the module lives for the
-    // app's lifetime, same as its route/menu registration.
+    // appconfig is fetched asynchronously, so at init() docsOn is usually still the default
+    // false. Refresh the NavRail whenever docs_on resolves/changes so the Docs entry appears (or
+    // disappears) the moment it does.
+    //
+    // Idempotent rebind: drop any listeners a previous init() on this instance bound before
+    // re-subscribing, so repeat registration / HMR doesn't stack duplicate refreshMenus closures
+    // on the shared remoteConfig singleton.
+    for (const unsub of this._configUnsubscribers) unsub()
+    this._configUnsubscribers = []
+
     const refreshMenus = (): void => wk.menus.refresh?.()
-    wk.remoteConfig?.addListener(refreshMenus)
-    wk.remoteConfig?.addConfigChangeListener(refreshMenus)
+    const rc = wk.remoteConfig
+    if (rc) {
+      // Honor the addListener contract: if the first appconfig load has ALREADY resolved (module
+      // initialized late — registration-order independent), addListener would return a noop and
+      // the entry would wait for an unrelated later change. Reflect the current docs_on now.
+      if (rc.requestSuccess) {
+        refreshMenus()
+      } else {
+        this._configUnsubscribers.push(rc.addListener(refreshMenus))
+      }
+      // Later toggles (ops flips docs_on after boot) always go through the change listener.
+      this._configUnsubscribers.push(rc.addConfigChangeListener(refreshMenus))
+    }
   }
 }

--- a/packages/docs/src/module.tsx
+++ b/packages/docs/src/module.tsx
@@ -273,10 +273,29 @@ export class DocsModule implements IModule {
     // routePath. Registering the menu fixes both the missing entry AND deep-link
     // mounting. Pattern mirrors MatterModule / dmworksummary. sort=4002 places it
     // after contacts(4000)/matter(4001) and before summary(5000).
+    //
+    // Gated by the backend appconfig `docs_on` flag (WKApp.remoteConfig.docsOn): the factory
+    // returns the menu only when docsOn is true, otherwise `undefined` (MenusManager.invokes
+    // filters falsy → the entry is hidden). Default is false (fail-safe) — docs-backend is an
+    // independent service whose reverse-proxy route / collab WS(:1234) / storage deps must be
+    // deployed before the entry is usable; ops flips docs_on on once ready. This is a pure
+    // display gate: /api/v1/docs auth still lives in docs-backend.
     wk.menus.register(
       'docs',
-      () => new Menus('docs', '/docs', t('docs.menu.title'), <DocsIcon />, <DocsIcon active />),
+      () =>
+        wk.remoteConfig?.docsOn
+          ? new Menus('docs', '/docs', t('docs.menu.title'), <DocsIcon />, <DocsIcon active />)
+          : undefined,
       4002,
     )
+
+    // appconfig is fetched asynchronously, so at init() docsOn is almost always still the
+    // default false. Subscribe to the FIRST successful load (addListener) and to later CHANGES
+    // (addConfigChangeListener) and refresh the NavRail on each, so the Docs entry appears (or
+    // disappears) the moment docs_on resolves — no unsubscribe needed, the module lives for the
+    // app's lifetime, same as its route/menu registration.
+    const refreshMenus = (): void => wk.menus.refresh?.()
+    wk.remoteConfig?.addListener(refreshMenus)
+    wk.remoteConfig?.addConfigChangeListener(refreshMenus)
   }
 }

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -9,6 +9,7 @@ import type {
   ApiResponse,
   IModule,
   LoginInfo,
+  RemoteConfigLite,
   RouteManager,
   SpaceMemberLite,
   WKAppShape,
@@ -69,16 +70,60 @@ export class MockRouteManager implements RouteManager {
 
 export class MockMenusManager {
   menus = new Map<string, (param?: any) => unknown>()
+  /** Number of times the docs module asked the NavRail to re-render (config gate flips). */
+  refreshCount = 0
   register(sid: string, f: (param?: any) => unknown): void {
     this.menus.set(sid, f)
   }
+  refresh(): void {
+    this.refreshCount++
+  }
 }
 
-export function createMockWKApp(loginInfo: LoginInfo = { uid: 'u_self', token: 'octo-session-token' }): WKAppShape & {
+/**
+ * Test double for the host WKApp.remoteConfig gate. `docsOn` defaults to true so the existing
+ * "menu registers" assertions keep exercising the enabled case; tests that cover the gate set
+ * it explicitly and call `emitLoad()` / `emitChange()` to simulate appconfig arriving/changing.
+ */
+export class MockRemoteConfig implements RemoteConfigLite {
+  docsOn: boolean
+  private loadListeners: Array<() => void> = []
+  private changeListeners: Array<() => void> = []
+  constructor(docsOn = true) {
+    this.docsOn = docsOn
+  }
+  addListener(cb: () => void): () => void {
+    this.loadListeners.push(cb)
+    return () => {
+      this.loadListeners = this.loadListeners.filter((l) => l !== cb)
+    }
+  }
+  addConfigChangeListener(cb: () => void): () => void {
+    this.changeListeners.push(cb)
+    return () => {
+      this.changeListeners = this.changeListeners.filter((l) => l !== cb)
+    }
+  }
+  /** Simulate the FIRST successful appconfig load firing its one-shot listeners. */
+  emitLoad(): void {
+    for (const l of [...this.loadListeners]) l()
+  }
+  /** Simulate a subsequent appconfig change firing its change listeners. */
+  emitChange(): void {
+    for (const l of [...this.changeListeners]) l()
+  }
+}
+
+export function createMockWKApp(
+  loginInfo: LoginInfo = { uid: 'u_self', token: 'octo-session-token' },
+  remoteConfig: MockRemoteConfig = new MockRemoteConfig(),
+): WKAppShape & {
   apiClient: MockApiClient
   route: MockRouteManager
   mockMenus: MockMenusManager
   registeredModules: IModule[]
+  /** Test hook: the docs gate double (set docsOn, emitLoad/emitChange). */
+  mockRemoteConfig: MockRemoteConfig
   /** Test hook: fake space members the seam's getSpaceMembers paginates over. */
   spaceMembers: SpaceMemberLite[]
 } {
@@ -94,6 +139,8 @@ export function createMockWKApp(loginInfo: LoginInfo = { uid: 'u_self', token: '
     route,
     menus: menus as unknown as WKAppShape['menus'],
     mockMenus: menus,
+    remoteConfig,
+    mockRemoteConfig: remoteConfig,
     loginInfo,
     registeredModules,
     spaceMembers,

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -87,12 +87,21 @@ export class MockMenusManager {
  */
 export class MockRemoteConfig implements RemoteConfigLite {
   docsOn: boolean
+  /** Mirrors the host contract: true once the first appconfig load has resolved. */
+  requestSuccess = false
   private loadListeners: Array<() => void> = []
   private changeListeners: Array<() => void> = []
   constructor(docsOn = true) {
     this.docsOn = docsOn
   }
   addListener(cb: () => void): () => void {
+    // Mirror the host: subscribing after the first load already resolved returns a noop, so a
+    // late subscriber never fires (it must check requestSuccess and self-handle instead).
+    if (this.requestSuccess) {
+      return () => {
+        /* noop */
+      }
+    }
     this.loadListeners.push(cb)
     return () => {
       this.loadListeners = this.loadListeners.filter((l) => l !== cb)
@@ -104,8 +113,13 @@ export class MockRemoteConfig implements RemoteConfigLite {
       this.changeListeners = this.changeListeners.filter((l) => l !== cb)
     }
   }
+  /** Number of change listeners currently registered (test hook for idempotent-rebind checks). */
+  changeListenerCount(): number {
+    return this.changeListeners.length
+  }
   /** Simulate the FIRST successful appconfig load firing its one-shot listeners. */
   emitLoad(): void {
+    this.requestSuccess = true
     for (const l of [...this.loadListeners]) l()
   }
   /** Simulate a subsequent appconfig change firing its change listeners. */

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -94,6 +94,13 @@ export interface MenusManager {
 export interface RemoteConfigLite {
   /** Docs module display switch (backend appconfig `docs_on`); false/absent → hidden. */
   docsOn: boolean
+  /**
+   * True once the FIRST appconfig load has resolved. Per the host contract, a subscriber that
+   * registers via `addListener` after this is already true will NOT be called (addListener
+   * returns a noop), so callers must check this and handle the already-loaded state themselves.
+   * Optional in the seam: the real host WKRemoteConfig always provides it; older mocks may omit.
+   */
+  requestSuccess?: boolean
   /** Fires once on the FIRST successful appconfig load. Returns an unsubscribe fn. */
   addListener(cb: () => void): () => void
   /** Fires on subsequent appconfig CHANGES (after the first load). Returns an unsubscribe fn. */

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -75,6 +75,29 @@ export interface RouteManager {
  */
 export interface MenusManager {
   register(sid: string, f: (param?: any) => unknown, sort?: number): void
+  /**
+   * Re-render the NavRail. The docs module calls this when the `docs_on` gate flips (appconfig
+   * arrives / changes) so a menu factory that now returns a Menus (or undefined) is re-evaluated.
+   * Optional in the seam: the real host MenusManager implements it; the test mock may stub it.
+   */
+  refresh?(): void
+}
+
+/**
+ * Minimal remote-config surface the docs module reads to gate its NavRail entry.
+ *
+ * Backed by the host `WKApp.remoteConfig` (a WKRemoteConfig instance) in production, whose
+ * `docsOn` mirrors the backend `/v1/common/appconfig` `docs_on` field. The listener methods
+ * each return an unsubscribe fn (see WKRemoteConfig). Optional on WKAppShape because it is
+ * surfaced via the host static cast in prod and provided by the test mock.
+ */
+export interface RemoteConfigLite {
+  /** Docs module display switch (backend appconfig `docs_on`); false/absent → hidden. */
+  docsOn: boolean
+  /** Fires once on the FIRST successful appconfig load. Returns an unsubscribe fn. */
+  addListener(cb: () => void): () => void
+  /** Fires on subsequent appconfig CHANGES (after the first load). Returns an unsubscribe fn. */
+  addConfigChangeListener(cb: () => void): () => void
 }
 
 /** Current login session — packages/dmworkbase/src/Service/...; token is opaque (non-JWT). */
@@ -114,6 +137,12 @@ export interface WKAppShape {
   menus: MenusManager
   apiClient: APIClient
   loginInfo: LoginInfo
+  /**
+   * Host remote config (WKApp.remoteConfig). The docs module reads `docsOn` to gate its NavRail
+   * entry and subscribes to its listeners to refresh when `docs_on` arrives/changes. Optional in
+   * the shape: surfaced via the host static cast in prod; the test mock supplies a stub.
+   */
+  remoteConfig?: RemoteConfigLite
   /**
    * The host's RIGHT (main) route pane manager (App.routeRight, a ContextRouteManager).
    * Matter/Summary push their detail view here so it fills the main content area while the


### PR DESCRIPTION
## Why

The Docs NavRail entry was registered unconditionally, so every build showed it — even in environments where `octo-docs-backend` (an independent service that needs a reverse-proxy route for `/api/v1/docs/*`, the Hocuspocus collab WS on `:1234`, and MySQL/Redis/object storage) is not deployed yet. In that state a user clicking Docs lands on a stuck "Loading document…".

## What

Gate the Docs entry on `WKApp.remoteConfig.docsOn`, sourced from the backend `/v1/common/appconfig` `docs_on` field. Default is **false (fail-safe)** — hidden until ops enables it once docs-backend is deployed.

- `WKRemoteConfig` (`App.tsx`): parse `docs_on` via `parseRemoteBool` (same pattern as `messages_search_on` / `sticker_custom_enabled`) and include it in change detection so a toggle refreshes subscribers.
- `Menus.register`: allow the factory to return `Menus | undefined` (`invokes()` already filters falsy), enabling runtime show/hide without an unregister API.
- `@octo/docs` module: the menu factory returns the entry only when `docsOn` is true; the module subscribes to the first appconfig load and to later changes and refreshes the NavRail, so the entry appears/hides the moment `docs_on` resolves.
- docs seam (`octoweb/types.ts`, `mock.ts`): add `RemoteConfigLite`, `WKAppShape.remoteConfig`, `MenusManager.refresh` + a controllable test double.

This is a **pure display gate** — `/api/v1/docs` authorization still lives entirely in docs-backend. It does not gate the `/docs` route element, but the host main view is menu-driven (`MainVM.didMount` only activates a route matching a registered menu), so with the menu hidden a direct `/docs?...` deep-link falls back to the chat shell and the editor never mounts.

## Backend dependency

Requires `octo-server` to emit `docs_on` in `/v1/common/appconfig` (on both the normal and version-short-circuit branches). Absent or falsy → entry stays hidden. No client change needed when ops later flips it on.

## Test plan

- [x] `packages/docs` vitest — 441 passed (incl. new gate cases: hidden / shown / async-flip-on / toggle-off)
- [x] `apps/web` `docsOn.test.ts` — 10 passed (bool parsing + source-wiring assertions)
- [x] docs typecheck clean for changed files (2 pre-existing errors in untouched `i18n/format.ts` / `members/sort.ts`, identical to `main`)
- [x] Local dev vs test env (`im-test`): appconfig returns `docs_on: null` → parsed false → Docs entry hidden (verified in-browser)