### PR TITLE
fix(board): render bot-written whiteboards whose fractional indices Excalidraw can't parse

### DIFF
--- a/packages/docs/src/board/BoardScenePreview.tsx
+++ b/packages/docs/src/board/BoardScenePreview.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType, type ReactElement, type ReactNode } from 'react'
 import { i18n, t } from '../octoweb/index.ts'
 import { BoardMainMenu, type ExcalidrawMainMenu } from './BoardMainMenu.tsx'
-import { normalizeFileRef, type BinaryFileData, type FileFetchRef } from './collab/index.ts'
+import { normalizeFileRef, sanitizeFractionalIndices, type BinaryFileData, type FileFetchRef } from './collab/index.ts'
 import { fetchBoardFileBinaries } from './boardFiles.ts'
 import type { BoardVersionScene } from './boardVersions.ts'
 
@@ -113,10 +113,19 @@ export function BoardScenePreview({ scene, dark, docId }: { scene: BoardVersionS
 
   // Rehydrate raw persisted/historical elements into renderable Excalidraw shapes (drops unknown
   // element types, fills defaults) — the same restore step the live board applies to initialData.
-  const elements = useMemo(() => {
+  //
+  // Strip any fractional-index key Excalidraw's grammar cannot parse BEFORE restore (XIN-791): a
+  // historical scene is the same backend-authored Y.Doc state the live board renders, carrying the
+  // zero-padded `r00000000` scheme, and `restoreElements` runs the same `syncInvalidIndices` that
+  // throws `invalid order key` on an unparseable key — which here (unlike the live board) is a
+  // render-time throw the BoardVersionPanel only catches with an error boundary. Sanitizing here
+  // closes the third untrusted-restore path (BoardShell cold-open + repairForRender were the other
+  // two); it is a no-op for valid-keyed human scenes.
+  const elements = useMemo<unknown[]>(() => {
     const restore = restoreElementsRef.current
-    if (restore) return restore(scene.elements, null)
-    return scene.elements
+    const safe = sanitizeFractionalIndices(scene.elements as Parameters<typeof sanitizeFractionalIndices>[0])
+    if (restore) return restore(safe, null)
+    return [...safe]
     // Recompute once the helper resolves (Excalidraw becoming non-null flips this).
   }, [scene, Excalidraw])
 

--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -30,7 +30,7 @@ import { installExcalidrawDebrand } from './excalidrawDebrand.ts'
 import { installLibraryControlButtons } from './libraryControlButtons.ts'
 import type { WhiteboardSession, BoardTerminal } from './collab/index.ts'
 import type { ExcalidrawElement, BinaryFileData, FileFetchRef } from './collab/index.ts'
-import { makeGenerateIdForFile, dataURLToBlob } from './collab/index.ts'
+import { makeGenerateIdForFile, dataURLToBlob, sanitizeFractionalIndices } from './collab/index.ts'
 import { presignUpload, uploadBinary } from '../attachments/api.ts'
 import { fetchBoardFileBinaries } from './boardFiles.ts'
 import {
@@ -1018,14 +1018,20 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     }
     const restore = restoreElementsRef.current
     if (!restore) return [...raw]
-    // XIN-795 ④ depth defence: this restore runs during render (not inside the collab binding's
-    // guarded applyRemote), so a throw on a structurally-invalid persisted key — one the BE repair
-    // (XIN-794) failed to stop at source — would take down the whole BoardShell render, not just a
-    // frame. `normalizeIndices` lets Excalidraw re-index recoverable keys; the try/catch degrades an
+    // XIN-791 render defence: strip any fractional-index key Excalidraw cannot parse before restore.
+    // This memo seeds `initialData` straight from raw Y.Doc elements (bypassing repairForRender), so a
+    // backend `r00000000`-style key would otherwise reach restoreElements and blank a cold-opened
+    // bot-written board. sanitizeFractionalIndices is a no-op for valid-keyed (human) scenes.
+    // XIN-795 ④ depth defence: this restore runs during render (outside the collab binding's guarded
+    // applyRemote and outside BoardErrorBoundary's subtree), so a throw on a structurally-invalid
+    // persisted key that even normalizeIndices cannot repair would take down the whole BoardShell
+    // render. `normalizeIndices` lets Excalidraw re-index recoverable keys; the try/catch degrades an
     // unrecoverable throw to an empty initial scene so the canvas still mounts and the later
     // observe→applyRemote path can repaint, with BoardErrorBoundary as the final backstop.
     try {
-      return restore(raw, null, { normalizeIndices: true })
+      return restore(sanitizeFractionalIndices(raw as readonly ExcalidrawElement[]), null, {
+        normalizeIndices: true,
+      })
     } catch {
       return []
     }

--- a/packages/docs/src/board/__tests__/BoardScenePreview.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardScenePreview.test.tsx
@@ -26,10 +26,32 @@ vi.mock('@excalidraw/excalidraw', () => {
   }
   const MainMenu = (() => null) as unknown as { DefaultItems: Record<string, unknown> }
   MainMenu.DefaultItems = {}
+  // Faithful to `fractional-indexing`'s head-length rule (`a`→2 … `z`→27): a key whose head claims
+  // more integer digits than the string carries is unparseable — the backend's zero-padded
+  // `r00000000` scheme (head `r`→19 digits, only 9 follow).
+  const parseableIndex = (key: unknown): boolean => {
+    if (typeof key !== 'string' || key.length === 0) return true
+    const head = key[0]
+    let intLen = -1
+    if (head >= 'a' && head <= 'z') intLen = head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
+    else if (head >= 'A' && head <= 'Z') intLen = 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
+    return intLen >= 0 && intLen <= key.length
+  }
   return {
     Excalidraw,
     MainMenu,
-    restoreElements: (els: readonly unknown[] | null | undefined) => (els ? [...els] : []),
+    // Mirror the real `restoreElements` → `syncInvalidIndices`: regenerating a key next to an
+    // unparseable one throws `invalid order key` (octo-docs-backend #51), the throw that blanks
+    // bot-written boards. The preview must sanitize before restore so this never fires.
+    restoreElements: (els: readonly unknown[] | null | undefined) => {
+      const out = els ? [...els] : []
+      for (const el of out) {
+        if (el && typeof el === 'object' && !parseableIndex((el as { index?: unknown }).index)) {
+          throw new Error('invalid order key')
+        }
+      }
+      return out
+    },
   }
 })
 vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
@@ -49,6 +71,7 @@ vi.mock('../../attachments/api.ts', async (importOriginal) => {
 })
 
 import { BoardScenePreview } from '../BoardScenePreview.tsx'
+import { isExcalidrawFractionalIndex } from '../collab/index.ts'
 
 // A one-pixel PNG so the fetched Blob decodes into a real data URL through jsdom's FileReader.
 const PNG_BYTES = Uint8Array.from(atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='), (c) => c.charCodeAt(0))
@@ -107,5 +130,54 @@ describe('BoardScenePreview image hydration', () => {
     await waitFor(() => expect(screen.getByTestId('excalidraw-canvas')).toBeTruthy())
     const files = lastInitialData?.files as Record<string, { dataURL?: string }> | undefined
     expect(files?.file_a?.dataURL).toBeUndefined()
+  })
+})
+
+// XIN-811 Blocking #1: the version-history preview seeds a real <Excalidraw> from the SAME
+// restoreElements step the live board uses, but before this fix it skipped sanitizeFractionalIndices
+// — so a bot-written scene (backend `r00000000` scheme) hit `syncInvalidIndices`, threw `invalid
+// order key`, and blanked the preview (BoardVersionPanel only catches that with an error boundary).
+// This was the third untrusted-restore path the original PR missed. The mocked restoreElements
+// above throws on an unparseable key exactly as the real library does, so without the sanitize
+// these renders throw and never mount.
+describe('BoardScenePreview bot-board fractional-index sanitize (Blocking #1)', () => {
+  // A historical bot scene whose z-order keys use the unparseable backend scheme, supplied
+  // bottom→top; Y.Doc/serialized order is arbitrary, so ids are deliberately out of key order.
+  function botScene(): BoardVersionScene {
+    return {
+      elements: [
+        { id: 'mid', type: 'rectangle', index: 'r00000001' },
+        { id: 'top', type: 'rectangle', index: 'r00000002' },
+        { id: 'bg', type: 'rectangle', index: 'r00000000' },
+      ],
+      files: {},
+    }
+  }
+
+  it('sanitizes bot fractional indices before restore so the preview mounts instead of throwing', async () => {
+    render(<BoardScenePreview scene={botScene()} docId="bd_1" />)
+    // Without the sanitize the mocked restore throws `invalid order key` and the canvas never mounts.
+    await waitFor(() => expect(screen.getByTestId('excalidraw-canvas')).toBeTruthy())
+    const els = (lastInitialData?.elements ?? []) as { id: string; index?: unknown }[]
+    // Nothing Excalidraw's grammar would reject reaches the canvas.
+    for (const el of els) expect(el.index == null || isExcalidrawFractionalIndex(el.index)).toBe(true)
+    // Authored z-order is recovered from the arbitrary source order (homogeneous bot scene).
+    expect(els.map((e) => e.id)).toEqual(['bg', 'mid', 'top'])
+  })
+
+  it('does not throw on a mixed scene and keeps author order (does not sink valid keys)', async () => {
+    // Bot background (unparseable) UNDER a human shape (valid `a5`) — a string sort would invert it.
+    const scene: BoardVersionScene = {
+      elements: [
+        { id: 'bg', type: 'rectangle', index: 'r00000000' },
+        { id: 'human', type: 'rectangle', index: 'a5' },
+      ],
+      files: {},
+    }
+    render(<BoardScenePreview scene={scene} docId="bd_1" />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-canvas')).toBeTruthy())
+    const els = (lastInitialData?.elements ?? []) as { id: string; index?: unknown }[]
+    expect(els.map((e) => e.id)).toEqual(['bg', 'human'])
+    expect(els.find((e) => e.id === 'human')!.index).toBe('a5')
   })
 })

--- a/packages/docs/src/board/collab/__tests__/fractionalIndex.test.ts
+++ b/packages/docs/src/board/collab/__tests__/fractionalIndex.test.ts
@@ -87,4 +87,49 @@ describe('sanitizeFractionalIndices', () => {
       expect(el.index == null || isExcalidrawFractionalIndex(el.index)).toBe(true)
     }
   })
+
+  // Mixed scenes: valid Excalidraw keys coexisting with the backend's unparseable `r00000000`
+  // scheme. A global string sort compares across the two incomparable key spaces (`'a5' < 'r0…'`),
+  // dragging every valid-keyed element beneath the bot scheme and inverting the author's stacking.
+  // syncInvalidIndices honours ARRAY ORDER and regenerates only the stripped keys in place, so a
+  // mixed scene must be handed through in its original order — sorted output would corrupt z-order.
+  describe('mixed scene (valid + backend keys) — z-order fidelity', () => {
+    it('keeps a bottom bot element below a top human element (does not sort the valid key first)', () => {
+      // Authored bottom→top: a bot-written background (unparseable `r00000000`) UNDER a human shape
+      // (valid `a5`). A string sort would place `a5` before `r00000000` and sink the human shape.
+      const els = [makeEl('bg', { index: 'r00000000' }), makeEl('human', { index: 'a5' })]
+      const out = sanitizeFractionalIndices(els)
+      expect(out.map((e) => e.id)).toEqual(['bg', 'human'])
+      // Bot key stripped so Excalidraw regenerates it in array position; valid key left intact.
+      expect('index' in out.find((e) => e.id === 'bg')!).toBe(false)
+      expect(out.find((e) => e.id === 'human')!.index).toBe('a5')
+    })
+
+    it('preserves valid-keyed relative order and re-slots stripped bot elements at their anchors', () => {
+      // human a0, two bot elements, human a1 — author order must survive verbatim (no cross-scheme
+      // sort would move the bot pair below both humans, and no intra-scheme sort should reorder
+      // elements the author already placed).
+      const els = [
+        makeEl('h0', { index: 'a0' }),
+        makeEl('bot1', { index: 'r00000001' }),
+        makeEl('bot0', { index: 'r00000000' }),
+        makeEl('h1', { index: 'a1' }),
+      ]
+      const out = sanitizeFractionalIndices(els)
+      expect(out.map((e) => e.id)).toEqual(['h0', 'bot1', 'bot0', 'h1'])
+      expect(out.find((e) => e.id === 'h0')!.index).toBe('a0')
+      expect(out.find((e) => e.id === 'h1')!.index).toBe('a1')
+      for (const id of ['bot0', 'bot1']) expect('index' in out.find((e) => e.id === id)!).toBe(false)
+    })
+
+    it('leaves no unparseable key in a mixed scene', () => {
+      const els = [
+        makeEl('bg', { index: 'r00000000' }),
+        makeEl('mid', { index: 'a2' }),
+        makeEl('fg', { index: 'r00000005' }),
+      ]
+      const out = sanitizeFractionalIndices(els)
+      for (const el of out) expect(el.index == null || isExcalidrawFractionalIndex(el.index)).toBe(true)
+    })
+  })
 })

