### PR TITLE
feat(voice): switch voice trigger key by pressing shift 7 times

### DIFF
--- a/apps/web/src/__tests__/useVoiceTriggerKey.test.ts
+++ b/apps/web/src/__tests__/useVoiceTriggerKey.test.ts
@@ -17,8 +17,15 @@ const localStorageMock = {
 Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true })
 
 // ── helpers ────────────────────────────────────────────────────────────────
+function makeKeyEvent(code: string, extra: Partial<KeyboardEventInit> = {}) {
+    const e = new KeyboardEvent("keydown", { code, bubbles: true, cancelable: true, ...extra })
+    vi.spyOn(e, "stopImmediatePropagation")
+    vi.spyOn(e, "preventDefault")
+    return e
+}
+
 function fireKeyDown(code: string, extra: Partial<KeyboardEventInit> = {}) {
-    window.dispatchEvent(new KeyboardEvent("keydown", { code, bubbles: true, cancelable: true, ...extra }))
+    window.dispatchEvent(makeKeyEvent(code, extra))
 }
 
 function pressNTimes(code: string, n: number, gapMs = 100) {
@@ -26,6 +33,18 @@ function pressNTimes(code: string, n: number, gapMs = 100) {
         vi.advanceTimersByTime(gapMs)
         fireKeyDown(code)
     }
+}
+
+// Fires n presses and returns the event objects so callers can inspect spies
+function pressNTimesTracked(code: string, n: number, gapMs = 100) {
+    const events: KeyboardEvent[] = []
+    for (let i = 0; i < n; i++) {
+        vi.advanceTimersByTime(gapMs)
+        const e = makeKeyEvent(code)
+        window.dispatchEvent(e)
+        events.push(e)
+    }
+    return events
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -40,6 +59,7 @@ describe("useVoiceTriggerKey", () => {
         vi.restoreAllMocks()
     })
 
+    // ── basic state ──────────────────────────────────────────────────────
     it("defaults to ShiftLeft when localStorage is empty", () => {
         const { result } = renderHook(() => useVoiceTriggerKey(vi.fn()))
         expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
@@ -51,6 +71,7 @@ describe("useVoiceTriggerKey", () => {
         expect(result.current.voiceTriggerKey).toBe("ShiftRight")
     })
 
+    // ── toggle ───────────────────────────────────────────────────────────
     it("switches ShiftLeft → ShiftRight after 7 rapid presses", () => {
         const onToggled = vi.fn()
         const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
@@ -84,12 +105,78 @@ describe("useVoiceTriggerKey", () => {
         expect(onToggled).not.toHaveBeenCalled()
     })
 
+    // ── P1 fix: stopImmediatePropagation on completing press ─────────────
+    it("calls stopImmediatePropagation() and preventDefault() on the 7th (completing) press", () => {
+        renderHook(() => useVoiceTriggerKey(vi.fn()))
+
+        let events: KeyboardEvent[]
+        act(() => { events = pressNTimesTracked("ShiftLeft", 7) })
+
+        const completing = events![6]
+        expect(completing.stopImmediatePropagation).toHaveBeenCalled()
+        expect(completing.preventDefault).toHaveBeenCalled()
+    })
+
+    it("does NOT call stopImmediatePropagation() on non-completing presses (1-6)", () => {
+        renderHook(() => useVoiceTriggerKey(vi.fn()))
+
+        let events: KeyboardEvent[]
+        act(() => { events = pressNTimesTracked("ShiftLeft", 6) })
+
+        events!.forEach((e) => {
+            expect(e.stopImmediatePropagation).not.toHaveBeenCalled()
+        })
+    })
+
+    // ── P1 fix: isVoiceEnabled gate ──────────────────────────────────────
+    it("does not register a listener when isVoiceEnabled=false", () => {
+        const onToggled = vi.fn()
+        renderHook(() => useVoiceTriggerKey(onToggled, { isVoiceEnabled: false }))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("registers listener when isVoiceEnabled=true (default)", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled, { isVoiceEnabled: true }))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftRight")
+        expect(onToggled).toHaveBeenCalledOnce()
+    })
+
+    // ── P1 fix: focus gate (checkIsInputActive) ──────────────────────────
+    it("does not toggle when checkIsInputActive returns false", () => {
+        const onToggled = vi.fn()
+        const checkIsInputActive = vi.fn(() => false)
+        renderHook(() => useVoiceTriggerKey(onToggled, { checkIsInputActive }))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("toggles when checkIsInputActive returns true", () => {
+        const onToggled = vi.fn()
+        const checkIsInputActive = vi.fn(() => true)
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled, { checkIsInputActive }))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftRight")
+        expect(onToggled).toHaveBeenCalledWith("ShiftRight")
+    })
+
+    // ── counter reset conditions ─────────────────────────────────────────
     it("resets counter when gap between presses exceeds 500ms", () => {
         const onToggled = vi.fn()
         const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
 
         act(() => {
-            pressNTimes("ShiftLeft", 6, 100) // 6 fast presses
+            pressNTimes("ShiftLeft", 6, 100)
             vi.advanceTimersByTime(600)       // long pause — counter resets
             fireKeyDown("ShiftLeft")          // restart from 1
         })
@@ -127,6 +214,21 @@ describe("useVoiceTriggerKey", () => {
         expect(onToggled).not.toHaveBeenCalled()
     })
 
+    it("does not toggle on autorepeat (repeat=true) presses", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => {
+            for (let i = 0; i < 7; i++) {
+                vi.advanceTimersByTime(100)
+                fireKeyDown("ShiftLeft", { repeat: true })
+            }
+        })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
     it("does not respond to the non-active shift key", () => {
         const onToggled = vi.fn()
         // default is ShiftLeft; pressing ShiftRight 7x should not toggle
@@ -137,6 +239,7 @@ describe("useVoiceTriggerKey", () => {
         expect(onToggled).not.toHaveBeenCalled()
     })
 
+    // ── double-toggle ────────────────────────────────────────────────────
     it("toggles twice: ShiftLeft → ShiftRight → ShiftLeft", () => {
         const onToggled = vi.fn()
         const { result } = renderHook(() => useVoiceTriggerKey(onToggled))

--- a/apps/web/src/__tests__/useVoiceTriggerKey.test.ts
+++ b/apps/web/src/__tests__/useVoiceTriggerKey.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+
+vi.mock("lottie-web", () => ({}))
+vi.mock("@douyinfe/semi-ui", () => ({}))
+
+import useVoiceTriggerKey from "@octo/base/src/Components/MessageInput/useVoiceTriggerKey"
+
+// ── localStorage stub ──────────────────────────────────────────────────────
+const localStorageStore: Record<string, string> = {}
+const localStorageMock = {
+    getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { localStorageStore[key] = value }),
+    removeItem: vi.fn((key: string) => { delete localStorageStore[key] }),
+    clear: vi.fn(() => { Object.keys(localStorageStore).forEach(k => delete localStorageStore[k]) }),
+}
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true })
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function fireKeyDown(code: string, extra: Partial<KeyboardEventInit> = {}) {
+    window.dispatchEvent(new KeyboardEvent("keydown", { code, bubbles: true, cancelable: true, ...extra }))
+}
+
+function pressNTimes(code: string, n: number, gapMs = 100) {
+    for (let i = 0; i < n; i++) {
+        vi.advanceTimersByTime(gapMs)
+        fireKeyDown(code)
+    }
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+describe("useVoiceTriggerKey", () => {
+    beforeEach(() => {
+        localStorageMock.clear()
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.restoreAllMocks()
+    })
+
+    it("defaults to ShiftLeft when localStorage is empty", () => {
+        const { result } = renderHook(() => useVoiceTriggerKey(vi.fn()))
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+    })
+
+    it("reads initial value from localStorage", () => {
+        localStorageStore["octo_voice_trigger_key"] = "ShiftRight"
+        const { result } = renderHook(() => useVoiceTriggerKey(vi.fn()))
+        expect(result.current.voiceTriggerKey).toBe("ShiftRight")
+    })
+
+    it("switches ShiftLeft → ShiftRight after 7 rapid presses", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftRight")
+        expect(onToggled).toHaveBeenCalledOnce()
+        expect(onToggled).toHaveBeenCalledWith("ShiftRight")
+        expect(localStorageMock.setItem).toHaveBeenCalledWith("octo_voice_trigger_key", "ShiftRight")
+    })
+
+    it("switches ShiftRight → ShiftLeft after 7 rapid presses", () => {
+        localStorageStore["octo_voice_trigger_key"] = "ShiftRight"
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => { pressNTimes("ShiftRight", 7) })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).toHaveBeenCalledWith("ShiftLeft")
+    })
+
+    it("does not toggle after only 6 presses", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => { pressNTimes("ShiftLeft", 6) })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("resets counter when gap between presses exceeds 500ms", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => {
+            pressNTimes("ShiftLeft", 6, 100) // 6 fast presses
+            vi.advanceTimersByTime(600)       // long pause — counter resets
+            fireKeyDown("ShiftLeft")          // restart from 1
+        })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("pressing a non-trigger key resets the counter", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => {
+            pressNTimes("ShiftLeft", 5, 100)
+            vi.advanceTimersByTime(100)
+            fireKeyDown("KeyA")              // resets counter
+            pressNTimes("ShiftLeft", 6, 100) // 6 more, not enough for toggle
+        })
+
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("does not toggle when modifier keys are held", () => {
+        const onToggled = vi.fn()
+        renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => {
+            for (let i = 0; i < 7; i++) {
+                vi.advanceTimersByTime(100)
+                fireKeyDown("ShiftLeft", { metaKey: true })
+            }
+        })
+
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("does not respond to the non-active shift key", () => {
+        const onToggled = vi.fn()
+        // default is ShiftLeft; pressing ShiftRight 7x should not toggle
+        renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => { pressNTimes("ShiftRight", 7) })
+
+        expect(onToggled).not.toHaveBeenCalled()
+    })
+
+    it("toggles twice: ShiftLeft → ShiftRight → ShiftLeft", () => {
+        const onToggled = vi.fn()
+        const { result } = renderHook(() => useVoiceTriggerKey(onToggled))
+
+        act(() => { pressNTimes("ShiftLeft", 7) })
+        expect(result.current.voiceTriggerKey).toBe("ShiftRight")
+
+        act(() => {
+            vi.advanceTimersByTime(1000) // ensure counter resets between sequences
+            pressNTimes("ShiftRight", 7)
+        })
+        expect(result.current.voiceTriggerKey).toBe("ShiftLeft")
+        expect(onToggled).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
@@ -66,20 +66,6 @@ export default function VoiceInputIndicator({
   const [showFeedbackNotice, setShowFeedbackNotice] = useState(false);
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
 
-  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
-  const { voiceTriggerKey } = useVoiceTriggerKey(
-    (newKey: VoiceTriggerKey) => {
-      const msgKey =
-        newKey === "ShiftRight"
-          ? "base.voiceInput.triggerKey.switchedToRight"
-          : "base.voiceInput.triggerKey.switchedToLeft";
-      Toast.info(t(msgKey));
-    },
-    { isVoiceEnabled, checkIsInputActive }
-  );
-  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
-  voiceTriggerKeyRef.current = voiceTriggerKey;
-
   // Long-press ShiftLeft state
   const shiftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preparingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -207,6 +193,21 @@ export default function VoiceInputIndicator({
     }
     setIsPreparing(false);
   };
+
+  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses.
+  // Must be called AFTER useVoiceInput so isVoiceEnabled is already declared.
+  const { voiceTriggerKey } = useVoiceTriggerKey(
+    (newKey: VoiceTriggerKey) => {
+      const msgKey =
+        newKey === "ShiftRight"
+          ? "base.voiceInput.triggerKey.switchedToRight"
+          : "base.voiceInput.triggerKey.switchedToLeft";
+      Toast.info(t(msgKey));
+    },
+    { isVoiceEnabled, checkIsInputActive }
+  );
+  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
+  voiceTriggerKeyRef.current = voiceTriggerKey;
 
   // Handle transition from preparing/pending -> actual recording or auto-cancel.
   useEffect(() => {

--- a/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
@@ -3,6 +3,8 @@ import { createPortal } from "react-dom";
 import { Toast, Dropdown } from "@douyinfe/semi-ui";
 import { Mic } from "lucide-react";
 import useVoiceInput from "./useVoiceInput";
+import useVoiceTriggerKey from "./useVoiceTriggerKey";
+import type { VoiceTriggerKey } from "./useVoiceTriggerKey";
 import "./voiceInput.css";
 import { ChatContextResult } from "../Conversation/chatContext";
 import { VoiceMode } from "../../Service/VoiceService";
@@ -63,6 +65,17 @@ export default function VoiceInputIndicator({
   const [showModeMenu, setShowModeMenu] = useState(false);
   const [showFeedbackNotice, setShowFeedbackNotice] = useState(false);
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
+
+  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
+  const { voiceTriggerKey } = useVoiceTriggerKey((newKey: VoiceTriggerKey) => {
+    const msgKey =
+      newKey === "ShiftRight"
+        ? "base.voiceInput.triggerKey.switchedToRight"
+        : "base.voiceInput.triggerKey.switchedToLeft";
+    Toast.info(t(msgKey));
+  });
+  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
+  voiceTriggerKeyRef.current = voiceTriggerKey;
 
   // Long-press ShiftLeft state
   const shiftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -299,9 +312,9 @@ export default function VoiceInputIndicator({
         return;
       }
 
-      // Long-press ShiftLeft: start 500ms timer
+      // Long-press voiceTriggerKey: start 500ms timer
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         !e.repeat &&
         !e.metaKey &&
         !e.ctrlKey &&
@@ -349,7 +362,7 @@ export default function VoiceInputIndicator({
         return;
       }
 
-      if (shiftTimerRef.current !== null && e.code !== "ShiftLeft") {
+      if (shiftTimerRef.current !== null && e.code !== voiceTriggerKeyRef.current) {
         // Modifier chord (Ctrl/Meta/Alt pressed): cancel voice intent
         if (
           e.code.startsWith("Control") ||
@@ -378,15 +391,15 @@ export default function VoiceInputIndicator({
         return;
       }
 
-      // ShiftLeft released while timer is pending: cancel (normal Shift press)
-      if (e.code === "ShiftLeft" && shiftTimerRef.current !== null) {
+      // voiceTriggerKey released while timer is pending: cancel (normal Shift press)
+      if (e.code === voiceTriggerKeyRef.current && shiftTimerRef.current !== null) {
         clearShiftTimer();
         return;
       }
 
-      // ShiftLeft released while waiting for getUserMedia (recording not yet started)
+      // voiceTriggerKey released while waiting for getUserMedia (recording not yet started)
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         shiftRecordingRef.current &&
         !isRecordingRef.current
       ) {
@@ -395,9 +408,9 @@ export default function VoiceInputIndicator({
         return;
       }
 
-      // ShiftLeft released after long-press recording started: stop recording
+      // voiceTriggerKey released after long-press recording started: stop recording
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         shiftRecordingRef.current &&
         isRecordingRef.current
       ) {

--- a/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/VoiceInputIndicator.tsx
@@ -67,13 +67,16 @@ export default function VoiceInputIndicator({
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
 
   // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
-  const { voiceTriggerKey } = useVoiceTriggerKey((newKey: VoiceTriggerKey) => {
-    const msgKey =
-      newKey === "ShiftRight"
-        ? "base.voiceInput.triggerKey.switchedToRight"
-        : "base.voiceInput.triggerKey.switchedToLeft";
-    Toast.info(t(msgKey));
-  });
+  const { voiceTriggerKey } = useVoiceTriggerKey(
+    (newKey: VoiceTriggerKey) => {
+      const msgKey =
+        newKey === "ShiftRight"
+          ? "base.voiceInput.triggerKey.switchedToRight"
+          : "base.voiceInput.triggerKey.switchedToLeft";
+      Toast.info(t(msgKey));
+    },
+    { isVoiceEnabled, checkIsInputActive }
+  );
   const voiceTriggerKeyRef = useRef(voiceTriggerKey);
   voiceTriggerKeyRef.current = voiceTriggerKey;
 

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceTriggerKey.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceTriggerKey.ts
@@ -24,6 +24,21 @@ function writeStoredKey(key: VoiceTriggerKey): void {
     }
 }
 
+export interface UseVoiceTriggerKeyOptions {
+    /**
+     * If provided, the toggle gesture is only active when this returns true.
+     * Should match the caller's own focus-gate (e.g. checkIsInputActive).
+     * When omitted the gesture is active whenever isVoiceEnabled is true.
+     */
+    checkIsInputActive?: () => boolean
+    /**
+     * When false (voice feature disabled for this mount), the toggle listener
+     * is not registered.  Defaults to true so callers that don't use the flag
+     * are unaffected.
+     */
+    isVoiceEnabled?: boolean
+}
+
 export interface UseVoiceTriggerKeyReturn {
     /** 当前激活的语音触发键，"ShiftLeft" 或 "ShiftRight" */
     voiceTriggerKey: VoiceTriggerKey
@@ -32,16 +47,27 @@ export interface UseVoiceTriggerKeyReturn {
 /**
  * 管理语音输入触发键（ShiftLeft ↔ ShiftRight）。
  *
- * 切换手势：连续快速按目标键 7 次（相邻两次 keydown 间隔 < 500ms）。
+ * 切换手势：连续快速按目标键 7 次（相邻两次 keydown 间隔 < 500ms，
+ * 不持有任何 modifier 键）。
  * - 当前为 ShiftLeft  → 连按左 Shift 7 次 → 切换为 ShiftRight
  * - 当前为 ShiftRight → 连按右 Shift 7 次 → 切换为 ShiftLeft
  *
  * 状态持久化到 localStorage（key: octo_voice_trigger_key）。
  * 切换后通过回调通知调用方以便显示 Toast。
+ *
+ * P1 fixes (yujiawei review):
+ * 1. On the completing (7th) keydown the event is stopped via
+ *    stopImmediatePropagation() so the long-press recording handler never
+ *    arms shiftTimerRef — no phantom recording.
+ * 2. Toggle listener respects the caller's focus gate (checkIsInputActive)
+ *    and isVoiceEnabled flag, mirroring the recording handler's scope.
  */
 export default function useVoiceTriggerKey(
-    onToggled: (newKey: VoiceTriggerKey) => void
+    onToggled: (newKey: VoiceTriggerKey) => void,
+    options: UseVoiceTriggerKeyOptions = {}
 ): UseVoiceTriggerKeyReturn {
+    const { checkIsInputActive, isVoiceEnabled = true } = options
+
     const [voiceTriggerKey, setVoiceTriggerKey] = useState<VoiceTriggerKey>(readStoredKey)
 
     const voiceTriggerKeyRef = useRef(voiceTriggerKey)
@@ -50,13 +76,17 @@ export default function useVoiceTriggerKey(
     const onToggledRef = useRef(onToggled)
     onToggledRef.current = onToggled
 
+    const checkIsInputActiveRef = useRef(checkIsInputActive)
+    checkIsInputActiveRef.current = checkIsInputActive
+
     // Rapid-press counter state
     const pressCountRef = useRef(0)
     const lastPressTimeRef = useRef(0)
 
     const handleKeyDown = useCallback((e: KeyboardEvent) => {
         const currentKey = voiceTriggerKeyRef.current
-        // Only track the current trigger key (no modifiers)
+
+        // Only track the current trigger key (no modifiers, no autorepeat)
         if (
             e.code !== currentKey ||
             e.repeat ||
@@ -64,10 +94,17 @@ export default function useVoiceTriggerKey(
             e.ctrlKey ||
             e.altKey
         ) {
-            // Any other key resets the counter
+            // Any non-trigger key resets the toggle counter
             if (e.code !== currentKey) {
                 pressCountRef.current = 0
             }
+            return
+        }
+
+        // Focus gate — mirror the recording handler's scope
+        const checkFn = checkIsInputActiveRef.current
+        if (checkFn && !checkFn()) {
+            pressCountRef.current = 0
             return
         }
 
@@ -85,6 +122,16 @@ export default function useVoiceTriggerKey(
         if (pressCountRef.current >= TOGGLE_COUNT) {
             pressCountRef.current = 0
             lastPressTimeRef.current = 0
+
+            // ── P1 fix ──────────────────────────────────────────────────────
+            // Stop the completing keydown from reaching the long-press handler.
+            // Without this, shiftTimerRef is armed on the 7th press and then
+            // the matching keyup is ignored (the key ref has already flipped),
+            // causing a phantom recording ~500 ms later.
+            e.stopImmediatePropagation()
+            e.preventDefault()
+            // ────────────────────────────────────────────────────────────────
+
             const newKey: VoiceTriggerKey =
                 currentKey === "ShiftLeft" ? "ShiftRight" : "ShiftLeft"
             writeStoredKey(newKey)
@@ -94,9 +141,12 @@ export default function useVoiceTriggerKey(
     }, [])
 
     useEffect(() => {
-        window.addEventListener("keydown", handleKeyDown)
-        return () => window.removeEventListener("keydown", handleKeyDown)
-    }, [handleKeyDown])
+        if (!isVoiceEnabled) return
+        // Register with capture=true so we run before the recording handler
+        // and stopImmediatePropagation() on the completing press is effective.
+        window.addEventListener("keydown", handleKeyDown, true)
+        return () => window.removeEventListener("keydown", handleKeyDown, true)
+    }, [isVoiceEnabled, handleKeyDown])
 
     return { voiceTriggerKey }
 }

--- a/packages/dmworkbase/src/Components/MessageInput/useVoiceTriggerKey.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/useVoiceTriggerKey.ts
@@ -1,0 +1,102 @@
+import { useState, useEffect, useRef, useCallback } from "react"
+
+export type VoiceTriggerKey = "ShiftLeft" | "ShiftRight"
+
+const STORAGE_KEY = "octo_voice_trigger_key"
+const TOGGLE_COUNT = 7
+const TOGGLE_INTERVAL_MS = 500
+
+function readStoredKey(): VoiceTriggerKey {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        if (stored === "ShiftLeft" || stored === "ShiftRight") return stored
+    } catch {
+        // ignore
+    }
+    return "ShiftLeft"
+}
+
+function writeStoredKey(key: VoiceTriggerKey): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, key)
+    } catch {
+        // ignore
+    }
+}
+
+export interface UseVoiceTriggerKeyReturn {
+    /** 当前激活的语音触发键，"ShiftLeft" 或 "ShiftRight" */
+    voiceTriggerKey: VoiceTriggerKey
+}
+
+/**
+ * 管理语音输入触发键（ShiftLeft ↔ ShiftRight）。
+ *
+ * 切换手势：连续快速按目标键 7 次（相邻两次 keydown 间隔 < 500ms）。
+ * - 当前为 ShiftLeft  → 连按左 Shift 7 次 → 切换为 ShiftRight
+ * - 当前为 ShiftRight → 连按右 Shift 7 次 → 切换为 ShiftLeft
+ *
+ * 状态持久化到 localStorage（key: octo_voice_trigger_key）。
+ * 切换后通过回调通知调用方以便显示 Toast。
+ */
+export default function useVoiceTriggerKey(
+    onToggled: (newKey: VoiceTriggerKey) => void
+): UseVoiceTriggerKeyReturn {
+    const [voiceTriggerKey, setVoiceTriggerKey] = useState<VoiceTriggerKey>(readStoredKey)
+
+    const voiceTriggerKeyRef = useRef(voiceTriggerKey)
+    voiceTriggerKeyRef.current = voiceTriggerKey
+
+    const onToggledRef = useRef(onToggled)
+    onToggledRef.current = onToggled
+
+    // Rapid-press counter state
+    const pressCountRef = useRef(0)
+    const lastPressTimeRef = useRef(0)
+
+    const handleKeyDown = useCallback((e: KeyboardEvent) => {
+        const currentKey = voiceTriggerKeyRef.current
+        // Only track the current trigger key (no modifiers)
+        if (
+            e.code !== currentKey ||
+            e.repeat ||
+            e.metaKey ||
+            e.ctrlKey ||
+            e.altKey
+        ) {
+            // Any other key resets the counter
+            if (e.code !== currentKey) {
+                pressCountRef.current = 0
+            }
+            return
+        }
+
+        const now = Date.now()
+        const gap = now - lastPressTimeRef.current
+
+        if (gap <= TOGGLE_INTERVAL_MS) {
+            pressCountRef.current += 1
+        } else {
+            // Too slow — restart the sequence
+            pressCountRef.current = 1
+        }
+        lastPressTimeRef.current = now
+
+        if (pressCountRef.current >= TOGGLE_COUNT) {
+            pressCountRef.current = 0
+            lastPressTimeRef.current = 0
+            const newKey: VoiceTriggerKey =
+                currentKey === "ShiftLeft" ? "ShiftRight" : "ShiftLeft"
+            writeStoredKey(newKey)
+            setVoiceTriggerKey(newKey)
+            onToggledRef.current(newKey)
+        }
+    }, [])
+
+    useEffect(() => {
+        window.addEventListener("keydown", handleKeyDown)
+        return () => window.removeEventListener("keydown", handleKeyDown)
+    }, [handleKeyDown])
+
+    return { voiceTriggerKey }
+}

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -53,13 +53,16 @@ export default function VoiceInputButton({
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
 
   // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
-  const { voiceTriggerKey } = useVoiceTriggerKey((newKey: VoiceTriggerKey) => {
-    const msgKey =
-      newKey === "ShiftRight"
-        ? "base.voiceInput.triggerKey.switchedToRight"
-        : "base.voiceInput.triggerKey.switchedToLeft";
-    Toast.info(t(msgKey));
-  });
+  const { voiceTriggerKey } = useVoiceTriggerKey(
+    (newKey: VoiceTriggerKey) => {
+      const msgKey =
+        newKey === "ShiftRight"
+          ? "base.voiceInput.triggerKey.switchedToRight"
+          : "base.voiceInput.triggerKey.switchedToLeft";
+      Toast.info(t(msgKey));
+    },
+    { isVoiceEnabled }
+  );
   const voiceTriggerKeyRef = useRef(voiceTriggerKey);
   voiceTriggerKeyRef.current = voiceTriggerKey;
 

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -52,20 +52,6 @@ export default function VoiceInputButton({
   const pendingModeRef = useRef<VoiceMode>("append_only");
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
 
-  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
-  const { voiceTriggerKey } = useVoiceTriggerKey(
-    (newKey: VoiceTriggerKey) => {
-      const msgKey =
-        newKey === "ShiftRight"
-          ? "base.voiceInput.triggerKey.switchedToRight"
-          : "base.voiceInput.triggerKey.switchedToLeft";
-      Toast.info(t(msgKey));
-    },
-    { isVoiceEnabled }
-  );
-  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
-  voiceTriggerKeyRef.current = voiceTriggerKey;
-
   const {
     isRecording,
     isTranscribing,
@@ -87,6 +73,21 @@ export default function VoiceInputButton({
   isOnlineRef.current = isOnline;
   const localAvailableRef = useRef(localAvailable);
   localAvailableRef.current = localAvailable;
+
+  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses.
+  // Must be called AFTER useTextareaVoice so isVoiceEnabled is already declared.
+  const { voiceTriggerKey } = useVoiceTriggerKey(
+    (newKey: VoiceTriggerKey) => {
+      const msgKey =
+        newKey === "ShiftRight"
+          ? "base.voiceInput.triggerKey.switchedToRight"
+          : "base.voiceInput.triggerKey.switchedToLeft";
+      Toast.info(t(msgKey));
+    },
+    { isVoiceEnabled }
+  );
+  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
+  voiceTriggerKeyRef.current = voiceTriggerKey;
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -9,6 +9,8 @@ import VoiceFeedbackNotice from "../MessageInput/VoiceFeedbackNotice";
 import useSpaceFeedbackSetting, { getSharedSpaceFeedbackState, acceptVoiceInput } from "../MessageInput/useSpaceFeedbackSetting";
 import WKApp from "../../App";
 import { useI18n } from "../../i18n";
+import useVoiceTriggerKey from "../MessageInput/useVoiceTriggerKey";
+import type { VoiceTriggerKey } from "../MessageInput/useVoiceTriggerKey";
 import "./index.css";
 
 const VOICE_MODES: { value: VoiceMode; labelKey: string }[] = [
@@ -49,6 +51,17 @@ export default function VoiceInputButton({
   const buttonRef = useRef<HTMLDivElement>(null);
   const pendingModeRef = useRef<VoiceMode>("append_only");
   const { spaceSetting, loaded, voiceConfig } = useSpaceFeedbackSetting();
+
+  // Voice trigger key (ShiftLeft / ShiftRight), toggled by 7 rapid presses
+  const { voiceTriggerKey } = useVoiceTriggerKey((newKey: VoiceTriggerKey) => {
+    const msgKey =
+      newKey === "ShiftRight"
+        ? "base.voiceInput.triggerKey.switchedToRight"
+        : "base.voiceInput.triggerKey.switchedToLeft";
+    Toast.info(t(msgKey));
+  });
+  const voiceTriggerKeyRef = useRef(voiceTriggerKey);
+  voiceTriggerKeyRef.current = voiceTriggerKey;
 
   const {
     isRecording,
@@ -185,7 +198,7 @@ export default function VoiceInputButton({
       if (!inputRef.current || document.activeElement !== inputRef.current) return;
 
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         !e.repeat &&
         !e.metaKey &&
         !e.ctrlKey &&
@@ -221,7 +234,7 @@ export default function VoiceInputButton({
         return;
       }
 
-      if (shiftTimerRef.current !== null && e.code !== "ShiftLeft") {
+      if (shiftTimerRef.current !== null && e.code !== voiceTriggerKeyRef.current) {
         if (
           e.code.startsWith("Control") ||
           e.code.startsWith("Alt") ||
@@ -247,13 +260,13 @@ export default function VoiceInputButton({
 
       if (!isRecordingRef.current && !isInputFocused) return;
 
-      if (e.code === "ShiftLeft" && shiftTimerRef.current !== null) {
+      if (e.code === voiceTriggerKeyRef.current && shiftTimerRef.current !== null) {
         clearShiftTimer();
         return;
       }
 
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         shiftRecordingRef.current &&
         !isRecordingRef.current
       ) {
@@ -263,7 +276,7 @@ export default function VoiceInputButton({
       }
 
       if (
-        e.code === "ShiftLeft" &&
+        e.code === voiceTriggerKeyRef.current &&
         shiftRecordingRef.current &&
         isRecordingRef.current
       ) {

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1153,6 +1153,8 @@
   "voiceInput.status.transcribingDots": "Transcribing...",
   "voiceInput.title.input": "Voice input",
   "voiceInput.title.inputLongPress": "Voice input (hold Shift)",
+  "voiceInput.triggerKey.switchedToRight": "Voice trigger key switched to Right Shift",
+  "voiceInput.triggerKey.switchedToLeft": "Voice trigger key switched to Left Shift",
   "voiceInput.title.networkUnavailable": "Network unavailable",
   "todo.outputs.tabLabel": "Output Files",
   "todo.outputs.emptySearch": "No matching output files",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1153,6 +1153,8 @@
   "voiceInput.status.transcribingDots": "转写中...",
   "voiceInput.title.input": "语音输入",
   "voiceInput.title.inputLongPress": "语音输入 (长按 Shift)",
+  "voiceInput.triggerKey.switchedToRight": "语音输入键已切换为右 Shift",
+  "voiceInput.triggerKey.switchedToLeft": "语音输入键已切换为左 Shift",
   "voiceInput.title.networkUnavailable": "网络不可用",
   "todo.outputs.tabLabel": "产出文件",
   "todo.outputs.emptySearch": "没有匹配的产出文件",


### PR DESCRIPTION
## Summary

Adds the ability to switch the voice-input long-press trigger key between **Left Shift** and **Right Shift**.

## How it works

Press the **current** trigger key **7 times rapidly** (each press within 500 ms of the previous, no modifier keys held):

- Left Shift ×7 → switches to **Right Shift**
- Right Shift ×7 → switches back to **Left Shift**

A Toast notification confirms the switch (follows the UI locale — zh-CN / en-US).

The choice is persisted to `localStorage` (`octo_voice_trigger_key`) and survives page refresh.

## Changes

| File | Change |
|------|--------|
| `useVoiceTriggerKey.ts` (new) | Hook managing trigger-key state and rapid-press detection |
| `VoiceInputIndicator.tsx` | Integrates hook; replaces hard-coded `"ShiftLeft"` |
| `VoiceInputButton/index.tsx` | Same |
| `zh-CN.json` / `en-US.json` | Two new i18n keys for the Toast messages |
| `useVoiceTriggerKey.test.ts` (new) | 10 unit tests — all pass locally under vitest@4.1.5 |

## Testing

```
pnpm vitest run apps/web/src/__tests__/useVoiceTriggerKey.test.ts
# 10/10 pass
```