### PR TITLE
feat(loop): add Multica CLI authorization page

### DIFF
--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -15,6 +15,7 @@ import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
 import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
+import { isMulticaCliAuthorizePath, MULTICA_CLI_AUTHORIZE_PATH } from "@octo/loop";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -346,6 +347,25 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const bindComponent = WKApp.route.get('/oidc/bind')
             if (bindComponent) {
                 return bindComponent
+            }
+        }
+
+        // The CLI authorization deep-link is a full-page flow outside the normal app shell.
+        // Reuse a single stored Octo session when the clean URL carries no sid-specific token.
+        if (isMulticaCliAuthorizePath(window.location.pathname)) {
+            if (!WKApp.loginInfo.token) {
+                WKApp.loginInfo.load();
+            }
+            if (!WKApp.loginInfo.token) {
+                recoverOctoSessionFromStorage(true);
+            }
+            if (WKApp.loginInfo.token) {
+                if (!WKApp.shared.currentSpaceId) {
+                    const cachedSpaceId = localStorage.getItem("currentSpaceId") || "";
+                    if (cachedSpaceId) WKApp.shared.currentSpaceId = cachedSpaceId;
+                }
+                const cliAuthorizeComponent = WKApp.route.get(MULTICA_CLI_AUTHORIZE_PATH);
+                if (cliAuthorizeComponent) return cliAuthorizeComponent;
             }
         }
 

--- a/apps/web/src/__tests__/multicaCliAuthorizeDeepLink.test.ts
+++ b/apps/web/src/__tests__/multicaCliAuthorizeDeepLink.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearPendingMulticaCliAuthorizeSearch,
+  isMulticaCliAuthorizePath,
+  resolveMulticaCliAuthorizeSearch,
+  visibleMulticaCliAuthorizeSearch,
+} from "../../../../packages/dmloop/src/cliAuthorizeSession";
+
+describe("Multica CLI authorize deep link", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("accepts the canonical route with or without a trailing slash", () => {
+    expect(isMulticaCliAuthorizePath("/loop/cli-authorize")).toBe(true);
+    expect(isMulticaCliAuthorizePath("/loop/cli-authorize/")).toBe(true);
+    expect(isMulticaCliAuthorizePath("/loop/multica")).toBe(false);
+  });
+
+  it("keeps callback parameters after RouteManager replaces the query with sid", () => {
+    const original =
+      "?cli_callback=http%3A%2F%2Flocalhost%3A57270%2Fcallback&cli_state=state-1";
+
+    expect(
+      resolveMulticaCliAuthorizeSearch(
+        "/loop/cli-authorize",
+        original,
+        sessionStorage
+      )
+    ).toBe(original);
+
+    expect(
+      resolveMulticaCliAuthorizeSearch(
+        "/loop/cli-authorize/",
+        "?sid=llg60f",
+        sessionStorage
+      )
+    ).toBe(original);
+  });
+
+  it("clears the pending callback after redirecting to the CLI", () => {
+    resolveMulticaCliAuthorizeSearch(
+      "/loop/cli-authorize",
+      "?cli_callback=http%3A%2F%2Flocalhost%3A57270%2Fcallback&cli_state=x",
+      sessionStorage
+    );
+
+    clearPendingMulticaCliAuthorizeSearch(sessionStorage);
+
+    expect(
+      resolveMulticaCliAuthorizeSearch(
+        "/loop/cli-authorize",
+        "?sid=next",
+        sessionStorage
+      )
+    ).toBe("?sid=next");
+  });
+
+  it("keeps the existing sid when callback parameters are hidden", () => {
+    expect(
+      visibleMulticaCliAuthorizeSearch(
+        "?sid=5asghu&cli_callback=http%3A%2F%2Flocalhost%3A52652%2Fcallback&cli_state=state"
+      )
+    ).toBe("?sid=5asghu");
+  });
+
+  it("wires the full-page route before the regular authenticated shell", () => {
+    const layout = fs.readFileSync(
+      path.join(__dirname, "../Layout/index.tsx"),
+      "utf-8"
+    );
+    const cliRoute = layout.indexOf("isMulticaCliAuthorizePath(");
+    const provider = layout.search(/return\s*(?:\(\s*)?<Provider/);
+
+    expect(cliRoute).toBeGreaterThan(-1);
+    expect(provider).toBeGreaterThan(-1);
+    expect(cliRoute).toBeLessThan(provider);
+    expect(layout).toContain("recoverOctoSessionFromStorage(true)");
+    expect(layout).toMatch(
+      /WKApp\.route\.get\(\s*MULTICA_CLI_AUTHORIZE_PATH\s*\)/
+    );
+  });
+});

