### PR TITLE
feat(loop): octo member management UI + octo identity resolution

### DIFF
--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -1,7 +1,10 @@
 // @octo/loop — Directory：解析展示用名字 + 提供 assignee 候选。
 // fleet 列表接口不返回 assignee_name/project_name 等，这里统一加载并缓存后回填。
+// member 身份按 octo_uid 解析成 octo IM 名字（octo web 面统一以 octo 身份展示，
+// 而非 multica 原生名）；无 octo_uid 的原生成员回退其 multica 名。
 import type { AssigneeCandidate, AssigneeType } from "./types";
 import { httpGet, currentWorkspaceId, currentWorkspaceSlug } from "./http";
+import { WKApp, SpaceService } from "@octo/base";
 
 interface Directory {
   slug: string;
@@ -19,16 +22,26 @@ async function build(): Promise<Directory> {
   const slug = currentWorkspaceSlug();
   const wsId = currentWorkspaceId();
   const [members, agents, squads, projectsResp] = await Promise.all([
-    wsId ? httpGet<Array<{ user_id: string; name: string }>>(`/workspaces/${wsId}/members`).catch(() => []) : Promise.resolve([]),
+    wsId ? httpGet<Array<{ user_id: string; name: string; octo_uid?: string | null }>>(`/workspaces/${wsId}/members`).catch(() => []) : Promise.resolve([]),
     httpGet<Array<{ id: string; name: string }>>("/agents").catch(() => []),
     httpGet<Array<{ id: string; name: string }>>("/squads").catch(() => []),
     httpGet<{ projects: Array<{ id: string; title: string }> }>("/projects").catch(() => ({ projects: [] })),
   ]);
+  // Resolve member identity to octo names — but only pull the (potentially large)
+  // space roster when at least one member is octo-bridged; a pure-multica
+  // workspace skips the roster fetch entirely.
+  const octoName = new Map<string, string>();
+  if (members.some((m) => m.octo_uid)) {
+    const roster = await SpaceService.shared.getAllMembers(WKApp.shared.currentSpaceId).catch(() => []);
+    for (const s of roster) octoName.set(s.uid, s.name);
+  }
   const memberName = new Map<string, string>();
   const candidates: AssigneeCandidate[] = [];
   for (const m of members) {
-    memberName.set(m.user_id, m.name);
-    candidates.push({ id: m.user_id, type: "member", name: m.name });
+    // octo 身份优先：octo_uid 命中 space 名册取 octo 名字，否则回退 multica 名。
+    const name = (m.octo_uid && octoName.get(m.octo_uid)) || m.name;
+    memberName.set(m.user_id, name);
+    candidates.push({ id: m.user_id, type: "member", name });
   }
   const agentName = new Map<string, string>();
   for (const a of agents) {

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -31,6 +31,9 @@ export interface WorkspaceMember {
   name: string;
   email?: string;
   avatar_url?: string | null;
+  // octo IM uid this multica user is bridged to, or null for native members.
+  // The UI renders member identity (name/avatar) from octo by this uid.
+  octo_uid?: string | null;
 }
 
 export interface Invitation {

--- a/packages/dmloop/src/api/workspaceApi.ts
+++ b/packages/dmloop/src/api/workspaceApi.ts
@@ -34,6 +34,17 @@ export function inviteMember(
   return httpPost<Invitation>(`/workspaces/${workspaceId}/members`, req);
 }
 
+/**
+ * 按 octo IM uid 直接加成员（octo web 面，无邮箱邀请/接受环节）。
+ * 后端校验目标 uid 属于当前 space 且非 AI，随即物化为 member。
+ */
+export function addOctoMember(
+  workspaceId: string,
+  req: { octo_uid: string; role?: string },
+): Promise<WorkspaceMember> {
+  return httpPost<WorkspaceMember>(`/workspaces/${workspaceId}/octo-members`, req);
+}
+
 /** 修改成员角色。 */
 export function updateMemberRole(
   workspaceId: string,

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -268,6 +268,10 @@
     "invited": "Invitation sent",
     "inviteEmail": "Invite a member by email",
     "invite": "Invite",
+    "addMember": "Add member",
+    "selectMember": "Search and select a space member",
+    "noCandidates": "No members available to add in this space",
+    "added": "Member added",
     "pendingInvites": "Pending invitations",
     "revoke": "Revoke"
   }

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -268,6 +268,10 @@
     "invited": "邀请已发送",
     "inviteEmail": "输入邮箱邀请成员",
     "invite": "邀请",
+    "addMember": "添加成员",
+    "selectMember": "搜索并选择 space 成员",
+    "noCandidates": "该 space 暂无可添加的成员",
+    "added": "成员已添加",
     "pendingInvites": "待处理邀请",
     "revoke": "撤销"
   }

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Typography, Input, Button, Tabs, TabPane, Table, Tag, Select, Spin, Toast, Banner, Modal, Avatar,
 } from "@douyinfe/semi-ui";
 import { Save, UserPlus, Trash2, User } from "lucide-react";
-import { useI18n } from "@octo/base";
+import { useI18n, WKApp, SpaceService } from "@octo/base";
+import type { SpaceMember } from "@octo/base";
 import type { Workspace, WorkspaceMember, Invitation } from "../api/types";
 import {
-  updateWorkspace, listWorkspaceMembers, inviteMember, updateMemberRole, removeMember,
+  updateWorkspace, listWorkspaceMembers, addOctoMember, updateMemberRole, removeMember,
   listWorkspaceInvitations, revokeInvitation,
 } from "../api/workspaceApi";
 
@@ -107,32 +108,57 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   const [invites, setInvites] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [email, setEmail] = useState("");
+  // octo space 成员（仅人，robot===0）+ uid→身份 映射，供选择器候选与列表渲染复用。
+  const [spaceHumans, setSpaceHumans] = useState<SpaceMember[]>([]);
+  const [selectedUid, setSelectedUid] = useState<string>("");
   const [role, setRole] = useState("member");
-  const [inviting, setInviting] = useState(false);
+  const [adding, setAdding] = useState(false);
+
+  const rosterByUid = useMemo(() => {
+    const m: Record<string, SpaceMember> = {};
+    for (const s of spaceHumans) m[s.uid] = s;
+    return m;
+  }, [spaceHumans]);
+
+  // 当前 space 全量成员，只保留人（候选来源）。
+  const loadSpaceMembers = useCallback(async (): Promise<SpaceMember[]> => {
+    const members = await SpaceService.shared.getAllMembers(WKApp.shared.currentSpaceId);
+    return members.filter((s) => s.robot === 0);
+  }, []);
 
   const reload = useCallback(() => {
     setLoading(true); setError(null);
     Promise.all([
       listWorkspaceMembers(workspaceId),
       listWorkspaceInvitations(workspaceId).catch(() => [] as Invitation[]),
+      loadSpaceMembers().catch(() => [] as SpaceMember[]),
     ])
-      .then(([m, inv]) => { setMembers(m); setInvites(inv); })
+      .then(([m, inv, humans]) => { setMembers(m); setInvites(inv); setSpaceHumans(humans); })
       .catch((e) => setError(e?.message ?? "load failed"))
       .finally(() => setLoading(false));
-  }, [workspaceId]);
+  }, [workspaceId, loadSpaceMembers]);
   useEffect(reload, [reload]);
 
