### PR TITLE
refactor(loop): make requestAssign symmetric with requestStatus

### DIFF
--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -36,7 +36,6 @@ interface Filters {
 
 const PAGE_SIZE = 50;
 
-
 export default function IssuePage() {
   const { t } = useI18n();
   const [issues, setIssues] = useState<Issue[]>([]);

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -234,8 +234,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     });
   };
 
-  // 运行中(可终止)vs 已结束(可重跑):用共享 isActiveRun(ui/meta)。
-
   const saveDesc = async () => {
     if (descDraft !== (issue?.description ?? "")) await patch({ description: descDraft });
     setEditingDesc(false);
@@ -293,7 +291,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   <Dropdown.Divider />
                   <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
                   {items.map((c) => (
-                    <Dropdown.Item key={c.id} active={issue?.assignee_id === c.id} onClick={() => issue && requestAssign({ issueId: issue.id, status: issue.status, assigneeType: c.type, assigneeId: c.id, assigneeName: c.name, apply: (extra) => patch({ assignee_id: c.id, assignee_type: c.type, ...extra }) })}>
+                    <Dropdown.Item key={c.id} active={issue?.assignee_id === c.id} onClick={() => issue && requestAssign(issue, c.type, c.id, c.name, (extra) => patch({ assignee_id: c.id, assignee_type: c.type, ...extra }))}>
                       {c.name}
                     </Dropdown.Item>
                   ))}
@@ -547,7 +545,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 <AssigneePicker
                   value={issue.assignee_id}
                   valueName={issue.assignee_name ?? null}
-                  onChange={(id, type, name) => requestAssign({ issueId: issue.id, status: issue.status, assigneeType: type, assigneeId: id, assigneeName: name, apply: (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }) })}
+                  onChange={(id, type, name) => requestAssign(issue, type, id, name, (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }))}
                 />
               </dd>
               <dt>{t("loop.field.project")}</dt>

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -107,7 +107,7 @@ export default function IssueList({
           size="small"
           value={r.assignee_id}
           valueName={r.assignee_name ?? null}
-          onChange={(id, type, name) => requestAssign({ issueId: r.id, status: r.status, assigneeType: type, assigneeId: id, assigneeName: name, apply: (extra) => patch(r.id, { assignee_id: id, assignee_type: type, ...extra }) })}
+          onChange={(id, type, name) => requestAssign(r, type, id, name, (extra) => patch(r.id, { assignee_id: id, assignee_type: type, ...extra }))}
         />
       ),
     },

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -6,8 +6,9 @@ import { previewIssueTrigger } from "../api/issueApi";
 
 const { Text } = Typography;
 
