### PR TITLE
fix(docs): sync line-spacing dropdown display and tidy custom input

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -685,6 +685,56 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   })
 })
 
+describe('Toolbar — line-spacing dropdown display sync (XIN-1039 #1)', () => {
+  // Regression: picking a value from the line-spacing dropdown changed the block's line-height
+  // but the dropdown kept showing the old label. setLineHeight is an attribute-only transaction
+  // that leaves the caret put, so a selection-keyed re-render never fired; React then restored
+  // the controlled <select> to its stale `value` prop. The control must re-render off the
+  // line-height value itself so the display follows the selection.
+  let lhEditor: Editor | null = null
+  let holder: HTMLDivElement | null = null
+
+  function mount(content = '<p>hello</p>') {
+    holder = document.createElement('div')
+    document.body.appendChild(holder)
+    lhEditor = new Editor({
+      element: holder,
+      extensions: [StarterKit.configure({ undoRedo: false }), LineHeight],
+      content,
+    })
+    render(<Toolbar editor={lhEditor} />)
+    return document.querySelector('select.octo-line-height') as HTMLSelectElement
+  }
+
+  afterEach(() => {
+    lhEditor?.destroy()
+    lhEditor = null
+    holder?.remove()
+    holder = null
+  })
+
+  it('reflects the picked preset in the dropdown display, not just the document', () => {
+    const select = mount()
+    expect(select.value).toBe('') // starts on the "Default spacing" option
+
+    fireEvent.change(select, { target: { value: '2' } })
+    // Both the document AND the control must show 2 — the control used to snap back to "".
+    expect(lhEditor!.getAttributes('paragraph').lineHeight).toBe('2')
+    expect(select.value).toBe('2')
+  })
+
+  it('updates the dropdown when a custom multiplier is committed via the input', () => {
+    const select = mount()
+    const input = document.querySelector('input.octo-line-height-custom') as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: '1.75' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    // 1.75 is off the preset list, so the dropdown must fall to the "custom" sentinel — not "".
+    expect(lhEditor!.getAttributes('paragraph').lineHeight).toBe('1.75')
+    expect(select.value).toBe('custom')
+  })
+})
+
 describe('Toolbar — paragraph spacing controls (SCHEMA_VERSION 17)', () => {
   // The schema/commands/docx/i18n all carried spaceBefore/spaceAfter, but the toolbar exposed no
   // UI to set them. These are the space-before / space-after dropdowns that close that gap.

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -583,7 +583,9 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   // on every keystroke: typing bounced the caret back into the editor (only the first char
   // landed) and an in-progress value like "1." was rejected by sanitizeLineHeight and snapped
   // back to empty — so a custom multiplier could not be typed at all. It is now a commit-on-
-  // blur/Enter field with a local draft. These tests pin that behaviour.
+  // blur/Enter field with a local draft. These tests pin that behaviour. The field now renders
+  // only while "custom" is the active option, so each test reveals it first (via revealCustom or
+  // by seeding a non-preset value into the block).
   let lhEditor: Editor | null = null
   let holder: HTMLDivElement | null = null
 
@@ -596,6 +598,12 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
       content,
     })
     render(<Toolbar editor={lhEditor} />)
+    return document.querySelector('select.octo-line-height') as HTMLSelectElement
+  }
+
+  // Pick "custom" from the dropdown to reveal the input, then hand it back.
+  function revealCustom(select: HTMLSelectElement) {
+    fireEvent.change(select, { target: { value: 'custom' } })
     return document.querySelector('input.octo-line-height-custom') as HTMLInputElement
   }
 
