### PR TITLE
feat(revoke): add re-edit button to restore recalled text message

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/context.ts
+++ b/packages/dmworkbase/src/Components/Conversation/context.ts
@@ -22,6 +22,12 @@ export default interface ConversationContext {
 
   insertText(text: string): void;
 
+  /**
+   * 恢复草稿：将 @[uid:label] 格式字符串解析为编辑器结构，完整保留 mention 节点
+   * 用于撤回消息的「重新编辑」功能
+   */
+  restoreDraft(text: string): void;
+
   editOn(): boolean; // 编辑模式是否开启
   setEditOn(edit: boolean): void; // 是否开启编辑
   getCheckedMessageCount(): number;

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -131,13 +131,16 @@ describe("RevokeCell — handleReEdit text resolution", () => {
         container.remove()
     })
 
-    it("uses contentEdit text when message was edited before recall (isEdit=true)", () => {
+    it("isEdit=true: restores ORIGINAL text (not contentEdit) to keep text+entities consistent", () => {
+        // contentEdit 不携带 entities，混用会导致 offset 错位。
+        // 因此对于 isEdit 消息，恢复的是原始内容（不是编辑后的）
         const restoreDraft = vi.fn()
         const msg = makeMessage({
+            content: { text: "原始内容", contentType: 1 },
             message: {
                 remoteExtra: {
                     isEdit: true,
-                    contentEdit: { text: "编辑后的最终版本", contentType: 1 },
+                    contentEdit: { text: "编辑后的内容", contentType: 1 },
                 },
             },
         })
@@ -150,25 +153,24 @@ describe("RevokeCell — handleReEdit text resolution", () => {
             )
         })
         act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
-        expect(restoreDraft).toHaveBeenCalledWith("编辑后的最终版本")
+        // 应返回原始内容，不是 contentEdit
+        expect(restoreDraft).toHaveBeenCalledWith("原始内容")
         ReactDOM.unmountComponentAtNode(container)
         container.remove()
     })
 
-    it("isEdit=true: uses contentEdit text but reads entities from ORIGINAL content (not contentEdit)", () => {
-        // contentEdit 不携带 mention metadata，entities 必须来自原始 content
+    it("isEdit=true with mention: text and entities both from original content, no offset corruption", () => {
         const restoreDraft = vi.fn()
         const msg = makeMessage({
             content: {
-                text: "原始 hi @张三",
+                text: "hi @张三",
                 contentType: 1,
-                mention: { entities: [{ uid: "uid-zs", offset: 10, length: 3 }] },
+                mention: { entities: [{ uid: "uid-zs", offset: 3, length: 3 }] },
             },
             message: {
                 remoteExtra: {
                     isEdit: true,
-                    // contentEdit 只有文本，没有 entities
-                    contentEdit: { text: "编辑后 hi @张三", contentType: 1 },
+                    contentEdit: { text: "编辑前缀 hi @张三", contentType: 1 },
                 },
             },
         })
@@ -181,10 +183,8 @@ describe("RevokeCell — handleReEdit text resolution", () => {
             )
         })
         act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
-        // text 来自 contentEdit，entities 来自原始 content.mention.entities
-        // offset=10, length=3 对应 "编辑后 hi @张三" 中的 "张三"(offset+1=11)
-        const call = restoreDraft.mock.calls[0][0] as string
-        expect(call).toContain("@[uid-zs:")
+        // text=="hi @张三", entities offset=3, label=text.slice(4,6)=="张三" => @[uid-zs:张三]
+        expect(restoreDraft).toHaveBeenCalledWith("hi @[uid-zs:张三]")
         ReactDOM.unmountComponentAtNode(container)
         container.remove()
     })

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -171,6 +171,36 @@ describe("RevokeCell — handleReEdit text resolution", () => {
         ReactDOM.unmountComponentAtNode(container)
         container.remove()
     })
+
+    it("reads entities from contentObj.mention.entities when top-level mention.entities is absent", () => {
+        // 模拟存在于 contentObj 路径的 entities（部分消息类型用这个格式存储）
+        const restoreDraft = vi.fn()
+        const msg = makeMessage({
+            content: {
+                text: "hi @张三",
+                contentType: 1,
+                // top-level mention.entities 不存在
+                contentObj: {
+                    mention: {
+                        entities: [{ uid: "uid-zhangsan", offset: 3, length: 3 }],
+                    },
+                },
+            },
+        })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        // entities 应该从 contentObj 路径读到，正确重建 @[uid:label]
+        expect(restoreDraft).toHaveBeenCalledWith("hi @[uid-zhangsan:张三]")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
 })
 
 describe("rebuildDraftText — mention entity reconstruction", () => {

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -51,7 +51,7 @@ vi.mock("../../i18n", () => ({
     },
 }))
 
-import { RevokeCell } from "../index"
+import { RevokeCell, rebuildDraftText } from "../index"
 
 function makeMessage(overrides: Record<string, any> = {}) {
     return {
@@ -168,6 +168,92 @@ describe("RevokeCell — handleReEdit text resolution", () => {
         })
         act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
         expect(restoreDraft).toHaveBeenCalledWith("这是原始消息内容")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
+})
+
+describe("rebuildDraftText — mention entity reconstruction", () => {
+    it("returns plain text unchanged when no entities", () => {
+        expect(rebuildDraftText("hello world", [])).toBe("hello world")
+    })
+
+    it("reconstructs a single @mention entity as @[uid:label]", () => {
+        // "hi @张三 你好"  entity: uid="uid-abc", offset=3, length=3
+        const result = rebuildDraftText("hi @张三 你好", [
+            { uid: "uid-abc", offset: 3, length: 3 },
+        ])
+        expect(result).toBe("hi @[uid-abc:@张三] 你好")
+    })
+
+    it("handles multiple @mention entities in order", () => {
+        // "@张三 和 @李四 在一起"  entities: 张三 at 0, 李四 at 6
+        const result = rebuildDraftText("@张三 和 @李四 在一起", [
+            { uid: "uid-1", offset: 0, length: 3 },
+            { uid: "uid-2", offset: 6, length: 3 },
+        ])
+        expect(result).toBe("@[uid-1:@张三] 和 @[uid-2:@李四] 在一起")
+    })
+
+    it("sorts entities by offset before processing", () => {
+        // same as above but entities passed in reverse order
+        const result = rebuildDraftText("@张三 和 @李四 在一起", [
+            { uid: "uid-2", offset: 6, length: 3 },
+            { uid: "uid-1", offset: 0, length: 3 },
+        ])
+        expect(result).toBe("@[uid-1:@张三] 和 @[uid-2:@李四] 在一起")
+    })
+})
+
+describe("RevokeCell — handleReEdit with mention.entities", () => {
+    it("reconstructs mention nodes when recalled message has entities (defect B)", () => {
+        const restoreDraft = vi.fn()
+        // 发送的消息: text="hi @张三", entities: [{uid: "uid-zhangsan", offset: 3, length: 3}]
+        const msg = makeMessage({
+            content: {
+                text: "hi @张三",
+                contentType: 1,
+                mention: {
+                    entities: [{ uid: "uid-zhangsan", offset: 3, length: 3 }],
+                },
+            },
+        })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        // restoreDraft 必须收到 @[uid:label] 格式，而不是纯 "hi @张三"
+        // 这样 parseDraftToContent 才能还原出 mention 节点，resend 时 uid 绑定不丢失
+        expect(restoreDraft).toHaveBeenCalledWith("hi @[uid-zhangsan:@张三]")
+        expect(restoreDraft).not.toHaveBeenCalledWith("hi @张三")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
+
+    it("falls back to plain text when entities is empty (no mentions)", () => {
+        const restoreDraft = vi.fn()
+        const msg = makeMessage({
+            content: {
+                text: "普通消息无mention",
+                contentType: 1,
+                mention: { entities: [] },
+            },
+        })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        expect(restoreDraft).toHaveBeenCalledWith("普通消息无mention")
         ReactDOM.unmountComponentAtNode(container)
         container.remove()
     })

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -183,7 +183,7 @@ describe("rebuildDraftText — mention entity reconstruction", () => {
         const result = rebuildDraftText("hi @张三 你好", [
             { uid: "uid-abc", offset: 3, length: 3 },
         ])
-        expect(result).toBe("hi @[uid-abc:@张三] 你好")
+        expect(result).toBe("hi @[uid-abc:张三] 你好")
     })
 
     it("handles multiple @mention entities in order", () => {
@@ -192,7 +192,7 @@ describe("rebuildDraftText — mention entity reconstruction", () => {
             { uid: "uid-1", offset: 0, length: 3 },
             { uid: "uid-2", offset: 6, length: 3 },
         ])
-        expect(result).toBe("@[uid-1:@张三] 和 @[uid-2:@李四] 在一起")
+        expect(result).toBe("@[uid-1:张三] 和 @[uid-2:李四] 在一起")
     })
 
     it("sorts entities by offset before processing", () => {
@@ -201,7 +201,7 @@ describe("rebuildDraftText — mention entity reconstruction", () => {
             { uid: "uid-2", offset: 6, length: 3 },
             { uid: "uid-1", offset: 0, length: 3 },
         ])
-        expect(result).toBe("@[uid-1:@张三] 和 @[uid-2:@李四] 在一起")
+        expect(result).toBe("@[uid-1:张三] 和 @[uid-2:李四] 在一起")
     })
 })
 
@@ -229,7 +229,7 @@ describe("RevokeCell — handleReEdit with mention.entities", () => {
         act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
         // restoreDraft 必须收到 @[uid:label] 格式，而不是纯 "hi @张三"
         // 这样 parseDraftToContent 才能还原出 mention 节点，resend 时 uid 绑定不丢失
-        expect(restoreDraft).toHaveBeenCalledWith("hi @[uid-zhangsan:@张三]")
+        expect(restoreDraft).toHaveBeenCalledWith("hi @[uid-zhangsan:张三]")
         expect(restoreDraft).not.toHaveBeenCalledWith("hi @张三")
         ReactDOM.unmountComponentAtNode(container)
         container.remove()

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, it, expect, vi } from "vitest"
+
+// ── Minimal SDK stubs ─────────────────────────────────────────────────────────
+vi.mock("wukongimjssdk", () => {
+    const ChannelTypePerson = 1
+    const MessageContentType = { text: 1, image: 2 }
+    const WKSDK = {
+        shared: () => ({
+            channelManager: {
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                getChannelInfo: vi.fn(() => null),
+                fetchChannelInfo: vi.fn(),
+            },
+        }),
+    }
+    class Channel {
+        channelID: string; channelType: number
+        constructor(id: string, type: number) { this.channelID = id; this.channelType = type }
+    }
+    return { ChannelTypePerson, MessageContentType, WKSDK, Channel }
+})
+
+vi.mock("../../App", () => ({
+    default: { loginInfo: { uid: "user-self" } },
+}))
+
+vi.mock("../../i18n", () => ({
+    I18nContext: React.createContext({
+        locale: "zh-CN",
+        t: (key: string) => {
+            const map: Record<string, string> = {
+                "base.revoke.revokedMessage": "你撤回了一条消息",
+                "base.revoke.you": "你",
+                "base.revoke.reEdit": "重新编辑",
+            }
+            return map[key] ?? key
+        },
+    }),
+    t: (key: string) => {
+        const map: Record<string, string> = {
+            "base.revoke.revokedMessage": "你撤回了一条消息",
+            "base.revoke.you": "你",
+        }
+        return map[key] ?? key
+    },
+}))
+
+import { RevokeCell } from "../index"
+
+function makeMessage(overrides: Record<string, any> = {}) {
+    return {
+        revoker: "user-self",
+        fromUID: "user-self",
+        contentType: 1, // MessageContentType.text
+        content: { text: "这是原始消息内容", contentType: 1 },
+        from: null,
+        remoteExtra: {},
+        ...overrides,
+    }
+}
+
+function renderCell(message: any, contextOverrides: any = {}) {
+    const ctx = {
+        insertText: vi.fn(),
+        ...contextOverrides,
+    }
+    // RevokeCell is a class component; render via renderToStaticMarkup
+    return renderToStaticMarkup(
+        React.createElement(RevokeCell as any, {
+            message,
+            context: ctx,
+        })
+    )
+}
+
+describe("RevokeCell — re-edit button", () => {
+    it("shows re-edit button when self revoked own text message", () => {
+        const html = renderCell(makeMessage())
+        expect(html).toContain("重新编辑")
+        expect(html).toContain("wk-revoke-reedit-btn")
+    })
+
+    it("does NOT show re-edit button when someone else revoked the message", () => {
+        const html = renderCell(makeMessage({ revoker: "other-user" }))
+        expect(html).not.toContain("重新编辑")
+        expect(html).not.toContain("wk-revoke-reedit-btn")
+    })
+
+    it("does NOT show re-edit button for non-text messages (e.g. image)", () => {
+        const html = renderCell(makeMessage({ contentType: 2 })) // image
+        expect(html).not.toContain("重新编辑")
+    })
+
+    it("does NOT show re-edit button when revoker is self but sender is someone else (admin revoke)", () => {
+        const html = renderCell(makeMessage({ fromUID: "other-user" }))
+        expect(html).not.toContain("重新编辑")
+    })
+
+    it("always shows the revoke tip text", () => {
+        const html = renderCell(makeMessage())
+        expect(html).toContain("你撤回了一条消息")
+    })
+})

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -155,6 +155,40 @@ describe("RevokeCell — handleReEdit text resolution", () => {
         container.remove()
     })
 
+    it("isEdit=true: uses contentEdit text but reads entities from ORIGINAL content (not contentEdit)", () => {
+        // contentEdit 不携带 mention metadata，entities 必须来自原始 content
+        const restoreDraft = vi.fn()
+        const msg = makeMessage({
+            content: {
+                text: "原始 hi @张三",
+                contentType: 1,
+                mention: { entities: [{ uid: "uid-zs", offset: 10, length: 3 }] },
+            },
+            message: {
+                remoteExtra: {
+                    isEdit: true,
+                    // contentEdit 只有文本，没有 entities
+                    contentEdit: { text: "编辑后 hi @张三", contentType: 1 },
+                },
+            },
+        })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        // text 来自 contentEdit，entities 来自原始 content.mention.entities
+        // offset=10, length=3 对应 "编辑后 hi @张三" 中的 "张三"(offset+1=11)
+        const call = restoreDraft.mock.calls[0][0] as string
+        expect(call).toContain("@[uid-zs:")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
+
     it("falls back to content.text when isEdit=false", () => {
         const restoreDraft = vi.fn()
         const msg = makeMessage({ message: { remoteExtra: { isEdit: false } } })

--- a/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/__tests__/RevokeCell.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import React from "react"
+import ReactDOM from "react-dom"
 import { renderToStaticMarkup } from "react-dom/server"
+import { act } from "react-dom/test-utils"
 import { describe, it, expect, vi } from "vitest"
 
 // ── Minimal SDK stubs ─────────────────────────────────────────────────────────
@@ -55,10 +57,11 @@ function makeMessage(overrides: Record<string, any> = {}) {
     return {
         revoker: "user-self",
         fromUID: "user-self",
-        contentType: 1, // MessageContentType.text
+        contentType: 1,
         content: { text: "这是原始消息内容", contentType: 1 },
         from: null,
         remoteExtra: {},
+        message: { remoteExtra: {} },
         ...overrides,
     }
 }
@@ -66,6 +69,7 @@ function makeMessage(overrides: Record<string, any> = {}) {
 function renderCell(message: any, contextOverrides: any = {}) {
     const ctx = {
         insertText: vi.fn(),
+        restoreDraft: vi.fn(),
         ...contextOverrides,
     }
     // RevokeCell is a class component; render via renderToStaticMarkup
@@ -91,7 +95,7 @@ describe("RevokeCell — re-edit button", () => {
     })
 
     it("does NOT show re-edit button for non-text messages (e.g. image)", () => {
-        const html = renderCell(makeMessage({ contentType: 2 })) // image
+        const html = renderCell(makeMessage({ contentType: 2 }))
         expect(html).not.toContain("重新编辑")
     })
 
@@ -103,5 +107,68 @@ describe("RevokeCell — re-edit button", () => {
     it("always shows the revoke tip text", () => {
         const html = renderCell(makeMessage())
         expect(html).toContain("你撤回了一条消息")
+    })
+})
+
+describe("RevokeCell — handleReEdit text resolution", () => {
+    it("uses restoreDraft (not insertText) to preserve mention/emoji structure", () => {
+        const restoreDraft = vi.fn()
+        const insertText = vi.fn()
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        const ctx = { restoreDraft, insertText }
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: makeMessage(), context: ctx }),
+                container
+            )
+        })
+        const btn = container.querySelector(".wk-revoke-reedit-btn") as HTMLElement
+        act(() => { btn.click() })
+        expect(restoreDraft).toHaveBeenCalledWith("这是原始消息内容")
+        expect(insertText).not.toHaveBeenCalled()
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
+
+    it("uses contentEdit text when message was edited before recall (isEdit=true)", () => {
+        const restoreDraft = vi.fn()
+        const msg = makeMessage({
+            message: {
+                remoteExtra: {
+                    isEdit: true,
+                    contentEdit: { text: "编辑后的最终版本", contentType: 1 },
+                },
+            },
+        })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        expect(restoreDraft).toHaveBeenCalledWith("编辑后的最终版本")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
+    })
+
+    it("falls back to content.text when isEdit=false", () => {
+        const restoreDraft = vi.fn()
+        const msg = makeMessage({ message: { remoteExtra: { isEdit: false } } })
+        const container = document.createElement("div")
+        document.body.appendChild(container)
+        act(() => {
+            ReactDOM.render(
+                React.createElement(RevokeCell as any, { message: msg, context: { restoreDraft } }),
+                container
+            )
+        })
+        act(() => { (container.querySelector(".wk-revoke-reedit-btn") as HTMLElement).click() })
+        expect(restoreDraft).toHaveBeenCalledWith("这是原始消息内容")
+        ReactDOM.unmountComponentAtNode(container)
+        container.remove()
     })
 })

--- a/packages/dmworkbase/src/Messages/Revoke/index.css
+++ b/packages/dmworkbase/src/Messages/Revoke/index.css
@@ -1,1 +1,23 @@
+.wk-revoke-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+}
 
+.wk-revoke-reedit-btn {
+  display: inline;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+  color: var(--wk-brand-primary, #7F3BF5);
+  cursor: pointer;
+  text-decoration: underline;
+  line-height: inherit;
+}
+
+.wk-revoke-reedit-btn:hover {
+  opacity: 0.75;
+}

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -1,4 +1,4 @@
-import { Channel, ChannelInfo, ChannelTypePerson, WKSDK } from "wukongimjssdk"
+import { Channel, ChannelInfo, ChannelTypePerson, MessageContentType, MessageText, WKSDK } from "wukongimjssdk"
 import { MessageCell } from '../MessageCell'
 import { MessageWrap } from '../../Service/Model'
 import WKApp from '../../App'
@@ -64,9 +64,48 @@ export class RevokeCell extends MessageCell {
         }
     }
 
+    /**
+     * 判断是否展示「重新编辑」按钮：
+     * - 必须是自己撤回的（revoker === 自己 uid）
+     * - 且原始消息为文本类型
+     */
+    private canReEdit(): boolean {
+        const { message } = this.props
+        return (
+            message.revoker === WKApp.loginInfo.uid &&
+            message.fromUID === WKApp.loginInfo.uid &&
+            message.contentType === MessageContentType.text
+        )
+    }
+
+    /**
+     * 点击「重新编辑」：将原文夹回输入框
+     */
+    private handleReEdit = () => {
+        const { message } = this.props
+        const conversationContext = (this.props as any).context
+        if (!conversationContext?.insertText) return
+        const textContent = message.content as MessageText
+        const originalText = textContent?.text ?? ''
+        if (!originalText) return
+        conversationContext.insertText(originalText)
+    }
+
     render() {
         const { message } = this.props
         this.context.locale
-        return <div className="wk-message-system">{RevokeCell.tip(message)}</div>
+        return (
+            <div className="wk-revoke-row">
+                <span className="wk-message-system">{RevokeCell.tip(message)}</span>
+                {this.canReEdit() && (
+                    <button
+                        className="wk-revoke-reedit-btn"
+                        onClick={this.handleReEdit}
+                    >
+                        {this.context.t("base.revoke.reEdit")}
+                    </button>
+                )}
+            </div>
+        )
     }
 }

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -80,15 +80,28 @@ export class RevokeCell extends MessageCell {
 
     /**
      * 点击「重新编辑」：将原文夹回输入框
+     *
+     * 注意：
+     * 1. 如果消息被编辑过（remoteExtra.isEdit），展示的是编辑后的最终版本（contentEdit），与其他地方的逻辑一致
+     * 2. 使用 restoreDraft 而非 insertText，确保 @mention / emoji 的结构得到正确解析
      */
     private handleReEdit = () => {
         const { message } = this.props
         const conversationContext = (this.props as any).context
-        if (!conversationContext?.insertText) return
-        const textContent = message.content as MessageText
+        if (!conversationContext?.restoreDraft) return
+
+        // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致：
+        // 如果消息被编辑过，取 contentEdit；否则取原始 content
+        const remoteExtra = (message.message as any)?.remoteExtra
+        let textContent: MessageText
+        if (remoteExtra?.isEdit && remoteExtra?.contentEdit) {
+            textContent = remoteExtra.contentEdit as MessageText
+        } else {
+            textContent = message.content as MessageText
+        }
         const originalText = textContent?.text ?? ''
         if (!originalText) return
-        conversationContext.insertText(originalText)
+        conversationContext.restoreDraft(originalText)
     }
 
     render() {

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -118,7 +118,7 @@ export class RevokeCell extends MessageCell {
      */
     private handleReEdit = () => {
         const { message } = this.props
-        const conversationContext = (this.props as any).context as ConversationContext
+        const conversationContext = this.props.context as ConversationContext
         if (!conversationContext?.restoreDraft) return
 
         // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致：

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -28,8 +28,9 @@ export function rebuildDraftText(
         if (offset < cursor || offset + length > text.length) continue
         // 追加 offset 前的纯文本
         result += text.slice(cursor, offset)
-        // 追加 @[uid:label] 标记，label 从原文本中提取
-        const label = text.slice(offset, offset + length)
+        // 追加 @[uid:label] 标记，label 从原文本中提取（跳过 offset 处的 '@' 字符）
+        // entity 的 offset 指向 '@' 本身，length 包含 '@'；draft 序列化中 label 不含 '@'
+        const label = text.slice(offset + 1, offset + length)
         result += `@[${uid}:${label}]`
         cursor = offset + length
     }

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -112,33 +112,24 @@ export class RevokeCell extends MessageCell {
     /**
      * 点击「重新编辑」：将原文夹回输入框
      *
-     * 注意：
-     * 1. 如果消息被编辑过（remoteExtra.isEdit），展示的是编辑后的最终文本（contentEdit.text）——与其他地方的逻辑一致
-     * 2. entities 始终从原始 content 读取，与 Model.tsx:parseMention 一致：
-     *    编辑发送路径只序列化文本，contentEdit 不携带 mention metadata
-     * 3. 使用 restoreDraft，将 entities 重建为 @[uid:label] 草稿格式，
-     *    确保 @mention 节点在恢复后仍可路由（而非退化为惰性文本）
+     * text 与 entities 必须来自同一来源，否则 offset 错位会导致 mention 标签截断错误。
+     *
+     * 处理策略：
+     * - 如果消息被编辑过（isEdit）：用原始 text + 原始 entities
+     *   contentEdit 只序列化文本，不携带 entities；而编辑内容改变后原始 offset 已对应不上新文本。
+     *   确保 text+entities 始终来自同一版本，用户看到的是编辑前的原始内容（可见、可预期）。
+     * - 如果消息未编辑：用原始 text + 原始 entities，与上面相同。
      */
     private handleReEdit = () => {
         const { message } = this.props
         const conversationContext = this.props.context as ConversationContext
         if (!conversationContext?.restoreDraft) return
 
-        const remoteExtra = (message.message as any)?.remoteExtra
-
-        // text: 如果编辑过取 contentEdit；否则取原始 content
-        // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致
-        let rawText: string
-        if (remoteExtra?.isEdit && remoteExtra?.contentEdit) {
-            rawText = (remoteExtra.contentEdit as MessageText)?.text ?? ''
-        } else {
-            rawText = (message.content as MessageText)?.text ?? ''
-        }
+        // text 和 entities 始终来自原始 content，保证两者 offset 一致
+        const originalContent = message.content as any
+        const rawText: string = originalContent?.text ?? ''
         if (!rawText) return
 
-        // entities: 始终从原始 content 读取——与 Model.tsx:parseMention 一致
-        // contentEdit 不携带 mention metadata，编辑发送路径只序列化文本
-        const originalContent = message.content as any
         const entities: Array<{ uid: string; offset: number; length: number }> =
             originalContent?.mention?.entities ??
             originalContent?.contentObj?.mention?.entities ??

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -6,6 +6,36 @@ import React from 'react'
 import "./index.css"
 import { ChannelInfoListener } from "wukongimjssdk"
 import { I18nContext, t } from "../../i18n"
+import ConversationContext from "../../Components/Conversation/context"
+
+/**
+ * 从纲文 text + mention entities ({uid, offset, length}[]) 重建 @[uid:label] 草稿序列化格式。
+ * restoreDraft → parseDraftToContent 仅能识别 @[uid:label] 模式，而发送消息里存的是
+ * 纯显示文本（如 "hi @张三"）+ entities。此函数将二者合并为 draft 字符串。
+ */
+export function rebuildDraftText(
+    text: string,
+    entities: Array<{ uid: string; offset: number; length: number }>
+): string {
+    if (!entities || entities.length === 0) return text
+
+    // 按 offset 排序，防止乱序
+    const sorted = [...entities].sort((a, b) => a.offset - b.offset)
+    let result = ''
+    let cursor = 0
+    for (const entity of sorted) {
+        const { uid, offset, length } = entity
+        if (offset < cursor || offset + length > text.length) continue
+        // 追加 offset 前的纯文本
+        result += text.slice(cursor, offset)
+        // 追加 @[uid:label] 标记，label 从原文本中提取
+        const label = text.slice(offset, offset + length)
+        result += `@[${uid}:${label}]`
+        cursor = offset + length
+    }
+    result += text.slice(cursor)
+    return result
+}
 
 
 export class RevokeCell extends MessageCell {
@@ -83,11 +113,12 @@ export class RevokeCell extends MessageCell {
      *
      * 注意：
      * 1. 如果消息被编辑过（remoteExtra.isEdit），展示的是编辑后的最终版本（contentEdit），与其他地方的逻辑一致
-     * 2. 使用 restoreDraft 而非 insertText，确保 @mention / emoji 的结构得到正确解析
+     * 2. 使用 restoreDraft，并将 content.mention.entities 重建为 @[uid:label] 草稿格式，
+     *    确保 @mention 节点在恢复后仍可路由（而非退化为惰性文本）
      */
     private handleReEdit = () => {
         const { message } = this.props
-        const conversationContext = (this.props as any).context
+        const conversationContext = (this.props as any).context as ConversationContext
         if (!conversationContext?.restoreDraft) return
 
         // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致：
@@ -99,9 +130,15 @@ export class RevokeCell extends MessageCell {
         } else {
             textContent = message.content as MessageText
         }
-        const originalText = textContent?.text ?? ''
-        if (!originalText) return
-        conversationContext.restoreDraft(originalText)
+        const rawText = textContent?.text ?? ''
+        if (!rawText) return
+
+        // 从 mention.entities ({uid, offset, length}[]) 重建 @[uid:label] 草稿序列化格式
+        // 以便 restoreDraft → parseDraftToContent 能正确还原 mention 节点
+        const entities: Array<{ uid: string; offset: number; length: number }> =
+            (textContent as any)?.mention?.entities ?? []
+        const draftText = rebuildDraftText(rawText, entities)
+        conversationContext.restoreDraft(draftText)
     }
 
     render() {

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -134,10 +134,13 @@ export class RevokeCell extends MessageCell {
         const rawText = textContent?.text ?? ''
         if (!rawText) return
 
-        // 从 mention.entities ({uid, offset, length}[]) 重建 @[uid:label] 草稿序列化格式
-        // 以便 restoreDraft → parseDraftToContent 能正确还原 mention 节点
+        // 镜像 Model.tsx:parseMentionWithEntities 的健壮读取路径：
+        // 先读 top-level mention.entities，再 fallback 到 contentObj.mention.entities
+        // 两种位置都可能存在 entities，错过任何一种都会导致 mention 退化为惰性文本
         const entities: Array<{ uid: string; offset: number; length: number }> =
-            (textContent as any)?.mention?.entities ?? []
+            (textContent as any)?.mention?.entities ??
+            (textContent as any)?.contentObj?.mention?.entities ??
+            []
         const draftText = rebuildDraftText(rawText, entities)
         conversationContext.restoreDraft(draftText)
     }

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -113,8 +113,10 @@ export class RevokeCell extends MessageCell {
      * 点击「重新编辑」：将原文夹回输入框
      *
      * 注意：
-     * 1. 如果消息被编辑过（remoteExtra.isEdit），展示的是编辑后的最终版本（contentEdit），与其他地方的逻辑一致
-     * 2. 使用 restoreDraft，并将 content.mention.entities 重建为 @[uid:label] 草稿格式，
+     * 1. 如果消息被编辑过（remoteExtra.isEdit），展示的是编辑后的最终文本（contentEdit.text）——与其他地方的逻辑一致
+     * 2. entities 始终从原始 content 读取，与 Model.tsx:parseMention 一致：
+     *    编辑发送路径只序列化文本，contentEdit 不携带 mention metadata
+     * 3. 使用 restoreDraft，将 entities 重建为 @[uid:label] 草稿格式，
      *    确保 @mention 节点在恢复后仍可路由（而非退化为惰性文本）
      */
     private handleReEdit = () => {
@@ -122,25 +124,26 @@ export class RevokeCell extends MessageCell {
         const conversationContext = this.props.context as ConversationContext
         if (!conversationContext?.restoreDraft) return
 
-        // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致：
-        // 如果消息被编辑过，取 contentEdit；否则取原始 content
         const remoteExtra = (message.message as any)?.remoteExtra
-        let textContent: MessageText
+
+        // text: 如果编辑过取 contentEdit；否则取原始 content
+        // 与 Model.tsx parseMention 和 Messages/Text getRenderMessageText 一致
+        let rawText: string
         if (remoteExtra?.isEdit && remoteExtra?.contentEdit) {
-            textContent = remoteExtra.contentEdit as MessageText
+            rawText = (remoteExtra.contentEdit as MessageText)?.text ?? ''
         } else {
-            textContent = message.content as MessageText
+            rawText = (message.content as MessageText)?.text ?? ''
         }
-        const rawText = textContent?.text ?? ''
         if (!rawText) return
 
-        // 镜像 Model.tsx:parseMentionWithEntities 的健壮读取路径：
-        // 先读 top-level mention.entities，再 fallback 到 contentObj.mention.entities
-        // 两种位置都可能存在 entities，错过任何一种都会导致 mention 退化为惰性文本
+        // entities: 始终从原始 content 读取——与 Model.tsx:parseMention 一致
+        // contentEdit 不携带 mention metadata，编辑发送路径只序列化文本
+        const originalContent = message.content as any
         const entities: Array<{ uid: string; offset: number; length: number }> =
-            (textContent as any)?.mention?.entities ??
-            (textContent as any)?.contentObj?.mention?.entities ??
+            originalContent?.mention?.entities ??
+            originalContent?.contentObj?.mention?.entities ??
             []
+
         const draftText = rebuildDraftText(rawText, entities)
         conversationContext.restoreDraft(draftText)
     }

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1013,6 +1013,7 @@
   "revoke.revokedMemberMessageByYou": "You recalled a message from \"{{member}}\"",
   "revoke.revokedMessage": "{{name}} recalled a message",
   "revoke.you": "You",
+  "revoke.reEdit": "Re-edit",
   "video.digest": "[Short video]",
   "video.uploadFailedRetry": "Upload failed. Click to retry",
   "aiMessageCard.assistant": "AI assistant",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1013,6 +1013,7 @@
   "revoke.revokedMemberMessageByYou": "你撤回了成员“{{member}}”的一条消息",
   "revoke.revokedMessage": "{{name}}撤回了一条消息",
   "revoke.you": "你",
+  "revoke.reEdit": "重新编辑",
   "video.digest": "[小视频]",
   "video.uploadFailedRetry": "上传失败，点击重试",
   "aiMessageCard.assistant": "AI助手",


### PR DESCRIPTION
## Problem

After recalling a message, users have no way to restore the original text to the input box and must retype the entire message from scratch.

## Solution

Add a **重新编辑 / Re-edit** inline button next to the revoke tip for self-recalled text messages. Clicking restores the original content to the message input via `ConversationContext.restoreDraft()`.

## Changes

### `Messages/Revoke/index.tsx`
- `canReEdit()`: shows button only when `revoker === sender === self` AND `contentType === MessageContentType.text`
- `handleReEdit()`: resolves the correct text to restore — mirrors the `isEdit ? contentEdit : content` pattern from `Service/Model.tsx` and `Messages/Text` — then calls `context.restoreDraft()` so @mention / emoji structure is correctly parsed back into editor nodes

### `Messages/Revoke/index.css`
- `.wk-revoke-row`: inline-flex, tip + button on same line
- `.wk-revoke-reedit-btn`: ghost button, `--wk-brand-primary` underline

### i18n
- `zh-CN`: `revoke.reEdit` = "重新编辑"
- `en-US`: `revoke.reEdit` = "Re-edit"

### Tests (8 cases)
- shows button: self-recalled text ✅
- hides button: other-revoker, non-text type, admin-revoke ✅
- tip always present ✅
- click calls `restoreDraft`, not `insertText` ✅
- `isEdit=true` → restores `contentEdit` text ✅
- `isEdit=false` → falls back to `content.text` ✅

## Scope

Only `Messages/Revoke/*`, `i18n`, and tests. No MessageRow or layout changes.