### PR TITLE
feat(base): enlarge custom sticker on hover in emoji panel

### DIFF
--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -334,6 +334,94 @@ describe("EmojiPanel sticker gating", () => {
     });
 });
 
+describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
+    const STICKER = {
+        sticker_id: "s1",
+        path: "sticker-1.png",
+        category: "sticker",
+        placeholder: "",
+        format: "png",
+    };
+
+    // 切到「我的贴纸」tab 并等首屏懒加载完成，返回渲染出来的第一个贴纸格子。
+    async function mountWithSticker(): Promise<HTMLElement> {
+        hoisted.userStickers.mockResolvedValueOnce({ list: [STICKER] });
+        render(<EmojiPanel />);
+        await act(async () => {
+            tabs()[1].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await Promise.resolve();
+        });
+        const item = container.querySelector(".wk-sticker-item") as HTMLElement;
+        expect(item).not.toBeNull();
+        return item;
+    }
+
+    // React 17 的 onMouseEnter/onMouseLeave 由根节点上的 mouseover/mouseout 合成而来，
+    // 直接 dispatch 原生 mouseenter/mouseleave 不会触发合成事件，故用 mouseover/mouseout。
+    function hover(el: HTMLElement) {
+        act(() => {
+            el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: document.body }));
+        });
+    }
+    function leave(el: HTMLElement) {
+        act(() => {
+            el.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }));
+        });
+    }
+
+    it("portals an enlarged preview to <body> after the hover delay elapses", async () => {
+        const item = await mountWithSticker();
+
+        vi.useFakeTimers();
+        hover(item);
+        // 延时未到之前不浮出，避免鼠标扫过网格时狂闪。
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+
+        const preview = document.body.querySelector(".wk-sticker-preview");
+        expect(preview).not.toBeNull();
+        // 位图贴纸走 <img>，且尺寸远大于 60px 缩略图（由 CSS 控制，这里只断言渲染出媒体）。
+        expect(preview!.querySelector("img")).not.toBeNull();
+    });
+
+    it("hides the preview when the pointer leaves the sticker grid", async () => {
+        const item = await mountWithSticker();
+        const ul = container.querySelector(".wk-emojipanel-content ul") as HTMLElement;
+
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        leave(ul);
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("clears a still-pending preview timer on unmount without throwing", async () => {
+        const item = await mountWithSticker();
+
+        vi.useFakeTimers();
+        hover(item); // 起了延时但还没浮出
+        act(() => {
+            ReactDOM.unmountComponentAtNode(container);
+        });
+        // 卸载后即使 fire 掉挂起的 timer 也不应 setState 报错或残留浮层。
+        expect(() => {
+            act(() => {
+                vi.advanceTimersByTime(500);
+            });
+        }).not.toThrow();
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+});
+
 describe("EmojiPanel sticker upload validation (WKApp.remoteConfig.stickerUploadLimits)", () => {
     const bytes = (size: number) => new Uint8Array(size);
 

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -30,6 +30,7 @@ const hoisted = vi.hoisted(() => {
         userStickers: vi.fn().mockResolvedValue({ list: [] }),
         uploadSticker: vi.fn().mockResolvedValue({ path: "sticker-path", format: "png" }),
         addSticker: vi.fn().mockResolvedValue({}),
+        deleteSticker: vi.fn().mockResolvedValue({}),
         toastError: vi.fn(),
         addConfigChangeListener: vi.fn((cb: () => void) => {
             state.listener = cb;
@@ -89,6 +90,7 @@ vi.mock("../../../App", () => ({
                 userStickers: hoisted.userStickers,
                 uploadSticker: hoisted.uploadSticker,
                 addSticker: hoisted.addSticker,
+                deleteSticker: hoisted.deleteSticker,
                 getFileURL: (p: string) => p,
             },
         },
@@ -149,6 +151,7 @@ beforeEach(() => {
     hoisted.getAllEmoji.mockClear();
     hoisted.uploadSticker.mockClear();
     hoisted.addSticker.mockClear();
+    hoisted.deleteSticker.mockClear();
     hoisted.userStickers.mockClear();
     hoisted.mittOn.mockClear();
     hoisted.mittOff.mockClear();
@@ -419,6 +422,102 @@ describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
         }).not.toThrow();
         vi.useRealTimers();
         expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("hides the preview on scroll while it is visible (frozen rect would go stale)", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 网格滚动/窗口缩放会让一次性捕获的 rect 失真；捕获阶段 scroll 监听应隐藏预览。
+        act(() => {
+            window.dispatchEvent(new Event("scroll"));
+        });
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("clears the preview when the hovered sticker is deleted (no ghost)", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 删除 × 的 onClick stopPropagation 绕过 <li> 的 hide；onDelete 顶部需自行清预览。
+        const del = item.querySelector(".wk-sticker-del") as HTMLElement;
+        act(() => {
+            del.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(hoisted.deleteSticker).toHaveBeenCalledTimes(1);
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("hides the preview when leaving a sticker for non-sticker space inside the grid", async () => {
+        const item = await mountWithSticker();
+        const ul = container.querySelector(".wk-emojipanel-content ul") as HTMLElement;
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 指针离开贴纸但仍在 <ul> 内（relatedTarget 是 ul，非贴纸）：<ul> 的 mouseleave
+        // 不触发，需靠 .wk-sticker-item 上的 onMouseLeave 隐藏，避免预览滞留在空白处。
+        act(() => {
+            item.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: ul }));
+        });
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("cancels a pending preview when leaving the sticker before the delay elapses", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item); // 起了 120ms 延时但还没浮出
+        leave(item); // 延时内离开 → 应清掉待触发的 timer
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("keeps the preview visible when moving directly onto another sticker (seamless swap)", async () => {
+        hoisted.userStickers.mockResolvedValueOnce({
+            list: [STICKER, { ...STICKER, sticker_id: "s2", path: "sticker-2.png" }],
+        });
+        render(<EmojiPanel />);
+        await act(async () => {
+            tabs()[1].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await Promise.resolve();
+        });
+        const items = container.querySelectorAll(".wk-sticker-item");
+        const a = items[0] as HTMLElement;
+        const b = items[1] as HTMLElement;
+
+        vi.useFakeTimers();
+        hover(a);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 从 a 直接移到另一张贴纸 b（relatedTarget 是贴纸）：不应隐藏——交给 b 的
+        // onMouseEnter 无缝切换目标，保留 Discord 式跟随。
+        act(() => {
+            a.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: b }));
+        });
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
     });
 });
 

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -547,6 +547,26 @@ describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
         expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
     });
 
+    it("clears a visible preview when a background refresh fails (grid goes empty too)", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 失败分支把 stickers 清空——和成功分支返回空列表是同一类残影，预览必须一起清掉，
+        // 否则放大卡片会浮在一个已经空掉的网格上方。
+        hoisted.userStickers.mockRejectedValueOnce(new Error("network error"));
+        await act(async () => {
+            hoisted.state.mittHandlers["stickers-updated"]?.();
+            await Promise.resolve();
+        });
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
     it("does not show a pending preview for a sticker removed by a refresh before the delay elapses", async () => {
         const item = await mountWithSticker();
         vi.useFakeTimers();

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -518,6 +518,12 @@ describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
             a.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: b }));
         });
         expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 仅证明"没被隐藏"还不够——真实鼠标移动会在 a 的 mouseout 之外，紧接着在 b 上触发
+        // mouseover。补上这一步，断言预览的媒体确实换成了 b（而不只是继续显示着 a 的旧图）。
+        hover(b);
+        const img = document.body.querySelector(".wk-sticker-preview img") as HTMLImageElement | null;
+        expect(img?.src).toContain("sticker-2.png");
     });
 
     it("clears a visible preview when a background refresh removes the previewed sticker (no ghost)", async () => {

--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -519,6 +519,59 @@ describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
         });
         expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
     });
