### PR TITLE
fix(export): correct Word math, nested-table columns, and cell images

### DIFF
--- a/packages/docs/src/export/docx/images.test.ts
+++ b/packages/docs/src/export/docx/images.test.ts
@@ -186,11 +186,40 @@ describe('getImageDimensions — aspect ratio preservation', () => {
     expect(getImageDimensions(img())).toEqual({ width: 400, height: 300 })
   })
 
+  it('caps the default box to the container width when bytes are unsniffable (SVG/WebP in a narrow cell)', () => {
+    // Blocker regression: readIntrinsicSize does not parse SVG/WebP, so such an
+    // image with no explicit width has no ratio and no attrWidth. The default
+    // box must still honour the container cap instead of rendering at the full
+    // 400px default and overflowing a narrow nested cell.
+    const capped = getImageDimensions(img(), undefined, 90)
+    expect(capped.width).toBe(90)
+    // Default box aspect (4:3) preserved: 90 * 300/400 = 68 (rounded).
+    expect(capped.height).toBe(68)
+  })
+
   it('uses attr width+height ratio when buffer unreadable', () => {
     // no buffer, but both attrs present -> derive from attr ratio
     expect(getImageDimensions(img({ width: 200, height: 100 }))).toEqual({
       width: 200,
       height: 100,
     })
+  })
+
+  it('bounds width to the container cap when supplied (nested table cell)', () => {
+    // 16:9 image at 1600 wide inside a narrow (120px) nested cell -> shrink to
+    // 120 and keep the ratio, instead of the page-wide 600 cap that overflows.
+    expect(getImageDimensions(img(), pngOf(1600, 900), 120)).toEqual({ width: 120, height: 68 })
+  })
+
+  it('caps a stored width attr to the container cap too', () => {
+    // Explicit width 500 but the cell is only 90px wide -> shrink to 90.
+    const d = getImageDimensions(img({ width: 500 }), pngOf(1000, 500), 90)
+    expect(d.width).toBe(90)
+    expect(d.height).toBe(45)
+  })
+
+  it('ignores a container cap larger than the page cap (never upscales)', () => {
+    // A huge cap does not raise the 600 page cap.
+    expect(getImageDimensions(img(), pngOf(1600, 900), 5000)).toEqual({ width: 600, height: 338 })
   })
 })

