### PR TITLE
fix(export): preserve image aspect ratio in DOCX export

### DIFF
--- a/packages/docs/src/export/docx/images.test.ts
+++ b/packages/docs/src/export/docx/images.test.ts
@@ -9,7 +9,7 @@
  * egress and remain the legitimate inline-image case.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { resolveAndFetchImages } from './images.ts'
+import { resolveAndFetchImages, readIntrinsicSize, getImageDimensions } from './images.ts'
 import type { MdNode } from './types.ts'
 import type { resolveAttachments } from '../../attachments/api.ts'
 
@@ -77,5 +77,120 @@ describe('resolveAndFetchImages — raw src SSRF gating', () => {
       await resolveAndFetchImages('d1', imageDoc(bad), { resolve: noopResolve })
     }
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+// --- Intrinsic dimension parsing ---------------------------------------------
+
+/** Build a minimal PNG buffer with the given IHDR width/height. */
+function pngOf(w: number, h: number): ArrayBuffer {
+  const buf = new Uint8Array(24)
+  buf.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0)
+  const dv = new DataView(buf.buffer)
+  dv.setUint32(16, w, false)
+  dv.setUint32(20, h, false)
+  return buf.buffer
+}
+
+/** Build a minimal GIF87a/89a header with the given logical screen size. */
+function gifOf(w: number, h: number): ArrayBuffer {
+  const buf = new Uint8Array(10)
+  buf.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0) // 'GIF89a'
+  const dv = new DataView(buf.buffer)
+  dv.setUint16(6, w, true)
+  dv.setUint16(8, h, true)
+  return buf.buffer
+}
+
+/** Build a minimal BMP with BITMAPINFOHEADER width/height. */
+function bmpOf(w: number, h: number): ArrayBuffer {
+  const buf = new Uint8Array(26)
+  buf.set([0x42, 0x4d], 0) // 'BM'
+  const dv = new DataView(buf.buffer)
+  dv.setInt32(18, w, true)
+  dv.setInt32(22, h, true)
+  return buf.buffer
+}
+
+/** Build a minimal JPEG: SOI + a SOF0 segment carrying height/width. */
+function jpegOf(w: number, h: number): ArrayBuffer {
+  // FFD8 (SOI) | FFC0 (SOF0) | len=0x0011 | prec | height | width | ...
+  const buf = new Uint8Array(20)
+  const dv = new DataView(buf.buffer)
+  buf[0] = 0xff
+  buf[1] = 0xd8
+  buf[2] = 0xff
+  buf[3] = 0xc0
+  dv.setUint16(4, 0x0011, false) // segment length
+  buf[6] = 8 // sample precision
+  dv.setUint16(7, h, false) // height at marker+5
+  dv.setUint16(9, w, false) // width at marker+7
+  return buf.buffer
+}
+
+describe('readIntrinsicSize', () => {
+  it('reads PNG IHDR dimensions', () => {
+    expect(readIntrinsicSize(pngOf(1920, 1080))).toEqual({ width: 1920, height: 1080 })
+  })
+  it('reads GIF logical screen dimensions', () => {
+    expect(readIntrinsicSize(gifOf(320, 240))).toEqual({ width: 320, height: 240 })
+  })
+  it('reads BMP header dimensions (abs height for top-down)', () => {
+    expect(readIntrinsicSize(bmpOf(800, -600))).toEqual({ width: 800, height: 600 })
+  })
+  it('reads JPEG SOF0 dimensions', () => {
+    expect(readIntrinsicSize(jpegOf(1024, 768))).toEqual({ width: 1024, height: 768 })
+  })
+  it('returns undefined for unrecognized/short bytes', () => {
+    expect(readIntrinsicSize(new Uint8Array([0x00, 0x01]).buffer)).toBeUndefined()
+    expect(readIntrinsicSize(new Uint8Array([0x12, 0x34, 0x56, 0x78]).buffer)).toBeUndefined()
+  })
+})
+
+describe('getImageDimensions — aspect ratio preservation', () => {
+  const img = (attrs: Record<string, unknown> = {}): MdNode =>
+    ({ type: 'image', attrs }) as MdNode
+
+  it('derives height from intrinsic ratio when no width attr (under cap)', () => {
+    // 16:9 image under the 600 cap -> use intrinsic size as-is
+    expect(getImageDimensions(img(), pngOf(480, 270))).toEqual({ width: 480, height: 270 })
+  })
+
+  it('caps intrinsic width over 600 while keeping ratio', () => {
+    // 16:9 image at 1600 wide -> capped to 600, height 338 (ratio preserved)
+    expect(getImageDimensions(img(), pngOf(1600, 900))).toEqual({ width: 600, height: 338 })
+  })
+
+  it('scales height to the true ratio when width attr is set', () => {
+    // stored width 300, intrinsic 1600x900 (ratio 0.5625) -> height 169
+    expect(getImageDimensions(img({ width: 300 }), pngOf(1600, 900))).toEqual({
+      width: 300,
+      height: 169,
+    })
+  })
+
+  it('caps width at 600 and keeps the ratio (no flattening)', () => {
+    // intrinsic 4000x1000 (4:1), no width attr -> cap 600, height 150
+    expect(getImageDimensions(img(), pngOf(4000, 1000))).toEqual({ width: 600, height: 150 })
+  })
+
+  it('does NOT force a 4:3 box for a tall image (regression: “扁了”)', () => {
+    // Portrait 600x1200 (1:2). Old code fell back to 400x300 (landscape) and
+    // squished it flat; now height must exceed width.
+    const d = getImageDimensions(img(), pngOf(600, 1200))
+    expect(d.height).toBeGreaterThan(d.width)
+    expect(d).toEqual({ width: 600, height: 1200 })
+  })
+
+  it('falls back to default box when buffer is undefined and no attrs', () => {
+    expect(getImageDimensions(img())).toEqual({ width: 400, height: 300 })
+  })
+
+  it('uses attr width+height ratio when buffer unreadable', () => {
+    // no buffer, but both attrs present -> derive from attr ratio
+    expect(getImageDimensions(img({ width: 200, height: 100 }))).toEqual({
+      width: 200,
+      height: 100,
+    })
   })
 })

