### PR TITLE
feat(docs): add DOCX export with security hardening

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -122,6 +122,12 @@ export default defineConfig(({ mode }) => {
       port: env.VITE_PORT ? Number(env.VITE_PORT) : 3000,
       host: env.VITE_HOST ?? true,
       proxy: {
+        // Docs service API — must be before the general /api/ rule
+        "/api/v1/docs": {
+          target: env.VITE_DOCS_API_URL || "http://localhost:4000",
+          changeOrigin: true,
+          secure: false,
+        },
         // Summary service API — must be before the general /api/ rule
         "/summary/api/v1": {
           target:

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,11 @@
     "y-indexeddb": "9.0.12",
     "y-prosemirror": "1.2.15",
     "y-protocols": "1.0.6",
-    "yjs": "13.6.21"
+    "yjs": "13.6.21",
+    "axios": "^0.25.0",
+    "docx": "^9.7.1",
+    "mathjax-full": "^3.2.2",
+    "xml-js": "^1.6.11"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -15,6 +15,8 @@ import { useCommentHighlights } from '../comments/useCommentHighlights.ts'
 import { useDocDelete } from './useDocDelete.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { exportDocToMarkdown, type MdNode } from '../export/markdown.ts'
+import { exportDocToDocx } from '../export/docx/index.ts'
+import { exportDocPdf } from '../pages/docsApi.ts'
 import { emojiGlyph } from './emoji.ts'
 import { colorFromId } from '../awareness/presence.ts'
 import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
@@ -33,6 +35,7 @@ import {
   DeleteIcon,
   type DocMoreMenuItem,
 } from './DocMoreMenu.tsx'
+import { ExportMenu } from './ExportMenu.tsx'
 import './styles.css'
 
 /** Which right-side drawer panel is open (mutually exclusive); null = drawer closed. */
@@ -422,8 +425,65 @@ export function EditorShell(props: EditorShellProps) {
       document.body.appendChild(a)
       a.click()
       a.remove()
-      URL.revokeObjectURL(url)
-    } catch {
+      // Defer revoke so Safari/iOS can start the download for larger blobs
+      // (matches the PDF branch).
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] Markdown export failed:', err)
+      setExportError(t('docs.toolbar.exportError'))
+    } finally {
+      setExporting(false)
+    }
+  }, [instance, docId, currentTitle, exporting])
+
+  const onExportDocx = useCallback(async () => {
+    const ed = instance?.editor
+    if (!ed || exporting) return
+    setExporting(true)
+    setExportError(null)
+    try {
+      const blob = await exportDocToDocx(docId, ed.getJSON() as unknown as MdNode, { emojiGlyph })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${exportDownloadName(currentTitle)}.docx`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      // Defer revoke so Safari/iOS can start the download for larger blobs
+      // (matches the PDF branch).
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] DOCX export failed:', err)
+      setExportError(t('docs.toolbar.exportError'))
+    } finally {
+      setExporting(false)
+    }
+  }, [instance, docId, currentTitle, exporting])
+
+  const onExportPdf = useCallback(async () => {
+    const ed = instance?.editor
+    if (!ed || exporting) return
+    setExporting(true)
+    setExportError(null)
+    try {
+      // Server-side (Puppeteer headless Chrome) PDF render (小吴's decision to
+      // go backend). The backend renders its own persisted copy of the doc
+      // with server-side KaTeX, so the output has real CJK, rendered math,
+      // emoji, selectable text and smart pagination — one-click download with
+      // no print dialog. Returns the PDF bytes directly.
+      const bytes = await exportDocPdf(docId)
+      const blob = new Blob([bytes], { type: 'application/pdf' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${exportDownloadName(currentTitle)}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] PDF export failed:', err)
       setExportError(t('docs.toolbar.exportError'))
     } finally {
       setExporting(false)
@@ -582,6 +642,13 @@ export function EditorShell(props: EditorShellProps) {
               ⤴ {t('docs.forward.entry')}
             </button>
           )}
+          {/* Export dropdown — combines Markdown and Word export into one menu. */}
+          <ExportMenu
+            disabled={exporting}
+            onExportMarkdown={() => void onExportMarkdown()}
+            onExportDocx={() => void onExportDocx()}
+            onExportPdf={() => void onExportPdf()}
+          />
           {manage && (
             <button
               type="button"

--- a/packages/docs/src/editor/ExportMenu.tsx
+++ b/packages/docs/src/editor/ExportMenu.tsx
@@ -1,0 +1,81 @@
+import { useState, useRef, useCallback, useEffect, type ReactElement } from 'react'
+import { t } from '../octoweb/index.ts'
+
+interface ExportMenuProps {
+  disabled: boolean
+  onExportMarkdown: () => void
+  onExportDocx: () => void
+  onExportPdf: () => void
+}
+
+/**
+ * Dropdown menu that groups export actions (Markdown, Word) under a single "导出" button.
+ * Closes on outside-click or Escape.
+ */
+export function ExportMenu({ disabled, onExportMarkdown, onExportDocx, onExportPdf }: ExportMenuProps): ReactElement {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  const toggle = useCallback(() => {
+    if (!disabled) setOpen((v) => !v)
+  }, [disabled])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open])
+
+  return (
+    <div className="octo-export-menu" ref={ref}>
+      <button
+        type="button"
+        className={open ? 'octo-tb-btn is-active' : 'octo-tb-btn'}
+        disabled={disabled}
+        onClick={toggle}
+        title={t('docs.toolbar.export')}
+      >
+        ⬇ {t('docs.toolbar.export')}
+      </button>
+      {open && (
+        <div className="octo-export-dropdown">
+          <button
+            type="button"
+            className="octo-export-item"
+            onClick={() => { setOpen(false); onExportMarkdown() }}
+          >
+            {t('docs.toolbar.exportMarkdown')}
+          </button>
+          <button
+            type="button"
+            className="octo-export-item"
+            onClick={() => { setOpen(false); onExportDocx() }}
+          >
+            {t('docs.toolbar.exportDocx')}
+          </button>
+          <button
+            type="button"
+            className="octo-export-item"
+            onClick={() => { setOpen(false); onExportPdf() }}
+          >
+            {t('docs.toolbar.exportPdf')}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2498,6 +2498,7 @@
   }
 }
 
+D
 /* ── Forward to chat / access requests (feature #511) ───────────────────────── */
 .octo-doc-forward-btn {
   font-weight: 600;
@@ -2629,4 +2630,38 @@
    nothing outside the spreadsheet is affected. */
 .octo-sheet-container .univer-justify-center.univer-overflow-x-auto {
   justify-content: flex-start !important;
+}
+
+/* Export dropdown menu */
+.octo-export-menu {
+  position: relative;
+  display: inline-block;
+}
+.octo-export-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--wk-bg-popup, #fff);
+  border: 1px solid var(--wk-border, #e0e0e0);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  z-index: 1000;
+  min-width: 140px;
+  white-space: nowrap;
+  padding: 4px 0;
+}
+.octo-export-item {
+  display: block;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+  color: inherit;
+}
+.octo-export-item:hover {
+  background: var(--wk-bg-hover, #f5f5f5);
 }

--- a/packages/docs/src/export/docx/attachment.test.ts
+++ b/packages/docs/src/export/docx/attachment.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+async function exportXml(content: MdNode[], urls?: Map<string, any>) {
+  const ctx: DocxContext = {
+    urls: urls ?? new Map(),
+    imageBuffers: new Map(),
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+  const children = convertBlocks(content, ctx)
+  const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `attach-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+describe('file attachment export', () => {
+  it('resolved attachment renders as hyperlink with filename', async () => {
+    const urls = new Map<string, any>([
+      ['a1', { url: 'https://cdn.example.com/report.pdf', fileName: '季度报告.pdf' }],
+    ])
+    const doc: MdNode[] = [
+      { type: 'fileAttachment', attrs: { attachId: 'a1', fileName: '季度报告.pdf' } },
+    ] as MdNode[]
+    const xml = await exportXml(doc, urls)
+    expect(xml).toContain('季度报告.pdf')
+    expect(xml).toContain('Hyperlink')
+    // hyperlink relationship should point at the url (external link stored in rels)
+    expect(xml).toMatch(/w:hyperlink/i)
+  })
+
+  it('unresolved attachment shows (unavailable) fallback', async () => {
+    const doc: MdNode[] = [
+      { type: 'fileAttachment', attrs: { fileName: '缺失文件.zip' } },
+    ] as MdNode[]
+    const xml = await exportXml(doc)
+    expect(xml).toContain('缺失文件.zip')
+    expect(xml).toContain('unavailable')
+    // The 📎 icon in the unavailable branch must also carry the emoji font.
+    expect(xml).toContain('Segoe UI Emoji')
+  })
+
+  it('attachment 📎 icon carries an emoji font (not blank)', async () => {
+    const urls = new Map<string, any>([
+      ['a1', { url: 'https://cdn.example.com/x.pdf', fileName: 'x.pdf' }],
+    ])
+    const doc: MdNode[] = [{ type: 'fileAttachment', attrs: { attachId: 'a1' } }] as MdNode[]
+    const xml = await exportXml(doc, urls)
+    // The 📎 run must have an emoji font so it does not render blank.
+    expect(xml).toContain('Segoe UI Emoji')
+  })
+})

--- a/packages/docs/src/export/docx/emoji-e2e.test.ts
+++ b/packages/docs/src/export/docx/emoji-e2e.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+describe('emoji end-to-end docx export', () => {
+  it('emoji in body text gets emoji font in document.xml', async () => {
+    const doc: MdNode[] = [
+      { type: 'paragraph', content: [{ type: 'text', text: '标题 😀 内容 ✅ 完成' }] },
+    ] as MdNode[]
+    const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+    const children = convertBlocks(doc, ctx)
+    const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+    const buf = await Packer.toBuffer(document)
+    const path = join(tmpdir(), `emoji-e2e-${Date.now()}.docx`)
+    writeFileSync(path, buf)
+    const xml = execSync(`unzip -p ${path} word/document.xml`).toString()
+
+    // The emoji runs (😀, ✅) must carry Segoe UI Emoji; the CJK runs must not.
+    const emojiRuns = [...xml.matchAll(/<w:r>(?:(?!<\/w:r>).)*?<w:t[^>]*>([^<]*(?:😀|✅)[^<]*)<\/w:t>[\s\S]*?<\/w:r>/g)]
+    // Fallback: just assert the font appears near an emoji.
+    expect(xml).toContain('Segoe UI Emoji')
+    // CJK-only run should NOT get the emoji font — check a run containing 标题 has 微软雅黑 default (no Segoe override)
+    const cjkRun = xml.match(/<w:r>(?:(?!<\/w:r>).)*?<w:t[^>]*>[^<]*标题[^<]*<\/w:t>[\s\S]*?<\/w:r>/)
+    expect(cjkRun?.[0] ?? '').not.toContain('Segoe UI Emoji')
+  })
+})

--- a/packages/docs/src/export/docx/emoji.test.ts
+++ b/packages/docs/src/export/docx/emoji.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for emoji font handling in DOCX export.
+ *
+ * The body font (微软雅黑) has no emoji glyphs and Word does not auto-fallback,
+ * so emoji must be tagged with an emoji font or they render as blank boxes.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildTextRuns, iconPrefix } from './marks.ts'
+import { FONT_EMOJI } from './styles.ts'
+
+/** Serialize a TextRun to inspect its text + font via the internal XML tree. */
+function runInfo(run: unknown): { text: string; font?: string } {
+  // TextRun stores children internally; use JSON round-trip on its root.
+  const anyRun = run as { root?: unknown[] }
+  const json = JSON.stringify(anyRun)
+  const textMatch = json.match(/"text":"([^"]*)"/)
+  const fontMatch = json.match(/"w:ascii":"([^"]*)"|"ascii":"([^"]*)"/)
+  return {
+    text: textMatch ? textMatch[1] : '',
+    font: fontMatch ? fontMatch[1] || fontMatch[2] : undefined,
+  }
+}
+
+describe('emoji font handling', () => {
+  it('plain text without emoji → single run, no emoji font', () => {
+    const runs = buildTextRuns('普通中文文本', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).not.toContain(FONT_EMOJI)
+  })
+
+  it('pure emoji → run tagged with emoji font', () => {
+    const runs = buildTextRuns('😀', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('mixed CJK + emoji → splits, only emoji run gets emoji font', () => {
+    const runs = buildTextRuns('你好😀世界', {})
+    // 你好 | 😀 | 世界
+    expect(runs.length).toBe(3)
+    const serialized = runs.map((r) => JSON.stringify(r))
+    // exactly one run carries the emoji font
+    const withFont = serialized.filter((s) => s.includes(FONT_EMOJI))
+    expect(withFont.length).toBe(1)
+    expect(withFont[0]).toContain('😀')
+  })
+
+  it('checkmark / symbol emoji ✅ tagged with emoji font', () => {
+    const runs = buildTextRuns('✅', {})
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('ZWJ sequence 👩‍💻 stays in one emoji run', () => {
+    const runs = buildTextRuns('👩‍💻', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('FE0F-variation emoji ℹ️ / ⚠️ stay in ONE emoji run with FE0F stripped (no tofu box)', () => {
+    // Regression: base symbol + trailing U+FE0F previously left an orphaned FE0F
+    // that rendered as a small box after the icon (esp. on macOS Word, whose
+    // emoji font has no composed FE0F glyph). Fix: keep them in one emoji run
+    // AND strip FE0F — the base char already resolves to the colored glyph.
+    for (const glyph of ['ℹ️', '⚠️', '‼️', '⁉️', '™️', '↔️']) {
+      const runs = buildTextRuns(glyph, {})
+      expect(runs.length).toBe(1)
+      const s = JSON.stringify(runs[0])
+      expect(s).toContain(FONT_EMOJI)
+      // no orphaned variation selector left in the run
+      expect(s).not.toContain('\uFE0F')
+      expect(/fe0f/i.test(s)).toBe(false)
+    }
+  })
+
+  it('iconPrefix strips FE0F from callout/UI icons (no trailing tofu box)', () => {
+    for (const glyph of ['ℹ️', '⚠️']) {
+      const parts = iconPrefix(glyph, { bold: true })
+      const s = JSON.stringify(parts)
+      expect(s).toContain(FONT_EMOJI)
+      expect(/fe0f/i.test(s)).toBe(false)
+    }
+  })
+
+  it('normal punctuation (ellipsis, em-dash, brackets) stays in body font', () => {
+    for (const text of ['中文…省略', '破折号——测试', '引用「文本」']) {
+      const runs = buildTextRuns(text, {})
+      expect(runs.length).toBe(1)
+      expect(JSON.stringify(runs[0])).not.toContain(FONT_EMOJI)
+    }
+  })
+
+  it('preserves base run options on non-emoji segments', () => {
+    const runs = buildTextRuns('粗体😀', { bold: true })
+    // both segments keep bold; only emoji adds font
+    const all = runs.map((r) => JSON.stringify(r))
+    expect(all.every((s) => s.includes('"bold":true') || s.includes('w:b'))).toBe(true)
+  })
+})

--- a/packages/docs/src/export/docx/href-safety.test.ts
+++ b/packages/docs/src/export/docx/href-safety.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { extractLinkHref } from './marks.ts'
+import { isSafeHref } from './nodes.ts'
+
+describe('extractLinkHref — scheme allowlist', () => {
+  const mk = (href: string) => [{ type: 'link', attrs: { href } }]
+
+  it('allows https URLs', () => {
+    expect(extractLinkHref(mk('https://example.com'))).toBe('https://example.com')
+  })
+
+  it('allows http URLs', () => {
+    expect(extractLinkHref(mk('http://example.com'))).toBe('http://example.com')
+  })
+
+  it('allows mailto URLs', () => {
+    expect(extractLinkHref(mk('mailto:a@b.com'))).toBe('mailto:a@b.com')
+  })
+
+  it('allows tel URLs', () => {
+    expect(extractLinkHref(mk('tel:+1234567890'))).toBe('tel:+1234567890')
+  })
+
+  it('allows relative URLs (no scheme)', () => {
+    expect(extractLinkHref(mk('/docs/abc'))).toBe('/docs/abc')
+    expect(extractLinkHref(mk('docs/abc'))).toBe('docs/abc')
+  })
+
+  it('rejects javascript: URLs', () => {
+    expect(extractLinkHref(mk('javascript:alert(1)'))).toBeNull()
+  })
+
+  it('rejects data: URLs', () => {
+    expect(extractLinkHref(mk('data:text/html,<script>alert(1)</script>'))).toBeNull()
+  })
+
+  it('rejects file: URLs', () => {
+    expect(extractLinkHref(mk('file:///etc/passwd'))).toBeNull()
+  })
+
+  it('rejects vbscript: URLs', () => {
+    expect(extractLinkHref(mk('vbscript:msgbox(1)'))).toBeNull()
+  })
+
+  it('rejects UNC paths (backslash)', () => {
+    expect(extractLinkHref(mk('\\\\server\\share'))).toBeNull()
+  })
+
+  it('rejects protocol-relative URLs (//host)', () => {
+    expect(extractLinkHref(mk('//evil.com/x'))).toBeNull()
+  })
+
+  it('returns null for non-string href', () => {
+    expect(extractLinkHref([{ type: 'link', attrs: { href: 123 } }])).toBeNull()
+  })
+
+  it('returns null when no link mark exists', () => {
+    expect(extractLinkHref([{ type: 'bold' }])).toBeNull()
+  })
+})
+
+describe('isSafeHref — scheme allowlist', () => {
+  it('allows https/http/mailto/tel', () => {
+    expect(isSafeHref('https://a.com')).toBe(true)
+    expect(isSafeHref('http://a.com')).toBe(true)
+    expect(isSafeHref('mailto:a@b.com')).toBe(true)
+    expect(isSafeHref('tel:+1')).toBe(true)
+  })
+
+  it('allows relative URLs', () => {
+    expect(isSafeHref('/path')).toBe(true)
+    expect(isSafeHref('path')).toBe(true)
+  })
+
+  it('rejects javascript/data/file/vbscript', () => {
+    expect(isSafeHref('javascript:alert(1)')).toBe(false)
+    expect(isSafeHref('data:text/html,x')).toBe(false)
+    expect(isSafeHref('file:///etc/passwd')).toBe(false)
+    expect(isSafeHref('vbscript:msgbox(1)')).toBe(false)
+  })
+
+  it('rejects UNC and protocol-relative', () => {
+    expect(isSafeHref('\\\\server\\share')).toBe(false)
+    expect(isSafeHref('//evil.com')).toBe(false)
+  })
+})

--- a/packages/docs/src/export/docx/images.ts
+++ b/packages/docs/src/export/docx/images.ts
@@ -1,0 +1,213 @@
+/**
+ * Image collection and batch fetching for DOCX export.
+ * Collects image references from the document tree and fetches them as ArrayBuffers.
+ */
+
+import { resolveAttachments, type ResolvedAttachment } from '../../attachments/api.ts'
+import type { MdNode, ImageRef, DocxContext } from './types.ts'
+
+/**
+ * Collect all image references (attachIds and direct src URLs) from the document tree.
+ */
+export function collectImageRefs(doc: MdNode): ImageRef[] {
+  const refs: ImageRef[] = []
+  const seen = new Set<string>()
+
+  const walk = (node: MdNode) => {
+    if (node.type === 'image') {
+      const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+      const src = typeof node.attrs?.src === 'string' ? node.attrs.src : undefined
+      const key = attachId || src || ''
+      if (key && !seen.has(key)) {
+        seen.add(key)
+        refs.push({ attachId, src })
+      }
+    }
+    node.content?.forEach(walk)
+  }
+  walk(doc)
+  return refs
+}
+
+/**
+ * Collect all unique attachIds from the document (images + fileAttachments).
+ */
+export function collectAttachIds(doc: MdNode): string[] {
+  const ids = new Set<string>()
+  const walk = (node: MdNode) => {
+    if (node.type === 'image' || node.type === 'fileAttachment') {
+      const id = node.attrs?.attachId
+      if (typeof id === 'string' && id) ids.add(id)
+    }
+    node.content?.forEach(walk)
+  }
+  walk(doc)
+  return [...ids]
+}
+
+/** Chunk an array into smaller arrays of the given size. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) return [arr]
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+/**
+ * Resolve all attachment URLs and fetch image buffers.
+ * Returns the resolved URL map and image buffer map for the context.
+ */
+export async function resolveAndFetchImages(
+  docId: string,
+  doc: MdNode,
+  options: {
+    batchSize?: number
+    resolve?: typeof resolveAttachments
+  } = {},
+): Promise<{ urls: Map<string, ResolvedAttachment>; imageBuffers: Map<string, ArrayBuffer> }> {
+  const batchSize = options.batchSize ?? 200
+  const resolve = options.resolve ?? resolveAttachments
+
+  // Step 1: resolve all attach IDs to get signed URLs
+  const ids = collectAttachIds(doc)
+  const urls = new Map<string, ResolvedAttachment>()
+  for (const idChunk of chunk(ids, batchSize)) {
+    if (idChunk.length === 0) continue
+    const res = await resolve(docId, idChunk)
+    for (const item of res.items) urls.set(item.attachId, item)
+  }
+
+  // Step 2: collect image refs and determine which URLs to fetch
+  const imageRefs = collectImageRefs(doc)
+  const imageBuffers = new Map<string, ArrayBuffer>()
+
+  // Fetch images in parallel (with concurrency limit)
+  const fetchQueue: Array<{ url: string; key: string }> = []
+  for (const ref of imageRefs) {
+    let url: string | undefined
+    if (ref.attachId) {
+      const resolved = urls.get(ref.attachId)
+      if (resolved?.url) url = resolved.url
+    }
+    if (!url && ref.src) {
+      // Only fetch raw src URLs with safe schemes (https/http/data).
+      // Blocks file:, javascript:, and UNC paths that could beacon or leak credentials.
+      if (/^(?:https?:|data:)/i.test(ref.src)) {
+        url = ref.src
+      }
+    }
+    if (url) {
+      const key = ref.attachId || url
+      fetchQueue.push({ url, key })
+    }
+  }
+
+  // Fetch with concurrency limit of 5
+  const CONCURRENCY = 5
+  for (let i = 0; i < fetchQueue.length; i += CONCURRENCY) {
+    const batch = fetchQueue.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(
+      batch.map(async ({ url, key }) => {
+        const MAX_BYTES = 10 * 1024 * 1024
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 15_000)
+        try {
+          const res = await fetch(url, { signal: controller.signal })
+          if (!res.ok) return
+          // Reject early on an honest content-length over the cap.
+          const contentLength = Number(res.headers.get('content-length')) || 0
+          if (contentLength > MAX_BYTES) return
+          // Stream the body and enforce the cap on accumulated bytes so a
+          // missing/spoofed content-length cannot force an unbounded
+          // allocation. The abort controller stays live through the whole
+          // body read, so a stalled/dribbling host still frees its pool slot.
+          const reader = res.body?.getReader()
+          if (!reader) {
+            // No stream reader (e.g. data: URL) — fall back to a guarded read.
+            const buffer = await res.arrayBuffer()
+            if (buffer.byteLength > MAX_BYTES) return
+            imageBuffers.set(key, buffer)
+            return
+          }
+          const chunks: Uint8Array[] = []
+          let total = 0
+          for (;;) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (value) {
+              total += value.byteLength
+              if (total > MAX_BYTES) {
+                controller.abort()
+                return
+              }
+              chunks.push(value)
+            }
+          }
+          const merged = new Uint8Array(total)
+          let offset = 0
+          for (const chunk of chunks) {
+            merged.set(chunk, offset)
+            offset += chunk.byteLength
+          }
+          imageBuffers.set(key, merged.buffer)
+        } catch {
+          // Timeout, abort, or network error — skip this image
+        } finally {
+          clearTimeout(timeoutId)
+        }
+      }),
+    )
+    // Silently skip failed image fetches — the export continues without them
+    void results
+  }
+
+  return { urls, imageBuffers }
+}
+
+/**
+ * Get the image buffer for a given node from the context.
+ * Returns undefined if the image couldn't be fetched.
+ */
+export function getImageBuffer(node: MdNode, ctx: DocxContext): ArrayBuffer | undefined {
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const src = typeof node.attrs?.src === 'string' ? node.attrs.src : undefined
+
+  if (attachId) {
+    const buffer = ctx.imageBuffers.get(attachId)
+    if (buffer) return buffer
+  }
+  if (src) {
+    return ctx.imageBuffers.get(src)
+  }
+  return undefined
+}
+
+/**
+ * Guess image dimensions from node attrs or use defaults.
+ */
+export function getImageDimensions(node: MdNode): { width: number; height: number } {
+  const width = typeof node.attrs?.width === 'number' ? node.attrs.width : undefined
+  const height = typeof node.attrs?.height === 'number' ? node.attrs.height : undefined
+
+  // Only accept strictly positive, finite dimensions; anything else
+  // (negative, zero, NaN, Infinity) falls back to the default size.
+  if (
+    width &&
+    height &&
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0
+  ) {
+    // Cap width at 600px for DOCX page width
+    const maxWidth = 600
+    if (width > maxWidth) {
+      const ratio = maxWidth / width
+      return { width: maxWidth, height: Math.round(height * ratio) }
+    }
+    return { width, height }
+  }
+
+  // Default image size
+  return { width: 400, height: 300 }
+}

--- a/packages/docs/src/export/docx/index.ts
+++ b/packages/docs/src/export/docx/index.ts
@@ -1,0 +1,92 @@
+/**
+ * DOCX Export Module — Main Entry Point.
+ *
+ * Converts a ProseMirror JSON document into a DOCX file (as Blob).
+ * Uses the `docx` library (github.com/dolanmiu/docx).
+ *
+ * Images are resolved via the resolveAttachments API (same as markdown export)
+ * and fetched as ArrayBuffers for embedding with ImageRun.
+ */
+
+import { Document, Packer, type ISectionOptions } from 'docx'
+import { resolveAttachments } from '../../attachments/api.ts'
+import { resolveAndFetchImages } from './images.ts'
+import { convertBlocks, NUMBERING_CONFIG, ORDERED_LIST_CONFIG_INDEX } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxExportOptions, DocxContext } from './types.ts'
+
+export type { MdNode, DocxExportOptions }
+
+/**
+ * Export a ProseMirror JSON document to a DOCX Blob.
+ *
+ * @param docId - The document ID (used for resolving attachments).
+ * @param doc - The ProseMirror JSON root node (from editor.getJSON()).
+ * @param opts - Optional configuration for batch size, resolve function, emoji resolver.
+ * @returns A Blob containing the .docx file.
+ */
+export async function exportDocToDocx(
+  docId: string,
+  doc: MdNode,
+  opts: DocxExportOptions = {},
+): Promise<Blob> {
+  const resolve = opts.resolve ?? resolveAttachments
+
+  // Resolve attachment URLs and fetch image buffers
+  const { urls, imageBuffers } = await resolveAndFetchImages(docId, doc, {
+    batchSize: opts.batchSize,
+    resolve,
+  })
+
+  // Build the conversion context
+  const ctx: DocxContext = {
+    urls,
+    imageBuffers,
+    emojiGlyph: opts.emojiGlyph,
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+
+  // Convert ProseMirror JSON blocks to docx elements
+  const children = convertBlocks(doc.content ?? [], ctx)
+
+  // Create the document section
+  const section: ISectionOptions = {
+    properties: {
+      page: {
+        margin: {
+          top: 1440,    // 1 inch
+          right: 1440,
+          bottom: 1440,
+          left: 1440,
+        },
+      },
+    },
+    children,
+  }
+
+  // Build numbering config: static defs + one reference per non-default-start
+  // ordered list. Each dynamic reference clones the ordered-list levels but sets
+  // level[0].start (docx derives an instance's first number from level[0].start).
+  const orderedLevels = NUMBERING_CONFIG.config[ORDERED_LIST_CONFIG_INDEX].levels
+  const numbering = {
+    config: [
+      ...NUMBERING_CONFIG.config,
+      ...ctx.dynamicNumbering.map((dn) => ({
+        reference: dn.reference,
+        levels: orderedLevels.map((lvl) => (lvl.level === dn.level ? { ...lvl, start: dn.start } : lvl)),
+      })),
+    ],
+  }
+
+  // Create the full document with styles and numbering
+  const document = new Document({
+    styles: DOCX_STYLES,
+    numbering,
+    sections: [section],
+  })
+
+  // Pack the document into a Blob
+  const buffer = await Packer.toBlob(document)
+  return buffer
+}

--- a/packages/docs/src/export/docx/marks.ts
+++ b/packages/docs/src/export/docx/marks.ts
@@ -1,0 +1,255 @@
+/**
+ * Inline mark converters for the DOCX export.
+ * Converts ProseMirror marks (bold, italic, code, strike, link, underline,
+ * highlight, textStyle, subscript, superscript) into docx TextRun options.
+ */
+
+import { type IRunOptions, ExternalHyperlink, TextRun, UnderlineType, type ParagraphChild } from 'docx'
+import { FONT_CODE, FONT_EMOJI } from './styles.ts'
+import { latexToMathComponent } from './math.ts'
+import type { MdNode } from './types.ts'
+
+type MarkDef = { type: string; attrs?: Record<string, unknown> }
+
+/**
+ * Regex matching emoji / pictographic codepoints that the body font (微软雅黑)
+ * cannot render. Covers the main emoji blocks + variation selectors + ZWJ so
+ * multi-codepoint emoji (e.g. 👩‍💻, keycaps, flags) stay in one run.
+ *
+ * Also covers a few BMP "letterlike / punctuation" symbols that combine with a
+ * trailing U+FE0F to form emoji (‼️ U+203C, ⁉️ U+2049, ™️ U+2122, ℹ️ U+2139,
+ * ↔️↕️ etc.). Without these, the base char stayed in the body font while the
+ * orphaned FE0F got split into an emoji-font run and rendered as a tofu box.
+ */
+const EMOJI_RE =
+  /([\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{1F1E6}-\u{1F1FF}\u{203C}\u{2049}\u{2122}\u{2139}\u{2190}-\u{21FF}\u{2300}-\u{23FF}\u{FE0F}\u{20E3}\u{200D}]+)/u
+
+/**
+ * Build a single TextRun for a literal emoji/pictographic glyph, tagged with the
+ * emoji font so it doesn't inherit the body font (微软雅黑) and render blank.
+ * Use for hardcoded UI glyphs like 📎 / 🔗 / ☑ / callout icons.
+ *
+ * Strips the U+FE0F variation selector: for base symbols like ℹ (U+2139) / ⚠
+ * (U+26A0), the emoji font already renders the colored glyph from the base char,
+ * and a trailing FE0F has no composed glyph in many Word emoji fonts (notably on
+ * macOS), so it shows up as an extra tofu box right after the icon. Dropping FE0F
+ * keeps the colored glyph and removes the box.
+ */
+export function emojiRun(text: string, opts: IRunOptions = {}): TextRun {
+  return new TextRun({ text: text.replace(/\uFE0F/gu, ''), ...opts, font: FONT_EMOJI })
+}
+
+/**
+ * Emit an icon glyph followed by a single normal-width space, as two runs.
+ *
+ * The glyph carries the emoji font; the trailing space is a separate run in the
+ * inherited body font. A space inside an emoji-font run renders far too wide in
+ * Word (looks like an accidental gap), so the separator space must NOT live in
+ * the emoji run. Pass the bare glyph here (no trailing space in the string).
+ */
+export function iconPrefix(glyph: string, opts: IRunOptions = {}): ParagraphChild[] {
+  return [emojiRun(glyph, opts), new TextRun({ text: ' ', ...opts })]
+}
+
+/**
+ * Split text into runs, applying the emoji font only to emoji segments so that
+ * CJK/latin text keeps its inherited body font. Returns one or more TextRuns.
+ */
+export function buildTextRuns(text: string, baseOpts: IRunOptions): TextRun[] {
+  if (!text) return []
+  // Fast path: no emoji → single run.
+  if (!EMOJI_RE.test(text)) return [new TextRun({ text, ...baseOpts })]
+
+  const runs: TextRun[] = []
+  // Split keeping delimiters (emoji chunks) via a global clone of the regex.
+  const parts = text.split(new RegExp(EMOJI_RE, 'gu'))
+  for (const part of parts) {
+    if (!part) continue
+    const isEmoji = new RegExp(`^${EMOJI_RE.source}$`, 'u').test(part)
+    runs.push(
+      new TextRun(
+        isEmoji
+          ? { text: part.replace(/\uFE0F/gu, ''), ...baseOpts, font: FONT_EMOJI }
+          : { text: part, ...baseOpts },
+      ),
+    )
+  }
+  return runs
+}
+
+/**
+ * Build IRunOptions properties from an array of marks.
+ * Returns run options that should be spread into the TextRun constructor.
+ * Uses a mutable intermediate to avoid readonly assignment errors.
+ */
+export function buildRunOptionsFromMarks(marks: MarkDef[]): IRunOptions {
+  const opts: Record<string, unknown> = {}
+
+  for (const mark of marks) {
+    switch (mark.type) {
+      case 'bold':
+      case 'strong':
+        opts.bold = true
+        break
+      case 'italic':
+      case 'em':
+        opts.italics = true
+        break
+      case 'code':
+        opts.font = FONT_CODE
+        opts.shading = { fill: 'F0F0F0' }
+        break
+      case 'strike':
+        opts.strike = true
+        break
+      case 'underline':
+        opts.underline = { type: UnderlineType.SINGLE }
+        break
+      case 'highlight': {
+        // docx highlight only supports named colors; use yellow as default
+        opts.highlight = 'yellow'
+        break
+      }
+      case 'textStyle': {
+        const textColor = mark.attrs?.color
+        if (typeof textColor === 'string' && textColor) {
+          opts.color = textColor.startsWith('#') ? textColor.slice(1) : textColor
+        }
+        const fontSize = mark.attrs?.fontSize
+        if (typeof fontSize === 'string') {
+          const pt = parseFloat(fontSize)
+          if (!isNaN(pt)) opts.size = Math.round(pt * 2) // half-points
+        }
+        break
+      }
+      case 'subscript':
+        opts.subScript = true
+        break
+      case 'superscript':
+        opts.superScript = true
+        break
+      // 'link' is handled separately as it wraps in ExternalHyperlink
+    }
+  }
+
+  return opts as IRunOptions
+}
+
+/**
+ * Allowed URL schemes for DOCX hyperlinks. Blocks javascript:, file:, data:,
+ * vbscript:, and UNC paths that could be injected via pasted content.
+ */
+const SAFE_HREF_SCHEMES = /^(?:https?|mailto|tel):/i
+
+/**
+ * Check if marks contain a link mark, and return its href (if safe).
+ * Returns null for unsafe schemes, UNC paths, or non-string values.
+ */
+export function extractLinkHref(marks: MarkDef[]): string | null {
+  const linkMark = marks.find((m) => m.type === 'link')
+  if (!linkMark) return null
+  const href = linkMark.attrs?.href
+  if (typeof href !== 'string') return null
+  // Strip leading whitespace / control chars before scheme check — prevents bypass
+  // like `\tjavascript:` or `\n  javascript:` that passes the regex otherwise.
+  const trimmed = href.replace(/^[\s\x00-\x20]+/, '')
+  // Block UNC paths (\\server\share or //server/share) — NTLM credential leak vector.
+  if (/^\\\\/.test(trimmed) || /^\/\//.test(trimmed)) return null
+  // Allow relative URLs (no scheme) and whitelisted schemes.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) && !SAFE_HREF_SCHEMES.test(trimmed)) return null
+  return trimmed
+}
+
+/**
+ * Convert inline nodes to an array of TextRun or ExternalHyperlink elements.
+ * Handles text nodes with marks, hardBreak, inlineMath, mention, and emoji.
+ */
+export function convertInlineContent(
+  nodes: MdNode[],
+  emojiGlyph?: (name: string | null | undefined) => string | undefined,
+): ParagraphChild[] {
+  const runs: ParagraphChild[] = []
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'text': {
+        const text = node.text ?? ''
+        if (!text) break
+        const marks = node.marks ?? []
+        const linkHref = extractLinkHref(marks)
+        const runOpts = buildRunOptionsFromMarks(marks.filter((m) => m.type !== 'link'))
+
+        if (linkHref) {
+          runs.push(
+            new ExternalHyperlink({
+              children: buildTextRuns(text, { ...runOpts, style: 'Hyperlink' }),
+              link: linkHref,
+            }),
+          )
+        } else {
+          runs.push(...buildTextRuns(text, runOpts))
+        }
+        break
+      }
+      case 'hardBreak':
+        runs.push(new TextRun({ break: 1 }))
+        break
+      case 'inlineMath': {
+        const latex = typeof node.attrs?.latex === 'string' ? node.attrs.latex : ''
+        const math = latexToMathComponent(latex, false)
+        if (math) {
+          // Real OMML formula, rendered natively by Word.
+          runs.push(math)
+        } else {
+          // Fallback: conversion failed — keep the LaTeX source (wrapped in `$`)
+          // as monospace text so no content is lost.
+          runs.push(
+            new TextRun({
+              text: `$${latex}$`,
+              font: FONT_CODE,
+              italics: true,
+            }),
+          )
+        }
+        break
+      }
+      case 'mention': {
+        const label = node.attrs?.label ?? node.attrs?.id ?? ''
+        runs.push(
+          new TextRun({
+            text: `@${label}`,
+            bold: true,
+            color: '1A73E8',
+          }),
+        )
+        break
+      }
+      case 'emoji': {
+        const name = typeof node.attrs?.name === 'string' ? node.attrs.name : null
+        const glyph = emojiGlyph?.(name)
+        const emojiText = glyph ?? (name ? `:${name}:` : '')
+        // Apply the emoji font: the body font (微软雅黑) has no emoji glyphs and
+        // Word does NOT auto-fallback, so bare runs render as blank boxes.
+        // buildTextRuns only tags actual emoji codepoints (leaves `:name:` text alone).
+        runs.push(...buildTextRuns(emojiText, {}))
+        break
+      }
+      case 'image': {
+        // Inline images are handled at a higher level; emit alt text as fallback
+        const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : '[image]'
+        runs.push(new TextRun({ text: alt, italics: true, color: '888888' }))
+        break
+      }
+      default: {
+        // Recurse into unknown inline containers
+        if (node.content && node.content.length) {
+          runs.push(...convertInlineContent(node.content, emojiGlyph))
+        } else if (node.text) {
+          runs.push(new TextRun({ text: node.text }))
+        }
+      }
+    }
+  }
+
+  return runs
+}

--- a/packages/docs/src/export/docx/math-fallback.test.ts
+++ b/packages/docs/src/export/docx/math-fallback.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Fallback behavior for math in the DOCX export.
+ *
+ * When LaTeX → OMML conversion fails (bad init, unsupported construct, etc.),
+ * `latexToMathComponent` returns null and the node/mark converters must fall
+ * back to rendering the raw LaTeX source as text rather than crashing the
+ * export or silently dropping the formula. We force the failure by mocking the
+ * math module so it always returns null.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// Force every conversion to "fail" so the fallback branches run.
+vi.mock('./math.ts', () => ({
+  latexToMathComponent: () => null,
+}))
+
+import { convertBlocks } from './nodes.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function newCtx(): DocxContext {
+  return { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+}
+
+/** Collect all text found in a docx element tree via JSON round-trip. */
+function serialize(el: unknown): string {
+  return JSON.stringify(el)
+}
+
+describe('math fallback when conversion fails', () => {
+  it('block math falls back to the raw LaTeX source text', () => {
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\int_0^1 x\\,dx' } },
+    ] as MdNode[]
+
+    const children = convertBlocks(doc, newCtx())
+    expect(children.length).toBe(1)
+    const json = serialize(children[0])
+    // Source text preserved, no OMML emitted.
+    expect(json).toContain('\\\\int_0^1 x')
+    expect(json).not.toContain('m:oMath')
+  })
+
+  it('inline math falls back to $...$ wrapped source text', () => {
+    const doc: MdNode[] = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'a ' },
+          { type: 'inlineMath', attrs: { latex: 'x^2' } },
+          { type: 'text', text: ' b' },
+        ],
+      },
+    ] as MdNode[]
+
+    const children = convertBlocks(doc, newCtx())
+    const json = serialize(children[0])
+    expect(json).toContain('$x^2$')
+    expect(json).not.toContain('m:oMath')
+    // Surrounding text still present.
+    expect(json).toContain('a ')
+    expect(json).toContain(' b')
+  })
+
+  it('does not throw — export stays alive on conversion failure', () => {
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: 'E = mc^2' } },
+    ] as MdNode[]
+    expect(() => convertBlocks(doc, newCtx())).not.toThrow()
+  })
+})

