### PR TITLE
chore(loop): drop upstream-brand references from source

### DIFF
--- a/packages/dmloop/src/api/agentApi.ts
+++ b/packages/dmloop/src/api/agentApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Agent API（真实 fleet 联调）
+// @octo/loop — Agent API（后端契约联调）
 import type { Agent, CreateAgentReq, UpdateAgentReq, ListParams, RuntimeDevice } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar } from "./directory";
@@ -46,7 +46,7 @@ export function updateAgent(id: string, req: UpdateAgentReq): Promise<Agent> {
   return httpPut<Agent>(`/agents/${id}`, req);
 }
 
-// fleet 不支持 DELETE /agents/:id（405）；改用归档。
+// 后端不支持 DELETE /agents/:id（405）；改用归档。
 export function archiveAgent(id: string): Promise<void> {
   return httpPost<void>(`/agents/${id}/archive`, {});
 }

--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -1,7 +1,7 @@
 // @octo/loop — Directory：解析展示用名字 + 提供 assignee 候选。
-// fleet 列表接口不返回 assignee_name/project_name 等，这里统一加载并缓存后回填。
+// 后端列表接口不返回 assignee_name/project_name 等，这里统一加载并缓存后回填。
 // member 身份按 octo_uid 解析成 octo IM 名字（octo web 面统一以 octo 身份展示，
-// 而非 multica 原生名）；无 octo_uid 的原生成员回退其 multica 名。
+// 而非 后端侧原生显示名）；无 octo_uid 的原生成员回退其后端显示名。
 import type { AssigneeCandidate, AssigneeType } from "./types";
 import { httpGet, currentWorkspaceId, currentWorkspaceSlug } from "./http";
 import { WKApp, SpaceService } from "@octo/base";
@@ -30,7 +30,7 @@ async function build(): Promise<Directory> {
     httpGet<{ projects: Array<{ id: string; title: string }> }>("/projects").catch(() => ({ projects: [] })),
   ]);
   // Resolve member identity to octo names — but only pull the (potentially large)
