### PR TITLE
fix(upload): prevent Octo session token leaking to COS pre-signed URL

### DIFF
--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -9,7 +9,8 @@ import { t } from "../i18n"
 // URLs are foreign-origin; sending the token there causes 403/400 (unexpected
 // header conflicts with the pre-signed signature).  This mirrors the pattern
 // used in packages/dmworkdatasource/src/task.ts and datasource.ts (uploadSticker).
-const noInterceptorAxios = axios.create({ timeout: 10 * 60 * 1000 }) // 10 min ceiling
+/** @internal — exported only for token-isolation tests; do not use in production code. */
+export const noInterceptorAxios = axios.create({ timeout: 10 * 60 * 1000 }) // 10 min ceiling
 
 /**
  * Return true iff uploadURL should receive the Octo session token, i.e. it

--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -20,13 +20,15 @@ const noInterceptorAxios = axios.create({ timeout: 10 * 60 * 1000 }) // 10 min c
 function shouldAttachToken(uploadURL: string, apiBaseURL: string): boolean {
     try {
         const locationHref = typeof window !== "undefined" ? window.location.href : ""
-        if (!locationHref) return true // non-browser: conservative, keep token
+        // Mirror datasource.ts: when origin is undetermined, default fail-closed
+        // (withhold the token) rather than fail-open (leak it to a foreign host).
+        if (!locationHref) return false
         const docOrigin = new URL(locationHref).origin
         const apiOrigin = new URL(apiBaseURL || locationHref, locationHref).origin
         const target = new URL(uploadURL, locationHref).origin
         return target === apiOrigin || target === docOrigin
     } catch {
-        return true // URL-parse failure: conservative, keep token
+        return false // URL-parse failure: fail-closed, withhold token
     }
 }
 

--- a/packages/dmworkbase/src/Service/UploadCredentials.ts
+++ b/packages/dmworkbase/src/Service/UploadCredentials.ts
@@ -3,6 +3,33 @@ import axios from "axios"
 import APIClient, { extractErrorMsg } from "./APIClient"
 import { t } from "../i18n"
 
+// Isolated axios instance — carries NONE of the global request interceptors.
+// The shared axios has a request interceptor (APIClient.initAxios) that injects
+// the Octo session token into every outgoing request.  COS pre-signed upload
+// URLs are foreign-origin; sending the token there causes 403/400 (unexpected
+// header conflicts with the pre-signed signature).  This mirrors the pattern
+// used in packages/dmworkdatasource/src/task.ts and datasource.ts (uploadSticker).
+const noInterceptorAxios = axios.create({ timeout: 10 * 60 * 1000 }) // 10 min ceiling
+
+/**
+ * Return true iff uploadURL should receive the Octo session token, i.e. it
+ * shares its origin with the API base URL or the document origin.
+ * Inlined from dmworkdatasource/src/datasource.ts to avoid a cross-package
+ * import (dmworkbase does not depend on dmworkdatasource).
+ */
+function shouldAttachToken(uploadURL: string, apiBaseURL: string): boolean {
+    try {
+        const locationHref = typeof window !== "undefined" ? window.location.href : ""
+        if (!locationHref) return true // non-browser: conservative, keep token
+        const docOrigin = new URL(locationHref).origin
+        const apiOrigin = new URL(apiBaseURL || locationHref, locationHref).origin
+        const target = new URL(uploadURL, locationHref).origin
+        return target === apiOrigin || target === docOrigin
+    } catch {
+        return true // URL-parse failure: conservative, keep token
+    }
+}
+
 interface UploadCredentials {
     uploadUrl: string
     downloadUrl: string
@@ -110,8 +137,13 @@ export async function uploadChatMedia(
         headers["Content-Disposition"] = credentials.contentDisposition
     }
 
+    // Use the isolated axios instance (no token injected) when the upload target
+    // is a foreign origin (e.g. COS pre-signed URL).  Mirrors task.ts / datasource.ts.
+    const apiBaseURL = APIClient.shared.config.apiURL
+    const client = shouldAttachToken(credentials.uploadUrl, apiBaseURL) ? axios : noInterceptorAxios
+
     try {
-        const resp = await axios.put(credentials.uploadUrl, file, { headers, timeout: timeoutMs })
+        const resp = await client.put(credentials.uploadUrl, file, { headers, timeout: timeoutMs })
         if (!(resp.status >= 200 && resp.status < 300)) {
             throwWithMsg(t("base.conversation.upload.failed"))
         }

--- a/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
@@ -2,8 +2,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import axios from "axios"
 import { Channel, ChannelTypePerson } from "wukongimjssdk"
 import APIClient from "../APIClient"
-import { precheckUploadCredentials, uploadChatMedia } from "../UploadCredentials"
+import { precheckUploadCredentials, uploadChatMedia, noInterceptorAxios } from "../UploadCredentials"
 import { i18n } from "../../i18n"
+
+// Block the barrel re-export paths that transitively pull in lottie-web / Semi-UI
+// canvas initialisers, which crash under jsdom ("Cannot set properties of null").
+// These stubs are enough for the tests in this file.
+vi.mock("../../i18n", () => ({
+    i18n: {
+        setLocale: vi.fn(),
+        t: (key: string) => key,
+        locale: "zh-CN",
+    },
+    // Map the keys used by UploadCredentials.ts to their Chinese strings so that
+    // the message-text assertions continue to match after the i18n mock.
+    t: (key: string): string => {
+        const map: Record<string, string> = {
+            "base.uploadCredentials.missingFields": "响应缺少凭证字段",
+            "base.uploadCredentials.failed": "上传凭证获取失败",
+            "base.conversation.upload.failed": "上传失败",
+        }
+        return map[key] ?? key
+    },
+}))
+vi.mock("@douyinfe/semi-ui", () => ({}))
+vi.mock("lottie-web", () => ({}))
 
 /**
  * GH Mininglamp-OSS/octo-web#119 / #135 — preflight credentials helper.
@@ -125,64 +148,53 @@ describe("uploadChatMedia — token isolation (COS pre-signed URL)", () => {
         contentType: "image/jpeg",
     })
 
-    // noInterceptorAxios is created once at module-load time via axios.create().
-    // We need a handle on that instance's .put to assert it was (or wasn't) called.
-    // Strategy: spy on axios.create so the module captures our stub instance;
-    // the module is already loaded, so we re-import with vi.isolateModules to
-    // get a fresh binding with the stubbed create, scoped to this describe block.
-    let mockNoInterceptorPut: ReturnType<typeof vi.fn>
-    let uploadChatMediaIsolated: typeof uploadChatMedia
-    let createSpy: ReturnType<typeof vi.spyOn>
+    // noInterceptorAxios is the module-level interceptor-free axios instance.
+    // It is now exported (@internal) so we can spy on it directly without
+    // module re-isolation.  This replaces the vi.isolateModules approach that
+    // was removed in Vitest 4.
 
-    beforeEach(async () => {
-        i18n.setLocale("zh-CN", { notify: false, persist: false })
+    beforeEach(() => {
         APIClient.shared.config.apiURL = "https://api.example.com/"
-
-        mockNoInterceptorPut = vi.fn().mockResolvedValue({ status: 200, data: {} })
-        // Spy on axios.create so the next module-load captures our stub instance.
-        createSpy = vi.spyOn(axios, "create").mockReturnValue(
-            { put: mockNoInterceptorPut } as any
-        )
-        // Re-import the module under test so its module-level noInterceptorAxios
-        // is the stub we just configured.
-        await vi.isolateModules(async () => {
-            const mod = await import("../UploadCredentials")
-            uploadChatMediaIsolated = mod.uploadChatMedia
-        })
-    })
-
-    afterEach(() => {
-        createSpy.mockRestore()
     })
 
     it("uses noInterceptorAxios (no token) for foreign-origin COS upload URL", async () => {
         const cosUrl = "https://bucket.cos.ap-shanghai.myqcloud.com/1/u-test/abc.jpg"
         const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(cosUrl))
+        // Spy on the exported no-interceptor instance — the production code will call
+        // noInterceptorAxios.put for foreign-origin URLs.
+        const noInterceptorPutSpy = vi
+            .spyOn(noInterceptorAxios, "put")
+            .mockResolvedValue({ status: 200, data: {} })
         const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
 
-        const result = await uploadChatMediaIsolated(fakeFile(), fakeChannel, "jpg")
+        const result = await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
 
         // The isolated (no-interceptor) instance must handle the PUT — not global axios
-        expect(mockNoInterceptorPut).toHaveBeenCalledOnce()
+        expect(noInterceptorPutSpy).toHaveBeenCalledOnce()
         expect(globalPutSpy).not.toHaveBeenCalled()
         expect(result).toBe("https://cdn.example.com/file.jpg")
 
         getStub.mockRestore()
+        noInterceptorPutSpy.mockRestore()
         globalPutSpy.mockRestore()
     })
 
     it("uses global axios (with token) for same-origin upload URL", async () => {
         const sameOriginUrl = "https://api.example.com/upload/1/u-test/abc.jpg"
         const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(sameOriginUrl))
+        const noInterceptorPutSpy = vi
+            .spyOn(noInterceptorAxios, "put")
+            .mockResolvedValue({ status: 200, data: {} })
         const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
 
-        await uploadChatMediaIsolated(fakeFile(), fakeChannel, "jpg")
+        await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
 
         // Same-origin: global axios carries the session token — correct
         expect(globalPutSpy).toHaveBeenCalledOnce()
-        expect(mockNoInterceptorPut).not.toHaveBeenCalled()
+        expect(noInterceptorPutSpy).not.toHaveBeenCalled()
 
         getStub.mockRestore()
+        noInterceptorPutSpy.mockRestore()
         globalPutSpy.mockRestore()
     })
 })

--- a/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
@@ -125,24 +125,46 @@ describe("uploadChatMedia — token isolation (COS pre-signed URL)", () => {
         contentType: "image/jpeg",
     })
 
-    beforeEach(() => {
+    // noInterceptorAxios is created once at module-load time via axios.create().
+    // We need a handle on that instance's .put to assert it was (or wasn't) called.
+    // Strategy: spy on axios.create so the module captures our stub instance;
+    // the module is already loaded, so we re-import with vi.isolateModules to
+    // get a fresh binding with the stubbed create, scoped to this describe block.
+    let mockNoInterceptorPut: ReturnType<typeof vi.fn>
+    let uploadChatMediaIsolated: typeof uploadChatMedia
+    let createSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(async () => {
         i18n.setLocale("zh-CN", { notify: false, persist: false })
         APIClient.shared.config.apiURL = "https://api.example.com/"
+
+        mockNoInterceptorPut = vi.fn()
+        // Spy on axios.create so the next module-load captures our stub instance.
+        createSpy = vi.spyOn(axios, "create").mockReturnValue(
+            { put: mockNoInterceptorPut } as any
+        )
+        // Re-import the module under test so its module-level noInterceptorAxios
+        // is the stub we just configured.
+        await vi.isolateModules(async () => {
+            const mod = await import("../UploadCredentials")
+            uploadChatMediaIsolated = mod.uploadChatMedia
+        })
+    })
+
+    afterEach(() => {
+        createSpy.mockRestore()
     })
 
     it("uses noInterceptorAxios (no token) for foreign-origin COS upload URL", async () => {
-        // Arrange: APIClient.get returns COS pre-signed credentials
         const cosUrl = "https://bucket.cos.ap-shanghai.myqcloud.com/1/u-test/abc.jpg"
         const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(cosUrl))
-
-        // Capture all axios.put calls at the global level
         const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
 
-        const result = await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
+        const result = await uploadChatMediaIsolated(fakeFile(), fakeChannel, "jpg")
 
-        // Global axios.put must NOT have been called (token would leak to COS)
+        // The isolated (no-interceptor) instance must handle the PUT — not global axios
+        expect(mockNoInterceptorPut).toHaveBeenCalledOnce()
         expect(globalPutSpy).not.toHaveBeenCalled()
-        // Result must be the downloadUrl from credentials
         expect(result).toBe("https://cdn.example.com/file.jpg")
 
         getStub.mockRestore()
@@ -150,16 +172,15 @@ describe("uploadChatMedia — token isolation (COS pre-signed URL)", () => {
     })
 
     it("uses global axios (with token) for same-origin upload URL", async () => {
-        // jsdom sets window.location.href to 'http://localhost/'
-        // Use a same-origin upload URL relative to the API base
         const sameOriginUrl = "https://api.example.com/upload/1/u-test/abc.jpg"
         const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(sameOriginUrl))
         const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
 
-        await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
+        await uploadChatMediaIsolated(fakeFile(), fakeChannel, "jpg")
 
         // Same-origin: global axios carries the session token — correct
         expect(globalPutSpy).toHaveBeenCalledOnce()
+        expect(mockNoInterceptorPut).not.toHaveBeenCalled()
 
         getStub.mockRestore()
         globalPutSpy.mockRestore()

--- a/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import axios from "axios"
 import { Channel, ChannelTypePerson } from "wukongimjssdk"
 import APIClient from "../APIClient"
-import { precheckUploadCredentials } from "../UploadCredentials"
+import { precheckUploadCredentials, uploadChatMedia } from "../UploadCredentials"
 import { i18n } from "../../i18n"
 
 /**
@@ -108,5 +108,60 @@ describe("precheckUploadCredentials", () => {
             expect(typeof msg).toBe("string")
             expect(msg!.length).toBeGreaterThan(0)
         }
+    })
+})
+
+// ---------------------------------------------------------------------------
+// uploadChatMedia — token isolation
+// ---------------------------------------------------------------------------
+describe("uploadChatMedia — token isolation (COS pre-signed URL)", () => {
+    const fakeChannel = new Channel("u-test", ChannelTypePerson)
+    const fakeFile = (name = "photo.jpg", type = "image/jpeg", size = 1024): File =>
+        new File([new Uint8Array(size)], name, { type })
+
+    const makeCreds = (uploadUrl: string) => ({
+        uploadUrl,
+        downloadUrl: "https://cdn.example.com/file.jpg",
+        contentType: "image/jpeg",
+    })
+
+    beforeEach(() => {
+        i18n.setLocale("zh-CN", { notify: false, persist: false })
+        APIClient.shared.config.apiURL = "https://api.example.com/"
+    })
+
+    it("uses noInterceptorAxios (no token) for foreign-origin COS upload URL", async () => {
+        // Arrange: APIClient.get returns COS pre-signed credentials
+        const cosUrl = "https://bucket.cos.ap-shanghai.myqcloud.com/1/u-test/abc.jpg"
+        const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(cosUrl))
+
+        // Capture all axios.put calls at the global level
+        const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
+
+        const result = await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
+
+        // Global axios.put must NOT have been called (token would leak to COS)
+        expect(globalPutSpy).not.toHaveBeenCalled()
+        // Result must be the downloadUrl from credentials
+        expect(result).toBe("https://cdn.example.com/file.jpg")
+
+        getStub.mockRestore()
+        globalPutSpy.mockRestore()
+    })
+
+    it("uses global axios (with token) for same-origin upload URL", async () => {
+        // jsdom sets window.location.href to 'http://localhost/'
+        // Use a same-origin upload URL relative to the API base
+        const sameOriginUrl = "https://api.example.com/upload/1/u-test/abc.jpg"
+        const getStub = vi.spyOn(APIClient.shared, "get").mockResolvedValue(makeCreds(sameOriginUrl))
+        const globalPutSpy = vi.spyOn(axios, "put").mockResolvedValue({ status: 200, data: {} })
+
+        await uploadChatMedia(fakeFile(), fakeChannel, "jpg")
+
+        // Same-origin: global axios carries the session token — correct
+        expect(globalPutSpy).toHaveBeenCalledOnce()
+
+        getStub.mockRestore()
+        globalPutSpy.mockRestore()
     })
 })

--- a/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UploadCredentials.test.ts
@@ -138,7 +138,7 @@ describe("uploadChatMedia — token isolation (COS pre-signed URL)", () => {
         i18n.setLocale("zh-CN", { notify: false, persist: false })
         APIClient.shared.config.apiURL = "https://api.example.com/"
 
-        mockNoInterceptorPut = vi.fn()
+        mockNoInterceptorPut = vi.fn().mockResolvedValue({ status: 200, data: {} })
         // Spy on axios.create so the next module-load captures our stub instance.
         createSpy = vi.spyOn(axios, "create").mockReturnValue(
             { put: mockNoInterceptorPut } as any

--- a/packages/dmworkdatasource/src/task.test.ts
+++ b/packages/dmworkdatasource/src/task.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
 
-// vi.hoisted runs before vi.mock hoisting, so these are available in factories
-const { TaskStatus, mockApiGet } = vi.hoisted(() => ({
+// Shared mock for the isolated (no-interceptor) axios instance created by task.ts.
+// vi.hoisted ensures this runs before vi.mock factories so the factory can
+// reference it.  task.ts calls axios.create() at module-load time; we capture
+// the returned mock via the factory below.
+const { TaskStatus, mockApiGet, mockNoInterceptorAxiosPut } = vi.hoisted(() => ({
   TaskStatus: {
     wait: 0,
     success: 1,
@@ -12,6 +15,7 @@ const { TaskStatus, mockApiGet } = vi.hoisted(() => ({
     cancel: 5,
   } as const,
   mockApiGet: vi.fn(),
+  mockNoInterceptorAxiosPut: vi.fn(),
 }))
 
 vi.mock('wukongimjssdk', () => {
@@ -34,12 +38,26 @@ vi.mock('@octo/base', () => ({
   WKApp: {
     apiClient: {
       get: (...args: any[]) => mockApiGet(...args),
+      config: { apiURL: 'https://api.example.com/' },
     },
   },
 }))
 
+// Mock datasource so we can control shouldAttachUploadToken.
+// Default: return false (foreign-origin upload URL) — the common production
+// case where files are uploaded directly to COS.
+const mockShouldAttach = vi.fn().mockReturnValue(false)
+vi.mock('./datasource', () => ({
+  shouldAttachUploadToken: (...args: any[]) => mockShouldAttach(...args),
+}))
+
 vi.mock('axios', () => ({
-  default: { put: vi.fn() },
+  default: {
+    put: vi.fn(),
+    // task.ts calls axios.create() at module load to build noInterceptorAxios.
+    // Return a stub whose .put we can inspect independently of the global put.
+    create: vi.fn(() => ({ put: mockNoInterceptorAxiosPut })),
+  },
 }))
 
 // --- Import under test (after mocks) ---
@@ -79,19 +97,23 @@ function createTask(fileOrNull: File | null = makeFile(), remoteUrl = ''): Media
 describe('MediaMessageUploadTask', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: foreign-origin upload URL (COS) — noInterceptorAxios should be used.
+    mockShouldAttach.mockReturnValue(false)
+    // Make noInterceptorAxios.put succeed by default so existing tests keep passing.
+    mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
   })
 
   describe('start() — normal upload flow', () => {
     it('sets status=success when upload succeeds', async () => {
       const creds = makeCredentials()
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const task = createTask()
       await task.start()
 
       expect(mockApiGet).toHaveBeenCalledOnce()
-      expect(axios.put).toHaveBeenCalledOnce()
+      expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
       expect(task.status).toBe(TaskStatus.success)
       expect((task.message.content as any).remoteUrl).toBe(creds.downloadUrl)
     })
@@ -99,7 +121,7 @@ describe('MediaMessageUploadTask', () => {
     it('sets both content.url and content.remoteUrl on success', async () => {
       const creds = makeCredentials()
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const task = createTask()
       await task.start()
@@ -146,7 +168,7 @@ describe('MediaMessageUploadTask', () => {
     it('sets status=fail when axios.put rejects', async () => {
       const creds = makeCredentials()
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockRejectedValue(new Error('ECONNRESET'))
+      mockNoInterceptorAxiosPut.mockRejectedValue(new Error('ECONNRESET'))
 
       const task = createTask()
       await task.start()
@@ -159,7 +181,7 @@ describe('MediaMessageUploadTask', () => {
     it('sets status=fail when response status is 403', async () => {
       const creds = makeCredentials()
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 403, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 403, data: {} })
 
       const task = createTask()
       await task.start()
@@ -174,7 +196,7 @@ describe('MediaMessageUploadTask', () => {
       mockApiGet.mockResolvedValue(creds)
 
       let abortSignal: AbortSignal | undefined
-      vi.mocked(axios.put).mockImplementation((_url: any, _data: any, config: any) => {
+      mockNoInterceptorAxiosPut.mockImplementation((_url: any, _data: any, config: any) => {
         abortSignal = config?.signal
         return new Promise(() => {}) // hang forever
       })
@@ -183,7 +205,7 @@ describe('MediaMessageUploadTask', () => {
       const startPromise = task.start()
 
       // Wait for axios.put to be called
-      await vi.waitFor(() => expect(axios.put).toHaveBeenCalled())
+      await vi.waitFor(() => expect(mockNoInterceptorAxiosPut).toHaveBeenCalled())
 
       task.cancel()
       expect(task.status).toBe(TaskStatus.cancel)
@@ -195,7 +217,7 @@ describe('MediaMessageUploadTask', () => {
       mockApiGet.mockResolvedValue(creds)
 
       // Simulate abort rejection
-      vi.mocked(axios.put).mockImplementation((_url: any, _data: any, config: any) => {
+      mockNoInterceptorAxiosPut.mockImplementation((_url: any, _data: any, config: any) => {
         return new Promise((_, reject) => {
           config?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
         })
@@ -204,7 +226,7 @@ describe('MediaMessageUploadTask', () => {
       const task = createTask()
       const startPromise = task.start()
 
-      await vi.waitFor(() => expect(axios.put).toHaveBeenCalled())
+      await vi.waitFor(() => expect(mockNoInterceptorAxiosPut).toHaveBeenCalled())
 
       task.cancel()
       // Let microtasks settle (catch handler runs)
@@ -219,7 +241,7 @@ describe('MediaMessageUploadTask', () => {
     it('re-fetches credentials and uploads again', async () => {
       const creds = makeCredentials()
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const task = createTask()
       task.status = TaskStatus.fail
@@ -227,7 +249,7 @@ describe('MediaMessageUploadTask', () => {
       await task.restart()
 
       expect(mockApiGet).toHaveBeenCalledOnce()
-      expect(axios.put).toHaveBeenCalledOnce()
+      expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
       expect(task.status).toBe(TaskStatus.success)
     })
 
@@ -244,7 +266,7 @@ describe('MediaMessageUploadTask', () => {
   describe('file.name empty fallback', () => {
     it('uses "file" when file.name is empty', async () => {
       mockApiGet.mockResolvedValue(makeCredentials())
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const file = makeFile('', 'application/octet-stream')
       const task = createTask(file)
@@ -260,12 +282,12 @@ describe('MediaMessageUploadTask', () => {
     it('includes Content-Disposition when present in credentials', async () => {
       const creds = makeCredentials({ contentDisposition: 'attachment; filename="photo.jpg"' })
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const task = createTask()
       await task.start()
 
-      const putCall = vi.mocked(axios.put).mock.calls[0]
+      const putCall = mockNoInterceptorAxiosPut.mock.calls[0]
       const headers = putCall[2]?.headers as Record<string, string>
       expect(headers['Content-Disposition']).toBe('attachment; filename="photo.jpg"')
     })
@@ -274,12 +296,12 @@ describe('MediaMessageUploadTask', () => {
       const creds = makeCredentials()
       delete (creds as any).contentDisposition
       mockApiGet.mockResolvedValue(creds)
-      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
       const task = createTask()
       await task.start()
 
-      const putCall = vi.mocked(axios.put).mock.calls[0]
+      const putCall = mockNoInterceptorAxiosPut.mock.calls[0]
       const headers = putCall[2]?.headers as Record<string, string>
       expect(headers['Content-Disposition']).toBeUndefined()
     })
@@ -306,6 +328,38 @@ describe('MediaMessageUploadTask', () => {
     it('returns 0 initially', () => {
       const task = createTask()
       expect(task.progress()).toBe(0)
+    })
+  })
+
+  describe('token isolation — COS pre-signed upload URL', () => {
+    it('uses noInterceptorAxios (not global axios) for foreign-origin upload URLs', async () => {
+      // Arrange: foreign-origin COS URL
+      mockShouldAttach.mockReturnValue(false)
+      const creds = makeCredentials({ uploadUrl: 'https://bucket.cos.ap-shanghai.myqcloud.com/file.jpg' })
+      mockApiGet.mockResolvedValue(creds)
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
+
+      const task = createTask()
+      await task.start()
+
+      // The isolated instance must be used — not global axios.put
+      expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
+      expect(axios.put).not.toHaveBeenCalled()
+    })
+
+    it('uses global axios for same-origin upload URLs', async () => {
+      // Arrange: same-origin URL (self-hosted storage)
+      mockShouldAttach.mockReturnValue(true)
+      const creds = makeCredentials({ uploadUrl: 'https://api.example.com/upload/file.jpg' })
+      mockApiGet.mockResolvedValue(creds)
+      vi.mocked(axios.put).mockResolvedValue({ status: 200, data: {} })
+
+      const task = createTask()
+      await task.start()
+
+      // Global axios carries the session token — correct for same-origin
+      expect(axios.put).toHaveBeenCalledOnce()
+      expect(mockNoInterceptorAxiosPut).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/dmworkdatasource/src/task.test.ts
+++ b/packages/dmworkdatasource/src/task.test.ts
@@ -363,21 +363,36 @@ describe('MediaMessageUploadTask', () => {
     })
 
     it('empty locationHref (non-browser): fail-closed — noInterceptorAxios, no token leaked', async () => {
-      // Mirror datasource.ts: !!locationHref && shouldAttachUploadToken
-      // When locationHref is empty, shouldAttachUploadToken is never reached;
-      // the overall expression is false → noInterceptorAxios (fail-closed).
-      // Here we simulate that by having mockShouldAttach return based on href.
-      mockShouldAttach.mockImplementation((_url: string, _api: string, href: string) => !!href)
-      const creds = makeCredentials({ uploadUrl: 'https://bucket.cos.ap-shanghai.myqcloud.com/file.jpg' })
-      mockApiGet.mockResolvedValue(creds)
-      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
+      // Production code: !!locationHref && shouldAttachUploadToken(url, api, locationHref)
+      // When locationHref is empty the &&-short-circuit fires before shouldAttachUploadToken
+      // is called — useSameOriginAxios=false → noInterceptorAxios (fail-closed).
+      // jsdom sets window.location.href = 'http://localhost/' (truthy) by default, so we
+      // must stub it to empty to actually exercise the short-circuit branch.
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: { href: '' },
+      })
+      try {
+        const creds = makeCredentials({ uploadUrl: 'https://bucket.cos.ap-shanghai.myqcloud.com/file.jpg' })
+        mockApiGet.mockResolvedValue(creds)
+        mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
 
-      const task = createTask()
-      await task.start()
+        const task = createTask()
+        await task.start()
 
-      // noInterceptorAxios must be used — token withheld (fail-closed)
-      expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
-      expect(axios.put).not.toHaveBeenCalled()
+        // With empty locationHref the !!locationHref guard fires — noInterceptorAxios
+        // must be chosen (fail-closed: token withheld regardless of upload URL)
+        expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
+        expect(axios.put).not.toHaveBeenCalled()
+      } finally {
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          writable: true,
+          value: originalLocation,
+        })
+      }
     })
   })
 })

--- a/packages/dmworkdatasource/src/task.test.ts
+++ b/packages/dmworkdatasource/src/task.test.ts
@@ -361,5 +361,23 @@ describe('MediaMessageUploadTask', () => {
       expect(axios.put).toHaveBeenCalledOnce()
       expect(mockNoInterceptorAxiosPut).not.toHaveBeenCalled()
     })
+
+    it('empty locationHref (non-browser): fail-closed — noInterceptorAxios, no token leaked', async () => {
+      // Mirror datasource.ts: !!locationHref && shouldAttachUploadToken
+      // When locationHref is empty, shouldAttachUploadToken is never reached;
+      // the overall expression is false → noInterceptorAxios (fail-closed).
+      // Here we simulate that by having mockShouldAttach return based on href.
+      mockShouldAttach.mockImplementation((_url: string, _api: string, href: string) => !!href)
+      const creds = makeCredentials({ uploadUrl: 'https://bucket.cos.ap-shanghai.myqcloud.com/file.jpg' })
+      mockApiGet.mockResolvedValue(creds)
+      mockNoInterceptorAxiosPut.mockResolvedValue({ status: 200, data: {} })
+
+      const task = createTask()
+      await task.start()
+
+      // noInterceptorAxios must be used — token withheld (fail-closed)
+      expect(mockNoInterceptorAxiosPut).toHaveBeenCalledOnce()
+      expect(axios.put).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/dmworkdatasource/src/task.ts
+++ b/packages/dmworkdatasource/src/task.ts
@@ -80,7 +80,10 @@ export class MediaMessageUploadTask extends MessageTask {
         // datasource.ts uploadSticker.
         const locationHref = typeof window !== "undefined" ? window.location.href : ""
         const apiBaseURL = WKApp.apiClient.config.apiURL
-        const useSameOriginAxios = !locationHref ||
+        // Mirror datasource.ts uploadSticker exactly: !!locationHref && shouldAttachUploadToken.
+        // When locationHref is empty (non-browser / origin undetermined), default to
+        // noInterceptorAxios (fail-closed: withhold the token rather than leak it).
+        const useSameOriginAxios = !!locationHref &&
             shouldAttachUploadToken(credentials.uploadUrl, apiBaseURL, locationHref)
         const client = useSameOriginAxios ? axios : noInterceptorAxios
         const resp = await client.put(credentials.uploadUrl, file, {

--- a/packages/dmworkdatasource/src/task.ts
+++ b/packages/dmworkdatasource/src/task.ts
@@ -2,6 +2,17 @@ import { WKApp } from "@octo/base";
 import axios from "axios";
 import { MediaMessageContent } from "wukongimjssdk";
 import {  MessageTask, TaskStatus } from "wukongimjssdk";
+import { shouldAttachUploadToken } from "./datasource";
+
+// Isolated axios instance: carries NONE of the global request interceptors.
+// The shared `axios` has an interceptor (APIClient) that injects the Octo
+// session token into EVERY outgoing request.  The COS pre-signed upload URL
+// is a *foreign-origin* endpoint — sending the token there causes COS to
+// reject the request with 403/400 (unexpected Authorization header on a
+// pre-signed URL).  datasource.ts already guards uploadSticker with the same
+// pattern; this instance mirrors that fix for chat-file uploads.
+// A finite timeout avoids hanging on an unreachable foreign host.
+const noInterceptorAxios = axios.create({ timeout: 10 * 60 * 1000 })  // 10 min ceiling
 
 interface UploadCredentials {
     uploadUrl: string
@@ -54,14 +65,25 @@ export class MediaMessageUploadTask extends MessageTask {
     }
 
     async uploadFile(file: File, credentials: UploadCredentials) {
-        // 动态超时：每 MB 预留 10 秒，最低 2 分钟兜底
+        // Dynamic timeout: 10 s/MB, minimum 2 min, so a 40 MB file gets ~6 min 40 s.
         const fileSizeMB = file.size / (1024 * 1024);
         const timeoutMs = Math.max(2 * 60 * 1000, fileSizeMB * 10 * 1000);
         const headers: Record<string, string> = { "Content-Type": credentials.contentType }
         if (credentials.contentDisposition) {
             headers["Content-Disposition"] = credentials.contentDisposition
         }
-        const resp = await axios.put(credentials.uploadUrl, file, {
+        // Use the isolated axios instance (no token injected) when the upload
+        // target is a foreign origin (e.g. COS pre-signed URL).  Sending the
+        // Octo session token to a third-party host causes 403/400 rejections
+        // because COS treats any unexpected Authorization/token header on a
+        // pre-signed URL as a conflict.  Mirror the same origin-check used by
+        // datasource.ts uploadSticker.
+        const locationHref = typeof window !== "undefined" ? window.location.href : ""
+        const apiBaseURL = WKApp.apiClient.config.apiURL
+        const useSameOriginAxios = !locationHref ||
+            shouldAttachUploadToken(credentials.uploadUrl, apiBaseURL, locationHref)
+        const client = useSameOriginAxios ? axios : noInterceptorAxios
+        const resp = await client.put(credentials.uploadUrl, file, {
             headers,
             signal: (this.controller = new AbortController()).signal,
             timeout: timeoutMs,


### PR DESCRIPTION
## Problem

Large file uploads (e.g. 40 MB) silently fail. The upload task shows a progress bar briefly then flips to error state with no useful message.

**Root cause:** `MediaMessageUploadTask.uploadFile()` uses the global `axios` instance for the `PUT` to the COS pre-signed upload URL. `APIClient.initAxios()` registers a global request interceptor that unconditionally injects the Octo session `token` header into **every** outgoing request — including to foreign-origin hosts. COS pre-signed URLs are self-contained credentials; an unexpected `token` header conflicts with the URL signing and causes COS to return `403`/`400`, aborting the upload. Smaller files may slip through before the connection is dropped; larger files reliably fail because COS rejects the signed URL on the first byte.

The same bug was already fixed for `uploadSticker` in `datasource.ts` using `noInterceptorAxios` + `shouldAttachUploadToken`, but `MediaMessageUploadTask` never adopted that pattern.

## Fix

Mirror the `datasource.ts` approach in `task.ts`:

1. Add a module-level `noInterceptorAxios = axios.create(...)` instance (no interceptors, 10 min timeout ceiling).
2. In `uploadFile()`, call `shouldAttachUploadToken()` to determine origin relationship:
   - **Foreign origin (COS/S3):** use `noInterceptorAxios` — no token leaked
   - **Same origin (self-hosted storage):** use global `axios` — token attached as before
3. The existing dynamic per-file timeout (`max(2 min, sizeMB × 10 s)`) is preserved on both paths.

## Tests

- Existing tests updated to route through `noInterceptorAxios` (the new default for foreign-origin URLs)
- Two new cases assert the correct axios instance is selected based on `shouldAttachUploadToken` return value

## Affected file

`packages/dmworkdatasource/src/task.ts`