### PR TITLE
feat(message-row): right-align self messages for clearer conversation UX

### DIFF
--- a/packages/dmworkbase/src/ui/message/Bubble/index.css
+++ b/packages/dmworkbase/src/ui/message/Bubble/index.css
@@ -47,3 +47,22 @@
 .wk-msg-bubble--last {
   border-radius: var(--wk-r-xs) var(--wk-r-lg) var(--wk-r-lg) var(--wk-r-lg);
 }
+
+/**
+ * 发送方气泡：圆角靠右（右侧靠近头像一侧为直角）
+ */
+
+/* send first: 右下直 */
+.wk-msg-bubble--send.wk-msg-bubble--first {
+  border-radius: var(--wk-r-lg) var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-lg);
+}
+
+/* send middle: 左圆右直 */
+.wk-msg-bubble--send.wk-msg-bubble--middle {
+  border-radius: var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-xs) var(--wk-r-lg);
+}
+
+/* send last: 右上直 */
+.wk-msg-bubble--send.wk-msg-bubble--last {
+  border-radius: var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-lg) var(--wk-r-lg);
+}

--- a/packages/dmworkbase/src/ui/message/Bubble/index.css
+++ b/packages/dmworkbase/src/ui/message/Bubble/index.css
@@ -52,6 +52,11 @@
  * 发送方气泡：圆角靠右（右侧靠近头像一侧为直角）
  */
 
+/* send single: 全圆角（对称气泡不需要缺角） */
+.wk-msg-bubble--send.wk-msg-bubble--single {
+  border-radius: var(--wk-r-lg);
+}
+
 /* send first: 右下直 */
 .wk-msg-bubble--send.wk-msg-bubble--first {
   border-radius: var(--wk-r-lg) var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-lg);

--- a/packages/dmworkbase/src/ui/message/Bubble/index.css
+++ b/packages/dmworkbase/src/ui/message/Bubble/index.css
@@ -47,27 +47,3 @@
 .wk-msg-bubble--last {
   border-radius: var(--wk-r-xs) var(--wk-r-lg) var(--wk-r-lg) var(--wk-r-lg);
 }
-
-/**
- * 发送方气泡：圆角靠右（右侧靠近头像一侧为直角）
- */
-
-/* send single: 全圆角（对称气泡不需要缺角） */
-.wk-msg-bubble--send.wk-msg-bubble--single {
-  border-radius: var(--wk-r-lg);
-}
-
-/* send first: 右下直 */
-.wk-msg-bubble--send.wk-msg-bubble--first {
-  border-radius: var(--wk-r-lg) var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-lg);
-}
-
-/* send middle: 左圆右直 */
-.wk-msg-bubble--send.wk-msg-bubble--middle {
-  border-radius: var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-xs) var(--wk-r-lg);
-}
-
-/* send last: 右上直 */
-.wk-msg-bubble--send.wk-msg-bubble--last {
-  border-radius: var(--wk-r-lg) var(--wk-r-xs) var(--wk-r-lg) var(--wk-r-lg);
-}

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -48,10 +48,36 @@
 }
 
 /**
- * 发送方消息（和接收方一样左对齐，只是可能没有头像）
+ * 发送方消息：flex-direction 反转，头像靠右，气泡靠右对齐
  */
 .wk-msg-row--send {
-  /* 发送方和接收方布局相同，都是左对齐 */
+  flex-direction: row-reverse;
+}
+
+/**
+ * 发送方：内容区文本靠右
+ */
+.wk-msg-row--send .wk-msg-row-content {
+  align-items: flex-end;
+}
+
+/**
+ * 发送方：隐藏自己的名字（自己知道自己是谁）
+ */
+.wk-msg-row--send .wk-msg-row-header {
+  flex-direction: row-reverse;
+}
+
+.wk-msg-row--send .wk-msg-row-sender {
+  display: none;
+}
+
+/**
+ * 发送方：连续消息 hover 时时间戳靠右对齐
+ */
+.wk-msg-row--send .wk-msg-row-avatar-placeholder {
+  display: flex;
+  justify-content: flex-end;
 }
 
 /**

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -48,9 +48,9 @@
 }
 
 /**
- * 发送方消息：flex-direction 反转，头像靠右，气泡靠右对齐
+ * 发送方消息：只对 avatar+content 的 wrapper 做镜像，checkbox 不参与反转
  */
