### PR TITLE
fix(loop): invalidate directory cache on member/agent/squad/project mutations

### DIFF
--- a/packages/dmloop/src/api/agentApi.ts
+++ b/packages/dmloop/src/api/agentApi.ts
@@ -1,7 +1,7 @@
 // @octo/loop — Agent API（后端契约联调）
 import type { Agent, CreateAgentReq, UpdateAgentReq, ListParams, RuntimeDevice } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
-import { ensureDirectory, actorName, actorAvatar } from "./directory";
+import { ensureDirectory, actorName, actorAvatar, afterDirectoryMutation } from "./directory";
 
 // runtime 名字缓存（用于 agent.runtime_name 回填）
 let _runtimeMap: Map<string, string> | null = null;
@@ -39,16 +39,16 @@ export async function getAgent(id: string): Promise<Agent> {
 }
 
 export function createAgent(req: CreateAgentReq): Promise<Agent> {
-  return httpPost<Agent>("/agents", req);
+  return httpPost<Agent>("/agents", req).then(afterDirectoryMutation);
 }
 
 export function updateAgent(id: string, req: UpdateAgentReq): Promise<Agent> {
-  return httpPut<Agent>(`/agents/${id}`, req);
+  return httpPut<Agent>(`/agents/${id}`, req).then(afterDirectoryMutation);
 }
 
 // 后端不支持 DELETE /agents/:id（405）；改用归档。
 export function archiveAgent(id: string): Promise<void> {
-  return httpPost<void>(`/agents/${id}/archive`, {});
+  return httpPost<void>(`/agents/${id}/archive`, {}).then(afterDirectoryMutation);
 }
 
 /* ---------- 环境变量（密钥） ---------- */

