### PR TITLE
fix(group-md): refresh channelInfo cache after save/delete so settings panel status updates

### DIFF
--- a/apps/web/src/__tests__/groupMdFlagCache.test.ts
+++ b/apps/web/src/__tests__/groupMdFlagCache.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+// Import the production pure function directly (no barrel — mdFlagCache.ts has no
+// heavy deps), so this test exercises the real field-mapping logic, not a copy.
+import { withMdFlags } from "../../../../packages/dmworkbase/src/Components/GroupMdEditor/mdFlagCache";
+
+describe("withMdFlags: group channel", () => {
+  it("writes has_group_md / group_md_version at root level on save (configured)", () => {
+    const next = withMdFlags({ displayName: "g" }, false, true, 5);
+    expect(next.has_group_md).toBe(true);
+    expect(next.group_md_version).toBe(5);
+    expect(next.displayName).toBe("g"); // preserves unrelated fields
+  });
+
+  it("clears has_group_md / group_md_version on delete", () => {
+    const next = withMdFlags({ has_group_md: true, group_md_version: 9 }, false, false, 0);
+    expect(next.has_group_md).toBe(false);
+    expect(next.group_md_version).toBe(0);
+  });
+
+  it("does not touch thread fields for a group channel", () => {
+    const next = withMdFlags({}, false, true, 1);
+    expect(next.has_thread_md).toBeUndefined();
+    expect(next.thread_md_version).toBeUndefined();
+    expect(next.thread).toBeUndefined();
+  });
+});
+
+describe("withMdFlags: thread channel", () => {
+  it("writes has_thread_md / thread_md_version at root AND nested thread on save", () => {
+    const orgData = {
+      displayName: "t",
+      thread: { name: "t", status: 1, has_thread_md: false, thread_md_version: 0 },
+    };
+    const next = withMdFlags(orgData, true, true, 3);
+    // root level (what the panel subtitle reads)
+    expect(next.has_thread_md).toBe(true);
+    expect(next.thread_md_version).toBe(3);
+    // nested thread object kept in sync (cache internal consistency)
+    const thread = next.thread as Record<string, unknown>;
+    expect(thread.has_thread_md).toBe(true);
+    expect(thread.thread_md_version).toBe(3);
+    expect(thread.name).toBe("t"); // preserves unrelated nested fields
+    expect(thread.status).toBe(1);
+  });
+
+  it("clears root and nested flags on delete", () => {
+    const orgData = {
+      thread: { has_thread_md: true, thread_md_version: 7 },
+    };
+    const next = withMdFlags(orgData, true, false, 0);
+    expect(next.has_thread_md).toBe(false);
+    expect(next.thread_md_version).toBe(0);
+    const thread = next.thread as Record<string, unknown>;
+    expect(thread.has_thread_md).toBe(false);
+    expect(thread.thread_md_version).toBe(0);
+  });
+
+  it("does not throw when the nested thread object is absent", () => {
+    const next = withMdFlags({ displayName: "t" }, true, true, 2);
+    expect(next.has_thread_md).toBe(true);
+    expect(next.thread_md_version).toBe(2);
+    expect(next.thread).toBeUndefined();
+  });
+
+  it("does not touch group fields for a thread channel", () => {
+    const next = withMdFlags({}, true, true, 1);
+    expect(next.has_group_md).toBeUndefined();
+    expect(next.group_md_version).toBeUndefined();
+  });
+});
+
+describe("withMdFlags: immutability", () => {
+  it("does not mutate the input orgData (root)", () => {
+    const orgData = { has_group_md: false, group_md_version: 0 };
+    const next = withMdFlags(orgData, false, true, 4);
+    expect(orgData.has_group_md).toBe(false); // input untouched
+    expect(orgData.group_md_version).toBe(0);
+    expect(next).not.toBe(orgData); // new object returned
+  });
+
+  it("does not mutate the input nested thread object", () => {
+    const thread = { has_thread_md: false, thread_md_version: 0 };
+    const orgData = { thread };
+    const next = withMdFlags(orgData, true, true, 6);
+    expect(thread.has_thread_md).toBe(false); // nested input untouched
+    expect(thread.thread_md_version).toBe(0);
+    expect(next.thread).not.toBe(thread); // new nested object returned
+  });
+});

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Button, Spin } from "@douyinfe/semi-ui";
 import { Toast } from "@douyinfe/semi-ui";
