### PR TITLE
feat(summary): increase custom template limits and improve description textarea UX

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -660,10 +660,10 @@ export default class ChatSummaryNewModal extends Component<
                         <input
                             className="summary-template-edit-input"
                             value={editingTemplateLabel}
-                            maxLength={40}
+                            maxLength={100}
                             disabled={savingTemplate}
                             placeholder={t('summary.templates.custom.namePlaceholder')}
-                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 40) })}
+                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 100) })}
                         />
                     </div>
                     <div className="summary-template-edit-field">
@@ -673,10 +673,10 @@ export default class ChatSummaryNewModal extends Component<
                         <textarea
                             className="summary-template-edit-input summary-template-edit-desc"
                             value={editingTemplateDescription}
-                            maxLength={120}
+                            maxLength={200}
                             disabled={savingTemplate}
                             placeholder={t('summary.templates.custom.descriptionPlaceholder')}
-                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 120) })}
+                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 200) })}
                         />
                     </div>
                     <div className="summary-template-edit-hint">

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -1941,8 +1941,8 @@
 
 .summary-template-edit-desc {
     min-height: 96px;
-    max-height: 180px;
     resize: vertical;
+    max-height: 180px;
     overflow-y: auto;
 }
 

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -1940,7 +1940,10 @@
 }
 
 .summary-template-edit-desc {
-    min-height: 72px;
+    min-height: 96px;
+    max-height: 180px;
+    resize: vertical;
+    overflow-y: auto;
 }
 
 .summary-template-edit-hint {

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -716,10 +716,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         <input
                             className="summary-template-edit-input"
                             value={editingTemplateLabel}
-                            maxLength={40}
+                            maxLength={100}
                             disabled={savingTemplate}
                             placeholder={translate("summary.templates.custom.namePlaceholder")}
-                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 40) })}
+                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 100) })}
                         />
                     </div>
                     <div className="summary-template-edit-field">
@@ -729,10 +729,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         <textarea
                             className="summary-template-edit-input summary-template-edit-desc"
                             value={editingTemplateDescription}
-                            maxLength={120}
+                            maxLength={200}
                             disabled={savingTemplate}
                             placeholder={translate("summary.templates.custom.descriptionPlaceholder")}
-                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 120) })}
+                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 200) })}
                         />
                     </div>
                     <div className="summary-template-edit-hint">


### PR DESCRIPTION
Closes #630

## Summary
Relax the character limits for custom topic templates and improve the description textarea behavior.

## Changes
- Increase the template name limit from 40 to 100 characters.
- Increase the template description limit from 120 to 200 characters.
- Limit the description textarea to vertical resizing.
- Add a maximum textarea height with internal scrolling for longer content.

## Testing
- Ran `git diff --check`.
- Verified the editor limits and textarea resize behavior locally.