### PR TITLE
feat(dmworkbase): octo/v2 rich inputs (Input.Number/Date/Time) + card_version 1.6 cap

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/guards.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/guards.test.ts
@@ -35,11 +35,11 @@ describe("compareCardVersion", () => {
 });
 
 describe("isSupportedCardVersion", () => {
-  it("<= 1.5 支持，> 1.5 不支持，非法不支持", () => {
+  it("<= 1.6 支持（对齐 SDK 上限），> 1.6 不支持，非法不支持", () => {
     expect(isSupportedCardVersion("1.5")).toBe(true);
     expect(isSupportedCardVersion("1.4")).toBe(true);
     expect(isSupportedCardVersion("1.0")).toBe(true);
-    expect(isSupportedCardVersion("1.6")).toBe(false);
+    expect(isSupportedCardVersion("1.6")).toBe(true);
     expect(isSupportedCardVersion("2.0")).toBe(false);
     expect(isSupportedCardVersion("bogus")).toBe(false);
     expect(isSupportedCardVersion("")).toBe(false);
@@ -51,6 +51,7 @@ describe("negotiate", () => {
     expect(negotiate("octo/v1", "1.5")).toEqual({ ok: true });
     expect(negotiate("octo/v1", "1.4")).toEqual({ ok: true });
     expect(negotiate("octo/v2", "1.5")).toEqual({ ok: true });
+    expect(negotiate("octo/v2", "1.6")).toEqual({ ok: true });
   });
 
   it("不支持 profile → unsupported-profile（优先于 version 判定）", () => {
@@ -66,7 +67,7 @@ describe("negotiate", () => {
   });
 
   it("profile 支持但 version 过高 → unsupported-version", () => {
-    expect(negotiate("octo/v1", "1.6")).toEqual({
+    expect(negotiate("octo/v1", "1.7")).toEqual({
       ok: false,
       reason: "unsupported-version",
     });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -33,6 +33,9 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
       "Input.Text",
       "Input.Toggle",
       "Input.ChoiceSet",
+      "Input.Number",
+      "Input.Date",
+      "Input.Time",
     ]) {
       expect(reg.findByName(t)).toBeDefined();
     }
@@ -44,9 +47,6 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
       "RichTextBlock",
       "ImageSet",
       "ActionSet",
-      "Input.Number",
-      "Input.Date",
-      "Input.Time",
     ]) {
       expect(reg.findByName(t)).toBeUndefined();
     }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
@@ -168,6 +168,26 @@ describe("decideCardBody — 协商（第二道闸，可信 sender 前提）", (
   });
 });
 
+describe("decideCardBody — card_version 1.6（对齐 SDK 上限，版本放宽但元素门禁不放松）", () => {
+  const trusted = { fromUID: "iwh_x", profile: "octo/v1" as const };
+
+  it("1.6 + octo 白名单元素 → card（版本协商放行，将来服务端升 1.6 无需发版）", () => {
+    expect(
+      decideCardBody({ ...trusted, cardVersion: "1.6", card: validCard }).kind
+    ).toBe("card");
+  });
+
+  it("1.6 + 非白名单元素 → plain（元素门禁仍 fail-closed，1.6-only 元素不放行）", () => {
+    expect(
+      decideCardBody({
+        ...trusted,
+        cardVersion: "1.6",
+        card: AC([{ type: "Carousel" }]),
+      }).kind
+    ).toBe("plain");
+  });
+});
+
 describe("decideCardBody — octo/v2 交互元素（allowInteractive）", () => {
   const trustedV2 = { fromUID: "iwh_x", profile: "octo/v2", cardVersion: "1.5" };
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -96,6 +96,27 @@ describe("renderOctoCard", () => {
     target.remove();
   });
 
+  it("P3-3 富输入 Input.Number/Date/Time 渲染出对应原生控件", () => {
+    const target = mountTarget();
+    renderOctoCard({
+      card: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          { type: "Input.Number", id: "n" },
+          { type: "Input.Date", id: "d" },
+          { type: "Input.Time", id: "tm" },
+        ],
+      },
+      target,
+      onAction: () => {},
+    });
+    expect(target.querySelector("input[type=number]")).not.toBeNull();
+    expect(target.querySelector("input[type=date]")).not.toBeNull();
+    expect(target.querySelector("input[type=time]")).not.toBeNull();
+    target.remove();
+  });
+
   it("requires+fallback 子树不被渲染（fallback/requires 已剥，防未校验子树逃逸）", () => {
     const target = mountTarget();
     renderOctoCard({

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
@@ -70,6 +70,34 @@ describe("validateCardForOcto — 合法（ok:true）", () => {
       ).ok
     ).toBe(true);
   });
+
+  it("v2：Input.Number/Date/Time（P3-3 富输入）", () => {
+    expect(
+      validateCardForOcto(
+        AC([
+          { type: "Input.Number", id: "amount", min: 0, max: 100 },
+          { type: "Input.Date", id: "date" },
+          { type: "Input.Time", id: "time" },
+        ]),
+        V2
+      ).ok
+    ).toBe(true);
+  });
+
+  it("v2：输入的 inlineAction(Submit) 合法且 id 登记", () => {
+    expect(
+      validateCardForOcto(
+        AC([
+          {
+            type: "Input.Text",
+            id: "q",
+            inlineAction: { type: "Action.Submit", id: "go" },
+          },
+        ]),
+        V2
+      ).ok
+    ).toBe(true);
+  });
 });
 
 describe("validateCardForOcto — 整卡降级（ok:false）", () => {
@@ -80,6 +108,32 @@ describe("validateCardForOcto — 整卡降级（ok:false）", () => {
   it("未知元素", () => bad(AC([{ type: "Media" }])));
   it("元素无 type", () => bad(AC([{ text: "no type" }])));
   it("Input.* 在 v1（禁交互）", () => bad(AC([{ type: "Input.Text", id: "t" }])));
+  it("Input.Number 在 v1（禁交互）", () =>
+    bad(AC([{ type: "Input.Number", id: "n" }])));
+  it("Input.Date 缺 id（v2，D1）", () =>
+    bad(AC([{ type: "Input.Date" }]), V2));
+  it("输入 inlineAction 为 Action.Execute（v2）→ 整卡降级", () =>
+    bad(
+      AC([
+        {
+          type: "Input.Text",
+          id: "q",
+          inlineAction: { type: "Action.Execute", id: "x" },
+        },
+      ]),
+      V2
+    ));
+  it("输入 inlineAction id 与输入 id 冲突（v2，D1）→ 整卡降级", () =>
+    bad(
+      AC([
+        {
+          type: "Input.Text",
+          id: "dup",
+          inlineAction: { type: "Action.Submit", id: "dup" },
+        },
+      ]),
+      V2
+    ));
   it("Action.Submit 在 v1", () =>
     bad(AC([{ type: "TextBlock", text: "x" }], { actions: [{ type: "Action.Submit", id: "s" }] })));
   it("Action.Execute 在 v2（永不支持）", () =>

--- a/packages/dmworkbase/src/Messages/InteractiveCard/index.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/index.css
@@ -98,6 +98,9 @@
 }
 
 .wk-interactive-card-sdk .ac-textInput,
+.wk-interactive-card-sdk .ac-numberInput,
+.wk-interactive-card-sdk .ac-dateInput,
+.wk-interactive-card-sdk .ac-timeInput,
 .wk-interactive-card-sdk .ac-choiceSetInput-compact {
   min-height: 30px;
   padding: var(--wk-sp-1, 4px) var(--wk-sp-2, 8px);
@@ -110,6 +113,9 @@
 }
 
 .wk-interactive-card-sdk .ac-textInput:focus-visible,
+.wk-interactive-card-sdk .ac-numberInput:focus-visible,
+.wk-interactive-card-sdk .ac-dateInput:focus-visible,
+.wk-interactive-card-sdk .ac-timeInput:focus-visible,
 .wk-interactive-card-sdk .ac-choiceSetInput-compact:focus-visible {
   outline: none;
   border-color: var(--wk-brand-primary);

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
@@ -14,8 +14,8 @@ import {
  *
  * - **动作**是有副作用的（触发 host 回调），移除 `Action.Execute`/`ShowCard`/`ToggleVisibility`，
  *   只留 octo 的 `Action.OpenUrl` + `Action.Submit`。
- * - **元素**移除非 octo 白名单类型（Table/Carousel/Media/RichTextBlock/ImageSet/ActionSet、
- *   Input.Number/Date/Time），只留 octo 允许的 9 类。即便 validate 疏漏，这些元素也无法被 SDK 反序列化。
+ * - **元素**移除非 octo 白名单类型（Table/Carousel/Media/RichTextBlock/ImageSet/ActionSet），
+ *   只留 octo 允许的类型。即便 validate 疏漏，这些元素也无法被 SDK 反序列化。
  *
  * 采用「populate 默认后 unregister 非白名单」而非 register-only：octo 允许的元素保持默认注册，
  * 避免漏注册导致合法卡半渲染；新版 AC 引入的未知元素虽不在此剔除列表，仍由 validate 整卡拦下。
@@ -27,8 +27,8 @@ const FORBIDDEN_ACTIONS = [
 ] as const;
 
 /** 非 octo 白名单元素（AC 默认注册但 octo 不支持）。octo 允许：TextBlock/Image/Container/
- *  ColumnSet/Column/FactSet/Input.Text/Input.Toggle/Input.ChoiceSet（Column 由 ColumnSet
- *  内部解析、非独立注册项，Table/Carousel 的行/页同理，故无需单列）。 */
+ *  ColumnSet/Column/FactSet + 6 类输入 Input.Text/Toggle/ChoiceSet/Number/Date/Time
+ *  （Column 及 Table/Carousel 的行/页由父元素内部解析、非独立注册项，故无需单列）。 */
 const FORBIDDEN_ELEMENTS = [
   "Table",
   "Carousel",
@@ -37,9 +37,6 @@ const FORBIDDEN_ELEMENTS = [
   "TextRun",
   "ImageSet",
   "ActionSet",
-  "Input.Number",
-  "Input.Date",
-  "Input.Time",
 ] as const;
 
 export function createOctoSerializationContext(): SerializationContext {

--- a/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
@@ -15,10 +15,11 @@
 export const CARD_PROFILE_OCTO_V1 = "octo/v1";
 export const CARD_PROFILE_OCTO_V2 = "octo/v2";
 export const CARD_VERSION_1_5 = "1.5";
+export const CARD_VERSION_1_6 = "1.6";
 
 /**
  * 客户端支持的 profile 集合（协商用）。
- * octo/v2 与 v1 共享 card_version 上限（<=1.5）；差异在元素/动作白名单
+ * octo/v2 与 v1 共享 card_version 上限；差异在元素/动作白名单
  * （见 validateCardForOcto 的 allowInteractive 分支）。
  */
 export const SUPPORTED_PROFILES: ReadonlySet<string> = new Set([
@@ -26,8 +27,13 @@ export const SUPPORTED_PROFILES: ReadonlySet<string> = new Set([
   CARD_PROFILE_OCTO_V2,
 ]);
 
-/** 客户端支持的最高 card_version。 */
-export const MAX_CARD_VERSION = CARD_VERSION_1_5;
+/**
+ * 客户端支持的最高 card_version —— 对齐官方 AdaptiveCards SDK 上限（1.6）。
+ * 抬到 1.6 只放宽**版本协商**（将来服务端升 1.6 信封无需前端发版）；
+ * **不放宽元素白名单**——具体元素仍由 validateCardForOcto fail-closed 门禁，
+ * 1.6-only 元素不在白名单内仍整卡降级。服务端目前仍 pin 1.5。
+ */
+export const MAX_CARD_VERSION = CARD_VERSION_1_6;
 
 /** 客户端防御上限（与服务端 enforced 上限对齐，信任服务端仍二次防御）。 */
 export const MAX_DEPTH = 16;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
@@ -144,7 +144,10 @@ function validateElement(el: unknown, ctx: Ctx): void {
     }
     case "Input.Text":
     case "Input.Toggle":
-    case "Input.ChoiceSet": {
+    case "Input.ChoiceSet":
+    case "Input.Number":
+    case "Input.Date":
+    case "Input.Time": {
       if (!ctx.allowInteractive) {
         // octo/v1 内出现 Input.* = 白名单外 → 整卡降级。
         throw new OctoInvalidCard("unsupported element (interactive)");
@@ -157,6 +160,14 @@ function validateElement(el: unknown, ctx: Ctx): void {
           if (!ctx.budget.consume())
             throw new OctoInvalidCard("node count exceeded");
         }
+      }
+      // 输入的 inlineAction（框内内联按钮，通常 Action.Submit）：按动作同规则校验
+      // （id 帧内唯一 / OpenUrl url 安全 / 非白名单动作整卡降级）并计入预算，
+      // 避免 SDK 渲染出未经 validate 的内联动作（对齐服务端 inlineAction 路由）。
+      if (obj.inlineAction !== undefined && obj.inlineAction !== null) {
+        validateAction(obj.inlineAction, ctx);
+        if (!ctx.budget.consume())
+          throw new OctoInvalidCard("node count exceeded");
       }
       return;
     }


### PR DESCRIPTION
## Summary

Client half of **octo-server P3-3** (server [#556](https://github.com/Mininglamp-OSS/octo-server/pull/556) extends the octo/v2 input whitelist from 3 to 6), plus a forward-compat bump of the client `card_version` cap to match the AdaptiveCards SDK.

Both changes are additive and keep the octo policy layer fail-closed. Follows #562 (SDK-based rendering).

## What's included

**1. Rich inputs — `Input.Number` / `Input.Date` / `Input.Time`** (all Adaptive Cards 1.0 elements; stay within `card_version` 1.5)
- `validateCardForOcto`: accept the three new inputs in the `allowInteractive` (octo/v2) branch — id required + frame-unique, same discipline as the existing inputs; rejected in octo/v1 as before.
- Also validate an input's **`inlineAction`** (the in-field inline button) through the action rules — id frame-unique, `Action.OpenUrl` url safe, non-whitelist action → whole-card fallback, counted against the budget. Closes a pre-existing gap (inlineAction was never walked for any input) and mirrors the server's inlineAction dispatch.
- `octoSerialization`: stop unregistering `Input.Number/Date/Time` from the SDK element registry so the SDK renders them natively (number spinner / date / time pickers).
- `css`: baseline styling for `ac-numberInput` / `ac-dateInput` / `ac-timeInput`.
- Submit collection unchanged (`getAllInputs`). Server remains authoritative for value validation (finite Number + min/max, Date/Time format + range).

**2. `card_version` cap 1.5 → 1.6** (align to the official SDK's max supported schema)
- Only widens **version negotiation**: a future server envelope bump to `"1.6"` needs no client release.
- Does **not** widen the element whitelist — `validateCardForOcto` stays fail-closed on the octo subset. A `"1.6"` card using octo elements renders; a 1.6-only element (e.g. `Carousel`) still whole-card-degrades to plain.

## Test plan

- [x] `pnpm test` (InteractiveCard): **14 files / 147 cases** green.
- [x] New inputs accepted in v2 / rejected in v1 / missing-id fallback; inlineAction (valid Submit, Execute → fallback, duplicate-id → fallback); element registry now allows the three; e2e render of native number/date/time controls.
- [x] `card_version` 1.6 accepted (2.0 still rejected); 1.6 + octo elements → card, 1.6 + non-whitelist element → plain.
- [x] `i18n:check` passes (no new keys).

## Rollout / dependencies

- Depends on **octo-server #556** being merged + deployed for the wire to actually carry the new inputs. Forward-compatible either way: shipping web first is harmless (no such cards arrive yet); server-first means older web whole-card-degrades to plain (§8, no per-element fallback) — a rollout-coordination concern, not a regression.
- **card_version 1.6** is forward-compat only; server still pins 1.5 today.

## Follow-up (not in this PR)
- **Zero-release element expansion** via the D12 capability manifest (`GET /v1/bot/card/profile` `elements`/`inputs`): let the client derive the allowlist from the server manifest so future server-side element additions need no client release, while staying fail-closed. Requires confirming that endpoint is reachable by the (non-bot) rendering client.