-import { Channel } from "wukongimjssdk";
+import { Channel, WKSDK } from "wukongimjssdk";
 import WKApp from "../../App";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
@@ -97,6 +97,21 @@ export class GroupMdEditor extends Component<
     return parseThreadChannelId(this.props.channel.channelID);
   }
 
+  // 保存/删除 md 后，channelInfo 缓存里的 has_group_md / has_thread_md 标志位已过期。
+  // 主动清缓存并重新拉取：fetchChannelInfo 拿到新数据后会触发 channelManager listener，
+  // 设置面板的 reloadChannelInfo 随之重跑，「已配置/未配置」副标题即可刷新。
+  // 与子区改名流程（module.tsx）的缓存刷新口径保持一致；thread 与 group 两种 channel
+  // 都适用（channelInfoCallback 会按 channelType 走对应接口重拉标志位）。
+  private refreshChannelInfoCache = async () => {
+    const { channel } = this.props;
+    try {
+      WKSDK.shared().channelManager.deleteChannelInfo(channel);
+      await WKSDK.shared().channelManager.fetchChannelInfo(channel);
+    } catch {
+      // 缓存刷新失败不影响本次保存/删除结果：面板下次进入会重新拉取，忽略即可。
+    }
+  };
+
   loadContent = async () => {
     try {
       let resp;
@@ -162,6 +177,7 @@ export class GroupMdEditor extends Component<
         saving: false,
       });
       Toast.success(this.context.t("base.groupMd.saved"));
+      void this.refreshChannelInfoCache();
     } catch (err: any) {
       Toast.error(err?.msg || this.context.t("base.groupMd.saveFailed"));
       this.setState({ saving: false });
@@ -195,6 +211,7 @@ export class GroupMdEditor extends Component<
             version: 0,
           });
           Toast.success(this.context.t("base.groupMd.deleted"));
+          void this.refreshChannelInfoCache();
         } catch (err: any) {
           Toast.error(err?.msg || this.context.t("base.groupMd.deleteFailed"));
         }

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -9,6 +9,7 @@ import { I18nContext } from "../../i18n";
 import { wkConfirm } from "../WKModal";
 import MarkdownContent from "../../Messages/Text/MarkdownContent";
 import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
+import { withMdFlags } from "./mdFlagCache";
 import "./index.css";
 
 export interface GroupMdEditorProps {
@@ -97,18 +98,39 @@ export class GroupMdEditor extends Component<
     return parseThreadChannelId(this.props.channel.channelID);
   }
 
