### PR TITLE
feat(loop): issue subscription + comment reactions (capability layer)

### DIFF
--- a/packages/dmloop/src/api/collabApi.ts
+++ b/packages/dmloop/src/api/collabApi.ts
@@ -1,0 +1,24 @@
+// @octo/loop — 协作 API(订阅 + 评论 emoji 反应,后端契约联调)。
+import type { IssueSubscriber } from "./types";
+import { httpGet, httpPost, httpDelete } from "./http";
+
+/* ---------- 订阅 ---------- */
+// subscribe/unsubscribe 均为 POST(不是 DELETE),body 可空 → 默认操作调用者本人;后端幂等。
+export function listSubscribers(issueId: string): Promise<IssueSubscriber[]> {
+  return httpGet<IssueSubscriber[]>(`/issues/${issueId}/subscribers`).then((r) => r ?? []);
+}
+export function subscribeIssue(issueId: string): Promise<void> {
+  return httpPost<void>(`/issues/${issueId}/subscribe`);
+}
+export function unsubscribeIssue(issueId: string): Promise<void> {
+  return httpPost<void>(`/issues/${issueId}/unsubscribe`);
+}
+
+/* ---------- 评论 emoji 反应 ---------- */
+// body 为 { emoji };删除也带 body,后端按 (actor, emoji) 定位并只删调用者自己那条。
+export function addCommentReaction(commentId: string, emoji: string): Promise<void> {
+  return httpPost<void>(`/comments/${commentId}/reactions`, { emoji });
+}
+export function removeCommentReaction(commentId: string, emoji: string): Promise<void> {
+  return httpDelete<void>(`/comments/${commentId}/reactions`, { emoji });
+}

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -178,6 +178,25 @@ export interface CommentTriggerAgent {
   name: string;
 }
 
+/** 评论 emoji 反应(后端 /comments/:id/reactions;list/timeline 端点按 comment 分组回填)。 */
+export interface CommentReaction {
+  id: string;
+  comment_id: string;
+  actor_type: string;
+  actor_id: string;
+  emoji: string;
+  created_at: string;
+}
+
+/** issue 订阅者(GET /issues/:id/subscribers)。reason: manual|creator|assignee|mention|... */
+export interface IssueSubscriber {
+  issue_id: string;
+  user_type: string;
+  user_id: string;
+  reason: string;
+  created_at: string;
+}
+
 export interface IssueComment {
   id: string;
   issue_id: string;
@@ -188,6 +207,8 @@ export interface IssueComment {
   created_at: string;
   author_name?: string | null;
   author_avatar?: string | null;
+  // 后端 list/timeline 端点按 comment 分组回填;其它端点不带 → 保持已有。
+  reactions?: CommentReaction[] | null;
 }
 
 export type TaskStatus =

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -248,6 +248,16 @@
     "newPlaceholder": "New label",
     "create": "Create label"
   },
+  "subscribe": {
+    "label": "Subscribers",
+    "subscribe": "Subscribe to issue",
+    "unsubscribe": "Unsubscribe",
+    "subscribed": "Subscribed",
+    "unsubscribed": "Unsubscribed"
+  },
+  "reaction": {
+    "add": "Add reaction"
+  },
   "agent": {
     "runtime": "Runtime",
     "model": "Model",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -248,6 +248,16 @@
     "newPlaceholder": "新标签名",
     "create": "创建标签"
   },
