### PR TITLE
feat(loop): sort control and creator filter on the issue list

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -33,6 +33,9 @@ export async function listIssues(
     status: params?.status,
     priority: params?.priority,
     assignee_id: params?.assignee_id,
+    creator_id: params?.creator_id,
+    sort: params?.sort_by,
+    direction: params?.sort_direction,
     limit: params?.limit,
     offset: params?.offset,
   });

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -49,12 +49,21 @@ export interface Invitation {
   created_at?: string;
 }
 
+// 后端 /issues sort 白名单(单一来源,派生类型 + 供 UI 枚举)。
+export const ISSUE_SORT_FIELDS = ["position", "priority", "title", "created_at", "start_date", "due_date"] as const;
+export type IssueSortField = (typeof ISSUE_SORT_FIELDS)[number];
+
 export interface ListParams {
   workspace_id?: string;
   keyword?: string;
   status?: IssueStatus;
   priority?: IssuePriority;
   assignee_id?: string;
+  creator_id?: string;
+  // 后端白名单 sort：position(默认)|priority|title|created_at|start_date|due_date。
+  // direction 仅在 sort_by != position 时被后端采纳(asc|desc)。
+  sort_by?: IssueSortField;
+  sort_direction?: "asc" | "desc";
   limit?: number;
   offset?: number;
 }

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -45,7 +45,17 @@
   "filter": {
     "status": "Status",
     "priority": "Priority",
-    "assignee": "Assignee"
+    "assignee": "Assignee",
+    "creator": "Creator"
+  },
+  "sort": {
+    "direction": "Asc/desc",
+    "position": "Manual",
+    "priority": "Priority",
+    "title": "Title",
+    "created_at": "Created",
+    "start_date": "Start date",
+    "due_date": "Due date"
   },
   "action": {
     "newIssue": "New Issue",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -45,7 +45,17 @@
   "filter": {
     "status": "状态",
     "priority": "优先级",
-    "assignee": "负责人"
+    "assignee": "负责人",
+    "creator": "创建者"
+  },
+  "sort": {
+    "direction": "升/降序",
+    "position": "手动排序",
+    "priority": "优先级",
+    "title": "标题",
+    "created_at": "创建时间",
+    "start_date": "开始日期",
+    "due_date": "截止日期"
   },
   "action": {
     "newIssue": "新建 Issue",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -8,9 +8,10 @@ import {
   Select,
   Pagination,
 } from "@douyinfe/semi-ui";
-import { Search, Plus, LayoutGrid, List as ListIcon, ClipboardList } from "lucide-react";
+import { Search, Plus, LayoutGrid, List as ListIcon, ClipboardList, ArrowUp, ArrowDown } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Issue, IssueStatus, IssuePriority } from "../api/types";
+import type { Issue, IssueStatus, IssuePriority, IssueSortField } from "../api/types";
+import { ISSUE_SORT_FIELDS } from "../api/types";
 import { listIssues } from "../api/issueApi";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import { ISSUE_STATUS_ORDER, PRIORITY_ORDER } from "../ui/meta";
@@ -28,9 +29,13 @@ interface Filters {
   status?: IssueStatus;
   priority?: IssuePriority;
   assignee?: string;
+  creator?: string;
+  sortBy: IssueSortField;
+  sortDir: "asc" | "desc";
 }
 
 const PAGE_SIZE = 50;
+
 
 export default function IssuePage() {
   const { t } = useI18n();
@@ -38,7 +43,7 @@ export default function IssuePage() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<ViewMode>("board");
-  const [f, setF] = useState<Filters>({ keyword: "" });
+  const [f, setF] = useState<Filters>({ keyword: "", sortBy: "position", sortDir: "desc" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   const [createOpen, setCreateOpen] = useState(false);
   const cands = useAssigneeCandidates();
@@ -53,6 +58,10 @@ export default function IssuePage() {
       status: f.status,
       priority: f.priority,
       assignee_id: f.assignee,
+      creator_id: f.creator,
+      // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
+      sort_by: paged ? f.sortBy : undefined,
+      sort_direction: paged ? f.sortDir : undefined,
       // ponytail: 看板不分页——按 status 分列需全量，取后端上限 100；超量请用筛选或列表视图。
       limit: paged ? PAGE_SIZE : 100,
       offset: paged ? page * PAGE_SIZE : 0,
@@ -133,6 +142,42 @@ export default function IssuePage() {
             <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
           ))}
         </Select>
+        <Select
+          placeholder={t("loop.filter.creator")}
+          value={f.creator}
+          onChange={(v) => update({ creator: v as string | undefined })}
+          showClear
+          filter
+          size="small"
+          style={{ width: 130 }}
+        >
+          {cands.filter((c) => c.type === "member").map((c) => (
+            <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
+          ))}
+        </Select>
+        {view === "list" && (
+        <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Select
+            value={f.sortBy}
+            onChange={(v) => update({ sortBy: v as IssueSortField })}
+            size="small"
+            style={{ width: 120 }}
+          >
+            {ISSUE_SORT_FIELDS.map((s) => (
+              <Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>
+            ))}
+          </Select>
+          <Button
+            size="small"
+            theme="borderless"
+            // position(手动序)后端忽略方向,禁用切换。
+            disabled={f.sortBy === "position"}
+            icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
+            aria-label={t("loop.sort.direction")}
+            onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })}
+          />
+        </div>
+        )}
         <Input
           prefix={<Search size={14} />}
           placeholder={t("loop.search.issue")}


### PR DESCRIPTION
## What

**Phase B (browse parity), slice 1.** Extends the issue browse bar with server-side **sort** and a **creator filter**, using existing `GET /issues` params (no new endpoint).

- `ListParams` gains `sort_by`/`sort_direction`/`creator_id`; `issueApi` maps `sort_by→sort`, `sort_direction→direction` (backend whitelist: position|priority|title|created_at|start_date|due_date; direction honored only when sort ≠ position).
- Sort control (field Select + asc/desc toggle, disabled for position) + creator Select (member candidates). Any filter change resets to page 1.
- **Sort applies to LIST view only**; board omits it and stays on position. *(Adversarial-review finding: board fetches a 100-cap and splits client-side by status, so a global non-position sort could push a whole status past the cap and render its column falsely empty. Board keeps position; sort control hidden in board.)*
- `ISSUE_SORT_FIELDS` is a single `as const` source of truth; `IssueSortField` derived from it.

## Verification (Alice, MV2 E2E)

| Check | Result |
|---|---|
| sort created_at desc / asc | list reorders; toggle reverses (MVE-4/2/1 ⇄ MVE-1/2/4) |
| direction toggle on position | disabled |
| creator = Alice | narrows to Alice-authored (excludes wangdeng-created MVE-4) |
| sort control visibility | shown in list, hidden in board |

## Blast radius (Rule 8)

Contained to dmloop issue browse — `ListParams`/`IssueSortField` have no consumers outside `issueApi`/`IssuePage`; no package imports `@octo/loop`. Retrospective check of the merged Phase A PRs (#605/606/608/609/610) also found **no out-of-module breakage**.

## Review

`/simplify` (single-source sort fields) + adversarial correctness + cross-module blast-radius pass. Follow-up: creator dropdown lists members only (agent/squad creators omitted) — completeness nit, deferred.

## Notes

- Off the current `feat/octo-loop` (all Phase A merged) — standalone, not stacked.
- No linked issue yet — `check-sprint` needs a maintainer. Frontend-only; no doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)