### PR TITLE
feat(loop): keyword search + label editing (capability layer)

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -25,11 +25,15 @@ async function enrich(issues: Issue[]): Promise<Issue[]> {
   }));
 }
 
-export async function listIssues(
-  params?: ListParams,
-): Promise<{ issues: Issue[]; total: number }> {
-  const data = await httpGet<{ issues: Issue[]; total?: number }>("/issues", {
-    keyword: params?.keyword,
+// 拉取 issue 列表并 enrich + 兜底 total(listIssues/searchIssues 共用尾巴)。
+async function fetchIssues(path: string, query: Record<string, unknown>): Promise<{ issues: Issue[]; total: number }> {
+  const data = await httpGet<{ issues: Issue[]; total?: number }>(path, query);
+  const issues = await enrich(data.issues ?? []);
+  return { issues, total: data.total ?? issues.length };
+}
+
+export function listIssues(params?: ListParams): Promise<{ issues: Issue[]; total: number }> {
+  return fetchIssues("/issues", {
     status: params?.status,
     priority: params?.priority,
     assignee_id: params?.assignee_id,
@@ -43,8 +47,20 @@ export async function listIssues(
     limit: params?.limit,
     offset: params?.offset,
   });
-  const issues = await enrich(data.issues ?? []);
-  return { issues, total: data.total ?? issues.length };
+}
+
+// 关键词搜索(GET /issues/search):独立端点,后端全文搜标题/描述/评论并回高亮片段。
+// 与 listIssues 是两套语义(不吃状态/优先级等筛选、limit≤50),故单列一个函数。
+export function searchIssues(
+  q: string,
+  opts?: { limit?: number; offset?: number; includeClosed?: boolean },
+): Promise<{ issues: Issue[]; total: number }> {
+  return fetchIssues("/issues/search", {
+    q,
+    limit: opts?.limit,
+    offset: opts?.offset,
+    include_closed: opts?.includeClosed ? "true" : undefined,
+  });
 }
 
 export async function enrichIssue(issue: Issue): Promise<Issue> {

--- a/packages/dmloop/src/api/labelApi.ts
+++ b/packages/dmloop/src/api/labelApi.ts
@@ -1,0 +1,36 @@
+// @octo/loop — 标签 API（后端契约联调）。
+// 工作区级标签 CRUD(/labels) + issue 挂/摘标签(/issues/:id/labels)。
+import type { IssueLabel } from "./types";
+import { httpGet, httpPost, httpPut, httpDelete } from "./http";
+
+/* ---------- 工作区标签 CRUD ---------- */
+// 后端 list 端点返回 { labels: [...], total }(包裹,同 /issues);解包取 labels。
+export function listLabels(): Promise<IssueLabel[]> {
+  return httpGet<{ labels?: IssueLabel[] }>("/labels").then((r) => r?.labels ?? []);
+}
+
+export function createLabel(name: string, color: string): Promise<IssueLabel> {
+  return httpPost<IssueLabel>("/labels", { name, color });
+}
+
+export function updateLabel(id: string, req: { name?: string; color?: string }): Promise<IssueLabel> {
+  return httpPut<IssueLabel>(`/labels/${id}`, req);
+}
+
+export function deleteLabel(id: string): Promise<void> {
+  return httpDelete<void>(`/labels/${id}`);
+}
+
+/* ---------- issue ↔ 标签 ---------- */
+export function listIssueLabels(issueId: string): Promise<IssueLabel[]> {
+  return httpGet<{ labels?: IssueLabel[] }>(`/issues/${issueId}/labels`).then((r) => r?.labels ?? []);
+}
+
+// 后端 POST /issues/:id/labels 体为 { label_id }。
+export function attachLabel(issueId: string, labelId: string): Promise<void> {
+  return httpPost<void>(`/issues/${issueId}/labels`, { label_id: labelId });
+}
+
+export function detachLabel(issueId: string, labelId: string): Promise<void> {
+  return httpDelete<void>(`/issues/${issueId}/labels/${labelId}`);
+}

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -59,6 +59,8 @@ export type IssueDateField = (typeof ISSUE_DATE_FIELDS)[number];
 
 export interface ListParams {
   workspace_id?: string;
+  // 客户端关键词过滤:projectApi/skillApi/squadApi/agentApi/runtimeApi 共用此字段。
+  // issue 列表不再用它(关键词走 searchIssues → /issues/search),但其它 list 端点仍需,勿删。
   keyword?: string;
   status?: IssueStatus;
   priority?: IssuePriority;
@@ -120,6 +122,11 @@ export interface Issue {
   creator_avatar?: string | null;
   // 后端 list/detail 端点批量回填；其它端点(update/ws)不带 → 保持已有。
   labels?: IssueLabel[] | null;
+  // 搜索结果专属(GET /issues/search):命中来源 + 高亮片段。列表/详情端点不返回。
+  match_source?: string;
+  matched_snippet?: string | null;
+  matched_description_snippet?: string | null;
+  matched_comment_snippet?: string | null;
 }
 
 export interface CreateIssueReq {

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -243,6 +243,11 @@
     "progress": "Progress",
     "lead": "Lead"
   },
+  "label": {
+    "add": "Add labels",
+    "newPlaceholder": "New label",
+    "create": "Create label"
+  },
   "agent": {
     "runtime": "Runtime",
     "model": "Model",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -243,6 +243,11 @@
     "progress": "进度",
     "lead": "负责人"
   },
+  "label": {
+    "add": "添加标签",
+    "newPlaceholder": "新标签名",
+    "create": "创建标签"
+  },
   "agent": {
     "runtime": "运行环境",
     "model": "模型",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -13,7 +13,7 @@ import { Search, Plus, LayoutGrid, List as ListIcon, ClipboardList, ArrowUp, Arr
 import { useI18n, WKApp } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority, IssueSortField, IssueDateField } from "../api/types";
 import { ISSUE_SORT_FIELDS, ISSUE_DATE_FIELDS } from "../api/types";
-import { listIssues } from "../api/issueApi";
+import { listIssues, searchIssues } from "../api/issueApi";
 import { listProjectOptions } from "../api/directory";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import { ISSUE_STATUS_ORDER, PRIORITY_ORDER } from "../ui/meta";
@@ -63,28 +63,32 @@ export default function IssuePage() {
     const my = ++seq.current;
     setLoading(true);
     const paged = view === "list";
+    const kw = f.keyword.trim();
     // 时间范围:三参数须同时给且 start<end。onChange 已把 dateRange 归一为 undefined|[起,止]。
     // 止端 +1 日历日 → 半开区间,既含止日当天、又保证 start<end(即使起止同一天);setDate 处理 DST。
     const dr = f.dateRange;
     const endExclusive = dr && new Date(dr[1]);
     if (endExclusive) endExclusive.setDate(endExclusive.getDate() + 1);
-    listIssues({
-      keyword: f.keyword,
-      status: f.status,
-      priority: f.priority,
-      assignee_id: f.assignee,
-      creator_id: f.creator,
-      project_id: f.project,
-      date_field: dr ? f.dateField : undefined,
-      date_start: dr ? dr[0].toISOString() : undefined,
-      date_end: endExclusive ? endExclusive.toISOString() : undefined,
-      // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
-      sort_by: paged ? f.sortBy : undefined,
-      sort_direction: paged ? f.sortDir : undefined,
-      // ponytail: 看板不分页——按 status 分列需全量，取后端上限 100；超量请用筛选或列表视图。
-      limit: paged ? PAGE_SIZE : 100,
-      offset: paged ? page * PAGE_SIZE : 0,
-    })
+    // 有关键词 → 走全文搜索端点(独立语义:后端不吃其它筛选/排序、上限 50);否则常规筛选列表。
+    const req = kw
+      ? searchIssues(kw, { limit: paged ? PAGE_SIZE : 50, offset: paged ? page * PAGE_SIZE : 0 })
+      : listIssues({
+          status: f.status,
+          priority: f.priority,
+          assignee_id: f.assignee,
+          creator_id: f.creator,
+          project_id: f.project,
+          date_field: dr ? f.dateField : undefined,
+          date_start: dr ? dr[0].toISOString() : undefined,
+          date_end: endExclusive ? endExclusive.toISOString() : undefined,
+          // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
+          sort_by: paged ? f.sortBy : undefined,
+          sort_direction: paged ? f.sortDir : undefined,
+          // ponytail: 看板不分页——按 status 分列需全量，取后端上限 100；超量请用筛选或列表视图。
+          limit: paged ? PAGE_SIZE : 100,
+          offset: paged ? page * PAGE_SIZE : 0,
+        });
+    req
       .then(({ issues, total }) => {
         if (my !== seq.current) return; // 有更新的请求在途，丢弃本次过期响应
         // 删除/改状态使匹配数下降时，当前 page 可能越界（offset≥total）→ 钳到最后一页并重取。

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -46,7 +46,7 @@ import {
 } from "../api/issueApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
-import LabelChips from "../ui/LabelChips";
+import LabelEditor from "../ui/LabelEditor";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -125,6 +125,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setIssue({ ...(await enrichIssue(updated)), labels: updated.labels ?? issue.labels });
     onChanged?.();
   };
+
+  // 轻量刷新 issue(标签挂/摘后重取 detail,含最新 labels;不重置草稿、不整页 loading)。
+  const syncIssue = () => getIssue(issueId).then(setIssue).catch(() => {});
 
   const submitComment = async () => {
     const content = commentDraft.trim();
@@ -559,7 +562,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               </dd>
               <dt>{t("loop.field.labels")}</dt>
               <dd>
-                {issue.labels && issue.labels.length > 0 ? <LabelChips labels={issue.labels} /> : <Text type="tertiary">—</Text>}
+                <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(); onChanged?.(); }} />
               </dd>
               <dt>{t("loop.field.startDate")}</dt>
               <dd>

--- a/packages/dmloop/src/ui/LabelEditor.tsx
+++ b/packages/dmloop/src/ui/LabelEditor.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import { Dropdown, Input, Button, Toast } from "@douyinfe/semi-ui";
+import { Check, Plus } from "lucide-react";
+import { useI18n } from "@octo/base";
+import type { IssueLabel } from "../api/types";
+import { listLabels, createLabel, attachLabel, detachLabel } from "../api/labelApi";
+import LabelChips from "./LabelChips";
+
+// issue 标签编辑器:点开下拉列出工作区标签(勾选=挂/摘),底部内联建新标签并挂上。
+// UI 从简(默认色,取色器等留待 UI 定稿);核心是把挂/摘/建标签能力接上后端。
+export default function LabelEditor({
+  issueId,
+  labels,
+  onChanged,
+}: {
+  issueId: string;
+  labels?: IssueLabel[] | null;
+  onChanged: () => void;
+}) {
+  const { t } = useI18n();
+  const [all, setAll] = useState<IssueLabel[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [newName, setNewName] = useState("");
+  const attached = new Set((labels ?? []).map((l) => l.id));
+
+  const loadAll = () => listLabels().then(setAll).catch(() => {});
+
+  const toggle = async (l: IssueLabel) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      if (attached.has(l.id)) await detachLabel(issueId, l.id);
+      else await attachLabel(issueId, l.id);
+      onChanged();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!name || busy) return;
+    setBusy(true);
+    try {
+      const label = await createLabel(name, "#8B5CF6"); // 默认紫,取色留待 UI 定稿
+      await attachLabel(issueId, label.id);
+      setNewName("");
+      await loadAll();
+      onChanged();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const menu = (
+    <Dropdown.Menu>
+      {all.map((l) => (
+        <Dropdown.Item key={l.id} onClick={() => toggle(l)}>
+          <span style={{ flex: 1, marginRight: 8 }}>{l.name}</span>
+          {attached.has(l.id) && <Check size={14} />}
+        </Dropdown.Item>
+      ))}
+      <Dropdown.Divider />
+      <div style={{ padding: "4px 8px", display: "flex", gap: 4 }} onClick={(e) => e.stopPropagation()}>
+        <Input
+          size="small"
+          value={newName}
+          onChange={setNewName}
+          placeholder={t("loop.label.newPlaceholder")}
+          onEnterPress={create}
+          style={{ width: 130 }}
+        />
+        <Button size="small" icon={<Plus size={14} />} onClick={create} loading={busy} aria-label={t("loop.label.create")} />
+      </div>
+    </Dropdown.Menu>
+  );
+
+  // clickToHide 默认 false:勾选多个标签时下拉保持打开;每次打开重新拉全量标签。
+  return (
+    <Dropdown trigger="click" position="bottomLeft" render={menu} onVisibleChange={(v) => v && loadAll()}>
+      <span style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 4 }}>
+        {labels && labels.length > 0 ? <LabelChips labels={labels} /> : <span style={{ opacity: 0.5 }}>{t("loop.label.add")}</span>}
+      </span>
+    </Dropdown>
+  );
+}


### PR DESCRIPTION
## What

第一枪「能力对齐」PR:关键词搜索 + 标签编辑。UI 保持最小(dmloop UI 后续会重做,当下把后端能力接进 API 层才是不会白做的部分)。

### 关键词搜索
- 新增 `searchIssues()` → `GET /issues/search`(后端对 标题/描述/评论 做全文检索并回高亮片段)。`IssuePage` 搜索框在有关键词时改走它;此前关键词被塞进 `/issues`(该端点根本不吃 keyword,等于空操作)。
- 搜索是独立端点/语义(不与筛选组合、后端上限 50),故单列函数;`listIssues` 不再发这个已死的 keyword 参数。

### 标签编辑
- 新增 `labelApi`:工作区标签 CRUD(`/labels`)+ issue 挂/摘(`/issues/:id/labels`)。
- 详情页标签行新增 `<LabelEditor>`:下拉勾选工作区标签挂/摘 + 内联建新标签。(取色器等留给 UI 重做。)

## Adversarial review(双模型)发现并已修的 2 个 bug
- label list 端点返回 `{labels:[...]}`(包裹,同 `/issues`)——客户端改为解包,否则下拉直接 crash。(Claude code-reviewer 抓到,codex:adversarial-review 漏掉——印证双模型价值。)
- 恢复 `ListParams.keyword`——它被另外 5 个 list 端点(project/skill/squad/agent/runtime)共用,只有 listIssues 停用它。(/simplify reuse agent 抓到 blast-radius。)

## /simplify
已跑:抽出 `fetchIssues()` 共享尾巴(list/search 共用 enrich+total)。

## 真实浏览器 e2e(dev 环境,Alice_Space / MV2 E2E 工作区)
- 搜索:输「头像」→ 精确命中 1 条(MVE-1),其余隐藏。
- 标签:新建「冒烟」→ 自动挂到 MVE-4;摘除 P0 → 详情+看板卡片同步变 冒烟/回归;列表/建新/挂/摘全绿。
- 测试数据按约定保留。

## Blast radius(模块外)
- `ListParams.keyword` 为共享字段,已确认 5 个下游 list 端点仍编译且行为不变(仅 issue 停用)。
- `labelApi` / `searchIssues` 为新增,无既有消费者。
- 整包 `tsc` clean。

Closes(能力对齐追踪,无单一 issue)。
