### PR TITLE
fix(loop): correctness fixes surfaced by codex adversarial backfill

### DIFF
--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -127,10 +127,16 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
         limit: 100,
       };
       // 「与我相关」= 指派给我 ∪ 我创建 ∪ 间接关联(后端三过滤并集,fan-out 合并);
-      // 其余 scope 单发一次、按 assignee_types 收窄。myMemberId 缺失时 pill 已禁用,不会走到此分支。
+      // 其余 scope 单发一次、按 assignee_types 收窄。
+      // scope=involves 需当前成员的后端 id;未解析出时**不回退成无 scope 全量**(否则「与我相关」
+      // 会错显全部)。清空并结束——myMemberId 在 reload 依赖里,解析后会自动重取。
+      if (scope === "involves" && !myMemberId) {
+        if (my === seq.current) { setGroups([]); setLoading(false); }
+        return;
+      }
       const req =
-        scope === "involves" && myMemberId
-          ? listMyGroupedIssues(myMemberId, gp)
+        scope === "involves"
+          ? listMyGroupedIssues(myMemberId!, gp) // 上方守卫已保证 myMemberId 存在
           : listGroupedIssues({ ...gp, assignee_types: scopeToAssigneeTypes(scope) });
       req
         .then((gs) => { if (my === seq.current) setGroups(gs); })
@@ -229,6 +235,10 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
 
   const title = defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
 
+  // 关键词走全文搜索端点(独立语义,后端不吃其它筛选/排序)。搜索激活时禁用面板内其它筛选,
+  // 避免它们「看起来生效、实际被忽略」的误导(grouped 视图隐藏关键词,故 searching 恒 false)。
+  const searching = view !== "grouped" && !!f.keyword.trim();
+
   // 「筛选」按钮上的激活计数(仅计当前视图会生效的维度)。
   const activeFilters =
     (view === "grouped"
@@ -257,7 +267,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
         {view === "grouped" ? (
           <Select multiple value={f.gStatuses} onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
         ) : (
-          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
+          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
         )}
       </div>
       <div className="loop-fields__row">
@@ -265,14 +275,14 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
         {view === "grouped" ? (
           <Select multiple value={f.gPriorities} onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
         ) : (
-          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
+          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
         )}
       </div>
       {/* assignee 单选仅扁平列表/看板(grouped 用 scope 按类型收窄)。 */}
       {view !== "grouped" && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.filter.assignee")}</div>
-          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
+          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
             {cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
           </Select>
         </div>
@@ -281,7 +291,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
       {!(view === "grouped" && scope === "involves") && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.filter.creator")}</div>
-          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
+          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
             {cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
           </Select>
         </div>
@@ -292,7 +302,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
           {view === "grouped" ? (
             <Select multiple value={f.gProjectIds} onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })} showClear filter maxTagCount={1} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
           ) : (
-            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
+            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
           )}
         </div>
       )}
@@ -305,10 +315,10 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.dateRange")}</div>
         <div className="loop-fields__inline">
-          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} dropdownClassName="loop-fields__dropdown" style={{ width: 104 }}>
+          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: 104 }}>
             {ISSUE_DATE_FIELDS.map((d) => (<Select.Option key={d} value={d}>{t(`loop.dateField.${d}`)}</Select.Option>))}
           </Select>
-          <DatePicker type="dateRange" density="compact" value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} style={{ flex: 1 }} />
+          <DatePicker type="dateRange" density="compact" disabled={searching} value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} style={{ flex: 1 }} />
         </div>
       </div>
       {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
@@ -340,10 +350,10 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.sort.direction")}</div>
           <div className="loop-fields__inline">
-            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} dropdownClassName="loop-fields__dropdown" style={{ flex: 1 }}>
+            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ flex: 1 }}>
               {ISSUE_SORT_FIELDS.map((s) => (<Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>))}
             </Select>
