### PR TITLE
fix(dmworkbase): 重连/回前台后重新同步会话成员，修复 @ 提及搜不到新成员 (#567)

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -9,6 +9,9 @@ export type MittEvents = {
   "emoji-manifest-updated": undefined;
   /** 收藏他人贴纸成功后广播,已加载过「我的贴纸」的 EmojiPanel 据此重拉列表 */
   "stickers-updated": undefined;
+  /** App 回前台(visibilitychange/focus):打开中的会话据此重同步成员列表,
+   * 修复合盖/息屏久后 WS 断连期间成员变更 CMD 丢失导致 @ 搜不到新成员(octo-web#567) */
+  "wk:app-foreground": undefined;
   "wk:pending-thread": {
     groupNo: string;
     thread: import("./Service/Thread").Thread | null;
@@ -847,6 +850,10 @@ export default class WKApp extends ProviderListener {
 
     const refresh = () => {
       this.refreshRemoteConfigOnForeground();
+      // 回前台时通知当前会话重同步成员列表。合盖/息屏久后 WS 可能已断、
+      // 断连期间的成员变更 CMD 已丢失，仅靠 remoteConfig 刷新不会补成员，
+      // 导致 @ 提及弹窗搜不到新龙虾/成员（octo-web#567）。
+      WKApp.mittBus.emit("wk:app-foreground");
     };
     document.addEventListener("visibilitychange", () => {
       if (!document.hidden) {

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/resyncSubscribers.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/resyncSubscribers.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+// Spy handles captured from the SDK mock so tests can assert which member-load
+// path resyncSubscribers took (super-group → first-page API vs normal group →
+// syncSubscribes) and inspect channel-info lookups.
+const syncSubscribes = vi.fn(() => Promise.resolve())
+const getSubscribes = vi.fn(() => [] as any[])
+const notifySubscribeChangeListeners = vi.fn()
+const dataSourceSubscribers = vi.fn(() => Promise.resolve([{ uid: "first-page" }]))
+// parent channel-info lookup for the community-topic branch; overridden per test
+let getChannelInfoImpl: (ch: any) => any = () => undefined
+
+vi.mock("wukongimjssdk", () => ({
+    Channel: class {
+        channelID: string
+        channelType: number
+        constructor(id: string, type: number) {
+            this.channelID = id
+            this.channelType = type
+        }
+        isEqual(other: any) {
+            return this.channelID === other.channelID && this.channelType === other.channelType
+        }
+        getChannelKey() {
+            return `${this.channelID}-${this.channelType}`
+        }
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    ChannelTypeCommunityTopic: 6,
+    WKSDK: {
+        shared: () => ({
+            channelManager: {
+                getSubscribes,
+                addSubscriberChangeListener: () => {},
+                removeSubscriberChangeListener: () => {},
+                syncSubscribes,
+                subscribeCacheMap: new Map(),
+                notifySubscribeChangeListeners,
+                getChannelInfo: (ch: any) => getChannelInfoImpl(ch),
+            },
+            conversationManager: { findConversation: () => null },
+        }),
+    },
+    ConversationAction: {},
+    Message: class {},
+    MessageContent: class {},
+    MessageStatus: {},
+    Subscriber: class {},
+    Conversation: class {},
+    MessageExtra: class {},
+    CMDContent: class {},
+    PullMode: {},
+    MessageContentType: {},
+    ChannelInfo: class {},
+    ChannelInfoListener: class {},
+    ConversationListener: class {},
+    MessageListener: class {},
+    MessageStatusListener: class {},
+    SendackPacket: class {},
+    Setting: class {},
+    SystemContent: class {},
+}))
+
+vi.mock("../../../App", () => ({
+    default: {
+        loginInfo: { uid: "me" },
+        dataSource: { channelDataSource: { subscribers: (...args: any[]) => dataSourceSubscribers(...args) } },
+        mittBus: { on: () => {}, off: () => {}, emit: () => {} },
+    },
+}))
+
+vi.mock("../../../Service/DataSource/DataProvider", () => ({}))
+vi.mock("../../../Service/Model", () => ({ MessageWrap: class {} }))
+vi.mock("../../../Service/Provider", () => ({
+    ProviderListener: class {
+        callback?: Function
+        notifyListener() { this.callback?.() }
+        listen(f: Function) { this.callback = f }
+        clearListeners() { this.callback = undefined }
+        didMount() {}
+        didUnMount() {}
+    },
+}))
+vi.mock("react-scroll", () => ({ animateScroll: {}, scroller: {} }))
+vi.mock("../../../Service/Const", () => ({
+    EndpointID: {},
+    MessageContentTypeConst: {},
+    OrderFactor: {},
+    ChannelTypeCommunityTopic: 6,
+}))
+vi.mock("moment", () => ({ default: () => ({ format: () => "" }) }))
+vi.mock("../../../Messages/Time", () => ({ TimeContent: class {} }))
+vi.mock("../../../Messages/HistorySplit", () => ({ HistorySplitContent: class {} }))
+vi.mock("../../../Messages/Mergeforward", () => ({ default: class {} }))
+vi.mock("../../../Service/TypingManager", () => ({ TypingListener: class {}, TypingManager: { shared: { addTypingListener: () => {}, removeTypingListener: () => {} } } }))
+vi.mock("../../../Service/ProhibitwordsService", () => ({ ProhibitwordsService: { shared: { getProhibitwords: () => [] } } }))
+vi.mock("../../../Service/SpaceService", () => ({ SYSTEM_BOTS: [] }))
+vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
+vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
+vi.mock("../historyScroll", () => ({ getPulldownRestoredScrollTop: () => 0 }))
+vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+
+import ConversationVM from "../vm"
+import { Channel } from "wukongimjssdk"
+
+describe("ConversationVM.resyncSubscribers — branch selection", () => {
+    beforeEach(() => {
+        syncSubscribes.mockClear()
+        getSubscribes.mockClear()
+        notifySubscribeChangeListeners.mockClear()
+        dataSourceSubscribers.mockClear()
+        getChannelInfoImpl = () => undefined
+    })
+
+    it("normal group → full server sync (syncSubscribes), not first-page API", async () => {
+        const vm = new ConversationVM(new Channel("group1", 2))
+        ;(vm as any).channelInfo = { orgData: { group_type: 0 } } // not SuperGroup
+
+        await vm.resyncSubscribers()
+
+        expect(syncSubscribes).toHaveBeenCalledTimes(1)
+        expect(dataSourceSubscribers).not.toHaveBeenCalled()
+    })
+
+    it("super group → first-page API only, never full syncSubscribes", async () => {
+        const vm = new ConversationVM(new Channel("supergroup1", 2))
+        ;(vm as any).channelInfo = { orgData: { group_type: 1 } } // SuperGroup
+
+        await vm.resyncSubscribers()
+
+        expect(dataSourceSubscribers).toHaveBeenCalledTimes(1)
+        expect(dataSourceSubscribers).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ limit: 100, page: 1 }),
+        )
+        expect(syncSubscribes).not.toHaveBeenCalled()
+    })
+
+    it("community-topic with SUPER-GROUP parent → first-page API only (mirrors entry-load, octo-web#568)", async () => {
+        const vm = new ConversationVM(new Channel("topic1", 6))
+        ;(vm as any).channelInfo = { orgData: { parentGroupNo: "parentSuper" } }
+        // parent is a super group
+        getChannelInfoImpl = (ch: any) =>
+            ch.channelID === "parentSuper" ? { orgData: { group_type: 1 } } : undefined
+
+        await vm.resyncSubscribers()
+
+        // must paginate the super-group parent, NOT full-sync it
+        expect(dataSourceSubscribers).toHaveBeenCalledTimes(1)
+        expect(dataSourceSubscribers).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ limit: 100, page: 1 }),
+        )
+        expect(syncSubscribes).not.toHaveBeenCalled()
+    })
+
+    it("community-topic with NORMAL parent → full syncSubscribes", async () => {
+        const vm = new ConversationVM(new Channel("topic2", 6))
+        ;(vm as any).channelInfo = { orgData: { parentGroupNo: "parentNormal" } }
+        getChannelInfoImpl = (ch: any) =>
+            ch.channelID === "parentNormal" ? { orgData: { group_type: 0 } } : undefined
+
+        await vm.resyncSubscribers()
+
+        expect(syncSubscribes).toHaveBeenCalledTimes(1)
+        expect(dataSourceSubscribers).not.toHaveBeenCalled()
+    })
+
+    it("1-1 (ChannelTypePerson) → no member load at all", async () => {
+        const vm = new ConversationVM(new Channel("person1", 1))
+        ;(vm as any).channelInfo = { orgData: {} }
+
+        await vm.resyncSubscribers()
+
+        expect(syncSubscribes).not.toHaveBeenCalled()
+        expect(dataSourceSubscribers).not.toHaveBeenCalled()
+    })
+})
+
+describe("ConversationVM.resyncSubscribers — independent throttle (octo-web#568)", () => {
+    beforeEach(() => {
+        syncSubscribes.mockClear()
+        dataSourceSubscribers.mockClear()
+        getChannelInfoImpl = () => undefined
+        vi.useFakeTimers()
+    })
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("member resync does NOT touch the reconnect message-refresh throttle (lastReconnectRefreshAt)", async () => {
+        const vm = new ConversationVM(new Channel("group1", 2))
+        ;(vm as any).channelInfo = { orgData: { group_type: 0 } }
+
+        // Simulate a foreground event driving member resync.
+        await (vm as any)._foregroundResyncHandler()
+
+        // The foreground path must NOT have bumped the reconnect message-refresh
+        // timestamp; otherwise a reconnect within 5s would skip requestMessagesOfFirstPage.
+        expect((vm as any).lastReconnectRefreshAt).toBe(0)
+        // It does use its own member-resync throttle.
+        expect((vm as any).lastSubscriberResyncAt).toBeGreaterThan(0)
+    })
+
+    it("throttles repeated member resyncs within 5s via its own timestamp", async () => {
+        const vm = new ConversationVM(new Channel("group1", 2))
+        ;(vm as any).channelInfo = { orgData: { group_type: 0 } }
+
+        await vm.resyncSubscribers()
+        expect(syncSubscribes).toHaveBeenCalledTimes(1)
+
+        // second call immediately after → throttled
+        await vm.resyncSubscribers()
+        expect(syncSubscribes).toHaveBeenCalledTimes(1)
+
+        // after 5s window → runs again
+        vi.advanceTimersByTime(5001)
+        await vm.resyncSubscribers()
+        expect(syncSubscribes).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1009,8 +1009,17 @@ export default class ConversationVM extends ProviderListener {
             }
             this.lastReconnectRefreshAt = now
             this.requestMessagesOfFirstPage(0)
+            // 断连期间的成员变更 CMD（加/减成员，含龙虾）随 WS 丢失，SDK 重连
+            // 只 reSubscribe 不补拉，subscriberChangeListener 因此不会被触发，
+            // 导致 subscribers 停在断连前旧快照 → @ 提及弹窗搜不到新成员。
+            // 这里在补拉首屏消息的同时补拉当前会话成员，修复 octo-web#567。
+            this.resyncSubscribers()
         }
         WKSDK.shared().connectManager.addConnectStatusListener(this.connectStatusListener)
+
+        // 回前台补刷：合盖/息屏久后回到页面，WS 可能已断且成员变更事件已丢失。
+        // App.tsx 的 visibilitychange/focus 只刷 remoteConfig，不碰成员，这里补上。
+        WKApp.mittBus.on("wk:app-foreground", this._foregroundResyncHandler)
 
         const conversation = WKSDK.shared().conversationManager.findConversation(this.channel)
         if (conversation) {
@@ -1088,6 +1097,7 @@ export default class ConversationVM extends ProviderListener {
 
         WKApp.mittBus.off("task-upload-failed", this._taskUploadFailedHandler)
         WKApp.mittBus.off("emoji-manifest-updated", this._emojiManifestUpdatedHandler)
+        WKApp.mittBus.off("wk:app-foreground", this._foregroundResyncHandler)
     }
 
     // 加载频道信息完成
@@ -1266,6 +1276,55 @@ export default class ConversationVM extends ProviderListener {
             this._resolveSubscribersReady()
         }
         this.notifyListener()
+    }
+
+    // 回前台重刷处理器：App.tsx 回前台时全局 emit，这里节流后重同步当前会话成员。
+    private _foregroundResyncHandler = () => {
+        const now = Date.now()
+        if (now - this.lastReconnectRefreshAt < 5000) {
+            return
+        }
+        this.lastReconnectRefreshAt = now
+        this.resyncSubscribers()
+    }
+
+    // 主动重同步当前会话成员列表（重连 / 回前台调用）。
+    // 断连期间的成员变更 CMD 随 WS 丢失、SDK 重连不补拉，subscriberChangeListener
+    // 因此不会触发，subscribers 停在旧快照 → @ 弹窗搜不到新成员（octo-web#567）。
+    // 这里复用进频道时的加载分支：超级群拉第一页，普通群走服务端全量同步。
+    async resyncSubscribers() {
+        try {
+            if (this.channel.channelType === ChannelTypeCommunityTopic) {
+                // 子区用父群成员，父群 syncSubscribes 后其 subscriberChangeListener
+                // 会回调刷新，这里不重复处理。
+                const parentGroupNo = this.channelInfo?.orgData?.parentGroupNo
+                if (parentGroupNo) {
+                    const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
+                    await WKSDK.shared().channelManager.syncSubscribes(parentChannel)
+                    this.subscribers = WKSDK.shared().channelManager.getSubscribes(parentChannel) || []
+                    this._resolveSubscribersReady()
+                    this.notifyListener()
+                }
+                return
+            }
+            if (this.channel.channelType !== ChannelTypeGroup) {
+                return
+            }
+            if (this.channelInfo?.orgData?.group_type == SuperGroup) {
+                // 超级群只拉第一页（与进频道时一致）
+                this.subscribers = await this.getFirstPageMembers()
+                this._resolveSubscribersReady()
+                WKSDK.shared().channelManager.subscribeCacheMap.set(this.channel.getChannelKey(), this.subscribers)
+                WKSDK.shared().channelManager.notifySubscribeChangeListeners(this.channel)
+                this.notifyListener()
+            } else {
+                // 普通群走服务端全量同步，完成后 subscriberChangeListener 回调刷新
+                await WKSDK.shared().channelManager.syncSubscribes(this.channel)
+                this.reloadSubscribers()
+            }
+        } catch (e) {
+            console.warn("[ConversationVM] resyncSubscribers failed", e)
+        }
     }
 
     // 通过uid获取订阅者对象

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -98,7 +98,8 @@ export default class ConversationVM extends ProviderListener {
     typingListener!: TypingListener // 输入中监听
     messageListener!: MessageListener // 消息监听
     connectStatusListener!: ConnectStatusListener // 连接状态监听（重连补刷当前会话）
-    private lastReconnectRefreshAt: number = 0 // 重连补刷去抖时间戳
+    private lastReconnectRefreshAt: number = 0 // 重连补刷（离线消息）去抖时间戳
+    private lastSubscriberResyncAt: number = 0 // 成员重同步去抖时间戳（独立于消息补刷，避免前台成员刷压制重连消息补拉，octo-web#568 review）
     cmdListener!: MessageListener // cmd消息监听
     messageStatusListener!: MessageStatusListener // 消息状态监听
     conversationListener!: ConversationListener // 会话监听
@@ -1012,7 +1013,8 @@ export default class ConversationVM extends ProviderListener {
             // 断连期间的成员变更 CMD（加/减成员，含龙虾）随 WS 丢失，SDK 重连
             // 只 reSubscribe 不补拉，subscriberChangeListener 因此不会被触发，
             // 导致 subscribers 停在断连前旧快照 → @ 提及弹窗搜不到新成员。
-            // 这里在补拉首屏消息的同时补拉当前会话成员，修复 octo-web#567。
+            // 成员重同步自带独立节流（lastSubscriberResyncAt），不与上方消息补拉
+            // 共用时间戳，修复 octo-web#567/#568。
             this.resyncSubscribers()
         }
         WKSDK.shared().connectManager.addConnectStatusListener(this.connectStatusListener)
@@ -1278,33 +1280,48 @@ export default class ConversationVM extends ProviderListener {
         this.notifyListener()
     }
 
-    // 回前台重刷处理器：App.tsx 回前台时全局 emit，这里节流后重同步当前会话成员。
+    // 回前台重刷处理器：App.tsx 回前台时全局 emit，这里直接重同步当前会话成员。
+    // 节流已下沉到 resyncSubscribers 内（lastSubscriberResyncAt），不再共用重连的
+    // lastReconnectRefreshAt，避免前台成员刷抢先设时间戳后压制重连的消息补拉（octo-web#568 review）。
     private _foregroundResyncHandler = () => {
-        const now = Date.now()
-        if (now - this.lastReconnectRefreshAt < 5000) {
-            return
-        }
-        this.lastReconnectRefreshAt = now
         this.resyncSubscribers()
     }
 
     // 主动重同步当前会话成员列表（重连 / 回前台调用）。
     // 断连期间的成员变更 CMD 随 WS 丢失、SDK 重连不补拉，subscriberChangeListener
     // 因此不会触发，subscribers 停在旧快照 → @ 弹窗搜不到新成员（octo-web#567）。
-    // 这里复用进频道时的加载分支：超级群拉第一页，普通群走服务端全量同步。
+    // 自带 5s 节流（lastSubscriberResyncAt），与重连的消息补拉节流相互独立。
+    // 复用进频道时的加载分支：超级群（含子区的超级群父群）拉第一页，普通群走服务端全量同步。
     async resyncSubscribers() {
+        const now = Date.now()
+        if (now - this.lastSubscriberResyncAt < 5000) {
+            return
+        }
+        this.lastSubscriberResyncAt = now
         try {
             if (this.channel.channelType === ChannelTypeCommunityTopic) {
-                // 子区用父群成员，父群 syncSubscribes 后其 subscriberChangeListener
-                // 会回调刷新，这里不重复处理。
+                // 子区用父群成员。需镜像进频道时的分支：父群是超级群时只拉第一页，
+                // 否则会对几千人的超级群父群每次重连/回前台都全量同步（octo-web#568 review）。
                 const parentGroupNo = this.channelInfo?.orgData?.parentGroupNo
-                if (parentGroupNo) {
-                    const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
+                if (!parentGroupNo) {
+                    return
+                }
+                const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
+                const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+                const isSuperGroup = parentChannelInfo?.orgData?.group_type == SuperGroup
+                if (isSuperGroup) {
+                    // 超级群父群：只拉第一页（与进频道时一致）
+                    this.subscribers = await WKApp.dataSource.channelDataSource.subscribers(parentChannel, {
+                        limit: 100,
+                        page: 1,
+                    })
+                } else {
+                    // 普通父群：全量同步后取缓存
                     await WKSDK.shared().channelManager.syncSubscribes(parentChannel)
                     this.subscribers = WKSDK.shared().channelManager.getSubscribes(parentChannel) || []
-                    this._resolveSubscribersReady()
-                    this.notifyListener()
                 }
+                this._resolveSubscribersReady()
+                this.notifyListener()
                 return
             }
             if (this.channel.channelType !== ChannelTypeGroup) {


### PR DESCRIPTION
## 背景

Fixes #567

Web 端在群聊输入框 `@` 提及时，弹窗候选列表搜不到群里新加入的成员（含龙虾），导致「@ 不到」。手动刷新页面后恢复。与群人数无关，小群同样复现。

## 根因

断连期间（合盖 / 息屏 / 网络切换）群里发生的成员变更 CMD（加 / 减成员）随 WebSocket 丢失。SDK 重连时"只 reSubscribe，不补拉断连期间的离线 CMD"（`App.tsx` 现有注释自述），因此 `subscriberChangeListener` 不会被触发，`ConversationVM.subscribers` 停在断连前的旧快照。`@` 弹窗候选（`buildMentionDropdownItems`）基于这份陈旧列表做本地过滤，于是搜不到新成员。手动刷新页面走 `loadChannelInfoFinished` 重新 `syncSubscribes` 才补全恢复。

> 佐证：手写 `@名字` 纯文本（非结构化 mention 节点）仍能触发龙虾，是**服务端**按名字兜底解析命中的 —— 说明服务端成员数据是全的，坏的只是前端这份陈旧缓存。

## 改动

- `ConversationVM` 新增 `resyncSubscribers()`：复用进频道时的加载分支 —— 超级群拉第一页、普通群走服务端全量同步、子区同步父群。
- 重连成功（`ConnectStatus.Connected`）时，在已有的补拉首屏消息逻辑旁补拉当前会话成员，沿用现有 5s 节流窗口。
- `App.tsx` 回前台（`visibilitychange` / `focus`）广播 `wk:app-foreground` 事件（已在 `MittEvents` 注册类型）；当前打开的会话 vm 监听后节流重同步成员。原本回前台只刷 `remoteConfig` + 清 typing，不碰成员。
- vm 在 `didUnMount` 中成对 `off("wk:app-foreground")`，避免 listener 泄漏。

## 验证

- `dmworkbase` 包 `tsc --noEmit`：改动前后错误数一致（7337 = 7337，均为 monorepo 裸 tsc 单包运行的既有 baseline 噪声，如 react 类型 / vite env），**零新增类型错误**。
- `vitest run src/Components/Conversation`：**117 tests passed**（含 `subscribersReady.test.ts` 6 项全过）。唯一失败的 `categoriesFallback.test.ts` 是 lottie-web + canvas 的测试环境依赖问题，与本改动无关（suite 加载即崩，0 test 运行）。

## 说明

原 issue #567 中对「P1 超级群未注册 subscriberChangeListener」的描述不准确 —— 经代码核对，`ChannelTypeGroup` 分支对普通群和超级群是统一注册监听的，子区走独立路径。真正的根因是本 PR 修复的「重连 / 回前台不主动重同步成员，只依赖断连期间不可靠的 WS 推送」，它涵盖了原 issue 的加 / 减成员两个方向。超级群「@ 候选只加载前 100 人」是一个相关但独立的次要隐患（本 PR 未处理，`resyncSubscribers` 对超级群保持与进频道一致的前 100 人行为，不扩大改动面）。
