### PR TITLE
fix(board): unify doc-level delete to the shared centered confirm modal

### DIFF
--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -20,6 +20,7 @@ import { useAccessRequests } from '../access-request/useAccessRequests.ts'
 import { startDocForward } from '../forward/startDocForward.ts'
 import { canManage, canEdit } from '../auth/roles.ts'
 import { useDocDelete } from '../editor/useDocDelete.ts'
+import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { getDoc, getUserName } from '../pages/docsApi.ts'
 import type { Role } from '../auth/roles.ts'
 import type { ConnState } from '../collab/createCollabEditor.ts'
@@ -1147,19 +1148,20 @@ export function BoardShell(props: BoardShellProps): ReactElement {
         </p>
       )}
 
-      {del.confirming && (
-        <div className="octo-docs-delete-confirm octo-doc-delete-confirm" role="alertdialog" aria-label={t('docs.doc.deleteConfirmTitle')}>
-          <p className="octo-docs-delete-confirm-text">{t('docs.doc.deleteConfirm')}</p>
-          <div className="octo-docs-delete-confirm-actions">
-            <button type="button" className="octo-tb-btn" disabled={del.deleting} onClick={del.cancel}>
-              {t('docs.doc.deleteCancel')}
-            </button>
-            <button type="button" className="octo-tb-btn octo-docs-delete-confirm-go" disabled={del.deleting} onClick={() => void del.confirm()}>
-              {t('docs.doc.delete')}
-            </button>
-          </div>
-        </div>
-      )}
+      {/* Delete confirm — the shared centered modal, identical to the document's and sheet's
+          delete dialog. Board-specific wording (title/message) with the generic delete/cancel
+          button labels. */}
+      <ConfirmModal
+        open={del.confirming}
+        title={t('docs.board.deleteConfirmTitle')}
+        message={t('docs.board.deleteConfirm')}
+        confirmLabel={t('docs.doc.delete')}
+        cancelLabel={t('docs.doc.deleteCancel')}
+        danger
+        busy={del.deleting}
+        onConfirm={() => void del.confirm()}
+        onCancel={del.cancel}
+      />
       {del.error && (
         <p className="octo-member-error" role="alert">
           {del.error}

--- a/packages/docs/src/board/__tests__/BoardShellDeleteConfirm.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellDeleteConfirm.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { BoardTerminal } from '../collab/index.ts'
+import type { WhiteboardSession } from '../collab/connect.ts'
+
+// Excalidraw stand-in (same shape as the other BoardShell tests): hands the imperative API up ONCE
+// from a mount effect so the excalidrawApi state settles instead of spinning an update loop.
+vi.mock('@excalidraw/excalidraw', async () => {
+  const { useEffect } = await import('react')
+  const api = { updateScene: () => {}, getAppState: () => ({}), updateLibrary: async () => [] }
+  const Excalidraw = ({
+    children,
+    excalidrawAPI,
+  }: {
+    children?: ReactNode
+    excalidrawAPI?: (api: unknown) => void
+  }) => {
+    useEffect(() => {
+      excalidrawAPI?.(api)
+    }, [excalidrawAPI])
+    return <div data-testid="excalidraw-canvas">{children}</div>
+  }
+  const MainMenu = (() => null) as unknown as { DefaultItems: Record<string, unknown> }
+  MainMenu.DefaultItems = {}
+  return {
+    Excalidraw,
+    MainMenu,
+    restoreElements: (els: readonly unknown[] | null | undefined) => (els ? [...els] : []),
+    reconcileElements: (local: readonly unknown[]) => [...local],
+    loadLibraryFromBlob: async () => [],
+    serializeLibraryAsJSON: () => '[]',
+  }
+})
+vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
+
+// Force the delete flow into its "awaiting confirmation" state so the confirm UI renders without
+// having to drive the ≡ menu → requestDelete click. Keeps the assertion on the UI shape, not the
+// hook's internals (which are covered by useDocDelete's own tests).
+vi.mock('../../editor/useDocDelete.ts', () => ({
+  useDocDelete: () => ({
+    confirming: true,
+    deleting: false,
+    error: null,
+    requestDelete: vi.fn(),
+    cancel: vi.fn(),
+    confirm: vi.fn(),
+  }),
+}))
+
+import { BoardShell } from '../BoardShell.tsx'
+
+function makeAwareness() {
+  return {
+    clientID: 1,
+    getStates: () => new Map(),
+    setLocalStateField: () => {},
+    on: () => {},
+    off: () => {},
+  }
+}
+
+function makeSession(role: 'admin' | 'writer' | 'reader'): WhiteboardSession {
+  const binding = {
+    setApi: () => {},
+    setRenderAdapter: () => {},
+    setFileSync: () => {},
+    handleLocalChange: () => {},
+    snapshotElements: () => [] as unknown[],
+  }
+  return {
+    getRole: () => role,
+    subscribeRole: () => () => {},
+    subscribeTerminal: (_cb: (t: BoardTerminal) => void) => () => {},
+    binding,
+    provider: {
+      awareness: makeAwareness(),
+      isSynced: true,
+      on: () => {},
+      off: () => {},
+    },
+  } as unknown as WhiteboardSession
+}
+
+describe('BoardShell doc-level delete confirm (XIN-892)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the shared centered ConfirmModal, not the legacy inline banner', async () => {
+    render(
+      <BoardShell docId="doc-1" title="Shared board" space="s1" collabSession={makeSession('admin')} collab />,
+    )
+    await screen.findByTestId('excalidraw-canvas')
+
+    // The delete confirm is the shared centered modal (same component the doc + sheet use)…
+    expect(document.querySelector('.octo-confirm-overlay')).not.toBeNull()
+    expect(document.querySelector('.octo-confirm-modal')).not.toBeNull()
+    // …and the early top-of-page inline banner is gone.
+    expect(document.querySelector('.octo-docs-delete-confirm')).toBeNull()
+  })
+
+  it('uses board-specific wording (not the document phrasing)', async () => {
+    render(
+      <BoardShell docId="doc-1" title="Shared board" space="s1" collabSession={makeSession('admin')} collab />,
+    )
+    await screen.findByTestId('excalidraw-canvas')
+
+    const modal = document.querySelector('.octo-confirm-modal')!
+    expect(modal.querySelector('.octo-confirm-title')?.textContent).toBe('docs.board.deleteConfirmTitle')
+    expect(modal.querySelector('.octo-confirm-message')?.textContent).toBe('docs.board.deleteConfirm')
+    // Confirm / cancel reuse the generic delete labels.
+    expect(modal.textContent).toContain('docs.doc.delete')
+    expect(modal.textContent).toContain('docs.doc.deleteCancel')
+  })
+})

