### PR TITLE
feat(loop): @mention picker in comments with non-navigable chips

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -312,6 +312,9 @@
   "reaction": {
     "add": "Add reaction"
   },
+  "mention": {
+    "add": "Mention"
+  },
   "agent": {
     "runtime": "Runtime",
     "model": "Model",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -312,6 +312,9 @@
   "reaction": {
     "add": "添加反应"
   },
+  "mention": {
+    "add": "@ 提及"
+  },
   "agent": {
     "runtime": "运行环境",
     "model": "模型",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   Bell,
   BellOff,
   Paperclip,
+  AtSign,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -38,6 +39,7 @@ import type {
   IssueSubscriber,
   TimelineEntry,
   Attachment,
+  AssigneeCandidate,
   TaskRun,
   IssueStatus,
   IssuePriority,
@@ -254,6 +256,15 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
     }
+  };
+
+  // @提及:选中候选(成员/AI队友/AI小队)→ 往草稿插入 mention markdown。
+  // 后端 util.MentionRe 认 [@Label](mention://<type>/<id>);插入草稿后 previewCommentTriggers 会反映"将唤醒"。
+  const insertMention = (c: AssigneeCandidate) => {
+    // label 剥掉 []:名字里的方括号会破坏 markdown 链接语法 [label](url);id 才是真引用,label 仅显示。
+    const label = c.name.replace(/[[\]]/g, "");
+    const token = `[@${label}](mention://${c.type}/${c.id})`;
+    setCommentDraft((d) => (d && !d.endsWith(" ") ? d + " " : d) + token + " ");
   };
 
   // 评论附件:本地持有 File,发送时才带 commentId 上传绑定(见 submitComment),
@@ -844,6 +855,29 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 placeholder={replyTo ? t("loop.comment.replyingHint") : t("loop.comment.placeholder")}
                 onEnterPress={submitComment}
               />
+              <Dropdown
+                trigger="click"
+                clickToHide
+                position="topRight"
+                render={
+                  <Dropdown.Menu>
+                    {(["member", "agent", "squad"] as const).map((type) => {
+                      const items = cands.filter((c) => c.type === type);
+                      if (!items.length) return null;
+                      return (
+                        <React.Fragment key={type}>
+                          <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
+                          {items.map((c) => (
+                            <Dropdown.Item key={c.id} onClick={() => insertMention(c)}>{c.name}</Dropdown.Item>
+                          ))}
+                        </React.Fragment>
+                      );
+                    })}
+                  </Dropdown.Menu>
+                }
+              >
+                <Button theme="borderless" icon={<AtSign size={16} />} disabled={!!replyTo} aria-label={t("loop.mention.add")} />
+              </Dropdown>
               <label className="loop-attach-btn" aria-label={t("loop.attach.add")} style={{ opacity: replyTo ? 0.4 : 1 }}>
                 <Paperclip size={16} />
                 <input

--- a/packages/dmloop/src/ui/LoopMarkdown.tsx
+++ b/packages/dmloop/src/ui/LoopMarkdown.tsx
@@ -1,7 +1,12 @@
 import React from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { uriTransformer } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import "./markdown.css";
+
+// react-markdown@8 默认只放行 http/https/mailto/tel，会把 mention:// 改写成 javascript:void(0)。
+// 放行 mention:，其余仍走默认清洗（保住对用户输入的 XSS 防护）。
+const transformLinkUri = (href: string) =>
+  href.startsWith("mention://") ? href : uriTransformer(href);
 
 /** Loop Markdown 渲染：标题/列表/代码块/行内代码/链接/表格/引用等美化展示。 */
 export default function LoopMarkdown({ content }: { content: string }) {
@@ -9,8 +14,15 @@ export default function LoopMarkdown({ content }: { content: string }) {
     <div className="loop-md">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        transformLinkUri={transformLinkUri}
         components={{
-          a: ({ node, ...props }) => <a target="_blank" rel="noreferrer" {...props} />,
+          a: ({ node, href, children, ...props }) => {
+            // mention 链接 [@Label](mention://type/id):渲染为不可导航的高亮 chip(点击无跳转)。
+            if (href && href.startsWith("mention://")) {
+              return <span className="loop-mention">{children}</span>;
+            }
+            return <a href={href} target="_blank" rel="noreferrer" {...props}>{children}</a>;
+          },
         }}
       >
         {content || ""}

--- a/packages/dmloop/src/ui/markdown.css
+++ b/packages/dmloop/src/ui/markdown.css
@@ -55,3 +55,10 @@
 .loop-md th { background: var(--semi-color-fill-0, #f5f6f8); font-weight: 600; }
 .loop-md hr { border: none; border-top: 1px solid var(--semi-color-border, #e8e9eb); margin: 16px 0; }
 .loop-md img { max-width: 100%; border-radius: 6px; }
+
+/* @提及 chip(mention:// 链接,不可导航;PR @提及) */
+.loop-mention {
+  color: var(--semi-color-primary, #0064fa);
+  background: var(--semi-color-primary-light-default, #e8f0ff);
+  border-radius: 4px; padding: 0 4px; font-weight: 500; white-space: nowrap;
+}


### PR DESCRIPTION
## What

Adds an **@ mention picker** to the Loop issue comment composer, and renders `mention://` links as non-navigable chips. Part of the MatterV2 capability-parity work (capability-layer-first, minimal UI).

### Composer
- New **"@ mention"** dropdown next to the comment box. Candidates come from the existing `useAssigneeCandidates` pipeline, grouped by member / agent / squad (reusing the `loop.assignee.*` i18n keys).
- Picking a candidate inserts a `[@Label](mention://type/id)` token into the draft. The token format matches octo-multica's `util.MentionRe` contract (`mention://(member|agent|squad|issue|all)/<uuid|all>`), so agent/squad mentions trigger runs on the backend and member/issue mentions link only.
- The label is stripped of `[` / `]` so a candidate name cannot corrupt the markdown link syntax.
- Disabled while replying (the reply composer is a separate scoped input).

### Rendering (`LoopMarkdown`)
- `mention://` links render as a non-navigable `.loop-mention` chip (no href, no navigation).
- **react-markdown@8's default `transformLinkUri` only allowlists http/https/mailto/tel** and would rewrite `mention://` to `javascript:void(0)` before the custom `a` renderer sees it — silently breaking the whole feature. A custom `transformLinkUri` passes `mention:` through while delegating every other scheme to the built-in `uriTransformer`, so **XSS sanitization of user-authored links is preserved** (a plain `transformLinkUri={false}` would have re-opened that hole).

## Verification (dev env, MV2 E2E workspace / MVE-4)

Real-browser e2e against the live bundle:
- `@ mention` → E2E Coworker (agent) inserts `[@E2E Coworker](mention://agent/<uuid>)`; the sent comment renders a `<span class="loop-mention">` chip (not a dead anchor). `将唤醒` preview reflects the agent.
- Regression: `[link](https://example.com/x)` still renders as `<a href="https://example.com/x" target="_blank">`.
- Security: `[xss](javascript:alert(1))` is neutralized to `href="javascript:void(0)"`.

## Review gate
- `/simplify` (4 agents): the one recurring finding (candidate-group render duplicated with the existing assign menu) was deliberately **kept** — the two consumers have diverged (assign has active/Divider, mention is plain) and real dedup would require editing the already-merged assign menu (out of this diff's blast radius); the altitude pass judged extracting-now to be over-abstraction (YAGNI). New block is same-shaped, so a future 3-site refactor stays easy.
- Dual-model adversarial review (codex + Claude code-reviewer). Claude caught the `transformLinkUri` neutralization bug above; both are fixed and verified.

## Tests
No unit test added: `packages/dmloop` currently has **no test harness** (no vitest config / script / test files anywhere in the package). Bootstrapping one for a single component is disproportionate infra scope for this feature PR; the changed branch is instead exercised end-to-end in the real runtime (above). A dmloop test harness is tracked as separate infra work.

## Blast radius
Scoped to `packages/dmloop`: `LoopMarkdown.tsx` (shared markdown renderer — the added `transformLinkUri`/chip branch is backward-compatible: non-mention links behave exactly as before), `IssueDetailPage.tsx` composer, two i18n files (additive `mention.add` key), one CSS rule. No shared type/prop/API signature changed; no consumer outside dmloop is affected.

Closes part of MatterV2 collaboration parity (mention capability, item 2 of subscribe-toggle + mention).
