### PR TITLE
fix(loop): show daemon version in Runtimes machine header, not the first agent's

### DIFF
--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -6,6 +6,7 @@ import type { RuntimeDevice, RuntimeMode } from "../api/types";
 import { listRuntimes } from "../api/runtimeApi";
 import { issueHeadlessCliToken, getDaemonServerUrl } from "../api/authApi";
 import { headlessCommand } from "./headlessCommand";
+import { deviceVersion, runtimeVersion } from "./runtimeVersion";
 import "./runtime.css";
 
 const { Title } = Typography;
@@ -51,24 +52,8 @@ function deviceName(r: RuntimeDevice): string {
   return head || r.name;
 }
 
-function runtimeVersion(r: RuntimeDevice): string {
-  const version = r.metadata?.version;
-  if (typeof version === "string" && version.trim()) return version.trim();
-  const info = r.device_info || "";
-  const parts = info.split("·").map((part) => part.trim()).filter(Boolean);
-  return parts.slice(1).join(" · ") || r.launch_header || "-";
-}
-
 function deviceStatus(runtimes: RuntimeDevice[]): RuntimeDevice["status"] {
   return runtimes.some((runtime) => runtime.status === "online") ? "online" : "offline";
-}
-
-function deviceVersion(runtimes: RuntimeDevice[]): string {
-  for (const runtime of runtimes) {
-    const version = runtimeVersion(runtime);
-    if (version !== "-") return version;
-  }
-  return "-";
 }
 
 function relTime(iso: string | null): string {

--- a/packages/dmloop/src/pages/__tests__/runtimeVersion.test.ts
+++ b/packages/dmloop/src/pages/__tests__/runtimeVersion.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { RuntimeDevice } from "../../api/types";
+import { deviceVersion, runtimeVersion } from "../runtimeVersion";
+
+// Minimal RuntimeDevice factory — only the fields the version helpers read.
+function rt(over: Partial<RuntimeDevice>): RuntimeDevice {
+  return {
+    id: "r1",
+    workspace_id: "w1",
+    name: "n",
+    runtime_mode: "builtin",
+    provider: "claude",
+    status: "online",
+    device_info: "",
+    visibility: "workspace",
+    last_seen_at: null,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  } as RuntimeDevice;
+}
+
+describe("deviceVersion (machine/daemon-level)", () => {
+  it("returns the daemon cli_version, NOT any agent runtime's own version", () => {
+    const runtimes = [
+      rt({ provider: "hermes", metadata: { version: "Hermes Agent v0.16.0", cli_version: "v0.3.31-3895-g3532fa88" } }),
+      rt({ provider: "claude", metadata: { version: "2.1.207 (Claude Code)", cli_version: "v0.3.31-3895-g3532fa88" } }),
+    ];
+    // The bug was returning the first runtime's agent version ("Hermes Agent ...").
+    expect(deviceVersion(runtimes)).toBe("v0.3.31-3895-g3532fa88");
+  });
+
+  it("falls back to '-' when no runtime reports a daemon cli_version", () => {
+    expect(deviceVersion([rt({ metadata: { version: "2.1.207 (Claude Code)" } })])).toBe("-");
+    expect(deviceVersion([])).toBe("-");
+  });
+});
+
+describe("runtimeVersion (per-agent)", () => {
+  it("returns the agent's own CLI version from metadata.version", () => {
+    expect(runtimeVersion(rt({ metadata: { version: "2.1.207 (Claude Code)" } }))).toBe("2.1.207 (Claude Code)");
+  });
+
+  it("derives from device_info when metadata.version is absent", () => {
+    expect(runtimeVersion(rt({ device_info: "casterdeMacBook-Pro.local · codex-cli 0.142.5" }))).toBe("codex-cli 0.142.5");
+  });
+
+  it("returns '-' when nothing is available", () => {
+    expect(runtimeVersion(rt({}))).toBe("-");
+  });
+});

--- a/packages/dmloop/src/pages/runtimeVersion.ts
+++ b/packages/dmloop/src/pages/runtimeVersion.ts
@@ -1,0 +1,23 @@
+import type { RuntimeDevice } from "../api/types";
+
+// runtimeVersion 返回单个 runtime 自己的 agent CLI 版本（如 "2.1.207 (Claude Code)"），
+// 优先取 metadata.version，其次从 device_info（"host · <version>"）推导，最后回退 launch_header。
+export function runtimeVersion(r: RuntimeDevice): string {
+  const version = r.metadata?.["version"];
+  if (typeof version === "string" && version.trim()) return version.trim();
+  const info = r.device_info || "";
+  const parts = info.split("·").map((part) => part.trim()).filter(Boolean);
+  return parts.slice(1).join(" · ") || r.launch_header || "-";
+}
+
+// deviceVersion 是机器/daemon 级版本——取 daemon 上报的自身 CLI 版本
+// （metadata.cli_version，同一台机器的所有 runtime 一致）。
+// 不能取某个 agent runtime 的版本：那是 agent 级信息，放在机器头部会误导
+// （看起来像整机版本），且与下方该 runtime 行重复。
+export function deviceVersion(runtimes: RuntimeDevice[]): string {
+  for (const runtime of runtimes) {
+    const cliVersion = runtime.metadata?.["cli_version"];
+    if (typeof cliVersion === "string" && cliVersion.trim()) return cliVersion.trim();
+  }
+  return "-";
+}


### PR DESCRIPTION
## Summary

Fixes the machine/group header on the Runtimes page showing one agent's CLI version (e.g. "Hermes Agent v0.16.0") as if it were the whole machine's version. The header now shows the daemon's own version (machine-level), while each runtime row keeps showing its own agent CLI version.

## Related Issue

N/A

## Changes

- `pages/runtimeVersion.ts` (new): extracted `runtimeVersion` (per-agent) and `deviceVersion` (machine/daemon-level) into a dependency-free module so they can be unit-tested without the component/CSS graph.
- `deviceVersion` now reads the daemon's `metadata.cli_version` (identical across a machine's runtimes) instead of returning the first runtime's agent version — which was arbitrary (array order) and duplicated the row below it.
- `pages/RuntimePage.tsx`: imports the two helpers instead of defining them inline.
- `pages/__tests__/runtimeVersion.test.ts` (new): asserts `deviceVersion` returns the daemon version (not any agent version), falls back to `-` when absent, and `runtimeVersion` still derives the per-agent version from `metadata.version` / `device_info`.

## Testing

- [ ] Unit tests added/updated
- [x] Manually verified

`vitest` unit tests pass (5/5). `pnpm typecheck` clean. Verified live in the local app: the machine header now renders the daemon version `v0.3.31-3895-g3532fa88` instead of the first agent's version, with each runtime row still showing its own version.

Note: the "Unit tests added/updated" box reflects the checklist wording; tests **were** added (`runtimeVersion.test.ts`).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [ ] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