--- a/packages/docs/src/export/docx/images.ts
+++ b/packages/docs/src/export/docx/images.ts
@@ -194,32 +194,147 @@ export function getImageBuffer(node: MdNode, ctx: DocxContext): ArrayBuffer | un
   return undefined
 }
 
-/**
- * Guess image dimensions from node attrs or use defaults.
- */
-export function getImageDimensions(node: MdNode): { width: number; height: number } {
-  const width = typeof node.attrs?.width === 'number' ? node.attrs.width : undefined
-  const height = typeof node.attrs?.height === 'number' ? node.attrs.height : undefined
+/** Max rendered image width (px) — keeps images inside the A4 content column. */
+const MAX_IMAGE_WIDTH = 600
+/** Fallback box only used when neither attrs nor the bytes yield a real size. */
+const DEFAULT_IMAGE = { width: 400, height: 300 }
 
-  // Only accept strictly positive, finite dimensions; anything else
-  // (negative, zero, NaN, Infinity) falls back to the default size.
-  if (
-    width &&
-    height &&
-    Number.isFinite(width) &&
-    Number.isFinite(height) &&
-    width > 0 &&
-    height > 0
-  ) {
-    // Cap width at 600px for DOCX page width
-    const maxWidth = 600
-    if (width > maxWidth) {
-      const ratio = maxWidth / width
-      return { width: maxWidth, height: Math.round(height * ratio) }
-    }
-    return { width, height }
+/**
+ * Read the intrinsic pixel dimensions from an encoded image's header bytes.
+ * Supports PNG, JPEG, GIF and BMP (the four types the exporter emits). Returns
+ * undefined when the bytes are too short or the format is unrecognized.
+ *
+ * The editor's ImageNode only persists `width` (resize is width-only, height is
+ * CSS `height:auto` in the browser), so the true aspect ratio is not in the
+ * document model — it must come from the image itself. Without this the export
+ * fell back to a fixed 400x300 box and squished every non-4:3 image flat.
+ */
+export function readIntrinsicSize(
+  buffer: ArrayBuffer,
+): { width: number; height: number } | undefined {
+  const b = new Uint8Array(buffer)
+  if (b.length < 4) return undefined
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A, IHDR width/height are big-endian at bytes 16..23.
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    if (b.length < 24) return undefined
+    const dv = new DataView(buffer)
+    const w = dv.getUint32(16, false)
+    const h = dv.getUint32(20, false)
+    if (w > 0 && h > 0) return { width: w, height: h }
+    return undefined
   }
 
-  // Default image size
-  return { width: 400, height: 300 }
+  // GIF: 'GIF', logical screen width/height are little-endian at bytes 6..9.
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) {
+    if (b.length < 10) return undefined
+    const dv = new DataView(buffer)
+    const w = dv.getUint16(6, true)
+    const h = dv.getUint16(8, true)
+    if (w > 0 && h > 0) return { width: w, height: h }
+    return undefined
+  }
+
+  // BMP: 'BM', BITMAPINFOHEADER width/height are little-endian int32 at bytes 18..25.
+  if (b[0] === 0x42 && b[1] === 0x4d) {
+    if (b.length < 26) return undefined
+    const dv = new DataView(buffer)
+    const w = dv.getInt32(18, true)
+    const h = Math.abs(dv.getInt32(22, true)) // height may be negative (top-down)
+    if (w > 0 && h > 0) return { width: w, height: h }
+    return undefined
+  }
+
+  // JPEG: FF D8, then walk marker segments to the SOF (start-of-frame) which
+  // carries height/width as big-endian uint16 at offsets +5 and +7 from the marker.
+  if (b[0] === 0xff && b[1] === 0xd8) {
+    let offset = 2
+    const dv = new DataView(buffer)
+    while (offset + 9 < b.length) {
+      if (b[offset] !== 0xff) {
+        offset++
+        continue
+      }
+      const marker = b[offset + 1]
+      // Standalone markers (no length): padding 0xFF, RSTn, TEM, EOI.
+      if (marker === 0xff) {
+        offset++
+        continue
+      }
+      if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+        offset += 2
+        continue
+      }
+      const segLen = dv.getUint16(offset + 2, false)
+      if (segLen < 2) return undefined
+      // SOF0..SOF15 except DHT(C4)/DAC(CC)/RSTn — these carry frame dimensions.
+      const isSof =
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc
+      if (isSof) {
+        if (offset + 9 >= b.length) return undefined
+        const h = dv.getUint16(offset + 5, false)
+        const w = dv.getUint16(offset + 7, false)
+        if (w > 0 && h > 0) return { width: w, height: h }
+        return undefined
+      }
+      offset += 2 + segLen
+    }
+    return undefined
+  }
+
+  return undefined
+}
+
+/**
+ * Compute the DOCX render dimensions for an image, preserving aspect ratio.
+ *
+ * Priority for the shape (aspect ratio): the image's intrinsic bytes, since the
+ * editor never stores height. The stored `width` attr (if any) sets the target
+ * display width; otherwise the intrinsic width is used. Result width is capped
+ * at MAX_IMAGE_WIDTH and height is always derived from the true ratio so nothing
+ * gets stretched or flattened.
+ */
+export function getImageDimensions(
+  node: MdNode,
+  buffer?: ArrayBuffer,
+): { width: number; height: number } {
+  const attrWidth =
+    typeof node.attrs?.width === 'number' && Number.isFinite(node.attrs.width) && node.attrs.width > 0
+      ? node.attrs.width
+      : undefined
+  const attrHeight =
+    typeof node.attrs?.height === 'number' &&
+    Number.isFinite(node.attrs.height) &&
+    node.attrs.height > 0
+      ? node.attrs.height
+      : undefined
+
+  const intrinsic = buffer ? readIntrinsicSize(buffer) : undefined
+
+  // Aspect ratio (height / width). Prefer intrinsic bytes; fall back to an
+  // explicit attr pair if both are present; otherwise the default box shape.
+  let ratio: number | undefined
+  if (intrinsic) ratio = intrinsic.height / intrinsic.width
+  else if (attrWidth && attrHeight) ratio = attrHeight / attrWidth
+
+  // Target display width: stored attr, else intrinsic, else default.
+  let width = attrWidth ?? intrinsic?.width ?? DEFAULT_IMAGE.width
+  if (width > MAX_IMAGE_WIDTH) width = MAX_IMAGE_WIDTH
+
+  // If we still have no real ratio, fall back to the legacy default box so we
+  // never emit a zero/NaN dimension.
+  if (!ratio || !Number.isFinite(ratio) || ratio <= 0) {
+    if (attrWidth) {
+      // Have a width but no ratio at all: keep the default box aspect.
+      const defRatio = DEFAULT_IMAGE.height / DEFAULT_IMAGE.width
+      return { width: Math.round(width), height: Math.round(width * defRatio) }
+    }
+    return { ...DEFAULT_IMAGE }
+  }
+
+  return { width: Math.round(width), height: Math.max(1, Math.round(width * ratio)) }
 }

