### PR TITLE
fix(loop): filter panel dropdowns hidden behind the panel; stale agent-status cache

### DIFF
--- a/packages/dmloop/src/api/agentApi.ts
+++ b/packages/dmloop/src/api/agentApi.ts
@@ -62,22 +62,29 @@ export function invalidateAgentStatus(): void {
   _agentStatusPromise = null;
 }
 
+// agent 增改会改变工作区的 agent 集合,除清目录缓存外一并清 agent 状态缓存,
+// 否则新建/恢复的 agent 在 @ 菜单里读到陈旧的在线状态。
+function afterAgentMutation<T>(r: T): T {
+  invalidateAgentStatus();
+  return afterDirectoryMutation(r);
+}
+
 export function createAgent(req: CreateAgentReq): Promise<Agent> {
-  return httpPost<Agent>("/agents", req).then(afterDirectoryMutation);
+  return httpPost<Agent>("/agents", req).then(afterAgentMutation);
 }
 
 export function updateAgent(id: string, req: UpdateAgentReq): Promise<Agent> {
-  return httpPut<Agent>(`/agents/${id}`, req).then(afterDirectoryMutation);
+  return httpPut<Agent>(`/agents/${id}`, req).then(afterAgentMutation);
 }
 
 // 后端不支持 DELETE /agents/:id（405）；改用归档。
 export function archiveAgent(id: string): Promise<void> {
-  return httpPost<void>(`/agents/${id}/archive`, {}).then(afterDirectoryMutation);
+  return httpPost<void>(`/agents/${id}/archive`, {}).then(afterAgentMutation);
 }
 
 // 恢复已归档 agent（软删除的逆操作）。
 export function restoreAgent(id: string): Promise<void> {
-  return httpPost<void>(`/agents/${id}/restore`, {}).then(afterDirectoryMutation);
+  return httpPost<void>(`/agents/${id}/restore`, {}).then(afterAgentMutation);
 }
 
 /* ---------- 环境变量（密钥） ---------- */

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -64,6 +64,10 @@ interface Filters {
 
 const PAGE_SIZE = 50;
 
+// 筛选/显示字段都挂在工具栏 Dropdown 面板(z-index 1060)里,其弹层默认取 Semi 基准 1030 →
+// 会被面板本体盖在下面(选项看不见也点不到)。统一抬到面板之上。
+const FIELD_POPUP = { dropdownClassName: "loop-fields__dropdown", zIndex: 2000 } as const;
+
 // 「我的回路」复用本页：defaultView="grouped" + defaultScope="involves" 即只看与我相关。
 interface IssuePageProps {
   defaultScope?: IssueScope;
@@ -280,24 +284,24 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.status")}</div>
         {view === "grouped" ? (
-          <Select multiple value={f.gStatuses} onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
+          <Select multiple value={f.gStatuses} onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })} showClear maxTagCount={2} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
         ) : (
-          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
+          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
         )}
       </div>
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.priority")}</div>
         {view === "grouped" ? (
-          <Select multiple value={f.gPriorities} onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })} showClear maxTagCount={2} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
+          <Select multiple value={f.gPriorities} onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })} showClear maxTagCount={2} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
         ) : (
-          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
+          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
         )}
       </div>
       {/* assignee 单选仅扁平列表/看板(grouped 用 scope 按类型收窄)。 */}
       {view !== "grouped" && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.filter.assignee")}</div>
-          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
+          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
             {cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
           </Select>
         </div>
@@ -306,7 +310,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       {!(view === "grouped" && scope === "involves") && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.filter.creator")}</div>
-          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
+          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
             {cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
           </Select>
         </div>
@@ -315,9 +319,9 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.filter.project")}</div>
           {view === "grouped" ? (
-            <Select multiple value={f.gProjectIds} onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })} showClear filter maxTagCount={1} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
+            <Select multiple value={f.gProjectIds} onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })} showClear filter maxTagCount={1} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
           ) : (
-            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
+            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
           )}
         </div>
       )}
@@ -330,10 +334,10 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.dateRange")}</div>
         <div className="loop-fields__inline">
-          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ width: 104 }}>
+          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} disabled={searching} {...FIELD_POPUP} style={{ width: 104 }}>
             {ISSUE_DATE_FIELDS.map((d) => (<Select.Option key={d} value={d}>{t(`loop.dateField.${d}`)}</Select.Option>))}
           </Select>
-          <DatePicker type="dateRange" density="compact" disabled={searching} value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} style={{ flex: 1 }} />
+          <DatePicker type="dateRange" density="compact" disabled={searching} value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} zIndex={FIELD_POPUP.zIndex} style={{ flex: 1 }} />
         </div>
       </div>
       {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
@@ -365,7 +369,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.sort.direction")}</div>
           <div className="loop-fields__inline">
-            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} disabled={searching} dropdownClassName="loop-fields__dropdown" style={{ flex: 1 }}>
+            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} disabled={searching} {...FIELD_POPUP} style={{ flex: 1 }}>
               {ISSUE_SORT_FIELDS.map((s) => (<Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>))}
             </Select>
             <Button theme="borderless" disabled={searching || f.sortBy === "position"} icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />} aria-label={t("loop.sort.direction")} onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })} />

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -10,7 +10,7 @@ import type { Workspace } from "../api/types";
 import { listWorkspaces, createWorkspace } from "../api/workspaceApi";
 import { setWorkspaceContext, currentWorkspaceId } from "../api/http";
 import { invalidateDirectory } from "../api/directory";
