### PR TITLE
feat(loop): Tier1 issue browse/edit — grouped board, scope pill, running chip, sub-issue create, batch ops

### DIFF
--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -15,7 +15,7 @@ import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
 import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
-import { isMulticaCliAuthorizePath, MULTICA_CLI_AUTHORIZE_PATH } from "@octo/loop";
+import { isLoopCliAuthorizePath, LOOP_CLI_AUTHORIZE_PATH } from "@octo/loop";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -352,7 +352,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
 
         // The CLI authorization deep-link is a full-page flow outside the normal app shell.
         // Reuse a single stored Octo session when the clean URL carries no sid-specific token.
-        if (isMulticaCliAuthorizePath(window.location.pathname)) {
+        if (isLoopCliAuthorizePath(window.location.pathname)) {
             if (!WKApp.loginInfo.token) {
                 WKApp.loginInfo.load();
             }
@@ -364,7 +364,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                     const cachedSpaceId = localStorage.getItem("currentSpaceId") || "";
                     if (cachedSpaceId) WKApp.shared.currentSpaceId = cachedSpaceId;
                 }
-                const cliAuthorizeComponent = WKApp.route.get(MULTICA_CLI_AUTHORIZE_PATH);
+                const cliAuthorizeComponent = WKApp.route.get(LOOP_CLI_AUTHORIZE_PATH);
                 if (cliAuthorizeComponent) return cliAuthorizeComponent;
             }
         }

--- a/apps/web/src/__tests__/loopCliAuthorizeDeepLink.test.ts
+++ b/apps/web/src/__tests__/loopCliAuthorizeDeepLink.test.ts
@@ -2,21 +2,21 @@ import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  clearPendingMulticaCliAuthorizeSearch,
-  isMulticaCliAuthorizePath,
-  resolveMulticaCliAuthorizeSearch,
-  visibleMulticaCliAuthorizeSearch,
+  clearPendingLoopCliAuthorizeSearch,
+  isLoopCliAuthorizePath,
+  resolveLoopCliAuthorizeSearch,
+  visibleLoopCliAuthorizeSearch,
 } from "../../../../packages/dmloop/src/cliAuthorizeSession";
 
