### PR TITLE
fix(global-search): filter panel full render + clear input on select

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/FilterSearchSelect.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/FilterSearchSelect.tsx
@@ -149,7 +149,18 @@ const FilterSearchSelect: React.FC<FilterSearchSelectProps> = ({
                   role="checkbox"
                   aria-checked={active}
                   className={active ? "is-selected" : undefined}
-                  onClick={() => onToggle(opt.id)}
+                  onClick={() => {
+                    // Mirror ChannelSearch's chooseSender pattern (packages/
+                    // dmworkbase/src/Components/ChannelSearch/index.tsx —
+                    // toggle + clear the typed query + keep the dropdown
+                    // open so the user can immediately pick another
+                    // candidate). Without the reset the input keeps the
+                    // narrowing text after a pick and users have to
+                    // manually clear it before searching the next name.
+                    onToggle(opt.id);
+                    onQueryChange("");
+                    setOpen(true);
+                  }}
                 >
                   <span className="wk-channel-search-filter-check" />
                   {opt.avatarUrl && (

--- a/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
@@ -452,6 +452,7 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
       className="wk-channel-search-filter-popover wk-global-search-filter-panel"
       onClick={(e) => e.stopPropagation()}
     >
+      <div className="wk-global-search-filter-body">
       <FilterSearchSelect
         title={t("base.channelSearch.filter.sender")}
         placeholder={t("base.channelSearch.filter.senderPlaceholder")}
@@ -662,6 +663,8 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
           value={dateFromSeconds(draft.endAt)}
           onChange={(v) => setCustomDate("endAt", v)}
         />
+      </div>
+
       </div>
 
       <div className="wk-channel-search-filter-actions">

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterSearchSelect.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterSearchSelect.test.tsx
@@ -118,6 +118,34 @@ describe("FilterSearchSelect — 发送者 (multi)", () => {
       within(field()).queryByRole("button", { name: /Alice/ })
     ).not.toBeInTheDocument();
   });
+
+  it("选中候选后清空输入 + 保持下拉打开：mirrors ChannelSearch's chooseSender", () => {
+    // Regression for YUJ-19: picking a candidate from the dropdown must reset
+    // the typed query (so the user can search for the next name from a clean
+    // input) and keep the listbox open so the follow-up pick doesn't need
+    // another focus click. ChannelSearch's `chooseSender` does exactly this.
+    render(<Harness mode="multi" master={SENDERS} />);
+    openDropdown();
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ali" } });
+    // Narrowed pool now only shows Alice.
+    expect(within(listbox()).getByText("Alice")).toBeInTheDocument();
+    expect(within(listbox()).queryByText("Bob")).not.toBeInTheDocument();
+
+    fireEvent.click(within(listbox()).getByText("Alice"));
+
+    // Query is now cleared.
+    expect(input.value).toBe("");
+    // Dropdown is still open, showing the full candidate pool again.
+    expect(within(listbox()).getByText("Alice")).toBeInTheDocument();
+    expect(within(listbox()).getByText("Bob")).toBeInTheDocument();
+    expect(within(listbox()).getByText("Carol")).toBeInTheDocument();
+    // Alice chip has landed in the field.
+    expect(
+      within(field()).getByRole("button", { name: /Alice/ })
+    ).toBeInTheDocument();
+  });
 });
 
 describe("FilterSearchSelect — 所在群聊 (multi, composite ids)", () => {

--- a/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
@@ -59,13 +59,45 @@
   Filter popover: reuse ChannelSearch's `wk-channel-search-filter-*` shell
   (popover / section / title / chip / actions) for identical chrome. This
   class only carries the global-search-specific sizing overrides — the global
-  panel has more sections than the in-conversation one, so it is wider and
-  scrolls.
+  panel has more sections than the in-conversation one, so it is wider,
+  laid out as a flex column, and its interior scrolls while the action bar
+  stays pinned at the bottom.
+
+  Why a flex column instead of a single `max-height + overflow-y: auto` on
+  the popover: the popover is `position: absolute` and its ancestors
+  (`.wk-global-content-search`, the Semi Modal `.semi-modal-content`) can
+  clip its bottom edge on shorter viewports, which used to hide the
+  「确定」 button below the visible area even though the popover said it
+  scrolled. Constraining the popover's own max-height with `calc(100vh -
+  <toolbar/tab offset>)` keeps the whole popover inside the modal body, and
+  the flex layout keeps `.wk-channel-search-filter-actions` visible as an
+  auto-sticky footer while the middle sections scroll.
 */
 .wk-global-content-search .wk-global-search-filter-panel {
+  display: flex;
+  flex-direction: column;
   width: 300px;
-  max-height: 70vh;
+  /* 200px ≈ modal top-chrome (30px marginTop + 40px input + tab strip +
+     toolbar padding) plus a safety gutter so the panel never touches the
+     modal's bottom edge. Capped at 70vh so the popover still shrinks on
+     tall viewports where the toolbar sits low in the modal. */
+  max-height: min(70vh, calc(100vh - 200px));
+}
+
+.wk-global-content-search .wk-global-search-filter-body {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
+}
+
+.wk-global-content-search .wk-global-search-filter-panel
+  .wk-channel-search-filter-actions {
+  flex: 0 0 auto;
+  /* Reuse the reset shared with ChannelSearch (`margin-top: 16px`) but keep
+     the actions row visually attached to the popover edge instead of
+     inheriting the section-list padding rhythm now that it lives outside
+     the scrollable body. */
+  margin-top: 12px;
 }
 
 .wk-global-content-search .wk-global-search-filter-chip-row {


### PR DESCRIPTION
## Summary

Fixes two interaction/rendering issues in the global search chat filter panel (follow-up to #554), aligned with the single-channel `ChannelSearch` filter behavior.

1. **Filter panel now fully renders inside the modal; the "Apply/确定" button is always reachable.** Previously the panel content/apply button could overflow the search modal, so users couldn't confirm after choosing filter conditions. Fixed the panel height/overflow model (scroll + reachable footer).
2. **Selecting a dropdown item now clears the search input** (sender / channel / member selectors). Previously the typed text lingered after picking a candidate. Reworked to mirror `ChannelSearch/index.tsx` `chooseSender` behavior (pick → add to selected chips → clear input).

## Reference
- Modeled on `ChannelSearch` (single-channel message search) filter interaction.

## Verification
Local acceptance against the dmwork-test backend (`VITE_API_URL=https://im-test.deepminer.com.cn`), Playwright (viewport 1440×900, zh-CN):
- **Issue 1 — PASS**: filter panel renders fully; "确定" button visible & clickable (boundingBox in-viewport).
- **Issue 2 — PASS**: after picking a dropdown candidate, the input is cleared and the selection moves to a chip.

Branch built off `main` (includes #554). Screenshots attached in the internal acceptance issue.