--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -19,6 +19,11 @@ interface Directory {
 
 let _cache: Directory | null = null;
 let _loading: Promise<Directory> | null = null;
+// generation:每次 invalidate 自增。in-flight build 只在自己启动时的 gen 未被 invalidate
+// 打断时才提交到 _cache —— 否则(mutation/切 workspace 在 build 途中发生)build 会把
+// **失效前的陈旧数据**写回 _cache,重新污染。等待者仍拿到本次 d(自身发起早于 mutation),
+// 但不毒害后续读。
+let _gen = 0;
 
 async function build(): Promise<Directory> {
   const slug = currentWorkspaceSlug();
@@ -67,9 +72,14 @@ export async function ensureDirectory(force = false): Promise<Directory> {
   // 已有 in-flight build 时并发调用者直接搭车(切 workspace 会 invalidateDirectory 清空 _loading),
   // 避免冷启动(_cache 尚为 null)多个消费者各拉一遍 directory。
   if (!force && _loading) return _loading;
+  const myGen = _gen;
   _loading = build().then((d) => {
-    _cache = d;
-    _loading = null;
+    // 只有本次 build 未被 invalidate 打断才提交并清 _loading;被打断则不写 _cache
+    // (下次 ensureDirectory 见 _cache/_loading 均已被 invalidate 清空 → 重新 build)。
+    if (myGen === _gen) {
+      _cache = d;
+      _loading = null;
+    }
     return d;
   });
   return _loading;
@@ -78,6 +88,15 @@ export async function ensureDirectory(force = false): Promise<Directory> {
 export function invalidateDirectory(): void {
   _cache = null;
   _loading = null;
+  _gen++;
+}
+
+// 目录相关实体(member/agent/squad/project)的写操作**成功后**链在 .then 上:清缓存,
+// 下次读(打开新建弹窗、渲染筛选/看板 enrich)即重建 → 增删改后候选/名字/项目选项不再陈旧。
+// 放在共享 API 层而非各 UI 处,一处收口护全部消费者(Rule 9)。
+export function afterDirectoryMutation<T>(result: T): T {
+  invalidateDirectory();
+  return result;
 }
 
 export function actorName(

--- a/packages/dmloop/src/api/projectApi.ts
+++ b/packages/dmloop/src/api/projectApi.ts
@@ -1,7 +1,7 @@
 // @octo/loop — Project API（后端契约联调）
 import type { Project, UpsertProjectReq, ListParams } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
-import { ensureDirectory, actorName } from "./directory";
+import { ensureDirectory, actorName, afterDirectoryMutation } from "./directory";
 
 export async function listProjects(params?: ListParams): Promise<Project[]> {
   const [data, dir] = await Promise.all([
@@ -26,13 +26,13 @@ export async function getProject(id: string): Promise<Project> {
 }
 
 export function createProject(req: UpsertProjectReq): Promise<Project> {
-  return httpPost<Project>("/projects", req);
+  return httpPost<Project>("/projects", req).then(afterDirectoryMutation);
 }
 
 export function updateProject(id: string, req: UpsertProjectReq): Promise<Project> {
-  return httpPut<Project>(`/projects/${id}`, req);
+  return httpPut<Project>(`/projects/${id}`, req).then(afterDirectoryMutation);
 }
 
 export function deleteProject(id: string): Promise<void> {
-  return httpDelete<void>(`/projects/${id}`);
+  return httpDelete<void>(`/projects/${id}`).then(afterDirectoryMutation);
 }

--- a/packages/dmloop/src/api/squadApi.ts
+++ b/packages/dmloop/src/api/squadApi.ts
@@ -1,7 +1,7 @@
 // @octo/loop — Squad API（后端契约联调）
 import type { Squad, SquadMember, UpsertSquadReq, ListParams } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete, httpPatch } from "./http";
-import { ensureDirectory, actorName, actorAvatar } from "./directory";
+import { ensureDirectory, actorName, actorAvatar, afterDirectoryMutation } from "./directory";
 
 function enrichSquad(s: Squad, dir: Awaited<ReturnType<typeof ensureDirectory>>): Squad {
   const members = (s.members ?? s.member_preview ?? []).map((m) => ({
@@ -37,15 +37,15 @@ export async function getSquad(id: string): Promise<Squad> {
 
 export function createSquad(req: UpsertSquadReq): Promise<Squad> {
   // 后端要求 leader_id；无则由页面校验。
-  return httpPost<Squad>("/squads", req);
+  return httpPost<Squad>("/squads", req).then(afterDirectoryMutation);
 }
 
 export function updateSquad(id: string, req: UpsertSquadReq): Promise<Squad> {
-  return httpPut<Squad>(`/squads/${id}`, req);
+  return httpPut<Squad>(`/squads/${id}`, req).then(afterDirectoryMutation);
 }
 
 export function deleteSquad(id: string): Promise<void> {
-  return httpDelete<void>(`/squads/${id}`);
+  return httpDelete<void>(`/squads/${id}`).then(afterDirectoryMutation);
 }
 
 export function listSquadMembers(id: string): Promise<SquadMember[]> {

--- a/packages/dmloop/src/api/workspaceApi.ts
+++ b/packages/dmloop/src/api/workspaceApi.ts
@@ -1,6 +1,7 @@
 // @octo/loop — Workspace / Members / Invitations API（后端契约联调）
 import type { Workspace, WorkspaceMember, Invitation } from "./types";
 import { httpGet, httpPost, httpPatch, httpDelete } from "./http";
+import { afterDirectoryMutation } from "./directory";
 
 export function listWorkspaces(): Promise<Workspace[]> {
   return httpGet<Workspace[]>("/workspaces");
@@ -42,7 +43,8 @@ export function addOctoMember(
   workspaceId: string,
   req: { octo_uid: string; role?: string },
 ): Promise<WorkspaceMember> {
-  return httpPost<WorkspaceMember>(`/workspaces/${workspaceId}/octo-members`, req);
+  // 加成员后目录候选(负责人/创建者下拉、内联指派)会变 → 清缓存,下次读重建。
+  return httpPost<WorkspaceMember>(`/workspaces/${workspaceId}/octo-members`, req).then(afterDirectoryMutation);
 }
 
 /** 修改成员角色。 */
@@ -56,7 +58,8 @@ export function updateMemberRole(
 
 /** 移除成员。 */
 export function removeMember(workspaceId: string, memberId: string): Promise<void> {
-  return httpDelete<void>(`/workspaces/${workspaceId}/members/${memberId}`);
+  // 删成员后目录候选变 → 清缓存,避免下拉仍显示已删成员。
+  return httpDelete<void>(`/workspaces/${workspaceId}/members/${memberId}`).then(afterDirectoryMutation);
 }
 
 /** 待处理邀请列表。 */


### PR DESCRIPTION
## Bug

In the dmloop Settings → Member management flow, after **adding** a workspace member the new person was missing from the "new issue" (新建回路) assignee dropdown, and after **removing** a member the removed person was still shown — both until a full reload.

## Root cause

The `Directory` cache in `packages/dmloop/src/api/directory.ts` (a module-level singleton holding member/agent/squad assignee candidates + project names, consumed by assignee dropdowns, filters, and list/board enrich) was only invalidated on **workspace switch**. Member add/remove — and, by the same class, agent/squad/project create/update/delete — never invalidated it, so every consumer read stale data.

## Fix (structural, one shared sink — Rule 9)

Add `afterDirectoryMutation<T>(result: T): T { invalidateDirectory(); return result; }` and chain it via `.then()` onto the directory-relevant mutation API functions, so the cache is cleared on success and the next read (fresh picker mount / filter render / enrich) rebuilds:

- `workspaceApi.ts`: `addOctoMember`, `removeMember`
- `agentApi.ts`: `createAgent`, `updateAgent`, `archiveAgent`
- `squadApi.ts`: `createSquad`, `updateSquad`, `deleteSquad`
- `projectApi.ts`: `createProject`, `updateProject`, `deleteProject`

`inviteMember` / `updateMemberRole` / `revokeInvitation` are intentionally **not** wrapped — invitations aren't materialized members and role changes don't affect cached name/candidate data.

Also closes a cache race the new invalidation points expose: `ensureDirectory`'s build-commit is now guarded by a generation counter, so an in-flight `build()` started **before** a mutation cannot repopulate `_cache` with pre-mutation data after `invalidateDirectory()` clears it. (Confirmed by adversarial review.)

## Verification

- **Real browser** (Loop-dev workspace): add member "Bob" → 新建回路 assignee dropdown shows `[未指派, Alice, Bob]` with no reload; remove Bob → dropdown shows `[未指派, Alice]`. Both halves of the reported bug fixed. Test data restored (member list back to 1).
- **Adversarial review** (Claude code-reviewer): its one finding was the in-flight-build race, already fixed by the generation guard; type/value preservation, error propagation, and wrapped-vs-unwrapped coverage all confirmed correct.
- `tsc -p packages/dmloop`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
