### PR TITLE
fix(docs): stop empty @mention/emoji/slash suggestion popup + Esc/outside-click close (#624)

### DIFF
--- a/packages/docs/src/editor/SlashCommand.test.ts
+++ b/packages/docs/src/editor/SlashCommand.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { SLASH_ITEMS, filterSlashItems } from './SlashCommand.ts'
+import { describe, it, expect, afterEach } from 'vitest'
+import { SLASH_ITEMS, filterSlashItems, createSlashMenuRenderer } from './SlashCommand.ts'
 
 describe('SlashCommand heading items', () => {
   it('exposes a slash entry for every heading level H1–H6', () => {
@@ -25,5 +25,80 @@ describe('SlashCommand heading items', () => {
 
   it('empty query returns the full item list', () => {
     expect(filterSlashItems('')).toEqual(SLASH_ITEMS)
+  })
+})
+
+// #624: the slash menu shares the mention/emoji failure modes — an empty result set must not
+// leave a floating empty box, and Escape / an outside click must close an open menu.
+describe('slash menu — zero results render nothing (#624)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  const menuCount = () => document.querySelectorAll('.octo-slash-menu').length
+
+  it('appends no menu when onStart receives an empty item list', () => {
+    createSlashMenuRenderer().onStart({ items: [], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+  })
+
+  it('renders one row per item when items are present', () => {
+    createSlashMenuRenderer().onStart({
+      items: SLASH_ITEMS.slice(0, 2),
+      command: () => {},
+      clientRect: null,
+    })
+    expect(menuCount()).toBe(1)
+    expect(document.querySelectorAll('.octo-slash-item').length).toBe(2)
+  })
+
+  it('removes the box when an update drops the results to zero', () => {
+    const r = createSlashMenuRenderer()
+    r.onStart({ items: SLASH_ITEMS.slice(0, 1), command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    r.onUpdate({ items: [], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+  })
+})
+
+describe('slash menu — Esc + outside click close (#624)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  const menuCount = () => document.querySelectorAll('.octo-slash-menu').length
+
+  it('Escape destroys the box and reports the key handled', () => {
+    const r = createSlashMenuRenderer()
+    r.onStart({ items: SLASH_ITEMS.slice(0, 2), command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    const handled = r.onKeyDown({ event: new KeyboardEvent('keydown', { key: 'Escape' }) })
+    expect(handled).toBe(true)
+    expect(menuCount()).toBe(0)
+  })
+
+  it('a mousedown outside the box closes it', () => {
+    createSlashMenuRenderer().onStart({
+      items: SLASH_ITEMS.slice(0, 2),
+      command: () => {},
+      clientRect: null,
+    })
+    expect(menuCount()).toBe(1)
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(menuCount()).toBe(0)
+  })
+
+  it('onExit detaches the outside listener (no cross-session leak)', () => {
+    const r = createSlashMenuRenderer()
+    r.onStart({ items: SLASH_ITEMS.slice(0, 1), command: () => {}, clientRect: null })
+    r.onExit()
+    createSlashMenuRenderer().onStart({
+      items: SLASH_ITEMS.slice(0, 1),
+      command: () => {},
+      clientRect: null,
+    })
+    expect(menuCount()).toBe(1)
   })
 })

--- a/packages/docs/src/editor/SlashCommand.ts
+++ b/packages/docs/src/editor/SlashCommand.ts
@@ -172,11 +172,15 @@ export function filterSlashItems(query: string): SlashItem[] {
 }
 
 // Minimal keyboard-navigable popup. Kept dependency-free (no tippy) so it runs headless-friendly.
-function createSlashMenuRenderer() {
+export function createSlashMenuRenderer() {
   let el: HTMLDivElement | null = null
   let items: SlashItem[] = []
   let selected = 0
   let cmd: ((item: SlashItem) => void) | null = null
+  // Set once the menu is dismissed (Escape / outside click) so a later onUpdate in the same
+  // suggestion session does not re-open it. Reset by onExit when the session ends (#624).
+  let closed = false
+  let onOutside: ((e: MouseEvent) => void) | null = null
 
   function paint() {
     if (!el) return
@@ -201,6 +205,44 @@ function createSlashMenuRenderer() {
     el.style.top = `${rect.bottom + 4}px`
   }
 
+  /** Tear down the menu element and its outside-click listener. Safe to call repeatedly. */
+  function destroy() {
+    if (onOutside) {
+      document.removeEventListener('mousedown', onOutside, true)
+      onOutside = null
+    }
+    el?.remove()
+    el = null
+  }
+
+  /** Mount the menu element (once) and wire the outside-click dismissal. */
+  function mount() {
+    if (el) return
+    el = document.createElement('div')
+    el.className = 'octo-slash-menu'
+    document.body.appendChild(el)
+    onOutside = (e) => {
+      if (el && (!(e.target instanceof Node) || !el.contains(e.target))) {
+        closed = true
+        destroy()
+      }
+    }
+    // Capture phase so the dismissal runs before ProseMirror handles the click.
+    document.addEventListener('mousedown', onOutside, true)
+  }
+
+  /** Reflect current items into the DOM: empty list renders NO box; non-empty (re)mounts (#624). */
+  function sync(clientRect?: (() => DOMRect | null) | null) {
+    if (closed) return
+    if (items.length === 0) {
+      destroy()
+      return
+    }
+    mount()
+    paint()
+    position(clientRect?.())
+  }
+
   return {
     onStart: (props: {
       items: SlashItem[]
@@ -210,11 +252,8 @@ function createSlashMenuRenderer() {
       items = props.items
       selected = 0
       cmd = props.command
-      el = document.createElement('div')
-      el.className = 'octo-slash-menu'
-      document.body.appendChild(el)
-      paint()
-      position(props.clientRect?.())
+      closed = false
+      sync(props.clientRect)
     },
     onUpdate: (props: {
       items: SlashItem[]
@@ -223,13 +262,18 @@ function createSlashMenuRenderer() {
     }) => {
       items = props.items
       cmd = props.command
-      selected = 0
-      paint()
-      position(props.clientRect?.())
+      selected = Math.min(selected, Math.max(0, items.length - 1))
+      sync(props.clientRect)
     },
     onKeyDown: (props: { event: KeyboardEvent }) => {
-      if (!items.length) return false
       const { key } = props.event
+      if (key === 'Escape') {
+        if (!el) return false
+        closed = true
+        destroy()
+        return true
+      }
+      if (!items.length || !el) return false
       if (key === 'ArrowDown') {
         selected = (selected + 1) % items.length
         paint()
@@ -244,14 +288,11 @@ function createSlashMenuRenderer() {
         cmd?.(items[selected])
         return true
       }
-      if (key === 'Escape') {
-        return true
-      }
       return false
     },
     onExit: () => {
-      el?.remove()
-      el = null
+      closed = false
+      destroy()
     },
   }
 }

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2442,11 +2442,6 @@
 .octo-suggest-item:hover {
   background: var(--octo-hover, #f2f3f5);
 }
-.octo-suggest-empty {
-  padding: 6px 10px;
-  color: var(--octo-fg-3, #86909c);
-  font-size: 12px;
-}
 .octo-emoji-menu .octo-suggest-item {
   font-size: 15px;
 }

--- a/packages/docs/src/editor/suggestionMenu.test.ts
+++ b/packages/docs/src/editor/suggestionMenu.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { createSuggestionMenuRenderer } from './suggestionMenu.ts'
+
+// The @-mention and :-emoji popups share this renderer, so covering it here covers both
+// (octo-web #624): (A) an empty result set must render NO floating box, and (B) Escape and
+// an outside mousedown must close an open popup.
+
+interface Row {
+  id: string
+  label: string
+}
+
+const A: Row = { id: 'a', label: 'Alice' }
+const B: Row = { id: 'b', label: 'Bob' }
+
+const MENU_CLASS = 'octo-test-menu'
+
+function menu() {
+  return createSuggestionMenuRenderer<Row>((r) => r.label, MENU_CLASS)
+}
+
+function menuCount(): number {
+  return document.querySelectorAll(`.${MENU_CLASS}`).length
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('suggestion menu — A: zero results render nothing (#624)', () => {
+  it('appends no menu element when onStart receives an empty item list', () => {
+    menu().onStart({ items: [], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+  })
+
+  it('never inserts the "—" empty placeholder', () => {
+    menu().onStart({ items: [], command: () => {}, clientRect: null })
+    expect(document.querySelector('.octo-suggest-empty')).toBeNull()
+  })
+
+  it('renders one row per item when items are present', () => {
+    menu().onStart({ items: [A, B], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    expect(document.querySelectorAll('.octo-suggest-item').length).toBe(2)
+  })
+
+  it('removes the box when an update drops the results to zero', () => {
+    const r = menu()
+    r.onStart({ items: [A], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    r.onUpdate({ items: [], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+  })
+
+  it('re-opens the box when a later update brings results back', () => {
+    const r = menu()
+    r.onStart({ items: [], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+    r.onUpdate({ items: [A], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+  })
+})
+
+describe('suggestion menu — B: Esc + outside click close (#624)', () => {
+  it('Escape destroys the box and reports the key handled', () => {
+    const r = menu()
+    r.onStart({ items: [A, B], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    const handled = r.onKeyDown({ event: new KeyboardEvent('keydown', { key: 'Escape' }) })
+    expect(handled).toBe(true)
+    expect(menuCount()).toBe(0)
+  })
+
+  it('a mousedown outside the box closes it', () => {
+    menu().onStart({ items: [A, B], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(menuCount()).toBe(0)
+  })
+
+  it('a mousedown inside the box does NOT close it', () => {
+    menu().onStart({ items: [A, B], command: () => {}, clientRect: null })
+    const row = document.querySelector('.octo-suggest-item') as HTMLElement
+    row.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(menuCount()).toBe(1)
+  })
+
+  it('stays closed on a later update after Escape (until the suggestion exits)', () => {
+    const r = menu()
+    r.onStart({ items: [A, B], command: () => {}, clientRect: null })
+    r.onKeyDown({ event: new KeyboardEvent('keydown', { key: 'Escape' }) })
+    r.onUpdate({ items: [A, B], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(0)
+  })
+
+  it('onExit removes the box and detaches the outside listener (no cross-session leak)', () => {
+    const r = menu()
+    r.onStart({ items: [A], command: () => {}, clientRect: null })
+    r.onExit()
+    expect(menuCount()).toBe(0)
+    // A stale listener from the first session must not double-close the second session's box.
+    const r2 = menu()
+    r2.onStart({ items: [A], command: () => {}, clientRect: null })
+    expect(menuCount()).toBe(1)
+  })
+})

--- a/packages/docs/src/editor/suggestionMenu.ts
+++ b/packages/docs/src/editor/suggestionMenu.ts
@@ -30,17 +30,14 @@ export function createSuggestionMenuRenderer<T>(
   let items: T[] = []
   let selected = 0
   let cmd: ((item: T) => void) | null = null
+  // Set once the popup is dismissed (Escape / outside click) so a later onUpdate in the same
+  // suggestion session does not re-open it. Reset by onExit when the session truly ends (#624).
+  let closed = false
+  let onOutside: ((e: MouseEvent) => void) | null = null
 
   function paint() {
     if (!el) return
     el.innerHTML = ''
-    if (items.length === 0) {
-      const empty = document.createElement('div')
-      empty.className = 'octo-suggest-empty'
-      empty.textContent = '—'
-      el.appendChild(empty)
-      return
-    }
     items.forEach((item, idx) => {
       const row = document.createElement('button')
       row.type = 'button'
@@ -61,27 +58,72 @@ export function createSuggestionMenuRenderer<T>(
     el.style.top = `${rect.bottom + 4}px`
   }
 
+  /** Tear down the popup element and its outside-click listener. Safe to call repeatedly. */
+  function destroy() {
+    if (onOutside) {
+      document.removeEventListener('mousedown', onOutside, true)
+      onOutside = null
+    }
+    el?.remove()
+    el = null
+  }
+
+  /** Mount the popup element (once) and wire the outside-click dismissal. */
+  function mount() {
+    if (el) return
+    el = document.createElement('div')
+    el.className = menuClass
+    document.body.appendChild(el)
+    onOutside = (e) => {
+      if (el && (!(e.target instanceof Node) || !el.contains(e.target))) {
+        closed = true
+        destroy()
+      }
+    }
+    // Capture phase so the dismissal runs before ProseMirror handles the click.
+    document.addEventListener('mousedown', onOutside, true)
+  }
+
+  /**
+   * Reflect the current items into the DOM: an empty list renders NO box (A), a non-empty list
+   * (re)mounts and paints. Never runs once the popup has been dismissed for this session.
+   */
+  function sync(clientRect?: (() => DOMRect | null) | null) {
+    if (closed) return
+    if (items.length === 0) {
+      destroy()
+      return
+    }
+    mount()
+    paint()
+    position(clientRect?.())
+  }
+
   return {
     onStart: (props) => {
       items = props.items
       selected = 0
       cmd = props.command
-      el = document.createElement('div')
-      el.className = menuClass
-      document.body.appendChild(el)
-      paint()
-      position(props.clientRect?.())
+      closed = false
+      sync(props.clientRect)
     },
     onUpdate: (props) => {
       items = props.items
       cmd = props.command
       selected = Math.min(selected, Math.max(0, items.length - 1))
-      paint()
-      position(props.clientRect?.())
+      sync(props.clientRect)
     },
     onKeyDown: (props) => {
-      if (!items.length) return false
       const { key } = props.event
+      if (key === 'Escape') {
+        // Only claim the key when a popup is actually open, so Escape stays available to other
+        // handlers (e.g. clearing a selection) when nothing is showing.
+        if (!el) return false
+        closed = true
+        destroy()
+        return true
+      }
+      if (!items.length || !el) return false
       if (key === 'ArrowDown') {
         selected = (selected + 1) % items.length
         paint()
@@ -96,14 +138,11 @@ export function createSuggestionMenuRenderer<T>(
         cmd?.(items[selected])
         return true
       }
-      if (key === 'Escape') {
-        return true
-      }
       return false
     },
     onExit: () => {
-      el?.remove()
-      el = null
+      closed = false
+      destroy()
     },
   }
 }


### PR DESCRIPTION
## What

Fixes the docs editor bug where the `@`-mention suggestion popup floats out unexpectedly and can't be dismissed (octo-web #624). Scope is exactly the approved **A + B** from the root-cause analysis — no trigger-rule changes, no schema/Yjs/mention-attr changes.

The `@`-mention and `:`-emoji popups share one renderer (`suggestionMenu.ts`); the slash menu has an equivalent inline renderer (`SlashCommand.ts`). Both had the same three defects, so both are fixed identically.

### A — zero results render nothing
- The shared renderer no longer mounts its container to `<body>` for an empty result set and no longer paints the `octo-suggest-empty` "—" placeholder; an update that drops results to zero tears the box down.
- The slash renderer gets the same treatment (an empty filtered list mounted an empty bordered box before).

### B — Esc + outside-click close
- Escape now destroys the popup and marks the session dismissed instead of only consuming the key. It no longer claims Escape when nothing is open.
- A capture-phase `document` `mousedown` listener closes the popup on an outside click / blur and is removed on `onExit` (no cross-session leak).

## Changed files
- `packages/docs/src/editor/suggestionMenu.ts` — shared mention/emoji renderer: empty→no-render, Esc destroy, outside-click close, listener cleanup.
- `packages/docs/src/editor/SlashCommand.ts` — same fixes for the slash menu; renderer factory exported for testing.
- `packages/docs/src/editor/styles.css` — remove the now-unused `.octo-suggest-empty` rule.
- `packages/docs/src/editor/suggestionMenu.test.ts` — new jsdom coverage (empty non-render, Esc, outside/inside click, exit cleanup).
- `packages/docs/src/editor/SlashCommand.test.ts` — same coverage for the slash menu.

## Testing
- Added tests were confirmed red on HEAD, green after the fix.
- `packages/docs` vitest: the suggestion/slash suites pass; full suite is 979 passed. The only failures (`EditorShell.test.tsx`, a WebSocket/undici component test) reproduce identically on clean `main` and are unrelated to this change.
- `tsc --noEmit`: no new errors introduced by this change (two pre-existing errors in unrelated files — `dmworkbase/i18n/format.ts`, `members/sort.ts` — exist on `main` unchanged).

Closes #624
