### PR TITLE
fix(docs): restore bullet markers in editor bullet lists (#615)

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -699,6 +699,28 @@
   text-decoration: line-through;
 }
 
+/* Restore bullet markers and indentation for plain bullet lists inside the editor.
+   The app-wide reset (App.css `ul { list-style-type: none; padding-inline-start: 0 }`)
+   strips the disc marker, which made the bullet-list button look like it did nothing.
+   Scope this to the editor prose so the app's other lists stay unaffected; the
+   `[data-type='taskList']` exclusion keeps the checkbox list untouched. Specificity
+   here (0,2,1) beats the global reset (0,0,1) with no `!important`. */
+.octo-prose .ProseMirror ul:not([data-type='taskList']) {
+  list-style: disc;
+  padding-left: 1.5em;
+}
+.octo-prose .ProseMirror ol {
+  list-style: decimal;
+  padding-left: 1.5em;
+}
+/* Nested bullet levels get distinct markers, matching common editor conventions. */
+.octo-prose .ProseMirror ul:not([data-type='taskList']) ul {
+  list-style: circle;
+}
+.octo-prose .ProseMirror ul:not([data-type='taskList']) ul ul {
+  list-style: square;
+}
+
 /* Remote collaboration carets (collaboration-caret; v3 default render uses
    the `collaboration-carets__*` class names, renamed from v2's
    `collaboration-cursor__*`). */


### PR DESCRIPTION
## What

Restore the bullet (disc) marker and indentation for plain bullet lists inside the docs editor.

## Why

Issue #615 — "bullet-list toolbar button does nothing". Runtime investigation showed the command and node insertion work fine: `<ul><li>` nodes are created correctly. The visible symptom is a CSS bug. The app-wide reset in `packages/dmworkbase/src/App.css`

```css
ul { list-style-type: none; padding-inline-start: 0; }
```

is global (no scope) and cascades onto the editor's `.octo-prose .ProseMirror ul`, stripping the disc marker and indent — so a bullet list looks identical to plain paragraphs and the button appears to do nothing. `ol` is unaffected (no global `ol` reset) and taskList uses a custom checkbox NodeView, so neither regressed.

## How

Add a scoped rule in `packages/docs/src/editor/styles.css` that only touches the editor prose:

```css
.octo-prose .ProseMirror ul:not([data-type='taskList']) { list-style: disc; padding-left: 1.5em; }
.octo-prose .ProseMirror ol { list-style: decimal; padding-left: 1.5em; }
```

- Scoped to `.octo-prose .ProseMirror` — the app's other `ul`s are untouched, so no global side effects.
- `:not([data-type='taskList'])` excludes the checkbox task list.
- Nested levels get `circle` / `square` markers.
- Specificity (0,2,1) beats the global reset (0,0,1) — **no `!important`**, and the global `App.css` reset is left unchanged.

## Verification

Reproduced the exact production cascade in a headless browser: loaded the real `editor/styles.css` plus the real global `ul` reset (reset injected *last*, so a mere source-order win would not count), rendered ProseMirror bullet/ordered/task list markup, and read computed styles:

| element | list-style-type | padding-left |
|---|---|---|
| bullet ul | `disc` | 1.5em |
| nested ul | `circle` | — |
| deep ul | `square` | — |
| ol | `decimal` | 1.5em |
| taskList ul | `none` (unchanged) | — |

`stylelint` on the file reports 0 errors (only pre-existing warnings).

Closes #615
