### PR TITLE
fix(loop): backfill outstanding request-changes blockers from merged loop PRs

### DIFF
--- a/packages/dmloop/package.json
+++ b/packages/dmloop/package.json
@@ -15,6 +15,11 @@
   "devDependencies": {
     "@types/react": "^18.3.28",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "vitest": "^4.1.5"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
   }
 }

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -638,6 +638,8 @@
     "addMember": "Add member",
     "selectMember": "Search and select a space member",
     "noCandidates": "No members available to add in this space",
+    "rosterLoadFailed": "Failed to load members",
+    "rosterRetry": "Retry",
     "added": "Member added",
     "pendingInvites": "Pending invitations",
     "revoke": "Revoke"

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -638,6 +638,8 @@
     "addMember": "添加成员",
     "selectMember": "搜索并选择 space 成员",
     "noCandidates": "该 space 暂无可添加的成员",
+    "rosterLoadFailed": "成员列表加载失败",
+    "rosterRetry": "重试",
     "added": "成员已添加",
     "pendingInvites": "待处理邀请",
     "revoke": "撤销"

--- a/packages/dmloop/src/pages/LoopCliAuthorizePage.tsx
+++ b/packages/dmloop/src/pages/LoopCliAuthorizePage.tsx
@@ -7,38 +7,10 @@ import { issueLoopCliToken } from "../api/authApi";
 import { listWorkspaces } from "../api/workspaceApi";
 import { currentWorkspaceId, setWorkspaceContext } from "../api/http";
 import { clearPendingLoopCliAuthorizeSearch } from "../cliAuthorizeSession";
+import { isSafeCliCallback } from "../ui/cliCallback";
 import "./loop.css";
 
 const { Text, Title } = Typography;
-
-function isPrivateIPv4(host: string): boolean {
-  const parts = host.split(".").map((p) => Number(p));
-  if (
-    parts.length !== 4 ||
-    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
-  ) {
-    return false;
-  }
-  const [a, b] = parts;
-  return (
-    a === 10 ||
-    a === 127 ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
-  );
-}
-
-function isSafeCliCallback(raw: string): boolean {
-  try {
-    const parsed = new URL(raw);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-      return false;
-    const host = parsed.hostname.toLowerCase();
-    return host === "localhost" || host === "::1" || isPrivateIPv4(host);
-  } catch {
-    return false;
-  }
-}
 
 function redirectToCli(
   callbackURL: string,

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   updateWorkspace, listWorkspaceMembers, addOctoMember, updateMemberRole, removeMember,
   listWorkspaceInvitations, revokeInvitation,
 } from "../api/workspaceApi";
+import { invalidateDirectory } from "../api/directory";
 
 const { Title, Text } = Typography;
 const ROLES = ["admin", "member"];
@@ -108,6 +109,9 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   const [invites, setInvites] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // roster(space 成员)单独的失败标记:与「space 确实没有可加成员」区分开——
+  // 抓取失败时不能显示误导性的「暂无成员」并禁用添加(#581 评审 B2)。
+  const [rosterError, setRosterError] = useState(false);
   // octo space 成员（仅人，robot===0）+ uid→身份 映射，供选择器候选与列表渲染复用。
   const [spaceHumans, setSpaceHumans] = useState<SpaceMember[]>([]);
   const seqRef = useRef(0); // reload 请求序号:切 workspace 时只让最新一次落地
@@ -129,13 +133,17 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
 
   const reload = useCallback(() => {
     const my = ++seqRef.current; // 切 workspace 时旧 in-flight 结果不得覆盖新的
-    setLoading(true); setError(null);
+    setLoading(true); setError(null); setRosterError(false);
+    let rosterFailed = false;
     Promise.all([
       listWorkspaceMembers(workspaceId),
       listWorkspaceInvitations(workspaceId).catch(() => [] as Invitation[]),
-      loadSpaceMembers().catch(() => [] as SpaceMember[]),
+      loadSpaceMembers().catch(() => { rosterFailed = true; return [] as SpaceMember[]; }),
     ])
-      .then(([m, inv, humans]) => { if (my !== seqRef.current) return; setMembers(m); setInvites(inv); setSpaceHumans(humans); })
+      .then(([m, inv, humans]) => {
+        if (my !== seqRef.current) return;
+        setMembers(m); setInvites(inv); setSpaceHumans(humans); setRosterError(rosterFailed);
+      })
       .catch((e) => { if (my === seqRef.current) setError(e?.message ?? "load failed"); })
       .finally(() => { if (my === seqRef.current) setLoading(false); });
   }, [workspaceId, loadSpaceMembers]);
