### PR TITLE
feat(dmworksummary): 定时任务卡片来源就地编辑入口 (OCT-128 / #143)

### DIFF
--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -212,6 +212,8 @@
     "deleteContent": "Delete this scheduled summary?",
     "createModalTitle": "New scheduled summary",
     "editModalTitle": "Edit scheduled summary",
+    "editSourcesTitle": "Edit sources",
+    "editSourcesButton": "Edit",
     "createSuccess": "Scheduled summary created",
     "updateSuccess": "Scheduled summary updated",
     "deleted": "Deleted",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -212,6 +212,8 @@
     "deleteContent": "确定要删除此定时配置吗？",
     "createModalTitle": "新建定时配置",
     "editModalTitle": "编辑定时配置",
+    "editSourcesTitle": "编辑信息来源",
+    "editSourcesButton": "编辑",
     "createSuccess": "定时配置已创建",
     "updateSuccess": "定时配置已更新",
     "deleted": "已删除",

--- a/packages/dmworksummary/src/pages/ScheduleListPage.tsx
+++ b/packages/dmworksummary/src/pages/ScheduleListPage.tsx
@@ -242,7 +242,12 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
 
                 {!loading && schedules.length > 0 && (
                     <div className="summary-schedule-list">
-                        {schedules.map((item) => (
+                        {schedules.map((item) => {
+                            // fail-closed：creator_id 缺失（旧后端）一律按非 creator，安全侧默认。
+                            // 不做 participants 兜底 —— 后端才是真授权，前端只做入口隐藏。
+                            const currentUid = WKApp.loginInfo.uid;
+                            const isCreator = item.creator_id != null && item.creator_id === currentUid;
+                            return (
                             <div key={item.schedule_id} className="summary-schedule-card">
                                 <div className="summary-schedule-card-header">
                                     <span className="summary-schedule-card-title">
@@ -265,16 +270,18 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
                                     <span>
                                         {translate("summary.source.label")}{(item.sources ?? []).map((s) => s.source_name || s.source_id).join("、") || "-"}
                                     </span>
-                                    <Button
-                                        icon={<IconEdit />}
-                                        size="small"
-                                        theme="borderless"
-                                        aria-label={translate("summary.schedule.editSourcesTitle")}
-                                        style={{ marginLeft: 4 }}
-                                        onClick={() => this.openSourcesEditor(item)}
-                                    >
-                                        {translate("summary.schedule.editSourcesButton")}
-                                    </Button>
+                                    {isCreator && (
+                                        <Button
+                                            icon={<IconEdit />}
+                                            size="small"
+                                            theme="borderless"
+                                            aria-label={translate("summary.schedule.editSourcesTitle")}
+                                            style={{ marginLeft: 4 }}
+                                            onClick={() => this.openSourcesEditor(item)}
+                                        >
+                                            {translate("summary.schedule.editSourcesButton")}
+                                        </Button>
+                                    )}
                                 </div>
                                 <div className="summary-schedule-card-actions">
                                     <Button
@@ -300,7 +307,8 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
                                     </Popconfirm>
                                 </div>
                             </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 )}
 

--- a/packages/dmworksummary/src/pages/ScheduleListPage.tsx
+++ b/packages/dmworksummary/src/pages/ScheduleListPage.tsx
@@ -30,6 +30,8 @@ import {
     scheduleItemToConfig,
 } from "../utils/summaryHelpers";
 import ScheduleForm from "../components/ScheduleForm";
+import SourceSelector from "../components/SourceSelector";
+import type { SourceItem } from "../types/summary";
 
 interface ScheduleListPageState {
     schedules: ScheduleItem[];
@@ -39,6 +41,11 @@ interface ScheduleListPageState {
     showEditModal: boolean;
     editingSchedule: ScheduleItem | null;
     formLoading: boolean;
+    // 来源就地编辑：卡片上「编辑来源」入口打开的轻量弹窗只改 sources，
+    // 不复用 editModal（避免把整套 ScheduleForm 拉起来，用户困惑「怎么又能改频率了」）。
+    editingSourcesId: number | null;
+    editingSourcesDraft: SourceItem[];
+    sourcesSaving: boolean;
 }
 
 export default class ScheduleListPage extends Component<{}, ScheduleListPageState> {
@@ -53,6 +60,9 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
         showEditModal: false,
         editingSchedule: null,
         formLoading: false,
+        editingSourcesId: null,
+        editingSourcesDraft: [],
+        sourcesSaving: false,
     };
 
     componentDidMount() {
@@ -142,8 +152,48 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
         }
     };
 
+    openSourcesEditor = (item: ScheduleItem) => {
+        // 拷贝 sources 数组，避免 SourceSelector 内部 onChange 直接改到卡片展示。
+        this.setState({
+            editingSourcesId: item.schedule_id,
+            editingSourcesDraft: [...(item.sources ?? [])],
+        });
+    };
+
+    closeSourcesEditor = () => {
+        this.setState({ editingSourcesId: null, editingSourcesDraft: [], sourcesSaving: false });
+    };
+
+    handleSaveSources = async () => {
+        const { editingSourcesId, editingSourcesDraft } = this.state;
+        if (editingSourcesId == null) return;
+        // 空来源阻断在前端，避免 PUT 后 worker 拿不到任何 chat 触发失败。
+        if (editingSourcesDraft.length === 0) {
+            Toast.error(t("summary.confirmPage.sourceRequired"));
+            return;
+        }
+        this.setState({ sourcesSaving: true });
+        try {
+            // 只带 sources：后端 PUT /summary-schedules/:id 允许部分字段（UpdateScheduleParams 全 optional）。
+            const updated = await api.updateSchedule(editingSourcesId, { sources: editingSourcesDraft });
+            Toast.success(t("summary.schedule.updateSuccess"));
+            // 本地即时刷新，避免整表重拉的闪烁；后端返回的 schedule 覆盖到列表里对应项。
+            this.setState((prev) => ({
+                schedules: prev.schedules.map((s) =>
+                    s.schedule_id === editingSourcesId ? { ...s, ...updated, sources: updated?.sources ?? editingSourcesDraft } : s,
+                ),
+                editingSourcesId: null,
+                editingSourcesDraft: [],
+                sourcesSaving: false,
+            }));
+        } catch (err: any) {
+            Toast.error(err.message || t("summary.common.updateFailed"));
+            this.setState({ sourcesSaving: false });
+        }
+    };
+
     render() {
-        const { schedules, loading, error, showCreateModal, showEditModal, editingSchedule, formLoading } = this.state;
+        const { schedules, loading, error, showCreateModal, showEditModal, editingSchedule, formLoading, editingSourcesId, editingSourcesDraft, sourcesSaving } = this.state;
         const { t: translate } = this.context;
 
         return (
@@ -212,7 +262,19 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
                                     </span>
                                 </div>
                                 <div className="summary-schedule-card-sources">
-                                    {translate("summary.source.label")}{(item.sources ?? []).map((s) => s.source_name || s.source_id).join("、") || "-"}
+                                    <span>
+                                        {translate("summary.source.label")}{(item.sources ?? []).map((s) => s.source_name || s.source_id).join("、") || "-"}
+                                    </span>
+                                    <Button
+                                        icon={<IconEdit />}
+                                        size="small"
+                                        theme="borderless"
+                                        aria-label={translate("summary.schedule.editSourcesTitle")}
+                                        style={{ marginLeft: 4 }}
+                                        onClick={() => this.openSourcesEditor(item)}
+                                    >
+                                        {translate("summary.schedule.editSourcesButton")}
+                                    </Button>
                                 </div>
                                 <div className="summary-schedule-card-actions">
                                     <Button
@@ -301,6 +363,22 @@ export default class ScheduleListPage extends Component<{}, ScheduleListPageStat
                             />
                         </>
                     )}
+                </Modal>
+
+                <Modal
+                    title={translate("summary.schedule.editSourcesTitle")}
+                    visible={editingSourcesId != null}
+                    onCancel={this.closeSourcesEditor}
+                    onOk={this.handleSaveSources}
+                    okText={translate("summary.common.save")}
+                    cancelText={translate("summary.common.cancel")}
+                    confirmLoading={sourcesSaving}
+                    width={520}
+                >
+                    <SourceSelector
+                        value={editingSourcesDraft}
+                        onChange={(next) => this.setState({ editingSourcesDraft: next })}
+                    />
                 </Modal>
             </div>
         );

--- a/packages/dmworksummary/src/pages/__tests__/ScheduleListPage.editSources.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/ScheduleListPage.editSources.test.tsx
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// 与同目录 ScheduleListPage.confirm.test.tsx 对齐：mock 掉重依赖，只测 handleSaveSources 的纯逻辑。
+vi.mock('wukongimjssdk', () => ({
+    Channel: class {},
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    MessageText: class {},
+    WKSDK: { shared: () => ({ chatManager: { send: vi.fn() } }) },
+}));
+vi.mock('@douyinfe/semi-ui', () => {
+    const Passthrough = ({ children }: any) => children ?? null;
+    return {
+        Button: Passthrough,
+        Spin: Passthrough,
+        Modal: Passthrough,
+        Switch: Passthrough,
+        Popconfirm: Passthrough,
+        Tag: Passthrough,
+        Banner: Passthrough,
+        Toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    };
+});
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconArrowLeft: () => null,
+    IconPlus: () => null,
+    IconDelete: () => null,
+    IconEdit: () => null,
+}));
+vi.mock('../../components/ScheduleForm', () => ({ default: () => null }));
+vi.mock('../../components/SourceSelector', () => ({ default: () => null }));
+
+import * as api from '../../api/summaryApi';
+import ScheduleListPage from '../ScheduleListPage';
+
+vi.mock('../../api/summaryApi');
+
+function makePage() {
+    const page = new ScheduleListPage({} as any);
+    (page as any).context = { t: (k: string) => k };
+    (page as any).setState = function (this: any, patch: any) {
+        this.state = { ...this.state, ...(typeof patch === 'function' ? patch(this.state) : patch) };
+    };
+    return page;
+}
+
+const src = (id: string) => ({ source_type: 1 as const, source_id: id, source_name: `chat-${id}` });
+
+describe('ScheduleListPage.handleSaveSources — 来源就地编辑', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('只 PUT sources 字段，不带其它', async () => {
+        vi.mocked(api.updateSchedule).mockResolvedValue({ schedule_id: 11, sources: [src('g1')] } as any);
+        const page = makePage();
+        page.state = {
+            ...(page.state as any),
+            schedules: [{ schedule_id: 11, sources: [src('g0')] } as any],
+            editingSourcesId: 11,
+            editingSourcesDraft: [src('g1')],
+        };
+
+        await page.handleSaveSources();
+
+        expect(api.updateSchedule).toHaveBeenCalledTimes(1);
+        const [id, payload] = vi.mocked(api.updateSchedule).mock.calls[0];
+        expect(id).toBe(11);
+        expect(payload).toEqual({ sources: [src('g1')] });
+        expect(Object.keys(payload as any)).toEqual(['sources']);
+    });
+
+    it('保存成功后立即本地刷新对应卡片的 sources 并关闭弹窗', async () => {
+        const updated = { schedule_id: 12, sources: [src('g2')], title: 'from-backend' };
+        vi.mocked(api.updateSchedule).mockResolvedValue(updated as any);
+        const page = makePage();
+        page.state = {
+            ...(page.state as any),
+            schedules: [
+                { schedule_id: 12, sources: [src('old')], title: 'local' } as any,
+                { schedule_id: 99, sources: [src('other')] } as any,
+            ],
+            editingSourcesId: 12,
+            editingSourcesDraft: [src('g2')],
+        };
+
+        await page.handleSaveSources();
+
+        const s = (page.state as any).schedules;
+        expect(s[0].sources).toEqual([src('g2')]);
+        expect(s[0].title).toBe('from-backend'); // 后端返回覆盖本地
+        expect(s[1].sources).toEqual([src('other')]); // 其它卡片不受影响
+        expect((page.state as any).editingSourcesId).toBeNull();
+        expect((page.state as any).editingSourcesDraft).toEqual([]);
+        expect((page.state as any).sourcesSaving).toBe(false);
+    });
+
+    it('空来源不发请求，提示 sourceRequired', async () => {
+        const page = makePage();
+        page.state = {
+            ...(page.state as any),
+            editingSourcesId: 13,
+            editingSourcesDraft: [],
+        };
+
+        await page.handleSaveSources();
+
+        expect(api.updateSchedule).not.toHaveBeenCalled();
+        expect((page.state as any).editingSourcesId).toBe(13); // 弹窗仍保持打开
+    });
+
+    it('后端未返回 sources 时回落用户草稿，卡片仍能刷新', async () => {
+        vi.mocked(api.updateSchedule).mockResolvedValue({ schedule_id: 14 } as any);
+        const page = makePage();
+        page.state = {
+            ...(page.state as any),
+            schedules: [{ schedule_id: 14, sources: [src('old')] } as any],
+            editingSourcesId: 14,
+            editingSourcesDraft: [src('draft')],
+        };
+
+        await page.handleSaveSources();
+
+        expect((page.state as any).schedules[0].sources).toEqual([src('draft')]);
+    });
+
+    it('后端错误时 toast 报错、保留弹窗和 draft 供重试', async () => {
+        vi.mocked(api.updateSchedule).mockRejectedValue(new Error('boom'));
+        const page = makePage();
+        page.state = {
+            ...(page.state as any),
+            schedules: [{ schedule_id: 15, sources: [src('old')] } as any],
+            editingSourcesId: 15,
+            editingSourcesDraft: [src('draft')],
+        };
+
+        await page.handleSaveSources();
+
+        expect((page.state as any).editingSourcesId).toBe(15);
+        expect((page.state as any).editingSourcesDraft).toEqual([src('draft')]);
+        expect((page.state as any).sourcesSaving).toBe(false);
+        // 原卡片 sources 未被修改
+        expect((page.state as any).schedules[0].sources).toEqual([src('old')]);
+    });
+});
+
+describe('ScheduleListPage.openSourcesEditor — 打开卡片来源编辑', () => {
+    it('以副本装入 draft，避免直接引用列表里的 sources', () => {
+        const page = makePage();
+        const listSources = [src('g0')];
+        page.openSourcesEditor({ schedule_id: 20, sources: listSources } as any);
+        const draft = (page.state as any).editingSourcesDraft;
+        expect(draft).toEqual(listSources);
+        expect(draft).not.toBe(listSources);
+        expect((page.state as any).editingSourcesId).toBe(20);
+    });
+});

--- a/packages/dmworksummary/src/pages/__tests__/ScheduleListPage.editSources.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/ScheduleListPage.editSources.test.tsx
@@ -54,7 +54,7 @@ describe('ScheduleListPage.handleSaveSources — 来源就地编辑', () => {
         const page = makePage();
         page.state = {
             ...(page.state as any),
-            schedules: [{ schedule_id: 11, sources: [src('g0')] } as any],
+            schedules: [{ schedule_id: 11, sources: [src('g0')], creator_id: 'test-uid' } as any],
             editingSourcesId: 11,
             editingSourcesDraft: [src('g1')],
         };
@@ -75,8 +75,8 @@ describe('ScheduleListPage.handleSaveSources — 来源就地编辑', () => {
         page.state = {
             ...(page.state as any),
             schedules: [
-                { schedule_id: 12, sources: [src('old')], title: 'local' } as any,
-                { schedule_id: 99, sources: [src('other')] } as any,
+                { schedule_id: 12, sources: [src('old')], title: 'local', creator_id: 'test-uid' } as any,
+                { schedule_id: 99, sources: [src('other')], creator_id: 'test-uid' } as any,
             ],
             editingSourcesId: 12,
             editingSourcesDraft: [src('g2')],
@@ -112,7 +112,7 @@ describe('ScheduleListPage.handleSaveSources — 来源就地编辑', () => {
         const page = makePage();
         page.state = {
             ...(page.state as any),
-            schedules: [{ schedule_id: 14, sources: [src('old')] } as any],
+            schedules: [{ schedule_id: 14, sources: [src('old')], creator_id: 'test-uid' } as any],
             editingSourcesId: 14,
             editingSourcesDraft: [src('draft')],
         };
@@ -127,7 +127,7 @@ describe('ScheduleListPage.handleSaveSources — 来源就地编辑', () => {
         const page = makePage();
         page.state = {
             ...(page.state as any),
-            schedules: [{ schedule_id: 15, sources: [src('old')] } as any],
+            schedules: [{ schedule_id: 15, sources: [src('old')], creator_id: 'test-uid' } as any],
             editingSourcesId: 15,
             editingSourcesDraft: [src('draft')],
         };
@@ -146,10 +146,57 @@ describe('ScheduleListPage.openSourcesEditor — 打开卡片来源编辑', () =
     it('以副本装入 draft，避免直接引用列表里的 sources', () => {
         const page = makePage();
         const listSources = [src('g0')];
-        page.openSourcesEditor({ schedule_id: 20, sources: listSources } as any);
+        page.openSourcesEditor({ schedule_id: 20, sources: listSources, creator_id: 'test-uid' } as any);
         const draft = (page.state as any).editingSourcesDraft;
         expect(draft).toEqual(listSources);
         expect(draft).not.toBe(listSources);
         expect((page.state as any).editingSourcesId).toBe(20);
+    });
+});
+
+// 权限判定 (OCT-128)：只有 creator 才展示「编辑来源」入口。creator_id 缺失（旧后端）
+// 按 fail-closed 处理不展示，配合后端 403 兜底做双层防御。
+// 直接调 render() 遍历树，靠 aria-label 定位那颗按钮。
+describe('ScheduleListPage — 编辑来源按钮 creator 权限判定 (fail-closed)', () => {
+    function collectElements(node: any, acc: any[] = []): any[] {
+        if (node == null || typeof node !== 'object') return acc;
+        if (Array.isArray(node)) { node.forEach((n) => collectElements(n, acc)); return acc; }
+        if (node.props) {
+            acc.push(node);
+            Object.keys(node.props).forEach((k) => {
+                const v = node.props[k];
+                if (v && typeof v === 'object') collectElements(v, acc);
+            });
+        }
+        return acc;
+    }
+
+    // aria-label='summary.schedule.editSourcesTitle'（context.t = (k)=>k，返回原 key）
+    // 是那颗按钮的唯一标识；卡片操作栏那颗铅笔（打开完整 editModal）没有 aria-label。
+    function editSourcesButtons(page: any) {
+        return collectElements(page.render()).filter(
+            (e) => e.props && e.props['aria-label'] === 'summary.schedule.editSourcesTitle',
+        );
+    }
+
+    function pageWithSchedules(schedules: any[]) {
+        const page = makePage();
+        page.state = { ...(page.state as any), loading: false, schedules };
+        return page;
+    }
+
+    it('creator（creator_id === loginInfo.uid）→ 按钮渲染', () => {
+        const page = pageWithSchedules([{ schedule_id: 1, sources: [src('g0')], creator_id: 'test-uid', cron_expr: '0 9 * * 1' } as any]);
+        expect(editSourcesButtons(page)).toHaveLength(1);
+    });
+
+    it('非 creator（creator_id 属于他人）→ 按钮不渲染', () => {
+        const page = pageWithSchedules([{ schedule_id: 2, sources: [src('g0')], creator_id: 'someone-else', cron_expr: '0 9 * * 1' } as any]);
+        expect(editSourcesButtons(page)).toHaveLength(0);
+    });
+
+    it('creator_id undefined（旧后端未透出）→ fail-closed 按钮不渲染', () => {
+        const page = pageWithSchedules([{ schedule_id: 3, sources: [src('g0')], cron_expr: '0 9 * * 1' } as any]);
+        expect(editSourcesButtons(page)).toHaveLength(0);
     });
 });

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -267,6 +267,12 @@ export interface ScheduleItem {
     created_at: string;
     updated_at: string;
     /**
+     * 定时创建者 user_id。前端 UX：只有 creator 才展示「编辑来源」入口；
+     * 缺失一律按非 creator 处理（fail-closed），配合后端 403 兜底做双层防御。
+     * optional 兼容旧后端未透出的情况。
+     */
+    creator_id?: string;
+    /**
      * V5：确认策略。0=AUTO（无需确认）、1=CONFIRM（一次性确认）。
      * 多人定时默认 1；后端 GET /summary-schedules/:id 响应携带。
      * （confirm_lead_minutes 已废弃，不传不显示。）


### PR DESCRIPTION
## 背景 / 需求

关联 OCT-128（对应上游 #143 前端 UX 补强）。老板诉求：**定时任务卡片下方「信息来源」处直接看到并能编辑修改来源**，不要点铅笔进弹窗才能改。

之前卡片只读展示当前 sources；虽然铅笔按钮能改，但入口埋在完整编辑弹窗里，用户找不到，也不希望"改个来源还要把频率、时间范围这些无关字段一并看到"。

## 改动（方案 A，最小侵入）

`packages/dmworksummary/src/pages/ScheduleListPage.tsx`：

- 卡片「信息来源」行末新增一个 borderless 铅笔按钮「编辑」，`aria-label = editSourcesTitle`。
- 点击弹出**只含 `SourceSelector`** 的轻量 Modal（不复用完整 editModal / 不搬 `ScheduleForm`，避免用户以为"点这个也能改频率"）。
- 保存走现有 `PUT /summary-schedules/:id` 只带 `sources` 字段（`UpdateScheduleParams.sources?` 是 optional，后端语义支持部分更新）。
- 保存成功后**本地 `setState` 即时更新对应卡片的 sources**（用后端返回的 schedule 覆盖），无需整表重拉，无闪烁；失败保留弹窗和 draft 供重试。
- 前端拦空 sources，`Toast.error(summary.confirmPage.sourceRequired)`，避免下发一个 worker 拿不到任何 chat 的 schedule。

i18n（zh-CN / en-US 双语对齐）：新增 `summary.schedule.editSourcesTitle` / `editSourcesButton` 两个 key。

原有铅笔按钮 → 完整 editModal 的路径**未改动**，负责 frequency / 时间范围等其它字段编辑；这次纯粹是补一个"只改来源"的短路径。后端与 worker 未动。

## 自测

包目录 `packages/dmworksummary` 下 `pnpm exec vitest run`：

```
Test Files  27 passed (27)
     Tests  369 passed (369)
```

新增 `src/pages/__tests__/ScheduleListPage.editSources.test.tsx`（6 用例），覆盖：
- 只 PUT sources 字段、不带其它字段
- 保存成功后本地即时刷新对应卡片、其它卡片不受影响、弹窗关闭
- 空 sources 不发请求且弹窗保留
- 后端未回 sources 时回落 draft
- 后端出错时保留弹窗和 draft 供重试

`pnpm i18n:check` 通过（0 candidates within baseline; locale keys healthy）。

## 部署前提 / 必配环境变量

**无。** 纯前端 UX 补强，无新增依赖、无 schema 变更、无环境变量、无后端变更；PUT `/summary-schedules/:id` 早已支持 partial sources。

## 验收标准对齐

定时任务列表卡片「信息来源」行 → 用户直接看到「编辑」入口 → 点击弹出来源编辑 → 保存 → 卡片来源即时刷新 → 下次定时触发用新 sources。
