### PR TITLE
refactor(docs): unify highlight and font-colour presets from a shared hue base

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -449,25 +449,25 @@ describe('Toolbar — highlight palette + custom picker', () => {
     expect(swatches).toHaveLength(10)
     const colours = swatches.map((s) => (s.getAttribute('title') || '').replace('Highlight ', ''))
     expect(colours).toEqual([
-      '#fff3a3',
-      '#ffe0a3',
-      '#ffd6cc',
-      '#ffd6e7',
-      '#e7d6ff',
-      '#d6ddff',
-      '#cfe2ff',
-      '#c9f0ef',
-      '#cdeccd',
-      '#e6e9ed',
+      '#d2d3d4',
+      '#e8e9ec',
+      '#f9d6d6',
+      '#fce8cc',
+      '#fcf1cd',
+      '#d5ecda',
+      '#ceede4',
+      '#d1e3f3',
+      '#d6e2ff',
+      '#ebd7f0',
     ])
   })
 
   it('applies a preset swatch highlight to the selection', () => {
     editor!.chain().focus().selectAll().run()
     const popover = openHighlightPopover()
-    const swatch = within(popover).getByTitle('Highlight #cfe2ff')
+    const swatch = within(popover).getByTitle('Highlight #d1e3f3')
     fireEvent.click(swatch)
-    expect(editor!.getAttributes('highlight').color).toBe('#cfe2ff')
+    expect(editor!.getAttributes('highlight').color).toBe('#d1e3f3')
   })
 
   it('exposes a native colour input that commits an arbitrary hex highlight on change', () => {

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -13,6 +13,7 @@ import { sanitizeLinkHref } from './sanitize.ts'
 import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { TableGridPicker } from './TableControls.tsx'
 import { capturePaintMarks, applyPaintMarks } from './formatPainter.ts'
+import { HIGHLIGHT_COLORS, TEXT_COLORS } from './colorPalette.ts'
 import { t } from '../octoweb/index.ts'
 import { FONT_FAMILY_ENABLED, LINE_SPACING_ENABLED } from '../config.ts'
 import { FONT_FAMILIES } from './fontFamilies.ts'
@@ -285,39 +286,11 @@ export function shouldShowFloatingMenu(args: {
   return isRootDepth && isEmptyTextBlock
 }
 
-// Common highlight (text-background) colours (octo-web follow-up to #719, same plan): a set of
-// light / pastel tints spread warm→cool so dark foreground text stays readable on every swatch.
-// The original five (yellow, peach, green, blue, purple) are preserved and kept in place; the new
-// entries fill out the spectrum (amber, pink, indigo, cyan, neutral grey). Values are standard
-// #rrggbb hex so DOCX/Markdown export keeps them lossless, mirroring TEXT_COLORS below.
-const HIGHLIGHT_COLORS = [
-  '#fff3a3',
-  '#ffe0a3',
-  '#ffd6cc',
-  '#ffd6e7',
-  '#e7d6ff',
-  '#d6ddff',
-  '#cfe2ff',
-  '#c9f0ef',
-  '#cdeccd',
-  '#e6e9ed',
-] as const
-// Common font colours (octo-web #719, plan A): near-black default, secondary grey, then the
-// warm→cool spread. Values are standard #rrggbb hex so DOCX export (normalizeDocxColor) keeps
-// them lossless. This scope covers font colour only — HIGHLIGHT_COLORS above is intentionally
-// left unchanged.
-const TEXT_COLORS = [
-  '#1f2329',
-  '#8a919e',
-  '#e03131',
-  '#f08c00',
-  '#f2b705',
-  '#2f9e44',
-  '#0ca678',
-  '#1971c2',
-  '#3370ff',
-  '#9c36b5',
-] as const
+// The highlight (text-background) and font-colour presets are DERIVED from one shared hue base
+// (PALETTE_HUES) in ./colorPalette.ts: TEXT_COLORS are the saturated hues, HIGHLIGHT_COLORS are the
+// same hues at the same index tinted light so dark text stays readable on top. Same count, same hue
+// order, same column ↦ same colour family across both pickers. Values stay #rrggbb so they survive
+// Yjs collaboration and the DOCX/Markdown exporters losslessly.
 
 /** Text-highlight control (SCHEMA-SPEC §3): palette of background colours + clear. */
 function HighlightControl({ editor }: { editor: Editor }) {

--- a/packages/docs/src/editor/colorPalette.test.ts
+++ b/packages/docs/src/editor/colorPalette.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PALETTE_HUES,
+  TEXT_COLORS,
+  HIGHLIGHT_COLORS,
+  HIGHLIGHT_TINT,
+  toHighlightTint,
+} from './colorPalette.ts'
+
+// Plan A: the highlight and font-colour presets are DERIVED from one shared hue base so the two
+// pickers can never drift apart in count, order, or hue family again. These tests pin that
+// relationship (not just the current literal values), so a future edit to PALETTE_HUES that breaks
+// the "same count / same order / Nth highlight = light of Nth text" contract fails loudly.
+
+const HEX = /^#[0-9a-f]{6}$/
+
+function relLuminance(hex: string): number {
+  const n = parseInt(hex.slice(1), 16)
+  // Perceived brightness proxy (sRGB weighted); good enough to assert "highlight is lighter".
+  return 0.2126 * ((n >> 16) & 0xff) + 0.7152 * ((n >> 8) & 0xff) + 0.0722 * (n & 0xff)
+}
+
+describe('colorPalette — shared hue base (plan A)', () => {
+  it('derives both preset lists from the same hue base, one entry per hue', () => {
+    expect(TEXT_COLORS).toHaveLength(PALETTE_HUES.length)
+    expect(HIGHLIGHT_COLORS).toHaveLength(PALETTE_HUES.length)
+    expect(TEXT_COLORS).toHaveLength(HIGHLIGHT_COLORS.length)
+  })
+
+  it('emits every swatch as lossless #rrggbb hex (DOCX/Markdown/Yjs safe)', () => {
+    for (const c of [...TEXT_COLORS, ...HIGHLIGHT_COLORS]) expect(c).toMatch(HEX)
+  })
+
+  it('keeps TEXT_COLORS as the saturated hue base itself, in order', () => {
+    expect([...TEXT_COLORS]).toEqual(PALETTE_HUES.map((h) => h.text))
+  })
+
+  it('makes the Nth highlight the light tint of the Nth text colour (same hue, same column)', () => {
+    HIGHLIGHT_COLORS.forEach((highlight, i) => {
+      expect(highlight).toBe(toHighlightTint(TEXT_COLORS[i]))
+    })
+  })
+
+  it('keeps every highlight lighter than its matching font colour (foreground/background contrast)', () => {
+    HIGHLIGHT_COLORS.forEach((highlight, i) => {
+      expect(relLuminance(highlight)).toBeGreaterThan(relLuminance(TEXT_COLORS[i]))
+    })
+  })
+})
+
+describe('colorPalette — toHighlightTint', () => {
+  it('leaves a colour unchanged at amount 0 and returns white at amount 1', () => {
+    expect(toHighlightTint('#3370ff', 0)).toBe('#3370ff')
+    expect(toHighlightTint('#3370ff', 1)).toBe('#ffffff')
+  })
+
+  it('mixes toward white by the default tint, lifting each channel', () => {
+    // #e03131 → light pink at the shared HIGHLIGHT_TINT.
+    expect(toHighlightTint('#e03131', HIGHLIGHT_TINT)).toBe('#f9d6d6')
+  })
+
+  it('rejects a non-#rrggbb input rather than emit a broken swatch', () => {
+    expect(() => toHighlightTint('red')).toThrow()
+    expect(() => toHighlightTint('#fff')).toThrow()
+  })
+})

--- a/packages/docs/src/editor/colorPalette.ts
+++ b/packages/docs/src/editor/colorPalette.ts
@@ -1,0 +1,63 @@
+// Shared colour palette for the editor toolbar (plan A: unify highlight + font-colour presets).
+//
+// Before this, the highlight and text-colour pickers each hard-coded their own independent 10-colour
+// array with no common source, so the two popovers disagreed on both count and hue order. Plan A
+// introduces a single hue base, PALETTE_HUES, and DERIVES both preset lists from it:
+//   - TEXT_COLORS      = the saturated hue itself (readable as foreground text)
+//   - HIGHLIGHT_COLORS = a light tint of the SAME hue at the SAME index (readable as a text
+//                        background, i.e. dark glyphs stay legible on top of it)
+// so the Nth highlight swatch is the light version of the Nth text swatch — same count, same hue
+// order, same column ↦ same colour family across both pickers.
+//
+// The foreground/background contrast difference is intentional and preserved: highlights must be
+// light so dark text on top stays readable, while font colours are saturated so they read as ink.
+// That is exactly what deriving the highlight tint via toHighlightTint() (mix the hue toward white)
+// guarantees for every hue at once, instead of two lists drifting apart by hand.
+//
+// All values are emitted as #rrggbb hex, so they round-trip losslessly through Yjs collaboration and
+// the DOCX/Markdown exporters (normalizeDocxColor). Existing document marks store their own literal
+// hex, so changing these presets never rewrites or migrates already-highlighted content.
+
+/** Fraction each saturated hue is mixed toward white to produce its light highlight tint. */
+export const HIGHLIGHT_TINT = 0.8
+
+/**
+ * Mix a #rrggbb colour toward white by `amount` (0 = unchanged, 1 = white) and return #rrggbb.
+ * A linear mix toward white keeps the hue and only lifts the lightness, which is what turns a
+ * saturated font colour into its matching light highlight background.
+ */
+export function toHighlightTint(hex: string, amount: number = HIGHLIGHT_TINT): string {
+  const m = /^#([0-9a-fA-F]{6})$/.exec(hex)
+  if (!m) throw new Error(`toHighlightTint expects #rrggbb, got: ${hex}`)
+  const n = parseInt(m[1], 16)
+  const r = (n >> 16) & 0xff
+  const g = (n >> 8) & 0xff
+  const b = n & 0xff
+  const lift = (c: number) => Math.round(c + (255 - c) * amount)
+  const to2 = (c: number) => lift(c).toString(16).padStart(2, '0')
+  return `#${to2(r)}${to2(g)}${to2(b)}`
+}
+
+/**
+ * Shared hue base. `text` is the saturated foreground colour; the matching highlight background is
+ * derived from it. Ordered neutrals-first (ink, grey) then warm→cool, mirroring the established
+ * font-colour identity set so the text picker keeps its familiar swatches.
+ */
+export const PALETTE_HUES = [
+  { name: 'ink', text: '#1f2329' },
+  { name: 'grey', text: '#8a919e' },
+  { name: 'red', text: '#e03131' },
+  { name: 'orange', text: '#f08c00' },
+  { name: 'amber', text: '#f2b705' },
+  { name: 'green', text: '#2f9e44' },
+  { name: 'teal', text: '#0ca678' },
+  { name: 'blue', text: '#1971c2' },
+  { name: 'indigo', text: '#3370ff' },
+  { name: 'purple', text: '#9c36b5' },
+] as const
+
+/** Saturated font colours — the hue base itself, one per column. */
+export const TEXT_COLORS = PALETTE_HUES.map((h) => h.text) as readonly string[]
+
+/** Light highlight backgrounds — same hue, same column, tinted toward white for dark-text contrast. */
+export const HIGHLIGHT_COLORS = PALETTE_HUES.map((h) => toHighlightTint(h.text)) as readonly string[]


### PR DESCRIPTION
## What

Unify the editor toolbar's highlight and font-colour presets so the two pickers stay consistent (plan A). Both preset lists are now derived from a single shared hue base instead of two independent hard-coded arrays.

## Why

`HIGHLIGHT_COLORS` and `TEXT_COLORS` in `Toolbar.tsx` were separate hard-coded arrays with no common source, so the highlight and text-colour popovers disagreed on hue order and colour family per column. There was no guarantee the two would stay in sync as either was edited.

## How

- New `packages/docs/src/editor/colorPalette.ts` defines one hue base, `PALETTE_HUES`, and derives both lists from it:
  - `TEXT_COLORS` = the saturated hues (readable as foreground ink).
  - `HIGHLIGHT_COLORS` = the same hue at the same index, tinted toward white via `toHighlightTint()` so dark text stays legible on the background.
- The Nth highlight swatch is now the light version of the Nth font colour: both pickers share count, hue order, and per-column colour family, while the foreground/background contrast difference is preserved by construction (highlights are always the lighter tint).
- `Toolbar.tsx` now imports the two lists from the shared module; the inline arrays are removed.

All values remain `#rrggbb`, so they round-trip losslessly through Yjs collaboration and the DOCX/Markdown exporters (`normalizeDocxColor`). Existing document highlight marks store their own literal hex and are untouched — no data migration.

## Tests

- New `colorPalette.test.ts` pins the derivation contract (same count, `TEXT_COLORS` = hue base, Nth highlight = light tint of Nth text, every highlight lighter than its font colour, lossless `#rrggbb`) plus `toHighlightTint` edge cases — so a future edit to `PALETTE_HUES` that breaks the invariant fails loudly rather than silently drifting.
- Updated `Toolbar.test.tsx` highlight-palette expectations to the derived values.
- `colorPalette.test.ts` + `Toolbar.test.tsx`: **58/58 pass**. `tsc` typecheck is clean for the touched files.

### Note on pre-existing repo state (not introduced by this change)

Verified against clean `origin/main` — the following fail identically before this branch and are unrelated to it:

- `EditorShell.test.tsx` (4 tests) — fails on baseline due to a `@douyinfe/semi-icons` ESM transform error.
- `tsc --noEmit` reports 2 errors in `dmworkbase/src/i18n/format.ts` and `members/sort.ts` — both untouched here.
- `build:standalone` fails on baseline with `MISSING_EXPORT` errors in the `dev/` standalone-harness stubs (`VoiceInputButton`, `buildDocLink`) — the docs package ships as a library consumed by `apps/web`, not built standalone in production.

Opening as **draft** for review.
