### PR TITLE
fix(loop): drive board & transcript refresh via realtime WS, remove blind polling

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -147,7 +147,17 @@ export default defineConfig(({ mode }) => {
             ? (path: string) => path.replace(/^\/matter/, "")
             : undefined,
         },
-        // Loop (fleet) service API — 真实 multica-server/fleet 联调。
+        // dmloop 实时 WS:直连后端 /ws(loop proxy 不处理 upgrade)。须在 /fleet/api 规则之前。
+        // 生产需网关把 /fleet/ws 的 WebSocket upgrade 转发到后端 /ws。
+        "/fleet/ws": {
+          target: env.VITE_FLEET_WS_URL || "ws://127.0.0.1:8080",
+          // changeOrigin:false 保留原 Host 与 Origin 同源,过后端 checkOrigin;置 true 会 403。
+          changeOrigin: false,
+          secure: false,
+          ws: true,
+          rewrite: (path: string) => path.replace(/^\/fleet\/ws/, "/ws"),
+        },
+        // Loop (fleet) service API — 真实后端 fleet 服务联调。
         // dev fleet 在 127.0.0.1:8091 直接提供完整 /fleet/api/v1/... 路径（不 strip）。
         // 必须放在下面通用 /fleet/api/ 规则之前（vite first-match）。
         "/fleet/api/v1": {

--- a/packages/dmloop/src/api/__tests__/ws.test.ts
+++ b/packages/dmloop/src/api/__tests__/ws.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { WKApp } from "@octo/base";
+import { loopWs } from "../ws";
+
+// loopWs 依赖:WKApp.mittBus(域刷新信号落点)、issueLoopCliToken(握手 token)、全局 WebSocket。
+// 这里全部替身,只验 loopWs 自身的事件→刷新映射、去抖合并、on() 分发,不打真实网络。
+vi.mock("@octo/base", () => ({
+  WKApp: { mittBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn() } },
+}));
+vi.mock("../authApi", () => ({
+  issueLoopCliToken: vi.fn(() => Promise.resolve({ token: "tok" })),
+}));
+
+// 可被测试驱动的假 WebSocket:记录 send、暴露 open()/message() 触发回调。
+class FakeWebSocket {
+  static last: FakeWebSocket | null = null;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: string[] = [];
+  constructor(public url: string) { FakeWebSocket.last = this; }
+  send(d: string) { this.sent.push(d); }
+  close() { /* no-op */ }
+  open() { this.onopen?.(); }
+  message(obj: unknown) { this.onmessage?.({ data: JSON.stringify(obj) }); }
+}
+
+const emitMock = () => (WKApp.mittBus.emit as unknown as Mock);
+
+// 起连并推进到「已鉴权、可收事件」:start → 等 token 微任务 → onopen(发 auth) → auth_ack。
+// 末尾推进过去抖窗口,把 auth_ack 自己排的那次 refresh 冲掉,让调用方从干净态开始断言。
+async function connectAndAuth(slug = "ws-test") {
+  loopWs.start(slug);
+  await vi.advanceTimersByTimeAsync(0); // flush issueLoopCliToken() 的微任务 → 创建 socket
+  const sock = FakeWebSocket.last!;
+  sock.open();
+  sock.message({ type: "auth_ack" });
+  await vi.advanceTimersByTimeAsync(250); // 冲掉 auth_ack 排的 refresh
+  return sock;
+}
+
+describe("loopWs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+    FakeWebSocket.last = null;
+    emitMock().mockClear();
+  });
+  afterEach(() => {
+    loopWs.stop();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("握手 token 作为首帧 auth 发送", async () => {
+    const sock = await connectAndAuth();
+    expect(sock.sent).toHaveLength(1);
+    expect(JSON.parse(sock.sent[0])).toEqual({ type: "auth", payload: { token: "tok" } });
+  });
+
+  it("一串 REFRESH 事件在去抖窗口内合并成一次 wk:loop-issues-refresh", async () => {
+    const sock = await connectAndAuth();
+    emitMock().mockClear(); // 忽略 auth_ack 自己排的那次
+    sock.message({ type: "issue:created" });
+    sock.message({ type: "task:dispatch" });
+    sock.message({ type: "task:running" });
+    expect(emitMock()).not.toHaveBeenCalled(); // 去抖窗口内不立即发
+    await vi.advanceTimersByTimeAsync(250);
+    const refreshCalls = emitMock().mock.calls.filter((c) => c[0] === "wk:loop-issues-refresh");
+    expect(refreshCalls).toHaveLength(1); // 三帧合并成一次
+  });
+
+  it("非看板事件(task:progress/activity:created)不触发看板刷新", async () => {
+    const sock = await connectAndAuth();
+    emitMock().mockClear();
+    sock.message({ type: "task:progress" });
+    sock.message({ type: "activity:created" });
+    sock.message({ type: "agent:status" }); // presence:也不刷看板
+    await vi.advanceTimersByTimeAsync(300);
+    expect(emitMock().mock.calls.filter((c) => c[0] === "wk:loop-issues-refresh")).toHaveLength(0);
+  });
+
+  it("auth_ack 触发一次刷新(重连补齐)", async () => {
+    loopWs.start("ws-test");
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeWebSocket.last!;
+    sock.open();
+    sock.message({ type: "auth_ack" });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(emitMock().mock.calls.filter((c) => c[0] === "wk:loop-issues-refresh")).toHaveLength(1);
+  });
+
+  it("on(type) 收到原始 payload;退订后不再回调", async () => {
+    const sock = await connectAndAuth();
+    const h = vi.fn();
+    const off = loopWs.on("task:progress", h);
+    sock.message({ type: "task:progress", payload: { seq: 1 } });
+    expect(h).toHaveBeenCalledWith({ seq: 1 });
+    off();
+    sock.message({ type: "task:progress", payload: { seq: 2 } });
+    expect(h).toHaveBeenCalledTimes(1);
+  });
+
+  it("坏帧(非 JSON / 无 type)被安全丢弃,不触发刷新", async () => {
+    const sock = await connectAndAuth();
+    emitMock().mockClear();
+    sock.onmessage?.({ data: "not-json" });
+    sock.message({ type: 123 }); // type 非 string
+    sock.message({ payload: {} }); // 无 type
+    await vi.advanceTimersByTimeAsync(300);
+    expect(emitMock().mock.calls.filter((c) => c[0] === "wk:loop-issues-refresh")).toHaveLength(0);
+  });
+});

