### PR TITLE
refactor(wksdk): extract runtime startup helpers

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -152,6 +152,7 @@ import { WKBaseContext } from "./Components/WKBase";
 import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
+import { syncClientMsgDeviceId } from "./im-runtime/clientMsgDevice";
 import { ImConnectAddressManager } from "./im-runtime/connectAddress";
 import { connectImClient } from "./im-runtime/connectClient";
 import { createImConnectStatusListener } from "./im-runtime/connectStatus";
@@ -963,23 +964,16 @@ export default class WKApp extends ProviderListener {
     WKApp.dataSource.contactsSync(); // 同步通讯录
     ProhibitwordsService.shared.sync(); // 同步敏感词
 
-    WKApp.apiClient
-      .get(`/user/devices/${WKApp.shared.deviceId}`)
-      .then((res) => {
-        if (res.id) {
-          WKSDK.shared().config.clientMsgDeviceId = res.id;
-        }
-      })
-      .catch((err) => {
-        // 设备记录不存在（status===400）或其它读取失败时，仅记录告警以消除
-        // unhandled promise rejection；不写 clientMsgDeviceId，保持原值降级运行。
-        // 服务端暂无设备注册端点，此处不做注册，仅兜底。
-        const notFound = err?.status === 400;
-        console.warn(
-          `[startMain] fetch device record failed${notFound ? " (device not found)" : ""}`,
-          { deviceId: WKApp.shared.deviceId, status: err?.status, code: err?.code }
-        );
-      });
+    // 设备记录不存在（status===400）或其它读取失败时，仅记录告警以消除
+    // unhandled promise rejection；不写 clientMsgDeviceId，保持原值降级运行。
+    // 服务端暂无设备注册端点，此处不做注册，仅兜底。
+    syncClientMsgDeviceId({
+      deviceId: WKApp.shared.deviceId,
+      fetchDevice: (path) => WKApp.apiClient.get(path),
+      setClientMsgDeviceId: (id) => {
+        WKSDK.shared().config.clientMsgDeviceId = id;
+      },
+    });
   }
 
   connectIM() {

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -153,9 +153,12 @@ import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
 import { syncClientMsgDeviceId } from "./im-runtime/clientMsgDevice";
-import { ImConnectAddressManager } from "./im-runtime/connectAddress";
+import {
+  ImConnectAddressManager,
+  registerImConnectAddressProvider,
+} from "./im-runtime/connectAddress";
 import { connectImClient } from "./im-runtime/connectClient";
-import { createImConnectStatusListener } from "./im-runtime/connectStatus";
+import { registerImConnectStatusListener } from "./im-runtime/connectStatus";
 import {
   clearAuthStorage,
   consumeOidcPostLogoutCleanup,
@@ -814,8 +817,10 @@ export default class WKApp extends ProviderListener {
     // 暗黑模式已关闭，强制亮色
     WKApp.config.themeMode = ThemeMode.light;
 
-    WKSDK.shared().config.provider.connectAddrCallback =
-      this.imConnectAddressManager.connectAddrCallback;
+    registerImConnectAddressProvider(
+      WKSDK.shared(),
+      this.imConnectAddressManager.connectAddrCallback
+    );
 
     WKApp.endpoints.addOnLogin(() => {
       this.startMain();
@@ -825,14 +830,12 @@ export default class WKApp extends ProviderListener {
       this.startMain();
     }
 
-    WKSDK.shared().connectManager.addConnectStatusListener(
-      createImConnectStatusListener({
-        logout: () => WKApp.shared.logout(),
-        resetTyping: () => TypingManager.shared.resetAll(),
-        rotateConnectAddress: () =>
-          this.imConnectAddressManager.rotateAfterDisconnect(),
-      })
-    );
+    registerImConnectStatusListener(WKSDK.shared(), {
+      logout: () => WKApp.shared.logout(),
+      resetTyping: () => TypingManager.shared.resetAll(),
+      rotateConnectAddress: () =>
+        this.imConnectAddressManager.rotateAfterDisconnect(),
+    });
 
     // 通知设置
     const notificationIsClose = StorageService.shared.getItem(

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -153,6 +153,7 @@ import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
 import { ImConnectAddressManager } from "./im-runtime/connectAddress";
+import { connectImClient } from "./im-runtime/connectClient";
 import { createImConnectStatusListener } from "./im-runtime/connectStatus";
 import {
   clearAuthStorage,
@@ -982,9 +983,10 @@ export default class WKApp extends ProviderListener {
   }
 
   connectIM() {
-    WKSDK.shared().config.uid = WKApp.loginInfo.uid;
-    WKSDK.shared().config.token = WKApp.loginInfo.token;
-    WKSDK.shared().connect();
+    connectImClient({
+      sdk: WKSDK.shared(),
+      loginInfo: WKApp.loginInfo,
+    });
   }
 
   registerModule(module: IModule) {

--- a/packages/dmworkbase/src/im-runtime/clientMsgDevice.test.ts
+++ b/packages/dmworkbase/src/im-runtime/clientMsgDevice.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { syncClientMsgDeviceId } from "./clientMsgDevice";
+
+describe("syncClientMsgDeviceId", () => {
+  it("fetches the device record and writes clientMsgDeviceId", async () => {
+    const fetchDevice = vi.fn().mockResolvedValue({ id: "srv-dev-1" });
+    const setClientMsgDeviceId = vi.fn();
+
+    await syncClientMsgDeviceId({
+      deviceId: "device-1",
+      fetchDevice,
+      setClientMsgDeviceId,
+    });
+
+    expect(fetchDevice).toHaveBeenCalledWith("/user/devices/device-1");
+    expect(setClientMsgDeviceId).toHaveBeenCalledWith("srv-dev-1");
+  });
+
+  it("does not write clientMsgDeviceId when the device record has no id", async () => {
+    const fetchDevice = vi.fn().mockResolvedValue({});
+    const setClientMsgDeviceId = vi.fn();
+
+    await syncClientMsgDeviceId({
+      deviceId: "device-1",
+      fetchDevice,
+      setClientMsgDeviceId,
+    });
+
+    expect(setClientMsgDeviceId).not.toHaveBeenCalled();
+  });
+
+  it("warns without throwing when the device record request fails", async () => {
+    const fetchDevice = vi.fn().mockRejectedValue({ status: 500, code: "E500" });
+    const setClientMsgDeviceId = vi.fn();
+    const warn = vi.fn();
+
+    await syncClientMsgDeviceId({
+      deviceId: "device-1",
+      fetchDevice,
+      setClientMsgDeviceId,
+      warn,
+    });
+
+    expect(setClientMsgDeviceId).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith("[startMain] fetch device record failed", {
+      deviceId: "device-1",
+      status: 500,
+      code: "E500",
+    });
+  });
+
+  it("marks missing device records in the warning message", async () => {
+    const fetchDevice = vi.fn().mockRejectedValue({ status: 400 });
+    const warn = vi.fn();
+
+    await syncClientMsgDeviceId({
+      deviceId: "device-1",
+      fetchDevice,
+      setClientMsgDeviceId: vi.fn(),
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[startMain] fetch device record failed (device not found)",
+      { deviceId: "device-1", status: 400, code: undefined }
+    );
+  });
+});

--- a/packages/dmworkbase/src/im-runtime/clientMsgDevice.ts
+++ b/packages/dmworkbase/src/im-runtime/clientMsgDevice.ts
@@ -1,0 +1,28 @@
+export interface ClientMsgDeviceRecord {
+  id?: string;
+}
+
+export interface SyncClientMsgDeviceIdDeps {
+  deviceId: string;
+  fetchDevice: (path: string) => Promise<ClientMsgDeviceRecord>;
+  setClientMsgDeviceId: (id: string) => void;
+  warn?: (message: string, context: unknown) => void;
+}
+
+export function syncClientMsgDeviceId(deps: SyncClientMsgDeviceIdDeps) {
+  return deps
+    .fetchDevice(`/user/devices/${deps.deviceId}`)
+    .then((res) => {
+      if (res.id) {
+        deps.setClientMsgDeviceId(res.id);
+      }
+    })
+    .catch((err) => {
+      const notFound = err?.status === 400;
+      const warn = deps.warn ?? console.warn;
+      warn(
+        `[startMain] fetch device record failed${notFound ? " (device not found)" : ""}`,
+        { deviceId: deps.deviceId, status: err?.status, code: err?.code }
+      );
+    });
+}

--- a/packages/dmworkbase/src/im-runtime/connectAddress.test.ts
+++ b/packages/dmworkbase/src/im-runtime/connectAddress.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ImConnectAddressManager } from "./connectAddress";
+import {
+  ImConnectAddressManager,
+  registerImConnectAddressProvider,
+} from "./connectAddress";
 
 function createDeps(addrs: string[]) {
   return {
@@ -68,5 +71,18 @@ describe("ImConnectAddressManager", () => {
     await manager.connectAddrCallback(callback);
 
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("registers the connect address callback on the SDK provider", () => {
+    const sdk = {
+      config: {
+        provider: {},
+      },
+    };
+    const connectAddrCallback = vi.fn();
+
+    registerImConnectAddressProvider(sdk, connectAddrCallback);
+
+    expect(sdk.config.provider.connectAddrCallback).toBe(connectAddrCallback);
   });
 });

--- a/packages/dmworkbase/src/im-runtime/connectAddress.ts
+++ b/packages/dmworkbase/src/im-runtime/connectAddress.ts
@@ -4,6 +4,14 @@ export interface ImConnectAddressManagerDeps {
   getConnectAddrs: () => Promise<string[]>;
 }
 
+export interface ImConnectAddressProviderSdk {
+  config: {
+    provider: {
+      connectAddrCallback?: (callback: ConnectAddrCallback) => Promise<void> | void;
+    };
+  };
+}
+
 export class ImConnectAddressManager {
   private wsaddrs = new Array<string>();
   private addrUsed = false;
@@ -28,4 +36,11 @@ export class ImConnectAddressManager {
       this.addrUsed = false;
     }
   }
+}
+
+export function registerImConnectAddressProvider(
+  sdk: ImConnectAddressProviderSdk,
+  connectAddrCallback: (callback: ConnectAddrCallback) => Promise<void> | void
+) {
+  sdk.config.provider.connectAddrCallback = connectAddrCallback;
 }

--- a/packages/dmworkbase/src/im-runtime/connectClient.test.ts
+++ b/packages/dmworkbase/src/im-runtime/connectClient.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { connectImClient, type ImConnectClientSdk } from "./connectClient";
+
+function createSdk(): ImConnectClientSdk {
+  return {
+    config: {
+      uid: "",
+      token: "",
+    },
+    connect: vi.fn(),
+  };
+}
+
+describe("connectImClient", () => {
+  it("sets uid and token before connecting", () => {
+    const sdk = createSdk();
+
+    connectImClient({
+      sdk,
+      loginInfo: {
+        uid: "user-1",
+        token: "token-1",
+      },
+    });
+
+    expect(sdk.config.uid).toBe("user-1");
+    expect(sdk.config.token).toBe("token-1");
+    expect(sdk.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest login info on repeated connect", () => {
+    const sdk = createSdk();
+
+    connectImClient({
+      sdk,
+      loginInfo: {
+        uid: "user-1",
+        token: "token-1",
+      },
+    });
+    connectImClient({
+      sdk,
+      loginInfo: {
+        uid: "user-2",
+        token: "token-2",
+      },
+    });
+
+    expect(sdk.config.uid).toBe("user-2");
+    expect(sdk.config.token).toBe("token-2");
+    expect(sdk.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dmworkbase/src/im-runtime/connectClient.ts
+++ b/packages/dmworkbase/src/im-runtime/connectClient.ts
@@ -1,0 +1,23 @@
+export interface ImConnectClientLoginInfo {
+  uid: string;
+  token: string;
+}
+
+export interface ImConnectClientSdk {
+  config: {
+    uid: string;
+    token: string;
+  };
+  connect: () => void;
+}
+
+export interface ConnectImClientDeps {
+  sdk: ImConnectClientSdk;
+  loginInfo: ImConnectClientLoginInfo;
+}
+
+export function connectImClient(deps: ConnectImClientDeps) {
+  deps.sdk.config.uid = deps.loginInfo.uid;
+  deps.sdk.config.token = deps.loginInfo.token;
+  deps.sdk.connect();
+}

--- a/packages/dmworkbase/src/im-runtime/connectStatus.test.ts
+++ b/packages/dmworkbase/src/im-runtime/connectStatus.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { ConnectStatus } from "wukongimjssdk";
-import { createImConnectStatusListener } from "./connectStatus";
+import {
+  createImConnectStatusListener,
+  registerImConnectStatusListener,
+} from "./connectStatus";
 
 function createDeps() {
   return {
@@ -53,5 +56,23 @@ describe("createImConnectStatusListener", () => {
     expect(deps.rotateConnectAddress).toHaveBeenCalledTimes(1);
     expect(deps.logout).not.toHaveBeenCalled();
     expect(deps.resetTyping).not.toHaveBeenCalled();
+  });
+
+  it("registers a connect status listener on the SDK connect manager", () => {
+    const deps = createDeps();
+    const sdk = {
+      connectManager: {
+        addConnectStatusListener: vi.fn(),
+      },
+    };
+
+    registerImConnectStatusListener(sdk, deps);
+
+    expect(sdk.connectManager.addConnectStatusListener).toHaveBeenCalledTimes(1);
+
+    const listener = sdk.connectManager.addConnectStatusListener.mock.calls[0][0];
+    listener(ConnectStatus.Connected);
+
+    expect(deps.resetTyping).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dmworkbase/src/im-runtime/connectStatus.ts
+++ b/packages/dmworkbase/src/im-runtime/connectStatus.ts
@@ -6,6 +6,17 @@ export interface ImConnectStatusListenerDeps {
   rotateConnectAddress: () => void;
 }
 
+export type ImConnectStatusListener = (
+  status: ConnectStatus,
+  reasonCode?: number
+) => void;
+
+export interface ImConnectStatusSdk {
+  connectManager: {
+    addConnectStatusListener: (listener: ImConnectStatusListener) => void;
+  };
+}
+
 export function createImConnectStatusListener(
   deps: ImConnectStatusListenerDeps
 ) {
@@ -20,4 +31,13 @@ export function createImConnectStatusListener(
       deps.rotateConnectAddress();
     }
   };
+}
+
+export function registerImConnectStatusListener(
+  sdk: ImConnectStatusSdk,
+  deps: ImConnectStatusListenerDeps
+) {
+  sdk.connectManager.addConnectStatusListener(
+    createImConnectStatusListener(deps)
+  );
 }


### PR DESCRIPTION
## Summary
本 PR 对 WKSDK runtime 启动链路做行为不变重构，将 App 入口中的连接启动、设备 ID 同步和 runtime 注册逻辑拆到独立 helper，降低后续维护成本。

- 抽离 uid/token/connect 启动逻辑到 im-runtime/connectClient
- 抽离 clientMsgDeviceId 同步逻辑到 im-runtime/clientMsgDevice
- 抽离连接地址 provider 注册和连接状态 listener 注册 helper
- 保留 startMain/startup/connectIM 的调用入口和执行时机
- 补充 runtime 单元测试

## Not Changed
- 未升级 WKSDK
- 未新增 disconnect 生命周期
- 未改变 connectIM/startMain/startup 调用时机
- 未改变断网恢复策略
- 未改变 UI
- 未改变接口协议

## Test
- pnpm --dir packages/dmworkbase test src/im-runtime/connectAddress.test.ts src/im-runtime/connectStatus.test.ts src/im-runtime/connectClient.test.ts src/im-runtime/clientMsgDevice.test.ts src/__tests__/App.startMain.test.ts
- pnpm --dir apps/web build
- git diff --check main..HEAD

## Manual Verification
- 登录和刷新后能正常进入
- 会话列表正常加载
- 消息收发正常
- 断网恢复在真实浏览器验证通过