+
+    it("clears a visible preview when a background refresh removes the previewed sticker (no ghost)", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).not.toBeNull();
+
+        // 已加载过贴纸的面板才会重拉（stickersLoaded 已在 mountWithSticker 里置 true），
+        // 模拟后台「stickers-updated」广播把正在预览的这张贴纸移除掉——指针没有移动，
+        // 不会触发任何既有的 hide 路径，必须靠 requestStickers 自己核对 sticker_id。
+        hoisted.userStickers.mockResolvedValueOnce({ list: [] });
+        await act(async () => {
+            hoisted.state.mittHandlers["stickers-updated"]?.();
+            await Promise.resolve();
+        });
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("does not show a pending preview for a sticker removed by a refresh before the delay elapses", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item); // 起了 120ms 延时，还没浮出
+
+        // 延时排队期间后台广播把这张贴纸移除掉。
+        hoisted.userStickers.mockResolvedValueOnce({ list: [] });
+        await act(async () => {
+            hoisted.state.mittHandlers["stickers-updated"]?.();
+            await Promise.resolve();
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+        expect(document.body.querySelector(".wk-sticker-preview")).toBeNull();
+    });
+
+    it("marks the portaled preview aria-hidden so it is not announced as a duplicate", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+
+        const preview = document.body.querySelector(".wk-sticker-preview");
+        expect(preview?.getAttribute("aria-hidden")).toBe("true");
+    });
 });
 
 describe("EmojiPanel sticker upload validation (WKApp.remoteConfig.stickerUploadLimits)", () => {

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.css
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.css
@@ -283,13 +283,15 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
     position: fixed;
     z-index: 1002;
     box-sizing: border-box;
-    padding: 10px;
+    padding: var(--wk-sp-3);
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 16px;
+    border-radius: var(--wk-r-lg);
+    /* 背景与阴影都用主题感知的语义 token（--wk-color-item / --wk-shadow-lg 在
+       body[theme-mode=dark] 下各自有暗色变体），所以不再需要单独的暗色覆盖块。 */
     background: var(--wk-color-item);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+    box-shadow: var(--wk-shadow-lg);
     pointer-events: none;
     animation: wkStickerPreviewIn .12s ease;
 }
@@ -302,10 +304,6 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
 @keyframes wkStickerPreviewIn {
     from { opacity: 0; transform: scale(.85); }
     to { opacity: 1; transform: scale(1); }
-}
-body[theme-mode=dark] .wk-sticker-preview {
-    background: var(--wk-color-secondary-2);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, .6);
 }
 
 /* dark mode */

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.css
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.css
@@ -276,6 +276,38 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
     color: var(--wk-brand-primary);
 }
 
