### PR TITLE
feat(loop): multi-file skill editor and revamped create flow

### DIFF
--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -261,6 +261,14 @@ export interface SkillOrigin {
   skill?: string;
   source_url?: string;
 }
+export interface SkillFile {
+  id: string;
+  skill_id: string;
+  path: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
 export interface Skill {
   id: string;
   workspace_id: string;
@@ -268,6 +276,7 @@ export interface Skill {
   description: string;
   config?: { origin?: SkillOrigin } & Record<string, unknown>;
   content?: string;
+  files?: SkillFile[];
   created_by?: string | null;
   created_at: string;
   updated_at: string;
@@ -276,6 +285,7 @@ export interface UpsertSkillReq {
   name: string;
   description?: string;
   content?: string;
+  files?: { path: string; content: string }[];
 }
 
 /** 从运行时拷贝技能：runtime 上发现的本地技能条目。 */

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -4,14 +4,14 @@
     "changeStatus": "Change status",
     "changePriority": "Change priority",
     "changeAssignee": "Change assignee",
-    "deleteIssue": "Delete issue"
+    "deleteIssue": "Delete Loop"
   },
   "nav": {
-    "issue": "Issue",
+    "issue": "Loop",
     "skill": "Skill",
     "project": "Project",
-    "agent": "Agent",
-    "squad": "Squad",
+    "agent": "AI teammate",
+    "squad": "AI squad",
     "runtime": "Runtimes",
     "settings": "Settings"
   },
@@ -36,11 +36,11 @@
     "list": "List"
   },
   "search": {
-    "issue": "Search issue / id",
+    "issue": "Search Loop / id",
     "skill": "Search skill",
     "project": "Search project",
-    "agent": "Search agent",
-    "squad": "Search squad"
+    "agent": "Search AI teammate",
+    "squad": "Search AI squad"
   },
   "filter": {
     "status": "Status",
@@ -64,11 +64,11 @@
     "due_date": "Due date"
   },
   "action": {
-    "newIssue": "New Issue",
+    "newIssue": "New Loop",
     "newSkill": "New Skill",
     "newProject": "New Project",
-    "newAgent": "New Agent",
-    "newSquad": "New Squad",
+    "newAgent": "New AI teammate",
+    "newSquad": "New AI squad",
     "create": "Create",
     "cancel": "Cancel",
     "save": "Save",
@@ -107,21 +107,21 @@
     "cancelled": "Cancelled"
   },
   "empty": {
-    "issue": "No issues",
+    "issue": "No Loops",
     "skill": "No skills",
     "project": "No projects",
-    "agent": "No agents",
-    "squad": "No squads",
-    "issueTitle": "No issues yet",
-    "issueDesc": "Create your first issue to start tracking work.",
+    "agent": "No AI teammates",
+    "squad": "No AI squads",
+    "issueTitle": "No Loops yet",
+    "issueDesc": "Create your first Loop to start tracking work.",
     "skillTitle": "No skills yet",
-    "skillDesc": "Create or import a skill for your agents to reuse.",
+    "skillDesc": "Create or import a skill for your AI teammates to reuse.",
     "projectTitle": "No projects yet",
-    "projectDesc": "Create a project to organize related issues.",
-    "agentTitle": "No agents yet",
-    "agentDesc": "Create an agent to automate your tasks.",
-    "squadTitle": "No squads yet",
-    "squadDesc": "Form a squad so members and agents collaborate."
+    "projectDesc": "Create a project to organize related Loops.",
+    "agentTitle": "No AI teammates yet",
+    "agentDesc": "Create an AI teammate to automate your tasks.",
+    "squadTitle": "No AI squads yet",
+    "squadDesc": "Form an AI squad so members and AI teammates collaborate."
   },
   "field": {
     "title": "Title",
@@ -173,21 +173,22 @@
   },
   "assignee": {
     "member": "Member",
-    "agent": "Agent",
-    "squad": "Squad",
+    "agent": "AI teammate",
+    "squad": "AI squad",
     "unassigned": "Unassigned"
   },
   "detail": {
-    "issueTitle": "Issue detail",
+    "issueTitle": "Loop detail",
     "skillTitle": "Skill detail",
     "projectTitle": "Project detail",
-    "agentTitle": "Agent detail",
-    "squadTitle": "Squad detail",
+    "agentTitle": "AI teammate detail",
+    "squadTitle": "AI squad detail",
     "notFound": "Item not found",
     "properties": "Properties",
     "comments": "Comments",
     "back": "Back",
     "created": "Created",
+    "updated": "Updated",
     "execLog": "Execution log",
     "execEmpty": "No runs yet"
   },
@@ -220,7 +221,7 @@
   },
   "confirm": {
     "delete": "Delete?",
-    "deleteIssue": "Delete this issue? This cannot be undone."
+    "deleteIssue": "Delete this Loop? This cannot be undone."
   },
   "skill": {
     "source": "Source",
@@ -230,6 +231,7 @@
       "workspace": "Workspace"
     },
     "usedBy": "Used by",
+    "usedCount": "{{count}} AI teammates",
     "content": "Content",
     "local": "Local",
     "fromWeb": "Copy from web",
@@ -240,7 +242,42 @@
     "importSelected": "Import selected",
     "imported": "Imported",
     "urlRequired": "URL is required",
-    "rtUnsupported": "This runtime does not support skill discovery"
+    "rtUnsupported": "This runtime does not support skill discovery",
+    "namePattern": "Skill names can only contain English letters, numbers, and hyphens (-)",
+    "importInvalidName": "Skipped {{name}}: skill names can only contain English letters, numbers, and hyphens (-)",
+    "create": {
+      "subtitle": "Choose a way to create — live preview on the right.",
+      "draft": "Blank draft",
+      "url": "Import from URL",
+      "runtime": "Copy from runtime",
+      "urlLabel": "Skill URL",
+      "supportedSources": "Supported sources",
+      "preview": "Preview",
+      "previewNote": "After creation it appears under workspace Skills and can be assigned to any AI teammate.",
+      "unnamed": "Untitled skill"
+    },
+    "detail": {
+      "files": "Files",
+      "noFiles": "No files",
+      "noContent": "No content",
+      "noDescription": "No description in SKILL.md frontmatter",
+      "preview": "Preview",
+      "edit": "Edit",
+      "deleteFile": "Delete file",
+      "usedAgents": "Used by {{count}} AI teammates",
+      "noUsedAgents": "No AI teammates use this yet",
+      "agentType": "AI teammate",
+      "contentPlaceholder": "Enter file content…",
+      "addFile": {
+        "add": "Add file",
+        "placeholder": "e.g. reference/guide.md",
+        "empty": "Path is required",
+        "absolute": "Path must not start with /",
+        "doubleDot": "Path must not contain ..",
+        "reserved": "SKILL.md is reserved",
+        "exists": "A file with this path already exists"
+      }
+    }
   },
   "project": {
     "progress": "Progress",
@@ -269,7 +306,7 @@
     "model": "Model",
     "runs30d": "Runs (30d)",
     "instructions": "Instructions",
-    "instructionsPlaceholder": "System prompt / agent behavior…",
+    "instructionsPlaceholder": "System prompt / AI teammate behavior…",
     "visibility": "Visibility",
     "visWorkspace": "Workspace",
     "visPrivate": "Private",
@@ -330,7 +367,7 @@
     "wsName": "Workspace name",
     "wsSlug": "Workspace slug",
     "slugHint": "Slug cannot be changed after creation",
-    "issuePrefix": "Issue prefix",
+    "issuePrefix": "Loop prefix",
     "role": "Role",
     "removeMember": "Remove member",
     "revokeInvite": "Revoke invitation",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -1,17 +1,17 @@
 {
   "menu": {
-    "title": "Loop",
+    "title": "回路",
     "changeStatus": "修改状态",
     "changePriority": "修改优先级",
     "changeAssignee": "修改负责人",
-    "deleteIssue": "删除 Issue"
+    "deleteIssue": "删除回路"
   },
   "nav": {
-    "issue": "Issue",
+    "issue": "回路",
     "skill": "技能",
     "project": "项目",
-    "agent": "智能体",
-    "squad": "小队",
+    "agent": "AI队友",
+    "squad": "AI小队",
     "runtime": "运行时",
     "settings": "设置"
   },
@@ -19,7 +19,7 @@
     "online": "在线",
     "offline": "离线",
     "empty": "暂无运行时",
-    "subtitle": "你名下的机器与运行时。工作区里的 AI 队友都跑在这里。",
+    "subtitle": "你名下的机器与运行时。工作区里的 AI队友都跑在这里。",
     "add": "添加电脑",
     "allSpace": "全部空间",
     "runtimeCount": "{{count}} 个运行时",
@@ -36,11 +36,11 @@
     "list": "列表"
   },
   "search": {
-    "issue": "搜索 Issue / 编号",
+    "issue": "搜索回路/ 编号",
     "skill": "搜索技能",
     "project": "搜索项目",
-    "agent": "搜索智能体",
-    "squad": "搜索小队"
+    "agent": "搜索 AI队友",
+    "squad": "搜索 AI小队"
   },
   "filter": {
     "status": "状态",
@@ -64,11 +64,11 @@
     "due_date": "截止日期"
   },
   "action": {
-    "newIssue": "新建 Issue",
+    "newIssue": "新建回路",
     "newSkill": "新建技能",
     "newProject": "新建项目",
-    "newAgent": "新建智能体",
-    "newSquad": "新建小队",
+    "newAgent": "新建 AI队友",
+    "newSquad": "新建 AI小队",
     "create": "创建",
     "cancel": "取消",
     "save": "保存",
@@ -83,11 +83,11 @@
     "nameRequired": "请填写工作区名称",
     "slugRequired": "请填写 slug",
     "emptyTitle": "还没有工作区",
-    "emptyDesc": "创建一个工作区开始使用 Loop。"
+    "emptyDesc": "创建一个工作区开始使用回路。"
   },
   "cliAuthorize": {
     "title": "授权当前电脑",
-    "description": "将当前电脑接入所选 Loop 工作区，授权后命令行会继续完成本机设备注册。",
+    "description": "将当前电脑接入所选回路工作区，授权后命令行会继续完成本机设备注册。",
     "authorize": "授权",
     "loading": "加载中",
     "workspaceLoading": "正在加载工作区",
@@ -107,21 +107,21 @@
     "cancelled": "已取消"
   },
   "empty": {
-    "issue": "暂无 Issue",
+    "issue": "暂无回路",
     "skill": "暂无技能",
     "project": "暂无项目",
-    "agent": "暂无智能体",
-    "squad": "暂无小队",
-    "issueTitle": "还没有 Issue",
-    "issueDesc": "创建第一个 Issue，开始跟踪你的工作。",
+    "agent": "暂无 AI队友",
+    "squad": "暂无 AI小队",
+    "issueTitle": "还没有回路",
+    "issueDesc": "创建第一个回路，开始跟踪你的工作。",
     "skillTitle": "还没有技能",
-    "skillDesc": "创建或导入技能，供智能体复用。",
+    "skillDesc": "创建或导入技能，供 AI队友复用。",
     "projectTitle": "还没有项目",
-    "projectDesc": "创建项目来组织相关的 Issue。",
-    "agentTitle": "还没有智能体",
-    "agentDesc": "创建智能体来自动处理你的任务。",
-    "squadTitle": "还没有小队",
-    "squadDesc": "组建小队，让成员与智能体协作。"
+    "projectDesc": "创建项目来组织相关的回路。",
+    "agentTitle": "还没有 AI队友",
+    "agentDesc": "创建 AI队友来自动处理你的任务。",
+    "squadTitle": "还没有 AI小队",
+    "squadDesc": "组建 AI小队，让成员与 AI队友协作。"
   },
   "field": {
     "title": "标题",
@@ -173,21 +173,22 @@
   },
   "assignee": {
     "member": "成员",
-    "agent": "智能体",
-    "squad": "小队",
+    "agent": "AI队友",
+    "squad": "AI小队",
     "unassigned": "未指派"
   },
   "detail": {
-    "issueTitle": "Issue 详情",
+    "issueTitle": "回路详情",
     "skillTitle": "技能详情",
     "projectTitle": "项目详情",
-    "agentTitle": "智能体详情",
-    "squadTitle": "小队详情",
+    "agentTitle": "AI队友详情",
+    "squadTitle": "AI小队详情",
     "notFound": "未找到该条目",
     "properties": "属性",
     "comments": "评论",
     "back": "返回",
     "created": "创建于",
+    "updated": "更新于",
     "execLog": "执行日志",
     "execEmpty": "暂无执行记录"
   },
@@ -220,7 +221,7 @@
   },
   "confirm": {
     "delete": "确定删除？",
-    "deleteIssue": "确定删除该 Issue？此操作不可撤销。"
+    "deleteIssue": "确定删除该回路？此操作不可撤销。"
   },
   "skill": {
     "source": "来源",
@@ -230,6 +231,7 @@
       "workspace": "工作区"
     },
     "usedBy": "被引用",
