### PR TITLE
feat(loop): issue delete, comment edit, list filters + pagination

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -2,7 +2,6 @@
 import type {
   Issue,
   IssueComment,
-  AgentTask,
   CreateIssueReq,
   UpdateIssueReq,
   ListParams,
@@ -23,11 +22,19 @@ async function enrich(issues: Issue[]): Promise<Issue[]> {
   }));
 }
 
-export async function listIssues(params?: ListParams): Promise<Issue[]> {
+export async function listIssues(
+  params?: ListParams,
+): Promise<{ issues: Issue[]; total: number }> {
   const data = await httpGet<{ issues: Issue[]; total?: number }>("/issues", {
     keyword: params?.keyword,
+    status: params?.status,
+    priority: params?.priority,
+    assignee_id: params?.assignee_id,
+    limit: params?.limit,
+    offset: params?.offset,
   });
-  return enrich(data.issues ?? []);
+  const issues = await enrich(data.issues ?? []);
+  return { issues, total: data.total ?? issues.length };
 }
 
 export async function getIssue(id: string): Promise<Issue> {
@@ -75,16 +82,9 @@ export function deleteComment(commentId: string): Promise<void> {
   return httpDelete<void>(`/comments/${commentId}`);
 }
 
-/* ---------- 执行日志 ---------- */
-export async function listTasks(issueId: string): Promise<AgentTask[]> {
-  const [rows, dir] = await Promise.all([
-    httpGet<AgentTask[]>(`/issues/${issueId}/tasks`).catch(() => [] as AgentTask[]),
-    ensureDirectory(),
-  ]);
-  return (rows ?? []).map((tk) => ({
-    ...tk,
-    agent_name: tk.agent_id ? dir.agentName.get(tk.agent_id) ?? null : null,
-  }));
+// 编辑评论：仅作者或 workspace owner/admin 可改（后端 PUT /comments/:id 强校验）。
+export function updateComment(commentId: string, content: string): Promise<IssueComment> {
+  return httpPut<IssueComment>(`/comments/${commentId}`, { content });
 }
 
 /* ---------- 指派候选 ---------- */

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -52,6 +52,11 @@ export interface Invitation {
 export interface ListParams {
   workspace_id?: string;
   keyword?: string;
+  status?: IssueStatus;
+  priority?: IssuePriority;
+  assignee_id?: string;
+  limit?: number;
+  offset?: number;
 }
 
 /* ---------- Issue ---------- */
@@ -123,17 +128,6 @@ export interface IssueComment {
 
 export type TaskStatus =
   | "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled" | string;
-
-export interface AgentTask {
-  id: string;
-  issue_id: string;
-  agent_id?: string | null;
-  status: TaskStatus;
-  trigger_summary?: string;
-  created_at: string;
-  completed_at?: string | null;
-  agent_name?: string | null;
-}
 
 /** 执行记录（run）：GET /issues/:id/task-runs。 */
 export interface TaskRun {

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -3,7 +3,8 @@
     "title": "Loop",
     "changeStatus": "Change status",
     "changePriority": "Change priority",
-    "changeAssignee": "Change assignee"
+    "changeAssignee": "Change assignee",
+    "deleteIssue": "Delete issue"
   },
   "nav": {
     "issue": "Issue",
@@ -40,6 +41,11 @@
     "project": "Search project",
     "agent": "Search agent",
     "squad": "Search squad"
+  },
+  "filter": {
+    "status": "Status",
+    "priority": "Priority",
+    "assignee": "Assignee"
   },
   "action": {
     "newIssue": "New Issue",
@@ -165,14 +171,18 @@
     "archived": "Archived",
     "deleted": "Deleted",
     "commentAdded": "Comment added",
-    "commentDeleted": "Comment deleted"
+    "commentDeleted": "Comment deleted",
+    "commentUpdated": "Comment updated",
+    "editFailed": "Edit failed",
+    "deleteFailed": "Delete failed"
   },
   "validate": {
     "nameRequired": "Name is required",
     "titleRequired": "Title is required"
   },
   "confirm": {
-    "delete": "Delete?"
+    "delete": "Delete?",
+    "deleteIssue": "Delete this issue? This cannot be undone."
   },
   "skill": {
     "source": "Source",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -3,7 +3,8 @@
     "title": "Loop",
     "changeStatus": "修改状态",
     "changePriority": "修改优先级",
-    "changeAssignee": "修改负责人"
+    "changeAssignee": "修改负责人",
+    "deleteIssue": "删除 Issue"
   },
   "nav": {
     "issue": "Issue",
@@ -40,6 +41,11 @@
     "project": "搜索项目",
     "agent": "搜索智能体",
     "squad": "搜索小队"
+  },
+  "filter": {
+    "status": "状态",
+    "priority": "优先级",
+    "assignee": "负责人"
   },
   "action": {
     "newIssue": "新建 Issue",
@@ -165,14 +171,18 @@
     "archived": "已归档",
     "deleted": "已删除",
     "commentAdded": "评论已添加",
-    "commentDeleted": "评论已删除"
+    "commentDeleted": "评论已删除",
+    "commentUpdated": "评论已更新",
+    "editFailed": "编辑失败",
+    "deleteFailed": "删除失败"
   },
   "validate": {
     "nameRequired": "请填写名称",
     "titleRequired": "请填写标题"
   },
   "confirm": {
-    "delete": "确定删除？"
+    "delete": "确定删除？",
+    "deleteIssue": "确定删除该 Issue？此操作不可撤销。"
   },
   "skill": {
     "source": "来源",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Typography,
   Input,
@@ -42,8 +42,10 @@ export default function IssuePage() {
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   const [createOpen, setCreateOpen] = useState(false);
   const cands = useAssigneeCandidates();
+  const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
 
   const reload = useCallback(() => {
+    const my = ++seq.current;
     setLoading(true);
     const paged = view === "list";
     listIssues({
@@ -56,10 +58,16 @@ export default function IssuePage() {
       offset: paged ? page * PAGE_SIZE : 0,
     })
       .then(({ issues, total }) => {
+        if (my !== seq.current) return; // 有更新的请求在途，丢弃本次过期响应
+        // 删除/改状态使匹配数下降时，当前 page 可能越界（offset≥total）→ 钳到最后一页并重取。
+        if (paged) {
+          const maxPage = Math.max(0, Math.ceil(total / PAGE_SIZE) - 1);
+          if (page > maxPage) { setPage(maxPage); return; }
+        }
         setIssues(issues);
         setTotal(total);
       })
-      .finally(() => setLoading(false));
+      .finally(() => { if (my === seq.current) setLoading(false); });
   }, [f, view, page]);
 
   useEffect(reload, [reload]);

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -5,11 +5,15 @@ import {
   Button,
   Spin,
   Toast,
+  Select,
+  Pagination,
 } from "@douyinfe/semi-ui";
 import { Search, Plus, LayoutGrid, List as ListIcon, ClipboardList } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Issue } from "../api/types";
+import type { Issue, IssueStatus, IssuePriority } from "../api/types";
 import { listIssues } from "../api/issueApi";
+import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
+import { ISSUE_STATUS_ORDER, PRIORITY_ORDER } from "../ui/meta";
 import IssueBoard from "../panel/IssueBoard";
 import IssueList from "../panel/IssueList";
 import IssueDetailPage from "../panel/IssueDetailPage";
@@ -19,22 +23,50 @@ const { Title } = Typography;
 
 type ViewMode = "board" | "list";
 
+interface Filters {
+  keyword: string;
+  status?: IssueStatus;
+  priority?: IssuePriority;
+  assignee?: string;
+}
+
+const PAGE_SIZE = 50;
+
 export default function IssuePage() {
   const { t } = useI18n();
   const [issues, setIssues] = useState<Issue[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<ViewMode>("board");
-  const [keyword, setKeyword] = useState("");
+  const [f, setF] = useState<Filters>({ keyword: "" });
+  const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   const [createOpen, setCreateOpen] = useState(false);
+  const cands = useAssigneeCandidates();
 
   const reload = useCallback(() => {
     setLoading(true);
-    listIssues({ keyword })
-      .then(setIssues)
+    const paged = view === "list";
+    listIssues({
+      keyword: f.keyword,
+      status: f.status,
+      priority: f.priority,
+      assignee_id: f.assignee,
+      // ponytail: 看板不分页——按 status 分列需全量，取后端上限 100；超量请用筛选或列表视图。
+      limit: paged ? PAGE_SIZE : 100,
+      offset: paged ? page * PAGE_SIZE : 0,
+    })
+      .then(({ issues, total }) => {
+        setIssues(issues);
+        setTotal(total);
+      })
       .finally(() => setLoading(false));
-  }, [keyword]);
+  }, [f, view, page]);
 
   useEffect(reload, [reload]);
+
+  // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
+  const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
+  const switchView = (v: ViewMode) => { setView(v); setPage(0); };
 
   // 点击 Issue → 跳转独立详情页（push 到右主栏，返回可 pop）。
   const openDetail = (id: string) => {
@@ -46,23 +78,60 @@ export default function IssuePage() {
       <div className="loop-page__head">
         <Title heading={4}>{t("loop.nav.issue")}</Title>
         <div className="loop-viewtoggle">
-          <button className={view === "board" ? "is-active" : ""} onClick={() => setView("board")}>
+          <button className={view === "board" ? "is-active" : ""} onClick={() => switchView("board")}>
             <LayoutGrid size={14} />
             {t("loop.view.board")}
           </button>
-          <button className={view === "list" ? "is-active" : ""} onClick={() => setView("list")}>
+          <button className={view === "list" ? "is-active" : ""} onClick={() => switchView("list")}>
             <ListIcon size={14} />
             {t("loop.view.list")}
           </button>
         </div>
         <div className="loop-page__spacer" />
+        <Select
+          placeholder={t("loop.filter.status")}
+          value={f.status}
+          onChange={(v) => update({ status: v as IssueStatus | undefined })}
+          showClear
+          size="small"
+          style={{ width: 130 }}
+        >
+          {ISSUE_STATUS_ORDER.map((s) => (
+            <Select.Option key={s} value={s}>{t(`loop.status.${s}`)}</Select.Option>
+          ))}
+        </Select>
+        <Select
+          placeholder={t("loop.filter.priority")}
+          value={f.priority}
+          onChange={(v) => update({ priority: v as IssuePriority | undefined })}
+          showClear
+          size="small"
+          style={{ width: 120 }}
+        >
+          {PRIORITY_ORDER.map((p) => (
+            <Select.Option key={p} value={p}>{t(`loop.priority.${p}`)}</Select.Option>
+          ))}
+        </Select>
+        <Select
+          placeholder={t("loop.filter.assignee")}
+          value={f.assignee}
+          onChange={(v) => update({ assignee: v as string | undefined })}
+          showClear
+          filter
+          size="small"
+          style={{ width: 150 }}
+        >
+          {cands.map((c) => (
+            <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
+          ))}
+        </Select>
         <Input
           prefix={<Search size={14} />}
           placeholder={t("loop.search.issue")}
-          value={keyword}
-          onChange={setKeyword}
+          value={f.keyword}
+          onChange={(v) => update({ keyword: v })}
           showClear
-          style={{ width: 220 }}
+          style={{ width: 200 }}
         />
         <Button theme="solid" icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
           {t("loop.action.newIssue")}
@@ -74,7 +143,7 @@ export default function IssuePage() {
           <div className="loop-page__center">
             <Spin />
           </div>
-        ) : issues.length === 0 ? (
+        ) : total === 0 ? (
           <div className="loop-empty">
             <ClipboardList size={40} className="loop-empty__icon" />
             <div className="loop-empty__title">{t("loop.empty.issueTitle")}</div>
@@ -86,7 +155,19 @@ export default function IssuePage() {
         ) : view === "board" ? (
           <IssueBoard issues={issues} onOpen={openDetail} onChanged={reload} />
         ) : (
-          <IssueList issues={issues} onOpen={openDetail} onChanged={reload} />
+          <>
+            <IssueList issues={issues} onOpen={openDetail} onChanged={reload} />
+            {total > PAGE_SIZE && (
+              <div style={{ display: "flex", justifyContent: "flex-end", padding: "12px 4px" }}>
+                <Pagination
+                  total={total}
+                  pageSize={PAGE_SIZE}
+                  currentPage={page + 1}
+                  onPageChange={(p) => setPage(p - 1)}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -29,18 +29,19 @@ import type {
   TaskRun,
   IssueStatus,
   IssuePriority,
-  AssigneeCandidate,
 } from "../api/types";
 import {
   getIssue,
   updateIssue,
+  deleteIssue,
   listComments,
   addComment,
   deleteComment,
-  listAssigneeCandidates,
+  updateComment,
 } from "../api/issueApi";
 import { listRuns } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
 import { confirmDelete } from "../ui/confirmDelete";
 import RunDetailModal from "./RunDetailModal";
@@ -78,12 +79,14 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
   const [runOpen, setRunOpen] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
-  const [cands, setCands] = useState<AssigneeCandidate[]>([]);
+  const cands = useAssigneeCandidates();
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
 
   const reload = () => {
     setLoading(true);
@@ -100,7 +103,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   };
 
   useEffect(reload, [issueId]);
-  useEffect(() => { listAssigneeCandidates().then(setCands); }, []);
 
   const patch = async (p: Parameters<typeof updateIssue>[1]) => {
     if (!issue) return;
@@ -123,6 +125,38 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     await deleteComment(id);
     setComments(await listComments(issueId));
     Toast.success(t("loop.toast.commentDeleted"));
+  };
+
+  const saveEdit = async (id: string) => {
+    const content = editDraft.trim();
+    if (!content) return;
+    try {
+      await updateComment(id, content);
+      setEditingId(null);
+      setComments(await listComments(issueId));
+      Toast.success(t("loop.toast.commentUpdated"));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.editFailed"));
+    }
+  };
+
+  const handleDeleteIssue = () => {
+    if (!issue) return;
+    confirmDelete({
+      title: t("loop.confirm.deleteIssue"),
+      okText: t("loop.action.delete"),
+      cancelText: t("loop.action.cancel"),
+      onOk: async () => {
+        try {
+          await deleteIssue(issue.id);
+          Toast.success(t("loop.toast.deleted"));
+          onChanged?.();
+          back();
+        } catch (e) {
+          Toast.error((e as Error)?.message ?? t("loop.toast.deleteFailed"));
+        }
+      },
+    });
   };
 
   const back = () => WKApp.routeRight.pop();
@@ -198,6 +232,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       >
         <Dropdown.Item>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
+      <Dropdown.Divider />
+      <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={handleDeleteIssue}>
+        {t("loop.menu.deleteIssue")}
+      </Dropdown.Item>
     </Dropdown.Menu>
   );
 
@@ -252,13 +290,29 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           <Button
             size="small"
             theme="borderless"
+            icon={<Pencil size={13} />}
+            onClick={() => { setEditingId(c.id); setEditDraft(c.content); setReplyTo(null); }}
+          />
+          <Button
+            size="small"
+            theme="borderless"
             type="danger"
             icon={<Trash2 size={13} />}
             onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })}
           />
         </div>
       </div>
-      <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
+      {editingId === c.id ? (
+        <div className="loop-comment__body" style={{ marginTop: 6 }}>
+          <TextArea value={editDraft} onChange={setEditDraft} autosize={{ minRows: 2, maxRows: 10 }} />
+          <div style={{ marginTop: 6, display: "flex", gap: 8 }}>
+            <Button size="small" theme="solid" onClick={() => saveEdit(c.id)}>{t("loop.action.save")}</Button>
+            <Button size="small" theme="borderless" onClick={() => setEditingId(null)}>{t("loop.action.cancel")}</Button>
+          </div>
+        </div>
+      ) : (
+        <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
+      )}
       {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
       {!reply && replyTo === c.id && (
         <div style={{ marginTop: 8, display: "flex", gap: 8 }}>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -132,12 +132,14 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (!content) return;
     try {
       await updateComment(id, content);
-      setEditingId(null);
-      setComments(await listComments(issueId));
-      Toast.success(t("loop.toast.commentUpdated"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.editFailed"));
+      return;
     }
+    // 编辑已落库；重拉以回填 directory 名字/头像。重拉失败不应报“编辑失败”。
+    setEditingId(null);
+    setComments(await listComments(issueId));
+    Toast.success(t("loop.toast.commentUpdated"));
   };
 
   const handleDeleteIssue = () => {
@@ -282,7 +284,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               size="small"
               theme="borderless"
               icon={<CornerDownRight size={13} />}
-              onClick={() => setReplyTo(replyTo === c.id ? null : c.id)}
+              onClick={() => { setReplyTo(replyTo === c.id ? null : c.id); setEditingId(null); }}
             >
               {t("loop.comment.reply")}
             </Button>

--- a/packages/dmloop/src/ui/useAssigneeCandidates.ts
+++ b/packages/dmloop/src/ui/useAssigneeCandidates.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+import type { AssigneeCandidate } from "../api/types";
+import { listAssigneeCandidates } from "../api/issueApi";
+
+/** 加载 assignee 候选（member/agent/squad）。底层 directory 已做缓存，多处调用不重复拉网。 */
+export function useAssigneeCandidates(): AssigneeCandidate[] {
+  const [cands, setCands] = useState<AssigneeCandidate[]>([]);
+  useEffect(() => {
+    listAssigneeCandidates().then(setCands).catch(() => setCands([]));
+  }, []);
+  return cands;
+}


### PR DESCRIPTION
## What

Brings the dmloop issue surface closer to multica's native web for table-stakes CRUD, and removes a dead code path.

- **Delete issue** — adds a *delete issue* item to the detail `···` menu with an irreversible-action confirm; navigates back and refreshes the list on success (backend `DELETE /issues/:id`).
- **Edit comment** — inline edit in the comment thread (author/admin enforced by backend `PUT /comments/:id`); refetches so the edited comment keeps its directory-enriched author name/avatar.
- **List filters + pagination** — server-side `status` / `priority` / `assignee_id` filters (GET `/issues` query params) plus list-view pagination (`limit`/`offset`; backend already returns `total`). Board view intentionally loads up to the backend cap (100) since status columns need the full set. Fixes the prior silent 100-cap where issues beyond the first 100 were unreachable.
- **Dead code** — removes `listTasks()` → `GET /issues/:id/tasks` (no such route, never called) and its unused `AgentTask` type; runs use `TaskRun` / `task-runs`.
- **Cleanup** — extracts a shared `useAssigneeCandidates` hook to de-duplicate candidate loading (`/simplify`).

## Verification

Verified end-to-end in the real web app (octo-web `:3000` → loop proxy → multica) signed in as Alice:

| Check | Result |
|---|---|
| Status filter = in_progress | board narrows 3 → 1 card server-side |
| Priority filter = high | narrows to only the high-priority issue |
| Comment add → edit | text persists, edit mode closes, author name/avatar intact |
| Delete issue via `···` → confirm | issue removed, returns to list, sibling issues untouched |
| i18n | new status/priority/assignee filter, delete-issue, confirm strings render (zh + en) |

Typecheck: no new errors in the changed files.

## Notes

- No linked issue yet — `check-sprint` will need a maintainer to attach one on the Board.
- Scope stays on table-stakes issue CRUD; the crown-jewel dispatch loop (quick-create / run-confirm / rerun-cancel / review-back) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)