-import { invalidateRuntimeMap } from "../api/agentApi";
+import { invalidateRuntimeMap, invalidateAgentStatus } from "../api/agentApi";
 import { slugSuffix, withRandomSuffix } from "../ui/slug";
 import IssuePage from "./IssuePage";
 import NewLoopPage from "./NewLoopPage";
@@ -23,6 +23,13 @@ import "./loop.css";
 import "../ui/loopControls.css";
 
 const { Title, Text } = Typography;
+
+// 切换工作区时统一重置所有工作区级缓存(目录/运行时/agent 状态),避免残留上个工作区数据。
+function resetWorkspaceCaches() {
+  invalidateDirectory();
+  invalidateRuntimeMap();
+  invalidateAgentStatus();
+}
 
 type TabKey = "myloop" | "issue" | "project" | "automation" | "agent" | "squad" | "settings";
 
@@ -100,8 +107,7 @@ export default function LoopPage() {
     if (ws) {
       setWorkspaceContext(ws.slug, ws.id);
       setWsId(ws.id);
-      invalidateDirectory();
-      invalidateRuntimeMap();
+      resetWorkspaceCaches();
       WKApp.routeRight.replaceToRoot(renderTab(tab, ws));
     } else {
       setWorkspaceContext("", "");
@@ -166,8 +172,7 @@ export default function LoopPage() {
   const switchWorkspace = (w: Workspace) => {
     setWorkspaceContext(w.slug, w.id);
     setWsId(w.id);
-    invalidateDirectory();
-    invalidateRuntimeMap();
+    resetWorkspaceCaches();
     WKApp.routeRight.replaceToRoot(renderTab(tab, w));
   };
 


### PR DESCRIPTION
Closes #738

## What

Two scoped fixes in `packages/dmloop`:

### 1. Filter/show panel dropdowns rendered behind the panel (#738)
Every `<Select>` and the `<DatePicker>` inside the toolbar「筛选」/「显示」`<Dropdown>` panel had its option popup rendered **behind** the panel, so options were invisible and unclickable — the filter was effectively unusable.

Root cause: the panel popover is Semi's default z-index **1060**, while Semi `Select`/`DatePicker` popups default to base z-index **1030** and portal to `document.body` (escaping the panel's stacking context). 1030 < 1060 → child popups paint behind the panel.

Fix: a shared `const FIELD_POPUP = { dropdownClassName: "loop-fields__dropdown", zIndex: 2000 }` spread onto every filter/show Select, plus `zIndex={FIELD_POPUP.zIndex}` on the DatePicker — lifting each field popup above the panel. Scoped local to `IssuePage` (the only `<Dropdown>` panel with nested popups); the other `loop-fields__dropdown` Selects live in Modals and are unaffected.

Why the prop and not CSS / `getPopupContainer`: Semi writes the winning z-index **inline on the `.semi-portal`** node (a class rule can't override it without `!important`, and the DatePicker popup carries no shared class); `getPopupContainer` would render the popup *inside* the narrow panel, clipping the wide date-range picker and fighting the panel's outside-click close.

### 2. Stale agent-status cache (follow-up to #727 review)
The module-level agent-status map (drives the @-mention online dots) mirrors the runtime map but was never invalidated, so the online dots went stale. Now invalidated across the whole class of agent-set changes:
- **workspace switch** — via a shared `resetWorkspaceCaches()` (directory + runtime + agent-status), replacing the duplicated invalidation blocks in `applyWorkspace`/`switchWorkspace`;
- **agent create/update/archive/restore** — via `afterAgentMutation` in `agentApi`, so a created/restored agent's dot is fresh without a reload.

## Verification (real browser, dev env)

- All filter fields (5 Selects + DatePicker) now render on top (z-index 2000), correctly positioned below the trigger, and are clickable; selecting a value applies the filter and updates the active-filter badge.
- Clicking a field/option does **not** close the panel (panel is controlled, closes only on outside-click); outside-click still closes it. No regression to the existing open/close behavior.
- z-index 2000 sits above the panel (1060) and below all global overlays (modals 9999, toasts 10000); the only z-2000 peer is the @-mention menu, which never co-renders with the issue-list filter panel.
- `pnpm --filter @octo/loop test` green (25/25); typecheck clean.

## Scope / blast radius

- Frontend only, presentational + cache invalidation; no backend/protocol/schema change.
- `FIELD_POPUP` is local to `IssuePage`; `afterAgentMutation` only wraps the existing `afterDirectoryMutation` for agent writes; `resetWorkspaceCaches` is a behavior-preserving extraction of the existing three invalidation calls.

## Review

Ran `/simplify` (4 angles) + two adversarial rounds (parallel reviewers): z-index fix confirmed clean (no prop-conflict, correct stacking); the agent-status class-completion (agent create/restore trigger) was applied per the review's Rule-9 finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)