### PR TITLE
feat(docs): freeze panes for editor tables with ribbon entry and right-click submenu

### DIFF
--- a/packages/docs/src/editor/TableControls.test.tsx
+++ b/packages/docs/src/editor/TableControls.test.tsx
@@ -244,9 +244,10 @@ describe('TableContextMenu — right-click inside a cell opens the menu (XIN-105
     // Selection was moved into the right-clicked cell so position-relative commands act on it.
     expect(e.isActive('table')).toBe(true)
     // All seven table commands are present (add row before/after, delete row, add column
-    // before/after, delete column, delete table).
+    // before/after, delete column, delete table), plus the collapsed "Freeze" submenu trigger (#755)
+    // whose sub-options are hidden until it is expanded.
     const buttons = menu!.querySelectorAll('button.octo-tb-btn')
-    expect(buttons.length).toBe(7)
+    expect(buttons.length).toBe(8)
     e.destroy()
     host.remove()
   })
@@ -500,5 +501,102 @@ describe('TableGridPicker — insert at a chosen size (no more hardcoded 3×3)',
     expect(screen.getByLabelText('1 × 1')).toBeTruthy()
     expect(screen.getByLabelText('8 × 8')).toBeTruthy()
     e.destroy()
+  })
+})
+
+// Table freeze panes (#755, XIN-1096). The freeze feature is greenfield — before this change the
+// right-click menu had no freeze option and no submenu at all. The tests below lock in (a) the
+// submenu opening reliably by construction (a click-toggled accordion, so the document mousedown
+// that immediately follows the trigger click can never race it closed — the failure mode behind the
+// reported "freeze submenu occasionally doesn't pop up" bug), and (b) the freeze commands actually
+// flipping the view-state the sticky renderer reads.
+import { TableFreeze, getFreezeSpec } from './TableFreeze.ts'
+
+function freezeTableEditor(content: string, element?: HTMLElement) {
+  return new Editor({
+    element,
+    editable: true,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableFreeze,
+    ],
+    content,
+  })
+}
+
+function openTableMenu(e: Editor) {
+  e.view.posAtCoords = () => ({ pos: firstCellTextPos(e), inside: -1 })
+  fireEvent(e.view.dom, createEvent.contextMenu(e.view.dom, { clientX: 120, clientY: 90 }))
+}
+
+describe('TableContextMenu — Freeze submenu opens reliably (#755)', () => {
+  it('hides the freeze sub-options until Freeze is clicked, then reveals them', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = freezeTableEditor(HISTORICAL_DOC, host)
+    render(<TableContextMenu editor={e} />)
+    openTableMenu(e)
+
+    // Collapsed: the sub-options are not in the DOM yet.
+    expect(document.querySelector('.octo-table-submenu')).toBeNull()
+    expect(screen.queryByTitle('docs.table.freezeHeaderRow')).toBeNull()
+
+    fireEvent.click(screen.getByTitle('docs.table.freeze'))
+
+    const submenu = document.querySelector('.octo-table-submenu')
+    expect(submenu).toBeTruthy()
+    expect(screen.getByTitle('docs.table.freezeHeaderRow')).toBeTruthy()
+    expect(screen.getByTitle('docs.table.freezeFirstColumn')).toBeTruthy()
+    expect(screen.getByTitle('docs.table.unfreeze')).toBeTruthy()
+    e.destroy()
+    host.remove()
+  })
+
+  it('stays open across the document mousedown that follows the trigger click (the flaky-open bug)', () => {
+    // A hover flyout / capture-phase-driven submenu can be closed by the same pointer interaction
+    // that was meant to open it, which is what produced the intermittent "submenu doesn't pop up".
+    // The accordion is click-toggled state on the menu itself, so a mousedown INSIDE the menu (which
+    // the outside-close handler ignores) leaves it open every time.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = freezeTableEditor(HISTORICAL_DOC, host)
+    render(<TableContextMenu editor={e} />)
+    openTableMenu(e)
+
+    const freezeBtn = screen.getByTitle('docs.table.freeze')
+    fireEvent.click(freezeBtn)
+    // Simulate the pointer settling on the menu (the interaction that used to collapse a flyout).
+    fireEvent.mouseDown(freezeBtn)
+
+    expect(document.querySelector('.octo-table-submenu')).toBeTruthy()
+    expect(screen.getByTitle('docs.table.freezeHeaderRow')).toBeTruthy()
+    e.destroy()
+    host.remove()
+  })
+
+  it('freezes the header row when the sub-option is clicked, and unfreezes it', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const e = freezeTableEditor(HISTORICAL_DOC, host)
+    render(<TableContextMenu editor={e} />)
+
+    openTableMenu(e)
+    fireEvent.click(screen.getByTitle('docs.table.freeze'))
+    fireEvent.click(screen.getByTitle('docs.table.freezeHeaderRow'))
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 0 })
+    // Menu closes after running a command.
+    expect(document.querySelector('.octo-table-context-menu')).toBeNull()
+
+    // Toggle it back off.
+    openTableMenu(e)
+    fireEvent.click(screen.getByTitle('docs.table.freeze'))
+    fireEvent.click(screen.getByTitle('docs.table.freezeHeaderRow'))
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 0, cols: 0 })
+    e.destroy()
+    host.remove()
   })
 })

--- a/packages/docs/src/editor/TableControls.tsx
+++ b/packages/docs/src/editor/TableControls.tsx
@@ -19,6 +19,7 @@ import type { ReactNode } from 'react'
 import { TextSelection } from '@tiptap/pm/state'
 import { CellSelection } from '@tiptap/pm/tables'
 import type { Editor } from '@tiptap/core'
+import { getFreezeSpec, isInTable } from './TableFreeze.ts'
 import { t } from '../octoweb/index.ts'
 
 // Largest table the grid picker can size in one drag. Big enough for the common cases; authors who
@@ -75,12 +76,41 @@ const IconTable = () => (
     <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5zm2 1v3h5V6H6zm7 0v3h5V6h-5zM6 11v3h5v-3H6zm7 0v3h5v-3h-5zm-7 5v2h5v-2H6zm7 0v2h5v-2h-5z" />
   </svg>
 )
+// Freeze glyphs: a table outline with the frozen band (top row / first column) filled solid so the
+// action reads at a glance, matching the 3×3-grid style of the add/delete icons above.
+const IconFreeze = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5z" opacity="0.35" />
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3H4V5zM4 8h5v12H5a1 1 0 0 1-1-1V8z" />
+  </svg>
+)
+const IconFreezeRow = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5z" opacity="0.35" />
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v4H4V5z" />
+  </svg>
+)
+const IconFreezeCol = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5z" opacity="0.35" />
+    <path d="M4 5a1 1 0 0 1 1-1h5v16H5a1 1 0 0 1-1-1V5z" />
+  </svg>
+)
+const IconUnfreeze = () => (
+  <svg className="octo-tb-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5zm2 1v12h12V6H6z" />
+    <path d="M8.7 8.7a1 1 0 0 1 1.4 0L12 10.6l1.9-1.9a1 1 0 1 1 1.4 1.4L13.4 12l1.9 1.9a1 1 0 0 1-1.4 1.4L12 13.4l-1.9 1.9a1 1 0 0 1-1.4-1.4L10.6 12 8.7 10.1a1 1 0 0 1 0-1.4z" />
+  </svg>
+)
 
 function TbBtn({
   onClick,
   label,
   title,
   text,
+  active,
+  disabled,
+  caret,
 }: {
   onClick: () => void
   label: ReactNode
@@ -89,18 +119,27 @@ function TbBtn({
   // delete controls (#621-2) so the user reads which row/column/table the action removes,
   // instead of guessing from an icon alone.
   text?: string
+  // Active (e.g. this freeze band is on) and disabled states, mirroring the toolbar Btn.
+  active?: boolean
+  disabled?: boolean
+  // Expander caret ("▸"/"▾") shown at the row's trailing edge for a submenu trigger (#755).
+  caret?: ReactNode
 }) {
   return (
     <button
       type="button"
-      className={'octo-tb-btn' + (text ? ' octo-tb-btn--labeled' : '')}
+      className={
+        'octo-tb-btn' + (text ? ' octo-tb-btn--labeled' : '') + (active ? ' is-active' : '')
+      }
       title={title}
       aria-label={title}
+      disabled={disabled}
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
     >
       {label}
       {text ? <span className="octo-tb-btn-label">{text}</span> : null}
+      {caret ? <span className="octo-tb-btn-caret">{caret}</span> : null}
     </button>
   )
 }
@@ -191,6 +230,10 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
   // Viewport-coord anchor point where the user right-clicked; null while the menu is closed.
   const [point, setPoint] = useState<{ x: number; y: number } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  // Whether the inline "Freeze" submenu is expanded (#755). Kept as plain React state on the menu
+  // itself and toggled by a click — no hover flyout, no portal, no capture-phase listener that could
+  // race the toggle — so the sub-options open reliably every time the user picks Freeze.
+  const [freezeOpen, setFreezeOpen] = useState(false)
   // Cell positions (anchor/head) of a multi-cell CellSelection captured at right-click time, or
   // null when the click was on a single cell. See the snapshot in onContextMenu below for why this
   // has to be remembered rather than re-read from the live selection when a menu item is clicked.
@@ -221,6 +264,7 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
         sel instanceof CellSelection
           ? { anchor: sel.$anchorCell.pos, head: sel.$headCell.pos }
           : null
+      setFreezeOpen(false)
       setPoint({ x: e.clientX, y: e.clientY })
     }
     dom.addEventListener('contextmenu', onContextMenu)
@@ -282,8 +326,12 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
     }
     fn()
     cellRangeRef.current = null