--- a/packages/docs/src/board/board.css
+++ b/packages/docs/src/board/board.css
@@ -18,7 +18,6 @@
   padding-right: 32px;
   flex: 0 0 auto;
 }
-.octo-board > .octo-docs-delete-confirm,
 .octo-board > .octo-member-error {
   margin-left: 32px;
   margin-right: 32px;

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1335,38 +1335,6 @@
 .octo-error {
   color: #eb5757;
 }
-.octo-docs-delete-confirm {
-  margin: 4px 10px 8px;
-  padding: 10px;
-  border: 1px solid var(--octo-border, #e5e6eb);
-  border-radius: 8px;
-  background: var(--octo-bg-2, #fafbfc);
-}
-.octo-docs-delete-confirm-text {
-  margin: 0 0 8px;
-  font-size: 13px;
-  color: var(--octo-fg, #1f2329);
-}
-.octo-docs-delete-confirm-actions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-}
-.octo-docs-delete-confirm-go {
-  color: #fff;
-  background: #eb5757;
-}
-.octo-docs-delete-confirm-go:hover:not(:disabled) {
-  background: #d64545;
-}
-
-/* Editor delete entry (Problem 4): the delete action now lives inside the header ≡ "more" menu
-   (danger row, see .octo-doc-more-item.is-danger below). The confirm card still sits just under
-   the header instead of floating in a list row. */
-.octo-doc-delete-confirm {
-  margin: 8px 0 0;
-  max-width: 420px;
-}
 
 /* ── Centered confirm dialog (ConfirmModal): shared by document + sheet delete so both pop the
    SAME card in the MIDDLE of the screen — replacing the sheet's native window.confirm and the

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -19,6 +19,8 @@
     "saveFailed": "Not saved — local storage is full or unavailable",
     "untitled": "Untitled board",
     "deleteEntry": "Delete board",
+    "deleteConfirmTitle": "Delete board",
+    "deleteConfirm": "This cannot be undone. Delete this board?",
     "importLibrary": "Import from local",
     "importLibraryError": "Couldn't import that library — please make sure it's a valid .excalidrawlib",
     "saveLibrary": "Save to file",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -19,6 +19,8 @@
     "saveFailed": "未保存 — 本地存储已满或不可用",
     "untitled": "未命名画板",
     "deleteEntry": "删除画板",
+    "deleteConfirmTitle": "删除画板",
+    "deleteConfirm": "删除后不可恢复，确认删除该画板？",
     "importLibrary": "从本地导入",
     "importLibraryError": "无法导入该素材库文件，请确认是有效的 .excalidrawlib",
     "saveLibrary": "导出到文件",


### PR DESCRIPTION
## What & why

The whiteboard's document-level delete confirmation was inconsistent with the document and sheet views. Documents and sheets already share the centered `ConfirmModal`, but the board still rendered the early top-anchored inline gray banner — and it reused the *document's* wording ("delete this document" / "该文档") even though it deletes a board.

This unifies the board's delete confirm to the same shared centered modal and gives it board-specific wording.

## Changes

- **`BoardShell.tsx`** — replace the inline confirm banner with the shared `ConfirmModal`, wired the same way as the document/sheet delete (`open`=confirming, `danger`, `busy`=deleting, confirm/cancel callbacks from the existing `useDocDelete` hook). No hook logic changed.
- **i18n** — new board-scoped `deleteConfirmTitle` / `deleteConfirm` keys in `en-US` and `zh-CN` with board phrasing. Confirm/cancel buttons reuse the generic `doc.delete` / `doc.deleteCancel` keys.
- **CSS** — removed the now-unused inline-banner rules (`.octo-docs-delete-confirm*`, `.octo-doc-delete-confirm`, and the board width override) after confirming no other consumers remain.
- **Test** — added `BoardShellDeleteConfirm.test.tsx` asserting the board delete renders the shared centered modal (not the legacy inline banner) and uses the board wording.

## Scope

Only the board's delete-confirm rendering + wording + dead styles. The `useDocDelete` logic, the document/sheet delete, and the version-history delete dialog are untouched.

## Verification

- Board test suite green (194 tests); new regression test passes.
- `typecheck` — no new errors (2 pre-existing errors on `main`, unrelated files).
- `lint:css` — 0 errors; `i18n:check` — passed.
