### PR TITLE
fix(docs): resolve non-friend bot names in member panel via space_bots

### DIFF
--- a/packages/docs/src/members/memberNames.test.ts
+++ b/packages/docs/src/members/memberNames.test.ts
@@ -32,3 +32,68 @@ describe('getSpaceMemberNames — uid → display name resolution', () => {
     expect(map.size).toBe(0)
   })
 })
+
+describe('getSpaceMemberNames — bot name backfill via /robot/space_bots (#60)', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    clearMemberNameCache()
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  /** Make the mock apiClient answer /robot/space_bots?space_id=... with the given bot rows. */
+  function respondBots(bots: unknown, opts: { fail?: boolean } = {}): void {
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) {
+        if (opts.fail) return Promise.reject(new Error('space_bots down'))
+        return { data: bots, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+  }
+
+  it('backfills names for bot uids missing from the space-member list (single request)', async () => {
+    // A non-friend / non-self-created bot never appears in the space-member list.
+    respondBots([{ uid: 'bot1', name: 'Helper Bot' }])
+    const map = await getSpaceMemberNames('s_1')
+    expect(map.get('bot1')).toBe('Helper Bot')
+    // One space_bots request only — no per-uid fanout.
+    const botCalls = wk.apiClient.calls.filter((c) => c.url.startsWith('/robot/space_bots'))
+    expect(botCalls).toHaveLength(1)
+    expect(botCalls[0].url).toBe('/robot/space_bots?space_id=s_1')
+  })
+
+  it('never overwrites an existing human/member display name', async () => {
+    wk.spaceMembers.push({ uid: 'u1', name: 'Alice' })
+    // Even if space_bots echoes u1 with a different name, the member name wins.
+    respondBots([
+      { uid: 'u1', name: 'Alice Bot Alias' },
+      { uid: 'bot1', name: 'Helper Bot' },
+    ])
+    const map = await getSpaceMemberNames('s_1')
+    expect(map.get('u1')).toBe('Alice') // human path unchanged
+    expect(map.get('bot1')).toBe('Helper Bot')
+  })
+
+  it('falls back to the raw uid for a bot with a blank name', async () => {
+    respondBots([{ uid: 'bot1', name: '' }])
+    const map = await getSpaceMemberNames('s_1')
+    expect(map.get('bot1')).toBe('bot1')
+  })
+
+  it('keeps human names when the space_bots request fails (best-effort backfill)', async () => {
+    wk.spaceMembers.push({ uid: 'u1', name: 'Alice' })
+    respondBots([], { fail: true })
+    const map = await getSpaceMemberNames('s_1')
+    expect(map.get('u1')).toBe('Alice')
+    expect(map.has('bot1')).toBe(false)
+  })
+
+  it('tolerates a non-array space_bots body without throwing', async () => {
+    wk.spaceMembers.push({ uid: 'u1', name: 'Alice' })
+    respondBots({ unexpected: true })
+    const map = await getSpaceMemberNames('s_1')
+    expect(map.get('u1')).toBe('Alice')
+  })
+})

--- a/packages/docs/src/members/memberNames.ts
+++ b/packages/docs/src/members/memberNames.ts
@@ -6,11 +6,18 @@
 // through the octoweb seam (fetchAllSpaceMembers). This module fetches that list ONCE per space
 // and caches the resulting uid → name map so the editor/member panel can resolve names cheaply.
 //
+// Bot backfill (octo-docs-backend #60): the space-member source (`queryMembers`) drops any bot the
+// current user did not create, so a non-friend / non-self-created bot has no name here and the panel
+// falls back to its raw uid. We backfill those names with a SINGLE `GET /robot/space_bots?space_id=`
+// request per space (not viewer-scoped, no per-uid fanout, no extra permission) and merge only the
+// uids that are still missing a real name — human members keep their original name untouched.
+//
 // Resilience: a fetch failure resolves to an EMPTY map (never throws) and the failed entry is
 // evicted so a later open retries — callers always fall back to the uid, so first paint can
-// never crash on a missing/slow member list.
+// never crash on a missing/slow member list. The bot backfill is independently best-effort: if it
+// fails the human names still resolve.
 
