### PR TITLE
refactor(wksdk): 收口连接状态 UI runtime 访问

### DIFF
--- a/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
+++ b/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
@@ -3,6 +3,13 @@ import { WKSDK, ConnectStatus } from "wukongimjssdk"
 import WKApp from "../../App"
 import { I18nContext } from "../../i18n"
 import { apiFetch } from "../../Service/apiFetch"
+import {
+    addImConnectStatusListener,
+    getImConnectStatus,
+    isImConnected,
+    reconnectImWhenNotConnected,
+    removeImConnectStatusListener,
+} from "../../im-runtime/connectStatus"
 import "./index.css"
 
 interface ConnectionStatusProps {
@@ -27,7 +34,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
     private connectedTime: number = 0
 
     state: ConnectionStatusState = {
-        status: WKSDK.shared().connectManager.status,
+        status: getImConnectStatus(WKSDK.shared()),
         latency: null,
         connectedSince: null,
         showTooltip: false,
@@ -46,9 +53,9 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
             }
             this.setState(newState as any)
         }
-        WKSDK.shared().connectManager.addConnectStatusListener(this.statusListener)
+        addImConnectStatusListener(WKSDK.shared(), this.statusListener)
 
-        if (WKSDK.shared().connectManager.status === ConnectStatus.Connected) {
+        if (isImConnected(WKSDK.shared())) {
             this.connectedTime = Date.now()
             this.setState({ connectedSince: this.connectedTime })
             this.startPing()
@@ -56,7 +63,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
     }
 
     componentWillUnmount() {
-        WKSDK.shared().connectManager.removeConnectStatusListener(this.statusListener)
+        removeImConnectStatusListener(WKSDK.shared(), this.statusListener)
         this.stopPing()
     }
 
@@ -82,7 +89,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
                 cache: "no-cache",
             })
             const latency = Date.now() - start
-            if (WKSDK.shared().connectManager.status === ConnectStatus.Connected) {
+            if (isImConnected(WKSDK.shared())) {
                 this.setState({ latency })
             }
         } catch {
@@ -115,9 +122,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
     }
 
     handleClick = () => {
-        if (this.state.status !== ConnectStatus.Connected) {
-            WKSDK.shared().connectManager.connect()
-        }
+        reconnectImWhenNotConnected(WKSDK.shared(), this.state.status)
     }
 
     render() {

--- a/packages/dmworkbase/src/im-runtime/connectStatus.test.ts
+++ b/packages/dmworkbase/src/im-runtime/connectStatus.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { ConnectStatus } from "wukongimjssdk";
 import {
+  addImConnectStatusListener,
   createImConnectStatusListener,
+  getImConnectStatus,
+  isImConnected,
+  reconnectImWhenNotConnected,
   registerImConnectStatusListener,
+  removeImConnectStatusListener,
 } from "./connectStatus";
 
 function createDeps() {
@@ -74,5 +79,57 @@ describe("createImConnectStatusListener", () => {
     listener(ConnectStatus.Connected);
 
     expect(deps.resetTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads current connect status from the SDK connect manager", () => {
+    const sdk = {
+      connectManager: {
+        status: ConnectStatus.Connected,
+        addConnectStatusListener: vi.fn(),
+        removeConnectStatusListener: vi.fn(),
+        connect: vi.fn(),
+      },
+    };
+
+    expect(getImConnectStatus(sdk)).toBe(ConnectStatus.Connected);
+    expect(isImConnected(sdk)).toBe(true);
+  });
+
+  it("adds and removes connect status listeners through the SDK connect manager", () => {
+    const sdk = {
+      connectManager: {
+        status: ConnectStatus.Disconnect,
+        addConnectStatusListener: vi.fn(),
+        removeConnectStatusListener: vi.fn(),
+        connect: vi.fn(),
+      },
+    };
+    const listener = vi.fn();
+
+    addImConnectStatusListener(sdk, listener);
+    removeImConnectStatusListener(sdk, listener);
+
+    expect(sdk.connectManager.addConnectStatusListener).toHaveBeenCalledWith(
+      listener
+    );
+    expect(sdk.connectManager.removeConnectStatusListener).toHaveBeenCalledWith(
+      listener
+    );
+  });
+
+  it("reconnects only when the provided status is not connected", () => {
+    const sdk = {
+      connectManager: {
+        status: ConnectStatus.Disconnect,
+        addConnectStatusListener: vi.fn(),
+        removeConnectStatusListener: vi.fn(),
+        connect: vi.fn(),
+      },
+    };
+
+    reconnectImWhenNotConnected(sdk, ConnectStatus.Disconnect);
+    reconnectImWhenNotConnected(sdk, ConnectStatus.Connected);
+
+    expect(sdk.connectManager.connect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dmworkbase/src/im-runtime/connectStatus.ts
+++ b/packages/dmworkbase/src/im-runtime/connectStatus.ts
@@ -17,6 +17,15 @@ export interface ImConnectStatusSdk {
   };
 }
 
+export interface ImConnectStatusRuntimeSdk {
+  connectManager: {
+    status: ConnectStatus;
+    addConnectStatusListener: (listener: ImConnectStatusListener) => void;
+    removeConnectStatusListener: (listener: ImConnectStatusListener) => void;
+    connect: () => void;
+  };
+}
+
 export function createImConnectStatusListener(
   deps: ImConnectStatusListenerDeps
 ) {
@@ -40,4 +49,35 @@ export function registerImConnectStatusListener(
   sdk.connectManager.addConnectStatusListener(
     createImConnectStatusListener(deps)
   );
+}
+
+export function getImConnectStatus(sdk: ImConnectStatusRuntimeSdk) {
+  return sdk.connectManager.status;
+}
+
+export function isImConnected(sdk: ImConnectStatusRuntimeSdk) {
+  return getImConnectStatus(sdk) === ConnectStatus.Connected;
+}
+
+export function addImConnectStatusListener(
+  sdk: ImConnectStatusRuntimeSdk,
+  listener: ImConnectStatusListener
+) {
+  sdk.connectManager.addConnectStatusListener(listener);
+}
+
+export function removeImConnectStatusListener(
+  sdk: ImConnectStatusRuntimeSdk,
+  listener: ImConnectStatusListener
+) {
+  sdk.connectManager.removeConnectStatusListener(listener);
+}
+
+export function reconnectImWhenNotConnected(
+  sdk: ImConnectStatusRuntimeSdk,
+  status: ConnectStatus
+) {
+  if (status !== ConnectStatus.Connected) {
+    sdk.connectManager.connect();
+  }
 }


### PR DESCRIPTION
## Summary
- Route the base ConnectionStatus component's WKSDK connect status reads through im-runtime helpers.
- Add runtime helper coverage for status reads, listener registration/removal, and reconnect guards.
- Keep UI rendering, displayed text, and reconnect behavior unchanged.

## Not Changed
- No SDK version change.
- No reconnect strategy change.
- No connection status product behavior change.

## Tests
- pnpm --dir packages/dmworkbase test src/im-runtime/connectStatus.test.ts src/im-runtime/connectAddress.test.ts src/im-runtime/connectClient.test.ts src/im-runtime/clientMsgDevice.test.ts
- pnpm --dir apps/web build
- git diff --check