### PR TITLE
feat(loop): re-run and cancel agent runs from the issue run panel

### DIFF
--- a/packages/dmloop/src/api/runsApi.ts
+++ b/packages/dmloop/src/api/runsApi.ts
@@ -1,6 +1,6 @@
 // @octo/loop — 执行记录 API（真实 fleet 联调）
 import type { TaskRun, RunMessage } from "./types";
-import { httpGet } from "./http";
+import { httpGet, httpPost } from "./http";
 import { ensureDirectory } from "./directory";
 
 /** 某 issue 的执行记录列表（runs）。 */
@@ -17,4 +17,14 @@ export async function listRuns(issueId: string): Promise<TaskRun[]> {
 /** 某次执行的消息流（run-messages）。 */
 export function listRunMessages(taskId: string): Promise<RunMessage[]> {
   return httpGet<RunMessage[]>(`/tasks/${taskId}/messages`);
+}
+
+/** 重跑 issue：不带 task_id 按当前 assignee 重跑，带则重跑该 task 的 agent。后端返回新建 task。 */
+export function rerunIssue(issueId: string, taskId?: string): Promise<TaskRun> {
+  return httpPost<TaskRun>(`/issues/${issueId}/rerun`, taskId ? { task_id: taskId } : {});
+}
+
+/** 取消某次执行（只能取消属于该 issue 的 task）。 */
+export function cancelTask(issueId: string, taskId: string): Promise<TaskRun> {
+  return httpPost<TaskRun>(`/issues/${issueId}/tasks/${taskId}/cancel`, {});
 }

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -149,7 +149,7 @@ export interface IssueComment {
 }
 
 export type TaskStatus =
-  | "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled" | string;
+  | "queued" | "dispatched" | "waiting_local_directory" | "running" | "completed" | "failed" | "cancelled" | string;
 
 /** 执行记录（run）：GET /issues/:id/task-runs。 */
 export interface TaskRun {

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -84,6 +84,7 @@
   "taskStatus": {
     "queued": "Queued",
     "dispatched": "Dispatched",
+    "waiting_local_directory": "Waiting for local dir",
     "running": "Running",
     "completed": "Completed",
     "failed": "Failed",
@@ -273,7 +274,12 @@
     "apply": "Apply",
     "handoffPlaceholder": "Optional: a handoff note for this dispatch…",
     "handoffUnsupported": "Target runtime is too old to support a handoff note",
-    "previewFailed": "Couldn't fetch dispatch info; treating as \"will start\" — please confirm"
+    "previewFailed": "Couldn't fetch dispatch info; treating as \"will start\" — please confirm",
+    "stop": "Stop",
+    "rerun": "Re-run",
+    "rerunStarted": "Re-dispatched",
+    "cancelConfirm": "Stop this run?",
+    "cancelled": "Stopped"
   },
   "device": {
     "devices": "Devices",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -84,6 +84,7 @@
   "taskStatus": {
     "queued": "排队中",
     "dispatched": "已派发",
+    "waiting_local_directory": "等待本地目录",
     "running": "运行中",
     "completed": "已完成",
     "failed": "失败",
@@ -273,7 +274,12 @@
     "apply": "应用",
     "handoffPlaceholder": "可选：给这次派单一段交接说明…",
     "handoffUnsupported": "目标运行环境版本较旧，暂不支持交接说明",
-    "previewFailed": "无法预取派单信息，将按“会启动执行”处理，请确认"
+    "previewFailed": "无法预取派单信息，将按“会启动执行”处理，请确认",
+    "stop": "终止",
+    "rerun": "重跑",
+    "rerunStarted": "已重新派单",
+    "cancelConfirm": "确定终止这次执行？",
+    "cancelled": "已终止"
   },
   "device": {
     "devices": "设备",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -21,6 +21,8 @@ import {
   CircleSlash,
   Pencil,
   Check,
+  Square,
+  RotateCcw,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -39,7 +41,7 @@ import {
   deleteComment,
   updateComment,
 } from "../api/issueApi";
-import { listRuns } from "../api/runsApi";
+import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
@@ -89,6 +91,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [commentDraft, setCommentDraft] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
+  const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
 
   const reload = () => {
     setLoading(true);
@@ -169,6 +172,45 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setActiveRun(run);
     setRunOpen(true);
   };
+
+  const reloadRuns = () => listRuns(issueId).then(setRuns).catch(() => {});
+
+  // 重跑该 task 的 agent（后端按 task_id 新建一次 fresh run）。busyRunId 防双击重复派单。
+  const rerun = async (taskId: string) => {
+    if (busyRunId) return;
+    setBusyRunId(taskId);
+    try {
+      await rerunIssue(issueId, taskId);
+      Toast.success(t("loop.run.rerunStarted"));
+      await reloadRuns();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      setBusyRunId(null);
+    }
+  };
+
+  // 终止运行中的 task，二次确认。
+  const cancelRun = (taskId: string) => {
+    confirmDelete({
+      title: t("loop.run.cancelConfirm"),
+      okText: t("loop.run.stop"),
+      cancelText: t("loop.action.cancel"),
+      onOk: async () => {
+        try {
+          await cancelTask(issueId, taskId);
+          Toast.success(t("loop.run.cancelled"));
+          await reloadRuns();
+        } catch (e) {
+          Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+        }
+      },
+    });
+  };
+
+  // 运行中(可终止)vs 已结束(可重跑)。
+  const isActiveRun = (s: TaskRun["status"]) =>
+    s === "queued" || s === "dispatched" || s === "waiting_local_directory" || s === "running";
 
   const saveDesc = async () => {
     if (descDraft !== (issue?.description ?? "")) await patch({ description: descDraft });
@@ -486,17 +528,31 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               </Text>
             ) : (
               <div className="loop-idp__tasks">
-                {runs.map((r) => (
-                  <button key={r.id} className="loop-idp__run" onClick={() => openRun(r)}>
-                    <span className="loop-idp__task-main">
-                      <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
-                      <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
-                    </span>
-                    <Tag size="small" color={RUN_STATUS_COLOR[r.status] ?? "grey"}>
-                      {t(`loop.taskStatus.${r.status}`)}
-                    </Tag>
-                  </button>
-                ))}
+                {runs.map((r) => {
+                  const active = isActiveRun(r.status);
+                  return (
+                    <div key={r.id} className="loop-idp__task">
+                      <button className="loop-idp__run" onClick={() => openRun(r)}>
+                        <span className="loop-idp__task-main">
+                          <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
+                          <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
+                        </span>
+                        <Tag size="small" color={RUN_STATUS_COLOR[r.status] ?? "grey"}>
+                          {t(`loop.taskStatus.${r.status}`)}
+                        </Tag>
+                      </button>
+                      <Button
+                        size="small"
+                        theme="borderless"
+                        type={active ? "danger" : "tertiary"}
+                        loading={!active && busyRunId === r.id}
+                        icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
+                        aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
+                        onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
+                      />
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -127,7 +127,8 @@
 
 /* 执行记录 run 行（可点击） */
 .loop-idp__run {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;

--- a/packages/dmloop/src/ui/meta.tsx
+++ b/packages/dmloop/src/ui/meta.tsx
@@ -89,6 +89,7 @@ export const ASSIGNEE_TYPE_COLOR: Record<AssigneeType, TagColor> = {
 export const RUN_STATUS_COLOR: Record<string, TagColor> = {
   queued: "grey",
   dispatched: "blue",
+  waiting_local_directory: "blue",
   running: "amber",
   completed: "green",
   failed: "red",


### PR DESCRIPTION
## What

Phase A of the crown loop, cont'd. The issue run panel was read-only; you can now **control** the agent runs it lists.

- `runsApi`: `rerunIssue()` → `POST /issues/:id/rerun {task_id?}` (backend creates a fresh run); `cancelTask()` → `POST /issues/:id/tasks/:taskId/cancel`.
- Run panel: each row gets an action button — **Stop** (confirm-gated) for active runs (`queued`/`dispatched`/`waiting_local_directory`/`running`), **Re-run** for terminal runs (`completed`/`failed`/`cancelled`). Panel refetches after either.
- Re-run guarded against double-submit (`busyRunId` → loading), per the idempotent-write rule; cancel is confirm-gated.
- `TaskStatus` / `RUN_STATUS_COLOR` / i18n gain `waiting_local_directory`.

## Verification (live daemon runtime, agent "E2E Coworker", Alice)

| Path | Result |
|---|---|
| Re-run a completed task | new task dispatched (queued), row switches to **Stop** |
| Stop the queued task → confirm | run goes to **cancelled**; panel refreshes |

Re-verified render/layout after the /simplify refactor (single action button + reused `.loop-idp__task` class).

## Review

- `/simplify` (merged the two action buttons; reused the existing `.loop-idp__task` CSS class instead of inline styles).
- **Adversarial correctness pass** — confirmed + fixed a double-submit gap on Re-run (added `busyRunId` loading guard); dismissed 2 false positives (stale comment, speculative unknown-status).

## Notes

- **Stacked on #605 → #602**; merge in order (#602, #605, then this). The commits from those PRs show in this diff until they land.
- No linked issue yet — `check-sprint` needs a maintainer.
- Docs: dmloop feature UI; no service/command/config change → no dev-README/deployment doc update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)