### PR TITLE
feat(docs): add document import/export with docx and markdown round-trip fixes

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -59,6 +59,7 @@
     "highlight.js": "^11.11.1",
     "jszip": "^3.10.1",
     "lowlight": "^3.3.0",
+    "markdown-it": "^14.1.1",
     "mathjax-full": "^3.2.2",
     "mathlive": "^0.104.0",
     "xlsx-js-style": "^1.2.0",
@@ -75,6 +76,7 @@
   "devDependencies": {
     "@testing-library/react": "16.1.0",
     "@types/node": "^22.19.21",
+    "@types/markdown-it": "^14.1.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^6.0.1",

--- a/packages/docs/src/attachments/api.ts
+++ b/packages/docs/src/attachments/api.ts
@@ -161,3 +161,74 @@ export async function uploadImage(docId: string, file: File): Promise<UploadedIm
   }
   return { attachId: presign.attachId, src }
 }
+
+/** A source attachment to copy into the target doc (its owning doc + durable attachId). */
+export interface CopySourceRef {
+  docId: string
+  attachId: string
+}
+
+/** One successful copy: source ref → new doc-scoped attachId + a freshly signed display URL. */
+export interface CopyMapping {
+  sourceDocId: string
+  sourceAttachId: string
+  attachId: string
+  url: string
+  mime: string
+  sizeBytes: number
+  fileName: string
+}
+
+export interface CopyResult {
+  mappings: CopyMapping[]
+  notCopied: Array<{ sourceDocId: string; sourceAttachId: string; reason: string }>
+}
+
+/**
+ * POST /docs/{docId}/attachments/copy — server-to-server copy of already-stored attachments
+ * into `docId`. Used by Markdown/PDF import to re-host images that reference another doc: the
+ * backend copies the bytes store-to-store (no signed-URL download in the browser, so it never
+ * expires) and enforces read permission on each source. Only attachments our service already
+ * stores are eligible — a foreign/external image has no source ref and is never sent here.
+ */
+export async function copyAttachments(
+  docId: string,
+  sources: CopySourceRef[],
+): Promise<CopyResult> {
+  const { data } = await apiClient().post<CopyResult>(
+    `/docs/${docId}/attachments/copy`,
+    { sources },
+  )
+  return { mappings: data.mappings ?? [], notCopied: data.notCopied ?? [] }
+}
+
+/** One successful external-image ingest: original URL → new doc-scoped attachId + display URL. */
+export interface IngestMapping {
+  sourceUrl: string
+  attachId: string
+  url: string
+  mime: string
+  sizeBytes: number
+}
+
+export interface IngestResult {
+  mappings: IngestMapping[]
+  notIngested: Array<{ sourceUrl: string; reason: string }>
+}
+
+/**
+ * POST /docs/{docId}/attachments/ingest — download EXTERNAL image URLs server-side (SSRF-guarded)
+ * and store them under `docId`. Used by Markdown/PDF import to re-host images that are not our
+ * own attachments, so the document does not break if the external host later disappears. On any
+ * failure the caller keeps the original URL (best-effort).
+ */
+export async function ingestAttachments(
+  docId: string,
+  urls: string[],
+): Promise<IngestResult> {
+  const { data } = await apiClient().post<IngestResult>(
+    `/docs/${docId}/attachments/ingest`,
+    { urls },
+  )
+  return { mappings: data.mappings ?? [], notIngested: data.notIngested ?? [] }
+}

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -26,6 +26,7 @@ import { getDoc, getUserName, updateDocTitle } from '../pages/docsApi.ts'
 import { startDocForward } from '../forward/startDocForward.ts'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { useAccessRequests } from '../access-request/useAccessRequests.ts'
+import { consumeImportContent, consumeImportWarnings, ImportContentCorruptError } from './importFlow.ts'
 import { DocTerminal } from './DocTerminal.tsx'
 import {
   DocMoreMenu,
@@ -297,6 +298,38 @@ export function EditorShell(props: EditorShellProps) {
       cancelled = true
     }
   }, [docId])
+
+  // Import injection (#import): when a doc was just created by a Markdown/Word import in DocsHome,
+  // the parsed ProseMirror document is stashed in sessionStorage keyed by docId. Once the editor
+  // is ready we drain the stash, inject it, then clear it. A corrupt stash (e.g. tampered
+  // sessionStorage) or non-fatal parse warnings surface as a dismissible notice instead of
+  // crashing the editor.
+  const [importNotice, setImportNotice] = useState<string | null>(null)
+  useEffect(() => {
+    const ed = instance?.editor
+    if (!ed || !ready) return
+    let pmDoc: unknown
+    try {
+      pmDoc = consumeImportContent(docId)
+    } catch (err) {
+      if (err instanceof ImportContentCorruptError) {
+        setImportNotice(t('docs.toolbar.importCorrupt'))
+      } else {
+        console.error('[docs] Import content read failed:', err)
+      }
+      return
+    }
+    if (!pmDoc) return
+    try {
+      ed.commands.setContent(pmDoc as never)
+    } catch (err) {
+      console.error('[docs] Import content injection failed:', err)
+      setImportNotice(t('docs.toolbar.importCorrupt'))
+      return
+    }
+    const warnings = consumeImportWarnings(docId)
+    if (warnings.length) setImportNotice(warnings.join(' '))
+  }, [instance, ready, docId, t])
 
   // uid → display name for this space (#8): once resolved, push the real name into awareness so
   // the presence avatar initial and the collaboration caret label show the name, not the uid.
@@ -718,6 +751,11 @@ export function EditorShell(props: EditorShellProps) {
       {exportError && (
         <p className="octo-member-error" role="alert">
           {exportError}
+        </p>
+      )}
+      {importNotice && (
+        <p className="octo-member-error" role="status" onClick={() => setImportNotice(null)}>
+          {importNotice}
         </p>
       )}
 

--- a/packages/docs/src/editor/importFlow.images.test.ts
+++ b/packages/docs/src/editor/importFlow.images.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the attachments API so migrateImportedImages re-hosts via the server-copy stub.
+const copyAttachments = vi.fn()
+const ingestAttachments = vi.fn()
+vi.mock('../attachments/api.ts', () => ({
+  copyAttachments: (...a: unknown[]) => copyAttachments(...a),
+  ingestAttachments: (...a: unknown[]) => ingestAttachments(...a),
+}))
+
+import { migrateImportedImages } from './importFlow.ts'
+
+// A signed export URL for a foreign doc: path carries the source doc + att_ id, query is a
+// short-lived signature. The editor would resolve this under the NEW doc's id and fail, so the
+// migrator must ask the backend to copy it under the new doc.
+const FOREIGN =
+  'http://localhost:28080/file/d_pdf_test_full/att_13a2f15faef2f55111bbfc69/222.png' +
+  '?X-Amz-Expires=600&X-Amz-Signature=***'
+
+// In real import output a block image is a top-level block (not wrapped in a paragraph). The
+// migrator mutates the image NODE in place — rewriting attachId/src on success, or replacing it
+// with a paragraph+link on external-ingest failure.
+function imageDoc(...srcs: string[]) {
+  return {
+    type: 'doc',
+    content: srcs.map((src) => ({ type: 'image', attrs: { src, attachId: 'att_13a2f15faef2f55111bbfc69' } })),
+  }
+}
+function firstImageNode(doc: { content: Array<Record<string, unknown>> }): Record<string, any> {
+  return doc.content[0]
+}
+
+/** Echo translator: returns the key plus its params so tests can assert both. */
+const echoT = (key: string, params?: Record<string, string | number>): string =>
+  params ? `${key} ${JSON.stringify(params)}` : key
+
+describe('migrateImportedImages', () => {
+  beforeEach(() => {
+    copyAttachments.mockReset()
+    ingestAttachments.mockReset()
+    ingestAttachments.mockResolvedValue({ mappings: [], notIngested: [] })
+  })
+
+  it('server-copies a foreign service image and rewrites its attachId + src to the new doc values', async () => {
+    copyAttachments.mockResolvedValue({
+      mappings: [
+        {
+          sourceDocId: 'd_pdf_test_full',
+          sourceAttachId: 'att_13a2f15faef2f55111bbfc69',
+          attachId: 'att_new123',
+          url: 'https://cdn/new.png?sig=fresh',
+          mime: 'image/png',
+          sizeBytes: 3,
+          fileName: '222.png',
+        },
+      ],
+      notCopied: [],
+    })
+
+    const doc = imageDoc(FOREIGN)
+    const warnings = await migrateImportedImages('d_new', doc)
+
+    expect(warnings).toEqual([])
+    // Sent exactly one source ref parsed from the URL path.
+    expect(copyAttachments).toHaveBeenCalledTimes(1)
+    const [docId, sources] = copyAttachments.mock.calls[0] as [string, Array<{ docId: string; attachId: string }>]
+    expect(docId).toBe('d_new')
+    expect(sources).toEqual([{ docId: 'd_pdf_test_full', attachId: 'att_13a2f15faef2f55111bbfc69' }])
+    const img = firstImageNode(doc)
+    expect(img.attrs.attachId).toBe('att_new123')
+    expect(img.attrs.src).toBe('https://cdn/new.png?sig=fresh')
+  })
+
+  it('de-dupes a repeated image into a single source ref and rewrites both nodes', async () => {
+    copyAttachments.mockResolvedValue({
+      mappings: [
+        {
+          sourceDocId: 'd_pdf_test_full',
+          sourceAttachId: 'att_13a2f15faef2f55111bbfc69',
+          attachId: 'att_shared',
+          url: 'https://cdn/shared.png',
+          mime: 'image/png',
+          sizeBytes: 1,
+          fileName: '222.png',
+        },
+      ],
+      notCopied: [],
+    })
+
+    const doc = imageDoc(FOREIGN, FOREIGN)
+    await migrateImportedImages('d_new', doc)
+
+    const [, sources] = copyAttachments.mock.calls[0] as [string, unknown[]]
+    expect(sources).toHaveLength(1)
+    expect(doc.content[0].attrs.attachId).toBe('att_shared')
+    expect(doc.content[1].attrs.attachId).toBe('att_shared')
+  })
+
+  it('server-ingests an external image and rewrites it to the new doc-scoped attachId', async () => {
+    ingestAttachments.mockResolvedValue({
+      mappings: [{ sourceUrl: 'https://example.com/pic.png', attachId: 'att_ext', url: 'https://cdn/ext.png', mime: 'image/png', sizeBytes: 9 }],
+      notIngested: [],
+    })
+    const doc = imageDoc('https://example.com/pic.png')
+    const warnings = await migrateImportedImages('d_new', doc)
+
+    expect(copyAttachments).not.toHaveBeenCalled()
+    expect(ingestAttachments).toHaveBeenCalledWith('d_new', ['https://example.com/pic.png'])
+    expect(warnings).toEqual([])
+    expect(firstImageNode(doc).attrs.attachId).toBe('att_ext')
+    expect(firstImageNode(doc).attrs.src).toBe('https://cdn/ext.png')
+  })
+
+  it('replaces a failed external image with a clickable link (no broken-image box) + one warning', async () => {
+    ingestAttachments.mockResolvedValue({
+      mappings: [],
+      notIngested: [{ sourceUrl: 'https://example.com/pic.png', reason: 'fetch_failed' }],
+    })
+    const doc = imageDoc('https://example.com/pic.png')
+    const warnings = await migrateImportedImages('d_new', doc, echoT)
+
+    expect(warnings).toEqual(['docs.import.externalImagesLinked'])
+    // The image node is now a paragraph carrying a link to the original URL (not an image).
+    const node = firstImageNode(doc)
+    expect(node.type).toBe('paragraph')
+    const textNode = (node.content as Array<Record<string, unknown>>)[0]
+    expect(textNode.type).toBe('text')
+    const marks = textNode.marks as Array<{ type: string; attrs: { href: string } }>
+    expect(marks[0].type).toBe('link')
+    expect(marks[0].attrs.href).toBe('https://example.com/pic.png')
+  })
+
+  it('uses the image alt as the link text when present, else the URL', async () => {
+    ingestAttachments.mockResolvedValue({ mappings: [], notIngested: [{ sourceUrl: 'https://x/y.png', reason: 'fetch_failed' }] })
+    const doc = { type: 'doc', content: [{ type: 'image', attrs: { src: 'https://x/y.png', alt: '图说明' } }] }
+    await migrateImportedImages('d_new', doc)
+    const node = doc.content[0] as Record<string, unknown>
+    const textNode = (node.content as Array<Record<string, unknown>>)[0]
+    expect(textNode.text).toBe('图说明')
+  })
+
+  it('turns EVERY external image into a link when the ingest request itself fails', async () => {
+    ingestAttachments.mockRejectedValue(new Error('network'))
+    const doc = imageDoc('https://example.com/pic.png')
+    const warnings = await migrateImportedImages('d_new', doc, echoT)
+    expect(warnings).toEqual(['docs.import.externalImagesLinked'])
+    expect(firstImageNode(doc).type).toBe('paragraph')
+  })
+
+  it('surfaces a warning for a source the backend could not copy (best-effort, no throw)', async () => {
+    copyAttachments.mockResolvedValue({
+      mappings: [],
+      notCopied: [{ sourceDocId: 'd_pdf_test_full', sourceAttachId: 'att_13a2f15faef2f55111bbfc69', reason: 'source_forbidden' }],
+    })
+
+    const doc = imageDoc(FOREIGN)
+    const warnings = await migrateImportedImages('d_new', doc, echoT)
+
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('docs.import.imageMigrateFailed')
+    expect(warnings[0]).toContain('source_forbidden')
+    // A copy failure keeps the original (short-lived signed) src so the image may still render
+    // briefly, but the FOREIGN attachId is stripped: leaving it would make ImageNodeView
+    // forever re-issue a doomed getReadUrl under the new doc once the src expires (permanent
+    // broken-image box). Stripping it degrades to a plain src render instead.
+    expect(firstImageNode(doc).attrs.src).toBe(FOREIGN)
+    expect('attachId' in firstImageNode(doc).attrs).toBe(false)
+  })
+
+  it('degrades to a single warning when the copy request itself fails', async () => {
+    copyAttachments.mockRejectedValue(new Error('network'))
+    const doc = imageDoc(FOREIGN)
+    const warnings = await migrateImportedImages('d_new', doc)
+    expect(warnings.length).toBe(1)
+  })
+
+  it('is a no-op for a doc with no images', async () => {
+    const doc = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }] }
+    const warnings = await migrateImportedImages('d_new', doc)
+    expect(warnings).toEqual([])
+    expect(copyAttachments).not.toHaveBeenCalled()
+  })
+
+  it('does not crash on a service-shaped URL with a malformed percent-escape in the doc-id segment', async () => {
+    // Imported .md is arbitrary user input. A service-shaped image URL whose doc-id
+    // segment carries a bad %-sequence used to reach an unguarded decodeURIComponent
+    // and throw URIError, aborting the whole migration and orphaning the new doc.
+    // It must degrade like any other non-service image (skip service copy) instead.
+    ingestAttachments.mockResolvedValue({ mappings: [], notIngested: [] })
+    const BAD = 'http://localhost:28080/file/bad%ZZname/att_abc123/pic.png?X-Amz-Signature=x'
+    const doc = imageDoc(BAD)
+    const warnings = await migrateImportedImages('d_new', doc, echoT)
+    // No throw; not treated as a copyable service image.
+    expect(copyAttachments).not.toHaveBeenCalled()
+    // Falls through to the external-image path (best-effort ingest by URL).
+    expect(ingestAttachments).toHaveBeenCalledWith('d_new', [BAD])
+    expect(Array.isArray(warnings)).toBe(true)
+  })
+})

