### PR TITLE
feat(export): consolidated document export (Markdown / Word / PDF)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -21,6 +21,10 @@
       "reason": "RichText(=14) plain-generation image placeholder. This [图片] literal is a cross-platform wire-format token that must byte-match octo-lib RichTextImagePlaceholder (common/richtext.go) so server/mobile/web produce identical plain text; it is protocol data, not translatable UI copy."
     },
     {
+      "path": "packages/docs/src/export/docx/styles.ts",
+      "reason": "DOCX export font-family constants (微软雅黑). These are Word/WPS font identifiers that must byte-match the actual Windows font name so exported documents render Chinese text correctly; they are font resource names, not translatable UI copy."
+    },
+    {
       "path": "packages/dmworkbase/src/Components/ChannelSearch/ChannelSearch.stories.mock.ts",
       "reason": "Channel search Storybook fixture data with sample sender names, message bodies, filenames, and match reasons; not UI copy."
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -122,6 +122,12 @@ export default defineConfig(({ mode }) => {
       port: env.VITE_PORT ? Number(env.VITE_PORT) : 3000,
       host: env.VITE_HOST ?? true,
       proxy: {
+        // Docs service API — must be before the general /api/ rule
+        "/api/v1/docs": {
+          target: env.VITE_DOCS_API_URL || "http://localhost:4000",
+          changeOrigin: true,
+          secure: false,
+        },
         // Summary service API — must be before the general /api/ rule
         "/summary/api/v1": {
           target:
@@ -151,13 +157,6 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: false,
           rewrite: (path: string) => path.replace(/^\/fleet\/api/, ''),
-        },
-        // Docs/Sheet collaborative backend — MUST be before the general /api/ rule.
-        // The docs-backend mounts its routes at /api/v1/docs, so no rewrite needed.
-        "/api/v1/docs": {
-          target: env.VITE_DOCS_API_URL || "http://127.0.0.1:3000",
-          changeOrigin: true,
-          secure: false,
         },
         "/api/": {
           target: apiOrigin,

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -130,11 +130,15 @@ export default class APIClient {
        return this.wrapResult<T>(axios.get(path, {
         params: config?.param,
         headers: config?.headers,
+        responseType: config?.responseType,
+        timeout: config?.timeout,
     }), config)
     }
     post(path: string, data?: any, config?: RequestConfig) {
         return this.wrapResult(axios.post(path, data, {
             headers: config?.headers,
+            responseType: config?.responseType,
+            timeout: config?.timeout,
         }), config)
     }
 
@@ -202,6 +206,18 @@ export class RequestConfig {
      * 保持既有无显式头行为。
      */
     headers?: Record<string, string>
+    /**
+     * Per-request axios responseType passthrough. Defaults to axios' `'json'`.
+     * `'arraybuffer'` is required for binary endpoints (e.g. server-side PDF
+     * export) so the response body is not decoded as UTF-8 text — every
+     * non-ASCII byte would otherwise become U+FFFD and corrupt the file.
+     */
+    responseType?: 'json' | 'arraybuffer' | 'blob' | 'text'
+    /**
+     * Per-request timeout in ms, overriding the shared 20s default. Long
+     * server-side renders (large document export) need a higher ceiling.
+     */
+    timeout?: number
 }
 
 export interface APIResp {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,10 @@
     "y-indexeddb": "9.0.12",
     "y-prosemirror": "1.2.15",
     "y-protocols": "1.0.6",
-    "yjs": "13.6.21"
+    "yjs": "13.6.21",
+    "docx": "^9.7.1",
+    "mathjax-full": "^3.2.2",
+    "xml-js": "^1.6.11"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/packages/docs/src/editor/DocMoreMenu.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.tsx
@@ -12,6 +12,12 @@ export interface DocMoreMenuItem {
   onClick: () => void
   danger?: boolean
   disabled?: boolean
+  /**
+   * Optional nested rows. When present the row acts as an expandable submenu: clicking it toggles
+   * the children instead of firing `onClick`. Used by the export row to fan out into
+   * Markdown / Word / PDF without leaving the ≡ menu.
+   */
+  children?: DocMoreMenuItem[]
 }
 
 export interface DocMoreMenuProps {
@@ -110,7 +116,46 @@ export const DeleteIcon = (
   </RowIcon>
 )
 
+/** ▸ caret shown on submenu rows; rotates to ▾ when expanded (CSS `.is-open`). */
+function CaretIcon() {
+  return (
+    <svg className="octo-doc-more-caret" viewBox="0 0 20 20" width="16" height="16" aria-hidden="true">
+      <path d="M8 6l4 4-4 4" />
+    </svg>
+  )
+}
+
 function MenuRow({ item, onSelect }: { item: DocMoreMenuItem; onSelect: () => void }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasChildren = !!item.children && item.children.length > 0
+
+  if (hasChildren) {
+    return (
+      <li role="none">
+        <button
+          type="button"
+          role="menuitem"
+          aria-haspopup="true"
+          aria-expanded={expanded}
+          className={expanded ? 'octo-doc-more-item is-parent is-open' : 'octo-doc-more-item is-parent'}
+          disabled={item.disabled}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <span className="octo-doc-more-icon">{item.icon}</span>
+          <span className="octo-doc-more-label">{item.label}</span>
+          <CaretIcon />
+        </button>
+        {expanded && (
+          <ul className="octo-doc-more-list octo-doc-more-sublist" role="menu">
+            {item.children!.map((child) => (
+              <MenuRow key={child.key} item={child} onSelect={onSelect} />
+            ))}
+          </ul>
+        )}
+      </li>
+    )
+  }
+
   return (
     <li role="none">
       <button

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -15,6 +15,7 @@ import { useCommentHighlights } from '../comments/useCommentHighlights.ts'
 import { useDocDelete } from './useDocDelete.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { exportDocToMarkdown, type MdNode } from '../export/markdown.ts'
+import { exportDocPdf } from '../pages/docsApi.ts'
 import { emojiGlyph } from './emoji.ts'
 import { colorFromId } from '../awareness/presence.ts'
 import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
@@ -423,8 +424,68 @@ export function EditorShell(props: EditorShellProps) {
       document.body.appendChild(a)
       a.click()
       a.remove()
-      URL.revokeObjectURL(url)
-    } catch {
+      // Defer revoke so Safari/iOS can start the download for larger blobs
+      // (matches the PDF branch).
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] Markdown export failed:', err)
+      setExportError(t('docs.toolbar.exportError'))
+    } finally {
+      setExporting(false)
+    }
+  }, [instance, docId, currentTitle, exporting])
+
+  const onExportDocx = useCallback(async () => {
+    const ed = instance?.editor
+    if (!ed || exporting) return
+    setExporting(true)
+    setExportError(null)
+    try {
+      // Lazy-load the DOCX exporter so `docx` + `mathjax-full` (multi-MB, DOCX-only)
+      // stay out of the eager editor bundle that loads on every document open.
+      const { exportDocToDocx } = await import('../export/docx/index.ts')
+      const blob = await exportDocToDocx(docId, ed.getJSON() as unknown as MdNode, { emojiGlyph })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${exportDownloadName(currentTitle)}.docx`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      // Defer revoke so Safari/iOS can start the download for larger blobs
+      // (matches the PDF branch).
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] DOCX export failed:', err)
+      setExportError(t('docs.toolbar.exportError'))
+    } finally {
+      setExporting(false)
+    }
+  }, [instance, docId, currentTitle, exporting])
+
+  const onExportPdf = useCallback(async () => {
+    const ed = instance?.editor
+    if (!ed || exporting) return
+    setExporting(true)
+    setExportError(null)
+    try {
+      // Server-side PDF render via Typst (小吴's decision to go backend). The
+      // backend renders its own persisted copy of the doc with Typst, so the
+      // output has real CJK, rendered math, emoji, selectable text and smart
+      // pagination — one-click download with no print dialog. Returns the PDF
+      // bytes directly.
+      const bytes = await exportDocPdf(docId)
+      const blob = new Blob([bytes], { type: 'application/pdf' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${exportDownloadName(currentTitle)}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      setTimeout(() => URL.revokeObjectURL(url), 5000)
+    } catch (err) {
+      console.error('[docs] PDF export failed:', err)
       setExportError(t('docs.toolbar.exportError'))
     } finally {
       setExporting(false)
@@ -514,10 +575,33 @@ export function EditorShell(props: EditorShellProps) {
     },
     {
       key: 'export',
-      label: t('docs.toolbar.exportMarkdown'),
+      label: t('docs.toolbar.export'),
       icon: ExportIcon,
       disabled: exporting,
-      onClick: () => void onExportMarkdown(),
+      onClick: () => {},
+      children: [
+        {
+          key: 'export-markdown',
+          label: t('docs.toolbar.exportMarkdown'),
+          icon: ExportIcon,
+          disabled: exporting,
+          onClick: () => void onExportMarkdown(),
+        },
+        {
+          key: 'export-docx',
+          label: t('docs.toolbar.exportDocx'),
+          icon: ExportIcon,
+          disabled: exporting,
+          onClick: () => void onExportDocx(),
+        },
+        {
+          key: 'export-pdf',
+          label: t('docs.toolbar.exportPdf'),
+          icon: ExportIcon,
+          disabled: exporting,
+          onClick: () => void onExportPdf(),
+        },
+      ],
     },
   )
   const deleteItem: DocMoreMenuItem | undefined = manage
@@ -583,6 +667,8 @@ export function EditorShell(props: EditorShellProps) {
               ⤴ {t('docs.forward.entry')}
             </button>
           )}
+          {/* Export moved into the header ≡ (more) menu as an expandable submenu
+              (Markdown / Word / PDF); the standalone dropdown was removed to avoid duplication. */}
           {manage && (
             <button
               type="button"

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1418,6 +1418,28 @@
 .octo-doc-more-item:disabled:hover {
   background: transparent;
 }
+/* Submenu parent (export): caret at the far right, rotates when open. Children indent under it. */
+.octo-doc-more-caret {
+  flex: 0 0 auto;
+  margin-left: auto;
+  fill: none;
+  stroke: #646a73;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 0.15s ease;
+}
+.octo-doc-more-item.is-open .octo-doc-more-caret {
+  transform: rotate(90deg);
+}
+.octo-doc-more-sublist {
+  background: #fafbfc;
+}
+.octo-doc-more-sublist .octo-doc-more-item {
+  padding-left: 44px;
+  height: 38px;
+  font-size: 13px;
+}
 .octo-doc-more-icon {
   flex: 0 0 auto;
   display: inline-flex;
@@ -2703,3 +2725,4 @@
 .octo-sheet-container .univer-justify-center.univer-overflow-x-auto {
   justify-content: flex-start !important;
 }
+

--- a/packages/docs/src/export/docx/attachment.test.ts
+++ b/packages/docs/src/export/docx/attachment.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+async function exportXml(content: MdNode[], urls?: Map<string, any>) {
+  const ctx: DocxContext = {
+    urls: urls ?? new Map(),
+    imageBuffers: new Map(),
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+  const children = convertBlocks(content, ctx)
+  const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `attach-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+describe('file attachment export', () => {
+  it('resolved attachment renders as hyperlink with filename', async () => {
+    const urls = new Map<string, any>([
+      ['a1', { url: 'https://cdn.example.com/report.pdf', fileName: '季度报告.pdf' }],
+    ])
+    const doc: MdNode[] = [
+      { type: 'fileAttachment', attrs: { attachId: 'a1', fileName: '季度报告.pdf' } },
+    ] as MdNode[]
+    const xml = await exportXml(doc, urls)
+    expect(xml).toContain('季度报告.pdf')
+    expect(xml).toContain('Hyperlink')
+    // hyperlink relationship should point at the url (external link stored in rels)
+    expect(xml).toMatch(/w:hyperlink/i)
+  })
+
+  it('unresolved attachment shows (unavailable) fallback', async () => {
+    const doc: MdNode[] = [
+      { type: 'fileAttachment', attrs: { fileName: '缺失文件.zip' } },
+    ] as MdNode[]
+    const xml = await exportXml(doc)
+    expect(xml).toContain('缺失文件.zip')
+    expect(xml).toContain('unavailable')
+    // The 📎 icon in the unavailable branch must also carry the emoji font.
+    expect(xml).toContain('Segoe UI Emoji')
+  })
+
+  it('attachment 📎 icon carries an emoji font (not blank)', async () => {
+    const urls = new Map<string, any>([
+      ['a1', { url: 'https://cdn.example.com/x.pdf', fileName: 'x.pdf' }],
+    ])
+    const doc: MdNode[] = [{ type: 'fileAttachment', attrs: { attachId: 'a1' } }] as MdNode[]
+    const xml = await exportXml(doc, urls)
+    // The 📎 run must have an emoji font so it does not render blank.
+    expect(xml).toContain('Segoe UI Emoji')
+  })
+})

--- a/packages/docs/src/export/docx/emoji-e2e.test.ts
+++ b/packages/docs/src/export/docx/emoji-e2e.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+describe('emoji end-to-end docx export', () => {
+  it('emoji in body text gets emoji font in document.xml', async () => {
+    const doc: MdNode[] = [
+      { type: 'paragraph', content: [{ type: 'text', text: '标题 😀 内容 ✅ 完成' }] },
+    ] as MdNode[]
+    const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+    const children = convertBlocks(doc, ctx)
+    const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+    const buf = await Packer.toBuffer(document)
+    const path = join(tmpdir(), `emoji-e2e-${Date.now()}.docx`)
+    writeFileSync(path, buf)
+    const xml = execSync(`unzip -p ${path} word/document.xml`).toString()
+
+    // The emoji runs (😀, ✅) must carry Segoe UI Emoji; the CJK runs must not.
+    const emojiRuns = [...xml.matchAll(/<w:r>(?:(?!<\/w:r>).)*?<w:t[^>]*>([^<]*(?:😀|✅)[^<]*)<\/w:t>[\s\S]*?<\/w:r>/g)]
+    // Fallback: just assert the font appears near an emoji.
+    expect(xml).toContain('Segoe UI Emoji')
+    // CJK-only run should NOT get the emoji font — check a run containing 标题 has 微软雅黑 default (no Segoe override)
+    const cjkRun = xml.match(/<w:r>(?:(?!<\/w:r>).)*?<w:t[^>]*>[^<]*标题[^<]*<\/w:t>[\s\S]*?<\/w:r>/)
+    expect(cjkRun?.[0] ?? '').not.toContain('Segoe UI Emoji')
+  })
+})

--- a/packages/docs/src/export/docx/emoji.test.ts
+++ b/packages/docs/src/export/docx/emoji.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for emoji font handling in DOCX export.
+ *
+ * The body font (微软雅黑) has no emoji glyphs and Word does not auto-fallback,
+ * so emoji must be tagged with an emoji font or they render as blank boxes.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildTextRuns, iconPrefix } from './marks.ts'
+import { FONT_EMOJI } from './styles.ts'
+
+/** Serialize a TextRun to inspect its text + font via the internal XML tree. */
+function runInfo(run: unknown): { text: string; font?: string } {
+  // TextRun stores children internally; use JSON round-trip on its root.
+  const anyRun = run as { root?: unknown[] }
+  const json = JSON.stringify(anyRun)
+  const textMatch = json.match(/"text":"([^"]*)"/)
+  const fontMatch = json.match(/"w:ascii":"([^"]*)"|"ascii":"([^"]*)"/)
+  return {
+    text: textMatch ? textMatch[1] : '',
+    font: fontMatch ? fontMatch[1] || fontMatch[2] : undefined,
+  }
+}
+
+describe('emoji font handling', () => {
+  it('plain text without emoji → single run, no emoji font', () => {
+    const runs = buildTextRuns('普通中文文本', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).not.toContain(FONT_EMOJI)
+  })
+
+  it('pure emoji → run tagged with emoji font', () => {
+    const runs = buildTextRuns('😀', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('mixed CJK + emoji → splits, only emoji run gets emoji font', () => {
+    const runs = buildTextRuns('你好😀世界', {})
+    // 你好 | 😀 | 世界
+    expect(runs.length).toBe(3)
+    const serialized = runs.map((r) => JSON.stringify(r))
+    // exactly one run carries the emoji font
+    const withFont = serialized.filter((s) => s.includes(FONT_EMOJI))
+    expect(withFont.length).toBe(1)
+    expect(withFont[0]).toContain('😀')
+  })
+
+  it('checkmark / symbol emoji ✅ tagged with emoji font', () => {
+    const runs = buildTextRuns('✅', {})
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('ZWJ sequence 👩‍💻 stays in one emoji run', () => {
+    const runs = buildTextRuns('👩‍💻', {})
+    expect(runs.length).toBe(1)
+    expect(JSON.stringify(runs[0])).toContain(FONT_EMOJI)
+  })
+
+  it('FE0F-variation emoji ℹ️ / ⚠️ stay in ONE emoji run with FE0F stripped (no tofu box)', () => {
+    // Regression: base symbol + trailing U+FE0F previously left an orphaned FE0F
+    // that rendered as a small box after the icon (esp. on macOS Word, whose
+    // emoji font has no composed FE0F glyph). Fix: keep them in one emoji run
+    // AND strip FE0F — the base char already resolves to the colored glyph.
+    for (const glyph of ['ℹ️', '⚠️', '‼️', '⁉️', '™️', '↔️']) {
+      const runs = buildTextRuns(glyph, {})
+      expect(runs.length).toBe(1)
+      const s = JSON.stringify(runs[0])
+      expect(s).toContain(FONT_EMOJI)
+      // no orphaned variation selector left in the run
+      expect(s).not.toContain('\uFE0F')
+      expect(/fe0f/i.test(s)).toBe(false)
+    }
+  })
+
+  it('iconPrefix strips FE0F from callout/UI icons (no trailing tofu box)', () => {
+    for (const glyph of ['ℹ️', '⚠️']) {
+      const parts = iconPrefix(glyph, { bold: true })
+      const s = JSON.stringify(parts)
+      expect(s).toContain(FONT_EMOJI)
+      expect(/fe0f/i.test(s)).toBe(false)
+    }
+  })
+
+  it('normal punctuation (ellipsis, em-dash, brackets) stays in body font', () => {
+    for (const text of ['中文…省略', '破折号——测试', '引用「文本」']) {
+      const runs = buildTextRuns(text, {})
+      expect(runs.length).toBe(1)
+      expect(JSON.stringify(runs[0])).not.toContain(FONT_EMOJI)
+    }
+  })
+
+  it('preserves base run options on non-emoji segments', () => {
+    const runs = buildTextRuns('粗体😀', { bold: true })
+    // both segments keep bold; only emoji adds font
+    const all = runs.map((r) => JSON.stringify(r))
+    expect(all.every((s) => s.includes('"bold":true') || s.includes('w:b'))).toBe(true)
+  })
+})

--- a/packages/docs/src/export/docx/href-safety.test.ts
+++ b/packages/docs/src/export/docx/href-safety.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { extractLinkHref } from './marks.ts'
+import { isSafeHref } from './nodes.ts'
+
+describe('extractLinkHref — scheme allowlist', () => {
+  const mk = (href: string) => [{ type: 'link', attrs: { href } }]
+
+  it('allows https URLs', () => {
+    expect(extractLinkHref(mk('https://example.com'))).toBe('https://example.com')
+  })
+
+  it('allows http URLs', () => {
+    expect(extractLinkHref(mk('http://example.com'))).toBe('http://example.com')
+  })
+
+  it('allows mailto URLs', () => {
+    expect(extractLinkHref(mk('mailto:a@b.com'))).toBe('mailto:a@b.com')
+  })
+
+  it('allows tel URLs', () => {
+    expect(extractLinkHref(mk('tel:+1234567890'))).toBe('tel:+1234567890')
+  })
+
+  it('allows relative URLs (no scheme)', () => {
+    expect(extractLinkHref(mk('/docs/abc'))).toBe('/docs/abc')
+    expect(extractLinkHref(mk('docs/abc'))).toBe('docs/abc')
+  })
+
+  it('rejects javascript: URLs', () => {
+    expect(extractLinkHref(mk('javascript:alert(1)'))).toBeNull()
+  })
+
+  it('rejects data: URLs', () => {
+    expect(extractLinkHref(mk('data:text/html,<script>alert(1)</script>'))).toBeNull()
+  })
+
+  it('rejects file: URLs', () => {
+    expect(extractLinkHref(mk('file:///etc/passwd'))).toBeNull()
+  })
+
+  it('rejects vbscript: URLs', () => {
+    expect(extractLinkHref(mk('vbscript:msgbox(1)'))).toBeNull()
+  })
+
+  it('rejects UNC paths (backslash)', () => {
+    expect(extractLinkHref(mk('\\\\server\\share'))).toBeNull()
+  })
+
+  it('rejects protocol-relative URLs (//host)', () => {
+    expect(extractLinkHref(mk('//evil.com/x'))).toBeNull()
+  })
+
+  it('returns null for non-string href', () => {
+    expect(extractLinkHref([{ type: 'link', attrs: { href: 123 } }])).toBeNull()
+  })
+
+  it('returns null when no link mark exists', () => {
+    expect(extractLinkHref([{ type: 'bold' }])).toBeNull()
+  })
+})
+
+describe('isSafeHref — scheme allowlist', () => {
+  it('allows https/http/mailto/tel', () => {
+    expect(isSafeHref('https://a.com')).toBe(true)
+    expect(isSafeHref('http://a.com')).toBe(true)
+    expect(isSafeHref('mailto:a@b.com')).toBe(true)
+    expect(isSafeHref('tel:+1')).toBe(true)
+  })
+
+  it('allows relative URLs', () => {
+    expect(isSafeHref('/path')).toBe(true)
+    expect(isSafeHref('path')).toBe(true)
+  })
+
+  it('rejects javascript/data/file/vbscript', () => {
+    expect(isSafeHref('javascript:alert(1)')).toBe(false)
+    expect(isSafeHref('data:text/html,x')).toBe(false)
+    expect(isSafeHref('file:///etc/passwd')).toBe(false)
+    expect(isSafeHref('vbscript:msgbox(1)')).toBe(false)
+  })
+
+  it('rejects UNC and protocol-relative', () => {
+    expect(isSafeHref('\\\\server\\share')).toBe(false)
+    expect(isSafeHref('//evil.com')).toBe(false)
+  })
+})

--- a/packages/docs/src/export/docx/href-safety.ts
+++ b/packages/docs/src/export/docx/href-safety.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared URL-safety policy for DOCX export hyperlinks.
+ *
+ * Kept in one place so inline links (marks.ts) and block/attachment links
+ * (nodes.ts) can never diverge. Blocks javascript:, file:, data:, vbscript:,
+ * and UNC paths (\\server\share or //server/share, an NTLM credential-leak
+ * vector); allows relative URLs and the http(s)/mailto/tel schemes.
+ */
+
+/** Allowed URL schemes for DOCX hyperlinks. */
+export const SAFE_HREF_SCHEMES = /^(?:https?|mailto|tel):/i
+
+/**
+ * Return true if `url` is safe to emit as a DOCX hyperlink target.
+ * Relative URLs (no scheme) are allowed; UNC paths and non-whitelisted
+ * schemes are rejected.
+ */
+export function isSafeHref(url: string): boolean {
+  // Strip leading whitespace / control chars before the scheme check — prevents
+  // a bypass like `\tjavascript:` or `\n  javascript:` that passes otherwise.
+  const trimmed = url.replace(/^[\s\x00-\x20]+/, '')
+  // Block UNC paths (\\server\share or //server/share) — NTLM credential leak vector.
+  if (/^\\\\/.test(trimmed) || /^\/\//.test(trimmed)) return false
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) && !SAFE_HREF_SCHEMES.test(trimmed)) return false
+  return true
+}

--- a/packages/docs/src/export/docx/images.test.ts
+++ b/packages/docs/src/export/docx/images.test.ts
@@ -1,0 +1,81 @@
+/**
+ * SSRF-gating tests for the DOCX image collector.
+ *
+ * Raw image `src` values must pass through the same trust boundary the editor
+ * enforces everywhere else (sanitizeAssetUrl: scheme + storage-host allowlist).
+ * A scheme-only check would let a document embed src="http://169.254.169.254/…"
+ * or an internal RFC1918 host and make the exporting user's browser fire a blind
+ * SSRF beacon from their authenticated session. data: URLs have no network
+ * egress and remain the legitimate inline-image case.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolveAndFetchImages } from './images.ts'
+import type { MdNode } from './types.ts'
+import type { resolveAttachments } from '../../attachments/api.ts'
+
+const noopResolve: typeof resolveAttachments = async () => ({ items: [], notFound: [] })
+
+function imageDoc(src: string): MdNode {
+  return { type: 'doc', content: [{ type: 'image', attrs: { src } }] } as MdNode
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('resolveAndFetchImages — raw src SSRF gating', () => {
+  it('does NOT fetch a non-allowlisted http host (internal/SSRF target)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { status: 200 }),
+    )
+    await resolveAndFetchImages('d1', imageDoc('http://169.254.169.254/latest/meta-data'), {
+      resolve: noopResolve,
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch an arbitrary external host lacking allowlist entry', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { status: 200 }),
+    )
+    await resolveAndFetchImages('d1', imageDoc('https://evil.attacker.example/x.png'), {
+      resolve: noopResolve,
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('DOES fetch an allowlisted storage host', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { status: 200 }),
+    )
+    await resolveAndFetchImages('d1', imageDoc('https://assets.octo.example.com/img.png'), {
+      resolve: noopResolve,
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('assets.octo.example.com')
+  })
+
+  it('DOES fetch a data: image (no network egress, inline case)', async () => {
+    // data: still goes through the guarded fetch path; jsdom/undici handles data URLs.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { status: 200 }),
+    )
+    await resolveAndFetchImages(
+      'd1',
+      imageDoc('data:image/png;base64,iVBORw0KGgo='),
+      { resolve: noopResolve },
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0][0])).toMatch(/^data:image\/png/)
+  })
+
+  it('does NOT fetch file:/blob:/javascript: schemes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { status: 200 }),
+    )
+    for (const bad of ['file:///etc/passwd', 'blob:https://x/y', 'javascript:alert(1)']) {
+      await resolveAndFetchImages('d1', imageDoc(bad), { resolve: noopResolve })
+    }
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/docs/src/export/docx/images.ts
+++ b/packages/docs/src/export/docx/images.ts
@@ -1,0 +1,225 @@
+/**
+ * Image collection and batch fetching for DOCX export.
+ * Collects image references from the document tree and fetches them as ArrayBuffers.
+ */
+
+import { resolveAttachments, type ResolvedAttachment } from '../../attachments/api.ts'
+import { sanitizeAssetUrl } from '../../editor/sanitize.ts'
+import type { MdNode, ImageRef, DocxContext } from './types.ts'
+
+/**
+ * Collect all image references (attachIds and direct src URLs) from the document tree.
+ */
+export function collectImageRefs(doc: MdNode): ImageRef[] {
+  const refs: ImageRef[] = []
+  const seen = new Set<string>()
+
+  const walk = (node: MdNode) => {
+    if (node.type === 'image') {
+      const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+      const src = typeof node.attrs?.src === 'string' ? node.attrs.src : undefined
+      const key = attachId || src || ''
+      if (key && !seen.has(key)) {
+        seen.add(key)
+        refs.push({ attachId, src })
+      }
+    }
+    node.content?.forEach(walk)
+  }
+  walk(doc)
+  return refs
+}
+
+/**
+ * Collect all unique attachIds from the document (images + fileAttachments).
+ */
+export function collectAttachIds(doc: MdNode): string[] {
+  const ids = new Set<string>()
+  const walk = (node: MdNode) => {
+    if (node.type === 'image' || node.type === 'fileAttachment') {
+      const id = node.attrs?.attachId
+      if (typeof id === 'string' && id) ids.add(id)
+    }
+    node.content?.forEach(walk)
+  }
+  walk(doc)
+  return [...ids]
+}
+
+/** Chunk an array into smaller arrays of the given size. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) return [arr]
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+/**
+ * Resolve all attachment URLs and fetch image buffers.
+ * Returns the resolved URL map and image buffer map for the context.
+ */
+export async function resolveAndFetchImages(
+  docId: string,
+  doc: MdNode,
+  options: {
+    batchSize?: number
+    resolve?: typeof resolveAttachments
+  } = {},
+): Promise<{ urls: Map<string, ResolvedAttachment>; imageBuffers: Map<string, ArrayBuffer> }> {
+  const batchSize = options.batchSize ?? 200
+  const resolve = options.resolve ?? resolveAttachments
+
+  // Step 1: resolve all attach IDs to get signed URLs
+  const ids = collectAttachIds(doc)
+  const urls = new Map<string, ResolvedAttachment>()
+  for (const idChunk of chunk(ids, batchSize)) {
+    if (idChunk.length === 0) continue
+    const res = await resolve(docId, idChunk)
+    for (const item of res.items) urls.set(item.attachId, item)
+  }
+
+  // Step 2: collect image refs and determine which URLs to fetch
+  const imageRefs = collectImageRefs(doc)
+  const imageBuffers = new Map<string, ArrayBuffer>()
+
+  // Fetch images in parallel (with concurrency limit)
+  const fetchQueue: Array<{ url: string; key: string }> = []
+  for (const ref of imageRefs) {
+    let url: string | undefined
+    if (ref.attachId) {
+      const resolved = urls.get(ref.attachId)
+      if (resolved?.url) url = resolved.url
+    }
+    if (!url && ref.src) {
+      // Gate raw src through the same trust boundary the editor enforces everywhere
+      // else (ImageNode/ImageNodeView -> sanitizeAssetUrl): scheme + storage-host
+      // allowlist. A scheme-only check here would let a document embed
+      // src="http://169.254.169.254/..." or an internal RFC1918 host and make the
+      // exporting user's browser fire a blind SSRF beacon from their authed session.
+      //
+      // data: URLs have no network egress (no SSRF) and are the legitimate inline
+      // image case, so they are allowed directly. http(s) must pass the host
+      // allowlist; anything else (file:, javascript:, blob:, cross-origin, UNC) is
+      // silently omitted — the resolved-attachment happy path covers the real embed.
+      if (/^data:/i.test(ref.src)) {
+        url = ref.src
+      } else {
+        const safe = sanitizeAssetUrl(ref.src)
+        if (safe) url = safe
+      }
+    }
+    if (url) {
+      const key = ref.attachId || url
+      fetchQueue.push({ url, key })
+    }
+  }
+
+  // Fetch with concurrency limit of 5
+  const CONCURRENCY = 5
+  for (let i = 0; i < fetchQueue.length; i += CONCURRENCY) {
+    const batch = fetchQueue.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(
+      batch.map(async ({ url, key }) => {
+        const MAX_BYTES = 10 * 1024 * 1024
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 15_000)
+        try {
+          const res = await fetch(url, { signal: controller.signal })
+          if (!res.ok) return
+          // Reject early on an honest content-length over the cap.
+          const contentLength = Number(res.headers.get('content-length')) || 0
+          if (contentLength > MAX_BYTES) return
+          // Stream the body and enforce the cap on accumulated bytes so a
+          // missing/spoofed content-length cannot force an unbounded
+          // allocation. The abort controller stays live through the whole
+          // body read, so a stalled/dribbling host still frees its pool slot.
+          const reader = res.body?.getReader()
+          if (!reader) {
+            // No stream reader (e.g. data: URL) — fall back to a guarded read.
+            const buffer = await res.arrayBuffer()
+            if (buffer.byteLength > MAX_BYTES) return
+            imageBuffers.set(key, buffer)
+            return
+          }
+          const chunks: Uint8Array[] = []
+          let total = 0
+          for (;;) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (value) {
+              total += value.byteLength
+              if (total > MAX_BYTES) {
+                controller.abort()
+                return
+              }
+              chunks.push(value)
+            }
+          }
+          const merged = new Uint8Array(total)
+          let offset = 0
+          for (const chunk of chunks) {
+            merged.set(chunk, offset)
+            offset += chunk.byteLength
+          }
+          imageBuffers.set(key, merged.buffer)
+        } catch {
+          // Timeout, abort, or network error — skip this image
+        } finally {
+          clearTimeout(timeoutId)
+        }
+      }),
+    )
+    // Silently skip failed image fetches — the export continues without them
+    void results
+  }
+
+  return { urls, imageBuffers }
+}
+
+/**
+ * Get the image buffer for a given node from the context.
+ * Returns undefined if the image couldn't be fetched.
+ */
+export function getImageBuffer(node: MdNode, ctx: DocxContext): ArrayBuffer | undefined {
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const src = typeof node.attrs?.src === 'string' ? node.attrs.src : undefined
+
+  if (attachId) {
+    const buffer = ctx.imageBuffers.get(attachId)
+    if (buffer) return buffer
+  }
+  if (src) {
+    return ctx.imageBuffers.get(src)
+  }
+  return undefined
+}
+
+/**
+ * Guess image dimensions from node attrs or use defaults.
+ */
+export function getImageDimensions(node: MdNode): { width: number; height: number } {
+  const width = typeof node.attrs?.width === 'number' ? node.attrs.width : undefined
+  const height = typeof node.attrs?.height === 'number' ? node.attrs.height : undefined
+
+  // Only accept strictly positive, finite dimensions; anything else
+  // (negative, zero, NaN, Infinity) falls back to the default size.
+  if (
+    width &&
+    height &&
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0
+  ) {
+    // Cap width at 600px for DOCX page width
+    const maxWidth = 600
+    if (width > maxWidth) {
+      const ratio = maxWidth / width
+      return { width: maxWidth, height: Math.round(height * ratio) }
+    }
+    return { width, height }
+  }
+
+  // Default image size
+  return { width: 400, height: 300 }
+}

--- a/packages/docs/src/export/docx/index.ts
+++ b/packages/docs/src/export/docx/index.ts
@@ -1,0 +1,92 @@
+/**
+ * DOCX Export Module — Main Entry Point.
+ *
+ * Converts a ProseMirror JSON document into a DOCX file (as Blob).
+ * Uses the `docx` library (github.com/dolanmiu/docx).
+ *
+ * Images are resolved via the resolveAttachments API (same as markdown export)
+ * and fetched as ArrayBuffers for embedding with ImageRun.
+ */
+
+import { Document, Packer, type ISectionOptions } from 'docx'
+import { resolveAttachments } from '../../attachments/api.ts'
+import { resolveAndFetchImages } from './images.ts'
+import { convertBlocks, NUMBERING_CONFIG, ORDERED_LIST_CONFIG_INDEX } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxExportOptions, DocxContext } from './types.ts'
+
+export type { MdNode, DocxExportOptions }
+
+/**
+ * Export a ProseMirror JSON document to a DOCX Blob.
+ *
+ * @param docId - The document ID (used for resolving attachments).
+ * @param doc - The ProseMirror JSON root node (from editor.getJSON()).
+ * @param opts - Optional configuration for batch size, resolve function, emoji resolver.
+ * @returns A Blob containing the .docx file.
+ */
+export async function exportDocToDocx(
+  docId: string,
+  doc: MdNode,
+  opts: DocxExportOptions = {},
+): Promise<Blob> {
+  const resolve = opts.resolve ?? resolveAttachments
+
+  // Resolve attachment URLs and fetch image buffers
+  const { urls, imageBuffers } = await resolveAndFetchImages(docId, doc, {
+    batchSize: opts.batchSize,
+    resolve,
+  })
+
+  // Build the conversion context
+  const ctx: DocxContext = {
+    urls,
+    imageBuffers,
+    emojiGlyph: opts.emojiGlyph,
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+
+  // Convert ProseMirror JSON blocks to docx elements
+  const children = convertBlocks(doc.content ?? [], ctx)
+
+  // Create the document section
+  const section: ISectionOptions = {
+    properties: {
+      page: {
+        margin: {
+          top: 1440,    // 1 inch
+          right: 1440,
+          bottom: 1440,
+          left: 1440,
+        },
+      },
+    },
+    children,
+  }
+
+  // Build numbering config: static defs + one reference per non-default-start
+  // ordered list. Each dynamic reference clones the ordered-list levels but sets
+  // level[0].start (docx derives an instance's first number from level[0].start).
+  const orderedLevels = NUMBERING_CONFIG.config[ORDERED_LIST_CONFIG_INDEX].levels
+  const numbering = {
+    config: [
+      ...NUMBERING_CONFIG.config,
+      ...ctx.dynamicNumbering.map((dn) => ({
+        reference: dn.reference,
+        levels: orderedLevels.map((lvl) => (lvl.level === dn.level ? { ...lvl, start: dn.start } : lvl)),
+      })),
+    ],
+  }
+
+  // Create the full document with styles and numbering
+  const document = new Document({
+    styles: DOCX_STYLES,
+    numbering,
+    sections: [section],
+  })
+
+  // Pack the document into a Blob
+  const buffer = await Packer.toBlob(document)
+  return buffer
+}

--- a/packages/docs/src/export/docx/marks.test.ts
+++ b/packages/docs/src/export/docx/marks.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeDocxColor, buildRunOptionsFromMarks } from './marks.ts'
+
+// <w:color w:val="…"/> requires a bare 6-hex value. Authored content from the
+// in-app picker is already #rrggbb, but pasted/imported content can carry
+// rgb(…) or short #abc forms the browser produced. Passing those straight
+// through yields OOXML Word rejects as corrupt, so normalizeDocxColor maps what
+// it can to 6-hex and drops the rest.
+describe('normalizeDocxColor', () => {
+  it('passes through 6-hex (with or without #), lowercased', () => {
+    expect(normalizeDocxColor('#FF0000')).toBe('ff0000')
+    expect(normalizeDocxColor('abcdef')).toBe('abcdef')
+  })
+
+  it('expands short #abc / abc to 6-hex', () => {
+    expect(normalizeDocxColor('#abc')).toBe('aabbcc')
+    expect(normalizeDocxColor('f0a')).toBe('ff00aa')
+  })
+
+  it('converts rgb()/rgba() with 0-255 components to 6-hex', () => {
+    expect(normalizeDocxColor('rgb(255, 0, 0)')).toBe('ff0000')
+    expect(normalizeDocxColor('rgba(0, 128, 255, 0.5)')).toBe('0080ff')
+  })
+
+  it('drops (returns null) values it cannot safely map', () => {
+    expect(normalizeDocxColor('red')).toBeNull() // named colour
+    expect(normalizeDocxColor('hsl(0, 100%, 50%)')).toBeNull()
+    expect(normalizeDocxColor('rgb(300, 0, 0)')).toBeNull() // out of range
+    expect(normalizeDocxColor('#12g')).toBeNull()
+    expect(normalizeDocxColor('')).toBeNull()
+  })
+})
+
+// <w:sz w:val="…"/> is in half-points. A hostile/corrupt textStyle fontSize can
+// carry a negative, zero, non-finite, or absurd value; an out-of-range w:sz
+// produces invalid/unusable OOXML, so buildRunOptionsFromMarks clamps it.
+describe('buildRunOptionsFromMarks — fontSize clamp', () => {
+  const sizeOf = (fontSize: string) =>
+    buildRunOptionsFromMarks([{ type: 'textStyle', attrs: { fontSize } }]).size
+
+  it('converts a normal pt size to half-points', () => {
+    expect(sizeOf('16px')).toBe(32)
+    expect(sizeOf('12')).toBe(24)
+  })
+
+  it('clamps an absurd size to the max (3276 half-points)', () => {
+    expect(sizeOf('100000px')).toBe(3276)
+  })
+
+  it('drops non-positive / non-finite sizes', () => {
+    expect(sizeOf('0')).toBeUndefined()
+    expect(sizeOf('-12px')).toBeUndefined()
+    expect(sizeOf('NaNpx')).toBeUndefined()
+    expect(sizeOf('abc')).toBeUndefined()
+  })
+
+  it('clamps a tiny sub-1pt size up to the min (2 half-points)', () => {
+    expect(sizeOf('0.1px')).toBe(2)
+  })
+})

--- a/packages/docs/src/export/docx/marks.ts
+++ b/packages/docs/src/export/docx/marks.ts
@@ -1,0 +1,287 @@
+/**
+ * Inline mark converters for the DOCX export.
+ * Converts ProseMirror marks (bold, italic, code, strike, link, underline,
+ * highlight, textStyle, subscript, superscript) into docx TextRun options.
+ */
+
+import { type IRunOptions, ExternalHyperlink, TextRun, UnderlineType, type ParagraphChild } from 'docx'
+import { FONT_CODE, FONT_EMOJI } from './styles.ts'
+import { isSafeHref } from './href-safety.ts'
+import { latexToMathComponent } from './math.ts'
+import type { MdNode } from './types.ts'
+
+type MarkDef = { type: string; attrs?: Record<string, unknown> }
+
+/**
+ * Normalise a CSS colour to the bare 6-hex value `<w:color w:val="…"/>` requires.
+ * The in-app picker emits `#rrggbb`, but pasted/imported content can carry named
+ * colours the browser rewrites to `rgb(…)`, or short `#abc` form. Passing those
+ * straight through yields OOXML Word rejects as corrupt, so map what we can to
+ * 6-hex and drop (return null) anything we can't, mirroring the safe-fallback
+ * approach used elsewhere.
+ */
+export function normalizeDocxColor(raw: string): string | null {
+  const s = raw.trim().toLowerCase()
+  // #rrggbb / rrggbb
+  let m = /^#?([0-9a-f]{6})$/.exec(s)
+  if (m) return m[1]
+  // #rgb / rgb -> expand each nibble
+  m = /^#?([0-9a-f]{3})$/.exec(s)
+  if (m) {
+    const [r, g, b] = m[1]
+    return `${r}${r}${g}${g}${b}${b}`
+  }
+  // rgb(r, g, b) with 0-255 components
+  m = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*[\d.]+\s*)?\)$/.exec(s)
+  if (m) {
+    const parts = [m[1], m[2], m[3]].map((n) => {
+      const v = Number(n)
+      if (v < 0 || v > 255) return null
+      return v.toString(16).padStart(2, '0')
+    })
+    if (parts.every((p) => p !== null)) return parts.join('')
+  }
+  return null // unmappable (named colour, hsl, etc.) -> drop rather than corrupt
+}
+
+/**
+ * Regex matching emoji / pictographic codepoints that the body font (微软雅黑)
+ * cannot render. Covers the main emoji blocks + variation selectors + ZWJ so
+ * multi-codepoint emoji (e.g. 👩‍💻, keycaps, flags) stay in one run.
+ *
+ * Also covers a few BMP "letterlike / punctuation" symbols that combine with a
+ * trailing U+FE0F to form emoji (‼️ U+203C, ⁉️ U+2049, ™️ U+2122, ℹ️ U+2139,
+ * ↔️↕️ etc.). Without these, the base char stayed in the body font while the
+ * orphaned FE0F got split into an emoji-font run and rendered as a tofu box.
+ */
+const EMOJI_RE =
+  /([\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{1F1E6}-\u{1F1FF}\u{203C}\u{2049}\u{2122}\u{2139}\u{2190}-\u{21FF}\u{2300}-\u{23FF}\u{FE0F}\u{20E3}\u{200D}]+)/u
+
+/**
+ * Build a single TextRun for a literal emoji/pictographic glyph, tagged with the
+ * emoji font so it doesn't inherit the body font (微软雅黑) and render blank.
+ * Use for hardcoded UI glyphs like 📎 / 🔗 / ☑ / callout icons.
+ *
+ * Strips the U+FE0F variation selector: for base symbols like ℹ (U+2139) / ⚠
+ * (U+26A0), the emoji font already renders the colored glyph from the base char,
+ * and a trailing FE0F has no composed glyph in many Word emoji fonts (notably on
+ * macOS), so it shows up as an extra tofu box right after the icon. Dropping FE0F
+ * keeps the colored glyph and removes the box.
+ */
+export function emojiRun(text: string, opts: IRunOptions = {}): TextRun {
+  return new TextRun({ text: text.replace(/\uFE0F/gu, ''), ...opts, font: FONT_EMOJI })
+}
+
+/**
+ * Emit an icon glyph followed by a single normal-width space, as two runs.
+ *
+ * The glyph carries the emoji font; the trailing space is a separate run in the
+ * inherited body font. A space inside an emoji-font run renders far too wide in
+ * Word (looks like an accidental gap), so the separator space must NOT live in
+ * the emoji run. Pass the bare glyph here (no trailing space in the string).
+ */
+export function iconPrefix(glyph: string, opts: IRunOptions = {}): ParagraphChild[] {
+  return [emojiRun(glyph, opts), new TextRun({ text: ' ', ...opts })]
+}
+
+/**
+ * Split text into runs, applying the emoji font only to emoji segments so that
+ * CJK/latin text keeps its inherited body font. Returns one or more TextRuns.
+ */
+export function buildTextRuns(text: string, baseOpts: IRunOptions): TextRun[] {
+  if (!text) return []
+  // Fast path: no emoji → single run.
+  if (!EMOJI_RE.test(text)) return [new TextRun({ text, ...baseOpts })]
+
+  const runs: TextRun[] = []
+  // Split keeping delimiters (emoji chunks) via a global clone of the regex.
+  const parts = text.split(new RegExp(EMOJI_RE, 'gu'))
+  for (const part of parts) {
+    if (!part) continue
+    const isEmoji = new RegExp(`^${EMOJI_RE.source}$`, 'u').test(part)
+    runs.push(
+      new TextRun(
+        isEmoji
+          ? { text: part.replace(/\uFE0F/gu, ''), ...baseOpts, font: FONT_EMOJI }
+          : { text: part, ...baseOpts },
+      ),
+    )
+  }
+  return runs
+}
+
+/**
+ * Build IRunOptions properties from an array of marks.
+ * Returns run options that should be spread into the TextRun constructor.
+ * Uses a mutable intermediate to avoid readonly assignment errors.
+ */
+export function buildRunOptionsFromMarks(marks: MarkDef[]): IRunOptions {
+  const opts: Record<string, unknown> = {}
+
+  for (const mark of marks) {
+    switch (mark.type) {
+      case 'bold':
+      case 'strong':
+        opts.bold = true
+        break
+      case 'italic':
+      case 'em':
+        opts.italics = true
+        break
+      case 'code':
+        opts.font = FONT_CODE
+        opts.shading = { fill: 'F0F0F0' }
+        break
+      case 'strike':
+        opts.strike = true
+        break
+      case 'underline':
+        opts.underline = { type: UnderlineType.SINGLE }
+        break
+      case 'highlight': {
+        // docx highlight only supports named colors; use yellow as default
+        opts.highlight = 'yellow'
+        break
+      }
+      case 'textStyle': {
+        const textColor = mark.attrs?.color
+        if (typeof textColor === 'string' && textColor) {
+          const hex = normalizeDocxColor(textColor)
+          if (hex) opts.color = hex // drop unmappable colours; a bad w:val corrupts the .docx
+        }
+        const fontSize = mark.attrs?.fontSize
+        if (typeof fontSize === 'string') {
+          const pt = parseFloat(fontSize)
+          // Clamp to a sane range before emitting <w:sz w:val="…"/> (half-points).
+          // A hostile/corrupt attr can carry a negative, zero, non-finite, or
+          // absurd size; an out-of-range w:sz produces invalid/unusable OOXML.
+          // 2 half-points (1pt) .. 3276 half-points (1638pt) is well within limits.
+          if (Number.isFinite(pt) && pt > 0) {
+            const halfPoints = Math.round(pt * 2)
+            opts.size = Math.min(3276, Math.max(2, halfPoints))
+          }
+        }
+        break
+      }
+      case 'subscript':
+        opts.subScript = true
+        break
+      case 'superscript':
+        opts.superScript = true
+        break
+      // 'link' is handled separately as it wraps in ExternalHyperlink
+    }
+  }
+
+  return opts as IRunOptions
+}
+
+/**
+ * Check if marks contain a link mark, and return its href (if safe).
+ * Returns null for unsafe schemes, UNC paths, or non-string values.
+ */
+export function extractLinkHref(marks: MarkDef[]): string | null {
+  const linkMark = marks.find((m) => m.type === 'link')
+  if (!linkMark) return null
+  const href = linkMark.attrs?.href
+  if (typeof href !== 'string') return null
+  // Strip leading whitespace / control chars, then apply the shared href policy
+  // (scheme allowlist + UNC block). Return the trimmed value so downstream emits
+  // the same string the policy vetted.
+  const trimmed = href.replace(/^[\s\x00-\x20]+/, '')
+  return isSafeHref(trimmed) ? trimmed : null
+}
+
+/**
+ * Convert inline nodes to an array of TextRun or ExternalHyperlink elements.
+ * Handles text nodes with marks, hardBreak, inlineMath, mention, and emoji.
+ */
+export function convertInlineContent(
+  nodes: MdNode[],
+  emojiGlyph?: (name: string | null | undefined) => string | undefined,
+): ParagraphChild[] {
+  const runs: ParagraphChild[] = []
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'text': {
+        const text = node.text ?? ''
+        if (!text) break
+        const marks = node.marks ?? []
+        const linkHref = extractLinkHref(marks)
+        const runOpts = buildRunOptionsFromMarks(marks.filter((m) => m.type !== 'link'))
+
+        if (linkHref) {
+          runs.push(
+            new ExternalHyperlink({
+              children: buildTextRuns(text, { ...runOpts, style: 'Hyperlink' }),
+              link: linkHref,
+            }),
+          )
+        } else {
+          runs.push(...buildTextRuns(text, runOpts))
+        }
+        break
+      }
+      case 'hardBreak':
+        runs.push(new TextRun({ break: 1 }))
+        break
+      case 'inlineMath': {
+        const latex = typeof node.attrs?.latex === 'string' ? node.attrs.latex : ''
+        const math = latexToMathComponent(latex, false)
+        if (math) {
+          // Real OMML formula, rendered natively by Word.
+          runs.push(math)
+        } else {
+          // Fallback: conversion failed — keep the LaTeX source (wrapped in `$`)
+          // as monospace text so no content is lost.
+          runs.push(
+            new TextRun({
+              text: `$${latex}$`,
+              font: FONT_CODE,
+              italics: true,
+            }),
+          )
+        }
+        break
+      }
+      case 'mention': {
+        const label = node.attrs?.label ?? node.attrs?.id ?? ''
+        runs.push(
+          new TextRun({
+            text: `@${label}`,
+            bold: true,
+            color: '1A73E8',
+          }),
+        )
+        break
+      }
+      case 'emoji': {
+        const name = typeof node.attrs?.name === 'string' ? node.attrs.name : null
+        const glyph = emojiGlyph?.(name)
+        const emojiText = glyph ?? (name ? `:${name}:` : '')
+        // Apply the emoji font: the body font (微软雅黑) has no emoji glyphs and
+        // Word does NOT auto-fallback, so bare runs render as blank boxes.
+        // buildTextRuns only tags actual emoji codepoints (leaves `:name:` text alone).
+        runs.push(...buildTextRuns(emojiText, {}))
+        break
+      }
+      case 'image': {
+        // Inline images are handled at a higher level; emit alt text as fallback
+        const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : '[image]'
+        runs.push(new TextRun({ text: alt, italics: true, color: '888888' }))
+        break
+      }
+      default: {
+        // Recurse into unknown inline containers
+        if (node.content && node.content.length) {
+          runs.push(...convertInlineContent(node.content, emojiGlyph))
+        } else if (node.text) {
+          runs.push(new TextRun({ text: node.text }))
+        }
+      }
+    }
+  }
+
+  return runs
+}

--- a/packages/docs/src/export/docx/math-fallback.test.ts
+++ b/packages/docs/src/export/docx/math-fallback.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Fallback behavior for math in the DOCX export.
+ *
+ * When LaTeX → OMML conversion fails (bad init, unsupported construct, etc.),
+ * `latexToMathComponent` returns null and the node/mark converters must fall
+ * back to rendering the raw LaTeX source as text rather than crashing the
+ * export or silently dropping the formula. We force the failure by mocking the
+ * math module so it always returns null.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// Force every conversion to "fail" so the fallback branches run.
+vi.mock('./math.ts', () => ({
+  latexToMathComponent: () => null,
+}))
+
+import { convertBlocks } from './nodes.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function newCtx(): DocxContext {
+  return { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+}
+
+/** Collect all text found in a docx element tree via JSON round-trip. */
+function serialize(el: unknown): string {
+  return JSON.stringify(el)
+}
+
+describe('math fallback when conversion fails', () => {
+  it('block math falls back to the raw LaTeX source text', () => {
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\int_0^1 x\\,dx' } },
+    ] as MdNode[]
+
+    const children = convertBlocks(doc, newCtx())
+    expect(children.length).toBe(1)
+    const json = serialize(children[0])
+    // Source text preserved, no OMML emitted.
+    expect(json).toContain('\\\\int_0^1 x')
+    expect(json).not.toContain('m:oMath')
+  })
+
+  it('inline math falls back to $...$ wrapped source text', () => {
+    const doc: MdNode[] = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'a ' },
+          { type: 'inlineMath', attrs: { latex: 'x^2' } },
+          { type: 'text', text: ' b' },
+        ],
+      },
+    ] as MdNode[]
+
+    const children = convertBlocks(doc, newCtx())
+    const json = serialize(children[0])
+    expect(json).toContain('$x^2$')
+    expect(json).not.toContain('m:oMath')
+    // Surrounding text still present.
+    expect(json).toContain('a ')
+    expect(json).toContain(' b')
+  })
+
+  it('does not throw — export stays alive on conversion failure', () => {
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: 'E = mc^2' } },
+    ] as MdNode[]
+    expect(() => convertBlocks(doc, newCtx())).not.toThrow()
+  })
+})

