### PR TITLE
fix(loop): resolve archived AI teammate names instead of showing raw id

### DIFF
--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -30,7 +30,10 @@ async function build(): Promise<Directory> {
   const wsId = currentWorkspaceId();
   const [members, agents, squads, projectsResp] = await Promise.all([
     wsId ? httpGet<Array<{ user_id: string; name: string; octo_uid?: string | null }>>(`/workspaces/${wsId}/members`).catch(() => []) : Promise.resolve([]),
-    httpGet<Array<{ id: string; name: string }>>("/agents").catch(() => []),
+    // include_archived: resolve names for archived (soft-deleted) agents too, so issues/comments/
+    // timeline referencing a deleted AI teammate show its name, not a raw id. Archived entries feed
+    // the name map only; the assignee picker (candidates) stays active-only.
+    httpGet<Array<{ id: string; name: string; archived_at?: string | null }>>("/agents", { include_archived: true }).catch(() => []),
     httpGet<Array<{ id: string; name: string }>>("/squads").catch(() => []),
     httpGet<{ projects: Array<{ id: string; title: string }> }>("/projects").catch(() => ({ projects: [] })),
   ]);
@@ -54,8 +57,8 @@ async function build(): Promise<Directory> {
   }
   const agentName = new Map<string, string>();
   for (const a of agents) {
-    agentName.set(a.id, a.name);
-    candidates.push({ id: a.id, type: "agent", name: a.name });
+    agentName.set(a.id, a.name); // resolve names incl. archived (for display)
+    if (!a.archived_at) candidates.push({ id: a.id, type: "agent", name: a.name }); // picker: active only
   }
   const squadName = new Map<string, string>();
   for (const s of squads) {


### PR DESCRIPTION
## Summary

After an AI teammate (agent) is **deleted** (soft-delete / archive) from a workspace, loop surfaces that reference it — comment authors, the activity timeline, automation cards, assignee/creator badges — stopped showing its **name** and rendered its raw **UUID** instead. Closes #777.

## Root cause

Loop resolves actor names client-side via a cached **directory** (`packages/dmloop/src/api/directory.ts`) built from `GET /agents`. That list excludes archived agents, so a deleted agent falls out of the `agentName` map, `actorName("agent", id)` returns `null`, and every `?? <id>` display fallback leaks the UUID.

Agent deletion is a **soft-delete** (`archived_at`, via `ArchiveAgent`) — the name is still in the DB and recoverable via `include_archived`.

## Fix

`directory.ts` `build()` now fetches `GET /agents?include_archived=true` and adds **all** agents (incl. archived) to the `agentName` map so names always resolve, while pushing **only active** agents (`!archived_at`) into the assignee/creator picker `candidates` (you can't newly assign to a deleted agent). One resolution-layer change covers every display site (Rule 9) — no per-site `?? id` patching.

Backend already supports `include_archived` on `/agents` (mirrors `ListAgents`).

## Scope

- **Agents only.** Squads have the same class of bug, but `ListSquads` has no `include_archived` param yet — tracked in **octo-multica#20**; the squad frontend follow-up lands together with that backend change (not speculatively wired here, to avoid a client contract that the backend doesn't honor).

## Verification

- **Live e2e** (dev stack, Alice-Loop): archived the E2E Coworker agent → confirmed it drops from default `GET /agents` (so without this fix its issues show the raw id) and is returned by `GET /agents?include_archived=true` with its name; with the fix the board still renders "E2E Coworker" and **no raw UUID appears anywhere**; restored the agent afterwards.
- `pnpm test` (dmloop): 63 tests green; tsc clean for the changed file.
- Two-model adversarial: skeptical code-reviewer — no real bugs (verified the picker still excludes archived, name maps include archived, `archived_at` truthiness, httpGet query serialization, cache untouched). No finding on this diff.

## Blast radius (Rule 8)

- `/agents` is fetched only in `directory.ts` `build()`; the added `archived_at` field is read locally and never escapes into `Directory`/`agentName`/`candidates` shapes, so `actorName`, `listAssigneeCandidates`, `agentApi.ts`, `squadApi.ts` consumers are unaffected. No brand leak.