@@ -615,7 +623,7 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   })
 
   it('keeps focus in the field and does not commit while typing a multi-char value', () => {
-    const input = mount()
+    const input = revealCustom(mount())
     input.focus()
     expect(document.activeElement).toBe(input)
 
@@ -638,7 +646,7 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   })
 
   it('commits the typed value to the editor on Enter', () => {
-    const input = mount()
+    const input = revealCustom(mount())
     input.focus()
     fireEvent.change(input, { target: { value: '1.15' } })
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -646,7 +654,7 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   })
 
   it('commits the typed value to the editor on blur', () => {
-    const input = mount()
+    const input = revealCustom(mount())
     input.focus()
     fireEvent.change(input, { target: { value: '1.75' } })
     fireEvent.blur(input)
@@ -654,32 +662,33 @@ describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal R
   })
 
   it('reverts an invalid/partial value to the last committed value on commit', () => {
-    const input = mount()
+    const input = revealCustom(mount())
     input.focus()
     // Commit a good value first.
-    fireEvent.change(input, { target: { value: '1.5' } })
+    fireEvent.change(input, { target: { value: '1.7' } })
     fireEvent.keyDown(input, { key: 'Enter' })
-    expect(lineHeightOf(lhEditor!)).toBe('1.5')
+    expect(lineHeightOf(lhEditor!)).toBe('1.7')
 
-    // Now type a partial value and commit it — it fails sanitize, so the field restores 1.5
+    // Now type a partial value and commit it — it fails sanitize, so the field restores 1.7
     // and the editor keeps the previous multiplier (no bogus value written).
     fireEvent.change(input, { target: { value: '2.' } })
     expect(input.value).toBe('2.') // stays while typing…
     fireEvent.blur(input) // …but on commit it reverts.
-    expect(input.value).toBe('1.5')
-    expect(lineHeightOf(lhEditor!)).toBe('1.5')
+    expect(input.value).toBe('1.7')
+    expect(lineHeightOf(lhEditor!)).toBe('1.7')
   })
 
   it('seeds the custom field from the block the caret is in (round-trip on mount)', () => {
-    // A block already carrying a custom multiplier shows it in the field when the toolbar mounts.
-    mount('<p style="line-height: 1.15">seed</p>')
+    // A block already carrying a non-preset multiplier shows the field seeded with it on mount —
+    // no need to pick "custom" first, because a non-preset value is inherently "custom".
+    mount('<p style="line-height: 1.3">seed</p>')
     const input = document.querySelector('input.octo-line-height-custom') as HTMLInputElement
-    expect(input.value).toBe('1.15')
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('1.3')
   })
 
   it('picking a preset from the dropdown writes the multiplier to the editor', () => {
-    const input = mount()
-    const select = input.parentElement!.querySelector('select.octo-line-height') as HTMLSelectElement
+    const select = mount()
     fireEvent.change(select, { target: { value: '2' } })
     expect(lineHeightOf(lhEditor!)).toBe('2')
   })