+  "subscribe": {
+    "label": "订阅者",
+    "subscribe": "订阅此 Issue",
+    "unsubscribe": "取消订阅",
+    "subscribed": "已订阅",
+    "unsubscribed": "已取消订阅"
+  },
+  "reaction": {
+    "add": "添加反应"
+  },
   "agent": {
     "runtime": "运行环境",
     "model": "模型",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -23,11 +23,15 @@ import {
   Check,
   Square,
   RotateCcw,
+  SmilePlus,
+  Bell,
+  BellOff,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
   Issue,
   IssueComment,
+  IssueSubscriber,
   TaskRun,
   IssueStatus,
   IssuePriority,
@@ -44,6 +48,13 @@ import {
   updateComment,
   previewCommentTriggers,
 } from "../api/issueApi";
+import {
+  listSubscribers,
+  subscribeIssue,
+  unsubscribeIssue,
+  addCommentReaction,
+  removeCommentReaction,
+} from "../api/collabApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelEditor from "../ui/LabelEditor";
@@ -65,6 +76,9 @@ import "./issueDetail.css";
 
 const { Title, Text } = Typography;
 
+// 反应选择器的固定 emoji 集(轻量,够验证能力;完整 picker 留给 UI 重做)。
+const REACTION_EMOJIS = ["👍", "❤️", "🎉", "😄", "🚀", "👀"];
+
 function fmt(iso?: string | null): string {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -84,6 +98,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const { t } = useI18n();
   const [issue, setIssue] = useState<Issue | null>(null);
   const [comments, setComments] = useState<IssueComment[]>([]);
+  const [subscribers, setSubscribers] = useState<IssueSubscriber[]>([]);
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
   const [runOpen, setRunOpen] = useState(false);
@@ -113,6 +128,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       })
       .catch(() => Toast.error(t("loop.detail.notFound")))
       .finally(() => setLoading(false));
+    // 订阅者旁路加载:失败不影响主体渲染。
+    listSubscribers(issueId).then(setSubscribers).catch(() => {});
   };
 
   useEffect(reload, [issueId]);
@@ -128,6 +145,27 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   // 轻量刷新 issue(标签挂/摘后重取 detail,含最新 labels;不重置草稿、不整页 loading)。
   const syncIssue = () => getIssue(issueId).then(setIssue).catch(() => {});
+
+  // 订阅/取消订阅(后端默认操作调用者本人、幂等);两项都常驻,不猜"我是否已订阅"。
+  const toggleSubscribe = async (on: boolean) => {
+    try {
+      await (on ? subscribeIssue : unsubscribeIssue)(issueId);
+      setSubscribers(await listSubscribers(issueId));
+      Toast.success(t(on ? "loop.subscribe.subscribed" : "loop.subscribe.unsubscribed"));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    }
+  };
+
+  // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
+  const reactComment = async (commentId: string, emoji: string, add: boolean) => {
+    try {
+      await (add ? addCommentReaction : removeCommentReaction)(commentId, emoji);
+      setComments(await listComments(issueId));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    }
+  };
 
   const submitComment = async () => {
     const content = commentDraft.trim();
@@ -312,6 +350,13 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
+      <Dropdown.Item icon={<Bell size={13} />} onClick={() => toggleSubscribe(true)}>
+        {t("loop.subscribe.subscribe")}
+      </Dropdown.Item>
+      <Dropdown.Item icon={<BellOff size={13} />} onClick={() => toggleSubscribe(false)}>
+        {t("loop.subscribe.unsubscribe")}
+      </Dropdown.Item>
+      <Dropdown.Divider />
       <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={handleDeleteIssue}>
         {t("loop.menu.deleteIssue")}
       </Dropdown.Item>
@@ -344,6 +389,38 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   const roots = comments.filter((c) => !c.parent_id);
   const repliesOf = (id: string) => comments.filter((c) => c.parent_id === id);
+
+  // 评论 emoji 反应条:已有反应按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
+  const renderReactions = (c: IssueComment) => {
+    const groups = new Map<string, number>();
+    (c.reactions ?? []).forEach((rx) => groups.set(rx.emoji, (groups.get(rx.emoji) ?? 0) + 1));
+    return (
+      <div className="loop-comment__reactions">
+        {[...groups.entries()].map(([emoji, n]) => (
+          <button key={emoji} type="button" className="loop-reaction" onClick={() => reactComment(c.id, emoji, false)}>
+            <span>{emoji}</span>
+            <b>{n}</b>
+          </button>
+        ))}
+        <Dropdown
+          trigger="click"
+          clickToHide
+          position="topLeft"
+          render={
+            <div className="loop-reaction-picker">
+              {REACTION_EMOJIS.map((e) => (
+                <button key={e} type="button" onClick={() => reactComment(c.id, e, true)}>{e}</button>
+              ))}
+            </div>
+          }
+        >
+          <button type="button" className="loop-reaction loop-reaction--add" aria-label={t("loop.reaction.add")}>
+            <SmilePlus size={13} />
+          </button>
+        </Dropdown>
+      </div>
+    );
+  };
 
   const renderComment = (c: IssueComment, reply = false) => (
     <div key={c.id} className={`loop-comment ${reply ? "is-reply" : ""}`}>
@@ -392,6 +469,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       ) : (
         <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
       )}