--- a/packages/docs/src/export/docx/math.test.ts
+++ b/packages/docs/src/export/docx/math.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for math (LaTeX → OMML) handling in the DOCX export.
+ *
+ * Word renders native, editable formulas only from OMML (`<m:oMath>`) markup.
+ * These tests cover the conversion chain (LaTeX → MathML → OMML → docx) at the
+ * unit level and end-to-end by packing a real .docx and asserting the OMML
+ * nodes land in word/document.xml. The fallback path (conversion failure →
+ * plain source text) is covered in math-fallback.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document, Paragraph } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { latexToMathComponent } from './math.ts'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/** The three formulas from the task brief. */
+const FORMULAS = [
+  'E = mc^2',
+  '\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}',
+  '\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
+]
+
+/** Build a full docx from blocks, pack it, unzip word/document.xml. */
+async function renderDocumentXml(doc: MdNode[]): Promise<string> {
+  const ctx: DocxContext = {
+    urls: new Map(),
+    imageBuffers: new Map(),
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+  const children = convertBlocks(doc, ctx)
+  const document = new Document({
+    styles: DOCX_STYLES,
+    numbering: NUMBERING_CONFIG,
+    sections: [{ children }],
+  })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `math-e2e-${process.pid}-${children.length}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+describe('latexToMathComponent (unit)', () => {
+  it('returns a component for each brief formula (block)', () => {
+    for (const latex of FORMULAS) {
+      const comp = latexToMathComponent(latex, true)
+      expect(comp, `block: ${latex}`).not.toBeNull()
+    }
+  })
+
+  it('returns a component for inline math', () => {
+    expect(latexToMathComponent('x^2', false)).not.toBeNull()
+  })
+
+  it('returns null for empty / whitespace latex (caller falls back)', () => {
+    expect(latexToMathComponent('', true)).toBeNull()
+    expect(latexToMathComponent('   ', false)).toBeNull()
+  })
+
+  it('produced component serializes to an <m:oMath> element', () => {
+    // A component placed in a paragraph must serialize as real OMML markup.
+    const comp = latexToMathComponent('E = mc^2', true)!
+    const p = new Paragraph({ children: [comp] })
+    const json = JSON.stringify(p)
+    expect(json).toContain('m:oMath')
+    // No malformed <undefined> wrapper (the fromXmlString trap).
+    expect(json).not.toContain('undefined')
+  })
+})
+
+describe('block math end-to-end docx export', () => {
+  it('each brief formula produces one <m:oMath> node in document.xml', async () => {
+    const doc: MdNode[] = FORMULAS.map((latex) => ({
+      type: 'blockMath',
+      attrs: { latex },
+    })) as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    // One native formula per input, balanced open/close, no malformed wrapper.
+    const opens = xml.match(/<m:oMath[ >]/g) ?? []
+    const closes = xml.match(/<\/m:oMath>/g) ?? []
+    expect(opens.length).toBe(FORMULAS.length)
+    expect(closes.length).toBe(FORMULAS.length)
+    expect(xml).not.toContain('<undefined')
+
+    // The LaTeX source must NOT be dumped verbatim as body text.
+    expect(xml).not.toContain('\\int_')
+    expect(xml).not.toContain('\\sqrt')
+    expect(xml).not.toContain('\\frac')
+  })
+
+  it('math structures + operators are present (radical, fraction, ∑, ∫)', async () => {
+    const doc: MdNode[] = FORMULAS.map((latex) => ({
+      type: 'blockMath',
+      attrs: { latex },
+    })) as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('schemas.openxmlformats.org/officeDocument/2006/math')
+    // √ becomes a radical structure, fractions a <m:f>, large operators carry
+    // their Unicode codepoint in m:chr.
+    expect(xml).toContain('<m:rad') // \sqrt{\pi}
+    expect(xml).toContain('<m:f>') // \frac{...}{...}
+    expect(xml).toContain('m:val="∑"') // \sum
+    expect(xml).toContain('m:val="∫"') // \int
+    // The invalid `m:sty m:val="undefined"` mml2omml quirk must be sanitized.
+    expect(xml).not.toContain('m:val="undefined"')
+    expect(xml).not.toContain('<undefined')
+  })
+
+  it('CORE: n-ary operators (∫ ∑) carry a NON-EMPTY <m:e> operand body', async () => {
+    // This is the regression that motivated replacing mml2omml: it emitted
+    // <m:nary>…<m:e/></m:nary> (empty body) and stranded the integrand, so Word
+    // drew an empty little box. Every nary MUST have a populated <m:e>.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: FORMULAS[1] } }, // integral
+      { type: 'blockMath', attrs: { latex: FORMULAS[2] } }, // sum
+    ] as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    // No empty operand body anywhere (neither self-closing nor <m:e></m:e>).
+    expect(xml).not.toContain('<m:e/>')
+    expect(xml).not.toMatch(/<m:e>\s*<\/m:e>/)
+
+    // Pull each nary's operand body out and prove it is non-empty and actually
+    // contains the integrand / summand content, not just whitespace.
+    const bodies = [...xml.matchAll(/<m:nary>[\s\S]*?<m:e>([\s\S]*?)<\/m:e>\s*<\/m:nary>/g)].map(
+      (m) => m[1],
+    )
+    expect(bodies.length).toBe(2) // one ∫, one ∑
+    for (const body of bodies) {
+      expect(body.length).toBeGreaterThan(0)
+      expect(body).toContain('<m:r>') // real runs inside the body
+    }
+    // The Gaussian integral's body must contain the integrand e and x
+    // (e^{-x^2} dx), and the ∑ body must contain its 1/n^2 fraction.
+    const integralBody = bodies.find((b) => b.includes('π') === false && b.includes('e</m:t>'))
+    expect(integralBody, 'integral operand body').toBeDefined()
+    expect(integralBody).toContain('>e<')
+    expect(integralBody).toContain('>x<')
+    expect(bodies.some((b) => b.includes('<m:f>'))).toBe(true) // ∑ body has the fraction
+  })
+
+})
+
+describe('inline math end-to-end docx export', () => {
+  it('inline formula lands inside a paragraph alongside its text', async () => {
+    const doc: MdNode[] = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: '质能方程 ' },
+          { type: 'inlineMath', attrs: { latex: 'E = mc^2' } },
+          { type: 'text', text: ' 很有名' },
+        ],
+      },
+    ] as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    expect(xml).toContain('<m:oMath')
+    expect((xml.match(/<m:oMath[ >]/g) ?? []).length).toBe(1)
+    // The surrounding CJK text must still be present as normal runs.
+    expect(xml).toContain('质能方程')
+    expect(xml).toContain('很有名')
+    // Not the old `$...$` literal source.
+    expect(xml).not.toContain('$E = mc^2$')
+  })
+})

--- a/packages/docs/src/export/docx/math.ts
+++ b/packages/docs/src/export/docx/math.ts
@@ -1,0 +1,123 @@
+/**
+ * LaTeX → OMML conversion for the DOCX export.
+ *
+ * Word only renders native, editable math from OMML (`<m:oMath>`) markup, so we
+ * cannot just drop the LaTeX source into a run (that renders as literal text).
+ * The conversion chain is:
+ *
+ *   LaTeX ──(mathjax-full, TeX input)──▶ MathML
+ *         ──(our mathmlToOmml)─────────▶ OMML string
+ *         ──(xml-js + docx.convertToXmlComponent)──▶ docx XmlComponent
+ *
+ * The resulting component can be pushed straight into a Paragraph's children.
+ *
+ * We convert MathML→OMML ourselves (see ./mathml-to-omml) rather than using the
+ * `mathml2omml` package: that package emits large operators (∫ ∑ …) as an
+ * `<m:nary>` with an EMPTY `<m:e>` and strands the integrand as sibling runs,
+ * which Word renders as an empty little box — the "公式还在小方格里" bug.
+ *
+ * docx 9.7.1 note: the package's index exports `Math`/`MathRun` builders, but
+ * assembling arbitrary formulas from those by hand would require a full LaTeX
+ * parser. Instead we inject the raw OMML via the exported `convertToXmlComponent`
+ * helper. `ImportedXmlComponent.fromXmlString` is NOT usable directly here: it
+ * feeds the whole string through `xml2js` and wraps the document root — whose
+ * xml-js node has no tag name — producing a malformed `<undefined>…</undefined>`
+ * wrapper around the `<m:oMath>`. So we parse ourselves and hand
+ * `convertToXmlComponent` the actual `<m:oMath>` element node.
+ *
+ * The MathJax pipeline is built lazily once and reused. Any failure anywhere in
+ * the chain returns null so callers can fall back to plain source text without
+ * crashing the whole export.
+ */
+
+import { convertToXmlComponent, type ParagraphChild } from 'docx'
+import { xml2js, type Element } from 'xml-js'
+import { mathjax } from 'mathjax-full/js/mathjax.js'
+import { TeX } from 'mathjax-full/js/input/tex.js'
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js'
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js'
+import { SerializedMmlVisitor } from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js'
+import { STATE } from 'mathjax-full/js/core/MathItem.js'
+import type { MmlNode } from 'mathjax-full/js/core/MmlTree/MmlNode.js'
+import { mathmlToOmml } from './mathml-to-omml.ts'
+
+/** LaTeX → MathML converter, or null if MathJax failed to initialize. */
+type MathMLConverter = (latex: string, display: boolean) => string
+
+// `undefined` = not yet initialized; `null` = init failed (don't retry).
+let converter: MathMLConverter | null | undefined
+
+/**
+ * Build the MathJax TeX→MathML pipeline once and cache it.
+ *
+ * We stop conversion at `STATE.COMPILED`: that yields the internal MathML tree
+ * (which we serialize) without running a display/output jax — MathJax ships no
+ * MathML output jax in this build, and later stages (e.g. the `AllPackages`
+ * `bussproofs` extension) demand an output jax with `getBBox()`. Restricting to
+ * the `base` + `ams` packages keeps us to macros that compile without one while
+ * still covering the vast majority of real-world formulas.
+ */
+function getConverter(): MathMLConverter | null {
+  if (converter !== undefined) return converter
+  try {
+    const adaptor = liteAdaptor()
+    RegisterHTMLHandler(adaptor)
+    const tex = new TeX({ packages: ['base', 'ams'] })
+    const doc = mathjax.document('', { InputJax: tex })
+    const visitor = new SerializedMmlVisitor()
+    converter = (latex: string, display: boolean): string => {
+      const node = doc.convert(latex, { display, end: STATE.COMPILED }) as MmlNode
+      return visitor.visitTree(node)
+    }
+  } catch (err) {
+    console.warn('[docx] MathJax pipeline init failed; math falls back to source text', err)
+    converter = null
+  }
+  return converter
+}
+
+/**
+ * Convert a LaTeX formula into a docx math component ready to be placed in a
+ * Paragraph's children.
+ *
+ * @param latex   the LaTeX source (without surrounding `$`/`$$`)
+ * @param display true for block/display math, false for inline
+ * @returns the math component, or null if conversion failed (caller should
+ *          fall back to rendering the raw source text)
+ */
+export function latexToMathComponent(latex: string, display: boolean): ParagraphChild | null {
+  const src = typeof latex === 'string' ? latex.trim() : ''
+  if (!src) return null
+
+  const convert = getConverter()
+  if (!convert) return null
+
+  try {
+    const mathml = convert(src, display)
+    const omml = mathmlToOmml(mathml)
+
+    // Parse the OMML ourselves and hand convertToXmlComponent the actual
+    // <m:oMath> element (see the file header for why fromXmlString is unsafe).
+    const parsed = xml2js(omml, { compact: false }) as Element
+    const root = (parsed.elements ?? []).find(
+      (el) => el.type === 'element' && el.name === 'm:oMath',
+    )
+    if (!root) {
+      console.warn(`[docx] LaTeX→OMML produced no <m:oMath> node for: ${src}`)
+      return null
+    }
+
+    const component = convertToXmlComponent(root)
+    if (!component || typeof component === 'string') {
+      console.warn(`[docx] LaTeX→OMML yielded a non-element component for: ${src}`)
+      return null
+    }
+    // convertToXmlComponent returns an ImportedXmlComponent, which docx
+    // serializes correctly but which is not part of the ParagraphChild union.
+    // The cast is the intended escape hatch for injecting raw OOXML.
+    return component as unknown as ParagraphChild
+  } catch (err) {
+    console.warn(`[docx] LaTeX→OMML conversion failed for: ${src}`, err)
+    return null
+  }
+}

--- a/packages/docs/src/export/docx/mathml-to-omml.ts
+++ b/packages/docs/src/export/docx/mathml-to-omml.ts
@@ -1,0 +1,301 @@
+/**
+ * MathML → OMML converter for the DOCX export.
+ *
+ * This replaces the `mathml2omml` npm package, which mistranslates large
+ * operators (∫ ∑ ∏ …): it emits an `<m:nary>` whose `<m:e>` operand body is
+ * EMPTY and leaves the integrand/summand stranded as sibling runs after the
+ * nary. Word then renders the operator as an empty little box with the body
+ * floating beside it — the long-standing "公式还在小方格里" bug.
+ *
+ * We walk the (correct) MathML tree MathJax produces and emit OMML ourselves,
+ * covering the structures real documents use: mi/mn/mo/mtext, msup/msub/
+ * msubsup, munder/mover/munderover, mfrac, msqrt/mroot, and large operators as
+ * proper `<m:nary>` with a non-empty `<m:e>`.
+ *
+ * The nary-body problem is genuinely ambiguous in *presentation* MathML: the
+ * operator and its integrand are siblings, with no markup delimiting where the
+ * integrand ends. We use the reading a human would: the body runs from just
+ * after the operator up to (but not including) the next relation operator
+ * (=, ≠, <, >, ≤, ≥, →, …) at the same level. So in
+ *   ∫_{-∞}^{∞} e^{-x²} dx = √π
+ * the body is `e^{-x²} dx` and `= √π` stays outside — exactly right.
+ *
+ * Any element we don't recognize throws, so the caller can fall back to
+ * rendering the raw LaTeX source instead of producing a broken formula.
+ */
+
+import { xml2js, type Element } from 'xml-js'
+
+const MATH_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+
+/**
+ * n-ary (large) operators that must become an OMML `<m:nary>` whose `<m:e>`
+ * holds the operand body. Covers integrals, sums, products, coproducts, and
+ * the big set/logic operators.
+ */
+const LARGE_OPS = new Set([
+  '∑', // ∑ sum
+  '∏', // ∏ product
+  '∐', // ∐ coproduct
+  '∫', // ∫ integral
+  '∬', // ∬ double integral
+  '∭', // ∭ triple integral
+  '∮', // ∮ contour integral
+  '∯', // ∯ surface integral
+  '⨀', // ⨀
+  '⨁', // ⨁
+  '⨂', // ⨂
+  '⨄', // ⨄
+  '⨆', // ⨆
+  '⋀', // ⋀ big wedge
+  '⋁', // ⋁ big vee
+  '⋂', // ⋂ big intersection
+  '⋃', // ⋃ big union
+])
+
+/**
+ * Relation operators that terminate an n-ary operand body: the integrand /
+ * summand does not extend past them (∫ f dx = … → body is just `f dx`).
+ */
+const RELATION_OPS = new Set([
+  '=',
+  '≠', // ≠
+  '<',
+  '>',
+  '≤', // ≤
+  '≥', // ≥
+  '≈', // ≈
+  '≡', // ≡
+  '≅', // ≅
+  '∝', // ∝
+  '→', // →
+  '←', // ←
+  '↔', // ↔
+  '↦', // ↦
+  '∈', // ∈
+  '⊆', // ⊆
+  '⊂', // ⊂
+])
+
+/**
+ * Binary arithmetic operators that terminate an n-ary body.
+ * For ∑ x + y = z, the body should be just `x`; `+ y = z` stays at top level.
+ */
+const BINARY_ARITH_OPS = new Set([
+  '+',
+  '-',
+  '×', // ×
+  '·', // ·
+  '÷', // ÷
+  '±', // ±
+  '∓', // ∓
+  '⊕', // ⊕
+  '⊗', // ⊗
+  '∧', // ∧
+  '∨', // ∨
+])
+
+/** Child *element* nodes (drops whitespace/text between pretty-printed tags). */
+function childElements(node: Element): Element[] {
+  return (node.elements ?? []).filter((e) => e.type === 'element') as Element[]
+}
+
+/** Concatenated text content of a token element (mi/mn/mo/mtext/ms). */
+function textOf(node: Element): string {
+  return (node.elements ?? [])
+    .map((e) => (e.type === 'text' ? String(e.text ?? '') : e.type === 'cdata' ? String(e.cdata ?? '') : ''))
+    .join('')
+}
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function escAttr(s: string): string {
+  return escXml(s).replace(/"/g, '&quot;')
+}
+
+/** A plain math run carrying literal text. */
+function run(text: string): string {
+  return `<m:r><m:t xml:space="preserve">${escXml(text)}</m:t></m:r>`
+}
+
+function sSup(base: Element, sup: Element): string {
+  return `<m:sSup><m:sSupPr><m:ctrlPr/></m:sSupPr><m:e>${convertNode(base)}</m:e><m:sup>${convertNode(sup)}</m:sup></m:sSup>`
+}
+
+function sSub(base: Element, sub: Element): string {
+  return `<m:sSub><m:sSubPr><m:ctrlPr/></m:sSubPr><m:e>${convertNode(base)}</m:e><m:sub>${convertNode(sub)}</m:sub></m:sSub>`
+}
+
+function sSubSup(base: Element, sub: Element, sup: Element): string {
+  return `<m:sSubSup><m:sSubSupPr><m:ctrlPr/></m:sSubSupPr><m:e>${convertNode(base)}</m:e><m:sub>${convertNode(sub)}</m:sub><m:sup>${convertNode(sup)}</m:sup></m:sSubSup>`
+}
+
+function frac(num: Element, den: Element): string {
+  return `<m:f><m:fPr><m:ctrlPr/></m:fPr><m:num>${convertNode(num)}</m:num><m:den>${convertNode(den)}</m:den></m:f>`
+}
+
+/** √ with hidden (empty) degree. */
+function sqrt(children: Element[]): string {
+  return `<m:rad><m:radPr><m:degHide m:val="on"/></m:radPr><m:deg/><m:e>${convertSequence(children)}</m:e></m:rad>`
+}
+
+/** ⁿ√ with a visible index. */
+function root(base: Element, index: Element): string {
+  return `<m:rad><m:radPr/><m:deg>${convertNode(index)}</m:deg><m:e>${convertNode(base)}</m:e></m:rad>`
+}
+
+/** True if `node` is an `<mo>` whose glyph is a large (n-ary) operator. */
+function isLargeOpMo(node: Element | undefined): boolean {
+  return !!node && node.name === 'mo' && LARGE_OPS.has(textOf(node).trim())
+}
+
+/** True if `node` is an `<mo>` that ends an n-ary operand body. */
+function isRelationMo(node: Element): boolean {
+  return node.name === 'mo' && RELATION_OPS.has(textOf(node).trim())
+}
+
+function isBinaryArithMo(node: Element): boolean {
+  return node.name === 'mo' && BINARY_ARITH_OPS.has(textOf(node).trim())
+}
+
+interface NaryInfo {
+  chr: string
+  sub?: Element
+  sup?: Element
+  limLoc: 'subSup' | 'undOvr'
+}
+
+/**
+ * If `node` introduces a large operator (bare, or scripted with limits),
+ * describe it as an n-ary; otherwise return null.
+ */
+function naryInfo(node: Element): NaryInfo | null {
+  if (node.name === 'mo' && LARGE_OPS.has(textOf(node).trim())) {
+    return { chr: textOf(node).trim(), limLoc: 'subSup' }
+  }
+  const kids = childElements(node)
+  if (!isLargeOpMo(kids[0])) return null
+  const chr = textOf(kids[0]).trim()
+  switch (node.name) {
+    case 'msubsup':
+      return { chr, sub: kids[1], sup: kids[2], limLoc: 'subSup' }
+    case 'munderover':
+      return { chr, sub: kids[1], sup: kids[2], limLoc: 'undOvr' }
+    case 'msub':
+      return { chr, sub: kids[1], limLoc: 'subSup' }
+    case 'munder':
+      return { chr, sub: kids[1], limLoc: 'undOvr' }
+    case 'msup':
+      return { chr, sup: kids[1], limLoc: 'subSup' }
+    case 'mover':
+      return { chr, sup: kids[1], limLoc: 'undOvr' }
+    default:
+      return null
+  }
+}
+
+/** Emit an `<m:nary>` with its limits and a (possibly empty) operand body. */
+function emitNary(info: NaryInfo, body: Element[]): string {
+  const subHide = info.sub ? 'off' : 'on'
+  const supHide = info.sup ? 'off' : 'on'
+  const sub = info.sub ? `<m:sub>${convertNode(info.sub)}</m:sub>` : '<m:sub/>'
+  const sup = info.sup ? `<m:sup>${convertNode(info.sup)}</m:sup>` : '<m:sup/>'
+  const e = `<m:e>${convertSequence(body)}</m:e>`
+  return (
+    `<m:nary><m:naryPr>` +
+    `<m:chr m:val="${escAttr(info.chr)}"/>` +
+    `<m:limLoc m:val="${info.limLoc}"/>` +
+    `<m:subHide m:val="${subHide}"/>` +
+    `<m:supHide m:val="${supHide}"/>` +
+    `<m:ctrlPr/></m:naryPr>${sub}${sup}${e}</m:nary>`
+  )
+}
+
+/**
+ * Convert a sequence of sibling MathML nodes. This is where n-ary operators
+ * pull their trailing siblings into `<m:e>` (up to the next relation op).
+ */
+function convertSequence(nodes: Element[]): string {
+  let out = ''
+  let i = 0
+  while (i < nodes.length) {
+    const node = nodes[i]
+    const nary = naryInfo(node)
+    if (nary) {
+      const body: Element[] = []
+      let j = i + 1
+      while (j < nodes.length && !isRelationMo(nodes[j]) && !isBinaryArithMo(nodes[j])) {
+        body.push(nodes[j])
+        j++
+      }
+      out += emitNary(nary, body)
+      i = j
+      continue
+    }
+    out += convertNode(node)
+    i++
+  }
+  return out
+}
+
+/** Convert a single MathML element to an OMML fragment. */
+function convertNode(node: Element): string {
+  if (!node) throw new Error('missing MathML child node')
+  const kids = childElements(node)
+  switch (node.name) {
+    case 'mi':
+    case 'mn':
+    case 'mo':
+    case 'mtext':
+    case 'ms':
+      return run(textOf(node))
+    case 'mspace':
+      return ''
+    // Grouping / styling wrappers are transparent in OMML.
+    case 'mrow':
+    case 'mstyle':
+    case 'mpadded':
+    case 'menclose':
+    case 'mphantom':
+      return convertSequence(kids)
+    case 'msup':
+      return sSup(kids[0], kids[1])
+    case 'msub':
+      return sSub(kids[0], kids[1])
+    case 'msubsup':
+      return sSubSup(kids[0], kids[1], kids[2])
+    // No native OMML "under/over"; approximate with scripts (rare off the
+    // n-ary path, e.g. \overrightarrow — good enough, and never empty).
+    case 'mover':
+      return sSup(kids[0], kids[1])
+    case 'munder':
+      return sSub(kids[0], kids[1])
+    case 'munderover':
+      return sSubSup(kids[0], kids[1], kids[2])
+    case 'mfrac':
+      return frac(kids[0], kids[1])
+    case 'msqrt':
+      return sqrt(kids)
+    case 'mroot':
+      return root(kids[0], kids[1])
+    default:
+      throw new Error(`unsupported MathML element <${node.name ?? '?'}>`)
+  }
+}
+
+/**
+ * Convert a serialized MathML `<math>` document into an OMML `<m:oMath>`
+ * string. Throws on malformed input or unsupported structures so the caller
+ * can fall back to the raw LaTeX source.
+ */
+export function mathmlToOmml(mathml: string): string {
+  const parsed = xml2js(mathml, { compact: false }) as Element
+  const math = (parsed.elements ?? []).find(
+    (e) => e.type === 'element' && e.name === 'math',
+  ) as Element | undefined
+  if (!math) throw new Error('no <math> root element in MathML')
+  const body = convertSequence(childElements(math))
+  return `<m:oMath xmlns:m="${MATH_NS}">${body}</m:oMath>`
+}

--- a/packages/docs/src/export/docx/nodes.ts
+++ b/packages/docs/src/export/docx/nodes.ts
@@ -1,0 +1,563 @@
+/**
+ * Block-level node converters for the DOCX export.
+ * Converts ProseMirror JSON nodes into docx Paragraph/Table/etc. elements.
+ */
+
+import {
+  Paragraph,
+  TextRun,
+  ImageRun,
+  CheckBox,
+  HeadingLevel,
+  LevelFormat,
+  AlignmentType,
+  ExternalHyperlink,
+  UnderlineType,
+  type ILevelsOptions,
+  type FileChild,
+} from 'docx'
+import { convertInlineContent, iconPrefix } from './marks.ts'
+import { latexToMathComponent } from './math.ts'
+
+/** Allowed URL schemes for DOCX hyperlinks (same policy as marks.ts). */
+const SAFE_HREF_SCHEMES = /^(?:https?|mailto|tel):/i
+export function isSafeHref(url: string): boolean {
+  // Strip leading whitespace / control chars before scheme check.
+  const trimmed = url.replace(/^[\s\x00-\x20]+/, '')
+  // Block UNC paths (\\server\share or //server/share) — NTLM credential leak vector.
+  if (/^\\\\/.test(trimmed) || /^\/\//.test(trimmed)) return false
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) && !SAFE_HREF_SCHEMES.test(trimmed)) return false
+  return true
+}
+import { convertTable } from './tables.ts'
+import { getImageBuffer, getImageDimensions } from './images.ts'
+import { FONT_CODE, mapTextAlign } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/** Map heading level 1-6 to docx HeadingLevel enum. */
+function toHeadingLevel(level: unknown): (typeof HeadingLevel)[keyof typeof HeadingLevel] {
+  const n = typeof level === 'number' ? level : 1
+  switch (Math.min(6, Math.max(1, n))) {
+    case 1: return HeadingLevel.HEADING_1
+    case 2: return HeadingLevel.HEADING_2
+    case 3: return HeadingLevel.HEADING_3
+    case 4: return HeadingLevel.HEADING_4
+    case 5: return HeadingLevel.HEADING_5
+    case 6: return HeadingLevel.HEADING_6
+    default: return HeadingLevel.HEADING_1
+  }
+}
+
+/** Numbering configuration for lists. */
+/** Index of 'ordered-list' in NUMBERING_CONFIG.config — used by dynamic numbering. */
+export const ORDERED_LIST_CONFIG_INDEX = 1
+
+export const NUMBERING_CONFIG = {
+  config: [
+    {
+      reference: 'bullet-list',
+      levels: [
+        { level: 0, format: LevelFormat.BULLET, text: '•', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 720, hanging: 360 } } } },
+        { level: 1, format: LevelFormat.BULLET, text: '◦', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
+        { level: 2, format: LevelFormat.BULLET, text: '▪', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2160, hanging: 360 } } } },
+        { level: 3, format: LevelFormat.BULLET, text: "‣", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2880, hanging: 360 } } } },
+        { level: 4, format: LevelFormat.BULLET, text: "⁃", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 3600, hanging: 360 } } } },
+      ] as ILevelsOptions[],
+    },
+    {
+      reference: 'ordered-list',
+      levels: [
+        { level: 0, format: LevelFormat.DECIMAL, text: '%1.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 720, hanging: 360 } } } },
+        { level: 1, format: LevelFormat.LOWER_LETTER, text: '%2.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
+        { level: 2, format: LevelFormat.LOWER_ROMAN, text: '%3.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2160, hanging: 360 } } } },
+        { level: 3, format: LevelFormat.DECIMAL, text: "%4.", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2880, hanging: 360 } } } },
+        { level: 4, format: LevelFormat.LOWER_LETTER, text: "%5.", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 3600, hanging: 360 } } } },
+      ] as ILevelsOptions[],
+    },
+    // Note: task lists do NOT use numbering — convertTaskList draws its own ☑/☐
+    // status box per item (see below). A numbering bullet here would duplicate it.
+  ],
+}
+
+/**
+ * Resolve the numbering reference + instance for an orderedList node.
+ *
+ * docx generates one independent concrete numbering per (reference, instance)
+ * pair, each counting from its abstract level[0].start. So:
+ *  - every ordered list gets a fresh instance → independent lists restart at 1
+ *  - a list with an explicit start > 1 gets its own reference whose level set
+ *    starts at that value (the config-level `overrideLevels` field is ignored
+ *    by docx, so the start must live in the level definition itself)
+ */
+function getOrderedListNumbering(node: MdNode, ctx: DocxContext, depth: number): { reference: string; instance: number } {
+  const start = typeof node.attrs?.start === 'number' ? node.attrs.start : 1
+  const instance = ctx.orderedListInstance++
+  if (start <= 1) return { reference: 'ordered-list', instance }
+  const reference = `ordered-list-start-${ctx.dynamicNumbering.length}`
+  ctx.dynamicNumbering.push({ reference, start, level: Math.min(depth, 4) })
+  return { reference, instance }
+}
+
+/**
+ * Convert a top-level document's content array into docx FileChild elements.
+ */
+export function convertBlocks(nodes: MdNode[], ctx: DocxContext): FileChild[] {
+  const result: FileChild[] = []
+  for (const node of nodes) {
+    const converted = convertBlock(node, ctx, 0)
+    result.push(...converted)
+  }
+  return result
+}
+
+/**
+ * Convert a single block-level node into one or more docx elements.
+ */
+function convertBlock(node: MdNode, ctx: DocxContext, listDepth: number): FileChild[] {
+  switch (node.type) {
+    case 'paragraph':
+      return [convertParagraph(node, ctx)]
+    case 'heading':
+      return [convertHeading(node, ctx)]
+    case 'bulletList':
+      return convertList(node, 'bullet-list', ctx, listDepth)
+    case 'orderedList': {
+      const { reference, instance } = getOrderedListNumbering(node, ctx, listDepth)
+      return convertList(node, reference, ctx, listDepth, instance)
+    }
+    case 'taskList':
+      return convertTaskList(node, ctx, listDepth)
+    case 'blockquote':
+      return convertBlockquote(node, ctx)
+    case 'codeBlock':
+      return convertCodeBlock(node)
+    case 'horizontalRule':
+      return [convertHorizontalRule()]
+    case 'table':
+      return [convertTable(node, ctx)]
+    case 'image':
+      return convertImage(node, ctx)
+    case 'fileAttachment':
+      return [convertFileAttachment(node, ctx)]
+    case 'bookmark':
+      return [convertBookmark(node)]
+    case 'callout':
+      return convertCallout(node, ctx)
+    case 'blockMath':
+      return [convertBlockMath(node)]
+    case 'details':
+      return convertDetails(node, ctx)
+    default:
+      // Never drop content: recurse into unknown container or emit raw text
+      if (node.content && node.content.length) return convertBlocks(node.content, ctx)
+      if (node.text) return [new Paragraph({ children: [new TextRun({ text: node.text })] })]
+      return []
+  }
+}
+
+/** Convert a paragraph node. */
+function convertParagraph(node: MdNode, ctx: DocxContext): Paragraph {
+  const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+  const align = mapTextAlign(node.attrs?.textAlign)
+  return new Paragraph({ children: runs, ...(align ? { alignment: align } : {}) })
+}
+
+/** Convert a heading node. */
+function convertHeading(node: MdNode, ctx: DocxContext): Paragraph {
+  const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+  const align = mapTextAlign(node.attrs?.textAlign)
+  return new Paragraph({
+    children: runs,
+    heading: toHeadingLevel(node.attrs?.level),
+    ...(align ? { alignment: align } : {}),
+  })
+}
+
+/** Convert a bullet/ordered list. `instance` selects an independent numbering instance for ordered lists. */
+function convertList(node: MdNode, reference: string, ctx: DocxContext, depth: number, instance = 0): FileChild[] {
+  const items = node.content ?? []
+  const result: FileChild[] = []
+
+  for (const item of items) {
+    const blocks = item.content ?? []
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      if (block.type === 'bulletList' || block.type === 'orderedList' || block.type === 'taskList') {
+        // Nested list: increase depth. Ordered lists get their own reference+instance.
+        if (block.type === 'orderedList') {
+          const nested = getOrderedListNumbering(block, ctx, depth + 1)
+          result.push(...convertList(block, nested.reference, ctx, depth + 1, nested.instance))
+        } else if (block.type === 'taskList') {
+          // Nested task list keeps its own ☑/☐ boxes (not bullet numbering).
+          result.push(...convertTaskList(block, ctx, depth + 1))
+        } else {
+          result.push(...convertList(block, 'bullet-list', ctx, depth + 1))
+        }
+      } else if (i === 0) {
+        // First block in list item — apply numbering
+        const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
+        result.push(
+          new Paragraph({
+            children: runs,
+            numbering: { reference, level: Math.min(depth, 4), instance },
+          }),
+        )
+      } else {
+        // Continuation blocks under the same item
+        result.push(...convertBlock(block, ctx, depth))
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Convert a task list.
+ *
+ * Each item gets a real interactive Word checkbox (docx CheckBox = a w:sdt
+ * content control with w14:checkbox), followed by one normal-width space, then
+ * the item content. The checkbox is clickable/toggleable in Word regardless of
+ * its initial checked state — not a static ☑/☐ glyph.
+ * We deliberately do NOT use list numbering here: a numbering bullet would add
+ * a second box and its own tab, producing the "two boxes + double space" bug.
+ * Indentation is applied manually so the layout still looks like a list.
+ */
+function convertTaskList(node: MdNode, ctx: DocxContext, depth: number): FileChild[] {
+  const items = node.content ?? []
+  const result: FileChild[] = []
+  const indentLeft = 720 * (Math.min(depth, 4) + 1)
+
+  for (const item of items) {
+    const checked = !!item.attrs?.checked
+    const blocks = item.content ?? []
+
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      if (block.type === 'bulletList' || block.type === 'orderedList' || block.type === 'taskList') {
+        if (block.type === 'orderedList') {
+          const nested = getOrderedListNumbering(block, ctx, depth + 1)
+          result.push(...convertList(block, nested.reference, ctx, depth + 1, nested.instance))
+        } else if (block.type === 'taskList') {
+          result.push(...convertTaskList(block, ctx, depth + 1))
+        } else {
+          result.push(...convertList(block, 'bullet-list', ctx, depth + 1))
+        }
+      } else if (i === 0) {
+        const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
+        result.push(
+          new Paragraph({
+            children: [
+              new CheckBox({
+                checked,
+                // Use ☑ (U+2611, check mark in box) for the checked state instead of
+                // docx's default ☒ (U+2612, X in box) — users expect a check mark.
+                checkedState: { value: '2611', font: 'MS Gothic' },
+                uncheckedState: { value: '2610', font: 'MS Gothic' },
+              }),
+              new TextRun({ text: ' ' }),
+              ...runs,
+            ],
+            indent: { left: indentLeft, hanging: 360 },
+          }),
+        )
+      } else {
+        result.push(...convertBlock(block, ctx, depth))
+      }
+    }
+  }
+
+  return result
+}
+
+/** Convert a blockquote. */
+function convertBlockquote(node: MdNode, ctx: DocxContext): FileChild[] {
+  const children = node.content ?? []
+  const result: FileChild[] = []
+
+  for (const child of children) {
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      result.push(
+        new Paragraph({
+          children: runs,
+          style: 'BlockQuote',
+          indent: { left: 720 },
+        }),
+      )
+    } else {
+      // Nested blocks in blockquote
+      const converted = convertBlock(child, ctx, 0)
+      result.push(...converted)
+    }
+  }
+
+  return result
+}
+
+/** Convert a code block. */
+function convertCodeBlock(node: MdNode): FileChild[] {
+  const code = (node.content ?? []).map((c) => c.text ?? '').join('')
+  const lines = code.split('\n')
+
+  return lines.map(
+    (line) =>
+      new Paragraph({
+        children: line
+          ? [
+              new TextRun({
+                text: line,
+                font: { name: FONT_CODE, hint: 'default' },
+                size: 20,
+              }),
+            ]
+          : [], // empty line — no TextRun needed, Paragraph renders as blank line
+        style: 'CodeBlock',
+        spacing: { before: 0, after: 0, line: 240 },
+        shading: { fill: 'F5F5F5' },
+      }),
+  )
+}
+
+/** Convert a horizontal rule. */
+function convertHorizontalRule(): Paragraph {
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: '─'.repeat(50),
+        color: 'CCCCCC',
+        size: 16,
+      }),
+    ],
+    spacing: { before: 120, after: 120 },
+    alignment: AlignmentType.CENTER,
+  })
+}
+
+/** Convert an image node. */
+function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
+  const buffer = getImageBuffer(node, ctx)
+  const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : ''
+
+  if (!buffer) {
+    // Image couldn't be fetched — emit alt text or placeholder
+    return [
+      new Paragraph({
+        children: [
+          new TextRun({
+            text: alt ? `[Image: ${alt}]` : '[Image unavailable]',
+            italics: true,
+            color: '888888',
+          }),
+        ],
+      }),
+    ]
+  }
+
+  const dims = getImageDimensions(node)
+  // Image uses `align` attr (left/center/right), not `textAlign`
+  const align = mapTextAlign(node.attrs?.align)
+
+  // Detect image type from attachId's resolved mime, fallback to png
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const resolved = attachId ? ctx.urls.get(attachId) : undefined
+  const mime = resolved?.mime ?? ''
+  let imgType: 'jpg' | 'png' | 'gif' | 'bmp' = 'png'
+  if (mime.includes('jpeg') || mime.includes('jpg')) imgType = 'jpg'
+  else if (mime.includes('gif')) imgType = 'gif'
+  else if (mime.includes('bmp')) imgType = 'bmp'
+
+  return [
+    new Paragraph({
+      children: [
+        new ImageRun({
+          data: buffer,
+          transformation: { width: dims.width, height: dims.height },
+          type: imgType,
+        }),
+      ],
+      ...(align ? { alignment: align } : {}),
+    }),
+  ]
+}
+
+/** Convert a file attachment node (signed download link, same as Markdown export). */
+function convertFileAttachment(node: MdNode, ctx: DocxContext): Paragraph {
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const resolved = attachId ? ctx.urls.get(attachId) : undefined
+  const name =
+    (typeof node.attrs?.fileName === 'string' && node.attrs.fileName) ||
+    resolved?.fileName ||
+    'attachment'
+
+  if (resolved?.url && isSafeHref(resolved.url)) {
+    return new Paragraph({
+      children: [
+        ...iconPrefix('📎'),
+        new ExternalHyperlink({
+          children: [
+            new TextRun({
+              text: name,
+              style: 'Hyperlink',
+              underline: { type: UnderlineType.SINGLE },
+              color: '1A73E8',
+            }),
+          ],
+          link: resolved.url,
+        }),
+      ],
+    })
+  }
+
+  return new Paragraph({
+    children: [
+      ...iconPrefix('📎'),
+      new TextRun({
+        text: name + ' (unavailable)',
+        italics: true,
+        color: '888888',
+      }),
+    ],
+  })
+}
+
+/** Convert a bookmark node. */
+function convertBookmark(node: MdNode): Paragraph {
+  const url = typeof node.attrs?.url === 'string' ? node.attrs.url : ''
+  const title = (typeof node.attrs?.title === 'string' && node.attrs.title) || url
+
+  if (url && isSafeHref(url)) {
+    return new Paragraph({
+      children: [
+        ...iconPrefix('🔗'),
+        new ExternalHyperlink({
+          children: [
+            new TextRun({
+              text: title,
+              style: 'Hyperlink',
+              underline: { type: UnderlineType.SINGLE },
+              color: '1A73E8',
+            }),
+          ],
+          link: url,
+        }),
+      ],
+    })
+  }
+
+  return new Paragraph({
+    children: [new TextRun({ text: title || '[bookmark]' })],
+  })
+}
+
+/** Callout variant → style mapping. */
+const CALLOUT_STYLES: Record<string, string> = {
+  info: 'CalloutInfo',
+  warn: 'CalloutWarn',
+  warning: 'CalloutWarn',
+  tip: 'CalloutTip',
+  success: 'CalloutSuccess',
+}
+
+/** Callout variant → emoji prefix (bare glyph; spacing added via iconPrefix). */
+const CALLOUT_EMOJI: Record<string, string> = {
+  info: 'ℹ️',
+  warn: '⚠️',
+  warning: '⚠️',
+  tip: '💡',
+  success: '✅',
+}
+
+/** Convert a callout node. */
+function convertCallout(node: MdNode, ctx: DocxContext): FileChild[] {
+  const variant = typeof node.attrs?.variant === 'string' ? node.attrs.variant : 'info'
+  const style = CALLOUT_STYLES[variant] ?? 'CalloutInfo'
+  const emoji = CALLOUT_EMOJI[variant] ?? 'ℹ️'
+  const children = node.content ?? []
+  const result: FileChild[] = []
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i]
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      // Prepend emoji to first paragraph
+      const prefix = i === 0 ? iconPrefix(emoji, { bold: true }) : []
+      result.push(
+        new Paragraph({
+          children: [...prefix, ...runs],
+          style,
+          indent: { left: 360 },
+        }),
+      )
+    } else {
+      result.push(...convertBlock(child, ctx, 0))
+    }
+  }
+
+  return result
+}
+
+/** Convert a block math node into a centered, native Word formula (OMML). */
+function convertBlockMath(node: MdNode): Paragraph {
+  const latex = typeof node.attrs?.latex === 'string' ? node.attrs.latex : ''
+  const math = latexToMathComponent(latex, true)
+  if (math) {
+    // Real OMML formula, rendered natively by Word.
+    return new Paragraph({
+      children: [math],
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 120, after: 120 },
+    })
+  }
+  // Fallback: conversion failed — keep the LaTeX source as monospace text so
+  // no content is lost (latexToMathComponent already logged the reason).
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: latex,
+        font: FONT_CODE,
+        italics: true,
+        size: 22,
+      }),
+    ],
+    alignment: AlignmentType.CENTER,
+    spacing: { before: 120, after: 120 },
+  })
+}
+
+/** Convert a details/collapsible node. */
+function convertDetails(node: MdNode, ctx: DocxContext): FileChild[] {
+  const children = node.content ?? []
+  const summaryNode = children.find((c) => c.type === 'detailsSummary')
+  const contentNode = children.find((c) => c.type === 'detailsContent')
+  const result: FileChild[] = []
+
+  // Summary as a bold paragraph with toggle indicator
+  if (summaryNode) {
+    const runs = convertInlineContent(summaryNode.content ?? [], ctx.emojiGlyph)
+    result.push(
+      new Paragraph({
+        children: [new TextRun({ text: '▸ ', bold: true }), ...runs],
+        spacing: { before: 80, after: 40 },
+      }),
+    )
+  }
+
+  // Content indented
+  const contentChildren = contentNode?.content ?? children.filter((c) => c.type !== 'detailsSummary')
+  for (const child of contentChildren) {
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      result.push(
+        new Paragraph({
+          children: runs,
+          indent: { left: 360 },
+        }),
+      )
+    } else {
+      result.push(...convertBlock(child, ctx, 0))
+    }
+  }
+
+  return result
+}

--- a/packages/docs/src/export/docx/numbering.test.ts
+++ b/packages/docs/src/export/docx/numbering.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for ordered-list numbering in DOCX export.
+ *
+ * Verifies:
+ *  - Two independent ordered lists each restart at 1 (not continuous counting).
+ *  - A list with explicit start > 1 begins at that value.
+ *  - Nested ordered lists restart independently at the correct level.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function ol(items: string[], start?: number): MdNode {
+  return {
+    type: 'orderedList',
+    ...(start ? { attrs: { start } } : {}),
+    content: items.map((t) => ({
+      type: 'listItem',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: t }] }],
+    })),
+  } as MdNode
+}
+
+function para(text: string): MdNode {
+  return { type: 'paragraph', content: [{ type: 'text', text }] } as MdNode
+}
+
+async function buildNumberingXml(content: MdNode[]) {
+  const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+  const children = convertBlocks(content, ctx)
+  const orderedLevels = NUMBERING_CONFIG.config[1].levels
+  const numbering = {
+    config: [
+      ...NUMBERING_CONFIG.config,
+      ...ctx.dynamicNumbering.map((dn) => ({
+        reference: dn.reference,
+        levels: orderedLevels.map((lvl) => (lvl.level === dn.level ? { ...lvl, start: dn.start } : lvl)),
+      })),
+    ],
+  }
+  const doc = new Document({ styles: DOCX_STYLES, numbering, sections: [{ children }] })
+  const buf = await Packer.toBuffer(doc)
+  const path = join(tmpdir(), `numbering-test-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  const numXml = execSync(`unzip -p ${path} word/numbering.xml`).toString()
+  const docXml = execSync(`unzip -p ${path} word/document.xml`).toString()
+  return { numXml, docXml, ctx }
+}
+
+/** For each numbered paragraph, resolve its numId → abstractNum → level[0] start value. */
+function resolveParagraphStarts(numXml: string, docXml: string): number[] {
+  // Map numId → abstractNumId
+  const numToAbstract = new Map<string, string>()
+  for (const m of numXml.matchAll(/<w:num w:numId="(\d+)">\s*<w:abstractNumId w:val="(\d+)"/g)) {
+    numToAbstract.set(m[1], m[2])
+  }
+  // Map abstractNumId → level0 start
+  const abstractLvl0Start = new Map<string, number>()
+  for (const m of numXml.matchAll(/<w:abstractNum w:abstractNumId="(\d+)"[\s\S]*?<w:lvl w:ilvl="0"[\s\S]*?<w:start w:val="(\d+)"/g)) {
+    abstractLvl0Start.set(m[1], Number(m[2]))
+  }
+  // Collect numId per numbered top-level paragraph (ilvl 0)
+  const starts: number[] = []
+  for (const m of docXml.matchAll(/<w:numPr>\s*<w:ilvl w:val="0"\/>\s*<w:numId w:val="(\d+)"/g)) {
+    const abs = numToAbstract.get(m[1])
+    if (abs) starts.push(abstractLvl0Start.get(abs) ?? 1)
+  }
+  return starts
+}
+
+describe('ordered list numbering', () => {
+  it('two independent lists each restart at 1 with distinct numbering instances', async () => {
+    const { numXml, docXml, ctx } = await buildNumberingXml([
+      ol(['a', 'b', 'c']),
+      para('gap'),
+      ol(['x', 'y']),
+    ])
+    // Each ordered list gets its own numbering instance (independent counting).
+    expect(ctx.orderedListInstance).toBe(2)
+    // The two lists reference distinct numIds so Word counts them separately.
+    const numIds = [...docXml.matchAll(/<w:numPr>\s*<w:ilvl w:val="0"\/>\s*<w:numId w:val="(\d+)"/g)].map((m) => m[1])
+    const list1 = numIds.slice(0, 3)
+    const list2 = numIds.slice(3, 5)
+    expect(new Set(list1).size).toBe(1) // list 1 items share one instance
+    expect(new Set(list2).size).toBe(1) // list 2 items share one instance
+    expect(list1[0]).not.toBe(list2[0]) // but the two lists differ
+    // Both start at 1.
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([1, 1, 1, 1, 1])
+  })
+
+  it('explicit start > 1 begins at that value', async () => {
+    const { numXml, docXml } = await buildNumberingXml([ol(['p', 'q'], 5)])
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([5, 5])
+  })
+
+  it('mixed: default list, then start=5 list — 1 and 5', async () => {
+    const { numXml, docXml } = await buildNumberingXml([
+      ol(['a', 'b', 'c']),
+      para('gap'),
+      ol(['p', 'q'], 5),
+    ])
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([1, 1, 1, 5, 5])
+  })
+
+  it('nested ordered list with start=3 begins at 3', async () => {
+    // bulletList > (item: para + orderedList(start=3))
+    const doc: MdNode = {
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [para('outer'), ol(['x', 'y'], 3)],
+        },
+      ],
+    } as MdNode
+    const { numXml } = await buildNumberingXml([doc])
+    // The nested start=3 list gets a dynamic reference whose level 1 starts at 3.
+    const dyn = [...numXml.matchAll(/<w:abstractNum[\s\S]*?<w:lvl w:ilvl="1"[\s\S]*?<w:start w:val="3"/g)]
+    expect(dyn.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/docs/src/export/docx/styles.ts
+++ b/packages/docs/src/export/docx/styles.ts
@@ -1,0 +1,217 @@
+/**
+ * Global style configuration for the DOCX export.
+ * Chinese font support: 微软雅黑 for body, 微软雅黑 bold for headings.
+ */
+
+import {
+  type IStylesOptions,
+  type IParagraphStyleOptions,
+  HeadingLevel,
+  AlignmentType,
+} from 'docx'
+
+/** Default font for body text. */
+export const FONT_BODY = '微软雅黑'
+
+/** Default font for headings. */
+export const FONT_HEADING = '微软雅黑'
+
+/** Monospace font for code. */
+export const FONT_CODE = 'Consolas'
+
+/** Fallback monospace fonts. */
+export const FONT_CODE_FALLBACK = 'Courier New'
+
+/**
+ * Emoji font. 微软雅黑 (the body font) has no emoji glyphs, so emoji inherit it
+ * and render as blank boxes in Word/WPS. Segoe UI Emoji is the standard Windows
+ * emoji font (used by WPS and Word on Windows); Word on macOS falls back to
+ * Apple Color Emoji automatically. Applying it only to emoji runs keeps CJK text
+ * on 微软雅黑.
+ */
+export const FONT_EMOJI = 'Segoe UI Emoji'
+
+/** Standard heading sizes in half-points. */
+const HEADING_SIZES: Record<string, number> = {
+  [HeadingLevel.HEADING_1]: 36, // 18pt
+  [HeadingLevel.HEADING_2]: 32, // 16pt
+  [HeadingLevel.HEADING_3]: 28, // 14pt
+  [HeadingLevel.HEADING_4]: 26, // 13pt
+  [HeadingLevel.HEADING_5]: 24, // 12pt
+  [HeadingLevel.HEADING_6]: 22, // 11pt
+}
+
+/** Create the default styles for the document. */
+export function createDefaultStyles(): NonNullable<IStylesOptions['default']> {
+  return {
+    document: {
+      run: {
+        font: FONT_BODY,
+        size: 24, // 12pt in half-points
+      },
+      paragraph: {
+        spacing: { after: 120, line: 276 },
+      },
+    },
+    heading1: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_1],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 240, after: 120 },
+      },
+    },
+    heading2: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_2],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 200, after: 100 },
+      },
+    },
+    heading3: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_3],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 160, after: 80 },
+      },
+    },
+    heading4: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_4],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 120, after: 60 },
+      },
+    },
+    heading5: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_5],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 100, after: 60 },
+      },
+    },
+    heading6: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_6],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 80, after: 40 },
+      },
+    },
+  }
+}
+
+/** Custom paragraph styles (e.g. code block, blockquote). */
+export function createParagraphStyles(): IParagraphStyleOptions[] {
+  return [
+    {
+      id: 'CodeBlock',
+      name: 'Code Block',
+      basedOn: 'Normal',
+      run: {
+        font: FONT_CODE,
+        size: 20, // 10pt
+      },
+      paragraph: {
+        spacing: { before: 60, after: 60, line: 240 },
+        shading: { fill: 'F5F5F5' },
+      },
+    },
+    {
+      id: 'BlockQuote',
+      name: 'Block Quote',
+      basedOn: 'Normal',
+      run: {
+        italics: true,
+        color: '555555',
+      },
+      paragraph: {
+        spacing: { before: 80, after: 80 },
+        indent: { left: 720 }, // 0.5 inch indent
+      },
+    },
+    {
+      id: 'CalloutInfo',
+      name: 'Callout Info',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'E8F4FD' },
+      },
+    },
+    {
+      id: 'CalloutWarn',
+      name: 'Callout Warning',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'FFF3CD' },
+      },
+    },
+    {
+      id: 'CalloutTip',
+      name: 'Callout Tip',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'D4EDDA' },
+      },
+    },
+    {
+      id: 'CalloutSuccess',
+      name: 'Callout Success',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'D4EDDA' },
+      },
+    },
+  ]
+}
+
+/** Create the full styles options for Document construction. */
+function createDocxStyles(): IStylesOptions {
+  return {
+    default: createDefaultStyles(),
+    paragraphStyles: createParagraphStyles(),
+  }
+}
+
+/** Module-level cached styles (pure static, no need to recreate per export). */
+export const DOCX_STYLES: IStylesOptions = createDocxStyles()
+
+/** Map heading level (1-6) to the docx AlignmentType equivalent. */
+export function mapTextAlign(align: unknown): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  if (typeof align !== 'string') return undefined
+  switch (align) {
+    case 'left':
+      return AlignmentType.LEFT
+    case 'center':
+      return AlignmentType.CENTER
+    case 'right':
+      return AlignmentType.RIGHT
+    case 'justify':
+      return AlignmentType.JUSTIFIED
+    default:
+      return undefined
+  }
+}

