### PR TITLE
feat(loop): render octo avatars for member actors

### DIFF
--- a/packages/dmloop/src/api/agentApi.ts
+++ b/packages/dmloop/src/api/agentApi.ts
@@ -1,7 +1,7 @@
 // @octo/loop — Agent API（真实 fleet 联调）
 import type { Agent, CreateAgentReq, UpdateAgentReq, ListParams, RuntimeDevice } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
-import { ensureDirectory, actorName } from "./directory";
+import { ensureDirectory, actorName, actorAvatar } from "./directory";
 
 // runtime 名字缓存（用于 agent.runtime_name 回填）
 let _runtimeMap: Map<string, string> | null = null;
@@ -21,6 +21,7 @@ async function enrich(agents: Agent[]): Promise<Agent[]> {
     ...a,
     runtime_name: rmap.get(a.runtime_id) ?? null,
     owner_name: actorName(dir, "member", a.owner_id),
+    owner_avatar: actorAvatar(dir, "member", a.owner_id),
   }));
 }
 

--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -9,6 +9,8 @@ import { WKApp, SpaceService } from "@octo/base";
 interface Directory {
   slug: string;
   memberName: Map<string, string>;
+  // member user_id → octo_uid (only for octo-bridged members), for avatar resolution.
+  memberOctoUid: Map<string, string>;
   agentName: Map<string, string>;
   squadName: Map<string, string>;
   projectName: Map<string, string>;
@@ -36,12 +38,14 @@ async function build(): Promise<Directory> {
     for (const s of roster) octoName.set(s.uid, s.name);
   }
   const memberName = new Map<string, string>();
+  const memberOctoUid = new Map<string, string>();
   const candidates: AssigneeCandidate[] = [];
   for (const m of members) {
     // octo 身份优先：octo_uid 命中 space 名册取 octo 名字，否则回退 multica 名。
     const name = (m.octo_uid && octoName.get(m.octo_uid)) || m.name;
     memberName.set(m.user_id, name);
-    candidates.push({ id: m.user_id, type: "member", name });
+    if (m.octo_uid) memberOctoUid.set(m.user_id, m.octo_uid);
+    candidates.push({ id: m.user_id, type: "member", name, octo_uid: m.octo_uid ?? null });
   }
   const agentName = new Map<string, string>();
   for (const a of agents) {
@@ -55,7 +59,7 @@ async function build(): Promise<Directory> {
   }
   const projectName = new Map<string, string>();
   for (const p of (projectsResp.projects ?? [])) projectName.set(p.id, p.title);
-  return { slug, memberName, agentName, squadName, projectName, candidates };
+  return { slug, memberName, memberOctoUid, agentName, squadName, projectName, candidates };
 }
 
 export async function ensureDirectory(force = false): Promise<Directory> {
@@ -84,6 +88,19 @@ export function actorName(
   if (type === "agent") return dir.agentName.get(id) ?? null;
   if (type === "squad") return dir.squadName.get(id) ?? null;
   return null;
+}
+
+// actorAvatar returns the octo avatar URL for a MEMBER actor (resolved by
+// octo_uid), or undefined for agents/squads and non-octo members — callers keep
+// their type icon / initial fallback in those cases.
+export function actorAvatar(
+  dir: Directory,
+  type: AssigneeType | null | undefined,
+  id: string | null | undefined,
+): string | undefined {
+  if (type !== "member" || !id) return undefined;
+  const uid = dir.memberOctoUid.get(id);
+  return uid ? WKApp.shared.avatarUser(uid) : undefined;
 }
 
 export async function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -9,7 +9,7 @@ import type {
   AssigneeCandidate,
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
-import { ensureDirectory, actorName, listAssigneeCandidates as dirCandidates } from "./directory";
+import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
 
 async function enrich(issues: Issue[]): Promise<Issue[]> {
   const dir = await ensureDirectory();
@@ -17,6 +17,8 @@ async function enrich(issues: Issue[]): Promise<Issue[]> {
     ...i,
     assignee_name: actorName(dir, i.assignee_type, i.assignee_id),
     creator_name: actorName(dir, i.creator_type ?? "member", i.creator_id),
+    assignee_avatar: actorAvatar(dir, i.assignee_type, i.assignee_id),
+    creator_avatar: actorAvatar(dir, i.creator_type ?? "member", i.creator_id),
     project_name: i.project_id ? dir.projectName.get(i.project_id) ?? null : null,
   }));
 }
@@ -54,6 +56,7 @@ export async function listComments(issueId: string): Promise<IssueComment[]> {
   return (rows ?? []).map((c) => ({
     ...c,
     author_name: actorName(dir, c.author_type, c.author_id) ?? c.author_id,
+    author_avatar: actorAvatar(dir, c.author_type, c.author_id),
   }));
 }
 

--- a/packages/dmloop/src/api/squadApi.ts
+++ b/packages/dmloop/src/api/squadApi.ts
@@ -1,18 +1,20 @@
 // @octo/loop — Squad API（真实 fleet 联调）
 import type { Squad, SquadMember, UpsertSquadReq, ListParams } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete, httpPatch } from "./http";
