### PR TITLE
feat(versions): unified VersionHistoryPanel shell + race guard util

### DIFF
--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -289,6 +289,22 @@ describe('VersionHistoryPanel — mutations & permissions', () => {
     await waitFor(() => expect(onRestored).toHaveBeenCalled())
   })
 
+  it('delete goes through the same in-panel confirm box (not window.confirm)', async () => {
+    // P2 (XIN-848): delete used a native window.confirm; it now uses the unified in-panel confirm
+    // box like restore. Guard against a regression to the native dialog and confirm the row is
+    // removed only after the box's confirm is clicked.
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    renderPanel('admin')
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.delete'))
+    // No native dialog; a centered in-panel confirm box appears instead.
+    expect(confirmSpy).not.toHaveBeenCalled()
+    const box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    fireEvent.click(btnByText(box, 'docs.version.delete'))
+    await waitFor(() => expect(deleteVersionMock).toHaveBeenCalledWith('d_1', 7))
+    confirmSpy.mockRestore()
+  })
+
   it('renames a named version inline (no native prompt)', async () => {
     renderPanel('admin')
     await screen.findByText('Draft v1')

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+
+// XIN-837 (拆单阶段 1): the unified <VersionHistoryPanel> shell. These tests pin the behavior the
+// three end panels will inherit: a single mixed list with filter tabs + counts + load-more, the
+// centered preview/diff modal (Esc / overlay-close / stopPropagation), inline save/rename (no native
+// prompt), the in-panel restore confirm box, role-gated affordances, and the unified race guard —
+// a slow earlier preview must never overwrite a newer selection.
+
+const NAMED = {
+  docVersionSeq: 7,
+  kind: 'named' as const,
+  label: 'Draft v1',
+  createdBy: 'u_self',
+  createdAt: '2026-06-20T10:00:00.000Z',
+  sizeBytes: 1234,
+  schemaVersion: 1,
+  restoredFrom: null,
+}
+const AUTO = {
+  docVersionSeq: 6,
+  kind: 'auto' as const,
+  label: '',
+  createdBy: 'u_self',
+  createdAt: '2026-06-20T09:30:00.000Z',
+  sizeBytes: 999,
+  schemaVersion: 1,
+  restoredFrom: null,
+}
+const COUNTS = { auto: 5, manual: 2, restore: 1, total: 8 }
+
+const listVersionsMock = vi.fn(
+  async (_docId: unknown, opts?: { kind?: string; cursor?: number | null }) => {
+    if (opts?.cursor != null) return { items: [{ ...AUTO, docVersionSeq: 4 }], nextCursor: null, counts: COUNTS }
+    return { items: [NAMED, AUTO], nextCursor: 100, counts: COUNTS }
+  },
+)
+const createNamedVersionMock = vi.fn(async () => 8)
+const restoreVersionMock = vi.fn(async () => ({ newDocVersionSeq: 9, restoredFrom: 7 }))
+const renameVersionMock = vi.fn(async () => undefined)
+const deleteVersionMock = vi.fn(async () => undefined)
+
+vi.mock('./api.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api.ts')>()
+  return {
+    ...actual,
+    listVersions: (...a: unknown[]) => listVersionsMock(...(a as [unknown, { kind?: string }?])),
+    createNamedVersion: (...a: unknown[]) => createNamedVersionMock(...(a as [])),
+    restoreVersion: (...a: unknown[]) => restoreVersionMock(...(a as [])),
+    renameVersion: (...a: unknown[]) => renameVersionMock(...(a as [])),
+    deleteVersion: (...a: unknown[]) => deleteVersionMock(...(a as [])),
+  }
+})
+
+import { VersionHistoryPanel } from './VersionHistoryPanel.tsx'
+import type { Role } from '../auth/roles.ts'
+
+interface PreviewState {
+  body: string
+}
+
+/** A default host wiring for the shell: preview returns a tagged body; diff/current provided. */
+function renderPanel(
+  role: Role = 'admin',
+  overrides: Partial<{
+    loadPreviewState: (seq: number, signal: AbortSignal) => Promise<PreviewState>
+    renderDiff?: (s: PreviewState, c: string | null) => React.ReactNode
+    getCurrent?: () => string | null
+    onRestored?: () => void
+  }> = {},
+) {
+  const loadPreviewState =
+    overrides.loadPreviewState ?? (async (seq: number) => ({ body: `body-${seq}` }))
+  return render(
+    <VersionHistoryPanel<PreviewState, string>
+      docId="d_1"
+      role={role}
+      loadPreviewState={loadPreviewState}
+      renderPreview={(s) => <div data-testid="preview-body">{s.body}</div>}
+      renderDiff={
+        'renderDiff' in overrides
+          ? overrides.renderDiff
+          : (s, c) => <div data-testid="diff-body">{`${s.body}|${c ?? 'null'}`}</div>
+      }
+      getCurrent={'getCurrent' in overrides ? overrides.getCurrent : () => 'CURRENT'}
+      onRestored={overrides.onRestored}
+    />,
+  )
+}
+
+const btnByText = (root: ParentNode, text: string) =>
+  Array.from(root.querySelectorAll('button')).find((b) => b.textContent === text) as HTMLButtonElement
+
+beforeEach(() => {
+  listVersionsMock.mockClear()
+  createNamedVersionMock.mockClear()
+  restoreVersionMock.mockClear()
+  renameVersionMock.mockClear()
+  deleteVersionMock.mockClear()
+})
+afterEach(() => cleanup())
+
+describe('VersionHistoryPanel — list / filter / counts', () => {
+  it('renders a single mixed list and requests kind="all" on mount', async () => {
+    renderPanel()
+    await screen.findByText('Draft v1')
+    expect(document.querySelectorAll('.octo-version-list .octo-version-row').length).toBe(2)
+    expect((listVersionsMock.mock.calls[0][1] as { kind?: string }).kind).toBe('all')
+  })
+
+  it('shows the unified counts header (manual+restore · auto)', async () => {
+    renderPanel()
+    await screen.findByText('Draft v1')
+    const counts = document.querySelector('.octo-version-counts') as HTMLElement
+    // manual(2) + restore(1) = 3 · auto = 5
+    expect(counts.textContent).toContain('3')
+    expect(counts.textContent).toContain('5')
+  })
+
+  it('reloads with the chosen kind when a filter tab is clicked', async () => {
+    renderPanel()
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.body, 'docs.version.filterManual'))
+    await waitFor(() =>
+      expect(listVersionsMock.mock.calls.some((c) => (c[1] as { kind?: string })?.kind === 'manual')).toBe(true),
+    )
+  })
+
+  it('pages the current filter via cursor on load-more', async () => {
+    renderPanel()
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.body, 'docs.version.loadMore'))
+    await waitFor(() =>
+      expect(listVersionsMock.mock.calls.some((c) => (c[1] as { cursor?: number })?.cursor === 100)).toBe(true),
+    )
+  })
+})
+
+describe('VersionHistoryPanel — centered preview modal', () => {
+  it('opens a centered modal (not inline) and renders the injected preview, honoring the signal', async () => {
+    const seen: AbortSignal[] = []
+    renderPanel('admin', {
+      loadPreviewState: async (seq, signal) => {
+        seen.push(signal)
+        return { body: `body-${seq}` }
+      },
+    })
+    await screen.findByText('Draft v1')
+    expect(document.querySelector('.docs-version-preview-modal')).toBeNull()
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.preview'))
+    await waitFor(() => expect(document.querySelector('.docs-version-preview-modal')).toBeTruthy())
+    const modal = document.querySelector('.docs-version-preview-modal') as HTMLElement
+    expect(modal.closest('.octo-modal-overlay')).toBeTruthy()
+    expect(modal.getAttribute('role')).toBe('dialog')
+    await waitFor(() => expect(modal.querySelector('[data-testid="preview-body"]')?.textContent).toBe('body-7'))
+    // The host received a real AbortSignal.
+    expect(seen[0]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('closes on Escape and on overlay click, but not when the dialog body is clicked', async () => {
+    renderPanel()
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.preview'))
+    await waitFor(() => expect(document.querySelector('.docs-version-preview-modal')).toBeTruthy())
+    // Body click does not close (stopPropagation).
+    fireEvent.mouseDown(document.querySelector('.docs-version-preview-modal')!)
+    expect(document.querySelector('.docs-version-preview-modal')).toBeTruthy()
+    // Escape closes.
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.querySelector('.docs-version-preview-modal')).toBeNull())
+  })
+
+  it('offers the compare toggle only when renderDiff + getCurrent are provided', async () => {
+    // With diff+current: toggle appears and renders the injected diff.
+    renderPanel()
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.preview'))
+    const modal = await waitFor(() => document.querySelector('.docs-version-preview-modal') as HTMLElement)
+    await waitFor(() => expect(modal.querySelector('[data-testid="preview-body"]')).toBeTruthy())
+    const toggle = btnByText(modal, 'docs.version.compare')
+    expect(toggle).toBeTruthy()
+    fireEvent.click(toggle)
+    await waitFor(() => expect(modal.querySelector('[data-testid="diff-body"]')?.textContent).toBe('body-7|CURRENT'))
+
+    cleanup()
+    // Without diff (board case): no compare toggle.
+    renderPanel('admin', { renderDiff: undefined, getCurrent: undefined })
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.preview'))
+    const modal2 = await waitFor(() => document.querySelector('.docs-version-preview-modal') as HTMLElement)
+    await waitFor(() => expect(modal2.querySelector('[data-testid="preview-body"]')).toBeTruthy())
+    expect(btnByText(modal2, 'docs.version.compare')).toBeUndefined()
+  })
+})
+
+describe('VersionHistoryPanel — race guard', () => {
+  it('a slow earlier preview never overwrites a newer selection', async () => {
+    const deferreds = new Map<number, (v: PreviewState) => void>()
+    const signals = new Map<number, AbortSignal>()
+    renderPanel('admin', {
+      loadPreviewState: (seq, signal) => {
+        signals.set(seq, signal)
+        return new Promise<PreviewState>((resolve) => deferreds.set(seq, resolve))
+      },
+    })
+    await screen.findByText('Draft v1')
+    const rows = document.querySelectorAll('.octo-version-row')
+    // Preview #7 (slow), then #6 (fast) before #7 resolves.
+    fireEvent.click(btnByText(rows[0], 'docs.version.preview'))
+    fireEvent.click(btnByText(rows[1], 'docs.version.preview'))
+    // The newer request aborted the earlier one on the wire.
+    expect(signals.get(7)!.aborted).toBe(true)
+    // Resolve the newer one first, then the stale earlier one.
+    deferreds.get(6)!({ body: 'body-6' })
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="preview-body"]')?.textContent).toBe('body-6'),
+    )
+    deferreds.get(7)!({ body: 'body-7' })
+    // The stale #7 response is discarded — the modal still shows #6.
+    await waitFor(() => {})
+    expect(document.querySelector('[data-testid="preview-body"]')?.textContent).toBe('body-6')
+  })
+})
+
+describe('VersionHistoryPanel — mutations & permissions', () => {
+  it('restore goes through an in-panel confirm box (not window.confirm) and fires onRestored', async () => {
+    const onRestored = vi.fn()
+    renderPanel('admin', { onRestored })
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.restore'))
+    // A centered confirm box appears in-panel.
+    const confirm = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    fireEvent.click(btnByText(confirm, 'docs.version.restore'))
+    await waitFor(() => expect(restoreVersionMock).toHaveBeenCalled())
+    await waitFor(() => expect(onRestored).toHaveBeenCalled())
+  })
+
+  it('renames a named version inline (no native prompt)', async () => {
+    renderPanel('admin')
+    await screen.findByText('Draft v1')
+    const row = document.querySelector('.octo-version-row-named') as HTMLElement
+    fireEvent.click(btnByText(row, 'docs.version.rename'))
+    const input = row.querySelector('input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Renamed' } })
+    fireEvent.click(btnByText(row, 'docs.version.save'))
+    await waitFor(() => expect(renameVersionMock).toHaveBeenCalledWith('d_1', 7, 'Renamed'))
+  })
+
+  it('gates save/restore/delete/rename behind role (reader sees none)', async () => {
+    renderPanel('reader')
+    await screen.findByText('Draft v1')
+    expect(btnByText(document.body, 'docs.version.saveCurrent')).toBeUndefined()
+    const row = document.querySelector('.octo-version-row') as HTMLElement
+    expect(btnByText(row, 'docs.version.restore')).toBeUndefined()
+    expect(btnByText(row, 'docs.version.delete')).toBeUndefined()
+    expect(btnByText(row, 'docs.version.rename')).toBeUndefined()
+    // Preview stays available to readers.
+    expect(btnByText(row, 'docs.version.preview')).toBeTruthy()
+  })
+
+  it('writer can save + rename but cannot restore/delete', async () => {
+    renderPanel('writer')
+    await screen.findByText('Draft v1')
+    expect(btnByText(document.body, 'docs.version.saveCurrent')).toBeTruthy()
+    const row = document.querySelector('.octo-version-row-named') as HTMLElement
+    expect(btnByText(row, 'docs.version.rename')).toBeTruthy()
+    expect(btnByText(row, 'docs.version.restore')).toBeUndefined()
+    expect(btnByText(row, 'docs.version.delete')).toBeUndefined()
+  })
+})

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -29,12 +29,11 @@ const AUTO = {
 }
 const COUNTS = { auto: 5, manual: 2, restore: 1, total: 8 }
 
