### PR TITLE
fix(docs): restore heading level hierarchy

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -578,6 +578,46 @@
   line-height: 1.6;
   font-size: 15px;
 }
+.octo-prose .ProseMirror h1,
+.octo-prose .ProseMirror h2,
+.octo-prose .ProseMirror h3,
+.octo-prose .ProseMirror h4,
+.octo-prose .ProseMirror h5,
+.octo-prose .ProseMirror h6 {
+  margin: var(--wk-sp-5) 0 var(--wk-sp-2);
+  font-family: var(--wk-font-sans);
+  letter-spacing: 0;
+}
+.octo-prose .ProseMirror h1 {
+  font-size: var(--wk-text-size-4xl);
+  font-weight: var(--wk-font-bold);
+  line-height: var(--wk-leading-tight);
+}
+.octo-prose .ProseMirror h2 {
+  font-size: var(--wk-text-size-3xl);
+  font-weight: var(--wk-font-bold);
+  line-height: var(--wk-leading-snug);
+}
+.octo-prose .ProseMirror h3 {
+  font-size: var(--wk-text-size-xl);
+  font-weight: var(--wk-font-semibold);
+  line-height: var(--wk-leading-snug);
+}
+.octo-prose .ProseMirror h4 {
+  font-size: var(--wk-text-size-md);
+  font-weight: var(--wk-font-semibold);
+  line-height: var(--wk-leading-normal);
+}
+.octo-prose .ProseMirror h5 {
+  font-size: var(--wk-text-size-base);
+  font-weight: var(--wk-font-semibold);
+  line-height: var(--wk-leading-normal);
+}
+.octo-prose .ProseMirror h6 {
+  font-size: var(--wk-text-size-sm);
+  font-weight: var(--wk-font-semibold);
+  line-height: var(--wk-leading-normal);
+}
 .octo-prose .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   color: var(--octo-muted);

--- a/packages/docs/src/editor/styles.test.ts
+++ b/packages/docs/src/editor/styles.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = fs.readFileSync(path.resolve(__dirname, "styles.css"), "utf8");
+
+function headingRule(level: number): string {
+  const matches = [
+    ...css.matchAll(
+      new RegExp(`\\.octo-prose \\.ProseMirror h${level}\\s*\\{([^}]*)\\}`, "g")
+    ),
+  ];
+  const rule = matches.find((match) => match[1].includes("font-size"))?.[1];
+  expect(rule, `missing scoped H${level} font-size rule`).toBeDefined();
+  return rule ?? "";
+}
+
+describe("editor heading hierarchy styles", () => {
+  it("assigns a distinct descending font-size token to every heading level", () => {
+    const sizeTokens = [
+      "--wk-text-size-4xl",
+      "--wk-text-size-3xl",
+      "--wk-text-size-xl",
+      "--wk-text-size-md",
+      "--wk-text-size-base",
+      "--wk-text-size-sm",
+    ];
+
+    sizeTokens.forEach((token, index) => {
+      expect(headingRule(index + 1)).toMatch(
+        new RegExp(`font-size:\\s*var\\(${token}\\)`)
+      );
+    });
+    expect(new Set(sizeTokens).size).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

- add scoped H1-H6 typography rules to the document editor
- use existing spacing, font-size, weight, and line-height tokens
- add a regression test that keeps every heading level on a distinct descending size token

## Verification

- `pnpm --filter @octo/docs exec vitest run src/editor/styles.test.ts --reporter=verbose`
- `pnpm --filter @octo/web build`
- browser computed styles: 28 / 22 / 16 / 14 / 13 / 12 px

Closes #614