### PR TITLE
fix: preserve adaptive card table rendering in production

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -4,7 +4,7 @@
 // HostConfig 颜色经可注入解析器映射自 --wk-* token。
 
 import { describe, expect, it, vi } from "vitest";
-import { FontType, GlobalRegistry } from "adaptivecards";
+import { FontType, GlobalRegistry, Table, Versions } from "adaptivecards";
 import { createOctoSerializationContext } from "../sdk/octoSerialization";
 import { buildOctoHostConfig } from "../sdk/octoHostConfig";
 
@@ -57,6 +57,7 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
       const ctx = createOctoSerializationContext();
       expect(ctx.elementRegistry.findByName("Table")).toBeDefined();
     } finally {
+      GlobalRegistry.defaultElements.register("Table", Table, Versions.v1_5);
       GlobalRegistry.reset();
     }
   });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/octoSdkConfig.test.ts
@@ -4,7 +4,7 @@
 // HostConfig 颜色经可注入解析器映射自 --wk-* token。
 
 import { describe, expect, it, vi } from "vitest";
-import { FontType } from "adaptivecards";
+import { FontType, GlobalRegistry } from "adaptivecards";
 import { createOctoSerializationContext } from "../sdk/octoSerialization";
 import { buildOctoHostConfig } from "../sdk/octoHostConfig";
 
@@ -48,6 +48,16 @@ describe("createOctoSerializationContext — 元素层防御纵深", () => {
     // 非白名单元素被移除。
     for (const t of ["Carousel", "Media"]) {
       expect(reg.findByName(t)).toBeUndefined();
+    }
+  });
+
+  it("Table 不依赖 adaptivecards 全局注册副作用，production tree-shaking 后仍可用", () => {
+    GlobalRegistry.defaultElements.unregister("Table");
+    try {
+      const ctx = createOctoSerializationContext();
+      expect(ctx.elementRegistry.findByName("Table")).toBeDefined();
+    } finally {
+      GlobalRegistry.reset();
     }
   });
 });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoSerialization.ts
@@ -2,6 +2,7 @@ import {
   CardObjectRegistry,
   GlobalRegistry,
   SerializationContext,
+  Table,
   Versions,
   type Action,
   type CardElement,
@@ -50,6 +51,9 @@ export function createOctoSerializationContext(): SerializationContext {
 
   const elementRegistry = new CardObjectRegistry<CardElement>();
   GlobalRegistry.populateWithDefaultElements(elementRegistry);
+  // adaptivecards 声明了 sideEffects:false；production build 可能剪掉 lib/table.js
+  // 的默认注册副作用。Table 是 octo 白名单元素，需显式注册，不能依赖全局 registry。
+  elementRegistry.register("Table", Table, Versions.v1_5);
   for (const type of FORBIDDEN_ELEMENTS) {
     elementRegistry.unregister(type);
   }


### PR DESCRIPTION
## Summary
- Explicitly register AdaptiveCards Table in the octo serialization context instead of relying on the package global registration side effect.
- Add a regression test that unregisters the global Table entry and verifies the octo context still supports Table.

## Why
Production build can tree-shake AdaptiveCards table registration because the package declares sideEffects:false. Dev server can still render Table, while build output may drop the side-effect registration and render cards without the table section.

## Verification
- pnpm exec vitest run packages/dmworkbase/src/Messages/InteractiveCard/__tests__
- git diff --check
- pnpm --filter ./apps/web build