### PR TITLE
fix(docs): drop the token-bucket ?sid from the three doc share links

### DIFF
--- a/apps/web/src/Layout/__tests__/recoverSession.test.ts
+++ b/apps/web/src/Layout/__tests__/recoverSession.test.ts
@@ -3,6 +3,7 @@ import {
   findStoredSession,
   findStoredSessions,
   findUniqueStoredSession,
+  findSameIdentityStoredSession,
   findSidForToken,
   adoptStoredSession,
   sidsForToken,
@@ -276,6 +277,99 @@ describe('adoptStoredSession — persist gating never pins a guessed identity (X
     const afterBackReload = new FakeLoginInfo(store, '')
     afterBackReload.load()
     expect(afterBackReload.token).toBe('octo-session-xyz')
+  })
+})
+
+describe('findSameIdentityStoredSession — one person, several buckets (XIN-519 blocker 2, decision B)', () => {
+  it('returns the first bucket when several buckets all share one non-empty uid', () => {
+    // The real-device multi-space case: one account signed in across two spaces leaves two random-sid
+    // buckets, both with the SAME uid.
+    const storage = makeStorage({
+      tokeni1mw4h: 'tok-space-a',
+      uidi1mw4h: 'u_same',
+      namei1mw4h: 'Ada',
+      tokenx519b: 'tok-space-b',
+      uidx519b: 'u_same',
+      namex519b: 'Ada',
+    })
+    expect(findSameIdentityStoredSession(storage)).toEqual({
+      token: 'tok-space-a',
+      uid: 'u_same',
+      name: 'Ada',
+    })
+  })
+
+  it('returns null when several buckets span DIFFERENT uids (genuinely ambiguous identity)', () => {
+    const storage = makeStorage({
+      tokenA: 'tok-a',
+      uidA: 'u_a',
+      tokenB: 'tok-b',
+      uidB: 'u_b',
+    })
+    expect(findSameIdentityStoredSession(storage)).toBeNull()
+  })
+
+  it('returns null for a single bucket (that is the unique-session case) and for none', () => {
+    expect(
+      findSameIdentityStoredSession(makeStorage({ tokenabc: 'only', uidabc: 'u_1' })),
+    ).toBeNull()
+    expect(findSameIdentityStoredSession(makeStorage({ currentSpaceId: 's_1' }))).toBeNull()
+  })
+
+  it('returns null when the shared uid is empty (cannot confirm same identity)', () => {
+    // Two token buckets, neither with a uid sibling: we cannot assert they are the same person, so we
+    // do NOT recover (falls through to login) rather than guess.
+    const storage = makeStorage({ tokenA: 'tok-a', tokenB: 'tok-b' })
+    expect(findSameIdentityStoredSession(storage)).toBeNull()
+  })
+})
+
+describe('adoptStoredSession — same-identity multi-bucket recovery, in memory only (XIN-519 blocker 2)', () => {
+  it('persist:true with several SAME-uid buckets adopts the first in memory but does NOT persist it', () => {
+    // One person, two spaces → two random-sid buckets, same uid. A sid-less /d/:docId cold load must
+    // recover (not bounce to login), but must NOT pin the pick into the cross-tab empty-sid slot.
+    const store = new Map<string, string>([
+      ['tokeni1mw4h', 'tok-space-a'],
+      ['uidi1mw4h', 'u_same'],
+      ['namei1mw4h', 'Ada'],
+      ['tokenx519b', 'tok-space-b'],
+      ['uidx519b', 'u_same'],
+      ['namex519b', 'Ada'],
+    ])
+    const onDeepLink = new FakeLoginInfo(store, '')
+    onDeepLink.load()
+    expect(onDeepLink.token).toBe('') // sid-less load misses → would bounce to login without recovery
+
+    expect(adoptStoredSession(onDeepLink, storageOver(store), { persist: true })).toBe(true)
+    expect(onDeepLink.token).toBe('tok-space-a') // recovered in memory → the doc opens
+    expect(onDeepLink.uid).toBe('u_same')
+
+    // NOT persisted: the empty-sid slot stays empty, so no multi-bucket pick is mirrored cross-tab.
+    expect(store.has('token')).toBe(false)
+    // A Back → /docs reload re-runs the same same-identity recovery, so the user stays authenticated
+    // across it without ever having pinned an identity into the shared slot.
+    const afterBackReload = new FakeLoginInfo(store, '')
+    afterBackReload.load()
+    expect(afterBackReload.token).toBe('') // empty-sid slot untouched
+    expect(adoptStoredSession(afterBackReload, storageOver(store), { persist: true })).toBe(true)
+    expect(afterBackReload.token).toBe('tok-space-a')
+    // Original per-sid buckets are left exactly as they were.
+    expect(store.get('tokeni1mw4h')).toBe('tok-space-a')
+    expect(store.get('tokenx519b')).toBe('tok-space-b')
+  })
+
+  it('persist:true with several DIFFERENT-uid buckets still falls through to login (XIN-392 intact)', () => {
+    const store = new Map<string, string>([
+      ['tokenA', 'tok-a'],
+      ['uidA', 'u_a'],
+      ['tokenB', 'tok-b'],
+      ['uidB', 'u_b'],
+    ])
+    const onDeepLink = new FakeLoginInfo(store, '')
+    onDeepLink.load()
+    expect(adoptStoredSession(onDeepLink, storageOver(store), { persist: true })).toBe(false)
+    expect(onDeepLink.token).toBe('')
+    expect(store.has('token')).toBe(false)
   })
 })
 

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -31,11 +31,15 @@ interface AppLayoutState {
  * returning 401 for everyone. No-op when a token is already present or none is stored (a genuinely
  * anonymous visitor). The scan itself lives in recoverSession.ts (pure + unit-tested).
  *
- * `persist` distinguishes the two callers (XIN-392 P1-2):
- *   - standalone (`persist: true`): also writes the session back to the current empty-sid bucket so
- *     the page's Back → /docs full reload stays authenticated (XIN-390). Because that write mirrors
- *     the identity into the cross-tab localStorage whitelist, adoptStoredSession only persists when
- *     EXACTLY ONE session is stored — a multi-session user's identity is never guessed-and-pinned.
+ * `persist` distinguishes the two callers (XIN-392 P1-2 / XIN-519 blocker 2):
+ *   - standalone (`persist: true`): recover a signed-in user's session on the sid-less cold load.
+ *     One stored bucket → adopt and persist it back to the empty-sid slot so the page's Back → /docs
+ *     full reload stays authenticated (XIN-390). Several buckets that all belong to the SAME identity
+ *     (same uid — one person signed in across e.g. two spaces, the real-device multi-space case) →
+ *     adopt the first IN MEMORY ONLY, so the link opens the doc instead of bouncing to login, without
+ *     pinning a multi-bucket pick into the cross-tab slot. Buckets spanning DIFFERENT identities stay
+ *     ambiguous → fall through to login (never guess a person). The doc's own space rides on `?sp`
+ *     (preflight addressing), not on bucket selection.
  *   - invite (`persist: false`): adopts the first stored session IN MEMORY ONLY and never persists,
  *     which is the invite branch's original pre-#512 behavior (it must not start persisting just
  *     because both branches now share this helper).