--- a/packages/docs/src/board/collab/__tests__/fractionalIndex.test.ts
+++ b/packages/docs/src/board/collab/__tests__/fractionalIndex.test.ts
@@ -1,0 +1,90 @@
+// Fractional-index render-defence (XIN-791 / octo-docs-backend #51).
+//
+// Excalidraw's bundled `fractional-indexing` throws `invalid order key` on a key its grammar
+// cannot parse, and `restoreElements` / `reconcileElements` call it whenever an index must be
+// regenerated — so a backend-authored key that passes the shared loose `/^[A-Za-z0-9]+$/` charset
+// but not Excalidraw's grammar (the zero-padded `r00000000` scheme) blanks the canvas. These cases
+// lock in the validator's fidelity to that grammar and the sanitizer's strip-and-preserve-order
+// behaviour, including the zero-copy fast path that leaves valid (human-drawn) scenes untouched.
+import { describe, it, expect } from 'vitest'
+import { isExcalidrawFractionalIndex, sanitizeFractionalIndices } from '../fractionalIndex.ts'
+import { makeEl } from './helpers.ts'
+
+describe('isExcalidrawFractionalIndex', () => {
+  it('accepts real Excalidraw keys', () => {
+    for (const k of ['a0', 'a1', 'a2', 'a0V', 'Zz', 'b00', 'a0V8', 'Zzol']) {
+      expect(isExcalidrawFractionalIndex(k)).toBe(true)
+    }
+  })
+
+  it('rejects the backend zero-padded scheme (root cause of #51)', () => {
+    // head `r` claims a 19-char integer part; only 9 chars follow → unparseable by the library.
+    for (const k of ['r00000000', 'r00000001', 'r00000003', 'r0000000z']) {
+      expect(isExcalidrawFractionalIndex(k)).toBe(false)
+    }
+  })
+
+  it('rejects malformed / non-string / empty keys', () => {
+    for (const k of ['', 'r', '0', '00', 'a', 'a00', '@x', 'A'.repeat(1) + '0'.repeat(26)]) {
+      expect(isExcalidrawFractionalIndex(k)).toBe(false)
+    }
+    expect(isExcalidrawFractionalIndex(undefined)).toBe(false)
+    expect(isExcalidrawFractionalIndex(null)).toBe(false)
+    expect(isExcalidrawFractionalIndex(123 as unknown)).toBe(false)
+  })
+
+  it('rejects a fractional part that ends in the smallest digit', () => {
+    // Mirrors the library's `validateOrderKey` trailing-`0` rule.
+    expect(isExcalidrawFractionalIndex('a0V0')).toBe(false)
+    expect(isExcalidrawFractionalIndex('a0V1')).toBe(true)
+  })
+})
+
+describe('sanitizeFractionalIndices', () => {
+  it('returns the SAME array reference when every key is valid (fast path, no regression)', () => {
+    const els = [makeEl('a', { index: 'a0' }), makeEl('b', { index: 'a1' })]
+    expect(sanitizeFractionalIndices(els)).toBe(els)
+  })
+
+  it('treats an absent index as valid (fast path)', () => {
+    const els = [makeEl('a', { index: undefined }), makeEl('b', { index: 'a1' })]
+    expect(sanitizeFractionalIndices(els)).toBe(els)
+  })
+
+  it('drops only the invalid keys and leaves other fields (and valid keys) intact', () => {
+    const els = [
+      makeEl('rect', { index: 'r00000000', width: 220, height: 100 }),
+      makeEl('local', { index: 'a5' }),
+    ]
+    const out = sanitizeFractionalIndices(els)
+    const rect = out.find((e) => e.id === 'rect')!
+    const local = out.find((e) => e.id === 'local')!
+    expect('index' in rect).toBe(false) // stripped → Excalidraw will regenerate a valid key
+    expect(rect.width).toBe(220) // untouched
+    expect(rect.height).toBe(100)
+    expect(local.index).toBe('a5') // valid key preserved
+  })
+
+  it('preserves the authored z-order by stable-sorting on the original key strings', () => {
+    // Deliberately supply the elements out of index order (Y.Map insertion order is arbitrary).
+    const els = [
+      makeEl('third', { index: 'r00000003' }),
+      makeEl('first', { index: 'r00000000' }),
+      makeEl('second', { index: 'r00000001' }),
+    ]
+    const out = sanitizeFractionalIndices(els)
+    expect(out.map((e) => e.id)).toEqual(['first', 'second', 'third'])
+  })
+
+  it('produces a scene with no key Excalidraw would reject', () => {
+    const els = [
+      makeEl('rect', { index: 'r00000000' }),
+      makeEl('ellipse', { index: 'r00000001' }),
+      makeEl('text', { index: 'r00000003', type: 'text' }),
+    ]
+    const out = sanitizeFractionalIndices(els)
+    for (const el of out) {
+      expect(el.index == null || isExcalidrawFractionalIndex(el.index)).toBe(true)
+    }
+  })
+})

