### PR TITLE
fix(versions): vertically center version-history confirm overlay

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1054,6 +1054,16 @@
   background: rgba(0, 0, 0, 0.4);
   overflow-y: auto;
 }
+/* Vertically-center modifier for the destructive-action confirm (decision #2). The base overlay is
+   top-anchored (align-items: flex-start) because the preview/diff modal can be taller than the
+   viewport and needs to scroll from the top. The small restore/delete confirm card, however, should
+   sit centered in the viewport. `safe center` keeps it centered but degrades to top-aligned if the
+   content ever overflows, so the action buttons stay reachable instead of being clipped off-screen.
+   Only the confirm overlays carry this modifier; the preview/diff overlay keeps its top-anchored,
+   scrollable behavior. */
+.octo-modal-overlay--center {
+  align-items: safe center;
+}
 .octo-modal {
   width: 100%;
   max-width: 560px;

--- a/packages/docs/src/versions/VersionHistoryPanel.test.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.test.tsx
@@ -336,6 +336,36 @@ describe('VersionHistoryPanel — mutations & permissions', () => {
     await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
   })
 
+  it('vertically-centers the confirm overlay via a scoped modifier the preview/diff overlay does not carry', async () => {
+    // Regression for XIN-887 (decision #2): the confirm card must sit centered in the viewport, not
+    // top-anchored like the preview/diff modal. The base .octo-modal-overlay is top-anchored (it can
+    // hold taller-than-viewport preview content that scrolls from the top), so the confirm overlay
+    // opts into centering with the scoped .octo-modal-overlay--center modifier. jsdom does not compute
+    // layout, so we assert the class contract: the confirm overlay carries the modifier and the
+    // preview overlay does not, keeping the two behaviors isolated.
+    renderPanel('admin', { loadPreviewState: async (seq) => ({ body: `body-${seq}` }) })
+    await screen.findByText('Draft v1')
+
+    // Delete confirm overlay is centered.
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.delete'))
+    let box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    expect(box.closest('.octo-modal-overlay')!.classList.contains('octo-modal-overlay--center')).toBe(true)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
+
+    // Restore confirm overlay is centered too.
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.restore'))
+    box = await waitFor(() => document.querySelector('.octo-version-confirm') as HTMLElement)
+    expect(box.closest('.octo-modal-overlay')!.classList.contains('octo-modal-overlay--center')).toBe(true)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.querySelector('.octo-version-confirm')).toBeNull())
+
+    // Preview/diff overlay keeps its top-anchored (non-centered) behavior — no modifier.
+    fireEvent.click(btnByText(document.querySelector('.octo-version-row')!, 'docs.version.preview'))
+    const modal = await waitFor(() => document.querySelector('.docs-version-preview-modal') as HTMLElement)
+    expect(modal.closest('.octo-modal-overlay')!.classList.contains('octo-modal-overlay--center')).toBe(false)
+  })
+
   it('does not dismiss the confirm overlay on backdrop-click or Escape while a restore is in flight (busy guard)', async () => {
     // The overlay-click and Escape cancel paths both no-op while a mutation is running, so a stray
     // backdrop click or keypress cannot tear the confirm down mid-request. Hold the restore mutation

--- a/packages/docs/src/versions/VersionHistoryPanel.tsx
+++ b/packages/docs/src/versions/VersionHistoryPanel.tsx
@@ -584,7 +584,7 @@ export function VersionHistoryPanel<TState, TCurrent>({
 
         {confirmRestore && (
           <div
-            className="octo-modal-overlay"
+            className="octo-modal-overlay octo-modal-overlay--center"
             role="presentation"
             onMouseDown={() => {
               if (!busy) setConfirmRestore(null)
@@ -623,7 +623,7 @@ export function VersionHistoryPanel<TState, TCurrent>({
 
         {confirmDelete && (
           <div
-            className="octo-modal-overlay"
+            className="octo-modal-overlay octo-modal-overlay--center"
             role="presentation"
             onMouseDown={() => {
               if (!busy) setConfirmDelete(null)


### PR DESCRIPTION
## What

Follow-up to #674. That PR moved the version-history restore/delete confirm box into the shared `.octo-modal-overlay` so it stays on-screen on long scrolled lists, but the overlay is top-anchored (`align-items: flex-start`, `48px` top padding) — the preview/diff modal needs that so tall content scrolls from the top. As a result the small confirm card sat near the top of the viewport (~48px from the top) rather than vertically centered, which does not match the centered-dialog decision.

## Changes

- Add a scoped `.octo-modal-overlay--center` modifier and apply it only to the two confirm overlays (restore + delete) in the unified `VersionHistoryPanel` shell. Since doc/sheet/board are all thin adapters over this shell, all three ends get the fix.
- The modifier flips vertical alignment to `safe center`: the card is viewport-centered but degrades to top-aligned if the content ever overflows, so the action buttons stay reachable instead of being clipped off-screen.
- The preview/diff overlay does **not** carry the modifier, so its top-anchored, scrollable behavior is unchanged — the two overlays stay naturally isolated.
- Shared `.octo-modal-overlay` rules, the confirm state machine, race guard, and mounted-ref liveness are untouched. No JS behavior change beyond the added class.
- Extend the shell regression test to assert the restore and delete confirm overlays carry the modifier and the preview overlay does not.

## Testing

- `packages/docs` version tests green (`vitest run src/versions/` — 78 passing, +1 new).
- `typecheck`: no new errors introduced by this change (two pre-existing errors in unrelated files remain).
- `stylelint`: no new violations; the added rule uses only `align-items`, no color literals.