--- a/packages/dmloop/src/api/ws.ts
+++ b/packages/dmloop/src/api/ws.ts
@@ -1,0 +1,139 @@
+// @octo/loop 实时 WebSocket 客户端:订阅 workspace 事件驱动看板/面板刷新。
+// token-mode 握手(浏览器 WS 不能设 header):连上后首帧 {type:"auth",payload:{token}},
+// token 取自 /cli-token。dev 经 vite `/fleet/ws` → 后端 /ws;VITE_FLEET_WS_URL 可覆盖直连。
+import { WKApp } from "@octo/base";
+import { issueLoopCliToken } from "./authApi";
+
+// 重连退避:base 起步、指数封顶,带抖动——避免 backend 重启后众客户端齐步重连、也避免死循环打满。
+const RECONNECT_BASE_MS = 2000;
+const RECONNECT_MAX_MS = 30000;
+// 一次派单连发多帧(issue:created→task:dispatch→…),去抖合并成一次看板重取。
+const REFRESH_DEBOUNCE_MS = 250;
+
+// 触发看板重取的事件。不含 task:progress/activity:created(高频、只关 transcript)、
+// agent:status(presence)——后者由 SquadDetailPage 经 on() 单订。
+const REFRESH_EVENTS = new Set([
+  "issue:created",
+  "issue:updated",
+  "issue:deleted",
+  "task:dispatch",
+  "task:queued",
+  "task:running",
+  "task:completed",
+  "task:failed",
+]);
+
+function wsUrl(slug: string): string {
+  const base = (import.meta as { env?: Record<string, string> }).env?.VITE_FLEET_WS_URL;
+  const q = `?workspace_slug=${encodeURIComponent(slug)}&client_platform=web`;
+  if (base) return `${base.replace(/\/$/, "")}/ws${q}`;
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  return `${proto}://${location.host}/fleet/ws${q}`;
+}
+
+// 单例:LoopPage 按 workspace start/stop。看板等域级刷新订全局 `wk:loop-issues-refresh`;
+// transcript/presence 等高频原始事件用 on(type) 精确订。
+class LoopWs {
+  private ws: WebSocket | null = null;
+  private slug = "";
+  private reconnectTimer: number | null = null;
+  private reconnectAttempts = 0;
+  private refreshTimer: number | null = null;
+  private stopped = true;
+  private handlers = new Map<string, Set<(payload: unknown) => void>>();
+
+  on(type: string, handler: (payload: unknown) => void): () => void {
+    let set = this.handlers.get(type);
+    if (!set) { set = new Set(); this.handlers.set(type, set); }
+    set.add(handler);
+    return () => { this.handlers.get(type)?.delete(handler); };
+  }
+
+  start(slug: string): void {
+    if (!slug) { this.stop(); return; }
+    if (!this.stopped && this.slug === slug) return;
+    this.stop();
+    this.slug = slug;
+    this.stopped = false;
+    void this.open();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.slug = "";
+    this.reconnectAttempts = 0;
+    if (this.reconnectTimer !== null) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    if (this.refreshTimer !== null) { clearTimeout(this.refreshTimer); this.refreshTimer = null; }
+    if (this.ws) {
+      // 先摘全部回调再 close,避免主动断开触发重连、或在途帧影响新上下文。
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      this.ws.onopen = null;
+      try { this.ws.close(); } catch { /* already closing */ }
+      this.ws = null;
+    }
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshTimer !== null) return;
+    this.refreshTimer = window.setTimeout(() => {
+      this.refreshTimer = null;
+      WKApp.mittBus.emit("wk:loop-issues-refresh");
+    }, REFRESH_DEBOUNCE_MS);
+  }
+
+  private async open(): Promise<void> {
+    if (this.stopped) return;
+    const slug = this.slug;
+    let token: string;
+    try {
+      token = (await issueLoopCliToken()).token;
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+    // 取 token 期间可能已 stop/切 workspace。
+    if (this.stopped || slug !== this.slug) return;
+
+    // 构造也可能同步抛(如 VITE_FLEET_WS_URL 畸形),不裹会逃出 open() 不排重连 → 单例僵死。
+    let ws: WebSocket;
+    try { ws = new WebSocket(wsUrl(slug)); } catch { this.scheduleReconnect(); return; }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      if (this.ws === ws) ws.send(JSON.stringify({ type: "auth", payload: { token } }));
+    };
+    ws.onmessage = (e) => {
+      if (this.ws !== ws) return; // 已被切换/stop 取代的旧 socket 排队帧不得影响新上下文
+      let msg: { type?: unknown; payload?: unknown };
+      try { msg = JSON.parse(typeof e.data === "string" ? e.data : ""); } catch { return; }
+      if (!msg || typeof msg.type !== "string") return;
+      // auth_ack:(重)连成功。重置退避计数,并刷新一次补齐断连期漏掉的变更。
+      if (msg.type === "auth_ack") { this.reconnectAttempts = 0; this.scheduleRefresh(); return; }
+      if (REFRESH_EVENTS.has(msg.type)) this.scheduleRefresh();
+      const hs = this.handlers.get(msg.type);
+      if (hs) for (const h of hs) { try { h(msg.payload); } catch { /* handler 自负 */ } }
+    };
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.ws = null;
+      this.scheduleReconnect();
+    };
+    ws.onerror = () => { /* onclose 负责重连 */ };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer !== null) return;
+    // 指数退避封顶 + 抖动([capped/2, capped)):backend 重启众客户端不齐步,持续失败也不打满。
+    const capped = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** this.reconnectAttempts);
+    this.reconnectAttempts += 1;
+    const delay = capped / 2 + Math.random() * (capped / 2);
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.open();
+    }, delay);
+  }
+}
+
+export const loopWs = new LoopWs();

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -100,9 +100,10 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
     listProjectOptions().then(setProjects).catch(() => {});
   }, []);
 
