### PR TITLE
fix(docs): reload document list when the current Space switches

### DIFF
--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -7,7 +7,7 @@
 // whenever no override has been set — i.e. in production and dev.
 
 import { WKApp, i18n, t, useI18n, Menus, SpaceService } from '@octo/base'
-import type { APIClient, ApiRequestConfig, ApiResponse, SpaceMemberLite, WKAppShape } from './types.ts'
+import type { APIClient, ApiRequestConfig, ApiResponse, MittBusLite, SpaceMemberLite, WKAppShape } from './types.ts'
 
 // Test-only override. When unset (production / dev), getWKApp() returns the real
 // `@octo/base` WKApp singleton below.
@@ -41,6 +41,30 @@ export function getRouteRight(): import('./types.ts').RouteRight | null {
   if (override) return override.routeRight ?? null
   const rr = (WKApp as unknown as { routeRight?: import('./types.ts').RouteRight }).routeRight
   return rr ?? null
+}
+
+/**
+ * Subscribe to the host's global "space switched" broadcast.
+ *
+ * The host emits `WKApp.mittBus.emit('space-changed', space)` whenever the user picks a
+ * different Space (packages/dmworkbase/src/Pages/Chat/vm.ts `set selectedSpace`, apps/web
+ * Pages/Main). `WKApp.shared.currentSpaceId` is a plain mutable field — reassigning it does
+ * NOT re-render React — so a component that derives state from it (DocsHome's document list)
+ * keeps showing the old Space's docs until a manual reload. Like the summary / todo /
+ * contacts modules, docs must listen to this event and re-read `currentSpaceId` to react.
+ *
+ * Returns an unsubscribe function. No-op (returns a noop unsubscribe) when no bus is
+ * available — an older test mock without one, or a non-browser context.
+ */
+export function onSpaceChanged(cb: () => void): () => void {
+  const bus: MittBusLite | undefined = override
+    ? override.mittBus
+    : (WKApp as unknown as { mittBus?: MittBusLite }).mittBus
+  if (!bus) return () => {}
+  // Ignore the payload: docs reacts to the switch by re-reading currentSpaceId itself.
+  const handler = () => cb()
+  bus.on('space-changed', handler)
+  return () => bus.off('space-changed', handler)
 }
 
 /** Page size for space-member fetches — mirrors the host useMemberList pattern (default 50). */

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -68,6 +68,32 @@ export class MockRouteManager implements RouteManager {
   }
 }
 
