### PR TITLE
feat(loop): state-aware subscribe toggle in issue detail

### DIFF
--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -220,6 +220,9 @@ export interface IssueSubscriber {
   user_id: string;
   reason: string;
   created_at: string;
+  /** octo IM uid the member is bridged to; null for agent/squad subscribers.
+   *  Lets the web tell whether the current octo member is subscribed. */
+  octo_uid?: string | null;
 }
 
 /** 附件(上传返回 + issue/comment 详情回填)。

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -211,7 +211,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       .catch(() => {});
   };
 
-  // 订阅/取消订阅(后端默认操作调用者本人、幂等);两项都常驻,不猜"我是否已订阅"。
+  // 订阅/取消订阅(后端默认操作调用者本人、幂等)。
   const toggleSubscribe = async (on: boolean) => {
     const token = reqRef.current;
     try {
@@ -223,6 +223,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
     }
   };
+
+  // 当前 octo 成员是否已订阅:subscriber 现在带 octo_uid(仅 member 有),与
+  // loginInfo.uid 比对即可判定,无需前端反查 member↔user 映射(去桥后仍成立)。
+  const myUid = WKApp.loginInfo.uid;
+  const amSubscribed =
+    !!myUid && subscribers.some((s) => s.user_type === "member" && s.octo_uid === myUid);
 
   // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
   const reactComment = async (commentId: string, emoji: string, add: boolean) => {
@@ -524,12 +530,15 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
-      <Dropdown.Item icon={<Bell size={13} />} onClick={() => toggleSubscribe(true)}>
-        {t("loop.subscribe.subscribe")}
-      </Dropdown.Item>
-      <Dropdown.Item icon={<BellOff size={13} />} onClick={() => toggleSubscribe(false)}>
-        {t("loop.subscribe.unsubscribe")}
-      </Dropdown.Item>
+      {amSubscribed ? (
+        <Dropdown.Item icon={<BellOff size={13} />} onClick={() => toggleSubscribe(false)}>
+          {t("loop.subscribe.unsubscribe")}
+        </Dropdown.Item>
+      ) : (
+        <Dropdown.Item icon={<Bell size={13} />} onClick={() => toggleSubscribe(true)}>
+          {t("loop.subscribe.subscribe")}
+        </Dropdown.Item>
+      )}
       <Dropdown.Divider />
       <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={handleDeleteIssue}>
         {t("loop.menu.deleteIssue")}
@@ -1014,6 +1023,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               <dt>{t("loop.subscribe.label")}</dt>
               <dd>
                 <Text type="tertiary" style={{ fontSize: 12 }}>{subscribers.length}</Text>
+                {amSubscribed && (
+                  <Text style={{ fontSize: 12, marginLeft: 6, color: "var(--semi-color-primary)" }}>
+                    · {t("loop.subscribe.subscribed")}
+                  </Text>
+                )}
               </dd>
             </dl>
           </div>


### PR DESCRIPTION
## What

Turns the issue subscribe control into a **real state-aware toggle**. Frontend half of Option A (backend: octo-multica MR !22, merged).

- `IssueSubscriber` gains `octo_uid?: string | null` (member subscribers only; null for agent/squad).
- The detail page derives `amSubscribed` by matching `WKApp.loginInfo.uid` against member subscribers' `octo_uid`.
- The "more" menu previously showed **both** "subscribe" and "unsubscribe" unconditionally (the client couldn't tell the current member's state). It now renders a single item — subscribe when not subscribed, unsubscribe when subscribed (`toggleSubscribe(!amSubscribed)`).
- The properties sidebar shows a "已订阅" indicator next to the subscriber count when the current member is subscribed.

## Why this identity resolution (Option A)

The backend surfaces `octo_uid` on the subscriber row so the web compares it to the logged-in octo uid directly. This survives multica de-bridge into octo — no frontend member↔multica-user id inversion (which would break then). Confirmed by review: the uid chain is `WKApp.loginInfo.token → octoResolver.Resolve → user.octo_uid → ListIssueSubscribers join → octo_uid`, i.e. `loginInfo.uid` and `subscriber.octo_uid` are the same namespace.

Agent/squad subscribers have `octo_uid === null` and never match; `!!myUid` guards the logged-out case — so neither is mistaken for the current member.

## Verification (dev, MV2 E2E / MVE-4)

Real-browser round-trip against the live backend serving `octo_uid`:
- Initial (Alice subscribed): sidebar shows "· 已订阅", subscriber count 4, menu shows "取消订阅".
- Click unsubscribe → indicator gone, count 3, menu flips to "订阅此 Issue".
- Click subscribe → indicator back, count 4, menu flips to "取消订阅" (state restored).

## Review gate

- `/simplify` (4 dims): applied — dropped a redundant `?.` on `WKApp.loginInfo` to match the repo convention (it's a never-null singleton; `!!myUid` covers the empty-string case). Ternary-vs-single-item was a wash, left explicit.
- Claude code-reviewer (skeptical): traced the full uid namespace chain, amSubscribed recompute timing, on/off semantics, null boundaries, consumer impact — no real bug.
- codex adversarial-review: the codex model stream was persistently dropping mid-turn this session (infra flakiness, `stream closed before response.completed`); on this feature's backend MR two codex runs did complete with "approve / no material findings" after reading the diff. The correctness gate is carried by the Claude reviewer + e2e here.

## Tests

No unit test added: `packages/dmloop` has no test harness (no vitest config/script/tests in the package); bootstrapping one for this is disproportionate infra scope. The change is exercised end-to-end in the real runtime (above). Tracked as separate infra work.

## Blast radius

`packages/dmloop` only. `IssueSubscriber` gains one optional field (additive; existing readers — the count, initial load — unaffected). `IssueDetailPage` swaps two static menu items for one derived item and adds a sidebar indicator; no shared type/prop/hook signature changed, no consumer outside dmloop touched.

## Docs

No doc change: additive optional type field + UI-only toggle behavior; no new service/command/config/env, dev tables unchanged.
