### PR TITLE
feat(loop): live-stream the agent run transcript

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -8,6 +8,7 @@ import type {
   AssigneeCandidate,
   IssueTriggerPreview,
   IssueTriggerPreviewParams,
+  CommentTriggerAgent,
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
@@ -78,11 +79,25 @@ export function addComment(
   issueId: string,
   content: string,
   parentId: string | null = null,
+  suppressAgentIds: string[] = [],
 ): Promise<IssueComment> {
   return httpPost<IssueComment>(`/issues/${issueId}/comments`, {
     content,
     parent_id: parentId ?? undefined,
+    suppress_agent_ids: suppressAgentIds.length ? suppressAgentIds : undefined,
   });
+}
+
+// 评论派单预览（只读）：这条评论会唤醒哪些 agent（issue 负责人 / @提及）。绝不前端猜。
+export function previewCommentTriggers(
+  issueId: string,
+  content: string,
+  parentId: string | null = null,
+): Promise<CommentTriggerAgent[]> {
+  return httpPost<{ agents?: CommentTriggerAgent[] }>(`/issues/${issueId}/comments/trigger-preview`, {
+    content,
+    parent_id: parentId ?? undefined,
+  }).then((r) => r.agents ?? []);
 }
 
 export function deleteComment(commentId: string): Promise<void> {

--- a/packages/dmloop/src/api/runsApi.ts
+++ b/packages/dmloop/src/api/runsApi.ts
@@ -14,9 +14,9 @@ export async function listRuns(issueId: string): Promise<TaskRun[]> {
     .sort((a, b) => (b.created_at ?? b.dispatched_at ?? "").localeCompare(a.created_at ?? a.dispatched_at ?? ""));
 }
 
-/** 某次执行的消息流（run-messages）。 */
-export function listRunMessages(taskId: string): Promise<RunMessage[]> {
-  return httpGet<RunMessage[]>(`/tasks/${taskId}/messages`);
+/** 某次执行的消息流（run-messages）。since 给出后只取 seq 更大的增量（clean 会剔除 undefined）。 */
+export function listRunMessages(taskId: string, since?: number): Promise<RunMessage[]> {
+  return httpGet<RunMessage[]>(`/tasks/${taskId}/messages`, { since });
 }
 
 /** 重跑 issue：不带 task_id 按当前 assignee 重跑，带则重跑该 task 的 agent。后端返回新建 task。 */

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -136,6 +136,13 @@ export interface IssueTriggerPreview {
   total_count: number;
 }
 
+/** 评论派单预览:这条评论会唤醒的 agent(POST /issues/:id/comments/trigger-preview)。
+ *  后端还返回 avatar_url/source/reason,前端暂只用 id+name,按需再加。 */
+export interface CommentTriggerAgent {
+  id: string;
+  name: string;
+}
+
 export interface IssueComment {
   id: string;
   issue_id: string;

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -177,17 +177,17 @@ export interface TaskRun {
   agent_name?: string | null;
 }
 
-/** 执行消息（run-messages）：GET /tasks/:id/messages。 */
+/** 执行消息（run-messages）：GET /tasks/:id/messages。对齐后端 TaskMessagePayload。 */
 export interface RunMessage {
   task_id: string;
   issue_id?: string;
   seq: number;
-  type: string;
-  tool?: string;
-  input?: unknown;
-  text?: string;
-  content?: unknown;
-  created_at: string;
+  type: string; // thinking | text | tool_use | tool_result | error
+  tool?: string; // tool_use/tool_result 的工具名
+  content?: string; // 文本内容(text/thinking/error)
+  input?: Record<string, unknown>; // tool_use 的入参
+  output?: string; // tool_result 的输出
+  created_at?: string;
 }
 
 /* ---------- Skill ---------- */

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -176,7 +176,9 @@
     "replyingHint": "Replying to a comment above — use its reply box",
     "empty": "No comments yet",
     "placeholder": "Write a comment…",
-    "send": "Send"
+    "send": "Send",
+    "willWake": "Will wake:",
+    "tapToSuppress": "(tap to skip one)"
   },
   "toast": {
     "created": "Created",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -176,7 +176,9 @@
     "replyingHint": "正在回复上方评论，请在对应输入框输入",
     "empty": "暂无评论",
     "placeholder": "写下评论…",
-    "send": "发送"
+    "send": "发送",
+    "willWake": "将唤醒：",
+    "tapToSuppress": "(点击可跳过某个)"
   },
   "toast": {
     "created": "已创建",

--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import { AssigneeBadge } from "../ui/AssigneePicker";
+import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
@@ -23,18 +24,22 @@ export default function IssueBoard({
   onChanged,
 }: IssueBoardProps) {
   const { t } = useI18n();
+  const { requestStatus, runConfirmModal } = useRunConfirm();
   const [dragId, setDragId] = useState<string | null>(null);
   const [dropCol, setDropCol] = useState<IssueStatus | null>(null);
 
-  const handleDrop = async (status: IssueStatus) => {
+  const handleDrop = (status: IssueStatus) => {
     setDropCol(null);
     const id = dragId;
     setDragId(null);
     if (!id) return;
     const issue = issues.find((i) => i.id === id);
     if (!issue || issue.status === status) return;
-    await updateIssue(id, { status });
-    onChanged();
+    // 拖到 agent 已指派的 backlog→活跃列会触发 run,先走确认;其余直接落库。
+    requestStatus(issue, status, async (extra) => {
+      await updateIssue(id, { status, ...extra });
+      onChanged();
+    });
   };
 
   return (
@@ -84,7 +89,7 @@ export default function IssueBoard({
                     </Tag>
                     <AssigneeBadge
                       type={issue.assignee_type}
-                      name={issue.assignee_name}
+                      name={issue.assignee_name ?? null}
                     />
                   </div>
                 </div>
@@ -93,6 +98,7 @@ export default function IssueBoard({
           </div>
         );
       })}
+      {runConfirmModal}
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -83,7 +83,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runOpen, setRunOpen] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
@@ -226,7 +226,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         render={
           <Dropdown.Menu>
             {ISSUE_STATUS_ORDER.map((s) => (
-              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => patch({ status: s })}>
+              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => issue && requestStatus(issue, s, (extra) => patch({ status: s, ...extra }))}>
                 <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
               </Dropdown.Item>
             ))}
@@ -465,7 +465,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dd>
                 <Select
                   value={issue.status}
-                  onChange={(v) => patch({ status: v as IssueStatus })}
+                  onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
                   size="small"
                   style={{ width: "100%" }}
                 >

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -56,6 +56,7 @@ import {
   PRIORITY_ORDER,
   PRIORITY_COLOR,
   RUN_STATUS_COLOR,
+  isActiveRun,
 } from "../ui/meta";
 import "./issueDetail.css";
 
@@ -233,9 +234,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     });
   };
 
-  // 运行中(可终止)vs 已结束(可重跑)。
-  const isActiveRun = (s: TaskRun["status"]) =>
-    s === "queued" || s === "dispatched" || s === "waiting_local_directory" || s === "running";
+  // 运行中(可终止)vs 已结束(可重跑):用共享 isActiveRun(ui/meta)。
 
   const saveDesc = async () => {
     if (descDraft !== (issue?.description ?? "")) await patch({ description: descDraft });

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -31,6 +31,7 @@ import type {
   TaskRun,
   IssueStatus,
   IssuePriority,
+  CommentTriggerAgent,
 } from "../api/types";
 import {
   getIssue,
@@ -40,6 +41,7 @@ import {
   addComment,
   deleteComment,
   updateComment,
+  previewCommentTriggers,
 } from "../api/issueApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
@@ -89,6 +91,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [descDraft, setDescDraft] = useState("");
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState("");
+  const [triggerAgents, setTriggerAgents] = useState<CommentTriggerAgent[]>([]); // 这条评论会唤醒的 agent
+  const [suppressed, setSuppressed] = useState<Set<string>>(new Set()); // 被用户跳过的 agent id
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
@@ -119,12 +123,33 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const submitComment = async () => {
     const content = commentDraft.trim();
     if (!content) return;
-    await addComment(issueId, content, replyTo);
+    const suppressIds = triggerAgents.filter((a) => suppressed.has(a.id)).map((a) => a.id);
+    await addComment(issueId, content, replyTo, suppressIds);
     setCommentDraft("");
     setReplyTo(null);
+    setTriggerAgents([]);
+    setSuppressed(new Set());
     setComments(await listComments(issueId));
     Toast.success(t("loop.toast.commentAdded"));
   };
+
+  // 顶层评论输入时防抖预览"会唤醒哪些 agent"(回复暂不预览)。
+  useEffect(() => {
+    const content = commentDraft.trim();
+    // 预览更新时把 suppressed 裁剪到当前触发集,避免"移除又重提及"的 agent 带着旧的跳过意图。
+    const prune = (ids: string[]) => setSuppressed((s) => new Set([...s].filter((id) => ids.includes(id))));
+    if (!content || replyTo) { setTriggerAgents([]); prune([]); return; }
+    let cancelled = false;
+    const h = setTimeout(() => {
+      previewCommentTriggers(issueId, content, null)
+        .then((a) => { if (cancelled) return; setTriggerAgents(a); prune(a.map((x) => x.id)); })
+        .catch(() => { if (cancelled) return; setTriggerAgents([]); prune([]); });
+    }, 400);
+    return () => { cancelled = true; clearTimeout(h); };
+  }, [commentDraft, replyTo, issueId]);
+
+  const toggleSuppress = (id: string) =>
+    setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
 
   const removeComment = async (id: string) => {
     await deleteComment(id);
@@ -441,6 +466,26 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               )}
               {roots.map((c) => renderComment(c))}
             </div>
+            {!replyTo && triggerAgents.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 10, alignItems: "center" }}>
+                <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.willWake")}</Text>
+                {triggerAgents.map((a) => {
+                  const off = suppressed.has(a.id);
+                  return (
+                    <Tag
+                      key={a.id}
+                      size="small"
+                      color={off ? "grey" : "light-blue"}
+                      style={{ cursor: "pointer", opacity: off ? 0.55 : 1, textDecoration: off ? "line-through" : "none" }}
+                      onClick={() => toggleSuppress(a.id)}
+                    >
+                      {a.name}
+                    </Tag>
+                  );
+                })}
+                <Text type="tertiary" style={{ fontSize: 11 }}>{t("loop.comment.tapToSuppress")}</Text>
+              </div>
+            )}
             <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
               <Input
                 value={replyTo ? "" : commentDraft}

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -27,7 +27,7 @@ export default function IssueList({
   onChanged,
 }: IssueListProps) {
   const { t } = useI18n();
-  const { requestAssign, runConfirmModal } = useRunConfirm();
+  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
 
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
     await updateIssue(id, p);
@@ -63,7 +63,7 @@ export default function IssueList({
           value={v}
           size="small"
           borderless
-          onChange={(nv) => patch(r.id, { status: nv as IssueStatus })}
+          onChange={(nv) => requestStatus(r, nv as IssueStatus, (extra) => patch(r.id, { status: nv as IssueStatus, ...extra }))}
           style={{ width: 130 }}
         >
           {ISSUE_STATUS_ORDER.map((s) => (

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Modal, Spin, Tag, Typography, Empty } from "@douyinfe/semi-ui";
 import { useI18n } from "@octo/base";
 import type { TaskRun, RunMessage } from "../api/types";
-import { listRunMessages } from "../api/runsApi";
-import { RUN_STATUS_COLOR } from "../ui/meta";
+import { listRunMessages, listRuns } from "../api/runsApi";
+import { RUN_STATUS_COLOR, isActiveRun } from "../ui/meta";
 
 const { Text } = Typography;
+
+const POLL_MS = 2000;
 
 function fmt(iso?: string | null): string {
   if (!iso) return "-";
@@ -14,10 +16,9 @@ function fmt(iso?: string | null): string {
 }
 
 function msgText(m: RunMessage): string {
-  if (m.text) return m.text;
-  if (typeof m.content === "string") return m.content;
-  if (m.input) return typeof m.input === "string" ? m.input : JSON.stringify(m.input, null, 2);
-  if (m.content) return JSON.stringify(m.content, null, 2);
+  if (m.output) return m.output; // tool_result
+  if (m.content) return m.content; // text / thinking / error
+  if (m.input) return JSON.stringify(m.input, null, 2); // tool_use
   return "";
 }
 
@@ -33,16 +34,57 @@ export default function RunDetailModal({
 }) {
   const { t } = useI18n();
   const [messages, setMessages] = useState<RunMessage[]>([]);
+  const [liveRun, setLiveRun] = useState<TaskRun | null>(run); // 随轮询刷新的 run 状态(点击时快照会过时)
   const [loading, setLoading] = useState(false);
+  const lastSeqRef = useRef(0);
 
+  // 打开时全量拉;运行中的 run 则每 2s 用 ?since 增量轮询消息 + 刷新 run 状态,终态即停(dmloop 无 fleet WS,退化为轮询)。
   useEffect(() => {
-    if (!visible || !run) return;
+    if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; return; }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    lastSeqRef.current = 0;
+    setLiveRun(run);
+
+    const apply = (batch: RunMessage[], incremental: boolean) => {
+      if (batch.length) lastSeqRef.current = Math.max(lastSeqRef.current, ...batch.map((m) => m.seq));
+      if (!incremental) { setMessages(batch); return; }
+      if (!batch.length) return;
+      // ponytail: dedup by seq——保险起见,防 ?since 若为闭区间(未从前端核实)时重复;严格排他时此过滤无副作用。
+      setMessages((prev) => {
+        const seen = new Set(prev.map((m) => m.seq));
+        return [...prev, ...batch.filter((m) => !seen.has(m.seq))];
+      });
+    };
+
+    // 每轮:拉消息增量 + 刷新 run 状态;run 到终态则停止轮询。
+    const poll = () => {
+      timer = setTimeout(async () => {
+        if (cancelled) return;
+        await listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? [], true); }).catch(() => {});
+        let stillActive = true;
+        try {
+          const fresh = (await listRuns(run.issue_id)).find((r) => r.id === run.id);
+          if (fresh && !cancelled) { setLiveRun(fresh); stillActive = isActiveRun(fresh.status); }
+        } catch { /* 保持轮询 */ }
+        if (!cancelled && stillActive) poll();
+      }, POLL_MS);
+    };
+
     setLoading(true);
     listRunMessages(run.id)
-      .then((m) => setMessages(m ?? []))
-      .catch(() => setMessages([]))
-      .finally(() => setLoading(false));
+      .then((m) => { if (!cancelled) apply(m ?? [], false); })
+      .catch(() => { if (!cancelled) setMessages([]); })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        if (isActiveRun(run.status)) poll();
+      });
+
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
   }, [visible, run]);
+
+  const shown = liveRun ?? run;
 
   return (
     <Modal
@@ -53,25 +95,25 @@ export default function RunDetailModal({
       width={720}
       bodyStyle={{ maxHeight: "70vh", overflow: "auto" }}
     >
-      {!run ? null : (
+      {!shown ? null : (
         <div className="loop-run-detail">
           <div className="loop-run-detail__head">
-            <Tag color={RUN_STATUS_COLOR[run.status] ?? "grey"}>{t(`loop.taskStatus.${run.status}`)}</Tag>
+            <Tag color={RUN_STATUS_COLOR[shown.status] ?? "grey"}>{t(`loop.taskStatus.${shown.status}`)}</Tag>
             <span className="loop-run-detail__meta">
-              <Text type="tertiary">{run.agent_name ?? run.agent_id ?? "—"}</Text>
-              {run.trigger_summary && <Text type="tertiary"> · {run.trigger_summary}</Text>}
+              <Text type="tertiary">{shown.agent_name ?? shown.agent_id ?? "—"}</Text>
+              {shown.trigger_summary && <Text type="tertiary"> · {shown.trigger_summary}</Text>}
             </span>
           </div>
           <dl className="loop-run-detail__props">
-            <dt>{t("loop.run.dispatched")}</dt><dd>{fmt(run.dispatched_at)}</dd>
-            <dt>{t("loop.run.started")}</dt><dd>{fmt(run.started_at)}</dd>
-            <dt>{t("loop.run.completed")}</dt><dd>{fmt(run.completed_at)}</dd>
+            <dt>{t("loop.run.dispatched")}</dt><dd>{fmt(shown.dispatched_at)}</dd>
+            <dt>{t("loop.run.started")}</dt><dd>{fmt(shown.started_at)}</dd>
+            <dt>{t("loop.run.completed")}</dt><dd>{fmt(shown.completed_at)}</dd>
           </dl>
 
-          {run.result?.output && (
+          {shown.result?.output && (
             <div className="loop-run-detail__section">
               <div className="loop-detail__section-title">{t("loop.run.result")}</div>
-              <pre className="loop-run-detail__output">{run.result.output}</pre>
+              <pre className="loop-run-detail__output">{shown.result.output}</pre>
             </div>
           )}
 

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Modal, Button, TextArea, Spin, Typography, Toast } from "@douyinfe/semi-ui";
 import { useI18n } from "@octo/base";
-import type { AssigneeType, IssueStatus } from "../api/types";
+import type { AssigneeType, IssueStatus, Issue } from "../api/types";
 import { previewIssueTrigger } from "../api/issueApi";
 
 const { Text } = Typography;
@@ -16,15 +16,33 @@ export interface RunConfirmRequest {
   apply: (extra: { suppress_run?: boolean; handoff_note?: string }) => void | Promise<void>;
 }
 
+// 该 actor 是否是会执行的 agent/squad(而非 member/未指派)。
+function isAgentAssignee(type: AssigneeType | null, id: string | null): boolean {
+  return (type === "agent" || type === "squad") && !!id;
+}
+
 // 是否需要“派单预确认”：与 multica 一致——agent/squad 指派且 issue 非 backlog。
 function needsConfirm(r: RunConfirmRequest): boolean {
-  return (r.assigneeType === "agent" || r.assigneeType === "squad") && !!r.assigneeId && r.status !== "backlog";
+  return isAgentAssignee(r.assigneeType, r.assigneeId) && r.status !== "backlog";
+}
+
+// 状态变更是否会触发 run(与后端 WillEnqueueRun status 源一致):
+// agent/squad 已指派,且从 backlog 移到非 backlog/done/cancelled。
+// ponytail: 这是**客户端尽力判断**,用的是本地缓存的 assignee;真正是否起 run 由 preview-trigger
+// 权威判定。并发场景(他人刚改派为 agent、本地视图未刷新)下本判断可能漏判 → 跳过确认弹窗,
+// 但后端仍按持久 assignee 正确起 run(只是少了一次确认 UX)。与 multica 原生 web 的客户端 gate 同源。
+function statusMightTrigger(issue: Issue, next: IssueStatus): boolean {
+  return (
+    isAgentAssignee(issue.assignee_type, issue.assignee_id) &&
+    issue.status === "backlog" &&
+    next !== "backlog" && next !== "done" && next !== "cancelled"
+  );
 }
 
 /**
  * 指派即触发的预确认 hook。用法：
- *   const { requestAssign, runConfirmModal } = useRunConfirm();
- *   <AssigneePicker onChange={(id,type)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
+ *   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
+ *   <AssigneePicker onChange={(id,type,name)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
  *   {runConfirmModal}
  * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
  */
@@ -32,17 +50,36 @@ export function useRunConfirm() {
   const { t } = useI18n();
   const [pending, setPending] = useState<RunConfirmRequest | null>(null);
 
+  const applyDirect = (apply: RunConfirmRequest["apply"]) => {
+    // 直接落库路径：失败要给反馈,别静默吞错。
+    Promise.resolve(apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
+  };
+
   const requestAssign = (r: RunConfirmRequest) => {
-    if (!needsConfirm(r)) {
-      // 直接落库路径（member/取消指派/backlog）：失败要给反馈，与确认路径一致，别静默吞错。
-      Promise.resolve(r.apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
-      return;
-    }
+    if (!needsConfirm(r)) { applyDirect(r.apply); return; }
     setPending(r);
   };
 
+  // 状态变更:仅在 backlog→活跃且已指派 agent/squad(会静默起 run)时弹确认;
+  // preview 传当前 assignee(不变)+ 新 status,后端按 status 源判定。
+  const requestStatus = (
+    issue: Issue,
+    next: IssueStatus,
+    apply: RunConfirmRequest["apply"],
+  ) => {
+    if (!statusMightTrigger(issue, next)) { applyDirect(apply); return; }
+    setPending({
+      issueId: issue.id,
+      status: next,
+      assigneeType: issue.assignee_type,
+      assigneeId: issue.assignee_id,
+      assigneeName: issue.assignee_name ?? null,
+      apply,
+    });
+  };
+
   const runConfirmModal = <RunConfirmModal pending={pending} onClose={() => setPending(null)} />;
-  return { requestAssign, runConfirmModal };
+  return { requestAssign, requestStatus, runConfirmModal };
 }
 
 function RunConfirmModal({ pending, onClose }: { pending: RunConfirmRequest | null; onClose: () => void }) {

--- a/packages/dmloop/src/ui/meta.tsx
+++ b/packages/dmloop/src/ui/meta.tsx
@@ -95,3 +95,9 @@ export const RUN_STATUS_COLOR: Record<string, TagColor> = {
   failed: "red",
   cancelled: "grey",
 };
+
+// run 是否处于活跃(未结束)态——可终止/仍在产生消息。单一来源,供运行面板与执行详情共用。
+const ACTIVE_RUN_STATUSES = ["queued", "dispatched", "waiting_local_directory", "running"];
+export function isActiveRun(status: string): boolean {
+  return ACTIVE_RUN_STATUSES.includes(status);
+}


### PR DESCRIPTION
## What

Phase A of the crown loop (final piece). The run detail modal was a one-shot read; it now streams messages while the run is active and keeps the run's own state fresh.

- `runsApi.listRunMessages` gains `since` → `GET /tasks/:id/messages?since=<seq>`.
- `RunMessage` realigned to backend `TaskMessagePayload`; `msgText` now renders **tool_result output** and **tool_use input** (previously read a nonexistent `text` field → those rows were blank).
- `RunDetailModal`: full fetch on open; for an active run, poll every 2s with `?since=lastSeq` and append (dedup by seq). Also refreshes the run's own state each poll and **stops once the run is terminal** — the header status / completed time / result update live instead of freezing at the click-time snapshot (fixes the review finding), and the poll self-terminates.
- Extracted shared `isActiveRun()`/`ACTIVE_RUN_STATUSES` in `ui/meta`, reused in RunDetailModal + IssueDetailPage.

## Verification (live daemon, agent "E2E Coworker", Alice)

| Path | Result |
|---|---|
| open a completed run | all 19 messages render non-empty (text + tool_use input + tool_result output) |
| re-run + open while active | messages streamed live 0 → 11 → 12 |
| run completes | header flips running → **completed**, `completed_at` fills, result section appears, polling stops (DB/UI-confirmed) |

## Review

- `/simplify`: shared `isActiveRun`, simplified `since` param; kept the seq dedup as insurance against an unverified `?since` inclusive/exclusive boundary.
- **Adversarial correctness pass** — fixed the confirmed frozen-run-status finding (poll now refreshes run state + self-terminates); dismissed a cosmetic tag-color nit.

## Notes

- dmloop has no fleet WebSocket client, so this is `?since` polling rather than the backend `task:message` WS.
- **Stacked on #609 → #608 → #606 → #605 → #602**; merge in order.
- No linked issue yet — `check-sprint` needs a maintainer. dmloop feature UI; no service/command/config change → no doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)