### PR TITLE
feat(loop): preview and suppress agents a comment will wake

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -8,6 +8,7 @@ import type {
   AssigneeCandidate,
   IssueTriggerPreview,
   IssueTriggerPreviewParams,
+  CommentTriggerAgent,
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
@@ -78,11 +79,25 @@ export function addComment(
   issueId: string,
   content: string,
   parentId: string | null = null,
+  suppressAgentIds: string[] = [],
 ): Promise<IssueComment> {
   return httpPost<IssueComment>(`/issues/${issueId}/comments`, {
     content,
     parent_id: parentId ?? undefined,
+    suppress_agent_ids: suppressAgentIds.length ? suppressAgentIds : undefined,
   });
+}
+
+// 评论派单预览（只读）：这条评论会唤醒哪些 agent（issue 负责人 / @提及）。绝不前端猜。
+export function previewCommentTriggers(
+  issueId: string,
+  content: string,
+  parentId: string | null = null,
+): Promise<CommentTriggerAgent[]> {
+  return httpPost<{ agents?: CommentTriggerAgent[] }>(`/issues/${issueId}/comments/trigger-preview`, {
+    content,
+    parent_id: parentId ?? undefined,
+  }).then((r) => r.agents ?? []);
 }
 
 export function deleteComment(commentId: string): Promise<void> {

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -136,6 +136,13 @@ export interface IssueTriggerPreview {
   total_count: number;
 }
 
+/** 评论派单预览:这条评论会唤醒的 agent(POST /issues/:id/comments/trigger-preview)。
+ *  后端还返回 avatar_url/source/reason,前端暂只用 id+name,按需再加。 */
+export interface CommentTriggerAgent {
+  id: string;
+  name: string;
+}
+
 export interface IssueComment {
   id: string;
   issue_id: string;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -176,7 +176,9 @@
     "replyingHint": "Replying to a comment above — use its reply box",
     "empty": "No comments yet",
     "placeholder": "Write a comment…",
-    "send": "Send"
+    "send": "Send",
+    "willWake": "Will wake:",
+    "tapToSuppress": "(tap to skip one)"
   },
   "toast": {
     "created": "Created",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -176,7 +176,9 @@
     "replyingHint": "正在回复上方评论，请在对应输入框输入",
     "empty": "暂无评论",
     "placeholder": "写下评论…",
-    "send": "发送"
+    "send": "发送",
+    "willWake": "将唤醒：",
+    "tapToSuppress": "(点击可跳过某个)"
   },
   "toast": {
     "created": "已创建",

--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import { AssigneeBadge } from "../ui/AssigneePicker";
+import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
@@ -23,18 +24,22 @@ export default function IssueBoard({
   onChanged,
 }: IssueBoardProps) {
   const { t } = useI18n();
+  const { requestStatus, runConfirmModal } = useRunConfirm();
   const [dragId, setDragId] = useState<string | null>(null);
   const [dropCol, setDropCol] = useState<IssueStatus | null>(null);
 
-  const handleDrop = async (status: IssueStatus) => {
+  const handleDrop = (status: IssueStatus) => {
     setDropCol(null);
     const id = dragId;
     setDragId(null);
     if (!id) return;
     const issue = issues.find((i) => i.id === id);
     if (!issue || issue.status === status) return;
-    await updateIssue(id, { status });
-    onChanged();
+    // 拖到 agent 已指派的 backlog→活跃列会触发 run,先走确认;其余直接落库。
+    requestStatus(issue, status, async (extra) => {
+      await updateIssue(id, { status, ...extra });
+      onChanged();
+    });
   };
 
   return (
@@ -84,7 +89,7 @@ export default function IssueBoard({
                     </Tag>
                     <AssigneeBadge
                       type={issue.assignee_type}
-                      name={issue.assignee_name}
+                      name={issue.assignee_name ?? null}
                     />
                   </div>
                 </div>
@@ -93,6 +98,7 @@ export default function IssueBoard({
           </div>
         );
       })}
+      {runConfirmModal}
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -83,7 +83,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runOpen, setRunOpen] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
@@ -226,7 +226,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         render={
           <Dropdown.Menu>
             {ISSUE_STATUS_ORDER.map((s) => (
-              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => patch({ status: s })}>
+              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => issue && requestStatus(issue, s, (extra) => patch({ status: s, ...extra }))}>
                 <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
               </Dropdown.Item>
             ))}
@@ -465,7 +465,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dd>
                 <Select
                   value={issue.status}
-                  onChange={(v) => patch({ status: v as IssueStatus })}
+                  onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
                   size="small"
                   style={{ width: "100%" }}
                 >

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -31,6 +31,7 @@ import type {
   TaskRun,
   IssueStatus,
   IssuePriority,
+  CommentTriggerAgent,
 } from "../api/types";
 import {
   getIssue,
@@ -40,6 +41,7 @@ import {
   addComment,
   deleteComment,
   updateComment,
+  previewCommentTriggers,
 } from "../api/issueApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
@@ -89,6 +91,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [descDraft, setDescDraft] = useState("");
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState("");
+  const [triggerAgents, setTriggerAgents] = useState<CommentTriggerAgent[]>([]); // 这条评论会唤醒的 agent
+  const [suppressed, setSuppressed] = useState<Set<string>>(new Set()); // 被用户跳过的 agent id
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
@@ -119,12 +123,33 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const submitComment = async () => {
     const content = commentDraft.trim();
     if (!content) return;
-    await addComment(issueId, content, replyTo);
+    const suppressIds = triggerAgents.filter((a) => suppressed.has(a.id)).map((a) => a.id);
+    await addComment(issueId, content, replyTo, suppressIds);
     setCommentDraft("");
     setReplyTo(null);
+    setTriggerAgents([]);
+    setSuppressed(new Set());
     setComments(await listComments(issueId));
     Toast.success(t("loop.toast.commentAdded"));
   };
+
+  // 顶层评论输入时防抖预览"会唤醒哪些 agent"(回复暂不预览)。
+  useEffect(() => {
+    const content = commentDraft.trim();
+    // 预览更新时把 suppressed 裁剪到当前触发集,避免"移除又重提及"的 agent 带着旧的跳过意图。
+    const prune = (ids: string[]) => setSuppressed((s) => new Set([...s].filter((id) => ids.includes(id))));
+    if (!content || replyTo) { setTriggerAgents([]); prune([]); return; }
+    let cancelled = false;
+    const h = setTimeout(() => {
+      previewCommentTriggers(issueId, content, null)
+        .then((a) => { if (cancelled) return; setTriggerAgents(a); prune(a.map((x) => x.id)); })
+        .catch(() => { if (cancelled) return; setTriggerAgents([]); prune([]); });
+    }, 400);
+    return () => { cancelled = true; clearTimeout(h); };
+  }, [commentDraft, replyTo, issueId]);
+
+  const toggleSuppress = (id: string) =>
+    setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
 
   const removeComment = async (id: string) => {
     await deleteComment(id);
@@ -441,6 +466,26 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               )}
               {roots.map((c) => renderComment(c))}
             </div>
+            {!replyTo && triggerAgents.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 10, alignItems: "center" }}>
+                <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.willWake")}</Text>
+                {triggerAgents.map((a) => {
+                  const off = suppressed.has(a.id);
+                  return (
+                    <Tag
+                      key={a.id}
+                      size="small"
+                      color={off ? "grey" : "light-blue"}
+                      style={{ cursor: "pointer", opacity: off ? 0.55 : 1, textDecoration: off ? "line-through" : "none" }}
+                      onClick={() => toggleSuppress(a.id)}
+                    >
+                      {a.name}
+                    </Tag>
+                  );
+                })}
+                <Text type="tertiary" style={{ fontSize: 11 }}>{t("loop.comment.tapToSuppress")}</Text>
+              </div>
+            )}
             <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
               <Input
                 value={replyTo ? "" : commentDraft}

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -27,7 +27,7 @@ export default function IssueList({
   onChanged,
 }: IssueListProps) {
   const { t } = useI18n();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
 
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
     await updateIssue(id, p);
@@ -63,7 +63,7 @@ export default function IssueList({
           value={v}
           size="small"
           borderless
-          onChange={(nv) => patch(r.id, { status: nv as IssueStatus })}
+          onChange={(nv) => requestStatus(r, nv as IssueStatus, (extra) => patch(r.id, { status: nv as IssueStatus, ...extra }))}
           style={{ width: 130 }}
         >
           {ISSUE_STATUS_ORDER.map((s) => (

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Modal, Button, TextArea, Spin, Typography, Toast } from "@douyinfe/semi-ui";
 import { useI18n } from "@octo/base";
-import type { AssigneeType, IssueStatus } from "../api/types";
+import type { AssigneeType, IssueStatus, Issue } from "../api/types";
 import { previewIssueTrigger } from "../api/issueApi";
 
 const { Text } = Typography;
@@ -16,15 +16,33 @@ export interface RunConfirmRequest {
   apply: (extra: { suppress_run?: boolean; handoff_note?: string }) => void | Promise<void>;
 }
 
+// 该 actor 是否是会执行的 agent/squad(而非 member/未指派)。
+function isAgentAssignee(type: AssigneeType | null, id: string | null): boolean {
+  return (type === "agent" || type === "squad") && !!id;
+}
+
 // 是否需要“派单预确认”：与 multica 一致——agent/squad 指派且 issue 非 backlog。
 function needsConfirm(r: RunConfirmRequest): boolean {
-  return (r.assigneeType === "agent" || r.assigneeType === "squad") && !!r.assigneeId && r.status !== "backlog";
+  return isAgentAssignee(r.assigneeType, r.assigneeId) && r.status !== "backlog";
+}
+
+// 状态变更是否会触发 run(与后端 WillEnqueueRun status 源一致):
+// agent/squad 已指派,且从 backlog 移到非 backlog/done/cancelled。
+// ponytail: 这是**客户端尽力判断**,用的是本地缓存的 assignee;真正是否起 run 由 preview-trigger
+// 权威判定。并发场景(他人刚改派为 agent、本地视图未刷新)下本判断可能漏判 → 跳过确认弹窗,
+// 但后端仍按持久 assignee 正确起 run(只是少了一次确认 UX)。与 multica 原生 web 的客户端 gate 同源。
+function statusMightTrigger(issue: Issue, next: IssueStatus): boolean {
+  return (
+    isAgentAssignee(issue.assignee_type, issue.assignee_id) &&
+    issue.status === "backlog" &&
+    next !== "backlog" && next !== "done" && next !== "cancelled"
+  );
 }
 
 /**
  * 指派即触发的预确认 hook。用法：
- *   const { requestAssign, runConfirmModal } = useRunConfirm();
- *   <AssigneePicker onChange={(id,type)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
+ *   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
+ *   <AssigneePicker onChange={(id,type,name)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
  *   {runConfirmModal}
  * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
  */
@@ -32,17 +50,36 @@ export function useRunConfirm() {
   const { t } = useI18n();
   const [pending, setPending] = useState<RunConfirmRequest | null>(null);
 
+  const applyDirect = (apply: RunConfirmRequest["apply"]) => {
+    // 直接落库路径：失败要给反馈,别静默吞错。
+    Promise.resolve(apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
+  };
+
   const requestAssign = (r: RunConfirmRequest) => {
-    if (!needsConfirm(r)) {
-      // 直接落库路径（member/取消指派/backlog）：失败要给反馈，与确认路径一致，别静默吞错。
-      Promise.resolve(r.apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
-      return;
-    }
+    if (!needsConfirm(r)) { applyDirect(r.apply); return; }
     setPending(r);
   };
 
+  // 状态变更:仅在 backlog→活跃且已指派 agent/squad(会静默起 run)时弹确认;
+  // preview 传当前 assignee(不变)+ 新 status,后端按 status 源判定。
+  const requestStatus = (
+    issue: Issue,
+    next: IssueStatus,
+    apply: RunConfirmRequest["apply"],
+  ) => {
+    if (!statusMightTrigger(issue, next)) { applyDirect(apply); return; }
+    setPending({
+      issueId: issue.id,
+      status: next,
+      assigneeType: issue.assignee_type,
+      assigneeId: issue.assignee_id,
+      assigneeName: issue.assignee_name ?? null,
+      apply,
+    });
+  };
+
   const runConfirmModal = <RunConfirmModal pending={pending} onClose={() => setPending(null)} />;
-  return { requestAssign, runConfirmModal };
+  return { requestAssign, requestStatus, runConfirmModal };
 }
 
 function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | null; onClose: () => void }) {


### PR DESCRIPTION
## What

Phase A of the crown loop. Commenting on an agent/squad-assigned issue wakes that agent (backend `issue_assignee` trigger). The composer now surfaces this and lets the user opt out per-agent before sending.

- `issueApi`: `previewCommentTriggers()` → `POST /issues/:id/comments/trigger-preview` `{content, parent_id}`; `addComment()` gains `suppress_agent_ids`.
- `IssueDetailPage`: debounced (400ms) preview as you type a top-level comment shows **"will wake: `<agent>`"** chips; tapping a chip suppresses that agent; submit sends `suppress_agent_ids` for the struck-through chips.
- `suppressed` set is pruned to the current preview on each refresh (an agent removed then re-mentioned defaults back to active, not silently suppressed).
- `CommentTriggerAgent` trimmed to the fields the UI consumes.

## Verification (live daemon, agent "E2E Coworker", Alice) — agent-assigned issue

| Path | Result |
|---|---|
| type a comment | "will wake: E2E Coworker" chip appears (preview) |
| suppress the chip → send | comment posted, **0 new tasks** dispatched (DB-confirmed) |
| send without suppressing | new task dispatched & **running** (DB-confirmed) |

## Review

- `/simplify`: trimmed `CommentTriggerAgent` to consumed fields.
- **Adversarial correctness pass** — fixed the confirmed stale-suppression default (prune `suppressed` on preview refresh); dismissed a debounce/submit race as a benign opt-out lag.

## Notes

- Replies don't preview yet (plain-text input, no mention editor) — follow-up. dmloop comments are plain text, so `mention_agent`/`mention_squad_leader` triggers don't fire from here; `issue_assignee` is the live path.
- **Stacked on #608 → #606 → #605 → #602**; merge in order.
- No linked issue yet — `check-sprint` needs a maintainer. dmloop feature UI; no service/command/config change → no doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)