### PR TITLE
feat(docs): add format painter to editor toolbar

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -636,4 +636,33 @@ describe('Toolbar — format painter (XIN-963)', () => {
     expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
     e.destroy()
   })
+
+  // XIN-1000 (P0): the painter is single-shot. A mouseup that lands on an empty (collapsed)
+  // selection must still end the session and disarm — otherwise the painter stays armed and a
+  // later, unrelated selection is silently repainted with the stale captured marks (data loss).
+  it('disarms after an empty-selection click and does not repaint a later unrelated selection', async () => {
+    const e = new Editor({
+      extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
+      content: '<p><strong>bold</strong></p><p>plain</p><p>other</p>',
+    })
+    render(<Toolbar editor={e} />)
+    // Arm from the bold source ("bold" = para 1 positions 1..5).
+    e.commands.setTextSelection({ from: 1, to: 5 })
+    fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+    // First gesture lands on an empty (collapsed) caret — no target was selected.
+    e.commands.setTextSelection(9)
+    fireEvent.mouseUp(e.view.dom)
+    await new Promise((r) => setTimeout(r, 0))
+    // Painter must have disarmed on that click (single-shot), not stay armed.
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+    // Now the user makes an unrelated selection ("other" = para 3) and finishes it.
+    e.commands.setTextSelection({ from: 14, to: 19 })
+    fireEvent.mouseUp(e.view.dom)
+    await new Promise((r) => setTimeout(r, 0))
+    // That selection must NOT have been painted — bold was never applied to it.
+    e.commands.setTextSelection({ from: 14, to: 19 })
+    expect(e.isActive('bold')).toBe(false)
+    e.destroy()
+  })
 })

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -598,3 +598,42 @@ describe('Toolbar — paragraph spacing controls (SCHEMA_VERSION 17)', () => {
     expect(sel(c, 'docs.toolbar.spaceBefore').value).toBe('custom')
   })
 })
+
+describe('Toolbar — format painter (XIN-963)', () => {
+  it('renders the format-painter button next to clear-format', () => {
+    render(<Toolbar editor={editor!} />)
+    expect(titleBtn('docs.toolbar.formatPainter')).toBeTruthy()
+    expect(titleBtn('docs.toolbar.clearFormat')).toBeTruthy()
+  })
+
+  it('arms (is-active) on click and disarms on a second click', () => {
+    render(<Toolbar editor={editor!} />)
+    const btn = titleBtn('docs.toolbar.formatPainter')
+    expect(btn.classList.contains('is-active')).toBe(false)
+    fireEvent.click(btn)
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+    fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+  })
+
+  it('paints the source format onto the target selection end-to-end (arm → select → mouseup)', async () => {
+    const e = new Editor({
+      extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
+      content: '<p><strong>bold</strong></p><p>plain</p>',
+    })
+    render(<Toolbar editor={e} />)
+    // Arm from the bold source ("bold" = para 1 positions 1..5).
+    e.commands.setTextSelection({ from: 1, to: 5 })
+    fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+    // Select the target ("plain" = para 2) and finish the gesture with a mouseup on the editor.
+    e.commands.setTextSelection({ from: 7, to: 12 })
+    fireEvent.mouseUp(e.view.dom)
+    await new Promise((r) => setTimeout(r, 0))
+    // Target is now bold, and the painter disarmed.
+    e.commands.setTextSelection({ from: 7, to: 12 })
+    expect(e.isActive('bold')).toBe(true)
+    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+    e.destroy()
+  })
+})

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, within, act } from '@testing-library/react'
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import TaskList from '@tiptap/extension-task-list'
@@ -637,32 +637,113 @@ describe('Toolbar — format painter (XIN-963)', () => {
     e.destroy()
   })
 
-  // XIN-1000 (P0): the painter is single-shot. A mouseup that lands on an empty (collapsed)
+  // XIN-1000 (P0): the painter is single-shot. A stray click that lands on an empty (collapsed)
   // selection must still end the session and disarm — otherwise the painter stays armed and a
   // later, unrelated selection is silently repainted with the stale captured marks (data loss).