--- a/apps/web/src/Layout/recoverSession.ts
+++ b/apps/web/src/Layout/recoverSession.ts
@@ -128,6 +128,31 @@ export function findUniqueStoredSession(store: StorageLike): RecoveredSession | 
 }
 
 /**
+ * The FIRST stored session when storage holds SEVERAL buckets that all belong to the SAME identity
+ * (same non-empty uid), or null otherwise (zero buckets, one bucket, or buckets spanning >1 uid).
+ *
+ * The multi-session / multi-space real-device case (XIN-519 blocker 2, boss decision B): one person
+ * signed in more than once — e.g. across two spaces — leaves several `token{sid}` buckets, all with
+ * the SAME uid. findUniqueStoredSession refuses these (length > 1), so a sid-less `/d/:docId` cold
+ * load recovered nothing and bounced the user to login even though every bucket is the same person.
+ * When every bucket shares one uid there is no IDENTITY to guess between, so returning the first is
+ * safe. Buckets spanning different uids stay genuinely ambiguous and return null — the caller falls
+ * through to login rather than picking a person (the XIN-392 P1-2 guarantee is untouched).
+ *
+ * Deliberately NOT a by-`sp` selection: token buckets store no space (see SESSION_KEY_PREFIXES) and
+ * same-identity buckets are interchangeable anyway, so `sp` cannot and need not pick among them — it
+ * stays the StandaloneDocPage preflight's space-addressing param only. The caller adopts this result
+ * IN MEMORY ONLY (never persists it) so a multi-bucket pick is never mirrored into the cross-tab slot.
+ */
+export function findSameIdentityStoredSession(store: StorageLike): RecoveredSession | null {
+  const sessions = findStoredSessions(store)
+  if (sessions.length <= 1) return null
+  const uid = sessions[0].uid
+  if (!uid) return null
+  return sessions.every((s) => s.uid === uid) ? sessions[0] : null
+}
+
+/**
  * The subset of `WKApp.loginInfo` the adoption path writes. Kept structural (not the concrete
  * `LoginInfo` class from `@octo/base`) so this stays a pure, host-free unit.
  */
