### PR TITLE
feat(loop): gate 回路 + 我的 NavRail entries behind dmloop_on / dmpersonal_on launch flags

### DIFF
--- a/packages/dmloop/src/api/authApi.ts
+++ b/packages/dmloop/src/api/authApi.ts
@@ -10,7 +10,7 @@ export function issueHeadlessCliToken(): Promise<{ token: string }> {
   return httpPost<{ token: string }>("/cli-token/headless");
 }
 
-// 取后端公开地址(daemon_server_url,源自 MULTICA_PUBLIC_URL)。
+// 取后端公开地址(daemon_server_url,由后端配置下发)。
 // headless 命令的 --server-url 用它,直连后端,避开 web 代理歧义。
 export function getDaemonServerUrl(): Promise<string> {
   return httpGet<{ daemon_server_url?: string }>("/config").then(

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -112,7 +112,7 @@
     "addComputerBrowser": "1. Browser authorization (this machine has a browser):",
     "addComputerHeadless": "2. Headless (no browser / remote / CI):",
     "headlessTokenPlaceholder": "<click Copy to generate>",
-    "headlessNoBackend": "The administrator has not configured a public backend URL (MULTICA_PUBLIC_URL); headless command unavailable",
+    "headlessNoBackend": "The administrator has not configured a public backend URL; headless command unavailable",
     "headlessFailed": "Failed to generate headless command, please retry",
     "headlessCopyManual": "Command generated below, but auto-copy failed — please copy it manually"
   },

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -112,7 +112,7 @@
     "addComputerBrowser": "1. 浏览器授权（本机有浏览器）：",
     "addComputerHeadless": "2. 免浏览器（headless / 远程 / CI 环境）：",
     "headlessTokenPlaceholder": "<点击右侧「复制」生成>",
-    "headlessNoBackend": "管理员未配置后端公开地址（MULTICA_PUBLIC_URL），无法生成 headless 命令",
+    "headlessNoBackend": "管理员未配置后端公开地址，无法生成 headless 命令",
     "headlessFailed": "生成 headless 命令失败，请重试",
     "headlessCopyManual": "命令已生成在下方，自动复制失败，请手动复制"
   },

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -14,8 +14,13 @@ import zhCN from "./i18n/zh-CN.json";
 
 let _initialized = false;
 let loopCliAuthorizeInitialSearch = "";
+// remoteConfig 监听的退订句柄:HMR 重新 init 时先退订旧的,避免 refreshMenus 闭包在共享
+// WKApp.remoteConfig 单例上越堆越多(镜像 DocsModule._configUnsubscribers)。
+let _configUnsubs: Array<() => void> = [];
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
+    _configUnsubs.forEach((u) => u());
+    _configUnsubs = [];
     _initialized = false;
   });
 }
@@ -94,18 +99,32 @@ export default class LoopModule implements IModule {
       renderLoopCliAuthorize
     );
 
+    // 上线开关:仅当后端 appconfig `dmloop_on`(WKApp.remoteConfig.dmloopOn)为 true 才在 NavRail
+    // 展示「回路」入口,否则工厂返回 undefined(MenusManager 过滤 falsy → 隐藏)。默认 false(fail-safe):
+    // 合入 main 也不暴露,运维就绪后下发 dmloop_on=true。镜像 DocsModule(docs_on)。纯显示门,路由仍注册。
     WKApp.menus.register(
       "loop",
-      () => {
-        return new Menus(
-          "loop",
-          "/loop",
-          translate("loop.menu.title"),
-          <LoopIcon />,
-          <LoopIcon active />
-        );
-      },
+      () =>
+        WKApp.remoteConfig?.dmloopOn
+          ? new Menus(
+              "loop",
+              "/loop",
+              translate("loop.menu.title"),
+              <LoopIcon />,
+              <LoopIcon active />
+            )
+          : undefined,
       4003
     );
