### PR TITLE
fix(docs): keep table toolbar clear of text and label delete controls (#625, #621-2)

### DIFF
--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -8,7 +8,7 @@ import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
 import { CellSelection } from '@tiptap/pm/tables'
 import { TextSelection } from '@tiptap/pm/state'
-import { shouldShowTableBubble, TableGridPicker, TableBubbleMenu } from './TableControls.tsx'
+import { shouldShowTableBubble, TableGridPicker, TableBubbleMenu, clampToolbarAnchorRect } from './TableControls.tsx'
 
 // #595 — table add/delete row/column UI. The critical acceptance point is that the controls work on
 // tables that ALREADY EXIST in a document (parsed from stored HTML), not only freshly inserted
@@ -173,6 +173,45 @@ describe('TableBubbleMenu — does not block the column-resize hot zone (#595 C1
     expect(buttons.length).toBeGreaterThan(0)
     e.destroy()
     host.remove()
+  })
+})
+
+describe('clampToolbarAnchorRect — keep the toolbar anchor inside the viewport (#625 off-screen)', () => {
+  const VIEWPORT = { width: 1200, height: 1000 }
+
+  it('leaves a fully-visible table at its real top edge (no TC-P0-001 regression)', () => {
+    // A normal table sitting mid-viewport: the band stays at the real top so the toolbar still
+    // floats above the table exactly as before.
+    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT)
+    expect(r.top).toBe(300)
+    expect(r.height).toBe(0)
+    expect(r.left).toBe(200)
+    expect(r.right).toBe(900)
+  })
+
+  it('clamps a long table scrolled past the top back inside the viewport', () => {
+    // The failing case: 34-row table scrolled so its top is far above the viewport and its bottom
+    // is below it. Previously the toolbar landed at ~1051 (below a 1000px viewport); now the anchor
+    // band is clamped to TOOLBAR_SAFE_TOP so the controls render near the top of the screen.
+    const r = clampToolbarAnchorRect({ top: -1248, bottom: 1052, left: 200, right: 900 }, VIEWPORT)
+    expect(r.top).toBe(64)
+    expect(r.bottom).toBe(64)
+    // and well within the viewport
+    expect(r.top).toBeGreaterThan(0)
+    expect(r.bottom).toBeLessThan(VIEWPORT.height)
+  })
+
+  it('never drops the band below the viewport bottom', () => {
+    const r = clampToolbarAnchorRect({ top: 5000, bottom: 6000, left: 100, right: 400 }, VIEWPORT)
+    expect(r.top).toBe(VIEWPORT.height - 8)
+    expect(r.top).toBeLessThan(VIEWPORT.height)
+  })
+
+  it('clamps the horizontal extent of a wide / off-screen table into the viewport', () => {
+    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: -500, right: 3000 }, VIEWPORT)
+    expect(r.left).toBe(0)
+    expect(r.right).toBe(VIEWPORT.width)
+    expect(r.width).toBe(VIEWPORT.width)
   })
 })
 

--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -176,42 +176,60 @@ describe('TableBubbleMenu — does not block the column-resize hot zone (#595 C1
   })
 })
 
