### PR TITLE
feat(loop): sub-issues + issue field editing (capability layer)

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -72,6 +72,13 @@ export async function getIssue(id: string): Promise<Issue> {
   return enrichIssue(issue);
 }
 
+// 子 issue 列表(GET /issues/:id/children):后端包裹 { issues }。子项含 status,
+// 进度(done/total)由页面本地算,不再调批量 /child-progress(那是列表/看板用的)。
+export async function listChildren(id: string): Promise<Issue[]> {
+  const data = await httpGet<{ issues?: Issue[] }>(`/issues/${id}/children`);
+  return enrich(data?.issues ?? []);
+}
+
 export function createIssue(req: CreateIssueReq): Promise<Issue> {
   return httpPost<Issue>("/issues", req);
 }

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -147,6 +147,13 @@ export interface UpdateIssueReq {
   assignee_id?: string | null;
   project_id?: string | null;
   position?: number;
+  // 后端按 rawFields 存在性判断：省略=不动；传值=设置；传 ""/null=清除。
+  // start_date/due_date 为日历日 "YYYY-MM-DD"(后端 ParseCalendarDate)。
+  // parent_issue_id 设置时后端做环检测(不能设自己或后代为父)。stage 需 >= 1。
+  start_date?: string | null;
+  due_date?: string | null;
+  parent_issue_id?: string | null;
+  stage?: number | null;
   // 指派/状态变更触发 agent run 时：suppress_run=true 表示“暂不开始”；handoff_note 仅在真起 run 时消费。
   suppress_run?: boolean;
   handoff_note?: string;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -137,7 +137,10 @@
     "creator": "Creator",
     "labels": "Labels",
     "startDate": "Start date",
-    "dueDate": "Due date"
+    "dueDate": "Due date",
+    "parent": "Parent issue",
+    "noParent": "No parent",
+    "stage": "Stage"
   },
   "status": {
     "backlog": "Backlog",
@@ -254,6 +257,9 @@
     "unsubscribe": "Unsubscribe",
     "subscribed": "Subscribed",
     "unsubscribed": "Unsubscribed"
+  },
+  "subIssue": {
+    "title": "Sub-issues"
   },
   "reaction": {
     "add": "Add reaction"

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -137,7 +137,10 @@
     "creator": "创建者",
     "labels": "标签",
     "startDate": "开始日期",
-    "dueDate": "截止日期"
+    "dueDate": "截止日期",
+    "parent": "父 Issue",
+    "noParent": "无父 Issue",
+    "stage": "阶段"
   },
   "status": {
     "backlog": "待规划",
@@ -254,6 +257,9 @@
     "unsubscribe": "取消订阅",
     "subscribed": "已订阅",
     "unsubscribed": "已取消订阅"
+  },
+  "subIssue": {
+    "title": "子 Issue"
   },
   "reaction": {
     "add": "添加反应"

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Typography,
   Input,
@@ -11,6 +11,9 @@ import {
   Popconfirm,
   TextArea,
   Dropdown,
+  DatePicker,
+  InputNumber,
+  Progress,
 } from "@douyinfe/semi-ui";
 import {
   ArrowLeft,
@@ -43,6 +46,8 @@ import {
   enrichIssue,
   deleteIssue,
   listComments,
+  listChildren,
+  listIssues,
   addComment,
   deleteComment,
   updateComment,
@@ -70,7 +75,6 @@ import {
   PRIORITY_COLOR,
   RUN_STATUS_COLOR,
   isActiveRun,
-  isOverdue,
 } from "../ui/meta";
 import "./issueDetail.css";
 
@@ -99,6 +103,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [issue, setIssue] = useState<Issue | null>(null);
   const [comments, setComments] = useState<IssueComment[]>([]);
   const [subscribers, setSubscribers] = useState<IssueSubscriber[]>([]);
+  const [children, setChildren] = useState<Issue[]>([]);
+  const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
   const [runOpen, setRunOpen] = useState(false);
@@ -116,35 +122,64 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [editDraft, setEditDraft] = useState("");
   const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
 
+  // 每次 reload 递增;异步响应回来前先比对 token,丢弃 issueId 原地切换后到达的旧请求结果,
+  // 防止慢请求(issue A)在切到 B 后把 A 的数据写进 B 的视图(导航竞态)。
+  const reqRef = useRef(0);
+
   const reload = () => {
+    const token = ++reqRef.current;
+    const fresh = () => token === reqRef.current;
     setLoading(true);
+    // 重置随 issueId 变化的异步辅助 state:避免 issueId 原地切换时(如后续点子项跳转)
+    // 短暂残留上一个 issue 的子列表、订阅者、父候选(旧候选还会漏掉新的自己)。
+    setChildren([]);
+    setSubscribers([]);
+    setParentCands([]);
     Promise.all([getIssue(issueId), listComments(issueId), listRuns(issueId)])
       .then(([i, c, r]) => {
+        if (!fresh()) return;
         setIssue(i);
         setComments(c);
         setRuns(r);
         setTitleDraft(i?.title ?? "");
         setDescDraft(i?.description ?? "");
       })
-      .catch(() => Toast.error(t("loop.detail.notFound")))
-      .finally(() => setLoading(false));
-    // 订阅者旁路加载:失败不影响主体渲染。
-    listSubscribers(issueId).then(setSubscribers).catch(() => {});
+      .catch(() => { if (fresh()) Toast.error(t("loop.detail.notFound")); })
+      .finally(() => { if (fresh()) setLoading(false); });
+    // 订阅者、子 issue 旁路加载:失败不影响主体渲染;同样按 token 丢弃过期响应。
+    listSubscribers(issueId).then((s) => { if (fresh()) setSubscribers(s); }).catch(() => {});
+    listChildren(issueId).then((c) => { if (fresh()) setChildren(c); }).catch(() => {});
   };
 
   useEffect(reload, [issueId]);
 
   const patch = async (p: Parameters<typeof updateIssue>[1]) => {
     if (!issue) return;
-    const updated = await updateIssue(issue.id, p);
-    // PUT 响应不带 labels(仅 list/detail 端点回填);re-enrich 修回 assignee_name/project_name
-    // 等展示字段(按新值重算),labels 保留当前值,避免编辑后属性栏字段被清成空。
-    setIssue({ ...(await enrichIssue(updated)), labels: updated.labels ?? issue.labels });
-    onChanged?.();
+    try {
+      const updated = await updateIssue(issue.id, p);
+      // PUT 响应不带 labels(仅 list/detail 端点回填);re-enrich 修回 assignee_name/project_name
+      // 等展示字段(按新值重算),labels 保留当前值,避免编辑后属性栏字段被清成空。
+      setIssue({ ...(await enrichIssue(updated)), labels: updated.labels ?? issue.labels });
+      onChanged?.();
+    } catch (e) {
+      // 后端可能拒绝(如父 issue 环检测、非法日期):给出反馈,避免静默失败。
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    }
   };
 
   // 轻量刷新 issue(标签挂/摘后重取 detail,含最新 labels;不重置草稿、不整页 loading)。
   const syncIssue = () => getIssue(issueId).then(setIssue).catch(() => {});
+
+  // 父 issue 选择器:下拉展开时懒加载工作区 issue 作候选(排除自己;环检测由后端兜底)。
+  const loadParentCands = (open: boolean) => {
+    if (!open || parentCands.length) return;
+    const token = reqRef.current;
+    // ponytail: 取前 100 条工作区 issue + Select 客户端过滤;小工作区够用,
+    // 大工作区需服务端 search-as-you-type,留给 UI 重做。
+    listIssues({ limit: 100 })
+      .then((r) => { if (token === reqRef.current) setParentCands(r.issues.filter((i) => i.id !== issueId)); })
+      .catch(() => {});
+  };
 
   // 订阅/取消订阅(后端默认操作调用者本人、幂等);两项都常驻,不猜"我是否已订阅"。
   const toggleSubscribe = async (on: boolean) => {
@@ -389,6 +424,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   const roots = comments.filter((c) => !c.parent_id);
   const repliesOf = (id: string) => comments.filter((c) => c.parent_id === id);
+  const childrenDone = children.filter((c) => c.status === "done").length;
 
   // 评论 emoji 反应条:已有反应按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
   const renderReactions = (c: IssueComment) => {
@@ -540,6 +576,29 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             )}
           </div>
 
+          {children.length > 0 && (
+            <div className="loop-idp__section">
+              <div className="loop-detail__section-title">
+                {t("loop.subIssue.title")} ({childrenDone}/{children.length})
+              </div>
+              <Progress
+                percent={Math.round((childrenDone / children.length) * 100)}
+                style={{ marginBottom: 10 }}
+              />
+              <div className="loop-subissues">
+                {children.map((c) => (
+                  <div key={c.id} className="loop-subissue">
+                    <Tag color={ISSUE_STATUS_COLOR[c.status]} size="small">
+                      {t(`loop.status.${c.status}`)}
+                    </Tag>
+                    <span className="loop-subissue__id">{c.identifier}</span>
+                    <span className="loop-subissue__title">{c.title}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="loop-idp__section">
             <div className="loop-detail__section-title">
               {t("loop.detail.comments")} ({comments.length})
@@ -642,18 +701,58 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dd>
                 <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(); onChanged?.(); }} />
               </dd>
+              <dt>{t("loop.field.parent")}</dt>
+              <dd>
+                <Select
+                  value={issue.parent_issue_id ?? undefined}
+                  onChange={(v) => patch({ parent_issue_id: (v as string) || "" })}
+                  onDropdownVisibleChange={loadParentCands}
+                  placeholder={t("loop.field.noParent")}
+                  size="small"
+                  filter
+                  showClear
+                  style={{ width: "100%" }}
+                >
+                  {parentCands.map((i) => (
+                    <Select.Option key={i.id} value={i.id}>
+                      {i.identifier} {i.title}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </dd>
               <dt>{t("loop.field.startDate")}</dt>
               <dd>
-                <Text type="tertiary" style={{ fontSize: 12 }}>{fmt(issue.start_date)}</Text>
+                <DatePicker
+                  type="date"
+                  format="yyyy-MM-dd"
+                  value={issue.start_date ? issue.start_date.slice(0, 10) : undefined}
+                  onChange={(_, ds) => patch({ start_date: (ds as string) || "" })}
+                  size="small"
+                  style={{ width: "100%" }}
+                />
               </dd>
               <dt>{t("loop.field.dueDate")}</dt>
               <dd>
-                <Text
-                  type={isOverdue(issue.due_date, issue.status) ? "danger" : "tertiary"}
-                  style={{ fontSize: 12 }}
-                >
-                  {fmt(issue.due_date)}
-                </Text>
+                <DatePicker
+                  type="date"
+                  format="yyyy-MM-dd"
+                  value={issue.due_date ? issue.due_date.slice(0, 10) : undefined}
+                  onChange={(_, ds) => patch({ due_date: (ds as string) || "" })}
+                  size="small"
+                  style={{ width: "100%" }}
+                />
+              </dd>
+              <dt>{t("loop.field.stage")}</dt>
+              <dd>
+                <InputNumber
+                  value={issue.stage ?? undefined}
+                  // 仅在有效数字时提交:编辑中退格清空会以空值触发 onChange,
+                  // 忽略它可避免误发 stage=null(unstage)+ 竞态。清 stage 待 UI 重做。
+                  onChange={(v) => { if (typeof v === "number") patch({ stage: v }); }}
+                  min={1}
+                  size="small"
+                  style={{ width: "100%" }}
+                />
               </dd>
               <dt>{t("loop.field.creator")}</dt>
               <dd>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -179,3 +179,13 @@
   line-height: 1; padding: 2px 4px; border-radius: 6px;
 }
 .loop-reaction-picker button:hover { background: var(--semi-color-fill-1, #eef0f3); }
+
+/* 子 issue 列表(PR-C) */
+.loop-subissues { display: flex; flex-direction: column; gap: 6px; }
+.loop-subissue {
+  display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 8px;
+  font-size: 13px;
+}
+.loop-subissue__id { color: var(--semi-color-text-2, #8590a6); font-size: 12px; flex-shrink: 0; }
+.loop-subissue__title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## What

第三枪「能力对齐」PR:子 issue + issue 字段编辑。UI 保持最小(dmloop UI 后续会重做,当下把字段编辑 + 子 issue 端点接进 API 层才是不会白做的部分)。

### 字段编辑(详情页侧栏)
- `UpdateIssueReq` 扩 `start_date`/`due_date`/`parent_issue_id`/`stage`。后端按 `rawFields` 存在性门控、`JSON.stringify` 丢 `undefined`,故 `patch()` 只发被改字段(省略=不动、`""`=清除)。
- start/due:只读文本 → 可编辑 `DatePicker`(yyyy-MM-dd);父 Issue:懒加载工作区 issue 的 `Select`(后端做环检测);stage:`InputNumber`。

### 子 issue
- `listChildren()` → `GET /issues/:id/children`;只读「子 Issue」区列出子项 + `done/total` 进度条(进度由子项 status 本地算,详情页无需再调批量 `/child-progress`)。

## 对抗审查发现并已修(全部提交前,双模型)
- **patch 无错误反馈** → 加 try/catch + Toast,后端拒绝(父环检测、非法日期)不再静默失败;这是所有字段编辑的共享漏斗,status/priority/assignee 也一并获得反馈;失败时 issue state 不变,受控输入自动回退。(Claude)
- **stage InputNumber 退格清空触发 spurious `patch({stage:null})`** → 改为仅在有效数字时提交。(Claude)
- **导航竞态**:reload 重置 children/subscribers/parentCands + `reqRef` request-token 守卫所有异步 setter,慢请求(issue A)不会在切到 B 后把 A 的数据写进 B(子区未来引出「点子项跳转」正会触发)。(codex,两轮)

## /simplify(4 agent)
reuse/simplification/efficiency/altitude 全 clean;采纳一条:给 100 条父候选上限加 `// ponytail:` 注释。altitude agent 评价共享 patch 的错误处理是「exemplary sink」(根因层)。

## 真实浏览器 e2e(dev / Alice_Space / MV2 E2E)
- 字段编辑:stage 落库回显、截止日期显示/编辑、父 Issue 选择器候选懒加载(排除自己)。
- 子 issue 闭环:设 MVE-1 父=MVE-4 → MVE-4「子 Issue (0/1)」显示 MVE-1(审核中,进度 0/1 正确)。
- token 守卫复验不破坏 happy path(children/subscribers/stage/日期全正常填充,无错误 toast)。
- 测试数据按约定保留。

## Blast radius(模块外)
- `UpdateIssueReq` 全为可选新增字段;IssueList/IssueBoard 等其它 `updateIssue` 调用者只发各自字段,`JSON.stringify` 丢 undefined → 与后端 rawFields 门控一致,无破坏。
- `listChildren` 复用既有 `enrich`;无新消费者破坏。整包 `tsc --skipLibCheck` 仅 2 处既有报错(非本 PR),PR-C 文件零错误。

基于最新 `feat/octo-loop`(#636 已合入)。
