### PR TITLE
feat(voice): 为 12 个长 prompt / 自由文本输入框接入语音输入法 (#571)

### DIFF
--- a/apps/web/src/Components/SpaceCreate/index.css
+++ b/apps/web/src/Components/SpaceCreate/index.css
@@ -22,12 +22,12 @@ body[theme-mode=dark] .wk-spacecreate-label {
     display: block;
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
     border: 1px solid var(--wk-border-default);
     border-radius: var(--wk-r-sm);
     background: var(--wk-bg-surface);
     color: var(--wk-text-primary);
-    font-size: 14px;
+    font-size: var(--wk-text-size-md);
     line-height: 1.5;
     resize: vertical;
     outline: none;

--- a/apps/web/src/Components/SpaceCreate/index.css
+++ b/apps/web/src/Components/SpaceCreate/index.css
@@ -18,6 +18,29 @@ body[theme-mode=dark] .wk-spacecreate-label {
     color: #ccc;
 }
 
+.wk-spacecreate-textarea {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--wk-border-default);
+    border-radius: var(--wk-r-sm);
+    background: var(--wk-bg-surface);
+    color: var(--wk-text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+}
+
+.wk-spacecreate-textarea:focus {
+    border-color: var(--wk-color-accent);
+}
+
+.wk-spacecreate-textarea::placeholder {
+    color: var(--wk-text-secondary);
+}
+
 .wk-spacecreate-actions {
     display: flex;
     justify-content: flex-end;

--- a/apps/web/src/Components/SpaceCreate/index.tsx
+++ b/apps/web/src/Components/SpaceCreate/index.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
-import { Input, TextArea, Toast } from "@douyinfe/semi-ui";
+import { Input, Toast } from "@douyinfe/semi-ui";
 import { I18nContext, SpaceService, WKModal, extractErrorMsg, t } from "@octo/base";
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import "./index.css";
 
 export interface SpaceCreateProps {
@@ -19,6 +20,29 @@ interface SpaceCreateState {
 export default class SpaceCreate extends Component<SpaceCreateProps, SpaceCreateState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
+
+    private descriptionRef = React.createRef<HTMLTextAreaElement>();
+
+    private handleVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            this.setState({ description: text.slice(0, 200) });
+        } else if (mode === "selection" && savedRange) {
+            this.setState((prev) => {
+                const updated = prev.description.slice(0, savedRange.from) + text + prev.description.slice(savedRange.to);
+                return { description: updated.slice(0, 200) };
+            });
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.description.length;
+                const updated = prev.description.slice(0, pos) + text + prev.description.slice(pos);
+                return { description: updated.slice(0, 200) };
+            });
+        }
+    };
 
     constructor(props: SpaceCreateProps) {
         super(props);
@@ -94,13 +118,25 @@ export default class SpaceCreate extends Component<SpaceCreateProps, SpaceCreate
                         </div>
                         <div className="wk-spacecreate-field">
                             <label className="wk-spacecreate-label">{t("app.spaceCreate.descriptionLabel")}</label>
-                            <TextArea
-                                placeholder={t("app.spaceCreate.descriptionPlaceholder")}
-                                value={description}
-                                onChange={(v) => this.setState({ description: v })}
-                                maxCount={200}
-                                autosize={{ minRows: 3, maxRows: 5 }}
-                            />
+                            <div style={{ position: "relative" }}>
+                                <textarea
+                                    ref={this.descriptionRef}
+                                    className="wk-spacecreate-textarea"
+                                    placeholder={t("app.spaceCreate.descriptionPlaceholder")}
+                                    value={description}
+                                    onChange={(e) => this.setState({ description: e.target.value.slice(0, 200) })}
+                                    maxLength={200}
+                                    rows={3}
+                                />
+                                <VoiceInputButton
+                                    inputRef={this.descriptionRef}
+                                    onTranscribed={this.handleVoiceTranscribed}
+                                    getCurrentText={() => this.state.description}
+                                    showModeMenu
+                                    size="sm"
+                                    className="wk-vib--textarea-corner"
+                                />
+                            </div>
                         </div>
                         <div className="wk-spacecreate-actions">
                             <button className="wk-spacecreate-btn wk-spacecreate-btn-cancel" onClick={this.handleClose}>

--- a/apps/web/src/Components/SpaceCreate/index.tsx
+++ b/apps/web/src/Components/SpaceCreate/index.tsx
@@ -32,14 +32,18 @@ export default class SpaceCreate extends Component<SpaceCreateProps, SpaceCreate
             this.setState({ description: text.slice(0, 200) });
         } else if (mode === "selection" && savedRange) {
             this.setState((prev) => {
-                const updated = prev.description.slice(0, savedRange.from) + text + prev.description.slice(savedRange.to);
-                return { description: updated.slice(0, 200) };
+                const before = prev.description.slice(0, savedRange.from);
+                const after = prev.description.slice(savedRange.to);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { description: before + text.slice(0, budget) + after };
             });
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.description.length;
-                const updated = prev.description.slice(0, pos) + text + prev.description.slice(pos);
-                return { description: updated.slice(0, 200) };
+                const before = prev.description.slice(0, pos);
+                const after = prev.description.slice(pos);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { description: before + text.slice(0, budget) + after };
             });
         }
     };

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.css
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.css
@@ -41,12 +41,12 @@
     display: block;
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
     border: 1px solid var(--wk-border-default);
     border-radius: var(--wk-r-sm);
     background: var(--wk-bg-surface);
     color: var(--wk-text-primary);
-    font-size: 14px;
+    font-size: var(--wk-text-size-md);
     line-height: 1.5;
     resize: vertical;
     outline: none;

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.css
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.css
@@ -37,6 +37,26 @@
 .wk-bot-detail-empty {
     color: #999;
 }
+.wk-bot-detail-textarea {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--wk-border-default);
+    border-radius: var(--wk-r-sm);
+    background: var(--wk-bg-surface);
+    color: var(--wk-text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+}
+.wk-bot-detail-textarea:focus {
+    border-color: var(--wk-color-accent);
+}
+.wk-bot-detail-textarea::placeholder {
+    color: var(--wk-text-secondary);
+}
 .wk-bot-detail-label {
     font-size: 12px;
     color: #999;

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -73,14 +73,18 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
             this.setState({ descriptionDraft: text.slice(0, 200) });
         } else if (mode === "selection" && savedRange) {
             this.setState((prev) => {
-                const updated = prev.descriptionDraft.slice(0, savedRange.from) + text + prev.descriptionDraft.slice(savedRange.to);
-                return { descriptionDraft: updated.slice(0, 200) };
+                const before = prev.descriptionDraft.slice(0, savedRange.from);
+                const after = prev.descriptionDraft.slice(savedRange.to);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { descriptionDraft: before + text.slice(0, budget) + after };
             });
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.descriptionDraft.length;
-                const updated = prev.descriptionDraft.slice(0, pos) + text + prev.descriptionDraft.slice(pos);
-                return { descriptionDraft: updated.slice(0, 200) };
+                const before = prev.descriptionDraft.slice(0, pos);
+                const after = prev.descriptionDraft.slice(pos);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { descriptionDraft: before + text.slice(0, budget) + after };
             });
         }
     };

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Button, Spin, Toast, Input, TextArea } from "@douyinfe/semi-ui";
+import { Button, Spin, Toast, Input } from "@douyinfe/semi-ui";
 import { IconEdit } from "@douyinfe/semi-icons";
 import axios from "axios";
 import WKModal from "../WKModal";