-.wk-msg-row--send {
+.wk-msg-row--send .wk-msg-row-body-wrap {
   flex-direction: row-reverse;
 }
 
@@ -62,18 +62,23 @@
 }
 
 /**
- * 发送方：隐藏自己的名字（自己知道自己是谁）
+ * 发送方：隐藏整个发送者身份组（名字/实名徽章/@Space 后缀作为整体隐藏）
+ */
+.wk-msg-row--send .wk-msg-row-sender,
+.wk-msg-row--send .wk-msg-row-sender-space,
+.wk-msg-row--send .wk-realname-badge {
+  display: none;
+}
+
+/**
+ * 发送方：header 右对齐（消息编辑标签 + 时间戳靠右）
  */
 .wk-msg-row--send .wk-msg-row-header {
   flex-direction: row-reverse;
 }
 
-.wk-msg-row--send .wk-msg-row-sender {
-  display: none;
-}
-
 /**
- * 发送方：连续消息 hover 时时间戳靠右对齐
+ * 发送方：连续消息 hover 时间戳靠右对齐
  */
 .wk-msg-row--send .wk-msg-row-avatar-placeholder {
   display: flex;
@@ -110,6 +115,16 @@
   flex-shrink: 0;
   width: 24px;
   cursor: pointer;
+}
+
+/**
+ * avatar + content 包裹层（checkbox 独立在外，不受发送方镜像影响）
+ */
+.wk-msg-row-body-wrap {
+  display: flex;
+  flex: 1;
+  gap: 12px;
+  min-width: 0;
 }
 
 /**

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.tsx
@@ -186,6 +186,8 @@ export default function MessageRow({
         </div>
       )}
       
+      {/* avatar + content 包在一起做镜像，checkbox 不参与反转 */}
+      <div className="wk-msg-row-body-wrap">
       {/* 头像（所有消息都在左侧） */}
       <div className="wk-msg-row-avatar">
         {showAvatar && (
@@ -250,6 +252,7 @@ export default function MessageRow({
           {children}
         </div>
       </div>
+      </div>{/* /wk-msg-row-body-wrap */}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

All messages in a conversation window are left-aligned regardless of who sent them, making it impossible to quickly distinguish your own messages from others at a glance.

## Solution

Implement right-align layout for self-sent messages using the existing `isSend` prop that was already wired through `MessageRow` — but never acted upon in CSS.

## Changes

### `packages/dmworkbase/src/ui/message/MessageRow/index.tsx`

- Wrap avatar + content in a new `.wk-msg-row-body-wrap` div so the multi-select checkbox remains a direct sibling of `.wk-msg-row` and is unaffected by the send/recv layout direction.

### `packages/dmworkbase/src/ui/message/MessageRow/index.css`

- `.wk-msg-row--send .wk-msg-row-body-wrap`: `flex-direction: row-reverse` → avatar moves to the right
- `.wk-msg-row--send .wk-msg-row-content`: `align-items: flex-end` → content right-justified
- `.wk-msg-row--send .wk-msg-row-header`: `flex-direction: row-reverse` → timestamp mirrors correctly
- `.wk-msg-row--send .wk-msg-row-sender` / `.wk-msg-row-sender-space` / `.wk-realname-badge`: hidden as a group — prevents orphaned badges when cross-space suffix or realname badge is present
- `.wk-msg-row--send .wk-msg-row-avatar-placeholder`: right-align hover timestamp for consecutive messages

## Scope note

This PR covers **MessageRow layout only** (right-align + checkbox isolation). The `Bubble` component is not in the live message render path (it is Storybook-only), so no bubble colour or corner changes are included. The shipped result is right-aligned plain text for self messages; a follow-up PR can wire `Bubble` into the live stack if coloured send bubbles are desired.

## Before / After

| Before | After |
|--------|-------|
| All messages left-aligned, hard to tell who sent what | Self messages right-aligned, others left-aligned |