-  // space roster when at least one member is octo-bridged; a pure-multica
+  // space roster when at least one member is octo-bridged; a pure-native
   // workspace skips the roster fetch entirely.
   const octoName = new Map<string, string>();
   if (members.some((m) => m.octo_uid)) {
@@ -41,7 +41,7 @@ async function build(): Promise<Directory> {
   const memberOctoUid = new Map<string, string>();
   const candidates: AssigneeCandidate[] = [];
   for (const m of members) {
-    // octo 身份优先：octo_uid 命中 space 名册取 octo 名字，否则回退 multica 名。
+    // octo 身份优先：octo_uid 命中 space 名册取 octo 名字，否则回退后端显示名。
     const name = (m.octo_uid && octoName.get(m.octo_uid)) || m.name;
     memberName.set(m.user_id, name);
     if (m.octo_uid) memberOctoUid.set(m.user_id, m.octo_uid);

--- a/packages/dmloop/src/api/http.ts
+++ b/packages/dmloop/src/api/http.ts
@@ -1,5 +1,5 @@
-// @octo/loop — HTTP 客户端（真实 fleet 联调）
-// 所有请求走 /fleet/api/v1（Vite dev proxy → http://127.0.0.1:8091），路径与 fleet 契约一致。
+// @octo/loop — HTTP 客户端（后端契约联调）
+// 所有请求走 /fleet/api/v1（Vite dev proxy → http://127.0.0.1:8091），路径与 后端契约一致。
 // workspace 相关接口统一携带 header `x-workspace-slug`（值取自顶部 workspace 下拉当前 slug）。
 import axios from "axios";
 import { WKApp } from "@octo/base";
@@ -62,7 +62,7 @@ export function setWorkspaceContext(slug: string, id: string): void {
 client.interceptors.request.use((config) => {
   config.headers = config.headers ?? {};
   if (_workspaceSlug) config.headers["x-workspace-slug"] = _workspaceSlug;
-  // fleet 后端对 loop 全域接口校验以下两个鉴权 header，复用 octo-web 其他模块
+  // 后端对 loop 全域接口校验以下两个鉴权 header，复用 octo-web 其他模块
   // （dmworkbase APIClient）的取值来源：token 取自 WKApp.loginInfo.token，
   // space_id 取自 WKApp.shared.currentSpaceId。仅在非空时注入。
   const token = WKApp.loginInfo.token;

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Issue API（真实 fleet 联调）
+// @octo/loop — Issue API（后端契约联调）
 import type {
   Issue,
   IssueComment,

--- a/packages/dmloop/src/api/projectApi.ts
+++ b/packages/dmloop/src/api/projectApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Project API（真实 fleet 联调）
+// @octo/loop — Project API（后端契约联调）
 import type { Project, UpsertProjectReq, ListParams } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName } from "./directory";

--- a/packages/dmloop/src/api/runsApi.ts
+++ b/packages/dmloop/src/api/runsApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — 执行记录 API（真实 fleet 联调）
+// @octo/loop — 执行记录 API（后端契约联调）
 import type { TaskRun, RunMessage } from "./types";
 import { httpGet, httpPost } from "./http";
 import { ensureDirectory } from "./directory";

--- a/packages/dmloop/src/api/runtimeApi.ts
+++ b/packages/dmloop/src/api/runtimeApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Runtime API（真实 fleet 联调；Runtime 已并入 Loop 二级菜单）
+// @octo/loop — Runtime API（后端契约联调；Runtime 已并入 Loop 二级菜单）
 import type { RuntimeDevice, ListParams } from "./types";
 import { httpGet } from "./http";
 

--- a/packages/dmloop/src/api/skillApi.ts
+++ b/packages/dmloop/src/api/skillApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Skill API（真实 fleet 联调）
+// @octo/loop — Skill API（后端契约联调）
 import type {
   Skill,
   UpsertSkillReq,

--- a/packages/dmloop/src/api/squadApi.ts
+++ b/packages/dmloop/src/api/squadApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Squad API（真实 fleet 联调）
+// @octo/loop — Squad API（后端契约联调）
 import type { Squad, SquadMember, UpsertSquadReq, ListParams } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete, httpPatch } from "./http";
 import { ensureDirectory, actorName, actorAvatar } from "./directory";
@@ -36,7 +36,7 @@ export async function getSquad(id: string): Promise<Squad> {
 }
 
 export function createSquad(req: UpsertSquadReq): Promise<Squad> {
-  // fleet 要求 leader_id；无则由页面校验。
+  // 后端要求 leader_id；无则由页面校验。
   return httpPost<Squad>("/squads", req);
 }
 

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -1,6 +1,6 @@
-// @octo/loop — 领域类型（对齐真实 fleet 契约）。
+// @octo/loop — 领域类型（对齐后端契约）。
 // 命名一律使用 Loop 语义，不暴露上游品牌。
-// 说明：fleet 列表接口不返回展示用名字（assignee_name / project_name 等），
+// 说明：后端列表接口不返回展示用名字（assignee_name / project_name 等），
 // 这些由 directory.ts 解析后作为可选字段回填，页面直接读取。
 
 export type AssigneeType = "member" | "agent" | "squad";
@@ -34,7 +34,7 @@ export interface WorkspaceMember {
   name: string;
   email?: string;
   avatar_url?: string | null;
-  // octo IM uid this multica user is bridged to, or null for native members.
+  // octo IM uid this backend user is bridged to, or null for native members.
   // The UI renders member identity (name/avatar) from octo by this uid.
   octo_uid?: string | null;
 }

--- a/packages/dmloop/src/api/workspaceApi.ts
+++ b/packages/dmloop/src/api/workspaceApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — Workspace / Members / Invitations API（真实 fleet 联调）
+// @octo/loop — Workspace / Members / Invitations API（后端契约联调）
 import type { Workspace, WorkspaceMember, Invitation } from "./types";
 import { httpGet, httpPost, httpPatch, httpDelete } from "./http";
 

--- a/packages/dmloop/src/cliAuthorizeSession.ts
+++ b/packages/dmloop/src/cliAuthorizeSession.ts
@@ -1,6 +1,6 @@
 export const MULTICA_CLI_AUTHORIZE_PATH = "/loop/cli-authorize";
 
-const PENDING_SEARCH_KEY = "octo.multica.cli-authorize.pending-search";
+const PENDING_SEARCH_KEY = "octo.loop.cli-authorize.pending-search";
 
 type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const { Title, Text } = Typography;
 const ROLES = ["admin", "member"];
 
 /**
- * Loop 设置页（对标 multica）：通用（General，无 Danger Zone）+ 成员管理（Members）。
+ * Loop 设置页（对齐产品设计）：通用（General，无 Danger Zone）+ 成员管理（Members）。
  */
 export default function SettingsPage({
   workspace,
@@ -190,7 +190,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
     });
   };
 
-  // octo 身份优先：按 octo_uid 命中 space 名册取名字，否则回退 multica 侧 name/email。
+  // octo 身份优先：按 octo_uid 命中 space 名册取名字，否则回退后端侧 name/email。
   const displayName = (m: WorkspaceMember): string =>
     (m.octo_uid && rosterByUid[m.octo_uid]?.name) || m.name || m.email || m.octo_uid || m.user_id;
   const avatarSrc = (m: WorkspaceMember): string | undefined =>

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -193,7 +193,7 @@
   max-width: 360px;
 }
 
-/* ===== Multica CLI 授权 ===== */
+/* ===== CLI 授权 ===== */
 .loop-cli-auth {
   min-height: 100vh;
   display: flex;

--- a/packages/dmloop/src/panel/AgentDetailPage.tsx
+++ b/packages/dmloop/src/panel/AgentDetailPage.tsx
@@ -37,7 +37,7 @@ interface EnvEntry {
 }
 
 /**
- * Agent 独立详情/编辑页（1:1 复刻 multica）：
+ * Agent 独立详情/编辑页（对齐产品设计）：
  * 左侧 Inspector（身份 + 属性）+ 右侧 Tabs（指令 / 技能 / 环境变量 / 自定义参数）。
  * 渲染在右主栏（routeRight.push），顶部返回 pop。
  */

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -74,7 +74,7 @@ export interface IssueDetailPageProps {
 }
 
 /**
- * Issue 独立详情页（1:1 复刻 multica）：主体(标题/描述/评论) + 右侧属性栏 + 执行日志。
+ * Issue 独立详情页（对齐产品设计）：主体(标题/描述/评论) + 右侧属性栏 + 执行日志。
  * 渲染在右主栏（routeRight.push），顶部返回按钮 pop 回列表/看板。
  */
 export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageProps) {
@@ -239,7 +239,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setEditingDesc(false);
   };
 
-  // 右上角 ··· 菜单：快速改 status / priority / assignee（1:1 复刻 multica）。
+  // 右上角 ··· 菜单：快速改 status / priority / assignee（对齐产品设计）。
   const renderMoreMenu = () => (
     <Dropdown.Menu>
       <Dropdown

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -38,7 +38,7 @@ export default function RunDetailModal({
   const [loading, setLoading] = useState(false);
   const lastSeqRef = useRef(0);
 
-  // 打开时全量拉;运行中的 run 则每 2s 用 ?since 增量轮询消息 + 刷新 run 状态,终态即停(dmloop 无 fleet WS,退化为轮询)。
+  // 打开时全量拉;运行中的 run 则每 2s 用 ?since 增量轮询消息 + 刷新 run 状态,终态即停(dmloop 无后端 WS 推送,退化为轮询)。
   useEffect(() => {
     if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; return; }
     let cancelled = false;

--- a/packages/dmloop/src/ui/CreateIssueModal.tsx
+++ b/packages/dmloop/src/ui/CreateIssueModal.tsx
@@ -19,7 +19,7 @@ export interface CreateIssueModalProps {
 }
 
 /**
- * 新建 Issue 弹窗（1:1 复刻 multica 手动创建）：
+ * 新建 Issue 弹窗（对齐产品设计的手动创建流程）：
  * 标题 / 描述 / 指派(member|agent|squad 三态) / 状态 / 优先级 / 项目。
  */
 export default function CreateIssueModal({ visible, onClose, onCreated }: CreateIssueModalProps) {

--- a/packages/dmloop/src/ui/RunConfirmModal.tsx
+++ b/packages/dmloop/src/ui/RunConfirmModal.tsx
@@ -22,7 +22,7 @@ function isAgentAssignee(type: AssigneeType | null, id: string | null): boolean 
   return (type === "agent" || type === "squad") && !!id;
 }
 
-// 是否需要“派单预确认”：与 multica 一致——agent/squad 指派且 issue 非 backlog。
+// 是否需要“派单预确认”：与产品设计一致——agent/squad 指派且 issue 非 backlog。
 function needsConfirm(r: RunConfirmRequest): boolean {
   return isAgentAssignee(r.assigneeType, r.assigneeId) && r.status !== "backlog";
 }
@@ -31,7 +31,7 @@ function needsConfirm(r: RunConfirmRequest): boolean {
 // agent/squad 已指派,且从 backlog 移到非 backlog/done/cancelled。
 // ponytail: 这是**客户端尽力判断**,用的是本地缓存的 assignee;真正是否起 run 由 preview-trigger
 // 权威判定。并发场景(他人刚改派为 agent、本地视图未刷新)下本判断可能漏判 → 跳过确认弹窗,
-// 但后端仍按持久 assignee 正确起 run(只是少了一次确认 UX)。与 multica 原生 web 的客户端 gate 同源。
+// 但后端仍按持久 assignee 正确起 run(只是少了一次确认 UX)。沿用同一套客户端预确认 gate。
 function statusMightTrigger(issue: Issue, next: IssueStatus): boolean {
   return (
     isAgentAssignee(issue.assignee_type, issue.assignee_id) &&


### PR DESCRIPTION
## What

Public OSS repo hygiene: remove upstream-brand references from the Loop
(`dmloop`) source so the package doesn't leak the underlying engine's name to
anyone browsing the repo.

Found via an automated brand-exposure scan (15 hits, classified). This PR
handles the safe, in-scope ones:

- **Comments (18 files)** reworded to neutral, meaning-preserved phrasing
  ("replicate <brand>" → "align with product design"; "<brand> API/contract"
  → "backend API/contract"; etc.). No logic touched.
- **One `sessionStorage` key** renamed to a neutral namespace. Self-contained:
  set/get/removed only within its own module, and it holds a transient CLI-auth
  handoff value, so no migration is needed.
- **One CSS section comment** neutralized.

No **user-facing** strings were affected — the i18n bundle was already
brand-free (all keys resolve to Loop/neutral copy), and the scan found no brand
in any rendered string.

## Deferred (follow-ups)

Left out because they need coordination or belong to a separate feature:

- CLI-auth symbol/file renames (pure-frontend but a distinct feature) — separate rename PR.
- CSRF cookie name — needs the backend to emit the matching name (double-submit).
- API path prefix — needs frontend + dev proxy + backend to move together.

## Verification / gates

Comment-and-string only, with a single self-contained transient storage-key
rename — no logic blast radius. Per the "no-logic-impact" carve-out the
/simplify + adversarial gates are exempt; the one functional touch was verified
self-contained (the key const + all three storage calls live in one module,
no external reader). `tsc` clean; diff is 19 files, all 1:1 line swaps.

Independent of the open Loop PRs (touches comments/strings, mostly different
lines/files); rebases cleanly on the current tip.
