### PR TITLE
perf(loop): reuse thread-reply index; load public CDN attachment URLs natively

### DIFF
--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -75,7 +75,7 @@ import LoopMarkdown from "../ui/LoopMarkdown";
 import AutoGrowTextarea from "../ui/AutoGrowTextarea";
 import CommentComposer, { type CommentComposerHandle } from "../ui/CommentComposer";
 import { useCommentTriggerPreview } from "../ui/useCommentTriggerPreview";
-import { collectThreadReplies } from "../ui/threadReplies";
+import { buildRepliesByParent, collectThreadReplies } from "../ui/threadReplies";
 import LoopAttachments from "../ui/LoopAttachments";
 import { confirmDelete } from "../ui/confirmDelete";
 import RunDetailModal from "./RunDetailModal";
@@ -717,7 +717,8 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
   // direct children: an agent reply nests under the member comment that
   // triggered it (a grandchild of the root), so direct-children-only would drop
   // every agent answer from the thread. See collectThreadReplies.
-  const repliesOf = (id: string) => collectThreadReplies(id, comments);
+  const repliesByParent = buildRepliesByParent(comments);
+  const repliesOf = (id: string) => collectThreadReplies(id, repliesByParent);
   const childrenDone = children.filter((c) => c.status === "done").length;
   // issue 附件区只显 issue 级(comment_id 为空);评论附件归各评论下,避免重复。
   const issueAtts = (issue.attachments ?? []).filter((a) => !a.comment_id);

--- a/packages/dmloop/src/ui/LoopAttachments.tsx
+++ b/packages/dmloop/src/ui/LoopAttachments.tsx
@@ -3,6 +3,7 @@ import { Paperclip } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { Attachment } from "../api/types";
 import { canPreviewInline } from "./attachmentPreview";
+import { isPublicAbsoluteUrl } from "./attachmentSrc";
 import { useAuthedAttachmentUrl, triggerAuthedDownload } from "./useAuthedAttachment";
 
 /**
@@ -31,6 +32,21 @@ function AuthedImage({ att }: { att: Attachment }) {
   return (
     <a href={url} target="_blank" rel="noreferrer" className="loop-att loop-att--img">
       <img src={url} alt={att.filename} />
+    </a>
+  );
+}
+
+/**
+ * A public (cross-origin absolute) download_url is a signed CDN link — publicly
+ * readable, so load it as a native <img src>: no auth is needed, and a
+ * cross-origin blob XHR would hit CORS. Only reached when the backend serves
+ * signed CDN URLs; the default site-relative (auth-only) download_url keeps the
+ * AuthedImage blob path.
+ */
+function NativeImage({ att }: { att: Attachment }) {
+  return (
+    <a href={att.download_url} target="_blank" rel="noreferrer" className="loop-att loop-att--img">
+      <img src={att.download_url} alt={att.filename} />
     </a>
   );
 }
