### PR TITLE
fix(docs): show all documents in the sidebar, not just the first page

### DIFF
--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -345,12 +345,37 @@ function DocsList({
     const seq = ++reloadSeq.current
     setLoading(true)
     setError(null)
-    listDocs({ spaceId: space || undefined, folderId: folder || undefined, sort: 'updatedAt:desc' })
-      .then((res) => {
+    // The backend paginates (default pageSize 20, max 100) and reports `total`.
+    // The sidebar must show every document, not just the first page, so fetch
+    // all pages and concatenate. pageSize is pinned to the backend maximum (100)
+    // to minimize round-trips; the loop stops once we have collected `total`
+    // items (or a short page comes back, guarding against a stalled total).
+    const fetchAll = async (): Promise<DocListItem[]> => {
+      const PAGE_SIZE = 100
+      const all: DocListItem[] = []
+      let page = 1
+      for (;;) {
+        const res = await listDocs({
+          spaceId: space || undefined,
+          folderId: folder || undefined,
+          sort: 'updatedAt:desc',
+          page,
+          pageSize: PAGE_SIZE,
+        })
+        const batch = res?.items ?? []
+        all.push(...batch)
+        const total = res?.total ?? all.length
+        if (batch.length < PAGE_SIZE || all.length >= total) break
+        page += 1
+      }
+      return all
+    }
+    fetchAll()
+      .then((items) => {
         // A newer reload has superseded this one (e.g. the Space changed again while this
         // request was in flight) — drop the stale response so it can't overwrite the current list.
         if (seq !== reloadSeq.current) return
-        setItems(res?.items ?? [])
+        setItems(items)
       })
       .catch((err) => {
         if (seq !== reloadSeq.current) return


### PR DESCRIPTION
## Summary
The docs sidebar only rendered the first 20 documents. The list backend (`GET /api/v1/docs`) paginates with a default `pageSize` of 20 and reports `total`, but `DocsList.reload()` called `listDocs(...)` with no page size and rendered only the first response. In a space with more than 20 documents the rest were silently invisible.

This fetches every page (pageSize pinned to the backend maximum of 100) and concatenates until the reported `total` is collected, then sets the list in one update. The existing stale-response guard (XIN-417) is preserved so a superseded reload cannot overwrite the current space's list.

## Linked Spec
Fixes #676

## How verified
- Confirmed the target space has 39 documents (all in the default folder) via the backend metadata store; before the fix only 20 were listed.
- Simulated the new pagination loop against the live list query: `pageSize=100` returns all 39 in one page, the loop terminates correctly (`batch < PAGE_SIZE` and `collected >= total`), and the sidebar renders all 39.
- `tsc --noEmit` on the docs typecheck project: no errors in the touched file.
- Verified live via Vite HMR on the running dev server.