@@ -148,9 +173,11 @@ export interface AdoptOptions {
    * Back → /docs full reload — reads the empty-sid slot; persisting into it there keeps an
    * already-signed-in user logged in across that reload (XIN-390 Back-keeps-login). But `save()` also
    * mirrors token/uid/name into the cross-tab localStorage whitelist (StorageService), so it is only
-   * safe when the stored session is UNAMBIGUOUS. Persisting therefore requires EXACTLY ONE stored
-   * session (findUniqueStoredSession); with zero or several this is a no-op (returns false) and the
-   * visitor falls through to login rather than having a guessed identity pinned across tabs (XIN-392).
+   * safe when the stored session is UNAMBIGUOUS. Persistence therefore happens ONLY when EXACTLY ONE
+   * session is stored (findUniqueStoredSession). With several buckets that all share one identity, the
+   * session is adopted IN MEMORY ONLY (never persisted) — see the standalone branch below; with
+   * buckets spanning different identities, this is a no-op (returns false) and the visitor falls
+   * through to login rather than having a guessed identity pinned across tabs (XIN-392).
    *
    * When false (the DEFAULT — the invite-landing branch): adopt the first stored session IN MEMORY
    * ONLY and never call `save()`. This is the invite branch's original, pre-#512 recovery behavior;
@@ -159,18 +186,34 @@ export interface AdoptOptions {
   persist?: boolean
 }
 
+/** Copy a recovered session's fields into `sink` (in-memory adoption; no persistence). */
+function applyRecoveredSession(sink: SessionSink, session: RecoveredSession): void {
+  sink.token = session.token
+  sink.uid = session.uid
+  sink.name = session.name
+}
+
 /**
  * Adopt a stored octo session into `sink` for a clean deep-link cold-load.
  *
  * By default (invite branch) this writes only the in-memory `token`/`uid`/`name` fields, adopting the
- * FIRST stored session and persisting nothing — the pre-#512 invite semantics. Pass `{ persist: true }`
- * (standalone branch) to also `sink.save()` the adopted session so a subsequent no-sid reload stays
- * authenticated (XIN-390) — but persistence only happens when EXACTLY ONE session is stored, so a
- * multi-session user's identity is never guessed-and-pinned across tabs (XIN-392).
+ * FIRST stored session and persisting nothing — the pre-#512 invite semantics.
+ *
+ * Pass `{ persist: true }` (standalone `/d/:docId` branch) to recover a signed-in user's session on a
+ * sid-less cold load. Bucket selection there is tiered so a multi-session user is neither bounced to
+ * login nor pinned to a guessed identity (XIN-392 P1-2 / XIN-519 blocker 2, boss decision B):
+ *   - exactly one stored bucket → adopt AND `sink.save()` it, so a later no-sid Back → /docs reload
+ *     stays authenticated (XIN-390 Back-keeps-login);
+ *   - several buckets, all the SAME identity (same non-empty uid — one person signed in across e.g.
+ *     two spaces) → adopt the first IN MEMORY ONLY (no `save()`), so the sid-less link opens the doc
+ *     instead of bouncing to login, without mirroring a multi-bucket pick into the cross-tab slot;
+ *   - several buckets spanning DIFFERENT identities → no-op (login), never guessing a person.
+ *
+ * `sp` is intentionally not consulted here: token buckets carry no space, and same-identity buckets
+ * are interchangeable, so `sp` cannot pick among them — it stays the preflight's addressing param.
  *
  * No-op (returns false) when a token is already loaded, when none is stored, or when persistence is
- * requested but the stored session is ambiguous — a genuinely anonymous (or ambiguous) visitor is
- * left untouched to fall through to the login screen.
+ * requested but the stored buckets span more than one identity — the visitor falls through to login.
  */
 export function adoptStoredSession(
   sink: SessionSink,
@@ -179,19 +222,32 @@ export function adoptStoredSession(
 ): boolean {
   if (sink.token) return false
   const { persist = false } = options
-  // Persisting demands an unambiguous session (never pin a guess cross-tab); in-memory-only
-  // recovery keeps the original "first wins" behavior.
-  const session = persist ? findUniqueStoredSession(store) : findStoredSession(store)
-  if (!session) return false
-  sink.token = session.token
-  sink.uid = session.uid
-  sink.name = session.name
-  if (persist) {
+  if (!persist) {
+    // Invite branch: first-wins, in-memory only (pre-#512 semantics).
+    const session = findStoredSession(store)
+    if (!session) return false
+    applyRecoveredSession(sink, session)
+    return true
+  }
+  // Standalone branch. Persisting mirrors the identity into the cross-tab whitelist, so we persist
+  // ONLY the unambiguous single-bucket case; a same-identity multi-bucket set is recovered in memory.
+  const unique = findUniqueStoredSession(store)
+  if (unique) {
+    applyRecoveredSession(sink, unique)
     // Persist to the current sid bucket so a later same-tab navigation that also lacks `?sid=`
     // (e.g. Back → /docs) reloads this session rather than an empty one.
     sink.save()
+    return true
   }
-  return true
+  const sameIdentity = findSameIdentityStoredSession(store)
+  if (sameIdentity) {
+    // Several buckets, one person: adopt the first IN MEMORY ONLY. No sink.save() — never pin a
+    // multi-bucket pick into the cross-tab empty-sid slot (XIN-392). A Back → /docs reload re-runs
+    // this same same-identity recovery, so the user stays authenticated across it without a pin.
+    applyRecoveredSession(sink, sameIdentity)
+    return true
+  }
+  return false
 }
 
 /**

--- a/packages/docs/src/forward/forward.test.ts
+++ b/packages/docs/src/forward/forward.test.ts
@@ -80,11 +80,13 @@ describe('buildDocLink — standalone `/d/:docId` share form (bypasses the host 
     expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
   })
 
-  it('keeps `?sp` DISTINCT from the token-bucket `?sid` (they are different identifiers)', () => {
+  it('never carries the token-bucket `?sid`, even when a currentSpaceId is persisted (XIN-513)', () => {
+    // The link no longer mints `?sid` — an already-logged-in recipient's session is recovered from
+    // storage independently of the URL. Only the doc's real space rides along, on `?sp`.
     try {
       window.localStorage.setItem('currentSpaceId', 'sp_current')
       const link = buildDocLink({ docId: 'd_1', space: '105d4a60d0fc4d55a5cfc3c2d0501361' })
-      expect(link).toContain('sid=sp_current')
+      expect(link).not.toContain('sid=')
       expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
     } finally {
       window.localStorage.removeItem('currentSpaceId')
@@ -99,11 +101,10 @@ describe('buildDocLink — standalone `/d/:docId` share form (bypasses the host 
     expect(buildDocLink({ docId: 'd_2' })).toContain('/d/d_2')
   })
 
-  it('carries the current space sid so the receiver loads their sid-scoped token (#511 problem 2)', () => {
-    // No sid in the (jsdom) URL — fall back to the persisted currentSpaceId.
+  it('never appends `?sid`, so a sid-less link works with only a docId (XIN-513)', () => {
     try {
       window.localStorage.setItem('currentSpaceId', 'sp_current')
-      expect(buildDocLink({ docId: 'd_3' })).toContain('sid=sp_current')
+      expect(buildDocLink({ docId: 'd_3' })).not.toContain('sid=')
     } finally {
       window.localStorage.removeItem('currentSpaceId')
     }

--- a/packages/docs/src/forward/link.ts
+++ b/packages/docs/src/forward/link.ts
@@ -16,12 +16,17 @@
 // We build against window.location.origin the same way invite links are built
 // (invite/api.ts buildInviteUrl), so the link is absolute and clickable in chat.
 //
-// #511 problem 2 (sid): the app stores the auth token per space, keyed by the URL's `?sid=` param
-// (LoginInfo.getStorageItemForSID reads `token<sid>`, where sid = getSID() = the `?sid=` query).
-// A link with no `?sid=` makes the receiver read the bare `token` key (empty) → isLogined() ===
-// false → the Layout guard bounces even an already-logged-in user to /login. So we carry the
-// current space's sid on the link; the receiver (a member of the same space) then loads their
-// `token<sid>` and opens the document without a login detour.
+// No `?sid=` on the link (XIN-513, boss decision + real-device evidence 2026-07-07): the app stores
+// the auth token per space, keyed by `token<sid>`, but the link no longer needs to carry that key.
+// An already-logged-in recipient's session is recovered from storage independently of the URL —
+// apps/web Layout runs recoverOctoSessionFromStorage on the `/d` path, which (via recoverSession.ts
+// findStoredSessions) scans every `token<sid>` bucket in localStorage and adopts a valid stored
+// session, so a sid-less link opens the document directly without a login detour. The earlier note
+// that a sid-less link bounced a signed-in user to /login described the pre-recovery state and no
+// longer holds. Two edge cases stay tracked separately and are out of scope here: a multi-session /
+// multi-space user's sid-less recovery may adopt the wrong space session (octo-web #551), and the
+// unauthenticated login-return to `/d/:docId` (octo-web #552). The `token<sid>` bucket / recoverSession
+// logic itself is untouched — only the minted link stops carrying `?sid`.
 
 export interface DocLinkTarget {
   docId: string
@@ -30,9 +35,10 @@ export interface DocLinkTarget {
    * `105d4a60…`), known to the sharer at forward time (the in-shell EditorShell space prop, which
    * is the live currentSpaceId). Embedded on the link as `?sp=` (XIN-501) so the recipient's
    * standalone preflight can address `GET /docs/:docId` at the doc's own space. This is NOT the same
-   * value as `?sid` (see below): `?sid` is the short octo token-bucket key, whereas `?sp` is the
-   * docs space the backend matches against in requireDocRole's cross-space guard. Optional: a link
-   * built without it degrades to the recipient resolving the space from their own session.
+   * value as the octo `?sid` token-bucket key: `?sp` is the docs space the backend matches against in
+   * requireDocRole's cross-space guard, whereas `?sid` (no longer minted on this link, XIN-513) only
+   * scoped the token store. Optional: a link built without it degrades to the recipient resolving the
+   * space from their own session.
    */
   space?: string
   folder?: string
@@ -44,49 +50,25 @@ function origin(): string {
 }
 
 /**
- * The current octo space id used to scope the auth token. The docs SPA runs at `/docs?sid=<space>`,
- * so the live `?sid=` is the authoritative value; we fall back to the persisted `currentSpaceId`
- * (localStorage) when the query is unavailable. Empty under SSR/tests or when neither is present —
- * the link then degrades to the sid-less form.
- */
-function currentSid(): string {
-  if (typeof window === 'undefined') return ''
-  try {
-    const fromUrl = new URLSearchParams(window.location.search).get('sid')
-    if (fromUrl) return fromUrl
-  } catch {
-    // Malformed / non-browser search: fall through to the persisted space id.
-  }
-  try {
-    return window.localStorage?.getItem('currentSpaceId') || ''
-  } catch {
-    return ''
-  }
-}
-
-/**
  * Build `${origin}/d/<docId>` — the standalone doc-page share form — carrying, when available:
- *   - `?sid=<space sid>`  the octo token-bucket key so the receiver loads their sid-scoped token
- *                         (`token<sid>`, #511 problem 2 / login-return);
  *   - `?sp=<space id>`    the doc's REAL space (doc_meta.space_id) so the receiver's preflight
  *                         (`GET /docs/:docId`) addresses the doc's own space (XIN-501).
  *
- * The two are DISTINCT identifiers and both are needed: `?sid` keys the token store, `?sp` is the
- * space the docs backend matches in requireDocRole's cross-space guard. XIN-497 reused `?sid` as the
+ * The link deliberately carries NO `?sid=` (XIN-513): an already-logged-in recipient's session is
+ * recovered from storage independently of the URL (apps/web Layout → recoverSession.ts
+ * findStoredSessions scans the `token<sid>` buckets and adopts a valid session), so the token-bucket
+ * sid does not need to ride on the shared link. `?sp` is still needed and DISTINCT: it is the space
+ * the docs backend matches in requireDocRole's cross-space guard. XIN-497 reused `?sid` as the
  * preflight space, but a token-bucket sid never equals the doc's space_id, so the preflight 404'd
  * for every recipient (including the owner's own doc). Carrying the real space on its own `?sp` param
  * fixes that without touching the `token<sid>` logic. The receiver opens it → Layout intercepts the
- * `/d` namespace → sid-scoped token loads → preflight against `?sp` → StandaloneDocPage mounts the
- * editor (reader / writer / forbidden-with-request / not-found / archived), all outside the app shell
- * and immune to the host's query-wiping re-push (the docId lives in the path, not the query).
+ * `/d` namespace → the stored session is recovered → preflight against `?sp` → StandaloneDocPage
+ * mounts the editor (reader / writer / forbidden-with-request / not-found / archived), all outside the
+ * app shell and immune to the host's query-wiping re-push (the docId lives in the path, not the query).
  */
 export function buildDocLink({ docId, space }: DocLinkTarget): string {
-  const sid = currentSid()
   const path = `/d/${encodeURIComponent(docId)}`
-  const parts: string[] = []
-  if (sid) parts.push(`sid=${encodeURIComponent(sid)}`)
   const docSpace = (space || '').trim()
-  if (docSpace) parts.push(`sp=${encodeURIComponent(docSpace)}`)
-  const query = parts.length > 0 ? `?${parts.join('&')}` : ''
+  const query = docSpace ? `?sp=${encodeURIComponent(docSpace)}` : ''
   return `${origin()}${path}${query}`
 }

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -296,12 +296,13 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
-  it('AC-1 (XIN-420): a multi-session user opens the standalone link carrying the current session sid', async () => {
+  it('XIN-513: the standalone link opens without a `?sid`, even when the in-shell URL carries one', async () => {
     const openSpy = vi.fn()
     Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
-    // Multi-session in-shell URL: the host's RouteManager re-push collapses the docs route to
-    // `/docs?sid=…`, so the active session's sid rides on window.location. Give the stub a real
-    // origin too — withReturnSid rebuilds the target against it.
+    // In-shell URL carries the active session's sid (the host's RouteManager re-push collapses the
+    // docs route to `/docs?sid=…`). The opened standalone link must NOT copy that sid forward: an
+    // already-logged-in user's session is recovered from storage independently of the URL (XIN-513),
+    // so a sid-less `/d/:docId` opens the document directly.
     Object.defineProperty(window, 'location', {
       configurable: true,
       writable: true,
@@ -327,10 +328,9 @@ describe('DocsHome navigation (split-pane)', () => {
     fireEvent.click(screen.getByText('Doc A'))
     fireEvent.click(screen.getByTestId('editor-open-new-page'))
 
-    // The new tab must carry the active sid so its sid-keyed load() hits the right bucket. Without
-    // it a multi-session user's new tab reads the empty-sid bucket, misses, and (since XIN-392's
-    // strict findUniqueStoredSession refuses to guess) bounces to login instead of the document.
-    expect(openSpy).toHaveBeenCalledWith('/d/d_a?sid=s_active', '_blank', 'noopener,noreferrer')
+    // No sid rides on the standalone link; the recipient/opener's session is recovered from storage.
+    // (The multi-session wrong-space-session recovery edge is tracked separately as octo-web #551.)
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
     expect(assignSpy).not.toHaveBeenCalled()
   })
 

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -291,24 +291,31 @@ describe('DocsHome navigation (split-pane)', () => {
     const entry = screen.getByTestId('editor-open-new-page')
     fireEvent.click(entry)
 
-    // It opens the clean standalone deep-link in a new tab — no in-app navigation.
-    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
+    // It opens the clean standalone deep-link in a new tab — no in-app navigation. The link carries
+    // the doc's real space as `?sp` (XIN-519 blocker 1); with no active space the shell falls back to
+    // the default doc space ('demo'). No `?sid` — the opener's session is recovered from storage.
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a?sp=demo', '_blank', 'noopener,noreferrer')
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
-  it('XIN-513: the standalone link opens without a `?sid`, even when the in-shell URL carries one', async () => {
+  it('XIN-513/519: the standalone link opens with `?sp` (doc space) but no `?sid`, even when the in-shell URL carries a sid', async () => {
     const openSpy = vi.fn()
     Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
     // In-shell URL carries the active session's sid (the host's RouteManager re-push collapses the
     // docs route to `/docs?sid=…`). The opened standalone link must NOT copy that sid forward: an
     // already-logged-in user's session is recovered from storage independently of the URL (XIN-513),
-    // so a sid-less `/d/:docId` opens the document directly.
+    // so a sid-less `/d/:docId` opens the document directly. It MUST, however, carry `?sp` (the doc's
+    // real space) so the recipient's standalone preflight can address the doc's own space — dropping
+    // it (XIN-519 blocker 1) sent the login-return path into the cross-space not_found terminal.
     Object.defineProperty(window, 'location', {
       configurable: true,
       writable: true,
       value: { origin: 'https://app.example.com', search: '?sid=s_active', assign: assignSpy },
     })
     const wk = createMockWKApp()
+    // Give the shell an active space so DocsHome's space (spaceRef) resolves to a real doc space id,
+    // which the opened standalone link must carry as `?sp`.
+    wk.shared.currentSpaceId = '105d4a60d0fc4d55a5cfc3c2d0501361'
     setWKApp(wk)
     wk.apiClient.responder = (method, url) => {
       if (method === 'get' && url.startsWith('/docs')) {
@@ -328,9 +335,14 @@ describe('DocsHome navigation (split-pane)', () => {
     fireEvent.click(screen.getByText('Doc A'))
     fireEvent.click(screen.getByTestId('editor-open-new-page'))
 
-    // No sid rides on the standalone link; the recipient/opener's session is recovered from storage.
+    // The standalone link carries `?sp` (the doc's real space) so the recipient's preflight addresses
+    // the doc's own space — but NO `?sid`; the opener's session is recovered from storage (XIN-513).
     // (The multi-session wrong-space-session recovery edge is tracked separately as octo-web #551.)
-    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
+    expect(openSpy).toHaveBeenCalledWith(
+      '/d/d_a?sp=105d4a60d0fc4d55a5cfc3c2d0501361',
+      '_blank',
+      'noopener,noreferrer',
+    )
     expect(assignSpy).not.toHaveBeenCalled()
   })
 

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -12,7 +12,6 @@ import {
   DOC_TARGET_STORAGE_KEY,
 } from '../config.ts'
 import { listDocs, createDoc, getDoc, type DocListItem } from './docsApi.ts'
-import { withReturnSid } from './StandaloneDocPage.tsx'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { createInvite, buildInviteUrl } from '../invite/api.ts'
 import { canManage, type Role } from '../auth/roles.ts'
@@ -787,19 +786,15 @@ export function DocsHome() {
   // in a new browser tab — the clean, shareable cold-load entry that lives outside the app shell.
   // The id only ever contains documentName-safe chars, so the built path stays a valid /d/ route.
   //
-  // Carry the current session's sid (XIN-420, same gap the XIN-398 post-login return path fixed):
-  // the host's RouteManager re-push collapses the in-shell docs route to `/docs?sid=…`, so a
-  // multi-session user's active sid rides on window.location. Route it through withReturnSid
-  // (query-only, percent-encoded, safe-path re-checked) so the new tab's sid-keyed load() hits the
-  // right bucket instead of missing the empty-sid bucket and — since XIN-392's strict
-  // findUniqueStoredSession refuses to guess an identity — bouncing to login. An empty sid (single
-  // / empty-sid session, no ambiguity) makes withReturnSid a no-op: the plain /d/:docId cold-load
-  // recovers on its own, so we never append a meaningless `?sid=`.
+  // The link carries NO `?sid=` (XIN-513): an already-logged-in user's session is recovered from
+  // storage independently of the URL — apps/web Layout runs recoverOctoSessionFromStorage on the
+  // `/d` path, which scans the `token<sid>` buckets and adopts a valid stored session — so the new
+  // tab opens the document directly without a login detour. The multi-session / multi-space case
+  // where storage recovery may adopt the wrong space session is tracked separately (octo-web #551)
+  // and is out of scope here; the `token<sid>` / recoverSession logic is untouched.
   const onOpenInNewPage = useCallback((id: string) => {
     if (typeof window !== 'undefined') {
-      const sid = new URLSearchParams(window.location.search).get('sid')
-      const target = withReturnSid(`/d/${encodeURIComponent(id)}`, sid)
-      window.open(target, '_blank', 'noopener,noreferrer')
+      window.open(`/d/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
     }
   }, [])
 

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -789,12 +789,20 @@ export function DocsHome() {
   // The link carries NO `?sid=` (XIN-513): an already-logged-in user's session is recovered from
   // storage independently of the URL — apps/web Layout runs recoverOctoSessionFromStorage on the
   // `/d` path, which scans the `token<sid>` buckets and adopts a valid stored session — so the new
-  // tab opens the document directly without a login detour. The multi-session / multi-space case
-  // where storage recovery may adopt the wrong space session is tracked separately (octo-web #551)
-  // and is out of scope here; the `token<sid>` / recoverSession logic is untouched.
+  // tab opens the document directly without a login detour.
+  //
+  // It DOES carry `?sp=` (XIN-519 blocker 1): the doc's real space — the active DocsHome space, which
+  // the resident list is scoped to, so the open document lives in it — exactly as the other two minted
+  // `/d/:docId` links do (buildDocLink forward link, StandaloneDocPage Copy-link). Without `?sp` the
+  // recipient's standalone preflight (`GET /docs/:docId`) has no space to address and hits the
+  // cross-space guard's not_found ("该文档不存在或已被删除"), notably on the unauthenticated
+  // login-return path. We read spaceRef (the authoritative current space id, kept in sync by
+  // onSpaceChanged) so the callback stays deps-free. We drop only `?sid`, never `?sp`.
   const onOpenInNewPage = useCallback((id: string) => {
     if (typeof window !== 'undefined') {
-      window.open(`/d/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
+      const sp = (spaceRef.current || '').trim()
+      const query = sp ? `?sp=${encodeURIComponent(sp)}` : ''
+      window.open(`/d/${encodeURIComponent(id)}${query}`, '_blank', 'noopener,noreferrer')
     }
   }, [])
 

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -334,6 +334,33 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(copied).not.toContain('?')
   })
 
+  it('XIN-513: Copy link keeps the doc space `?sp` but strips the session `?sid`', async () => {
+    // The standalone page was opened from a share link carrying `?sp=` (the doc's real space, XIN-501)
+    // and the live URL may also carry the sharer's own `?sid=`. The copied canonical link must
+    // preserve `?sp` — the next recipient's preflight needs it to address the doc's space — while
+    // dropping the session-scoped `?sid`.
+    window.history.pushState({}, '', '/d/d_ok?sid=sharer-secret&sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('lead-copy-link')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('lead-copy-link'))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    const copied = writeText.mock.calls[0][0] as string
+    expect(copied).toBe(`${window.location.origin}/d/d_ok?sp=105d4a60d0fc4d55a5cfc3c2d0501361`)
+    expect(copied).not.toContain('sid')
+  })
+
   it('AC-6: after copying, a menu-external "Link copied" toast appears (visible even though the menu row closes)', async () => {
     // Reviewer's blocker (XIN-386): the old in-row "Link copied" label was dead — selecting the row
     // closes the ≡ menu, so the panel that hosted the label unmounts and the user never sees it.

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -391,13 +391,16 @@ export function StandaloneDocPage({
   const onCopyLink = useCallback(async () => {
     if (typeof window === 'undefined') return
     try {
-      // Copy the CANONICAL share link — origin + `/d/:docId` only — never the live URL. The current
-      // address may carry session-scoped query params (notably `?sid=`, added when opening a doc in a
-      // new page / returning post-login), and copying window.location.href would leak the sharer's own
-      // session id into the shared link. Strip the whole query (and any hash) so what is shared is the
-      // clean document link every recipient should get; the recipient's own session resolves normally.
+      // Copy the CANONICAL share link — origin + `/d/:docId` — carrying only the doc's real space
+      // `?sp=` and NEVER the session-scoped `?sid=`. The live URL can carry `?sid=` (the sharer's
+      // own token-bucket key, added when opening a doc in a new page / returning post-login); copying
+      // window.location.href verbatim would leak the sharer's session id into the shared link. So we
+      // rebuild from the path and re-attach ONLY `?sp` (the doc's own space, XIN-501 preflight
+      // addressing), which every recipient needs and which is safe to share. The recipient's own
+      // session is recovered from storage independently of the link (XIN-513), so no `?sid` is needed.
       const here = new URL(window.location.href)
-      const canonical = here.origin + here.pathname
+      const sp = standaloneLinkSpace()
+      const canonical = here.origin + here.pathname + (sp ? `?sp=${encodeURIComponent(sp)}` : '')
       await navigator.clipboard?.writeText(canonical)
       // Drive the menu-external "Link copied" toast (below). The menu closes on selection, so this
       // confirmation must live outside the (now-unmounted) menu panel — hence page-level state, not


### PR DESCRIPTION
## Summary

Drop the token-bucket `?sid=` from the three minted document share links. An already
signed-in recipient's session is recovered from storage independently of the URL, so the
share link no longer needs to carry the sid.

The real space param `?sp=` (used by the recipient's standalone preflight for cross-space
addressing) is preserved everywhere.

## Why

`?sid` was only the key of the per-space auth-token bucket (`token<sid>`). It was originally
carried on the link so the recipient could load their sid-scoped token and avoid a login
detour. That is no longer needed: on the `/d` path, Layout runs `recoverOctoSessionFromStorage`,
which (via `recoverSession.ts` `findStoredSessions`) scans every `token<sid>` bucket in
localStorage and adopts a valid stored session. A signed-in user therefore opens a sid-less
link directly, with no login bounce.

## Changes

Three link-generation sites, all now sid-less (and `?sp` kept where applicable):

1. `packages/docs/src/forward/link.ts` — `buildDocLink` mints `/d/:docId` with only `?sp=`;
   the `currentSid` helper is removed and the stale sid comments are rewritten to reflect the
   storage-recovery behavior.
2. `packages/docs/src/pages/DocsHome.tsx` — "open in new page" opens the plain `/d/:docId`
   instead of threading the active session sid through `withReturnSid`.
3. `packages/docs/src/pages/StandaloneDocPage.tsx` — the Copy-link keeps `?sp=` on the
   canonical link while still stripping the session-scoped `?sid`.

The `token<sid>` bucket / `recoverSession` logic itself is untouched — only the minted links
stop carrying `?sid`.

## Out of scope

Two edge cases are tracked separately and intentionally not addressed here (no regression
introduced):

- Multi-session / multi-space users' sid-less recovery may adopt the wrong space session — #551
- Unauthenticated login-return to `/d/:docId` — #552

## Verification

- Unit tests updated and green (docs package: forward/DocsHome/StandaloneDocPage suites).
- Browser e2e (`standalone-doc` AC-3, real Chromium): a signed-in user opens the clean,
  sid-less `/d/:docId` link; the session is recovered from the `token<sid>` bucket and its
  token rides the preflight — direct open, no login wall.
- `@octo/web` production build passes.

Related issue: #511 follow-up (share-link sid cleanup).