-const listVersionsMock = vi.fn(
-  async (_docId: unknown, opts?: { kind?: string; cursor?: number | null }) => {
-    if (opts?.cursor != null) return { items: [{ ...AUTO, docVersionSeq: 4 }], nextCursor: null, counts: COUNTS }
-    return { items: [NAMED, AUTO], nextCursor: 100, counts: COUNTS }
-  },
-)
+const defaultListImpl = async (_docId: unknown, opts?: { kind?: string; cursor?: number | null }) => {
+  if (opts?.cursor != null) return { items: [{ ...AUTO, docVersionSeq: 4 }], nextCursor: null, counts: COUNTS }
+  return { items: [NAMED, AUTO], nextCursor: 100, counts: COUNTS }
+}
+const listVersionsMock = vi.fn(defaultListImpl)
 const createNamedVersionMock = vi.fn(async () => 8)
 const restoreVersionMock = vi.fn(async () => ({ newDocVersionSeq: 9, restoredFrom: 7 }))
 const renameVersionMock = vi.fn(async () => undefined)
@@ -92,7 +91,8 @@ const btnByText = (root: ParentNode, text: string) =>
   Array.from(root.querySelectorAll('button')).find((b) => b.textContent === text) as HTMLButtonElement
 
 beforeEach(() => {
-  listVersionsMock.mockClear()
+  listVersionsMock.mockReset()
+  listVersionsMock.mockImplementation(defaultListImpl)
   createNamedVersionMock.mockClear()
   restoreVersionMock.mockClear()
   renameVersionMock.mockClear()
@@ -126,13 +126,18 @@ describe('VersionHistoryPanel — list / filter / counts', () => {
     )
   })
 
-  it('pages the current filter via cursor on load-more', async () => {
+  it('pages the current filter via cursor on load-more and appends the page (no stale error)', async () => {
     renderPanel()
     await screen.findByText('Draft v1')
+    expect(document.querySelectorAll('.octo-version-row').length).toBe(2)
     fireEvent.click(btnByText(document.body, 'docs.version.loadMore'))
     await waitFor(() =>
       expect(listVersionsMock.mock.calls.some((c) => (c[1] as { cursor?: number })?.cursor === 100)).toBe(true),
     )
+    // The fetched page (seq 4) is appended onto the existing rows — the append path the load-more
+    // guard protects. isCurrent() gates both append and errorMore, so no stale error leaks.
+    await waitFor(() => expect(document.querySelectorAll('.octo-version-row').length).toBe(3))
+    expect(document.body.textContent).not.toContain('docs.version.errorMore')
   })
 })
 

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -139,6 +139,55 @@ describe('VersionHistoryPanel — list / filter / counts', () => {
     await waitFor(() => expect(document.querySelectorAll('.octo-version-row').length).toBe(3))
     expect(document.body.textContent).not.toContain('docs.version.errorMore')
   })
+
+  it('re-enables Load More after a superseded load-more (no stuck loadingMore deadlock)', async () => {
+    // Regression for the P1 flagged on #656: setLoadingMore(false) used to be gated on isCurrent(),
+    // so a load-more superseded (by a filter switch / refresh / restore) before its finally ran
+    // would skip the reset and wedge loadingMore=true forever — permanently disabling the Load More
+    // button. Here we hang the load-more page, supersede it with a primary refresh (docId change →
+    // begin()), then release the stale page: its result must be dropped, but loadingMore MUST clear
+    // regardless of isCurrent(), so the fresh list's Load More button is enabled, not deadlocked.
+    let releaseLoadMore: (() => void) | null = null
+    listVersionsMock.mockImplementation(
+      async (_docId: unknown, opts?: { kind?: string; cursor?: number | null }) => {
+        if (opts?.cursor != null) {
+          await new Promise<void>((resolve) => {
+            releaseLoadMore = resolve as () => void
+          })
+          return { items: [{ ...AUTO, docVersionSeq: 4 }], nextCursor: 200, counts: COUNTS }
+        }
+        return { items: [NAMED, AUTO], nextCursor: 100, counts: COUNTS }
+      },
+    )
+    const Panel = (p: { docId: string }) => (
+      <VersionHistoryPanel<PreviewState, string>
+        docId={p.docId}
+        role="admin"
+        loadPreviewState={async (seq: number) => ({ body: `body-${seq}` })}
+        renderPreview={(s) => <div data-testid="preview-body">{s.body}</div>}
+      />
+    )
+    const { rerender } = render(<Panel docId="d_1" />)
+    await screen.findByText('Draft v1')
+    // Kick off load-more; its page request now hangs, so loadingMore stays true and the button
+    // is disabled.
+    fireEvent.click(btnByText(document.body, 'docs.version.loadMore'))
+    await waitFor(() => expect(btnByText(document.body, 'docs.version.loadMore').disabled).toBe(true))
+    // Supersede the in-flight follow-up with a primary refresh (docId change → begin()), which
+    // makes the hanging load-more's isCurrent() report false.
+    rerender(<Panel docId="d_2" />)
+    await waitFor(() =>
+      expect(listVersionsMock.mock.calls.some((c) => c[0] === 'd_2')).toBe(true),
+    )
+    // Release the now-stale load-more: its rows are dropped (isCurrent() false), but the finally
+    // must still clear loadingMore. Before the fix this reset was gated out and the flag stuck.
+    ;(releaseLoadMore as (() => void) | null)?.()
+    await waitFor(() => {
+      const btn = btnByText(document.body, 'docs.version.loadMore')
+      expect(btn).toBeTruthy()
+      expect(btn.disabled).toBe(false)
+    })
+  })
 })
 
 describe('VersionHistoryPanel — centered preview modal', () => {

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 
@@ -336,5 +337,35 @@ describe('VersionHistoryPanel — mutations & permissions', () => {
     expect(btnByText(row, 'docs.version.rename')).toBeTruthy()
     expect(btnByText(row, 'docs.version.restore')).toBeUndefined()
     expect(btnByText(row, 'docs.version.delete')).toBeUndefined()
+  })
+})
+
+describe('VersionHistoryPanel — StrictMode liveness (mounted-ref re-arm)', () => {
+  it('finishes a mutation after a StrictMode double-mount (mounted ref stays live)', async () => {
+    // React 18 StrictMode (dev) runs an effect mount → cleanup → remount on the same node. The
+    // abort/cleanup effect flips the `mounted` liveness ref to false on cleanup; unless the effect
+    // body re-arms it to true on every (re)mount, the ref stays false for the real mount's whole
+    // lifetime and every mutation handler early-returns after its await — the trailing state reset
+    // (busy=false / confirm cleared) never runs and the panel freezes with buttons stuck busy.
+    // This pins that the delete confirm box closes once the delete resolves, which only happens
+    // while the liveness ref is true through the double-mount.
+    render(
+      <StrictMode>
+        <VersionHistoryPanel<PreviewState, string>
+          docId="d_1"
+          role="admin"
+          loadPreviewState={async (seq: number) => ({ body: `body-${seq}` })}
+          renderPreview={(s) => <div data-testid="preview-body">{s.body}</div>}
+        />
+      </StrictMode>,
+    )
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.delete'))
+    const box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    fireEvent.click(btnByText(box, 'docs.version.delete'))
+    await waitFor(() => expect(deleteVersionMock).toHaveBeenCalledWith('d_1', 7))
+    // Re-armed: onDelete runs past its `if (!mounted.current) return` gate → setConfirmDelete(null)
+    // closes the box. Gated (no re-arm): ref stuck false → early return → the box never closes.
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
   })
 })

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -206,8 +206,11 @@ export function VersionHistoryPanel<TState, TCurrent>({
     setError(null)
     try {
       const res = await listVersions(docId, { kind: filter, cursor: nextCursor, limit: pageSize, signal })
-      // Bound to the list generation: if a refresh / filter switch / restore replaced the list
-      // before this page landed, drop it rather than append onto a list that no longer exists.
+      // Bound to the list guard: if a refresh / filter switch / restore (begin) OR a newer
+      // load-more (beginFollowUp) superseded this page before it landed, isCurrent() is false and
+      // we drop it — never appending stale/duplicate rows onto a list that moved on. The follow-up
+      // token in createRaceGuard is what makes the "newer load-more" case report non-current even
+      // though the aborted request may have resolved a hair before its abort.
       if (!isCurrent()) return
       setItems((cur) => [...cur, ...res.items])
       setNextCursor(res.nextCursor)

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -198,6 +198,7 @@ export function VersionHistoryPanel<TState, TCurrent>({
 
   // Abort any in-flight request when the panel unmounts.
   useEffect(() => {
+    mounted.current = true // re-arm on (re)mount so StrictMode's mount→cleanup→remount stays live
     const list = listGuard.current
     const preview = previewGuard.current
     return () => {

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -219,7 +219,14 @@ export function VersionHistoryPanel<TState, TCurrent>({
       if (!isCurrent()) return
       setError(t('docs.version.errorMore'))
     } finally {
-      if (isCurrent()) setLoadingMore(false)
+      // Always clear the loading flag on this follow-up's own completion, independent of
+      // isCurrent(). The guard's job is to discard the stale *result* (handled by the early
+      // returns above); the *loading flag* must not be gated on isCurrent(), or a superseded
+      // load-more (filter switch / refresh / restore while a page is in flight) would skip this
+      // reset and wedge loadingMore=true forever, permanently disabling the Load More button.
+      // A superseded-but-mounted setState is harmless; a genuine unmount is covered by the guard
+      // util's abort; a newer load-more re-sets the flag true itself.
+      setLoadingMore(false)
     }
   }
 

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -139,6 +139,9 @@ export function VersionHistoryPanel<TState, TCurrent>({
 
   // Restore is confirmed in a centered in-panel box (doc model), not a native window.confirm.
   const [confirmRestore, setConfirmRestore] = useState<VersionMeta | null>(null)
+  // Delete is likewise confirmed in the same in-panel box (was a native window.confirm) so the
+  // destructive-action UX is unified across doc/sheet/board rather than falling back to the browser.
+  const [confirmDelete, setConfirmDelete] = useState<VersionMeta | null>(null)
 
   // Centered preview / diff modal.
   const [selected, setSelected] = useState<VersionMeta | null>(null)
@@ -151,6 +154,10 @@ export function VersionHistoryPanel<TState, TCurrent>({
   // preview — both from the shared createRaceGuard so all three chains abort + last-write-win.
   const listGuard = useRef(createRaceGuard())
   const previewGuard = useRef(createRaceGuard())
+  // Liveness flag: mutation handlers setState after an await, and refresh()/the guards only cover
+  // their own async chains — this guards the trailing setBusy/setNotice/onRestored in the handlers
+  // so they no-op if the panel unmounted mid-flight (no setState-after-unmount).
+  const mounted = useRef(true)
 
   const mySnapshot = canSnapshot(role)
   const myRestore = canRestoreVersion(role)
@@ -194,6 +201,7 @@ export function VersionHistoryPanel<TState, TCurrent>({
     const list = listGuard.current
     const preview = previewGuard.current
     return () => {
+      mounted.current = false
       list.abort()
       preview.abort()
     }
@@ -244,13 +252,16 @@ export function VersionHistoryPanel<TState, TCurrent>({
     try {
       await createNamedVersion(docId, snapshotLabel.trim() || undefined)
     } catch {
+      if (!mounted.current) return
       setError(t('docs.version.errorSave'))
       setBusy(false)
       return
     }
+    if (!mounted.current) return
     setSnapshotOpen(false)
     setSnapshotLabel('')
     const ok = await refresh({ soft: true })
+    if (!mounted.current) return
     if (!ok) setNotice(t('docs.version.staleNotice'))
     setBusy(false)
   }
@@ -273,33 +284,40 @@ export function VersionHistoryPanel<TState, TCurrent>({
     try {
       await renameVersion(docId, seq, label)
     } catch {
+      if (!mounted.current) return
       setError(t('docs.version.errorRename'))
       setBusy(false)
       return
     }
+    if (!mounted.current) return
     // Optimistic label update, then reconcile with server ordering/counts (soft: rename landed).
     setItems((cur) => cur.map((v) => (v.docVersionSeq === seq ? { ...v, label } : v)))
     cancelRename()
     const ok = await refresh({ soft: true })
+    if (!mounted.current) return
     if (!ok) setNotice(t('docs.version.staleNotice'))
     setBusy(false)
   }
 
   const onDelete = async (v: VersionMeta) => {
-    if (!window.confirm(t('docs.version.deleteConfirm', { values: { seq: v.docVersionSeq } }))) return
     setBusy(true)
     setError(null)
     try {
       await deleteVersion(docId, v.docVersionSeq)
     } catch {
+      if (!mounted.current) return
       setError(t('docs.version.errorDelete'))
+      setConfirmDelete(null)
       setBusy(false)
       return
     }
+    if (!mounted.current) return
+    setConfirmDelete(null)
     if (selected?.docVersionSeq === v.docVersionSeq) closePreview()
     if (renamingSeq === v.docVersionSeq) cancelRename()
     setItems((cur) => cur.filter((x) => x.docVersionSeq !== v.docVersionSeq))
     const ok = await refresh({ soft: true })
+    if (!mounted.current) return
     if (!ok) setNotice(t('docs.version.staleNotice'))
     setBusy(false)
   }
@@ -312,15 +330,18 @@ export function VersionHistoryPanel<TState, TCurrent>({
     try {
       res = await restoreVersion(docId, v.docVersionSeq)
     } catch (e) {
+      if (!mounted.current) return
       setError(t(restoreErrorKey ? restoreErrorKey(e) : 'docs.version.errorRestore'))
       setConfirmRestore(null)
       setBusy(false)
       return
     }
+    if (!mounted.current) return
     // Restore landed — the live surface reconciles via Yjs. A follow-up refresh miss is soft.
     setConfirmRestore(null)
     closePreview()
     const ok = await refresh({ soft: true })
+    if (!mounted.current) return
     setNotice(
       ok
         ? t('docs.version.restoredNotice', { values: { from: res.restoredFrom, seq: res.newDocVersionSeq } })
@@ -458,7 +479,7 @@ export function VersionHistoryPanel<TState, TCurrent>({
                     type="button"
                     className="octo-tb-btn"
                     disabled={busy}
-                    onClick={() => void onDelete(v)}
+                    onClick={() => setConfirmDelete(v)}
                   >
                     {t('docs.version.delete')}
                   </button>
@@ -564,6 +585,30 @@ export function VersionHistoryPanel<TState, TCurrent>({
                 className="octo-tb-btn"
                 disabled={busy}
                 onClick={() => setConfirmRestore(null)}
+              >
+                {t('docs.version.cancel')}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {confirmDelete && (
+          <div className="octo-version-confirm">
+            <p>{t('docs.version.deleteConfirm', { values: { seq: confirmDelete.docVersionSeq } })}</p>
+            <div className="octo-member-row">
+              <button
+                type="button"
+                className="octo-tb-btn"
+                disabled={busy}
+                onClick={() => void onDelete(confirmDelete)}
+              >
+                {t('docs.version.delete')}
+              </button>
+              <button
+                type="button"
+                className="octo-tb-btn"
+                disabled={busy}
+                onClick={() => setConfirmDelete(null)}
               >
                 {t('docs.version.cancel')}
               </button>

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -1,0 +1,611 @@
+// Unified version-history shell (XIN-836 交付物① / 拆单阶段 1).
+//
+// This is the single container that the doc, sheet and board version panels will each become a
+// thin adapter over. It owns everything that is identical across the three ends — list + filter
+// tabs + counts + pagination, save / rename / delete / restore, the restore confirm box, the
+// unified race guard, and the centered preview / diff modal (Esc / overlay-close / focus) — and
+// leaves each end to inject ONLY what is genuinely end-specific: how to load one version's state,
+// how to render its preview, how to render its diff, and what "current" is.
+//
+// It changes NOTHING for users yet: this phase adds the shell and its guard util + tests, and does
+// not wire any end to it (the doc/sheet/board panels are untouched, so there is zero visible
+// change until an adapter phase switches an end over).
+//
+// Reuse contract (unchanged by design): list / create / rename / delete / restore all go through
+// the shared REST layer in ./api.ts — the shell adds NO new endpoint. Preview alone is pluggable
+// because each end decodes a different payload (PM-JSON doc / sheet cells / board scene).
+//
+// i18n: this shell reuses the existing `docs.version.*` message keys. A handful of new keys it
+// references — filterAll / filterManual / filterAuto, countManual / countAuto, and staleNotice —
+// are intentionally NOT added in this phase: the acceptance gate keeps this phase's diff to new
+// files + tests only, and the shell is not mounted anywhere yet, so no user ever sees a raw key.
+// Those keys land in the doc-adapter phase, when an end first renders the shell.
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import type { Role } from '../auth/roles.ts'
+import { canSnapshot, canRestoreVersion } from '../auth/roles.ts'
+import { t } from '../octoweb/index.ts'
+import { formatRelative, formatAbsolute, autosaveLabel } from './format.ts'
+import {
+  listVersions,
+  createNamedVersion,
+  restoreVersion,
+  renameVersion,
+  deleteVersion,
+  VersionSchemaIncompatibleError,
+  VersionSchemaNewerError,
+  type VersionMeta,
+  type VersionCounts,
+} from './api.ts'
+import { createRaceGuard } from './raceGuard.ts'
+
+export type KindFilter = 'all' | 'manual' | 'auto'
+
+/** Default page size when a host does not override it (doc 25 / board 30 / sheet 50 → unify at 30). */
+const DEFAULT_PAGE_SIZE = 30
+
+export interface VersionHistoryPanelProps<TState, TCurrent> {
+  docId: string
+  role: Role
+  /** uid → display-name map so a row's author shows a name, not a raw uid. */
+  names?: Map<string, string>
+  onClose?: () => void
+
+  // —— list data source (always the shared listVersions; knobs only) ——
+  pageSize?: number
+  defaultFilter?: KindFilter
+
+  // —— change hooks (all mutations reuse ./api.ts; these only tune error text / post-effects) ——
+  /** Called after a successful restore (board refreshes chrome; doc/sheet may omit). */
+  onRestored?: () => void
+  /** Map a preview error to an i18n key (board passes versionErrorKey; default handles schema/network). */
+  previewErrorKey?: (e: unknown) => string
+  /** Map a restore error to an i18n key (same default; board passes its richer classifier). */
+  restoreErrorKey?: (e: unknown) => string
+
+  // —— preview / diff (the pluggable core) ——
+  /** Load one version's decoded state for preview/diff. MUST honor the AbortSignal. */
+  loadPreviewState: (seq: number, signal: AbortSignal) => Promise<TState>
+  /** Render the read-only preview of a loaded state (throwaway editor / grid / scene). */
+  renderPreview: (state: TState) => ReactNode
+  /** Render the diff of a version against current. Omit → the modal hides the "compare" entry. */
+  renderDiff?: (state: TState, current: TCurrent | null) => ReactNode
+  /** The "current" side of a diff (live editor JSON / sheet cells). Omit when there is no diff. */
+  getCurrent?: () => TCurrent | null
+}
+
+/** Preview modal state machine — end-agnostic (the payload itself is TState, held separately). */
+type PreviewState = 'idle' | 'loading' | 'ready' | 'error'
+
+/** Default error → i18n key mapping when a host does not inject its own classifier. */
+function defaultErrorKey(e: unknown): string {
+  if (e instanceof VersionSchemaNewerError) return 'docs.version.previewSchemaNewer'
+  if (e instanceof VersionSchemaIncompatibleError) return 'docs.version.previewSchemaIncompatible'
+  return 'docs.version.previewNetworkError'
+}
+
+function kindBadge(v: VersionMeta): string {
+  if (v.kind === 'named') return t('docs.version.badgeNamed')
+  if (v.kind === 'restore-marker') {
+    return v.restoredFrom != null
+      ? t('docs.version.badgeRestoredFrom', { values: { from: v.restoredFrom } })
+      : t('docs.version.badgeRestored')
+  }
+  return t('docs.version.badgeAuto')
+}
+
+function displayLabel(v: VersionMeta): string {
+  if (v.label && v.label.trim() !== '') return v.label
+  if (v.kind === 'restore-marker') {
+    return v.restoredFrom != null
+      ? t('docs.version.labelRestoredFrom', { values: { from: v.restoredFrom } })
+      : t('docs.version.labelRestored')
+  }
+  return autosaveLabel(v.createdAt)
+}
+
+export function VersionHistoryPanel<TState, TCurrent>({
+  docId,
+  role,
+  names,
+  onClose,
+  pageSize = DEFAULT_PAGE_SIZE,
+  defaultFilter = 'all',
+  onRestored,
+  previewErrorKey,
+  restoreErrorKey,
+  loadPreviewState,
+  renderPreview,
+  renderDiff,
+  getCurrent,
+}: VersionHistoryPanelProps<TState, TCurrent>) {
+  const [items, setItems] = useState<VersionMeta[]>([])
+  const [counts, setCounts] = useState<VersionCounts | null>(null)
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [filter, setFilter] = useState<KindFilter>(defaultFilter)
+  const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  // Inline "save current version" compose row (no native prompt — unified across ends).
+  const [snapshotOpen, setSnapshotOpen] = useState(false)
+  const [snapshotLabel, setSnapshotLabel] = useState('')
+
+  // Inline rename compose row (replaces the sheet panel's native window.prompt).
+  const [renamingSeq, setRenamingSeq] = useState<number | null>(null)
+  const [renameLabel, setRenameLabel] = useState('')
+
+  // Restore is confirmed in a centered in-panel box (doc model), not a native window.confirm.
+  const [confirmRestore, setConfirmRestore] = useState<VersionMeta | null>(null)
+
+  // Centered preview / diff modal.
+  const [selected, setSelected] = useState<VersionMeta | null>(null)
+  const [previewData, setPreviewData] = useState<TState | null>(null)
+  const [previewState, setPreviewState] = useState<PreviewState>('idle')
+  const [previewErr, setPreviewErr] = useState<string>('docs.version.previewNetworkError')
+  const [compare, setCompare] = useState(false)
+
+  // One guard for the list (refresh = primary, load-more = follow-up) and an independent one for
+  // preview — both from the shared createRaceGuard so all three chains abort + last-write-win.
+  const listGuard = useRef(createRaceGuard())
+  const previewGuard = useRef(createRaceGuard())
+
+  const mySnapshot = canSnapshot(role)
+  const myRestore = canRestoreVersion(role)
+  const nameOf = (uid: string) => names?.get(uid) || uid
+  // Compare is only offered when the host can both diff and supply "current".
+  const canCompare = !!(renderDiff && getCurrent)
+
+  // Reload the first page for the current filter. `soft` suppresses the red load error for the
+  // post-mutation case (the mutation itself already succeeded; a refresh miss only means the list
+  // may be stale). Returns whether the fresh list was applied.
+  const refresh = useCallback(
+    async (opts?: { soft?: boolean }): Promise<boolean> => {
+      const { signal, isCurrent } = listGuard.current.begin()
+      setLoading(true)
+      setError(null)
+      setNotice(null)
+      try {
+        const res = await listVersions(docId, { kind: filter, limit: pageSize, signal })
+        if (!isCurrent()) return false
+        setItems(res.items)
+        setNextCursor(res.nextCursor)
+        setCounts(res.counts ?? null)
+        return true
+      } catch {
+        if (!isCurrent()) return false
+        if (!opts?.soft) setError(t('docs.version.errorList'))
+        return false
+      } finally {
+        if (isCurrent()) setLoading(false)
+      }
+    },
+    [docId, filter, pageSize],
+  )
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Abort any in-flight request when the panel unmounts.
+  useEffect(() => {
+    const list = listGuard.current
+    const preview = previewGuard.current
+    return () => {
+      list.abort()
+      preview.abort()
+    }
+  }, [])
+
+  const onLoadMore = async () => {
+    if (loadingMore || nextCursor == null) return
+    const { signal, isCurrent } = listGuard.current.beginFollowUp()
+    setLoadingMore(true)
+    setError(null)
+    try {
+      const res = await listVersions(docId, { kind: filter, cursor: nextCursor, limit: pageSize, signal })
+      // Bound to the list generation: if a refresh / filter switch / restore replaced the list
+      // before this page landed, drop it rather than append onto a list that no longer exists.
+      if (!isCurrent()) return
+      setItems((cur) => [...cur, ...res.items])
+      setNextCursor(res.nextCursor)
+      if (res.counts) setCounts(res.counts)
+    } catch {
+      if (!isCurrent()) return
+      setError(t('docs.version.errorMore'))
+    } finally {
+      if (isCurrent()) setLoadingMore(false)
+    }
+  }
+
+  const selectFilter = (k: KindFilter) => {
+    if (k === filter) return
+    // Switching filter reloads the list; drop the open preview (it belongs to the previous set).
+    closePreview()
+    setFilter(k)
+  }
+
+  const onCreateSnapshot = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await createNamedVersion(docId, snapshotLabel.trim() || undefined)
+    } catch {
+      setError(t('docs.version.errorSave'))
+      setBusy(false)
+      return
+    }
+    setSnapshotOpen(false)
+    setSnapshotLabel('')
+    const ok = await refresh({ soft: true })
+    if (!ok) setNotice(t('docs.version.staleNotice'))
+    setBusy(false)
+  }
+
+  const beginRename = (seq: number, cur: string) => {
+    setRenamingSeq(seq)
+    setRenameLabel(cur)
+  }
+
+  const cancelRename = () => {
+    setRenamingSeq(null)
+    setRenameLabel('')
+  }
+
+  const commitRename = async (seq: number) => {
+    const label = renameLabel.trim()
+    if (label === '') return
+    setBusy(true)
+    setError(null)
+    try {
+      await renameVersion(docId, seq, label)
+    } catch {
+      setError(t('docs.version.errorRename'))
+      setBusy(false)
+      return
+    }
+    // Optimistic label update, then reconcile with server ordering/counts (soft: rename landed).
+    setItems((cur) => cur.map((v) => (v.docVersionSeq === seq ? { ...v, label } : v)))
+    cancelRename()
+    const ok = await refresh({ soft: true })
+    if (!ok) setNotice(t('docs.version.staleNotice'))
+    setBusy(false)
+  }
+
+  const onDelete = async (v: VersionMeta) => {
+    if (!window.confirm(t('docs.version.deleteConfirm', { values: { seq: v.docVersionSeq } }))) return
+    setBusy(true)
+    setError(null)
+    try {
+      await deleteVersion(docId, v.docVersionSeq)
+    } catch {
+      setError(t('docs.version.errorDelete'))
+      setBusy(false)
+      return
+    }
+    if (selected?.docVersionSeq === v.docVersionSeq) closePreview()
+    if (renamingSeq === v.docVersionSeq) cancelRename()
+    setItems((cur) => cur.filter((x) => x.docVersionSeq !== v.docVersionSeq))
+    const ok = await refresh({ soft: true })
+    if (!ok) setNotice(t('docs.version.staleNotice'))
+    setBusy(false)
+  }
+
+  const onConfirmRestore = async (v: VersionMeta) => {
+    setBusy(true)
+    setError(null)
+    setNotice(null)
+    let res: { newDocVersionSeq: number; restoredFrom: number }
+    try {
+      res = await restoreVersion(docId, v.docVersionSeq)
+    } catch (e) {
+      setError(t(restoreErrorKey ? restoreErrorKey(e) : 'docs.version.errorRestore'))
+      setConfirmRestore(null)
+      setBusy(false)
+      return
+    }
+    // Restore landed — the live surface reconciles via Yjs. A follow-up refresh miss is soft.
+    setConfirmRestore(null)
+    closePreview()
+    const ok = await refresh({ soft: true })
+    setNotice(
+      ok
+        ? t('docs.version.restoredNotice', { values: { from: res.restoredFrom, seq: res.newDocVersionSeq } })
+        : t('docs.version.staleNotice'),
+    )
+    onRestored?.()
+    setBusy(false)
+  }
+
+  const onPreview = async (v: VersionMeta) => {
+    const { signal, isCurrent } = previewGuard.current.begin()
+    setSelected(v)
+    setCompare(false)
+    setPreviewState('loading')
+    setPreviewData(null)
+    setError(null)
+    setNotice(null)
+    try {
+      const state = await loadPreviewState(v.docVersionSeq, signal)
+      if (!isCurrent()) return // superseded by a newer preview
+      setPreviewData(state)
+      setPreviewState('ready')
+    } catch (e) {
+      if (!isCurrent()) return // superseded; swallow the stale error
+      setPreviewErr(previewErrorKey ? previewErrorKey(e) : defaultErrorKey(e))
+      setPreviewState('error')
+    }
+  }
+
+  const closePreview = useCallback(() => {
+    // Abort an in-flight preview so a late response can't reopen the modal after close.
+    previewGuard.current.begin()
+    setSelected(null)
+    setPreviewData(null)
+    setPreviewState('idle')
+    setCompare(false)
+  }, [])
+
+  // Escape closes the preview modal (mirrors the doc panel / manage-members convention).
+  useEffect(() => {
+    if (!selected) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closePreview()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [selected, closePreview])
+
+  const filterBtn = (k: KindFilter, label: string) => (
+    <button
+      type="button"
+      className={filter === k ? 'octo-tb-btn is-active' : 'octo-tb-btn'}
+      aria-pressed={filter === k}
+      disabled={loading || loadingMore}
+      onClick={() => selectFilter(k)}
+    >
+      {label}
+    </button>
+  )
+
+  function renderRow(v: VersionMeta) {
+    const isSelected = selected?.docVersionSeq === v.docVersionSeq
+    const renameable = mySnapshot && v.kind === 'named'
+    const isRenaming = renamingSeq === v.docVersionSeq
+    return (
+      <li
+        key={v.docVersionSeq}
+        className={`octo-version-row octo-version-row-${v.kind}${isSelected ? ' is-selected' : ''}`}
+      >
+        <div className="octo-version-line1">
+          <span className={`octo-version-badge octo-version-badge-${v.kind}`}>{kindBadge(v)}</span>
+          {isRenaming ? (
+            <input
+              className="octo-uid"
+              value={renameLabel}
+              placeholder={t('docs.version.labelPlaceholder')}
+              onChange={(e) => setRenameLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void commitRename(v.docVersionSeq)
+                else if (e.key === 'Escape') cancelRename()
+              }}
+              autoFocus
+            />
+          ) : (
+            <span className="octo-version-label">{displayLabel(v)}</span>
+          )}
+          <span className="octo-version-time" title={formatAbsolute(v.createdAt)}>
+            {formatRelative(v.createdAt)}
+          </span>
+        </div>
+        <div className="octo-version-line2">
+          <span className="octo-version-author">{nameOf(v.createdBy)}</span>
+          <div className="octo-version-actions">
+            {isRenaming ? (
+              <>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy || renameLabel.trim() === ''}
+                  onClick={() => void commitRename(v.docVersionSeq)}
+                >
+                  {t('docs.version.save')}
+                </button>
+                <button type="button" className="octo-tb-btn" disabled={busy} onClick={cancelRename}>
+                  {t('docs.version.cancel')}
+                </button>
+              </>
+            ) : (
+              <>
+                <button type="button" className="octo-tb-btn" onClick={() => void onPreview(v)}>
+                  {t('docs.version.preview')}
+                </button>
+                {renameable && (
+                  <button
+                    type="button"
+                    className="octo-tb-btn"
+                    disabled={busy}
+                    onClick={() => beginRename(v.docVersionSeq, v.label)}
+                  >
+                    {t('docs.version.rename')}
+                  </button>
+                )}
+                {myRestore && (
+                  <button
+                    type="button"
+                    className="octo-tb-btn"
+                    disabled={busy}
+                    onClick={() => setConfirmRestore(v)}
+                  >
+                    {t('docs.version.restore')}
+                  </button>
+                )}
+                {myRestore && (
+                  <button
+                    type="button"
+                    className="octo-tb-btn"
+                    disabled={busy}
+                    onClick={() => void onDelete(v)}
+                  >
+                    {t('docs.version.delete')}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </li>
+    )
+  }
+
+  const currentForDiff = compare && getCurrent ? getCurrent() : null
+
+  return (
+    <>
+      <section className="octo-version-panel octo-version-history-panel">
+        <div className="octo-member-row">
+          <h3 style={{ flex: 1, margin: 0 }}>{t('docs.version.title')}</h3>
+          {onClose && (
+            <button type="button" className="octo-tb-btn" onClick={onClose}>
+              {t('docs.version.close')}
+            </button>
+          )}
+        </div>
+
+        <div className="octo-member-row octo-version-filters">
+          {filterBtn('all', t('docs.version.filterAll'))}
+          {filterBtn('manual', t('docs.version.filterManual'))}
+          {filterBtn('auto', t('docs.version.filterAuto'))}
+          {counts && (
+            <span className="octo-version-counts" style={{ marginLeft: 'auto', fontSize: 12, opacity: 0.7 }}>
+              {t('docs.version.countManual')} {counts.manual + counts.restore} · {t('docs.version.countAuto')} {counts.auto}
+            </span>
+          )}
+        </div>
+
+        {mySnapshot && (
+          <div className="octo-version-save">
+            {snapshotOpen ? (
+              <div className="octo-member-row">
+                <input
+                  className="octo-uid"
+                  placeholder={t('docs.version.labelPlaceholder')}
+                  value={snapshotLabel}
+                  onChange={(e) => setSnapshotLabel(e.target.value)}
+                  autoFocus
+                />
+                <button type="button" className="octo-tb-btn" disabled={busy} onClick={() => void onCreateSnapshot()}>
+                  {t('docs.version.save')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => {
+                    setSnapshotOpen(false)
+                    setSnapshotLabel('')
+                  }}
+                >
+                  {t('docs.version.cancel')}
+                </button>
+              </div>
+            ) : (
+              <button type="button" className="octo-tb-btn" disabled={busy} onClick={() => setSnapshotOpen(true)}>
+                {t('docs.version.saveCurrent')}
+              </button>
+            )}
+          </div>
+        )}
+
+        {notice && <p className="octo-version-notice">{notice}</p>}
+        {error && <p className="octo-member-error">{error}</p>}
+
+        {loading && items.length === 0 && <p className="octo-loading">{t('docs.version.loadingList')}</p>}
+        {!loading && items.length === 0 && <p className="octo-version-empty">{t('docs.version.empty')}</p>}
+
+        <ul className="octo-version-list">{items.map(renderRow)}</ul>
+
+        {nextCursor != null && (
+          <div className="octo-member-row" style={{ justifyContent: 'center' }}>
+            <button type="button" className="octo-tb-btn" disabled={loading || loadingMore} onClick={() => void onLoadMore()}>
+              {t('docs.version.loadMore')}
+            </button>
+          </div>
+        )}
+
+        {confirmRestore && (
+          <div className="octo-version-confirm">
+            <p>{t('docs.version.confirmTitle', { values: { seq: confirmRestore.docVersionSeq } })}</p>
+            <p className="octo-version-confirm-detail">{t('docs.version.confirmDetail')}</p>
+            <div className="octo-member-row">
+              <button
+                type="button"
+                className="octo-tb-btn"
+                disabled={busy}
+                onClick={() => void onConfirmRestore(confirmRestore)}
+              >
+                {t('docs.version.restore')}
+              </button>
+              <button
+                type="button"
+                className="octo-tb-btn"
+                disabled={busy}
+                onClick={() => setConfirmRestore(null)}
+              >
+                {t('docs.version.cancel')}
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {selected && (
+        <div className="octo-modal-overlay" role="presentation" onMouseDown={closePreview}>
+          <div
+            className="octo-modal docs-version-preview-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label={compare ? t('docs.version.compareTitle') : t('docs.version.previewTitle')}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="octo-member-row">
+              <h4 style={{ flex: 1, margin: 0 }}>
+                {compare ? t('docs.version.compareTitle') : t('docs.version.previewTitle')} — #{selected.docVersionSeq}
+              </h4>
+              {canCompare && (
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={previewState !== 'ready'}
+                  onClick={() => setCompare((c) => !c)}
+                >
+                  {compare ? t('docs.version.showPreview') : t('docs.version.compare')}
+                </button>
+              )}
+              <button type="button" className="octo-tb-btn" onClick={closePreview}>
+                {t('docs.version.close')}
+              </button>
+            </div>
+
+            <div className="docs-version-preview-modal-body">
+              {previewState === 'loading' && <p className="octo-loading">{t('docs.version.loadingPreview')}</p>}
+              {previewState === 'error' && (
+                <div className="octo-version-preview-error">
+                  <p className="octo-member-error">{t(previewErr)}</p>
+                  <button type="button" className="octo-tb-btn" onClick={() => selected && void onPreview(selected)}>
+                    {t('docs.version.previewRetry')}
+                  </button>
+                </div>
+              )}
+              {previewState === 'ready' && previewData != null && !compare && renderPreview(previewData)}
+              {previewState === 'ready' && previewData != null && compare && renderDiff && renderDiff(previewData, currentForDiff)}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/docs/src/versions/raceGuard.test.ts
+++ b/packages/docs/src/versions/raceGuard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { createRaceGuard } from './raceGuard.ts'
+
+// XIN-836 技术统一项②: the unified race guard must (1) truly abort the superseded in-flight
+// request and (2) discard any response that resolves after a newer request started. These are the
+// two properties the doc panel's token-only previewGuard lacked; assert both directly.
+
+describe('createRaceGuard — primary lane (refresh / preview)', () => {
+  it('marks only the latest ticket current and invalidates the previous one', () => {
+    const guard = createRaceGuard()
+    const first = guard.begin()
+    expect(first.isCurrent()).toBe(true)
+
+    const second = guard.begin()
+    // The newer request wins last-write-wins; the earlier one is stale.
+    expect(second.isCurrent()).toBe(true)
+    expect(first.isCurrent()).toBe(false)
+  })
+
+  it('aborts the previous in-flight request on the wire when a new one begins', () => {
+    const guard = createRaceGuard()
+    const first = guard.begin()
+    expect(first.signal.aborted).toBe(false)
+    guard.begin()
+    // Not merely ignored on arrival — the earlier fetch is cancelled.
+    expect(first.signal.aborted).toBe(true)
+  })
+})
+
+describe('createRaceGuard — follow-up lane (load-more)', () => {
+  it('binds a follow-up to the current generation without bumping it', () => {
+    const guard = createRaceGuard()
+    guard.begin()
+    const page = guard.beginFollowUp()
+    // A page that resolves while its list is still current is applied.
+    expect(page.isCurrent()).toBe(true)
+  })
+
+  it('drops a follow-up whose list was replaced by a newer primary before it landed', () => {
+    const guard = createRaceGuard()
+    guard.begin()
+    const page = guard.beginFollowUp()
+    // A filter switch / restore / delete fires a fresh primary before the page returns.
+    guard.begin()
+    expect(page.isCurrent()).toBe(false)
+    // …and the in-flight page is aborted, not left running.
+    expect(page.signal.aborted).toBe(true)
+  })
+
+  it('aborts a prior follow-up when a newer follow-up starts', () => {
+    const guard = createRaceGuard()
+    guard.begin()
+    const firstPage = guard.beginFollowUp()
+    const secondPage = guard.beginFollowUp()
+    expect(firstPage.signal.aborted).toBe(true)
+    // Both belong to the current generation, so the newest page still applies.
+    expect(secondPage.isCurrent()).toBe(true)
+  })
+})
+
+describe('createRaceGuard — abort() cleanup', () => {
+  it('aborts every in-flight request and invalidates outstanding tickets', () => {
+    const guard = createRaceGuard()
+    const primary = guard.begin()
+    const page = guard.beginFollowUp()
+    guard.abort()
+    expect(primary.signal.aborted).toBe(true)
+    expect(page.signal.aborted).toBe(true)
+    expect(primary.isCurrent()).toBe(false)
+    expect(page.isCurrent()).toBe(false)
+  })
+})

--- a/packages/docs/src/versions/raceGuard.test.ts
+++ b/packages/docs/src/versions/raceGuard.test.ts
@@ -47,12 +47,16 @@ describe('createRaceGuard — follow-up lane (load-more)', () => {
     expect(page.signal.aborted).toBe(true)
   })
 
-  it('aborts a prior follow-up when a newer follow-up starts', () => {
+  it('aborts a prior follow-up AND makes its ticket stale when a newer follow-up starts', () => {
     const guard = createRaceGuard()
     guard.begin()
     const firstPage = guard.beginFollowUp()
     const secondPage = guard.beginFollowUp()
     expect(firstPage.signal.aborted).toBe(true)
+    // Regression (PM CHANGES_REQUESTED / Jerry-Xin): the superseded follow-up must NOT report
+    // itself current — otherwise a load-more whose request resolved just before it was aborted
+    // would still pass the isCurrent() gate and append stale / duplicate rows.
+    expect(firstPage.isCurrent()).toBe(false)
     // Both belong to the current generation, so the newest page still applies.
     expect(secondPage.isCurrent()).toBe(true)
   })

--- a/packages/docs/src/versions/raceGuard.ts
+++ b/packages/docs/src/versions/raceGuard.ts
@@ -14,12 +14,20 @@
 //
 // A guard has a PRIMARY lane (refresh / filter switch / preview) and a subordinate FOLLOW-UP
 // lane (load-more):
-//   - begin() bumps the generation and aborts EVERYTHING in the guard (primary + any follow-up),
-//     then hands back a ticket bound to the new generation.
-//   - beginFollowUp() starts a request bound to the CURRENT generation with its own abort
-//     controller (aborting only a prior follow-up). It does NOT bump the generation, so a later
-//     begin() supersedes it: a page that resolves after a filter switch / restore / delete
-//     replaced the list is dropped rather than appended onto a list that no longer exists.
+//   - begin() bumps the PRIMARY generation and aborts EVERYTHING in the guard (primary + any
+//     follow-up), then hands back a primary ticket bound to the new generation.
+//   - beginFollowUp() bumps a SEPARATE follow-up token and aborts only a prior follow-up. Its
+//     ticket is current only while BOTH the primary generation is unchanged AND it is still the
+//     latest follow-up, so:
+//       * a later begin() (filter switch / restore / delete) supersedes it — the page is dropped
+//         rather than appended onto a list that no longer exists; and
+//       * a later beginFollowUp() (a second rapid load-more) also supersedes it — the earlier
+//         page, even if its request resolved a hair before being aborted, is dropped rather than
+//         appended as stale / duplicate rows. (A shared generation alone could not express this:
+//         two follow-ups share the primary generation, so the aborted first ticket would wrongly
+//         still report itself current — the bug this lane token fixes.)
+//   The primary lane is NOT affected by follow-ups: a load-more never invalidates an in-flight
+//   refresh/preview ticket.
 //
 // A panel typically holds one guard for the list (refresh = primary, load-more = follow-up) and a
 // second, independent guard for preview (primary only — it never calls beginFollowUp).
@@ -52,13 +60,22 @@ export interface RaceGuard {
 
 /** Create a fresh race guard (one per lane, held in a useRef for the component's lifetime). */
 export function createRaceGuard(): RaceGuard {
+  // Primary generation (refresh / preview). Follow-ups also observe it so a new primary drops them.
   let generation = 0
+  // Separate follow-up token: distinguishes rapid successive load-mores that share `generation`.
+  let followToken = 0
   let primary: AbortController | null = null
   let followUp: AbortController | null = null
 
-  const ticketFor = (gen: number, controller: AbortController): GuardTicket => ({
+  const primaryTicket = (gen: number, controller: AbortController): GuardTicket => ({
     signal: controller.signal,
     isCurrent: () => gen === generation,
+  })
+
+  const followTicket = (gen: number, token: number, controller: AbortController): GuardTicket => ({
+    signal: controller.signal,
+    // Current only if neither a newer primary NOR a newer follow-up has superseded this one.
+    isCurrent: () => gen === generation && token === followToken,
   })
 
   return {
@@ -70,23 +87,29 @@ export function createRaceGuard(): RaceGuard {
       const controller = new AbortController()
       primary = controller
       const gen = ++generation
-      return ticketFor(gen, controller)
+      // Invalidate any outstanding follow-up ticket bound to the previous list.
+      followToken++
+      return primaryTicket(gen, controller)
     },
     beginFollowUp() {
-      // Cancel a prior page but keep the current generation: this page belongs to the list the
-      // most recent begin() produced, and a later begin() must be able to invalidate it.
+      // Cancel a prior page and advance the follow-up token so its ticket goes stale — being
+      // aborted alone does not flip isCurrent(), so a page that resolved just before the abort
+      // must be excluded by the token, not merely by the signal. Keeps the primary generation so a
+      // later begin() can still invalidate this page.
       followUp?.abort()
       const controller = new AbortController()
       followUp = controller
-      return ticketFor(generation, controller)
+      const token = ++followToken
+      return followTicket(generation, token, controller)
     },
     abort() {
       primary?.abort()
       followUp?.abort()
       primary = null
       followUp = null
-      // Bump so any outstanding ticket's isCurrent() flips to false even without a fresh begin().
+      // Bump both so any outstanding ticket's isCurrent() flips to false even without a fresh begin().
       generation++
+      followToken++
     },
   }
 }

--- a/packages/docs/src/versions/raceGuard.ts
+++ b/packages/docs/src/versions/raceGuard.ts
@@ -1,0 +1,92 @@
+// Unified async race guard for the version-history panels (XIN-836 技术统一项②).
+//
+// This consolidates the board panel's "AbortController + monotonic generation" pattern into a
+// single reusable primitive so every end's version panel guards its list-refresh / load-more /
+// preview chains identically. It supersedes the doc panel's `previewGuard` (last-write-wins
+// TOKEN only, never aborts the in-flight request) — that guard is a strict subset of this one.
+//
+// Two guarantees matter, and both are enforced here:
+//   1. In-flight requests are TRULY aborted (AbortController), not merely ignored on arrival, so
+//      switching filters fast, or previewing #A then #B, cancels the wasted request on the wire.
+//   2. A response that resolves AFTER a newer request started is discarded (monotonic
+//      generation), so a slow earlier call can never overwrite a newer selection — the stale
+//      "#A body under a Preview #B header" bug that sits right next to the restore red line.
+//
+// A guard has a PRIMARY lane (refresh / filter switch / preview) and a subordinate FOLLOW-UP
+// lane (load-more):
+//   - begin() bumps the generation and aborts EVERYTHING in the guard (primary + any follow-up),
+//     then hands back a ticket bound to the new generation.
+//   - beginFollowUp() starts a request bound to the CURRENT generation with its own abort
+//     controller (aborting only a prior follow-up). It does NOT bump the generation, so a later
+//     begin() supersedes it: a page that resolves after a filter switch / restore / delete
+//     replaced the list is dropped rather than appended onto a list that no longer exists.
+//
+// A panel typically holds one guard for the list (refresh = primary, load-more = follow-up) and a
+// second, independent guard for preview (primary only — it never calls beginFollowUp).
+
+/** A single guarded request's handle. */
+export interface GuardTicket {
+  /**
+   * Pass this to the underlying fetch (`{ signal }`) so a superseding request aborts this one on
+   * the wire. Reading it is always safe even after the request is superseded.
+   */
+  readonly signal: AbortSignal
+  /**
+   * True only while this ticket is still the guard's latest generation. Call it after EVERY await
+   * — both when the request resolves AND in the catch — and bail out when it returns false, so a
+   * stale response (or a stale error) never touches state.
+   */
+  isCurrent(): boolean
+}
+
+export interface RaceGuard {
+  /** Start a new primary request (refresh / filter switch / preview). Aborts all in-flight work in
+   *  this guard and bumps the generation. */
+  begin(): GuardTicket
+  /** Start a follow-up request (load-more) bound to the current generation. Aborts only a prior
+   *  follow-up; does not bump the generation, so a later begin() supersedes it. */
+  beginFollowUp(): GuardTicket
+  /** Abort every in-flight request and invalidate all outstanding tickets (unmount cleanup). */
+  abort(): void
+}
+
+/** Create a fresh race guard (one per lane, held in a useRef for the component's lifetime). */
+export function createRaceGuard(): RaceGuard {
+  let generation = 0
+  let primary: AbortController | null = null
+  let followUp: AbortController | null = null
+
+  const ticketFor = (gen: number, controller: AbortController): GuardTicket => ({
+    signal: controller.signal,
+    isCurrent: () => gen === generation,
+  })
+
+  return {
+    begin() {
+      // A new primary supersedes both the prior primary and any subordinate page in flight.
+      primary?.abort()
+      followUp?.abort()
+      followUp = null
+      const controller = new AbortController()
+      primary = controller
+      const gen = ++generation
+      return ticketFor(gen, controller)
+    },
+    beginFollowUp() {
+      // Cancel a prior page but keep the current generation: this page belongs to the list the
+      // most recent begin() produced, and a later begin() must be able to invalidate it.
+      followUp?.abort()
+      const controller = new AbortController()
+      followUp = controller
+      return ticketFor(generation, controller)
+    },
+    abort() {
+      primary?.abort()
+      followUp?.abort()
+      primary = null
+      followUp = null
+      // Bump so any outstanding ticket's isCurrent() flips to false even without a fresh begin().
+      generation++
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the version-history & preview unification (design in XIN-836, approved). This adds the shared shell and its race-guard primitive **only** — no end (doc / sheet / board) is wired to it yet, so there is **no user-visible change**. The doc/sheet/board panels are untouched and keep working exactly as before; adapter phases follow separately and can each be reverted independently. `versions/api.ts` and `versions/format.ts` are unchanged; the doc `previewGuard` is intentionally kept this phase (its removal is deferred to the doc-adapter phase).

**Diff is purely additive: 4 new files (2 source + 2 test), zero modified files.**

### What's added

- **`versions/VersionHistoryPanel.tsx`** — a generic `<VersionHistoryPanel<TState, TCurrent>>` that owns everything identical across the three ends:
  - single mixed list, reverse-chronological, with `all / manual / auto` filter tabs (board `filterBtn` pattern), a per-kind counts header (`manual+restore · auto`), and cursor-paginated load-more;
  - inline save-current and inline rename compose rows (collapsed button → input + save/cancel; no native `prompt`);
  - restore: row action → **centered in-panel confirm box** → `restoreVersion` (reuses `versions/api.ts`, no new endpoint) → non-destructive reconcile, live surface refreshes via Yjs;
  - centered preview / diff modal reusing the doc `octo-modal-overlay` (overlay-close, `stopPropagation`, Escape, `aria-modal`).
  - Props contract (per XIN-836 / PM spec): `docId`, `role`, `names?`, `onClose?`, `pageSize?` (default 30), `defaultFilter?` (default `all`), `onRestored?`, `previewErrorKey?`, `restoreErrorKey?`, `loadPreviewState(seq, signal)`, `renderPreview(state)`, `renderDiff?(state, current)`, `getCurrent?()`. When `renderDiff` is omitted the modal hides the compare entry.
  - Permissions gate internally on `canSnapshot(role)` (save/rename) and `canRestoreVersion(role)` (restore/delete).

- **`versions/raceGuard.ts`** — a reusable `createRaceGuard()` (AbortController + monotonic generation) consolidating the board panel's pattern into one primitive covering the list-refresh / load-more / preview chains: superseded in-flight requests are **truly aborted on the wire**, and a response that resolves after a newer request started is **discarded**. Strict superset of the doc panel's token-only preview guard (`begin` = primary lane; `beginFollowUp` = load-more bound to the current generation).

### i18n (deferred by design)

The shell references a few keys not yet in the `docs.version.*` namespace (`filterAll/filterManual/filterAuto`, `countManual/countAuto`, `staleNotice`). They are **intentionally not added in this phase** to keep the diff to new files + tests only; the shell is not mounted anywhere yet, so no user sees a raw key. These keys land in the doc-adapter phase when an end first renders the shell. (Noted in the file header.)

### Tests (red → green gate)

- `raceGuard.test.ts` — abort-on-supersede + last-write-wins for the primary and follow-up lanes, and `abort()` cleanup.
- `VersionHistoryPanel.test.tsx` — list / filter / counts / load-more, centered preview modal (open, Escape, overlay-close, `stopPropagation`), compare-toggle gating (shown only when `renderDiff` + `getCurrent` present, hidden otherwise), inline rename (no native prompt), in-panel restore confirm + `onRestored`, role gating (reader / writer / admin), and the stale-preview race.

The new race assertions were first proven **red** against a deliberately neutered guard (generation check + abort removed), then **green** after restoring the real implementation.

```
vitest run src/versions        →  8 files, 83 passed (was 6 files pre-change)
vitest run src/versions src/board →  157 passed (no regressions)
tsc --noEmit                   →  no new errors in versions/*
```

Related: XIN-837 (this phase), XIN-836 (design).
