### PR TITLE
style(global-search): align chat/file filter panel visuals with ChannelSearch

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
@@ -53,6 +53,21 @@ function dateFromSeconds(seconds?: number) {
   if (!seconds) return undefined;
   return new Date(seconds * 1000);
 }
+
+// Mirror of ChannelSearch's date label ("2026/07/10 周四") so the global-search
+// date trigger reads identically to the in-conversation one. Copied verbatim
+// from ChannelSearch/index.tsx to keep the two surfaces visually in lock-step.
+function dateDisplayValue(seconds?: number, locale?: string) {
+  if (!seconds) return "";
+  const date = new Date(seconds * 1000);
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  const weekday = new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+  }).format(date);
+  return `${year}/${month}/${day} ${weekday}`;
+}
 function datePickerValueToDate(
   value?: Date | Date[] | string | string[] | null
 ) {
@@ -92,7 +107,7 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
   onApply,
   onClose,
 }) => {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [draft, setDraft] = useState<GlobalSearchFilters>(filters);
   const [senderQuery, setSenderQuery] = useState("");
   const [senderOptions, setSenderOptions] = useState<ChannelSearchSender[]>(
@@ -700,16 +715,48 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
           })}
         </div>
         <DatePicker
-          density="compact"
-          type="date"
+          className="wk-channel-search-date-picker"
           value={dateFromSeconds(draft.startAt)}
           onChange={(v) => setCustomDate("startAt", v)}
+          density="compact"
+          position="bottomLeft"
+          autoSwitchDate={false}
+          disabledDate={(date) => {
+            if (!date || !draft.endAt) return false;
+            return toSeconds(startOfDay(date)) > draft.endAt;
+          }}
+          triggerRender={() => (
+            <button className="wk-channel-search-date-input" type="button">
+              <span className={draft.startAt ? undefined : "is-placeholder"}>
+                {draft.startAt
+                  ? dateDisplayValue(draft.startAt, locale)
+                  : t("base.channelSearch.filter.startDate")}
+              </span>
+              <CalendarDays size={16} />
+            </button>
+          )}
         />
         <DatePicker
-          density="compact"
-          type="date"
+          className="wk-channel-search-date-picker"
           value={dateFromSeconds(draft.endAt)}
           onChange={(v) => setCustomDate("endAt", v)}
+          density="compact"
+          position="bottomLeft"
+          autoSwitchDate={false}
+          disabledDate={(date) => {
+            if (!date || !draft.startAt) return false;
+            return toSeconds(endOfDay(date)) < draft.startAt;
+          }}
+          triggerRender={() => (
+            <button className="wk-channel-search-date-input" type="button">
+              <span className={draft.endAt ? undefined : "is-placeholder"}>
+                {draft.endAt
+                  ? dateDisplayValue(draft.endAt, locale)
+                  : t("base.channelSearch.filter.endDate")}
+              </span>
+              <CalendarDays size={16} />
+            </button>
+          )}
         />
       </div>
 

--- a/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
@@ -126,6 +126,18 @@
   gap: 6px;
 }
 
+/*
+  Title -> content rhythm. ChannelSearch always wraps its section title in
+  `.wk-channel-search-filter-title-row` (margin-bottom: 8px), so its titles sit
+  8px above their field/chips. The global panel renders the bare
+  `.wk-channel-search-filter-title` (no per-section clear row), which ships no
+  bottom margin — leaving every title glued to its control. Restore the same
+  8px gap here so the two filter surfaces share one vertical rhythm.
+*/
+.wk-global-content-search .wk-channel-search-filter-title {
+  margin-bottom: 8px;
+}
+
 /* Toggle-chip active / disabled states. ChannelSearch's chip is a removable
    tag with no selected state, so these modifiers live here (global-only). */
 .wk-global-content-search .wk-channel-search-filter-chip.is-active {


### PR DESCRIPTION
## What

Align the Global search **Chat/File** filter panel visuals with the `ChannelSearch` panel.

- **+8px title→content gap** — the filter panel title was too close to the first input. Scoped so it only affects **GlobalSearch**, not `ChannelSearch`.
- **"Sent time" date pickers** now reuse `ChannelSearch`'s `wk-channel-search-date-input` visual (field background, `lucide` `CalendarDays` icon, localized *Start date* / *End date* placeholders, formatted value), replacing the previous bare Semi widget.

## Why

The Global search filter panel and `ChannelSearch` were visually inconsistent — different title spacing and a different date-picker look. This brings them in line.

## Scope / Non-goals

Pure visual change. **No** search logic, contract, i18n-key, or hard-coded-color changes. GlobalSearch-scoped — `ChannelSearch` is untouched.

## Changed files

- `packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx`
- `packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css`

## Verification

- build ✅
- typecheck ✅
- lint:wkmodal ✅
- lint:css ✅ (0 errors)
- i18n:check ✅
- tests ✅ (no new failures)


Fixes #617