-  // 保存/删除 md 后，channelInfo 缓存里的 has_group_md / has_thread_md 标志位已过期。
-  // 主动清缓存并重新拉取：fetchChannelInfo 拿到新数据后会触发 channelManager listener，
-  // 设置面板的 reloadChannelInfo 随之重跑，「已配置/未配置」副标题即可刷新。
-  // 与子区改名流程（module.tsx）的缓存刷新口径保持一致；thread 与 group 两种 channel
-  // 都适用（channelInfoCallback 会按 channelType 走对应接口重拉标志位）。
-  private refreshChannelInfoCache = async () => {
+  // 保存/删除 md 后，channelInfo 缓存里的 has_group_md / has_thread_md 标志位（及版本号）
+  // 已过期，设置面板副标题「已配置 v{n} / 未配置」不会刷新。
+  //
+  // 这里【不走】deleteChannelInfo + fetchChannelInfo：SDK 的 fetchChannelInfo 按 channelKey
+  // 用 requestQueueMap 去重，而 deleteChannelInfo 只清 channelInfocacheMap；若保存瞬间恰有
+  // 「携旧标志」的 fetch 在途，delete+fetch 会退化成 no-op 并被旧请求覆盖，复发副标题不刷新。
+  // 与 syncThreadArchiveState(#345) / syncGroupDisbandState(#447) 同款收口：把权威值原地
+  // 写回缓存并 notifyListeners，绕过该去重竞态。
+  //
+  // configured / version 由调用方用后端返回的权威 version 派生（version > 0 即已配置），
+  // 而非前端假设——与副标题「已配置 v{version}」及编辑器 version>0 显示版本标签的判断一致。
+  // 仅写副标题依赖的标志位与版本号，不动 *_md_updated_at（当前无处显示）。
+  private applyMdFlagToCache = (configured: boolean, version: number) => {
     const { channel } = this.props;
     try {
-      WKSDK.shared().channelManager.deleteChannelInfo(channel);
-      await WKSDK.shared().channelManager.fetchChannelInfo(channel);
+      const channelManager = WKSDK.shared().channelManager;
+      const channelInfo = channelManager.getChannelInfo(channel);
+      // 缓存未命中（罕见：设置面板通常已 fetch 过）：无本地权威可原地写回，
+      // 退回 SDK 拉取兜底，仍以后端为准。
+      if (!channelInfo) {
+        void channelManager.fetchChannelInfo(channel);
+        return;
+      }
+      channelInfo.orgData = withMdFlags(
+        (channelInfo.orgData as Record<string, unknown>) || {},
+        this.isThreadMd(),
+        configured,
+        version
+      );
+      channelManager.setChannleInfoForCache(channelInfo);
+      channelManager.notifyListeners(channelInfo);
     } catch {
-      // 缓存刷新失败不影响本次保存/删除结果：面板下次进入会重新拉取，忽略即可。
+      // 缓存写回失败不影响本次保存/删除结果：面板下次进入会重新拉取。
     }
   };
 
@@ -177,7 +199,8 @@ export class GroupMdEditor extends Component<
         saving: false,
       });
       Toast.success(this.context.t("base.groupMd.saved"));
-      void this.refreshChannelInfoCache();
+      // 保存成功：用后端返回的权威 version 派生已配置状态（version>0 即已配置）。
+      this.applyMdFlagToCache(resp.version > 0, resp.version);
     } catch (err: any) {
       Toast.error(err?.msg || this.context.t("base.groupMd.saveFailed"));
       this.setState({ saving: false });
@@ -211,7 +234,8 @@ export class GroupMdEditor extends Component<
             version: 0,
           });
           Toast.success(this.context.t("base.groupMd.deleted"));
-          void this.refreshChannelInfoCache();
+          // 删除成功：确定已无 md，标志位置未配置、版本归零。
+          this.applyMdFlagToCache(false, 0);
         } catch (err: any) {
           Toast.error(err?.msg || this.context.t("base.groupMd.deleteFailed"));
         }