--- a/packages/dmloop/src/api/authApi.ts
+++ b/packages/dmloop/src/api/authApi.ts
@@ -1,0 +1,5 @@
+import { httpPost } from "./http";
+
+export function issueMulticaCliToken(): Promise<{ token: string }> {
+  return httpPost<{ token: string }>("/cli-token");
+}

--- a/packages/dmloop/src/cliAuthorizeSession.ts
+++ b/packages/dmloop/src/cliAuthorizeSession.ts
@@ -1,0 +1,56 @@
+export const MULTICA_CLI_AUTHORIZE_PATH = "/loop/cli-authorize";
+
+const PENDING_SEARCH_KEY = "octo.multica.cli-authorize.pending-search";
+
+type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function isMulticaCliAuthorizePath(pathname: string): boolean {
+  return pathname.replace(/\/+$/, "") === MULTICA_CLI_AUTHORIZE_PATH;
+}
+
+/**
+ * Preserve the CLI callback while Octo's RouteManager replaces the live query
+ * string with a sid-only URL. The pending value also survives the full reload
+ * performed after an interactive login.
+ */
+export function resolveMulticaCliAuthorizeSearch(
+  pathname: string,
+  search: string,
+  storage: SessionStorageLike
+): string {
+  if (!isMulticaCliAuthorizePath(pathname)) return search;
+
+  const params = new URLSearchParams(search);
+  if (params.get("cli_callback")) {
+    try {
+      storage.setItem(PENDING_SEARCH_KEY, search);
+    } catch {
+      // Session storage may be unavailable in hardened browser contexts.
+    }
+    return search;
+  }
+
+  try {
+    return storage.getItem(PENDING_SEARCH_KEY) || search;
+  } catch {
+    return search;
+  }
+}
+
+export function clearPendingMulticaCliAuthorizeSearch(
+  storage: SessionStorageLike
+): void {
+  try {
+    storage.removeItem(PENDING_SEARCH_KEY);
+  } catch {
+    // Best-effort cleanup; redirecting to the loopback callback remains safe.
+  }
+}
+
+export function visibleMulticaCliAuthorizeSearch(search: string): string {
+  const params = new URLSearchParams(search);
+  params.delete("cli_callback");
+  params.delete("cli_state");
+  const visible = params.toString();
+  return visible ? `?${visible}` : "";
+}

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -63,6 +63,18 @@
     "emptyTitle": "No workspace yet",
     "emptyDesc": "Create a workspace to start using Loop."
   },
+  "cliAuthorize": {
+    "title": "Authorize this computer",
+    "description": "Connect this computer to the selected Loop workspace. The CLI will continue local device registration after authorization.",
+    "authorize": "Authorize",
+    "loading": "Loading",
+    "workspaceLoading": "Loading workspace",
+    "invalidCallback": "Invalid CLI callback URL",
+    "loginRequired": "Sign in to Octo and select a Space first",
+    "noWorkspace": "No workspace is available in this Space",
+    "loadFailed": "Failed to load workspaces",
+    "authorizeFailed": "Authorization failed"
+  },
   "taskStatus": {
     "queued": "Queued",
     "dispatched": "Dispatched",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -63,6 +63,18 @@
     "emptyTitle": "还没有工作区",
     "emptyDesc": "创建一个工作区开始使用 Loop。"
   },
