### PR TITLE
feat(docs): inline hex input for the font-colour picker (#719)

### DIFF
--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -787,6 +787,74 @@ describe('Toolbar — highlight palette + custom picker', () => {
   })
 })
 
+// XIN-1095 re-review (Jerry-Xin CHANGES_REQUESTED): the highlight popover's inline hex entry carried
+// two user-visible bugs the font-colour path did not.
+//  (1) maxLength={7} on the raw field truncated a pasted hex that arrived with surrounding whitespace
+//      (" #1971c2" / "#1971c2 ") BEFORE the Enter handler could trim it, so a valid paste was wrongly
+//      rejected. normalizeHexColor already trims + validates, so the raw field must not cap length.
+//  (2) it committed with toggleHighlight, so re-entering the colour already on the selection REMOVED
+//      the highlight instead of confirming it. It now uses setHighlight, matching the native
+//      highlight picker (setHighlight on the <input type="color"> change).
+describe('Toolbar — highlight inline hex input (XIN-1095 re-review)', () => {
+  function openHighlightHex(): HTMLInputElement {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.highlight'))
+    const input = document.querySelector<HTMLInputElement>('.octo-highlight-color-popover .octo-color-hex')
+    if (!input) throw new Error('no hex input in the highlight popover')
+    return input
+  }
+
+  it('applies a typed hex highlight to the selection and collapses the popover', () => {
+    const input = openHighlightHex()
+    fireEvent.change(input, { target: { value: '#d1e3f3' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(editor!.getAttributes('highlight').color).toBe('#d1e3f3')
+    // A valid pick collapses the popover, like the preset swatches.
+    expect(document.querySelector('.octo-highlight-color-popover')).toBeNull()
+  })
+
+  // Fix 2 regression: re-entering the SAME colour already on the selection must KEEP the highlight
+  // (setHighlight = apply/confirm), not clear it. This assertion is red on the old toggleHighlight
+  // path (which removes the mark for a same-colour toggle) and green on setHighlight.
+  it('does not clear the highlight when the same colour is re-entered', () => {
+    // Seed the selection with a highlight first…
+    editor!.chain().focus().selectAll().setHighlight({ color: '#d1e3f3' }).run()
+    expect(editor!.getAttributes('highlight').color).toBe('#d1e3f3')
+
+    // …then type the identical hex through the inline field.
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.highlight'))
+    const input = document.querySelector<HTMLInputElement>('.octo-highlight-color-popover .octo-color-hex')!
+    fireEvent.change(input, { target: { value: '#d1e3f3' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // The highlight is still applied — the same-colour entry confirmed it, it did not toggle it off.
+    expect(editor!.getAttributes('highlight').color).toBe('#d1e3f3')
+    expect(editor!.getHTML()).toContain('<mark')
+  })
+
+  // Fix 1 regression: the raw field must not carry a truncating length cap. maxLength={7} clipped a
+  // pasted value with surrounding whitespace before the Enter handler could trim it.
+  it('does not cap the raw input length (so a pasted hex with whitespace is not truncated)', () => {
+    const input = openHighlightHex()
+    // No maxlength attribute → the DOM reports the "no limit" sentinel (-1).
+    expect(input.getAttribute('maxlength')).toBeNull()
+    expect(input.maxLength).toBe(-1)
+  })
+
+  // …and a whitespace-padded hex is trimmed + accepted end-to-end (the reviewer's " #1971c2" paste).
+  it('accepts a whitespace-padded hex and applies the trimmed colour', () => {
+    const input = openHighlightHex()
+    fireEvent.change(input, { target: { value: '  #1971c2  ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(editor!.getAttributes('highlight').color).toBe('#1971c2')
+    // The value parsed, so it was never flagged invalid.
+    expect(input.className).not.toContain('octo-color-hex-invalid')
+  })
+})
+
 describe('Toolbar — custom line-height input (SCHEMA_VERSION 17, focus-steal RC fix)', () => {
   // The custom multiplier input used to be a controlled field that called editor.chain().focus()
   // on every keystroke: typing bounced the caret back into the editor (only the first char

--- a/packages/docs/src/editor/Toolbar.test.tsx
+++ b/packages/docs/src/editor/Toolbar.test.tsx
@@ -111,6 +111,46 @@ describe('Toolbar — batch 7 quote/code/link/highlight/colour tooltips', () => 
   })
 })
 
+describe('Toolbar — font-colour inline hex input (#719)', () => {
+  function openTextColor() {
+    render(<Toolbar editor={editor!} />)
+    editor!.chain().focus().selectAll().run()
+    fireEvent.click(titleBtn('docs.toolbar.textColor'))
+    const input = document.querySelector<HTMLInputElement>('.octo-text-color-popover .octo-color-hex')
+    if (!input) throw new Error('no hex input in the text-colour popover')
+    return input
+  }
+
+  it('applies a typed hex to the selection and persists it as a colour mark', () => {
+    const input = openTextColor()
+    fireEvent.change(input, { target: { value: '#1971c2' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    // The colour lands on the textStyle mark's `color` attr — the content-model value, same as a
+    // preset swatch (getHTML serialises it to rgb() via the DOM, but the stored attr is the hex).
+    expect(editor!.getAttributes('textStyle').color).toBe('#1971c2')
+    // A valid pick collapses the popover, like the preset swatches.
+    expect(document.querySelector('.octo-text-color-popover')).toBeNull()
+  })
+
+  it('normalises a 3-digit shorthand entered without the leading #', () => {
+    const input = openTextColor()
+    fireEvent.change(input, { target: { value: 'f00' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(editor!.getAttributes('textStyle').color).toBe('#ff0000')
+  })
+
+  it('flags an invalid hex and leaves the document untouched', () => {
+    const input = openTextColor()
+    fireEvent.change(input, { target: { value: 'nothex' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(input.className).toContain('octo-color-hex-invalid')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    // No colour mark was written, and the popover stays open so the user can correct it in place.
+    expect(editor!.getAttributes('textStyle').color).toBeUndefined()
+    expect(document.querySelector('.octo-text-color-popover')).toBeTruthy()
+  })
+})
+
 describe('Toolbar — batch 7 floating link popover (item 5)', () => {
   it('opens a floating popover (not an inline toolbar widget) with stacked fields', () => {
     render(<Toolbar editor={editor!} />)

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -14,7 +14,7 @@ import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { INDENT_MAX_LEVEL } from './ParagraphIndent.ts'
 import { TableGridPicker } from './TableControls.tsx'
 import { capturePaintMarks, applyPaintMarks } from './formatPainter.ts'
-import { HIGHLIGHT_COLORS, TEXT_COLORS } from './colorPalette.ts'
+import { HIGHLIGHT_COLORS, TEXT_COLORS, normalizeHexColor } from './colorPalette.ts'
 import { t } from '../octoweb/index.ts'
 import { FONT_FAMILY_ENABLED, LINE_SPACING_ENABLED } from '../config.ts'
 import { FONT_FAMILIES } from './fontFamilies.ts'
@@ -345,6 +345,50 @@ export function shouldShowFloatingMenu(args: {
 // order, same column ↦ same colour family across both pickers. Values stay #rrggbb so they survive
 // Yjs collaboration and the DOCX/Markdown exporters losslessly.
 
+/**
+ * Inline hex entry shared by the font-colour and highlight popovers. It complements the preset
+ * swatches and the native OS wheel (<input type="color">) with an OS-independent way to type or paste
+ * an arbitrary #rrggbb — the "hex 输入" path in #719 — so a user can enter a brand hex directly instead
+ * of hunting for it in the platform colour dialog. It commits ONCE, on Enter, and only when the value
+ * parses to a valid 3-/6-digit hex (normalizeHexColor): one entry is one ProseMirror transaction, i.e.
+ * one undo record and one Yjs update, the same commit-once discipline the native picker uses. Invalid
+ * input is flagged via aria-invalid and never reaches the document; an empty value is a no-op. Typing
+ * into the field blurs the editor but ProseMirror keeps the last selection, and the parent's onCommit
+ * re-focuses via editor.chain().focus() before applying — the same idiom the link popover relies on.
+ */
+function HexColorInput({ onCommit }: { onCommit: (hex: string) => void }) {
+  const [value, setValue] = useState('')
+  const [invalid, setInvalid] = useState(false)
+  return (
+    <input
+      type="text"
+      className={`octo-color-hex${invalid ? ' octo-color-hex-invalid' : ''}`}
+      placeholder={t('docs.toolbar.hexPlaceholder')}
+      aria-label={t('docs.toolbar.hexInput')}
+      aria-invalid={invalid || undefined}
+      value={value}
+      spellCheck={false}
+      maxLength={7}
+      onChange={(e) => {
+        setValue(e.target.value)
+        if (invalid) setInvalid(false)
+      }}
+      onKeyDown={(e) => {
+        if (e.key !== 'Enter') return
+        e.preventDefault()
+        const raw = value.trim()
+        if (raw === '') return
+        const hex = normalizeHexColor(raw)
+        if (!hex) {
+          setInvalid(true)
+          return
+        }
+        onCommit(hex)
+      }}
+    />
+  )
+}
+
 /** Text-highlight control (SCHEMA-SPEC §3): palette of background colours + clear. */
 function HighlightControl({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false)
@@ -423,6 +467,12 @@ function HighlightControl({ editor }: { editor: Editor }) {
               aria-label={t('docs.toolbar.customColor')}
             />
           </label>
+          <HexColorInput
+            onCommit={(hex) => {
+              editor.chain().focus().toggleHighlight({ color: hex }).run()
+              setOpen(false)
+            }}
+          />
         </span>
       )}
     </span>
@@ -495,6 +545,12 @@ function TextColorControl({ editor }: { editor: Editor }) {
               aria-label={t('docs.toolbar.customColor')}
             />
           </label>
+          <HexColorInput
+            onCommit={(hex) => {
+              editor.chain().focus().setColor(hex).run()
+              setOpen(false)
+            }}
+          />
         </span>
       )}
     </span>

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -368,7 +368,10 @@ function HexColorInput({ onCommit }: { onCommit: (hex: string) => void }) {
       aria-invalid={invalid || undefined}
       value={value}
       spellCheck={false}
-      maxLength={7}
+      // No maxLength on the raw input: normalizeHexColor trims and sanitises on Enter, so a paste
+      // that carries leading/trailing whitespace (e.g. " #1971c2") must not be clipped to 7 chars
+      // before it is trimmed — that would wrongly reject an otherwise valid hex. Bad input is still
+      // caught (and flagged via aria-invalid) by the parse, never by a length cap on the raw value.
       onChange={(e) => {
         setValue(e.target.value)
         if (invalid) setInvalid(false)
@@ -469,7 +472,12 @@ function HighlightControl({ editor }: { editor: Editor }) {
           </label>
           <HexColorInput
             onCommit={(hex) => {
-              editor.chain().focus().toggleHighlight({ color: hex }).run()
+              // setHighlight (not toggleHighlight): the hex field is an explicit "apply this
+              // colour" action like the native picker above (Toolbar's setHighlight at the custom
+              // <input type="color"> commit). toggleHighlight would REMOVE the highlight when the
+              // selection already carries the same colour, so re-entering an identical hex must
+              // still leave it applied, not clear it.
+              editor.chain().focus().setHighlight({ color: hex }).run()
               setOpen(false)
             }}
           />

--- a/packages/docs/src/editor/colorPalette.test.ts
+++ b/packages/docs/src/editor/colorPalette.test.ts
@@ -5,6 +5,7 @@ import {
   HIGHLIGHT_COLORS,
   HIGHLIGHT_TINT,
   toHighlightTint,
+  normalizeHexColor,
 } from './colorPalette.ts'
 
 // Plan A: the highlight and font-colour presets are DERIVED from one shared hue base so the two
@@ -62,5 +63,37 @@ describe('colorPalette — toHighlightTint', () => {
   it('rejects a non-#rrggbb input rather than emit a broken swatch', () => {
     expect(() => toHighlightTint('red')).toThrow()
     expect(() => toHighlightTint('#fff')).toThrow()
+  })
+})
+
+describe('colorPalette — normalizeHexColor', () => {
+  it('accepts a 6-digit hex with or without the leading # and lowercases it', () => {
+    expect(normalizeHexColor('#3370FF')).toBe('#3370ff')
+    expect(normalizeHexColor('3370ff')).toBe('#3370ff')
+  })
+
+  it('expands the 3-digit shorthand to #rrggbb', () => {
+    expect(normalizeHexColor('#f00')).toBe('#ff0000')
+    expect(normalizeHexColor('abc')).toBe('#aabbcc')
+  })
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(normalizeHexColor('  #1971c2  ')).toBe('#1971c2')
+  })
+
+  it('emits the same #rrggbb shape as the presets so it round-trips losslessly', () => {
+    TEXT_COLORS.forEach((c) => {
+      expect(normalizeHexColor(c)).toBe(c)
+      expect(normalizeHexColor(c)).toMatch(/^#[0-9a-f]{6}$/)
+    })
+  })
+
+  it('returns null for anything that is not a 3-/6-digit hex', () => {
+    expect(normalizeHexColor('')).toBeNull()
+    expect(normalizeHexColor('#ff')).toBeNull()
+    expect(normalizeHexColor('#ffff')).toBeNull()
+    expect(normalizeHexColor('#gggggg')).toBeNull()
+    expect(normalizeHexColor('rgb(0,0,0)')).toBeNull()
+    expect(normalizeHexColor('red')).toBeNull()
   })
 })

--- a/packages/docs/src/editor/colorPalette.ts
+++ b/packages/docs/src/editor/colorPalette.ts
@@ -39,6 +39,24 @@ export function toHighlightTint(hex: string, amount: number = HIGHLIGHT_TINT): s
 }
 
 /**
+ * Normalise a user-typed hex string to a canonical lowercase `#rrggbb`, or return null if it is not
+ * a valid 3- or 6-digit hex colour. Accepts an optional leading `#`, surrounding whitespace, and any
+ * case; expands the 3-digit shorthand (`#f00` → `#ff0000`). This is the input-side counterpart to the
+ * preset swatches: it lets the font-colour popover accept an arbitrary hex typed/pasted directly
+ * (the "hex 输入" path in #719), OS-dialog-independent, and emits the same `#rrggbb` shape the presets
+ * use — so setColor stays lossless through Yjs collaboration and the DOCX/Markdown exporters.
+ */
+export function normalizeHexColor(raw: string): string | null {
+  const s = raw.trim().replace(/^#/, '')
+  if (/^[0-9a-fA-F]{3}$/.test(s)) {
+    const [r, g, b] = s
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase()
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(s)) return `#${s}`.toLowerCase()
+  return null
+}
+
+/**
  * Shared hue base. `text` is the saturated foreground colour; the matching highlight background is
  * derived from it. Ordered neutrals-first (ink, grey) then warm→cool, mirroring the established
  * font-colour identity set so the text picker keeps its familiar swatches.

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -366,6 +366,34 @@
   opacity: 0;
   cursor: pointer;
 }
+/* Inline hex entry (#719): an OS-independent way to type/paste an arbitrary #rrggbb alongside the
+   preset swatches and the native wheel. Sized to sit inline in the popover row; the invalid state
+   flags a hex that failed to parse (see normalizeHexColor) so it reads before the user hits Enter. */
+.octo-color-hex {
+  width: 74px;
+  height: 22px;
+  padding: 0 6px;
+  font-size: 12px;
+  color: var(--octo-fg);
+  background: var(--octo-bg);
+  border: 1px solid var(--octo-border);
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+.octo-color-hex:focus {
+  outline: none;
+  border-color: var(--octo-accent);
+}
+/* Reuse the same invalid-input red the link field uses, so a rejected value reads consistently
+   across the toolbar. It is an intentional literal signal colour, not a themeable UI token —
+   declared as an exception to the hardcoded-colour policy (stylelint.ci.config.mjs → color-no-hex),
+   matching .octo-link-field.is-invalid. */
+/* stylelint-disable color-no-hex */
+.octo-color-hex-invalid,
+.octo-color-hex-invalid:focus {
+  border-color: #eb5757;
+}
+/* stylelint-enable color-no-hex */
 .octo-code-lang {
   border: 1px solid var(--octo-border);
   border-radius: 6px;

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -138,6 +138,8 @@
     "highlight": "Highlight",
     "textColor": "Text color",
     "customColor": "Custom color",
+    "hexInput": "Hex color",
+    "hexPlaceholder": "#rrggbb",
     "table": "Table",
     "image": "Image",
     "file": "File",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -138,6 +138,8 @@
     "highlight": "高亮",
     "textColor": "文字颜色",
     "customColor": "自定义颜色",
+    "hexInput": "十六进制颜色",
+    "hexPlaceholder": "#rrggbb",
     "table": "表格",
     "image": "图片",
     "file": "文件",


### PR DESCRIPTION
## Summary

Closes part of #719. The font-colour picker already ships preset swatches and a native colour wheel (`<input type="color">`); the remaining gap in the issue's acceptance criteria was an **OS-independent way to enter an exact hex**. Today the only path to a specific brand colour is the platform colour dialog, where the hex field is buried and varies across OSes/browsers.

This adds an inline `#rrggbb` text field to the popover so a colour can be typed or pasted directly, alongside the presets and the wheel.

## What changed

- **`normalizeHexColor()`** (`colorPalette.ts`) — parses a 3- or 6-digit hex (optional leading `#`, any case, surrounding whitespace) to a canonical lowercase `#rrggbb`, or `null` when invalid.
- **`HexColorInput`** (`Toolbar.tsx`) — a small shared field wired into both the font-colour and highlight popovers. It applies through the **existing** `textStyle` colour mark via `setColor` / `setHighlight`, so the value persists into the document content model and round-trips through Yjs collaboration and the DOCX/Markdown exporters exactly like a preset swatch — no new UI state, no new dependency.
- Commits **once, on Enter** (one ProseMirror transaction = one undo record, one Yjs update), matching the native picker's commit-once behaviour. Invalid input is flagged via `aria-invalid` and never reaches the document; an empty value is a no-op.
- i18n keys added for both `zh-CN` and `en-US`; CSS follows the existing popover/theme-token conventions.

## Acceptance criteria (#719)

- [x] Preset palette of common font colours (already shipped — 10 swatches).
- [x] Custom colour picker for any colour — native wheel (already shipped) **plus** the new inline hex input.
- [x] Chosen colour applied to the selection and saved into the content model (`textStyle` colour mark).
- [x] Rendering consistent across editing and read-only views (both register the same `TextStyle` + `Color` extensions, so the colour renders through the identical inline style).

## Testing

- `colorPalette.test.ts` — hex normalization (shorthand expansion, `#`-optional, case/whitespace, lossless round-trip of the presets, rejection of non-hex).
- `Toolbar.test.tsx` — the popover applies a typed hex to the selection as a colour mark, normalises `f00` → `#ff0000`, and flags an invalid value without touching the document.
- Manual browser verification (local standalone build): typed a custom hex, confirmed it applies to the selection and renders identically in edit and read-only views.

## Notes

Draft on purpose — kept open for review only, not for merge. Promotion to a ready PR is handled separately.