@@ -725,6 +734,8 @@ describe('Toolbar — line-spacing dropdown display sync (XIN-1039 #1)', () => {
 
   it('updates the dropdown when a custom multiplier is committed via the input', () => {
     const select = mount()
+    // Reveal the custom input by picking "custom", then commit an off-preset value through it.
+    fireEvent.change(select, { target: { value: 'custom' } })
     const input = document.querySelector('input.octo-line-height-custom') as HTMLInputElement
     input.focus()
     fireEvent.change(input, { target: { value: '1.75' } })
@@ -732,6 +743,86 @@ describe('Toolbar — line-spacing dropdown display sync (XIN-1039 #1)', () => {
     // 1.75 is off the preset list, so the dropdown must fall to the "custom" sentinel — not "".
     expect(lhEditor!.getAttributes('paragraph').lineHeight).toBe('1.75')
     expect(select.value).toBe('custom')
+  })
+})
+
+describe('Toolbar — custom line-height input conditional visibility (XIN-1055)', () => {
+  // The custom multiplier input used to be permanently mounted next to the dropdown, which read as
+  // a confusing always-there box. It must now appear ONLY while "custom" is the active option —
+  // when the user picks "custom" from the dropdown, or when the caret sits in a block already
+  // carrying a non-preset value — and be truly absent (not just hidden) otherwise, so it occupies
+  // no layout space.
+  let lhEditor: Editor | null = null
+  let holder: HTMLDivElement | null = null
+
+  function mount(content = '<p>hello</p>') {
+    holder = document.createElement('div')
+    document.body.appendChild(holder)
+    lhEditor = new Editor({
+      element: holder,
+      extensions: [StarterKit.configure({ undoRedo: false }), LineHeight],
+      content,
+    })
+    render(<Toolbar editor={lhEditor} />)
+    return document.querySelector('select.octo-line-height') as HTMLSelectElement
+  }
+
+  const input = () => document.querySelector('input.octo-line-height-custom') as HTMLInputElement | null
+
+  afterEach(() => {
+    lhEditor?.destroy()
+    lhEditor = null
+    holder?.remove()
+    holder = null
+  })
+
+  it('does not render the custom input on a default-spacing block', () => {
+    mount()
+    expect(input()).toBeNull()
+  })
+
+  it('does not render the custom input while a preset is selected', () => {
+    const select = mount()
+    fireEvent.change(select, { target: { value: '1.5' } })
+    expect(select.value).toBe('1.5')
+    expect(input()).toBeNull()
+  })
+
+  it('reveals the custom input when "custom" is picked from the dropdown', () => {
+    const select = mount()
+    expect(input()).toBeNull()
+    fireEvent.change(select, { target: { value: 'custom' } })
+    expect(select.value).toBe('custom')
+    expect(input()).not.toBeNull()
+  })
+
+  it('hides the custom input again when switching from custom back to a preset', () => {
+    const select = mount()
+    // Enter custom, commit an off-preset value so the input is genuinely showing a custom value.
+    fireEvent.change(select, { target: { value: 'custom' } })
+    const field = input()!
+    field.focus()
+    fireEvent.change(field, { target: { value: '1.3' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+    expect(lhEditor!.getAttributes('paragraph').lineHeight).toBe('1.3')
+    expect(input()).not.toBeNull()
+
+    // Switch back to a preset: the input must disappear and the preset must apply.
+    fireEvent.change(select, { target: { value: '2' } })
+    expect(lhEditor!.getAttributes('paragraph').lineHeight).toBe('2')
+    expect(select.value).toBe('2')
+    expect(input()).toBeNull()
+  })
+
+  it('shows the input seeded with the value when the caret is in a block already on a custom multiplier (#1 sync, not regressed)', () => {
+    // Continuation of the XIN-1039 #1 display-sync guarantee: a block whose line-height is off the
+    // preset list must surface as "custom" in the dropdown AND reveal the input carrying that value
+    // — without the user having to pick "custom" first.
+    const select = mount('<p style="line-height: 1.3">seed</p>')
+    expect(select.value).toBe('custom')
+    const field = input()
+    expect(field).not.toBeNull()
+    expect(field!.value).toBe('1.3')
   })
 })
 

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -190,6 +190,31 @@ function useEditorTick(editor: Editor): void {
 }
 
 /**
+ * Like useEditorTick but also re-renders when the value returned by `read(editor)` changes —
+ * not only when the selection moves. A setLineHeight / setSpaceBefore transaction rewrites a
+ * block attribute while leaving the caret put, so the selection-keyed snapshot of useEditorTick
+ * does NOT change and React skips the re-render; a controlled <select> is then restored to its
+ * stale `value` prop, so the dropdown kept showing the old label after a value was picked
+ * (line-spacing display desync, XIN-1039 #1). Keying the snapshot off the displayed value itself
+ * makes the control re-render exactly when that value changes — the same fix shape as useFindState
+ * below. Returns the freshly read value so the caller renders from it directly.
+ */
+function useEditorValueTick(editor: Editor, read: (editor: Editor) => string): string {
+  useSyncExternalStore(
+    (cb) => {
+      editor.on('transaction', cb)
+      editor.on('selectionUpdate', cb)
+      return () => {
+        editor.off('transaction', cb)
+        editor.off('selectionUpdate', cb)
+      }
+    },
+    () => `${editor.state.selection.from}:${editor.state.selection.to}:${read(editor)}`,
+  )
+  return read(editor)
+}
+
+/**
  * Subscribe a component to the find/replace plugin state, returning the live FindReplaceState.
  *
  * The plain useEditorTick snapshot keys only off the selection (from:to), so a setFindQuery
@@ -772,8 +797,7 @@ function LineHeightCustomInput({ editor }: { editor: Editor }) {
  * two block types is active, so the control reflects the caret's block.
  */
 function LineHeightSelect({ editor }: { editor: Editor }) {
-  useEditorTick(editor)
-  const current = currentLineHeight(editor)
+  const current = useEditorValueTick(editor, currentLineHeight)
   const isPreset = (LINE_HEIGHTS as readonly string[]).includes(current)
   return (
     <span className="octo-line-height-control">
@@ -814,12 +838,14 @@ const PARAGRAPH_SPACINGS = ['0px', '4px', '8px', '12px', '16px', '24px'] as cons
  * (e.g. an em length pasted in) still shows as "Custom" so it isn't silently reset.
  */
 function ParagraphSpacingSelect({ editor, edge }: { editor: Editor; edge: 'before' | 'after' }) {
-  useEditorTick(editor)
   const attr = edge === 'before' ? 'spaceBefore' : 'spaceAfter'
-  const current =
-    (editor.getAttributes('paragraph')[attr] as string | undefined) ??
-    (editor.getAttributes('heading')[attr] as string | undefined) ??
-    ''
+  const current = useEditorValueTick(
+    editor,
+    (e) =>
+      (e.getAttributes('paragraph')[attr] as string | undefined) ??
+      (e.getAttributes('heading')[attr] as string | undefined) ??
+      '',
+  )
   const isPreset = (PARAGRAPH_SPACINGS as readonly string[]).includes(current)
   const titleKey = edge === 'before' ? 'docs.toolbar.spaceBefore' : 'docs.toolbar.spaceAfter'
   return (

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -731,9 +731,19 @@ function currentLineHeight(editor: Editor): string {
  * and the value is pushed to the editor once, on blur or Enter. An invalid draft on commit is
  * reverted to the last committed value rather than written.
  */
-function LineHeightCustomInput({ editor }: { editor: Editor }) {
+function LineHeightCustomInput({ editor, autoFocus = false }: { editor: Editor; autoFocus?: boolean }) {
   const committed = currentLineHeight(editor)
   const [draft, setDraft] = useState(committed)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus the field the moment it is revealed by picking "custom" from the dropdown, so the user
+  // can type a multiplier straight away. Only on mount, and only when the reveal was an explicit
+  // pick — never when the field appears because the caret entered a block that already carries a
+  // custom value (stealing focus there would yank the caret out of the document mid-navigation).
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Adopt the committed value into the draft when it changes underneath us (caret moved to
   // another block, a preset was picked, or our own commit landed) — done as a render-phase
@@ -771,6 +781,7 @@ function LineHeightCustomInput({ editor }: { editor: Editor }) {
 
   return (
     <input
+      ref={inputRef}
       type="text"
       inputMode="decimal"
       className="octo-line-height-custom"
@@ -792,25 +803,51 @@ function LineHeightCustomInput({ editor }: { editor: Editor }) {
 
 /**
  * Line-spacing dropdown (SCHEMA_VERSION 17): sets the `lineHeight` attr on the current
- * heading/paragraph block (or clears it). The presets cover the common multipliers; the
- * adjacent number input takes a custom value. Reads the current value from whichever of the
- * two block types is active, so the control reflects the caret's block.
+ * heading/paragraph block (or clears it). The presets cover the common multipliers; a custom
+ * multiplier is entered in a number input that appears ONLY while "custom" is the active option —
+ * either because the caret sits in a block already carrying a non-preset value, or because the
+ * user just picked "custom" from the dropdown. Any preset/default selection hides the input, and
+ * because it is conditionally rendered (not merely hidden) it takes up no layout space when absent.
+ * Reads the current value from whichever of the two block types is active, so the control reflects
+ * the caret's block.
  */
 function LineHeightSelect({ editor }: { editor: Editor }) {
   const current = useEditorValueTick(editor, currentLineHeight)
   const isPreset = (LINE_HEIGHTS as readonly string[]).includes(current)
+  // A non-preset, non-empty value (e.g. a pasted 1.3, or one typed via the input) already means
+  // the block is on a custom multiplier — the input must show and seed from it (#1 display sync).
+  const hasCustomValue = !isPreset && current !== ''
+
+  // "Custom" is also a sticky UI mode: picking it from the dropdown reveals the input even before a
+  // value is typed (nothing is written to the block until a multiplier is committed). The mode is
+  // dropped as soon as the caret moves to another block, so the input never lingers over a
+  // preset/default block after navigation.
+  const [customPicked, setCustomPicked] = useState(false)
+  const seenFrom = useRef(editor.state.selection.from)
+  if (editor.state.selection.from !== seenFrom.current) {
+    seenFrom.current = editor.state.selection.from
+    if (customPicked) setCustomPicked(false)
+  }
+
+  const showCustom = hasCustomValue || customPicked
   return (
     <span className="octo-line-height-control">
       <select
         className="octo-line-height"
         title={t('docs.toolbar.lineHeight')}
-        value={isPreset ? current : current ? 'custom' : ''}
+        value={showCustom ? 'custom' : isPreset ? current : ''}
         onMouseDown={(e) => e.stopPropagation()}
         onChange={(e) => {
           const v = e.target.value
+          if (v === 'custom') {
+            // Reveal the custom input; the block value stays untouched until a multiplier is
+            // committed via the input.
+            setCustomPicked(true)
+            return
+          }
+          setCustomPicked(false)
           if (!v) editor.chain().focus().unsetLineHeight().run()
-          else if (v !== 'custom') editor.chain().focus().setLineHeight(v).run()
-          // 'custom' leaves the value untouched — the number input drives custom multipliers.
+          else editor.chain().focus().setLineHeight(v).run()
         }}
       >
         <option value="">{t('docs.toolbar.lineHeightDefault')}</option>
@@ -821,7 +858,7 @@ function LineHeightSelect({ editor }: { editor: Editor }) {
         ))}
         <option value="custom">{t('docs.toolbar.lineHeightCustom')}</option>
       </select>
-      <LineHeightCustomInput editor={editor} />
+      {showCustom && <LineHeightCustomInput editor={editor} autoFocus={customPicked} />}
     </span>
   )
 }

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -183,6 +183,31 @@
   opacity: 0.4;
   cursor: default;
 }
+
+/* Line-spacing controls (SCHEMA_VERSION 17). The custom line-height field holds only a short
+   numeric multiplier (e.g. "1.5"), so it is sized to a few characters — an unstyled text input
+   renders at the browser default width (~20 chars) and read as an oversized box next to the
+   dropdown (XIN-1039 #3). */
+.octo-line-height-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.octo-line-height-custom {
+  width: 4.5ch;
+  box-sizing: content-box;
+  border: 1px solid var(--octo-border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 13px;
+  background: var(--octo-bg);
+  color: var(--octo-fg);
+}
+.octo-line-height-custom:focus {
+  outline: none;
+  border-color: var(--octo-accent);
+}
+
 /* (Legacy inline link-input styles removed in batch 7 — the link editor is now a floating panel,
    see .octo-link-popover / .octo-link-field below near the colour-popover styles.) */
 

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -115,7 +115,7 @@
     "alignRight": "Align right",
     "alignJustify": "Justify",
     "lineHeight": "Line spacing",
-    "lineHeightDefault": "Default",
+    "lineHeightDefault": "Default spacing",
     "lineHeightCustom": "Custom",
     "spaceBefore": "Space before",
     "spaceAfter": "Space after",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -115,7 +115,7 @@
     "alignRight": "右对齐",
     "alignJustify": "两端对齐",
     "lineHeight": "行距",
-    "lineHeightDefault": "默认",
+    "lineHeightDefault": "默认行距",
     "lineHeightCustom": "自定义",
     "spaceBefore": "段前距",
     "spaceAfter": "段后距",


### PR DESCRIPTION
## Summary

Fixes the four issues reported from the line-spacing toolbar (schema v17) in the docs editor.

### 1. Line-spacing dropdown display desync (bug — fixed)
Picking a value from the line-spacing dropdown changed the block's line-height in the document, but the dropdown kept showing the previous label ("Default"/old value). Root cause: `setLineHeight` is an attribute-only transaction that leaves the caret put, so the toolbar's selection-keyed re-render (`useEditorTick`, snapshot = `from:to`) never fired. With no re-render, React restored the controlled `<select>` to its stale `value` prop.

Fix: added `useEditorValueTick`, which keys the re-render off the displayed value itself (same shape as the existing `useFindState` fix), and used it for both the line-spacing dropdown and the paragraph space-before/after dropdowns so the display always reflects the current selection. Added a red→green regression test proving the controlled value now follows the document.

### 2. Default option label (fixed)
`默认` → `默认行距` (zh-CN) and `Default` → `Default spacing` (en-US), so the empty option reads clearly as "no explicit line spacing".

### 3. Wide custom input (investigated + narrowed)
The oversized field to the right of the dropdown is the **custom line-height multiplier input** (`.octo-line-height-custom`): a commit-on-blur/Enter field for arbitrary multipliers (e.g. `1.75`) that the presets (`1 / 1.15 / 1.5 / 2`) don't cover. It is **not** redundant with the dropdown and should stay. It had no CSS at all, so it rendered at the browser default text-input width (~20 chars). Capped it to `4.5ch` with padding/border matching the toolbar's visual language.

### 4. Space-before / space-after (investigated — conclusion + recommendation)
- **Semantics confirmed correct:** `spaceBefore` → `margin-top` (space above the paragraph), `spaceAfter` → `margin-bottom` (space below).
- **End-to-end verified via existing coverage:** the attrs are sanitized global attributes on paragraph/heading, default to `null` (old docs round-trip losslessly), persist through the Y.Doc as inline styles, are covered by the paragraph-spacing toolbar tests and the schema round-trip tests, and export to docx (`mapSpacing` converts px/em → twips, `spacing.test.ts`). Editing, persistence, HTML round-trip and docx export are all wired and tested.
- **On the px unit — recommend keeping px, do NOT change here.** px is byte-aligned end-to-end today: the frontend sanitizer, the backend `toDOM`, and the docx twips conversion all agree on it (and `em` is already accepted for pasted values, shown as "Custom"). Switching the stored unit to a more document-native one (pt/磅 or em) would be a **schema/semantics change** that must be coordinated across the frontend sanitizer, the backend schema serialization, and the docx exporter — out of scope for a UI/display fix. Flagging this for a separate ticket (发号) for PM/owner to decide; not changed here. The presets already carry the unit in their labels ("4px", "8px", …), so the control is self-documenting in the meantime.

## Verification
- New regression test (`Toolbar — line-spacing dropdown display sync`) is red without the hook change and green with it; the full `Toolbar.test.tsx` suite passes (52/52).
- `tsc --noEmit` clean for all touched files; stylelint reports 0 errors for `styles.css` (added rules use theme variables only, no new warnings).
- Note: the standalone dev harness build is broken on `main` for unrelated reasons (`VoiceInputButton` / `buildDocLink` missing exports in the dev shim), so verification was done through the component tests, which mount the real `Toolbar` + a real Tiptap `Editor` and reproduce the exact controlled-select desync.

## Scope
Pure frontend — no schema, storage semantics, or backend contract touched.
