### PR TITLE
feat(docs): table row/column controls as a right-click context menu

### DIFF
--- a/packages/docs/src/editor/EditorShell.badge.test.tsx
+++ b/packages/docs/src/editor/EditorShell.badge.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../collab/useCollabEditor.ts', () => ({
 // Stub presentational children that take the live editor/provider — not under test here.
 vi.mock('@tiptap/react', () => ({ EditorContent: () => null }))
 vi.mock('./Toolbar.tsx', () => ({ Toolbar: () => null, EditorBubbleMenu: () => null }))
-vi.mock('./TableControls.tsx', () => ({ TableBubbleMenu: () => null }))
+vi.mock('./TableControls.tsx', () => ({ TableContextMenu: () => null }))
 vi.mock('./Outline.tsx', () => ({ Outline: () => null }))
 vi.mock('./StatusBar.tsx', () => ({ StatusBar: () => null }))
 vi.mock('./PresenceBar.tsx', () => ({ PresenceBar: () => null }))

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../export/markdown.ts', () => ({
 // Stub the presentational children that take the live editor/provider — they are not under test.
 vi.mock('@tiptap/react', () => ({ EditorContent: () => null }))
 vi.mock('./Toolbar.tsx', () => ({ Toolbar: () => null, EditorBubbleMenu: () => null }))
-vi.mock('./TableControls.tsx', () => ({ TableBubbleMenu: () => null }))
+vi.mock('./TableControls.tsx', () => ({ TableContextMenu: () => null }))
 vi.mock('./Outline.tsx', () => ({ Outline: () => null }))
 vi.mock('./StatusBar.tsx', () => ({ StatusBar: () => null }))
 vi.mock('./PresenceBar.tsx', () => ({ PresenceBar: () => null }))

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -3,7 +3,7 @@ import { useCollabEditor } from '../collab/useCollabEditor.ts'
 import type { CollabEditorOptions } from '../collab/createCollabEditor.ts'
 import { canManage } from '../auth/roles.ts'
 import { Toolbar, EditorBubbleMenu } from './Toolbar.tsx'
-import { TableBubbleMenu } from './TableControls.tsx'
+import { TableContextMenu } from './TableControls.tsx'
 import { Outline } from './Outline.tsx'
 import { StatusBar } from './StatusBar.tsx'
 import { PresenceBar } from './PresenceBar.tsx'
