### PR TITLE
fix(whiteboard): reject structurally-invalid fractional-index keys and harden restore

### DIFF
--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -99,6 +99,7 @@ type ExcalidrawComponent = ComponentType<ExcalidrawProps>
 type RestoreElementsFn = (
   elements: readonly unknown[] | null | undefined,
   localElements: readonly unknown[] | null | undefined,
+  opts?: { refreshDimensions?: boolean; repairBindings?: boolean; normalizeIndices?: boolean },
 ) => ExcalidrawElement[]
 type ReconcileElementsFn = (
   localElements: readonly unknown[],
@@ -828,7 +829,12 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     if (restore && reconcile) {
       const imperative = api as { getAppState?: () => unknown }
       binding.setRenderAdapter({
-        restore: (remote) => restore(remote, null),
+        // XIN-795 ④ depth defence: ask Excalidraw to re-index on restore so a recoverable
+        // out-of-order key is normalised rather than thrown on. A structurally-invalid key that
+        // even normalizeIndices cannot repair still throws, but that throw is caught by
+        // `applyRemote` (collab/binding.ts), which keeps the last good scene instead of blanking
+        // the canvas — the root fix for invalid persisted keys lives in BE repair (XIN-794).
+        restore: (remote) => restore(remote, null, { normalizeIndices: true }),
         reconcile: (local, restoredRemote) => reconcile(local, restoredRemote, imperative.getAppState?.()),
       })
     }
@@ -1011,7 +1017,18 @@ export function BoardShell(props: BoardShellProps): ReactElement {
       if (docEls.length > 0) raw = docEls
     }
     const restore = restoreElementsRef.current
-    return restore ? restore(raw, null) : [...raw]
+    if (!restore) return [...raw]
+    // XIN-795 ④ depth defence: this restore runs during render (not inside the collab binding's
+    // guarded applyRemote), so a throw on a structurally-invalid persisted key — one the BE repair
+    // (XIN-794) failed to stop at source — would take down the whole BoardShell render, not just a
+    // frame. `normalizeIndices` lets Excalidraw re-index recoverable keys; the try/catch degrades an
+    // unrecoverable throw to an empty initial scene so the canvas still mounts and the later
+    // observe→applyRemote path can repaint, with BoardErrorBoundary as the final backstop.
+    try {
+      return restore(raw, null, { normalizeIndices: true })
+    } catch {
+      return []
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [Excalidraw, collabSession, accessConfirmed])
 

--- a/packages/docs/src/board/__tests__/BoardShellRestoreDefense.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellRestoreDefense.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { BoardTerminal } from '../collab/index.ts'
+import type { WhiteboardSession } from '../collab/connect.ts'
+import { setWKApp } from '../../octoweb/index.ts'
+import { createMockWKApp } from '../../octoweb/mock.ts'
+
+// XIN-795 ④ FE depth defence. `BoardShell.initialElements` restores the initially-loaded / cold-reopen
+// scene DURING RENDER, outside the collab binding's guarded applyRemote path and outside the
+// BoardErrorBoundary (which only wraps the <Excalidraw> subtree). A structurally-invalid persisted
+// order key (e.g. the synthetic `r00000003` a since-fixed BE repair produced) makes Excalidraw's real
+// `restoreElements` THROW. Before the fix that throw propagated straight out of BoardShell and tore
+// down the whole host tree; the fix wraps the restore in try/catch and degrades to an empty initial
+// scene so the canvas still mounts (the later observe→applyRemote path can repaint).
+//
+// This Excalidraw stand-in reproduces that throw: restoreElements rejects any element whose `index`
+// fails the jitterbug structural rule, exactly as the real library does.
+function isJitterbugValid(index: unknown): boolean {
+  if (typeof index !== 'string' || !/^[0-9A-Za-z]+$/.test(index)) return false
+  const head = index.charAt(0)
+  let intLen = 0
+  if (head >= 'a' && head <= 'z') intLen = head.charCodeAt(0) - 97 + 2
+  else if (head >= 'A' && head <= 'Z') intLen = 90 - head.charCodeAt(0) + 2
+  return intLen > 0 && intLen <= index.length
+}
+
+vi.mock('@excalidraw/excalidraw', async () => {
+  const { useEffect } = await import('react')
+  const api = { updateScene: () => {}, getAppState: () => ({}), updateLibrary: async () => [] }
+  const Excalidraw = ({
+    children,
+    excalidrawAPI,
+  }: {
+    children?: ReactNode
+    excalidrawAPI?: (api: unknown) => void
+  }) => {
+    useEffect(() => {
+      excalidrawAPI?.(api)
+    }, [excalidrawAPI])
+    return <div data-testid="excalidraw-canvas">{children}</div>
+  }
+  const MainMenu = (() => null) as unknown as { DefaultItems: Record<string, unknown> }
+  MainMenu.DefaultItems = {}
+  return {
+    Excalidraw,
+    MainMenu,
+    restoreElements: (els: readonly unknown[] | null | undefined) => {
+      const arr = els ? [...els] : []
+      for (const el of arr) {
+        // Mirror the real jitterbug throw on a structurally-invalid `index`.
+        if (el && typeof el === 'object' && !isJitterbugValid((el as { index?: unknown }).index)) {
+          throw new Error('invalid order key: ' + String((el as { index?: unknown }).index))
+        }
+      }
+      return arr
+    },
+    reconcileElements: (local: readonly unknown[]) => [...local],
+    loadLibraryFromBlob: async () => [],
+    serializeLibraryAsJSON: () => '[]',
+  }
+})
+vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
+vi.mock('../../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+
+// Imported AFTER the mocks so the mocked modules are in place.
+import { BoardShell } from '../BoardShell.tsx'
+
+function makeAwareness() {
+  return {
+    clientID: 1,
+    getStates: () => new Map(),
+    setLocalStateField: () => {},
+    on: () => {},
+    off: () => {},
+  }
+}
+
+/** Admin session whose Y.Doc snapshot carries an element with a structurally-invalid order key. */
+function makeSessionWithInvalidIndex(): WhiteboardSession {
+  const binding = {
+    setApi: () => {},
+    setRenderAdapter: () => {},
+    setFileSync: () => {},
+    handleLocalChange: () => {},
+    // Cold-reopen seed for BoardShell.initialElements: a single invalid-index element.
+    snapshotElements: () => [{ id: 'bad', type: 'rectangle', index: 'r00000003' }] as unknown[],
+  }
+  return {
+    getRole: () => 'admin',
+    subscribeRole: () => () => {},
+    subscribeTerminal: (_cb: (t: BoardTerminal) => void) => () => {},
+    binding,
+    provider: { awareness: makeAwareness(), isSynced: true, on: () => {}, off: () => {} },
+  } as unknown as WhiteboardSession
+}
+
+let wk: ReturnType<typeof createMockWKApp>
+
+beforeEach(() => {
+  wk = createMockWKApp()
+  setWKApp(wk)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('BoardShell restore depth defence (XIN-795 ④)', () => {
+  it('degrades to an empty initial scene instead of crashing the shell when restore throws on an invalid key', async () => {
+    wk.apiClient.responder = (method: string, url: string) => {
+      if (method === 'get' && url === '/docs/board-1') {
+        return { data: { docId: 'board-1', title: 'Board', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(
+      <BoardShell
+        docId="board-1"
+        title="Board"
+        space="s1"
+        collabSession={makeSessionWithInvalidIndex()}
+        collab
+      />,
+    )
+
+    // The canvas mounts: BoardShell caught the restore throw and fed Excalidraw an empty scene rather
+    // than letting the throw unmount the host tree. Before the fix this render threw and no canvas
+    // appeared.
+    expect(await screen.findByTestId('excalidraw-canvas')).toBeTruthy()
+  })
+})

--- a/packages/whiteboard-schema/src/normalize.test.ts
+++ b/packages/whiteboard-schema/src/normalize.test.ts
@@ -1,0 +1,56 @@
+// Fractional-index (order key) validity — the FE half of the cross-repo contract (XIN-794/795).
+//
+// `isValidIndex` used to be a bare charset check (`/^[A-Za-z0-9]+$/`), so a structurally-invalid
+// synthetic key like `r00000003` — head 'r' declares a 19-char integer part, the key is 9 chars —
+// passed as valid, reached Excalidraw's `updateScene`, and crashed the canvas. These tests pin the
+// jitterbug structural rule (a boolean port of fractional-indexing's `validateOrderKey`) that both
+// the FE binding and the BE authoritative repair must agree on byte-for-byte.
+import { describe, it, expect } from 'vitest'
+import { isValidIndex, normalizeElement } from './normalize.ts'
+
+describe('isValidIndex — jitterbug structural rule (XIN-795 ②-FE)', () => {
+  it('rejects the synthetic r00000003 key that the old charset regex let through', () => {
+    // Regression pin: the old rule returned true here, which is exactly what crashed the board.
+    expect(isValidIndex('r00000003')).toBe(false)
+  })
+
+  it('rejects the whole `^r[0-9a-z]{8}$` family produced by the since-fixed BE repair', () => {
+    for (const key of ['r00000000', 'r0000000z', 'rzzzzzzzz', 'r12345678']) {
+      expect(isValidIndex(key)).toBe(false)
+    }
+  })
+
+  it('accepts the order keys Excalidraw / fractional-indexing actually generate', () => {
+    // generateNKeysBetween(null, null, n) => a0, a1, a2, ...; midpoints add a fraction (a0V);
+    // the negative-integer region uses upper-case heads (Zz).
+    for (const key of ['a0', 'a1', 'a2', 'a0V', 'Zz', 'a0G']) {
+      expect(isValidIndex(key)).toBe(true)
+    }
+  })
+
+  it('rejects non-string, empty, non-base62, sentinel, and short-integer heads', () => {
+    expect(isValidIndex(undefined)).toBe(false)
+    expect(isValidIndex(null)).toBe(false)
+    expect(isValidIndex(42)).toBe(false)
+    expect(isValidIndex('')).toBe(false)
+    expect(isValidIndex('a0!')).toBe(false) // non-base62 char
+    expect(isValidIndex('A00000000000000000000000000')).toBe(false) // SMALLEST_INTEGER sentinel
+    expect(isValidIndex('a')).toBe(false) // head 'a' needs a 2-char integer part, key is 1 char
+    expect(isValidIndex('a00')).toBe(false) // fraction may not end in the first digit ('0')
+  })
+})
+
+describe('normalizeElement strips an invalid index to a clean absent state', () => {
+  const base = { id: 'e1', type: 'rectangle', version: 3, versionNonce: 7 }
+
+  it('drops a structurally-invalid index (r00000003) so repair can refill a legal key', () => {
+    const out = normalizeElement({ ...base, index: 'r00000003' })
+    expect(out).not.toBeNull()
+    expect('index' in (out as Record<string, unknown>)).toBe(false)
+  })
+
+  it('keeps a structurally-valid index untouched', () => {
+    const out = normalizeElement({ ...base, index: 'a1' })
+    expect((out as Record<string, unknown>).index).toBe('a1')
+  })
+})

--- a/packages/whiteboard-schema/src/normalize.ts
+++ b/packages/whiteboard-schema/src/normalize.ts
@@ -20,8 +20,51 @@
 import { WB_ELEMENT_TYPES, FILE_BEARING_TYPES } from './constants.ts'
 import type { WhiteboardElement, NormalizeContext } from './types.ts'
 
-/** Fractional-index keys are non-empty base62 strings (Excalidraw `index`). */
-const INDEX_RE = /^[A-Za-z0-9]+$/
+/**
+ * Fractional-index (order key) validity — cross-repo contract (XIN-794/795).
+ *
+ * Excalidraw's `index` is a jitterbug / fractional-indexing order key, NOT just
+ * any base62 string. The old rule `/^[A-Za-z0-9]+$/` only checked the character
+ * set, so a synthetic key like `r00000003` (produced by a since-fixed BE repair)
+ * passed as valid, reached `updateScene`, and crashed the canvas — the head 'r'
+ * declares a 19-char integer part but the key is 9 chars, so the real library
+ * rejects it. The rules below replicate `fractional-indexing`'s `validateOrderKey`
+ * as a pure boolean (no throw, no runtime dependency), so the FE binding, the BE
+ * authoritative repair, and the Agent path all agree byte-for-byte on legality.
+ *
+ * A key is valid iff ALL hold:
+ *   1. non-empty and every char is in the base62 alphabet below;
+ *   2. it is not the reserved SMALLEST_INTEGER sentinel;
+ *   3. the head char is 'a'..'z' or 'A'..'Z' AND the integer-part length it
+ *      declares (2..27) fits inside the key;
+ *   4. the fractional part (everything after the integer part) does not end in
+ *      the first digit ('0').
+ */
+const BASE62_DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+const BASE62_RE = /^[0-9A-Za-z]+$/
+const SMALLEST_INTEGER = 'A00000000000000000000000000'
+
+/**
+ * Integer-part length encoded by an order key's head char (jitterbug):
+ * 'a'..'z' -> 2..27 and 'A'..'Z' -> 27..2. Any other head is illegal.
+ * Mirrors fractional-indexing `getIntegerLength`; returns 0 for an illegal head.
+ */
+function orderKeyIntegerLength(head: string): number {
+  if (head >= 'a' && head <= 'z') return head.charCodeAt(0) - 97 + 2
+  if (head >= 'A' && head <= 'Z') return 90 - head.charCodeAt(0) + 2
+  return 0
+}
+
+/** Structural validity of a fractional-index key (see contract above). */
+function isValidOrderKey(key: string): boolean {
+  if (key.length === 0 || !BASE62_RE.test(key)) return false
+  if (key === SMALLEST_INTEGER) return false
+  const intLen = orderKeyIntegerLength(key.charAt(0))
+  if (intLen === 0 || intLen > key.length) return false
+  const fraction = key.slice(intLen)
+  if (fraction.slice(-1) === BASE62_DIGITS[0]) return false
+  return true
+}
 
 /** Known numeric fields clamped to finite values; opacity additionally [0,100]. */
 const FINITE_FIELDS = ['x', 'y', 'width', 'height', 'angle', 'strokeWidth', 'fontSize'] as const
@@ -42,9 +85,9 @@ export function deterministicNonce(seed: string): number {
   return h & 0x7fffffff
 }
 
-/** True if `v` is a valid fractional-index key. */
+/** True if `v` is a structurally valid fractional-index (order) key. */
 export function isValidIndex(v: unknown): v is string {
-  return typeof v === 'string' && v.length > 0 && INDEX_RE.test(v)
+  return typeof v === 'string' && isValidOrderKey(v)
 }
 
 function coerceVersion(v: unknown): number {


### PR DESCRIPTION
## Summary

A whiteboard element's `index` is an Excalidraw jitterbug / fractional-indexing **order key**, not merely a base62 string. `isValidIndex` only validated the character set (`/^[A-Za-z0-9]+$/`), so a synthetic key like `r00000003` — head `r` declares a **19-char** integer part while the key is only **9 chars** — passed as valid, reached `updateScene`, and crashed the canvas.

This PR does the FE half of the fix (schema struct-check + restore depth defence). The backend main fix (stop producing the invalid keys at the source, in repair `fillIndexKey`, + migration) is tracked separately.

## Changes

**②-FE struct-check — `packages/whiteboard-schema/src/normalize.ts`**
- Replaces the charset regex with a pure boolean port of `fractional-indexing`'s `validateOrderKey` (no runtime dependency added; the package stays framework-free). `isValidIndex("r00000003") === false`, and `normalizeElement` strips an invalid `index` to a clean absent state (`normalize.ts` `isValidIndex` / the `delete out.index` line).

**④ FE depth defence — `packages/docs/src/board/BoardShell.tsx`**
- Both restore call sites now pass `{ normalizeIndices: true }` so Excalidraw re-indexes recoverable keys.
- The `initialData` restore runs **during render**, outside the collab binding's guarded `applyRemote` and outside `BoardErrorBoundary` (which only wraps the `<Excalidraw>` subtree). It is now wrapped in try/catch: an unrecoverable key degrades to an empty initial scene so the canvas still mounts (the later observe→applyRemote path repaints), instead of a render throw tearing down the whole shell. The `applyRemote` path already caught restore throws and keeps the last good scene.

This is **depth defence, not a root fix**: `normalizeIndices` / `syncInvalidIndices` / `generateNKeysBetween` themselves throw on a structurally-invalid *existing* key, so the FE cannot repair such a key — it can only avoid crashing. The root fix is the backend ceasing to persist invalid keys.

## Adopted legality rule (for cross-repo alignment)

The backend single-issue had not written back its rule when this was implemented, so this PR **defines** the rule; the backend `normalize.ts` must match it byte-for-byte. A key is valid iff **all** hold:

1. non-empty and every char is in the base62 alphabet `0-9A-Za-z`;
2. it is not the reserved `SMALLEST_INTEGER` sentinel (`A00000000000000000000000000`);
3. the head char is `a`..`z` or `A`..`Z`, and the integer-part length it declares (`a`/`Z` → 2 … `z`/`A` → 27) fits inside the key;
4. the fractional part (everything after the integer part) does not end in the first digit (`0`).

This is exactly `fractional-indexing`'s `validateOrderKey` expressed as a non-throwing boolean.

## Testing (red → green)

- `packages/whiteboard-schema/src/normalize.test.ts` — new. On the old code 4 assertions fail (incl. `isValidIndex("r00000003")` and the `normalizeElement` strip); green after the fix.
- `packages/docs/src/board/__tests__/BoardShellRestoreDefense.test.tsx` — new. Seeds a cold-reopen scene carrying `r00000003`, with a restore stub that throws on it (as the real library does); the canvas fails to mount on the old code and mounts (degraded) after the fix.
- `pnpm vitest run` — whiteboard-schema 12/12; `packages/docs` `src/board` 176/176.
- `tsc` — no new errors in the touched files (the schema package typechecks clean).

## Notes

Draft PR — held open for review + deploy + QA; do not merge or mark ready yet.
