### PR TITLE
fix(versions): keep version-history confirm box on-screen in shared overlay

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -6,6 +6,8 @@
   --octo-accent: #3370ff;
   --octo-border: #e5e6eb;
   --octo-hover: #f2f3f5;
+  /* Shared elevation for overlay-anchored cards (preview/diff modal + destructive confirm). */
+  --octo-modal-shadow: 0 12px 48px rgba(0, 0, 0, 0.24);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1059,7 +1061,7 @@
   color: var(--octo-fg, #1f2329);
   border: 1px solid var(--octo-border, #e5e6eb);
   border-radius: 12px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.24);
+  box-shadow: var(--octo-modal-shadow);
   padding: 20px 24px;
   box-sizing: border-box;
 }
@@ -1387,7 +1389,7 @@
   color: var(--octo-fg, #1f2329);
   border: 1px solid var(--octo-border, #e5e6eb);
   border-radius: 12px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.24);
+  box-shadow: var(--octo-modal-shadow);
   padding: 20px 24px;
   box-sizing: border-box;
 }
@@ -1724,12 +1726,28 @@
   justify-content: flex-end;
   gap: 6px;
 }
-.octo-version-confirm {
-  margin-top: 12px;
-  padding: 12px;
+/* Destructive-action confirm box (restore / delete). The VersionHistoryPanel shell — the single
+   confirm renderer the doc / sheet / board ends now share — renders it inside the shared
+   .octo-modal-overlay (fixed, viewport-centered), the same overlay the preview/diff modal uses
+   (decision #2), so it is always visible and clickable regardless of how far the version list has
+   scrolled. Before this, it sat at the end of the panel's content flow with only box-model styling
+   and no positioning, so on long scrolled lists it fell below the fold and users could not see the
+   confirm they had just triggered. The modal-card chrome (white bg + shadow) is scoped under
+   .octo-modal-overlay so it only applies to the overlay-anchored card and never leaks onto any path
+   that might still render this class inline in the content flow. */
+.octo-modal-overlay .octo-version-confirm {
+  width: 100%;
+  max-width: 420px;
+  padding: 16px 20px;
   border: 1px solid var(--octo-border, #e5e6eb);
-  border-radius: 8px;
-  background: var(--octo-accent-weak, #f2f3f5);
+  border-radius: 12px;
+  background: var(--octo-bg, #fff);
+  color: var(--octo-fg, #1f2329);
+  box-shadow: var(--octo-modal-shadow);
+  box-sizing: border-box;
+}
+.octo-version-confirm > p:first-child {
+  margin-top: 0;
 }
 .octo-version-confirm-detail {
   color: var(--octo-muted, #86909c);

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -306,6 +306,66 @@ describe('VersionHistoryPanel — mutations & permissions', () => {
     confirmSpy.mockRestore()
   })
 
+  it('renders the confirm box in a fixed viewport-centered overlay (stays visible on long scrolled lists)', async () => {
+    // Regression for XIN-867: the in-panel confirm box used to render at the end of the panel's
+    // content flow (after the version list) with only box-model styling and no positioning, so on a
+    // long, scrolled list it fell below the fold — users clicked delete/restore and never saw the
+    // confirm. It now renders inside the shared .octo-modal-overlay (position: fixed; inset: 0), the
+    // same viewport-anchored overlay the preview/diff modal uses, so it is always on-screen and its
+    // buttons clickable regardless of scroll. jsdom does not compute layout, so we assert the overlay
+    // structure (which pins the fixed positioning) rather than measured coordinates, and verify the
+    // overlay-click / Esc cancel paths that match the preview modal.
+    renderPanel('admin')
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.delete'))
+    const box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    // The confirm card is wrapped by the fixed viewport overlay, not left inline in the panel flow.
+    const overlay = box.closest('.octo-modal-overlay') as HTMLElement
+    expect(overlay).toBeTruthy()
+    expect(box.getAttribute('role')).toBe('dialog')
+    expect(box.getAttribute('aria-modal')).toBe('true')
+    // Clicking the card body does not dismiss (stopPropagation); clicking the overlay backdrop does.
+    fireEvent.mouseDown(box)
+    expect(document.querySelector('.octo-version-confirm')).toBeTruthy()
+    fireEvent.mouseDown(overlay)
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
+    // Reopen and confirm Escape cancels too (mirrors the preview modal).
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.restore'))
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeTruthy())
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
+  })
+
+  it('does not dismiss the confirm overlay on backdrop-click or Escape while a restore is in flight (busy guard)', async () => {
+    // The overlay-click and Escape cancel paths both no-op while a mutation is running, so a stray
+    // backdrop click or keypress cannot tear the confirm down mid-request. Hold the restore mutation
+    // open to keep the panel busy, then assert both dismissals are ignored until it settles.
+    let release!: (v: { newDocVersionSeq: number; restoredFrom: number }) => void
+    restoreVersionMock.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        release = resolve
+      }),
+    )
+    renderPanel('admin')
+    await screen.findByText('Draft v1')
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.restore'))
+    const box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    const overlay = box.closest('.octo-modal-overlay') as HTMLElement
+
+    // Trigger the restore → busy is now true (mutation pending).
+    fireEvent.click(btnByText(box, 'docs.version.restore'))
+    await waitFor(() => expect(restoreVersionMock).toHaveBeenCalled())
+
+    // Backdrop click and Escape are both no-ops while busy.
+    fireEvent.mouseDown(overlay)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.querySelector('.octo-version-confirm')).toBeTruthy()
+
+    // Once the mutation settles, the confirm clears on its own.
+    release({ newDocVersionSeq: 9, restoredFrom: 7 })
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
+  })
+
   it('renames a named version inline (no native prompt)', async () => {
     renderPanel('admin')
     await screen.findByText('Draft v1')

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -391,6 +391,20 @@ export function VersionHistoryPanel<TState, TCurrent>({
     return () => document.removeEventListener('keydown', onKey)
   }, [selected, closePreview])
 
+  // Escape also cancels the restore / delete confirm overlay, matching the preview modal's Esc/
+  // overlay-close behavior. It only clears the confirm state (never the in-flight mutation), and it
+  // no-ops while a mutation is running so a keypress can't dismiss the box mid-request.
+  useEffect(() => {
+    if (!confirmRestore && !confirmDelete) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || busy) return
+      setConfirmRestore(null)
+      setConfirmDelete(null)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [confirmRestore, confirmDelete, busy])
+
   const filterBtn = (k: KindFilter, label: string) => (
     <button
       type="button"
@@ -569,50 +583,78 @@ export function VersionHistoryPanel<TState, TCurrent>({
         )}
 
         {confirmRestore && (
-          <div className="octo-version-confirm">
-            <p>{t('docs.version.confirmTitle', { values: { seq: confirmRestore.docVersionSeq } })}</p>
-            <p className="octo-version-confirm-detail">{t('docs.version.confirmDetail')}</p>
-            <div className="octo-member-row">
-              <button
-                type="button"
-                className="octo-tb-btn"
-                disabled={busy}
-                onClick={() => void onConfirmRestore(confirmRestore)}
-              >
-                {t('docs.version.restore')}
-              </button>
-              <button
-                type="button"
-                className="octo-tb-btn"
-                disabled={busy}
-                onClick={() => setConfirmRestore(null)}
-              >
-                {t('docs.version.cancel')}
-              </button>
+          <div
+            className="octo-modal-overlay"
+            role="presentation"
+            onMouseDown={() => {
+              if (!busy) setConfirmRestore(null)
+            }}
+          >
+            <div
+              className="octo-version-confirm"
+              role="dialog"
+              aria-modal="true"
+              aria-label={t('docs.version.restore')}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <p>{t('docs.version.confirmTitle', { values: { seq: confirmRestore.docVersionSeq } })}</p>
+              <p className="octo-version-confirm-detail">{t('docs.version.confirmDetail')}</p>
+              <div className="octo-member-row">
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => void onConfirmRestore(confirmRestore)}
+                >
+                  {t('docs.version.restore')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => setConfirmRestore(null)}
+                >
+                  {t('docs.version.cancel')}
+                </button>
+              </div>
             </div>
           </div>
         )}
 
         {confirmDelete && (
-          <div className="octo-version-confirm">
-            <p>{t('docs.version.deleteConfirm', { values: { seq: confirmDelete.docVersionSeq } })}</p>
-            <div className="octo-member-row">
-              <button
-                type="button"
-                className="octo-tb-btn"
-                disabled={busy}
-                onClick={() => void onDelete(confirmDelete)}
-              >
-                {t('docs.version.delete')}
-              </button>
-              <button
-                type="button"
-                className="octo-tb-btn"
-                disabled={busy}
-                onClick={() => setConfirmDelete(null)}
-              >
-                {t('docs.version.cancel')}
-              </button>
+          <div
+            className="octo-modal-overlay"
+            role="presentation"
+            onMouseDown={() => {
+              if (!busy) setConfirmDelete(null)
+            }}
+          >
+            <div
+              className="octo-version-confirm"
+              role="dialog"
+              aria-modal="true"
+              aria-label={t('docs.version.delete')}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <p>{t('docs.version.deleteConfirm', { values: { seq: confirmDelete.docVersionSeq } })}</p>
+              <div className="octo-member-row">
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => void onDelete(confirmDelete)}
+                >
+                  {t('docs.version.delete')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => setConfirmDelete(null)}
+                >
+                  {t('docs.version.cancel')}
+                </button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## What

The restore/delete confirm box in the unified `VersionHistoryPanel` shell rendered at the end of the panel's content flow with only box-model styling and no positioning. On a long, scrolled version list it appeared below the fold, so users clicked delete/restore and never saw the confirm they had just triggered.

Now that the doc, sheet and board panels are all thin adapters over `VersionHistoryPanel`, the shell is the single place that renders the destructive-action confirm for every end — so fixing it here fixes all three.

## Changes

- Render the restore and delete confirm boxes inside the shared `.octo-modal-overlay` (fixed, viewport-centered) — the same overlay the preview/diff modal uses — so the box is always visible and its buttons clickable regardless of scroll position.
- Clicking the backdrop or pressing `Escape` cancels, mirroring the preview modal. Both paths are guarded so an in-flight restore/delete can't be dismissed mid-request. The confirm state machine, race guard, and mounted-ref liveness are untouched.
- Scope the modal-card chrome under `.octo-modal-overlay .octo-version-confirm` so it only styles the overlay-anchored card and never leaks onto any path that might still render the class inline in the content flow.
- Share the elevation via a new `--octo-modal-shadow` token; the confirm and the existing preview/diff modals now reuse it instead of hardcoded `rgba` shadow literals.
- Add regression tests asserting the shell confirm is overlay-wrapped, cancels on backdrop-click / `Escape`, and holds while a restore is in flight.

## Notes

Rebased onto the latest `main`. Since the three version panels were unified behind `VersionHistoryPanel`, the live `VersionPanel` no longer renders its own inline confirm — the earlier inline-confirm migration is dropped, and the final diff is limited to the shell, its tests, and the shared card styles.

## Testing

- `packages/docs` version tests green (`vitest run src/versions/` — 77 passing).
- `typecheck`: no new errors introduced by this change.
- `stylelint`: no new violations; net fewer raw `rgba` literals after consolidating the shadow into a token.