--- a/packages/docs/src/export/docx/table-layout.test.ts
+++ b/packages/docs/src/export/docx/table-layout.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for DOCX table export layout:
+ *  1. Column widths — columns are distributed evenly when the doc has no
+ *     explicit colwidth (Word's auto layout otherwise squeezes empty columns),
+ *     and explicit colwidth values are honored when present.
+ *  2. Repeating header row across page breaks (w:tblHeader).
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertTable } from './tables.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function makeCtx(): DocxContext {
+  return { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 } as DocxContext
+}
+
+async function exportXml(table: MdNode) {
+  const document = new Document({ sections: [{ children: [convertTable(table, makeCtx())] }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `tbl-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+function cell(text: string, attrs?: Record<string, unknown>, header = false): MdNode {
+  return {
+    type: header ? 'tableHeader' : 'tableCell',
+    attrs,
+    content: [{ type: 'paragraph', content: text ? [{ type: 'text', text }] : [] }],
+  } as MdNode
+}
+
+describe('DOCX table layout', () => {
+  it('distributes columns evenly when there is no explicit colwidth', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('列A', undefined, true), cell('列B', undefined, true), cell('列C', undefined, true)] },
+        { type: 'tableRow', content: [cell('很多很多内容占满一整行'), cell(''), cell('')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols.length).toBe(3)
+    // Even distribution: all three widths equal (fallbackEven), not content-based.
+    expect(new Set(gridCols).size).toBe(1)
+    expect(gridCols[0]).toBeGreaterThan(1000)
+  })
+
+  it('honors explicit colwidth values (wide vs narrow)', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('宽', { colwidth: [300] }, true), cell('窄', { colwidth: [100] }, true)] },
+        { type: 'tableRow', content: [cell('a', { colwidth: [300] }), cell('b', { colwidth: [100] })] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols.length).toBe(2)
+    // 300px*15 = 4500, 100px*15 = 1500
+    expect(gridCols[0]).toBe(4500)
+    expect(gridCols[1]).toBe(1500)
+    expect(gridCols[0]).toBeGreaterThan(gridCols[1])
+  })
+
+  it('marks the first header row to repeat on every page (w:tblHeader)', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('H1', undefined, true), cell('H2', undefined, true)] },
+        { type: 'tableRow', content: [cell('a'), cell('b')] },
+        { type: 'tableRow', content: [cell('c'), cell('d')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const headerCount = (xml.match(/<w:tblHeader/g) || []).length
+    // Exactly one row flagged as the repeating header.
+    expect(headerCount).toBe(1)
+  })
+
+  it('does not flag a header when the first row has no tableHeader cells', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('a'), cell('b')] },
+        { type: 'tableRow', content: [cell('c'), cell('d')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    expect((xml.match(/<w:tblHeader/g) || []).length).toBe(0)
+  })
+
+  it('uses fixed table layout so columns stay predictable', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [cell('a'), cell('b')] }],
+    } as MdNode
+    const xml = await exportXml(table)
+    expect(xml).toContain('w:type="fixed"')
+  })
+
+  it('maps column widths correctly when a cell spans multiple columns', async () => {
+    // Grid columns: [c0=200px, c1=100px, c2=100px]. First data row has a cell
+    // that spans c0+c1, then a normal cell for c2. The spanning cell must get
+    // the SUM of its covered columns' widths, and the following cell must not
+    // be shifted off by one.
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            cell('A', { colwidth: [200] }, true),
+            cell('B', { colwidth: [100] }, true),
+            cell('C', { colwidth: [100] }, true),
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [cell('span2', { colspan: 2 }), cell('c')],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    // Grid definition: 200*15=3000, 100*15=1500, 100*15=1500
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols).toEqual([3000, 1500, 1500])
+    // The spanning cell's own width (w:tcW) should be the sum of c0+c1 = 4500.
+    const tcW = [...xml.matchAll(/<w:tcW w:type="dxa" w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(tcW).toContain(4500)
+    // The spanning cell must also carry gridSpan=2.
+    expect(xml).toContain('<w:gridSpan w:val="2"')
+  })
+
+  it('does not overflow the page width when explicit widths already fill it', async () => {
+    // Two explicit wide columns (700px each = 10500 DXA) plus one column with no
+    // width. The missing column must not add a 600 minimum on top; with no
+    // remaining space it falls back to the small minimum (200).
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            cell('W1', { colwidth: [700] }, true),
+            cell('W2', { colwidth: [700] }, true),
+            cell('empty', undefined, true),
+          ],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols[0]).toBe(10500)
+    expect(gridCols[1]).toBe(10500)
+    // Missing column falls back to the small minimum (200), not 600.
+    expect(gridCols[2]).toBe(200)
+  })
+})

--- a/packages/docs/src/export/docx/tables.ts
+++ b/packages/docs/src/export/docx/tables.ts
@@ -1,0 +1,218 @@
+/**
+ * Table conversion for DOCX export.
+ * Supports merged cells (colspan/rowspan) via TableCell columnSpan/rowSpan properties.
+ */
+
+/** Hard cap on colspan/rowspan to prevent malicious/corrupt attrs from freezing the export. */
+const MAX_SPAN = 100
+
+/**
+ * Coerce a span attribute to a safe integer in [1, MAX_SPAN].
+ * `Number('')`/`Number('x')` yield NaN, and `?? 1` only guards null/undefined,
+ * so a non-numeric colspan/rowspan would otherwise collapse the grid; `|| 1`
+ * catches NaN/0 and falls back to a single span.
+ */
+function clampSpan(raw: unknown): number {
+  const n = Math.floor(Number(raw)) || 1
+  return Math.min(MAX_SPAN, Math.max(1, n))
+}
+
+import {
+  Table,
+  TableRow,
+  TableCell,
+  TableLayoutType,
+  Paragraph,
+  TextRun,
+  WidthType,
+  BorderStyle,
+  type ITableCellOptions,
+} from 'docx'
+import { convertInlineContent } from './marks.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/**
+ * Convert a table node to a docx Table element.
+ * Handles colspan and rowspan via columnSpan/rowSpan on TableCell.
+ */
+export function convertTable(node: MdNode, ctx: DocxContext): Table {
+  const rows = node.content ?? []
+
+  // Derive per-column widths (in DXA/twips). Always returns a full array so
+  // fixed layout produces even columns even when the doc has no explicit widths.
+  const columnWidths = deriveColumnWidths(rows)
+
+  const tableRows = rows.map((row, rowIdx) => {
+    // Track the grid-column index so cell widths map to the right columns even
+    // when earlier cells span multiple columns (colIdx alone is the in-row cell
+    // index, not the grid column).
+    let gridCol = 0
+    const cells = (row.content ?? []).map((cell) => {
+      const span = clampSpan(cell.attrs?.colspan)
+      // A spanning cell's width is the sum of the grid columns it covers.
+      let widthDxa = 0
+      for (let i = 0; i < span; i++) widthDxa += columnWidths[gridCol + i] ?? 0
+      gridCol += span
+      return convertTableCell(cell, ctx, widthDxa)
+    })
+    // Repeat the first row as a header on every page when it is a header row.
+    const isHeaderRow =
+      rowIdx === 0 && (row.content ?? []).some((c) => c.type === 'tableHeader')
+    return new TableRow({ children: cells, tableHeader: isHeaderRow || undefined })
+  })
+
+  return new Table({
+    rows: tableRows,
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    // Fixed layout honors explicit column widths. When the doc has explicit
+    // widths we use them; otherwise we distribute the page width evenly so
+    // columns don't collapse to their content (Word's auto layout squeezes
+    // empty columns). Either way fixed layout gives predictable, even columns.
+    columnWidths,
+    layout: TableLayoutType.FIXED,
+    borders: {
+      top: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      bottom: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      left: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      right: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      insideHorizontal: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      insideVertical: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+    },
+  })
+}
+
+/**
+ * Convert a single table cell (tableCell or tableHeader) node.
+ */
+function convertTableCell(
+  cell: MdNode,
+  ctx: DocxContext,
+  columnWidthDxa?: number,
+): TableCell {
+  const colspan = clampSpan(cell.attrs?.colspan)
+  const rowspan = clampSpan(cell.attrs?.rowspan)
+  const isHeader = cell.type === 'tableHeader'
+
+  // Cell width: use the resolved column width so fixed layout stays even.
+  const cellWidthDxa =
+    Number.isFinite(columnWidthDxa) && (columnWidthDxa as number) > 0
+      ? Math.round(columnWidthDxa as number)
+      : undefined
+
+  // Convert cell content — cells contain block content (paragraphs, etc.)
+  const paragraphs = convertCellContent(cell.content ?? [], ctx)
+
+  // Ensure at least one paragraph (docx requires it)
+  if (paragraphs.length === 0) {
+    paragraphs.push(new Paragraph({ children: [] }))
+  }
+
+  const cellOptions: ITableCellOptions = {
+    children: paragraphs,
+    columnSpan: colspan > 1 ? colspan : undefined,
+    rowSpan: rowspan > 1 ? rowspan : undefined,
+    ...(cellWidthDxa ? { width: { size: cellWidthDxa, type: WidthType.DXA } } : {}),
+    ...(isHeader ? { shading: { fill: 'F0F0F0' } } : {}),
+  }
+
+  return new TableCell(cellOptions)
+}
+
+/**
+ * Derive per-column widths (in DXA/twips). Reads explicit ProseMirror
+ * `colwidth` (px) when present; any column without an explicit width gets an
+ * even share of the remaining page width. Always returns a full array so the
+ * table can use fixed layout with evenly distributed columns (Word's auto
+ * layout otherwise squeezes empty columns to near-zero).
+ */
+function deriveColumnWidths(rows: MdNode[]): number[] {
+  const firstRow = rows[0]
+  const cells = firstRow?.content ?? []
+
+  // Usable content width for A4 portrait with ~1in margins ≈ 9026 twips.
+  const PAGE_CONTENT_DXA = 9026
+
+  // Expand colspans so the array is one entry per grid column.
+  const explicit: (number | null)[] = []
+  for (const cell of cells) {
+    const span = clampSpan(cell.attrs?.colspan)
+    const cw = Array.isArray(cell.attrs?.colwidth) ? cell.attrs?.colwidth : null
+    for (let i = 0; i < span; i++) {
+      const raw = cw ? Number(cw[i]) : NaN
+      explicit.push(Number.isFinite(raw) && raw > 0 ? Math.round(raw * 15) : null)
+    }
+  }
+
+  const colCount = explicit.length || 1
+  const explicitSum = explicit.reduce<number>((s, w) => s + (w ?? 0), 0)
+  const missing = explicit.filter((w) => w === null).length
+
+  if (missing > 0) {
+    // Distribute the remaining page width across columns without an explicit
+    // width. Guard against overflow: if explicit widths already fill/exceed the
+    // page, fall back to a small minimum so the total stays near the page width
+    // instead of blowing past the margin (fixed layout would otherwise clip).
+    const remaining = PAGE_CONTENT_DXA - explicitSum
+    const evenShare = remaining > 0 ? Math.round(remaining / missing) : 0
+    const MIN_COL = 200
+    const share = Math.max(MIN_COL, evenShare)
+    return explicit.map((w) => w ?? share)
+  }
+
+  // No explicit widths: split the page evenly across all grid columns.
+  const fallbackEven = Math.round(PAGE_CONTENT_DXA / colCount)
+  return explicit.map((w) => w ?? fallbackEven)
+}
+
+/**
+ * Convert cell content (usually paragraphs) into Paragraph elements.
+ */
+function convertCellContent(nodes: MdNode[], ctx: DocxContext): Paragraph[] {
+  const paragraphs: Paragraph[] = []
+
+  for (const node of nodes) {
+    if (node.type === 'paragraph') {
+      const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+      paragraphs.push(
+        new Paragraph({
+          children: runs,
+          spacing: { before: 40, after: 40 },
+        }),
+      )
+    } else if (node.type === 'bulletList' || node.type === 'orderedList') {
+      // Flatten nested lists in cells into paragraphs with bullet/number prefix
+      const items = node.content ?? []
+      items.forEach((item, idx) => {
+        const prefix = node.type === 'orderedList' ? `${idx + 1}. ` : '• '
+        // Extract inline content from the first paragraph inside the list item
+        const firstPara = (item.content ?? []).find((c) => c.type === 'paragraph')
+        const runs = firstPara
+          ? [new TextRun({ text: prefix }), ...convertInlineContent(firstPara.content ?? [], ctx.emojiGlyph)]
+          : [new TextRun({ text: prefix + extractPlainText(item) })]
+        paragraphs.push(
+          new Paragraph({
+            children: runs,
+            spacing: { before: 20, after: 20 },
+          }),
+        )
+      })
+    } else {
+      // For other block types in cells, extract text content
+      const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+      if (runs.length > 0) {
+        paragraphs.push(new Paragraph({ children: runs }))
+      }
+    }
+  }
+
+  return paragraphs
+}
+
+/**
+ * Extract plain text from a node tree (for simplified table cell content).
+ */
+function extractPlainText(node: MdNode): string {
+  if (node.text) return node.text
+  if (!node.content) return ''
+  return node.content.map(extractPlainText).join('')
+}

--- a/packages/docs/src/export/docx/task-list.test.ts
+++ b/packages/docs/src/export/docx/task-list.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for task list (checkbox list) export in DOCX.
+ *
+ * Task items must export as REAL interactive Word checkboxes (docx CheckBox =
+ * a w:sdt content control with w14:checkbox), so they can be clicked/toggled in
+ * Word regardless of their initial checked state — not static ☑/☐ glyphs.
+ *
+ * Also a regression guard for the old "two boxes + double space" bug: exactly
+ * one checkbox per item, no duplicated bullet from list numbering.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function taskList(items: { text: string; checked: boolean }[]): MdNode {
+  return {
+    type: 'taskList',
+    content: items.map((it) => ({
+      type: 'taskItem',
+      attrs: { checked: it.checked },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: it.text }] }],
+    })),
+  } as MdNode
+}
+
+async function exportXml(content: MdNode[]) {
+  const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+  const children = convertBlocks(content, ctx)
+  const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `task-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+const count = (s: string, sub: string) => s.split(sub).length - 1
+
+describe('task list export', () => {
+  it('every item is an interactive checkbox content control (w:sdt + w14:checkbox)', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: '完成的任务', checked: true },
+        { text: '未完成的任务', checked: false },
+      ]),
+    ])
+    // Both items must be real toggleable Word checkboxes, not static glyphs.
+    expect(count(xml, '<w14:checkbox>')).toBe(2)
+    expect(count(xml, '<w:sdt>')).toBe(2)
+  })
+
+  it('checked vs unchecked initial state is preserved', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: '完成的任务', checked: true },
+        { text: '未完成的任务', checked: false },
+      ]),
+    ])
+    // Checked box → w14:checked val="1"; unchecked → val="0". Checked state renders
+    // a check mark ☑ (2611), NOT an X ☒ (2612).
+    expect(xml).toContain('<w14:checked w14:val="1"/>')
+    expect(xml).toContain('<w14:checked w14:val="0"/>')
+    expect(xml).toContain('w14:val="2611"')
+    expect(xml).not.toContain('w14:val="2612"')
+    // Both remain interactive regardless of initial state (same content-control markup).
+    expect(count(xml, 'w14:checkbox')).toBeGreaterThanOrEqual(2)
+  })
+
+  it('exactly one checkbox per item — no duplicate boxes', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: 'a', checked: true },
+        { text: 'b', checked: false },
+        { text: 'c', checked: false },
+      ]),
+    ])
+    // 3 items → exactly 3 checkbox content controls, no extra bullet boxes.
+    expect(count(xml, '<w14:checkbox>')).toBe(3)
+    // No leftover static glyphs.
+    expect(xml).not.toContain('☑')
+    expect(xml).not.toContain('☐')
+  })
+
+  it('nested task list keeps its own interactive checkboxes', async () => {
+    const nested: MdNode = {
+      type: 'taskList',
+      content: [
+        {
+          type: 'taskItem',
+          attrs: { checked: false },
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: '父任务' }] },
+            taskList([
+              { text: '子任务已完成', checked: true },
+              { text: '子任务未完成', checked: false },
+            ]),
+          ],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml([nested])
+    // parent + 2 children = 3 checkboxes
+    expect(count(xml, '<w14:checkbox>')).toBe(3)
+    expect(xml).toContain('<w14:checked w14:val="1"/>')
+    expect(xml).toContain('<w14:checked w14:val="0"/>')
+  })
+})

