### PR TITLE
feat(loop): confirm dispatch on status change out of backlog

### DIFF
--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import { AssigneeBadge } from "../ui/AssigneePicker";
+import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
@@ -23,18 +24,22 @@ export default function IssueBoard({
   onChanged,
 }: IssueBoardProps) {
   const { t } = useI18n();
+  const { requestStatus, runConfirmModal } = useRunConfirm();
   const [dragId, setDragId] = useState<string | null>(null);
   const [dropCol, setDropCol] = useState<IssueStatus | null>(null);
 
-  const handleDrop = async (status: IssueStatus) => {
+  const handleDrop = (status: IssueStatus) => {
     setDropCol(null);
     const id = dragId;
     setDragId(null);
     if (!id) return;
     const issue = issues.find((i) => i.id === id);
     if (!issue || issue.status === status) return;
-    await updateIssue(id, { status });
-    onChanged();
+    // 拖到 agent 已指派的 backlog→活跃列会触发 run,先走确认;其余直接落库。
+    requestStatus(issue, status, async (extra) => {
+      await updateIssue(id, { status, ...extra });
+      onChanged();
+    });
   };
 
   return (
@@ -84,7 +89,7 @@ export default function IssueBoard({
                     </Tag>
                     <AssigneeBadge
                       type={issue.assignee_type}
-                      name={issue.assignee_name}
+                      name={issue.assignee_name ?? null}
                     />
                   </div>
                 </div>
@@ -93,6 +98,7 @@ export default function IssueBoard({
           </div>
         );
       })}
+      {runConfirmModal}
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -83,7 +83,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runOpen, setRunOpen] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
@@ -226,7 +226,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         render={
           <Dropdown.Menu>
             {ISSUE_STATUS_ORDER.map((s) => (
-              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => patch({ status: s })}>
+              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => issue && requestStatus(issue, s, (extra) => patch({ status: s, ...extra }))}>
                 <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
               </Dropdown.Item>
             ))}
@@ -465,7 +465,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dd>
                 <Select
                   value={issue.status}
-                  onChange={(v) => patch({ status: v as IssueStatus })}
+                  onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
                   size="small"
                   style={{ width: "100%" }}
                 >

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -27,7 +27,7 @@ export default function IssueList({
   onChanged,
 }: IssueListProps) {
   const { t } = useI18n();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
 
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
     await updateIssue(id, p);
@@ -63,7 +63,7 @@ export default function IssueList({
           value={v}
           size="small"
           borderless
-          onChange={(nv) => patch(r.id, { status: nv as IssueStatus })}
+          onChange={(nv) => requestStatus(r, nv as IssueStatus, (extra) => patch(r.id, { status: nv as IssueStatus, ...extra }))}
           style={{ width: 130 }}
         >
           {ISSUE_STATUS_ORDER.map((s) => (

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Modal, Button, TextArea, Spin, Typography, Toast } from "@douyinfe/semi-ui";
 import { useI18n } from "@octo/base";
-import type { AssigneeType, IssueStatus } from "../api/types";
+import type { AssigneeType, IssueStatus, Issue } from "../api/types";
 import { previewIssueTrigger } from "../api/issueApi";
 
 const { Text } = Typography;
@@ -16,15 +16,33 @@ export interface RunConfirmRequest {
   apply: (extra: { suppress_run?: boolean; handoff_note?: string }) => void | Promise<void>;
 }
 
+// 该 actor 是否是会执行的 agent/squad(而非 member/未指派)。
+function isAgentAssignee(type: AssigneeType | null, id: string | null): boolean {
+  return (type === "agent" || type === "squad") && !!id;
+}
+
 // 是否需要“派单预确认”：与 multica 一致——agent/squad 指派且 issue 非 backlog。
 function needsConfirm(r: RunConfirmRequest): boolean {
-  return (r.assigneeType === "agent" || r.assigneeType === "squad") && !!r.assigneeId && r.status !== "backlog";
+  return isAgentAssignee(r.assigneeType, r.assigneeId) && r.status !== "backlog";
+}
+
+// 状态变更是否会触发 run(与后端 WillEnqueueRun status 源一致):
+// agent/squad 已指派,且从 backlog 移到非 backlog/done/cancelled。
+// ponytail: 这是**客户端尽力判断**,用的是本地缓存的 assignee;真正是否起 run 由 preview-trigger
+// 权威判定。并发场景(他人刚改派为 agent、本地视图未刷新)下本判断可能漏判 → 跳过确认弹窗,
+// 但后端仍按持久 assignee 正确起 run(只是少了一次确认 UX)。与 multica 原生 web 的客户端 gate 同源。
+function statusMightTrigger(issue: Issue, next: IssueStatus): boolean {
+  return (
+    isAgentAssignee(issue.assignee_type, issue.assignee_id) &&
+    issue.status === "backlog" &&
+    next !== "backlog" && next !== "done" && next !== "cancelled"
+  );
 }
 
 /**
  * 指派即触发的预确认 hook。用法：
- *   const { requestAssign, runConfirmModal } = useRunConfirm();
- *   <AssigneePicker onChange={(id,type)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
+ *   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
+ *   <AssigneePicker onChange={(id,type,name)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
  *   {runConfirmModal}
  * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
  */
@@ -32,17 +50,36 @@ export function useRunConfirm() {
   const { t } = useI18n();
   const [pending, setPending] = useState<RunConfirmRequest | null>(null);
 
+  const applyDirect = (apply: RunConfirmRequest["apply"]) => {
+    // 直接落库路径：失败要给反馈,别静默吞错。
+    Promise.resolve(apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
+  };
+
   const requestAssign = (r: RunConfirmRequest) => {
-    if (!needsConfirm(r)) {
-      // 直接落库路径（member/取消指派/backlog）：失败要给反馈，与确认路径一致，别静默吞错。
-      Promise.resolve(r.apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
-      return;
-    }
+    if (!needsConfirm(r)) { applyDirect(r.apply); return; }
     setPending(r);
   };
 
+  // 状态变更:仅在 backlog→活跃且已指派 agent/squad(会静默起 run)时弹确认;
+  // preview 传当前 assignee(不变)+ 新 status,后端按 status 源判定。
+  const requestStatus = (
+    issue: Issue,
+    next: IssueStatus,
+    apply: RunConfirmRequest["apply"],
+  ) => {
+    if (!statusMightTrigger(issue, next)) { applyDirect(apply); return; }
+    setPending({
+      issueId: issue.id,
+      status: next,
+      assigneeType: issue.assignee_type,
+      assigneeId: issue.assignee_id,
+      assigneeName: issue.assignee_name ?? null,
+      apply,
+    });
+  };
+
   const runConfirmModal = <RunConfirmModal pending={pending} onClose={() => setPending(null)} />;
-  return { requestAssign, runConfirmModal };
+  return { requestAssign, requestStatus, runConfirmModal };
 }
 
 function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | null; onClose: () => void }) {


### PR DESCRIPTION
## What

Closes the gap the RunConfirm (#605) adversarial review flagged: an issue already assigned to an agent/squad that is moved **backlog → active** starts a run (backend `WillEnqueueRun` status source), but the status-change entry points bypassed the confirm dialog and dispatched **silently**.

- `useRunConfirm` gains `requestStatus(issue, next, apply)`: opens the same preview-backed confirm only when the change would trigger a run (agent/squad-assigned + `backlog` → non `backlog`/`done`/`cancelled`); otherwise applies directly. Preview sends the current (unchanged) assignee + new status, so the backend evaluates it as a status-source trigger.
- Wired all four status entry points: detail status `Select` + `···` menu, list inline `Select`, board drag-drop.
- Refactor: reuse the `Issue` type (dropped the redundant `StatusChangeIssue`) + a shared `isAgentAssignee()` predicate across both gates.
- Also fixes a pre-existing `IssueBoard` type error (`assignee_name ?? null`).

## Verification (live daemon, agent "E2E Coworker", Alice)

| Path | Result |
|---|---|
| backlog issue (agent-assigned) → todo | RunConfirm opens ("will start") |
| "Don't start yet" | status=todo, **0 tasks** dispatched (DB-confirmed) |
| todo → in_progress (not from backlog) | no modal, applied directly (no over-prompt) |

Setup (kept): created `[status触发验证]` backlog issue assigned to the agent — backlog assign correctly dispatched nothing.

## Review

- `/simplify`: reused `Issue` type + deduped the assignee predicate.
- **Adversarial correctness pass** — one confirmed low finding: the client-side gate keys on the *cached* assignee, so a concurrent reassignment could skip the confirm UX (the dispatch itself stays backend-correct). Documented as a known limitation (ponytail comment) matching multica's own client-side gate, rather than adding a preview call to every status change. No false positives dismissed beyond that.

## Notes

- **Stacked on #606 → #605 → #602**; merge in order.
- No linked issue yet — `check-sprint` needs a maintainer.
- Docs: dmloop feature UI; no service/command/config change → no dev-README/deployment doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)