--- a/packages/docs/src/editor/importFlow.ts
+++ b/packages/docs/src/editor/importFlow.ts
@@ -1,0 +1,487 @@
+// Import flow: file picker → parse Markdown → create new doc → navigate → inject content.
+//
+// Design doc §5 (方案 A1 + B1): user picks a .md file, we parse it to PM JSON,
+// create a new empty doc via REST, stash the PM JSON in sessionStorage keyed by docId,
+// then navigate to the new doc. EditorShell picks up the stashed content on mount and
+// injects it via setContent once the editor is ready.
+
+import { parseMarkdownToPmDoc } from '../import/markdown.ts'
+import { createDoc, importDocx } from '../pages/docsApi.ts'
+import { copyAttachments, ingestAttachments, type CopySourceRef } from '../attachments/api.ts'
+import { emojiGlyph } from './emoji.ts'
+
+const IMPORT_KEY_PREFIX = 'octo-import-pm-'
+const IMPORT_WARN_PREFIX = 'octo-import-warn-'
+
+/** Stash parsed PM JSON for a newly-created doc so EditorShell can pick it up on mount. */
+export function stashImportContent(docId: string, pmDoc: unknown): void {
+  try {
+    sessionStorage.setItem(IMPORT_KEY_PREFIX + docId, JSON.stringify(pmDoc))
+  } catch {
+    // sessionStorage full or unavailable — non-fatal; user just won't get auto-inject
+  }
+}
+
+/** Stash import warnings so the destination EditorShell can surface them after navigation. */
+export function stashImportWarnings(docId: string, warnings: string[]): void {
+  if (!warnings.length) return
+  try {
+    sessionStorage.setItem(IMPORT_WARN_PREFIX + docId, JSON.stringify(warnings))
+  } catch {
+    // non-fatal — warnings just won't surface after navigation
+  }
+}
+
+/** Retrieve and clear stashed import warnings for a doc. Returns [] when none/invalid. */
+export function consumeImportWarnings(docId: string): string[] {
+  const key = IMPORT_WARN_PREFIX + docId
+  let raw: string | null
+  try {
+    raw = sessionStorage.getItem(key)
+    if (raw) sessionStorage.removeItem(key)
+  } catch {
+    return []
+  }
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) return parsed.filter((w): w is string => typeof w === 'string')
+  } catch {
+    // ignore
+  }
+  return []
+}
+
+/**
+ * Retrieve and clear stashed import content for a doc.
+ * Returns the validated PM doc, or null if none. Throws `ImportContentCorruptError`
+ * when a stash entry exists but fails schema validation (sessionStorage is user-controlled
+ * via DevTools, so a hostile/garbled payload must not reach editor.setContent unchecked).
+ */
+export function consumeImportContent(docId: string): PmDoc | null {
+  const key = IMPORT_KEY_PREFIX + docId
+  let raw: string | null
+  try {
+    raw = sessionStorage.getItem(key)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+  // Always clear the stash, even on a bad payload, so a corrupt entry can't wedge the doc.
+  try {
+    sessionStorage.removeItem(key)
+  } catch {
+    // ignore — non-fatal
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new ImportContentCorruptError('stashed import content is not valid JSON')
+  }
+  if (!isValidPmDoc(parsed)) {
+    throw new ImportContentCorruptError('stashed import content is not a valid document')
+  }
+  return parsed
+}
+
+/** Raised when stashed import content exists but is malformed; caller shows a user-facing notice. */
+export class ImportContentCorruptError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ImportContentCorruptError'
+  }
+}
+
+interface PmDoc {
+  type: 'doc'
+  content: unknown[]
+}
+
+/**
+ * Structural validation for a stashed ProseMirror document. This is a shallow shape gate
+ * (root is a `doc` with a `content` array of plain node objects that each carry a string
+ * `type`); the editor's schema still rejects unknown node types on setContent. The goal here
+ * is only to keep obviously-hostile / corrupt sessionStorage payloads out of setContent.
+ */
+function isValidPmDoc(value: unknown): value is PmDoc {
+  if (typeof value !== 'object' || value === null) return false
+  const doc = value as Record<string, unknown>
+  if (doc.type !== 'doc') return false
+  if (!Array.isArray(doc.content)) return false
+  return doc.content.every(isPlainNode)
+}
+
+function isPlainNode(node: unknown): boolean {
+  if (typeof node !== 'object' || node === null) return false
+  const n = node as Record<string, unknown>
+  if (typeof n.type !== 'string' || !n.type) return false
+  if ('content' in n && n.content !== undefined) {
+    if (!Array.isArray(n.content)) return false
+    if (!n.content.every(isPlainNode)) return false
+  }
+  return true
+}
+
+export interface ImportResult {
+  docId: string
+  title: string
+  warnings: string[]
+}
+
+/**
+ * Run the full import flow: pick file → parse → create doc → stash content.
+ * Caller navigates to result.docId after this resolves.
+ */
+/** Translator type threaded from the calling React component (has useTranslation). */
+type Translate = (key: string, params?: Record<string, string | number>) => string
+
+/** Resolve an i18n key via the optional translator, falling back to the key. */
+function tr(t: Translate | undefined, key: string, params?: Record<string, string | number>): string {
+  return t ? t(key, params) : key
+}
+
+export async function runMarkdownImport(
+  spaceId?: string,
+  folderId?: string,
+  t?: Translate,
+): Promise<ImportResult> {
+  // 1. File picker
+  const { text, fileName } = await pickMdFile(t)
+
+  // 1b. Extension guard. `input.accept` is only a UI hint (the OS dialog still lets the user pick
+  // "all files"), so reject anything that is not a Markdown file here — this import path is for
+  // Markdown only, not arbitrary .txt/plain text.
+  if (!/\.(md|markdown)$/i.test(fileName)) {
+    throw new Error(tr(t, 'docs.import.mdOnly'))
+  }
+
+  // 2. Parse (emojiName resolves `:shortcode:` against the editor's bundled GitHub emoji set;
+  // unknown shortcodes stay literal text rather than becoming blank emoji nodes).
+  const parsed = parseMarkdownToPmDoc(text, { emojiName: emojiGlyph, t })
+
+  // 3. Determine title. Use the file name (matching the .docx import), so the sidebar label is
+  // always the imported file's name rather than the document's first heading.
+  const title = stripExtension(fileName) || 'Imported document'
+
+  // 4. Create new doc
+  const created = await createDoc({ title, spaceId, folderId })
+
+  // 4b. Migrate imported images into the NEW doc. The parsed image nodes still point at the
+  // SOURCE doc's attachId + a short-lived signed URL. The editor resolves an image's URL with
+  // the CURRENT doc's id (getReadUrl(thisDoc, attachId)), so a foreign attachId never resolves
+  // and the image renders blank once the signed src expires. Re-upload each image under the new
+  // doc so it gets a doc-scoped attachId the editor can re-sign. Best-effort: an image that
+  // can't be fetched/re-uploaded degrades to a warning instead of blocking the whole import.
+  const migrateWarnings = await migrateImportedImages(created.docId, parsed.doc, t)
+
+  // 5. Stash content + warnings for EditorShell to pick up after navigation
+  stashImportContent(created.docId, parsed.doc)
+  stashImportWarnings(created.docId, [...parsed.warnings, ...migrateWarnings])
+
+  return {
+    docId: created.docId,
+    title,
+    warnings: [...parsed.warnings, ...migrateWarnings],
+  }
+}
+
+/**
+ * Re-host every image that our own service already stores under `newDocId`, using a server-side
+ * store-to-store copy. The parsed image nodes still point at the SOURCE doc's attachId + a
+ * short-lived signed URL; the editor resolves an image's URL with the CURRENT doc's id
+ * (getReadUrl(thisDoc, attachId)), so a foreign attachId never resolves and the image renders
+ * blank once the signed src expires. We ask the backend to copy the bytes store-to-store (it
+ * never depends on the expiring signed URL) and rewrite each node's attachId/src to the new
+ * doc-scoped values.
+ *
+ * Re-host every image an imported document references so it survives under the new doc:
+ *   - OUR-SERVICE images (src path `/file/<docId>/att_<id>/`) are copied store-to-store by the
+ *     backend (`copyAttachments`) — never depends on the expiring signed URL.
+ *   - EXTERNAL images (any other http(s) URL) are downloaded + stored server-side
+ *     (`ingestAttachments`, SSRF-guarded) so the doc does not break if the host later 404s; if
+ *     ingest fails the node KEEPS its original URL (best-effort) so it still shows while reachable.
+ * Both rewrite each node's attachId/src to the new doc-scoped values. Non-http(s) srcs (already
+ * degraded to text markers upstream) are ignored. Returns non-fatal warnings. Exported for tests.
+ */
+export async function migrateImportedImages(
+  newDocId: string,
+  doc: unknown,
+  t?: Translate,
+): Promise<string[]> {
+  const images: Array<Record<string, unknown>> = []
+  collectImageNodes(doc, images)
+  if (images.length === 0) return []
+
+  // Split image nodes into our-service (by source ref) vs external (by URL), de-duped. We keep
+  // the NODE objects (not just attrs) so a failed external image can be transformed into a link.
+  const byRef = new Map<string, { ref: CopySourceRef; nodes: Array<Record<string, unknown>> }>()
+  const byUrl = new Map<string, Array<Record<string, unknown>>>()
+  for (const node of images) {
+    const attrs = (node.attrs ?? {}) as Record<string, unknown>
+    const src = typeof attrs.src === 'string' ? attrs.src : ''
+    if (!/^https?:\/\//i.test(src)) continue // local/data/relative: already degraded upstream
+    const ref = parseServiceImageRef(src)
+    if (ref) {
+      const key = `${ref.docId}\u0000${ref.attachId}`
+      const entry = byRef.get(key)
+      if (entry) entry.nodes.push(node)
+      else byRef.set(key, { ref, nodes: [node] })
+    } else {
+      const list = byUrl.get(src)
+      if (list) list.push(node)
+      else byUrl.set(src, [node])
+    }
+  }
+
+  const warnings: string[] = []
+
+  // 1) Our-service images → server-to-server copy.
+  if (byRef.size > 0) {
+    const copiedRefs = new Set<string>()
+    try {
+      const result = await copyAttachments(newDocId, [...byRef.values()].map((e) => e.ref))
+      for (const m of result.mappings) {
+        const key = `${m.sourceDocId}\u0000${m.sourceAttachId}`
+        const entry = byRef.get(key)
+        if (!entry) continue
+        copiedRefs.add(key)
+        for (const node of entry.nodes) {
+          const attrs = (node.attrs ?? {}) as Record<string, unknown>
+          attrs.attachId = m.attachId
+          if (m.url) attrs.src = m.url
+          node.attrs = attrs
+        }
+      }
+      for (const nc of result.notCopied)
+        warnings.push(tr(t, 'docs.import.imageMigrateFailed', { reason: nc.reason }))
+    } catch {
+      warnings.push(tr(t, 'docs.import.imagesMigratePartial'))
+    }
+    // Any our-service image that was NOT copied under the new doc keeps a FOREIGN attachId,
+    // which ImageNodeView.resolveFromAttach would forever try to resolve under the new doc
+    // (a doomed getReadUrl re-issued on every render) once the short-lived signed src expires.
+    // Strip the useless foreign attachId so the NodeView degrades to a plain src render instead
+    // of a permanently broken image box.
+    for (const [key, entry] of byRef) {
+      if (copiedRefs.has(key)) continue
+      for (const node of entry.nodes) {
+        const attrs = (node.attrs ?? {}) as Record<string, unknown>
+        if ('attachId' in attrs) delete attrs.attachId
+        node.attrs = attrs
+      }
+    }
+  }
+
+  // 2) External images → server-side download + store. On success rewrite to the stored
+  //    attachment; on failure REPLACE the broken image node with a clickable link to the
+  //    original URL (no red "Image unavailable" box), plus one top-level warning.
+  if (byUrl.size > 0) {
+    const succeeded = new Set<string>()
+    try {
+      const result = await ingestAttachments(newDocId, [...byUrl.keys()])
+      for (const m of result.mappings) {
+        succeeded.add(m.sourceUrl)
+        const nodes = byUrl.get(m.sourceUrl)
+        if (!nodes) continue
+        for (const node of nodes) {
+          const attrs = (node.attrs ?? {}) as Record<string, unknown>
+          attrs.attachId = m.attachId
+          if (m.url) attrs.src = m.url
+          node.attrs = attrs
+        }
+      }
+    } catch {
+      // Request-level failure: nothing succeeded; every external image falls through to link.
+    }
+    // Any external image not successfully ingested → turn into a clickable link so it never
+    // renders a broken-image box. The document keeps a live reference to the original URL.
+    let anyFailed = false
+    for (const [url, nodes] of byUrl) {
+      if (succeeded.has(url)) continue
+      anyFailed = true
+      for (const node of nodes) imageNodeToLink(node, url)
+    }
+    if (anyFailed) warnings.push(tr(t, 'docs.import.externalImagesLinked'))
+  }
+
+  return warnings
+}
+
+/**
+ * Transform a (block) image node in place into a paragraph containing a clickable link to the
+ * original URL. Used when an external image can't be downloaded: instead of a broken-image box
+ * the reader gets a live link. The link text is the image alt, else the URL.
+ */
+function imageNodeToLink(node: Record<string, unknown>, url: string): void {
+  const attrs = (node.attrs ?? {}) as Record<string, unknown>
+  const alt = typeof attrs.alt === 'string' && attrs.alt.trim() !== '' ? attrs.alt : url
+  node.type = 'paragraph'
+  node.attrs = {}
+  node.content = [
+    {
+      type: 'text',
+      text: alt,
+      marks: [{ type: 'link', attrs: { href: url } }],
+    },
+  ]
+}
+
+/**
+ * Parse a service storage URL into its source ref. Our exporter emits image src as a signed URL
+ * whose path is `/file/<docId>/att_<id>/<name>?<signature>`. Returns { docId, attachId } when the
+ * path matches that shape, else null (external image → not migrated). Requires BOTH the doc id
+ * segment and the `att_` id so a random URL that merely contains `att_` is not misread.
+ */
+function parseServiceImageRef(src: string): CopySourceRef | null {
+  if (!/^https?:\/\//i.test(src)) return null
+  let pathname: string
+  try {
+    pathname = new URL(src).pathname
+  } catch {
+    return null
+  }
+  const m = /\/file\/([^/]+)\/(att_[A-Za-z0-9]+)(?:\/|$)/.exec(pathname)
+  if (!m) return null
+  // decodeURIComponent throws URIError on a malformed %-sequence. The imported
+  // doc is arbitrary user input, so a service-shaped URL with a bad escape in
+  // the doc-id segment must degrade to "skip this image" (like the new URL guard
+  // above), not abort the whole migration and orphan the freshly-created doc.
+  let docId: string
+  try {
+    docId = decodeURIComponent(m[1]!)
+  } catch {
+    return null
+  }
+  return { docId, attachId: m[2]! }
+}
+
+/** Depth-first collect every image node's attrs object (mutated in place by the migrator). */
+/** Depth-first collect every image NODE object (mutated in place by the migrator). */
+function collectImageNodes(node: unknown, out: Array<Record<string, unknown>>): void {
+  if (typeof node !== 'object' || node === null) return
+  const n = node as Record<string, unknown>
+  if (n.type === 'image') out.push(n)
+  if (Array.isArray(n.content)) for (const c of n.content) collectImageNodes(c, out)
+}
+
+/**
+ * Run the full .docx import flow: pick file → create an empty doc → POST the file
+ * to the server-side importer → stash the returned ProseMirror JSON. Unlike the
+ * Markdown flow (which parses client-side), docx parsing + image upload happen
+ * on the server, so we must create the doc FIRST to get a docId that scopes the
+ * uploaded image attachments. Caller navigates to result.docId after this
+ * resolves; EditorShell drains the stash on mount.
+ */
+export async function runDocxImport(
+  spaceId?: string,
+  folderId?: string,
+  t?: Translate,
+): Promise<ImportResult> {
+  // 1. File picker
+  const { file, fileName } = await pickDocxFile(t)
+
+  // 2. Create the destination doc first (its id scopes server-side image uploads).
+  const title = stripDocxExtension(fileName) || 'Imported document'
+  const created = await createDoc({ title, spaceId, folderId })
+
+  // 3. Server parses the .docx to ProseMirror JSON and uploads embedded images.
+  const { doc, warnings } = await importDocx(created.docId, file)
+
+  // 4. Stash content + warnings for EditorShell to pick up after navigation.
+  stashImportContent(created.docId, doc)
+  stashImportWarnings(created.docId, warnings)
+
+  return {
+    docId: created.docId,
+    title,
+    warnings,
+  }
+}
+
+// ── File picker ───────────────────────────────────────────────────────────────
+
+interface PickedFile {
+  text: string
+  fileName: string
+}
+
+/**
+ * Open a native file picker and read the chosen file as UTF-8 text. Resolves with both the
+ * text and its file name so the caller never depends on module-level mutable state (which
+ * would race when the user triggers two imports in quick succession — the second pick would
+ * clobber the first's file name and both docs would take the same title).
+ */
+function pickMdFile(t?: Translate): Promise<PickedFile> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.md,.markdown'
+    input.style.display = 'none'
+
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (!file) { reject(new Error(tr(t, 'docs.import.noFileChosen'))); cleanup(); return }
+      const fileName = file.name
+      const reader = new FileReader()
+      reader.onload = () => resolve({ text: reader.result as string, fileName })
+      reader.onerror = () => reject(new Error(tr(t, 'docs.import.fileReadFailed')))
+      reader.readAsText(file, 'UTF-8')
+      cleanup()
+    }
+
+    input.oncancel = () => { reject(new Error(tr(t, 'docs.import.cancelled'))); cleanup() }
+
+    const cleanup = () => {
+      setTimeout(() => input.remove(), 100)
+    }
+
+    document.body.appendChild(input)
+    input.click()
+  })
+}
+
+function stripExtension(name: string): string {
+  return name.replace(/\.(md|markdown|txt|text)$/i, '')
+}
+
+interface PickedDocxFile {
+  file: File
+  fileName: string
+}
+
+/**
+ * Open a native file picker for a single .docx file and hand back the raw File (the bytes are
+ * uploaded to the server importer, so we never read them client-side). Resolves with the file
+ * and its name so the caller derives the doc title without relying on module-level state.
+ */
+function pickDocxFile(t?: Translate): Promise<PickedDocxFile> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept =
+      '.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    input.style.display = 'none'
+
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (!file) { reject(new Error(tr(t, 'docs.import.noFileChosen'))); cleanup(); return }
+      resolve({ file, fileName: file.name })
+      cleanup()
+    }
+
+    input.oncancel = () => { reject(new Error(tr(t, 'docs.import.cancelled'))); cleanup() }
+
+    const cleanup = () => {
+      setTimeout(() => input.remove(), 100)
+    }
+
+    document.body.appendChild(input)
+    input.click()
+  })
+}
+
+function stripDocxExtension(name: string): string {
+  return name.replace(/\.docx$/i, '')
+}
+

--- a/packages/docs/src/export/docx/marks.test.ts
+++ b/packages/docs/src/export/docx/marks.test.ts
@@ -93,3 +93,36 @@ describe('buildRunOptionsFromMarks — fontFamily', () => {
     expect(a).not.toBe('Arial')
   })
 })
+
+// The editor's Highlight extension is multicolor: the chosen background rides on
+// the mark's `color` attr. Word's `w:highlight` only supports ~16 named colours,
+// so an arbitrary hex is emitted as `w:shd` (shading fill) instead, which the
+// importer reads back verbatim for a lossless round-trip.
+describe('buildRunOptionsFromMarks — highlight colour', () => {
+  it('emits an arbitrary highlight colour as a shading fill (not w:highlight)', () => {
+    const opts = buildRunOptionsFromMarks([
+      { type: 'highlight', attrs: { color: '#00FFCC' } },
+    ])
+    expect(opts.shading).toEqual({ type: 'clear', color: 'auto', fill: '00ffcc' })
+    expect(opts.highlight).toBeUndefined()
+  })
+
+  it('normalises rgb()/short-hex highlight colours to 6-hex fill', () => {
+    expect(
+      buildRunOptionsFromMarks([{ type: 'highlight', attrs: { color: 'rgb(255, 0, 0)' } }])
+        .shading,
+    ).toEqual({ type: 'clear', color: 'auto', fill: 'ff0000' })
+    expect(
+      buildRunOptionsFromMarks([{ type: 'highlight', attrs: { color: '#fc0' } }]).shading,
+    ).toEqual({ type: 'clear', color: 'auto', fill: 'ffcc00' })
+  })
+
+  it('falls back to a named yellow highlight when no usable colour is present', () => {
+    expect(buildRunOptionsFromMarks([{ type: 'highlight' }]).highlight).toBe('yellow')
+    // An unmappable colour (e.g. hsl) also degrades to the yellow fallback.
+    expect(
+      buildRunOptionsFromMarks([{ type: 'highlight', attrs: { color: 'hsl(0,100%,50%)' } }])
+        .highlight,
+    ).toBe('yellow')
+  })
+})

--- a/packages/docs/src/export/docx/marks.ts
+++ b/packages/docs/src/export/docx/marks.ts
@@ -4,7 +4,7 @@
  * highlight, textStyle, subscript, superscript) into docx TextRun options.
  */
 
-import { type IRunOptions, ExternalHyperlink, TextRun, UnderlineType, type ParagraphChild } from 'docx'
+import { type IRunOptions, ExternalHyperlink, TextRun, UnderlineType, ShadingType, type ParagraphChild } from 'docx'
 import { FONT_CODE, FONT_EMOJI } from './styles.ts'
 import { isSafeHref } from './href-safety.ts'
 import { latexToMathComponent } from './math.ts'
