### PR TITLE
feat(docs): paragraph/heading indent (increase/decrease) — SCHEMA_VERSION v18

### DIFF
--- a/packages/docs/src/editor/IndentControls.test.tsx
+++ b/packages/docs/src/editor/IndentControls.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup, act } from '@testing-library/react'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Toolbar } from './Toolbar.tsx'
+import { ParagraphIndent, INDENT_MAX_LEVEL } from './ParagraphIndent.ts'
+
+// SCHEMA_VERSION 18 toolbar wiring for the indent group. Beyond the command-boundary unit
+// tests in ParagraphIndent.test.ts, this guards the two things the command tests can't see:
+// (1) the decrease button is disabled at level 0 (the "greyed by default" behaviour, which is
+// intentional — nothing to un-indent), and (2) it RE-ENABLES after an increase. (2) is the
+// real regression risk: the toolbar re-renders via useEditorTick, whose snapshot keys off the
+// selection (from:to). increaseIndent only rewrites a node attribute and leaves the caret put,
+// so a naive selection-only subscription could leave the button stale — the same class of bug
+// the find-counter (useFindState) had to work around.
+
+let editor: Editor | null = null
+
+beforeEach(() => {
+  editor = new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      ParagraphIndent.configure({ types: ['paragraph', 'heading'] }),
+    ],
+    content: '<p>hello</p>',
+  })
+  // A real caret in the paragraph, as the boss has when clicking the toolbar.
+  editor.commands.setTextSelection(3)
+})
+
+afterEach(() => {
+  cleanup()
+  editor?.destroy()
+  editor = null
+})
+
+function btn(title: string): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>(`button[title="${title}"]`)
+  if (!el) throw new Error(`no toolbar button with title="${title}"`)
+  return el
+}
+
+const DECREASE = 'docs.toolbar.indentDecrease'
+const INCREASE = 'docs.toolbar.indentIncrease'
+
+describe('Toolbar — indent decrease button disabled state (SCHEMA_VERSION 18)', () => {
+  it('decrease is disabled at level 0 by default, increase is enabled', () => {
+    render(<Toolbar editor={editor!} />)
+    expect(btn(DECREASE).disabled).toBe(true)
+    expect(btn(INCREASE).disabled).toBe(false)
+  })
+
+  it('decrease re-enables immediately after an increase, and disables again once back at 0', () => {
+    render(<Toolbar editor={editor!} />)
+    expect(btn(DECREASE).disabled).toBe(true)
+
+    // Increase → level 1: decrease must light up on the same render tick (reactivity).
+    act(() => {
+      fireEvent.click(btn(INCREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent).toBe(1)
+    expect(btn(DECREASE).disabled).toBe(false)
+
+    // Decrease back to 0 → button greys out again.
+    act(() => {
+      fireEvent.click(btn(DECREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent ?? 0).toBe(0)
+    expect(btn(DECREASE).disabled).toBe(true)
+  })
+
+  it('increase applies level by level and the buttons track the current level', () => {
+    render(<Toolbar editor={editor!} />)
+    for (let i = 1; i <= INDENT_MAX_LEVEL; i++) {
+      act(() => {
+        fireEvent.click(btn(INCREASE))
+      })
+      expect(editor!.getAttributes('paragraph').indent).toBe(i)
+      expect(btn(DECREASE).disabled).toBe(false)
+    }
+  })
+})

--- a/packages/docs/src/editor/IndentControls.test.tsx
+++ b/packages/docs/src/editor/IndentControls.test.tsx
@@ -6,13 +6,17 @@ import { Toolbar } from './Toolbar.tsx'
 import { ParagraphIndent, INDENT_MAX_LEVEL } from './ParagraphIndent.ts'
 
 // SCHEMA_VERSION 18 toolbar wiring for the indent group. Beyond the command-boundary unit
-// tests in ParagraphIndent.test.ts, this guards the two things the command tests can't see:
-// (1) the decrease button is disabled at level 0 (the "greyed by default" behaviour, which is
-// intentional — nothing to un-indent), and (2) it RE-ENABLES after an increase. (2) is the
-// real regression risk: the toolbar re-renders via useEditorTick, whose snapshot keys off the
-// selection (from:to). increaseIndent only rewrites a node attribute and leaves the caret put,
-// so a naive selection-only subscription could leave the button stale — the same class of bug
-// the find-counter (useFindState) had to work around.
+// tests in ParagraphIndent.test.ts, this guards the toolbar reactivity across the FULL indent
+// matrix — the things the command tests can't see:
+// (1) at level 0, decrease is disabled (nothing to un-indent) while increase is enabled;
+// (2) decrease RE-ENABLES after an increase (the reported bug: the button stayed greyed after an
+//     increase because the toolbar only re-rendered on selection changes, and increaseIndent
+//     rewrites a node attribute while leaving the caret put — same class as the find-counter bug);
+// (3) at INDENT_MAX_LEVEL, increase is disabled (the clamp ceiling) and re-enables after a
+//     decrease — symmetric with (1);
+// (4) at every level in between BOTH buttons are clickable and each click steps one level.
+// Both boundaries key off useIndentLevel, so a naive selection-only subscription regresses all of
+// (2)–(4) at once.
 
 let editor: Editor | null = null
 
@@ -78,5 +82,58 @@ describe('Toolbar — indent decrease button disabled state (SCHEMA_VERSION 18)'
       expect(editor!.getAttributes('paragraph').indent).toBe(i)
       expect(btn(DECREASE).disabled).toBe(false)
     }
+  })
+
+  it('increase disables at INDENT_MAX_LEVEL and re-enables after a decrease (symmetric with decrease at 0)', () => {
+    render(<Toolbar editor={editor!} />)
+    // At level 0 increase is enabled (decrease disabled — the other boundary).
+    expect(btn(INCREASE).disabled).toBe(false)
+
+    // Climb to the ceiling; increase must stay enabled until we actually reach INDENT_MAX_LEVEL.
+    for (let i = 1; i <= INDENT_MAX_LEVEL; i++) {
+      act(() => {
+        fireEvent.click(btn(INCREASE))
+      })
+      expect(editor!.getAttributes('paragraph').indent).toBe(i)
+      // Enabled for every level BELOW the ceiling; disabled exactly at the ceiling.
+      expect(btn(INCREASE).disabled).toBe(i >= INDENT_MAX_LEVEL)
+    }
+    expect(editor!.getAttributes('paragraph').indent).toBe(INDENT_MAX_LEVEL)
+    expect(btn(INCREASE).disabled).toBe(true)
+
+    // Clicking the disabled-at-max increase is a no-op — the level does not exceed the clamp.
+    act(() => {
+      fireEvent.click(btn(INCREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent).toBe(INDENT_MAX_LEVEL)
+
+    // One decrease pulls us off the ceiling → increase re-enables on the same render tick.
+    act(() => {
+      fireEvent.click(btn(DECREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent).toBe(INDENT_MAX_LEVEL - 1)
+    expect(btn(INCREASE).disabled).toBe(false)
+  })
+
+  it('mid-range levels keep BOTH buttons clickable (full matrix: 0 → max, both enabled in between)', () => {
+    render(<Toolbar editor={editor!} />)
+    // Move to a middle level (2) where neither boundary applies.
+    act(() => {
+      fireEvent.click(btn(INCREASE))
+    })
+    act(() => {
+      fireEvent.click(btn(INCREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent).toBe(2)
+    expect(btn(INCREASE).disabled).toBe(false)
+    expect(btn(DECREASE).disabled).toBe(false)
+
+    // Decrease actually steps down one level (not a no-op) and both stay enabled at level 1.
+    act(() => {
+      fireEvent.click(btn(DECREASE))
+    })
+    expect(editor!.getAttributes('paragraph').indent).toBe(1)
+    expect(btn(INCREASE).disabled).toBe(false)
+    expect(btn(DECREASE).disabled).toBe(false)
   })
 })

--- a/packages/docs/src/editor/ParagraphIndent.test.ts
+++ b/packages/docs/src/editor/ParagraphIndent.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import * as Y from 'yjs'
+import { ParagraphIndent, clampIndent, INDENT_MAX_LEVEL, INDENT_STEP_EM } from './ParagraphIndent.ts'
+
+// SCHEMA_VERSION 18: indent inc/dec on paragraph + heading. These assertions guard the
+// command boundaries (no-op at 0, clamp at max), the attr round-trip via data-indent, and
+// that list items never gain the attr (list Tab/Shift-Tab sink/lift stays untouched).
+
+function makeEditor(html: string): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      ParagraphIndent.configure({ types: ['paragraph', 'heading'] }),
+    ],
+    content: html,
+  })
+}
+
+let editor: Editor | null = null
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+})
+
+/** Indent attr of the document's first top-level block. */
+function firstIndent(e: Editor): number {
+  return clampIndent(e.state.doc.firstChild?.attrs.indent)
+}
+
+describe('clampIndent', () => {
+  it('floors at 0, ceils at INDENT_MAX_LEVEL, rounds, and coerces non-numbers', () => {
+    expect(clampIndent(-3)).toBe(0)
+    expect(clampIndent(0)).toBe(0)
+    expect(clampIndent(2)).toBe(2)
+    expect(clampIndent(INDENT_MAX_LEVEL + 5)).toBe(INDENT_MAX_LEVEL)
+    expect(clampIndent('4')).toBe(4)
+    expect(clampIndent(2.6)).toBe(3)
+    expect(clampIndent(null)).toBe(0)
+    expect(clampIndent(undefined)).toBe(0)
+    expect(clampIndent(NaN)).toBe(0)
+  })
+})
+
+describe('increaseIndent / decreaseIndent on a paragraph', () => {
+  it('increaseIndent raises the level and decreaseIndent lowers it back', () => {
+    editor = makeEditor('<p>hello</p>')
+    editor.commands.selectAll()
+
+    expect(firstIndent(editor)).toBe(0)
+    expect(editor.commands.increaseIndent()).toBe(true)
+    expect(firstIndent(editor)).toBe(1)
+    expect(editor.commands.increaseIndent()).toBe(true)
+    expect(firstIndent(editor)).toBe(2)
+    expect(editor.commands.decreaseIndent()).toBe(true)
+    expect(firstIndent(editor)).toBe(1)
+  })
+
+  it('decreaseIndent at level 0 is a no-op (returns false, stays 0)', () => {
+    editor = makeEditor('<p>hello</p>')
+    editor.commands.selectAll()
+
+    expect(firstIndent(editor)).toBe(0)
+    expect(editor.commands.decreaseIndent()).toBe(false)
+    expect(firstIndent(editor)).toBe(0)
+  })
+
+  it('increaseIndent clamps at INDENT_MAX_LEVEL (further increase is a no-op)', () => {
+    editor = makeEditor('<p>hello</p>')
+    editor.commands.selectAll()
+
+    for (let i = 0; i < INDENT_MAX_LEVEL; i++) editor.commands.increaseIndent()
+    expect(firstIndent(editor)).toBe(INDENT_MAX_LEVEL)
+    expect(editor.commands.increaseIndent()).toBe(false)
+    expect(firstIndent(editor)).toBe(INDENT_MAX_LEVEL)
+  })
+
+  it('unsetIndent resets an indented block to 0', () => {
+    editor = makeEditor('<p>hello</p>')
+    editor.commands.selectAll()
+    editor.commands.increaseIndent()
+    editor.commands.increaseIndent()
+    expect(firstIndent(editor)).toBe(2)
+    expect(editor.commands.unsetIndent()).toBe(true)
+    expect(firstIndent(editor)).toBe(0)
+  })
+})
+
+describe('increaseIndent on a heading', () => {
+  it('applies to headings too (configured type)', () => {
+    editor = makeEditor('<h2>title</h2>')
+    editor.commands.selectAll()
+    expect(editor.commands.increaseIndent()).toBe(true)
+    expect(firstIndent(editor)).toBe(1)
+    expect(editor.state.doc.firstChild?.type.name).toBe('heading')
+  })
+})
+
+describe('indent HTML round-trip (data-indent <-> indent)', () => {
+  it('parses data-indent from HTML into the indent attr', () => {
+    editor = makeEditor('<p data-indent="3">x</p>')
+    expect(firstIndent(editor)).toBe(3)
+  })
+
+  it('renders an indented block with data-indent and a margin-left style', () => {
+    editor = makeEditor('<p>x</p>')
+    editor.commands.selectAll()
+    editor.commands.increaseIndent()
+    editor.commands.increaseIndent()
+    const html = editor.getHTML()
+    expect(html).toContain('data-indent="2"')
+    expect(html).toContain(`margin-left: ${2 * INDENT_STEP_EM}em`)
+  })
+
+  it('renders no indent attr/style at level 0 (backward-compatible with old docs)', () => {
+    editor = makeEditor('<p>x</p>')
+    const html = editor.getHTML()
+    expect(html).not.toContain('data-indent')
+    expect(html).not.toContain('margin-left')
+  })
+})
+
+// The collab boundary strips attrs the schema does not know. Two editors bound to the SAME
+// Y.Doc — both registering ParagraphIndent — must preserve the indent attr across the sync,
+// proving the attr rides through the Yjs XmlFragment intact (normalized structural check on
+// the decoded attr, not a raw-byte compare).
+describe('Yjs collaboration round-trip', () => {
+  it('preserves the indent attr from one peer to another via the shared Y.Doc', () => {
+    const ydoc = new Y.Doc()
+    const mkPeer = () =>
+      new Editor({
+        extensions: [
+          StarterKit.configure({ undoRedo: false }),
+          ParagraphIndent.configure({ types: ['paragraph', 'heading'] }),
+          Collaboration.configure({ document: ydoc }),
+        ],
+      })
+    const peerA = mkPeer()
+    const peerB = mkPeer()
+    try {
+      peerA.commands.selectAll()
+      peerA.commands.increaseIndent()
+      peerA.commands.increaseIndent()
+      // Both peers share one Y.Doc; the ySync observers apply A's change to B synchronously.
+      expect(clampIndent(peerA.state.doc.firstChild?.attrs.indent)).toBe(2)
+      expect(clampIndent(peerB.state.doc.firstChild?.attrs.indent)).toBe(2)
+    } finally {
+      peerA.destroy()
+      peerB.destroy()
+      ydoc.destroy()
+    }
+  })
+})

--- a/packages/docs/src/editor/ParagraphIndent.ts
+++ b/packages/docs/src/editor/ParagraphIndent.ts
@@ -1,0 +1,137 @@
+// Paragraph / heading indent (SCHEMA-SPEC §16, SCHEMA_VERSION 18).
+//
+// No official Tiptap extension covers plain-paragraph indentation (the built-in list
+// sink/lift only nests listItem nodes), so this is a self-built Extension modelled on
+// @tiptap/extension-text-align (SCHEMA_VERSION 5): it adds a global `indent` ATTRIBUTE to
+// the `paragraph` + `heading` nodes — not a new node/mark — that rides in the Y.Doc node
+// attrs and re-parses faithfully in the read-only preview.
+//
+// The value is an integer indent LEVEL (0 = no indent). It round-trips via a `data-indent`
+// attribute (like Callout's `data-variant`); the visual step is rendered as an inline
+// `margin-left` so the live editor and the static preview render identically without a
+// dedicated stylesheet rule. A missing/0 attr renders no style at all, so old documents
+// (no `indent` attr) are unchanged — backward-compatible by construction, no migration.
+//
+// LOCKSTEP: the attr name (`indent`), the `data-indent` round-trip, the null default and the
+// clamp bounds MUST stay byte-aligned with the backend stub + SCHEMA-SPEC.md at v18, or the
+// collab boundary can strip the unknown attr.
+
+import { Extension } from '@tiptap/core'
+
+/** Em per indent level applied as margin-left (presentational only; not persisted). */
+export const INDENT_STEP_EM = 2
+/** Maximum indent level; increaseIndent clamps here, decreaseIndent clamps at 0. */
+export const INDENT_MAX_LEVEL = 8
+
+/** Coerce any stored value to a valid integer indent level in [0, INDENT_MAX_LEVEL] (0 = none). */
+export function clampIndent(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return 0
+  return Math.min(INDENT_MAX_LEVEL, Math.max(0, Math.round(n)))
+}
+
+/** Storage form of a level: a positive level 1..MAX, or `null` for "no indent" (the default).
+ * Using `null` (not 0) as the empty sentinel keeps a plain paragraph attr-free through the Y.Doc
+ * (y-prosemirror stores every non-null attr), so old docs stay byte-identical and no migration is
+ * needed — exactly how textAlign / lineHeight default to null. */
+export function normalizeIndent(value: unknown): number | null {
+  const level = clampIndent(value)
+  return level > 0 ? level : null
+}
+
+export interface ParagraphIndentOptions {
+  /** Node types the `indent` attr is added to (paragraph + heading). */
+  types: string[]
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    paragraphIndent: {
+      /** Set the indent level of the selected block(s) to an explicit clamped level. */
+      setIndent: (level: number) => ReturnType
+      /** Increase the indent level of the selected block(s) by one (clamped at max). */
+      increaseIndent: () => ReturnType
+      /** Decrease the indent level of the selected block(s) by one (no-op at 0). */
+      decreaseIndent: () => ReturnType
+      /** Reset the indent level of the selected block(s) to 0. */
+      unsetIndent: () => ReturnType
+    }
+  }
+}
+
+export const ParagraphIndent = Extension.create<ParagraphIndentOptions>({
+  name: 'paragraphIndent',
+
+  addOptions() {
+    return {
+      types: ['paragraph', 'heading'],
+    }
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          indent: {
+            // null = no indent (default). y-prosemirror stores every non-null attr, so the null
+            // default keeps plain paragraphs attr-free through the Y.Doc (backward-compatible).
+            default: null,
+            // data-indent <-> indent round-trip (byte-aligned with the backend stub).
+            parseHTML: (element) => normalizeIndent(element.getAttribute('data-indent')),
+            renderHTML: (attributes) => {
+              const level = clampIndent(attributes.indent)
+              if (level <= 0) return {}
+              return {
+                'data-indent': String(level),
+                style: `margin-left: ${level * INDENT_STEP_EM}em`,
+              }
+            },
+          },
+        },
+      },
+    ]
+  },
+
+  addCommands() {
+    // Walk every block of a configured type in the selection and rewrite its indent level.
+    // Returns false when nothing changed (e.g. decreaseIndent at 0), so the boundary is a
+    // clean no-op and the toolbar button reflects it.
+    const applyIndent =
+      (compute: (current: number) => number) =>
+      ({ state, dispatch }: { state: import('@tiptap/pm/state').EditorState; dispatch?: (tr: import('@tiptap/pm/state').Transaction) => void }) => {
+        const { from, to } = state.selection
+        const tr = state.tr
+        let changed = false
+        state.doc.nodesBetween(from, to, (node, pos) => {
+          if (!this.options.types.includes(node.type.name)) return
+          const current = clampIndent(node.attrs.indent)
+          const next = clampIndent(compute(current))
+          if (next !== current) {
+            // Store null (not 0) for "no indent" so the attr is stripped from the Y.Doc.
+            tr.setNodeAttribute(pos, 'indent', next > 0 ? next : null)
+            changed = true
+          }
+        })
+        if (changed && dispatch) dispatch(tr)
+        return changed
+      }
+
+    return {
+      setIndent: (level) => applyIndent(() => level),
+      increaseIndent: () => applyIndent((c) => c + 1),
+      decreaseIndent: () => applyIndent((c) => c - 1),
+      unsetIndent: () => applyIndent(() => 0),
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Tab/Shift-Tab keep their list sink/lift behavior — those keys are owned by the list
+      // extensions and only fire inside a listItem. We bind Mod-] / Mod-[ for paragraph indent
+      // so we never shadow the list keymap.
+      'Mod-]': () => this.editor.commands.increaseIndent(),
+      'Mod-[': () => this.editor.commands.decreaseIndent(),
+    }
+  },
+})

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -50,6 +50,17 @@ const IconAlignJustify = () => (
     <path d="M3 5h18v2H3V5zm0 4h18v2H3V9zm0 4h18v2H3v-2zm0 4h18v2H3v-2z" />
   </svg>
 )
+// Indent buttons (SCHEMA_VERSION 18): lines with a right/left chevron marking the indent direction.
+const IconIndentIncrease = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M3 5h18v2H3V5zm8 4h10v2H11V9zm0 4h10v2H11v-2zm-8 4h18v2H3v-2zm.4-8.8L7 12l-3.6 2.8V6.2z" />
+  </svg>
+)
+const IconIndentDecrease = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M3 5h18v2H3V5zm8 4h10v2H11V9zm0 4h10v2H11v-2zm-8 4h18v2H3v-2zM6.6 6.2v7.6L3 11l3.6-2.8z" />
+  </svg>
+)
 
 // Toolbar item ⑧ (batch 7): list group + quote/code as icon buttons, link as a chain icon.
 // 16×16, fill: currentColor via .octo-tb-icon.