-            <Button theme="borderless" disabled={f.sortBy === "position"} icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />} aria-label={t("loop.sort.direction")} onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })} />
+            <Button theme="borderless" disabled={searching || f.sortBy === "position"} icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />} aria-label={t("loop.sort.direction")} onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })} />
           </div>
         </div>
       )}

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Typography, Button, Tabs, TabPane, Table, Tag, Select, Spin, Toast, Banner, Modal, Avatar,
 } from "@douyinfe/semi-ui";
@@ -110,6 +110,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   const [error, setError] = useState<string | null>(null);
   // octo space 成员（仅人，robot===0）+ uid→身份 映射，供选择器候选与列表渲染复用。
   const [spaceHumans, setSpaceHumans] = useState<SpaceMember[]>([]);
+  const seqRef = useRef(0); // reload 请求序号:切 workspace 时只让最新一次落地
   const [selectedUid, setSelectedUid] = useState<string>("");
   const [role, setRole] = useState("member");
   const [adding, setAdding] = useState(false);
@@ -127,15 +128,16 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   }, []);
 
   const reload = useCallback(() => {
+    const my = ++seqRef.current; // 切 workspace 时旧 in-flight 结果不得覆盖新的
     setLoading(true); setError(null);
     Promise.all([
       listWorkspaceMembers(workspaceId),
       listWorkspaceInvitations(workspaceId).catch(() => [] as Invitation[]),
       loadSpaceMembers().catch(() => [] as SpaceMember[]),
     ])
-      .then(([m, inv, humans]) => { setMembers(m); setInvites(inv); setSpaceHumans(humans); })
-      .catch((e) => setError(e?.message ?? "load failed"))
-      .finally(() => setLoading(false));
+      .then(([m, inv, humans]) => { if (my !== seqRef.current) return; setMembers(m); setInvites(inv); setSpaceHumans(humans); })
+      .catch((e) => { if (my === seqRef.current) setError(e?.message ?? "load failed"); })
+      .finally(() => { if (my === seqRef.current) setLoading(false); });
   }, [workspaceId, loadSpaceMembers]);
   useEffect(reload, [reload]);
 