@@ -731,7 +731,7 @@ export function EditorShell(props: EditorShellProps) {
 
           <div className="octo-editor-region">
             <EditorBubbleMenu editor={editor} />
-            <TableBubbleMenu editor={editor} />
+            <TableContextMenu editor={editor} />
             <CommentBubble editor={editor} onCreate={comments.createRoot} />
             <Outline editor={editor} />
             <div className="octo-editor-main">

--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -1,21 +1,27 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { render, cleanup, screen, fireEvent } from '@testing-library/react'
+import { render, cleanup, screen, fireEvent, createEvent } from '@testing-library/react'
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
-import { CellSelection } from '@tiptap/pm/tables'
-import { TextSelection } from '@tiptap/pm/state'
-import { shouldShowTableBubble, TableGridPicker, TableBubbleMenu, clampToolbarAnchorRect } from './TableControls.tsx'
+import {
+  TableGridPicker,
+  TableContextMenu,
+  moveSelectionIntoCell,
+  clampMenuPosition,
+} from './TableControls.tsx'
 
-// #595 — table add/delete row/column UI. The critical acceptance point is that the controls work on
-// tables that ALREADY EXIST in a document (parsed from stored HTML), not only freshly inserted
-// ones. These tests seed the editor from HTML so every assertion runs against a "historical" table.
+// XIN-1052 — table add/delete row/column UI moved from a floating bubble toolbar to a right-click
+// context menu. The critical acceptance points are that the menu opens only on a right-click INSIDE
+// a table cell, the native browser menu is suppressed there, the selection is first moved into the
+// right-clicked cell so the position-relative commands act on it, and the same commands work on
+// tables that ALREADY EXIST in a document (parsed from stored HTML), not only freshly inserted ones.
 
-function tableEditor(content: string) {
+function tableEditor(content: string, element?: HTMLElement) {
   return new Editor({
+    element,
     extensions: [
       StarterKit.configure({ undoRedo: false }),
       Table.configure({ resizable: false }),
@@ -63,43 +69,30 @@ function tableDims(e: Editor): { rows: number; cols: number } | null {
 
 afterEach(() => cleanup())
 
-describe('shouldShowTableBubble — visibility gate (covers historical tables)', () => {
-  it('is true when the caret sits inside a cell of a pre-existing table', () => {
+describe('moveSelectionIntoCell — gate + selection move for the right-clicked cell', () => {
+  it('moves the selection into a pre-existing table cell and reports the caret is in a table', () => {
     const e = tableEditor(HISTORICAL_DOC)
-    e.commands.setTextSelection(firstCellTextPos(e))
-    expect(e.isActive('table')).toBe(true)
-    expect(shouldShowTableBubble(e)).toBe(true)
-    e.destroy()
-  })
-
-  it('is false when the caret is outside any table', () => {
-    const e = tableEditor(HISTORICAL_DOC)
-    e.commands.setTextSelection(2) // inside the leading "before" paragraph
+    e.commands.setTextSelection(2) // start with the caret in the leading "before" paragraph
     expect(e.isActive('table')).toBe(false)
-    expect(shouldShowTableBubble(e)).toBe(false)
+
+    const inTable = moveSelectionIntoCell(e, firstCellTextPos(e))
+    expect(inTable).toBe(true)
+    expect(e.isActive('table')).toBe(true)
     e.destroy()
   })
 
-  it('is true for a whole-cell (CellSelection) selection', () => {
+  it('reports false (do not open a table menu) when the pointer is outside any table', () => {
     const e = tableEditor(HISTORICAL_DOC)
-    const cellPos = firstCellTextPos(e) - 2 // position just before the first cell node
-    const { tr } = e.state
-    const $cell = e.state.doc.resolve(cellPos)
-    tr.setSelection(new CellSelection($cell))
-    e.view.dispatch(tr)
-    expect(e.state.selection).toBeInstanceOf(CellSelection)
-    expect(shouldShowTableBubble(e)).toBe(true)
+    const paragraphPos = 2 // inside the leading "before" paragraph
+    expect(moveSelectionIntoCell(e, paragraphPos)).toBe(false)
+    expect(e.isActive('table')).toBe(false)
     e.destroy()
   })
 
-  it('is false while a plain text run inside a cell is selected (defers to the formatting bubble)', () => {
+  it('is safe against out-of-range positions', () => {
     const e = tableEditor(HISTORICAL_DOC)
-    const pos = firstCellTextPos(e)
-    const { tr } = e.state
-    tr.setSelection(TextSelection.create(tr.doc, pos, pos + 1)) // select the "a" character
-    e.view.dispatch(tr)
-    expect(e.state.selection.empty).toBe(false)
-    expect(shouldShowTableBubble(e)).toBe(false)
+    expect(() => moveSelectionIntoCell(e, 1e9)).not.toThrow()
+    expect(() => moveSelectionIntoCell(e, -5)).not.toThrow()
     e.destroy()
   })
 })
@@ -135,101 +128,114 @@ describe('table commands operate on a pre-existing (historical) table', () => {
   })
 })
 
-describe('TableBubbleMenu — does not block the column-resize hot zone (#595 C1)', () => {
-  // The toolbar floats over the table while the caret is in a cell. Its floating wrapper must stay
-  // transparent to pointer events so the column-resize plugin (which listens for hover/mousedown on
-  // the editor DOM) still sees the column border; only the buttons may re-capture the pointer.
-  it('marks the floating wrapper pointer-events exempt while keeping the buttons interactive', () => {
-    // jsdom has no layout, so give Range the rect-query methods tiptap's positioning needs; the
-    // returned rect is all-zero, which is fine — we only care about the DOM the menu renders, not
-    // where it lands. Without this the BubbleMenu never attaches its floating wrapper.
-    const zeroRect = { top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0, x: 0, y: 0 }
-    type RangeRectFns = { getClientRects?: () => unknown; getBoundingClientRect?: () => unknown }
-    const rangeProto = Range.prototype as unknown as RangeRectFns
-    if (!rangeProto.getClientRects) rangeProto.getClientRects = () => [zeroRect]
-    if (!rangeProto.getBoundingClientRect) rangeProto.getBoundingClientRect = () => zeroRect
-
+describe('TableContextMenu — right-click inside a cell opens the menu (XIN-1052)', () => {
+  it('renders nothing until a right-click lands inside a table cell', () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
-    const e = new Editor({
-      element: host,
-      extensions: [
-        StarterKit.configure({ undoRedo: false }),
-        Table.configure({ resizable: false }),
-        TableRow,
-        TableHeader,
-        TableCell,
-      ],
-      content: HISTORICAL_DOC,
-    })
-    // Caret inside a cell → the toolbar shows and attaches its floating wrapper to the DOM.
-    e.commands.setTextSelection(firstCellTextPos(e))
-    render(<TableBubbleMenu editor={e} />)
+    const e = tableEditor(HISTORICAL_DOC, host)
+    render(<TableContextMenu editor={e} />)
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    e.destroy()
+    host.remove()
+  })
 
-    const portal = document.querySelector('.octo-table-bubble-portal')
-    expect(portal).toBeTruthy()
-    // Every action button lives under the exempt wrapper and opts back into pointer events.
-    const buttons = portal!.querySelectorAll('button.octo-tb-btn')
-    expect(buttons.length).toBeGreaterThan(0)
+  it('opens at the pointer, suppresses the native menu, and exposes every table command', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host)
+    // jsdom has no layout, so posAtCoords can't map real client coords to a doc position. Point it
+    // at the first cell so the handler behaves as it would when the user right-clicks that cell.
+    e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    const evt = createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 })
+    fireEvent(e.view.dom, evt)
+
+    // Native context menu is suppressed only when the click is inside a table.
+    expect(evt.defaultPrevented).toBe(true)
+    const menu = document.querySelector('.octo-table-context-menu') as HTMLElement | null
+    expect(menu).toBeTruthy()
+    // Selection was moved into the right-clicked cell so position-relative commands act on it.
+    expect(e.isActive('table')).toBe(true)
+    // All seven table commands are present (add row before/after, delete row, add column
+    // before/after, delete column, delete table).
+    const buttons = menu!.querySelectorAll('button.octo-tb-btn')
+    expect(buttons.length).toBe(7)
+    e.destroy()
+    host.remove()
+  })
+
+  it('leaves the native menu alone when the right-click is outside any table', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host)
+    // Point posAtCoords at the trailing paragraph, i.e. not inside the table.
+    e.view.posAtCoords = () => ({ pos: e.state.doc.content.size - 1, inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    const evt = createEvent.contextMenu(e.view.dom, { clientX: 10, clientY: 10 })
+    fireEvent(e.view.dom, evt)
+
+    expect(evt.defaultPrevented).toBe(false)
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    e.destroy()
+    host.remove()
+  })
+
+  it('runs a command and closes when a menu item is clicked', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host)
+    e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    fireEvent(e.view.dom, createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 }))
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 2 })
+
+    // "Add row after" — reuse the accessible name from the shared i18n keys.
+    fireEvent.click(screen.getByTitle('docs.table.addRowAfter'))
+    expect(tableDims(e)).toEqual({ rows: 3, cols: 2 })
+    // Menu closes after the action.
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    e.destroy()
+    host.remove()
+  })
+
+  it('closes on Escape', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host)
+    e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    fireEvent(e.view.dom, createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 }))
+    expect(document.querySelector('.octo-table-context-menu')).toBeTruthy()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
     e.destroy()
     host.remove()
   })
 })
 
-describe('clampToolbarAnchorRect — keep the toolbar clear of the fixed toolbar (#625 off-screen + #716)', () => {
-  const VIEWPORT = { width: 1200, height: 1000 }
-  // Bottom edge of the fixed editor toolbar in viewport coords, as tableReferenceElement measures it.
-  const TOOLBAR_BOTTOM = 64
+describe('clampMenuPosition — keep the context menu inside the viewport', () => {
+  const VIEWPORT = { width: 1200, height: 800 }
+  const MENU = { width: 180, height: 220 }
 
-  it('leaves a fully-visible table at its real top edge (no TC-P0-001 regression)', () => {
-    // A normal table sitting mid-viewport, well below the fixed toolbar: the band stays a
-    // zero-height anchor at the real top so the toolbar still floats above the table as before.
-    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT, TOOLBAR_BOTTOM)
-    expect(r.top).toBe(300)
-    expect(r.height).toBe(0)
-    expect(r.left).toBe(200)
-    expect(r.right).toBe(900)
+  it('opens at the pointer when there is room in both directions', () => {
+    expect(clampMenuPosition({ x: 300, y: 200 }, MENU, VIEWPORT)).toEqual({ left: 300, top: 200 })
   })
 
-  it('anchors a long table scrolled past the top to the toolbar strip so it flips below (XIN-939)', () => {
-    // The XIN-939 case: 34-row table scrolled so its top is far above the viewport and its bottom
-    // is below it. The band becomes the toolbar strip [0 .. toolbarBottom]; placement:'top' then
-    // overflows the viewport top and Floating-UI flips the controls to just below the fixed toolbar
-    // (top === 0 is what forces that flip; bottom === toolbarBottom is where they land).
-    const r = clampToolbarAnchorRect({ top: -1248, bottom: 1052, left: 200, right: 900 }, VIEWPORT, TOOLBAR_BOTTOM)
-    expect(r.top).toBe(0)
-    expect(r.bottom).toBe(TOOLBAR_BOTTOM)
-    expect(r.left).toBe(200)
-    expect(r.right).toBe(900)
+  it('shifts left/up so the menu never overflows the right/bottom edges', () => {
+    const { left, top } = clampMenuPosition({ x: 1190, y: 790 }, MENU, VIEWPORT)
+    expect(left).toBe(VIEWPORT.width - MENU.width)
+    expect(top).toBe(VIEWPORT.height - MENU.height)
   })
 
-  it('anchors a table jammed under the fixed toolbar to the strip so it flips below it (#716)', () => {
-    // The #716 follow-up: a table at the very top of the doc sits right beneath a tall fixed
-    // toolbar (bottom 180). Floating above would land the controls behind the fixed toolbar; the
-    // strip band flips them to just below it instead.
-    const tallToolbar = 180
-    const r = clampToolbarAnchorRect({ top: 185, bottom: 405, left: 200, right: 900 }, VIEWPORT, tallToolbar)
-    expect(r.top).toBe(0)
-    expect(r.bottom).toBe(tallToolbar)
-  })
-
-  it('never drops the band below the viewport bottom', () => {
-    const r = clampToolbarAnchorRect({ top: 5000, bottom: 6000, left: 100, right: 400 }, VIEWPORT, TOOLBAR_BOTTOM)
-    expect(r.top).toBe(VIEWPORT.height - 8)
-    expect(r.top).toBeLessThan(VIEWPORT.height)
-  })
-
-  it('clamps the horizontal extent of a wide / off-screen table into the viewport', () => {
-    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: -500, right: 3000 }, VIEWPORT, TOOLBAR_BOTTOM)
-    expect(r.left).toBe(0)
-    expect(r.right).toBe(VIEWPORT.width)
-    expect(r.width).toBe(VIEWPORT.width)
-  })
-
-  it('with no fixed toolbar (toolbarBottom defaults to 0) keeps a fully-visible table at its top', () => {
-    const r = clampToolbarAnchorRect({ top: 300, bottom: 520, left: 200, right: 900 }, VIEWPORT)
-    expect(r.top).toBe(300)
-    expect(r.height).toBe(0)
+  it('never goes negative', () => {
+    const { left, top } = clampMenuPosition({ x: -50, y: -50 }, MENU, VIEWPORT)
+    expect(left).toBe(0)
+    expect(top).toBe(0)
   })
 })
 

--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -7,6 +7,7 @@ import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
 import { CellSelection } from '@tiptap/pm/tables'
+import { TextSelection } from '@tiptap/pm/state'
 import {
   TableGridPicker,
   TableContextMenu,
@@ -320,6 +321,141 @@ describe('TableContextMenu — right-click inside a cell opens the menu (XIN-105
 
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    e.destroy()
+    host.remove()
+  })
+})
+
+// Multi-cell delete through the REAL right-click flow, reproducing the behaviour a browser (not
+// jsdom) produces. When a user frames a multi-column/row CellSelection and then right-clicks a cell
+// inside it, the browser processes the native right-click AFTER our contextmenu handler returns: it
+// moves the caret into the clicked cell and fires `selectionchange`, which ProseMirror syncs back
+// into a single-cell TextSelection — collapsing the framed rectangle before the user can click a
+// menu item. The previous unit tests called moveSelectionIntoCell directly and asserted on the
+// still-intact selection, so they never exercised this collapse and stayed green while the real
+// browser deleted only the one clicked column ("select N, only 1 goes"). These tests drive the full
+// contextmenu -> collapse -> menu-click path and assert the whole framed range is removed.
+describe('TableContextMenu — multi-cell delete survives the browser right-click selection collapse', () => {
+  // 2 rows × 4 columns, so deleting a 2- or 3-column selection still leaves a table behind.
+  const WIDE_DOC =
+    '<table><tbody>' +
+    '<tr><td>a</td><td>b</td><td>c</td><td>d</td></tr>' +
+    '<tr><td>e</td><td>f</td><td>g</td><td>h</td></tr>' +
+    '</tbody></table>'
+  // 4 rows × 2 columns, for the delete-row counterpart.
+  const TALL_DOC =
+    '<table><tbody>' +
+    '<tr><td>a</td><td>b</td></tr>' +
+    '<tr><td>c</td><td>d</td></tr>' +
+    '<tr><td>e</td><td>f</td></tr>' +
+    '<tr><td>g</td><td>h</td></tr>' +
+    '</tbody></table>'
+
+  /**
+   * Open the context menu over a framed CellSelection (anchor..head cells), then reproduce the
+   * browser collapsing that selection to the single clicked cell before the menu item is clicked.
+   * Returns the editor mounted in a live DOM host, ready for a menu-item click.
+   */
+  function openMenuOverSelectionThenCollapse(
+    doc: string,
+    anchorCellIdx: number,
+    headCellIdx: number,
+    clickedCellIdx: number,
+  ): { e: Editor; host: HTMLElement } {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(doc, host)
+    const cells = cellPositions(e)
+    e.view.dispatch(
+      e.state.tr.setSelection(CellSelection.create(e.state.doc, cells[anchorCellIdx], cells[headCellIdx])),
+    )
+    expect(e.state.selection instanceof CellSelection).toBe(true)
+
+    // Right-click a text position inside a cell that is part of the framed selection.
+    const clickPos = cells[clickedCellIdx] + 2
+    e.view.posAtCoords = () => ({ pos: clickPos, inside: -1 })
+    render(<TableContextMenu editor={e} />)
+    fireEvent(e.view.dom, createEvent.contextMenu(e.view.dom, { clientX: 60, clientY: 40 }))
+    expect(document.querySelector('.octo-table-context-menu')).toBeTruthy()
+
+    // The browser now moves the caret into the clicked cell and ProseMirror collapses the
+    // CellSelection to a single-cell TextSelection — exactly what jsdom never does on its own.
+    e.view.dispatch(e.state.tr.setSelection(TextSelection.create(e.state.doc, clickPos)))
+    expect(e.state.selection instanceof CellSelection).toBe(false)
+
+    return { e, host }
+  }
+
+  it('deletes both framed columns (select 2 of 4 -> 2 remain), not just the clicked one', () => {
+    // Columns 1 and 2 = cells b(1), c(2), f(5), g(6). Right-click cell c, inside the selection.
+    const { e, host } = openMenuOverSelectionThenCollapse(WIDE_DOC, 1, 6, 2)
+    fireEvent.click(screen.getByTitle('docs.table.deleteColumn'))
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 2 })
+    e.destroy()
+    host.remove()
+  })
+
+  it('deletes N framed columns (select 3 of 4 -> 1 remains)', () => {
+    // Columns 0..2 = cells a(0), b(1), c(2), e(4), f(5), g(6). Right-click cell b, inside it.
+    const { e, host } = openMenuOverSelectionThenCollapse(WIDE_DOC, 0, 6, 1)
+    fireEvent.click(screen.getByTitle('docs.table.deleteColumn'))
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 1 })
+    e.destroy()
+    host.remove()
+  })
+
+  it('deletes both framed rows (select 2 of 4 -> 2 remain) via delete row', () => {
+    // Rows 1 and 2 = cells c(2), d(3), e(4), f(5). Right-click cell d, inside the selection.
+    const { e, host } = openMenuOverSelectionThenCollapse(TALL_DOC, 2, 5, 3)
+    fireEvent.click(screen.getByTitle('docs.table.deleteRow'))
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 2 })
+    e.destroy()
+    host.remove()
+  })
+
+  it('still collapses to the single clicked cell when the right-click lands outside the framed selection', () => {
+    // Complement: a single-cell right-click must NOT be treated as a range. Frame columns 0-1, then
+    // right-click cell d (column 3), outside the selection: only that one column is removed.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(WIDE_DOC, host)
+    const cells = cellPositions(e)
+    e.view.dispatch(e.state.tr.setSelection(CellSelection.create(e.state.doc, cells[0], cells[5])))
+    const clickPos = cells[3] + 2 // cell d, column 3, outside the selection
+    e.view.posAtCoords = () => ({ pos: clickPos, inside: -1 })
+    render(<TableContextMenu editor={e} />)
+    fireEvent(e.view.dom, createEvent.contextMenu(e.view.dom, { clientX: 60, clientY: 40 }))
+    e.view.dispatch(e.state.tr.setSelection(TextSelection.create(e.state.doc, clickPos)))
+
+    fireEvent.click(screen.getByTitle('docs.table.deleteColumn'))
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 3 })
+    e.destroy()
+    host.remove()
+  })
+})
+
+describe('TableContextMenu — read-only editor never mutates a table', () => {
+  it('right-clicking a table cell in a read-only editor leaves the table unchanged (native menu passes through)', () => {
+    // Runnable read-only pass-through evidence: on a reader (editable === false) the handler must
+    // bail before touching the selection or opening the menu, so no table command can ever run and
+    // the document is untouched. Complements the "native menu intact" assertion above with a direct
+    // mutation check.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host, false)
+    expect(e.isEditable).toBe(false)
+    const before = e.getHTML()
+    e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    const evt = createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 })
+    fireEvent(e.view.dom, evt)
+
+    // No custom menu, native menu left intact, and the table is byte-for-byte unchanged.
+    expect(evt.defaultPrevented).toBe(false)
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 2 })
+    expect(e.getHTML()).toBe(before)
     e.destroy()
     host.remove()
   })