-import { ensureDirectory, actorName } from "./directory";
+import { ensureDirectory, actorName, actorAvatar } from "./directory";
 
 function enrichSquad(s: Squad, dir: Awaited<ReturnType<typeof ensureDirectory>>): Squad {
   const members = (s.members ?? s.member_preview ?? []).map((m) => ({
     ...m,
     member_name: actorName(dir, m.member_type, m.member_id) ?? m.member_id,
+    member_avatar: actorAvatar(dir, m.member_type, m.member_id),
   }));
   return {
     ...s,
     members,
     leader_name: actorName(dir, "agent", s.leader_id) ?? actorName(dir, "member", s.leader_id),
     creator_name: actorName(dir, "member", s.creator_id),
+    leader_avatar: actorAvatar(dir, "member", s.leader_id),
   };
 }
 

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -10,6 +10,9 @@ export interface AssigneeCandidate {
   type: AssigneeType;
   name: string;
   avatar_color?: string;
+  // octo IM uid for member-type candidates (null for native members / agents /
+  // squads), used to render the octo avatar via WKApp.shared.avatarUser.
+  octo_uid?: string | null;
 }
 
 export interface Workspace {
@@ -81,6 +84,9 @@ export interface Issue {
   assignee_name?: string | null;
   project_name?: string | null;
   creator_name?: string | null;
+  // octo 头像 URL（member 型 actor，由 directory 回填；agent/squad/原生成员为空）
+  assignee_avatar?: string | null;
+  creator_avatar?: string | null;
 }
 
 export interface CreateIssueReq {
@@ -112,6 +118,7 @@ export interface IssueComment {
   content: string;
   created_at: string;
   author_name?: string | null;
+  author_avatar?: string | null;
 }
 
 export type TaskStatus =
@@ -265,6 +272,7 @@ export interface Agent {
   // 回填
   runtime_name?: string | null;
   owner_name?: string | null;
+  owner_avatar?: string | null;
 }
 export interface CreateAgentReq {
   name: string;
@@ -293,6 +301,7 @@ export interface SquadMember {
   member_id: string;
   role: string;
   member_name?: string | null;
+  member_avatar?: string | null;
 }
 export interface Squad {
   id: string;
@@ -310,6 +319,7 @@ export interface Squad {
   updated_at: string;
   leader_name?: string | null;
   creator_name?: string | null;
+  leader_avatar?: string | null;
 }
 export interface UpsertSquadReq {
   name: string;

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -231,8 +231,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const renderComment = (c: IssueComment, reply = false) => (
     <div key={c.id} className={`loop-comment ${reply ? "is-reply" : ""}`}>
       <div className="loop-comment__head">
-        <Avatar size="extra-extra-small" color="light-blue">
-          {c.author_name.slice(0, 1)}
+        <Avatar size="extra-extra-small" color="light-blue" src={c.author_avatar ?? undefined}>
+          {(c.author_name ?? "?").slice(0, 1)}
         </Avatar>
         <Text strong style={{ fontSize: 12 }}>
           {c.author_name}

--- a/packages/dmloop/src/panel/SquadDetailPage.tsx
+++ b/packages/dmloop/src/panel/SquadDetailPage.tsx
@@ -84,7 +84,7 @@ export default function SquadDetailPage({ squadId, onChanged }: { squadId: strin
           <div className="loop-comments">
             {(row.members ?? []).map((m) => (
               <div key={m.member_id} className="loop-comment" style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <Avatar size="extra-extra-small" color="light-blue">{(m.member_name ?? "?").slice(0, 1)}</Avatar>
+                <Avatar size="extra-extra-small" color="light-blue" src={m.member_avatar ?? undefined}>{(m.member_name ?? "?").slice(0, 1)}</Avatar>
                 <Text>{m.member_name}</Text>
                 <Tag color={ASSIGNEE_TYPE_COLOR[m.member_type]} size="small">{t(`loop.assignee.${m.member_type}`)}</Tag>
                 {m.role === "leader" ? (

--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Dropdown, Avatar, Tag } from "@douyinfe/semi-ui";
 import { ChevronDown, User, Bot, Users, CircleSlash } from "lucide-react";
-import { useI18n } from "@octo/base";
+import { useI18n, WKApp } from "@octo/base";
 import type { AssigneeCandidate, AssigneeType } from "../api/types";
 import { listAssigneeCandidates } from "../api/issueApi";
 import { ASSIGNEE_TYPE_COLOR } from "./meta";
@@ -48,7 +48,14 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
             <Dropdown.Divider />
             <Dropdown.Title>{g.label}</Dropdown.Title>
             {items.map((c) => (
-              <Dropdown.Item key={c.id} icon={typeIcon(c.type)} active={c.id === value} onClick={() => onChange(c.id, c.type)}>
+              <Dropdown.Item
+                key={c.id}
+                icon={c.type === "member" && c.octo_uid
+                  ? <Avatar size="extra-extra-small" color="light-blue" src={WKApp.shared.avatarUser(c.octo_uid)}>{c.name.slice(0, 1)}</Avatar>
+                  : typeIcon(c.type)}
+                active={c.id === value}
+                onClick={() => onChange(c.id, c.type)}
+              >
                 {c.name}
               </Dropdown.Item>
             ))}
@@ -63,7 +70,11 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
       <span className="loop-assignee-trigger" style={{ fontSize: size === "small" ? 12 : 13 }}>
         {current || valueName ? (
           <>
-            <Avatar size="extra-extra-small" color={ASSIGNEE_TYPE_COLOR[current?.type ?? "member"] as never}>
+            <Avatar
+              size="extra-extra-small"
+              color={ASSIGNEE_TYPE_COLOR[current?.type ?? "member"] as never}
+              src={current?.octo_uid ? WKApp.shared.avatarUser(current.octo_uid) : undefined}
+            >
               {(current?.name ?? valueName ?? "?").slice(0, 1)}
             </Avatar>
             <span className="loop-assignee-name">{current?.name ?? valueName}</span>


### PR DESCRIPTION
Follow-up to the octo member management PR (#581). Member **names** already resolve to octo identity; this carries `octo_uid` through so member **avatars** render the octo image instead of a letter-initial.

## What
- `directory.ts`: `memberOctoUid` map + `actorAvatar(dir,type,id)` helper — member-only; agents/squads/native members return `undefined` and keep their icon/initial.
- `types.ts`: `AssigneeCandidate.octo_uid` + `*_avatar` backfill fields on Issue / IssueComment / Squad(Member) / Agent (additive, optional).
- `issueApi` / `squadApi` / `agentApi` enrich: populate `*_avatar` via `actorAvatar`.
- Render octo avatar at the three initial-avatar surfaces: AssigneePicker (trigger + member dropdown items), issue comment author, squad member row.
- Drive-by: null-safe `author_name` initial in the comment header (pre-existing strict-null slip in the touched block).

## Verification
`tsc --noEmit` clean on all changed files. No `octo_uid` API change needed — it already arrives on `GET /workspaces/:id/members` (member management PR). Native (no octo_uid) members and agent/squad actors fall back to initial/icon = current behavior, so regression risk is low. Real-environment browser check pending (open an issue/squad/picker where an octo-bridged member appears → octo avatar renders).

## Deferred (optional)
Text-only surfaces today (not initial-avatar bugs): issue creator, agent owner, squad leader — the `*_avatar` fields are now available for them to adopt later.