--- a/packages/dmloop/src/panel/IssueList.tsx
+++ b/packages/dmloop/src/panel/IssueList.tsx
@@ -45,6 +45,11 @@ export default function IssueList({
   // busy(可能陈旧),双击开两个弹窗/两次 onOk 会各自看到 busy=false 而重复批量写。ref
   // 在进入 runBatch 时同步置位,结构性挡住重入(setBusy 仅驱动 UI 的 disabled)。
   const busyRef = useRef(false);
+  // 删除确认层的重入守卫:删除先开 Modal.confirm,busyRef 只在 onOk 进 runBatch 后才置位,
+  // 故双击可在任一 OK 执行前叠开两个确认框;第一个 OK 跑完 runBatch 即复位 busyRef,第二个框
+  // 的 OK 再次 batchDeleteIssues(同一批 ids)→ 重复删除。confirmingRef 在开框时同步置位、
+  // onOk 完成/onCancel 时复位,把互斥下沉到确认框本身(codex 补审 #665 抓到)。
+  const confirmingRef = useRef(false);
 
   // 行内指派改派（保留旧列表的行内编辑能力）：写库后刷新；触发 agent run 走 RunConfirm 预确认。
   const patch = async (id: string, p: Parameters<typeof updateIssue>[1]) => {
@@ -140,14 +145,21 @@ export default function IssueList({
             theme="borderless"
             icon={<Trash2 size={14} />}
             disabled={busy}
-            onClick={() =>
+            onClick={() => {
+              if (confirmingRef.current) return; // 已有删除确认框在途,不叠开第二个
+              confirmingRef.current = true;
+              const ids = selected; // 快照:runBatch 成功会清空 selected,删除须用开框时捕获的 ids
               confirmDelete({
-                title: t("loop.batch.deleteConfirm", { values: { count: selected.length } }),
+                title: t("loop.batch.deleteConfirm", { values: { count: ids.length } }),
                 okText: t("loop.action.delete"),
                 cancelText: t("loop.action.cancel"),
-                onOk: () => runBatch(() => batchDeleteIssues(selected)),
-              })
-            }
+                onOk: async () => {
+                  try { await runBatch(() => batchDeleteIssues(ids)); }
+                  finally { confirmingRef.current = false; }
+                },
+                onCancel: () => { confirmingRef.current = false; },
+              });
+            }}
           >
             {t("loop.action.delete")}
           </Button>

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -143,13 +143,19 @@ export default function RunDetailModal({
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
   const lastSeqRef = useRef(0);
+  // listRuns 内部吞掉 task-runs 的 HTTP 失败返回 []([] 既可能是"run 消失"也可能是"瞬时网络失败",
+  // 无法区分)。连续 miss 计数:容忍偶发 [](下轮即恢复),连续多次才判定 run 真消失并停轮询——
+  // 既修原「run 消失后无限轮询」,又不因一次网络抖动误停仍在跑的 run。
+  const missRef = useRef(0);
+  const MAX_MISSES = 3;
 
   // 打开时全量拉;运行中的 run 则每 2s 增量轮询 + 刷新状态,终态即停(无 WS,退化轮询)。
   useEffect(() => {
-    if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; return; }
+    if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; missRef.current = 0; return; }
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     lastSeqRef.current = 0;
+    missRef.current = 0;
     setLiveRun(run);
 
     const apply = (batch: RunMessage[], incremental: boolean) => {
@@ -169,8 +175,10 @@ export default function RunDetailModal({
         let stillActive = true;
         try {
           const fresh = (await listRuns(run.issue_id)).find((r) => r.id === run.id);
-          if (fresh && !cancelled) { setLiveRun(fresh); stillActive = isActiveRun(fresh.status); }
-        } catch { /* 保持轮询 */ }
+          if (cancelled) return;
+          if (fresh) { setLiveRun(fresh); stillActive = isActiveRun(fresh.status); missRef.current = 0; }
+          else { missRef.current += 1; stillActive = missRef.current < MAX_MISSES; } // 连续 miss 达阈值才停(容忍瞬时 [])
+        } catch { /* ensureDirectory 等抛错:保持轮询 */ }
         if (!cancelled && stillActive) poll();
       }, POLL_MS);
     };

--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -27,9 +27,10 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
   const { t } = useI18n();
   const [cands, setCands] = useState<AssigneeCandidate[]>([]);
 
-  useEffect(() => {
-    listAssigneeCandidates().then(setCands).catch(() => setCands([]));
-  }, []);
+  // 挂载先取一次;每次开框再取 —— afterDirectoryMutation 只清共享缓存,挂载中的 picker
+  // 不会自动重读,故开框时刷新以反映其间的成员/agent/squad 增删。
+  const loadCands = () => { listAssigneeCandidates().then(setCands).catch(() => setCands([])); };
+  useEffect(() => { loadCands(); }, []);
 
   const current = cands.find((c) => c.id === value);
   const allGroups: { type: AssigneeType; label: string }[] = [
@@ -74,7 +75,7 @@ export default function AssigneePicker({ value, valueName, onChange, size = "def
   );
 
   return (
-    <Dropdown render={menu} trigger="click" position="bottomLeft" clickToHide>
+    <Dropdown render={menu} trigger="click" position="bottomLeft" clickToHide onVisibleChange={(v) => { if (v) loadCands(); }}>
       <span className="loop-assignee-trigger" style={{ fontSize: size === "small" ? 12 : 13 }}>
         {current || valueName ? (
           <>

--- a/packages/dmloop/src/ui/confirmDelete.ts
+++ b/packages/dmloop/src/ui/confirmDelete.ts
@@ -10,6 +10,7 @@ export function confirmDelete(opts: {
   okText: string;
   cancelText: string;
   onOk: () => void | Promise<void>;
+  onCancel?: () => void;
 }): void {
   Modal.confirm({
     title: opts.title,
@@ -19,5 +20,6 @@ export function confirmDelete(opts: {
     okButtonProps: { type: "danger" },
     centered: true,
     onOk: opts.onOk,
+    onCancel: opts.onCancel,
   });
 }


### PR DESCRIPTION
Backfilled codex adversarial review over dmloop capability PRs that had merged without a clean codex verdict (the codex endpoint was chronically flaky). Six verified real bugs, one PR (all small, all in `packages/dmloop`, blast-radius contained to the package).

## Fixes

1. **Batch-delete confirm was replayable** (`IssueList.tsx`, `confirmDelete.ts`). Two stacked `Modal.confirm` dialogs could both pass the in-body `busyRef` guard — the first resets it before the second's `onOk` runs — re-issuing `batchDeleteIssues` over the same ids. Guard the confirm-*open* with `confirmingRef` + snapshot `ids`; `confirmDelete` gains `onCancel` to release the guard on every dismiss path (X / Esc / mask / cancel).

2. **"与我相关" could show ALL issues** (`IssuePage.tsx`). When `scope=involves` but the current member id hadn't resolved, the request fell through to an unscoped grouped fetch. Now hold empty until identity resolves (`reload` re-runs on `myMemberId`), never the all-issues fallback.

3. **Keyword search silently ignored active filters** (`IssuePage.tsx`). Full-text search drops status/priority/assignee/creator/project/date/sort, but the controls stayed enabled and selected. Disable them while a keyword is active (grouped view hides keyword, so `searching` is structurally false there).

4. **Member list race** (`SettingsPage.tsx`). `reload` wrote members/invites/spaceHumans unconditionally; a workspace switch mid-flight let a stale result win. Added a `seqRef` guard so only the latest reload lands.

5. **Run-detail polling failure modes** (`RunDetailModal.tsx`). Originally polled forever when the run vanished. `listRuns` swallows task-runs HTTP errors to `[]` (it is shared with `IssueDetailPage`'s full-detail load, so it must not throw), so `[]` can't distinguish "gone" from "transient blip". Tolerate consecutive misses (`MAX_MISSES=3`) before stopping — a transient `[]` recovers next poll, a genuinely gone run stops in ~6s; the `try/catch` still keeps polling on a thrown error (ensureDirectory).

6. **AssigneePicker didn't refresh on invalidation** (`AssigneePicker.tsx`). It read candidates once on mount; a mounted picker stayed stale after a member/agent/squad mutation. Re-fetch candidates on dropdown open.

## Not bugs (verified, intentionally unchanged)
- The status-change client-side trigger gate (`RunConfirmModal.statusMightTrigger`) is a documented best-effort UX check; the backend remains authoritative on whether a run starts.
- The directory in-flight cache join (`ensureDirectory`) is closed by `invalidateDirectory` running adjacent to `setWorkspaceContext` on workspace switch (`LoopPage`).

## Blast radius (Rule 8)
Real diff is **6 files, all in `packages/dmloop`** (`git diff origin/feat/octo-loop...HEAD`). No shared/exported signature changed: `confirmDelete` gained an optional `onCancel` (backward-compatible); `listRuns` is deliberately left unchanged (shared with `IssueDetailPage`); all refs/flags are component-local. No out-of-module consumer affected.

## Verification
- Real browser (dev, Alice / `mv2-e2e-alice` + `loop-dev`): keyword-active disables all filter Selects + datepicker + sort (and clears on empty); "我的回路"/involves and grouped/board/list load with no regression; SettingsPage members load. Race/edge guards (#1/#4/#5/#6) are inherently hard to trigger live and were verified by review + code trace.
- `tsc --noEmit` clean (0 errors in package sources).
- Gates: `/simplify` (clean) + Claude code-reviewer (caught a regression in an earlier version of fix #5 — premature poll-stop on transient `[]` — since fixed with the consecutive-miss counter and re-reviewed clean).

> Codex: adversarial-review **approve / no material findings** on the final diff (incl. the fix #5 `missRef` refinement). Two-model gate complete — Claude code-reviewer caught the earlier fix-#5 regression, codex confirms the final state clean.