### PR TITLE
feat(loop): add built-in skills install tip to runtime install prompt

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -111,7 +111,7 @@
     "copyInstall": "Copy install instructions",
     "installHint": "Copy these instructions to your Bot to run (contains a one-time credential — do not share):",
     "installTokenPlaceholder": "<generated when you click Copy>",
-    "installPrompt": "Please install and configure the octo-daemon runtime on this machine. Run these steps in order:\n\n1. Install:\n{{install}}\n\n2. Configure permissions (login):\n{{auth}}\n\n3. Start / restart to apply:\n{{start}}\n\nWhen done, confirm the daemon shows as online in the runtime list.",
+    "installPrompt": "Please install and configure the octo-daemon runtime on this machine. Run these steps in order:\n\n1. Install:\n{{install}}\n\n2. Configure permissions (login):\n{{auth}}\n\n3. Start / restart to apply:\n{{start}}\n\n4. Refer to octo-daemon --help to install the built-in skills.\n\nWhen done, confirm the daemon shows as online in the runtime list.",
     "headlessNoBackend": "The administrator has not configured a public backend URL; install instructions unavailable",
     "headlessFailed": "Failed to generate install instructions, please retry"
   },

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -111,7 +111,7 @@
     "copyInstall": "复制安装指令",
     "installHint": "把这段指令复制给 Bot 执行（含一次性认证凭证，请勿外传）：",
     "installTokenPlaceholder": "<点击「复制安装指令」时生成>",
-    "installPrompt": "请在这台电脑上安装并配置 octo-daemon 运行时，依次执行：\n\n1. 安装：\n{{install}}\n\n2. 配置权限（登录认证）：\n{{auth}}\n\n3. 启动 / 重启使其生效：\n{{start}}\n\n完成后请确认该 daemon 在运行时列表中显示为在线。",
+    "installPrompt": "请在这台电脑上安装并配置 octo-daemon 运行时，依次执行：\n\n1. 安装：\n{{install}}\n\n2. 配置权限（登录认证）：\n{{auth}}\n\n3. 启动 / 重启使其生效：\n{{start}}\n\n4. 参考 octo-daemon --help 安装内置的 skills。\n\n完成后请确认该 daemon 在运行时列表中显示为在线。",
     "headlessNoBackend": "管理员未配置后端公开地址，无法生成安装指令",
     "headlessFailed": "生成安装指令失败，请重试"
   },


### PR DESCRIPTION
## Goal

Closes #770.

The **Runtime → Add computer** install prompt only told the Bot to install, authenticate and start the octo-daemon runtime. It never installed the bundled coding-agent skill, so a freshly connected machine had a runtime online but no `octo-loop` skill available to the local agent. This change makes the generated prompt fully provision a machine in one pass.

## Changes

- `packages/dmloop/src/i18n/en-US.json` — add step 4 to `loop.runtime.installPrompt`: "Refer to octo-daemon --help to install the built-in skills."
- `packages/dmloop/src/i18n/zh-CN.json` — add the same step 4 (`参考 octo-daemon --help 安装内置的 skills。`).

Only i18n copy changes; no command-builder or runtime logic changes.

## Verification

- `en-US.json` and `zh-CN.json` both parse as valid JSON.
- Open Loop → Runtime → **Add computer**, click **Copy install instructions**, and confirm the generated prompt now includes a fourth step instructing the Bot to install the built-in skills via `octo-daemon --help`, placed after the daemon start step and before the final online-confirmation line.