-describe("Multica CLI authorize deep link", () => {
+describe("Loop CLI authorize deep link", () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
 
   it("accepts the canonical route with or without a trailing slash", () => {
-    expect(isMulticaCliAuthorizePath("/loop/cli-authorize")).toBe(true);
-    expect(isMulticaCliAuthorizePath("/loop/cli-authorize/")).toBe(true);
-    expect(isMulticaCliAuthorizePath("/loop/multica")).toBe(false);
+    expect(isLoopCliAuthorizePath("/loop/cli-authorize")).toBe(true);
+    expect(isLoopCliAuthorizePath("/loop/cli-authorize/")).toBe(true);
+    expect(isLoopCliAuthorizePath("/loop/not-authorize")).toBe(false);
   });
 
   it("keeps callback parameters after RouteManager replaces the query with sid", () => {
@@ -24,7 +24,7 @@ describe("Multica CLI authorize deep link", () => {
       "?cli_callback=http%3A%2F%2Flocalhost%3A57270%2Fcallback&cli_state=state-1";
 
     expect(
-      resolveMulticaCliAuthorizeSearch(
+      resolveLoopCliAuthorizeSearch(
         "/loop/cli-authorize",
         original,
         sessionStorage
@@ -32,7 +32,7 @@ describe("Multica CLI authorize deep link", () => {
     ).toBe(original);
 
     expect(
-      resolveMulticaCliAuthorizeSearch(
+      resolveLoopCliAuthorizeSearch(
         "/loop/cli-authorize/",
         "?sid=llg60f",
         sessionStorage
@@ -41,16 +41,16 @@ describe("Multica CLI authorize deep link", () => {
   });
 
   it("clears the pending callback after redirecting to the CLI", () => {
-    resolveMulticaCliAuthorizeSearch(
+    resolveLoopCliAuthorizeSearch(
       "/loop/cli-authorize",
       "?cli_callback=http%3A%2F%2Flocalhost%3A57270%2Fcallback&cli_state=x",
       sessionStorage
     );
 
-    clearPendingMulticaCliAuthorizeSearch(sessionStorage);
+    clearPendingLoopCliAuthorizeSearch(sessionStorage);
 
     expect(
-      resolveMulticaCliAuthorizeSearch(
+      resolveLoopCliAuthorizeSearch(
         "/loop/cli-authorize",
         "?sid=next",
         sessionStorage
@@ -60,7 +60,7 @@ describe("Multica CLI authorize deep link", () => {
 
   it("keeps the existing sid when callback parameters are hidden", () => {
     expect(
-      visibleMulticaCliAuthorizeSearch(
+      visibleLoopCliAuthorizeSearch(
         "?sid=5asghu&cli_callback=http%3A%2F%2Flocalhost%3A52652%2Fcallback&cli_state=state"
       )
     ).toBe("?sid=5asghu");
@@ -71,7 +71,7 @@ describe("Multica CLI authorize deep link", () => {
       path.join(__dirname, "../Layout/index.tsx"),
       "utf-8"
     );
-    const cliRoute = layout.indexOf("isMulticaCliAuthorizePath(");
+    const cliRoute = layout.indexOf("isLoopCliAuthorizePath(");
     const provider = layout.search(/return\s*(?:\(\s*)?<Provider/);
 
     expect(cliRoute).toBeGreaterThan(-1);
@@ -79,7 +79,7 @@ describe("Multica CLI authorize deep link", () => {
     expect(cliRoute).toBeLessThan(provider);
     expect(layout).toContain("recoverOctoSessionFromStorage(true)");
     expect(layout).toMatch(
-      /WKApp\.route\.get\(\s*MULTICA_CLI_AUTHORIZE_PATH\s*\)/
+      /WKApp\.route\.get\(\s*LOOP_CLI_AUTHORIZE_PATH\s*\)/
     );
   });
 });

--- a/packages/dmloop/src/api/attachmentApi.ts
+++ b/packages/dmloop/src/api/attachmentApi.ts
@@ -1,4 +1,4 @@
-// @octo/loop — 附件 API(上传走 multica /api/upload-file,multipart)。
+// @octo/loop — 附件 API(上传走后端 /api/upload-file,multipart)。
 import type { Attachment } from "./types";
 import { httpPost } from "./http";
 

--- a/packages/dmloop/src/api/authApi.ts
+++ b/packages/dmloop/src/api/authApi.ts
@@ -1,5 +1,5 @@
 import { httpPost } from "./http";
 
-export function issueMulticaCliToken(): Promise<{ token: string }> {
+export function issueLoopCliToken(): Promise<{ token: string }> {
   return httpPost<{ token: string }>("/cli-token");
 }

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -5,6 +5,9 @@ import type {
   CreateIssueReq,
   UpdateIssueReq,
   ListParams,
+  GroupedParams,
+  IssueGroup,
+  AgentTaskSnapshotItem,
   AssigneeCandidate,
   IssueTriggerPreview,
   IssueTriggerPreviewParams,
@@ -13,8 +16,8 @@ import type {
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
 
-async function enrich(issues: Issue[]): Promise<Issue[]> {
-  const dir = await ensureDirectory();
+// enrich 的同步核心:调用方已拿到 directory 时复用,避免每组重复 ensureDirectory。
+function enrichWith(dir: Awaited<ReturnType<typeof ensureDirectory>>, issues: Issue[]): Issue[] {
   return issues.map((i) => ({
     ...i,
     assignee_name: actorName(dir, i.assignee_type, i.assignee_id),
@@ -23,6 +26,11 @@ async function enrich(issues: Issue[]): Promise<Issue[]> {
     creator_avatar: actorAvatar(dir, i.creator_type ?? "member", i.creator_id),
     project_name: i.project_id ? dir.projectName.get(i.project_id) ?? null : null,
   }));
+}
+
+async function enrich(issues: Issue[]): Promise<Issue[]> {
+  const dir = await ensureDirectory();
+  return enrichWith(dir, issues);
 }
 
 // 拉取 issue 列表并 enrich + 兜底 total(listIssues/searchIssues 共用尾巴)。
@@ -89,6 +97,85 @@ export function updateIssue(id: string, req: UpdateIssueReq): Promise<Issue> {
 
 export function deleteIssue(id: string): Promise<void> {
   return httpDelete<void>(`/issues/${id}`);
+}
+
+// 按负责人分组板(GET /issues/grouped,group_by 固定 assignee)。scope pill 通过
+// assignee_types / involves_user_id 收窄。一次拿 directory 供全部分组同步 enrich +
+// 回填分组头负责人名(未指派组 assignee_type=null → actorName 返回 null)。
+export async function listGroupedIssues(params: GroupedParams): Promise<IssueGroup[]> {
+  const dir = await ensureDirectory();
+  const data = await httpGet<{ groups?: IssueGroup[] }>("/issues/grouped", {
+    group_by: "assignee",
+    statuses: params.statuses?.join(","),
+    priorities: params.priorities?.join(","),
+    assignee_types: params.assignee_types?.join(","),
+    assignee_id: params.assignee_id,
+    involves_user_id: params.involves_user_id,
+    creator_id: params.creator_id,
+    project_id: params.project_id,
+    date_field: params.date_field,
+    date_start: params.date_start,
+    date_end: params.date_end,
+    limit: params.limit,
+  });
+  return (data.groups ?? []).map((g) => ({
+    ...g,
+    issues: enrichWith(dir, g.issues ?? []),
+    assignee_name: actorName(dir, g.assignee_type, g.assignee_id),
+    assignee_avatar: actorAvatar(dir, g.assignee_type, g.assignee_id),
+  }));
+}
+
+// 「与我相关」= 后端三个单用户过滤的并集(assignee_id / creator_id / involves_user_id)。
+// 后端 involves_user_id 按设计**不含**直接指派/创建(仅间接:我拥有的 agent、我所在 squad),
+// 故只发它会漏掉「指派给我」「我创建」的 issue。后端无跨用户 OR → 并行拉三次,按
+// (assignee_type, assignee_id) 合并分组、按 issue id 去重,total 取去重后条数。
+// 对齐后端「我的 issue」三过滤并集语义(assignee_types 对本 scope 无意义,剥离)。
+export async function listMyGroupedIssues(userId: string, params: GroupedParams): Promise<IssueGroup[]> {
+  // 剥离所有「用户关系」过滤:三 leg 各自设一个,base 保留任何一个都会污染另两 leg
+  // (如下拉 creator 会被 creator leg 覆盖、却在其余 leg 变成意外 AND)。assignee_types 同样无意义。
+  const base: GroupedParams = { ...params, assignee_types: undefined, assignee_id: undefined, creator_id: undefined, involves_user_id: undefined };
+  const variants: GroupedParams[] = [
+    { ...base, assignee_id: userId },
+    { ...base, creator_id: userId },
+    { ...base, involves_user_id: userId },
+  ];
+  const results = await Promise.all(variants.map(listGroupedIssues));
+  const key = (g: IssueGroup) => `${g.assignee_type ?? "_"}::${g.assignee_id ?? "_"}`;
+  const merged = new Map<string, IssueGroup>();
+  for (const groups of results) {
+    for (const g of groups) {
+      const existing = merged.get(key(g));
+      if (!existing) {
+        merged.set(key(g), { ...g, issues: [...g.issues], total: g.issues.length });
+        continue;
+      }
+      const seen = new Set(existing.issues.map((i) => i.id));
+      for (const issue of g.issues) {
+        if (seen.has(issue.id)) continue;
+        seen.add(issue.id);
+        existing.issues.push(issue);
+      }
+      existing.total = existing.issues.length;
+    }
+  }
+  return [...merged.values()];
+}
+
+// 批量改(POST /issues/batch-update)：同一 updates 应用到多个 issue,返回受影响数。
+export function batchUpdateIssues(issueIds: string[], updates: UpdateIssueReq): Promise<{ updated: number }> {
+  return httpPost<{ updated: number }>("/issues/batch-update", { issue_ids: issueIds, updates });
+}
+
+// 批量删(POST /issues/batch-delete)。
+export function batchDeleteIssues(issueIds: string[]): Promise<{ deleted: number }> {
+  return httpPost<{ deleted: number }>("/issues/batch-delete", { issue_ids: issueIds });
+}
+
+// 工作区级运行中任务快照(GET /agent-task-snapshot,裸数组)。调用方一遍扫出
+// 「有 agent 正在跑」的 issue-id 集合,喂给卡片渲染 running chip(非 per-card,无 N+1)。
+export function getAgentTaskSnapshot(): Promise<AgentTaskSnapshotItem[]> {
+  return httpGet<AgentTaskSnapshotItem[]>("/agent-task-snapshot");
 }
 
 // 派单预触发（只读）：问后端“这次指派/状态变更会不会起 run、谁跑”。绝不前端猜。

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -80,6 +80,44 @@ export interface ListParams {
   offset?: number;
 }
 
+/* ---------- 按负责人分组板 (GET /issues/grouped) ---------- */
+// 后端仅支持 group_by=assignee。scope pill 通过 assignee_types / involves_user_id 收窄范围。
+// "involves" 需后端 user UUID(非 octo uid):由候选里 octo_uid===loginInfo.uid 的成员解析。
+export type IssueScope = "all" | "members" | "agents" | "involves";
+
+export interface GroupedParams {
+  statuses?: IssueStatus[];
+  priorities?: IssuePriority[];
+  assignee_types?: AssigneeType[];
+  assignee_id?: string;
+  involves_user_id?: string;
+  creator_id?: string;
+  project_id?: string;
+  date_field?: IssueDateField;
+  date_start?: string;
+  date_end?: string;
+  limit?: number;
+}
+
+// 一个负责人分组;assignee_type/assignee_id 为 null 表示「未指派」组。
+export interface IssueGroup {
+  id: string;
+  assignee_type: AssigneeType | null;
+  assignee_id: string | null;
+  issues: Issue[];
+  total: number;
+  // 由 directory 回填(展示用):分组头显示的负责人名。
+  assignee_name?: string | null;
+  assignee_avatar?: string | null;
+}
+
+// 工作区级运行中任务快照的最小消费形状 (GET /agent-task-snapshot 裸数组)。
+// 只取 issue_id + status,用于算「哪些 issue 有 agent 正在跑」的集合。
+export interface AgentTaskSnapshotItem {
+  issue_id: string; // 空串表示无关联 issue(聊天/autopilot 触发)
+  status: TaskStatus;
+}
+
 /* ---------- Issue ---------- */
 export type IssueStatus =
   | "backlog" | "todo" | "in_progress" | "in_review" | "done" | "blocked" | "cancelled";
@@ -141,6 +179,8 @@ export interface CreateIssueReq {
   assignee_type?: AssigneeType | null;
   assignee_id?: string | null;
   project_id?: string | null;
+  // 新建子 issue 时绑定父任务(后端 CreateIssueRequest.parent_issue_id)。
+  parent_issue_id?: string | null;
   // 新建时绑定已上传附件(上传返回的 id 列表)。
   attachment_ids?: string[];
 }

--- a/packages/dmloop/src/cliAuthorizeSession.ts
+++ b/packages/dmloop/src/cliAuthorizeSession.ts
@@ -1,11 +1,11 @@
-export const MULTICA_CLI_AUTHORIZE_PATH = "/loop/cli-authorize";
+export const LOOP_CLI_AUTHORIZE_PATH = "/loop/cli-authorize";
 
 const PENDING_SEARCH_KEY = "octo.loop.cli-authorize.pending-search";
 
 type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
-export function isMulticaCliAuthorizePath(pathname: string): boolean {
-  return pathname.replace(/\/+$/, "") === MULTICA_CLI_AUTHORIZE_PATH;
+export function isLoopCliAuthorizePath(pathname: string): boolean {
+  return pathname.replace(/\/+$/, "") === LOOP_CLI_AUTHORIZE_PATH;
 }
 
 /**
@@ -13,12 +13,12 @@ export function isMulticaCliAuthorizePath(pathname: string): boolean {
  * string with a sid-only URL. The pending value also survives the full reload
  * performed after an interactive login.
  */
-export function resolveMulticaCliAuthorizeSearch(
+export function resolveLoopCliAuthorizeSearch(
   pathname: string,
   search: string,
   storage: SessionStorageLike
 ): string {
-  if (!isMulticaCliAuthorizePath(pathname)) return search;
+  if (!isLoopCliAuthorizePath(pathname)) return search;
 
   const params = new URLSearchParams(search);
   if (params.get("cli_callback")) {
@@ -37,7 +37,7 @@ export function resolveMulticaCliAuthorizeSearch(
   }
 }
 
-export function clearPendingMulticaCliAuthorizeSearch(
+export function clearPendingLoopCliAuthorizeSearch(
   storage: SessionStorageLike
 ): void {
   try {
@@ -47,7 +47,7 @@ export function clearPendingMulticaCliAuthorizeSearch(
   }
 }
 
-export function visibleMulticaCliAuthorizeSearch(search: string): string {
+export function visibleLoopCliAuthorizeSearch(search: string): string {
   const params = new URLSearchParams(search);
   params.delete("cli_callback");
   params.delete("cli_state");

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -33,7 +33,19 @@
   },
   "view": {
     "board": "Board",
+    "grouped": "Grouped",
     "list": "List"
+  },
+  "scope": {
+    "all": "All",
+    "members": "Members",
+    "agents": "AI",
+    "involves": "Involves me"
+  },
+  "batch": {
+    "selected": "{{count}} selected",
+    "done": "Updated",
+    "deleteConfirm": "Delete {{count}} selected issue(s)? This cannot be undone."
   },
   "search": {
     "issue": "Search Loop / id",
@@ -309,7 +321,8 @@
     "unsubscribed": "Unsubscribed"
   },
   "subIssue": {
-    "title": "Sub-issues"
+    "title": "Sub-issues",
+    "create": "New sub-issue"
   },
   "reaction": {
     "add": "Add reaction"

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -33,7 +33,19 @@
   },
   "view": {
     "board": "看板",
+    "grouped": "分组",
     "list": "列表"
+  },
+  "scope": {
+    "all": "全部",
+    "members": "成员",
+    "agents": "AI",
+    "involves": "与我相关"
+  },
+  "batch": {
+    "selected": "已选 {{count}} 项",
+    "done": "已更新",
+    "deleteConfirm": "确定删除选中的 {{count}} 项？此操作不可撤销。"
   },
   "search": {
     "issue": "搜索回路/ 编号",
@@ -309,7 +321,8 @@
     "unsubscribed": "已取消订阅"
   },
   "subIssue": {
-    "title": "子 Issue"
+    "title": "子 Issue",
+    "create": "新建子 Issue"
   },
   "reaction": {
     "add": "添加反应"

--- a/packages/dmloop/src/index.tsx
+++ b/packages/dmloop/src/index.tsx
@@ -2,12 +2,12 @@
 
 export { default as LoopModule } from "./module";
 export { default as LoopPage } from "./pages/LoopPage";
-export { default as MulticaCliAuthorizePage } from "./pages/MulticaCliAuthorizePage";
+export { default as LoopCliAuthorizePage } from "./pages/LoopCliAuthorizePage";
 export { default as RuntimePage } from "./pages/RuntimePage";
 export { default as SkillPage } from "./pages/SkillPage";
 export {
-  isMulticaCliAuthorizePath,
-  MULTICA_CLI_AUTHORIZE_PATH,
+  isLoopCliAuthorizePath,
+  LOOP_CLI_AUTHORIZE_PATH,
 } from "./cliAuthorizeSession";
 
 export * from "./api/types";

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -2,18 +2,18 @@ import React from "react";
 import { WKApp, Menus, i18n, t as translate } from "@octo/base";
 import type { IModule } from "@octo/base";
 import LoopPage from "./pages/LoopPage";
-import MulticaCliAuthorizePage from "./pages/MulticaCliAuthorizePage";
+import LoopCliAuthorizePage from "./pages/LoopCliAuthorizePage";
 import {
-  isMulticaCliAuthorizePath,
-  MULTICA_CLI_AUTHORIZE_PATH,
-  resolveMulticaCliAuthorizeSearch,
-  visibleMulticaCliAuthorizeSearch,
+  isLoopCliAuthorizePath,
+  LOOP_CLI_AUTHORIZE_PATH,
+  resolveLoopCliAuthorizeSearch,
+  visibleLoopCliAuthorizeSearch,
 } from "./cliAuthorizeSession";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 
 let _initialized = false;
-let multicaCliAuthorizeInitialSearch = "";
+let loopCliAuthorizeInitialSearch = "";
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     _initialized = false;
@@ -58,9 +58,9 @@ export default class LoopModule implements IModule {
 
     if (
       typeof window !== "undefined" &&
-      isMulticaCliAuthorizePath(window.location.pathname)
+      isLoopCliAuthorizePath(window.location.pathname)
     ) {
-      multicaCliAuthorizeInitialSearch = resolveMulticaCliAuthorizeSearch(
+      loopCliAuthorizeInitialSearch = resolveLoopCliAuthorizeSearch(
         window.location.pathname,
         window.location.search,
         window.sessionStorage
@@ -74,7 +74,7 @@ export default class LoopModule implements IModule {
             {},
             "",
             window.location.pathname +
-              visibleMulticaCliAuthorizeSearch(window.location.search)
+              visibleLoopCliAuthorizeSearch(window.location.search)
           );
         } catch {
           // The captured prop still protects the flow if History is unavailable.
@@ -83,15 +83,15 @@ export default class LoopModule implements IModule {
     }
 
     WKApp.route.register("/loop", () => <LoopPage />);
-    const renderMulticaCliAuthorize = () => (
-      <MulticaCliAuthorizePage
-        initialSearch={multicaCliAuthorizeInitialSearch}
+    const renderLoopCliAuthorize = () => (
+      <LoopCliAuthorizePage
+        initialSearch={loopCliAuthorizeInitialSearch}
       />
     );
-    WKApp.route.register(MULTICA_CLI_AUTHORIZE_PATH, renderMulticaCliAuthorize);
+    WKApp.route.register(LOOP_CLI_AUTHORIZE_PATH, renderLoopCliAuthorize);
     WKApp.route.register(
-      `${MULTICA_CLI_AUTHORIZE_PATH}/`,
-      renderMulticaCliAuthorize
+      `${LOOP_CLI_AUTHORIZE_PATH}/`,
+      renderLoopCliAuthorize
     );
 
     WKApp.menus.register(

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Typography,
   Input,
@@ -8,23 +8,41 @@ import {
   Select,
   Pagination,
   DatePicker,
+  RadioGroup,
+  Radio,
 } from "@douyinfe/semi-ui";
-import { Search, Plus, LayoutGrid, List as ListIcon, ClipboardList, ArrowUp, ArrowDown } from "lucide-react";
+import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, ArrowUp, ArrowDown } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Issue, IssueStatus, IssuePriority, IssueSortField, IssueDateField } from "../api/types";
+import type {
+  Issue,
+  IssueGroup,
+  IssueScope,
+  IssueStatus,
+  IssuePriority,
+  IssueSortField,
+  IssueDateField,
+} from "../api/types";
 import { ISSUE_SORT_FIELDS, ISSUE_DATE_FIELDS } from "../api/types";
-import { listIssues, searchIssues } from "../api/issueApi";
+import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAgentTaskSnapshot } from "../api/issueApi";
 import { listProjectOptions } from "../api/directory";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
-import { ISSUE_STATUS_ORDER, PRIORITY_ORDER } from "../ui/meta";
+import { ISSUE_STATUS_ORDER, PRIORITY_ORDER, isActiveRun } from "../ui/meta";
 import IssueBoard from "../panel/IssueBoard";
+import IssueGroupBoard from "../panel/IssueGroupBoard";
 import IssueList from "../panel/IssueList";
 import IssueDetailPage from "../panel/IssueDetailPage";
 import CreateIssueModal from "../ui/CreateIssueModal";
 
 const { Title } = Typography;
 
-type ViewMode = "board" | "list";
+type ViewMode = "board" | "grouped" | "list";
+
+// scope pill → assignee_types 过滤(仅 /grouped 支持;all/involves 不按类型收窄)。
+function scopeToAssigneeTypes(scope: IssueScope): ("member" | "agent" | "squad")[] | undefined {
+  if (scope === "members") return ["member"];
+  if (scope === "agents") return ["agent", "squad"];
+  return undefined;
+}
 
 interface Filters {
   keyword: string;
@@ -44,13 +62,22 @@ const PAGE_SIZE = 50;
 export default function IssuePage() {
   const { t } = useI18n();
   const [issues, setIssues] = useState<Issue[]>([]);
+  const [groups, setGroups] = useState<IssueGroup[]>([]);
+  const [running, setRunning] = useState<ReadonlySet<string>>(new Set());
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<ViewMode>("board");
+  const [scope, setScope] = useState<IssueScope>("all");
   const [f, setF] = useState<Filters>({ keyword: "", sortBy: "position", sortDir: "desc", dateField: "created_at" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   const [createOpen, setCreateOpen] = useState(false);
   const cands = useAssigneeCandidates();
+  // 当前 octo 成员的后端 user_id(involves_user_id 需 UUID,非 octo uid)：
+  // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
+  const myMemberId = useMemo(() => {
+    const uid = WKApp.loginInfo.uid;
+    return uid ? cands.find((c) => c.type === "member" && c.octo_uid === uid)?.id : undefined;
+  }, [cands]);
   // 项目下拉复用 directory 已缓存的 /projects(避免重复请求);随 workspace 切换整页重挂而刷新。
   const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
   const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
@@ -62,13 +89,40 @@ export default function IssuePage() {
   const reload = useCallback(() => {
     const my = ++seq.current;
     setLoading(true);
-    const paged = view === "list";
-    const kw = f.keyword.trim();
     // 时间范围:三参数须同时给且 start<end。onChange 已把 dateRange 归一为 undefined|[起,止]。
-    // 止端 +1 日历日 → 半开区间,既含止日当天、又保证 start<end(即使起止同一天);setDate 处理 DST。
+    // 止端 +1 日历日 → 半开区间,既含止日当天、又保证 start<end;setDate 处理 DST。
     const dr = f.dateRange;
     const endExclusive = dr && new Date(dr[1]);
     if (endExclusive) endExclusive.setDate(endExclusive.getDate() + 1);
+
+    // 分组板:走 /issues/grouped(按负责人);scope pill 收窄 assignee_types。
+    // grouped 不吃关键词/排序,故这两项在分组视图隐藏。
+    if (view === "grouped") {
+      const gp = {
+        statuses: f.status ? [f.status] : undefined,
+        priorities: f.priority ? [f.priority] : undefined,
+        creator_id: f.creator,
+        project_id: f.project,
+        date_field: dr ? f.dateField : undefined,
+        date_start: dr ? dr[0].toISOString() : undefined,
+        date_end: endExclusive ? endExclusive.toISOString() : undefined,
+        // ponytail: 每组取后端上限 100；超量请用筛选。
+        limit: 100,
+      };
+      // 「与我相关」= 指派给我 ∪ 我创建 ∪ 间接关联(后端三过滤并集,fan-out 合并);
+      // 其余 scope 单发一次、按 assignee_types 收窄。myMemberId 缺失时 pill 已禁用,不会走到此分支。
+      const req =
+        scope === "involves" && myMemberId
+          ? listMyGroupedIssues(myMemberId, gp)
+          : listGroupedIssues({ ...gp, assignee_types: scopeToAssigneeTypes(scope) });
+      req
+        .then((gs) => { if (my === seq.current) setGroups(gs); })
+        .finally(() => { if (my === seq.current) setLoading(false); });
+      return;
+    }
+
+    const paged = view === "list";
+    const kw = f.keyword.trim();
     // 有关键词 → 走全文搜索端点(独立语义:后端不吃其它筛选/排序、上限 50);否则常规筛选列表。
     const req = kw
       ? searchIssues(kw, { limit: paged ? PAGE_SIZE : 50, offset: paged ? page * PAGE_SIZE : 0 })
@@ -100,9 +154,28 @@ export default function IssuePage() {
         setTotal(total);
       })
       .finally(() => { if (my === seq.current) setLoading(false); });
-  }, [f, view, page]);
+  }, [f, view, page, scope, myMemberId]);
 
   useEffect(reload, [reload]);
+
+  // 运行中快照:视图/筛选无关(工作区级),故不进 reload 的依赖 —— 不随筛选/翻页/切视图白拉。
+  // seq 守卫:agent 任务独立起停,多次刷新在途时只让最新一次落地,防旧响应覆盖新。
+  const runSeq = useRef(0);
+  const refreshRunning = useCallback(() => {
+    const my = ++runSeq.current;
+    getAgentTaskSnapshot()
+      .then((tasks) => { if (my === runSeq.current) setRunning(new Set(tasks.filter((tk) => isActiveRun(tk.status) && tk.issue_id).map((tk) => tk.issue_id))); })
+      .catch(() => {});
+  }, []);
+  // 挂载取一次 + 每 15s 轮询:无 WS 推送,agent 起停靠轮询让 running chip 最终收敛(而非只在本地 mutation 后)。
+  useEffect(() => {
+    refreshRunning();
+    const timer = setInterval(refreshRunning, 15000);
+    return () => clearInterval(timer);
+  }, [refreshRunning]);
+
+  // 变更后刷新:既重取列表,又刷新运行中快照(指派/状态变更可能起/停 agent run)。
+  const onMutated = useCallback(() => { reload(); refreshRunning(); }, [reload, refreshRunning]);
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
   const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
@@ -112,8 +185,10 @@ export default function IssuePage() {
   // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
   // (如未来点子 issue 原地切换时,慢请求无法把旧 issue 数据写进新 issue 视图)。
   const openDetail = (id: string) => {
-    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={reload} />);
+    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onMutated} />);
   };
+
+  const isEmpty = view === "grouped" ? groups.every((g) => g.issues.length === 0) : total === 0;
 
   return (
     <div className="loop-page">
@@ -124,11 +199,29 @@ export default function IssuePage() {
             <LayoutGrid size={14} />
             {t("loop.view.board")}
           </button>
+          <button className={view === "grouped" ? "is-active" : ""} onClick={() => switchView("grouped")}>
+            <Users size={14} />
+            {t("loop.view.grouped")}
+          </button>
           <button className={view === "list" ? "is-active" : ""} onClick={() => switchView("list")}>
             <ListIcon size={14} />
             {t("loop.view.list")}
           </button>
         </div>
+        {view === "grouped" && (
+          <RadioGroup
+            type="button"
+            buttonSize="small"
+            value={scope}
+            onChange={(e) => setScope(e.target.value as IssueScope)}
+          >
+            <Radio value="all">{t("loop.scope.all")}</Radio>
+            <Radio value="members">{t("loop.scope.members")}</Radio>
+            <Radio value="agents">{t("loop.scope.agents")}</Radio>
+            {/* 「与我相关」需当前成员的后端 id;未解析出则禁用(而非静默失效)。 */}
+            <Radio value="involves" disabled={!myMemberId}>{t("loop.scope.involves")}</Radio>
+          </RadioGroup>
+        )}
         <div className="loop-page__spacer" />
         <Select
           placeholder={t("loop.filter.status")}
@@ -154,32 +247,38 @@ export default function IssuePage() {
             <Select.Option key={p} value={p}>{t(`loop.priority.${p}`)}</Select.Option>
           ))}
         </Select>
-        <Select
-          placeholder={t("loop.filter.assignee")}
-          value={f.assignee}
-          onChange={(v) => update({ assignee: v as string | undefined })}
-          showClear
-          filter
-          size="small"
-          style={{ width: 150 }}
-        >
-          {cands.map((c) => (
-            <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
-          ))}
-        </Select>
-        <Select
-          placeholder={t("loop.filter.creator")}
-          value={f.creator}
-          onChange={(v) => update({ creator: v as string | undefined })}
-          showClear
-          filter
-          size="small"
-          style={{ width: 130 }}
-        >
-          {cands.filter((c) => c.type === "member").map((c) => (
-            <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
-          ))}
-        </Select>
+        {/* assignee 单选筛选仅扁平列表/看板用(grouped 用 scope pill 按类型收窄)。 */}
+        {view !== "grouped" && (
+          <Select
+            placeholder={t("loop.filter.assignee")}
+            value={f.assignee}
+            onChange={(v) => update({ assignee: v as string | undefined })}
+            showClear
+            filter
+            size="small"
+            style={{ width: 150 }}
+          >
+            {cands.map((c) => (
+              <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
+            ))}
+          </Select>
+        )}
+        {/* 「与我相关」自带 creator=我 的并集腿,creator 下拉对它无效 → 隐藏,避免设了不生效。 */}
+        {!(view === "grouped" && scope === "involves") && (
+          <Select
+            placeholder={t("loop.filter.creator")}
+            value={f.creator}
+            onChange={(v) => update({ creator: v as string | undefined })}
+            showClear
+            filter
+            size="small"
+            style={{ width: 130 }}
+          >
+            {cands.filter((c) => c.type === "member").map((c) => (
+              <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
+            ))}
+          </Select>
+        )}
         {projects.length > 0 && (
           <Select
             placeholder={t("loop.filter.project")}
@@ -241,14 +340,17 @@ export default function IssuePage() {
           />
         </div>
         )}
-        <Input
-          prefix={<Search size={14} />}
-          placeholder={t("loop.search.issue")}
-          value={f.keyword}
-          onChange={(v) => update({ keyword: v })}
-          showClear
-          style={{ width: 200 }}
-        />
+        {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
+        {view !== "grouped" && (
+          <Input
+            prefix={<Search size={14} />}
+            placeholder={t("loop.search.issue")}
+            value={f.keyword}
+            onChange={(v) => update({ keyword: v })}
+            showClear
+            style={{ width: 200 }}
+          />
+        )}
         <Button theme="solid" icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
           {t("loop.action.newIssue")}
         </Button>
@@ -259,7 +361,7 @@ export default function IssuePage() {
           <div className="loop-page__center">
             <Spin />
           </div>
-        ) : total === 0 ? (
+        ) : isEmpty ? (
           <div className="loop-empty">
             <ClipboardList size={40} className="loop-empty__icon" />
             <div className="loop-empty__title">{t("loop.empty.issueTitle")}</div>
@@ -269,10 +371,12 @@ export default function IssuePage() {
             </Button>
           </div>
         ) : view === "board" ? (
-          <IssueBoard issues={issues} onOpen={openDetail} onChanged={reload} />
+          <IssueBoard issues={issues} onOpen={openDetail} onChanged={onMutated} running={running} />
+        ) : view === "grouped" ? (
+          <IssueGroupBoard groups={groups} onOpen={openDetail} running={running} />
         ) : (
           <>
-            <IssueList issues={issues} onOpen={openDetail} onChanged={reload} />
+            <IssueList issues={issues} onOpen={openDetail} onChanged={onMutated} running={running} />
             {total > PAGE_SIZE && (
               <div style={{ display: "flex", justifyContent: "flex-end", padding: "12px 4px" }}>
                 <Pagination
@@ -290,7 +394,7 @@ export default function IssuePage() {
       <CreateIssueModal
         visible={createOpen}
         onClose={() => setCreateOpen(false)}
-        onCreated={() => { Toast.success(t("loop.toast.created")); reload(); }}
+        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); }}
       />
     </div>
   );

--- a/packages/dmloop/src/pages/LoopCliAuthorizePage.tsx
+++ b/packages/dmloop/src/pages/LoopCliAuthorizePage.tsx
@@ -3,10 +3,10 @@ import { Avatar, Button, Toast, Typography } from "@douyinfe/semi-ui";
 import { Laptop, ShieldCheck } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { Workspace } from "../api/types";
-import { issueMulticaCliToken } from "../api/authApi";
+import { issueLoopCliToken } from "../api/authApi";
 import { listWorkspaces } from "../api/workspaceApi";
 import { currentWorkspaceId, setWorkspaceContext } from "../api/http";
-import { clearPendingMulticaCliAuthorizeSearch } from "../cliAuthorizeSession";
+import { clearPendingLoopCliAuthorizeSearch } from "../cliAuthorizeSession";
 import "./loop.css";
 
 const { Text, Title } = Typography;
@@ -45,7 +45,7 @@ function redirectToCli(
   token: string,
   state: string | null
 ): void {
-  // TODO(octo-multica!18 security follow-up): replace this JWT-in-query
+  // TODO(security follow-up): replace this JWT-in-query
   // handoff with server-bound device authorization or a one-time PKCE code.
   const target = new URL(callbackURL);
   target.searchParams.set("token", token);
@@ -53,13 +53,13 @@ function redirectToCli(
   window.location.href = target.toString();
 }
 
-interface MulticaCliAuthorizePageProps {
+interface LoopCliAuthorizePageProps {
   initialSearch?: string;
 }
 
-export default function MulticaCliAuthorizePage({
+export default function LoopCliAuthorizePage({
   initialSearch = window.location.search,
-}: MulticaCliAuthorizePageProps) {
+}: LoopCliAuthorizePageProps) {
   const { t } = useI18n();
   const params = useMemo(
     () => new URLSearchParams(initialSearch),
@@ -115,8 +115,8 @@ export default function MulticaCliAuthorizePage({
     setAuthorizing(true);
     setError("");
     try {
-      const { token } = await issueMulticaCliToken();
-      clearPendingMulticaCliAuthorizeSearch(window.sessionStorage);
+      const { token } = await issueLoopCliToken();
+      clearPendingLoopCliAuthorizeSearch(window.sessionStorage);
       redirectToCli(cliCallback, token, cliState);
     } catch (err) {
       const msg =

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -411,6 +411,9 @@
 .loop-card__key {
   font-size: 11px;
   color: var(--semi-color-text-2, #8590a6);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .loop-card__title {
@@ -931,4 +934,51 @@
   .loop-nsk__form,
   .loop-nsk__preview { width: 100%; }
   .loop-nsk__preview { border-left: none; border-top: 1px solid var(--semi-color-border, #e8e9eb); }
+}
+
+/* ---------- running chip 旋转 ---------- */
+.loop-spin { animation: loop-spin 1s linear infinite; }
+@keyframes loop-spin { to { transform: rotate(360deg); } }
+
+/* ---------- 按负责人分组板 ---------- */
+.loop-groupboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 4px;
+  overflow: auto;
+}
+
+.loop-groupboard__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.loop-groupboard__head em {
+  font-style: normal;
+  color: var(--semi-color-text-2, #8590a6);
+}
+
+.loop-groupboard__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
+}
+
+/* 分组板卡片非拖拽,光标用指针而非 grab。 */
+.loop-groupboard .loop-card { cursor: pointer; }
+
+/* ---------- 列表批量操作条 ---------- */
+.loop-batchbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  background: var(--semi-color-fill-0, #f6f7f9);
+  border-radius: 8px;
 }

--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -1,24 +1,18 @@
 import React, { useState } from "react";
 import { Tag } from "@douyinfe/semi-ui";
-import { CalendarClock } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
-import { AssigneeBadge } from "../ui/AssigneePicker";
-import LabelChips from "../ui/LabelChips";
+import IssueCard from "../ui/IssueCard";
 import { useRunConfirm } from "../ui/RunConfirmModal";
-import {
-  ISSUE_STATUS_ORDER,
-  ISSUE_STATUS_COLOR,
-  PRIORITY_COLOR,
-  formatShortDate,
-  isOverdue,
-} from "../ui/meta";
+import { ISSUE_STATUS_ORDER, ISSUE_STATUS_COLOR } from "../ui/meta";
 
 export interface IssueBoardProps {
   issues: Issue[];
   onOpen: (id: string) => void;
   onChanged: () => void;
+  /** 有 agent 正在跑的 issue-id 集合(渲染 running chip)。 */
+  running?: ReadonlySet<string>;
 }
 
 /** 看板：按 status 分列 + 原生 HTML5 拖拽跨列改状态。 */
@@ -26,6 +20,7 @@ export default function IssueBoard({
   issues,
   onOpen,
   onChanged,
+  running,
 }: IssueBoardProps) {
   const { t } = useI18n();
   const { requestStatus, runConfirmModal } = useRunConfirm();
@@ -74,41 +69,19 @@ export default function IssueBoard({
             </div>
             <div className="loop-board__cards">
               {cards.map((issue) => (
-                <div
+                <IssueCard
                   key={issue.id}
-                  className={`loop-card ${dragId === issue.id ? "is-dragging" : ""}`}
+                  issue={issue}
+                  onOpen={onOpen}
+                  running={running?.has(issue.id)}
                   draggable
+                  dragging={dragId === issue.id}
                   onDragStart={() => setDragId(issue.id)}
                   onDragEnd={() => {
                     setDragId(null);
                     setDropCol(null);
                   }}
-                  onClick={() => onOpen(issue.id)}
-                >
-                  <div className="loop-card__key">{issue.identifier}</div>
-                  <div className="loop-card__title">{issue.title}</div>
-                  {issue.labels && issue.labels.length > 0 && (
-                    <div style={{ marginTop: 4 }}><LabelChips labels={issue.labels} max={3} /></div>
-                  )}
-                  <div className="loop-card__foot">
-                    <Tag color={PRIORITY_COLOR[issue.priority]} size="small">
-                      {t(`loop.priority.${issue.priority}`)}
-                    </Tag>
-                    {issue.due_date && (
-                      <span
-                        className="loop-card__due"
-                        style={{ color: isOverdue(issue.due_date, issue.status) ? "var(--semi-color-danger)" : "var(--semi-color-text-2)" }}
-                      >
-                        <CalendarClock size={12} />
-                        {formatShortDate(issue.due_date)}
-                      </span>
-                    )}
-                    <AssigneeBadge
-                      type={issue.assignee_type}
-                      name={issue.assignee_name ?? null}
-                    />
-                  </div>
-                </div>
+                />
               ))}
             </div>
           </div>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -31,6 +31,7 @@ import {
   BellOff,
   Paperclip,
   AtSign,
+  Plus,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -79,6 +80,7 @@ import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
 import { confirmDelete } from "../ui/confirmDelete";
 import RunDetailModal from "./RunDetailModal";
+import CreateIssueModal from "../ui/CreateIssueModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
@@ -117,6 +119,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   // 订阅者列表是否已成功加载:未加载/加载失败时"我是否已订阅"不可判定,菜单回退到两项都显示。
   const [subLoaded, setSubLoaded] = useState(false);
   const [children, setChildren] = useState<Issue[]>([]);
+  const [childCreateOpen, setChildCreateOpen] = useState(false); // 新建子 issue 弹窗
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
   const [runs, setRuns] = useState<TaskRun[]>([]);
@@ -810,28 +813,41 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             )}
           </div>
 
-          {children.length > 0 && (
-            <div className="loop-idp__section">
-              <div className="loop-detail__section-title">
-                {t("loop.subIssue.title")} ({childrenDone}/{children.length})
-              </div>
-              <Progress
-                percent={Math.round((childrenDone / children.length) * 100)}
-                style={{ marginBottom: 10 }}
-              />
-              <div className="loop-subissues">
-                {children.map((c) => (
-                  <div key={c.id} className="loop-subissue">
-                    <Tag color={ISSUE_STATUS_COLOR[c.status]} size="small">
-                      {t(`loop.status.${c.status}`)}
-                    </Tag>
-                    <span className="loop-subissue__id">{c.identifier}</span>
-                    <span className="loop-subissue__title">{c.title}</span>
-                  </div>
-                ))}
-              </div>
+          <div className="loop-idp__section">
+            <div className="loop-detail__section-title loop-idp__desc-title">
+              <span>
+                {t("loop.subIssue.title")}
+                {children.length > 0 && ` (${childrenDone}/${children.length})`}
+              </span>
+              <Button
+                theme="borderless"
+                size="small"
+                icon={<Plus size={13} />}
+                onClick={() => setChildCreateOpen(true)}
+              >
+                {t("loop.subIssue.create")}
+              </Button>
             </div>
-          )}
+            {children.length > 0 && (
+              <>
+                <Progress
+                  percent={Math.round((childrenDone / children.length) * 100)}
+                  style={{ margin: "8px 0 10px" }}
+                />
+                <div className="loop-subissues">
+                  {children.map((c) => (
+                    <div key={c.id} className="loop-subissue">
+                      <Tag color={ISSUE_STATUS_COLOR[c.status]} size="small">
+                        {t(`loop.status.${c.status}`)}
+                      </Tag>
+                      <span className="loop-subissue__id">{c.identifier}</span>
+                      <span className="loop-subissue__title">{c.title}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
 
           <div className="loop-idp__section">
             <div className="loop-detail__section-title loop-idp__desc-title">
@@ -1139,6 +1155,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
       <RunDetailModal run={activeRun} visible={runOpen} onClose={() => setRunOpen(false)} />
       {runConfirmModal}
+      <CreateIssueModal
+        visible={childCreateOpen}
+        parentIssueId={issueId}
+        onClose={() => setChildCreateOpen(false)}
+        onCreated={() => {
+          Toast.success(t("loop.toast.created"));
+          // 只刷新子列表(非整页 reload,避免详情主体闪 loading);key-remount 已隔离跨 issue 陈旧写入。
+          listChildren(issueId).then(setChildren).catch(() => {});
+        }}
+      />
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueGroupBoard.tsx
+++ b/packages/dmloop/src/panel/IssueGroupBoard.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useI18n } from "@octo/base";
+import type { IssueGroup } from "../api/types";
+import IssueCard from "../ui/IssueCard";
+import { AssigneeBadge } from "../ui/AssigneePicker";
+
+export interface IssueGroupBoardProps {
+  groups: IssueGroup[];
+  onOpen: (id: string) => void;
+  /** 有 agent 正在跑的 issue-id 集合(渲染 running chip)。 */
+  running?: ReadonlySet<string>;
+}
+
+/** 按负责人分组板：每个负责人一段(段头 + 卡片行)。数据源 /issues/grouped。
+ *  拖拽改派属重交互(Tier3),此处仅浏览 + 点开。 */
+export default function IssueGroupBoard({ groups, onOpen, running }: IssueGroupBoardProps) {
+  const { t } = useI18n();
+  return (
+    <div className="loop-groupboard">
+      {groups.map((g) => (
+        <div key={g.id} className="loop-groupboard__group">
+          <div className="loop-groupboard__head">
+            {g.assignee_type ? (
+              <AssigneeBadge type={g.assignee_type} name={g.assignee_name ?? null} />
+            ) : (
+              <span className="loop-assignee-empty">{t("loop.assignee.unassigned")}</span>
+            )}
+            <em>{g.total}</em>
+          </div>
+          <div className="loop-groupboard__cards">
+            {g.issues.map((issue) => (
+              <IssueCard key={issue.id} issue={issue} onOpen={onOpen} running={running?.has(issue.id)} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -1,10 +1,13 @@
-import React from "react";
-import { Table, Select, Tag, Typography } from "@douyinfe/semi-ui";
+import React, { useEffect, useState } from "react";
+import { Table, Select, Tag, Typography, Button, Toast } from "@douyinfe/semi-ui";
+import { Trash2, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority } from "../api/types";
-import { updateIssue } from "../api/issueApi";
+import { updateIssue, batchUpdateIssues, batchDeleteIssues } from "../api/issueApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelChips from "../ui/LabelChips";
+import RunningChip from "../ui/RunningChip";
+import { confirmDelete } from "../ui/confirmDelete";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
@@ -15,24 +18,60 @@ import {
 
 const { Text } = Typography;
 
+// 批量操作下拉是纯命令菜单(选后触发动作、不持有值);受控 value 恒空。
+const NO_VALUE = undefined as unknown as string;
+
 export interface IssueListProps {
   issues: Issue[];
   onOpen: (id: string) => void;
   onChanged: () => void;
+  /** 有 agent 正在跑的 issue-id 集合(标题旁 running chip)。 */
+  running?: ReadonlySet<string>;
 }
 
-/** 列表视图：行内改 status/priority/assignee。 */
+/** 列表视图：行内改 status/priority/assignee + 多选批量改删。 */
 export default function IssueList({
   issues,
   onOpen,
   onChanged,
+  running,
 }: IssueListProps) {
   const { t } = useI18n();
   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  // 筛选/搜索/排序/翻页令 issues 变化后,裁掉已不可见的选中项 —— 否则批量条会对
+  // 当前结果集看不到的行发批量写(改/删隐藏行)。只保留仍在可见集合里的 id。
+  useEffect(() => {
+    setSelected((prev) => {
+      const visible = new Set(issues.map((i) => i.id));
+      const next = prev.filter((id) => visible.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [issues]);
 
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
     await updateIssue(id, p);
     onChanged();
+  };
+
+  // 批量:写失败 toast+中止;成功清选择+刷新。批量不走 RunConfirm 预览(显式批操作,
+  // 与原生 web 一致);状态/指派若触发 agent run 由后端处理。
+  // busy 守卫放这里(而非逐个控件 disabled):结构性防重入,任一触发器在途都挡住重叠批量写。
+  const runBatch = async (fn: () => Promise<unknown>) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await fn();
+      Toast.success(t("loop.batch.done"));
+      setSelected([]);
+      onChanged();
+    } catch (e) {
+      Toast.error((e as Error).message || t("loop.toast.saveFailed"));
+    } finally {
+      setBusy(false);
+    }
   };
 
   const columns = [
@@ -52,6 +91,7 @@ export default function IssueList({
       render: (v: string, r: Issue) => (
         <span className="loop-cell-title" onClick={() => onOpen(r.id)}>
           {v}
+          {running?.has(r.id) && <RunningChip />}
           <LabelChips labels={r.labels} max={3} />
         </span>
       ),
@@ -123,12 +163,69 @@ export default function IssueList({
 
   return (
     <>
+      {selected.length > 0 && (
+        <div className="loop-batchbar">
+          <Text strong>{t("loop.batch.selected", { values: { count: selected.length } })}</Text>
+          <Select
+            placeholder={t("loop.menu.changeStatus")}
+            size="small"
+            disabled={busy}
+            value={NO_VALUE}
+            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { status: v as IssueStatus }))}
+            style={{ width: 130 }}
+          >
+            {ISSUE_STATUS_ORDER.map((s) => (
+              <Select.Option key={s} value={s}>{t(`loop.status.${s}`)}</Select.Option>
+            ))}
+          </Select>
+          <Select
+            placeholder={t("loop.menu.changePriority")}
+            size="small"
+            disabled={busy}
+            value={NO_VALUE}
+            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { priority: v as IssuePriority }))}
+            style={{ width: 120 }}
+          >
+            {PRIORITY_ORDER.map((p) => (
+              <Select.Option key={p} value={p}>{t(`loop.priority.${p}`)}</Select.Option>
+            ))}
+          </Select>
+          <AssigneePicker
+            size="small"
+            value={null}
+            valueName={null}
+            onChange={(id, type) => runBatch(() => batchUpdateIssues(selected, { assignee_id: id, assignee_type: type }))}
+          />
+          <Button
+            size="small"
+            type="danger"
+            theme="borderless"
+            icon={<Trash2 size={14} />}
+            disabled={busy}
+            onClick={() =>
+              confirmDelete({
+                title: t("loop.batch.deleteConfirm", { values: { count: selected.length } }),
+                okText: t("loop.action.delete"),
+                cancelText: t("loop.action.cancel"),
+                onOk: () => runBatch(() => batchDeleteIssues(selected)),
+              })
+            }
+          >
+            {t("loop.action.delete")}
+          </Button>
+          <Button size="small" theme="borderless" icon={<X size={14} />} onClick={() => setSelected([])} aria-label={t("loop.action.cancel")} />
+        </div>
+      )}
       <Table
         rowKey="id"
         columns={columns}
         dataSource={issues}
         pagination={false}
         size="small"
+        rowSelection={{
+          selectedRowKeys: selected,
+          onChange: (keys) => setSelected((keys ?? []) as string[]),
+        }}
       />
       {runConfirmModal}
     </>

--- a/packages/dmloop/src/panel/ProjectDetailPage.tsx
+++ b/packages/dmloop/src/panel/ProjectDetailPage.tsx
@@ -30,7 +30,7 @@ export default function ProjectDetailPage({ projectId, onChanged }: { projectId:
   const back = () => WKApp.routeRight.pop();
   const patch = async (p: Parameters<typeof updateProject>[1]) => {
     if (!row) return;
-    const next = await updateProject(row.id, { title: p.title ?? row.title, ...p });
+    const next = await updateProject(row.id, { ...p, title: p.title ?? row.title });
     setRow(next);
     onChanged?.();
   };

--- a/packages/dmloop/src/ui/CreateIssueModal.tsx
+++ b/packages/dmloop/src/ui/CreateIssueModal.tsx
@@ -16,13 +16,16 @@ export interface CreateIssueModalProps {
   visible: boolean;
   onClose: () => void;
   onCreated?: () => void;
+  /** 传入即新建为该 issue 的子任务(绑定 parent_issue_id)。 */
+  parentIssueId?: string;
 }
 
 /**
  * 新建 Issue 弹窗（对齐产品设计的手动创建流程）：
  * 标题 / 描述 / 指派(member|agent|squad 三态) / 状态 / 优先级 / 项目。
+ * 传 parentIssueId 时创建为子任务。
  */
-export default function CreateIssueModal({ visible, onClose, onCreated }: CreateIssueModalProps) {
+export default function CreateIssueModal({ visible, onClose, onCreated, parentIssueId }: CreateIssueModalProps) {
   const { t } = useI18n();
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
@@ -54,6 +57,7 @@ export default function CreateIssueModal({ visible, onClose, onCreated }: Create
         assignee_id: assigneeId,
         assignee_type: assigneeType,
         project_id: projectId,
+        parent_issue_id: parentIssueId,
       });
       onClose();
       onCreated?.();
@@ -64,7 +68,7 @@ export default function CreateIssueModal({ visible, onClose, onCreated }: Create
 
   return (
     <Modal
-      title={t("loop.action.newIssue")}
+      title={parentIssueId ? t("loop.subIssue.create") : t("loop.action.newIssue")}
       visible={visible}
       onOk={submit}
       onCancel={onClose}

--- a/packages/dmloop/src/ui/IssueCard.tsx
+++ b/packages/dmloop/src/ui/IssueCard.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Tag } from "@douyinfe/semi-ui";
+import { CalendarClock } from "lucide-react";
+import { useI18n } from "@octo/base";
+import type { Issue } from "../api/types";
+import { AssigneeBadge } from "./AssigneePicker";
+import LabelChips from "./LabelChips";
+import RunningChip from "./RunningChip";
+import { PRIORITY_COLOR, formatShortDate, isOverdue } from "./meta";
+
+export interface IssueCardProps {
+  issue: Issue;
+  onOpen: (id: string) => void;
+  /** 有 agent 正在该 issue 上跑任务(数据源:工作区 agent-task-snapshot)。 */
+  running?: boolean;
+  /** status 看板的跨列拖拽;分组板不传即普通卡片。 */
+  draggable?: boolean;
+  dragging?: boolean;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+}
+
+/** issue 卡片:status 看板与分组板复用的单一呈现(running 状态由共享 RunningChip 渲染)。 */
+export default function IssueCard({
+  issue,
+  onOpen,
+  running,
+  draggable,
+  dragging,
+  onDragStart,
+  onDragEnd,
+}: IssueCardProps) {
+  const { t } = useI18n();
+  return (
+    <div
+      className={`loop-card ${dragging ? "is-dragging" : ""}`}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onClick={() => onOpen(issue.id)}
+    >
+      <div className="loop-card__key">
+        {issue.identifier}
+        {running && <RunningChip />}
+      </div>
+      <div className="loop-card__title">{issue.title}</div>
+      {issue.labels && issue.labels.length > 0 && (
+        <div style={{ marginTop: 4 }}><LabelChips labels={issue.labels} max={3} /></div>
+      )}
+      <div className="loop-card__foot">
+        <Tag color={PRIORITY_COLOR[issue.priority]} size="small">
+          {t(`loop.priority.${issue.priority}`)}
+        </Tag>
+        {issue.due_date && (
+          <span
+            className="loop-card__due"
+            style={{ color: isOverdue(issue.due_date, issue.status) ? "var(--semi-color-danger)" : "var(--semi-color-text-2)" }}
+          >
+            <CalendarClock size={12} />
+            {formatShortDate(issue.due_date)}
+          </span>
+        )}
+        <AssigneeBadge type={issue.assignee_type} name={issue.assignee_name ?? null} />
+      </div>
+    </div>
+  );
+}

--- a/packages/dmloop/src/ui/RunningChip.tsx
+++ b/packages/dmloop/src/ui/RunningChip.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Tag } from "@douyinfe/semi-ui";
+import { Loader } from "lucide-react";
+import { useI18n } from "@octo/base";
+
+/** 「AI 运行中」小徽标:issue 卡片与列表行共用的单一呈现(改色/图标/文案只此一处)。
+ *  数据源:工作区 agent-task-snapshot 算出的 running issue-id 集合。 */
+export default function RunningChip() {
+  const { t } = useI18n();
+  return (
+    <Tag color="green" size="small" prefixIcon={<Loader size={11} className="loop-spin" />}>
+      {t("loop.taskStatus.running")}
+    </Tag>
+  );
+}

--- a/packages/dmloop/src/vite-env.d.ts
+++ b/packages/dmloop/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_LOOP_API_BASE?: string
+  readonly VITE_APP_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## What

Tier1 of the dmloop (`@octo/loop`) issue browse/edit parity work. Five cohesive capabilities, all backed by existing octo-multica endpoints (frontend-only, no backend/DB change):

1. **Grouped-by-assignee board** — `GET /issues/grouped?group_by=assignee`.
2. **Scope pill** (All / Members / AI / Involves me). "Involves me" fans out three server filters (`assignee_id` ∪ `creator_id` ∪ `involves_user_id`) and merges/dedupes client-side, because the backend `involves_user_id` filter is by design disjoint from direct assignment/creation (mirrors the native `fetchAllMyAssigneeGroups`).
3. **Agent-running chip** — from `GET /agent-task-snapshot` (one workspace-level snapshot → client-derived running-issue set; no per-card N+1). 15s poll + sequence guard.
4. **Sub-issue create entry** — `parent_issue_id` on create, from the issue detail sub-issue section.
5. **Batch update/delete** — `POST /issues/batch-update|batch-delete` via Semi `Table` rowSelection; selection pruned to visible rows on filter/sort/page change; `runBatch` reentrancy guard.

Shared `IssueCard` + `RunningChip` extracted (dedupes board/list/grouped rendering).

Also folded in (frontend-only brand hygiene): renamed `Multica*` CLI-authorize identifiers/files to `Loop*` (route value `/loop/cli-authorize` unchanged; cross-repo `MULTICA_APP_URL` env / `multica_csrf` cookie / `/fleet` path deferred — they need backend/CLI coordination). Added `packages/dmloop/src/vite-env.d.ts` so the package typechecks clean.

## Verification (real browser, MV2 E2E workspace, real backend)

- **Grouped board**: issues grouped under assignee "E2E Coworker" + an "Unassigned" group.
- **Scope pill**: All (3) → Members (0, all agent-assigned) → Involves me (2, deduped union). After creating an unassigned sub-issue authored by me, it appears in "Involves me" **only via the creator leg** — confirming the 3-way union is live (not involves-only).
- **Running chip**: rendered on the issue with an active agent task, across board / grouped / list.
- **Batch**: multi-select 2 issues, batch priority change → persisted (confirmed in the issue activity log). Selecting a row then applying a status filter that hides it prunes the selection (batch bar clears — no mutation of hidden rows).
- **Sub-issue**: created MVE-5 under MVE-2, progress shows `(0/1)`.
- **CLI-authorize rename**: `apps/web/src/__tests__/loopCliAuthorizeDeepLink.test.ts` passes (5/5).
- **Typecheck**: `tsc -p packages/dmloop` → 0 errors.

## Review

- `/simplify` (4 agents) applied.
- Two-model adversarial review (Claude code-reviewer ×2 rounds + Codex adversarial-review) found and fixed real bugs: involves-scope union (was dropping directly-assigned/created issues), batch reentrancy guard, batch selection staleness, fan-out filter cross-contamination, running-snapshot staleness + stale-overwrite.
- Batch endpoints are workspace-scoped server-side (`GetIssueInWorkspace` per id) — no cross-tenant IDOR.
- A final clean Codex confirmation re-run is pending due to endpoint instability today; it will be added as a follow-up once the endpoint recovers.
- `packages/dmloop` has no unit-test harness (whole package); regression is the real-browser e2e above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
