### PR TITLE
feat(conversation): 1v1 未读会话享有与群聊@我同等的高优先级深红提示

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -292,6 +292,71 @@ describe("ConversationList unread indicators", () => {
     ).toBe("5");
   });
 
+  it("renders the 1v1 unread-priority marker for an unread DM without mention", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[makeConversation({ unread: 2 })] as any}
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+    // 1v1 未读→独立的 unreadPriorityMarker（非 @我）
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.unreadPriorityMarker"
+    );
+    expect(indicators?.querySelector(".wk-conv-unread-num")?.textContent).toBe(
+      "2"
+    );
+  });
+
+  it("suppresses the 1v1 priority marker when the DM is muted", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[makeConversation({ unread: 4, mute: true })] as any}
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+    // 免打扰 1v1：不点亮深红标记，但仍显示静音未读数
+    expect(indicators?.querySelector(".wk-mention")).toBeNull();
+    expect(
+      indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
+    ).toBe("4");
+  });
+
+  it("prefers the group mention marker over the 1v1 marker when both would apply", () => {
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={
+            [makeConversation({ unread: 1, mention: true })] as any
+          }
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+    const markers = indicators?.querySelectorAll(".wk-mention");
+    // 只有一个标记，且是群聊 @我（hasMention 优先，不叠加 1v1）
+    expect(markers?.length).toBe(1);
+    expect(markers?.[0]?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
+  });
+
   it("does not render indicators when there is no unread count or mention", () => {
     act(() => {
       ReactDOM.render(

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -720,6 +720,15 @@ export default class ConversationList extends Component<
     // 不再套 .wk-conversationlist-item-thread（避免缩进 + 树形连接线视觉嵌套）。
     const avatarChannel = isThread && parentChannel ? parentChannel : conversationWrap.channel;
     const isDM = avatarChannel.channelType === ChannelTypePerson;
+    // 1v1 未读高优先级：与群聊「@我」共用同一深红视觉信号（注意力分级——「有人在等我响应」），
+    // 触发条件在 1v1 退化为「未读 > 0」。三个前提对齐 Android / iOS：
+    //  1）unread 已是 Space 过滤后的口径（见 Model.unread：Person 频道用 spaceUnread、
+    //     系统 Bot 跨 Space 清零），跨 Space 污染不会误点亮；
+    //  2）排除免打扰 1v1（effectiveMute）——不是「有人在等回复」；
+    //  3）语义与群聊 mention 区分，用独立文案 [未读]/[unread]，不复用 [@我]/[@me]。
+    // 群聊 mention（hasMention）优先，命中时不再叠加 1v1 标记。
+    const is1v1Priority =
+      isDM && !hasMention && !effectiveMute && totalUnread > 0;
     const unreadNudgeClass =
       locatingUnreadKey === conversationWrap.channel.getChannelKey()
         ? locatingUnreadPulse % 2 === 0
@@ -859,11 +868,16 @@ export default class ConversationList extends Component<
                   ? this._getTypingUI(conversationWrap)
                   : this.lastContent(conversationWrap)}
               </div>
-              {(hasMention || totalUnread > 0) && (
+              {(hasMention || is1v1Priority || totalUnread > 0) && (
                 <span className="wk-conversationlist-item-indicators">
                   {hasMention && (
                     <span className="wk-mention" aria-hidden="true">
                       {t("base.conversationList.mentionMarker")}
+                    </span>
+                  )}
+                  {is1v1Priority && (
+                    <span className="wk-mention" aria-hidden="true">
+                      {t("base.conversationList.unreadPriorityMarker")}
                     </span>
                   )}
                   {totalUnread > 0 && (

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -35,6 +35,7 @@
   "conversationList.externalGroup": "External group",
   "conversationList.justNow": "Just now",
   "conversationList.mentionMarker": "@me",
+  "conversationList.unreadPriorityMarker": "unread",
   "conversationList.minutesAgoShort": "{{count}}m",
   "conversationList.toggleThreads": "Expand or collapse threads",
   "conversationList.typing": "typing",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -35,6 +35,7 @@
   "conversationList.externalGroup": "外部群",
   "conversationList.justNow": "刚刚",
   "conversationList.mentionMarker": "@我",
+  "conversationList.unreadPriorityMarker": "未读",
   "conversationList.minutesAgoShort": "{{count}}分钟",
   "conversationList.toggleThreads": "展开或收起子区",
   "conversationList.typing": "正在输入",


### PR DESCRIPTION
## 需求

会话列表里，群聊「有人@我」会显示醒目的深红色高优先级提示（`.wk-mention` + `[@我]` 文案）。但**一对一（1v1）聊天的未读消息没有这个提示**——而 1v1 中对方发来的每条消息本质上都等价于「@我」（点对点直达，有人在等回复）。

本 PR 是 octo-server#564 三端（Web/iOS/Android）中的 **Web 端**实现，对齐已合入的 Android（octo-android#85）；iOS 现状已符合。

## 设计原则

深红提示不是群聊专属样式，它是一个**注意力分级信号**——「有人在等我响应」。在人机协同场景里，核心是帮人从消息洪流里识别出真正需要关注的信息。1v1 里「对方发消息」即等价 mention，因此**复用同一深红视觉信号（`.wk-mention` → `var(--wk-color-error)`）**，触发条件在 1v1 退化为 `unread > 0`。

但语义上 1v1 未读 ≠ 群聊被 @，所以文案用独立的 `[未读]/[unread]`（新增 `conversationList.unreadPriorityMarker`），不复用 `[@我]/[@me]`。

## 改动

`packages/dmworkbase/src/Components/ConversationList/index.tsx`，仅 normal row（1v1 实际渲染路径）：

```ts
const is1v1Priority = isDM && !hasMention && !effectiveMute && totalUnread > 0;
```

命中时在指示区渲染独立的 `.wk-mention` + `unreadPriorityMarker`。三个前提对齐 Android/iOS：

1. **走 Space 过滤后的 unread**：`conversationWrap.unread`（见 `Model.unread`）对 Person 频道已用 `spaceUnread`、对系统 Bot 跨 Space 清零、对系统消息置 0，所以跨 Space 污染的会话不会误点亮深红——等价于 Android 的 `getRenderUnreadCount()`。
2. **排除免打扰 1v1**（`effectiveMute`）——不是「有人在等回复」。mute 切换后 `onMuteWithValue` 会 `fetchChannelInfo().then(setState)` 触发整组件重渲染，`effectiveMute` 与标记同步刷新，无 Android 那种 payload 局部刷新导致标签残留的问题。
3. **群聊 mention（`hasMention`）优先**，命中时不叠加 1v1 标记。

未触碰 `CompactGroupItem`（群聊 Tab 专用，1v1 不走该路径）。

## 测试

`packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx` 新增 3 例并全绿（本文件共 7 例通过）：
- 1v1 未读（无 mention）→ 点亮独立 `unreadPriorityMarker` + 未读数；
- 免打扰 1v1 → 不点亮深红、仍显示静音未读数；
- 群 mention 与 1v1 同时成立 → 只显示群 `@我`（优先，不叠加）。

```
✓ src/Components/ConversationList/__tests__/layout.test.tsx (7 tests)
```

（说明：本地全量跑 ConversationList 目录时，`categoriesFallback.test.ts` 因 jsdom 缺 canvas/lottie-web 而加载失败，属**预存在**环境问题，已在 clean main 上复现，与本改动无关。）

## 一致性

三端共用同一深红语义 `(群聊 && 有@我reminder) || (1v1 && 非系统 && 非免打扰 && Space过滤后未读>0)` + 独立「未读」文案。Web 侧色值走既有 `.wk-mention`（`var(--wk-color-error)`），与 Android `#FF5353` 保持视觉一致。

Closes Mininglamp-OSS/octo-server#564
