### PR TITLE
feat(loop): add manual-create mode to assign loops to people, not only AI

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -655,6 +655,7 @@
     "agentUnavailable": "That AI teammate is offline right now, so it can't be dispatched — wait for it to come online, or pick one that's online.",
     "daemonUnsupported": "That AI teammate's runtime is too old to dispatch safely — please upgrade its runtime and try again.",
     "attachFailedAbort": "{{count}} attachment(s) failed to upload, so dispatch was cancelled — attachments are the AI's context; please retry.",
+    "manualSwitch": "Create manually · assign to a person",
     "examplesTitle": "Start from an example",
     "ex1Title": "Polish the demo script",
     "ex1Desc": "Take one line from ticket to loop, end to end.",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -655,6 +655,7 @@
     "agentUnavailable": "AI 队友当前不在线，无法派单——请等它上线，或换一个在线的队友。",
     "daemonUnsupported": "AI 队友的运行环境版本过低，无法安全派单——请先升级它的运行时后重试。",
     "attachFailedAbort": "有 {{count}} 个附件上传失败，已取消派单——附件是 AI 的上下文，请重试。",
+    "manualSwitch": "手动建单 · 指派给人",
     "examplesTitle": "从一个例子开始",
     "ex1Title": "打磨演示脚本",
     "ex1Desc": "从建单到回路，把一句话派单全链路走顺。",

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Select, Button, Toast, Spin } from "@douyinfe/semi-ui";
-import { ArrowLeft, Paperclip, CornerDownLeft } from "lucide-react";
+import { ArrowLeft, Paperclip, CornerDownLeft, UserPlus } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { AssigneeType, Project } from "../api/types";
 import { quickCreateIssue } from "../api/issueApi";
 import { listProjects } from "../api/projectApi";
 import { uploadAttachment } from "../api/attachmentApi";
 import AssigneePicker from "../ui/AssigneePicker";
+import CreateIssueModal from "../ui/CreateIssueModal";
 import AutoGrowTextarea from "../ui/AutoGrowTextarea";
 import "./loop.css";
 import "../ui/loopControls.css";
@@ -21,6 +22,9 @@ export interface NewLoopPageProps {
  * 派给 agent/squad 恒走 quickCreateIssue(POST /issues/quick-create,建单前查 runtime 在线 + daemon
  * 版本,离线/过旧当场 422,返回 task_id 由 agent 异步建单)。指派器只给 AI(agent/squad),故须选一个
  * AI 队友才能派单——无指派时按钮置灰(无 AI 的回路没人跑,不是本页的意图)。
+ * 需指派给「人」时走顶部「手动建单」切换,唤起 CreateIssueModal(title + member/agent/squad 三态 +
+ * 状态/优先级,createIssue 同步建单不派单)——对齐上游 quick-create(AI)/manual(可指人)双模式,
+ * 上游亦在框内切换而非入口菜单(create-mode-store)。
  * 渲染在右主栏（routeRight.push），返回 pop。
  */
 export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
@@ -33,6 +37,7 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
   const [assigneeName, setAssigneeName] = useState<string | null>(null);
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
 
   useEffect(() => {
     listProjects().then(setProjects).catch(() => setProjects([]));
@@ -110,6 +115,10 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
       <div className="loop-newloop__bar-top">
         <Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>
           {t("loop.detail.back")}
+        </Button>
+        {/* 指派给「人」→ 切到手动建单(CreateIssueModal 支持 member/agent/squad),对齐上游框内切换。 */}
+        <Button icon={<UserPlus size={14} />} theme="borderless" onClick={() => setManualOpen(true)} style={{ marginLeft: "auto" }}>
+          {t("loop.newLoop.manualSwitch")}
         </Button>
       </div>
 
@@ -189,6 +198,15 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
       </div>
 
       {submitting && <div className="loop-newloop__overlay"><Spin /></div>}
+
+      {/* 手动建单(可指派给人):顶层建单,无 parentIssueId;成功后复用同一 onCreated 回落看板。
+          成功 toast 归此处的调用方(对齐 AI 派单路 + IssueDetailPage 约定:CreateIssueModal 自身不弹,
+          由调用方弹「已创建」;单弹一次,不与派单路重复)。 */}
+      <CreateIssueModal
+        visible={manualOpen}
+        onClose={() => setManualOpen(false)}
+        onCreated={() => { setManualOpen(false); Toast.success({ content: t("loop.toast.created"), duration: 3 }); onCreated?.(); }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

The new-loop composer only does quick-create — dispatch to an **AI** agent/squad. You cannot assign a loop to a **person** from it. This adds a "手动建单 · 指派给人" (Create manually · assign to a person) switch in the composer top bar that opens the existing member-capable `CreateIssueModal`, so loops can be assigned to a human colleague.

## Why this shape (consistency with upstream)

Upstream splits creation into **two flows**, and this mirrors it exactly:
- **quick-create** — `QuickCreateActorType = "agent" | "squad"`, prompt-based, dispatches. → our `NewLoopPage` (unchanged here).
- **manual create** — `title` + `assignee_type: "member" | "agent" | "squad"`, `createIssue`, no dispatch. → our `CreateIssueModal` (already existed, only wired for sub-issues).

Upstream switches mode **inside the composer** (`create-mode-store`: "the switch button in either modal"), not via an entry menu. So instead of polluting the AI-dispatch composer with a member option (which would diverge from upstream's quick-create contract), we add an in-composer switch to the existing manual modal. Quick-create stays agent/squad only.

## Changes

- `NewLoopPage.tsx`: `manualOpen` state + a top-bar switch button; renders the existing `CreateIssueModal` (no `parentIssueId` → top-level issue). Its `onCreated` forwards to the same callback the dispatch path uses, so the board refreshes and the composer pops. Success toast (`已创建`) is fired by the caller here — matching the AI-dispatch branch and the established `CreateIssueModal` convention (the modal itself never toasts). Single toast, no double-fire.
- i18n: `loop.newLoop.manualSwitch` (zh + en).

Net diff: 3 files, +21/-1. Maximal reuse — no new form, no new entry-point plumbing (all top-level create entries already land on `NewLoopPage`).

## Verification (real-env e2e)

Reproduced in the running dev stack (Alice_Space, Loop-dev board):
1. 回路 board → 新建回路 → **手动建单 · 指派给人** → modal opens with the three-state assignee picker (未指派 / 成员: Alice, Bob / agent / squad).
2. Assigned **Bob** (member), title, Create → **LOO-2** appears on the board assigned to Bob, no AI dispatch (member → `createIssue`, `WillEnqueueRun` doesn't fire). Composer popped, board refreshed.
3. Repeated assigning **Alice** → **LOO-3** on board + single **已创建** success toast (semantics correct, not "已派单").

## Review

- Codex adversarial-review: approve, no material findings.
- Claude code-reviewer: found the missing success-toast on the manual path (silent success vs every other create flow) — **fixed** in this branch (caller-side `Toast.success(已创建)`), re-verified by e2e above. No other findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)