+    setFreezeOpen(false)
     setPoint(null)
   }
+
+  // Freeze extent of the right-clicked table, so the submenu can show which bands are already on.
+  const freeze = getFreezeSpec(editor.state)
 
   return (
     <div
@@ -330,6 +378,52 @@ export function TableContextMenu({ editor }: { editor: Editor }) {
         text={t('docs.table.deleteColumn')}
         onClick={() => run(() => editor.chain().focus().deleteColumn().run())}
       />
+      <span className="octo-tb-sep" />
+      <TbBtn
+        label={<IconFreeze />}
+        title={t('docs.table.freeze')}
+        text={t('docs.table.freeze')}
+        active={freeze.rows > 0 || freeze.cols > 0}
+        caret={freezeOpen ? '▾' : '▸'}
+        onClick={() => setFreezeOpen((v) => !v)}
+      />
+      {freezeOpen && (
+        <div className="octo-table-submenu" role="group" aria-label={t('docs.table.freeze')}>
+          <TbBtn
+            label={<IconFreezeRow />}
+            title={t('docs.table.freezeHeaderRow')}
+            text={t('docs.table.freezeHeaderRow')}
+            active={freeze.rows > 0}
+            onClick={() => run(() => editor.chain().focus().toggleFreezeHeaderRow().run())}
+          />
+          <TbBtn
+            label={<IconFreezeRow />}
+            title={t('docs.table.freezeThroughRow')}
+            text={t('docs.table.freezeThroughRow')}
+            onClick={() => run(() => editor.chain().focus().freezeThroughSelectedRow().run())}
+          />
+          <TbBtn
+            label={<IconFreezeCol />}
+            title={t('docs.table.freezeFirstColumn')}
+            text={t('docs.table.freezeFirstColumn')}
+            active={freeze.cols > 0}
+            onClick={() => run(() => editor.chain().focus().toggleFreezeFirstColumn().run())}
+          />
+          <TbBtn
+            label={<IconFreezeCol />}
+            title={t('docs.table.freezeThroughColumn')}
+            text={t('docs.table.freezeThroughColumn')}
+            onClick={() => run(() => editor.chain().focus().freezeThroughSelectedColumn().run())}
+          />
+          <TbBtn
+            label={<IconUnfreeze />}
+            title={t('docs.table.unfreeze')}
+            text={t('docs.table.unfreeze')}
+            disabled={freeze.rows === 0 && freeze.cols === 0}
+            onClick={() => run(() => editor.chain().focus().clearTableFreeze().run())}
+          />
+        </div>
+      )}
       <span className="octo-tb-sep" />
       <TbBtn
         label={<IconDeleteTable />}
@@ -417,6 +511,111 @@ export function TableGridPicker({ editor }: { editor: Editor }) {
             )}
           </span>
           <span className="octo-table-grid-label">{label}</span>
+        </span>
+      )}
+    </span>
+  )
+}
+
+/**
+ * Ribbon entry for freeze panes (#755): a dedicated toolbar button that opens a small popover with
+ * the same freeze actions as the right-click submenu, so authors can freeze rows/columns without
+ * discovering the context menu. Disabled unless the caret is inside a table; the button reads active
+ * while any band of the current table is frozen. Reuses the shared color-control popover pattern
+ * (relative wrapper + absolute float, outside-click / Escape close) so it matches the toolbar's other
+ * dropdowns. All state lives in the freeze plugin — this only dispatches commands.
+ */
+export function TableFreezeControl({ editor }: { editor: Editor }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLSpanElement>(null)
+
+  // Re-render on selection / document changes so the enabled + active states track the caret.
+  const [, force] = useState(0)
+  useEffect(() => {
+    const bump = () => force((n) => n + 1)
+    editor.on('transaction', bump)
+    editor.on('selectionUpdate', bump)
+    return () => {
+      editor.off('transaction', bump)
+      editor.off('selectionUpdate', bump)
+    }
+  }, [editor])
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const inTable = isInTable(editor.state)
+  const freeze = getFreezeSpec(editor.state)
+  const frozen = freeze.rows > 0 || freeze.cols > 0
+
+  // Run a freeze command then close the popover. Focus stays in the editor so the command sees the
+  // same caret/cell the popover was opened for.
+  const run = (fn: () => void) => {
+    fn()
+    setOpen(false)
+  }
+
+  return (
+    <span className="octo-color-control octo-table-freeze-control" ref={ref}>
+      <button
+        type="button"
+        className={'octo-tb-btn' + (frozen ? ' is-active' : '')}
+        title={t('docs.toolbar.freeze')}
+        aria-label={t('docs.toolbar.freeze')}
+        disabled={!inTable}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <IconFreeze />
+      </button>
+      {open && inTable && (
+        <span className="octo-color-popover octo-table-freeze-popover" role="menu">
+          <TbBtn
+            label={<IconFreezeRow />}
+            title={t('docs.table.freezeHeaderRow')}
+            text={t('docs.table.freezeHeaderRow')}
+            active={freeze.rows > 0}
+            onClick={() => run(() => editor.chain().focus().toggleFreezeHeaderRow().run())}
+          />
+          <TbBtn
+            label={<IconFreezeRow />}
+            title={t('docs.table.freezeThroughRow')}
+            text={t('docs.table.freezeThroughRow')}
+            onClick={() => run(() => editor.chain().focus().freezeThroughSelectedRow().run())}
+          />
+          <TbBtn
+            label={<IconFreezeCol />}
+            title={t('docs.table.freezeFirstColumn')}
+            text={t('docs.table.freezeFirstColumn')}
+            active={freeze.cols > 0}
+            onClick={() => run(() => editor.chain().focus().toggleFreezeFirstColumn().run())}
+          />
+          <TbBtn
+            label={<IconFreezeCol />}
+            title={t('docs.table.freezeThroughColumn')}
+            text={t('docs.table.freezeThroughColumn')}
+            onClick={() => run(() => editor.chain().focus().freezeThroughSelectedColumn().run())}
+          />
+          <TbBtn
+            label={<IconUnfreeze />}
+            title={t('docs.table.unfreeze')}
+            text={t('docs.table.unfreeze')}
+            disabled={!frozen}
+            onClick={() => run(() => editor.chain().focus().clearTableFreeze().run())}
+          />
         </span>
       )}
     </span>

--- a/packages/docs/src/editor/TableFreeze.test.ts
+++ b/packages/docs/src/editor/TableFreeze.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Editor } from '@tiptap/core'
+import type { Node as PMNode } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
@@ -199,36 +200,58 @@ describe('TableFreeze plugin state', () => {
 
 describe('applyFrozenStyles — sticky styling of the frozen bands', () => {
   // jsdom has no layout, so stub the box metrics the styler measures. Row heights = 20px each,
-  // column widths = 50px each, so cumulative offsets are predictable.
-  function buildTable(rows: number, cols: number): HTMLTableElement {
-    const table = document.createElement('table')
-    const wrapper = document.createElement('div')
-    wrapper.className = 'tableWrapper'
-    wrapper.appendChild(table)
-    const tbody = document.createElement('tbody')
-    for (let r = 0; r < rows; r++) {
-      const tr = document.createElement('tr')
-      Object.defineProperty(tr, 'offsetHeight', {
-        value: 20,
-        configurable: true,
-      })
-      for (let c = 0; c < cols; c++) {
-        const td = document.createElement('td')
+  // and each visual column is 50px wide (a colspan=N cell reports 50*N), so cumulative offsets are
+  // predictable. Tables are rendered through a real editor so the DOM and the ProseMirror node the
+  // styler derives its TableMap from are guaranteed to line up (as they do in the live plugin).
+  function renderTable(tableHtml: string): { e: Editor; node: PMNode; table: HTMLTableElement } {
+    const e = editor('<p>x</p>' + tableHtml)
+    let pos = -1
+    e.state.doc.descendants((n, p) => {
+      if (pos === -1 && n.type.name === 'table') {
+        pos = p
+        return false
+      }
+      return pos === -1
+    })
+    const node = e.state.doc.nodeAt(pos)!
+    const dom = e.view.nodeDOM(pos) as HTMLElement
+    const table = (dom instanceof HTMLTableElement ? dom : dom.querySelector('table'))!
+    // The live editor renders tables inside a `.tableWrapper` scroll container (the styler toggles
+    // `octo-has-frozen-rows` on it). With resizing off the test editor omits that NodeView, so add
+    // the wrapper in place to mirror production without detaching the table from the editor DOM.
+    if (!table.closest('.tableWrapper')) {
+      const wrapper = document.createElement('div')
+      wrapper.className = 'tableWrapper'
+      table.parentNode?.insertBefore(wrapper, table)
+      wrapper.appendChild(table)
+    }
+    Array.from(table.rows).forEach((tr) => {
+      Object.defineProperty(tr, 'offsetHeight', { value: 20, configurable: true })
+      Array.from(tr.cells).forEach((td) => {
         Object.defineProperty(td, 'offsetWidth', {
-          value: 50,
+          value: 50 * (td.colSpan || 1),
           configurable: true,
         })
-        tr.appendChild(td)
-      }
-      tbody.appendChild(tr)
+      })
+    })
+    return { e, node, table }
+  }
+
+  /** Uniform `rows`×`cols` grid (no merged cells), rendered like the live editor. */
+  function buildTable(rows: number, cols: number): { e: Editor; node: PMNode; table: HTMLTableElement } {
+    let html = '<table><tbody>'
+    for (let r = 0; r < rows; r++) {
+      html += '<tr>'
+      for (let c = 0; c < cols; c++) html += `<td>r${r}c${c}</td>`
+      html += '</tr>'
     }
-    table.appendChild(tbody)
-    return table
+    html += '</tbody></table>'
+    return renderTable(html)
   }
 
   it('marks the first two rows sticky-top with cumulative offsets and z-index', () => {
-    const table = buildTable(4, 3)
-    applyFrozenStyles(table, { rows: 2, cols: 0 })
+    const { e, node, table } = buildTable(4, 3)
+    applyFrozenStyles(table, node, { rows: 2, cols: 0 })
     const rows = Array.from(table.rows)
     expect(rows[0].cells[0].style.position).toBe('sticky')
     expect(rows[0].cells[0].style.top).toBe('0px')
@@ -238,11 +261,12 @@ describe('applyFrozenStyles — sticky styling of the frozen bands', () => {
     expect(table.closest('.tableWrapper')!.classList.contains('octo-has-frozen-rows')).toBe(true)
     // The table switches to the separate-border class so sticky cells actually hold in Chromium.
     expect(table.classList.contains('octo-frozen-table')).toBe(true)
+    e.destroy()
   })
 
   it('marks the first column sticky-left and gives the corner the top z-index', () => {
-    const table = buildTable(3, 4)
-    applyFrozenStyles(table, { rows: 1, cols: 1 })
+    const { e, node, table } = buildTable(3, 4)
+    applyFrozenStyles(table, node, { rows: 1, cols: 1 })
     const rows = Array.from(table.rows)
     expect(rows[1].cells[0].style.position).toBe('sticky')
     expect(rows[1].cells[0].style.left).toBe('0px')
@@ -250,11 +274,70 @@ describe('applyFrozenStyles — sticky styling of the frozen bands', () => {
     expect(rows[0].cells[0].style.zIndex).toBe('4')
     expect(rows[0].cells[1].style.zIndex).toBe('3')
     expect(table.closest('.tableWrapper')!.classList.contains('octo-has-frozen-rows')).toBe(true)
+    e.destroy()
+  })
+
+  // Merged-cell regression (#775 review). Both cases fail with the old DOM-index styler: a colspan
+  // cell is one DOM entry but several visual columns, and a rowspan cell is absent from the rows it
+  // covers — so `row.cells[i]` is NOT visual column `i`. The TableMap-derived styler keys off the
+  // grid rect instead, so the frozen band follows the real column geometry.
+  it('freezes the true columns of a header row containing a colspan cell', () => {
+    // Row 0: [colspan=2 over cols 0-1][col 2]; rows 1-2: three single cells. Freeze first 2 columns.
+    const { e, node, table } = renderTable(
+      '<table><tbody>' +
+        '<tr><th colspan="2">ab</th><th>c</th></tr>' +
+        '<tr><td>d</td><td>e</td><td>f</td></tr>' +
+        '<tr><td>g</td><td>h</td><td>i</td></tr>' +
+        '</tbody></table>',
+    )
+    applyFrozenStyles(table, node, { rows: 0, cols: 2 })
+    const rows = Array.from(table.rows)
+
+    // Header: the colspan cell spans cols 0-1 → frozen at left 0; the lone col-2 cell is NOT frozen.
+    // The old code froze both (DOM index 1 < 2) and mis-offset the col-2 header by a column.
+    expect(rows[0].cells[0].classList.contains('octo-frozen-col-cell')).toBe(true)
+    expect(rows[0].cells[0].style.left).toBe('0px')
+    expect(rows[0].cells[1].classList.contains('octo-frozen-cell')).toBe(false)
+    expect(rows[0].cells[1].hasAttribute('data-octo-frozen')).toBe(false)
+
+    // Body rows: columns 0 and 1 frozen at 0px / 50px, column 2 untouched.
+    expect(rows[1].cells[0].style.left).toBe('0px')
+    expect(rows[1].cells[1].style.left).toBe('50px')
+    expect(rows[1].cells[2].classList.contains('octo-frozen-cell')).toBe(false)
+    e.destroy()
+  })
+
+  it('freezes the first column without leaking into a row skipped by a rowspan cell', () => {
+    // Col 0 of row 0 spans rows 0-1 (rowspan=2). Row 1 therefore has ONE DOM cell — its col-1 cell.
+    // Freeze the first column: only the real col-0 cells should stick.
+    const { e, node, table } = renderTable(
+      '<table><tbody>' +
+        '<tr><td rowspan="2">a</td><td>b</td></tr>' +
+        '<tr><td>c</td></tr>' +
+        '<tr><td>d</td><td>e</td></tr>' +
+        '</tbody></table>',
+    )
+    applyFrozenStyles(table, node, { rows: 0, cols: 1 })
+    const rows = Array.from(table.rows)
+
+    // Row 0: the rowspan cell is col 0 → frozen; its sibling is col 1 → not frozen.
+    expect(rows[0].cells[0].classList.contains('octo-frozen-col-cell')).toBe(true)
+    expect(rows[0].cells[1].classList.contains('octo-frozen-cell')).toBe(false)
+
+    // Row 1's only DOM cell is col 1 (col 0 is covered by the rowspan) → it must NOT be frozen.
+    // The old code froze it because it sat at DOM index 0 (< frozenCols).
+    expect(rows[1].cells[0].classList.contains('octo-frozen-cell')).toBe(false)
+    expect(rows[1].cells[0].hasAttribute('data-octo-frozen')).toBe(false)
+
+    // Row 2 is a normal row: col 0 frozen, col 1 not.
+    expect(rows[2].cells[0].classList.contains('octo-frozen-col-cell')).toBe(true)
+    expect(rows[2].cells[1].classList.contains('octo-frozen-cell')).toBe(false)
+    e.destroy()
   })
 
   it('clearFrozenCell fully reverts a styled cell', () => {
-    const table = buildTable(2, 2)
-    applyFrozenStyles(table, { rows: 1, cols: 1 })
+    const { e, node, table } = buildTable(2, 2)
+    applyFrozenStyles(table, node, { rows: 1, cols: 1 })
     const cell = table.rows[0].cells[0]
     expect(cell.getAttribute('data-octo-frozen')).toBe('')
     clearFrozenCell(cell)
@@ -264,5 +347,6 @@ describe('applyFrozenStyles — sticky styling of the frozen bands', () => {
     expect(cell.style.zIndex).toBe('')
     expect(cell.hasAttribute('data-octo-frozen')).toBe(false)
     expect(cell.classList.contains('octo-frozen-cell')).toBe(false)
+    e.destroy()
   })
 })

--- a/packages/docs/src/editor/TableFreeze.test.ts
+++ b/packages/docs/src/editor/TableFreeze.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import {
+  TableFreeze,
+  tableFreezeKey,
+  cumulativeOffsets,
+  getFreezeSpec,
+  isInTable,
+  applyFrozenStyles,
+  clearFrozenCell,
+} from './TableFreeze.ts'
+
+// #755 (XIN-1096) — freeze panes for the Docs editor table. Freeze is VIEW-STATE: the extension
+// keeps a Map<tablePos, {rows, cols}> in a ProseMirror plugin (never written to the Y.Doc). These
+// tests exercise the pure offset helper, the commands, and the plugin's position remapping across
+// edits — the pixel-level sticky styling is verified in the browser (jsdom has no layout).
+
+function editor(content: string) {
+  return new Editor({
+    editable: true,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableFreeze,
+    ],
+    content,
+  })
+}
+
+const DOC =
+  '<p>before</p>' +
+  '<table><tbody>' +
+  '<tr><th>a</th><th>b</th><th>c</th></tr>' +
+  '<tr><td>d</td><td>e</td><td>f</td></tr>' +
+  '<tr><td>g</td><td>h</td><td>i</td></tr>' +
+  '</tbody></table>' +
+  '<p>after</p>'
+
+/** First text position inside the first table cell. */
+function firstCellTextPos(e: Editor): number {
+  let pos = -1
+  e.state.doc.descendants((node, p) => {
+    if (pos === -1 && (node.type.name === 'tableCell' || node.type.name === 'tableHeader')) {
+      pos = p + 2
+      return false
+    }
+    return pos === -1
+  })
+  return pos
+}
+
+/** Text position inside the cell at (row, col) of the first table (0-based). */
+function cellTextPos(e: Editor, row: number, col: number): number {
+  let tableStart = -1
+  e.state.doc.descendants((node, p) => {
+    if (tableStart === -1 && node.type.name === 'table') {
+      tableStart = p
+      return false
+    }
+    return tableStart === -1
+  })
+  const table = e.state.doc.nodeAt(tableStart)!
+  let target = -1
+  let rowIdx = 0
+  table.forEach((rowNode, rowOffset) => {
+    if (rowIdx === row) {
+      let colIdx = 0
+      rowNode.forEach((cellNode, cellOffset) => {
+        if (colIdx === col) {
+          // tableStart + 1 (into table) + rowOffset + 1 (into row) + cellOffset + 1 (into cell) + 1 (into paragraph)
+          target = tableStart + 1 + rowOffset + 1 + cellOffset + 2
+        }
+        colIdx++
+      })
+    }
+    rowIdx++
+  })
+  return target
+}
+
+describe('cumulativeOffsets', () => {
+  it('returns prefix sums with a leading zero', () => {
+    expect(cumulativeOffsets([])).toEqual([])
+    expect(cumulativeOffsets([40])).toEqual([0])
+    expect(cumulativeOffsets([40, 80, 30])).toEqual([0, 40, 120])
+  })
+})
+
+describe('TableFreeze commands', () => {
+  it('toggleFreezeHeaderRow freezes then unfreezes the top row', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(firstCellTextPos(e))
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 0, cols: 0 })
+
+    e.chain().focus().toggleFreezeHeaderRow().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 0 })
+
+    e.chain().focus().toggleFreezeHeaderRow().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 0, cols: 0 })
+    e.destroy()
+  })
+
+  it('toggleFreezeFirstColumn freezes the first column independently of rows', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(firstCellTextPos(e))
+    e.chain().focus().toggleFreezeHeaderRow().run()
+    e.chain().focus().toggleFreezeFirstColumn().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 1 })
+
+    e.chain().focus().toggleFreezeFirstColumn().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 0 })
+    e.destroy()
+  })
+
+  it('freezeThroughSelectedRow freezes N rows up to the caret row', () => {
+    const e = editor(DOC)
+    // Caret in row index 1 (the second row) -> freeze 2 rows.
+    e.commands.setTextSelection(cellTextPos(e, 1, 0))
+    e.chain().focus().freezeThroughSelectedRow().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 2, cols: 0 })
+    e.destroy()
+  })
+
+  it('freezeThroughSelectedColumn freezes N columns up to the caret column', () => {
+    const e = editor(DOC)
+    // Caret in column index 2 (the third column) -> freeze 3 columns.
+    e.commands.setTextSelection(cellTextPos(e, 0, 2))
+    e.chain().focus().freezeThroughSelectedColumn().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 0, cols: 3 })
+    e.destroy()
+  })
+
+  it('setTableFreeze clamps the request to the table dimensions', () => {
+    const e = editor(DOC) // 3 rows × 3 cols
+    e.commands.setTextSelection(firstCellTextPos(e))
+    e.chain().focus().setTableFreeze({ rows: 99, cols: 99 }).run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 3, cols: 3 })
+    e.destroy()
+  })
+
+  it('clearTableFreeze removes the entry entirely', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(firstCellTextPos(e))
+    e.chain().focus().setTableFreeze({ rows: 2, cols: 1 }).run()
+    expect(tableFreezeKey.getState(e.state)!.size).toBe(1)
+
+    e.chain().focus().clearTableFreeze().run()
+    expect(tableFreezeKey.getState(e.state)!.size).toBe(0)
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 0, cols: 0 })
+    e.destroy()
+  })
+
+  it('does nothing when the caret is not inside a table', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(2) // in the leading "before" paragraph
+    expect(isInTable(e.state)).toBe(false)
+    const ok = e.chain().focus().toggleFreezeHeaderRow().run()
+    expect(ok).toBe(false)
+    expect(tableFreezeKey.getState(e.state)!.size).toBe(0)
+    e.destroy()
+  })
+})
+
+describe('TableFreeze plugin state', () => {
+  it('keeps the freeze pinned to the table as content is inserted before it', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(firstCellTextPos(e))
+    e.chain().focus().toggleFreezeHeaderRow().run()
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 0 })
+
+    // Type into the leading paragraph (shifts every position after it, including the table).
+    e.chain().setTextSelection(2).insertContent('XYZ more text ').run()
+
+    // The freeze survived the remap and still resolves for the (now shifted) table.
+    e.commands.setTextSelection(firstCellTextPos(e))
+    expect(getFreezeSpec(e.state)).toEqual({ rows: 1, cols: 0 })
+    e.destroy()
+  })
+
+  it('drops the freeze entry when its table is deleted', () => {
+    const e = editor(DOC)
+    e.commands.setTextSelection(firstCellTextPos(e))
+    e.chain().focus().setTableFreeze({ rows: 1, cols: 1 }).run()
+    expect(tableFreezeKey.getState(e.state)!.size).toBe(1)
+
+    e.chain().focus().deleteTable().run()
+    expect(tableFreezeKey.getState(e.state)!.size).toBe(0)
+    e.destroy()
+  })
+})
+
+describe('applyFrozenStyles — sticky styling of the frozen bands', () => {
+  // jsdom has no layout, so stub the box metrics the styler measures. Row heights = 20px each,
+  // column widths = 50px each, so cumulative offsets are predictable.
+  function buildTable(rows: number, cols: number): HTMLTableElement {
+    const table = document.createElement('table')
+    const wrapper = document.createElement('div')
+    wrapper.className = 'tableWrapper'
+    wrapper.appendChild(table)
+    const tbody = document.createElement('tbody')
+    for (let r = 0; r < rows; r++) {
+      const tr = document.createElement('tr')
+      Object.defineProperty(tr, 'offsetHeight', {
+        value: 20,
+        configurable: true,
+      })
+      for (let c = 0; c < cols; c++) {
+        const td = document.createElement('td')
+        Object.defineProperty(td, 'offsetWidth', {
+          value: 50,
+          configurable: true,
+        })
+        tr.appendChild(td)
+      }
+      tbody.appendChild(tr)
+    }
+    table.appendChild(tbody)
+    return table
+  }
+
+  it('marks the first two rows sticky-top with cumulative offsets and z-index', () => {
+    const table = buildTable(4, 3)
+    applyFrozenStyles(table, { rows: 2, cols: 0 })
+    const rows = Array.from(table.rows)
+    expect(rows[0].cells[0].style.position).toBe('sticky')
+    expect(rows[0].cells[0].style.top).toBe('0px')
+    expect(rows[0].cells[0].style.zIndex).toBe('3')
+    expect(rows[1].cells[2].style.top).toBe('20px')
+    expect(rows[2].cells[0].style.position).toBe('')
+    expect(table.closest('.tableWrapper')!.classList.contains('octo-has-frozen-rows')).toBe(true)
+    // The table switches to the separate-border class so sticky cells actually hold in Chromium.
+    expect(table.classList.contains('octo-frozen-table')).toBe(true)
+  })
+
+  it('marks the first column sticky-left and gives the corner the top z-index', () => {
+    const table = buildTable(3, 4)
+    applyFrozenStyles(table, { rows: 1, cols: 1 })
+    const rows = Array.from(table.rows)
+    expect(rows[1].cells[0].style.position).toBe('sticky')
+    expect(rows[1].cells[0].style.left).toBe('0px')
+    expect(rows[1].cells[0].style.zIndex).toBe('2')
+    expect(rows[0].cells[0].style.zIndex).toBe('4')
+    expect(rows[0].cells[1].style.zIndex).toBe('3')
+    expect(table.closest('.tableWrapper')!.classList.contains('octo-has-frozen-rows')).toBe(true)
+  })
+
+  it('clearFrozenCell fully reverts a styled cell', () => {
+    const table = buildTable(2, 2)
+    applyFrozenStyles(table, { rows: 1, cols: 1 })
+    const cell = table.rows[0].cells[0]
+    expect(cell.getAttribute('data-octo-frozen')).toBe('')
+    clearFrozenCell(cell)
+    expect(cell.style.position).toBe('')
+    expect(cell.style.top).toBe('')
+    expect(cell.style.left).toBe('')
+    expect(cell.style.zIndex).toBe('')
+    expect(cell.hasAttribute('data-octo-frozen')).toBe(false)
+    expect(cell.classList.contains('octo-frozen-cell')).toBe(false)
+  })
+})