-  const reload = useCallback(() => {
+  // silent=true:后台重取不切 loading(WS 刷新 / mutation 回读用,避免闪屏);首次/改筛选/切视图走非静默。
+  const reload = useCallback((silent = false) => {
     const my = ++seq.current;
-    setLoading(true);
+    if (!silent) setLoading(true);
     // 时间范围:三参数须同时给且 start<end。onChange 已把 dateRange 归一为 undefined|[起,止]。
     // 止端 +1 日历日 → 半开区间,既含止日当天、又保证 start<end;setDate 处理 DST。
     const dr = f.dateRange;
@@ -189,21 +190,11 @@ export default function IssuePage({ defaultScope, defaultView }: IssuePageProps 
       .then((tasks) => { if (my === runSeq.current) setRunning(new Set(tasks.filter((tk) => isActiveRun(tk.status) && tk.issue_id).map((tk) => tk.issue_id))); })
       .catch(() => {});
   }, []);
-  // 挂载取一次 + 每 15s 轮询:无 WS 推送,agent 起停靠轮询让 running chip 最终收敛(而非只在本地 mutation 后)。
-  useEffect(() => {
-    refreshRunning();
-    const timer = setInterval(refreshRunning, 15000);
-    return () => clearInterval(timer);
-  }, [refreshRunning]);
+  useEffect(() => { refreshRunning(); }, [refreshRunning]);
 
-  // 变更后刷新:既重取列表,又刷新运行中快照(指派/状态变更可能起/停 agent run)。
-  const onMutated = useCallback(() => { reload(); refreshRunning(); }, [reload, refreshRunning]);
+  const onMutated = useCallback(() => { reload(true); refreshRunning(); }, [reload, refreshRunning]);
 
-  // 派单(quick-create)是异步的:agent 稍后才建 issue(dmloop 无 WS 推送,见记忆 dmloop-no-realtime-defer-ws)。
-  // NewLoopPage 派单成功发 `wk:loop-issues-dispatched`,常驻的 LoopPage 据此有界补发 `wk:loop-issues-refresh`,
-  // 看板收到即重取——一套机制覆盖"看板内新建"与"侧栏新建"两个入口(定时器归 LoopPage,见那里)。
-  // 走 ref 读最新 onMutated:延迟刷新须用当前筛选/视图,否则会用陈旧入参覆盖(reload 的 seq 守卫只防乱序)。
-  // ponytail: 真正的修法是 WS 实时推送(已记后期做),此为 stopgap;派单低频,几次补刷可接受。
+  // WS 事件 → 静默重取。走 ref 读最新 onMutated,用当前筛选/视图重取(避免陈旧闭包)。
   const onMutatedRef = useRef(onMutated);
   useEffect(() => { onMutatedRef.current = onMutated; }, [onMutated]);
   useEffect(() => {

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Typography, Dropdown, Avatar, Modal, Toast, Button } from "@douyinfe/semi-ui";
 import {
   ClipboardList, Briefcase, Bot, Users, Settings,
@@ -11,6 +11,7 @@ import { listWorkspaces, createWorkspace } from "../api/workspaceApi";
 import { setWorkspaceContext, currentWorkspaceId } from "../api/http";
 import { invalidateDirectory } from "../api/directory";
 import { invalidateRuntimeMap } from "../api/agentApi";
+import { loopWs } from "../api/ws";
 import IssuePage from "./IssuePage";
 import NewLoopPage from "./NewLoopPage";
 import ProjectPage from "./ProjectPage";
@@ -24,9 +25,6 @@ import "../ui/loopControls.css";
 const { Title, Text } = Typography;
 
 type TabKey = "myloop" | "issue" | "project" | "automation" | "agent" | "squad" | "settings";
-
-// 派单后看板补刷的退避时刻(ms):agent 异步建单的落库延迟不可观测,手调的退避窗口(非可推导状态)。
-const SETTLE_DELAYS_MS = [2000, 5000, 9000, 14000];
 
 
 // 顶部独立入口：我的回路（复用 Issue 视图的「与我相关」分组）。
@@ -104,10 +102,12 @@ export default function LoopPage() {
       setWsId(ws.id);
       invalidateDirectory();
       invalidateRuntimeMap();
+      loopWs.start(ws.slug);
       WKApp.routeRight.replaceToRoot(renderTab(tab, ws));
     } else {
       setWorkspaceContext("", "");
       setWsId("");
+      loopWs.stop();
       showEmptyGuide();
     }
     setWorkspaces(list);
@@ -149,27 +149,15 @@ export default function LoopPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaces, wsId, loaded]);
 
-  // 派单后看板补刷:quick-create 异步(agent 稍后建 issue,dmloop 无 WS,见记忆 dmloop-no-realtime-defer-ws)。
-  // NewLoopPage 派单成功发 `wk:loop-issues-dispatched`;由常驻(不随 tab/建单入口重挂)的 LoopPage 持有定时器,
-  // 有界补发 `wk:loop-issues-refresh`,当前挂载的看板(IssuePage)订阅后重取——一套机制统一覆盖
-  // 「看板内新建」与「侧栏新建」两个入口(此前 settle 只挂在看板实例上,漏了侧栏 openTab 重挂的路径)。
-  const settleTimersRef = useRef<number[]>([]);
-  useEffect(() => {
-    const onDispatched = () => {
-      settleTimersRef.current.forEach(clearTimeout);
-      settleTimersRef.current = SETTLE_DELAYS_MS.map((d) =>
-        window.setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), d),
-      );
-    };
-    WKApp.mittBus.on("wk:loop-issues-dispatched", onDispatched);
-    return () => { WKApp.mittBus.off("wk:loop-issues-dispatched", onDispatched); settleTimersRef.current.forEach(clearTimeout); };
-  }, []);
+  // LoopPage 常驻:WS 连接由 applyWorkspace/switchWorkspace 建立,卸载时断开。
+  useEffect(() => () => loopWs.stop(), []);
 
   const switchWorkspace = (w: Workspace) => {
     setWorkspaceContext(w.slug, w.id);
     setWsId(w.id);
     invalidateDirectory();
     invalidateRuntimeMap();
+    loopWs.start(w.slug);
     WKApp.routeRight.replaceToRoot(renderTab(tab, w));
   };
 

--- a/packages/dmloop/src/pages/NewLoopPage.tsx
+++ b/packages/dmloop/src/pages/NewLoopPage.tsx
@@ -85,10 +85,7 @@ export default function NewLoopPage({ onCreated }: NewLoopPageProps) {
       });
       // 单一 toast 归属此处(异步派单的准确措辞);duration 显式设 3s 保证自动消失。
       Toast.success({ content: t("loop.newLoop.dispatched"), duration: 3 });
