### PR TITLE
fix(loop): auto-refresh board after quick-create; signal vanished runs

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -606,6 +606,7 @@
     "cancelled": "Stopped",
     "copyAll": "Copy all",
     "copied": "Copied",
+    "gone": "Run no longer exists",
     "events": "{{count}} events",
     "toolCalls": "{{count}} tool calls",
     "duration": "Duration",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -606,6 +606,7 @@
     "cancelled": "已终止",
     "copyAll": "复制全部",
     "copied": "已复制",
+    "gone": "运行记录已不存在",
     "events": "{{count}} 个事件",
     "toolCalls": "{{count}} 次工具调用",
     "duration": "时长",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -201,15 +201,19 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
 
   // 派单(quick-create)是异步的:agent 稍后才建 issue,单次刷新太早看不到(dmloop 无 WS 推送,
   // 见记忆 dmloop-no-realtime-defer-ws)。这里有界补刷几次直到新回路出现。
-  // ponytail: 真正的修法是 WS 实时推送(已记后期做),此为 stopgap;派单低频,几次冗余刷新可接受。
+  // ponytail: 真正的修法是 WS 实时推送(已记后期做),此为 stopgap;派单低频,几次补刷可接受。
   // 手动建单是同步的,立即那次即命中,后续定时刷新只是无害冗余。
+  // 定时回调必须走 ref 读最新 onMutated —— 否则闭包捕获派单时刻的筛选/视图,窗口内用户改了筛选后
+  // 延迟刷新会用旧筛选参数覆盖当前视图(reload 的 seq 守卫只防乱序、不防陈旧入参)。
   const settleTimersRef = useRef<number[]>([]);
+  const onMutatedRef = useRef(onMutated);
+  useEffect(() => { onMutatedRef.current = onMutated; }, [onMutated]);
   useEffect(() => () => settleTimersRef.current.forEach(clearTimeout), []);
   const settleReload = useCallback(() => {
     settleTimersRef.current.forEach(clearTimeout);
-    onMutated(); // 立即刷一次
-    settleTimersRef.current = [2000, 5000, 9000, 14000].map((d) => window.setTimeout(onMutated, d));
-  }, [onMutated]);
+    onMutatedRef.current(); // 立即刷一次
+    settleTimersRef.current = [2000, 5000, 9000, 14000].map((d) => window.setTimeout(() => onMutatedRef.current(), d));
+  }, []);
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
   const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -199,6 +199,18 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   // 变更后刷新:既重取列表,又刷新运行中快照(指派/状态变更可能起/停 agent run)。
   const onMutated = useCallback(() => { reload(); refreshRunning(); }, [reload, refreshRunning]);
 
+  // 派单(quick-create)是异步的:agent 稍后才建 issue,单次刷新太早看不到(dmloop 无 WS 推送,
+  // 见记忆 dmloop-no-realtime-defer-ws)。这里有界补刷几次直到新回路出现。
+  // ponytail: 真正的修法是 WS 实时推送(已记后期做),此为 stopgap;派单低频,几次冗余刷新可接受。
+  // 手动建单是同步的,立即那次即命中,后续定时刷新只是无害冗余。
+  const settleTimersRef = useRef<number[]>([]);
+  useEffect(() => () => settleTimersRef.current.forEach(clearTimeout), []);
+  const settleReload = useCallback(() => {
+    settleTimersRef.current.forEach(clearTimeout);
+    onMutated(); // 立即刷一次
+    settleTimersRef.current = [2000, 5000, 9000, 14000].map((d) => window.setTimeout(onMutated, d));
+  }, [onMutated]);
+
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
   const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
   const switchView = (v: ViewMode) => { setView(v); setPage(0); };
@@ -214,7 +226,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   const openNewLoop = () => {
     WKApp.routeRight.push(
       <NewLoopPage
-        onCreated={() => { onMutated(); WKApp.routeRight.pop(); }}
+        onCreated={() => { settleReload(); WKApp.routeRight.pop(); }}
       />,
     );
   };

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -199,20 +199,17 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   // 变更后刷新:既重取列表,又刷新运行中快照(指派/状态变更可能起/停 agent run)。
   const onMutated = useCallback(() => { reload(); refreshRunning(); }, [reload, refreshRunning]);
 
