### PR TITLE
feat(summary): add /s/:taskNo standalone deep-link route to summary detail

### DIFF
--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -14,6 +14,7 @@ import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
 import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
+import { SummaryDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 import { isLoopCliAuthorizePath, LOOP_CLI_AUTHORIZE_PATH } from "@octo/loop";
 
@@ -75,6 +76,28 @@ function clearExpiredStandaloneSessionAndReload(): void {
     if (typeof window !== "undefined") window.location.reload();
 }
 
+/** `/s/:taskNo` — summary taskNo is a single URL path segment, optional trailing slash. */
+const STANDALONE_SUMMARY_PATH = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
+
+export function parseStandaloneSummaryTaskNo(pathname: string): string | null {
+    if (typeof pathname !== "string") return null;
+    const m = STANDALONE_SUMMARY_PATH.exec(pathname);
+    return m ? m[1] : null;
+}
+
+// Only a well-formed single-segment `/s/<taskNo>` counts as standalone; `/s`,
+// `/s/`, and nested `/s/a/b` must fall through (else the render branch mounts
+// SummaryDetailPage with an undefined taskId).
+export function isStandaloneSummaryPath(pathname: string): boolean {
+    return parseStandaloneSummaryTaskNo(pathname) !== null;
+}
+
+function applyStandaloneSummarySpaceFromQuery(): void {
+    const params = new URLSearchParams(window.location.search);
+    const spaceId = params.get("sp") || params.get("space") || "";
+    if (spaceId) WKApp.shared.currentSpaceId = spaceId;
+}
+
 export default class AppLayout extends Component<{}, AppLayoutState> {
     state: AppLayoutState = { showJoinSpace: false };
 
@@ -124,12 +147,16 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const forwardDoc = getQueryParam("doc") || ""
             const forwardSpace = getQueryParam("space") || ""
             const forwardFolder = getQueryParam("folder") || ""
+            const forwardSp = getQueryParam("sp") || ""
             const redirectQuery = new URLSearchParams()
             if (existingSid) redirectQuery.set("sid", existingSid)
             if (forwardDoc) {
                 redirectQuery.set("doc", forwardDoc)
                 if (forwardSpace) redirectQuery.set("space", forwardSpace)
                 if (forwardFolder) redirectQuery.set("folder", forwardFolder)
+            }
+            if (isStandaloneSummaryPath(window.location.pathname) && forwardSp) {
+                redirectQuery.set("sp", forwardSp)
             }
             const redirectQs = redirectQuery.toString()
             const sidParam = redirectQs ? `?${redirectQs}` : ""
@@ -404,6 +431,25 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             // the login screen (below) without navigating away. The standalone page itself only
             // mounts once a token exists, so the anonymous path is the ONLY place this key gets
             // written for a first-time visitor — onLogin consumes it via consumeStandaloneReturn.
+            persistStandaloneReturn();
+            // Anonymous: fall through to the login screen (below) without navigating away.
+        }
+
+        // Standalone summary deep-link (`/s/:taskNo`): notification cards use task_no (not numeric
+        // task_id), so pass the raw path segment into the detail fetch. Auth/session recovery mirrors
+        // `/d/:docId`; anonymous visitors stash the exact target and return after login.
+        if (isStandaloneSummaryPath(window.location.pathname)) {
+            if (!WKApp.loginInfo.token) {
+                WKApp.loginInfo.load();
+            }
+            if (!WKApp.loginInfo.token) {
+                recoverOctoSessionFromStorage(true);
+            }
+            if (WKApp.loginInfo.token) {
+                applyStandaloneSummarySpaceFromQuery();
+                const standaloneTaskNo = parseStandaloneSummaryTaskNo(window.location.pathname);
+                return <SummaryDetailPage taskId={standaloneTaskNo ?? undefined} />;
+            }
             persistStandaloneReturn();
             // Anonymous: fall through to the login screen (below) without navigating away.
         }

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -71,3 +71,54 @@ describe('Layout — standalone /d/:docId clean cold-load path', () => {
     expect(layout).toMatch(/window\.location\.reload\(\)/)
   })
 })