-      // 派单是异步的(agent 稍后建 issue),通知常驻 LoopPage 有界补刷看板,使新回路自动出现(无需手动 reload)。
-      // 见 LoopPage 的 wk:loop-issues-dispatched 处理;覆盖看板内/侧栏两个入口。
-      WKApp.mittBus.emit("wk:loop-issues-dispatched");
-      // 成功后由调用方负责导航(切回回路看板)——此处不再自行 back(),避免叠加把新根 pop 掉。
+      // 看板刷新由 WS 驱动,此处只导航回看板。
       onCreated?.();
     } catch (e) {
       // quick-create 结构化 422:LoopApiError.code 映射成友好提示(即时失败反馈)。

--- a/packages/dmloop/src/panel/RunDetailModal.tsx
+++ b/packages/dmloop/src/panel/RunDetailModal.tsx
@@ -12,13 +12,15 @@ import {
   ChevronRight,
   Clock,
 } from "lucide-react";
-import { useI18n } from "@octo/base";
+import { useI18n, WKApp } from "@octo/base";
 import type { TaskRun, RunMessage } from "../api/types";
 import { listRunMessages, listRuns } from "../api/runsApi";
+import { loopWs } from "../api/ws";
 import { isActiveRun } from "../ui/meta";
 import { formatDurationMs } from "../ui/time";
 
-const POLL_MS = 2000;
+// 终态后再补一次增量抓取的延迟(收尾 result/error 消息常在 status 翻转后才写入,#610)。
+const TAIL_FETCH_MS = 2000;
 
 type EventColor = "agent" | "thinking" | "tool" | "result" | "error";
 
@@ -152,55 +154,86 @@ export default function RunDetailModal({
   const missRef = useRef(0);
   const MAX_MISSES = 3;
 
-  // 打开时全量拉;运行中的 run 则每 2s 增量轮询 + 刷新状态,终态即停(无 WS,退化轮询)。
+  // 打开全量拉;运行中订阅 WS 事件驱动增量 + 状态,终态即停。
   useEffect(() => {
     if (!visible || !run) { setMessages([]); setLiveRun(null); lastSeqRef.current = 0; missRef.current = 0; setGone(false); return; }
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    let finalTimer: ReturnType<typeof setTimeout> | undefined;
+    let unsub: Array<() => void> = [];
+    const stopListening = () => { unsub.forEach((f) => f()); unsub = []; };
     lastSeqRef.current = 0;
     missRef.current = 0;
     setGone(false);
     setLiveRun(run);
+    setMessages([]); // 切 run 时清空,后续一律 append+dedup(避免整表替换盖掉并发到达的增量)
 
-    const apply = (batch: RunMessage[], incremental: boolean) => {
-      if (batch.length) lastSeqRef.current = Math.max(lastSeqRef.current, ...batch.map((m) => m.seq));
-      if (!incremental) { setMessages(batch); return; }
+    const apply = (batch: RunMessage[]) => {
       if (!batch.length) return;
+      lastSeqRef.current = Math.max(lastSeqRef.current, ...batch.map((m) => m.seq));
       setMessages((prev) => {
         const seen = new Set(prev.map((m) => m.seq));
         return [...prev, ...batch.filter((m) => !seen.has(m.seq))];
       });
     };
 
-    const poll = () => {
-      timer = setTimeout(async () => {
-        if (cancelled) return;
-        await listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? [], true); }).catch(() => {});
-        let stillActive = true;
+    // 增量抓取 + 状态检查。in-flight 守卫:突发事件不并发重叠,进行中再来的合并成一次尾随重跑。
+    // 事件为 workspace 级未按 run 过滤,抓本 run 自己的消息即可。
+    let ticking = false;
+    let pending = false;
+    const tick = async () => {
+      if (cancelled) return;
+      if (ticking) { pending = true; return; }
+      ticking = true;
+      try {
+        await listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? []); }).catch(() => {});
         try {
           const fresh = (await listRuns(run.issue_id)).find((r) => r.id === run.id);
           if (cancelled) return;
-          if (fresh) { setLiveRun(fresh); stillActive = isActiveRun(fresh.status); missRef.current = 0; }
-          else { missRef.current += 1; stillActive = missRef.current < MAX_MISSES; if (!stillActive) setGone(true); } // 连续 miss 达阈值:判定 run 已消失,停轮询并提示
-        } catch { /* ensureDirectory 等抛错:保持轮询 */ }
-        if (!cancelled && stillActive) poll();
-        // 终止前再做一次增量抓取:run 完成时的最后一批消息(result/error)常在上面抓取返回后、
-        // status 翻转前才写入,不补一次会永久丢失最关键的收尾消息(#610 评审)。
-        else if (!cancelled) await listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? [], true); }).catch(() => {});
-      }, POLL_MS);
+          if (fresh) {
+            setLiveRun(fresh);
+            missRef.current = 0;
+            if (!isActiveRun(fresh.status)) {
+              // 终态:停订阅,再延迟补一次增量——收尾 result/error 消息常在 status 翻转后才写入(#610)。
+              stopListening();
+              finalTimer = setTimeout(() => {
+                listRunMessages(run.id, lastSeqRef.current).then((b) => { if (!cancelled) apply(b ?? []); }).catch(() => {});
+              }, TAIL_FETCH_MS);
+            }
+          } else {
+            missRef.current += 1;
+            if (missRef.current >= MAX_MISSES) { setGone(true); stopListening(); } // 连续 miss:run 已消失,停并提示
+          }
+        } catch { /* ensureDirectory 等抛错:忽略,下个事件再试 */ }
+      } finally {
+        ticking = false;
+        if (pending && !cancelled) { pending = false; void tick(); }
+      }
     };