@@ -139,8 +139,21 @@ export function buildRunOptionsFromMarks(marks: MarkDef[]): IRunOptions {
         opts.underline = { type: UnderlineType.SINGLE }
         break
       case 'highlight': {
-        // docx highlight only supports named colors; use yellow as default
-        opts.highlight = 'yellow'
+        // The editor's Highlight extension is multicolor: the chosen background
+        // rides on the mark's `color` attr (any CSS colour, usually #rrggbb).
+        // Word's `w:highlight` only accepts ~16 named colours, so it cannot carry
+        // an arbitrary hex losslessly. Emit `w:shd` (shading) with the exact hex
+        // fill instead — that renders the true background and round-trips 1:1
+        // through the importer (which reads w:shd/@w:fill back into the mark).
+        // Fall back to a plain yellow highlight when no usable colour is present.
+        const hl = mark.attrs?.color
+        const hlHex =
+          typeof hl === 'string' && hl ? normalizeDocxColor(hl) : null
+        if (hlHex) {
+          opts.shading = { type: ShadingType.CLEAR, color: 'auto', fill: hlHex }
+        } else {
+          opts.highlight = 'yellow'
+        }
         break
       }
       case 'textStyle': {

--- a/packages/docs/src/export/docx/math.test.ts
+++ b/packages/docs/src/export/docx/math.test.ts
@@ -62,6 +62,27 @@ describe('latexToMathComponent (unit)', () => {
     expect(latexToMathComponent('   ', false)).toBeNull()
   })
 
+  // Regression: these previously errored in MathJax (color package missing /
+  // non-standard command) and degraded to raw LaTeX text runs, which imported
+  // back as red literal LaTeX. They must now produce real OMML components.
+  it('converts \\color / \\textcolor to a real math component (not text fallback)', () => {
+    expect(latexToMathComponent('\\color{red} E = mc^2', true)).not.toBeNull()
+    expect(latexToMathComponent('\\textcolor{blue}{\\frac{1}{2}} + F = ma', true)).not.toBeNull()
+  })
+
+  it('converts \\hdots (mapped to \\dots) to a real math component', () => {
+    expect(latexToMathComponent('a_1 \\le a_2 \\le \\hdots \\le a_n', true)).not.toBeNull()
+  })
+
+  it('converts a piecewise cases / matrix to a real math component', () => {
+    expect(
+      latexToMathComponent(
+        'f(x)=\\left\\{\\begin{matrix} x^{2} & x \\geq 0 \\\\ -x & x<0 \\end{matrix}\\right.',
+        true,
+      ),
+    ).not.toBeNull()
+  })
+
   it('produced component serializes to an <m:oMath> element', () => {
     // A component placed in a paragraph must serialize as real OMML markup.
     const comp = latexToMathComponent('E = mc^2', true)!
@@ -330,5 +351,31 @@ describe('inline math end-to-end docx export', () => {
     // No LaTeX leaked as fallback text.
     expect(xml).not.toContain('\\overset')
     expect(xml).not.toContain('\\xrightarrow')
+  })
+
+  it('renders \\binom as a no-bar OMML fraction (no spurious horizontal line)', async () => {
+    // Regression: \binom came through as <mfrac linethickness="0"> but the
+    // exporter emitted a normal <m:f>, adding a fraction bar on round-trip
+    // ("41 本来没有横线怎么多了横线"). It must carry <m:type m:val="noBar"/>.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\binom{n}{x}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    expect(xml).toContain('<m:type m:val="noBar"/>')
+    expect(xml).toContain('<m:f>')
+  })
+
+  it('renders wide accents (\\overrightarrow \\widehat) as stretchy <m:groupChr>, not narrow <m:acc>', async () => {
+    // Regression: \overrightarrow{AB} / \widehat{ABC} exported as a narrow
+    // <m:acc> combining mark, shrinking the accent and spacing the letters
+    // ("21 abc 太小"). A stretchy accent over a multi-char base must be a
+    // <m:groupChr> that spans the base.
+    const doc: MdNode[] = [
+      { type: 'blockMath', attrs: { latex: '\\overrightarrow{AB}, \\widehat{ABC}' } },
+    ] as MdNode[]
+    const xml = await renderDocumentXml(doc)
+    // Two stretchy group chars (arrow + hat); no narrow accent for the wide ones.
+    expect((xml.match(/<m:groupChr>/g) ?? []).length).toBeGreaterThanOrEqual(2)
+    expect(xml).toContain('m:val="\u2192"') // stretchy right arrow over AB
   })
 })

--- a/packages/docs/src/export/docx/math.ts
+++ b/packages/docs/src/export/docx/math.ts
@@ -46,6 +46,10 @@ import type { MmlNode } from 'mathjax-full/js/core/MmlTree/MmlNode.js'
 // degrades to raw LaTeX source text in Word. The import wires up the extension.
 import 'mathjax-full/js/input/tex/base/BaseConfiguration.js'
 import 'mathjax-full/js/input/tex/ams/AmsConfiguration.js'
+// Registers the `color` TeX package so `\color{…}` / `\textcolor{…}{…}` compile
+// to `<mstyle mathcolor>` instead of failing with "Undefined control sequence"
+// and degrading the whole formula to raw LaTeX source text in Word.
+import 'mathjax-full/js/input/tex/color/ColorConfiguration.js'
 import { mathmlToOmml } from './mathml-to-omml.ts'
 
 /** LaTeX → MathML converter, or null if MathJax failed to initialize. */
@@ -69,7 +73,9 @@ function getConverter(): MathMLConverter | null {
   try {
     const adaptor = liteAdaptor()
     RegisterHTMLHandler(adaptor)
-    const tex = new TeX({ packages: ['base', 'ams'] })
+    // `color` covers \color/\textcolor so they compile to `<mstyle mathcolor>`
+    // instead of erroring and degrading the whole formula to raw source text.
+    const tex = new TeX({ packages: ['base', 'ams', 'color'] })
     const doc = mathjax.document('', { InputJax: tex })
     const visitor = new SerializedMmlVisitor()
     converter = (latex: string, display: boolean): string => {
@@ -92,8 +98,22 @@ function getConverter(): MathMLConverter | null {
  * @returns the math component, or null if conversion failed (caller should
  *          fall back to rendering the raw source text)
  */
+/**
+ * Rewrite a few non-standard TeX commands seen in real source data onto their
+ * standard equivalents so MathJax compiles them instead of emitting an
+ * `<merror>` (which forces the whole formula to degrade to raw LaTeX text in
+ * Word). Kept intentionally small and exact so it never mangles valid input.
+ *   - `\hdots` is not a real LaTeX command; treat it as `\dots`.
+ */
+function normalizeSourceLatex(src: string): string {
+  if (!src) return src
+  // Replace \hdots only when it is a complete command token (followed by a
+  // non-letter or end of string), so we never touch a longer macro name.
+  return src.replace(/\\hdots(?![a-zA-Z])/g, '\\dots')
+}
+
 export function latexToMathComponent(latex: string, display: boolean): ParagraphChild | null {
-  const src = typeof latex === 'string' ? latex.trim() : ''
+  const src = normalizeSourceLatex(typeof latex === 'string' ? latex.trim() : '')
   if (!src) return null
 
   const convert = getConverter()

--- a/packages/docs/src/export/docx/mathml-to-omml.ts
+++ b/packages/docs/src/export/docx/mathml-to-omml.ts
@@ -115,9 +115,38 @@ function escAttr(s: string): string {
   return escXml(s).replace(/"/g, '&quot;')
 }
 
-/** A plain math run carrying literal text. */
+/**
+ * Current math text color (a 6-hex RRGGBB string) while converting inside an
+ * `<mstyle mathcolor>` subtree, or null. OMML has no subtree color wrapper, so
+ * we thread it down and stamp each run's `<m:rPr>`, which is how Word carries
+ * math run color. A stack supports nested/overriding color scopes.
+ */
+const colorStack: string[] = []
+function currentColor(): string | null {
+  return colorStack.length ? colorStack[colorStack.length - 1]! : null
+}
+
+/** Normalize a MathML color (name or #hex) to a 6-hex RRGGBB, or null. */
+function normalizeColor(raw: string | undefined): string | null {
+  if (!raw) return null
+  const v = raw.trim().toLowerCase()
+  const NAMES: Record<string, string> = {
+    red: 'FF0000', blue: '0000FF', green: '008000', black: '000000',
+    white: 'FFFFFF', yellow: 'FFFF00', orange: 'FFA500', purple: '800080',
+    gray: '808080', grey: '808080', cyan: '00FFFF', magenta: 'FF00FF',
+  }
+  if (NAMES[v]) return NAMES[v]
+  const hex = v.replace(/^#/, '')
+  if (/^[0-9a-f]{6}$/.test(hex)) return hex.toUpperCase()
+  if (/^[0-9a-f]{3}$/.test(hex)) return hex.split('').map((c) => c + c).join('').toUpperCase()
+  return null
+}
+
+/** A plain math run carrying literal text (with the active color, if any). */
 function run(text: string): string {
-  return `<m:r><m:t xml:space="preserve">${escXml(text)}</m:t></m:r>`
+  const color = currentColor()
+  const rPr = color ? `<m:rPr><w:color w:val="${color}"/></m:rPr>` : ''
+  return `<m:r>${rPr}<m:t xml:space="preserve">${escXml(text)}</m:t></m:r>`
 }
 
 function sSup(base: Element, sup: Element): string {
@@ -132,8 +161,12 @@ function sSubSup(base: Element, sub: Element, sup: Element): string {
   return `<m:sSubSup><m:sSubSupPr><m:ctrlPr/></m:sSubSupPr><m:e>${convertNode(base)}</m:e><m:sub>${convertNode(sub)}</m:sub><m:sup>${convertNode(sup)}</m:sup></m:sSubSup>`
 }
 
-function frac(num: Element, den: Element): string {
-  return `<m:f><m:fPr><m:ctrlPr/></m:fPr><m:num>${convertNode(num)}</m:num><m:den>${convertNode(den)}</m:den></m:f>`
+function frac(num: Element, den: Element, noBar = false): string {
+  // A zero line-thickness fraction is a binomial-style stack (\binom): OMML
+  // represents it with `<m:type m:val="noBar"/>`. Without this the bar shows up
+  // as a spurious horizontal line on round-trip.
+  const typeProp = noBar ? '<m:type m:val="noBar"/>' : ''
+  return `<m:f><m:fPr>${typeProp}<m:ctrlPr/></m:fPr><m:num>${convertNode(num)}</m:num><m:den>${convertNode(den)}</m:den></m:f>`
 }
 
 /** √ with hidden (empty) degree. */
@@ -182,6 +215,32 @@ const ACCENT_CHARS: Record<string, string> = {
 function accentChar(over: Element | undefined): string | undefined {
   if (!over || over.name !== 'mo') return undefined
   return ACCENT_CHARS[textOf(over).trim()]
+}
+
+/**
+ * True when an accent `<mo>` is stretchy (wide). MathJax marks NARROW accents
+ * (\hat \vec over a single token) with `stretchy="false"`; the WIDE variants
+ * (\overrightarrow \widehat \widetilde over a multi-token base) omit it and are
+ * stretchy by default. Stretchy accents must become a `<m:groupChr>` so the mark
+ * spans the whole base instead of shrinking to a centered combining glyph.
+ */
+function isStretchyAccent(over: Element | undefined): boolean {
+  if (!over || over.name !== 'mo') return false
+  return over.attributes?.stretchy !== 'false'
+}
+
+/**
+ * Combining accent → the stretchy glyph OMML uses for its WIDE form in
+ * `<m:groupChr>`. Only accents that have a genuine wide TeX variant appear here
+ * (\overrightarrow, \widehat, \widetilde, \overline-as-bar); the rest fall back
+ * to the narrow `<m:acc>`.
+ */
+const WIDE_ACCENT_CHARS: Record<string, string> = {
+  '\u20d7': '\u2192', // combining right arrow → stretchy → (\overrightarrow)
+  '\u20d6': '\u2190', // combining left arrow → stretchy ← (\overleftarrow)
+  '\u0302': '\u0302', // circumflex (\widehat) — stretchy caret over the base
+  '\u0303': '\u0303', // tilde (\widetilde) — stretchy tilde over the base
+  '\u0304': '\u2015', // macron → horizontal bar (\overline over wide base)
 }
 
 /** `<m:acc>` — a combining accent centered over the base. */
@@ -259,9 +318,22 @@ function overUnder(node: Element, kind: 'over' | 'under'): string {
   const base = kids[0]
   const script = kids[1]
   // 1. Diacritic accent (over only; \hat \vec \dot \ddot \tilde \bar …).
+  //    A NON-stretchy `<mo>` (MathJax marks narrow accents `stretchy="false"`)
+  //    is a small combining accent → `<m:acc>`. A stretchy accent over a wide
+  //    base (\overrightarrow, \widehat, \widetilde) must instead stretch across
+  //    the base, so it is emitted as a `<m:groupChr>` (step 2b) — using `<m:acc>`
+  //    there shrinks the mark and spaces the letters (the "abc 太小" bug).
   if (kind === 'over') {
     const acc = accentChar(script)
-    if (acc) return accent(base, acc)
+    if (acc) {
+      // A stretchy accent that has a genuine WIDE variant (\overrightarrow,
+      // \widehat, \widetilde, \overline) over a wide base → `<m:groupChr>` so the
+      // mark spans the base. Everything else (all narrow diacritics, incl. dot/
+      // ddot which simply omit `stretchy`) stays a centered `<m:acc>`.
+      const wide = WIDE_ACCENT_CHARS[acc]
+      if (wide && isStretchyAccent(script)) return groupChr(base, wide, 'top')
+      return accent(base, acc)
+    }
   }
   // 2. Stretchy brace/line directly on this node.
   const grp = groupCharOf(node)
@@ -587,11 +659,22 @@ function convertNode(node: Element): string {
       return ''
     // Grouping / styling wrappers are transparent in OMML.
     case 'mrow':
-    case 'mstyle':
     case 'mpadded':
     case 'menclose':
     case 'mphantom':
       return convertSequence(kids)
+    case 'mstyle': {
+      // `\color{…}` / `\textcolor{…}{…}` compile to `<mstyle mathcolor>`. OMML
+      // carries color per run, so push the color while converting the subtree.
+      const color = normalizeColor(node.attributes?.mathcolor as string | undefined)
+      if (!color) return convertSequence(kids)
+      colorStack.push(color)
+      try {
+        return convertSequence(kids)
+      } finally {
+        colorStack.pop()
+      }
+    }
     case 'msup':
       return sSup(kids[0], kids[1])
     case 'msub':
@@ -606,8 +689,11 @@ function convertNode(node: Element): string {
       return overUnder(node, 'under')
     case 'munderover':
       return sSubSup(kids[0], kids[1], kids[2])
-    case 'mfrac':
-      return frac(kids[0], kids[1])
+    case 'mfrac': {
+      const lt = node.attributes?.linethickness
+      const noBar = typeof lt === 'string' && /^0(\.0+)?(em|px|pt)?$/.test(lt.trim())
+      return frac(kids[0], kids[1], noBar)
+    }
     case 'msqrt':
       return sqrt(kids)
     case 'mroot':

--- a/packages/docs/src/export/docx/nodes.ts
+++ b/packages/docs/src/export/docx/nodes.ts
@@ -11,6 +11,7 @@ import {
   HeadingLevel,
   LevelFormat,
   AlignmentType,
+  BorderStyle,
   ExternalHyperlink,
   UnderlineType,
   type ILevelsOptions,
@@ -213,14 +214,8 @@ function convertList(node: MdNode, reference: string, ctx: DocxContext, depth: n
           result.push(...convertList(block, 'bullet-list', ctx, depth + 1))
         }
       } else if (i === 0) {
-        // First block in list item — apply numbering
-        const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
-        result.push(
-          new Paragraph({
-            children: runs,
-            numbering: { reference, level: Math.min(depth, 4), instance },
-          }),
-        )
+        // First block in list item — apply numbering.
+        result.push(...numberedFirstBlock(block, reference, depth, instance, ctx))
       } else {
         // Continuation blocks under the same item
         result.push(...convertBlock(block, ctx, depth))
@@ -229,6 +224,52 @@ function convertList(node: MdNode, reference: string, ctx: DocxContext, depth: n
   }
 
   return result
+}
+
+/**
+ * Produce the first block of a list item with the list marker (numbering)
+ * attached. A list item's first block is usually a paragraph, but it can be a
+ * display formula (blockMath), code block, table, etc. Converting only the
+ * paragraph's inline content — the old behavior — silently dropped any
+ * non-paragraph first block AND its list number (e.g. an ordered list where
+ * every item is a standalone display formula lost all its numbers on export).
+ *
+ * We special-case the known item shapes: a paragraph keeps its inline runs; a
+ * display formula (blockMath) becomes a numbered paragraph carrying the OMML
+ * formula, so the number renders next to the formula just like in the editor.
+ * Rarer leading blocks fall back to a normal conversion.
+ */
+function numberedFirstBlock(
+  block: MdNode,
+  reference: string,
+  depth: number,
+  instance: number,
+  ctx: DocxContext,
+): FileChild[] {
+  const numbering = { reference, level: Math.min(depth, 4), instance }
+
+  if (block.type === 'paragraph') {
+    const runs = convertInlineContent(block.content ?? [], ctx.emojiGlyph)
+    return [new Paragraph({ children: runs, numbering })]
+  }
+
+  // Display formula as the item body: build a numbered paragraph that carries
+  // the OMML formula (or the LaTeX fallback), so the list marker renders next
+  // to the formula — exactly like a numbered equation in the editor. Not
+  // centered here: a list marker + centered body reads as a broken indent.
+  if (block.type === 'blockMath') {
+    const latex = typeof block.attrs?.latex === 'string' ? block.attrs.latex : ''
+    const math = latexToMathComponent(latex, true)
+    const children = math
+      ? [math]
+      : [new TextRun({ text: latex, font: FONT_CODE, italics: true, size: 22 })]
+    return [new Paragraph({ children, numbering })]
+  }
+
+  // Any other leading block (code block, table, nested container, …): convert
+  // it normally. These shapes cannot carry a list marker as their first line in
+  // a lossless way, so we preserve the prior behavior and just emit the block.
+  return convertBlock(block, ctx, depth)
 }
 
 /**
@@ -289,10 +330,21 @@ function convertTaskList(node: MdNode, ctx: DocxContext, depth: number): FileChi
   return result
 }
 
-/** Convert a blockquote. */
+/** Convert a blockquote.
+ *
+ * A blockquote can contain arbitrary blocks (paragraphs, lists, nested quotes,
+ * code, …). Tagging only the direct child paragraphs with the `BlockQuote`
+ * pStyle loses everything else — a nested list would export as ordinary list
+ * paragraphs and escape the quote on re-import. So we bracket the whole content
+ * with invisible `BlockQuoteStart`/`BlockQuoteEnd` marker paragraphs (mirroring
+ * the details pattern) and convert inner blocks normally; the importer rebuilds
+ * the quote (and any nesting) from the marker stack. Direct paragraphs still
+ * carry the `BlockQuote` pStyle so Word renders them with the quote look. */
 function convertBlockquote(node: MdNode, ctx: DocxContext): FileChild[] {
   const children = node.content ?? []
   const result: FileChild[] = []
+
+  result.push(new Paragraph({ style: 'BlockQuoteStart', children: [] }))
 
   for (const child of children) {
     if (child.type === 'paragraph') {
@@ -305,11 +357,13 @@ function convertBlockquote(node: MdNode, ctx: DocxContext): FileChild[] {
         }),
       )
     } else {
-      // Nested blocks in blockquote
-      const converted = convertBlock(child, ctx, 0)
-      result.push(...converted)
+      // Nested blocks (lists, nested blockquotes, code, …) convert normally and
+      // stay inside the Start/End frame so the importer keeps them in the quote.
+      result.push(...convertBlock(child, ctx, 0))
     }
   }
+
+  result.push(new Paragraph({ style: 'BlockQuoteEnd', children: [] }))
 
   return result
 }
@@ -319,7 +373,7 @@ function convertCodeBlock(node: MdNode): FileChild[] {
   const code = (node.content ?? []).map((c) => c.text ?? '').join('')
   const lines = code.split('\n')
 
-  return lines.map(
+  const out: FileChild[] = lines.map(
     (line) =>
       new Paragraph({
         children: line
@@ -336,20 +390,26 @@ function convertCodeBlock(node: MdNode): FileChild[] {
         shading: { fill: 'F5F5F5' },
       }),
   )
+  // Boundary marker so the importer does not merge this code block with an
+  // immediately-following one (both export as consecutive CodeBlock paragraphs,
+  // one per line, with no other separator between distinct blocks).
+  out.push(new Paragraph({ style: 'CodeBlockEnd', children: [] }))
+  return out
 }
 
 /** Convert a horizontal rule. */
 function convertHorizontalRule(): Paragraph {
+  // A thematic break is an empty paragraph carrying only a bottom border
+  // (`w:pBdr`). Word renders that as a full-width horizontal rule, and the
+  // importer round-trips it back to a `horizontalRule` node. (The previous
+  // representation — a centered run of 50 ‘─’ glyphs — rendered as a short,
+  // mid-page dash line and imported as a literal text paragraph.)
   return new Paragraph({
-    children: [
-      new TextRun({
-        text: '─'.repeat(50),
-        color: 'CCCCCC',
-        size: 16,
-      }),
-    ],
+    children: [],
+    border: {
+      bottom: { style: BorderStyle.SINGLE, size: 6, space: 1, color: 'CCCCCC' },
+    },
     spacing: { before: 120, after: 120 },
-    alignment: AlignmentType.CENTER,
   })
 }
 
@@ -551,39 +611,43 @@ function convertBlockMath(node: MdNode): Paragraph {
   })
 }
 
-/** Convert a details/collapsible node. */
+/** Convert a details/collapsible node into a boundary-delimited block sequence.
+ *
+ * Word has no native collapsible block, so we bracket the summary + content
+ * with invisible `DetailsStart`/`DetailsEnd` marker paragraphs and tag the
+ * summary line with the `DetailsSummary` pStyle. The importer maintains a stack
+ * of these markers, which reconstructs arbitrarily nested details (a nested
+ * details node simply recurses here and emits its own Start/End pair). */
 function convertDetails(node: MdNode, ctx: DocxContext): FileChild[] {
   const children = node.content ?? []
   const summaryNode = children.find((c) => c.type === 'detailsSummary')
   const contentNode = children.find((c) => c.type === 'detailsContent')
   const result: FileChild[] = []
 
-  // Summary as a bold paragraph with toggle indicator
-  if (summaryNode) {
-    const runs = convertInlineContent(summaryNode.content ?? [], ctx.emojiGlyph)
-    result.push(
-      new Paragraph({
-        children: [new TextRun({ text: '▸ ', bold: true }), ...runs],
-        spacing: { before: 80, after: 40 },
-      }),
-    )
-  }
+  // Opening boundary marker (empty, invisible).
+  result.push(new Paragraph({ style: 'DetailsStart', children: [] }))
 
-  // Content indented
+  // Summary line, tagged so the importer maps it to detailsSummary.
+  const summaryRuns = summaryNode
+    ? convertInlineContent(summaryNode.content ?? [], ctx.emojiGlyph)
+    : []
+  result.push(
+    new Paragraph({
+      style: 'DetailsSummary',
+      children: [new TextRun({ text: '▸ ', bold: true }), ...summaryRuns],
+    }),
+  )
+
+  // Content blocks, converted normally so nested details / lists / code blocks
+  // round-trip. A nested details recurses through convertBlock → convertDetails
+  // and emits its own Start/End markers, so the importer's stack rebuilds depth.
   const contentChildren = contentNode?.content ?? children.filter((c) => c.type !== 'detailsSummary')
   for (const child of contentChildren) {
-    if (child.type === 'paragraph') {
-      const runs = convertInlineContent(child.content ?? [], ctx.emojiGlyph)
-      result.push(
-        new Paragraph({
-          children: runs,
-          indent: { left: 360 },
-        }),
-      )
-    } else {
-      result.push(...convertBlock(child, ctx, 0))
-    }
+    result.push(...convertBlock(child, ctx, 0))
   }
+
+  // Closing boundary marker.
+  result.push(new Paragraph({ style: 'DetailsEnd', children: [] }))
 
   return result
 }

--- a/packages/docs/src/export/docx/numbering.test.ts
+++ b/packages/docs/src/export/docx/numbering.test.ts
@@ -108,6 +108,28 @@ describe('ordered list numbering', () => {
     expect(resolveParagraphStarts(numXml, docXml)).toEqual([1, 1, 1, 5, 5])
   })
 
+  it('ordered list of display formulas keeps its numbering and the formulas', async () => {
+    // path treated the first block as inline runs, silently dropping both the
+    // formula and the list number — a numbered equation list lost all its
+    // "1. 2. 3." markers. Assert every item now emits a w:numPr AND the OMML.
+    const mathList: MdNode = {
+      type: 'orderedList',
+      content: ['a^2 + b^2 = c^2', 'E = mc^2', '\\int_0^1 x\\,dx'].map((latex) => ({
+        type: 'listItem',
+        content: [{ type: 'blockMath', attrs: { latex } }],
+      })),
+    } as MdNode
+    const { docXml } = await buildNumberingXml([mathList])
+    // Three numbered items at ilvl 0, all sharing one numbering instance.
+    const numIds = [...docXml.matchAll(/<w:numPr>\s*<w:ilvl w:val="0"\/>\s*<w:numId w:val="(\d+)"/g)].map(
+      (m) => m[1],
+    )
+    expect(numIds).toHaveLength(3)
+    expect(new Set(numIds).size).toBe(1)
+    // Each numbered paragraph carries a native OMML formula (not dropped).
+    expect((docXml.match(/<m:oMath\b/g) ?? []).length).toBe(3)
+  })
+
   it('nested ordered list with start=3 begins at 3', async () => {
     // bulletList > (item: para + orderedList(start=3))
     const doc: MdNode = {

--- a/packages/docs/src/export/docx/styles.ts
+++ b/packages/docs/src/export/docx/styles.ts
@@ -188,6 +188,64 @@ export function createParagraphStyles(): IParagraphStyleOptions[] {
         shading: { fill: 'D4EDDA' },
       },
     },
+    {
+      // Summary line of a collapsible <details> block. The importer keys on this
+      // pStyle id to rebuild the detailsSummary node.
+      id: 'DetailsSummary',
+      name: 'Details Summary',
+      basedOn: 'Normal',
+      run: {
+        bold: true,
+      },
+      paragraph: {
+        spacing: { before: 80, after: 40 },
+      },
+    },
+    {
+      // Invisible boundary markers wrapping a <details> block's content. The
+      // importer uses a stack of Start/End markers to reconstruct arbitrarily
+      // nested details. Rendered tiny + light so they are visually unobtrusive
+      // in Word (they carry no user text).
+      id: 'DetailsStart',
+      name: 'Details Start',
+      basedOn: 'Normal',
+      run: { size: 2, color: 'FFFFFF', vanish: true },
+      paragraph: { spacing: { before: 0, after: 0 } },
+    },
+    {
+      id: 'DetailsEnd',
+      name: 'Details End',
+      basedOn: 'Normal',
+      run: { size: 2, color: 'FFFFFF', vanish: true },
+      paragraph: { spacing: { before: 0, after: 0 } },
+    },
+    {
+      // Invisible boundary markers wrapping a blockquote's content. Like the
+      // details markers, the importer uses a Start/End stack to rebuild the
+      // quote and keep nested blocks (lists, nested quotes) inside it.
+      id: 'BlockQuoteStart',
+      name: 'Block Quote Start',
+      basedOn: 'Normal',
+      run: { size: 2, color: 'FFFFFF', vanish: true },
+      paragraph: { spacing: { before: 0, after: 0 } },
+    },
+    {
+      id: 'BlockQuoteEnd',
+      name: 'Block Quote End',
+      basedOn: 'Normal',
+      run: { size: 2, color: 'FFFFFF', vanish: true },
+      paragraph: { spacing: { before: 0, after: 0 } },
+    },
+    {
+      // Invisible boundary after a code block, so the importer breaks the run of
+      // per-line CodeBlock paragraphs at block boundaries instead of merging two
+      // adjacent code blocks into one.
+      id: 'CodeBlockEnd',
+      name: 'Code Block End',
+      basedOn: 'Normal',
+      run: { size: 2, color: 'FFFFFF', vanish: true },
+      paragraph: { spacing: { before: 0, after: 0 } },
+    },
   ]
 }
 

--- a/packages/docs/src/export/markdown.test.ts
+++ b/packages/docs/src/export/markdown.test.ts
@@ -6,6 +6,9 @@ import {
   type ExportOptions,
 } from './markdown.ts'
 import type { ResolveResult } from '../attachments/api.ts'
+import { parseMarkdownToPmDoc } from '../import/markdown.ts'
+import { getSchema } from '@tiptap/core'
+import { buildPreviewExtensions } from '../editor/extensions.ts'
 
 // Resolve stub: every id resolves to a deterministic signed URL except 'missing',
 // which lands in notFound (so the exporter must degrade gracefully).
@@ -478,5 +481,180 @@ describe('exportDocToMarkdown — XSS hardening of hrefs and attributes', () => 
     // The injected quote is backslash-escaped inside the markdown title, never closing it early.
     expect(out).not.toContain('cap" onerror=')
     expect(out).toContain('\\"')
+  })
+})
+
+// Round-trip nesting: a nested list under an ordered item must stay nested after re-import.
+// Regression for a flattening bug where a fixed 2-space indent step was narrower than an
+// ordered marker (`2. ` is 3 cols), so CommonMark counted the sublist as a sibling and the
+// child items (e.g. `2.1`, `2.2`) were promoted to the parent level.
+describe('exportDocToMarkdown — nested list round-trip', () => {
+  const li = (t: string, ...extra: MdNode[]): MdNode => ({
+    type: 'listItem',
+    content: [p(text(t)), ...extra],
+  })
+
+  // Walk to find the first list of `type` and return its item count.
+  function listItemCount(node: MdNode, type: string): number {
+    if (node.type === type) return (node.content ?? []).length
+    for (const c of node.content ?? []) {
+      const n = listItemCount(c, type)
+      if (n >= 0) return n
+    }
+    return -1
+  }
+  function findNested(node: MdNode): boolean {
+    // true when an orderedList/bulletList appears inside a listItem
+    if (node.type === 'listItem') {
+      if ((node.content ?? []).some((c) => c.type === 'orderedList' || c.type === 'bulletList'))
+        return true
+    }
+    return (node.content ?? []).some(findNested)
+  }
+
+  it('keeps a nested ordered sublist nested (indent aligns past the parent marker)', async () => {
+    const doc0 = doc({
+      type: 'orderedList',
+      content: [
+        li('第一步'),
+        li('第二步', {
+          type: 'orderedList',
+          content: [li('2.1'), li('2.2')],
+        }),
+        li('第三步'),
+      ],
+    })
+    const out = await md(doc0)
+    // The child items must be indented to at least the marker width (3 cols for `2. `).
+    expect(out).toMatch(/\n {3}1\. 2\.1/)
+    expect(out).toMatch(/\n {3}2\. 2\.2/)
+
+    const re = parseMarkdownToPmDoc(out).doc
+    // Top-level ordered list keeps exactly 3 items (child list not flattened into it).
+    expect(listItemCount(re, 'orderedList')).toBe(3)
+    expect(findNested(re)).toBe(true)
+  })
+
+  it('keeps an ordered sublist nested under a bullet item (mixed nesting)', async () => {
+    const doc0 = doc({
+      type: 'bulletList',
+      content: [
+        li('B-2-a', {
+          type: 'orderedList',
+          content: [
+            li('第一步'),
+            li('第二步', { type: 'orderedList', content: [li('2.1'), li('2.2')] }),
+            li('第三步'),
+          ],
+        }),
+      ],
+    })
+    const out = await md(doc0)
+    const re = parseMarkdownToPmDoc(out).doc
+    // Bullet has 1 item; the ordered sublist inside it keeps its own 3 items, and 2.1/2.2 stay
+    // one level deeper (three-level nesting preserved).
+    expect(listItemCount(re, 'bulletList')).toBe(1)
+    expect(findNested(re)).toBe(true)
+    // 2.1 must NOT appear as a sibling of 第一步 in the first ordered list.
+    const flat = JSON.stringify(re)
+    expect(flat).toContain('2.1')
+    expect(flat).toContain('2.2')
+  })
+})
+
+// Emphasis whitespace: CommonMark forbids a bold/italic delimiter next to whitespace, so text
+// like a bold `1. ` (trailing space) must export as `**1.** ` (space outside the delimiters),
+// not `**1. **` — otherwise the asterisks render literally and the bold is lost on import.
+describe('exportDocToMarkdown — emphasis whitespace', () => {
+  it('moves a trailing space outside a bold run so the emphasis still forms', async () => {
+    const out = await md(doc(p(text('1. ', [{ type: 'bold' }]), text('内容'))))
+    expect(out).toContain('**1.** 内容')
+    expect(out).not.toContain('**1. **')
+  })
+
+  it('moves a leading space outside a bold run', async () => {
+    const out = await md(doc(p(text('a'), text(' bold', [{ type: 'bold' }]))))
+    expect(out).toContain('a **bold**')
+    expect(out).not.toContain('** bold**')
+  })
+
+  it('does not emit empty delimiters for an all-whitespace bold run', async () => {
+    const out = await md(doc(p(text('x'), text(' ', [{ type: 'bold' }]), text('y'))))
+    expect(out).not.toContain('****')
+    expect(out).toContain('x y')
+  })
+
+  it('round-trips a bold run that has a trailing space (bold survives)', async () => {
+    const out = await md(doc(p(text('重点 ', [{ type: 'bold' }]), text('普通'))))
+    const re = parseMarkdownToPmDoc(out).doc
+    const flat = JSON.stringify(re)
+    // The bold text must import back with a bold mark, not as literal `**` characters.
+    expect(flat).toContain('"bold"')
+    expect(flat).not.toContain('**')
+  })
+})
+
+describe('table export — nested tables & block cell content', () => {
+  const cell = (...blocks: MdNode[]): MdNode => ({ type: 'tableCell', content: blocks.length ? blocks : [{ type: 'paragraph' }] })
+  const hcell = (...inline: MdNode[]): MdNode => ({ type: 'tableHeader', content: [inline.length ? p(...inline) : { type: 'paragraph' }] })
+  const rowOf = (...cells: MdNode[]): MdNode => ({ type: 'tableRow', content: cells })
+  const table = (...rows: MdNode[]): MdNode => ({ type: 'table', content: rows })
+  const img = (src: string, attachId?: string): MdNode => ({
+    type: 'image',
+    attrs: attachId ? { src, attachId } : { src },
+  })
+
+  it('emits an HTML table (not a flattened pipe row) when a cell holds a nested table', async () => {
+    const inner = table(rowOf(hcell(text('x')), hcell(text('y'))), rowOf(cell(p(text('1'))), cell(p(text('2')))))
+    const outer = table(rowOf(hcell(text('说明')), hcell(text('图'))), rowOf(cell(inner), cell(p(text('z')))))
+    const out = await md(doc(outer))
+    // Must use the HTML fallback with a real nested <table>, NOT a collapsed `| | | |` pipe row.
+    expect(out).toContain('<table>')
+    expect(out).not.toMatch(/\|\s*---\s*\|\s*---\s*\|\s*\|/) // no collapsed nested separator
+  })
+
+  it('round-trips a nested table (table inside a cell survives import)', async () => {
+    const inner = table(rowOf(hcell(text('A')), hcell(text('B'))), rowOf(cell(p(text('1'))), cell(p(text('2')))))
+    const outer = table(rowOf(hcell(text('说明')), hcell(text('图'))), rowOf(cell(inner), cell(p(text('末'))))) 
+    const out = await md(doc(outer))
+    const re = parseMarkdownToPmDoc(out).doc
+    // Find the outer table, then a cell that itself contains a table node.
+    const outerT = re.content!.find((n) => n.type === 'table')!
+    const bodyRow = outerT.content!.find((r) => r.content!.some((c) => c.type === 'tableCell'))!
+    const nestedCell = bodyRow.content!.find((c) => c.content!.some((b) => b.type === 'table'))
+    expect(nestedCell).toBeDefined()
+    const nested = nestedCell!.content!.find((b) => b.type === 'table')!
+    // Inner table has 2 rows.
+    expect(nested.content!.length).toBe(2)
+  })
+
+  it('round-trips a block image inside a table cell via the HTML fallback', async () => {
+    const url = 'http://localhost:28080/file/d_x/att_abc123/pic.png'
+    const t = table(rowOf(hcell(text('说明')), hcell(text('图'))), rowOf(cell(p(text('文字'))), cell(img(url, 'att_abc123'))))
+    const out = await md(doc(t))
+    expect(out).toContain('<img')
+    const re = parseMarkdownToPmDoc(out).doc
+    const outerT = re.content!.find((n) => n.type === 'table')!
+    const bodyRow = outerT.content!.find((r) => r.content!.some((c) => c.type === 'tableCell'))!
+    const imgCell = bodyRow.content!.find((c) => c.content!.some((b) => b.type === 'image'))
+    expect(imgCell).toBeDefined()
+    const image = imgCell!.content!.find((b) => b.type === 'image')!
+    expect(image.attrs?.attachId).toBe('att_abc123')
+  })
+
+  it('a re-imported nested table with EMPTY cells validates against the editor schema (no empty text nodes → no blank page)', async () => {
+    // Regression: empty cells were imported as a paragraph holding an empty text node, which
+    // ProseMirror rejects ("Empty text nodes are not allowed"), throwing in setContent and
+    // blanking the whole editor. Empty cells must be an empty paragraph instead.
+    const inner = table(
+      rowOf(hcell(), hcell()),                 // empty headers
+      rowOf(cell(), cell(img('http://localhost:28080/file/d/att_z9/i.png', 'att_z9'))),
+    )
+    const outer = table(rowOf(hcell(text('a')), hcell(text('b'))), rowOf(cell(inner), cell()))
+    const out = await md(doc(outer))
+    const re = parseMarkdownToPmDoc(out).doc
+    const schema = getSchema(buildPreviewExtensions('d_test'))
+    // nodeFromJSON + check() throws on any schema violation (the exact blank-page cause).
+    expect(() => schema.nodeFromJSON(re).check()).not.toThrow()
   })
 })

--- a/packages/docs/src/export/markdown.ts
+++ b/packages/docs/src/export/markdown.ts
@@ -157,11 +157,11 @@ function serializeBlock(node: MdNode, ctx: Ctx): string {
       return wrapAlign(`${'#'.repeat(level)} ${serializeInline(node.content ?? [], ctx)}`, node)
     }
     case 'bulletList':
-      return serializeList(node, false, ctx, 0)
+      return serializeList(node, false, ctx, '')
     case 'orderedList':
-      return serializeList(node, true, ctx, 0)
+      return serializeList(node, true, ctx, '')
     case 'taskList':
-      return serializeList(node, false, ctx, 0)
+      return serializeList(node, false, ctx, '')
     case 'blockquote':
       return prefixLines(serializeBlocks(node.content ?? [], ctx), '> ')
     case 'codeBlock': {
@@ -252,14 +252,14 @@ function escapeLeadingBlockMarkers(text: string): string {
 
 // ── Lists ────────────────────────────────────────────────────────────────────
 
-function serializeList(node: MdNode, ordered: boolean, ctx: Ctx, depth: number): string {
+function serializeList(node: MdNode, ordered: boolean, ctx: Ctx, indent: string): string {
   const items = node.content ?? []
   // Ordered lists may start at a value other than 1 (ProseMirror `start` attr); honour it so the
   // rendered markers match the editor instead of always counting from 1.
   const rawStart = node.attrs?.start
   const start = ordered && typeof rawStart === 'number' && rawStart >= 0 ? Math.floor(rawStart) : 1
   return items
-    .map((item, idx) => serializeListItem(item, ordered, start + idx, ctx, depth))
+    .map((item, idx) => serializeListItem(item, ordered, start + idx, ctx, indent))
     // Drop empty items so an item with no content never emits a bare dangling marker (`- `).
     .filter((s) => s !== '')
     .join('\n')
@@ -270,12 +270,22 @@ function serializeListItem(
   ordered: boolean,
   num: number,
   ctx: Ctx,
-  depth: number,
+  indent: string,
 ): string {
-  const indent = '  '.repeat(depth)
   let marker: string
-  if (item.type === 'taskItem') marker = item.attrs?.checked ? '- [x] ' : '- [ ] '
-  else marker = ordered ? `${num}. ` : '- '
+  if (item.type === 'taskItem') {
+    // GFM task-list syntax (`- [x]` / `- [ ]`). GFM-aware viewers render an
+    // interactive checkbox; the import side maps `[x]`/`[X]` (and a checked box
+    // glyph) back to a checked taskItem, so the round-trip is correct even if a
+    // given previewer shows the literal `x`.
+    marker = item.attrs?.checked ? '- [x] ' : '- [ ] '
+  } else marker = ordered ? `${num}. ` : '- '
+
+  // CommonMark counts a sub-block as nested only when it is indented to at least the parent
+  // marker's width. An ordered marker like `10. ` is wider than `- `, so a fixed 2-space step
+  // would flatten deep ordered lists on re-import. Derive the child indent from this item's
+  // actual marker width (parent indent + marker length) so nesting always survives a round-trip.
+  const childIndent = indent + ' '.repeat(marker.length)
 
   const blocks = item.content ?? []
   let line = indent + marker
@@ -283,13 +293,13 @@ function serializeListItem(
   const trailing: string[] = []
   blocks.forEach((b, i) => {
     if (b.type === 'bulletList' || b.type === 'orderedList' || b.type === 'taskList') {
-      trailing.push(serializeList(b, b.type === 'orderedList', ctx, depth + 1))
+      trailing.push(serializeList(b, b.type === 'orderedList', ctx, childIndent))
     } else if (i === 0) {
       body = serializeBlock(b, ctx)
       line += body
     } else {
       // Continuation block under the same item — indent to align with the marker text.
-      trailing.push(prefixLines(serializeBlock(b, ctx), indent + '  '))
+      trailing.push(prefixLines(serializeBlock(b, ctx), childIndent))
     }
   })
   // An item with no first-block text AND no nested/trailing content is empty — emit nothing
@@ -303,6 +313,38 @@ function serializeListItem(
 function cellText(cell: MdNode, ctx: Ctx): string {
   // A cell holds block content (usually paragraphs); flatten to single-line inline.
   return serializeBlocks(cell.content ?? [], ctx).replace(/\n+/g, ' ').trim()
+}
+
+/**
+ * A GFM pipe-table cell is single-line inline only. A cell whose content cannot survive being
+ * flattened to one inline line (a NESTED TABLE, a block image, a list, a code block, a blockquote,
+ * a details/callout, a horizontal rule, block math, or more than one block) forces the whole
+ * table onto the HTML fallback, where the cell body is rendered as real (possibly nested) HTML.
+ * Without this a nested table's multi-line markdown has its newlines collapsed to spaces
+ * (`| | | || --- | --- |`) and can never be re-parsed.
+ */
+const CELL_BLOCK_TYPES = new Set([
+  'table',
+  'image',
+  'bulletList',
+  'orderedList',
+  'taskList',
+  'codeBlock',
+  'blockquote',
+  'details',
+  'callout',
+  'horizontalRule',
+  'blockMath',
+])
+
+function cellNeedsHtml(cell: MdNode): boolean {
+  const blocks = cell.content ?? []
+  if (blocks.length > 1) return true
+  return blocks.some((b) => CELL_BLOCK_TYPES.has(b.type))
+}
+
+function tableNeedsHtml(node: MdNode): boolean {
+  return (node.content ?? []).some((row) => (row.content ?? []).some((cell) => cellNeedsHtml(cell)))
 }
 
 /**
@@ -329,8 +371,9 @@ function hasMergedCells(node: MdNode): boolean {
 }
 
 function serializeTable(node: MdNode, ctx: Ctx): string {
-  // Merged cells can't be expressed in GFM pipe tables → inline HTML fallback.
-  if (hasMergedCells(node)) return serializeTableHtml(node, ctx)
+  // Merged cells can't be expressed in GFM pipe tables, and neither can block cell content
+  // (nested tables, images, lists…) → inline HTML fallback with real (nested) HTML cells.
+  if (hasMergedCells(node) || tableNeedsHtml(node)) return serializeTableHtml(node, ctx)
 
   const rows = node.content ?? []
   if (rows.length === 0) return ''
@@ -356,7 +399,7 @@ function serializeTableHtml(node: MdNode, ctx: Ctx): string {
       const rowspan = Number(cell.attrs?.rowspan ?? 1)
       const attrs =
         (colspan > 1 ? ` colspan="${colspan}"` : '') + (rowspan > 1 ? ` rowspan="${rowspan}"` : '')
-      out.push(`<${tag}${attrs}>${escapeHtmlText(cellText(cell, ctx))}</${tag}>`)
+      out.push(`<${tag}${attrs}>${cellHtml(cell, ctx)}</${tag}>`)
     }
     out.push('</tr>')
   }
@@ -364,12 +407,61 @@ function serializeTableHtml(node: MdNode, ctx: Ctx): string {
   return out.join('\n')
 }
 
+/**
+ * Render a table cell's body as HTML for the HTML-table fallback. A simple inline-only cell stays
+ * flattened+escaped text (the historical behavior, cheap + readable). A cell carrying block
+ * content (nested table, image, list…) is rendered as real HTML so it round-trips: the import
+ * side's DOM-based HTML-table parser reconstructs the nested structure.
+ */
+function cellHtml(cell: MdNode, ctx: Ctx): string {
+  if (!cellNeedsHtml(cell)) return escapeHtmlText(cellText(cell, ctx))
+  return (cell.content ?? []).map((b) => blockToHtml(b, ctx)).join('')
+}
+
+/** Recursively render a block node to HTML for embedding inside an HTML-fallback table cell. */
+function blockToHtml(node: MdNode, ctx: Ctx): string {
+  switch (node.type) {
+    case 'table':
+      return serializeTableHtml(node, ctx)
+    case 'image': {
+      const src = imageSrc(node, ctx)
+      if (!src) return ''
+      const alt = escapeHtmlAttr(typeof node.attrs?.alt === 'string' ? node.attrs.alt : '')
+      return `<img src="${escapeHtmlAttr(src)}" alt="${alt}" />`
+    }
+    case 'paragraph':
+      return `<p>${escapeHtmlText(serializeInline(node.content ?? [], ctx))}</p>`
+    case 'heading': {
+      const level = clampLevel(node.attrs?.level)
+      return `<h${level}>${escapeHtmlText(serializeInline(node.content ?? [], ctx))}</h${level}>`
+    }
+    case 'bulletList':
+    case 'taskList':
+      return `<ul>${(node.content ?? []).map((li) => `<li>${listItemHtml(li, ctx)}</li>`).join('')}</ul>`
+    case 'orderedList':
+      return `<ol>${(node.content ?? []).map((li) => `<li>${listItemHtml(li, ctx)}</li>`).join('')}</ol>`
+    case 'codeBlock': {
+      const code = (node.content ?? []).map((c) => c.text ?? '').join('')
+      return `<pre><code>${escapeHtmlText(code)}</code></pre>`
+    }
+    case 'blockquote':
+      return `<blockquote>${(node.content ?? []).map((b) => blockToHtml(b, ctx)).join('')}</blockquote>`
+    case 'horizontalRule':
+      return '<hr />'
+    default:
+      // Unknown/other block: fall back to escaped flattened text so nothing is dropped.
+      return escapeHtmlText(serializeBlocks([node], ctx).replace(/\n+/g, ' ').trim())
+  }
+}
+
+function listItemHtml(li: MdNode, ctx: Ctx): string {
+  return (li.content ?? []).map((b) => blockToHtml(b, ctx)).join('')
+}
+
 // ── Atoms ────────────────────────────────────────────────────────────────────
 
 function serializeImage(node: MdNode, ctx: Ctx): string {
-  const attachId = node.attrs?.attachId
-  const resolved = typeof attachId === 'string' ? ctx.urls.get(attachId) : undefined
-  const rawUrl = resolved?.url ?? (typeof node.attrs?.src === 'string' ? node.attrs.src : '') ?? ''
+  const rawUrl = imageSrc(node, ctx)
   // An image destination is not a navigable `<a href>` (a `javascript:` img src does not execute),
   // so we don't scheme-gate it — but we DO escape it so it can't break out of the `(...)`.
   const url = escapeMarkdownUrl(rawUrl)
@@ -378,6 +470,13 @@ function serializeImage(node: MdNode, ctx: Ctx): string {
   // The title sits inside `"..."`; backslash-escape the quote/backslash so it can't terminate early.
   const title = rawTitle ? ` "${rawTitle.replace(/(["\\])/g, '\\$1')}"` : ''
   return `![${alt}](${url}${title})`
+}
+
+/** Resolve an image node's export URL: freshly-resolved signed URL by attachId, else its src. */
+function imageSrc(node: MdNode, ctx: Ctx): string {
+  const attachId = node.attrs?.attachId
+  const resolved = typeof attachId === 'string' ? ctx.urls.get(attachId) : undefined
+  return resolved?.url ?? (typeof node.attrs?.src === 'string' ? node.attrs.src : '') ?? ''
 }
 
 function serializeFileAttachment(node: MdNode, ctx: Ctx): string {
@@ -450,23 +549,38 @@ function serializeInlineNode(node: MdNode, ctx: Ctx): string {
   }
 }
 
+/**
+ * Wrap `text` in an emphasis delimiter (`**`, `*`, `~~`). CommonMark forbids a delimiter run
+ * that is preceded (closing) or followed (opening) by Unicode whitespace, so `**1. **` renders
+ * as literal asterisks and the bold is lost. Move any leading/trailing whitespace OUTSIDE the
+ * delimiters (`**1. **` -> `**1.** `) so the emphasis actually forms; an all-whitespace or
+ * empty run keeps its text unwrapped (nothing to emphasize).
+ */
+function wrapEmphasis(text: string, delim: string): string {
+  const m = /^(\s*)([\s\S]*?)(\s*)$/.exec(text)
+  if (!m) return text
+  const [, lead, core, trail] = m
+  if (core === '') return text // nothing but whitespace: don't emit empty `****`
+  return `${lead}${delim}${core}${delim}${trail}`
+}
+
 function applyMarks(text: string, marks: Array<{ type: string; attrs?: Record<string, unknown> }>): string {
   let out = text
   for (const mark of marks) {
     switch (mark.type) {
       case 'bold':
       case 'strong':
-        out = `**${out}**`
+        out = wrapEmphasis(out, '**')
         break
       case 'italic':
       case 'em':
-        out = `*${out}*`
+        out = wrapEmphasis(out, '*')
         break
       case 'code':
         out = '`' + out + '`'
         break
       case 'strike':
-        out = `~~${out}~~`
+        out = wrapEmphasis(out, '~~')
         break
       case 'link': {
         // Scheme-gate the href (drop javascript:/data:/…) and escape it for the `(...)` target.
@@ -492,9 +606,14 @@ function applyMarks(text: string, marks: Array<{ type: string; attrs?: Record<st
       }
       case 'textStyle': {
         const color = mark.attrs?.color
-        // Color lands inside a `style="..."` attribute — escape it so it can't break out of the
-        // attribute (and inject markup). `color: red"><img onerror=…>` becomes inert text.
-        if (typeof color === 'string' && color) out = `<span style="color:${escapeHtmlAttr(color)}">${out}</span>`
+        const fontSize = mark.attrs?.fontSize
+        // Collect inline style declarations. Both color and fontSize land inside a
+        // `style="..."` attribute, so escape each value so it can't break out of the
+        // attribute and inject markup (`color: red"><img onerror=…>` becomes inert text).
+        const decls: string[] = []
+        if (typeof color === 'string' && color) decls.push(`color:${escapeHtmlAttr(color)}`)
+        if (typeof fontSize === 'string' && fontSize) decls.push(`font-size:${escapeHtmlAttr(fontSize)}`)
+        if (decls.length > 0) out = `<span style="${decls.join(';')}">${out}</span>`
         break
       }
       case 'subscript':

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -178,7 +178,25 @@
     "exportPdf": "Export as PDF",
     "exportError": "Couldn't export this document. Please try again.",
     "export": "Export",
-    "exportSignedLinkNotice": "This document contains shared links — please verify access permissions"
+    "exportSignedLinkNotice": "This document contains shared links — please verify access permissions",
+    "importCorrupt": "The imported content is corrupt or unreadable and couldn't be loaded."
+  },
+  "import": {
+    "word": "Import from Word",
+    "wordError": "Couldn't parse this Word document. Please make sure it's a valid .docx.",
+    "wordTooLarge": "This Word document is too large or too complex to import.",
+    "markdown": "Import from Markdown",
+    "pdf": "Import from PDF",
+    "pdfError": "Couldn't parse this PDF. Please make sure it's a valid PDF with a text layer.",
+    "localImagesSkipped": "{{count}} local image(s) were not imported (only network image URLs are supported).",
+    "imageNotImported": "[image: {{name}} not imported]",
+    "imageMigrateFailed": "An image could not be migrated to the new document ({{reason}}).",
+    "imagesMigratePartial": "Some images could not be migrated to the new document.",
+    "externalImagesLinked": "Some external images could not be saved to the document and were kept as links.",
+    "mdOnly": "Only Markdown files (.md / .markdown) can be imported.",
+    "noFileChosen": "No file selected.",
+    "fileReadFailed": "Failed to read the file.",
+    "cancelled": "Cancelled by user."
   },
   "slash": {
     "groupBasic": "Basic",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -178,7 +178,25 @@
     "exportPdf": "导出为 PDF",
     "exportError": "导出文档失败，请重试。",
     "export": "导出",
-    "exportSignedLinkNotice": "此文档包含共享链接，请注意访问权限"
+    "exportSignedLinkNotice": "此文档包含共享链接，请注意访问权限",
+    "importCorrupt": "导入内容已损坏或无法解析，未能载入。"
+  },
+  "import": {
+    "word": "从 Word 导入",
+    "wordError": "无法解析该 Word 文档，请确认是有效的 .docx",
+    "wordTooLarge": "该 Word 文档过大或结构过于复杂，无法导入",
+    "markdown": "从 Markdown 导入",
+    "pdf": "从 PDF 导入",
+    "pdfError": "无法解析该 PDF，请确认是带文本层的有效 PDF",
+    "localImagesSkipped": "{{count}} 张本地图片未导入（仅支持网络图片 URL）",
+    "imageNotImported": "[图片: {{name}} 未导入]",
+    "imageMigrateFailed": "图片未能迁移到新文档（{{reason}}）",
+    "imagesMigratePartial": "部分图片未能迁移到新文档",
+    "externalImagesLinked": "部分外部图片未能保存到文档，已改为链接",
+    "mdOnly": "仅支持导入 Markdown 文件（.md / .markdown）",
+    "noFileChosen": "未选择文件",
+    "fileReadFailed": "文件读取失败",
+    "cancelled": "用户取消"
   },
   "slash": {
     "groupBasic": "基础",

--- a/packages/docs/src/import/frontmatter.ts
+++ b/packages/docs/src/import/frontmatter.ts
@@ -1,0 +1,34 @@
+// YAML front-matter stripping for Markdown import (design §7).
+//
+// We do NOT do a full YAML parse — only strip a leading `---\n…\n---` block and best-effort
+// extract a `title:` line. Everything else in the front matter is discarded (v1). This keeps
+// the import safe (no arbitrary YAML type coercion) and matches the design's degrade policy.
+
+export interface FrontMatter {
+  title?: string
+}
+
+export interface StripResult {
+  body: string
+  frontMatter: FrontMatter
+}
+
+const FM_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/
+
+/**
+ * If the input begins with a `---` fenced YAML block, remove it and pull out a `title:` value.
+ * Otherwise return the input unchanged with an empty front matter.
+ */
+export function stripFrontMatter(input: string): StripResult {
+  const m = FM_RE.exec(input)
+  if (!m) return { body: input, frontMatter: {} }
+
+  const yaml = m[1]
+  const fm: FrontMatter = {}
+  // Best-effort: match a top-level `title: value` (quoted or bare), first occurrence.
+  const titleMatch = /^title:\s*(.+?)\s*$/m.exec(yaml)
+  if (titleMatch) {
+    fm.title = titleMatch[1].replace(/^["']|["']$/g, '').trim()
+  }
+  return { body: input.slice(m[0].length), frontMatter: fm }
+}

--- a/packages/docs/src/import/html-inline.ts
+++ b/packages/docs/src/import/html-inline.ts
@@ -1,0 +1,494 @@
+// Whitelist HTML → ProseMirror node/mark reverse mapping for Markdown import.
+//
+// The exporter (../export/markdown.ts) emits inline HTML for nodes/marks that Markdown
+// can't express natively: <u>, <mark>, <sub>, <sup>, <span style="color:…">, and block-level
+// <div data-callout>, <details>, and <table> with colspan/rowspan. This module parses those
+// specific patterns back into PM JSON. Unknown/unhandled HTML is NEVER innerHTML-injected;
+// it degrades to plain text (security line inherited from PDF-export lessons).
+//
+// Security:
+//   - isSafeHref: scheme whitelist http/https/mailto/tel + relative. Blocks javascript:/data:/
+//     vbscript: and tab/newline bypass variants.
+//   - isSafeCssColor: #hex / rgb(a) / hsl(a) / named CSS colors only. Rejects anything with
+//     `;`, `(`, `)` outside known function syntax, or unknown tokens (blocks declaration injection).
+//   - parseInlineHtml / parseHtmlBlock: only recognize the exact tags the exporter emits.
+
+import type { PmNode } from './markdown.ts'
+
+// ── URL safety ────────────────────────────────────────────────────────────────
+
+const SAFE_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+/**
+ * Return the href if it passes the scheme whitelist, or null.
+ * Relative URLs are accepted (resolved against about:blank — caller decides).
+ * Blocks javascript:, data:, vbscript:, and control-char bypass variants.
+ */
+export function isSafeHref(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  // Strip control characters that can hide protocol boundaries (tab, newline, etc.)
+  const cleaned = raw.replace(/[\x00-\x20]/g, '').toLowerCase()
+  // Check for known-dangerous prefixes before URL parsing (defense in depth)
+  if (/^(javascript|data|vbscript):/i.test(cleaned)) return null
+  try {
+    const u = new URL(raw, 'https://safe.local/')
+    if (SAFE_SCHEMES.has(u.protocol)) return u.href
+    // Relative URL (parsed against our dummy base) — accept if no scheme was intended
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(raw.trim())) return raw
+    return null
+  } catch {
+    return null
+  }
+}
+
+// ── CSS color safety ──────────────────────────────────────────────────────────
+
+// Named CSS colors subset (common ones the editor might produce). Full list not needed;
+// unrecognized names just fail the regex and get dropped.
+const NAMED_COLORS = new Set([
+  'black', 'white', 'red', 'green', 'blue', 'yellow', 'orange', 'purple', 'pink',
+  'brown', 'gray', 'grey', 'cyan', 'magenta', 'lime', 'navy', 'teal', 'maroon',
+  'olive', 'silver', 'fuchsia', 'aqua', 'coral', 'salmon', 'tomato', 'gold',
+  'khaki', 'plum', 'orchid', 'sienna', 'peru', 'tan', 'wheat', 'linen', 'beige',
+  'ivory', 'snow', 'azure', 'mintcream', 'honeydew', 'aliceblue', 'ghostwhite',
+  'lavender', 'mistyrose', 'antiquewhite', 'floralwhite', 'seashell', 'oldlace',
+  'papayawhip', 'blanchedalmond', 'bisque', 'moccasin', 'navajowhite', 'peachpuff',
+  'palegoldenrod', 'lemonchiffon', 'lightyellow', 'lightgoldenrodyellow',
+  'cornsilk', 'darkred', 'darkgreen', 'darkblue', 'darkcyan', 'darkmagenta',
+  'darkorange', 'darkviolet', 'darkgoldenrod', 'darkolivegreen', 'darkseagreen',
+  'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise',
+  'deepskyblue', 'dodgerblue', 'firebrick', 'forestgreen', 'hotpink',
+  'indianred', 'lawngreen', 'lightblue', 'lightcoral', 'lightcyan',
+  'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
+  'lightslategray', 'lightsteelblue', 'mediumblue', 'mediumorchid',
+  'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen',
+  'mediumturquoise', 'midnightblue', 'olivedrab', 'orangered', 'palegreen',
+  'paleturquoise', 'palevioletred', 'powderblue', 'royalblue', 'saddlebrown',
+  'sandybrown', 'seagreen', 'skyblue', 'slateblue', 'slategray', 'springgreen',
+  'steelblue', 'yellowgreen', 'rebeccapurple', 'crimson', 'chocolate',
+])
+
+/**
+ * Validate a CSS color value. Accepts #hex, rgb()/rgba(), hsl()/hsla(), and named colors.
+ * Returns the original value if safe, null if suspicious (contains `;`, extra parens, etc.).
+ */
+export function isSafeCssColor(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const v = raw.trim().toLowerCase()
+  if (!v) return null
+
+  // Block any semicolon, colon, or parentheses outside known function syntax
+  // (prevents `red;position:fixed` or `red;background:url(...)` injection).
+
+  // #hex: 3, 4, 6, or 8 hex digits
+  if (/^#[0-9a-f]{3,8}$/.test(v)) return raw.trim()
+
+  // rgb()/rgba()/hsl()/hsla(): allow only digits, commas, dots, spaces, %, and one pair of parens
+  if (/^(rgb|rgba|hsl|hsla)\(\s*[\d.,%\s]+\)$/.test(v)) return raw.trim()
+
+  // Named color
+  if (NAMED_COLORS.has(v)) return raw.trim()
+
+  return null
+}
+
+/**
+ * Validate a CSS font-size value so it can be safely placed on a textStyle mark.
+ * Accepts a number followed by a known length/relative unit (px, pt, em, rem, %),
+ * mirroring what the exporter emits (`font-size:24px`). Rejects anything with extra
+ * declarations, functions, or characters that could break out of the attribute.
+ * Returns the normalized value (trimmed original) or null when unsafe.
+ */
+export function isSafeFontSize(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const v = raw.trim()
+  if (!v) return null
+  // number (int or decimal) + unit; no semicolons/colons/parens or other declarations.
+  if (/^\d+(?:\.\d+)?(?:px|pt|em|rem|%)$/i.test(v)) return v
+  return null
+}
+
+/**
+ * Whitelist a block `align` attribute value to the alignments the editor's
+ * paragraph/heading `textAlign` attr supports. Any other value (including a
+ * quote-escaped injection attempt) yields null so it is never written onto the
+ * node. `left` is the default and carries no explicit alignment.
+ */
+function sanitizeAlign(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const v = raw.trim().toLowerCase()
+  return v === 'center' || v === 'right' || v === 'justify' ? v : null
+}
+
+// ── Inline HTML parsing ───────────────────────────────────────────────────────
+
+export interface InlineHtmlResult {
+  /** If this HTML fragment is pure text content (no recognized tag), emit as text node. */
+  textNode: PmNode | null
+  /** Mutations to apply to the caller's mark stack (open/close whitelisted marks). */
+}
+
+/**
+ * Parse an inline html_inline token's content. Recognizes the exact tags the exporter emits:
+ *   <u>, </u>, <mark>, </mark>, <sub>, </sub>, <sup>, </sup>,
+ *   <span style="color:X">, </span>
+ * Returns a textNode if the content is unrecognized HTML (degrade to text).
+ * Also mutates markStack via the returned mutations array.
+ */
+export function parseInlineHtml(
+  html: string,
+  markStack: Array<{ type: string; attrs?: Record<string, unknown> }>,
+): InlineHtmlResult {
+  const trimmed = html.trim()
+
+  // Opening tags
+  if (/^<u>$/i.test(trimmed)) { markStack.push({ type: 'underline' }); return { textNode: null } }
+  if (/^<\/u>$/i.test(trimmed)) { popMark(markStack, 'underline'); return { textNode: null } }
+  if (/^<mark>$/i.test(trimmed)) { markStack.push({ type: 'highlight' }); return { textNode: null } }
+  // <mark style="background-color:VALUE"> — preserve the highlight color when it round-trips.
+  const markColor = /^<mark\s+style="background-color:\s*([^"]+)"\s*>$/i.exec(trimmed)
+  if (markColor) {
+    const color = isSafeCssColor(markColor[1])
+    markStack.push(color ? { type: 'highlight', attrs: { color } } : { type: 'highlight' })
+    return { textNode: null }
+  }
+  if (/^<\/mark>$/i.test(trimmed)) { popMark(markStack, 'highlight'); return { textNode: null } }
+  if (/^<sub>$/i.test(trimmed)) { markStack.push({ type: 'subscript' }); return { textNode: null } }
+  if (/^<\/sub>$/i.test(trimmed)) { popMark(markStack, 'subscript'); return { textNode: null } }
+  if (/^<sup>$/i.test(trimmed)) { markStack.push({ type: 'superscript' }); return { textNode: null } }
+  if (/^<\/sup>$/i.test(trimmed)) { popMark(markStack, 'superscript'); return { textNode: null } }
+
+  // <span style="..."> — the exporter emits color and/or font-size declarations inside a
+  // single style attribute (e.g. `color:red;font-size:24px`). Parse each declaration and
+  // build one textStyle mark carrying whichever safe attrs are present, so color-only,
+  // font-size-only, and combined spans all round-trip (previously only pure color matched,
+  // so font-size was silently dropped — and a combined span lost its color too).
+  const spanOpen = /^<span\s+style="([^"]*)"\s*>$/i.exec(trimmed)
+  if (spanOpen) {
+    const attrs: Record<string, unknown> = {}
+    for (const decl of spanOpen[1].split(';')) {
+      const idx = decl.indexOf(':')
+      if (idx < 0) continue
+      const prop = decl.slice(0, idx).trim().toLowerCase()
+      const value = decl.slice(idx + 1).trim()
+      if (prop === 'color') {
+        const color = isSafeCssColor(value)
+        if (color) attrs.color = color
+      } else if (prop === 'font-size') {
+        const fontSize = isSafeFontSize(value)
+        if (fontSize) attrs.fontSize = fontSize
+      }
+    }
+    // Always push a mark for the open tag so the matching </span> pops the right one, even
+    // when every declaration was unsafe/unknown (mark carries no attrs in that case).
+    markStack.push(Object.keys(attrs).length > 0 ? { type: 'textStyle', attrs } : { type: 'textStyle' })
+    return { textNode: null }
+  }
+  if (/^<\/span>$/i.test(trimmed)) { popMark(markStack, 'textStyle'); return { textNode: null } }
+
+  // Unrecognized inline HTML → degrade to plain text (never innerHTML)
+  return { textNode: { type: 'text', text: html } }
+}
+
+function popMark(stack: Array<{ type: string }>, type: string): void {
+  for (let i = stack.length - 1; i >= 0; i--) {
+    if (stack[i].type === type) { stack.splice(i, 1); return }
+  }
+}
+
+// ── Block HTML parsing ─────────────────────────────────────────────────────────
+
+type InlineMapper = (text: string, warnings: string[]) => PmNode[]
+
+/**
+ * Re-parse a fragment of Markdown source into block-level PM nodes. Injected by markdown.ts so
+ * callout/details bodies can contain real block content (headings, lists, code, nested
+ * blockquotes) instead of collapsing to a single plain-text paragraph.
+ */
+export type BlockMapper = (markdown: string, warnings: string[]) => PmNode[]
+
+/**
+ * Parse a block-level html_block token. Recognizes:
+ *   - <div data-callout data-variant="X">…</div> → callout node
+ *   - <details><summary>…</summary>…</details> → details node
+ *   - <table> with colspan/rowspan → table node
+ * Unrecognized blocks degrade to paragraphs of plain text.
+ *
+ * When `blockMap` is supplied, callout/details BODIES are re-parsed as block content so nested
+ * headings/lists/etc. survive; the summary stays inline. Without it, bodies fall back to a single
+ * plain-text paragraph (legacy behavior).
+ */
+export function parseHtmlBlock(
+  html: string,
+  inlineMap: InlineMapper,
+  warnings: string[],
+  blockMap?: BlockMapper,
+): PmNode[] {
+  const trimmed = html.trim()
+
+  // HTML comments (e.g. the exporter's signed-link notice `<!-- … -->`) carry no document
+  // content — drop them entirely instead of degrading to a literal text paragraph.
+  if (/^<!--[\s\S]*-->$/.test(trimmed)) return []
+
+  // Callout: <div data-callout data-variant="info">…</div>
+  const calloutMatch = /^<div\s+data-callout\s+data-variant="([^"]*)">\s*([\s\S]*)\s*<\/div>$/i.exec(trimmed)
+  if (calloutMatch) {
+    const variant = calloutMatch[1] || 'info'
+    const innerText = calloutMatch[2].trim()
+    const innerBlocks = blockMap
+      ? blockMap(innerText, warnings)
+      : wrapInlineAsParagraph(inlineMap(innerText, warnings))
+    return [{
+      type: 'callout',
+      attrs: { variant },
+      content: innerBlocks.length ? innerBlocks : [{ type: 'paragraph' }],
+    }]
+  }
+
+  // Details: <details>\n<summary>SUMMARY</summary>\n\nINNER\n\n</details>
+  const detailsMatch = /^<details>\s*<summary>([\s\S]*?)<\/summary>\s*([\s\S]*)\s*<\/details>$/i.exec(trimmed)
+  if (detailsMatch) {
+    const summaryText = detailsMatch[1].trim()
+    const innerText = detailsMatch[2].trim()
+    const summaryNodes = inlineMap(summaryText, warnings)
+    const innerBlocks = blockMap
+      ? blockMap(innerText, warnings)
+      : wrapInlineAsParagraph(inlineMap(innerText, warnings))
+    return [{
+      type: 'details',
+      content: [
+        { type: 'detailsSummary', content: summaryNodes.length ? summaryNodes : [] },
+        { type: 'detailsContent', content: innerBlocks.length ? innerBlocks : [{ type: 'paragraph' }] },
+      ],
+    }]
+  }
+
+  // Table with colspan/rowspan (HTML table)
+  if (/^<table[\s>]/i.test(trimmed)) {
+    const table = parseHtmlTable(trimmed, inlineMap, warnings)
+    if (table) return [table]
+  }
+
+  // Aligned block: the exporter wraps a non-default `textAlign` paragraph as
+  // `<p align="…">INNER</p>` and an aligned heading as `<div align="…">INNER</div>`
+  // (INNER is markdown). Parse it symmetrically: re-parse INNER as block content
+  // and stamp `textAlign` back onto the resulting paragraph/heading nodes so the
+  // round-trip preserves alignment instead of leaking the raw tag as text.
+  const alignMatch = /^<(p|div)\s+align="([^"]*)">\s*([\s\S]*?)\s*<\/\1>$/i.exec(trimmed)
+  if (alignMatch) {
+    const align = sanitizeAlign(alignMatch[2])
+    const innerText = alignMatch[3].trim()
+    const innerBlocks = blockMap
+      ? blockMap(innerText, warnings)
+      : wrapInlineAsParagraph(inlineMap(innerText, warnings))
+    const blocks = innerBlocks.length ? innerBlocks : [{ type: 'paragraph' } as PmNode]
+    if (align) {
+      for (const b of blocks) {
+        if (b.type === 'paragraph' || b.type === 'heading') {
+          b.attrs = { ...(b.attrs ?? {}), textAlign: align }
+        }
+      }
+    }
+    return blocks
+  }
+
+  // Unrecognized → degrade to plain text paragraph(s)
+  const lines = trimmed.split('\n').map(l => l.trim()).filter(Boolean)
+  return lines.map(line => ({
+    type: 'paragraph',
+    content: [{ type: 'text', text: line }],
+  }))
+}
+
+// ── HTML table parser ─────────────────────────────────────────────────────────
+
+/** Wrap a run of inline nodes in a single paragraph (legacy fallback when no blockMap given). */
+function wrapInlineAsParagraph(inline: PmNode[]): PmNode[] {
+  return inline.length ? [{ type: 'paragraph', content: inline }] : []
+}
+
+/**
+ * Parse an exporter HTML-fallback `<table>` into a PM table node. Uses the DOM (DOMParser is
+ * available in the browser and in the jsdom test env) rather than regex, so it correctly handles
+ * NESTED tables and block cell content (images, lists, paragraphs) that the exporter emits when a
+ * cell can't fit a single GFM pipe cell. A cell's children are mapped recursively to PM blocks;
+ * a cell that is only inline content collapses to a single paragraph (matching a plain cell).
+ */
+function parseHtmlTable(
+  html: string,
+  inlineMap: InlineMapper,
+  warnings: string[],
+): PmNode | null {
+  if (typeof DOMParser === 'undefined') return parseHtmlTableRegex(html, inlineMap, warnings)
+  let root: Element | null
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    root = doc.querySelector('table')
+  } catch {
+    return parseHtmlTableRegex(html, inlineMap, warnings)
+  }
+  if (!root) return null
+  const table = domTableToNode(root, inlineMap, warnings)
+  return table && (table.content?.length ?? 0) > 0 ? table : null
+}
+
+/** Convert a DOM <table> element to a PM table node (recurses for nested tables). */
+function domTableToNode(tableEl: Element, inlineMap: InlineMapper, warnings: string[]): PmNode {
+  const rows: PmNode[] = []
+  // Only DIRECT rows of THIS table (skip rows that belong to a nested table in a cell).
+  const trEls: Element[] = []
+  for (const section of Array.from(tableEl.children)) {
+    const tag = section.tagName.toLowerCase()
+    if (tag === 'tr') trEls.push(section)
+    else if (tag === 'thead' || tag === 'tbody' || tag === 'tfoot') {
+      for (const tr of Array.from(section.children)) if (tr.tagName.toLowerCase() === 'tr') trEls.push(tr)
+    }
+  }
+  for (const tr of trEls) {
+    const cells: PmNode[] = []
+    for (const cellEl of Array.from(tr.children)) {
+      const tag = cellEl.tagName.toLowerCase()
+      if (tag !== 'td' && tag !== 'th') continue
+      const colspan = Math.max(1, parseInt(cellEl.getAttribute('colspan') ?? '1', 10) || 1)
+      const rowspan = Math.max(1, parseInt(cellEl.getAttribute('rowspan') ?? '1', 10) || 1)
+      const blocks = domCellToBlocks(cellEl, inlineMap, warnings)
+      const cell: PmNode = {
+        type: tag === 'th' ? 'tableHeader' : 'tableCell',
+        content: blocks.length ? blocks : [{ type: 'paragraph' }],
+      }
+      if (colspan > 1 || rowspan > 1) {
+        cell.attrs = {}
+        if (colspan > 1) cell.attrs.colspan = colspan
+        if (rowspan > 1) cell.attrs.rowspan = rowspan
+      }
+      cells.push(cell)
+    }
+    if (cells.length) rows.push({ type: 'tableRow', content: cells })
+  }
+  return { type: 'table', content: rows }
+}
+
+/** Map a <td>/<th>'s children to PM block nodes. Bare inline content becomes one paragraph. */
+function domCellToBlocks(cellEl: Element, inlineMap: InlineMapper, warnings: string[]): PmNode[] {
+  const out: PmNode[] = []
+  let inlineRun = ''
+  const flushInline = () => {
+    const text = inlineRun.trim()
+    inlineRun = ''
+    if (!text) return
+    const inline = inlineMap(text, warnings)
+    if (inline.length) out.push({ type: 'paragraph', content: inline })
+  }
+  for (const child of Array.from(cellEl.childNodes)) {
+    if (child.nodeType === 3 /* text */) {
+      inlineRun += (child.textContent ?? '')
+      continue
+    }
+    if (child.nodeType !== 1) continue
+    const el = child as Element
+    const tag = el.tagName.toLowerCase()
+    if (tag === 'table') {
+      flushInline()
+      out.push(domTableToNode(el, inlineMap, warnings))
+    } else if (tag === 'img') {
+      flushInline()
+      const img = domImgToNode(el)
+      if (img) out.push(img)
+    } else if (tag === 'p') {
+      flushInline()
+      const inline = inlineMap((el.innerHTML || '').trim(), warnings)
+      out.push(inline.length ? { type: 'paragraph', content: inline } : { type: 'paragraph' })
+    } else if (tag === 'ul' || tag === 'ol') {
+      flushInline()
+      out.push(domListToNode(el, tag === 'ol', inlineMap, warnings))
+    } else if (/^h[1-6]$/.test(tag)) {
+      flushInline()
+      out.push({ type: 'heading', attrs: { level: Number(tag[1]) }, content: inlineMap((el.innerHTML || '').trim(), warnings) })
+    } else if (tag === 'pre') {
+      flushInline()
+      const code = el.textContent ?? ''
+      const codeBlock: PmNode = { type: 'codeBlock', attrs: {} }
+      if (code) codeBlock.content = [{ type: 'text', text: code }]
+      out.push(codeBlock)
+    } else if (tag === 'blockquote') {
+      flushInline()
+      const inner = domCellToBlocks(el, inlineMap, warnings)
+      out.push({ type: 'blockquote', content: inner.length ? inner : [{ type: 'paragraph' }] })
+    } else if (tag === 'hr') {
+      flushInline()
+      out.push({ type: 'horizontalRule' })
+    } else {
+      // Unknown inline-ish element: fold its HTML into the inline run.
+      inlineRun += el.outerHTML
+    }
+  }
+  flushInline()
+  return out
+}
+
+function domImgToNode(el: Element): PmNode | null {
+  const src = el.getAttribute('src') ?? ''
+  if (!/^https?:\/\//i.test(src.trim())) return null
+  const safe = isSafeHref(src)
+  if (!safe) return null
+  const attrs: Record<string, unknown> = { src: safe }
+  const m = /\/(att_[A-Za-z0-9]+)(?:\/|\?|$)/.exec(src)
+  if (m) attrs.attachId = m[1]
+  const alt = el.getAttribute('alt')
+  if (alt) attrs.alt = alt
+  return { type: 'image', attrs }
+}
+
+function domListToNode(el: Element, ordered: boolean, inlineMap: InlineMapper, warnings: string[]): PmNode {
+  const items: PmNode[] = []
+  for (const liEl of Array.from(el.children)) {
+    if (liEl.tagName.toLowerCase() !== 'li') continue
+    const blocks = domCellToBlocks(liEl, inlineMap, warnings)
+    items.push({ type: 'listItem', content: blocks.length ? blocks : [{ type: 'paragraph' }] })
+  }
+  return { type: ordered ? 'orderedList' : 'bulletList', content: items }
+}
+
+/** Legacy regex fallback for environments without DOMParser (kept for flat exporter tables). */
+function parseHtmlTableRegex(
+  html: string,
+  inlineMap: InlineMapper,
+  _warnings: string[],
+): PmNode | null {
+  const rows: PmNode[] = []
+  const trRe = /<tr>([\s\S]*?)<\/tr>/gi
+  let trMatch: RegExpExecArray | null
+  while ((trMatch = trRe.exec(html))) {
+    const cells: PmNode[] = []
+    const cellRe = /<(th|td)([^>]*)>([\s\S]*?)<\/\1>/gi
+    let cellMatch: RegExpExecArray | null
+    while ((cellMatch = cellRe.exec(trMatch[1]))) {
+      const tag = cellMatch[1].toLowerCase()
+      const attrStr = cellMatch[2]
+      const content = cellMatch[3].trim()
+
+      const colspan = parseAttr(attrStr, 'colspan')
+      const rowspan = parseAttr(attrStr, 'rowspan')
+
+      const cellInline = content ? inlineMap(content, []) : []
+      const cell: PmNode = {
+        type: tag === 'th' ? 'tableHeader' : 'tableCell',
+        content: cellInline.length ? [{ type: 'paragraph', content: cellInline }] : [{ type: 'paragraph' }],
+      }
+      if (colspan > 1 || rowspan > 1) {
+        cell.attrs = {}
+        if (colspan > 1) cell.attrs.colspan = colspan
+        if (rowspan > 1) cell.attrs.rowspan = rowspan
+      }
+      cells.push(cell)
+    }
+    if (cells.length) rows.push({ type: 'tableRow', content: cells })
+  }
+  if (!rows.length) return null
+  return { type: 'table', content: rows }
+}
+
+function parseAttr(attrStr: string, name: string): number {
+  const m = new RegExp(`${name}="(\\d+)"`, 'i').exec(attrStr)
+  return m ? Math.max(1, parseInt(m[1], 10)) : 1
+}

--- a/packages/docs/src/import/markdown.math.test.ts
+++ b/packages/docs/src/import/markdown.math.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { parseMarkdownToPmDoc } from './markdown.ts'
+
+function mathAndText(md: string): { math: string[]; text: string[] } {
+  const res = parseMarkdownToPmDoc(md) as { doc?: unknown }
+  const doc = res.doc ?? res
+  const math: string[] = []
+  const text: string[] = []
+  const walk = (n: unknown): void => {
+    if (!n || typeof n !== 'object') return
+    const node = n as { type?: string; attrs?: { latex?: string }; content?: unknown[]; text?: string }
+    if (node.type === 'inlineMath' || node.type === 'blockMath') math.push(node.attrs?.latex ?? '')
+    if (node.type === 'text' && node.text) text.push(node.text)
+    if (Array.isArray(node.content)) node.content.forEach(walk)
+  }
+  walk(doc)
+  return { math, text }
+}
+
+describe('markdown import — dollar math', () => {
+  it('detects a formula that starts with a digit', () => {
+    expect(mathAndText('公式 $2^{2^{2}}$ 结束').math).toEqual(['2^{2^{2}}'])
+  })
+
+  it('preserves LaTeX row breaks (\\\\) inside inline math', () => {
+    const { math } = mathAndText('$\\begin{matrix} a \\\\ b \\end{matrix}$')
+    expect(math[0]).toContain('\\\\')
+    expect(math[0]).toBe('\\begin{matrix} a \\\\ b \\end{matrix}')
+  })
+
+  it('maps $$…$$ to blockMath, preserving escapes', () => {
+    const { math } = mathAndText('$$\\frac{a}{b} \\\\ c$$')
+    expect(math).toEqual(['\\frac{a}{b} \\\\ c'])
+  })
+
+  it('does NOT swallow currency like $5 and $9', () => {
+    const { math, text } = mathAndText('价格 $5 到 $9 之间')
+    expect(math).toEqual([])
+    expect(text.join('')).toContain('$5')
+    expect(text.join('')).toContain('$9')
+  })
+
+  it('does not treat a lone $ as math', () => {
+    const { math } = mathAndText('cost is $ today')
+    expect(math).toEqual([])
+  })
+
+  it('lifts an inline $$…$$ out of the paragraph so it is a schema-valid block node', () => {
+    // Regression: a `$$…$$` mixed with surrounding text (or inside a list/quote/cell) used to be
+    // emitted as a blockMath nested INSIDE a paragraph's inline content — schema-invalid, so
+    // setContent silently dropped it. blocksFromInline must lift blockMath to a top-level block.
+    const res = parseMarkdownToPmDoc('foo $$E=mc^2$$ bar') as { doc?: { content?: unknown[] } }
+    const doc = (res.doc ?? res) as { content?: Array<{ type?: string; content?: Array<{ type?: string }> }> }
+    const top = doc.content ?? []
+    // blockMath appears as a direct top-level block, NOT nested inside a paragraph.
+    const topBlockMath = top.filter((n) => n.type === 'blockMath')
+    expect(topBlockMath).toHaveLength(1)
+    const nestedInParagraph = top.some(
+      (n) => n.type === 'paragraph' && (n.content ?? []).some((c) => c.type === 'blockMath'),
+    )
+    expect(nestedInParagraph).toBe(false)
+    // The surrounding text survives as its own paragraph(s).
+    expect(mathAndText('foo $$E=mc^2$$ bar').text.join('')).toContain('foo')
+  })
+
+  it('lifts a $$…$$ block out of a list item paragraph', () => {
+    const res = parseMarkdownToPmDoc('- item with $$x^2$$ here') as { doc?: unknown }
+    const doc = res.doc ?? res
+    let nestedInParagraph = 0
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== 'object') return
+      const node = n as { type?: string; content?: unknown[] }
+      if (node.type === 'paragraph' && Array.isArray(node.content)) {
+        for (const c of node.content) if ((c as { type?: string }).type === 'blockMath') nestedInParagraph++
+      }
+      if (Array.isArray(node.content)) node.content.forEach(walk)
+    }
+    walk(doc)
+    expect(nestedInParagraph).toBe(0)
+    expect(mathAndText('- item with $$x^2$$ here').math).toContain('x^2')
+  })
+})

--- a/packages/docs/src/import/markdown.test.ts
+++ b/packages/docs/src/import/markdown.test.ts
@@ -1,0 +1,592 @@
+import { describe, it, expect } from 'vitest'
+import { parseMarkdownToPmDoc, type PmNode } from './markdown.ts'
+import { isSafeHref, isSafeCssColor } from './html-inline.ts'
+import { stripFrontMatter } from './frontmatter.ts'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function parse(input: string) {
+  return parseMarkdownToPmDoc(input)
+}
+
+function firstBlock(result: ReturnType<typeof parse>): PmNode {
+  return result.doc.content![0]
+}
+
+function textContent(node: PmNode): string {
+  if (node.type === 'text') return node.text ?? ''
+  return (node.content ?? []).map(textContent).join('')
+}
+
+// ── Block nodes ───────────────────────────────────────────────────────────────
+
+describe('parseMarkdownToPmDoc — block nodes', () => {
+  it('parses headings with correct level', () => {
+    const r = parse('# H1\n## H2\n### H3')
+    expect(r.doc.content!.length).toBe(3)
+    expect(r.doc.content![0]).toMatchObject({ type: 'heading', attrs: { level: 1 } })
+    expect(r.doc.content![1]).toMatchObject({ type: 'heading', attrs: { level: 2 } })
+    expect(r.doc.content![2]).toMatchObject({ type: 'heading', attrs: { level: 3 } })
+  })
+
+  it('extracts title from first H1', () => {
+    const r = parse('# My Title\nSome content')
+    expect(r.title).toBe('My Title')
+  })
+
+  it('parses paragraphs', () => {
+    const r = parse('Hello world')
+    expect(firstBlock(r)).toMatchObject({ type: 'paragraph' })
+    expect(textContent(firstBlock(r))).toBe('Hello world')
+  })
+
+  it('parses bullet lists', () => {
+    const r = parse('- item A\n- item B')
+    expect(firstBlock(r).type).toBe('bulletList')
+    expect(firstBlock(r).content!.length).toBe(2)
+    expect(firstBlock(r).content![0].type).toBe('listItem')
+  })
+
+  it('parses ordered lists', () => {
+    const r = parse('1. first\n2. second')
+    expect(firstBlock(r).type).toBe('orderedList')
+  })
+
+  it('parses task lists', () => {
+    const r = parse('- [ ] todo\n- [x] done')
+    expect(firstBlock(r).type).toBe('taskList')
+    expect(firstBlock(r).content![0]).toMatchObject({ type: 'taskItem', attrs: { checked: false } })
+    expect(firstBlock(r).content![1]).toMatchObject({ type: 'taskItem', attrs: { checked: true } })
+  })
+
+  it('maps a checkmark glyph in the checkbox to a checked task item', () => {
+    // Someone may hand-write `[✓]` / `[√]` instead of `[x]`; treat as checked.
+    const r = parse('- [✓] a\n- [√] b\n- [ ] c')
+    expect(firstBlock(r).type).toBe('taskList')
+    expect(firstBlock(r).content![0]).toMatchObject({ type: 'taskItem', attrs: { checked: true } })
+    expect(firstBlock(r).content![1]).toMatchObject({ type: 'taskItem', attrs: { checked: true } })
+    expect(firstBlock(r).content![2]).toMatchObject({ type: 'taskItem', attrs: { checked: false } })
+  })
+
+  it('does NOT treat a normal bullet starting with a check emoji as a task', () => {
+    // A bare leading ✅ (no brackets) is ordinary list content, not a checkbox.
+    const r = parse('- ✅ 这是普通列表项\n- ⚠／ 警告项')
+    expect(firstBlock(r).type).toBe('bulletList')
+  })
+
+  it('parses blockquotes', () => {
+    const r = parse('> quoted text')
+    expect(firstBlock(r).type).toBe('blockquote')
+  })
+
+  it('parses fenced code blocks with language', () => {
+    const r = parse('```ts\nconst x = 1\n```')
+    const cb = firstBlock(r)
+    expect(cb.type).toBe('codeBlock')
+    expect(cb.attrs?.language).toBe('ts')
+    expect(textContent(cb)).toBe('const x = 1')
+  })
+
+  it('parses horizontal rules', () => {
+    const r = parse('---')
+    expect(firstBlock(r).type).toBe('horizontalRule')
+  })
+
+  it('parses GFM tables', () => {
+    const r = parse('| A | B |\n| --- | --- |\n| 1 | 2 |')
+    const table = firstBlock(r)
+    expect(table.type).toBe('table')
+    expect(table.content!.length).toBe(2) // header + body row
+    expect(table.content![0].content![0].type).toBe('tableHeader')
+  })
+
+  it('produces empty paragraph for empty input', () => {
+    const r = parse('')
+    expect(r.doc.content!.length).toBe(1)
+    expect(r.doc.content![0].type).toBe('paragraph')
+  })
+
+  it('parses a standalone $$...$$ paragraph as blockMath (export inverse)', () => {
+    const r = parse('$$\nE=mc^2\n$$')
+    const b = firstBlock(r)
+    expect(b.type).toBe('blockMath')
+    expect(b.attrs?.latex).toBe('E=mc^2')
+  })
+
+  it('preserves multi-line LaTeX in block math', () => {
+    const r = parse('$$\n\\sum_{i=1}^n i\n= \\frac{n(n+1)}{2}\n$$')
+    const b = firstBlock(r)
+    expect(b.type).toBe('blockMath')
+    expect(b.attrs?.latex).toBe('\\sum_{i=1}^n i\n= \\frac{n(n+1)}{2}')
+  })
+
+  it('block math surrounded by paragraphs keeps order', () => {
+    const r = parse('before\n\n$$\na+b\n$$\n\nafter')
+    expect(r.doc.content!.map(n => n.type)).toEqual(['paragraph', 'blockMath', 'paragraph'])
+  })
+
+  it('does not treat inline $..$ text as block math', () => {
+    const r = parse('cost is $5 and $10 total')
+    const b = firstBlock(r)
+    expect(b.type).toBe('paragraph')
+  })
+
+  it('preserves a non-default ordered list start index', () => {
+    const r = parse('5. five\n6. six\n7. seven')
+    const list = firstBlock(r)
+    expect(list.type).toBe('orderedList')
+    expect(list.attrs?.start).toBe(5)
+    expect(list.content!.length).toBe(3)
+  })
+
+  it('omits start when an ordered list begins at 1', () => {
+    const r = parse('1. one\n2. two')
+    const list = firstBlock(r)
+    expect(list.type).toBe('orderedList')
+    expect(list.attrs?.start).toBeUndefined()
+  })
+})
+
+// ── Inline / marks ────────────────────────────────────────────────────────────
+
+describe('parseMarkdownToPmDoc — inline marks', () => {
+  it('parses bold', () => {
+    const r = parse('**bold**')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'bold' })
+  })
+
+  it('parses italic', () => {
+    const r = parse('*italic*')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'italic' })
+  })
+
+  it('parses inline code', () => {
+    const r = parse('`code`')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'code' })
+  })
+
+  it('parses strikethrough', () => {
+    const r = parse('~~struck~~')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'strike' })
+  })
+
+  it('parses ==highlight== as highlight mark', () => {
+    const r = parse('a ==marked== b')
+    const p = firstBlock(r)
+    const hl = p.content!.find(n => n.marks?.some(m => m.type === 'highlight'))
+    expect(hl).toBeDefined()
+    expect(hl!.text).toBe('marked')
+  })
+
+  it('parses <mark style="background-color:..."> into a colored highlight', () => {
+    const r = parse('<mark style="background-color:#fff3a3">yellow</mark>')
+    const p = firstBlock(r)
+    const hl = p.content!.find(n => n.marks?.some(m => m.type === 'highlight'))
+    expect(hl).toBeDefined()
+    expect(hl!.marks).toContainEqual({ type: 'highlight', attrs: { color: '#fff3a3' } })
+  })
+
+  it('parses links with safe href', () => {
+    const r = parse('[click](https://example.com)')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'link', attrs: { href: 'https://example.com/' } })
+  })
+
+  it('drops unsafe link hrefs', () => {
+    const r = parse('[evil](javascript:alert(1))')
+    const p = firstBlock(r)
+    // Link mark should NOT be present
+    expect(p.content![0].marks ?? []).not.toContainEqual(expect.objectContaining({ type: 'link' }))
+  })
+
+  it('parses inline math $...$', () => {
+    const r = parse('Formula $E=mc^2$ here')
+    const p = firstBlock(r)
+    const mathNode = p.content!.find(n => n.type === 'inlineMath')
+    expect(mathNode).toBeDefined()
+    expect(mathNode!.attrs?.latex).toBe('E=mc^2')
+  })
+
+  it('does not treat currency dollar amounts as inline math', () => {
+    const r = parse('这件 $5 那件 $9 都不贵')
+    const p = firstBlock(r)
+    expect(p.content!.some(n => n.type === 'inlineMath')).toBe(false)
+    expect(textContent(p)).toBe('这件 $5 那件 $9 都不贵')
+  })
+
+  it('keeps currency but still parses a real formula on the same line', () => {
+    const r = parse('价格 $5 但公式 $x^2$ 对')
+    const p = firstBlock(r)
+    const math = p.content!.filter(n => n.type === 'inlineMath')
+    expect(math.length).toBe(1)
+    expect(math[0].attrs?.latex).toBe('x^2')
+    expect(textContent(p)).toContain('$5')
+  })
+
+  it('parses emoji shortcodes when the resolver confirms them', () => {
+    const r = parseMarkdownToPmDoc('Hello :smile: world', { emojiName: (n) => (n === 'smile' ? '😄' : undefined) })
+    const p = firstBlock(r)
+    const emojiNode = p.content!.find(n => n.type === 'emoji')
+    expect(emojiNode).toBeDefined()
+    expect(emojiNode!.attrs?.name).toBe('smile')
+  })
+
+  it('keeps unknown emoji shortcodes as literal text', () => {
+    const r = parseMarkdownToPmDoc('a :not_a_real_emoji: b', { emojiName: () => undefined })
+    const p = firstBlock(r)
+    expect(p.content!.find(n => n.type === 'emoji')).toBeUndefined()
+    expect(textContent(p)).toBe('a :not_a_real_emoji: b')
+  })
+
+  it('does not emit emoji nodes without a resolver', () => {
+    const r = parse('Hello :smile: world')
+    const p = firstBlock(r)
+    expect(p.content!.find(n => n.type === 'emoji')).toBeUndefined()
+    expect(textContent(p)).toContain(':smile:')
+  })
+})
+
+// ── Images ────────────────────────────────────────────────────────────────────
+
+describe('parseMarkdownToPmDoc — images', () => {
+  it('imports network images', () => {
+    const r = parse('![alt](https://example.com/img.png)')
+    // An image is a BLOCK node: it must be a top-level block, NOT wrapped in a paragraph
+    // (a block node inside a paragraph's inline content is schema-invalid and gets dropped).
+    const img = r.doc.content!.find(n => n.type === 'image')
+    expect(img).toBeDefined()
+    expect(img!.attrs?.src).toBe('https://example.com/img.png')
+    expect(img!.attrs?.alt).toBe('alt')
+  })
+
+  it('degrades local images to text placeholder', () => {
+    const r = parse('![logo](./logo.png)')
+    expect(r.warnings.length).toBeGreaterThan(0)
+    expect(r.warnings[0]).toContain('docs.import.localImagesSkipped')
+    const p = firstBlock(r)
+    // Should be text, not image
+    expect(p.content!.find(n => n.type === 'image')).toBeUndefined()
+  })
+
+  it('degrades data: images to text placeholder', () => {
+    const r = parse('![x](data:image/png;base64,abc)')
+    expect(r.warnings.length).toBeGreaterThan(0)
+  })
+
+  it('recovers the durable attachId from a signed export URL (survives signature expiry)', () => {
+    const url =
+      'http://localhost:28080/file/d_pdf_test_full/att_13a2f15faef2f55111bbfc69/222.png' +
+      '?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=600&X-Amz-Signature=deadbeef'
+    const r = parse(`![测试 PNG](${url})`)
+    const img = r.doc.content!.find(n => n.type === 'image')
+    expect(img).toBeDefined()
+    expect(img!.attrs?.attachId).toBe('att_13a2f15faef2f55111bbfc69')
+    expect(img!.attrs?.src).toBe(url)
+    expect(r.warnings.length).toBe(0)
+  })
+
+  it('leaves attachId unset for a plain external image URL', () => {
+    const r = parse('![a](https://example.com/pic.png)')
+    const img = r.doc.content!.find(n => n.type === 'image')
+    expect(img!.attrs?.attachId).toBeUndefined()
+  })
+
+  it('puts a block image inside a table cell as a block child, not wrapped in a paragraph', () => {
+    // The exact regression: `| ![](url) |` used to wrap the block image in the cell's
+    // paragraph (schema-invalid) so the image loaded bytes but never rendered.
+    const md = [
+      '| 说明 | 图 |',
+      '| --- | --- |',
+      '| 单元格文字 | ![p](https://example.com/x.png) |',
+    ].join('\n')
+    const r = parse(md)
+    const table = r.doc.content!.find(n => n.type === 'table')!
+    // body row -> second cell -> should contain a block-level image node directly.
+    const bodyRow = table.content!.find(row => row.content!.some(c => c.type === 'tableCell'))!
+    const imgCell = bodyRow.content!.find(c => c.content!.some(b => b.type === 'image'))
+    expect(imgCell).toBeDefined()
+    const img = imgCell!.content!.find(b => b.type === 'image')!
+    expect(img.attrs?.src).toBe('https://example.com/x.png')
+    // The image must NOT be nested inside a paragraph in the cell.
+    const para = imgCell!.content!.find(b => b.type === 'paragraph')
+    expect(para?.content?.some(n => n.type === 'image')).not.toBe(true)
+  })
+
+  it('keeps text and a block image as separate blocks in the same cell', () => {
+    const md = [
+      '| c |',
+      '| --- |',
+      '| hi ![p](https://example.com/y.png) |',
+    ].join('\n')
+    const r = parse(md)
+    const table = r.doc.content!.find(n => n.type === 'table')!
+    const bodyRow = table.content!.find(row => row.content!.some(c => c.type === 'tableCell'))!
+    const cell = bodyRow.content!.find(c => c.type === 'tableCell')!
+    // Expect a paragraph ("hi") AND a standalone image block.
+    expect(cell.content!.some(b => b.type === 'paragraph')).toBe(true)
+    expect(cell.content!.some(b => b.type === 'image')).toBe(true)
+  })
+
+  it('does not emit an empty text node for an empty <pre> in a table cell (white-screen guard)', () => {
+    // Empty <pre></pre> inside a cell used to produce content:[{type:'text',text:''}],
+    // an empty text node that makes setContent throw -> whole page goes blank.
+    const md = '<table><tr><td><pre></pre></td><td>x</td></tr></table>'
+    const r = parse(md)
+    const table = r.doc.content!.find(n => n.type === 'table')!
+    const bodyRow = table.content!.find(row => row.content!.some(c => c.type === 'tableCell'))!
+    const cb = bodyRow.content!
+      .flatMap(c => c.content ?? [])
+      .find(b => b.type === 'codeBlock')!
+    expect(cb).toBeDefined()
+    // Empty code block must NOT carry an empty text node.
+    expect(cb.content).toBeUndefined()
+  })
+})
+
+// ── Security ──────────────────────────────────────────────────────────────────
+
+describe('isSafeHref', () => {
+  it('accepts http/https/mailto/tel', () => {
+    expect(isSafeHref('https://example.com')).toBeTruthy()
+    expect(isSafeHref('http://example.com')).toBeTruthy()
+    expect(isSafeHref('mailto:a@b.com')).toBeTruthy()
+    expect(isSafeHref('tel:+1234567890')).toBeTruthy()
+  })
+
+  it('rejects javascript:/data:/vbscript:', () => {
+    expect(isSafeHref('javascript:alert(1)')).toBeNull()
+    expect(isSafeHref('data:text/html,<h1>hi</h1>')).toBeNull()
+    expect(isSafeHref('vbscript:msgbox')).toBeNull()
+  })
+
+  it('rejects tab-bypass variants', () => {
+    expect(isSafeHref('java\tscript:alert(1)')).toBeNull()
+  })
+
+  it('accepts relative URLs', () => {
+    expect(isSafeHref('/path/to/page')).toBeTruthy()
+    expect(isSafeHref('page.html')).toBeTruthy()
+  })
+})
+
+describe('isSafeCssColor', () => {
+  it('accepts hex colors', () => {
+    expect(isSafeCssColor('#ff0000')).toBe('#ff0000')
+    expect(isSafeCssColor('#f00')).toBe('#f00')
+  })
+
+  it('accepts rgb/rgba/hsl', () => {
+    expect(isSafeCssColor('rgb(255, 0, 0)')).toBeTruthy()
+    expect(isSafeCssColor('rgba(255, 0, 0, 0.5)')).toBeTruthy()
+    expect(isSafeCssColor('hsl(120, 100%, 50%)')).toBeTruthy()
+  })
+
+  it('accepts named colors', () => {
+    expect(isSafeCssColor('red')).toBe('red')
+    expect(isSafeCssColor('blue')).toBe('blue')
+  })
+
+  it('rejects CSS injection attempts', () => {
+    expect(isSafeCssColor('red;position:fixed')).toBeNull()
+    expect(isSafeCssColor('red;background:url(evil)')).toBeNull()
+  })
+})
+
+// ── Front matter ──────────────────────────────────────────────────────────────
+
+describe('stripFrontMatter', () => {
+  it('extracts title from YAML front matter', () => {
+    const r = stripFrontMatter('---\ntitle: My Doc\nauthor: test\n---\nBody')
+    expect(r.frontMatter.title).toBe('My Doc')
+    expect(r.body).toBe('Body')
+  })
+
+  it('returns input unchanged when no front matter', () => {
+    const r = stripFrontMatter('Just text')
+    expect(r.frontMatter.title).toBeUndefined()
+    expect(r.body).toBe('Just text')
+  })
+
+  it('uses front matter title as doc title', () => {
+    const r = parse('---\ntitle: FM Title\n---\n# H1 Title\nBody')
+    expect(r.title).toBe('FM Title')
+  })
+})
+
+// ── HTML blocks (whitelist) ───────────────────────────────────────────────────
+
+describe('parseMarkdownToPmDoc — HTML blocks', () => {
+  it('drops HTML comments instead of emitting them as text', () => {
+    const r = parse('<!-- 注意：签名链接可能过期 -->\n\n# 标题\n\n正文')
+    expect(r.doc.content!.map(n => n.type)).toEqual(['heading', 'paragraph'])
+  })
+
+  it('drops a leading export-header comment (no stray text block)', () => {
+    const r = parse('<!-- 注意：图片/附件为签名链接，可能过期 -->\n\n正文段落')
+    expect(r.doc.content!.length).toBe(1)
+    expect(firstBlock(r).type).toBe('paragraph')
+    expect(textContent(firstBlock(r))).toBe('正文段落')
+  })
+
+  it('parses callout divs', () => {
+    const r = parse('<div data-callout data-variant="warning">\n\nWatch out!\n\n</div>')
+    const callout = firstBlock(r)
+    expect(callout.type).toBe('callout')
+    expect(callout.attrs?.variant).toBe('warning')
+  })
+
+  it('re-parses callout body as block content (headings, lists survive)', () => {
+    const r = parse('<div data-callout data-variant="info">\n\n# Title\n\nbody para\n\n- one\n- two\n\n</div>')
+    const callout = firstBlock(r)
+    expect(callout.type).toBe('callout')
+    const kinds = callout.content!.map(n => n.type)
+    expect(kinds).toEqual(['heading', 'paragraph', 'bulletList'])
+    expect(callout.content![0].attrs?.level).toBe(1)
+  })
+
+  it('parses details/summary', () => {
+    const r = parse('<details>\n<summary>Click me</summary>\n\nHidden content\n\n</details>')
+    const details = firstBlock(r)
+    expect(details.type).toBe('details')
+    expect(details.content!.length).toBe(2)
+    expect(details.content![0].type).toBe('detailsSummary')
+    expect(details.content![1].type).toBe('detailsContent')
+  })
+
+  it('re-parses details body as block content', () => {
+    const r = parse('<details>\n<summary>More</summary>\n\n## Sub\n\n- a\n- b\n\n</details>')
+    const details = firstBlock(r)
+    const body = details.content!.find(n => n.type === 'detailsContent')!
+    expect(body.content!.map(n => n.type)).toEqual(['heading', 'bulletList'])
+  })
+
+  it('parses NESTED details (inner collapse stays a details node, not literal text)', () => {
+    // Regression: the assembler stopped at the FIRST </details>, so a nested inner details had
+    // its `<details>`/`<summary>`/`</details>` leak through as plain text and the outer close
+    // was orphaned. Depth-balanced matching keeps the inner details as a real details node.
+    const md =
+      '<details>\n<summary>外层折叠</summary>\n\n' +
+      '<details>\n<summary>内层折叠</summary>\n\n' +
+      '内层内容\n\n' +
+      '</details>\n\n' +
+      '</details>'
+    const r = parse(md)
+    const outer = firstBlock(r)
+    expect(outer.type).toBe('details')
+    const outerBody = outer.content!.find(n => n.type === 'detailsContent')!
+    // The outer body must contain the inner details as a real node — not literal `<details>` text.
+    const inner = outerBody.content!.find(n => n.type === 'details')
+    expect(inner).toBeDefined()
+    const innerSummary = inner!.content!.find(n => n.type === 'detailsSummary')!
+    const text = (node: PmNode): string =>
+      node.type === 'text' ? (node.text ?? '') : (node.content ?? []).map(text).join('')
+    expect(text(innerSummary)).toBe('内层折叠')
+    // No orphaned literal HTML tags anywhere in the result.
+    const flat = JSON.stringify(r.doc)
+    expect(flat).not.toContain('&lt;details&gt;')
+    expect(flat).not.toContain('<details>')
+    expect(flat).not.toContain('</details>')
+  })
+
+  it('parses HTML tables with colspan/rowspan', () => {
+    const html = '<table>\n<tr><th colspan="2">Header</th></tr>\n<tr><td>A</td><td>B</td></tr>\n</table>'
+    const r = parse(html)
+    const table = firstBlock(r)
+    expect(table.type).toBe('table')
+    expect(table.content![0].content![0].attrs?.colspan).toBe(2)
+  })
+})
+
+// ── Inline HTML marks ─────────────────────────────────────────────────────────
+
+describe('parseMarkdownToPmDoc — inline HTML marks', () => {
+  it('parses <u> as underline', () => {
+    const r = parse('<u>underlined</u>')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'underline' })
+  })
+
+  it('parses <mark> as highlight', () => {
+    const r = parse('<mark>highlighted</mark>')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'highlight' })
+  })
+
+  it('parses <sub>/<sup>', () => {
+    const r = parse('H<sub>2</sub>O and x<sup>2</sup>')
+    const p = firstBlock(r)
+    expect(p.content!.some(n => n.marks?.some(m => m.type === 'subscript'))).toBe(true)
+    expect(p.content!.some(n => n.marks?.some(m => m.type === 'superscript'))).toBe(true)
+  })
+
+  it('parses <span style="color:..."> as textStyle', () => {
+    const r = parse('<span style="color:red">colored</span>')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'textStyle', attrs: { color: 'red' } })
+  })
+
+  it('parses <span style="font-size:..."> as textStyle (export inverse)', () => {
+    const r = parse('<span style="font-size:24px">big</span>')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({ type: 'textStyle', attrs: { fontSize: '24px' } })
+  })
+
+  it('parses a combined color + font-size span into one textStyle mark', () => {
+    const r = parse('<span style="color:red;font-size:18px">both</span>')
+    const p = firstBlock(r)
+    expect(p.content![0].marks).toContainEqual({
+      type: 'textStyle',
+      attrs: { color: 'red', fontSize: '18px' },
+    })
+  })
+
+  it('drops an unsafe font-size value but keeps the text', () => {
+    const r = parse('<span style="font-size:24px;position:fixed">x</span>')
+    const p = firstBlock(r)
+    // The bogus `position:fixed` declaration is ignored; the safe font-size still applies.
+    expect(p.content![0].marks).toContainEqual({ type: 'textStyle', attrs: { fontSize: '24px' } })
+    expect(textContent(p)).toBe('x')
+  })
+
+  it('ignores non-whitelisted declarations while keeping the safe color', () => {
+    // Per-declaration parsing neutralizes the injected `position:fixed` (dropped as a
+    // non-whitelisted property) while preserving the legitimate color. The dangerous
+    // declaration never reaches the DOM — marks only ever carry color/fontSize.
+    const r = parse('<span style="color:red;position:fixed">evil</span>')
+    const p = firstBlock(r)
+    const ts = p.content![0].marks?.find((m) => m.type === 'textStyle')
+    expect(ts).toEqual({ type: 'textStyle', attrs: { color: 'red' } })
+    expect((ts?.attrs as Record<string, unknown> | undefined)?.position).toBeUndefined()
+  })
+})
+
+describe('parseMarkdownToPmDoc — aligned blocks (round-trip with export)', () => {
+  it('recovers a centered paragraph from the exporter <p align> wrapper', () => {
+    const r = parse('<p align="center">hello world</p>')
+    const p = r.doc.content!.find((n) => n.type === 'paragraph')
+    expect(p).toBeDefined()
+    expect((p!.attrs as Record<string, unknown>).textAlign).toBe('center')
+    // The literal tag must not leak into the text content.
+    expect(JSON.stringify(r.doc)).not.toContain('<p align')
+  })
+
+  it('recovers a right-aligned heading from the exporter <div align> wrapper', () => {
+    const r = parse('<div align="right">## Title</div>')
+    const h = r.doc.content!.find((n) => n.type === 'heading')
+    expect(h).toBeDefined()
+    expect((h!.attrs as Record<string, unknown>).textAlign).toBe('right')
+    expect((h!.attrs as Record<string, unknown>).level).toBe(2)
+    expect(JSON.stringify(r.doc)).not.toContain('<div align')
+  })
+
+  it('ignores an unsafe/unknown align value instead of writing it onto the node', () => {
+    const r = parse('<p align="center;evil">x</p>')
+    const p = r.doc.content!.find((n) => n.type === 'paragraph')
+    expect(p).toBeDefined()
+    expect((p!.attrs as Record<string, unknown> | undefined)?.textAlign).toBeUndefined()
+  })
+})