+
+    // appconfig 异步拉取:init() 时 dmloopOn 通常还是默认 false。dmloop_on resolve / 后续切换时
+    // 刷新 NavRail,让「回路」入口即时出现/消失(镜像 DocsModule 的 listener)。HMR 退订见顶部 _configUnsubs。
+    const refreshMenus = (): void => WKApp.menus.refresh?.();
+    const rc = WKApp.remoteConfig;
+    if (rc) {
+      if (rc.requestSuccess) refreshMenus();
+      else _configUnsubs.push(rc.addListener(refreshMenus));
+      _configUnsubs.push(rc.addConfigChangeListener(refreshMenus));
+    }
   }
 }

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -265,7 +265,7 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
       gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, dateRange: undefined,
     });
 
-  // 「筛选」面板：把原工具栏散落的下拉收进一个面板（对齐 multica 的筛选框）。维度按视图切换单选/多选。
+  // 「筛选」面板：把原工具栏散落的下拉收进一个面板（对齐产品设计 的筛选框）。维度按视图切换单选/多选。
   const filterPanel = (
     <div className="loop-fields loop-filter-panel">
       <div className="loop-filter-panel__head">

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -95,7 +95,7 @@ import "./issueDetail.css";
 
 const { Text } = Typography;
 
-// 线程回复输入：常驻在每张评论卡底部(对标 multica),各自独立 draft/附件(不共享全局状态),
+// 线程回复输入：常驻在每张评论卡底部(对标产品设计),各自独立 draft/附件(不共享全局状态),
 // 提交成功后清空。回评一律归到该线程根评论;附件在评论创建后绑到 commentId(见 replyToThread)。
 function ThreadReply({
   onSubmit,
@@ -201,7 +201,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const [runOpen, setRunOpen] = useState(false);
   const [showRuns, setShowRuns] = useState(false); // 「执行日志」折叠展开
   const [collapsedSecs, setCollapsedSecs] = useState<Set<string>>(new Set()); // 右栏分区折叠
-  // 动态块展开态：最后一个动态块默认展开(第一次进来即见最新动态,对标 multica);
+  // 动态块展开态：最后一个动态块默认展开(第一次进来即见最新动态,对标产品设计);
   // expandedActs=被显式展开的(非默认块),collapsedActs=被显式折叠的(默认块)。二者覆盖默认。
   const [expandedActs, setExpandedActs] = useState<Set<string>>(new Set());
   const [collapsedActs, setCollapsedActs] = useState<Set<string>>(new Set());
@@ -605,7 +605,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   };
 
   // 右上角 ··· 菜单：编辑属性(标签/父回路/日期/阶段) / 新建子回路 / 订阅 / 删除。
-  // 状态/优先级/负责人/项目 改走右栏内联点击 popup(对标 multica),不在此重复。
+  // 状态/优先级/负责人/项目 改走右栏内联点击 popup(对标产品设计),不在此重复。
   const renderMoreMenu = () => (
     <Dropdown.Menu>
       <Dropdown.Item icon={<SlidersHorizontal size={13} />} onClick={() => { loadParentCands(); setPropsOpen(true); }}>
@@ -668,7 +668,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   const toggleSec = (k: string) =>
     setCollapsedSecs((s) => { const n = new Set(s); if (n.has(k)) n.delete(k); else n.add(k); return n; });
 
-  // 评论线程(对标 multica)：主评论为首行,其所有回评都是同级平铺行(分隔线区分先后,不缩进)；
+  // 评论线程(对标产品设计)：主评论为首行,其所有回评都是同级平铺行(分隔线区分先后,不缩进)；
   // 卡片底部一个回复输入。任何回评都归到主评论(parent=root),视觉上像一张「主评论 + 评审意见」表。
   const renderRow = (c: IssueComment, isRoot: boolean, rootId: string) => (
     <div key={c.id} className={`loop-cmt__row${isRoot ? " is-root" : ""}`}>
@@ -773,11 +773,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
       </div>
     );
   };
-  // 运行中/排队中重点常显在外;仅终态归入「显示历史运行」折叠(对标 multica)。
+  // 运行中/排队中重点常显在外;仅终态归入「显示历史运行」折叠(对标产品设计)。
   const activeRuns = runs.filter((r) => isActiveRun(r.status));
   const pastRuns = runs.filter((r) => !isActiveRun(r.status));
 
-  // 动态区(对标 multica)：根评论与「有意义的活动」按时间升序合并；连续活动归并成一个折叠动态块，
+  // 动态区(对标产品设计)：根评论与「有意义的活动」按时间升序合并；连续活动归并成一个折叠动态块，
   // 评论各自独立成卡片。噪声活动(activityText 为 null)先过滤，不进块、不计数。
   const visibleActs = activities.filter((a) => activityText(a.action) !== null);
   type FeedNode = { ts: string; c?: IssueComment; a?: TimelineEntry };
@@ -1051,7 +1051,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
           </div>
         </div>
 
-        {/* 右侧属性栏（只读展示,对齐 Figma 29-1593；改属性走右上角 ⋯ 菜单，对标 multica） */}
+        {/* 右侧属性栏（只读展示,对齐 Figma 29-1593；改属性走右上角 ⋯ 菜单，对标产品设计） */}
         <aside className="loop-idp__aside">
           <section className="loop-idp__asec">
             <button type="button" className="loop-idp__asec-head" onClick={() => toggleSec("props")}>
@@ -1060,7 +1060,7 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
             </button>
             {secOpen("props") && (
               <div className="loop-idp__asec-body">
-                {/* 状态：点击值弹 popup 改(对标 multica) */}
+                {/* 状态：点击值弹 popup 改(对标产品设计) */}
                 <div className="loop-idp__prop loop-idp__prop--inline">
                   <span className="loop-idp__prop-k">{t("loop.field.status")}</span>
                   <Dropdown

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -127,7 +127,7 @@ function TimelineBar({ messages }: { messages: RunMessage[] }) {
   );
 }
 
-/** 执行详情弹窗：转写体验（对齐 multica）——状态/时长 + 时间线 + 可展开事件流。 */
+/** 执行详情弹窗：转写体验（对齐产品设计）——状态/时长 + 时间线 + 可展开事件流。 */
 export default function RunDetailModal({
   run,
   visible,

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -258,7 +258,7 @@
 .loop-cmt__reply-row { display: flex; gap: 8px; align-items: center; }
 .loop-cmt__reply .loop-field { flex: 1; min-width: 0; }
 
-/* 附件 pill（对标 multica：边框 + 文件图标 + 文件名 + 操作） */
+/* 附件 pill（对标产品设计：边框 + 文件图标 + 文件名 + 操作） */
 .loop-filechips { display: flex; flex-wrap: wrap; gap: 6px; }
 .loop-filechip {
   display: inline-flex;
@@ -339,7 +339,7 @@
 .loop-idp__prop-k { font-size: 12px; color: var(--semi-color-text-2, #8a8f99); }
 .loop-idp__prop-v { font-size: 13px; color: var(--semi-color-text-0, #1f2329); }
 .loop-idp__prop-v--muted { color: var(--semi-color-text-2, #6b7075); }
-/* 内联可编辑属性值：点击弹 popup(对标 multica),hover 提示可点 */
+/* 内联可编辑属性值：点击弹 popup(对标产品设计),hover 提示可点 */
 .loop-idp__prop-edit {
   display: inline-flex;
   align-items: center;

--- a/packages/dmloop/src/ui/autopilotSchedule.ts
+++ b/packages/dmloop/src/ui/autopilotSchedule.ts
@@ -1,5 +1,5 @@
 // @octo/loop — 自动化触发排程助手：频率(每天/每周/每月) ↔ cron。
-// 后端只支持 5 段 cron 的定时触发，无一次性触发，故不提供「单次」（与 multica 一致）。
+// 后端只支持 5 段 cron 的定时触发，无一次性触发，故不提供「单次」（与产品设计一致）。
 
 export type Frequency = "daily" | "weekly" | "monthly";
 

--- a/packages/dmpersonal/src/module.tsx
+++ b/packages/dmpersonal/src/module.tsx
@@ -6,8 +6,12 @@ import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 
 let _initialized = false;
+// remoteConfig 监听退订句柄:HMR 重新 init 时先退订旧的(镜像 DocsModule._configUnsubscribers)。
+let _configUnsubs: Array<() => void> = [];
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
+    _configUnsubs.forEach((u) => u());
+    _configUnsubs = [];
     _initialized = false;
   });
 }
@@ -50,16 +54,31 @@ export default class PersonalModule implements IModule {
 
     WKApp.route.register("/personal", () => <PersonalPage />);
 
+    // 上线开关:仅当后端 appconfig `dmpersonal_on`(WKApp.remoteConfig.dmpersonalOn)为 true 才展示
+    // 「我的 / 运行时」入口,否则返回 undefined 隐藏。与 dmloop_on 独立(「我的」后续脱离 loop 演进)。
+    // 默认 false(fail-safe),镜像 DocsModule(docs_on)。纯显示门,/personal 路由仍注册。
     WKApp.menus.register(
       "dmpersonal",
-      () => new Menus(
-        "dmpersonal",
-        "/personal",
-        translate("personal.menu.title"),
-        <PersonalIcon />,
-        <PersonalIcon active />,
-      ),
+      () =>
+        WKApp.remoteConfig?.dmpersonalOn
+          ? new Menus(
+              "dmpersonal",
+              "/personal",
+              translate("personal.menu.title"),
+              <PersonalIcon />,
+              <PersonalIcon active />,
+            )
+          : undefined,
       4004,
     );
+
+    // appconfig 异步:dmpersonal_on resolve / 切换时刷新 NavRail 让入口即时出现/消失。
+    const refreshMenus = (): void => WKApp.menus.refresh?.();
+    const rc = WKApp.remoteConfig;
+    if (rc) {
+      if (rc.requestSuccess) refreshMenus();
+      else _configUnsubs.push(rc.addListener(refreshMenus));
+      _configUnsubs.push(rc.addConfigChangeListener(refreshMenus));
+    }
   }
 }

--- a/packages/dmpersonal/src/vite-env.d.ts
+++ b/packages/dmpersonal/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -246,6 +246,22 @@ export class WKRemoteConfig {
    */
   docsOn: boolean = false;
   /**
+   * Loop(回路)模块展示开关。后端字段 dmloop_on 为 true 时，前端在侧边栏 NavRail
+   * 展示「回路」(LoopModule) 入口；false 或字段缺失时隐藏。
+   *
+   * 默认 false(fail-safe): loop 依赖后端服务 + fleet 代理 + daemon 运行时一整套未就绪前保持隐藏——
+   * feature 分支合入 main 也不对用户暴露；运维在依赖部署就绪后再下发 dmloop_on=true 放量。
+   * 镜像 docs_on(system_setting dmloop.enabled),纯 UI 展示门,不承担鉴权:/fleet/api 相关接口的
+   * 权限校验仍由后端负责。
+   */
+  dmloopOn: boolean = false;
+  /**
+   * 「我的 / 运行时」(PersonalModule) 模块展示开关。后端字段 dmpersonal_on 为 true 时展示入口。
+   * 与 dmloop_on 分开:「我的」后续会重新设计、脱离 loop 独立演进,故独立门控(可分阶段放量)。
+   * 默认 false(fail-safe),运维就绪后下发 dmpersonal_on=true。纯 UI 展示门,不承担鉴权。
+   */
+  dmpersonalOn: boolean = false;
+  /**
    * OIDC provider 元数据数组, 由后端 /v1/common/appconfig 的 oidc_providers 字段下发。
    * OIDC 关闭时为空数组。前端不再硬编码具体 IdP, 部署 env 切 provider。
    * 顶层 oidc_account_url / oidc_reset_password_url 是后端兼容老前端用的,新前端只读这里。
@@ -346,6 +362,8 @@ export class WKRemoteConfig {
         this.suppressLoginMigrationNotice;
       const previousStickerCustomEnabled = this.stickerCustomEnabled;
       const previousDocsOn = this.docsOn;
+      const previousDmloopOn = this.dmloopOn;
+      const previousDmpersonalOn = this.dmpersonalOn;
       this.requestSuccess = true;
       this.revokeSecond = result["revoke_second"];
       this.threadOn = !!result["thread_on"];
@@ -360,6 +378,8 @@ export class WKRemoteConfig {
         result["sticker_custom_enabled"]
       );
       this.docsOn = parseRemoteBool(result["docs_on"]);
+      this.dmloopOn = parseRemoteBool(result["dmloop_on"]);
+      this.dmpersonalOn = parseRemoteBool(result["dmpersonal_on"]);
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();
@@ -369,7 +389,9 @@ export class WKRemoteConfig {
         previousSuppressLoginMigrationNotice !==
           this.suppressLoginMigrationNotice ||
         previousStickerCustomEnabled !== this.stickerCustomEnabled ||
-        previousDocsOn !== this.docsOn
+        previousDocsOn !== this.docsOn ||
+        previousDmloopOn !== this.dmloopOn ||
+        previousDmpersonalOn !== this.dmpersonalOn
       ) {
         this.notifyConfigChangeListeners();
       }


### PR DESCRIPTION
Launch switch for the loop feature, mirroring the existing `docs_on` pattern, so feat/octo-loop can merge to main but stay hidden until ops enables it (fail-safe default off). Backend half (appconfig `dmloop_on`/`dmpersonal_on`) is a paired octo-server PR.

## What
- **RemoteConfig** (`packages/dmworkbase/src/App.tsx`): add `dmloopOn` / `dmpersonalOn` (default false), mapped from appconfig `dmloop_on` / `dmpersonal_on` (parseRemoteBool), added to the config change-detection so a later ops toggle notifies listeners.
- **LoopModule** (`packages/dmloop/src/module.tsx`): the `loop` menu factory returns the「回路」entry only when `WKApp.remoteConfig.dmloopOn` is true, else undefined (MenusManager filters falsy → hidden); refresh the NavRail on flag resolve/change (addListener + addConfigChangeListener), HMR-unsubscribed. Route stays registered — pure display gate.
- **PersonalModule** (`packages/dmpersonal/src/module.tsx`): same, gated by `dmpersonalOn`. **Two independent flags** because 我的/运行时 will be redesigned to decouple from loop and may roll out on its own schedule.
- `packages/dmpersonal/src/vite-env.d.ts` added — fixes a pre-existing `import.meta.hot` typecheck gap in the edited file (dmloop already has one).

## Two switches, why
回路 (LoopModule) and 我的/运行时 (PersonalModule) are gated by separate flags per product decision: 我的 is slated for a redesign that decouples it from loop, so it needs an independent rollout knob.

## Blast radius (Rule 8)
Internal to the three files + additive RemoteConfig fields. No exported type/prop/hook signature changes. Faithfully mirrors DocsModule/docsOn.

## Verification (real-env e2e, dev, Alice)
- **Default off** (neither flag served by appconfig): 回路 and 我的 NavRail entries are **hidden** — verified.
- **Enabled** (set system_setting dmloop.enabled=1 + dmpersonal.enabled=1, restart octo-server → appconfig serves dmloop_on/dmpersonal_on=true): both entries **reappear** on reload — verified.
- Claude code-reviewer: clean (traced gate/listener/HMR + change-detection vs the docs reference). Codex adversarial-review returned a malformed placeholder response (endpoint glitch, not a finding) — clean codex re-check to follow. tsc clean.

Paired backend PR (octo-server): exposes `dmloop_on` / `dmpersonal_on` from `/v1/common/appconfig` (system_setting dmloop.enabled / dmpersonal.enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**追加 commit(brand hygiene, Rule 10)**: scrubbed upstream brand from dmloop — 13 「对标/对齐 multica」comments → 产品设计, dropped MULTICA_PUBLIC_URL from the user-facing `headlessNoBackend` i18n (zh+en) + an authApi comment. Comments/i18n-text only, no logic (no-logic-blast-radius → adversarial-review/simplify exempt). **Left (cross-repo contract, coordinated rename needed): the `multica_csrf` double-submit cookie in api/http.ts.**