-/** 一次指派/状态变更请求：apply 由调用方给出（真正落库的 updateIssue 调用）。 */
-export interface RunConfirmRequest {
+/** 一次指派/状态变更请求：apply 由调用方给出（真正落库的 updateIssue 调用）。
+ *  hook 内部类型——调用方走 requestAssign / requestStatus,不直接构造。 */
+interface RunConfirmRequest {
   issueId: string;
   status: IssueStatus;
   assigneeType: AssigneeType | null;
@@ -42,7 +43,7 @@ function statusMightTrigger(issue: Issue, next: IssueStatus): boolean {
 /**
  * 指派即触发的预确认 hook。用法：
  *   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
- *   <AssigneePicker onChange={(id,type,name)=>requestAssign({...,apply:(extra)=>patch({assignee_id:id,assignee_type:type,...extra})})}/>
+ *   <AssigneePicker onChange={(id,type,name)=>requestAssign(issue,type,id,name,(extra)=>patch({assignee_id:id,assignee_type:type,...extra}))}/>
  *   {runConfirmModal}
  * 不需确认（member/取消指派/backlog）直接 apply；需确认则弹窗，先 preview-trigger 问后端。
  */
@@ -55,8 +56,24 @@ export function useRunConfirm() {
     Promise.resolve(apply({})).catch((e) => Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed")));
   };
 
-  const requestAssign = (r: RunConfirmRequest) => {
-    if (!needsConfirm(r)) { applyDirect(r.apply); return; }
+  // 指派 actor：status 保持 issue 当前值(指派不改状态),请求对象在此组装,
+  // 与 requestStatus 同构——调用方只给 issue + 新 assignee + apply。
+  const requestAssign = (
+    issue: Issue,
+    assigneeType: AssigneeType | null,
+    assigneeId: string | null,
+    assigneeName: string | null,
+    apply: RunConfirmRequest["apply"],
+  ) => {
+    const r: RunConfirmRequest = {
+      issueId: issue.id,
+      status: issue.status,
+      assigneeType,
+      assigneeId,
+      assigneeName,
+      apply,
+    };
+    if (!needsConfirm(r)) { applyDirect(apply); return; }
     setPending(r);
   };
 


### PR DESCRIPTION
## What

Retrospective `/simplify` of the merged Phase A dmloop work (#605/#606/#608/#609/#610/#613/#623), which shipped with adversarial correctness review but without a formal `/simplify` pass. Ran `/simplify` (reuse / simplification / efficiency / altitude) over the combined diff; this PR applies the one material finding plus two trivial cleanups.

## Material: symmetric `requestAssign`

`useRunConfirm`'s `requestAssign` required each call site to hand-build the full `RunConfirmRequest` object — `{issueId, status, assigneeType, assigneeId, assigneeName, apply}` — repeated verbatim in three places (issue detail ··· menu, detail properties picker, list row). If the request shape changes, all three must change in lockstep (drift risk). `requestStatus` already assembled its request internally; `requestAssign` was the asymmetric odd one out.

Fix: `requestAssign(issue, assigneeType, assigneeId, assigneeName, apply)`, assembling the request inside the hook (status stays the issue's current status — assigning doesn't change it). The three call sites collapse to a single call each; `RunConfirmRequest` becomes hook-internal (no external importers). **Behavior unchanged.**

## Also

- Removed an orphaned comment (isActiveRun note left after the logic moved inline) and a stray double blank line.

## Deliberately skipped (noted, not applied)

From the same `/simplify` pass, judged not worth the churn/risk in this cleanup:
- RunDetailModal poll: parallelize the two serial GETs / avoid full `listRuns` per tick — touches the live-transcript feature for a marginal per-2s RTT; the full-list refetch needs a backend single-run endpoint anyway.
- Transcript dedup Set rebuild — behavior-sensitive (depends on `?since` interval semantics), current form verified working in #610.
- Package-wide `Toast.error` helper, `IssueTriggerPreview` mirror fields, `rerunIssue` unused branch — out of scope / low value.

## Blast radius (cross-module)

Confined to dmloop. `RunConfirmRequest` had no external importers (de-export safe). `IssueBoard` uses `useRunConfirm` but only `requestStatus`, whose signature is unchanged. `requestStatus` / `runConfirmModal` exports unchanged. `@octo/loop` is a leaf package.

## Verification

- **Adversarial review**: a Claude reviewer confirmed the three reassembled requests are field-for-field identical to the originals, all three call sites pass a non-null `issue` (list row is `Issue`; ··· menu has an `issue &&` guard; properties picker is past the `if (!issue) return` early-return), `needsConfirm` semantics unchanged, and de-export is safe. Codex was also invoked for the two-model cross-check but did not complete a verdict this session (as in the prior PR) — flagged honestly.
- **Real browser (dev env, MV2 E2E / MVE-4)**:
  - Assign to a **member** (Bob) via the properties picker → applies directly, no confirmation modal (member path).
  - Assign to an **agent** (E2E Coworker) on an in-progress issue via the ··· menu → the dispatch-confirmation modal appears (preview ran); chose "暂不开始" → assignee applied without dispatching a run (execution log stayed 0). Assignee restored to its original value.

Scope note: no linked issue; maintainer may need to set a Sprint for check-sprint.
