### PR TITLE
fix(loop): guard AssigneePicker candidate loads against stale-response race

### DIFF
--- a/packages/dmloop/src/ui/AssigneePicker.tsx
+++ b/packages/dmloop/src/ui/AssigneePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Dropdown, Avatar } from "@douyinfe/semi-ui";
 import { ChevronDown, User, Bot, Users, CircleSlash } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -26,11 +26,20 @@ export interface AssigneePickerProps {
 export default function AssigneePicker({ value, valueName, onChange, size = "default", types }: AssigneePickerProps) {
   const { t } = useI18n();
   const [cands, setCands] = useState<AssigneeCandidate[]>([]);
+  // 请求序号:挂载 + 每次开框都会重取候选,多个 in-flight 时只让最新一次落地
+  // (镜像 SettingsPage 的 seqRef 守卫);旧请求后到不得覆盖新候选。
+  const seqRef = useRef(0);
 
   // 挂载先取一次;每次开框再取 —— afterDirectoryMutation 只清共享缓存,挂载中的 picker
   // 不会自动重读,故开框时刷新以反映其间的成员/agent/squad 增删。
-  const loadCands = () => { listAssigneeCandidates().then(setCands).catch(() => setCands([])); };
-  useEffect(() => { loadCands(); }, []);
+  const loadCands = () => {
+    const my = ++seqRef.current;
+    listAssigneeCandidates()
+      .then((list) => { if (my === seqRef.current) setCands(list); })
+      .catch(() => { if (my === seqRef.current) setCands([]); });
+  };
+  // 卸载时自增序号,使在途响应全部作废(避免卸载后 setState)。
+  useEffect(() => { loadCands(); return () => { seqRef.current++; }; }, []);
 
   const current = cands.find((c) => c.id === value);
   const allGroups: { type: AssigneeType; label: string }[] = [


### PR DESCRIPTION
## What

`AssigneePicker` refetches assignee candidates (`listAssigneeCandidates` → `setCands`) on mount and on every dropdown open (`onVisibleChange`), but had **no sequence guard**. With two loads in flight, the later-resolving one wins, so an older request can overwrite newer candidates after a directory mutation (`afterDirectoryMutation` clears the shared cache). Transient and self-healing, but a real stale-state race.

This is the sibling instance of the exact race class already fixed in `SettingsPage.tsx` (its `seqRef` guard). The #672 review flagged this AssigneePicker instance; it was merged as a known-issue follow-up (downgraded 🔴→🟡). This PR closes it before it reaches `main`.

## Fix

Mirror `SettingsPage`'s `seqRef` idiom in `packages/dmloop/src/ui/AssigneePicker.tsx`:
- Capture a monotonic token (`const my = ++seqRef.current`) synchronously before the fetch; only let the latest response call `setCands` (`if (my === seqRef.current)`).
- Increment `seqRef` in the mount effect's cleanup so **all** in-flight responses are invalidated on unmount (no `setState` after unmount) — covers both the mount fetch and any `onVisibleChange` fetch.

No prop/signature change.

## Blast radius (Rule 8)

Change is entirely internal to `AssigneePicker` — its props (`value`, `valueName`, `onChange`, `size`, `types`) are unchanged. All consumers (`NewLoopPage`, `CreateIssueModal`, `IssueList` batch bar, `IssueDetailPage`) are unaffected: they still get the same candidate list, just without the stale-overwrite window. Zero out-of-module impact.

## Verification

- **Real-env e2e** (dev, Alice, Loop-dev): the three-state picker (`CreateIssueModal` 负责人) loads candidates correctly after the change — menu shows 未指派 / 成员 Alice / Bob. The 执行方 picker (`types=[agent,squad]`) renders empty as expected (no agents in that workspace). No regression to candidate loading or selection.
- The race itself is a timing race (needs a directory mutation between two in-flight loads) — verified by code inspection that the guard is now present and correct; reviewers confirmed the token-capture/compare and unmount-invalidation logic.
- Codex adversarial-review: approve, no material findings. Claude code-reviewer: clean (verified token capture, unmount invalidation, latest-response-not-rejected, React 18 + StrictMode double-invoke). tsc clean.

## Follow-ups (not in this PR)
- `RunDetailModal` silently stops polling after `MAX_MISSES` without signalling "run no longer exists" (can stay on a stale running state).
- `packages/dmloop` race/polling logic still lacks focused tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)