--- a/packages/docs/src/import/markdown.ts
+++ b/packages/docs/src/import/markdown.ts
@@ -1,0 +1,819 @@
+// Markdown → ProseMirror-JSON import (reverse of ../export/markdown.ts).
+//
+// Parses a Markdown/GFM string with markdown-it, then maps the token stream onto the
+// editor's ProseMirror schema (SCHEMA_VERSION 15). This is the strict inverse of the
+// export serializer: every node/mark the exporter can emit has a mapping back here, so a
+// round-trip (export → import) reconstructs the document structure.
+//
+// Design doc: docs/markdown-import-design.md
+//
+// Security (inherited from the PDF-export lessons):
+//   - every link href / image src passes a scheme whitelist (http/https/mailto/tel/relative);
+//     javascript:/data:/vbscript: and tab-bypass variants are dropped.
+//   - inline <span style="color:…"> values pass a CSS-color whitelist; anything with
+//     `;`/`(`/`)` or an unknown token is discarded (blocks `red;position:fixed` injection).
+//   - unknown/unhandled HTML is NEVER innerHTML-injected — it degrades to plain text.
+
+import MarkdownIt from 'markdown-it'
+import type Token from 'markdown-it/lib/token.mjs'
+import { stripFrontMatter } from './frontmatter.ts'
+import { isSafeHref, parseInlineHtml, parseHtmlBlock, type BlockMapper } from './html-inline.ts'
+
+/** ProseMirror-JSON node (mirrors export's MdNode). */
+export interface PmNode {
+  type: string
+  attrs?: Record<string, unknown>
+  content?: PmNode[]
+  text?: string
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>
+}
+
+export interface ImportResult {
+  /** The parsed ProseMirror document (type: 'doc'). Ready for editor.commands.setContent. */
+  doc: PmNode
+  /** Best-effort title: front-matter title → first H1 text → null (caller falls back to filename). */
+  title: string | null
+  /** Non-fatal notes surfaced to the user (e.g. "3 local images could not be imported"). */
+  warnings: string[]
+}
+
+export interface ImportOptions {
+  /**
+   * Resolver for `:shortcode:` emoji: given the shortcode/name, return its glyph (or any truthy
+   * value) when it is a real emoji, or undefined when unknown. Unknown shortcodes stay as literal
+   * `:name:` text instead of becoming blank emoji nodes.
+   */
+  emojiName?: (name: string) => string | undefined
+  /**
+   * Translator for user-facing warning / placeholder text. Given an i18n key
+   * (and optional interpolation params) it returns the localized string. When
+   * omitted, callers fall back to the raw key so the parser stays pure and the
+   * source carries no hard-coded UI strings.
+   */
+  t?: (key: string, params?: Record<string, string | number>) => string
+}
+
+let mdInstance: MarkdownIt | null = null
+function md(): MarkdownIt {
+  if (mdInstance) return mdInstance
+  mdInstance = new MarkdownIt('commonmark', { html: true, linkify: false, breaks: false })
+    .enable(['table', 'strikethrough'])
+  // Tokenize `$…$` / `$$…$$` math BEFORE markdown-it's escape rule runs, so that
+  // LaTeX backslash sequences survive verbatim. Without this the inline text
+  // pass collapses `\\` (a matrix/cases/substack row break) to `\` and eats
+  // other `\x` escapes, corrupting every multi-line formula. The tokens carry
+  // the RAW source; mapInline maps math_inline/math_block below.
+  mdInstance.inline.ruler.before('escape', 'math_dollar', mathInlineRule)
+  return mdInstance
+}
+
+/**
+ * markdown-it inline rule for dollar-delimited math. Recognises `$$…$$` (inline
+ * display) and `$…$`, applying CommonMark/pandoc-ish boundary rules so ordinary
+ * currency (`$5`, `$5 到 $9`) is not swallowed: the opening `$` must not be
+ * followed by whitespace, and the closing `$` must not be preceded by whitespace
+ * nor (for single `$`) directly followed by a digit. Content is taken verbatim
+ * from the source so LaTeX escapes (`\\`, `\{`, …) are preserved.
+ */
+function mathInlineRule(state: unknown, silent: boolean): boolean {
+  const s = state as {
+    src: string
+    pos: number
+    posMax: number
+    push: (type: string, tag: string, nesting: number) => { content: string; markup: string }
+  }
+  const src = s.src
+  let pos = s.pos
+  if (src.charCodeAt(pos) !== 0x24 /* $ */) return false
+
+  const isDisplay = src.charCodeAt(pos + 1) === 0x24
+  const open = isDisplay ? 2 : 1
+  const start = pos + open
+  if (start >= s.posMax) return false
+  // Opening boundary: no whitespace right after the opener.
+  if (/\s/.test(src[start] ?? '')) return false
+
+  // Find the matching closer within the current inline span.
+  const closer = isDisplay ? '$$' : '$'
+  let end = -1
+  for (let i = start; i < s.posMax; i++) {
+    if (isDisplay) {
+      if (src.charCodeAt(i) === 0x24 && src.charCodeAt(i + 1) === 0x24) {
+        end = i
+        break
+      }
+    } else if (src.charCodeAt(i) === 0x24) {
+      end = i
+      break
+    }
+  }
+  if (end < 0 || end === start) return false
+
+  const content = src.slice(start, end)
+  // Closing boundary for single `$`: no trailing whitespace before it, and not a
+  // bare currency range (closer not directly followed by a digit).
+  if (!isDisplay) {
+    if (/\s$/.test(content)) return false
+    if (/[0-9]/.test(src[end + 1] ?? '')) return false
+  }
+  if (!content.trim()) return false
+
+  if (!silent) {
+    const token = s.push(isDisplay ? 'math_block' : 'math_inline', 'math', 0)
+    token.content = content
+    token.markup = closer
+  }
+  s.pos = end + open
+  return true
+}
+
+/**
+ * Parse a Markdown string into a ProseMirror document. Pure (no network, no editor);
+ * the caller creates the doc and injects `result.doc` after the editor loads.
+ */
+export function parseMarkdownToPmDoc(input: string, opts: ImportOptions = {}): ImportResult {
+  const warnings: string[] = []
+  const { body, frontMatter } = stripFrontMatter(input)
+
+  const tokens = md().parse(body, {})
+  const ctx: Ctx = { opts, warnings, localImageCount: 0, sourceLines: body.split('\n') }
+  const content = mapBlockTokens(tokens, ctx)
+
+  // Empty doc guard: ProseMirror requires at least one block child.
+  if (content.length === 0) content.push({ type: 'paragraph' })
+
+  const fmTitle = frontMatter.title?.trim() || null
+  const title = fmTitle ?? firstHeadingText(content)
+
+  if (ctx.localImageCount > 0) {
+    warnings.push(
+      tr(opts, 'docs.import.localImagesSkipped', { count: ctx.localImageCount }),
+    )
+  }
+
+  return { doc: { type: 'doc', content }, title, warnings }
+}
+
+/**
+ * Translate an i18n key via the optional translator, falling back to the key
+ * itself when none is supplied. Keeps the parser free of hard-coded UI strings
+ * (the i18n gate scans source for CJK literals).
+ */
+function tr(
+  opts: ImportOptions,
+  key: string,
+  params?: Record<string, string | number>,
+): string {
+  return opts.t ? opts.t(key, params) : key
+}
+
+interface Ctx {
+  opts: ImportOptions
+  warnings: string[]
+  localImageCount: number
+  /** Raw body source split by line, so html_block reassembly can slice original Markdown. */
+  sourceLines: string[]
+}
+
+function firstHeadingText(nodes: PmNode[]): string | null {
+  for (const n of nodes) {
+    if (n.type === 'heading' && (n.attrs?.level ?? 1) === 1) {
+      const txt = collectText(n).trim()
+      if (txt) return txt
+    }
+  }
+  return null
+}
+
+function collectText(node: PmNode): string {
+  if (node.type === 'text') return node.text ?? ''
+  return (node.content ?? []).map(collectText).join('')
+}
+
+// ── Block token walk ───────────────────────────────────────────────────────
+
+/**
+ * markdown-it emits a flat token stream with *_open / *_close pairs. We consume it with a
+ * cursor and recurse into container ranges.
+ */
+function mapBlockTokens(tokens: Token[], ctx: Ctx): PmNode[] {
+  const out: PmNode[] = []
+  let i = 0
+  while (i < tokens.length) {
+    const tok = tokens[i]
+    switch (tok.type) {
+      case 'heading_open': {
+        const level = clampLevel(Number(tok.tag.slice(1)))
+        const { inline, next } = takeInline(tokens, i, ctx)
+        out.push({ type: 'heading', attrs: { level }, content: inline })
+        i = next
+        break
+      }
+      case 'paragraph_open': {
+        // A whole-paragraph `$$…$$` is block math. CommonMark has no math node and this repo
+        // doesn't load a texmath plugin, so the exporter's `$$\n…\n$$` arrives as a plain
+        // paragraph; detect it from the raw inline source (which preserves newlines) and emit
+        // a blockMath node — the strict inverse of export's serializeBlock('blockMath').
+        const rawInline = tokens[i + 1]
+        const rawText =
+          rawInline && rawInline.type === 'inline' ? rawInline.content : ''
+        const blockMath = detectBlockMath(rawText)
+        if (blockMath) {
+          out.push(blockMath)
+          i = i + 3 // paragraph_open + inline + paragraph_close
+          break
+        }
+        const { inline, next } = takeInline(tokens, i, ctx)
+        // A paragraph's inline run may contain BLOCK image nodes (our image node is
+        // group 'block', not inline). A block node inside a paragraph's inline content is
+        // schema-invalid — ProseMirror drops/normalizes it, so the image silently vanishes
+        // even though its bytes load. Split the run into valid blocks: standalone images
+        // become their own block, contiguous true-inline nodes stay in a paragraph.
+        for (const b of blocksFromInline(inline)) out.push(b)
+        i = next
+        break
+      }
+      case 'bullet_list_open': {
+        const { node, next } = takeList(tokens, i, 'bulletList', ctx)
+        out.push(node)
+        i = next
+        break
+      }
+      case 'ordered_list_open': {
+        const { node, next } = takeList(tokens, i, 'orderedList', ctx)
+        out.push(node)
+        i = next
+        break
+      }
+      case 'blockquote_open': {
+        const end = matchClose(tokens, i, 'blockquote_open', 'blockquote_close')
+        const inner = mapBlockTokens(tokens.slice(i + 1, end), ctx)
+        out.push({ type: 'blockquote', content: inner.length ? inner : [{ type: 'paragraph' }] })
+        i = end + 1
+        break
+      }
+      case 'fence':
+      case 'code_block': {
+        const lang = tok.type === 'fence' ? (tok.info || '').trim().split(/\s+/)[0] : ''
+        const code = tok.content.replace(/\n$/, '')
+        const node: PmNode = { type: 'codeBlock', attrs: lang ? { language: lang } : {} }
+        if (code) node.content = [{ type: 'text', text: code }]
+        out.push(node)
+        i += 1
+        break
+      }
+      case 'hr':
+        out.push({ type: 'horizontalRule' })
+        i += 1
+        break
+      case 'table_open': {
+        const end = matchClose(tokens, i, 'table_open', 'table_close')
+        out.push(mapTable(tokens.slice(i + 1, end), ctx))
+        i = end + 1
+        break
+      }
+      case 'math_block': // markdown-it-texmath style; also handled via fence info below
+        out.push({ type: 'blockMath', attrs: { latex: tok.content.trim() } })
+        i += 1
+        break
+      case 'html_block': {
+        // markdown-it splits multi-line HTML blocks at blank lines, so a callout/details
+        // becomes: html_block(open) → paragraph(s) → html_block(close). Reassemble them.
+        // The re-parse of a callout/details BODY runs on a NEW substring, so it needs a ctx
+        // whose sourceLines match THAT substring (nested details reassembly slices sourceLines
+        // by the substring's own `.map` ranges; sharing the outer sourceLines would slice the
+        // wrong lines and leak the inner `<details>`/`<summary>` tags as literal text).
+        const blockMap: BlockMapper = (markdown) =>
+          mapBlockTokens(md().parse(markdown, {}), { ...ctx, sourceLines: markdown.split('\n') })
+        const assembled = tryAssembleHtmlBlock(tokens, i, ctx)
+        if (assembled) {
+          const nodes = parseHtmlBlock(assembled.html, (t) => mapInlineHtmlText(t, ctx), ctx.warnings, blockMap)
+          for (const n of nodes) out.push(n)
+          i = assembled.next
+        } else {
+          const nodes = parseHtmlBlock(tok.content, (t) => mapInlineHtmlText(t, ctx), ctx.warnings, blockMap)
+          for (const n of nodes) out.push(n)
+          i += 1
+        }
+        break
+      }
+      default:
+        i += 1
+    }
+  }
+  return out
+}
+
+/**
+ * Try to reassemble a split HTML block. markdown-it breaks multi-line HTML at blank lines,
+ * so `<div data-callout>\n\ncontent\n\n</div>` becomes several tokens:
+ *   html_block("<div ...>") → heading/paragraph/list… → html_block("</div>")
+ * We reassemble the RAW body Markdown by slicing the original source lines between the open
+ * and close html_block tokens (using their `.map` line ranges) rather than re-serializing the
+ * already-parsed inner tokens — the latter drops block markup (`#`, `-`, `1.`) and would
+ * flatten a callout heading/list into plain text. The caller re-parses the raw body as blocks.
+ */
+function tryAssembleHtmlBlock(
+  tokens: Token[],
+  openIdx: number,
+  ctx: Ctx,
+): { html: string; next: number } | null {
+  const openTok = tokens[openIdx]
+  const openContent = openTok.content.trim()
+
+  // Detect opening tags that we know get split
+  const isCalloutOpen = /^<div\s+data-callout/i.test(openContent)
+  const isDetailsOpen = /^<details>/i.test(openContent)
+
+  if (!isCalloutOpen && !isDetailsOpen) return null
+
+  const closeTag = isCalloutOpen ? '</div>' : '</details>'
+  // Regexes to recognise a nested opener of the SAME kind, so we can depth-balance and stop at
+  // the opener's OWN closing tag rather than the first inner one. markdown-it emits each nested
+  // `<details>`/`<div data-callout>` opener as its own html_block token (they start on their own
+  // line), so counting opener vs closer html_block tokens gives correct nesting depth.
+  const openRe = isCalloutOpen ? /^<div\s+data-callout/i : /^<details>/i
+
+  // Scan forward for the matching closing html_block, balancing nested openers of the same kind.
+  let depth = 1
+  for (let j = openIdx + 1; j < tokens.length; j++) {
+    const t = tokens[j]
+    if (t.type !== 'html_block') continue
+    const content = t.content.trim()
+    if (openRe.test(content)) {
+      depth++
+      continue
+    }
+    if (content === closeTag) {
+      depth--
+      if (depth > 0) continue
+      // Slice the raw body Markdown from the source (open block end → close block start).
+      const openEnd = openTok.map ? openTok.map[1] : null
+      const closeStart = t.map ? t.map[0] : null
+      let inner: string
+      if (openEnd != null && closeStart != null && closeStart >= openEnd) {
+        inner = ctx.sourceLines.slice(openEnd, closeStart).join('\n').trim()
+      } else {
+        // No line map (shouldn't happen for block tokens) — fall back to the parsed inline text.
+        inner = collectRawInline(tokens, openIdx + 1, j)
+      }
+      const html = `${openContent}\n\n${inner}\n\n${closeTag}`
+      return { html, next: j + 1 }
+    }
+  }
+  return null
+}
+
+/** Fallback body reconstruction from parsed inline tokens (loses block markup; last resort). */
+function collectRawInline(tokens: Token[], from: number, to: number): string {
+  const parts: string[] = []
+  for (let j = from; j < to; j++) {
+    const t = tokens[j]
+    if (t.type === 'inline') parts.push(t.content)
+    else if (t.type === 'html_block') parts.push(t.content.trim())
+  }
+  return parts.join('\n').trim()
+}
+
+/**
+ * Detect a whole-paragraph `$$…$$` block (the exporter emits block math as `$$\n<latex>\n$$`).
+ * Operates on the raw inline source so multi-line LaTeX keeps its newlines. Returns a
+ * blockMath node, or null when the paragraph is not a standalone math block.
+ */
+function detectBlockMath(rawText: string): PmNode | null {
+  const t = rawText.trim()
+  const m = /^\$\$([\s\S]+?)\$\$$/.exec(t)
+  if (!m) return null
+  const latex = m[1].trim()
+  if (!latex) return null
+  return { type: 'blockMath', attrs: { latex } }
+}
+
+function clampLevel(n: number): number {
+  if (!Number.isFinite(n)) return 1
+  return Math.min(6, Math.max(1, Math.trunc(n)))
+}
+
+function matchClose(tokens: Token[], openIdx: number, openType: string, closeType: string): number {
+  let depth = 0
+  for (let j = openIdx; j < tokens.length; j++) {
+    if (tokens[j].type === openType) depth++
+    else if (tokens[j].type === closeType) {
+      depth--
+      if (depth === 0) return j
+    }
+  }
+  return tokens.length - 1
+}
+
+/** Consume a heading_open/paragraph_open → inline → *_close triple, return inline PM nodes. */
+function takeInline(tokens: Token[], openIdx: number, ctx: Ctx): { inline: PmNode[]; next: number } {
+  const inlineTok = tokens[openIdx + 1]
+  const closeIdx = openIdx + 2
+  const inline = inlineTok && inlineTok.type === 'inline' ? mapInline(inlineTok, ctx) : []
+  return { inline, next: closeIdx + 1 }
+}
+
+/**
+ * Split a flat inline-node run (from mapInline) into schema-valid BLOCK nodes.
+ *
+ * Our `image` node is group 'block' (not inline), so it must never sit inside a paragraph's
+ * inline content — ProseMirror treats a block child in an inline position as invalid and
+ * drops/normalizes it away, which is exactly why imported images (top-level and inside table
+ * cells) load their bytes but never render. This lifts every block image out to its own block
+ * node and keeps contiguous true-inline nodes (text, hardBreak, inlineMath, emoji…) grouped
+ * into paragraphs, preserving order. Trailing/leading whitespace-only paragraphs are dropped
+ * when an image is present so a lone `![](url)` cell doesn't gain an empty paragraph.
+ */
+function blocksFromInline(inline: PmNode[]): PmNode[] {
+  const out: PmNode[] = []
+  let run: PmNode[] = []
+  const flush = () => {
+    if (run.length === 0) return
+    // Drop a run that is only whitespace text (e.g. the spaces around a block image).
+    const meaningful = run.some((n) => n.type !== 'text' || (n.text ?? '').trim() !== '')
+    if (meaningful) out.push({ type: 'paragraph', content: run })
+    run = []
+  }
+  for (const n of inline) {
+    if (n.type === 'image' || n.type === 'blockMath') {
+      flush()
+      out.push(n) // block-level node (image / display math): lift out of the inline run
+    } else {
+      run.push(n)
+    }
+  }
+  flush()
+  return out
+}
+
+// ── Lists ────────────────────────────────────────────────────────────────────
+
+function takeList(
+  tokens: Token[],
+  openIdx: number,
+  kind: 'bulletList' | 'orderedList',
+  ctx: Ctx,
+): { node: PmNode; next: number } {
+  const closeType = kind === 'bulletList' ? 'bullet_list_close' : 'ordered_list_close'
+  const openType = kind === 'bulletList' ? 'bullet_list_open' : 'ordered_list_open'
+  const end = matchClose(tokens, openIdx, openType, closeType)
+
+  const items: PmNode[] = []
+  let taskListDetected = false
+  let j = openIdx + 1
+  while (j < end) {
+    if (tokens[j].type === 'list_item_open') {
+      const itemEnd = matchClose(tokens, j, 'list_item_open', 'list_item_close')
+      const itemBlocks = mapBlockTokens(tokens.slice(j + 1, itemEnd), ctx)
+      const task = extractTask(itemBlocks)
+      if (task.isTask) {
+        taskListDetected = true
+        items.push({ type: 'taskItem', attrs: { checked: task.checked }, content: task.content })
+      } else {
+        items.push({ type: 'listItem', content: itemBlocks.length ? itemBlocks : [{ type: 'paragraph' }] })
+      }
+      j = itemEnd + 1
+    } else {
+      j += 1
+    }
+  }
+
+  // If any item is a task item, the whole list becomes a taskList (matches export's taskList).
+  if (taskListDetected) {
+    const normalized = items.map((it) =>
+      it.type === 'taskItem'
+        ? it
+        : { type: 'taskItem', attrs: { checked: false }, content: it.content },
+    )
+    return { node: { type: 'taskList', content: normalized }, next: end + 1 }
+  }
+  if (kind === 'orderedList') {
+    // Preserve a non-default start index (`5. …` → start:5) so the rendered numbering matches
+    // the source; markdown-it exposes it on the ordered_list_open token's attrs.
+    const start = orderedListStart(tokens[openIdx])
+    const attrs = start != null && start !== 1 ? { start } : undefined
+    return { node: attrs ? { type: kind, attrs, content: items } : { type: kind, content: items }, next: end + 1 }
+  }
+  return { node: { type: kind, content: items }, next: end + 1 }
+}
+
+/** Read the `start` attribute markdown-it sets on an ordered_list_open token (e.g. `5. …`). */
+function orderedListStart(openTok: Token): number | null {
+  const attrs = openTok.attrs
+  if (!attrs) return null
+  for (const [k, v] of attrs) {
+    if (k === 'start') {
+      const n = typeof v === 'number' ? v : parseInt(String(v), 10)
+      return Number.isFinite(n) ? n : null
+    }
+  }
+  return null
+}
+
+/**
+ * Detect a task-list checkbox prefix inside the item's first paragraph.
+ *
+ * Only the bracketed GFM-style checkbox counts as a task marker, so a normal
+ * bullet whose text merely starts with a check/cross emoji is NOT misread as a
+ * task item. Within the brackets we accept the ASCII `x`/`X` plus common
+ * check glyphs some editors emit, and treat any non-space bracket content as
+ * checked:
+ *   checked:   [x] [X] [✓] [✔] [√]
+ *   unchecked: [ ]
+ */
+function extractTask(blocks: PmNode[]): { isTask: boolean; checked: boolean; content: PmNode[] } {
+  const first = blocks[0]
+  if (first?.type === 'paragraph' && first.content && first.content.length) {
+    const firstInline = first.content[0]
+    if (firstInline?.type === 'text' && typeof firstInline.text === 'string') {
+      // Bracketed checkbox only: [ ] (unchecked) / [x] [X] [✓] [✔] [√] (checked).
+      const m = /^\[([ xX✓✔√])\]\s+/.exec(firstInline.text)
+      if (m) {
+        const checked = m[1] !== ' '
+        const stripped = firstInline.text.slice(m[0].length)
+        const newContent = [...blocks]
+        const newFirstInline = stripped
+          ? [{ ...firstInline, text: stripped }, ...first.content.slice(1)]
+          : first.content.slice(1)
+        newContent[0] = { ...first, content: newFirstInline }
+        return { isTask: true, checked, content: newContent }
+      }
+    }
+  }
+  return { isTask: false, checked: false, content: blocks }
+}
+
+// ── Tables ────────────────────────────────────────────────────────────────────
+
+function mapTable(inner: Token[], ctx: Ctx): PmNode {
+  const rows: PmNode[] = []
+  let i = 0
+  let isHeaderSection = false
+  while (i < inner.length) {
+    const t = inner[i]
+    if (t.type === 'thead_open') { isHeaderSection = true; i++; continue }
+    if (t.type === 'thead_close') { isHeaderSection = false; i++; continue }
+    if (t.type === 'tbody_open' || t.type === 'tbody_close') { i++; continue }
+    if (t.type === 'tr_open') {
+      const trEnd = matchClose(inner, i, 'tr_open', 'tr_close')
+      const cells: PmNode[] = []
+      let j = i + 1
+      while (j < trEnd) {
+        if (inner[j].type === 'th_open' || inner[j].type === 'td_open') {
+          const isHeader = inner[j].type === 'th_open'
+          const closeType = isHeader ? 'th_close' : 'td_close'
+          const cellEnd = matchClose(inner, j, inner[j].type, closeType)
+          const inlineTok = inner.slice(j + 1, cellEnd).find((x) => x.type === 'inline')
+          const cellInline = inlineTok ? mapInline(inlineTok, ctx) : []
+          // A cell may hold block images too (e.g. `| ![](url) |`). Wrapping a block image in
+          // the cell's paragraph is schema-invalid and the image silently vanishes, so split
+          // the inline run into proper block children (image blocks + paragraphs). tableCell
+          // content is block+, so an empty cell still needs one paragraph.
+          const cellBlocks = blocksFromInline(cellInline)
+          cells.push({
+            type: isHeader ? 'tableHeader' : 'tableCell',
+            content: cellBlocks.length ? cellBlocks : [{ type: 'paragraph' }],
+          })
+          j = cellEnd + 1
+        } else j++
+      }
+      rows.push({ type: 'tableRow', content: cells })
+      i = trEnd + 1
+    } else i++
+  }
+  return { type: 'table', content: rows }
+}
+
+// ── Inline ─────────────────────────────────────────────────────────────────--
+
+function mapInline(inlineTok: Token, ctx: Ctx): PmNode[] {
+  const children = inlineTok.children ?? []
+  const out: PmNode[] = []
+  const markStack: Array<{ type: string; attrs?: Record<string, unknown> }> = []
+
+  for (let i = 0; i < children.length; i++) {
+    const c = children[i]
+    switch (c.type) {
+      case 'text':
+        if (c.content) out.push(withMarks({ type: 'text', text: c.content }, markStack))
+        break
+      case 'softbreak':
+        out.push(withMarks({ type: 'text', text: ' ' }, markStack))
+        break
+      case 'hardbreak':
+        out.push({ type: 'hardBreak' })
+        break
+      case 'code_inline':
+        out.push(withMarks({ type: 'text', text: c.content }, [...markStack, { type: 'code' }]))
+        break
+      case 'strong_open': markStack.push({ type: 'bold' }); break
+      case 'strong_close': popMark(markStack, 'bold'); break
+      case 'em_open': markStack.push({ type: 'italic' }); break
+      case 'em_close': popMark(markStack, 'italic'); break
+      case 's_open': markStack.push({ type: 'strike' }); break
+      case 's_close': popMark(markStack, 'strike'); break
+      case 'link_open': {
+        const href = c.attrGet('href')
+        const safe = isSafeHref(href)
+        if (safe) markStack.push({ type: 'link', attrs: { href: safe } })
+        else markStack.push({ type: '__dropped_link' })
+        break
+      }
+      case 'link_close': popMark(markStack, 'link', '__dropped_link'); break
+      case 'image': {
+        const node = mapImage(c, ctx)
+        if (node) out.push(withMarks(node, markStack))
+        break
+      }
+      case 'html_inline': {
+        const res = parseInlineHtml(c.content, markStack)
+        if (res.textNode) out.push(withMarks(res.textNode, markStack))
+        // open/close of whitelisted inline HTML marks handled inside parseInlineHtml via markStack mutation
+        break
+      }
+      case 'math_inline':
+        // Real inline math from the dollar-math inline rule (raw LaTeX preserved).
+        out.push({ type: 'inlineMath', attrs: { latex: c.content.trim() } })
+        break
+      case 'math_block':
+        // `$$…$$` written inline still maps to a blockMath node (matches export).
+        out.push({ type: 'blockMath', attrs: { latex: c.content.trim() } })
+        break
+      default:
+        // Detect inline `$…$` math and `:emoji:` inside plain runs is done at text level;
+        // unknown inline tokens with content become text.
+        if (c.content) out.push(withMarks({ type: 'text', text: c.content }, markStack))
+    }
+  }
+  return postProcessInline(out, ctx)
+}
+
+function withMarks(
+  node: PmNode,
+  stack: Array<{ type: string; attrs?: Record<string, unknown> }>,
+): PmNode {
+  const marks = stack.filter((m) => m.type !== '__dropped_link')
+  if (node.type === 'text' && marks.length) return { ...node, marks: marks.map((m) => ({ ...m })) }
+  return node
+}
+
+function popMark(stack: Array<{ type: string }>, ...types: string[]): void {
+  for (let i = stack.length - 1; i >= 0; i--) {
+    if (types.includes(stack[i].type)) { stack.splice(i, 1); return }
+  }
+}
+
+function mapImage(tok: Token, ctx: Ctx): PmNode | null {
+  const src = tok.attrGet('src') ?? ''
+  const alt = tok.content || tok.attrGet('alt') || ''
+  const title = tok.attrGet('title') || ''
+  // Check original src for network URL (not resolved — isSafeHref resolves relative URLs
+  // against a dummy base, making ./foo.png look like https://safe.local/foo.png).
+  const isNetwork = /^https?:\/\//i.test(src.trim())
+  if (!isNetwork) {
+    // Local / data: / relative / unsafe image — can't import. Degrade to text marker (§6.1 b).
+    ctx.localImageCount += 1
+    return {
+      type: 'text',
+      text: tr(ctx.opts, 'docs.import.imageNotImported', { name: alt || src || '' }),
+    }
+  }
+  const safe = isSafeHref(src)
+  if (!safe) {
+    // Network URL but failed safety check (e.g. javascript: disguised)
+    ctx.localImageCount += 1
+    return {
+      type: 'text',
+      text: tr(ctx.opts, 'docs.import.imageNotImported', { name: alt || src || '' }),
+    }
+  }
+  const attrs: Record<string, unknown> = { src: safe }
+  // Recover the durable attachId from our own storage URL scheme
+  // (`.../file/<docId>/att_<id>/<name>?<signature>`). The signed `src` is short-lived
+  // (`X-Amz-Expires`), so on a same-system round-trip we MUST keep the attachId or the image
+  // silently vanishes once the signature expires. The editor re-resolves a fresh URL from it.
+  const attachId = extractAttachId(src)
+  if (attachId) attrs.attachId = attachId
+  if (alt) attrs.alt = alt
+  if (title) attrs.title = title
+  return { type: 'image', attrs }
+}
+
+/**
+ * Pull the durable attachId out of an export storage URL. Our exporter emits image src as a
+ * signed URL whose path contains an `att_<hex>` segment (`/file/<docId>/att_<id>/<file>`).
+ * Returns the `att_...` id when present, else null (external images keep only their src).
+ */
+function extractAttachId(src: string): string | null {
+  const m = /\/(att_[A-Za-z0-9]+)(?:\/|\?|$)/.exec(src)
+  return m ? m[1] : null
+}
+
+/**
+ * Post-process a run of inline nodes to extract inline math (`$…$`) and emoji (`:name:`)
+ * from plain text runs. Splits text nodes, preserving marks on the surrounding text.
+ */
+function postProcessInline(nodes: PmNode[], ctx: Ctx): PmNode[] {
+  const out: PmNode[] = []
+  for (const n of nodes) {
+    if (n.type !== 'text' || !n.text || (n.marks ?? []).some((m) => m.type === 'code')) {
+      out.push(n)
+      continue
+    }
+    out.push(...splitMathAndEmoji(n, ctx))
+  }
+  return out
+}
+
+// Inline math `$…$`, using the CommonMark/pandoc dollar-math boundary rules so currency like
+// `$5` or a price range `$5 到 $9` is NOT swallowed:
+//   - the opening `$` must not be followed by whitespace or a digit,
+//   - the closing `$` must not be preceded by whitespace, and must not be followed by a digit.
+// The content itself still excludes `$` and newlines.
+const INLINE_MATH_RE = /\$(?![\s\d])([^$\n]*[^$\n\s])\$(?!\d)/g
+const EMOJI_RE = /:([a-z0-9_+-]+):/gi
+// `==text==` highlight (GFM-ish; used by Typora/Obsidian). CommonMark has no mark rule and our
+// exporter emits `<mark>` HTML, but external files commonly use `==…==`, so support both.
+const HIGHLIGHT_RE = /==([^=\n]+)==/g
+
+function splitMathAndEmoji(textNode: PmNode, ctx: Ctx): PmNode[] {
+  const text = textNode.text ?? ''
+  const marks = textNode.marks
+  // Split order: highlight (==…==) → inline math ($…$) → emoji (:name:). Highlight adds a mark
+  // to the enclosed text and lets math/emoji still resolve inside it.
+  const pieces: PmNode[] = []
+  let last = 0
+  let m: RegExpExecArray | null
+  HIGHLIGHT_RE.lastIndex = 0
+  while ((m = HIGHLIGHT_RE.exec(text))) {
+    if (m.index > last) splitMath(pieces, text.slice(last, m.index), marks, ctx)
+    const hlMarks = addMark(marks, 'highlight')
+    splitMath(pieces, m[1], hlMarks, ctx)
+    last = m.index + m[0].length
+  }
+  if (last < text.length) splitMath(pieces, text.slice(last), marks, ctx)
+  return pieces
+}
+
+/** Append `type` to a marks list (deduped), returning a new array. */
+function addMark(marks: PmNode['marks'], type: string): PmNode['marks'] {
+  const base = marks ? marks.map((x) => ({ ...x })) : []
+  if (!base.some((x) => x.type === type)) base.push({ type })
+  return base
+}
+
+/** Split a text run on inline math, then hand remaining text to emoji splitting. */
+function splitMath(out: PmNode[], text: string, marks: PmNode['marks'], ctx: Ctx): void {
+  if (!text) return
+  let last = 0
+  let m: RegExpExecArray | null
+  INLINE_MATH_RE.lastIndex = 0
+  while ((m = INLINE_MATH_RE.exec(text))) {
+    if (m.index > last) pushText(out, text.slice(last, m.index), marks, ctx)
+    out.push({ type: 'inlineMath', attrs: { latex: m[1].trim() } })
+    last = m.index + m[0].length
+  }
+  if (last < text.length) pushText(out, text.slice(last), marks, ctx)
+}
+
+function pushText(
+  out: PmNode[],
+  text: string,
+  marks: PmNode['marks'],
+  ctx: Ctx,
+): void {
+  if (!text) return
+  let last = 0
+  let m: RegExpExecArray | null
+  EMOJI_RE.lastIndex = 0
+  while ((m = EMOJI_RE.exec(text))) {
+    const name = m[1]
+    // Only convert `:name:` to an emoji node when a resolver confirms it maps to a real glyph.
+    // Without a resolver we can't tell `:smile:` from `:not_a_real_thing:`, so keep the literal
+    // text (the exporter round-trips unknown shortcodes as text anyway) rather than emit an
+    // emoji node that renders blank.
+    const known = ctx.opts.emojiName ? Boolean(ctx.opts.emojiName(name)) : false
+    if (known) {
+      if (m.index > last) emitText(out, text.slice(last, m.index), marks)
+      out.push({ type: 'emoji', attrs: { name } })
+      last = m.index + m[0].length
+    }
+  }
+  if (last < text.length) emitText(out, text.slice(last), marks)
+}
+
+function emitText(out: PmNode[], text: string, marks: PmNode['marks']): void {
+  if (!text) return
+  const node: PmNode = { type: 'text', text }
+  if (marks && marks.length) node.marks = marks.map((x) => ({ ...x }))
+  out.push(node)
+}
+
+/** Helper for html-inline to turn a raw text fragment into inline PM nodes. */
+function mapInlineHtmlText(text: string, ctx: Ctx): PmNode[] {
+  return [{ type: 'text', text }]
+}
+
+// Re-export the block-math paragraph detector so tests can exercise it.
+export { detectBlockMath }

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -5,6 +5,7 @@ import { SheetView } from '../sheet/SheetView.tsx'
 import { parseXlsxToMatrix, pendingSheetImports } from '../sheet/xlsxImport.ts'
 import { BoardSession } from '../board/BoardSession.tsx'
 import { isBoardDoc, isBoardIdLocally, rememberBoard } from '../board/boardStore.ts'
