### PR TITLE
fix(global-search): sub-tab default scrollbar + filter panel footer truncation

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -122,6 +123,51 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
 
   const keywordActive = keyword.trim().length > 0;
   const selfUid = dataSource.getSelfUid();
+
+  // Task 3 (footer truncation): the popover is `position: absolute` under the
+  // filter trigger and its natural height (~600px) exceeds the space between
+  // its top and the bottom of the enclosing Semi modal, so the 「发送时间」
+  // section + Apply/Clear footer render below the fold — and because the footer
+  // lives OUTSIDE the scrollable body, body-scroll alone can't reach it. This is
+  // what #592's pure-CSS `max-height` cap missed on two counts: CSS can't read
+  // the panel's own viewport top (it shifts with the vertically-centered modal),
+  // and the true clipping edge is the Semi `.semi-modal-content` (which has
+  // `overflow: hidden`), NOT the viewport. Measure the panel's top on open (and
+  // on resize) and cap max-height to `min(clippingAncestorsBottom, viewport) -
+  // top - gutter` so the whole panel — footer included — always fits inside the
+  // modal while the body scrolls internally. useLayoutEffect runs before paint,
+  // so the oversized frame is never shown.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelMaxHeight, setPanelMaxHeight] = useState<number | undefined>(
+    undefined
+  );
+  useLayoutEffect(() => {
+    const measure = () => {
+      const el = panelRef.current;
+      if (!el) return;
+      const top = el.getBoundingClientRect().top;
+      const gutter = 16; // keep the panel clear of the clipping bottom edge
+      // The visible bottom is bounded by the viewport AND by every clipping
+      // ancestor (overflow != visible) — the Semi modal content clips with
+      // overflow:hidden. Take the tightest.
+      let boundBottom = window.innerHeight;
+      let anc: HTMLElement | null = el.parentElement;
+      while (anc) {
+        const cs = window.getComputedStyle(anc);
+        if (cs.overflowY !== "visible" || cs.overflowX !== "visible") {
+          boundBottom = Math.min(boundBottom, anc.getBoundingClientRect().bottom);
+        }
+        anc = anc.parentElement;
+      }
+      const avail = boundBottom - top - gutter;
+      // Floor guards degenerate/tiny containers; when the content is shorter
+      // than `avail` the panel keeps its natural (smaller) height regardless.
+      setPanelMaxHeight(Math.max(160, Math.round(avail)));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
 
   // Load sender candidates on open + when query changes (debounced light).
   useEffect(() => {
@@ -449,7 +495,9 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
 
   return (
     <div
+      ref={panelRef}
       className="wk-channel-search-filter-popover wk-global-search-filter-panel"
+      style={panelMaxHeight ? { maxHeight: `${panelMaxHeight}px` } : undefined}
       onClick={(e) => e.stopPropagation()}
     >
       <div className="wk-global-search-filter-body">

--- a/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
@@ -56,6 +56,26 @@
 }
 
 /*
+  Task 2 (sub-tab scrollbar): the shared ChannelSearch empty / loading / error
+  states carry `min-height: 520px; padding-top: 160px` (index.css) sized for the
+  full-height in-conversation panel. Inside the global modal the scroll area is
+  only ~50vh minus the filter toolbar (~356px at an 800px viewport), so that
+  fixed 520px block overflows and forces a scrollbar on the DEFAULT
+  (no-result / "Searching…") state — content that is not long enough to warrant
+  scrolling. Let these states fill the available content height and center their
+  illustration instead, matching the 群组 sub-tab (`.wk-tab-group`), which never
+  scrolls until it actually has more items than fit. Real result lists
+  (`wk-channel-search-*-list`) are untouched and still scroll when they overflow.
+*/
+.wk-global-content-search .wk-channel-search-empty,
+.wk-global-content-search .wk-channel-search-loading,
+.wk-global-content-search .wk-channel-search-error {
+  min-height: 100%;
+  padding-top: 0;
+  justify-content: center;
+}
+
+/*
   Filter popover: reuse ChannelSearch's `wk-channel-search-filter-*` shell
   (popover / section / title / chip / actions) for identical chrome. This
   class only carries the global-search-specific sizing overrides — the global


### PR DESCRIPTION
# Global search: sub-tab default scrollbar + filter panel footer truncation

Follow-up to #553 / #554 / #592 covering three post-merge issues in Global Search (YUJ-24).

## Summary of the three items

1. **Latency profiling for Global Search Chat/Files** (investigation only; documented, not fixed in this PR — see the "Task 1" section below).
2. **Chat/Files sub-tabs render an unnecessary scrollbar on default load.** (Fixed here.)
3. **Filter panel footer (`Sent time` + `Confirm` / `Clear` buttons) is still cut off after #592.** (Fixed here.)

This PR delivers items **2 + 3**. Item 1 is a diagnosis + recommendation set with no code change; the full write-up sits in the tracker so backend can act on OpenSearch-side profiling / `Server-Timing` per-phase timing.

---

## Item 2 — Default scrollbar on Chat/Files sub-tabs

**Root cause.** The shared `ChannelSearch` empty / loading / error states carry `min-height: 520px; padding-top: 160px`, sized for the full-height in-conversation panel. Inside the Global Search modal, the scroll area is only ~50vh minus the filter toolbar (~356px at an 800px viewport), so that fixed 520px block overflows and forces a scrollbar on the **default** (no-result / "Searching...") state — content that is not long enough to warrant scrolling. The Groups sub-tab (`.wk-tab-group`) never has this problem because it uses a fill-available layout for those states.

**Fix.** Add 20 lines to `packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css`, scoped to `.wk-global-content-search`, capping the three states to `min-height: 100%; padding-top: 0; justify-content: center`. Real result lists (`.wk-channel-search-*-list`) are untouched and still scroll when they legitimately overflow. Shared `ChannelSearch` defaults are not modified, so the in-conversation full-height path is unaffected.

---

## Item 3 — Filter panel footer truncation (#592 follow-up)

**Root cause.** `GlobalSearchFilterPanel` is a `position: absolute` popover. Its natural height (~600px, driven by the sender chip grid + `Sent time` section + footer) exceeds the space between the popover top and the bottom of the enclosing Semi modal, which clips with `overflow: hidden`. The `Sent time` section and the `Confirm` / `Clear` footer therefore render below the fold, and because the footer sits **outside** the scrollable body, body-scroll alone cannot reach them.

`#592` tried to cap this with pure-CSS `max-height: 80vh`. That fails on two counts:

- CSS cannot read the panel's own viewport top — it shifts with the vertically-centered modal — so 80vh mis-caps at short viewports and large modals.
- The true clipping edge is `.semi-modal-content` (the Semi modal wrapper), not the viewport. A vh cap therefore over-shoots the clip in some configurations while under-shooting in others.

**Fix.** 48 lines in `packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx`. On mount and on window resize, measure the panel's `getBoundingClientRect().top`, walk up the DOM to find the nearest ancestor with `overflow != visible` (the Semi modal), and cap the popover's `max-height` at `min(clippingAncestorsBottom, viewport.innerHeight) - top - 16px gutter`. The measurement runs inside `useLayoutEffect`, so the browser never paints an oversized frame. The footer remains its natural sticky/flow element; the body scrolls internally.

No new dependencies. The existing `wk-channel-search-filter-*` shell classes are still used unchanged.

---

## Task 1 — Latency profiling (no code change in this PR; posted for backend follow-up)

Measured on dmwork-test via Playwright + `kubectl logs deploy/dmworkim-develop`, 2026-07-10.

| tab | keyword | frontend TTFB = backend `took_ms` |
|-----|---------|-----------------------------------|
| Chat | 项目 | 5257 ms |
| Chat | the | 4722 ms |
| Chat | 会议 | 5117 ms |
| Files | 报告 | 4654 ms |
| Files | pdf | 4565 / 4584 ms |
| Files | 文档 | 4540 ms |

Backend audit `took_ms` sits at a **flat ~4.5 s floor regardless of hit count (0 / 1 / 3)**, versus 16-25 ms for the legacy contacts/groups allowlist path. Isolation experiments (empty-keyword vs keyword replays; 0-hit vs 3-hit) rule out `_analyze` (ik_smart tokenization), hit-count, result size, MySQL allowlist build, and the frontend. Backend `context canceled` errors always point at the OpenSearch `_search` round-trip to `10.10.148.15:9200/test-octo-message-read/_search`, and `OCTO_SEARCH_TIMEOUT` defaults to 5s — a ceiling that sits right above the observed 4.5 s floor, hence the frequent deadline 400s users see as "search failed".

**Recommendations (priority order):**

1. Emit per-phase timing (`allowlist_ms / analyze_ms / os_search_ms / filter_visible_ms / sender_join_ms / oversample_pages`) into the `messages_search.audit` line and/or a `Server-Timing` response header. Cheap; unblocks precise attribution in staging and prod.
2. Attack the OpenSearch `_search` latency: pull OS `took` and run Profile API / slow-log on `test-octo-message-read`; verify shard fan-out on the global (routing-less) path; check dmwork-test OS cluster health and sizing; confirm the pooled elastic client reuses keep-alive and that `SetHealthcheck(true)` is not adding blocking waits behind the VIP.
3. Timeout + cancellation hygiene: `OCTO_SEARCH_TIMEOUT=5s` is barely above the floor — fix the OS latency first; interim, raise the timeout so legitimate slow queries complete. Frontend: add an `AbortController` so superseded requests (tab switch / new keyword) are cancelled client-side.
4. Allowlist caching / terms-lookup: defence-in-depth, **lower** priority — evidence shows it is not today's bottleneck.

Detailed evidence (raw + curated backend logs, isolation experiments, per-request frontend timings, screenshots) is retained locally at `~/Projects/global-search-design/screens/perf-analysis.md`; happy to attach on request.

---

## Verification

Playwright (system Chromium, `VITE_API_URL=https://im-test.deepminer.com.cn`, real login):

- **Item 2** — viewport 800, Chat + Files sub-tabs default load → no scrollbar on the right; illustration is centered in the available space. Screenshots: `t2-chat-fixed.png`, `t2-files-fixed.png`.
- **Item 3** — viewport 640 / 800 / 900 (three heights), Chat filter panel opened → whole panel fits in the modal; scrolling the body to the bottom reveals `Sent time` + `Confirm` / `Clear`, all visible and hit-testable. Compared against `t3-before-vh{640,800,900}[-scrolled].png`, which show the pre-fix truncation clearly.

Local checks:

- `pnpm i18n:check` — green.
- `pnpm lint:wkmodal` — green (21 WKModal class names scanned; existing 21 native Semi overrides left as pre-existing technical debt).
- `pnpm build @octo/web` — green. Only pre-existing warnings: direct `eval` in `lottie-web` / `lottie-player` / `pdfjs-dist`, chunk-size warning on the BoardSession bundle, and one `INEFFECTIVE_DYNAMIC_IMPORT` on `@douyinfe/semi-ui`. None introduced by this PR.
- Rebased onto latest `upstream/main` (`1b0ec3d4 fix: align interactive card element manifest`).

## Non-regressions

- No hard-coded colors (no color tokens touched at all).
- No revert of #553 / #554 / #592 — item 3 is a strict improvement over #592's pure-CSS cap.
- Reuses existing `ChannelSearch` / Groups tab rendering; no new dependencies.

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;


Fixes #603