--- a/packages/docs/src/editor/TableFreeze.ts
+++ b/packages/docs/src/editor/TableFreeze.ts
@@ -1,0 +1,363 @@
+// Table freeze panes (#755, XIN-1096).
+//
+// Adds "freeze rows / freeze columns" (冻结窗格) to the Docs editor table without touching the
+// collaborative content model. Freeze is a VIEW-STATE feature:
+//
+//   - The set of frozen tables (keyed by the table node's document position) lives in a ProseMirror
+//     plugin state, NOT in the Y.Doc. Nothing is written to the schema, so SCHEMA_VERSION and the
+//     backend stub are untouched and there is no collab-sync surface to conflict on. The trade-off
+//     is that freeze is per-client and does not persist across reload — documented in the PR. (If
+//     leadership later wants durable, shared freeze, it becomes a coordinated schema-version bump
+//     adding frozenRows/frozenCols attrs to the `table` node, the same class of change as v18.)
+//
+//   - The plugin's view applies `position: sticky` to the first N rows / first N columns of each
+//     frozen table, measuring row heights / column widths from the live DOM so the sticky offsets
+//     line up with resized columns (#749). A frozen table is also flipped to separate borders
+//     (`octo-frozen-table` class) because Chromium ignores sticky on `<td>/<th>` under
+//     border-collapse:collapse and the table's default overflow:hidden captures the sticky offset —
+//     both verified in the browser. Styling the cells' own DOM is safe under collaboration:
+//     TableCellView.ignoreMutation already discards attribute/style mutations on the cell element,
+//     so these writes never round-trip as document edits.
+//
+// The ribbon button (Toolbar) and the right-click submenu (TableControls) both drive the commands
+// declared here; they never manipulate freeze state directly.
+
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import type { EditorState } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { TableMap, selectionCell } from '@tiptap/pm/tables'
+
+/** How many leading rows / columns of a table are frozen. `{ rows: 0, cols: 0 }` means unfrozen. */
+export interface FreezeSpec {
+  rows: number
+  cols: number
+}
+
+/** Frozen tables, keyed by the document position immediately BEFORE the table node. */
+export type FreezeMap = Map<number, FreezeSpec>
+
+interface FreezeMeta {
+  pos: number
+  spec: FreezeSpec
+}
+
+export const tableFreezeKey = new PluginKey<FreezeMap>('octoTableFreeze')
+
+/**
+ * Prefix sums of `sizes`: element i is the sum of every size before it (so the first is always 0).
+ * Used to turn a list of frozen row heights / column widths into the sticky `top` / `left` offset
+ * for each frozen band. Pure so it can be unit-tested without a real layout (jsdom reports 0-size
+ * boxes, so the browser is where the pixel offsets are actually verified).
+ */
+export function cumulativeOffsets(sizes: number[]): number[] {
+  const out: number[] = []
+  let acc = 0
+  for (const s of sizes) {
+    out.push(acc)
+    acc += s
+  }
+  return out
+}
+
+interface CellContext {
+  /** Position immediately before the enclosing table node (the FreezeMap key). */
+  tablePos: number
+  /** Zero-based row / column index of the cell holding the selection head. */
+  rowIndex: number
+  colIndex: number
+  /** Table dimensions, used to clamp a freeze request to what the table can actually offer. */
+  rowCount: number
+  colCount: number
+}
+
+/**
+ * Resolve the table cell around the selection head, or null when the caret is not inside a table.
+ * Returns the enclosing table's position (used as the freeze key) plus the clicked cell's row/column
+ * index so "freeze up to this row/column" can turn the caret position into a frozen band count.
+ */
+function cellContext(state: EditorState): CellContext | null {
+  let $cell
+  try {
+    $cell = selectionCell(state)
+  } catch {
+    return null
+  }
+  if (!$cell) return null
+  const table = $cell.node(-1)
+  if (!table || table.type.name !== 'table') return null
+  const map = TableMap.get(table)
+  const tableStart = $cell.start(-1)
+  const rect = map.findCell($cell.pos - tableStart)
+  return {
+    tablePos: $cell.before(-1),
+    rowIndex: rect.top,
+    colIndex: rect.left,
+    rowCount: map.height,
+    colCount: map.width,
+  }
+}
+
+/** Whether the caret currently sits inside a table (gates the freeze UI). */
+export function isInTable(state: EditorState): boolean {
+  return cellContext(state) !== null
+}
+
+/**
+ * Freeze spec for the table around the current selection, `{ rows: 0, cols: 0 }` when unfrozen or
+ * outside a table. The ribbon/menu read this to show active state.
+ */
+export function getFreezeSpec(state: EditorState): FreezeSpec {
+  const ctx = cellContext(state)
+  if (!ctx) return { rows: 0, cols: 0 }
+  return tableFreezeKey.getState(state)?.get(ctx.tablePos) ?? { rows: 0, cols: 0 }
+}
+
+// --- rendering (plugin view) -------------------------------------------------------------------
+
+const FROZEN_ATTR = 'data-octo-frozen'
+
+export function clearFrozenCell(cell: HTMLElement): void {
+  cell.style.position = ''
+  cell.style.top = ''
+  cell.style.left = ''
+  cell.style.zIndex = ''
+  cell.classList.remove('octo-frozen-cell', 'octo-frozen-row-cell', 'octo-frozen-col-cell')
+  cell.removeAttribute(FROZEN_ATTR)
+}
+
+/**
+ * Apply sticky styling to the first `spec.rows` rows and `spec.cols` columns of `table`. Offsets are
+ * measured from the live DOM so they follow column resizes. A frozen row's cells stick to the top; a
+ * frozen column's cells stick to the left; a corner cell (both) stacks above either single axis.
+ */
+export function applyFrozenStyles(table: HTMLTableElement, spec: FreezeSpec): void {
+  const rows = Array.from(table.rows)
+  if (!rows.length) return
+  const frozenRows = Math.max(0, Math.min(spec.rows, rows.length))
+  const colCount = rows[0].cells.length
+  const frozenCols = Math.max(0, Math.min(spec.cols, colCount))
+  const anyFrozen = frozenRows > 0 || frozenCols > 0
+
+  // A frozen table switches to separate borders and is no longer its own scroll container — both
+  // required for position:sticky on cells to actually hold (Chromium ignores sticky cells under
+  // border-collapse:collapse, and the table's default overflow:hidden captures the sticky offset).
+  // The border redraw lives in CSS keyed off this class.
+  table.classList.toggle('octo-frozen-table', anyFrozen)
+
+  // A frozen header needs a vertical scroll container to stick within — the wrapper already scrolls
+  // horizontally, so bound its height (CSS) only while rows are frozen.
+  const wrapper = table.closest('.tableWrapper')
+  if (wrapper) wrapper.classList.toggle('octo-has-frozen-rows', frozenRows > 0)
+
+  const rowTops = cumulativeOffsets(rows.slice(0, frozenRows).map((r) => r.offsetHeight))
+  const colLefts = cumulativeOffsets(
+    Array.from(rows[0].cells)
+      .slice(0, frozenCols)
+      .map((c) => c.offsetWidth),
+  )
+
+  rows.forEach((row, rIdx) => {
+    Array.from(row.cells).forEach((cell, cIdx) => {
+      const inFrozenRow = rIdx < frozenRows
+      const inFrozenCol = cIdx < frozenCols
+      if (!inFrozenRow && !inFrozenCol) return
+      cell.setAttribute(FROZEN_ATTR, '')
+      cell.classList.add('octo-frozen-cell')
+      cell.style.position = 'sticky'
+      if (inFrozenRow) {
+        cell.classList.add('octo-frozen-row-cell')
+        cell.style.top = `${rowTops[rIdx]}px`
+      }
+      if (inFrozenCol) {
+        cell.classList.add('octo-frozen-col-cell')
+        cell.style.left = `${colLefts[cIdx]}px`
+      }
+      cell.style.zIndex = inFrozenRow && inFrozenCol ? '4' : inFrozenRow ? '3' : '2'
+    })
+  })
+}
+
+/**
+ * Plugin view that keeps the DOM in sync with the freeze state: on every editor update it clears any
+ * previously frozen cells and re-applies sticky styling for the currently frozen tables. Re-measuring
+ * each time keeps the offsets correct after column resizes, row insert/delete, or remote edits.
+ */
+class FreezeStyleView {
+  private view: EditorView
+
+  constructor(view: EditorView) {
+    this.view = view
+    this.render()
+  }
+
+  update(): void {
+    this.render()
+  }
+
+  destroy(): void {
+    this.reset()
+  }
+
+  private reset(): void {
+    this.view.dom
+      .querySelectorAll<HTMLElement>(`[${FROZEN_ATTR}]`)
+      .forEach((el) => clearFrozenCell(el))
+    this.view.dom
+      .querySelectorAll('.octo-has-frozen-rows')
+      .forEach((el) => el.classList.remove('octo-has-frozen-rows'))
+    this.view.dom
+      .querySelectorAll('.octo-frozen-table')
+      .forEach((el) => el.classList.remove('octo-frozen-table'))
+  }
+
+  private render(): void {
+    this.reset()
+    const map = tableFreezeKey.getState(this.view.state)
+    if (!map || map.size === 0) return
+    map.forEach((spec, pos) => {
+      if (spec.rows <= 0 && spec.cols <= 0) return
+      let dom: Node | null = null
+      try {
+        dom = this.view.nodeDOM(pos)
+      } catch {
+        dom = null
+      }
+      if (!(dom instanceof HTMLElement)) return
+      const table =
+        dom instanceof HTMLTableElement ? dom : dom.querySelector<HTMLTableElement>('table')
+      if (!table) return
+      applyFrozenStyles(table, spec)
+    })
+  }
+}
+
+/**
+ * The freeze plugin: holds the FreezeMap, remaps it across document edits (dropping entries whose
+ * table was deleted), and mounts the styling view.
+ */
+export function tableFreezePlugin(): Plugin<FreezeMap> {
+  return new Plugin<FreezeMap>({
+    key: tableFreezeKey,
+    state: {
+      init: () => new Map(),
+      apply(tr, value) {
+        let next = value
+        if (tr.docChanged && value.size) {
+          const mapped: FreezeMap = new Map()
+          value.forEach((spec, pos) => {
+            const mappedPos = tr.mapping.map(pos, -1)
+            const node = tr.doc.nodeAt(mappedPos)
+            if (node && node.type.name === 'table') mapped.set(mappedPos, spec)
+          })
+          next = mapped
+        }
+        const meta = tr.getMeta(tableFreezeKey) as FreezeMeta | undefined
+        if (meta) {
+          next = new Map(next)
+          if (meta.spec.rows <= 0 && meta.spec.cols <= 0) next.delete(meta.pos)
+          else next.set(meta.pos, meta.spec)
+        }
+        return next
+      },
+    },
+    view(view) {
+      return new FreezeStyleView(view)
+    },
+  })
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    tableFreeze: {
+      /** Set an explicit freeze extent on the current table (fields left undefined keep their value). */
+      setTableFreeze: (spec: Partial<FreezeSpec>) => ReturnType
+      /** Toggle freezing the top header row (rows 0 ↔ 1), keeping the frozen-column count. */
+      toggleFreezeHeaderRow: () => ReturnType
+      /** Toggle freezing the first column (cols 0 ↔ 1), keeping the frozen-row count. */
+      toggleFreezeFirstColumn: () => ReturnType
+      /** Freeze every row down to and including the row holding the caret. */
+      freezeThroughSelectedRow: () => ReturnType
+      /** Freeze every column up to and including the column holding the caret. */
+      freezeThroughSelectedColumn: () => ReturnType
+      /** Remove all freezing from the current table. */
+      clearTableFreeze: () => ReturnType
+    }
+  }
+}
+
+/** Table freeze-panes extension: view-state freeze plus the commands the UI drives. */
+export const TableFreeze = Extension.create({
+  name: 'tableFreeze',
+
+  addProseMirrorPlugins() {
+    return [tableFreezePlugin()]
+  },
+
+  addCommands() {
+    const dispatchFreeze = (
+      state: EditorState,
+      dispatch: ((tr: import('@tiptap/pm/state').Transaction) => void) | undefined,
+      compute: (current: FreezeSpec, ctx: CellContext) => FreezeSpec,
+    ): boolean => {
+      const ctx = cellContext(state)
+      if (!ctx) return false
+      const current = tableFreezeKey.getState(state)?.get(ctx.tablePos) ?? {
+        rows: 0,
+        cols: 0,
+      }
+      const wanted = compute(current, ctx)
+      const spec: FreezeSpec = {
+        rows: Math.max(0, Math.min(Math.round(wanted.rows), ctx.rowCount)),
+        cols: Math.max(0, Math.min(Math.round(wanted.cols), ctx.colCount)),
+      }
+      if (dispatch) {
+        const meta: FreezeMeta = { pos: ctx.tablePos, spec }
+        dispatch(state.tr.setMeta(tableFreezeKey, meta))
+      }
+      return true
+    }
+
+    return {
+      setTableFreeze:
+        (spec) =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, (current) => ({
+            rows: spec.rows ?? current.rows,
+            cols: spec.cols ?? current.cols,
+          })),
+      toggleFreezeHeaderRow:
+        () =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, (current) => ({
+            rows: current.rows >= 1 ? 0 : 1,
+            cols: current.cols,
+          })),
+      toggleFreezeFirstColumn:
+        () =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, (current) => ({
+            rows: current.rows,
+            cols: current.cols >= 1 ? 0 : 1,
+          })),
+      freezeThroughSelectedRow:
+        () =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, (current, ctx) => ({
+            rows: ctx.rowIndex + 1,
+            cols: current.cols,
+          })),
+      freezeThroughSelectedColumn:
+        () =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, (current, ctx) => ({
+            rows: current.rows,
+            cols: ctx.colIndex + 1,
+          })),
+      clearTableFreeze:
+        () =>
+        ({ state, dispatch }) =>
+          dispatchFreeze(state, dispatch, () => ({ rows: 0, cols: 0 })),
+    }
+  },
+})

