### PR TITLE
feat(loop): dispatch new loops via quick-create for fail-fast feedback

### DIFF
--- a/packages/dmloop/src/api/http.ts
+++ b/packages/dmloop/src/api/http.ts
@@ -79,24 +79,28 @@ client.interceptors.request.use((config) => {
 /* ---------- 结构化错误（供页面展示异常态） ---------- */
 export class LoopApiError extends Error {
   status?: number;
-  constructor(message: string, status?: number) {
+  code?: string; // 后端结构化错误码(如 quick-create 的 agent_unavailable / daemon_version_unsupported)
+  constructor(message: string, status?: number, code?: string) {
     super(message);
     this.name = "LoopApiError";
     this.status = status;
+    this.code = code;
   }
 }
 
 function toApiError(err: unknown): LoopApiError {
   const e = err as {
-    response?: { status?: number; data?: { error?: string; message?: string } };
+    response?: { status?: number; data?: { error?: string; message?: string; code?: string; reason?: string } };
     message?: string;
   };
+  const data = e?.response?.data;
   const msg =
-    e?.response?.data?.error ||
-    e?.response?.data?.message ||
+    data?.error ||
+    data?.message ||
+    data?.reason || // 结构化 422(如 quick-create)只带 {code, reason},reason 是可读文案
     e?.message ||
     "Request failed";
-  return new LoopApiError(String(msg), e?.response?.status);
+  return new LoopApiError(String(msg), e?.response?.status, data?.code);
 }
 
 function clean(params?: Record<string, unknown>): Record<string, string> {

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -3,6 +3,7 @@ import type {
   Issue,
   IssueComment,
   CreateIssueReq,
+  QuickCreateReq,
   UpdateIssueReq,
   ListParams,
   GroupedParams,
@@ -89,6 +90,13 @@ export async function listChildren(id: string): Promise<Issue[]> {
 
 export function createIssue(req: CreateIssueReq): Promise<Issue> {
   return httpPost<Issue>("/issues", req);
+}
+
+// 一句话派单(POST /issues/quick-create):异步建单 + 派给 agent/squad,返回 { task_id }。
+// 相比 createIssue,后端建单前查 runtime 在线 + daemon 版本,离线/过旧当场返 422
+// (LoopApiError.code = agent_unavailable / daemon_version_unsupported)供即时反馈。
+export function quickCreateIssue(req: QuickCreateReq): Promise<{ task_id: string }> {
+  return httpPost<{ task_id: string }>("/issues/quick-create", req);
 }
 
 export function updateIssue(id: string, req: UpdateIssueReq): Promise<Issue> {

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -188,6 +188,17 @@ export interface CreateIssueReq {
   // 新建时绑定已上传附件(上传返回的 id 列表)。
   attachment_ids?: string[];
 }
+// 一句话派单(POST /issues/quick-create):把 prompt 交给 agent/squad,后端异步建单+派单,返 { task_id }。
+// agent_id / squad_id 恰好给一个(后端 XOR 校验)。与 createIssue 的区别:建单前查 runtime 在线 +
+// daemon 版本,离线/过旧当场返 422(agent_unavailable / daemon_version_unsupported)。
+export interface QuickCreateReq {
+  agent_id?: string;
+  squad_id?: string;
+  prompt: string;
+  project_id?: string | null;
+  parent_issue_id?: string | null;
+  attachment_ids?: string[];
+}
 export interface UpdateIssueReq {
   title?: string;
   description?: string | null;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -654,6 +654,7 @@
     "dispatched": "Dispatched",
     "agentUnavailable": "That AI teammate is offline right now, so it can't be dispatched — wait for it to come online, or pick one that's online.",
     "daemonUnsupported": "That AI teammate's runtime is too old to dispatch safely — please upgrade its runtime and try again.",
+    "attachFailedAbort": "{{count}} attachment(s) failed to upload, so dispatch was cancelled — attachments are the AI's context; please retry.",
     "examplesTitle": "Start from an example",
     "ex1Title": "Polish the demo script",
     "ex1Desc": "Take one line from ticket to loop, end to end.",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -652,6 +652,8 @@
     "pickAssignee": "Pick an AI teammate",
     "dispatch": "Dispatch",
     "dispatched": "Dispatched",
+    "agentUnavailable": "That AI teammate is offline right now, so it can't be dispatched — wait for it to come online, or pick one that's online.",
+    "daemonUnsupported": "That AI teammate's runtime is too old to dispatch safely — please upgrade its runtime and try again.",
     "examplesTitle": "Start from an example",
     "ex1Title": "Polish the demo script",
     "ex1Desc": "Take one line from ticket to loop, end to end.",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -652,6 +652,8 @@
     "pickAssignee": "选择 AI 队友",
     "dispatch": "派单",
     "dispatched": "已派单",
+    "agentUnavailable": "AI 队友当前不在线，无法派单——请等它上线，或换一个在线的队友。",
+    "daemonUnsupported": "AI 队友的运行环境版本过低，无法安全派单——请先升级它的运行时后重试。",
     "examplesTitle": "从一个例子开始",
     "ex1Title": "打磨演示脚本",
     "ex1Desc": "从建单到回路，把一句话派单全链路走顺。",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -654,6 +654,7 @@
     "dispatched": "已派单",
     "agentUnavailable": "AI 队友当前不在线，无法派单——请等它上线，或换一个在线的队友。",
     "daemonUnsupported": "AI 队友的运行环境版本过低，无法安全派单——请先升级它的运行时后重试。",
+    "attachFailedAbort": "有 {{count}} 个附件上传失败，已取消派单——附件是 AI 的上下文，请重试。",
     "examplesTitle": "从一个例子开始",
     "ex1Title": "打磨演示脚本",
     "ex1Desc": "从建单到回路，把一句话派单全链路走顺。",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -3,7 +3,6 @@ import {
   Input,
   Button,
   Spin,
-  Toast,
   Select,
   Pagination,
   DatePicker,
@@ -215,7 +214,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   const openNewLoop = () => {
     WKApp.routeRight.push(
       <NewLoopPage
-        onCreated={() => { Toast.success(t("loop.toast.created")); onMutated(); WKApp.routeRight.pop(); }}
+        onCreated={() => { onMutated(); WKApp.routeRight.pop(); }}
       />,
     );
   };

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -79,7 +79,7 @@ export default function LoopPage() {
   // 新建回路 → 唤起 composer 独立页；成功后落到回路看板（新回路即在其中）。
   const openNewLoop = () => {
     WKApp.routeRight.push(
-      <NewLoopPage onCreated={() => { Toast.success(t("loop.toast.created")); openTab("issue"); }} />,
+      <NewLoopPage onCreated={() => { openTab("issue"); }} />,
     );
   };
 

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -54,7 +54,9 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
     if (!text || !assigneeId || submitting) return;
     setSubmitting(true);
     try {
-      // 附件先上传拿 id（issue 尚不存在），再随派单绑定。单个失败只提示、不阻断。
+      // 附件先上传拿 id（issue 尚不存在），再随派单绑定。
+      // 派单流的附件是 agent 的上下文:任一上传失败就整体中止派单(不静默用残缺上下文派单——
+      // 异步 fire-and-forget,用户导航走后无法补救),提示重试。全成功才继续。
       let attachmentIds: string[] | undefined;
       if (pendingFiles.length) {
         const ids: string[] = [];
@@ -62,7 +64,10 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
         for (const f of pendingFiles) {
           try { ids.push((await uploadAttachment(f)).id); } catch { failed++; }
         }
-        if (failed) Toast.error({ content: t("loop.toast.attachFailed", { values: { count: failed } }), duration: 3 });
+        if (failed) {
+          Toast.error({ content: t("loop.newLoop.attachFailedAbort", { values: { count: failed } }), duration: 3 });
+          return; // finally 会复位 submitting;不派单,用户可重试
+        }
         if (ids.length) attachmentIds = ids;
       }
       // 一句话派单 → quick-create:建单前查 runtime 在线 + daemon 版本,离线/过旧当场 422 反馈,

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -3,7 +3,7 @@ import { Select, Button, Toast, Spin } from "@douyinfe/semi-ui";
 import { ArrowLeft, Paperclip, CornerDownLeft } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { AssigneeType, Project } from "../api/types";
-import { createIssue } from "../api/issueApi";
+import { quickCreateIssue } from "../api/issueApi";
 import { listProjects } from "../api/projectApi";
 import { uploadAttachment } from "../api/attachmentApi";
 import AssigneePicker from "../ui/AssigneePicker";
@@ -16,15 +16,11 @@ export interface NewLoopPageProps {
   onCreated?: () => void;
 }
 
-// 从 prompt 派生标题：取首个非空行、裁到 ~80 字（其余保留在描述里）。
-function deriveTitle(prompt: string): string {
-  const line = prompt.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
-  return line.length > 80 ? line.slice(0, 80) : line;
-}
-
 /**
  * 新建回路独立页（对齐 Figma「把活交给 AI 队友」）：一句话 prompt + 项目/附件 + 指派 AI 队友 → 派单。
- * 映射到现有 createIssue（title 由 prompt 派生，description=prompt，assignee=agent/squad，status=todo 触发派单）。
+ * 派给 agent/squad 恒走 quickCreateIssue(POST /issues/quick-create,建单前查 runtime 在线 + daemon
+ * 版本,离线/过旧当场 422,返回 task_id 由 agent 异步建单)。指派器只给 AI(agent/squad),故须选一个
+ * AI 队友才能派单——无指派时按钮置灰(无 AI 的回路没人跑,不是本页的意图)。
  * 渲染在右主栏（routeRight.push），返回 pop。
  */
 export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
@@ -54,10 +50,11 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
 
   const submit = async () => {
     const text = prompt.trim();
-    if (!text || submitting) return;
+    // 需 prompt + 指派 AI 队友(agent/squad)。本页只派单,无指派不可提交(按钮已置灰,这里双保险)。
+    if (!text || !assigneeId || submitting) return;
     setSubmitting(true);
     try {
-      // 附件先上传拿 id（issue 尚不存在），再随 createIssue 绑定。单个失败只提示、不阻断建单。
+      // 附件先上传拿 id（issue 尚不存在），再随派单绑定。单个失败只提示、不阻断。
       let attachmentIds: string[] | undefined;
       if (pendingFiles.length) {
         const ids: string[] = [];
@@ -65,24 +62,29 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
         for (const f of pendingFiles) {
           try { ids.push((await uploadAttachment(f)).id); } catch { failed++; }
         }
-        if (failed) Toast.error(t("loop.toast.attachFailed", { values: { count: failed } }));
+        if (failed) Toast.error({ content: t("loop.toast.attachFailed", { values: { count: failed } }), duration: 3 });
         if (ids.length) attachmentIds = ids;
       }
-      await createIssue({
-        title: deriveTitle(text),
-        description: text,
-        status: "todo",
-        priority: "none",
-        assignee_id: assigneeId,
-        assignee_type: assigneeType,
+      // 一句话派单 → quick-create:建单前查 runtime 在线 + daemon 版本,离线/过旧当场 422 反馈,
+      // 返回 task_id(异步:agent 稍后建单并跑)。assignee 恒为 agent/squad(指派器只给 AI)。
+      await quickCreateIssue({
+        ...(assigneeType === "squad" ? { squad_id: assigneeId } : { agent_id: assigneeId }),
+        prompt: text,
         project_id: projectId,
         attachment_ids: attachmentIds,
       });
-      // 创建成功后由调用方负责导航(pop 回列表 / 切到回路看板)——此处不再自行 back(),
-      // 避免与调用方的 replaceToRoot 叠加导致把新根也 pop 掉、右栏变空。
+      // 单一 toast 归属此处(异步派单的准确措辞);duration 显式设 3s 保证自动消失。
+      Toast.success({ content: t("loop.newLoop.dispatched"), duration: 3 });
+      // 成功后由调用方负责导航(切回回路看板)——此处不再自行 back(),避免叠加把新根 pop 掉。
       onCreated?.();
     } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+      // quick-create 结构化 422:LoopApiError.code 映射成友好提示(即时失败反馈)。
+      const err = e as { code?: string; message?: string };
+      const msg =
+        err.code === "agent_unavailable" ? t("loop.newLoop.agentUnavailable")
+        : err.code === "daemon_version_unsupported" ? t("loop.newLoop.daemonUnsupported")
+        : (err.message ?? t("loop.toast.saveFailed"));
+      Toast.error({ content: msg, duration: 3 });
     } finally {
       setSubmitting(false);
     }
@@ -150,7 +152,7 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
                   onChange={(id, type, name) => { setAssigneeId(id); setAssigneeType(type); setAssigneeName(name); }}
                 />
               </div>
-              <Button theme="solid" loading={submitting} disabled={!prompt.trim()} onClick={submit} icon={<CornerDownLeft size={14} />} iconPosition="right">
+              <Button theme="solid" loading={submitting} disabled={!prompt.trim() || !assigneeId} onClick={submit} icon={<CornerDownLeft size={14} />} iconPosition="right">
                 {t("loop.newLoop.dispatch")}
               </Button>
             </div>


### PR DESCRIPTION
Upgrades NewLoopPage's one-line dispatch from the generic `createIssue` endpoint to the dedicated `POST /issues/quick-create`, and tightens the dispatch UX.

## Why
`createIssue` with a non-backlog status + agent assignee *does* trigger an agent run on create (backend `WillEnqueueRun`, `RunSourceAssign`), but it gives **no immediate feedback** when the assignee's runtime is offline or its daemon CLI is too old — the loop is created and the run silently never starts. `/issues/quick-create` pre-checks runtime liveness + daemon version server-side and returns a structured `422` (`agent_unavailable` / `daemon_version_unsupported`) plus a `202 { task_id }`, so the user learns immediately.

## Changes
- **api/http.ts** — `LoopApiError` now carries the backend error `code`; `toApiError` reads `response.data.code` and falls back to `reason` for the message (quick-create 422 bodies are `{ code, reason }`). Additive: the new `reason` tier is strictly lower priority than `error`/`message`, and no other endpoint returns a bare `{reason}` error body, so the 45 other `httpPost`/`httpGet` callers are unaffected.
- **api/types.ts + api/issueApi.ts** — `QuickCreateReq` type + `quickCreateIssue()`.
- **pages/NewLoopPage.tsx**
  - The assignee picker only offers AI (`types=["agent","squad"]`), and a loop with no AI can't run, so **dispatch now requires an assignee**: the 派单 button is disabled without one (same as without a prompt). This removes the old no-assignee `createIssue` branch — it only ever produced orphan loops stuck in 待办 that never run. `submit` always quick-creates (`agent_id` XOR `squad_id`). Plain unassigned issues are still created elsewhere (`CreateIssueModal`, used for sub-issues).
  - Maps the two 422 codes to friendly toasts; the async 202 shows a **single** "已派单" toast owned here (accurate wording for async dispatch).
  - Toasts pass explicit `duration: 3` so they auto-dismiss (they were lingering).
- **pages/LoopPage.tsx** — drops the caller's second `Toast.success("已创建")` in NewLoopPage's `onCreated`: it double-toasted and mislabeled the async dispatch as a sync create. NewLoopPage now owns the single accurate toast.
- **i18n** — `newLoop.agentUnavailable` / `daemonUnsupported` (zh + en).

## Blast radius (Rule 8)
Real diff: **7 files, all in `packages/dmloop`** (`git diff origin/feat/octo-loop...HEAD`). No shared signature changed — `LoopApiError` gains an optional field, `toApiError`'s message chain only *appends* a lower-priority fallback, `createIssue` is untouched. `AssigneePicker.onChange` sets `assigneeType`+`assigneeId` atomically (both null or both set from an agent/squad candidate), so the XOR branch is sound. No out-of-`dmloop` consumer affected.

## Verification (real browser, dev — Alice / `mv2-e2e-alice`)
- No assignee (prompt only) → 派单 button **disabled**.
- Assignee (E2E Coworker) + online runtime → 派单 enabled → `POST /issues/quick-create` **202**, single "已派单" toast that **auto-dismisses** (old behavior lingered), page navigates to the board; the async agent then creates the loop.
- Offline runtime (daemon stopped) → `POST /issues/quick-create` **422** — mapped to the friendly `agent_unavailable` toast.
- `tsc --noEmit` clean.

## Gates
`/simplify` (4-agent, clean) + Claude code-reviewer (clean — verified XOR soundness, `toApiError` non-regression, single-toast) + Codex adversarial-review (no material code findings) + real-browser e2e above.

> Note: the async dispatch shows "已派单" and navigates immediately; the created loop appears on the board once the agent builds it (202 + task_id semantics). Deliberately out of scope: client-side CLI-version pre-gate (handled reactively via the 422) and task_id correlation/inbox tracking.