+/**
+ * Test double for the host WKApp.mittBus (a `mitt` emitter). Only the `space-changed` channel
+ * the docs module subscribes to is modeled. Tests drive a Space switch by mutating
+ * `wk.shared.currentSpaceId` and calling `emitSpaceChanged()` — mirroring the host, which sets
+ * `currentSpaceId` then emits `space-changed` (packages/dmworkbase/src/Pages/Chat/vm.ts).
+ */
+export class MockMittBus {
+  private spaceChangedListeners: Array<(payload?: unknown) => void> = []
+  on(type: 'space-changed', handler: (payload?: unknown) => void): void {
+    if (type === 'space-changed') this.spaceChangedListeners.push(handler)
+  }
+  off(type: 'space-changed', handler: (payload?: unknown) => void): void {
+    if (type === 'space-changed') {
+      this.spaceChangedListeners = this.spaceChangedListeners.filter((l) => l !== handler)
+    }
+  }
+  /** Number of space-changed listeners currently registered (leak / idempotency checks). */
+  spaceChangedListenerCount(): number {
+    return this.spaceChangedListeners.length
+  }
+  /** Simulate the host broadcasting a Space switch. */
+  emitSpaceChanged(payload?: unknown): void {
+    for (const l of [...this.spaceChangedListeners]) l(payload)
+  }
+}
+
 export class MockMenusManager {
   menus = new Map<string, (param?: any) => unknown>()
   /** Number of times the docs module asked the NavRail to re-render (config gate flips). */
@@ -140,10 +166,13 @@ export function createMockWKApp(
   mockRemoteConfig: MockRemoteConfig
   /** Test hook: fake space members the seam's getSpaceMembers paginates over. */
   spaceMembers: SpaceMemberLite[]
+  /** Test hook: the host event-bus double (emitSpaceChanged to simulate a Space switch). */
+  mockMittBus: MockMittBus
 } {
   const apiClient = new MockApiClient()
   const route = new MockRouteManager()
   const menus = new MockMenusManager()
+  const mittBus = new MockMittBus()
   const registeredModules: IModule[] = []
   // Fake space membership tests can populate (wk.spaceMembers.push(...)) so docs can resolve
   // uid → display name through the seam without a live host.
@@ -158,6 +187,8 @@ export function createMockWKApp(
     loginInfo,
     registeredModules,
     spaceMembers,
+    mittBus,
+    mockMittBus: mittBus,
     // Mirror the real host's paged getMembers: return the requested page slice. Docs loops
     // pages until a short/empty page, so a slice-based mock terminates fetchAllSpaceMembers.
     getSpaceMembers(_spaceId: string, page: number, limit: number) {
@@ -165,6 +196,9 @@ export function createMockWKApp(
       return Promise.resolve(spaceMembers.slice(start, start + limit))
     },
     shared: {
+      // Selected Space id. '' by default (host default); tests set it before/after a
+      // mockMittBus.emitSpaceChanged() to simulate switching Space.
+      currentSpaceId: '',
       registerModule(module: IModule) {
         registeredModules.push(module)
         // Mirror real octo-web: registering a module initializes it (route registration etc.).

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -175,10 +175,31 @@ export interface WKAppShape {
    * host. Absent → docs falls back to showing the raw uid.
    */
   getSpaceMembers?(spaceId: string, page: number, limit: number): Promise<SpaceMemberLite[]>
+  /**
+   * The host global event bus (WKApp.mittBus). Optional in the shape, declared like
+   * `routeRight`: surfaced via the host static cast in production; the test mock supplies a
+   * lightweight emitter. Docs subscribes to its `space-changed` event so the list reloads
+   * when the user switches Space (`currentSpaceId` is a plain mutable field, so a switch does
+   * NOT re-render React on its own — see onSpaceChanged in octoweb/index.ts).
+   */
+  mittBus?: MittBusLite
 }
 
 /** Minimal surface of the host's right-pane route manager (ContextRouteManager). */
 export interface RouteRight {
   replaceToRoot(view: unknown): void
   popToRoot(): void
+}
+
+/**
+ * Minimal view of the host global event bus (WKApp.mittBus, a `mitt` emitter — see
+ * packages/dmworkbase/src/App.tsx). The docs module only needs to (un)subscribe to the
+ * `space-changed` broadcast the host fires when the user switches Space
+ * (`WKApp.mittBus.emit('space-changed', space)` in Chat/vm.ts and apps/web Main), the same
+ * signal the summary / todo / contacts modules listen to. Payload is left `unknown` because
+ * docs reacts to the switch itself (re-reading `currentSpaceId`), not to the payload.
+ */
+export interface MittBusLite {
+  on(type: 'space-changed', handler: (payload?: unknown) => void): void
+  off(type: 'space-changed', handler: (payload?: unknown) => void): void
 }

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -419,6 +419,56 @@ describe('DocsHome — reloads the list when the current Space switches', () => 
   })
 })
 
+describe('DocsHome — a stale (out-of-order) list response cannot overwrite the current Space (P0, XIN-417)', () => {
+  // Regression (XIN-417): switching Space fires a fresh listDocs, but the previous Space's request
+  // may still be in flight. Responses settle in network order, not call order, so an OLDER Space's
+  // response can land AFTER the newer one; the unconditional setItems then rendered the old Space's
+  // documents into the new Space's page — the very class of bug this PR fixes. A monotonic
+  // request-sequence guard must drop any response that a newer reload has superseded.
+  it('drops the late old-Space response and keeps the new Space documents rendered', async () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+
+    // Deferred resolvers keyed by the Space each GET was scoped to, so the test drives the ORDER
+    // responses settle independently of the order the requests were issued (delayed / reordered).
+    const deferred: Record<string, (items: unknown[]) => void> = {}
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        const spaceId = new URLSearchParams(url.split('?')[1] ?? '').get('spaceId') ?? ''
+        return new Promise((resolve) => {
+          deferred[spaceId] = (items) =>
+            resolve({ data: { total: items.length, items }, status: 200 })
+        })
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    // Initial load for the first Space is in flight (its resolver is registered but not settled).
+    await waitFor(() => expect(deferred['space-a']).toBeTruthy())
+
+    // Host switches Space BEFORE the first request resolves → a second GET starts for space-b.
+    wk.shared.currentSpaceId = 'space-b'
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-b' })
+    await waitFor(() => expect(deferred['space-b']).toBeTruthy())
+
+    // Settle the NEWER (space-b) request first so its documents render...
+    deferred['space-b']([{ docId: 'd_b', title: 'Space B Doc', ownerId: 'u_self', role: 'admin' }])
+    await waitFor(() => expect(screen.getByText('Space B Doc')).toBeTruthy())
+
+    // ...then let the OLDER (space-a) request resolve LAST (out of order). Without the guard this
+    // stale setItems would clobber the list with the old Space's doc.
+    deferred['space-a']([{ docId: 'd_a', title: 'Space A Doc', ownerId: 'u_self', role: 'admin' }])
+    // Give the stale promise a chance to (wrongly) apply before asserting.
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The current Space's documents survive; the stale old-Space doc never appears.
+    expect(screen.getByText('Space B Doc')).toBeTruthy()
+    expect(screen.queryByText('Space A Doc')).toBeNull()
+  })
+})
+
 describe('DocsHome — production (routeRight) editor has no header back button (#2)', () => {
   it('pushes the editor without onBack but with onExit (return-on-delete)', async () => {
     window.sessionStorage.setItem(TARGET_KEY, JSON.stringify({ doc: 'd_persist' }))

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -344,6 +344,81 @@ describe('DocsHome navigation (split-pane)', () => {
   })
 })
 
+describe('DocsHome — reloads the list when the current Space switches', () => {
+  // Regression (XIN-410): switching Space did NOT refresh the document list. `space` was derived
+  // directly from the mutable `WKApp.shared.currentSpaceId`, which is not React state — reassigning
+  // it on a switch never re-rendered DocsHome, so the list kept showing the old Space's docs until a
+  // manual reload. DocsHome now subscribes to the host `space-changed` bus and re-reads the id.
+  const listGets = (wk: ReturnType<typeof createMockWKApp>) =>
+    wk.apiClient.calls.filter((c) => c.method === 'get' && c.url.startsWith('/docs?'))
+
+  it('re-fetches the list for the new Space when space-changed fires', async () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    // Initial load queries the first Space.
+    await waitFor(() => expect(listGets(wk).length).toBe(1))
+    expect(listGets(wk)[0].url).toContain('spaceId=space-a')
+
+    // The host switches Space: it mutates currentSpaceId then broadcasts space-changed.
+    wk.shared.currentSpaceId = 'space-b'
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-b' })
+
+    // The list re-fetches — now scoped to the new Space.
+    await waitFor(() => expect(listGets(wk).length).toBe(2))
+    expect(listGets(wk).at(-1)!.url).toContain('spaceId=space-b')
+  })
+
+  it('re-fetches exactly once per switch (no duplicate-request storm)', async () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(listGets(wk).length).toBe(1))
+
+    wk.shared.currentSpaceId = 'space-b'
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-b' })
+    await waitFor(() => expect(listGets(wk).length).toBe(2))
+
+    // A redundant broadcast for the SAME space must not trigger another fetch.
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-b' })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(listGets(wk).length).toBe(2)
+  })
+
+  it('unsubscribes from the bus on unmount (no leaked listener)', async () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { unmount } = render(<DocsHome />)
+    await waitFor(() => expect(wk.mockMittBus.spaceChangedListenerCount()).toBe(1))
+    unmount()
+    expect(wk.mockMittBus.spaceChangedListenerCount()).toBe(0)
+  })
+})
+
 describe('DocsHome — production (routeRight) editor has no header back button (#2)', () => {
   it('pushes the editor without onBack but with onExit (return-on-delete)', async () => {
     window.sessionStorage.setItem(TARGET_KEY, JSON.stringify({ doc: 'd_persist' }))

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -419,6 +419,74 @@ describe('DocsHome — reloads the list when the current Space switches', () => 
   })
 })
 
+describe('DocsHome — a Space switch reconciles the open selection back to the list (P0)', () => {
+  // Regression (XIN-448): switching Space bumped `space` but left `selectedDocId`, the persisted
+  // `octo.docs.target`, and the URL pointing at the doc opened under the PREVIOUS Space. That
+  // rebuilt EditorShell with the OLD docId under the NEW space — a cross-Space collab session
+  // (octo:<newSpace>:<folder>:<oldDoc>), a data-isolation leak — and a refresh restored the old
+  // Space's doc from the persisted target. A switch must reconcile the selection back to the
+  // list of the new Space (same primitive as the explicit "back to list").
+  it('clears selectedDocId, the persisted target, and the URL doc addressing when the Space switches', async () => {
+    // A doc is open under the first Space (persisted target mounts it inline on first paint).
+    window.sessionStorage.setItem(
+      TARGET_KEY,
+      JSON.stringify({ space: 'space-a', folder: 'f_default', doc: 'd_open' }),
+    )
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    // The editor for the doc opened under space-a is mounted.
+    expect(screen.getByTestId('editor-shell')).toBeTruthy()
+    expect(screen.getByTestId('editor-doc').textContent).toBe('d_open')
+
+    // Host switches Space: mutate currentSpaceId then broadcast.
+    wk.shared.currentSpaceId = 'space-b'
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-b' })
+
+    // The old doc must NOT stay mounted under the new Space — selection is reset to the list.
+    await waitFor(() => expect(screen.queryByTestId('editor-shell')).toBeNull())
+    // The persisted target is cleared so a refresh does not restore the previous Space's doc.
+    expect(window.sessionStorage.getItem(TARGET_KEY)).toBeNull()
+    // The URL is mirrored back to the list (doc addressing dropped), never a full navigation.
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(String(replaceStateSpy.mock.calls.at(-1)![2])).not.toContain('doc=')
+  })
+
+  it('does not reconcile (nor refetch) on a redundant same-Space broadcast while a doc is open', async () => {
+    window.sessionStorage.setItem(
+      TARGET_KEY,
+      JSON.stringify({ space: 'space-a', folder: 'f_default', doc: 'd_open' }),
+    )
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'space-a'
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    expect(screen.getByTestId('editor-shell')).toBeTruthy()
+
+    // A redundant broadcast for the SAME Space must not yank the open doc back to the list.
+    wk.mockMittBus.emitSpaceChanged({ space_id: 'space-a' })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.getByTestId('editor-shell')).toBeTruthy()
+    expect(screen.getByTestId('editor-doc').textContent).toBe('d_open')
+    expect(window.sessionStorage.getItem(TARGET_KEY)).not.toBeNull()
+  })
+})
+
 describe('DocsHome — a stale (out-of-order) list response cannot overwrite the current Space (P0, XIN-417)', () => {
   // Regression (XIN-417): switching Space fires a fresh listDocs, but the previous Space's request
   // may still be in flight. Responses settle in network order, not call order, so an OLDER Space's

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -365,16 +365,10 @@ export function DocsHome() {
   const [space, setSpace] = useState<string>(() => wk.shared?.currentSpaceId || DEFAULT_DOC_SPACE)
   const folder = DEFAULT_DOC_FOLDER
 
-  // Subscribe to the host's Space-switch broadcast. On a switch the host mutates currentSpaceId
-  // then emits `space-changed`; we re-read the id into state. setSpace bails out when the value
-  // is unchanged, so a redundant broadcast for the same Space causes no extra render/fetch — one
-  // switch = one reload, no request storm. The effect runs once (empty deps): getWKApp() returns
-  // the stable singleton, and the handler always reads the latest currentSpaceId off it.
-  useEffect(() => {
-    return onSpaceChanged(() => {
-      setSpace(getWKApp().shared?.currentSpaceId || DEFAULT_DOC_SPACE)
-    })
-  }, [])
+  // The Space this component last reconciled to. The space-changed handler reads it to tell a
+  // real switch from a redundant same-Space broadcast; only a real switch reconciles/refetches.
+  // setSpace is only ever called from that handler, so this ref is the authoritative previous id.
+  const spaceRef = useRef(space)
 
   // Initial selection from URL deep-link / persisted target (so a shared `/docs?doc=` or a
   // refresh opens that doc in the right pane on first paint).
@@ -433,6 +427,32 @@ export function DocsHome() {
       }
     }
   }, [routeRight, buildEmptyState])