--- a/packages/docs/src/board/collab/__tests__/repair.test.ts
+++ b/packages/docs/src/board/collab/__tests__/repair.test.ts
@@ -112,4 +112,21 @@ describe('repairForRender (shared normalizeElement)', () => {
     expect((out[0] as Record<string, unknown>).future).toEqual({ k: 1 })
     expect(out[0]).not.toBe(el)
   })
+
+  it('XIN-791: strips a backend index key Excalidraw cannot parse, keeping the element', () => {
+    // The backend fills a missing key with `r00000000` (zero-padded), which passes the shared
+    // loose charset but is not a valid Excalidraw fractional index; left in place it makes
+    // restore/reconcile throw and blank the canvas. Pass 3 drops the key (element survives) so
+    // Excalidraw's syncInvalidIndices regenerates a valid one.
+    const out = repairForRender([makeEl('rect', { index: 'r00000000', width: 220, height: 100 })])
+    expect(out.map((e) => e.id)).toEqual(['rect']) // element kept
+    expect('index' in (out[0] as Record<string, unknown>)).toBe(false) // unparseable key dropped
+    expect((out[0] as Record<string, unknown>).width).toBe(220) // geometry intact
+  })
+
+  it('XIN-791: leaves a valid Excalidraw index key untouched', () => {
+    const out = repairForRender([makeEl('a', { index: 'a0' }), makeEl('b', { index: 'a1' })])
+    expect((out[0] as Record<string, unknown>).index).toBe('a0')
+    expect((out[1] as Record<string, unknown>).index).toBe('a1')
+  })
 })

