### PR TITLE
feat(loop): redesign board, list, detail, run and new-loop views

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -297,7 +297,6 @@
     "reply": "Reply",
     "deleteConfirm": "Delete this comment?",
     "replyPlaceholder": "Reply…",
-    "replyingHint": "Replying to a comment above — use its reply box",
     "empty": "No comments yet",
     "placeholder": "Write a comment…",
     "send": "Send",
@@ -305,7 +304,8 @@
     "tapToSuppress": "(tap to skip one)",
     "resolve": "Resolve",
     "unresolve": "Unresolve",
-    "resolved": "Resolved"
+    "resolved": "Resolved",
+    "newTitle": "Add a comment"
   },
   "activity": {
     "title": "Activity",
@@ -324,8 +324,6 @@
     "deleted": "Deleted",
     "commentAdded": "Comment added",
     "commentDeleted": "Comment deleted",
-    "commentUpdated": "Comment updated",
-    "editFailed": "Edit failed",
     "deleteFailed": "Delete failed",
     "saveFailed": "Save failed",
     "loadFailed": "Load failed",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -42,7 +42,11 @@
     "runFailed": "Failed to trigger",
     "triggerFailed": "Automation created, but scheduling failed — retry from Edit",
     "confirmDelete": "Delete this automation?",
-    "statusLabel": { "active": "Active", "paused": "Paused", "archived": "Archived" },
+    "statusLabel": {
+      "active": "Active",
+      "paused": "Paused",
+      "archived": "Archived"
+    },
     "triggers": "Triggers",
     "addTrigger": "Add trigger",
     "editTrigger": "Edit trigger",
@@ -53,8 +57,19 @@
     "runsError": "Failed to load run history",
     "retry": "Retry",
     "noTaskDesc": "No task instructions",
-    "runStatus": { "issue_created": "Loop created", "running": "Running", "completed": "Succeeded", "failed": "Failed", "skipped": "Skipped" },
-    "runSource": { "schedule": "Schedule", "manual": "Manual", "webhook": "Webhook", "api": "API" },
+    "runStatus": {
+      "issue_created": "Loop created",
+      "running": "Running",
+      "completed": "Succeeded",
+      "failed": "Failed",
+      "skipped": "Skipped"
+    },
+    "runSource": {
+      "schedule": "Schedule",
+      "manual": "Manual",
+      "webhook": "Webhook",
+      "api": "API"
+    },
     "emptyTitle": "No automations yet",
     "emptyDesc": "Create an automation to let AI teammates run on a cadence",
     "freq": {
@@ -149,7 +164,11 @@
     "cancel": "Cancel",
     "save": "Save",
     "delete": "Delete",
-    "edit": "Edit"
+    "edit": "Edit",
+    "filter": "Filter",
+    "show": "Display",
+    "clearFilters": "Clear filters",
+    "dispatch": "Dispatch"
   },
   "workspace": {
     "title": "Workspaces",
@@ -268,7 +287,9 @@
     "created": "Created",
     "updated": "Updated",
     "execLog": "Execution log",
-    "execEmpty": "No runs yet"
+    "execEmpty": "No runs yet",
+    "board": "Board",
+    "detailsTitle": "Details"
   },
   "comment": {
     "reply": "Reply",
@@ -580,7 +601,22 @@
     "rerun": "Re-run",
     "rerunStarted": "Re-dispatched",
     "cancelConfirm": "Stop this run?",
-    "cancelled": "Stopped"
+    "cancelled": "Stopped",
+    "copyAll": "Copy all",
+    "copied": "Copied",
+    "events": "{{count}} events",
+    "toolCalls": "{{count}} tool calls",
+    "duration": "Duration",
+    "noData": "No data",
+    "waiting": "Waiting for events…",
+    "event": {
+      "text": "Agent",
+      "thinking": "Thinking",
+      "tool": "Tool",
+      "result": "Result",
+      "error": "Error"
+    },
+    "showHistory": "Show run history ({{count}})"
   },
   "settings": {
     "general": "General",
@@ -603,5 +639,40 @@
     "added": "Member added",
     "pendingInvites": "Pending invitations",
     "revoke": "Revoke"
+  },
+  "newLoop": {
+    "title": "Hand it to an AI teammate",
+    "subtitle": "Describe the outcome in one line — {{name}} turns it into a running loop.",
+    "subtitleGeneric": "Describe the outcome in one line — an AI teammate turns it into a running loop.",
+    "placeholder": "e.g. \"Have Bohan fix the slow inbox loading in the Web project\"",
+    "skills": "Skills",
+    "noProject": "No project",
+    "pickAssignee": "Pick an AI teammate",
+    "dispatch": "Dispatch",
+    "dispatched": "Dispatched",
+    "examplesTitle": "Start from an example",
+    "ex1Title": "Polish the demo script",
+    "ex1Desc": "Take one line from ticket to loop, end to end.",
+    "ex1Prompt": "Polish the OctoLoop demo script: one-line dispatch, full chain",
+    "ex2Title": "Digest user feedback",
+    "ex2Desc": "Merge last week's feedback into a top-10 pain-point table.",
+    "ex2Prompt": "Merge last week's user feedback into a top-10 pain-point table",
+    "ex3Title": "Debug slow inbox",
+    "ex3Desc": "Have a teammate fix the slow inbox loading in the Web project.",
+    "ex3Prompt": "Fix the slow inbox loading in the Web project"
+  },
+  "activityAction": {
+    "created": "created this loop",
+    "statusChanged": "updated the status",
+    "priorityChanged": "updated the priority",
+    "assigneeChanged": "changed the assignee",
+    "projectChanged": "changed the project",
+    "titleChanged": "edited the title",
+    "descriptionChanged": "updated the description",
+    "labelChanged": "updated labels",
+    "dateChanged": "updated dates",
+    "reopened": "reopened",
+    "completed": "marked complete",
+    "generic": "updated this loop"
   }
 }

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -4,7 +4,8 @@
     "changeStatus": "Change status",
     "changePriority": "Change priority",
     "changeAssignee": "Change assignee",
-    "deleteIssue": "Delete Loop"
+    "deleteIssue": "Delete Loop",
+    "editProps": "Edit properties"
   },
   "nav": {
     "myloop": "My loops",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -168,7 +168,9 @@
     "filter": "Filter",
     "show": "Display",
     "clearFilters": "Clear filters",
-    "dispatch": "Dispatch"
+    "dispatch": "Dispatch",
+    "copy": "Copy",
+    "more": "More"
   },
   "workspace": {
     "title": "Workspaces",
@@ -306,7 +308,8 @@
     "resolved": "Resolved"
   },
   "activity": {
-    "title": "Activity"
+    "title": "Activity",
+    "count": "{{count}} activities"
   },
   "attach": {
     "title": "Attachments",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -42,7 +42,11 @@
     "runFailed": "触发失败",
     "triggerFailed": "自动化已创建，但排程设置失败，请在编辑里重试",
     "confirmDelete": "删除这个自动化？",
-    "statusLabel": { "active": "运行中", "paused": "已停用", "archived": "已归档" },
+    "statusLabel": {
+      "active": "运行中",
+      "paused": "已停用",
+      "archived": "已归档"
+    },
     "triggers": "触发器",
     "addTrigger": "添加触发器",
     "editTrigger": "编辑触发器",
@@ -53,8 +57,19 @@
     "runsError": "运行历史加载失败",
     "retry": "重试",
     "noTaskDesc": "暂无任务说明",
-    "runStatus": { "issue_created": "已建回路", "running": "运行中", "completed": "成功", "failed": "失败", "skipped": "跳过" },
-    "runSource": { "schedule": "定时触发", "manual": "手动触发", "webhook": "Webhook", "api": "API" },
+    "runStatus": {
+      "issue_created": "已建回路",
+      "running": "运行中",
+      "completed": "成功",
+      "failed": "失败",
+      "skipped": "跳过"
+    },
+    "runSource": {
+      "schedule": "定时触发",
+      "manual": "手动触发",
+      "webhook": "Webhook",
+      "api": "API"
+    },
     "emptyTitle": "暂无自动化",
     "emptyDesc": "创建一个自动化，让 AI 队友按节奏自动运行",
     "freq": {
@@ -149,7 +164,11 @@
     "cancel": "取消",
     "save": "保存",
     "delete": "删除",
-    "edit": "编辑"
+    "edit": "编辑",
+    "filter": "筛选",
+    "show": "显示",
+    "clearFilters": "清除筛选",
+    "dispatch": "派单"
   },
   "workspace": {
     "title": "工作空间",
@@ -268,7 +287,9 @@
     "created": "创建于",
     "updated": "更新于",
     "execLog": "执行日志",
-    "execEmpty": "暂无执行记录"
+    "execEmpty": "暂无执行记录",
+    "board": "看板",
+    "detailsTitle": "详情"
   },
   "comment": {
     "reply": "回复",
@@ -285,7 +306,7 @@
     "resolved": "已解决"
   },
   "activity": {
-    "title": "活动"
+    "title": "动态"
   },
   "attach": {
     "title": "附件",
@@ -580,7 +601,22 @@
     "rerun": "重跑",
     "rerunStarted": "已重新派单",
     "cancelConfirm": "确定终止这次执行？",
-    "cancelled": "已终止"
+    "cancelled": "已终止",
+    "copyAll": "复制全部",
+    "copied": "已复制",
+    "events": "{{count}} 个事件",
+    "toolCalls": "{{count}} 次工具调用",
+    "duration": "时长",
+    "noData": "暂无数据",
+    "waiting": "等待事件…",
+    "event": {
+      "text": "回答",
+      "thinking": "思考",
+      "tool": "工具",
+      "result": "结果",
+      "error": "错误"
+    },
+    "showHistory": "显示历史运行 ({{count}})"
   },
   "settings": {
     "general": "通用",
@@ -603,5 +639,40 @@
     "added": "成员已添加",
     "pendingInvites": "待处理邀请",
     "revoke": "撤销"
+  },
+  "newLoop": {
+    "title": "把活交给 AI 队友",
+    "subtitle": "一句话描述你要的结果，{{name}} 会把它变成一个跑起来的回路。",
+    "subtitleGeneric": "一句话描述你要的结果，AI 队友会把它变成一个跑起来的回路。",
+    "placeholder": "例如：“让 Bohan 修一下 Web 项目里收件箱加载慢的问题”",
+    "skills": "Skills",
+    "noProject": "无项目",
+    "pickAssignee": "选择 AI 队友",
+    "dispatch": "派单",
+    "dispatched": "已派单",
+    "examplesTitle": "从一个例子开始",
+    "ex1Title": "打磨演示脚本",
+    "ex1Desc": "从建单到回路，把一句话派单全链路走顺。",
+    "ex1Prompt": "打磨 OctoLoop 演示脚本：一句话派单全链路",
+    "ex2Title": "整理用户反馈",
+    "ex2Desc": "把上周反馈归并成 top 10 痛点表格。",
+    "ex2Prompt": "把上周用户反馈归并成 top 10 痛点表格",
+    "ex3Title": "排查收件箱加载慢",
+    "ex3Desc": "让 AI 队友修一下 Web 项目里收件箱加载慢的问题。",
+    "ex3Prompt": "修一下 Web 项目里收件箱加载慢的问题"
+  },
+  "activityAction": {
+    "created": "创建了这个回路",
+    "statusChanged": "更新了状态",
+    "priorityChanged": "更新了优先级",
+    "assigneeChanged": "变更了负责人",
+    "projectChanged": "变更了项目",
+    "titleChanged": "修改了标题",
+    "descriptionChanged": "更新了描述",
+    "labelChanged": "更新了标签",
+    "dateChanged": "更新了时间",
+    "reopened": "重新打开",
+    "completed": "标记完成",
+    "generic": "更新了这个回路"
   }
 }

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -168,7 +168,9 @@
     "filter": "筛选",
     "show": "显示",
     "clearFilters": "清除筛选",
-    "dispatch": "派单"
+    "dispatch": "派单",
+    "copy": "复制",
+    "more": "更多"
   },
   "workspace": {
     "title": "工作空间",
@@ -306,7 +308,8 @@
     "resolved": "已解决"
   },
   "activity": {
-    "title": "动态"
+    "title": "动态",
+    "count": "{{count}} 条动态"
   },
   "attach": {
     "title": "附件",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -297,7 +297,6 @@
     "reply": "回复",
     "deleteConfirm": "确定删除这条评论？",
     "replyPlaceholder": "回复…",
-    "replyingHint": "正在回复上方评论，请在对应输入框输入",
     "empty": "暂无评论",
     "placeholder": "写下评论…",
     "send": "发送",
@@ -305,7 +304,8 @@
     "tapToSuppress": "(点击可跳过某个)",
     "resolve": "标记解决",
     "unresolve": "取消解决",
-    "resolved": "已解决"
+    "resolved": "已解决",
+    "newTitle": "写下评论"
   },
   "activity": {
     "title": "动态",
@@ -324,8 +324,6 @@
     "deleted": "已删除",
     "commentAdded": "评论已添加",
     "commentDeleted": "评论已删除",
-    "commentUpdated": "评论已更新",
-    "editFailed": "编辑失败",
     "deleteFailed": "删除失败",
     "saveFailed": "保存失败",
     "loadFailed": "加载失败",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -4,7 +4,8 @@
     "changeStatus": "修改状态",
     "changePriority": "修改优先级",
     "changeAssignee": "修改负责人",
-    "deleteIssue": "删除回路"
+    "deleteIssue": "删除回路",
+    "editProps": "编辑属性"
   },
   "nav": {
     "myloop": "我的回路",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  Typography,
   Input,
   Button,
   Spin,
@@ -9,8 +8,9 @@ import {
   Pagination,
   DatePicker,
   Checkbox,
+  Dropdown,
 } from "@douyinfe/semi-ui";
-import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, ArrowUp, ArrowDown } from "lucide-react";
+import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, ArrowUp, ArrowDown, SlidersHorizontal, Filter } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
   Issue,
@@ -30,9 +30,7 @@ import IssueBoard from "../panel/IssueBoard";
 import IssueGroupBoard from "../panel/IssueGroupBoard";
 import IssueList from "../panel/IssueList";
 import IssueDetailPage from "../panel/IssueDetailPage";
-import CreateIssueModal from "../ui/CreateIssueModal";
-
-const { Title } = Typography;
+import NewLoopPage from "./NewLoopPage";
 
 type ViewMode = "board" | "grouped" | "list";
 
@@ -83,7 +81,6 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   const [scope, setScope] = useState<IssueScope>(defaultScope ?? "all");
   const [f, setF] = useState<Filters>({ keyword: "", gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, sortBy: "position", sortDir: "desc", dateField: "created_at" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
-  const [createOpen, setCreateOpen] = useState(false);
   const cands = useAssigneeCandidates();
   // 当前 octo 成员的后端 user_id(involves_user_id 需 UUID,非 octo uid)：
   // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
@@ -203,6 +200,15 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
     WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onMutated} />);
   };
 
+  // 新建回路 → 唤起独立 composer 页（非弹窗，对齐 Figma）。创建成功后返回并刷新列表。
+  const openNewLoop = () => {
+    WKApp.routeRight.push(
+      <NewLoopPage
+        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); }}
+      />,
+    );
+  };
+
   const isEmpty = view === "grouped" ? groups.every((g) => g.issues.length === 0) : total === 0;
 
   // 状态/优先级/项目的选项列表:单选与多选两个分支共用(避免重复 map)。
@@ -216,226 +222,175 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
     <Select.Option key={p.id} value={p.id}>{p.title}</Select.Option>
   ));
 
