### PR TITLE
fix(docs): make link popover keyboard-safe and refresh the link icon

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, cleanup, within, act } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, within, act, waitFor } from '@testing-library/react'
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import TaskList from '@tiptap/extension-task-list'
@@ -105,7 +105,8 @@ describe('Toolbar — batch 7 quote/code/link/highlight/colour tooltips', () => 
   it('renders the link button as an icon button', () => {
     render(<Toolbar editor={editor!} />)
     const link = titleBtn('docs.toolbar.link')
-    expect(link.querySelector('svg.octo-tb-icon')).toBeTruthy()
+    // XIN-1051: the link glyph is now a stroke-style chain icon (lucide `link`), not a filled one.
+    expect(link.querySelector('svg.octo-tb-icon-stroke')).toBeTruthy()
     expect(link.textContent?.trim()).toBe('')
   })
 })
@@ -133,6 +134,138 @@ describe('Toolbar — batch 7 floating link popover (item 5)', () => {
     expect(field).toBeTruthy()
     fireEvent.keyDown(field, { key: 'Escape' })
     expect(document.querySelector('.octo-link-popover')).toBeNull()
+  })
+})
+
+// XIN-1051 regression: the link popover used to lose the link / type a newline into the body when
+// Enter was pressed, and silently discarded the popover on an empty/invalid URL. These cover the
+// three paths from the acceptance criteria — existing selection, no selection, brand-new link — plus
+// the empty/invalid-URL inline-error behaviour and the focus isolation that keeps Enter off the
+// editor. The `t()` stub returns keys unchanged, so error text is asserted on its i18n key.
+describe('Toolbar — XIN-1051 link popover enter / focus regression', () => {
+  function urlField(): HTMLInputElement {
+    return screen.getByPlaceholderText('docs.toolbar.linkPlaceholder') as HTMLInputElement
+  }
+  function textField(): HTMLInputElement {
+    return screen.getByPlaceholderText('docs.toolbar.linkText') as HTMLInputElement
+  }
+
+  it('path 1 — existing selection: Enter applies the link to the selection and closes the popover', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run() // select "hello"
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    const url = urlField()
+    fireEvent.change(url, { target: { value: 'https://example.com' } })
+    fireEvent.keyDown(url, { key: 'Enter' })
+
+    expect(document.querySelector('.octo-link-popover')).toBeNull()
+    const html = editor!.getHTML()
+    expect(html).toContain('example.com')
+    expect(html).toContain('>hello</a>')
+    // No newline leaked into the body: still exactly one paragraph.
+    expect(editor!.state.doc.childCount).toBe(1)
+  })
+
+  it('path 2 — no selection: Enter inserts a new linked label at the caret and closes', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().setTextSelection(6).run() // caret after "hello", no selection
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.change(textField(), { target: { value: 'Example' } })
+    const url = urlField()
+    fireEvent.change(url, { target: { value: 'https://example.com' } })
+    fireEvent.keyDown(url, { key: 'Enter' })
+
+    expect(document.querySelector('.octo-link-popover')).toBeNull()
+    const html = editor!.getHTML()
+    expect(html).toContain('>Example</a>')
+    expect(html).toContain('hello') // original text untouched
+    expect(editor!.state.doc.childCount).toBe(1)
+  })
+
+  it('path 3 — brand-new link: Enter in the text field also confirms (no body newline)', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().setTextSelection(6).run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.change(textField(), { target: { value: 'Docs' } })
+    fireEvent.change(urlField(), { target: { value: 'https://example.com' } })
+    // Confirm from the TEXT field's Enter handler (both inputs must guard Enter).
+    fireEvent.keyDown(textField(), { key: 'Enter' })
+
+    expect(document.querySelector('.octo-link-popover')).toBeNull()
+    expect(editor!.getHTML()).toContain('>Docs</a>')
+    expect(editor!.state.doc.childCount).toBe(1)
+  })
+
+  it('empty URL: Enter keeps the popover open with an inline error and never discards input or types into the body', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().setTextSelection(6).run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.change(textField(), { target: { value: 'Keep me' } })
+    const before = editor!.getHTML()
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+
+    // Popover stays open (the old code silently closed it) and shows the inline error…
+    expect(document.querySelector('.octo-link-popover')).toBeTruthy()
+    expect(screen.getByText('docs.toolbar.linkErrorEmpty')).toBeTruthy()
+    // …the typed text is preserved, no link is created, and the body is unchanged (no newline).
+    expect(textField().value).toBe('Keep me')
+    expect(editor!.getHTML()).toBe(before)
+    expect(editor!.getHTML()).not.toContain('</a>')
+  })
+
+  it('invalid URL: Enter surfaces an inline error and inserts nothing', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    const before = editor!.getHTML()
+    fireEvent.change(urlField(), { target: { value: 'javascript:alert(1)' } })
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+
+    expect(document.querySelector('.octo-link-popover')).toBeTruthy()
+    expect(screen.getByText('docs.toolbar.linkErrorInvalid')).toBeTruthy()
+    expect(editor!.getHTML()).toBe(before)
+    expect(editor!.getHTML()).not.toContain('</a>')
+  })
+
+  it('a scheme-less host (e.g. "example.com") is linked as https, not a same-origin path', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.change(urlField(), { target: { value: 'example.com' } })
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+
+    expect(editor!.getHTML()).toContain('href="https://example.com')
+  })
+
+  it('editing the URL after an error clears the inline error', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.keyDown(urlField(), { key: 'Enter' }) // empty → error
+    expect(screen.getByText('docs.toolbar.linkErrorEmpty')).toBeTruthy()
+    fireEvent.change(urlField(), { target: { value: 'h' } })
+    expect(document.querySelector('.octo-link-error')).toBeNull()
+  })
+
+  it('Escape from the URL field still closes the popover', () => {
+    render(<Toolbar editor={editor!} />)
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.keyDown(urlField(), { key: 'Escape' })
+    expect(document.querySelector('.octo-link-popover')).toBeNull()
+  })
+
+  it('focus isolation: opening over a selection moves focus into the URL field', async () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    await waitFor(() => expect(document.activeElement).toBe(urlField()))
+  })
+
+  it('focus isolation: opening a brand-new link (no selection) focuses the text field', async () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().setTextSelection(6).run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    await waitFor(() => expect(document.activeElement).toBe(textField()))
   })
 })
 

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -227,6 +227,42 @@ describe('Toolbar — XIN-1051 link popover enter / focus regression', () => {
     expect(editor!.getHTML()).not.toContain('</a>')
   })
 
