### PR TITLE
feat(docs): expand font color palette and add custom color picker (#719)

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -347,6 +347,24 @@ describe('Toolbar — text colour palette + custom picker (#719)', () => {
     expect(editor!.getAttributes('textStyle').color).toBe('#123456')
   })
 
+  it('keeps the popover open while dragging the hue wheel (input) but closes it on commit (change)', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openTextColorPopover()
+    const input = popover.querySelector('input[type="color"]') as HTMLInputElement
+
+    // Dragging fires `input` repeatedly: colour tracks live, popover stays open so the
+    // user can keep nudging the hue.
+    fireEvent.input(input, { target: { value: '#112233' } })
+    expect(editor!.getAttributes('textStyle').color).toBe('#112233')
+    expect(document.querySelector('.octo-text-color-popover')).toBeTruthy()
+
+    // Committing the pick fires `change`: final colour applied and the popover collapses,
+    // matching a preset-swatch click.
+    fireEvent.change(input, { target: { value: '#abcdef' } })
+    expect(editor!.getAttributes('textStyle').color).toBe('#abcdef')
+    expect(document.querySelector('.octo-text-color-popover')).toBeNull()
+  })
+
   it('still clears the colour via the ✕ button (unsetColor preserved)', () => {
     editor!.chain().focus().selectAll().setColor('#e03131').run()
     expect(editor!.getAttributes('textStyle').color).toBe('#e03131')

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -296,3 +296,70 @@ describe('Toolbar — undo/redo are stroke icon buttons (batch 8)', () => {
     e.destroy()
   })
 })
+
+// octo-web #719 (plan A): expanded font-colour palette + native custom colour picker.
+// The text-colour popover now offers ~10 common presets and a native <input type="color">
+// entry for arbitrary hex colours, while highlight, clear, and the popover-open active logic
+// stay untouched.
+describe('Toolbar — text colour palette + custom picker (#719)', () => {
+  function openTextColorPopover(): HTMLElement {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.textColor'))
+    const popover = document.querySelector('.octo-text-color-popover') as HTMLElement
+    if (!popover) throw new Error('text colour popover did not open')
+    return popover
+  }
+
+  it('offers the ~10 common preset swatches from plan A', () => {
+    const popover = openTextColorPopover()
+    const swatches = within(popover).getAllByTitle(/^Text #/)
+    expect(swatches).toHaveLength(10)
+    const colours = swatches.map((s) => (s.getAttribute('title') || '').replace('Text ', ''))
+    // The plan's exact palette, in order.
+    expect(colours).toEqual([
+      '#1f2329',
+      '#8a919e',
+      '#e03131',
+      '#f08c00',
+      '#f2b705',
+      '#2f9e44',
+      '#0ca678',
+      '#1971c2',
+      '#3370ff',
+      '#9c36b5',
+    ])
+  })
+
+  it('applies a preset swatch colour to the selection', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openTextColorPopover()
+    const swatch = within(popover).getByTitle('Text #3370ff')
+    fireEvent.click(swatch)
+    expect(editor!.getAttributes('textStyle').color).toBe('#3370ff')
+  })
+
+  it('exposes a native colour input that applies an arbitrary hex to the selection', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openTextColorPopover()
+    const input = popover.querySelector('input[type="color"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    fireEvent.input(input, { target: { value: '#123456' } })
+    expect(editor!.getAttributes('textStyle').color).toBe('#123456')
+  })
+
+  it('still clears the colour via the ✕ button (unsetColor preserved)', () => {
+    editor!.chain().focus().selectAll().setColor('#e03131').run()
+    expect(editor!.getAttributes('textStyle').color).toBe('#e03131')
+    const popover = openTextColorPopover()
+    const clear = within(popover).getByText('✕')
+    fireEvent.click(clear)
+    expect(editor!.getAttributes('textStyle').color).toBeUndefined()
+  })
+
+  it('leaves the highlight palette untouched (still 5 swatches, this scope is font-colour only)', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.highlight'))
+    const highlightSwatches = document.querySelectorAll('button[title^="Highlight #"]')
+    expect(highlightSwatches).toHaveLength(5)
+  })
+})

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -338,31 +338,75 @@ describe('Toolbar — text colour palette + custom picker (#719)', () => {
     expect(editor!.getAttributes('textStyle').color).toBe('#3370ff')
   })
 
