### PR TITLE
refactor(loop): funnel mutation-then-refresh handlers through one helper

### DIFF
--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -257,38 +257,55 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     </Dropdown.Item>
   );
 
-  // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
-  const reactComment = async (commentId: string, emoji: string, add: boolean) => {
-    const token = reqRef.current;
+  // 写操作与"写后刷新"分离的通用漏斗:只有写失败才报错并中止;写成功后先跑同步的成功处理
+  // (onOk:toast / 本地 state,不会抛),再刷新——刷新失败不当作写失败、不误报、也不 strand 已成功的写。
+  // 收敛这一类 async 写(reaction / resolve / 删评论),杜绝"写+刷新同一 try"导致刷新失败误报或漏处理
+  // (原则:修一类而非单点)。
+  const mutateThenRefresh = async (
+    mutate: () => Promise<unknown>,
+    refresh: () => Promise<unknown>,
+    onOk?: () => void,
+  ) => {
     try {
-      await (add ? addCommentReaction : removeCommentReaction)(commentId, emoji);
-      await reloadComments(token);
+      await mutate();
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      return;
+    }
+    onOk?.();
+    try {
+      await refresh();
+    } catch {
+      /* 刷新失败:写已成功,不误报;下次 reload 自愈 */
     }
   };
 
-  // issue 级 emoji 反应:同评论,读回走 getIssue 的 issue.reactions(syncIssue 重取详情)。
-  const reactIssue = async (emoji: string, add: boolean) => {
+  // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
+  const reactComment = (commentId: string, emoji: string, add: boolean) => {
     const token = reqRef.current;
-    try {
-      await (add ? addIssueReaction : removeIssueReaction)(issueId, emoji);
-      await syncIssue(token);
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
-    }
+    return mutateThenRefresh(
+      () => (add ? addCommentReaction : removeCommentReaction)(commentId, emoji),
+      () => reloadComments(token),
+    );
+  };
+
+  // issue 级 emoji 反应:同评论,读回走 getIssue 的 issue.reactions(syncIssue 重取详情)。
+  const reactIssue = (emoji: string, add: boolean) => {
+    const token = reqRef.current;
+    return mutateThenRefresh(
+      () => (add ? addIssueReaction : removeIssueReaction)(issueId, emoji),
+      () => syncIssue(token),
+    );
   };
 
   // 评论 resolve/unresolve:后端「一线程至多一条 resolved」会清同线程兄弟,操作后重拉评论即可。
   // (resolve 只发实时事件、不写 activity_log,故活动流无需刷新。)
-  const toggleResolve = async (commentId: string, resolved: boolean) => {
+  const toggleResolve = (commentId: string, resolved: boolean) => {
     const token = reqRef.current;
-    try {
-      await (resolved ? unresolveComment : resolveComment)(commentId);
-      await reloadComments(token);
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
-    }
+    return mutateThenRefresh(
+      () => (resolved ? unresolveComment : resolveComment)(commentId),
+      () => reloadComments(token),
+    );
   };
 
   // @提及:选中候选(成员/AI队友/AI小队)→ 往草稿插入 mention markdown。
@@ -418,11 +435,14 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const toggleSuppress = (id: string) =>
     setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
 
-  const removeComment = async (id: string) => {
+  const removeComment = (id: string) => {
     const token = reqRef.current;
-    await deleteComment(id);
-    await reloadComments(token);
-    Toast.success(t("loop.toast.commentDeleted"));
+    // 删除失败→报错(否则静默);删除成功→先弹 commentDeleted(刷新前),再刷新评论列表。
+    return mutateThenRefresh(
+      () => deleteComment(id),
+      () => reloadComments(token),
+      () => Toast.success(t("loop.toast.commentDeleted")),
+    );
   };
 
   const saveEdit = async (id: string) => {


### PR DESCRIPTION
## Why

Global pass after the #643 / #646 / #647 review churn kept surfacing the *same class* of bug in different `IssueDetailPage` write handlers. Rather than keep point-fixing, this converges them.

**The class:** a write and its follow-up refresh in one `try`, so a *refresh* failure gets reported as a *write* failure or strands state. A whole-component scan found:
- `reactComment` / `reactIssue` / `toggleResolve` — reaction/resolve succeeds but the refresh throws → misleading "save failed" toast + stale UI (non-data-loss, self-corrects, but wrong feedback).
- `removeComment` — **no `try/catch` at all**: a failed delete was silent (unhandled rejection, no feedback); a delete-success-but-reload-fail dropped the success toast.

(`submitComment` was the data-loss instance — fixed in #647. `saveEdit` / `patch` are minor and left out of scope.)

## What

Add one helper encoding the correct shape:

```ts
mutateThenRefresh(mutate, refresh, onOk?):
  try { await mutate() } catch(e){ Toast.error(e.message ?? saveFailed); return }  // only a WRITE failure toasts + aborts
  onOk?.()                                                                          // sync success handling (toast/state) — cannot throw
  try { await refresh() } catch {}                                                  // refresh failure never re-surfaces as a write failure
```

Converge the four handlers onto it:
- `reactComment` / `reactIssue` / `toggleResolve` — drop their per-handler `try`; a refresh failure after a successful reaction/resolve no longer shows "save failed".
- `removeComment` — now surfaces an error toast on a failed delete (was silent), and the success toast fires before the reload.

Token capture is unchanged (each handler still reads `reqRef.current` synchronously before calling the helper and passes it into `reloadComments`/`syncIssue`, whose own staleness guard is preserved).

## Verification (dev, MV2 E2E / MVE-4)

- Reaction toggles through the helper with no spurious error (happy path intact).
- With `DELETE /comments/:id` forced to fail, deleting a comment now surfaces an error toast ("Network Error") instead of failing silently.

## Review gate

- Claude code-reviewer (skeptical): 6-point check — helper semantics, token capture timing, `removeComment` behavior change, `confirmDelete` call-site compatibility (helper returns `Promise<void>`, `onOk: () => void | Promise<void>` accepts it), `syncIssue` never-rejects interaction, no lost per-handler behavior — no real bug.
- codex adversarial-review: approve, no material findings.
- `/simplify`: helper abstraction appropriate/mergeable; applied its two comment-readability notes (dropped PR-history narration + a brittle rule-number reference).

## Blast radius

`packages/dmloop/src/panel/IssueDetailPage.tsx` only — one new in-component helper + four handlers reshaped; call sites unchanged (`confirmDelete({ onOk })` still compatible). No shared type/prop/signature change, no consumer outside dmloop.

## Docs

No doc change: internal error-handling consistency refactor, no new service/command/config/env. (The "fix the class, not the instance" principle this follows was added to the global dev rules separately.)