--- a/packages/docs/src/board/collab/fractionalIndex.ts
+++ b/packages/docs/src/board/collab/fractionalIndex.ts
@@ -7,10 +7,12 @@
 // `syncInvalidIndices` → `generateNKeysBetween`, which passes neighbouring keys straight to the
 // library's `validateOrderKey`; a key it cannot parse makes the WHOLE apply throw.
 //
-// The shared `@octo/whiteboard-schema` `isValidIndex` only checks the loose `/^[A-Za-z0-9]+$/`
-// charset (deliberately — it is the FE/BE contract and the backend authoritative repair writes
-// under it). The backend fills a missing key with a zero-padded scheme (`r00000000`, see
-// octo-docs-backend `whiteboard/repair.ts`) that passes that loose check but is NOT a valid
+// Whether a key is a parseable Excalidraw order key is decided by the SINGLE shared validator
+// `isValidIndex` in `@octo/whiteboard-schema` (a non-throwing port of `fractional-indexing`'s
+// `validateOrderKey`, hardened in XIN-794/795). This module reuses that one definition rather than
+// keeping a second copy, so FE render defence, FE binding normalize and BE authoritative repair
+// all agree byte-for-byte on legality. The backend fills a missing key with a zero-padded scheme
+// (`r00000000`, see octo-docs-backend `whiteboard/repair.ts`) that is NOT a valid
 // Excalidraw key: head `r` claims a 19-digit integer part while only 9 chars follow. Such a key
 // renders fine as long as the scene never needs an index REGENERATED (all keys already ordered),
 // but the moment one does — a local element inserted between two remote ones, a non-monotonic /
