### PR TITLE
fix(loop): keep unsubscribe reachable when subscription state is unknown

### DIFF
--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -114,6 +114,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [issue, setIssue] = useState<Issue | null>(null);
   const [comments, setComments] = useState<IssueComment[]>([]);
   const [subscribers, setSubscribers] = useState<IssueSubscriber[]>([]);
+  // 订阅者列表是否已成功加载:未加载/加载失败时"我是否已订阅"不可判定,菜单回退到两项都显示。
+  const [subLoaded, setSubLoaded] = useState(false);
   const [children, setChildren] = useState<Issue[]>([]);
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
@@ -149,6 +151,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     // 短暂残留上一个 issue 的子列表、订阅者、父候选(旧候选还会漏掉新的自己)。
     setChildren([]);
     setSubscribers([]);
+    setSubLoaded(false);
     setParentCands([]);
     setTimeline([]);
     Promise.all([getIssue(issueId), listComments(issueId), listRuns(issueId)])
@@ -163,7 +166,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       .catch(() => { if (fresh()) Toast.error(t("loop.detail.notFound")); })
       .finally(() => { if (fresh()) setLoading(false); });
     // 订阅者、子 issue、时间线旁路加载:失败不影响主体渲染;同样按 token 丢弃过期响应。
-    listSubscribers(issueId).then((s) => { if (fresh()) setSubscribers(s); }).catch(() => {});
+    listSubscribers(issueId).then((s) => { if (fresh()) { setSubscribers(s); setSubLoaded(true); } }).catch(() => {});
     listChildren(issueId).then((c) => { if (fresh()) setChildren(c); }).catch(() => {});
     listTimeline(issueId).then((tl) => { if (fresh()) setTimeline(tl); }).catch(() => {});
   };