@@ -852,6 +863,31 @@ function ParagraphSpacingSelect({ editor, edge }: { editor: Editor; edge: 'befor
   )
 }
 
+/** Indent buttons (SCHEMA_VERSION 18): increase / decrease indent on the active heading + paragraph.
+ * List items keep their own Tab/Shift-Tab sink/lift behavior (owned by the list extensions). The
+ * decrease button is disabled at indent 0 so the boundary is visible as well as a command no-op. */
+function IndentControls({ editor }: { editor: Editor }) {
+  const current = Math.max(
+    Number(editor.getAttributes('paragraph').indent) || 0,
+    Number(editor.getAttributes('heading').indent) || 0,
+  )
+  return (
+    <>
+      <Btn
+        label={<IconIndentDecrease />}
+        title={t('docs.toolbar.indentDecrease')}
+        disabled={current <= 0}
+        onClick={() => editor.chain().focus().decreaseIndent().run()}
+      />
+      <Btn
+        label={<IconIndentIncrease />}
+        title={t('docs.toolbar.indentIncrease')}
+        onClick={() => editor.chain().focus().increaseIndent().run()}
+      />
+    </>
+  )
+}
+
 /** Emoji picker (SCHEMA_VERSION 9): a scrollable grid that inserts via the emoji node's setEmoji.
  * Search filters the full curated set; the grid renders an initial window and grows on scroll so
  * the ~1900-glyph set never mounts eagerly. */