--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -6,6 +6,7 @@ import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
+import { CellSelection } from '@tiptap/pm/tables'
 import {
   TableGridPicker,
   TableContextMenu,
@@ -19,9 +20,10 @@ import {
 // right-clicked cell so the position-relative commands act on it, and the same commands work on
 // tables that ALREADY EXIST in a document (parsed from stored HTML), not only freshly inserted ones.
 
-function tableEditor(content: string, element?: HTMLElement) {
+function tableEditor(content: string, element?: HTMLElement, editable = true) {
   return new Editor({
     element,
+    editable,
     extensions: [
       StarterKit.configure({ undoRedo: false }),
       Table.configure({ resizable: false }),
@@ -31,6 +33,25 @@ function tableEditor(content: string, element?: HTMLElement) {
     ],
     content,
   })
+}
+
+// A 2-row × 3-column table, used for the multi-column CellSelection regression so deleting the two
+// selected columns still leaves one column behind (a 2×2 table would collapse entirely).
+const MULTI_COL_DOC =
+  '<table><tbody>' +
+  '<tr><td>a</td><td>b</td><td>c</td></tr>' +
+  '<tr><td>d</td><td>e</td><td>f</td></tr>' +
+  '</tbody></table>'
+
+/** Positions (pointing AT the cell node, i.e. the value forEachCell / $pos.before report) of every
+ *  table cell in document order. */
+function cellPositions(e: Editor): number[] {
+  const positions: number[] = []
+  e.state.doc.descendants((node, p) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') positions.push(p)
+    return true
+  })
+  return positions
 }
 
 // A 2-row × 2-column table sitting between two paragraphs, as it would arrive from stored content.
@@ -116,6 +137,49 @@ describe('moveSelectionIntoCell — gate + selection move for the right-clicked 
     expect(() => moveSelectionIntoCell(e, -5)).not.toThrow()
     e.destroy()
   })
+
+  it('keeps a multi-cell CellSelection when the right-click lands inside it, so delete-column removes every selected column', () => {
+    // Regression (P1): a user framed a multi-column CellSelection then right-clicked a cell already
+    // inside it. moveSelectionIntoCell used to collapse the selection to that single cell, so
+    // "delete column" only removed the clicked column instead of the whole multi-column selection.
+    const e = tableEditor(MULTI_COL_DOC)
+    const cells = cellPositions(e) // [a, b, c, d, e, f] as positions pointing at each cell
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 3 })
+
+    // Select columns 0 and 1 (cells a,b,d,e): anchor at cell a (0,0), head at cell e (1,1).
+    const sel = CellSelection.create(e.state.doc, cells[0], cells[4])
+    e.view.dispatch(e.state.tr.setSelection(sel))
+    expect(e.state.selection instanceof CellSelection).toBe(true)
+
+    // Right-click a text position inside cell "b" — which is inside the current selection.
+    const insidePos = cells[1] + 2 // step into the cell, then into its paragraph's text
+    expect(moveSelectionIntoCell(e, insidePos)).toBe(true)
+
+    // Selection is preserved (not collapsed to the single clicked cell)...
+    expect(e.state.selection instanceof CellSelection).toBe(true)
+    // ...so delete-column removes BOTH selected columns, leaving the third behind.
+    e.chain().focus().deleteColumn().run()
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 1 })
+    e.destroy()
+  })
+
+  it('moves the selection when the right-click lands on a cell outside the current CellSelection', () => {
+    // The complement of the case above: right-clicking a cell that is NOT part of the multi-cell
+    // selection collapses to that cell, matching the single-cell behaviour authors expect.
+    const e = tableEditor(MULTI_COL_DOC)
+    const cells = cellPositions(e)
+    // Select columns 0 and 1 (cells a,b,d,e).
+    e.view.dispatch(e.state.tr.setSelection(CellSelection.create(e.state.doc, cells[0], cells[4])))
+
+    // Right-click cell "c" (column 2), outside the selection.
+    const outsidePos = cells[2] + 2
+    expect(moveSelectionIntoCell(e, outsidePos)).toBe(true)
+    // Selection collapsed to the clicked cell, so delete-column removes only that one column.
+    expect(e.state.selection instanceof CellSelection).toBe(false)
+    e.chain().focus().deleteColumn().run()
+    expect(tableDims(e)).toEqual({ rows: 2, cols: 2 })
+    e.destroy()
+  })
 })
 
 describe('table commands operate on a pre-existing (historical) table', () => {
@@ -195,6 +259,28 @@ describe('TableContextMenu — right-click inside a cell opens the menu (XIN-105
     render(<TableContextMenu editor={e} />)
 
     const evt = createEvent.contextMenu(e.view.dom, { clientX: 10, clientY: 10 })
+    fireEvent(e.view.dom, evt)
+
+    expect(evt.defaultPrevented).toBe(false)
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+    e.destroy()
+    host.remove()
+  })
+
+  it('leaves the native menu fully intact on a read-only editor, even inside a table cell', () => {
+    // Regression (P1): a reader (editable === false) right-clicking a table used to still get the
+    // native menu suppressed and the custom table menu opened, letting them "edit" a read-only doc.
+    // A read-only editor must pass the native browser menu through untouched — no preventDefault,
+    // no selection move, no custom menu.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = tableEditor(HISTORICAL_DOC, host, false)
+    expect(e.isEditable).toBe(false)
+    // Point posAtCoords at a real cell; the handler must bail on the isEditable gate before it runs.
+    e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+    render(<TableContextMenu editor={e} />)
+
+    const evt = createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 })
     fireEvent(e.view.dom, evt)
 
     expect(evt.defaultPrevented).toBe(false)

--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -89,6 +89,27 @@ describe('moveSelectionIntoCell — gate + selection move for the right-clicked 
     e.destroy()
   })
 