@@ -157,6 +165,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
     try {
       await addOctoMember(workspaceId, { octo_uid: selectedUid, role });
       setSelectedUid("");
+      invalidateDirectory(); // 成员变动后清共享目录缓存,否则指派选择器仍返回旧候选(#581 评审)
       Toast.success(t("loop.settings.added"));
       reload();
     } catch (e) { Toast.error((e as Error)?.message ?? "add failed"); }
@@ -164,7 +173,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
   };
 
   const changeRole = async (m: WorkspaceMember, r: string) => {
-    try { await updateMemberRole(workspaceId, m.id, r); Toast.success(t("loop.toast.saved")); reload(); }
+    try { await updateMemberRole(workspaceId, m.id, r); invalidateDirectory(); Toast.success(t("loop.toast.saved")); reload(); }
     catch (e) { Toast.error((e as Error)?.message ?? "failed"); }
   };
   const remove = (m: WorkspaceMember) => {
@@ -174,7 +183,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
       okText: t("loop.action.delete"),
       cancelText: t("loop.action.cancel"),
       onOk: async () => {
-        try { await removeMember(workspaceId, m.id); Toast.success(t("loop.toast.deleted")); reload(); }
+        try { await removeMember(workspaceId, m.id); invalidateDirectory(); Toast.success(t("loop.toast.deleted")); reload(); }
         catch (e) { Toast.error((e as Error)?.message ?? "failed"); }
       },
     });
@@ -225,6 +234,18 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
 
   return (
     <div style={{ paddingTop: 12, display: "flex", flexDirection: "column", gap: 16, maxWidth: 720 }}>
+      {rosterError && (
+        <Banner
+          type="danger"
+          closeIcon={null}
+          description={
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 12 }}>
+              {t("loop.settings.rosterLoadFailed")}
+              <Button size="small" onClick={reload}>{t("loop.settings.rosterRetry")}</Button>
+            </span>
+          }
+        />
+      )}
       <div className="loop-settings-invite">
         <Select
           filter