+import { runMarkdownImport, runDocxImport, ImportContentCorruptError } from '../editor/importFlow.ts'
 import '../editor/styles.css'
 import {
   DEFAULT_DOC_SPACE,
@@ -684,6 +685,61 @@ function DocsList({
     )
   }
 
+  // "从 Markdown 导入" → pick a .md file, parse it to a ProseMirror document client-side, create a
+  // NEW doc (title from the H1 / filename), stash the parsed content, then open it. Import never
+  // touches an existing doc — it always lands in its own new file, mirroring the Excel import flow.
+  const onImportMarkdown = async () => {
+    if (creating) return
+    setCreating(true)
+    try {
+      const result = await runMarkdownImport(space || undefined, folder || undefined, t)
+      onSelect(result.docId, 'doc')
+      reloadViews()
+    } catch (err) {
+      // User-cancelled picker rejects with a benign error; only surface real failures.
+      if (err instanceof ImportContentCorruptError) {
+        setCreateError(t('docs.toolbar.importCorrupt'))
+      } else if (err instanceof Error && /取消|cancel/i.test(err.message)) {
+        // silent: user closed the file picker
+      } else {
+        setCreateError(t('docs.state.error'))
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  // "从 Word 导入" → pick a .docx file, create a NEW doc, POST the file to the server-side
+  // importer (parses OOXML → ProseMirror JSON, uploads embedded images scoped to the new doc),
+  // stash the returned content, then open it. Like every import path, it lands in its own new
+  // file and never overwrites an existing doc.
+  const onImportWord = async () => {
+    if (creating) return
+    setCreating(true)
+    try {
+      const result = await runDocxImport(space || undefined, folder || undefined, t)
+      onSelect(result.docId, 'doc')
+      reloadViews()
+    } catch (err) {
+      if (err instanceof ImportContentCorruptError) {
+        setCreateError(t('docs.toolbar.importCorrupt'))
+      } else if (err instanceof Error && /取消|cancel/i.test(err.message)) {
+        // silent: user closed the file picker
+      } else if (
+        typeof (err as { response?: { status?: number } })?.response?.status === 'number' &&
+        (err as { response: { status: number } }).response.status === 413
+      ) {
+        // The server rejected the upload as too large / too complex (zip-bomb
+        // guard, size / entry-count / compression-ratio bound).
+        setCreateError(t('docs.import.wordTooLarge'))
+      } else {
+        setCreateError(t('docs.import.wordError'))
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
   return (
     <div className="octo-docs-list">
       <div className="octo-docs-list-header">
@@ -796,6 +852,30 @@ function DocsList({
               }}
             >
               📄 {t('docs.sheet.importExcel')}
+            </button>
+            <button
+              type="button"
+              className="octo-tb-btn"
+              disabled={creating}
+              style={{ display: 'block', width: '100%', textAlign: 'left' }}
+              onClick={() => {
+                setImportMenuAt(null)
+                void onImportWord()
+              }}
+            >
+              📃 {t('docs.import.word')}
+            </button>
+            <button
+              type="button"
+              className="octo-tb-btn"
+              disabled={creating}
+              style={{ display: 'block', width: '100%', textAlign: 'left' }}
+              onClick={() => {
+                setImportMenuAt(null)
+                void onImportMarkdown()
+              }}
+            >
+              📝 {t('docs.import.markdown')}
             </button>
           </PortalMenu>
         )}

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -336,6 +336,43 @@ export async function exportDocPdf(docId: string): Promise<ArrayBuffer> {
 }
 
 /**
+ * Parsed ProseMirror document + non-fatal warnings returned by the server-side
+ * .docx import. `doc` is a ProseMirror `doc` JSON ready to inject via setContent;
+ * `warnings` surface best-effort degradations (e.g. an image that failed to
+ * upload was replaced by a file-attachment placeholder).
+ */
+export interface DocxImportResult {
+  doc: unknown
+  warnings: string[]
+}
+
+/**
+ * Import a .docx file into an (already created, empty) doc. The raw file bytes
+ * are POSTed to the server-side importer, which parses the OOXML to ProseMirror
+ * JSON, uploads embedded images as attachments scoped to `docId`, and returns
+ * the document plus any degradation warnings. The caller injects `doc` into the
+ * editor. Requires editor role on `docId` (import writes content).
+ *
+ * Goes through the shared host apiClient so the global token / X-Space-Id
+ * interceptor and `/api/v1/` baseURL apply. The docx content-type is set per
+ * request; a longer timeout covers large documents with many images.
+ */
+export async function importDocx(docId: string, file: File): Promise<DocxImportResult> {
+  const bytes = await file.arrayBuffer()
+  const { data } = await apiClient().post<DocxImportResult>(
+    `/docs/${docId}/import/docx`,
+    bytes,
+    {
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      },
+      timeout: 120_000,
+    },
+  )
+  return data
+}
+
+/**
  * Delete outcome classification (contract C3 final), kept as a pure function so the 200/404/403/409
  * handling is unit-testable and shared wherever the delete entry lives:
  *   200 → 'deleted'; 404 → 'gone' (already removed — treat as success); 403 → 'forbidden';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,9 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       mathjax-full:
         specifier: ^3.2.2
         version: 3.2.2
@@ -978,6 +981,9 @@ importers:
       '@testing-library/react':
         specifier: 16.1.0
         version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21


### PR DESCRIPTION
## Summary

Adds document import/export for the docs editor (Markdown, DOCX, PDF) with a batch of round-trip fidelity fixes. Focus of this change: DOCX export and Markdown import correctness so exported files re-import with their structure and math intact.

DOCX export:
- Emit a no-bar fraction for `\binom` so it does not re-import with a spurious horizontal line.
- Emit stretchy group characters for wide accents (`\overrightarrow`, `\widehat`) so they span the base instead of shrinking to a narrow combining accent.
- Preserve highlight color, horizontal rule width, blockquote-in-list nesting, and code-block boundaries.

Markdown import:
- Tokenize inline/block math before the escape rule so `\\` line breaks and digit-leading formulas survive.
- Migrate imported images into the new document and recover a persistent attach id so they do not disappear once the signed URL expires.
- Title an imported document by its file name.

## Linked Spec

Tracking issue: Mininglamp-OSS/octo-docs-backend#71 (https://github.com/Mininglamp-OSS/octo-docs-backend/issues/71).

## Review findings addressed

- All user-facing import warnings/errors routed through i18n keys (no hard-coded strings) so the i18n gate passes; keys added to both `en-US` and `zh-CN`.
- Import `useEffect` dependency list aligned.
- Rebased so the branch is a single commit off the current base.

## What this change does

- Before: no import path; DOCX export lost binom/accent fidelity; Markdown import dropped math line breaks and images.
- After: `import`/`export` cover Markdown, DOCX, and PDF; formulas and images survive the round-trip.

## What could break

- Import/export surface only; existing editor behavior is unchanged when the import entry points are not used.
- Image migration degrades to a warning (keeps the original URL) when a fetch or upload fails, so an import never hard-fails on one image.

## How verified

- Docs package suites green (export, import, importFlow images: 240 tests), `tsc --noEmit` clean.
- New regression tests cover each defect (`math.test`, `marks.test`, `markdown.math.test`, `markdown.test`, `importFlow.images.test`).