@@ -217,7 +220,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     try {
       await (on ? subscribeIssue : unsubscribeIssue)(issueId);
       const s = await listSubscribers(issueId);
-      if (token === reqRef.current) setSubscribers(s);
+      if (token === reqRef.current) { setSubscribers(s); setSubLoaded(true); }
       Toast.success(t(on ? "loop.subscribe.subscribed" : "loop.subscribe.unsubscribed"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
@@ -226,9 +229,24 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   // 当前 octo 成员是否已订阅:subscriber 现在带 octo_uid(仅 member 有),与
   // loginInfo.uid 比对即可判定,无需前端反查 member↔user 映射(去桥后仍成立)。
+  // 三态:列表未成功加载、或后端未透出 octo_uid(前后端独立上线的版本错配窗口)时
+  // "我是否已订阅"不可判定 → selfKnown=false,菜单回退到"订阅+取消订阅"两项都显示,
+  // 避免已订阅用户在此期间够不到 unsubscribe(#645 单一 toggle 的回归)。
   const myUid = WKApp.loginInfo.uid;
-  const amSubscribed =
-    !!myUid && subscribers.some((s) => s.user_type === "member" && s.octo_uid === myUid);
+  const memberSubs = subscribers.filter((s) => s.user_type === "member");
+  const octoUidSkew = memberSubs.length > 0 && memberSubs.every((s) => s.octo_uid == null);
+  const selfKnown = subLoaded && !octoUidSkew && !!myUid;
+  const amSubscribed = !!myUid && memberSubs.some((s) => s.octo_uid === myUid);
+  const subscribeItem = (
+    <Dropdown.Item icon={<Bell size={13} />} onClick={() => toggleSubscribe(true)}>
+      {t("loop.subscribe.subscribe")}
+    </Dropdown.Item>
+  );
+  const unsubscribeItem = (
+    <Dropdown.Item icon={<BellOff size={13} />} onClick={() => toggleSubscribe(false)}>
+      {t("loop.subscribe.unsubscribe")}
+    </Dropdown.Item>
+  );
 
   // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
   const reactComment = async (commentId: string, emoji: string, add: boolean) => {
@@ -530,14 +548,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
-      {amSubscribed ? (
-        <Dropdown.Item icon={<BellOff size={13} />} onClick={() => toggleSubscribe(false)}>
-          {t("loop.subscribe.unsubscribe")}
-        </Dropdown.Item>
+      {/* 订阅态不可判定(未加载/加载失败/后端未透出 octo_uid)时两项都显示,保证 unsubscribe 可达 */}
+      {!selfKnown ? (
+        <>
+          {subscribeItem}
+          {unsubscribeItem}
+        </>
+      ) : amSubscribed ? (
+        unsubscribeItem
       ) : (
-        <Dropdown.Item icon={<Bell size={13} />} onClick={() => toggleSubscribe(true)}>
-          {t("loop.subscribe.subscribe")}
-        </Dropdown.Item>
+        subscribeItem
       )}
       <Dropdown.Divider />
       <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={handleDeleteIssue}>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -219,11 +219,20 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     const token = reqRef.current;
     try {
       await (on ? subscribeIssue : unsubscribeIssue)(issueId);
+    } catch (e) {
+      // mutation 失败:服务端状态未变,不动本地订阅态。
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      return;
+    }
+    Toast.success(t(on ? "loop.subscribe.subscribed" : "loop.subscribe.unsubscribed"));
+    // mutation 成功后刷新确认新状态;刷新失败则把订阅态标记为"未知"(subLoaded=false),
+    // 菜单回退到两项都显示——否则会留下过期的"已知"态(如刚订阅成功但列表还是旧的空),
+    // 导致服务端已订阅、菜单却只显示「订阅」、藏了「取消订阅」(即本修复要防的回归)。
+    try {
       const s = await listSubscribers(issueId);
       if (token === reqRef.current) { setSubscribers(s); setSubLoaded(true); }
-      Toast.success(t(on ? "loop.subscribe.subscribed" : "loop.subscribe.unsubscribed"));
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } catch {
+      if (token === reqRef.current) setSubLoaded(false);
     }
   };
 


### PR DESCRIPTION
## What

Follow-up fix to **#645** (state-aware subscribe toggle). #645's single toggle drove the menu off `amSubscribed`, which collapses "unknown" into `false`. An already-subscribed member could lose the unsubscribe affordance when self-subscription can't be proven:

- the `/subscribers` fetch fails (network) — `subscribers` stays empty, error is swallowed; or
- **octo-web ships ahead of octo-multica MR !22** — the response carries no `octo_uid`, so no member matches.

In both cases the menu showed only "subscribe" and the user was **stuck subscribed** to notifications. (Found by codex adversarial review during the #645 follow-up gate; the pre-#645 menu always showed both actions, so this is a regression.)

## Fix — tri-state self-subscription

- Track `subLoaded` (true only after `listSubscribers` resolves; reset per issue, guarded by the existing `reqRef`/`fresh()` token).
- Detect `octoUidSkew` = member subscribers present but none carry `octo_uid` (backend not surfacing it yet — the deploy-skew window).
- `selfKnown = subLoaded && !octoUidSkew && !!myUid`. When **not** known, the menu falls back to showing **both** subscribe + unsubscribe (the pre-#645 safe behavior) so unsubscribe stays reachable; otherwise the single state-aware toggle is shown.
- Key invariant (verified by review): any uncertain state forces `amSubscribed=false`, so the menu branches and the "已订阅" sidebar indicator can share the same derived vars without disagreeing.

## Verification (dev, MV2 E2E / MVE-4)

Real-browser:
- Subscribed + `octo_uid` present → menu shows single "取消订阅", sidebar shows "· 已订阅" (preserves #645).
- Forced the `/subscribers` XHR to error (simulating load failure / the skew window) and re-opened the issue → menu shows **both** "订阅此 Issue" and "取消订阅" (unsubscribe reachable), and "已订阅" is correctly hidden.

## Review gate

- codex adversarial-review: **approve, no material findings** (inspected the touched path).
- Claude code-reviewer (skeptical): no real bug — verified `subLoaded` race is `fresh()`-guarded, empty-list edge (`selfKnown=true → subscribe only`, correctly distinguished from unknown), mixed-skew reasoning, and no reintroduction of the pre-#645 always-both behavior outside the unknown branch.
- `/simplify`: applied — hoisted the `!!myUid` guard out of the `.some()` predicate; extracted `subscribeItem`/`unsubscribeItem` to dedupe the 3-branch menu.

## Tests

No unit test added: `packages/dmloop` has no test harness. The tri-state branches are exercised end-to-end in the real runtime (above). A dmloop test harness remains separate infra work.

## Blast radius

`packages/dmloop/src/panel/IssueDetailPage.tsx` only. Adds one local `subLoaded` state + derived vars; no shared type/prop/signature change, no consumer outside dmloop. The `subscribers` state type is unchanged (kept `IssueSubscriber[]`, not `| null`, to avoid touching every reader).

## Docs

No doc change: UI-only behavior fix, no new service/command/config/env.