--- a/packages/docs/src/export/docx/types.ts
+++ b/packages/docs/src/export/docx/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Type definitions for the DOCX export module.
+ * Re-exports the MdNode interface from markdown.ts for consistency.
+ */
+
+import type { MdNode } from '../markdown.ts'
+import type { ResolvedAttachment } from '../../attachments/api.ts'
+
+export type { MdNode }
+
+/** Options for the DOCX export function. */
+export interface DocxExportOptions {
+  /** Batch size for the resolve endpoint (RES-1 cap). Default 200. */
+  batchSize?: number
+  /** Resolve fn injection point (tests pass a stub). Defaults to the real REST client. */
+  resolve?: (docId: string, attachIds: string[]) => Promise<{ items: ResolvedAttachment[]; notFound: string[] }>
+  /** name → unicode glyph for emoji nodes; defaults to the editor's emoji map. */
+  emojiGlyph?: (name: string | null | undefined) => string | undefined
+}
+
+/** Internal context passed through the node/mark converters. */
+export interface DocxContext {
+  /** Resolved attachment URLs keyed by attachId. */
+  urls: Map<string, ResolvedAttachment>
+  /** Fetched image buffers keyed by URL. */
+  imageBuffers: Map<string, ArrayBuffer>
+  /** Emoji glyph resolver. */
+  emojiGlyph?: (name: string | null | undefined) => string | undefined
+  /**
+   * Dynamic numbering references for ordered lists whose start > 1.
+   * docx derives an instance's starting number from its abstract level[0].start,
+   * so a non-default start needs its own reference with a customized level set.
+   */
+  dynamicNumbering: Array<{ reference: string; start: number; level: number }>
+  /** Monotonic counter handing each ordered list its own numbering instance (independent counting). */
+  orderedListInstance: number
+}
+
+/** Represents a collected image reference that needs to be fetched. */
+export interface ImageRef {
+  attachId?: string
+  src?: string
+  resolvedUrl?: string
+}

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -79,8 +79,11 @@
     "members": "Members",
     "more": "More",
     "exportMarkdown": "Export as Markdown",
