### PR TITLE
refactor(user): 收口用户资料接口访问

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,6 +13,7 @@
 | 提交/分支管理 | 七 |
 | 做视觉审查 | 二、十二 |
 | 新增业务能力/调整模块边界 | 先读“模块边界与代码落点”，再按二、三、四、五判断实现方式 |
+| 新增/改造接口调用 | 先读“API Service 分层规则”，再按对应模块补测试 |
 
 不需要读全部，按任务找对应章节即可。
 
@@ -46,6 +47,62 @@
 - 是否修改了共享组件或基础服务？如果是，是否说明影响范围？
 - 是否把完整业务流程写进了通用组件目录？
 - 是否补了测试、Story 或必要文档？
+
+## API Service 分层规则
+
+新增接口调用或改造现有接口调用时，优先把 HTTP 边界收口到 `Service/`，不要让 UI 组件、页面组件或 VM 直接拼接口。
+
+### 基本原则
+
+- 新增接口默认放到 `packages/dmworkbase/src/Service/*Service.ts`，按业务实体命名，例如 `UserService`、`FollowService`。
+- Service 层负责拼 endpoint、query/body、响应 envelope 兼容和接口类型；组件/VM 负责页面状态、交互流程和错误展示。
+- Service 层使用 `APIClient.shared`；不要在 Service 层 import `WKApp`。需要登录态、space、路由等运行时上下文时，由调用方传入必要参数。
+- 新代码不要在 `Components/`、`Pages/`、`Messages/` 里直接调用 `WKApp.apiClient` 或 `APIClient.shared`。改造老代码时按模块逐步迁移，不要求一次性清空历史调用。
+- Service 方法命名用业务语义，不用 HTTP 动词堆叠；例如 `getUserProfile(uid, groupNo)` 比 `getUsersByUid()` 更清楚。
+- 类型优先放在对应 Service 文件里导出；多个模块共享且稳定后，再考虑移动到公共 types 文件。
+
+### 推荐写法
+
+```ts
+// Service/UserService.ts
+import APIClient from "./APIClient"
+
+export interface UserProfile {
+  uid?: string
+  name?: string
+  vercode?: string
+  [key: string]: any
+}
+
+const UserService = {
+  getUserProfile(uid: string, groupNo?: string): Promise<UserProfile> {
+    return APIClient.shared.get(`users/${uid}`, {
+      param: { group_no: groupNo || "" },
+    })
+  },
+}
+
+export default UserService
+```
+
+```ts
+// Components/UserInfo/vm.tsx
+const profile = await UserService.getUserProfile(uid, groupNo)
+```
+
+### 测试要求
+
+- 新增 Service 方法时，至少补 Service 单测，覆盖 endpoint、query/body 和关键响应兼容逻辑。
+- 如果改动会影响页面状态、缓存、重试、乐观更新或错误提示，还需要补 VM/组件测试。
+- 迁移已有接口时，保持接口路径、参数和错误语义不变；除非 PR 明确声明并验证行为变更。
+- PR 描述里写清楚影响范围：只改接口边界、还是同时改了业务行为。
+
+### 提交前自查
+
+- Service 是否只依赖 `APIClient.shared` 和纯工具函数？
+- 调用方是否只传必要参数，而不是把 `WKApp` 或整块全局状态传进 Service？
+- 是否避免把未上线、不可人工验证的功能作为唯一改造样板？
+- 是否有一条可人工验证的用户路径？
 
 ## 一、环境要求
 

--- a/packages/dmworkbase/src/Components/UserInfo/vm.tsx
+++ b/packages/dmworkbase/src/Components/UserInfo/vm.tsx
@@ -12,6 +12,7 @@ import WKApp from "../../App";
 import RouteContext from "../../Service/Context";
 import { GroupRole } from "../../Service/Const";
 import { Convert } from "../../Service/Convert";
+import UserService from "../../Service/UserService";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { isRealnameVerified, displayName as resolveDisplayName } from "../../Utils/displayName";
 
@@ -252,9 +253,7 @@ export class UserInfoVM extends ProviderListener {
   }
 
   async reloadChannelInfo() {
-    const res = await WKApp.apiClient.get(`users/${this.uid}`, {
-      param: { group_no: this.fromChannel?.channelID || '' },
-    });
+    const res = await UserService.getUserProfile(this.uid, this.fromChannel?.channelID);
     this.channelInfo = Convert.userToChannelInfo(res);
     if (!this.vercode || this.vercode === "") {
       if (res.vercode && res.vercode !== "") {

--- a/packages/dmworkbase/src/Service/UserService.ts
+++ b/packages/dmworkbase/src/Service/UserService.ts
@@ -1,0 +1,16 @@
+import APIClient from "./APIClient"
+
+export interface UserProfile {
+  vercode?: string
+  [key: string]: any
+}
+
+const UserService = {
+  getUserProfile(uid: string, groupNo?: string): Promise<UserProfile> {
+    return APIClient.shared.get(`users/${uid}`, {
+      param: { group_no: groupNo || "" },
+    })
+  },
+}
+
+export default UserService

--- a/packages/dmworkbase/src/Service/__tests__/UserService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UserService.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      get: vi.fn(),
+    },
+  },
+}))
+
+import APIClient from "../APIClient"
+import UserService from "../UserService"
+
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  apiGet.mockReset()
+})
+
+describe("UserService", () => {
+  it("getUserProfile calls users/:uid with empty group_no by default", async () => {
+    const profile = { uid: "u1", name: "User 1" }
+    apiGet.mockResolvedValueOnce(profile)
+
+    await expect(UserService.getUserProfile("u1")).resolves.toEqual(profile)
+    expect(apiGet).toHaveBeenCalledWith("users/u1", {
+      param: { group_no: "" },
+    })
+  })
+
+  it("getUserProfile passes group_no when provided", async () => {
+    apiGet.mockResolvedValueOnce({ uid: "u2" })
+
+    await UserService.getUserProfile("u2", "group-a")
+    expect(apiGet).toHaveBeenCalledWith("users/u2", {
+      param: { group_no: "group-a" },
+    })
+  })
+
+  it("normalizes blank groupNo to empty string", async () => {
+    apiGet.mockResolvedValueOnce({ uid: "u3" })
+
+    await UserService.getUserProfile("u3", "")
+    expect(apiGet).toHaveBeenCalledWith("users/u3", {
+      param: { group_no: "" },
+    })
+  })
+})


### PR DESCRIPTION
## 变更说明

- 在 `DEVELOPMENT.md` 补充 API Service 分层规则，明确新增/改造接口调用的落点、边界和测试要求。
- 新增 `UserService.getUserProfile`，把用户资料接口 `users/:uid` 收口到 Service 层。
- 调整 `UserInfo` VM，用户资料刷新改走 `UserService`，保持原接口路径、`group_no` 参数和业务行为不变。
- 补充 `UserService` 单测，覆盖默认 `group_no`、传入群号和空字符串兼容。

## 验证

- `pnpm --dir packages/dmworkbase test src/Service/__tests__/UserService.test.ts`
- `git diff --check`
- `pnpm --dir apps/web build`

## 影响范围

- 本次只收口用户资料接口访问边界，不改 UI、不引入新依赖、不调整用户资料弹窗业务行为。
