### PR TITLE
fix(loop): render nested agent replies and load attachments with auth (#751)

### DIFF
--- a/packages/dmloop/src/api/attachmentApi.ts
+++ b/packages/dmloop/src/api/attachmentApi.ts
@@ -1,6 +1,6 @@
 // @octo/loop — 附件 API(上传走后端 /api/upload-file,multipart)。
 import type { Attachment } from "./types";
-import { httpPost } from "./http";
+import { httpPost, httpGetBlob } from "./http";
 
 // 上传单个文件。可选 issueId/commentId 在上传时直接绑定(需目标已存在);
 // 否则拿返回的 id,通过 create/update issue|comment 的 attachment_ids 绑定(如新评论)。
@@ -14,4 +14,15 @@ export function uploadAttachment(
   if (opts?.issueId) form.append("issue_id", opts.issueId);
   if (opts?.commentId) form.append("comment_id", opts.commentId);
   return httpPost<Attachment>("/upload-file", form);
+}
+
+// Fetch an attachment's bytes through the authenticated loop client. The
+// download endpoint is auth-only, so it cannot be used as a native <img>/<a>
+// src (those carry no auth headers). The loop client base is `/fleet/api/v1`,
+// which the deployment's rewrite layer (nginx in prod, the vite proxy in dev)
+// maps to the backend the same way it does for every other loop call — so this
+// relative path resolves to the attachment endpoint with auth headers attached.
+// Callers wrap the Blob in an object URL for <img>/<a> and revoke it when done.
+export function fetchAttachmentBlob(id: string): Promise<Blob> {
+  return httpGetBlob(`/attachments/${id}/download`);
 }

--- a/packages/dmloop/src/api/http.ts
+++ b/packages/dmloop/src/api/http.ts
@@ -103,6 +103,23 @@ export async function httpGet<T>(
   }
 }
 