+    "exportDocx": "Export as Word",
+    "exportPdf": "Export as PDF",
     "exportError": "Couldn't export this document. Please try again.",
-    "exportSignedLinkNotice": "Note: images and attachments are signed links and may expire. Once expired, reopen the source document to fetch them again, or download them manually."
+    "export": "Export",
+    "exportSignedLinkNotice": "This document contains shared links — please verify access permissions"
   },
   "slash": {
     "groupBasic": "Basic",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -79,8 +79,11 @@
     "members": "成员",
     "more": "更多",
     "exportMarkdown": "导出为 Markdown",
+    "exportDocx": "导出为 Word",
+    "exportPdf": "导出为 PDF",
     "exportError": "导出文档失败，请重试。",
-    "exportSignedLinkNotice": "注意：图片/附件为签名链接，可能过期；过期后请回原文档重新获取或手动下载。"
+    "export": "导出",
+    "exportSignedLinkNotice": "此文档包含共享链接，请注意访问权限"
   },
   "slash": {
     "groupBasic": "基础",

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -5,6 +5,7 @@
 // header; no auth code here.
 
 import { apiClient } from '../octoweb/index.ts'
+import axios from 'axios'
 import type { Role } from '../auth/roles.ts'
 
 export interface DocListItem {
@@ -149,6 +150,28 @@ export async function updateDocTitle(docId: string, title: string): Promise<DocM
  */
 export async function deleteDoc(docId: string): Promise<void> {
   await apiClient().delete(`/docs/${docId}`)
+}
+
+/**
+ * POST /api/v1/docs/{docId}/export/pdf — server-side (Puppeteer) PDF render.
+ * Returns the PDF bytes as an ArrayBuffer.
+ *
+ * IMPORTANT: this goes DIRECTLY through axios (not the shared WKApp APIClient
+ * wrapper). The wrapper's `post()` hard-codes an empty axios config (`{}`) and
+ * drops `responseType`, so a binary PDF response gets decoded as UTF-8 text —
+ * every non-ASCII byte becomes U+FFFD (0xEFBFBD), corrupting the file into a
+ * blank/broken PDF. axios already has the global request interceptor that
+ * injects the `token` + `X-Space-Id` headers and the `/api/v1/` baseURL, so a
+ * direct `axios.post` still authenticates correctly — we just get to set
+ * `responseType: 'arraybuffer'` and receive the raw bytes intact.
+ */
+export async function exportDocPdf(docId: string): Promise<ArrayBuffer> {
+  const res = await axios.post<ArrayBuffer>(
+    `/docs/${docId}/export/pdf`,
+    undefined,
+    { responseType: 'arraybuffer' },
+  )
+  return res.data
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 1.59.1
       '@storybook/addon-vitest':
         specifier: ^10.3.3
-        version: 10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
+        version: 10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -58,7 +58,7 @@ importers:
         version: 13.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+        version: 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -67,7 +67,7 @@ importers:
         version: 0.0.0(eslint@7.32.0)(typescript@5.9.3)
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       prettier:
         specifier: ^2.5.1
         version: 2.8.8
@@ -85,7 +85,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   apps/extension:
     dependencies:
@@ -134,10 +134,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@wxt-dev/auto-icons':
         specifier: ^1.1.1
-        version: 1.1.1(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
+        version: 1.1.1(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
       '@wxt-dev/module-react':
         specifier: ^1.1.5
-        version: 1.2.2(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
+        version: 1.2.2(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -146,10 +146,10 @@ importers:
         version: 0.10.4
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
       wxt:
         specifier: ^0.20.20
-        version: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+        version: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
 
   apps/web:
     dependencies:
@@ -542,7 +542,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworkcontacts:
     dependencies:
@@ -576,7 +576,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworkdatasource:
     dependencies:
@@ -625,10 +625,10 @@ importers:
         version: 4.4.5
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworksummary:
     dependencies:
@@ -823,6 +823,12 @@ importers:
       '@univerjs/preset-sheets-core':
         specifier: 0.25.1
         version: 0.25.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)
+      axios:
+        specifier: ^0.25.0
+        version: 0.25.0
+      docx:
+        specifier: ^9.7.1
+        version: 9.7.1
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -832,9 +838,15 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      mathjax-full:
+        specifier: ^3.2.2
+        version: 3.2.2
       xlsx-js-style:
         specifier: ^1.2.0
         version: 1.2.0
+      xml-js:
+        specifier: ^1.6.11
+        version: 1.6.11
       y-indexeddb:
         specifier: 9.0.12
         version: 9.0.12(yjs@13.6.21)
@@ -868,7 +880,7 @@ importers:
         version: 6.0.0
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -880,7 +892,7 @@ importers:
         version: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/eslint-config-custom:
     dependencies:
@@ -895,7 +907,7 @@ importers:
         version: 8.10.2(eslint@7.32.0)
       eslint-config-turbo:
         specifier: latest
-        version: 2.10.3(eslint@7.32.0)(turbo@2.2.1)
+        version: 2.9.5(eslint@7.32.0)(turbo@2.2.1)
       eslint-plugin-react:
         specifier: 7.28.0
         version: 7.28.0(eslint@7.32.0)
@@ -2309,10 +2321,6 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
-    engines: {node: '>= 20.19.0'}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2390,8 +2398,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@radix-ui/primitive@1.1.4':
-    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
 
   '@radix-ui/react-arrow@1.1.11':
     resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
@@ -2406,8 +2414,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-collection@1.1.11':
-    resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2428,8 +2436,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context@1.1.4':
-    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2437,8 +2445,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dialog@1.1.18':
-    resolution: {integrity: sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==}
+  '@radix-ui/react-dialog@1.1.19':
+    resolution: {integrity: sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2459,8 +2467,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dismissable-layer@1.1.14':
-    resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
+  '@radix-ui/react-dismissable-layer@1.1.15':
+    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2472,8 +2480,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.19':
-    resolution: {integrity: sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==}
+  '@radix-ui/react-dropdown-menu@2.1.20':
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2494,8 +2502,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.11':
-    resolution: {integrity: sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==}
+  '@radix-ui/react-focus-scope@1.1.12':
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2507,8 +2515,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-hover-card@1.1.18':
-    resolution: {integrity: sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==}
+  '@radix-ui/react-hover-card@1.1.19':
+    resolution: {integrity: sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2529,8 +2537,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-menu@2.1.19':
-    resolution: {integrity: sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==}
+  '@radix-ui/react-menu@2.1.20':
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2542,8 +2550,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popover@1.1.18':
-    resolution: {integrity: sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==}
+  '@radix-ui/react-popover@1.1.19':
+    resolution: {integrity: sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2555,8 +2563,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popper@1.3.2':
-    resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
+  '@radix-ui/react-popper@1.3.3':
+    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2581,8 +2589,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-presence@1.1.6':
-    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2607,8 +2615,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-roving-focus@1.1.14':
-    resolution: {integrity: sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==}
+  '@radix-ui/react-roving-focus@1.1.15':
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2662,6 +2670,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3705,6 +3722,9 @@ packages:
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
+  '@types/node@25.9.4':
+    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
   '@types/pako@1.0.7':
     resolution: {integrity: sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==}
 
@@ -4161,6 +4181,10 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -4805,6 +4829,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@2.14.1:
     resolution: {integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==}
 
@@ -5141,6 +5169,10 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  docx@9.7.1:
+    resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
+    engines: {node: '>=10'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -5407,8 +5439,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-config-turbo@2.10.3:
-    resolution: {integrity: sha512-P509ALgsf9fA8hxUVuF6MFZdcE2CAdEZIiUq9eHIm8h58u4us0qUZ5SPTxWOQjX+in5vfikXfX4qBrP2Tx//EA==}
+  eslint-config-turbo@2.9.5:
+    resolution: {integrity: sha512-MwAmBEge6WOONTll4BAI1ZbbtD4PrhEaumcu6MNIdrwygMXw2Ne2eV8wxVpj6cnPgyUNE6iS6WdOoi/vPI4YFg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5511,8 +5543,8 @@ packages:
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
 
-  eslint-plugin-turbo@2.10.3:
-    resolution: {integrity: sha512-R6aIYTa0bqxPn1IhAom3/zIJF9lPChAq+o7cywdEY8GxPnktGMW04P6oFCrg/V3zvhtF4+n1d5Og2r0GqrBtQA==}
+  eslint-plugin-turbo@2.9.5:
+    resolution: {integrity: sha512-mwsR2dVy35crMS39TKSKG1xMxfn9M9t/sHXg70GAVqJxoFhsmM1XOcVGQ5w2z7GFUuMP70xUcpSendFzyuuSlQ==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5549,6 +5581,10 @@ packages:
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
 
   espree@7.3.1:
     resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
@@ -6015,6 +6051,9 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
@@ -6957,6 +6996,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mathjax-full@3.2.2:
+    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
+
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
@@ -7076,6 +7119,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
 
   micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
@@ -7310,6 +7356,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7375,6 +7424,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mj-context-menu@0.6.1:
+    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -7422,6 +7474,11 @@ packages:
 
   nanoid@5.1.11:
     resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -8746,6 +8803,10 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
+    hasBin: true
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -9239,6 +9300,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
@@ -9639,6 +9703,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
@@ -9730,6 +9797,10 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -9737,6 +9808,9 @@ packages:
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
@@ -11385,9 +11459,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
-    optionalDependencies:
-      '@noble/hashes': 2.2.0
+  '@exodus/bytes@1.15.0': {}
 
   '@fast-csv/format@4.3.5':
     dependencies:
@@ -11710,9 +11782,6 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
-  '@noble/hashes@2.2.0':
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11784,7 +11853,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@radix-ui/primitive@1.1.4': {}
+  '@radix-ui/primitive@1.1.5': {}
 
   '@radix-ui/react-arrow@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11795,10 +11864,10 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-collection@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11813,23 +11882,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-context@1.1.4(@types/react@18.3.28)(react@18.3.1)':
+  '@radix-ui/react-context@1.2.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-dialog@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dialog@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
@@ -11847,9 +11916,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
@@ -11860,13 +11929,13 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-dropdown-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11881,7 +11950,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-focus-scope@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11892,15 +11961,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-hover-card@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-hover-card@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11916,22 +11985,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-menu@2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
@@ -11942,18 +12011,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popover@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popover@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
@@ -11965,12 +12034,12 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popper@1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popper@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-arrow': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
@@ -11993,7 +12062,7 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -12011,17 +12080,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-roving-focus@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -12061,6 +12132,12 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
@@ -12354,21 +12431,21 @@ snapshots:
       '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)':
+  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -13110,11 +13187,12 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
-  '@types/estree@1.0.9': {}
+  '@types/estree@1.0.9':
+    optional: true
 
   '@types/filesystem@0.0.36':
     dependencies:
@@ -13184,6 +13262,10 @@ snapshots:
   '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@25.9.4':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/pako@1.0.7': {}
 
@@ -13272,7 +13354,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
     optional: true
 
   '@types/zxcvbn@4.4.5': {}
@@ -13481,11 +13563,11 @@ snapshots:
 
   '@univerjs/design@0.25.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dropdown-menu': 2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-hover-card': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popover': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-separator': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@univerjs/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13726,13 +13808,18 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
 
+  '@vitejs/plugin-react@6.0.1(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+
   '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13746,7 +13833,21 @@ snapshots:
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13762,7 +13863,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13780,7 +13881,25 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13828,6 +13947,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+
+  '@vitest/mocker@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -13908,23 +14035,23 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@wxt-dev/auto-icons@1.1.1(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
+  '@wxt-dev/auto-icons@1.1.1(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
     dependencies:
       defu: 6.1.7
       fs-extra: 11.3.4
       sharp: 0.34.5
-      wxt: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+      wxt: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
 
   '@wxt-dev/browser@0.1.40':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
+  '@wxt-dev/module-react@1.2.2(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
     dependencies:
-      '@vitejs/plugin-react': 6.0.1(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
-      wxt: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+      '@vitejs/plugin-react': 6.0.1(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      wxt: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -13936,6 +14063,8 @@ snapshots:
       dequal: 2.0.3
 
   '@xmldom/xmldom@0.8.12': {}
+
+  '@xmldom/xmldom@0.9.10': {}
 
   abbrev@1.1.1:
     optional: true
@@ -14705,6 +14834,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@13.1.0: {}
+
   commander@2.14.1: {}
 
   commander@2.17.1: {}
@@ -14865,10 +14996,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0(@noble/hashes@2.2.0):
+  data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -15050,6 +15181,15 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  docx@9.7.1:
+    dependencies:
+      '@types/node': 25.9.4
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.16
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   dom-accessibility-api@0.5.16: {}
 
@@ -15486,10 +15626,10 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-turbo@2.10.3(eslint@7.32.0)(turbo@2.2.1):
+  eslint-config-turbo@2.9.5(eslint@7.32.0)(turbo@2.2.1):
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 2.10.3(eslint@7.32.0)(turbo@2.2.1)
+      eslint-plugin-turbo: 2.9.5(eslint@7.32.0)(turbo@2.2.1)
       turbo: 2.2.1
 
   eslint-import-resolver-node@0.3.10:
@@ -15689,7 +15829,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-turbo@2.10.3(eslint@7.32.0)(turbo@2.2.1):
+  eslint-plugin-turbo@2.9.5(eslint@7.32.0)(turbo@2.2.1):
     dependencies:
       dotenv: 16.0.3
       eslint: 7.32.0
@@ -15759,6 +15899,8 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esm@3.2.25: {}
+
   espree@7.3.1:
     dependencies:
       acorn: 7.4.1
@@ -15781,7 +15923,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -15794,7 +15936,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -15812,7 +15954,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -16274,6 +16416,11 @@ snapshots:
   has-unicode@2.0.1:
     optional: true
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hashery@1.5.1:
     dependencies:
       hookified: 1.15.1
@@ -16338,7 +16485,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -16359,7 +16506,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -16441,9 +16588,9 @@ snapshots:
 
   howler@2.2.4: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+  html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16795,17 +16942,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.2(@noble/hashes@2.2.0):
+  jsdom@29.0.2:
     dependencies:
       '@asamuzakjp/css-color': 5.1.8
       '@asamuzakjp/dom-selector': 7.0.8
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      data-urls: 7.0.0
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.2
       parse5: 8.0.0
@@ -16816,7 +16963,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      whatwg-url: 16.0.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -17253,6 +17400,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mathjax-full@3.2.2:
+    dependencies:
+      esm: 3.2.25
+      mhchemparser: 4.2.1
+      mj-context-menu: 0.6.1
+      speech-rule-engine: 4.1.4
+
   mathml-tag-names@4.0.0: {}
 
   md5-typescript@1.0.5: {}
@@ -17554,6 +17708,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  mhchemparser@4.2.1: {}
+
   micromark-core-commonmark@1.1.0:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -17720,7 +17876,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -17731,7 +17887,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -17748,7 +17904,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -17797,7 +17953,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -17913,7 +18069,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -18045,6 +18201,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -18112,6 +18270,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mj-context-menu@0.6.1: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -18151,6 +18311,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.11: {}
+
+  nanoid@5.1.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -19197,7 +19359,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -19212,14 +19374,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -19308,7 +19470,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -19838,6 +20000,12 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
+
+  speech-rule-engine@4.1.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      commander: 13.1.0
+      wicked-good-xpath: 1.3.0
 
   split2@4.2.0: {}
 
@@ -20450,6 +20618,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.24.6: {}
+
   undici@7.24.7: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -20730,13 +20900,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@6.0.0(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1):
+  vite-node@6.0.0(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1):
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -20774,12 +20944,12 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20810,7 +20980,20 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)):
+  vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.4
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
@@ -20835,12 +21018,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
     optional: true
 
-  vitest@4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
+  vitest@4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
@@ -20865,7 +21048,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.21
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.4
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
 
@@ -20922,9 +21134,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+  whatwg-url@16.0.1:
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -21003,6 +21215,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wicked-good-xpath@1.3.0: {}
+
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
@@ -21071,7 +21285,7 @@ snapshots:
       curve25519-js: 0.0.4
       md5-typescript: 1.0.5
 
-  wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0):
+  wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.62.0)
@@ -21114,8 +21328,8 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.16
       unimport: 6.0.2
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
-      vite-node: 6.0.0(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      vite-node: 6.0.0(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
       web-ext-run: 0.2.4
     optionalDependencies:
       eslint: 7.32.0
@@ -21160,12 +21374,18 @@ snapshots:
       wmf: 1.0.2
       word: 0.3.0
 
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
   xml-name-validator@5.0.0: {}
 
   xml2js@0.6.2:
     dependencies:
       sax: 1.6.0
       xmlbuilder: 11.0.1
+
+  xml@1.0.1: {}
 
   xmlbuilder@11.0.1: {}
 


### PR DESCRIPTION
## Summary

Add DOCX export functionality for Octo Docs with comprehensive security hardening.

- DOCX export with math (MathML→OMML), emoji, task lists, tables
- Security: href scheme allowlist, UNC bypass block, image fetch gating on safe schemes
- Restored main-branch safety code (XSS sanitization, axios timeout, error adapter)
- Removed dead client-side PDF/print export code (~2500 lines + 2.5MB fonts)
- Export menu component combining Markdown/DOCX/PDF export

## Linked Spec

Refs Mininglamp-OSS/octo-server#504

## How verified

- All existing tests pass (findReplace atom-break sentinel, FileAttachment NodeSelection guard preserved)
- DOCX export unit tests: math, emoji, task-list, numbering, table-layout, attachment, images
- Security tests: href scheme allowlist, UNC bypass, image fetch gating
- Rebased cleanly onto latest main (93659b58)
- No regressions to markdown.ts XSS sanitization, APIClient timeout, or octoweb error handling