@@ -15,6 +15,7 @@ import BotManageModal from "../BotManage";
 import AgentCardService from "../../Service/AgentCardService";
 import { I18nContext, t } from "../../i18n";
 import { canvasToPngFile, isAvatarFileTooLarge, isGifImageFile } from "../avatarUpload";
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
 import "./index.css";
 
 interface BotDetailModalProps {
@@ -61,6 +62,28 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
     private $fileInput: HTMLInputElement | null = null;
     private avatarEdit: WKAvatarEditor | null = null;
     private mounted = false;
+    private descriptionRef = React.createRef<HTMLTextAreaElement>();
+
+    private handleDescriptionVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            this.setState({ descriptionDraft: text.slice(0, 200) });
+        } else if (mode === "selection" && savedRange) {
+            this.setState((prev) => {
+                const updated = prev.descriptionDraft.slice(0, savedRange.from) + text + prev.descriptionDraft.slice(savedRange.to);
+                return { descriptionDraft: updated.slice(0, 200) };
+            });
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.descriptionDraft.length;
+                const updated = prev.descriptionDraft.slice(0, pos) + text + prev.descriptionDraft.slice(pos);
+                return { descriptionDraft: updated.slice(0, 200) };
+            });
+        }
+    };
 
     state: BotDetailModalState = {
         loading: true,
@@ -686,14 +709,25 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                             </div>
                             {isOwner && editingDescription ? (
                                 <div>
-                                    <TextArea
-                                        value={descriptionDraft}
-                                        onChange={(v) => this.setState({ descriptionDraft: v })}
-                                        placeholder={t("base.botDetail.descriptionPlaceholder")}
-                                        maxCount={200}
-                                        autosize={{ minRows: 3, maxRows: 6 }}
-                                        style={{ marginBottom: 8 }}
-                                    />
+                                    <div style={{ position: "relative", marginBottom: 8 }}>
+                                        <textarea
+                                            ref={this.descriptionRef}
+                                            className="wk-bot-detail-textarea"
+                                            value={descriptionDraft}
+                                            onChange={(e) => this.setState({ descriptionDraft: e.target.value.slice(0, 200) })}
+                                            placeholder={t("base.botDetail.descriptionPlaceholder")}
+                                            maxLength={200}
+                                            rows={3}
+                                        />
+                                        <VoiceInputButton
+                                            inputRef={this.descriptionRef}
+                                            onTranscribed={this.handleDescriptionVoiceTranscribed}
+                                            getCurrentText={() => this.state.descriptionDraft}
+                                            showModeMenu
+                                            size="sm"
+                                            className="wk-vib--textarea-corner"
+                                        />
+                                    </div>
                                     <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
                                         <Button
                                             size="small"

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.css
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.css
@@ -52,6 +52,30 @@
   overflow: auto;
 }
 
+.wk-groupmd-textarea {
+  display: block;
+  width: 100%;
+  min-height: 320px;
+  padding: var(--wk-sp-3);
+  box-sizing: border-box;
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-md);
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+
+.wk-groupmd-textarea:focus {
+  border-color: var(--wk-color-accent);
+}
+
+.wk-groupmd-textarea::placeholder {
+  color: var(--wk-text-secondary);
+}
+
 .wk-groupmd-preview {
   flex: 1;
   overflow: auto;

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Button, TextArea, Spin } from "@douyinfe/semi-ui";
+import { Button, Spin } from "@douyinfe/semi-ui";
 import { Toast } from "@douyinfe/semi-ui";
 import { Channel } from "wukongimjssdk";
 import WKApp from "../../App";
@@ -8,6 +8,7 @@ import { parseThreadChannelId } from "../../Service/Thread";
 import { I18nContext } from "../../i18n";
 import { wkConfirm } from "../WKModal";
 import MarkdownContent from "../../Messages/Text/MarkdownContent";
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
 import "./index.css";
 
 export interface GroupMdEditorProps {
@@ -47,6 +48,30 @@ export class GroupMdEditor extends Component<
 > {
   static contextType = I18nContext;
   declare context: React.ContextType<typeof I18nContext>;
+
+  private textareaRef = React.createRef<HTMLTextAreaElement>();
+
+  private handleVoiceTranscribed = (
+    text: string,
+    mode: ReplaceMode,
+    savedRange?: SelectionRange
+  ) => {
+    if (mode === "all") {
+      this.setState({ content: text });
+    } else if (mode === "selection" && savedRange) {
+      this.setState((prev) => ({
+        content:
+          prev.content.slice(0, savedRange.from) +
+          text +
+          prev.content.slice(savedRange.to),
+      }));
+    } else {
+      this.setState((prev) => {
+        const pos = savedRange?.from ?? prev.content.length;
+        return { content: prev.content.slice(0, pos) + text + prev.content.slice(pos) };
+      });
+    }
+  };
 
   constructor(props: GroupMdEditorProps) {
     super(props);
@@ -249,13 +274,25 @@ export class GroupMdEditor extends Component<
 
         {mode === "edit" && canEdit ? (
           <div className="wk-groupmd-edit-area">
-            <TextArea
-              value={content}
-              onChange={(value) => this.setState({ content: value })}
-              placeholder={t("base.groupMd.placeholder")}
-              autosize={{ minRows: 15 }}
-              style={{ fontFamily: "monospace" }}
-            />
+            <div style={{ position: "relative" }}>
+              <textarea
+                ref={this.textareaRef}
+                className="wk-groupmd-textarea"
+                value={content}
+                onChange={(e) => this.setState({ content: e.target.value })}
+                placeholder={t("base.groupMd.placeholder")}
+                rows={15}
+                style={{ fontFamily: "monospace" }}
+              />
+              <VoiceInputButton
+                inputRef={this.textareaRef}
+                onTranscribed={this.handleVoiceTranscribed}
+                getCurrentText={() => this.state.content}
+                showModeMenu
+                size="md"
+                className="wk-vib--textarea-corner"
+              />
+            </div>
           </div>
         ) : (
           <div className="wk-groupmd-preview">

--- a/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/PersonaEdit.tsx
@@ -4,6 +4,7 @@ import Provider, { IProviderListener } from "../../Service/Provider"
 import { Switch, Toast } from "@douyinfe/semi-ui"
 import { OboGrant, OboScope, PersonaEditVM } from "./vm"
 import { I18nContext } from "../../i18n"
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton"
 
 /**
  * PersonaEdit — 单个 grant 的编辑页（mode + global toggle + scope 列表 + 删除）。
@@ -76,6 +77,26 @@ export default class PersonaEdit extends Component<PersonaEditProps, PersonaEdit
         saving: false,
     }
     private confirmTimer?: ReturnType<typeof setTimeout>
+    private promptRef = React.createRef<HTMLTextAreaElement>()
+
+    private handleVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            this.setState({ prompt: text })
+        } else if (mode === "selection" && savedRange) {
+            this.setState((prev) => ({
+                prompt: prev.prompt.slice(0, savedRange.from) + text + prev.prompt.slice(savedRange.to),
+            }))
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.prompt.length
+                return { prompt: prev.prompt.slice(0, pos) + text + prev.prompt.slice(pos) }
+            })
+        }
+    }
 
     componentWillUnmount() {
         if (this.confirmTimer) clearTimeout(this.confirmTimer)
@@ -180,16 +201,27 @@ export default class PersonaEdit extends Component<PersonaEditProps, PersonaEdit
                                     <div className="wk-persona-edit-row-title">
                                         {t("base.persona.edit.promptLabel")}
                                     </div>
-                                    <textarea
-                                        className="wk-persona-edit-prompt"
-                                        placeholder={t("base.persona.edit.promptPlaceholder")}
-                                        value={this.state.prompt}
-                                        onChange={(e) =>
-                                            this.setState({ prompt: e.target.value })
-                                        }
-                                        rows={4}
-                                        data-testid="persona-edit-prompt"
-                                    />
+                                    <div style={{ position: "relative" }}>
+                                        <textarea
+                                            ref={this.promptRef}
+                                            className="wk-persona-edit-prompt"
+                                            placeholder={t("base.persona.edit.promptPlaceholder")}
+                                            value={this.state.prompt}
+                                            onChange={(e) =>
+                                                this.setState({ prompt: e.target.value })
+                                            }
+                                            rows={4}
+                                            data-testid="persona-edit-prompt"
+                                        />
+                                        <VoiceInputButton
+                                            inputRef={this.promptRef}
+                                            onTranscribed={this.handleVoiceTranscribed}
+                                            getCurrentText={() => this.state.prompt}
+                                            showModeMenu
+                                            size="sm"
+                                            className="wk-vib--textarea-corner"
+                                        />
+                                    </div>
                                 </div>
                                 <div className="wk-persona-edit-row">
                                     <div className="wk-persona-edit-row-title">

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
@@ -62,6 +62,14 @@ vi.mock("@douyinfe/semi-ui", () => ({
     },
 }))
 
+// VoiceInputButton 是 hooks-based 函数组件，会在本套 React 17 + RTL/react-dom 18
+// 混搭 env 里触发 invalid hook call（详见 PersonaCreate 顶部注释）。它与 persona
+// 表单逻辑无关，用一个 no-op stub 替换，保持测试聚焦在 prompt/active 行为上。
+vi.mock("../../VoiceInputButton", () => ({
+    default: () => null,
+    __esModule: true,
+}))
+
 // 在所有 mock 之后再 import 被测组件 + VM。
 import PersonaEdit from "../PersonaEdit"
 import { OboGrant, OboScope } from "../vm"

--- a/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/index.tsx
@@ -6,6 +6,7 @@ import RoutePage from "../RoutePage"
 import { MyBot, OboGrant, PersonaSettingsVM } from "./vm"
 import PersonaEdit from "./PersonaEdit"
 import { I18nContext, useI18n } from "../../i18n"
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton"
 import "./index.css"
 
 /**
@@ -367,6 +368,23 @@ function PersonaCreate(props: {
     const [selectedUid, setSelectedUid] = React.useState<string>("")
     const [prompt, setPrompt] = React.useState<string>("")
     const [submitting, setSubmitting] = React.useState<boolean>(false)
+    const promptRef = React.useRef<HTMLTextAreaElement>(null)
+    const handleVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            setPrompt(text)
+        } else if (mode === "selection" && savedRange) {
+            setPrompt((prev) => prev.slice(0, savedRange.from) + text + prev.slice(savedRange.to))
+        } else {
+            setPrompt((prev) => {
+                const pos = savedRange?.from ?? prev.length
+                return prev.slice(0, pos) + text + prev.slice(pos)
+            })
+        }
+    }
     // 让 VM 的 notifyListener 能驱动本组件重渲染（octo-web#95）。
     //
     // 历史背景：`PersonaCreate` 通过父级 `routeContext.push()` 推入 RoutePage 的
@@ -434,14 +452,25 @@ function PersonaCreate(props: {
                     <div className="wk-persona-create-form-label">
                         {t("base.persona.edit.promptOptionalLabel")}
                     </div>
-                    <textarea
-                        className="wk-persona-create-prompt"
-                        placeholder={t("base.persona.edit.promptPlaceholder")}
-                        value={prompt}
-                        onChange={(e) => setPrompt(e.target.value)}
-                        rows={4}
-                        data-testid="persona-create-prompt"
-                    />
+                    <div style={{ position: "relative" }}>
+                        <textarea
+                            ref={promptRef}
+                            className="wk-persona-create-prompt"
+                            placeholder={t("base.persona.edit.promptPlaceholder")}
+                            value={prompt}
+                            onChange={(e) => setPrompt(e.target.value)}
+                            rows={4}
+                            data-testid="persona-create-prompt"
+                        />
+                        <VoiceInputButton
+                            inputRef={promptRef}
+                            onTranscribed={handleVoiceTranscribed}
+                            getCurrentText={() => prompt}
+                            showModeMenu
+                            size="sm"
+                            className="wk-vib--textarea-corner"
+                        />
+                    </div>
                     <button
                         className="wk-persona-add-btn"
                         disabled={submitting}

--- a/packages/dmworkbase/src/Components/SpaceSettings/index.css
+++ b/packages/dmworkbase/src/Components/SpaceSettings/index.css
@@ -55,6 +55,34 @@ body[theme-mode=dark] .wk-spacesettings-label {
     color: #ccc;
 }
 
+.wk-spacesettings-textarea {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--wk-border-default);
+    border-radius: var(--wk-r-sm);
+    background: var(--wk-bg-surface);
+    color: var(--wk-text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+}
+
+.wk-spacesettings-textarea:focus {
+    border-color: var(--wk-color-accent);
+}
+
+.wk-spacesettings-textarea:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.wk-spacesettings-textarea::placeholder {
+    color: var(--wk-text-secondary);
+}
+
 .wk-spacesettings-btn {
     width: 100%;
     padding: 8px 16px;

--- a/packages/dmworkbase/src/Components/SpaceSettings/index.css
+++ b/packages/dmworkbase/src/Components/SpaceSettings/index.css
@@ -59,12 +59,12 @@ body[theme-mode=dark] .wk-spacesettings-label {
     display: block;
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
     border: 1px solid var(--wk-border-default);
     border-radius: var(--wk-r-sm);
     background: var(--wk-bg-surface);
     color: var(--wk-text-primary);
-    font-size: 14px;
+    font-size: var(--wk-text-size-md);
     line-height: 1.5;
     resize: vertical;
     outline: none;

--- a/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
-import { Input, TextArea, Toast, Button } from "@douyinfe/semi-ui";
+import { Input, Toast, Button } from "@douyinfe/semi-ui";
 import { IconCopy, IconLink } from "@douyinfe/semi-icons";
 import { Space, SpaceService } from "../../Service/SpaceService";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
+import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
 import "./index.css";
 
 export interface SpaceSettingsProps {
@@ -24,6 +25,29 @@ interface SpaceSettingsState {
 export default class SpaceSettings extends Component<SpaceSettingsProps, SpaceSettingsState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
+
+    private descriptionRef = React.createRef<HTMLTextAreaElement>();
+
+    private handleVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            this.setState({ description: text.slice(0, 200) });
+        } else if (mode === "selection" && savedRange) {
+            this.setState((prev) => {
+                const updated = prev.description.slice(0, savedRange.from) + text + prev.description.slice(savedRange.to);
+                return { description: updated.slice(0, 200) };
+            });
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.description.length;
+                const updated = prev.description.slice(0, pos) + text + prev.description.slice(pos);
+                return { description: updated.slice(0, 200) };
+            });
+        }
+    };
 
     constructor(props: SpaceSettingsProps) {
         super(props);
@@ -155,13 +179,27 @@ export default class SpaceSettings extends Component<SpaceSettingsProps, SpaceSe
                     </div>
                     <div className="wk-spacesettings-field">
                         <label className="wk-spacesettings-label">{t("base.spaceSettings.description")}</label>
-                        <TextArea
-                            value={description}
-                            onChange={(v) => this.setState({ description: v })}
-                            maxCount={200}
-                            autosize={{ minRows: 3, maxRows: 5 }}
-                            disabled={!isOwner}
-                        />
+                        <div style={{ position: "relative" }}>
+                            <textarea
+                                ref={this.descriptionRef}
+                                className="wk-spacesettings-textarea"
+                                value={description}
+                                onChange={(e) => this.setState({ description: e.target.value.slice(0, 200) })}
+                                maxLength={200}
+                                rows={3}
+                                disabled={!isOwner}
+                            />
+                            {isOwner && (
+                                <VoiceInputButton
+                                    inputRef={this.descriptionRef}
+                                    onTranscribed={this.handleVoiceTranscribed}
+                                    getCurrentText={() => this.state.description}
+                                    showModeMenu
+                                    size="sm"
+                                    className="wk-vib--textarea-corner"
+                                />
+                            )}
+                        </div>
                     </div>
                     {isOwner && (
                         <button

--- a/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
+++ b/packages/dmworkbase/src/Components/SpaceSettings/index.tsx
@@ -37,14 +37,18 @@ export default class SpaceSettings extends Component<SpaceSettingsProps, SpaceSe
             this.setState({ description: text.slice(0, 200) });
         } else if (mode === "selection" && savedRange) {
             this.setState((prev) => {
-                const updated = prev.description.slice(0, savedRange.from) + text + prev.description.slice(savedRange.to);
-                return { description: updated.slice(0, 200) };
+                const before = prev.description.slice(0, savedRange.from);
+                const after = prev.description.slice(savedRange.to);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { description: before + text.slice(0, budget) + after };
             });
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.description.length;
-                const updated = prev.description.slice(0, pos) + text + prev.description.slice(pos);
-                return { description: updated.slice(0, 200) };
+                const before = prev.description.slice(0, pos);
+                const after = prev.description.slice(pos);
+                const budget = Math.max(0, 200 - before.length - after.length);
+                return { description: before + text.slice(0, budget) + after };
             });
         }
     };

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -102,6 +102,8 @@ export { isSafeUrl } from './Utils/security'
 // 等包外组件在「按当前查看 Space 相对渲染」时复用，避免各自复制逻辑漂移。
 export { resolveExternalForViewer } from './Utils/externalViewer'
 export type { ExternalViewerInput, ExternalViewerResult } from './Utils/externalViewer'
+export { default as VoiceInputButton } from './Components/VoiceInputButton'
+export type { ReplaceMode, SelectionRange } from './Components/VoiceInputButton'
 
 // Claw components
 export { default as ClawOverviewTab } from './Components/ClawOverviewTab'

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.css
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.css
@@ -45,6 +45,13 @@
     border-color: var(--wk-color-primary, #3370FF);
 }
 
+.chat-summary-modal-input-wrap {
+    position: relative;
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+
 .chat-summary-modal-input {
     width: 100%;
     padding: 10px 12px;

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -471,7 +471,7 @@ export default class ChatSummaryNewModal extends Component<
                     </div>
 
                     <div className="chat-summary-modal-input-area">
-                        <div style={{ position: 'relative' }}>
+                        <div className="chat-summary-modal-input-wrap">
                             <textarea
                                 ref={this.inputRef}
                                 className="chat-summary-modal-input"

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -2,6 +2,8 @@ import React, { Component, createRef } from 'react';
 import { Modal, Toast, Tag, Button } from '@douyinfe/semi-ui';
 import { IconPlus, IconClock } from '@douyinfe/semi-icons';
 import { WKApp, I18nContext } from '@octo/base';
+import VoiceInputButton from '@octo/base/src/Components/VoiceInputButton';
+import type { ReplaceMode, SelectionRange } from '@octo/base/src/Components/VoiceInputButton';
 import type { TopicTemplate, ChatCandidate, ScheduleConfig } from '../types/summary';
 import { SourceType, SummaryMode } from '../types/summary';
 import { getSourceType } from '../utils/channelType';
@@ -52,6 +54,29 @@ export default class ChatSummaryNewModal extends Component<
     declare context: React.ContextType<typeof I18nContext>;
 
     private inputRef = createRef<HTMLTextAreaElement>();
+
+    private handleVoiceTranscribed = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === 'all') {
+            this.setState({ topic: text, templatePlaceholderRange: null });
+        } else if (mode === 'selection' && savedRange) {
+            this.setState((prev) => ({
+                topic: prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to),
+                templatePlaceholderRange: null,
+            }));
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.topic.length;
+                return {
+                    topic: prev.topic.slice(0, pos) + text + prev.topic.slice(pos),
+                    templatePlaceholderRange: null,
+                };
+            });
+        }
+    };
 
     constructor(props: ChatSummaryNewModalProps) {
         super(props);
@@ -446,20 +471,30 @@ export default class ChatSummaryNewModal extends Component<
                     </div>
 
                     <div className="chat-summary-modal-input-area">
-                        <textarea
-                            ref={this.inputRef}
-                            className="chat-summary-modal-input"
-                            placeholder={t('summary.create.topicPlaceholderInChat')}
-                            value={topic}
-                            onChange={(e) => this.setState({ topic: e.target.value, templatePlaceholderRange: null })}
-                            onFocus={this.handleInputFocus}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' && !e.shiftKey && !submitting) {
-                                    e.preventDefault();
-                                    void this.handleSubmit();
-                                }
-                            }}
-                        />
+                        <div style={{ position: 'relative' }}>
+                            <textarea
+                                ref={this.inputRef}
+                                className="chat-summary-modal-input"
+                                placeholder={t('summary.create.topicPlaceholderInChat')}
+                                value={topic}
+                                onChange={(e) => this.setState({ topic: e.target.value, templatePlaceholderRange: null })}
+                                onFocus={this.handleInputFocus}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && !e.shiftKey && !submitting) {
+                                        e.preventDefault();
+                                        void this.handleSubmit();
+                                    }
+                                }}
+                            />
+                            <VoiceInputButton
+                                inputRef={this.inputRef}
+                                onTranscribed={this.handleVoiceTranscribed}
+                                getCurrentText={() => this.state.topic}
+                                showModeMenu
+                                size="sm"
+                                className="wk-vib--textarea-corner"
+                            />
+                        </div>
                         {topic.trim() && appliedTemplateLabel && (
                             <div className="summary-template-applied-bar">
                                 <span className="summary-template-applied-text">

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -659,11 +659,11 @@
 .summary-regenerate-topic-textarea {
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px;
-    font-size: 14px;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    font-size: var(--wk-text-size-md);
     line-height: 1.6;
     border: 1px solid var(--semi-color-border);
-    border-radius: 6px;
+    border-radius: var(--wk-r-sm);
     resize: vertical;
     font-family: inherit;
     color: var(--semi-color-text-0);

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -656,6 +656,27 @@
     margin-top: 14px;
 }
 
+.summary-regenerate-topic-textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    font-size: 14px;
+    line-height: 1.6;
+    border: 1px solid var(--semi-color-border);
+    border-radius: 6px;
+    resize: vertical;
+    font-family: inherit;
+    color: var(--semi-color-text-0);
+    background-color: var(--semi-color-fill-0);
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.summary-regenerate-topic-textarea:focus {
+    border-color: var(--semi-color-primary);
+    box-shadow: 0 0 0 2px var(--semi-color-primary-light-default);
+}
+
 .summary-detail-team-meta {
     display: flex;
     align-items: center;

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -115,14 +115,18 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             this.setState({ regenerateTopic: text.slice(0, 1000) });
         } else if (mode === "selection" && savedRange) {
             this.setState((prev) => {
-                const updated = prev.regenerateTopic.slice(0, savedRange.from) + text + prev.regenerateTopic.slice(savedRange.to);
-                return { regenerateTopic: updated.slice(0, 1000) };
+                const before = prev.regenerateTopic.slice(0, savedRange.from);
+                const after = prev.regenerateTopic.slice(savedRange.to);
+                const budget = Math.max(0, 1000 - before.length - after.length);
+                return { regenerateTopic: before + text.slice(0, budget) + after };
             });
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.regenerateTopic.length;
-                const updated = prev.regenerateTopic.slice(0, pos) + text + prev.regenerateTopic.slice(pos);
-                return { regenerateTopic: updated.slice(0, 1000) };
+                const before = prev.regenerateTopic.slice(0, pos);
+                const after = prev.regenerateTopic.slice(pos);
+                const budget = Math.max(0, 1000 - before.length - after.length);
+                return { regenerateTopic: before + text.slice(0, budget) + after };
             });
         }
     };

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -7,13 +7,14 @@ import {
     Dropdown,
     Tag,
     Modal,
-    TextArea,
     Popconfirm,
 } from "@douyinfe/semi-ui";
 import { IconEdit, IconMore, IconSend, IconClock, IconTick, IconClose, IconInfoCircle, IconHistory, IconUser, IconPlus, IconMinusCircle, IconExit } from "@douyinfe/semi-icons";
 import { Channel, ChannelTypeGroup, ChannelTypePerson, MessageText, WKSDK } from "wukongimjssdk";
 import { I18nContext, t } from "@octo/base";
 import WKApp from "@octo/base/src/App";
+import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
+import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import { splitSummaryText } from "../utils/splitMessage";
 import SummaryConfirmPage from "./SummaryConfirmPage";
 import * as api from "../api/summaryApi";
@@ -102,6 +103,29 @@ const SUMMARY_WORKFLOW_STAGES: Array<{ key: WorkflowStage; labelKey: string }> =
 export default class SummaryDetailPage extends Component<SummaryDetailPageProps, SummaryDetailPageState> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
+
+    private regenerateTopicRef = React.createRef<HTMLTextAreaElement>();
+
+    private handleRegenerateTopicVoice = (
+        text: string,
+        mode: ReplaceMode,
+        savedRange?: SelectionRange
+    ) => {
+        if (mode === "all") {
+            this.setState({ regenerateTopic: text.slice(0, 1000) });
+        } else if (mode === "selection" && savedRange) {
+            this.setState((prev) => {
+                const updated = prev.regenerateTopic.slice(0, savedRange.from) + text + prev.regenerateTopic.slice(savedRange.to);
+                return { regenerateTopic: updated.slice(0, 1000) };
+            });
+        } else {
+            this.setState((prev) => {
+                const pos = savedRange?.from ?? prev.regenerateTopic.length;
+                const updated = prev.regenerateTopic.slice(0, pos) + text + prev.regenerateTopic.slice(pos);
+                return { regenerateTopic: updated.slice(0, 1000) };
+            });
+        }
+    };
 
     state: SummaryDetailPageState = {
         detail: null,
@@ -2299,13 +2323,25 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     <label id="regenerate-topic-label" style={{ display: "block", marginBottom: 8, color: "var(--semi-color-text-1)" }}>
                         {t("summary.detail.regenerateTopicLabel")}
                     </label>
-                    <TextArea
-                        aria-labelledby="regenerate-topic-label"
-                        autosize={{ minRows: 3, maxRows: 8 }}
-                        maxCount={1000}
-                        value={this.state.regenerateTopic}
-                        onChange={(value) => this.setState({ regenerateTopic: value.slice(0, 1000) })}
-                    />
+                    <div style={{ position: "relative" }}>
+                        <textarea
+                            ref={this.regenerateTopicRef}
+                            aria-labelledby="regenerate-topic-label"
+                            className="summary-regenerate-topic-textarea"
+                            rows={3}
+                            maxLength={1000}
+                            value={this.state.regenerateTopic}
+                            onChange={(e) => this.setState({ regenerateTopic: e.target.value.slice(0, 1000) })}
+                        />
+                        <VoiceInputButton
+                            inputRef={this.regenerateTopicRef}
+                            onTranscribed={this.handleRegenerateTopicVoice}
+                            getCurrentText={() => this.state.regenerateTopic}
+                            showModeMenu
+                            size="sm"
+                            className="wk-vib--textarea-corner"
+                        />
+                    </div>
                 </Modal>
             </div>
         );

--- a/packages/docs/src/__mocks__/octoBase.ts
+++ b/packages/docs/src/__mocks__/octoBase.ts
@@ -89,3 +89,13 @@ export class SpaceService {
     return []
   }
 }
+
+// VoiceInputButton stub (#571): the real component is a hooks-based functional component that
+// pulls the full voice/recording stack (WKApp, semi-ui, media APIs) into jsdom. Docs tests only
+// need it to render nothing so the comment composers mount cleanly; behaviour is covered by the
+// dmworkbase VoiceInputButton tests.
+export function VoiceInputButton() {
+  return null
+}
+export type ReplaceMode = 'append' | 'all' | 'selection'
+export type SelectionRange = { from: number; to: number }

--- a/packages/docs/src/__mocks__/octoBase.ts
+++ b/packages/docs/src/__mocks__/octoBase.ts
@@ -97,5 +97,5 @@ export class SpaceService {
 export function VoiceInputButton() {
   return null
 }
-export type ReplaceMode = 'append' | 'all' | 'selection'
+export type ReplaceMode = 'all' | 'selection' | 'insert'
 export type SelectionRange = { from: number; to: number }

--- a/packages/docs/src/comments/CommentBubble.tsx
+++ b/packages/docs/src/comments/CommentBubble.tsx
@@ -6,12 +6,13 @@
 // for the body and POSTs a root comment. A distinct pluginKey keeps it from clashing with the
 // formatting BubbleMenu in Toolbar.tsx.
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import type { Editor } from '@tiptap/core'
 import { encodeAnchorRange, type EncodedAnchor } from './anchor.ts'
-import { t } from '../octoweb/index.ts'
+import { t, VoiceInputButton } from '../octoweb/index.ts'
 import type { CreateRootInput } from './api.ts'
+import { applyVoiceTranscription } from './voiceText.ts'
 
 export function CommentBubble({
   editor,
@@ -24,6 +25,7 @@ export function CommentBubble({
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const bodyRef = useRef<HTMLTextAreaElement>(null)
 
   function startComposing() {
     const { from, to } = editor.state.selection
@@ -72,13 +74,26 @@ export function CommentBubble({
       <div className="octo-comment-bubble">
         {pending ? (
           <div className="octo-comment-compose">
-            <textarea
-              className="octo-comment-input"
-              placeholder={t('docs.comment.composePlaceholder')}
-              value={body}
-              autoFocus
-              onChange={(e) => setBody(e.target.value)}
-            />
+            <div style={{ position: 'relative' }}>
+              <textarea
+                ref={bodyRef}
+                className="octo-comment-input"
+                placeholder={t('docs.comment.composePlaceholder')}
+                value={body}
+                autoFocus
+                onChange={(e) => setBody(e.target.value)}
+              />
+              <VoiceInputButton
+                inputRef={bodyRef}
+                onTranscribed={(text, mode, savedRange) =>
+                  setBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+                }
+                getCurrentText={() => body}
+                showModeMenu
+                size="sm"
+                className="wk-vib--textarea-corner"
+              />
+            </div>
             <div className="octo-comment-compose-actions">
               <button
                 type="button"

--- a/packages/docs/src/comments/CommentPanel.tsx
+++ b/packages/docs/src/comments/CommentPanel.tsx
@@ -10,11 +10,12 @@ import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import type { Editor } from '@tiptap/core'
 import type { Role } from '../auth/roles.ts'
 import { canComment, canEdit, canManage } from '../auth/roles.ts'
-import { getCurrentUid, t } from '../octoweb/index.ts'
+import { getCurrentUid, t, VoiceInputButton } from '../octoweb/index.ts'
 import { formatRelative, formatAbsolute } from '../versions/format.ts'
 import { decodeRelPos, resolveAnchorRange, getYBinding } from './anchor.ts'
 import type { Comment, CommentThread } from './api.ts'
 import type { UseDocComments } from './useDocComments.ts'
+import { applyVoiceTranscription } from './voiceText.ts'
 
 /** Re-render on editor doc/selection changes so orphan status + scroll targets stay current. */
 function useEditorTick(editor: Editor): void {
@@ -55,6 +56,7 @@ function CommentBody({
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(comment.body)
   const [busy, setBusy] = useState(false)
+  const draftRef = useRef<HTMLTextAreaElement>(null)
 
   const isAuthor = comment.authorUid === currentUid
   const canHardDelete = !isAuthor && canManage(role)
@@ -90,12 +92,25 @@ function CommentBody({
       </div>
       {editing ? (
         <div className="octo-comment-compose">
-          <textarea
-            className="octo-comment-input"
-            value={draft}
-            autoFocus
-            onChange={(e) => setDraft(e.target.value)}
-          />
+          <div style={{ position: 'relative' }}>
+            <textarea
+              ref={draftRef}
+              className="octo-comment-input"
+              value={draft}
+              autoFocus
+              onChange={(e) => setDraft(e.target.value)}
+            />
+            <VoiceInputButton
+              inputRef={draftRef}
+              onTranscribed={(text, mode, savedRange) =>
+                setDraft((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+              }
+              getCurrentText={() => draft}
+              showModeMenu
+              size="sm"
+              className="wk-vib--textarea-corner"
+            />
+          </div>
           <div className="octo-comment-compose-actions">
             <button
               type="button"
@@ -161,6 +176,7 @@ function Thread({
   const [replyOpen, setReplyOpen] = useState(false)
   const [replyBody, setReplyBody] = useState('')
   const [busy, setBusy] = useState(false)
+  const replyRef = useRef<HTMLTextAreaElement>(null)
 
   const ready = getYBinding(editor) != null
   const range = anchorRange(editor, thread)
@@ -232,13 +248,26 @@ function Thread({
 
       {replyOpen && (
         <div className="octo-comment-compose">
-          <textarea
-            className="octo-comment-input"
-            placeholder={t('docs.comment.replyPlaceholder')}
-            value={replyBody}
-            autoFocus
-            onChange={(e) => setReplyBody(e.target.value)}
-          />
+          <div style={{ position: 'relative' }}>
+            <textarea
+              ref={replyRef}
+              className="octo-comment-input"
+              placeholder={t('docs.comment.replyPlaceholder')}
+              value={replyBody}
+              autoFocus
+              onChange={(e) => setReplyBody(e.target.value)}
+            />
+            <VoiceInputButton
+              inputRef={replyRef}
+              onTranscribed={(text, mode, savedRange) =>
+                setReplyBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+              }
+              getCurrentText={() => replyBody}
+              showModeMenu
+              size="sm"
+              className="wk-vib--textarea-corner"
+            />
+          </div>
           <div className="octo-comment-compose-actions">
             <button
               type="button"

--- a/packages/docs/src/comments/voiceText.ts
+++ b/packages/docs/src/comments/voiceText.ts
@@ -1,0 +1,20 @@
+// Shared helper for wiring VoiceInputButton (#571) into the docs/sheet comment composers.
+// Each composer keeps its body in a plain string state; this computes the next value from a
+// transcription result, mirroring the splice semantics used by SummaryEditor in dmworksummary.
+
+import type { ReplaceMode, SelectionRange } from '../octoweb/index.ts'
+
+/** Apply a voice transcription to `current` given the replace mode + saved selection range. */
+export function applyVoiceTranscription(
+  current: string,
+  text: string,
+  mode: ReplaceMode,
+  savedRange?: SelectionRange,
+): string {
+  if (mode === 'all') return text
+  if (mode === 'selection' && savedRange) {
+    return current.slice(0, savedRange.from) + text + current.slice(savedRange.to)
+  }
+  const pos = savedRange?.from ?? current.length
+  return current.slice(0, pos) + text + current.slice(pos)
+}

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -7,6 +7,8 @@
 // whenever no override has been set — i.e. in production and dev.
 
 import { WKApp, i18n, t, useI18n, Menus, SpaceService } from '@octo/base'
+import { VoiceInputButton } from '@octo/base'
+import type { ReplaceMode, SelectionRange } from '@octo/base'
 import type {
   APIClient,
   ApiRequestConfig,
@@ -306,5 +308,10 @@ export { t, useI18n }
 /** Re-export the real Menus class so the docs module can register a NavRail entry
  * through the seam without importing @octo/base directly. */
 export { Menus }
+
+/** Re-export the shared VoiceInputButton (#571) through the seam so docs comment composers
+ * can wire voice input without importing @octo/base subpaths directly (tests alias the seam). */
+export { VoiceInputButton }
+export type { ReplaceMode, SelectionRange }
 
 export * from './types.ts'

--- a/packages/docs/src/sheet/SheetCommentPanel.tsx
+++ b/packages/docs/src/sheet/SheetCommentPanel.tsx
@@ -14,11 +14,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Role } from '../auth/roles.ts'
 import { canComment, canEdit, canManage } from '../auth/roles.ts'
-import { getCurrentUid, t } from '../octoweb/index.ts'
+import { getCurrentUid, t, VoiceInputButton } from '../octoweb/index.ts'
 import { formatRelative, formatAbsolute } from '../versions/format.ts'
 import type { UseDocComments } from '../comments/useDocComments.ts'
 import type { Comment, CommentThread } from '../comments/api.ts'
 import type { CollabSheet } from './CollabSheet.ts'
+import { applyVoiceTranscription } from '../comments/voiceText.ts'
 
 /**
  * Legacy V1 single-sheet docs anchored comments to the raw Univer sheet id (`octo-sheet-1`,
@@ -82,6 +83,7 @@ function CommentBody({
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(comment.body)
   const [busy, setBusy] = useState(false)
+  const draftRef = useRef<HTMLTextAreaElement>(null)
 
   const isAuthor = comment.authorUid === currentUid
   const canHardDelete = !isAuthor && canManage(role)
@@ -117,12 +119,25 @@ function CommentBody({
       </div>
       {editing ? (
         <div className="octo-comment-compose">
-          <textarea
-            className="octo-comment-input"
-            value={draft}
-            autoFocus
-            onChange={(e) => setDraft(e.target.value)}
-          />
+          <div style={{ position: 'relative' }}>
+            <textarea
+              ref={draftRef}
+              className="octo-comment-input"
+              value={draft}
+              autoFocus
+              onChange={(e) => setDraft(e.target.value)}
+            />
+            <VoiceInputButton
+              inputRef={draftRef}
+              onTranscribed={(text, mode, savedRange) =>
+                setDraft((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+              }
+              getCurrentText={() => draft}
+              showModeMenu
+              size="sm"
+              className="wk-vib--textarea-corner"
+            />
+          </div>
           <div className="octo-comment-compose-actions">
             <button type="button" className="octo-tb-btn" disabled={busy || draft.trim() === ''} onClick={saveEdit}>
               {t('docs.comment.save')}
@@ -182,6 +197,7 @@ function Thread({
   const [replyBody, setReplyBody] = useState('')
   const [busy, setBusy] = useState(false)
   const ref = useRef<HTMLLIElement>(null)
+  const replyRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     if (active) ref.current?.scrollIntoView({ block: 'nearest' })
@@ -245,13 +261,26 @@ function Thread({
 
       {replyOpen && (
         <div className="octo-comment-compose">
-          <textarea
-            className="octo-comment-input"
-            placeholder={t('docs.comment.replyPlaceholder')}
-            value={replyBody}
-            autoFocus
-            onChange={(e) => setReplyBody(e.target.value)}
-          />
+          <div style={{ position: 'relative' }}>
+            <textarea
+              ref={replyRef}
+              className="octo-comment-input"
+              placeholder={t('docs.comment.replyPlaceholder')}
+              value={replyBody}
+              autoFocus
+              onChange={(e) => setReplyBody(e.target.value)}
+            />
+            <VoiceInputButton
+              inputRef={replyRef}
+              onTranscribed={(text, mode, savedRange) =>
+                setReplyBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+              }
+              getCurrentText={() => replyBody}
+              showModeMenu
+              size="sm"
+              className="wk-vib--textarea-corner"
+            />
+          </div>
           <div className="octo-comment-compose-actions">
             <button type="button" className="octo-tb-btn" disabled={busy || replyBody.trim() === ''} onClick={submitReply}>
               {t('docs.comment.reply')}
@@ -299,6 +328,7 @@ export function SheetCommentPanel({
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null)
   const [composeError, setComposeError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+  const bodyRef = useRef<HTMLTextAreaElement>(null)
 
   // Map every thread to its cell (for selection matching), keyed by thread id.
   const cellByThread = useMemo(() => {
@@ -382,13 +412,26 @@ export function SheetCommentPanel({
 
       {canComment(role) && (
         <div className="octo-comment-compose">
-          <textarea
-            className="octo-comment-input"
-            placeholder={t('docs.sheet.comment.placeholder')}
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            rows={2}
-          />
+          <div style={{ position: 'relative' }}>
+            <textarea
+              ref={bodyRef}
+              className="octo-comment-input"
+              placeholder={t('docs.sheet.comment.placeholder')}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={2}
+            />
+            <VoiceInputButton
+              inputRef={bodyRef}
+              onTranscribed={(text, mode, savedRange) =>
+                setBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+              }
+              getCurrentText={() => body}
+              showModeMenu
+              size="sm"
+              className="wk-vib--textarea-corner"
+            />
+          </div>
           <div className="octo-comment-compose-actions">
             <button type="button" className="octo-tb-btn" disabled={busy || !body.trim()} onClick={() => void submit()}>
               {activeCellKey ? `${t('docs.sheet.comment.menu')} ${activeCellKey}` : t('docs.sheet.comment.current')}

--- a/packages/docs/src/sheet/SheetView.tsx
+++ b/packages/docs/src/sheet/SheetView.tsx
@@ -34,7 +34,8 @@ import {
 } from '../editor/DocMoreMenu.tsx'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { useDocDelete } from '../editor/useDocDelete.ts'
-import { t, getCurrentUid, canForwardToChat } from '../octoweb/index.ts'
+import { t, getCurrentUid, canForwardToChat, VoiceInputButton } from '../octoweb/index.ts'
+import { applyVoiceTranscription } from '../comments/voiceText.ts'
 import '../editor/styles.css'
 
 export type SheetViewProps = Omit<CollabSheetOptions, 'container' | 'onRole' | 'onConnState' | 'onTerminal'> & {
@@ -97,6 +98,7 @@ function SheetCommentComposer({
 }) {
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
+  const bodyRef = useRef<HTMLTextAreaElement>(null)
   const submit = async () => {
     if (busy || !body.trim()) return
     setBusy(true)
@@ -124,19 +126,32 @@ function SheetCommentComposer({
       }}
     >
       <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>{t('docs.sheet.comment.menu')} {anchor.a1}</div>
-      <textarea
-        autoFocus
-        className="octo-comment-input"
-        placeholder={t('docs.sheet.comment.add')}
-        value={body}
-        rows={3}
-        onChange={(e) => setBody(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') onCancel()
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void submit()
-        }}
-        style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical' }}
-      />
+      <div style={{ position: 'relative' }}>
+        <textarea
+          ref={bodyRef}
+          autoFocus
+          className="octo-comment-input"
+          placeholder={t('docs.sheet.comment.add')}
+          value={body}
+          rows={3}
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') onCancel()
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void submit()
+          }}
+          style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical' }}
+        />
+        <VoiceInputButton
+          inputRef={bodyRef}
+          onTranscribed={(text, mode, savedRange) =>
+            setBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+          }
+          getCurrentText={() => body}
+          showModeMenu
+          size="sm"
+          className="wk-vib--textarea-corner"
+        />
+      </div>
       <div className="octo-comment-compose-actions" style={{ marginTop: 6, display: 'flex', gap: 8 }}>
         <button type="button" className="octo-tb-btn" disabled={busy || !body.trim()} onClick={() => void submit()}>
           {t('docs.sheet.comment.menu')}

--- a/packages/docs/types/octo-base.shim.d.ts
+++ b/packages/docs/types/octo-base.shim.d.ts
@@ -78,4 +78,31 @@ declare module '@octo/base' {
     static shared: SpaceService
     getMembers(spaceId: string, page?: number, limit?: number): Promise<SpaceMember[]>
   }
+
+  // Voice-input transcription contract (#571). The docs comment composers wire the shared
+  // VoiceInputButton and receive transcribed text back through `onTranscribed`. Only the
+  // surface octoweb/index.ts re-exports is declared here; the real component lives in
+  // packages/dmworkbase/src/Components/VoiceInputButton.
+  export type ReplaceMode = 'all' | 'selection' | 'insert'
+  export interface SelectionRange {
+    from: number
+    to: number
+  }
+  // Props the docs composers pass. `inputRef`/icons are typed loosely (`unknown`/`any`) to
+  // avoid pulling host react typings across the seam (mirrors WKApp/Menus above), while
+  // `onTranscribed` keeps precise signatures so composer callbacks infer their params.
+  export interface VoiceInputButtonProps {
+    inputRef: { current: HTMLTextAreaElement | HTMLInputElement | null }
+    onTranscribed: (
+      text: string,
+      replaceMode: ReplaceMode,
+      savedSelectionRange?: SelectionRange,
+    ) => void
+    getCurrentText?: () => string
+    showModeMenu?: boolean
+    size?: 'sm' | 'md'
+    className?: string
+    onRecordingStart?: () => void
+  }
+  export function VoiceInputButton(props: VoiceInputButtonProps): any
 }


### PR DESCRIPTION
## 背景

Closes #571

语音输入法此前只在少数输入框可用（智能总结、待办、聊天主输入框等 8 处）。产品要求：**在大部分输入框中都支持语音输入法，尤其是需要输入较长 prompt 的场景**。本 PR 复用已组件化的共享组件 `VoiceInputButton`（契约：`inputRef` + `onTranscribed`），将语音输入扩展到另外 12 个点位，**不改动** VoiceInputButton 组件本体及其 hooks / Service。

## 改动点位

### 第一 / 二档 · 原生 textarea（长 prompt / 自由文本）

| 组件 | 输入框内容 |
|------|-----------|
| GroupMdEditor | GROUP.md 群组说明（markdown 长文） |
| PersonaSettings / PersonaEdit | 分身人格 prompt |
| BotDetailModal | 龙虾 / 机器人简介 |
| SpaceSettings / SpaceCreate | Space 描述 |
| SummaryDetailPage | 「重新生成」弹窗 topic |
| ChatSummaryNewModal | 群内新建总结 topic |

其中用 Semi UI `<TextArea>` 的点位统一替换为原生 `<textarea>`——因为 `VoiceInputButton` 只能挂在原生 DOM 节点上（Semi `TextArea` 不暴露原生 ref），这也与仓库既有的接入范式（SummaryEditor、dmworktodo、ThreadCreateModal 全用原生 input/textarea）一致。替换时完整保留 `value` / `onChange` / `placeholder` / `disabled`，`maxCount` 上限改用 `slice` 强制。

### 第三档 · docs 文档 / 表格评论（原生 textarea）

CommentPanel、CommentBubble、SheetCommentPanel、SheetView。核查后这些评论撰写框均为原生 `<textarea>`（非 ProseMirror contentEditable），故按与第一档相同方式接入，**未触碰 ProseMirror 编辑器本体**。新增 `voiceText.ts` 提供共享的 `applyVoiceTranscription` splice 辅助函数。

docs 包约定不直接 import `@octo/base` 子路径，故 `VoiceInputButton` 经 `octoweb` seam 再导出；同步在 docs 的 typecheck shim（`types/octo-base.shim.d.ts`）中补充其类型声明，保证 docs 独立 typecheck 通过。

## 验证

- **docs `pnpm typecheck`**：本 PR 引入的新增错误为 **0**，错误数与 baseline 一致（剩余 27 项为既有 `docx` / `mathjax` / `members` 历史问题，与本 PR 无关）。
- **dmworksummary 测试**：**376 / 376 通过**。
- **dmworkbase 测试**：与 baseline 一致（PersonaEdit 测试已按既有 `Switch`/`semi-ui` 的 mock 惯例补齐 `VoiceInputButton` mock）。
- 未新增任何用户可见文案（复用现有 i18n key / placeholder）；`VoiceInputButton` 及其 hooks / Service 未改动。

> 注：本地全量 `turbo build` 因运行环境缺失 `docx` npm 依赖（lockfile 既有状态，与本 PR 无关，未触碰任何 `export/docx/*` 文件）在无关的导出链上失败；CI 依赖完整环境下不受影响。

## 不在本 PR 范围

短标签 / 搜索框 / 一次性短语类输入框（版本标签、成员搜索、加好友申请语、备注名等）按 #571 讨论明确排除。
