### PR TITLE
feat(loop): dispatch confirmation when assigning an issue to an agent

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -6,6 +6,8 @@ import type {
   UpdateIssueReq,
   ListParams,
   AssigneeCandidate,
+  IssueTriggerPreview,
+  IssueTriggerPreviewParams,
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
@@ -52,6 +54,11 @@ export function updateIssue(id: string, req: UpdateIssueReq): Promise<Issue> {
 
 export function deleteIssue(id: string): Promise<void> {
   return httpDelete<void>(`/issues/${id}`);
+}
+
+// 派单预触发（只读）：问后端“这次指派/状态变更会不会起 run、谁跑”。绝不前端猜。
+export function previewIssueTrigger(params: IssueTriggerPreviewParams): Promise<IssueTriggerPreview> {
+  return httpPost<IssueTriggerPreview>("/issues/preview-trigger", params);
 }
 
 /* ---------- 评论 ---------- */

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -112,6 +112,28 @@ export interface UpdateIssueReq {
   assignee_id?: string | null;
   project_id?: string | null;
   position?: number;
+  // 指派/状态变更触发 agent run 时：suppress_run=true 表示“暂不开始”；handoff_note 仅在真起 run 时消费。
+  suppress_run?: boolean;
+  handoff_note?: string;
+}
+
+/* ---------- 派单预触发（RunConfirm 预确认，只读） ---------- */
+export interface IssueTriggerPreviewParams {
+  issue_ids?: string[];
+  is_create?: boolean;
+  assignee_type?: AssigneeType | null;
+  assignee_id?: string | null;
+  status?: IssueStatus;
+}
+export interface IssueTriggerPreviewItem {
+  issue_id: string;
+  agent_id: string; // 将运行的 agent（squad 则为 leader）
+  source: string; // "assign" | "status"
+  handoff_supported: boolean; // 目标 runtime CLI 版本是否支持渲染 handoff note
+}
+export interface IssueTriggerPreview {
+  triggers: IssueTriggerPreviewItem[];
+  total_count: number;
 }
 
 export interface IssueComment {

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -186,7 +186,8 @@
     "commentDeleted": "Comment deleted",
     "commentUpdated": "Comment updated",
     "editFailed": "Edit failed",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "saveFailed": "Save failed"
   },
   "validate": {
     "nameRequired": "Name is required",
@@ -263,7 +264,15 @@
     "completed": "Completed",
     "result": "Result",
     "messages": "Messages",
-    "noMessages": "No messages"
+    "noMessages": "No messages",
+    "confirmTitle": "Dispatch confirmation",
+    "willStart": "This will dispatch to {{name}} and start running now.",
+    "nothing": "Assign to {{name}} — this will not start a run.",
+    "suppress": "Don't start yet",
+    "start": "Start",
+    "apply": "Apply",
+    "handoffPlaceholder": "Optional: a handoff note for this dispatch…",
+    "handoffUnsupported": "Target runtime is too old to support a handoff note"
   },
   "device": {
     "devices": "Devices",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -272,7 +272,8 @@
     "start": "Start",
     "apply": "Apply",
     "handoffPlaceholder": "Optional: a handoff note for this dispatch…",
-    "handoffUnsupported": "Target runtime is too old to support a handoff note"
+    "handoffUnsupported": "Target runtime is too old to support a handoff note",
+    "previewFailed": "Couldn't fetch dispatch info; treating as \"will start\" — please confirm"
   },
   "device": {
     "devices": "Devices",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -272,7 +272,8 @@
     "start": "开始",
     "apply": "应用",
     "handoffPlaceholder": "可选：给这次派单一段交接说明…",
-    "handoffUnsupported": "目标运行环境版本较旧，暂不支持交接说明"
+    "handoffUnsupported": "目标运行环境版本较旧，暂不支持交接说明",
+    "previewFailed": "无法预取派单信息，将按“会启动执行”处理，请确认"
   },
   "device": {
     "devices": "设备",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -186,7 +186,8 @@
     "commentDeleted": "评论已删除",
     "commentUpdated": "评论已更新",
     "editFailed": "编辑失败",
-    "deleteFailed": "删除失败"
+    "deleteFailed": "删除失败",
+    "saveFailed": "保存失败"
   },
   "validate": {
     "nameRequired": "请填写名称",
@@ -263,7 +264,15 @@
     "completed": "完成时间",
     "result": "结果",
     "messages": "消息流",
-    "noMessages": "暂无消息"
+    "noMessages": "暂无消息",
+    "confirmTitle": "派单确认",
+    "willStart": "将立即派单给 {{name}} 开始执行。",
+    "nothing": "指派给 {{name}}，不会触发执行。",
+    "suppress": "暂不开始",
+    "start": "开始",
+    "apply": "应用",
+    "handoffPlaceholder": "可选：给这次派单一段交接说明…",
+    "handoffUnsupported": "目标运行环境版本较旧，暂不支持交接说明"
   },
   "device": {
     "devices": "设备",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -41,6 +41,7 @@ import {
 } from "../api/issueApi";
 import { listRuns } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
 import { confirmDelete } from "../ui/confirmDelete";
@@ -80,6 +81,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runOpen, setRunOpen] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
+  const { requestAssign, runConfirmModal } = useRunConfirm();
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
@@ -222,7 +224,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   <Dropdown.Divider />
                   <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
                   {items.map((c) => (
-                    <Dropdown.Item key={c.id} active={issue?.assignee_id === c.id} onClick={() => patch({ assignee_id: c.id, assignee_type: c.type })}>
+                    <Dropdown.Item key={c.id} active={issue?.assignee_id === c.id} onClick={() => issue && requestAssign({ issueId: issue.id, status: issue.status, assigneeType: c.type, assigneeId: c.id, assigneeName: c.name, apply: (extra) => patch({ assignee_id: c.id, assignee_type: c.type, ...extra }) })}>
                       {c.name}
                     </Dropdown.Item>
                   ))}
@@ -456,7 +458,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 <AssigneePicker
                   value={issue.assignee_id}
                   valueName={issue.assignee_name ?? null}
-                  onChange={(id, type) => patch({ assignee_id: id, assignee_type: type })}
+                  onChange={(id, type, name) => requestAssign({ issueId: issue.id, status: issue.status, assigneeType: type, assigneeId: id, assigneeName: name, apply: (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }) })}
                 />
               </dd>
               <dt>{t("loop.field.project")}</dt>
@@ -502,6 +504,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       </div>
 
       <RunDetailModal run={activeRun} visible={runOpen} onClose={() => setRunOpen(false)} />
+      {runConfirmModal}
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
@@ -26,6 +27,7 @@ export default function IssueList({
   onChanged,
 }: IssueListProps) {
   const { t } = useI18n();
+  const { requestAssign, runConfirmModal } = useRunConfirm();
 
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
     await updateIssue(id, p);
@@ -105,7 +107,7 @@ export default function IssueList({
           size="small"
           value={r.assignee_id}
           valueName={r.assignee_name ?? null}
-          onChange={(id, type) => patch(r.id, { assignee_id: id, assignee_type: type })}
+          onChange={(id, type, name) => requestAssign({ issueId: r.id, status: r.status, assigneeType: type, assigneeId: id, assigneeName: name, apply: (extra) => patch(r.id, { assignee_id: id, assignee_type: type, ...extra }) })}
         />
       ),
     },
@@ -118,12 +120,15 @@ export default function IssueList({
   ];
 
   return (
-    <Table
-      rowKey="id"
-      columns={columns}
-      dataSource={issues}
-      pagination={false}
-      size="small"
-    />
+    <>
+      <Table
+        rowKey="id"
+        columns={columns}
+        dataSource={issues}
+        pagination={false}
+        size="small"
+      />
+      {runConfirmModal}
+    </>
   );
 }

--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -15,7 +15,7 @@ function typeIcon(type: AssigneeType) {
 export interface AssigneePickerProps {
   value: string | null;
   valueName: string | null;
-  onChange: (id: string | null, type: AssigneeType | null) => void;
+  onChange: (id: string | null, type: AssigneeType | null, name: string | null) => void;
   size?: "small" | "default";
 }
 
@@ -37,7 +37,7 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
 
   const menu = (
     <Dropdown.Menu>
-      <Dropdown.Item onClick={() => onChange(null, null)} icon={<CircleSlash size={13} />}>
+      <Dropdown.Item onClick={() => onChange(null, null, null)} icon={<CircleSlash size={13} />}>
         {t("loop.assignee.unassigned")}
       </Dropdown.Item>
       {groups.map((g) => {
@@ -54,7 +54,7 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
                   ? <Avatar size="extra-extra-small" color="light-blue" src={WKApp.shared.avatarUser(c.octo_uid)}>{c.name.slice(0, 1)}</Avatar>
                   : typeIcon(c.type)}
                 active={c.id === value}
-                onClick={() => onChange(c.id, c.type)}
+                onClick={() => onChange(c.id, c.type, c.name)}
               >
                 {c.name}
               </Dropdown.Item>

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -29,10 +29,15 @@ function needsConfirm(r: RunConfirmRequest): boolean {
  * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
  */
 export function useRunConfirm() {
+  const { t } = useI18n();
   const [pending, setPending] = useState<RunConfirmRequest | null>(null);
 
   const requestAssign = (r: RunConfirmRequest) => {
-    if (!needsConfirm(r)) { void r.apply({}); return; }
+    if (!needsConfirm(r)) {
+      // 直接落库路径（member/取消指派/backlog）：失败要给反馈，与确认路径一致，别静默吞错。
+      Promise.resolve(r.apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
+      return;
+    }
     setPending(r);
   };
 
@@ -47,11 +52,14 @@ function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | nu
   const [handoffSupported, setHandoffSupported] = useState(false);
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [errored, setErrored] = useState(false); // 预览失败:无法确定,按“会起 run”处理(fail-safe)
 
   useEffect(() => {
     if (!pending) return;
+    let cancelled = false; // 切换 issue 时丢弃过期预览响应,防串台
     setNote("");
     setSubmitting(false);
+    setErrored(false);
     setLoading(true);
     previewIssueTrigger({
       issue_ids: [pending.issueId],
@@ -60,13 +68,21 @@ function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | nu
       status: pending.status,
     })
       .then((p) => {
+        if (cancelled) return;
         // 后端保证不起 run 的 issue 直接缺席 → total_count == triggers.length;用单一来源判定。
         const starts = p.triggers.length > 0;
         setWillStart(starts);
         setHandoffSupported(starts && p.triggers.every((x) => x.handoff_supported));
       })
-      .catch(() => { setWillStart(false); setHandoffSupported(false); })
-      .finally(() => setLoading(false));
+      .catch(() => {
+        if (cancelled) return;
+        // fail-safe:预览拿不到就当“会起 run”,给出 suppress/开始 选项,绝不静默派单。
+        setErrored(true);
+        setWillStart(true);
+        setHandoffSupported(false);
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, [pending]);
 
   const run = async (extra: { suppress_run?: boolean; handoff_note?: string }) => {
@@ -109,6 +125,7 @@ function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | nu
         <div style={{ display: "flex", justifyContent: "center", padding: 24 }}><Spin /></div>
       ) : willStart ? (
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {errored && <Text type="warning" size="small">{t("loop.run.previewFailed")}</Text>}
           <Text>{t("loop.run.willStart", { values: { name: pending?.assigneeName ?? "" } })}</Text>
           <TextArea
             value={note}

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Button, TextArea, Spin, Typography, Toast } from "@douyinfe/semi-ui";
+import { useI18n } from "@octo/base";
+import type { AssigneeType, IssueStatus } from "../api/types";
+import { previewIssueTrigger } from "../api/issueApi";
+
+const { Text } = Typography;
+
+/** 一次指派/状态变更请求：apply 由调用方给出（真正落库的 updateIssue 调用）。 */
+export interface RunConfirmRequest {
+  issueId: string;
+  status: IssueStatus;
+  assigneeType: AssigneeType | null;
+  assigneeId: string | null;
+  assigneeName: string | null;
+  apply: (extra: { suppress_run?: boolean; handoff_note?: string }) => void | Promise<void>;
+}
+
+// 是否需要“派单预确认”：与 multica 一致——agent/squad 指派且 issue 非 backlog。
+function needsConfirm(r: RunConfirmRequest): boolean {
+  return (r.assigneeType === "agent" || r.assigneeType === "squad") && !!r.assigneeId && r.status !== "backlog";
+}
+
+/**
+ * 指派即触发的预确认 hook。用法：
+ *   const { requestAssign, runConfirmModal } = useRunConfirm();
+ *   <AssigneePicker onChange={(id,type)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
+ *   {runConfirmModal}
+ * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
+ */
+export function useRunConfirm() {
+  const [pending, setPending] = useState<RunConfirmRequest | null>(null);
+
+  const requestAssign = (r: RunConfirmRequest) => {
+    if (!needsConfirm(r)) { void r.apply({}); return; }
+    setPending(r);
+  };
+
+  const runConfirmModal = <RunConfirmModal pending={pending} onClose={() => setPending(null)} />;
+  return { requestAssign, runConfirmModal };
+}
+
+function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | null; onClose: () => void }) {
+  const { t } = useI18n();
+  const [loading, setLoading] = useState(false);
+  const [willStart, setWillStart] = useState(false);
+  const [handoffSupported, setHandoffSupported] = useState(false);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!pending) return;
+    setNote("");
+    setSubmitting(false);
+    setLoading(true);
+    previewIssueTrigger({
+      issue_ids: [pending.issueId],
+      assignee_type: pending.assigneeType,
+      assignee_id: pending.assigneeId,
+      status: pending.status,
+    })
+      .then((p) => {
+        // 后端保证不起 run 的 issue 直接缺席 → total_count == triggers.length;用单一来源判定。
+        const starts = p.triggers.length > 0;
+        setWillStart(starts);
+        setHandoffSupported(starts && p.triggers.every((x) => x.handoff_supported));
+      })
+      .catch(() => { setWillStart(false); setHandoffSupported(false); })
+      .finally(() => setLoading(false));
+  }, [pending]);
+
+  const run = async (extra: { suppress_run?: boolean; handoff_note?: string }) => {
+    if (!pending) return;
+    setSubmitting(true);
+    try {
+      await pending.apply(extra);
+      onClose();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      setSubmitting(false);
+    }
+  };
+
+  const footer = loading ? null : willStart ? (
+    <>
+      <Button theme="borderless" disabled={submitting} onClick={() => run({ suppress_run: true })}>
+        {t("loop.run.suppress")}
+      </Button>
+      <Button theme="solid" loading={submitting} onClick={() => run({ handoff_note: note.trim() || undefined })}>
+        {t("loop.run.start")}
+      </Button>
+    </>
+  ) : (
+    <Button theme="solid" loading={submitting} onClick={() => run({})}>
+      {t("loop.run.apply")}
+    </Button>
+  );
+
+  return (
+    <Modal
+      title={t("loop.run.confirmTitle")}
+      visible={!!pending}
+      onCancel={onClose}
+      maskClosable={!submitting}
+      footer={footer}
+      width={420}
+    >
+      {loading ? (
+        <div style={{ display: "flex", justifyContent: "center", padding: 24 }}><Spin /></div>
+      ) : willStart ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <Text>{t("loop.run.willStart", { values: { name: pending?.assigneeName ?? "" } })}</Text>
+          <TextArea
+            value={note}
+            onChange={setNote}
+            disabled={!handoffSupported}
+            maxCount={2000}
+            autosize={{ minRows: 2, maxRows: 6 }}
+            placeholder={handoffSupported ? t("loop.run.handoffPlaceholder") : t("loop.run.handoffUnsupported")}
+          />
+        </div>
+      ) : (
+        <Text type="tertiary">{t("loop.run.nothing", { values: { name: pending?.assigneeName ?? "" } })}</Text>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
## What

Phase A of surfacing multica's crown **assign → run** loop in the octo (dmloop) face. Assigning an issue to an **agent or squad** now confirms with the backend whether a run will start *before* committing — instead of silently dispatching.

- **`previewIssueTrigger()` → `POST /issues/preview-trigger`** (read-only): the backend decides whether a run starts and which agent runs. Never guessed on the frontend.
- **`RunConfirmModal` + `useRunConfirm`**: gate mirrors multica (`agent`/`squad` assignee on a non-backlog issue). On confirm the user can **start now** (optional handoff note) or **assign without starting** (`suppress_run`). Member / unassign / backlog assignments skip the modal and apply directly.
- `UpdateIssueReq` gains `suppress_run` / `handoff_note`; wired at the detail assignee picker, the `···` menu, and the list inline picker.
- `AssigneePicker.onChange` now emits `(id, type, name)` so callers don't re-resolve the name (drops a duplicate candidate load).

## Verification (live daemon runtime, agent "E2E Coworker", Alice)

| Path | Result |
|---|---|
| **Start** (agent + handoff note) | real task dispatched → agent ran to **completed**, `handoff_note` persisted on the task (DB-confirmed) |
| **Don't start** (suppress) | assignee set, **0 tasks** dispatched (DB-confirmed) |
| Member assign | no modal, applied directly |
| Re-assign same agent | modal shows "won't trigger" (correct — not a change) |

Ran `/simplify` (4-dimension); applied the consensus fix (widen `onChange` to drop duplicate name lookup). Typecheck clean on changed files.

## Notes

- **Stacked on #602** (issue CRUD). Merge #602 first; the two issue-crud commits shown in this diff drop out once #602 lands.
- Status-change-triggered runs (`backlog → active`) are modeled in the types but not yet wired to the confirm dialog — follow-up within Phase A.
- No linked issue yet — `check-sprint` needs a maintainer to attach one.
- Docs: dmloop feature UI; no service/command/config change, so no dev-README/deployment doc update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)