@@ -77,10 +93,12 @@ export default function LoopAttachments({
   return (
     <div className="loop-atts">
       {attachments.map((a) =>
-        canPreviewInline(a.content_type) ? (
-          <AuthedImage key={a.id} att={a} />
-        ) : (
+        !canPreviewInline(a.content_type) ? (
           <AuthedDownload key={a.id} att={a} />
+        ) : isPublicAbsoluteUrl(a.download_url) ? (
+          <NativeImage key={a.id} att={a} />
+        ) : (
+          <AuthedImage key={a.id} att={a} />
         ),
       )}
     </div>

--- a/packages/dmloop/src/ui/__tests__/attachmentSrc.test.ts
+++ b/packages/dmloop/src/ui/__tests__/attachmentSrc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { attachmentIdFromSrc } from "../attachmentSrc";
+import { attachmentIdFromSrc, isPublicAbsoluteUrl } from "../attachmentSrc";
 
 const ID = "019f6039-eebb-72bf-8746-59e58476c47b";
 
@@ -27,5 +27,36 @@ describe("attachmentIdFromSrc", () => {
     expect(attachmentIdFromSrc("")).toBeNull();
     expect(attachmentIdFromSrc(null)).toBeNull();
     expect(attachmentIdFromSrc(undefined)).toBeNull();
+  });
+});
+
+describe("isPublicAbsoluteUrl", () => {
+  const APP = "http://localhost:3000";
+
+  it("is false for a site-relative (auth-only) download_url — keeps blob path", () => {
+    expect(isPublicAbsoluteUrl(`/api/attachments/${ID}/download`, APP)).toBe(false);
+  });
+
+  it("is false for an absolute same-origin URL", () => {
+    expect(isPublicAbsoluteUrl(`${APP}/api/attachments/${ID}/download`, APP)).toBe(false);
+  });
+
+  it("is true for a cross-origin absolute (signed CDN) URL — native <img>", () => {
+    expect(isPublicAbsoluteUrl("https://cdn.example.com/x.png?sig=abc", APP)).toBe(true);
+  });
+
+  it("is false for empty / nullish / unknown origin", () => {
+    expect(isPublicAbsoluteUrl("", APP)).toBe(false);
+    expect(isPublicAbsoluteUrl(null, APP)).toBe(false);
+    expect(isPublicAbsoluteUrl(undefined, APP)).toBe(false);
+    expect(isPublicAbsoluteUrl("https://cdn.example.com/x.png", "")).toBe(false);
+  });
+
+  // A hostile download_url must never become a native <a href>/<img src>:
+  // non-web schemes are rejected even though their "origin" differs from APP.
+  it("is false for javascript:/data:/blob: schemes", () => {
+    expect(isPublicAbsoluteUrl("javascript:alert(1)", APP)).toBe(false);
+    expect(isPublicAbsoluteUrl("data:text/html,<script>alert(1)</script>", APP)).toBe(false);
+    expect(isPublicAbsoluteUrl("blob:https://cdn.example.com/uuid", APP)).toBe(false);
   });
 });

--- a/packages/dmloop/src/ui/__tests__/threadReplies.test.ts
+++ b/packages/dmloop/src/ui/__tests__/threadReplies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { collectThreadReplies } from "../threadReplies";
+import { buildRepliesByParent, collectThreadReplies } from "../threadReplies";
 import type { IssueComment } from "../../api/types";
 
 function comment(
@@ -25,7 +25,7 @@ describe("collectThreadReplies", () => {
       comment("r1", "2026-07-14T10:01:00Z", "root"),
       comment("r2", "2026-07-14T10:02:00Z", "root"),
     ];
-    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+    expect(collectThreadReplies("root", buildRepliesByParent(comments)).map((c) => c.id)).toEqual([
       "r1",
       "r2",
     ]);
@@ -42,7 +42,7 @@ describe("collectThreadReplies", () => {
       comment("m2", "2026-07-14T10:42:27Z", "root"),
       comment("a2", "2026-07-14T10:43:10Z", "m2"), // agent reply to m2
     ];
-    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+    expect(collectThreadReplies("root", buildRepliesByParent(comments)).map((c) => c.id)).toEqual([
       "m1",
       "m2",
       "a1",
@@ -58,7 +58,7 @@ describe("collectThreadReplies", () => {
       comment("a1", "2026-07-14T10:05:00Z", "m1"), // slow answer
       comment("m2", "2026-07-14T10:02:00Z", "root"),
     ];
-    expect(collectThreadReplies("root", comments).map((c) => c.id)).toEqual([
+    expect(collectThreadReplies("root", buildRepliesByParent(comments)).map((c) => c.id)).toEqual([
       "m1",
       "m2",
       "a1",
@@ -72,6 +72,22 @@ describe("collectThreadReplies", () => {
       comment("y", "2026-07-14T10:02:00Z", "x"),
     ];
     // Cycle is unreachable from root → simply excluded, no hang.
-    expect(collectThreadReplies("root", comments)).toEqual([]);
+    expect(collectThreadReplies("root", buildRepliesByParent(comments))).toEqual([]);
+  });
+});
+
+describe("buildRepliesByParent", () => {
+  it("groups replies under their parent_id and skips roots", () => {
+    const comments = [
+      comment("root", "2026-07-14T10:00:00Z", null),
+      comment("r1", "2026-07-14T10:01:00Z", "root"),
+      comment("a1", "2026-07-14T10:02:00Z", "r1"),
+      comment("r2", "2026-07-14T10:03:00Z", "root"),
+    ];
+    const byParent = buildRepliesByParent(comments);
+    expect(byParent.get("root")!.map((c) => c.id)).toEqual(["r1", "r2"]);
+    expect(byParent.get("r1")!.map((c) => c.id)).toEqual(["a1"]);
+    // Roots (no parent_id) are never keyed.
+    expect(byParent.has("a1")).toBe(false);
   });
 });

--- a/packages/dmloop/src/ui/attachmentSrc.ts
+++ b/packages/dmloop/src/ui/attachmentSrc.ts
@@ -19,3 +19,32 @@ export function attachmentIdFromSrc(src: string | null | undefined): string | nu
   const m = ATTACHMENT_PATH_RE.exec(src);
   return m ? m[1]! : null;
 }
+
+/**
+ * Whether `src` is a public, cross-origin absolute URL. The backend only emits
+ * an absolute `download_url` when it is a signed public CDN link (CFSigner is
+ * configured); such a URL is publicly readable and loads natively — no auth
+ * blob fetch is needed, and a cross-origin XHR blob fetch would hit CORS. A
+ * site-relative `download_url` (the default, auth-only endpoint) is same-origin
+ * → false, so the current deployment always takes the authed blob path.
+ *
+ * Only `http:`/`https:` count: a `javascript:` / `data:` / `blob:` URL is
+ * rejected so a hostile `download_url` can never become a native `<a href>` /
+ * `<img src>` (defense in depth — download_url is backend-issued, not user text).
+ *
+ * `appOrigin` is injectable for tests; it defaults to the current window origin
+ * and returns false when the origin can't be determined (safe: keep authed path).
+ */
+export function isPublicAbsoluteUrl(
+  src: string | null | undefined,
+  appOrigin: string = typeof window !== "undefined" ? window.location.origin : "",
+): boolean {
+  if (!src || !appOrigin) return false;
+  try {
+    const u = new URL(src, appOrigin);
+    if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+    return u.origin !== appOrigin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/dmloop/src/ui/threadReplies.ts
+++ b/packages/dmloop/src/ui/threadReplies.ts
@@ -1,8 +1,25 @@
 import type { IssueComment } from "../api/types";
 
 /**
+ * Index replies by parent_id once. A page that renders many thread roots can
+ * build this map a single time and pass it to collectThreadReplies for each
+ * root, instead of rescanning every comment per root (was O(roots × comments)).
+ */
+export function buildRepliesByParent(comments: IssueComment[]): Map<string, IssueComment[]> {
+  const byParent = new Map<string, IssueComment[]>();
+  for (const c of comments) {
+    if (!c.parent_id) continue;
+    const list = byParent.get(c.parent_id) ?? [];
+    list.push(c);
+    byParent.set(c.parent_id, list);
+  }
+  return byParent;
+}
+
+/**
  * Collect every descendant reply of a thread root, flattened in chronological
- * order (created_at ASC, id tie-break).
+ * order (created_at ASC, id tie-break). Takes the parent→children index from
+ * buildRepliesByParent so callers build it once and reuse it across roots.
  *
  * A thread is not always two levels deep: an agent reply is stored with its
  * `parent_id` pointing at the specific comment that triggered it (a member's
@@ -15,20 +32,12 @@ import type { IssueComment } from "../api/types";
  */
 export function collectThreadReplies(
   rootId: string,
-  comments: IssueComment[],
+  repliesByParent: Map<string, IssueComment[]>,
 ): IssueComment[] {
-  const childrenByParent = new Map<string, IssueComment[]>();
-  for (const c of comments) {
-    if (!c.parent_id) continue;
-    const list = childrenByParent.get(c.parent_id) ?? [];
-    list.push(c);
-    childrenByParent.set(c.parent_id, list);
-  }
-
   const out: IssueComment[] = [];
   const seen = new Set<string>();
   const walk = (id: string) => {
-    for (const child of childrenByParent.get(id) ?? []) {
+    for (const child of repliesByParent.get(id) ?? []) {
       // Guard against a parent_id cycle (self- or mutual reference): a bad
       // write must not spin the render into an infinite loop.
       if (seen.has(child.id)) continue;


### PR DESCRIPTION
## Summary

Two small, non-blocking optimizations deferred from the #753 review (frontend-only, `packages/dmloop`).

### 1. Build the thread-reply index once per render (was O(roots × comments))
`collectThreadReplies` rebuilt its `parent → children` map on **every** call, and `IssueDetailPage.repliesOf` calls it **once per thread root**. Extracted `buildRepliesByParent(comments)`; the page builds the index once per render and passes it in. The walk + chronological `(created_at, id)` sort are unchanged — behavior-preserving.

### 2. Load a public (signed CDN) attachment URL natively
The image card always blob-fetched by id (the auth-only endpoint) — correct for a site-relative `download_url`, but when the backend serves a **signed public CDN URL** (absolute, cross-origin) that URL is publicly readable: a native `<img src>` loads it directly, while an unconditional cross-origin blob XHR adds a round-trip and hits **CORS**. `isPublicAbsoluteUrl(download_url)` now routes those to a native `<img>`; the site-relative default keeps the authed blob path.
- **Scheme-restricted:** `isPublicAbsoluteUrl` only accepts `http:`/`https:`, so a `javascript:` / `data:` URL can never become a native `<a href>`/`<img src>` (defense in depth — `download_url` is backend-issued, not user text).
- **Forward-guard only:** the current deployment serves site-relative `download_url`s, so this branch never fires today (site-relative → same-origin → unchanged authed blob path). The inline-markdown image path already loads CDN URLs natively, so only the card needed the guard.

## Blast radius
- Contained in `packages/dmloop`: `ui/threadReplies.ts`, `panel/IssueDetailPage.tsx`, `ui/attachmentSrc.ts`, `ui/LoopAttachments.tsx` (+ unit tests). No backend/contract/shared-type change.
- `collectThreadReplies` signature `(rootId, comments)` → `(rootId, index)`: its **only** caller (`IssueDetailPage`) and its unit test are updated here — no stale call sites (grep-verified).
- `NativeImage` is only reached after `canPreviewInline` has filtered to safe raster types, so the SVG stored-XSS guard is not bypassed.

## Verification
- `packages/dmloop` vitest: **58 passed** (incl. new `buildRepliesByParent` + `isPublicAbsoluteUrl` cases, and `javascript:`/`data:` scheme rejection).
- Typecheck clean on changed files.
- **Real-env e2e** (dev, Alice-Loop / ALI-14): nested agent replies still render across all levels (two DB-verified level-3 grandchildren present after fresh load); site-relative image attachments still load via authed blob (`isPublicAbsoluteUrl` → false → unchanged path); non-images still download. No regression.

## Review
- Adversarial code-review (correctness) + simplification pass + automated security review: clean / addressed — the security review's MEDIUM (URL scheme not restricted) is fixed by the `http/https`-only guard + tests above.
- A second external adversarial pass is **pending** (its gateway key hit a quota limit) and will be run + commented once the key is restored.

## Docs
No docs change: frontend perf/refactor with no new user-facing feature, command, or config.

Closes #767