+// Fetch a binary resource (e.g. an attachment) through the SAME authenticated
+// client as every other loop request. The attachment download endpoint is
+// auth-only and is meant to be loaded as a native <img>/<video> src — but a
+// native element request cannot carry the `token` / `X-Space-Id` headers this
+// client injects, and under octo-web the document origin proxies `/api/*` to a
+// different backend than the loop API, so a raw `download_url` src 404s. Going
+// through the client (which rewrites to the loop backend and injects auth) and
+// handing the caller a Blob to wrap in an object URL fixes both.
+export async function httpGetBlob(path: string): Promise<Blob> {
+  try {
+    const resp = await client.get(path, { responseType: "blob" });
+    return resp.data as Blob;
+  } catch (err) {
+    throw toApiError(err);
+  }
+}
+
 export async function httpPost<T>(path: string, body?: unknown): Promise<T> {
   try {
     const resp = await client.post<T>(path, body);

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -327,6 +327,7 @@
   "attach": {
     "title": "Attachments",
     "add": "Add attachment",
+    "download": "Download {{name}}",
     "empty": "No attachments"
   },
   "toast": {

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -327,6 +327,7 @@
   "attach": {
     "title": "附件",
     "add": "添加附件",
+    "download": "下载 {{name}}",
     "empty": "暂无附件"
   },
   "toast": {

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -76,6 +76,8 @@ import LoopMarkdown from "../ui/LoopMarkdown";
 import AutoGrowTextarea from "../ui/AutoGrowTextarea";
 import CommentComposer, { type CommentComposerHandle } from "../ui/CommentComposer";
 import { useCommentTriggerPreview } from "../ui/useCommentTriggerPreview";
+import { collectThreadReplies } from "../ui/threadReplies";
+import LoopAttachments from "../ui/LoopAttachments";
 import { confirmDelete } from "../ui/confirmDelete";
 import RunDetailModal from "./RunDetailModal";
 import CreateIssueModal from "../ui/CreateIssueModal";
@@ -489,26 +491,12 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     }
   };
 
-  // 附件渲染(评论/issue 共用):图片内联缩略,其它为带图标的下载链接(用短时 download_url)。
-  const renderAttachments = (atts: Attachment[] | null | undefined) => {
-    if (!atts?.length) return null;
-    return (
-      <div className="loop-atts">
-        {atts.map((a) =>
-          a.content_type.startsWith("image/") ? (
-            <a key={a.id} href={a.download_url} target="_blank" rel="noreferrer" className="loop-att loop-att--img">
-              <img src={a.download_url} alt={a.filename} />
-            </a>
-          ) : (
-            <a key={a.id} href={a.download_url} target="_blank" rel="noreferrer" className="loop-att">
-              <Paperclip size={12} />
-              <span>{a.filename}</span>
-            </a>
-          ),
-        )}
-      </div>
-    );
-  };
+  // 附件渲染(评论/issue 共用):图片内联缩略,其它为带图标的下载链接。
+  // 走 LoopAttachments:带鉴权取字节转 object URL —— download_url 是 auth-only,
+  // 原生 <img src> 带不上 token,且 octo-web 下 /api 代理到别的后端会 404(裂图)。
+  const renderAttachments = (atts: Attachment[] | null | undefined) => (
+    <LoopAttachments attachments={atts} />
+  );
 
   const submitComment = async () => {
     const content = commentDraft.trim();
@@ -724,7 +712,11 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   }
 
   const roots = comments.filter((c) => !c.parent_id);
-  const repliesOf = (id: string) => comments.filter((c) => c.parent_id === id);
+  // Every descendant of a thread root, flattened chronologically. Not just
+  // direct children: an agent reply nests under the member comment that
+  // triggered it (a grandchild of the root), so direct-children-only would drop
+  // every agent answer from the thread. See collectThreadReplies.
+  const repliesOf = (id: string) => collectThreadReplies(id, comments);
   const childrenDone = children.filter((c) => c.status === "done").length;
   // issue 附件区只显 issue 级(comment_id 为空);评论附件归各评论下,避免重复。
   const issueAtts = (issue.attachments ?? []).filter((a) => !a.comment_id);

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -436,6 +436,20 @@
 .loop-att span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .loop-att--img { padding: 0; border: none; background: none; }
 .loop-att--img img { max-height: 96px; max-width: 220px; border-radius: 8px; display: block; object-fit: cover; }
+/* Skeleton shown while an attachment's bytes are being fetched. */
+.loop-att--loading {
+  width: 120px;
+  height: 72px;
+  border-radius: 8px;
+  border: none;
+  background: linear-gradient(90deg, var(--semi-color-fill-0, #f5f6f8) 25%, var(--semi-color-fill-1, #eaebef) 37%, var(--semi-color-fill-0, #f5f6f8) 63%);
+  background-size: 400% 100%;
+  animation: loop-att-shimmer 1.2s ease-in-out infinite;
+}
+@keyframes loop-att-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: 0 0; }
+}
 .loop-att--pending button {
   border: none; background: transparent; cursor: pointer; color: var(--semi-color-text-2, #8590a6);
   font-size: 14px; line-height: 1; padding: 0 0 0 2px;

--- a/packages/dmloop/src/ui/LoopAttachments.tsx
+++ b/packages/dmloop/src/ui/LoopAttachments.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react";
+import { Paperclip } from "lucide-react";
+import { useI18n } from "@octo/base";
+import type { Attachment } from "../api/types";
+import { fetchAttachmentBlob } from "../api/attachmentApi";
+import { loadObjectUrl } from "./objectUrl";
+
+/**
+ * Attachment renderer for the loop timeline. Loads bytes through the
+ * authenticated loop client instead of setting a native src to `download_url`.
+ *
+ * Why not `<img src={download_url}>`: that endpoint is auth-only and, under
+ * octo-web, the document origin proxies `/api/*` to a different backend than
+ * the loop API — so a native element request (which can't carry the loop
+ * `token`/`X-Space-Id` headers) 404s and the image breaks. Fetching the Blob
+ * via the client and wrapping it in an object URL loads it with auth against
+ * the correct backend. The object URL is revoked on unmount / id change so a
+ * long timeline doesn't leak blobs (lifecycle isolated in loadObjectUrl).
+ */
+function AuthedImage({ att }: { att: Attachment }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setUrl(null);
+    setFailed(false);
+    // loadObjectUrl returns the disposer; running it on cleanup revokes the URL
+    // (or drops a still-pending load) so unmount / id change can't leak blobs.
+    return loadObjectUrl(att.id, {
+      onLoad: setUrl,
+      onError: () => setFailed(true),
+    }, { fetchBlob: fetchAttachmentBlob });
+  }, [att.id]);
+
+  if (failed) {
+    // Fall back to a plain download link so the attachment is still reachable.
+    return <AuthedDownload att={att} />;
+  }
+  if (!url) {
+    // Visible placeholder while bytes load (not loop-att--img, which zeroes
+    // out box styling and would render an invisible 0×0 span).
+    return <span className="loop-att loop-att--loading" aria-label={att.filename} />;
+  }
+  return (
+    <a href={url} target="_blank" rel="noreferrer" className="loop-att loop-att--img">
+      <img src={url} alt={att.filename} />
+    </a>
+  );
+}
+
+/**
+ * Non-image attachment: an icon + filename that downloads on click. Same auth
+ * reasoning as AuthedImage — we can't point an <a href> at the auth-only
+ * endpoint, so we fetch the Blob on click, then trigger a download from an
+ * object URL and revoke it.
+ */
+function AuthedDownload({ att }: { att: Attachment }) {
+  const { t } = useI18n();
+  const [busy, setBusy] = useState(false);
+
+  const onClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    try {
+      const blob = await fetchAttachmentBlob(att.id);
+      const objUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objUrl;
+      a.download = att.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      // Revoke after the click has had a chance to start the download.
+      setTimeout(() => URL.revokeObjectURL(objUrl), 10_000);
+    } catch {
+      /* swallowed: a failed download shows no toast here to stay unobtrusive */
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <a
+      href={att.download_url}
+      onClick={onClick}
+      className="loop-att"
+      aria-busy={busy}
+      aria-label={t("loop.attach.download", { values: { name: att.filename } })}
+    >
+      <Paperclip size={12} />
+      <span>{att.filename}</span>
+    </a>
+  );
+}
+
+/** Renders a list of attachments (shared between issue-level and comment-level). */
+export default function LoopAttachments({
+  attachments,
+}: {
+  attachments: Attachment[] | null | undefined;
+}) {
+  if (!attachments?.length) return null;
+  return (
+    <div className="loop-atts">
+      {attachments.map((a) =>
+        a.content_type.startsWith("image/") ? (
+          <AuthedImage key={a.id} att={a} />
+        ) : (
+          <AuthedDownload key={a.id} att={a} />
+        ),
+      )}
+    </div>
+  );
+}

--- a/packages/dmloop/src/ui/LoopAttachments.tsx
+++ b/packages/dmloop/src/ui/LoopAttachments.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@octo/base";
 import type { Attachment } from "../api/types";
 import { fetchAttachmentBlob } from "../api/attachmentApi";
 import { loadObjectUrl } from "./objectUrl";
+import { canPreviewInline } from "./attachmentPreview";
 
 /**
  * Attachment renderer for the loop timeline. Loads bytes through the
@@ -29,7 +30,7 @@ function AuthedImage({ att }: { att: Attachment }) {
     return loadObjectUrl(att.id, {
       onLoad: setUrl,
       onError: () => setFailed(true),
-    }, { fetchBlob: fetchAttachmentBlob });
+    }, { fetchBlob: fetchAttachmentBlob, isInlineSafe: canPreviewInline });
   }, [att.id]);
 
   if (failed) {
@@ -104,7 +105,7 @@ export default function LoopAttachments({
   return (
     <div className="loop-atts">
       {attachments.map((a) =>
-        a.content_type.startsWith("image/") ? (
+        canPreviewInline(a.content_type) ? (
           <AuthedImage key={a.id} att={a} />
         ) : (
           <AuthedDownload key={a.id} att={a} />

--- a/packages/dmloop/src/ui/LoopAttachments.tsx
+++ b/packages/dmloop/src/ui/LoopAttachments.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Paperclip } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Attachment } from "../api/types";
-import { fetchAttachmentBlob } from "../api/attachmentApi";
-import { loadObjectUrl } from "./objectUrl";
 import { canPreviewInline } from "./attachmentPreview";
+import { useAuthedAttachmentUrl, triggerAuthedDownload } from "./useAuthedAttachment";
 
 /**
  * Attachment renderer for the loop timeline. Loads bytes through the
@@ -15,26 +14,13 @@ import { canPreviewInline } from "./attachmentPreview";
  * the loop API — so a native element request (which can't carry the loop
  * `token`/`X-Space-Id` headers) 404s and the image breaks. Fetching the Blob
  * via the client and wrapping it in an object URL loads it with auth against
- * the correct backend. The object URL is revoked on unmount / id change so a
- * long timeline doesn't leak blobs (lifecycle isolated in loadObjectUrl).
+ * the correct backend (lifecycle isolated in useAuthedAttachmentUrl).
  */
 function AuthedImage({ att }: { att: Attachment }) {
-  const [url, setUrl] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    setUrl(null);
-    setFailed(false);
-    // loadObjectUrl returns the disposer; running it on cleanup revokes the URL
-    // (or drops a still-pending load) so unmount / id change can't leak blobs.
-    return loadObjectUrl(att.id, {
-      onLoad: setUrl,
-      onError: () => setFailed(true),
-    }, { fetchBlob: fetchAttachmentBlob, isInlineSafe: canPreviewInline });
-  }, [att.id]);
+  const { url, failed } = useAuthedAttachmentUrl(att.id);
 
   if (failed) {
-    // Fall back to a plain download link so the attachment is still reachable.
+    // Fall back to a click-to-download link so the attachment is still reachable.
     return <AuthedDownload att={att} />;
   }
   if (!url) {
@@ -52,8 +38,8 @@ function AuthedImage({ att }: { att: Attachment }) {
 /**
  * Non-image attachment: an icon + filename that downloads on click. Same auth
  * reasoning as AuthedImage — we can't point an <a href> at the auth-only
- * endpoint, so we fetch the Blob on click, then trigger a download from an
- * object URL and revoke it.
+ * endpoint, so we fetch the Blob on click (triggerAuthedDownload) and trigger a
+ * download from an object URL.
  */
 function AuthedDownload({ att }: { att: Attachment }) {
   const { t } = useI18n();
@@ -63,27 +49,13 @@ function AuthedDownload({ att }: { att: Attachment }) {
     e.preventDefault();
     if (busy) return;
     setBusy(true);
-    try {
-      const blob = await fetchAttachmentBlob(att.id);
-      const objUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = objUrl;
-      a.download = att.filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      // Revoke after the click has had a chance to start the download.
-      setTimeout(() => URL.revokeObjectURL(objUrl), 10_000);
-    } catch {
-      /* swallowed: a failed download shows no toast here to stay unobtrusive */
-    } finally {
-      setBusy(false);
-    }
+    await triggerAuthedDownload(att.id, att.filename);
+    setBusy(false);
   };
 
   return (
     <a
-      href={att.download_url}
+      href="#"
       onClick={onClick}
       className="loop-att"
       aria-busy={busy}

--- a/packages/dmloop/src/ui/LoopMarkdown.tsx
+++ b/packages/dmloop/src/ui/LoopMarkdown.tsx
@@ -1,12 +1,52 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ReactMarkdown, { uriTransformer } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { fetchAttachmentBlob } from "../api/attachmentApi";
+import { loadObjectUrl } from "./objectUrl";
+import { canPreviewInline } from "./attachmentPreview";
+import { attachmentIdFromSrc } from "./attachmentSrc";
 import "./markdown.css";
 
 // react-markdown@8 默认只放行 http/https/mailto/tel，会把 mention:// 改写成 javascript:void(0)。
 // 放行 mention:，其余仍走默认清洗（保住对用户输入的 XSS 防护）。
 const transformLinkUri = (href: string) =>
   href.startsWith("mention://") ? href : uriTransformer(href);
+
+/**
+ * Inline markdown image whose src points at a loop attachment. Same problem as
+ * the attachment card: the download endpoint is auth-only, so a native <img src>
+ * carries no auth and 404/401s. Load the bytes through the authenticated client
+ * and wrap them in an object URL, gated by the same inline-safe MIME whitelist
+ * (an SVG attachment is never inlined — it would run in the document origin).
+ * On any failure (unsafe MIME, fetch error) fall back to a download link.
+ */
+function MarkdownAttachmentImage({ id, src, alt }: { id: string; src: string; alt: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setUrl(null);
+    setFailed(false);
+    return loadObjectUrl(id, {
+      onLoad: setUrl,
+      onError: () => setFailed(true),
+    }, { fetchBlob: fetchAttachmentBlob, isInlineSafe: canPreviewInline });
+  }, [id]);
+
+  if (failed) {
+    // Not inline-safe (e.g. SVG) or failed to load → downloadable link, never
+    // a navigable same-origin blob preview.
+    return (
+      <a href={src} target="_blank" rel="noreferrer" download>
+        {alt || src}
+      </a>
+    );
+  }
+  if (!url) {
+    return <span className="loop-att loop-att--loading" aria-label={alt || undefined} />;
+  }
+  return <img src={url} alt={alt} />;
+}
 
 /** Loop Markdown 渲染：标题/列表/代码块/行内代码/链接/表格/引用等美化展示。 */
 export default function LoopMarkdown({ content }: { content: string }) {
@@ -22,6 +62,15 @@ export default function LoopMarkdown({ content }: { content: string }) {
               return <span className="loop-mention">{children}</span>;
             }
             return <a href={href} target="_blank" rel="noreferrer" {...props}>{children}</a>;
+          },
+          img: ({ node, src, alt, ...props }) => {
+            // Loop attachment images need authenticated loading (see
+            // MarkdownAttachmentImage); external / data: images load natively.
+            const id = attachmentIdFromSrc(src);
+            if (id) {
+              return <MarkdownAttachmentImage id={id} src={src ?? ""} alt={alt ?? ""} />;
+            }
+            return <img src={src} alt={alt} {...props} />;
           },
         }}
       >

--- a/packages/dmloop/src/ui/LoopMarkdown.tsx
+++ b/packages/dmloop/src/ui/LoopMarkdown.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import ReactMarkdown, { uriTransformer } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { fetchAttachmentBlob } from "../api/attachmentApi";
-import { loadObjectUrl } from "./objectUrl";
-import { canPreviewInline } from "./attachmentPreview";
 import { attachmentIdFromSrc } from "./attachmentSrc";
+import { useAuthedAttachmentUrl, triggerAuthedDownload } from "./useAuthedAttachment";
 import "./markdown.css";
 
 // react-markdown@8 默认只放行 http/https/mailto/tel，会把 mention:// 改写成 javascript:void(0)。
@@ -16,29 +14,30 @@ const transformLinkUri = (href: string) =>
  * Inline markdown image whose src points at a loop attachment. Same problem as
  * the attachment card: the download endpoint is auth-only, so a native <img src>
  * carries no auth and 404/401s. Load the bytes through the authenticated client
- * and wrap them in an object URL, gated by the same inline-safe MIME whitelist
+ * (shared useAuthedAttachmentUrl), gated by the same inline-safe MIME whitelist
  * (an SVG attachment is never inlined — it would run in the document origin).
- * On any failure (unsafe MIME, fetch error) fall back to a download link.
+ * On failure (unsafe MIME or fetch error) fall back to a click-to-download that
+ * also goes through the authed client — a native <a href> to the auth-only
+ * endpoint would itself dead-link under octo-web.
  */
-function MarkdownAttachmentImage({ id, src, alt }: { id: string; src: string; alt: string }) {
-  const [url, setUrl] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    setUrl(null);
-    setFailed(false);
-    return loadObjectUrl(id, {
-      onLoad: setUrl,
-      onError: () => setFailed(true),
-    }, { fetchBlob: fetchAttachmentBlob, isInlineSafe: canPreviewInline });
-  }, [id]);
+function MarkdownAttachmentImage({ id, filename, alt }: { id: string; filename: string; alt: string }) {
+  const { url, failed } = useAuthedAttachmentUrl(id);
+  const [busy, setBusy] = useState(false);
 
   if (failed) {
-    // Not inline-safe (e.g. SVG) or failed to load → downloadable link, never
-    // a navigable same-origin blob preview.
+    // Not inline-safe (e.g. SVG) or fetch failed → click-to-download through the
+    // authed client. NOT a native <a href={src} download>: src is the auth-only
+    // endpoint and would dead-link under octo-web.
+    const onClick = async (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (busy) return;
+      setBusy(true);
+      await triggerAuthedDownload(id, filename);
+      setBusy(false);
+    };
     return (
-      <a href={src} target="_blank" rel="noreferrer" download>
-        {alt || src}
+      <a href="#" onClick={onClick} aria-busy={busy}>
+        {alt || filename}
       </a>
     );
   }
@@ -68,7 +67,11 @@ export default function LoopMarkdown({ content }: { content: string }) {
             // MarkdownAttachmentImage); external / data: images load natively.
             const id = attachmentIdFromSrc(src);
             if (id) {
-              return <MarkdownAttachmentImage id={id} src={src ?? ""} alt={alt ?? ""} />;
+              // Prefer the markdown alt text as the download name; the URL's
+              // last path segment is "download"/"content" (or a query), never a
+              // real filename, so fall back to a stable generic instead.
+              const name = alt || "attachment";
+              return <MarkdownAttachmentImage id={id} filename={name} alt={alt ?? ""} />;
             }
             return <img src={src} alt={alt} {...props} />;
           },

--- a/packages/dmloop/src/ui/__tests__/attachmentPreview.test.ts
+++ b/packages/dmloop/src/ui/__tests__/attachmentPreview.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { canPreviewInline } from "../attachmentPreview";
+
+describe("canPreviewInline", () => {
+  it("allows known-safe raster formats", () => {
+    for (const t of [
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+      "image/avif",
+    ]) {
+      expect(canPreviewInline(t)).toBe(true);
+    }
+  });
+
+  // Security guarantee: an inline SVG blob would run in the document origin and
+  // bypass the backend's attachment disposition + CSP → stored XSS. SVG must
+  // always take the download path, never render as an inline <img>/blob.
+  it("never inlines SVG", () => {
+    expect(canPreviewInline("image/svg+xml")).toBe(false);
+    expect(canPreviewInline("IMAGE/SVG+XML")).toBe(false);
+    expect(canPreviewInline("image/svg+xml; charset=utf-8")).toBe(false);
+    expect(canPreviewInline("  image/svg+xml  ")).toBe(false);
+  });
+
+  it("does not inline unknown or non-image types", () => {
+    for (const t of [
+      "image/bmp",
+      "image/tiff",
+      "image/x-icon",
+      "text/html",
+      "application/pdf",
+      "application/octet-stream",
+      "",
+    ]) {
+      expect(canPreviewInline(t)).toBe(false);
+    }
+  });
+
+  it("handles null / undefined without throwing", () => {
+    expect(canPreviewInline(null)).toBe(false);
+    expect(canPreviewInline(undefined)).toBe(false);
+  });
+
+  it("normalizes case and mime parameters", () => {
+    expect(canPreviewInline("IMAGE/PNG")).toBe(true);
+    expect(canPreviewInline("image/jpeg; charset=binary")).toBe(true);
+    expect(canPreviewInline(" image/webp ")).toBe(true);
+  });
+});

--- a/packages/dmloop/src/ui/__tests__/attachmentSrc.test.ts
+++ b/packages/dmloop/src/ui/__tests__/attachmentSrc.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { attachmentIdFromSrc } from "../attachmentSrc";
+
+const ID = "019f6039-eebb-72bf-8746-59e58476c47b";
+
+describe("attachmentIdFromSrc", () => {
+  it("extracts the id from a site-relative attachment URL", () => {
+    expect(attachmentIdFromSrc(`/api/attachments/${ID}/download`)).toBe(ID);
+  });
+
+  it("extracts the id from an absolute attachment URL", () => {
+    expect(
+      attachmentIdFromSrc(`https://host.example.com/api/attachments/${ID}/download`),
+    ).toBe(ID);
+  });
+
+  it("extracts the id when the URL has a query or fragment", () => {
+    expect(attachmentIdFromSrc(`/api/attachments/${ID}/download?x=1`)).toBe(ID);
+    expect(attachmentIdFromSrc(`/api/attachments/${ID}/download#frag`)).toBe(ID);
+  });
+
+  it("returns null for non-attachment URLs (loaded natively)", () => {
+    expect(attachmentIdFromSrc("https://example.com/logo.png")).toBeNull();
+    expect(attachmentIdFromSrc("data:image/png;base64,AAAA")).toBeNull();
+    expect(attachmentIdFromSrc("/api/attachments/not-a-uuid/download")).toBeNull();
+    expect(attachmentIdFromSrc(`/api/attachments/${ID}`)).toBeNull();
+    expect(attachmentIdFromSrc("")).toBeNull();
+    expect(attachmentIdFromSrc(null)).toBeNull();
+    expect(attachmentIdFromSrc(undefined)).toBeNull();
+  });
+});

--- a/packages/dmloop/src/ui/__tests__/downloadAttachment.test.ts
+++ b/packages/dmloop/src/ui/__tests__/downloadAttachment.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { downloadAttachmentById } from "../downloadAttachment";
+
+const ID = "019f6039-eebb-72bf-8746-59e58476c47b";
+
+describe("downloadAttachmentById", () => {
+  // The core guarantee behind the SVG/unsafe fallback and the non-image card:
+  // a download must fetch bytes by id through the authed client, never navigate
+  // to the raw auth-only attachment URL (which dead-links under octo-web).
+  it("fetches the blob by id and saves it (never touches a raw URL)", async () => {
+    const blob = new Blob(["x"], { type: "image/svg+xml" });
+    const fetchBlob = vi.fn().mockResolvedValue(blob);
+    const saveBlob = vi.fn();
+
+    const ok = await downloadAttachmentById(ID, "diagram.svg", { fetchBlob, saveBlob });
+
+    expect(ok).toBe(true);
+    expect(fetchBlob).toHaveBeenCalledExactlyOnceWith(ID);
+    expect(saveBlob).toHaveBeenCalledExactlyOnceWith(blob, "diagram.svg");
+  });
+
+  it("returns false and does not save when the authed fetch fails", async () => {
+    const fetchBlob = vi.fn().mockRejectedValue(new Error("401"));
+    const saveBlob = vi.fn();
+
+    const ok = await downloadAttachmentById(ID, "diagram.svg", { fetchBlob, saveBlob });
+
+    expect(ok).toBe(false);
+    expect(saveBlob).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmloop/src/ui/__tests__/objectUrl.test.ts
+++ b/packages/dmloop/src/ui/__tests__/objectUrl.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadObjectUrl } from "../objectUrl";
+
+// A blob whose creation we can trace by identity.
+const fakeBlob = new Blob(["x"], { type: "image/jpeg" });
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("loadObjectUrl", () => {
+  it("delivers the object URL on success", async () => {
+    const onLoad = vi.fn();
+    const onError = vi.fn();
+    loadObjectUrl(
+      "att-1",
+      { onLoad, onError },
+      {
+        fetchBlob: () => Promise.resolve(fakeBlob),
+        createObjectURL: () => "blob:fake-1",
+        revokeObjectURL: vi.fn(),
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onLoad).toHaveBeenCalledWith("blob:fake-1");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("revokes the delivered URL exactly once on dispose", async () => {
+    const revoke = vi.fn();
+    const dispose = loadObjectUrl(
+      "att-1",
+      { onLoad: vi.fn(), onError: vi.fn() },
+      {
+        fetchBlob: () => Promise.resolve(fakeBlob),
+        createObjectURL: () => "blob:fake-1",
+        revokeObjectURL: revoke,
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    dispose();
+    dispose(); // idempotent
+    expect(revoke).toHaveBeenCalledTimes(1);
+    expect(revoke).toHaveBeenCalledWith("blob:fake-1");
+  });
+
+  it("does not deliver, and revokes, when the load resolves after dispose", async () => {
+    const d = deferred<Blob>();
+    const onLoad = vi.fn();
+    const revoke = vi.fn();
+    const dispose = loadObjectUrl(
+      "att-1",
+      { onLoad, onError: vi.fn() },
+      {
+        fetchBlob: () => d.promise,
+        createObjectURL: () => "blob:late",
+        revokeObjectURL: revoke,
+      },
+    );
+    // Dispose before the fetch resolves (unmount / id change mid-flight).
+    dispose();
+    d.resolve(fakeBlob);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onLoad).not.toHaveBeenCalled();
+    // The URL created after cancellation must still be revoked (no leak).
+    expect(revoke).toHaveBeenCalledWith("blob:late");
+  });
+
+  it("reports error and creates no URL on fetch failure", async () => {
+    const onError = vi.fn();
+    const create = vi.fn();
+    const revoke = vi.fn();
+    loadObjectUrl(
+      "att-1",
+      { onLoad: vi.fn(), onError },
+      {
+        fetchBlob: () => Promise.reject(new Error("401")),
+        createObjectURL: create,
+        revokeObjectURL: revoke,
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+    expect(revoke).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the error callback when disposed before failure", async () => {
+    const d = deferred<Blob>();
+    const onError = vi.fn();
+    const dispose = loadObjectUrl(
+      "att-1",
+      { onLoad: vi.fn(), onError },
+      {
+        fetchBlob: () => d.promise,
+        createObjectURL: vi.fn(),
+        revokeObjectURL: vi.fn(),
+      },
+    );
+    dispose();
+    d.reject(new Error("late failure"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmloop/src/ui/__tests__/objectUrl.test.ts
+++ b/packages/dmloop/src/ui/__tests__/objectUrl.test.ts
@@ -113,4 +113,44 @@ describe("loadObjectUrl", () => {
     await Promise.resolve();
     expect(onError).not.toHaveBeenCalled();
   });
+
+  // Security guard: a blob whose MIME is not inline-safe (e.g. SVG) must never
+  // become an object URL — onError fires so the caller falls back to download.
+  it("rejects an inline-unsafe blob without creating a URL", async () => {
+    const onLoad = vi.fn();
+    const onError = vi.fn();
+    const create = vi.fn();
+    loadObjectUrl(
+      "att-1",
+      { onLoad, onError },
+      {
+        fetchBlob: () => Promise.resolve(new Blob(["<svg/>"], { type: "image/svg+xml" })),
+        isInlineSafe: (m) => m === "image/png",
+        createObjectURL: create,
+        revokeObjectURL: vi.fn(),
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onLoad).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("delivers an inline-safe blob through the guard", async () => {
+    const onLoad = vi.fn();
+    loadObjectUrl(
+      "att-1",
+      { onLoad, onError: vi.fn() },
+      {
+        fetchBlob: () => Promise.resolve(new Blob(["x"], { type: "image/png" })),
+        isInlineSafe: (m) => m === "image/png",
+        createObjectURL: () => "blob:safe",
+        revokeObjectURL: vi.fn(),
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onLoad).toHaveBeenCalledWith("blob:safe");
+  });
 });

--- a/packages/dmloop/src/ui/__tests__/threadReplies.test.ts
+++ b/packages/dmloop/src/ui/__tests__/threadReplies.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { collectThreadReplies } from "../threadReplies";
+import type { IssueComment } from "../../api/types";
+
+function comment(
+  id: string,
+  createdAt: string,
+  parentId: string | null,
+): IssueComment {
+  return {
+    id,
+    issue_id: "issue-1",
+    parent_id: parentId,
+    author_type: "member",
+    author_id: "u1",
+    content: id,
+    created_at: createdAt,
+  };
+}
+
+describe("collectThreadReplies", () => {
+  it("returns direct replies of the root", () => {
+    const comments = [
+      comment("root", "2026-07-14T10:00:00Z", null),
+      comment("r1", "2026-07-14T10:01:00Z", "root"),
+      comment("r2", "2026-07-14T10:02:00Z", "root"),
+    ];
+    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+      "r1",
+      "r2",
+    ]);
+  });
+
+  // Regression: an agent reply nests under the member comment that triggered it,
+  // not under the thread root. Taking only direct children dropped every agent
+  // answer from the timeline even though the API returned them.
+  it("includes grandchildren (agent replies nested under a member question)", () => {
+    const comments = [
+      comment("root", "2026-07-14T10:33:00Z", null),
+      comment("m1", "2026-07-14T10:42:17Z", "root"),
+      comment("a1", "2026-07-14T10:42:29Z", "m1"), // agent reply to m1
+      comment("m2", "2026-07-14T10:42:27Z", "root"),
+      comment("a2", "2026-07-14T10:43:10Z", "m2"), // agent reply to m2
+    ];
+    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+      "m1",
+      "m2",
+      "a1",
+      "a2",
+    ]);
+  });
+
+  it("orders the whole subtree chronologically, not depth-first", () => {
+    // A slow agent's late reply must not jump ahead of an earlier sibling.
+    const comments = [
+      comment("root", "2026-07-14T10:00:00Z", null),
+      comment("m1", "2026-07-14T10:01:00Z", "root"),
+      comment("a1", "2026-07-14T10:05:00Z", "m1"), // slow answer
+      comment("m2", "2026-07-14T10:02:00Z", "root"),
+    ];
+    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+      "m1",
+      "m2",
+      "a1",
+    ]);
+  });
+
+  it("does not infinite-loop on a parent_id cycle", () => {
+    const comments = [
+      comment("root", "2026-07-14T10:00:00Z", null),
+      comment("x", "2026-07-14T10:01:00Z", "y"),
+      comment("y", "2026-07-14T10:02:00Z", "x"),
+    ];
+    // Cycle is unreachable from root → simply excluded, no hang.
+    expect(collectThreadReplies("root", comments)).toEqual([]);
+  });
+});

--- a/packages/dmloop/src/ui/attachmentPreview.ts
+++ b/packages/dmloop/src/ui/attachmentPreview.ts
@@ -1,0 +1,29 @@
+// Attachment inline-preview policy. Kept dependency-free (no React / UI imports)
+// so the SVG-must-not-inline guarantee can be unit tested in a plain node env.
+
+// Raster image types safe to preview inline as an authenticated blob <img>.
+// Deliberately NOT `image/*`: SVG (image/svg+xml) is XML that can carry
+// <script>/<foreignObject>/onload= and executes in the document origin when
+// rendered inline. The backend forces Content-Disposition: attachment + a
+// strict attachment CSP for SVG to prevent stored XSS; turning any image into a
+// same-origin blob strips those headers and would reinstate the hole. So only
+// these known-safe raster formats get the inline blob preview — everything else
+// (SVG, unknown image/*, non-images) downloads.
+const INLINE_PREVIEW_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+]);
+
+/**
+ * Whether an attachment may be previewed inline. Only the known-safe raster
+ * formats above qualify; SVG and any other type must download instead.
+ */
+export function canPreviewInline(contentType: string | null | undefined): boolean {
+  if (!contentType) return false;
+  // Strip any `; charset=…` / parameters and normalize before matching.
+  const base = contentType.split(";")[0]!.trim().toLowerCase();
+  return INLINE_PREVIEW_TYPES.has(base);
+}

--- a/packages/dmloop/src/ui/attachmentSrc.ts
+++ b/packages/dmloop/src/ui/attachmentSrc.ts
@@ -1,0 +1,21 @@
+// Recognize markdown image URLs that point at a loop attachment download
+// endpoint so inline images can be loaded through the authenticated client
+// (same as attachment cards) instead of a native <img src> that carries no
+// auth. Kept dependency-free so it is unit-testable in a plain node env.
+//
+// The backend's `markdown_url` for a private attachment is either site-relative
+// (`/api/attachments/<id>/download`) or absolute against the public origin
+// (`https://host/api/attachments/<id>/download`). Both are matched. A publicly
+// readable storage URL (a different shape, e.g. a signed CDN link) is NOT
+// matched and is left to load natively.
+const ATTACHMENT_PATH_RE = /\/api\/attachments\/([0-9a-fA-F-]{36})\/download(?:$|[?#])/;
+
+/**
+ * If `src` is a loop attachment download URL, return its attachment id;
+ * otherwise null (external URL, data:, or a non-attachment path — load natively).
+ */
+export function attachmentIdFromSrc(src: string | null | undefined): string | null {
+  if (!src) return null;
+  const m = ATTACHMENT_PATH_RE.exec(src);
+  return m ? m[1]! : null;
+}

--- a/packages/dmloop/src/ui/downloadAttachment.ts
+++ b/packages/dmloop/src/ui/downloadAttachment.ts
@@ -1,0 +1,44 @@
+// Authenticated attachment download, dependency-free so the "download goes
+// through the authed client by id, never the raw attachment URL" behavior is
+// unit-testable in a plain node env. `fetchBlob` (and the DOM save step) are
+// injected; the React component supplies the real implementations.
+//
+// Why this exists: the attachment download endpoint is auth-only. A native
+// <a href="/api/attachments/<id>/download" download> dead-links under octo-web
+// (that path proxies to a different backend and can't carry the loop auth
+// headers) — the exact bug the PR fixes. So every download affordance must
+// fetch the bytes by id through the authed client and save the resulting blob.
+
+export type SaveBlob = (blob: Blob, filename: string) => void;
+
+/**
+ * Fetch an attachment by id through the authed client and save it. Returns true
+ * if the download started, false if the fetch failed. Never references the raw
+ * attachment URL — only the server-scoped id.
+ */
+export async function downloadAttachmentById(
+  id: string,
+  filename: string,
+  deps: { fetchBlob: (id: string) => Promise<Blob>; saveBlob: SaveBlob },
+): Promise<boolean> {
+  try {
+    const blob = await deps.fetchBlob(id);
+    deps.saveBlob(blob, filename);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Default DOM-based blob saver (anchor click + delayed revoke). */
+export function domSaveBlob(blob: Blob, filename: string): void {
+  const objUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has had a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(objUrl), 10_000);
+}

--- a/packages/dmloop/src/ui/objectUrl.ts
+++ b/packages/dmloop/src/ui/objectUrl.ts
@@ -1,0 +1,59 @@
+/**
+ * Load an attachment as an object URL and hand back a disposer, isolating the
+ * fetch → createObjectURL → revoke lifecycle from React so it can be unit
+ * tested without a DOM. This is the part most prone to leaking: the URL must be
+ * revoked exactly once when the consumer unmounts or switches to another
+ * attachment, and a load that resolves after cancellation must revoke the URL
+ * it just created instead of handing back a live one.
+ *
+ * `fetchBlob` is injected (not imported) so this module stays free of the API
+ * client's transitive UI deps and remains unit-testable in a plain node env.
+ *
+ * Returns a `cancel` function. Call it on unmount / id change:
+ *   - before onLoad fired  → the pending load is dropped; if it later resolves,
+ *     the freshly created URL is revoked immediately (no leak, no callback).
+ *   - after onLoad fired   → the delivered URL is revoked.
+ * `cancel` is idempotent.
+ */
+export function loadObjectUrl(
+  attachmentId: string,
+  handlers: { onLoad: (url: string) => void; onError: () => void },
+  deps: {
+    fetchBlob: (id: string) => Promise<Blob>;
+    createObjectURL?: (blob: Blob) => string;
+    revokeObjectURL?: (url: string) => void;
+  },
+): () => void {
+  const { fetchBlob } = deps;
+  const createObjectURL =
+    deps.createObjectURL ?? ((b: Blob) => URL.createObjectURL(b));
+  const revokeObjectURL =
+    deps.revokeObjectURL ?? ((u: string) => URL.revokeObjectURL(u));
+
+  let cancelled = false;
+  let liveUrl: string | null = null;
+
+  fetchBlob(attachmentId)
+    .then((blob) => {
+      const url = createObjectURL(blob);
+      if (cancelled) {
+        // Resolved after cancel: revoke the URL we just made, deliver nothing.
+        revokeObjectURL(url);
+        return;
+      }
+      liveUrl = url;
+      handlers.onLoad(url);
+    })
+    .catch(() => {
+      if (!cancelled) handlers.onError();
+    });
+
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    if (liveUrl) {
+      revokeObjectURL(liveUrl);
+      liveUrl = null;
+    }
+  };
+}

--- a/packages/dmloop/src/ui/objectUrl.ts
+++ b/packages/dmloop/src/ui/objectUrl.ts
@@ -9,6 +9,13 @@
  * `fetchBlob` is injected (not imported) so this module stays free of the API
  * client's transitive UI deps and remains unit-testable in a plain node env.
  *
+ * `isInlineSafe` gates object-URL creation on the fetched blob's actual MIME
+ * type: a blob whose type is not inline-safe (e.g. image/svg+xml, which can run
+ * script in the document origin) is treated as a load failure — onError fires,
+ * no object URL is created — so callers fall back to a download link. This is
+ * the last line of defense for the inline-image path, which only has a URL and
+ * cannot pre-filter by declared content type the way the attachment card can.
+ *
  * Returns a `cancel` function. Call it on unmount / id change:
  *   - before onLoad fired  → the pending load is dropped; if it later resolves,
  *     the freshly created URL is revoked immediately (no leak, no callback).
@@ -20,11 +27,12 @@ export function loadObjectUrl(
   handlers: { onLoad: (url: string) => void; onError: () => void },
   deps: {
     fetchBlob: (id: string) => Promise<Blob>;
+    isInlineSafe?: (mimeType: string) => boolean;
     createObjectURL?: (blob: Blob) => string;
     revokeObjectURL?: (url: string) => void;
   },
 ): () => void {
-  const { fetchBlob } = deps;
+  const { fetchBlob, isInlineSafe } = deps;
   const createObjectURL =
     deps.createObjectURL ?? ((b: Blob) => URL.createObjectURL(b));
   const revokeObjectURL =
@@ -35,6 +43,12 @@ export function loadObjectUrl(
 
   fetchBlob(attachmentId)
     .then((blob) => {
+      // Reject unsafe MIME before ever creating an object URL: an SVG blob
+      // inlined as <img> would execute in the document origin (stored XSS).
+      if (isInlineSafe && !isInlineSafe(blob.type)) {
+        if (!cancelled) handlers.onError();
+        return;
+      }
       const url = createObjectURL(blob);
       if (cancelled) {
         // Resolved after cancel: revoke the URL we just made, deliver nothing.

--- a/packages/dmloop/src/ui/threadReplies.ts
+++ b/packages/dmloop/src/ui/threadReplies.ts
@@ -1,0 +1,48 @@
+import type { IssueComment } from "../api/types";
+
+/**
+ * Collect every descendant reply of a thread root, flattened in chronological
+ * order (created_at ASC, id tie-break).
+ *
+ * A thread is not always two levels deep: an agent reply is stored with its
+ * `parent_id` pointing at the specific comment that triggered it (a member's
+ * @mention), not at the thread root. So a member question sits one level under
+ * the root while the agent's answer sits one level under that member question —
+ * a grandchild. Taking only direct children of the root drops every agent reply
+ * from the view even though the API returned them. Walking the whole subtree
+ * keeps replies at any depth, and flattening chronologically renders the
+ * back-and-forth (member ask → agent answer) in the order it happened.
+ */
+export function collectThreadReplies(
+  rootId: string,
+  comments: IssueComment[],
+): IssueComment[] {
+  const childrenByParent = new Map<string, IssueComment[]>();
+  for (const c of comments) {
+    if (!c.parent_id) continue;
+    const list = childrenByParent.get(c.parent_id) ?? [];
+    list.push(c);
+    childrenByParent.set(c.parent_id, list);
+  }
+
+  const out: IssueComment[] = [];
+  const seen = new Set<string>();
+  const walk = (id: string) => {
+    for (const child of childrenByParent.get(id) ?? []) {
+      // Guard against a parent_id cycle (self- or mutual reference): a bad
+      // write must not spin the render into an infinite loop.
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      out.push(child);
+      walk(child.id);
+    }
+  };
+  walk(rootId);
+
+  return out.sort((a, b) => {
+    const ta = new Date(a.created_at).getTime();
+    const tb = new Date(b.created_at).getTime();
+    if (ta !== tb) return ta - tb;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}

--- a/packages/dmloop/src/ui/useAuthedAttachment.ts
+++ b/packages/dmloop/src/ui/useAuthedAttachment.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { fetchAttachmentBlob } from "../api/attachmentApi";
+import { loadObjectUrl } from "./objectUrl";
+import { canPreviewInline } from "./attachmentPreview";
+import { downloadAttachmentById, domSaveBlob } from "./downloadAttachment";
+
+/**
+ * Load an attachment as an authenticated object URL for inline <img> display.
+ * Shared by the attachment card (AuthedImage) and the inline markdown image so
+ * the two render paths cannot drift. Returns `{ url, failed }`:
+ *   - url === null && !failed → still loading
+ *   - failed === true         → not inline-safe (e.g. SVG) or fetch failed;
+ *                               caller should show a download affordance instead
+ *   - url set                 → object URL ready for <img src>
+ *
+ * The object URL is revoked on unmount / id change (lifecycle in loadObjectUrl),
+ * and inline-unsafe MIME types are refused before any URL is created.
+ */
+export function useAuthedAttachmentUrl(id: string): { url: string | null; failed: boolean } {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setUrl(null);
+    setFailed(false);
+    return loadObjectUrl(
+      id,
+      { onLoad: setUrl, onError: () => setFailed(true) },
+      { fetchBlob: fetchAttachmentBlob, isInlineSafe: canPreviewInline },
+    );
+  }, [id]);
+
+  return { url, failed };
+}
+
+/**
+ * Fetch an attachment through the authenticated client and trigger a browser
+ * download. Used wherever a download affordance points at the auth-only
+ * endpoint — a native <a href> there would 404/401 under octo-web (the exact
+ * bug this module works around), so both the attachment card and the inline
+ * markdown fallback route clicks through here.
+ *
+ * Returns true if the download was started, false if the fetch failed.
+ */
+export function triggerAuthedDownload(id: string, filename: string): Promise<boolean> {
+  return downloadAttachmentById(id, filename, {
+    fetchBlob: fetchAttachmentBlob,
+    saveBlob: domSaveBlob,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes two rendering defects in the Loop (dmloop) issue detail timeline that hid AI teammate collaboration output from the user under the octo-web host. Both are frontend-only; the backend and daemon are correct and the API already returns the data.

## Related Issue

Fixes #751

## Changes

- **Nested agent replies were dropped.** The timeline only collected *direct* children of a thread root, but an agent reply nests under the comment that triggered it — a grandchild — so agent answers vanished even though the API returned them. Added `collectThreadReplies` to walk the whole reply subtree and flatten it chronologically (with `parent_id` cycle protection); `repliesOf` now uses it.
- **Attachments 404'd / broke.** The auth-only download endpoint was used as a native `<img>`/`<a>` src via the site-relative `/api` path, which cannot carry the header-based auth this client uses. Now the bytes are fetched through the authenticated loop client (same `/fleet/api/v1` prefix as every other loop call — the deployment's rewrite layer maps it to the backend identically) and wrapped in an object URL.
- Isolated the fetch → `createObjectURL` → `revoke` lifecycle in `objectUrl.ts` (`loadObjectUrl`) so unmount / id change cannot leak blobs; `fetchBlob` is injected to keep the module free of UI transitive deps and unit-testable in node.
- Added a visible loading skeleton (`.loop-att--loading`) and a download-semantic `aria-label` (new `loop.attach.download` i18n key, en + zh).
- Tests: `threadReplies.test.ts` (direct children / grandchildren / chronological order / cycle) and `objectUrl.test.ts` (delivery / revoke-once / resolve-after-dispose / failure / error-suppressed-after-dispose).

## Architecture / Module Boundary

- Affected module(s): `packages/dmloop` (Loop issue detail — timeline + attachments)
- New or changed user-visible entry point: no (fixes rendering of an existing view)
- Shared layer touched: none (changes are contained in dmloop)
- If shared code changed, impact scope: n/a
- Duplicate entry point checked: not applicable

## Testing

- `vitest run` in `packages/dmloop`: **39 passed** (7 files), including the 9 new tests above.
- Type-check: no errors in the changed files.
- `pnpm i18n:check`: passed (locale keys healthy).
- Manually verified end-to-end on a local Loop issue and against the standard test environment (im-test): nested agent replies now render; the image attachment loads (4032×2268, via blob URL) instead of showing a broken-image placeholder.

### Note on the attachment path (for reviewers)

The fix routes attachments through `/fleet/api/v1/attachments/<id>/download`. On the standard deployment this resolves to the backend the same way every other loop API does — the `/fleet/api/v1 → backend` rewrite is done by the deployment layer (nginx), **not** by frontend config. Verified on im-test: `GET /fleet/api/v1/attachments/<id>/download` returns **401** (route exists, just needs auth — which `LoopAttachments` sends), while the old `GET /api/attachments/<id>/download` returns **404**. No vite/nginx config change is included in this PR.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