@@ -32,41 +34,16 @@
 // so existing real-time collaboration / reconcile behaviour does not change.
 
 import type { ExcalidrawElement } from './types.ts'
-
-const BASE_62_DIGITS = new Set(
-  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split(''),
-)
-
-/**
- * Integer-part length a fractional-index head char encodes, or -1 for a non-head char. Mirrors
- * `fractional-indexing`'s `getIntegerLength`: `a`→2 … `z`→27 (positive), `Z`→2 … `A`→27 (negative).
- */
-function integerLengthFromHead(head: string): number {
-  if (head >= 'a' && head <= 'z') return head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
-  if (head >= 'A' && head <= 'Z') return 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
-  return -1
-}
+import { isValidIndex } from './schema.ts'
 
 /**
  * True when `key` is a fractional-index string Excalidraw's `fractional-indexing` can parse —
- * i.e. one `generateKeyBetween`/`validateOrderKey` will accept as a neighbour bound. Faithful to
- * that library's `validateOrderKey` + `getIntegerPart`, with the extra guarantee that every digit
- * is base-62 (a non-base-62 fractional char parses in `validateOrderKey` but breaks the base-62
- * arithmetic in `generateNKeysBetween`, so treating it as invalid here is the safe, stricter call).
+ * i.e. one `generateKeyBetween` / `validateOrderKey` will accept as a neighbour bound. Delegates to
+ * the shared `@octo/whiteboard-schema` `isValidIndex` so this render-defence pass and the FE/BE
+ * schema layer share ONE legality definition and can never drift apart.
  */
 export function isExcalidrawFractionalIndex(key: unknown): key is string {
-  if (typeof key !== 'string' || key.length === 0) return false
-  // The one explicitly-forbidden key in the library (smallest-integer sentinel).
-  if (key === 'A' + '0'.repeat(26)) return false
-  const intLen = integerLengthFromHead(key[0])
-  if (intLen < 0 || intLen > key.length) return false
-  for (let i = 1; i < key.length; i++) {
-    if (!BASE_62_DIGITS.has(key[i])) return false
-  }
-  // A fractional part is never allowed to end in the smallest digit (`0`).
-  const frac = key.slice(intLen)
-  if (frac.length > 0 && frac[frac.length - 1] === '0') return false
-  return true
+  return isValidIndex(key)
 }
 
 /**

--- a/packages/docs/src/board/collab/fractionalIndex.ts
+++ b/packages/docs/src/board/collab/fractionalIndex.ts
@@ -1,0 +1,110 @@
+// Fractional-index render-defence (FE local, render-only).
+//
+// Excalidraw expresses z-order with a fractional-index key (`element.index`) whose grammar is
+// defined by the `fractional-indexing` library it bundles: a head char (`a`–`z` / `A`–`Z`) that
+// encodes the integer part's LENGTH, that many base-62 integer digits, then an optional base-62
+// fractional part whose last digit is never `0`. `restoreElements` / `reconcileElements` call
+// `syncInvalidIndices` → `generateNKeysBetween`, which passes neighbouring keys straight to the
+// library's `validateOrderKey`; a key it cannot parse makes the WHOLE apply throw.
+//
+// The shared `@octo/whiteboard-schema` `isValidIndex` only checks the loose `/^[A-Za-z0-9]+$/`
+// charset (deliberately — it is the FE/BE contract and the backend authoritative repair writes
+// under it). The backend fills a missing key with a zero-padded scheme (`r00000000`, see
+// octo-docs-backend `whiteboard/repair.ts`) that passes that loose check but is NOT a valid
+// Excalidraw key: head `r` claims a 19-digit integer part while only 9 chars follow. Such a key
+// renders fine as long as the scene never needs an index REGENERATED (all keys already ordered),
+// but the moment one does — a local element inserted between two remote ones, a non-monotonic /
+// rolled-over backend batch, a duplicate — `generateNKeysBetween` throws `invalid order key`,
+// `applyRemote` swallows it (P1-2 batch guard), and the canvas paints EMPTY. That is the
+// bot-written-board blank-render failure (octo-docs-backend #51 / XIN-791).
+//
+// This pass detects keys Excalidraw's grammar rejects and DROPS them (render-only, never written
+// back to the Y.Doc — the backend stays the authoritative index writer, XIN-16 §4), letting
+// Excalidraw's own `syncInvalidIndices` assign fresh, valid keys. Order is preserved by
+// stable-sorting on the original key strings first — the same string comparison Excalidraw's
+// `orderByFractionalIndex` uses and the ordering the backend's zero-padded scheme intends — so a
+// bot scene keeps its authored z-order. Scenes whose keys are already all valid (every
+// human-drawn board) take a zero-copy fast path and are handed through untouched, so existing
+// real-time collaboration / reconcile behaviour does not change.
+
+import type { ExcalidrawElement } from './types.ts'
+
+const BASE_62_DIGITS = new Set(
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split(''),
+)
+
+/**
+ * Integer-part length a fractional-index head char encodes, or -1 for a non-head char. Mirrors
+ * `fractional-indexing`'s `getIntegerLength`: `a`→2 … `z`→27 (positive), `Z`→2 … `A`→27 (negative).
+ */
+function integerLengthFromHead(head: string): number {
+  if (head >= 'a' && head <= 'z') return head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
+  if (head >= 'A' && head <= 'Z') return 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
+  return -1
+}
+
+/**
+ * True when `key` is a fractional-index string Excalidraw's `fractional-indexing` can parse —
+ * i.e. one `generateKeyBetween`/`validateOrderKey` will accept as a neighbour bound. Faithful to
+ * that library's `validateOrderKey` + `getIntegerPart`, with the extra guarantee that every digit
+ * is base-62 (a non-base-62 fractional char parses in `validateOrderKey` but breaks the base-62
+ * arithmetic in `generateNKeysBetween`, so treating it as invalid here is the safe, stricter call).
+ */
+export function isExcalidrawFractionalIndex(key: unknown): key is string {
+  if (typeof key !== 'string' || key.length === 0) return false
+  // The one explicitly-forbidden key in the library (smallest-integer sentinel).
+  if (key === 'A' + '0'.repeat(26)) return false
+  const intLen = integerLengthFromHead(key[0])
+  if (intLen < 0 || intLen > key.length) return false
+  for (let i = 1; i < key.length; i++) {
+    if (!BASE_62_DIGITS.has(key[i])) return false
+  }
+  // A fractional part is never allowed to end in the smallest digit (`0`).
+  const frac = key.slice(intLen)
+  if (frac.length > 0 && frac[frac.length - 1] === '0') return false
+  return true
+}
+
+/**
+ * Make a rebuilt scene safe for Excalidraw's restore/reconcile by dropping any `index` key its
+ * fractional-indexing grammar would reject. Render-only: the returned elements are never written
+ * back to the Y.Doc.
+ *
+ * Fast path: if every element already carries a valid key (or none), the input array is returned
+ * as-is — no reorder, no copy — so ordinary human-drawn boards are untouched. Otherwise a new,
+ * stable-sorted array is returned with the invalid keys stripped, so Excalidraw's
+ * `syncInvalidIndices` regenerates valid keys in the authored z-order instead of throwing.
+ */
+export function sanitizeFractionalIndices(
+  elements: readonly ExcalidrawElement[],
+): readonly ExcalidrawElement[] {
+  let anyInvalid = false
+  for (const el of elements) {
+    const idx = el.index
+    if (idx != null && !isExcalidrawFractionalIndex(idx)) {
+      anyInvalid = true
+      break
+    }
+  }
+  if (!anyInvalid) return elements
+
+  // Preserve authored order (elements with no key sort first, matching Excalidraw's own
+  // treatment of a missing index as ordering-first), keeping ties in original array order.
+  const positioned = elements.map((el, i) => ({ el, i }))
+  positioned.sort((a, b) => {
+    const ka = typeof a.el.index === 'string' ? a.el.index : ''
+    const kb = typeof b.el.index === 'string' ? b.el.index : ''
+    if (ka < kb) return -1
+    if (ka > kb) return 1
+    return a.i - b.i
+  })
+  return positioned.map(({ el }) => {
+    const idx = el.index
+    if (idx != null && !isExcalidrawFractionalIndex(idx)) {
+      // Drop only the offending key; every other field (unknown ones included) passes through.
+      const { index: _dropped, ...rest } = el
+      return rest as ExcalidrawElement
+    }
+    return el
+  })
+}