--- a/packages/docs/src/editor/TableFreeze.ts
+++ b/packages/docs/src/editor/TableFreeze.ts
@@ -26,6 +26,7 @@ import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import type { EditorState } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
+import type { Node as PMNode } from '@tiptap/pm/model'
 import { TableMap, selectionCell } from '@tiptap/pm/tables'
 
 /** How many leading rows / columns of a table are frozen. `{ rows: 0, cols: 0 }` means unfrozen. */
@@ -127,16 +128,69 @@ export function clearFrozenCell(cell: HTMLElement): void {
 }
 
 /**
- * Apply sticky styling to the first `spec.rows` rows and `spec.cols` columns of `table`. Offsets are
- * measured from the live DOM so they follow column resizes. A frozen row's cells stick to the top; a
- * frozen column's cells stick to the left; a corner cell (both) stacks above either single axis.
+ * Per-visual-column widths for a table, measured from the live DOM against the span-aware grid.
+ *
+ * A `colspan` cell owns several grid columns (one DOM cell, N visual columns) and a `rowspan` cell
+ * is absent from the `<tr>`s it covers, so a plain `row.cells[i].offsetWidth` is NOT the width of
+ * visual column `i`. We walk the ProseMirror rows/cells in lockstep with the DOM cells — they render
+ * in the same order — and size each column from a `colspan=1` cell wherever one exists, falling back
+ * to splitting a spanning cell's width across the columns it is the only source for.
  */
