### PR TITLE
feat(loop): timeline feed + issue reactions + comment resolve (Phase C data layer)

### DIFF
--- a/packages/dmloop/src/api/collabApi.ts
+++ b/packages/dmloop/src/api/collabApi.ts
@@ -1,6 +1,7 @@
-// @octo/loop — 协作 API(订阅 + 评论 emoji 反应,后端契约联调)。
-import type { IssueSubscriber } from "./types";
+// @octo/loop — 协作 API(订阅 + 评论/issue 反应 + 评论 resolve + 时间线,后端契约联调)。
+import type { IssueSubscriber, TimelineEntry, AssigneeType } from "./types";
 import { httpGet, httpPost, httpDelete } from "./http";
+import { ensureDirectory, actorName, actorAvatar } from "./directory";
 
 /* ---------- 订阅 ---------- */
 // subscribe/unsubscribe 均为 POST(不是 DELETE),body 可空 → 默认操作调用者本人;后端幂等。
@@ -21,4 +22,39 @@ export function addCommentReaction(commentId: string, emoji: string): Promise<vo
 }
 export function removeCommentReaction(commentId: string, emoji: string): Promise<void> {
   return httpDelete<void>(`/comments/${commentId}/reactions`, { emoji });
+}
+
+/* ---------- issue 级 emoji 反应 ---------- */
+// 与评论反应同形(body { emoji }、按 actor+emoji 定位);读回走 GetIssue 的 issue.reactions。
+export function addIssueReaction(issueId: string, emoji: string): Promise<void> {
+  return httpPost<void>(`/issues/${issueId}/reactions`, { emoji });
+}
+export function removeIssueReaction(issueId: string, emoji: string): Promise<void> {
+  return httpDelete<void>(`/issues/${issueId}/reactions`, { emoji });
+}
+
+/* ---------- 评论 resolve / unresolve ---------- */
+// POST/DELETE /comments/:id/resolve(无 body,返回该评论)。后端「一线程至多一条 resolved」,
+// resolve 一条会清同线程兄弟 → 调用方 resolve/unresolve 后重拉评论列表即可。
+export function resolveComment(commentId: string): Promise<void> {
+  return httpPost<void>(`/comments/${commentId}/resolve`);
+}
+export function unresolveComment(commentId: string): Promise<void> {
+  return httpDelete<void>(`/comments/${commentId}/resolve`);
+}
+
+/* ---------- 时间线 ---------- */
+// GET /issues/:id/timeline 不带分页参数 → 裸数组(ASC),合并 comment + activity。
+// 回填 actor 展示名/头像(directory 缓存);页面活动流只取 type==="activity"。
+export async function listTimeline(issueId: string): Promise<TimelineEntry[]> {
+  const [rows, dir] = await Promise.all([
+    httpGet<TimelineEntry[]>(`/issues/${issueId}/timeline`),
+    ensureDirectory(),
+  ]);
+  return (rows ?? []).map((e) => ({
+    ...e,
+    // actor_type 为 string(活动可能是 member/agent/squad/system 等);actorName 对未知有兜底。
+    actor_name: actorName(dir, e.actor_type as AssigneeType, e.actor_id),
+    actor_avatar: actorAvatar(dir, e.actor_type as AssigneeType, e.actor_id),
+  }));
 }

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -122,6 +122,8 @@ export interface Issue {
   creator_avatar?: string | null;
   // 后端 list/detail 端点批量回填；其它端点(update/ws)不带 → 保持已有。
   labels?: IssueLabel[] | null;
+  // issue 级 emoji 反应:仅详情端点(GetIssue)回填;list/update/ws 不带 → 保持已有。
+  reactions?: IssueReaction[] | null;
   // 搜索结果专属(GET /issues/search):命中来源 + 高亮片段。列表/详情端点不返回。
   match_source?: string;
   matched_snippet?: string | null;
@@ -195,6 +197,16 @@ export interface CommentReaction {
   created_at: string;
 }
 
+/** issue 级 emoji 反应(GET issue 详情回填 issue.reactions;POST/DELETE /issues/:id/reactions)。 */
+export interface IssueReaction {
+  id: string;
+  issue_id: string;
+  actor_type: string;
+  actor_id: string;
+  emoji: string;
+  created_at: string;
+}
+
 /** issue 订阅者(GET /issues/:id/subscribers)。reason: manual|creator|assignee|mention|... */
 export interface IssueSubscriber {
   issue_id: string;
@@ -202,6 +214,24 @@ export interface IssueSubscriber {
   user_id: string;
   reason: string;
   created_at: string;
+}
+
+/** issue 时间线条目(GET /issues/:id/timeline,不带分页参数时为裸数组、ASC)。
+ *  合并 comment + activity 两类;活动流只用 activity 类(action/details)。 */
+export interface TimelineEntry {
+  type: "activity" | "comment";
+  id: string;
+  actor_type: string;
+  actor_id: string;
+  created_at: string;
+  // activity 专属
+  action?: string;
+  details?: unknown;
+  // comment 专属(活动流不用,列全为完整性)
+  content?: string | null;
+  // 由 directory 回填(展示用)
+  actor_name?: string | null;
+  actor_avatar?: string | null;
 }
 
 export interface IssueComment {
@@ -216,6 +246,8 @@ export interface IssueComment {
   author_avatar?: string | null;
   // 后端 list/timeline 端点按 comment 分组回填;其它端点不带 → 保持已有。
   reactions?: CommentReaction[] | null;
+  // 已解决时间(resolve/unresolve);非空=该评论已标记为线程结论。后端一线程至多一条 resolved。
+  resolved_at?: string | null;
 }
 
 export type TaskStatus =

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -200,7 +200,13 @@
     "placeholder": "Write a comment…",
     "send": "Send",
     "willWake": "Will wake:",
-    "tapToSuppress": "(tap to skip one)"
+    "tapToSuppress": "(tap to skip one)",
+    "resolve": "Resolve",
+    "unresolve": "Unresolve",
+    "resolved": "Resolved"
+  },
+  "activity": {
+    "title": "Activity"
   },
   "toast": {
     "created": "Created",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -200,7 +200,13 @@
     "placeholder": "写下评论…",
     "send": "发送",
     "willWake": "将唤醒：",
-    "tapToSuppress": "(点击可跳过某个)"
+    "tapToSuppress": "(点击可跳过某个)",
+    "resolve": "标记解决",
+    "unresolve": "取消解决",
+    "resolved": "已解决"
+  },
+  "activity": {
+    "title": "活动"
   },
   "toast": {
     "created": "已创建",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -109,8 +109,10 @@ export default function IssuePage() {
   const switchView = (v: ViewMode) => { setView(v); setPage(0); };
 
   // 点击 Issue → 跳转独立详情页（push 到右主栏，返回可 pop）。
+  // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
+  // (如未来点子 issue 原地切换时,慢请求无法把旧 issue 数据写进新 issue 视图)。
   const openDetail = (id: string) => {
-    WKApp.routeRight.push(<IssueDetailPage issueId={id} onChanged={reload} />);
+    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={reload} />);
   };
 
   return (

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -35,6 +35,7 @@ import type {
   Issue,
   IssueComment,
   IssueSubscriber,
+  TimelineEntry,
   TaskRun,
   IssueStatus,
   IssuePriority,
@@ -59,6 +60,11 @@ import {
   unsubscribeIssue,
   addCommentReaction,
   removeCommentReaction,
+  addIssueReaction,
+  removeIssueReaction,
+  resolveComment,
+  unresolveComment,
+  listTimeline,
 } from "../api/collabApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
@@ -104,6 +110,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [comments, setComments] = useState<IssueComment[]>([]);
   const [subscribers, setSubscribers] = useState<IssueSubscriber[]>([]);
   const [children, setChildren] = useState<Issue[]>([]);
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
@@ -135,6 +142,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setChildren([]);
     setSubscribers([]);
     setParentCands([]);
+    setTimeline([]);
     Promise.all([getIssue(issueId), listComments(issueId), listRuns(issueId)])
       .then(([i, c, r]) => {
         if (!fresh()) return;
@@ -146,9 +154,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       })
       .catch(() => { if (fresh()) Toast.error(t("loop.detail.notFound")); })
       .finally(() => { if (fresh()) setLoading(false); });
-    // 订阅者、子 issue 旁路加载:失败不影响主体渲染;同样按 token 丢弃过期响应。
+    // 订阅者、子 issue、时间线旁路加载:失败不影响主体渲染;同样按 token 丢弃过期响应。
     listSubscribers(issueId).then((s) => { if (fresh()) setSubscribers(s); }).catch(() => {});
     listChildren(issueId).then((c) => { if (fresh()) setChildren(c); }).catch(() => {});
+    listTimeline(issueId).then((tl) => { if (fresh()) setTimeline(tl); }).catch(() => {});
   };
 
   useEffect(reload, [issueId]);
@@ -157,9 +166,13 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (!issue) return;
     try {
       const updated = await updateIssue(issue.id, p);
-      // PUT 响应不带 labels(仅 list/detail 端点回填);re-enrich 修回 assignee_name/project_name
-      // 等展示字段(按新值重算),labels 保留当前值,避免编辑后属性栏字段被清成空。
-      setIssue({ ...(await enrichIssue(updated)), labels: updated.labels ?? issue.labels });
+      // PUT 响应不带 labels/reactions(仅 list/detail 端点回填);re-enrich 修回 assignee_name/
+      // project_name 等展示字段(按新值重算),labels/reactions 保留当前值,避免编辑后被清空。
+      setIssue({
+        ...(await enrichIssue(updated)),
+        labels: updated.labels ?? issue.labels,
+        reactions: updated.reactions ?? issue.reactions,
+      });
       onChanged?.();
     } catch (e) {
       // 后端可能拒绝(如父 issue 环检测、非法日期):给出反馈,避免静默失败。
@@ -167,8 +180,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     }
   };
 
-  // 轻量刷新 issue(标签挂/摘后重取 detail,含最新 labels;不重置草稿、不整页 loading)。
-  const syncIssue = () => getIssue(issueId).then(setIssue).catch(() => {});
+  // 轻量刷新 issue(标签挂/摘、反应后重取 detail,含最新 labels/reactions;不重置草稿、不整页 loading)。
+  // token 由调用方在 mutation 前捕获传入:issueId 原地切换后到达的旧结果丢弃(同 reload)。
+  const syncIssue = (token: number) =>
+    getIssue(issueId).then((i) => { if (token === reqRef.current) setIssue(i); }).catch(() => {});
+
+  // 变更后重取评论并写状态;token 同样由调用方在 mutation 前捕获传入(避免切 issue 后旧评论写进新视图)。
+  const reloadComments = async (token: number) => {
+    const c = await listComments(issueId);
+    if (token === reqRef.current) setComments(c);
+  };
 
   // 父 issue 选择器:下拉展开时懒加载工作区 issue 作候选(排除自己;环检测由后端兜底)。
   const loadParentCands = (open: boolean) => {
@@ -183,9 +204,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   // 订阅/取消订阅(后端默认操作调用者本人、幂等);两项都常驻,不猜"我是否已订阅"。
   const toggleSubscribe = async (on: boolean) => {
+    const token = reqRef.current;
     try {
       await (on ? subscribeIssue : unsubscribeIssue)(issueId);
-      setSubscribers(await listSubscribers(issueId));
+      const s = await listSubscribers(issueId);
+      if (token === reqRef.current) setSubscribers(s);
       Toast.success(t(on ? "loop.subscribe.subscribed" : "loop.subscribe.unsubscribed"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
@@ -194,9 +217,33 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
   const reactComment = async (commentId: string, emoji: string, add: boolean) => {
+    const token = reqRef.current;
     try {
       await (add ? addCommentReaction : removeCommentReaction)(commentId, emoji);
-      setComments(await listComments(issueId));
+      await reloadComments(token);
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    }
+  };
+
+  // issue 级 emoji 反应:同评论,读回走 getIssue 的 issue.reactions(syncIssue 重取详情)。
+  const reactIssue = async (emoji: string, add: boolean) => {
+    const token = reqRef.current;
+    try {
+      await (add ? addIssueReaction : removeIssueReaction)(issueId, emoji);
+      await syncIssue(token);
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    }
+  };
+
+  // 评论 resolve/unresolve:后端「一线程至多一条 resolved」会清同线程兄弟,操作后重拉评论即可。
+  // (resolve 只发实时事件、不写 activity_log,故活动流无需刷新。)
+  const toggleResolve = async (commentId: string, resolved: boolean) => {
+    const token = reqRef.current;
+    try {
+      await (resolved ? unresolveComment : resolveComment)(commentId);
+      await reloadComments(token);
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
     }
@@ -205,13 +252,14 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const submitComment = async () => {
     const content = commentDraft.trim();
     if (!content) return;
+    const token = reqRef.current;
     const suppressIds = triggerAgents.filter((a) => suppressed.has(a.id)).map((a) => a.id);
     await addComment(issueId, content, replyTo, suppressIds);
     setCommentDraft("");
     setReplyTo(null);
     setTriggerAgents([]);
     setSuppressed(new Set());
-    setComments(await listComments(issueId));
+    await reloadComments(token);
     Toast.success(t("loop.toast.commentAdded"));
   };
 
@@ -234,14 +282,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
 
   const removeComment = async (id: string) => {
+    const token = reqRef.current;
     await deleteComment(id);
-    setComments(await listComments(issueId));
+    await reloadComments(token);
     Toast.success(t("loop.toast.commentDeleted"));
   };
 
   const saveEdit = async (id: string) => {
     const content = editDraft.trim();
     if (!content) return;
+    const token = reqRef.current;
     try {
       await updateComment(id, content);
     } catch (e) {
@@ -250,7 +300,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     }
     // 编辑已落库；重拉以回填 directory 名字/头像。重拉失败不应报“编辑失败”。
     setEditingId(null);
-    setComments(await listComments(issueId));
+    await reloadComments(token);
     Toast.success(t("loop.toast.commentUpdated"));
   };
 
@@ -425,15 +475,20 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const roots = comments.filter((c) => !c.parent_id);
   const repliesOf = (id: string) => comments.filter((c) => c.parent_id === id);
   const childrenDone = children.filter((c) => c.status === "done").length;
+  // 活动流只取 activity 类(评论已在评论区渲染,避免重复)。filter 返回新数组,reverse 不改原 state。倒序:最新在上。
+  const activities = timeline.filter((e) => e.type === "activity").reverse();
 
-  // 评论 emoji 反应条:已有反应按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
-  const renderReactions = (c: IssueComment) => {
+  // emoji 反应条(评论 + issue 通用):按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
+  const renderReactionBar = (
+    reactions: Array<{ emoji: string }> | null | undefined,
+    onToggle: (emoji: string, add: boolean) => void,
+  ) => {
     const groups = new Map<string, number>();
-    (c.reactions ?? []).forEach((rx) => groups.set(rx.emoji, (groups.get(rx.emoji) ?? 0) + 1));
+    (reactions ?? []).forEach((rx) => groups.set(rx.emoji, (groups.get(rx.emoji) ?? 0) + 1));
     return (
       <div className="loop-comment__reactions">
         {[...groups.entries()].map(([emoji, n]) => (
-          <button key={emoji} type="button" className="loop-reaction" onClick={() => reactComment(c.id, emoji, false)}>
+          <button key={emoji} type="button" className="loop-reaction" onClick={() => onToggle(emoji, false)}>
             <span>{emoji}</span>
             <b>{n}</b>
           </button>
@@ -445,7 +500,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           render={
             <div className="loop-reaction-picker">
               {REACTION_EMOJIS.map((e) => (
-                <button key={e} type="button" onClick={() => reactComment(c.id, e, true)}>{e}</button>
+                <button key={e} type="button" onClick={() => onToggle(e, true)}>{e}</button>
               ))}
             </div>
           }
@@ -468,6 +523,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           {c.author_name}
         </Text>
         <time>{fmt(c.created_at)}</time>
+        {c.resolved_at && <Tag size="small" color="green">{t("loop.comment.resolved")}</Tag>}
         <div className="loop-comment__actions">
           {!reply && (
             <Button
@@ -477,6 +533,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               onClick={() => { setReplyTo(replyTo === c.id ? null : c.id); setEditingId(null); }}
             >
               {t("loop.comment.reply")}
+            </Button>
+          )}
+          {!reply && (
+            <Button
+              size="small"
+              theme="borderless"
+              icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />}
+              onClick={() => toggleResolve(c.id, !!c.resolved_at)}
+            >
+              {t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")}
             </Button>
           )}
           <Button
@@ -505,7 +571,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       ) : (
         <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
       )}
-      {renderReactions(c)}
+      {renderReactionBar(c.reactions, (emoji, add) => reactComment(c.id, emoji, add))}
       {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
       {!reply && replyTo === c.id && (
         <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
@@ -547,6 +613,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             onBlur={() => titleDraft.trim() && titleDraft !== issue.title && patch({ title: titleDraft.trim() })}
             style={{ fontWeight: 600, fontSize: 20 }}
           />
+
+          {/* issue 级 emoji 反应条 */}
+          {renderReactionBar(issue.reactions, reactIssue)}
 
           <div className="loop-idp__section">
             <div className="loop-detail__section-title loop-idp__desc-title">
@@ -593,6 +662,29 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                     </Tag>
                     <span className="loop-subissue__id">{c.identifier}</span>
                     <span className="loop-subissue__title">{c.title}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {activities.length > 0 && (
+            <div className="loop-idp__section">
+              <div className="loop-detail__section-title">
+                {t("loop.activity.title")} ({activities.length})
+              </div>
+              <div className="loop-activities">
+                {activities.map((a) => (
+                  <div key={a.id} className="loop-activity">
+                    <Avatar size="extra-extra-small" color="light-blue" src={a.actor_avatar ?? undefined}>
+                      {(a.actor_name ?? "?").slice(0, 1)}
+                    </Avatar>
+                    <Text style={{ fontSize: 12 }}>
+                      <strong>{a.actor_name ?? a.actor_id}</strong>{" "}
+                      {/* ponytail: 原样展示 action(如 status_changed);细化文案映射留给 UI 重做 */}
+                      <Text type="tertiary">{(a.action ?? "").replace(/_/g, " ")}</Text>
+                    </Text>
+                    <time>{fmt(a.created_at)}</time>
                   </div>
                 ))}
               </div>
@@ -699,7 +791,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               </dd>
               <dt>{t("loop.field.labels")}</dt>
               <dd>
-                <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(); onChanged?.(); }} />
+                <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
               </dd>
               <dt>{t("loop.field.parent")}</dt>
               <dd>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -189,3 +189,8 @@
 }
 .loop-subissue__id { color: var(--semi-color-text-2, #8590a6); font-size: 12px; flex-shrink: 0; }
 .loop-subissue__title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* 活动流(PR-D 时间线) */
+.loop-activities { display: flex; flex-direction: column; gap: 8px; }
+.loop-activity { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.loop-activity time { margin-left: auto; font-size: 11px; color: var(--semi-color-text-2, #8590a6); }


### PR DESCRIPTION
## What

补齐 **Phase C(协作层)数据层** —— 之前三枪能力对齐把协作层只做了一半(标签/订阅/评论反应),timeline 与 issue reactions 被我误延后。本 PR 收口。UI 保持最小(dmloop UI 后续重做),耐久的是把剩余协作端点接进 API 层。

- **活动流**:`listTimeline()` → `GET /issues/:id/timeline`(裸数组)。详情页新增只读「活动」区,渲染 activity 条目(状态/优先级/负责人变更、创建、任务完成)—— 这些审计历史此前在 dmloop 完全不可见。过滤 `type==='activity'` 避免与评论区重复。
- **issue 级反应**:`addIssueReaction`/`removeIssueReaction`;`issue.reactions` 经 `GetIssue`(详情端点填充,list/PUT 不填)读回。评论反应条泛化为 `renderReactionBar(reactions, onToggle)`,标题下的 issue 反应条复用它。
- **评论 resolve**:`resolveComment`/`unresolveComment`(POST/DELETE `/comments/:id/resolve`);根评论加 resolve/unresolve 切换 + 已解决徽标。

**纠正一处此前的错误延后**:issue reactions 曾以「无读回路径」为由被我从前面的 PR 剔除——错的,`GetIssue` 会返回它们(源码核实纠正了凭空判断)。

## 对抗审查发现并已修(全部提交前)
- **patch 会清空 issue.reactions**:PUT 响应不带 reactions → 编辑任意字段后 issue 反应条消失(与之前 labels 同类 bug)。已加 `reactions: updated.reactions ?? issue.reactions` 保留。(Claude)
- **导航竞态守卫捕获太晚**:所有 post-mutation 重取改为在 **mutation await 之前**捕获 `reqRef` token 并传入守卫版 `reloadComments(token)`/`syncIssue(token)`;去掉 syncIssue 默认 token 让 TS 强制显式传。(codex,3 轮)
- **结构性根治**:push 点加 `<IssueDetailPage key={id}>` —— issueId 变化即整页重挂载,任何 issue A 的慢响应都无法画进 issue B(含 LabelEditor→syncIssue 路径)。token 守卫退化为其上的 defense-in-depth。

## /simplify(4 agent)
- 删冗余 `.slice()`(filter 已返新数组);
- 删 resolve 后**浪费的** `listTimeline` 重拉(核实 octo-multica:resolve 只发实时事件、不写 activity_log,活动流不变);
- renderReactionBar 泛化、directory 复用、token 守卫模式复用均评为 clean。

## 真实浏览器 e2e(dev / Alice_Space / MV2 E2E)
- issue 反应:加 🚀 → 标题下反应条显示「🚀1」(reactIssue→syncIssue 读回 issue.reactions)。
- 评论 resolve:「标记解决」→ 已解决徽标 + 按钮变「取消解决」→ unresolve 复原。
- 活动流:MVE-4 显示「活动 (10)」—— created(wangdeng)/status changed×2/priority changed×4/assignee changed×2/task completed,均含 actor 名 + action + 时间。
- 测试数据按约定保留。

## Blast radius(模块外)
- `Issue.reactions`/`IssueComment.resolved_at`/`IssueReaction`/`TimelineEntry` 均为可选新增;IssueList/IssueBoard 不消费,无破坏。
- `IssuePage` 仅给 push 的 IssueDetailPage 加 `key`(只影响 issueId 变化时的重挂载,当前每次 push 本就新实例,行为不变)。
- 整包 `tsc --skipLibCheck` 仅 2 处既有报错(非本 PR),PR-D 文件零错误。

基于最新 `feat/octo-loop`(#635/#636/#637 已合入)。附件 UI / @提及 属重交互,继续缓做(需与王登细聊 UI 方向)。