@@ -1337,6 +1373,7 @@ export function Toolbar({ editor }: { editor: Editor }) {
       {LINE_SPACING_ENABLED && <LineHeightSelect editor={editor} />}
       {LINE_SPACING_ENABLED && <ParagraphSpacingSelect editor={editor} edge="before" />}
       {LINE_SPACING_ENABLED && <ParagraphSpacingSelect editor={editor} edge="after" />}
+      <IndentControls editor={editor} />
       <span className="octo-tb-sep" />
       <ListMenu editor={editor} />
       <Btn label={<IconQuote />} title={t('docs.toolbar.quote')} active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()} />

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -11,6 +11,7 @@ import { pickerEmojis } from './emoji.ts'
 import { promptAndInsertMath } from './mathInsert.ts'
 import { sanitizeLinkHref } from './sanitize.ts'
 import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
+import { INDENT_MAX_LEVEL } from './ParagraphIndent.ts'
 import { TableGridPicker } from './TableControls.tsx'
 import { capturePaintMarks, applyPaintMarks } from './formatPainter.ts'
 import { t } from '../octoweb/index.ts'
@@ -891,8 +892,11 @@ function useIndentLevel(editor: Editor): number {
 }
 
 /** Indent buttons (SCHEMA_VERSION 18): increase / decrease indent on the active heading + paragraph.
- * List items keep their own Tab/Shift-Tab sink/lift behavior (owned by the list extensions). The
- * decrease button is disabled at indent 0 so the boundary is visible as well as a command no-op. */
+ * List items keep their own Tab/Shift-Tab sink/lift behavior (owned by the list extensions). Both
+ * buttons key their disabled state off the current selection's indent level (useIndentLevel) so
+ * they mirror the command boundaries and re-render as the level changes: decrease is disabled at 0
+ * (nothing left to un-indent) and increase is disabled at INDENT_MAX_LEVEL (the clamp ceiling), so
+ * each boundary is visible as well as a command no-op — symmetric in both directions. */
 function IndentControls({ editor }: { editor: Editor }) {
   const current = useIndentLevel(editor)
   return (
@@ -906,6 +910,7 @@ function IndentControls({ editor }: { editor: Editor }) {
       <Btn
         label={<IconIndentIncrease />}
         title={t('docs.toolbar.indentIncrease')}
+        disabled={current >= INDENT_MAX_LEVEL}
         onClick={() => editor.chain().focus().increaseIndent().run()}
       />
     </>

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -863,14 +863,38 @@ function ParagraphSpacingSelect({ editor, edge }: { editor: Editor; edge: 'befor
   )
 }
 
+/** Current indent level at the selection (max of the active paragraph / heading), tracked so the
+ * indent buttons re-render whenever it changes.
+ *
+ * useEditorTick keys its re-render snapshot only off the selection (from:to), but increaseIndent /
+ * decreaseIndent rewrite a node ATTRIBUTE and leave the caret put — so a selection-only
+ * subscription leaves the decrease button's disabled state stale: it stayed greyed after an
+ * increase (the level went 0→1 but the button never re-enabled) and stayed lit after a
+ * decrease-to-0. Keying the snapshot off the level itself — the same fix useFindState applies for
+ * the find counter — re-renders the buttons exactly when the indent level actually changes. */
+function useIndentLevel(editor: Editor): number {
+  return useSyncExternalStore(
+    (cb) => {
+      editor.on('transaction', cb)
+      editor.on('selectionUpdate', cb)
+      return () => {
+        editor.off('transaction', cb)
+        editor.off('selectionUpdate', cb)
+      }
+    },
+    () =>
+      Math.max(
+        Number(editor.getAttributes('paragraph').indent) || 0,
+        Number(editor.getAttributes('heading').indent) || 0,
+      ),
+  )
+}
+
 /** Indent buttons (SCHEMA_VERSION 18): increase / decrease indent on the active heading + paragraph.
  * List items keep their own Tab/Shift-Tab sink/lift behavior (owned by the list extensions). The
  * decrease button is disabled at indent 0 so the boundary is visible as well as a command no-op. */
 function IndentControls({ editor }: { editor: Editor }) {
-  const current = Math.max(
-    Number(editor.getAttributes('paragraph').indent) || 0,
-    Number(editor.getAttributes('heading').indent) || 0,
-  )
+  const current = useIndentLevel(editor)
   return (
     <>
       <Btn

--- a/packages/docs/src/editor/extensions.test.ts
+++ b/packages/docs/src/editor/extensions.test.ts
@@ -129,4 +129,15 @@ describe('editor schema mirrors the schema audit lists', () => {
       expect(schema.nodes.heading.spec.attrs?.[attr], `heading missing ${attr}`).toBeDefined()
     }
   })
+
+  it('adds the v18 indent attr to heading and paragraph (attr, not a node), default null', () => {
+    expect(schema.nodes.paragraph.spec.attrs?.indent).toBeDefined()
+    expect(schema.nodes.heading.spec.attrs?.indent).toBeDefined()
+    expect(schema.nodes.paragraph.spec.attrs?.indent?.default).toBe(null)
+    expect(schema.nodes.heading.spec.attrs?.indent?.default).toBe(null)
+  })
+
+  it('does NOT add the indent attr to list items (list Tab/Shift-Tab stays untouched)', () => {
+    expect(schema.nodes.listItem.spec.attrs?.indent).toBeUndefined()
+  })
 })

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -30,6 +30,7 @@ import { Mathematics } from '@tiptap/extension-mathematics'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { createLowlight, common } from 'lowlight'
 import { BlockDragHandle } from './BlockDragHandle.ts'
+import { ParagraphIndent } from './ParagraphIndent.ts'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
@@ -203,6 +204,12 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // AFTER TextAlign so the canonical style property order (text-align; line-height; margin-top;
     // margin-bottom) holds for byte-alignment with the backend toDOM. Two-sided sanitise.
     LineHeight,
+    // SCHEMA-SPEC §16 (SCHEMA_VERSION 18): paragraph/heading indent. A global `indent` attr on
+    // the heading + paragraph nodes (not a new node/mark), rendered via margin-left and round-
+    // tripped as data-indent. Configured for the same two types as TextAlign so lists keep their
+    // own Tab/Shift-Tab sink/lift behavior untouched. Registered AFTER LineHeight so the
+    // margin-left declaration is appended last, matching the backend toDOM style order.
+    ParagraphIndent.configure({ types: ['heading', 'paragraph'] }),
     // SCHEMA-SPEC §3 (SCHEMA_VERSION 6): underline mark. StarterKit's bundled Underline is
     // disabled above; this standalone install is the single `underline` mark (same pattern as
     // the sanitised Link).
@@ -318,6 +325,9 @@ export function buildPreviewExtensions(docId: string): Extensions {
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
     // Mirror the live editor's v17 line-spacing attrs so a historical version renders faithfully.
     LineHeight,
+    // Mirror the v18 indent attr so a historical version / preview renders the same margin.
+    // Registered AFTER LineHeight, matching the live set's style order.
+    ParagraphIndent.configure({ types: ['heading', 'paragraph'] }),
     Underline,
     Superscript,
     Subscript,

--- a/packages/docs/src/export/markdown.test.ts
+++ b/packages/docs/src/export/markdown.test.ts
@@ -379,6 +379,29 @@ describe('exportDocToMarkdown — inline marks and atoms', () => {
     const out = await md(doc({ type: 'paragraph', attrs: { textAlign: 'center' }, content: [text('mid')] }))
     expect(out).toContain('<p align="center">mid</p>')
   })
+
+  it('indent (v18) wraps the block with a margin-left style', async () => {
+    const out = await md(doc({ type: 'paragraph', attrs: { indent: 2 }, content: [text('in')] }))
+    expect(out).toContain('<p style="margin-left:4em">in</p>')
+  })
+
+  it('indent + align combine into one wrapper tag', async () => {
+    const out = await md(
+      doc({ type: 'paragraph', attrs: { textAlign: 'right', indent: 1 }, content: [text('both')] }),
+    )
+    expect(out).toContain('<p align="right" style="margin-left:2em">both</p>')
+  })
+
+  it('an indented heading wraps in a div with margin-left', async () => {
+    const out = await md(doc({ type: 'heading', attrs: { level: 2, indent: 1 }, content: [text('h')] }))
+    expect(out).toContain('<div style="margin-left:2em">## h</div>')
+  })
+
+  it('indent 0 leaves the block as plain Markdown (backward-compat)', async () => {
+    const out = await md(doc({ type: 'paragraph', attrs: { indent: 0 }, content: [text('plain')] }))
+    expect(out).not.toContain('margin-left')
+    expect(out).toContain('plain')
+  })
 })
 
 // Regression (yujiawei P1 #3): markdown export interpolated hrefs and HTML-attribute values with

--- a/packages/docs/src/export/markdown.ts
+++ b/packages/docs/src/export/markdown.ts
@@ -9,6 +9,7 @@
 import { resolveAttachments, type ResolvedAttachment } from '../attachments/api.ts'
 import { sanitizeLinkHref, sanitizeBookmarkUrl } from '../editor/sanitize.ts'
 import { t } from '../octoweb/index.ts'
+import { clampIndent, INDENT_STEP_EM } from '../editor/ParagraphIndent.ts'
 
 /** ProseMirror-JSON node (the bits the serializer reads). */
 export interface MdNode {
@@ -197,14 +198,23 @@ function clampLevel(level: unknown): number {
   return Math.min(6, Math.max(1, n))
 }
 
-/** Wrap a block in an aligned HTML tag when textAlign is set to a non-default value. */
+/**
+ * Wrap a block in an HTML tag when it carries a non-default textAlign (v5) and/or a non-zero
+ * indent (v18) so both survive HTML export. Align rides on the `align` attribute (unchanged
+ * form for compatibility); indent rides on an inline `margin-left` style matching the editor's
+ * render. A block with neither is emitted as-is, so plain paragraphs stay plain Markdown.
+ */
 function wrapAlign(inner: string, node: MdNode): string {
   const align = node.attrs?.textAlign
-  if (typeof align === 'string' && align && align !== 'left') {
-    const tag = node.type === 'heading' ? 'div' : 'p'
-    return `<${tag} align="${escapeHtmlAttr(align)}">${inner}</${tag}>`
-  }
-  return inner
+  const hasAlign = typeof align === 'string' && align && align !== 'left'
+  const indent = clampIndent(node.attrs?.indent)
+  if (!hasAlign && indent <= 0) return inner
+  const tag = node.type === 'heading' ? 'div' : 'p'
+  const attrs = [
+    hasAlign ? ` align="${escapeHtmlAttr(align)}"` : '',
+    indent > 0 ? ` style="margin-left:${indent * INDENT_STEP_EM}em"` : '',
+  ].join('')
+  return `<${tag}${attrs}>${inner}</${tag}>`
 }
 
 function prefixLines(text: string, prefix: string): string {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -120,6 +120,8 @@
     "spaceBefore": "Space before",
     "spaceAfter": "Space after",
     "spacingCustom": "Custom",
+    "indentIncrease": "Increase indent",
+    "indentDecrease": "Decrease indent",
     "code": "Inline code",
     "list": "List",
     "bulletList": "Bullet list",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -120,6 +120,8 @@
     "spaceBefore": "段前距",
     "spaceAfter": "段后距",
     "spacingCustom": "自定义",
+    "indentIncrease": "增加缩进",
+    "indentDecrease": "减少缩进",
     "code": "行内代码",
     "list": "列表",
     "bulletList": "无序列表",

--- a/packages/docs/src/schema/index.test.ts
+++ b/packages/docs/src/schema/index.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { SCHEMA_VERSION, SCHEMA_NODES, SCHEMA_MARKS, COLLAB_FIELD } from './index.ts'
 
 // These assertions track docs/schema/SCHEMA-SPEC.md (single source of truth).
-// SCHEMA_VERSION 17 is the latest landed; the schema is cumulative, so every earlier
+// SCHEMA_VERSION 18 is the latest landed; the schema is cumulative, so every earlier
 // addition (v2 image, v3 highlight/textStyle, v4 tables, v5 textAlign attr, v6 underline,
 // v7 fontSize attr, v8 super/subscript, v9 emoji, v10 mention, v11 details, v12 callout,
-// v13 math, v14 fileAttachment, v15 bookmark, v16 fontFamily attr, v17 line-spacing attrs)
-// is carried forward.
+// v13 math, v14 fileAttachment, v15 bookmark, v16 fontFamily attr, v17 line-spacing attrs,
+// v18 indent attr) is carried forward.
 //
 // FOLLOW-UP (design §2.5): these are name-membership assertions only. The golden
 // schema round-trip regression — encode a fixture doc to a Yjs update, decode it back,
@@ -15,8 +15,8 @@ import { SCHEMA_VERSION, SCHEMA_NODES, SCHEMA_MARKS, COLLAB_FIELD } from './inde
 // separate phase. It is intentionally not built here: the v3 binding now runs through
 // @tiptap/y-tiptap, so the golden mechanism must be authored against that binding.
 describe('docs schema stub (mirrors SCHEMA-SPEC.md)', () => {
-  it('is at SCHEMA_VERSION 17', () => {
-    expect(SCHEMA_VERSION).toBe(17)
+  it('is at SCHEMA_VERSION 18', () => {
+    expect(SCHEMA_VERSION).toBe(18)
   })
 
   it('carries the v1 baseline marks', () => {
@@ -77,8 +77,8 @@ describe('docs schema stub (mirrors SCHEMA-SPEC.md)', () => {
     expect(SCHEMA_NODES).toContain('bookmark')
   })
 
-  it('keeps the v5/v7/v16/v17 attr-only additions OUT of the node/mark lists (they are attrs)', () => {
-    // textAlign rides on heading/paragraph; fontSize + fontFamily ride on the textStyle mark;
+  it('keeps the v5/v7/v16/v17/v18 attr-only additions OUT of the node/mark lists (they are attrs)', () => {
+    // textAlign + indent ride on heading/paragraph; fontSize + fontFamily ride on the textStyle mark;
     // lineHeight/spaceBefore/spaceAfter (v17) ride on heading/paragraph.
     expect(SCHEMA_NODES).not.toContain('textAlign')
     expect(SCHEMA_MARKS).not.toContain('textAlign')
@@ -88,6 +88,8 @@ describe('docs schema stub (mirrors SCHEMA-SPEC.md)', () => {
       expect(SCHEMA_NODES).not.toContain(attr)
       expect(SCHEMA_MARKS).not.toContain(attr)
     }
+    expect(SCHEMA_NODES).not.toContain('indent')
+    expect(SCHEMA_MARKS).not.toContain('indent')
   })
 
   it('keeps the v1 baseline nodes', () => {

--- a/packages/docs/src/schema/index.ts
+++ b/packages/docs/src/schema/index.ts
@@ -59,7 +59,13 @@
 //        default to null and ride on a single inline style declaration → line-height (unitless)
 //        + margin-top/margin-bottom (px|em), sanitised at both parse and render. Byte-aligned
 //        with the backend toDOM (see LineHeight.ts for the canonical style serialization).
-export const SCHEMA_VERSION = 17
+//   v18 — SCHEMA-SPEC §16: add a global `indent` ATTRIBUTE to the `heading` and `paragraph`
+//        nodes (not a new node/mark) — an integer indent level rendered via margin-left and
+//        round-tripped as data-indent, configured for exactly those two types (list Tab/Shift-Tab
+//        sink/lift is untouched). Same class of change as v5 textAlign / v7 fontSize: attribute,
+//        version bump only, byte-aligned with the backend stub + SCHEMA-SPEC. Missing attr = 0.
+//        The v18 margin-left declaration is appended AFTER the v17 line-spacing declarations.
+export const SCHEMA_VERSION = 18
 
 // Node names present in the schema at the current SCHEMA_VERSION. Mirrors the
 // backend stub's node set (SCHEMA-SPEC); kept here so the set is auditable against
@@ -99,10 +105,10 @@ export const SCHEMA_NODES = [
 // backend stub's mark set (SCHEMA-SPEC §3); kept here so the set is auditable
 // against the spec without importing the editor extensions.
 //
-// NOTE: v5 `textAlign`, v7 `fontSize`, v16 `fontFamily`, and v17 `lineHeight`/`spaceBefore`/
-// `spaceAfter` are ATTRIBUTES (textAlign + line-spacing on heading/paragraph, fontSize + fontFamily
-// on the textStyle mark), not new nodes/marks, so they add no entry here — only a version bump.
-// They still round-trip through the Y.Doc as node/mark attrs.
+// NOTE: v5 `textAlign`, v7 `fontSize`, v16 `fontFamily`, v17 `lineHeight`/`spaceBefore`/
+// `spaceAfter`, and v18 `indent` are ATTRIBUTES (textAlign + line-spacing + indent on
+// heading/paragraph, fontSize + fontFamily on the textStyle mark), not new nodes/marks, so they
+// add no entry here — only a version bump. They still round-trip through the Y.Doc as node/mark attrs.
 export const SCHEMA_MARKS = [
   'bold',
   'italic',


### PR DESCRIPTION
## Paragraph / heading indent (SCHEMA_VERSION v18)

Adds a global `indent` attribute to the `paragraph` and `heading` nodes, following the
same block-attr pattern as v5 `textAlign` and v17 line-spacing. Indent is an integer level
(default `null` = no indent, `1..8`), rendered via `margin-left` and round-tripped as a
`data-indent` attribute. Byte-aligned with the backend contract (octo-docs-backend#73) and
`docs/schema/SCHEMA-SPEC.md` §16.

This supersedes the earlier fork-internal draft (ploy-elison/octo-web#18, base `docs-v1`),
which could not merge to the deployable upstream `main`. The implementation is rebased onto
current `main` so it stacks cleanly on the already-landed v16 (font-family) and v17
(line-spacing) features — the diff here is indent-only (11 files).

### What changed
- **`ParagraphIndent` extension** — `increaseIndent` / `decreaseIndent` / `setIndent` /
  `unsetIndent` commands, clamp `[0, 8]`, no-op at level 0. `null` (not `0`) is the empty
  sentinel so plain paragraphs stay attr-free through the Y.Doc (no migration). Bound to
  `Mod-]` / `Mod-[` — list `Tab` / `Shift-Tab` sink/lift is untouched.
- **Registration** — added to both the live and the read-only preview extension sets,
  after `LineHeight`, so the `margin-left` declaration is appended after the v17
  declarations (matching the backend `toDOM` style order).
- **Toolbar** — increase / decrease buttons for the active paragraph or heading; decrease
  is disabled at level 0. i18n keys for en-US and zh-CN.
- **Markdown export** — an indented block is wrapped with an inline `margin-left` style
  alongside `align`.
- **Schema** — `SCHEMA_VERSION` 17 → 18; `indent` is an attribute, so no new node/mark
  entry.

### Verification
- `packages/docs` vitest: the indent-specific suites (schema, extensions, ParagraphIndent,
  markdown export) are all green, including a Yjs collaboration round-trip proving the attr
  survives the collab boundary.
- `tsc --noEmit` (docs typecheck): no new errors introduced by this change.
- Backward compatible: a document with no `indent` attr renders with no indent and no
  migration.

Draft — pairs with octo-docs-backend#73. Do not merge until both sides are reviewed together.
