### PR TITLE
fix(loop): don't lose comment attachments when upload fails after post

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -224,7 +224,9 @@
     "commentUpdated": "Comment updated",
     "editFailed": "Edit failed",
     "deleteFailed": "Delete failed",
-    "saveFailed": "Save failed"
+    "saveFailed": "Save failed",
+    "commentAttachFailed": "Comment posted, but {{count}} attachment(s) failed to upload — re-added to the box, please retry",
+    "attachFailed": "{{count}} attachment(s) failed to upload"
   },
   "validate": {
     "nameRequired": "Name is required",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -224,7 +224,9 @@
     "commentUpdated": "评论已更新",
     "editFailed": "编辑失败",
     "deleteFailed": "删除失败",
-    "saveFailed": "保存失败"
+    "saveFailed": "保存失败",
+    "commentAttachFailed": "评论已发送，但 {{count}} 个附件上传失败，已放回输入框请重试",
+    "attachFailed": "{{count}} 个附件上传失败"
   },
   "validate": {
     "nameRequired": "请填写名称",

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -384,7 +384,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           failedFiles.push(f);
         }
       }
-      await reloadComments(token);
+      // 先做失败回填 + 文案(同步、不会抛),再刷新评论列表:reloadComments await listComments 可能抛,
+      // 若放在其后,reload 失败会跳过回填 → 失败文件再次丢失(#647 评审抓到的排序缺口)。
       if (failedFiles.length) {
         // 评论已建成功、仅附件失败:把失败文件放回输入区(否则文件对象被丢弃、永久丢失且无重试入口),
         // 并用区分于"评论失败"的文案——避免误导用户以为整条评论没发出去。
@@ -393,6 +394,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       } else {
         Toast.success(t("loop.toast.commentAdded"));
       }
+      await reloadComments(token);
     } finally {
       setSubmitting(false);
     }

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -313,11 +313,18 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (!files?.length) return;
     const token = reqRef.current;
     setUploading(true);
+    let failed = 0;
     try {
-      for (const f of Array.from(files)) await uploadAttachment(f, { issueId });
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      // 逐文件隔离:一个失败不影响其余(与 submitComment 一致),否则首个失败会漏传后续文件。
+      for (const f of Array.from(files)) {
+        try {
+          await uploadAttachment(f, { issueId });
+        } catch {
+          failed++;
+        }
+      }
     } finally {
+      if (failed) Toast.error(t("loop.toast.attachFailed", { values: { count: failed } }));
       // 先解锁再触发重取(syncIssue 自带 catch、fire-and-forget):即使重取失败也不会把上传按钮永久卡在 disabled。
       setUploading(false);
       syncIssue(token);
@@ -369,17 +376,23 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       setSuppressed(new Set());
       if (!replyTo) setPendingFiles([]);
       // 把待发文件带 commentId 绑到已建评论;单个失败只记录、不回滚评论。
-      let attFailed = false;
+      const failedFiles: File[] = [];
       for (const f of files) {
         try {
           await uploadAttachment(f, { commentId: comment.id });
         } catch {
-          attFailed = true;
+          failedFiles.push(f);
         }
       }
       await reloadComments(token);
-      if (attFailed) Toast.error(t("loop.toast.saveFailed"));
-      else Toast.success(t("loop.toast.commentAdded"));
+      if (failedFiles.length) {
+        // 评论已建成功、仅附件失败:把失败文件放回输入区(否则文件对象被丢弃、永久丢失且无重试入口),
+        // 并用区分于"评论失败"的文案——避免误导用户以为整条评论没发出去。
+        if (!replyTo) setPendingFiles(failedFiles);
+        Toast.error(t("loop.toast.commentAttachFailed", { values: { count: failedFiles.length } }));
+      } else {
+        Toast.success(t("loop.toast.commentAdded"));
+      }
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## What

Follow-up fix to **#643** (file attachments). Reviewer **yujiawei** flagged a P1 that shipped with #643: a failed comment attachment was silently and permanently lost.

`submitComment` cleared `pendingFiles` before the upload loop and, on a per-file failure, only set `attFailed` and discarded the `File` — so the file was gone with no retry path, behind a generic **"save failed"** toast that wrongly implied the whole comment failed (it had already been created successfully). For an attachments feature, silently dropping the user's file behind a misleading error is a functional defect.

## Fix

- **Re-stage failed files + accurate message** — collect failed `File`s into `failedFiles`; after the loop, put them back into `pendingFiles` (non-reply path) so they aren't lost, and show a distinct toast: *"评论已发送，但 N 个附件上传失败，已放回输入框请重试"* instead of the generic save-failed.
- **`uploadForIssue` per-file isolation** — replace the single `try` around the awaited loop (which aborted remaining files after the first failure) with per-file `try/catch` + a failure count, consistent with `submitComment`.
- **i18n** — add `commentAttachFailed` / `attachFailed` (zh + en). Passed via this repo's `I18nService` convention `{ values: { count } }` (not `{ count }`).

## Verification (dev, MV2 E2E / MVE-4)

Real-browser, `/upload-file` XHR forced to fail:
- Sending a comment with an attachment → **comment is posted**, the failed file is **re-staged in the composer** (`pr-g2.txt` reappears — not lost), and the toast reads **"评论已发送，但 1 个附件上传失败，已放回输入框请重试"** — the `{{count}}` is interpolated to `1` (no literal placeholder).

## Review gate

- Claude code-reviewer (skeptical): caught a **Critical** in the first pass — the two new `t(...)` calls used `{ count }` instead of the project's `{ values: { count } }`, so interpolation silently failed (users would see literal `{{count}}`) and it may trip TS excess-property-check. **Fixed** (verified above the count now renders); re-reviewed clean on the other points (re-stage/replyTo, token race — mooted by `key={issueId}` remount, `finally` ordering).
- codex adversarial-review: approve, no material findings.
- `/simplify`: no changes needed.

## Not fixed here (deferred, from the same review — non-blocking P2)

- Client-side size/type/`accept` validation (needs a product decision on limits).
- Attachment-only comment (Send gated on non-empty content) — needs the backend contract for empty-content comments.
- `download_url` thumbnail `onError` fallback (short-lived signed URL past TTL).
- Index-as-key on the pending-file chips (documented no-runtime-bug nit; a proper fix needs per-file ids).

## Blast radius

`packages/dmloop` only — `IssueDetailPage.tsx` (`submitComment` / `uploadForIssue`) + two additive i18n keys. No shared type/prop/signature change, no consumer outside dmloop.

## Docs

No doc change: UI error-handling fix, no new service/command/config/env.
