### PR TITLE
fix(docs): allow table column resize drag to start

### DIFF
--- a/packages/docs/src/editor/TableCellView.test.ts
+++ b/packages/docs/src/editor/TableCellView.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableCellView } from './TableCellView.ts'
+
+// #621-1 regression: the self-built cell NodeView must NOT stop the
+// column-resize-handle mousedown. Returning true there short-circuits
+// prosemirror-view's eventBelongsToView, so prosemirror-tables' columnResizing
+// plugin never sees the mousedown and the column can't be dragged (the handle
+// still shows on hover — matching the original bug report). It must also keep
+// ignoreMutation so the resize plugin's colwidth → inline-width writes on the
+// cell are not re-parsed as content edits under collaboration.
+
+function firstCellNode(): PMNode {
+  const editor = new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+    ],
+    content:
+      '<table><tbody><tr><td><p>a</p></td><td><p>b</p></td></tr></tbody></table>',
+  })
+  let cell: PMNode | null = null
+  editor.state.doc.descendants((node) => {
+    if (!cell && (node.type.name === 'tableCell' || node.type.name === 'tableHeader')) {
+      cell = node
+      return false
+    }
+    return true
+  })
+  editor.destroy()
+  if (!cell) throw new Error('no table cell node found in seeded document')
+  return cell
+}
+
+let view: TableCellView | null = null
+afterEach(() => {
+  view = null
+})
+
+describe('TableCellView.stopEvent (column resize drag)', () => {
+  it('returns false for a .column-resize-handle mousedown so the drag can start', () => {
+    view = new TableCellView(firstCellNode(), 'td')
+    const handle = document.createElement('div')
+    handle.className = 'column-resize-handle'
+    const event = { type: 'mousedown', target: handle } as unknown as Event
+    // stopEvent is narrowed to () => boolean; call through the PM contract type
+    // to express that the resize-handle event specifically is not stopped.
+    const stopEvent = view.stopEvent as unknown as (e: Event) => boolean
+    expect(stopEvent.call(view, event)).toBe(false)
+  })
+
+  it('does not stop ordinary in-cell events either (typing/selection flow to PM)', () => {
+    view = new TableCellView(firstCellNode(), 'td')
+    const event = { type: 'mousedown', target: view.dom } as unknown as Event
+    const stopEvent = view.stopEvent as unknown as (e: Event) => boolean
+    expect(stopEvent.call(view, event)).toBe(false)
+  })
+
+  it('still ignores attribute mutations on its own cell element (colwidth writes)', () => {
+    view = new TableCellView(firstCellNode(), 'td')
+    expect(view.ignoreMutation({ type: 'attributes', target: view.dom })).toBe(true)
+  })
+})

--- a/packages/docs/src/editor/TableCellView.ts
+++ b/packages/docs/src/editor/TableCellView.ts
@@ -68,11 +68,13 @@ export class TableCellView {
     return false
   }
 
-  /** Don't let the resize plugin's own mousedown/handle events be treated as
-   * editor input; everything else (typing, selection) flows to PM. */
-  stopEvent(event: Event): boolean {
-    const target = event.target as HTMLElement | null
-    if (!target) return false
-    return target.classList?.contains('column-resize-handle') ?? false
+  /** Let every event flow to ProseMirror. In particular the column-resize-handle
+   * mousedown MUST reach prosemirror-tables' columnResizing plugin
+   * (handleDOMEvents.mousedown) — stopping it here short-circuits eventBelongsToView
+   * so the drag never starts (the handle shows on hover but the column can't be
+   * dragged). Content mutations that resizing makes to the cell are already handled
+   * by ignoreMutation above, so nothing needs to be suppressed at the event level. */
+  stopEvent(): boolean {
+    return false
   }
 }

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -136,10 +136,10 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // ProseMirror's native drag pipeline, so moves sync as ordinary transactions.
     BlockDragHandle,
     // SCHEMA-SPEC §4 (SCHEMA_VERSION 4): tables. extension-table series pinned at
-    // 2.27.2 (matching the stack — v3 would pull a second Tiptap core). Column
-    // resizing is on; cells use a self-built NodeView (TableCellView) that gives
-    // ProseMirror explicit ignoreMutation/stopEvent rules so resize/remote DOM
-    // writes don't desync collaborative cursors (§3.2 requirement).
+    // 3.22.2 (matching the Tiptap core). Column resizing is on; cells use a
+    // self-built NodeView (TableCellView) that gives ProseMirror explicit
+    // ignoreMutation/stopEvent rules so resize/remote DOM writes don't desync
+    // collaborative cursors (§3.2 requirement).
     Table.configure({ resizable: true }),
     TableRow,
     TableHeader.extend({


### PR DESCRIPTION
## Summary

Table column widths could not be dragged in the docs editor (Tiptap + Yjs). The hover handle showed on the column border, but dragging it did nothing.

Root cause: the self-built cell NodeView `TableCellView.stopEvent` returned `true` for `.column-resize-handle`. That short-circuits ProseMirror's `eventBelongsToView`, so the handle's `mousedown` never reached `prosemirror-tables`' `columnResizing` plugin (`handleDOMEvents.mousedown`) and the drag never started. `mousemove` runs through a non-guarded path, which is why the hover handle still appeared — matching the reported symptom (visible handle, no drag).

The Table config itself is correct (`Table.configure({ resizable: true })`, columnResizing plugin mounted), so the fix is a single event-level change in the NodeView.

## Changes

- `packages/docs/src/editor/TableCellView.ts` (stopEvent, ~line 71-76): return `false` so the resize handle's `mousedown` reaches the columnResizing plugin. Cell DOM writes during resize are still guarded by `ignoreMutation` (kept unchanged), so collaborative cursors don't desync.
- `packages/docs/src/editor/extensions.ts` (~line 138): corrected a stale comment (extension-table is pinned at `3.22.2`, not `2.27.2`).

`ignoreMutation` is intentionally left in place — it prevents the resize plugin's `colwidth → inline width` writes from being re-parsed as content edits under collaboration.

## Testing

- typecheck (`tsc --noEmit`): no new errors introduced (the two pre-existing errors in `dmworkbase/src/i18n/format.ts` and `src/members/sort.ts` are present on `main` and unrelated to this change).
- vitest: table-specific suites green — `src/editor/TableControls.test.tsx` + `src/export/docx/table-layout.test.ts` (24/24). The repo's remaining vitest failures are flaky jsdom `requestAnimationFrame` / undici WebSocket environment errors that also fail on a clean checkout (same failure count, different files across runs) and are independent of this change.
- eslint: repo `pnpm lint` (turbo) defines no lint tasks for any package, so there is nothing to run.

Closes #621 (sub-issue 1: column resize drag).

Draft: keep in draft until reviewer / deploy / QA sign-off, then promote to a regular PR.
