### PR TITLE
fix(docs): pass real doc owner to sheet member panel

### DIFF
--- a/packages/docs/src/sheet/SheetView.tsx
+++ b/packages/docs/src/sheet/SheetView.tsx
@@ -735,7 +735,7 @@ export function SheetView(props: SheetViewProps) {
             aria-label={t('docs.member.manage')}
             onMouseDown={(e) => e.stopPropagation()}
           >
-            <MemberPanel docId={docId} role={role} space={space} ownerId={uid} onClose={closePanel} />
+            <MemberPanel docId={docId} role={role} space={space} ownerId={ownerId} onClose={closePanel} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes #611. The sheet member panel showed two owners and let the real owner (a bot created via CLI) be removed, while the document member panel behaved correctly.

## Root cause

`SheetView` passed the current logged-in `uid` as `MemberPanel`'s `ownerId` instead of the owner lifted from doc meta:

```diff
-<MemberPanel docId={docId} role={role} space={space} ownerId={uid} onClose={closePanel} />
+<MemberPanel docId={docId} role={role} space={space} ownerId={ownerId} onClose={closePanel} />
```

When a non-owner admin opened a sheet's member panel, `MemberPanel` resolved the owner to the viewer, so the viewer got the owner badge and the non-removable rule, and the real owner was rendered as an ordinary, removable member.

`EditorShell` and `BoardShell` already pass the lifted `ownerId` meta state, which is why the document path was correct. This change reuses the existing `ownerId` state in `SheetView` (line 168, lifted from doc meta) — no new variable, no backend or schema change.

## Behavior after fix

The sheet path now matches the document path:
- The unique owner is the real owner; it carries the owner badge and cannot be removed.
- Other members are shown as `direct` and remain removable.

## Testing

- `packages/docs` members + sheet suites pass (98 tests), including `MemberPanel` cases for the owner badge, the owner being disabled/non-removable, and other members being removable.
- Typecheck shows only pre-existing errors unrelated to this change (`dmworkbase/format.ts`, `members/sort.ts`).

Draft PR for review only — not for merge.