+  // XIN-1073 (real-machine 4a): a bare, scheme-less word ("abc", "test") is NOT a URL. The old
+  // code blindly prefixed https:// so sanitizeLinkHref returned https://abc/ — the popover accepted
+  // the junk, closed, and lost the input with no error. It must now behave like any other invalid
+  // URL: inline error, popover stays open, input preserved, nothing inserted.
+  it('scheme-less bare word (no dot): Enter shows the inline error, keeps the popover + input, inserts nothing', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run() // select "hello"
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    const before = editor!.getHTML()
+    fireEvent.change(urlField(), { target: { value: 'abc' } })
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+
+    expect(document.querySelector('.octo-link-popover')).toBeTruthy()
+    expect(screen.getByText('docs.toolbar.linkErrorInvalid')).toBeTruthy()
+    expect(urlField().value).toBe('abc') // typed value preserved for correction
+    expect(editor!.getHTML()).toBe(before) // no https://abc/ link created
+    expect(editor!.getHTML()).not.toContain('</a>')
+    expect(editor!.getHTML()).not.toContain('abc')
+  })
+
+  it('scheme-less bare word: retyping a valid host clears the error and links on the next Enter', () => {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.link'))
+    fireEvent.change(urlField(), { target: { value: 'abc' } })
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+    expect(screen.getByText('docs.toolbar.linkErrorInvalid')).toBeTruthy()
+
+    // Correcting the input clears the error, and a valid host now links + closes.
+    fireEvent.change(urlField(), { target: { value: 'abc.com' } })
+    expect(document.querySelector('.octo-link-error')).toBeNull()
+    fireEvent.keyDown(urlField(), { key: 'Enter' })
+    expect(document.querySelector('.octo-link-popover')).toBeNull()
+    expect(editor!.getHTML()).toContain('href="https://abc.com')
+  })
+
   it('a scheme-less host (e.g. "example.com") is linked as https, not a same-origin path', () => {
     render(<Toolbar editor={editor!} />)
     editor!.chain().focus().selectAll().run()

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -1316,14 +1316,23 @@ export function Toolbar({ editor }: { editor: Editor }) {
     return () => cancelAnimationFrame(id)
   }, [linkOpen])
 
-  // XIN-1051: a bare host/domain with no scheme ("google.com") would otherwise resolve relative to
-  // the current origin and become a same-origin path link, not the external URL the user meant.
-  // Prepend https:// when there is no explicit scheme (and it is not protocol-relative) so the
-  // value sanitizes into a proper absolute link.
-  function normalizeLinkInput(raw: string): string {
+  // XIN-1051 / XIN-1073: resolve the raw popover input into a safe, absolute href — or null when it
+  // is not a usable link, so confirmLink can surface the inline error instead of inserting junk.
+  //   - explicit scheme ("https://x", "mailto:a@b") / protocol-relative ("//cdn/x") → hand straight
+  //     to sanitizeLinkHref so the §3.7 scheme whitelist still rejects javascript:/data:/ftp: etc.
+  //   - scheme-less: a bare host/domain ("google.com") would resolve relative to the origin and
+  //     become a same-origin path, so we prepend https:// — but ONLY when it actually looks like a
+  //     host (a dotted label, or "localhost"). A bare word like "abc" is NOT a URL: without this
+  //     guard https:// was blindly prepended and sanitizeLinkHref returned https://abc/, so the
+  //     popover accepted the junk and closed with no error (the 4a real-machine defect). Such input
+  //     now resolves to null → inline error, popover stays open, user's text is preserved.
+  function resolveLinkHref(raw: string): string | null {
     const v = raw.trim()
-    if (!v || v.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(v)) return v
-    return `https://${v}`
+    if (!v) return null
+    if (v.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(v)) return sanitizeLinkHref(v)
+    const host = v.split(/[/?#]/, 1)[0]
+    const looksLikeHost = host === 'localhost' || /[^.\s]\.[^.\s]/.test(host)
+    return looksLikeHost ? sanitizeLinkHref(`https://${v}`) : null
   }
 
   // C7: insert a link at the cursor (or apply it to the selection). With no selection a brand-new
@@ -1339,7 +1348,7 @@ export function Toolbar({ editor }: { editor: Editor }) {
       linkUrlRef.current?.focus()
       return
     }
-    const href = sanitizeLinkHref(normalizeLinkInput(raw))
+    const href = resolveLinkHref(raw)
     if (!href) {
       setLinkError(t('docs.toolbar.linkErrorInvalid'))
       linkUrlRef.current?.focus()

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -85,24 +85,40 @@ const IconCode = () => (
     <path d="M8.7 17.3 3.4 12l5.3-5.3 1.3 1.4L5.9 12l4.1 4.1-1.3 1.2zm6.6 0L14 16.1l4.1-4.1-4.1-4.1 1.3-1.4L20.6 12l-5.3 5.3zM13.9 5.2l1.9.5-3.9 13.1-1.9-.5 3.9-13.1z" />
   </svg>
 )
-// Link: two interlocking pill-shaped rings linked at ~45° (classic chain-link, boss reference).
-// Filled rings via the evenodd fill-rule (outer capsule minus an inner capsule = hollow ring);
-// the whole pair is rotated 45° so the links sit on the diagonal.
+// Link (XIN-1051): the standard chain-link glyph (lucide `link`) — two diagonal, interlocking
+// hooked curves. Stroke line-art, not filled: uses .octo-tb-icon-stroke (fill:none;
+// stroke:currentColor) with round caps/joins so it reads as a recognizable link icon at 16px
+// rather than the old two-capsule filled blob. Aligned with IconUnlink below.
 const IconLink = () => (
-  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
-    <g transform="rotate(45 12 12)" fillRule="evenodd">
-      <path d="M4 8.6h9a3.4 3.4 0 0 1 0 6.8H4a3.4 3.4 0 0 1 0-6.8zm0 1.6a1.8 1.8 0 0 0 0 3.6h9a1.8 1.8 0 0 0 0-3.6H4z" />
-      <path d="M11 8.6h9a3.4 3.4 0 0 1 0 6.8h-9a3.4 3.4 0 0 1 0-6.8zm0 1.6a1.8 1.8 0 0 0 0 3.6h9a1.8 1.8 0 0 0 0-3.6h-9z" />
-    </g>
+  <svg
+    className="octo-tb-icon-stroke"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
   </svg>
 )
-// Unlink: the same two rings pulled apart with a gap between them (broken chain).
+// Unlink (XIN-1051): the same chain pulled apart (lucide `unlink`) — the two hooked curves with a
+// break plus the four short "snap" ticks. Same stroke style as IconLink so the pair reads as a set.
 const IconUnlink = () => (
-  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
-    <g transform="rotate(45 12 12)" fillRule="evenodd">
-      <path d="M3 8.6h6.5a3.4 3.4 0 0 1 0 6.8H3a3.4 3.4 0 0 1 0-6.8zm0 1.6a1.8 1.8 0 0 0 0 3.6h6.5a1.8 1.8 0 0 0 0-3.6H3z" />
-      <path d="M14.5 8.6H21a3.4 3.4 0 0 1 0 6.8h-6.5a3.4 3.4 0 0 1 0-6.8zm0 1.6a1.8 1.8 0 0 0 0 3.6H21a1.8 1.8 0 0 0 0-3.6h-6.5z" />
-    </g>
+  <svg
+    className="octo-tb-icon-stroke"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m18.84 12.25 1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07 5.006 5.006 0 0 0-6.95 0l-1.72 1.71" />
+    <path d="m5.17 11.75-1.71 1.71a5.004 5.004 0 0 0 .12 7.07 5.006 5.006 0 0 0 6.95 0l1.71-1.71" />
+    <line x1="8" x2="8" y1="2" y2="5" />
+    <line x1="2" x2="5" y1="8" y2="8" />
+    <line x1="16" x2="16" y1="19" y2="22" />
+    <line x1="19" x2="22" y1="16" y2="16" />
   </svg>
 )
 
@@ -1172,8 +1188,20 @@ export function Toolbar({ editor }: { editor: Editor }) {
   const [linkOpen, setLinkOpen] = useState(false)
   const [linkText, setLinkText] = useState('')
   const [linkValue, setLinkValue] = useState('')
+  // Inline validation message for the URL field (empty / unsafe URL). `null` = no error.
+  // XIN-1051: an empty or invalid URL must surface here instead of silently discarding the
+  // popover (the old confirmLink closed on a falsy href, so a mistyped URL just vanished).
+  const [linkError, setLinkError] = useState<string | null>(null)
   const [findOpen, setFindOpen] = useState(false)
   const linkRef = useRef<HTMLSpanElement>(null)
+  // XIN-1051 focus isolation: refs to the two popover inputs so opening the popover can move
+  // keyboard focus INTO the panel (URL field when a selection is being linked, text field for a
+  // brand-new link). Without this the caret stays in the editor and Enter is handled by
+  // ProseMirror — the link is lost and the keystroke lands as a newline in the body.
+  const linkTextRef = useRef<HTMLInputElement>(null)
+  const linkUrlRef = useRef<HTMLInputElement>(null)
+  // Whether the popover was opened over a non-empty selection — decides the initial focus target.
+  const linkHadSelectionRef = useRef(false)
 
   // Format painter (XIN-963): armed state holds the inline marks captured from the source
   // selection. `null` = disarmed. Clicking the button captures the current selection's marks and
@@ -1256,8 +1284,11 @@ export function Toolbar({ editor }: { editor: Editor }) {
       const next = !v
       if (next) {
         const { from, to } = editor.state.selection
-        setLinkText(from !== to ? editor.state.doc.textBetween(from, to, ' ') : '')
+        const hasSelection = from !== to
+        linkHadSelectionRef.current = hasSelection
+        setLinkText(hasSelection ? editor.state.doc.textBetween(from, to, ' ') : '')
         setLinkValue((editor.getAttributes('link').href as string) || '')
+        setLinkError(null)
       }
       return next
     })
@@ -1267,21 +1298,57 @@ export function Toolbar({ editor }: { editor: Editor }) {
     setLinkOpen(false)
     setLinkText('')
     setLinkValue('')
+    setLinkError(null)
+  }
+
+  // XIN-1051 focus isolation: when the popover opens, pull keyboard focus into it so Enter/Escape
+  // are handled by the input (see the per-input onKeyDown guards) and never fall through to the
+  // editor's contenteditable. With a selection the text is already known, so focus the URL field;
+  // for a brand-new link focus the text field first. Runs only on the open transition.
+  useEffect(() => {
+    if (!linkOpen) return
+    const target = linkHadSelectionRef.current ? linkUrlRef.current : linkTextRef.current
+    // Focus after paint so the input is mounted; select existing content for quick replace.
+    const id = requestAnimationFrame(() => {
+      target?.focus()
+      target?.select()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [linkOpen])
+
+  // XIN-1051: a bare host/domain with no scheme ("google.com") would otherwise resolve relative to
+  // the current origin and become a same-origin path link, not the external URL the user meant.
+  // Prepend https:// when there is no explicit scheme (and it is not protocol-relative) so the
+  // value sanitizes into a proper absolute link.
+  function normalizeLinkInput(raw: string): string {
+    const v = raw.trim()
+    if (!v || v.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(v)) return v
+    return `https://${v}`
   }
 
   // C7: insert a link at the cursor (or apply it to the selection). With no selection a brand-new
   // linked label is inserted at the caret; with a selection whose text is unchanged the link is
   // applied to it (preserving any other marks); if the text was edited it replaces the selection.
-  // sanitizeLinkHref enforces the scheme whitelist (§3.7) — an unsafe or empty URL inserts nothing.
+  // sanitizeLinkHref enforces the scheme whitelist (§3.7). XIN-1051: an empty or unsafe URL no
+  // longer silently closes the popover — it surfaces an inline error and keeps the user's input,
+  // so a mistyped URL is never lost and a stray Enter can't discard the panel.
   function confirmLink() {
-    const href = sanitizeLinkHref(linkValue.trim())
-    if (!href) {
-      closeLink()
+    const raw = linkValue.trim()
+    if (!raw) {
+      setLinkError(t('docs.toolbar.linkErrorEmpty'))
+      linkUrlRef.current?.focus()
       return
     }
+    const href = sanitizeLinkHref(normalizeLinkInput(raw))
+    if (!href) {
+      setLinkError(t('docs.toolbar.linkErrorInvalid'))
+      linkUrlRef.current?.focus()
+      return
+    }
+    setLinkError(null)
     const { from, to } = editor.state.selection
     const selText = from !== to ? editor.state.doc.textBetween(from, to, ' ') : ''
-    const text = linkText.trim() || linkValue.trim()
+    const text = linkText.trim() || raw
     if (selText && text === selText.trim()) {
       // Unchanged selection → just apply the link mark, keeping bold/italic/etc.
       editor.chain().focus().setLink({ href }).run()
@@ -1369,6 +1436,7 @@ export function Toolbar({ editor }: { editor: Editor }) {
           <span className="octo-color-popover octo-link-popover" role="dialog">
             <input
               className="octo-link-field"
+              ref={linkTextRef}
               value={linkText}
               onChange={(e) => setLinkText(e.target.value)}
               placeholder={t('docs.toolbar.linkText')}
@@ -1376,30 +1444,43 @@ export function Toolbar({ editor }: { editor: Editor }) {
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault()
+                  e.stopPropagation()
                   confirmLink()
                 } else if (e.key === 'Escape') {
                   e.preventDefault()
+                  e.stopPropagation()
                   closeLink()
                 }
               }}
             />
             <input
-              className="octo-link-field"
+              className={'octo-link-field' + (linkError ? ' is-invalid' : '')}
+              ref={linkUrlRef}
               value={linkValue}
-              autoFocus
-              onChange={(e) => setLinkValue(e.target.value)}
+              aria-invalid={linkError ? true : undefined}
+              onChange={(e) => {
+                setLinkValue(e.target.value)
+                if (linkError) setLinkError(null)
+              }}
               placeholder={t('docs.toolbar.linkPlaceholder')}
               onMouseDown={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault()
+                  e.stopPropagation()
                   confirmLink()
                 } else if (e.key === 'Escape') {
                   e.preventDefault()
+                  e.stopPropagation()
                   closeLink()
                 }
               }}
             />
+            {linkError && (
+              <span className="octo-link-error" role="alert">
+                {linkError}
+              </span>
+            )}
             <div className="octo-link-popover-actions">
               <Btn label={t('docs.toolbar.linkSet')} onClick={confirmLink} />
             </div>

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -417,6 +417,20 @@
   display: flex;
   justify-content: flex-end;
 }
+/* XIN-1051: inline validation for an empty / unsafe URL. The field gets a red border and a small
+   message sits between the fields and the Set action, so a mistyped URL is corrected in place
+   instead of the popover silently discarding it. */
+.octo-link-field.is-invalid {
+  border-color: #eb5757;
+}
+.octo-link-field.is-invalid:focus {
+  border-color: #eb5757;
+}
+.octo-link-error {
+  color: #eb5757;
+  font-size: 12px;
+  line-height: 1.3;
+}
 
 .octo-bubble-menu,
 .octo-floating-menu {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -153,6 +153,8 @@
     "linkText": "Link text",
     "linkPlaceholder": "https://…",
     "linkSet": "Set",
+    "linkErrorEmpty": "Enter a URL",
+    "linkErrorInvalid": "Enter a valid URL (http, https or mailto)",
     "insert": "Insert",
     "undo": "Undo",
     "redo": "Redo",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -153,6 +153,8 @@
     "linkText": "链接文字",
     "linkPlaceholder": "https://…",
     "linkSet": "确定",
+    "linkErrorEmpty": "请输入链接地址",
+    "linkErrorInvalid": "请输入有效的链接地址（http、https 或 mailto）",
     "insert": "插入",
     "undo": "撤销",
     "redo": "重做",


### PR DESCRIPTION
## What & why

The `packages/docs` toolbar link popover had two problems confirmed on production:

1. **Enter in the link popover lost the link or typed into the document body.** The popover was not an isolated, focus-owning input: only the URL field had `autoFocus`, the text field had no focus management, and both inputs' `onKeyDown` handlers called `preventDefault()` without `stopPropagation()`. When focus wasn't inside a field, Enter reached the editor's contenteditable and ProseMirror inserted a newline. Separately, `confirmLink` silently `closeLink()`-ed on an empty/unsafe URL, so a mistyped URL just vanished.
2. **The link icon was hard to recognise** — a filled two-capsule glyph rotated 45°.

## Changes

**4a — keyboard/focus correctness**
- On open, move keyboard focus into the popover: the URL field when a selection is being linked, the text field for a brand-new link. Keeps Enter/Escape on the input, never on the editor.
- Add `stopPropagation()` next to `preventDefault()` on both inputs' Enter/Escape handlers so a keystroke can never bubble back to the editor.
- Empty or unsafe URL no longer silently closes the popover: it surfaces an inline error, preserves the typed input, and re-focuses the URL field.
- A scheme-less host (e.g. `example.com`) is prepended with `https://` so it becomes an absolute link instead of a same-origin path.

**4b — icon**
- Replace `IconLink` / `IconUnlink` with the standard stroke chain-link glyphs (`octo-tb-icon-stroke`, `strokeWidth=2`, rounded caps/joins).

## Tests

Added regression coverage in `Toolbar.test.tsx` for the three acceptance paths — existing selection / no selection / brand-new link — plus the empty & invalid-URL inline error, scheme completion, error-clearing on edit, Escape close, and focus isolation. Previously this area had zero enter/focus coverage, which is why the bug shipped.

## Verification

- `packages/docs` unit tests green (all Toolbar tests pass, incl. the new ones).
- Typecheck clean for the changed files.
- Verified in a real browser (Chromium) against the standalone editor: all three paths apply/insert the link correctly with focus landing in the right field and no stray newline in the body; the empty-URL case keeps the popover open with an inline error and preserves input; scheme-less input links as `https://`; Escape closes; the link button renders the new stroke chain icon.

## Scope

No schema / collaboration changes. Draft PR only.