--- a/packages/docs/src/export/docx/math.test.ts
+++ b/packages/docs/src/export/docx/math.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for math (LaTeX → OMML) handling in the DOCX export.
+ *
+ * Word renders native, editable formulas only from OMML (`<m:oMath>`) markup.
+ * These tests cover the conversion chain (LaTeX → MathML → OMML → docx) at the
+ * unit level and end-to-end by packing a real .docx and asserting the OMML
+ * nodes land in word/document.xml. The fallback path (conversion failure →
+ * plain source text) is covered in math-fallback.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document, Paragraph } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { latexToMathComponent } from './math.ts'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/** The three formulas from the task brief. */
+const FORMULAS = [
+  'E = mc^2',
+  '\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}',
+  '\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}',
+]
+
+/** Build a full docx from blocks, pack it, unzip word/document.xml. */
+async function renderDocumentXml(doc: MdNode[]): Promise<string> {
+  const ctx: DocxContext = {
+    urls: new Map(),
+    imageBuffers: new Map(),
+    dynamicNumbering: [],
+    orderedListInstance: 0,
+  }
+  const children = convertBlocks(doc, ctx)
+  const document = new Document({
+    styles: DOCX_STYLES,
+    numbering: NUMBERING_CONFIG,
+    sections: [{ children }],
+  })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `math-e2e-${process.pid}-${children.length}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+describe('latexToMathComponent (unit)', () => {
+  it('returns a component for each brief formula (block)', () => {
+    for (const latex of FORMULAS) {
+      const comp = latexToMathComponent(latex, true)
+      expect(comp, `block: ${latex}`).not.toBeNull()
+    }
+  })
+
+  it('returns a component for inline math', () => {
+    expect(latexToMathComponent('x^2', false)).not.toBeNull()
+  })
+
+  it('returns null for empty / whitespace latex (caller falls back)', () => {
+    expect(latexToMathComponent('', true)).toBeNull()
+    expect(latexToMathComponent('   ', false)).toBeNull()
+  })
+
+  it('produced component serializes to an <m:oMath> element', () => {
+    // A component placed in a paragraph must serialize as real OMML markup.
+    const comp = latexToMathComponent('E = mc^2', true)!
+    const p = new Paragraph({ children: [comp] })
+    const json = JSON.stringify(p)
+    expect(json).toContain('m:oMath')
+    // No malformed <undefined> wrapper (the fromXmlString trap).
+    expect(json).not.toContain('undefined')
+  })
+})
+
+describe('block math end-to-end docx export', () => {
+  it('each brief formula produces one <m:oMath> node in document.xml', async () => {
+    const doc: MdNode[] = FORMULAS.map((latex) => ({
+      type: 'blockMath',
+      attrs: { latex },
+    })) as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    // One native formula per input, balanced open/close, no malformed wrapper.
+    const opens = xml.match(/<m:oMath[ >]/g) ?? []
+    const closes = xml.match(/<\/m:oMath>/g) ?? []
+    expect(opens.length).toBe(FORMULAS.length)
+    expect(closes.length).toBe(FORMULAS.length)
+    expect(xml).not.toContain('<undefined')
+
+    // The LaTeX source must NOT be dumped verbatim as body text.
+    expect(xml).not.toContain('\\int_')
+    expect(xml).not.toContain('\\sqrt')
+    expect(xml).not.toContain('\\frac')
+  })
+
+  it('math structures + operators are present (radical, fraction, ∑, ∫)', async () => {
+    const doc: MdNode[] = FORMULAS.map((latex) => ({
+      type: 'blockMath',
+      attrs: { latex },
+    })) as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('schemas.openxmlformats.org/officeDocument/2006/math')
+    // √ becomes a radical structure, fractions a <m:f>, large operators carry
+    // their Unicode codepoint in m:chr.
+    expect(xml).toContain('<m:rad') // \sqrt{\pi}
+    expect(xml).toContain('<m:f>') // \frac{...}{...}
+    expect(xml).toContain('m:val="∑"') // \sum
+    expect(xml).toContain('m:val="∫"') // \int
+    // The invalid `m:sty m:val="undefined"` mml2omml quirk must be sanitized.
+    expect(xml).not.toContain('m:val="undefined"')
+    expect(xml).not.toContain('<undefined')
+  })
+
+  it('CORE: n-ary operators (∫ ∑) carry a NON-EMPTY <m:e> operand body', async () => {
+    // This is the regression that motivated replacing mml2omml: it emitted
+    // <m:nary>…<m:e/></m:nary> (empty body) and stranded the integrand, so Word
+    // drew an empty little box. Every nary MUST have a populated <m:e>.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: FORMULAS[1] } }, // integral
+      { type: 'blockMath', attrs: { latex: FORMULAS[2] } }, // sum
+    ] as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    // No empty operand body anywhere (neither self-closing nor <m:e></m:e>).
+    expect(xml).not.toContain('<m:e/>')
+    expect(xml).not.toMatch(/<m:e>\s*<\/m:e>/)
+
+    // Pull each nary's operand body out and prove it is non-empty and actually
+    // contains the integrand / summand content, not just whitespace.
+    const bodies = [...xml.matchAll(/<m:nary>[\s\S]*?<m:e>([\s\S]*?)<\/m:e>\s*<\/m:nary>/g)].map(
+      (m) => m[1],
+    )
+    expect(bodies.length).toBe(2) // one ∫, one ∑
+    for (const body of bodies) {
+      expect(body.length).toBeGreaterThan(0)
+      expect(body).toContain('<m:r>') // real runs inside the body
+    }
+    // The Gaussian integral's body must contain the integrand e and x
+    // (e^{-x^2} dx), and the ∑ body must contain its 1/n^2 fraction.
+    const integralBody = bodies.find((b) => b.includes('π') === false && b.includes('e</m:t>'))
+    expect(integralBody, 'integral operand body').toBeDefined()
+    expect(integralBody).toContain('>e<')
+    expect(integralBody).toContain('>x<')
+    expect(bodies.some((b) => b.includes('<m:f>'))).toBe(true) // ∑ body has the fraction
+  })
+
+})
+
+describe('inline math end-to-end docx export', () => {
+  it('inline formula lands inside a paragraph alongside its text', async () => {
+    const doc: MdNode[] = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: '质能方程 ' },
+          { type: 'inlineMath', attrs: { latex: 'E = mc^2' } },
+          { type: 'text', text: ' 很有名' },
+        ],
+      },
+    ] as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    expect(xml).toContain('<m:oMath')
+    expect((xml.match(/<m:oMath[ >]/g) ?? []).length).toBe(1)
+    // The surrounding CJK text must still be present as normal runs.
+    expect(xml).toContain('质能方程')
+    expect(xml).toContain('很有名')
+    // Not the old `$...$` literal source.
+    expect(xml).not.toContain('$E = mc^2$')
+  })
+
+  it('n-ary operand keeps a parenthesised body across an inner +/- (bracket depth)', async () => {
+    // Regression: the operand-body scan used to stop at the first relation /
+    // binary-arith `mo` with no bracket tracking, so `\int (x+1)\,dx` truncated
+    // the operand at the inner `+` and stranded `1) dx` outside the integral.
+    // With fence-depth tracking, the `+` inside `(...)` no longer terminates the
+    // body, so the whole `(x+1) dx` stays inside a single <m:e>.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\int (x+1)\\,dx' } },
+    ] as MdNode[]
+
+    const xml = await renderDocumentXml(doc)
+
+    // Exactly one integral, with a populated (non-empty) operand body.
+    expect(xml).toContain('m:val="∫"')
+    expect(xml).not.toContain('<m:e/>')
+    expect(xml).not.toMatch(/<m:e>\s*<\/m:e>/)
+    // The body must still carry the `dx` tail that used to be stranded — i.e. a
+    // `d` and an `x` variable run survive inside the math, and no LaTeX leaks.
+    expect(xml).not.toContain('\\int')
+    expect(xml).not.toContain('\\,')
+  })
+})

--- a/packages/docs/src/export/docx/math.ts
+++ b/packages/docs/src/export/docx/math.ts
@@ -1,0 +1,123 @@
+/**
+ * LaTeX → OMML conversion for the DOCX export.
+ *
+ * Word only renders native, editable math from OMML (`<m:oMath>`) markup, so we
+ * cannot just drop the LaTeX source into a run (that renders as literal text).
+ * The conversion chain is:
+ *
+ *   LaTeX ──(mathjax-full, TeX input)──▶ MathML
+ *         ──(our mathmlToOmml)─────────▶ OMML string
+ *         ──(xml-js + docx.convertToXmlComponent)──▶ docx XmlComponent
+ *
+ * The resulting component can be pushed straight into a Paragraph's children.
+ *
+ * We convert MathML→OMML ourselves (see ./mathml-to-omml) rather than using the
+ * `mathml2omml` package: that package emits large operators (∫ ∑ …) as an
+ * `<m:nary>` with an EMPTY `<m:e>` and strands the integrand as sibling runs,
+ * which Word renders as an empty little box — the "公式还在小方格里" bug.
+ *
+ * docx 9.7.1 note: the package's index exports `Math`/`MathRun` builders, but
+ * assembling arbitrary formulas from those by hand would require a full LaTeX
+ * parser. Instead we inject the raw OMML via the exported `convertToXmlComponent`
+ * helper. `ImportedXmlComponent.fromXmlString` is NOT usable directly here: it
+ * feeds the whole string through `xml2js` and wraps the document root — whose
+ * xml-js node has no tag name — producing a malformed `<undefined>…</undefined>`
+ * wrapper around the `<m:oMath>`. So we parse ourselves and hand
+ * `convertToXmlComponent` the actual `<m:oMath>` element node.
+ *
+ * The MathJax pipeline is built lazily once and reused. Any failure anywhere in
+ * the chain returns null so callers can fall back to plain source text without
+ * crashing the whole export.
+ */
+
+import { convertToXmlComponent, type ParagraphChild } from 'docx'
+import { xml2js, type Element } from 'xml-js'
+import { mathjax } from 'mathjax-full/js/mathjax.js'
+import { TeX } from 'mathjax-full/js/input/tex.js'
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js'
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js'
+import { SerializedMmlVisitor } from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js'
+import { STATE } from 'mathjax-full/js/core/MathItem.js'
+import type { MmlNode } from 'mathjax-full/js/core/MmlTree/MmlNode.js'
+import { mathmlToOmml } from './mathml-to-omml.ts'
+
+/** LaTeX → MathML converter, or null if MathJax failed to initialize. */
+type MathMLConverter = (latex: string, display: boolean) => string
+
+// `undefined` = not yet initialized; `null` = init failed (don't retry).
+let converter: MathMLConverter | null | undefined
+
+/**
+ * Build the MathJax TeX→MathML pipeline once and cache it.
+ *
+ * We stop conversion at `STATE.COMPILED`: that yields the internal MathML tree
+ * (which we serialize) without running a display/output jax — MathJax ships no
+ * MathML output jax in this build, and later stages (e.g. the `AllPackages`
+ * `bussproofs` extension) demand an output jax with `getBBox()`. Restricting to
+ * the `base` + `ams` packages keeps us to macros that compile without one while
+ * still covering the vast majority of real-world formulas.
+ */
+function getConverter(): MathMLConverter | null {
+  if (converter !== undefined) return converter
+  try {
+    const adaptor = liteAdaptor()
+    RegisterHTMLHandler(adaptor)
+    const tex = new TeX({ packages: ['base', 'ams'] })
+    const doc = mathjax.document('', { InputJax: tex })
+    const visitor = new SerializedMmlVisitor()
+    converter = (latex: string, display: boolean): string => {
+      const node = doc.convert(latex, { display, end: STATE.COMPILED }) as MmlNode
+      return visitor.visitTree(node)
+    }
+  } catch (err) {
+    console.warn('[docx] MathJax pipeline init failed; math falls back to source text', err)
+    converter = null
+  }
+  return converter
+}
+
+/**
+ * Convert a LaTeX formula into a docx math component ready to be placed in a
+ * Paragraph's children.
+ *
+ * @param latex   the LaTeX source (without surrounding `$`/`$$`)
+ * @param display true for block/display math, false for inline
+ * @returns the math component, or null if conversion failed (caller should
+ *          fall back to rendering the raw source text)
+ */
+export function latexToMathComponent(latex: string, display: boolean): ParagraphChild | null {
+  const src = typeof latex === 'string' ? latex.trim() : ''
+  if (!src) return null
+
+  const convert = getConverter()
+  if (!convert) return null
+
+  try {
+    const mathml = convert(src, display)
+    const omml = mathmlToOmml(mathml)
+
+    // Parse the OMML ourselves and hand convertToXmlComponent the actual
+    // <m:oMath> element (see the file header for why fromXmlString is unsafe).
+    const parsed = xml2js(omml, { compact: false }) as Element
+    const root = (parsed.elements ?? []).find(
+      (el) => el.type === 'element' && el.name === 'm:oMath',
+    )
+    if (!root) {
+      console.warn(`[docx] LaTeX→OMML produced no <m:oMath> node for: ${src}`)
+      return null
+    }
+
+    const component = convertToXmlComponent(root)
+    if (!component || typeof component === 'string') {
+      console.warn(`[docx] LaTeX→OMML yielded a non-element component for: ${src}`)
+      return null
+    }
+    // convertToXmlComponent returns an ImportedXmlComponent, which docx
+    // serializes correctly but which is not part of the ParagraphChild union.
+    // The cast is the intended escape hatch for injecting raw OOXML.
+    return component as unknown as ParagraphChild
+  } catch (err) {
+    console.warn(`[docx] LaTeX→OMML conversion failed for: ${src}`, err)
+    return null
+  }
+}

--- a/packages/docs/src/export/docx/mathml-to-omml.ts
+++ b/packages/docs/src/export/docx/mathml-to-omml.ts
@@ -1,0 +1,328 @@
+/**
+ * MathML → OMML converter for the DOCX export.
+ *
+ * This replaces the `mathml2omml` npm package, which mistranslates large
+ * operators (∫ ∑ ∏ …): it emits an `<m:nary>` whose `<m:e>` operand body is
+ * EMPTY and leaves the integrand/summand stranded as sibling runs after the
+ * nary. Word then renders the operator as an empty little box with the body
+ * floating beside it — the long-standing "公式还在小方格里" bug.
+ *
+ * We walk the (correct) MathML tree MathJax produces and emit OMML ourselves,
+ * covering the structures real documents use: mi/mn/mo/mtext, msup/msub/
+ * msubsup, munder/mover/munderover, mfrac, msqrt/mroot, and large operators as
+ * proper `<m:nary>` with a non-empty `<m:e>`.
+ *
+ * The nary-body problem is genuinely ambiguous in *presentation* MathML: the
+ * operator and its integrand are siblings, with no markup delimiting where the
+ * integrand ends. We use the reading a human would: the body runs from just
+ * after the operator up to (but not including) the next relation operator
+ * (=, ≠, <, >, ≤, ≥, →, …) at the same level. So in
+ *   ∫_{-∞}^{∞} e^{-x²} dx = √π
+ * the body is `e^{-x²} dx` and `= √π` stays outside — exactly right.
+ *
+ * Any element we don't recognize throws, so the caller can fall back to
+ * rendering the raw LaTeX source instead of producing a broken formula.
+ */
+
+import { xml2js, type Element } from 'xml-js'
+
+const MATH_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+
+/**
+ * n-ary (large) operators that must become an OMML `<m:nary>` whose `<m:e>`
+ * holds the operand body. Covers integrals, sums, products, coproducts, and
+ * the big set/logic operators.
+ */
+const LARGE_OPS = new Set([
+  '∑', // ∑ sum
+  '∏', // ∏ product
+  '∐', // ∐ coproduct
+  '∫', // ∫ integral
+  '∬', // ∬ double integral
+  '∭', // ∭ triple integral
+  '∮', // ∮ contour integral
+  '∯', // ∯ surface integral
+  '⨀', // ⨀
+  '⨁', // ⨁
+  '⨂', // ⨂
+  '⨄', // ⨄
+  '⨆', // ⨆
+  '⋀', // ⋀ big wedge
+  '⋁', // ⋁ big vee
+  '⋂', // ⋂ big intersection
+  '⋃', // ⋃ big union
+])
+
+/**
+ * Relation operators that terminate an n-ary operand body: the integrand /
+ * summand does not extend past them (∫ f dx = … → body is just `f dx`).
+ */
+const RELATION_OPS = new Set([
+  '=',
+  '≠', // ≠
+  '<',
+  '>',
+  '≤', // ≤
+  '≥', // ≥
+  '≈', // ≈
+  '≡', // ≡
+  '≅', // ≅
+  '∝', // ∝
+  '→', // →
+  '←', // ←
+  '↔', // ↔
+  '↦', // ↦
+  '∈', // ∈
+  '⊆', // ⊆
+  '⊂', // ⊂
+])
+
+/**
+ * Binary arithmetic operators that terminate an n-ary body.
+ * For ∑ x + y = z, the body should be just `x`; `+ y = z` stays at top level.
+ */
+const BINARY_ARITH_OPS = new Set([
+  '+',
+  '-',
+  '×', // ×
+  '·', // ·
+  '÷', // ÷
+  '±', // ±
+  '∓', // ∓
+  '⊕', // ⊕
+  '⊗', // ⊗
+  '∧', // ∧
+  '∨', // ∨
+])
+
+/** Child *element* nodes (drops whitespace/text between pretty-printed tags). */
+function childElements(node: Element): Element[] {
+  return (node.elements ?? []).filter((e) => e.type === 'element') as Element[]
+}
+
+/** Concatenated text content of a token element (mi/mn/mo/mtext/ms). */
+function textOf(node: Element): string {
+  return (node.elements ?? [])
+    .map((e) => (e.type === 'text' ? String(e.text ?? '') : e.type === 'cdata' ? String(e.cdata ?? '') : ''))
+    .join('')
+}
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function escAttr(s: string): string {
+  return escXml(s).replace(/"/g, '&quot;')
+}
+
+/** A plain math run carrying literal text. */
+function run(text: string): string {
+  return `<m:r><m:t xml:space="preserve">${escXml(text)}</m:t></m:r>`
+}
+
+function sSup(base: Element, sup: Element): string {
+  return `<m:sSup><m:sSupPr><m:ctrlPr/></m:sSupPr><m:e>${convertNode(base)}</m:e><m:sup>${convertNode(sup)}</m:sup></m:sSup>`
+}
+
+function sSub(base: Element, sub: Element): string {
+  return `<m:sSub><m:sSubPr><m:ctrlPr/></m:sSubPr><m:e>${convertNode(base)}</m:e><m:sub>${convertNode(sub)}</m:sub></m:sSub>`
+}
+
+function sSubSup(base: Element, sub: Element, sup: Element): string {
+  return `<m:sSubSup><m:sSubSupPr><m:ctrlPr/></m:sSubSupPr><m:e>${convertNode(base)}</m:e><m:sub>${convertNode(sub)}</m:sub><m:sup>${convertNode(sup)}</m:sup></m:sSubSup>`
+}
+
+function frac(num: Element, den: Element): string {
+  return `<m:f><m:fPr><m:ctrlPr/></m:fPr><m:num>${convertNode(num)}</m:num><m:den>${convertNode(den)}</m:den></m:f>`
+}
+
+/** √ with hidden (empty) degree. */
+function sqrt(children: Element[]): string {
+  return `<m:rad><m:radPr><m:degHide m:val="on"/></m:radPr><m:deg/><m:e>${convertSequence(children)}</m:e></m:rad>`
+}
+
+/** ⁿ√ with a visible index. */
+function root(base: Element, index: Element): string {
+  return `<m:rad><m:radPr/><m:deg>${convertNode(index)}</m:deg><m:e>${convertNode(base)}</m:e></m:rad>`
+}
+
+/** True if `node` is an `<mo>` whose glyph is a large (n-ary) operator. */
+function isLargeOpMo(node: Element | undefined): boolean {
+  return !!node && node.name === 'mo' && LARGE_OPS.has(textOf(node).trim())
+}
+
+/** True if `node` is an `<mo>` that ends an n-ary operand body. */
+function isRelationMo(node: Element): boolean {
+  return node.name === 'mo' && RELATION_OPS.has(textOf(node).trim())
+}
+
+function isBinaryArithMo(node: Element): boolean {
+  return node.name === 'mo' && BINARY_ARITH_OPS.has(textOf(node).trim())
+}
+
+const OPEN_FENCES = new Set(['(', '[', '{', '\u2308', '\u230a', '\u27e8', '|', '\u2016'])
+const CLOSE_FENCES = new Set([')', ']', '}', '\u2309', '\u230b', '\u27e9', '|', '\u2016'])
+/**
+ * Bracket-depth delta for an operand-body `mo`. An opening fence returns +1, a
+ * closing fence -1, everything else 0. This lets the n-ary body scan skip a
+ * relation/binary-arith operator that lives *inside* parentheses (e.g. the `+`
+ * in `\int (x+1)\,dx`) instead of truncating the operand there. Ambiguous
+ * fences (`|`, `\u2016`) that are both open and close are treated as neutral so
+ * they never push depth negative or swallow the real terminator.
+ */
+function fenceDepthDelta(node: Element): number {
+  if (!node || node.name !== 'mo') return 0
+  const t = textOf(node).trim()
+  const isOpen = OPEN_FENCES.has(t)
+  const isClose = CLOSE_FENCES.has(t)
+  if (isOpen && isClose) return 0 // ambiguous (|): treat as neutral
+  if (isOpen) return 1
+  if (isClose) return -1
+  return 0
+}
+
+interface NaryInfo {
+  chr: string
+  sub?: Element
+  sup?: Element
+  limLoc: 'subSup' | 'undOvr'
+}
+
+/**
+ * If `node` introduces a large operator (bare, or scripted with limits),
+ * describe it as an n-ary; otherwise return null.
+ */
+function naryInfo(node: Element): NaryInfo | null {
+  if (node.name === 'mo' && LARGE_OPS.has(textOf(node).trim())) {
+    return { chr: textOf(node).trim(), limLoc: 'subSup' }
+  }
+  const kids = childElements(node)
+  if (!isLargeOpMo(kids[0])) return null
+  const chr = textOf(kids[0]).trim()
+  switch (node.name) {
+    case 'msubsup':
+      return { chr, sub: kids[1], sup: kids[2], limLoc: 'subSup' }
+    case 'munderover':
+      return { chr, sub: kids[1], sup: kids[2], limLoc: 'undOvr' }
+    case 'msub':
+      return { chr, sub: kids[1], limLoc: 'subSup' }
+    case 'munder':
+      return { chr, sub: kids[1], limLoc: 'undOvr' }
+    case 'msup':
+      return { chr, sup: kids[1], limLoc: 'subSup' }
+    case 'mover':
+      return { chr, sup: kids[1], limLoc: 'undOvr' }
+    default:
+      return null
+  }
+}
+
+/** Emit an `<m:nary>` with its limits and a (possibly empty) operand body. */
+function emitNary(info: NaryInfo, body: Element[]): string {
+  const subHide = info.sub ? 'off' : 'on'
+  const supHide = info.sup ? 'off' : 'on'
+  const sub = info.sub ? `<m:sub>${convertNode(info.sub)}</m:sub>` : '<m:sub/>'
+  const sup = info.sup ? `<m:sup>${convertNode(info.sup)}</m:sup>` : '<m:sup/>'
+  const e = `<m:e>${convertSequence(body)}</m:e>`
+  return (
+    `<m:nary><m:naryPr>` +
+    `<m:chr m:val="${escAttr(info.chr)}"/>` +
+    `<m:limLoc m:val="${info.limLoc}"/>` +
+    `<m:subHide m:val="${subHide}"/>` +
+    `<m:supHide m:val="${supHide}"/>` +
+    `<m:ctrlPr/></m:naryPr>${sub}${sup}${e}</m:nary>`
+  )
+}
+
+/**
+ * Convert a sequence of sibling MathML nodes. This is where n-ary operators
+ * pull their trailing siblings into `<m:e>` (up to the next relation op).
+ */
+function convertSequence(nodes: Element[]): string {
+  let out = ''
+  let i = 0
+  while (i < nodes.length) {
+    const node = nodes[i]
+    const nary = naryInfo(node)
+    if (nary) {
+      const body: Element[] = []
+      let j = i + 1
+      let depth = 0
+      while (j < nodes.length) {
+        // Only a top-level (depth 0) relation/binary-arith operator ends the
+        // operand; one nested inside a fence stays part of the body.
+        if (depth === 0 && (isRelationMo(nodes[j]) || isBinaryArithMo(nodes[j]))) break
+        depth += fenceDepthDelta(nodes[j])
+        if (depth < 0) depth = 0 // unbalanced close: clamp, don't go negative
+        body.push(nodes[j])
+        j++
+      }
+      out += emitNary(nary, body)
+      i = j
+      continue
+    }
+    out += convertNode(node)
+    i++
+  }
+  return out
+}
+
+/** Convert a single MathML element to an OMML fragment. */
+function convertNode(node: Element): string {
+  if (!node) throw new Error('missing MathML child node')
+  const kids = childElements(node)
+  switch (node.name) {
+    case 'mi':
+    case 'mn':
+    case 'mo':
+    case 'mtext':
+    case 'ms':
+      return run(textOf(node))
+    case 'mspace':
+      return ''
+    // Grouping / styling wrappers are transparent in OMML.
+    case 'mrow':
+    case 'mstyle':
+    case 'mpadded':
+    case 'menclose':
+    case 'mphantom':
+      return convertSequence(kids)
+    case 'msup':
+      return sSup(kids[0], kids[1])
+    case 'msub':
+      return sSub(kids[0], kids[1])
+    case 'msubsup':
+      return sSubSup(kids[0], kids[1], kids[2])
+    // No native OMML "under/over"; approximate with scripts (rare off the
+    // n-ary path, e.g. \overrightarrow — good enough, and never empty).
+    case 'mover':
+      return sSup(kids[0], kids[1])
+    case 'munder':
+      return sSub(kids[0], kids[1])
+    case 'munderover':
+      return sSubSup(kids[0], kids[1], kids[2])
+    case 'mfrac':
+      return frac(kids[0], kids[1])
+    case 'msqrt':
+      return sqrt(kids)
+    case 'mroot':
+      return root(kids[0], kids[1])
+    default:
+      throw new Error(`unsupported MathML element <${node.name ?? '?'}>`)
+  }
+}
+
+/**
+ * Convert a serialized MathML `<math>` document into an OMML `<m:oMath>`
+ * string. Throws on malformed input or unsupported structures so the caller
+ * can fall back to the raw LaTeX source.
+ */
+export function mathmlToOmml(mathml: string): string {
+  const parsed = xml2js(mathml, { compact: false }) as Element
+  const math = (parsed.elements ?? []).find(
+    (e) => e.type === 'element' && e.name === 'math',
+  ) as Element | undefined
+  if (!math) throw new Error('no <math> root element in MathML')
+  const body = convertSequence(childElements(math))
+  return `<m:oMath xmlns:m="${MATH_NS}">${body}</m:oMath>`
+}

--- a/packages/docs/src/export/docx/nodes.ts
+++ b/packages/docs/src/export/docx/nodes.ts
@@ -1,0 +1,582 @@
+/**
+ * Block-level node converters for the DOCX export.
+ * Converts ProseMirror JSON nodes into docx Paragraph/Table/etc. elements.
+ */
+
+import {
+  Paragraph,
+  TextRun,
+  ImageRun,
+  CheckBox,
+  HeadingLevel,
+  LevelFormat,
+  AlignmentType,
+  ExternalHyperlink,
+  UnderlineType,
+  type ILevelsOptions,
+  type FileChild,
+} from 'docx'
+import { convertInlineContent, iconPrefix } from './marks.ts'
+import { isSafeHref } from './href-safety.ts'
+import { latexToMathComponent } from './math.ts'
+
+/** Re-exported so existing importers (e.g. href-safety.test.ts) keep working. */
+export { isSafeHref } from './href-safety.ts'
+
+/**
+ * Sniff the DOCX image type from a buffer's magic bytes. Used for raw-src / data:
+ * images that carry no resolved attachment mime, so a JPEG/GIF/BMP is embedded
+ * with the correct type instead of a broken default. Returns null when unknown.
+ */
+function sniffImageType(buffer: ArrayBuffer): 'jpg' | 'png' | 'gif' | 'bmp' | null {
+  const b = new Uint8Array(buffer)
+  if (b.length < 4) return null
+  // JPEG: FF D8 FF
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'jpg'
+  // PNG: 89 50 4E 47
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'png'
+  // GIF: 47 49 46 (GIF)
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) return 'gif'
+  // BMP: 42 4D (BM)
+  if (b[0] === 0x42 && b[1] === 0x4d) return 'bmp'
+  return null
+}
+import { convertTable } from './tables.ts'
+import { getImageBuffer, getImageDimensions } from './images.ts'
+import { FONT_CODE, mapTextAlign } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/** Map heading level 1-6 to docx HeadingLevel enum. */
+function toHeadingLevel(level: unknown): (typeof HeadingLevel)[keyof typeof HeadingLevel] {
+  const n = typeof level === 'number' ? level : 1
+  switch (Math.min(6, Math.max(1, n))) {
+    case 1: return HeadingLevel.HEADING_1
+    case 2: return HeadingLevel.HEADING_2
+    case 3: return HeadingLevel.HEADING_3
+    case 4: return HeadingLevel.HEADING_4
+    case 5: return HeadingLevel.HEADING_5
+    case 6: return HeadingLevel.HEADING_6
+    default: return HeadingLevel.HEADING_1
+  }
+}
+
+/** Numbering configuration for lists. */
+/** Index of 'ordered-list' in NUMBERING_CONFIG.config — used by dynamic numbering. */
+export const ORDERED_LIST_CONFIG_INDEX = 1
+
+export const NUMBERING_CONFIG = {
+  config: [
+    {
+      reference: 'bullet-list',
+      levels: [
+        { level: 0, format: LevelFormat.BULLET, text: '•', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 720, hanging: 360 } } } },
+        { level: 1, format: LevelFormat.BULLET, text: '◦', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
+        { level: 2, format: LevelFormat.BULLET, text: '▪', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2160, hanging: 360 } } } },
+        { level: 3, format: LevelFormat.BULLET, text: "‣", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2880, hanging: 360 } } } },
+        { level: 4, format: LevelFormat.BULLET, text: "⁃", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 3600, hanging: 360 } } } },
+      ] as ILevelsOptions[],
+    },
+    {
+      reference: 'ordered-list',
+      levels: [
+        { level: 0, format: LevelFormat.DECIMAL, text: '%1.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 720, hanging: 360 } } } },
+        { level: 1, format: LevelFormat.LOWER_LETTER, text: '%2.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
+        { level: 2, format: LevelFormat.LOWER_ROMAN, text: '%3.', alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2160, hanging: 360 } } } },
+        { level: 3, format: LevelFormat.DECIMAL, text: "%4.", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 2880, hanging: 360 } } } },
+        { level: 4, format: LevelFormat.LOWER_LETTER, text: "%5.", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 3600, hanging: 360 } } } },
+      ] as ILevelsOptions[],
+    },
+    // Note: task lists do NOT use numbering — convertTaskList draws its own ☑/☐
+    // status box per item (see below). A numbering bullet here would duplicate it.
+  ],
+}
+
+/**
+ * Resolve the numbering reference + instance for an orderedList node.
+ *
+ * docx generates one independent concrete numbering per (reference, instance)
+ * pair, each counting from its abstract level[0].start. So:
+ *  - every ordered list gets a fresh instance → independent lists restart at 1
+ *  - a list with an explicit start > 1 gets its own reference whose level set
+ *    starts at that value (the config-level `overrideLevels` field is ignored
+ *    by docx, so the start must live in the level definition itself)
+ */
+function getOrderedListNumbering(node: MdNode, ctx: DocxContext, depth: number): { reference: string; instance: number } {
+  const start = typeof node.attrs?.start === 'number' ? node.attrs.start : 1
+  const instance = ctx.orderedListInstance++
+  if (start <= 1) return { reference: 'ordered-list', instance }
+  const reference = `ordered-list-start-${ctx.dynamicNumbering.length}`
+  ctx.dynamicNumbering.push({ reference, start, level: Math.min(depth, 4) })
+  return { reference, instance }
+}
+
+/**
+ * Convert a top-level document's content array into docx FileChild elements.
+ */
+export function convertBlocks(nodes: MdNode[], ctx: DocxContext): FileChild[] {
+  const result: FileChild[] = []
+  for (const node of nodes) {
+    const converted = convertBlock(node, ctx, 0)
+    result.push(...converted)
+  }
+  return result
+}
+
+/**
+ * Convert a single block-level node into one or more docx elements.
+ */
+function convertBlock(node: MdNode, ctx: DocxContext, listDepth: number): FileChild[] {
+  switch (node.type) {
+    case 'paragraph':
+      return [convertParagraph(node, ctx)]
+    case 'heading':
+      return [convertHeading(node, ctx)]
+    case 'bulletList':
+      return convertList(node, 'bullet-list', ctx, listDepth)
+    case 'orderedList': {
+      const { reference, instance } = getOrderedListNumbering(node, ctx, listDepth)
+      return convertList(node, reference, ctx, listDepth, instance)
+    }
+    case 'taskList':
+      return convertTaskList(node, ctx, listDepth)
+    case 'blockquote':
+      return convertBlockquote(node, ctx)
+    case 'codeBlock':
+      return convertCodeBlock(node)
+    case 'horizontalRule':
+      return [convertHorizontalRule()]
+    case 'table':
+      return [convertTable(node, ctx)]
+    case 'image':
+      return convertImage(node, ctx)
+    case 'fileAttachment':
+      return [convertFileAttachment(node, ctx)]
+    case 'bookmark':
+      return [convertBookmark(node)]
+    case 'callout':
+      return convertCallout(node, ctx)
+    case 'blockMath':
+      return [convertBlockMath(node)]
+    case 'details':
+      return convertDetails(node, ctx)
+    default:
+      // Never drop content: recurse into unknown container or emit raw text
+      if (node.content && node.content.length) return convertBlocks(node.content, ctx)
+      if (node.text) return [new Paragraph({ children: [new TextRun({ text: node.text })] })]
+      return []
+  }
+}
+
+/** Convert a paragraph node. */
+function convertParagraph(node: MdNode, ctx: DocxContext): Paragraph {
+  const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+  const align = mapTextAlign(node.attrs?.textAlign)
+  return new Paragraph({ children: runs, ...(align ? { alignment: align } : {}) })
+}
+
+/** Convert a heading node. */
+function convertHeading(node: MdNode, ctx: DocxContext): Paragraph {
+  const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+  const align = mapTextAlign(node.attrs?.textAlign)
+  return new Paragraph({
+    children: runs,
+    heading: toHeadingLevel(node.attrs?.level),
+    ...(align ? { alignment: align } : {}),
+  })
+}
+
+/** Convert a bullet/ordered list. `instance` selects an independent numbering instance for ordered lists. */
+function convertList(node: MdNode, reference: string, ctx: DocxContext, depth: number, instance = 0): FileChild[] {
+  const items = node.content ?? []
+  const result: FileChild[] = []
+
+  for (const item of items) {
+    const blocks = item.content ?? []
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      if (block.type === 'bulletList' || block.type === 'orderedList' || block.type === 'taskList') {
+        // Nested list: increase depth. Ordered lists get their own reference+instance.
+        if (block.type === 'orderedList') {
+          const nested = getOrderedListNumbering(block, ctx, depth + 1)
+          result.push(...convertList(block, nested.reference, ctx, depth + 1, nested.instance))
+        } else if (block.type === 'taskList') {
+          // Nested task list keeps its own ☑/☐ boxes (not bullet numbering).
+          result.push(...convertTaskList(block, ctx, depth + 1))
+        } else {
+          result.push(...convertList(block, 'bullet-list', ctx, depth + 1))
+        }
+      } else if (i === 0) {
+        // First block in list item — apply numbering
+        const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
+        result.push(
+          new Paragraph({
+            children: runs,
+            numbering: { reference, level: Math.min(depth, 4), instance },
+          }),
+        )
+      } else {
+        // Continuation blocks under the same item
+        result.push(...convertBlock(block, ctx, depth))
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Convert a task list.
+ *
+ * Each item gets a real interactive Word checkbox (docx CheckBox = a w:sdt
+ * content control with w14:checkbox), followed by one normal-width space, then
+ * the item content. The checkbox is clickable/toggleable in Word regardless of
+ * its initial checked state — not a static ☑/☐ glyph.
+ * We deliberately do NOT use list numbering here: a numbering bullet would add
+ * a second box and its own tab, producing the "two boxes + double space" bug.
+ * Indentation is applied manually so the layout still looks like a list.
+ */
+function convertTaskList(node: MdNode, ctx: DocxContext, depth: number): FileChild[] {
+  const items = node.content ?? []
+  const result: FileChild[] = []
+  const indentLeft = 720 * (Math.min(depth, 4) + 1)
+
+  for (const item of items) {
+    const checked = !!item.attrs?.checked
+    const blocks = item.content ?? []
+
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      if (block.type === 'bulletList' || block.type === 'orderedList' || block.type === 'taskList') {
+        if (block.type === 'orderedList') {
+          const nested = getOrderedListNumbering(block, ctx, depth + 1)
+          result.push(...convertList(block, nested.reference, ctx, depth + 1, nested.instance))
+        } else if (block.type === 'taskList') {
+          result.push(...convertTaskList(block, ctx, depth + 1))
+        } else {
+          result.push(...convertList(block, 'bullet-list', ctx, depth + 1))
+        }
+      } else if (i === 0) {
+        const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
+        result.push(
+          new Paragraph({
+            children: [
+              new CheckBox({
+                checked,
+                // Use ☑ (U+2611, check mark in box) for the checked state instead of
+                // docx's default ☒ (U+2612, X in box) — users expect a check mark.
+                checkedState: { value: '2611', font: 'MS Gothic' },
+                uncheckedState: { value: '2610', font: 'MS Gothic' },
+              }),
+              new TextRun({ text: ' ' }),
+              ...runs,
+            ],
+            indent: { left: indentLeft, hanging: 360 },
+          }),
+        )
+      } else {
+        result.push(...convertBlock(block, ctx, depth))
+      }
+    }
+  }
+
+  return result
+}
+
+/** Convert a blockquote. */
+function convertBlockquote(node: MdNode, ctx: DocxContext): FileChild[] {
+  const children = node.content ?? []
+  const result: FileChild[] = []
+
+  for (const child of children) {
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      result.push(
+        new Paragraph({
+          children: runs,
+          style: 'BlockQuote',
+          indent: { left: 720 },
+        }),
+      )
+    } else {
+      // Nested blocks in blockquote
+      const converted = convertBlock(child, ctx, 0)
+      result.push(...converted)
+    }
+  }
+
+  return result
+}
+
+/** Convert a code block. */
+function convertCodeBlock(node: MdNode): FileChild[] {
+  const code = (node.content ?? []).map((c) => c.text ?? '').join('')
+  const lines = code.split('\n')
+
+  return lines.map(
+    (line) =>
+      new Paragraph({
+        children: line
+          ? [
+              new TextRun({
+                text: line,
+                font: { name: FONT_CODE, hint: 'default' },
+                size: 20,
+              }),
+            ]
+          : [], // empty line — no TextRun needed, Paragraph renders as blank line
+        style: 'CodeBlock',
+        spacing: { before: 0, after: 0, line: 240 },
+        shading: { fill: 'F5F5F5' },
+      }),
+  )
+}
+
+/** Convert a horizontal rule. */
+function convertHorizontalRule(): Paragraph {
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: '─'.repeat(50),
+        color: 'CCCCCC',
+        size: 16,
+      }),
+    ],
+    spacing: { before: 120, after: 120 },
+    alignment: AlignmentType.CENTER,
+  })
+}
+
+/** Convert an image node. */
+function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
+  const buffer = getImageBuffer(node, ctx)
+  const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : ''
+
+  if (!buffer) {
+    // Image couldn't be fetched — emit alt text or placeholder
+    return [
+      new Paragraph({
+        children: [
+          new TextRun({
+            text: alt ? `[Image: ${alt}]` : '[Image unavailable]',
+            italics: true,
+            color: '888888',
+          }),
+        ],
+      }),
+    ]
+  }
+
+  const dims = getImageDimensions(node)
+  // Image uses `align` attr (left/center/right), not `textAlign`
+  const align = mapTextAlign(node.attrs?.align)
+
+  // Detect image type. Prefer a resolved attachment's mime; for raw src / data:
+  // images (no attachment mime) sniff the buffer's magic bytes so a JPEG/GIF/BMP
+  // is not mislabelled as PNG (which Word renders broken). Default png when unknown.
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const resolved = attachId ? ctx.urls.get(attachId) : undefined
+  const mime = resolved?.mime ?? ''
+  let imgType: 'jpg' | 'png' | 'gif' | 'bmp' = 'png'
+  if (mime.includes('jpeg') || mime.includes('jpg')) imgType = 'jpg'
+  else if (mime.includes('gif')) imgType = 'gif'
+  else if (mime.includes('bmp')) imgType = 'bmp'
+  else if (mime.includes('png')) imgType = 'png'
+  else {
+    const sniffed = sniffImageType(buffer)
+    if (sniffed) imgType = sniffed
+  }
+
+  return [
+    new Paragraph({
+      children: [
+        new ImageRun({
+          data: buffer,
+          transformation: { width: dims.width, height: dims.height },
+          type: imgType,
+        }),
+      ],
+      ...(align ? { alignment: align } : {}),
+    }),
+  ]
+}
+
+/** Convert a file attachment node (signed download link, same as Markdown export). */
+function convertFileAttachment(node: MdNode, ctx: DocxContext): Paragraph {
+  const attachId = typeof node.attrs?.attachId === 'string' ? node.attrs.attachId : undefined
+  const resolved = attachId ? ctx.urls.get(attachId) : undefined
+  const name =
+    (typeof node.attrs?.fileName === 'string' && node.attrs.fileName) ||
+    resolved?.fileName ||
+    'attachment'
+
+  if (resolved?.url && isSafeHref(resolved.url)) {
+    return new Paragraph({
+      children: [
+        ...iconPrefix('📎'),
+        new ExternalHyperlink({
+          children: [
+            new TextRun({
+              text: name,
+              style: 'Hyperlink',
+              underline: { type: UnderlineType.SINGLE },
+              color: '1A73E8',
+            }),
+          ],
+          link: resolved.url,
+        }),
+      ],
+    })
+  }
+
+  return new Paragraph({
+    children: [
+      ...iconPrefix('📎'),
+      new TextRun({
+        text: name + ' (unavailable)',
+        italics: true,
+        color: '888888',
+      }),
+    ],
+  })
+}
+
+/** Convert a bookmark node. */
+function convertBookmark(node: MdNode): Paragraph {
+  const url = typeof node.attrs?.url === 'string' ? node.attrs.url : ''
+  const title = (typeof node.attrs?.title === 'string' && node.attrs.title) || url
+
+  if (url && isSafeHref(url)) {
+    return new Paragraph({
+      children: [
+        ...iconPrefix('🔗'),
+        new ExternalHyperlink({
+          children: [
+            new TextRun({
+              text: title,
+              style: 'Hyperlink',
+              underline: { type: UnderlineType.SINGLE },
+              color: '1A73E8',
+            }),
+          ],
+          link: url,
+        }),
+      ],
+    })
+  }
+
+  return new Paragraph({
+    children: [new TextRun({ text: title || '[bookmark]' })],
+  })
+}
+
+/** Callout variant → style mapping. */
+const CALLOUT_STYLES: Record<string, string> = {
+  info: 'CalloutInfo',
+  warn: 'CalloutWarn',
+  warning: 'CalloutWarn',
+  tip: 'CalloutTip',
+  success: 'CalloutSuccess',
+}
+
+/** Callout variant → emoji prefix (bare glyph; spacing added via iconPrefix). */
+const CALLOUT_EMOJI: Record<string, string> = {
+  info: 'ℹ️',
+  warn: '⚠️',
+  warning: '⚠️',
+  tip: '💡',
+  success: '✅',
+}
+
+/** Convert a callout node. */
+function convertCallout(node: MdNode, ctx: DocxContext): FileChild[] {
+  const variant = typeof node.attrs?.variant === 'string' ? node.attrs.variant : 'info'
+  const style = CALLOUT_STYLES[variant] ?? 'CalloutInfo'
+  const emoji = CALLOUT_EMOJI[variant] ?? 'ℹ️'
+  const children = node.content ?? []
+  const result: FileChild[] = []
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i]
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      // Prepend emoji to first paragraph
+      const prefix = i === 0 ? iconPrefix(emoji, { bold: true }) : []
+      result.push(
+        new Paragraph({
+          children: [...prefix, ...runs],
+          style,
+          indent: { left: 360 },
+        }),
+      )
+    } else {
+      result.push(...convertBlock(child, ctx, 0))
+    }
+  }
+
+  return result
+}
+
+/** Convert a block math node into a centered, native Word formula (OMML). */
+function convertBlockMath(node: MdNode): Paragraph {
+  const latex = typeof node.attrs?.latex === 'string' ? node.attrs.latex : ''
+  const math = latexToMathComponent(latex, true)
+  if (math) {
+    // Real OMML formula, rendered natively by Word.
+    return new Paragraph({
+      children: [math],
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 120, after: 120 },
+    })
+  }
+  // Fallback: conversion failed — keep the LaTeX source as monospace text so
+  // no content is lost (latexToMathComponent already logged the reason).
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: latex,
+        font: FONT_CODE,
+        italics: true,
+        size: 22,
+      }),
+    ],
+    alignment: AlignmentType.CENTER,
+    spacing: { before: 120, after: 120 },
+  })
+}
+
+/** Convert a details/collapsible node. */
+function convertDetails(node: MdNode, ctx: DocxContext): FileChild[] {
+  const children = node.content ?? []
+  const summaryNode = children.find((c) => c.type === 'detailsSummary')
+  const contentNode = children.find((c) => c.type === 'detailsContent')
+  const result: FileChild[] = []
+
+  // Summary as a bold paragraph with toggle indicator
+  if (summaryNode) {
+    const runs = convertInlineContent(summaryNode.content ?? [], ctx.emojiGlyph)
+    result.push(
+      new Paragraph({
+        children: [new TextRun({ text: '▸ ', bold: true }), ...runs],
+        spacing: { before: 80, after: 40 },
+      }),
+    )
+  }
+
+  // Content indented
+  const contentChildren = contentNode?.content ?? children.filter((c) => c.type !== 'detailsSummary')
+  for (const child of contentChildren) {
+    if (child.type === 'paragraph') {
+      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
+      result.push(
+        new Paragraph({
+          children: runs,
+          indent: { left: 360 },
+        }),
+      )
+    } else {
+      result.push(...convertBlock(child, ctx, 0))
+    }
+  }
+
+  return result
+}

--- a/packages/docs/src/export/docx/numbering.test.ts
+++ b/packages/docs/src/export/docx/numbering.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for ordered-list numbering in DOCX export.
+ *
+ * Verifies:
+ *  - Two independent ordered lists each restart at 1 (not continuous counting).
+ *  - A list with explicit start > 1 begins at that value.
+ *  - Nested ordered lists restart independently at the correct level.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function ol(items: string[], start?: number): MdNode {
+  return {
+    type: 'orderedList',
+    ...(start ? { attrs: { start } } : {}),
+    content: items.map((t) => ({
+      type: 'listItem',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: t }] }],
+    })),
+  } as MdNode
+}
+
+function para(text: string): MdNode {
+  return { type: 'paragraph', content: [{ type: 'text', text }] } as MdNode
+}
+
+async function buildNumberingXml(content: MdNode[]) {
+  const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+  const children = convertBlocks(content, ctx)
+  const orderedLevels = NUMBERING_CONFIG.config[1].levels
+  const numbering = {
+    config: [
+      ...NUMBERING_CONFIG.config,
+      ...ctx.dynamicNumbering.map((dn) => ({
+        reference: dn.reference,
+        levels: orderedLevels.map((lvl) => (lvl.level === dn.level ? { ...lvl, start: dn.start } : lvl)),
+      })),
+    ],
+  }
+  const doc = new Document({ styles: DOCX_STYLES, numbering, sections: [{ children }] })
+  const buf = await Packer.toBuffer(doc)
+  const path = join(tmpdir(), `numbering-test-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  const numXml = execSync(`unzip -p ${path} word/numbering.xml`).toString()
+  const docXml = execSync(`unzip -p ${path} word/document.xml`).toString()
+  return { numXml, docXml, ctx }
+}
+
+/** For each numbered paragraph, resolve its numId → abstractNum → level[0] start value. */
+function resolveParagraphStarts(numXml: string, docXml: string): number[] {
+  // Map numId → abstractNumId
+  const numToAbstract = new Map<string, string>()
+  for (const m of numXml.matchAll(/<w:num w:numId="(\d+)">\s*<w:abstractNumId w:val="(\d+)"/g)) {
+    numToAbstract.set(m[1], m[2])
+  }
+  // Map abstractNumId → level0 start
+  const abstractLvl0Start = new Map<string, number>()
+  for (const m of numXml.matchAll(/<w:abstractNum w:abstractNumId="(\d+)"[\s\S]*?<w:lvl w:ilvl="0"[\s\S]*?<w:start w:val="(\d+)"/g)) {
+    abstractLvl0Start.set(m[1], Number(m[2]))
+  }
+  // Collect numId per numbered top-level paragraph (ilvl 0)
+  const starts: number[] = []
+  for (const m of docXml.matchAll(/<w:numPr>\s*<w:ilvl w:val="0"\/>\s*<w:numId w:val="(\d+)"/g)) {
+    const abs = numToAbstract.get(m[1])
+    if (abs) starts.push(abstractLvl0Start.get(abs) ?? 1)
+  }
+  return starts
+}
+
+describe('ordered list numbering', () => {
+  it('two independent lists each restart at 1 with distinct numbering instances', async () => {
+    const { numXml, docXml, ctx } = await buildNumberingXml([
+      ol(['a', 'b', 'c']),
+      para('gap'),
+      ol(['x', 'y']),
+    ])
+    // Each ordered list gets its own numbering instance (independent counting).
+    expect(ctx.orderedListInstance).toBe(2)
+    // The two lists reference distinct numIds so Word counts them separately.
+    const numIds = [...docXml.matchAll(/<w:numPr>\s*<w:ilvl w:val="0"\/>\s*<w:numId w:val="(\d+)"/g)].map((m) => m[1])
+    const list1 = numIds.slice(0, 3)
+    const list2 = numIds.slice(3, 5)
+    expect(new Set(list1).size).toBe(1) // list 1 items share one instance
+    expect(new Set(list2).size).toBe(1) // list 2 items share one instance
+    expect(list1[0]).not.toBe(list2[0]) // but the two lists differ
+    // Both start at 1.
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([1, 1, 1, 1, 1])
+  })
+
+  it('explicit start > 1 begins at that value', async () => {
+    const { numXml, docXml } = await buildNumberingXml([ol(['p', 'q'], 5)])
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([5, 5])
+  })
+
+  it('mixed: default list, then start=5 list — 1 and 5', async () => {
+    const { numXml, docXml } = await buildNumberingXml([
+      ol(['a', 'b', 'c']),
+      para('gap'),
+      ol(['p', 'q'], 5),
+    ])
+    expect(resolveParagraphStarts(numXml, docXml)).toEqual([1, 1, 1, 5, 5])
+  })
+
+  it('nested ordered list with start=3 begins at 3', async () => {
+    // bulletList > (item: para + orderedList(start=3))
+    const doc: MdNode = {
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [para('outer'), ol(['x', 'y'], 3)],
+        },
+      ],
+    } as MdNode
+    const { numXml } = await buildNumberingXml([doc])
+    // The nested start=3 list gets a dynamic reference whose level 1 starts at 3.
+    const dyn = [...numXml.matchAll(/<w:abstractNum[\s\S]*?<w:lvl w:ilvl="1"[\s\S]*?<w:start w:val="3"/g)]
+    expect(dyn.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/docs/src/export/docx/styles.ts
+++ b/packages/docs/src/export/docx/styles.ts
@@ -1,0 +1,217 @@
+/**
+ * Global style configuration for the DOCX export.
+ * Chinese font support: 微软雅黑 for body, 微软雅黑 bold for headings.
+ */
+
+import {
+  type IStylesOptions,
+  type IParagraphStyleOptions,
+  HeadingLevel,
+  AlignmentType,
+} from 'docx'
+
+/** Default font for body text. */
+export const FONT_BODY = '微软雅黑'
+
+/** Default font for headings. */
+export const FONT_HEADING = '微软雅黑'
+
+/** Monospace font for code. */
+export const FONT_CODE = 'Consolas'
+
+/** Fallback monospace fonts. */
+export const FONT_CODE_FALLBACK = 'Courier New'
+
+/**
+ * Emoji font. 微软雅黑 (the body font) has no emoji glyphs, so emoji inherit it
+ * and render as blank boxes in Word/WPS. Segoe UI Emoji is the standard Windows
+ * emoji font (used by WPS and Word on Windows); Word on macOS falls back to
+ * Apple Color Emoji automatically. Applying it only to emoji runs keeps CJK text
+ * on 微软雅黑.
+ */
+export const FONT_EMOJI = 'Segoe UI Emoji'
+
+/** Standard heading sizes in half-points. */
+const HEADING_SIZES: Record<string, number> = {
+  [HeadingLevel.HEADING_1]: 36, // 18pt
+  [HeadingLevel.HEADING_2]: 32, // 16pt
+  [HeadingLevel.HEADING_3]: 28, // 14pt
+  [HeadingLevel.HEADING_4]: 26, // 13pt
+  [HeadingLevel.HEADING_5]: 24, // 12pt
+  [HeadingLevel.HEADING_6]: 22, // 11pt
+}
+
+/** Create the default styles for the document. */
+export function createDefaultStyles(): NonNullable<IStylesOptions['default']> {
+  return {
+    document: {
+      run: {
+        font: FONT_BODY,
+        size: 24, // 12pt in half-points
+      },
+      paragraph: {
+        spacing: { after: 120, line: 276 },
+      },
+    },
+    heading1: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_1],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 240, after: 120 },
+      },
+    },
+    heading2: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_2],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 200, after: 100 },
+      },
+    },
+    heading3: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_3],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 160, after: 80 },
+      },
+    },
+    heading4: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_4],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 120, after: 60 },
+      },
+    },
+    heading5: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_5],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 100, after: 60 },
+      },
+    },
+    heading6: {
+      run: {
+        font: FONT_HEADING,
+        size: HEADING_SIZES[HeadingLevel.HEADING_6],
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 80, after: 40 },
+      },
+    },
+  }
+}
+
+/** Custom paragraph styles (e.g. code block, blockquote). */
+export function createParagraphStyles(): IParagraphStyleOptions[] {
+  return [
+    {
+      id: 'CodeBlock',
+      name: 'Code Block',
+      basedOn: 'Normal',
+      run: {
+        font: FONT_CODE,
+        size: 20, // 10pt
+      },
+      paragraph: {
+        spacing: { before: 60, after: 60, line: 240 },
+        shading: { fill: 'F5F5F5' },
+      },
+    },
+    {
+      id: 'BlockQuote',
+      name: 'Block Quote',
+      basedOn: 'Normal',
+      run: {
+        italics: true,
+        color: '555555',
+      },
+      paragraph: {
+        spacing: { before: 80, after: 80 },
+        indent: { left: 720 }, // 0.5 inch indent
+      },
+    },
+    {
+      id: 'CalloutInfo',
+      name: 'Callout Info',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'E8F4FD' },
+      },
+    },
+    {
+      id: 'CalloutWarn',
+      name: 'Callout Warning',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'FFF3CD' },
+      },
+    },
+    {
+      id: 'CalloutTip',
+      name: 'Callout Tip',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'D4EDDA' },
+      },
+    },
+    {
+      id: 'CalloutSuccess',
+      name: 'Callout Success',
+      basedOn: 'Normal',
+      paragraph: {
+        spacing: { before: 60, after: 60 },
+        indent: { left: 360 },
+        shading: { fill: 'D4EDDA' },
+      },
+    },
+  ]
+}
+
+/** Create the full styles options for Document construction. */
+function createDocxStyles(): IStylesOptions {
+  return {
+    default: createDefaultStyles(),
+    paragraphStyles: createParagraphStyles(),
+  }
+}
+
+/** Module-level cached styles (pure static, no need to recreate per export). */
+export const DOCX_STYLES: IStylesOptions = createDocxStyles()
+
+/** Map heading level (1-6) to the docx AlignmentType equivalent. */
+export function mapTextAlign(align: unknown): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  if (typeof align !== 'string') return undefined
+  switch (align) {
+    case 'left':
+      return AlignmentType.LEFT
+    case 'center':
+      return AlignmentType.CENTER
+    case 'right':
+      return AlignmentType.RIGHT
+    case 'justify':
+      return AlignmentType.JUSTIFIED
+    default:
+      return undefined
+  }
+}

