### PR TITLE
feat(docs): body font family (fontFamily) with feature-flag gating (SCHEMA_VERSION 16)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -31,6 +31,10 @@
     {
       "path": "packages/docs/src/board/excalidrawDebrand.ts",
       "reason": "Whiteboard de-brand helper. Its only CJK literal is BOARD_BRAND ('画布'), the fixed product word that replaces the upstream Excalidraw brand token at runtime; it is intentionally locale-invariant (a brand replacement, not translatable UI copy) and the docs package has no i18n namespace to key it against."
+    },
+    {
+      "path": "packages/docs/src/editor/fontFamilies.ts",
+      "reason": "Toolbar font-family presets. The only CJK literals are the localized family-name aliases inside the CSS font-family values (e.g. \"微软雅黑\", \"宋体\") that must byte-match the native font name so browsers matching a font by its Chinese name still render it; they are font resource identifiers, not translatable UI copy (mirrors export/docx/styles.ts). The user-facing display name is localized separately via the labelKey i18n keys resolved with t()."
     }
   ]
 }

--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -110,6 +110,21 @@ export function resolveBoardWsUrl(collabWsUrl?: string): string {
 /** Refresh collab token when it is within this window of expiry. */
 export const TOKEN_REFRESH_LEEWAY_MS = 30_000
 
+/**
+ * Feature flag for the body-font (fontFamily) toolbar entry (SCHEMA_VERSION 16).
+ *
+ * DEFAULT OFF. This gates ONLY the toolbar's font-family selector — the entry the user
+ * uses to *set* a font. The FontFamily extension itself is always registered (extensions.ts),
+ * so the schema knows the `fontFamily` textStyle attr and round-trips it faithfully; that is
+ * what makes the phased rollout safe. Keeping the entry OFF until every client has this bundle
+ * (version convergence) prevents the "旧客户端编辑带字体文档静默 strip 丢数据" hazard: a font set by
+ * a flag-on client would be silently dropped when an older bundle (no fontFamily attr in its
+ * schema) opens and edits the same doc. The boss flips this on via VITE_DOCS_FONT_FAMILY=true
+ * after client versions converge —放量 is not part of this ticket. When off, the selector is not
+ * rendered at all (invisible/unusable) and there is no toolbar regression.
+ */
+export const FONT_FAMILY_ENABLED = envOr(import.meta.env?.VITE_DOCS_FONT_FAMILY, '') === 'true'
+
 // ── Default document addressing (frontend-design §7.2) ───────────────────────
 //
 // The docs-backend currently exposes only per-doc endpoints (`/docs/:docId/...`)

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -13,6 +13,7 @@ import { sanitizeLinkHref } from './sanitize.ts'
 import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { TableGridPicker } from './TableControls.tsx'
 import { t } from '../octoweb/index.ts'
+import { FONT_FAMILY_ENABLED } from '../config.ts'
 
 // Inline SVG toolbar icons (C2–C4): crisp, correct glyphs for underline / strikethrough /
 // alignment, replacing the ambiguous text placeholders. 16×16, fill: currentColor (via .octo-tb-icon).
@@ -354,6 +355,24 @@ function TextColorControl({ editor }: { editor: Editor }) {
 /** Font-size presets (px) offered by the toolbar dropdown (SCHEMA_VERSION 7). */
 const FONT_SIZES = ['12', '14', '16', '18', '24', '32'] as const
 
+/**
+ * Font-family presets offered by the toolbar dropdown (SCHEMA_VERSION 16). `value` is written
+ * verbatim into the textStyle `fontFamily` attr → `style="font-family:…"`, so each carries a
+ * generic fallback so the glyphs still render if the primary face is absent. `label` is the face
+ * name (a proper noun, shown as-is like the raw px numbers of FONT_SIZES — not translated). The
+ * empty-value "Default" option (i18n) clears the attr and inherits the document font.
+ */
+const FONT_FAMILIES = [
+  { label: '微软雅黑', value: '"Microsoft YaHei", "微软雅黑", sans-serif' },
+  { label: '宋体', value: 'SimSun, "宋体", serif' },
+  { label: '黑体', value: 'SimHei, "黑体", sans-serif' },
+  { label: '楷体', value: 'KaiTi, "楷体", serif' },
+  { label: 'Arial', value: 'Arial, Helvetica, sans-serif' },
+  { label: 'Times New Roman', value: '"Times New Roman", Times, serif' },
+  { label: 'Georgia', value: 'Georgia, serif' },
+  { label: 'Courier New', value: '"Courier New", Courier, monospace' },
+] as const
+
 /** Text-alignment options (SCHEMA_VERSION 5) — value passed to setTextAlign, icon per direction (C4). */
 const ALIGNMENTS = [
   { value: 'left', icon: <IconAlignLeft />, key: 'alignLeft' },
@@ -467,6 +486,37 @@ function FontSizeSelect({ editor }: { editor: Editor }) {
       {FONT_SIZES.map((s) => (
         <option key={s} value={s}>
           {s}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+/**
+ * Font-family dropdown (SCHEMA_VERSION 16): sets the textStyle `fontFamily` attr, or clears it.
+ * Mirrors FontSizeSelect. Rendered ONLY when FONT_FAMILY_ENABLED is on (feature flag, default
+ * off) — the caller gates it, so when off the selector is absent from the DOM entirely and the
+ * user cannot set a font (see config.ts for the phased-rollout rationale).
+ */
+function FontFamilySelect({ editor }: { editor: Editor }) {
+  useEditorTick(editor)
+  const current = (editor.getAttributes('textStyle').fontFamily as string) || ''
+  return (
+    <select
+      className="octo-font-family"
+      title={t('docs.toolbar.fontFamily')}
+      value={current}
+      onMouseDown={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        const v = e.target.value
+        if (!v) editor.chain().focus().unsetFontFamily().run()
+        else editor.chain().focus().setFontFamily(v).run()
+      }}
+    >
+      <option value="">{t('docs.toolbar.fontFamilyDefault')}</option>
+      {FONT_FAMILIES.map((f) => (
+        <option key={f.label} value={f.value} style={{ fontFamily: f.value }}>
+          {f.label}
         </option>
       ))}
     </select>
@@ -933,6 +983,7 @@ export function Toolbar({ editor }: { editor: Editor }) {
       <Btn label="x²" title={t('docs.toolbar.superscript')} active={editor.isActive('superscript')} onClick={() => editor.chain().focus().toggleSuperscript().run()} />
       <Btn label="x₂" title={t('docs.toolbar.subscript')} active={editor.isActive('subscript')} onClick={() => editor.chain().focus().toggleSubscript().run()} />
       <FontSizeSelect editor={editor} />
+      {FONT_FAMILY_ENABLED && <FontFamilySelect editor={editor} />}
       <span className="octo-tb-sep" />
       <AlignControls editor={editor} />
       <span className="octo-tb-sep" />

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -14,6 +14,7 @@ import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { TableGridPicker } from './TableControls.tsx'
 import { t } from '../octoweb/index.ts'
 import { FONT_FAMILY_ENABLED } from '../config.ts'
+import { FONT_FAMILIES } from './fontFamilies.ts'
 
 // Inline SVG toolbar icons (C2–C4): crisp, correct glyphs for underline / strikethrough /
 // alignment, replacing the ambiguous text placeholders. 16×16, fill: currentColor (via .octo-tb-icon).
@@ -355,24 +356,6 @@ function TextColorControl({ editor }: { editor: Editor }) {
 /** Font-size presets (px) offered by the toolbar dropdown (SCHEMA_VERSION 7). */
 const FONT_SIZES = ['12', '14', '16', '18', '24', '32'] as const
 
-/**
- * Font-family presets offered by the toolbar dropdown (SCHEMA_VERSION 16). `value` is written
- * verbatim into the textStyle `fontFamily` attr → `style="font-family:…"`, so each carries a
- * generic fallback so the glyphs still render if the primary face is absent. `label` is the face
- * name (a proper noun, shown as-is like the raw px numbers of FONT_SIZES — not translated). The
- * empty-value "Default" option (i18n) clears the attr and inherits the document font.
- */
-const FONT_FAMILIES = [
-  { label: '微软雅黑', value: '"Microsoft YaHei", "微软雅黑", sans-serif' },
-  { label: '宋体', value: 'SimSun, "宋体", serif' },
-  { label: '黑体', value: 'SimHei, "黑体", sans-serif' },
-  { label: '楷体', value: 'KaiTi, "楷体", serif' },
-  { label: 'Arial', value: 'Arial, Helvetica, sans-serif' },
-  { label: 'Times New Roman', value: '"Times New Roman", Times, serif' },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Courier New', value: '"Courier New", Courier, monospace' },
-] as const
-
 /** Text-alignment options (SCHEMA_VERSION 5) — value passed to setTextAlign, icon per direction (C4). */
 const ALIGNMENTS = [
   { value: 'left', icon: <IconAlignLeft />, key: 'alignLeft' },
@@ -515,8 +498,8 @@ function FontFamilySelect({ editor }: { editor: Editor }) {
     >
       <option value="">{t('docs.toolbar.fontFamilyDefault')}</option>
       {FONT_FAMILIES.map((f) => (
-        <option key={f.label} value={f.value} style={{ fontFamily: f.value }}>
-          {f.label}
+        <option key={f.labelKey} value={f.value} style={{ fontFamily: f.value }}>
+          {t(f.labelKey)}
         </option>
       ))}
     </select>

--- a/packages/docs/src/editor/extensions.test.ts
+++ b/packages/docs/src/editor/extensions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getSchema } from '@tiptap/core'
+import { DOMParser as PMDOMParser, DOMSerializer } from '@tiptap/pm/model'
 import { createDocsLowlight, buildPreviewExtensions } from './extensions.ts'
 import { SCHEMA_NODES, SCHEMA_MARKS } from '../schema/index.ts'
 
@@ -85,5 +86,40 @@ describe('editor schema mirrors the schema audit lists', () => {
 
   it('adds the v7 fontSize attr to the textStyle mark (attr, not a mark)', () => {
     expect(schema.marks.textStyle.spec.attrs?.fontSize).toBeDefined()
+  })
+
+  it('adds the v16 fontFamily attr to the textStyle mark (attr, not a mark)', () => {
+    // Registered unconditionally in buildPreviewExtensions so the schema always round-trips the
+    // attr; the toolbar entry that SETS it is what the FONT_FAMILY_ENABLED flag gates, not this.
+    expect(schema.marks.textStyle.spec.attrs?.fontFamily).toBeDefined()
+  })
+
+  it('round-trips a fontFamily style through parseDOM/toDOM (v16)', () => {
+    // The Y.Doc preserves whatever the ProseMirror schema parses+renders, so proving the DOM
+    // round-trip here proves the collaborative round-trip: a <span style="font-family:…"> parses
+    // into the textStyle fontFamily attr and renders back out to a font-family style.
+    const stack = 'SimSun, serif'
+    const dom = new window.DOMParser().parseFromString(
+      `<p><span style="font-family: ${stack}">hi</span></p>`,
+      'text/html',
+    )
+    const doc = PMDOMParser.fromSchema(schema).parse(dom.body)
+    // The parsed text carries a textStyle mark whose fontFamily attr holds the stack.
+    let parsedFamily: unknown
+    doc.descendants((node) => {
+      const mark = node.marks.find((m) => m.type.name === 'textStyle')
+      if (mark) parsedFamily = mark.attrs.fontFamily
+    })
+    expect(typeof parsedFamily).toBe('string')
+    expect(parsedFamily).toContain('SimSun')
+
+    // Serializing back out emits the font-family style again (no strip).
+    const out = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, {
+      document: window.document,
+    })
+    const holder = window.document.createElement('div')
+    holder.appendChild(out)
+    expect(holder.innerHTML).toContain('font-family')
+    expect(holder.innerHTML).toContain('SimSun')
   })
 })

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -18,7 +18,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import Highlight from '@tiptap/extension-highlight'
-import { TextStyle, FontSize } from '@tiptap/extension-text-style'
+import { TextStyle, FontSize, FontFamily } from '@tiptap/extension-text-style'
 import Color from '@tiptap/extension-color'
 import TextAlign from '@tiptap/extension-text-align'
 import Underline from '@tiptap/extension-underline'
@@ -116,7 +116,15 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // 3.22.2); it adds a `fontSize` global attribute to the textStyle mark → <span
     // style="font-size:…">. MUST be registered after TextStyle (its carrier mark).
     FontSize,
-    // SCHEMA-SPEC §1 (SCHEMA_VERSION 5): text alignment. A global `textAlign` attr on the
+    // SCHEMA-SPEC §6 (SCHEMA_VERSION 16): font family. FontFamily also ships inside
+    // @tiptap/extension-text-style (there is no standalone @tiptap/extension-font-family at
+    // 3.22.2); it adds a `fontFamily` global attribute to the textStyle mark → <span
+    // style="font-family:…">. MUST be registered after TextStyle (its carrier mark), same as
+    // FontSize. Registered UNCONDITIONALLY — the schema must always know the attr so this bundle
+    // round-trips fonts faithfully and never strips them; the toolbar *entry* is what the
+    // FONT_FAMILY_ENABLED flag gates (Toolbar.tsx), not the schema. This is the byte-aligned
+    // counterpart of the backend fontFamily attr under the shared SCHEMA_VERSION 16 contract.
+    FontFamily,
     // heading + paragraph nodes (not a new node/mark) → style="text-align:…". Configured for
     // exactly those two types so lists/tables/etc. keep their own layout.
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
@@ -227,8 +235,11 @@ export function buildPreviewExtensions(docId: string): Extensions {
     TextStyle,
     Color,
     // Mirror the live editor's schema-touching marks/attrs so a historical version renders
-    // faithfully (SCHEMA_VERSION 5–8): font size + alignment + underline + super/sub-script.
+    // faithfully (SCHEMA_VERSION 5–8, 16): font size + font family + alignment + underline +
+    // super/sub-script. FontFamily is mirrored here too so a stored `fontFamily` attr renders in
+    // the read-only preview/diff even while the live toolbar entry is flag-gated off.
     FontSize,
+    FontFamily,
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
     Underline,
     Superscript,

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -80,19 +80,24 @@ const lowlight = createDocsLowlight()
 // Exported so the paste-gate can be exercised through the real ProseMirror plugin (not by
 // calling the sanitizer directly) in fontFamilyPaste.test.ts.
 export const LiveFontFamily = FontFamily.extend({
-  // Harden the `fontFamily` textStyle attribute so an EMPTY resolved family never writes an
-  // empty `fontFamily` key into the shared Y.Doc. The flag-off paste gate (transformPastedHTML
-  // below) strips the family from a `font` shorthand — `font: 14px Georgia` becomes
-  // `font-size: 14px` — but the surviving span still parses through FontFamily.parseHTML, and
-  // `element.style.fontFamily` on that span resolves to "" (empty string). Upstream's parseHTML
-  // returns that "" verbatim, and Tiptap treats it as a real attr value → the textStyle mark is
-  // stored as `fontFamily=""`. That empty key still "reaches" the Y.Doc, violating the strict
-  // flag-off invariant the three human reviewers gate on ("no fontFamily reaches Y.Doc via paste
-  // when flag off") even though renderHTML emits nothing for it. Normalizing an empty /
-  // whitespace-only resolution to null lets the attr default out entirely, so NO fontFamily key
-  // is ever serialized. This is universally correct (an empty font-family is never a meaningful
-  // value) and independent of the flag: a real family (flag on, or a stored font) is non-empty
-  // and passes through untouched, so the toolbar write path and round-trip stay intact.
+  // Harden the `fontFamily` textStyle attribute on the parse (write-from-HTML) path. Two jobs:
+  //
+  //  1. FLAG-OFF BACKSTOP. transformPastedHTML below strips font-family from pasted HTML, but
+  //     that textual pass keys on what it can see in the string. The authoritative gate is
+  //     here: parseHTML reads the *browser-resolved* `element.style.fontFamily`, so whatever
+  //     the CSSOM resolved a family to — including comment/escape/whitespace-encoded property
+  //     names that a purely textual strip might not model — is visible at this point. With the
+  //     write flag off we normalize that resolved family to null (the schema default), so NO
+  //     fontFamily value can reach the shared Y.Doc from any HTML parse, by construction. This
+  //     is a WRITE gate, not a read gate: collaborative round-trip loads from the Y.Doc (not
+  //     HTML parseHTML), and with the flag off no font is ever written to begin with, so there
+  //     is nothing legitimate to strip on read. When the flag is on this is a pass-through.
+  //  2. EMPTY→NULL (flag-on, universally correct). When the flag is on, a `font` shorthand whose
+  //     family the sanitizer removed (`font: 14px Georgia` → `font-size: 14px`) still parses
+  //     through here with `element.style.fontFamily === ""`; upstream would store that "" as a
+  //     real `fontFamily=""` key. An empty family is never meaningful, so we default it out to
+  //     null. A real family (flag on, or a stored font) is non-empty and passes through
+  //     untouched, so the toolbar write path and round-trip stay intact.
   addGlobalAttributes() {
     return (this.parent?.() ?? []).map((group) =>
       group.attributes && 'fontFamily' in group.attributes
@@ -103,6 +108,7 @@ export const LiveFontFamily = FontFamily.extend({
               fontFamily: {
                 ...group.attributes.fontFamily,
                 parseHTML: (element: HTMLElement) => {
+                  if (!FONT_FAMILY_ENABLED) return null // flag-off backstop: nothing reaches the Y.Doc
                   const family = (element.style.fontFamily ?? '').trim()
                   return family === '' ? null : family
                 },

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -80,6 +80,38 @@ const lowlight = createDocsLowlight()
 // Exported so the paste-gate can be exercised through the real ProseMirror plugin (not by
 // calling the sanitizer directly) in fontFamilyPaste.test.ts.
 export const LiveFontFamily = FontFamily.extend({
+  // Harden the `fontFamily` textStyle attribute so an EMPTY resolved family never writes an
+  // empty `fontFamily` key into the shared Y.Doc. The flag-off paste gate (transformPastedHTML
+  // below) strips the family from a `font` shorthand — `font: 14px Georgia` becomes
+  // `font-size: 14px` — but the surviving span still parses through FontFamily.parseHTML, and
+  // `element.style.fontFamily` on that span resolves to "" (empty string). Upstream's parseHTML
+  // returns that "" verbatim, and Tiptap treats it as a real attr value → the textStyle mark is
+  // stored as `fontFamily=""`. That empty key still "reaches" the Y.Doc, violating the strict
+  // flag-off invariant the three human reviewers gate on ("no fontFamily reaches Y.Doc via paste
+  // when flag off") even though renderHTML emits nothing for it. Normalizing an empty /
+  // whitespace-only resolution to null lets the attr default out entirely, so NO fontFamily key
+  // is ever serialized. This is universally correct (an empty font-family is never a meaningful
+  // value) and independent of the flag: a real family (flag on, or a stored font) is non-empty
+  // and passes through untouched, so the toolbar write path and round-trip stay intact.
+  addGlobalAttributes() {
+    return (this.parent?.() ?? []).map((group) =>
+      group.attributes && 'fontFamily' in group.attributes
+        ? {
+            ...group,
+            attributes: {
+              ...group.attributes,
+              fontFamily: {
+                ...group.attributes.fontFamily,
+                parseHTML: (element: HTMLElement) => {
+                  const family = (element.style.fontFamily ?? '').trim()
+                  return family === '' ? null : family
+                },
+              },
+            },
+          }
+        : group,
+    )
+  },
   addProseMirrorPlugins() {
     return [
       ...(this.parent?.() ?? []),

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -50,9 +50,11 @@ import type { HocuspocusProvider } from '@hocuspocus/provider'
 // editor and the read-only preview pick up the math typography.
 import 'katex/dist/katex.min.css'
 
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { COLLAB_FIELD } from '../schema/index.ts'
+import { FONT_FAMILY_ENABLED } from '../config.ts'
 import { colorFromId, type OctoAwarenessUser } from '../awareness/presence.ts'
-import { sanitizeLinkHref } from './sanitize.ts'
+import { sanitizeLinkHref, stripPastedFontFamily } from './sanitize.ts'
 import { SlashCommand } from './SlashCommand.ts'
 import { FindReplace } from './findReplace.ts'
 import CharacterCount from '@tiptap/extension-character-count'
@@ -65,6 +67,30 @@ export function createDocsLowlight() {
 }
 
 const lowlight = createDocsLowlight()
+
+// SCHEMA_VERSION 16: FontFamily is registered UNCONDITIONALLY (schema must always know the
+// `fontFamily` textStyle attr so this bundle round-trips stored fonts faithfully). But the
+// FONT_FAMILY_ENABLED flag must gate every WRITE path, not just the toolbar selector. Paste is
+// the second write path: FontFamily.parseHTML(element.style.fontFamily) runs on pasted HTML
+// regardless of the flag, so a `<span style="font-family:…">` pasted from Word/browser would
+// land fontFamily in the shared Y.Doc while the flag is off — an older client (no attr in its
+// schema) opening the same doc then silently strips it (data loss). This paste guard strips the
+// inline font-family from pasted HTML while the flag is off; parsing/rendering already-stored
+// content is untouched (round-trip stays intact). When the flag is on, the transform is identity.
+const LiveFontFamily = FontFamily.extend({
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        key: new PluginKey('fontFamilyPasteGate'),
+        props: {
+          transformPastedHTML: (html) =>
+            FONT_FAMILY_ENABLED ? html : stripPastedFontFamily(html),
+        },
+      }),
+    ]
+  },
+})
 
 export interface BuildExtensionsOptions {
   ydoc: Y.Doc
@@ -124,7 +150,9 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // round-trips fonts faithfully and never strips them; the toolbar *entry* is what the
     // FONT_FAMILY_ENABLED flag gates (Toolbar.tsx), not the schema. This is the byte-aligned
     // counterpart of the backend fontFamily attr under the shared SCHEMA_VERSION 16 contract.
-    FontFamily,
+    // Uses LiveFontFamily (FontFamily + a paste-write gate) so the FONT_FAMILY_ENABLED flag
+    // also covers the paste write path, not just the toolbar selector — see LiveFontFamily above.
+    LiveFontFamily,
     // heading + paragraph nodes (not a new node/mark) → style="text-align:…". Configured for
     // exactly those two types so lists/tables/etc. keep their own layout.
     TextAlign.configure({ types: ['heading', 'paragraph'] }),

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -77,7 +77,9 @@ const lowlight = createDocsLowlight()
 // schema) opening the same doc then silently strips it (data loss). This paste guard strips the
 // inline font-family from pasted HTML while the flag is off; parsing/rendering already-stored
 // content is untouched (round-trip stays intact). When the flag is on, the transform is identity.
-const LiveFontFamily = FontFamily.extend({
+// Exported so the paste-gate can be exercised through the real ProseMirror plugin (not by
+// calling the sanitizer directly) in fontFamilyPaste.test.ts.
+export const LiveFontFamily = FontFamily.extend({
   addProseMirrorPlugins() {
     return [
       ...(this.parent?.() ?? []),

--- a/packages/docs/src/editor/fontFamilies.ts
+++ b/packages/docs/src/editor/fontFamilies.ts
@@ -1,0 +1,24 @@
+/**
+ * Font-family presets for the toolbar dropdown (SCHEMA_VERSION 16).
+ *
+ * `value` is written verbatim into the textStyle `fontFamily` attr → `style="font-family:…"`.
+ * Each value carries a generic fallback so glyphs still render if the primary face is absent, and
+ * the CJK faces keep their localized family-name alias (e.g. `"微软雅黑"`, `"宋体"`) so browsers
+ * that only know the font by its Chinese name still match it. These CSS values are font resource
+ * identifiers that MUST byte-match the native font names — they are NOT translatable UI copy, so
+ * this module is listed in `.i18n/scan-config.json` (mirroring `export/docx/styles.ts`).
+ *
+ * The user-facing display name is driven by `labelKey`, an i18n key resolved via `t()` at render
+ * time so the dropdown localizes correctly (zh-CN shows the Chinese face name, en-US the romanized
+ * family name; Latin faces read the same in both locales).
+ */
+export const FONT_FAMILIES = [
+  { labelKey: 'docs.toolbar.font.yahei', value: '"Microsoft YaHei", "微软雅黑", sans-serif' },
+  { labelKey: 'docs.toolbar.font.simsun', value: 'SimSun, "宋体", serif' },
+  { labelKey: 'docs.toolbar.font.simhei', value: 'SimHei, "黑体", sans-serif' },
+  { labelKey: 'docs.toolbar.font.kaiti', value: 'KaiTi, "楷体", serif' },
+  { labelKey: 'docs.toolbar.font.arial', value: 'Arial, Helvetica, sans-serif' },
+  { labelKey: 'docs.toolbar.font.timesNewRoman', value: '"Times New Roman", Times, serif' },
+  { labelKey: 'docs.toolbar.font.georgia', value: 'Georgia, serif' },
+  { labelKey: 'docs.toolbar.font.courierNew', value: '"Courier New", Courier, monospace' },
+] as const

--- a/packages/docs/src/editor/fontFamilies.verify.test.ts
+++ b/packages/docs/src/editor/fontFamilies.verify.test.ts
@@ -42,7 +42,7 @@ describe('FONT_FAMILIES i18n refactor (XIN-936)', () => {
   })
 
   it('applies a selected value to the textStyle fontFamily attr and serializes it to the DOM', () => {
-    const schema = getSchema(buildPreviewExtensions())
+    const schema = getSchema(buildPreviewExtensions('doc-test'))
     const simhei = FONT_FAMILIES.find((f) => f.labelKey === 'docs.toolbar.font.simhei')!.value
     const textStyle = schema.marks.textStyle.create({ fontFamily: simhei })
     const doc = schema.node('doc', null, [

--- a/packages/docs/src/editor/fontFamilies.verify.test.ts
+++ b/packages/docs/src/editor/fontFamilies.verify.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { getSchema } from '@tiptap/core'
+import { DOMSerializer } from '@tiptap/pm/model'
+import { buildPreviewExtensions } from './extensions.ts'
+import { FONT_FAMILIES } from './fontFamilies.ts'
+import zhCN from '../i18n/zh-CN.json'
+import enUS from '../i18n/en-US.json'
+
+// VERIFY (XIN-936): after moving the font display names onto i18n keys, prove that (a) the CSS
+// font-family *values* are byte-unchanged and still reach the DOM as `font-family:…`, and (b)
+// every labelKey resolves in both locales. This is the red→green check behind the i18n refactor.
+
+function resolve(bundle: Record<string, unknown>, key: string): string | undefined {
+  // Keys are `docs.toolbar.font.x`; the JSON is registered under the `docs` namespace, so the
+  // stored path drops the leading `docs.`.
+  const path = key.replace(/^docs\./, '').split('.')
+  let cur: unknown = bundle
+  for (const seg of path) {
+    if (cur && typeof cur === 'object') cur = (cur as Record<string, unknown>)[seg]
+    else return undefined
+  }
+  return typeof cur === 'string' ? cur : undefined
+}
+
+describe('FONT_FAMILIES i18n refactor (XIN-936)', () => {
+  it('keeps the CSS font-family values byte-identical to the SCHEMA_VERSION 16 spec', () => {
+    const byKey = Object.fromEntries(FONT_FAMILIES.map((f) => [f.labelKey, f.value]))
+    expect(byKey['docs.toolbar.font.yahei']).toBe('"Microsoft YaHei", "微软雅黑", sans-serif')
+    expect(byKey['docs.toolbar.font.simsun']).toBe('SimSun, "宋体", serif')
+    expect(byKey['docs.toolbar.font.simhei']).toBe('SimHei, "黑体", sans-serif')
+    expect(byKey['docs.toolbar.font.kaiti']).toBe('KaiTi, "楷体", serif')
+  })
+
+  it('resolves every labelKey in both zh-CN and en-US', () => {
+    for (const { labelKey } of FONT_FAMILIES) {
+      expect(resolve(zhCN, labelKey), `${labelKey} zh-CN`).toBeTruthy()
+      expect(resolve(enUS, labelKey), `${labelKey} en-US`).toBeTruthy()
+    }
+    // Sanity: the CJK faces localize (zh shows the Chinese name, en the romanized family name).
+    expect(resolve(zhCN, 'docs.toolbar.font.simhei')).toBe('黑体')
+    expect(resolve(enUS, 'docs.toolbar.font.simhei')).toBe('SimHei')
+  })
+
+  it('applies a selected value to the textStyle fontFamily attr and serializes it to the DOM', () => {
+    const schema = getSchema(buildPreviewExtensions())
+    const simhei = FONT_FAMILIES.find((f) => f.labelKey === 'docs.toolbar.font.simhei')!.value
+    const textStyle = schema.marks.textStyle.create({ fontFamily: simhei })
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('黑体样张', [textStyle])]),
+    ])
+    const out = DOMSerializer.fromSchema(schema).serializeFragment(doc.content, {
+      document: window.document,
+    })
+    const holder = window.document.createElement('div')
+    holder.appendChild(out)
+    expect(holder.innerHTML).toContain('font-family')
+    expect(holder.innerHTML).toContain('SimHei')
+    expect(holder.innerHTML).toContain('黑体')
+  })
+})

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -1,8 +1,4 @@
-import { describe, it, expect } from 'vitest'
-import { getSchema } from '@tiptap/core'
-import { DOMParser as PMDOMParser, type Node as PMNode } from '@tiptap/pm/model'
-import StarterKit from '@tiptap/starter-kit'
-import { TextStyle, FontFamily } from '@tiptap/extension-text-style'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { stripPastedFontFamily } from './sanitize.ts'
 
 // FONT_FAMILY_ENABLED (config.ts) must gate every WRITE path while it is off, not just the
@@ -12,31 +8,6 @@ import { stripPastedFontFamily } from './sanitize.ts'
 // copied from Word/browser would write fontFamily into the shared Y.Doc, and an older client
 // whose schema lacks the attr would silently strip it (data loss). stripPastedFontFamily is the
 // flag-off transform; when the flag is on the caller skips it and the font is preserved.
-
-// The exact schema-touching pair for this attr: textStyle carries the fontFamily global attr.
-const schema = getSchema([
-  StarterKit.configure({ undoRedo: false, codeBlock: false }),
-  TextStyle,
-  FontFamily,
-])
-
-/** Parse an HTML fragment into a doc and return the fontFamily of the first textStyle mark. */
-function pastedFontFamily(html: string): string | null | undefined {
-  const container = document.createElement('div')
-  container.innerHTML = html
-  const doc = PMDOMParser.fromSchema(schema).parse(container)
-  let found: string | null | undefined
-  doc.descendants((node: PMNode) => {
-    const mark = node.marks.find((m) => m.type.name === 'textStyle')
-    if (mark && found === undefined) found = (mark.attrs.fontFamily as string | null) ?? null
-  })
-  // No textStyle mark, an explicit null, OR an empty string all mean "no font family was
-  // written". The shorthand path keeps font-size, so the span retains a style attr and a
-  // textStyle mark is still created — its fontFamily resolves to '' (falsy), which is the
-  // absence of a font choice, not a leaked family. Normalize '' → null so the assertion
-  // reflects that no real family reached the doc.
-  return found || null
-}
 
 describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
   it('removes the inline font-family declaration', () => {
@@ -93,9 +64,7 @@ describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
   })
 
   it('handles an uppercase `FONT` shorthand and sibling declarations', () => {
-    const out = stripPastedFontFamily(
-      '<span style="color: red; FONT: 16px Arial">x</span>',
-    )
+    const out = stripPastedFontFamily('<span style="color: red; FONT: 16px Arial">x</span>')
     expect(out).not.toMatch(/arial/i)
     expect(out).toMatch(/color:\s*red/i)
     expect(out).toMatch(/font-size:\s*16px/i)
@@ -108,28 +77,98 @@ describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
   })
 })
 
-describe('paste write path — fontFamily gating end to end', () => {
-  const pasted = '<span style="font-family: Georgia, serif">styled</span>'
+// End-to-end through the REAL paste path. Rather than call stripPastedFontFamily directly, this
+// builds a live editor with the actual LiveFontFamily extension and pushes clipboard HTML through
+// ProseMirror's `transformPastedHTML` aggregation — the same hook the plugin registers — so the
+// FONT_FAMILY_ENABLED branch inside the plugin is what decides whether the sanitizer runs.
+// FONT_FAMILY_ENABLED is resolved from import.meta.env at module load (config.ts), so each flag
+// value stubs the env, resets the module cache, and re-imports the whole editor module graph fresh
+// (one consistent prosemirror/tiptap instance) before constructing the editor.
+async function pasteThroughEditor(
+  html: string,
+  flagOn: boolean,
+): Promise<{ family: string | null; size: string | null }> {
+  vi.resetModules()
+  vi.stubEnv('VITE_DOCS_FONT_FAMILY', flagOn ? 'true' : 'false')
 
-  it('flag ON (no sanitizer): pasted font-family survives into the doc (no false strip)', () => {
-    // FONT_FAMILY_ENABLED === true → the plugin transform is identity, so the raw HTML is parsed.
-    expect(pastedFontFamily(pasted)).toBe('Georgia, serif')
+  const [{ Editor }, starterKitMod, textStyleMod, ext] = await Promise.all([
+    import('@tiptap/core'),
+    import('@tiptap/starter-kit'),
+    import('@tiptap/extension-text-style'),
+    import('./extensions.ts'),
+  ])
+  const StarterKit = starterKitMod.default
+  const { TextStyle, FontSize } = textStyleMod
+  const { LiveFontFamily } = ext
+
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      StarterKit.configure({ undoRedo: false, codeBlock: false }),
+      TextStyle,
+      FontSize,
+      LiveFontFamily,
+    ],
+    content: '<p></p>',
   })
 
-  it('flag OFF (sanitizer runs): pasted font-family never reaches the doc', () => {
-    // FONT_FAMILY_ENABLED === false → the plugin applies stripPastedFontFamily before PM parses.
-    expect(pastedFontFamily(stripPastedFontFamily(pasted))).toBe(null)
+  try {
+    // Grab the real paste-gate plugin LiveFontFamily.addProseMirrorPlugins() registered on the
+    // live editor and invoke its transformPastedHTML — the exact hook (and FONT_FAMILY_ENABLED
+    // branch) ProseMirror runs on a paste. It is the only registered plugin carrying this prop.
+    const gate = editor.view.state.plugins.find(
+      (p) => typeof p.props?.transformPastedHTML === 'function',
+    )
+    expect(gate, 'LiveFontFamily should register a transformPastedHTML paste-gate plugin').toBeTruthy()
+    const transformed = gate!.props.transformPastedHTML!.call(gate!, html, editor.view) ?? html
+    editor.commands.setContent(transformed)
+
+    let family: string | null = null
+    let size: string | null = null
+    editor.state.doc.descendants((node) => {
+      const mark = node.marks.find((m) => m.type.name === 'textStyle')
+      if (mark) {
+        // '' (an empty resolved fontFamily, e.g. a span that only kept font-size) means no font
+        // was chosen — normalize it to null so the assertion tracks a real family, not a shell.
+        family = family || ((mark.attrs.fontFamily as string | null) || null)
+        size = size || ((mark.attrs.fontSize as string | null) || null)
+      }
+    })
+    return { family, size }
+  } finally {
+    editor.destroy()
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('paste write path — LiveFontFamily plugin + FONT_FAMILY_ENABLED gating', () => {
+  const longhand = '<span style="font-family: Georgia, serif">styled</span>'
+  const shorthand = '<span style="font: 14px Georgia">styled</span>'
+
+  it('flag ON: a pasted font-family longhand survives into the doc (transform is identity)', async () => {
+    const { family } = await pasteThroughEditor(longhand, true)
+    expect(family).toBe('Georgia, serif')
   })
 
-  // RC2: the `font` shorthand path — the browser/jsdom CSSOM expands `font: 14px Georgia`
-  // into element.style.fontFamily === "Georgia", so without gating it leaks into the doc.
-  const pastedShorthand = '<span style="font: 14px Georgia">styled</span>'
-
-  it('flag ON (no sanitizer): a `font` shorthand family survives into the doc', () => {
-    expect(pastedFontFamily(pastedShorthand)).toBe('Georgia')
+  it('flag OFF: a pasted font-family longhand never reaches the doc', async () => {
+    const { family } = await pasteThroughEditor(longhand, false)
+    expect(family).toBe(null)
   })
 
-  it('flag OFF (sanitizer runs): a `font` shorthand family never reaches the doc', () => {
-    expect(pastedFontFamily(stripPastedFontFamily(pastedShorthand))).toBe(null)
+  // RC2: the browser/jsdom CSSOM expands `font: 14px Georgia` into element.style.fontFamily ===
+  // "Georgia", so the shorthand is a fontFamily write path the gate must also cover.
+  it('flag ON: a `font` shorthand family survives, and font-size is preserved', async () => {
+    const { family, size } = await pasteThroughEditor(shorthand, true)
+    expect(family).toBe('Georgia')
+    expect(size).toBe('14px')
+  })
+
+  it('flag OFF: a `font` shorthand family is gated out, but font-size is not harmed', async () => {
+    const { family, size } = await pasteThroughEditor(shorthand, false)
+    expect(family).toBe(null)
+    expect(size).toBe('14px')
   })
 })

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -96,6 +96,50 @@ describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
     expect(out).toContain('x')
   })
 
+  // RC (yujiawei variant, OctoBoooot real-Chrome byte-verified @ d7f0edae): a CSS COMMENT in the
+  // property NAME defeated the old raw-name string compare (`prop === 'font-family'`) while the
+  // CSSOM strips the comment and still resolves the family → leak with the flag off. The gate now
+  // decides on the resolved property (comment stripped in name normalization), so it is covered.
+  it('strips a font-family whose name carries a trailing CSS comment (font-family/**/:)', () => {
+    const out = stripPastedFontFamily('<span style="font-family/**/:Georgia">x</span>')
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toContain('x')
+  })
+
+  it('strips a font-family whose name carries a leading CSS comment (/**/font-family:)', () => {
+    const out = stripPastedFontFamily('<span style="/**/font-family:Georgia">x</span>')
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toContain('x')
+  })
+
+  it('strips a `font` shorthand whose name carries a CSS comment, keeping font-size', () => {
+    const out = stripPastedFontFamily('<span style="color: red; font/**/:14px Georgia">x</span>')
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toMatch(/color:\s*red/i)
+    expect(out).toMatch(/font-size:\s*14px/i)
+  })
+
+  // RC (Jerry-Xin standing 🔴 from a6ac93f): a CSS ESCAPE in the property NAME likewise defeated
+  // the raw-name compare while a browser's CSSOM decodes the escape and resolves the family. The
+  // name normalization decodes identifier escapes (`\-` → '-', `\66 ` → 'f') so the resolved
+  // property is `font-family` and the declaration is dropped. (Note: jsdom's cssstyle does NOT
+  // decode escapes in property names, so this variant's leak is real-browser-only and cannot be
+  // reproduced through the CSSOM/Y.Doc path in this test env — it is closed here by construction
+  // at the string level, and by the flag-off parseHTML backstop at runtime.)
+  it('strips a font-family whose hyphen is CSS-escaped (font\\-family:)', () => {
+    const out = stripPastedFontFamily('<span style="font\\-family:Georgia">x</span>')
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toContain('x')
+  })
+
+  it('strips a font-family whose leading char is CSS hex-escaped (\\66 ont-family:)', () => {
+    const out = stripPastedFontFamily('<span style="\\66 ont-family:Georgia">x</span>')
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toContain('x')
+  })
+
   // RC (yujiawei P1 @ 58e999d0): ReDoS regression on the default flag-off paste path. The old
   // FONT_SIZE_LENGTH pattern (`\d+\.?\d*`) backtracked O(n²) on a long all-digit token, freezing
   // the main thread (~11s at 80k, ~73s at 200k). The unambiguous pattern + length cap keep it
@@ -328,6 +372,51 @@ describe('strict flag-off Y.Doc invariant — no fontFamily value from a pasted 
     const { xml } = await pasteIntoYDocFragment(shorthand, true)
     expect(xml).toMatch(/fontFamily="Georgia"/)
     expect(xml).toMatch(/fontSize="14px"/)
+  })
+})
+
+// CSS-comment bypass, driven end-to-end through the REAL y-prosemirror binding. jsdom's CSSOM
+// (like a real browser) strips a comment in the property name and resolves the family, so the old
+// raw-name string compare leaked these into the shared Y.Doc with the flag off. Both boundary
+// variants the RC calls out — `font-family/**/:` and `/**/font-family:` — plus the `font/**/:`
+// shorthand are asserted to write NO fontFamily value flag-off, and to still write it flag-on
+// (proving the fix is a write gate, not a read gate).
+describe('flag-off Y.Doc invariant — CSS-comment property-name bypass', () => {
+  const commentTrailing = '<span style="font-family/**/:Georgia, serif">styled</span>'
+  const commentLeading = '<span style="/**/font-family:Georgia, serif">styled</span>'
+  const commentShorthand = '<span style="font/**/:14px Georgia">styled</span>'
+
+  it('flag OFF: a trailing-comment font-family name writes NO fontFamily value into the Y.Doc', async () => {
+    const { xml, markAttrs } = await pasteIntoYDocFragment(commentTrailing, false)
+    expect(xml).not.toContain('fontFamily=""')
+    expect(xml).not.toMatch(/fontFamily="(?!null")[^"]/i)
+    for (const attrs of markAttrs) {
+      expect(attrs.fontFamily, `fontFamily should be null, got ${JSON.stringify(attrs.fontFamily)}`).toBeNull()
+    }
+  })
+
+  it('flag OFF: a leading-comment font-family name writes NO fontFamily value into the Y.Doc', async () => {
+    const { xml, markAttrs } = await pasteIntoYDocFragment(commentLeading, false)
+    expect(xml).not.toContain('fontFamily=""')
+    expect(xml).not.toMatch(/fontFamily="(?!null")[^"]/i)
+    for (const attrs of markAttrs) {
+      expect(attrs.fontFamily, `fontFamily should be null, got ${JSON.stringify(attrs.fontFamily)}`).toBeNull()
+    }
+  })
+
+  it('flag OFF: a comment-in-name `font` shorthand leaks no family but keeps its size', async () => {
+    const { xml, markAttrs } = await pasteIntoYDocFragment(commentShorthand, false)
+    expect(xml).not.toMatch(/fontFamily="(?!null")[^"]/i)
+    expect(xml).not.toContain('fontFamily=""')
+    expect(xml).toMatch(/fontSize="14px"/)
+    for (const attrs of markAttrs) {
+      expect(attrs.fontFamily).toBeNull()
+    }
+  })
+
+  it('flag ON: the trailing-comment font-family still resolves and reaches the Y.Doc (not a read gate)', async () => {
+    const { xml } = await pasteIntoYDocFragment(commentTrailing, true)
+    expect(xml).toMatch(/fontFamily="Georgia, serif"/)
   })
 })
 

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -75,6 +75,39 @@ describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
     const out = stripPastedFontFamily(html)
     expect(out).toMatch(/font-size:\s*18px/i)
   })
+
+  // RC (Jerry-Xin / OctoBoooot / yujiawei @ 58e999d0): the old raw-HTML fast-path guard
+  // (`/font(-family)?\s*:/i.test(html)`) tested the clipboard string BEFORE the parser
+  // entity-decodes it. An entity-encoded colon carries no literal `font-family:` in the raw
+  // string, so the guard early-returned unchanged — but after parse `element.style.fontFamily`
+  // resolves to the family and leaks into the shared Y.Doc with the flag off. The strip now
+  // always walks the parsed DOM (getAttribute('style') is entity-decoded), so it is covered.
+  it('strips a font-family hidden behind an entity-encoded colon (&#58;)', () => {
+    const out = stripPastedFontFamily('<span style="font-family&#58;Georgia">x</span>')
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toContain('x')
+  })
+
+  it('strips a `font` shorthand family hidden behind a hex entity colon (&#x3a;)', () => {
+    const out = stripPastedFontFamily('<span style="font&#x3a;14px Arial">x</span>')
+    expect(out).not.toMatch(/arial/i)
+    expect(out).toMatch(/font-size:\s*14px/i)
+    expect(out).toContain('x')
+  })
+
+  // RC (yujiawei P1 @ 58e999d0): ReDoS regression on the default flag-off paste path. The old
+  // FONT_SIZE_LENGTH pattern (`\d+\.?\d*`) backtracked O(n²) on a long all-digit token, freezing
+  // the main thread (~11s at 80k, ~73s at 200k). The unambiguous pattern + length cap keep it
+  // instant. Bound is generous (real font-size tokens are tiny); pre-fix this took tens of seconds.
+  it('does not backtrack (ReDoS) on a huge digit run in a `font` shorthand', () => {
+    const huge = '<span style="font: ' + '1'.repeat(200000) + 'zz Arial">x</span>'
+    const start = performance.now()
+    const out = stripPastedFontFamily(huge)
+    const elapsed = performance.now() - start
+    expect(elapsed).toBeLessThan(1000)
+    expect(out).not.toMatch(/arial/i)
+  })
 })
 
 // End-to-end through the REAL paste path. Rather than call stripPastedFontFamily directly, this
@@ -170,5 +203,19 @@ describe('paste write path — LiveFontFamily plugin + FONT_FAMILY_ENABLED gatin
     const { family, size } = await pasteThroughEditor(shorthand, false)
     expect(family).toBe(null)
     expect(size).toBe('14px')
+  })
+
+  // RC @ 58e999d0: an entity-encoded colon must not let a pasted font-family slip past the gate
+  // into the shared Y.Doc while the flag is off. Driven end-to-end through the real plugin.
+  const entityLonghand = '<span style="font-family&#58;Georgia, serif">styled</span>'
+
+  it('flag OFF: an entity-colon font-family never reaches the doc', async () => {
+    const { family } = await pasteThroughEditor(entityLonghand, false)
+    expect(family).toBe(null)
+  })
+
+  it('flag ON: the same entity-colon font-family resolves and survives (parser decodes it)', async () => {
+    const { family } = await pasteThroughEditor(entityLonghand, true)
+    expect(family).toBe('Georgia, serif')
   })
 })

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { getSchema } from '@tiptap/core'
+import { DOMParser as PMDOMParser, type Node as PMNode } from '@tiptap/pm/model'
+import StarterKit from '@tiptap/starter-kit'
+import { TextStyle, FontFamily } from '@tiptap/extension-text-style'
+import { stripPastedFontFamily } from './sanitize.ts'
+
+// FONT_FAMILY_ENABLED (config.ts) must gate every WRITE path while it is off, not just the
+// toolbar selector. Paste is the second write path: FontFamily is registered unconditionally
+// (so old docs round-trip), and its parseHTML reads element.style.fontFamily on pasted HTML no
+// matter the flag. If the flag-off paste kept font-family, a `<span style="font-family:…">`
+// copied from Word/browser would write fontFamily into the shared Y.Doc, and an older client
+// whose schema lacks the attr would silently strip it (data loss). stripPastedFontFamily is the
+// flag-off transform; when the flag is on the caller skips it and the font is preserved.
+
+// The exact schema-touching pair for this attr: textStyle carries the fontFamily global attr.
+const schema = getSchema([
+  StarterKit.configure({ undoRedo: false, codeBlock: false }),
+  TextStyle,
+  FontFamily,
+])
+
+/** Parse an HTML fragment into a doc and return the fontFamily of the first textStyle mark. */
+function pastedFontFamily(html: string): string | null | undefined {
+  const container = document.createElement('div')
+  container.innerHTML = html
+  const doc = PMDOMParser.fromSchema(schema).parse(container)
+  let found: string | null | undefined
+  doc.descendants((node: PMNode) => {
+    const mark = node.marks.find((m) => m.type.name === 'textStyle')
+    if (mark && found === undefined) found = (mark.attrs.fontFamily as string | null) ?? null
+  })
+  // No textStyle mark at all → the attr was never written, same as an explicit null.
+  return found ?? null
+}
+
+describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
+  it('removes the inline font-family declaration', () => {
+    const out = stripPastedFontFamily('<span style="font-family: Arial">hi</span>')
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).toContain('hi')
+  })
+
+  it('drops the style attribute entirely when font-family was its only declaration', () => {
+    const out = stripPastedFontFamily('<span style="font-family: Georgia">x</span>')
+    expect(out).not.toContain('style=')
+    expect(out).toContain('x')
+  })
+
+  it('keeps other inline styles while stripping only font-family', () => {
+    const out = stripPastedFontFamily(
+      '<span style="color: red; font-family: Georgia; font-size: 14px">x</span>',
+    )
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).toMatch(/color:\s*red/i)
+    expect(out).toMatch(/font-size:\s*14px/i)
+  })
+
+  it('handles multiple spans and mixed casing', () => {
+    const out = stripPastedFontFamily(
+      '<p><span style="FONT-FAMILY: Arial">a</span><span style="font-family:\'Times New Roman\'">b</span></p>',
+    )
+    expect(out).not.toMatch(/font-family/i)
+    expect(out).toContain('a')
+    expect(out).toContain('b')
+  })
+
+  it('is a no-op when there is no font-family to strip', () => {
+    const html = '<p><strong>bold</strong> and <em>italic</em></p>'
+    expect(stripPastedFontFamily(html)).toBe(html)
+  })
+})
+
+describe('paste write path — fontFamily gating end to end', () => {
+  const pasted = '<span style="font-family: Georgia, serif">styled</span>'
+
+  it('flag ON (no sanitizer): pasted font-family survives into the doc (no false strip)', () => {
+    // FONT_FAMILY_ENABLED === true → the plugin transform is identity, so the raw HTML is parsed.
+    expect(pastedFontFamily(pasted)).toBe('Georgia, serif')
+  })
+
+  it('flag OFF (sanitizer runs): pasted font-family never reaches the doc', () => {
+    // FONT_FAMILY_ENABLED === false → the plugin applies stripPastedFontFamily before PM parses.
+    expect(pastedFontFamily(stripPastedFontFamily(pasted))).toBe(null)
+  })
+})

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -161,8 +161,9 @@ async function pasteThroughEditor(
     editor.state.doc.descendants((node) => {
       const mark = node.marks.find((m) => m.type.name === 'textStyle')
       if (mark) {
-        // '' (an empty resolved fontFamily, e.g. a span that only kept font-size) means no font
-        // was chosen — normalize it to null so the assertion tracks a real family, not a shell.
+        // LiveFontFamily normalizes an empty resolved family to null (schema default), so a span
+        // that only kept font-size no longer carries a `fontFamily=""` shell. The `|| null` here
+        // is belt-and-suspenders — it keeps this helper tracking a real family, not an empty one.
         family = family || ((mark.attrs.fontFamily as string | null) || null)
         size = size || ((mark.attrs.fontSize as string | null) || null)
       }
@@ -219,3 +220,115 @@ describe('paste write path — LiveFontFamily plugin + FONT_FAMILY_ENABLED gatin
     expect(family).toBe('Georgia, serif')
   })
 })
+
+// Strict Y.Doc invariant (three human reviewers gate on it): with the flag off, a pasted `font`
+// shorthand must write NO fontFamily VALUE into the shared Y.Doc. The sanitizer strips the family
+// from `font: 14px Georgia` (→ `font-size: 14px`), but the surviving span still parses through
+// FontFamily.parseHTML, whose upstream reads element.style.fontFamily, resolves "" (empty string)
+// and stores it as `fontFamily=""` on the textStyle mark — an empty-but-written key that still
+// "reaches" the Y.Doc and trips the invariant. (fontFamily is registered UNCONDITIONALLY so the
+// schema always round-trips stored fonts, so the attr's schema DEFAULT — null — is present on
+// every textStyle mark regardless of the flag, exactly as it is for a plain flag-off `font-size`
+// paste; the invariant is about a WRITTEN value, not the schema default.) These tests drive the
+// paste end-to-end through the REAL Collaboration binding (y-prosemirror) and assert on the
+// serialized Y.Doc fragment: they fail on `fontFamily=""` and pass only when the attr sits at its
+// default, indistinguishable from a paste that never carried a font.
+async function pasteIntoYDocFragment(
+  html: string,
+  flagOn: boolean,
+): Promise<{ xml: string; markAttrs: Array<Record<string, unknown>> }> {
+  vi.resetModules()
+  vi.stubEnv('VITE_DOCS_FONT_FAMILY', flagOn ? 'true' : 'false')
+
+  const [{ Editor }, starterKitMod, textStyleMod, collabMod, ext, Y] = await Promise.all([
+    import('@tiptap/core'),
+    import('@tiptap/starter-kit'),
+    import('@tiptap/extension-text-style'),
+    import('@tiptap/extension-collaboration'),
+    import('./extensions.ts'),
+    import('yjs'),
+  ])
+  const StarterKit = starterKitMod.default
+  const { TextStyle, FontSize } = textStyleMod
+  const Collaboration = collabMod.default
+  const { LiveFontFamily } = ext
+  const ydoc = new Y.Doc()
+
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      StarterKit.configure({ undoRedo: false, codeBlock: false }),
+      TextStyle,
+      FontSize,
+      LiveFontFamily,
+      // The real collaborative binding: y-prosemirror mirrors the ProseMirror doc into this
+      // Y.Doc, so whatever value survives on the textStyle mark is exactly what reaches the Y.Doc.
+      Collaboration.configure({ document: ydoc, field: 'default' }),
+    ],
+  })
+
+  try {
+    const gate = editor.view.state.plugins.find(
+      (p) => typeof p.props?.transformPastedHTML === 'function',
+    )
+    const transformed = gate!.props.transformPastedHTML!.call(gate!, html, editor.view) ?? html
+    editor.commands.setContent(transformed)
+
+    // Raw (un-normalized) textStyle attrs, so an empty-string fontFamily is NOT hidden.
+    const markAttrs: Array<Record<string, unknown>> = []
+    editor.state.doc.descendants((node) => {
+      const mark = node.marks.find((m) => m.type.name === 'textStyle')
+      if (mark) markAttrs.push({ ...mark.attrs })
+    })
+    return { xml: ydoc.getXmlFragment('default').toString(), markAttrs }
+  } finally {
+    editor.destroy()
+  }
+}
+
+describe('strict flag-off Y.Doc invariant — no fontFamily value from a pasted `font` shorthand', () => {
+  const shorthand = '<span style="font: 14px Georgia">styled</span>'
+
+  it('flag OFF: the shorthand paste writes NO fontFamily value into the Y.Doc (not even an empty one)', async () => {
+    const { xml, markAttrs } = await pasteIntoYDocFragment(shorthand, false)
+    // The bug signature — an empty, but WRITTEN, fontFamily — must be gone from the Y.Doc …
+    expect(xml).not.toContain('fontFamily=""')
+    // … and no real family may leak either.
+    expect(xml).not.toMatch(/fontFamily="(?!null")[^"]/i)
+    // font-size must survive (we gate the family out, not the size).
+    expect(xml).toMatch(/fontSize="14px"/)
+    // The textStyle mark must carry fontFamily at its schema DEFAULT (null), never a string — an
+    // empty string "" is the bug, a family name is a leak; only null means "no font was written".
+    for (const attrs of markAttrs) {
+      expect(attrs.fontFamily, `fontFamily should be null, got ${JSON.stringify(attrs.fontFamily)}`).toBeNull()
+    }
+  })
+
+  it('flag OFF: the shorthand paste is indistinguishable in the Y.Doc from a plain `font-size` paste', async () => {
+    // Proves the family truly never reached the Y.Doc: the shorthand (family stripped, size kept)
+    // serializes to exactly the same fragment as a paste that only ever carried a font-size, so
+    // the fontFamily attr sits at its unconditional-registration default in both — nothing extra.
+    const { xml: fromShorthand } = await pasteIntoYDocFragment(shorthand, false)
+    const { xml: fromPlainSize } = await pasteIntoYDocFragment(
+      '<span style="font-size: 14px">styled</span>',
+      false,
+    )
+    expect(fromShorthand).toBe(fromPlainSize)
+  })
+
+  // A malicious/degenerate shorthand with no parseable font-size (the ReDoS-style sample shape)
+  // is dropped whole by the sanitizer, so it leaves no textStyle mark and no fontFamily at all.
+  it('flag OFF: a shorthand with no parseable size leaves no textStyle mark (no fontFamily)', async () => {
+    const { xml, markAttrs } = await pasteIntoYDocFragment('<span style="font: Georgia">styled</span>', false)
+    expect(xml).not.toMatch(/fontFamily/i)
+    expect(markAttrs).toHaveLength(0)
+  })
+
+  it('flag ON: the same shorthand DOES write the family into the Y.Doc (round-trip intact)', async () => {
+    const { xml } = await pasteIntoYDocFragment(shorthand, true)
+    expect(xml).toMatch(/fontFamily="Georgia"/)
+    expect(xml).toMatch(/fontSize="14px"/)
+  })
+})
+
+

--- a/packages/docs/src/editor/fontFamilyPaste.test.ts
+++ b/packages/docs/src/editor/fontFamilyPaste.test.ts
@@ -30,8 +30,12 @@ function pastedFontFamily(html: string): string | null | undefined {
     const mark = node.marks.find((m) => m.type.name === 'textStyle')
     if (mark && found === undefined) found = (mark.attrs.fontFamily as string | null) ?? null
   })
-  // No textStyle mark at all → the attr was never written, same as an explicit null.
-  return found ?? null
+  // No textStyle mark, an explicit null, OR an empty string all mean "no font family was
+  // written". The shorthand path keeps font-size, so the span retains a style attr and a
+  // textStyle mark is still created — its fontFamily resolves to '' (falsy), which is the
+  // absence of a font choice, not a leaked family. Normalize '' → null so the assertion
+  // reflects that no real family reached the doc.
+  return found || null
 }
 
 describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
@@ -69,6 +73,39 @@ describe('stripPastedFontFamily — flag-off paste sanitizer', () => {
     const html = '<p><strong>bold</strong> and <em>italic</em></p>'
     expect(stripPastedFontFamily(html)).toBe(html)
   })
+
+  // RC2: the `font` shorthand (`font: 14px Georgia`) also populates element.style.fontFamily,
+  // so it must be stripped too — but keep the font-size/line-height it carries.
+  it('strips the family from a `font` shorthand while keeping font-size', () => {
+    const out = stripPastedFontFamily('<span style="font: 14px Georgia">x</span>')
+    expect(out).not.toMatch(/georgia/i)
+    expect(out).toMatch(/font-size:\s*14px/i)
+    expect(out).toContain('x')
+  })
+
+  it('keeps font-size and line-height from a full `font` shorthand, drops the family', () => {
+    const out = stripPastedFontFamily(
+      '<span style="font: italic bold 12px/1.5 &quot;Times New Roman&quot;">x</span>',
+    )
+    expect(out).not.toMatch(/times new roman/i)
+    expect(out).toMatch(/font-size:\s*12px/i)
+    expect(out).toMatch(/line-height:\s*1\.5/i)
+  })
+
+  it('handles an uppercase `FONT` shorthand and sibling declarations', () => {
+    const out = stripPastedFontFamily(
+      '<span style="color: red; FONT: 16px Arial">x</span>',
+    )
+    expect(out).not.toMatch(/arial/i)
+    expect(out).toMatch(/color:\s*red/i)
+    expect(out).toMatch(/font-size:\s*16px/i)
+  })
+
+  it('does not touch a `font-size` longhand (no false shorthand match)', () => {
+    const html = '<span style="font-size: 18px">x</span>'
+    const out = stripPastedFontFamily(html)
+    expect(out).toMatch(/font-size:\s*18px/i)
+  })
 })
 
 describe('paste write path — fontFamily gating end to end', () => {
@@ -82,5 +119,17 @@ describe('paste write path — fontFamily gating end to end', () => {
   it('flag OFF (sanitizer runs): pasted font-family never reaches the doc', () => {
     // FONT_FAMILY_ENABLED === false → the plugin applies stripPastedFontFamily before PM parses.
     expect(pastedFontFamily(stripPastedFontFamily(pasted))).toBe(null)
+  })
+
+  // RC2: the `font` shorthand path — the browser/jsdom CSSOM expands `font: 14px Georgia`
+  // into element.style.fontFamily === "Georgia", so without gating it leaks into the doc.
+  const pastedShorthand = '<span style="font: 14px Georgia">styled</span>'
+
+  it('flag ON (no sanitizer): a `font` shorthand family survives into the doc', () => {
+    expect(pastedFontFamily(pastedShorthand)).toBe('Georgia')
+  })
+
+  it('flag OFF (sanitizer runs): a `font` shorthand family never reaches the doc', () => {
+    expect(pastedFontFamily(stripPastedFontFamily(pastedShorthand))).toBe(null)
   })
 })

--- a/packages/docs/src/editor/sanitize.ts
+++ b/packages/docs/src/editor/sanitize.ts
@@ -78,3 +78,43 @@ export function renderLinkAttrs(href: string): { href: string | null; rel?: stri
   const safe = sanitizeLinkHref(href)
   return safe ? { href: safe, rel: 'noopener noreferrer' } : { href: null }
 }
+
+/**
+ * Strip inline `font-family` declarations from pasted HTML.
+ *
+ * Gates the paste WRITE path while FONT_FAMILY_ENABLED is off (config.ts): the flag
+ * exists so fontFamily stays unwritable until every client bundle carries the attr
+ * (version convergence). The toolbar selector is the first write path and is already
+ * flag-gated (Toolbar.tsx); paste is the second — a `<span style="font-family:…">`
+ * copied from Word/browser would otherwise be parsed by the (unconditionally
+ * registered) FontFamily extension and land in the shared Y.Doc, so an older client
+ * whose schema lacks the attr would silently strip it → data loss.
+ *
+ * This removes ONLY the inline `font-family` style — exactly what FontFamily.parseHTML
+ * reads (`element.style.fontFamily`) — leaving all other markup, styles, and text
+ * intact. It touches the paste path ONLY: parsing/rendering already-stored fonts
+ * (round-trip, opening old docs) is unaffected, so the flag stays a write gate, not a
+ * read gate. When the flag is on, callers skip this and pasted fonts are preserved.
+ */
+export function stripPastedFontFamily(html: string): string {
+  if (typeof document === 'undefined' || !/font-family/i.test(html)) return html
+  try {
+    const parsed = new DOMParser().parseFromString(html, 'text/html')
+    parsed.querySelectorAll('[style]').forEach((el) => {
+      const style = el.getAttribute('style') ?? ''
+      // Rebuild the inline style without any `font-family` declaration. Work on the raw
+      // attribute string (not the CSSOM) so an upper/mixed-case `FONT-FAMILY` — which a
+      // browser normalizes and reads, but jsdom's CSSOM does not — is stripped too.
+      const kept = style
+        .split(';')
+        .filter((decl) => decl.trim() && decl.split(':', 1)[0].trim().toLowerCase() !== 'font-family')
+        .map((decl) => decl.trim())
+        .join('; ')
+      if (kept) el.setAttribute('style', kept)
+      else el.removeAttribute('style')
+    })
+    return parsed.body.innerHTML
+  } catch {
+    return html
+  }
+}

--- a/packages/docs/src/editor/sanitize.ts
+++ b/packages/docs/src/editor/sanitize.ts
@@ -95,9 +95,15 @@ export function renderLinkAttrs(href: string): { href: string | null; rel?: stri
  *   1. the `font-family` longhand (`font-family: Georgia`), and
  *   2. the `font` shorthand (`font: 14px Georgia`), whose family component the browser
  *      (and jsdom's CSSOM) expands into `element.style.fontFamily` just the same.
- * The shorthand path was the RC miss: stripping only the longhand let a
- * `<span style="font: 14px Georgia">` copied from Word/browser still write fontFamily
- * into the Y.Doc while the flag was off.
+ * The shorthand path was one RC miss; keying the strip on a raw property-NAME byte compare
+ * was the deeper one. That compare is defeated by any writing the CSSOM normalizes away but
+ * the raw bytes differ on — a CSS comment in the name (`font-family/**​/:`, `/**​/font-family:`),
+ * a CSS escape (`font\-family:`, `\66 ont-family:`), or odd casing/whitespace — while the
+ * browser still resolves the family and leaks it into the Y.Doc with the flag off. The strip
+ * now decides on the RESOLVED property (a modelled name normalization plus the real CSSOM),
+ * not the raw name, so every CSSOM-equivalent variant is covered by construction. It is
+ * paired with a flag-off `parseHTML` backstop in LiveFontFamily (extensions.ts) that nulls
+ * any browser-resolved family regardless — the last line if a novel encoding still slips by.
  *
  * All other markup, styles, and text stay intact. It touches the paste path ONLY:
  * parsing/rendering already-stored fonts (round-trip, opening old docs) is unaffected,
@@ -115,12 +121,26 @@ export function stripPastedFontFamily(html: string): string {
   if (typeof document === 'undefined') return html
   try {
     const parsed = new DOMParser().parseFromString(html, 'text/html')
+    // One reusable probe element for the CSSOM-resolved signal (see declSetsFontFamily).
+    const probe = document.createElement('span')
     parsed.querySelectorAll('[style]').forEach((el) => {
       const style = el.getAttribute('style') ?? ''
       // Rebuild the inline style declaration-by-declaration, dropping every font-family
-      // source. Work on the raw attribute string (not the CSSOM) so an upper/mixed-case
-      // `FONT-FAMILY` / `FONT` — which a browser normalizes and reads, but jsdom's CSSOM
-      // does not surface when reading a specific longhand — is handled too.
+      // source. The decision is made on the *resolved* property, never on a raw byte
+      // compare of the attribute name — that byte compare was the whole bug class here,
+      // defeated in turn by an entity-colon, a CSS comment, a CSS escape, or odd casing,
+      // while the browser's CSSOM resolved the family all the same. We combine two
+      // resolved signals and drop if EITHER fires:
+      //   (A) normalizeCssPropName() — models how the CSS parser reads a property NAME
+      //       (strip comments, decode identifier escapes, drop whitespace, lowercase), so
+      //       `font-family/**​/`, `/**​/font-family`, `font\-family`, and `FONT-FAMILY` all
+      //       resolve to `font-family`. This is the signal jsdom can evaluate for casing
+      //       and escapes, which its CSSOM does not surface.
+      //   (B) declSetsFontFamily() — feeds the declaration through the real CSSOM and asks
+      //       whether font-family ended up set. This is the browser's own answer, covering
+      //       any encoding the name normalizer above did not model.
+      // Erring toward removal is safe for a paste gate; the LiveFontFamily parseHTML
+      // backstop (flag-off → null) is the final guarantee for anything that still slips by.
       const kept = style
         .split(';')
         .map((decl) => decl.trim())
@@ -128,10 +148,16 @@ export function stripPastedFontFamily(html: string): string {
         .map((decl) => {
           const colon = decl.indexOf(':')
           if (colon === -1) return decl // malformed fragment: leave as-is (carries no family)
-          const prop = decl.slice(0, colon).trim().toLowerCase()
-          if (prop === 'font-family') return null // longhand: drop the whole declaration
-          if (prop === 'font') return keptFromFontShorthand(decl.slice(colon + 1)) // shorthand
-          return decl
+          const value = decl.slice(colon + 1)
+          const name = normalizeCssPropName(decl.slice(0, colon)) // signal A
+          if (name === 'font-family') return null // longhand: drop the whole declaration
+          if (name === 'font') return keptFromFontShorthand(value) // shorthand: keep size only
+          // signal B — the CSSOM resolved this declaration to a font-family despite a name
+          // the normalizer above did not classify (a browser-only escape/encoding). Treat a
+          // co-resolved font-size as a `font` shorthand so its size survives.
+          const resolved = declSetsFontFamily(probe, decl)
+          if (resolved.family) return resolved.size ? keptFromFontShorthand(value) : null
+          return decl // carries no family by either signal → keep verbatim
         })
         .filter((decl): decl is string => Boolean(decl))
         .join('; ')
@@ -141,6 +167,49 @@ export function stripPastedFontFamily(html: string): string {
     return parsed.body.innerHTML
   } catch {
     return html
+  }
+}
+
+/**
+ * Normalize a raw CSS property NAME the way the CSS parser reads it before matching it to
+ * a known property: strip comments, decode identifier escapes, drop whitespace, lowercase.
+ * This makes the gate key on the RESOLVED property rather than a raw byte compare that each
+ * of `font-family/**​/`, `/**​/font-family`, `font\-family`, `\66 ont-family`, and
+ * `FONT-FAMILY` defeats while the browser resolves them all to `font-family`. It is a
+ * principled model of name resolution, not a per-variant special case. Input is capped
+ * because a real property name is a handful of chars; a longer string is not one.
+ */
+function normalizeCssPropName(rawName: string): string {
+  const capped = rawName.length > 256 ? rawName.slice(0, 256) : rawName
+  return capped
+    .replace(/\/\*[\s\S]*?\*\//g, '') // CSS comments act as token separators → remove
+    .replace(/\\([0-9a-fA-F]{1,6})\s?|\\([\s\S])/g, (_m, hex: string, lit: string) => {
+      if (lit !== undefined) return lit // `\-`, `\.`… → the literal char
+      const cp = parseInt(hex, 16) // `\66 ` → 'f'
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : '�'
+    })
+    .replace(/\s+/g, '') // a property name has no internal/surrounding whitespace
+    .toLowerCase()
+}
+
+/**
+ * Ask the real CSSOM whether a single declaration ends up setting font-family (and whether
+ * it also set a font-size, which marks a `font` shorthand). This is the browser's own parse
+ * — it strips comments, decodes escapes, and expands the `font` shorthand exactly as the
+ * downstream `element.style.fontFamily` read (FontFamily.parseHTML) would — so a family this
+ * returns true for is precisely one that would otherwise leak. Declarations already routed
+ * by name never reach here, so this adds no new work to the ReDoS-sensitive `font` path.
+ */
+function declSetsFontFamily(probe: HTMLElement, decl: string): { family: boolean; size: boolean } {
+  try {
+    probe.style.cssText = '' // clear any residue from the previous declaration
+    probe.style.cssText = decl
+    return {
+      family: (probe.style.fontFamily ?? '').trim() !== '',
+      size: (probe.style.fontSize ?? '').trim() !== '',
+    }
+  } catch {
+    return { family: false, size: false }
   }
 }
 

--- a/packages/docs/src/editor/sanitize.ts
+++ b/packages/docs/src/editor/sanitize.ts
@@ -105,9 +105,14 @@ export function renderLinkAttrs(href: string): { href: string | null; rel?: stri
  * this and pasted fonts are preserved.
  */
 export function stripPastedFontFamily(html: string): string {
-  // Guard matches both `font-family:` and the `font:` shorthand (any case), but not
-  // sibling longhands like `font-size:`/`font-weight:` or the plain word "font" in text.
-  if (typeof document === 'undefined' || !/font(-family)?\s*:/i.test(html)) return html
+  // Only skip when there is no DOM to parse (SSR). We must NOT gate on a raw-HTML regex
+  // fast-path: the parser entity-decodes the clipboard string, so `font-family&#58;Georgia`
+  // (entity colon — likewise `&#x3a;`, `font&#45;family`, `f&#111;nt-family`) carries no
+  // literal `font-family:` in the raw string and would slip past such a guard, yet
+  // `element.style.fontFamily` still resolves to the family and leaks into the shared Y.Doc
+  // with the flag off. The per-element walk below reads `getAttribute('style')`, which the
+  // parser has already fully entity-decoded, so running it unconditionally is entity-safe.
+  if (typeof document === 'undefined') return html
   try {
     const parsed = new DOMParser().parseFromString(html, 'text/html')
     parsed.querySelectorAll('[style]').forEach((el) => {
@@ -143,7 +148,12 @@ export function stripPastedFontFamily(html: string): string {
 // font-family: only the size and the (slash-prefixed) line-height. Size keywords per
 // the <font-size> grammar; anything with a unit or `%` is a length/percentage size.
 const FONT_SIZE_KEYWORD = /^(xx-small|x-small|small|medium|large|x-large|xx-large|smaller|larger)$/i
-const FONT_SIZE_LENGTH = /^[+-]?(\d+\.?\d*|\.\d+)(px|pt|pc|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|in|q|%)$/i
+// The number sub-pattern is written unambiguously — `\d+(?:\.\d+)?|\.\d+`, NOT the
+// `\d+\.?\d*` form. The latter lets `\d+` and `\d*` both consume the same digit run, so a
+// long all-digit token followed by a failing unit forces O(n²) backtracking (a pasted
+// `font: 111…111zz` freezes the main thread for seconds — reachable on the default flag-off
+// paste path). The unambiguous form has a single parse and is linear.
+const FONT_SIZE_LENGTH = /^[+-]?(\d+(?:\.\d+)?|\.\d+)(px|pt|pc|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|in|q|%)$/i
 // `font: caption|icon|…` sets a *system* font — no explicit family text and no reusable
 // size — so it is dropped wholesale.
 const SYSTEM_FONT_KEYWORDS = new Set(['caption', 'icon', 'menu', 'message-box', 'small-caption', 'status-bar'])
@@ -167,6 +177,10 @@ function keptFromFontShorthand(value: string): string | null {
   let fontSize: string | null = null
   let lineHeight: string | null = null
   for (let i = 0; i < tokens.length; i++) {
+    // A real font-size token is a handful of chars; cap length before the regex so no
+    // pathological token can ever drive super-linear matching (defense-in-depth alongside
+    // the unambiguous FONT_SIZE_LENGTH pattern).
+    if (tokens[i].length > 32) continue
     if (FONT_SIZE_KEYWORD.test(tokens[i]) || FONT_SIZE_LENGTH.test(tokens[i])) {
       fontSize = tokens[i]
       if (tokens[i + 1] === '/' && tokens[i + 2]) lineHeight = tokens[i + 2]

--- a/packages/docs/src/editor/sanitize.ts
+++ b/packages/docs/src/editor/sanitize.ts
@@ -90,25 +90,45 @@ export function renderLinkAttrs(href: string): { href: string | null; rel?: stri
  * registered) FontFamily extension and land in the shared Y.Doc, so an older client
  * whose schema lacks the attr would silently strip it → data loss.
  *
- * This removes ONLY the inline `font-family` style — exactly what FontFamily.parseHTML
- * reads (`element.style.fontFamily`) — leaving all other markup, styles, and text
- * intact. It touches the paste path ONLY: parsing/rendering already-stored fonts
- * (round-trip, opening old docs) is unaffected, so the flag stays a write gate, not a
- * read gate. When the flag is on, callers skip this and pasted fonts are preserved.
+ * This removes the inline font-family that FontFamily.parseHTML reads
+ * (`element.style.fontFamily`) via BOTH inline paths that populate it:
+ *   1. the `font-family` longhand (`font-family: Georgia`), and
+ *   2. the `font` shorthand (`font: 14px Georgia`), whose family component the browser
+ *      (and jsdom's CSSOM) expands into `element.style.fontFamily` just the same.
+ * The shorthand path was the RC miss: stripping only the longhand let a
+ * `<span style="font: 14px Georgia">` copied from Word/browser still write fontFamily
+ * into the Y.Doc while the flag was off.
+ *
+ * All other markup, styles, and text stay intact. It touches the paste path ONLY:
+ * parsing/rendering already-stored fonts (round-trip, opening old docs) is unaffected,
+ * so the flag stays a write gate, not a read gate. When the flag is on, callers skip
+ * this and pasted fonts are preserved.
  */
 export function stripPastedFontFamily(html: string): string {
-  if (typeof document === 'undefined' || !/font-family/i.test(html)) return html
+  // Guard matches both `font-family:` and the `font:` shorthand (any case), but not
+  // sibling longhands like `font-size:`/`font-weight:` or the plain word "font" in text.
+  if (typeof document === 'undefined' || !/font(-family)?\s*:/i.test(html)) return html
   try {
     const parsed = new DOMParser().parseFromString(html, 'text/html')
     parsed.querySelectorAll('[style]').forEach((el) => {
       const style = el.getAttribute('style') ?? ''
-      // Rebuild the inline style without any `font-family` declaration. Work on the raw
-      // attribute string (not the CSSOM) so an upper/mixed-case `FONT-FAMILY` — which a
-      // browser normalizes and reads, but jsdom's CSSOM does not — is stripped too.
+      // Rebuild the inline style declaration-by-declaration, dropping every font-family
+      // source. Work on the raw attribute string (not the CSSOM) so an upper/mixed-case
+      // `FONT-FAMILY` / `FONT` — which a browser normalizes and reads, but jsdom's CSSOM
+      // does not surface when reading a specific longhand — is handled too.
       const kept = style
         .split(';')
-        .filter((decl) => decl.trim() && decl.split(':', 1)[0].trim().toLowerCase() !== 'font-family')
         .map((decl) => decl.trim())
+        .filter(Boolean)
+        .map((decl) => {
+          const colon = decl.indexOf(':')
+          if (colon === -1) return decl // malformed fragment: leave as-is (carries no family)
+          const prop = decl.slice(0, colon).trim().toLowerCase()
+          if (prop === 'font-family') return null // longhand: drop the whole declaration
+          if (prop === 'font') return keptFromFontShorthand(decl.slice(colon + 1)) // shorthand
+          return decl
+        })
+        .filter((decl): decl is string => Boolean(decl))
         .join('; ')
       if (kept) el.setAttribute('style', kept)
       else el.removeAttribute('style')
@@ -117,4 +137,44 @@ export function stripPastedFontFamily(html: string): string {
   } catch {
     return html
   }
+}
+
+// CSS `font` shorthand components that are safe to keep because they never carry a
+// font-family: only the size and the (slash-prefixed) line-height. Size keywords per
+// the <font-size> grammar; anything with a unit or `%` is a length/percentage size.
+const FONT_SIZE_KEYWORD = /^(xx-small|x-small|small|medium|large|x-large|xx-large|smaller|larger)$/i
+const FONT_SIZE_LENGTH = /^[+-]?(\d+\.?\d*|\.\d+)(px|pt|pc|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|in|q|%)$/i
+// `font: caption|icon|…` sets a *system* font — no explicit family text and no reusable
+// size — so it is dropped wholesale.
+const SYSTEM_FONT_KEYWORDS = new Set(['caption', 'icon', 'menu', 'message-box', 'small-caption', 'status-bar'])
+
+/**
+ * Rebuild a `font` shorthand value with its font-family removed, preserving font-size
+ * and line-height. In the shorthand grammar the font-family always trails the required
+ * `<font-size> [ / <line-height> ]?`, so we scan left-to-right for the first size token
+ * (a size keyword, length, or percentage — unitless weights like `400` are skipped),
+ * keep it plus any `/line-height`, and drop everything else (the family, and also
+ * style/variant/weight/stretch — an acceptable conservative loss for a paste gate that
+ * is off by default). Returns null to drop the declaration entirely when no font-size
+ * can be identified (e.g. a system-font keyword or an unparseable value), which keeps
+ * the gate safe: family text is never re-emitted.
+ */
+function keptFromFontShorthand(value: string): string | null {
+  const v = value.trim()
+  if (!v || SYSTEM_FONT_KEYWORDS.has(v.toLowerCase())) return null
+  // Normalize `12px/1.5` → `12px / 1.5` so the line-height slash is its own token.
+  const tokens = v.replace(/\//g, ' / ').split(/\s+/).filter(Boolean)
+  let fontSize: string | null = null
+  let lineHeight: string | null = null
+  for (let i = 0; i < tokens.length; i++) {
+    if (FONT_SIZE_KEYWORD.test(tokens[i]) || FONT_SIZE_LENGTH.test(tokens[i])) {
+      fontSize = tokens[i]
+      if (tokens[i + 1] === '/' && tokens[i + 2]) lineHeight = tokens[i + 2]
+      break
+    }
+  }
+  if (!fontSize) return null
+  const out = [`font-size: ${fontSize}`]
+  if (lineHeight) out.push(`line-height: ${lineHeight}`)
+  return out.join('; ')
 }

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2411,6 +2411,18 @@
   cursor: pointer;
 }
 
+.octo-font-family {
+  height: 26px;
+  max-width: 120px;
+  border: 1px solid var(--octo-border, #e5e6eb);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  padding: 0 4px;
+  cursor: pointer;
+}
+
 /* Shared dependency-free suggestion popup (mention @ + emoji :). Mirrors the slash menu. */
 .octo-suggest-menu {
   z-index: 1000;

--- a/packages/docs/src/export/docx/marks.test.ts
+++ b/packages/docs/src/export/docx/marks.test.ts
@@ -58,3 +58,38 @@ describe('buildRunOptionsFromMarks — fontSize clamp', () => {
     expect(sizeOf('0.1px')).toBe(2)
   })
 })
+
+// v16: the textStyle fontFamily attr carries a CSS font-family stack; docx runs want a single
+// real face name, so buildRunOptionsFromMarks takes the first family, strips quotes, and drops
+// generic CSS keywords (which are not .docx font names). The `code` mark's monospace font wins.
+describe('buildRunOptionsFromMarks — fontFamily', () => {
+  const fontOf = (fontFamily: string) =>
+    buildRunOptionsFromMarks([{ type: 'textStyle', attrs: { fontFamily } }]).font
+
+  it('takes the first family from a stack and strips quotes', () => {
+    expect(fontOf('SimSun, "宋体", serif')).toBe('SimSun')
+    expect(fontOf('"Times New Roman", Times, serif')).toBe('Times New Roman')
+    expect(fontOf('Arial, Helvetica, sans-serif')).toBe('Arial')
+  })
+
+  it('drops a bare generic keyword (not a real docx font name)', () => {
+    expect(fontOf('serif')).toBeUndefined()
+    expect(fontOf('sans-serif')).toBeUndefined()
+    expect(fontOf('')).toBeUndefined()
+  })
+
+  it('lets the code mark font win over a textStyle fontFamily', () => {
+    // Order-independent: the code branch pins the monospace face and the fontFamily
+    // branch must not overwrite it, whichever mark is processed first.
+    const a = buildRunOptionsFromMarks([
+      { type: 'code' },
+      { type: 'textStyle', attrs: { fontFamily: 'Arial' } },
+    ]).font
+    const b = buildRunOptionsFromMarks([
+      { type: 'textStyle', attrs: { fontFamily: 'Arial' } },
+      { type: 'code' },
+    ]).font
+    expect(a).toBe(b)
+    expect(a).not.toBe('Arial')
+  })
+})

--- a/packages/docs/src/export/docx/marks.ts
+++ b/packages/docs/src/export/docx/marks.ts
@@ -161,6 +161,30 @@ export function buildRunOptionsFromMarks(marks: MarkDef[]): IRunOptions {
             opts.size = Math.min(3276, Math.max(2, halfPoints))
           }
         }
+        // v16 fontFamily attr → docx run font. The attr holds a CSS font-family stack
+        // (e.g. `SimSun, "宋体", serif`); docx wants a single face name, so take the first
+        // family, strip quotes/whitespace, and drop generic CSS keywords (serif/sans-serif/…)
+        // which are not real .docx font names. Don't set `opts.font` for `code` — the code
+        // branch above already pinned FONT_CODE and must win.
+        const fontFamily = mark.attrs?.fontFamily
+        if (typeof fontFamily === 'string' && opts.font !== FONT_CODE) {
+          const face = fontFamily
+            .split(',')[0]
+            .replace(/["']/g, '')
+            .trim()
+          const GENERIC = new Set([
+            'serif',
+            'sans-serif',
+            'monospace',
+            'cursive',
+            'fantasy',
+            'system-ui',
+            'ui-serif',
+            'ui-sans-serif',
+            'ui-monospace',
+          ])
+          if (face && !GENERIC.has(face.toLowerCase())) opts.font = face
+        }
         break
       }
       case 'subscript':

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -98,6 +98,16 @@
     "fontSizeDefault": "Default",
     "fontFamily": "Font",
     "fontFamilyDefault": "Default",
+    "font": {
+      "yahei": "Microsoft YaHei",
+      "simsun": "SimSun",
+      "simhei": "SimHei",
+      "kaiti": "KaiTi",
+      "arial": "Arial",
+      "timesNewRoman": "Times New Roman",
+      "georgia": "Georgia",
+      "courierNew": "Courier New"
+    },
     "alignLeft": "Align left",
     "alignCenter": "Align center",
     "alignRight": "Align right",

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -96,6 +96,8 @@
     "subscript": "Subscript",
     "fontSize": "Font size",
     "fontSizeDefault": "Default",
+    "fontFamily": "Font",
+    "fontFamilyDefault": "Default",
     "alignLeft": "Align left",
     "alignCenter": "Align center",
     "alignRight": "Align right",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -96,6 +96,8 @@
     "subscript": "下标",
     "fontSize": "字号",
     "fontSizeDefault": "默认",
+    "fontFamily": "字体",
+    "fontFamilyDefault": "默认",
     "alignLeft": "左对齐",
     "alignCenter": "居中对齐",
     "alignRight": "右对齐",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -98,6 +98,16 @@
     "fontSizeDefault": "默认",
     "fontFamily": "字体",
     "fontFamilyDefault": "默认",
+    "font": {
+      "yahei": "微软雅黑",
+      "simsun": "宋体",
+      "simhei": "黑体",
+      "kaiti": "楷体",
+      "arial": "Arial",
+      "timesNewRoman": "Times New Roman",
+      "georgia": "Georgia",
+      "courierNew": "Courier New"
+    },
     "alignLeft": "左对齐",
     "alignCenter": "居中对齐",
     "alignRight": "右对齐",

--- a/packages/docs/src/schema/index.test.ts
+++ b/packages/docs/src/schema/index.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { SCHEMA_VERSION, SCHEMA_NODES, SCHEMA_MARKS, COLLAB_FIELD } from './index.ts'
 
 // These assertions track docs/schema/SCHEMA-SPEC.md (single source of truth).
-// SCHEMA_VERSION 15 is the latest landed; the schema is cumulative, so every earlier
+// SCHEMA_VERSION 16 is the latest landed; the schema is cumulative, so every earlier
 // addition (v2 image, v3 highlight/textStyle, v4 tables, v5 textAlign attr, v6 underline,
 // v7 fontSize attr, v8 super/subscript, v9 emoji, v10 mention, v11 details, v12 callout,
-// v13 math, v14 fileAttachment, v15 bookmark) is carried forward.
+// v13 math, v14 fileAttachment, v15 bookmark, v16 fontFamily attr) is carried forward.
 //
 // FOLLOW-UP (design §2.5): these are name-membership assertions only. The golden
 // schema round-trip regression — encode a fixture doc to a Yjs update, decode it back,
@@ -14,8 +14,8 @@ import { SCHEMA_VERSION, SCHEMA_NODES, SCHEMA_MARKS, COLLAB_FIELD } from './inde
 // separate phase. It is intentionally not built here: the v3 binding now runs through
 // @tiptap/y-tiptap, so the golden mechanism must be authored against that binding.
 describe('docs schema stub (mirrors SCHEMA-SPEC.md)', () => {
-  it('is at SCHEMA_VERSION 15', () => {
-    expect(SCHEMA_VERSION).toBe(15)
+  it('is at SCHEMA_VERSION 16', () => {
+    expect(SCHEMA_VERSION).toBe(16)
   })
 
   it('carries the v1 baseline marks', () => {
@@ -76,11 +76,12 @@ describe('docs schema stub (mirrors SCHEMA-SPEC.md)', () => {
     expect(SCHEMA_NODES).toContain('bookmark')
   })
 
-  it('keeps the v5/v7 attr-only additions OUT of the node/mark lists (they are attrs)', () => {
-    // textAlign rides on heading/paragraph; fontSize rides on the textStyle mark.
+  it('keeps the v5/v7/v16 attr-only additions OUT of the node/mark lists (they are attrs)', () => {
+    // textAlign rides on heading/paragraph; fontSize + fontFamily ride on the textStyle mark.
     expect(SCHEMA_NODES).not.toContain('textAlign')
     expect(SCHEMA_MARKS).not.toContain('textAlign')
     expect(SCHEMA_MARKS).not.toContain('fontSize')
+    expect(SCHEMA_MARKS).not.toContain('fontFamily')
   })
 
   it('keeps the v1 baseline nodes', () => {

--- a/packages/docs/src/schema/index.ts
+++ b/packages/docs/src/schema/index.ts
@@ -48,7 +48,12 @@
 //        EXACTLY url/title/description/image/siteName/fetchedAt; round-trips via data-url/
 //        data-title/data-description/data-image/data-site-name/data-fetched-at). Inserting a URL
 //        calls POST /docs/{docId}/link-card for OG metadata; only http/https URLs become cards.
-export const SCHEMA_VERSION = 15
+//   v16 — SCHEMA-SPEC §6: add a `fontFamily` ATTRIBUTE to the `textStyle` mark (FontFamily ships in
+//        @tiptap/extension-text-style; no standalone font-family at 3.22.2) → <span style="font-family:…">.
+//        Byte-aligned with the backend fontFamily attr under this shared version. The FontFamily
+//        extension is always registered so the attr round-trips faithfully; the toolbar entry that
+//        SETS it is gated behind FONT_FAMILY_ENABLED (default off) for the phased rollout.
+export const SCHEMA_VERSION = 16
 
 // Node names present in the schema at the current SCHEMA_VERSION. Mirrors the
 // backend stub's node set (SCHEMA-SPEC); kept here so the set is auditable against
@@ -88,9 +93,9 @@ export const SCHEMA_NODES = [
 // backend stub's mark set (SCHEMA-SPEC §3); kept here so the set is auditable
 // against the spec without importing the editor extensions.
 //
-// NOTE: v5 `textAlign` and v7 `fontSize` are ATTRIBUTES (textAlign on heading/paragraph,
-// fontSize on the textStyle mark), not new nodes/marks, so they add no entry here — only a
-// version bump. They still round-trip through the Y.Doc as node/mark attrs.
+// NOTE: v5 `textAlign`, v7 `fontSize` and v16 `fontFamily` are ATTRIBUTES (textAlign on
+// heading/paragraph, fontSize + fontFamily on the textStyle mark), not new nodes/marks, so they
+// add no entry here — only a version bump. They still round-trip through the Y.Doc as node/mark attrs.
 export const SCHEMA_MARKS = [
   'bold',
   'italic',
@@ -98,7 +103,7 @@ export const SCHEMA_MARKS = [
   'code',
   'link',
   'highlight', // v3 — <mark style="background-color:…">
-  'textStyle', // v3 — <span style="color:…"> (carries the color attr; v7 adds the fontSize attr)
+  'textStyle', // v3 — <span style="color:…"> (carries the color attr; v7 adds fontSize, v16 adds fontFamily)
   'underline', // v6 — <u> / text-decoration:underline
   'superscript', // v8 — <sup>
   'subscript', // v8 — <sub>


### PR DESCRIPTION
## Summary

Adds body **font family** support to the docs editor (`packages/docs`), byte-aligned with the backend `fontFamily` attribute under the shared **SCHEMA_VERSION 16** contract. Mirrors the existing `fontSize` path (a `textStyle` global attr → `<span style="font-family:…">`), with `parseDOM`/`toDOM` and Y.Doc ↔ ProseMirror round-trip.

Rollout is phased and seamless: the frontend can deploy to everyone, but the font entry stays gated behind a flag that is **off by default**.

## Changes

- **Extension** (`editor/extensions.ts`): register `FontFamily` (from `@tiptap/extension-text-style`, same package as `FontSize`) after `TextStyle` in both the live editor and the read-only preview. Registration is **unconditional** — the schema must always know the attr so this bundle round-trips fonts faithfully and never strips them. That is precisely what makes the phased rollout safe.
- **Feature flag** (`config.ts`): `FONT_FAMILY_ENABLED` (via `VITE_DOCS_FONT_FAMILY`), **default off**. It gates **only** the toolbar entry — the control the user uses to *set* a font. When off, the selector is not rendered at all (invisible/unusable), so there is no toolbar regression. Keeping the entry off until client versions converge prevents an older bundle (no `fontFamily` in its schema) from silently dropping a font set by a newer client. Turning it on is a separate decision, not part of this change.
- **Toolbar** (`editor/Toolbar.tsx`): `FontFamilySelect` mirroring `FontSizeSelect`, a curated CJK + Western preset list (each value carries a generic fallback), rendered only when the flag is on.
- **Schema** (`schema/index.ts`): bump `SCHEMA_VERSION` 15 → 16 with a cumulative changelog entry. `fontFamily` is an attribute (like `fontSize`/`textAlign`), so it stays out of the node/mark audit lists.
- **i18n** (`zh-CN` / `en-US`): `toolbar.fontFamily` + `toolbar.fontFamilyDefault` (parity-checked).
- **DOCX export** (`export/docx/marks.ts`): map `fontFamily` → run `font` (first family, quotes stripped, generic CSS keywords dropped; the `code` mark's monospace font still wins).

## Backward compatibility

Old documents without `fontFamily` render unchanged; existing color / fontSize / alignment behaviour is untouched.

## Testing

- `pnpm --filter @octo/docs test` — all suites green (pre-existing unrelated flaky Toolbar cross-file pollution aside; new tests all pass).
- New tests: `fontFamily` schema attr + a `parseDOM`/`toDOM` round-trip assertion, docx `fontFamily` mapping (incl. code-wins), `SCHEMA_VERSION` 16 bump, i18n parity.
- `pnpm --filter @octo/docs typecheck` — no new errors introduced.

> Related: octo-docs-backend #59 (body font family). Depends on the backend `fontFamily` attr / SCHEMA_VERSION 16 contract; the round-trip is implemented against the shared contract and can be finalized once the backend spec lands.

**Draft** — opened to carry review; not for merge in this state.
