### PR TITLE
feat: add personal runtimes and skills module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ grp_out.txt
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/
+.omx

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,6 +63,7 @@
     "@octo/docs": "workspace:*",
     "@octo/login": "workspace:*",
     "@octo/loop": "workspace:*",
+    "@octo/personal": "workspace:*",
     "@octo/todo": "workspace:*",
     "@react-pdf-viewer/core": "^3.12.0",
     "@react-pdf-viewer/page-navigation": "^3.12.0",

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -13,6 +13,7 @@ import { SummaryModule } from '@dmwork/summary';
 import { AppBotModule } from '@dmwork/appbot';
 import { DocsModule } from '@octo/docs';
 import { LoopModule } from '@octo/loop';
+import { PersonalModule } from '@octo/personal';
 import { version as pkgVersion } from '../package.json';
 import appEnUS from './i18n/en-US.json';
 import appZhCN from './i18n/zh-CN.json';
@@ -75,6 +76,7 @@ WKApp.shared.registerModule(new SummaryModule()); // 智能总结模块
 WKApp.shared.registerModule(new AppBotModule()); // App Bot 模块
 WKApp.shared.registerModule(new DocsModule()); // Docs module
 WKApp.shared.registerModule(new LoopModule()); // Loop 面板（Issue/Skill/Project/Agent/Squad/Runtime）
+WKApp.shared.registerModule(new PersonalModule()); // 我的（Runtimes/Skills）
 
 WKApp.shared.startup() // app启动
 

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -31,12 +31,18 @@
     "search": "Search device / provider",
     "empty": "No runtimes",
     "subtitle": "Machines and runtimes under your account. Workspace AI teammates run here.",
-    "add": "Add runtime",
+    "add": "Add computer",
     "allSpace": "All spaces",
     "runtimeCount": "{{count}} runtimes",
     "servingAgents": "Serving {{count}} AI teammates",
     "noAgents": "—",
