### PR TITLE
fix(web): preserve main layout around onboarding

### DIFF
--- a/apps/web/src/Pages/Main/index.css
+++ b/apps/web/src/Pages/Main/index.css
@@ -14,6 +14,12 @@
     background-color: var(--bg-primary);
 }
 
+.wk-main-onboarding-background {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
 /* ========== MeInfo Modal（原 tab_normal_screen.css 迁移过来） ========== */
 .wk-main-sider-modal .wk-modal-shell {
     padding: 0;

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -230,6 +230,7 @@ export class MainPage extends Component<{}, MainPageState> {
                 return (
                     <>
                         <div
+                            className="wk-main-onboarding-background"
                             aria-hidden={showOnboardingGate ? true : undefined}
                             {...(showOnboardingGate ? { inert: "" } : {})}
                         >


### PR DESCRIPTION
## Summary
- Fix the onboarding background wrapper introduced for inert/aria-hidden so it preserves the full-height WKLayout chain.
- Prevent the signed-in shell from collapsing to a blank main area after the onboarding dialog closes.

## Verification
- pnpm lint:css:ci
- pnpm --filter @octo/web build
- git diff --check upstream/main...HEAD

## Context
Follow-up hotfix for #573 after deployment showed the main content area could render blank once onboarding closed.