### PR TITLE
feat(loop): unify board/list/grouped filters + scope across views

### DIFF
--- a/packages/dmloop/src/api/__tests__/issueFilterQuery.test.ts
+++ b/packages/dmloop/src/api/__tests__/issueFilterQuery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { arrayFilterQuery } from "../issueFilterQuery";
+
+// Locks the query-string contract the board/list/grouped requests emit for the
+// unified multi-select filters (backend: octo-multica flat ListIssues + grouped).
+describe("arrayFilterQuery", () => {
+  it("joins arrays with commas and maps booleans to true-string", () => {
+    expect(
+      arrayFilterQuery({
+        statuses: ["todo", "in_progress"],
+        priorities: ["high"],
+        assignee_types: ["member", "agent"],
+        assignee_ids: ["a1", "a2"],
+        include_no_assignee: true,
+        creator_ids: ["c1"],
+        project_ids: ["p1", "p2"],
+        include_no_project: true,
+        label_ids: ["l1"],
+      }),
+    ).toEqual({
+      statuses: "todo,in_progress",
+      priorities: "high",
+      assignee_types: "member,agent",
+      assignee_ids: "a1,a2",
+      include_no_assignee: "true",
+      creator_ids: "c1",
+      project_ids: "p1,p2",
+      include_no_project: "true",
+      label_ids: "l1",
+    });
+  });
+
+  it("omits unset dimensions as undefined so they are never sent", () => {
+    const q = arrayFilterQuery({});
+    for (const v of Object.values(q)) expect(v).toBeUndefined();
+    // false booleans drop to undefined, never a false-string.
+    expect(arrayFilterQuery({ include_no_assignee: false }).include_no_assignee).toBeUndefined();
+  });
+});

--- a/packages/dmloop/src/api/__tests__/issueFilterQuery.test.ts
+++ b/packages/dmloop/src/api/__tests__/issueFilterQuery.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { arrayFilterQuery } from "../issueFilterQuery";
 
 // Locks the query-string contract the board/list/grouped requests emit for the