+  "cliAuthorize": {
+    "title": "授权当前电脑",
+    "description": "将当前电脑接入所选 Loop 工作区，授权后命令行会继续完成本机设备注册。",
+    "authorize": "授权",
+    "loading": "加载中",
+    "workspaceLoading": "正在加载工作区",
+    "invalidCallback": "CLI 回调地址无效",
+    "loginRequired": "请先登录 Octo 并选择 Space",
+    "noWorkspace": "当前 Space 下没有可用工作区",
+    "loadFailed": "加载工作区失败",
+    "authorizeFailed": "授权失败"
+  },
   "taskStatus": {
     "queued": "排队中",
     "dispatched": "已派发",

--- a/packages/dmloop/src/index.tsx
+++ b/packages/dmloop/src/index.tsx
@@ -3,6 +3,10 @@
 export { default as LoopModule } from "./module";
 export { default as LoopPage } from "./pages/LoopPage";
 export { default as MulticaCliAuthorizePage } from "./pages/MulticaCliAuthorizePage";
+export {
+  isMulticaCliAuthorizePath,
+  MULTICA_CLI_AUTHORIZE_PATH,
+} from "./cliAuthorizeSession";
 
 export * from "./api/types";
 export * as issueApi from "./api/issueApi";

--- a/packages/dmloop/src/index.tsx
+++ b/packages/dmloop/src/index.tsx
@@ -2,6 +2,7 @@
 
 export { default as LoopModule } from "./module";
 export { default as LoopPage } from "./pages/LoopPage";
+export { default as MulticaCliAuthorizePage } from "./pages/MulticaCliAuthorizePage";
 
 export * from "./api/types";
 export * as issueApi from "./api/issueApi";
@@ -11,6 +12,7 @@ export * as agentApi from "./api/agentApi";
 export * as squadApi from "./api/squadApi";
 export * as runtimeApi from "./api/runtimeApi";
 export * as workspaceApi from "./api/workspaceApi";
+export * as authApi from "./api/authApi";
 export {
   LOOP_API_BASE,
   currentWorkspaceSlug,

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -3,10 +3,17 @@ import { WKApp, Menus, i18n, t as translate } from "@octo/base";
 import type { IModule } from "@octo/base";
 import LoopPage from "./pages/LoopPage";
 import MulticaCliAuthorizePage from "./pages/MulticaCliAuthorizePage";
+import {
+  isMulticaCliAuthorizePath,
+  MULTICA_CLI_AUTHORIZE_PATH,
+  resolveMulticaCliAuthorizeSearch,
+  visibleMulticaCliAuthorizeSearch,
+} from "./cliAuthorizeSession";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 
 let _initialized = false;
+let multicaCliAuthorizeInitialSearch = "";
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     _initialized = false;
@@ -49,11 +56,43 @@ export default class LoopModule implements IModule {
       "en-US": enUS,
     });
 
+    if (
+      typeof window !== "undefined" &&
+      isMulticaCliAuthorizePath(window.location.pathname)
+    ) {
+      multicaCliAuthorizeInitialSearch = resolveMulticaCliAuthorizeSearch(
+        window.location.pathname,
+        window.location.search,
+        window.sessionStorage
+      );
+
+      // RouteManager keeps only `sid` on pageshow. Capture the callback above,
+      // then remove it from the address bar before it can remain in history.
+      if (new URLSearchParams(window.location.search).get("cli_callback")) {
+        try {
+          window.history.replaceState(
+            {},
+            "",
+            window.location.pathname +
+              visibleMulticaCliAuthorizeSearch(window.location.search)
+          );
+        } catch {
+          // The captured prop still protects the flow if History is unavailable.
+        }
+      }
+    }
+
     WKApp.route.register("/loop", () => <LoopPage />);
-    // TODO(octo-multica): adjust this path after the Octo Web product route is finalized.
-    WKApp.route.register("/loop/multica/cli-authorize", () => (
-      <MulticaCliAuthorizePage />
-    ));
+    const renderMulticaCliAuthorize = () => (
+      <MulticaCliAuthorizePage
+        initialSearch={multicaCliAuthorizeInitialSearch}
+      />
+    );
+    WKApp.route.register(MULTICA_CLI_AUTHORIZE_PATH, renderMulticaCliAuthorize);
+    WKApp.route.register(
+      `${MULTICA_CLI_AUTHORIZE_PATH}/`,
+      renderMulticaCliAuthorize
+    );
 
     WKApp.menus.register(
       "loop",

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { WKApp, Menus, i18n, t as translate } from "@octo/base";
 import type { IModule } from "@octo/base";
 import LoopPage from "./pages/LoopPage";
+import MulticaCliAuthorizePage from "./pages/MulticaCliAuthorizePage";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 
@@ -49,6 +50,10 @@ export default class LoopModule implements IModule {
     });
 
     WKApp.route.register("/loop", () => <LoopPage />);
+    // TODO(octo-multica): adjust this path after the Octo Web product route is finalized.
+    WKApp.route.register("/loop/multica/cli-authorize", () => (
+      <MulticaCliAuthorizePage />
+    ));
 
     WKApp.menus.register(
       "loop",
@@ -58,10 +63,10 @@ export default class LoopModule implements IModule {
           "/loop",
           translate("loop.menu.title"),
           <LoopIcon />,
-          <LoopIcon active />,
+          <LoopIcon active />
         );
       },
-      4003,
+      4003
     );
   }
 }