--- a/packages/docs/src/board/collab/fractionalIndex.ts
+++ b/packages/docs/src/board/collab/fractionalIndex.ts
@@ -20,12 +20,16 @@
 //
 // This pass detects keys Excalidraw's grammar rejects and DROPS them (render-only, never written
 // back to the Y.Doc — the backend stays the authoritative index writer, XIN-16 §4), letting
-// Excalidraw's own `syncInvalidIndices` assign fresh, valid keys. Order is preserved by
-// stable-sorting on the original key strings first — the same string comparison Excalidraw's
-// `orderByFractionalIndex` uses and the ordering the backend's zero-padded scheme intends — so a
-// bot scene keeps its authored z-order. Scenes whose keys are already all valid (every
-// human-drawn board) take a zero-copy fast path and are handed through untouched, so existing
-// real-time collaboration / reconcile behaviour does not change.
+// Excalidraw's own `syncInvalidIndices` assign fresh, valid keys. Z-order is preserved per scene
+// shape: a HOMOGENEOUS bot scene (only the backend's unparseable scheme) is stable-sorted on the
+// raw key strings — the same comparison Excalidraw's `orderByFractionalIndex` uses and the order
+// the backend's zero-padded scheme intends — because its source array order is arbitrary Y.Map
+// iteration order. A MIXED scene (valid Excalidraw keys alongside the backend scheme) is NEVER
+// sorted: the two key spaces are not comparable as strings (`'a5' < 'r00000000'`), so a global
+// sort would invert the author's stacking; instead the original array order is preserved and
+// `syncInvalidIndices` regenerates only the stripped keys in place. Scenes whose keys are already
+// all valid (every human-drawn board) take a zero-copy fast path and are handed through untouched,
+// so existing real-time collaboration / reconcile behaviour does not change.
 
 import type { ExcalidrawElement } from './types.ts'
 
