### PR TITLE
feat(docs): expand highlight palette and add custom highlight picker

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -548,6 +548,26 @@ describe('Toolbar — highlight palette + custom picker', () => {
     const clear = within(popover).getByText('✕')
     fireEvent.click(clear)
     expect(editor!.getAttributes('highlight').color).toBeUndefined()
+    // The <mark> must actually leave the document, not just the caret attributes.
+    expect(editor!.getHTML()).not.toContain('<mark')
+  })
+
+  // Regression (XIN-1022): clicking into highlighted text leaves a COLLAPSED caret inside the
+  // <mark>. unsetHighlight() on its own clears only stored marks in that case, so the <mark>
+  // stayed in the document and the ✕ button looked dead. The ✕ now extends the selection over the
+  // whole highlight first (extendMarkRange), so the mark is truly removed from a collapsed caret.
+  it('clears the highlight from a collapsed caret inside the mark (✕ removes the <mark>)', () => {
+    // Highlight "hello", then drop a collapsed caret in the middle of it — no range selected.
+    editor!.chain().focus().selectAll().setHighlight({ color: '#fff3a3' }).run()
+    editor!.chain().focus().setTextSelection(3).run()
+    expect(editor!.state.selection.empty).toBe(true)
+    expect(editor!.getHTML()).toContain('<mark')
+
+    const popover = openHighlightPopover()
+    fireEvent.click(within(popover).getByText('✕'))
+
+    expect(editor!.getHTML()).not.toContain('<mark')
+    expect(editor!.getAttributes('highlight').color).toBeUndefined()
   })
 
   it('leaves the text-colour palette untouched (still 10 swatches, this scope is highlight only)', () => {

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -419,11 +419,142 @@ describe('Toolbar — text colour palette + custom picker (#719)', () => {
     expect(editor!.getAttributes('textStyle').color).toBeUndefined()
   })
 
-  it('leaves the highlight palette untouched (still 5 swatches, this scope is font-colour only)', () => {
+  it('leaves the highlight palette untouched by the text-colour scope (highlight has its own presets)', () => {
+    // #719 (font colour) did not alter the highlight palette; the highlight expansion is a
+    // separate follow-up and is covered by its own describe block below. Here we only assert the
+    // text-colour popover does not leak swatches into the highlight control.
     render(<Toolbar editor={editor!} />)
     fireEvent.click(titleBtn('docs.toolbar.highlight'))
     const highlightSwatches = document.querySelectorAll('button[title^="Highlight #"]')
-    expect(highlightSwatches).toHaveLength(5)
+    expect(highlightSwatches).toHaveLength(10)
+  })
+})
+
+// octo-web highlight follow-up (same plan as #719): expanded highlight (text-background) palette
+// + native custom highlight picker. The highlight popover now offers ~10 light presets and a
+// native <input type="color"> entry for arbitrary hex, while clear (unsetHighlight) and the
+// popover-open active logic stay untouched, mirroring the text-colour control.
+describe('Toolbar — highlight palette + custom picker', () => {
+  function openHighlightPopover(): HTMLElement {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.highlight'))
+    const popover = document.querySelector('.octo-highlight-color-popover') as HTMLElement
+    if (!popover) throw new Error('highlight popover did not open')
+    return popover
+  }
+
+  it('offers the ~10 common light preset swatches, in order', () => {
+    const popover = openHighlightPopover()
+    const swatches = within(popover).getAllByTitle(/^Highlight #/)
+    expect(swatches).toHaveLength(10)
+    const colours = swatches.map((s) => (s.getAttribute('title') || '').replace('Highlight ', ''))
+    expect(colours).toEqual([
+      '#fff3a3',
+      '#ffe0a3',
+      '#ffd6cc',
+      '#ffd6e7',
+      '#e7d6ff',
+      '#d6ddff',
+      '#cfe2ff',
+      '#c9f0ef',
+      '#cdeccd',
+      '#e6e9ed',
+    ])
+  })
+
+  it('applies a preset swatch highlight to the selection', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openHighlightPopover()
+    const swatch = within(popover).getByTitle('Highlight #cfe2ff')
+    fireEvent.click(swatch)
+    expect(editor!.getAttributes('highlight').color).toBe('#cfe2ff')
+  })
+
+  it('exposes a native colour input that commits an arbitrary hex highlight on change', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openHighlightPopover()
+    const input = popover.querySelector('input[type="color"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    // Commit happens on `change` (picker closed / value settled), not on the raw `input`
+    // stream that fires continuously while the OS hue wheel is dragged.
+    fireEvent.change(input, { target: { value: '#123456' } })
+    expect(editor!.getAttributes('highlight').color).toBe('#123456')
+  })
+
+  it('leaves the popover open during a drag (input) and commits + closes on change', () => {
+    editor!.chain().focus().selectAll().run()
+    const popover = openHighlightPopover()
+    const input = popover.querySelector('input[type="color"]') as HTMLInputElement
+
+    // Dragging fires `input` repeatedly. RC1: we intentionally do NOT commit per tick (that
+    // flooded undo/Yjs); the popover simply stays open so the user can keep nudging the hue.
+    fireEvent.input(input, { target: { value: '#112233' } })
+    expect(editor!.getAttributes('highlight').color).toBeUndefined()
+    expect(document.querySelector('.octo-highlight-color-popover')).toBeTruthy()
+
+    // Committing the pick fires `change`: the final colour is applied and the popover collapses,
+    // matching a preset-swatch click.
+    fireEvent.change(input, { target: { value: '#abcdef' } })
+    expect(editor!.getAttributes('highlight').color).toBe('#abcdef')
+    expect(document.querySelector('.octo-highlight-color-popover')).toBeNull()
+  })
+
+  // RC1: dragging the native hue wheel fires `input` continuously. Committing on every `input`
+  // pushed one ProseMirror transaction per event — tens of undo records and a Yjs update flood
+  // per single pick. The picker now previews via the OS dialog and commits exactly once on
+  // `change`, so one pick == one undo step == one collaboration update.
+  it('does not commit while dragging (raw input events) — a pick is a single undo step', () => {
+    // A history-enabled editor (StarterKit default) so we can assert the undo depth of one pick.
+    const e = new Editor({
+      extensions: [StarterKit, TaskList, TaskItem, Highlight.configure({ multicolor: true }), TextStyle, Color, Link, FindReplace],
+      content: '<p>hello</p>',
+    })
+    e.chain().focus().selectAll().run()
+    render(<Toolbar editor={e} />)
+    fireEvent.click(titleBtn('docs.toolbar.highlight'))
+    const input = document.querySelector('.octo-highlight-color-popover input[type="color"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    let docChanges = 0
+    e.on('transaction', ({ transaction }) => {
+      if (transaction.docChanged) docChanges++
+    })
+
+    // Simulate a drag across the hue wheel: a stream of intermediate `input` events.
+    fireEvent.input(input, { target: { value: '#111111' } })
+    fireEvent.input(input, { target: { value: '#222222' } })
+    fireEvent.input(input, { target: { value: '#333333' } })
+    // Nothing is committed to the document (and undo history is untouched) during the drag.
+    expect(e.getAttributes('highlight').color).toBeUndefined()
+    expect(docChanges).toBe(0)
+
+    // Releasing the picker fires `change` once → exactly one document-changing transaction.
+    fireEvent.change(input, { target: { value: '#345678' } })
+    expect(e.getAttributes('highlight').color).toBe('#345678')
+    expect(docChanges).toBe(1)
+
+    // And a single undo fully reverts the pick — proof it is one undo record, not many.
+    expect(e.can().undo()).toBe(true)
+    e.chain().undo().run()
+    expect(e.getAttributes('highlight').color).toBeUndefined()
+
+    e.destroy()
+  })
+
+  it('still clears the highlight via the ✕ button (unsetHighlight preserved)', () => {
+    editor!.chain().focus().selectAll().setHighlight({ color: '#fff3a3' }).run()
+    expect(editor!.getAttributes('highlight').color).toBe('#fff3a3')
+    const popover = openHighlightPopover()
+    const clear = within(popover).getByText('✕')
+    fireEvent.click(clear)
+    expect(editor!.getAttributes('highlight').color).toBeUndefined()
+  })
+
+  it('leaves the text-colour palette untouched (still 10 swatches, this scope is highlight only)', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.textColor'))
+    const textSwatches = document.querySelectorAll('button[title^="Text #"]')
+    expect(textSwatches).toHaveLength(10)
   })
 })
 

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -275,7 +275,23 @@ export function shouldShowFloatingMenu(args: {
   return isRootDepth && isEmptyTextBlock
 }
 
-const HIGHLIGHT_COLORS = ['#fff3a3', '#ffd6cc', '#cdeccd', '#cfe2ff', '#e7d6ff'] as const
+// Common highlight (text-background) colours (octo-web follow-up to #719, same plan): a set of
+// light / pastel tints spread warm→cool so dark foreground text stays readable on every swatch.
+// The original five (yellow, peach, green, blue, purple) are preserved and kept in place; the new
+// entries fill out the spectrum (amber, pink, indigo, cyan, neutral grey). Values are standard
+// #rrggbb hex so DOCX/Markdown export keeps them lossless, mirroring TEXT_COLORS below.
+const HIGHLIGHT_COLORS = [
+  '#fff3a3',
+  '#ffe0a3',
+  '#ffd6cc',
+  '#ffd6e7',
+  '#e7d6ff',
+  '#d6ddff',
+  '#cfe2ff',
+  '#c9f0ef',
+  '#cdeccd',
+  '#e6e9ed',
+] as const
 // Common font colours (octo-web #719, plan A): near-black default, secondary grey, then the
 // warm→cool spread. Values are standard #rrggbb hex so DOCX export (normalizeDocxColor) keeps
 // them lossless. This scope covers font colour only — HIGHLIGHT_COLORS above is intentionally
@@ -296,6 +312,27 @@ const TEXT_COLORS = [
 /** Text-highlight control (SCHEMA-SPEC §3): palette of background colours + clear. */
 function HighlightControl({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false)
+  // Native <input type="color"> distinguishes drag from commit only at the DOM level: `input`
+  // streams while the hue wheel moves, `change` fires once the pick is committed. React folds
+  // both onto its synthetic onChange (native `input`), so we bind the raw `change` event via a ref.
+  // RC1: commit the highlight once, on `change` only — never on the `input` stream. Applying per
+  // `input` tick ran one ProseMirror transaction each, so a single pick piled up dozens of undo
+  // records and flooded collaborators with a Yjs update per intermediate hue. The OS colour dialog
+  // previews the hue live in its own UI while dragging, so committing on `change` keeps one pick =
+  // one undo record + one Yjs update, and the popover collapses on commit like a preset swatch.
+  const customRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    const input = customRef.current
+    if (!input) return
+    const onCommit = () => {
+      editor.chain().focus().setHighlight({ color: input.value }).run()
+      setOpen(false)
+    }
+    input.addEventListener('change', onCommit)
+    return () => {
+      input.removeEventListener('change', onCommit)
+    }
+  }, [editor, open])
   return (
     <span className="octo-color-control">
       <Btn
@@ -305,7 +342,7 @@ function HighlightControl({ editor }: { editor: Editor }) {
         onClick={() => setOpen((v) => !v)}
       />
       {open && (
-        <span className="octo-color-popover">
+        <span className="octo-color-popover octo-highlight-color-popover">
           {HIGHLIGHT_COLORS.map((c) => (
             <button
               key={c}
@@ -327,6 +364,22 @@ function HighlightControl({ editor }: { editor: Editor }) {
               setOpen(false)
             }}
           />
+          {/* Custom highlight (same approach as the text-colour picker): native picker, zero new
+              deps. It emits standard #rrggbb, so setHighlight stays lossless through Yjs and the
+              DOCX/Markdown exporters. The picker stays open while dragging the hue wheel and
+              commits once on `change`, collapsing the popover — see the ref-bound listener above. */}
+          <label
+            className="octo-swatch octo-color-custom"
+            title={t('docs.toolbar.customColor')}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <input
+              ref={customRef}
+              type="color"
+              className="octo-color-custom-input"
+              aria-label={t('docs.toolbar.customColor')}
+            />
+          </label>
         </span>
       )}
     </span>

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -360,7 +360,14 @@ function HighlightControl({ editor }: { editor: Editor }) {
           <Btn
             label="✕"
             onClick={() => {
-              editor.chain().focus().unsetHighlight().run()
+              // Clear the highlight the caret sits in. unsetHighlight() alone only clears a
+              // non-empty selection range — with a collapsed caret inside a highlight (the common
+              // "click into highlighted text, then hit ✕" flow) it clears stored marks only and
+              // leaves the surrounding <mark> in the document. extendMarkRange('highlight') first
+              // grows the selection to span the whole highlight under the caret (a no-op when a
+              // range is already selected), so unsetHighlight() reliably removes the mark. Same
+              // idiom TipTap uses for link clearing (extendMarkRange('link').unsetLink()).
+              editor.chain().focus().extendMarkRange('highlight').unsetHighlight().run()
               setOpen(false)
             }}
           />


### PR DESCRIPTION
## What & why

Follow-up to the font-colour enhancement (#719 / merged #720): apply the
same treatment to the **highlight** (text-background) control in the docs
editor. Front-end only, no schema/backend touch — highlight colour stays a
`Highlight` mark attribute (`multicolor: true`), so no `SCHEMA_VERSION` bump.

1. **Palette expansion** — `HIGHLIGHT_COLORS` in
   `packages/docs/src/editor/Toolbar.tsx` grows from 5 to 10 light / pastel
   presets, spread warm→cool: `#fff3a3` `#ffe0a3` `#ffd6cc` `#ffd6e7`
   `#e7d6ff` `#d6ddff` `#cfe2ff` `#c9f0ef` `#cdeccd` `#e6e9ed`. Every swatch
   is a light tint so dark foreground text stays readable on the highlight.
   The original five are preserved. The `✕` clear (`unsetHighlight`) is
   untouched. Values are standard `#rrggbb`, kept lossless by the DOCX /
   Markdown exporters.
2. **Native custom picker** — a rainbow swatch at the bottom of the
   highlight popover wraps a native `<input type="color">` (zero new
   dependencies), reusing the shared `.octo-color-custom` styling introduced
   by #720. It calls `setHighlight({ color })` and closes the popover, and
   reuses the existing `toolbar.customColor` i18n key (no new keys).

## RC notes (same three lessons as #719/#720)

- **RC1 — single transaction**: the picker commits exactly once, on the
  native `change` event (bound via a ref), never on the `input` stream. One
  pick = one ProseMirror transaction = one undo step = one Yjs update. The
  OS colour dialog previews the hue live in its own UI while dragging, so the
  popover just stays open during the drag and collapses on commit, matching a
  preset-swatch click.
- **RC2 — stylelint**: no new CSS. The rainbow swatch and its scoped
  `stylelint-disable color-no-hex` exception already exist from #720 and are
  reused as-is; the new highlight presets are applied as inline
  `style={{ backgroundColor }}`, so nothing new reaches the CSS linter.
- **RC3 — keyboard focus**: the visible `:focus-within` accent-token outline
  on `.octo-color-custom` (from #720) applies to the highlight custom picker
  too, since it reuses the same class.

## Tests

Added a `Toolbar — highlight palette + custom picker` describe block to
`Toolbar.test.tsx` (mirrors the #719 text-colour suite): palette contents &
order (10), preset apply to selection, custom-input apply of an arbitrary
hex, popover stays open on `input` / commits + closes on `change`, a
single-undo assertion proving one pick is one transaction, `✕` clear
(`unsetHighlight`) preserved, and text-colour palette left unchanged (still
10). The obsolete "highlight still 5" assertion inside the #719 suite is
updated to the new reality.

`packages/docs`:
- `Toolbar.test.tsx`: 24 → **31** pass (all green), `+7` tests.
- Full docs suite baseline (before → after): `1043 → 1050` pass, `+7` new.
  The one failing file (`DocsHome.test.tsx`, 4 failures + 5 undici WebSocket
  errors) is **pre-existing on clean HEAD** — verified by stashing this change
  and re-running (identical `4 failed | 1043 passed`, and the file passes in
  isolation). Unrelated to this change, which touches only `Toolbar.tsx`.
- Typecheck: the pre-existing `tsc` errors in `dmworkbase` / `react-markdown`
  are unchanged; none in the touched files.

## Non-regression

Preserved: existing preset highlights (`toggleHighlight`), `✕` clear
(`unsetHighlight`), font colour (#719), other formatting, Yjs collab
round-trip, Markdown / DOCX highlight export, light/dark theme, popover
active-only-while-open logic.

Draft — carries review only; not for merge on this branch.