+
+    // 先订阅再 fetch:监听器必须在初始 fetch 之前挂——否则 fetch 那一 round-trip 内到达的终态事件
+    // 会因无监听器丢失(终态不复发 → tick 永不触发 → 弹窗永远卡在"运行中")。仅运行中 run 订阅。
+    if (isActiveRun(run.status)) {
+      const trigger = () => { void tick(); };
+      WKApp.mittBus.on("wk:loop-issues-refresh", trigger); // 域级:含 issue:deleted / 终态 / 重连
+      unsub = [
+        () => WKApp.mittBus.off("wk:loop-issues-refresh", trigger),
+        loopWs.on("activity:created", trigger), // transcript 增量
+        loopWs.on("task:progress", trigger),
+      ];
+    }
 
     setLoading(true);
     listRunMessages(run.id)
-      .then((m) => { if (!cancelled) apply(m ?? [], false); })
+      .then((m) => { if (!cancelled) apply(m ?? []); })
       .catch(() => { if (!cancelled) setMessages([]); })
       .finally(() => {
         if (cancelled) return;
         setLoading(false);
-        if (isActiveRun(run.status)) poll();
+        // reconcile:补齐 fetch 窗口内到达的事件,并用 listRuns 查最新状态(mount 时 run.status 可能已陈旧)。
+        if (isActiveRun(run.status)) void tick();
       });
 