--- a/packages/docs/src/export/docx/images.ts
+++ b/packages/docs/src/export/docx/images.ts
@@ -301,6 +301,7 @@ export function readIntrinsicSize(
 export function getImageDimensions(
   node: MdNode,
   buffer?: ArrayBuffer,
+  maxWidthPx?: number,
 ): { width: number; height: number } {
   const attrWidth =
     typeof node.attrs?.width === 'number' && Number.isFinite(node.attrs.width) && node.attrs.width > 0
@@ -321,19 +322,29 @@ export function getImageDimensions(
   if (intrinsic) ratio = intrinsic.height / intrinsic.width
   else if (attrWidth && attrHeight) ratio = attrHeight / attrWidth
 
+  // Effective width cap: the page-wide default, further tightened to the current
+  // container (e.g. a table cell) when a bound is supplied. Nested tables shrink
+  // the cell well below the page width, so without this an image keeps its
+  // page-scale width and overflows the cell.
+  const widthCap =
+    typeof maxWidthPx === 'number' && Number.isFinite(maxWidthPx) && maxWidthPx > 0
+      ? Math.min(MAX_IMAGE_WIDTH, maxWidthPx)
+      : MAX_IMAGE_WIDTH
+
   // Target display width: stored attr, else intrinsic, else default.
   let width = attrWidth ?? intrinsic?.width ?? DEFAULT_IMAGE.width
-  if (width > MAX_IMAGE_WIDTH) width = MAX_IMAGE_WIDTH
+  if (width > widthCap) width = widthCap
 
   // If we still have no real ratio, fall back to the legacy default box so we
   // never emit a zero/NaN dimension.
   if (!ratio || !Number.isFinite(ratio) || ratio <= 0) {
-    if (attrWidth) {
-      // Have a width but no ratio at all: keep the default box aspect.
-      const defRatio = DEFAULT_IMAGE.height / DEFAULT_IMAGE.width
-      return { width: Math.round(width), height: Math.round(width * defRatio) }
-    }
-    return { ...DEFAULT_IMAGE }
+    // Keep the default box aspect, but always honour the width cap so an image
+    // whose bytes we can't sniff (e.g. SVG/WebP, which readIntrinsicSize does
+    // not parse) and that carries no explicit width can't render at the full
+    // 400px default and overflow a narrow nested cell.
+    const defRatio = DEFAULT_IMAGE.height / DEFAULT_IMAGE.width
+    const boxWidth = attrWidth ? width : Math.min(DEFAULT_IMAGE.width, widthCap)
+    return { width: Math.round(boxWidth), height: Math.max(1, Math.round(boxWidth * defRatio)) }
   }
 
   return { width: Math.round(width), height: Math.max(1, Math.round(width * ratio)) }

--- a/packages/docs/src/export/docx/math.test.ts
+++ b/packages/docs/src/export/docx/math.test.ts
@@ -195,4 +195,140 @@ describe('inline math end-to-end docx export', () => {
     expect(xml).not.toContain('\\int')
     expect(xml).not.toContain('\\,')
   })
+
+  it('converts a pmatrix to an OMML matrix (<m:m>) instead of falling back to source', async () => {
+    // Regression: <mtable>/<mtr>/<mtd> hit the default branch and threw, so any
+    // formula containing a matrix / cases environment degraded to raw LaTeX text
+    // in Word. Now the table becomes a real OMML matrix.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('<m:m>')
+    expect((xml.match(/<m:mr>/g) ?? []).length).toBe(2)
+    // The parentheses become a growing OMML delimiter <m:d> (begChr "(" / endChr
+    // ")") wrapping the matrix, so Word auto-sizes the brackets to the matrix
+    // height instead of rendering tiny single-line "(" ")" characters.
+    expect(xml).toContain('<m:d>')
+    expect(xml).toContain('<m:begChr m:val="("/>')
+    expect(xml).toContain('<m:endChr m:val=")"/>')
+    // No raw LaTeX leaked as fallback text.
+    expect(xml).not.toContain('pmatrix')
+    expect(xml).not.toContain('\\begin')
+  })
+
+  it('keeps a \\tag-numbered equation row (mlabeledtr) instead of silently dropping it', async () => {
+    // Regression: MathJax emits <mlabeledtr> (not <mtr>) for a \tag-numbered
+    // row; the matrix converter filtered to `mtr` only, so the whole row --
+    // equation body AND its number -- vanished from the Word output with no
+    // error and no fallback. matrix() must include mlabeledtr and drop only its
+    // leading label cell (the equation number), still rendering the body.
+    const doc: MdNode[] = [
+      {
+        type: 'blockMath',
+        attrs: { latex: '\\begin{align} a &= b \\tag{1} \\\\ c &= d \\end{align}' },
+      },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('<m:m>')
+    // Both rows survive: the \tag{1} row (mlabeledtr) and the plain row (mtr).
+    expect((xml.match(/<m:mr>/g) ?? []).length).toBe(2)
+    // The tagged row's body still renders (its `a`/`b` content is not dropped).
+    expect(xml).toContain('a')
+    expect(xml).toContain('b')
+    // No raw LaTeX leaked as fallback text.
+    expect(xml).not.toContain('mlabeledtr')
+    expect(xml).not.toContain('\\begin')
+  })
+
+  it('converts a cases environment to an OMML matrix (piecewise function)', async () => {
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: 'f(x) = \\begin{cases} x^2 & x \\ge 0 \\\\ -x & x < 0 \\end{cases}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('<m:m>')
+    // The piecewise opening brace becomes a one-sided growing delimiter
+    // (begChr "{" / empty endChr) around the matrix, so Word draws a tall brace
+    // instead of a tiny single-line "{" beside the rows.
+    expect(xml).toContain('<m:begChr m:val="{"/>')
+    expect(xml).toContain('<m:endChr m:val=""/>')
+    // The brace is not emitted as a plain literal text run.
+    expect(xml).not.toContain('<m:t xml:space="preserve">{</m:t>')
+    expect(xml).not.toContain('cases')
+    expect(xml).not.toContain('\\begin')
+  })
+
+  it('renders diacritic accents (\\vec \\hat \\dot …) as centered <m:acc>, not superscripts', async () => {
+    // Regression: \vec/\hat/\dot/\ddot/\tilde/\bar came through as <mover> and
+    // were mapped to a superscript, shoving the mark up-and-right of the base
+    // ("公式符号偏移"). They must become an OMML <m:acc> so the accent sits
+    // centered on top of the base like Word/LaTeX draw it.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\hat{x}, \\bar{y}, \\dot{z}, \\ddot{w}, \\tilde{u}, \\vec{v}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    // Six accents, one per diacritic; none degraded to a superscript wrapper.
+    expect((xml.match(/<m:acc>/g) ?? []).length).toBe(6)
+    // The vec arrow must be the *combining* right-arrow-above (U+20D7), which
+    // stacks on the base, not the spacing → (U+2192) sitting beside it.
+    expect(xml).toContain('m:val="\u20d7"')
+    // The accent glyph is not left as a plain text run next to the base.
+    expect(xml).not.toContain('<m:t xml:space="preserve">\u2192</m:t>')
+  })
+
+  it('grows |…| absolute-value / determinant bars with an OMML delimiter', async () => {
+    // Regression: vmatrix and |\vec a| left the bars as literal single-height
+    // `|` runs, far too short around a matrix or an accented vector. They must
+    // become a growing <m:d> delimiter with `|` begChr/endChr.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\begin{vmatrix} a & b \\\\ c & d \\end{vmatrix} = ad - bc' } },
+      { type: 'blockMath', attrs: { latex: '\\vec{a} \\cdot \\vec{b} = |\\vec{a}||\\vec{b}|\\cos\\theta' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    // vmatrix: a matrix wrapped in a bar delimiter.
+    expect(xml).toContain('<m:m>')
+    expect(xml).toContain('<m:begChr m:val="|"/>')
+    expect(xml).toContain('<m:endChr m:val="|"/>')
+    // The abs-value formula produces its own bar delimiters too (at least the
+    // two |·| groups plus the vmatrix = 3 bar-open chars total).
+    expect((xml.match(/<m:begChr m:val="\|"\/>/g) ?? []).length).toBeGreaterThanOrEqual(3)
+    expect(xml).not.toContain('vmatrix')
+  })
+
+  it('renders \\overbrace / \\underbrace as stretchy <m:groupChr> braces', async () => {
+    // Regression: \overbrace/\underbrace came through as <mover>/<munder> over a
+    // brace glyph and were mapped to super/subscript, so the brace did not grow
+    // over the group. They must become an OMML <m:groupChr> stretchy brace.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\overbrace{a + b + c}^{n} = \\underbrace{x + y}_{m}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    expect((xml.match(/<m:groupChr>/g) ?? []).length).toBe(2)
+    // The over-brace glyph sits on top, the under-brace below.
+    expect(xml).toContain('<m:pos m:val="top"/>')
+    expect(xml).toContain('<m:pos m:val="bot"/>')
+    // The labels (n above, m below) sit centered on the braced group via OMML
+    // limit boxes (limUpp / limLow), not corner super/subscripts.
+    expect(xml).toContain('<m:limUpp>')
+    expect(xml).toContain('<m:limLow>')
+  })
+
+  it('centers \\overset / \\underset / stretchy-arrow labels with limit boxes, not corner scripts', async () => {
+    // Regression: \overset{n}{X}, \underset{i}{\star}, \stackrel{?}{=}, and the
+    // label on \xrightarrow{f} came through as super/subscripts, so the mark sat
+    // at the base's upper/lower-right corner instead of centered above/below it
+    // ("34/35 符号不在正位置"). They must become OMML <m:limUpp>/<m:limLow>.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: 'a \\stackrel{?}{=} b, \\quad \\overset{n}{X}, \\quad \\underset{i}{\\star}' } },
+      { type: 'blockMath', attrs: { latex: 'x \\xrightarrow{\\ f\\ } y \\xleftarrow{g} z' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    // stackrel + overset + two arrow labels -> at least 3 upper limit boxes;
+    // underset -> a lower limit box.
+    expect((xml.match(/<m:limUpp>/g) ?? []).length).toBeGreaterThanOrEqual(3)
+    expect(xml).toContain('<m:limLow>')
+    // No LaTeX leaked as fallback text.
+    expect(xml).not.toContain('\\overset')
+    expect(xml).not.toContain('\\xrightarrow')
+  })
 })

--- a/packages/docs/src/export/docx/math.ts
+++ b/packages/docs/src/export/docx/math.ts
@@ -39,6 +39,13 @@ import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js'
 import { SerializedMmlVisitor } from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js'
 import { STATE } from 'mathjax-full/js/core/MathItem.js'
 import type { MmlNode } from 'mathjax-full/js/core/MmlTree/MmlNode.js'
+// Importing these configuration modules registers the `base` and `ams` TeX
+// packages as a side-effect. Without the AMS import, `new TeX({ packages:
+// ['base','ams'] })` silently leaves AMS environments unregistered, so every
+// matrix/pmatrix/cases/align formula fails with "Unknown environment" and
+// degrades to raw LaTeX source text in Word. The import wires up the extension.
+import 'mathjax-full/js/input/tex/base/BaseConfiguration.js'
+import 'mathjax-full/js/input/tex/ams/AmsConfiguration.js'
 import { mathmlToOmml } from './mathml-to-omml.ts'
 
 /** LaTeX → MathML converter, or null if MathJax failed to initialize. */

--- a/packages/docs/src/export/docx/mathml-to-omml.ts
+++ b/packages/docs/src/export/docx/mathml-to-omml.ts
@@ -146,6 +146,182 @@ function root(base: Element, index: Element): string {
   return `<m:rad><m:radPr/><m:deg>${convertNode(index)}</m:deg><m:e>${convertNode(base)}</m:e></m:rad>`
 }
 
+/**
+ * Non-stretchy diacritic accents (\hat \vec \dot \ddot \tilde \check \acute
+ * \grave \breve …). MathJax renders these as `<mover><base><mo>accent</mo></mover>`
+ * with a small, non-stretchy accent glyph. Mapping them to a superscript (the old
+ * behavior) shoves the mark up-and-to-the-right of the base instead of centering
+ * it on top — the "符号偏移" bug. OMML `<m:acc>` places a combining accent centered
+ * over the base, which is what Word/LaTeX both do.
+ *
+ * Values are the *combining* code points Word expects in `<m:chr>`; several source
+ * glyphs (spacing ^ ~ ¨ ˙, or the → arrow) must be normalized to their combining
+ * form so the accent actually stacks on the base rather than sitting beside it.
+ */
+const ACCENT_CHARS: Record<string, string> = {
+  '^': '\u0302', // \hat  → combining circumflex
+  '\u02c6': '\u0302', // ˆ modifier circumflex
+  '~': '\u0303', // \tilde → combining tilde
+  '\u02dc': '\u0303', // ˜ small tilde
+  '\u00af': '\u0304', // ¯ macron → combining macron (\bar)
+  '\u0304': '\u0304', // combining macron
+  '\u02d9': '\u0307', // ˙ dot above → combining dot (\dot)
+  '\u0307': '\u0307',
+  '\u00a8': '\u0308', // ¨ diaeresis → combining diaeresis (\ddot)
+  '\u0308': '\u0308',
+  '\u02c7': '\u030c', // ˇ caron → combining caron (\check)
+  '\u00b4': '\u0301', // ´ acute → combining acute (\acute)
+  '`': '\u0300', // grave → combining grave (\grave)
+  '\u02d8': '\u0306', // ˘ breve → combining breve (\breve)
+  '\u2192': '\u20d7', // → arrow → combining right arrow above (\vec)
+  '\u21c0': '\u20d7', // ⇀ harpoon (\vec variant)
+  '\u2190': '\u20d6', // ← combining left arrow above
+}
+
+/** True when `over` is a small diacritic accent (not a stretchy brace/bar). */
+function accentChar(over: Element | undefined): string | undefined {
+  if (!over || over.name !== 'mo') return undefined
+  return ACCENT_CHARS[textOf(over).trim()]
+}
+
+/** `<m:acc>` — a combining accent centered over the base. */
+function accent(base: Element, chr: string): string {
+  return `<m:acc><m:accPr><m:chr m:val="${escAttr(chr)}"/><m:ctrlPr/></m:accPr><m:e>${convertNode(base)}</m:e></m:acc>`
+}
+
+/**
+ * Stretchy over/under characters used by \overbrace ⏞ (U+23DE), \underbrace ⏟
+ * (U+23DF), \overline ‾ / macron, and \underline. OMML `<m:groupChr>` draws a
+ * single stretchy glyph above or below the base that grows to the base width —
+ * exactly the brace/line behavior. `pos` places the glyph, `vertJc` aligns the
+ * base to the opposite edge.
+ */
+const GROUP_CHARS: Record<string, 'top' | 'bot'> = {
+  '\u23de': 'top', // ⏞ over-brace
+  '\u23df': 'bot', // ⏟ under-brace
+  '\u23b4': 'top', // ⎴ top square bracket
+  '\u23b5': 'bot', // ⎵ bottom square bracket
+  '\u0332': 'bot', // combining low line (\underline)
+  '\u005f': 'bot', // _ underline glyph
+  '\u2015': 'top', // ― horizontal bar
+}
+
+/** `<m:groupChr>` — a stretchy brace/line above or below the base. */
+function groupChr(base: Element, chr: string, pos: 'top' | 'bot'): string {
+  const vertJc = pos === 'top' ? 'bot' : 'top'
+  return (
+    `<m:groupChr><m:groupChrPr><m:chr m:val="${escAttr(chr)}"/>` +
+    `<m:pos m:val="${pos}"/><m:vertJc m:val="${vertJc}"/><m:ctrlPr/></m:groupChrPr>` +
+    `<m:e>${convertNode(base)}</m:e></m:groupChr>`
+  )
+}
+
+/**
+ * Handle an `<mover>`/`<munder>` whose script child is a stretchy group glyph
+ * (over/under-brace, over/under-line). The label that \overbrace{…}^{n} adds is
+ * an *outer* mover/munder wrapping this inner one; the caller resolves that as a
+ * normal sub/sup on top of the group. Returns null when the script is not a
+ * group character.
+ */
+function groupCharOf(node: Element): { base: Element; chr: string; pos: 'top' | 'bot' } | null {
+  const kids = childElements(node)
+  const script = kids[1]
+  if (!script || script.name !== 'mo') return null
+  const chr = textOf(script).trim()
+  const pos = GROUP_CHARS[chr]
+  if (!pos) return null
+  if ((node.name === 'mover' && pos !== 'top') || (node.name === 'munder' && pos !== 'bot')) {
+    return null
+  }
+  return { base: kids[0], chr, pos }
+}
+
+/** `<m:limUpp>` — places `lim` centered *above* the base (e.g. \overset, x→y arrow label). */
+function limUpp(baseOmml: string, limOmml: string): string {
+  return `<m:limUpp><m:limUppPr><m:ctrlPr/></m:limUppPr><m:e>${baseOmml}</m:e><m:lim>${limOmml}</m:lim></m:limUpp>`
+}
+
+/** `<m:limLow>` — places `lim` centered *below* the base (e.g. \underset). */
+function limLow(baseOmml: string, limOmml: string): string {
+  return `<m:limLow><m:limLowPr><m:ctrlPr/></m:limLowPr><m:e>${baseOmml}</m:e><m:lim>${limOmml}</m:lim></m:limLow>`
+}
+
+/**
+ * Convert an `<mover>`/`<munder>` element. Priority:
+ *   1. a small diacritic accent (\hat \vec \dot …) → `<m:acc>` centered on top;
+ *   2. a stretchy group glyph (\overbrace \underbrace \overline …) → `<m:groupChr>`;
+ *   3. the label of `\overbrace{body}^{label}` — an outer mover wrapping an inner
+ *      group-char mover — → script (sub/sup) sitting on the braced group;
+ *   4. anything else → sub/sup approximation (never empty).
+ */
+function overUnder(node: Element, kind: 'over' | 'under'): string {
+  const kids = childElements(node)
+  const base = kids[0]
+  const script = kids[1]
+  // 1. Diacritic accent (over only; \hat \vec \dot \ddot \tilde \bar …).
+  if (kind === 'over') {
+    const acc = accentChar(script)
+    if (acc) return accent(base, acc)
+  }
+  // 2. Stretchy brace/line directly on this node.
+  const grp = groupCharOf(node)
+  if (grp) return groupChr(grp.base, grp.chr, grp.pos)
+  // 3. \overbrace{...}^{n}: base carries the brace (possibly wrapped in an
+  //    ORD/OP <mrow>); `script` is the label. Emit the braced group, then label.
+  const innerNode =
+    base && (base.name === 'mover' || base.name === 'munder')
+      ? base
+      : base && base.name === 'mrow'
+        ? childElements(base).find((c) => c.name === 'mover' || c.name === 'munder')
+        : undefined
+  const inner = innerNode ? groupCharOf(innerNode) : null
+  if (inner) {
+    const grouped = groupChr(inner.base, inner.chr, inner.pos)
+    return kind === 'over'
+      ? limUpp(grouped, convertNode(script))
+      : limLow(grouped, convertNode(script))
+  }
+  // 4. Fallback: an over/under script that is NOT a diacritic accent — e.g.
+  //    \overset{n}{X}, \underset{i}{\star}, \stackrel{?}{=}, or the label on a
+  //    stretchy arrow \xrightarrow{f}. These belong centered directly above /
+  //    below the base, which is exactly what OMML's limit boxes do. Using a
+  //    super/subscript instead shoves the mark to the base's upper/lower-right
+  //    corner — the "符号不在正位置" bug for 28/34/35.
+  return kind === 'over'
+    ? limUpp(convertNode(base), convertNode(script))
+    : limLow(convertNode(base), convertNode(script))
+}
+
+/**
+ * Convert an `<mtable>` (matrix / cases body) into an OMML matrix `<m:m>`.
+ * Each `<mtr>` becomes an `<m:mr>` row; each `<mtd>` becomes an `<m:e>` cell.
+ * MathJax renders `\begin{pmatrix}…`, `\begin{cases}…`, etc. as an `<mtable>`
+ * (usually wrapped by fence `<mo>` siblings for the brackets). Without this the
+ * table hit the default branch and threw, forcing the whole formula to fall
+ * back to raw LaTeX source in Word.
+ *
+ * A numbered equation (`\tag{}`, or a numbered `align`/`equation`/`gather`
+ * environment) is emitted by MathJax as an `<mlabeledtr>` whose first `<mtd>`
+ * holds the equation number and whose remaining cells hold the equation body.
+ * OMML has no native per-row equation number, so we drop the label cell and
+ * render the body cells like a normal row. Treating `mlabeledtr` as a plain
+ * `mtr` (or omitting it) would silently drop the numbered equation entirely.
+ */
+function matrix(node: Element): string {
+  const rows = childElements(node).filter((r) => r.name === 'mtr' || r.name === 'mlabeledtr')
+  const mrs = rows
+    .map((r) => {
+      const cells = childElements(r).filter((c) => c.name === 'mtd')
+      // In an `<mlabeledtr>` the first `<mtd>` is the equation-number label;
+      // skip it so only the equation body is emitted (OMML has no row label).
+      const bodyCells = r.name === 'mlabeledtr' ? cells.slice(1) : cells
+      const es = bodyCells.map((c) => `<m:e>${convertSequence(childElements(c))}</m:e>`).join('')
+      return `<m:mr>${es}</m:mr>`
+    })
+    .join('')
+  return `<m:m><m:mPr><m:ctrlPr/></m:mPr>${mrs}</m:m>`
+}
+
 /** True if `node` is an `<mo>` whose glyph is a large (n-ary) operator. */
 function isLargeOpMo(node: Element | undefined): boolean {
   return !!node && node.name === 'mo' && LARGE_OPS.has(textOf(node).trim())
@@ -238,11 +414,140 @@ function emitNary(info: NaryInfo, body: Element[]): string {
  * Convert a sequence of sibling MathML nodes. This is where n-ary operators
  * pull their trailing siblings into `<m:e>` (up to the next relation op).
  */
+const FENCE_PAIRS: Record<string, string> = {
+  '(': ')',
+  '[': ']',
+  '{': '}',
+  '\u2308': '\u2309', // ⌈ ⌉
+  '\u230a': '\u230b', // ⌊ ⌋
+  '\u27e8': '\u27e9', // ⟨ ⟩
+}
+
+/** Symmetric fences where the open and close glyph are identical (| ‖). */
+const SYMMETRIC_FENCES = new Set(['|', '\u2016'])
+
+/** The `data-mjx-texclass` attribute of a node, if present (OPEN/CLOSE/…). */
+function texClass(node: Element | undefined): string | undefined {
+  const v = node?.attributes?.['data-mjx-texclass']
+  return typeof v === 'string' ? v : undefined
+}
+
+/**
+ * MathJax often wraps a bare bar `|` in `<mrow data-mjx-texclass="ORD"><mo>|</mo></mrow>`
+ * (e.g. `|\vec a|`). Unwrap a single-child mrow so fence detection sees the `<mo>`.
+ */
+function unwrapSoleMo(node: Element | undefined): Element | undefined {
+  if (!node) return undefined
+  if (node.name === 'mo') return node
+  if (node.name === 'mrow') {
+    const inner = childElements(node)
+    if (inner.length === 1 && inner[0].name === 'mo') return inner[0]
+  }
+  return undefined
+}
+
+/**
+ * If the node at `start` is an opening fence `<mo>`, scan for its matching
+ * closing fence (respecting nested fence depth) and emit an OMML delimiter
+ * `<m:d>` so Word auto-grows the brackets to their content height. Returns the
+ * produced markup and the index just past the closing fence, or null when the
+ * node is not an opening fence or has no matching close in this sequence.
+ */
+function tryConvertFenced(
+  nodes: Element[],
+  start: number,
+): { omml: string; next: number } | null {
+  const open = unwrapSoleMo(nodes[start])
+  if (!open) return null
+  const openChr = textOf(open).trim()
+
+  // Symmetric bars (| ‖): open and close glyphs are identical, so we cannot rely
+  // on glyph matching alone. Use the MathJax texclass hint when present
+  // (OPEN…CLOSE, as around a vmatrix), otherwise pair the next same-glyph bar
+  // (as in `|\vec a|`). Emitting a `<m:d>` makes Word grow the bars to the
+  // content height instead of leaving tiny single-line `|` characters.
+  if (SYMMETRIC_FENCES.has(openChr)) {
+    const openClass = texClass(nodes[start]) ?? texClass(open)
+    // Only treat as an opening bar when it is classed OPEN, or unclassed (a
+    // plain `|` pair). A CLOSE-classed bar is someone else's terminator.
+    if (openClass === 'CLOSE') return null
+    for (let j = start + 1; j < nodes.length; j++) {
+      const cand = unwrapSoleMo(nodes[j])
+      if (!cand) continue
+      if (textOf(cand).trim() === openChr) {
+        const inner = convertSequence(nodes.slice(start + 1, j))
+        const esc = escAttr(openChr)
+        const omml =
+          `<m:d><m:dPr><m:begChr m:val="${esc}"/><m:endChr m:val="${esc}"/>` +
+          `<m:ctrlPr/></m:dPr><m:e>${inner}</m:e></m:d>`
+        return { omml, next: j + 1 }
+      }
+    }
+    return null
+  }
+
+  if (open.name !== 'mo') return null
+  const closeChr = FENCE_PAIRS[openChr]
+  if (!closeChr) return null
+  // Find the matching close, honoring nesting of the same fence family.
+  let depth = 0
+  let end = -1
+  for (let j = start + 1; j < nodes.length; j++) {
+    const n = nodes[j]
+    if (n.name === 'mo') {
+      const t = textOf(n).trim()
+      if (t === openChr && openChr !== closeChr) depth++
+      else if (t === closeChr) {
+        if (depth === 0) {
+          end = j
+          break
+        }
+        depth--
+      }
+    }
+  }
+  if (end === -1) {
+    // Special case: a lone opening brace `{` immediately followed by an <mtable>
+    // is MathJax's rendering of a `cases`/piecewise environment (there is no
+    // matching closing brace). Emit a one-sided growing delimiter — begChr `{`,
+    // empty endChr — wrapping the matrix, so Word draws a tall brace instead of
+    // a tiny single-line `{` next to the rows.
+    if (openChr === '{') {
+      const nextEl = nodes[start + 1]
+      if (nextEl && nextEl.name === 'mtable') {
+        const inner = convertNode(nextEl)
+        const omml =
+          `<m:d><m:dPr><m:begChr m:val="{"/><m:endChr m:val=""/>` +
+          `<m:ctrlPr/></m:dPr><m:e>${inner}</m:e></m:d>`
+        return { omml, next: start + 2 }
+      }
+    }
+    return null
+  }
+  const inner = convertSequence(nodes.slice(start + 1, end))
+  const begEsc = escAttr(openChr)
+  const endEsc = escAttr(closeChr)
+  const omml =
+    `<m:d><m:dPr><m:begChr m:val="${begEsc}"/><m:endChr m:val="${endEsc}"/>` +
+    `<m:ctrlPr/></m:dPr><m:e>${inner}</m:e></m:d>`
+  return { omml, next: end + 1 }
+}
+
 function convertSequence(nodes: Element[]): string {
   let out = ''
   let i = 0
   while (i < nodes.length) {
     const node = nodes[i]
+    // A fenced group `(...)` `[...]` `{...}` etc. becomes an OMML delimiter
+    // `<m:d>` so Word auto-grows the brackets to the height of their content
+    // (e.g. matrices / column vectors). Without this the fences are literal
+    // single-height `(` `)` characters that look far too small around a matrix.
+    const fenced = tryConvertFenced(nodes, i)
+    if (fenced) {
+      out += fenced.omml
+      i = fenced.next
+      continue
+    }
     const nary = naryInfo(node)
     if (nary) {
       const body: Element[] = []
@@ -296,9 +601,9 @@ function convertNode(node: Element): string {
     // No native OMML "under/over"; approximate with scripts (rare off the
     // n-ary path, e.g. \overrightarrow — good enough, and never empty).
     case 'mover':
-      return sSup(kids[0], kids[1])
+      return overUnder(node, 'over')
     case 'munder':
-      return sSub(kids[0], kids[1])
+      return overUnder(node, 'under')
     case 'munderover':
       return sSubSup(kids[0], kids[1], kids[2])
     case 'mfrac':
@@ -307,6 +612,12 @@ function convertNode(node: Element): string {
       return sqrt(kids)
     case 'mroot':
       return root(kids[0], kids[1])
+    case 'mtable':
+      return matrix(node)
+    case 'mtr':
+    case 'mtd':
+      // Normally consumed by matrix(); if one appears standalone, flatten it.
+      return convertSequence(kids)
     default:
       throw new Error(`unsupported MathML element <${node.name ?? '?'}>`)
   }

--- a/packages/docs/src/export/docx/nodes.ts
+++ b/packages/docs/src/export/docx/nodes.ts
@@ -347,7 +347,7 @@ function convertHorizontalRule(): Paragraph {
 }
 
 /** Convert an image node. */
-function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
+export function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
   const buffer = getImageBuffer(node, ctx)
   const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : ''
 
@@ -366,7 +366,7 @@ function convertImage(node: MdNode, ctx: DocxContext): FileChild[] {
     ]
   }
 
-  const dims = getImageDimensions(node, buffer)
+  const dims = getImageDimensions(node, buffer, ctx.maxImageWidthPx)
   // Image uses `align` attr (left/center/right), not `textAlign`
   const align = mapTextAlign(node.attrs?.align)
 

--- a/packages/docs/src/export/docx/table-layout.test.ts
+++ b/packages/docs/src/export/docx/table-layout.test.ts
@@ -161,4 +161,284 @@ describe('DOCX table layout', () => {
     // Missing column falls back to the small minimum (200), not 600.
     expect(gridCols[2]).toBe(200)
   })
+
+  it('renders an image inside a table cell (regression: cell images were dropped)', async () => {
+    // A 1x1 PNG is enough — getImageDimensions falls back to a default box when
+    // the bytes do not parse, so the ImageRun still embeds a valid drawing.
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+      0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+      0x42, 0x60, 0x82,
+    ])
+    const ctx: DocxContext = {
+      urls: new Map([['att_cell_img', { attachId: 'att_cell_img', mime: 'image/png', url: '', fileName: 'x.png' }]]),
+      imageBuffers: new Map([['att_cell_img', png.buffer]]),
+      dynamicNumbering: [],
+      orderedListInstance: 0,
+    } as unknown as DocxContext
+    const table: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('说明', undefined, true), cell('图', undefined, true)] },
+        {
+          type: 'tableRow',
+          content: [
+            cell('单元格文字'),
+            {
+              type: 'tableCell',
+              content: [{ type: 'image', attrs: { attachId: 'att_cell_img', alt: '格内图' } }],
+            } as MdNode,
+          ],
+        },
+      ],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(table, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const path = join(tmpdir(), `tbl-img-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(path, buf)
+    const xml = execSync(`unzip -p ${path} word/document.xml`).toString()
+    // A drawing with an embedded blip must appear inside the table, not vanish.
+    expect(xml).toContain('<w:drawing>')
+    expect(xml).toMatch(/<a:blip[^>]*r:embed=/)
+    // And it must be inside a table cell (<w:tc>), not a stray body paragraph.
+    const tcCount = (xml.match(/<w:tc>/g) ?? []).length
+    expect(tcCount).toBeGreaterThanOrEqual(4)
+  })
+
+  it('renders a nested table (with an image) inside a cell (regression: nested tables/images dropped)', async () => {
+    // Regression: a table nested inside a cell hit the text-extract fallback and
+    // was dropped entirely, taking any images inside it with it.
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+      0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+      0x42, 0x60, 0x82,
+    ])
+    const ctx: DocxContext = {
+      urls: new Map([['att_nested_img', { attachId: 'att_nested_img', mime: 'image/png', url: '', fileName: 'n.png' }]]),
+      imageBuffers: new Map([['att_nested_img', png.buffer]]),
+      dynamicNumbering: [],
+      orderedListInstance: 0,
+    } as unknown as DocxContext
+    const innerTable: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [
+          { type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: '内层文字' }] }] },
+          { type: 'tableCell', content: [{ type: 'image', attrs: { attachId: 'att_nested_img', alt: '内层图' } }] },
+        ] },
+      ],
+    } as MdNode
+    const outerTable: MdNode = {
+      type: 'table',
+      content: [
+        { type: 'tableRow', content: [cell('外层表头', undefined, true)] },
+        { type: 'tableRow', content: [{ type: 'tableCell', content: [
+          { type: 'paragraph', content: [{ type: 'text', text: '外层单元格，下面是嵌套表' }] },
+          innerTable,
+        ] }] },
+      ],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(outerTable, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const path = join(tmpdir(), `tbl-nested-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(path, buf)
+    const xml = execSync(`unzip -p ${path} word/document.xml`).toString()
+    // Two tables must exist (outer + nested), i.e. a nested <w:tbl> appears inside a <w:tc>.
+    expect((xml.match(/<w:tbl>/g) ?? []).length).toBeGreaterThanOrEqual(2)
+    // The nested cell text survives.
+    expect(xml).toContain('内层文字')
+    // The image inside the nested table is embedded, not dropped.
+    expect(xml).toContain('<w:drawing>')
+    expect(xml).toMatch(/<a:blip[^>]*r:embed=/)
+  })
+
+  it('shrinks a cell image proportionally as it nests deeper (regression: nested img too big)', async () => {
+    // 1000x600 intrinsic PNG (IHDR encodes the size). At each level of a 2-column
+    // nested table the cell gets narrower, so the image must shrink to fit —
+    // previously it kept its page-scale width and looked identical at every depth.
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x03, 0xe8, 0x00, 0x00, 0x02, 0x58, 0x08, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05,
+      0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+      0x60, 0x82,
+    ])
+    const mkCtx = (): DocxContext =>
+      ({
+        urls: new Map([['ai', { attachId: 'ai', mime: 'image/png', url: '', fileName: 'i.png' }]]),
+        imageBuffers: new Map([['ai', png.buffer]]),
+        dynamicNumbering: [],
+        orderedListInstance: 0,
+      }) as unknown as DocxContext
+    const img = (): MdNode => ({ type: 'image', attrs: { attachId: 'ai', alt: 'x' } }) as MdNode
+    const tc = (content: unknown[]): MdNode => ({ type: 'tableCell', content }) as MdNode
+    const txt = (s: string): MdNode => ({ type: 'paragraph', content: [{ type: 'text', text: s }] }) as MdNode
+    const twoCol = (inner: MdNode): MdNode =>
+      ({ type: 'table', content: [{ type: 'tableRow', content: [tc([txt('c')]), tc([inner])] }] }) as MdNode
+    const imgWidthPx = async (doc: MdNode): Promise<number> => {
+      const document = new Document({ sections: [{ children: [convertTable(doc, mkCtx())] }] })
+      const buf = await Packer.toBuffer(document)
+      const p = join(tmpdir(), `nz-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+      writeFileSync(p, buf)
+      const xml = execSync(`unzip -p ${p} word/document.xml`).toString()
+      const m = xml.match(/<wp:extent cx="(\d+)"/)
+      return m ? Math.round(Number(m[1]) / 9525) : 0
+    }
+    const l1 = await imgWidthPx(twoCol(img()))
+    const l2 = await imgWidthPx(twoCol(twoCol(img())))
+    expect(l1).toBeGreaterThan(l2)
+    expect(l2).toBeLessThan(300)
+  })
+
+  it('sizes a nested table with an absolute DXA width, not 100% pct (regression: inner column collapsed to a sliver)', async () => {
+    // A nested table left at width:100% pct made Word fall back to auto layout,
+    // where an oversized image in one cell stole the width and collapsed the
+    // sibling column to a one-character-per-line sliver. Nested tables must be
+    // sized in absolute twips (bounded by their containing cell) so fixed layout
+    // keeps the columns even regardless of cell content.
+    const ctx: DocxContext = {
+      urls: new Map(),
+      imageBuffers: new Map(),
+      dynamicNumbering: [],
+      orderedListInstance: 0,
+    } as unknown as DocxContext
+    const cell = (s: string): MdNode =>
+      ({ type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }] }) as MdNode
+    const innerTable: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [cell('内层左'), cell('内层右')] }],
+    } as MdNode
+    const outer: MdNode = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [cell('外左'), { type: 'tableCell', content: [innerTable] } as MdNode],
+        },
+      ],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(outer, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const p = join(tmpdir(), `nw-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(p, buf)
+    const xml = execSync(`unzip -p ${p} word/document.xml`).toString()
+    const tblW = [...xml.matchAll(/<w:tblW w:type="(\w+)" w:w="([0-9%]+)"/g)].map((m) => ({ type: m[1], w: m[2] }))
+    // Two tables: the outer (top-level) stays pct 100%, the inner (nested) is dxa.
+    expect(tblW.length).toBe(2)
+    expect(tblW[0]).toEqual({ type: 'pct', w: '100%' })
+    expect(tblW[1].type).toBe('dxa')
+    expect(Number(tblW[1].w)).toBeGreaterThan(0)
+  })
+
+  it('clamps a lopsided NESTED table so no column collapses to a sliver', async () => {
+    // Regression (秒退-era "ffdsaf" vertical-text bug): a nested 3-col table whose
+    // editor colwidths are 259px + 14px + 14px would pass through as 3885/209/209
+    // twips and Word's fixed layout crushed the 209-twip columns into one char
+    // per line. The nested clamp must lift the slivers to a readable share while
+    // keeping the wide column widest. Top-level tables are unaffected (see above).
+    const ctx = {
+      urls: new Map(),
+      imageBuffers: new Map(),
+      dynamicNumbering: [],
+      orderedListInstance: 0,
+    } as unknown as DocxContext
+    const c = (w: number, s: string): MdNode =>
+      ({ type: 'tableCell', attrs: { colwidth: [w] }, content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }] }) as MdNode
+    const inner: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [c(259, 'ffdsaf'), c(14, 'x'), c(14, 'y')] }],
+    } as MdNode
+    const outer: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [{ type: 'tableCell', content: [inner] } as MdNode] }],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(outer, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const p = join(tmpdir(), `lop-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(p, buf)
+    const xml = execSync(`unzip -p ${p} word/document.xml`).toString()
+    const grids = [...xml.matchAll(/<w:tblGrid>(.*?)<\/w:tblGrid>/gs)].map((m) =>
+      [...m[1].matchAll(/<w:gridCol w:w="(\d+)"/g)].map((g) => Number(g[1])),
+    )
+    // The nested (inner) table's grid is the 3-col one.
+    const nested = grids.find((g) => g.length === 3)!
+    expect(nested).toBeDefined()
+    const even = nested.reduce((s, w) => s + w, 0) / 3
+    // No column collapses below 0.6x even; wide column still the widest.
+    for (const w of nested) expect(w).toBeGreaterThanOrEqual(Math.floor(even * 0.6) - 1)
+    expect(nested[0]).toBeGreaterThan(nested[1])
+    expect(nested[0]).toBeGreaterThan(nested[2])
+  })
+
+  it('keeps a nested table within its cell for inverse-lopsided widths (no overflow)', async () => {
+    // Blocker regression: the inverse of the ffdsaf case — one narrow + two wide
+    // columns (14px + 259px + 259px). Flooring the narrow column up while the
+    // wide columns sit near the max used to push the total past the cell width
+    // and re-trigger overflow. The final grid sum must stay within the cell.
+    const ctx = {
+      urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0,
+    } as unknown as DocxContext
+    const c = (w: number, s: string): MdNode =>
+      ({ type: 'tableCell', attrs: { colwidth: [w] }, content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }] }) as MdNode
+    const inner: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [c(14, 'n'), c(259, 'wide1'), c(259, 'wide2')] }],
+    } as MdNode
+    const outer: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [{ type: 'tableCell', content: [inner] } as MdNode] }],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(outer, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const p = join(tmpdir(), `inv-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(p, buf)
+    const xml = execSync(`unzip -p ${p} word/document.xml`).toString()
+    const grids = [...xml.matchAll(/<w:tblGrid>(.*?)<\/w:tblGrid>/gs)].map((m) =>
+      [...m[1].matchAll(/<w:gridCol w:w="(\d+)"/g)].map((g) => Number(g[1])),
+    )
+    const outerCol = grids.find((g) => g.length === 1)![0]
+    const nested = grids.find((g) => g.length === 3)!
+    const nestedSum = nested.reduce((s, w) => s + w, 0)
+    // Invariant: the nested table never exceeds its containing cell width.
+    expect(nestedSum).toBeLessThanOrEqual(outerCol + 2)
+  })
+
+  it('keeps a nested mixed-width table within its cell (missing columns branch)', async () => {
+    // Blocker regression: partial resize leaves some columns with an explicit
+    // colwidth and others without (the common case, since ProseMirror only
+    // stores widths for dragged columns). Oversized explicit columns plus an
+    // appended minimum sliver used to blow far past the cell (e.g. 2.76-4.93x).
+    // The nested mixed branch must fit the whole row to the cell.
+    const ctx = {
+      urls: new Map(), imageBuffers: new Map(), dynamicNumbering: [], orderedListInstance: 0,
+    } as unknown as DocxContext
+    const cW = (w: number, s: string): MdNode =>
+      ({ type: 'tableCell', attrs: { colwidth: [w] }, content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }] }) as MdNode
+    const cNull = (s: string): MdNode =>
+      ({ type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }] }) as MdNode
+    const inner: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [cW(700, 'big1'), cW(700, 'big2'), cNull('rest')] }],
+    } as MdNode
+    const outer: MdNode = {
+      type: 'table',
+      content: [{ type: 'tableRow', content: [{ type: 'tableCell', content: [inner] } as MdNode] }],
+    } as MdNode
+    const document = new Document({ sections: [{ children: [convertTable(outer, ctx)] }] })
+    const buf = await Packer.toBuffer(document)
+    const p = join(tmpdir(), `mix-${Date.now()}-${Math.random().toString(36).slice(2)}.docx`)
+    writeFileSync(p, buf)
+    const xml = execSync(`unzip -p ${p} word/document.xml`).toString()
+    const grids = [...xml.matchAll(/<w:tblGrid>(.*?)<\/w:tblGrid>/gs)].map((m) =>
+      [...m[1].matchAll(/<w:gridCol w:w="(\d+)"/g)].map((g) => Number(g[1])),
+    )
+    const outerCol = grids.find((g) => g.length === 1)![0]
+    const nested = grids.find((g) => g.length === 3)!
+    const nestedSum = nested.reduce((s, w) => s + w, 0)
+    expect(nestedSum).toBeLessThanOrEqual(outerCol + 2)
+  })
 })

