### PR TITLE
feat(chat): 群名最大长度50，子区名最大长度100

### DIFF
--- a/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react"
 import ThreadIcon from "../Icons/ThreadIcon"
 import WKApp from "../../App"
 import { I18nContext, t } from "../../i18n"
+import { THREAD_NAME_MAX_LENGTH } from "../../Service/nameLimits"
 import "./index.css"
 
 export interface ThreadCreateProps {
@@ -49,7 +50,7 @@ export class ThreadCreate extends Component<ThreadCreateProps, ThreadCreateState
       return
     }
 
-    if (name.length > 100) {
+    if (name.length > THREAD_NAME_MAX_LENGTH) {
       Toast.warning(t("base.threadCreate.nameMaxLength"))
       return
     }
@@ -94,7 +95,7 @@ export class ThreadCreate extends Component<ThreadCreateProps, ThreadCreateState
             value={name}
             onChange={this.handleNameChange}
             onKeyDown={this.handleKeyDown}
-            maxLength={100}
+            maxLength={THREAD_NAME_MAX_LENGTH}
             autoFocus
           />
         </div>

--- a/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadCreate/index.tsx
@@ -49,7 +49,7 @@ export class ThreadCreate extends Component<ThreadCreateProps, ThreadCreateState
       return
     }
 