--- a/packages/docs/src/export/docx/nodes.ts
+++ b/packages/docs/src/export/docx/nodes.ts
@@ -366,7 +366,7 @@ function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
     ]
   }
 
-  const dims = getImageDimensions(node)
+  const dims = getImageDimensions(node, buffer)
   // Image uses `align` attr (left/center/right), not `textAlign`
   const align = mapTextAlign(node.attrs?.align)
 


### PR DESCRIPTION
## Summary

Images exported to DOCX were flattened/squished because the exporter fell back to a fixed 400x300 box for almost every image. This restores the true aspect ratio by reading the image's intrinsic dimensions from its encoded bytes.

## Linked Spec

**Goal:** DOCX-exported images keep their original aspect ratio instead of being forced into a fixed 400x300 box.

**Load-bearing:** `packages/docs/src/export/docx/images.ts` (`getImageDimensions`), consumed by `nodes.ts` `convertImage` on the export critical path.

**Out of scope:** the editor's ImageNode data model (intentionally width-only), PDF/Typst export, and the unrelated in-progress import work.

## Root cause

The editor's `ImageNode` persists only `width` (resize is width-only; the browser derives height via CSS `height:auto`), so the document model never carries a real `height`. The old `getImageDimensions` required **both** `width` and `height` to be finite positive numbers before using real dimensions; since `height` is always `null`, that branch never fired and every image fell back to a hardcoded 400x300 (4:3) box. Any non-4:3 image was stretched/flattened.