-    return () => { cancelled = true; if (timer) clearTimeout(timer); };
+    return () => { cancelled = true; stopListening(); if (finalTimer) clearTimeout(finalTimer); };
   }, [visible, run]);
 
   const shown = liveRun ?? run;

--- a/packages/dmloop/src/panel/SquadDetailPage.tsx
+++ b/packages/dmloop/src/panel/SquadDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   getSquad, updateSquad, deleteSquad, addSquadMember, removeSquadMember, updateSquadMemberRole, getSquadMemberStatus,
 } from "../api/squadApi";
 import { listAssigneeCandidates } from "../api/issueApi";
+import { loopWs } from "../api/ws";
 import { confirmDelete } from "../ui/confirmDelete";
 import { formatRelativeTime } from "../ui/time";
 import AgentDetailPage from "./AgentDetailPage";
@@ -63,10 +64,10 @@ export default function SquadDetailPage({ squadId, onChanged }: { squadId: strin
   }, [squadId]);
   useEffect(load, [load]);
   useEffect(() => { listAssigneeCandidates().then((cs) => setCands(cs.filter((c) => c.type !== "squad"))).catch(() => setCands([])); }, []);
-  // 成员状态非实时推送：面板打开期间每 30s 轮询一次，作为 staleTime 式兜底。
+  // 成员在线状态由 WS agent:status 驱动;断连期间的变化在重连后下个心跳自愈。
   useEffect(() => {
-    const id = window.setInterval(() => { getSquadMemberStatus(squadId).then(setStatusList).catch(() => undefined); }, 30000);
-    return () => window.clearInterval(id);
+    const refetch = () => { getSquadMemberStatus(squadId).then(setStatusList).catch(() => undefined); };
+    return loopWs.on("agent:status", refetch);
   }, [squadId]);
 
   const statusById = useMemo(() => {

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -71,12 +71,7 @@ export type MittEvents = {
    * 不会自动 remount, 接收方需要主动 reload。
    */
   'wk:nav-menu-activated': { menuId: string };
-  /**
-   * dmloop 派单(quick-create)后的看板补刷协议。派单是异步的(agent 稍后建 issue,dmloop 暂无 WS 推送):
-   * NewLoopPage 派单成功发 `wk:loop-issues-dispatched`;常驻的 LoopPage 据此有界补发 `wk:loop-issues-refresh`,
-   * 当前挂载的看板(IssuePage)订阅后重取,使新回路自动出现——统一覆盖看板内/侧栏两个建单入口。
-   */
-  'wk:loop-issues-dispatched': void;
+  /** dmloop 看板实时刷新信号:WS 客户端(dmloop/api/ws.ts)收到 issue/task 事件时发出,看板订阅后静默重取。 */
   'wk:loop-issues-refresh': void;
   /**
    * 打开「密钥 / Secrets」管理面板（YUJ-3539）。由聊天反向跳转（bot 消息里的


### PR DESCRIPTION
Closes #713

## Problem
After a quick-create dispatch on the Loop board, the new issue did **not** appear without a manual full-page reload, and the timer-based settle-poll flashed the board (loading state) repeatedly. Root cause: dmloop had no realtime channel, so it *guessed* when the async agent-created issue would land — too few polls miss the window (issue never shows), more polls flicker. Blind polling can't win.

## Fix
Subscribe to the backend's existing realtime stream instead of guessing. A small WS client (`packages/dmloop/src/api/ws.ts`) connects per-workspace, and a single debounced silent refetch runs when the backend actually reports a change. This removes **all** blind polling in dmloop (Rule-9 class fix):

| Poll removed | Replaced by |
|---|---|
| board settle-poll `[2,5,9,14]s` | WS `issue:*` / `task:*` → `wk:loop-issues-refresh` (debounced 250ms) |
| IssuePage running-chip 15s | same WS refresh signal |
| RunDetailModal transcript 2s | WS `activity:created`/`task:progress` (transcript) + `wk:loop-issues-refresh` (liveness/terminal/gone) |
| SquadDetailPage presence 30s | WS `agent:status` |

Key points:
- **Auth**: token-mode handshake — first frame `{type:"auth",payload:{token}}` with the session token from the existing `/cli-token` endpoint (browsers can't set WS handshake headers). No new endpoint, no new backend/service.
- **De-flicker**: `IssuePage.reload(silent)` — WS-driven refetches don't toggle the loading state; only initial load / filter change / view switch show loading.
- **Resilience**: 3s auto-reconnect; `auth_ack` re-emits the refresh signal so a reconnect backfills anything missed while down.
- **RunDetailModal** keeps its terminal final-fetch (#610) + gone guard, now driven by the workspace-wide `wk:loop-issues-refresh` signal (covers `issue:deleted` / terminal / reconnect) so liveness/gone detection can't freeze.

## Blast radius (Rule 8)
- `packages/dmworkbase/src/App.tsx` (shared `MittEvents`): removed the now-unused `wk:loop-issues-dispatched` key (grep confirms zero remaining refs repo-wide); kept `wk:loop-issues-refresh`. No other package consumes these.
- New `loopWs` singleton is consumed only within `packages/dmloop` (LoopPage/IssuePage/RunDetailModal/SquadDetailPage).
- `apps/web/vite.config.ts`: additive `/fleet/ws` proxy rule; no change to existing routes.

## Verification
- **Real-env e2e (dev, not just unit tests)**: dispatched via the composer — the new issue (`ALI-10`) auto-appeared on the board with no manual reload (待办 → 运行中 driven by WS `task:*`), no flicker, console error-free. Re-verified after applying review fixes. WS handshake confirmed against the backend (`auth_ack`; dispatch pushes `issue:created` + `task:*` + `activity:created`).
- **Unit tests**: added `packages/dmloop/src/api/__tests__/ws.test.ts` (6 cases: debounce coalescing, non-board events don't refresh, `auth_ack` refresh, `on()` dispatch/unsubscribe, malformed-frame safety). `pnpm --filter @octo/loop test` → 23/23 pass.
- `tsc` clean on changed files.

## Review
- `/simplify` (4 angles) applied. Adversarial code review found one real bug — RunDetailModal could freeze "running" forever if the run vanished via `issue:deleted` (event not in its old whitelist) — fixed by subscribing to the broad `wk:loop-issues-refresh` signal.

## Deploy coordination (cross-end follow-up)
Production gateway must proxy `/fleet/ws` → backend `/ws` **with WebSocket upgrade** (prefer same-origin so the backend `checkOrigin` same-origin branch passes; otherwise set the backend `ALLOWED_ORIGINS` to include the octo-web origin). Dev is handled by the vite `/fleet/ws` rule (`ws:true`, `changeOrigin:false`). No backend deploy otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)