### PR TITLE
feat(base): roomier sticker grid + larger hover preview with caret

### DIFF
--- a/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/__tests__/EmojiPanel.test.tsx
@@ -598,6 +598,23 @@ describe("EmojiPanel sticker hover preview（原位放大预览）", () => {
         const preview = document.body.querySelector(".wk-sticker-preview");
         expect(preview?.getAttribute("aria-hidden")).toBe("true");
     });
+
+    it("renders a caret pointing at the source cell alongside the preview", async () => {
+        const item = await mountWithSticker();
+        vi.useFakeTimers();
+        hover(item);
+        act(() => {
+            vi.advanceTimersByTime(120);
+        });
+        vi.useRealTimers();
+
+        // caret 与预览同在浮层内；朝向类名二选一（jsdom 下 rect 全 0，上方放不下会翻到下方）。
+        const caret = document.body.querySelector(".wk-sticker-preview .wk-sticker-preview-caret");
+        expect(caret).not.toBeNull();
+        expect(
+            caret!.classList.contains("is-above") || caret!.classList.contains("is-below")
+        ).toBe(true);
+    });
 });
 
 describe("EmojiPanel sticker upload validation (WKApp.remoteConfig.stickerUploadLimits)", () => {

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.css
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.css
@@ -208,11 +208,16 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
     box-shadow: 0 4px 10px rgba(0, 0, 0, .12);
 }
 
-/* sticker thumbnails are 60px — override the 28px emoji-img rule via higher specificity */
+/* sticker thumbnails are 60px — override the 28px emoji-img rule via higher specificity。
+   max-width/height:100% 是给 grid 化后的兜底：格子随窄面板收缩到 <72px 时内容盒会小于
+   60px，固定 60px 的媒体会被 .wk-sticker-item{overflow:hidden} 裁掉；封顶到内容盒后随格子
+   缩、object-fit 保持比例、永不裁。正常宽度下内容盒 ≥60px，媒体仍是 60px，观感不变。 */
 .wk-emojipanel-content ul li.wk-sticker-item img,
 .wk-emojipanel-content ul li.wk-sticker-item tgs-player {
     width: 60px;
     height: 60px;
+    max-width: 100%;
+    max-height: 100%;
     object-fit: contain;
     margin: 0;
 }
@@ -295,7 +300,7 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
 
 /* hover「原位弹大」预览：portal 到 <body>、position:fixed，盖过面板（面板 z-index:999）。
    pointer-events:none 让它不拦截鼠标——既不打断「点击即发送」，也保证网格的 mouseleave
-   能正常触发去隐藏预览。尺寸/坐标由行内 style 给（computeStickerPreviewStyle）。 */
+   能正常触发去隐藏预览。尺寸/坐标由行内 style 给（computeStickerPreviewGeometry）。 */
 .wk-sticker-preview {
     position: fixed;
     z-index: 1002;

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.css
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.css
@@ -165,8 +165,25 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
 }
 
 /* ===== 我的贴纸（用户自定义贴纸）===== */
+/* 固定 5 列网格 + gap，替代原来的 flex-wrap。flex 下 74px 格子 + 12px gap 在面板出现滚动条
+   时（可用宽度少 ~15px）会时而挤成一排 5 个、时而回落到 4 个，随贴纸数量抖动。改用 grid 5 列
+   + 1fr 让列宽自适应，稳定一排 5 个，格子之间恒定留 12px（--wk-sp-3），不再贴在一起。 */
 .wk-emojipanel-content-sticker ul {
     align-content: flex-start;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: var(--wk-sp-3);
+}
+/* grid 化后格子撑满列宽（原来是固定 74px），用 aspect-ratio 保持正方。 */
+.wk-emojipanel-content-sticker ul .wk-sticker-item,
+.wk-emojipanel-content-sticker ul .wk-sticker-add {
+    width: auto;
+    height: auto;
+    aspect-ratio: 1 / 1;
+}
+/* 空态提示铺满整行（否则在 grid 里只占 1 列）。 */
+.wk-emojipanel-content-sticker ul .wk-sticker-empty {
+    grid-column: 1 / -1;
 }
 
 .wk-sticker-item,
@@ -301,9 +318,33 @@ body[theme-mode=dark] .wk-emojipanel-tab-item-selected {
     height: 100%;
     object-fit: contain;
 }
+/* 指向源格子的小三角：朝向由 is-above/is-below 决定，水平位置由行内 left 给（对齐格子中心）。
+   用 --wk-color-item 填充、与卡片同色，像卡片探出的尾巴；主题感知，暗色下自动跟着变。 */
+.wk-sticker-preview-caret {
+    position: absolute;
+    width: 0;
+    height: 0;
+    transform: translateX(-50%);
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+}
+.wk-sticker-preview-caret.is-above {
+    bottom: -8px;
+    border-top: 9px solid var(--wk-color-item);
+}
+.wk-sticker-preview-caret.is-below {
+    top: -8px;
+    border-bottom: 9px solid var(--wk-color-item);
+}
 @keyframes wkStickerPreviewIn {
     from { opacity: 0; transform: scale(.85); }
     to { opacity: 1; transform: scale(1); }
+}
+/* 尊重「减少动态」偏好：关掉浮入动画，直接显示。 */
+@media (prefers-reduced-motion: reduce) {
+    .wk-sticker-preview {
+        animation: none;
+    }
 }
 
 /* dark mode */

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -82,6 +82,9 @@ const STICKER_PREVIEW_SIZE = 170
 const STICKER_PREVIEW_MARGIN = 8
 // 放大卡片与格子之间的间距，避免贴着格子边缘。
 const STICKER_PREVIEW_GAP = 8
+// caret 尖角在卡片内的最小左右内边距：--wk-r-lg 圆角 16 + 尖角半基座 8 = 24，
+// 保证边列贴纸把卡片夹到视口边时，尖角基座仍整段落在卡片直边、不压圆角。
+const STICKER_PREVIEW_CARET_INSET = 24
 // 首次悬停到浮出的延时：扫过网格时不会一路狂闪；一旦浮出，格子间移动直接无缝切换。
 const STICKER_PREVIEW_DELAY = 120
 
@@ -480,7 +483,8 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
     // 把放大卡片定位并夹进视口（口径同 computePanelPos）：水平以格子中心对齐；垂直优先浮在
     // 格子上方（保留格子与删除「×」可见），上方空间不足则翻到格子下方，最后统一夹进视口。
     // 一并算出指向源格子的 caret：placement=above 时卡片在格子上方、尖朝下；below 时反之。
-    // caretLeft 是尖角相对卡片左边缘的偏移，对齐格子中心并夹在卡片左右内 14px（不压圆角）。
+    // caretLeft 是尖角相对卡片左边缘的偏移，对齐格子中心并夹进卡片内 STICKER_PREVIEW_CARET_INSET，
+    // 保证尖角基座整段落在卡片直边上、不压到圆角。
     private computeStickerPreviewGeometry(rect: DOMRect): {
         style: React.CSSProperties
         placement: "above" | "below"
@@ -501,7 +505,10 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
             placement = "below"
         }
         top = Math.max(m, Math.min(top, vh - size - m))
-        const caretLeft = Math.max(14, Math.min(cellCenterX - left, size - 14))
+        const caretLeft = Math.max(
+            STICKER_PREVIEW_CARET_INSET,
+            Math.min(cellCenterX - left, size - STICKER_PREVIEW_CARET_INSET)
+        )
         return { style: { left, top, width: size, height: size }, placement, caretLeft }
     }
 