-describe('clampToolbarAnchorRect — keep the toolbar anchor inside the viewport (#625 off-screen)', () => {
+describe('clampToolbarAnchorRect — keep the toolbar clear of the fixed toolbar (#625 off-screen + #716)', () => {
   const VIEWPORT = { width: 1200, height: 1000 }
+  // Bottom edge of the fixed editor toolbar in viewport coords, as tableReferenceElement measures it.
+  const TOOLBAR_BOTTOM = 64
 
   it('leaves a fully-visible table at its real top edge (no TC-P0-001 regression)', () => {
-    // A normal table sitting mid-viewport: the band stays at the real top so the toolbar still
-    // floats above the table exactly as before.
-    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT)
+    // A normal table sitting mid-viewport, well below the fixed toolbar: the band stays a
+    // zero-height anchor at the real top so the toolbar still floats above the table as before.
+    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT, TOOLBAR_BOTTOM)
     expect(r.top).toBe(300)
     expect(r.height).toBe(0)
     expect(r.left).toBe(200)
     expect(r.right).toBe(900)
   })
 
-  it('clamps a long table scrolled past the top back inside the viewport', () => {
-    // The failing case: 34-row table scrolled so its top is far above the viewport and its bottom
-    // is below it. Previously the toolbar landed at ~1051 (below a 1000px viewport); now the anchor
-    // band is clamped to TOOLBAR_SAFE_TOP so the controls render near the top of the screen.
-    const r = clampToolbarAnchorRect({ top: -1248, bottom: 1052, left: 200, right: 900 }, VIEWPORT)
-    expect(r.top).toBe(64)
-    expect(r.bottom).toBe(64)
-    // and well within the viewport
-    expect(r.top).toBeGreaterThan(0)
-    expect(r.bottom).toBeLessThan(VIEWPORT.height)
+  it('anchors a long table scrolled past the top to the toolbar strip so it flips below (XIN-939)', () => {
+    // The XIN-939 case: 34-row table scrolled so its top is far above the viewport and its bottom
+    // is below it. The band becomes the toolbar strip [0 .. toolbarBottom]; placement:'top' then
+    // overflows the viewport top and Floating-UI flips the controls to just below the fixed toolbar
+    // (top === 0 is what forces that flip; bottom === toolbarBottom is where they land).
+    const r = clampToolbarAnchorRect({ top: -1248, bottom: 1052, left: 200, right: 900 }, VIEWPORT, TOOLBAR_BOTTOM)
+    expect(r.top).toBe(0)
+    expect(r.bottom).toBe(TOOLBAR_BOTTOM)
+    expect(r.left).toBe(200)
+    expect(r.right).toBe(900)
+  })
+
+  it('anchors a table jammed under the fixed toolbar to the strip so it flips below it (#716)', () => {
+    // The #716 follow-up: a table at the very top of the doc sits right beneath a tall fixed
+    // toolbar (bottom 180). Floating above would land the controls behind the fixed toolbar; the
+    // strip band flips them to just below it instead.
+    const tallToolbar = 180
+    const r = clampToolbarAnchorRect({ top: 185, bottom: 405, left: 200, right: 900 }, VIEWPORT, tallToolbar)
+    expect(r.top).toBe(0)
+    expect(r.bottom).toBe(tallToolbar)
   })
 
   it('never drops the band below the viewport bottom', () => {
-    const r = clampToolbarAnchorRect({ top: 5000, bottom: 6000, left: 100, right: 400 }, VIEWPORT)
+    const r = clampToolbarAnchorRect({ top: 5000, bottom: 6000, left: 100, right: 400 }, VIEWPORT, TOOLBAR_BOTTOM)
     expect(r.top).toBe(VIEWPORT.height - 8)
     expect(r.top).toBeLessThan(VIEWPORT.height)
   })
 
   it('clamps the horizontal extent of a wide / off-screen table into the viewport', () => {
-    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: -500, right: 3000 }, VIEWPORT)
+    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: -500, right: 3000 }, VIEWPORT, TOOLBAR_BOTTOM)
     expect(r.left).toBe(0)
     expect(r.right).toBe(VIEWPORT.width)
     expect(r.width).toBe(VIEWPORT.width)
+  })
+
+  it('with no fixed toolbar (toolbarBottom defaults to 0) keeps a fully-visible table at its top', () => {
+    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT)
+    expect(r.top).toBe(300)
+    expect(r.height).toBe(0)
   })
 })
 

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -80,23 +80,56 @@ function TbBtn({
   onClick,
   label,
   title,
+  text,
 }: {
   onClick: () => void
   label: ReactNode
   title: string
+  // When set, a visible text caption is shown next to the icon. Used for the destructive
+  // delete controls (#621-2) so the user reads which row/column/table the action removes,
+  // instead of guessing from an icon alone.
+  text?: string
 }) {
   return (
     <button
       type="button"
-      className="octo-tb-btn"
+      className={'octo-tb-btn' + (text ? ' octo-tb-btn--labeled' : '')}
       title={title}
       aria-label={title}
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
     >
       {label}
+      {text ? <span className="octo-tb-btn-label">{text}</span> : null}
     </button>
   )
+}
+
+/**
+ * Reference rect for the floating table toolbar (#625). Anchors to the OUTER edge of the table
+ * (its scroll wrapper when present) rather than the caret's cell, so the toolbar — placed above
+ * with `placement: 'top'` — floats in the block margin above the whole table instead of landing on
+ * top of the text rows above the caret. Returns a Floating-UI virtual element (computed lazily so
+ * scrolling/resizing stays accurate), or null when the caret is not inside a table, in which case
+ * the BubbleMenu falls back to its default cursor-based positioning.
+ */
+function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => DOMRect; getClientRects: () => DOMRect[] } | null {
+  const { $from } = editor.state.selection
+  for (let depth = $from.depth; depth > 0; depth--) {
+    if ($from.node(depth).type.name === 'table') {
+      const dom = editor.view.nodeDOM($from.before(depth))
+      if (dom instanceof HTMLElement) {
+        // Prefer the ProseMirror `.tableWrapper` scroll box so a horizontally scrolled wide table
+        // still anchors to the visible table region.
+        const anchor = (dom.closest('.tableWrapper') as HTMLElement | null) ?? dom
+        return {
+          getBoundingClientRect: () => anchor.getBoundingClientRect(),
+          getClientRects: () => [anchor.getBoundingClientRect()],
+        }
+      }
+    }
+  }
+  return null
 }
 
 /**
@@ -127,6 +160,11 @@ export function TableBubbleMenu({ editor }: { editor: Editor }) {
       // plugin listens for on the editor DOM. octo-table-bubble-portal makes the floating wrapper
       // transparent to pointer events (see styles.css); only the buttons below re-capture them.
       className="octo-table-bubble-portal"
+      // Anchor the toolbar to the table's outer edge rather than the caret's cell, so with
+      // placement: 'top' it floats in the block margin above the whole table and never covers the
+      // in-table text rows above the caret (#625). Falls back to the default caret rect when the
+      // helper can't find a table (never happens while shouldShow is satisfied).
+      getReferencedVirtualElement={() => tableReferenceElement(editor)}
       options={{ placement: 'top', offset: 8 }}
       shouldShow={({ editor: e }) => shouldShowTableBubble(e)}
     >
@@ -144,6 +182,7 @@ export function TableBubbleMenu({ editor }: { editor: Editor }) {
         <TbBtn
           label={<IconDeleteRow />}
           title={t('docs.table.deleteRow')}
+          text={t('docs.table.deleteRow')}
           onClick={() => editor.chain().focus().deleteRow().run()}
         />
         <span className="octo-tb-sep" />
@@ -160,12 +199,14 @@ export function TableBubbleMenu({ editor }: { editor: Editor }) {
         <TbBtn
           label={<IconDeleteCol />}
           title={t('docs.table.deleteColumn')}
+          text={t('docs.table.deleteColumn')}
           onClick={() => editor.chain().focus().deleteColumn().run()}
         />
         <span className="octo-tb-sep" />
         <TbBtn
           label={<IconDeleteTable />}
           title={t('docs.table.deleteTable')}
+          text={t('docs.table.deleteTable')}
           onClick={() => editor.chain().focus().deleteTable().run()}
         />
       </div>

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -105,65 +105,85 @@ function TbBtn({
   )
 }
 
-// Vertical space (px) reserved above the anchor band so the toolbar — placed above the anchor with
-// `placement: 'top'` — always has room to render inside the viewport. Covers the ~40px control row
-// plus the 8px placement offset with margin to spare.
-const TOOLBAR_SAFE_TOP = 64
+// Vertical clearance (px) the floating toolbar needs to sit ABOVE a table without colliding with
+// the fixed editor toolbar: the ~32px control row plus the 8px placement offset, with margin. Used
+// only to decide whether the table sits far enough below the fixed `.octo-toolbar` for the toolbar
+// to keep floating above it, or whether it must instead drop BELOW the fixed toolbar.
+const TOOLBAR_CLEARANCE = 48
 
 /**
- * Clamp a table's rect into the visual viewport and collapse it to a thin anchor band near its
- * visible top (#625 off-screen fix). This is the pure core of {@link tableReferenceElement},
- * split out so it can be unit-tested without a real layout.
+ * Clamp a table's rect into the visual viewport and collapse it to an anchor band, keyed to the
+ * bottom of the fixed editor toolbar (`.octo-toolbar`), so the floating table toolbar never renders
+ * behind — and gets its clicks swallowed by — that fixed toolbar (#625 off-screen fix + #716
+ * follow-up). Pure core of {@link tableReferenceElement}, split out so it can be unit-tested
+ * without a real layout.
  *
- * Why: the toolbar anchors to the table's OUTER edge and floats above it with `placement: 'top'`.
- * For a long table scrolled so its top leaves the viewport (`rect.top` a large negative), the raw
- * rect's top is off-screen above and its bottom is far below the viewport; Floating-UI's default
- * `flip` then re-anchors to that off-screen bottom edge and the controls land below the viewport
- * (observed: toolbar top ~1051 vs a 1000px viewport), completely unreachable. `shift` doesn't save
- * it because its default boundary is the tall scroll container, not the visual viewport.
+ * The toolbar anchors to the table's OUTER edge and floats above it with `placement: 'top'`. Two
+ * boundaries have to hold at once:
  *
- * Fix: build the reference from a zero-height band whose `top` is the table's top edge CLAMPED into
- * `[TOOLBAR_SAFE_TOP, viewport.height - 8]`, with the horizontal extent clamped into the viewport.
- * A thin band near the top means both `top` and any flipped `bottom` placement resolve to a y just
- * inside the viewport, so the controls stay reachable regardless of flip/shift boundary quirks. In
- * the normal, fully-visible case the table top already sits below `TOOLBAR_SAFE_TOP`, so the band
- * stays at the real top edge and the toolbar floats above the table exactly as before — no
- * TC-P0-001 regression.
+ *  - **Long table scrolled past the top (XIN-939 / #625).** `rect.top` is a large negative and the
+ *    bottom is far below the viewport; Floating-UI's default `flip` would re-anchor to that
+ *    off-screen bottom edge and push the controls below the viewport, unreachable.
+ *  - **Table jammed under the fixed toolbar (#716 follow-up).** A table at the very top of the doc
+ *    sits right beneath the fixed `.octo-toolbar`; floating the controls ABOVE it lands them in the
+ *    band the fixed toolbar occupies, which is opaque and higher in the stack, so it covers the
+ *    controls and intercepts their pointer events.
+ *
+ * Fix: when the table's top is far enough below the fixed toolbar (with {@link TOOLBAR_CLEARANCE}
+ * room to float above), keep a zero-height band at the real top edge — the normal, fully-visible
+ * case is untouched (no #625 / TC-P0-001 regression). Otherwise anchor to the toolbar strip
+ * `[0 .. toolbarBottom]`: `placement: 'top'` then overflows the viewport top, Floating-UI's `flip`
+ * drops the controls to BOTTOM, and they land just below the fixed toolbar in the clear — reachable
+ * and never behind the fixed toolbar, for both the off-screen and top-of-doc cases.
+ *
+ * `toolbarBottom` is the fixed toolbar's bottom edge in viewport coordinates (0 when there is no
+ * toolbar, e.g. a read-only view), clamped defensively into the viewport.
  */
 export function clampToolbarAnchorRect(
   rect: { top: number; bottom: number; left: number; right: number },
   viewport: { width: number; height: number },
+  toolbarBottom = 0,
 ): DOMRect {
   const left = Math.max(0, Math.min(rect.left, viewport.width))
   const right = Math.min(viewport.width, Math.max(rect.right, left))
   const width = Math.max(0, right - left)
-  // Keep the band at least TOOLBAR_SAFE_TOP from the viewport top (room for the toolbar above it)
-  // and never below the viewport bottom, following the real top edge in between.
-  const top = Math.max(TOOLBAR_SAFE_TOP, Math.min(rect.top, viewport.height - 8))
-  return {
-    x: left,
-    y: top,
-    left,
-    top,
-    right: left + width,
-    bottom: top,
-    width,
-    height: 0,
-    toJSON() {
-      return this
-    },
-  } as DOMRect
+  const safeTop = Math.max(0, Math.min(toolbarBottom, viewport.height - 8))
+  const build = (top: number, bottom: number): DOMRect =>
+    ({
+      x: left,
+      y: top,
+      left,
+      top,
+      right: left + width,
+      bottom,
+      width,
+      height: Math.max(0, bottom - top),
+      toJSON() {
+        return this
+      },
+    } as DOMRect)
+  // Table sits clear below the fixed toolbar with room for the controls to float above it: keep a
+  // zero-height band at the real top edge so the toolbar floats above the table exactly as before.
+  if (rect.top - TOOLBAR_CLEARANCE >= safeTop) {
+    const top = Math.min(rect.top, viewport.height - 8)
+    return build(top, top)
+  }
+  // Table jammed under / above the fixed toolbar (top-of-doc or scrolled off the top): anchor to
+  // the toolbar strip so `placement: 'top'` overflows the viewport top and flips to BOTTOM, landing
+  // the controls just below the fixed toolbar's bottom edge — clickable, never behind it.
+  return build(0, safeTop)
 }
 
 /**
  * Reference rect for the floating table toolbar (#625). Anchors to the OUTER edge of the table
  * (its scroll wrapper when present) rather than the caret's cell, so the toolbar — placed above
  * with `placement: 'top'` — floats in the block margin above the whole table instead of landing on
- * top of the text rows above the caret. The rect is clamped into the visual viewport (see
- * {@link clampToolbarAnchorRect}) so a long table scrolled past the top of the viewport keeps the
- * controls reachable instead of pushing them off-screen. Returns a Floating-UI virtual element
- * (computed lazily so scrolling/resizing stays accurate), or null when the caret is not inside a
- * table, in which case the BubbleMenu falls back to its default cursor-based positioning.
+ * top of the text rows above the caret. The rect is clamped relative to the fixed editor toolbar
+ * (see {@link clampToolbarAnchorRect}) so a long table scrolled past the top of the viewport keeps
+ * the controls reachable and a table at the top of the doc keeps them clear of the fixed
+ * `.octo-toolbar`. Returns a Floating-UI virtual element (computed lazily so scrolling/resizing
+ * stays accurate), or null when the caret is not inside a table, in which case the BubbleMenu falls
+ * back to its default cursor-based positioning.
  */
 function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => DOMRect; getClientRects: () => DOMRect[] } | null {
   const { $from } = editor.state.selection
@@ -174,11 +194,21 @@ function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => D
         // Prefer the ProseMirror `.tableWrapper` scroll box so a horizontally scrolled wide table
         // still anchors to the visible table region.
         const anchor = (dom.closest('.tableWrapper') as HTMLElement | null) ?? dom
+        // Bottom edge of the fixed editor toolbar, measured live so a taller toolbar (e.g. the find
+        // bar expands `.octo-toolbar-wrap`) is always accounted for. Scoped to this editor's shell
+        // so an unrelated toolbar elsewhere on the page is never picked up.
+        const shell = (editor.view.dom.closest('.octo-doc--editor') as HTMLElement | null) ?? undefined
+        const toolbarBottom = () => {
+          const toolbarEl = (shell ?? document).querySelector('.octo-toolbar') as HTMLElement | null
+          const fixed = (toolbarEl?.closest('.octo-toolbar-wrap') as HTMLElement | null) ?? toolbarEl
+          return fixed ? fixed.getBoundingClientRect().bottom : 0
+        }
         const band = () =>
-          clampToolbarAnchorRect(anchor.getBoundingClientRect(), {
-            width: window.innerWidth,
-            height: window.innerHeight,
-          })
+          clampToolbarAnchorRect(
+            anchor.getBoundingClientRect(),
+            { width: window.innerWidth, height: window.innerHeight },
+            toolbarBottom(),
+          )
         return {
           getBoundingClientRect: band,
           getClientRects: () => [band()],

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -105,13 +105,65 @@ function TbBtn({
   )
 }
 
+// Vertical space (px) reserved above the anchor band so the toolbar — placed above the anchor with
+// `placement: 'top'` — always has room to render inside the viewport. Covers the ~40px control row
+// plus the 8px placement offset with margin to spare.
+const TOOLBAR_SAFE_TOP = 64
+
+/**
+ * Clamp a table's rect into the visual viewport and collapse it to a thin anchor band near its
+ * visible top (#625 off-screen fix). This is the pure core of {@link tableReferenceElement},
+ * split out so it can be unit-tested without a real layout.
+ *
+ * Why: the toolbar anchors to the table's OUTER edge and floats above it with `placement: 'top'`.
+ * For a long table scrolled so its top leaves the viewport (`rect.top` a large negative), the raw
+ * rect's top is off-screen above and its bottom is far below the viewport; Floating-UI's default
+ * `flip` then re-anchors to that off-screen bottom edge and the controls land below the viewport
+ * (observed: toolbar top ~1051 vs a 1000px viewport), completely unreachable. `shift` doesn't save
+ * it because its default boundary is the tall scroll container, not the visual viewport.
+ *
+ * Fix: build the reference from a zero-height band whose `top` is the table's top edge CLAMPED into
+ * `[TOOLBAR_SAFE_TOP, viewport.height - 8]`, with the horizontal extent clamped into the viewport.
+ * A thin band near the top means both `top` and any flipped `bottom` placement resolve to a y just
+ * inside the viewport, so the controls stay reachable regardless of flip/shift boundary quirks. In
+ * the normal, fully-visible case the table top already sits below `TOOLBAR_SAFE_TOP`, so the band
+ * stays at the real top edge and the toolbar floats above the table exactly as before — no
+ * TC-P0-001 regression.
+ */
+export function clampToolbarAnchorRect(
+  rect: { top: number; bottom: number; left: number; right: number },
+  viewport: { width: number; height: number },
+): DOMRect {
+  const left = Math.max(0, Math.min(rect.left, viewport.width))
+  const right = Math.min(viewport.width, Math.max(rect.right, left))
+  const width = Math.max(0, right - left)
+  // Keep the band at least TOOLBAR_SAFE_TOP from the viewport top (room for the toolbar above it)
+  // and never below the viewport bottom, following the real top edge in between.
+  const top = Math.max(TOOLBAR_SAFE_TOP, Math.min(rect.top, viewport.height - 8))
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    right: left + width,
+    bottom: top,
+    width,
+    height: 0,
+    toJSON() {
+      return this
+    },
+  } as DOMRect
+}
+
 /**
  * Reference rect for the floating table toolbar (#625). Anchors to the OUTER edge of the table
  * (its scroll wrapper when present) rather than the caret's cell, so the toolbar — placed above
  * with `placement: 'top'` — floats in the block margin above the whole table instead of landing on
- * top of the text rows above the caret. Returns a Floating-UI virtual element (computed lazily so
- * scrolling/resizing stays accurate), or null when the caret is not inside a table, in which case
- * the BubbleMenu falls back to its default cursor-based positioning.
+ * top of the text rows above the caret. The rect is clamped into the visual viewport (see
+ * {@link clampToolbarAnchorRect}) so a long table scrolled past the top of the viewport keeps the
+ * controls reachable instead of pushing them off-screen. Returns a Floating-UI virtual element
+ * (computed lazily so scrolling/resizing stays accurate), or null when the caret is not inside a
+ * table, in which case the BubbleMenu falls back to its default cursor-based positioning.
  */
 function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => DOMRect; getClientRects: () => DOMRect[] } | null {
   const { $from } = editor.state.selection
@@ -122,9 +174,14 @@ function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => D
         // Prefer the ProseMirror `.tableWrapper` scroll box so a horizontally scrolled wide table
         // still anchors to the visible table region.
         const anchor = (dom.closest('.tableWrapper') as HTMLElement | null) ?? dom
+        const band = () =>
+          clampToolbarAnchorRect(anchor.getBoundingClientRect(), {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          })
         return {
-          getBoundingClientRect: () => anchor.getBoundingClientRect(),
-          getClientRects: () => [anchor.getBoundingClientRect()],
+          getBoundingClientRect: band,
+          getClientRects: () => [band()],
         }
       }
     }

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -394,6 +394,20 @@
 .octo-table-bubble .octo-tb-sep {
   align-self: stretch;
 }