-import { fetchAllSpaceMembers } from '../octoweb/index.ts'
+import { fetchAllSpaceMembers, fetchSpaceBotNames } from '../octoweb/index.ts'
 
 const cache = new Map<string, Promise<Map<string, string>>>()
 
@@ -22,19 +29,32 @@ export function getSpaceMemberNames(spaceId: string): Promise<Map<string, string
   if (!spaceId) return Promise.resolve(new Map<string, string>())
   const cached = cache.get(spaceId)
   if (cached) return cached
-  const pending = fetchAllSpaceMembers(spaceId)
-    .then((members) => {
-      const map = new Map<string, string>()
-      for (const m of members) {
-        if (m.uid) map.set(m.uid, m.name || m.uid)
-      }
-      return map
-    })
-    .catch(() => {
-      // Transient failure: forget it so a later open retries instead of caching "no names".
-      cache.delete(spaceId)
-      return new Map<string, string>()
-    })
+  const pending = Promise.all([
+    // Human/self-created-bot names from the space-member source.
+    fetchAllSpaceMembers(spaceId).then(
+      (members) => members,
+      () => null, // signal a transient member-fetch failure so we can evict + retry below
+    ),
+    // Bot names from the single non-viewer-scoped space_bots request (#60). Independently
+    // best-effort: a failure here must never take down the human-member names.
+    fetchSpaceBotNames(spaceId).catch(() => [] as Awaited<ReturnType<typeof fetchSpaceBotNames>>),
+  ]).then(([members, bots]) => {
+    // Transient failure of the member list: forget it so a later open retries instead of
+    // caching "no names". We still merge whatever bot names we got for this render.
+    if (members === null) cache.delete(spaceId)
+    const map = new Map<string, string>()
+    for (const m of members ?? []) {
+      if (m.uid) map.set(m.uid, m.name || m.uid)
+    }
+    // Backfill ONLY uids that are absent or still resolve to their raw uid — never overwrite a
+    // real human/member name (bots filtered out of queryMembers are exactly the missing ones).
+    for (const b of bots) {
+      if (!b.uid) continue
+      const existing = map.get(b.uid)
+      if (!existing || existing === b.uid) map.set(b.uid, b.name || b.uid)
+    }
+    return map
+  })
   cache.set(spaceId, pending)
   return pending
 }

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -154,6 +154,36 @@ export async function fetchAllSpaceMembers(spaceId: string): Promise<SpaceMember
   return all
 }
 