--- a/packages/dmloop/src/pages/MulticaCliAuthorizePage.tsx
+++ b/packages/dmloop/src/pages/MulticaCliAuthorizePage.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Avatar, Button, Toast, Typography } from "@douyinfe/semi-ui";
+import { Laptop, ShieldCheck } from "lucide-react";
+import { useI18n, WKApp } from "@octo/base";
+import type { Workspace } from "../api/types";
+import { issueMulticaCliToken } from "../api/authApi";
+import { listWorkspaces } from "../api/workspaceApi";
+import { currentWorkspaceId, setWorkspaceContext } from "../api/http";
+import "./loop.css";
+
+const { Text, Title } = Typography;
+
+function isPrivateIPv4(host: string): boolean {
+  const parts = host.split(".").map((p) => Number(p));
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+  ) {
+    return false;
+  }
+  const [a, b] = parts;
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function isSafeCliCallback(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      return false;
+    const host = parsed.hostname.toLowerCase();
+    return host === "localhost" || host === "::1" || isPrivateIPv4(host);
+  } catch {
+    return false;
+  }
+}
+
+function redirectToCli(
+  callbackURL: string,
+  token: string,
+  state: string | null
+): void {
+  const target = new URL(callbackURL);
+  target.searchParams.set("token", token);
+  if (state) target.searchParams.set("state", state);
+  window.location.href = target.toString();
+}
+
+export default function MulticaCliAuthorizePage() {
+  const { t } = useI18n();
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const cliCallback = params.get("cli_callback") ?? "";
+  const cliState = params.get("cli_state");
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [authorizing, setAuthorizing] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!cliCallback || !isSafeCliCallback(cliCallback)) {
+      setError(t("loop.cliAuthorize.invalidCallback"));
+      setLoading(false);
+      return;
+    }
+    if (!WKApp.loginInfo.token || !WKApp.shared.currentSpaceId) {
+      setError(t("loop.cliAuthorize.loginRequired"));
+      setLoading(false);
+      return;
+    }
+    listWorkspaces()
+      .then((list) => {
+        if (cancelled) return;
+        const selected =
+          list.find((w) => w.id === currentWorkspaceId()) ?? list[0] ?? null;
+        if (!selected) {
+          setError(t("loop.cliAuthorize.noWorkspace"));
+          return;
+        }
+        setWorkspaceContext(selected.slug, selected.id);
+        setWorkspace(selected);
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setError(
+            (err as Error)?.message ?? t("loop.cliAuthorize.loadFailed")
+          );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cliCallback, t]);
+
+  const authorize = async () => {
+    if (!workspace || !cliCallback || !isSafeCliCallback(cliCallback)) return;
+    setAuthorizing(true);
+    setError("");
+    try {
+      const { token } = await issueMulticaCliToken();
+      redirectToCli(cliCallback, token, cliState);
+    } catch (err) {
+      const msg =
+        (err as Error)?.message ?? t("loop.cliAuthorize.authorizeFailed");
+      setError(msg);
+      Toast.error(msg);
+      setAuthorizing(false);
+    }
+  };
+
+  return (
+    <div className="loop-cli-auth">
+      <div className="loop-cli-auth__panel">
+        <div className="loop-cli-auth__icon">
+          <Laptop size={26} />
+        </div>
+        <Title heading={3} className="loop-cli-auth__title">
+          {t("loop.cliAuthorize.title")}
+        </Title>
+        <Text type="secondary" className="loop-cli-auth__desc">
+          {t("loop.cliAuthorize.description")}
+        </Text>
+
+        <div className="loop-cli-auth__workspace">
+          <Avatar size="small" color="blue" shape="square">
+            {(workspace?.name ?? "L").slice(0, 1)}
+          </Avatar>
+          <div className="loop-cli-auth__workspace-meta">
+            <Text strong>
+              {workspace?.name ?? t("loop.cliAuthorize.workspaceLoading")}
+            </Text>
+            <Text type="tertiary" size="small">
+              {workspace?.slug ??
+                (loading ? t("loop.cliAuthorize.loading") : "-")}
+            </Text>
+          </div>
+        </div>
+
+        {error && <div className="loop-cli-auth__error">{error}</div>}
+
+        <Button
+          theme="solid"
+          type="primary"
+          size="large"
+          block
+          icon={<ShieldCheck size={16} />}
+          loading={authorizing}
+          disabled={loading || !!error || !workspace}
+          onClick={authorize}
+        >
+          {t("loop.cliAuthorize.authorize")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/dmloop/src/pages/MulticaCliAuthorizePage.tsx
+++ b/packages/dmloop/src/pages/MulticaCliAuthorizePage.tsx
@@ -6,6 +6,7 @@ import type { Workspace } from "../api/types";
 import { issueMulticaCliToken } from "../api/authApi";
 import { listWorkspaces } from "../api/workspaceApi";
 import { currentWorkspaceId, setWorkspaceContext } from "../api/http";
+import { clearPendingMulticaCliAuthorizeSearch } from "../cliAuthorizeSession";
 import "./loop.css";
 
 const { Text, Title } = Typography;
@@ -44,15 +45,26 @@ function redirectToCli(
   token: string,
   state: string | null
 ): void {
+  // TODO(octo-multica!18 security follow-up): replace this JWT-in-query
+  // handoff with server-bound device authorization or a one-time PKCE code.
   const target = new URL(callbackURL);
   target.searchParams.set("token", token);
   if (state) target.searchParams.set("state", state);
   window.location.href = target.toString();
 }
 
-export default function MulticaCliAuthorizePage() {
+interface MulticaCliAuthorizePageProps {
+  initialSearch?: string;
+}
+
+export default function MulticaCliAuthorizePage({
+  initialSearch = window.location.search,
+}: MulticaCliAuthorizePageProps) {
   const { t } = useI18n();
-  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const params = useMemo(
+    () => new URLSearchParams(initialSearch),
+    [initialSearch]
+  );
   const cliCallback = params.get("cli_callback") ?? "";
   const cliState = params.get("cli_state");
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
@@ -104,6 +116,7 @@ export default function MulticaCliAuthorizePage() {
     setError("");
     try {
       const { token } = await issueMulticaCliToken();
+      clearPendingMulticaCliAuthorizeSearch(window.sessionStorage);
       redirectToCli(cliCallback, token, cliState);
     } catch (err) {
       const msg =

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -193,6 +193,79 @@
   max-width: 360px;
 }
 
+/* ===== Multica CLI 授权 ===== */
+.loop-cli-auth {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--semi-color-bg-0);
+}
+
+.loop-cli-auth__panel {
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px;
+  border: 1px solid var(--semi-color-border);
+  border-radius: 8px;
+  background: var(--semi-color-bg-1);
+}
+
+.loop-cli-auth__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--semi-color-primary);
+  background: var(--semi-color-primary-light-default);
+}
+
+.loop-cli-auth__title {
+  margin: 0;
+}
+
+.loop-cli-auth__desc {
+  display: block;
+  line-height: 1.6;
+}
+
+.loop-cli-auth__workspace {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 56px;
+  padding: 10px 12px;
+  border: 1px solid var(--semi-color-border);
+  border-radius: 8px;
+}
+
+.loop-cli-auth__workspace-meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.loop-cli-auth__workspace-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-cli-auth__error {
+  padding: 10px 12px;
+  border-radius: 8px;
+  color: var(--semi-color-danger);
+  background: var(--semi-color-danger-light-default);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 /* ===== 视图切换按钮 ===== */
 .loop-viewtoggle {
   display: inline-flex;


### PR DESCRIPTION
## Summary
Add an Octo Web confirmation page for the Multica CLI add-computer authorization flow.

## Changes
- Register `/loop/multica/cli-authorize` as the temporary CLI authorization route, with a TODO to revisit the product path.
- Validate the CLI callback URL before redirecting back to the local CLI listener.
- Reuse Octo Web login state and selected Space, load Loop workspaces, and issue a Multica CLI token through the existing `/cli-token` API path.
- Add localized copy and styles for the authorization page.

## Testing
- `pnpm i18n:check`
- `pnpm exec prettier --check packages/dmloop/src/api/authApi.ts packages/dmloop/src/pages/MulticaCliAuthorizePage.tsx packages/dmloop/src/index.tsx packages/dmloop/src/module.tsx`
- `git diff --check`

## Notes
The route is intentionally temporary and can be renamed once the final Octo Web product path is confirmed.