+/* hover「原位弹大」预览：portal 到 <body>、position:fixed，盖过面板（面板 z-index:999）。
+   pointer-events:none 让它不拦截鼠标——既不打断「点击即发送」，也保证网格的 mouseleave
+   能正常触发去隐藏预览。尺寸/坐标由行内 style 给（computeStickerPreviewStyle）。 */
+.wk-sticker-preview {
+    position: fixed;
+    z-index: 1002;
+    box-sizing: border-box;
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    background: var(--wk-color-item);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+    pointer-events: none;
+    animation: wkStickerPreviewIn .12s ease;
+}
+.wk-sticker-preview img,
+.wk-sticker-preview tgs-player {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+@keyframes wkStickerPreviewIn {
+    from { opacity: 0; transform: scale(.85); }
+    to { opacity: 1; transform: scale(1); }
+}
+body[theme-mode=dark] .wk-sticker-preview {
+    background: var(--wk-color-secondary-2);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, .6);
+}
+
 /* dark mode */
 body[theme-mode=dark] .wk-sticker-item {
     background: var(--wk-color-secondary-2);

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -73,6 +73,18 @@ const EMOJI_PANEL_HEIGHT = 372
 const EMOJI_PANEL_GAP = 12
 const EMOJI_PANEL_MARGIN = 8
 
+// 贴纸 hover 放大预览（对齐 Discord 贴纸面板的「悬停看大图」）。60px 缩略图看不清复杂
+// 插画，悬停时在格子上方浮出一张 STICKER_PREVIEW_SIZE 的圆角大图卡片。放大层 portal 到
+// <body>、position:fixed 并夹进视口——因为面板内容区 .wk-emojipanel-content 是
+// overflow:hidden，放大卡片会被裁掉顶部/边缘，portal 才能让它浮出面板而不被裁。
+// 浮在格子上方（而非盖住格子）是为了不遮挡 hover 才出现的右上角删除「×」。
+const STICKER_PREVIEW_SIZE = 140
+const STICKER_PREVIEW_MARGIN = 8
+// 放大卡片与格子之间的间距，避免贴着格子边缘。
+const STICKER_PREVIEW_GAP = 8
+// 首次悬停到浮出的延时：扫过网格时不会一路狂闪；一旦浮出，格子间移动直接无缝切换。
+const STICKER_PREVIEW_DELAY = 120
+
 interface EmojiToolbarProps {
     conversationContext: ConversationContext
     icon: string | React.ReactNode
@@ -185,6 +197,8 @@ interface EmojiPanelState {
     category: string
     stickers: StickerItem[]
     uploading: boolean
+    // 当前 hover 放大预览的目标贴纸及其格子在视口中的矩形；null 表示不显示。
+    preview: { sticker: StickerItem; rect: DOMRect } | null
 }
 
 interface EmojiPanelProps {
@@ -202,6 +216,8 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     private stickersLoaded = false
     // 订阅 appconfig 字段变化，让 sticker_custom_enabled 灰度切换后无需刷新前台即可生效。
     private removeConfigChangeListener?: () => void
+    // hover 放大预览的浮出延时句柄；卸载/隐藏时清除，避免离屏后 setState。
+    private previewTimer: ReturnType<typeof setTimeout> | null = null
 
     constructor(props: any) {
         super(props)
@@ -211,6 +227,7 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
             category: "emoji",
             stickers: [],
             uploading: false,
+            preview: null,
         }
     }
 
@@ -238,6 +255,10 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         WKApp.mittBus.off("stickers-updated", this._onStickersUpdated)
         this.removeConfigChangeListener?.()
         this.removeConfigChangeListener = undefined
+        if (this.previewTimer) {
+            clearTimeout(this.previewTimer)
+            this.previewTimer = null
+        }
     }
 
     private _onEmojiManifestUpdated = () => {
@@ -378,8 +399,55 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         return <tgs-player autoplay mode="normal" src={url}></tgs-player>
     }
 
+    // hover 进入某张贴纸：已有预览显示时立刻切换目标（格子间移动无缝跟随，对齐 Discord），
+    // 否则起一个短延时再浮出，避免鼠标扫过网格时一路狂闪。rect 在进入时即取，用于把放大
+    // 卡片按格子中心定位。
+    private scheduleStickerPreview = (sticker: StickerItem, target: HTMLElement) => {
+        const rect = target.getBoundingClientRect()
+        if (this.state.preview) {
+            this.setState({ preview: { sticker, rect } })
+            return
+        }
+        if (this.previewTimer) {
+            clearTimeout(this.previewTimer)
+        }
+        this.previewTimer = setTimeout(() => {
+            this.previewTimer = null
+            if (!this.isUnmounted) {
+                this.setState({ preview: { sticker, rect } })
+            }
+        }, STICKER_PREVIEW_DELAY)
+    }
+
+    // 离开贴纸网格或点击发送后隐藏放大预览，并清掉尚未浮出的延时。
+    private hideStickerPreview = () => {
+        if (this.previewTimer) {
+            clearTimeout(this.previewTimer)
+            this.previewTimer = null
+        }
+        if (this.state.preview) {
+            this.setState({ preview: null })
+        }
+    }
+
+    // 把放大卡片定位并夹进视口（口径同 computePanelPos）：水平以格子中心对齐；垂直优先浮在
+    // 格子上方（保留格子与删除「×」可见），上方空间不足则翻到格子下方，最后统一夹进视口。
+    private computeStickerPreviewStyle(rect: DOMRect): React.CSSProperties {
+        const vw = typeof window !== "undefined" ? window.innerWidth : STICKER_PREVIEW_SIZE
+        const vh = typeof window !== "undefined" ? window.innerHeight : STICKER_PREVIEW_SIZE
+        const size = STICKER_PREVIEW_SIZE
+        const m = STICKER_PREVIEW_MARGIN
+        const left = Math.max(m, Math.min(rect.left + rect.width / 2 - size / 2, vw - size - m))
+        let top = rect.top - STICKER_PREVIEW_GAP - size
+        if (top < m) {
+            top = rect.bottom + STICKER_PREVIEW_GAP
+        }
+        top = Math.max(m, Math.min(top, vh - size - m))
+        return { left, top, width: size, height: size }
+    }
+
     render(): React.ReactNode {
-        const { emojis, category, stickers, uploading } = this.state
+        const { emojis, category, stickers, uploading, preview } = this.state
         const { onEmoji, onSticker } = this.props
         // stickerCustomEnabled 关闭时: 隐藏贴纸 tab, 并把 isSticker 强制视为 false, 兜住
         // 「面板已打开且当前在 sticker tab, 后端灰度关掉开关」的边界——避免 tab 消失但
@@ -387,9 +455,19 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         const stickerCustomEnabled = WKApp.remoteConfig.stickerCustomEnabled
         const stickerUploadLimits = WKApp.remoteConfig.stickerUploadLimits
         const isSticker = stickerCustomEnabled && category === STICKER_CATEGORY
+        // 放大预览层 portal 到 <body>，逃出 .wk-emojipanel-content 的 overflow:hidden 裁剪，
+        // 并盖过面板（面板 z-index:999）。pointer-events:none（见 CSS）保证不拦截点击即发送。
+        const previewOverlay = isSticker && preview && typeof document !== "undefined"
+            ? ReactDOM.createPortal(
+                <div className="wk-sticker-preview" style={this.computeStickerPreviewStyle(preview.rect)}>
+                    {this.renderStickerMedia(preview.sticker)}
+                </div>,
+                document.body
+            )
+            : null
         return <div className="wk-emojipanel">
             <div className={classNames("wk-emojipanel-content", isSticker ? "wk-emojipanel-content-sticker" : undefined)}>
-                <ul>
+                <ul onMouseLeave={this.hideStickerPreview}>
                     {
                         !isSticker ? emojis.map((emoji, i) => {
                             return <li key={i} onClick={(e) => {
@@ -418,8 +496,11 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
                     }
                     {
                         isSticker ? stickers.map((sticker) => {
-                            return <li key={sticker.sticker_id} className="wk-sticker-item" onClick={(e) => {
+                            return <li key={sticker.sticker_id} className="wk-sticker-item"
+                                onMouseEnter={(e) => this.scheduleStickerPreview(sticker, e.currentTarget)}
+                                onClick={(e) => {
                                 e.stopPropagation()
+                                this.hideStickerPreview()
                                 if (onSticker) {
                                     onSticker(sticker)
                                 }
@@ -469,6 +550,7 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
                 accept={stickerUploadLimits.allowedFormats.join(",")}
                 style={{ display: "none" }}
             />
+            {previewOverlay}
         </div>
     }
 }

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -321,7 +321,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
             }
         }).catch(() => {
             if (!this.isUnmounted) {
-                this.setState({ stickers: [] })
+                // 失败分支把 stickers 清空，等于「新列表里不含任何 sticker_id」——和成功分支
+                // 同一类残影，正在显示的预览必然指向一个已经不在（空）列表里的贴纸，一并清掉。
+                this.setState({ stickers: [], preview: null })
             }
         })
     }

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -249,7 +249,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         // 缩放后该 rect 会失真，而滚动不冒泡、也不触发 <ul> 的 mouseleave，卡片会悬在旧
         // 坐标、盖到错的贴纸上。捕获阶段监听任意滚动 + resize，一发生就隐藏预览（最简且
         // 正确，下次 hover 自然重新浮出）。
-        window.addEventListener("scroll", this.hideStickerPreview, true)
+        // passive: true — 这个监听器只读、从不 preventDefault，标记 passive 让浏览器不用
+        // 等它跑完就能开始滚动，避免不必要的滚动卡顿。
+        window.addEventListener("scroll", this.hideStickerPreview, { capture: true, passive: true })
         window.addEventListener("resize", this.hideStickerPreview)
         // 贴纸列表延迟到首次切到「我的贴纸」tab 时再拉（ensureStickersLoaded），
         // 避免每次打开表情面板都打一次 sticker/user 请求（PR#496 review P2-1）。
@@ -261,7 +263,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         WKApp.mittBus.off("stickers-updated", this._onStickersUpdated)
         this.removeConfigChangeListener?.()
         this.removeConfigChangeListener = undefined
-        window.removeEventListener("scroll", this.hideStickerPreview, true)
+        // removeEventListener 按 capture 标志匹配（passive 不参与匹配），{capture:true} 与
+        // 注册时的 {capture:true, passive:true} 匹配一致。
+        window.removeEventListener("scroll", this.hideStickerPreview, { capture: true })
         window.removeEventListener("resize", this.hideStickerPreview)
         if (this.previewTimer) {
             clearTimeout(this.previewTimer)
@@ -303,7 +307,17 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         return WKApp.dataSource.commonDataSource.userStickers().then((result) => {
             this.stickersLoaded = true
             if (!this.isUnmounted) {
-                this.setState({ stickers: result.list || [] })
+                const list = result.list || []
+                this.setState((prev) => ({
+                    stickers: list,
+                    // 后台刷新（如「stickers-updated」广播）可能悄悄把正在 hover 预览的那张
+                    // 贴纸移除/替换掉，而指针并没有移动去触发任何 hide 路径——预览会滞留、
+                    // 展示一张已经不存在的贴纸。新列表里已经找不到该 sticker_id 时一并清掉，
+                    // 和 onDelete 是同一类残影，只是触发源不同。
+                    preview: prev.preview && !list.some((s) => s.sticker_id === prev.preview!.sticker.sticker_id)
+                        ? null
+                        : prev.preview,
+                }))
             }
         }).catch(() => {
             if (!this.isUnmounted) {
@@ -431,7 +445,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         }
         this.previewTimer = setTimeout(() => {
             this.previewTimer = null
-            if (!this.isUnmounted) {
+            // 延时排队期间贴纸列表也可能刷新掉这张（同 requestStickers 里的残影修复），
+            // fire 时再核对一次，避免浮出一张已经不存在的贴纸。
+            if (!this.isUnmounted && this.state.stickers.some((s) => s.sticker_id === sticker.sticker_id)) {
                 this.setState({ preview: { sticker, rect } })
             }
         }, STICKER_PREVIEW_DELAY)
@@ -490,7 +506,7 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         // 并盖过面板（面板 z-index:999）。pointer-events:none（见 CSS）保证不拦截点击即发送。
         const previewOverlay = isSticker && preview && typeof document !== "undefined"
             ? ReactDOM.createPortal(
-                <div className="wk-sticker-preview" style={this.computeStickerPreviewStyle(preview.rect)}>
+                <div className="wk-sticker-preview" style={this.computeStickerPreviewStyle(preview.rect)} aria-hidden="true">
                     {/* key 按 sticker_id：切换目标时重建媒体元素，避免复用同一 <tgs-player>、
                         只换 src 时 Lottie 动画不重启（沿用 renderStickerMedia 的分流）。 */}
                     {React.cloneElement(

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -245,6 +245,12 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         this.removeConfigChangeListener = WKApp.remoteConfig.addConfigChangeListener(
             this._onRemoteConfigChange
         )
+        // 放大预览用 hover 那一刻捕获的格子 rect 做 position:fixed 定位；网格滚动或窗口
+        // 缩放后该 rect 会失真，而滚动不冒泡、也不触发 <ul> 的 mouseleave，卡片会悬在旧
+        // 坐标、盖到错的贴纸上。捕获阶段监听任意滚动 + resize，一发生就隐藏预览（最简且
+        // 正确，下次 hover 自然重新浮出）。
+        window.addEventListener("scroll", this.hideStickerPreview, true)
+        window.addEventListener("resize", this.hideStickerPreview)
         // 贴纸列表延迟到首次切到「我的贴纸」tab 时再拉（ensureStickersLoaded），
         // 避免每次打开表情面板都打一次 sticker/user 请求（PR#496 review P2-1）。
     }
@@ -255,6 +261,8 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         WKApp.mittBus.off("stickers-updated", this._onStickersUpdated)
         this.removeConfigChangeListener?.()
         this.removeConfigChangeListener = undefined
+        window.removeEventListener("scroll", this.hideStickerPreview, true)
+        window.removeEventListener("resize", this.hideStickerPreview)
         if (this.previewTimer) {
             clearTimeout(this.previewTimer)
             this.previewTimer = null
@@ -280,6 +288,11 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     private _onRemoteConfigChange = () => {
         if (this.isUnmounted) {
             return
+        }
+        // 灰度关掉自定义贴纸时，顺手清掉可能仍在显示的放大预览——面板常驻不卸载，否则
+        // stale preview 状态会跨这次 tab 消失继续留着。
+        if (!WKApp.remoteConfig.stickerCustomEnabled) {
+            this.hideStickerPreview()
         }
         // 开关值直接从 WKApp.remoteConfig 读取, 用 forceUpdate 触发 render 拾取最新值。
         // 不需要拷贝到 state, 避免 state 与 remoteConfig 双源不一致。
@@ -378,6 +391,9 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
 
     onDelete = (e: React.MouseEvent, sticker: StickerItem) => {
         e.stopPropagation()
+        // × 的 onClick stopPropagation 会绕过 <li> 的 hideStickerPreview，删掉正在 hover 的
+        // 那张贴纸后预览会残留在空位上（还会短暂渲染一张已不存在的贴纸），先清掉。
+        this.hideStickerPreview()
         WKApp.dataSource.commonDataSource.deleteSticker(sticker.sticker_id).then(() => {
             this.requestStickers()
         }).catch(() => {
@@ -404,12 +420,14 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     // 卡片按格子中心定位。
     private scheduleStickerPreview = (sticker: StickerItem, target: HTMLElement) => {
         const rect = target.getBoundingClientRect()
+        // 先清掉可能仍在排队的旧延时，避免它稍后 fire 用旧 sticker/rect 覆盖更新的目标。
+        if (this.previewTimer) {
+            clearTimeout(this.previewTimer)
+            this.previewTimer = null
+        }
         if (this.state.preview) {
             this.setState({ preview: { sticker, rect } })
             return
-        }
-        if (this.previewTimer) {
-            clearTimeout(this.previewTimer)
         }
         this.previewTimer = setTimeout(() => {
             this.previewTimer = null
@@ -430,13 +448,26 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         }
     }
 
+    // 离开某张贴纸格子：移到另一张贴纸时不隐藏（让它的 onMouseEnter 无缝切换目标，保留
+    // Discord 式跟随）；移到「+」号 / 网格空白内边距 / 网格外等非贴纸目标时隐藏——否则指针
+    // 虽已不在任何贴纸上、但仍在 <ul> 内，<ul> 的 mouseleave 不触发，预览会滞留在空位上。
+    private onStickerLeave = (e: React.MouseEvent) => {
+        const related = e.relatedTarget
+        if (related instanceof Element && related.closest(".wk-sticker-item")) {
+            return
+        }
+        this.hideStickerPreview()
+    }
+
     // 把放大卡片定位并夹进视口（口径同 computePanelPos）：水平以格子中心对齐；垂直优先浮在
     // 格子上方（保留格子与删除「×」可见），上方空间不足则翻到格子下方，最后统一夹进视口。
     private computeStickerPreviewStyle(rect: DOMRect): React.CSSProperties {
         const vw = typeof window !== "undefined" ? window.innerWidth : STICKER_PREVIEW_SIZE
         const vh = typeof window !== "undefined" ? window.innerHeight : STICKER_PREVIEW_SIZE
-        const size = STICKER_PREVIEW_SIZE
         const m = STICKER_PREVIEW_MARGIN
+        // 小视口兜底：卡片边长不超过可用视口，避免极窄/极矮窗口下夹取退化后仍溢出、盖住
+        // 格子与删除「×」。正常面板尺寸下就是 STICKER_PREVIEW_SIZE。
+        const size = Math.max(0, Math.min(STICKER_PREVIEW_SIZE, vw - 2 * m, vh - 2 * m))
         const left = Math.max(m, Math.min(rect.left + rect.width / 2 - size / 2, vw - size - m))
         let top = rect.top - STICKER_PREVIEW_GAP - size
         if (top < m) {
@@ -460,7 +491,12 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         const previewOverlay = isSticker && preview && typeof document !== "undefined"
             ? ReactDOM.createPortal(
                 <div className="wk-sticker-preview" style={this.computeStickerPreviewStyle(preview.rect)}>
-                    {this.renderStickerMedia(preview.sticker)}
+                    {/* key 按 sticker_id：切换目标时重建媒体元素，避免复用同一 <tgs-player>、
+                        只换 src 时 Lottie 动画不重启（沿用 renderStickerMedia 的分流）。 */}
+                    {React.cloneElement(
+                        this.renderStickerMedia(preview.sticker) as React.ReactElement,
+                        { key: preview.sticker.sticker_id }
+                    )}
                 </div>,
                 document.body
             )
@@ -498,6 +534,7 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
                         isSticker ? stickers.map((sticker) => {
                             return <li key={sticker.sticker_id} className="wk-sticker-item"
                                 onMouseEnter={(e) => this.scheduleStickerPreview(sticker, e.currentTarget)}
+                                onMouseLeave={this.onStickerLeave}
                                 onClick={(e) => {
                                 e.stopPropagation()
                                 this.hideStickerPreview()
@@ -524,6 +561,7 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
             <div className="wk-emojipanel-tab">
                 <div className={classNames("wk-emojipanel-tab-item", !isSticker ? "wk-emojipanel-tab-item-selected" : undefined)} onClick={(e) => {
                     e.stopPropagation()
+                    this.hideStickerPreview()
                     this.setState({ category: "emoji" })
                 }}>
                     <img alt="" src={require("./emoji_tab_icon.png")}></img>


### PR DESCRIPTION
## Summary

The 60px sticker thumbnails in the "我的贴纸" (My Stickers) panel are too small to make out complex sticker artwork, so users can't tell what they're about to send. This adds a Discord-style hover preview: hovering a sticker floats an enlarged (140px) rounded card above the cell so it can be seen clearly before sending. Click-to-send behavior is unchanged.

## Related Issue

Closes #587

## Changes

- `EmojiPanel` now tracks a `preview` state and renders an enlarged sticker card on hover.
- The preview is portaled to `<body>` via `ReactDOM.createPortal` (`position: fixed`, clamped to the viewport) so it escapes `.wk-emojipanel-content`'s `overflow: hidden` and is never clipped; `z-index: 1002` keeps it above the panel (`999`).
- The card floats **above** the hovered cell (flipping below when there's no room) and uses `pointer-events: none`, so it never covers the hover-revealed delete "×" and never interrupts click-to-send.
- A short show delay (120ms) prevents flicker while sweeping across the grid; once visible, moving between stickers swaps the target seamlessly. The pending timer is cleared on unmount.
- New CSS: `.wk-sticker-preview` (card, shadow, fade-in animation) with a dark-mode variant.

Touched files: `packages/dmworkbase/src/Components/EmojiToolbar/{index.tsx,index.css}` and its `__tests__/EmojiPanel.test.tsx`.

## Testing

- **Unit tests:** added 3 cases (preview appears after the hover delay, hides on grid leave, timer cleared on unmount without throwing). `pnpm test` → **24/24 passing** in `EmojiPanel.test.tsx`.
- **Browser verification:** rendered the real `EmojiPanel` + real `index.css` in headless Chromium and drove the hover with Playwright. Runtime assertions confirmed the preview image is **120px vs the 60px thumbnail**, `position: fixed`, `z-index: 1002`, `pointer-events: none`, and portaled to `<body>`. Verified in both light and dark themes; the delete "×" stays visible and the card overflows past the panel's top edge (portal escapes the clip).
- `stylelint` on the CSS passes (0 errors).

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation (N/A — no doc changes needed)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy (no new UI copy / i18n keys — the preview is image-only)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqK7GsbQNc77pFQ3Gis3Zq