--- a/packages/docs/src/export/docx/table-layout.test.ts
+++ b/packages/docs/src/export/docx/table-layout.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for DOCX table export layout:
+ *  1. Column widths — columns are distributed evenly when the doc has no
+ *     explicit colwidth (Word's auto layout otherwise squeezes empty columns),
+ *     and explicit colwidth values are honored when present.
+ *  2. Repeating header row across page breaks (w:tblHeader).
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertTable } from './tables.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function makeCtx(): DocxContext {
+  return { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 } as DocxContext
+}
+
+async function exportXml(table: MdNode) {
+  const document = new Document({ sections: [{ children: [convertTable(table, makeCtx())] }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `tbl-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+function cell(text: string, attrs?: Record<string, unknown>, header = false): MdNode {
+  return {
+    type: header ? 'tableHeader' : 'tableCell',
+    attrs,
+    content: [{ type: 'paragraph', content: text ? [{ type: 'text', text }] : [] }],
+  } as MdNode
+}
+
+describe('DOCX table layout', () => {
+  it('distributes columns evenly when there is no explicit colwidth', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('列A', undefined, true), cell('列B', undefined, true), cell('列C', undefined, true)] },
+        { type: 'tableRow', content: [cell('很多很多内容占满一整行'), cell(''), cell('')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols.length).toBe(3)
+    // Even distribution: all three widths equal (fallbackEven), not content-based.
+    expect(new Set(gridCols).size).toBe(1)
+    expect(gridCols[0]).toBeGreaterThan(1000)
+  })
+
+  it('honors explicit colwidth values (wide vs narrow)', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('宽', { colwidth: [300] }, true), cell('窄', { colwidth: [100] }, true)] },
+        { type: 'tableRow', content: [cell('a', { colwidth: [300] }), cell('b', { colwidth: [100] })] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols.length).toBe(2)
+    // 300px*15 = 4500, 100px*15 = 1500
+    expect(gridCols[0]).toBe(4500)
+    expect(gridCols[1]).toBe(1500)
+    expect(gridCols[0]).toBeGreaterThan(gridCols[1])
+  })
+
+  it('marks the first header row to repeat on every page (w:tblHeader)', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('H1', undefined, true), cell('H2', undefined, true)] },
+        { type: 'tableRow', content: [cell('a'), cell('b')] },
+        { type: 'tableRow', content: [cell('c'), cell('d')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const headerCount = (xml.match(/<w:tblHeader/g) || []).length
+    // Exactly one row flagged as the repeating header.
+    expect(headerCount).toBe(1)
+  })
+
+  it('does not flag a header when the first row has no tableHeader cells', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('a'), cell('b')] },
+        { type: 'tableRow', content: [cell('c'), cell('d')] },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    expect((xml.match(/<w:tblHeader/g) || []).length).toBe(0)
+  })
+
+  it('uses fixed table layout so columns stay predictable', async () => {
+    const table: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [cell('a'), cell('b')] }],
+    } as MdNode
+    const xml = await exportXml(table)
+    expect(xml).toContain('w:type="fixed"')
+  })
+
+  it('maps column widths correctly when a cell spans multiple columns', async () => {
+    // Grid columns: [c0=200px, c1=100px, c2=100px]. First data row has a cell
+    // that spans c0+c1, then a normal cell for c2. The spanning cell must get
+    // the SUM of its covered columns' widths, and the following cell must not
+    // be shifted off by one.
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            cell('A', { colwidth: [200] }, true),
+            cell('B', { colwidth: [100] }, true),
+            cell('C', { colwidth: [100] }, true),
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [cell('span2', { colspan: 2 }), cell('c')],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    // Grid definition: 200*15=3000, 100*15=1500, 100*15=1500
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols).toEqual([3000, 1500, 1500])
+    // The spanning cell's own width (w:tcW) should be the sum of c0+c1 = 4500.
+    const tcW = [...xml.matchAll(/<w:tcW w:type="dxa" w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(tcW).toContain(4500)
+    // The spanning cell must also carry gridSpan=2.
+    expect(xml).toContain('<w:gridSpan w:val="2"')
+  })
+
+  it('does not overflow the page width when explicit widths already fill it', async () => {
+    // Two explicit wide columns (700px each = 10500 DXA) plus one column with no
+    // width. The missing column must not add a 600 minimum on top; with no
+    // remaining space it falls back to the small minimum (200).
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            cell('W1', { colwidth: [700] }, true),
+            cell('W2', { colwidth: [700] }, true),
+            cell('empty', undefined, true),
+          ],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml(table)
+    const gridCols = [...xml.matchAll(/<w:gridCol w:w="(\d+)"/g)].map((m) => Number(m[1]))
+    expect(gridCols[0]).toBe(10500)
+    expect(gridCols[1]).toBe(10500)
+    // Missing column falls back to the small minimum (200), not 600.
+    expect(gridCols[2]).toBe(200)
+  })
+})

--- a/packages/docs/src/export/docx/tables.ts
+++ b/packages/docs/src/export/docx/tables.ts
@@ -1,0 +1,218 @@
+/**
+ * Table conversion for DOCX export.
+ * Supports merged cells (colspan/rowspan) via TableCell columnSpan/rowSpan properties.
+ */
+
+/** Hard cap on colspan/rowspan to prevent malicious/corrupt attrs from freezing the export. */
+const MAX_SPAN = 100
+
+/**
+ * Coerce a span attribute to a safe integer in [1, MAX_SPAN].
+ * `Number('')`/`Number('x')` yield NaN, and `?? 1` only guards null/undefined,
+ * so a non-numeric colspan/rowspan would otherwise collapse the grid; `|| 1`
+ * catches NaN/0 and falls back to a single span.
+ */
+function clampSpan(raw: unknown): number {
+  const n = Math.floor(Number(raw)) || 1
+  return Math.min(MAX_SPAN, Math.max(1, n))
+}
+
+import {
+  Table,
+  TableRow,
+  TableCell,
+  TableLayoutType,
+  Paragraph,
+  TextRun,
+  WidthType,
+  BorderStyle,
+  type ITableCellOptions,
+} from 'docx'
+import { convertInlineContent } from './marks.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+/**
+ * Convert a table node to a docx Table element.
+ * Handles colspan and rowspan via columnSpan/rowSpan on TableCell.
+ */
+export function convertTable(node: MdNode, ctx: DocxContext): Table {
+  const rows = node.content ?? []
+
+  // Derive per-column widths (in DXA/twips). Always returns a full array so
+  // fixed layout produces even columns even when the doc has no explicit widths.
+  const columnWidths = deriveColumnWidths(rows)
+
+  const tableRows = rows.map((row, rowIdx) => {
+    // Track the grid-column index so cell widths map to the right columns even
+    // when earlier cells span multiple columns (colIdx alone is the in-row cell
+    // index, not the grid column).
+    let gridCol = 0
+    const cells = (row.content ?? []).map((cell) => {
+      const span = clampSpan(cell.attrs?.colspan)
+      // A spanning cell's width is the sum of the grid columns it covers.
+      let widthDxa = 0
+      for (let i = 0; i < span; i++) widthDxa += columnWidths[gridCol + i] ?? 0
+      gridCol += span
+      return convertTableCell(cell, ctx, widthDxa)
+    })
+    // Repeat the first row as a header on every page when it is a header row.
+    const isHeaderRow =
+      rowIdx === 0 && (row.content ?? []).some((c) => c.type === 'tableHeader')
+    return new TableRow({ children: cells, tableHeader: isHeaderRow || undefined })
+  })
+
+  return new Table({
+    rows: tableRows,
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    // Fixed layout honors explicit column widths. When the doc has explicit
+    // widths we use them; otherwise we distribute the page width evenly so
+    // columns don't collapse to their content (Word's auto layout squeezes
+    // empty columns). Either way fixed layout gives predictable, even columns.
+    columnWidths,
+    layout: TableLayoutType.FIXED,
+    borders: {
+      top: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      bottom: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      left: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      right: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      insideHorizontal: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      insideVertical: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+    },
+  })
+}
+
+/**
+ * Convert a single table cell (tableCell or tableHeader) node.
+ */
+function convertTableCell(
+  cell: MdNode,
+  ctx: DocxContext,
+  columnWidthDxa?: number,
+): TableCell {
+  const colspan = clampSpan(cell.attrs?.colspan)
+  const rowspan = clampSpan(cell.attrs?.rowspan)
+  const isHeader = cell.type === 'tableHeader'
+
+  // Cell width: use the resolved column width so fixed layout stays even.
+  const cellWidthDxa =
+    Number.isFinite(columnWidthDxa) && (columnWidthDxa as number) > 0
+      ? Math.round(columnWidthDxa as number)
+      : undefined
+
+  // Convert cell content — cells contain block content (paragraphs, etc.)
+  const paragraphs = convertCellContent(cell.content ?? [], ctx)
+
+  // Ensure at least one paragraph (docx requires it)
+  if (paragraphs.length === 0) {
+    paragraphs.push(new Paragraph({ children: [] }))
+  }
+
+  const cellOptions: ITableCellOptions = {
+    children: paragraphs,
+    columnSpan: colspan > 1 ? colspan : undefined,
+    rowSpan: rowspan > 1 ? rowspan : undefined,
+    ...(cellWidthDxa ? { width: { size: cellWidthDxa, type: WidthType.DXA } } : {}),
+    ...(isHeader ? { shading: { fill: 'F0F0F0' } } : {}),
+  }
+
+  return new TableCell(cellOptions)
+}
+
+/**
+ * Derive per-column widths (in DXA/twips). Reads explicit ProseMirror
+ * `colwidth` (px) when present; any column without an explicit width gets an
+ * even share of the remaining page width. Always returns a full array so the
+ * table can use fixed layout with evenly distributed columns (Word's auto
+ * layout otherwise squeezes empty columns to near-zero).
+ */
+function deriveColumnWidths(rows: MdNode[]): number[] {
+  const firstRow = rows[0]
+  const cells = firstRow?.content ?? []
+
+  // Usable content width for A4 portrait with ~1in margins ≈ 9026 twips.
+  const PAGE_CONTENT_DXA = 9026
+
+  // Expand colspans so the array is one entry per grid column.
+  const explicit: (number | null)[] = []
+  for (const cell of cells) {
+    const span = clampSpan(cell.attrs?.colspan)
+    const cw = Array.isArray(cell.attrs?.colwidth) ? cell.attrs?.colwidth : null
+    for (let i = 0; i < span; i++) {
+      const raw = cw ? Number(cw[i]) : NaN
+      explicit.push(Number.isFinite(raw) && raw > 0 ? Math.round(raw * 15) : null)
+    }
+  }
+
+  const colCount = explicit.length || 1
+  const explicitSum = explicit.reduce<number>((s, w) => s + (w ?? 0), 0)
+  const missing = explicit.filter((w) => w === null).length
+
+  if (missing > 0) {
+    // Distribute the remaining page width across columns without an explicit
+    // width. Guard against overflow: if explicit widths already fill/exceed the
+    // page, fall back to a small minimum so the total stays near the page width
+    // instead of blowing past the margin (fixed layout would otherwise clip).
+    const remaining = PAGE_CONTENT_DXA - explicitSum
+    const evenShare = remaining > 0 ? Math.round(remaining / missing) : 0
+    const MIN_COL = 200
+    const share = Math.max(MIN_COL, evenShare)
+    return explicit.map((w) => w ?? share)
+  }
+
+  // No explicit widths: split the page evenly across all grid columns.
+  const fallbackEven = Math.round(PAGE_CONTENT_DXA / colCount)
+  return explicit.map((w) => w ?? fallbackEven)
+}
+
+/**
+ * Convert cell content (usually paragraphs) into Paragraph elements.
+ */
+function convertCellContent(nodes: MdNode[], ctx: DocxContext): Paragraph[] {
+  const paragraphs: Paragraph[] = []
+
+  for (const node of nodes) {
+    if (node.type === 'paragraph') {
+      const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+      paragraphs.push(
+        new Paragraph({
+          children: runs,
+          spacing: { before: 40, after: 40 },
+        }),
+      )
+    } else if (node.type === 'bulletList' || node.type === 'orderedList') {
+      // Flatten nested lists in cells into paragraphs with bullet/number prefix
+      const items = node.content ?? []
+      items.forEach((item, idx) => {
+        const prefix = node.type === 'orderedList' ? `${idx + 1}. ` : '• '
+        // Extract inline content from the first paragraph inside the list item
+        const firstPara = (item.content ?? []).find((c) => c.type === 'paragraph')
+        const runs = firstPara
+          ? [new TextRun({ text: prefix }), ...convertInlineContent(firstPara.content ?? [], ctx.emojiGlyph)]
+          : [new TextRun({ text: prefix + extractPlainText(item) })]
+        paragraphs.push(
+          new Paragraph({
+            children: runs,
+            spacing: { before: 20, after: 20 },
+          }),
+        )
+      })
+    } else {
+      // For other block types in cells, extract text content
+      const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
+      if (runs.length > 0) {
+        paragraphs.push(new Paragraph({ children: runs }))
+      }
+    }
+  }
+
+  return paragraphs
+}
+
+/**
+ * Extract plain text from a node tree (for simplified table cell content).
+ */
+function extractPlainText(node: MdNode): string {
+  if (node.text) return node.text
+  if (!node.content) return ''
+  return node.content.map(extractPlainText).join('')
+}

--- a/packages/docs/src/export/docx/task-list.test.ts
+++ b/packages/docs/src/export/docx/task-list.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for task list (checkbox list) export in DOCX.
+ *
+ * Task items must export as REAL interactive Word checkboxes (docx CheckBox =
+ * a w:sdt content control with w14:checkbox), so they can be clicked/toggled in
+ * Word regardless of their initial checked state — not static ☑/☐ glyphs.
+ *
+ * Also a regression guard for the old "two boxes + double space" bug: exactly
+ * one checkbox per item, no duplicated bullet from list numbering.
+ */
+import { describe, it, expect } from 'vitest'
+import { Packer, Document } from 'docx'
+import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertBlocks, NUMBERING_CONFIG } from './nodes.ts'
+import { DOCX_STYLES } from './styles.ts'
+import type { MdNode, DocxContext } from './types.ts'
+
+function taskList(items: { text: string; checked: boolean }[]): MdNode {
+  return {
+    type: 'taskList',
+    content: items.map((it) => ({
+      type: 'taskItem',
+      attrs: { checked: it.checked },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: it.text }] }],
+    })),
+  } as MdNode
+}
+
+async function exportXml(content: MdNode[]) {
+  const ctx: DocxContext = { urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0 }
+  const children = convertBlocks(content, ctx)
+  const document = new Document({ styles: DOCX_STYLES, numbering: NUMBERING_CONFIG, sections: [{ children }] })
+  const buf = await Packer.toBuffer(document)
+  const path = join(tmpdir(), `task-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+  writeFileSync(path, buf)
+  return execSync(`unzip -p ${path} word/document.xml`).toString()
+}
+
+const count = (s: string, sub: string) => s.split(sub).length - 1
+
+describe('task list export', () => {
+  it('every item is an interactive checkbox content control (w:sdt + w14:checkbox)', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: '完成的任务', checked: true },
+        { text: '未完成的任务', checked: false },
+      ]),
+    ])
+    // Both items must be real toggleable Word checkboxes, not static glyphs.
+    expect(count(xml, '<w14:checkbox>')).toBe(2)
+    expect(count(xml, '<w:sdt>')).toBe(2)
+  })
+
+  it('checked vs unchecked initial state is preserved', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: '完成的任务', checked: true },
+        { text: '未完成的任务', checked: false },
+      ]),
+    ])
+    // Checked box → w14:checked val="1"; unchecked → val="0". Checked state renders
+    // a check mark ☑ (2611), NOT an X ☒ (2612).
+    expect(xml).toContain('<w14:checked w14:val="1"/>')
+    expect(xml).toContain('<w14:checked w14:val="0"/>')
+    expect(xml).toContain('w14:val="2611"')
+    expect(xml).not.toContain('w14:val="2612"')
+    // Both remain interactive regardless of initial state (same content-control markup).
+    expect(count(xml, 'w14:checkbox')).toBeGreaterThanOrEqual(2)
+  })
+
+  it('exactly one checkbox per item — no duplicate boxes', async () => {
+    const xml = await exportXml([
+      taskList([
+        { text: 'a', checked: true },
+        { text: 'b', checked: false },
+        { text: 'c', checked: false },
+      ]),
+    ])
+    // 3 items → exactly 3 checkbox content controls, no extra bullet boxes.
+    expect(count(xml, '<w14:checkbox>')).toBe(3)
+    // No leftover static glyphs.
+    expect(xml).not.toContain('☑')
+    expect(xml).not.toContain('☐')
+  })
+
+  it('nested task list keeps its own interactive checkboxes', async () => {
+    const nested: MdNode = {
+      type: 'taskList',
+      content: [
+        {
+          type: 'taskItem',
+          attrs: { checked: false },
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: '父任务' }] },
+            taskList([
+              { text: '子任务已完成', checked: true },
+              { text: '子任务未完成', checked: false },
+            ]),
+          ],
+        },
+      ],
+    } as MdNode
+    const xml = await exportXml([nested])
+    // parent + 2 children = 3 checkboxes
+    expect(count(xml, '<w14:checkbox>')).toBe(3)
+    expect(xml).toContain('<w14:checked w14:val="1"/>')
+    expect(xml).toContain('<w14:checked w14:val="0"/>')
+  })
+})

