### PR TITLE
fix(dmworkbase): interactive card fold-session grouping + container-style rendering

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/foldSessionFileAttachment.test.ts
@@ -120,6 +120,7 @@ vi.mock("../../../Service/Const", () => ({
         smallVideo: 5,
         file: 8,
         richText: 14,
+        interactiveCard: 17,
         rtcData: 9994,
     },
     OrderFactor: 10000,
@@ -170,6 +171,7 @@ const VOICE = 4
 const SMALL_VIDEO = 5
 const FILE = 8
 const RICH_TEXT = 14
+const INTERACTIVE_CARD = 17
 
 function humanMessage(contentType: number, timestamp: number, fromUID: string = "alice") {
     const messageSeq = seqCounter++
@@ -199,6 +201,7 @@ describe("ConversationVM fold session file attachment", () => {
         { name: "smallVideo", contentType: SMALL_VIDEO },
         { name: "file", contentType: FILE },
         { name: "richText", contentType: RICH_TEXT },
+        { name: "interactiveCard", contentType: INTERACTIVE_CARD },
     ])("does not fold a bot $name message (contentType=$contentType) into a fold session", ({ contentType }) => {
         const vm = new ConversationVM(channel)
         const messages = [
@@ -332,6 +335,47 @@ describe("ConversationVM fold session file attachment", () => {
         expect((items[0] as any).session.count).toBe(2)
         expect(items[1].type).toBe("message")
         expect((items[1] as any).message.contentType).toBe(IMAGE)
+        expect(items[2].type).toBe("foldSession")
+        expect((items[2] as any).session.count).toBe(2)
+    })
+
+    // --- Interactive card (type-17) must stay interactive: never folded ---
+
+    it("keeps an interactive card standalone when followed by a bot command-result message", () => {
+        const vm = new ConversationVM(channel)
+        // Mirrors the reported bug: a card ("确认部署?") + a command-result text
+        // were folded together into "收起2条讨论", hiding the card's buttons.
+        const messages = [
+            botMessage(INTERACTIVE_CARD, 100),
+            botMessage(TEXT, 110),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.every((item) => item.type === "message")).toBe(true)
+        expect(items.map((item) => (item as any).message.contentType)).toEqual([
+            INTERACTIVE_CARD,
+            TEXT,
+        ])
+    })
+
+    it("breaks a fold group when an interactive card sits between bot text messages", () => {
+        const vm = new ConversationVM(channel)
+        const messages = [
+            botMessage(TEXT, 100),
+            botMessage(TEXT, 110),
+            botMessage(INTERACTIVE_CARD, 120),
+            botMessage(TEXT, 130),
+            botMessage(TEXT, 140),
+        ]
+
+        const items = vm.buildRenderItems(messages)
+
+        expect(items.length).toBe(3)
+        expect(items[0].type).toBe("foldSession")
+        expect((items[0] as any).session.count).toBe(2)
+        expect(items[1].type).toBe("message")
+        expect((items[1] as any).message.contentType).toBe(INTERACTIVE_CARD)
         expect(items[2].type).toBe("foldSession")
         expect((items[2] as any).session.count).toBe(2)
     })

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -290,16 +290,19 @@ export default class ConversationVM extends ProviderListener {
         return channelInfo?.orgData?.robot === 1
     }
 
-    // 是否为带附件的消息（图片/GIF/小视频/文件/富文本）。
-    // 这类消息是用户需要直接看到的交付物，不应被折叠进 FoldSessionCard。
+    // 不可折叠的独立交付物：带附件的消息（图片/GIF/小视频/文件/富文本）
+    // 以及互动卡片（interactiveCard=17）。
+    // 这类消息是用户需要直接看到、直接操作的交付物，不应被折叠进 FoldSessionCard
+    // ——尤其互动卡片带按钮/输入，一旦被折叠就无法交互。
     // 注意：语音（voice=4）可以折叠，故不在此列。
-    private hasFileAttachment(message: MessageWrap): boolean {
+    private isUnfoldableDeliverable(message: MessageWrap): boolean {
         switch (message.contentType) {
             case MessageContentTypeConst.image:
             case MessageContentTypeConst.gif:
             case MessageContentTypeConst.smallVideo:
             case MessageContentTypeConst.file:
             case MessageContentTypeConst.richText:
+            case MessageContentTypeConst.interactiveCard:
                 return true
             default:
                 return false
@@ -405,9 +408,9 @@ export default class ConversationVM extends ProviderListener {
 
         for (const message of sourceMessages) {
             if (this.isBotMessage(message)) {
-                // 带附件的 bot 消息作为折叠分组的边界：先 flush 当前分组，再独立渲染，
-                // 保证图片/文件等交付物始终可见，无需展开折叠卡片。
-                if (this.hasFileAttachment(message)) {
+                // 带附件的 bot 消息 / 互动卡片作为折叠分组的边界：先 flush 当前分组，再独立渲染，
+                // 保证图片/文件/卡片等交付物始终可见，无需展开折叠卡片。
+                if (this.isUnfoldableDeliverable(message)) {
                     flushPendingSession(false)
                     renderItems.push({ type: "message", message })
                     continue

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/ImageRenderer.css
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/ImageRenderer.css
@@ -120,7 +120,7 @@
   gap: var(--wk-sp-3);
   color: var(--wk-text-tertiary);
   font-size: var(--wk-text-size-md);
-  background: var(--wk-bg-subtle);
+  background: var(--wk-bg-elevated);
   border-radius: var(--wk-r-md);
 }
 
@@ -161,5 +161,5 @@ body[theme-mode="dark"] .wk-file-preview-image-renderer {
 }
 
 body[theme-mode="dark"] .wk-file-preview-image-renderer__error {
-  background: var(--wk-bg-subtle);
+  background: var(--wk-bg-elevated);
 }

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.css
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/VideoRenderer.css
@@ -32,7 +32,7 @@
   gap: var(--wk-sp-3);
   color: var(--wk-text-tertiary);
   font-size: var(--wk-text-size-md);
-  background: var(--wk-bg-subtle);
+  background: var(--wk-bg-elevated);
   border-radius: var(--wk-r-md);
 }
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/columnWidth.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/columnWidth.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+//
+// SDK 契约金丝雀：Column.width 数字权重 → flex-basis 百分比。
+// 排查「卡片三列比例失效」时实证：AC 3.0.6 把 width:3/1/1 渲染为 flex 1 1 60%/20%/20%，
+// 权重本就生效；此前的「等宽」错觉源于 Container.style 填色缺失、列边界不可见。
+// 锁定此行为，防止 SDK 升级后数字权重支持漂移。
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { AdaptiveCard, HostConfig } from "adaptivecards";
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    (window as any).matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+    });
+  }
+  AdaptiveCard.onProcessMarkdown = (text, result) => {
+    result.outputHtml = text;
+    result.didProcess = true;
+  };
+});
+
+function renderColumnWidths(widths: Array<number | string>): string[] {
+  const card = new AdaptiveCard();
+  card.hostConfig = new HostConfig({});
+  card.parse({
+    type: "AdaptiveCard",
+    version: "1.5",
+    body: [
+      {
+        type: "ColumnSet",
+        columns: widths.map((width) => ({
+          type: "Column",
+          width,
+          items: [{ type: "TextBlock", text: String(width) }],
+        })),
+      },
+    ],
+  });
+  const el = card.render();
+  if (!el) throw new Error("card did not render");
+  const columns = Array.from(
+    el.querySelectorAll<HTMLElement>(".ac-columnSet > .ac-container")
+  );
+  return columns.map((c) => c.style.flexBasis);
+}
+
+describe("Column.width 数字权重契约", () => {
+  it("width 3/1/1 渲染为 60%/20%/20% 的 flex-basis", () => {
+    expect(renderColumnWidths([3, 1, 1])).toEqual(["60%", "20%", "20%"]);
+  });
+
+  it("width 1/1/1 渲染为等宽 33.333%", () => {
+    const bases = renderColumnWidths([1, 1, 1]);
+    for (const b of bases) {
+      expect(b.startsWith("33.33")).toBe(true);
+    }
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/containerFillRender.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/containerFillRender.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// config→render 集成测试：验证 buildOctoHostConfig 产出的 containerStyles 背景填色
+// 真正被官方 SDK 落到 DOM（AC 3.0.6 applyBackground 写为 .ac-container 的 inline
+// background-color）。补足 octoSdkConfig.test.ts 的 config-object 层断言之外、
+// 「填色是否真的渲染出来」的盲区（review #590 建议）。
+//
+// 用注入 stub resolver 提供确定色值——jsdom 不解析 var(--wk-*)，故不能用
+// browserCssVarResolver；这与 octoSdkConfig.test.ts 的做法一致。
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { AdaptiveCard } from "adaptivecards";
+import { buildOctoHostConfig } from "../sdk/octoHostConfig";
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    (window as any).matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+    });
+  }
+  AdaptiveCard.onProcessMarkdown = (text, result) => {
+    result.outputHtml = text;
+    result.didProcess = true;
+  };
+});
+
+const STUB: Record<string, string> = {
+  "var(--wk-text-primary)": "rgb(10, 10, 10)",
+  "var(--wk-text-secondary)": "rgb(120, 120, 120)",
+  "var(--wk-text-accent)": "rgb(30, 100, 255)",
+  "var(--wk-bg-surface)": "rgb(255, 255, 255)",
+  "var(--wk-bg-elevated)": "rgb(245, 245, 245)",
+  "var(--wk-accent-tint-10)": "rgb(230, 240, 255)",
+  "var(--wk-color-success)": "rgb(0, 150, 0)",
+  "var(--wk-color-success-bg)": "rgb(230, 250, 230)",
+  "var(--wk-color-warning)": "rgb(200, 150, 0)",
+  "var(--wk-color-warning-bg)": "rgb(255, 250, 230)",
+  "var(--wk-color-danger)": "rgb(200, 0, 0)",
+  "var(--wk-color-danger-bg)": "rgb(255, 235, 235)",
+};
+
+// 按 body 顺序：每个 Container.style → 期望渲染出的 inline background-color。
+const CASES: Array<{ style: string; bg: string }> = [
+  { style: "emphasis", bg: "rgb(245, 245, 245)" },
+  { style: "accent", bg: "rgb(230, 240, 255)" },
+  { style: "good", bg: "rgb(230, 250, 230)" },
+  { style: "warning", bg: "rgb(255, 250, 230)" },
+  { style: "attention", bg: "rgb(255, 235, 235)" },
+];
+
+describe("Container.style 填色渲染到 DOM（config→render）", () => {
+  it("五种 containerStyle 各自的背景色被渲染为 .ac-container 的 inline background-color", () => {
+    const card = new AdaptiveCard();
+    card.hostConfig = buildOctoHostConfig((expr) => STUB[expr] ?? expr);
+    card.parse({
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: CASES.map((c) => ({
+        type: "Container",
+        style: c.style,
+        items: [{ type: "TextBlock", text: c.style }],
+      })),
+    });
+
+    const el = card.render();
+    expect(el).not.toBeNull();
+
+    const containers = el!.querySelectorAll<HTMLElement>(".ac-container");
+    expect(containers.length).toBe(CASES.length);
+    CASES.forEach((c, i) => {
+      expect(containers[i].style.backgroundColor).toBe(c.bg);
+    });
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -62,7 +62,6 @@ describe("buildOctoHostConfig — --wk-* 颜色映射", () => {
         "var(--wk-text-accent)": "rgb(30, 100, 255)",
         "var(--wk-bg-surface)": "rgb(255, 255, 255)",
         "var(--wk-bg-elevated)": "rgb(245, 245, 245)",
-        "var(--wk-border-default)": "rgb(220, 220, 220)",
         "var(--wk-accent-tint-10)": "rgb(230, 240, 255)",
         "var(--wk-color-success)": "rgb(0, 150, 0)",
         "var(--wk-color-success-bg)": "rgb(230, 250, 230)",
@@ -91,13 +90,12 @@ describe("buildOctoHostConfig — --wk-* 颜色映射", () => {
     expect(hc.supportsInteractivity).toBe(true);
   });
 
-  it("emphasis 有区别于 default 的背景填色 + 边框（灰底可见）", () => {
+  it("emphasis 有区别于 default 的背景填色（灰底可见）", () => {
     const hc = buildOctoHostConfig(buildStubResolver());
     const emphasis = hc.containerStyles.getStyleByName("emphasis");
     const def = hc.containerStyles.getStyleByName("default");
     expect(emphasis.backgroundColor).toBe("rgb(245, 245, 245)");
     expect(emphasis.backgroundColor).not.toBe(def.backgroundColor);
-    expect(emphasis.borderColor).toBe("rgb(220, 220, 220)");
   });
 
   it("accent 容器有蓝色 badge 底（不再裸露成白底）", () => {

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -54,18 +54,30 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
 });
 
 describe("buildOctoHostConfig — --wk-* 颜色映射", () => {
-  it("用注入解析器解析语义色，产出 HostConfig 实例", () => {
-    const resolve = vi.fn((expr: string) => {
+  const buildStubResolver = () =>
+    vi.fn((expr: string) => {
       const map: Record<string, string> = {
         "var(--wk-text-primary)": "rgb(10, 10, 10)",
         "var(--wk-text-secondary)": "rgb(120, 120, 120)",
         "var(--wk-text-accent)": "rgb(30, 100, 255)",
         "var(--wk-bg-surface)": "rgb(255, 255, 255)",
+        "var(--wk-bg-elevated)": "rgb(245, 245, 245)",
+        "var(--wk-border-default)": "rgb(220, 220, 220)",
+        "var(--wk-accent-tint-10)": "rgb(230, 240, 255)",
+        "var(--wk-color-success)": "rgb(0, 150, 0)",
+        "var(--wk-color-success-bg)": "rgb(230, 250, 230)",
+        "var(--wk-color-warning)": "rgb(200, 150, 0)",
+        "var(--wk-color-warning-bg)": "rgb(255, 250, 230)",
+        "var(--wk-color-danger)": "rgb(200, 0, 0)",
+        "var(--wk-color-danger-bg)": "rgb(255, 235, 235)",
       };
       return map[expr] ?? expr;
     });
+
+  it("用注入解析器解析语义色，产出 HostConfig 实例", () => {
+    const resolve = buildStubResolver();
     const hc = buildOctoHostConfig(resolve);
-    // 四个语义色都被解析。
+    // 四个基础语义色都被解析。
     expect(resolve).toHaveBeenCalledWith("var(--wk-text-primary)");
     expect(resolve).toHaveBeenCalledWith("var(--wk-text-secondary)");
     expect(resolve).toHaveBeenCalledWith("var(--wk-text-accent)");
@@ -78,4 +90,35 @@ describe("buildOctoHostConfig — --wk-* 颜色映射", () => {
     expect(style.foregroundColors.accent.default).toBe("rgb(30, 100, 255)");
     expect(hc.supportsInteractivity).toBe(true);
   });
+
+  it("emphasis 有区别于 default 的背景填色 + 边框（灰底可见）", () => {
+    const hc = buildOctoHostConfig(buildStubResolver());
+    const emphasis = hc.containerStyles.getStyleByName("emphasis");
+    const def = hc.containerStyles.getStyleByName("default");
+    expect(emphasis.backgroundColor).toBe("rgb(245, 245, 245)");
+    expect(emphasis.backgroundColor).not.toBe(def.backgroundColor);
+    expect(emphasis.borderColor).toBe("rgb(220, 220, 220)");
+  });
+
+  it("accent 容器有蓝色 badge 底（不再裸露成白底）", () => {
+    const hc = buildOctoHostConfig(buildStubResolver());
+    const accent = hc.containerStyles.getStyleByName("accent");
+    expect(accent.backgroundColor).toBe("rgb(230, 240, 255)");
+  });
+
+  it.each([
+    { name: "good", bg: "rgb(230, 250, 230)", fgToken: "rgb(0, 150, 0)" },
+    { name: "warning", bg: "rgb(255, 250, 230)", fgToken: "rgb(200, 150, 0)" },
+    { name: "attention", bg: "rgb(255, 235, 235)", fgToken: "rgb(200, 0, 0)" },
+  ])(
+    "$name 容器有语义填色背景（进度条分段可见）",
+    ({ name, bg, fgToken }) => {
+      const hc = buildOctoHostConfig(buildStubResolver());
+      const style = hc.containerStyles.getStyleByName(name);
+      expect(style.backgroundColor).toBe(bg);
+      // 对应语义前景色也映射到位，使 TextBlock color=Good/Warning/Attention 生效。
+      const fgKey = name as "good" | "warning" | "attention";
+      expect(style.foregroundColors[fgKey].default).toBe(fgToken);
+    }
+  );
 });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoHostConfig.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoHostConfig.ts
@@ -42,7 +42,6 @@ const COLOR_TOKENS = {
   // backgroundColor 为 undefined，故 emphasis/accent/good/warning/attention 的背景
   // 必须由 HostConfig 显式提供，否则一律退化为透明/父白底（见排查结论）。
   emphasisBackground: "var(--wk-bg-elevated)",
-  emphasisBorder: "var(--wk-border-default)",
   accentBackground: "var(--wk-accent-tint-10)",
   good: "var(--wk-color-success)",
   goodBackground: "var(--wk-color-success-bg)",
@@ -58,7 +57,6 @@ export function buildOctoHostConfig(resolve: CssColorResolver): HostConfig {
   const accent = resolve(COLOR_TOKENS.accent);
   const background = resolve(COLOR_TOKENS.background);
   const emphasisBackground = resolve(COLOR_TOKENS.emphasisBackground);
-  const emphasisBorder = resolve(COLOR_TOKENS.emphasisBorder);
   const accentBackground = resolve(COLOR_TOKENS.accentBackground);
   const good = resolve(COLOR_TOKENS.good);
   const goodBackground = resolve(COLOR_TOKENS.goodBackground);
@@ -107,7 +105,6 @@ export function buildOctoHostConfig(resolve: CssColorResolver): HostConfig {
       },
       emphasis: {
         backgroundColor: emphasisBackground,
-        borderColor: emphasisBorder,
         foregroundColors: fg,
       },
       accent: {

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoHostConfig.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoHostConfig.ts
@@ -38,6 +38,18 @@ const COLOR_TOKENS = {
   textSubtle: "var(--wk-text-secondary)",
   accent: "var(--wk-text-accent)",
   background: "var(--wk-bg-surface)",
+  // 容器填色（Container.style 背景）。AC 3.x 内置 containerStyles 只带前景色、
+  // backgroundColor 为 undefined，故 emphasis/accent/good/warning/attention 的背景
+  // 必须由 HostConfig 显式提供，否则一律退化为透明/父白底（见排查结论）。
+  emphasisBackground: "var(--wk-bg-elevated)",
+  emphasisBorder: "var(--wk-border-default)",
+  accentBackground: "var(--wk-accent-tint-10)",
+  good: "var(--wk-color-success)",
+  goodBackground: "var(--wk-color-success-bg)",
+  warning: "var(--wk-color-warning)",
+  warningBackground: "var(--wk-color-warning-bg)",
+  attention: "var(--wk-color-danger)",
+  attentionBackground: "var(--wk-color-danger-bg)",
 } as const;
 
 export function buildOctoHostConfig(resolve: CssColorResolver): HostConfig {
@@ -45,14 +57,25 @@ export function buildOctoHostConfig(resolve: CssColorResolver): HostConfig {
   const subtle = resolve(COLOR_TOKENS.textSubtle);
   const accent = resolve(COLOR_TOKENS.accent);
   const background = resolve(COLOR_TOKENS.background);
+  const emphasisBackground = resolve(COLOR_TOKENS.emphasisBackground);
+  const emphasisBorder = resolve(COLOR_TOKENS.emphasisBorder);
+  const accentBackground = resolve(COLOR_TOKENS.accentBackground);
+  const good = resolve(COLOR_TOKENS.good);
+  const goodBackground = resolve(COLOR_TOKENS.goodBackground);
+  const warning = resolve(COLOR_TOKENS.warning);
+  const warningBackground = resolve(COLOR_TOKENS.warningBackground);
+  const attention = resolve(COLOR_TOKENS.attention);
+  const attentionBackground = resolve(COLOR_TOKENS.attentionBackground);
 
+  // 前景色集：good/warning/attention 映射到语义色，使 TextBlock color=Good/... 也正确着色。
+  // 所有 containerStyle 共用同一前景集，仅背景/边框不同——文本默认取 default（深色），
+  // 叠在浅色填色底上依旧可读。
   const fg = {
     default: { default: text, subtle },
     accent: { default: accent, subtle: accent },
-    // good/warning/attention 复用语义色（octo 卡不强依赖，给合理缺省）。
-    good: { default: text, subtle },
-    warning: { default: text, subtle },
-    attention: { default: text, subtle },
+    good: { default: good, subtle: good },
+    warning: { default: warning, subtle: warning },
+    attention: { default: attention, subtle: attention },
   };
 
   return new HostConfig({
@@ -76,13 +99,31 @@ export function buildOctoHostConfig(resolve: CssColorResolver): HostConfig {
       actionsOrientation: "horizontal",
       actionAlignment: "left",
     },
+    // 六种 containerStyle 全部显式提供背景填色（缺任一都会退化成裸白底）。
     containerStyles: {
       default: {
         backgroundColor: background,
         foregroundColors: fg,
       },
       emphasis: {
-        backgroundColor: background,
+        backgroundColor: emphasisBackground,
+        borderColor: emphasisBorder,
+        foregroundColors: fg,
+      },
+      accent: {
+        backgroundColor: accentBackground,
+        foregroundColors: fg,
+      },
+      good: {
+        backgroundColor: goodBackground,
+        foregroundColors: fg,
+      },
+      warning: {
+        backgroundColor: warningBackground,
+        foregroundColors: fg,
+      },
+      attention: {
+        backgroundColor: attentionBackground,
         foregroundColors: fg,
       },
     },


### PR DESCRIPTION
## Summary

Two client-side fixes for interactive card (type-17) messages, both reproduced and verified in the dev environment against `im-test`:

1. **Cards no longer get folded into "收起N条讨论".** Interactive cards were treated as ordinary bot messages and folded together with adjacent bot messages into a `FoldSessionCard`, hiding the card's buttons/inputs so users could not interact with them.
2. **`Container.style` fills now render.** `accent` / `emphasis` / `good` / `warning` / `attention` containers previously rendered as bare white; the fill colors, the accent badge, and the emphasis panels were all missing.

## Root cause

**Fold-session grouping** — `ConversationVM.buildRenderItems` only excluded image/gif/video/file/richText deliverables from folding. Cards fell through and were grouped with the next bot message.

**Container styles** — the octo `HostConfig` only defined `default` + `emphasis` container styles, and `emphasis` reused the `default` background (zero visual distinction). AdaptiveCards 3.0.6 built-in container styles carry **no** `backgroundColor` — the host must supply it — so `accent`/`good`/`warning`/`attention` degraded to the default white. Separately, `emphasis` referenced `--wk-bg-subtle`, a token that is **not defined anywhere in the repo**, which made the CSS-var resolver fall back to a dark inherited color (dark-blue panels with low-contrast text).

**Column width was never broken.** AC 3.0.6 renders `width: 3/1/1` as `flex: 1 1 60%/20%/20%` correctly; the earlier "equal columns" impression was a side effect of the missing container fills making column boundaries invisible. A contract test now locks this in.

## Changes

- `Conversation/vm.ts` — add `interactiveCard` to the unfoldable-deliverable whitelist; rename `hasFileAttachment` → `isUnfoldableDeliverable` (a card is not a file attachment).
- `sdk/octoHostConfig.ts` — define `backgroundColor` for all six container styles from `--wk-*` tokens (accent tint, success/warning/danger bg); `emphasis` now uses `--wk-bg-elevated` + border; map good/warning/attention foreground colors so `TextBlock color=...` works.
- Replace the undefined `--wk-bg-subtle` token with `--wk-bg-elevated` in `ImageRenderer.css` / `VideoRenderer.css` (its only other uses — same silent-fallback bug in file-preview placeholders).
- Tests: extended `octoSdkConfig.test.ts` (container-style fills), new `columnWidth.test.tsx` (3/1/1 → 60/20/20 flex-basis contract), extended `foldSessionFileAttachment.test.ts` (cards stay standalone).

## Test plan

- [x] `pnpm vitest run` for InteractiveCard + Conversation fold-session suites — 16 files / 169 tests pass
- [x] `tsc --noEmit` on dmworkbase — no type errors on touched files
- [x] stylelint on the two touched CSS files — clean
- [x] Manual: sent the reported card payload in dev (`im-test`); accent badge, emphasis panels, and good/warning/attention progress segments all fill correctly; `width 3/1/1` shows 60/20/20; cards render standalone with interactive buttons
- [ ] Reviewer: sanity-check emphasis panel contrast in dark theme