### PR TITLE
fix(ui): 修复控制台警告和连接状态显示

### DIFF
--- a/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
+++ b/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
@@ -90,10 +90,23 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
             })
             const latency = Date.now() - start
             if (isImConnected(WKSDK.shared())) {
-                this.setState({ latency })
+                const nextState: Partial<ConnectionStatusState> = {
+                    status: ConnectStatus.Connected,
+                    latency,
+                }
+                if (!this.state.connectedSince) {
+                    this.connectedTime = Date.now()
+                    nextState.connectedSince = this.connectedTime
+                }
+                this.setState(nextState as any)
             }
         } catch {
-            // ignore
+            this.connectedTime = 0
+            this.setState({
+                status: ConnectStatus.Disconnect,
+                latency: null,
+                connectedSince: null,
+            })
         }
     }
 

--- a/packages/dmworkbase/src/Components/Sections/index.tsx
+++ b/packages/dmworkbase/src/Components/Sections/index.tsx
@@ -21,8 +21,10 @@ export default class Sections extends Component<SectionsProps> {
                         <div className="wk-channelsetting-section-rows">
                             {
                                 section.rows?.map((row, j) => {
+                                    const Cell = row.cell
+                                    const { key: cellKey, ...cellProps } = row.properties ?? {}
                                     return <div key={j} className="wk-section-row">
-                                        <row.cell  {...row.properties}></row.cell>
+                                        <Cell key={cellKey} {...cellProps}></Cell>
                                     </div>
                                 })
                             }

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -575,7 +575,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
       );
     const wrap =
       (Tag: string) =>
-      ({ node, children, ...props }: any) =>
+      ({ node, children, ordered, checked, index, siblingCount, ...props }: any) =>
         React.createElement(Tag, props, process(children));
     return {
       ...baseComponents,


### PR DESCRIPTION
## Summary
- 修复 Sections 动态组件 props 中 key 被 spread 导致的 React warning
- 过滤 Markdown 渲染器转发到 DOM 的内部字段，避免 ordered=false warning
- 健康检查失败时同步更新连接状态展示，避免断网后仍显示已连接

## Tests
- pnpm --dir packages/dmworkbase test src/Messages/Text/__tests__/MarkdownContentMention.test.tsx src/Messages/Text/__tests__/MarkdownContentForwardClamp.test.tsx
- pnpm --dir packages/dmworkbase test src/im-runtime/connectStatus.test.ts src/Pages/Chat/__tests__/vm.sortConversations.test.ts src/Pages/Chat/__tests__/vm.channelListener.test.ts
- pnpm --dir apps/web build
- git diff --check