--- a/packages/dmworkbase/src/Components/GroupMdEditor/mdFlagCache.ts
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/mdFlagCache.ts
@@ -1,0 +1,44 @@
+/**
+ * GROUP.md / Thread.md「已配置」状态写回 channelInfo.orgData 的字段映射（纯函数）。
+ *
+ * 设置面板副标题读 orgData.has_group_md / has_thread_md（根层）+ 对应 *_md_version，
+ * 渲染「已配置 v{n}」或「未配置」。保存/删除 md 后，需按 channelType 把这两个标志位写回：
+ *   - 群频道：has_group_md / group_md_version（均在 orgData 根层）。
+ *   - 子区频道：has_thread_md / thread_md_version；注意子区在 orgData 根层与嵌套的
+ *     thread 对象里各存一份（见 datasource.ts toThread 与 channelInfo.ts 子区分支），
+ *     两处必须同步，否则缓存内部自相矛盾。
+ *
+ * configured / version 由调用方用后端返回的权威 version 派生（version > 0 即已配置），
+ * 不是前端假设——与副标题「已配置 v{version}」及编辑器 version>0 显示版本标签的判断自洽。
+ *
+ * 返回新的 orgData（不 mutate 入参）。字段映射是本次改动最主要的出错面，
+ * 独立成纯函数以便单测精确覆盖 thread/group、根层/嵌套、保存/删除各分支。
+ */
+export function withMdFlags(
+  orgData: Record<string, unknown>,
+  isThread: boolean,
+  configured: boolean,
+  version: number
+): Record<string, unknown> {
+  if (!isThread) {
+    return { ...orgData, has_group_md: configured, group_md_version: version };
+  }
+
+  const next: Record<string, unknown> = {
+    ...orgData,
+    has_thread_md: configured,
+    thread_md_version: version,
+  };
+
+  // 嵌套 thread 对象若存在，同步其标志位（副标题只读根层，但保持缓存一致）。
+  const thread = next.thread as Record<string, unknown> | undefined;
+  if (thread) {
+    next.thread = {
+      ...thread,
+      has_thread_md: configured,
+      thread_md_version: version,
+    };
+  }
+
+  return next;
+}


### PR DESCRIPTION
Closes #778

## Problem

In a group thread, after configuring **Thread.md**, opening the thread's settings panel (right side) still showed **「GROUP.md 未配置」** (not configured), even though clicking into it correctly displayed the saved content.

The panel subtitle reads the `has_thread_md` / `has_group_md` flag from the cached `channelInfo`, but `GroupMdEditor` only updated its own component state after save/delete and never refreshed that cache — so the flag stayed stale.

## Fix

After a successful save/delete, write the md flag + version **authoritatively** into the cached `channelInfo.orgData` and call `notifyListeners`, so the panel subtitle refreshes immediately.

Two commits:
1. `905d0bfe` — initial fix via `deleteChannelInfo` + `fetchChannelInfo`.
2. `64b592d0` — switched to authoritative write-back to avoid a known SDK dedup race: `fetchChannelInfo` dedups by channelKey via `requestQueueMap` while `deleteChannelInfo` clears only `channelInfocacheMap`; if a fetch carrying the pre-write flag is already in flight, delete+fetch degrades to a no-op and the stale response wins. This mirrors the sibling handling in `syncThreadArchiveState` (#345) and `syncGroupDisbandState` (#447).

Details:
- Configured state is derived from the backend-returned `version` (`version > 0`), not a client-side assumption — consistent with the subtitle's 「已配置 v{n}」 display and the editor's `version > 0` version badge.
- Field mapping (thread root + nested `thread` object; group root) is extracted into a pure `withMdFlags()` helper.
- Cache miss falls back to `fetchChannelInfo` (still backend-authoritative).
- Covers both thread (Thread.md) and group (GROUP.md); delete correctly falls back to "not configured".

## Test plan

- [x] Manual: configure Thread.md → open settings panel (kept open) → edit + save → return; subtitle updates to 「已配置 v{n}」 (previously stuck on 「未配置」). Verified against `https://im-test.deepminer.com.cn` with SSO dev server on :3000.
- [x] Unit tests: `threadGroupMd.test.ts` (24) + new `groupMdFlagCache.test.ts` (9) — 33/33 pass.
- [ ] Reviewer: confirm the delete path falls back to 「未配置」 and group (non-thread) GROUP.md behaves the same.

## Notes

- No `package.json` version bump — app version is injected via `VITE_APP_VERSION` in CI (consistent with recent PRs).
- Assumption: `has_thread_md ⟺ version > 0`. This cannot be proven from the frontend (the backend returns the two fields independently), but it is consistent with the existing subtitle logic, and the delete path sets `version = 0` deterministically.