-  // 派单(quick-create)是异步的:agent 稍后才建 issue,单次刷新太早看不到(dmloop 无 WS 推送,
-  // 见记忆 dmloop-no-realtime-defer-ws)。这里有界补刷几次直到新回路出现。
+  // 派单(quick-create)是异步的:agent 稍后才建 issue(dmloop 无 WS 推送,见记忆 dmloop-no-realtime-defer-ws)。
+  // NewLoopPage 派单成功发 `wk:loop-issues-dispatched`,常驻的 LoopPage 据此有界补发 `wk:loop-issues-refresh`,
+  // 看板收到即重取——一套机制覆盖"看板内新建"与"侧栏新建"两个入口(定时器归 LoopPage,见那里)。
+  // 走 ref 读最新 onMutated:延迟刷新须用当前筛选/视图,否则会用陈旧入参覆盖(reload 的 seq 守卫只防乱序)。
   // ponytail: 真正的修法是 WS 实时推送(已记后期做),此为 stopgap;派单低频,几次补刷可接受。
-  // 手动建单是同步的,立即那次即命中,后续定时刷新只是无害冗余。
-  // 定时回调必须走 ref 读最新 onMutated —— 否则闭包捕获派单时刻的筛选/视图,窗口内用户改了筛选后
-  // 延迟刷新会用旧筛选参数覆盖当前视图(reload 的 seq 守卫只防乱序、不防陈旧入参)。
-  const settleTimersRef = useRef<number[]>([]);
   const onMutatedRef = useRef(onMutated);
   useEffect(() => { onMutatedRef.current = onMutated; }, [onMutated]);
-  useEffect(() => () => settleTimersRef.current.forEach(clearTimeout), []);
-  const settleReload = useCallback(() => {
-    settleTimersRef.current.forEach(clearTimeout);
-    onMutatedRef.current(); // 立即刷一次
-    settleTimersRef.current = [2000, 5000, 9000, 14000].map((d) => window.setTimeout(() => onMutatedRef.current(), d));
+  useEffect(() => {
+    const onRefresh = () => onMutatedRef.current();
+    WKApp.mittBus.on("wk:loop-issues-refresh", onRefresh);
+    return () => WKApp.mittBus.off("wk:loop-issues-refresh", onRefresh);
   }, []);
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
@@ -230,7 +227,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
   const openNewLoop = () => {
     WKApp.routeRight.push(
       <NewLoopPage
-        onCreated={() => { settleReload(); WKApp.routeRight.pop(); }}
+        onCreated={() => { onMutated(); WKApp.routeRight.pop(); }}
       />,
     );
   };

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Typography, Dropdown, Avatar, Modal, Toast, Button } from "@douyinfe/semi-ui";
 import {
   ClipboardList, Briefcase, Bot, Users, Settings,
@@ -24,6 +24,10 @@ import "../ui/loopControls.css";
 const { Title, Text } = Typography;
 
 type TabKey = "myloop" | "issue" | "project" | "automation" | "agent" | "squad" | "settings";
+
+// 派单后看板补刷的退避时刻(ms):agent 异步建单的落库延迟不可观测,手调的退避窗口(非可推导状态)。
+const SETTLE_DELAYS_MS = [2000, 5000, 9000, 14000];
+
 
 // 顶部独立入口：我的回路（复用 Issue 视图的「与我相关」分组）。
 const MY_TAB: { key: TabKey; icon: React.ReactNode } = { key: "myloop", icon: <CircleUserRound size={16} /> };
@@ -144,6 +148,22 @@ export default function LoopPage() {
     return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaces, wsId, loaded]);
+
+  // 派单后看板补刷:quick-create 异步(agent 稍后建 issue,dmloop 无 WS,见记忆 dmloop-no-realtime-defer-ws)。
+  // NewLoopPage 派单成功发 `wk:loop-issues-dispatched`;由常驻(不随 tab/建单入口重挂)的 LoopPage 持有定时器,
+  // 有界补发 `wk:loop-issues-refresh`,当前挂载的看板(IssuePage)订阅后重取——一套机制统一覆盖
+  // 「看板内新建」与「侧栏新建」两个入口(此前 settle 只挂在看板实例上,漏了侧栏 openTab 重挂的路径)。
+  const settleTimersRef = useRef<number[]>([]);
+  useEffect(() => {
+    const onDispatched = () => {
+      settleTimersRef.current.forEach(clearTimeout);
+      settleTimersRef.current = SETTLE_DELAYS_MS.map((d) =>
+        window.setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), d),
+      );
+    };
+    WKApp.mittBus.on("wk:loop-issues-dispatched", onDispatched);
+    return () => { WKApp.mittBus.off("wk:loop-issues-dispatched", onDispatched); settleTimersRef.current.forEach(clearTimeout); };
+  }, []);
 
   const switchWorkspace = (w: Workspace) => {
     setWorkspaceContext(w.slug, w.id);

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -85,6 +85,9 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
       });
       // 单一 toast 归属此处(异步派单的准确措辞);duration 显式设 3s 保证自动消失。
       Toast.success({ content: t("loop.newLoop.dispatched"), duration: 3 });