+  const title = defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
+
+  // 「筛选」按钮上的激活计数(仅计当前视图会生效的维度)。
+  const activeFilters =
+    (view === "grouped"
+      ? f.gStatuses.length + f.gPriorities.length + f.gProjectIds.length + (f.noProject ? 1 : 0)
+      : (f.status ? 1 : 0) + (f.priority ? 1 : 0) + (f.assignee ? 1 : 0) + (f.project ? 1 : 0) + (f.keyword.trim() ? 1 : 0)) +
+    (f.creator ? 1 : 0) +
+    (f.dateRange ? 1 : 0);
+
+  const clearFilters = () =>
+    update({
+      keyword: "", status: undefined, priority: undefined, assignee: undefined, creator: undefined, project: undefined,
+      gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, dateRange: undefined,
+    });
+
+  // 「筛选」面板：把原工具栏散落的下拉收进一个面板（对齐 multica 的筛选框）。维度按视图切换单选/多选。
+  const filterPanel = (
+    <div className="loop-fields loop-filter-panel">
+      <div className="loop-filter-panel__head">
+        <span>{t("loop.action.filter")}</span>
+        {activeFilters > 0 && (
+          <button type="button" className="loop-filter-panel__clear" onClick={clearFilters}>{t("loop.action.clearFilters")}</button>
+        )}
+      </div>
+      <div className="loop-fields__row">
+        <div className="loop-fields__label">{t("loop.filter.status")}</div>
+        {view === "grouped" ? (
+          <Select multiple value={f.gStatuses} onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
+        ) : (
+          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
+        )}
+      </div>
+      <div className="loop-fields__row">
+        <div className="loop-fields__label">{t("loop.filter.priority")}</div>
+        {view === "grouped" ? (
+          <Select multiple value={f.gPriorities} onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
+        ) : (
+          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
+        )}
+      </div>
+      {/* assignee 单选仅扁平列表/看板(grouped 用 scope 按类型收窄)。 */}
+      {view !== "grouped" && (
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{t("loop.filter.assignee")}</div>
+          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
+            {cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
+          </Select>
+        </div>
+      )}
+      {/* 「与我相关」自带 creator=我 并集腿,creator 下拉对它无效 → 隐藏。 */}
+      {!(view === "grouped" && scope === "involves") && (
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{t("loop.filter.creator")}</div>
+          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
+            {cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
+          </Select>
+        </div>
+      )}
+      {projects.length > 0 && (
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{t("loop.filter.project")}</div>
+          {view === "grouped" ? (
+            <Select multiple value={f.gProjectIds} onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })} showClear filter maxTagCount={1} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
+          ) : (
+            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
+          )}
+        </div>
+      )}
+      {/* no-project:仅分组板(后端 include_no_project 仅 /grouped 支持)。 */}
+      {view === "grouped" && (
+        <div className="loop-fields__row">
+          <Checkbox className="loop-nofilter" checked={f.noProject} onChange={(e) => update({ noProject: !!e.target.checked })}>{t("loop.filter.noProject")}</Checkbox>
+        </div>
+      )}
+      <div className="loop-fields__row">
+        <div className="loop-fields__label">{t("loop.filter.dateRange")}</div>
+        <div className="loop-fields__inline">
+          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} dropdownClassName="loop-fields__dropdown" style={{ width: 104 }}>
+            {ISSUE_DATE_FIELDS.map((d) => (<Select.Option key={d} value={d}>{t(`loop.dateField.${d}`)}</Select.Option>))}
+          </Select>
+          <DatePicker type="dateRange" density="compact" value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} style={{ flex: 1 }} />
+        </div>
+      </div>
+      {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
+      {view !== "grouped" && (
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{t("loop.search.issue")}</div>
+          <Input className="loop-search" prefix={<Search size={14} />} placeholder={t("loop.search.issue")} value={f.keyword} onChange={(v) => update({ keyword: v })} showClear style={{ width: "100%" }} />
+        </div>
+      )}
+    </div>
+  );
+
+  // 「显示」面板：视图切换 + 列表排序。
+  const showPanel = (
+    <div className="loop-fields loop-show-panel">
+      <div className="loop-filter-panel__head"><span>{t("loop.action.show")}</span></div>
+      <div className="loop-fields__row">
+        <div className="loop-fields__label">{t("loop.view.board")}</div>
+        <div className="loop-seg" role="tablist">
+          {(["board", "grouped", "list"] as ViewMode[]).map((v) => (
+            <button key={v} type="button" role="tab" aria-selected={view === v} className={`loop-seg__btn${view === v ? " is-active" : ""}`} onClick={() => switchView(v)}>
+              {v === "board" ? <LayoutGrid size={14} /> : v === "grouped" ? <Users size={14} /> : <ListIcon size={14} />}
+              {t(`loop.view.${v}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+      {view === "list" && (
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{t("loop.sort.direction")}</div>
+          <div className="loop-fields__inline">
+            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} dropdownClassName="loop-fields__dropdown" style={{ flex: 1 }}>
+              {ISSUE_SORT_FIELDS.map((s) => (<Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>))}
+            </Select>
+            <Button theme="borderless" disabled={f.sortBy === "position"} icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />} aria-label={t("loop.sort.direction")} onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div className="loop-page">
-      <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.issue")}</Title>
-        <div className="loop-viewtoggle">
-          <button className={view === "board" ? "is-active" : ""} onClick={() => switchView("board")}>
-            <LayoutGrid size={14} />
-            {t("loop.view.board")}
-          </button>
-          <button className={view === "grouped" ? "is-active" : ""} onClick={() => switchView("grouped")}>
-            <Users size={14} />
-            {t("loop.view.grouped")}
-          </button>
-          <button className={view === "list" ? "is-active" : ""} onClick={() => switchView("list")}>
-            <ListIcon size={14} />
-            {t("loop.view.list")}
-          </button>
+      <div className="loop-page__head loop-page__head--stack">
+        <div className="loop-page__title-row">
+          <h2 className="loop-page__title">{title}</h2>
         </div>
-        {view === "grouped" && (
-          <div className="loop-seg" role="tablist">
-            {(["all", "members", "agents", "involves"] as IssueScope[]).map((s) => {
-              // 「与我相关」需当前成员的后端 id；未解析出则禁用（而非静默失效）。
-              const disabled = s === "involves" && !myMemberId;
-              return (
-                <button
-                  key={s}
-                  type="button"
-                  role="tab"
-                  aria-selected={scope === s}
-                  disabled={disabled}
-                  className={`loop-seg__btn${scope === s ? " is-active" : ""}`}
-                  onClick={() => setScope(s)}
-                >
-                  {t(`loop.scope.${s}`)}
-                </button>
-              );
-            })}
-          </div>
-        )}
-        <div className="loop-page__spacer" />
-        {view === "grouped" ? (
-          <Select
-            placeholder={t("loop.filter.status")}
-            multiple
-            value={f.gStatuses}
-            onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })}
-            showClear
-            maxTagCount={2}
-            size="small"
-            style={{ minWidth: 150, maxWidth: 260 }}
-          >
-            {statusOpts}
-          </Select>
-        ) : (
-          <Select
-            placeholder={t("loop.filter.status")}
-            value={f.status}
-            onChange={(v) => update({ status: v as IssueStatus | undefined })}
-            showClear
-            size="small"
-            style={{ width: 130 }}
-          >
-            {statusOpts}
-          </Select>
-        )}
-        {view === "grouped" ? (
-          <Select
-            placeholder={t("loop.filter.priority")}
-            multiple
-            value={f.gPriorities}
-            onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })}
-            showClear
-            maxTagCount={2}
-            size="small"
-            style={{ minWidth: 140, maxWidth: 240 }}
-          >
-            {priorityOpts}
-          </Select>
-        ) : (
-          <Select
-            placeholder={t("loop.filter.priority")}
-            value={f.priority}
-            onChange={(v) => update({ priority: v as IssuePriority | undefined })}
-            showClear
-            size="small"
-            style={{ width: 120 }}
-          >
-            {priorityOpts}
-          </Select>
-        )}
-        {/* assignee 单选筛选仅扁平列表/看板用(grouped 用 scope pill 按类型收窄)。 */}
-        {view !== "grouped" && (
-          <Select
-            placeholder={t("loop.filter.assignee")}
-            value={f.assignee}
-            onChange={(v) => update({ assignee: v as string | undefined })}
-            showClear
-            filter
-            size="small"
-            style={{ width: 150 }}
-          >
-            {cands.map((c) => (
-              <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
-            ))}
-          </Select>
-        )}
-        {/* 「与我相关」自带 creator=我 的并集腿,creator 下拉对它无效 → 隐藏,避免设了不生效。 */}
-        {!(view === "grouped" && scope === "involves") && (
-          <Select
-            placeholder={t("loop.filter.creator")}
-            value={f.creator}
-            onChange={(v) => update({ creator: v as string | undefined })}
-            showClear
-            filter
-            size="small"
-            style={{ width: 130 }}
-          >
-            {cands.filter((c) => c.type === "member").map((c) => (
-              <Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>
-            ))}
-          </Select>
-        )}
-        {projects.length > 0 && (view === "grouped" ? (
-          <Select
-            placeholder={t("loop.filter.project")}
-            multiple
-            value={f.gProjectIds}
-            onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })}
-            showClear
-            filter
-            maxTagCount={1}
-            size="small"
-            style={{ minWidth: 150, maxWidth: 240 }}
-          >
-            {projectOpts}
-          </Select>
-        ) : (
-          <Select
-            placeholder={t("loop.filter.project")}
-            value={f.project}
-            onChange={(v) => update({ project: v as string | undefined })}
-            showClear
-            filter
-            size="small"
-            style={{ width: 140 }}
-          >
-            {projectOpts}
-          </Select>
-        ))}
-        {/* no-project:仅分组板(后端 include_no_project 仅 /grouped 支持),与项目多选配对
-            = 所选项目 ∪ 无项目。project 维度独立于 assignee,与 scope/involves 都能正确 AND。 */}
-        {view === "grouped" && (
-          <Checkbox
-            className="loop-nofilter"
-            checked={f.noProject}
-            onChange={(e) => update({ noProject: !!e.target.checked })}
-          >
-            {t("loop.filter.noProject")}
-          </Checkbox>
-        )}
-        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-          {f.dateRange && (
-            <Select
-              value={f.dateField}
-              onChange={(v) => update({ dateField: v as IssueDateField })}
-              size="small"
-              style={{ width: 104 }}
-            >
-              {ISSUE_DATE_FIELDS.map((d) => (
-                <Select.Option key={d} value={d}>{t(`loop.dateField.${d}`)}</Select.Option>
-              ))}
-            </Select>
+        <div className="loop-page__toolbar">
+          {/* 作用域文字 tab —— grouped 视图按负责人类型收窄(all/成员/AI/与我相关)。 */}
+          {view === "grouped" && (
+            <div className="loop-agent-scope" role="tablist">
+              {(["all", "members", "agents", "involves"] as IssueScope[]).map((s) => {
+                const disabled = s === "involves" && !myMemberId;
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    role="tab"
+                    aria-selected={scope === s}
+                    disabled={disabled}
+                    className={`loop-agent-scope__btn${scope === s ? " is-active" : ""}`}
+                    onClick={() => setScope(s)}
+                  >
+                    {t(`loop.scope.${s}`)}
+                  </button>
+                );
+              })}
+            </div>
           )}
-          <DatePicker
-            type="dateRange"
-            size="small"
-            density="compact"
-            value={f.dateRange}
-            onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })}
-            placeholder={t("loop.filter.dateRange")}
-            style={{ width: 220 }}
-          />
+          <div className="loop-page__spacer" />
+          <Dropdown trigger="click" position="bottomRight" clickToHide render={filterPanel}>
+            <button className={`loop-toolbtn${activeFilters > 0 ? " is-on" : ""}`}>
+              <Filter size={14} />
+              {t("loop.action.filter")}
+              {activeFilters > 0 && <span className="loop-toolbtn__badge">{activeFilters}</span>}
+            </button>
+          </Dropdown>
+          <Dropdown trigger="click" position="bottomRight" clickToHide render={showPanel}>
+            <button className="loop-toolbtn">
+              <SlidersHorizontal size={14} />
+              {t("loop.action.show")}
+            </button>
+          </Dropdown>
+          <Button theme="solid" icon={<Plus size={14} />} onClick={openNewLoop}>
+            {t("loop.action.newIssue")}
+          </Button>
         </div>
-        {view === "list" && (
-        <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Select
-            value={f.sortBy}
-            onChange={(v) => update({ sortBy: v as IssueSortField })}
-            size="small"
-            style={{ width: 120 }}
-          >
-            {ISSUE_SORT_FIELDS.map((s) => (
-              <Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>
-            ))}
-          </Select>
-          <Button
-            size="small"
-            theme="borderless"
-            // position(手动序)后端忽略方向,禁用切换。
-            disabled={f.sortBy === "position"}
-            icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
-            aria-label={t("loop.sort.direction")}
-            onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })}
-          />
-        </div>
-        )}
-        {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
-        {view !== "grouped" && (
-          <Input
-            prefix={<Search size={14} />}
-            placeholder={t("loop.search.issue")}
-            value={f.keyword}
-            onChange={(v) => update({ keyword: v })}
-            showClear
-            style={{ width: 200 }}
-          />
-        )}
-        <Button theme="solid" icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>
-          {t("loop.action.newIssue")}
-        </Button>
       </div>
 
       <div className="loop-page__body">
@@ -448,7 +403,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
             <ClipboardList size={40} className="loop-empty__icon" />
             <div className="loop-empty__title">{t("loop.empty.issueTitle")}</div>
             <div className="loop-empty__desc">{t("loop.empty.issueDesc")}</div>
-            <Button theme="solid" icon={<Plus size={14} />} onClick={() => setCreateOpen(true)} style={{ marginTop: 12 }}>
+            <Button theme="solid" icon={<Plus size={14} />} onClick={openNewLoop} style={{ marginTop: 12 }}>
               {t("loop.action.newIssue")}
             </Button>
           </div>
@@ -472,12 +427,6 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
           </>
         )}
       </div>
-
-      <CreateIssueModal
-        visible={createOpen}
-        onClose={() => setCreateOpen(false)}
-        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); }}
-      />
     </div>
   );
 }

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -200,11 +200,11 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
     WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onMutated} />);
   };
 
-  // 新建回路 → 唤起独立 composer 页（非弹窗，对齐 Figma）。创建成功后返回并刷新列表。
+  // 新建回路 → 唤起独立 composer 页（非弹窗，对齐 Figma）。创建成功后 pop 回列表并刷新。
   const openNewLoop = () => {
     WKApp.routeRight.push(
       <NewLoopPage
-        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); }}
+        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); WKApp.routeRight.pop(); }}
       />,
     );
   };

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -81,6 +81,11 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   const [scope, setScope] = useState<IssueScope>(defaultScope ?? "all");
   const [f, setF] = useState<Filters>({ keyword: "", gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, sortBy: "position", sortDir: "desc", dateField: "created_at" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
+  // 筛选/显示 面板受控可见:不用 clickToHide(它会在点击内部 Select/DatePicker/Checkbox
+  // 时冒泡关闭,且这些控件的 portal 选项面板点击也会误触发关闭),改为显式
+  // onVisibleChange —— 仅外部点击关闭,内部多字段交互保持面板打开。
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [showOpen, setShowOpen] = useState(false);
   const cands = useAssigneeCandidates();
   // 当前 octo 成员的后端 user_id(involves_user_id 需 UUID,非 octo uid)：
   // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
@@ -374,14 +379,14 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
             </div>
           )}
           <div className="loop-page__spacer" />
-          <Dropdown trigger="click" position="bottomRight" clickToHide render={filterPanel}>
+          <Dropdown trigger="click" visible={filterOpen} onVisibleChange={setFilterOpen} position="bottomRight" render={filterPanel}>
             <button className={`loop-toolbtn${activeFilters > 0 ? " is-on" : ""}`}>
               <Filter size={14} />
               {t("loop.action.filter")}
               {activeFilters > 0 && <span className="loop-toolbtn__badge">{activeFilters}</span>}
             </button>
           </Dropdown>
-          <Dropdown trigger="click" position="bottomRight" clickToHide render={showPanel}>
+          <Dropdown trigger="click" visible={showOpen} onVisibleChange={setShowOpen} position="bottomRight" render={showPanel}>
             <button className="loop-toolbtn">
               <SlidersHorizontal size={14} />
               {t("loop.action.show")}

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -11,8 +11,8 @@ import { listWorkspaces, createWorkspace } from "../api/workspaceApi";
 import { setWorkspaceContext, currentWorkspaceId } from "../api/http";
 import { invalidateDirectory } from "../api/directory";
 import { invalidateRuntimeMap } from "../api/agentApi";
-import CreateIssueModal from "../ui/CreateIssueModal";
 import IssuePage from "./IssuePage";
+import NewLoopPage from "./NewLoopPage";
 import ProjectPage from "./ProjectPage";
 import AgentPage from "./AgentPage";
 import SquadPage from "./SquadPage";
@@ -47,7 +47,6 @@ export default function LoopPage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [wsId, setWsId] = useState<string>(currentWorkspaceId());
   const [loaded, setLoaded] = useState(false);
-  const [newIssueOpen, setNewIssueOpen] = useState(false);
   const [wsModalOpen, setWsModalOpen] = useState(false);
   const [wsName, setWsName] = useState("");
   const [wsSlug, setWsSlug] = useState("");
@@ -75,6 +74,13 @@ export default function LoopPage() {
   const openTab = (key: TabKey) => {
     setTab(key);
     WKApp.routeRight.replaceToRoot(renderTab(key, findWs(workspaces, wsId)));
+  };
+
+  // 新建回路 → 唤起 composer 独立页；成功后落到回路看板（新回路即在其中）。
+  const openNewLoop = () => {
+    WKApp.routeRight.push(
+      <NewLoopPage onCreated={() => { Toast.success(t("loop.toast.created")); openTab("issue"); }} />,
+    );
   };
 
   // 空态引导：无 workspace 时右栏提示创建
@@ -207,7 +213,7 @@ export default function LoopPage() {
       ) : (
         <>
           <div className="loop-sidebar__new">
-            <button className="loop-sidebar__new-btn" onClick={() => setNewIssueOpen(true)}>
+            <button className="loop-sidebar__new-btn" onClick={openNewLoop}>
               <SquarePen size={15} />
               <span>{t("loop.action.newIssue")}</span>
               <Plus size={14} style={{ marginLeft: "auto", opacity: 0.5 }} />
@@ -232,8 +238,6 @@ export default function LoopPage() {
           </nav>
         </>
       )}
-
-      <CreateIssueModal visible={newIssueOpen} onClose={() => setNewIssueOpen(false)} onCreated={() => openTab("issue")} />
 
       <Modal
         className="loop-modal"

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -78,8 +78,9 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
         project_id: projectId,
         attachment_ids: attachmentIds,
       });
+      // 创建成功后由调用方负责导航(pop 回列表 / 切到回路看板)——此处不再自行 back(),
+      // 避免与调用方的 replaceToRoot 叠加导致把新根也 pop 掉、右栏变空。
       onCreated?.();
-      back();
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
     } finally {

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -46,7 +46,9 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
 
   const addFiles = (files: FileList | null) => {
     if (!files?.length) return;
-    setPendingFiles((p) => [...p, ...Array.from(files)]);
+    // 同步捕获:调用点随后 e.target.value="" 会清空 FileList,延迟到 setState 更新函数里读会丢多选。
+    const arr = Array.from(files);
+    setPendingFiles((p) => [...p, ...arr]);
   };
   const removeFile = (idx: number) => setPendingFiles((p) => p.filter((_, i) => i !== idx));
 

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from "react";
+import { Select, Button, Toast, Spin } from "@douyinfe/semi-ui";
+import { ArrowLeft, Paperclip, CornerDownLeft } from "lucide-react";
+import { useI18n, WKApp } from "@octo/base";
+import type { AssigneeType, Project } from "../api/types";
+import { createIssue } from "../api/issueApi";
+import { listProjects } from "../api/projectApi";
+import { uploadAttachment } from "../api/attachmentApi";
+import AssigneePicker from "../ui/AssigneePicker";
+import AutoGrowTextarea from "../ui/AutoGrowTextarea";
+import "./loop.css";
+import "../ui/loopControls.css";
+
+export interface NewLoopPageProps {
+  /** 创建成功回调（父列表刷新 + toast）。 */
+  onCreated?: () => void;
+}
+
+// 从 prompt 派生标题：取首个非空行、裁到 ~80 字（其余保留在描述里）。
+function deriveTitle(prompt: string): string {
+  const line = prompt.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+  return line.length > 80 ? line.slice(0, 80) : line;
+}
+
+/**
+ * 新建回路独立页（对齐 Figma「把活交给 AI 队友」）：一句话 prompt + 项目/附件 + 指派 AI 队友 → 派单。
+ * 映射到现有 createIssue（title 由 prompt 派生，description=prompt，assignee=agent/squad，status=todo 触发派单）。
+ * 渲染在右主栏（routeRight.push），返回 pop。
+ */
+export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
+  const { t } = useI18n();
+  const [prompt, setPrompt] = useState("");
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [assigneeId, setAssigneeId] = useState<string | null>(null);
+  const [assigneeType, setAssigneeType] = useState<AssigneeType | null>(null);
+  const [assigneeName, setAssigneeName] = useState<string | null>(null);
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    listProjects().then(setProjects).catch(() => setProjects([]));
+  }, []);
+
+  const back = () => WKApp.routeRight.pop();
+
+  const addFiles = (files: FileList | null) => {
+    if (!files?.length) return;
+    setPendingFiles((p) => [...p, ...Array.from(files)]);
+  };
+  const removeFile = (idx: number) => setPendingFiles((p) => p.filter((_, i) => i !== idx));
+
+  const submit = async () => {
+    const text = prompt.trim();
+    if (!text || submitting) return;
+    setSubmitting(true);
+    try {
+      // 附件先上传拿 id（issue 尚不存在），再随 createIssue 绑定。单个失败只提示、不阻断建单。
+      let attachmentIds: string[] | undefined;
+      if (pendingFiles.length) {
+        const ids: string[] = [];
+        let failed = 0;
+        for (const f of pendingFiles) {
+          try { ids.push((await uploadAttachment(f)).id); } catch { failed++; }
+        }
+        if (failed) Toast.error(t("loop.toast.attachFailed", { values: { count: failed } }));
+        if (ids.length) attachmentIds = ids;
+      }
+      await createIssue({
+        title: deriveTitle(text),
+        description: text,
+        status: "todo",
+        priority: "none",
+        assignee_id: assigneeId,
+        assignee_type: assigneeType,
+        project_id: projectId,
+        attachment_ids: attachmentIds,
+      });
+      onCreated?.();
+      back();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const subtitle = assigneeName
+    ? t("loop.newLoop.subtitle", { values: { name: assigneeName } })
+    : t("loop.newLoop.subtitleGeneric");
+
+  const examples = [
+    { title: t("loop.newLoop.ex1Title"), desc: t("loop.newLoop.ex1Desc"), prompt: t("loop.newLoop.ex1Prompt") },
+    { title: t("loop.newLoop.ex2Title"), desc: t("loop.newLoop.ex2Desc"), prompt: t("loop.newLoop.ex2Prompt") },
+    { title: t("loop.newLoop.ex3Title"), desc: t("loop.newLoop.ex3Desc"), prompt: t("loop.newLoop.ex3Prompt") },
+  ];
+
+  return (
+    <div className="loop-page loop-newloop">
+      <div className="loop-newloop__bar-top">
+        <Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>
+          {t("loop.detail.back")}
+        </Button>
+      </div>
+
+      <div className="loop-newloop__inner">
+        <div className="loop-newloop__hero">
+          <h2 className="loop-newloop__title">{t("loop.newLoop.title")}</h2>
+          <p className="loop-newloop__subtitle">{subtitle}</p>
+        </div>
+
+        <div className="loop-newloop__composer">
+          <AutoGrowTextarea
+            className="loop-field-textarea loop-field-textarea--lg loop-field-textarea--auto loop-newloop__input"
+            value={prompt}
+            onChange={setPrompt}
+            placeholder={t("loop.newLoop.placeholder")}
+            autoFocus
+            onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submit(); }}
+          />
+          <div className="loop-newloop__composer-bar">
+            <div className="loop-newloop__composer-left">
+              <Select
+                value={projectId ?? undefined}
+                onChange={(v) => setProjectId((v as string) ?? null)}
+                dropdownClassName="loop-fields__dropdown"
+                size="small"
+                showClear
+                placeholder={t("loop.newLoop.noProject")}
+                style={{ width: 150 }}
+              >
+                {projects.map((p) => (
+                  <Select.Option key={p.id} value={p.id}>{p.icon} {p.title}</Select.Option>
+                ))}
+              </Select>
+              <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
+                <Paperclip size={16} />
+                <input type="file" multiple hidden disabled={submitting} onChange={(e) => { addFiles(e.target.files); e.target.value = ""; }} />
+              </label>
+            </div>
+            <div className="loop-newloop__composer-right">
+              <div className="loop-newloop__assignee">
+                <AssigneePicker
+                  types={["agent", "squad"]}
+                  value={assigneeId}
+                  valueName={assigneeName}
+                  onChange={(id, type, name) => { setAssigneeId(id); setAssigneeType(type); setAssigneeName(name); }}
+                />
+              </div>
+              <Button theme="solid" loading={submitting} disabled={!prompt.trim()} onClick={submit} icon={<CornerDownLeft size={14} />} iconPosition="right">
+                {t("loop.newLoop.dispatch")}
+              </Button>
+            </div>
+          </div>
+          {pendingFiles.length > 0 && (
+            <div className="loop-atts loop-newloop__atts">
+              {pendingFiles.map((f, i) => (
+                <span key={i} className="loop-att loop-att--pending">
+                  <Paperclip size={12} />
+                  <span>{f.name}</span>
+                  <button type="button" aria-label={t("loop.action.delete")} onClick={() => removeFile(i)}>×</button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="loop-newloop__examples">
+          <div className="loop-newloop__examples-head">{t("loop.newLoop.examplesTitle")}</div>
+          <div className="loop-newloop__examples-grid">
+            {examples.map((ex) => (
+              <button key={ex.title} type="button" className="loop-newloop__example" onClick={() => setPrompt(ex.prompt)}>
+                <strong>{ex.title}</strong>
+                <span>{ex.desc}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {submitting && <div className="loop-newloop__overlay"><Spin /></div>}
+    </div>
+  );
+}

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -137,6 +137,109 @@
   height: 60%;
 }
 
+/* 页头：标题行 + 工具栏行（对齐 Figma：左作用域 tab，右 筛选/显示） */
+.loop-page__head--stack {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  padding: 20px 24px 8px;
+}
+
+.loop-page__title-row {
+  display: flex;
+  align-items: center;
+}
+
+.loop-page__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-page__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+}
+
+/* 工具栏按钮（筛选 / 显示）：白底描边胶囊 */
+.loop-toolbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  background: var(--semi-color-bg-0, #fff);
+  color: var(--semi-color-text-1, #555b61);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.loop-toolbtn:hover {
+  border-color: var(--semi-color-text-3, #c9cdd4);
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-toolbtn.is-on {
+  border-color: var(--semi-color-primary, #6a5cff);
+  color: var(--semi-color-primary, #6a5cff);
+  background: var(--semi-color-primary-light-default, #eef2ff);
+}
+
+.loop-toolbtn__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--semi-color-primary, #6a5cff);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* 筛选 / 显示 面板 */
+.loop-filter-panel,
+.loop-show-panel {
+  width: 300px;
+  max-height: 70vh;
+  overflow: auto;
+  padding: 14px 16px;
+  gap: 12px;
+}
+
+.loop-filter-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-filter-panel__clear {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--semi-color-primary, #6a5cff);
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+
+.loop-filter-panel__clear:hover {
+  background: var(--semi-color-primary-light-default, #eef2ff);
+}
+
 /* ===== Skill 列表页头部 ===== */
 .loop-skill-page-head {
   display: flex;
@@ -213,6 +316,160 @@
   min-height: 30px;
   display: flex;
   align-items: center;
+}
+
+/* ===== 新建回路 composer 页 ===== */
+.loop-newloop {
+  position: relative;
+  overflow: auto;
+}
+
+.loop-newloop__bar-top {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.loop-newloop__inner {
+  width: min(680px, 100%);
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.loop-newloop__hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 24px;
+}
+
+.loop-newloop__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-newloop__subtitle {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-newloop__composer {
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 12px;
+  background: var(--semi-color-bg-0, #fff);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.loop-newloop__input.loop-field-textarea {
+  border: none;
+  box-shadow: none;
+  min-height: 92px;
+  padding: 4px 2px;
+}
+
+.loop-newloop__input.loop-field-textarea:hover,
+.loop-newloop__input.loop-field-textarea:focus {
+  border: none;
+  box-shadow: none;
+}
+
+.loop-newloop__composer-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.loop-newloop__composer-left,
+.loop-newloop__composer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.loop-newloop__assignee {
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 8px;
+  padding: 2px 4px;
+}
+
+.loop-newloop__atts {
+  margin-top: 0;
+}
+
+.loop-newloop__examples {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.loop-newloop__examples-head {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-1, #4e5969);
+}
+
+.loop-newloop__examples-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.loop-newloop__example {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 10px;
+  background: var(--semi-color-bg-0, #fff);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.loop-newloop__example:hover {
+  border-color: var(--semi-color-text-3, #c9cdd4);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.loop-newloop__example strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-newloop__example span {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-newloop__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+@media (max-width: 720px) {
+  .loop-newloop__examples-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ===== 空状态引导 ===== */
@@ -356,7 +613,7 @@
 .loop-board {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(240px, 1fr);
+  grid-auto-columns: 296px;
   gap: 12px;
   height: 100%;
   overflow-x: auto;
@@ -366,79 +623,134 @@
 .loop-board__col {
   display: flex;
   flex-direction: column;
-  background: var(--semi-color-fill-0, #f6f7f9);
+  /* 浅色轨道背景：即使整列为空也保有辨识度（对齐用户反馈，克制不花哨） */
+  background: var(--semi-color-fill-0, #f5f6f8);
+  border: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.05));
   border-radius: 10px;
-  min-height: 120px;
+  padding: 0 8px 8px;
+  min-height: 96px;
 }
 
 .loop-board__col.is-drop {
-  outline: 2px dashed var(--semi-color-primary, #6a5cff);
-  outline-offset: -2px;
+  border-color: var(--semi-color-primary, #6a5cff);
+  outline: 1px solid var(--semi-color-primary, #6a5cff);
+  background: var(--semi-color-primary-light-default, #eef2ff);
 }
 
 .loop-board__col-head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 12px 6px;
-  font-size: 12px;
+  gap: 8px;
+  height: 38px;
+  padding: 0 4px;
+  font-size: 13px;
   font-weight: 600;
+  flex: 0 0 auto;
+}
+
+.loop-board__col-name {
+  color: var(--semi-color-text-0, #1f2329);
 }
 
 .loop-board__col-head em {
   margin-left: auto;
   font-style: normal;
-  color: var(--semi-color-text-2, #8590a6);
+  font-weight: 500;
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-variant-numeric: tabular-nums;
 }
 
 .loop-board__cards {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 6px 10px 12px;
+  padding: 2px 0 4px;
   overflow: auto;
   flex: 1;
+  min-height: 0;
 }
 
 .loop-card {
   background: var(--semi-color-bg-0, #fff);
-  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.08));
   border-radius: 8px;
-  padding: 10px 12px;
+  padding: 11px 13px;
   cursor: grab;
   text-align: left;
   width: 100%;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.06);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .loop-card:hover {
-  border-color: var(--semi-color-primary, #6a5cff);
+  border-color: var(--semi-color-text-3, #c9cdd4);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .loop-card.is-dragging {
   opacity: 0.4;
 }
 
-.loop-card__key {
-  font-size: 11px;
-  color: var(--semi-color-text-2, #8590a6);
+.loop-card__top {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
+.loop-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loop-card__id {
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11.5px;
+  color: var(--semi-color-text-3, #b8bcc8);
+}
+
+.loop-card__time {
+  margin-left: auto;
+  font-size: 11.5px;
+  color: var(--semi-color-text-2, #8590a6);
+  white-space: nowrap;
+}
+
 .loop-card__title {
   font-size: 13px;
-  font-weight: 500;
-  margin: 3px 0 8px;
-  line-height: 1.4;
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--semi-color-text-0, #1f2329);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.loop-card__labels {
+  margin-top: -2px;
 }
 
 .loop-card__foot {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+}
+
+.loop-card__project {
+  font-size: 12px;
+  color: var(--semi-color-text-2, #6b7075);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 150px;
+}
+
+.loop-card__spacer {
+  flex: 1;
 }
 
 .loop-card__due {
@@ -446,16 +758,6 @@
   align-items: center;
   gap: 3px;
   font-size: 12px;
-}
-
-/* ===== 通用表格辅助 ===== */
-.loop-cell-title {
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.loop-cell-title:hover {
-  color: var(--semi-color-primary, #6a5cff);
 }
 
 /* ===== AI队友列表（行） ===== */
@@ -838,6 +1140,22 @@
   color: var(--semi-color-text-2, #8590a6);
 }
 
+/* 只读指派徽标：中性胶囊，图标形状区分类型（不用高亮紫/蓝底，避免突兀） */
+.loop-abadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 160px;
+  padding: 2px 9px 2px 7px;
+  border-radius: 999px;
+  background: var(--semi-color-fill-0, #f2f3f5);
+  color: var(--semi-color-text-1, #4e5969);
+  font-size: 12px;
+  line-height: 18px;
+}
+.loop-abadge svg { color: var(--semi-color-text-2, #8a8f99); flex: 0 0 auto; }
+.loop-abadge__name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
 /* ===== 详情抽屉 ===== */
 .loop-detail {
   display: flex;
@@ -872,49 +1190,6 @@
 
 .loop-detail__fields dd {
   margin: 0;
-}
-
-/* ===== 评论 ===== */
-.loop-comments {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.loop-comment {
-  border: 1px solid var(--semi-color-border, #e8e9eb);
-  border-radius: 8px;
-  padding: 10px 12px;
-}
-
-.loop-comment.is-reply {
-  margin-left: 28px;
-  background: var(--semi-color-fill-0, #f7f8fa);
-}
-
-.loop-comment__head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
-}
-
-.loop-comment__head time {
-  font-size: 11px;
-  color: var(--semi-color-text-2, #8590a6);
-}
-
-.loop-comment__actions {
-  margin-left: auto;
-  display: flex;
-  gap: 6px;
-}
-
-.loop-comment__body {
-  font-size: 13px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
 }
 
 /* 从运行时拷贝技能列表 */
@@ -1185,6 +1460,145 @@
   margin-bottom: 8px;
   background: var(--semi-color-fill-0, #f6f7f9);
   border-radius: 8px;
+  font-size: 13px;
+}
+
+/* ---------- 列表视图（按状态分组的清爽行） ---------- */
+.loop-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.loop-list__group {
+  display: flex;
+  flex-direction: column;
+}
+
+.loop-list__group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.loop-list__group-name {
+  color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-list__group-head em {
+  font-style: normal;
+  font-weight: 500;
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-variant-numeric: tabular-nums;
+}
+
+.loop-list__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 38px;
+  padding: 5px 6px;
+  border-radius: 8px;
+  transition: background-color 120ms ease;
+}
+
+.loop-list__row:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+
+.loop-list__row.is-selected {
+  background: var(--semi-color-primary-light-default, #eef2ff);
+}
+
+.loop-list__check {
+  display: inline-flex;
+  align-items: center;
+  width: 16px;
+  flex: 0 0 auto;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.loop-list__row:hover .loop-list__check,
+.loop-list__row.is-selected .loop-list__check {
+  opacity: 1;
+}
+
+.loop-list__check input {
+  cursor: pointer;
+  accent-color: var(--semi-color-primary, #6a5cff);
+}
+
+.loop-list__icon {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.loop-list__title {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 620px;
+}
+
+.loop-list__title:hover {
+  color: var(--semi-color-primary, #6a5cff);
+}
+
+.loop-list__spacer {
+  flex: 1;
+}
+
+.loop-list__project {
+  font-size: 12px;
+  color: var(--semi-color-text-2, #6b7075);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+  flex: 0 0 auto;
+}
+
+.loop-list__id {
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11.5px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  flex: 0 0 auto;
+}
+
+.loop-list__assignee {
+  flex: 0 0 auto;
+}
+
+.loop-list__time {
+  width: 80px;
+  text-align: right;
+  font-size: 12px;
+  color: var(--semi-color-text-2, #8590a6);
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 900px) {
+  .loop-list__project { display: none; }
+  .loop-list__title { max-width: 320px; }
 }
 
 /* ---------- 分组板 no-* 复选(含无负责人/无项目) ---------- */

--- a/packages/dmloop/src/panel/IssueBoard.tsx
+++ b/packages/dmloop/src/panel/IssueBoard.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
-import { Tag } from "@douyinfe/semi-ui";
 import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus } from "../api/types";
 import { updateIssue } from "../api/issueApi";
 import IssueCard from "../ui/IssueCard";
 import { useRunConfirm } from "../ui/RunConfirmModal";
-import { ISSUE_STATUS_ORDER, ISSUE_STATUS_COLOR } from "../ui/meta";
+import { ISSUE_STATUS_ORDER, ISSUE_STATUS_ICON, ISSUE_STATUS_HEX } from "../ui/meta";
 
 export interface IssueBoardProps {
   issues: Issue[];
@@ -45,6 +44,7 @@ export default function IssueBoard({
     <div className="loop-board">
       {ISSUE_STATUS_ORDER.map((status) => {
         const cards = issues.filter((i) => i.status === status);
+        const StatusIcon = ISSUE_STATUS_ICON[status];
         return (
           <div
             key={status}
@@ -62,9 +62,8 @@ export default function IssueBoard({
             onDrop={() => handleDrop(status)}
           >
             <div className="loop-board__col-head">
-              <Tag color={ISSUE_STATUS_COLOR[status]} size="small">
-                {t(`loop.status.${status}`)}
-              </Tag>
+              <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[status] }} />
+              <span className="loop-board__col-name">{t(`loop.status.${status}`)}</span>
               <em>{cards.length}</em>
             </div>
             <div className="loop-board__cards">

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -8,15 +8,13 @@ import {
   Spin,
   Toast,
   Dropdown,
-  DatePicker,
-  InputNumber,
 } from "@douyinfe/semi-ui";
 import {
   ArrowLeft,
   Trash2,
-  CornerDownRight,
   Send,
   MoreHorizontal,
+  Copy,
   CircleSlash,
   Pencil,
   Check,
@@ -25,6 +23,7 @@ import {
   Bell,
   BellOff,
   Paperclip,
+  FileText,
   AtSign,
   Plus,
   ChevronRight,
@@ -49,7 +48,6 @@ import {
   deleteIssue,
   listComments,
   listChildren,
-  listIssues,
   addComment,
   deleteComment,
   updateComment,
@@ -69,8 +67,7 @@ import {
 } from "../api/collabApi";
 import { uploadAttachment } from "../api/attachmentApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
-import AssigneePicker from "../ui/AssigneePicker";
-import LabelEditor from "../ui/LabelEditor";
+import { AssigneeBadge } from "../ui/AssigneePicker";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -94,6 +91,75 @@ import {
 import "./issueDetail.css";
 
 const { Text } = Typography;
+
+// 线程回复输入：常驻在每张评论卡底部(对标 multica),各自独立 draft/附件(不共享全局状态),
+// 提交成功后清空。回评一律归到该线程根评论;附件在评论创建后绑到 commentId(见 replyToThread)。
+function ThreadReply({
+  onSubmit,
+  placeholder,
+  sendLabel,
+}: {
+  onSubmit: (content: string, files: File[]) => Promise<boolean>;
+  placeholder: string;
+  sendLabel: string;
+}) {
+  const { t } = useI18n();
+  const [draft, setDraft] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [busy, setBusy] = useState(false);
+  const submit = async () => {
+    const c = draft.trim();
+    if ((!c && files.length === 0) || busy) return;
+    setBusy(true);
+    const ok = await onSubmit(c, files);
+    setBusy(false);
+    if (ok) { setDraft(""); setFiles([]); }
+  };
+  return (
+    <div className="loop-cmt__reply">
+      <div className="loop-cmt__reply-row">
+        <input
+          className="loop-field"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={placeholder}
+          disabled={busy}
+          onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+        />
+        <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
+          <Paperclip size={16} />
+          <input
+            type="file"
+            multiple
+            hidden
+            disabled={busy}
+            onChange={(e) => {
+              // 先同步捕获选中文件再清空 value：若在异步 setFiles 里读 e.target.files,
+              // value 已被重置、FileList 清空,会丢掉多选文件(只剩一个/为空)。
+              const picked = Array.from(e.target.files ?? []);
+              e.target.value = "";
+              if (picked.length) setFiles((p) => [...p, ...picked]);
+            }}
+          />
+        </label>
+        <Button theme="solid" icon={<Send size={14} />} onClick={submit} loading={busy} disabled={!draft.trim() && files.length === 0} aria-label={sendLabel} />
+      </div>
+      {files.length > 0 && (
+        <div className="loop-filechips">
+          {files.map((f, i) => (
+            <div key={i} className="loop-filechip">
+              <FileText size={16} className="loop-filechip__icon" />
+              <span className="loop-filechip__name">{f.name}</span>
+              <button type="button" className="loop-filechip__act" onClick={() => setFiles((p) => p.filter((_, idx) => idx !== i))} aria-label={t("loop.action.delete")}>
+                <Trash2 size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function fmt(iso?: string | null): string {
   if (!iso) return "-";
@@ -120,11 +186,15 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [children, setChildren] = useState<Issue[]>([]);
   const [childCreateOpen, setChildCreateOpen] = useState(false); // 新建子 issue 弹窗
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
-  const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
   const [runOpen, setRunOpen] = useState(false);
   const [showRuns, setShowRuns] = useState(false); // 「执行日志」折叠展开
+  const [collapsedSecs, setCollapsedSecs] = useState<Set<string>>(new Set()); // 右栏分区折叠
+  // 动态块展开态：最后一个动态块默认展开(第一次进来即见最新动态,对标 multica);
+  // expandedActs=被显式展开的(非默认块),collapsedActs=被显式折叠的(默认块)。二者覆盖默认。
+  const [expandedActs, setExpandedActs] = useState<Set<string>>(new Set());
+  const [collapsedActs, setCollapsedActs] = useState<Set<string>>(new Set());
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
@@ -155,7 +225,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setChildren([]);
     setSubscribers([]);
     setSubLoaded(false);
-    setParentCands([]);
     setTimeline([]);
     Promise.all([getIssue(issueId), listComments(issueId), listRuns(issueId)])
       .then(([i, c, r]) => {
@@ -204,17 +273,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const reloadComments = async (token: number) => {
     const c = await listComments(issueId);
     if (token === reqRef.current) setComments(c);
-  };
-
-  // 父 issue 选择器:下拉展开时懒加载工作区 issue 作候选(排除自己;环检测由后端兜底)。
-  const loadParentCands = (open: boolean) => {
-    if (!open || parentCands.length) return;
-    const token = reqRef.current;
-    // ponytail: 取前 100 条工作区 issue + Select 客户端过滤;小工作区够用,
-    // 大工作区需服务端 search-as-you-type,留给 UI 重做。
-    listIssues({ limit: 100 })
-      .then((r) => { if (token === reqRef.current) setParentCands(r.issues.filter((i) => i.id !== issueId)); })
-      .catch(() => {});
   };
 
   // 订阅/取消订阅(后端默认操作调用者本人、幂等)。
@@ -306,7 +364,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   // 避免像 issue-first 那样在评论发出前就产生 issue 级孤儿附件。取消/离开=什么都没上传。
   const addPendingFiles = (files: FileList | null) => {
     if (!files?.length) return;
-    setPendingFiles((p) => [...p, ...Array.from(files)]);
+    // 同步捕获数组:调用点随后会 e.target.value="" 清空 FileList,若在 setState 更新函数里再读会丢多选文件。
+    const arr = Array.from(files);
+    setPendingFiles((p) => [...p, ...arr]);
   };
   const removePendingFile = (idx: number) => setPendingFiles((p) => p.filter((_, i) => i !== idx));
 
@@ -419,6 +479,27 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   const toggleSuppress = (id: string) =>
     setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
+
+  // 线程回复:回评归到根评论(parent=rootId)。附件在评论创建后带 commentId 绑定(逐个隔离,失败只提示)。
+  // 成功返回 true 供输入框清空。
+  const replyToThread = async (rootId: string, content: string, files: File[]): Promise<boolean> => {
+    const token = reqRef.current;
+    let comment: IssueComment;
+    try {
+      comment = await addComment(issueId, content, rootId, []);
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      return false;
+    }
+    let failed = 0;
+    for (const f of files) {
+      try { await uploadAttachment(f, { commentId: comment.id }); } catch { failed++; }
+    }
+    if (failed) Toast.error(t("loop.toast.commentAttachFailed", { values: { count: failed } }));
+    else Toast.success(t("loop.toast.commentAdded"));
+    try { await reloadComments(token); } catch { /* 刷新失败:下次 reload 自愈 */ }
+    return true;
+  };
 
   const removeComment = (id: string) => {
     const token = reqRef.current;
@@ -629,30 +710,52 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const childrenDone = children.filter((c) => c.status === "done").length;
   // issue 附件区只显 issue 级(comment_id 为空);评论附件归各评论下,避免重复。
   const issueAtts = (issue.attachments ?? []).filter((a) => !a.comment_id);
+  const StatusIcon = ISSUE_STATUS_ICON[issue.status];
+  const PriIcon = PRIORITY_ICON[issue.priority];
+  const secOpen = (k: string) => !collapsedSecs.has(k);
+  const toggleSec = (k: string) =>
+    setCollapsedSecs((s) => { const n = new Set(s); if (n.has(k)) n.delete(k); else n.add(k); return n; });
 
-  // 评论渲染（评论 + 其回复；无 emoji 反应）。
-  const renderComment = (c: IssueComment, reply = false) => (
-    <div key={c.id} className={`loop-comment ${reply ? "is-reply" : ""}`}>
-      <div className="loop-comment__head">
+  // 评论线程(对标 multica)：主评论为首行,其所有回评都是同级平铺行(分隔线区分先后,不缩进)；
+  // 卡片底部一个回复输入。任何回评都归到主评论(parent=root),视觉上像一张「主评论 + 评审意见」表。
+  const renderRow = (c: IssueComment, isRoot: boolean, rootId: string) => (
+    <div key={c.id} className={`loop-cmt__row${isRoot ? " is-root" : ""}`}>
+      <div className="loop-cmt__head">
         <Avatar size="extra-extra-small" color="light-blue" src={c.author_avatar ?? undefined}>
           {(c.author_name ?? "?").slice(0, 1)}
         </Avatar>
-        <Text strong style={{ fontSize: 12 }}>{c.author_name}</Text>
+        <Text strong style={{ fontSize: 13 }}>{c.author_name}</Text>
         <time>{fmt(c.created_at)}</time>
-        {c.resolved_at && <Tag size="small" color="green">{t("loop.comment.resolved")}</Tag>}
-        <div className="loop-comment__actions">
-          {!reply && (
-            <Button size="small" theme="borderless" icon={<CornerDownRight size={13} />} onClick={() => { setReplyTo(replyTo === c.id ? null : c.id); setEditingId(null); }} aria-label={t("loop.comment.reply")} />
-          )}
-          {!reply && (
-            <Button size="small" theme="borderless" icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />} onClick={() => toggleResolve(c.id, !!c.resolved_at)} aria-label={t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")} />
-          )}
-          <Button size="small" theme="borderless" icon={<Pencil size={13} />} onClick={() => { setEditingId(c.id); setEditDraft(c.content); setReplyTo(null); }} aria-label={t("loop.action.edit")} />
-          <Button size="small" theme="borderless" type="danger" icon={<Trash2 size={13} />} onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })} aria-label={t("loop.action.delete")} />
+        {c.resolved_at && <span className="loop-cmt__resolved">{t("loop.comment.resolved")}</span>}
+        <div className="loop-cmt__actions">
+          <Dropdown
+            trigger="click"
+            position="bottomRight"
+            clickToHide
+            render={
+              <Dropdown.Menu>
+                <Dropdown.Item icon={<Copy size={13} />} onClick={() => { navigator.clipboard?.writeText(c.content).then(() => Toast.success(t("loop.run.copied"))).catch(() => {}); }}>
+                  {t("loop.action.copy")}
+                </Dropdown.Item>
+                <Dropdown.Item icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />} onClick={() => toggleResolve(c.id, !!c.resolved_at)}>
+                  {t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")}
+                </Dropdown.Item>
+                <Dropdown.Item icon={<Pencil size={13} />} onClick={() => { setEditingId(c.id); setEditDraft(c.content); }}>
+                  {t("loop.action.edit")}
+                </Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })}>
+                  {t("loop.action.delete")}
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            }
+          >
+            <Button size="small" theme="borderless" icon={<MoreHorizontal size={15} />} aria-label={t("loop.action.more")} />
+          </Dropdown>
         </div>
       </div>
       {editingId === c.id ? (
-        <div className="loop-comment__body" style={{ marginTop: 6 }}>
+        <div className="loop-cmt__body" style={{ marginTop: 6 }}>
           <AutoGrowTextarea className="loop-field-textarea loop-field-textarea--auto" value={editDraft} onChange={setEditDraft} />
           <div style={{ marginTop: 6, display: "flex", gap: 8 }}>
             <Button size="small" theme="solid" onClick={() => saveEdit(c.id)}>{t("loop.action.save")}</Button>
@@ -660,22 +763,21 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </div>
         </div>
       ) : (
-        <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
+        <div className="loop-cmt__body"><LoopMarkdown content={c.content} /></div>
       )}
       {renderAttachments(c.attachments)}
-      {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
-      {!reply && replyTo === c.id && (
-        <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
-          <input
-            className="loop-field"
-            value={commentDraft}
-            onChange={(e) => setCommentDraft(e.target.value)}
-            placeholder={t("loop.comment.replyPlaceholder")}
-            onKeyDown={(e) => { if (e.key === "Enter") submitComment(); }}
-          />
-          <Button icon={<Send size={14} />} onClick={submitComment} aria-label={t("loop.comment.send")} />
-        </div>
-      )}
+    </div>
+  );
+
+  const renderComment = (root: IssueComment) => (
+    <div key={root.id} className="loop-cmt">
+      {renderRow(root, true, root.id)}
+      {repliesOf(root.id).map((r) => renderRow(r, false, root.id))}
+      <ThreadReply
+        onSubmit={(content, files) => replyToThread(root.id, content, files)}
+        placeholder={t("loop.comment.replyPlaceholder")}
+        sendLabel={t("loop.comment.send")}
+      />
     </div>
   );
 
@@ -683,7 +785,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   // 对齐 Figma —— 不再把「活动」「评论」拆成两个挤在一起的区块。timeline 为 ASC。
   const activities = timeline.filter((e) => e.type === "activity");
   // 活动文案人话化：后端 action 是机器串(如 status_changed),普通运营看不懂。按语义归类成中文；
-  // 订阅类噪声直接隐藏(返回 null → 不渲染)；未知归为通用「更新了这个回路」，绝不暴露原始串。
+  // 订阅类噪声直接隐藏(返回 null → 不渲染、不计数)；未知归为通用「更新了这个回路」，绝不暴露原始串。
   const activityText = (action?: string): string | null => {
     if (!action) return null;
     const a = action.toLowerCase();
@@ -701,25 +803,69 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (a.includes("clos") || a.includes("complet") || a.includes("done")) return t("loop.activityAction.completed");
     return t("loop.activityAction.generic");
   };
-  const feed: Array<{ ts: string; node: React.ReactNode }> = [
-    ...activities.flatMap((a) => {
-      const verb = activityText(a.action);
-      if (!verb) return [];
-      return [{
-        ts: a.created_at,
-        node: (
-          <div key={`a-${a.id}`} className="loop-feed__act">
-            <span className="loop-feed__act-dot" />
-            <span className="loop-feed__act-text">
-              <strong>{a.actor_name ?? a.actor_id}</strong> {verb}
-            </span>
-            <time>{fmt(a.created_at)}</time>
-          </div>
-        ),
-      }];
-    }),
-    ...roots.map((c) => ({ ts: c.created_at, node: renderComment(c) })),
+
+  // 动态区(对标 multica)：根评论与「有意义的活动」按时间升序合并；连续活动归并成一个折叠动态块，
+  // 评论各自独立成卡片。噪声活动(activityText 为 null)先过滤，不进块、不计数。
+  const visibleActs = activities.filter((a) => activityText(a.action) !== null);
+  type FeedNode = { ts: string; c?: IssueComment; a?: TimelineEntry };
+  const seq: FeedNode[] = [
+    ...roots.map((c) => ({ ts: c.created_at, c })),
+    ...visibleActs.map((a) => ({ ts: a.created_at, a })),
   ].sort((x, y) => new Date(x.ts).getTime() - new Date(y.ts).getTime());
+  type FeedGroup =
+    | { kind: "comment"; comment: IssueComment }
+    | { kind: "acts"; id: string; entries: TimelineEntry[] };
+  const feedGroups: FeedGroup[] = [];
+  for (const n of seq) {
+    if (n.c) {
+      feedGroups.push({ kind: "comment", comment: n.c });
+    } else if (n.a) {
+      const last = feedGroups[feedGroups.length - 1];
+      if (last && last.kind === "acts") last.entries.push(n.a);
+      else feedGroups.push({ kind: "acts", id: n.a.id, entries: [n.a] });
+    }
+  }
+
+  // 最后一个动态块默认展开(用户可再折叠);其余默认折叠(用户可再展开)。
+  let lastActsId: string | null = null;
+  for (const g of feedGroups) if (g.kind === "acts") lastActsId = g.id;
+  const isActsOpen = (id: string) =>
+    collapsedActs.has(id) ? false : (expandedActs.has(id) || id === lastActsId);
+  const toggleActs = (id: string, open: boolean) => {
+    if (open) {
+      setCollapsedActs((s) => new Set(s).add(id));
+      setExpandedActs((s) => { const n = new Set(s); n.delete(id); return n; });
+    } else {
+      setExpandedActs((s) => new Set(s).add(id));
+      setCollapsedActs((s) => { const n = new Set(s); n.delete(id); return n; });
+    }
+  };
+
+  // 单个折叠动态块：折叠时只一行「N 条动态」(chevron-right,小灰字);展开显示每条活动小行。
+  const renderActsBlock = (g: { id: string; entries: TimelineEntry[] }) => {
+    const open = isActsOpen(g.id);
+    return (
+      <div key={`acts-${g.id}`} className="loop-acts">
+        <button type="button" className="loop-acts__toggle" onClick={() => toggleActs(g.id, open)}>
+          <ChevronRight size={13} className={`loop-acts__chevron${open ? " is-open" : ""}`} />
+          <span>{t("loop.activity.count", { values: { count: g.entries.length } })}</span>
+        </button>
+        {open && (
+          <div className="loop-acts__list">
+            {g.entries.map((a) => (
+              <div key={a.id} className="loop-acts__item">
+                <span className="loop-acts__dot" />
+                <span className="loop-acts__text">
+                  <strong>{a.actor_name ?? a.actor_id}</strong> {activityText(a.action)}
+                </span>
+                <time>{fmt(a.created_at)}</time>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="loop-idp">
@@ -837,10 +983,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             </div>
 
             <div className="loop-feed">
-              {feed.length === 0 ? (
+              {feedGroups.length === 0 ? (
                 <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.empty")}</Text>
               ) : (
-                feed.map((it) => it.node)
+                feedGroups.map((g) =>
+                  g.kind === "comment" ? renderComment(g.comment) : renderActsBlock(g),
+                )
               )}
             </div>
 
@@ -924,172 +1072,120 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </div>
         </div>
 
-        {/* 右侧属性栏 */}
+        {/* 右侧属性栏（只读展示,对齐 Figma 29-1593；改属性走右上角 ⋯ 菜单，对标 multica） */}
         <aside className="loop-idp__aside">
           <section className="loop-idp__asec">
-            <div className="loop-idp__asec-head">{t("loop.detail.properties")}</div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.status")}</span>
-              <Select
-                value={issue.status}
-                onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
-                dropdownClassName="loop-fields__dropdown"
-                size="small"
-                style={{ width: "100%" }}
-              >
-                {ISSUE_STATUS_ORDER.map((s) => (
-                  <Select.Option key={s} value={s}>
-                    <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
-                  </Select.Option>
-                ))}
-              </Select>
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.priority")}</span>
-              <Select
-                value={issue.priority}
-                onChange={(v) => patch({ priority: v as IssuePriority })}
-                dropdownClassName="loop-fields__dropdown"
-                size="small"
-                style={{ width: "100%" }}
-              >
-                {PRIORITY_ORDER.map((p) => (
-                  <Select.Option key={p} value={p}>
-                    <Tag color={PRIORITY_COLOR[p]} size="small">{t(`loop.priority.${p}`)}</Tag>
-                  </Select.Option>
-                ))}
-              </Select>
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.assignee")}</span>
-              <AssigneePicker
-                value={issue.assignee_id}
-                valueName={issue.assignee_name ?? null}
-                onChange={(id, type, name) => requestAssign(issue, type, id, name, (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }))}
-              />
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.project")}</span>
-              <span className="loop-idp__prop-v">{issue.project_name ?? "—"}</span>
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.labels")}</span>
-              <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.parent")}</span>
-              <Select
-                value={issue.parent_issue_id ?? undefined}
-                onChange={(v) => patch({ parent_issue_id: (v as string) || "" })}
-                onDropdownVisibleChange={loadParentCands}
-                dropdownClassName="loop-fields__dropdown"
-                placeholder={t("loop.field.noParent")}
-                size="small"
-                filter
-                showClear
-                style={{ width: "100%" }}
-              >
-                {parentCands.map((i) => (
-                  <Select.Option key={i.id} value={i.id}>{i.identifier} {i.title}</Select.Option>
-                ))}
-              </Select>
-            </div>
-            <div className="loop-idp__prop-row2">
-              <div className="loop-idp__prop">
-                <span className="loop-idp__prop-k">{t("loop.field.startDate")}</span>
-                <DatePicker
-                  type="date"
-                  format="yyyy-MM-dd"
-                  value={issue.start_date ? issue.start_date.slice(0, 10) : undefined}
-                  onChange={(_, ds) => patch({ start_date: (ds as string) || "" })}
-                  size="small"
-                  style={{ width: "100%" }}
-                />
+            <button type="button" className="loop-idp__asec-head" onClick={() => toggleSec("props")}>
+              <ChevronRight size={13} className={`loop-idp__asec-chevron${secOpen("props") ? " is-open" : ""}`} />
+              {t("loop.detail.properties")}
+            </button>
+            {secOpen("props") && (
+              <div className="loop-idp__asec-body">
+                <div className="loop-idp__prop">
+                  <span className="loop-idp__prop-k">{t("loop.field.status")}</span>
+                  <span className="loop-idp__prop-val">
+                    <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[issue.status] }} />
+                    {t(`loop.status.${issue.status}`)}
+                  </span>
+                </div>
+                <div className="loop-idp__prop">
+                  <span className="loop-idp__prop-k">{t("loop.field.priority")}</span>
+                  <span className="loop-idp__prop-val">
+                    <PriIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[issue.priority] }} />
+                    {t(`loop.priority.${issue.priority}`)}
+                  </span>
+                </div>
+                <div className="loop-idp__prop">
+                  <span className="loop-idp__prop-k">{t("loop.field.assignee")}</span>
+                  <AssigneeBadge type={issue.assignee_type} name={issue.assignee_name ?? null} />
+                </div>
+                <div className="loop-idp__prop">
+                  <span className="loop-idp__prop-k">{t("loop.field.project")}</span>
+                  <span className="loop-idp__prop-v">{issue.project_name ?? "—"}</span>
+                </div>
               </div>
-              <div className="loop-idp__prop">
-                <span className="loop-idp__prop-k">{t("loop.field.dueDate")}</span>
-                <DatePicker
-                  type="date"
-                  format="yyyy-MM-dd"
-                  value={issue.due_date ? issue.due_date.slice(0, 10) : undefined}
-                  onChange={(_, ds) => patch({ due_date: (ds as string) || "" })}
-                  size="small"
-                  style={{ width: "100%" }}
-                />
-              </div>
-            </div>
-            <div className="loop-idp__prop">
-              <span className="loop-idp__prop-k">{t("loop.field.stage")}</span>
-              <InputNumber
-                value={issue.stage ?? undefined}
-                onChange={(v) => { if (typeof v === "number") patch({ stage: v }); }}
-                min={1}
-                size="small"
-                style={{ width: "100%" }}
-              />
-            </div>
+            )}
           </section>
 
           <section className="loop-idp__asec">
-            <div className="loop-idp__asec-head">{t("loop.detail.detailsTitle")}</div>
-            <div className="loop-idp__prop loop-idp__prop--inline">
-              <span className="loop-idp__prop-k">{t("loop.field.creator")}</span>
-              <span className="loop-idp__prop-v">{issue.creator_name ?? "—"}</span>
-            </div>
-            <div className="loop-idp__prop loop-idp__prop--inline">
-              <span className="loop-idp__prop-k">{t("loop.detail.created")}</span>
-              <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.created_at)}</span>
-            </div>
-            <div className="loop-idp__prop loop-idp__prop--inline">
-              <span className="loop-idp__prop-k">{t("loop.detail.updated")}</span>
-              <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.updated_at)}</span>
-            </div>
+            <button type="button" className="loop-idp__asec-head" onClick={() => toggleSec("detail")}>
+              <ChevronRight size={13} className={`loop-idp__asec-chevron${secOpen("detail") ? " is-open" : ""}`} />
+              {t("loop.detail.detailsTitle")}
+            </button>
+            {secOpen("detail") && (
+              <div className="loop-idp__asec-body">
+                <div className="loop-idp__prop loop-idp__prop--inline">
+                  <span className="loop-idp__prop-k">{t("loop.field.creator")}</span>
+                  <span className="loop-idp__prop-person">
+                    <Avatar size="extra-extra-small" color="light-blue" src={issue.creator_avatar ?? undefined}>
+                      {(issue.creator_name ?? "?").slice(0, 1)}
+                    </Avatar>
+                    {issue.creator_name ?? "—"}
+                  </span>
+                </div>
+                <div className="loop-idp__prop loop-idp__prop--inline">
+                  <span className="loop-idp__prop-k">{t("loop.detail.created")}</span>
+                  <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.created_at)}</span>
+                </div>
+                <div className="loop-idp__prop loop-idp__prop--inline">
+                  <span className="loop-idp__prop-k">{t("loop.detail.updated")}</span>
+                  <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.updated_at)}</span>
+                </div>
+              </div>
+            )}
           </section>
 
           <section className="loop-idp__asec">
-            <div className="loop-idp__asec-head">{t("loop.detail.execLog")}</div>
-            {runs.length === 0 ? (
-              <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.run.empty")}</Text>
-            ) : (
-              <>
-                <button type="button" className="loop-idp__runs-toggle" onClick={() => setShowRuns((s) => !s)}>
-                  <ChevronRight size={13} className={`loop-idp__runs-chevron${showRuns ? " is-open" : ""}`} />
-                  {t("loop.run.showHistory", { values: { count: runs.length } })}
-                </button>
-                {showRuns && (
-                  <div className="loop-idp__tasks">
-                    {runs.map((r) => {
-                      const active = isActiveRun(r.status);
-                      return (
-                        <div key={r.id} className="loop-idp__task">
-                          <button className="loop-idp__run" onClick={() => openRun(r)}>
-                            <span
-                              className={`loop-idp__run-dot${active ? " is-active" : ""}`}
-                              style={{ background: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}
-                            />
-                            <span className="loop-idp__task-main">
-                              <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
-                              <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
-                            </span>
-                            <span className="loop-idp__run-status" style={{ color: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}>
-                              {t(`loop.taskStatus.${r.status}`)}
-                            </span>
-                          </button>
-                          <Button
-                            size="small"
-                            theme="borderless"
-                            type={active ? "danger" : "tertiary"}
-                            loading={!active && busyRunId === r.id}
-                            icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
-                            aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
-                            onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
-                          />
-                        </div>
-                      );
-                    })}
-                  </div>
+            <button type="button" className="loop-idp__asec-head" onClick={() => toggleSec("runs")}>
+              <ChevronRight size={13} className={`loop-idp__asec-chevron${secOpen("runs") ? " is-open" : ""}`} />
+              {t("loop.detail.execLog")}
+            </button>
+            {secOpen("runs") && (
+              <div className="loop-idp__asec-body">
+                {runs.length === 0 ? (
+                  <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.run.empty")}</Text>
+                ) : (
+                  <>
+                    <button type="button" className="loop-idp__runs-toggle" onClick={() => setShowRuns((s) => !s)}>
+                      <ChevronRight size={13} className={`loop-idp__runs-chevron${showRuns ? " is-open" : ""}`} />
+                      {t("loop.run.showHistory", { values: { count: runs.length } })}
+                    </button>
+                    {showRuns && (
+                      <div className="loop-idp__tasks">
+                        {runs.map((r) => {
+                          const active = isActiveRun(r.status);
+                          return (
+                            <div key={r.id} className="loop-idp__task">
+                              <button className="loop-idp__run" onClick={() => openRun(r)}>
+                                <span
+                                  className={`loop-idp__run-dot${active ? " is-active" : ""}`}
+                                  style={{ background: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}
+                                />
+                                <span className="loop-idp__task-main">
+                                  <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
+                                  <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
+                                </span>
+                                <span className="loop-idp__run-status" style={{ color: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}>
+                                  {t(`loop.taskStatus.${r.status}`)}
+                                </span>
+                              </button>
+                              <Button
+                                size="small"
+                                theme="borderless"
+                                type={active ? "danger" : "tertiary"}
+                                loading={!active && busyRunId === r.id}
+                                icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
+                                aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
+                                onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </>
                 )}
-              </>
+              </div>
             )}
           </section>
         </aside>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -1,19 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import {
   Typography,
-  Input,
   Select,
   Button,
   Avatar,
   Tag,
   Spin,
   Toast,
-  Popconfirm,
-  TextArea,
   Dropdown,
   DatePicker,
   InputNumber,
-  Progress,
 } from "@douyinfe/semi-ui";
 import {
   ArrowLeft,
@@ -26,12 +22,12 @@ import {
   Check,
   Square,
   RotateCcw,
-  SmilePlus,
   Bell,
   BellOff,
   Paperclip,
   AtSign,
   Plus,
+  ChevronRight,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -78,23 +74,26 @@ import LabelEditor from "../ui/LabelEditor";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
+import AutoGrowTextarea from "../ui/AutoGrowTextarea";
 import { confirmDelete } from "../ui/confirmDelete";
 import RunDetailModal from "./RunDetailModal";
 import CreateIssueModal from "../ui/CreateIssueModal";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_COLOR,
+  ISSUE_STATUS_ICON,
+  ISSUE_STATUS_HEX,
   PRIORITY_ORDER,
   PRIORITY_COLOR,
-  RUN_STATUS_COLOR,
+  PRIORITY_ICON,
+  PRIORITY_HEX,
+  RUN_STATUS_HEX,
+  RUN_STATUS_HEX_FALLBACK,
   isActiveRun,
 } from "../ui/meta";
 import "./issueDetail.css";
 
-const { Title, Text } = Typography;
-
-// 反应选择器的固定 emoji 集(轻量,够验证能力;完整 picker 留给 UI 重做)。
-const REACTION_EMOJIS = ["👍", "❤️", "🎉", "😄", "🚀", "👀"];
+const { Text } = Typography;
 
 function fmt(iso?: string | null): string {
   if (!iso) return "-";
@@ -125,6 +124,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
   const [runOpen, setRunOpen] = useState(false);
+  const [showRuns, setShowRuns] = useState(false); // 「执行日志」折叠展开
   const [editingDesc, setEditingDesc] = useState(false);
   const cands = useAssigneeCandidates();
   const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
@@ -281,24 +281,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     } catch {
       /* 刷新失败:写已成功,不误报;下次 reload 自愈 */
     }
-  };
-
-  // 评论 emoji 反应:选择器点 emoji=加,已有 chip 点击=删自己那条(后端按 actor+emoji 定位)。
-  const reactComment = (commentId: string, emoji: string, add: boolean) => {
-    const token = reqRef.current;
-    return mutateThenRefresh(
-      () => (add ? addCommentReaction : removeCommentReaction)(commentId, emoji),
-      () => reloadComments(token),
-    );
-  };
-
-  // issue 级 emoji 反应:同评论,读回走 getIssue 的 issue.reactions(syncIssue 重取详情)。
-  const reactIssue = (emoji: string, add: boolean) => {
-    const token = reqRef.current;
-    return mutateThenRefresh(
-      () => (add ? addIssueReaction : removeIssueReaction)(issueId, emoji),
-      () => syncIssue(token),
-    );
   };
 
   // 评论 resolve/unresolve:后端「一线程至多一条 resolved」会清同线程兄弟,操作后重拉评论即可。
@@ -490,6 +472,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setRunOpen(true);
   };
 
+  // 打开子回路详情（递归复用本页，key 隔离跨 issue 陈旧写入）。
+  const openChild = (id: string) => {
+    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onChanged} />);
+  };
+
   const reloadRuns = () => listRuns(issueId).then(setRuns).catch(() => {});
 
   // 重跑该 task 的 agent（后端按 task_id 新建一次 fresh run）。busyRunId 防双击重复派单。
@@ -640,96 +627,33 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const roots = comments.filter((c) => !c.parent_id);
   const repliesOf = (id: string) => comments.filter((c) => c.parent_id === id);
   const childrenDone = children.filter((c) => c.status === "done").length;
-  // 活动流只取 activity 类(评论已在评论区渲染,避免重复)。filter 返回新数组,reverse 不改原 state。倒序:最新在上。
-  const activities = timeline.filter((e) => e.type === "activity").reverse();
   // issue 附件区只显 issue 级(comment_id 为空);评论附件归各评论下,避免重复。
   const issueAtts = (issue.attachments ?? []).filter((a) => !a.comment_id);
 
-  // emoji 反应条(评论 + issue 通用):按 emoji 分组显示计数(点=删自己那条)+ 选择器加新反应。
-  const renderReactionBar = (
-    reactions: Array<{ emoji: string }> | null | undefined,
-    onToggle: (emoji: string, add: boolean) => void,
-  ) => {
-    const groups = new Map<string, number>();
-    (reactions ?? []).forEach((rx) => groups.set(rx.emoji, (groups.get(rx.emoji) ?? 0) + 1));
-    return (
-      <div className="loop-comment__reactions">
-        {[...groups.entries()].map(([emoji, n]) => (
-          <button key={emoji} type="button" className="loop-reaction" onClick={() => onToggle(emoji, false)}>
-            <span>{emoji}</span>
-            <b>{n}</b>
-          </button>
-        ))}
-        <Dropdown
-          trigger="click"
-          clickToHide
-          position="topLeft"
-          render={
-            <div className="loop-reaction-picker">
-              {REACTION_EMOJIS.map((e) => (
-                <button key={e} type="button" onClick={() => onToggle(e, true)}>{e}</button>
-              ))}
-            </div>
-          }
-        >
-          <button type="button" className="loop-reaction loop-reaction--add" aria-label={t("loop.reaction.add")}>
-            <SmilePlus size={13} />
-          </button>
-        </Dropdown>
-      </div>
-    );
-  };
-
+  // 评论渲染（评论 + 其回复；无 emoji 反应）。
   const renderComment = (c: IssueComment, reply = false) => (
     <div key={c.id} className={`loop-comment ${reply ? "is-reply" : ""}`}>
       <div className="loop-comment__head">
         <Avatar size="extra-extra-small" color="light-blue" src={c.author_avatar ?? undefined}>
           {(c.author_name ?? "?").slice(0, 1)}
         </Avatar>
-        <Text strong style={{ fontSize: 12 }}>
-          {c.author_name}
-        </Text>
+        <Text strong style={{ fontSize: 12 }}>{c.author_name}</Text>
         <time>{fmt(c.created_at)}</time>
         {c.resolved_at && <Tag size="small" color="green">{t("loop.comment.resolved")}</Tag>}
         <div className="loop-comment__actions">
           {!reply && (
-            <Button
-              size="small"
-              theme="borderless"
-              icon={<CornerDownRight size={13} />}
-              onClick={() => { setReplyTo(replyTo === c.id ? null : c.id); setEditingId(null); }}
-            >
-              {t("loop.comment.reply")}
-            </Button>
+            <Button size="small" theme="borderless" icon={<CornerDownRight size={13} />} onClick={() => { setReplyTo(replyTo === c.id ? null : c.id); setEditingId(null); }} aria-label={t("loop.comment.reply")} />
           )}
           {!reply && (
-            <Button
-              size="small"
-              theme="borderless"
-              icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />}
-              onClick={() => toggleResolve(c.id, !!c.resolved_at)}
-            >
-              {t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")}
-            </Button>
+            <Button size="small" theme="borderless" icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />} onClick={() => toggleResolve(c.id, !!c.resolved_at)} aria-label={t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")} />
           )}
-          <Button
-            size="small"
-            theme="borderless"
-            icon={<Pencil size={13} />}
-            onClick={() => { setEditingId(c.id); setEditDraft(c.content); setReplyTo(null); }}
-          />
-          <Button
-            size="small"
-            theme="borderless"
-            type="danger"
-            icon={<Trash2 size={13} />}
-            onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })}
-          />
+          <Button size="small" theme="borderless" icon={<Pencil size={13} />} onClick={() => { setEditingId(c.id); setEditDraft(c.content); setReplyTo(null); }} aria-label={t("loop.action.edit")} />
+          <Button size="small" theme="borderless" type="danger" icon={<Trash2 size={13} />} onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })} aria-label={t("loop.action.delete")} />
         </div>
       </div>
       {editingId === c.id ? (
         <div className="loop-comment__body" style={{ marginTop: 6 }}>
-          <TextArea value={editDraft} onChange={setEditDraft} autosize={{ minRows: 2, maxRows: 10 }} />
+          <AutoGrowTextarea className="loop-field-textarea loop-field-textarea--auto" value={editDraft} onChange={setEditDraft} />
           <div style={{ marginTop: 6, display: "flex", gap: 8 }}>
             <Button size="small" theme="solid" onClick={() => saveEdit(c.id)}>{t("loop.action.save")}</Button>
             <Button size="small" theme="borderless" onClick={() => setEditingId(null)}>{t("loop.action.cancel")}</Button>
@@ -739,33 +663,81 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <div className="loop-comment__body"><LoopMarkdown content={c.content} /></div>
       )}
       {renderAttachments(c.attachments)}
-      {renderReactionBar(c.reactions, (emoji, add) => reactComment(c.id, emoji, add))}
       {!reply && repliesOf(c.id).map((r) => renderComment(r, true))}
       {!reply && replyTo === c.id && (
         <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
-          <Input
+          <input
+            className="loop-field"
             value={commentDraft}
-            onChange={setCommentDraft}
+            onChange={(e) => setCommentDraft(e.target.value)}
             placeholder={t("loop.comment.replyPlaceholder")}
-            onEnterPress={submitComment}
+            onKeyDown={(e) => { if (e.key === "Enter") submitComment(); }}
           />
-          <Button icon={<Send size={14} />} onClick={submitComment} />
+          <Button icon={<Send size={14} />} onClick={submitComment} aria-label={t("loop.comment.send")} />
         </div>
       )}
     </div>
   );
 
+  // 动态：把活动流(activity) 与顶层评论合并成一条时间线(升序,最新在下、贴近底部输入框),
+  // 对齐 Figma —— 不再把「活动」「评论」拆成两个挤在一起的区块。timeline 为 ASC。
+  const activities = timeline.filter((e) => e.type === "activity");
+  // 活动文案人话化：后端 action 是机器串(如 status_changed),普通运营看不懂。按语义归类成中文；
+  // 订阅类噪声直接隐藏(返回 null → 不渲染)；未知归为通用「更新了这个回路」，绝不暴露原始串。
+  const activityText = (action?: string): string | null => {
+    if (!action) return null;
+    const a = action.toLowerCase();
+    if (a.includes("subscrib") || a.includes("view")) return null;
+    if (a.includes("creat")) return t("loop.activityAction.created");
+    if (a.includes("status")) return t("loop.activityAction.statusChanged");
+    if (a.includes("priorit")) return t("loop.activityAction.priorityChanged");
+    if (a.includes("assign")) return t("loop.activityAction.assigneeChanged");
+    if (a.includes("project")) return t("loop.activityAction.projectChanged");
+    if (a.includes("title")) return t("loop.activityAction.titleChanged");
+    if (a.includes("descri")) return t("loop.activityAction.descriptionChanged");
+    if (a.includes("label")) return t("loop.activityAction.labelChanged");
+    if (a.includes("due") || a.includes("date")) return t("loop.activityAction.dateChanged");
+    if (a.includes("reopen")) return t("loop.activityAction.reopened");
+    if (a.includes("clos") || a.includes("complet") || a.includes("done")) return t("loop.activityAction.completed");
+    return t("loop.activityAction.generic");
+  };
+  const feed: Array<{ ts: string; node: React.ReactNode }> = [
+    ...activities.flatMap((a) => {
+      const verb = activityText(a.action);
+      if (!verb) return [];
+      return [{
+        ts: a.created_at,
+        node: (
+          <div key={`a-${a.id}`} className="loop-feed__act">
+            <span className="loop-feed__act-dot" />
+            <span className="loop-feed__act-text">
+              <strong>{a.actor_name ?? a.actor_id}</strong> {verb}
+            </span>
+            <time>{fmt(a.created_at)}</time>
+          </div>
+        ),
+      }];
+    }),
+    ...roots.map((c) => ({ ts: c.created_at, node: renderComment(c) })),
+  ].sort((x, y) => new Date(x.ts).getTime() - new Date(y.ts).getTime());
+
   return (
     <div className="loop-idp">
       <div className="loop-idp__topbar">
-        <Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>
-          {t("loop.detail.back")}
-        </Button>
-        <Text type="tertiary" style={{ fontSize: 12 }}>
-          {issue.project_name ? `${issue.project_name} · ` : ""}
-          {issue.identifier}
-        </Text>
+        <div className="loop-idp__crumbs">
+          <button className="loop-idp__crumb" onClick={back}>
+            {issue.project_name ?? t("loop.nav.issue")}
+          </button>
+          <ChevronRight size={14} className="loop-idp__crumb-sep" />
+          <span className="loop-idp__crumb-cur">
+            <span className="loop-idp__crumb-id">{issue.identifier}</span>
+            <span className="loop-idp__crumb-title">{issue.title}</span>
+          </span>
+        </div>
         <div style={{ flex: 1 }} />
+        <Button className="loop-idp__boardbtn" theme="borderless" onClick={back}>
+          {t("loop.detail.board")}
+        </Button>
         <Dropdown trigger="click" position="bottomRight" render={renderMoreMenu()} clickToHide>
           <Button icon={<MoreHorizontal size={18} />} theme="borderless" aria-label="more" />
         </Dropdown>
@@ -774,139 +746,106 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       <div className="loop-idp__body">
         {/* 主体 */}
         <div className="loop-idp__main">
-          <Input
-            size="large"
+          <input
+            className="loop-field loop-field--lg loop-idp__title"
             value={titleDraft}
-            onChange={setTitleDraft}
+            onChange={(e) => setTitleDraft(e.target.value)}
             onBlur={() => titleDraft.trim() && titleDraft !== issue.title && patch({ title: titleDraft.trim() })}
-            style={{ fontWeight: 600, fontSize: 20 }}
           />
 
-          {/* issue 级 emoji 反应条 */}
-          {renderReactionBar(issue.reactions, reactIssue)}
-
-          <div className="loop-idp__section">
-            <div className="loop-detail__section-title loop-idp__desc-title">
-              <span>{t("loop.field.description")}</span>
-              {editingDesc ? (
-                <Button size="small" theme="borderless" icon={<Check size={13} />} onClick={saveDesc}>
-                  {t("loop.action.save")}
-                </Button>
+          {/* 描述：紧贴标题的段落（点击进入编辑），无独立分区标题，对齐 Figma */}
+          {editingDesc ? (
+            <AutoGrowTextarea
+              className="loop-field-textarea loop-field-textarea--lg loop-field-textarea--auto"
+              value={descDraft}
+              onChange={setDescDraft}
+              onBlur={saveDesc}
+              autoFocus
+              placeholder={t("loop.field.descriptionPlaceholder")}
+            />
+          ) : (
+            <div className="loop-idp__desc" onClick={() => setEditingDesc(true)}>
+              {issue.description ? (
+                <LoopMarkdown content={issue.description} />
               ) : (
-                <Button size="small" theme="borderless" icon={<Pencil size={13} />} onClick={() => setEditingDesc(true)}>
-                  {t("loop.action.edit")}
-                </Button>
+                <span className="loop-idp__desc-empty">{t("loop.field.descriptionPlaceholder")}</span>
               )}
             </div>
-            {editingDesc ? (
-              <TextArea
-                value={descDraft}
-                onChange={setDescDraft}
-                onBlur={saveDesc}
-                autosize={{ minRows: 4, maxRows: 20 }}
-                placeholder={t("loop.field.descriptionPlaceholder")}
+          )}
+
+          {/* issue 附件 + 工具栏（附件上传） */}
+          {issueAtts.length > 0 && renderAttachments(issueAtts)}
+          <div className="loop-idp__toolbar">
+            <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
+              {uploading ? <Spin size="small" /> : <Paperclip size={15} />}
+              <input
+                type="file"
+                multiple
+                hidden
+                disabled={uploading}
+                onChange={(e) => { uploadForIssue(e.target.files); e.target.value = ""; }}
               />
-            ) : issue.description ? (
-              <LoopMarkdown content={issue.description} />
-            ) : (
-              <Text type="tertiary" style={{ fontSize: 13 }}>{t("loop.field.descriptionPlaceholder")}</Text>
-            )}
+            </label>
           </div>
 
+          {/* 子回路 */}
           <div className="loop-idp__section">
-            <div className="loop-detail__section-title loop-idp__desc-title">
+            <div className="loop-idp__stitle loop-idp__desc-title">
               <span>
                 {t("loop.subIssue.title")}
-                {children.length > 0 && ` (${childrenDone}/${children.length})`}
+                {children.length > 0 && <em className="loop-idp__count"> {childrenDone} / {children.length}</em>}
               </span>
               <Button
                 theme="borderless"
                 size="small"
-                icon={<Plus size={13} />}
+                icon={<Plus size={14} />}
+                aria-label={t("loop.subIssue.create")}
                 onClick={() => setChildCreateOpen(true)}
-              >
-                {t("loop.subIssue.create")}
-              </Button>
+              />
             </div>
             {children.length > 0 && (
-              <>
-                <Progress
-                  percent={Math.round((childrenDone / children.length) * 100)}
-                  style={{ margin: "8px 0 10px" }}
-                />
-                <div className="loop-subissues">
-                  {children.map((c) => (
-                    <div key={c.id} className="loop-subissue">
-                      <Tag color={ISSUE_STATUS_COLOR[c.status]} size="small">
-                        {t(`loop.status.${c.status}`)}
-                      </Tag>
+              <div className="loop-subissues">
+                {children.map((c) => {
+                  const SIcon = ISSUE_STATUS_ICON[c.status];
+                  const PIcon = PRIORITY_ICON[c.priority];
+                  return (
+                    <div key={c.id} className="loop-subissue" onClick={() => openChild(c.id)}>
+                      <SIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[c.status] }} />
                       <span className="loop-subissue__id">{c.identifier}</span>
                       <span className="loop-subissue__title">{c.title}</span>
+                      <span className="loop-subissue__spacer" />
+                      <PIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[c.priority] }} />
                     </div>
-                  ))}
-                </div>
-              </>
+                  );
+                })}
+              </div>
             )}
           </div>
 
-          <div className="loop-idp__section">
-            <div className="loop-detail__section-title loop-idp__desc-title">
-              <span>{t("loop.attach.title")} ({issueAtts.length})</span>
-              <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
-                {uploading ? <Spin size="small" /> : <Paperclip size={13} />}
-                <input
-                  type="file"
-                  multiple
-                  hidden
-                  disabled={uploading}
-                  onChange={(e) => { uploadForIssue(e.target.files); e.target.value = ""; }}
-                />
-              </label>
+          {/* 动态：活动 + 评论 合并时间线 */}
+          <div className="loop-idp__section loop-idp__feed-sec">
+            <div className="loop-idp__feed-head">
+              <span className="loop-idp__stitle">{t("loop.activity.title")}</span>
+              <button
+                type="button"
+                className="loop-idp__subbtn"
+                onClick={() => toggleSubscribe(!(selfKnown && amSubscribed))}
+              >
+                {selfKnown && amSubscribed ? <BellOff size={13} /> : <Bell size={13} />}
+                {selfKnown && amSubscribed ? t("loop.subscribe.unsubscribe") : t("loop.subscribe.subscribe")}
+              </button>
             </div>
-            {issueAtts.length ? (
-              renderAttachments(issueAtts)
-            ) : (
-              <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.attach.empty")}</Text>
-            )}
-          </div>
 
-          {activities.length > 0 && (
-            <div className="loop-idp__section">
-              <div className="loop-detail__section-title">
-                {t("loop.activity.title")} ({activities.length})
-              </div>
-              <div className="loop-activities">
-                {activities.map((a) => (
-                  <div key={a.id} className="loop-activity">
-                    <Avatar size="extra-extra-small" color="light-blue" src={a.actor_avatar ?? undefined}>
-                      {(a.actor_name ?? "?").slice(0, 1)}
-                    </Avatar>
-                    <Text style={{ fontSize: 12 }}>
-                      <strong>{a.actor_name ?? a.actor_id}</strong>{" "}
-                      {/* ponytail: 原样展示 action(如 status_changed);细化文案映射留给 UI 重做 */}
-                      <Text type="tertiary">{(a.action ?? "").replace(/_/g, " ")}</Text>
-                    </Text>
-                    <time>{fmt(a.created_at)}</time>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          <div className="loop-idp__section">
-            <div className="loop-detail__section-title">
-              {t("loop.detail.comments")} ({comments.length})
-            </div>
-            <div className="loop-comments">
-              {roots.length === 0 && (
-                <Text type="tertiary" style={{ fontSize: 12 }}>
-                  {t("loop.comment.empty")}
-                </Text>
+            <div className="loop-feed">
+              {feed.length === 0 ? (
+                <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.empty")}</Text>
+              ) : (
+                feed.map((it) => it.node)
               )}
-              {roots.map((c) => renderComment(c))}
             </div>
+
             {!replyTo && triggerAgents.length > 0 && (
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 10, alignItems: "center" }}>
+              <div className="loop-idp__wake">
                 <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.willWake")}</Text>
                 {triggerAgents.map((a) => {
                   const off = suppressed.has(a.id);
@@ -936,13 +875,16 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 ))}
               </div>
             )}
-            <div style={{ marginTop: 12, display: "flex", gap: 8, alignItems: "center" }}>
-              <Input
+
+            {/* 评论输入区 */}
+            <div className="loop-idp__composer">
+              <input
+                className="loop-field"
                 value={replyTo ? "" : commentDraft}
                 disabled={!!replyTo}
-                onChange={setCommentDraft}
+                onChange={(e) => setCommentDraft(e.target.value)}
                 placeholder={replyTo ? t("loop.comment.replyingHint") : t("loop.comment.placeholder")}
-                onEnterPress={submitComment}
+                onKeyDown={(e) => { if (e.key === "Enter") submitComment(); }}
               />
               <Dropdown
                 trigger="click"
@@ -977,89 +919,84 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   onChange={(e) => { addPendingFiles(e.target.files); e.target.value = ""; }}
                 />
               </label>
-              <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} loading={submitting} disabled={!!replyTo}>
-                {t("loop.comment.send")}
-              </Button>
+              <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} loading={submitting} disabled={!!replyTo} aria-label={t("loop.comment.send")} />
             </div>
           </div>
         </div>
 
         {/* 右侧属性栏 */}
         <aside className="loop-idp__aside">
-          <div className="loop-idp__aside-card">
-            <div className="loop-detail__section-title">{t("loop.detail.properties")}</div>
-            <dl className="loop-idp__props">
-              <dt>{t("loop.field.status")}</dt>
-              <dd>
-                <Select
-                  value={issue.status}
-                  onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
-                  size="small"
-                  style={{ width: "100%" }}
-                >
-                  {ISSUE_STATUS_ORDER.map((s) => (
-                    <Select.Option key={s} value={s}>
-                      <Tag color={ISSUE_STATUS_COLOR[s]} size="small">
-                        {t(`loop.status.${s}`)}
-                      </Tag>
-                    </Select.Option>
-                  ))}
-                </Select>
-              </dd>
-              <dt>{t("loop.field.priority")}</dt>
-              <dd>
-                <Select
-                  value={issue.priority}
-                  onChange={(v) => patch({ priority: v as IssuePriority })}
-                  size="small"
-                  style={{ width: "100%" }}
-                >
-                  {PRIORITY_ORDER.map((p) => (
-                    <Select.Option key={p} value={p}>
-                      <Tag color={PRIORITY_COLOR[p]} size="small">
-                        {t(`loop.priority.${p}`)}
-                      </Tag>
-                    </Select.Option>
-                  ))}
-                </Select>
-              </dd>
-              <dt>{t("loop.field.assignee")}</dt>
-              <dd>
-                <AssigneePicker
-                  value={issue.assignee_id}
-                  valueName={issue.assignee_name ?? null}
-                  onChange={(id, type, name) => requestAssign(issue, type, id, name, (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }))}
-                />
-              </dd>
-              <dt>{t("loop.field.project")}</dt>
-              <dd>
-                <Text>{issue.project_name ?? "—"}</Text>
-              </dd>
-              <dt>{t("loop.field.labels")}</dt>
-              <dd>
-                <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
-              </dd>
-              <dt>{t("loop.field.parent")}</dt>
-              <dd>
-                <Select
-                  value={issue.parent_issue_id ?? undefined}
-                  onChange={(v) => patch({ parent_issue_id: (v as string) || "" })}
-                  onDropdownVisibleChange={loadParentCands}
-                  placeholder={t("loop.field.noParent")}
-                  size="small"
-                  filter
-                  showClear
-                  style={{ width: "100%" }}
-                >
-                  {parentCands.map((i) => (
-                    <Select.Option key={i.id} value={i.id}>
-                      {i.identifier} {i.title}
-                    </Select.Option>
-                  ))}
-                </Select>
-              </dd>
-              <dt>{t("loop.field.startDate")}</dt>
-              <dd>
+          <section className="loop-idp__asec">
+            <div className="loop-idp__asec-head">{t("loop.detail.properties")}</div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.status")}</span>
+              <Select
+                value={issue.status}
+                onChange={(v) => requestStatus(issue, v as IssueStatus, (extra) => patch({ status: v as IssueStatus, ...extra }))}
+                dropdownClassName="loop-fields__dropdown"
+                size="small"
+                style={{ width: "100%" }}
+              >
+                {ISSUE_STATUS_ORDER.map((s) => (
+                  <Select.Option key={s} value={s}>
+                    <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
+                  </Select.Option>
+                ))}
+              </Select>
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.priority")}</span>
+              <Select
+                value={issue.priority}
+                onChange={(v) => patch({ priority: v as IssuePriority })}
+                dropdownClassName="loop-fields__dropdown"
+                size="small"
+                style={{ width: "100%" }}
+              >
+                {PRIORITY_ORDER.map((p) => (
+                  <Select.Option key={p} value={p}>
+                    <Tag color={PRIORITY_COLOR[p]} size="small">{t(`loop.priority.${p}`)}</Tag>
+                  </Select.Option>
+                ))}
+              </Select>
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.assignee")}</span>
+              <AssigneePicker
+                value={issue.assignee_id}
+                valueName={issue.assignee_name ?? null}
+                onChange={(id, type, name) => requestAssign(issue, type, id, name, (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }))}
+              />
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.project")}</span>
+              <span className="loop-idp__prop-v">{issue.project_name ?? "—"}</span>
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.labels")}</span>
+              <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.parent")}</span>
+              <Select
+                value={issue.parent_issue_id ?? undefined}
+                onChange={(v) => patch({ parent_issue_id: (v as string) || "" })}
+                onDropdownVisibleChange={loadParentCands}
+                dropdownClassName="loop-fields__dropdown"
+                placeholder={t("loop.field.noParent")}
+                size="small"
+                filter
+                showClear
+                style={{ width: "100%" }}
+              >
+                {parentCands.map((i) => (
+                  <Select.Option key={i.id} value={i.id}>{i.identifier} {i.title}</Select.Option>
+                ))}
+              </Select>
+            </div>
+            <div className="loop-idp__prop-row2">
+              <div className="loop-idp__prop">
+                <span className="loop-idp__prop-k">{t("loop.field.startDate")}</span>
                 <DatePicker
                   type="date"
                   format="yyyy-MM-dd"
@@ -1068,9 +1005,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   size="small"
                   style={{ width: "100%" }}
                 />
-              </dd>
-              <dt>{t("loop.field.dueDate")}</dt>
-              <dd>
+              </div>
+              <div className="loop-idp__prop">
+                <span className="loop-idp__prop-k">{t("loop.field.dueDate")}</span>
                 <DatePicker
                   type="date"
                   format="yyyy-MM-dd"
@@ -1079,77 +1016,82 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   size="small"
                   style={{ width: "100%" }}
                 />
-              </dd>
-              <dt>{t("loop.field.stage")}</dt>
-              <dd>
-                <InputNumber
-                  value={issue.stage ?? undefined}
-                  // 仅在有效数字时提交:编辑中退格清空会以空值触发 onChange,
-                  // 忽略它可避免误发 stage=null(unstage)+ 竞态。清 stage 待 UI 重做。
-                  onChange={(v) => { if (typeof v === "number") patch({ stage: v }); }}
-                  min={1}
-                  size="small"
-                  style={{ width: "100%" }}
-                />
-              </dd>
-              <dt>{t("loop.field.creator")}</dt>
-              <dd>
-                <Text>{issue.creator_name}</Text>
-              </dd>
-              <dt>{t("loop.detail.created")}</dt>
-              <dd>
-                <Text type="tertiary" style={{ fontSize: 12 }}>{fmt(issue.created_at)}</Text>
-              </dd>
-              <dt>{t("loop.subscribe.label")}</dt>
-              <dd>
-                <Text type="tertiary" style={{ fontSize: 12 }}>{subscribers.length}</Text>
-                {amSubscribed && (
-                  <Text style={{ fontSize: 12, marginLeft: 6, color: "var(--semi-color-primary)" }}>
-                    · {t("loop.subscribe.subscribed")}
-                  </Text>
-                )}
-              </dd>
-            </dl>
-          </div>
-
-          <div className="loop-idp__aside-card">
-            <div className="loop-detail__section-title">
-              {t("loop.run.title")} ({runs.length})
-            </div>
-            {runs.length === 0 ? (
-              <Text type="tertiary" style={{ fontSize: 12 }}>
-                {t("loop.run.empty")}
-              </Text>
-            ) : (
-              <div className="loop-idp__tasks">
-                {runs.map((r) => {
-                  const active = isActiveRun(r.status);
-                  return (
-                    <div key={r.id} className="loop-idp__task">
-                      <button className="loop-idp__run" onClick={() => openRun(r)}>
-                        <span className="loop-idp__task-main">
-                          <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
-                          <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
-                        </span>
-                        <Tag size="small" color={RUN_STATUS_COLOR[r.status] ?? "grey"}>
-                          {t(`loop.taskStatus.${r.status}`)}
-                        </Tag>
-                      </button>
-                      <Button
-                        size="small"
-                        theme="borderless"
-                        type={active ? "danger" : "tertiary"}
-                        loading={!active && busyRunId === r.id}
-                        icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
-                        aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
-                        onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
-                      />
-                    </div>
-                  );
-                })}
               </div>
+            </div>
+            <div className="loop-idp__prop">
+              <span className="loop-idp__prop-k">{t("loop.field.stage")}</span>
+              <InputNumber
+                value={issue.stage ?? undefined}
+                onChange={(v) => { if (typeof v === "number") patch({ stage: v }); }}
+                min={1}
+                size="small"
+                style={{ width: "100%" }}
+              />
+            </div>
+          </section>
+
+          <section className="loop-idp__asec">
+            <div className="loop-idp__asec-head">{t("loop.detail.detailsTitle")}</div>
+            <div className="loop-idp__prop loop-idp__prop--inline">
+              <span className="loop-idp__prop-k">{t("loop.field.creator")}</span>
+              <span className="loop-idp__prop-v">{issue.creator_name ?? "—"}</span>
+            </div>
+            <div className="loop-idp__prop loop-idp__prop--inline">
+              <span className="loop-idp__prop-k">{t("loop.detail.created")}</span>
+              <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.created_at)}</span>
+            </div>
+            <div className="loop-idp__prop loop-idp__prop--inline">
+              <span className="loop-idp__prop-k">{t("loop.detail.updated")}</span>
+              <span className="loop-idp__prop-v loop-idp__prop-v--muted">{fmt(issue.updated_at)}</span>
+            </div>
+          </section>
+
+          <section className="loop-idp__asec">
+            <div className="loop-idp__asec-head">{t("loop.detail.execLog")}</div>
+            {runs.length === 0 ? (
+              <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.run.empty")}</Text>
+            ) : (
+              <>
+                <button type="button" className="loop-idp__runs-toggle" onClick={() => setShowRuns((s) => !s)}>
+                  <ChevronRight size={13} className={`loop-idp__runs-chevron${showRuns ? " is-open" : ""}`} />
+                  {t("loop.run.showHistory", { values: { count: runs.length } })}
+                </button>
+                {showRuns && (
+                  <div className="loop-idp__tasks">
+                    {runs.map((r) => {
+                      const active = isActiveRun(r.status);
+                      return (
+                        <div key={r.id} className="loop-idp__task">
+                          <button className="loop-idp__run" onClick={() => openRun(r)}>
+                            <span
+                              className={`loop-idp__run-dot${active ? " is-active" : ""}`}
+                              style={{ background: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}
+                            />
+                            <span className="loop-idp__task-main">
+                              <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
+                              <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
+                            </span>
+                            <span className="loop-idp__run-status" style={{ color: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}>
+                              {t(`loop.taskStatus.${r.status}`)}
+                            </span>
+                          </button>
+                          <Button
+                            size="small"
+                            theme="borderless"
+                            type={active ? "danger" : "tertiary"}
+                            loading={!active && busyRunId === r.id}
+                            icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
+                            aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
+                            onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
             )}
-          </div>
+          </section>
         </aside>
       </div>
 

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -16,7 +16,6 @@ import {
   MoreHorizontal,
   Copy,
   CircleSlash,
-  Pencil,
   Check,
   Square,
   RotateCcw,
@@ -50,17 +49,12 @@ import {
   listChildren,
   addComment,
   deleteComment,
-  updateComment,
   previewCommentTriggers,
 } from "../api/issueApi";
 import {
   listSubscribers,
   subscribeIssue,
   unsubscribeIssue,
-  addCommentReaction,
-  removeCommentReaction,
-  addIssueReaction,
-  removeIssueReaction,
   resolveComment,
   unresolveComment,
   listTimeline,
@@ -201,12 +195,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [loading, setLoading] = useState(true);
   const [titleDraft, setTitleDraft] = useState("");
   const [descDraft, setDescDraft] = useState("");
-  const [replyTo, setReplyTo] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState("");
   const [triggerAgents, setTriggerAgents] = useState<CommentTriggerAgent[]>([]); // 这条评论会唤醒的 agent
   const [suppressed, setSuppressed] = useState<Set<string>>(new Set()); // 被用户跳过的 agent id
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editDraft, setEditDraft] = useState("");
   const [busyRunId, setBusyRunId] = useState<string | null>(null); // 正在重跑的 task,防双击
   const [pendingFiles, setPendingFiles] = useState<File[]>([]); // 评论输入区:待随评论提交的本地文件(发送时才上传)
   const [uploading, setUploading] = useState(false); // issue 附件上传中
@@ -257,6 +248,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         reactions: updated.reactions ?? issue.reactions,
         attachments: updated.attachments ?? issue.attachments,
       });
+      Toast.success(t("loop.toast.saved"));
       onChanged?.();
     } catch (e) {
       // 后端可能拒绝(如父 issue 环检测、非法日期):给出反馈,避免静默失败。
@@ -418,14 +410,13 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     const content = commentDraft.trim();
     if (!content || submitting) return;
     const token = reqRef.current;
-    // 附件只随顶层评论;回复不带(pendingFiles 属主输入区)。
-    const files = replyTo ? [] : pendingFiles;
+    const files = pendingFiles;
     const suppressIds = triggerAgents.filter((a) => suppressed.has(a.id)).map((a) => a.id);
     setSubmitting(true);
     try {
       let comment: IssueComment;
       try {
-        comment = await addComment(issueId, content, replyTo, suppressIds);
+        comment = await addComment(issueId, content, null, suppressIds);
       } catch (e) {
         // 评论未创建:保留草稿/待发文件供重试。
         Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
@@ -433,10 +424,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       }
       // 评论已创建 → 立即清理输入态,避免后续附件上传失败时用户重复提交同一条评论。
       setCommentDraft("");
-      setReplyTo(null);
       setTriggerAgents([]);
       setSuppressed(new Set());
-      if (!replyTo) setPendingFiles([]);
+      setPendingFiles([]);
       // 把待发文件带 commentId 绑到已建评论;单个失败只记录、不回滚评论。
       const failedFiles: File[] = [];
       for (const f of files) {
@@ -451,7 +441,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       if (failedFiles.length) {
         // 评论已建成功、仅附件失败:把失败文件放回输入区(否则文件对象被丢弃、永久丢失且无重试入口),
         // 并用区分于"评论失败"的文案——避免误导用户以为整条评论没发出去。
-        if (!replyTo) setPendingFiles(failedFiles);
+        setPendingFiles(failedFiles);
         Toast.error(t("loop.toast.commentAttachFailed", { values: { count: failedFiles.length } }));
       } else {
         Toast.success(t("loop.toast.commentAdded"));
@@ -462,12 +452,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     }
   };
 
-  // 顶层评论输入时防抖预览"会唤醒哪些 agent"(回复暂不预览)。
+  // 新建评论输入时防抖预览"会唤醒哪些 agent"。
   useEffect(() => {
     const content = commentDraft.trim();
     // 预览更新时把 suppressed 裁剪到当前触发集,避免"移除又重提及"的 agent 带着旧的跳过意图。
     const prune = (ids: string[]) => setSuppressed((s) => new Set([...s].filter((id) => ids.includes(id))));
-    if (!content || replyTo) { setTriggerAgents([]); prune([]); return; }
+    if (!content) { setTriggerAgents([]); prune([]); return; }
     let cancelled = false;
     const h = setTimeout(() => {
       previewCommentTriggers(issueId, content, null)
@@ -475,7 +465,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         .catch(() => { if (cancelled) return; setTriggerAgents([]); prune([]); });
     }, 400);
     return () => { cancelled = true; clearTimeout(h); };
-  }, [commentDraft, replyTo, issueId]);
+  }, [commentDraft, issueId]);
 
   const toggleSuppress = (id: string) =>
     setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
@@ -509,22 +499,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       () => reloadComments(token),
       () => Toast.success(t("loop.toast.commentDeleted")),
     );
-  };
-
-  const saveEdit = async (id: string) => {
-    const content = editDraft.trim();
-    if (!content) return;
-    const token = reqRef.current;
-    try {
-      await updateComment(id, content);
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.editFailed"));
-      return;
-    }
-    // 编辑已落库；重拉以回填 directory 名字/头像。重拉失败不应报“编辑失败”。
-    setEditingId(null);
-    await reloadComments(token);
-    Toast.success(t("loop.toast.commentUpdated"));
   };
 
   const handleDeleteIssue = () => {
@@ -740,9 +714,6 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                 <Dropdown.Item icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />} onClick={() => toggleResolve(c.id, !!c.resolved_at)}>
                   {t(c.resolved_at ? "loop.comment.unresolve" : "loop.comment.resolve")}
                 </Dropdown.Item>
-                <Dropdown.Item icon={<Pencil size={13} />} onClick={() => { setEditingId(c.id); setEditDraft(c.content); }}>
-                  {t("loop.action.edit")}
-                </Dropdown.Item>
                 <Dropdown.Divider />
                 <Dropdown.Item type="danger" icon={<Trash2 size={13} />} onClick={() => confirmDelete({ title: t("loop.comment.deleteConfirm"), okText: t("loop.action.delete"), cancelText: t("loop.action.cancel"), onOk: () => removeComment(c.id) })}>
                   {t("loop.action.delete")}
@@ -754,17 +725,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </Dropdown>
         </div>
       </div>
-      {editingId === c.id ? (
-        <div className="loop-cmt__body" style={{ marginTop: 6 }}>
-          <AutoGrowTextarea className="loop-field-textarea loop-field-textarea--auto" value={editDraft} onChange={setEditDraft} />
-          <div style={{ marginTop: 6, display: "flex", gap: 8 }}>
-            <Button size="small" theme="solid" onClick={() => saveEdit(c.id)}>{t("loop.action.save")}</Button>
-            <Button size="small" theme="borderless" onClick={() => setEditingId(null)}>{t("loop.action.cancel")}</Button>
-          </div>
-        </div>
-      ) : (
-        <div className="loop-cmt__body"><LoopMarkdown content={c.content} /></div>
-      )}
+      <div className="loop-cmt__body"><LoopMarkdown content={c.content} /></div>
       {renderAttachments(c.attachments)}
     </div>
   );
@@ -803,6 +764,40 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     if (a.includes("clos") || a.includes("complet") || a.includes("done")) return t("loop.activityAction.completed");
     return t("loop.activityAction.generic");
   };
+
+  // 执行记录单行(运行中/历史 复用)：状态点 + agent 名 + 触发摘要 + 状态文字 + 终止/重跑。
+  const renderRunRow = (r: TaskRun) => {
+    const active = isActiveRun(r.status);
+    return (
+      <div key={r.id} className="loop-idp__task">
+        <button className="loop-idp__run" onClick={() => openRun(r)}>
+          <span
+            className={`loop-idp__run-dot${active ? " is-active" : ""}`}
+            style={{ background: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}
+          />
+          <span className="loop-idp__task-main">
+            <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
+            <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
+          </span>
+          <span className="loop-idp__run-status" style={{ color: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}>
+            {t(`loop.taskStatus.${r.status}`)}
+          </span>
+        </button>
+        <Button
+          size="small"
+          theme="borderless"
+          type={active ? "danger" : "tertiary"}
+          loading={!active && busyRunId === r.id}
+          icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
+          aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
+          onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
+        />
+      </div>
+    );
+  };
+  // 运行中/排队中重点常显在外;仅终态归入「显示历史运行」折叠(对标 multica)。
+  const activeRuns = runs.filter((r) => isActiveRun(r.status));
+  const pastRuns = runs.filter((r) => !isActiveRun(r.status));
 
   // 动态区(对标 multica)：根评论与「有意义的活动」按时间升序合并；连续活动归并成一个折叠动态块，
   // 评论各自独立成卡片。噪声活动(activityText 为 null)先过滤，不进块、不计数。
@@ -934,22 +929,22 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             </label>
           </div>
 
-          {/* 子回路 */}
-          <div className="loop-idp__section">
-            <div className="loop-idp__stitle loop-idp__desc-title">
-              <span>
-                {t("loop.subIssue.title")}
-                {children.length > 0 && <em className="loop-idp__count"> {childrenDone} / {children.length}</em>}
-              </span>
-              <Button
-                theme="borderless"
-                size="small"
-                icon={<Plus size={14} />}
-                aria-label={t("loop.subIssue.create")}
-                onClick={() => setChildCreateOpen(true)}
-              />
-            </div>
-            {children.length > 0 && (
+          {/* 子回路：仅当确有子回路时才展示整个模块(空则不显示,避免突兀的孤零标题) */}
+          {children.length > 0 && (
+            <div className="loop-idp__section">
+              <div className="loop-idp__stitle loop-idp__desc-title">
+                <span>
+                  {t("loop.subIssue.title")}
+                  <em className="loop-idp__count"> {childrenDone} / {children.length}</em>
+                </span>
+                <Button
+                  theme="borderless"
+                  size="small"
+                  icon={<Plus size={14} />}
+                  aria-label={t("loop.subIssue.create")}
+                  onClick={() => setChildCreateOpen(true)}
+                />
+              </div>
               <div className="loop-subissues">
                 {children.map((c) => {
                   const SIcon = ISSUE_STATUS_ICON[c.status];
@@ -965,8 +960,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   );
                 })}
               </div>
-            )}
-          </div>
+            </div>
+          )}
 
           {/* 动态：活动 + 评论 合并时间线 */}
           <div className="loop-idp__section loop-idp__feed-sec">
@@ -992,82 +987,88 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
               )}
             </div>
 
-            {!replyTo && triggerAgents.length > 0 && (
-              <div className="loop-idp__wake">
-                <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.willWake")}</Text>
-                {triggerAgents.map((a) => {
-                  const off = suppressed.has(a.id);
-                  return (
-                    <Tag
-                      key={a.id}
-                      size="small"
-                      color={off ? "grey" : "light-blue"}
-                      style={{ cursor: "pointer", opacity: off ? 0.55 : 1, textDecoration: off ? "line-through" : "none" }}
-                      onClick={() => toggleSuppress(a.id)}
-                    >
-                      {a.name}
-                    </Tag>
-                  );
-                })}
-                <Text type="tertiary" style={{ fontSize: 11 }}>{t("loop.comment.tapToSuppress")}</Text>
-              </div>
-            )}
-            {!replyTo && pendingFiles.length > 0 && (
-              <div className="loop-atts" style={{ marginTop: 10 }}>
-                {pendingFiles.map((f, i) => (
-                  <span key={i} className="loop-att loop-att--pending">
-                    <Paperclip size={12} />
-                    <span>{f.name}</span>
-                    <button type="button" aria-label={t("loop.action.delete")} onClick={() => removePendingFile(i)}>×</button>
-                  </span>
-                ))}
-              </div>
-            )}
-
-            {/* 评论输入区 */}
-            <div className="loop-idp__composer">
-              <input
-                className="loop-field"
-                value={replyTo ? "" : commentDraft}
-                disabled={!!replyTo}
-                onChange={(e) => setCommentDraft(e.target.value)}
-                placeholder={replyTo ? t("loop.comment.replyingHint") : t("loop.comment.placeholder")}
-                onKeyDown={(e) => { if (e.key === "Enter") submitComment(); }}
+            {/* 新建评论：独立区块(分割线 + 多行 textarea),明确区别于上方逐条回复 */}
+            <div className="loop-idp__newcomment">
+              <div className="loop-idp__newcomment-title">{t("loop.comment.newTitle")}</div>
+              <AutoGrowTextarea
+                className="loop-field-textarea loop-field-textarea--auto loop-idp__newcomment-input"
+                value={commentDraft}
+                onChange={setCommentDraft}
+                placeholder={t("loop.comment.placeholder")}
+                onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submitComment(); }}
               />
-              <Dropdown
-                trigger="click"
-                clickToHide
-                position="topRight"
-                render={
-                  <Dropdown.Menu>
-                    {(["member", "agent", "squad"] as const).map((type) => {
-                      const items = cands.filter((c) => c.type === type);
-                      if (!items.length) return null;
-                      return (
-                        <React.Fragment key={type}>
-                          <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
-                          {items.map((c) => (
-                            <Dropdown.Item key={c.id} onClick={() => insertMention(c)}>{c.name}</Dropdown.Item>
-                          ))}
-                        </React.Fragment>
-                      );
-                    })}
-                  </Dropdown.Menu>
-                }
-              >
-                <Button theme="borderless" icon={<AtSign size={16} />} disabled={!!replyTo} aria-label={t("loop.mention.add")} />
-              </Dropdown>
-              <label className="loop-attach-btn" aria-label={t("loop.attach.add")} style={{ opacity: replyTo ? 0.4 : 1 }}>
-                <Paperclip size={16} />
-                <input
-                  type="file"
-                  multiple
-                  hidden
-                  disabled={!!replyTo || submitting}
-                  onChange={(e) => { addPendingFiles(e.target.files); e.target.value = ""; }}
-                />
-              </label>
-              <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} loading={submitting} disabled={!!replyTo} aria-label={t("loop.comment.send")} />
+              {triggerAgents.length > 0 && (
+                <div className="loop-idp__wake">
+                  <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.comment.willWake")}</Text>
+                  {triggerAgents.map((a) => {
+                    const off = suppressed.has(a.id);
+                    return (
+                      <Tag
+                        key={a.id}
+                        size="small"
+                        color={off ? "grey" : "light-blue"}
+                        style={{ cursor: "pointer", opacity: off ? 0.55 : 1, textDecoration: off ? "line-through" : "none" }}
+                        onClick={() => toggleSuppress(a.id)}
+                      >
+                        {a.name}
+                      </Tag>
+                    );
+                  })}
+                  <Text type="tertiary" style={{ fontSize: 11 }}>{t("loop.comment.tapToSuppress")}</Text>
+                </div>
+              )}
+              {pendingFiles.length > 0 && (
+                <div className="loop-filechips">
+                  {pendingFiles.map((f, i) => (
+                    <div key={i} className="loop-filechip">
+                      <FileText size={16} className="loop-filechip__icon" />
+                      <span className="loop-filechip__name">{f.name}</span>
+                      <button type="button" className="loop-filechip__act" aria-label={t("loop.action.delete")} onClick={() => removePendingFile(i)}>
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="loop-idp__newcomment-bar">
+                <Dropdown
+                  trigger="click"
+                  clickToHide
+                  position="topRight"
+                  render={
+                    <Dropdown.Menu>
+                      {(["member", "agent", "squad"] as const).map((type) => {
+                        const items = cands.filter((c) => c.type === type);
+                        if (!items.length) return null;
+                        return (
+                          <React.Fragment key={type}>
+                            <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
+                            {items.map((c) => (
+                              <Dropdown.Item key={c.id} onClick={() => insertMention(c)}>{c.name}</Dropdown.Item>
+                            ))}
+                          </React.Fragment>
+                        );
+                      })}
+                    </Dropdown.Menu>
+                  }
+                >
+                  <Button theme="borderless" icon={<AtSign size={16} />} aria-label={t("loop.mention.add")} />
+                </Dropdown>
+                <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
+                  <Paperclip size={16} />
+                  <input
+                    type="file"
+                    multiple
+                    hidden
+                    disabled={submitting}
+                    onChange={(e) => { addPendingFiles(e.target.files); e.target.value = ""; }}
+                  />
+                </label>
+                <span style={{ flex: 1 }} />
+                <Button theme="solid" icon={<Send size={14} />} onClick={submitComment} loading={submitting} disabled={!commentDraft.trim() && pendingFiles.length === 0}>
+                  {t("loop.comment.send")}
+                </Button>
+              </div>
             </div>
           </div>
         </div>
@@ -1146,42 +1147,21 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.run.empty")}</Text>
                 ) : (
                   <>
-                    <button type="button" className="loop-idp__runs-toggle" onClick={() => setShowRuns((s) => !s)}>
-                      <ChevronRight size={13} className={`loop-idp__runs-chevron${showRuns ? " is-open" : ""}`} />
-                      {t("loop.run.showHistory", { values: { count: runs.length } })}
-                    </button>
-                    {showRuns && (
+                    {/* 运行中/排队中 —— 重点常显 */}
+                    {activeRuns.length > 0 && (
                       <div className="loop-idp__tasks">
-                        {runs.map((r) => {
-                          const active = isActiveRun(r.status);
-                          return (
-                            <div key={r.id} className="loop-idp__task">
-                              <button className="loop-idp__run" onClick={() => openRun(r)}>
-                                <span
-                                  className={`loop-idp__run-dot${active ? " is-active" : ""}`}
-                                  style={{ background: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}
-                                />
-                                <span className="loop-idp__task-main">
-                                  <strong>{r.agent_name ?? r.agent_id ?? "—"}</strong>
-                                  <small>{r.trigger_summary || fmt(r.dispatched_at ?? r.created_at)}</small>
-                                </span>
-                                <span className="loop-idp__run-status" style={{ color: RUN_STATUS_HEX[r.status] ?? RUN_STATUS_HEX_FALLBACK }}>
-                                  {t(`loop.taskStatus.${r.status}`)}
-                                </span>
-                              </button>
-                              <Button
-                                size="small"
-                                theme="borderless"
-                                type={active ? "danger" : "tertiary"}
-                                loading={!active && busyRunId === r.id}
-                                icon={active ? <Square size={13} /> : <RotateCcw size={13} />}
-                                aria-label={t(active ? "loop.run.stop" : "loop.run.rerun")}
-                                onClick={() => (active ? cancelRun(r.id) : rerun(r.id))}
-                              />
-                            </div>
-                          );
-                        })}
+                        {activeRuns.map(renderRunRow)}
                       </div>
+                    )}
+                    {/* 历史(终态) —— 折叠 */}
+                    {pastRuns.length > 0 && (
+                      <>
+                        <button type="button" className="loop-idp__runs-toggle" onClick={() => setShowRuns((s) => !s)}>
+                          <ChevronRight size={13} className={`loop-idp__runs-chevron${showRuns ? " is-open" : ""}`} />
+                          {t("loop.run.showHistory", { values: { count: pastRuns.length } })}
+                        </button>
+                        {showRuns && <div className="loop-idp__tasks">{pastRuns.map(renderRunRow)}</div>}
+                      </>
                     )}
                   </>
                 )}

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -669,7 +669,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     <div key={c.id} className={`loop-cmt__row${isRoot ? " is-root" : ""}`}>
       <div className="loop-cmt__head">
         <Avatar size="extra-extra-small" color="light-blue" src={c.author_avatar ?? undefined}>
-          {(c.author_name ?? "?").slice(0, 1)}
+          {[...(c.author_name ?? "?")][0]}
         </Avatar>
         <Text strong style={{ fontSize: 13 }}>{c.author_name}</Text>
         <time>{fmt(c.created_at)}</time>
@@ -1155,7 +1155,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
                   <span className="loop-idp__prop-k">{t("loop.field.creator")}</span>
                   <span className="loop-idp__prop-person">
                     <Avatar size="extra-extra-small" color="light-blue" src={issue.creator_avatar ?? undefined}>
-                      {(issue.creator_name ?? "?").slice(0, 1)}
+                      {[...(issue.creator_name ?? "?")][0]}
                     </Avatar>
                     {issue.creator_name ?? "—"}
                   </span>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -29,6 +29,7 @@ import {
   AtSign,
   Plus,
   ChevronRight,
+  ChevronDown,
   SlidersHorizontal,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -42,6 +43,7 @@ import type {
   TaskRun,
   IssueStatus,
   IssuePriority,
+  Project,
   CommentTriggerAgent,
 } from "../api/types";
 import {
@@ -65,8 +67,9 @@ import {
   listTimeline,
 } from "../api/collabApi";
 import { uploadAttachment } from "../api/attachmentApi";
+import { listProjects } from "../api/projectApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
-import { AssigneeBadge } from "../ui/AssigneePicker";
+import AssigneePicker from "../ui/AssigneePicker";
 import LabelEditor from "../ui/LabelEditor";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
@@ -187,6 +190,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [childCreateOpen, setChildCreateOpen] = useState(false); // 新建子 issue 弹窗
   const [propsOpen, setPropsOpen] = useState(false); // 「编辑属性」弹窗(标签/父回路/日期/阶段)
   const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
+  const [projects, setProjects] = useState<Project[]>([]); // 项目候选(内联项目 popup)
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
@@ -244,6 +248,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   };
 
   useEffect(reload, [issueId]);
+
+  // 项目候选:内联「项目」popup 用;工作区级、随详情挂载取一次。
+  useEffect(() => {
+    listProjects().then(setProjects).catch(() => {});
+  }, []);
 
   const patch = async (p: Parameters<typeof updateIssue>[1]) => {
     if (!issue) return;
@@ -590,71 +599,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setEditingDesc(false);
   };
 
-  // 右上角 ··· 菜单：快速改 status / priority / assignee（对齐产品设计）。
+  // 右上角 ··· 菜单：编辑属性(标签/父回路/日期/阶段) / 新建子回路 / 订阅 / 删除。
+  // 状态/优先级/负责人/项目 改走右栏内联点击 popup(对标 multica),不在此重复。
   const renderMoreMenu = () => (
     <Dropdown.Menu>
-      <Dropdown
-        position="leftTop"
-        trigger="hover"
-        clickToHide
-        render={
-          <Dropdown.Menu>
-            {ISSUE_STATUS_ORDER.map((s) => (
-              <Dropdown.Item key={s} active={issue?.status === s} onClick={() => issue && requestStatus(issue, s, (extra) => patch({ status: s, ...extra }))}>
-                <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        }
-      >
-        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeStatus")}</Dropdown.Item>
-      </Dropdown>
-      <Dropdown
-        position="leftTop"
-        trigger="hover"
-        clickToHide
-        render={
-          <Dropdown.Menu>
-            {PRIORITY_ORDER.map((p) => (
-              <Dropdown.Item key={p} active={issue?.priority === p} onClick={() => patch({ priority: p })}>
-                <Tag color={PRIORITY_COLOR[p]} size="small">{t(`loop.priority.${p}`)}</Tag>
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        }
-      >
-        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changePriority")}</Dropdown.Item>
-      </Dropdown>
-      <Dropdown
-        position="leftTop"
-        trigger="hover"
-        clickToHide
-        render={
-          <Dropdown.Menu>
-            <Dropdown.Item icon={<CircleSlash size={13} />} onClick={() => patch({ assignee_id: null, assignee_type: null })}>
-              {t("loop.assignee.unassigned")}
-            </Dropdown.Item>
-            {(["member", "agent", "squad"] as const).map((type) => {
-              const items = cands.filter((c) => c.type === type);
-              if (!items.length) return null;
-              return (
-                <React.Fragment key={type}>
-                  <Dropdown.Divider />
-                  <Dropdown.Title>{t(`loop.assignee.${type}`)}</Dropdown.Title>
-                  {items.map((c) => (
-                    <Dropdown.Item key={c.id} active={issue?.assignee_id === c.id} onClick={() => issue && requestAssign(issue, c.type, c.id, c.name, (extra) => patch({ assignee_id: c.id, assignee_type: c.type, ...extra }))}>
-                      {c.name}
-                    </Dropdown.Item>
-                  ))}
-                </React.Fragment>
-              );
-            })}
-          </Dropdown.Menu>
-        }
-      >
-        <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
-      </Dropdown>
-      <Dropdown.Divider />
       <Dropdown.Item icon={<SlidersHorizontal size={13} />} onClick={() => { loadParentCands(); setPropsOpen(true); }}>
         {t("loop.menu.editProps")}
       </Dropdown.Item>
@@ -1107,27 +1055,90 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             </button>
             {secOpen("props") && (
               <div className="loop-idp__asec-body">
-                <div className="loop-idp__prop">
+                {/* 状态：点击值弹 popup 改(对标 multica) */}
+                <div className="loop-idp__prop loop-idp__prop--inline">
                   <span className="loop-idp__prop-k">{t("loop.field.status")}</span>
-                  <span className="loop-idp__prop-val">
-                    <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[issue.status] }} />
-                    {t(`loop.status.${issue.status}`)}
-                  </span>
+                  <Dropdown
+                    trigger="click"
+                    position="bottomRight"
+                    clickToHide
+                    render={
+                      <Dropdown.Menu>
+                        {ISSUE_STATUS_ORDER.map((s) => (
+                          <Dropdown.Item key={s} active={issue.status === s} onClick={() => requestStatus(issue, s, (extra) => patch({ status: s, ...extra }))}>
+                            <Tag color={ISSUE_STATUS_COLOR[s]} size="small">{t(`loop.status.${s}`)}</Tag>
+                          </Dropdown.Item>
+                        ))}
+                      </Dropdown.Menu>
+                    }
+                  >
+                    <button type="button" className="loop-idp__prop-edit">
+                      <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[issue.status] }} />
+                      {t(`loop.status.${issue.status}`)}
+                      <ChevronDown size={12} className="loop-idp__prop-caret" />
+                    </button>
+                  </Dropdown>
                 </div>
-                <div className="loop-idp__prop">
+                {/* 优先级 */}
+                <div className="loop-idp__prop loop-idp__prop--inline">
                   <span className="loop-idp__prop-k">{t("loop.field.priority")}</span>
-                  <span className="loop-idp__prop-val">
-                    <PriIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[issue.priority] }} />
-                    {t(`loop.priority.${issue.priority}`)}
-                  </span>
+                  <Dropdown
+                    trigger="click"
+                    position="bottomRight"
+                    clickToHide
+                    render={
+                      <Dropdown.Menu>
+                        {PRIORITY_ORDER.map((p) => (
+                          <Dropdown.Item key={p} active={issue.priority === p} onClick={() => patch({ priority: p })}>
+                            <Tag color={PRIORITY_COLOR[p]} size="small">{t(`loop.priority.${p}`)}</Tag>
+                          </Dropdown.Item>
+                        ))}
+                      </Dropdown.Menu>
+                    }
+                  >
+                    <button type="button" className="loop-idp__prop-edit">
+                      <PriIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[issue.priority] }} />
+                      {t(`loop.priority.${issue.priority}`)}
+                      <ChevronDown size={12} className="loop-idp__prop-caret" />
+                    </button>
+                  </Dropdown>
                 </div>
-                <div className="loop-idp__prop">
+                {/* 负责人：复用 AssigneePicker(自带点击 popup + 三态) */}
+                <div className="loop-idp__prop loop-idp__prop--inline">
                   <span className="loop-idp__prop-k">{t("loop.field.assignee")}</span>
-                  <AssigneeBadge type={issue.assignee_type} name={issue.assignee_name ?? null} />
+                  <AssigneePicker
+                    size="small"
+                    value={issue.assignee_id}
+                    valueName={issue.assignee_name ?? null}
+                    onChange={(id, type, name) => requestAssign(issue, type, id, name, (extra) => patch({ assignee_id: id, assignee_type: type, ...extra }))}
+                  />
                 </div>
-                <div className="loop-idp__prop">
+                {/* 项目 */}
+                <div className="loop-idp__prop loop-idp__prop--inline">
                   <span className="loop-idp__prop-k">{t("loop.field.project")}</span>
-                  <span className="loop-idp__prop-v">{issue.project_name ?? "—"}</span>
+                  <Dropdown
+                    trigger="click"
+                    position="bottomRight"
+                    clickToHide
+                    render={
+                      <Dropdown.Menu>
+                        <Dropdown.Item active={!issue.project_id} onClick={() => patch({ project_id: null })}>
+                          {t("loop.field.noProject")}
+                        </Dropdown.Item>
+                        {projects.length > 0 && <Dropdown.Divider />}
+                        {projects.map((p) => (
+                          <Dropdown.Item key={p.id} active={issue.project_id === p.id} onClick={() => patch({ project_id: p.id })}>
+                            {p.icon} {p.title}
+                          </Dropdown.Item>
+                        ))}
+                      </Dropdown.Menu>
+                    }
+                  >
+                    <button type="button" className="loop-idp__prop-edit loop-idp__prop-edit--text">
+                      {issue.project_name ?? t("loop.field.noProject")}
+                      <ChevronDown size={12} className="loop-idp__prop-caret" />
+                    </button>
+                  </Dropdown>
                 </div>
               </div>
             )}

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -637,6 +637,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
+      <Dropdown.Item icon={<Plus size={13} />} onClick={() => setChildCreateOpen(true)}>
+        {t("loop.subIssue.create")}
+      </Dropdown.Item>
+      <Dropdown.Divider />
       {/* 订阅态不可判定(未加载/加载失败/后端未透出 octo_uid)时两项都显示,保证 unsubscribe 可达 */}
       {!selfKnown ? (
         <>
@@ -708,7 +712,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             clickToHide
             render={
               <Dropdown.Menu>
-                <Dropdown.Item icon={<Copy size={13} />} onClick={() => { navigator.clipboard?.writeText(c.content).then(() => Toast.success(t("loop.run.copied"))).catch(() => {}); }}>
+                <Dropdown.Item icon={<Copy size={13} />} onClick={() => { navigator.clipboard?.writeText(c.content)?.then(() => Toast.success(t("loop.run.copied"))).catch(() => {}); }}>
                   {t("loop.action.copy")}
                 </Dropdown.Item>
                 <Dropdown.Item icon={c.resolved_at ? <CircleSlash size={13} /> : <Check size={13} />} onClick={() => toggleResolve(c.id, !!c.resolved_at)}>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -8,6 +8,9 @@ import {
   Spin,
   Toast,
   Dropdown,
+  Modal,
+  DatePicker,
+  InputNumber,
 } from "@douyinfe/semi-ui";
 import {
   ArrowLeft,
@@ -26,6 +29,7 @@ import {
   AtSign,
   Plus,
   ChevronRight,
+  SlidersHorizontal,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
@@ -47,6 +51,7 @@ import {
   deleteIssue,
   listComments,
   listChildren,
+  listIssues,
   addComment,
   deleteComment,
   previewCommentTriggers,
@@ -62,6 +67,7 @@ import {
 import { uploadAttachment } from "../api/attachmentApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import { AssigneeBadge } from "../ui/AssigneePicker";
+import LabelEditor from "../ui/LabelEditor";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -179,6 +185,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [subLoaded, setSubLoaded] = useState(false);
   const [children, setChildren] = useState<Issue[]>([]);
   const [childCreateOpen, setChildCreateOpen] = useState(false); // 新建子 issue 弹窗
+  const [propsOpen, setPropsOpen] = useState(false); // 「编辑属性」弹窗(标签/父回路/日期/阶段)
+  const [parentCands, setParentCands] = useState<Issue[]>([]); // 父 issue 选择器候选(懒加载)
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [runs, setRuns] = useState<TaskRun[]>([]);
   const [activeRun, setActiveRun] = useState<TaskRun | null>(null);
@@ -216,6 +224,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     setChildren([]);
     setSubscribers([]);
     setSubLoaded(false);
+    setParentCands([]);
     setTimeline([]);
     Promise.all([getIssue(issueId), listComments(issueId), listRuns(issueId)])
       .then(([i, c, r]) => {
@@ -265,6 +274,15 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const reloadComments = async (token: number) => {
     const c = await listComments(issueId);
     if (token === reqRef.current) setComments(c);
+  };
+
+  // 父 issue 选择器:「编辑属性」弹窗展开时懒加载工作区 issue 作候选(排除自己;环检测由后端兜底)。
+  const loadParentCands = () => {
+    if (parentCands.length) return;
+    const token = reqRef.current;
+    listIssues({ limit: 100 })
+      .then((r) => { if (token === reqRef.current) setParentCands(r.issues.filter((i) => i.id !== issueId)); })
+      .catch(() => {});
   };
 
   // 订阅/取消订阅(后端默认操作调用者本人、幂等)。
@@ -637,6 +655,9 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
         <Dropdown.Item onClick={(e) => e.stopPropagation()}>{t("loop.menu.changeAssignee")}</Dropdown.Item>
       </Dropdown>
       <Dropdown.Divider />
+      <Dropdown.Item icon={<SlidersHorizontal size={13} />} onClick={() => { loadParentCands(); setPropsOpen(true); }}>
+        {t("loop.menu.editProps")}
+      </Dropdown.Item>
       <Dropdown.Item icon={<Plus size={13} />} onClick={() => setChildCreateOpen(true)}>
         {t("loop.subIssue.create")}
       </Dropdown.Item>
@@ -1189,6 +1210,72 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           onChanged?.();
         }}
       />
+
+      {/* 编辑属性弹窗：标签 / 父回路 / 开始/截止日期 / 阶段（侧栏保持只读，编辑走 ⋯ → 此弹窗） */}
+      <Modal
+        className="loop-modal"
+        title={t("loop.menu.editProps")}
+        visible={propsOpen}
+        onCancel={() => setPropsOpen(false)}
+        footer={null}
+        width={460}
+      >
+        <div className="loop-fields">
+          <div className="loop-fields__row">
+            <div className="loop-fields__label">{t("loop.field.labels")}</div>
+            <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
+          </div>
+          <div className="loop-fields__row">
+            <div className="loop-fields__label">{t("loop.field.parent")}</div>
+            <Select
+              value={issue.parent_issue_id ?? undefined}
+              onChange={(v) => patch({ parent_issue_id: (v as string) || "" })}
+              dropdownClassName="loop-fields__dropdown"
+              placeholder={t("loop.field.noParent")}
+              filter
+              showClear
+              style={{ width: "100%" }}
+            >
+              {parentCands.map((i) => (
+                <Select.Option key={i.id} value={i.id}>{i.identifier} {i.title}</Select.Option>
+              ))}
+            </Select>
+          </div>
+          <div className="loop-fields__row">
+            <div className="loop-fields__inline">
+              <div style={{ flex: 1 }}>
+                <div className="loop-fields__label">{t("loop.field.startDate")}</div>
+                <DatePicker
+                  type="date"
+                  format="yyyy-MM-dd"
+                  value={issue.start_date ? issue.start_date.slice(0, 10) : undefined}
+                  onChange={(_, ds) => patch({ start_date: (ds as string) || "" })}
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div className="loop-fields__label">{t("loop.field.dueDate")}</div>
+                <DatePicker
+                  type="date"
+                  format="yyyy-MM-dd"
+                  value={issue.due_date ? issue.due_date.slice(0, 10) : undefined}
+                  onChange={(_, ds) => patch({ due_date: (ds as string) || "" })}
+                  style={{ width: "100%" }}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="loop-fields__row">
+            <div className="loop-fields__label">{t("loop.field.stage")}</div>
+            <InputNumber
+              value={issue.stage ?? undefined}
+              onChange={(v) => { if (typeof v === "number") patch({ stage: v }); }}
+              min={1}
+              style={{ width: "100%" }}
+            />
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Table, Select, Tag, Typography, Button, Toast } from "@douyinfe/semi-ui";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Select, Button, Toast } from "@douyinfe/semi-ui";
 import { Trash2, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Issue, IssueStatus, IssuePriority } from "../api/types";
-import { updateIssue, batchUpdateIssues, batchDeleteIssues } from "../api/issueApi";
+import { batchUpdateIssues, batchDeleteIssues, updateIssue } from "../api/issueApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelChips from "../ui/LabelChips";
 import RunningChip from "../ui/RunningChip";
@@ -11,12 +11,13 @@ import { confirmDelete } from "../ui/confirmDelete";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import {
   ISSUE_STATUS_ORDER,
-  ISSUE_STATUS_COLOR,
+  ISSUE_STATUS_ICON,
+  ISSUE_STATUS_HEX,
   PRIORITY_ORDER,
-  PRIORITY_COLOR,
+  PRIORITY_ICON,
+  PRIORITY_HEX,
 } from "../ui/meta";
-
-const { Text } = Typography;
+import { formatRelativeTime } from "../ui/time";
 
 // 批量操作下拉是纯命令菜单(选后触发动作、不持有值);受控 value 恒空。
 const NO_VALUE = undefined as unknown as string;
@@ -29,21 +30,27 @@ export interface IssueListProps {
   running?: ReadonlySet<string>;
 }
 
-/** 列表视图：行内改 status/priority/assignee + 多选批量改删。 */
+/** 列表视图：按状态分组的清爽行 + 多选批量改删（对齐 Figma；行内编辑收敛到批量条与详情页）。 */
 export default function IssueList({
   issues,
   onOpen,
   onChanged,
   running,
 }: IssueListProps) {
-  const { t } = useI18n();
-  const { requestAssign, requestStatus, runConfirmModal } = useRunConfirm();
+  const { t, format } = useI18n();
+  const { requestAssign, runConfirmModal } = useRunConfirm();
   const [selected, setSelected] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   // busy 的同步镜像:setBusy 是异步的,confirmDelete 弹窗的 onOk 闭包捕获的是渲染时的
   // busy(可能陈旧),双击开两个弹窗/两次 onOk 会各自看到 busy=false 而重复批量写。ref
   // 在进入 runBatch 时同步置位,结构性挡住重入(setBusy 仅驱动 UI 的 disabled)。
   const busyRef = useRef(false);
+
+  // 行内指派改派（保留旧列表的行内编辑能力）：写库后刷新；触发 agent run 走 RunConfirm 预确认。
+  const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
+    await updateIssue(id, p);
+    onChanged();
+  };
 
   // 筛选/搜索/排序/翻页令 issues 变化后,裁掉已不可见的选中项 —— 否则批量条会对
   // 当前结果集看不到的行发批量写(改/删隐藏行)。只保留仍在可见集合里的 id。
@@ -55,15 +62,24 @@ export default function IssueList({
     });
   }, [issues]);
 
-  const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
-    await updateIssue(id, p);
-    onChanged();
-  };
+  // 按状态分组（保留服务端返回的组内顺序，即用户所选排序）；仅渲染非空组。
+  const groups = useMemo(
+    () =>
+      ISSUE_STATUS_ORDER.map((status) => ({
+        status,
+        rows: issues.filter((i) => i.status === status),
+      })).filter((g) => g.rows.length > 0),
+    [issues],
+  );
+
+  const selectedSet = new Set(selected);
+  const toggleRow = (id: string) =>
+    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
 
   // 批量:写失败 toast+中止;成功清选择+刷新。批量不走 RunConfirm 预览(显式批操作);
   // 且一律带 suppress_run —— 批量改状态/指派是管理性整理,绝不能每条静默起一个 agent run
   // (要派单请逐条走 RunConfirm 预览确认)。派单是有意的单条动作,不是批量副作用。
-  // 重入守卫用 busyRef 同步置位(见上):任一触发器在途都挡住重叠批量写,不受闭包 stale 影响。
+  // 重入守卫用 busyRef 同步置位:任一触发器在途都挡住重叠批量写,不受闭包 stale 影响。
   const runBatch = async (fn: () => Promise<unknown>) => {
     if (busyRef.current) return;
     busyRef.current = true;
@@ -81,103 +97,17 @@ export default function IssueList({
     }
   };
 
-  const columns = [
-    {
-      title: "ID",
-      dataIndex: "identifier",
-      width: 96,
-      render: (v: string) => (
-        <Text type="tertiary" style={{ fontSize: 12 }}>
-          {v}
-        </Text>
-      ),
-    },
-    {
-      title: t("loop.field.title"),
-      dataIndex: "title",
-      render: (v: string, r: Issue) => (
-        <span className="loop-cell-title" onClick={() => onOpen(r.id)}>
-          {v}
-          {running?.has(r.id) && <RunningChip />}
-          <LabelChips labels={r.labels} max={3} />
-        </span>
-      ),
-    },
-    {
-      title: t("loop.field.status"),
-      dataIndex: "status",
-      width: 150,
-      render: (v: IssueStatus, r: Issue) => (
-        <Select
-          value={v}
-          size="small"
-          borderless
-          onChange={(nv) => requestStatus(r, nv as IssueStatus, (extra) => patch(r.id, { status: nv as IssueStatus, ...extra }))}
-          style={{ width: 130 }}
-        >
-          {ISSUE_STATUS_ORDER.map((s) => (
-            <Select.Option key={s} value={s}>
-              <Tag color={ISSUE_STATUS_COLOR[s]} size="small">
-                {t(`loop.status.${s}`)}
-              </Tag>
-            </Select.Option>
-          ))}
-        </Select>
-      ),
-    },
-    {
-      title: t("loop.field.priority"),
-      dataIndex: "priority",
-      width: 130,
-      render: (v: IssuePriority, r: Issue) => (
-        <Select
-          value={v}
-          size="small"
-          borderless
-          onChange={(nv) => patch(r.id, { priority: nv as IssuePriority })}
-          style={{ width: 110 }}
-        >
-          {PRIORITY_ORDER.map((p) => (
-            <Select.Option key={p} value={p}>
-              <Tag color={PRIORITY_COLOR[p]} size="small">
-                {t(`loop.priority.${p}`)}
-              </Tag>
-            </Select.Option>
-          ))}
-        </Select>
-      ),
-    },
-    {
-      title: t("loop.field.assignee"),
-      dataIndex: "assignee_id",
-      width: 180,
-      render: (_v: string, r: Issue) => (
-        <AssigneePicker
-          size="small"
-          value={r.assignee_id}
-          valueName={r.assignee_name ?? null}
-          onChange={(id, type, name) => requestAssign(r, type, id, name, (extra) => patch(r.id, { assignee_id: id, assignee_type: type, ...extra }))}
-        />
-      ),
-    },
-    {
-      title: t("loop.field.project"),
-      dataIndex: "project_name",
-      width: 130,
-      render: (v: string | null) => <Text>{v ?? "—"}</Text>,
-    },
-  ];
-
   return (
     <>
       {selected.length > 0 && (
         <div className="loop-batchbar">
-          <Text strong>{t("loop.batch.selected", { values: { count: selected.length } })}</Text>
+          <strong>{t("loop.batch.selected", { values: { count: selected.length } })}</strong>
           <Select
             placeholder={t("loop.menu.changeStatus")}
             size="small"
             disabled={busy}
             value={NO_VALUE}
+            dropdownClassName="loop-fields__dropdown"
             onChange={(v) => runBatch(() => batchUpdateIssues(selected, { status: v as IssueStatus, suppress_run: true }))}
             style={{ width: 130 }}
           >
@@ -190,6 +120,7 @@ export default function IssueList({
             size="small"
             disabled={busy}
             value={NO_VALUE}
+            dropdownClassName="loop-fields__dropdown"
             onChange={(v) => runBatch(() => batchUpdateIssues(selected, { priority: v as IssuePriority, suppress_run: true }))}
             style={{ width: 120 }}
           >
@@ -223,17 +154,52 @@ export default function IssueList({
           <Button size="small" theme="borderless" icon={<X size={14} />} onClick={() => setSelected([])} aria-label={t("loop.action.cancel")} />
         </div>
       )}
-      <Table
-        rowKey="id"
-        columns={columns}
-        dataSource={issues}
-        pagination={false}
-        size="small"
-        rowSelection={{
-          selectedRowKeys: selected,
-          onChange: (keys) => setSelected((keys ?? []) as string[]),
-        }}
-      />
+
+      <div className="loop-list">
+        {groups.map((g) => {
+          const StatusIcon = ISSUE_STATUS_ICON[g.status];
+          return (
+            <div key={g.status} className="loop-list__group">
+              <div className="loop-list__group-head">
+                <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[g.status] }} />
+                <span className="loop-list__group-name">{t(`loop.status.${g.status}`)}</span>
+                <em>{g.rows.length}</em>
+              </div>
+              {g.rows.map((r) => {
+                const PriIcon = PRIORITY_ICON[r.priority];
+                const checked = selectedSet.has(r.id);
+                return (
+                  <div key={r.id} className={`loop-list__row ${checked ? "is-selected" : ""}`}>
+                    <label className="loop-list__check" onClick={(e) => e.stopPropagation()}>
+                      <input type="checkbox" checked={checked} onChange={() => toggleRow(r.id)} />
+                    </label>
+                    <span className="loop-list__icon" title={t(`loop.priority.${r.priority}`)}>
+                      <PriIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[r.priority] }} />
+                    </span>
+                    <button className="loop-list__title" onClick={() => onOpen(r.id)}>
+                      {r.title}
+                      {running?.has(r.id) && <RunningChip />}
+                    </button>
+                    <LabelChips labels={r.labels} max={2} />
+                    <span className="loop-list__spacer" />
+                    {r.project_name && <span className="loop-list__project">{r.project_name}</span>}
+                    <span className="loop-list__id">{r.identifier}</span>
+                    <span className="loop-list__assignee" onClick={(e) => e.stopPropagation()}>
+                      <AssigneePicker
+                        size="small"
+                        value={r.assignee_id}
+                        valueName={r.assignee_name ?? null}
+                        onChange={(id, type, name) => requestAssign(r, type, id, name, (extra) => patch(r.id, { assignee_id: id, assignee_type: type, ...extra }))}
+                      />
+                    </span>
+                    <time className="loop-list__time">{formatRelativeTime(r.updated_at ?? r.created_at, format)}</time>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
       {runConfirmModal}
     </>
   );

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -1,28 +1,133 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Modal, Spin, Tag, Typography, Empty } from "@douyinfe/semi-ui";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Modal, Spin, Empty, Toast } from "@douyinfe/semi-ui";
+import {
+  Bot,
+  Brain,
+  AlertCircle,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Copy,
+  Check,
+  ChevronRight,
+  Clock,
+} from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { TaskRun, RunMessage } from "../api/types";
 import { listRunMessages, listRuns } from "../api/runsApi";
-import { RUN_STATUS_COLOR, isActiveRun } from "../ui/meta";
-
-const { Text } = Typography;
+import { isActiveRun } from "../ui/meta";
+import { formatDurationMs } from "../ui/time";
 
 const POLL_MS = 2000;
 
-function fmt(iso?: string | null): string {
-  if (!iso) return "-";
+type EventColor = "agent" | "thinking" | "tool" | "result" | "error";
+
+function eventColor(m: RunMessage): EventColor {
+  switch (m.type) {
+    case "text": return "agent";
+    case "thinking": return "thinking";
+    case "tool_use": return "tool";
+    case "tool_result": return "result";
+    case "error": return "error";
+    default: return "result";
+  }
+}
+
+function shortenPath(p: string): string {
+  const parts = p.split("/");
+  return parts.length <= 3 ? p : ".../" + parts.slice(-2).join("/");
+}
+
+function eventSummary(m: RunMessage): string {
+  switch (m.type) {
+    case "text": return m.content?.split("\n").find((l) => l.trim().length > 0) ?? "";
+    case "thinking": return m.content?.slice(0, 200) ?? "";
+    case "tool_use": {
+      const inp = (m.input ?? {}) as Record<string, unknown>;
+      const pick = inp.query ?? inp.file_path ?? inp.path ?? inp.pattern ?? inp.description ?? inp.command ?? inp.prompt ?? inp.skill;
+      if (typeof pick === "string") {
+        const s = inp.file_path || inp.path ? shortenPath(pick) : pick;
+        return s.length > 140 ? s.slice(0, 140) + "…" : s;
+      }
+      return "";
+    }
+    case "tool_result": return m.output?.slice(0, 200) ?? "";
+    case "error": return m.content ?? "";
+    default: return "";
+  }
+}
+
+function eventDetail(m: RunMessage): string {
+  if (m.type === "tool_use") return m.input ? JSON.stringify(m.input, null, 2) : "";
+  if (m.type === "tool_result") {
+    const o = m.output ?? "";
+    return o.length > 4000 ? o.slice(0, 4000) + "\n… (truncated)" : o;
+  }
+  return m.content ?? "";
+}
+
+function fmtTime(iso?: string | null): string {
+  if (!iso) return "";
   const d = new Date(iso);
-  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
 }
 
-function msgText(m: RunMessage): string {
-  if (m.output) return m.output; // tool_result
-  if (m.content) return m.content; // text / thinking / error
-  if (m.input) return JSON.stringify(m.input, null, 2); // tool_use
-  return "";
+/** 单个事件行：类型徽标 + 摘要 + 序号/时间 + 可展开详情。 */
+function TranscriptRow({ m, label }: { m: RunMessage; label: string }) {
+  const [open, setOpen] = useState(false);
+  const color = eventColor(m);
+  const summary = eventSummary(m);
+  const detail = eventDetail(m);
+  const hasDetail = detail.length > 0;
+  return (
+    <div className={`loop-tr__row loop-tr__row--${color}`}>
+      <button type="button" className="loop-tr__line" disabled={!hasDetail} onClick={() => setOpen((o) => !o)}>
+        <span className={`loop-tr__badge loop-tr__badge--${color}`}>
+          {m.type === "thinking" && <Brain size={11} />}
+          {m.type === "error" && <AlertCircle size={11} />}
+          {label}
+        </span>
+        <span className="loop-tr__summary">
+          {hasDetail && <ChevronRight size={12} className={`loop-tr__chevron${open ? " is-open" : ""}`} />}
+          <span className="loop-tr__summary-text">{summary || "—"}</span>
+        </span>
+        <span className="loop-tr__seq">#{m.seq}</span>
+        {m.created_at && <time className="loop-tr__time">{fmtTime(m.created_at)}</time>}
+      </button>
+      {open && hasDetail && (
+        <pre className="loop-tr__detail">{detail}</pre>
+      )}
+    </div>
+  );
 }
 
-/** 执行详情弹窗：状态/时间/触发 + 消息流（run-messages）。 */
+/** 时间线进度条：按连续同色分段，点击滚动到对应事件（简化为纯展示）。 */
+function TimelineBar({ messages }: { messages: RunMessage[] }) {
+  const segments = useMemo(() => {
+    const segs: { color: EventColor; count: number }[] = [];
+    let cur: EventColor | null = null;
+    for (const m of messages) {
+      const c = eventColor(m);
+      if (c !== cur) { segs.push({ color: c, count: 1 }); cur = c; }
+      else segs[segs.length - 1].count += 1;
+    }
+    return segs;
+  }, [messages]);
+  const total = messages.length || 1;
+  return (
+    <div className="loop-tr__bar">
+      {segments.map((s, i) => (
+        <span
+          key={i}
+          className={`loop-tr__bar-seg loop-tr__bar-seg--${s.color}`}
+          style={{ width: `${Math.max((s.count / total) * 100, 0.5)}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** 执行详情弹窗：转写体验（对齐 multica）——状态/时长 + 时间线 + 可展开事件流。 */
 export default function RunDetailModal({
   run,
   visible,
@@ -34,11 +139,12 @@ export default function RunDetailModal({
 }) {
   const { t } = useI18n();
   const [messages, setMessages] = useState<RunMessage[]>([]);
-  const [liveRun, setLiveRun] = useState<TaskRun | null>(run); // 随轮询刷新的 run 状态(点击时快照会过时)
+  const [liveRun, setLiveRun] = useState<TaskRun | null>(run);
   const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
   const lastSeqRef = useRef(0);
 
-  // 打开时全量拉;运行中的 run 则每 2s 用 ?since 增量轮询消息 + 刷新 run 状态,终态即停(dmloop 无后端 WS 推送,退化为轮询)。
+  // 打开时全量拉;运行中的 run 则每 2s 增量轮询 + 刷新状态,终态即停(无 WS,退化轮询)。
   useEffect(() => {
     if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; return; }
     let cancelled = false;
@@ -50,14 +156,12 @@ export default function RunDetailModal({
       if (batch.length) lastSeqRef.current = Math.max(lastSeqRef.current, ...batch.map((m) => m.seq));
       if (!incremental) { setMessages(batch); return; }
       if (!batch.length) return;
-      // ponytail: dedup by seq——保险起见,防 ?since 若为闭区间(未从前端核实)时重复;严格排他时此过滤无副作用。
       setMessages((prev) => {
         const seen = new Set(prev.map((m) => m.seq));
         return [...prev, ...batch.filter((m) => !seen.has(m.seq))];
       });
     };
 
-    // 每轮:拉消息增量 + 刷新 run 状态;run 到终态则停止轮询。
     const poll = () => {
       timer = setTimeout(async () => {
         if (cancelled) return;
@@ -85,58 +189,91 @@ export default function RunDetailModal({
   }, [visible, run]);
 
   const shown = liveRun ?? run;
+  const active = shown ? isActiveRun(shown.status) : false;
+
+  const eventLabel = (m: RunMessage): string => {
+    if ((m.type === "tool_use" || m.type === "tool_result") && m.tool) return m.tool;
+    if (m.type === "text") return t("loop.run.event.text");
+    if (m.type === "thinking") return t("loop.run.event.thinking");
+    if (m.type === "tool_use") return t("loop.run.event.tool");
+    if (m.type === "tool_result") return t("loop.run.event.result");
+    if (m.type === "error") return t("loop.run.event.error");
+    return m.type;
+  };
+
+  const toolCount = messages.filter((m) => m.type === "tool_use").length;
+  const duration = shown?.started_at && shown?.completed_at
+    ? formatDurationMs(new Date(shown.completed_at).getTime() - new Date(shown.started_at).getTime())
+    : null;
+
+  const copyAll = () => {
+    const text = messages.map((m) => `[${eventLabel(m)}] ${eventSummary(m)}`).join("\n");
+    navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      Toast.success(t("loop.run.copied"));
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  };
+
+  const statusBadge = !shown ? null : active ? (
+    <span className="loop-tr__status loop-tr__status--running"><Loader2 size={12} className="loop-spin" />{t("loop.taskStatus.running")}</span>
+  ) : shown.status === "completed" ? (
+    <span className="loop-tr__status loop-tr__status--ok"><CheckCircle2 size={12} />{t("loop.taskStatus.completed")}</span>
+  ) : shown.status === "failed" ? (
+    <span className="loop-tr__status loop-tr__status--fail"><XCircle size={12} />{t("loop.taskStatus.failed")}</span>
+  ) : (
+    <span className="loop-tr__status">{t(`loop.taskStatus.${shown.status}`)}</span>
+  );
+
+  const header = (
+    <div className="loop-tr__head">
+      <span className="loop-tr__agent"><Bot size={15} />{shown?.agent_name ?? shown?.agent_id ?? "—"}</span>
+      {statusBadge}
+      <button type="button" className="loop-tr__copy" onClick={copyAll}>
+        {copied ? <Check size={13} /> : <Copy size={13} />}
+        {copied ? t("loop.run.copied") : t("loop.run.copyAll")}
+      </button>
+    </div>
+  );
 
   return (
     <Modal
-      className="loop-modal"
-      title={t("loop.run.detailTitle")}
+      className="loop-modal loop-tr-modal"
+      title={header}
       visible={visible}
       onCancel={onClose}
       footer={null}
-      width={720}
-      bodyStyle={{ maxHeight: "70vh", overflow: "auto" }}
+      width={880}
+      bodyStyle={{ maxHeight: "72vh", overflow: "auto", padding: 0 }}
     >
       {!shown ? null : (
-        <div className="loop-run-detail">
-          <div className="loop-run-detail__head">
-            <Tag color={RUN_STATUS_COLOR[shown.status] ?? "grey"}>{t(`loop.taskStatus.${shown.status}`)}</Tag>
-            <span className="loop-run-detail__meta">
-              <Text type="tertiary">{shown.agent_name ?? shown.agent_id ?? "—"}</Text>
-              {shown.trigger_summary && <Text type="tertiary"> · {shown.trigger_summary}</Text>}
-            </span>
+        <div className="loop-tr">
+          <div className="loop-tr__chips">
+            {shown.trigger_summary && <span className="loop-tr__chip">{shown.trigger_summary}</span>}
+            {duration && <span className="loop-tr__chip"><Clock size={12} />{duration}</span>}
+            {toolCount > 0 && <span className="loop-tr__chip">{t("loop.run.toolCalls", { values: { count: toolCount } })}</span>}
+            <span className="loop-tr__chip">{t("loop.run.events", { values: { count: messages.length } })}</span>
           </div>
-          <dl className="loop-run-detail__props">
-            <dt>{t("loop.run.dispatched")}</dt><dd>{fmt(shown.dispatched_at)}</dd>
-            <dt>{t("loop.run.started")}</dt><dd>{fmt(shown.started_at)}</dd>
-            <dt>{t("loop.run.completed")}</dt><dd>{fmt(shown.completed_at)}</dd>
-          </dl>
+
+          {messages.length > 0 && <TimelineBar messages={messages} />}
 
           {shown.result?.output && (
-            <div className="loop-run-detail__section">
-              <div className="loop-detail__section-title">{t("loop.run.result")}</div>
-              <pre className="loop-run-detail__output">{shown.result.output}</pre>
-            </div>
+            <pre className="loop-tr__result">{shown.result.output}</pre>
           )}
 
-          <div className="loop-run-detail__section">
-            <div className="loop-detail__section-title">{t("loop.run.messages")}</div>
+          <div className="loop-tr__list">
             {loading ? (
-              <div style={{ textAlign: "center", padding: 24 }}><Spin /></div>
+              <div className="loop-tr__center"><Spin /></div>
             ) : messages.length === 0 ? (
-              <Empty description={t("loop.run.noMessages")} />
-            ) : (
-              <div className="loop-run-msgs">
-                {messages.map((m, i) => (
-                  <div key={`${m.seq}-${i}`} className="loop-run-msg">
-                    <div className="loop-run-msg__head">
-                      <Tag size="small" color="blue">{m.type}</Tag>
-                      {m.tool && <Text type="tertiary" style={{ fontSize: 12 }}>{m.tool}</Text>}
-                      <time>{fmt(m.created_at)}</time>
-                    </div>
-                    <pre className="loop-run-msg__body">{msgText(m)}</pre>
-                  </div>
-                ))}
+              <div className="loop-tr__center">
+                {active ? (
+                  <span className="loop-tr__waiting"><Loader2 size={14} className="loop-spin" />{t("loop.run.waiting")}</span>
+                ) : (
+                  <Empty description={t("loop.run.noData")} />
+                )}
               </div>
+            ) : (
+              messages.map((m, i) => <TranscriptRow key={`${m.seq}-${i}`} m={m} label={eventLabel(m)} />)
             )}
           </div>
         </div>

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -208,7 +208,7 @@ export default function RunDetailModal({
 
   const copyAll = () => {
     const text = messages.map((m) => `[${eventLabel(m)}] ${eventSummary(m)}`).join("\n");
-    navigator.clipboard?.writeText(text).then(() => {
+    navigator.clipboard?.writeText(text)?.then(() => {
       setCopied(true);
       Toast.success(t("loop.run.copied"));
       setTimeout(() => setCopied(false), 2000);

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -339,15 +339,27 @@
 .loop-idp__prop-k { font-size: 12px; color: var(--semi-color-text-2, #8a8f99); }
 .loop-idp__prop-v { font-size: 13px; color: var(--semi-color-text-0, #1f2329); }
 .loop-idp__prop-v--muted { color: var(--semi-color-text-2, #6b7075); }
-/* 状态/优先级 只读值：图标 + 文字 */
-.loop-idp__prop-val {
+/* 内联可编辑属性值：点击弹 popup(对标 multica),hover 提示可点 */
+.loop-idp__prop-edit {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  max-width: 170px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 3px 6px;
+  margin-right: -6px;
+  border-radius: 6px;
   font-size: 13px;
   font-weight: 500;
   color: var(--semi-color-text-0, #1f2329);
+  transition: background-color 120ms ease;
 }
+.loop-idp__prop-edit:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-idp__prop-edit--text { overflow: hidden; }
+.loop-idp__prop-edit--text > :first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-idp__prop-caret { flex: 0 0 auto; color: var(--semi-color-text-3, #b8bcc8); }
 /* 创建者 只读值：头像 + 名字 */
 .loop-idp__prop-person {
   display: inline-flex;

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -76,13 +76,22 @@
   margin-bottom: 8px;
 }
 
-/* 评论输入区 */
-.loop-idp__composer {
-  margin-top: 12px;
+/* 新建评论区块：分割线 + 多行 textarea + 工具栏，明确区别于逐条回复 */
+.loop-idp__newcomment {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--semi-color-border, #e8e9eb);
   display: flex;
-  gap: 8px;
-  align-items: center;
+  flex-direction: column;
+  gap: 10px;
 }
+.loop-idp__newcomment-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+}
+.loop-idp__newcomment-input.loop-field-textarea { min-height: 76px; }
+.loop-idp__newcomment-bar { display: flex; align-items: center; gap: 6px; }
 
 /* 执行记录行：状态圆点 + 名称 + 状态文字 */
 .loop-idp__run-dot {
@@ -297,14 +306,15 @@
 .loop-idp__aside {
   border-left: 1px solid var(--semi-color-border, #e8e9eb);
   overflow: auto;
-  padding: 20px 18px;
+  padding: 4px 18px 20px;
   background: var(--semi-color-bg-0, #fff);
   display: flex;
   flex-direction: column;
-  gap: 22px;
 }
 
-.loop-idp__asec { display: flex; flex-direction: column; gap: 12px; }
+.loop-idp__asec { display: flex; flex-direction: column; gap: 12px; padding: 18px 0; }
+/* 分组之间用分割线分开(对齐 Figma 29-1593) */
+.loop-idp__asec + .loop-idp__asec { border-top: 1px solid var(--semi-color-border, #e8e9eb); }
 .loop-idp__asec-head {
   display: flex;
   align-items: center;

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -12,62 +12,215 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 16px;
+  height: 48px;
+  padding: 0 16px;
   border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
   flex: 0 0 auto;
 }
 
+/* 面包屑：项目 › 编号 + 标题 */
+.loop-idp__crumbs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.loop-idp__crumb {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 3px 6px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-1, #555b61);
+  white-space: nowrap;
+}
+.loop-idp__crumb:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-idp__crumb-sep { color: var(--semi-color-text-3, #b8bcc8); flex: 0 0 auto; }
+.loop-idp__crumb-cur { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
+.loop-idp__crumb-id {
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  flex: 0 0 auto;
+}
+.loop-idp__crumb-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.loop-idp__boardbtn { flex: 0 0 auto; }
+
+/* 主体标题输入 */
+.loop-idp__title.loop-field {
+  height: auto;
+  padding: 6px 10px;
+  font-size: 22px;
+  font-weight: 700;
+  border-color: transparent;
+  background: transparent;
+}
+.loop-idp__title.loop-field:hover { border-color: var(--semi-color-border, #e8e9eb); background: var(--semi-color-bg-0, #fff); }
+.loop-idp__title.loop-field:focus { background: var(--semi-color-bg-0, #fff); }
+
+/* 分区标题（替代旧 loop-detail__section-title，落在 loop 设计准则内） */
+.loop-idp__stitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+  margin-bottom: 8px;
+}
+
+/* 评论输入区 */
+.loop-idp__composer {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* 执行记录行：状态圆点 + 名称 + 状态文字 */
+.loop-idp__run-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.loop-idp__run-dot.is-active { animation: loop-pulse 1.4s ease-in-out infinite; }
+@keyframes loop-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+.loop-idp__run-status {
+  flex: 0 0 auto;
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
 .loop-idp__body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) 300px;
   flex: 1;
   min-height: 0;
 }
 
 .loop-idp__main {
   overflow: auto;
-  padding: 24px 28px;
+  padding: 28px 32px 48px;
   min-width: 0;
+}
+
+/* 主体内容限定阅读宽度并居中，避免宽屏下右侧一大片空白 */
+.loop-idp__main > * {
+  width: 100%;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .loop-idp__section {
-  margin-top: 22px;
+  margin-top: 26px;
 }
 
-.loop-idp__aside {
-  border-left: 1px solid var(--semi-color-border, #e8e9eb);
-  overflow: auto;
-  padding: 16px;
-  background: var(--semi-color-bg-1, #fbfbfc);
+/* 描述：紧贴标题的段落 */
+.loop-idp__desc {
+  padding: 4px 10px;
+  border-radius: 8px;
+  cursor: text;
+  color: var(--semi-color-text-1, #4e5969);
+  transition: background-color 120ms ease;
+}
+.loop-idp__desc:hover { background: var(--semi-color-fill-0, #f7f8fa); }
+.loop-idp__desc .loop-md { font-size: 13.5px; }
+.loop-idp__desc-empty { color: var(--semi-color-text-3, #b8bcc8); font-size: 13px; }
+
+/* 主体附件下的工具栏（附件按钮） */
+.loop-idp__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.loop-idp__count { font-style: normal; font-weight: 500; color: var(--semi-color-text-3, #b8bcc8); }
+
+/* 描述/子回路 分区标题行（右侧动作） */
+.loop-idp__desc-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* ===== 动态（活动 + 评论合并时间线） ===== */
+.loop-idp__feed-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.loop-idp__feed-head .loop-idp__stitle { margin-bottom: 0; }
+.loop-idp__subbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--semi-color-text-2, #6b7075);
+}
+.loop-idp__subbtn:hover { background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-0, #1f2329); }
+
+.loop-feed {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
-.loop-idp__aside-card {
+/* 活动条：细圆点 + 人话文案 + 时间（克制，不抢戏） */
+.loop-feed__act {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--semi-color-text-2, #6b7075);
+  padding-left: 2px;
+}
+.loop-feed__act-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--semi-color-fill-2, #d5d8dd);
+  flex: 0 0 auto;
+}
+.loop-feed__act-text { flex: 1; min-width: 0; }
+.loop-feed__act-text strong { color: var(--semi-color-text-1, #4e5969); font-weight: 600; }
+.loop-feed__act time { flex: 0 0 auto; font-size: 11.5px; color: var(--semi-color-text-3, #b8bcc8); }
+
+.loop-idp__wake { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; align-items: center; }
+
+/* ===== 评论卡片（白底、无灰块） ===== */
+.loop-comment {
   border: 1px solid var(--semi-color-border, #e8e9eb);
   border-radius: 10px;
-  padding: 14px;
+  padding: 12px 14px;
   background: var(--semi-color-bg-0, #fff);
 }
-
-.loop-idp__props {
-  display: grid;
-  grid-template-columns: 68px 1fr;
-  gap: 10px 10px;
-  align-items: center;
-  margin: 0;
+.loop-comment.is-reply {
+  margin-left: 24px;
+  background: var(--semi-color-bg-0, #fff);
+  border-color: var(--semi-color-fill-1, #eceef1);
 }
-
-.loop-idp__props dt {
-  font-size: 12px;
-  color: var(--semi-color-text-2, #8590a6);
-}
-
-.loop-idp__props dd {
-  margin: 0;
-  min-width: 0;
-}
+.loop-comment__head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.loop-comment__head time { font-size: 11.5px; color: var(--semi-color-text-3, #b8bcc8); }
+.loop-comment__actions { margin-left: auto; display: flex; gap: 2px; opacity: 0; transition: opacity 120ms ease; }
+.loop-comment:hover .loop-comment__actions { opacity: 1; }
+.loop-comment__body { font-size: 13px; line-height: 1.6; white-space: normal; word-break: break-word; }
+.loop-comment__body .loop-md { font-size: 13px; line-height: 1.6; }
 
 .loop-idp__center {
   display: flex;
@@ -76,134 +229,96 @@
   flex: 1;
 }
 
-.loop-idp__tasks {
+/* ===== 右侧属性栏（属性 / 详情 / 执行日志） ===== */
+.loop-idp__aside {
+  border-left: 1px solid var(--semi-color-border, #e8e9eb);
+  overflow: auto;
+  padding: 20px 18px;
+  background: var(--semi-color-bg-0, #fff);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 22px;
 }
 
-.loop-idp__task {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.loop-idp__task-main {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-
-.loop-idp__task-main strong {
+.loop-idp__asec { display: flex; flex-direction: column; gap: 12px; }
+.loop-idp__asec-head {
   font-size: 12px;
   font-weight: 600;
+  color: var(--semi-color-text-2, #8a8f99);
+  letter-spacing: 0.02em;
 }
 
-.loop-idp__task-main small {
-  font-size: 11px;
-  color: var(--semi-color-text-2, #8590a6);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+.loop-idp__prop { display: flex; flex-direction: column; gap: 5px; }
+.loop-idp__prop--inline { flex-direction: row; align-items: center; justify-content: space-between; }
+.loop-idp__prop-k { font-size: 12px; color: var(--semi-color-text-2, #8a8f99); }
+.loop-idp__prop-v { font-size: 13px; color: var(--semi-color-text-0, #1f2329); }
+.loop-idp__prop-v--muted { color: var(--semi-color-text-2, #6b7075); }
+.loop-idp__prop-row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 
-@media (max-width: 900px) {
-  .loop-idp__body {
-    grid-template-columns: 1fr;
-  }
-  .loop-idp__aside {
-    border-left: none;
-    border-top: 1px solid var(--semi-color-border, #e8e9eb);
-  }
-}
-
-/* 描述标题行（含编辑按钮） */
-.loop-idp__desc-title {
-  display: flex;
+/* 执行日志：折叠开关 + run 列表 */
+.loop-idp__runs-toggle {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-}
-
-/* 执行记录 run 行（可点击） */
-.loop-idp__run {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 8px;
+  gap: 5px;
   border: none;
   background: transparent;
-  border-radius: 6px;
   cursor: pointer;
-  text-align: left;
+  padding: 2px 0;
+  font-size: 13px;
+  color: var(--semi-color-primary, #6a5cff);
+}
+.loop-idp__runs-chevron { transition: transform 120ms ease; }
+.loop-idp__runs-chevron.is-open { transform: rotate(90deg); }
+
+.loop-idp__tasks { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+.loop-idp__task { display: flex; align-items: center; gap: 6px; }
+.loop-idp__task-main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.loop-idp__task-main strong { font-size: 12px; font-weight: 600; }
+.loop-idp__task-main small {
+  font-size: 11px; color: var(--semi-color-text-2, #8590a6);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+.loop-idp__run {
+  flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px; border: none; background: transparent; border-radius: 8px;
+  cursor: pointer; text-align: left;
 }
 .loop-idp__run:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-idp__run-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
+.loop-idp__run-dot.is-active { animation: loop-pulse 1.4s ease-in-out infinite; }
+@keyframes loop-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+.loop-idp__run-status { flex: 0 0 auto; font-size: 11.5px; font-weight: 600; }
 
-/* 执行详情弹窗 */
-.loop-run-detail__head { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
-.loop-run-detail__props {
-  display: grid; grid-template-columns: 72px 1fr; gap: 6px 10px; margin: 0 0 14px;
-  font-size: 13px;
-}
-.loop-run-detail__props dt { color: var(--semi-color-text-2, #8590a6); font-size: 12px; }
-.loop-run-detail__props dd { margin: 0; }
-.loop-run-detail__section { margin-top: 14px; }
-.loop-run-detail__output {
-  background: var(--semi-color-fill-0, #f5f6f8); border-radius: 8px; padding: 12px;
-  white-space: pre-wrap; word-break: break-word; font-size: 12.5px; line-height: 1.55; max-height: 240px; overflow: auto;
-}
-.loop-run-msgs { display: flex; flex-direction: column; gap: 10px; }
-.loop-run-msg { border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 8px; padding: 8px 10px; }
-.loop-run-msg__head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
-.loop-run-msg__head time { margin-left: auto; font-size: 11px; color: var(--semi-color-text-2, #8590a6); }
-.loop-run-msg__body {
-  margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.5;
-  font-family: var(--semi-font-family-mono, monospace); max-height: 200px; overflow: auto;
+@media (max-width: 900px) {
+  .loop-idp__body { grid-template-columns: 1fr; }
+  .loop-idp__aside { border-left: none; border-top: 1px solid var(--semi-color-border, #e8e9eb); }
 }
 
-/* 评论 emoji 反应条(PR-B 协作层) */
-.loop-comment__reactions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 6px; }
-.loop-reaction {
-  display: inline-flex; align-items: center; gap: 3px; padding: 1px 7px;
-  border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 11px;
-  background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-1, #4e5969);
-  font-size: 12px; line-height: 18px; cursor: pointer;
-}
-.loop-reaction:hover { background: var(--semi-color-fill-1, #eef0f3); }
-.loop-reaction--add { color: var(--semi-color-text-2, #8590a6); padding: 2px 6px; }
-.loop-reaction-picker { display: flex; gap: 4px; padding: 6px 8px; }
-.loop-reaction-picker button {
-  border: none; background: transparent; cursor: pointer; font-size: 17px;
-  line-height: 1; padding: 2px 4px; border-radius: 6px;
-}
-.loop-reaction-picker button:hover { background: var(--semi-color-fill-1, #eef0f3); }
-
-/* 子 issue 列表(PR-C) */
-.loop-subissues { display: flex; flex-direction: column; gap: 6px; }
+/* ===== 子回路列表 ===== */
+.loop-subissues { display: flex; flex-direction: column; gap: 4px; }
 .loop-subissue {
-  display: flex; align-items: center; gap: 8px; padding: 6px 8px;
-  border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 8px;
-  font-size: 13px;
+  display: flex; align-items: center; gap: 8px; padding: 8px 10px;
+  border-radius: 8px; font-size: 13px; cursor: pointer;
+  transition: background-color 120ms ease;
 }
-.loop-subissue__id { color: var(--semi-color-text-2, #8590a6); font-size: 12px; flex-shrink: 0; }
-.loop-subissue__title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-subissue:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-subissue__id {
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--semi-color-text-3, #b8bcc8); font-size: 11.5px; flex-shrink: 0;
+}
+.loop-subissue__title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--semi-color-text-0, #1f2329); }
+.loop-subissue__spacer { flex: 1; }
 
-/* 活动流(PR-D 时间线) */
-.loop-activities { display: flex; flex-direction: column; gap: 8px; }
-.loop-activity { display: flex; align-items: center; gap: 8px; font-size: 12px; }
-.loop-activity time { margin-left: auto; font-size: 11px; color: var(--semi-color-text-2, #8590a6); }
-
-/* 附件(PR-E) */
+/* ===== 附件 ===== */
 .loop-atts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 .loop-att {
-  display: inline-flex; align-items: center; gap: 4px; max-width: 220px;
-  padding: 2px 8px; border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 8px;
-  background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-1, #4e5969);
-  font-size: 12px; line-height: 18px; text-decoration: none;
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%;
+  padding: 8px 12px; border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 10px;
+  background: var(--semi-color-bg-0, #fff); color: var(--semi-color-text-1, #4e5969);
+  font-size: 13px; line-height: 1.4; text-decoration: none;
 }
-.loop-att:hover { background: var(--semi-color-fill-1, #eef0f3); }
+.loop-att:hover { border-color: var(--semi-color-text-3, #c9cdd4); }
 .loop-att span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .loop-att--img { padding: 0; border: none; background: none; }
 .loop-att--img img { max-height: 96px; max-width: 220px; border-radius: 8px; display: block; object-fit: cover; }
@@ -213,6 +328,87 @@
 }
 .loop-attach-btn {
   display: inline-flex; align-items: center; justify-content: center; cursor: pointer;
-  color: var(--semi-color-text-2, #8590a6); padding: 4px; border-radius: 6px;
+  color: var(--semi-color-text-2, #8590a6); padding: 5px; border-radius: 8px;
 }
-.loop-attach-btn:hover { background: var(--semi-color-fill-1, #eef0f3); color: var(--semi-color-text-0, #1c1f23); }
+.loop-attach-btn:hover { background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-0, #1c1f23); }
+
+/* ===== 执行详情弹窗：转写体验（低亮度、克制饱和，去 semi 灰底） ===== */
+.loop-tr-modal .semi-modal-header { padding: 14px 16px; border-bottom: 1px solid var(--semi-color-border, #e8e9eb); margin: 0; }
+.loop-tr-modal .semi-modal-body { padding: 0; background: var(--semi-color-bg-0, #fff); }
+.loop-tr { --c-agent: #3f8f63; --c-thinking: #6b5bd6; --c-tool: #4a72d6; --c-result: #aeb4bf; --c-error: #cf5b5b; }
+
+.loop-tr__head { display: flex; align-items: center; gap: 12px; }
+.loop-tr__agent { display: inline-flex; align-items: center; gap: 7px; font-size: 14px; font-weight: 600; color: var(--semi-color-text-0, #1f2329); }
+.loop-tr__status { display: inline-flex; align-items: center; gap: 4px; padding: 2px 9px; border-radius: 999px; font-size: 12px; font-weight: 600; color: var(--semi-color-text-2, #6b7075); background: var(--semi-color-fill-0, #f2f3f5); }
+.loop-tr__status--running { background: rgba(74, 114, 214, 0.12); color: #4a72d6; }
+.loop-tr__status--ok { background: rgba(63, 143, 99, 0.14); color: #3f8f63; }
+.loop-tr__status--fail { background: rgba(207, 91, 91, 0.14); color: #cf5b5b; }
+.loop-tr__copy {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 5px;
+  border: none; background: transparent; cursor: pointer; padding: 4px 8px; border-radius: 6px;
+  font-size: 12px; color: var(--semi-color-text-2, #6b7075);
+}
+.loop-tr__copy:hover { background: var(--semi-color-fill-0, #f5f6f8); color: var(--semi-color-text-0, #1f2329); }
+
+.loop-tr__chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 12px 16px 8px; }
+.loop-tr__chip {
+  display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb); border-radius: 6px;
+  color: var(--semi-color-text-2, #6b7075); font-size: 11.5px;
+}
+
+.loop-tr__bar { display: flex; gap: 2px; height: 6px; margin: 0 16px 10px; border-radius: 3px; overflow: hidden; }
+.loop-tr__bar-seg { min-width: 3px; height: 100%; opacity: 0.85; }
+.loop-tr__bar-seg--agent { background: var(--c-agent); }
+.loop-tr__bar-seg--thinking { background: var(--c-thinking); }
+.loop-tr__bar-seg--tool { background: var(--c-tool); }
+.loop-tr__bar-seg--result { background: var(--c-result); }
+.loop-tr__bar-seg--error { background: var(--c-error); }
+
+.loop-tr__result {
+  margin: 0 16px 8px; padding: 12px; border-radius: 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb); background: var(--semi-color-bg-1, #fbfbfc);
+  white-space: pre-wrap; word-break: break-word;
+  font-size: 12.5px; line-height: 1.55; max-height: 200px; overflow: auto;
+}
+
+.loop-tr__list { display: flex; flex-direction: column; }
+.loop-tr__center { display: flex; align-items: center; justify-content: center; padding: 40px; }
+.loop-tr__waiting { display: inline-flex; align-items: center; gap: 8px; color: var(--semi-color-text-2, #8590a6); font-size: 13px; }
+
+.loop-tr__row { border-top: 1px solid var(--semi-color-fill-1, #eceef1); }
+.loop-tr__row:first-child { border-top: none; }
+.loop-tr__line {
+  display: flex; align-items: flex-start; gap: 10px; width: 100%;
+  border: none; background: transparent; text-align: left; cursor: pointer;
+  padding: 9px 16px; transition: background-color 120ms ease;
+}
+.loop-tr__line:disabled { cursor: default; }
+.loop-tr__line:not(:disabled):hover { background: var(--semi-color-fill-0, #f7f8fa); }
+
+.loop-tr__badge {
+  flex: 0 0 auto; display: inline-flex; align-items: center; gap: 4px; justify-content: center;
+  min-width: 62px; padding: 2px 8px; border-radius: 5px; margin-top: 1px;
+  font-size: 11px; font-weight: 600;
+  color: var(--semi-color-text-2, #6b7075); background: var(--semi-color-fill-0, #f2f3f5);
+}
+.loop-tr__badge--agent { background: rgba(63, 143, 99, 0.12); color: var(--c-agent); }
+.loop-tr__badge--thinking { background: rgba(107, 91, 214, 0.12); color: var(--c-thinking); }
+.loop-tr__badge--tool { background: rgba(74, 114, 214, 0.12); color: var(--c-tool); }
+.loop-tr__badge--error { background: rgba(207, 91, 91, 0.12); color: var(--c-error); }
+
+.loop-tr__summary { flex: 1; min-width: 0; display: flex; align-items: flex-start; gap: 5px; font-size: 12.5px; color: var(--semi-color-text-1, #4e5969); }
+.loop-tr__row--error .loop-tr__summary { color: var(--c-error); }
+.loop-tr__chevron { flex: 0 0 auto; margin-top: 2px; color: var(--semi-color-text-3, #b8bcc8); transition: transform 120ms ease; }
+.loop-tr__chevron.is-open { transform: rotate(90deg); }
+.loop-tr__summary-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-tr__seq { flex: 0 0 auto; font-size: 10.5px; color: var(--semi-color-text-3, #b8bcc8); font-variant-numeric: tabular-nums; margin-top: 2px; }
+.loop-tr__time { flex: 0 0 auto; font-size: 10.5px; color: var(--semi-color-text-3, #b8bcc8); font-variant-numeric: tabular-nums; margin-top: 2px; }
+
+.loop-tr__detail {
+  margin: 0 16px 12px 88px; padding: 10px 12px; border-radius: 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb); background: var(--semi-color-bg-1, #fbfbfc);
+  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11.5px; line-height: 1.55; white-space: pre-wrap; word-break: break-word;
+  max-height: 260px; overflow: auto;
+}

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -108,14 +108,15 @@
 
 .loop-idp__main {
   overflow: auto;
-  padding: 28px 32px 48px;
+  padding: 28px 40px 48px;
   min-width: 0;
 }
 
-/* 主体内容限定阅读宽度并居中，避免宽屏下右侧一大片空白 */
+/* 主体内容：居中、限定阅读宽度 —— 标题(原生 input,inline-block)也需 display:block 才能随 margin:auto 居中,
+   否则标题靠左、正文居中导致错位 */
 .loop-idp__main > * {
-  width: 100%;
-  max-width: 720px;
+  display: block;
+  max-width: 820px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -178,49 +179,112 @@
 .loop-feed {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
-/* 活动条：细圆点 + 人话文案 + 时间（克制，不抢戏） */
-.loop-feed__act {
+/* 折叠动态块：默认一行「N 条动态」(chevron + 小灰字)；展开显示小活动行 */
+.loop-acts { display: flex; flex-direction: column; gap: 8px; }
+.loop-acts__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px 2px 2px 4px;
+  font-size: 12px;
+  color: var(--semi-color-text-2, #8a8f99);
+  transition: color 120ms ease;
+}
+.loop-acts__toggle:hover { color: var(--semi-color-text-0, #1f2329); }
+.loop-acts__chevron { flex: 0 0 auto; transition: transform 120ms ease; }
+.loop-acts__chevron.is-open { transform: rotate(90deg); }
+
+.loop-acts__list { display: flex; flex-direction: column; gap: 8px; padding-left: 8px; }
+.loop-acts__item {
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 12.5px;
-  color: var(--semi-color-text-2, #6b7075);
-  padding-left: 2px;
+  font-size: 12px;
+  color: var(--semi-color-text-2, #8a8f99);
 }
-.loop-feed__act-dot {
-  width: 7px;
-  height: 7px;
+.loop-acts__dot {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--semi-color-fill-2, #d5d8dd);
   flex: 0 0 auto;
 }
-.loop-feed__act-text { flex: 1; min-width: 0; }
-.loop-feed__act-text strong { color: var(--semi-color-text-1, #4e5969); font-weight: 600; }
-.loop-feed__act time { flex: 0 0 auto; font-size: 11.5px; color: var(--semi-color-text-3, #b8bcc8); }
+.loop-acts__text { flex: 1; min-width: 0; }
+.loop-acts__text strong { color: var(--semi-color-text-1, #4e5969); font-weight: 600; }
+.loop-acts__item time { flex: 0 0 auto; font-size: 11px; color: var(--semi-color-text-3, #b8bcc8); }
 
 .loop-idp__wake { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; align-items: center; }
 
-/* ===== 评论卡片（白底、无灰块） ===== */
-.loop-comment {
+/* ===== 评论线程：一张卡 = 主评论 + 平铺回评（分隔线,不缩进）+ 底部回复框 ===== */
+.loop-cmt {
   border: 1px solid var(--semi-color-border, #e8e9eb);
   border-radius: 10px;
-  padding: 12px 14px;
   background: var(--semi-color-bg-0, #fff);
+  overflow: hidden;
 }
-.loop-comment.is-reply {
-  margin-left: 24px;
-  background: var(--semi-color-bg-0, #fff);
-  border-color: var(--semi-color-fill-1, #eceef1);
+.loop-cmt__row { padding: 12px 14px; }
+.loop-cmt__row + .loop-cmt__row { border-top: 1px solid var(--semi-color-fill-1, #eceef1); }
+.loop-cmt__head { display: flex; align-items: center; gap: 8px; }
+.loop-cmt__head time { font-size: 11.5px; color: var(--semi-color-text-3, #b8bcc8); }
+.loop-cmt__resolved { font-size: 11.5px; font-weight: 600; color: var(--semi-color-success, #35824a); }
+.loop-cmt__actions { margin-left: auto; flex: 0 0 auto; }
+.loop-cmt__body { margin-top: 6px; font-size: 13px; line-height: 1.6; word-break: break-word; }
+.loop-cmt__body .loop-md { font-size: 13px; line-height: 1.6; }
+/* 底部回复输入（卡内,分隔线隔开） */
+.loop-cmt__reply {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--semi-color-fill-1, #eceef1);
+  background: var(--semi-color-bg-1, #fbfbfc);
 }
-.loop-comment__head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
-.loop-comment__head time { font-size: 11.5px; color: var(--semi-color-text-3, #b8bcc8); }
-.loop-comment__actions { margin-left: auto; display: flex; gap: 2px; opacity: 0; transition: opacity 120ms ease; }
-.loop-comment:hover .loop-comment__actions { opacity: 1; }
-.loop-comment__body { font-size: 13px; line-height: 1.6; white-space: normal; word-break: break-word; }
-.loop-comment__body .loop-md { font-size: 13px; line-height: 1.6; }
+.loop-cmt__reply-row { display: flex; gap: 8px; align-items: center; }
+.loop-cmt__reply .loop-field { flex: 1; min-width: 0; }
+
+/* 附件 pill（对标 multica：边框 + 文件图标 + 文件名 + 操作） */
+.loop-filechips { display: flex; flex-wrap: wrap; gap: 6px; }
+.loop-filechip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 260px;
+  padding: 4px 8px 4px 10px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 8px;
+  background: var(--semi-color-fill-0, #f7f8fa);
+  transition: background-color 120ms ease;
+}
+.loop-filechip:hover { background: var(--semi-color-fill-1, #eceef1); }
+.loop-filechip__icon { flex: 0 0 auto; color: var(--semi-color-text-2, #8a8f99); }
+.loop-filechip__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--semi-color-text-0, #1f2329);
+}
+.loop-filechip__act {
+  flex: 0 0 auto;
+  display: inline-flex;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 3px;
+  border-radius: 6px;
+  color: var(--semi-color-text-2, #8a8f99);
+  transition: background-color 120ms ease, color 120ms ease;
+}
+.loop-filechip__act:hover { background: var(--semi-color-danger-light-default, #fde2e2); color: var(--semi-color-danger, #f5222d); }
 
 .loop-idp__center {
   display: flex;
@@ -242,18 +306,46 @@
 
 .loop-idp__asec { display: flex; flex-direction: column; gap: 12px; }
 .loop-idp__asec-head {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
   font-size: 12px;
   font-weight: 600;
   color: var(--semi-color-text-2, #8a8f99);
   letter-spacing: 0.02em;
 }
+.loop-idp__asec-head:hover { color: var(--semi-color-text-1, #4e5969); }
+.loop-idp__asec-chevron { flex: 0 0 auto; transition: transform 120ms ease; }
+.loop-idp__asec-chevron.is-open { transform: rotate(90deg); }
+.loop-idp__asec-body { display: flex; flex-direction: column; gap: 12px; }
 
 .loop-idp__prop { display: flex; flex-direction: column; gap: 5px; }
 .loop-idp__prop--inline { flex-direction: row; align-items: center; justify-content: space-between; }
 .loop-idp__prop-k { font-size: 12px; color: var(--semi-color-text-2, #8a8f99); }
 .loop-idp__prop-v { font-size: 13px; color: var(--semi-color-text-0, #1f2329); }
 .loop-idp__prop-v--muted { color: var(--semi-color-text-2, #6b7075); }
-.loop-idp__prop-row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+/* 状态/优先级 只读值：图标 + 文字 */
+.loop-idp__prop-val {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--semi-color-text-0, #1f2329);
+}
+/* 创建者 只读值：头像 + 名字 */
+.loop-idp__prop-person {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--semi-color-text-0, #1f2329);
+}
 
 /* 执行日志：折叠开关 + run 列表 */
 .loop-idp__runs-toggle {

--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Dropdown, Avatar, Tag } from "@douyinfe/semi-ui";
+import { Dropdown, Avatar } from "@douyinfe/semi-ui";
 import { ChevronDown, User, Bot, Users, CircleSlash } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { AssigneeCandidate, AssigneeType } from "../api/types";
@@ -99,15 +99,13 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
   );
 }
 
-/** 只读小徽标：展示 assignee 类型 + 名称。 */
+/** 只读小徽标：中性胶囊 + 类型图标（member/agent/squad 靠图标形状区分，不用高亮色，避免突兀）。 */
 export function AssigneeBadge({ type, name }: { type: AssigneeType | null; name: string | null }) {
   if (!type || !name) return <span className="loop-assignee-empty">—</span>;
   return (
-    <Tag color={ASSIGNEE_TYPE_COLOR[type]} size="small" shape="circle">
-      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-        {typeIcon(type)}
-        {name}
-      </span>
-    </Tag>
+    <span className="loop-abadge" data-type={type}>
+      {typeIcon(type)}
+      <span className="loop-abadge__name">{name}</span>
+    </span>
   );
 }

--- a/packages/dmloop/src/ui/IssueCard.tsx
+++ b/packages/dmloop/src/ui/IssueCard.tsx
@@ -1,12 +1,19 @@
 import React from "react";
-import { Tag } from "@douyinfe/semi-ui";
 import { CalendarClock } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Issue } from "../api/types";
 import { AssigneeBadge } from "./AssigneePicker";
 import LabelChips from "./LabelChips";
 import RunningChip from "./RunningChip";
-import { PRIORITY_COLOR, formatShortDate, isOverdue } from "./meta";
+import {
+  PRIORITY_ICON,
+  PRIORITY_HEX,
+  ISSUE_STATUS_ICON,
+  ISSUE_STATUS_HEX,
+  formatShortDate,
+  isOverdue,
+} from "./meta";
+import { formatRelativeTime } from "./time";
 
 export interface IssueCardProps {
   issue: Issue;
@@ -30,7 +37,9 @@ export default function IssueCard({
   onDragStart,
   onDragEnd,
 }: IssueCardProps) {
-  const { t } = useI18n();
+  const { t, format } = useI18n();
+  const PriIcon = PRIORITY_ICON[issue.priority];
+  const StatusIcon = ISSUE_STATUS_ICON[issue.status];
   return (
     <div
       className={`loop-card ${dragging ? "is-dragging" : ""}`}
@@ -39,27 +48,36 @@ export default function IssueCard({
       onDragEnd={onDragEnd}
       onClick={() => onOpen(issue.id)}
     >
-      <div className="loop-card__key">
-        {issue.identifier}
+      <div className="loop-card__top">
+        <span className="loop-card__icon" title={t(`loop.priority.${issue.priority}`)}>
+          <PriIcon size={14} strokeWidth={2} style={{ color: PRIORITY_HEX[issue.priority] }} />
+        </span>
+        <span className="loop-card__icon" title={t(`loop.status.${issue.status}`)}>
+          <StatusIcon size={14} strokeWidth={2} style={{ color: ISSUE_STATUS_HEX[issue.status] }} />
+        </span>
+        <span className="loop-card__id">{issue.identifier}</span>
         {running && <RunningChip />}
+        <time className="loop-card__time">{formatRelativeTime(issue.updated_at ?? issue.created_at, format)}</time>
       </div>
+
       <div className="loop-card__title">{issue.title}</div>
+
       {issue.labels && issue.labels.length > 0 && (
-        <div style={{ marginTop: 4 }}><LabelChips labels={issue.labels} max={3} /></div>
+        <div className="loop-card__labels"><LabelChips labels={issue.labels} max={3} /></div>
       )}
+
       <div className="loop-card__foot">
-        <Tag color={PRIORITY_COLOR[issue.priority]} size="small">
-          {t(`loop.priority.${issue.priority}`)}
-        </Tag>
+        {issue.project_name && <span className="loop-card__project">{issue.project_name}</span>}
         {issue.due_date && (
           <span
             className="loop-card__due"
-            style={{ color: isOverdue(issue.due_date, issue.status) ? "var(--semi-color-danger)" : "var(--semi-color-text-2)" }}
+            style={{ color: isOverdue(issue.due_date, issue.status) ? "var(--semi-color-danger, #f5222d)" : "var(--semi-color-text-2, #8590a6)" }}
           >
             <CalendarClock size={12} />
             {formatShortDate(issue.due_date)}
           </span>
         )}
+        <span className="loop-card__spacer" />
         <AssigneeBadge type={issue.assignee_type} name={issue.assignee_name ?? null} />
       </div>
     </div>

--- a/packages/dmloop/src/ui/meta.tsx
+++ b/packages/dmloop/src/ui/meta.tsx
@@ -1,4 +1,19 @@
 import React from "react";
+import {
+  Circle,
+  CircleDashed,
+  CircleDot,
+  CircleDotDashed,
+  CircleCheck,
+  CircleAlert,
+  CircleX,
+  SignalLow,
+  SignalMedium,
+  SignalHigh,
+  TriangleAlert,
+  Minus,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type {
   IssueStatus,
   IssuePriority,
@@ -49,6 +64,27 @@ export const ISSUE_STATUS_COLOR: Record<IssueStatus, TagColor> = {
   cancelled: "grey",
 };
 
+// 状态图标 + 语义色（看板列头 / 卡片 / 列表行 / 详情共用；hex 用于内联 icon 上色）。
+export const ISSUE_STATUS_ICON: Record<IssueStatus, LucideIcon> = {
+  backlog: CircleDashed,
+  todo: Circle,
+  in_progress: CircleDot,
+  in_review: CircleDotDashed,
+  done: CircleCheck,
+  blocked: CircleAlert,
+  cancelled: CircleX,
+};
+
+export const ISSUE_STATUS_HEX: Record<IssueStatus, string> = {
+  backlog: "#8a8f99",
+  todo: "#6b7280",
+  in_progress: "var(--semi-color-warning, #f5a623)",
+  in_review: "#7f3bf5",
+  done: "var(--semi-color-success, #23a55a)",
+  blocked: "var(--semi-color-danger, #f5222d)",
+  cancelled: "#b8bcc8",
+};
+
 export const PRIORITY_ORDER: IssuePriority[] = [
   "urgent",
   "high",
@@ -56,6 +92,23 @@ export const PRIORITY_ORDER: IssuePriority[] = [
   "low",
   "none",
 ];
+
+// 优先级图标 + 语义色（信号强度隐喻；urgent 用告警三角）。
+export const PRIORITY_ICON: Record<IssuePriority, LucideIcon> = {
+  urgent: TriangleAlert,
+  high: SignalHigh,
+  medium: SignalMedium,
+  low: SignalLow,
+  none: Minus,
+};
+
+export const PRIORITY_HEX: Record<IssuePriority, string> = {
+  urgent: "var(--semi-color-danger, #f5222d)",
+  high: "#fc8800",
+  medium: "#f5a623",
+  low: "#6b93ff",
+  none: "#c9cdd4",
+};
 
 export const PRIORITY_COLOR: Record<IssuePriority, TagColor> = {
   urgent: "red",
@@ -94,15 +147,17 @@ export const ASSIGNEE_TYPE_COLOR: Record<AssigneeType, TagColor> = {
   squad: "purple",
 };
 
-export const RUN_STATUS_COLOR: Record<string, TagColor> = {
-  queued: "grey",
-  dispatched: "blue",
-  waiting_local_directory: "blue",
-  running: "amber",
-  completed: "green",
-  failed: "red",
-  cancelled: "grey",
+// run 状态点颜色（执行记录行的状态圆点；未知值走灰兜底）。
+export const RUN_STATUS_HEX: Record<string, string> = {
+  queued: "#b8bcc8",
+  dispatched: "var(--semi-color-info, #2f6fed)",
+  waiting_local_directory: "var(--semi-color-info, #2f6fed)",
+  running: "var(--semi-color-warning, #f5a623)",
+  completed: "var(--semi-color-success, #35824a)",
+  failed: "var(--semi-color-danger, #f5222d)",
+  cancelled: "#b8bcc8",
 };
+export const RUN_STATUS_HEX_FALLBACK = "#c9cdd4";
 
 // Autopilot 运行状态 → 状态点颜色（卡片 last-run 点与详情运行行共用；未知值走灰兜底）。
 export const AUTOPILOT_RUN_DOT: Record<string, string> = {


### PR DESCRIPTION
## Goal

Restyle the loop (回路) screens to the new UX/Figma design language and the
shared loop design-system skin, while preserving all existing issue-tracking
functionality. No backend/API changes.

## Changes

**Board**
- Status-icon column headers with counts; faint column tracks so empty
  status columns stay legible.
- Cards show priority + status icons, mono identifier, relative time, title,
  project and a neutral assignee badge. Drag-to-change-status preserved.

**List**
- Replaced the table with clean status-grouped rows; row click opens detail.
- Kept multi-select batch bar (status / priority / assignee with
  suppress_run, delete) and inline assignee edit with run pre-confirm.
- Pagination preserved.

**Header / filters**
- Title row + a 筛选 (filter) popover holding all existing filters and a
  显示 (display) popover for view switch + list sort. Filter logic unchanged.

**Detail**
- Breadcrumb topbar; native single-line/multi-line inputs for title,
  description and comments.
- Unified activity feed: system actions collapse into a "N activities" block
  (humanized text; noise hidden; the latest block is expanded by default,
  older blocks fold and are toggleable).
- Comment threads are flat (root + replies as sibling rows) inside one card,
  each with an always-visible reply box supporting multiple attachments
  (file chips). Comment row actions live in a top-right three-dot menu
  (copy / resolve / delete); existing comments are not editable.
- New-comment composer is a separated multi-line block distinct from replies.
- Read-only right sidebar (Properties / Details / Execution log) with
  collapsible, divider-separated groups; property edits go through the
  top-right three-dot menu. Active runs are always visible; only terminal
  runs fold behind "show history (N)". Sub-issue module shows only when the
  loop has children.

**Run detail modal**
- Rebuilt as a transcript (status badge, metadata chips, timeline bar,
  collapsible events) using the same polling data source, with a refined
  low-key palette.

**New loop**
- Now a standalone composer page (routed, not a modal) that maps to the
  existing create-issue + upload-attachment endpoints. Child-issue creation
  stays a modal.

## Verification

- `npx tsc --noEmit --skipLibCheck -p packages/dmloop/tsconfig.json` — 0 errors.
- `npx stylelint "packages/dmloop/src/**/*.css"` — 0 errors (only the
  repo-wide rgba/hex warnings, unchanged by this work).
- Vite dev server boots and compiles the loop modules cleanly.
- Two-axis (standards + spec) code review run across the change; findings
  fixed (dead-code cleanup, success toasts, multi-file upload fix).
- Note: manual in-browser visual verification of each screen is still
  recommended before merge.