### PR TITLE
feat(chat-header): add search entry to open in-channel search

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -33,6 +33,8 @@ export type MittEvents = {
   "wk:toggle-matter-detail-panel": { channelId: string; channelType: number };
   "wk:toggle-summary-panel": { channelId: string; channelType: number; summaryPanelView: 'history' | 'new'; forceOpen?: boolean };
   "wk:open-summary-modal": { channelId: string; channelType: number };
+  /** 主聊天框头部搜索入口点击：请求打开该频道的会话内搜索面板（与信息栏「查找聊天内容」同一效果）。 */
+  "wk:open-channel-search": { channelId: string; channelType: number };
   /** 打开多选→添加到事项的弹出菜单（由 dmworktodo 模块接管渲染） */
   "wk:open-matter-link-menu": { anchor: HTMLElement; channelId: string; channelType: number; messages?: Array<{ messageSeq?: number; messageID?: string; fromUID?: string; fromUName?: string; content?: string; timestamp?: number; attachments?: any[] }> };
   "wk:switch-sidebar-tab": string;

--- a/packages/dmworkbase/src/Components/ChannelSearch/ChatSearchEntryButton.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/ChatSearchEntryButton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Search } from "lucide-react";
+import { Channel } from "wukongimjssdk";
+import WKApp from "../../App";
+import { t } from "../../i18n";
+import { isChannelSearchEnabled } from "./feature";
+
+interface ChatSearchEntryButtonProps {
+  channel: Channel;
+}
+
+export default function ChatSearchEntryButton({
+  channel,
+}: ChatSearchEntryButtonProps) {
+  if (!isChannelSearchEnabled(channel)) return null;
+
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        WKApp.mittBus.emit("wk:open-channel-search", {
+          channelId: channel.channelID,
+          channelType: channel.channelType,
+        });
+      }}
+      style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
+      title={t("base.module.channelSettings.messageHistory")}
+    >
+      <Search size={20} fill="none" color="currentColor" />
+    </div>
+  );
+}

--- a/packages/dmworkbase/src/Components/ChannelSearch/__tests__/ChatSearchEntryButton.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSearch/__tests__/ChatSearchEntryButton.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  remoteConfig: {
+    messagesSearchOn: true,
+  },
+  emittedEvents: [] as Array<{ event: string; payload: unknown }>,
+}));
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class {
+    channelID: string;
+    channelType: number;
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  },
+  ChannelTypeGroup: 2,
+  ChannelTypePerson: 1,
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    remoteConfig: mockState.remoteConfig,
+    mittBus: {
+      emit: (event: string, payload: unknown) => {
+        mockState.emittedEvents.push({ event, payload });
+      },
+    },
+  },
+}));
+
+vi.mock("../../../Service/Const", () => ({
+  ChannelTypeCommunityTopic: 5,
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+}));
+
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import ChatSearchEntryButton from "../ChatSearchEntryButton";
+
+let container: HTMLDivElement | null = null;
+
+beforeEach(() => {
+  mockState.emittedEvents = [];
+  mockState.remoteConfig.messagesSearchOn = true;
+});
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(element, container);
+  });
+}
+
+describe("ChatSearchEntryButton", () => {
+  it("renders when channel search is enabled for supported channel", () => {
+    const channel = new Channel("group-a", ChannelTypeGroup);
+    render(<ChatSearchEntryButton channel={channel as any} />);
+    const button = container?.querySelector('[title="base.module.channelSettings.messageHistory"]');
+    expect(button).toBeTruthy();
+  });
+
+  it("does not render when feature flag is off", () => {
+    mockState.remoteConfig.messagesSearchOn = false;
+    const channel = new Channel("group-a", ChannelTypeGroup);
+    render(<ChatSearchEntryButton channel={channel as any} />);
+    expect(container?.querySelector("div")).toBeFalsy();
+  });
+
+  it("does not render on unsupported channel type (customer service)", () => {
+    const channel = new Channel("cs-a", 4);
+    render(<ChatSearchEntryButton channel={channel as any} />);
+    expect(container?.querySelector("div")).toBeFalsy();
+  });
+
+  it("emits wk:open-channel-search with channel identity on click", () => {
+    const channel = new Channel("group-a", ChannelTypeGroup);
+    render(<ChatSearchEntryButton channel={channel as any} />);
+    const button = container?.querySelector(
+      '[title="base.module.channelSettings.messageHistory"]'
+    ) as HTMLElement;
+    expect(button).toBeTruthy();
+    act(() => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mockState.emittedEvents).toEqual([
+      {
+        event: "wk:open-channel-search",
+        payload: { channelId: "group-a", channelType: ChannelTypeGroup },
+      },
+    ]);
+  });
+});

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -694,6 +694,18 @@ export class ChatContentPage extends Component<
     };
     WKApp.mittBus.on("wk:toggle-summary-panel", this._onToggleSummaryPanel);
 