+  it('leaves an existing selection untouched when the pointer is outside any table', () => {
+    // Regression: a right-click on ordinary (non-table) text must be a complete no-op — it must
+    // NOT collapse the user's current selection, so the browser's native context menu / Copy keeps
+    // operating on the still-selected text. Previously the selection was moved before the
+    // isActive('table') gate, which collapsed any selection on every out-of-table right-click.
+    const e = tableEditor(HISTORICAL_DOC)
+    // Select a range inside the leading "before" paragraph (text occupies positions 1..7).
+    e.commands.setTextSelection({ from: 2, to: 5 })
+    expect(e.state.selection.empty).toBe(false)
+
+    const paragraphPos = 3 // right-click lands inside that same paragraph, outside the table
+    expect(moveSelectionIntoCell(e, paragraphPos)).toBe(false)
+
+    // Selection is preserved exactly — not collapsed, not moved.
+    expect(e.state.selection.from).toBe(2)
+    expect(e.state.selection.to).toBe(5)
+    expect(e.state.selection.empty).toBe(false)
+    expect(e.isActive('table')).toBe(false)
+    e.destroy()
+  })
+
   it('is safe against out-of-range positions', () => {
     const e = tableEditor(HISTORICAL_DOC)
     expect(() => moveSelectionIntoCell(e, 1e9)).not.toThrow()

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { TextSelection } from '@tiptap/pm/state'
+import { CellSelection } from '@tiptap/pm/tables'
 import type { Editor } from '@tiptap/core'
 import { t } from '../octoweb/index.ts'
 
@@ -117,24 +118,46 @@ function TbBtn({
  * on ordinary (non-table) text is a complete no-op: the selection is only moved when `pos` really
  * lands inside a table cell. That keeps a right-click outside a table from collapsing the user's
  * existing selection, so the browser's native context menu / Copy still act on the selected text.
+ *
+ * When a multi-cell {@link CellSelection} is already active and the right-clicked cell is one of the
+ * selected cells, the selection is left intact so a range operation (delete column / delete row)
+ * still spans every selected cell instead of collapsing to the single clicked one. The selection is
+ * only moved when the click lands on a cell OUTSIDE the current selection.
+ *
  * Returns whether the click was inside a table — the gate the caller uses to decide whether to open
  * a table menu (and suppress the native one) at all.
  */
 export function moveSelectionIntoCell(editor: Editor, pos: number): boolean {
-  const { doc } = editor.state
+  const { doc, selection } = editor.state
   const safe = Math.max(0, Math.min(pos, doc.content.size))
   const $pos = doc.resolve(safe)
 
   // Walk the resolved position's ancestors to see whether it sits inside a table, without touching
-  // the current selection. Mirrors editor.isActive('table') but for an arbitrary position.
+  // the current selection. Mirrors editor.isActive('table') but for an arbitrary position. Also
+  // capture the position of the enclosing cell so we can test CellSelection membership below.
   let inTable = false
+  let cellPos: number | null = null
   for (let depth = $pos.depth; depth > 0; depth--) {
-    if ($pos.node(depth).type.name === 'table') {
+    const name = $pos.node(depth).type.name
+    if (cellPos === null && (name === 'tableCell' || name === 'tableHeader')) {
+      cellPos = $pos.before(depth)
+    }
+    if (name === 'table') {
       inTable = true
       break
     }
   }
   if (!inTable) return false
+
+  // Preserve an existing multi-cell selection when the click lands inside it, so delete-column /
+  // delete-row keep acting on the whole selected range rather than collapsing to one cell.
+  if (selection instanceof CellSelection && cellPos !== null) {
+    let insideSelection = false
+    selection.forEachCell((_cell, p) => {
+      if (p === cellPos) insideSelection = true
+    })
+    if (insideSelection) return true
+  }
 
   editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($pos)))
   return true
@@ -174,6 +197,9 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
   useEffect(() => {
     const dom = editor.view.dom
     const onContextMenu = (e: MouseEvent) => {
+      // Read-only editors must never edit a table: leave the native browser menu fully intact —
+      // no preventDefault, no selection move, no custom menu. Table mutations are meaningless there.
+      if (!editor.isEditable) return
       const coords = editor.view.posAtCoords({ left: e.clientX, top: e.clientY })
       if (!coords) return
       if (!moveSelectionIntoCell(editor, coords.pos)) return

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -1,23 +1,22 @@
-// Table editing UI (#595).
+// Table editing UI (#595, right-click menu XIN-1052).
 //
 // Two pieces, both pure frontend on top of the already-loaded @tiptap/extension-table series
 // (schema unchanged):
 //
-//  1. TableBubbleMenu — a floating toolbar that appears whenever the caret sits inside ANY table
-//     cell (`editor.isActive('table')`), so it covers tables that already exist in a document, not
-//     just freshly inserted ones. It exposes add/delete row & column (+ delete table), wired to the
-//     Tiptap table commands that only look at the caret position, never at how the table was born.
+//  1. TableContextMenu — a right-click (contextmenu) menu that opens whenever the user right-clicks
+//     inside ANY table cell, so it covers tables that already exist in a document, not just freshly
+//     inserted ones. It exposes add/delete row & column (+ delete table), wired to the exact same
+//     Tiptap table commands as before — commands that only look at the caret position, never at how
+//     the table was born. Before opening, it moves the ProseMirror selection into the right-clicked
+//     cell (via posAtCoords) so the position-relative commands act on THAT cell, and it suppresses
+//     the native browser context menu only when the click lands inside a table.
 //
 //  2. TableGridPicker — replaces the old fixed 3×3 insert with a hover grid so the author picks the
 //     initial row/column count before inserting.
-//
-// A distinct pluginKey ('octoTableBubble') keeps this menu from clashing with the inline formatting
-// BubbleMenu and the comment BubbleMenu that share the same editor.
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
-import { BubbleMenu } from '@tiptap/react/menus'
-import { CellSelection } from '@tiptap/pm/tables'
+import { TextSelection } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/core'
 import { t } from '../octoweb/index.ts'
 
@@ -105,199 +104,161 @@ function TbBtn({
   )
 }
 
-// Vertical clearance (px) the floating toolbar needs to sit ABOVE a table without colliding with
-// the fixed editor toolbar: the ~32px control row plus the 8px placement offset, with margin. Used
-// only to decide whether the table sits far enough below the fixed `.octo-toolbar` for the toolbar
-// to keep floating above it, or whether it must instead drop BELOW the fixed toolbar.
-const TOOLBAR_CLEARANCE = 48
+/**
+ * Move the ProseMirror selection to `pos` and report whether the caret then sits inside a table.
+ *
+ * Called by {@link TableContextMenu} right before it opens: the user right-clicked at a screen
+ * point, `posAtCoords` mapped that to a document position, and this moves the selection there so the
+ * position-relative table commands (addRow / deleteColumn / …) act on the cell that was clicked
+ * rather than wherever the caret happened to be. `pos` is clamped into the document so an
+ * out-of-range value from `posAtCoords` can never throw. Returns `editor.isActive('table')` — the
+ * gate the caller uses to decide whether to open a table menu (and suppress the native one) at all.
+ */
+export function moveSelectionIntoCell(editor: Editor, pos: number): boolean {
+  const { doc, tr } = editor.state
+  const safe = Math.max(0, Math.min(pos, doc.content.size))
+  editor.view.dispatch(tr.setSelection(TextSelection.near(doc.resolve(safe))))
+  return editor.isActive('table')
+}
 
 /**
- * Clamp a table's rect into the visual viewport and collapse it to an anchor band, keyed to the
- * bottom of the fixed editor toolbar (`.octo-toolbar`), so the floating table toolbar never renders
- * behind — and gets its clicks swallowed by — that fixed toolbar (#625 off-screen fix + #716
- * follow-up). Pure core of {@link tableReferenceElement}, split out so it can be unit-tested
- * without a real layout.
- *
- * The toolbar anchors to the table's OUTER edge and floats above it with `placement: 'top'`. Two
- * boundaries have to hold at once:
- *
- *  - **Long table scrolled past the top (XIN-939 / #625).** `rect.top` is a large negative and the
- *    bottom is far below the viewport; Floating-UI's default `flip` would re-anchor to that
- *    off-screen bottom edge and push the controls below the viewport, unreachable.
- *  - **Table jammed under the fixed toolbar (#716 follow-up).** A table at the very top of the doc
- *    sits right beneath the fixed `.octo-toolbar`; floating the controls ABOVE it lands them in the
- *    band the fixed toolbar occupies, which is opaque and higher in the stack, so it covers the
- *    controls and intercepts their pointer events.
- *
- * Fix: when the table's top is far enough below the fixed toolbar (with {@link TOOLBAR_CLEARANCE}
- * room to float above), keep a zero-height band at the real top edge — the normal, fully-visible
- * case is untouched (no #625 / TC-P0-001 regression). Otherwise anchor to the toolbar strip
- * `[0 .. toolbarBottom]`: `placement: 'top'` then overflows the viewport top, Floating-UI's `flip`
- * drops the controls to BOTTOM, and they land just below the fixed toolbar in the clear — reachable
- * and never behind the fixed toolbar, for both the off-screen and top-of-doc cases.
- *
- * `toolbarBottom` is the fixed toolbar's bottom edge in viewport coordinates (0 when there is no
- * toolbar, e.g. a read-only view), clamped defensively into the viewport.
+ * Clamp the menu's top-left corner so a menu of the given size stays fully inside the viewport when
+ * opened at the pointer `point`. Right-clicks near the right / bottom edge would otherwise open a
+ * menu that overflows off-screen; shift it left / up just enough to fit, never past the top-left
+ * origin. Pure so it can be unit-tested without a real layout.
  */
-export function clampToolbarAnchorRect(
-  rect: { top: number; bottom: number; left: number; right: number },
+export function clampMenuPosition(
+  point: { x: number; y: number },
+  menu: { width: number; height: number },
   viewport: { width: number; height: number },
-  toolbarBottom = 0,
-): DOMRect {
-  const left = Math.max(0, Math.min(rect.left, viewport.width))
-  const right = Math.min(viewport.width, Math.max(rect.right, left))
-  const width = Math.max(0, right - left)
-  const safeTop = Math.max(0, Math.min(toolbarBottom, viewport.height - 8))
-  const build = (top: number, bottom: number): DOMRect =>
-    ({
-      x: left,
-      y: top,
-      left,
-      top,
-      right: left + width,
-      bottom,
-      width,
-      height: Math.max(0, bottom - top),
-      toJSON() {
-        return this
-      },
-    } as DOMRect)
-  // Table sits clear below the fixed toolbar with room for the controls to float above it: keep a
-  // zero-height band at the real top edge so the toolbar floats above the table exactly as before.
-  if (rect.top - TOOLBAR_CLEARANCE >= safeTop) {
-    const top = Math.min(rect.top, viewport.height - 8)
-    return build(top, top)
-  }
-  // Table jammed under / above the fixed toolbar (top-of-doc or scrolled off the top): anchor to
-  // the toolbar strip so `placement: 'top'` overflows the viewport top and flips to BOTTOM, landing
-  // the controls just below the fixed toolbar's bottom edge — clickable, never behind it.
-  return build(0, safeTop)
+): { left: number; top: number } {
+  const left = Math.max(0, Math.min(point.x, viewport.width - menu.width))
+  const top = Math.max(0, Math.min(point.y, viewport.height - menu.height))
+  return { left, top }
 }
 
 /**
- * Reference rect for the floating table toolbar (#625). Anchors to the OUTER edge of the table
- * (its scroll wrapper when present) rather than the caret's cell, so the toolbar — placed above
- * with `placement: 'top'` — floats in the block margin above the whole table instead of landing on
- * top of the text rows above the caret. The rect is clamped relative to the fixed editor toolbar
- * (see {@link clampToolbarAnchorRect}) so a long table scrolled past the top of the viewport keeps
- * the controls reachable and a table at the top of the doc keeps them clear of the fixed
- * `.octo-toolbar`. Returns a Floating-UI virtual element (computed lazily so scrolling/resizing
- * stays accurate), or null when the caret is not inside a table, in which case the BubbleMenu falls
- * back to its default cursor-based positioning.
+ * Right-click (contextmenu) table menu. Opens whenever the user right-clicks inside a table cell —
+ * which naturally covers tables that were already in the document, since it keys off the clicked
+ * position, not how the table was created. On open it moves the selection into the clicked cell (so
+ * the position-relative commands act on it) and suppresses the native browser menu; a right-click
+ * outside any table is left alone so the browser's own menu still works. Closes on outside-click /
+ * Escape, and after any command runs.
  */
-function tableReferenceElement(editor: Editor): { getBoundingClientRect: () => DOMRect; getClientRects: () => DOMRect[] } | null {
-  const { $from } = editor.state.selection
-  for (let depth = $from.depth; depth > 0; depth--) {
-    if ($from.node(depth).type.name === 'table') {
-      const dom = editor.view.nodeDOM($from.before(depth))
-      if (dom instanceof HTMLElement) {
-        // Prefer the ProseMirror `.tableWrapper` scroll box so a horizontally scrolled wide table
-        // still anchors to the visible table region.
-        const anchor = (dom.closest('.tableWrapper') as HTMLElement | null) ?? dom
-        // Bottom edge of the fixed editor toolbar, measured live so a taller toolbar (e.g. the find
-        // bar expands `.octo-toolbar-wrap`) is always accounted for. Scoped to this editor's shell
-        // so an unrelated toolbar elsewhere on the page is never picked up.
-        const shell = (editor.view.dom.closest('.octo-doc--editor') as HTMLElement | null) ?? undefined
-        const toolbarBottom = () => {
-          const toolbarEl = (shell ?? document).querySelector('.octo-toolbar') as HTMLElement | null
-          const fixed = (toolbarEl?.closest('.octo-toolbar-wrap') as HTMLElement | null) ?? toolbarEl
-          return fixed ? fixed.getBoundingClientRect().bottom : 0
-        }
-        const band = () =>
-          clampToolbarAnchorRect(
-            anchor.getBoundingClientRect(),
-            { width: window.innerWidth, height: window.innerHeight },
-            toolbarBottom(),
-          )
-        return {
-          getBoundingClientRect: band,
-          getClientRects: () => [band()],
-        }
-      }
+export function TableContextMenu({ editor }: { editor: Editor }) {
+  // Viewport-coord anchor point where the user right-clicked; null while the menu is closed.
+  const [point, setPoint] = useState<{ x: number; y: number } | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Attach the contextmenu listener to this editor's DOM. Right-click inside a cell opens the menu
+  // at the pointer and preventDefault()s the native menu; anywhere else is left untouched.
+  useEffect(() => {
+    const dom = editor.view.dom
+    const onContextMenu = (e: MouseEvent) => {
+      const coords = editor.view.posAtCoords({ left: e.clientX, top: e.clientY })
+      if (!coords) return
+      if (!moveSelectionIntoCell(editor, coords.pos)) return
+      e.preventDefault()
+      setPoint({ x: e.clientX, y: e.clientY })
     }
+    dom.addEventListener('contextmenu', onContextMenu)
+    return () => dom.removeEventListener('contextmenu', onContextMenu)
+  }, [editor])
+
+  // Close on outside-click / Escape, mirroring TableGridPicker.
+  useEffect(() => {
+    if (!point) return
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setPoint(null)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPoint(null)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [point])
+
+  // Once the menu has real dimensions, nudge it back inside the viewport if the pointer was near an
+  // edge. jsdom reports a zero rect (no layout), so this is a harmless no-op in tests.
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    if (!point || !el) return
+    const rect = el.getBoundingClientRect()
+    const { left, top } = clampMenuPosition(
+      point,
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight },
+    )
+    el.style.left = `${left}px`
+    el.style.top = `${top}px`
+  }, [point])
+
+  if (!point) return null
+
+  // Run a table command then close. The selection already sits in the right-clicked cell, so
+  // .focus() keeps it there and the command acts on that cell.
+  const run = (fn: () => void) => {
+    fn()
+    setPoint(null)
   }
-  return null
-}
 
-/**
- * Whether the floating table toolbar should be visible for the editor's current selection. Shown
- * whenever the caret is inside a table cell — which naturally covers tables that were already in
- * the document, since it keys off the selection, not how the table was created. Suppressed while a
- * plain text run inside a cell is selected so it doesn't fight the inline formatting / comment
- * bubbles; a collapsed caret or a whole-cell (CellSelection) drag both keep it visible.
- */
-export function shouldShowTableBubble(editor: Editor): boolean {
-  if (!editor.isEditable || !editor.isActive('table')) return false
-  const sel = editor.state.selection
-  return sel.empty || sel instanceof CellSelection
-}
-
-/**
- * Floating table toolbar. See {@link shouldShowTableBubble} for the visibility rule. A distinct
- * pluginKey keeps it from clashing with the inline formatting / comment BubbleMenus on the same
- * editor.
- */
-export function TableBubbleMenu({ editor }: { editor: Editor }) {
   return (
-    <BubbleMenu
-      editor={editor}
-      pluginKey="octoTableBubble"
-      // The toolbar floats over the table while the caret sits in a cell, so its frame would
-      // otherwise sit on top of the column-resize hot zone and swallow the hover/drag the resize
-      // plugin listens for on the editor DOM. octo-table-bubble-portal makes the floating wrapper
-      // transparent to pointer events (see styles.css); only the buttons below re-capture them.
-      className="octo-table-bubble-portal"
-      // Anchor the toolbar to the table's outer edge rather than the caret's cell, so with
-      // placement: 'top' it floats in the block margin above the whole table and never covers the
-      // in-table text rows above the caret (#625). Falls back to the default caret rect when the
-      // helper can't find a table (never happens while shouldShow is satisfied).
-      getReferencedVirtualElement={() => tableReferenceElement(editor)}
-      options={{ placement: 'top', offset: 8 }}
-      shouldShow={({ editor: e }) => shouldShowTableBubble(e)}
+    <div
+      ref={menuRef}
+      className="octo-bubble-menu octo-table-context-menu"
+      role="menu"
+      style={{ position: 'fixed', left: point.x, top: point.y }}
+      onContextMenu={(e) => e.preventDefault()}
     >
-      <div className="octo-bubble-menu octo-table-bubble">
-        <TbBtn
-          label={<IconRowBefore />}
-          title={t('docs.table.addRowBefore')}
-          onClick={() => editor.chain().focus().addRowBefore().run()}
-        />
-        <TbBtn
-          label={<IconRowAfter />}
-          title={t('docs.table.addRowAfter')}
-          onClick={() => editor.chain().focus().addRowAfter().run()}
-        />
-        <TbBtn
-          label={<IconDeleteRow />}
-          title={t('docs.table.deleteRow')}
-          text={t('docs.table.deleteRow')}
-          onClick={() => editor.chain().focus().deleteRow().run()}
-        />
-        <span className="octo-tb-sep" />
-        <TbBtn
-          label={<IconColBefore />}
-          title={t('docs.table.addColumnBefore')}
-          onClick={() => editor.chain().focus().addColumnBefore().run()}
-        />
-        <TbBtn
-          label={<IconColAfter />}
-          title={t('docs.table.addColumnAfter')}
-          onClick={() => editor.chain().focus().addColumnAfter().run()}
-        />
-        <TbBtn
-          label={<IconDeleteCol />}
-          title={t('docs.table.deleteColumn')}
-          text={t('docs.table.deleteColumn')}
-          onClick={() => editor.chain().focus().deleteColumn().run()}
-        />
-        <span className="octo-tb-sep" />
-        <TbBtn
-          label={<IconDeleteTable />}
-          title={t('docs.table.deleteTable')}
-          text={t('docs.table.deleteTable')}
-          onClick={() => editor.chain().focus().deleteTable().run()}
-        />
-      </div>
-    </BubbleMenu>
+      <TbBtn
+        label={<IconRowBefore />}
+        title={t('docs.table.addRowBefore')}
+        text={t('docs.table.addRowBefore')}
+        onClick={() => run(() => editor.chain().focus().addRowBefore().run())}
+      />
+      <TbBtn
+        label={<IconRowAfter />}
+        title={t('docs.table.addRowAfter')}
+        text={t('docs.table.addRowAfter')}
+        onClick={() => run(() => editor.chain().focus().addRowAfter().run())}
+      />
+      <TbBtn
+        label={<IconDeleteRow />}
+        title={t('docs.table.deleteRow')}
+        text={t('docs.table.deleteRow')}
+        onClick={() => run(() => editor.chain().focus().deleteRow().run())}
+      />
+      <span className="octo-tb-sep" />
+      <TbBtn
+        label={<IconColBefore />}
+        title={t('docs.table.addColumnBefore')}
+        text={t('docs.table.addColumnBefore')}
+        onClick={() => run(() => editor.chain().focus().addColumnBefore().run())}
+      />
+      <TbBtn
+        label={<IconColAfter />}
+        title={t('docs.table.addColumnAfter')}
+        text={t('docs.table.addColumnAfter')}
+        onClick={() => run(() => editor.chain().focus().addColumnAfter().run())}
+      />
+      <TbBtn
+        label={<IconDeleteCol />}
+        title={t('docs.table.deleteColumn')}
+        text={t('docs.table.deleteColumn')}
+        onClick={() => run(() => editor.chain().focus().deleteColumn().run())}
+      />
+      <span className="octo-tb-sep" />
+      <TbBtn
+        label={<IconDeleteTable />}
+        title={t('docs.table.deleteTable')}
+        text={t('docs.table.deleteTable')}
+        onClick={() => run(() => editor.chain().focus().deleteTable().run())}
+      />
+    </div>
   )
 }
 

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -191,6 +191,10 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
   // Viewport-coord anchor point where the user right-clicked; null while the menu is closed.
   const [point, setPoint] = useState<{ x: number; y: number } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  // Cell positions (anchor/head) of a multi-cell CellSelection captured at right-click time, or
+  // null when the click was on a single cell. See the snapshot in onContextMenu below for why this
+  // has to be remembered rather than re-read from the live selection when a menu item is clicked.
+  const cellRangeRef = useRef<{ anchor: number; head: number } | null>(null)
 
   // Attach the contextmenu listener to this editor's DOM. Right-click inside a cell opens the menu
   // at the pointer and preventDefault()s the native menu; anywhere else is left untouched.
@@ -204,6 +208,19 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
       if (!coords) return
       if (!moveSelectionIntoCell(editor, coords.pos)) return
       e.preventDefault()
+      // Snapshot a multi-cell CellSelection NOW, while it is still intact. After this handler
+      // returns the browser processes the native right-click: it moves the caret to the clicked
+      // cell and fires `selectionchange`, which ProseMirror syncs back into a single-cell
+      // TextSelection — collapsing the multi-column/row rectangle before the user gets to click a
+      // menu item. If deleteColumn/deleteRow then read the live selection they would only see the
+      // one clicked cell and remove a single column/row (the real-browser "delete N, only 1 goes"
+      // bug; jsdom never fires that selectionchange, which is why the old unit tests were green).
+      // Remembering the cell range here lets us re-establish it right before the command runs.
+      const sel = editor.state.selection
+      cellRangeRef.current =
+        sel instanceof CellSelection
+          ? { anchor: sel.$anchorCell.pos, head: sel.$headCell.pos }
+          : null
       setPoint({ x: e.clientX, y: e.clientY })
     }
     dom.addEventListener('contextmenu', onContextMenu)
@@ -244,10 +261,27 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
 
   if (!point) return null
 
-  // Run a table command then close. The selection already sits in the right-clicked cell, so
-  // .focus() keeps it there and the command acts on that cell.
+  // Run a table command then close. When the menu was opened over a multi-cell selection we first
+  // re-establish that CellSelection (the browser's right-click caret move will have collapsed it to
+  // a single cell in the meantime — see the snapshot in onContextMenu), so range operations such as
+  // deleteColumn / deleteRow act on every selected column/row instead of just the clicked one. No
+  // document edit happens between opening the menu and this click, so the captured cell positions
+  // are still valid; CellSelection.create is guarded in case a position is somehow stale.
   const run = (fn: () => void) => {
+    const range = cellRangeRef.current
+    if (range) {
+      try {
+        editor.view.dispatch(
+          editor.state.tr.setSelection(
+            CellSelection.create(editor.state.doc, range.anchor, range.head),
+          ),
+        )
+      } catch {
+        // Stale range (e.g. the table changed out from under us) — fall back to the live selection.
+      }
+    }
     fn()
+    cellRangeRef.current = null
     setPoint(null)
   }
 

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -111,14 +111,33 @@ function TbBtn({
  * point, `posAtCoords` mapped that to a document position, and this moves the selection there so the
  * position-relative table commands (addRow / deleteColumn / …) act on the cell that was clicked
  * rather than wherever the caret happened to be. `pos` is clamped into the document so an
- * out-of-range value from `posAtCoords` can never throw. Returns `editor.isActive('table')` — the
- * gate the caller uses to decide whether to open a table menu (and suppress the native one) at all.
+ * out-of-range value from `posAtCoords` can never throw.
+ *
+ * The table test is done on the *resolved* position WITHOUT dispatching anything, so a right-click
+ * on ordinary (non-table) text is a complete no-op: the selection is only moved when `pos` really
+ * lands inside a table cell. That keeps a right-click outside a table from collapsing the user's
+ * existing selection, so the browser's native context menu / Copy still act on the selected text.
+ * Returns whether the click was inside a table — the gate the caller uses to decide whether to open
+ * a table menu (and suppress the native one) at all.
  */
 export function moveSelectionIntoCell(editor: Editor, pos: number): boolean {
-  const { doc, tr } = editor.state
+  const { doc } = editor.state
   const safe = Math.max(0, Math.min(pos, doc.content.size))
-  editor.view.dispatch(tr.setSelection(TextSelection.near(doc.resolve(safe))))
-  return editor.isActive('table')
+  const $pos = doc.resolve(safe)
+
+  // Walk the resolved position's ancestors to see whether it sits inside a table, without touching
+  // the current selection. Mirrors editor.isActive('table') but for an arbitrary position.
+  let inTable = false
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    if ($pos.node(depth).type.name === 'table') {
+      inTable = true
+      break
+    }
+  }
+  if (!inTable) return false
+
+  editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($pos)))
+  return true
 }
 
 /**

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -429,19 +429,33 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
-/* Table editing UI (#595). The floating table toolbar reuses .octo-bubble-menu; it only needs to
-   keep its buttons on one line and align the separators vertically. */
-.octo-table-bubble {
-  align-items: center;
+/* Table editing UI (#595, right-click menu XIN-1052). The right-click table menu reuses
+   .octo-bubble-menu for its frame; it lays the actions out as a vertical list anchored at the
+   pointer (position/left/top set inline), sitting above the editor content. */
+.octo-table-context-menu {
+  position: fixed;
+  z-index: 1000;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 168px;
 }
-.octo-table-bubble .octo-tb-sep {
+.octo-table-context-menu .octo-tb-sep {
+  height: 1px;
   align-self: stretch;
+  background: var(--octo-border);
+  margin: 2px 0;
 }
-/* Delete controls carry a text caption (#621-2) so it's clear which row / column / table the
-   action removes. Lay the icon and caption out inline; icon-only buttons are unaffected. */
-.octo-table-bubble .octo-tb-btn {
+/* Each action reads as a full-width row: icon on the left, its caption next to it, so the user
+   sees exactly which row / column / table the action affects. */
+.octo-table-context-menu .octo-tb-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  text-align: left;
 }
 .octo-tb-btn--labeled {
   gap: 4px;
@@ -450,18 +464,6 @@
   font-size: 12px;
   line-height: 1;
   white-space: nowrap;
-}
-/* While the caret is inside a table cell this toolbar floats over the table (placement: top). Its
-   frame would otherwise sit on top of the column-resize hot zone and swallow the hover/mousedown
-   the resize plugin listens for on the editor DOM, so `.column-resize-handle` never appears and the
-   column can't be dragged (#595 C1). pointer-events is inherited, so making the floating wrapper
-   transparent lets those events fall through to the table underneath; only the buttons re-capture
-   the pointer so they stay clickable. */
-.octo-table-bubble-portal {
-  pointer-events: none;
-}
-.octo-table-bubble-portal .octo-tb-btn {
-  pointer-events: auto;
 }
 
 /* Grid picker for inserting a table at a chosen size (replaces the fixed 3×3). Floats under the


### PR DESCRIPTION
## What

Switches the docs table row/column controls (`packages/docs`) from the floating bubble toolbar to a **right-click context menu**.

Right-clicking inside any table cell now opens a menu at the pointer with the same seven actions:

- Add row before / after, delete row
- Add column before / after, delete column
- Delete table

## Why

The floating bubble toolbar appeared above the whole table whenever the caret sat in a cell, which required the off-screen/toolbar-collision anchoring logic and a `pointer-events` transparency hack over the column-resize hot zone. A right-click menu is a more familiar, less intrusive entry point for table operations.

## How

- Replaced the `BubbleMenu`-based `TableBubbleMenu` with a `TableContextMenu` component that listens for `contextmenu` on the editor DOM.
- On right-click, `posAtCoords` maps the pointer to a document position and the selection is moved into that cell first, so the position-relative Tiptap commands act on the clicked cell. The native browser menu is suppressed **only** when the click lands inside a table; clicks elsewhere keep the browser's own menu.
- The menu is positioned at the pointer, clamped to stay inside the viewport, and closes on outside-click, Escape, or after a command runs.
- **Command layer is unchanged** — the seven `editor.chain().focus().<cmd>().run()` calls are moved as-is. `TableGridPicker` (the insert-table entry) is untouched.
- Removed the now-unused float-above-table anchoring (`clampToolbarAnchorRect` / `tableReferenceElement`) and the `.octo-table-bubble-portal` pointer-events hack.

## Testing

- Rewrote `TableControls.test.tsx` for the new interaction: gate + selection move (`moveSelectionIntoCell`), the menu opening only inside a table and suppressing the native menu, running a command + closing, Escape close, and viewport clamping (`clampMenuPosition`). The existing command and grid-picker assertions are preserved.
- `packages/docs` full test suite passes (pre-existing unrelated failures in `pages/DocsHome.test.tsx` are untouched by this change).
- Typecheck clean for the changed files.

Relates to XIN-1052.

---

Draft: opening for review before marking ready.
