### PR TITLE
fix(loop): stop batch edits silently dispatching agent runs

### DIFF
--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -1163,6 +1163,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           Toast.success(t("loop.toast.created"));
           // 只刷新子列表(非整页 reload,避免详情主体闪 loading);key-remount 已隔离跨 issue 陈旧写入。
           listChildren(issueId).then(setChildren).catch(() => {});
+          // 通知父级:新子 issue 改变了父看板的子进度/计数,不刷父会陈旧。
+          onChanged?.();
         }}
       />
     </div>

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Table, Select, Tag, Typography, Button, Toast } from "@douyinfe/semi-ui";
 import { Trash2, X } from "lucide-react";
 import { useI18n } from "@octo/base";
@@ -40,6 +40,10 @@ export default function IssueList({
   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
   const [selected, setSelected] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
+  // busy 的同步镜像:setBusy 是异步的,confirmDelete 弹窗的 onOk 闭包捕获的是渲染时的
+  // busy(可能陈旧),双击开两个弹窗/两次 onOk 会各自看到 busy=false 而重复批量写。ref
+  // 在进入 runBatch 时同步置位,结构性挡住重入(setBusy 仅驱动 UI 的 disabled)。
+  const busyRef = useRef(false);
 
   // 筛选/搜索/排序/翻页令 issues 变化后,裁掉已不可见的选中项 —— 否则批量条会对
   // 当前结果集看不到的行发批量写(改/删隐藏行)。只保留仍在可见集合里的 id。
@@ -56,11 +60,13 @@ export default function IssueList({
     onChanged();
   };
 
-  // 批量:写失败 toast+中止;成功清选择+刷新。批量不走 RunConfirm 预览(显式批操作,
-  // 与原生 web 一致);状态/指派若触发 agent run 由后端处理。
-  // busy 守卫放这里(而非逐个控件 disabled):结构性防重入,任一触发器在途都挡住重叠批量写。
+  // 批量:写失败 toast+中止;成功清选择+刷新。批量不走 RunConfirm 预览(显式批操作);
+  // 且一律带 suppress_run —— 批量改状态/指派是管理性整理,绝不能每条静默起一个 agent run
+  // (要派单请逐条走 RunConfirm 预览确认)。派单是有意的单条动作,不是批量副作用。
+  // 重入守卫用 busyRef 同步置位(见上):任一触发器在途都挡住重叠批量写,不受闭包 stale 影响。
   const runBatch = async (fn: () => Promise<unknown>) => {
-    if (busy) return;
+    if (busyRef.current) return;
+    busyRef.current = true;
     setBusy(true);
     try {
       await fn();
@@ -70,6 +76,7 @@ export default function IssueList({
     } catch (e) {
       Toast.error((e as Error).message || t("loop.toast.saveFailed"));
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
   };
@@ -171,7 +178,7 @@ export default function IssueList({
             size="small"
             disabled={busy}
             value={NO_VALUE}
-            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { status: v as IssueStatus }))}
+            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { status: v as IssueStatus, suppress_run: true }))}
             style={{ width: 130 }}
           >
             {ISSUE_STATUS_ORDER.map((s) => (
@@ -183,7 +190,7 @@ export default function IssueList({
             size="small"
             disabled={busy}
             value={NO_VALUE}
-            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { priority: v as IssuePriority }))}
+            onChange={(v) => runBatch(() => batchUpdateIssues(selected, { priority: v as IssuePriority, suppress_run: true }))}
             style={{ width: 120 }}
           >
             {PRIORITY_ORDER.map((p) => (
@@ -194,7 +201,7 @@ export default function IssueList({
             size="small"
             value={null}
             valueName={null}
-            onChange={(id, type) => runBatch(() => batchUpdateIssues(selected, { assignee_id: id, assignee_type: type }))}
+            onChange={(id, type) => runBatch(() => batchUpdateIssues(selected, { assignee_id: id, assignee_type: type, suppress_run: true }))}
           />
           <Button
             size="small"


### PR DESCRIPTION
Follow-up to #653, fixing three findings surfaced by the adversarial review and verified against the backend.

## Findings & fixes

1. **[high] Batch edits silently launched agent runs.** The batch bar called `batchUpdateIssues` without `suppress_run`, and the backend `BatchUpdateIssues` dispatches an agent run per issue unless `updates.suppress_run` is set (`issue.go` `!req.Updates.SuppressRun`). A bulk status/assignee change over N issues fired N runs with no confirmation. Batch edits are administrative bulk mutations; dispatching an agent is the deliberate *per-issue* action, which stays behind the `RunConfirm` preview. All three batch calls (`status` / `priority` / `assignee`) now pass `suppress_run: true`. The single-issue edit path (`requestStatus` / `requestAssign` → `RunConfirm`) is untouched.

2. **[medium] Sub-issue create left the parent board stale.** `onCreated` only refreshed the detail page's own child list; the parent board's child progress/counts did not update. `onCreated` now also calls `onChanged?.()`, so the parent list reloads (matching every other single-field mutation in the file).

3. **[medium] Batch-delete re-entrancy guard was ineffective.** The confirm dialog opened while `busy` was `false`, and its `onOk` closure captured the render-time `busy`; double-opening the dialog let two `onOk` callbacks both pass `if (busy) return` and call `batchDeleteIssues` twice. `runBatch` now sets a synchronous `busyRef` at entry (check-and-set with no `await` between), so a second invocation is always blocked; `busy` state still drives the UI `disabled`.

## Verification (real browser, dev — Alice / `mv2-e2e-alice`)

- **#1** — batch status change: request body is `{"updates":{"status":"in_progress","suppress_run":true}}`, response `{"updated":2}`, rows update to the new status, and `agent-task-snapshot` shows no new running task.
- **#2** — sub-issue create fires `POST /issues` → `GET /issues/:id/children` → **`GET /issues?...` (parent reload)** → `agent-task-snapshot`; before the fix the parent reload was absent.
- **#3** — batch path runs cleanly through the new `busyRef` guard; the double-fire race is a synchronous check-and-set with no await window (verified by review).

Typecheck clean (`tsc --noEmit`, dmloop package, 0 errors in package sources).

> Note: Claude adversarial review passed clean end-to-end. Codex adversarial review emitted an early `approve` but its stream dropped mid-analysis on the proxy endpoint (a known infra flake, not a finding); a clean Codex re-run is a follow-up once the endpoint is stable.

## Blast radius (Rule 8)

Real diff is **2 files** (`git diff --stat origin/feat/octo-loop...HEAD` → `IssueList.tsx`, `IssueDetailPage.tsx`); the CI/hook file count is inflated by counting against `origin/main`.

- `batchUpdateIssues` is called **only** from `IssueList.tsx` (all three call sites are in this diff). Its signature is unchanged — `suppress_run?: boolean` already exists on the shared `UpdateIssueReq` type, so no shared-type or contract change and no other consumer is affected.
- `onChanged?.()` is an existing optional prop already invoked elsewhere in `IssueDetailPage.tsx` (lines 191/477/1040); this adds one more call site. No prop/signature change; the parent `IssuePage` already routes it through `onMutated`.
- `busyRef` is component-local.

No exported/shared type, prop, hook signature, util, cross-package import, or DB/API contract changed → no out-of-module consumer impacted.