+
+describe('Layout — standalone /s/:taskNo summary clean cold-load path', () => {
+  let layout: string
+
+  beforeAll(() => {
+    layout = fs.readFileSync(path.join(__dirname, '../Layout/index.tsx'), 'utf-8')
+  })
+
+  it('matches only a well-formed single-segment /s/<taskNo>, not /s, /s/, or nested paths', () => {
+    expect(layout).toMatch(/isStandaloneSummaryPath\(\s*window\.location\.pathname\s*\)/)
+    expect(layout).toMatch(/function\s+parseStandaloneSummaryTaskNo/)
+    // The matcher must delegate to the strict parser (single segment) rather than a
+    // loose /s namespace regex, so /s, /s/, and /s/a/b fall through instead of
+    // mounting SummaryDetailPage with an undefined taskId.
+    expect(layout).toMatch(/return\s+parseStandaloneSummaryTaskNo\(pathname\)\s*!==\s*null/)
+    expect(layout).not.toMatch(/STANDALONE_SUMMARY_NAMESPACE/)
+    expect(layout).not.toMatch(/if\s*\(\s*standaloneTaskNo\s*\)/)
+    // The strict single-segment path regex is the sole source of truth.
+    expect(layout).toMatch(/STANDALONE_SUMMARY_PATH\s*=\s*\/\^\\\/s\\\/\(\[A-Za-z0-9_-\]\+\)/)
+  })
+
+  it('recovers a stored session before rendering the summary detail page', () => {
+    const branchIdx = layout.indexOf('Standalone summary deep-link')
+    expect(branchIdx).toBeGreaterThan(0)
+    const nsIdx = layout.indexOf('isStandaloneSummaryPath(window.location.pathname)', branchIdx)
+    expect(nsIdx).toBeGreaterThan(0)
+    const recoverIdx = layout.indexOf('recoverOctoSessionFromStorage(true)', nsIdx)
+    const renderIdx = layout.indexOf('<SummaryDetailPage', nsIdx)
+    expect(recoverIdx).toBeGreaterThan(nsIdx)
+    expect(renderIdx).toBeGreaterThan(recoverIdx)
+  })
+
+  it('renders summary detail only with a token, passing the raw task_no string through', () => {
+    expect(layout).toMatch(/if\s*\(\s*WKApp\.loginInfo\.token\s*\)\s*\{[\s\S]*?<SummaryDetailPage/)
+    expect(layout).toMatch(/const\s+standaloneTaskNo\s*=\s*parseStandaloneSummaryTaskNo\(window\.location\.pathname\)/)
+    expect(layout).toMatch(/<SummaryDetailPage\s+taskId=\{standaloneTaskNo\s*\?\?\s*undefined\}/)
+  })
+
+  it('stashes anonymous /s targets and carries sp through post-login return', () => {
+    const branchIdx = layout.indexOf('Standalone summary deep-link')
+    expect(branchIdx).toBeGreaterThan(0)
+    const nsIdx = layout.indexOf('isStandaloneSummaryPath(window.location.pathname)', branchIdx)
+    expect(nsIdx).toBeGreaterThan(0)
+    const stashIdx = layout.indexOf('persistStandaloneReturn()', nsIdx)
+    expect(stashIdx).toBeGreaterThan(nsIdx)
+    expect(layout).toMatch(/const\s+forwardSp\s*=\s*getQueryParam\("sp"\)\s*\|\|\s*""/)
+    expect(layout).toMatch(/redirectQuery\.set\("sp",\s*forwardSp\)/)
+    expect(layout).toMatch(/consumeStandaloneReturn\(\)/)
+    expect(layout).toMatch(/withReturnSid\(standaloneReturn,\s*sessionSid\)/)
+  })
+})

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -703,7 +703,7 @@ export default class WKApp extends ProviderListener {
   static menus = MenusManager.shared; // 菜单
   // Callback to switch the active sidebar menu by id (set by Main page)
   static switchToMenuById?: (menuId: string) => void;
-  static openSummaryDetail?: (taskId: number) => void;
+  static openSummaryDetail?: (taskId: number | string) => void;
   static searchChatCandidates?: (params: { keyword?: string; chat_type?: string; space_id?: string }) => Promise<any[]>;
   // Id of the currently active sidebar menu (kept in sync by Main page)
   static currentMenuId?: string;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openSummaryDetailMock, wkAppMock } = vi.hoisted(() => {
+  const openSummaryDetailMock = vi.fn();
+  return {
+    openSummaryDetailMock,
+    wkAppMock: {
+      openSummaryDetail: openSummaryDetailMock as ((taskId: number | string) => void) | undefined,
+    },
+  };
+});
+
+vi.mock("../../../App", () => ({
+  default: wkAppMock,
+}));
+
+import { openUrl } from "../renderer/actions";
+
+describe("openUrl", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    openSummaryDetailMock.mockReset();
+    wkAppMock.openSummaryDetail = openSummaryDetailMock;
+    vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  it("routes /s/<taskNo> summary links internally", () => {
+    openUrl("https://web.example.com/s/ST202607145kstyh08?sp=space-1");
+
+    expect(openSummaryDetailMock).toHaveBeenCalledTimes(1);
+    expect(openSummaryDetailMock).toHaveBeenCalledWith("ST202607145kstyh08");
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("opens external https links in a new tab", () => {
+    openUrl("https://web.example.com/docs/ST202607145kstyh08");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      "https://web.example.com/docs/ST202607145kstyh08",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("ignores unsafe urls", () => {
+    openUrl("javascript:alert(1)");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("falls back to window.open when summary routing is unavailable", () => {
+    wkAppMock.openSummaryDetail = undefined;
+
+    openUrl("https://web.example.com/s/ST202607145kstyh08?sp=space-1");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      "https://web.example.com/s/ST202607145kstyh08?sp=space-1",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
@@ -1,4 +1,7 @@
+import WKApp from "../../../App";
 import { isSafeUrl } from "../../../Utils/security";
+
+const SUMMARY_DETAIL_PATH_RE = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
 
 /**
  * Action.OpenUrl 导航。
@@ -11,6 +14,18 @@ import { isSafeUrl } from "../../../Utils/security";
 /** 在新标签打开 URL；提交前二次 isSafeUrl 校验（http/https），非法直接忽略。 */
 export function openUrl(url: string): void {
   if (!isSafeUrl(url)) return;
+
+  const parsed = new URL(url);
+  const summaryMatch = parsed.pathname.match(SUMMARY_DETAIL_PATH_RE);
+  if (summaryMatch) {
+    const taskNo = summaryMatch[1];
+    if (WKApp.openSummaryDetail) {
+      // 卡片深链可能来自 https 生产域，本地调试是 http/端口；/s/<taskNo> 路径本身是内部详情信号。
+      WKApp.openSummaryDetail(taskNo);
+      return;
+    }
+  }
+
   window.open(url, "_blank", "noopener,noreferrer");
 }
 

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -133,7 +133,7 @@ export async function listSummaries(
     return get('/summaries', params as Record<string, unknown>, config);
 }
 
-export async function getSummaryDetail(taskId: number): Promise<SummaryDetail> {
+export async function getSummaryDetail(taskId: number | string): Promise<SummaryDetail> {
     return get(`/summaries/${taskId}`);
 }
 

--- a/packages/dmworksummary/src/hooks/useSummaryDetail.ts
+++ b/packages/dmworksummary/src/hooks/useSummaryDetail.ts
@@ -12,7 +12,7 @@ interface UseSummaryDetailReturn {
     cancel: () => Promise<void>;
 }
 
-export function useSummaryDetail(taskId: number | null): UseSummaryDetailReturn {
+export function useSummaryDetail(taskId: number | string | null): UseSummaryDetailReturn {
     const [detail, setDetail] = useState<SummaryDetail | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -41,13 +41,13 @@ export function useSummaryDetail(taskId: number | null): UseSummaryDetailReturn 
     }, []);
 
     const regenerate = useCallback(async () => {
-        if (taskId == null) return;
+        if (typeof taskId !== "number") return;
         await api.regenerateSummary(taskId);
         refresh();
     }, [taskId, refresh]);
 
     const cancel = useCallback(async () => {
-        if (taskId == null) return;
+        if (typeof taskId !== "number") return;
         await api.cancelSummary(taskId);
         refresh();
     }, [taskId, refresh]);

--- a/packages/dmworksummary/src/index.tsx
+++ b/packages/dmworksummary/src/index.tsx
@@ -1,1 +1,2 @@
 export { SummaryModule } from "./module";
+export { default as SummaryDetailPage } from "./pages/SummaryDetailPage";

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -55,7 +55,7 @@ export class SummaryModule implements IModule {
             "en-US": enUS,
         });
 
-        WKApp.openSummaryDetail = (taskId: number) => {
+        WKApp.openSummaryDetail = (taskId: number | string) => {
             WKApp.switchToMenuById?.("summary");
             WKApp.routeLeft.popToRoot();
             WKApp.routeRight.replaceToRoot(

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -47,7 +47,7 @@ import MemberSelectorModal from "../components/MemberSelectorModal";
 import type { MemberCandidate } from "../types/summary";
 
 interface SummaryDetailPageProps {
-    taskId?: number;
+    taskId?: number | string;
 }
 
 interface SummaryDetailPageState {
@@ -192,7 +192,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
 
     componentDidUpdate(prevProps: any) {
         const prevTaskId = prevProps.taskId;
-        const currentTaskId = this.taskId;
+        const currentTaskId = this.detailLookupId;
         if (prevTaskId !== currentTaskId && currentTaskId != null) {
             this.listPageActive = false;
             this.clearAllTimers();
@@ -313,15 +313,20 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     get taskId(): number | null {
+        return typeof this.props.taskId === "number" ? this.props.taskId : this.state.detail?.task_id ?? null;
+    }
+
+    private get detailLookupId(): number | string | null {
         return this.props.taskId ?? null;
     }
 
     async loadDetail() {
-        if (this.taskId == null) return;
+        const lookupId = this.detailLookupId;
+        if (lookupId == null) return;
         // Blocking 5：每轮 detail 加载开始就 bump 序列号。这样旧 task 未完成的
         // loadSchedule（包括本函数下面发起的）都会被后续轮作废，不会回填到新 task。
         const seq = this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
+        const requestTaskId = lookupId;
         // F1：切 task / 重拉 detail 时复位全部编辑态，避免旧 task 编辑态（尤其
         // editingTeamSummary）被带入新 task——否则切到非 creator 新 task 会绕过权限进编辑器。
         // FE-1（切任务竞态）：开始新 task 加载时同步清空上一 task 的 personalResult/members，
@@ -352,9 +357,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             workflowRevealDone: false,
         });
         try {
-            const detail = await api.getSummaryDetail(this.taskId);
+            const detail = await api.getSummaryDetail(lookupId);
             // detail 本身也可能是旧请求：期间切了 task / 又发了一轮 loadDetail 就丢弃。
-            if (this.scheduleLoadSeq !== seq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== seq || this.detailLookupId !== requestTaskId) return;
             this.setState({
                 detail,
                 loading: false,
@@ -385,13 +390,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             // Load BY_PERSON data
             if (detail.summary_mode === SummaryMode.BY_PERSON) {
                 // FE-1：把本轮 seq 传给二次异步加载，迟到响应按 seq/taskId 校验后才 setState。
-                this.loadPersonalResult(seq);
-                this.loadMembers(seq);
+                this.loadPersonalResult(seq, detail.task_id);
+                this.loadMembers(seq, detail.task_id);
             }
         } catch (err: any) {
             // FE-1（切 task 竞态）：迟到的失败响应也要校验归属，否则旧 task 的加载失败
             // 会把错误/loading 状态写到已切换的新 task 上。
-            if (this.scheduleLoadSeq !== seq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== seq || this.detailLookupId !== requestTaskId) return;
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
         }
     }
@@ -427,13 +432,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      * 仍一致才能 setState。过期响应（期间切了 task / 又发了一轮加载）一律
      * 忽略（return），绝不把旧任务的 personalResult 写到新任务界面（泄漏他人报告）。
      */
-    async loadPersonalResult(seq?: number) {
-        if (this.taskId == null) return;
+    async loadPersonalResult(seq?: number, taskIdOverride?: number) {
+        const requestTaskId = taskIdOverride ?? this.taskId;
+        if (requestTaskId == null) return;
         const reqSeq = seq ?? this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
         this.setState({ personalLoading: true });
         try {
-            const result = await api.getPersonalResult(this.taskId);
+            const result = await api.getPersonalResult(requestTaskId);
             // 迟到响应（期间切 task / 重新加载）：丢弃，不污染新 task。
             if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
             const shouldGateWorkflow = this.shouldGateWorkflowForPersonalResult(result);
@@ -464,13 +469,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      * 把旧 task 的成员名单 setState 到新 task（否则泄漏他人报告 / 污染 team
      * citations、schedule participant 写入）。seq/taskId 不一致一律忽略。
      */
-    async loadMembers(seq?: number) {
-        if (this.taskId == null) return;
+    async loadMembers(seq?: number, taskIdOverride?: number) {
+        const requestTaskId = taskIdOverride ?? this.taskId;
+        if (requestTaskId == null) return;
         const reqSeq = seq ?? this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
         this.setState({ membersLoading: true });
         try {
-            const members = await api.getMembers(this.taskId);
+            const members = await api.getMembers(requestTaskId);
             if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
             this.setState({ members, membersLoading: false });
         } catch {

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
@@ -53,7 +53,7 @@ import SummaryDetailPage from '../SummaryDetailPage';
 
 vi.mock('../../api/summaryApi');
 
-function makePage(taskId: number) {
+function makePage(taskId: number | string) {
     const page = new SummaryDetailPage({ taskId } as any);
     (page as any).context = { t: (k: string) => k };
     (page as any).setState = function (this: any, patch: any) {
@@ -182,6 +182,29 @@ describe('SummaryDetailPage — Blocking 5: scheduleItem must track current deta
 // 且 loadDetail 入口同步清空 stale personalResult/members。
 describe('SummaryDetailPage — FE-1: 切任务竞态，旧 members/personalResult 迟到返回被忽略', () => {
     beforeEach(() => vi.clearAllMocks());
+
+    it('string task_no detail load starts BY_PERSON secondary fetches with numeric detail.task_id', async () => {
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2 }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: '我的报告', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid'), member('u_b')] as any);
+
+        const page = makePage('SUM-740');
+        const queuedSetStates: any[] = [];
+        (page as any).setState = function (this: any, patch: any, callback?: () => void) {
+            queuedSetStates.push({ patch, callback });
+        };
+
+        await page.loadDetail();
+
+        expect(api.getSummaryDetail).toHaveBeenCalledWith('SUM-740');
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);
+        expect(api.getMembers).toHaveBeenCalledWith(740);
+        expect(queuedSetStates.some(({ patch }) => patch?.detail?.task_id === 740)).toBe(true);
+    });
 
     // loadDetail 入口必须同步清空上一 task 的 personalResult/members，避免新 detail 返回前残留显示。
     it('loadDetail clears stale personalResult/members at entry (no leak before new detail resolves)', async () => {

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -800,6 +800,13 @@ describe('standalone return target — open-redirect-safe post-login bounce (blo
     }
   })
 
+  it('accepts a safe same-origin /s/:taskNo target for summary notification returns', () => {
+    for (const good of ['/s/TN_20260713_abcd', '/s/TN-9_x?sp=space-1']) {
+      window.sessionStorage.setItem(STANDALONE_RETURN_KEY, good)
+      expect(consumeStandaloneReturn()).toBe(good)
+    }
+  })
+
   it('AC-11 anonymous entry: the sign-in terminal stashes a safe, consumable return target', async () => {
     window.history.pushState({}, '', '/d/d_locked_out')
     wk.apiClient.responder = (method, url) => {
@@ -824,6 +831,7 @@ describe('withReturnSid — carry the current session sid on the post-login /d/:
     // now-strict multi-session recovery (which would loop back to login).
     expect(withReturnSid('/d/d_abc', 'fresh6')).toBe('/d/d_abc?sid=fresh6')
     expect(withReturnSid('/d/d_abc/', 'fresh6')).toBe('/d/d_abc/?sid=fresh6')
+    expect(withReturnSid('/s/TN_20260713_abcd?sp=space-1', 'fresh6')).toBe('/s/TN_20260713_abcd?sp=space-1&sid=fresh6')
   })
 
   it('leaves a target that already carries a sid untouched (no doubling)', () => {

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -25,6 +25,9 @@ export const STANDALONE_RETURN_KEY = 'octo.docs.standaloneReturn'
 /** `/d/:docId` — docId is a single documentName segment (A-Z a-z 0-9 _ -), optional trailing slash. */
 const STANDALONE_PATH = /^\/d\/([A-Za-z0-9_-]+)\/?$/
 
+/** `/s/:taskNo` — summary notification deep-link target, same segment safety as `/d/:docId`. */
+const STANDALONE_SUMMARY_PATH = /^\/s\/([A-Za-z0-9_-]+)\/?$/
+
 /** The standalone-doc URL namespace: `/d`, `/d/`, or `/d/<anything>` (top-level only). */
 const STANDALONE_NAMESPACE = /^\/d(?:\/|$)/
 
@@ -65,7 +68,7 @@ export function persistStandaloneReturn(): void {
 }
 
 /**
- * Whether a stashed return target is a SAFE same-origin link that lands on a standalone doc page.
+ * Whether a stashed return target is a SAFE same-origin standalone link.
  *
  * Open-redirect guard (hardened, XIN-392). The value lives in sessionStorage, so it is
  * attacker-influenceable, and it is later fed to `window.location.assign` — it must clear three
@@ -80,10 +83,9 @@ export function persistStandaloneReturn(): void {
  *   2. Same origin. Resolve against the current origin and require `url.origin === origin`. This
  *      rejects absolute (`https://evil`), scheme-relative (`//host`), and backslash-smuggled
  *      (`/\host`) targets structurally, instead of hand-checking leading characters.
- *   3. Standalone-doc target only (P2-2). Even a same-origin path must resolve to `/d/:docId`
- *      (`parseStandaloneDocId(url.pathname) !== null`), so a tampered value can't bounce the user to
- *      another same-origin page (`/settings`, `/oidc/bind`, …) after login — the post-login return
- *      is scoped to the standalone document the user actually opened.
+ *   3. Standalone target only (P2-2). Even a same-origin path must resolve to `/d/:docId` or the
+ *      summary notification target `/s/:taskNo`, so a tampered value can't bounce the user to another
+ *      same-origin page (`/settings`, `/oidc/bind`, …) after login.
  */
 function isSafeReturnPath(path: string | null): path is string {
   if (typeof path !== 'string' || path.length === 0) return false
@@ -103,7 +105,7 @@ function isSafeReturnPath(path: string | null): path is string {
     return false
   }
   if (url.origin !== origin) return false
-  return parseStandaloneDocId(url.pathname) !== null
+  return parseStandaloneDocId(url.pathname) !== null || STANDALONE_SUMMARY_PATH.test(url.pathname)
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a browser-openable `/s/:taskNo` standalone deep-link route that opens a summary's detail page, mirroring the existing `/d/:docId` standalone doc route. This is the octo-web half that makes the smart-summary notification card's "查看详情" button actually land on the detail page — including surviving the login redirect.

Supports smart-summary #150. Pairs with the smart-summary notify-card PR and the `task_no` detail-lookup PR.

## Problem
The notification card links to `/s/{task_no}?sp={space_id}`, but octo-web had no such route, so a click bounced to login and lost the target (landing on the app root, not the detail).

## Change (mirrors `/d/:docId`)
- **Strict matcher** `isStandaloneSummaryPath` → only a well-formed single-segment `/s/<taskNo>` (regex `^/s/([A-Za-z0-9_-]+)/?$`); `/s`, `/s/`, `/s/a/b` fall through.
- **Login redirect** carries `sp` (space id) through the bounce so an anonymous user returns to the exact `/s/:taskNo?sp=` target after login.
- **Render branch**: logged-in → `SummaryDetailPage`; anonymous → stash target + login, then post-login return (reuses `persist/consumeStandaloneReturn` + `withReturnSid`).
- **task_no is a string**: raw path segment is passed to the initial detail fetch (`getSummaryDetail`/`useSummaryDetail` widened to `number | string`); numeric-only actions (regenerate/cancel/delete) keep using the numeric `detail.task_id` after the response arrives.
- The **shared** standalone return-target validator (`StandaloneDocPage`) now accepts `/s/:taskNo` under the **same** same-origin + single-segment open-redirect guard as `/d/:docId` (no loosening).

## Safety
Open-redirect guard verified: rooted path, no control chars, same-origin via `new URL`, exact single-segment `/d` or `/s` match — `//evil.com`, `/s/../..`, encoded-slash payloads all rejected. Anonymous users never render the detail (no data leak).

## Deployment prerequisites
None (front-end only). The deep-link origin comes from octo-server `external.webLoginURL` (must be https), unrelated to this PR.

## Testing
`npx vitest run` green in all three touched areas: Layout standalone path (9), docs `StandaloneDocPage` (43, incl. new `/s/` return-target cases), full `dmworksummary` suite (376). Trusted vitest over bare tsc (known Vite false-positives). Independently re-verified + adversarially reviewed (2 rounds, APPROVE). No `package.json` / lockfile changes.