--- a/packages/docs/src/export/docx/types.ts
+++ b/packages/docs/src/export/docx/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Type definitions for the DOCX export module.
+ * Re-exports the MdNode interface from markdown.ts for consistency.
+ */
+
+import type { MdNode } from '../markdown.ts'
+import type { ResolvedAttachment } from '../../attachments/api.ts'
+
+export type { MdNode }
+
+/** Options for the DOCX export function. */
+export interface DocxExportOptions {
+  /** Batch size for the resolve endpoint (RES-1 cap). Default 200. */
+  batchSize?: number
+  /** Resolve fn injection point (tests pass a stub). Defaults to the real REST client. */
+  resolve?: (docId: string, attachIds: string[]) => Promise<{ items: ResolvedAttachment[]; notFound: string[] }>
+  /** name → unicode glyph for emoji nodes; defaults to the editor's emoji map. */
+  emojiGlyph?: (name: string | null | undefined) => string | undefined
+}
+
+/** Internal context passed through the node/mark converters. */
+export interface DocxContext {
+  /** Resolved attachment URLs keyed by attachId. */
+  urls: Map<string, ResolvedAttachment>
+  /** Fetched image buffers keyed by URL. */
+  imageBuffers: Map<string, ArrayBuffer>
+  /** Emoji glyph resolver. */
+  emojiGlyph?: (name: string | null | undefined) => string | undefined
+  /**
+   * Dynamic numbering references for ordered lists whose start > 1.
+   * docx derives an instance's starting number from its abstract level[0].start,
+   * so a non-default start needs its own reference with a customized level set.
+   */
+  dynamicNumbering: Array<{ reference: string; start: number; level: number }>
+  /** Monotonic counter handing each ordered list its own numbering instance (independent counting). */
+  orderedListInstance: number
+}
+
+/** Represents a collected image reference that needs to be fetched. */
+export interface ImageRef {
+  attachId?: string
+  src?: string
+  resolvedUrl?: string
+}