-  it('disarms after an empty-selection click and does not repaint a later unrelated selection', async () => {
-    const e = new Editor({
-      extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
-      content: '<p><strong>bold</strong></p><p>plain</p><p>other</p>',
-    })
-    render(<Toolbar editor={e} />)
-    // Arm from the bold source ("bold" = para 1 positions 1..5).
-    e.commands.setTextSelection({ from: 1, to: 5 })
-    fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
-    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
-    // First gesture lands on an empty (collapsed) caret — no target was selected.
-    e.commands.setTextSelection(9)
-    fireEvent.mouseUp(e.view.dom)
-    await new Promise((r) => setTimeout(r, 0))
-    // Painter must have disarmed on that click (single-shot), not stay armed.
-    expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
-    // Now the user makes an unrelated selection ("other" = para 3) and finishes it.
-    e.commands.setTextSelection({ from: 14, to: 19 })
-    fireEvent.mouseUp(e.view.dom)
-    await new Promise((r) => setTimeout(r, 0))
-    // That selection must NOT have been painted — bold was never applied to it.
-    e.commands.setTextSelection({ from: 14, to: 19 })
-    expect(e.isActive('bold')).toBe(false)
-    e.destroy()
+  // XIN-1016: the disarm is now deferred past the multi-click window (so a double/triple-click's
+  // empty first beat is not mistaken for a misclick), so a genuine misclick disarms once that
+  // window elapses. Fake timers advance the coalescing window without real wall-clock waits.
+  it('disarms after an empty-selection click and does not repaint a later unrelated selection', () => {
+    vi.useFakeTimers()
+    try {
+      const e = new Editor({
+        extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
+        content: '<p><strong>bold</strong></p><p>plain</p><p>other</p>',
+      })
+      render(<Toolbar editor={e} />)
+      // Arm from the bold source ("bold" = para 1 positions 1..5).
+      e.commands.setTextSelection({ from: 1, to: 5 })
+      fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+      // First gesture lands on an empty (collapsed) caret — no target was selected. A single beat
+      // with no follow-up click is a stray misclick.
+      e.commands.setTextSelection(9)
+      fireEvent.mouseUp(e.view.dom, { detail: 1 })
+      // Once the multi-click window has elapsed with the selection still empty, the painter disarms.
+      act(() => vi.advanceTimersByTime(400))
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+      // Now the user makes an unrelated selection ("other" = para 3) and finishes it.
+      e.commands.setTextSelection({ from: 14, to: 19 })
+      fireEvent.mouseUp(e.view.dom, { detail: 1 })
+      act(() => vi.advanceTimersByTime(400))
+      // That selection must NOT have been painted — bold was never applied to it.
+      e.commands.setTextSelection({ from: 14, to: 19 })
+      expect(e.isActive('bold')).toBe(false)
+      e.destroy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // XIN-1016 (P0): the XIN-1000 single-shot disarm over-corrected and broke double-click-to-paint.
+  // A double click selects a word, but it fires two mouseups: the first lands on a collapsed caret
+  // (word not yet selected) and only the second expands to the word. Disarming on that empty first
+  // beat killed the paint. The word the double click selects must still be painted.
+  it('paints the word a double-click selects (empty first beat must not disarm)', () => {
+    vi.useFakeTimers()
+    try {
+      const e = new Editor({
+        extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
+        content: '<p><strong>bold</strong></p><p>plain</p>',
+      })
+      render(<Toolbar editor={e} />)
+      // Arm from the bold source ("bold" = para 1 positions 1..5).
+      e.commands.setTextSelection({ from: 1, to: 5 })
+      fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+      // Beat 1: the browser collapses the caret at the click point — selection is still empty. Its
+      // deferred handler runs (advance the 0ms tick) before the second beat arrives.
+      e.commands.setTextSelection(8)
+      fireEvent.mouseUp(e.view.dom, { detail: 1 })
+      act(() => vi.advanceTimersByTime(0))
+      // Beat 2: the double click expands the selection to the word ("plain" = para 2, 7..12).
+      e.commands.setTextSelection({ from: 7, to: 12 })
+      fireEvent.mouseUp(e.view.dom, { detail: 2 })
+      act(() => vi.advanceTimersByTime(400))
+      // The word must now carry the source format, and the painter is spent (single-shot).
+      e.commands.setTextSelection({ from: 7, to: 12 })
+      expect(e.isActive('bold')).toBe(true)
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+      e.destroy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // XIN-1016 (P0): a triple click selects a paragraph via three mouseups (caret → word →
+  // paragraph). The painter must settle on the final paragraph selection and paint it, not act on
+  // the intermediate empty/word beats.
+  it('paints the paragraph a triple-click selects', () => {
+    vi.useFakeTimers()
+    try {
+      const e = new Editor({
+        extensions: [StarterKit.configure({ undoRedo: false }), Highlight.configure({ multicolor: true }), TextStyle, Color, Link],
+        content: '<p><strong>bold</strong></p><p>plain words here</p>',
+      })
+      render(<Toolbar editor={e} />)
+      // Arm from the bold source ("bold" = para 1 positions 1..5).
+      e.commands.setTextSelection({ from: 1, to: 5 })
+      fireEvent.click(titleBtn('docs.toolbar.formatPainter'))
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(true)
+      // Beat 1: caret collapses inside para 2 (empty).
+      e.commands.setTextSelection(8)
+      fireEvent.mouseUp(e.view.dom, { detail: 1 })
+      act(() => vi.advanceTimersByTime(0))
+      // Beat 2: expands to the word.
+      e.commands.setTextSelection({ from: 7, to: 12 })
+      fireEvent.mouseUp(e.view.dom, { detail: 2 })
+      act(() => vi.advanceTimersByTime(0))
+      // Beat 3: expands to the whole paragraph ("plain words here" = 7..23).
+      e.commands.setTextSelection({ from: 7, to: 23 })
+      fireEvent.mouseUp(e.view.dom, { detail: 3 })
+      act(() => vi.advanceTimersByTime(400))
+      // The full paragraph must now carry the source format, and the painter is spent.
+      e.commands.setTextSelection({ from: 7, to: 23 })
+      expect(e.isActive('bold')).toBe(true)
+      expect(titleBtn('docs.toolbar.formatPainter').classList.contains('is-active')).toBe(false)
+      e.destroy()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -1117,10 +1117,9 @@ export function Toolbar({ editor }: { editor: Editor }) {
 
   // Format painter (XIN-963): armed state holds the inline marks captured from the source
   // selection. `null` = disarmed. Clicking the button captures the current selection's marks and
-  // arms; the next completed mouseup in the editor ends the session (single-shot) — a non-empty
-  // selection is painted once, an empty click is abandoned — and either way disarms. A ref
-  // mirrors the state so the editor mouseup listener always reads the latest value without
-  // re-subscribing on every arm/disarm.
+  // arms; the next completed selection gesture in the editor paints them once, then disarms
+  // (single-shot). A ref mirrors the state so the editor mouseup listener always reads the latest
+  // value without re-subscribing on every arm/disarm.
   const [painterMarks, setPainterMarks] = useState<readonly Mark[] | null>(null)
   const painterMarksRef = useRef<readonly Mark[] | null>(null)
   painterMarksRef.current = painterMarks
@@ -1135,22 +1134,58 @@ export function Toolbar({ editor }: { editor: Editor }) {
   useEffect(() => {
     if (!painterMarks) return
     const dom = editor.view.dom
-    const onMouseUp = () => {
+    // Coalescing window for multi-click gestures (XIN-1016). A double-click (select word) or
+    // triple-click (select paragraph) fires 2–3 mouseups in quick succession; the FIRST beat lands
+    // on a collapsed caret (empty selection) and only a later beat expands it to the word/paragraph.
+    // Slightly larger than the platform double-click interval so the whole gesture is treated as
+    // one target rather than acted on beat-by-beat.
+    const MULTI_CLICK_MS = 300
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+    const clearSettle = () => {
+      if (settleTimer !== null) {
+        clearTimeout(settleTimer)
+        settleTimer = null
+      }
+    }
+    // Act on the settled selection: paint a real target, disarm either way (single-shot).
+    const settle = () => {
+      settleTimer = null
       const marks = painterMarksRef.current
       if (!marks) return
-      // Single-shot (XIN-1000): the first completed mouseup ends this painter session no matter
-      // where it lands. A non-empty target is painted; an empty (collapsed) click abandons the
-      // paint. Either way we disarm — leaving the painter armed after a stray click would let a
-      // later, unrelated selection be silently repainted with the stale captured marks.
-      if (!editor.state.selection.empty) {
-        applyPaintMarks(editor, marks)
-      }
+      if (!editor.state.selection.empty) applyPaintMarks(editor, marks)
       setPainterMarks(null)
     }
-    // Deferred to the next tick so ProseMirror has committed the selection for this mouseup.
-    const handler = () => setTimeout(onMouseUp, 0)
+    const onMouseUp = (detail: number) => {
+      const marks = painterMarksRef.current
+      if (!marks) return
+      if (detail <= 1 && !editor.state.selection.empty) {
+        // A drag-select: a single, deliberate gesture that already produced a range. No multi-click
+        // beats are coming, so paint immediately and end the session.
+        clearSettle()
+        applyPaintMarks(editor, marks)
+        setPainterMarks(null)
+        return
+      }
+      // Otherwise the gesture is not yet settled: either an empty first beat / stray misclick
+      // (detail 1, collapsed), or a multi-click beat (detail ≥ 2) whose selection a further beat may
+      // still extend (double → triple). Debounce and act once on the final selection — a genuine
+      // misclick settles empty and disarms without repainting (XIN-1000, XIN-981 unaffected), while
+      // double/triple-click settles on the word/paragraph it selected and paints it (XIN-1016).
+      clearSettle()
+      settleTimer = setTimeout(settle, MULTI_CLICK_MS)
+    }
+    // Deferred to the next tick so ProseMirror has committed the selection for this mouseup. Read
+    // `detail` (the running click count) synchronously — the event object is recycled after the
+    // handler returns.
+    const handler = (ev: MouseEvent) => {
+      const { detail } = ev
+      setTimeout(() => onMouseUp(detail), 0)
+    }
     dom.addEventListener('mouseup', handler)
-    return () => dom.removeEventListener('mouseup', handler)
+    return () => {
+      clearSettle()
+      dom.removeEventListener('mouseup', handler)
+    }
   }, [editor, painterMarks])
 
 

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -12,9 +12,11 @@ import { promptAndInsertMath } from './mathInsert.ts'
 import { sanitizeLinkHref } from './sanitize.ts'
 import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { TableGridPicker } from './TableControls.tsx'
+import { capturePaintMarks, applyPaintMarks } from './formatPainter.ts'
 import { t } from '../octoweb/index.ts'
 import { FONT_FAMILY_ENABLED, LINE_SPACING_ENABLED } from '../config.ts'
 import { FONT_FAMILIES } from './fontFamilies.ts'
+import type { Mark } from '@tiptap/pm/model'
 
 // Inline SVG toolbar icons (C2–C4): crisp, correct glyphs for underline / strikethrough /
 // alignment, replacing the ambiguous text placeholders. 16×16, fill: currentColor (via .octo-tb-icon).
@@ -109,6 +111,14 @@ const IconUnlink = () => (
 const IconEraser = () => (
   <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
     <path d="M15.1 3.7 21.4 10a2 2 0 0 1 0 2.8l-7 7H17v1.7h-7.4a2 2 0 0 1-1.4-.6L3.7 16.6a2 2 0 0 1 0-2.8l8.6-8.6a2 2 0 0 1 2.8 0zM8.3 14.2l-3.2 3.2 2.9 2.9h1.7l2.8-2.8-4.2-3.3z" />
+  </svg>
+)
+
+// Format painter (XIN-963): a paint-roller glyph — the classic "copy formatting" affordance used
+// by Word / Feishu / Google Docs. Filled via .octo-tb-icon to match the other toolbar icons.
+const IconFormatPainter = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 4h13a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1zm14 3h1.5a1.5 1.5 0 0 1 1.5 1.5V12a1 1 0 0 1-1 1h-6a1 1 0 0 0-1 1v1.2a2 2 0 0 1 1 1.8v4a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-4a2 2 0 0 1 1-1.8V14a3 3 0 0 1 3-3h5V9h-1V7z" />
   </svg>
 )
 
@@ -1105,6 +1115,39 @@ export function Toolbar({ editor }: { editor: Editor }) {
   const [findOpen, setFindOpen] = useState(false)
   const linkRef = useRef<HTMLSpanElement>(null)
 
+  // Format painter (XIN-963): armed state holds the inline marks captured from the source
+  // selection. `null` = disarmed. Clicking the button captures the current selection's marks and
+  // arms; the next non-empty selection made in the editor paints them once, then disarms. A ref
+  // mirrors the state so the editor mouseup listener always reads the latest value without
+  // re-subscribing on every arm/disarm.
+  const [painterMarks, setPainterMarks] = useState<readonly Mark[] | null>(null)
+  const painterMarksRef = useRef<readonly Mark[] | null>(null)
+  painterMarksRef.current = painterMarks
+
+  function toggleFormatPainter() {
+    setPainterMarks((prev) => (prev ? null : capturePaintMarks(editor.state)))
+  }
+
+  // While armed, paint onto the target selection when the user finishes selecting it (mouseup).
+  // Using mouseup — not selectionUpdate — avoids re-applying on every intermediate range during a
+  // drag; the paint happens once, on the completed gesture, then the painter disarms.
+  useEffect(() => {
+    if (!painterMarks) return
+    const dom = editor.view.dom
+    const onMouseUp = () => {
+      const marks = painterMarksRef.current
+      if (!marks) return
+      if (editor.state.selection.empty) return
+      applyPaintMarks(editor, marks)
+      setPainterMarks(null)
+    }
+    // Deferred to the next tick so ProseMirror has committed the selection for this mouseup.
+    const handler = () => setTimeout(onMouseUp, 0)
+    dom.addEventListener('mouseup', handler)
+    return () => dom.removeEventListener('mouseup', handler)
+  }, [editor, painterMarks])
+
+
   // C7: open the link popup, pre-filling the text from the current selection and the URL from any
   // link already under the cursor.
   function openLink() {
@@ -1263,6 +1306,12 @@ export function Toolbar({ editor }: { editor: Editor }) {
         )}
       </span>
       <span className="octo-tb-sep" />
+      <Btn
+        label={<IconFormatPainter />}
+        title={t('docs.toolbar.formatPainter')}
+        active={painterMarks !== null}
+        onClick={toggleFormatPainter}
+      />
       <Btn
         label={<IconEraser />}
         title={t('docs.toolbar.clearFormat')}

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -1117,7 +1117,8 @@ export function Toolbar({ editor }: { editor: Editor }) {
 
   // Format painter (XIN-963): armed state holds the inline marks captured from the source
   // selection. `null` = disarmed. Clicking the button captures the current selection's marks and
-  // arms; the next non-empty selection made in the editor paints them once, then disarms. A ref
+  // arms; the next completed mouseup in the editor ends the session (single-shot) — a non-empty
+  // selection is painted once, an empty click is abandoned — and either way disarms. A ref
   // mirrors the state so the editor mouseup listener always reads the latest value without
   // re-subscribing on every arm/disarm.
   const [painterMarks, setPainterMarks] = useState<readonly Mark[] | null>(null)
@@ -1137,8 +1138,13 @@ export function Toolbar({ editor }: { editor: Editor }) {
     const onMouseUp = () => {
       const marks = painterMarksRef.current
       if (!marks) return
-      if (editor.state.selection.empty) return
-      applyPaintMarks(editor, marks)
+      // Single-shot (XIN-1000): the first completed mouseup ends this painter session no matter
+      // where it lands. A non-empty target is painted; an empty (collapsed) click abandons the
+      // paint. Either way we disarm — leaving the painter armed after a stray click would let a
+      // later, unrelated selection be silently repainted with the stale captured marks.
+      if (!editor.state.selection.empty) {
+        applyPaintMarks(editor, marks)
+      }
       setPainterMarks(null)
     }
     // Deferred to the next tick so ProseMirror has committed the selection for this mouseup.

--- a/packages/docs/src/editor/formatPainter.test.ts
+++ b/packages/docs/src/editor/formatPainter.test.ts
@@ -102,4 +102,33 @@ describe('formatPainter — applyPaintMarks', () => {
     editor!.commands.setTextSelection(12)
     expect(applyPaintMarks(editor!, marks)).toBe(false)
   })
+
+  it('paint inline code onto linked target preserves link', () => {
+    // Source is inline `code`; the `code` mark declares `excludes: '_'`, so adding it to a range
+    // makes ProseMirror strip every other mark on that range — including a `link` — and the
+    // exclusion is mutual, so code and link cannot share text. Painting a code source onto a
+    // target that contains linked text must NOT delete the target's href (data loss). The link
+    // portion keeps its href (and does not receive code); any plain portion still gets code.
+    editor!.commands.setContent(
+      '<p><code>snippet</code></p>' +
+        '<p><a href="https://example.com">ab</a>cd</p>',
+    )
+    // Capture the code mark from the source ("snippet", para 1: 1..8).
+    selectText(editor!, 1, 8)
+    const marks = capturePaintMarks(editor!.state)
+    expect(marks.map((m) => m.type.name)).toContain('code')
+    // Paint across the whole target "abcd" (para 2: 10..14) — "ab" is linked, "cd" is plain.
+    selectText(editor!, 10, 14)
+    const applied = applyPaintMarks(editor!, marks)
+    expect(applied).toBe(true)
+    // Linked portion "ab": href survives and code was skipped there (would have destroyed it).
+    selectText(editor!, 10, 12)
+    expect(editor!.isActive('link')).toBe(true)
+    expect(editor!.getAttributes('link').href).toBe('https://example.com')
+    expect(editor!.isActive('code')).toBe(false)
+    // Plain portion "cd": code is applied normally, no link.
+    selectText(editor!, 12, 14)
+    expect(editor!.isActive('code')).toBe(true)
+    expect(editor!.isActive('link')).toBe(false)
+  })
 })

--- a/packages/docs/src/editor/formatPainter.test.ts
+++ b/packages/docs/src/editor/formatPainter.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Highlight from '@tiptap/extension-highlight'
+import { TextStyle } from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
+import Underline from '@tiptap/extension-underline'
+import Link from '@tiptap/extension-link'
+import { capturePaintMarks, applyPaintMarks, PAINTABLE_MARK_NAMES } from './formatPainter.ts'
+
+// XIN-963 format painter: record the inline (textStyle-family) marks of a source selection and
+// re-apply exactly that set to a target selection, without touching node structure or links.
+
+let editor: Editor | null = null
+
+beforeEach(() => {
+  editor = new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false, underline: false, link: false }),
+      Highlight.configure({ multicolor: true }),
+      TextStyle,
+      Color,
+      Underline,
+      Link,
+    ],
+    // "boldred" (bold + red) then "plain" then "italic" in separate paragraphs.
+    content:
+      '<p><strong><span style="color: #ff0000">boldred</span></strong></p>' +
+      '<p>plain</p>' +
+      '<p><em>italic</em></p>',
+  })
+})
+
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+})
+
+// Helper: the 1-based document offsets of a paragraph's text run. ProseMirror opens the doc with a
+// leading position, so paragraph 1's text spans [1, 1+len].
+function selectText(ed: Editor, from: number, to: number) {
+  ed.commands.setTextSelection({ from, to })
+}
+
+describe('formatPainter — capturePaintMarks', () => {
+  it('records the paintable marks of the source selection (bold + textStyle colour)', () => {
+    // Select "boldred" (para 1: positions 1..8).
+    selectText(editor!, 1, 8)
+    const marks = capturePaintMarks(editor!.state)
+    const names = marks.map((m) => m.type.name).sort()
+    expect(names).toEqual(['bold', 'textStyle'])
+    const textStyle = marks.find((m) => m.type.name === 'textStyle')!
+    expect(textStyle.attrs.color).toBe('#ff0000')
+  })
+
+  it('excludes non-paintable marks (link is never copied)', () => {
+    expect(PAINTABLE_MARK_NAMES).not.toContain('link')
+    editor!.commands.setContent('<p><a href="https://example.com">linked</a></p>')
+    selectText(editor!, 1, 7)
+    const marks = capturePaintMarks(editor!.state)
+    expect(marks.map((m) => m.type.name)).not.toContain('link')
+  })
+
+  it('returns an empty set for a plain-text selection', () => {
+    // Para 2 "plain": doc offset starts after para 1 (len 7 + 2 boundary tokens) → 10..15.
+    selectText(editor!, 10, 15)
+    expect(capturePaintMarks(editor!.state)).toEqual([])
+  })
+})
+
+describe('formatPainter — applyPaintMarks', () => {
+  it('paints the recorded marks onto a target selection', () => {
+    // Record bold+red from para 1.
+    selectText(editor!, 1, 8)
+    const marks = capturePaintMarks(editor!.state)
+    // Paint onto "plain" (para 2).
+    selectText(editor!, 10, 15)
+    const applied = applyPaintMarks(editor!, marks)
+    expect(applied).toBe(true)
+    expect(editor!.getAttributes('textStyle').color).toBe('#ff0000')
+    // Re-select the painted range and confirm bold is active across it.
+    selectText(editor!, 10, 15)
+    expect(editor!.isActive('bold')).toBe(true)
+    expect(editor!.isActive('textStyle', { color: '#ff0000' })).toBe(true)
+  })
+
+  it('replaces the target formatting rather than merging it', () => {
+    // Record plain (empty mark set) from para 2.
+    selectText(editor!, 10, 15)
+    const marks = capturePaintMarks(editor!.state)
+    expect(marks).toEqual([])
+    // Paint onto italic para 3 → italic should be stripped.
+    selectText(editor!, 17, 23)
+    applyPaintMarks(editor!, marks)
+    selectText(editor!, 17, 23)
+    expect(editor!.isActive('italic')).toBe(false)
+  })
+
+  it('is a no-op on an empty (collapsed) target selection', () => {
+    selectText(editor!, 1, 8)
+    const marks = capturePaintMarks(editor!.state)
+    editor!.commands.setTextSelection(12)
+    expect(applyPaintMarks(editor!, marks)).toBe(false)
+  })
+})

--- a/packages/docs/src/editor/formatPainter.ts
+++ b/packages/docs/src/editor/formatPainter.ts
@@ -85,12 +85,46 @@ export function applyPaintMarks(editor: Editor, marks: readonly Mark[]): boolean
     .chain()
     .focus()
     .command(({ tr, state }) => {
+      // Find the target's `link` spans up front. The `code` mark declares `excludes: '_'`
+      // (@tiptap/extension-code), so ProseMirror will not let `code` and `link` share a range:
+      // adding `code` strips the link, and the exclusion is mutual, so a link can't be re-applied
+      // on top of code either. The painter must never touch the target's links, so any captured
+      // mark whose type excludes `link` (e.g. `code`) is applied only to the *non-linked* portions
+      // of the range — the linked text keeps its href and simply does not receive that mark.
+      const linkType = state.schema.marks.link
+      const linkSpans: { from: number; to: number }[] = []
+      if (linkType) {
+        state.doc.nodesBetween(from, to, (node, pos) => {
+          if (!node.isText && !node.isInline) return true
+          if (node.marks.some((m) => m.type === linkType)) {
+            const spanFrom = Math.max(from, pos)
+            const spanTo = Math.min(to, pos + node.nodeSize)
+            if (spanTo > spanFrom) linkSpans.push({ from: spanFrom, to: spanTo })
+          }
+          return true
+        })
+      }
+
+      // The sub-ranges of [from, to] that carry no link — the complement of linkSpans.
+      const unlinkedSpans: { from: number; to: number }[] = []
+      let cursor = from
+      for (const span of linkSpans.sort((a, b) => a.from - b.from)) {
+        if (span.from > cursor) unlinkedSpans.push({ from: cursor, to: span.from })
+        cursor = Math.max(cursor, span.to)
+      }
+      if (cursor < to) unlinkedSpans.push({ from: cursor, to })
+
       for (const name of PAINTABLE_MARK_NAMES) {
         const markType = state.schema.marks[name]
         if (markType) tr.removeMark(from, to, markType)
       }
       for (const mark of marks) {
-        tr.addMark(from, to, mark)
+        // A mark that excludes `link` (code) would strip the href; confine it to unlinked spans.
+        if (linkType && linkSpans.length > 0 && mark.type.excludes(linkType)) {
+          for (const span of unlinkedSpans) tr.addMark(span.from, span.to, mark)
+        } else {
+          tr.addMark(from, to, mark)
+        }
       }
       return true
     })

--- a/packages/docs/src/editor/formatPainter.ts
+++ b/packages/docs/src/editor/formatPainter.ts
@@ -1,0 +1,98 @@
+import type { Editor } from '@tiptap/core'
+import type { EditorState } from '@tiptap/pm/state'
+import type { Mark } from '@tiptap/pm/model'
+
+/**
+ * Format painter (XIN-963): copy the inline formatting of one selection and paint it onto another.
+ *
+ * This is a pure inline-mark operation — it reads the textStyle-family marks (bold / italic /
+ * underline / strike / inline-code / colour / highlight / font size + family / super- & subscript)
+ * of the source selection and re-applies exactly that set to the target selection. It never touches
+ * node structure, block types, alignment, links, or comment anchors, so it introduces no schema
+ * changes and keeps the Yjs document shape untouched.
+ */
+
+/**
+ * Inline mark types the painter is allowed to copy. An allowlist (not a denylist) so marks that are
+ * NOT plain inline formatting — `link` (target-specific href) and the `octoCommentHighlight`
+ * decoration — are never carried across text, and any future mark defaults to non-paintable.
+ *
+ * `textStyle` is the carrier mark for text colour, font size and font family (extension-text-style /
+ * extension-color store those as its attrs), so copying the `textStyle` mark instance carries all
+ * three at once.
+ */
+export const PAINTABLE_MARK_NAMES: readonly string[] = [
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  'code',
+  'textStyle',
+  'highlight',
+  'superscript',
+  'subscript',
+]
+
+function isPaintable(mark: Mark): boolean {
+  return PAINTABLE_MARK_NAMES.includes(mark.type.name)
+}
+
+/**
+ * Capture the paintable inline marks describing the current selection.
+ *
+ * - Collapsed cursor: the marks that would apply to typed text (stored marks, else the marks at the
+ *   caret) — so the painter can be armed from a caret sitting inside formatted text.
+ * - Range selection: the marks of the first inline (text) node in the range. This mirrors the common
+ *   format-painter convention of copying the formatting at the start of the selection; a mixed-format
+ *   selection paints its leading run's format rather than an ambiguous union.
+ *
+ * Returns a (possibly empty) array. An empty result is meaningful: it means "plain text", and
+ * painting it onto a target strips that target's paintable formatting.
+ */
+export function capturePaintMarks(state: EditorState): Mark[] {
+  const { from, to, empty, $from } = state.selection
+  if (empty) {
+    const marks = state.storedMarks ?? $from.marks()
+    return marks.filter(isPaintable)
+  }
+  let found: readonly Mark[] | null = null
+  state.doc.nodesBetween(from, to, (node) => {
+    if (found) return false
+    if (node.isText || node.isInline) {
+      found = node.marks
+      return false
+    }
+    return true
+  })
+  return (found ?? []).filter(isPaintable)
+}
+
+/**
+ * Paint the captured marks onto the current (target) selection.
+ *
+ * Replaces the target's inline formatting: every paintable mark type is first removed across the
+ * range, then each captured mark is applied. This makes painting deterministic — the target ends up
+ * with exactly the source's inline format, not a union of the two. Block structure, alignment, links
+ * and comment anchors are left untouched.
+ *
+ * No-op (returns false) when the target selection is empty, so a stray caret click never mutates the
+ * document.
+ */
+export function applyPaintMarks(editor: Editor, marks: readonly Mark[]): boolean {
+  const { from, to, empty } = editor.state.selection
+  if (empty) return false
+  return editor
+    .chain()
+    .focus()
+    .command(({ tr, state }) => {
+      for (const name of PAINTABLE_MARK_NAMES) {
+        const markType = state.schema.marks[name]
+        if (markType) tr.removeMark(from, to, markType)
+      }
+      for (const mark of marks) {
+        tr.addMark(from, to, mark)
+      }
+      return true
+    })
+    .run()
+}

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -127,6 +127,7 @@
     "codeBlock": "Code block",
     "divider": "Divider",
     "clearFormat": "Clear formatting",
+    "formatPainter": "Format painter",
     "blockType": "Text style",
     "bodyText": "Body text",
     "find": "Find & replace",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -127,6 +127,7 @@
     "codeBlock": "代码块",
     "divider": "分割线",
     "clearFormat": "清除格式",
+    "formatPainter": "格式刷",
     "blockType": "文本样式",
     "bodyText": "正文",
     "find": "查找替换",


### PR DESCRIPTION
## What

Adds a **Format Painter** to the docs editor toolbar (next to Clear formatting). It copies the inline formatting of one selection and paints it onto another — matching the affordance shipped by Feishu / Tencent Docs / Google Docs.

Marks copied (textStyle family): **bold, italic, underline, strikethrough, inline code, text colour, highlight, font size, font family, superscript, subscript.**

## How

- New `editor/formatPainter.ts`:
  - `capturePaintMarks(state)` — reads the paintable inline marks of the current selection (first inline run of a range; stored/caret marks for a collapsed cursor).
  - `applyPaintMarks(editor, marks)` — clears the paintable mark types across the target range, then re-applies the captured marks via a single ProseMirror transaction.
  - Paintable set is an **allowlist**, so `link` (target-specific href) and the comment-highlight decoration are never carried across text.
- `Toolbar.tsx`: a paint-roller button. Click captures the current selection's marks and *arms* (active state); the next selection completed in the editor (`mouseup`) is painted once, then the painter disarms. Painting **replaces** the target's inline formatting rather than merging it.

## Constraints honoured

- **Frontend-only.** No new schema, no node/block/alignment changes, no Yjs document-shape change — it only reads and re-applies existing inline marks.
- **i18n.** Tooltip driven by `t('docs.toolbar.formatPainter')`; keys added to `zh-CN.json` (`格式刷`) and `en-US.json` (`Format painter`). No hardcoded strings. `i18n:check` green.

## Testing

- `formatPainter.test.ts` — capture records bold + textStyle colour, excludes links, returns empty for plain text; apply paints onto a target, replaces (does not merge) formatting, and is a no-op on a collapsed selection.
- `Toolbar.test.tsx` — button renders next to Clear formatting, arms/disarms on click, and an **end-to-end** case (arm → select target → mouseup → target becomes formatted, painter disarms) exercised against a real Tiptap editor.
- New assertions proven red before the change (module absent), green after.
- `tsc` (no new errors — two pre-existing unrelated errors in `dmworkbase/i18n/format.ts` and `members/sort.ts` remain untouched), `i18n:check`, and the docs vitest suite green (the 4 pre-existing `DocsHome` sheet-view flakes are unrelated and present on `main`).

## Acceptance

- Select formatted text → click format painter → select another run → that run receives the same inline formatting; block structure and body content are untouched. ✅

Opened as **draft** to carry review.