+      {renderReactions(c)}
       {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
       {!reply && replyTo === c.id && (
         <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
@@ -584,6 +662,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dt>{t("loop.detail.created")}</dt>
               <dd>
                 <Text type="tertiary" style={{ fontSize: 12 }}>{fmt(issue.created_at)}</Text>
+              </dd>
+              <dt>{t("loop.subscribe.label")}</dt>
+              <dd>
+                <Text type="tertiary" style={{ fontSize: 12 }}>{subscribers.length}</Text>
               </dd>
             </dl>
           </div>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -162,3 +162,20 @@
   margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.5;
   font-family: var(--semi-font-family-mono, monospace); max-height: 200px; overflow: auto;
 }
+
+/* 评论 emoji 反应条(PR-B 协作层) */
+.loop-comment__reactions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 6px; }
+.loop-reaction {
+  display: inline-flex; align-items: center; gap: 3px; padding: 1px 7px;
+  border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 11px;
+  background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-1, #4e5969);
+  font-size: 12px; line-height: 18px; cursor: pointer;
+}
+.loop-reaction:hover { background: var(--semi-color-fill-1, #eef0f3); }
+.loop-reaction--add { color: var(--semi-color-text-2, #8590a6); padding: 2px 6px; }
+.loop-reaction-picker { display: flex; gap: 4px; padding: 6px 8px; }
+.loop-reaction-picker button {
+  border: none; background: transparent; cursor: pointer; font-size: 17px;
+  line-height: 1; padding: 2px 4px; border-radius: 6px;
+}
+.loop-reaction-picker button:hover { background: var(--semi-color-fill-1, #eef0f3); }


### PR DESCRIPTION
## What

第二枪「能力对齐」PR:issue 订阅 + 评论 emoji 反应。UI 保持最小(dmloop UI 后续会重做,当下把后端协作端点接进 API 层才是不会白做的部分)。

### 订阅
- 新增 `collabApi`:`listSubscribers` + `subscribe`/`unsubscribe`(**都是 POST** —— 后端路由是 `POST /issues/:id/(un)subscribe`,不是 DELETE;body 可空则默认操作调用者)。
- 详情页 more 菜单加「订阅 / 取消订阅」两个**幂等**项(而非 toggle:前端无「当前成员身份」可判断「我是否已订阅」;后端 add 是 upsert、remove 是按 actor 定位的 no-op,两项都安全)。侧栏显示订阅者数。

### 评论 emoji 反应
- `addCommentReaction`(POST)/ `removeCommentReaction`(DELETE 带 `{emoji}` body),端点 `/comments/:id/reactions`。`IssueComment` 加可选 `reactions[]`(list 端点 `ListComments` 已 groupReactions 回填,**不改数据源**)。
- 每条评论加反应条:按 emoji 分组的「emoji×计数」chip(点 chip 删自己那条)+ 一个「+」选择器从固定小集合加。

## 明确延后(避免白做 UI)
- **timeline / 活动流**、**issue 级反应** —— 它们的渲染表面正是 UI 重做要定的东西;订阅 toggle 同样等「当前成员」查询就位后再做。

## 审查(全绿)
- **/simplify**(4 agent):抽出 `renderReactions` helper 去掉 JSX 内 IIFE;reuse/efficiency/altitude 均 clean。
- **双模型对抗审查**:Claude code-reviewer + `codex:adversarial-review` 均 clean —— 端点 method/path 对齐 `octo-multica/server/cmd/server/router.go`(subscribe POST、reaction 删除 DELETE 带 body)、reactions 经 `ListComments` 往返、`IssueComment.reactions` 为可选故 blast-radius 受控(全包仅 3 文件引用 `IssueComment`)。
- **真实浏览器 e2e**(dev / Alice_Space / MV2 E2E):订阅者 3→4、取消订阅 no-op(Alice 不在原 3 人内);评论反应 加 🎉(chip 出现)/ 删(chip 消失);列表/详情同步。测试数据按约定保留。

## Blast radius(模块外)
- `IssueComment` 仅新增可选字段 `reactions`,IssueList/IssueBoard 等不消费 `IssueComment`,无破坏。
- `collabApi` / `CommentReaction` / `IssueSubscriber` 为新增,无既有消费者。
- 整包 `tsc --skipLibCheck` 仅 2 处**既有**报错(module.tsx / ProjectDetailPage,非本 PR),PR-B 文件零错误。

基于最新 `feat/octo-loop`(#635 已合入)。
