### PR TITLE
fix(docs): editor quickfixes — emoji popover, formula titles, toolbar overflow, font labels/order

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -898,3 +898,49 @@ describe('Toolbar — format painter (XIN-963)', () => {
     }
   })
 })
+
+// XIN-1048 #3: the inline and block formula popovers shared one MathControl and rendered an
+// identical body, so the two dialogs were indistinguishable once open. Each popover now carries a
+// kind-specific title (the existing mathInline / mathBlock i18n keys) at the top.
+describe('Toolbar — math popover kind title (XIN-1048 #3)', () => {
+  it('titles the inline-formula popover with the inline key', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.mathInline'))
+    const popover = document.querySelector('.octo-math-popover') as HTMLElement
+    expect(popover).toBeTruthy()
+    const title = popover.querySelector('.octo-math-popover-title')
+    expect(title?.textContent).toBe('docs.toolbar.mathInline')
+  })
+
+  it('titles the block-formula popover with the block key', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.mathBlock'))
+    const popover = document.querySelector('.octo-math-popover') as HTMLElement
+    expect(popover).toBeTruthy()
+    const title = popover.querySelector('.octo-math-popover-title')
+    expect(title?.textContent).toBe('docs.toolbar.mathBlock')
+  })
+
+  it('gives the inline and block popovers different titles', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.mathInline'))
+    const inlineTitle = document.querySelector('.octo-math-popover-title')?.textContent
+    fireEvent.click(titleBtn('docs.toolbar.mathInline')) // close
+    fireEvent.click(titleBtn('docs.toolbar.mathBlock'))
+    const blockTitle = document.querySelector('.octo-math-popover-title')?.textContent
+    expect(inlineTitle).not.toBe(blockTitle)
+  })
+})
+
+// XIN-1048 #7b: the font-family selector now sits BEFORE the font-size selector in the toolbar
+// (family → size), matching the requested control order. FONT_FAMILY_ENABLED defaults on in tests.
+describe('Toolbar — font family precedes font size (XIN-1048 #7b)', () => {
+  it('renders the font-family select before the font-size select in document order', () => {
+    const { container } = render(<Toolbar editor={editor!} />)
+    const family = container.querySelector('.octo-font-family') as HTMLElement
+    const size = container.querySelector('.octo-font-size') as HTMLElement
+    expect(family).toBeTruthy()
+    expect(size).toBeTruthy()
+    expect(family.compareDocumentPosition(size) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -1141,25 +1141,30 @@ function MathControl({ editor, kind }: { editor: Editor; kind: 'inline' | 'block
       />
       {open && (
         <span className="octo-color-popover octo-math-popover">
-          <input
-            className="octo-find-input"
-            autoFocus
-            value={latex}
-            placeholder={t('docs.toolbar.mathPlaceholder')}
-            onMouseDown={(e) => e.stopPropagation()}
-            onChange={(e) => setLatex(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                confirm()
-              } else if (e.key === 'Escape') {
-                e.preventDefault()
-                setOpen(false)
-                setLatex('')
-              }
-            }}
-          />
-          <Btn label={t('docs.toolbar.insert')} onClick={confirm} />
+          <span className="octo-math-popover-title">
+            {t(kind === 'inline' ? 'docs.toolbar.mathInline' : 'docs.toolbar.mathBlock')}
+          </span>
+          <span className="octo-math-popover-row">
+            <input
+              className="octo-find-input"
+              autoFocus
+              value={latex}
+              placeholder={t('docs.toolbar.mathPlaceholder')}
+              onMouseDown={(e) => e.stopPropagation()}
+              onChange={(e) => setLatex(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  confirm()
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  setOpen(false)
+                  setLatex('')
+                }
+              }}
+            />
+            <Btn label={t('docs.toolbar.insert')} onClick={confirm} />
+          </span>
         </span>
       )}
     </span>
@@ -1330,8 +1335,8 @@ export function Toolbar({ editor }: { editor: Editor }) {
       <Btn label={<IconStrike />} title={t('docs.toolbar.strike')} active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()} />
       <Btn label="x²" title={t('docs.toolbar.superscript')} active={editor.isActive('superscript')} onClick={() => editor.chain().focus().toggleSuperscript().run()} />
       <Btn label="x₂" title={t('docs.toolbar.subscript')} active={editor.isActive('subscript')} onClick={() => editor.chain().focus().toggleSubscript().run()} />
-      <FontSizeSelect editor={editor} />
       {FONT_FAMILY_ENABLED && <FontFamilySelect editor={editor} />}
+      <FontSizeSelect editor={editor} />
       <span className="octo-tb-sep" />
       <AlignControls editor={editor} />
       {LINE_SPACING_ENABLED && <LineHeightSelect editor={editor} />}

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -64,6 +64,11 @@
 .octo-doc-scroll {
   height: 100%;
   overflow-y: auto;
+  /* The document itself should never scroll horizontally — tables carry their own inner
+     horizontal scroll. Without this, overflow-y:auto promotes the other axis to `auto`,
+     which combined with the sticky toolbar's negative bleed margins turns this into a
+     silent horizontal scroll container and pushes the right-side toolbar buttons out of view. */
+  overflow-x: hidden;
   box-sizing: border-box;
   padding: 0 32px 24px;
 }
@@ -494,6 +499,24 @@
   text-align: center;
   font-size: 12px;
   color: var(--octo-muted, #8a919e);
+}
+
+/* Math insert popover (XIN-1048 #3): stack a kind-specific title above the LaTeX input +
+   insert button so inline vs block formula dialogs are visually distinguishable. */
+.octo-math-popover {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+.octo-math-popover-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--octo-muted, #8a919e);
+}
+.octo-math-popover-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .octo-editor-region {
@@ -2512,6 +2535,8 @@
 /* Emoji toolbar picker grid (v9). */
 .octo-emoji-popover {
   position: absolute;
+  top: 100%;
+  left: 0;
   z-index: 1000;
   margin-top: 6px;
   display: flex;

--- a/packages/docs/src/editor/styles.test.ts
+++ b/packages/docs/src/editor/styles.test.ts
@@ -34,3 +34,30 @@ describe("editor heading hierarchy styles", () => {
     expect(new Set(sizeTokens).size).toBe(6);
   });
 });
+
+/** Grab the declaration block of a top-level class rule by exact selector. */
+function classRule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  expect(match, `missing rule for ${selector}`).not.toBeNull();
+  return match?.[1] ?? "";
+}
+
+describe("emoji popover positioning (XIN-1048 #2)", () => {
+  it("anchors .octo-emoji-popover under its trigger with top:100% and left:0", () => {
+    const rule = classRule(".octo-emoji-popover");
+    expect(rule).toMatch(/position:\s*absolute/);
+    expect(rule).toMatch(/top:\s*100%/);
+    expect(rule).toMatch(/left:\s*0/);
+  });
+});
+
+describe("document scroll container overflow (XIN-1048 #5)", () => {
+  it("pins .octo-doc-scroll to vertical-only scrolling (overflow-x:hidden)", () => {
+    const rule = classRule(".octo-doc-scroll");
+    expect(rule).toMatch(/overflow-y:\s*auto/);
+    // Without overflow-x:hidden the sticky toolbar bleeds into a document-level horizontal
+    // scroll and the right-side buttons drift out of view.
+    expect(rule).toMatch(/overflow-x:\s*hidden/);
+  });
+});

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -99,7 +99,7 @@
     "fontSize": "Font size",
     "fontSizeDefault": "Default",
     "fontFamily": "Font",
-    "fontFamilyDefault": "Default",
+    "fontFamilyDefault": "Default font",
     "font": {
       "yahei": "Microsoft YaHei",
       "simsun": "SimSun",

--- a/packages/docs/src/i18n/i18n.test.ts
+++ b/packages/docs/src/i18n/i18n.test.ts
@@ -35,6 +35,19 @@ describe('docs i18n', () => {
       expect(Object.prototype.hasOwnProperty.call(zhCN, g), `zh-CN missing group ${g}`).toBe(true)
     }
   })
+
+  // XIN-1048 #7a: the font-family default option read a bare "默认"/"Default" — the same string as
+  // the font-SIZE default — so users could not tell which "默认" belonged to which control. The
+  // font-family default is now explicitly labelled, and the font-size default is left untouched.
+  it('labels the font-family default distinctly from the font-size default', () => {
+    expect(zhCN.toolbar.fontFamilyDefault).toBe('默认字体')
+    expect(enUS.toolbar.fontFamilyDefault).toBe('Default font')
+    // The size default must NOT have been swept up in the change.
+    expect(zhCN.toolbar.fontSizeDefault).toBe('默认')
+    expect(enUS.toolbar.fontSizeDefault).toBe('Default')
+    expect(zhCN.toolbar.fontFamilyDefault).not.toBe(zhCN.toolbar.fontSizeDefault)
+    expect(enUS.toolbar.fontFamilyDefault).not.toBe(enUS.toolbar.fontSizeDefault)
+  })
 })
 
 describe('DocsModule i18n registration', () => {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -99,7 +99,7 @@
     "fontSize": "字号",
     "fontSizeDefault": "默认",
     "fontFamily": "字体",
-    "fontFamilyDefault": "默认",
+    "fontFamilyDefault": "默认字体",
     "font": {
       "yahei": "微软雅黑",
       "simsun": "宋体",


### PR DESCRIPTION
## Summary

A batch of five low-risk, independently-located quickfixes for the `packages/docs` editor (Tiptap). Each change is scoped to a single located spot; no unrelated refactoring.

### 1. Emoji picker popover overlapped its trigger
`.octo-emoji-popover` was `position: absolute` but had no `top`/`left`, so it floated over the button with only a `margin-top`. Added `top: 100%; left: 0;` to align it with the sibling `.octo-color-popover` pattern, so the panel now opens directly below its trigger.

### 2. Inline vs block formula popups were indistinguishable
The inline and block formula controls share one `MathControl` and rendered an identical body — only the trigger button differed. Each popover now shows a kind-specific title at the top, reusing the existing `docs.toolbar.mathInline` / `docs.toolbar.mathBlock` i18n strings (no new copy). The input + insert button are grouped in a row beneath the title.

### 3. Toolbar right-side buttons drifted out of view (horizontal scroll)
`.octo-doc-scroll` was `overflow-y: auto`, which promotes the other axis to `auto`; combined with the sticky toolbar's negative bleed margins this turned the document into a silent horizontal scroll container and pushed the right-side toolbar buttons off-screen when the vertical scrollbar appeared. Added `overflow-x: hidden` — tables keep their own inner horizontal scroll, so nothing legitimate needs document-level horizontal scrolling.

### 4. Font-family default label collided with font-size default
Both the font-family and font-size default options read a bare `默认` / `Default`, so users couldn't tell which control's default was which. The font-family default is now `默认字体` / `Default font`; the font-size default is untouched.

### 5. Font-family selector moved before font-size
Reordered the two toolbar selectors so the font-family selector precedes the font-size selector (family → size). The `FONT_FAMILY_ENABLED` feature-flag gate is preserved.

## Tests
- `Toolbar.test.tsx`: math popover carries the correct kind-specific title (inline / block / distinct); font-family select renders before font-size in document order.
- `styles.test.ts`: `.octo-emoji-popover` has `top:100%`/`left:0`; `.octo-doc-scroll` has `overflow-x:hidden`.
- `i18n.test.ts`: font-family default is distinct from the font-size default in both locales.

All new tests pass; `packages/docs` suite green (the 4 pre-existing `DocsHome` WebSocket-env flakes are unrelated and identical on `main`), typecheck introduces no new errors, and the `apps/web` production build passes.

Relates to internal tickets XIN-1048 (this batch) and XIN-1035 / XIN-1037 (root-cause analysis).

> Draft: opened for review only — do not mark ready until QA sign-off.