+
+  // Subscribe to the host's Space-switch broadcast. On a switch the host mutates currentSpaceId
+  // then emits `space-changed`; we re-read the id into state AND reconcile the open selection.
+  //
+  // Reconciliation (XIN-448): a switch must not carry the doc opened under the PREVIOUS Space
+  // into the new one. Left as-is, buildEditor(selectedDocId) would rebuild EditorShell with the
+  // OLD docId under the NEW space → a cross-Space collab session (octo:<newSpace>:<folder>:
+  // <oldDoc>), a data-isolation leak — and the persisted `octo.docs.target` would restore the
+  // old Space's doc on refresh. We reuse the existing "back to list" primitive so the switch
+  // lands on the new Space's list (clears selectedDocId + the persisted target + mirrors the URL).
+  //
+  // Only a REAL switch reconciles: spaceRef gates redundant same-Space broadcasts, so one switch =
+  // one reload and a duplicate broadcast is a no-op (no request storm, no doc yanked to the list).
+  // The effect runs once (empty deps): getWKApp() is the stable singleton and backToList is
+  // referentially stable (deps: the singleton routeRight + the []-stable buildEmptyState), so the
+  // subscription never captures a stale reconciler and the onSpaceChanged cleanup stays intact.
+  useEffect(() => {
+    return onSpaceChanged(() => {
+      const next = getWKApp().shared?.currentSpaceId || DEFAULT_DOC_SPACE
+      if (next === spaceRef.current) return
+      spaceRef.current = next
+      setSpace(next)
+      backToList()
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Called after a successful delete (now from the editor detail page, Problem 4). If the deleted
   // doc is the one open in the right pane, return to the empty/list state (which also resets the

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { getWKApp, getRouteRight, t } from '../octoweb/index.ts'
+import { getWKApp, getRouteRight, onSpaceChanged, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import '../editor/styles.css'
 import { DEFAULT_DOC_SPACE, DEFAULT_DOC_FOLDER, DEFAULT_DOC_ID } from '../config.ts'
@@ -336,8 +336,24 @@ export function DocsHome() {
   // error-boundary screen, so default to '' and let the editor/list resolve identity from
   // the collab-token round-trip instead of crashing first paint.
   const uid = wk.loginInfo?.uid ?? ''
-  const space = wk.shared?.currentSpaceId || DEFAULT_DOC_SPACE
+  // The active Space. `wk.shared.currentSpaceId` is a plain mutable field on the host WKApp, NOT
+  // React state — reassigning it when the user switches Space does not re-render this component,
+  // so deriving `space` inline left the list stuck on the old Space's docs until a manual reload
+  // (XIN-410). Mirror it into state and re-read it whenever the host broadcasts `space-changed`
+  // (see the effect below) so the switch flows through to reload/useMemberNames.
+  const [space, setSpace] = useState<string>(() => wk.shared?.currentSpaceId || DEFAULT_DOC_SPACE)
   const folder = DEFAULT_DOC_FOLDER
+
+  // Subscribe to the host's Space-switch broadcast. On a switch the host mutates currentSpaceId
+  // then emits `space-changed`; we re-read the id into state. setSpace bails out when the value
+  // is unchanged, so a redundant broadcast for the same Space causes no extra render/fetch — one
+  // switch = one reload, no request storm. The effect runs once (empty deps): getWKApp() returns
+  // the stable singleton, and the handler always reads the latest currentSpaceId off it.
+  useEffect(() => {
+    return onSpaceChanged(() => {
+      setSpace(getWKApp().shared?.currentSpaceId || DEFAULT_DOC_SPACE)
+    })
+  }, [])
 
   // Initial selection from URL deep-link / persisted target (so a shared `/docs?doc=` or a
   // refresh opens that doc in the right pane on first paint).

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -183,18 +183,39 @@ function DocsList({
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
 
+  // Stale-response guard (XIN-417). Switching Space bumps `space`, which recreates `reload` and
+  // fires a fresh listDocs — but the previous Space's request may still be in flight. listDocs
+  // resolves in network order, not call order, so an older-Space response can land AFTER the
+  // newer one and its unconditional setItems would render the wrong Space's documents into the
+  // current page (exactly the class of bug this PR fixes). We stamp each reload with a monotonic
+  // sequence and only let the LATEST reload's response touch state; superseded responses are
+  // dropped. A ref (not state) so it survives re-renders without itself triggering one.
+  const reloadSeq = useRef(0)
+
   const reload = useCallback(() => {
+    const seq = ++reloadSeq.current
     setLoading(true)
     setError(null)
     listDocs({ spaceId: space || undefined, folderId: folder || undefined, sort: 'updatedAt:desc' })
-      .then((res) => setItems(res?.items ?? []))
+      .then((res) => {
+        // A newer reload has superseded this one (e.g. the Space changed again while this
+        // request was in flight) — drop the stale response so it can't overwrite the current list.
+        if (seq !== reloadSeq.current) return
+        setItems(res?.items ?? [])
+      })
       .catch((err) => {
+        if (seq !== reloadSeq.current) return
         // Don't swallow the failure: surface it so a first-load error is diagnosable
         // (and offer a retry below) instead of a silently sticky error state.
         console.error('[docs] list failed', err)
         setError(t('docs.state.error'))
       })
-      .finally(() => setLoading(false))
+      .finally(() => {
+        // Keep the spinner up until the latest reload settles; a stale request finishing first
+        // must not clear loading while the current one is still pending.
+        if (seq !== reloadSeq.current) return
+        setLoading(false)
+      })
   }, [space, folder])
 
   useEffect(reload, [reload])


### PR DESCRIPTION
## Problem

On the `/docs` page, switching the current Space did not refresh the document list — it kept showing the previous Space's documents until a full page reload.

Root cause: `DocsHome` derived its Space inline from `WKApp.shared.currentSpaceId`. That field is a plain mutable property on the host `WKApp`, **not** React state. When the user switches Space the host reassigns `currentSpaceId` and broadcasts a `space-changed` event on `WKApp.mittBus` (see `packages/dmworkbase/src/Pages/Chat/vm.ts` `set selectedSpace` and `apps/web/src/Pages/Main`), but nothing re-rendered `DocsHome`, so the list's `reload` (keyed on `[space, folder]`) never re-ran.

The backend already isolates docs strictly by `X-Space-Id` (octo-docs-backend #18) — this is purely the missing frontend refresh.

## Fix

- Mirror the current Space into component state (`useState`) and subscribe to the host `space-changed` bus, re-reading `currentSpaceId` on each broadcast. This is the same signal the summary / todo / contacts modules already listen to — no new host mechanism, no raw effect off a mutable prop.
- The subscription is wired through the existing `octoweb` seam as `onSpaceChanged(cb)` (production → real `WKApp.mittBus`; tests → mock bus), keeping `DocsHome` decoupled from `@octo/base` internals like the rest of the module.
- A same-value `setSpace` is a no-op in React, so **one Space switch triggers exactly one reload** — no duplicate-request storm. Same-Space `rename` / `create` / `reloadToken` refreshes and first-load behavior are unchanged.
- The listener is removed on unmount (effect cleanup) — no leaked subscriptions.

## Tests

Regression coverage added in `DocsHome.test.tsx`:
- the list re-fetches scoped to the **new** `spaceId` when `space-changed` fires;
- exactly one re-fetch per switch (a redundant same-Space broadcast triggers none);
- the bus listener is removed on unmount.

All three fail on the pre-fix code and pass after. Full docs package suite: **446 passed** (was 443). `tsc` adds no new errors (two pre-existing baseline errors in `dmworkbase/i18n/format.ts` and `members/sort.ts` are unrelated and present on `main`).

## Verification

The regression tests drive the exact host contract — they mutate `currentSpaceId` and emit `space-changed` the way `Chat/vm.ts` does, then assert the list re-fetches with the new `spaceId` — so the fix is exercised end-to-end at the seam boundary, not just at the unit level.

Live in-browser space-switch verification against a real environment (with real Spaces + auth) is best done on the deployed env; that manual check is being coordinated on the tracking issue.

Closes the docs-list-not-refreshing-after-space-switch bug.