+    "usedCount": "{{count}} 个 AI队友",
     "content": "内容",
     "local": "本地",
     "fromWeb": "从 Web 拷贝",
@@ -240,7 +242,42 @@
     "importSelected": "导入所选",
     "imported": "已导入",
     "urlRequired": "请填写 URL",
-    "rtUnsupported": "该运行时不支持技能发现"
+    "rtUnsupported": "该运行时不支持技能发现",
+    "namePattern": "Skill 名称只能包含英文字母、数字和连字符 -",
+    "importInvalidName": "已跳过 {{name}}：Skill 名称只能包含英文字母、数字和连字符 -",
+    "create": {
+      "subtitle": "选一种方式创建，右侧实时预览。",
+      "draft": "空白起草",
+      "url": "从 URL 导入",
+      "runtime": "从运行时复制",
+      "urlLabel": "Skill URL",
+      "supportedSources": "支持的来源",
+      "preview": "预览",
+      "previewNote": "创建后出现在工作区 Skills，可分配给任意 AI队友。",
+      "unnamed": "未命名 Skill"
+    },
+    "detail": {
+      "files": "文件",
+      "noFiles": "暂无文件",
+      "noContent": "暂无内容",
+      "noDescription": "SKILL.md frontmatter 中暂无 description",
+      "preview": "预览",
+      "edit": "编辑",
+      "deleteFile": "删除文件",
+      "usedAgents": "被 {{count}} 个 AI队友使用",
+      "noUsedAgents": "暂无 AI队友使用",
+      "agentType": "AI队友",
+      "contentPlaceholder": "输入文件内容…",
+      "addFile": {
+        "add": "新增文件",
+        "placeholder": "例如 reference/guide.md",
+        "empty": "请填写路径",
+        "absolute": "路径不能以 / 开头",
+        "doubleDot": "路径不能包含 ..",
+        "reserved": "SKILL.md 为保留名",
+        "exists": "该路径的文件已存在"
+      }
+    }
   },
   "project": {
     "progress": "进度",
@@ -269,7 +306,7 @@
     "model": "模型",
     "runs30d": "近 30 天任务",
     "instructions": "指令",
-    "instructionsPlaceholder": "系统提示词 / 智能体行为定义…",
+    "instructionsPlaceholder": "系统提示词 / AI队友行为定义…",
     "visibility": "可见性",
     "visWorkspace": "工作区",
     "visPrivate": "私有",
@@ -330,7 +367,7 @@
     "wsName": "工作区名称",
     "wsSlug": "工作区 slug",
     "slugHint": "slug 创建后不可修改",
-    "issuePrefix": "Issue 前缀",
+    "issuePrefix": "回路前缀",
     "role": "角色",
     "removeMember": "移除成员",
     "revokeInvite": "撤销邀请",

--- a/packages/dmloop/src/pages/SkillPage.tsx
+++ b/packages/dmloop/src/pages/SkillPage.tsx
@@ -1,29 +1,52 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Typography, Input, Button, Table, Tag, Spin, Modal, Toast, Popconfirm, TextArea, Banner,
-  Tabs, TabPane, Select, Checkbox,
+  Typography, Input, Button, Tag, Spin, Modal, Toast, TextArea, Banner,
+  Select, Checkbox, Tooltip,
 } from "@douyinfe/semi-ui";
-import { Search, Plus, Trash2, Sparkles, Download, Monitor, Globe, FileText } from "lucide-react";
+import { Search, Plus, Trash2, Sparkles, Download, FileText, Link2, Copy, Clock3, Users } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Skill, RuntimeDevice, RuntimeLocalSkillSummary } from "../api/types";
+import type { I18nFormatter } from "@octo/base";
+import type { Agent, Skill, RuntimeDevice, RuntimeLocalSkillSummary } from "../api/types";
 import {
   listSkills, createSkill, deleteSkill, skillSource, importSkill,
   fetchRuntimeSkills, importRuntimeSkill,
 } from "../api/skillApi";
+import { listAgents } from "../api/agentApi";
 import { listRuntimes } from "../api/runtimeApi";
 import SkillDetailPage from "../panel/SkillDetailPage";
 import { confirmDelete } from "../ui/confirmDelete";
+import { isValidSkillName } from "../ui/skillName";
+import { ensureSkillFrontmatter, parseFrontmatter } from "../ui/frontmatter";
 
 const { Title, Text } = Typography;
 const SRC: Record<string, "green" | "blue" | "grey"> = { github: "green", local: "blue", workspace: "grey" };
+type CreateTab = "local" | "web" | "runtime";
+
+function formatSkillTime(value: string | undefined, format: Pick<I18nFormatter, "date" | "relativeTime">): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  const diff = date.getTime() - Date.now();
+  const absDiff = Math.abs(diff);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (absDiff < minute) return format.relativeTime(0, "minute");
+  if (absDiff < hour) return format.relativeTime(Math.round(diff / minute), "minute");
+  if (absDiff < day) return format.relativeTime(Math.round(diff / hour), "hour");
+  if (absDiff < 10 * day) return format.relativeTime(Math.round(diff / day), "day");
+  return format.date(date, { month: "short", day: "numeric" });
+}
 
 export default function SkillPage() {
-  const { t } = useI18n();
+  const { t, format } = useI18n();
   const [rows, setRows] = useState<Skill[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [keyword, setKeyword] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  const [createTab, setCreateTab] = useState<CreateTab>("local");
 
   // local
   const [nName, setNName] = useState("");
@@ -42,22 +65,49 @@ export default function SkillPage() {
 
   const reload = useCallback(() => {
     setLoading(true); setError(null);
-    listSkills({ keyword }).then(setRows).catch((e) => setError(e?.message ?? "load failed")).finally(() => setLoading(false));
-  }, [keyword]);
+    Promise.all([listSkills(), listAgents().catch(() => [] as Agent[])])
+      .then(([sk, ag]) => { setRows(sk); setAgents(ag); })
+      .catch((e) => setError(e?.message ?? "load failed"))
+      .finally(() => setLoading(false));
+  }, []);
   useEffect(reload, [reload]);
 
+  // 每个 skill 被多少个 AI队友引用：由 agents 的 skills 反向折叠得到。
+  const usedByCount = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const a of agents) for (const s of a.skills ?? []) m.set(s.id, (m.get(s.id) ?? 0) + 1);
+    return m;
+  }, [agents]);
+
   const openDetail = (id: string) => WKApp.routeRight.push(<SkillDetailPage skillId={id} onChanged={reload} />);