-export function applyFrozenStyles(table: HTMLTableElement, spec: FreezeSpec): void {
-  const rows = Array.from(table.rows)
-  if (!rows.length) return
-  const frozenRows = Math.max(0, Math.min(spec.rows, rows.length))
-  const colCount = rows[0].cells.length
-  const frozenCols = Math.max(0, Math.min(spec.cols, colCount))
+function measureColumnWidths(domRows: HTMLTableRowElement[], node: PMNode, map: TableMap): number[] {
+  const widths = new Array<number>(map.width).fill(NaN)
+  const spanning: { left: number; right: number; width: number }[] = []
+
+  node.forEach((rowNode, rowOffset, rowIdx) => {
+    const domRow = domRows[rowIdx]
+    if (!domRow) return
+    const domCells = domRow.cells
+    let d = 0
+    rowNode.forEach((_cellNode, cellOffset) => {
+      const cell = domCells[d++]
+      if (!cell) return
+      const rect = map.findCell(rowOffset + 1 + cellOffset)
+      if (rect.right - rect.left === 1) {
+        if (Number.isNaN(widths[rect.left])) widths[rect.left] = cell.offsetWidth
+      } else {
+        spanning.push({ left: rect.left, right: rect.right, width: cell.offsetWidth })
+      }
+    })
+  })
+
+  // Columns only ever covered by spanning cells: split the spanning cell's width across the columns
+  // it alone touches, so cumulative left offsets stay monotonic.
+  for (const s of spanning) {
+    const unknown: number[] = []
+    let known = 0
+    for (let c = s.left; c < s.right; c++) {
+      if (Number.isNaN(widths[c])) unknown.push(c)
+      else known += widths[c]
+    }
+    if (unknown.length) {
+      const each = Math.max(0, (s.width - known) / unknown.length)
+      for (const c of unknown) widths[c] = each
+    }
+  }
+
+  for (let c = 0; c < widths.length; c++) if (Number.isNaN(widths[c])) widths[c] = 0
+  return widths
+}
+
+/**
+ * Apply sticky styling to the first `spec.rows` rows and `spec.cols` columns of `table`. Frozen-band
+ * membership and the sticky offsets are derived from the table's `TableMap` — the same span-aware
+ * grid model the freeze commands use — NOT from raw DOM cell indices, so merged cells stay aligned:
+ * a `colspan` cell occupies its full column range and a `rowspan` cell only lives in the row it
+ * starts in (the rows it covers have no DOM cell of their own). Offsets are still measured from the
+ * live DOM so they follow column resizes. A frozen row's cells stick to the top; a frozen column's
+ * cells stick to the left; a corner cell (both) stacks above either single axis.
+ */
+export function applyFrozenStyles(table: HTMLTableElement, node: PMNode, spec: FreezeSpec): void {
+  const domRows = Array.from(table.rows)
+  if (!domRows.length) return
+  const map = TableMap.get(node)
+  const frozenRows = Math.max(0, Math.min(spec.rows, map.height))
+  const frozenCols = Math.max(0, Math.min(spec.cols, map.width))
   const anyFrozen = frozenRows > 0 || frozenCols > 0
 
   // A frozen table switches to separate borders and is no longer its own scroll container — both
@@ -150,28 +204,34 @@ export function applyFrozenStyles(table: HTMLTableElement, spec: FreezeSpec): vo
   const wrapper = table.closest('.tableWrapper')
   if (wrapper) wrapper.classList.toggle('octo-has-frozen-rows', frozenRows > 0)
 
-  const rowTops = cumulativeOffsets(rows.slice(0, frozenRows).map((r) => r.offsetHeight))
-  const colLefts = cumulativeOffsets(
-    Array.from(rows[0].cells)
-      .slice(0, frozenCols)
-      .map((c) => c.offsetWidth),
-  )
+  // Each <tr> is exactly one visual row, so DOM row index == grid row index — top offsets come
+  // straight from the row boxes. Column widths must respect spans, so measure against the grid.
+  const rowTops = cumulativeOffsets(domRows.slice(0, frozenRows).map((r) => r.offsetHeight))
+  const colWidths = measureColumnWidths(domRows, node, map)
+  const colLefts = cumulativeOffsets(colWidths.slice(0, frozenCols))
 
-  rows.forEach((row, rIdx) => {
-    Array.from(row.cells).forEach((cell, cIdx) => {
-      const inFrozenRow = rIdx < frozenRows
-      const inFrozenCol = cIdx < frozenCols
+  node.forEach((rowNode, rowOffset, rowIdx) => {
+    const domRow = domRows[rowIdx]
+    if (!domRow) return
+    const domCells = domRow.cells
+    let d = 0
+    rowNode.forEach((_cellNode, cellOffset) => {
+      const cell = domCells[d++]
+      if (!cell) return
+      const rect = map.findCell(rowOffset + 1 + cellOffset)
+      const inFrozenRow = rect.top < frozenRows
+      const inFrozenCol = rect.left < frozenCols
       if (!inFrozenRow && !inFrozenCol) return
       cell.setAttribute(FROZEN_ATTR, '')
       cell.classList.add('octo-frozen-cell')
       cell.style.position = 'sticky'
       if (inFrozenRow) {
         cell.classList.add('octo-frozen-row-cell')
-        cell.style.top = `${rowTops[rIdx]}px`
+        cell.style.top = `${rowTops[rect.top]}px`
       }
       if (inFrozenCol) {
         cell.classList.add('octo-frozen-col-cell')
-        cell.style.left = `${colLefts[cIdx]}px`
+        cell.style.left = `${colLefts[rect.left]}px`
       }
       cell.style.zIndex = inFrozenRow && inFrozenCol ? '4' : inFrozenRow ? '3' : '2'
     })
@@ -217,6 +277,8 @@ class FreezeStyleView {
     if (!map || map.size === 0) return
     map.forEach((spec, pos) => {
       if (spec.rows <= 0 && spec.cols <= 0) return
+      const node = this.view.state.doc.nodeAt(pos)
+      if (!node || node.type.name !== 'table') return
       let dom: Node | null = null
       try {
         dom = this.view.nodeDOM(pos)
@@ -227,7 +289,7 @@ class FreezeStyleView {
       const table =
         dom instanceof HTMLTableElement ? dom : dom.querySelector<HTMLTableElement>('table')
       if (!table) return
-      applyFrozenStyles(table, spec)
+      applyFrozenStyles(table, node, spec)
     })
   }
 }

--- a/packages/docs/src/editor/Toolbar.tsx
+++ b/packages/docs/src/editor/Toolbar.tsx
@@ -12,7 +12,7 @@ import { promptAndInsertMath } from './mathInsert.ts'
 import { sanitizeLinkHref } from './sanitize.ts'
 import { CALLOUT_VARIANTS, type CalloutVariant } from './Callout.ts'
 import { INDENT_MAX_LEVEL } from './ParagraphIndent.ts'
-import { TableGridPicker } from './TableControls.tsx'
+import { TableGridPicker, TableFreezeControl } from './TableControls.tsx'
 import { capturePaintMarks, applyPaintMarks } from './formatPainter.ts'
 import { HIGHLIGHT_COLORS, TEXT_COLORS } from './colorPalette.ts'
 import { t } from '../octoweb/index.ts'
@@ -1530,6 +1530,7 @@ export function Toolbar({ editor }: { editor: Editor }) {
       <HighlightControl editor={editor} />
       <TextColorControl editor={editor} />
       <TableGridPicker editor={editor} />
+      <TableFreezeControl editor={editor} />
       <Btn label="Image" title={t('docs.toolbar.image')} onClick={() => void pickAndUploadImage(editor)} />
       <Btn label="File" title={t('docs.toolbar.file')} onClick={() => void pickAndUploadFile(editor)} />
       <Btn label="Bookmark" title={t('docs.toolbar.bookmark')} onClick={() => void promptAndInsertBookmark(editor)} />

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -36,6 +36,7 @@ import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
 import { TableCellView } from './TableCellView.ts'
+import { TableFreeze } from './TableFreeze.ts'
 import { OctoImage } from './ImageNode.ts'
 import { CommentHighlight } from '../comments/CommentDecorations.ts'
 import { buildEmoji } from './emoji.ts'
@@ -242,6 +243,10 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
         return ({ node }) => new TableCellView(node, 'td')
       },
     }),
+    // #755 (XIN-1096): freeze rows/columns (冻结窗格). View-state only — a plugin marks the first N
+    // rows / columns sticky, nothing is written to the Y.Doc (see TableFreeze.ts). Registered on the
+    // live editor only; the static/export editor below has no interactive freeze.
+    TableFreeze,
     // SCHEMA-SPEC §2 (SCHEMA_VERSION 2): image node. Extends @tiptap/extension-image
     // (pinned 2.27.2, single core) with the backend-aligned attr set + parse/render
     // mapping and a self-built NodeView. docId is threaded so the NodeView and the

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -509,6 +509,41 @@
   line-height: 1;
   white-space: nowrap;
 }
+/* Trailing expander caret on a submenu-trigger row (#755 Freeze), pushed to the right edge. */
+.octo-tb-btn-caret {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--octo-muted, #8a919e);
+}
+/* Inline "Freeze" submenu inside the right-click menu (#755): a click-toggled accordion (no hover
+   flyout, no portal) so the sub-options open reliably. Indented under the Freeze row to read as a
+   nested group. */
+.octo-table-submenu {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding-left: 10px;
+  margin-left: 2px;
+  border-left: 2px solid var(--octo-border);
+}
+/* Freeze popover launched from the ribbon button (#755): same vertical row layout as the context
+   menu, floated under the toolbar button via the shared color-popover frame. */
+.octo-table-freeze-popover {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 176px;
+}
+.octo-table-freeze-popover .octo-tb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  text-align: left;
+}
 
 /* Grid picker for inserting a table at a chosen size (replaces the fixed 3×3). Floats under the
    toolbar button via the shared .octo-color-control / .octo-color-popover pattern. */
@@ -1931,6 +1966,49 @@
 }
 .octo-prose .tableWrapper {
   overflow-x: auto;
+}
+
+/* Table freeze panes (#755, XIN-1096). Freeze is VIEW-STATE: the TableFreeze plugin marks the first
+   N rows / columns of a table position:sticky (offsets measured + set inline by its view), so they
+   stay put while the body scrolls. Nothing is written to the Y.Doc — freeze is per-client and not
+   persisted across reload (see PR notes). The rules here supply the opaque backgrounds sticky cells
+   need (so scrolled content does not show through), the scroll box a frozen header sticks within,
+   and the separate-border treatment sticky cells require; positioning + z-index are set inline. */
+.octo-prose table td.octo-frozen-cell {
+  background: var(--octo-bg, #fff);
+}
+.octo-prose table th.octo-frozen-cell {
+  background: var(--octo-hover, #f2f3f5);
+}
+/* A frozen table must not use border-collapse:collapse (Chromium ignores position:sticky on
+   <td>/<th> under collapsed borders) and must not be its own scroll container (the default
+   overflow:hidden captures the sticky offset so the band scrolls away anyway — both confirmed in
+   the browser). Switch a frozen table to separate borders with no spacing, then redraw single 1px
+   lines: the table paints the outer top + left, each cell paints its own right + bottom. The class
+   is added by the plugin only while a table is frozen, so normal tables are untouched. */
+.octo-prose table.octo-frozen-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: visible;
+  border-top: 1px solid var(--octo-border);
+  border-left: 1px solid var(--octo-border);
+}
+.octo-prose table.octo-frozen-table td,
+.octo-prose table.octo-frozen-table th {
+  border-width: 0 1px 1px 0;
+}
+/* A frozen header needs a bounded vertical scroll container to stick within (the wrapper already
+   scrolls horizontally). Only applied while at least one row is frozen, so default tables that flow
+   in the page are unchanged. */
+.octo-prose .tableWrapper.octo-has-frozen-rows {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+/* #749 interplay: sticky frozen cells create stacking contexts (z-index ≤ 4, set inline) that would
+   otherwise occlude the un-z-indexed column-resize handle at right:-2px, so a frozen column could
+   not be resized. Lift the handle above every frozen cell to keep column-width dragging working. */
+.octo-prose table .column-resize-handle {
+  z-index: 6;
 }
 
 /* Image node (SCHEMA-SPEC §2). The NodeView renders a wrapper + <img>; alignment is

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -193,7 +193,8 @@
     "bookmark": "Bookmark",
     "collapsible": "Collapsible block",
     "callout": "Callout",
-    "mathBlock": "Block formula"
+    "mathBlock": "Block formula",
+    "freeze": "Freeze panes"
   },
   "table": {
     "addRowBefore": "Insert row above",
@@ -204,7 +205,13 @@
     "deleteColumn": "Delete column",
     "deleteTable": "Delete table",
     "pickerHint": "Pick a size",
-    "pickerLabel": "Table size"
+    "pickerLabel": "Table size",
+    "freeze": "Freeze",
+    "freezeHeaderRow": "Freeze header row",
+    "freezeThroughRow": "Freeze up to this row",
+    "freezeFirstColumn": "Freeze first column",
+    "freezeThroughColumn": "Freeze up to this column",
+    "unfreeze": "Unfreeze"
   },
   "callout": {
     "info": "Info",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -193,7 +193,8 @@
     "bookmark": "书签",
     "collapsible": "折叠块",
     "callout": "标注",
-    "mathBlock": "公式块"
+    "mathBlock": "公式块",
+    "freeze": "冻结窗格"
   },
   "table": {
     "addRowBefore": "在上方插入行",
@@ -204,7 +205,13 @@
     "deleteColumn": "删除列",
     "deleteTable": "删除表格",
     "pickerHint": "选择尺寸",
-    "pickerLabel": "表格尺寸"
+    "pickerLabel": "表格尺寸",
+    "freeze": "冻结",
+    "freezeHeaderRow": "冻结首行",
+    "freezeThroughRow": "冻结到当前行",
+    "freezeFirstColumn": "冻结首列",
+    "freezeThroughColumn": "冻结到当前列",
+    "unfreeze": "取消冻结"
   },
   "callout": {
     "info": "信息",


### PR DESCRIPTION
## Summary

Adds **freeze panes (冻结行列)** to the Docs editor table (closes #755): a ribbon entry, a reliable right-click submenu, and sticky freezing of the top N rows / first N columns.

> **Draft on purpose — do not merge.** Opened as a draft to carry review. Promotion to a normal PR (`gh pr ready`) is out of scope for this change and happens only after review + deploy + QA are green and the change is signed off.

## What changed

- **Ribbon button.** A dedicated **Freeze** control sits next to the table insert control. It is disabled unless the caret is inside a table and reads active while the current table has any frozen band. Clicking opens a small popover with: freeze header row, freeze up to current row, freeze first column, freeze up to current column, unfreeze.
- **Right-click submenu.** The table context menu gains an inline **Freeze ▸** entry that expands the same five actions.
- **Freeze behaviour.** Freezes the top **N** rows and/or first **N** columns; frozen cells stay fixed on both horizontal and vertical scroll. Offsets are measured from the live DOM, so they stay correct after column resizes.

## The "submenu occasionally doesn't pop up" bug

On the current `main` the table context menu is a **flat** menu — there is no freeze option and no submenu at all, so there was no existing flaky submenu to reproduce a red against. Rather than reintroduce the classic failure mode, the freeze submenu is built to be **reliable by construction**:

- it is a **click-toggled** inline accordion (state on the menu component), **not** a CSS-hover flyout — so there is no diagonal-gap / pointer-traversal race, and
- the outside-click close handler ignores clicks inside the menu, so the `mousedown` that immediately follows the trigger click can never race the submenu closed.

A regression test locks this in: after clicking **Freeze**, a `mousedown` landing inside the menu leaves the sub-options open.

## View-state vs. content model (Yjs)

Freeze is **view-state**, deliberately. The frozen tables are tracked in a ProseMirror plugin (keyed by table position, remapped across edits) and rendered with `position: sticky`; **nothing is written to the Y.Doc**. This keeps the schema, `SCHEMA_VERSION` (currently 18) and the backend contract untouched, and there is no collaborative-sync surface to conflict on.

Trade-off: freeze is **per-client and not persisted across reload or shared with collaborators**. Making it durable + shared would be a coordinated schema-version bump adding `frozenRows`/`frozenCols` attributes to the `table` node (the same class of change as v18) plus a backend stub update — intentionally left as a follow-up, not folded into a frontend-only change.

## Interplay with existing table interactions (#749, #625/#716)

- Chromium ignores `position: sticky` on `<td>/<th>` under `border-collapse: collapse`, and the table's default `overflow: hidden` captures the sticky offset — **both were caught in browser verification** (the first attempt scrolled the "frozen" band away). A frozen table is therefore flipped to `border-collapse: separate; border-spacing: 0; overflow: visible`, with borders redrawn to single 1px lines (table paints the outer top+left, each cell its own right+bottom).
- **#749:** sticky frozen cells create stacking contexts that would otherwise occlude the un-z-indexed column-resize handle at `right:-2px`. The handle is lifted above frozen cells so a frozen column can still be resized.
- The freeze UI reuses the existing table toolbar/context-menu styling, so it stacks consistently with #625/#716.

## Testing

- **45 unit tests pass** (`TableFreeze.test.ts`, `TableControls.test.tsx`, `i18n.test.ts`), covering the command logic (toggle/through-row/through-column/clamp/clear), the plugin's position remapping across edits and table deletion, the submenu reliability, and the sticky-style DOM assignment (classes, `position/top/left/z-index`, wrapper + separate-border classes).
- **Full docs suite:** no new failures introduced (the 4 pre-existing `EditorShell.test.tsx` failures are unrelated to this change and present on `main`).
- **Typecheck:** clean for all files in this change (the 2 pre-existing `tsc` errors are in unrelated files).
- **Browser verification (Chromium):** a frozen table (header row + first column) was scrolled down and right; the header row and first column stayed pinned while the body scrolled — captured below.

### Freeze holding while scrolled (down + right)

_The header row (Col …) stays at the top and the first column (Row …) stays at the left after scrolling; columns 1–2 have scrolled out so Col 3 is the next visible column._

<!-- Reviewer note: screenshot attached in the linked issue comment; local standalone dev harness
     (vite.dev.config.ts) is currently broken by pre-existing missing-export stubs unrelated to this
     change, so visual verification was done against a Chromium reproduction of the produced DOM+CSS. -->

## Related

- GitHub issue: #755
- Related: #749 (column resize), #625 / #716 (table toolbar)