-    "builtIn": "Built-in"
+    "builtIn": "Built-in",
+    "addComputerTitle": "Add computer",
+    "addComputerDesc": "Run this command on the computer you want to connect. After login, its runtimes will appear in the list.",
+    "copyCommand": "Copy command",
+    "copied": "Copied",
+    "copySuccess": "Command copied",
+    "copyFailed": "Copy failed. Please copy manually."
   },
   "view": {
     "board": "Board",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -16,26 +16,13 @@
     "settings": "Settings"
   },
   "runtime": {
-    "provider": "Provider",
-    "mode": "Mode",
-    "modeVal": {
-      "local": "Local",
-      "cloud": "Cloud"
-    },
     "online": "Online",
     "offline": "Offline",
-    "device": "Device info",
-    "launchHeader": "Launch header",
-    "visibility": "Visibility",
-    "lastSeen": "Last seen",
-    "search": "Search device / provider",
     "empty": "No runtimes",
     "subtitle": "Machines and runtimes under your account. Workspace AI teammates run here.",
     "add": "Add computer",
     "allSpace": "All spaces",
     "runtimeCount": "{{count}} runtimes",
-    "servingAgents": "Serving {{count}} AI teammates",
-    "noAgents": "—",
     "builtIn": "Built-in",
     "addComputerTitle": "Add computer",
     "addComputerDesc": "Run this command on the computer you want to connect. After login, its runtimes will appear in the list.",
@@ -306,16 +293,6 @@
     "rerunStarted": "Re-dispatched",
     "cancelConfirm": "Stop this run?",
     "cancelled": "Stopped"
-  },
-  "device": {
-    "devices": "Devices",
-    "runtimes": "Runtimes",
-    "local": "Local",
-    "remote": "Remote",
-    "pickDevice": "Pick a device",
-    "pickRuntime": "Select a runtime to view detail",
-    "agentsUsing": "Agents using",
-    "noAgents": "No agents use this runtime"
   },
   "settings": {
     "general": "General",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -12,7 +12,7 @@
     "project": "Project",
     "agent": "Agent",
     "squad": "Squad",
-    "runtime": "Devices",
+    "runtime": "Runtimes",
     "settings": "Settings"
   },
   "runtime": {
@@ -29,7 +29,14 @@
     "visibility": "Visibility",
     "lastSeen": "Last seen",
     "search": "Search device / provider",
-    "empty": "No devices"
+    "empty": "No runtimes",
+    "subtitle": "Machines and runtimes under your account. Workspace AI teammates run here.",
+    "add": "Add runtime",
+    "allSpace": "All spaces",
+    "runtimeCount": "{{count}} runtimes",
+    "servingAgents": "Serving {{count}} AI teammates",
+    "noAgents": "—",
+    "builtIn": "Built-in"
   },
   "view": {
     "board": "Board",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -31,12 +31,18 @@
     "search": "搜索运行时 / 提供方",
     "empty": "暂无运行时",
     "subtitle": "你名下的机器与运行时。工作区里的 AI 队友都跑在这里。",
-    "add": "添加运行时",
+    "add": "添加电脑",
     "allSpace": "全部空间",
     "runtimeCount": "{{count}} 个运行时",
     "servingAgents": "服务 {{count}} 个 AI 队友",
     "noAgents": "—",
-    "builtIn": "内置"
+    "builtIn": "内置",
+    "addComputerTitle": "添加电脑",
+    "addComputerDesc": "在需要接入的电脑上运行下面的命令，完成登录后运行时会出现在列表里。",
+    "copyCommand": "复制命令",
+    "copied": "已复制",
+    "copySuccess": "命令已复制",
+    "copyFailed": "复制失败，请手动复制"
   },
   "view": {
     "board": "看板",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -12,7 +12,7 @@
     "project": "项目",
     "agent": "智能体",
     "squad": "小队",
-    "runtime": "设备",
+    "runtime": "运行时",
     "settings": "设置"
   },
   "runtime": {
@@ -28,8 +28,15 @@
     "launchHeader": "启动标识",
     "visibility": "可见性",
     "lastSeen": "最近在线",
-    "search": "搜索设备 / 提供方",
-    "empty": "暂无设备"
+    "search": "搜索运行时 / 提供方",
+    "empty": "暂无运行时",
+    "subtitle": "你名下的机器与运行时。工作区里的 AI 队友都跑在这里。",
+    "add": "添加运行时",
+    "allSpace": "全部空间",
+    "runtimeCount": "{{count}} 个运行时",
+    "servingAgents": "服务 {{count}} 个 AI 队友",
+    "noAgents": "—",
+    "builtIn": "内置"
   },
   "view": {
     "board": "看板",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -16,26 +16,13 @@
     "settings": "设置"
   },
   "runtime": {
-    "provider": "提供方",
-    "mode": "类型",
-    "modeVal": {
-      "local": "本地",
-      "cloud": "云端"
-    },
     "online": "在线",
     "offline": "离线",
-    "device": "设备信息",
-    "launchHeader": "启动标识",
-    "visibility": "可见性",
-    "lastSeen": "最近在线",
-    "search": "搜索运行时 / 提供方",
     "empty": "暂无运行时",
     "subtitle": "你名下的机器与运行时。工作区里的 AI 队友都跑在这里。",
     "add": "添加电脑",
     "allSpace": "全部空间",
     "runtimeCount": "{{count}} 个运行时",
-    "servingAgents": "服务 {{count}} 个 AI 队友",
-    "noAgents": "—",
     "builtIn": "内置",
     "addComputerTitle": "添加电脑",
     "addComputerDesc": "在需要接入的电脑上运行下面的命令，完成登录后运行时会出现在列表里。",
@@ -306,16 +293,6 @@
     "rerunStarted": "已重新派单",
     "cancelConfirm": "确定终止这次执行？",
     "cancelled": "已终止"
-  },
-  "device": {
-    "devices": "设备",
-    "runtimes": "运行时",
-    "local": "本地",
-    "remote": "远程",
-    "pickDevice": "选择左侧设备",
-    "pickRuntime": "选择一个 Runtime 查看详情",
-    "agentsUsing": "使用中的智能体",
-    "noAgents": "暂无智能体使用该 Runtime"
   },
   "settings": {
     "general": "通用",

--- a/packages/dmloop/src/index.tsx
+++ b/packages/dmloop/src/index.tsx
@@ -3,6 +3,8 @@
 export { default as LoopModule } from "./module";
 export { default as LoopPage } from "./pages/LoopPage";
 export { default as MulticaCliAuthorizePage } from "./pages/MulticaCliAuthorizePage";
+export { default as RuntimePage } from "./pages/RuntimePage";
+export { default as SkillPage } from "./pages/SkillPage";
 export {
   isMulticaCliAuthorizePath,
   MULTICA_CLI_AUTHORIZE_PATH,

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Typography, Dropdown, Avatar, Modal, Input, Toast, Button } from "@douyinfe/semi-ui";
 import {
-  ClipboardList, Sparkles, Briefcase, Bot, Users, Cpu, Settings,
+  ClipboardList, Briefcase, Bot, Users, Settings,
   ChevronDown, Check, Plus, SquarePen, FolderPlus,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -12,25 +12,21 @@ import { invalidateDirectory } from "../api/directory";
 import { invalidateRuntimeMap } from "../api/agentApi";
 import CreateIssueModal from "../ui/CreateIssueModal";
 import IssuePage from "./IssuePage";
-import SkillPage from "./SkillPage";
 import ProjectPage from "./ProjectPage";
 import AgentPage from "./AgentPage";
 import SquadPage from "./SquadPage";
-import RuntimePage from "./RuntimePage";
 import SettingsPage from "./SettingsPage";
 import "./loop.css";
 
 const { Title, Text } = Typography;
 
-type TabKey = "issue" | "skill" | "project" | "agent" | "squad" | "runtime" | "settings";
+type TabKey = "issue" | "project" | "agent" | "squad" | "settings";
 
 const TABS: { key: TabKey; icon: React.ReactNode }[] = [
   { key: "issue", icon: <ClipboardList size={16} /> },
-  { key: "skill", icon: <Sparkles size={16} /> },
   { key: "project", icon: <Briefcase size={16} /> },
   { key: "agent", icon: <Bot size={16} /> },
   { key: "squad", icon: <Users size={16} /> },
-  { key: "runtime", icon: <Cpu size={16} /> },
   { key: "settings", icon: <Settings size={16} /> },
 ];
 
@@ -59,11 +55,9 @@ export default function LoopPage() {
     const k = `${key}:${ws?.id ?? "none"}`;
     switch (key) {
       case "issue": return <IssuePage key={k} />;
-      case "skill": return <SkillPage key={k} />;
       case "project": return <ProjectPage key={k} />;
       case "agent": return <AgentPage key={k} />;
       case "squad": return <SquadPage key={k} />;
-      case "runtime": return <RuntimePage key={k} />;
       case "settings": return <SettingsPage key={k} workspace={ws} onUpdated={() => reloadWorkspaces()} />;
       default: return <IssuePage key={k} />;
     }

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Typography, Spin, Tag, Banner, Button } from "@douyinfe/semi-ui";
-import { Box, Circle, Code2, Cpu, Monitor, Plus, Terminal } from "lucide-react";
-import { useI18n } from "@octo/base";
+import { Typography, Spin, Tag, Banner, Button, Toast } from "@douyinfe/semi-ui";
+import { Box, Check, Circle, Code2, Copy, Cpu, Monitor, Plus, Terminal } from "lucide-react";
+import { copyToClipboard, useI18n, WKModal } from "@octo/base";
 import type { RuntimeDevice, RuntimeMode } from "../api/types";
 import { listRuntimes } from "../api/runtimeApi";
 import "./runtime.css";
 
 const { Title } = Typography;
+
+const ADD_COMPUTER_COMMAND = `MULTICA_APP_URL=https://octo-dev.mlamp.cn \\
+./octo-daemon \\
+  --server-url https://octo-dev.mlamp.cn/fleet/api/v1 \\
+  login`;
 
 interface Device {
   key: string;
@@ -76,6 +81,8 @@ export default function RuntimePage() {
   const [runtimes, setRuntimes] = useState<RuntimeDevice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -102,6 +109,17 @@ export default function RuntimePage() {
     return Array.from(map.values());
   }, [runtimes]);
 
+  const copyCommand = async () => {
+    const ok = await copyToClipboard(ADD_COMPUTER_COMMAND);
+    if (!ok) {
+      Toast.error(t("loop.runtime.copyFailed"));
+      return;
+    }
+    setCopied(true);
+    Toast.success(t("loop.runtime.copySuccess"));
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
   return (
     <div className="loop-page">
       <div className="loop-runtime-hero">
@@ -112,7 +130,7 @@ export default function RuntimePage() {
           </div>
           <div className="loop-runtime-hero__subtitle">{t("loop.runtime.subtitle")}</div>
         </div>
-        <Button className="loop-runtime-hero__action" theme="solid" type="tertiary" icon={<Plus size={13} />}>
+        <Button className="loop-runtime-hero__action" theme="solid" type="tertiary" icon={<Plus size={13} />} onClick={() => setAddOpen(true)}>
           {t("loop.runtime.add")}
         </Button>
       </div>
@@ -167,6 +185,27 @@ export default function RuntimePage() {
           </div>
         )}
       </div>
+      <WKModal
+        visible={addOpen}
+        onCancel={() => setAddOpen(false)}
+        title={t("loop.runtime.addComputerTitle")}
+        size="lg"
+        footer={(
+          <>
+            <Button theme="borderless" type="tertiary" onClick={() => setAddOpen(false)}>
+              {t("loop.action.cancel")}
+            </Button>
+            <Button theme="solid" type="tertiary" icon={copied ? <Check size={14} /> : <Copy size={14} />} onClick={copyCommand}>
+              {copied ? t("loop.runtime.copied") : t("loop.runtime.copyCommand")}
+            </Button>
+          </>
+        )}
+      >
+        <div className="loop-runtime-add">
+          <p>{t("loop.runtime.addComputerDesc")}</p>
+          <pre className="loop-runtime-add__command"><code>{ADD_COMPUTER_COMMAND}</code></pre>
+        </div>
+      </WKModal>
     </div>
   );
 }

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Typography, Input, Spin, Empty, Tag, Avatar, Banner } from "@douyinfe/semi-ui";
-import { Search, Monitor, Cloud, Cpu, Circle, Bot } from "lucide-react";
+import { Typography, Spin, Tag, Banner, Button } from "@douyinfe/semi-ui";
+import { Box, Circle, Code2, Cpu, Monitor, Plus, Terminal } from "lucide-react";
 import { useI18n } from "@octo/base";
-import type { RuntimeDevice, RuntimeMode, Agent } from "../api/types";
+import type { RuntimeDevice, RuntimeMode } from "../api/types";
 import { listRuntimes } from "../api/runtimeApi";
-import { listAgents } from "../api/agentApi";
 import "./runtime.css";
 
-const { Title, Text } = Typography;
+const { Title } = Typography;
 
 interface Device {
   key: string;
@@ -16,10 +15,20 @@ interface Device {
   runtimes: RuntimeDevice[];
 }
 
+type ProviderTone = "claude" | "codex" | "hermes" | "openclaw" | "opencode" | "default";
+
 function deviceName(r: RuntimeDevice): string {
   const info = r.device_info || "";
   const head = info.split("·")[0]?.trim();
   return head || r.name;
+}
+
+function runtimeVersion(r: RuntimeDevice): string {
+  const version = r.metadata?.version;
+  if (typeof version === "string" && version.trim()) return version.trim();
+  const info = r.device_info || "";
+  const parts = info.split("·").map((part) => part.trim()).filter(Boolean);
+  return parts.slice(1).join(" · ") || r.launch_header || "-";
 }
 
 function relTime(iso: string | null): string {
@@ -33,39 +42,55 @@ function relTime(iso: string | null): string {
   return `${Math.floor(hr / 24)}d`;
 }
 
-/**
- * 设备页（四栏）：Loop一级 + 二级菜单 + [设备列表(本地/远程) | 选中设备的 Runtime 列表 | Runtime 详情]。
- * 设备 = 按 daemon_id 聚合的机器；Runtime = 该机器上的各运行时；详情含「哪些 agents 在用」。
- */
+function shortDaemon(id?: string | null): string {
+  if (!id) return "-";
+  return `daemon ${id.slice(0, 8)}`;
+}
+
+function providerName(provider: string): string {
+  if (!provider) return "-";
+  return provider.slice(0, 1).toUpperCase() + provider.slice(1);
+}
+
+function providerTone(provider: string): ProviderTone {
+  const key = provider.toLowerCase();
+  if (key.includes("claude")) return "claude";
+  if (key.includes("codex")) return "codex";
+  if (key.includes("hermes")) return "hermes";
+  if (key.includes("openclaw")) return "openclaw";
+  if (key.includes("opencode")) return "opencode";
+  return "default";
+}
+
+function providerIcon(provider: string) {
+  const tone = providerTone(provider);
+  if (tone === "codex") return <Box size={12} />;
+  if (tone === "opencode") return <Code2 size={12} />;
+  if (tone === "default") return <Terminal size={12} />;
+  return <span aria-hidden>{providerName(provider).slice(0, 1)}</span>;
+}
+
+/** Runtime 列表页：机器作为分组，组内展示该机器上的 runtimes。 */
 export default function RuntimePage() {
   const { t } = useI18n();
   const [runtimes, setRuntimes] = useState<RuntimeDevice[]>([]);
-  const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [keyword, setKeyword] = useState("");
-  const [deviceKey, setDeviceKey] = useState<string | null>(null);
-  const [runtimeId, setRuntimeId] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    Promise.all([listRuntimes(), listAgents()])
-      .then(([rs, ags]) => {
+    listRuntimes()
+      .then((rs) => {
         setRuntimes(rs);
-        setAgents(ags);
       })
       .catch((e) => setError(e?.message ?? "load failed"))
       .finally(() => setLoading(false));
   }, []);
 
   const devices = useMemo<Device[]>(() => {
-    const kw = keyword.trim().toLowerCase();
-    const rows = kw
-      ? runtimes.filter((r) => deviceName(r).toLowerCase().includes(kw) || r.provider.toLowerCase().includes(kw))
-      : runtimes;
     const map = new Map<string, Device>();
-    for (const r of rows) {
+    for (const r of runtimes) {
       const key = r.daemon_id || deviceName(r);
       let d = map.get(key);
       if (!d) {
@@ -75,35 +100,21 @@ export default function RuntimePage() {
       d.runtimes.push(r);
     }
     return Array.from(map.values());
-  }, [runtimes, keyword]);
-
-  // 默认选中第一个设备 + 第一个 runtime
-  useEffect(() => {
-    if (!deviceKey && devices[0]) {
-      setDeviceKey(devices[0].key);
-      setRuntimeId(devices[0].runtimes[0]?.id ?? null);
-    }
-  }, [devices, deviceKey]);
-
-  const groups = useMemo(() => {
-    const local = devices.filter((d) => d.mode !== "cloud");
-    const remote = devices.filter((d) => d.mode === "cloud");
-    return [
-      { key: "local", label: t("loop.device.local"), icon: <Monitor size={13} />, items: local },
-      { key: "remote", label: t("loop.device.remote"), icon: <Cloud size={13} />, items: remote },
-    ].filter((g) => g.items.length > 0);
-  }, [devices, t]);
-
-  const activeDevice = devices.find((d) => d.key === deviceKey) ?? null;
-  const activeRuntime = runtimes.find((r) => r.id === runtimeId) ?? null;
-  const agentsUsing = activeRuntime ? agents.filter((a) => a.runtime_id === activeRuntime.id) : [];
+  }, [runtimes]);
 
   return (
     <div className="loop-page">
-      <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.runtime")}</Title>
-        <div className="loop-page__spacer" />
-        <Input prefix={<Search size={14} />} placeholder={t("loop.runtime.search")} value={keyword} onChange={setKeyword} showClear style={{ width: 220 }} />
+      <div className="loop-runtime-hero">
+        <div>
+          <div className="loop-runtime-hero__title">
+            <Title heading={4}>{t("loop.nav.runtime")}</Title>
+            <span>{runtimes.length}</span>
+          </div>
+          <div className="loop-runtime-hero__subtitle">{t("loop.runtime.subtitle")}</div>
+        </div>
+        <Button className="loop-runtime-hero__action" theme="solid" type="tertiary" icon={<Plus size={13} />}>
+          {t("loop.runtime.add")}
+        </Button>
       </div>
       <div className="loop-page__body" style={{ padding: 0 }}>
         {error ? (
@@ -113,85 +124,46 @@ export default function RuntimePage() {
         ) : devices.length === 0 ? (
           <div className="loop-empty"><Cpu size={40} className="loop-empty__icon" /><div className="loop-empty__title">{t("loop.runtime.empty")}</div></div>
         ) : (
-          <div className="loop-dev">
-            {/* 第3栏：设备列表（本地/远程分组） */}
-            <div className="loop-dev__col loop-dev__devices">
-              <div className="loop-dev__col-title">{t("loop.device.devices")}</div>
-              {groups.map((g) => (
-                <div key={g.key} className="loop-dev__grp">
-                  <div className="loop-dev__grp-title">{g.icon}<span>{g.label}</span><em>{g.items.length}</em></div>
-                  {g.items.map((d) => (
-                    <button key={d.key} className={`loop-dev__row ${d.key === deviceKey ? "is-active" : ""}`}
-                      onClick={() => { setDeviceKey(d.key); setRuntimeId(d.runtimes[0]?.id ?? null); }}>
-                      <Monitor size={14} />
-                      <span className="loop-dev__row-main"><strong>{d.name}</strong><small>{d.runtimes.length} runtimes</small></span>
-                    </button>
+          <div className="loop-runtime-list">
+            {devices.map((device) => (
+              <section className="loop-runtime-machine" key={device.key} aria-label={device.name}>
+                <div className="loop-runtime-machine__head">
+                  <div className="loop-runtime-machine__identity">
+                    <span className="loop-runtime-machine__icon"><Monitor size={14} /></span>
+                    <strong>{device.name}</strong>
+                    <span className="loop-runtime-status is-online">
+                      <Circle size={6} fill="currentColor" />
+                      {t("loop.runtime.online")}
+                    </span>
+                  </div>
+                  <div className="loop-runtime-machine__meta">
+                    <Tag size="small" color="grey">v0.3.12</Tag>
+                    <span>{shortDaemon(device.runtimes[0]?.daemon_id)}</span>
+                    <span>{t("loop.runtime.allSpace")}</span>
+                    <strong>{t("loop.runtime.runtimeCount", { values: { count: device.runtimes.length } })}</strong>
+                  </div>
+                </div>
+                <div className="loop-runtime-rows" role="table" aria-label={`${device.name} ${t("loop.nav.runtime")}`}>
+                  {device.runtimes.map((runtime) => (
+                    <div key={runtime.id} className="loop-runtime-row" role="row">
+                      <div className="loop-runtime-row__name" role="cell">
+                        <span className={`loop-runtime-row__provider is-${providerTone(runtime.provider)}`}>
+                          {providerIcon(runtime.provider)}
+                        </span>
+                        <strong>{providerName(runtime.provider)}</strong>
+                        <Tag size="small" color="grey">{t("loop.runtime.builtIn")}</Tag>
+                      </div>
+                      <div className={`loop-runtime-status is-${runtime.status}`} role="cell">
+                        <Circle size={6} fill="currentColor" />
+                        {t(`loop.runtime.${runtime.status}`)}
+                      </div>
+                      <div className="loop-runtime-row__version" role="cell">{runtimeVersion(runtime)}</div>
+                      <time className="loop-runtime-row__seen" role="cell">{relTime(runtime.last_seen_at)}</time>
+                    </div>
                   ))}
                 </div>
-              ))}
-            </div>
-
-            {/* 第4栏：选中设备的 Runtime 列表 */}
-            <div className="loop-dev__col loop-dev__runtimes">
-              <div className="loop-dev__col-title">{t("loop.device.runtimes")}</div>
-              {!activeDevice ? (
-                <div className="loop-dev__hint">{t("loop.device.pickDevice")}</div>
-              ) : (
-                activeDevice.runtimes.map((r) => (
-                  <button key={r.id} className={`loop-dev__row ${r.id === runtimeId ? "is-active" : ""}`} onClick={() => setRuntimeId(r.id)}>
-                    <Circle size={8} style={{ color: r.status === "online" ? "#23a55a" : "#c9cdd4" }} />
-                    <span className="loop-dev__row-main"><strong>{r.provider}</strong><small>{r.name}</small></span>
-                    <time>{relTime(r.last_seen_at)}</time>
-                  </button>
-                ))
-              )}
-            </div>
-
-            {/* Runtime 详情（含使用中的 agents） */}
-            <div className="loop-dev__col loop-dev__detail">
-              {!activeRuntime ? (
-                <div className="loop-dev__hint">{t("loop.device.pickRuntime")}</div>
-              ) : (
-                <div className="loop-dev__detail-inner">
-                  <header className="loop-dev__detail-head">
-                    <Avatar color="light-blue" shape="square"><Cpu size={18} /></Avatar>
-                    <div>
-                      <Title heading={5} style={{ margin: 0 }}>
-                        <Circle size={9} style={{ marginRight: 6, color: activeRuntime.status === "online" ? "#23a55a" : "#c9cdd4" }} />
-                        {activeRuntime.name}
-                      </Title>
-                      <Text type="tertiary" style={{ fontSize: 12 }}>{activeRuntime.provider}</Text>
-                    </div>
-                    <Tag color={activeRuntime.status === "online" ? "green" : "grey"} style={{ marginLeft: "auto" }}>
-                      {t(`loop.runtime.${activeRuntime.status}`)}
-                    </Tag>
-                  </header>
-
-                  <dl className="loop-dev__fields">
-                    <dt>{t("loop.runtime.mode")}</dt><dd>{t(`loop.runtime.modeVal.${activeRuntime.runtime_mode}`) || activeRuntime.runtime_mode}</dd>
-                    <dt>{t("loop.runtime.device")}</dt><dd>{activeRuntime.device_info}</dd>
-                    <dt>{t("loop.runtime.launchHeader")}</dt><dd>{activeRuntime.launch_header ?? "—"}</dd>
-                    <dt>{t("loop.runtime.visibility")}</dt><dd>{activeRuntime.visibility}</dd>
-                    <dt>{t("loop.runtime.lastSeen")}</dt><dd>{relTime(activeRuntime.last_seen_at)} ago</dd>
-                  </dl>
-
-                  <div className="loop-dev__section-title">{t("loop.device.agentsUsing")} ({agentsUsing.length})</div>
-                  {agentsUsing.length === 0 ? (
-                    <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.device.noAgents")}</Text>
-                  ) : (
-                    <div className="loop-dev__agents">
-                      {agentsUsing.map((a) => (
-                        <div key={a.id} className="loop-dev__agent">
-                          <Avatar size="extra-extra-small" color="violet"><Bot size={12} /></Avatar>
-                          <Text>{a.name}</Text>
-                          <Tag size="small" color="grey">{a.model}</Tag>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+              </section>
+            ))}
           </div>
         )}
       </div>

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -4,14 +4,71 @@ import { Box, Check, Circle, Code2, Copy, Cpu, Monitor, Plus, Terminal } from "l
 import { copyToClipboard, useI18n, WKModal } from "@octo/base";
 import type { RuntimeDevice, RuntimeMode } from "../api/types";
 import { listRuntimes } from "../api/runtimeApi";
+import { LOOP_API_BASE } from "../api/http";
 import "./runtime.css";
 
 const { Title } = Typography;
 
-const ADD_COMPUTER_COMMAND = `MULTICA_APP_URL=https://octo-dev.mlamp.cn \\
+const DEFAULT_FLEET_API_PATH = "/fleet/api/v1";
+
+function envValue(key: string): string {
+  return (import.meta as { env?: Record<string, string | undefined> }).env?.[key]?.trim() ?? "";
+}
+
+function trimEndSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    return Boolean(new URL(value).origin);
+  } catch {
+    return false;
+  }
+}
+
+function originOf(value: string): string {
+  if (!value) return "";
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+function currentOrigin(): string {
+  if (typeof window !== "undefined" && window.location.origin) {
+    return window.location.origin;
+  }
+  return originOf(envValue("VITE_APP_URL")) || originOf(envValue("VITE_API_URL"));
+}
+
+function withOrigin(pathOrUrl: string, origin: string): string {
+  if (isAbsoluteUrl(pathOrUrl)) return trimEndSlash(pathOrUrl);
+  if (!origin) return trimEndSlash(pathOrUrl);
+  return `${trimEndSlash(origin)}${pathOrUrl.startsWith("/") ? "" : "/"}${trimEndSlash(pathOrUrl)}`;
+}
+
+function fleetApiUrl(): string {
+  const explicitLoopBase = envValue("VITE_LOOP_API_BASE");
+  if (explicitLoopBase) {
+    return withOrigin(explicitLoopBase, currentOrigin());
+  }
+  return withOrigin(LOOP_API_BASE || DEFAULT_FLEET_API_PATH, currentOrigin());
+}
+
+function appUrl(): string {
+  const configuredAppUrl = originOf(envValue("VITE_APP_URL"));
+  if (configuredAppUrl) return configuredAppUrl;
+  return currentOrigin();
+}
+
+function addComputerCommand(): string {
+  return `MULTICA_APP_URL=${appUrl()} \\
 ./octo-daemon \\
-  --server-url https://octo-dev.mlamp.cn/fleet/api/v1 \\
+  --server-url ${fleetApiUrl()} \\
   login`;
+}
 
 interface Device {
   key: string;
@@ -34,6 +91,18 @@ function runtimeVersion(r: RuntimeDevice): string {
   const info = r.device_info || "";
   const parts = info.split("·").map((part) => part.trim()).filter(Boolean);
   return parts.slice(1).join(" · ") || r.launch_header || "-";
+}
+
+function deviceStatus(runtimes: RuntimeDevice[]): RuntimeDevice["status"] {
+  return runtimes.some((runtime) => runtime.status === "online") ? "online" : "offline";
+}
+
+function deviceVersion(runtimes: RuntimeDevice[]): string {
+  for (const runtime of runtimes) {
+    const version = runtimeVersion(runtime);
+    if (version !== "-") return version;
+  }
+  return "-";
 }
 
 function relTime(iso: string | null): string {
@@ -116,7 +185,7 @@ export default function RuntimePage() {
   }, [runtimes]);
 
   const copyCommand = async () => {
-    const ok = await copyToClipboard(ADD_COMPUTER_COMMAND);
+    const ok = await copyToClipboard(addComputerCommand());
     if (!ok) {
       Toast.error(t("loop.runtime.copyFailed"));
       return;
@@ -148,19 +217,22 @@ export default function RuntimePage() {
           <div className="loop-empty"><Cpu size={40} className="loop-empty__icon" /><div className="loop-empty__title">{t("loop.runtime.empty")}</div></div>
         ) : (
           <div className="loop-runtime-list">
-            {devices.map((device) => (
+            {devices.map((device) => {
+              const status = deviceStatus(device.runtimes);
+              const version = deviceVersion(device.runtimes);
+              return (
               <section className="loop-runtime-machine" key={device.key} aria-label={device.name}>
                 <div className="loop-runtime-machine__head">
                   <div className="loop-runtime-machine__identity">
                     <span className="loop-runtime-machine__icon"><Monitor size={14} /></span>
                     <strong>{device.name}</strong>
-                    <span className="loop-runtime-status is-online">
+                    <span className={`loop-runtime-status is-${status}`}>
                       <Circle size={6} fill="currentColor" />
-                      {t("loop.runtime.online")}
+                      {t(`loop.runtime.${status}`)}
                     </span>
                   </div>
                   <div className="loop-runtime-machine__meta">
-                    <Tag size="small" color="grey">v0.3.12</Tag>
+                    {version !== "-" && <Tag size="small" color="grey">{version}</Tag>}
                     <span>{shortDaemon(device.runtimes[0]?.daemon_id)}</span>
                     <span>{t("loop.runtime.allSpace")}</span>
                     <strong>{t("loop.runtime.runtimeCount", { values: { count: device.runtimes.length } })}</strong>
@@ -186,7 +258,8 @@ export default function RuntimePage() {
                   ))}
                 </div>
               </section>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -208,7 +281,7 @@ export default function RuntimePage() {
       >
         <div className="loop-runtime-add">
           <p>{t("loop.runtime.addComputerDesc")}</p>
-          <pre className="loop-runtime-add__command"><code>{ADD_COMPUTER_COMMAND}</code></pre>
+          <pre className="loop-runtime-add__command"><code>{addComputerCommand()}</code></pre>
         </div>
       </WKModal>
     </div>

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -85,6 +85,12 @@ export default function RuntimePage() {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
+    if (!copied) return undefined;
+    const timer = window.setTimeout(() => setCopied(false), 1600);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  useEffect(() => {
     setLoading(true);
     setError(null);
     listRuntimes()
@@ -117,7 +123,6 @@ export default function RuntimePage() {
     }
     setCopied(true);
     Toast.success(t("loop.runtime.copySuccess"));
-    window.setTimeout(() => setCopied(false), 1600);
   };
 
   return (

--- a/packages/dmloop/src/pages/runtime.css
+++ b/packages/dmloop/src/pages/runtime.css
@@ -1,57 +1,249 @@
-/* 设备页四栏：设备列表 | Runtime 列表 | Runtime 详情 */
-.loop-dev {
-  display: grid;
-  grid-template-columns: 220px 240px minmax(0, 1fr);
-  height: 100%;
-  min-height: 0;
+.loop-runtime-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--wk-sp-4);
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--wk-sp-8) var(--wk-sp-4) var(--wk-sp-4);
 }
 
-.loop-dev__col {
-  overflow: auto;
-  min-height: 0;
-  padding: 10px 8px;
+.loop-runtime-hero__title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--wk-sp-2);
 }
 
-.loop-dev__devices,
-.loop-dev__runtimes {
-  border-right: 1px solid var(--semi-color-border, #e8e9eb);
+.loop-runtime-hero__title h4 {
+  margin: 0;
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-3xl);
+  font-weight: 700;
+  line-height: 1.25;
 }
 
-.loop-dev__col-title {
-  font-size: 12px;
+.loop-runtime-hero__title span {
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-md);
+  font-weight: 500;
+}
+
+.loop-runtime-hero__subtitle {
+  margin-top: var(--wk-sp-1);
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-sm);
+  line-height: 1.5;
+}
+
+.loop-runtime-hero__action.semi-button {
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-text-primary);
+  color: var(--wk-text-inverse);
+  font-size: var(--wk-text-size-sm);
   font-weight: 600;
-  color: var(--semi-color-text-2, #8590a6);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 4px 8px 8px;
 }
 
-.loop-dev__grp { margin-bottom: 8px; }
-.loop-dev__grp-title {
-  display: flex; align-items: center; gap: 6px;
-  padding: 6px 8px 3px; font-size: 12px; color: var(--semi-color-text-2, #8590a6);
+.loop-runtime-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-4);
+  width: 100%;
+  max-width: 1280px;
+  min-width: 920px;
+  margin: 0 auto;
+  padding: 0 var(--wk-sp-4) var(--wk-sp-12);
+  overflow: auto;
 }
-.loop-dev__grp-title em { margin-left: auto; font-style: normal; opacity: 0.7; }
 
-.loop-dev__row {
-  width: 100%; display: flex; align-items: center; gap: 8px;
-  padding: 8px 10px; border: none; background: transparent; border-radius: 8px;
-  cursor: pointer; text-align: left;
+.loop-runtime-machine {
+  overflow: hidden;
+  border: 1px solid var(--semi-color-border);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  box-shadow: var(--wk-shadow-sm);
 }
-.loop-dev__row:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-dev__row.is-active { background: var(--semi-color-primary-light-default, #eef2ff); }
-.loop-dev__row-main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
-.loop-dev__row-main strong { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-dev__row-main small { font-size: 12px; color: var(--semi-color-text-2, #8590a6); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-dev__row time { font-size: 11px; color: var(--semi-color-text-2, #8590a6); }
 
-.loop-dev__hint { padding: 24px 12px; color: var(--semi-color-text-2, #8590a6); font-size: 13px; text-align: center; }
+.loop-runtime-machine__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--wk-sp-5);
+  min-height: 40px;
+  padding: var(--wk-sp-2) var(--wk-sp-4);
+  border-bottom: 1px solid var(--semi-color-border);
+  background: var(--wk-bg-surface);
+}
 
-.loop-dev__detail { padding: 18px 20px; }
-.loop-dev__detail-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
-.loop-dev__fields { display: grid; grid-template-columns: 96px 1fr; gap: 10px; margin: 0 0 18px; }
-.loop-dev__fields dt { font-size: 12px; color: var(--semi-color-text-2, #8590a6); }
-.loop-dev__fields dd { margin: 0; font-size: 13px; word-break: break-word; }
-.loop-dev__section-title { font-size: 13px; font-weight: 600; margin-bottom: 10px; }
-.loop-dev__agents { display: flex; flex-direction: column; gap: 8px; }
-.loop-dev__agent { display: flex; align-items: center; gap: 8px; }
+.loop-runtime-machine__identity {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  min-width: 0;
+}
+
+.loop-runtime-machine__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-tertiary);
+}
+
+.loop-runtime-machine__identity strong {
+  overflow: hidden;
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-base);
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-runtime-machine__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--wk-sp-4);
+  min-width: 0;
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-xs);
+  white-space: nowrap;
+}
+
+.loop-runtime-machine__meta strong {
+  color: var(--wk-text-secondary);
+  font-weight: 600;
+}
+
+.loop-runtime-rows {
+  background: var(--wk-bg-surface);
+}
+
+.loop-runtime-row {
+  display: grid;
+  grid-template-columns: minmax(260px, 2.2fr) minmax(120px, 0.8fr) minmax(260px, 1.6fr) 88px;
+  align-items: center;
+  min-height: 44px;
+  border-bottom: 1px solid color-mix(in srgb, var(--semi-color-border), transparent 45%);
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-sm);
+}
+
+.loop-runtime-row:last-child {
+  border-bottom: none;
+}
+
+.loop-runtime-row:hover {
+  background: var(--wk-bg-hover);
+}
+
+.loop-runtime-row > div,
+.loop-runtime-row > time {
+  min-width: 0;
+  padding: 0 var(--wk-sp-4);
+}
+
+.loop-runtime-row__name,
+.loop-runtime-status {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  min-width: 0;
+}
+
+.loop-runtime-row__name strong {
+  overflow: hidden;
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-base);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-runtime-row__provider {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--wk-r-xs);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-tiny);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.loop-runtime-row__provider.is-claude {
+  background: var(--semi-color-success-light-default);
+  color: var(--semi-color-success);
+}
+
+.loop-runtime-row__provider.is-codex {
+  background: var(--semi-color-info-light-default);
+  color: var(--semi-color-info);
+}
+
+.loop-runtime-row__provider.is-hermes {
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-primary);
+  border-radius: var(--wk-r-full);
+}
+
+.loop-runtime-row__provider.is-openclaw {
+  background: var(--semi-color-warning-light-default);
+  color: var(--semi-color-warning);
+}
+
+.loop-runtime-row__provider.is-opencode {
+  background: var(--wk-text-primary);
+  color: var(--wk-text-inverse);
+}
+
+.loop-runtime-status {
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-sm);
+}
+
+.loop-runtime-status.is-online {
+  color: var(--semi-color-success);
+}
+
+.loop-runtime-status.is-offline {
+  color: var(--wk-text-disabled);
+}
+
+.loop-runtime-row__version {
+  overflow: hidden;
+  color: var(--wk-text-tertiary);
+  font: var(--wk-text-mono-sm);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-runtime-row__seen {
+  overflow: hidden;
+  color: var(--wk-text-disabled);
+  font: var(--wk-text-mono-sm);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 960px) {
+  .loop-runtime-hero {
+    padding-right: var(--wk-sp-4);
+    padding-left: var(--wk-sp-4);
+  }
+
+  .loop-runtime-list {
+    padding-right: var(--wk-sp-4);
+    padding-left: var(--wk-sp-4);
+  }
+}

--- a/packages/dmloop/src/pages/runtime.css
+++ b/packages/dmloop/src/pages/runtime.css
@@ -236,6 +236,30 @@
   white-space: nowrap;
 }
 
+.loop-runtime-add {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-4);
+}
+
+.loop-runtime-add p {
+  margin: 0;
+  color: var(--wk-text-secondary);
+  font: var(--wk-text-caption);
+}
+
+.loop-runtime-add__command {
+  margin: 0;
+  padding: var(--wk-sp-4);
+  overflow: auto;
+  border: 1px solid var(--semi-color-border);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-primary);
+  font: var(--wk-text-code);
+  white-space: pre;
+}
+
 @media (max-width: 960px) {
   .loop-runtime-hero {
     padding-right: var(--wk-sp-4);

--- a/packages/dmpersonal/package.json
+++ b/packages/dmpersonal/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@octo/personal",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "dependencies": {
+    "@octo/base": "workspace:*",
+    "@octo/loop": "workspace:*",
+    "lucide-react": "^0.577.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.28",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { AlertCircle, Cpu, FolderPlus, Loader2, Sparkles } from "lucide-react";
-import { RuntimePage, SkillPage } from "@octo/loop";
+import { currentWorkspaceId, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
 import { useI18n, WKApp } from "@octo/base";
-import { listWorkspaces } from "@octo/loop/src/api/workspaceApi";
-import { currentWorkspaceId, setWorkspaceContext } from "@octo/loop";
 import "@octo/loop/src/pages/loop.css";
 import "./personal.css";
 
@@ -45,7 +43,7 @@ export default function PersonalPage() {
       <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
     );
 
-    listWorkspaces()
+    workspaceApi.listWorkspaces()
       .then((workspaces) => {
         if (cancelled) return;
         const selected = workspaces.find((workspace) => workspace.id === currentWorkspaceId()) ?? workspaces[0] ?? null;
@@ -86,7 +84,7 @@ export default function PersonalPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [t]);
 
   return (
     <div className="dmpersonal-sidebar">

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from "react";
+import { AlertCircle, Cpu, FolderPlus, Loader2, Sparkles } from "lucide-react";
+import { RuntimePage, SkillPage } from "@octo/loop";
+import { useI18n, WKApp } from "@octo/base";
+import { listWorkspaces } from "@octo/loop/src/api/workspaceApi";
+import { currentWorkspaceId, setWorkspaceContext } from "@octo/loop";
+import "@octo/loop/src/pages/loop.css";
+import "./personal.css";
+
+type PersonalTabKey = "runtime" | "skill";
+
+const PERSONAL_TABS: { key: PersonalTabKey; icon: React.ReactNode }[] = [
+  { key: "runtime", icon: <Cpu size={16} /> },
+  { key: "skill", icon: <Sparkles size={16} /> },
+];
+
+function renderTab(key: PersonalTabKey): JSX.Element {
+  switch (key) {
+    case "runtime":
+      return <RuntimePage key="runtime" />;
+    case "skill":
+      return <SkillPage key="skill" />;
+    default:
+      return <RuntimePage key="runtime" />;
+  }
+}
+
+export default function PersonalPage() {
+  const { t } = useI18n();
+  const [tab, setTab] = useState<PersonalTabKey>("runtime");
+  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const [workspaceEmpty, setWorkspaceEmpty] = useState(false);
+  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+
+  const openTab = (key: PersonalTabKey) => {
+    if (!workspaceReady) return;
+    setTab(key);
+    WKApp.routeRight.replaceToRoot(renderTab(key));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    WKApp.routeRight.replaceToRoot(
+      <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
+    );
+
+    listWorkspaces()
+      .then((workspaces) => {
+        if (cancelled) return;
+        const selected = workspaces.find((workspace) => workspace.id === currentWorkspaceId()) ?? workspaces[0] ?? null;
+
+        if (!selected) {
+          setWorkspaceEmpty(true);
+          setWorkspaceReady(false);
+          WKApp.routeRight.replaceToRoot(
+            <PersonalWorkspaceState
+              icon={<FolderPlus size={40} />}
+              title={t("personal.workspace.requiredTitle")}
+              desc={t("personal.workspace.requiredDesc")}
+            />,
+          );
+          return;
+        }
+
+        setWorkspaceContext(selected.slug, selected.id);
+        setWorkspaceReady(true);
+        setWorkspaceEmpty(false);
+        setWorkspaceError(null);
+        WKApp.routeRight.replaceToRoot(renderTab("runtime"));
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        const message = error?.message ? String(error.message) : t("personal.workspace.loadFailed");
+        setWorkspaceError(message);
+        setWorkspaceReady(false);
+        WKApp.routeRight.replaceToRoot(
+          <PersonalWorkspaceState
+            icon={<AlertCircle size={40} />}
+            title={t("personal.workspace.loadFailed")}
+            desc={message}
+          />,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="dmpersonal-sidebar">
+      <div className="dmpersonal-sidebar__title">{t("personal.menu.title")}</div>
+      <nav className="dmpersonal-sidebar__menu">
+        {PERSONAL_TABS.map((item) => (
+          <button
+            key={item.key}
+            className={`dmpersonal-sidebar__item ${tab === item.key ? "is-active" : ""}`}
+            disabled={!workspaceReady}
+            onClick={() => openTab(item.key)}
+          >
+            {item.icon}
+            <span>{t(`personal.nav.${item.key}`)}</span>
+          </button>
+        ))}
+      </nav>
+      {(workspaceEmpty || workspaceError) && (
+        <div className="dmpersonal-sidebar__hint">
+          {workspaceError || t("personal.workspace.requiredTitle")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PersonalWorkspaceState({
+  icon,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc?: string;
+}) {
+  return (
+    <div className="loop-page">
+      <div className="dmpersonal-state">
+        <div className="dmpersonal-state__icon">{icon}</div>
+        <div className="dmpersonal-state__title">{title}</div>
+        {desc && <div className="dmpersonal-state__desc">{desc}</div>}
+      </div>
+    </div>
+  );
+}

--- a/packages/dmpersonal/src/i18n/en-US.json
+++ b/packages/dmpersonal/src/i18n/en-US.json
@@ -1,0 +1,15 @@
+{
+  "menu": {
+    "title": "Personal"
+  },
+  "nav": {
+    "runtime": "Runtimes",
+    "skill": "Skills"
+  },
+  "workspace": {
+    "loading": "Loading workspace...",
+    "requiredTitle": "Join a workspace first",
+    "requiredDesc": "Runtimes and Skills are currently managed within a workspace. Join or create one, then come back.",
+    "loadFailed": "Failed to load workspaces"
+  }
+}

--- a/packages/dmpersonal/src/i18n/zh-CN.json
+++ b/packages/dmpersonal/src/i18n/zh-CN.json
@@ -1,0 +1,15 @@
+{
+  "menu": {
+    "title": "我的"
+  },
+  "nav": {
+    "runtime": "运行时",
+    "skill": "Skills"
+  },
+  "workspace": {
+    "loading": "正在加载工作区…",
+    "requiredTitle": "请先加入一个 workspace",
+    "requiredDesc": "Runtimes 和 Skills 当前仍按 workspace 管理。加入或创建 workspace 后再回来查看。",
+    "loadFailed": "工作区加载失败"
+  }
+}

--- a/packages/dmpersonal/src/index.tsx
+++ b/packages/dmpersonal/src/index.tsx
@@ -1,0 +1,2 @@
+export { default as PersonalModule } from "./module";
+export { default as PersonalPage } from "./PersonalPage";

--- a/packages/dmpersonal/src/module.tsx
+++ b/packages/dmpersonal/src/module.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { WKApp, Menus, i18n, t as translate } from "@octo/base";
+import type { IModule } from "@octo/base";
+import PersonalPage from "./PersonalPage";
+import enUS from "./i18n/en-US.json";
+import zhCN from "./i18n/zh-CN.json";
+
+let _initialized = false;
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    _initialized = false;
+  });
+}
+
+function PersonalIcon({ active }: { active?: boolean }) {
+  const color = active ? "var(--wk-brand-primary)" : "currentColor";
+
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M16 21v-2a4 4 0 00-4-4H7a4 4 0 00-4 4v2" />
+      <circle cx="9.5" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 00-3-3.87" />
+      <path d="M16 3.13a4 4 0 010 7.75" />
+    </svg>
+  );
+}
+
+export default class PersonalModule implements IModule {
+  id(): string {
+    return "DMPersonalModule";
+  }
+
+  init(): void {
+    if (_initialized) return;
+    _initialized = true;
+
+    i18n.registerNamespace("personal", {
+      "zh-CN": zhCN,
+      "en-US": enUS,
+    });
+
+    WKApp.route.register("/personal", () => <PersonalPage />);
+
+    WKApp.menus.register(
+      "dmpersonal",
+      () => new Menus(
+        "dmpersonal",
+        "/personal",
+        translate("personal.menu.title"),
+        <PersonalIcon />,
+        <PersonalIcon active />,
+      ),
+      4004,
+    );
+  }
+}

--- a/packages/dmpersonal/src/personal.css
+++ b/packages/dmpersonal/src/personal.css
@@ -1,0 +1,94 @@
+.dmpersonal-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--semi-color-bg-1);
+  color: var(--semi-color-text-0);
+}
+
+.dmpersonal-sidebar__title {
+  padding: 20px 20px 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--semi-color-text-0);
+}
+
+.dmpersonal-sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 8px;
+}
+
+.dmpersonal-sidebar__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--semi-color-text-1);
+  text-align: left;
+}
+
+.dmpersonal-sidebar__item:hover {
+  background: var(--semi-color-fill-0);
+}
+
+.dmpersonal-sidebar__item.is-active {
+  background: var(--semi-color-primary-light-default);
+  color: var(--semi-color-primary);
+  font-weight: 600;
+}
+
+.dmpersonal-sidebar__item:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.dmpersonal-sidebar__hint {
+  margin: 12px 12px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--semi-color-warning-light-default);
+  color: var(--semi-color-warning);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.dmpersonal-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 70%;
+  padding: 24px;
+  text-align: center;
+  color: var(--semi-color-text-2);
+}
+
+.dmpersonal-state__icon {
+  display: flex;
+  margin-bottom: 12px;
+  color: var(--semi-color-text-2);
+  opacity: 0.55;
+}
+
+.dmpersonal-state__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--semi-color-text-0);
+}
+
+.dmpersonal-state__desc {
+  max-width: 360px;
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--semi-color-text-2);
+}

--- a/packages/dmpersonal/src/personal.css
+++ b/packages/dmpersonal/src/personal.css
@@ -8,8 +8,8 @@
 }
 
 .dmpersonal-sidebar__title {
-  padding: 20px 20px 12px;
-  font-size: 16px;
+  padding: var(--wk-sp-5) var(--wk-sp-5) var(--wk-sp-3);
+  font-size: var(--wk-text-size-xl);
   font-weight: 600;
   color: var(--semi-color-text-0);
 }
@@ -17,21 +17,21 @@
 .dmpersonal-sidebar__menu {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 4px 8px;
+  gap: var(--wk-sp-0-5);
+  padding: var(--wk-sp-1) var(--wk-sp-2);
 }
 
 .dmpersonal-sidebar__item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--wk-sp-2);
   width: 100%;
-  padding: 9px 12px;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
   border: none;
   background: transparent;
-  border-radius: 8px;
+  border-radius: var(--wk-r-md);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--wk-text-size-base);
   color: var(--semi-color-text-1);
   text-align: left;
 }
@@ -52,13 +52,12 @@
 }
 
 .dmpersonal-sidebar__hint {
-  margin: 12px 12px 0;
-  padding: 10px 12px;
-  border-radius: 8px;
+  margin: var(--wk-sp-3) var(--wk-sp-3) 0;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border-radius: var(--wk-r-md);
   background: var(--semi-color-warning-light-default);
   color: var(--semi-color-warning);
-  font-size: 12px;
-  line-height: 18px;
+  font: var(--wk-text-caption);
 }
 
 .dmpersonal-state {
@@ -67,28 +66,28 @@
   align-items: center;
   justify-content: center;
   height: 70%;
-  padding: 24px;
+  padding: var(--wk-sp-6);
   text-align: center;
   color: var(--semi-color-text-2);
 }
 
 .dmpersonal-state__icon {
   display: flex;
-  margin-bottom: 12px;
+  margin-bottom: var(--wk-sp-3);
   color: var(--semi-color-text-2);
   opacity: 0.55;
 }
 
 .dmpersonal-state__title {
-  font-size: 15px;
+  font-size: var(--wk-text-size-lg);
   font-weight: 600;
   color: var(--semi-color-text-0);
 }
 
 .dmpersonal-state__desc {
   max-width: 360px;
-  margin-top: 6px;
-  font-size: 13px;
-  line-height: 20px;
+  margin-top: var(--wk-sp-1-5);
+  font-size: var(--wk-text-size-base);
+  line-height: 1.5;
   color: var(--semi-color-text-2);
 }

--- a/packages/dmpersonal/tsconfig.json
+++ b/packages/dmpersonal/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../packages/tsconfig/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- Add the new `@octo/personal` package and register the top-level Personal / 我的 module.
- Move Runtimes and Skills navigation out of Loop into Personal while reusing the existing Loop pages.
- Bootstrap Personal pages by listing workspaces and setting the active workspace context before loading workspace-scoped APIs.
- Redesign the Runtimes list as a grouped machine table and add the Add computer setup modal.
- Ignore local `.omx` runtime state in `.gitignore`.

## Verification
- `corepack pnpm i18n:check`
- `git diff --check origin/feat/octo-loop...HEAD`
- `corepack pnpm --filter @octo/web build`

## Notes
- The web build completes with existing warnings around lottie/pdfjs direct eval, large chunks, and Semi dynamic import handling.