--- a/packages/docs/src/export/markdown.test.ts
+++ b/packages/docs/src/export/markdown.test.ts
@@ -81,6 +81,18 @@ describe('exportDocToMarkdown — lists', () => {
     expect(out).toContain('2. two')
   })
 
+  it('ordered list honours the start attr', async () => {
+    const li = (t: string): MdNode => ({ type: 'listItem', content: [p(text(t))] })
+    const out = await md(
+      doc(
+        { type: 'orderedList', attrs: { start: 3 }, content: [li('three'), li('four')] },
+      ),
+    )
+    expect(out).toContain('3. three')
+    expect(out).toContain('4. four')
+    expect(out).not.toContain('1. three')
+  })
+
   it('task list checked / unchecked', async () => {
     const out = await md(
       doc({
@@ -309,6 +321,39 @@ describe('exportDocToMarkdown — inline marks and atoms', () => {
     expect(out).toContain('<span style="color:#ff0000">col</span>')
     expect(out).toContain('<sup>sup</sup>')
     expect(out).toContain('<sub>sub</sub>')
+  })
+
+  it('highlight with a colour keeps its background-color in the <mark> style', async () => {
+    const out = await md(
+      doc(
+        p(
+          text('hl', [{ type: 'highlight', attrs: { color: '#ffeb3b' } }]),
+        ),
+      ),
+    )
+    expect(out).toContain('<mark style="background-color:#ffeb3b">hl</mark>')
+  })
+
+  it('colourless highlight degrades to a bare <mark>', async () => {
+    const out = await md(doc(p(text('h', [{ type: 'highlight' }]))))
+    expect(out).toContain('<mark>h</mark>')
+    expect(out).not.toContain('style=')
+  })
+
+  it('malicious highlight colour is escaped inside the style attribute (no breakout)', async () => {
+    const out = await md(
+      doc(
+        p(
+          text('x', [
+            { type: 'highlight', attrs: { color: '"><img src=x onerror=alert(1)>' } },
+          ]),
+        ),
+      ),
+    )
+    // The `"` and `<`/`>` are entity-escaped so the value stays trapped inside style="...".
+    expect(out).not.toContain('<img src=x onerror=alert(1)>')
+    expect(out).toContain('&quot;')
+    expect(out).toContain('<mark style="background-color:')
   })
 
   it('mention renders as plain @displayName (no dead uid link)', async () => {

--- a/packages/docs/src/export/markdown.ts
+++ b/packages/docs/src/export/markdown.ts
@@ -244,8 +244,12 @@ function escapeLeadingBlockMarkers(text: string): string {
 
 function serializeList(node: MdNode, ordered: boolean, ctx: Ctx, depth: number): string {
   const items = node.content ?? []
+  // Ordered lists may start at a value other than 1 (ProseMirror `start` attr); honour it so the
+  // rendered markers match the editor instead of always counting from 1.
+  const rawStart = node.attrs?.start
+  const start = ordered && typeof rawStart === 'number' && rawStart >= 0 ? Math.floor(rawStart) : 1
   return items
-    .map((item, idx) => serializeListItem(item, ordered, idx, ctx, depth))
+    .map((item, idx) => serializeListItem(item, ordered, start + idx, ctx, depth))
     // Drop empty items so an item with no content never emits a bare dangling marker (`- `).
     .filter((s) => s !== '')
     .join('\n')
@@ -254,14 +258,14 @@ function serializeList(node: MdNode, ordered: boolean, ctx: Ctx, depth: number):
 function serializeListItem(
   item: MdNode,
   ordered: boolean,
-  idx: number,
+  num: number,
   ctx: Ctx,
   depth: number,
 ): string {
   const indent = '  '.repeat(depth)
   let marker: string
   if (item.type === 'taskItem') marker = item.attrs?.checked ? '- [x] ' : '- [ ] '
-  else marker = ordered ? `${idx + 1}. ` : '- '
+  else marker = ordered ? `${num}. ` : '- '
 
   const blocks = item.content ?? []
   let line = indent + marker
@@ -289,6 +293,19 @@ function serializeListItem(
 function cellText(cell: MdNode, ctx: Ctx): string {
   // A cell holds block content (usually paragraphs); flatten to single-line inline.
   return serializeBlocks(cell.content ?? [], ctx).replace(/\n+/g, ' ').trim()
+}
+
+/**
+ * Neutralise bare angle brackets before a cell body is embedded inline in the
+ * raw-HTML table fallback. Unlike the callout/details fallbacks (which wrap
+ * inner content in a blank-line markdown island that is re-parsed as Markdown),
+ * the table fallback interpolates cell text directly into `<td>`/`<th>`, so a
+ * literal `<`/`>` in the text would reach the rendered HTML verbatim. Escaping
+ * just `<`/`>` keeps intended inline Markdown (`**`, `[x](y)`) intact while
+ * closing the injection surface for defence-in-depth.
+ */
+function escapeHtmlText(value: string): string {
+  return value.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 function hasMergedCells(node: MdNode): boolean {
@@ -329,7 +346,7 @@ function serializeTableHtml(node: MdNode, ctx: Ctx): string {
       const rowspan = Number(cell.attrs?.rowspan ?? 1)
       const attrs =
         (colspan > 1 ? ` colspan="${colspan}"` : '') + (rowspan > 1 ? ` rowspan="${rowspan}"` : '')
-      out.push(`<${tag}${attrs}>${cellText(cell, ctx)}</${tag}>`)
+      out.push(`<${tag}${attrs}>${escapeHtmlText(cellText(cell, ctx))}</${tag}>`)
     }
     out.push('</tr>')
   }
@@ -451,9 +468,18 @@ function applyMarks(text: string, marks: Array<{ type: string; attrs?: Record<st
       case 'underline':
         out = `<u>${out}</u>`
         break
-      case 'highlight':
-        out = `<mark>${out}</mark>`
+      case 'highlight': {
+        // Highlight carries its background colour in the `color` attr (extension-highlight,
+        // multicolor). Emit it as an inline style so the highlight colour survives the export;
+        // escape it inside the `style="..."` attribute so a crafted value can't break out. A
+        // colourless highlight degrades to a bare <mark> (default yellow in most renderers).
+        const hl = mark.attrs?.color
+        out =
+          typeof hl === 'string' && hl
+            ? `<mark style="background-color:${escapeHtmlAttr(hl)}">${out}</mark>`
+            : `<mark>${out}</mark>`
         break
+      }
       case 'textStyle': {
         const color = mark.attrs?.color
         // Color lands inside a `style="..."` attribute — escape it so it can't break out of the

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -79,8 +79,11 @@
     "members": "Members",
     "more": "More",
     "exportMarkdown": "Export as Markdown",
+    "exportDocx": "Export as Word",
+    "exportPdf": "Export as PDF",
     "exportError": "Couldn't export this document. Please try again.",
-    "exportSignedLinkNotice": "Note: images and attachments are signed links and may expire. Once expired, reopen the source document to fetch them again, or download them manually."
+    "export": "Export",
+    "exportSignedLinkNotice": "This document contains shared links — please verify access permissions"
   },
   "slash": {
     "groupBasic": "Basic",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -79,8 +79,11 @@
     "members": "成员",
     "more": "更多",
     "exportMarkdown": "导出为 Markdown",
+    "exportDocx": "导出为 Word",
+    "exportPdf": "导出为 PDF",
     "exportError": "导出文档失败，请重试。",
-    "exportSignedLinkNotice": "注意：图片/附件为签名链接，可能过期；过期后请回原文档重新获取或手动下载。"
+    "export": "导出",
+    "exportSignedLinkNotice": "此文档包含共享链接，请注意访问权限"
   },
   "slash": {
     "groupBasic": "基础",

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -41,6 +41,11 @@ export interface ApiRequestConfig {
    */
   responseType?: 'json' | 'arraybuffer'
   /**
+   * Per-request timeout in ms, overriding the host client's shared default.
+   * Long server-side renders (large document PDF export) need a higher ceiling.
+   */
+  timeout?: number
+  /**
    * Per-request headers, merged over the global request interceptor's headers by axios
    * (request-config headers win). The standalone `/d/:docId` preflight uses this to carry an
    * explicit `X-Space-Id`: it mounts via the Layout early-return, before the app shell restores

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -152,6 +152,27 @@ export async function deleteDoc(docId: string): Promise<void> {
 }
 
 /**
+ * POST /api/v1/docs/{docId}/export/pdf — server-side (Typst) PDF render.
+ * Returns the PDF bytes as an ArrayBuffer.
+ *
+ * Goes through the shared host apiClient with `responseType: 'arraybuffer'` so
+ * the binary PDF body is not decoded as UTF-8 text (which would turn every
+ * non-ASCII byte into U+FFFD and corrupt the file). Using the host client keeps
+ * this on the same axios instance as the rest of the app, so the global request
+ * interceptor (token + X-Space-Id) and `/api/v1/` baseURL apply — docs does not
+ * depend on axios directly. A longer per-request timeout covers big documents
+ * that the shared 20s default would otherwise cut off mid-success.
+ */
+export async function exportDocPdf(docId: string): Promise<ArrayBuffer> {
+  const { data } = await apiClient().post<ArrayBuffer>(
+    `/docs/${docId}/export/pdf`,
+    undefined,
+    { responseType: 'arraybuffer', timeout: 120_000 },
+  )
+  return data
+}
+
+/**
  * Delete outcome classification (contract C3 final), kept as a pure function so the 200/404/403/409
  * handling is unit-testable and shared wherever the delete entry lives:
  *   200 → 'deleted'; 404 → 'gone' (already removed — treat as success); 403 → 'forbidden';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 1.59.1
       '@storybook/addon-vitest':
         specifier: ^10.3.3
-        version: 10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
+        version: 10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -58,7 +58,7 @@ importers:
         version: 13.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+        version: 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -67,7 +67,7 @@ importers:
         version: 0.0.0(eslint@7.32.0)(typescript@5.9.3)
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       prettier:
         specifier: ^2.5.1
         version: 2.8.8
@@ -85,7 +85,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   apps/extension:
     dependencies:
@@ -134,10 +134,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@wxt-dev/auto-icons':
         specifier: ^1.1.1
-        version: 1.1.1(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
+        version: 1.1.1(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
       '@wxt-dev/module-react':
         specifier: ^1.1.5
-        version: 1.2.2(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
+        version: 1.2.2(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -146,10 +146,10 @@ importers:
         version: 0.10.4
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
       wxt:
         specifier: ^0.20.20
-        version: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+        version: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
 
   apps/web:
     dependencies:
@@ -548,7 +548,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworkcontacts:
     dependencies:
@@ -582,7 +582,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworkdatasource:
     dependencies:
@@ -631,10 +631,10 @@ importers:
         version: 4.4.5
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmworksummary:
     dependencies:
@@ -829,6 +829,9 @@ importers:
       '@univerjs/preset-sheets-core':
         specifier: 0.25.1
         version: 0.25.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)
+      docx:
+        specifier: ^9.7.1
+        version: 9.7.1
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -838,9 +841,15 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      mathjax-full:
+        specifier: ^3.2.2
+        version: 3.2.2
       xlsx-js-style:
         specifier: ^1.2.0
         version: 1.2.0
+      xml-js:
+        specifier: ^1.6.11
+        version: 1.6.11
       y-indexeddb:
         specifier: 9.0.12
         version: 9.0.12(yjs@13.6.21)
@@ -874,7 +883,7 @@ importers:
         version: 6.0.0
       jsdom:
         specifier: ^29.0.1
-        version: 29.0.2(@noble/hashes@2.2.0)
+        version: 29.0.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -886,7 +895,7 @@ importers:
         version: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/eslint-config-custom:
     dependencies:
@@ -901,7 +910,7 @@ importers:
         version: 8.10.2(eslint@7.32.0)
       eslint-config-turbo:
         specifier: latest
-        version: 2.10.4(eslint@7.32.0)(turbo@2.2.1)
+        version: 2.9.5(eslint@7.32.0)(turbo@2.2.1)
       eslint-plugin-react:
         specifier: 7.28.0
         version: 7.28.0(eslint@7.32.0)
@@ -2315,10 +2324,6 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
-    engines: {node: '>= 20.19.0'}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2396,8 +2401,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@radix-ui/primitive@1.1.4':
-    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
 
   '@radix-ui/react-arrow@1.1.11':
     resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
@@ -2412,8 +2417,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-collection@1.1.11':
-    resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2434,8 +2439,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context@1.1.4':
-    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2443,8 +2448,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dialog@1.1.18':
-    resolution: {integrity: sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==}
+  '@radix-ui/react-dialog@1.1.19':
+    resolution: {integrity: sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2465,8 +2470,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dismissable-layer@1.1.14':
-    resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
+  '@radix-ui/react-dismissable-layer@1.1.15':
+    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2478,8 +2483,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.19':
-    resolution: {integrity: sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==}
+  '@radix-ui/react-dropdown-menu@2.1.20':
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2500,8 +2505,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-focus-scope@1.1.11':
-    resolution: {integrity: sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==}
+  '@radix-ui/react-focus-scope@1.1.12':
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2513,8 +2518,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-hover-card@1.1.18':
-    resolution: {integrity: sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==}
+  '@radix-ui/react-hover-card@1.1.19':
+    resolution: {integrity: sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2535,8 +2540,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-menu@2.1.19':
-    resolution: {integrity: sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==}
+  '@radix-ui/react-menu@2.1.20':
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2548,8 +2553,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popover@1.1.18':
-    resolution: {integrity: sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==}
+  '@radix-ui/react-popover@1.1.19':
+    resolution: {integrity: sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2561,8 +2566,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popper@1.3.2':
-    resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
+  '@radix-ui/react-popper@1.3.3':
+    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2587,8 +2592,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-presence@1.1.6':
-    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2613,8 +2618,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-roving-focus@1.1.14':
-    resolution: {integrity: sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==}
+  '@radix-ui/react-roving-focus@1.1.15':
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2668,6 +2673,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3711,6 +3725,9 @@ packages:
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
+  '@types/node@25.9.4':
+    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
   '@types/pako@1.0.7':
     resolution: {integrity: sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==}
 
@@ -4167,6 +4184,10 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -4816,6 +4837,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@2.14.1:
     resolution: {integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==}
 
@@ -5152,6 +5177,10 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  docx@9.7.1:
+    resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
+    engines: {node: '>=10'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -5418,8 +5447,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-config-turbo@2.10.4:
-    resolution: {integrity: sha512-CtWm7UbtsfR+PJOCRIPoLVKUGSDUEeSwKsrlnPGSql9nngUHbVWwWr4xdiMaapvFfiwlks65e5LB7z9uAETgLQ==}
+  eslint-config-turbo@2.9.5:
+    resolution: {integrity: sha512-MwAmBEge6WOONTll4BAI1ZbbtD4PrhEaumcu6MNIdrwygMXw2Ne2eV8wxVpj6cnPgyUNE6iS6WdOoi/vPI4YFg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5522,8 +5551,8 @@ packages:
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
 
-  eslint-plugin-turbo@2.10.4:
-    resolution: {integrity: sha512-nhpzZoQmjlXlrEkeYbzPA/uXnMmUUpkp/88mEU2V+vhGEO1z/CwlBg+3m64JkgO+MX4ODRoBiSo0gg35KcPryA==}
+  eslint-plugin-turbo@2.9.5:
+    resolution: {integrity: sha512-mwsR2dVy35crMS39TKSKG1xMxfn9M9t/sHXg70GAVqJxoFhsmM1XOcVGQ5w2z7GFUuMP70xUcpSendFzyuuSlQ==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5560,6 +5589,10 @@ packages:
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
 
   espree@7.3.1:
     resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
@@ -6026,6 +6059,9 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
@@ -6968,6 +7004,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mathjax-full@3.2.2:
+    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
+
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
@@ -7087,6 +7127,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
 
   micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
@@ -7321,6 +7364,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7386,6 +7432,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mj-context-menu@0.6.1:
+    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -7433,6 +7482,11 @@ packages:
 
   nanoid@5.1.11:
     resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -8760,6 +8814,10 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
+    hasBin: true
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -9257,6 +9315,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
@@ -9657,6 +9718,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
@@ -9748,6 +9812,10 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -9755,6 +9823,9 @@ packages:
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
@@ -11403,9 +11474,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
-    optionalDependencies:
-      '@noble/hashes': 2.2.0
+  '@exodus/bytes@1.15.0': {}
 
   '@fast-csv/format@4.3.5':
     dependencies:
@@ -11728,9 +11797,6 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
-  '@noble/hashes@2.2.0':
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11802,7 +11868,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@radix-ui/primitive@1.1.4': {}
+  '@radix-ui/primitive@1.1.5': {}
 
   '@radix-ui/react-arrow@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11813,10 +11879,10 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-collection@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11831,23 +11897,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-context@1.1.4(@types/react@18.3.28)(react@18.3.1)':
+  '@radix-ui/react-context@1.2.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-dialog@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dialog@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
@@ -11865,9 +11931,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
@@ -11878,13 +11944,13 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-dropdown-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11899,7 +11965,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-focus-scope@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11910,15 +11976,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-hover-card@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-hover-card@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -11934,22 +12000,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-menu@2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       aria-hidden: 1.2.6
@@ -11960,18 +12026,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popover@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popover@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
@@ -11983,12 +12049,12 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popper@1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popper@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-arrow': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
@@ -12011,7 +12077,7 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
@@ -12029,17 +12095,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-roving-focus@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-id': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -12079,6 +12147,12 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
@@ -12372,21 +12446,21 @@ snapshots:
       '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)':
+  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -13128,11 +13202,12 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
-  '@types/estree@1.0.9': {}
+  '@types/estree@1.0.9':
+    optional: true
 
   '@types/filesystem@0.0.36':
     dependencies:
@@ -13202,6 +13277,10 @@ snapshots:
   '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@25.9.4':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/pako@1.0.7': {}
 
@@ -13290,7 +13369,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
     optional: true
 
   '@types/zxcvbn@4.4.5': {}
@@ -13499,11 +13578,11 @@ snapshots:
 
   '@univerjs/design@0.25.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.3.1)
-      '@radix-ui/react-dropdown-menu': 2.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-hover-card': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popover': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-separator': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
       '@univerjs/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13744,13 +13823,18 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
 
+  '@vitejs/plugin-react@6.0.1(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+
   '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13764,7 +13848,21 @@ snapshots:
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@vitest/browser': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13780,7 +13878,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13798,7 +13896,25 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13846,6 +13962,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+
+  '@vitest/mocker@4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -13926,23 +14050,23 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@wxt-dev/auto-icons@1.1.1(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
+  '@wxt-dev/auto-icons@1.1.1(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
     dependencies:
       defu: 6.1.7
       fs-extra: 11.3.4
       sharp: 0.34.5
-      wxt: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+      wxt: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
 
   '@wxt-dev/browser@0.1.40':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
+  '@wxt-dev/module-react@1.2.2(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0))':
     dependencies:
-      '@vitejs/plugin-react': 6.0.1(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
-      wxt: 0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
+      '@vitejs/plugin-react': 6.0.1(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      wxt: 0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -13954,6 +14078,8 @@ snapshots:
       dequal: 2.0.3
 
   '@xmldom/xmldom@0.8.12': {}
+
+  '@xmldom/xmldom@0.9.10': {}
 
   abbrev@1.1.1:
     optional: true
@@ -14727,6 +14853,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@13.1.0: {}
+
   commander@2.14.1: {}
 
   commander@2.17.1: {}
@@ -14887,10 +15015,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0(@noble/hashes@2.2.0):
+  data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -15072,6 +15200,15 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  docx@9.7.1:
+    dependencies:
+      '@types/node': 25.9.4
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.16
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   dom-accessibility-api@0.5.16: {}
 
@@ -15508,10 +15645,10 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-turbo@2.10.4(eslint@7.32.0)(turbo@2.2.1):
+  eslint-config-turbo@2.9.5(eslint@7.32.0)(turbo@2.2.1):
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 2.10.4(eslint@7.32.0)(turbo@2.2.1)
+      eslint-plugin-turbo: 2.9.5(eslint@7.32.0)(turbo@2.2.1)
       turbo: 2.2.1
 
   eslint-import-resolver-node@0.3.10:
@@ -15711,7 +15848,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-turbo@2.10.4(eslint@7.32.0)(turbo@2.2.1):
+  eslint-plugin-turbo@2.9.5(eslint@7.32.0)(turbo@2.2.1):
     dependencies:
       dotenv: 16.0.3
       eslint: 7.32.0
@@ -15781,6 +15918,8 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esm@3.2.25: {}
+
   espree@7.3.1:
     dependencies:
       acorn: 7.4.1
@@ -15803,7 +15942,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -15816,7 +15955,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -15834,7 +15973,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -16296,6 +16435,11 @@ snapshots:
   has-unicode@2.0.1:
     optional: true
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hashery@1.5.1:
     dependencies:
       hookified: 1.15.1
@@ -16360,7 +16504,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -16381,7 +16525,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -16463,9 +16607,9 @@ snapshots:
 
   howler@2.2.4: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+  html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16817,17 +16961,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.2(@noble/hashes@2.2.0):
+  jsdom@29.0.2:
     dependencies:
       '@asamuzakjp/css-color': 5.1.8
       '@asamuzakjp/dom-selector': 7.0.8
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      data-urls: 7.0.0
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.2
       parse5: 8.0.0
@@ -16838,7 +16982,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      whatwg-url: 16.0.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -17275,6 +17419,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mathjax-full@3.2.2:
+    dependencies:
+      esm: 3.2.25
+      mhchemparser: 4.2.1
+      mj-context-menu: 0.6.1
+      speech-rule-engine: 4.1.4
+
   mathml-tag-names@4.0.0: {}
 
   md5-typescript@1.0.5: {}
@@ -17576,6 +17727,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  mhchemparser@4.2.1: {}
+
   micromark-core-commonmark@1.1.0:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -17742,7 +17895,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -17753,7 +17906,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -17770,7 +17923,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -17819,7 +17972,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -17935,7 +18088,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -18067,6 +18220,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -18134,6 +18289,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mj-context-menu@0.6.1: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -18173,6 +18330,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.11: {}
+
+  nanoid@5.1.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -19221,7 +19380,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -19236,14 +19395,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -19332,7 +19491,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -19862,6 +20021,12 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
+
+  speech-rule-engine@4.1.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      commander: 13.1.0
+      wicked-good-xpath: 1.3.0
 
   split2@4.2.0: {}
 
@@ -20476,6 +20641,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.24.6: {}
+
   undici@7.24.7: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -20756,13 +20923,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@6.0.0(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1):
+  vite-node@6.0.0(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1):
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -20800,12 +20967,12 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20836,7 +21003,20 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)):
+  vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.4
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
@@ -20861,12 +21041,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
     optional: true
 
-  vitest@4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
+  vitest@4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
@@ -20891,7 +21071,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.21
       '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@25.9.4)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.4
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
 
@@ -20948,9 +21157,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+  whatwg-url@16.0.1:
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      '@exodus/bytes': 1.15.0
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -21029,6 +21238,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wicked-good-xpath@1.3.0: {}
+
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
@@ -21097,7 +21308,7 @@ snapshots:
       curve25519-js: 0.0.4
       md5-typescript: 1.0.5
 
-  wxt@0.20.20(@types/node@22.19.21)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0):
+  wxt@0.20.20(@types/node@25.9.4)(canvas@2.11.2(encoding@0.1.13))(eslint@7.32.0)(jiti@2.6.1)(rollup@4.62.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.62.0)
@@ -21140,8 +21351,8 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.16
       unimport: 6.0.2
-      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
-      vite-node: 6.0.0(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.7(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
+      vite-node: 6.0.0(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)
       web-ext-run: 0.2.4
     optionalDependencies:
       eslint: 7.32.0
@@ -21186,12 +21397,18 @@ snapshots:
       wmf: 1.0.2
       word: 0.3.0
 
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
   xml-name-validator@5.0.0: {}
 
   xml2js@0.6.2:
     dependencies:
       sax: 1.6.0
       xmlbuilder: 11.0.1
+
+  xml@1.0.1: {}
 
   xmlbuilder@11.0.1: {}
 


### PR DESCRIPTION
## Summary

Consolidated document export for Octo Docs. One export surface: an expandable submenu (Markdown / Word / PDF) inside the header more-menu, replacing the standalone export dropdown.

- PDF export calls the server-side Typst endpoint `POST /:docId/export/pdf` (direct axios + arraybuffer to avoid binary corruption)
- DOCX export retained (MathML->OMML math, emoji, task lists, tables, security hardening)
- Markdown export fixes: honour ordered-list `start`; keep text highlight background colour
- Export moved into the header more-menu submenu; standalone dropdown removed

## Linked Spec

Closes #564
Refs Mininglamp-OSS/octo-server#504

## Comprehension

**What this change does (before/after):** Before, export lived in a standalone toolbar dropdown and Markdown export dropped ordered-list start offsets and highlight colours. After, the three formats are grouped under one Export submenu in the header more-menu (standalone dropdown removed), PDF is served by the Typst backend, and Markdown export preserves ordered-list numbering and `<mark style="background-color:...">`.

**What could break (dependents + failure mode):** Only the export UI + Markdown serializer. The submenu adds optional `children` to `DocMoreMenuItem`; parent rows toggle expansion and only leaf rows fire an action (existing flat rows unchanged; the panel unmounts on close so the expanded state resets). Highlight colour is escaped for the style attribute, degrading to a bare `<mark>` when unset — no injection or regression for colourless highlights.

**How I know it works (evidence):** tsc clean on touched files; docs export tests pass (37) incl. new colourless-highlight and injection-escape cases; verified in the running docs UI — submenu export for all three formats, PDF via Typst returns 200, Markdown highlight colour preserved.

## How verified

- tsc clean on changed files
- export tests 37 pass (Markdown start + highlight colour/injection, DOCX)
- verified in-browser: submenu export for all three formats; PDF via Typst