+  const filteredRows = useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((row) => {
+      const name = row.name?.toLowerCase() ?? "";
+      const desc = row.description?.toLowerCase() ?? "";
+      return name.includes(q) || desc.includes(q);
+    });
+  }, [keyword, rows]);
 
   const openCreate = () => {
     setCreateOpen(true);
+    setCreateTab("local");
     setNName(""); setNDesc(""); setNContent(""); setWebUrl("");
     setRtSkills([]); setRtPicked(new Set()); setRtErr(null);
     listRuntimes().then((rs) => { setRuntimes(rs); if (rs[0]) setRtId(rs[0].id); }).catch(() => setRuntimes([]));
   };
 
   const createLocal = async () => {
-    if (!nName.trim()) { Toast.warning(t("loop.validate.nameRequired")); return; }
-    try { await createSkill({ name: nName.trim(), description: nDesc, content: nContent }); setCreateOpen(false); Toast.success(t("loop.toast.created")); reload(); }
+    const skillName = nName.trim();
+    if (!skillName) { Toast.warning(t("loop.validate.nameRequired")); return; }
+    if (!isValidSkillName(skillName)) { Toast.warning(t("loop.skill.namePattern")); return; }
+    const content = ensureSkillFrontmatter(skillName, nDesc.trim(), nContent);
+    const frontmatter = parseFrontmatter(content).frontmatter;
+    const frontmatterName = frontmatter?.name?.trim() || skillName;
+    if (!isValidSkillName(frontmatterName)) { Toast.warning(t("loop.skill.namePattern")); return; }
+    const frontmatterDesc = frontmatter?.description?.trim() ?? "";
+    try { await createSkill({ name: frontmatterName, description: frontmatterDesc, content }); setCreateOpen(false); Toast.success(t("loop.toast.created")); reload(); }
     catch (e) { Toast.error((e as Error)?.message ?? "create failed"); }
   };
   const importFromWeb = async () => {
@@ -85,6 +135,10 @@ export default function SkillPage() {
       let ok = 0;
       for (const key of rtPicked) {
         const sk = rtSkills.find((s) => s.key === key);
+        if (sk?.name && !isValidSkillName(sk.name)) {
+          Toast.warning(t("loop.skill.importInvalidName", { values: { name: sk.name } }));
+          continue;
+        }
         const res = await importRuntimeSkill(rtId, key, sk?.name);
         if (res.status === "completed" || res.skill) ok += 1;
       }
@@ -99,20 +153,24 @@ export default function SkillPage() {
     catch (e) { Toast.error((e as Error)?.message ?? "delete failed"); }
   };
 
-  const columns = [
-    { title: t("loop.field.name"), dataIndex: "name", render: (v: string, r: Skill) => <span className="loop-cell-title" onClick={() => openDetail(r.id)}>{v}</span> },
-    { title: t("loop.field.description"), dataIndex: "description", render: (v: string) => <Text type="tertiary">{v || "—"}</Text> },
-    { title: t("loop.skill.source"), dataIndex: "id", width: 120, render: (_v: string, r: Skill) => { const s = skillSource(r); return <Tag color={SRC[s]} size="small">{t(`loop.skill.sourceType.${s}`)}</Tag>; } },
-    { title: "", dataIndex: "id", width: 60, render: (v: string) => <Button theme="borderless" type="danger" size="small" icon={<Trash2 size={14} />} onClick={() => confirmDelete({ title: t("loop.confirm.delete"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => remove(v) })} /> },
-  ];
-
   return (
     <div className="loop-page">
-      <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.skill")}</Title>
-        <div className="loop-page__spacer" />
-        <Input prefix={<Search size={14} />} placeholder={t("loop.search.skill")} value={keyword} onChange={setKeyword} showClear style={{ width: 220 }} />
-        <Button theme="solid" icon={<Plus size={14} />} onClick={openCreate}>{t("loop.action.newSkill")}</Button>
+      <div className="loop-skill-page-head">
+        <div className="loop-skill-page-head__row">
+          <div className="loop-skill-page-head__title">
+            <Title heading={4}>{t("loop.nav.skill")}</Title>
+            <Text type="tertiary" className="loop-skill-page-head__desc">{t("loop.empty.skillDesc")}</Text>
+          </div>
+          <Button theme="solid" icon={<Plus size={14} />} onClick={openCreate}>{t("loop.action.newSkill")}</Button>
+        </div>
+        <Input
+          prefix={<Search size={14} />}
+          placeholder={t("loop.search.skill")}
+          value={keyword}
+          onChange={setKeyword}
+          showClear
+          className="loop-skill-page-head__search"
+        />
       </div>
       <div className="loop-page__body">
         {error ? <Banner type="danger" description={error} />
@@ -124,72 +182,213 @@ export default function SkillPage() {
               <div className="loop-empty__desc">{t("loop.empty.skillDesc")}</div>
               <Button theme="solid" icon={<Plus size={14} />} onClick={openCreate} style={{ marginTop: 12 }}>{t("loop.action.newSkill")}</Button>
             </div>
-          ) : <Table rowKey="id" columns={columns} dataSource={rows} pagination={false} size="small" />}
+          ) : filteredRows.length === 0 ? (
+            <div className="loop-empty">
+              <Sparkles size={40} className="loop-empty__icon" />
+              <div className="loop-empty__title">{t("loop.empty.skill")}</div>
+            </div>
+          ) : (
+            <div className="loop-skill-list" role="list">
+              {filteredRows.map((row) => {
+                const src = skillSource(row);
+                const desc = row.description?.trim();
+                return (
+                  <div key={row.id} className="loop-skill-list__row" role="listitem" onClick={() => openDetail(row.id)}>
+                    <div className="loop-skill-list__main">
+                      <div className="loop-skill-list__name">{row.name}</div>
+                      {desc && (
+                        <Tooltip content={<div className="loop-skill-list__tip">{desc}</div>} position="bottomLeft">
+                          <div className="loop-skill-list__desc">{desc}</div>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <div className="loop-skill-list__meta">
+                      {(usedByCount.get(row.id) ?? 0) > 0 && (
+                        <span className="loop-skill-list__used">
+                          <Users size={13} />{t("loop.skill.usedCount", { values: { count: usedByCount.get(row.id) ?? 0 } })}
+                        </span>
+                      )}
+                      <Tag color={SRC[src]} size="small">{t(`loop.skill.sourceType.${src}`)}</Tag>
+                      <span className="loop-skill-list__time"><Clock3 size={13} />{formatSkillTime(row.updated_at ?? row.created_at, format)}</span>
+                      <Button
+                        theme="borderless"
+                        type="danger"
+                        size="small"
+                        icon={<Trash2 size={14} />}
+                        className="loop-skill-list__delete"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          confirmDelete({
+                            title: t("loop.confirm.delete"),
+                            okText: t("loop.action.delete"),
+                            cancelText: t("loop.action.cancel"),
+                            onOk: () => remove(row.id),
+                          });
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
       </div>
 
-      <Modal title={t("loop.action.newSkill")} visible={createOpen} onCancel={() => setCreateOpen(false)} footer={null} width={620}>
-        <Tabs type="line">
-          {/* 本地 */}
-          <TabPane tab={<span><FileText size={13} style={{ marginRight: 6 }} />{t("loop.skill.local")}</span>} itemKey="local">
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, paddingTop: 8 }}>
-              <div><div className="loop-detail__section-title">{t("loop.field.name")}</div><Input value={nName} onChange={setNName} /></div>
-              <div><div className="loop-detail__section-title">{t("loop.field.description")}</div><Input value={nDesc} onChange={setNDesc} /></div>
-              <div><div className="loop-detail__section-title">{t("loop.skill.content")}</div><TextArea value={nContent} onChange={setNContent} autosize={{ minRows: 5, maxRows: 12 }} /></div>
-              <div style={{ textAlign: "right" }}><Button theme="solid" onClick={createLocal}>{t("loop.action.create")}</Button></div>
-            </div>
-          </TabPane>
-
-          {/* 从 web 拷贝 */}
-          <TabPane tab={<span><Globe size={13} style={{ marginRight: 6 }} />{t("loop.skill.fromWeb")}</span>} itemKey="web">
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, paddingTop: 8 }}>
-              <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.skill.fromWebHint")}</Text>
-              <Input value={webUrl} onChange={setWebUrl} placeholder="https://www.skills.sh/owner/repo/skill" />
-              <div style={{ textAlign: "right" }}><Button theme="solid" loading={webBusy} icon={<Download size={14} />} onClick={importFromWeb}>{t("loop.skill.import")}</Button></div>
-            </div>
-          </TabPane>
-
-          {/* 从运行时拷贝 */}
-          <TabPane tab={<span><Monitor size={13} style={{ marginRight: 6 }} />{t("loop.skill.fromRuntime")}</span>} itemKey="runtime">
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, paddingTop: 8 }}>
-              <div style={{ display: "flex", gap: 8 }}>
-                <Select value={rtId} onChange={(v) => setRtId(v as string)} style={{ flex: 1 }} placeholder={t("loop.agent.runtime")}>
-                  {runtimes.map((r) => <Select.Option key={r.id} value={r.id}>{r.name}（{r.provider}）</Select.Option>)}
-                </Select>
-                <Button loading={rtBusy} onClick={loadRuntimeSkills}>{t("loop.skill.fetch")}</Button>
+      <Modal
+        visible={createOpen}
+        onCancel={() => setCreateOpen(false)}
+        footer={null}
+        width={760}
+        bodyStyle={{ padding: 0 }}
+        title={
+          <div className="loop-nsk__head">
+            <div className="loop-nsk__head-title">{t("loop.action.newSkill")}</div>
+            <div className="loop-nsk__head-sub">{t("loop.skill.create.subtitle")}</div>
+          </div>
+        }
+      >
+        <div className="loop-nsk">
+          <div className="loop-nsk__body">
+            {/* 左侧：tab + 表单 */}
+            <div className="loop-nsk__form">
+              <div className="loop-nsk__tabs" role="tablist">
+                <button type="button" className={`loop-nsk__tab${createTab === "local" ? " is-active" : ""}`} onClick={() => setCreateTab("local")}>
+                  <FileText size={14} />{t("loop.skill.create.draft")}
+                </button>
+                <button type="button" className={`loop-nsk__tab${createTab === "web" ? " is-active" : ""}`} onClick={() => setCreateTab("web")}>
+                  <Link2 size={14} />{t("loop.skill.create.url")}
+                </button>
+                <button type="button" className={`loop-nsk__tab${createTab === "runtime" ? " is-active" : ""}`} onClick={() => setCreateTab("runtime")}>
+                  <Copy size={14} />{t("loop.skill.create.runtime")}
+                </button>
               </div>
-              {rtErr && <Banner type="warning" description={rtErr} closeIcon={null} />}
-              {rtBusy && rtSkills.length === 0 && !rtErr && <div style={{ textAlign: "center", padding: 16 }}><Spin /></div>}
-              {rtSkills.length > 0 && (
-                <>
-                  <div className="loop-skill-rtlist">
-                    {rtSkills.map((s) => (
-                      <label key={s.key} className="loop-skill-rtitem">
-                        <Checkbox
-                          checked={rtPicked.has(s.key)}
-                          onChange={(e) => {
-                            const next = new Set(rtPicked);
-                            if (e.target.checked) next.add(s.key); else next.delete(s.key);
-                            setRtPicked(next);
-                          }}
-                        />
-                        <span className="loop-skill-rtitem__main">
-                          <strong>{s.name}</strong>
-                          {s.description && <small>{s.description}</small>}
-                        </span>
-                        {s.provider && <Tag size="small" color="grey">{s.provider}</Tag>}
-                      </label>
-                    ))}
+
+              {createTab === "local" && (
+                <div className="loop-nsk__fields">
+                  <div className="loop-nsk__field">
+                    <label className="loop-nsk__label">{t("loop.field.name")}</label>
+                    <Input value={nName} onChange={setNName} placeholder={t("loop.field.name")} />
                   </div>
-                  <div style={{ textAlign: "right" }}>
-                    <Button theme="solid" loading={rtBusy} disabled={rtPicked.size === 0} icon={<Download size={14} />} onClick={importFromRuntime}>
-                      {t("loop.skill.importSelected")}（{rtPicked.size}）
-                    </Button>
+                  <div className="loop-nsk__field">
+                    <label className="loop-nsk__label">{t("loop.field.description")}</label>
+                    <Input value={nDesc} onChange={setNDesc} placeholder={t("loop.field.descriptionPlaceholder")} />
                   </div>
-                </>
+                  <div className="loop-nsk__field">
+                    <label className="loop-nsk__label">{t("loop.skill.content")}</label>
+                    <TextArea value={nContent} onChange={setNContent} autosize={{ minRows: 5, maxRows: 12 }} />
+                  </div>
+                </div>
+              )}
+
+              {createTab === "web" && (
+                <div className="loop-nsk__fields">
+                  <div className="loop-nsk__field">
+                    <label className="loop-nsk__label">{t("loop.skill.create.urlLabel")}</label>
+                    <Input value={webUrl} onChange={setWebUrl} placeholder="https://clawhub.ai/owner/skill" />
+                  </div>
+                  <div className="loop-nsk__field">
+                    <label className="loop-nsk__label">{t("loop.skill.create.supportedSources")}</label>
+                    <div className="loop-nsk__sources">
+                      <div className="loop-nsk__source"><strong>ClawHub</strong><small>clawhub.ai/owner/skill</small></div>
+                      <div className="loop-nsk__source"><strong>Skills.sh</strong><small>skills.sh/owner/skill</small></div>
+                      <div className="loop-nsk__source"><strong>GitHub</strong><small>github.com/owner/repo</small></div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {createTab === "runtime" && (
+                <div className="loop-nsk__fields">
+                  <div className="loop-nsk__rtbar">
+                    <Select value={rtId} onChange={(v) => setRtId(v as string)} style={{ flex: 1 }} placeholder={t("loop.agent.runtime")}>
+                      {runtimes.map((r) => <Select.Option key={r.id} value={r.id}>{r.name}（{r.provider}）</Select.Option>)}
+                    </Select>
+                    <Button loading={rtBusy} onClick={loadRuntimeSkills}>{t("loop.skill.fetch")}</Button>
+                  </div>
+                  {rtErr && <Banner type="warning" description={rtErr} closeIcon={null} />}
+                  {rtBusy && rtSkills.length === 0 && !rtErr && <div className="loop-nsk__rtloading"><Spin /></div>}
+                  {rtSkills.length > 0 && (
+                    <div className="loop-skill-rtlist">
+                      {rtSkills.map((s) => (
+                        <label key={s.key} className="loop-skill-rtitem">
+                          <Checkbox
+                            checked={rtPicked.has(s.key)}
+                            onChange={(e) => {
+                              const next = new Set(rtPicked);
+                              if (e.target.checked) next.add(s.key); else next.delete(s.key);
+                              setRtPicked(next);
+                            }}
+                          />
+                          <span className="loop-skill-rtitem__main">
+                            <strong>{s.name}</strong>
+                            {s.description && <small>{s.description}</small>}
+                          </span>
+                          {s.provider && <Tag size="small" color="grey">{s.provider}</Tag>}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
               )}
             </div>
-          </TabPane>
-        </Tabs>
+
+            {/* 右侧：实时预览 */}
+            <div className="loop-nsk__preview">
+              <div className="loop-nsk__preview-label">{t("loop.skill.create.preview")}</div>
+              <div className="loop-nsk__preview-card">
+                <div className="loop-nsk__preview-top">
+                  <span className="loop-nsk__preview-ico">
+                    {createTab === "local" ? <FileText size={20} /> : createTab === "web" ? <Link2 size={20} /> : <Copy size={20} />}
+                  </span>
+                  <span className="loop-nsk__preview-badge">
+                    {createTab === "local" ? t("loop.skill.create.draft") : createTab === "web" ? t("loop.skill.create.url") : t("loop.skill.create.runtime")}
+                  </span>
+                </div>
+                {createTab === "local" && (
+                  <>
+                    <div className="loop-nsk__preview-name">{nName.trim() || t("loop.skill.create.unnamed")}</div>
+                    {nDesc.trim() && <div className="loop-nsk__preview-desc">{nDesc.trim()}</div>}
+                    <div className="loop-nsk__preview-file"><FileText size={13} />SKILL.md</div>
+                  </>
+                )}
+                {createTab === "web" && (
+                  <>
+                    <div className="loop-nsk__preview-name">{t("loop.skill.create.url")}</div>
+                    <div className="loop-nsk__preview-desc">{webUrl.trim() || "https://clawhub.ai/owner/skill"}</div>
+                    <div className="loop-nsk__preview-file"><FileText size={13} />SKILL.md</div>
+                  </>
+                )}
+                {createTab === "runtime" && (
+                  <>
+                    <div className="loop-nsk__preview-name">
+                      {runtimes.find((r) => r.id === rtId)?.name || t("loop.skill.create.runtime")}
+                    </div>
+                    <div className="loop-nsk__preview-desc">
+                      {rtPicked.size > 0 ? `${t("loop.skill.importSelected")}（${rtPicked.size}）` : t("loop.skill.fromRuntime")}
+                    </div>
+                  </>
+                )}
+              </div>
+              <p className="loop-nsk__preview-note">{t("loop.skill.create.previewNote")}</p>
+            </div>
+          </div>
+
+          {/* 底部操作 */}
+          <div className="loop-nsk__footer">
+            <Button onClick={() => setCreateOpen(false)}>{t("loop.action.cancel")}</Button>
+            {createTab === "local" && (
+              <Button theme="solid" icon={<Plus size={14} />} disabled={!nName.trim()} onClick={createLocal}>{t("loop.action.create")}</Button>
+            )}
+            {createTab === "web" && (
+              <Button theme="solid" icon={<Download size={14} />} loading={webBusy} disabled={!webUrl.trim()} onClick={importFromWeb}>{t("loop.skill.import")}</Button>
+            )}
+            {createTab === "runtime" && (
+              <Button theme="solid" icon={<Download size={14} />} loading={rtBusy} disabled={rtPicked.size === 0} onClick={importFromRuntime}>
+                {t("loop.skill.importSelected")}（{rtPicked.size}）
+              </Button>
+            )}
+          </div>
+        </div>
       </Modal>
     </div>
   );

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -137,6 +137,56 @@
   height: 60%;
 }
 
+/* ===== Skill 列表页头部 ===== */
+.loop-skill-page-head {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 20px 14px;
+}
+
+.loop-skill-page-head__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.loop-skill-page-head__title {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  min-width: 0;
+}
+
+.loop-skill-page-head__title h4 {
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.loop-skill-page-head__desc {
+  min-width: 0;
+  font-size: 13px;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-skill-page-head__search {
+  width: 240px;
+  height: 28px;
+  min-height: 28px;
+  border-radius: 6px;
+  background: var(--semi-color-bg-0, #fff);
+  border-color: var(--semi-color-border, rgba(0, 0, 0, 0.08));
+}
+
+.loop-skill-page-head__search input {
+  height: 26px;
+  font-size: 12px;
+}
+
 /* ===== 新建 Issue 弹窗 ===== */
 .loop-createissue__row {
   display: flex;
@@ -394,6 +444,153 @@
   color: var(--semi-color-primary, #6a5cff);
 }
 
+/* ===== Skill list ===== */
+.loop-skill-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.loop-skill-list__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 20px;
+  min-height: 48px;
+  padding: 7px 10px 7px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.loop-skill-list__row:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+
+.loop-skill-list__row:focus-within {
+  background: var(--semi-color-fill-0, #f5f6f8);
+  box-shadow: inset 0 0 0 1px var(--semi-color-border, #e8e9eb);
+}
+
+.loop-skill-list__main {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  min-width: 0;
+}
+
+.loop-skill-list__name {
+  flex: 0 0 220px;
+  min-width: 120px;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--semi-color-text-0, #1c1f23);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.loop-skill-list__desc {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.loop-skill-list__tip {
+  max-width: 520px;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.loop-skill-list__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+  min-width: 360px;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 12px;
+}
+
+.loop-skill-list__time {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  width: 96px;
+  white-space: nowrap;
+}
+
+.loop-skill-list__time svg {
+  color: var(--semi-color-text-3, #b6bbc6);
+}
+
+.loop-skill-list__used {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.loop-skill-list__used svg {
+  color: var(--semi-color-text-3, #b6bbc6);
+}
+
+.loop-skill-list__delete {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.loop-skill-list__row:hover .loop-skill-list__delete,
+.loop-skill-list__row:focus-within .loop-skill-list__delete {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 900px) {
+  .loop-skill-list__row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  .loop-skill-list__main {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .loop-skill-list__name {
+    flex-basis: auto;
+    max-width: none;
+  }
+
+  .loop-skill-list__meta {
+    justify-content: flex-start;
+    min-width: 0;
+    gap: 10px;
+  }
+
+  .loop-skill-list__time {
+    width: auto;
+  }
+
+  .loop-skill-list__delete {
+    margin-left: auto;
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .loop-progress {
   display: flex;
   align-items: center;
@@ -523,3 +720,215 @@
 
 /* 设置页-成员邀请行 */
 .loop-settings-invite { display: flex; gap: 8px; align-items: center; }
+
+/* ===== 新建 Skill 弹框：左表单 + 右预览 ===== */
+.loop-nsk__head-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1c1f23);
+}
+.loop-nsk__head-sub {
+  margin-top: 2px;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-nsk {
+  display: flex;
+  flex-direction: column;
+  height: 480px;
+}
+
+.loop-nsk__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+/* 左侧表单 */
+.loop-nsk__form {
+  width: 60%;
+  padding: 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.loop-nsk__tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 8px;
+  background: var(--semi-color-fill-0, #f5f6f8);
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+}
+.loop-nsk__tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 4px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--semi-color-text-2, #8a8f99);
+  transition: all 0.15s;
+}
+.loop-nsk__tab:hover {
+  background: var(--semi-color-bg-0, #fff);
+}
+.loop-nsk__tab.is-active {
+  background: var(--semi-color-bg-0, #fff);
+  color: var(--semi-color-text-0, #1c1f23);
+  border-color: var(--semi-color-border, #e8e9eb);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.loop-nsk__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.loop-nsk__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.loop-nsk__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--semi-color-text-1, #4e5969);
+}
+
+.loop-nsk__sources {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.loop-nsk__source {
+  padding: 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 6px;
+  background: var(--semi-color-fill-0, #f7f8fa);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.loop-nsk__source strong {
+  font-size: 11px;
+  color: var(--semi-color-text-0, #1c1f23);
+}
+.loop-nsk__source small {
+  font-size: 9px;
+  color: var(--semi-color-text-2, #8a8f99);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-nsk__rtbar {
+  display: flex;
+  gap: 8px;
+}
+.loop-nsk__rtloading {
+  text-align: center;
+  padding: 16px;
+}
+
+/* 右侧预览 */
+.loop-nsk__preview {
+  width: 40%;
+  padding: 20px;
+  border-left: 1px solid var(--semi-color-border, #e8e9eb);
+  background: var(--semi-color-fill-0, #f7f8fa);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+}
+.loop-nsk__preview-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+.loop-nsk__preview-card {
+  background: var(--semi-color-bg-0, #fff);
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.loop-nsk__preview-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.loop-nsk__preview-ico {
+  display: inline-flex;
+  padding: 8px;
+  border-radius: 8px;
+  background: var(--semi-color-fill-0, #f0f1f2);
+  color: var(--semi-color-text-2, #8a8f99);
+}
+.loop-nsk__preview-badge {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--semi-color-text-2, #8a8f99);
+  background: var(--semi-color-fill-0, #f0f1f2);
+  padding: 3px 6px;
+  border-radius: 5px;
+}
+.loop-nsk__preview-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1c1f23);
+  word-break: break-word;
+}
+.loop-nsk__preview-desc {
+  font-size: 11px;
+  color: var(--semi-color-text-2, #8a8f99);
+  word-break: break-word;
+}
+.loop-nsk__preview-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+.loop-nsk__preview-note {
+  margin: 0;
+  font-size: 10px;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+/* 底部操作 */
+.loop-nsk__footer {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--semi-color-border, #e8e9eb);
+  background: var(--semi-color-fill-0, #f7f8fa);
+}
+
+@media (max-width: 720px) {
+  .loop-nsk { height: auto; }
+  .loop-nsk__body { flex-direction: column; }
+  .loop-nsk__form,
+  .loop-nsk__preview { width: 100%; }
+  .loop-nsk__preview { border-left: none; border-top: 1px solid var(--semi-color-border, #e8e9eb); }
+}

--- a/packages/dmloop/src/panel/SkillDetailPage.tsx
+++ b/packages/dmloop/src/panel/SkillDetailPage.tsx
@@ -1,47 +1,181 @@
-import React, { useEffect, useState } from "react";
-import { Typography, Input, Button, Spin, Tag, Toast, TextArea, Banner } from "@douyinfe/semi-ui";
-import { ArrowLeft, Save, Trash2 } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Typography, Input, Button, Spin, Toast, Banner, Tooltip } from "@douyinfe/semi-ui";
+import { ArrowLeft, BookOpen, Clock3, ExternalLink, Save, Trash2, Plus, Users } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Skill } from "../api/types";
+import type { I18nFormatter } from "@octo/base";
+import type { Agent, Skill, SkillFile } from "../api/types";
 import { getSkill, updateSkill, deleteSkill, skillSource } from "../api/skillApi";
+import { listAgents } from "../api/agentApi";
+import { confirmDelete } from "../ui/confirmDelete";
+import SkillFileTree from "./SkillFileTree";
+import SkillFileViewer from "./SkillFileViewer";
+import { isValidSkillName } from "../ui/skillName";
+import { parseFrontmatter } from "../ui/frontmatter";
 import "./sideDetail.css";
 
 const { Text } = Typography;
-const SRC: Record<string, "green" | "blue" | "grey"> = { github: "green", local: "blue", workspace: "grey" };
+const SKILL_MD = "SKILL.md";
 
-/** Skill 独立详情页：左侧元信息 + 右侧内容编辑。 */
+type DraftFile = { path: string; content: string };
+
+function toDraftFiles(files?: SkillFile[]): DraftFile[] {
+  return (files ?? [])
+    .filter((f) => f.path !== SKILL_MD)
+    .map((f) => ({ path: f.path, content: f.content }));
+}
+
+function formatSkillTime(value: string | undefined, format: Pick<I18nFormatter, "date" | "relativeTime">): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  const diff = date.getTime() - Date.now();
+  if (!Number.isFinite(diff)) return "-";
+  const absDiff = Math.abs(diff);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (absDiff < minute) return format.relativeTime(0, "minute");
+  if (absDiff < hour) return format.relativeTime(Math.round(diff / minute), "minute");
+  if (absDiff < day) return format.relativeTime(Math.round(diff / hour), "hour");
+  if (absDiff < 10 * day) return format.relativeTime(Math.round(diff / day), "day");
+  return format.date(date, { month: "short", day: "numeric" });
+}
+
+/** Skill 详情页：左侧文件树 + 右侧多文件编辑器（SKILL.md 映射到 content）。 */
 export default function SkillDetailPage({ skillId, onChanged }: { skillId: string; onChanged?: () => void }) {
-  const { t } = useI18n();
+  const { t, format } = useI18n();
   const [row, setRow] = useState<Skill | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [usedAgents, setUsedAgents] = useState<Agent[]>([]);
+
   const [name, setName] = useState("");
-  const [desc, setDesc] = useState("");
   const [content, setContent] = useState("");
+  const [files, setFiles] = useState<DraftFile[]>([]);
+  const [selectedPath, setSelectedPath] = useState(SKILL_MD);
   const [dirty, setDirty] = useState(false);
+  const [editingName, setEditingName] = useState(false);
+
+  const [addingFile, setAddingFile] = useState(false);
+  const [newPath, setNewPath] = useState("");
+  const [addError, setAddError] = useState("");
+
+  const seed = (s: Skill) => {
+    setRow(s);
+    setName(s.name);
+    setContent(s.content ?? "");
+    setFiles(toDraftFiles(s.files));
+    setDirty(false);
+  };
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    getSkill(skillId)
-      .then((s) => { setRow(s); setName(s.name); setDesc(s.description); setContent(s.content ?? ""); setDirty(false); })
+    setSelectedPath(SKILL_MD);
+    Promise.all([
+      getSkill(skillId),
+      listAgents().catch(() => [] as Agent[]),
+    ])
+      .then(([skill, agents]) => {
+        seed(skill);
+        setUsedAgents(agents.filter((agent) => (agent.skills ?? []).some((sk) => sk.id === skill.id)));
+      })
       .catch((e) => setError(e?.message ?? "load failed"))
       .finally(() => setLoading(false));
   }, [skillId]);
 
+  const fileMap = useMemo(() => {
+    const map = new Map<string, string>();
+    map.set(SKILL_MD, content);
+    for (const f of files) if (f.path.trim()) map.set(f.path, f.content);
+    return map;
+  }, [content, files]);
+  const filePaths = useMemo(() => Array.from(fileMap.keys()), [fileMap]);
+  const selectedContent = fileMap.get(selectedPath) ?? "";
+  const skillFrontmatter = useMemo(() => parseFrontmatter(content).frontmatter, [content]);
+  const skillDescription = skillFrontmatter?.description?.trim() ?? "";
+
+  useEffect(() => {
+    if (selectedPath !== SKILL_MD && !fileMap.has(selectedPath)) setSelectedPath(SKILL_MD);
+  }, [fileMap, selectedPath]);
+
   const back = () => WKApp.routeRight.pop();
-  const save = async () => {
-    if (!name.trim()) { Toast.warning(t("loop.validate.nameRequired")); return; }
-    try { await updateSkill(skillId, { name: name.trim(), description: desc, content }); setDirty(false); Toast.success(t("loop.toast.saved")); onChanged?.(); }
-    catch (e) { Toast.error((e as Error)?.message ?? "save failed"); }
+
+  const onFileContentChange = (next: string) => {
+    if (selectedPath === SKILL_MD) setContent(next);
+    else setFiles((prev) => prev.map((f) => (f.path === selectedPath ? { ...f, content: next } : f)));
+    setDirty(true);
   };
-  const remove = async () => {
-    try { await deleteSkill(skillId); Toast.success(t("loop.toast.deleted")); onChanged?.(); back(); }
-    catch (e) { Toast.error((e as Error)?.message ?? "delete failed"); }
+
+  const validateNewPath = (p: string): string => {
+    const v = p.trim();
+    if (!v) return t("loop.skill.detail.addFile.empty");
+    if (v.startsWith("/")) return t("loop.skill.detail.addFile.absolute");
+    if (v.split("/").includes("..")) return t("loop.skill.detail.addFile.doubleDot");
+    if (v === SKILL_MD) return t("loop.skill.detail.addFile.reserved");
+    if (filePaths.includes(v)) return t("loop.skill.detail.addFile.exists");
+    return "";
+  };
+
+  const submitNewFile = () => {
+    const err = validateNewPath(newPath);
+    if (err) { setAddError(err); return; }
+    const p = newPath.trim();
+    setFiles((prev) => [...prev, { path: p, content: "" }]);
+    setSelectedPath(p);
+    setDirty(true);
+    setAddingFile(false);
+    setNewPath("");
+    setAddError("");
+  };
+
+  const cancelNewFile = () => { setAddingFile(false); setNewPath(""); setAddError(""); };
+
+  const deleteSelectedFile = () => {
+    if (selectedPath === SKILL_MD) return;
+    setFiles((prev) => prev.filter((f) => f.path !== selectedPath));
+    setSelectedPath(SKILL_MD);
+    setDirty(true);
+  };
+
+  const save = async () => {
+    const skillName = name.trim();
+    if (!skillName) { Toast.warning(t("loop.validate.nameRequired")); return; }
+    if (!isValidSkillName(skillName)) { Toast.warning(t("loop.skill.namePattern")); return; }
+    try {
+      const updated = await updateSkill(skillId, {
+        name: skillName,
+        description: skillDescription,
+        content,
+        files: files.filter((f) => f.path.trim() && f.path !== SKILL_MD),
+      });
+      seed(updated);
+      Toast.success(t("loop.toast.saved"));
+      onChanged?.();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? "save failed");
+    }
+  };
+
+  const remove = () => {
+    confirmDelete({
+      title: t("loop.confirm.delete"),
+      okText: t("loop.action.delete"),
+      cancelText: t("loop.action.cancel"),
+      onOk: async () => {
+        try { await deleteSkill(skillId); Toast.success(t("loop.toast.deleted")); onChanged?.(); back(); }
+        catch (e) { Toast.error((e as Error)?.message ?? "delete failed"); }
+      },
+    });
   };
 
   if (loading) return <div className="loop-sd"><div className="loop-sd__center"><Spin /></div></div>;
-  if (error || !row) return <div className="loop-sd"><div className="loop-sd__topbar"><Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>{t("loop.detail.back")}</Button></div><div className="loop-sd__center">{error ? <Banner type="danger" description={error} /> : <Text type="tertiary">{t("loop.detail.notFound")}</Text>}</div></div>;
+  if (error || !row) return (
+    <div className="loop-sd">
+      <div className="loop-sd__topbar"><Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>{t("loop.detail.back")}</Button></div>
+      <div className="loop-sd__center">{error ? <Banner type="danger" description={error} /> : <Text type="tertiary">{t("loop.detail.notFound")}</Text>}</div>
+    </div>
+  );
 
   const src = skillSource(row);
 
@@ -54,18 +188,118 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
         <Button theme="borderless" type="danger" icon={<Trash2 size={14} />} onClick={remove}>{t("loop.action.delete")}</Button>
         <Button theme="solid" icon={<Save size={14} />} disabled={!dirty} onClick={save}>{t("loop.action.save")}</Button>
       </div>
-      <div className="loop-sd__body">
-        <aside className="loop-sd__aside">
-          <div className="loop-detail__section-title">{t("loop.field.name")}</div>
-          <Input value={name} onChange={(v) => { setName(v); setDirty(true); }} />
-          <div className="loop-detail__section-title" style={{ marginTop: 14 }}>{t("loop.field.description")}</div>
-          <TextArea value={desc} onChange={(v) => { setDesc(v); setDirty(true); }} autosize={{ minRows: 2, maxRows: 5 }} />
-          <div className="loop-detail__section-title" style={{ marginTop: 14 }}>{t("loop.skill.source")}</div>
-          <Tag color={SRC[src]} size="small">{t(`loop.skill.sourceType.${src}`)}</Tag>
+
+      <div className="loop-skill-body">
+        <aside className="loop-skill-tree">
+          <section className="loop-skill-profile">
+            <div className="loop-skill-profile__main">
+              <div className="loop-skill-profile__icon"><BookOpen size={18} /></div>
+              <div className="loop-skill-profile__copy">
+                {editingName ? (
+                  <Input
+                    autoFocus
+                    value={name}
+                    onBlur={() => setEditingName(false)}
+                    onChange={(v) => { setName(v); setDirty(true); }}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === "Escape") setEditingName(false); }}
+                    placeholder={t("loop.field.name")}
+                    className="loop-skill-profile__nameInput"
+                  />
+                ) : (
+                  <button type="button" className="loop-skill-profile__name" onClick={() => setEditingName(true)}>
+                    {name || t("loop.field.name")}
+                  </button>
+                )}
+                <Tooltip
+                  content={<div className="loop-skill-profile__descTip">{skillDescription || t("loop.skill.detail.noDescription")}</div>}
+                  position="bottomLeft"
+                >
+                  <div className={skillDescription ? "loop-skill-profile__desc" : "loop-skill-profile__desc is-empty"}>
+                    {skillDescription || t("loop.skill.detail.noDescription")}
+                  </div>
+                </Tooltip>
+              </div>
+            </div>
+            <div className="loop-skill-profile__subline">
+              <div className="loop-skill-profile__fact">
+                <ExternalLink size={12} />
+                <span>{t("loop.skill.source")}</span>
+                <strong>{t(`loop.skill.sourceType.${src}`)}</strong>
+              </div>
+              <div className="loop-skill-profile__fact">
+                <Clock3 size={12} />
+                <span>{t("loop.detail.updated")}</span>
+                <strong>{formatSkillTime(row.updated_at, format)}</strong>
+              </div>
+            </div>
+          </section>
+
+          <section className="loop-skill-files">
+            <div className="loop-skill-files__head">
+              <span className="loop-skill-files__label">{t("loop.skill.detail.files")}（{filePaths.length}）</span>
+              <Tooltip content={t("loop.skill.detail.addFile.add")}>
+                <Button theme="borderless" size="small" icon={<Plus size={14} />} onClick={() => setAddingFile(true)} />
+              </Tooltip>
+            </div>
+            {addingFile && (
+              <div className="loop-skill-files__addfile">
+                <Input
+                  autoFocus
+                  size="small"
+                  value={newPath}
+                  placeholder={t("loop.skill.detail.addFile.placeholder")}
+                  onChange={(v) => { setNewPath(v); setAddError(""); }}
+                  onKeyDown={(e) => { if (e.key === "Enter") submitNewFile(); if (e.key === "Escape") cancelNewFile(); }}
+                />
+                {addError && <div className="loop-skill-files__adderr">{addError}</div>}
+                <div className="loop-skill-files__addbtns">
+                  <Button size="small" theme="solid" onClick={submitNewFile}>{t("loop.skill.detail.addFile.add")}</Button>
+                  <Button size="small" theme="borderless" onClick={cancelNewFile}>{t("loop.action.cancel")}</Button>
+                </div>
+              </div>
+            )}
+            <div className="loop-skill-files__scroll">
+              <SkillFileTree
+                filePaths={filePaths}
+                selectedPath={selectedPath}
+                onSelect={setSelectedPath}
+                emptyText={t("loop.skill.detail.noFiles")}
+              />
+            </div>
+            {selectedPath !== SKILL_MD && (
+              <div className="loop-skill-files__foot">
+                <Button theme="borderless" type="danger" size="small" icon={<Trash2 size={13} />} onClick={deleteSelectedFile}>
+                  {t("loop.skill.detail.deleteFile")}
+                </Button>
+              </div>
+            )}
+          </section>
+
+          <section className="loop-skill-agents">
+            <div className="loop-skill-agents__head">
+              <Users size={13} />
+              <span>{t("loop.skill.detail.usedAgents", { values: { count: usedAgents.length } })}</span>
+            </div>
+            {usedAgents.length > 0 ? (
+              <div className="loop-skill-agents__list">
+                {usedAgents.map((agent) => (
+                  <div key={agent.id} className="loop-skill-agents__item">
+                    <span className="loop-skill-agents__avatar">{agent.name.trim().slice(0, 1).toUpperCase() || "A"}</span>
+                    <span className="loop-skill-agents__name">{agent.name}</span>
+                    <span className="loop-skill-agents__type">{t("loop.skill.detail.agentType")}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="loop-skill-agents__empty">{t("loop.skill.detail.noUsedAgents")}</div>
+            )}
+          </section>
         </aside>
-        <section className="loop-sd__main">
-          <div className="loop-detail__section-title">{t("loop.skill.content")}</div>
-          <TextArea value={content} onChange={(v) => { setContent(v); setDirty(true); }} autosize={{ minRows: 16, maxRows: 40 }} className="loop-mono" />
+
+        <section className="loop-skill-editor">
+          <div className="loop-skill-editor__viewer">
+            <SkillFileViewer key={selectedPath} path={selectedPath} content={selectedContent} onChange={onFileContentChange} />
+          </div>
         </section>
       </div>
     </div>

--- a/packages/dmloop/src/panel/SkillFileTree.tsx
+++ b/packages/dmloop/src/panel/SkillFileTree.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import {
+  ChevronRight, ChevronDown, FileText, File, Folder, FolderOpen,
+} from "lucide-react";
+
+const SKILL_MD = "SKILL.md";
+
+interface FileTreeNode {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  children: FileTreeNode[];
+}
+
+function buildTree(filePaths: string[]): FileTreeNode[] {
+  const root: FileTreeNode[] = [];
+  for (const filePath of filePaths) {
+    const parts = filePath.split("/");
+    let current = root;
+    for (let i = 0; i < parts.length; i++) {
+      const name = parts[i]!;
+      const isLast = i === parts.length - 1;
+      const path = parts.slice(0, i + 1).join("/");
+      let existing = current.find((n) => n.name === name);
+      if (!existing) {
+        existing = { name, path, isDirectory: !isLast, children: [] };
+        current.push(existing);
+      }
+      if (!isLast) current = existing.children;
+    }
+  }
+  function sortNodes(nodes: FileTreeNode[]): FileTreeNode[] {
+    nodes.sort((a, b) => {
+      if (a.path === SKILL_MD) return -1;
+      if (b.path === SKILL_MD) return 1;
+      if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const node of nodes) if (node.isDirectory) sortNodes(node.children);
+    return nodes;
+  }
+  return sortNodes(root);
+}
+
+function getFileIcon(name: string) {
+  if (name.endsWith(".md") || name.endsWith(".mdx")) return FileText;
+  return File;
+}
+
+function TreeNodeItem({
+  node, selectedPath, onSelect, depth = 0,
+}: {
+  node: FileTreeNode;
+  selectedPath: string;
+  onSelect: (path: string) => void;
+  depth?: number;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const isSelected = node.path === selectedPath;
+
+  if (node.isDirectory) {
+    const FolderIcon = expanded ? FolderOpen : Folder;
+    const ChevronIcon = expanded ? ChevronDown : ChevronRight;
+    return (
+      <div>
+        <button
+          type="button"
+          className="loop-ftree__row"
+          onClick={() => setExpanded(!expanded)}
+          style={{ paddingLeft: depth * 12 + 8 }}
+        >
+          <ChevronIcon size={12} className="loop-ftree__chev" />
+          <FolderIcon size={14} className="loop-ftree__icon" />
+          <span className="loop-ftree__name">{node.name}</span>
+        </button>
+        {expanded && node.children.map((child) => (
+          <TreeNodeItem key={child.path} node={child} selectedPath={selectedPath} onSelect={onSelect} depth={depth + 1} />
+        ))}
+      </div>
+    );
+  }
+
+  const Icon = getFileIcon(node.name);
+  return (
+    <button
+      type="button"
+      className={`loop-ftree__row loop-ftree__file${isSelected ? " is-selected" : ""}`}
+      onClick={() => onSelect(node.path)}
+      style={{ paddingLeft: depth * 12 + 8 + 16 }}
+    >
+      <Icon size={14} className="loop-ftree__icon" />
+      <span className="loop-ftree__name">{node.name}</span>
+    </button>
+  );
+}
+
+export default function SkillFileTree({
+  filePaths, selectedPath, onSelect, emptyText,
+}: {
+  filePaths: string[];
+  selectedPath: string;
+  onSelect: (path: string) => void;
+  emptyText: string;
+}) {
+  const tree = buildTree(filePaths);
+  if (tree.length === 0) {
+    return (
+      <div className="loop-ftree__empty">
+        <FolderOpen size={20} />
+        <p>{emptyText}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="loop-ftree">
+      {tree.map((node) => (
+        <TreeNodeItem key={node.path} node={node} selectedPath={selectedPath} onSelect={onSelect} />
+      ))}
+    </div>
+  );
+}

--- a/packages/dmloop/src/panel/SkillFileViewer.tsx
+++ b/packages/dmloop/src/panel/SkillFileViewer.tsx
@@ -1,0 +1,90 @@
+import React, { useMemo, useState } from "react";
+import { Button } from "@douyinfe/semi-ui";
+import { Pencil, Eye } from "lucide-react";
+import { useI18n } from "@octo/base";
+import { parseFrontmatter } from "../ui/frontmatter";
+import LoopMarkdown from "../ui/LoopMarkdown";
+
+function isMarkdown(path: string) {
+  return path.endsWith(".md") || path.endsWith(".mdx");
+}
+
+/** 单文件查看/编辑：md 支持预览/编辑切换 + frontmatter；其它文件仅编辑。 */
+export default function SkillFileViewer({
+  path, content, readOnly, onChange,
+}: {
+  path: string;
+  content: string;
+  readOnly?: boolean;
+  onChange: (content: string) => void;
+}) {
+  const { t } = useI18n();
+  const isMd = isMarkdown(path);
+  const [mode, setMode] = useState<"preview" | "edit">(isMd ? "preview" : "edit");
+
+  const { frontmatter, body } = useMemo(
+    () => (isMd ? parseFrontmatter(content) : { frontmatter: null, body: content }),
+    [content, isMd],
+  );
+  const frontmatterRows = useMemo(() => Object.entries(frontmatter ?? {}), [frontmatter]);
+
+  const showPreview = isMd && mode === "preview";
+
+  return (
+    <div className="loop-fv">
+      <div className="loop-fv__head">
+        <span className="loop-fv__path">{path}</span>
+        {isMd && (
+          <div className="loop-fv__modes" role="tablist" aria-label={path}>
+            <Button
+              size="small"
+              theme={mode === "edit" ? "light" : "borderless"}
+              icon={<Pencil size={13} />}
+              className={`loop-fv__mode${mode === "edit" ? " is-active" : ""}`}
+              onClick={() => setMode("edit")}
+            >
+              {t("loop.skill.detail.edit")}
+            </Button>
+            <Button
+              size="small"
+              theme={mode === "preview" ? "light" : "borderless"}
+              icon={<Eye size={13} />}
+              className={`loop-fv__mode${mode === "preview" ? " is-active" : ""}`}
+              onClick={() => setMode("preview")}
+            >
+              {t("loop.skill.detail.preview")}
+            </Button>
+          </div>
+        )}
+      </div>
+      <div className="loop-fv__body">
+        {showPreview ? (
+          <div className="loop-fv__preview">
+            {path === "SKILL.md" && frontmatterRows.length > 0 && (
+              <table className="loop-fv__frontmatter">
+                <tbody>
+                  {frontmatterRows.map(([key, value]) => (
+                    <tr key={key}>
+                      <th>{key}</th>
+                      <td>{value}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            <LoopMarkdown content={body || t("loop.skill.detail.noContent")} />
+          </div>
+        ) : (
+          <textarea
+            className="loop-fv__editor loop-mono"
+            value={content}
+            readOnly={readOnly}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={t("loop.skill.detail.contentPlaceholder")}
+            spellCheck={false}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dmloop/src/panel/sideDetail.css
+++ b/packages/dmloop/src/panel/sideDetail.css
@@ -57,3 +57,461 @@
     border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
   }
 }
+
+/* ===== Skill 多文件详情：文件树 | 编辑器 ===== */
+.loop-skill-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.loop-skill-tree {
+  display: flex;
+  flex-direction: column;
+  width: 260px;
+  flex: 0 0 260px;
+  border-right: 1px solid var(--semi-color-border, #e8e9eb);
+  background: var(--semi-color-bg-1, #fbfbfc);
+  min-height: 0;
+}
+
+.loop-skill-profile {
+  flex: 0 0 auto;
+  padding: 18px 14px 14px;
+  border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.loop-skill-profile__main {
+  display: flex;
+  gap: 14px;
+  min-width: 0;
+}
+
+.loop-skill-profile__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  flex: 0 0 46px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 5px;
+  color: var(--semi-color-text-2, #8a8f99);
+  background: var(--semi-color-bg-0, #fff);
+}
+
+.loop-skill-profile__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.loop-skill-profile__name {
+  width: 100%;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--semi-color-text-0, #1c1f23);
+  cursor: text;
+  text-align: left;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-skill-profile__name:hover {
+  color: var(--semi-color-primary, #0064fa);
+}
+
+.loop-skill-profile__nameInput {
+  height: 22px;
+  min-height: 22px;
+}
+
+.loop-skill-profile__nameInput input {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 20px;
+}
+
+.loop-skill-profile__desc {
+  display: -webkit-box;
+  max-height: 45px;
+  overflow: hidden;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 12px;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow-wrap: anywhere;
+}
+
+.loop-skill-profile__desc.is-empty {
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-skill-profile__descTip {
+  max-width: 360px;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
+}
+
+.loop-skill-profile__subline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.loop-skill-profile__fact {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  column-gap: 4px;
+  row-gap: 1px;
+  min-width: 0;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.loop-skill-profile__fact svg {
+  grid-row: 1 / span 2;
+  align-self: start;
+  margin-top: 1px;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-skill-profile__fact span,
+.loop-skill-profile__fact strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loop-skill-profile__fact strong {
+  color: var(--semi-color-text-2, #8a8f99);
+  font-weight: 500;
+}
+
+.loop-skill-files {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 120px;
+  overflow: hidden;
+}
+
+.loop-skill-files__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 38px;
+  padding: 0 8px 0 14px;
+  flex: 0 0 auto;
+}
+
+.loop-skill-files__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-skill-files__addfile {
+  padding: 8px;
+  margin: 0 8px 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 6px;
+  background: var(--semi-color-bg-2, #f4f5f7);
+}
+
+.loop-skill-files__adderr {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--semi-color-danger, #f5222d);
+}
+
+.loop-skill-files__addbtns {
+  margin-top: 6px;
+  display: flex;
+  gap: 6px;
+}
+
+.loop-skill-files__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0 8px 8px;
+}
+
+.loop-skill-files__foot {
+  flex: 0 0 auto;
+  padding: 6px 8px 8px;
+}
+
+.loop-skill-agents {
+  flex: 0 0 auto;
+  max-height: 168px;
+  overflow: auto;
+  border-top: 1px solid var(--semi-color-border, #e8e9eb);
+  padding: 10px 12px 12px;
+  background: var(--semi-color-bg-1, #fbfbfc);
+}
+
+.loop-skill-agents__head {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 8px;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.loop-skill-agents__list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.loop-skill-agents__item {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  min-height: 24px;
+}
+
+.loop-skill-agents__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--semi-color-fill-1, #eaebee);
+  color: var(--semi-color-text-1, #4d535c);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.loop-skill-agents__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--semi-color-text-0, #1c1f23);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.loop-skill-agents__type,
+.loop-skill-agents__empty {
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 10px;
+}
+
+/* 文件树节点 */
+.loop-ftree__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 28px;
+  padding: 5px 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  color: var(--semi-color-text-0, #1c1f23);
+  border-radius: 5px;
+}
+.loop-ftree__row:hover {
+  background: var(--semi-color-fill-0, #f0f1f2);
+}
+.loop-ftree__file.is-selected {
+  background: var(--semi-color-fill-1, #e9eaed);
+  color: var(--semi-color-text-0, #1c1f23);
+  font-weight: 500;
+}
+.loop-ftree__chev,
+.loop-ftree__icon {
+  flex: 0 0 auto;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+.loop-ftree__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-ftree__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 8px;
+  color: var(--semi-color-text-2, #8a8f99);
+  font-size: 12px;
+}
+
+/* 右侧编辑器列 */
+.loop-skill-editor {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.loop-skill-editor__viewer {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+}
+
+/* 文件查看/编辑 */
+.loop-fv {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+.loop-fv__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+  padding: 5px 8px 5px 16px;
+  border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
+  flex: 0 0 auto;
+  gap: 12px;
+}
+.loop-fv__path {
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  color: var(--semi-color-text-2, #8a8f99);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-fv__modes {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 6px;
+  background: var(--semi-color-fill-0, #f5f6f8);
+  flex: 0 0 auto;
+}
+.loop-fv__mode {
+  min-width: 68px;
+  border-radius: 4px;
+}
+.loop-fv__mode.is-active {
+  background: var(--semi-color-bg-0, #fff);
+  color: var(--semi-color-text-0, #1c1f23);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.loop-fv__body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+}
+.loop-fv__preview {
+  min-width: 0;
+  padding: 16px 20px;
+  overflow-wrap: anywhere;
+}
+
+.loop-fv__preview .loop-md {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.loop-fv__frontmatter {
+  width: 100%;
+  max-width: 100%;
+  margin: 0 0 18px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--semi-color-bg-0, #fff);
+}
+
+.loop-fv__frontmatter th,
+.loop-fv__frontmatter td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
+  vertical-align: top;
+}
+
+.loop-fv__frontmatter tr:last-child th,
+.loop-fv__frontmatter tr:last-child td {
+  border-bottom: 0;
+}
+
+.loop-fv__frontmatter th {
+  width: 160px;
+  color: var(--semi-color-text-2, #8a8f99);
+  background: var(--semi-color-fill-0, #f5f6f8);
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.loop-fv__frontmatter td {
+  color: var(--semi-color-text-0, #1c1f23);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.loop-fv__editor {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+  resize: none;
+  padding: 16px 20px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--semi-color-text-0, #1c1f23);
+  background: var(--semi-color-bg-0, #fff);
+}
+
+@media (max-width: 900px) {
+  .loop-skill-body {
+    flex-direction: column;
+  }
+  .loop-skill-tree {
+    width: 100%;
+    flex: 0 0 auto;
+    max-height: 320px;
+    border-right: none;
+    border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
+  }
+}

--- a/packages/dmloop/src/ui/frontmatter.ts
+++ b/packages/dmloop/src/ui/frontmatter.ts
@@ -1,0 +1,69 @@
+// 保留捕获组尾部换行以对齐服务端 Go 侧 `server/internal/skill` 的正则语义。
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?\r?\n)---\r?\n?/;
+
+export type SkillFrontmatter = Record<string, string>;
+
+export interface ParsedFrontmatter {
+  frontmatter: SkillFrontmatter | null;
+  body: string;
+}
+
+function stripQuotes(v: string): string {
+  if (v.length >= 2 && ((v[0] === '"' && v.endsWith('"')) || (v[0] === "'" && v.endsWith("'")))) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+// 轻量 frontmatter 解析：仅用于展示技能文件头部的 key: value 字段。
+// 不引入 yaml 依赖；如需严格 YAML 解析（多行块标量等），改用 `yaml` 包的 parse。
+function parseSimpleYaml(block: string): SkillFrontmatter {
+  const result: SkillFrontmatter = {};
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = stripQuotes(line.slice(idx + 1).trim());
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/** 解析 Markdown frontmatter：无头/无字段时回退为纯正文。 */
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+  const match = FRONTMATTER_RE.exec(raw);
+  if (!match) return { frontmatter: null, body: raw };
+
+  const body = raw.slice(match[0].length);
+  const parsed = parseSimpleYaml(match[1]!);
+
+  return {
+    frontmatter: Object.keys(parsed).length > 0 ? parsed : null,
+    body,
+  };
+}
+
+/** 是否已带 `---\n...\n---` frontmatter 分隔块（不要求字段非空）。 */
+export function hasFrontmatter(raw: string): boolean {
+  return FRONTMATTER_RE.test(raw);
+}
+
+// 把值渲染成安全的 YAML 标量：含冒号/井号/引号/换行或首尾空格等不安全字符时用
+// 双引号包裹（JSON 字符串是合法的 YAML 双引号标量，转义规则一致）。
+function yamlScalar(v: string): string {
+  const unsafe = v === "" || /[:#\n"'\\]/.test(v) || /^[\s\-?&*!|>%@`[\]{},]/.test(v) || /\s$/.test(v);
+  return unsafe ? JSON.stringify(v) : v;
+}
+
+/**
+ * 确保 SKILL.md 带标准 frontmatter：若正文已含分隔块则原样返回；否则按
+ * `---\nname: ...\ndescription: ...\n---` 生成头部并拼在正文前，使新建的
+ * SKILL.md 符合服务端 ParseSkillFrontmatter 的解析格式。
+ */
+export function ensureSkillFrontmatter(name: string, description: string, content: string): string {
+  if (hasFrontmatter(content)) return content;
+  const header = `---\nname: ${yamlScalar(name)}\ndescription: ${yamlScalar(description)}\n---\n`;
+  return content.trim() ? `${header}\n${content}` : header;
+}

--- a/packages/dmloop/src/ui/skillName.ts
+++ b/packages/dmloop/src/ui/skillName.ts
@@ -1,0 +1,5 @@
+export const SKILL_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
+
+export function isValidSkillName(name: string): boolean {
+  return SKILL_NAME_PATTERN.test(name.trim());
+}


### PR DESCRIPTION
## Goal

Bring octo-web's Skill management UI to parity with the multica reference: multi-file skills backed by a file tree + code/markdown editor, a redesigned creation flow, and skill-usage visibility. Reuses the existing backend contract (`GET/PUT/POST /skills` return/accept inline `files[]`; `GET /agents` carries each agent's `skills`).

## Changes

- **Data layer** (`api/types.ts`): add `SkillFile`, `Skill.files`, `UpsertSkillReq.files` so skills carry `SKILL.md` (`content`) plus additional files inline.
- **Skill detail** (`panel/SkillDetailPage.tsx`): 3-pane layout — file tree | editor | metadata.
  - `SkillFileTree` — hierarchical tree, folder expand/collapse, `SKILL.md` pinned first.
  - `SkillFileViewer` — preview/edit toggle for markdown (rendered via LoopMarkdown), frontmatter card, plain editor for other files.
  - Add/delete file with path validation (no `/` prefix, no `..`, `SKILL.md` reserved, no dup); save submits the full file set.
  - "Used by N AI teammates" section, derived by inverting each agent's `skills`.
- **Frontmatter** (`ui/frontmatter.ts`): lightweight parser + `ensureSkillFrontmatter`, which prepends a standard `---\nname/description\n---` block on local create when missing, matching the server's `ParseSkillFrontmatter`.
- **New Skill modal** (`pages/SkillPage.tsx`): single two-column dialog — left tabs (blank draft / import from URL / copy from runtime) + right live preview, shared footer. Same APIs (`createSkill` / `importSkill` / runtime import).
- **Usage count**: list rows show "N AI teammates" (from `GET /agents`).
- **Misc**: en/zh i18n, CSS, skill-name validation (`ui/skillName.ts`), and fixed `t()` interpolation to pass `{ values: {...} }`.

## Verification

- `pnpm --filter web build` (vite) passes.
- Strict `tsc --skipLibCheck` clean for changed files.
- Manual smoke: open a multi-file skill → tree loads, `SKILL.md` preview renders frontmatter; toggle preview/edit; add/delete file; save persists after reload; create via all 3 tabs; long frontmatter wraps without breaking the toggle; list shows usage count.

## Note

Base `feat/octo-loop` advanced by #639 after this branch forked (benign divergence, different files). Recommend a rebase onto `feat/octo-loop` before merge.