+    // 主聊天头「查找聊天内容」入口按钮触发。等同于信息栏「查找聊天内容」：
+    // 复用 _openChannelSearchPanel，内含 feature 门禁 + 与其它侧边面板互斥。
+    this._onOpenChannelSearch = (data) => {
+      if (
+        data.channelId !== channel.channelID ||
+        data.channelType !== channel.channelType
+      )
+        return;
+      this._openChannelSearchPanel();
+    };
+    WKApp.mittBus.on("wk:open-channel-search", this._onOpenChannelSearch);
+
     // 检查是否需要自动打开子区面板（查看全部子区）
     if (WKApp.shared.pendingThreadPanel === channel.channelID) {
       this.setState({
@@ -874,6 +886,10 @@ export class ChatContentPage extends Component<
     summaryPanelView: "history" | "new";
     forceOpen?: boolean;
   }) => void;
+  private _onOpenChannelSearch?: (data: {
+    channelId: string;
+    channelType: number;
+  }) => void;
 
   componentWillUnmount() {
     WKApp.mittBus.off("wk:file-preview", this._onFilePreview);
@@ -894,6 +910,9 @@ export class ChatContentPage extends Component<
     }
     if (this._onToggleSummaryPanel) {
       WKApp.mittBus.off("wk:toggle-summary-panel", this._onToggleSummaryPanel);
+    }
+    if (this._onOpenChannelSearch) {
+      WKApp.mittBus.off("wk:open-channel-search", this._onOpenChannelSearch);
     }
     this._unsubscribeChannelSearchConfig?.();
     this._unsubscribeChannelSearchConfig = undefined;

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -19,6 +19,7 @@ import { Smile, Scissors, ImagePlus, Paperclip, AtSign } from "lucide-react";
 import { Howl, Howler } from "howler";
 import WKApp, { FriendApply, FriendApplyState, ThemeMode } from "./App";
 import { isChannelSearchEnabled } from "./Components/ChannelSearch/feature";
+import ChatSearchEntryButton from "./Components/ChannelSearch/ChatSearchEntryButton";
 import ChannelQRCode from "./Components/ChannelQRCode";
 import { ChannelSettingRouteData } from "./Components/ChannelSetting/context";
 import { IndexTableItem } from "./Components/IndexTable";
@@ -647,6 +648,24 @@ export default class BaseModule implements IModule {
     this.registerMessageContextMenus(); // 注册消息上下文菜单
 
     this.registerChatToolbars(); // 注册聊天工具栏
+    this.registerChannelHeaderRightItems(); // 注册频道头部右侧入口按钮
+  }
+
+  /**
+   * 频道头右侧入口按钮。dmworksummary / dmworktodo 各自注册了「智能总结」/「事项」
+   * 图标；这里注册「查找聊天内容」按钮，与信息栏入口 (channel.base.settingMessageHistory)
+   * 使用同一 feature 门禁 (isChannelSearchEnabled) 与同一打开效果，通过 mittBus
+   * 事件 wk:open-channel-search 通知 Pages/Chat 调 _openChannelSearchPanel()。
+   */
+  registerChannelHeaderRightItems() {
+    WKApp.endpoints.registerChannelHeaderRightItem(
+      "channelheader.search",
+      ({ channel }) => {
+        if (!isChannelSearchEnabled(channel)) return undefined;
+        return <ChatSearchEntryButton channel={channel} />;
+      },
+      4900, // 排在 matter (5000) / summary (5100) 之前
+    );
   }
 
   tipsAudio() {


### PR DESCRIPTION
# feat(chat-header): add search entry to open in-channel search

Adds a search icon to the main chat header (right side), matching the visual style of the summary/matter entries. Clicking opens the in-channel ChannelSearch panel — the same effect as opening the conversation info sidebar → "查找聊天内容".

## Background

This was originally bundled into PR #688 (4 global-search filter-panel bug fixes, YUJ-30). Reviewers correctly flagged it as out-of-scope for the bug-fix issue (#687), and it has been split out per their request. The commit was reverted from `fix/global-search-filter-4bugs-fe` and cherry-picked here onto a fresh branch from `main`.

## Implementation

Mirror of the summary/matter entry-button pattern:

- `packages/dmworkbase/src/App.tsx` — new `wk:open-channel-search` mittBus event type.
- `packages/dmworkbase/src/Components/ChannelSearch/ChatSearchEntryButton.tsx` (new, +32) — lucide `Search` icon, gated by `isChannelSearchEnabled(channel)`, tooltip reuses existing i18n key `module.channelSettings.messageHistory`.
- `packages/dmworkbase/src/module.tsx` — registers the button via `registerChannelHeaderRightItem("channelheader.search", ...)` at sort=4900 (before summary=5100 and matter=5000).
- `packages/dmworkbase/src/Pages/Chat/index.tsx` — mittBus listener registered in `componentDidMount` with channel-match guard, cleaned up in `componentWillUnmount`; handler invokes existing `_openChannelSearchPanel()` (same feature gate + side-panel mutual exclusion as the info-sidebar entry).

## Tests

- 4 new unit tests for `ChatSearchEntryButton` (render gating, click emit).
- `pnpm build` / `lint` / `i18n:check` green.

## Verification

Design/mockup: `global-search-design/feat-chat-header-search-entry.md` (spec doc referenced by the commit).


Fixes #694