-    if (name.length > 50) {
+    if (name.length > 100) {
       Toast.warning(t("base.threadCreate.nameMaxLength"))
       return
     }
@@ -94,7 +94,7 @@ export class ThreadCreate extends Component<ThreadCreateProps, ThreadCreateState
             value={name}
             onChange={this.handleNameChange}
             onKeyDown={this.handleKeyDown}
-            maxLength={50}
+            maxLength={100}
             autoFocus
           />
         </div>

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.css
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.css
@@ -58,6 +58,14 @@ body[theme-mode="dark"] .wk-thread-panel {
   font-size: 14px;
   font-weight: 600;
   color: var(--wk-text-primary);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.wk-thread-panel-header-title > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wk-thread-panel-header-icon {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -90,13 +90,12 @@ const ThreadNameInput = React.forwardRef<
         type="text"
         value={value}
         placeholder={placeholder}
-        maxLength={THREAD_NAME_MAX_LENGTH}
         autoFocus={autoFocus}
         style={{
           width: "100%",
           padding: "10px 12px",
           background: "var(--wk-bg-base)",
-          border: "1px solid var(--wk-border-default)",
+          border: exceeded ? "1px solid var(--wk-color-danger)" : "1px solid var(--wk-border-default)",
           borderRadius: "6px",
           fontSize: "14px",
           color: "var(--wk-text-primary)",
@@ -769,6 +768,10 @@ export default class ThreadPanel extends Component<
             Toast.error(t("base.threadPanel.nameRequired"));
             return;
           }
+          if (newName.length > THREAD_NAME_MAX_LENGTH) {
+            Toast.warning(t("base.threadCreate.nameMaxLength"));
+            return;
+          }
           try {
             await WKApp.dataSource.channelDataSource.threadUpdate(
               groupNo,
@@ -1080,6 +1083,10 @@ export default class ThreadPanel extends Component<
         threadName = inputRef.current?.value ?? "";
         if (!threadName || threadName.trim() === "") {
           Toast.error(t("base.module.createThread.nameRequired"));
+          return;
+        }
+        if (threadName.length > THREAD_NAME_MAX_LENGTH) {
+          Toast.warning(t("base.threadCreate.nameMaxLength"));
           return;
         }
         try {

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useState } from "react";
 import {
   Channel,
   ChannelTypePerson,
@@ -65,6 +65,59 @@ import {
   persistThreadWidth,
 } from "../WKLayout/layoutWidth";
 import "./index.css";
+
+const THREAD_NAME_MAX_LENGTH = 100;
+
+/**
+ * 子区名称输入框 — 带字数计数器（当前/最大）
+ * 用于 ThreadPanel 内创建/编辑子区名的 wkConfirm 弹窗。
+ */
+const ThreadNameInput = React.forwardRef<
+  HTMLInputElement,
+  {
+    defaultValue?: string;
+    placeholder?: string;
+    autoFocus?: boolean;
+  }
+>(({ defaultValue = "", placeholder, autoFocus }, ref) => {
+  const [value, setValue] = useState(defaultValue);
+  const exceeded = value.length > THREAD_NAME_MAX_LENGTH;
+  return (
+    <div>
+      <input
+        ref={ref}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        maxLength={THREAD_NAME_MAX_LENGTH}
+        autoFocus={autoFocus}
+        style={{
+          width: "100%",
+          padding: "10px 12px",
+          background: "var(--wk-bg-base)",
+          border: "1px solid var(--wk-border-default)",
+          borderRadius: "6px",
+          fontSize: "14px",
+          color: "var(--wk-text-primary)",
+          outline: "none",
+          boxSizing: "border-box",
+        }}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <div
+        style={{
+          textAlign: "right",
+          marginTop: "4px",
+          fontSize: "12px",
+          color: exceeded ? "var(--wk-color-danger)" : "var(--wk-text-tertiary)",
+        }}
+      >
+        {value.length} / {THREAD_NAME_MAX_LENGTH}
+      </div>
+    </div>
+  );
+});
+ThreadNameInput.displayName = "ThreadNameInput";
 
 // 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
 // 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
@@ -697,34 +750,20 @@ export default class ThreadPanel extends Component<
     // 延迟弹窗，等 Popover 完全关闭后再触发，避免 Modal 被 Popover 关闭事件误关
     setTimeout(() => {
       let newName = thread.name;
+      const inputRef = React.createRef<HTMLInputElement>();
       wkConfirm({
         title: t("base.threadPanel.editNameTitle"),
         okText: t("base.threadPanel.save"),
         cancelText: t("base.common.cancel"),
         content: (
-          <div>
-            <input
-              type="text"
-              defaultValue={thread.name}
-              style={{
-                width: "100%",
-                padding: "10px 12px",
-                background: "var(--wk-bg-base)",
-                border: "1px solid var(--wk-border-default)",
-                borderRadius: "6px",
-                fontSize: "14px",
-                color: "var(--wk-text-primary)",
-                outline: "none",
-                boxSizing: "border-box",
-              }}
-              onChange={(e) => {
-                newName = e.target.value;
-              }}
-              autoFocus
-            />
-          </div>
+          <ThreadNameInput
+            ref={inputRef}
+            defaultValue={thread.name}
+            autoFocus
+          />
         ),
         onOk: async () => {
+          newName = inputRef.current?.value ?? thread.name;
           if (!newName || newName.trim() === "") {
             Toast.error(t("base.threadPanel.nameRequired"));
             return;
@@ -1013,6 +1052,7 @@ export default class ThreadPanel extends Component<
     if (!groupNo) return;
 
     let threadName = "";
+    const inputRef = React.createRef<HTMLInputElement>();
     wkConfirm({
       title: t("base.module.createThread.title"),
       okText: t("base.module.createThread.ok"),
@@ -1028,28 +1068,15 @@ export default class ThreadPanel extends Component<
           >
             {t("base.module.createThread.nameLabel")}
           </div>
-          <input
-            type="text"
+          <ThreadNameInput
+            ref={inputRef}
             placeholder={t("base.module.createThread.namePlaceholder")}
-            style={{
-              width: "100%",
-              padding: "10px 12px",
-              background: "var(--wk-bg-base)",
-              border: "1px solid var(--wk-border-default)",
-              borderRadius: "6px",
-              fontSize: "14px",
-              color: "var(--wk-text-primary)",
-              outline: "none",
-              boxSizing: "border-box",
-            }}
-            onChange={(e) => {
-              threadName = e.target.value;
-            }}
             autoFocus
           />
         </div>
       ),
       onOk: async () => {
+        threadName = inputRef.current?.value ?? "";
         if (!threadName || threadName.trim() === "") {
           Toast.error(t("base.module.createThread.nameRequired"));
           return;

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -51,6 +51,7 @@ import { VideoRenderer } from "../FilePreviewPanel/renderers/VideoRenderer";
 import { isChannelSearchEnabled } from "../ChannelSearch/feature";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
+import { THREAD_NAME_MAX_LENGTH } from "../../Service/nameLimits";
 import {
   ArchiveAction,
   deriveArchiveAction,
@@ -66,7 +67,7 @@ import {
 } from "../WKLayout/layoutWidth";
 import "./index.css";
 
-const THREAD_NAME_MAX_LENGTH = 100;
+
 
 /**
  * 子区名称输入框 — 带字数计数器（当前/最大）

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -366,6 +366,8 @@
 .wk-chat-conversation-header-channel {
   display: flex;
   align-items: center;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .wk-chat-conversation-header-channel-avatar img {
@@ -390,6 +392,8 @@
 .wk-chat-conversation-header-channel-info {
   display: flex;
   align-items: center;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .wk-chat-conversation-header-channel-info-name {
@@ -409,20 +413,22 @@
   gap: 4px;
   flex-wrap: nowrap;
   overflow: hidden;
+  min-width: 0;
 }
 
 /* 父群组 badge：# icon + 群组名，可点击 */
 .wk-chat-conversation-header-parent-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
+  display: block;
   color: var(--wk-text-tertiary, #9498a8);
   font-size: 13px;
   font-weight: 400;
   cursor: pointer;
   transition: color 150ms;
   white-space: nowrap;
-  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .wk-chat-conversation-header-parent-group:hover {
@@ -446,15 +452,15 @@
 
 /* 子区名称（当前频道）：🧵 icon + 名称，加粗 */
 .wk-chat-conversation-header-thread-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
+  display: block;
   color: var(--wk-text-primary, #1a1c24);
   font-size: 13px;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .wk-chat-conversation-header-content {

--- a/packages/dmworkbase/src/Service/nameLimits.ts
+++ b/packages/dmworkbase/src/Service/nameLimits.ts
@@ -1,0 +1,9 @@
+/**
+ * 群名/子区名长度限制常量
+ *
+ * 客户端限制（前端各入口共享），后端需独立校验。
+ * - 群名：50 字符
+ * - 子区名：100 字符
+ */
+export const GROUP_NAME_MAX_LENGTH = 50;
+export const THREAD_NAME_MAX_LENGTH = 100;

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -704,7 +704,7 @@
   "module.userInfo.removeFromBlacklist": "Remove from blacklist",
   "module.userInfo.source": "Source",
   "threadCreate.creating": "Creating...",
-  "threadCreate.nameMaxLength": "Thread name cannot exceed 50 characters",
+  "threadCreate.nameMaxLength": "Thread name cannot exceed 100 characters",
   "threadCreate.namePlaceholder": "Enter thread name",
   "threadCreate.nameRequired": "Please enter a thread name",
   "threadCreate.success": "Created",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -704,7 +704,7 @@
   "module.userInfo.removeFromBlacklist": "拉出黑名单",
   "module.userInfo.source": "来源",
   "threadCreate.creating": "创建中...",
-  "threadCreate.nameMaxLength": "子区名称不能超过50个字符",
+  "threadCreate.nameMaxLength": "子区名称不能超过100个字符",
   "threadCreate.namePlaceholder": "输入子区名称",
   "threadCreate.nameRequired": "请输入子区名称",
   "threadCreate.success": "创建成功",

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -1656,7 +1656,7 @@ export default class BaseModule implements IModule {
                         });
                     },
                     t("base.module.channelSettings.groupNamePlaceholder"),
-                    20
+                    50
                   );
                 },
               },
@@ -2362,7 +2362,7 @@ export default class BaseModule implements IModule {
                     data.refresh();
                   },
                   t("base.module.thread.name"),
-                  50
+                  100
                 );
               },
             },

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -113,6 +113,7 @@ import {
 } from "./Utils/clipboard";
 import { shouldSkipMessageForSpace } from "./Service/SpaceService";
 import { t, I18nText } from "./i18n";
+import { GROUP_NAME_MAX_LENGTH, THREAD_NAME_MAX_LENGTH } from "./Service/nameLimits";
 import {
   ThreadCreatedCell,
   ThreadCreatedContent,
@@ -1656,7 +1657,7 @@ export default class BaseModule implements IModule {
                         });
                     },
                     t("base.module.channelSettings.groupNamePlaceholder"),
-                    50
+                    GROUP_NAME_MAX_LENGTH
                   );
                 },
               },
@@ -2362,7 +2363,7 @@ export default class BaseModule implements IModule {
                     data.refresh();
                   },
                   t("base.module.thread.name"),
-                  100
+                  THREAD_NAME_MAX_LENGTH
                 );
               },
             },

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -1040,6 +1040,7 @@ export default class BaseModule implements IModule {
                     type="text"
                     placeholder={t("base.module.createThread.namePlaceholder")}
                     defaultValue={defaultName}
+                    maxLength={THREAD_NAME_MAX_LENGTH}
                     style={{
                       width: "100%",
                       padding: "10px 12px",
@@ -1061,6 +1062,10 @@ export default class BaseModule implements IModule {
               onOk: async () => {
                 if (!threadName || threadName.trim() === "") {
                   Toast.error(t("base.module.createThread.nameRequired"));
+                  return;
+                }
+                if (threadName.length > THREAD_NAME_MAX_LENGTH) {
+                  Toast.warning(t("base.threadCreate.nameMaxLength"));
                   return;
                 }
                 try {

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
@@ -417,3 +417,7 @@
   font-size: 12px;
   color: var(--wk-text-tertiary, #9498a8);
 }
+
+.group-create-input-count--exceeded {
+  color: var(--wk-color-danger, #e5353b);
+}

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
@@ -410,3 +410,10 @@
   overflow-y: auto;
   padding: 0 12px;
 }
+
+.group-create-input-count {
+  text-align: right;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--wk-text-tertiary, #9498a8);
+}

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -767,10 +767,13 @@ export class OrganizationalGroupNew extends Component<
             </div>
             <Input
               value={groupName}
-              maxLength={20}
+              maxLength={50}
               placeholder={t("contacts.groupCreate.namePlaceholder")}
               onChange={(value) => this.setState({ groupName: value })}
             />
+            <div className="group-create-input-count">
+              {groupName.length} / 50
+            </div>
           </div>
 
           <div className="group-create-field">

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -17,6 +17,7 @@ import WKAvatar from "@octo/base/src/Components/WKAvatar";
 import AiBadge from "@octo/base/src/Components/AiBadge";
 import "./index.css";
 import { SuperGroup } from "@octo/base/src/Utils/const";
+import { GROUP_NAME_MAX_LENGTH } from "@octo/base/src/Service/nameLimits";
 import { buildPrivateChatGroupMemberUids } from "./memberUids";
 
 export enum OrganizationalGroupNewAction {
@@ -767,12 +768,12 @@ export class OrganizationalGroupNew extends Component<
             </div>
             <Input
               value={groupName}
-              maxLength={50}
+              maxLength={GROUP_NAME_MAX_LENGTH}
               placeholder={t("contacts.groupCreate.namePlaceholder")}
               onChange={(value) => this.setState({ groupName: value })}
             />
-            <div className="group-create-input-count">
-              {groupName.length} / 50
+            <div className={`group-create-input-count ${groupName.length > GROUP_NAME_MAX_LENGTH ? "group-create-input-count--exceeded" : ""}`}>
+              {groupName.length} / {GROUP_NAME_MAX_LENGTH}
             </div>
           </div>
 


### PR DESCRIPTION
## 需求

- 群名最大长度：50
- 子区名最大长度：100

## 改动

### 群名长度限制（50）

| 入口 | 文件 | 改动 |
|------|------|------|
| 创建群 | `GroupNew/index.tsx` | maxLength 20 → 50，加字数计数器 |
| 编辑群名 | `module.tsx` | inputEditPush maxCount 20 → 50 |

### 子区名长度限制（100）

| 入口 | 文件 | 改动 |
|------|------|------|
| 创建子区 | `ThreadCreate/index.tsx` | maxLength 50 → 100，校验 50 → 100 |
| 创建子区(ThreadPanel) | `ThreadPanel/index.tsx` | 原生 input 替换为 ThreadNameInput 组件，带计数器 |
| 编辑子区名(ThreadPanel) | `ThreadPanel/index.tsx` | 同上 |
| 编辑子区名(module.tsx) | `module.tsx` | inputEditPush maxCount 50 → 100 |

### ThreadNameInput 组件

新增受控输入组件，带 `当前字数 / 100` 计数器，超限时变红。用于 ThreadPanel 内创建/编辑子区名的 wkConfirm 弹窗。

### CSS 防御

- `ThreadPanel/index.css`: header-title 加 `min-width: 0` + `overflow: hidden` + `text-overflow: ellipsis`
- `Chat/index.css`: 面包屑 flex 链贯通（channel、channel-info、channel-info-name 加 `min-width: 0`；parent-group、thread-name 加 `flex-shrink: 1` + `text-overflow: ellipsis`）

### i18n

- 子区名称长度提示 50 → 100（中/英）

## 验证

- 群名创建/编辑：maxLength=50，显示字数计数器
- 子区名创建/编辑：maxLength=100，显示字数计数器
- 长名称在 header 中显示省略号，不挤压按钮