-// unified multi-select filters (backend: octo-multica flat ListIssues + grouped).
+// unified multi-select filters (flat /issues + /issues/grouped query params).
 describe("arrayFilterQuery", () => {
   it("joins arrays with commas and maps booleans to true-string", () => {
     expect(
@@ -31,9 +31,13 @@ describe("arrayFilterQuery", () => {
     });
   });
 
-  it("omits unset dimensions as undefined so they are never sent", () => {
+  it("omits unset and empty dimensions as undefined so they are never sent", () => {
     const q = arrayFilterQuery({});
     for (const v of Object.values(q)) expect(v).toBeUndefined();
+    // empty arrays fold to undefined locally (not "" which would be sent).
+    expect(arrayFilterQuery({ statuses: [], assignee_ids: [] })).toEqual(
+      arrayFilterQuery({}),
+    );
     // false booleans drop to undefined, never a false-string.
     expect(arrayFilterQuery({ include_no_assignee: false }).include_no_assignee).toBeUndefined();
   });

--- a/packages/dmloop/src/api/__tests__/issueGrouping.test.ts
+++ b/packages/dmloop/src/api/__tests__/issueGrouping.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { groupIssuesByAssignee } from "../issueGrouping";
+import type { Issue } from "../types";
+
+const issue = (id: string, type: Issue["assignee_type"], assignee: string | null, name?: string): Issue =>
+  ({ id, assignee_type: type, assignee_id: assignee, assignee_name: name } as Issue);
+
+// Locks the client-side grouping used to render flat /issues/search results in
+// the grouped view (keyword search, scheme B).
+describe("groupIssuesByAssignee", () => {
+  it("groups by (assignee_type, assignee_id), preserves first-seen order, counts per group", () => {
+    const groups = groupIssuesByAssignee([
+      issue("1", "member", "u1", "Alice"),
+      issue("2", "agent", "a1", "Bot"),
+      issue("3", "member", "u1", "Alice"),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["member::u1", "agent::a1"]);
+    expect(groups[0].total).toBe(2);
+    expect(groups[0].assignee_name).toBe("Alice");
+    expect(groups[1].total).toBe(1);
+    expect(groups[0].issues.map((i) => i.id)).toEqual(["1", "3"]);
+  });
+
+  it("folds unassigned issues into a single null group", () => {
+    const groups = groupIssuesByAssignee([
+      issue("1", null, null),
+      issue("2", null, null),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].assignee_type).toBeNull();
+    expect(groups[0].assignee_id).toBeNull();
+    expect(groups[0].total).toBe(2);
+  });
+
+  it("returns [] for no issues", () => {
+    expect(groupIssuesByAssignee([])).toEqual([]);
+  });
+});

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -43,11 +43,6 @@ async function fetchIssues(path: string, query: Record<string, unknown>): Promis
 
 export function listIssues(params?: ListParams): Promise<{ issues: Issue[]; total: number }> {
   return fetchIssues("/issues", {
-    status: params?.status,
-    priority: params?.priority,
-    assignee_id: params?.assignee_id,
-    creator_id: params?.creator_id,
-    project_id: params?.project_id,
     ...arrayFilterQuery(params ?? {}),
     date_field: params?.date_field,
     date_start: params?.date_start,
@@ -132,9 +127,16 @@ export async function listGroupedIssues(params: GroupedParams): Promise<IssueGro
 // (assignee_type, assignee_id) 合并分组、按 issue id 去重,total 取去重后条数。
 // 对齐后端「我的 issue」三过滤并集语义(assignee_types 对本 scope 无意义,剥离)。
 export async function listMyGroupedIssues(userId: string, params: GroupedParams): Promise<IssueGroup[]> {
-  // 剥离所有「用户关系」过滤:三 leg 各自设一个,base 保留任何一个都会污染另两 leg
-  // (如下拉 creator 会被 creator leg 覆盖、却在其余 leg 变成意外 AND)。assignee_types 同样无意义。
-  const base: GroupedParams = { ...params, assignee_types: undefined, assignee_id: undefined, creator_id: undefined, involves_user_id: undefined };
+  // 剥离所有「用户关系」过滤(单值 + 复数):三 leg 各自设一个,base 保留任何一个都会污染另两 leg
+  // (如 creator 下拉会在其余 leg 变成意外 AND)。复数 assignee_ids/creator_ids 同理必须剥,
+  // 否则 My Loop 面板选的负责人/创建者会 AND 进三腿、破坏并集语义。assignee_types 对本 scope 无意义。
+  const base: GroupedParams = {
+    ...params,
+    assignee_types: undefined,
+    assignee_id: undefined, assignee_ids: undefined,
+    creator_id: undefined, creator_ids: undefined,
+    involves_user_id: undefined,
+  };
   const variants: GroupedParams[] = [
     { ...base, assignee_id: userId },
     { ...base, creator_id: userId },

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
 import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
+import { arrayFilterQuery } from "./issueFilterQuery";
 
 // enrich 的同步核心:调用方已拿到 directory 时复用,避免每组重复 ensureDirectory。
 function enrichWith(dir: Awaited<ReturnType<typeof ensureDirectory>>, issues: Issue[]): Issue[] {
@@ -47,6 +48,7 @@ export function listIssues(params?: ListParams): Promise<{ issues: Issue[]; tota
     assignee_id: params?.assignee_id,
     creator_id: params?.creator_id,
     project_id: params?.project_id,
+    ...arrayFilterQuery(params ?? {}),
     date_field: params?.date_field,
     date_start: params?.date_start,
     date_end: params?.date_end,
@@ -106,15 +108,11 @@ export async function listGroupedIssues(params: GroupedParams): Promise<IssueGro
   const dir = await ensureDirectory();
   const data = await httpGet<{ groups?: IssueGroup[] }>("/issues/grouped", {
     group_by: "assignee",
-    statuses: params.statuses?.join(","),
-    priorities: params.priorities?.join(","),
-    assignee_types: params.assignee_types?.join(","),
+    ...arrayFilterQuery(params),
     assignee_id: params.assignee_id,
     involves_user_id: params.involves_user_id,
     creator_id: params.creator_id,
     project_id: params.project_id,
-    project_ids: params.project_ids?.join(","),
-    include_no_project: params.include_no_project ? "true" : undefined,
     date_field: params.date_field,
     date_start: params.date_start,
     date_end: params.date_end,

--- a/packages/dmloop/src/api/issueFilterQuery.ts
+++ b/packages/dmloop/src/api/issueFilterQuery.ts
@@ -1,0 +1,21 @@
+import type { ListParams } from "./types";
+
+// 数组/布尔筛选参 → 查询串(逗号连接数组、布尔转 "true")。listIssues 与 grouped 共用,防漂移。
+// 空数组由调用方在 reload 里预折叠成 undefined,故此处不发空串。纯函数、只依赖类型,便于契约测试。
+export type ArrayFilterParams = Pick<ListParams,
+  "statuses" | "priorities" | "assignee_types" | "assignee_ids" | "include_no_assignee" |
+  "creator_ids" | "project_ids" | "include_no_project" | "label_ids">;
+
+export function arrayFilterQuery(p: ArrayFilterParams): Record<string, string | undefined> {
+  return {
+    statuses: p.statuses?.join(","),
+    priorities: p.priorities?.join(","),
+    assignee_types: p.assignee_types?.join(","),
+    assignee_ids: p.assignee_ids?.join(","),
+    include_no_assignee: p.include_no_assignee ? "true" : undefined,
+    creator_ids: p.creator_ids?.join(","),
+    project_ids: p.project_ids?.join(","),
+    include_no_project: p.include_no_project ? "true" : undefined,
+    label_ids: p.label_ids?.join(","),
+  };
+}

--- a/packages/dmloop/src/api/issueFilterQuery.ts
+++ b/packages/dmloop/src/api/issueFilterQuery.ts
@@ -1,21 +1,23 @@
 import type { ListParams } from "./types";
 
 // 数组/布尔筛选参 → 查询串(逗号连接数组、布尔转 "true")。listIssues 与 grouped 共用,防漂移。
-// 空数组由调用方在 reload 里预折叠成 undefined,故此处不发空串。纯函数、只依赖类型,便于契约测试。
+// 空数组本地折叠成 undefined(不发空串),契约不再依赖调用方预折叠。纯函数、只依赖类型,便于契约测试。
 export type ArrayFilterParams = Pick<ListParams,
   "statuses" | "priorities" | "assignee_types" | "assignee_ids" | "include_no_assignee" |
   "creator_ids" | "project_ids" | "include_no_project" | "label_ids">;
 
+const csv = (a?: string[]): string | undefined => (a && a.length ? a.join(",") : undefined);
+
 export function arrayFilterQuery(p: ArrayFilterParams): Record<string, string | undefined> {
   return {
-    statuses: p.statuses?.join(","),
-    priorities: p.priorities?.join(","),
-    assignee_types: p.assignee_types?.join(","),
-    assignee_ids: p.assignee_ids?.join(","),
+    statuses: csv(p.statuses),
+    priorities: csv(p.priorities),
+    assignee_types: csv(p.assignee_types),
+    assignee_ids: csv(p.assignee_ids),
     include_no_assignee: p.include_no_assignee ? "true" : undefined,
-    creator_ids: p.creator_ids?.join(","),
-    project_ids: p.project_ids?.join(","),
+    creator_ids: csv(p.creator_ids),
+    project_ids: csv(p.project_ids),
     include_no_project: p.include_no_project ? "true" : undefined,
-    label_ids: p.label_ids?.join(","),
+    label_ids: csv(p.label_ids),
   };
 }

--- a/packages/dmloop/src/api/issueGrouping.ts
+++ b/packages/dmloop/src/api/issueGrouping.ts
@@ -1,0 +1,29 @@
+import type { Issue, IssueGroup } from "./types";
+
+// 把平铺 issue 列表(全文搜索结果)按负责人聚成分组板所需的 IssueGroup[]。用于分组视图的
+// 关键词搜索:搜索端点只返回平铺结果,前端按 (assignee_type, assignee_id) 分组,组头名/头像取
+// 自已 enrich 的 issue 字段;未指派项归入一个空负责人组。保持首次出现顺序(即搜索相关性序)。
+export function groupIssuesByAssignee(issues: Issue[]): IssueGroup[] {
+  const order: string[] = [];
+  const map = new Map<string, IssueGroup>();
+  for (const i of issues) {
+    const key = `${i.assignee_type ?? "_"}::${i.assignee_id ?? "_"}`;
+    let g = map.get(key);
+    if (!g) {
+      g = {
+        id: key,
+        assignee_type: i.assignee_type ?? null,
+        assignee_id: i.assignee_id ?? null,
+        assignee_name: i.assignee_name ?? null,
+        assignee_avatar: i.assignee_avatar ?? null,
+        issues: [],
+        total: 0,
+      };
+      map.set(key, g);
+      order.push(key);
+    }
+    g.issues.push(i);
+  }
+  for (const g of map.values()) g.total = g.issues.length;
+  return order.map((k) => map.get(k)!);
+}

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -62,13 +62,8 @@ export interface ListParams {
   // 客户端关键词过滤:projectApi/skillApi/squadApi/agentApi/runtimeApi 共用此字段。
   // issue 列表不再用它(关键词走 searchIssues → /issues/search),但其它 list 端点仍需,勿删。
   keyword?: string;
-  status?: IssueStatus;
-  priority?: IssuePriority;
-  assignee_id?: string;
-  creator_id?: string;
-  project_id?: string;
-  // 统一多选筛选(后端数组参,与看板/列表/分组共用)。空数组 = 不发。数组与同维单值
-  // 互斥使用:issue 列表发数组,单值字段留给其它复用 ListParams 的 list 端点。
+  // 统一多选筛选(后端数组参,与看板/列表/分组共用)。空数组 = 不发。issue 列表只用这套数组,
+  // 不再有同维单值(已移除,避免单/复数同发的歧义)。
   statuses?: IssueStatus[];
   priorities?: IssuePriority[];
   assignee_ids?: string[];

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -67,6 +67,17 @@ export interface ListParams {
   assignee_id?: string;
   creator_id?: string;
   project_id?: string;
+  // 统一多选筛选(后端数组参,与看板/列表/分组共用)。空数组 = 不发。数组与同维单值
+  // 互斥使用:issue 列表发数组,单值字段留给其它复用 ListParams 的 list 端点。
+  statuses?: IssueStatus[];
+  priorities?: IssuePriority[];
+  assignee_ids?: string[];
+  assignee_types?: AssigneeType[];
+  include_no_assignee?: boolean;
+  creator_ids?: string[];
+  project_ids?: string[];
+  include_no_project?: boolean;
+  label_ids?: string[];
   // 时间范围筛选:date_field(仅 created_at|updated_at)+ date_start + date_end 必须同时给,
   // 值为 RFC3339;后端要求 start 严格早于 end。
   date_field?: IssueDateField;
@@ -90,13 +101,16 @@ export interface GroupedParams {
   priorities?: IssuePriority[];
   assignee_types?: AssigneeType[];
   assignee_id?: string;
+  assignee_ids?: string[];
+  include_no_assignee?: boolean;
   involves_user_id?: string;
   creator_id?: string;
+  creator_ids?: string[];
   project_id?: string;
   project_ids?: string[];
   // 纳入无项目的 issue(后端 include_no_project)。与项目多选配对 = 所选项目 ∪ 无项目。
-  // (未加 include_no_assignee:仅与 assignee_filters 配对有意义,本 UI 用 assignee_types/involves。)
   include_no_project?: boolean;
+  label_ids?: string[];
   date_field?: IssueDateField;
   date_start?: string;
   date_end?: string;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -145,8 +145,10 @@
     "assignee": "Assignee",
     "creator": "Creator",
     "project": "Project",
+    "label": "Label",
     "dateRange": "Date range",
-    "noProject": "Incl. no project"
+    "noProject": "Incl. no project",
+    "noAssignee": "Incl. no assignee"
   },
   "dateField": {
     "created_at": "Created",
@@ -465,7 +467,7 @@
   },
   "mention": {
     "groupUsers": "Users",
-    "groupIssues": "Issues",
+    "groupIssues": "Loops",
     "allMembers": "All members"
   },
   "agent": {

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -145,8 +145,10 @@
     "assignee": "负责人",
     "creator": "创建者",
     "project": "项目",
+    "label": "标签",
     "dateRange": "时间范围",
-    "noProject": "含无项目"
+    "noProject": "含无项目",
+    "noAssignee": "含无负责人"
   },
   "dateField": {
     "created_at": "创建时间",
@@ -465,7 +467,7 @@
   },
   "mention": {
     "groupUsers": "用户",
-    "groupIssues": "事项",
+    "groupIssues": "回路",
     "allMembers": "所有成员"
   },
   "agent": {

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -25,6 +25,7 @@ import type {
 } from "../api/types";
 import { ISSUE_SORT_FIELDS, ISSUE_DATE_FIELDS } from "../api/types";
 import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAgentTaskSnapshot } from "../api/issueApi";
+import { groupIssuesByAssignee } from "../api/issueGrouping";
 import { listProjectOptions } from "../api/directory";
 import { listLabels } from "../api/labelApi";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
@@ -150,8 +151,18 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       date_end: endExclusive ? endExclusive.toISOString() : undefined,
     };
 
-    // 分组板:走 /issues/grouped(按负责人);grouped 不吃关键词/排序,故在分组视图隐藏。
+    // 分组板:走 /issues/grouped(按负责人)。
     if (view === "grouped") {
+      const gkw = f.keyword.trim();
+      // 关键词(仅主看板,非「我的回路」)→ 全文搜索平铺结果,前端按负责人分组呈现。搜索端点
+      // 独立语义(不吃 scope/其它筛选,上限 50),故与常规分组拉取分道;「我的回路」隐藏关键词、不入此路。
+      if (gkw && !isMyLoop) {
+        searchIssues(gkw, { limit: 50 })
+          .then(({ issues }) => { if (my === seq.current) setGroups(groupIssuesByAssignee(issues)); })
+          .catch(onErr)
+          .finally(() => { if (my === seq.current) setLoading(false); });
+        return;
+      }
       // 「与我相关」(仅「我的回路」页)= 指派给我 ∪ 我创建 ∪ 间接关联的并集扇出;需当前成员
       // 后端 id,未解析出则清空并等待(不回退成无 scope 全量)。myMemberId 在依赖里,解析后自动重取。
       if (scope === "involves") {
@@ -269,20 +280,23 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   const title = defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
 
-  // 关键词走全文搜索端点(独立语义,后端不吃其它筛选/排序)。搜索激活时禁用面板内其它筛选,
-  // 避免它们「看起来生效、实际被忽略」的误导(grouped 视图隐藏关键词,故 searching 恒 false)。
-  const searching = view !== "grouped" && !!f.keyword.trim();
+  // 关键词走全文搜索端点(独立语义,不吃其它筛选/排序)。搜索激活时禁用面板内其它筛选/scope,
+  // 避免它们「看起来生效、实际被忽略」的误导。主看板三视图均支持;「我的回路」无关键词(搜索不吃 involves)。
+  const searching = !isMyLoop && !!f.keyword.trim();
 
-  // 「筛选」按钮上的激活计数(每个非空维度记 1;keyword 仅在其生效的视图计)。
+  // 「筛选」按钮上的激活计数(每个生效维度记 1)。搜索激活时只有 keyword 生效——其它维度被
+  // 搜索端点忽略且面板已禁用,故不计,免得徽章高亮却对结果无影响(与 scope tab 搜索时去激活一致)。
   const activeFilters =
-    (f.statuses.length ? 1 : 0) +
-    (f.priorities.length ? 1 : 0) +
-    (f.assigneeIds.length || noAssigneeActive ? 1 : 0) +
-    (f.creatorIds.length ? 1 : 0) +
-    (f.projectIds.length || f.noProject ? 1 : 0) +
-    (f.labelIds.length ? 1 : 0) +
-    (f.dateRange ? 1 : 0) +
-    (view !== "grouped" && f.keyword.trim() ? 1 : 0);
+    (searching
+      ? 0
+      : (f.statuses.length ? 1 : 0) +
+        (f.priorities.length ? 1 : 0) +
+        (f.assigneeIds.length || noAssigneeActive ? 1 : 0) +
+        (f.creatorIds.length ? 1 : 0) +
+        (f.projectIds.length || f.noProject ? 1 : 0) +
+        (f.labelIds.length ? 1 : 0) +
+        (f.dateRange ? 1 : 0)) +
+    (!isMyLoop && f.keyword.trim() ? 1 : 0);
 
   const clearFilters = () =>
     update({
@@ -316,11 +330,15 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       </div>
       {filterSelect(t("loop.filter.status"), f.statuses, (v) => update({ statuses: v as IssueStatus[] }), statusOpts, { maxTagCount: 2 })}
       {filterSelect(t("loop.filter.priority"), f.priorities, (v) => update({ priorities: v as IssuePriority[] }), priorityOpts, { maxTagCount: 2 })}
-      {filterSelect(t("loop.filter.assignee"), f.assigneeIds, (v) => update({ assigneeIds: v }), cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
-      <div className="loop-fields__row">
-        <Checkbox className="loop-nofilter" checked={noAssigneeActive} onChange={(e) => update({ noAssignee: !!e.target.checked })} disabled={searching || scope !== "all"}>{t("loop.filter.noAssignee")}</Checkbox>
-      </div>
-      {filterSelect(t("loop.filter.creator"), f.creatorIds, (v) => update({ creatorIds: v }), cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
+      {/* 「谁」类筛选(负责人/无负责人/创建者)在「我的回路」隐藏——该页本就锁定「与我相关」,
+          按他人负责人/创建者筛与语义矛盾,且会污染并集扇出(见 listMyGroupedIssues)。 */}
+      {!isMyLoop && filterSelect(t("loop.filter.assignee"), f.assigneeIds, (v) => update({ assigneeIds: v }), cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
+      {!isMyLoop && (
+        <div className="loop-fields__row">
+          <Checkbox className="loop-nofilter" checked={noAssigneeActive} onChange={(e) => update({ noAssignee: !!e.target.checked })} disabled={searching || scope !== "all"}>{t("loop.filter.noAssignee")}</Checkbox>
+        </div>
+      )}
+      {!isMyLoop && filterSelect(t("loop.filter.creator"), f.creatorIds, (v) => update({ creatorIds: v }), cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
       {projects.length > 0 && filterSelect(t("loop.filter.project"), f.projectIds, (v) => update({ projectIds: v }), projectOpts, { filter: true })}
       <div className="loop-fields__row">
         <Checkbox className="loop-nofilter" checked={f.noProject} onChange={(e) => update({ noProject: !!e.target.checked })} disabled={searching}>{t("loop.filter.noProject")}</Checkbox>
@@ -335,8 +353,8 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
           <DatePicker type="dateRange" density="compact" disabled={searching} value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} zIndex={FIELD_POPUP.zIndex} style={{ flex: 1 }} />
         </div>
       </div>
-      {/* 关键词走全文搜索(独立语义,不与 grouped 组合),故分组视图隐藏。 */}
-      {view !== "grouped" && (
+      {/* 关键词走全文搜索(平铺,分组视图前端按负责人再分组呈现)。「我的回路」不支持(搜索不吃 involves)。 */}
+      {!isMyLoop && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.search.issue")}</div>
           <Input className="loop-search" prefix={<Search size={14} />} placeholder={t("loop.search.issue")} value={f.keyword} onChange={(v) => update({ keyword: v })} showClear style={{ width: "100%" }} />

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -21,10 +21,12 @@ import type {
   IssuePriority,
   IssueSortField,
   IssueDateField,
+  IssueLabel,
 } from "../api/types";
 import { ISSUE_SORT_FIELDS, ISSUE_DATE_FIELDS } from "../api/types";
 import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAgentTaskSnapshot } from "../api/issueApi";
 import { listProjectOptions } from "../api/directory";
+import { listLabels } from "../api/labelApi";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import { ISSUE_STATUS_ORDER, PRIORITY_ORDER, isActiveRun } from "../ui/meta";
 import IssueBoard from "../panel/IssueBoard";
@@ -36,28 +38,26 @@ import { readView, writeView } from "../ui/viewMode";
 
 type ViewMode = "board" | "grouped" | "list";
 
-// scope pill → assignee_types 过滤(仅 /grouped 支持;all/involves 不按类型收窄)。
+// scope pill → assignee_types 过滤(看板/列表/分组统一走后端 assignee_types)。
+// all / involves 不按类型收窄(involves 走用户关系并集,见 reload)。
 function scopeToAssigneeTypes(scope: IssueScope): ("member" | "agent" | "squad")[] | undefined {
   if (scope === "members") return ["member"];
   if (scope === "agents") return ["agent", "squad"];
   return undefined;
 }
 
+// 统一筛选:全维度数组多选 + 正交的「无负责人 / 无项目」布尔,同一套应用到看板/列表/分组
+// 三视图。keyword 走独立全文搜索端点,故与其它维度不并存于同一请求。
 interface Filters {
   keyword: string;
-  status?: IssueStatus;        // board/list 单选
-  priority?: IssuePriority;    // board/list 单选
-  assignee?: string;
-  creator?: string;
-  project?: string;            // board/list 单选
-  // 分组板专属多选 + no-project(仅 /grouped 支持 statuses[]/priorities[]/project_ids[]/include_no_project)。
-  // 注:无 include_no_assignee —— scope pill 用 assignee_types(类型级、顶层 AND),后端
-  // include_no_assignee 只与 assignee_filters(具体 actor)配对才是「含」语义;与 assignee_types/
-  // involves 的 assignee_id 腿 AND 会矛盾成空。grouped 在 scope=all 下本就显示未指派组。
-  gStatuses: IssueStatus[];
-  gPriorities: IssuePriority[];
-  gProjectIds: string[];
+  statuses: IssueStatus[];
+  priorities: IssuePriority[];
+  assigneeIds: string[];
+  noAssignee: boolean;
+  creatorIds: string[];
+  projectIds: string[];
   noProject: boolean;
+  labelIds: string[];
   dateField: IssueDateField; // 时间范围筛选的列(created_at|updated_at)
   dateRange?: Date[];        // [start, end];为空则不按时间筛选
   sortBy: IssueSortField;
@@ -80,15 +80,20 @@ interface IssuePageProps {
 
 export default function IssuePage({ defaultScope, defaultView, viewKey }: IssuePageProps = {}) {
   const { t } = useI18n();
+  // 「我的回路」= involves:只有分组视图能表达「指派/创建/关联」三路并集(listMyGroupedIssues 扇出),
+  // 看板/列表无对应查询会退化成显示全工作区 → 该页锁死分组、不给切视图。
+  const isMyLoop = defaultScope === "involves";
   const [issues, setIssues] = useState<Issue[]>([]);
   const [groups, setGroups] = useState<IssueGroup[]>([]);
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set());
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [view, setView] = useState<ViewMode>(() => viewKey ? readView(viewKey, ["board", "grouped", "list"], defaultView ?? "board") : (defaultView ?? "board"));
+  const [view, setView] = useState<ViewMode>(() => isMyLoop ? "grouped" : (viewKey ? readView(viewKey, ["board", "grouped", "list"], defaultView ?? "board") : (defaultView ?? "board")));
   const [scope, setScope] = useState<IssueScope>(defaultScope ?? "all");
-  const [f, setF] = useState<Filters>({ keyword: "", gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, sortBy: "position", sortDir: "desc", dateField: "created_at" });
+  const [f, setF] = useState<Filters>({ keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false, creatorIds: [], projectIds: [], noProject: false, labelIds: [], sortBy: "position", sortDir: "desc", dateField: "created_at" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
+  // 「无负责人」仅在 scope=全部 时有效(与 assignee_types 组合恒空)。单一来源:发送/勾选态/计数共用,防漂移。
+  const noAssigneeActive = scope === "all" && f.noAssignee;
   // 筛选/显示 面板受控可见:不用 clickToHide(它会在点击内部 Select/DatePicker/Checkbox
   // 时冒泡关闭,且这些控件的 portal 选项面板点击也会误触发关闭),改为显式
   // onVisibleChange —— 仅外部点击关闭,内部多字段交互保持面板打开。
@@ -103,51 +108,67 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   }, [cands]);
   // 项目下拉复用 directory 已缓存的 /projects(避免重复请求);随 workspace 切换整页重挂而刷新。
   const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
+  const [labels, setLabels] = useState<IssueLabel[]>([]);
   const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
 
   useEffect(() => {
     listProjectOptions().then(setProjects).catch(() => {});
+    listLabels().then(setLabels).catch(() => {});
   }, []);
 
   const reload = useCallback(() => {
     const my = ++seq.current;
     setLoading(true);
+    // 请求失败(网络/权限/500):清空结果集 + 提示。不保留旧行——否则旧数据会残留在新筛选态下,
+    // 且列表勾选态仍指向陈旧行,可能被批量删改误作用。seq 守卫:仅最新一次在途请求可清。
+    const onErr = () => {
+      if (my !== seq.current) return;
+      setIssues([]); setGroups([]); setTotal(0);
+      Toast.error(t("loop.toast.loadFailed"));
+    };
     // 时间范围:三参数须同时给且 start<end。onChange 已把 dateRange 归一为 undefined|[起,止]。
     // 止端 +1 日历日 → 半开区间,既含止日当天、又保证 start<end;setDate 处理 DST。
     const dr = f.dateRange;
     const endExclusive = dr && new Date(dr[1]);
     if (endExclusive) endExclusive.setDate(endExclusive.getDate() + 1);
 
-    // 分组板:走 /issues/grouped(按负责人);scope pill 收窄 assignee_types。
-    // grouped 不吃关键词/排序,故这两项在分组视图隐藏。
+    // 统一多选筛选:同一套数组/布尔应用到三视图(空数组/未选 → 不发)。keyword 走独立
+    // 全文搜索端点(不吃其它筛选),故不并入 common。
+    const common = {
+      statuses: f.statuses.length ? f.statuses : undefined,
+      priorities: f.priorities.length ? f.priorities : undefined,
+      assignee_ids: f.assigneeIds.length ? f.assigneeIds : undefined,
+      // 无负责人仅在 scope=全部 时生效:成员/AI 用 assignee_types 收窄(顶层 AND),
+      // 未指派项 assignee_type 为空、不满足类型谓词,二者组合恒空 → 只在 all 下发,面板亦禁用。
+      include_no_assignee: noAssigneeActive || undefined,
+      creator_ids: f.creatorIds.length ? f.creatorIds : undefined,
+      project_ids: f.projectIds.length ? f.projectIds : undefined,
+      include_no_project: f.noProject || undefined,
+      label_ids: f.labelIds.length ? f.labelIds : undefined,
+      date_field: dr ? f.dateField : undefined,
+      date_start: dr ? dr[0].toISOString() : undefined,
+      date_end: endExclusive ? endExclusive.toISOString() : undefined,
+    };
+
+    // 分组板:走 /issues/grouped(按负责人);grouped 不吃关键词/排序,故在分组视图隐藏。
     if (view === "grouped") {
-      const gp = {
-        // 分组板多选:空数组 → 不发(不收窄)。
-        statuses: f.gStatuses.length ? f.gStatuses : undefined,
-        priorities: f.gPriorities.length ? f.gPriorities : undefined,
-        project_ids: f.gProjectIds.length ? f.gProjectIds : undefined,
-        include_no_project: f.noProject || undefined,
-        creator_id: f.creator,
-        date_field: dr ? f.dateField : undefined,
-        date_start: dr ? dr[0].toISOString() : undefined,
-        date_end: endExclusive ? endExclusive.toISOString() : undefined,
-        // ponytail: 每组取后端上限 100；超量请用筛选。
-        limit: 100,
-      };
-      // 「与我相关」= 指派给我 ∪ 我创建 ∪ 间接关联(后端三过滤并集,fan-out 合并);
-      // 其余 scope 单发一次、按 assignee_types 收窄。
-      // scope=involves 需当前成员的后端 id;未解析出时**不回退成无 scope 全量**(否则「与我相关」
-      // 会错显全部)。清空并结束——myMemberId 在 reload 依赖里,解析后会自动重取。
-      if (scope === "involves" && !myMemberId) {
-        if (my === seq.current) { setGroups([]); setLoading(false); }
+      // 「与我相关」(仅「我的回路」页)= 指派给我 ∪ 我创建 ∪ 间接关联的并集扇出;需当前成员
+      // 后端 id,未解析出则清空并等待(不回退成无 scope 全量)。myMemberId 在依赖里,解析后自动重取。
+      if (scope === "involves") {
+        if (!myMemberId) {
+          if (my === seq.current) { setGroups([]); setLoading(false); }
+          return;
+        }
+        listMyGroupedIssues(myMemberId, { ...common, limit: 100 })
+          .then((gs) => { if (my === seq.current) setGroups(gs); })
+          .catch(onErr)
+          .finally(() => { if (my === seq.current) setLoading(false); });
         return;
       }
-      const req =
-        scope === "involves"
-          ? listMyGroupedIssues(myMemberId!, gp) // 上方守卫已保证 myMemberId 存在
-          : listGroupedIssues({ ...gp, assignee_types: scopeToAssigneeTypes(scope) });
-      req
+      // ponytail: 每组取后端上限 100；超量请用筛选。
+      listGroupedIssues({ ...common, assignee_types: scopeToAssigneeTypes(scope), limit: 100 })
         .then((gs) => { if (my === seq.current) setGroups(gs); })
+        .catch(onErr)
         .finally(() => { if (my === seq.current) setLoading(false); });
       return;
     }
@@ -158,14 +179,8 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     const req = kw
       ? searchIssues(kw, { limit: paged ? PAGE_SIZE : 50, offset: paged ? page * PAGE_SIZE : 0 })
       : listIssues({
-          status: f.status,
-          priority: f.priority,
-          assignee_id: f.assignee,
-          creator_id: f.creator,
-          project_id: f.project,
-          date_field: dr ? f.dateField : undefined,
-          date_start: dr ? dr[0].toISOString() : undefined,
-          date_end: endExclusive ? endExclusive.toISOString() : undefined,
+          ...common,
+          assignee_types: scopeToAssigneeTypes(scope),
           // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
           sort_by: paged ? f.sortBy : undefined,
           sort_direction: paged ? f.sortDir : undefined,
@@ -184,8 +199,9 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         setIssues(issues);
         setTotal(total);
       })
+      .catch(onErr)
       .finally(() => { if (my === seq.current) setLoading(false); });
-  }, [f, view, page, scope, myMemberId]);
+  }, [f, view, page, scope, myMemberId, noAssigneeActive]);
 
   useEffect(reload, [reload]);
 
@@ -220,7 +236,8 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
   const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
-  const switchView = (v: ViewMode) => { setView(v); setPage(0); if (viewKey) writeView(viewKey, v); };
+  // 切视图后关闭「显示」面板;但列表视图会露出「升/降序」子选项,保持面板打开让用户接着选。
+  const switchView = (v: ViewMode) => { setView(v); setPage(0); if (viewKey) writeView(viewKey, v); if (v !== "list") setShowOpen(false); };
 
   // 点击 Issue → 跳转独立详情页（push 到右主栏，返回可 pop）。
   // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
@@ -231,12 +248,12 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   const [createOpen, setCreateOpen] = useState(false);
 
-  // 新建回路 → 唤起统一建单弹窗（对齐 multica，不再拉起独立 AI 页）。创建成功后刷新列表。
+  // 新建回路 → 唤起统一建单弹窗(不再拉起独立 AI 页)。创建成功后刷新列表。
   const openNewLoop = () => setCreateOpen(true);
 
   const isEmpty = view === "grouped" ? groups.every((g) => g.issues.length === 0) : total === 0;
 
-  // 状态/优先级/项目的选项列表:单选与多选两个分支共用(避免重复 map)。
+  // 选项列表(多选共用,避免重复 map)。
   const statusOpts = ISSUE_STATUS_ORDER.map((s) => (
     <Select.Option key={s} value={s}>{t(`loop.status.${s}`)}</Select.Option>
   ));
@@ -246,6 +263,9 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   const projectOpts = projects.map((p) => (
     <Select.Option key={p.id} value={p.id}>{p.title}</Select.Option>
   ));
+  const labelOpts = labels.map((l) => (
+    <Select.Option key={l.id} value={l.id}>{l.name}</Select.Option>
+  ));
 
   const title = defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
 
@@ -253,21 +273,39 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 避免它们「看起来生效、实际被忽略」的误导(grouped 视图隐藏关键词,故 searching 恒 false)。
   const searching = view !== "grouped" && !!f.keyword.trim();
 
-  // 「筛选」按钮上的激活计数(仅计当前视图会生效的维度)。
+  // 「筛选」按钮上的激活计数(每个非空维度记 1;keyword 仅在其生效的视图计)。
   const activeFilters =
-    (view === "grouped"
-      ? f.gStatuses.length + f.gPriorities.length + f.gProjectIds.length + (f.noProject ? 1 : 0)
-      : (f.status ? 1 : 0) + (f.priority ? 1 : 0) + (f.assignee ? 1 : 0) + (f.project ? 1 : 0) + (f.keyword.trim() ? 1 : 0)) +
-    (f.creator ? 1 : 0) +
-    (f.dateRange ? 1 : 0);
+    (f.statuses.length ? 1 : 0) +
+    (f.priorities.length ? 1 : 0) +
+    (f.assigneeIds.length || noAssigneeActive ? 1 : 0) +
+    (f.creatorIds.length ? 1 : 0) +
+    (f.projectIds.length || f.noProject ? 1 : 0) +
+    (f.labelIds.length ? 1 : 0) +
+    (f.dateRange ? 1 : 0) +
+    (view !== "grouped" && f.keyword.trim() ? 1 : 0);
 
   const clearFilters = () =>
     update({
-      keyword: "", status: undefined, priority: undefined, assignee: undefined, creator: undefined, project: undefined,
-      gStatuses: [], gPriorities: [], gProjectIds: [], noProject: false, dateRange: undefined,
+      keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false,
+      creatorIds: [], projectIds: [], noProject: false, labelIds: [], dateRange: undefined,
     });
 
-  // 「筛选」面板：把原工具栏散落的下拉收进一个面板（对齐产品设计 的筛选框）。维度按视图切换单选/多选。
+  // 一行多选筛选(标签 + Select multiple)。各维度只差 options / filter / maxTagCount,收进一个函数。
+  const filterSelect = (
+    label: string,
+    value: string[],
+    onChange: (v: string[]) => void,
+    children: React.ReactNode,
+    opts?: { filter?: boolean; maxTagCount?: number },
+  ) => (
+    <div className="loop-fields__row">
+      <div className="loop-fields__label">{label}</div>
+      <Select multiple value={value} onChange={(v) => onChange((v ?? []) as string[])} showClear filter={opts?.filter} disabled={searching} maxTagCount={opts?.maxTagCount ?? 1} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={label}>
+        {children}
+      </Select>
+    </div>
+  );
+
   const filterPanel = (
     <div className="loop-fields loop-filter-panel">
       <div className="loop-filter-panel__head">
@@ -276,56 +314,18 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
           <button type="button" className="loop-filter-panel__clear" onClick={clearFilters}>{t("loop.action.clearFilters")}</button>
         )}
       </div>
+      {filterSelect(t("loop.filter.status"), f.statuses, (v) => update({ statuses: v as IssueStatus[] }), statusOpts, { maxTagCount: 2 })}
+      {filterSelect(t("loop.filter.priority"), f.priorities, (v) => update({ priorities: v as IssuePriority[] }), priorityOpts, { maxTagCount: 2 })}
+      {filterSelect(t("loop.filter.assignee"), f.assigneeIds, (v) => update({ assigneeIds: v }), cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
       <div className="loop-fields__row">
-        <div className="loop-fields__label">{t("loop.filter.status")}</div>
-        {view === "grouped" ? (
-          <Select multiple value={f.gStatuses} onChange={(v) => update({ gStatuses: (v ?? []) as IssueStatus[] })} showClear maxTagCount={2} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
-        ) : (
-          <Select value={f.status} onChange={(v) => update({ status: v as IssueStatus | undefined })} showClear disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.status")}>{statusOpts}</Select>
-        )}
+        <Checkbox className="loop-nofilter" checked={noAssigneeActive} onChange={(e) => update({ noAssignee: !!e.target.checked })} disabled={searching || scope !== "all"}>{t("loop.filter.noAssignee")}</Checkbox>
       </div>
+      {filterSelect(t("loop.filter.creator"), f.creatorIds, (v) => update({ creatorIds: v }), cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
+      {projects.length > 0 && filterSelect(t("loop.filter.project"), f.projectIds, (v) => update({ projectIds: v }), projectOpts, { filter: true })}
       <div className="loop-fields__row">
-        <div className="loop-fields__label">{t("loop.filter.priority")}</div>
-        {view === "grouped" ? (
-          <Select multiple value={f.gPriorities} onChange={(v) => update({ gPriorities: (v ?? []) as IssuePriority[] })} showClear maxTagCount={2} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
-        ) : (
-          <Select value={f.priority} onChange={(v) => update({ priority: v as IssuePriority | undefined })} showClear disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.priority")}>{priorityOpts}</Select>
-        )}
+        <Checkbox className="loop-nofilter" checked={f.noProject} onChange={(e) => update({ noProject: !!e.target.checked })} disabled={searching}>{t("loop.filter.noProject")}</Checkbox>
       </div>
-      {/* assignee 单选仅扁平列表/看板(grouped 用 scope 按类型收窄)。 */}
-      {view !== "grouped" && (
-        <div className="loop-fields__row">
-          <div className="loop-fields__label">{t("loop.filter.assignee")}</div>
-          <Select value={f.assignee} onChange={(v) => update({ assignee: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.assignee")}>
-            {cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
-          </Select>
-        </div>
-      )}
-      {/* 「与我相关」自带 creator=我 并集腿,creator 下拉对它无效 → 隐藏。 */}
-      {!(view === "grouped" && scope === "involves") && (
-        <div className="loop-fields__row">
-          <div className="loop-fields__label">{t("loop.filter.creator")}</div>
-          <Select value={f.creator} onChange={(v) => update({ creator: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.creator")}>
-            {cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}
-          </Select>
-        </div>
-      )}
-      {projects.length > 0 && (
-        <div className="loop-fields__row">
-          <div className="loop-fields__label">{t("loop.filter.project")}</div>
-          {view === "grouped" ? (
-            <Select multiple value={f.gProjectIds} onChange={(v) => update({ gProjectIds: (v ?? []) as string[] })} showClear filter maxTagCount={1} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
-          ) : (
-            <Select value={f.project} onChange={(v) => update({ project: v as string | undefined })} showClear filter disabled={searching} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={t("loop.filter.project")}>{projectOpts}</Select>
-          )}
-        </div>
-      )}
-      {/* no-project:仅分组板(后端 include_no_project 仅 /grouped 支持)。 */}
-      {view === "grouped" && (
-        <div className="loop-fields__row">
-          <Checkbox className="loop-nofilter" checked={f.noProject} onChange={(e) => update({ noProject: !!e.target.checked })}>{t("loop.filter.noProject")}</Checkbox>
-        </div>
-      )}
+      {labels.length > 0 && filterSelect(t("loop.filter.label"), f.labelIds, (v) => update({ labelIds: v }), labelOpts, { filter: true })}
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.dateRange")}</div>
         <div className="loop-fields__inline">
@@ -381,20 +381,23 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
           <h2 className="loop-page__title">{title}</h2>
         </div>
         <div className="loop-page__toolbar">
-          {/* 作用域文字 tab —— grouped 视图按负责人类型收窄(all/成员/AI/与我相关)。 */}
-          {view === "grouped" && (
+          {/* 作用域 tab:全部/成员/AI,贯三视图,走后端 assignee_types。
+              「我的回路」锁定 involves、不给切 scope(否则点「全部」会显示全工作区),故不渲染。 */}
+          {!isMyLoop && (
             <div className="loop-agent-scope" role="tablist">
-              {(["all", "members", "agents", "involves"] as IssueScope[]).map((s) => {
-                const disabled = s === "involves" && !myMemberId;
+              {(["all", "members", "agents"] as IssueScope[]).map((s) => {
+                // 搜索激活时 scope 不参与(searchIssues 不吃 scope):既禁用、也不显选中态,
+                // 免得高亮的 tab 暗示"结果已按此 scope 收窄"。scope 状态保留,清空搜索后恢复。
+                const active = !searching && scope === s;
                 return (
                   <button
                     key={s}
                     type="button"
                     role="tab"
-                    aria-selected={scope === s}
-                    disabled={disabled}
-                    className={`loop-agent-scope__btn${scope === s ? " is-active" : ""}`}
-                    onClick={() => setScope(s)}
+                    aria-selected={active}
+                    disabled={searching}
+                    className={`loop-agent-scope__btn${active ? " is-active" : ""}`}
+                    onClick={() => { setScope(s); setPage(0); }}
                   >
                     {t(`loop.scope.${s}`)}
                   </button>
@@ -410,12 +413,15 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
               {activeFilters > 0 && <span className="loop-toolbtn__badge">{activeFilters}</span>}
             </button>
           </Dropdown>
-          <Dropdown trigger="click" visible={showOpen} onVisibleChange={setShowOpen} position="bottomRight" render={showPanel}>
-            <button className="loop-toolbtn">
-              <SlidersHorizontal size={14} />
-              {t("loop.action.show")}
-            </button>
-          </Dropdown>
+          {/* 「我的回路」锁死分组视图,不给切视图/排序 → 隐藏「显示」入口。 */}
+          {!isMyLoop && (
+            <Dropdown trigger="click" visible={showOpen} onVisibleChange={setShowOpen} position="bottomRight" render={showPanel}>
+              <button className="loop-toolbtn">
+                <SlidersHorizontal size={14} />
+                {t("loop.action.show")}
+              </button>
+            </Dropdown>
+          )}
           <LoopButton icon={<Plus size={14} />} onClick={openNewLoop}>
             {t("loop.action.newIssue")}
           </LoopButton>


### PR DESCRIPTION
## Summary

Unifies the loop issues board/list/grouped views onto **one shared multi-select filter model + scope**, aligning with the reference board. Closes #746.

Before: filters were split — board/list used single-value params, grouped used a separate multi-select set + a scope tab that only appeared in grouped view. Selections didn't carry across views.

After — one filter panel, applied identically across all three views:
- **Array multi-select** for every dimension: statuses / priorities / assignee_ids / creator_ids / project_ids / label_ids, plus orthogonal **no-assignee / no-project** toggles.
- **scope** (全部/成员/AI) spans all three views via `assignee_types` (previously grouped-only). The board drops the old 「与我相关」tab.
- **label** and **no-assignee** filters added (board-parity).
- `filterSelect` helper + `arrayFilterQuery` serializer remove per-view duplication.

Server-side + paginated filtering is retained (only the filter-state shape is unified). Keyword search still routes to the full-text `/issues/search` endpoint.

## Backend dependency (cross-repo)

The unified board/list filters send the plural query params to flat `/issues`. Backend support is delivered by **octo-multica MR !55 (merged)** and **MR !57** (label_ids + include_no_assignee). This frontend must deploy **after** those land (backend-first, per the ecosystem's staged-rollout convention). Verified live against the dev backend: `assignee_types`, `statuses`, `priorities`, `creator_ids`, `project_ids`, `include_no_project`, `label_ids`, `include_no_assignee` are all honored (each narrows results); backend integration tests in octo-multica prove per-param narrowing (incl. cross-workspace label scoping).

## Interaction correctness (7-dim UX + adversarial)

- **My Loop (`involves`) locked to grouped**: view-switch and scope tabs hidden — closes a latent escape where switching My Loop to board/list showed the whole workspace under a "my" title.
- **no-assignee × scope**: only effective at scope=全部 (combining with `assignee_types` is empty-by-construction) — checkbox disabled + unchecked + not sent otherwise; the active-filter badge is gated the same way (single source `noAssigneeActive`).
- **keyword search × scope/filters**: search bypasses filters (separate endpoint), so scope tabs + filters are disabled and shown inactive while searching.
- **显示 dropdown**: closes after picking board/grouped; stays open for list so the newly-revealed sort control is reachable.
- **reload failure**: clears the result set + toasts (no stale actionable rows under new filters; list selection auto-prunes).
- Empty/loading/edge (seq-guarded concurrency, maxTagCount overflow, pagination clamp) covered.

## Verification

- `pnpm test` (dmloop) — 11 files / 60 tests green, incl. new `arrayFilterQuery` query-contract test (plural join + boolean→"true" + unset→undefined).
- tsc clean for changed files.
- **Live e2e** (Alice-Loop): 3-view filter panel identical (board=list; grouped omits keyword by design); scope→assignee_types on board (empties board when all issues are agent-assigned); label filter renders+filters; no-assignee disables under members/AI; scope tabs disabled during search; My Loop shows no view-switch/scope controls; @-mention group relabeled 事项→回路.
- Two-model adversarial: Codex (multiple rounds — My-Loop escape, search-scope visual, involves-path error handling, badge count, scope pagination reset, duplicate i18n key all fixed) + skeptical code-reviewer (confirmed clean; caught the badge-count gate).

## Blast radius (Rule 8)

- `listIssues`/`listGroupedIssues`/`ListParams`/`GroupedParams`/`IssueScope` — all additive (new optional fields); other `listIssues` callers (`mentionExtension.ts`, `IssueDetailPage.tsx`) pass only `limit`, unaffected.
- `loop.mention.groupIssues` i18n relabel used only by `CommentComposer`.
- No brand leak (scanned): removed 3 upstream-brand code comments in touched files.

## Grouped-view keyword search (now included)

Keyword search works in the grouped view too: `searchIssues` flat results are grouped client-side by assignee (`groupIssuesByAssignee`, unit-tested). Excluded on My Loop (search endpoint can't scope to `involves`).

## Review round (commit db83d203)

Addressed all review findings: My Loop involves fan-out now strips the plural `assignee_ids`/`creator_ids` (blocking) + hides the who-filters on My Loop; `arrayFilterQuery` folds empty arrays to `undefined` locally; `activeFilters` suppresses non-keyword dimensions during search; removed the dead singular `status`/`priority`/`assignee_id`/`creator_id`/`project_id` from `ListParams` + `listIssues`. Backend plural-param support: octo-multica MR !55 + !57 (both merged). Re-ran two-model adversarial (both clean) + 63 unit tests green.
