### PR TITLE
feat(loop): show machine-level runtimes on the runtime page when there is no workspace

### DIFF
--- a/packages/dmloop/src/api/__tests__/workspaceSelection.test.ts
+++ b/packages/dmloop/src/api/__tests__/workspaceSelection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkspaceSelection, runtimeListPath } from "../workspaceSelection";
+import type { Workspace } from "../types";
+
+const ws = (id: string, slug: string): Workspace => ({ id, name: slug, slug } as Workspace);
+
+describe("resolveWorkspaceSelection", () => {
+  it("returns machine mode when there are no workspaces", () => {
+    expect(resolveWorkspaceSelection([], "")).toEqual({ mode: "machine" });
+  });
+  it("picks the current workspace when present", () => {
+    expect(resolveWorkspaceSelection([ws("a", "alpha"), ws("b", "beta")], "b")).toEqual({
+      mode: "workspace",
+      slug: "beta",
+      id: "b",
+    });
+  });
+  it("falls back to the first workspace when current id is absent", () => {
+    expect(resolveWorkspaceSelection([ws("a", "alpha"), ws("b", "beta")], "zzz")).toEqual({
+      mode: "workspace",
+      slug: "alpha",
+      id: "a",
+    });
+  });
+});
+
+describe("runtimeListPath", () => {
+  it("uses the workspace-scoped endpoint when a slug is present", () => {
+    expect(runtimeListPath("alpha")).toBe("/runtimes");
+  });
+  it("uses the auth-only machine endpoint when there is no slug", () => {
+    expect(runtimeListPath("")).toBe("/machine-runtimes");
+  });
+});

--- a/packages/dmloop/src/api/runtimeApi.ts
+++ b/packages/dmloop/src/api/runtimeApi.ts
@@ -1,9 +1,10 @@
 // @octo/loop — Runtime API（后端契约联调；Runtime 已并入 Loop 二级菜单）
 import type { RuntimeDevice, ListParams } from "./types";