+/* Delete controls carry a text caption (#621-2) so it's clear which row / column / table the
+   action removes. Lay the icon and caption out inline; icon-only buttons are unaffected. */
+.octo-table-bubble .octo-tb-btn {
+  display: inline-flex;
+  align-items: center;
+}
+.octo-tb-btn--labeled {
+  gap: 4px;
+}
+.octo-tb-btn-label {
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
 /* While the caret is inside a table cell this toolbar floats over the table (placement: top). Its
    frame would otherwise sit on top of the column-resize hot zone and swallow the hover/mousedown
    the resize plugin listens for on the editor DOM, so `.column-resize-handle` never appears and the


### PR DESCRIPTION
## Summary

Fixes two same-origin issues with the docs table editing toolbar (`TableBubbleMenu`):

- **#625 — toolbar covers surrounding text.** The floating toolbar was anchored to the caret's cell rect with `placement: 'top'`, so once the caret sat in row 2+ the toolbar floated 8px above the cell and landed on top of the text rows above it. It now anchors to the table's outer edge (its `.tableWrapper` scroll box when present) via the BubbleMenu `getReferencedVirtualElement`, so with `placement: 'top'` it floats in the block margin above the whole table and never overlaps in-table text, regardless of caret row.
- **#621-2 — delete controls unclear.** The delete row / column / table controls were icon-only, giving no indication of what would be removed. They now show a text caption next to the icon (reusing the existing `docs.table.deleteRow` / `deleteColumn` / `deleteTable` i18n strings, en-US + zh-CN).

## Changes

- `packages/docs/src/editor/TableControls.tsx`
  - New `tableReferenceElement(editor)` helper returning a Floating-UI virtual element anchored to the table's outer edge (lazy rect so scroll/resize stays accurate); wired via `getReferencedVirtualElement`. Falls back to the default caret positioning when no table is found.
  - `TbBtn` gains an optional `text` prop; the three delete controls pass it.
- `packages/docs/src/editor/styles.css`
  - Inline layout for icon + caption (`.octo-tb-btn--labeled`, `.octo-tb-btn-label`). Icon-only buttons are unaffected.

## Scope / safety

- Changes are confined to `TableControls.tsx` and `styles.css`. `TableCellView.ts` is untouched, and the portal `pointer-events` passthrough that keeps the column-resize hot zone reachable (`.octo-table-bubble-portal`) is unchanged.
- The visible caption is decorative for screen readers — the existing `aria-label`/`title` already carry the same string, so there is no double announcement.

## Verification

- `tsc --noEmit` (docs `typecheck`): no new errors in changed files. (Two pre-existing errors in unrelated files — `dmworkbase/src/i18n/format.ts`, `src/members/sort.ts` — are present on `main` as well.)
- `vitest` — `TableControls.test.tsx` passes 10/10, including the #595 C1 pointer-events case. The full docs suite result is identical to `main` (one pre-existing `Toolbar.test.tsx` animation-frame teardown flake that only surfaces in the full run and passes in isolation).
- ESLint: the repo has no configured lint pipeline for the docs package (root config is commented out, no `lint` script); a standalone `@typescript-eslint` self-check on the changed file is clean.

Closes #625
Closes #621 (sub-issue 2)
