### PR TITLE
fix(web): land /summary/detail?taskId= deep link on boot (#150)

### DIFF
--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -11,6 +11,7 @@ import { ContactsIcon } from '../Components/Icons/ContactsIcon';
 import { SummaryIcon } from '../Components/Icons/SummaryIcon';
 import { Toast } from '@douyinfe/semi-ui';
 import { clearDeprecatedFriendApplyReddotOnce } from './friendApplyReddotCleanup';
+import { runSummaryDetailLanding } from './summaryDetailLanding';
 
 let _summaryBadgeCount = 0;
 let _badgeListenerSetup = false;
@@ -45,8 +46,26 @@ function useRealnameVerifiedLandingHandler() {
   }, []);
 }
 
+function useSummaryDetailLandingHandler() {
+  useEffect(() => {
+    const cleanup = runSummaryDetailLanding({
+      getPathname: () => window.location.pathname,
+      getSearch: () => window.location.search,
+      isLoggedIn: () => WKApp.loginInfo.isLogined(),
+      getOpenSummaryDetail: () => WKApp.openSummaryDetail,
+      cleanUrl: () => {
+        window.history.replaceState(null, '', '/' + window.location.hash);
+      },
+      setRetry: (cb, delayMs) => window.setTimeout(cb, delayMs),
+      clearRetry: (handle) => window.clearTimeout(handle),
+    });
+    return cleanup;
+  }, []);
+}
+
 function App() {
   useRealnameVerifiedLandingHandler()
+  useSummaryDetailLandingHandler()
   useDeprecatedFriendApplyReddotCleanup()
   registerMenus()
   return (

--- a/apps/web/src/App/summaryDetailLanding.ts
+++ b/apps/web/src/App/summaryDetailLanding.ts
@@ -1,0 +1,61 @@
+export type SummaryDetailLandingDeps = {
+  // 拆成 getter 而非直取值：landing 时序上 openSummaryDetail 由 dmworksummary 模块
+  // init 注册，首帧 effect 执行时可能尚未挂到 WKApp 上，故每次重试都重新读取。
+  getPathname: () => string;
+  getSearch: () => string;
+  isLoggedIn: () => boolean;
+  getOpenSummaryDetail: () => ((taskId: number) => void) | undefined;
+  cleanUrl?: (taskId: number) => void;
+  setRetry: (cb: () => void, delayMs: number) => number;
+  clearRetry: (handle: number) => void;
+};
+
+const SUMMARY_DETAIL_PATH = '/summary/detail';
+const SUMMARY_DETAIL_RETRY_INTERVAL_MS = 100;
+const SUMMARY_DETAIL_MAX_RETRIES = 20; // ~2s 兜底：等 dmworksummary 模块 init 注册 openSummaryDetail
+
+/**
+ * URL 直达落地：通知 DM 里的 `${origin}/summary/detail?taskId=<id>` 被点击后浏览器
+ * 直接打开该地址，但 App 启动默认渲染 ChatPage、不消费 location。这里在启动时读一次
+ * location，命中该路径且已登录时调用 WKApp.openSummaryDetail(taskId) 落到详情页。
+ *
+ * 纯依赖注入以便脱离 @octo/base 重模块图做单测（对齐 friendApplyReddotCleanup.ts 风格）。
+ *
+ * @returns cleanup 函数（停止仍在排队的重试）；返回 undefined 表示未启动任何重试。
+ */
+export function runSummaryDetailLanding(deps: SummaryDetailLandingDeps): (() => void) | undefined {
+  try {
+    const pathname = (deps.getPathname() || '').replace(/\/+$/, '') || '/';
+    if (pathname !== SUMMARY_DETAIL_PATH) return undefined;
+
+    // 未登录不动作：登录前落地会被登录流程打断，且详情页依赖登录态。
+    if (!deps.isLoggedIn()) return undefined;
+
+    const raw = new URLSearchParams(deps.getSearch()).get('taskId');
+    // 只收正整数：后端 %d 只发真实 ID，负数/小数/十六进制/超 2^53 均非法，收严更防御。
+    const taskId = Number(raw);
+    if (raw === null || !/^\d+$/.test(raw.trim()) || !Number.isSafeInteger(taskId) || taskId <= 0) return undefined;
+
+    let handle: number | undefined;
+    let attempts = 0;
+    const tryOpen = () => {
+      const open = deps.getOpenSummaryDetail();
+      if (open) {
+        open(taskId);
+        // 清 URL 回干净路径：避免用户刷新时重复落地（openSummaryDetail 已切到 summary 主 Tab）。
+        deps.cleanUrl?.(taskId);
+        return;
+      }
+      if (++attempts >= SUMMARY_DETAIL_MAX_RETRIES) return;
+      handle = deps.setRetry(tryOpen, SUMMARY_DETAIL_RETRY_INTERVAL_MS);
+    };
+    tryOpen();
+
+    return () => {
+      if (handle !== undefined) deps.clearRetry(handle);
+    };
+  } catch (e) {
+    // URL API / location 在 SSR / 非浏览器环境下可能不可用——静默忽略不阻塞渲染。
+    return undefined;
+  }
+}

--- a/apps/web/src/__tests__/summaryDetailLanding.test.tsx
+++ b/apps/web/src/__tests__/summaryDetailLanding.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runSummaryDetailLanding, type SummaryDetailLandingDeps } from '../App/summaryDetailLanding'
+
+/**
+ * Coverage for #150: a summary-completed DM carries `${origin}/summary/detail?taskId=<id>`.
+ * Clicking it opens the browser at that URL, but App boot renders the default ChatPage and
+ * never consumes location — so the landing handler must call WKApp.openSummaryDetail(taskId).
+ *
+ * Tested against the pure `runSummaryDetailLanding` DI helper (no @octo/base module graph),
+ * matching the house style of mainMenuReconcile.test.tsx. Retries run synchronously here via a
+ * setRetry stub that invokes its callback immediately, so we can assert the timing fallback for
+ * a not-yet-registered openSummaryDetail without real timers.
+ */
+
+function makeDeps(overrides: Partial<SummaryDetailLandingDeps>): {
+  deps: SummaryDetailLandingDeps
+  open: ReturnType<typeof vi.fn>
+} {
+  const open = vi.fn()
+  const deps: SummaryDetailLandingDeps = {
+    getPathname: () => '/summary/detail',
+    getSearch: () => '?taskId=123',
+    isLoggedIn: () => true,
+    getOpenSummaryDetail: () => open,
+    setRetry: (cb) => {
+      cb() // synchronous retry for deterministic tests
+      return 0
+    },
+    clearRetry: () => {},
+    ...overrides,
+  }
+  return { deps, open }
+}
+
+describe('runSummaryDetailLanding (#150)', () => {
+  it('opens the detail page when path=/summary/detail?taskId=123 and logged in', () => {
+    const { deps, open } = makeDeps({})
+    runSummaryDetailLanding(deps)
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(open).toHaveBeenCalledWith(123)
+  })
+
+  it('tolerates a trailing slash on the pathname', () => {
+    const { deps, open } = makeDeps({ getPathname: () => '/summary/detail/' })
+    runSummaryDetailLanding(deps)
+    expect(open).toHaveBeenCalledWith(123)
+  })
+
+  it('does nothing when the pathname is not /summary/detail', () => {
+    const { deps, open } = makeDeps({ getPathname: () => '/' })
+    runSummaryDetailLanding(deps)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when taskId is missing', () => {
+    const { deps, open } = makeDeps({ getSearch: () => '' })
+    runSummaryDetailLanding(deps)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when taskId is non-numeric', () => {
+    const { deps, open } = makeDeps({ getSearch: () => '?taskId=abc' })
+    runSummaryDetailLanding(deps)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-canonical taskId values (0, negative, float, hex)', () => {
+    for (const q of ['?taskId=0', '?taskId=-5', '?taskId=1.5', '?taskId=0x1F']) {
+      const { deps, open } = makeDeps({ getSearch: () => q })
+      runSummaryDetailLanding(deps)
+      expect(open, `taskId query ${q} must be rejected`).not.toHaveBeenCalled()
+    }
+  })
+
+  it('does nothing when the user is not logged in', () => {
+    const { deps, open } = makeDeps({ isLoggedIn: () => false })
+    runSummaryDetailLanding(deps)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('retries until openSummaryDetail is registered, then stops', () => {
+    let ready = false
+    const open = vi.fn()
+    let calls = 0
+    const deps: SummaryDetailLandingDeps = {
+      getPathname: () => '/summary/detail',
+      getSearch: () => '?taskId=7',
+      isLoggedIn: () => true,
+      getOpenSummaryDetail: () => (ready ? open : undefined),
+      setRetry: (cb) => {
+        // Ready on the 3rd attempt; each setRetry drives the next synchronous poll.
+        if (++calls === 2) ready = true
+        cb()
+        return calls
+      },
+      clearRetry: () => {},
+    }
+    runSummaryDetailLanding(deps)
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(open).toHaveBeenCalledWith(7)
+  })
+
+  it('gives up after the retry cap without throwing when openSummaryDetail never appears', () => {
+    let calls = 0
+    const deps: SummaryDetailLandingDeps = {
+      getPathname: () => '/summary/detail',
+      getSearch: () => '?taskId=9',
+      isLoggedIn: () => true,
+      getOpenSummaryDetail: () => undefined, // never registers
+      setRetry: (cb) => {
+        calls++
+        cb()
+        return calls
+      },
+      clearRetry: () => {},
+    }
+    expect(() => runSummaryDetailLanding(deps)).not.toThrow()
+    // Initial attempt + retries, capped: setRetry is called (MAX_RETRIES - 1) times because
+    // the final attempt hits the cap and returns without scheduling. Must be finite (no infinite loop).
+    expect(calls).toBe(19)
+  })
+
+  it('cleans the URL after a successful landing', () => {
+    const cleanUrl = vi.fn()
+    const { deps, open } = makeDeps({ cleanUrl })
+    runSummaryDetailLanding(deps)
+    expect(open).toHaveBeenCalledWith(123)
+    expect(cleanUrl).toHaveBeenCalledWith(123)
+  })
+})


### PR DESCRIPTION
## What & why
`Closes #150` (web side).

A completed-summary notification DM carries a deep link `${origin}/summary/detail?taskId=<id>`. Clicking it opens the browser at that URL, but the app boot renders the default ChatPage and never consumes `location.pathname`, so the detail page never opened — this is the front-end root cause of "点了跳不过去".

## Change
- `apps/web/src/App/index.tsx`: add a startup landing hook `useSummaryDetailLandingHandler` (thin adapter injecting browser deps), called next to the existing `useRealnameVerifiedLandingHandler`.
- `apps/web/src/App/summaryDetailLanding.ts` (new): pure DI logic `runSummaryDetailLanding` — on `/summary/detail` (trailing slash tolerated) and when logged in, parse a canonical positive-integer `taskId` and call `WKApp.openSummaryDetail(taskId)`. Because `openSummaryDetail` is registered by the dmworksummary module init and may not be ready on the first effect, it retries every 100ms up to 20 times (~2s), then gives up. On success it cleans the URL (preserving the hash). Fully guarded (SSR/non-browser => no-op). Logic is extracted (mirroring the repo's `friendApplyReddotCleanup.ts` pattern) so it can be unit-tested off the heavy `@octo/base` module graph.
- `apps/web/src/__tests__/summaryDetailLanding.test.tsx` (new): 10 cases (happy path, trailing slash, wrong path, missing/non-numeric/0/negative/float/hex taskId rejected, not-logged-in, retry-until-ready, retry-cap no-throw, URL cleanup).

## Deploy prerequisite (env vars)
None on the web container itself. The link is produced by the worker side (PR on octo-smart-summary): the worker must set `SUMMARY_WEB_BASE_URL=<this web origin>` for the link to be emitted. Empty there => no link (safe plain-text fallback), and this handler simply never fires.

## Tests
`cd apps/web && npx vitest run src/__tests__/summaryDetailLanding.test.tsx` → 10 passed.
(Repo has ~33 pre-existing unrelated test failures — CSS dimensions / avatar positions — not touched here.)