## What changed

- Add `readIntrinsicSize(buffer)` that parses real pixel dimensions from the encoded image header: PNG (IHDR), JPEG (walk marker segments to SOF), GIF (logical screen), BMP (BITMAPINFOHEADER, abs height for top-down).
- Rework `getImageDimensions(node, buffer)` to derive the aspect ratio from the intrinsic bytes (the buffer is already fetched for embedding), use the stored `width` attr as the target display width (or intrinsic width if absent), cap width at 600px, and compute height from the true ratio. The 400x300 default is only used when neither bytes nor attrs yield a real size.
- `convertImage` now passes the image buffer into `getImageDimensions`.

## COMPREHENSION

1. **What does this change actually do?** Before: exported images used a fixed 400x300 box (wrong aspect ratio for anything not 4:3). After: exported images keep their original aspect ratio, scaled to the stored display width and capped at 600px.
2. **What could break?** Only the DOCX image sizing path. Dependents: `convertImage` in `nodes.ts` (updated to pass the buffer). Failure mode is bounded: if the header can't be parsed and no valid attrs exist, it still falls back to the legacy 400x300 default (never zero/NaN dimensions).
3. **How do you know it works?** New unit tests parse PNG/JPEG/GIF/BMP headers and assert aspect-ratio preservation, including a regression test for a tall (portrait) image that previously got flattened. Full DOCX suite passes 82/82; touched files typecheck clean.

## How verified

- `vitest run src/export/docx/` -> 82/82 passing (images.test.ts grew 5 -> 17 cases: header parsers + aspect-ratio regressions).
- `tsc --noEmit` -> zero errors in `images.ts` / `nodes.ts` (remaining repo baseline errors are pre-existing and unrelated).
