### PR TITLE
fix: align interactive card element manifest

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -23,13 +23,17 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
   it("保留 octo 白名单元素，移除非白名单元素", () => {
     const ctx = createOctoSerializationContext();
     const reg = ctx.elementRegistry;
-    // octo 允许的元素仍注册（Column 由 ColumnSet 内部解析，非独立注册项，不单列）。
+    // octo manifest 允许的展示元素仍注册（Column / TextRun 为父元素内部节点，不单列）。
     for (const t of [
       "TextBlock",
+      "RichTextBlock",
       "Image",
+      "ImageSet",
       "Container",
       "ColumnSet",
       "FactSet",
+      "Table",
+      "ActionSet",
       "Input.Text",
       "Input.Toggle",
       "Input.ChoiceSet",
@@ -40,14 +44,7 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
       expect(reg.findByName(t)).toBeDefined();
     }
     // 非白名单元素被移除。
-    for (const t of [
-      "Table",
-      "Carousel",
-      "Media",
-      "RichTextBlock",
-      "ImageSet",
-      "ActionSet",
-    ]) {
+    for (const t of ["Carousel", "Media"]) {
       expect(reg.findByName(t)).toBeUndefined();
     }
   });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
@@ -248,6 +248,20 @@ describe("decideCardBody — 渲染/整卡 fallback（第三道闸）", () => {
     }
   });
 
+  it("服务端 manifest 展示元素 RichTextBlock → card", () => {
+    expect(
+      decideCardBody({
+        ...trusted,
+        card: AC([
+          {
+            type: "RichTextBlock",
+            inlines: [{ type: "TextRun", text: "读取文件" }],
+          },
+        ]),
+      }).kind
+    ).toBe("card");
+  });
+
   it("未知元素 → plain（整卡 fallback，非 per-element）", () => {
     expect(
       decideCardBody({ ...trusted, card: AC([{ type: "Media" }]) }).kind

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -48,6 +48,39 @@ describe("renderOctoCard", () => {
     target.remove();
   });
 
+  it("渲染 RichTextBlock/TextRun（服务端 manifest 展示元素）", () => {
+    const target = mountTarget();
+    renderOctoCard({
+      card: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          {
+            type: "RichTextBlock",
+            inlines: [
+              { type: "TextRun", text: "📖 " },
+              { type: "TextRun", text: "读取文件", weight: "Bolder" },
+              { type: "TextRun", text: "：/work/README.md" },
+              { type: "TextRun", text: " · 180ms", color: "good" },
+            ],
+          },
+        ],
+      },
+      target,
+      onAction: () => {},
+    });
+    const runs = Array.from(target.querySelectorAll(".ac-textRun"));
+    const renderedText = runs
+      .map((run) => (run as HTMLElement).innerText || run.textContent || "")
+      .join("");
+    expect(renderedText).toContain("读取文件");
+    expect(renderedText).toContain("/work/README.md");
+    expect(
+      runs.some((run) => (run as HTMLElement).style.fontWeight === "600")
+    ).toBe(true);
+    target.remove();
+  });
+
   it("按钮点击 → onAction 收到对应动作（OpenUrl / Submit 均经回调）", () => {
     const target = mountTarget();
     const types: string[] = [];

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
@@ -32,6 +32,58 @@ describe("validateCardForOcto — 合法（ok:true）", () => {
       ).ok
     ).toBe(true);
   });
+  it("RichTextBlock/TextRun（服务端 manifest 展示元素）", () => {
+    expect(
+      validateCardForOcto(
+        AC([
+          {
+            type: "RichTextBlock",
+            inlines: [
+              { type: "TextRun", text: "读取文件", weight: "Bolder" },
+              { type: "TextRun", text: " · 180ms", color: "good" },
+            ],
+          },
+        ])
+      ).ok
+    ).toBe(true);
+  });
+  it("ImageSet / ActionSet / Table（服务端 manifest 展示元素）", () => {
+    expect(
+      validateCardForOcto(
+        AC([
+          {
+            type: "ImageSet",
+            images: [{ type: "Image", url: "https://cdn/a.png" }],
+          },
+          {
+            type: "ActionSet",
+            actions: [
+              {
+                type: "Action.OpenUrl",
+                title: "打开",
+                url: "https://example.com",
+              },
+            ],
+          },
+          {
+            type: "Table",
+            columns: [{ width: 1 }],
+            rows: [
+              {
+                type: "TableRow",
+                cells: [
+                  {
+                    type: "TableCell",
+                    items: [{ type: "TextBlock", text: "cell" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+      ).ok
+    ).toBe(true);
+  });
   it("Image http url → ok（混合内容属 per-element，不整卡降级）", () => {
     expect(
       validateCardForOcto(AC([{ type: "Image", url: "http://x/a.png" }])).ok
@@ -106,6 +158,36 @@ describe("validateCardForOcto — 整卡降级（ok:false）", () => {
 
   it("非 AdaptiveCard 根", () => bad({ type: "Nope" }));
   it("未知元素", () => bad(AC([{ type: "Media" }])));
+  it("RichTextBlock 只允许 TextRun inline", () =>
+    bad(
+      AC([
+        { type: "RichTextBlock", inlines: [{ type: "TextBlock", text: "x" }] },
+      ])
+    ));
+  it("TextRun.selectAction 也必须满足动作白名单与 URL 安全", () =>
+    bad(
+      AC([
+        {
+          type: "RichTextBlock",
+          inlines: [
+            {
+              type: "TextRun",
+              text: "bad",
+              selectAction: {
+                type: "Action.OpenUrl",
+                url: "javascript:alert(1)",
+              },
+            },
+          ],
+        },
+      ])
+    ));
+  it("TextRun 不能作为 body 元素单独出现", () =>
+    bad(AC([{ type: "TextRun", text: "x" }])));
+  it("ImageSet.images 只能包含 Image 元素", () =>
+    bad(AC([{ type: "ImageSet", images: [{ type: "TextBlock", text: "x" }] }])));
+  it("TableCell.items 非数组", () =>
+    bad(AC([{ type: "Table", rows: [{ cells: [{ items: "bad" }] }] }])));
   it("元素无 type", () => bad(AC([{ text: "no type" }])));
   it("Input.* 在 v1（禁交互）", () => bad(AC([{ type: "Input.Text", id: "t" }])));
   it("Input.Number 在 v1（禁交互）", () =>

--- a/packages/dmworkbase/src/Messages/InteractiveCard/index.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/index.css
@@ -13,7 +13,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--wk-sp-1, 4px);
-  max-width: 420px;
+  width: 520px;
+  max-width: 100%;
   min-width: 0;
 }
 
@@ -21,13 +22,13 @@
 .wk-interactive-card-plain {
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.5;
+  line-height: var(--wk-leading-normal, 1.5);
   color: var(--wk-text-primary, inherit);
 }
 
 .wk-interactive-card-hint {
   margin-top: var(--wk-sp-1, 4px);
-  font-size: 12px;
+  font-size: var(--wk-text-size-sm, 12px);
   color: var(--wk-text-secondary);
 }
 
@@ -56,6 +57,38 @@
 .wk-interactive-card-sdk {
   position: relative;
   min-width: 0;
+  background: var(--wk-bg-surface);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-md);
+  box-shadow: var(--wk-shadow-sm);
+  overflow: hidden;
+}
+
+.wk-interactive-card-sdk::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  width: var(--wk-sp-0-5, 2px);
+  background: var(--wk-text-accent, var(--wk-brand-primary));
+  pointer-events: none;
+}
+
+.wk-interactive-card-sdk > .ac-adaptiveCard {
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.wk-interactive-card-sdk > .ac-adaptiveCard > :first-child {
+  margin-top: 0;
+}
+
+.wk-interactive-card-sdk > .ac-adaptiveCard > :last-child {
+  margin-bottom: 0;
 }
 
 /* 提交中：整卡置灰、禁点，等新帧或 10s 超时恢复 */
@@ -82,19 +115,130 @@
 /* ── SDK(AdaptiveCards) 输出基线样式 ──
  * SDK 未引入默认样式表，按钮/输入本无样式；此处用 --wk-* token 补基线，待真机微调。
  * 颜色/间距/字体等由 HostConfig 就地注入（inline），此处只补 SDK 未覆盖的控件外观。 */
+.wk-interactive-card-sdk .ac-textBlock,
+.wk-interactive-card-sdk .ac-textRun {
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.wk-interactive-card-sdk .ac-textBlock {
+  color: var(--wk-text-primary);
+}
+
+.wk-interactive-card-sdk .ac-container {
+  box-sizing: border-box;
+  border-radius: var(--wk-r-sm);
+  overflow: hidden;
+}
+
+.wk-interactive-card-sdk .ac-columnSet {
+  box-sizing: border-box;
+  border-radius: var(--wk-r-sm);
+}
+
+.wk-interactive-card-sdk .ac-columnSet > .ac-container {
+  border: 1px solid var(--wk-border-subtle);
+}
+
+.wk-interactive-card-sdk .ac-richTextBlock {
+  box-sizing: border-box;
+  padding: var(--wk-sp-1, 4px) 0;
+  color: var(--wk-text-primary);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+.wk-interactive-card-sdk .ac-richTextBlock .ac-textRun {
+  line-height: var(--wk-leading-normal);
+}
+
+.wk-interactive-card-sdk > .ac-adaptiveCard > .ac-richTextBlock + .ac-richTextBlock {
+  border-top: 1px solid var(--wk-border-subtle);
+}
+
+.wk-interactive-card-sdk .ac-factset {
+  width: 100%;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+.wk-interactive-card-sdk .ac-fact-title,
+.wk-interactive-card-sdk .ac-fact-value {
+  padding: var(--wk-sp-1, 4px) 0;
+  vertical-align: top;
+}
+
+.wk-interactive-card-sdk .ac-fact-title {
+  width: 62%;
+  padding-right: var(--wk-sp-3, 12px);
+  color: var(--wk-text-secondary);
+}
+
+.wk-interactive-card-sdk .ac-fact-value {
+  color: var(--wk-text-primary);
+  font-weight: var(--wk-font-medium);
+}
+
+.wk-interactive-card-sdk .ac-factset tr + tr .ac-fact-title,
+.wk-interactive-card-sdk .ac-factset tr + tr .ac-fact-value {
+  border-top: 1px solid var(--wk-border-subtle);
+}
+
+.wk-interactive-card-sdk table:not(.ac-factset) {
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-sm);
+  border-spacing: 0;
+  background: var(--wk-bg-surface);
+}
+
+.wk-interactive-card-sdk table:not(.ac-factset) td,
+.wk-interactive-card-sdk table:not(.ac-factset) th {
+  padding: var(--wk-sp-1-5, 6px) var(--wk-sp-2, 8px);
+  border-bottom: 1px solid var(--wk-border-subtle);
+  vertical-align: top;
+}
+
+.wk-interactive-card-sdk table:not(.ac-factset) tr:last-child td,
+.wk-interactive-card-sdk table:not(.ac-factset) tr:last-child th {
+  border-bottom: none;
+}
+
+.wk-interactive-card-sdk .ac-image {
+  border-radius: var(--wk-r-sm);
+}
+
+.wk-interactive-card-sdk .ac-imageSet {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--wk-sp-2, 8px);
+}
+
 .wk-interactive-card-sdk .ac-pushButton {
   min-height: 30px;
   padding: var(--wk-sp-1, 4px) var(--wk-sp-3, 12px);
-  font-size: 13px;
+  font-size: var(--wk-text-size-base, 13px);
   color: var(--wk-text-accent, var(--wk-brand-primary));
-  background: transparent;
+  background: var(--wk-bg-surface);
   border: 1px solid var(--wk-border-default);
   border-radius: var(--wk-r-sm, 4px);
   cursor: pointer;
+  transition:
+    background var(--wk-dur-fast) var(--wk-ease),
+    border-color var(--wk-dur-fast) var(--wk-ease);
 }
 
 .wk-interactive-card-sdk .ac-pushButton:hover {
-  background: var(--wk-bg-elevated);
+  background: var(--wk-bg-hover);
+  border-color: var(--wk-border-strong);
+}
+
+.wk-interactive-card-sdk .ac-pushButton:focus-visible {
+  outline: none;
+  border-color: var(--wk-border-glow);
+  box-shadow: 0 0 0 var(--wk-sp-0-5, 2px) var(--wk-border-glow);
 }
 
 .wk-interactive-card-sdk .ac-textInput,
@@ -104,7 +248,7 @@
 .wk-interactive-card-sdk .ac-choiceSetInput-compact {
   min-height: 30px;
   padding: var(--wk-sp-1, 4px) var(--wk-sp-2, 8px);
-  font-size: 13px;
+  font-size: var(--wk-text-size-base, 13px);
   color: var(--wk-text-primary);
   background: var(--wk-bg-surface, transparent);
   border: 1px solid var(--wk-border-default);
@@ -119,4 +263,5 @@
 .wk-interactive-card-sdk .ac-choiceSetInput-compact:focus-visible {
   outline: none;
   border-color: var(--wk-brand-primary);
+  box-shadow: 0 0 0 var(--wk-sp-0-5, 2px) var(--wk-border-glow);
 }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
@@ -2,6 +2,7 @@ import {
   CardObjectRegistry,
   GlobalRegistry,
   SerializationContext,
+  Versions,
   type Action,
   type CardElement,
 } from "adaptivecards";
@@ -14,7 +15,7 @@ import {
  *
  * - **动作**是有副作用的（触发 host 回调），移除 `Action.Execute`/`ShowCard`/`ToggleVisibility`，
  *   只留 octo 的 `Action.OpenUrl` + `Action.Submit`。
- * - **元素**移除非 octo 白名单类型（Table/Carousel/Media/RichTextBlock/ImageSet/ActionSet），
+ * - **元素**移除非 octo 白名单类型（Carousel/Media），
  *   只留 octo 允许的类型。即便 validate 疏漏，这些元素也无法被 SDK 反序列化。
  *
  * 采用「populate 默认后 unregister 非白名单」而非 register-only：octo 允许的元素保持默认注册，
@@ -26,21 +27,16 @@ const FORBIDDEN_ACTIONS = [
   "Action.ToggleVisibility",
 ] as const;
 
-/** 非 octo 白名单元素（AC 默认注册但 octo 不支持）。octo 允许：TextBlock/Image/Container/
- *  ColumnSet/Column/FactSet + 6 类输入 Input.Text/Toggle/ChoiceSet/Number/Date/Time
- *  （Column 及 Table/Carousel 的行/页由父元素内部解析、非独立注册项，故无需单列）。 */
-const FORBIDDEN_ELEMENTS = [
-  "Table",
-  "Carousel",
-  "Media",
-  "RichTextBlock",
-  "TextRun",
-  "ImageSet",
-  "ActionSet",
-] as const;
+/** 非 octo 白名单元素（AC 默认注册但 octo 不支持）。octo manifest 允许：
+ *  TextBlock/RichTextBlock/Image/ImageSet/Container/ColumnSet/FactSet/Table/ActionSet
+ *  + 6 类输入 Input.Text/Toggle/ChoiceSet/Number/Date/Time。
+ *  TextRun 是 RichTextBlock.inlines 的 inline 节点，需保留。 */
+const FORBIDDEN_ELEMENTS = ["Carousel", "Media"] as const;
 
 export function createOctoSerializationContext(): SerializationContext {
-  const ctx = new SerializationContext();
+  // 受限 context 也要显式使用 SDK 上限版本；否则默认目标版本可能过低，
+  // RichTextBlock/TextRun(v1.2+) 或 Table(v1.5) 会因版本门槛无法实例化。
+  const ctx = new SerializationContext(Versions.latest);
 
   const actionRegistry = new CardObjectRegistry<Action>();
   GlobalRegistry.populateWithDefaultActions(actionRegistry);

--- a/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
@@ -4,7 +4,8 @@
  * 权威来源：octo-server `pkg/cardmsg/*` + 其 `*_test.go`（`docs/card-protocol.md` 为镜像）。
  * 与 type=7 名片（Card）无任何关系。
  *
- * octo/v1（展示型）：5 类元素 + Action.OpenUrl + selectAction(仅含 OpenUrl)。
+ * octo/v1（展示型）：TextBlock/RichTextBlock/Image/ImageSet/Container/ColumnSet/
+ *   FactSet/Table/ActionSet + Action.OpenUrl + selectAction(仅含 OpenUrl)。
  * octo/v2（交互型，波 2）：追加 Input.Text/Toggle/ChoiceSet + Action.Submit（含 selectAction 携带），
  *   Input.* / Action.Submit 的 id 必填且帧内唯一。
  * 未知元素/动作、未知 profile/version、损坏 payload 一律整卡降级为 plain。

--- a/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
@@ -93,6 +93,24 @@ function validateItems(items: unknown[], ctx: Ctx): void {
   for (const el of items) validateElement(el, ctx);
 }
 
+function validateRichTextInline(inline: unknown, ctx: Ctx): void {
+  if (!ctx.budget.consume()) throw new OctoInvalidCard("node count exceeded");
+  const obj = asObject(inline);
+  if (!obj || obj.type !== "TextRun") {
+    throw new OctoInvalidCard("unsupported rich text inline");
+  }
+  validateSelectAction(obj.selectAction, ctx);
+}
+
+function validateImageSetImage(image: unknown, ctx: Ctx): void {
+  if (!ctx.budget.consume()) throw new OctoInvalidCard("node count exceeded");
+  const obj = asObject(image);
+  if (!obj || obj.type !== "Image") {
+    throw new OctoInvalidCard("malformed image set image");
+  }
+  validateSelectAction(obj.selectAction, ctx);
+}
+
 function validateElement(el: unknown, ctx: Ctx): void {
   if (!ctx.budget.consume()) throw new OctoInvalidCard("node count exceeded");
   const obj = asObject(el);
@@ -102,10 +120,20 @@ function validateElement(el: unknown, ctx: Ctx): void {
   switch (obj.type) {
     case "TextBlock":
       return;
+    case "RichTextBlock": {
+      const inlines = requireArray(obj.inlines);
+      for (const inline of inlines) validateRichTextInline(inline, ctx);
+      return;
+    }
     case "Image":
       // Image.url 混合内容属 per-element（喂 SDK 前消毒），结构层合法。
       validateSelectAction(obj.selectAction, ctx);
       return;
+    case "ImageSet": {
+      const images = requireArray(obj.images);
+      for (const image of images) validateImageSetImage(image, ctx);
+      return;
+    }
     case "FactSet": {
       const facts = requireArray(obj.facts);
       for (const _f of facts) {
@@ -114,10 +142,48 @@ function validateElement(el: unknown, ctx: Ctx): void {
       }
       return;
     }
+    case "ActionSet": {
+      const actions = requireArray(obj.actions);
+      for (const action of actions) {
+        if (!ctx.budget.consume())
+          throw new OctoInvalidCard("node count exceeded");
+        validateAction(action, ctx);
+      }
+      return;
+    }
     case "Container": {
       if (!ctx.budget.enter()) throw new OctoInvalidCard("depth exceeded");
       validateItems(requireArray(obj.items), ctx);
       validateSelectAction(obj.selectAction, ctx);
+      ctx.budget.leave();
+      return;
+    }
+    case "Table": {
+      if (!ctx.budget.enter()) throw new OctoInvalidCard("depth exceeded");
+      const columns = requireArray(obj.columns);
+      for (const column of columns) {
+        if (!asObject(column)) throw new OctoInvalidCard("malformed table column");
+        if (!ctx.budget.consume())
+          throw new OctoInvalidCard("node count exceeded");
+      }
+      const rows = requireArray(obj.rows);
+      for (const row of rows) {
+        const rowObj = asObject(row);
+        if (!rowObj) throw new OctoInvalidCard("malformed table row");
+        if (!ctx.budget.consume())
+          throw new OctoInvalidCard("node count exceeded");
+        const cells = requireArray(rowObj.cells);
+        for (const cell of cells) {
+          const cellObj = asObject(cell);
+          if (!cellObj) throw new OctoInvalidCard("malformed table cell");
+          if (!ctx.budget.consume())
+            throw new OctoInvalidCard("node count exceeded");
+          if (!ctx.budget.enter()) throw new OctoInvalidCard("depth exceeded");
+          validateSelectAction(cellObj.selectAction, ctx);
+          validateItems(requireArray(cellObj.items), ctx);
+          ctx.budget.leave();
+        }
+      }
       ctx.budget.leave();
       return;
     }


### PR DESCRIPTION
## Summary
- Align interactive card frontend allowlist with the server capability manifest for display elements.
- Allow RichTextBlock/TextRun, ImageSet, Table, and ActionSet while keeping unsupported elements fail-closed.
- Keep TextRun action validation under the same action whitelist and URL safety checks.

## Verification
- pnpm exec vitest run packages/dmworkbase/src/Messages/InteractiveCard/__tests__
- git diff --check origin/main...HEAD