### PR TITLE
feat(loop): show issue labels and due dates on the issue views

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -44,9 +44,13 @@ export async function listIssues(
   return { issues, total: data.total ?? issues.length };
 }
 
+export async function enrichIssue(issue: Issue): Promise<Issue> {
+  return (await enrich([issue]))[0];
+}
+
 export async function getIssue(id: string): Promise<Issue> {
   const issue = await httpGet<Issue>(`/issues/${id}`);
-  return (await enrich([issue]))[0];
+  return enrichIssue(issue);
 }
 
 export function createIssue(req: CreateIssueReq): Promise<Issue> {

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -74,6 +74,13 @@ export type IssueStatus =
   | "backlog" | "todo" | "in_progress" | "in_review" | "done" | "blocked" | "cancelled";
 export type IssuePriority = "urgent" | "high" | "medium" | "low" | "none";
 
+/** issue 标签(后端 list/detail 端点批量回填 issue.labels)。color 为 hex。 */
+export interface IssueLabel {
+  id: string;
+  name: string;
+  color: string;
+}
+
 export interface Issue {
   id: string;
   workspace_id: string;
@@ -102,6 +109,8 @@ export interface Issue {
   // octo 头像 URL（member 型 actor，由 directory 回填；agent/squad/原生成员为空）
   assignee_avatar?: string | null;
   creator_avatar?: string | null;
+  // 后端 list/detail 端点批量回填；其它端点(update/ws)不带 → 保持已有。
+  labels?: IssueLabel[] | null;
 }
 
 export interface CreateIssueReq {

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -129,7 +129,10 @@
     "assignee": "Assignee",
     "project": "Project",
     "noProject": "No project",
-    "creator": "Creator"
+    "creator": "Creator",
+    "labels": "Labels",
+    "startDate": "Start date",
+    "dueDate": "Due date"
   },
   "status": {
     "backlog": "Backlog",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -129,7 +129,10 @@
     "assignee": "负责人",
     "project": "项目",
     "noProject": "无项目",
-    "creator": "创建者"
+    "creator": "创建者",
+    "labels": "标签",
+    "startDate": "开始日期",
+    "dueDate": "截止日期"
   },
   "status": {
     "backlog": "待规划",

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -377,6 +377,13 @@
   flex-wrap: wrap;
 }
 
+.loop-card__due {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 12px;
+}
+
 /* ===== 通用表格辅助 ===== */
 .loop-cell-title {
   font-weight: 500;

--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -1,14 +1,18 @@
 import React, { useState } from "react";
 import { Tag } from "@douyinfe/semi-ui";
+import { CalendarClock } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import { AssigneeBadge } from "../ui/AssigneePicker";
+import LabelChips from "../ui/LabelChips";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
   PRIORITY_COLOR,
+  formatShortDate,
+  isOverdue,
 } from "../ui/meta";
 
 export interface IssueBoardProps {
@@ -83,10 +87,22 @@ export default function IssueBoard({
                 >
                   <div className="loop-card__key">{issue.identifier}</div>
                   <div className="loop-card__title">{issue.title}</div>
+                  {issue.labels && issue.labels.length > 0 && (
+                    <div style={{ marginTop: 4 }}><LabelChips labels={issue.labels} max={3} /></div>
+                  )}
                   <div className="loop-card__foot">
                     <Tag color={PRIORITY_COLOR[issue.priority]} size="small">
                       {t(`loop.priority.${issue.priority}`)}
                     </Tag>
+                    {issue.due_date && (
+                      <span
+                        className="loop-card__due"
+                        style={{ color: isOverdue(issue.due_date, issue.status) ? "var(--semi-color-danger)" : "var(--semi-color-text-2)" }}
+                      >
+                        <CalendarClock size={12} />
+                        {formatShortDate(issue.due_date)}
+                      </span>
+                    )}
                     <AssigneeBadge
                       type={issue.assignee_type}
                       name={issue.assignee_name ?? null}

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -36,6 +36,7 @@ import type {
 import {
   getIssue,
   updateIssue,
+  enrichIssue,
   deleteIssue,
   listComments,
   addComment,
@@ -45,6 +46,7 @@ import {
 } from "../api/issueApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import LabelChips from "../ui/LabelChips";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -57,6 +59,7 @@ import {
   PRIORITY_COLOR,
   RUN_STATUS_COLOR,
   isActiveRun,
+  isOverdue,
 } from "../ui/meta";
 import "./issueDetail.css";
 
@@ -116,8 +119,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   const patch = async (p: Parameters<typeof updateIssue>[1]) => {
     if (!issue) return;
-    const next = await updateIssue(issue.id, p);
-    setIssue(next);
+    const updated = await updateIssue(issue.id, p);
+    // PUT 响应不带 labels(仅 list/detail 端点回填);re-enrich 修回 assignee_name/project_name
+    // 等展示字段(按新值重算),labels 保留当前值,避免编辑后属性栏字段被清成空。
+    setIssue({ ...(await enrichIssue(updated)), labels: updated.labels ?? issue.labels });
     onChanged?.();
   };
 
@@ -551,6 +556,23 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dt>{t("loop.field.project")}</dt>
               <dd>
                 <Text>{issue.project_name ?? "—"}</Text>
+              </dd>
+              <dt>{t("loop.field.labels")}</dt>
+              <dd>
+                {issue.labels && issue.labels.length > 0 ? <LabelChips labels={issue.labels} /> : <Text type="tertiary">—</Text>}
+              </dd>
+              <dt>{t("loop.field.startDate")}</dt>
+              <dd>
+                <Text type="tertiary" style={{ fontSize: 12 }}>{fmt(issue.start_date)}</Text>
+              </dd>
+              <dt>{t("loop.field.dueDate")}</dt>
+              <dd>
+                <Text
+                  type={isOverdue(issue.due_date, issue.status) ? "danger" : "tertiary"}
+                  style={{ fontSize: 12 }}
+                >
+                  {fmt(issue.due_date)}
+                </Text>
               </dd>
               <dt>{t("loop.field.creator")}</dt>
               <dd>

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import LabelChips from "../ui/LabelChips";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
@@ -51,6 +52,7 @@ export default function IssueList({
       render: (v: string, r: Issue) => (
         <span className="loop-cell-title" onClick={() => onOpen(r.id)}>
           {v}
+          <LabelChips labels={r.labels} max={3} />
         </span>
       ),
     },

--- a/packages/dmloop/src/ui/LabelChips.tsx
+++ b/packages/dmloop/src/ui/LabelChips.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Tag } from "@douyinfe/semi-ui";
+import type { IssueLabel } from "../api/types";
+
+/**
+ * 渲染 issue 的标签为彩色 chips（列表/看板卡片/详情共用）。
+ * color 为后端给的 hex；用淡色底 + 同色字，兼顾任意色相的可读性。
+ * 非法/非 #RRGGBB 颜色回退到 Semi 默认 Tag 样式。
+ * max 限制展示数量，其余折叠成「+N」（用于卡片这类空间有限处）。
+ */
+export default function LabelChips({ labels, max }: { labels?: IssueLabel[] | null; max?: number }) {
+  if (!labels || labels.length === 0) return null;
+  const shown = max ? labels.slice(0, max) : labels;
+  const rest = labels.length - shown.length;
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: 4, alignItems: "center" }}>
+      {shown.map((l) => {
+        const hex = /^#[0-9a-fA-F]{6}$/.test(l.color) ? l.color : undefined;
+        return (
+          <Tag
+            key={l.id}
+            size="small"
+            style={hex ? { backgroundColor: `${hex}1f`, color: hex, border: `1px solid ${hex}3d` } : undefined}
+          >
+            {l.name}
+          </Tag>
+        );
+      })}
+      {rest > 0 && <Tag size="small">{`+${rest}`}</Tag>}
+    </span>
+  );
+}

--- a/packages/dmloop/src/ui/meta.tsx
+++ b/packages/dmloop/src/ui/meta.tsx
@@ -101,3 +101,14 @@ const ACTIVE_RUN_STATUSES = ["queued", "dispatched", "waiting_local_directory", 
 export function isActiveRun(status: string): boolean {
   return ACTIVE_RUN_STATUSES.includes(status);
 }
+
+// 日期展示辅助(列表/看板/详情共用):短格式 M/D,以及是否逾期(未完成且已过截止)。
+export function formatShortDate(iso?: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+export function isOverdue(due: string | null | undefined, status: IssueStatus): boolean {
+  if (!due || status === "done" || status === "cancelled") return false;
+  return new Date(due).getTime() < Date.now();
+}


### PR DESCRIPTION
## What

Surface issue data the backend already returns but the client was dropping:

- **Labels**: a shared `<LabelChips>` component renders an issue's labels as
  colored chips (per-label hex → tinted bg + matching text; falls back to the
  default Tag style for non-`#RRGGBB` colors; folds overflow to "+N"). Shown on
  list rows, board cards, and the detail properties panel. `types.ts` gains
  `IssueLabel` + optional `Issue.labels` (list/detail endpoints backfill it;
  `enrich()` already passes it through via spread, so no API-layer change).
- **Dates**: `meta.tsx` gains `formatShortDate` + `isOverdue`; board cards show
  a due-date badge (red when overdue and not done/cancelled); the detail
  properties panel shows start/due rows (due in danger color when overdue).

## Bug fix (made visible by labels)

`IssueDetailPage.patch()` replaced the issue with the **un-enriched** PUT
response, which lacks `labels` (and `assignee_name`/`project_name` — display
fields only list/detail endpoints backfill). So any inline edit in the detail
view wiped those fields until leave+reenter. `patch()` now re-enriches the PUT
response (recomputes name fields for the new values) and preserves labels;
extracted an `enrichIssue()` helper (also DRYs `getIssue`).

## Quality gates

- **/simplify** (4 angles): the labels slice came back clean (shared component,
  right altitude; the one flagged redundancy — board's outer guard — is a
  deliberate spacing-wrapper control, kept).
- **Adversarial review, two models**: a Claude reviewer found the `patch()`
  label-wipe bug (confidence 85) — fixed as above; a Codex review of the final
  diff (inlined, no repo exploration) confirmed no remaining defect (patch fix
  correct, `isOverdue`/hex/`LabelChips` guards safe, blast-radius compatible).
- **Real browser (dev env, MV2 E2E / MVE-4 with injected labels + due date)**:
  - Board card: `P0`/`回归` chips (tinted per hex) + due badge `7/9` in red (overdue).
  - Detail properties: labels row + start(`-`)/due(`7/9 08:00`, danger) rows.
  - Bug-fix regression: changing priority in the detail view keeps the labels
    row intact (previously flipped to `—`).
  - Loop-dev (no labels/dates) renders cleanly with nothing shown.

## Blast radius

Additive only: `Issue.labels` optional field, two new `meta` exports, new
`enrichIssue` export, new `LabelChips` component. No existing export signature
changed; other `Issue`/`meta` consumers unaffected; `@octo/loop` is a leaf
package. Verified against the just-merged #627 (project filter) and #629
(requestAssign) — rebased cleanly on top, requestAssign call sites use #629's form.

Scope note: no linked issue; maintainer may need to set a Sprint for check-sprint.