+/** Minimal view of a `/robot/space_bots` entry the docs seam reads (uid + display name). */
+interface HostSpaceBot {
+  uid: string
+  name?: string
+}
+
+/**
+ * Fetch the display names of ALL bots in a space via the single `GET /robot/space_bots?space_id=`
+ * request (the same endpoint the contacts module already calls — dmworkcontacts Contacts/index.tsx).
+ *
+ * WHY: `queryMembers` (the source behind fetchAllSpaceMembers) filters out bots the current user did
+ * not create, so the member panel falls back to the raw uid for a non-friend / non-self-created bot
+ * (octo-docs-backend #60). This endpoint is NOT viewer-scoped — it returns every bot in the space —
+ * so one request per space backfills those names with no per-uid fanout and no extra permission.
+ *
+ * Returns `{ uid, name }` pairs (name falls back to the uid so a bot with no display name is never
+ * blank). Resolves to an EMPTY list on any failure or non-array body so callers can merge safely and
+ * fall back to the uid — this must never break the human-member name path.
+ */
+export async function fetchSpaceBotNames(spaceId: string): Promise<SpaceMemberLite[]> {
+  if (!spaceId) return []
+  const { data } = await apiClient().get<HostSpaceBot[]>(
+    `/robot/space_bots?space_id=${encodeURIComponent(spaceId)}`,
+  )
+  const bots = Array.isArray(data) ? data : []
+  return bots
+    .filter((b): b is HostSpaceBot => !!b && !!b.uid)
+    .map((b) => ({ uid: b.uid, name: b.name || b.uid }))
+}
+
 /**
  * Re-wrap the REAL host APIClient so its responses look axios-style to docs callers.
  *

--- a/packages/docs/src/octoweb/spaceMembers.test.ts
+++ b/packages/docs/src/octoweb/spaceMembers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { setWKApp, getSpaceMembers, fetchAllSpaceMembers } from './index.ts'
+import { setWKApp, getSpaceMembers, fetchAllSpaceMembers, fetchSpaceBotNames } from './index.ts'
 import { createMockWKApp } from './mock.ts'
 
 // Seam spike acceptance (#7): prove the docs package can reach the host's space-member source
@@ -56,5 +56,50 @@ describe('octoweb space-member seam', () => {
     expect(page[0]).toEqual({ uid: 'u_plain', name: 'Plain' })
     // Rich member: avatar + isBot preserved.
     expect(page[1]).toEqual({ uid: 'u_bot', name: 'Bot', avatar: 'https://cdn/x.png', isBot: true })
+  })
+})
+
+// #60: the space-member source filters out non-self-created bots, so their names come from the
+// single non-viewer-scoped `GET /robot/space_bots?space_id=` request instead.
+describe('octoweb fetchSpaceBotNames seam', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  it('issues one space_bots request and maps {uid, name} pairs', async () => {
+    wk.apiClient.responder = (_m, url) =>
+      url.startsWith('/robot/space_bots')
+        ? { data: [{ uid: 'bot1', name: 'Helper' }, { uid: 'bot2', name: 'Scribe' }], status: 200 }
+        : { data: {}, status: 200 }
+    const bots = await fetchSpaceBotNames('s_1')
+    expect(bots).toEqual([
+      { uid: 'bot1', name: 'Helper' },
+      { uid: 'bot2', name: 'Scribe' },
+    ])
+    const calls = wk.apiClient.calls.filter((c) => c.url.startsWith('/robot/space_bots'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('/robot/space_bots?space_id=s_1')
+  })
+
+  it('falls back to the uid for a bot with no name and skips entries without a uid', async () => {
+    wk.apiClient.responder = () => ({
+      data: [{ uid: 'bot1', name: '' }, { name: 'ghost' }],
+      status: 200,
+    })
+    const bots = await fetchSpaceBotNames('s_1')
+    expect(bots).toEqual([{ uid: 'bot1', name: 'bot1' }])
+  })
+
+  it('returns an empty list for a non-array body', async () => {
+    wk.apiClient.responder = () => ({ data: { nope: true }, status: 200 })
+    expect(await fetchSpaceBotNames('s_1')).toEqual([])
+  })
+
+  it('returns an empty list for a blank space id without touching the host', async () => {
+    expect(await fetchSpaceBotNames('')).toEqual([])
+    expect(wk.apiClient.calls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary

Non-friend / non-self-created bots showed their raw uid (instead of a name) in the docs **member panel**. Root cause: the panel resolves `uid → display name` only from the space-member source (`queryMembers`), which filters out any bot the current user did not create — so those bots never carry a name and the panel falls back to the uid.

This is a **frontend-only** fix. It backfills the missing names with a single `GET /robot/space_bots?space_id=<spaceId>` request per space — the same non-viewer-scoped endpoint the contacts module already calls (`dmworkcontacts/src/Contacts/index.tsx`). No backend change, no per-uid fanout, no extra permission.

## Changes

- `packages/docs/src/octoweb/index.ts` — add `fetchSpaceBotNames(spaceId)` seam helper: one `GET /robot/space_bots?space_id=` request, mapped to `{ uid, name }` (name falls back to the uid). Resolves to `[]` on failure or a non-array body so callers can merge safely.
- `packages/docs/src/members/memberNames.ts` — fetch members and space bots together; merge a bot name **only** for uids that are absent or still resolve to their raw uid. Human/member names are never overwritten. The bot backfill is independently best-effort — if it fails, human names still resolve; a member-fetch failure still evicts the cache so a later open retries.

## Behavior

- Non-friend / non-self-created bots now display their real name in the member panel.
- Single request per space, no per-uid fanout.
- Human members unchanged; empty name / request failure degrades to the raw uid without crashing.
- No extra permission dependency.

## Tests

- `memberNames.test.ts` — backfill, no-overwrite of human names, blank-name fallback, request-failure fallback, non-array body tolerance.
- `spaceMembers.test.ts` — `fetchSpaceBotNames` seam: single request + URL, uid fallback / skip-no-uid, non-array body, blank space id.

New tests pass; `tsc --noEmit` reports no new errors (two pre-existing errors in untouched files remain).

Ref: Mininglamp-OSS/octo-docs-backend#60