-  const invite = async () => {
-    if (!email.trim()) { Toast.warning(t("loop.settings.emailRequired")); return; }
-    setInviting(true);
+  // 候选 = space 里的人，排除已是本工作区成员的（按 octo_uid）。
+  const existingOctoUids = useMemo(
+    () => new Set(members.map((m) => m.octo_uid).filter(Boolean) as string[]),
+    [members],
+  );
+  const candidates = useMemo(
+    () => spaceHumans.filter((s) => !existingOctoUids.has(s.uid)),
+    [spaceHumans, existingOctoUids],
+  );
+
+  const add = async () => {
+    if (!selectedUid) return;
+    setAdding(true);
     try {
-      await inviteMember(workspaceId, { email: email.trim(), role });
-      setEmail("");
-      Toast.success(t("loop.settings.invited"));
+      await addOctoMember(workspaceId, { octo_uid: selectedUid, role });
+      setSelectedUid("");
+      Toast.success(t("loop.settings.added"));
       reload();
-    } catch (e) { Toast.error((e as Error)?.message ?? "invite failed"); }
-    finally { setInviting(false); }
+    } catch (e) { Toast.error((e as Error)?.message ?? "add failed"); }
+    finally { setAdding(false); }
   };
 
   const changeRole = async (m: WorkspaceMember, r: string) => {
@@ -142,7 +168,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   const remove = (m: WorkspaceMember) => {
     Modal.confirm({
       title: t("loop.settings.removeMember"),
-      content: m.name || m.email,
+      content: displayName(m),
       okText: t("loop.action.delete"),
       cancelText: t("loop.action.cancel"),
       onOk: async () => {
@@ -164,15 +190,25 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
     });
   };
 
+  // octo 身份优先：按 octo_uid 命中 space 名册取名字，否则回退 multica 侧 name/email。
+  const displayName = (m: WorkspaceMember): string =>
+    (m.octo_uid && rosterByUid[m.octo_uid]?.name) || m.name || m.email || m.octo_uid || m.user_id;
+  const avatarSrc = (m: WorkspaceMember): string | undefined =>
+    m.octo_uid ? WKApp.shared.avatarUser(m.octo_uid) : undefined;
+
   if (loading) return <div style={{ textAlign: "center", padding: 40 }}><Spin /></div>;
   if (error) return <Banner type="danger" description={error} />;
 
   const memberCols = [
-    { title: t("loop.field.name"), dataIndex: "name", render: (v: string, r: WorkspaceMember) => (
-      <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-        <Avatar size="extra-small" color="light-blue"><User size={13} /></Avatar>
-        <span><div>{v}</div><Text type="tertiary" style={{ fontSize: 12 }}>{r.email}</Text></span>
-      </span>) },
+    { title: t("loop.field.name"), dataIndex: "name", render: (_v: string, r: WorkspaceMember) => {
+      const src = avatarSrc(r);
+      return (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+          <Avatar size="extra-small" color="light-blue" src={src}>{src ? undefined : <User size={13} />}</Avatar>
+          <span>{displayName(r)}</span>
+        </span>
+      );
+    } },
     { title: t("loop.settings.role"), dataIndex: "role", width: 160, render: (v: string, r: WorkspaceMember) => (
       v === "owner"
         ? <Tag color="amber" size="small">owner</Tag>
@@ -188,11 +224,28 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   return (
     <div style={{ paddingTop: 12, display: "flex", flexDirection: "column", gap: 16, maxWidth: 720 }}>
       <div className="loop-settings-invite">
-        <Input value={email} onChange={setEmail} placeholder={t("loop.settings.inviteEmail")} style={{ flex: 1 }} />
+        <Select
+          filter
+          value={selectedUid || undefined}
+          onChange={(v) => setSelectedUid(v as string)}
+          placeholder={candidates.length ? t("loop.settings.selectMember") : t("loop.settings.noCandidates")}
+          disabled={!candidates.length}
+          style={{ flex: 1 }}
+          emptyContent={t("loop.settings.noCandidates")}
+        >
+          {candidates.map((c) => (
+            <Select.Option key={c.uid} value={c.uid} showTick={false}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <Avatar size="extra-small" color="light-blue" src={WKApp.shared.avatarUser(c.uid)}>{c.name?.slice(0, 1)}</Avatar>
+                <span>{c.name}</span>
+              </span>
+            </Select.Option>
+          ))}
+        </Select>
         <Select value={role} onChange={(v) => setRole(v as string)} style={{ width: 120 }}>
           {ROLES.map((x) => <Select.Option key={x} value={x}>{x}</Select.Option>)}
         </Select>
-        <Button theme="solid" icon={<UserPlus size={14} />} loading={inviting} onClick={invite}>{t("loop.settings.invite")}</Button>
+        <Button theme="solid" icon={<UserPlus size={14} />} loading={adding} disabled={!selectedUid} onClick={add}>{t("loop.settings.addMember")}</Button>
       </div>
 
       <div>

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -276,6 +276,20 @@ export class SpaceService {
         return resp || []
     }
 
+    // 拉取一个 space 的全部成员（分页循环到取空/达上限）。收敛此前散落在
+    // dmloop directory / SettingsPage / dmworktodo useMemberList 各自复制的分页逻辑，
+    // 避免翻页上限相互漂移。
+    async getAllMembers(spaceId: string, pageLimit: number = 100, maxPages: number = 50): Promise<SpaceMember[]> {
+        if (!spaceId) return []
+        const acc: SpaceMember[] = []
+        for (let page = 1; page <= maxPages; page++) {
+            const batch = await this.getMembers(spaceId, page, pageLimit)
+            acc.push(...batch)
+            if (!batch || batch.length < pageLimit) break
+        }
+        return acc
+    }
+
     async createInvite(spaceId: string): Promise<InviteResp> {
         return WKApp.apiClient.post(`space/${spaceId}/invite`, {})
     }


### PR DESCRIPTION
Member management on the octo web plane now uses octo IM members, not multica-native accounts. Pairs with octo-multica MR !13 (backend `POST /octo-members` + `octo_uid` in member responses).

## What
- Settings → Members: replace the email-invite input with a searchable octo member picker (space roster via `SpaceService`, humans only — AI/bots filtered), wired to `POST /workspaces/{id}/octo-members`. Member list + picker render octo identity (name via roster, avatar via `WKApp.shared.avatarUser`) keyed on `octo_uid`; native members fall back to their multica name.
- `directory.ts`: resolve member display names to octo identity by `octo_uid`, so every member surface (assignee/creator/author/owner/leader) shows the octo name. Skips the roster fetch when no member is octo-bridged.
- `SpaceService.getAllMembers`: shared full-roster pagination (removes copies in directory.ts + SettingsPage).
- `workspaceApi.addOctoMember` + `WorkspaceMember.octo_uid` + i18n (zh/en).

## Verification
`tsc` clean on changed files. **Real-environment browser regression pending** (login as octo user → create workspace → @add octo member → list shows octo identity) — final gate before merge.

## Deferred (follow-up issue)
octo avatars in issue/agent/squad member surfaces (names fixed here; those still render letter-initial avatars); daemon prompt `@octo.local` leak; `InvitationResponse` octo_uid.