### PR TITLE
feat(loop): new-issue project picker, workspace-default teammate, remove dead daemon-version handling

### DIFF
--- a/packages/dmloop/src/api/http.ts
+++ b/packages/dmloop/src/api/http.ts
@@ -66,7 +66,7 @@ client.interceptors.request.use((config) => {
 /* ---------- 结构化错误（供页面展示异常态） ---------- */
 export class LoopApiError extends Error {
   status?: number;
-  code?: string; // 后端结构化错误码(如 quick-create 的 agent_unavailable / daemon_version_unsupported)
+  code?: string; // 后端结构化错误码(如 quick-create 的 agent_unavailable)
   constructor(message: string, status?: number, code?: string) {
     super(message);
     this.name = "LoopApiError";

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -675,7 +675,6 @@
     "dispatch": "Dispatch",
     "dispatched": "Dispatched",
     "agentUnavailable": "That AI teammate is offline right now, so it can't be dispatched — wait for it to come online, or pick one that's online.",
-    "daemonUnsupported": "That AI teammate's runtime is too old to dispatch safely — please upgrade its runtime and try again.",
     "attachFailedAbort": "{{count}} attachment(s) failed to upload, so dispatch was cancelled — attachments are the AI's context; please retry.",
     "manualSwitch": "Create manually · assign to a person",
     "examplesTitle": "Start from an example",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -675,7 +675,6 @@
     "dispatch": "派单",
     "dispatched": "已派单",
     "agentUnavailable": "AI 队友当前不在线，无法派单——请等它上线，或换一个在线的队友。",
-    "daemonUnsupported": "AI 队友的运行环境版本过低，无法安全派单——请先升级它的运行时后重试。",
     "attachFailedAbort": "有 {{count}} 个附件上传失败，已取消派单——附件是 AI 的上下文，请重试。",
     "manualSwitch": "手动建单 · 指派给人",
     "examplesTitle": "从一个例子开始",

--- a/packages/dmloop/src/pages/AgentPage.tsx
+++ b/packages/dmloop/src/pages/AgentPage.tsx
@@ -3,7 +3,7 @@ import { Typography, Input, Button, Select, Avatar, Spin, Modal, Toast, Banner }
 import LoopButton from "../ui/LoopButton";
 import { Search, Plus, Trash2, Bot, RotateCcw } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import type { Agent, AgentVisibility, RuntimeDevice } from "../api/types";
+import type { Agent, RuntimeDevice } from "../api/types";
 import { listAgents, createAgent, archiveAgent, restoreAgent, listRuntimesForAgent } from "../api/agentApi";
 import { listAssigneeCandidates } from "../api/issueApi";
 import AgentDetailPage from "../panel/AgentDetailPage";
@@ -29,7 +29,6 @@ export default function AgentPage() {
   const [nName, setNName] = useState("");
   const [nDesc, setNDesc] = useState("");
   const [nModel, setNModel] = useState("");
-  const [nVis, setNVis] = useState<AgentVisibility>("workspace");
   const [nRuntimeId, setNRuntimeId] = useState<string | undefined>();
   const [runtimes, setRuntimes] = useState<RuntimeDevice[]>([]);
 
@@ -77,7 +76,7 @@ export default function AgentPage() {
     if (!nName.trim()) { Toast.warning(t("loop.validate.nameRequired")); return; }
     if (!nRuntimeId) { Toast.warning(t("loop.agent.runtimeRequired")); return; }
     try {
-      await createAgent({ name: nName.trim(), description: nDesc, runtime_id: nRuntimeId, model: nModel || undefined, visibility: nVis });
+      await createAgent({ name: nName.trim(), description: nDesc, runtime_id: nRuntimeId, model: nModel || undefined, visibility: "workspace" });
       setCreateOpen(false); setNName(""); setNDesc("");
       Toast.success(t("loop.toast.created")); reload();
     } catch (e) { Toast.error((e as Error)?.message ?? "create failed"); }
@@ -177,13 +176,6 @@ export default function AgentPage() {
           <div className="loop-fields__row">
             <div className="loop-fields__label">{t("loop.agent.model")}</div>
             <input className="loop-field" value={nModel} onChange={(e) => setNModel(e.target.value)} placeholder="claude-opus-4 / codex-latest…" />
-          </div>
-          <div className="loop-fields__row">
-            <div className="loop-fields__label">{t("loop.agent.visibility")}</div>
-            <Select value={nVis} onChange={(v) => setNVis(v as AgentVisibility)} dropdownClassName="loop-fields__dropdown" style={{ width: "100%" }}>
-              <Select.Option value="workspace">{t("loop.agent.visWorkspace")}</Select.Option>
-              <Select.Option value="private">{t("loop.agent.visPrivate")}</Select.Option>
-            </Select>
           </div>
         </div>
       </Modal>

--- a/packages/dmloop/src/ui/CreateIssueModal.tsx
+++ b/packages/dmloop/src/ui/CreateIssueModal.tsx
@@ -4,6 +4,7 @@ import { ChevronRight, X, Paperclip } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { IssueStatus, IssuePriority, AssigneeType } from "../api/types";
 import { createIssue, listAssigneeCandidates } from "../api/issueApi";
+import { listProjectOptions } from "../api/directory";
 import { uploadAttachment } from "../api/attachmentApi";
 import { currentWorkspaceName } from "../api/http";
 import AssigneePicker from "./AssigneePicker";
@@ -53,6 +54,8 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
   const [desc, setDesc] = useState("");
   const [status, setStatus] = useState<IssueStatus>("todo");
   const [priority, setPriority] = useState<IssuePriority>("none");
+  const [projectId, setProjectId] = useState<string>("");
+  const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
   const [assigneeId, setAssigneeId] = useState<string | null>(null);
   const [assigneeType, setAssigneeType] = useState<AssigneeType | null>(null);
   const [assigneeName, setAssigneeName] = useState<string | null>(null);
@@ -61,10 +64,11 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
 
   useEffect(() => {
     if (!visible) return;
-    setTitle(""); setDesc(""); setStatus("todo"); setPriority("none"); setPendingFiles([]);
+    setTitle(""); setDesc(""); setStatus("todo"); setPriority("none"); setProjectId(""); setPendingFiles([]);
     setAssigneeId(null); setAssigneeType(null); setAssigneeName(null);
-    // 默认指派:优先复用上次选择(若仍是有效候选),否则落到我的第一个 AI队友(agent)。
     let alive = true;
+    listProjectOptions().then((ps) => { if (alive) setProjects(ps); }).catch(() => { if (alive) setProjects([]); });
+    // 默认指派:优先复用上次选择(若仍是有效候选),否则落到我的第一个 AI队友(agent)。
     listAssigneeCandidates()
       .then((cands) => {
         if (!alive) return;
@@ -108,6 +112,7 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
         priority,
         assignee_id: assigneeId,
         assignee_type: assigneeType,
+        project_id: projectId || null,
         parent_issue_id: parentIssueId,
         attachment_ids: attachmentIds,
       });
@@ -130,6 +135,10 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
     const Icon = PRIORITY_ICON[p];
     return { value: p, label: t(`loop.priority.${p}`), icon: <Icon size={14} style={{ color: PRIORITY_HEX[p] }} /> };
   });
+  const projectOptions: LoopPropertyPillOption<string>[] = [
+    { value: "", label: t("loop.field.noProject") },
+    ...projects.map((p) => ({ value: p.id, label: p.title })),
+  ];
 
   const wsName = currentWorkspaceName();
 
@@ -189,6 +198,7 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
             valueName={assigneeName}
             onChange={(id, type, name) => { setAssigneeId(id); setAssigneeType(type); setAssigneeName(name); }}
           />
+          <LoopPropertyPill value={projectId} options={projectOptions} onChange={setProjectId} ariaLabel={t("loop.field.project")} />
         </div>
 
         {pendingFiles.length > 0 && (


### PR DESCRIPTION
## Summary

Three small, frontend-only Loop (dmloop) changes, batched into one PR (15 lines across 5 files):

- **#764** — Add a **Project** selector pill to the New Loop (create issue) modal. Defaults to *No project* (`project_id = null`); reuses `listProjectOptions()` (cached directory, no extra request) + the existing `LoopPropertyPill` and `loop.field.project` / `loop.field.noProject` i18n keys. Submit sends `project_id: projectId || null`.
- **#763** — Remove the **Visibility** selector from the New AI Teammate modal; always create with `visibility: "workspace"`. The request contract is unchanged; only the UI control is removed. The detail page still displays visibility.
- **#747** — Remove dead `daemon_version_unsupported` handling: the unused i18n key `loop.newLoop.daemonUnsupported` (both locales) and a stale comment mention in `api/http.ts`. The backend gate was removed upstream, so this client branch was already unreachable.

## Files

- `packages/dmloop/src/ui/CreateIssueModal.tsx` (#764)
- `packages/dmloop/src/pages/AgentPage.tsx` (#763)
- `packages/dmloop/src/api/http.ts` + `i18n/{en-US,zh-CN}.json` (#747)

## Blast radius

- **Backend / contract:** none. `CreateIssueReq.project_id` already accepted (`string | null`); `createAgent` still receives `visibility`.
- **Types:** `AgentVisibility` type kept (still used by `types.ts` + the agent detail view); only the now-unused import in `AgentPage.tsx` was dropped.
- **i18n:** the removed key had **zero** remaining references (grep + `i18n:check` confirm); the agent-visibility display keys are untouched.
- Contained entirely in `packages/dmloop`; no shared/cross-module surface changed.

## Verification

- `pnpm i18n:check` — passed (locale keys healthy).
- `packages/dmloop` vitest — **52 passed** (10 files).
- Typecheck — the changed files are clean (any errors reported are pre-existing `react@17` type-resolution noise in `dmworkbase`, untouched here).
- **Real-env e2e** (dev workspace): New Loop modal now shows the **Project** pill (defaults to *No project*) alongside Status/Priority; New AI Teammate modal no longer shows the Visibility field; dispatch path unaffected; `grep daemon_version_unsupported|daemonUnsupported packages/dmloop` returns nothing.

## Review

- Adversarial code-review (correctness) + a separate simplification pass: both **clean** — no confirmed bugs, no simplification debt, comments net-reduced.
- A second adversarial pass via the external reviewer is **pending** (its gateway key hit a quota limit); it will be run and its result added as a comment once the key is restored. Given the diff is 15 trivial UI / dead-code lines, this is not expected to change the outcome.

Closes #764
Closes #763
Closes #747