--- a/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
+++ b/packages/dmworkbase/src/Components/EmojiToolbar/index.tsx
@@ -78,7 +78,7 @@ const EMOJI_PANEL_MARGIN = 8
 // <body>、position:fixed 并夹进视口——因为面板内容区 .wk-emojipanel-content 是
 // overflow:hidden，放大卡片会被裁掉顶部/边缘，portal 才能让它浮出面板而不被裁。
 // 浮在格子上方（而非盖住格子）是为了不遮挡 hover 才出现的右上角删除「×」。
-const STICKER_PREVIEW_SIZE = 140
+const STICKER_PREVIEW_SIZE = 170
 const STICKER_PREVIEW_MARGIN = 8
 // 放大卡片与格子之间的间距，避免贴着格子边缘。
 const STICKER_PREVIEW_GAP = 8
@@ -479,20 +479,30 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
 
     // 把放大卡片定位并夹进视口（口径同 computePanelPos）：水平以格子中心对齐；垂直优先浮在
     // 格子上方（保留格子与删除「×」可见），上方空间不足则翻到格子下方，最后统一夹进视口。
-    private computeStickerPreviewStyle(rect: DOMRect): React.CSSProperties {
+    // 一并算出指向源格子的 caret：placement=above 时卡片在格子上方、尖朝下；below 时反之。
+    // caretLeft 是尖角相对卡片左边缘的偏移，对齐格子中心并夹在卡片左右内 14px（不压圆角）。
+    private computeStickerPreviewGeometry(rect: DOMRect): {
+        style: React.CSSProperties
+        placement: "above" | "below"
+        caretLeft: number
+    } {
         const vw = typeof window !== "undefined" ? window.innerWidth : STICKER_PREVIEW_SIZE
         const vh = typeof window !== "undefined" ? window.innerHeight : STICKER_PREVIEW_SIZE
         const m = STICKER_PREVIEW_MARGIN
         // 小视口兜底：卡片边长不超过可用视口，避免极窄/极矮窗口下夹取退化后仍溢出、盖住
         // 格子与删除「×」。正常面板尺寸下就是 STICKER_PREVIEW_SIZE。
         const size = Math.max(0, Math.min(STICKER_PREVIEW_SIZE, vw - 2 * m, vh - 2 * m))
-        const left = Math.max(m, Math.min(rect.left + rect.width / 2 - size / 2, vw - size - m))
+        const cellCenterX = rect.left + rect.width / 2
+        const left = Math.max(m, Math.min(cellCenterX - size / 2, vw - size - m))
         let top = rect.top - STICKER_PREVIEW_GAP - size
+        let placement: "above" | "below" = "above"
         if (top < m) {
             top = rect.bottom + STICKER_PREVIEW_GAP
+            placement = "below"
         }
         top = Math.max(m, Math.min(top, vh - size - m))
-        return { left, top, width: size, height: size }
+        const caretLeft = Math.max(14, Math.min(cellCenterX - left, size - 14))
+        return { style: { left, top, width: size, height: size }, placement, caretLeft }
     }
 
     render(): React.ReactNode {
@@ -506,15 +516,21 @@ export class EmojiPanel extends Component<EmojiPanelProps, EmojiPanelState> {
         const isSticker = stickerCustomEnabled && category === STICKER_CATEGORY
         // 放大预览层 portal 到 <body>，逃出 .wk-emojipanel-content 的 overflow:hidden 裁剪，
         // 并盖过面板（面板 z-index:999）。pointer-events:none（见 CSS）保证不拦截点击即发送。
-        const previewOverlay = isSticker && preview && typeof document !== "undefined"
+        const previewGeo = isSticker && preview ? this.computeStickerPreviewGeometry(preview.rect) : null
+        const previewOverlay = isSticker && preview && previewGeo && typeof document !== "undefined"
             ? ReactDOM.createPortal(
-                <div className="wk-sticker-preview" style={this.computeStickerPreviewStyle(preview.rect)} aria-hidden="true">
+                <div className="wk-sticker-preview" style={previewGeo.style} aria-hidden="true">
                     {/* key 按 sticker_id：切换目标时重建媒体元素，避免复用同一 <tgs-player>、
                         只换 src 时 Lottie 动画不重启（沿用 renderStickerMedia 的分流）。 */}
                     {React.cloneElement(
                         this.renderStickerMedia(preview.sticker) as React.ReactElement,
                         { key: preview.sticker.sticker_id }
                     )}
+                    {/* 指向被 hover 的源格子的小三角，让"大图 ↔ 哪张贴纸"连起来。 */}
+                    <span
+                        className={classNames("wk-sticker-preview-caret", previewGeo.placement === "below" ? "is-below" : "is-above")}
+                        style={{ left: previewGeo.caretLeft }}
+                    />
                 </div>,
                 document.body
             )


### PR DESCRIPTION
## Summary

Follow-up polish on the custom-sticker panel from #586. The sticker cells were cramped (no gap between them), the hover preview was a touch small for text-heavy stickers, and nothing linked the enlarged card to the sticker it previewed. This adds grid spacing, a bigger preview, and a caret pointing at the source cell.

## Related Issue

Closes #649

## Changes

- **Grid spacing**: the sticker grid was `flex-wrap` with no gap, so the 74px cell backgrounds sat directly against each other and read as cramped. Switched to a fixed 5-column CSS grid with a 12px gap (`--wk-sp-3`); cells fill the columns (square via `aspect-ratio: 1/1`), and the empty-state row spans all columns. Grid (not `flex + gap`) keeps it a **stable 5-per-row** — under flex, 5 cells + 12px gaps sit ~8px under the content width and would flip to 4 whenever the panel's scrollbar claims that width.
- **Thumbnails don't clip**: on a panel narrower than ~457px (it shrinks via `max-width: calc(100vw - 16px)`) the grid cells shrink; the media is capped with `max-width/height: 100%` so it scales down to the cell instead of being clipped by `overflow: hidden`, while staying 60px at normal widths.
- **Preview size**: 140 → 170px, so text-heavy stickers read comfortably at the enlarged size.
- **Caret**: the preview renders a small triangle pointing at the hovered cell (above/below follows the flip; horizontally aligned to the cell centre and clamped clear of the card's 16px rounded corner). Filled with `--wk-color-item` so it matches the card and adapts to dark mode.
- **Reduced motion**: drop the fade-in under `prefers-reduced-motion`.

Touched files: `packages/dmworkbase/src/Components/EmojiToolbar/{index.tsx,index.css}` and its `__tests__/EmojiPanel.test.tsx`.

## Testing

- **Unit tests**: added a caret-presence case; `pnpm test` → **34/34 passing** in `EmojiPanel.test.tsx`.
- **Browser verification**: rendered the real `EmojiPanel` + real `index.css` in headless Chromium. Confirmed `display: grid`, 5 columns, `gap: 12px`, preview media 146px (170 card), caret rendered (`is-above`). On a narrow 404px panel, cells shrink to 64px and the media scales to 52px with **no clipping** (`clipped: false`).
- `stylelint` on the CSS passes (0 errors).
- Self-reviewed via `/code-review` (xhigh); the findings it surfaced (narrow-panel clip, caret vs rounded corner, a stale comment) are fixed in this branch.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation (N/A — no doc changes needed)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy (no new UI copy / i18n keys — layout + preview sizing only)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqK7GsbQNc77pFQ3Gis3Zq

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqK7GsbQNc77pFQ3Gis3Zq)_