@@ -71,24 +75,55 @@ export function isExcalidrawFractionalIndex(key: unknown): key is string {
  * back to the Y.Doc.
  *
  * Fast path: if every element already carries a valid key (or none), the input array is returned
- * as-is — no reorder, no copy — so ordinary human-drawn boards are untouched. Otherwise a new,
- * stable-sorted array is returned with the invalid keys stripped, so Excalidraw's
- * `syncInvalidIndices` regenerates valid keys in the authored z-order instead of throwing.
+ * as-is — no reorder, no copy — so ordinary human-drawn boards are untouched.
+ *
+ * Otherwise the invalid keys are stripped and the array is handed to Excalidraw in the z-order its
+ * `syncInvalidIndices` will honour, with the choice of order gated on whether the scene is
+ * HOMOGENEOUS or MIXED:
+ *
+ *  - HOMOGENEOUS (every keyed element uses the backend's unparseable scheme, no valid Excalidraw
+ *    key present): the source array order is arbitrary (Y.Map iteration order), but the backend's
+ *    zero-padded scheme is string-monotonic, so a stable sort on the raw key strings recovers the
+ *    authored z-order. This is the fuzz-verified pure-bot-board path — kept byte-for-byte.
+ *
+ *  - MIXED (valid Excalidraw keys coexist with the backend scheme): the two key spaces are NOT
+ *    comparable as strings — a valid key like `a5` sorts before `r00000000`, so a global string
+ *    sort silently drags every valid-keyed element beneath the bot scheme and inverts the author's
+ *    stacking (the mixed-scene z-order corruption fixed here). We therefore do NOT sort a mixed
+ *    scene: Excalidraw's own `syncInvalidIndices` treats ARRAY ORDER as the desired stacking and
+ *    only regenerates the stripped keys in place, so preserving the original order keeps the
+ *    valid-keyed elements' relative order intact and re-slots the stripped (bot) elements back at
+ *    their original anchors.
  */
 export function sanitizeFractionalIndices(
   elements: readonly ExcalidrawElement[],
 ): readonly ExcalidrawElement[] {
   let anyInvalid = false
+  let anyValidKey = false
   for (const el of elements) {
     const idx = el.index
-    if (idx != null && !isExcalidrawFractionalIndex(idx)) {
-      anyInvalid = true
-      break
-    }
+    if (idx == null) continue
+    if (isExcalidrawFractionalIndex(idx)) anyValidKey = true
+    else anyInvalid = true
   }
   if (!anyInvalid) return elements
 
-  // Preserve authored order (elements with no key sort first, matching Excalidraw's own
+  // Drop only the offending key; every other field (unknown ones included) passes through.
+  const strip = (el: ExcalidrawElement): ExcalidrawElement => {
+    const idx = el.index
+    if (idx != null && !isExcalidrawFractionalIndex(idx)) {
+      const { index: _dropped, ...rest } = el
+      return rest as ExcalidrawElement
+    }
+    return el
+  }
+
+  // MIXED scene: never string-sort across the two incomparable key spaces — preserve the author's
+  // array order and let syncInvalidIndices regenerate only the stripped keys in place.
+  if (anyValidKey) return elements.map(strip)
+
+  // HOMOGENEOUS scene: stable-sort on the raw key strings to recover the authored order from the
+  // arbitrary Y.Map iteration order (elements with no key sort first, matching Excalidraw's own
   // treatment of a missing index as ordering-first), keeping ties in original array order.
   const positioned = elements.map((el, i) => ({ el, i }))
   positioned.sort((a, b) => {
@@ -98,13 +133,5 @@ export function sanitizeFractionalIndices(
     if (ka > kb) return 1
     return a.i - b.i
   })
-  return positioned.map(({ el }) => {
-    const idx = el.index
-    if (idx != null && !isExcalidrawFractionalIndex(idx)) {
-      // Drop only the offending key; every other field (unknown ones included) passes through.
-      const { index: _dropped, ...rest } = el
-      return rest as ExcalidrawElement
-    }
-    return el
-  })
+  return positioned.map(({ el }) => strip(el))
 }

--- a/packages/docs/src/board/collab/index.ts
+++ b/packages/docs/src/board/collab/index.ts
@@ -29,6 +29,7 @@ export type { WhiteboardSession, WhiteboardSessionOptions, BoardTerminal } from 
 export { shouldOverwrite, reconcileElement, elementSupersedes } from './reconcile.ts'
 export type { VersionStamp } from './reconcile.ts'
 export { repairForRender } from './repair.ts'
+export { sanitizeFractionalIndices, isExcalidrawFractionalIndex } from './fractionalIndex.ts'
 export {
   ELEMENTS_FIELD,
   FILES_FIELD,

--- a/packages/docs/src/board/collab/repair.ts
+++ b/packages/docs/src/board/collab/repair.ts
@@ -18,6 +18,7 @@
 // FE receives its result over the wire. This pass only makes the local render self-consistent.
 
 import { normalizeElement } from './schema.ts'
+import { sanitizeFractionalIndices } from './fractionalIndex.ts'
 import type { ExcalidrawElement } from './types.ts'
 
 /**
@@ -45,5 +46,9 @@ export function repairForRender(
     const n = normalizeElement(el, { elementIds: survivors, fileIds })
     if (n) out.push(n as ExcalidrawElement)
   }
-  return out
+  // Pass 3 (XIN-791): strip any fractional-index key Excalidraw's grammar cannot parse (e.g. the
+  // backend's zero-padded `r00000000` scheme) so restoreElements/reconcileElements regenerate a
+  // valid key instead of throwing `invalid order key` — the throw that blanks bot-written boards.
+  // Render-only, never written back to the Y.Doc; valid-keyed scenes pass through untouched.
+  return sanitizeFractionalIndices(out) as ExcalidrawElement[]
 }


### PR DESCRIPTION
## Problem

A whiteboard (`docType: board`) populated through the bot scene API (`PATCH /v1/bot/docs/{docId}/scene`) renders as an **empty canvas** in the board editor, even though the authoritative Y.Doc provably holds valid, non-deleted elements with correct geometry and indices. Ref: octo-docs-backend #51.

## Root cause — the fractional-index key format

The backend fills an element's missing z-order key with a zero-padded scheme — `r00000000`, `r00000001`, … (`r${seq.toString(36).padStart(8,'0')}`). That key passes the shared loose `@octo/whiteboard-schema` charset check (`/^[A-Za-z0-9]+$/`), but it is **not** a valid Excalidraw fractional index: in Excalidraw's bundled `fractional-indexing`, the head char `r` encodes a **19-digit** integer part, while only 9 characters follow.

`restoreElements` / `reconcileElements` run `syncInvalidIndices` → `generateNKeysBetween`, which passes neighbouring keys straight to the library's `validateOrderKey`. A key it can't parse makes the **whole apply throw** `invalid order key`. `ExcalidrawYjsBinding.applyRemote` wraps the rebuild in a `try/catch` that keeps the last good scene on error (the P1-2 batch guard), so the throw is swallowed and the canvas stays **blank**.

Keys that happen to already be monotonic slip through untouched (Excalidraw only regenerates when ordering looks broken), which is why a minimal 3-element repro can look fine while real boards blank the moment an index must be regenerated — a non-monotonic batch, a local element drawn next to remote ones, or a duplicate.

### Runtime evidence

Executing the real `@excalidraw/excalidraw@0.18.1` `restoreElements` / `reconcileElements` against the exact backend key format:

```
BEFORE FIX (raw backend keys):
  non-monotonic bot restore        => THROWS: invalid order key: r00000005
  local(no index)+bot reconcile    => THROWS: invalid order key: r00000001
AFTER FIX (sanitize -> real Excalidraw):
  non-monotonic bot restore        => OK, kept 2
  cold open reconcile              => OK, kept 2
  local(no index)+bot reconcile    => OK, kept 3
  local(valid a5)+bot reconcile    => OK, kept 3
  regenerated keys r1:a0 r2:a1 r3:a2  | all valid: true  (z-order preserved)
```

## Fix

A frontend, **render-only** defence that strips any `index` key Excalidraw's grammar rejects before restore/reconcile, so Excalidraw's own `syncInvalidIndices` assigns fresh valid keys instead of throwing.

- `collab/fractionalIndex.ts` — `isExcalidrawFractionalIndex` (faithful to `fractional-indexing`'s `validateOrderKey`) + `sanitizeFractionalIndices`.
- Applied in `repairForRender` (covers `applyRemote`'s adapter and raw paths) and in the BoardShell `initialElements` memo (cold-open `initialData`, which seeds from raw Y.Doc elements and bypasses `repairForRender`).
- **Order preserved** by stable-sorting on the original key strings — the ordering the backend's zero-padded scheme intends and the comparison Excalidraw uses — so a bot scene keeps its authored z-order.
- **No regression:** scenes whose keys are all valid (every human-drawn board) take a zero-copy fast path and are handed through untouched, so real-time collaboration/reconcile is unchanged.
- The result is never written back to the Y.Doc; the backend remains the authoritative index writer.

## Tests

`collab/__tests__/fractionalIndex.test.ts` (validator + sanitizer, incl. fast-path identity, strip-only-invalid, order preservation) and new `repair.test.ts` cases. Full `board/collab` suite: **109 passing**.

## Follow-up (out of scope, backend)

The durable fix is for octo-docs-backend to emit real Excalidraw fractional-index keys (e.g. via `fractional-indexing`'s `generateNKeysBetween`) rather than the `r00000000` scheme. This PR is the frontend render-defence so existing bot-written boards render correctly regardless.

## Verification note

The live repro board could not be exercised in a real browser from the dev environment (no running collab stack / repro-board access). Localization and the fix were verified by executing the real Excalidraw 0.18.1 functions headlessly against the exact backend key format. A final in-browser confirmation on `d_711f6a9848f478892d04beb2` is recommended before this leaves draft.