-import { httpGet } from "./http";
+import { currentWorkspaceSlug, httpGet } from "./http";
+import { runtimeListPath } from "./workspaceSelection";
 
 export async function listRuntimes(params?: ListParams): Promise<RuntimeDevice[]> {
-  const rows = await httpGet<RuntimeDevice[]>("/runtimes");
+  const rows = await httpGet<RuntimeDevice[]>(runtimeListPath(currentWorkspaceSlug()));
   const kw = params?.keyword?.trim().toLowerCase();
   if (!kw) return rows ?? [];
   return (rows ?? []).filter(

--- a/packages/dmloop/src/api/workspaceSelection.ts
+++ b/packages/dmloop/src/api/workspaceSelection.ts
@@ -1,0 +1,28 @@
+// @octo/loop — 运行时/我的 页的 workspace 作用域决策(纯函数,便于单测)。
+import type { Workspace } from "./types";
+
+export type WorkspaceSelection =
+  | { mode: "workspace"; slug: string; id: string }
+  | { mode: "machine" };
+
+// 决定「我的/运行时」页如何取上下文:
+// - ≥1 workspace:选当前(或第一个)-> workspace 模式。
+// - 0 workspace:machine 模式,页面照常挂载并展示用户的机器级 runtime
+//   (daemon 以空 workspace 注册)。不创建任何 workspace,切换器里也不会多出东西。
+export function resolveWorkspaceSelection(
+  workspaces: Workspace[],
+  currentId: string,
+): WorkspaceSelection {
+  if (!workspaces || workspaces.length === 0) {
+    return { mode: "machine" };
+  }
+  const selected = workspaces.find((w) => w.id === currentId) ?? workspaces[0];
+  return { mode: "workspace", slug: selected.slug, id: selected.id };
+}
+
+// runtimeListPath 选运行时列表端点:有 workspace slug 用 workspace 作用域的
+// /runtimes(强 workspace 组);无 slug(0 workspace / 机器级模式)用 auth-only
+// 的 /machine-runtimes —— /runtimes 在此情形会被 workspace 中间件 403。
+export function runtimeListPath(slug: string): string {
+  return slug ? "/runtimes" : "/machine-runtimes";
+}

--- a/packages/dmloop/src/index.tsx
+++ b/packages/dmloop/src/index.tsx
@@ -27,3 +27,5 @@ export {
   setWorkspaceContext,
   LoopApiError,
 } from "./api/http";
+export { resolveWorkspaceSelection, runtimeListPath } from "./api/workspaceSelection";
+export type { WorkspaceSelection } from "./api/workspaceSelection";

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -27,70 +27,55 @@ export default function PersonalPage() {
   const { t } = useI18n();
   const [tab, setTab] = useState<PersonalTabKey>("runtime");
   const [workspaceReady, setWorkspaceReady] = useState(false);
-  const [workspaceEmpty, setWorkspaceEmpty] = useState(false);
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
-  // machine 模式(0 workspace):只有 runtime 走机器级端点;skill 仍按 workspace 管理,
-  // 无 workspace 时不可用。用 state 驱动 tab 禁用渲染,用 ref 供挂载/导航副作用读取。
+  // machine 模式(0 workspace)标记:machine 模式禁用 Skills、清空 workspace 作用域。
+  // 用 state 驱动 tab 禁用渲染,用 ref 供导航激活副作用同步读取。
   const [machineMode, setMachineMode] = useState(false);
   // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
   // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
   const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
-  // machine 模式(0 workspace)标记:nav 重激活 / tab 切换时据此清空 workspace 作用域并重铺,
-  // 而不是像 workspace 模式那样重设 slug。避免 selectedWsRef 为 null 时右栏被清空不重铺。
   const machineModeRef = useRef(false);
   const tabRef = useRef<PersonalTabKey>("runtime");
   tabRef.current = tab;
+  const mountedRef = useRef(true);
 
-  const openTab = (key: PersonalTabKey) => {
-    if (!workspaceReady) return;
-    if (machineModeRef.current && key === "skill") return; // skill 需 workspace,机器级模式禁用
-    const ws = selectedWsRef.current;
-    if (machineModeRef.current) {
-      setWorkspaceContext("", ""); // 机器级模式:清空作用域,列表走 /machine-runtimes
-    } else if (ws) {
-      setWorkspaceContext(ws.slug, ws.id); // 铺视图前先把全局上下文拨回本页的 workspace
+  // 解析当前 workspace 归属并铺右栏。每次调用都重新 listWorkspaces —— 本页常驻不重挂,
+  // 且 workspace 可能在别处(如 Loop)被创建/删除,machine↔workspace 模式必须每次重判,
+  // 不能沿用挂载时缓存的判断(#729 评审:否则建了 workspace 仍卡在 machine 模式)。
+  const resolveAndPaint = (showLoading: boolean) => {
+    if (showLoading) {
+      WKApp.routeRight.replaceToRoot(
+        <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
+      );
     }
-    setTab(key);
-    WKApp.routeRight.replaceToRoot(renderTab(key));
-  };
-
-  useEffect(() => {
-    let cancelled = false;
-
-    WKApp.routeRight.replaceToRoot(
-      <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
-    );
-
     workspaceApi.listWorkspaces()
       .then((workspaces) => {
-        if (cancelled) return;
+        if (!mountedRef.current) return;
         const selection = resolveWorkspaceSelection(workspaces, currentWorkspaceId());
-
         if (selection.mode === "machine") {
           // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
-          // 运行时列表转而走 /machine-runtimes;不显示「请先加入 workspace」。
+          // 运行时列表走 /machine-runtimes;Skills 需 workspace,禁用。
           machineModeRef.current = true;
           setMachineMode(true);
           selectedWsRef.current = null;
           setWorkspaceContext("", "");
-          setWorkspaceReady(true);
-          setWorkspaceEmpty(false);
-          setWorkspaceError(null);
-          WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
-          return;
+          // machine 模式禁用 Skills:若当前正停在 Skills tab,回落到 runtime。
+          if (tabRef.current === "skill") {
+            tabRef.current = "runtime";
+            setTab("runtime");
+          }
+        } else {
+          machineModeRef.current = false;
+          setMachineMode(false);
+          selectedWsRef.current = { slug: selection.slug, id: selection.id };
+          setWorkspaceContext(selection.slug, selection.id);
         }
-
-        machineModeRef.current = false;
-        setMachineMode(false);
-        selectedWsRef.current = { slug: selection.slug, id: selection.id };
-        setWorkspaceContext(selection.slug, selection.id);
         setWorkspaceReady(true);
-        setWorkspaceEmpty(false);
         setWorkspaceError(null);
         WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
       })
       .catch((error) => {
-        if (cancelled) return;
+        if (!mountedRef.current) return;
         const message = error?.message ? String(error.message) : t("personal.workspace.loadFailed");
         setWorkspaceError(message);
         setWorkspaceReady(false);
@@ -102,30 +87,43 @@ export default function PersonalPage() {
           />,
         );
       });
+  };
+  // 始终指向最新的 resolveAndPaint,供 []-依赖的副作用调用(避免陈旧闭包,同时不让
+  // 副作用因 t 变化而重挂——对齐 LoopPage 的 mount-once 行为,切语言不闪回加载态)。
+  const resolveRef = useRef(resolveAndPaint);
+  resolveRef.current = resolveAndPaint;
 
+  const openTab = (key: PersonalTabKey) => {
+    if (!workspaceReady) return;
+    if (machineModeRef.current && key === "skill") return; // skill 需 workspace,机器级模式禁用
+    const ws = selectedWsRef.current;
+    if (machineModeRef.current) {
+      setWorkspaceContext("", "");
+    } else if (ws) {
+      setWorkspaceContext(ws.slug, ws.id);
+    }
+    setTab(key);
+    WKApp.routeRight.replaceToRoot(renderTab(key));
+  };
+
+  useEffect(() => {
+    mountedRef.current = true;
+    resolveRef.current(true);
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
     };
     // 只在挂载时跑一次(对齐 LoopPage):依赖 [t] 会让切语言时重跑,闪回加载态、丢失当前 tab/弹框。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 顶部一级导航「Personal」被再次点击时,onMenuClick 会先 popToRoot 清空右栏,且本页常驻不重挂
-  // (挂载副作用不会重跑)。这里监听激活事件:重新断言 workspace 上下文并铺回当前 tab,
-  // 修复「切回后右栏空白」与「用别处 workspace 的上下文拉数据」两个问题(#619 评审)。
+  // (挂载副作用不会重跑)。这里监听激活事件:重新解析 workspace 归属(machine↔workspace 可能已变)
+  // 并铺回当前 tab,修复「切回后右栏空白」「用别处 workspace 上下文拉数据」以及「建 workspace 后
+  // 仍卡在机器级模式」(#729 评审)。
   useEffect(() => {
     const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
       if (menuId !== "dmpersonal") return;
-      // 用 ref 判就绪(避免 [] 依赖下的陈旧闭包):machine 模式已就绪但无 selectedWs;
-      // workspace 模式以 selectedWsRef 非空为就绪标志。两者皆未定=加载中,挂载副作用会自铺。
-      if (machineModeRef.current) {
-        setWorkspaceContext("", "");
-      } else {
-        const ws = selectedWsRef.current;
-        if (!ws) return;
-        setWorkspaceContext(ws.slug, ws.id);
-      }
-      WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
+      resolveRef.current(false);
     };
     WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
     return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
@@ -147,10 +145,8 @@ export default function PersonalPage() {
           </button>
         ))}
       </nav>
-      {(workspaceEmpty || workspaceError) && (
-        <div className="dmpersonal-sidebar__hint">
-          {workspaceError || t("personal.workspace.requiredTitle")}
-        </div>
+      {workspaceError && (
+        <div className="dmpersonal-sidebar__hint">{workspaceError}</div>
       )}
     </div>
   );

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -29,6 +29,9 @@ export default function PersonalPage() {
   const [workspaceReady, setWorkspaceReady] = useState(false);
   const [workspaceEmpty, setWorkspaceEmpty] = useState(false);
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  // machine 模式(0 workspace):只有 runtime 走机器级端点;skill 仍按 workspace 管理,
+  // 无 workspace 时不可用。用 state 驱动 tab 禁用渲染,用 ref 供挂载/导航副作用读取。
+  const [machineMode, setMachineMode] = useState(false);
   // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
   // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
   const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
@@ -40,6 +43,7 @@ export default function PersonalPage() {
 
   const openTab = (key: PersonalTabKey) => {
     if (!workspaceReady) return;
+    if (machineModeRef.current && key === "skill") return; // skill 需 workspace,机器级模式禁用
     const ws = selectedWsRef.current;
     if (machineModeRef.current) {
       setWorkspaceContext("", ""); // 机器级模式:清空作用域,列表走 /machine-runtimes
@@ -66,6 +70,7 @@ export default function PersonalPage() {
           // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
           // 运行时列表转而走 /machine-runtimes;不显示「请先加入 workspace」。
           machineModeRef.current = true;
+          setMachineMode(true);
           selectedWsRef.current = null;
           setWorkspaceContext("", "");
           setWorkspaceReady(true);
@@ -76,6 +81,7 @@ export default function PersonalPage() {
         }
 
         machineModeRef.current = false;
+        setMachineMode(false);
         selectedWsRef.current = { slug: selection.slug, id: selection.id };
         setWorkspaceContext(selection.slug, selection.id);
         setWorkspaceReady(true);
@@ -133,7 +139,7 @@ export default function PersonalPage() {
           <button
             key={item.key}
             className={`dmpersonal-sidebar__item ${tab === item.key ? "is-active" : ""}`}
-            disabled={!workspaceReady}
+            disabled={!workspaceReady || (machineMode && item.key === "skill")}
             onClick={() => openTab(item.key)}
           >
             {item.icon}

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -38,11 +38,15 @@ export default function PersonalPage() {
   const tabRef = useRef<PersonalTabKey>("runtime");
   tabRef.current = tab;
   const mountedRef = useRef(true);
+  // 请求代号:resolveAndPaint 由导航事件驱动,快速切换可能并发多个 listWorkspaces;
+  // 每次进入自增,回来时若代号已过期就丢弃,保证"最后一次点击胜出"、不被慢的旧响应覆盖。
+  const resolveSeqRef = useRef(0);
 
   // 解析当前 workspace 归属并铺右栏。每次调用都重新 listWorkspaces —— 本页常驻不重挂,
   // 且 workspace 可能在别处(如 Loop)被创建/删除,machine↔workspace 模式必须每次重判,
   // 不能沿用挂载时缓存的判断(#729 评审:否则建了 workspace 仍卡在 machine 模式)。
   const resolveAndPaint = (showLoading: boolean) => {
+    const seq = ++resolveSeqRef.current;
     if (showLoading) {
       WKApp.routeRight.replaceToRoot(
         <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
@@ -50,8 +54,11 @@ export default function PersonalPage() {
     }
     workspaceApi.listWorkspaces()
       .then((workspaces) => {
-        if (!mountedRef.current) return;
-        const selection = resolveWorkspaceSelection(workspaces, currentWorkspaceId());
+        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
+        // 优先用本页自己存的 workspace,仅当它不存在(如在别处被删)时才回落到共享全局。
+        // 直接读 currentWorkspaceId() 会让 Personal 跟随 Loop 最后选中的 workspace(#619 污染)。
+        const targetId = selectedWsRef.current?.id ?? currentWorkspaceId();
+        const selection = resolveWorkspaceSelection(workspaces, targetId);
         if (selection.mode === "machine") {
           // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
           // 运行时列表走 /machine-runtimes;Skills 需 workspace,禁用。
@@ -75,7 +82,7 @@ export default function PersonalPage() {
         WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
       })
       .catch((error) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
         const message = error?.message ? String(error.message) : t("personal.workspace.loadFailed");
         setWorkspaceError(message);
         setWorkspaceReady(false);
@@ -123,7 +130,8 @@ export default function PersonalPage() {
   useEffect(() => {
     const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
       if (menuId !== "dmpersonal") return;
-      resolveRef.current(false);
+      // showLoading=true:框架会先 popToRoot 清空右栏,重解析是异步的,先铺加载态避免空白闪一下。
+      resolveRef.current(true);
     };
     WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
     return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { AlertCircle, Cpu, FolderPlus, Loader2, Sparkles } from "lucide-react";
-import { currentWorkspaceId, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
+import { AlertCircle, Cpu, Loader2, Sparkles } from "lucide-react";
+import { currentWorkspaceId, resolveWorkspaceSelection, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
 import { useI18n, WKApp } from "@octo/base";
 import "@octo/loop/src/pages/loop.css";
 import "./personal.css";
@@ -32,13 +32,20 @@ export default function PersonalPage() {
   // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
   // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
   const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
+  // machine 模式(0 workspace)标记:nav 重激活 / tab 切换时据此清空 workspace 作用域并重铺,
+  // 而不是像 workspace 模式那样重设 slug。避免 selectedWsRef 为 null 时右栏被清空不重铺。
+  const machineModeRef = useRef(false);
   const tabRef = useRef<PersonalTabKey>("runtime");
   tabRef.current = tab;
 
   const openTab = (key: PersonalTabKey) => {
     if (!workspaceReady) return;
     const ws = selectedWsRef.current;
-    if (ws) setWorkspaceContext(ws.slug, ws.id); // 铺视图前先把全局上下文拨回本页的 workspace
+    if (machineModeRef.current) {
+      setWorkspaceContext("", ""); // 机器级模式:清空作用域,列表走 /machine-runtimes
+    } else if (ws) {
+      setWorkspaceContext(ws.slug, ws.id); // 铺视图前先把全局上下文拨回本页的 workspace
+    }
     setTab(key);
     WKApp.routeRight.replaceToRoot(renderTab(key));
   };
@@ -53,24 +60,24 @@ export default function PersonalPage() {
     workspaceApi.listWorkspaces()
       .then((workspaces) => {
         if (cancelled) return;
-        const selected = workspaces.find((workspace) => workspace.id === currentWorkspaceId()) ?? workspaces[0] ?? null;
+        const selection = resolveWorkspaceSelection(workspaces, currentWorkspaceId());
 
-        if (!selected) {
+        if (selection.mode === "machine") {
+          // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
+          // 运行时列表转而走 /machine-runtimes;不显示「请先加入 workspace」。
+          machineModeRef.current = true;
           selectedWsRef.current = null;
-          setWorkspaceEmpty(true);
-          setWorkspaceReady(false);
-          WKApp.routeRight.replaceToRoot(
-            <PersonalWorkspaceState
-              icon={<FolderPlus size={40} />}
-              title={t("personal.workspace.requiredTitle")}
-              desc={t("personal.workspace.requiredDesc")}
-            />,
-          );
+          setWorkspaceContext("", "");
+          setWorkspaceReady(true);
+          setWorkspaceEmpty(false);
+          setWorkspaceError(null);
+          WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
           return;
         }
 
-        selectedWsRef.current = { slug: selected.slug, id: selected.id };
-        setWorkspaceContext(selected.slug, selected.id);
+        machineModeRef.current = false;
+        selectedWsRef.current = { slug: selection.slug, id: selection.id };
+        setWorkspaceContext(selection.slug, selection.id);
         setWorkspaceReady(true);
         setWorkspaceEmpty(false);
         setWorkspaceError(null);
@@ -103,9 +110,15 @@ export default function PersonalPage() {
   useEffect(() => {
     const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
       if (menuId !== "dmpersonal") return;
-      const ws = selectedWsRef.current;
-      if (!ws) return; // 尚未就绪:挂载副作用会在加载完成后自行铺视图
-      setWorkspaceContext(ws.slug, ws.id);
+      // 用 ref 判就绪(避免 [] 依赖下的陈旧闭包):machine 模式已就绪但无 selectedWs;
+      // workspace 模式以 selectedWsRef 非空为就绪标志。两者皆未定=加载中,挂载副作用会自铺。
+      if (machineModeRef.current) {
+        setWorkspaceContext("", "");
+      } else {
+        const ws = selectedWsRef.current;
+        if (!ws) return;
+        setWorkspaceContext(ws.slug, ws.id);
+      }
       WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
     };
     WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);

--- a/packages/dmpersonal/src/i18n/en-US.json
+++ b/packages/dmpersonal/src/i18n/en-US.json
@@ -8,8 +8,6 @@
   },
   "workspace": {
     "loading": "Loading workspace...",
-    "requiredTitle": "Join a workspace first",
-    "requiredDesc": "Runtimes and Skills are currently managed within a workspace. Join or create one, then come back.",
     "loadFailed": "Failed to load workspaces"
   }
 }

--- a/packages/dmpersonal/src/i18n/zh-CN.json
+++ b/packages/dmpersonal/src/i18n/zh-CN.json
@@ -8,8 +8,6 @@
   },
   "workspace": {
     "loading": "正在加载工作区…",
-    "requiredTitle": "请先加入一个 workspace",
-    "requiredDesc": "Runtimes 和 Skills 当前仍按 workspace 管理。加入或创建 workspace 后再回来查看。",
     "loadFailed": "工作区加载失败"
   }
 }


### PR DESCRIPTION
## Summary

Make the **我的 → 运行时** (Runtime) page usable when the user has no workspace. Previously `PersonalPage` gated the page with "请先加入一个 workspace" and never mounted `RuntimePage`, so a user with zero workspaces could not open **添加电脑** or see the runtimes on their own machine. This adds a machine-level (workspace-independent) mode.

## Related Issue

Fixes #728

## Changes

- Add `resolveWorkspaceSelection()` — decides `workspace` vs `machine` mode from the workspace list (pure function, unit-tested).
- Add `runtimeListPath()` — selects the auth-only `/machine-runtimes` endpoint when there is no workspace slug, otherwise the workspace-scoped `/runtimes`.
- `runtimeApi.listRuntimes()` picks the endpoint via `runtimeListPath(currentWorkspaceSlug())`.
- `PersonalPage`: when `listWorkspaces()` is empty, mount `RuntimePage` in machine mode (clear the workspace slug) instead of showing the join-a-workspace gate; disable the Skills tab in machine mode; keep the workspace/loading/error states otherwise unchanged.

## Architecture / Module Boundary

- Affected module(s): `packages/dmpersonal` (PersonalPage), `packages/dmloop` (runtime API + workspace selection helper).
- New or changed user-visible entry point: no new route; the existing Runtime page now also renders in the 0-workspace state.
- Shared layer touched: none (`ui` / `Components` / `bridge` / `service` untouched).
- If shared code changed, impact scope: n/a.
- Duplicate entry point checked: yes — reuses the existing Runtime page, no new entry point.

Depends on the octo-multica backend providing the owner-scoped `GET /api/machine-runtimes` endpoint and machine-level runtime registration; that side ships separately in the octo-multica repository.

## Testing

- `pnpm --filter @octo/loop test` — `workspaceSelection`/`runtimeListPath` unit tests pass (5 cases).
- Manually verified end-to-end against a local backend + daemon: with 0 workspace the Runtime page renders and lists the machine's runtimes (`claude`/`codex`/`hermes`/`openclaw`) via `/machine-runtimes`; Skills is disabled; after creating a workspace the page falls back to the per-workspace list.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