--- a/packages/docs/src/export/docx/tables.ts
+++ b/packages/docs/src/export/docx/tables.ts
@@ -29,18 +29,22 @@ import {
   type ITableCellOptions,
 } from 'docx'
 import { convertInlineContent } from './marks.ts'
+import { convertImage } from './nodes.ts'
 import type { MdNode, DocxContext } from './types.ts'
 
 /**
  * Convert a table node to a docx Table element.
  * Handles colspan and rowspan via columnSpan/rowSpan on TableCell.
  */
-export function convertTable(node: MdNode, ctx: DocxContext): Table {
+export function convertTable(node: MdNode, ctx: DocxContext, availWidthDxa?: number): Table {
   const rows = node.content ?? []
 
   // Derive per-column widths (in DXA/twips). Always returns a full array so
   // fixed layout produces even columns even when the doc has no explicit widths.
-  const columnWidths = deriveColumnWidths(rows)
+  // A nested table is constrained by its containing cell's width, not the full
+  // page — pass that down so inner columns (and the images inside them) shrink
+  // to fit instead of being laid out at page scale.
+  const columnWidths = deriveColumnWidths(rows, availWidthDxa)
 
   const tableRows = rows.map((row, rowIdx) => {
     // Track the grid-column index so cell widths map to the right columns even
@@ -63,7 +67,14 @@ export function convertTable(node: MdNode, ctx: DocxContext): Table {
 
   return new Table({
     rows: tableRows,
-    width: { size: 100, type: WidthType.PERCENTAGE },
+    // A nested table (availWidthDxa provided) must be sized in absolute twips and
+    // bounded by its containing cell, otherwise a `100%` percentage width lets it
+    // (and an oversized image inside) spill past the cell and collapse its
+    // siblings to a sliver. Top-level tables keep 100% of the page content width.
+    width:
+      typeof availWidthDxa === 'number' && Number.isFinite(availWidthDxa) && availWidthDxa > 0
+        ? { size: columnWidths.reduce((s, w) => s + w, 0), type: WidthType.DXA }
+        : { size: 100, type: WidthType.PERCENTAGE },
     // Fixed layout honors explicit column widths. When the doc has explicit
     // widths we use them; otherwise we distribute the page width evenly so
     // columns don't collapse to their content (Word's auto layout squeezes
@@ -71,12 +82,12 @@ export function convertTable(node: MdNode, ctx: DocxContext): Table {
     columnWidths,
     layout: TableLayoutType.FIXED,
     borders: {
-      top: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
-      bottom: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
-      left: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
-      right: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
-      insideHorizontal: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
-      insideVertical: { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' },
+      top: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
+      bottom: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
+      left: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
+      right: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
+      insideHorizontal: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
+      insideVertical: { style: BorderStyle.SINGLE, size: 1, color: 'E5E6EB' },
     },
   })
 }
@@ -99,20 +110,43 @@ function convertTableCell(
       ? Math.round(columnWidthDxa as number)
       : undefined
 
-  // Convert cell content — cells contain block content (paragraphs, etc.)
-  const paragraphs = convertCellContent(cell.content ?? [], ctx)
+  // Convert cell content — cells contain block content (paragraphs, nested
+  // tables, images, lists, etc.). Bound image width to the cell's inner width so
+  // images (including those in nested tables) shrink to fit rather than
+  // overflowing: px ≈ DXA/15, minus the left+right cell inset (~7pt each ≈ 19px).
+  const CELL_INSET_PX = 19
+  const cellInnerPx =
+    cellWidthDxa && cellWidthDxa > 0
+      ? Math.max(24, Math.round(cellWidthDxa / 15) - CELL_INSET_PX)
+      : undefined
+  // Tighten any inherited (outer-cell) bound further with this cell's own width,
+  // so deeply nested cells keep shrinking their images.
+  const inheritedMax = ctx.maxImageWidthPx
+  const nextMax =
+    cellInnerPx != null && inheritedMax != null
+      ? Math.min(cellInnerPx, inheritedMax)
+      : (cellInnerPx ?? inheritedMax)
+  const cellCtx: DocxContext = nextMax != null ? { ...ctx, maxImageWidthPx: nextMax } : ctx
+  // Inner DXA width available to a NESTED table in this cell: the cell width
+  // minus both insets (~7pt = ~105 twips each). Falls back to undefined so a
+  // cell with no resolved width lets the nested table use the page default.
+  const CELL_INSET_DXA = 105
+  const cellInnerDxa =
+    cellWidthDxa && cellWidthDxa > 0 ? Math.max(360, cellWidthDxa - CELL_INSET_DXA * 2) : undefined
+  const children = convertCellContent(cell.content ?? [], cellCtx, cellInnerDxa)
 
-  // Ensure at least one paragraph (docx requires it)
-  if (paragraphs.length === 0) {
-    paragraphs.push(new Paragraph({ children: [] }))
+  // Ensure at least one paragraph (docx requires a cell to be non-empty, and a
+  // cell ending in a table must still be followed by a paragraph).
+  if (children.length === 0 || children[children.length - 1] instanceof Table) {
+    children.push(new Paragraph({ children: [] }))
   }
 
   const cellOptions: ITableCellOptions = {
-    children: paragraphs,
+    children,
     columnSpan: colspan > 1 ? colspan : undefined,
     rowSpan: rowspan > 1 ? rowspan : undefined,
     ...(cellWidthDxa ? { width: { size: cellWidthDxa, type: WidthType.DXA } } : {}),
-    ...(isHeader ? { shading: { fill: 'F0F0F0' } } : {}),
+    ...(isHeader ? { shading: { fill: 'F2F3F5' } } : {}),
   }
 
   return new TableCell(cellOptions)
@@ -125,12 +159,17 @@ function convertTableCell(
  * table can use fixed layout with evenly distributed columns (Word's auto
  * layout otherwise squeezes empty columns to near-zero).
  */
-function deriveColumnWidths(rows: MdNode[]): number[] {
+function deriveColumnWidths(rows: MdNode[], availWidthDxa?: number): number[] {
   const firstRow = rows[0]
   const cells = firstRow?.content ?? []
 
-  // Usable content width for A4 portrait with ~1in margins ≈ 9026 twips.
-  const PAGE_CONTENT_DXA = 9026
+  // Usable content width. For a top-level table this is A4 portrait with ~1in
+  // margins ≈ 9026 twips; for a nested table it is the containing cell's inner
+  // width so the nested grid never exceeds the space it actually occupies.
+  const PAGE_CONTENT_DXA =
+    typeof availWidthDxa === 'number' && Number.isFinite(availWidthDxa) && availWidthDxa > 0
+      ? availWidthDxa
+      : 9026
 
   // Expand colspans so the array is one entry per grid column.
   const explicit: (number | null)[] = []
@@ -146,6 +185,7 @@ function deriveColumnWidths(rows: MdNode[]): number[] {
   const colCount = explicit.length || 1
   const explicitSum = explicit.reduce<number>((s, w) => s + (w ?? 0), 0)
   const missing = explicit.filter((w) => w === null).length
+  const isNested = typeof availWidthDxa === 'number' && Number.isFinite(availWidthDxa) && availWidthDxa > 0
 
   if (missing > 0) {
     // Distribute the remaining page width across columns without an explicit
@@ -156,29 +196,117 @@ function deriveColumnWidths(rows: MdNode[]): number[] {
     const evenShare = remaining > 0 ? Math.round(remaining / missing) : 0
     const MIN_COL = 200
     const share = Math.max(MIN_COL, evenShare)
-    return explicit.map((w) => w ?? share)
+    const mixed = explicit.map((w) => w ?? share)
+    // For a NESTED table, oversized explicit columns plus an appended minimum
+    // sliver can push the total well past the cell width (e.g. [10500,10500]
+    // + 1 missing -> [10500,10500,200] = 21200 twips in a 4303 cell). Fit the
+    // whole row to the cell so the nested table can never overflow. Top-level
+    // tables keep the page-scale distribution.
+    return isNested ? fitColumnWidths(mixed, PAGE_CONTENT_DXA) : mixed
   }
 
   // No explicit widths: split the page evenly across all grid columns.
   const fallbackEven = Math.round(PAGE_CONTENT_DXA / colCount)
-  return explicit.map((w) => w ?? fallbackEven)
+  const resolved = explicit.map((w) => w ?? fallbackEven)
+
+  // All columns have explicit widths. For a NESTED table (availWidthDxa given)
+  // the editor colwidths are page-scale pixels and are frequently lopsided
+  // (e.g. a resized cell 259px + two 14px siblings -> 3885/209/209 twips). Under
+  // FIXED layout Word honours those literally, so a ~14px sliver column crushes
+  // its text into a one-character-per-line vertical stack (the "ffdsaf" bug) and
+  // inner tables/images overflow. Normalize to the cell's inner width and clamp
+  // each column to a sane band so no column collapses to a sliver or hogs the
+  // row. Top-level tables keep literal explicit widths (page-scale already), so
+  // only nested tables are reflowed. Mirrors the PDF (Typst) nested clamp.
+  return isNested ? fitColumnWidths(resolved, PAGE_CONTENT_DXA) : resolved
+}
+
+/**
+ * Fit a full set of column widths to `avail` for a nested table.
+ *
+ * Two goals, in priority order:
+ *   1. The final total must never exceed `avail` (Word fixed layout would
+ *      otherwise overflow the containing cell and crush its siblings).
+ *   2. No column should collapse to an unreadable sliver.
+ *
+ * Steps: scale to `avail`, clamp each column to [MIN_SHARE, MAX_SHARE] x the
+ * even share, then — because flooring narrow columns up can push the sum back
+ * over `avail` — redistribute any excess by shrinking the above-minimum columns
+ * proportionally until `sum <= avail`. If even every column at its floor still
+ * exceeds `avail` (very many columns), fall back to an even split.
+ */
+function fitColumnWidths(widths: number[], avail: number): number[] {
+  const n = widths.length
+  if (n <= 1) return [Math.round(avail)]
+  const sum = widths.reduce((s, w) => s + w, 0)
+  if (sum <= 0) return widths.map(() => Math.round(avail / n))
+
+  const even = avail / n
+  const MIN_SHARE = 0.6 // no column narrower than 60% of the even share
+  const MAX_SHARE = 1.6 // no column wider than 160% of the even share
+  const minW = even * MIN_SHARE
+  const maxW = even * MAX_SHARE
+
+  // If flooring every column already overflows (too many columns for the min
+  // share to fit), the min band is unsatisfiable — split evenly instead.
+  if (minW * n > avail) return widths.map(() => Math.round(avail / n))
+
+  // Scale to the available width, then clamp each column into the band.
+  const scale = avail / sum
+  const clamped = widths.map((w) => Math.min(maxW, Math.max(minW, w * scale)))
+
+  // Flooring narrow columns up can make the total exceed `avail`. Shrink the
+  // columns that sit above the floor, proportionally to their slack, until the
+  // total fits. This preserves min floors and never overshoots.
+  let total = clamped.reduce((s, w) => s + w, 0)
+  let excess = total - avail
+  if (excess > 1e-6) {
+    for (let guard = 0; guard < 8 && excess > 1e-6; guard++) {
+      const slack = clamped.reduce((s, w) => s + Math.max(0, w - minW), 0)
+      if (slack <= 1e-6) break
+      const factor = Math.min(1, excess / slack)
+      for (let i = 0; i < n; i++) {
+        const room = clamped[i] - minW
+        if (room > 0) clamped[i] -= room * factor
+      }
+      total = clamped.reduce((s, w) => s + w, 0)
+      excess = total - avail
+    }
+  }
+  return clamped.map((w) => Math.round(w))
 }
 
 /**
  * Convert cell content (usually paragraphs) into Paragraph elements.
  */
-function convertCellContent(nodes: MdNode[], ctx: DocxContext): Paragraph[] {
-  const paragraphs: Paragraph[] = []
+function convertCellContent(
+  nodes: MdNode[],
+  ctx: DocxContext,
+  availWidthDxa?: number,
+): (Paragraph | Table)[] {
+  const children: (Paragraph | Table)[] = []
 
   for (const node of nodes) {
     if (node.type === 'paragraph') {
       const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
-      paragraphs.push(
+      children.push(
         new Paragraph({
           children: runs,
           spacing: { before: 40, after: 40 },
         }),
       )
+    } else if (node.type === 'image') {
+      // Images are block atoms, so inside a cell they appear as sibling block
+      // nodes (not inline). convertImage returns Paragraph(s) carrying the
+      // ImageRun; push them so cell images render instead of vanishing.
+      for (const child of convertImage(node, ctx)) {
+        if (child instanceof Paragraph) children.push(child)
+      }
+    } else if (node.type === 'table') {
+      // Nested table inside a cell. docx TableCell children accept Table, so
+      // recurse instead of dropping it (and its images) via the text-extract
+      // fallback below.
+      children.push(convertTable(node, ctx, availWidthDxa))
     } else if (node.type === 'bulletList' || node.type === 'orderedList') {
       // Flatten nested lists in cells into paragraphs with bullet/number prefix
       const items = node.content ?? []
@@ -189,7 +317,7 @@ function convertCellContent(nodes: MdNode[], ctx: DocxContext): Paragraph[] {
         const runs = firstPara
           ? [new TextRun({ text: prefix }), ...convertInlineContent(firstPara.content ?? [], ctx.emojiGlyph)]
           : [new TextRun({ text: prefix + extractPlainText(item) })]
-        paragraphs.push(
+        children.push(
           new Paragraph({
             children: runs,
             spacing: { before: 20, after: 20 },
@@ -200,12 +328,12 @@ function convertCellContent(nodes: MdNode[], ctx: DocxContext): Paragraph[] {
       // For other block types in cells, extract text content
       const runs = convertInlineContent(node.content ?? [], ctx.emojiGlyph)
       if (runs.length > 0) {
-        paragraphs.push(new Paragraph({ children: runs }))
+        children.push(new Paragraph({ children: runs }))
       }
     }
   }
 
-  return paragraphs
+  return children
 }
 
 /**

--- a/packages/docs/src/export/docx/types.ts
+++ b/packages/docs/src/export/docx/types.ts
@@ -34,6 +34,13 @@ export interface DocxContext {
   dynamicNumbering: Array<{ reference: string; start: number; level: number }>
   /** Monotonic counter handing each ordered list its own numbering instance (independent counting). */
   orderedListInstance: number
+  /**
+   * Optional upper bound (px) on rendered image width for the current context.
+   * Set when converting content inside a table cell so images shrink to fit the
+   * cell (which can be much narrower than the page when tables are nested),
+   * instead of overflowing at the page-wide MAX_IMAGE_WIDTH cap.
+   */
+  maxImageWidthPx?: number
 }
 
 /** Represents a collected image reference that needs to be fetched. */


### PR DESCRIPTION
## Summary
Fix Word (DOCX) export defects: math constructs (accents, fences, braces, over/under labels, AMS environments), nested-table column collapse, and cell-image overflow.

## Linked Spec / Issue
Fixes #666

## What this change actually does (before/after)
- **Math OMML** (`export/docx/mathml-to-omml.ts`, `math.ts`):
  - Before: accents rendered as a right-superscript; `|`/`\|` stayed single-line height; `\overbrace`/`\underbrace` did not stretch; over/under labels misplaced; AMS environments (matrix/pmatrix/cases/align) failed as "Unknown environment" and fell back to raw LaTeX text.
  - After: accents map to `<m:acc>` with combining codepoints (centered over the base); `|`/`\|` pair into a growing `<m:d>`; braces map to `<m:groupChr>`; over/under/stackrel/xrightarrow map to `<m:limUpp>`/`<m:limLow>`; the AMS TeX package is registered via side-effect imports so those environments render as real math.
- **Nested tables** (`export/docx/tables.ts`): a nested table with all-explicit, lopsided column widths is scaled to the cell inner width and each column clamped to [0.6, 1.6]x the even share (clamp as the final step). Top-level tables keep literal explicit widths, so top-level layout is unchanged.
- **Cell images** (`export/docx/images.ts`, `nodes.ts`, `types.ts`): image width is capped to the containing cell's inner width (`maxImageWidthPx`), so nested-cell images shrink to fit instead of overflowing at the page-wide cap.

## What could break
- Dependents: any DOCX export containing math, tables, or images.
- Failure modes considered: top-level tables intentionally left on literal explicit widths (only nested tables reflow) to avoid changing existing layouts; the AMS side-effect imports only register TeX packages and do not alter non-AMS formulas; accent normalization is limited to a fixed accent set.

## How verified
- `packages/docs` docx export suite: 96 tests pass (includes new regression tests for accents/fences/braces in `math.test.ts` and nested-table clamp in `table-layout.test.ts`).
- `tsc --noEmit` clean for the touched files.
- Manual: exported the math and image-mixing test documents; OMML structure verified for each construct.

## Notes
- PDF export defects are addressed separately (Mininglamp-OSS/octo-docs-backend#57).
- Document import (Markdown/Word/PDF) is intentionally not part of this PR.