+      // 派单是异步的(agent 稍后建 issue),通知常驻 LoopPage 有界补刷看板,使新回路自动出现(无需手动 reload)。
+      // 见 LoopPage 的 wk:loop-issues-dispatched 处理;覆盖看板内/侧栏两个入口。
+      WKApp.mittBus.emit("wk:loop-issues-dispatched");
       // 成功后由调用方负责导航(切回回路看板)——此处不再自行 back(),避免叠加把新根 pop 掉。
       onCreated?.();
     } catch (e) {

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -142,6 +142,9 @@ export default function RunDetailModal({
   const [liveRun, setLiveRun] = useState<TaskRun | null>(run);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
+  // run 连续 miss 达阈值判定"已消失"——与终态停轮询区分:终态是 run 仍在、只是跑完了;
+  // gone 是 run 从列表里没了(被删/清理),此时不能静默冻在陈旧的 running,要给用户提示。
+  const [gone, setGone] = useState(false);
   const lastSeqRef = useRef(0);
   // listRuns 内部吞掉 task-runs 的 HTTP 失败返回 []([] 既可能是"run 消失"也可能是"瞬时网络失败",
   // 无法区分)。连续 miss 计数:容忍偶发 [](下轮即恢复),连续多次才判定 run 真消失并停轮询——
@@ -151,11 +154,12 @@ export default function RunDetailModal({
 
   // 打开时全量拉;运行中的 run 则每 2s 增量轮询 + 刷新状态,终态即停(无 WS,退化轮询)。
   useEffect(() => {
-    if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; missRef.current = 0; return; }
+    if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; missRef.current = 0; setGone(false); return; }
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     lastSeqRef.current = 0;
     missRef.current = 0;
+    setGone(false);
     setLiveRun(run);
 
     const apply = (batch: RunMessage[], incremental: boolean) => {
@@ -177,7 +181,7 @@ export default function RunDetailModal({
           const fresh = (await listRuns(run.issue_id)).find((r) => r.id === run.id);
           if (cancelled) return;
           if (fresh) { setLiveRun(fresh); stillActive = isActiveRun(fresh.status); missRef.current = 0; }
-          else { missRef.current += 1; stillActive = missRef.current < MAX_MISSES; } // 连续 miss 达阈值才停(容忍瞬时 [])
+          else { missRef.current += 1; stillActive = missRef.current < MAX_MISSES; if (!stillActive) setGone(true); } // 连续 miss 达阈值:判定 run 已消失,停轮询并提示
         } catch { /* ensureDirectory 等抛错:保持轮询 */ }
         if (!cancelled && stillActive) poll();
         // 终止前再做一次增量抓取:run 完成时的最后一批消息(result/error)常在上面抓取返回后、
@@ -226,7 +230,9 @@ export default function RunDetailModal({
     }).catch(() => {});
   };
 
-  const statusBadge = !shown ? null : active ? (
+  const statusBadge = !shown ? null : gone ? (
+    <span className="loop-tr__status loop-tr__status--fail"><XCircle size={12} />{t("loop.run.gone")}</span>
+  ) : active ? (
     <span className="loop-tr__status loop-tr__status--running"><Loader2 size={12} className="loop-spin" />{t("loop.taskStatus.running")}</span>
   ) : shown.status === "completed" ? (
     <span className="loop-tr__status loop-tr__status--ok"><CheckCircle2 size={12} />{t("loop.taskStatus.completed")}</span>

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -67,6 +67,13 @@ export type MittEvents = {
    */
   'wk:nav-menu-activated': { menuId: string };
   /**
+   * dmloop 派单(quick-create)后的看板补刷协议。派单是异步的(agent 稍后建 issue,dmloop 暂无 WS 推送):
+   * NewLoopPage 派单成功发 `wk:loop-issues-dispatched`;常驻的 LoopPage 据此有界补发 `wk:loop-issues-refresh`,
+   * 当前挂载的看板(IssuePage)订阅后重取,使新回路自动出现——统一覆盖看板内/侧栏两个建单入口。
+   */
+  'wk:loop-issues-dispatched': void;
+  'wk:loop-issues-refresh': void;
+  /**
    * 打开「密钥 / Secrets」管理面板（YUJ-3539）。由聊天反向跳转（bot 消息里的
    * 「去添加密钥」按钮）或输入框防手滑提示触发；payload 可携带预填名字 / 明文，
    * 接收方 NavSecretsSettingsItem 据此打开面板并预填新增弹窗（绝不自动发送/保存）。


### PR DESCRIPTION
Auto-refresh the loop board after an async quick-create dispatch, plus a vanished-run signal. Verified by real-env e2e on both create entry points + two-model adversarial review + /simplify.

## 1. Board didn't auto-refresh after quick-create dispatch
Quick-create is async: `POST /issues/quick-create` returns only `{task_id}`; the agent creates the issue moments later. The board's single post-dispatch reload fired before the issue existed → new loop only appeared on manual reload. (Upstream uses a WS event stream to invalidate the list; dmloop has no realtime layer yet — deferred, see below.)

**Unified event-bus stopgap** (covers BOTH create entry points):
- `NewLoopPage.submit()` emits `wk:loop-issues-dispatched` on quick-create success.
- The **persistent** `LoopPage` (never remounts across tabs/entries) owns bounded settle timers and re-emits `wk:loop-issues-refresh` at `SETTLE_DELAYS_MS = [2000,5000,9000,14000]`.
- The mounted `IssuePage` subscribes → reloads through `onMutatedRef` (latest filters — a `seq` guard only orders responses, not stale inputs).
- 2 events added to `MittEvents` (`@octo/base`, additive).

Why this shape (from /simplify altitude review): reload-on-activation was rejected — `WKViewQueue.replaceToRoot` keys the board by `issue:${wsId}`, so re-activating the same tab reuses the fiber (no reload); forcing it needs a key-bump that drops filter/scroll state and still re-races the async create. Timed settle owned by the persistent parent is the right stopgap; the real fix is WS push (deferred). This also fixed the incomplete first cut, which only covered the in-board `+` entry and left the more prominent **sidebar** "新建回路" stale.

## 2. RunDetailModal silently froze on a vanished run (P2)
When a run disappears from `listRuns` for `MAX_MISSES` consecutive polls, the modal stopped polling but froze on the last (possibly "running") status. Added a `gone` state, set **only** on the miss-exhausted path (never on a normal terminal stop), rendering a "运行记录已不存在" badge. i18n zh+en.

## Blast radius (Rule 8)
- `packages/dmworkbase/src/App.tsx` `MittEvents`: **additive** (2 new event keys) — existing consumers reference neither key, zero breakage.
- `IssuePage` / `LoopPage` / `NewLoopPage` / `RunDetailModal`: internal changes; no exported type/prop/hook signature changes. `settleReload` reuses existing `onMutated`/`reload`.

## Verification (real-env e2e, Alice's bridged workspace)
- **In-board `+` entry**: dispatched → board auto-showed ALI-2 within ~11s, no manual reload.
- **Sidebar "新建回路" entry** (the gap /simplify caught): dispatched → board auto-showed ALI-3 within ~12s, no manual reload — confirming the unified mechanism covers the remount path.
- New issues confirmed in DB (agent async-created them).
- Codex adversarial-review: approve. Claude code-reviewer: clean (traced WKViewQueue reconcile + mitt types: both entries covered, 2s margin >> sync remount, listener/timer cleanup complete, no stale-closure, multi-instance unreachable). /simplify (reuse/efficiency/altitude): clean. tsc clean.

## Deferred follow-ups (tracked)
- The class fix: dmloop **WS realtime** (loop proxy WS passthrough + WS client + event→invalidate), matching upstream — subsumes this stopgap.
- Focused unit tests for the polling/race guards (dmloop now has a vitest harness as of #681; tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)