### PR TITLE
fix(loop): auto-close dropdown menus after making a selection

### DIFF
--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -169,7 +169,7 @@ export default function LoopPage() {
   return (
     <div className="loop-sidebar">
       <div className="loop-sidebar__ws">
-        <Dropdown render={wsMenu} trigger="click" position="bottomLeft">
+        <Dropdown render={wsMenu} trigger="click" position="bottomLeft" clickToHide>
           <button className="loop-sidebar__ws-btn">
             <Avatar size="extra-extra-small" color="blue" shape="square">{(current?.name ?? "L").slice(0, 1)}</Avatar>
             <span className="loop-sidebar__ws-name">{current?.name ?? (loaded && !hasWs ? t("loop.workspace.none") : t("loop.menu.title"))}</span>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -247,6 +247,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       <Dropdown
         position="leftTop"
         trigger="hover"
+        clickToHide
         render={
           <Dropdown.Menu>
             {ISSUE_STATUS_ORDER.map((s) => (
@@ -257,11 +258,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </Dropdown.Menu>
         }
       >
-        <Dropdown.Item>{t("loop.menu.changeStatus")}</Dropdown.Item>
+        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeStatus")}</Dropdown.Item>
       </Dropdown>
       <Dropdown
         position="leftTop"
         trigger="hover"
+        clickToHide
         render={
           <Dropdown.Menu>
             {PRIORITY_ORDER.map((p) => (
@@ -272,11 +274,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </Dropdown.Menu>
         }
       >
-        <Dropdown.Item>{t("loop.menu.changePriority")}</Dropdown.Item>
+        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changePriority")}</Dropdown.Item>
       </Dropdown>
       <Dropdown
         position="leftTop"
         trigger="hover"
+        clickToHide
         render={
           <Dropdown.Menu>
             <Dropdown.Item icon={<CircleSlash size={13} />} onClick={() => patch({ assignee_id: null, assignee_type: null })}>
@@ -300,7 +303,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </Dropdown.Menu>
         }
       >
-        <Dropdown.Item>{t("loop.menu.changeAssignee")}</Dropdown.Item>
+        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
       <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={handleDeleteIssue}>
@@ -409,7 +412,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           {issue.identifier}
         </Text>
         <div style={{ flex: 1 }} />
-        <Dropdown trigger="click" position="bottomRight" render={renderMoreMenu()}>
+        <Dropdown trigger="click" position="bottomRight" render={renderMoreMenu()} clickToHide>
           <Button icon={<MoreHorizontal size={18} />} theme="borderless" aria-label="more" />
         </Dropdown>
       </div>

--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -66,7 +66,7 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
   );
 
   return (
-    <Dropdown render={menu} trigger="click" position="bottomLeft">
+    <Dropdown render={menu} trigger="click" position="bottomLeft" clickToHide>
       <span className="loop-assignee-trigger" style={{ fontSize: size === "small" ? 12 : 13 }}>
         {current || valueName ? (
           <>


### PR DESCRIPTION
## Problem

In the Loop (dmloop) module, several dropdown menus stayed open after the user
made a selection, instead of dismissing:

- **Workspace switcher** (sidebar): picking a workspace left the menu open (reported with screenshot).
- **Inline assignee picker** (list/board): picking an assignee left the menu open.
- **Issue `···` menu** (detail page) and its status/priority/assignee submenus.

Root cause: Semi UI's `Dropdown` does not auto-dismiss when a `Dropdown.Item`
is clicked unless `clickToHide` is set.

## Fix

Add `clickToHide` to all six selection dropdowns.

Semi binds `clickToHide`'s close handler on the popup container, so a click
anywhere inside it (via React-tree bubbling) dismisses the menu. The `···`
menu's three submenu triggers (*change status / priority / assignee*) are
plain hover-only labels with **no** `onClick`; without guarding them, a click
on such a label bubbled to the outer container and closed the whole menu
before the submenu could open. We `stopPropagation` on those three triggers so
a click on the label is a no-op (hover still opens the submenu), while leaf
selections still dismiss the entire menu.

## Blast radius (cross-module)

- Change is purely additive: one optional boolean prop on existing Semi
  `Dropdown` call sites + `stopPropagation` on three no-op label items. No
  exported signature, Props type, or shared type changed.
- `@octo/loop` is a leaf package. Grep for external importers of `@octo/loop`
  finds only `apps/web/src/Layout/index.tsx` importing an unrelated CLI-auth
  path constant/util — none of the three edited components are referenced
  outside dmloop. No out-of-module consumer is affected.

## Verification (real browser, dev env)

| Case | Before | After |
|---|---|---|
| Workspace switcher: pick a workspace | menu stays open | menu closes ✅ |
| `···` menu: **click** a submenu trigger label | whole menu closes, submenu unreachable | menu stays open, submenu opens ✅ |
| `···` menu: pick a leaf option (e.g. priority) | menu + submenu stay open | whole menu closes ✅ |

All reproduced and re-verified in the running dev environment against a live
workspace (MV2 E2E). An adversarial correctness review caught the submenu
trigger-label regression (clicking the label closing the whole menu), which
was reproduced in-browser and then fixed and re-verified as above.

Scope note: no linked issue (reported directly); maintainer may need to set a
Sprint for check-sprint.