@@ -237,7 +258,8 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
           emptyContent={t("loop.settings.noCandidates")}
         >
           {candidates.map((c) => (
-            <Select.Option key={c.uid} value={c.uid} showTick={false}>
+            // label 提供可匹配的纯字符串,否则 Semi 的 filter 拿 JSX children 无法匹配,输入即空(#581 评审 B1)
+            <Select.Option key={c.uid} value={c.uid} label={c.name} showTick={false}>
               <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
                 <Avatar size="extra-small" color="light-blue" src={WKApp.shared.avatarUser(c.uid)}>{c.name?.slice(0, 1)}</Avatar>
                 <span>{c.name}</span>

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -102,7 +102,9 @@ function ThreadReply({
   placeholder,
   sendLabel,
 }: {
-  onSubmit: (content: string, files: File[]) => Promise<boolean>;
+  // 返回 null:评论未创建(保留草稿+全部文件供重试);返回 File[]:评论已建,
+  // 数组为附件上传失败的文件(空=全部成功)——评论已存在故清空草稿、仅回填失败附件。
+  onSubmit: (content: string, files: File[]) => Promise<File[] | null>;
   placeholder: string;
   sendLabel: string;
 }) {
@@ -114,9 +116,11 @@ function ThreadReply({
     const c = draft.trim();
     if ((!c && files.length === 0) || busy) return;
     setBusy(true);
-    const ok = await onSubmit(c, files);
+    const res = await onSubmit(c, files);
     setBusy(false);
-    if (ok) { setDraft(""); setFiles([]); }
+    if (res === null) return; // 评论未创建:保留草稿与文件
+    setDraft("");
+    setFiles(res); // 评论已创建:仅保留失败附件(空数组=清空)
   };
   return (
     <div className="loop-cmt__reply">
@@ -127,7 +131,7 @@ function ThreadReply({
           onChange={(e) => setDraft(e.target.value)}
           placeholder={placeholder}
           disabled={busy}
-          onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.nativeEvent.isComposing) submit(); }}
         />
         <label className="loop-attach-btn" aria-label={t("loop.attach.add")}>
           <Paperclip size={16} />
@@ -497,25 +501,26 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const toggleSuppress = (id: string) =>
     setSuppressed((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
 
-  // 线程回复:回评归到根评论(parent=rootId)。附件在评论创建后带 commentId 绑定(逐个隔离,失败只提示)。
-  // 成功返回 true 供输入框清空。
-  const replyToThread = async (rootId: string, content: string, files: File[]): Promise<boolean> => {
+  // 线程回复:回评归到根评论(parent=rootId)。附件在评论创建后带 commentId 绑定(逐个隔离)。
+  // 返回 null:评论未创建(输入框保留草稿+全部文件);返回失败附件列表:评论已建,
+  // 仅这些附件上传失败——与 submitComment 一致地回填失败文件而非静默丢弃(#668 评审)。
+  const replyToThread = async (rootId: string, content: string, files: File[]): Promise<File[] | null> => {
     const token = reqRef.current;
     let comment: IssueComment;
     try {
       comment = await addComment(issueId, content, rootId, []);
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
-      return false;
+      return null;
     }
-    let failed = 0;
+    const failedFiles: File[] = [];
     for (const f of files) {
-      try { await uploadAttachment(f, { commentId: comment.id }); } catch { failed++; }
+      try { await uploadAttachment(f, { commentId: comment.id }); } catch { failedFiles.push(f); }
     }
-    if (failed) Toast.error(t("loop.toast.commentAttachFailed", { values: { count: failed } }));
+    if (failedFiles.length) Toast.error(t("loop.toast.commentAttachFailed", { values: { count: failedFiles.length } }));
     else Toast.success(t("loop.toast.commentAdded"));
     try { await reloadComments(token); } catch { /* 刷新失败:下次 reload 自愈 */ }
-    return true;
+    return failedFiles;
   };
 
   const removeComment = (id: string) => {

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -180,6 +180,9 @@ export default function RunDetailModal({
           else { missRef.current += 1; stillActive = missRef.current < MAX_MISSES; } // 连续 miss 达阈值才停(容忍瞬时 [])
         } catch { /* ensureDirectory 等抛错:保持轮询 */ }
         if (!cancelled && stillActive) poll();
+        // 终止前再做一次增量抓取:run 完成时的最后一批消息(result/error)常在上面抓取返回后、
+        // status 翻转前才写入,不补一次会永久丢失最关键的收尾消息(#610 评审)。
+        else if (!cancelled) await listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? [], true); }).catch(() => {});
       }, POLL_MS);
     };
 

--- a/packages/dmloop/src/ui/__tests__/cliCallback.test.ts
+++ b/packages/dmloop/src/ui/__tests__/cliCallback.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { isLoopbackHost, isSafeCliCallback } from "../cliCallback";
+
+// 安全回归锁:回调地址是 CLI token 的送达终点,只能是本机回环。
+describe("isSafeCliCallback", () => {
+  it("accepts loopback callbacks", () => {
+    expect(isSafeCliCallback("http://localhost:52001/cb")).toBe(true);
+    expect(isSafeCliCallback("http://127.0.0.1:52001/cb")).toBe(true);
+    expect(isSafeCliCallback("http://127.1.2.3/cb")).toBe(true); // 127.0.0.0/8 全段
+    expect(isSafeCliCallback("http://[::1]:52001/cb")).toBe(true); // IPv6 回环(带方括号)
+    expect(isSafeCliCallback("https://localhost/cb")).toBe(true);
+  });
+
+  it("rejects LAN / private-network hosts (token exfil vector)", () => {
+    expect(isSafeCliCallback("http://192.168.1.50:8080/cb")).toBe(false);
+    expect(isSafeCliCallback("http://10.0.0.9/cb")).toBe(false);
+    expect(isSafeCliCallback("http://172.16.0.1/cb")).toBe(false);
+    expect(isSafeCliCallback("http://172.31.255.254/cb")).toBe(false);
+  });
+
+  it("rejects public hosts and IPs", () => {
+    expect(isSafeCliCallback("http://evil.com/cb")).toBe(false);
+    expect(isSafeCliCallback("https://1.2.3.4/cb")).toBe(false);
+    expect(isSafeCliCallback("http://localhost.evil.com/cb")).toBe(false);
+  });
+
+  it("defeats the userinfo open-redirect trick (host resolves to attacker)", () => {
+    expect(isSafeCliCallback("http://127.0.0.1@evil.com/cb")).toBe(false);
+    expect(isSafeCliCallback("http://localhost@evil.com/cb")).toBe(false);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(isSafeCliCallback("javascript:alert(1)")).toBe(false);
+    expect(isSafeCliCallback("file:///etc/passwd")).toBe(false);
+    expect(isSafeCliCallback("data:text/html,x")).toBe(false);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(isSafeCliCallback("not a url")).toBe(false);
+    expect(isSafeCliCallback("")).toBe(false);
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it("handles bracketed and bare IPv6 loopback", () => {
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("[::ffff:127.0.0.1]")).toBe(true);
+  });
+
+  it("rejects boundary private ranges just outside RFC1918-but-not-loopback", () => {
+    expect(isLoopbackHost("172.15.0.1")).toBe(false);
+    expect(isLoopbackHost("172.32.0.1")).toBe(false);
+    expect(isLoopbackHost("128.0.0.1")).toBe(false);
+  });
+});

--- a/packages/dmloop/src/ui/cliCallback.ts
+++ b/packages/dmloop/src/ui/cliCallback.ts
@@ -1,0 +1,30 @@
+// CLI add-computer 授权回调地址的安全校验。浏览器把刚签发的 CLI token 以 ?token= 拼到回调 URL 后
+// 直接 window.location.href 跳转,所以这里是「token 送到哪」的唯一信任边界(#597 评审)。
+// 独立成无 React/Semi 依赖的模块,便于单测锁死 accept/reject 行为。
+
+// CLI 监听器与浏览器同机,只会绑在回环地址。放开整个 LAN/私网(10/172.16-31/192.168)会让 token
+// 被重定向到同网段的其他主机,构成 token exfil。故只允许 loopback。
+export function isLoopbackHost(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === "localhost") return true;
+  // URL.hostname 对 IPv6 会保留方括号(如 "[::1]"),先剥离再比对——否则合法的 IPv6 回环被误拒。
+  const bare = h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
+  if (bare === "::1" || bare === "::ffff:127.0.0.1") return true;
+  // 整个 127.0.0.0/8 都是回环。
+  const parts = bare.split(".");
+  if (parts.length === 4) {
+    const nums = parts.map((p) => Number(p));
+    if (nums.every((n) => Number.isInteger(n) && n >= 0 && n <= 255) && nums[0] === 127) return true;
+  }
+  return false;
+}
+
+export function isSafeCliCallback(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    return isLoopbackHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { AlertCircle, Cpu, FolderPlus, Loader2, Sparkles } from "lucide-react";
 import { currentWorkspaceId, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
 import { useI18n, WKApp } from "@octo/base";
@@ -29,9 +29,16 @@ export default function PersonalPage() {
   const [workspaceReady, setWorkspaceReady] = useState(false);
   const [workspaceEmpty, setWorkspaceEmpty] = useState(false);
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
+  // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
+  const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
+  const tabRef = useRef<PersonalTabKey>("runtime");
+  tabRef.current = tab;
 
   const openTab = (key: PersonalTabKey) => {
     if (!workspaceReady) return;
+    const ws = selectedWsRef.current;
+    if (ws) setWorkspaceContext(ws.slug, ws.id); // 铺视图前先把全局上下文拨回本页的 workspace
     setTab(key);
     WKApp.routeRight.replaceToRoot(renderTab(key));
   };
@@ -49,6 +56,7 @@ export default function PersonalPage() {
         const selected = workspaces.find((workspace) => workspace.id === currentWorkspaceId()) ?? workspaces[0] ?? null;
 
         if (!selected) {
+          selectedWsRef.current = null;
           setWorkspaceEmpty(true);
           setWorkspaceReady(false);
           WKApp.routeRight.replaceToRoot(
@@ -61,11 +69,12 @@ export default function PersonalPage() {
           return;
         }
 
+        selectedWsRef.current = { slug: selected.slug, id: selected.id };
         setWorkspaceContext(selected.slug, selected.id);
         setWorkspaceReady(true);
         setWorkspaceEmpty(false);
         setWorkspaceError(null);
-        WKApp.routeRight.replaceToRoot(renderTab("runtime"));
+        WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
       })
       .catch((error) => {
         if (cancelled) return;
@@ -84,7 +93,24 @@ export default function PersonalPage() {
     return () => {
       cancelled = true;
     };
-  }, [t]);
+    // 只在挂载时跑一次(对齐 LoopPage):依赖 [t] 会让切语言时重跑,闪回加载态、丢失当前 tab/弹框。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 顶部一级导航「Personal」被再次点击时,onMenuClick 会先 popToRoot 清空右栏,且本页常驻不重挂
+  // (挂载副作用不会重跑)。这里监听激活事件:重新断言 workspace 上下文并铺回当前 tab,
+  // 修复「切回后右栏空白」与「用别处 workspace 的上下文拉数据」两个问题(#619 评审)。
+  useEffect(() => {
+    const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
+      if (menuId !== "dmpersonal") return;
+      const ws = selectedWsRef.current;
+      if (!ws) return; // 尚未就绪:挂载副作用会在加载完成后自行铺视图
+      setWorkspaceContext(ws.slug, ws.id);
+      WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
+    };
+    WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
+    return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
+  }, []);
 
   return (
     <div className="dmpersonal-sidebar">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       react-dom:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/dmpersonal:
     dependencies:
@@ -11909,7 +11912,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13


### PR DESCRIPTION
## Summary

Several loop PRs were merged into `feat/octo-loop` while their reviews were still `CHANGES_REQUESTED`. Most of those blockers were later fixed by follow-up PRs (e.g. #654, #679, and #668's own follow-up commits). This PR backfills the ones that were **still live** in the current `feat/octo-loop` tip, newest → oldest.

| PR | Live blocker fixed |
|----|--------------------|
| #668 | `ThreadReply` submitted on bare **Enter** with no IME guard → half-composed CJK replies. Guard with `!e.nativeEvent.isComposing`. `replyToThread` also returned `true` unconditionally, silently dropping failed attachments — now returns the failed-file list so the reply box re-stages them (mirrors `submitComment`). |
| #610 | `RunDetailModal` poll stopped on the terminal tick without draining the final messages written during completion. Added one last incremental `listRunMessages` drain before stopping. |
| #619 | `PersonalPage` shares `@octo/loop`'s module-level workspace global with Loop. It now re-asserts `setWorkspaceContext` on tab-open and on `wk:nav-menu-activated`, and the bootstrap effect is mount-once (`[]` not `[t]`) — fixes cross-workspace data contamination, the blank right pane after returning from another menu, and the view reset on locale switch. |
| #597 | CLI auth callback allowlist accepted the whole private-IPv4 range → LAN token exfil. Restricted to **loopback only**, fixed the bracketed `::1` IPv6 case, extracted the validator to `ui/cliCallback.ts`, and added a vitest suite locking accept/reject behavior. |
| #581 | Member-picker `Select.Option`s had no string `label`, so search filtered to empty on the first keystroke — added `label={c.name}`. Roster load-failure now shows a distinct error + retry instead of a false "no members". Member add/role-change/remove now call `invalidateDirectory()` so assignee pickers reflect membership changes. |

Already-fixed-by-follow-ups (verified, not re-touched): #663 once-cron & my-loops scope fallback, #657/#640 skill name/description round-trip, #605 preview fail-open/race/status-gate, #619 dev-host, #643 comment-attachment retry, #668 blockers 1–3 + filter popovers.

## Test plan

- [x] `vitest run` — new `cliCallback.test.ts` (8 tests) passes: loopback accept, LAN/public/userinfo/scheme/malformed reject, bracketed `::1`, RFC1918 boundaries.
- [x] `tsc --noEmit` clean for all changed files (remaining errors are pre-existing Semi/node_modules noise, not in changed files).
- [ ] Manual: IME reply (Pinyin Enter confirm doesn't post), run modal shows final result on completion, Personal↔Loop workspace switching, member search + roster-error retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)