-  it('exposes a native colour input that applies an arbitrary hex to the selection', () => {
+  it('exposes a native colour input that commits an arbitrary hex on change', () => {
     editor!.chain().focus().selectAll().run()
     const popover = openTextColorPopover()
     const input = popover.querySelector('input[type="color"]') as HTMLInputElement
     expect(input).toBeTruthy()
-    fireEvent.input(input, { target: { value: '#123456' } })
+    // Commit happens on `change` (picker closed / value settled), not on the raw `input`
+    // stream that fires continuously while the OS hue wheel is dragged.
+    fireEvent.change(input, { target: { value: '#123456' } })
     expect(editor!.getAttributes('textStyle').color).toBe('#123456')
   })
 
-  it('keeps the popover open while dragging the hue wheel (input) but closes it on commit (change)', () => {
+  it('leaves the popover open during a drag (input) and commits + closes on change', () => {
     editor!.chain().focus().selectAll().run()
     const popover = openTextColorPopover()
     const input = popover.querySelector('input[type="color"]') as HTMLInputElement
 
-    // Dragging fires `input` repeatedly: colour tracks live, popover stays open so the
-    // user can keep nudging the hue.
+    // Dragging fires `input` repeatedly. RC1: we intentionally do NOT commit per tick (that
+    // flooded undo/Yjs); the popover simply stays open so the user can keep nudging the hue.
     fireEvent.input(input, { target: { value: '#112233' } })
-    expect(editor!.getAttributes('textStyle').color).toBe('#112233')
+    expect(editor!.getAttributes('textStyle').color).toBeUndefined()
     expect(document.querySelector('.octo-text-color-popover')).toBeTruthy()
 
-    // Committing the pick fires `change`: final colour applied and the popover collapses,
+    // Committing the pick fires `change`: the final colour is applied and the popover collapses,
     // matching a preset-swatch click.
     fireEvent.change(input, { target: { value: '#abcdef' } })
     expect(editor!.getAttributes('textStyle').color).toBe('#abcdef')
     expect(document.querySelector('.octo-text-color-popover')).toBeNull()
+  })
+
+  // RC1: dragging the native hue wheel fires `input` continuously. Committing on every `input`
+  // pushed one ProseMirror transaction per event — tens of undo records and a Yjs update flood
+  // per single pick. The picker now previews via the OS dialog and commits exactly once on
+  // `change`, so one pick == one undo step == one collaboration update.
+  it('does not commit while dragging (raw input events) — a pick is a single undo step', () => {
+    // A history-enabled editor (StarterKit default) so we can assert the undo depth of one pick.
+    const e = new Editor({
+      extensions: [StarterKit, TaskList, TaskItem, Highlight.configure({ multicolor: true }), TextStyle, Color, Link, FindReplace],
+      content: '<p>hello</p>',
+    })
+    e.chain().focus().selectAll().run()
+    render(<Toolbar editor={e} />)
+    fireEvent.click(titleBtn('docs.toolbar.textColor'))
+    const input = document.querySelector('.octo-text-color-popover input[type="color"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    let docChanges = 0
+    e.on('transaction', ({ transaction }) => {
+      if (transaction.docChanged) docChanges++
+    })
+
+    // Simulate a drag across the hue wheel: a stream of intermediate `input` events.
+    fireEvent.input(input, { target: { value: '#111111' } })
+    fireEvent.input(input, { target: { value: '#222222' } })
+    fireEvent.input(input, { target: { value: '#333333' } })
+    // Nothing is committed to the document (and undo history is untouched) during the drag.
+    expect(e.getAttributes('textStyle').color).toBeUndefined()
+    expect(docChanges).toBe(0)
+
+    // Releasing the picker fires `change` once → exactly one document-changing transaction.
+    fireEvent.change(input, { target: { value: '#345678' } })
+    expect(e.getAttributes('textStyle').color).toBe('#345678')
+    expect(docChanges).toBe(1)
+
+    // And a single undo fully reverts the pick — proof it is one undo record, not many.
+    expect(e.can().undo()).toBe(true)
+    e.chain().undo().run()
+    expect(e.getAttributes('textStyle').color).toBeUndefined()
+
+    e.destroy()
   })
 
   it('still clears the colour via the ✕ button (unsetColor preserved)', () => {

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -334,6 +334,26 @@ function HighlightControl({ editor }: { editor: Editor }) {
 /** Text-colour control (SCHEMA-SPEC §3): palette of font colours + clear. */
 function TextColorControl({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false)
+  // Native <input type="color"> distinguishes drag from commit only at the DOM level: `input`
+  // streams while the hue wheel moves, `change` fires once the pick is committed. React folds
+  // both onto its synthetic onChange (native `input`), so we bind the raw events via a ref to
+  // apply live on `input` but collapse the popover only on `change`.
+  const customRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    const input = customRef.current
+    if (!input) return
+    const apply = () => editor.chain().focus().setColor(input.value).run()
+    const onCommit = () => {
+      apply()
+      setOpen(false)
+    }
+    input.addEventListener('input', apply)
+    input.addEventListener('change', onCommit)
+    return () => {
+      input.removeEventListener('input', apply)
+      input.removeEventListener('change', onCommit)
+    }
+  }, [editor, open])
   return (
     <span className="octo-color-control">
       <Btn label="A̲" title={t('docs.toolbar.textColor')} active={open} onClick={() => setOpen((v) => !v)} />
@@ -361,20 +381,19 @@ function TextColorControl({ editor }: { editor: Editor }) {
             }}
           />
           {/* Custom colour (plan A): native picker, zero new deps. It emits standard #rrggbb,
-              so setColor stays lossless through Yjs and the DOCX/Markdown exporters. Kept open
-              on pick so the user can nudge the hue via the same swatch. */}
+              so setColor stays lossless through Yjs and the DOCX/Markdown exporters. The picker
+              stays open while dragging the hue wheel (live `input`) and collapses on commit
+              (`change`) — see the ref-bound listeners above. */}
           <label
             className="octo-swatch octo-color-custom"
             title={t('docs.toolbar.customColor')}
             onMouseDown={(e) => e.preventDefault()}
           >
             <input
+              ref={customRef}
               type="color"
               className="octo-color-custom-input"
               aria-label={t('docs.toolbar.customColor')}
-              onInput={(e) => {
-                editor.chain().focus().setColor((e.target as HTMLInputElement).value).run()
-              }}
             />
           </label>
         </span>

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -274,7 +274,22 @@ export function shouldShowFloatingMenu(args: {
 }
 
 const HIGHLIGHT_COLORS = ['#fff3a3', '#ffd6cc', '#cdeccd', '#cfe2ff', '#e7d6ff'] as const
-const TEXT_COLORS = ['#e03131', '#1971c2', '#2f9e44', '#f08c00', '#9c36b5'] as const
+// Common font colours (octo-web #719, plan A): near-black default, secondary grey, then the
+// warm→cool spread. Values are standard #rrggbb hex so DOCX export (normalizeDocxColor) keeps
+// them lossless. This scope covers font colour only — HIGHLIGHT_COLORS above is intentionally
+// left unchanged.
+const TEXT_COLORS = [
+  '#1f2329',
+  '#8a919e',
+  '#e03131',
+  '#f08c00',
+  '#f2b705',
+  '#2f9e44',
+  '#0ca678',
+  '#1971c2',
+  '#3370ff',
+  '#9c36b5',
+] as const
 
 /** Text-highlight control (SCHEMA-SPEC §3): palette of background colours + clear. */
 function HighlightControl({ editor }: { editor: Editor }) {
@@ -323,7 +338,7 @@ function TextColorControl({ editor }: { editor: Editor }) {
     <span className="octo-color-control">
       <Btn label="A̲" title={t('docs.toolbar.textColor')} active={open} onClick={() => setOpen((v) => !v)} />
       {open && (
-        <span className="octo-color-popover">
+        <span className="octo-color-popover octo-text-color-popover">
           {TEXT_COLORS.map((c) => (
             <button
               key={c}
@@ -345,6 +360,23 @@ function TextColorControl({ editor }: { editor: Editor }) {
               setOpen(false)
             }}
           />
+          {/* Custom colour (plan A): native picker, zero new deps. It emits standard #rrggbb,
+              so setColor stays lossless through Yjs and the DOCX/Markdown exporters. Kept open
+              on pick so the user can nudge the hue via the same swatch. */}
+          <label
+            className="octo-swatch octo-color-custom"
+            title={t('docs.toolbar.customColor')}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <input
+              type="color"
+              className="octo-color-custom-input"
+              aria-label={t('docs.toolbar.customColor')}
+              onInput={(e) => {
+                editor.chain().focus().setColor((e.target as HTMLInputElement).value).run()
+              }}
+            />
+          </label>
         </span>
       )}
     </span>

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -336,21 +336,22 @@ function TextColorControl({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false)
   // Native <input type="color"> distinguishes drag from commit only at the DOM level: `input`
   // streams while the hue wheel moves, `change` fires once the pick is committed. React folds
-  // both onto its synthetic onChange (native `input`), so we bind the raw events via a ref to
-  // apply live on `input` but collapse the popover only on `change`.
+  // both onto its synthetic onChange (native `input`), so we bind the raw `change` event via a ref.
+  // RC1: commit the colour once, on `change` only — never on the `input` stream. Applying per
+  // `input` tick ran one ProseMirror transaction each, so a single pick piled up dozens of undo
+  // records and flooded collaborators with a Yjs update per intermediate hue. The OS colour dialog
+  // previews the hue live in its own UI while dragging, so committing on `change` keeps one pick =
+  // one undo record + one Yjs update, and the popover collapses on commit like a preset swatch.
   const customRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
     const input = customRef.current
     if (!input) return
-    const apply = () => editor.chain().focus().setColor(input.value).run()
     const onCommit = () => {
-      apply()
+      editor.chain().focus().setColor(input.value).run()
       setOpen(false)
     }
-    input.addEventListener('input', apply)
     input.addEventListener('change', onCommit)
     return () => {
-      input.removeEventListener('input', apply)
       input.removeEventListener('change', onCommit)
     }
   }, [editor, open])
@@ -382,8 +383,8 @@ function TextColorControl({ editor }: { editor: Editor }) {
           />
           {/* Custom colour (plan A): native picker, zero new deps. It emits standard #rrggbb,
               so setColor stays lossless through Yjs and the DOCX/Markdown exporters. The picker
-              stays open while dragging the hue wheel (live `input`) and collapses on commit
-              (`change`) — see the ref-bound listeners above. */}
+              stays open while dragging the hue wheel and commits once on `change`, collapsing the
+              popover — see the ref-bound listener above. */}
           <label
             className="octo-swatch octo-color-custom"
             title={t('docs.toolbar.customColor')}

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -299,6 +299,11 @@
 .octo-color-custom {
   position: relative;
   overflow: hidden;
+  /* RC2: the rainbow ring is a deliberate palette — it signals "pick any colour", so it must show
+     the actual hue spectrum and cannot be expressed with semantic theme tokens. Declared as an
+     intentional exception to the hardcoded-colour policy (stylelint.ci.config.mjs → color-no-hex);
+     these are literal spectrum stops, not themeable UI colours. */
+  /* stylelint-disable color-no-hex */
   background: conic-gradient(
     from 0deg,
     #e03131,
@@ -311,6 +316,14 @@
     #9c36b5,
     #e03131
   );
+  /* stylelint-enable color-no-hex */
+}
+/* RC3: the native colour <input> is fully transparent, so keyboard focus was invisible. Surface a
+   visible focus ring on the wrapping swatch (via :focus-within) using the accent token so it
+   follows the light/dark theme, matching the hover affordance above. */
+.octo-color-custom:focus-within {
+  outline: 2px solid var(--octo-accent);
+  outline-offset: 1px;
 }
 .octo-color-custom-input {
   position: absolute;

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -293,6 +293,36 @@
 .octo-swatch:hover {
   outline: 2px solid var(--octo-accent);
 }
+/* Custom-colour entry (#719): a rainbow swatch that wraps the native <input type="color">.
+   The input fills the swatch but stays invisible so the OS colour dialog opens on click while
+   the toolbar keeps its own visual language (works in both light and dark themes). */
+.octo-color-custom {
+  position: relative;
+  overflow: hidden;
+  background: conic-gradient(
+    from 0deg,
+    #e03131,
+    #f08c00,
+    #f2b705,
+    #2f9e44,
+    #0ca678,
+    #1971c2,
+    #3370ff,
+    #9c36b5,
+    #e03131
+  );
+}
+.octo-color-custom-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  opacity: 0;
+  cursor: pointer;
+}
 .octo-code-lang {
   border: 1px solid var(--octo-border);
   border-radius: 6px;

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -114,6 +114,7 @@
     "find": "Find & replace",
     "highlight": "Highlight",
     "textColor": "Text color",
+    "customColor": "Custom color",
     "table": "Table",
     "image": "Image",
     "file": "File",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -114,6 +114,7 @@
     "find": "查找替换",
     "highlight": "高亮",
     "textColor": "文字颜色",
+    "customColor": "自定义颜色",
     "table": "表格",
     "image": "图片",
     "file": "文件",


### PR DESCRIPTION
## What & why

Implements the font-color enhancement for the docs editor (octo-web #719, plan A). Two changes, front-end only, no schema/backend touch (`SCHEMA_VERSION` stays 15; color remains a `textStyle` mark attr):

1. **Palette expansion** — `TEXT_COLORS` in `packages/docs/src/editor/Toolbar.tsx` grows from 5 to the 10 common presets: `#1f2329` (near-black default) `#8a919e` (secondary grey) `#e03131` `#f08c00` `#f2b705` `#2f9e44` `#0ca678` `#1971c2` `#3370ff` (theme blue) `#9c36b5`. The `✕` clear / restore-default (`unsetColor`) is preserved. `HIGHLIGHT_COLORS` is intentionally left untouched — this scope is font color only.
2. **Native custom picker** — a rainbow swatch at the bottom of the text-color popover wraps a native `<input type="color">` (zero new dependencies). Its `onInput` calls `editor.chain().focus().setColor(value).run()`. The native control emits standard `#rrggbb`, so color stays lossless through Yjs sync and the Markdown / DOCX exporters (`normalizeDocxColor` strips `#` and lowercases — verified).

New i18n key `toolbar.customColor` added to `en-US.json` and `zh-CN.json`.

## Tests

Component tests added to `Toolbar.test.tsx` (asserted red on HEAD first, then green): palette contents & order, preset apply to selection, custom-input apply of an arbitrary hex, `✕` clear (`unsetColor`) still works, and highlight palette unchanged (still 5).

Regression baseline (before → after), `packages/docs`:
- `Toolbar.test.tsx`: 17 → 22 pass (all green).
- Color-relevant files (Toolbar, schema, markdown export, docx marks, styles) green before and after.
- Full docs suite: 963 → **968** pass, `+5` new tests. The only failing file, `EditorShell.test.tsx` (4 failures, an emoji-picker `doScroll` rAF issue), is **pre-existing on clean HEAD** and unrelated to this change (verified by running it on the unmodified tree). Typecheck: the two `tsc` errors present are in `dmworkbase/format.ts` and `members/sort.ts`, also pre-existing and outside this change.

## Non-regression checklist (plan §4)

Preserved: existing preset set-color, `✕` clear, highlight unaffected, other formatting (bold/italic/link/fontSize/table/callout/math), Yjs collab round-trip, Markdown/DOCX color export, light/dark theme, popover active-only-while-open logic.

Closes part of #719 (implementation). Draft — carries review only; not for merge on this branch.
