### PR TITLE
feat(loop): filter issues by project on the issue list

### DIFF
--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -64,7 +64,9 @@ async function build(): Promise<Directory> {
 
 export async function ensureDirectory(force = false): Promise<Directory> {
   if (!force && _cache && _cache.slug === currentWorkspaceSlug()) return _cache;
-  if (_loading && _cache?.slug === currentWorkspaceSlug()) return _loading;
+  // 已有 in-flight build 时并发调用者直接搭车(切 workspace 会 invalidateDirectory 清空 _loading),
+  // 避免冷启动(_cache 尚为 null)多个消费者各拉一遍 directory。
+  if (!force && _loading) return _loading;
   _loading = build().then((d) => {
     _cache = d;
     _loading = null;
@@ -106,4 +108,11 @@ export function actorAvatar(
 export async function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {
   const dir = await ensureDirectory();
   return dir.candidates;
+}
+
+// 项目筛选下拉的选项，复用已缓存的 directory（不额外请求 /projects），与
+// listAssigneeCandidates 对称——调用方无需伸手进 Directory 内部结构。
+export async function listProjectOptions(): Promise<Array<{ id: string; title: string }>> {
+  const dir = await ensureDirectory();
+  return [...dir.projectName].map(([id, title]) => ({ id, title }));
 }

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -34,6 +34,7 @@ export async function listIssues(
     priority: params?.priority,
     assignee_id: params?.assignee_id,
     creator_id: params?.creator_id,
+    project_id: params?.project_id,
     sort: params?.sort_by,
     direction: params?.sort_direction,
     limit: params?.limit,

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -60,6 +60,7 @@ export interface ListParams {
   priority?: IssuePriority;
   assignee_id?: string;
   creator_id?: string;
+  project_id?: string;
   // 后端白名单 sort：position(默认)|priority|title|created_at|start_date|due_date。
   // direction 仅在 sort_by != position 时被后端采纳(asc|desc)。
   sort_by?: IssueSortField;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -46,7 +46,8 @@
     "status": "Status",
     "priority": "Priority",
     "assignee": "Assignee",
-    "creator": "Creator"
+    "creator": "Creator",
+    "project": "Project"
   },
   "sort": {
     "direction": "Asc/desc",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -46,7 +46,8 @@
     "status": "状态",
     "priority": "优先级",
     "assignee": "负责人",
-    "creator": "创建者"
+    "creator": "创建者",
+    "project": "项目"
   },
   "sort": {
     "direction": "升/降序",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -13,6 +13,7 @@ import { useI18n, WKApp } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority, IssueSortField } from "../api/types";
 import { ISSUE_SORT_FIELDS } from "../api/types";
 import { listIssues } from "../api/issueApi";
+import { listProjectOptions } from "../api/directory";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import { ISSUE_STATUS_ORDER, PRIORITY_ORDER } from "../ui/meta";
 import IssueBoard from "../panel/IssueBoard";
@@ -30,6 +31,7 @@ interface Filters {
   priority?: IssuePriority;
   assignee?: string;
   creator?: string;
+  project?: string;
   sortBy: IssueSortField;
   sortDir: "asc" | "desc";
 }
@@ -47,7 +49,13 @@ export default function IssuePage() {
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   const [createOpen, setCreateOpen] = useState(false);
   const cands = useAssigneeCandidates();
+  // 项目下拉复用 directory 已缓存的 /projects(避免重复请求);随 workspace 切换整页重挂而刷新。
+  const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
   const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
+
+  useEffect(() => {
+    listProjectOptions().then(setProjects).catch(() => {});
+  }, []);
 
   const reload = useCallback(() => {
     const my = ++seq.current;
@@ -59,6 +67,7 @@ export default function IssuePage() {
       priority: f.priority,
       assignee_id: f.assignee,
       creator_id: f.creator,
+      project_id: f.project,
       // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
       sort_by: paged ? f.sortBy : undefined,
       sort_direction: paged ? f.sortDir : undefined,
@@ -155,6 +164,21 @@ export default function IssuePage() {
             <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
           ))}
         </Select>
+        {projects.length > 0 && (
+          <Select
+            placeholder={t("loop.filter.project")}
+            value={f.project}
+            onChange={(v) => update({ project: v as string | undefined })}
+            showClear
+            filter
+            size="small"
+            style={{ width: 140 }}
+          >
+            {projects.map((p) => (
+              <Select.Option key={p.id} value={p.id}>{p.title}</Select.Option>
+            ))}
+          </Select>
+        )}
         {view === "list" && (
         <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
           <Select


### PR DESCRIPTION
## What

Add a **project filter** to the Loop issue list/board header, mirroring the
existing status / priority / assignee / creator filters.

## Why / how

The backend `GET /issues` already accepts a `project_id` query param
(`octo-multica` `ListIssues`), so this is a pure-frontend addition:

- `ListParams` gains an optional `project_id`; `listIssues` forwards it.
- `IssuePage` renders a project `Select`, shown only when the workspace has
  projects.
- Project options come from a new `directory` helper `listProjectOptions()`
  (symmetric to `listAssigneeCandidates()`), reusing the already-cached
  directory instead of a second `/projects` fetch.

### /simplify pass

Ran `/simplify` (reuse / simplification / efficiency / altitude). Two things
landed:
- **reuse/altitude**: extracted `listProjectOptions()` into `directory.ts`
  instead of reaching into the `projectName` Map from the page.
- **efficiency**: tightened `ensureDirectory`'s in-flight dedupe. The old guard
  also required a matching cached slug, so on a cold start (cache still null)
  two concurrent callers (`useAssigneeCandidates` + the new project loader) each
  kicked off a full directory build. Now it guards on the in-flight promise
  alone (still bypassed by `force`), so concurrent callers share one build.

## Blast radius (cross-module)

- `listIssues` has a single caller (`IssuePage`); the new optional `ListParams`
  field is a no-op for the squad/agent/skill/runtime `list*` helpers.
- The `ensureDirectory` dedupe change is shared infra. Verified: workspace
  switch calls `invalidateDirectory()` synchronously before the keyed remount,
  so no stale in-flight build leaks across workspaces; all consumers
  (`enrich`/`actorName`/`actorAvatar`/squad enrich) receive the same `Directory`
  as before, only fewer requests. `@octo/loop` is a leaf package.

## Verification

- **Adversarial review**: a Claude reviewer went through the dedupe change
  point-by-point (workspace-switch staleness, `force` semantics, `_loading`
  race, consumer blast-radius) and found no confirmed defect. Codex was also
  run per the two-model cross-check, but its runs did not complete this session
  (stream disconnects) — flagging that honestly rather than claiming a codex
  pass.
- **Real browser (dev env)**:
  - Workspace without projects (Loop-dev) → project Select hidden.
  - Workspace with a project (MV2 E2E, created "筛选测试项目") → Select shows,
    populated via `listProjectOptions`; selecting it narrows the board from 3
    issues to 0 (none assigned), proving `project_id` reaches the backend.
  - Switching Loop-dev ↔ MV2 E2E loads the correct per-workspace directory
    (issues, assignee names, project list) with no cross-workspace bleed.

Scope note: no linked issue; maintainer may need to set a Sprint for check-sprint.
