### PR TITLE
feat(loop): file attachments on issues and comments

### DIFF
--- a/packages/dmloop/src/api/attachmentApi.ts
+++ b/packages/dmloop/src/api/attachmentApi.ts
@@ -1,0 +1,17 @@
+// @octo/loop — 附件 API(上传走 multica /api/upload-file,multipart)。
+import type { Attachment } from "./types";
+import { httpPost } from "./http";
+
+// 上传单个文件。可选 issueId/commentId 在上传时直接绑定(需目标已存在);
+// 否则拿返回的 id,通过 create/update issue|comment 的 attachment_ids 绑定(如新评论)。
+// 走现成 http client:axios 对 FormData 自动设 multipart 边界,鉴权/workspace header 由拦截器注入。
+export function uploadAttachment(
+  file: File,
+  opts?: { issueId?: string; commentId?: string },
+): Promise<Attachment> {
+  const form = new FormData();
+  form.append("file", file);
+  if (opts?.issueId) form.append("issue_id", opts.issueId);
+  if (opts?.commentId) form.append("comment_id", opts.commentId);
+  return httpPost<Attachment>("/upload-file", form);
+}

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -124,6 +124,8 @@ export interface Issue {
   labels?: IssueLabel[] | null;
   // issue 级 emoji 反应:仅详情端点(GetIssue)回填;list/update/ws 不带 → 保持已有。
   reactions?: IssueReaction[] | null;
+  // issue 附件:仅详情端点(GetIssue)回填;list/update/ws 不带 → 保持已有。
+  attachments?: Attachment[] | null;
   // 搜索结果专属(GET /issues/search):命中来源 + 高亮片段。列表/详情端点不返回。
   match_source?: string;
   matched_snippet?: string | null;
@@ -139,6 +141,8 @@ export interface CreateIssueReq {
   assignee_type?: AssigneeType | null;
   assignee_id?: string | null;
   project_id?: string | null;
+  // 新建时绑定已上传附件(上传返回的 id 列表)。
+  attachment_ids?: string[];
 }
 export interface UpdateIssueReq {
   title?: string;
@@ -156,6 +160,8 @@ export interface UpdateIssueReq {
   due_date?: string | null;
   parent_issue_id?: string | null;
   stage?: number | null;
+  // 绑定新上传的附件(id 列表);后端幂等,重复 id 无副作用。
+  attachment_ids?: string[];
   // 指派/状态变更触发 agent run 时：suppress_run=true 表示“暂不开始”；handoff_note 仅在真起 run 时消费。
   suppress_run?: boolean;
   handoff_note?: string;
@@ -216,6 +222,23 @@ export interface IssueSubscriber {
   created_at: string;
 }
 
+/** 附件(上传返回 + issue/comment 详情回填)。
+ *  download_url 为短时签名 URL(仅即时展示、勿持久化);markdown_url 可持久化内联进 markdown 正文。 */
+export interface Attachment {
+  id: string;
+  filename: string;
+  url: string;
+  download_url: string;
+  markdown_url: string;
+  content_type: string;
+  size_bytes: number;
+  created_at?: string;
+  // 归属:issue 级附件 comment_id 为空;评论附件 comment_id 指向评论。
+  // (后端 attachment 先绑 issue_id,再由 comment 的 attachment_ids 补 comment_id。)
+  issue_id?: string | null;
+  comment_id?: string | null;
+}
+
 /** issue 时间线条目(GET /issues/:id/timeline,不带分页参数时为裸数组、ASC)。
  *  合并 comment + activity 两类;活动流只用 activity 类(action/details)。 */
 export interface TimelineEntry {
@@ -248,6 +271,8 @@ export interface IssueComment {
   reactions?: CommentReaction[] | null;
   // 已解决时间(resolve/unresolve);非空=该评论已标记为线程结论。后端一线程至多一条 resolved。
   resolved_at?: string | null;
+  // 评论附件:后端 list/timeline 端点按 comment 分组回填;其它端点不带 → 保持已有。
+  attachments?: Attachment[] | null;
 }
 
 export type TaskStatus =

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -209,6 +209,11 @@
   "activity": {
     "title": "Activity"
   },
+  "attach": {
+    "title": "Attachments",
+    "add": "Add attachment",
+    "empty": "No attachments"
+  },
   "toast": {
     "created": "Created",
     "saved": "Saved",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -209,6 +209,11 @@
   "activity": {
     "title": "活动"
   },
+  "attach": {
+    "title": "附件",
+    "add": "添加附件",
+    "empty": "暂无附件"
+  },
   "toast": {
     "created": "已创建",
     "saved": "已保存",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -29,6 +29,7 @@ import {
   SmilePlus,
   Bell,
   BellOff,
+  Paperclip,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -36,6 +37,7 @@ import type {
   IssueComment,
   IssueSubscriber,
   TimelineEntry,
+  Attachment,
   TaskRun,
   IssueStatus,
   IssuePriority,
@@ -66,6 +68,7 @@ import {
   unresolveComment,
   listTimeline,
 } from "../api/collabApi";
+import { uploadAttachment } from "../api/attachmentApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelEditor from "../ui/LabelEditor";
@@ -128,6 +131,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]); // 评论输入区:待随评论提交的本地文件(发送时才上传)
+  const [uploading, setUploading] = useState(false); // issue 附件上传中
+  const [submitting, setSubmitting] = useState(false); // 评论提交中(含附件上传),防重复提交
 
   // 每次 reload 递增;异步响应回来前先比对 token,丢弃 issueId 原地切换后到达的旧请求结果,
   // 防止慢请求(issue A)在切到 B 后把 A 的数据写进 B 的视图(导航竞态)。
@@ -166,12 +172,13 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (!issue) return;
     try {
       const updated = await updateIssue(issue.id, p);
-      // PUT 响应不带 labels/reactions(仅 list/detail 端点回填);re-enrich 修回 assignee_name/
-      // project_name 等展示字段(按新值重算),labels/reactions 保留当前值,避免编辑后被清空。
+      // PUT 响应不带 labels/reactions/attachments(仅 list/detail 端点回填);re-enrich 修回
+      // assignee_name/project_name 等展示字段(按新值重算),labels/reactions/attachments 保留当前值,避免编辑后被清空。
       setIssue({
         ...(await enrichIssue(updated)),
         labels: updated.labels ?? issue.labels,
         reactions: updated.reactions ?? issue.reactions,
+        attachments: updated.attachments ?? issue.attachments,
       });
       onChanged?.();
     } catch (e) {
@@ -249,18 +256,89 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     }
   };
 
+  // 评论附件:本地持有 File,发送时才带 commentId 上传绑定(见 submitComment),
+  // 避免像 issue-first 那样在评论发出前就产生 issue 级孤儿附件。取消/离开=什么都没上传。
+  const addPendingFiles = (files: FileList | null) => {
+    if (!files?.length) return;
+    setPendingFiles((p) => [...p, ...Array.from(files)]);
+  };
+  const removePendingFile = (idx: number) => setPendingFiles((p) => p.filter((_, i) => i !== idx));
+
+  // issue 附件:issue 已存在,选完即刻带 issueId 上传绑定并重取详情读回。
+  const uploadForIssue = async (files: FileList | null) => {
+    if (!files?.length) return;
+    const token = reqRef.current;
+    setUploading(true);
+    try {
+      for (const f of Array.from(files)) await uploadAttachment(f, { issueId });
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      // 先解锁再触发重取(syncIssue 自带 catch、fire-and-forget):即使重取失败也不会把上传按钮永久卡在 disabled。
+      setUploading(false);
+      syncIssue(token);
+    }
+  };
+
+  // 附件渲染(评论/issue 共用):图片内联缩略,其它为带图标的下载链接(用短时 download_url)。
+  const renderAttachments = (atts: Attachment[] | null | undefined) => {
+    if (!atts?.length) return null;
+    return (
+      <div className="loop-atts">
+        {atts.map((a) =>
+          a.content_type.startsWith("image/") ? (
+            <a key={a.id} href={a.download_url} target="_blank" rel="noreferrer" className="loop-att loop-att--img">
+              <img src={a.download_url} alt={a.filename} />
+            </a>
+          ) : (
+            <a key={a.id} href={a.download_url} target="_blank" rel="noreferrer" className="loop-att">
+              <Paperclip size={12} />
+              <span>{a.filename}</span>
+            </a>
+          ),
+        )}
+      </div>
+    );
+  };
+
   const submitComment = async () => {
     const content = commentDraft.trim();
-    if (!content) return;
+    if (!content || submitting) return;
     const token = reqRef.current;
+    // 附件只随顶层评论;回复不带(pendingFiles 属主输入区)。
+    const files = replyTo ? [] : pendingFiles;
     const suppressIds = triggerAgents.filter((a) => suppressed.has(a.id)).map((a) => a.id);
-    await addComment(issueId, content, replyTo, suppressIds);
-    setCommentDraft("");
-    setReplyTo(null);
-    setTriggerAgents([]);
-    setSuppressed(new Set());
-    await reloadComments(token);
-    Toast.success(t("loop.toast.commentAdded"));
+    setSubmitting(true);
+    try {
+      let comment: IssueComment;
+      try {
+        comment = await addComment(issueId, content, replyTo, suppressIds);
+      } catch (e) {
+        // 评论未创建:保留草稿/待发文件供重试。
+        Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+        return;
+      }
+      // 评论已创建 → 立即清理输入态,避免后续附件上传失败时用户重复提交同一条评论。
+      setCommentDraft("");
+      setReplyTo(null);
+      setTriggerAgents([]);
+      setSuppressed(new Set());
+      if (!replyTo) setPendingFiles([]);
+      // 把待发文件带 commentId 绑到已建评论;单个失败只记录、不回滚评论。
+      let attFailed = false;
+      for (const f of files) {
+        try {
+          await uploadAttachment(f, { commentId: comment.id });
+        } catch {
+          attFailed = true;
+        }
+      }
+      await reloadComments(token);
+      if (attFailed) Toast.error(t("loop.toast.saveFailed"));
+      else Toast.success(t("loop.toast.commentAdded"));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   // 顶层评论输入时防抖预览"会唤醒哪些 agent"(回复暂不预览)。
@@ -477,6 +555,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const childrenDone = children.filter((c) => c.status === "done").length;
   // 活动流只取 activity 类(评论已在评论区渲染,避免重复)。filter 返回新数组,reverse 不改原 state。倒序:最新在上。
   const activities = timeline.filter((e) => e.type === "activity").reverse();
+  // issue 附件区只显 issue 级(comment_id 为空);评论附件归各评论下,避免重复。
+  const issueAtts = (issue.attachments ?? []).filter((a) => !a.comment_id);
 
   // emoji 反应条(评论 + issue 通用):按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
   const renderReactionBar = (
@@ -571,6 +651,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       ) : (
         <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
       )}
+      {renderAttachments(c.attachments)}
       {renderReactionBar(c.reactions, (emoji, add) => reactComment(c.id, emoji, add))}
       {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
       {!reply && replyTo === c.id && (
@@ -668,6 +749,27 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             </div>
           )}
 
+          <div className="loop-idp__section">
+            <div className="loop-detail__section-title loop-idp__desc-title">
+              <span>{t("loop.attach.title")} ({issueAtts.length})</span>
+              <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
+                {uploading ? <Spin size="small" /> : <Paperclip size={13} />}
+                <input
+                  type="file"
+                  multiple
+                  hidden
+                  disabled={uploading}
+                  onChange={(e) => { uploadForIssue(e.target.files); e.target.value = ""; }}
+                />
+              </label>
+            </div>
+            {issueAtts.length ? (
+              renderAttachments(issueAtts)
+            ) : (
+              <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.attach.empty")}</Text>
+            )}
+          </div>
+
           {activities.length > 0 && (
             <div className="loop-idp__section">
               <div className="loop-detail__section-title">
@@ -723,7 +825,18 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 <Text type="tertiary" style={{ fontSize: 11 }}>{t("loop.comment.tapToSuppress")}</Text>
               </div>
             )}
-            <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+            {!replyTo && pendingFiles.length > 0 && (
+              <div className="loop-atts" style={{ marginTop: 10 }}>
+                {pendingFiles.map((f, i) => (
+                  <span key={i} className="loop-att loop-att--pending">
+                    <Paperclip size={12} />
+                    <span>{f.name}</span>
+                    <button type="button" aria-label={t("loop.action.delete")} onClick={() => removePendingFile(i)}>×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div style={{ marginTop: 12, display: "flex", gap: 8, alignItems: "center" }}>
               <Input
                 value={replyTo ? "" : commentDraft}
                 disabled={!!replyTo}
@@ -731,7 +844,17 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 placeholder={replyTo ? t("loop.comment.replyingHint") : t("loop.comment.placeholder")}
                 onEnterPress={submitComment}
               />
-              <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} disabled={!!replyTo}>
+              <label className="loop-attach-btn" aria-label={t("loop.attach.add")} style={{ opacity: replyTo ? 0.4 : 1 }}>
+                <Paperclip size={16} />
+                <input
+                  type="file"
+                  multiple
+                  hidden
+                  disabled={!!replyTo || submitting}
+                  onChange={(e) => { addPendingFiles(e.target.files); e.target.value = ""; }}
+                />
+              </label>
+              <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} loading={submitting} disabled={!!replyTo}>
                 {t("loop.comment.send")}
               </Button>
             </div>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -194,3 +194,25 @@
 .loop-activities { display: flex; flex-direction: column; gap: 8px; }
 .loop-activity { display: flex; align-items: center; gap: 8px; font-size: 12px; }
 .loop-activity time { margin-left: auto; font-size: 11px; color: var(--semi-color-text-2, #8590a6); }
+
+/* 附件(PR-E) */
+.loop-atts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.loop-att {
+  display: inline-flex; align-items: center; gap: 4px; max-width: 220px;
+  padding: 2px 8px; border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 8px;
+  background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-1, #4e5969);
+  font-size: 12px; line-height: 18px; text-decoration: none;
+}
+.loop-att:hover { background: var(--semi-color-fill-1, #eef0f3); }
+.loop-att span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-att--img { padding: 0; border: none; background: none; }
+.loop-att--img img { max-height: 96px; max-width: 220px; border-radius: 8px; display: block; object-fit: cover; }
+.loop-att--pending button {
+  border: none; background: transparent; cursor: pointer; color: var(--semi-color-text-2, #8590a6);
+  font-size: 14px; line-height: 1; padding: 0 0 0 2px;
+}
+.loop-attach-btn {
+  display: inline-flex; align-items: center; justify-content: center; cursor: pointer;
+  color: var(--semi-color-text-2, #8590a6); padding: 4px; border-radius: 6px;
+}
+.loop-attach-btn:hover { background: var(--semi-color-fill-1, #eef0f3); color: var(--semi-color-text-0, #1c1f23); }


### PR DESCRIPTION
## What

第五枪能力对齐:**issue / 评论文件附件**。基于跨仓调研(octo 附件能力核实)结论——multica 已有 `/api/upload-file` + `attachment_ids` 绑定,dmloop 复用现成 http 通道 + markdown 渲染,新增面很小。

- `attachmentApi.uploadAttachment(file, {issueId?|commentId?})` → `POST /api/upload-file`(multipart;共享 axios client 自动设 boundary,拦截器注入 token/workspace/CSRF)。types 加 `Attachment` + `issue.attachments`/`comment.attachments`(详情/列表端点回填)。
- **issue 附件**:详情页「附件」区列出 issue 级附件(过滤 `comment_id==null`),上传按钮带 issueId 即时绑定后重取。图片内联(download_url),其它为下载链接。
- **评论附件**:输入区**本地持有**选中文件(pendingFiles),**发送时才带 commentId 上传绑定**——取消/离开不上传任何东西(无 issue 孤儿附件)。渲染在各评论下。

## 对抗审查发现并已修(全部提交前,e2e+DB 双证)
- patch() 补 `attachments` 保留(PUT 不回填,同 labels/reactions 类,否则编辑任意字段清空附件)。(Claude)
- 评论附件从「带 issueId 上传 + attachment_ids link」改为 **File-hold 发送时带 commentId 直传**:前者会让被取消/放弃的评论草稿变成永久 issue 附件(comment_id null / issue_id set);后者直接绑 comment_id(该后端路径无需 issue_id)——**DB 验证评论附件 issue_id=null、无 issue 孤儿**。(codex)
- submitComment:评论创建成功后**先清输入态再传附件**,单个附件失败隔离——附件报错不再残留可重复提交的草稿(防重复评论)。(codex)
- 上传守卫:提交中禁发送;uploadForIssue 先解锁 uploading 再 fire-and-forget 重取,避免重取失败卡死选择器。(codex)

## /simplify(4 agent)
clean —— 内联而非跨包复用 dmworkbase 的 FileToolbar(dmloop 不依赖 dmworkbase)、不抽 withUpload(2 处且变体漏)、自写 chip,均判为「能力层优先、UI 后续重画」下的正确懒选择。

## 真实浏览器 e2e(dev / Alice_Space / MV2 E2E,3 轮)
- issue 图片附件:上传 → 「附件 (1)」内联渲染 `<img src=/api/attachments/<uuid>/download>`。
- 评论附件 File-hold:选文件(本地 chip,未上传)→ 填评论 → 发送 → 评论下渲染附件链接;**DB 确认 comment_id 绑定、issue_id=null(无孤儿)、issue 附件区未被污染**。
- 测试数据按约定保留。

## Blast radius(模块外)
- `Attachment`/`issue.attachments`/`comment.attachments` 均可选新增;IssueList/IssueBoard 不消费;addComment 已回退去掉临时的 attachment_ids 参数(File-hold 改走 commentId 上传),无死参。
- FormData 上传经现成 axios(^0.25)+ 拦截器,不覆盖 Content-Type(浏览器设 multipart+boundary),实证工作。
- 整包 `tsc --skipLibCheck` 仅 2 处既有报错(非本 PR),PR-E 文件零错误。

基于最新 `feat/octo-loop`(含 #635/#636/#637/#639 我方四枪 + 他人 #640 skill-editor)。附件删除入口、图片内联进 markdown 正文属重 UI,随后续 UI 重画;@提及、订阅 toggle 另行。
