### PR TITLE
feat(docs): table row/column drag-to-reorder (octo-docs-backend#76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ packages/docs/dev-dist/
 # docs collab smoke screenshots / artifacts
 packages/docs/dev/smoke-out/
 packages/docs/dev/presence-out/
+packages/docs/dev/reorder-out/
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/

--- a/packages/docs/dev/octoBase.dev.ts
+++ b/packages/docs/dev/octoBase.dev.ts
@@ -9,7 +9,7 @@
 // This file is NEVER part of the production build: apps/web builds docs against the real
 // `@octo/base`. It exists purely so `pnpm --filter @octo/docs dev:standalone` can run.
 
-export { WKApp, Menus, SpaceService } from '../src/__mocks__/octoBase.ts'
+export { WKApp, Menus, SpaceService, VoiceInputButton } from '../src/__mocks__/octoBase.ts'
 export type { SpaceMember } from '../src/__mocks__/octoBase.ts'
 
 type Tree = Record<string, unknown>

--- a/packages/docs/dev/reorder.harness.tsx
+++ b/packages/docs/dev/reorder.harness.tsx
@@ -1,0 +1,252 @@
+// Real-browser two-peer harness for the table row/column reorder concurrency guard
+// (octo-docs-backend#76 / XIN-1225). Companion to dev/presence.harness.tsx.
+//
+// WHY a real browser: the reorder is DOM/pointer driven and the concurrency guard runs inside the
+// ProseMirror plugin's `state.apply` on every transaction that lands during a drag. jsdom unit tests
+// call the guard's pure functions directly and stayed green, yet real-browser TC01 (a collaborator
+// edits prose OUTSIDE the dragged table) and TC02 (a collaborator edits an identical SECOND table)
+// STILL false-aborted the reorder. Only a real drag (real mouse buttons) with a genuine concurrent
+// transaction arriving mid-drag reproduces that, which is exactly what the strong verification gate
+// on XIN-1225 requires.
+//
+// The harness mounts TWO real collaborative editors (A = the peer the user drags on, B = the remote
+// collaborator) bound to two Y.Docs bridged the way HocuspocusProvider relays updates over the wire:
+// every local Y update is applied to the other doc as a remote update, so B's edit reaches A as a
+// real remote transaction while A holds a drag. `window.__reorderHarness` exposes the seams the
+// Playwright driver (dev/run-reorder.mjs) needs; `window.__reorderAbortDebug` (armed by the driver)
+// captures the guard's per-transaction decision. Dev-only.
+
+import { useEffect, useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import * as Y from 'yjs'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TableMap, moveTableRow } from '@tiptap/pm/tables'
+import { TextSelection } from '@tiptap/pm/state'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { setWKApp } from '../src/octoweb/index.ts'
+import { createMockWKApp } from '../src/octoweb/mock.ts'
+import { TableReorderHandle } from '../src/editor/TableReorderHandle.ts'
+
+// i18n / WKApp seam — the reorder-conflict toast calls t(); wire the mock so it resolves in dev.
+setWKApp(createMockWKApp({ uid: 'u_reorder', token: 'dev' }))
+
+const FIELD = 'default'
+
+function makeEditor(ydoc: Y.Doc, element: HTMLElement): Editor {
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Collaboration.configure({ document: ydoc, field: FIELD }),
+      Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+    ],
+  })
+}
+
+/** Relay every local Y update from `from` into `to`, tagged so it is not echoed back — the same
+ *  incremental relay HocuspocusProvider performs over the WS. */
+function bridge(from: Y.Doc, to: Y.Doc, tag: string): () => void {
+  const onUpdate = (update: Uint8Array, origin: unknown) => {
+    if (origin === 'bridge') return
+    Y.applyUpdate(to, update, 'bridge')
+  }
+  void tag
+  from.on('update', onUpdate)
+  return () => from.off('update', onUpdate)
+}
+
+function firstTable(editor: Editor): { node: PMNode; pos: number } {
+  let node: PMNode | null = null
+  let pos = -1
+  editor.state.doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+
+function nthTable(editor: Editor, n: number): { node: PMNode; pos: number } {
+  const found: { node: PMNode; pos: number }[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'table') {
+      found.push({ node, pos })
+      return false
+    }
+    return true
+  })
+  if (!found[n]) throw new Error(`no table #${n}`)
+  return found[n]
+}
+
+/** Cell text as a row × col grid from the first table. */
+function gridOf(editor: Editor): string[][] {
+  const { node } = firstTable(editor)
+  const map = TableMap.get(node)
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const row: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cell = node.nodeAt(map.map[r * map.width + c])
+      row.push(cell ? cell.textContent : '')
+    }
+    out.push(row)
+  }
+  return out
+}
+
+// Documents used by the scenarios. A single table with prose around it (TC01), and two byte-identical
+// tables (TC02). Row labels rNcM so a reorder is observable in the grid.
+const DOC_SINGLE =
+  '<p>heading paragraph — edit me from the other peer</p>' +
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>' +
+  '<p>trailing paragraph</p>'
+
+const DOC_TWINS =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>' +
+  '<p>between the two identical tables</p>' +
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>'
+
+function Harness(): React.ReactElement {
+  const refA = useRef<HTMLDivElement>(null)
+  const refB = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!refA.current || !refB.current) return
+    let edA: Editor | null = null
+    let edB: Editor | null = null
+    let offA: (() => void) | null = null
+    let offB: (() => void) | null = null
+
+    const mount = (html: string) => {
+      offA?.()
+      offB?.()
+      edA?.destroy()
+      edB?.destroy()
+      refA.current!.innerHTML = ''
+      refB.current!.innerHTML = ''
+      const docA = new Y.Doc()
+      const docB = new Y.Doc()
+      edA = makeEditor(docA, refA.current!)
+      // Seed on A via a real transaction so ySyncPlugin writes it into the Y.Doc, then fork B.
+      edA.commands.insertContent(html)
+      Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA), 'bridge')
+      edB = makeEditor(docB, refB.current!)
+      offA = bridge(docA, docB, 'A→B')
+      offB = bridge(docB, docA, 'B→A')
+      return { edA, edB }
+    }
+
+    // Remote edit helpers run on peer B and propagate to A over the bridge as a real transaction.
+    const remoteProseEdit = () => {
+      // TC01: edit prose OUTSIDE any table (inside the leading paragraph, position 3).
+      edB!.view.dispatch(edB!.state.tr.insertText('EDITED', 3))
+    }
+    const remoteSecondTableEdit = () => {
+      // TC02: edit a cell of the SECOND (identical) table — never the dragged first table.
+      const t1 = nthTable(edB!, 1)
+      const m1 = TableMap.get(t1.node)
+      const inside = t1.pos + 1 + m1.map[0] + 1
+      edB!.view.dispatch(edB!.state.tr.insertText('X', inside))
+    }
+    const remoteReorderFirstTable = () => {
+      // TC03: reorder the SAME (dragged) first table on the remote peer — a real structural conflict.
+      const { node, pos } = firstTable(edB!)
+      const map = TableMap.get(node)
+      const $in = edB!.state.doc.resolve(pos + 1 + map.map[1 * map.width + 0] + 1)
+      edB!.view.dispatch(edB!.state.tr.setSelection(TextSelection.near($in)))
+      moveTableRow({ from: 1, to: 0 })(edB!.state, edB!.view.dispatch)
+    }
+
+    const harness = {
+      mountSingle: () => {
+        mount(DOC_SINGLE)
+      },
+      mountTwins: () => {
+        mount(DOC_TWINS)
+      },
+      // TC08: a freshly-created document whose only content is a table (the "new document / table
+      // context" path). No surrounding prose, table at document position 0.
+      mountNewDoc: () => {
+        mount(
+          '<table><tbody>' +
+            '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+            '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+            '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+            '</tbody></table>',
+        )
+      },
+      gridA: () => gridOf(edA!),
+      gridB: () => gridOf(edB!),
+      remoteProseEdit,
+      remoteSecondTableEdit,
+      remoteReorderFirstTable,
+      // Bounding rect of a cell in editor A (row,col), for the driver to hover/drag against.
+      cellRectA: (row: number, col: number): { left: number; top: number; width: number; height: number } | null => {
+        const { node, pos } = firstTable(edA!)
+        const map = TableMap.get(node)
+        const cellPos = pos + 1 + map.map[row * map.width + col]
+        const dom = edA!.view.nodeDOM(cellPos)
+        if (!(dom instanceof HTMLElement)) return null
+        const r = dom.getBoundingClientRect()
+        return { left: r.left, top: r.top, width: r.width, height: r.height }
+      },
+      // Bounding rect of the visible row/col reorder handle (null when hidden).
+      handleRect: (kind: 'row' | 'col'): { left: number; top: number; width: number; height: number } | null => {
+        const el = document.querySelector(`.octo-table-reorder--${kind}`) as HTMLElement | null
+        if (!el || el.style.display === 'none') return null
+        const r = el.getBoundingClientRect()
+        return { left: r.left, top: r.top, width: r.width, height: r.height }
+      },
+    }
+    ;(window as unknown as { __reorderHarness: typeof harness }).__reorderHarness = harness
+
+    return () => {
+      offA?.()
+      offB?.()
+      edA?.destroy()
+      edB?.destroy()
+    }
+  }, [])
+
+  return (
+    <div style={{ display: 'flex', gap: 8, height: '100vh', padding: 40, boxSizing: 'border-box', font: '14px system-ui' }}>
+      <div style={{ flex: 1, position: 'relative', padding: '48px 24px 24px 48px', overflow: 'auto', border: '2px solid #2f9e44' }}>
+        <div style={{ position: 'absolute', top: 4, left: 8, color: '#2f9e44' }}>A (drag here)</div>
+        <div ref={refA} style={{ position: 'relative' }} />
+      </div>
+      <div style={{ flex: 1, position: 'relative', padding: '48px 24px 24px 48px', overflow: 'auto', border: '2px solid #1971c2' }}>
+        <div style={{ position: 'absolute', top: 4, left: 8, color: '#1971c2' }}>B (remote collaborator)</div>
+        <div ref={refB} style={{ position: 'relative' }} />
+      </div>
+    </div>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<Harness />)

--- a/packages/docs/dev/run-reorder.mjs
+++ b/packages/docs/dev/run-reorder.mjs
@@ -1,0 +1,180 @@
+// Playwright driver for the table reorder concurrency guard (octo-docs-backend#76 / XIN-1225).
+// Real Chromium, real left-button drag on the row reorder handle, with a genuine concurrent remote
+// transaction (peer B) arriving mid-drag. Reproduces:
+//   TC01 — remote edits PROSE OUTSIDE the dragged table  → reorder must COMPLETE (no abort).
+//   TC02 — remote edits an identical SECOND table         → reorder must COMPLETE (no abort).
+//   TC03 — remote reorders the SAME dragged table         → reorder must ABORT (data-safety guard).
+// Usage: node dev/run-reorder.mjs   (expects the standalone dev server on :4178)
+import { chromium } from '@playwright/test'
+
+const PORT = process.env.HARNESS_PORT || '4178'
+const URL = `http://localhost:${PORT}/reorder.html`
+const OUT = 'dev/reorder-out'
+import { mkdirSync } from 'node:fs'
+mkdirSync(OUT, { recursive: true })
+
+let failed = 0
+const fail = (msg) => {
+  console.error('  ✗ FAIL:', msg)
+  failed++
+}
+const ok = (msg) => console.log('  ✓', msg)
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+page.on('pageerror', (e) => console.log('[pageerror]', e.message))
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('[page error]', m.text())
+})
+
+await page.goto(URL, { waitUntil: 'networkidle' })
+await page.waitForFunction(() => !!window.__reorderHarness, { timeout: 30000 })
+
+/** Perform a full row-2→top drag on peer A, firing `remoteFn` (a __reorderHarness method name) mid-drag.
+ *  Returns { grid, abortDebug } observed after mouseup. */
+async function dragRowWithConcurrentEdit(remoteFn) {
+  // Arm the guard debug sink fresh for this run.
+  await page.evaluate(() => {
+    window.__reorderAbortDebug = []
+    window.__tableReorderDebug = []
+  })
+
+  // 1) Hover over the source cell (row 2, col 0) so the row grab handle appears for that row.
+  const src = await page.evaluate(() => window.__reorderHarness.cellRectA(2, 0))
+  if (!src) throw new Error('source cell rect not found')
+  await page.mouse.move(src.left + src.width / 2, src.top + src.height / 2)
+  await page.waitForTimeout(80)
+
+  // 2) Grab the row handle (sits in the left gutter at the hovered row's Y).
+  const handle = await page.evaluate(() => window.__reorderHarness.handleRect('row'))
+  if (!handle) throw new Error('row handle not visible after hover')
+  await page.mouse.move(handle.left + handle.width / 2, handle.top + handle.height / 2)
+  await page.mouse.down()
+
+  // 3) Drag up toward row 0. Several held moves so pointerHeldSeen latches and dropIndex resolves.
+  const dst = await page.evaluate(() => window.__reorderHarness.cellRectA(0, 0))
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 6 })
+  await page.waitForTimeout(50)
+
+  // 4) Fire the concurrent remote edit on peer B — it reaches A as a real transaction mid-drag.
+  await page.evaluate((fn) => window.__reorderHarness[fn](), remoteFn)
+  await page.waitForTimeout(50)
+
+  // 5) Re-settle the drop target on the now-updated document, then release.
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2 - 2, { steps: 3 })
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 3 })
+  await page.waitForTimeout(30)
+  await page.mouse.up()
+  await page.waitForTimeout(120)
+
+  return await page.evaluate(() => ({
+    grid: window.__reorderHarness.gridA(),
+    abortDebug: window.__reorderAbortDebug,
+    dispatchDebug: window.__tableReorderDebug,
+  }))
+}
+
+const firstColMoved = (grid) => grid.map((r) => r[0])
+
+/** A plain row-2→top drag on peer A with NO concurrent edit (the happy path). */
+async function dragRowNoConcurrent() {
+  await page.evaluate(() => {
+    window.__reorderAbortDebug = []
+    window.__tableReorderDebug = []
+  })
+  const src = await page.evaluate(() => window.__reorderHarness.cellRectA(2, 0))
+  await page.mouse.move(src.left + src.width / 2, src.top + src.height / 2)
+  await page.waitForTimeout(80)
+  const handle = await page.evaluate(() => window.__reorderHarness.handleRect('row'))
+  if (!handle) throw new Error('row handle not visible after hover')
+  await page.mouse.move(handle.left + handle.width / 2, handle.top + handle.height / 2)
+  await page.mouse.down()
+  const dst = await page.evaluate(() => window.__reorderHarness.cellRectA(0, 0))
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 6 })
+  await page.waitForTimeout(30)
+  await page.mouse.up()
+  await page.waitForTimeout(100)
+  return await page.evaluate(() => window.__reorderHarness.gridA())
+}
+
+// ── TC01 ────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nTC01 — remote prose edit OUTSIDE the dragged table (must NOT abort)')
+await page.evaluate(() => window.__reorderHarness.mountSingle())
+await page.waitForTimeout(200)
+{
+  const before = await page.evaluate(() => window.__reorderHarness.gridA())
+  console.log('  grid before:', JSON.stringify(firstColMoved(before)))
+  const { grid, abortDebug, dispatchDebug } = await dragRowWithConcurrentEdit('remoteProseEdit')
+  console.log('  grid after :', JSON.stringify(firstColMoved(grid)))
+  console.log('  abortDebug :', JSON.stringify(abortDebug))
+  const aborted = abortDebug.some((e) => e.conflict)
+  const moved = grid[0][0] === 'r3c1'
+  const dispatched = dispatchDebug.some((e) => e.phase === 'dispatch' && e.dispatched)
+  if (aborted) fail('TC01 guard aborted on an OUTSIDE prose edit')
+  else ok('guard did not abort on outside prose edit')
+  if (!moved) fail(`TC01 reorder did not complete (row 3 not at top): ${JSON.stringify(firstColMoved(grid))}`)
+  else ok('reorder completed — r3 row moved to top')
+  if (!dispatched) fail('TC01 move command was never dispatched')
+  await page.screenshot({ path: `${OUT}/tc01-after.png` })
+}
+
+// ── TC02 ────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nTC02 — remote edit of an identical SECOND table (must NOT abort)')
+await page.evaluate(() => window.__reorderHarness.mountTwins())
+await page.waitForTimeout(200)
+{
+  const before = await page.evaluate(() => window.__reorderHarness.gridA())
+  console.log('  grid before:', JSON.stringify(firstColMoved(before)))
+  const { grid, abortDebug } = await dragRowWithConcurrentEdit('remoteSecondTableEdit')
+  console.log('  grid after :', JSON.stringify(firstColMoved(grid)))
+  console.log('  abortDebug :', JSON.stringify(abortDebug))
+  const aborted = abortDebug.some((e) => e.conflict)
+  const moved = grid[0][0] === 'r3c1'
+  if (aborted) fail('TC02 guard aborted on an edit to the OTHER identical table')
+  else ok('guard did not abort on identical-second-table edit')
+  if (!moved) fail(`TC02 reorder did not complete: ${JSON.stringify(firstColMoved(grid))}`)
+  else ok('reorder completed — r3 row moved to top')
+  await page.screenshot({ path: `${OUT}/tc02-after.png` })
+}
+
+// ── TC03 ────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nTC03 — remote reorder of the SAME dragged table (MUST abort — data-safety guard)')
+await page.evaluate(() => window.__reorderHarness.mountSingle())
+await page.waitForTimeout(200)
+{
+  const { grid, abortDebug } = await dragRowWithConcurrentEdit('remoteReorderFirstTable')
+  console.log('  grid after :', JSON.stringify(firstColMoved(grid)))
+  console.log('  abortDebug :', JSON.stringify(abortDebug))
+  const aborted = abortDebug.some((e) => e.conflict)
+  if (!aborted) fail('TC03 guard did NOT abort on a concurrent same-table reorder (data-safety hole)')
+  else ok('guard aborted on concurrent same-table reorder — data-safety preserved')
+  await page.screenshot({ path: `${OUT}/tc03-after.png` })
+}
+
+// ── TC08 ────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nTC08 — new document / table-only context: reorder works and is stable (no regression)')
+await page.evaluate(() => window.__reorderHarness.mountNewDoc())
+await page.waitForTimeout(200)
+{
+  const before = await page.evaluate(() => window.__reorderHarness.gridA())
+  console.log('  grid before  :', JSON.stringify(firstColMoved(before)))
+  const g1 = await dragRowNoConcurrent() // r3 -> top
+  console.log('  after drag #1:', JSON.stringify(firstColMoved(g1)))
+  if (g1[0][0] !== 'r3c1') fail(`TC08 first reorder failed on a new doc: ${JSON.stringify(firstColMoved(g1))}`)
+  else ok('reorder works on a fresh table-only document')
+  // Stability: a second reorder must also apply cleanly, not wedge the handles into the unusable state.
+  const expectSecond = g1[2][0]
+  const g2 = await dragRowNoConcurrent()
+  console.log('  after drag #2:', JSON.stringify(firstColMoved(g2)))
+  if (g2[0][0] !== expectSecond) fail(`TC08 second consecutive reorder unstable: ${JSON.stringify(firstColMoved(g2))}`)
+  else ok('second consecutive reorder is stable (handles not wedged)')
+  await page.screenshot({ path: `${OUT}/tc08-after.png` })
+}
+
+await browser.close()
+if (failed) {
+  console.error(`\n=== REORDER HARNESS FAILED (${failed}) ===`)
+  process.exitCode = 1
+} else {
+  console.log('\n=== REORDER HARNESS PASSED: TC01 + TC02 complete, TC03 aborts ===')
+}

--- a/packages/docs/reorder.html
+++ b/packages/docs/reorder.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Table reorder concurrency real-runtime harness (XIN-1225)</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      td,
+      th {
+        border: 1px solid #adb5bd;
+        padding: 6px 10px;
+        min-width: 48px;
+      }
+      /* Make the reorder grab handles visible/hittable in the harness (production styles live in
+         editor/styles.css, not loaded here). */
+      .octo-table-reorder {
+        background: #4263eb;
+        opacity: 0.85;
+        cursor: grab;
+        z-index: 10;
+      }
+      .octo-table-reorder-indicator {
+        background: #f03e3e;
+        z-index: 11;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dev/reorder.harness.tsx"></script>
+  </body>
+</html>

--- a/packages/docs/src/editor/TableReorderConcurrency.test.ts
+++ b/packages/docs/src/editor/TableReorderConcurrency.test.ts
@@ -36,7 +36,7 @@ import {
   tableEditingKey,
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
-import { tableStructureSignature } from './TableReorderHandle.ts'
+import { tableStructureSignature, signatureOfTable, countTableSignature, draggedTableConflict } from './TableReorderHandle.ts'
 
 // Same collab field name the editor wires in production (schema/index.ts COLLAB_FIELD).
 const FIELD = 'default'
@@ -341,5 +341,119 @@ describe('table reorder — plan B conflict-abort guard eliminates silent corrup
     selectCell(edA, 2, 0)
     moveTableRow({ from: 2, to: 0 })(edA.state, edA.view.dispatch)
     expect(grid(edA).map((row) => row[0])).toEqual(['r3c1', 'r1c1', 'r2c1'])
+  })
+})
+
+// octo-docs-backend#76 FAIL-2 (XIN-1206): the plan-B guard must fire ONLY for a concurrent change to
+// the DRAGGED table. The original guard re-fingerprinted a single remapped `cellPos`; under real
+// collaboration y-prosemirror applies a remote update as one coarse ReplaceStep, so mapping that
+// anchor forward collapses it to the replace boundary — it stops resolving to a cell even when the
+// dragged table is untouched, and the old `signature === null → conflict` branch then FALSE-ABORTED
+// on edits to prose or to a different table (observed as: "editing text outside the table cancels my
+// reorder"). These tests exercise the exact dual-Y.Doc merge and drive conflict detection through the
+// position-independent `countTableSignature` / `draggedTableConflict` the guard now uses.
+describe('table reorder — plan B guard scope: same-table only (#76 FAIL-2)', () => {
+  const TWO_TABLES =
+    '<p>lead</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>A1</p></td><td><p>A2</p></td></tr>' +
+    '<tr><td><p>A3</p></td><td><p>A4</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>between</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>B1</p></td><td><p>B2</p></td></tr>' +
+    '</tbody></table>'
+
+  function nthTable(editor: Editor, n: number): { node: PMNode; pos: number } {
+    const found: { node: PMNode; pos: number }[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'table') {
+        found.push({ node, pos })
+        return false
+      }
+      return true
+    })
+    if (!found[n]) throw new Error(`no table #${n}`)
+    return found[n]
+  }
+  function cellInsideOf(editor: Editor, tableIndex: number, row: number, col: number): number {
+    const { node, pos } = nthTable(editor, tableIndex)
+    const map = TableMap.get(node)
+    return pos + 1 + map.map[row * map.width + col] + 1 // inside the cell
+  }
+
+  // Diagnostic: prove the anchor-drift that broke the OLD approach is real in this harness. After a
+  // remote edit merges, the dragged cell's remapped position no longer fingerprints the table.
+  it('remapped cellPos drifts under a coarse remote ReplaceStep (root cause of the false abort)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
+    track(edA, edB)
+    let cellPos = cellPosOf(edA, 0, 0) // dragging table #0
+    const baseline = tableStructureSignature(edA.state.doc, cellPos)
+    expect(baseline).not.toBeNull()
+
+    const onTr = ({ transaction }: { transaction: { docChanged: boolean; mapping: { map(p: number): number } } }) => {
+      if (transaction.docChanged) cellPos = transaction.mapping.map(cellPos)
+    }
+    edA.on('transaction', onTr)
+    // Peer B edits prose OUTSIDE any table.
+    edB.view.dispatch(edB.state.tr.insertText('typed', 2))
+    mergeConcurrent(docA, docB, base)
+    edA.off('transaction', onTr)
+
+    // OLD behaviour: the remapped anchor's signature is now null → old guard would abort. This is the
+    // FAIL-2 false positive we are eliminating.
+    expect(tableStructureSignature(edA.state.doc, cellPos)).toBeNull()
+    // NEW behaviour: the dragged table's signature is still present in the doc → no conflict.
+    const baselineCount = countTableSignature(edA.state.doc, baseline!) // recount post-merge
+    expect(baselineCount).toBeGreaterThanOrEqual(1)
+    expect(draggedTableConflict(edA.state.doc, baseline, baselineCount)).toBe(false)
+  })
+
+  it('reorder ⟂ remote edit of a DIFFERENT table → guard stays clear (no false abort)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
+    track(edA, edB)
+    const baselineSig = signatureOfTable(nthTable(edA, 0).node) // dragging table #0
+    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
+    expect(baselineSig).not.toBeNull()
+
+    // Peer B edits the OTHER table's cell text.
+    const insideB = cellInsideOf(edB, 1, 0, 0)
+    edB.view.dispatch(edB.state.tr.insertText('CHANGED', insideB))
+    mergeConcurrent(docA, docB, base)
+
+    // Dragged table #0 unchanged → its signature still present → reorder allowed.
+    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(false)
+    expect(xml(docA)).toBe(xml(docB))
+  })
+
+  it('reorder ⟂ remote edit of prose OUTSIDE any table → guard stays clear', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
+    track(edA, edB)
+    const baselineSig = signatureOfTable(nthTable(edA, 0).node)
+    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
+
+    edB.view.dispatch(edB.state.tr.insertText('hello', 2)) // prose before the tables
+    mergeConcurrent(docA, docB, base)
+
+    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(false)
+    expect(xml(docA)).toBe(xml(docB))
+  })
+
+  it('reorder ⟂ remote structural change to the DRAGGED table → guard fires (data-safety kept)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
+    track(edA, edB)
+    const baselineSig = signatureOfTable(nthTable(edA, 0).node) // dragging table #0
+    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
+
+    // Peer B reorders the SAME table #0 (row swap).
+    const { pos } = nthTable(edB, 0)
+    const mapB = TableMap.get(nthTable(edB, 0).node)
+    const $inB = edB.state.doc.resolve(pos + 1 + mapB.map[1 * mapB.width + 0] + 1)
+    edB.view.dispatch(edB.state.tr.setSelection(TextSelection.near($inB)))
+    moveTableRow({ from: 1, to: 0 })(edB.state, edB.view.dispatch)
+    mergeConcurrent(docA, docB, base)
+
+    // The drag-start signature no longer matches any table → conflict → local reorder aborts.
+    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(true)
   })
 })

--- a/packages/docs/src/editor/TableReorderConcurrency.test.ts
+++ b/packages/docs/src/editor/TableReorderConcurrency.test.ts
@@ -36,6 +36,7 @@ import {
   tableEditingKey,
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
+import { tableStructureSignature } from './TableReorderHandle.ts'
 
 // Same collab field name the editor wires in production (schema/index.ts COLLAB_FIELD).
 const FIELD = 'default'
@@ -93,6 +94,14 @@ function selectCell(editor: Editor, row: number, col: number): void {
   const cellRel = map.map[row * map.width + col]
   const $inside = editor.state.doc.resolve(pos + 1 + cellRel + 1)
   editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($inside)))
+}
+
+/** Absolute document position just before the (row,col) cell — the anchor a drag captures as
+ *  `cellPos` at drag start and the plan-B guard fingerprints from. */
+function cellPosOf(editor: Editor, row: number, col: number): number {
+  const { node, pos } = firstTable(editor)
+  const map = TableMap.get(node)
+  return pos + 1 + map.map[row * map.width + col]
 }
 
 /** Seed peer A with `html`, fork peer B from A's identical Y state, return both peers plus the
@@ -238,5 +247,99 @@ describe('table reorder — collaborative convergence baseline (#76)', () => {
     const texts = new Set(grid(edA).flat())
     const anyPristineRowLabel = ['r1c1', 'r2c1', 'r3c1'].some((t) => texts.has(t))
     expect(anyPristineRowLabel).toBe(false) // documents today's garbling; a fix should flip this
+  })
+})
+
+// Plan B (octo-docs-backend#76 / XIN-1187 —老板拍板 B). The guard added to TableReorderHandle
+// snapshots the dragged table's structure at drag start and, if a concurrent edit lands on that
+// table during the drag, ABORTS the local reorder (shows an i18n toast) instead of committing the
+// coarse whole-table replace. These tests reuse the same dual-Y.Doc harness as the baseline above
+// and show the guard's two halves: (1) `tableStructureSignature` detects exactly the concurrent
+// structural races the characterization test corrupts on, and (2) once the losing peer aborts, only
+// the surviving edit lands, so the peers converge to a clean, non-corrupt table — no silent data
+// loss. The baseline/characterization tests above are left untouched as the evidence of the hazard.
+describe('table reorder — plan B conflict-abort guard eliminates silent corruption (#76)', () => {
+  // The exact scenario the characterization test corrupts on: two concurrent reorders of the same
+  // table. With the guard, the peer that detects the concurrent reorder aborts its own move, so only
+  // ONE whole-table replace is ever committed — the peers converge to a clean reorder, labels intact.
+  it('two concurrent reorders → losing peer aborts, peers converge with NO corruption', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(HTML_3x3)
+    track(edA, edB)
+
+    // Peer A begins dragging row 2 and snapshots the table (beginDrag → dragBaseline).
+    const dragCell = cellPosOf(edA, 2, 0)
+    const baseline = tableStructureSignature(edA.state.doc, dragCell)
+    expect(baseline).not.toBeNull()
+
+    // Peer B concurrently reorders the SAME table (row 0 → bottom) and commits it.
+    selectCell(edB, 0, 0)
+    moveTableRow({ from: 0, to: 2 })(edB.state, edB.view.dispatch)
+
+    // B's concurrent edit reaches A (y-prosemirror). A's guard re-fingerprints the dragged table and
+    // sees it diverge from the baseline → the drop is aborted, so A commits NOTHING.
+    mergeConcurrent(docA, docB, base)
+    const afterMerge = tableStructureSignature(edA.state.doc, cellPosOf(edA, 0, 0))
+    expect(afterMerge).not.toBe(baseline) // guard fires → A aborts its reorder
+
+    // Because A aborted, only B's single reorder is in the CRDT: peers converge and every original
+    // cell label survives verbatim — the char-interleaving corruption is gone.
+    expect(xml(docA)).toBe(xml(docB))
+    expect(grid(edA)).toEqual(grid(edB))
+    const texts = grid(edA).flat()
+    for (const cell of [
+      'r1c1', 'r1c2', 'r1c3',
+      'r2c1', 'r2c2', 'r2c3',
+      'r3c1', 'r3c2', 'r3c3',
+    ]) {
+      expect(texts).toContain(cell)
+    }
+    // B's reorder landed cleanly: row 0 ("r1") moved to the bottom.
+    expect(grid(edA).map((row) => row[0])).toEqual(['r2c1', 'r3c1', 'r1c1'])
+  })
+
+  it('reorder ⟂ concurrent remote row insert → guard fires, insert survives, nothing lost', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(HTML_3x2)
+    track(edA, edB)
+
+    // Peer A begins dragging row 2 and snapshots the table.
+    const dragCell = cellPosOf(edA, 2, 0)
+    const baseline = tableStructureSignature(edA.state.doc, dragCell)
+
+    // Peer B concurrently inserts a row above the first row of the SAME table.
+    selectCell(edB, 0, 0)
+    addRowBefore(edB.state, edB.view.dispatch)
+
+    mergeConcurrent(docA, docB, base)
+
+    // Row count changed → guard fires → A aborts. Only B's insert lands; peers converge with no loss.
+    expect(tableStructureSignature(edA.state.doc, cellPosOf(edA, 0, 0))).not.toBe(baseline)
+    expect(xml(docA)).toBe(xml(docB))
+    expect(grid(edA)).toEqual(grid(edB))
+    const texts = grid(edA).flat()
+    for (const cell of ['r1c1', 'r2c1', 'r3c1', 'r1c2', 'r2c2', 'r3c2']) {
+      expect(texts).toContain(cell)
+    }
+    // A brand-new empty row was inserted (a blank leading cell), and the original order is intact.
+    expect(texts.filter((t) => t === '').length).toBeGreaterThanOrEqual(1)
+    expect(grid(edA).map((row) => row[0]).filter((t) => t.startsWith('r'))).toEqual([
+      'r1c1',
+      'r2c1',
+      'r3c1',
+    ])
+  })
+
+  it('reorder with NO concurrent edit → guard stays clear, reorder proceeds normally', () => {
+    const { edA } = forkedPeers(HTML_3x3)
+    track(edA)
+
+    // Single-user drag: snapshot, no concurrent transaction arrives, so the fingerprint is unchanged
+    // and the reorder is allowed — the guard never blocks the happy path.
+    const dragCell = cellPosOf(edA, 2, 0)
+    const baseline = tableStructureSignature(edA.state.doc, dragCell)
+    expect(tableStructureSignature(edA.state.doc, cellPosOf(edA, 2, 0))).toBe(baseline)
+
+    selectCell(edA, 2, 0)
+    moveTableRow({ from: 2, to: 0 })(edA.state, edA.view.dispatch)
+    expect(grid(edA).map((row) => row[0])).toEqual(['r3c1', 'r1c1', 'r2c1'])
   })
 })

--- a/packages/docs/src/editor/TableReorderConcurrency.test.ts
+++ b/packages/docs/src/editor/TableReorderConcurrency.test.ts
@@ -1,0 +1,242 @@
+// Concurrent-collaboration convergence baseline for table row/column reorder
+// (octo-docs-backend#76, XIN-1174 #12). These tests bind TWO real Y.Docs through the SAME
+// binding the app uses at runtime — @tiptap/extension-collaboration over @tiptap/y-tiptap
+// (Tiptap's y-prosemirror fork) — seed an identical table on both, apply a reorder on one peer
+// and a concurrent edit on the other, exchange only the concurrent diffs, and compare the merged
+// Y.Doc XmlFragment on both peers.
+//
+// WHY: the reorder command (prosemirror-tables moveTableRow/moveTableColumn) rebuilds the whole
+// table with a single `tr.replaceWith`. The concern raised in #76 was that this coarse whole-table
+// replace would make the CRDT diverge against a concurrent row insert. These tests are the
+// evidence base for that question and the regression baseline for whatever fix is chosen.
+//
+// WHAT THEY SHOW (see the issue analysis comment for the full write-up):
+//   * The CRDT layer CONVERGES in every case measured here — both peers reach a byte-identical
+//     XmlFragment. Strict Yjs non-convergence from the whole-table replace is NOT reproduced.
+//   * The real hazard of the coarse replace is convergent-but-CORRUPT content: two concurrent
+//     whole-table replaces (reorder vs reorder) interleave cell text char-by-char, so both peers
+//     agree on a garbled table. That is the behaviour a finer-grained fix must eliminate — it is
+//     pinned as a characterization test below, not as desired behaviour.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import * as Y from 'yjs'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TextSelection } from '@tiptap/pm/state'
+import {
+  TableMap,
+  moveTableRow,
+  moveTableColumn,
+  addRowBefore,
+  tableEditingKey,
+} from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+
+// Same collab field name the editor wires in production (schema/index.ts COLLAB_FIELD).
+const FIELD = 'default'
+
+function makeCollabEditor(ydoc: Y.Doc): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false }), // yUndo owns history under collaboration
+      Collaboration.configure({ document: ydoc, field: FIELD }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+    ],
+  })
+}
+
+function firstTable(editor: Editor): { node: PMNode; pos: number } {
+  const { doc } = editor.state
+  let node: PMNode | null = null
+  let pos = -1
+  doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+
+/** Cell text as a `row × col` grid, read from the current TableMap. */
+function grid(editor: Editor): string[][] {
+  const { node } = firstTable(editor)
+  const map = TableMap.get(node)
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const row: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cell = node.nodeAt(map.map[r * map.width + c])
+      row.push(cell ? cell.textContent : '')
+    }
+    out.push(row)
+  }
+  return out
+}
+
+/** Drop the caret into the (row,col) cell — the move commands resolve the target table from the
+ *  selection, exactly as the drop handler does before dispatching. */
+function selectCell(editor: Editor, row: number, col: number): void {
+  const { node, pos } = firstTable(editor)
+  const map = TableMap.get(node)
+  const cellRel = map.map[row * map.width + col]
+  const $inside = editor.state.doc.resolve(pos + 1 + cellRel + 1)
+  editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($inside)))
+}
+
+/** Seed peer A with `html`, fork peer B from A's identical Y state, return both peers plus the
+ *  shared base state vector (used to extract each peer's concurrent-only diff). */
+function forkedPeers(html: string): {
+  docA: Y.Doc
+  edA: Editor
+  docB: Y.Doc
+  edB: Editor
+  base: Uint8Array
+} {
+  const docA = new Y.Doc()
+  const edA = makeCollabEditor(docA)
+  // Seed via a real transaction so ySyncPlugin writes the table into the Y.Doc (passing `content`
+  // to the editor while Collaboration is attached does not reliably seed the shared type).
+  edA.commands.insertContent(html)
+  const docB = new Y.Doc()
+  Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+  const edB = makeCollabEditor(docB)
+  return { docA, edA, docB, edB, base: Y.encodeStateVector(docA) }
+}
+
+/** Exchange only the post-base (concurrent) diffs in both directions — a true concurrent merge. */
+function mergeConcurrent(docA: Y.Doc, docB: Y.Doc, base: Uint8Array): void {
+  const uA = Y.encodeStateAsUpdate(docA, base)
+  const uB = Y.encodeStateAsUpdate(docB, base)
+  Y.applyUpdate(docA, uB)
+  Y.applyUpdate(docB, uA)
+}
+
+const xml = (doc: Y.Doc): string => doc.getXmlFragment(FIELD).toString()
+
+const HTML_3x2 =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>'
+
+const HTML_3x3 =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td><td><p>r1c3</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td><td><p>r2c3</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td><td><p>r3c3</p></td></tr>' +
+  '</tbody></table>'
+
+const editors: Editor[] = []
+afterEach(() => {
+  while (editors.length) editors.pop()?.destroy()
+})
+function track(...eds: Editor[]): void {
+  editors.push(...eds)
+}
+
+describe('table reorder — collaborative convergence baseline (#76)', () => {
+  it('binds through the runtime table-editing plugin (harness fidelity)', () => {
+    const { edA } = forkedPeers(HTML_3x2)
+    track(edA)
+    // prosemirror-tables registers tableEditingKey ("selectingCells") and runs fixTables in its
+    // appendTransaction; its presence confirms we exercise the same repair path as production.
+    expect(tableEditingKey.get(edA.state)).toBeTruthy()
+  })
+
+  it('two peers start byte-identical after fork', () => {
+    const { docA, edA, docB, edB } = forkedPeers(HTML_3x2)
+    track(edA, edB)
+    expect(xml(docA)).toBe(xml(docB))
+    expect(grid(edA)).toEqual(grid(edB))
+  })
+
+  // BASELINE INVARIANT — the healthy path the acceptance criteria pin down: a reorder on one peer
+  // and a concurrent row insert on the other must converge with no lost content on either side.
+  it('row reorder ⟂ concurrent insert-row-above → peers converge, nothing lost', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(HTML_3x2)
+    track(edA, edB)
+
+    // Peer A: drag row 2 to the top (whole-table tr.replaceWith).
+    selectCell(edA, 2, 0)
+    moveTableRow({ from: 2, to: 0 })(edA.state, edA.view.dispatch)
+    // Peer B (concurrent): insert a row above the first row.
+    selectCell(edB, 0, 0)
+    addRowBefore(edB.state, edB.view.dispatch)
+
+    mergeConcurrent(docA, docB, base)
+
+    // CRDT convergence: both peers reach the same Y state.
+    expect(xml(docA)).toBe(xml(docB))
+    expect(grid(edA)).toEqual(grid(edB))
+    // No content loss: the reorder result and the inserted row both survive the merge.
+    const merged = grid(edA)
+    const texts = merged.flat()
+    for (const cell of ['r1c1', 'r2c1', 'r3c1', 'r1c2', 'r2c2', 'r3c2']) {
+      expect(texts).toContain(cell)
+    }
+    // The moved row (r3) sits above the rows that were below it pre-move.
+    expect(merged.map((row) => row[0]).filter((t) => t.startsWith('r'))).toEqual([
+      'r3c1',
+      'r1c1',
+      'r2c1',
+    ])
+    // A brand-new empty row was inserted (one blank leading cell).
+    expect(texts.filter((t) => t === '').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('column reorder ⟂ concurrent insert-row-above → peers converge, nothing lost', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(HTML_3x2)
+    track(edA, edB)
+
+    selectCell(edA, 0, 1)
+    moveTableColumn({ from: 1, to: 0 })(edA.state, edA.view.dispatch)
+    selectCell(edB, 0, 0)
+    addRowBefore(edB.state, edB.view.dispatch)
+
+    mergeConcurrent(docA, docB, base)
+
+    expect(xml(docA)).toBe(xml(docB))
+    expect(grid(edA)).toEqual(grid(edB))
+    for (const cell of ['r1c1', 'r2c1', 'r3c1', 'r1c2', 'r2c2', 'r3c2']) {
+      expect(grid(edA).flat()).toContain(cell)
+    }
+  })
+
+  // CHARACTERIZATION — documents the real hazard of the coarse whole-table replace. Two concurrent
+  // reorders (each a whole-table tr.replaceWith) DO converge, but y-prosemirror re-diffs each
+  // replace against the base and maps cell text to different target cells, so the concurrent
+  // character edits interleave and cell content is GARBLED. This is convergent-but-corrupt, and it
+  // is the behaviour the chosen fix must eliminate. When a fix lands, tighten this test.
+  it('CHARACTERIZATION: two concurrent reorders converge but corrupt cell content', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(HTML_3x3)
+    track(edA, edB)
+
+    // Peer A moves row 2 to top; peer B moves row 0 to bottom — both whole-table replaces.
+    selectCell(edA, 2, 0)
+    moveTableRow({ from: 2, to: 0 })(edA.state, edA.view.dispatch)
+    selectCell(edB, 0, 0)
+    moveTableRow({ from: 0, to: 2 })(edB.state, edB.view.dispatch)
+
+    mergeConcurrent(docA, docB, base)
+
+    // Still converges (CRDT invariant holds even here)…
+    expect(xml(docA)).toBe(xml(docB))
+    // …but the content is corrupted: the clean, per-row cell labels no longer survive intact.
+    const texts = new Set(grid(edA).flat())
+    const anyPristineRowLabel = ['r1c1', 'r2c1', 'r3c1'].some((t) => texts.has(t))
+    expect(anyPristineRowLabel).toBe(false) // documents today's garbling; a fix should flip this
+  })
+})

--- a/packages/docs/src/editor/TableReorderConcurrency.test.ts
+++ b/packages/docs/src/editor/TableReorderConcurrency.test.ts
@@ -36,7 +36,8 @@ import {
   tableEditingKey,
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
-import { tableStructureSignature, signatureOfTable, countTableSignature, tableSignatures, draggedTableIndex, draggedTableConflict } from './TableReorderHandle.ts'
+import { tableStructureSignature, signatureOfTable, countTableSignature, tableSignatures, draggedTableIndex, draggedTableConflict, analyzeDraggedTableConflict, resolveDragSourceByOrdinal, resolveDragSource } from './TableReorderHandle.ts'
+import type { Transaction } from '@tiptap/pm/state'
 
 // Same collab field name the editor wires in production (schema/index.ts COLLAB_FIELD).
 const FIELD = 'default'
@@ -604,5 +605,160 @@ describe('table reorder — plan B guard: single table, edits outside must not a
     mergeConcurrent(docA, docB, base)
 
     expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(true)
+  })
+})
+
+// octo-docs-backend#76 XIN-1225 — the runtime rework. Real-browser instrumentation
+// (window.__reorderAbortDebug, dev/run-reorder.mjs) showed WHY the signature-by-ordinal guard kept
+// passing these jsdom tests yet TC01 (prose edit outside) / TC02 (identical second table) still failed
+// on a real machine: y-tiptap applies a remote edit on the local peer as ONE COARSE ReplaceStep over
+// (nearly) the whole document. That (a) makes any "does a step's RANGE overlap the table" test useless
+// (the step covers everything) and (b) collapses the remapped drag cell/table anchor, so the DROP
+// silently no-op'd even when the guard allowed the reorder — the real "reorder didn't happen" defect.
+// These tests drive the two functions that fix it through the REAL transaction y-prosemirror produces
+// on the merge (not a hand-built signature): `analyzeDraggedTableConflict` (guard, ordinal-anchored)
+// and `resolveDragSourceByOrdinal` (drop, ordinal-anchored).
+describe('table reorder — XIN-1225 real coarse-transaction guard + drop anchor (#76)', () => {
+  const TABLE_WITH_PROSE =
+    '<p>heading</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+    '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+    '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>trailing paragraph</p>'
+
+  const TWO_TABLES =
+    '<table><tbody>' +
+    '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+    '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+    '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>between</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+    '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+    '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+    '</tbody></table>'
+
+  /** Position just before the nth table in document order. */
+  function tablePosByOrdinal(doc: PMNode, ordinal: number): number {
+    let seen = 0
+    let pos = -1
+    doc.descendants((node, p) => {
+      if (node.type.name === 'table') {
+        if (seen === ordinal) pos = p
+        seen++
+        return false
+      }
+      return true
+    })
+    return pos
+  }
+
+  /** Apply peer B's concurrent diff into A and return the REAL doc-changing transactions y-prosemirror
+   *  produces on A (the ones the plugin's state.apply guard would see mid-drag). */
+  function captureMergeTransactions(edA: Editor, docA: Y.Doc, docB: Y.Doc, base: Uint8Array): Transaction[] {
+    const trs: Transaction[] = []
+    const on = ({ transaction }: { transaction: Transaction }) => {
+      if (transaction.docChanged) trs.push(transaction)
+    }
+    edA.on('transaction', on)
+    Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB, base))
+    edA.off('transaction', on)
+    return trs
+  }
+
+  it('TC01: remote prose edit outside → NO transaction flags a conflict (guard stays clear)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    const cellPos = cellPosOf(edA, 2, 0)
+    const dragOrdinal = draggedTableIndex(edA.state.doc, cellPos) // table #0
+    const baselineSigs = tableSignatures(edA.state.doc)
+
+    edB.view.dispatch(edB.state.tr.insertText(' edited', 8)) // prose inside the leading paragraph
+    const trs = captureMergeTransactions(edA, docA, docB, base)
+
+    expect(trs.length).toBeGreaterThan(0)
+    for (const tr of trs) {
+      const oldPos = tablePosByOrdinal(tr.before, dragOrdinal)
+      const decision = analyzeDraggedTableConflict(tr, tr.before, tr.doc, oldPos, dragOrdinal, baselineSigs)
+      expect(decision.conflict).toBe(false)
+    }
+  })
+
+  it('TC02: remote edit of an identical SECOND table → NO transaction flags a conflict', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
+    track(edA, edB)
+    const cellPos = cellPosOf(edA, 2, 0)
+    const dragOrdinal = draggedTableIndex(edA.state.doc, cellPos) // dragging table #0
+    expect(dragOrdinal).toBe(0)
+    const baselineSigs = tableSignatures(edA.state.doc)
+
+    // Edit a cell of the SECOND identical table.
+    let secondPos = -1
+    let seen = 0
+    edB.state.doc.descendants((node, p) => {
+      if (node.type.name === 'table') {
+        if (seen === 1) secondPos = p
+        seen++
+        return false
+      }
+      return true
+    })
+    const m1 = TableMap.get(edB.state.doc.nodeAt(secondPos)!)
+    edB.view.dispatch(edB.state.tr.insertText('X', secondPos + 1 + m1.map[0] + 1))
+    const trs = captureMergeTransactions(edA, docA, docB, base)
+
+    expect(trs.length).toBeGreaterThan(0)
+    for (const tr of trs) {
+      const oldPos = tablePosByOrdinal(tr.before, dragOrdinal)
+      const decision = analyzeDraggedTableConflict(tr, tr.before, tr.doc, oldPos, dragOrdinal, baselineSigs)
+      expect(decision.conflict).toBe(false)
+    }
+  })
+
+  it('TC03: remote reorder of the SAME dragged table → a transaction flags a conflict (data-safety)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    const cellPos = cellPosOf(edA, 2, 0)
+    const dragOrdinal = draggedTableIndex(edA.state.doc, cellPos)
+    const baselineSigs = tableSignatures(edA.state.doc)
+
+    selectCell(edB, 0, 0)
+    addRowBefore(edB.state, edB.view.dispatch) // structural change to the dragged table
+    const trs = captureMergeTransactions(edA, docA, docB, base)
+
+    const anyConflict = trs.some((tr) => {
+      const oldPos = tablePosByOrdinal(tr.before, dragOrdinal)
+      return analyzeDraggedTableConflict(tr, tr.before, tr.doc, oldPos, dragOrdinal, baselineSigs).conflict
+    })
+    expect(anyConflict).toBe(true)
+  })
+
+  it('drop anchor: after the merge the dragged source resolves by ORDINAL', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    let cellPos = cellPosOf(edA, 2, 0) // row 3 of table #0
+    const dragOrdinal = draggedTableIndex(edA.state.doc, cellPos)
+
+    // Peer B edits prose outside; remap the drag anchor through the real merge transactions exactly as
+    // the plugin used to — this is the coarse ReplaceStep that collapsed the anchor at runtime.
+    edB.view.dispatch(edB.state.tr.insertText(' edited', 8))
+    const on = ({ transaction }: { transaction: Transaction }) => {
+      if (transaction.docChanged) cellPos = transaction.mapping.map(cellPos)
+    }
+    edA.on('transaction', on)
+    Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB, base))
+    edA.off('transaction', on)
+
+    // The ordinal-anchored resolver still finds the dragged source row (index 2) — this is what makes the
+    // drop complete instead of silently no-op'ing on a collapsed anchor.
+    const src = resolveDragSourceByOrdinal(edA.state.doc, dragOrdinal, 'row', 2)
+    expect(src).not.toBeNull()
+    expect(src!.rect.top).toBe(2)
+    // The position-based resolver is the fragile path we moved off of (may return null under a coarse
+    // ReplaceStep). Referenced only to document the contrast; the drop no longer depends on it.
+    void resolveDragSource(edA.state.doc, cellPos)
   })
 })

--- a/packages/docs/src/editor/TableReorderConcurrency.test.ts
+++ b/packages/docs/src/editor/TableReorderConcurrency.test.ts
@@ -36,7 +36,7 @@ import {
   tableEditingKey,
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
-import { tableStructureSignature, signatureOfTable, countTableSignature, draggedTableConflict } from './TableReorderHandle.ts'
+import { tableStructureSignature, signatureOfTable, countTableSignature, tableSignatures, draggedTableIndex, draggedTableConflict } from './TableReorderHandle.ts'
 
 // Same collab field name the editor wires in production (schema/index.ts COLLAB_FIELD).
 const FIELD = 'default'
@@ -344,14 +344,19 @@ describe('table reorder — plan B conflict-abort guard eliminates silent corrup
   })
 })
 
-// octo-docs-backend#76 FAIL-2 (XIN-1206): the plan-B guard must fire ONLY for a concurrent change to
-// the DRAGGED table. The original guard re-fingerprinted a single remapped `cellPos`; under real
-// collaboration y-prosemirror applies a remote update as one coarse ReplaceStep, so mapping that
-// anchor forward collapses it to the replace boundary — it stops resolving to a cell even when the
-// dragged table is untouched, and the old `signature === null → conflict` branch then FALSE-ABORTED
-// on edits to prose or to a different table (observed as: "editing text outside the table cancels my
-// reorder"). These tests exercise the exact dual-Y.Doc merge and drive conflict detection through the
-// position-independent `countTableSignature` / `draggedTableConflict` the guard now uses.
+// octo-docs-backend#76 FAIL-2 (XIN-1206 → XIN-1221): the plan-B guard must fire ONLY for a concurrent
+// change to the DRAGGED table. Two earlier scopings still false-aborted on edits OUTSIDE that table:
+//   (1) re-fingerprinting a single remapped `cellPos` — under real collaboration y-prosemirror applies
+//       a remote update as one coarse ReplaceStep, so mapping that interior anchor forward collapses it
+//       to the replace boundary; it stops resolving to a cell even when the dragged table is untouched,
+//       and the old `signature === null → conflict` branch then FALSE-ABORTED on prose / other-table
+//       edits ("editing text outside the table cancels my reorder").
+//   (2) counting how many tables still carry the drag-start signature — position-independent, but a
+//       document with two byte-identical tables makes the count ambiguous: editing the OTHER identical
+//       table drops the global count and the guard false-aborted, though the dragged table never moved.
+// The guard now pins the dragged table by a STABLE IDENTITY — its ORDINAL among tables plus the ordered
+// signature list (`tableSignatures` / `draggedTableIndex`) — and aborts only when the signature at that
+// ordinal changes. These tests drive that decision through the exact dual-Y.Doc merge.
 describe('table reorder — plan B guard scope: same-table only (#76 FAIL-2)', () => {
   const TWO_TABLES =
     '<p>lead</p>' +
@@ -382,14 +387,17 @@ describe('table reorder — plan B guard scope: same-table only (#76 FAIL-2)', (
     return pos + 1 + map.map[row * map.width + col] + 1 // inside the cell
   }
 
-  // Diagnostic: prove the anchor-drift that broke the OLD approach is real in this harness. After a
-  // remote edit merges, the dragged cell's remapped position no longer fingerprints the table.
+  // Diagnostic: prove the anchor-drift that broke the OLD position-based approach is real in this
+  // harness. After a remote edit merges, the dragged cell's remapped position no longer fingerprints
+  // the table — so the guard must NOT depend on that position.
   it('remapped cellPos drifts under a coarse remote ReplaceStep (root cause of the false abort)', () => {
     const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
     track(edA, edB)
     let cellPos = cellPosOf(edA, 0, 0) // dragging table #0
-    const baseline = tableStructureSignature(edA.state.doc, cellPos)
-    expect(baseline).not.toBeNull()
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPos)
+    expect(dragIndex).toBe(0)
+    expect(baselineSigs[dragIndex]).not.toBeNull()
 
     const onTr = ({ transaction }: { transaction: { docChanged: boolean; mapping: { map(p: number): number } } }) => {
       if (transaction.docChanged) cellPos = transaction.mapping.map(cellPos)
@@ -400,50 +408,48 @@ describe('table reorder — plan B guard scope: same-table only (#76 FAIL-2)', (
     mergeConcurrent(docA, docB, base)
     edA.off('transaction', onTr)
 
-    // OLD behaviour: the remapped anchor's signature is now null → old guard would abort. This is the
-    // FAIL-2 false positive we are eliminating.
+    // The remapped anchor's signature is now null (position collapsed) — an approach that trusted it
+    // would abort. This is the FAIL-2 false positive we are eliminating.
     expect(tableStructureSignature(edA.state.doc, cellPos)).toBeNull()
-    // NEW behaviour: the dragged table's signature is still present in the doc → no conflict.
-    const baselineCount = countTableSignature(edA.state.doc, baseline!) // recount post-merge
-    expect(baselineCount).toBeGreaterThanOrEqual(1)
-    expect(draggedTableConflict(edA.state.doc, baseline, baselineCount)).toBe(false)
+    // Identity approach: the dragged table's ordinal slot is unchanged → no conflict.
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
   })
 
   it('reorder ⟂ remote edit of a DIFFERENT table → guard stays clear (no false abort)', () => {
     const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
     track(edA, edB)
-    const baselineSig = signatureOfTable(nthTable(edA, 0).node) // dragging table #0
-    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
-    expect(baselineSig).not.toBeNull()
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 0, 0)) // dragging table #0
+    expect(dragIndex).toBe(0)
 
     // Peer B edits the OTHER table's cell text.
     const insideB = cellInsideOf(edB, 1, 0, 0)
     edB.view.dispatch(edB.state.tr.insertText('CHANGED', insideB))
     mergeConcurrent(docA, docB, base)
 
-    // Dragged table #0 unchanged → its signature still present → reorder allowed.
-    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(false)
+    // Dragged table #0 unchanged → its ordinal slot still matches → reorder allowed.
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
     expect(xml(docA)).toBe(xml(docB))
   })
 
   it('reorder ⟂ remote edit of prose OUTSIDE any table → guard stays clear', () => {
     const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
     track(edA, edB)
-    const baselineSig = signatureOfTable(nthTable(edA, 0).node)
-    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 0, 0))
 
     edB.view.dispatch(edB.state.tr.insertText('hello', 2)) // prose before the tables
     mergeConcurrent(docA, docB, base)
 
-    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(false)
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
     expect(xml(docA)).toBe(xml(docB))
   })
 
   it('reorder ⟂ remote structural change to the DRAGGED table → guard fires (data-safety kept)', () => {
     const { docA, edA, docB, edB, base } = forkedPeers(TWO_TABLES)
     track(edA, edB)
-    const baselineSig = signatureOfTable(nthTable(edA, 0).node) // dragging table #0
-    const baselineCount = countTableSignature(edA.state.doc, baselineSig!)
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 0, 0)) // dragging table #0
 
     // Peer B reorders the SAME table #0 (row swap).
     const { pos } = nthTable(edB, 0)
@@ -453,7 +459,150 @@ describe('table reorder — plan B guard scope: same-table only (#76 FAIL-2)', (
     moveTableRow({ from: 1, to: 0 })(edB.state, edB.view.dispatch)
     mergeConcurrent(docA, docB, base)
 
-    // The drag-start signature no longer matches any table → conflict → local reorder aborts.
-    expect(draggedTableConflict(edA.state.doc, baselineSig, baselineCount)).toBe(true)
+    // The dragged table's ordinal slot changed → conflict → local reorder aborts.
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(true)
+  })
+})
+
+// octo-docs-backend#76 FAIL-2 continuation (XIN-1221): the specific regression the old global-count
+// heuristic could not handle. When the document holds two BYTE-IDENTICAL tables, editing the table the
+// user is NOT dragging must not cancel the drag — yet counting drag-start signatures dropped the global
+// count (2 → 1) and false-aborted. The stable-identity guard distinguishes the twins by ordinal, so an
+// edit to the sibling leaves the dragged table's slot untouched, while a change to the dragged twin
+// itself still aborts (data-safety guard preserved even against an identical sibling).
+describe('table reorder — plan B guard: identical-twin tables (#76 FAIL-2, XIN-1221)', () => {
+  // Two tables with byte-identical content — the case the old count heuristic could not disambiguate.
+  const TWIN_TABLES =
+    '<table><tbody>' +
+    '<tr><td><p>x1</p></td></tr>' +
+    '<tr><td><p>x2</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>between</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>x1</p></td></tr>' +
+    '<tr><td><p>x2</p></td></tr>' +
+    '</tbody></table>'
+
+  function nthTwin(editor: Editor, n: number): { node: PMNode; pos: number } {
+    const found: { node: PMNode; pos: number }[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'table') {
+        found.push({ node, pos })
+        return false
+      }
+      return true
+    })
+    if (!found[n]) throw new Error(`no table #${n}`)
+    return found[n]
+  }
+
+  it('twins share one signature — the count heuristic is ambiguous, identity is not', () => {
+    const { edA } = forkedPeers(TWIN_TABLES)
+    track(edA)
+    const s0 = signatureOfTable(nthTwin(edA, 0).node)
+    const s1 = signatureOfTable(nthTwin(edA, 1).node)
+    expect(s0).toBe(s1) // byte-identical tables → identical signatures
+    expect(countTableSignature(edA.state.doc, s0!)).toBe(2) // global count cannot tell them apart
+    // Identity: two distinct ordinals carry that same signature.
+    expect(tableSignatures(edA.state.doc)).toEqual([s0, s1])
+    expect(draggedTableIndex(edA.state.doc, nthTwin(edA, 0).pos + 1)).toBe(0)
+    expect(draggedTableIndex(edA.state.doc, nthTwin(edA, 1).pos + 1)).toBe(1)
+  })
+
+  it('reorder ⟂ remote edit of the OTHER identical twin → guard stays clear (no false abort)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWIN_TABLES)
+    track(edA, edB)
+    // A drags twin #0.
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, nthTwin(edA, 0).pos + 1)
+    expect(dragIndex).toBe(0)
+
+    // Peer B edits the OTHER twin's (#1) cell text — this dropped the global signature count 2→1 and
+    // false-aborted under the old heuristic.
+    const t1 = nthTwin(edB, 1)
+    const m1 = TableMap.get(t1.node)
+    const insideB = t1.pos + 1 + m1.map[0] + 1
+    edB.view.dispatch(edB.state.tr.insertText('EDIT', insideB))
+    mergeConcurrent(docA, docB, base)
+
+    // Dragged twin #0 is untouched → its ordinal slot still matches → NO abort.
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
+    expect(xml(docA)).toBe(xml(docB))
+  })
+
+  it('reorder ⟂ remote structural change to the DRAGGED twin → guard still fires (data-safety kept)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TWIN_TABLES)
+    track(edA, edB)
+    // A drags twin #0.
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, nthTwin(edA, 0).pos + 1)
+
+    // Peer B reorders the SAME twin #0 (swap its two rows) — even though an identical sibling exists,
+    // the dragged twin's own slot must change and abort.
+    const { pos } = nthTwin(edB, 0)
+    const mapB = TableMap.get(nthTwin(edB, 0).node)
+    const $inB = edB.state.doc.resolve(pos + 1 + mapB.map[1 * mapB.width + 0] + 1)
+    edB.view.dispatch(edB.state.tr.setSelection(TextSelection.near($inB)))
+    moveTableRow({ from: 1, to: 0 })(edB.state, edB.view.dispatch)
+    mergeConcurrent(docA, docB, base)
+
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(true)
+  })
+})
+
+// octo-docs-backend#76 XIN-1220/1221 — the exact browser-repro scenario, at the unit level: a SINGLE
+// table with prose around it, one peer holding a row drag while the other edits body text OUTSIDE the
+// table. The guard must stay clear so the reorder completes; only a change to the table itself aborts.
+// This is the "表外正文编辑不误触中止" regression pinned so it cannot come back.
+describe('table reorder — plan B guard: single table, edits outside must not abort (#76 XIN-1220)', () => {
+  const TABLE_WITH_PROSE =
+    '<p>heading</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+    '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+    '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>trailing paragraph</p>'
+
+  // Mirror the runtime beginDrag capture exactly: snapshot the ordered table signatures and the
+  // dragged table's ordinal from the drag-start cell position.
+  it('remote edit of prose BEFORE the table → guard stays clear, reorder allowed', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 2, 0)) // dragging row 3
+    expect(dragIndex).toBe(0)
+
+    edB.view.dispatch(edB.state.tr.insertText(' edited', 8)) // inside the leading paragraph
+    mergeConcurrent(docA, docB, base)
+
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
+    expect(xml(docA)).toBe(xml(docB))
+  })
+
+  it('remote edit of prose AFTER the table → guard stays clear, reorder allowed', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 2, 0))
+
+    edB.view.dispatch(edB.state.tr.insertText('X', edB.state.doc.content.size - 2)) // trailing paragraph
+    mergeConcurrent(docA, docB, base)
+
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(false)
+    expect(xml(docA)).toBe(xml(docB))
+  })
+
+  it('remote structural change to the single table → guard still fires (data-safety kept)', () => {
+    const { docA, edA, docB, edB, base } = forkedPeers(TABLE_WITH_PROSE)
+    track(edA, edB)
+    const baselineSigs = tableSignatures(edA.state.doc)
+    const dragIndex = draggedTableIndex(edA.state.doc, cellPosOf(edA, 2, 0))
+
+    selectCell(edB, 0, 0)
+    addRowBefore(edB.state, edB.view.dispatch) // changes the dragged table's row count
+    mergeConcurrent(docA, docB, base)
+
+    expect(draggedTableConflict(edA.state.doc, baselineSigs, dragIndex)).toBe(true)
   })
 })

--- a/packages/docs/src/editor/TableReorderHandle.test.ts
+++ b/packages/docs/src/editor/TableReorderHandle.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
 import type { Transaction } from '@tiptap/pm/state'
-import { TableReorderHandle, tableReorderPluginKey, resolveDragSource } from './TableReorderHandle.ts'
+import { TableReorderHandle, tableReorderPluginKey, resolveDragSource, tableStructureSignature } from './TableReorderHandle.ts'
 
 // octo-docs-backend#76: table row/column reorder. The drag handle UI is DOM/pointer-driven and
 // needs real layout (jsdom reports zero rects), so these tests exercise the reorder MOVE that a
@@ -400,5 +400,122 @@ describe('concurrent reorder remapping (collaboration correctness)', () => {
     const mapped = remoteTr.mapping.map(cellPos)
     editor.view.dispatch(remoteTr)
     expect(resolveDragSource(editor.state.doc, mapped)).toBeNull()
+  })
+})
+
+// octo-docs-backend#76 / XIN-1187 (plan B —老板拍板 B): serialize-or-abort guard. The reorder
+// command rebuilds the whole table with a coarse `tr.replaceWith`; two such replaces that land
+// concurrently converge in the CRDT but interleave cell text (silent corruption — see
+// TableReorderConcurrency.test.ts). Plan B snapshots the dragged table's structure at drag start
+// (`tableStructureSignature`) and, in the plugin `state.apply`, re-fingerprints it against every
+// transaction that arrives mid-drag; if the fingerprint diverges the drop is aborted instead of
+// committing the replace. These tests pin the detection primitive and drive it through the exact
+// `tr.mapping` flow `state.apply` uses in production (a captured remote transaction, replayed).
+describe('plan-B concurrency guard — table structure signature', () => {
+  const HTML_3x2 =
+    '<table><tbody>' +
+    '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+    '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+    '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+    '</tbody></table>'
+
+  it('is stable for an unchanged table (no false conflict)', () => {
+    editor = makeEditor(HTML_3x2)
+    const cellPos = cellPosOf(editor, 2, 0)
+    const a = tableStructureSignature(editor.state.doc, cellPos)
+    const b = tableStructureSignature(editor.state.doc, cellPos)
+    expect(a).not.toBeNull()
+    expect(a).toBe(b)
+  })
+
+  it('detects a concurrent REMOTE reorder of the dragged table (same dimensions)', () => {
+    editor = makeEditor(HTML_3x2)
+    // Drag starts on row 2; capture the baseline exactly like beginDrag.
+    let cellPos = cellPosOf(editor, 2, 0)
+    const baseline = tableStructureSignature(editor.state.doc, cellPos)
+
+    // A remote peer reorders the SAME table (row 0 → bottom). Capture as a transaction and remap the
+    // drag anchor through it, mirroring the plugin state.apply.
+    selectCell(editor, 0, 0)
+    const remoteTr = captureTr(editor, moveTableRow({ from: 0, to: 2 }))
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    // Row/col counts are unchanged, so a dimension-only check would miss this. A whole-table
+    // replace collapses the remapped anchor to the replace boundary (signature null) OR the
+    // text-in-order fingerprint diverges — either way matches the guard's `current === null ||
+    // current !== baseline` test, so it latches a conflict and the drop aborts.
+    const after = tableStructureSignature(editor.state.doc, cellPos)
+    expect(after === null || after !== baseline).toBe(true)
+  })
+
+  it('detects a concurrent remote row insert into the dragged table', () => {
+    editor = makeEditor(HTML_3x2)
+    let cellPos = cellPosOf(editor, 2, 0)
+    const baseline = tableStructureSignature(editor.state.doc, cellPos)
+
+    selectCell(editor, 0, 0)
+    const remoteTr = captureTr(editor, addRowBefore)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    expect(tableStructureSignature(editor.state.doc, cellPos)).not.toBe(baseline)
+  })
+
+  it('detects a concurrent remote column insert into the dragged table', () => {
+    editor = makeEditor(HTML_3x2)
+    let cellPos = cellPosOf(editor, 2, 0)
+    const baseline = tableStructureSignature(editor.state.doc, cellPos)
+
+    selectCell(editor, 0, 0)
+    const remoteTr = captureTr(editor, addColumnBefore)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    expect(tableStructureSignature(editor.state.doc, cellPos)).not.toBe(baseline)
+  })
+
+  it('treats a deleted source table as a conflict (signature null)', () => {
+    editor = makeEditor(HTML_3x2)
+    const cellPos = cellPosOf(editor, 2, 0)
+    expect(tableStructureSignature(editor.state.doc, cellPos)).not.toBeNull()
+
+    const { doc } = editor.state
+    let tableStart = -1
+    let tableEnd = -1
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'table') {
+        tableStart = pos
+        tableEnd = pos + node.nodeSize
+        return false
+      }
+      return true
+    })
+    const remoteTr = editor.state.tr.delete(tableStart, tableEnd)
+    const mapped = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+    expect(tableStructureSignature(editor.state.doc, mapped)).toBeNull()
+  })
+
+  it('does NOT fire for a benign edit outside the dragged table (no false abort)', () => {
+    editor = makeEditor(
+      '<p>lead</p>' +
+        '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    let cellPos = cellPosOf(editor, 1, 0)
+    const baseline = tableStructureSignature(editor.state.doc, cellPos)
+
+    // A collaborator types into the leading paragraph (position 1), well before the table. This
+    // shifts every table position, so the anchor must be remapped — but the table itself is
+    // untouched, so the fingerprint stays equal and the reorder is allowed to proceed.
+    const remoteTr = editor.state.tr.insertText('xyz', 1)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    const after = tableStructureSignature(editor.state.doc, cellPos)
+    expect(after).toBe(baseline)
   })
 })

--- a/packages/docs/src/editor/TableReorderHandle.test.ts
+++ b/packages/docs/src/editor/TableReorderHandle.test.ts
@@ -6,9 +6,17 @@ import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
 import { TextSelection } from '@tiptap/pm/state'
-import { TableMap, moveTableColumn, moveTableRow, cellAround } from '@tiptap/pm/tables'
+import {
+  TableMap,
+  moveTableColumn,
+  moveTableRow,
+  cellAround,
+  addRowBefore,
+  addColumnBefore,
+} from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
-import { TableReorderHandle, tableReorderPluginKey } from './TableReorderHandle.ts'
+import type { Transaction } from '@tiptap/pm/state'
+import { TableReorderHandle, tableReorderPluginKey, resolveDragSource } from './TableReorderHandle.ts'
 
 // octo-docs-backend#76: table row/column reorder. The drag handle UI is DOM/pointer-driven and
 // needs real layout (jsdom reports zero rects), so these tests exercise the reorder MOVE that a
@@ -74,8 +82,8 @@ function selectCell(editor: Editor, row: number, col: number): void {
     }
     return true
   })
-  const t = table as PMNode
-  const map = TableMap.get(t)
+  if (!table) throw new Error('no table')
+  const map = TableMap.get(table)
   const cellRel = map.map[row * map.width + col]
   const $inside = doc.resolve(tablePos + 1 + cellRel + 1)
   editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($inside)))
@@ -86,6 +94,38 @@ afterEach(() => {
   editor?.destroy()
   editor = null
 })
+
+/** Absolute document position just before the cell at grid (row,col) — the same anchor the drag
+ * captures as `cellPos` at drag start. */
+function cellPosOf(editor: Editor, row: number, col: number): number {
+  const { doc } = editor.state
+  let table: PMNode | null = null
+  let tablePos = -1
+  doc.descendants((node, pos) => {
+    if (!table && node.type.name === 'table') {
+      table = node
+      tablePos = pos
+      return false
+    }
+    return true
+  })
+  if (!table) throw new Error('no table')
+  const map = TableMap.get(table)
+  const cellRel = map.map[row * map.width + col]
+  return tablePos + 1 + cellRel
+}
+
+/** Capture (without applying) the transaction a prosemirror-tables command would dispatch, so a
+ * test can read its mapping — this is how a concurrent REMOTE edit's mapping reaches the drag
+ * anchor in production (via the plugin `state.apply`). */
+function captureTr(editor: Editor, command: (state: Editor['state'], dispatch: (tr: Transaction) => void) => boolean): Transaction {
+  let captured: Transaction | null = null
+  command(editor.state, (tr) => {
+    captured = tr
+  })
+  if (!captured) throw new Error('command produced no transaction')
+  return captured
+}
 
 describe('TableReorderHandle extension', () => {
   it('registers its ProseMirror plugin', () => {
@@ -188,5 +228,177 @@ describe('merged-cell safety', () => {
     // Command reports it did nothing; the grid is unchanged (merge preserved).
     expect(moved).toBe(false)
     expect(grid(editor)).toEqual(before)
+  })
+})
+
+// octo-docs-backend#76 review (Jerry-Xin, CHANGES_REQUESTED): the blocking collab correctness bug.
+// A drag captures its source row/column at drag start; during the drag a remote collaborator may
+// insert or delete rows/columns ABOVE the dragged one, remapping the document. The fix remaps the
+// drag's cell POSITION through each incoming transaction (plugin state.apply) and re-derives the
+// source INDEX from that remapped position at drop time via `resolveDragSource`, so the reorder
+// still moves the row/column the user grabbed — not whatever now sits at the stale drag-start index.
+describe('concurrent reorder remapping (collaboration correctness)', () => {
+  it('RED: the stale drag-start row index moves the WRONG row after a remote insert above', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    // Drag starts on row index 2 ("r3"). This is the value the OLD code stored and reused at drop.
+    const staleFromIndex = 2
+
+    // A remote peer inserts a blank row above the whole table (caret in row 0, addRowBefore).
+    selectCell(editor, 0, 0)
+    editor.view.dispatch(captureTr(editor, addRowBefore))
+    expect(grid(editor)).toEqual([
+      ['', ''],
+      ['r1c1', 'r1c2'],
+      ['r2c1', 'r2c2'],
+      ['r3c1', 'r3c2'],
+    ])
+
+    // Reordering with the stale index moves index 2 — now "r2", NOT the grabbed "r3". This is the
+    // reviewer's bug: the wrong row moves.
+    selectCell(editor, staleFromIndex, 0)
+    moveTableRow({ from: staleFromIndex, to: 0 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)[0]).toEqual(['r2c1', 'r2c2']) // wrong row bubbled to the top
+    expect(grid(editor)[0]).not.toEqual(['r3c1', 'r3c2'])
+  })
+
+  it('GREEN: remapping the drag source keeps the move on the original row under a remote insert', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    // Drag starts on row 2 ("r3"); capture its cell position, exactly like beginDrag.
+    let cellPos = cellPosOf(editor, 2, 0)
+    expect(resolveDragSource(editor.state.doc, cellPos)?.rect.top).toBe(2)
+
+    // Remote peer inserts a blank row above; remap the drag anchor through that transaction's
+    // mapping (the plugin state.apply does this in production).
+    selectCell(editor, 0, 0)
+    const remoteTr = captureTr(editor, addRowBefore)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    // The remapped anchor now resolves to grid row index 3 — the grabbed "r3" shifted down by one.
+    const source = resolveDragSource(editor.state.doc, cellPos)
+    expect(source?.rect.top).toBe(3)
+
+    // Move using the RE-DERIVED index → the original row moves, not the stale index's neighbour.
+    const fromIndex = source!.rect.top
+    selectCell(editor, fromIndex, 0)
+    moveTableRow({ from: fromIndex, to: 0 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+    expect(grid(editor)).toEqual([
+      ['r3c1', 'r3c2'],
+      ['', ''],
+      ['r1c1', 'r1c2'],
+      ['r2c1', 'r2c2'],
+    ])
+  })
+
+  it('GREEN: remapping the drag source survives a remote row DELETE above', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    // Drag starts on row 2 ("r3").
+    let cellPos = cellPosOf(editor, 2, 0)
+    expect(resolveDragSource(editor.state.doc, cellPos)?.rect.top).toBe(2)
+
+    // Remote peer deletes row 0 ("r1"). Build the delete as a transaction and remap through it.
+    const { doc } = editor.state
+    let firstRowStart = -1
+    let firstRowEnd = -1
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'tableRow' && firstRowStart < 0) {
+        firstRowStart = pos
+        firstRowEnd = pos + node.nodeSize
+        return false
+      }
+      return true
+    })
+    const remoteTr = editor.state.tr.delete(firstRowStart, firstRowEnd)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+    expect(grid(editor)).toEqual([
+      ['r2c1', 'r2c2'],
+      ['r3c1', 'r3c2'],
+    ])
+
+    // "r3" is now at index 1; the remapped anchor tracks it.
+    const source = resolveDragSource(editor.state.doc, cellPos)
+    expect(source?.rect.top).toBe(1)
+
+    const fromIndex = source!.rect.top
+    selectCell(editor, fromIndex, 0)
+    moveTableRow({ from: fromIndex, to: 0 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)).toEqual([
+      ['r3c1', 'r3c2'],
+      ['r2c1', 'r2c2'],
+    ])
+  })
+
+  it('GREEN: remaps the drag source across a concurrent column insert to the left', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>a1</p></td><td><p>b1</p></td><td><p>c1</p></td></tr>' +
+        '<tr><td><p>a2</p></td><td><p>b2</p></td><td><p>c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    // Drag starts on column 2 ("c").
+    let cellPos = cellPosOf(editor, 0, 2)
+    expect(resolveDragSource(editor.state.doc, cellPos)?.rect.left).toBe(2)
+
+    // Remote peer inserts a column to the left of column 0.
+    selectCell(editor, 0, 0)
+    const remoteTr = captureTr(editor, addColumnBefore)
+    cellPos = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+
+    // The grabbed column "c" shifted from index 2 to index 3.
+    const source = resolveDragSource(editor.state.doc, cellPos)
+    expect(source?.rect.left).toBe(3)
+
+    const fromIndex = source!.rect.left
+    selectCell(editor, 0, fromIndex)
+    moveTableColumn({ from: fromIndex, to: 0 })(editor.state, editor.view.dispatch)
+    // Column "c" lands first; the freshly inserted blank column and the rest follow.
+    expect(grid(editor)[0]).toEqual(['c1', '', 'a1', 'b1'])
+  })
+
+  it('a drop whose source cell was deleted by a collaborator resolves to null (safe no-op)', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    const cellPos = cellPosOf(editor, 1, 0)
+    // Remote peer deletes the whole table — the source can no longer resolve.
+    const { doc } = editor.state
+    let tableStart = -1
+    let tableEnd = -1
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'table') {
+        tableStart = pos
+        tableEnd = pos + node.nodeSize
+        return false
+      }
+      return true
+    })
+    const remoteTr = editor.state.tr.delete(tableStart, tableEnd)
+    const mapped = remoteTr.mapping.map(cellPos)
+    editor.view.dispatch(remoteTr)
+    expect(resolveDragSource(editor.state.doc, mapped)).toBeNull()
   })
 })

--- a/packages/docs/src/editor/TableReorderHandle.test.ts
+++ b/packages/docs/src/editor/TableReorderHandle.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
 import type { Transaction } from '@tiptap/pm/state'
-import { TableReorderHandle, tableReorderPluginKey, resolveDragSource, tableStructureSignature, signatureOfTable, countTableSignature, draggedTableConflict } from './TableReorderHandle.ts'
+import { TableReorderHandle, tableReorderPluginKey, resolveDragSource, tableStructureSignature, signatureOfTable, countTableSignature, tableSignatures, draggedTableIndex, draggedTableConflict } from './TableReorderHandle.ts'
 
 // octo-docs-backend#76: table row/column reorder. The drag handle UI is DOM/pointer-driven and
 // needs real layout (jsdom reports zero rects), so these tests exercise the reorder MOVE that a
@@ -520,14 +520,15 @@ describe('plan-B concurrency guard — table structure signature', () => {
   })
 })
 
-// octo-docs-backend#76 FAIL-2 (XIN-1206): the plan-B guard's scope was too wide — it re-fingerprinted
-// the dragged table via a single remapped `cellPos`, so an edit ELSEWHERE in the doc false-aborted
-// the reorder. Under real collaboration y-prosemirror applies a remote update as one coarse
-// ReplaceStep, which collapses the remapped `cellPos` to a boundary (it stops resolving to a cell)
-// even when the dragged table is untouched — the old `signature === null → conflict` branch then
-// fired on prose / other-table edits. The fix keys conflict detection off the dragged table's
-// structure signature and how many tables carry it (`countTableSignature` / `draggedTableConflict`),
-// which is position-independent, so only a change to the DRAGGED table drops the count.
+// octo-docs-backend#76 FAIL-2 (XIN-1206 → XIN-1221): the plan-B guard's scope was too wide. Two
+// scopings still false-aborted on edits ELSEWHERE in the doc: (1) re-fingerprinting a single remapped
+// `cellPos` — a coarse remote ReplaceStep collapses it to a boundary so it stops resolving to a cell
+// even when the dragged table is untouched, firing the old `signature === null → conflict` branch on
+// prose / other-table edits; (2) counting how many tables carry the drag-start signature — a document
+// with two byte-identical tables makes the count ambiguous, so editing the OTHER twin dropped it and
+// false-aborted. The guard now keys off a STABLE IDENTITY: the dragged table's ordinal among tables
+// plus the ordered signature list (`tableSignatures` / `draggedTableIndex` / `draggedTableConflict`),
+// so only a change to the DRAGGED table's own ordinal slot aborts.
 describe('plan-B guard scope — same-table only (FAIL-2)', () => {
   const TWO_TABLES =
     '<table><tbody>' +
@@ -574,76 +575,110 @@ describe('plan-B guard scope — same-table only (FAIL-2)', () => {
     expect(signatureOfTable(para as unknown as PMNode)).toBeNull()
   })
 
-  it('countTableSignature counts only tables that carry the signature', () => {
+  it('tableSignatures lists every table in document order; draggedTableIndex pins one by ordinal', () => {
     editor = makeEditor(TWO_TABLES)
     const sigA = signatureOfTable(nthTable(editor, 0).node)!
     const sigB = signatureOfTable(nthTable(editor, 1).node)!
     expect(sigA).not.toBe(sigB)
+    expect(tableSignatures(editor.state.doc)).toEqual([sigA, sigB])
+    expect(draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0))).toBe(0)
+    expect(draggedTableIndex(editor.state.doc, cellPosInTable(editor, 1, 0, 0))).toBe(1)
+    // An out-of-range position has no table ordinal.
+    expect(draggedTableIndex(editor.state.doc, -5)).toBe(-1)
+    expect(draggedTableIndex(editor.state.doc, editor.state.doc.content.size + 10)).toBe(-1)
+  })
+
+  it('countTableSignature still counts tables carrying a signature (position-independent primitive)', () => {
+    editor = makeEditor(TWO_TABLES)
+    const sigA = signatureOfTable(nthTable(editor, 0).node)!
+    const sigB = signatureOfTable(nthTable(editor, 1).node)!
     expect(countTableSignature(editor.state.doc, sigA)).toBe(1)
     expect(countTableSignature(editor.state.doc, sigB)).toBe(1)
     expect(countTableSignature(editor.state.doc, 'nonexistent')).toBe(0)
   })
 
-  it('two identical tables → count is 2, and a change to one drops it to 1 (conflict)', () => {
+  it('two identical tables → editing the OTHER twin does NOT abort, editing the dragged one does', () => {
     editor = makeEditor(
       '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>' +
         '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>',
     )
     const sig = signatureOfTable(nthTable(editor, 0).node)!
-    expect(countTableSignature(editor.state.doc, sig)).toBe(2)
-    // Dragging one of the twins: baseline count 2. A reorder of the FIRST table (columns swap)
-    // drops the count of the drag-start signature to 1 → the guard still detects the same-table race
-    // even when an identical twin exists elsewhere.
-    selectCell(editor, 0, 0)
+    expect(countTableSignature(editor.state.doc, sig)).toBe(2) // count cannot tell the twins apart
+
+    // Drag twin #0: capture its stable identity BEFORE any edit.
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0))
+    expect(dragIndex).toBe(0)
+
+    // A reorder of the OTHER twin (#1, columns swap) leaves the dragged twin's slot untouched → the
+    // old global-count heuristic false-aborted here (2 → 1); the identity guard does not.
+    selectCell2(editor, 1, 0, 0)
     moveTableColumn({ from: 0, to: 1 })(editor.state, editor.view.dispatch)
-    expect(draggedTableConflict(editor.state.doc, sig, 2)).toBe(true)
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(false)
+  })
+
+  it('two identical tables → a reorder of the DRAGGED twin still aborts (data-safety kept)', () => {
+    editor = makeEditor(
+      '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>' +
+        '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>',
+    )
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0)) // twin #0
+
+    // Reorder the DRAGGED twin (#0): columns swap. Its own ordinal slot changes → conflict, even
+    // though an identical sibling exists.
+    selectCell2(editor, 0, 0, 0)
+    moveTableColumn({ from: 0, to: 1 })(editor.state, editor.view.dispatch)
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(true)
   })
 
   it('does NOT flag a conflict when a DIFFERENT table is edited (FAIL-2 false-abort gone)', () => {
     editor = makeEditor(TWO_TABLES)
-    const baselineSig = signatureOfTable(nthTable(editor, 0).node)! // dragging table #0
-    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0)) // dragging table #0
 
     // Edit a cell in the OTHER table (#1) — a same-doc structural/content change, but not to the
     // dragged table.
     selectCell2(editor, 1, 0, 0)
     editor.view.dispatch(editor.state.tr.insertText('CHANGED'))
 
-    // The dragged table's signature is still present exactly once → no conflict, reorder allowed.
-    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(false)
+    // The dragged table's ordinal slot is unchanged → no conflict, reorder allowed.
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(false)
   })
 
   it('does NOT flag a conflict when prose OUTSIDE any table is edited', () => {
     editor = makeEditor('<p>lead</p>' + TWO_TABLES)
-    const baselineSig = signatureOfTable(nthTable(editor, 0).node)!
-    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0))
     editor.view.dispatch(editor.state.tr.insertText('typed', 2)) // inside the leading paragraph
-    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(false)
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(false)
   })
 
   it('DOES flag a conflict when the dragged table itself is structurally changed', () => {
     editor = makeEditor(TWO_TABLES)
-    const baselineSig = signatureOfTable(nthTable(editor, 0).node)! // dragging table #0
-    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0)) // dragging table #0
 
     // A concurrent reorder of the DRAGGED table (#0): row swap.
     selectCell2(editor, 0, 1, 0)
     moveTableRow({ from: 1, to: 0 })(editor.state, editor.view.dispatch)
-    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(true)
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(true)
   })
 
   it('DOES flag a conflict when the dragged table is deleted', () => {
     editor = makeEditor(TWO_TABLES)
-    const baselineSig = signatureOfTable(nthTable(editor, 0).node)!
-    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    const baselineSigs = tableSignatures(editor.state.doc)
+    const dragIndex = draggedTableIndex(editor.state.doc, cellPosInTable(editor, 0, 0, 0))
     const { pos, node } = nthTable(editor, 0)
     editor.view.dispatch(editor.state.tr.delete(pos, pos + node.nodeSize))
-    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(true)
+    // The table set shrank → ordinals no longer align → conflict.
+    expect(draggedTableConflict(editor.state.doc, baselineSigs, dragIndex)).toBe(true)
   })
 
-  it('a null baseline disables the guard (never a blind abort)', () => {
+  it('a null baseline or out-of-range ordinal disables the guard (never a blind abort)', () => {
     editor = makeEditor(TWO_TABLES)
     expect(draggedTableConflict(editor.state.doc, null, 0)).toBe(false)
+    expect(draggedTableConflict(editor.state.doc, tableSignatures(editor.state.doc), -1)).toBe(false)
   })
 
   /** selectCell for an arbitrary table index (the file-level selectCell targets the first table). */

--- a/packages/docs/src/editor/TableReorderHandle.test.ts
+++ b/packages/docs/src/editor/TableReorderHandle.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TextSelection } from '@tiptap/pm/state'
+import { TableMap, moveTableColumn, moveTableRow, cellAround } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableReorderHandle, tableReorderPluginKey } from './TableReorderHandle.ts'
+
+// octo-docs-backend#76: table row/column reorder. The drag handle UI is DOM/pointer-driven and
+// needs real layout (jsdom reports zero rects), so these tests exercise the reorder MOVE that a
+// drop dispatches — the part the acceptance criteria pin down: a single-transaction, TableMap-
+// based reorder that preserves cell content and leaves the schema untouched. They also cover the
+// merged-cell boundary (a drop that would split a merge must be a safe no-op, not corruption).
+
+function makeEditor(content: string): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+    ],
+    content,
+  })
+}
+
+/** Text of every cell as a `row × col` grid, read from the current TableMap. */
+function grid(editor: Editor): string[][] {
+  const { doc } = editor.state
+  let tablePos = -1
+  let table: PMNode | null = null
+  doc.descendants((node, pos) => {
+    if (!table && node.type.name === 'table') {
+      table = node
+      tablePos = pos
+      return false
+    }
+    return true
+  })
+  if (!table) throw new Error('no table')
+  const t = table as PMNode
+  const map = TableMap.get(t)
+  const start = tablePos + 1
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const row: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cellRel = map.map[r * map.width + c]
+      const cell = t.nodeAt(cellRel)
+      row.push(cell ? cell.textContent : '')
+    }
+    out.push(row)
+  }
+  return out
+}
+
+/** Put the caret inside the cell at grid (row,col) — the move commands resolve the target table
+ * from the current selection, exactly as the drop handler does before dispatching. */
+function selectCell(editor: Editor, row: number, col: number): void {
+  const { doc } = editor.state
+  let table: PMNode | null = null
+  let tablePos = -1
+  doc.descendants((node, pos) => {
+    if (!table && node.type.name === 'table') {
+      table = node
+      tablePos = pos
+      return false
+    }
+    return true
+  })
+  const t = table as PMNode
+  const map = TableMap.get(t)
+  const cellRel = map.map[row * map.width + col]
+  const $inside = doc.resolve(tablePos + 1 + cellRel + 1)
+  editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($inside)))
+}
+
+let editor: Editor | null = null
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+})
+
+describe('TableReorderHandle extension', () => {
+  it('registers its ProseMirror plugin', () => {
+    editor = makeEditor(
+      '<table><tbody><tr><td><p>a</p></td><td><p>b</p></td></tr></tbody></table>',
+    )
+    expect(tableReorderPluginKey.get(editor.state)).toBeTruthy()
+  })
+})
+
+describe('column reorder (moveTableColumn)', () => {
+  it('moves a column and preserves cell content in one transaction', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>a1</p></td><td><p>b1</p></td><td><p>c1</p></td></tr>' +
+        '<tr><td><p>a2</p></td><td><p>b2</p></td><td><p>c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    expect(grid(editor)).toEqual([
+      ['a1', 'b1', 'c1'],
+      ['a2', 'b2', 'c2'],
+    ])
+    selectCell(editor, 0, 0)
+    const before = editor.state.doc
+    // Drag column 0 onto column 2 → lands after it (from < to ⇒ "after"), like the drop handler.
+    moveTableColumn({ from: 0, to: 2 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)).toEqual([
+      ['b1', 'c1', 'a1'],
+      ['b2', 'c2', 'a2'],
+    ])
+    // Single content transaction: exactly one step replaced the table node.
+    const steps = before.eq(editor.state.doc) ? 0 : 1
+    expect(steps).toBe(1)
+  })
+
+  it('moving a column back to a lower index lands before it', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>a1</p></td><td><p>b1</p></td><td><p>c1</p></td></tr>' +
+        '</tbody></table>',
+    )
+    selectCell(editor, 0, 2)
+    moveTableColumn({ from: 2, to: 0 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)).toEqual([['c1', 'a1', 'b1']])
+  })
+})
+
+describe('row reorder (moveTableRow)', () => {
+  it('moves a row and preserves cell content', () => {
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+        '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+        '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    selectCell(editor, 2, 0)
+    moveTableRow({ from: 2, to: 0 })(editor.state, editor.view.dispatch)
+    expect(grid(editor)).toEqual([
+      ['r3c1', 'r3c2'],
+      ['r1c1', 'r1c2'],
+      ['r2c1', 'r2c2'],
+    ])
+  })
+})
+
+describe('merged-cell safety', () => {
+  it('leaves the schema version untouched (pure reorder, no node/mark changes)', () => {
+    editor = makeEditor(
+      '<table><tbody><tr><td><p>a</p></td><td><p>b</p></td></tr></tbody></table>',
+    )
+    const names = new Set<string>()
+    editor.state.doc.descendants((n) => {
+      names.add(n.type.name)
+    })
+    selectCell(editor, 0, 0)
+    moveTableColumn({ from: 0, to: 1 })(editor.state, editor.view.dispatch)
+    const after = new Set<string>()
+    editor.state.doc.descendants((n) => {
+      after.add(n.type.name)
+    })
+    // Same node types before/after — the reorder introduces no new schema constructs.
+    expect([...after].sort()).toEqual([...names].sort())
+  })
+
+  it('a drop that would split a horizontally-merged cell is a safe no-op', () => {
+    // Row 0 col 0 spans two columns (colspan=2). Dropping column 0 between the two columns it
+    // spans is rejected by the command (target inside the moved merge group) — no corruption.
+    editor = makeEditor(
+      '<table><tbody>' +
+        '<tr><td colspan="2"><p>merged</p></td><td><p>c</p></td></tr>' +
+        '<tr><td><p>a2</p></td><td><p>b2</p></td><td><p>c2</p></td></tr>' +
+        '</tbody></table>',
+    )
+    const $pos = editor.state.doc.resolve(3)
+    expect(cellAround($pos)).toBeTruthy()
+    selectCell(editor, 1, 0)
+    const before = grid(editor)
+    const moved = moveTableColumn({ from: 0, to: 1 })(editor.state, editor.view.dispatch)
+    // Command reports it did nothing; the grid is unchanged (merge preserved).
+    expect(moved).toBe(false)
+    expect(grid(editor)).toEqual(before)
+  })
+})

--- a/packages/docs/src/editor/TableReorderHandle.test.ts
+++ b/packages/docs/src/editor/TableReorderHandle.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
 import type { Transaction } from '@tiptap/pm/state'
-import { TableReorderHandle, tableReorderPluginKey, resolveDragSource, tableStructureSignature } from './TableReorderHandle.ts'
+import { TableReorderHandle, tableReorderPluginKey, resolveDragSource, tableStructureSignature, signatureOfTable, countTableSignature, draggedTableConflict } from './TableReorderHandle.ts'
 
 // octo-docs-backend#76: table row/column reorder. The drag handle UI is DOM/pointer-driven and
 // needs real layout (jsdom reports zero rects), so these tests exercise the reorder MOVE that a
@@ -518,4 +518,140 @@ describe('plan-B concurrency guard — table structure signature', () => {
     const after = tableStructureSignature(editor.state.doc, cellPos)
     expect(after).toBe(baseline)
   })
+})
+
+// octo-docs-backend#76 FAIL-2 (XIN-1206): the plan-B guard's scope was too wide — it re-fingerprinted
+// the dragged table via a single remapped `cellPos`, so an edit ELSEWHERE in the doc false-aborted
+// the reorder. Under real collaboration y-prosemirror applies a remote update as one coarse
+// ReplaceStep, which collapses the remapped `cellPos` to a boundary (it stops resolving to a cell)
+// even when the dragged table is untouched — the old `signature === null → conflict` branch then
+// fired on prose / other-table edits. The fix keys conflict detection off the dragged table's
+// structure signature and how many tables carry it (`countTableSignature` / `draggedTableConflict`),
+// which is position-independent, so only a change to the DRAGGED table drops the count.
+describe('plan-B guard scope — same-table only (FAIL-2)', () => {
+  const TWO_TABLES =
+    '<table><tbody>' +
+    '<tr><td><p>A1</p></td><td><p>A2</p></td></tr>' +
+    '<tr><td><p>A3</p></td><td><p>A4</p></td></tr>' +
+    '</tbody></table>' +
+    '<p>between</p>' +
+    '<table><tbody>' +
+    '<tr><td><p>B1</p></td><td><p>B2</p></td></tr>' +
+    '</tbody></table>'
+
+  /** nth (0-based) table node + its doc position. */
+  function nthTable(editor: Editor, n: number): { node: PMNode; pos: number } {
+    const found: { node: PMNode; pos: number }[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'table') {
+        found.push({ node, pos })
+        return false
+      }
+      return true
+    })
+    if (!found[n]) throw new Error(`no table #${n}`)
+    return found[n]
+  }
+  function cellPosInTable(editor: Editor, tableIndex: number, row: number, col: number): number {
+    const { node, pos } = nthTable(editor, tableIndex)
+    const map = TableMap.get(node)
+    return pos + 1 + map.map[row * map.width + col]
+  }
+
+  it('signatureOfTable fingerprints a node directly and equals the cellPos-based signature', () => {
+    editor = makeEditor(TWO_TABLES)
+    const { node } = nthTable(editor, 0)
+    const viaNode = signatureOfTable(node)
+    const viaCell = tableStructureSignature(editor.state.doc, cellPosInTable(editor, 0, 0, 0))
+    expect(viaNode).not.toBeNull()
+    expect(viaNode).toBe(viaCell)
+    // A prose node has no table signature.
+    let para: PMNode | null = null
+    editor.state.doc.descendants((n) => {
+      if (!para && n.type.name === 'paragraph') para = n
+      return true
+    })
+    expect(signatureOfTable(para as unknown as PMNode)).toBeNull()
+  })
+
+  it('countTableSignature counts only tables that carry the signature', () => {
+    editor = makeEditor(TWO_TABLES)
+    const sigA = signatureOfTable(nthTable(editor, 0).node)!
+    const sigB = signatureOfTable(nthTable(editor, 1).node)!
+    expect(sigA).not.toBe(sigB)
+    expect(countTableSignature(editor.state.doc, sigA)).toBe(1)
+    expect(countTableSignature(editor.state.doc, sigB)).toBe(1)
+    expect(countTableSignature(editor.state.doc, 'nonexistent')).toBe(0)
+  })
+
+  it('two identical tables → count is 2, and a change to one drops it to 1 (conflict)', () => {
+    editor = makeEditor(
+      '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>' +
+        '<table><tbody><tr><td><p>x</p></td><td><p>y</p></td></tr></tbody></table>',
+    )
+    const sig = signatureOfTable(nthTable(editor, 0).node)!
+    expect(countTableSignature(editor.state.doc, sig)).toBe(2)
+    // Dragging one of the twins: baseline count 2. A reorder of the FIRST table (columns swap)
+    // drops the count of the drag-start signature to 1 → the guard still detects the same-table race
+    // even when an identical twin exists elsewhere.
+    selectCell(editor, 0, 0)
+    moveTableColumn({ from: 0, to: 1 })(editor.state, editor.view.dispatch)
+    expect(draggedTableConflict(editor.state.doc, sig, 2)).toBe(true)
+  })
+
+  it('does NOT flag a conflict when a DIFFERENT table is edited (FAIL-2 false-abort gone)', () => {
+    editor = makeEditor(TWO_TABLES)
+    const baselineSig = signatureOfTable(nthTable(editor, 0).node)! // dragging table #0
+    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+
+    // Edit a cell in the OTHER table (#1) — a same-doc structural/content change, but not to the
+    // dragged table.
+    selectCell2(editor, 1, 0, 0)
+    editor.view.dispatch(editor.state.tr.insertText('CHANGED'))
+
+    // The dragged table's signature is still present exactly once → no conflict, reorder allowed.
+    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(false)
+  })
+
+  it('does NOT flag a conflict when prose OUTSIDE any table is edited', () => {
+    editor = makeEditor('<p>lead</p>' + TWO_TABLES)
+    const baselineSig = signatureOfTable(nthTable(editor, 0).node)!
+    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    editor.view.dispatch(editor.state.tr.insertText('typed', 2)) // inside the leading paragraph
+    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(false)
+  })
+
+  it('DOES flag a conflict when the dragged table itself is structurally changed', () => {
+    editor = makeEditor(TWO_TABLES)
+    const baselineSig = signatureOfTable(nthTable(editor, 0).node)! // dragging table #0
+    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+
+    // A concurrent reorder of the DRAGGED table (#0): row swap.
+    selectCell2(editor, 0, 1, 0)
+    moveTableRow({ from: 1, to: 0 })(editor.state, editor.view.dispatch)
+    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(true)
+  })
+
+  it('DOES flag a conflict when the dragged table is deleted', () => {
+    editor = makeEditor(TWO_TABLES)
+    const baselineSig = signatureOfTable(nthTable(editor, 0).node)!
+    const baselineCount = countTableSignature(editor.state.doc, baselineSig)
+    const { pos, node } = nthTable(editor, 0)
+    editor.view.dispatch(editor.state.tr.delete(pos, pos + node.nodeSize))
+    expect(draggedTableConflict(editor.state.doc, baselineSig, baselineCount)).toBe(true)
+  })
+
+  it('a null baseline disables the guard (never a blind abort)', () => {
+    editor = makeEditor(TWO_TABLES)
+    expect(draggedTableConflict(editor.state.doc, null, 0)).toBe(false)
+  })
+
+  /** selectCell for an arbitrary table index (the file-level selectCell targets the first table). */
+  function selectCell2(editor: Editor, tableIndex: number, row: number, col: number): void {
+    const { node, pos } = nthTable(editor, tableIndex)
+    const map = TableMap.get(node)
+    const cellRel = map.map[row * map.width + col]
+    const $inside = editor.state.doc.resolve(pos + 1 + cellRel + 1)
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.near($inside)))
+  }
 })

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -32,11 +32,25 @@
 // add/delete row·column / merge·split racing our drag) DO converge in the CRDT, but y-prosemirror
 // re-diffs each replace against the base and interleaves cell text — the peers agree on a GARBLED
 // table, i.e. silent data loss. The fine-grained fix (plan A) is scheduled separately; plan B is a
-// serialize-or-abort guard layered on top: we snapshot the dragged table's structure at drag start
-// (`tableStructureSignature`) and, if any transaction that arrives DURING the drag changes that
-// table (structure or cell content), we ABORT the reorder instead of committing the replace — a
-// clear i18n toast tells the user to retry. Aborting is a pure early return before any dispatch, so
-// there is no half-commit and no dirty state; we would rather cancel than silently corrupt.
+// serialize-or-abort guard layered on top: if any transaction that arrives DURING the drag changes
+// the DRAGGED table (structure or cell content), we ABORT the reorder instead of committing the
+// replace — a clear i18n toast tells the user to retry. Aborting is a pure early return before any
+// dispatch, so there is no half-commit and no dirty state; we would rather cancel than silently
+// corrupt.
+//
+// The guard must react to changes of the DRAGGED table ONLY — an edit to prose or to a different
+// table must never cancel the reorder. Two earlier tries got the SCOPE wrong (octo-docs-backend#76
+// FAIL-2, XIN-1206/1221): (1) re-fingerprinting a single remapped cell anchor false-aborted on ANY
+// edit, because a coarse remote ReplaceStep collapses interior positions to a boundary (so the
+// anchor stops resolving even when the table is untouched); (2) counting how many tables still
+// carry the drag-start signature false-aborts as soon as the document holds two byte-identical
+// tables and the OTHER one is edited (the global count drops though the dragged table never moved).
+// Both failure modes come from using a POSITION or a GLOBAL COUNT as a stand-in for table identity.
+// The guard now uses a stable, position-independent identity instead: at drag start it snapshots the
+// ordered signature list of every table plus the dragged table's ORDINAL within it, and it aborts
+// only when the signature at THAT ordinal changes. Position-independent (a ReplaceStep can move the
+// table freely) and twin-safe (an edit to an identical sibling table changes a different ordinal),
+// while a real structural/content change to the dragged table still flips its slot and aborts.
 
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
@@ -193,14 +207,12 @@ export function tableStructureSignature(doc: PMNode, cellPos: number): string | 
   return signatureOfTable($inside.node(depth))
 }
 
-/** How many tables in `doc` currently have structure signature `sig`. The plan-B guard uses this
- * instead of re-fingerprinting a single remapped anchor. WHY: under real collaboration y-prosemirror
- * applies a remote update as one coarse `ReplaceStep`, and mapping an interior anchor (the dragged
- * cell) through that replace collapses it to the replace boundary — so the anchor no longer resolves
- * to its cell even when the dragged table is UNTOUCHED, and the old anchor+null==conflict check then
- * false-aborted on any edit elsewhere in the doc (octo-docs-backend#76 FAIL-2). Counting tables that
- * still carry the drag-start signature is position-independent, so an edit to OTHER tables or prose
- * leaves the count unchanged, while a structural change to the dragged table drops it. */
+/** How many tables in `doc` currently have structure signature `sig`. Kept as a position-independent
+ * diagnostic primitive (see TableReorderConcurrency.test.ts): an edit to OTHER tables or prose leaves
+ * the count unchanged, while a structural change to the dragged table drops it. The guard itself no
+ * longer decides on this global count — a document with two byte-identical tables makes the count
+ * ambiguous (editing the twin drops it too) — see `draggedTableConflict` for the identity-based
+ * decision that replaced it. */
 export function countTableSignature(doc: PMNode, sig: string): number {
   let n = 0
   doc.descendants((node) => {
@@ -213,15 +225,82 @@ export function countTableSignature(doc: PMNode, sig: string): number {
   return n
 }
 
-/** Plan-B conflict decision, scoped to the DRAGGED table only. `baselineSig` is the dragged table's
- * signature at drag start and `baselineCount` how many tables shared it then. A conflict is latched
- * only when the number of tables carrying that signature DROPS — i.e. the dragged table's structure
- * (or content) actually changed, or it was deleted. Concurrent edits to other tables or to prose
- * leave the dragged table's signature present, so they no longer trigger a false abort. A null
- * baseline (drag never fingerprinted a table) disables the guard rather than aborting blindly. */
-export function draggedTableConflict(doc: PMNode, baselineSig: string | null, baselineCount: number): boolean {
-  if (baselineSig === null) return false
-  return countTableSignature(doc, baselineSig) < baselineCount
+/** Ordered signature of EVERY table in `doc`, in document order. This is the position-independent
+ * identity basis for the drag guard: the dragged table is pinned by its ORDINAL in this list (see
+ * `draggedTableIndex`) plus the signature at that ordinal, never by an absolute position — a coarse
+ * remote `ReplaceStep` can move the table freely and the ordinal still selects it. Entries are null
+ * for a table that isn't currently laid out (see `signatureOfTable`). */
+export function tableSignatures(doc: PMNode): (string | null)[] {
+  const sigs: (string | null)[] = []
+  doc.descendants((node) => {
+    if (node.type.spec.tableRole === 'table') {
+      sigs.push(signatureOfTable(node))
+      return false // tables don't nest; don't descend
+    }
+    return true
+  })
+  return sigs
+}
+
+/** Ordinal of the table containing `cellPos` among all tables in document order, or -1 when the
+ * position is not inside a table. Captured at drag start as the dragged table's STABLE IDENTITY:
+ * combined with `tableSignatures` it lets the guard re-select exactly the dragged table after any
+ * transaction, without trusting an absolute position (which a coarse remote ReplaceStep collapses to
+ * a boundary). Positions are valid at drag start, so resolving the ordinal here is reliable even
+ * though the position itself becomes unusable once concurrent edits land. */
+export function draggedTableIndex(doc: PMNode, cellPos: number): number {
+  if (cellPos < 0 || cellPos + 1 > doc.content.size) return -1
+  let $inside
+  try {
+    $inside = doc.resolve(cellPos + 1)
+  } catch {
+    return -1
+  }
+  let depth = -1
+  for (let d = $inside.depth; d > 0; d--) {
+    if ($inside.node(d).type.spec.tableRole === 'table') {
+      depth = d
+      break
+    }
+  }
+  if (depth < 0) return -1
+  const tablePos = $inside.before(depth)
+  let seen = 0
+  let found = -1
+  doc.descendants((node, pos) => {
+    if (node.type.spec.tableRole === 'table') {
+      if (pos === tablePos) found = seen
+      seen++
+      return false // tables don't nest; don't descend
+    }
+    return true
+  })
+  return found
+}
+
+/** Plan-B conflict decision, scoped to the DRAGGED table only, by STABLE IDENTITY. `baselineSigs` is
+ * the ordered table-signature list captured at drag start (`tableSignatures`) and `dragIndex` the
+ * dragged table's ordinal within it (`draggedTableIndex`). A conflict is latched only when the
+ * signature at THAT ordinal changes:
+ *   - edits to prose, or to any OTHER table (even a byte-identical twin), leave `now[dragIndex]`
+ *     equal to the baseline, so they never false-abort (octo-docs-backend#76 FAIL-2);
+ *   - a structural or content change to the dragged table itself flips its slot → abort (the data-
+ *     safety guard the acceptance criteria require);
+ *   - a concurrent whole-table ADD/DELETE changes the table count, so ordinals no longer align and
+ *     we cannot prove the dragged table is untouched → abort conservatively (data-safe; this is a
+ *     rare concurrent structural edit, and the user is simply asked to retry).
+ * A null baseline list, an out-of-range ordinal, or a null baseline signature at that ordinal (drag
+ * never fingerprinted a laid-out table) disables the guard rather than aborting blindly. */
+export function draggedTableConflict(
+  doc: PMNode,
+  baselineSigs: (string | null)[] | null,
+  dragIndex: number,
+): boolean {
+  if (baselineSigs === null || dragIndex < 0 || dragIndex >= baselineSigs.length) return false
+  if (baselineSigs[dragIndex] === null) return false
+  const now = tableSignatures(doc)
+  if (now.length !== baselineSigs.length) return true
+  return now[dragIndex] !== baselineSigs[dragIndex]
 }
 
 /** Transient, document-external toast telling the user their reorder was cancelled because a
@@ -288,15 +367,18 @@ export const TableReorderHandle = Extension.create({
     let drag: DragState | null = null
     // Resolved drop target row/column index during a drag (null = no valid target yet).
     let dropIndex: number | null = null
-    // Plan-B concurrency guard. `dragBaseline` is the dragged table's structure signature captured
-    // at drag start and `dragBaselineCount` how many tables shared it then; `concurrentEdit` latches
-    // true when a transaction landing during the drag drops that count — i.e. the dragged table's own
-    // structure/content changed (a remote reorder / add·delete row·column / merge·split / cell edit
-    // on THAT table — see the plugin `state.apply`). Edits to other tables or prose leave the count
-    // unchanged, so they never latch. When latched, `runMove` aborts the reorder rather than
-    // committing a whole-table replace that would silently corrupt against the concurrent edit.
-    let dragBaseline: string | null = null
-    let dragBaselineCount = 0
+    // Plan-B concurrency guard. `dragBaselineSigs` is the ordered signature of every table at drag
+    // start and `dragTableIndex` the dragged table's ordinal within it — together a stable,
+    // position-independent identity for the dragged table (see `draggedTableConflict`).
+    // `concurrentEdit` latches true when a transaction landing during the drag changes the signature
+    // at that ordinal — i.e. the dragged table's own structure/content changed (a remote reorder /
+    // add·delete row·column / merge·split / cell edit on THAT table), or a whole table was added/
+    // deleted so the ordinals no longer align (see the plugin `state.apply`). Edits to prose or to a
+    // different table (even an identical twin) leave that slot unchanged, so they never latch. When
+    // latched, `runMove` aborts the reorder rather than committing a whole-table replace that would
+    // silently corrupt against the concurrent edit.
+    let dragBaselineSigs: (string | null)[] | null = null
+    let dragTableIndex = -1
     let concurrentEdit = false
     // Latches true once we have seen a mid-drag mousemove that actually reports the primary button
     // held (`buttons & 1`). It gates the "released outside the window" abort below: that abort must
@@ -459,8 +541,8 @@ export const TableReorderHandle = Extension.create({
     const resetDragState = () => {
       drag = null
       dropIndex = null
-      dragBaseline = null
-      dragBaselineCount = 0
+      dragBaselineSigs = null
+      dragTableIndex = -1
       concurrentEdit = false
       pointerHeldSeen = false
       document.body.classList.remove('octo-table-reordering')
@@ -577,11 +659,11 @@ export const TableReorderHandle = Extension.create({
         tablePos: hover.tablePos,
         cellPos: hover.cellPos,
       }
-      // Snapshot the dragged table's structure so the plan-B guard can detect a concurrent edit to
-      // it during the drag: its signature plus how many tables currently share that signature. Reset
-      // the latch for this fresh drag.
-      dragBaseline = tableStructureSignature(view.state.doc, hover.cellPos)
-      dragBaselineCount = dragBaseline === null ? 0 : countTableSignature(view.state.doc, dragBaseline)
+      // Snapshot the dragged table's stable identity so the plan-B guard can detect a concurrent
+      // edit to it during the drag: the ordered signature of every table plus the dragged table's
+      // ordinal within that list. Reset the latch for this fresh drag.
+      dragBaselineSigs = tableSignatures(view.state.doc)
+      dragTableIndex = draggedTableIndex(view.state.doc, hover.cellPos)
       concurrentEdit = false
       pointerHeldSeen = false
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
@@ -614,16 +696,19 @@ export const TableReorderHandle = Extension.create({
                 tablePos: tr.mapping.map(drag.tablePos),
                 tableStart: tr.mapping.map(drag.tableStart),
               }
-              // Plan-B conflict detection, scoped to the dragged table only. Count the tables that
-              // still carry the drag-start signature; a DROP means the dragged table's own structure
-              // or content changed (or it was deleted) — latch a conflict so `runMove` aborts. This
-              // is position-independent, so it does NOT depend on the remapped `cellPos` (which a
-              // coarse y-prosemirror ReplaceStep can collapse to a boundary even when the table is
-              // untouched) — that anchor drift is exactly what made edits OUTSIDE the dragged table
-              // false-abort before (octo-docs-backend#76 FAIL-2). Benign edits elsewhere leave the
-              // count unchanged, so the latch stays clear.
-              if (!concurrentEdit && dragBaseline !== null) {
-                if (draggedTableConflict(newState.doc, dragBaseline, dragBaselineCount)) concurrentEdit = true
+              // Plan-B conflict detection, scoped to the dragged table only by STABLE IDENTITY.
+              // Re-select the dragged table by its drag-start ordinal and compare its signature to
+              // the baseline; a change means the dragged table's own structure/content changed (or
+              // the table set changed) — latch a conflict so `runMove` aborts. This is fully
+              // position-independent, so it does NOT depend on the remapped `cellPos`/`tablePos`
+              // (which a coarse y-prosemirror ReplaceStep collapses to a boundary even when the table
+              // is untouched) — that anchor drift, and the earlier global-count heuristic that
+              // false-aborted whenever an identical twin table was edited, are exactly what made
+              // edits OUTSIDE the dragged table cancel the reorder before (octo-docs-backend#76
+              // FAIL-2 / XIN-1221). Benign edits to prose or another table leave that slot unchanged,
+              // so the latch stays clear.
+              if (!concurrentEdit && dragBaselineSigs !== null) {
+                if (draggedTableConflict(newState.doc, dragBaselineSigs, dragTableIndex)) concurrentEdit = true
               }
             }
             return null
@@ -672,8 +757,8 @@ export const TableReorderHandle = Extension.create({
               rowHandle = colHandle = indicator = null
               activeView = null
               drag = null
-              dragBaseline = null
-              dragBaselineCount = 0
+              dragBaselineSigs = null
+              dragTableIndex = -1
               concurrentEdit = false
               pointerHeldSeen = false
             },

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -397,17 +397,48 @@ export const TableReorderHandle = Extension.create({
       view.focus()
     }
 
-    const endDrag = (view: EditorView) => {
+    // Tear down every document/window listener a drag installs. Kept in one place so endDrag (a
+    // completed drop), cancelDrag (an interrupted drag) and the plugin destroy all detach the SAME
+    // set — a listener left attached after the drag ends would keep firing against stale state.
+    const removeDragListeners = () => {
       document.removeEventListener('mousemove', onDocMove, true)
       document.removeEventListener('mouseup', onDocUp, true)
-      document.body.classList.remove('octo-table-reordering')
-      runMove(view)
+      document.removeEventListener('pointercancel', onDocCancel, true)
+      document.removeEventListener('keydown', onDocKey, true)
+      window.removeEventListener('blur', onWindowBlur)
+    }
+
+    // Clear all drag bookkeeping and restore the resting UI. Critically this un-freezes handle
+    // placement: the resting-handle mousemove handler early-returns while `drag` is non-null, so
+    // leaving `drag` set (or the body class) after a drag ends would strand the grab cursor and stop
+    // the handles from ever tracking the pointer again — the "handles unavailable" failure mode.
+    const resetDragState = () => {
       drag = null
       dropIndex = null
       dragBaseline = null
       concurrentEdit = false
+      document.body.classList.remove('octo-table-reordering')
       hideIndicator()
       hideHandles()
+    }
+
+    const endDrag = (view: EditorView) => {
+      removeDragListeners()
+      runMove(view)
+      resetDragState()
+    }
+
+    // Abort an in-flight drag WITHOUT committing a move. Used when the drag is interrupted rather
+    // than completed with a real drop — the window loses focus (alt-tab), the OS cancels the pointer
+    // (touch/pen), or the user presses Escape. Without this, a missed mouseup leaves `drag` set and
+    // the `octo-table-reordering` body class stuck until the next stray mouseup, wedging the reorder
+    // UI (stuck grab cursor + frozen handles). Aborting is a pure early return — no dispatch, no doc
+    // change — so it can never corrupt content.
+    const cancelDrag = () => {
+      if (!drag) return
+      reorderDebug({ phase: 'drop', dispatched: false, reason: 'drag interrupted — cancelled' })
+      removeDragListeners()
+      resetDragState()
     }
 
     // Bound once so add/removeEventListener pair up; `activeView` is set on drag start.
@@ -459,8 +490,18 @@ export const TableReorderHandle = Extension.create({
     const onDocUp = () => {
       if (activeView) endDrag(activeView)
     }
+    // Interruption handlers: an interrupted drag must abort cleanly, never commit a move.
+    const onDocCancel = () => cancelDrag()
+    const onWindowBlur = () => cancelDrag()
+    const onDocKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') cancelDrag()
+    }
 
     const beginDrag = (view: EditorView, kind: 'row' | 'col', event: MouseEvent) => {
+      // Only a primary (left) button starts a reorder. A right/middle-click on the grab handle must
+      // not begin a drag — it would fight the context menu and, with no matching left mouseup, could
+      // strand the drag state (octo-docs-backend#76 review).
+      if (event.button !== 0) return
       if (!view.editable || !hover) return
       event.preventDefault()
       drag = {
@@ -479,6 +520,9 @@ export const TableReorderHandle = Extension.create({
       document.body.classList.add('octo-table-reordering')
       document.addEventListener('mousemove', onDocMove, true)
       document.addEventListener('mouseup', onDocUp, true)
+      document.addEventListener('pointercancel', onDocCancel, true)
+      document.addEventListener('keydown', onDocKey, true)
+      window.addEventListener('blur', onWindowBlur)
     }
 
     return [
@@ -546,8 +590,7 @@ export const TableReorderHandle = Extension.create({
 
           return {
             destroy() {
-              document.removeEventListener('mousemove', onDocMove, true)
-              document.removeEventListener('mouseup', onDocUp, true)
+              removeDragListeners()
               document.body.classList.remove('octo-table-reordering')
               rowHandle?.removeEventListener('mousedown', onRowDown)
               colHandle?.removeEventListener('mousedown', onColDown)

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -25,12 +25,25 @@
 // (`tr.replaceWith`), so y-prosemirror syncs it like any other edit — no bespoke collab code.
 // The handle + drop-indicator are plugin-managed DOM outside the document (like
 // BlockDragHandle), so the mutation observer never sees them as content.
+//
+// Concurrency guard (plan B, octo-docs-backend#76 / XIN-1187). The reorder command rebuilds the
+// whole table with a single coarse `tr.replaceWith`. TableReorderConcurrency.test.ts shows the
+// real hazard: two whole-table replaces that land concurrently (a remote reorder, or a remote
+// add/delete row·column / merge·split racing our drag) DO converge in the CRDT, but y-prosemirror
+// re-diffs each replace against the base and interleaves cell text — the peers agree on a GARBLED
+// table, i.e. silent data loss. The fine-grained fix (plan A) is scheduled separately; plan B is a
+// serialize-or-abort guard layered on top: we snapshot the dragged table's structure at drag start
+// (`tableStructureSignature`) and, if any transaction that arrives DURING the drag changes that
+// table (structure or cell content), we ABORT the reorder instead of committing the replace — a
+// clear i18n toast tells the user to retry. Aborting is a pure early return before any dispatch, so
+// there is no half-commit and no dirty state; we would rather cancel than silently corrupt.
 
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import { TableMap, cellAround, moveTableColumn, moveTableRow } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
+import { t } from '../octoweb/index.ts'
 
 export const tableReorderPluginKey = new PluginKey('octoTableReorder')
 
@@ -129,6 +142,68 @@ export function resolveDragSource(
   }
 }
 
+/** Fingerprint of the table that contains `cellPos`, used by the plan-B concurrency guard to tell
+ * whether a transaction arriving mid-drag changed the dragged table. The signature folds in exactly
+ * the things a corrupting concurrent edit would move: the grid dimensions (add/delete row·column),
+ * each cell's colspan/rowspan (merge·split) and each cell's text in grid order (a remote reorder
+ * reshuffles the text, a concurrent cell edit rewrites it). Anything OUTSIDE this table — edits to
+ * other tables or prose — leaves the signature untouched, so the guard only fires on same-table
+ * races. Returns null when `cellPos` no longer resolves to a table cell (e.g. a peer deleted it),
+ * which the guard also treats as a conflict. Deliberately conservative: any same-table change aborts
+ * the reorder, because the coarse whole-table replace can silently corrupt against any of them until
+ * the fine-grained plan-A move lands. */
+export function tableStructureSignature(doc: PMNode, cellPos: number): string | null {
+  if (cellPos < 0 || cellPos + 1 > doc.content.size) return null
+  let $inside
+  try {
+    $inside = doc.resolve(cellPos + 1)
+  } catch {
+    return null
+  }
+  let depth = -1
+  for (let d = $inside.depth; d > 0; d--) {
+    if ($inside.node(d).type.spec.tableRole === 'table') {
+      depth = d
+      break
+    }
+  }
+  if (depth < 0) return null
+  const table = $inside.node(depth)
+  let map: TableMap
+  try {
+    map = TableMap.get(table)
+  } catch {
+    return null
+  }
+  const parts: string[] = [`${map.height}x${map.width}`]
+  for (let r = 0; r < map.height; r++) {
+    for (let c = 0; c < map.width; c++) {
+      const cell = table.nodeAt(map.map[r * map.width + c])
+      if (!cell) {
+        parts.push('-')
+        continue
+      }
+      const colspan = (cell.attrs.colspan as number | undefined) ?? 1
+      const rowspan = (cell.attrs.rowspan as number | undefined) ?? 1
+      parts.push(`${cell.textContent}#${colspan},${rowspan}`)
+    }
+  }
+  return parts.join('|')
+}
+
+/** Transient, document-external toast telling the user their reorder was cancelled because a
+ * collaborator changed the same table mid-drag. Lives in <body> (never the Y.Doc), so it cannot
+ * desync collab content — mirrors `notifyFileError` in fileUpload.ts. */
+function notifyReorderConflict(): void {
+  if (typeof document === 'undefined') return
+  const el = document.createElement('div')
+  el.className = 'octo-table-reorder-error'
+  el.setAttribute('role', 'alert')
+  el.textContent = t('docs.table.reorderConflict')
+  document.body.appendChild(el)
+  setTimeout(() => el.remove(), 4000)
+}
+
 function cellContextAt(view: EditorView, clientX: number, clientY: number): CellContext | null {
   const found = view.posAtCoords({ left: clientX, top: clientY })
   if (!found) return null
@@ -180,6 +255,13 @@ export const TableReorderHandle = Extension.create({
     let drag: DragState | null = null
     // Resolved drop target row/column index during a drag (null = no valid target yet).
     let dropIndex: number | null = null
+    // Plan-B concurrency guard. `dragBaseline` is the dragged table's structure signature captured
+    // at drag start; `concurrentEdit` latches true when any transaction that lands during the drag
+    // changes that table (a remote reorder / add·delete row·column / merge·split / cell edit — see
+    // the plugin `state.apply`). When latched, `runMove` aborts the reorder rather than committing a
+    // whole-table replace that would silently corrupt against the concurrent edit.
+    let dragBaseline: string | null = null
+    let concurrentEdit = false
 
     const hideHandles = () => {
       if (rowHandle) rowHandle.style.display = 'none'
@@ -276,6 +358,14 @@ export const TableReorderHandle = Extension.create({
         reorderDebug({ phase: 'drop', dispatched: false, reason: 'no valid target', drag, dropIndex })
         return
       }
+      // Plan-B guard: a collaborator changed this table during the drag. Abort BEFORE any dispatch
+      // (no selection change, no move) so there is zero half-commit, and tell the user to retry —
+      // committing the whole-table replace now would silently corrupt against their edit.
+      if (concurrentEdit) {
+        reorderDebug({ phase: 'drop', dispatched: false, reason: 'concurrent structural edit — aborted' })
+        notifyReorderConflict()
+        return
+      }
       // Re-resolve the source cell against the CURRENT doc from its remapped position, then take
       // the move's `from` from the live grid rect — never the drag-start index. Under concurrent
       // collaboration a remote peer may have inserted/deleted rows or columns above the dragged
@@ -314,6 +404,8 @@ export const TableReorderHandle = Extension.create({
       runMove(view)
       drag = null
       dropIndex = null
+      dragBaseline = null
+      concurrentEdit = false
       hideIndicator()
       hideHandles()
     }
@@ -377,6 +469,10 @@ export const TableReorderHandle = Extension.create({
         tablePos: hover.tablePos,
         cellPos: hover.cellPos,
       }
+      // Snapshot the dragged table's structure so the plan-B guard can detect a concurrent edit to
+      // it during the drag. Reset the latch for this fresh drag.
+      dragBaseline = tableStructureSignature(view.state.doc, hover.cellPos)
+      concurrentEdit = false
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
       dropIndex = null
       activeView = view
@@ -396,13 +492,22 @@ export const TableReorderHandle = Extension.create({
         // holds no value of its own; it exists only for the mapping side effect on the drag anchor.
         state: {
           init: () => null,
-          apply: (tr) => {
+          apply: (tr, _value, _oldState, newState) => {
             if (drag && tr.docChanged) {
               drag = {
                 ...drag,
                 cellPos: tr.mapping.map(drag.cellPos),
                 tablePos: tr.mapping.map(drag.tablePos),
                 tableStart: tr.mapping.map(drag.tableStart),
+              }
+              // Plan-B conflict detection. Re-fingerprint the dragged table (via the just-remapped
+              // cellPos, against the post-transaction doc) and latch a conflict if it diverges from
+              // the drag-start baseline — i.e. this transaction changed the table we are dragging in.
+              // A benign edit elsewhere leaves the signature equal, so the latch stays clear. Once
+              // latched it stays latched for the rest of the drag; `runMove` then aborts.
+              if (!concurrentEdit && dragBaseline !== null) {
+                const current = tableStructureSignature(newState.doc, drag.cellPos)
+                if (current === null || current !== dragBaseline) concurrentEdit = true
               }
             }
             return null
@@ -452,6 +557,8 @@ export const TableReorderHandle = Extension.create({
               rowHandle = colHandle = indicator = null
               activeView = null
               drag = null
+              dragBaseline = null
+              concurrentEdit = false
             },
           }
         },

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -1,0 +1,323 @@
+// Self-built table row/column reorder handles (octo-docs-backend#76). A ProseMirror
+// plugin renders a grab handle at the left edge of the hovered row and the top edge of
+// the hovered column; dragging a handle reorders that row/column within the table.
+//
+// Why NOT reuse BlockDragHandle: that handle moves a whole top-level block via a
+// NodeSelection slice through ProseMirror's native drag pipeline. A table row/column is
+// not a top-level block — it lives inside the table's TableMap grid — so a slice move
+// would tear the table apart. Reordering has to rebuild the grid in one transaction.
+//
+// Why NOT hand-roll the grid rebuild: prosemirror-tables (bundled with @tiptap/pm 3.22.2)
+// already ships `moveTableRow` / `moveTableColumn` — the exact "TableMap-based reorder in a
+// single transaction" the issue asks us to build. They:
+//   - rebuild the table with a single `tr.replaceWith` (one transaction, content preserved);
+//   - expand the moved index range to cover merged cells (colspan/rowspan) via
+//     getSelectionRangeInColumn / …InRow, so a merge group moves as a unit and a drop that
+//     would split a merge is a safe no-op (the command returns false) rather than corrupting
+//     the grid;
+//   - restore a CellSelection on the moved row/column afterwards (`select: true`), which is
+//     the "selection/decoration recovery after TableMap rebuild" concern — the library
+//     re-resolves the selection against the rebuilt map for us.
+// So the reorder COMMAND is the library's; this file is only the drag-handle UI + hit-testing
+// that drives it. See the PR description for the full feasibility write-up.
+//
+// Collaboration-safe by design: the move lands as an ordinary editor transaction
+// (`tr.replaceWith`), so y-prosemirror syncs it like any other edit — no bespoke collab code.
+// The handle + drop-indicator are plugin-managed DOM outside the document (like
+// BlockDragHandle), so the mutation observer never sees them as content.
+
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { TableMap, cellAround, moveTableColumn, moveTableRow } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+
+export const tableReorderPluginKey = new PluginKey('octoTableReorder')
+
+// Thickness (px) of the grab bar that sits in the gutter above a column / left of a row. Kept
+// slim so it hugs the table edge and stays clear of the column-resize handle (interior, right
+// edge of each cell) and the block drag handle (further out in the left gutter).
+const BAR = 14
+
+/** Resolved geometry for the table cell under a screen point. `rect` holds TableMap grid
+ * indices ({left,top,right,bottom} as column/row indices), `cellPos` is the document position
+ * just before the cell. Returns null when the point is not inside a table cell. */
+interface CellContext {
+  table: PMNode
+  tableStart: number
+  tablePos: number
+  map: TableMap
+  rect: { left: number; top: number; right: number; bottom: number }
+  cellPos: number
+}
+
+function cellContextAt(view: EditorView, clientX: number, clientY: number): CellContext | null {
+  const found = view.posAtCoords({ left: clientX, top: clientY })
+  if (!found) return null
+  const $pos = view.state.doc.resolve(found.pos)
+  let depth = -1
+  for (let d = $pos.depth; d > 0; d--) {
+    if ($pos.node(d).type.spec.tableRole === 'table') {
+      depth = d
+      break
+    }
+  }
+  if (depth < 0) return null
+  const table = $pos.node(depth)
+  const tableStart = $pos.start(depth)
+  const tablePos = $pos.before(depth)
+  const $cell = cellAround($pos)
+  if (!$cell) return null
+  const map = TableMap.get(table)
+  const rect = map.findCell($cell.pos - tableStart)
+  return { table, tableStart, tablePos, map, rect, cellPos: $cell.pos }
+}
+
+/** State captured at drag start: which axis, the source row/column index, and enough table
+ * identity to (a) confirm a drop lands in the SAME table and (b) place the selection back
+ * inside the source before running the move command. */
+interface DragState {
+  kind: 'row' | 'col'
+  index: number
+  tableStart: number
+  cellPos: number
+}
+
+/** Table row/column reorder extension. */
+export const TableReorderHandle = Extension.create({
+  name: 'tableReorderHandle',
+
+  addProseMirrorPlugins() {
+    let rowHandle: HTMLElement | null = null
+    let colHandle: HTMLElement | null = null
+    let indicator: HTMLElement | null = null
+    // Last cell the pointer hovered while idle — the source for a drag that starts on a handle.
+    let hover: CellContext | null = null
+    // Non-null only while a handle is being dragged.
+    let drag: DragState | null = null
+    // Resolved drop target row/column index during a drag (null = no valid target yet).
+    let dropIndex: number | null = null
+
+    const hideHandles = () => {
+      if (rowHandle) rowHandle.style.display = 'none'
+      if (colHandle) colHandle.style.display = 'none'
+      hover = null
+    }
+    const hideIndicator = () => {
+      if (indicator) indicator.style.display = 'none'
+    }
+
+    // Position the resting row/column handles against the hovered cell. Geometry is read live
+    // from the DOM each move so the handles track scrolling inside .tableWrapper.
+    const placeHandles = (view: EditorView, ctx: CellContext) => {
+      if (!rowHandle || !colHandle) return
+      const cellDom = view.nodeDOM(ctx.cellPos)
+      const tableDom = view.nodeDOM(ctx.tablePos)
+      if (!(cellDom instanceof HTMLElement) || !(tableDom instanceof HTMLElement)) {
+        hideHandles()
+        return
+      }
+      const base = (view.dom as HTMLElement).getBoundingClientRect()
+      const cell = cellDom.getBoundingClientRect()
+      const table = tableDom.getBoundingClientRect()
+
+      // Column handle: a bar spanning the hovered column's width, just above the table.
+      colHandle.style.display = 'flex'
+      colHandle.style.left = `${cell.left - base.left}px`
+      colHandle.style.top = `${table.top - base.top - BAR - 2}px`
+      colHandle.style.width = `${cell.width}px`
+      colHandle.style.height = `${BAR}px`
+
+      // Row handle: a bar spanning the hovered row's height, just left of the table.
+      rowHandle.style.display = 'flex'
+      rowHandle.style.left = `${table.left - base.left - BAR - 2}px`
+      rowHandle.style.top = `${cell.top - base.top}px`
+      rowHandle.style.width = `${BAR}px`
+      rowHandle.style.height = `${cell.height}px`
+
+      hover = ctx
+    }
+
+    // Draw the insertion caret at the boundary a drop would land on. Mirrors the library's
+    // move semantics: dragging toward a lower index lands BEFORE the hovered row/column, toward
+    // a higher index lands AFTER it. A drop on the source itself shows nothing (it's a no-op).
+    const showIndicator = (view: EditorView, ctx: CellContext) => {
+      if (!indicator || !drag) return
+      const hovered = drag.kind === 'col' ? ctx.rect.left : ctx.rect.top
+      if (hovered === drag.index) {
+        dropIndex = null
+        hideIndicator()
+        return
+      }
+      const cellDom = view.nodeDOM(ctx.cellPos)
+      const tableDom = view.nodeDOM(ctx.tablePos)
+      if (!(cellDom instanceof HTMLElement) || !(tableDom instanceof HTMLElement)) return
+      const base = (view.dom as HTMLElement).getBoundingClientRect()
+      const cell = cellDom.getBoundingClientRect()
+      const table = tableDom.getBoundingClientRect()
+      const before = hovered < drag.index
+
+      indicator.style.display = 'block'
+      if (drag.kind === 'col') {
+        const x = before ? cell.left : cell.right
+        indicator.style.left = `${x - base.left - 1}px`
+        indicator.style.top = `${table.top - base.top}px`
+        indicator.style.width = '2px'
+        indicator.style.height = `${table.height}px`
+      } else {
+        const y = before ? cell.top : cell.bottom
+        indicator.style.left = `${table.left - base.left}px`
+        indicator.style.top = `${y - base.top - 1}px`
+        indicator.style.width = `${table.width}px`
+        indicator.style.height = '2px'
+      }
+      dropIndex = hovered
+    }
+
+    // Run the reorder. The move command resolves the target table from the CURRENT selection
+    // (getCellsInColumn/…Row read selection.$from), so first drop the caret into a cell of the
+    // source row/column — a pure selection change (no doc edit, so y-prosemirror ignores it) —
+    // then dispatch the single-transaction move on the updated state.
+    const runMove = (view: EditorView) => {
+      if (!drag || dropIndex == null || dropIndex === drag.index) return
+      const { doc } = view.state
+      if (drag.cellPos + 1 > doc.content.size) return
+      let $inside
+      try {
+        $inside = doc.resolve(drag.cellPos + 1)
+      } catch {
+        return
+      }
+      view.dispatch(view.state.tr.setSelection(TextSelection.near($inside)))
+      const command =
+        drag.kind === 'col'
+          ? moveTableColumn({ from: drag.index, to: dropIndex })
+          : moveTableRow({ from: drag.index, to: dropIndex })
+      command(view.state, view.dispatch)
+      view.focus()
+    }
+
+    const endDrag = (view: EditorView) => {
+      document.removeEventListener('mousemove', onDocMove, true)
+      document.removeEventListener('mouseup', onDocUp, true)
+      document.body.classList.remove('octo-table-reordering')
+      runMove(view)
+      drag = null
+      dropIndex = null
+      hideIndicator()
+      hideHandles()
+    }
+
+    // Bound once so add/removeEventListener pair up; `activeView` is set on drag start.
+    let activeView: EditorView | null = null
+    const onDocMove = (event: MouseEvent) => {
+      if (!drag || !activeView) return
+      event.preventDefault()
+      const ctx = cellContextAt(activeView, event.clientX, event.clientY)
+      if (!ctx || ctx.tableStart !== drag.tableStart) {
+        dropIndex = null
+        hideIndicator()
+        return
+      }
+      showIndicator(activeView, ctx)
+    }
+    const onDocUp = () => {
+      if (activeView) endDrag(activeView)
+    }
+
+    const beginDrag = (view: EditorView, kind: 'row' | 'col', event: MouseEvent) => {
+      if (!view.editable || !hover) return
+      event.preventDefault()
+      drag = {
+        kind,
+        index: kind === 'col' ? hover.rect.left : hover.rect.top,
+        tableStart: hover.tableStart,
+        cellPos: hover.cellPos,
+      }
+      dropIndex = null
+      activeView = view
+      document.body.classList.add('octo-table-reordering')
+      document.addEventListener('mousemove', onDocMove, true)
+      document.addEventListener('mouseup', onDocUp, true)
+    }
+
+    return [
+      new Plugin({
+        key: tableReorderPluginKey,
+        view(view) {
+          const wrapper = view.dom.parentElement
+          rowHandle = document.createElement('div')
+          rowHandle.className = 'octo-table-reorder octo-table-reorder--row'
+          rowHandle.setAttribute('contenteditable', 'false')
+          rowHandle.setAttribute('aria-label', 'Drag to reorder row')
+          rowHandle.style.display = 'none'
+          colHandle = document.createElement('div')
+          colHandle.className = 'octo-table-reorder octo-table-reorder--col'
+          colHandle.setAttribute('contenteditable', 'false')
+          colHandle.setAttribute('aria-label', 'Drag to reorder column')
+          colHandle.style.display = 'none'
+          indicator = document.createElement('div')
+          indicator.className = 'octo-table-reorder-indicator'
+          indicator.setAttribute('contenteditable', 'false')
+          indicator.style.display = 'none'
+
+          if (wrapper) {
+            rowHandle.style.position = 'absolute'
+            colHandle.style.position = 'absolute'
+            indicator.style.position = 'absolute'
+            wrapper.appendChild(rowHandle)
+            wrapper.appendChild(colHandle)
+            wrapper.appendChild(indicator)
+          }
+
+          const onRowDown = (e: MouseEvent) => beginDrag(view, 'row', e)
+          const onColDown = (e: MouseEvent) => beginDrag(view, 'col', e)
+          rowHandle.addEventListener('mousedown', onRowDown)
+          colHandle.addEventListener('mousedown', onColDown)
+
+          return {
+            destroy() {
+              document.removeEventListener('mousemove', onDocMove, true)
+              document.removeEventListener('mouseup', onDocUp, true)
+              document.body.classList.remove('octo-table-reordering')
+              rowHandle?.removeEventListener('mousedown', onRowDown)
+              colHandle?.removeEventListener('mousedown', onColDown)
+              rowHandle?.remove()
+              colHandle?.remove()
+              indicator?.remove()
+              rowHandle = colHandle = indicator = null
+              activeView = null
+              drag = null
+            },
+          }
+        },
+        props: {
+          handleDOMEvents: {
+            mousemove(view, event) {
+              // Freeze the resting handles while a drag is in flight (the document-level
+              // listeners own the pointer then).
+              if (drag) return false
+              if (!view.editable) return false
+              const ctx = cellContextAt(view, event.clientX, event.clientY)
+              if (!ctx) {
+                hideHandles()
+                return false
+              }
+              placeHandles(view, ctx)
+              return false
+            },
+            mouseleave(_view, event) {
+              if (drag) return false
+              // Keep the handles up when the pointer moves onto one of them (they live outside
+              // the editor DOM, so leaving the prose region toward a handle must not hide it).
+              const to = (event as MouseEvent).relatedTarget as Node | null
+              if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) return false
+              hideHandles()
+              return false
+            },
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -82,6 +82,53 @@ function tableElementAt(view: EditorView, tablePos: number): HTMLElement | null 
   return inner instanceof HTMLElement ? inner : dom
 }
 
+/** Re-resolve a drag's source cell against a document, by the position just before it.
+ *
+ * The blocking collab bug (octo-docs-backend#76 review): `beginDrag` captures the source
+ * row/column index and cell position as ABSOLUTE values at drag start. On drop, `runMove` used
+ * those stale numbers directly — but this is a y-prosemirror collaborative editor, so a remote
+ * peer inserting or deleting a row/column ABOVE the dragged one during the drag remaps the
+ * document; the stale index then points at a DIFFERENT row/column and the reorder moves the
+ * wrong one (a correctness defect, not a crash).
+ *
+ * The fix has two halves that meet here: (1) the drag's `cellPos` is remapped through every
+ * transaction that arrives mid-drag (the plugin `state.apply` below maps it via `tr.mapping`, so
+ * it keeps pointing at the SAME cell across concurrent edits), and (2) at drop / hover time we
+ * re-derive the live grid index from that remapped position with this helper instead of trusting
+ * the drag-start index. Returns null when the source cell no longer resolves (e.g. a collaborator
+ * deleted it), which makes the drop a safe no-op rather than a mis-move. */
+export function resolveDragSource(
+  doc: PMNode,
+  cellPos: number,
+): { tableStart: number; rect: { left: number; top: number; right: number; bottom: number }; cellPos: number } | null {
+  if (cellPos < 0 || cellPos + 1 > doc.content.size) return null
+  let $inside
+  try {
+    $inside = doc.resolve(cellPos + 1)
+  } catch {
+    return null
+  }
+  let depth = -1
+  for (let d = $inside.depth; d > 0; d--) {
+    if ($inside.node(d).type.spec.tableRole === 'table') {
+      depth = d
+      break
+    }
+  }
+  if (depth < 0) return null
+  const table = $inside.node(depth)
+  const tableStart = $inside.start(depth)
+  const $cell = cellAround($inside)
+  if (!$cell) return null
+  const map = TableMap.get(table)
+  try {
+    const rect = map.findCell($cell.pos - tableStart)
+    return { tableStart, rect, cellPos: $cell.pos }
+  } catch {
+    return null
+  }
+}
+
 function cellContextAt(view: EditorView, clientX: number, clientY: number): CellContext | null {
   const found = view.posAtCoords({ left: clientX, top: clientY })
   if (!found) return null
@@ -104,12 +151,16 @@ function cellContextAt(view: EditorView, clientX: number, clientY: number): Cell
   return { table, tableStart, tablePos, map, rect, cellPos: $cell.pos }
 }
 
-/** State captured at drag start: which axis, the source row/column index, and enough table
- * identity to (a) confirm a drop lands in the SAME table and (b) place the selection back
- * inside the source before running the move command. */
+/** State captured at drag start: which axis, plus enough table/cell identity to (a) confirm a
+ * drop lands in the SAME table and (b) place the selection back inside the source before running
+ * the move command. `cellPos`, `tableStart` and `tablePos` are POSITIONS, remapped through every
+ * transaction that arrives during the drag (see the plugin `state.apply`), so they survive
+ * concurrent remote edits. The source row/column INDEX is intentionally NOT stored: it is
+ * re-derived from the (remapped) `cellPos` via `resolveDragSource` at hover/drop time, so a
+ * collaborator changing the grid above the dragged row/column can never leave us moving a stale
+ * index (octo-docs-backend#76 review fix). */
 interface DragState {
   kind: 'row' | 'col'
-  index: number
   tableStart: number
   tablePos: number
   cellPos: number
@@ -175,8 +226,18 @@ export const TableReorderHandle = Extension.create({
     // a higher index lands AFTER it. A drop on the source itself shows nothing (it's a no-op).
     const showIndicator = (view: EditorView, ctx: CellContext) => {
       if (!indicator || !drag) return
+      // Re-derive the source index from the (remapped) cellPos against the CURRENT doc, so a
+      // concurrent remote insert/delete above the dragged row/column shifts the caret and the
+      // drop-direction test onto the row/column the user actually grabbed.
+      const source = resolveDragSource(view.state.doc, drag.cellPos)
+      if (!source) {
+        dropIndex = null
+        hideIndicator()
+        return
+      }
+      const srcIndex = drag.kind === 'col' ? source.rect.left : source.rect.top
       const hovered = drag.kind === 'col' ? ctx.rect.left : ctx.rect.top
-      if (hovered === drag.index) {
+      if (hovered === srcIndex) {
         dropIndex = null
         hideIndicator()
         return
@@ -187,7 +248,7 @@ export const TableReorderHandle = Extension.create({
       const base = (view.dom as HTMLElement).getBoundingClientRect()
       const cell = cellDom.getBoundingClientRect()
       const table = tableDom.getBoundingClientRect()
-      const before = hovered < drag.index
+      const before = hovered < srcIndex
 
       indicator.style.display = 'block'
       if (drag.kind === 'col') {
@@ -211,25 +272,38 @@ export const TableReorderHandle = Extension.create({
     // source row/column — a pure selection change (no doc edit, so y-prosemirror ignores it) —
     // then dispatch the single-transaction move on the updated state.
     const runMove = (view: EditorView) => {
-      if (!drag || dropIndex == null || dropIndex === drag.index) {
+      if (!drag || dropIndex == null) {
         reorderDebug({ phase: 'drop', dispatched: false, reason: 'no valid target', drag, dropIndex })
         return
       }
-      const { doc } = view.state
-      if (drag.cellPos + 1 > doc.content.size) return
+      // Re-resolve the source cell against the CURRENT doc from its remapped position, then take
+      // the move's `from` from the live grid rect — never the drag-start index. Under concurrent
+      // collaboration a remote peer may have inserted/deleted rows or columns above the dragged
+      // one during the drag; the stale index would move the wrong row/column, but the remapped
+      // cellPos still identifies the original cell (octo-docs-backend#76 review fix).
+      const source = resolveDragSource(view.state.doc, drag.cellPos)
+      if (!source) {
+        reorderDebug({ phase: 'drop', dispatched: false, reason: 'source no longer resolves', drag, dropIndex })
+        return
+      }
+      const fromIndex = drag.kind === 'col' ? source.rect.left : source.rect.top
+      if (dropIndex === fromIndex) {
+        reorderDebug({ phase: 'drop', dispatched: false, reason: 'no-op (same index)', from: fromIndex, dropIndex })
+        return
+      }
       let $inside
       try {
-        $inside = doc.resolve(drag.cellPos + 1)
+        $inside = view.state.doc.resolve(source.cellPos + 1)
       } catch {
         return
       }
       view.dispatch(view.state.tr.setSelection(TextSelection.near($inside)))
       const command =
         drag.kind === 'col'
-          ? moveTableColumn({ from: drag.index, to: dropIndex })
-          : moveTableRow({ from: drag.index, to: dropIndex })
+          ? moveTableColumn({ from: fromIndex, to: dropIndex })
+          : moveTableRow({ from: fromIndex, to: dropIndex })
       const dispatched = command(view.state, view.dispatch)
-      reorderDebug({ phase: 'dispatch', kind: drag.kind, from: drag.index, to: dropIndex, dispatched })
+      reorderDebug({ phase: 'dispatch', kind: drag.kind, from: fromIndex, to: dropIndex, dispatched })
       view.focus()
     }
 
@@ -299,12 +373,11 @@ export const TableReorderHandle = Extension.create({
       event.preventDefault()
       drag = {
         kind,
-        index: kind === 'col' ? hover.rect.left : hover.rect.top,
         tableStart: hover.tableStart,
         tablePos: hover.tablePos,
         cellPos: hover.cellPos,
       }
-      reorderDebug({ phase: 'begin', kind, index: drag.index })
+      reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
       dropIndex = null
       activeView = view
       document.body.classList.add('octo-table-reordering')
@@ -315,6 +388,26 @@ export const TableReorderHandle = Extension.create({
     return [
       new Plugin({
         key: tableReorderPluginKey,
+        // Keep an in-flight drag's captured positions valid across every transaction that lands
+        // during the drag — crucially the REMOTE ones y-prosemirror applies for collaborators.
+        // Mapping `cellPos`/`tablePos`/`tableStart` through `tr.mapping` means a peer inserting or
+        // deleting rows/columns above the dragged one shifts our anchors with the document, so the
+        // drop still targets the original row/column (octo-docs-backend#76 review fix). This state
+        // holds no value of its own; it exists only for the mapping side effect on the drag anchor.
+        state: {
+          init: () => null,
+          apply: (tr) => {
+            if (drag && tr.docChanged) {
+              drag = {
+                ...drag,
+                cellPos: tr.mapping.map(drag.cellPos),
+                tablePos: tr.mapping.map(drag.tablePos),
+                tableStart: tr.mapping.map(drag.tableStart),
+              }
+            }
+            return null
+          },
+        },
         view(view) {
           const wrapper = view.dom.parentElement
           rowHandle = document.createElement('div')

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -298,6 +298,14 @@ export const TableReorderHandle = Extension.create({
     let dragBaseline: string | null = null
     let dragBaselineCount = 0
     let concurrentEdit = false
+    // Latches true once we have seen a mid-drag mousemove that actually reports the primary button
+    // held (`buttons & 1`). It gates the "released outside the window" abort below: that abort must
+    // only fire on a genuine release, i.e. AFTER the button was observed down. Some event sources
+    // deliver a drag whose moves never set `buttons` (a synthetic MouseEvent built without it, a raw
+    // CDP `Input.dispatchMouseEvent` that omits the field) — those report `buttons === 0` for the
+    // whole drag even though a real button is logically down, and treating the first such move as a
+    // release wrongly cancelled the reorder (octo-docs-backend#76 / XIN-1215 headed-Chromium repro).
+    let pointerHeldSeen = false
 
     const hideHandles = () => {
       if (rowHandle) rowHandle.style.display = 'none'
@@ -454,6 +462,7 @@ export const TableReorderHandle = Extension.create({
       dragBaseline = null
       dragBaselineCount = 0
       concurrentEdit = false
+      pointerHeldSeen = false
       document.body.classList.remove('octo-table-reordering')
       hideIndicator()
       hideHandles()
@@ -488,7 +497,18 @@ export const TableReorderHandle = Extension.create({
       // re-enters. Treat it as an interruption, NOT a drop: abort with zero dispatch. Without this
       // the drag stays armed and the NEXT stray mouseup would wrongly commit the reorder — the
       // "interrupted drag still reordered the table" defect (octo-docs-backend#76 FAIL-1).
-      if (event.buttons === 0) {
+      //
+      // Gate this on `pointerHeldSeen`: only abort once a mid-drag move has actually reported the
+      // button held. A drag whose moves never carry `buttons` (a hand-built MouseEvent, a raw CDP
+      // mouse event that omits the field) reports `buttons === 0` throughout even though the button
+      // is logically down; without the gate the very first such move cancelled a perfectly good
+      // reorder — which is exactly what made the handle look "unusable" under headed-Chromium
+      // automation while a real held-button drag (buttons === 1) worked (octo-docs-backend#76 /
+      // XIN-1215). A genuine release is always preceded by at least one held move, so the gate keeps
+      // FAIL-1 intact.
+      if ((event.buttons & 1) !== 0) {
+        pointerHeldSeen = true
+      } else if (pointerHeldSeen) {
         cancelDrag()
         return
       }
@@ -563,6 +583,7 @@ export const TableReorderHandle = Extension.create({
       dragBaseline = tableStructureSignature(view.state.doc, hover.cellPos)
       dragBaselineCount = dragBaseline === null ? 0 : countTableSignature(view.state.doc, dragBaseline)
       concurrentEdit = false
+      pointerHeldSeen = false
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
       dropIndex = null
       activeView = view
@@ -654,6 +675,7 @@ export const TableReorderHandle = Extension.create({
               dragBaseline = null
               dragBaselineCount = 0
               concurrentEdit = false
+              pointerHeldSeen = false
             },
           }
         },

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -26,34 +26,38 @@
 // The handle + drop-indicator are plugin-managed DOM outside the document (like
 // BlockDragHandle), so the mutation observer never sees them as content.
 //
-// Concurrency guard (plan B, octo-docs-backend#76 / XIN-1187). The reorder command rebuilds the
-// whole table with a single coarse `tr.replaceWith`. TableReorderConcurrency.test.ts shows the
-// real hazard: two whole-table replaces that land concurrently (a remote reorder, or a remote
+// Concurrency guard (octo-docs-backend#76 / XIN-1187 plan B, reworked in XIN-1225). The reorder command
+// rebuilds the whole table with a single coarse `tr.replaceWith`. TableReorderConcurrency.test.ts shows
+// the real hazard: two whole-table replaces that land concurrently (a remote reorder, or a remote
 // add/delete row·column / merge·split racing our drag) DO converge in the CRDT, but y-prosemirror
 // re-diffs each replace against the base and interleaves cell text — the peers agree on a GARBLED
-// table, i.e. silent data loss. The fine-grained fix (plan A) is scheduled separately; plan B is a
-// serialize-or-abort guard layered on top: if any transaction that arrives DURING the drag changes
-// the DRAGGED table (structure or cell content), we ABORT the reorder instead of committing the
-// replace — a clear i18n toast tells the user to retry. Aborting is a pure early return before any
-// dispatch, so there is no half-commit and no dirty state; we would rather cancel than silently
-// corrupt.
+// table, i.e. silent data loss. So if a transaction that arrives DURING the drag changes the DRAGGED
+// table, we ABORT the reorder instead of committing the replace — a clear i18n toast tells the user to
+// retry. Aborting is a pure early return before any dispatch, so there is no half-commit and no dirty
+// state; we would rather cancel than silently corrupt.
 //
-// The guard must react to changes of the DRAGGED table ONLY — an edit to prose or to a different
-// table must never cancel the reorder. Two earlier tries got the SCOPE wrong (octo-docs-backend#76
-// FAIL-2, XIN-1206/1221): (1) re-fingerprinting a single remapped cell anchor false-aborted on ANY
-// edit, because a coarse remote ReplaceStep collapses interior positions to a boundary (so the
-// anchor stops resolving even when the table is untouched); (2) counting how many tables still
-// carry the drag-start signature false-aborts as soon as the document holds two byte-identical
-// tables and the OTHER one is edited (the global count drops though the dragged table never moved).
-// Both failure modes come from using a POSITION or a GLOBAL COUNT as a stand-in for table identity.
-// The guard now uses a stable, position-independent identity instead: at drag start it snapshots the
-// ordered signature list of every table plus the dragged table's ORDINAL within it, and it aborts
-// only when the signature at THAT ordinal changes. Position-independent (a ReplaceStep can move the
-// table freely) and twin-safe (an edit to an identical sibling table changes a different ordinal),
-// while a real structural/content change to the dragged table still flips its slot and aborts.
+// The guard must react to changes of the DRAGGED table ONLY — an edit to prose or to a different table
+// (even an identical twin) must never cancel the reorder. Earlier tries got the SCOPE wrong by keying off
+// a remapped cell anchor or a global signature count. XIN-1225 settled it with RUNTIME EVIDENCE rather
+// than another source-level guess: instrumenting `window.__reorderAbortDebug` in a real browser (see
+// dev/run-reorder.mjs) showed that @tiptap/y-tiptap delivers a remote edit — even a one-character prose
+// edit OUTSIDE the table — to the local peer as ONE coarse ReplaceStep spanning (nearly) the whole
+// document. That has two consequences the old attempts fell foul of:
+//   • a literal "does a step's RANGE overlap the table" test can't discriminate (the step covers
+//     everything), and
+//   • any ABSOLUTE position (a remapped cell/table anchor) collapses to the replace boundary — which is
+//     ALSO why the drop silently no-op'd (resolveDragSource returned null) even when the guard allowed the
+//     reorder: that no-op, not only the guard, was the real "TC01/TC02 reorder didn't happen" defect.
+// The only identity that survives a whole-document ReplaceStep is the table's ORDINAL among tables in
+// document order. So both the guard and the drop are anchored to that ordinal (captured at drag start):
+// the guard aborts only when the dragged table's signature AT ITS ORDINAL changes (twin-safe — an
+// identical sibling is a different ordinal), and the drop resolves the source row/column by ordinal +
+// the drag-start index (valid because any structural change to the dragged table aborts first). See
+// `analyzeDraggedTableConflict` and `resolveDragSourceByOrdinal`.
 
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import type { Transaction } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import { TableMap, cellAround, moveTableColumn, moveTableRow } from '@tiptap/pm/tables'
 import type { Node as PMNode } from '@tiptap/pm/model'
@@ -74,6 +78,29 @@ interface ReorderDebugEvent {
 function reorderDebug(event: ReorderDebugEvent): void {
   if (typeof window === 'undefined') return
   const sink = (window as unknown as { __tableReorderDebug?: ReorderDebugEvent[] }).__tableReorderDebug
+  if (Array.isArray(sink)) sink.push(event)
+}
+
+// Opt-in runtime tracing for the CONCURRENCY GUARD specifically (octo-docs-backend#76 / XIN-1225). The
+// signature-by-ordinal guard kept passing its jsdom unit tests while real-browser TC01 (prose edit
+// outside the table) and TC02 (edit of an identical second table) STILL false-aborted the reorder — a
+// runtime-only divergence a source read could not settle. This hook records, for every transaction that
+// lands during a drag, what the step-range decision actually saw: the dragged table's node range, each
+// step's changed range, whether any step fell inside the dragged table, whether that table's structure
+// signature changed, and the resulting abort decision + reason. Inert and zero-cost unless a page opts
+// in with `window.__reorderAbortDebug = []` before dragging. This is the "instrument, don't infer"
+// evidence base the rework was gated on.
+interface ReorderAbortDebugEvent {
+  tableRange: { from: number; to: number } | null
+  steps: { type: string; ranges: [number, number][] }[]
+  touched: boolean
+  signatureChanged: boolean | null
+  conflict: boolean
+  reason: string
+}
+function reorderAbortDebug(event: ReorderAbortDebugEvent): void {
+  if (typeof window === 'undefined') return
+  const sink = (window as unknown as { __reorderAbortDebug?: ReorderAbortDebugEvent[] }).__reorderAbortDebug
   if (Array.isArray(sink)) sink.push(event)
 }
 
@@ -183,6 +210,163 @@ export function signatureOfTable(table: PMNode): string | null {
     }
   }
   return parts.join('|')
+}
+
+// ────────────────────────────────────────────────────────────────────────────────────────────────
+// Step-range concurrency detection (octo-docs-backend#76 / XIN-1225 — replaces the signature-by-ordinal
+// guard). The rule the acceptance criteria pin down: a concurrent reorder is aborted ONLY when a
+// transaction that lands during the drag actually MODIFIES THE DRAGGED TABLE'S OWN NODE RANGE. An edit to
+// prose, or to a different table (even a byte-identical twin), never touches that range, so it can never
+// abort — that is TC01/TC02 by construction, with no dependence on table ordinals, a global signature
+// count, or a remapped cell anchor (all three of which false-aborted before: an ordinal/count is
+// ambiguous with twin tables and shifts on any concurrent table add/delete, and a coarse y-tiptap
+// ReplaceStep collapses a remapped interior anchor to a boundary). Here we work in the OLD document's
+// coordinate space, where the dragged table's range is exactly known, and ask a direct question of the
+// transaction's steps.
+
+/** The dragged table node's position range in `doc`. `tablePos` is the position just BEFORE the table
+ * node (what `beginDrag` captures and the plugin remaps each transaction). Returns `{ from, to }` with
+ * `from` = tablePos and `to` = tablePos + nodeSize (one past the table's closing token), or null when
+ * the position no longer resolves to a table node. */
+export function tableNodeRange(doc: PMNode, tablePos: number): { from: number; to: number } | null {
+  if (tablePos < 0 || tablePos >= doc.content.size) return null
+  const node = doc.nodeAt(tablePos)
+  if (!node || node.type.spec.tableRole !== 'table') return null
+  return { from: tablePos, to: tablePos + node.nodeSize }
+}
+
+/** Does any step in `tr` modify content strictly INSIDE the range `[from, to)` of the document BEFORE
+ * `tr` was applied? Each step's changed span is read from its own StepMap in that step's coordinate
+ * space, and the table range is mapped forward through the PRIOR steps (`tr.mapping.slice(0, i)`) so both
+ * are compared in the same space — a transaction can carry several steps. The overlap test is strict
+ * interior (`start < to && end > from`), so an edit that merely abuts the table (an insertion exactly at
+ * the boundary before/after it — e.g. typing in the paragraph immediately adjacent) does NOT count, only
+ * an edit that lands within the table. Also collects each step's ranges + type for the debug hook. */
+export function stepsTouchRange(
+  tr: Transaction,
+  from: number,
+  to: number,
+): { touched: boolean; steps: { type: string; ranges: [number, number][] }[] } {
+  const steps: { type: string; ranges: [number, number][] }[] = []
+  let touched = false
+  for (let i = 0; i < tr.steps.length; i++) {
+    const prior = tr.mapping.slice(0, i)
+    const iFrom = prior.map(from, -1)
+    const iTo = prior.map(to, 1)
+    const ranges: [number, number][] = []
+    tr.mapping.maps[i].forEach((s: number, e: number) => {
+      ranges.push([s, e])
+      if (s < iTo && e > iFrom) touched = true
+    })
+    steps.push({ type: tr.steps[i].constructor.name, ranges })
+  }
+  return { touched, steps }
+}
+
+/** The concurrency decision for one mid-drag transaction, scoped to the DRAGGED table only.
+ *
+ * RUNTIME EVIDENCE (octo-docs-backend#76 / XIN-1225, `window.__reorderAbortDebug`): a remote edit —
+ * even a one-character prose edit OUTSIDE the table — arrives on the local peer as a single COARSE
+ * ReplaceStep spanning (almost) the whole document, because @tiptap/y-tiptap re-renders the changed
+ * XmlFragment wholesale. That has two consequences the earlier attempts missed:
+ *   • a literal "does a step's RANGE overlap the table" test is useless — the step covers everything,
+ *     so it can never separate an inside-table edit from an outside one; and
+ *   • any ABSOLUTE position (a remapped cell/table anchor) collapses to the replace boundary, so it
+ *     can no longer locate the dragged table.
+ * The only identity that survives a whole-document ReplaceStep is the table's ORDINAL among tables in
+ * document order (the tree order is preserved). So we decide the conflict by comparing the dragged
+ * table's signature AT ITS ORDINAL against the drag-start baseline: an edit to prose or to another
+ * table (even an identical twin — a different ordinal) leaves that slot byte-identical and never
+ * aborts (TC01/TC02), while a real reorder / add·delete row·column / merge·split / cell edit on the
+ * dragged table itself flips its slot and aborts (TC03, data-safety). A change in the table COUNT
+ * means the ordinals no longer align, so we abort conservatively (rare concurrent table add/delete).
+ *
+ * `stepsTouchRange` is still evaluated — it is an exact FAST PATH for the fine-grained case (a local
+ * or non-coarse transaction whose steps provably miss the table's range is benign without a full
+ * signature scan) and the evidence recorded by the debug hook — but it is never the sole decider,
+ * precisely because the observed remote steps are coarse. */
+export function analyzeDraggedTableConflict(
+  tr: Transaction,
+  oldDoc: PMNode,
+  newDoc: PMNode,
+  oldTablePos: number,
+  dragOrdinal: number,
+  baselineSigs: (string | null)[],
+): ReorderAbortDebugEvent {
+  const range = tableNodeRange(oldDoc, oldTablePos)
+  const { touched, steps } = range
+    ? stepsTouchRange(tr, range.from, range.to)
+    : { touched: true, steps: stepsTouchRange(tr, 0, 0).steps }
+  // Fast path: a fine-grained transaction whose steps all miss the dragged table's range cannot have
+  // changed it. (Remote edits are coarse and take the ordinal path below.)
+  if (range && !touched) {
+    return { tableRange: range, steps, touched: false, signatureChanged: null, conflict: false, reason: 'no step inside dragged table range — benign (fine-grained outside edit)' }
+  }
+  // Ordinal path: compare the dragged table's signature at its stable ordinal. Coarse-ReplaceStep-proof.
+  const baselineSig = dragOrdinal >= 0 && dragOrdinal < baselineSigs.length ? baselineSigs[dragOrdinal] : null
+  if (baselineSig === null) {
+    return { tableRange: range, steps, touched, signatureChanged: null, conflict: false, reason: 'no drag-start signature for dragged table — guard disabled' }
+  }
+  const nowSigs = tableSignatures(newDoc)
+  if (nowSigs.length !== baselineSigs.length) {
+    return { tableRange: range, steps, touched, signatureChanged: true, conflict: true, reason: 'table count changed mid-drag — ordinals unaligned, abort (data-safe)' }
+  }
+  const changed = nowSigs[dragOrdinal] !== baselineSig
+  return {
+    tableRange: range,
+    steps,
+    touched,
+    signatureChanged: changed,
+    conflict: changed,
+    reason: changed
+      ? 'dragged table (by ordinal) changed structure/content — abort (data-safe)'
+      : 'dragged table (by ordinal) unchanged — benign (outside/other-table edit)',
+  }
+}
+
+/** Locate the DRAGGED table by its drag-start ORDINAL among tables in `doc` and resolve the source
+ * row/column's live cell position + grid rect. This is the coarse-ReplaceStep-proof replacement for
+ * position-remapped source resolution: the whole-document ReplaceStep y-tiptap emits for a remote edit
+ * collapses any absolute cell/table anchor, but the table's ordinal is stable, and the source row/column
+ * INDEX captured at drag start stays valid because ANY structural change to the dragged table aborts the
+ * drag (see the guard) — so if we reach a drop, the dragged table's grid is exactly as it was. Returns
+ * null when the ordinal no longer resolves to a table or the source index is out of range. */
+export function resolveDragSourceByOrdinal(
+  doc: PMNode,
+  ordinal: number,
+  kind: 'row' | 'col',
+  sourceIndex: number,
+): { tableStart: number; tablePos: number; rect: { left: number; top: number; right: number; bottom: number }; cellPos: number } | null {
+  if (ordinal < 0) return null
+  let seen = 0
+  let found: { node: PMNode; pos: number } | null = null
+  doc.descendants((node, pos) => {
+    if (node.type.spec.tableRole === 'table') {
+      if (seen === ordinal) found = { node, pos }
+      seen++
+      return false // tables don't nest
+    }
+    return true
+  })
+  if (!found) return null
+  const { node, pos } = found
+  let map: TableMap
+  try {
+    map = TableMap.get(node)
+  } catch {
+    return null
+  }
+  if (kind === 'row' ? sourceIndex >= map.height : sourceIndex >= map.width) return null
+  const row = kind === 'row' ? sourceIndex : 0
+  const col = kind === 'col' ? sourceIndex : 0
+  const cellRel = map.map[row * map.width + col]
+  let rect
+  try {
+    rect = map.findCell(cellRel)
+  } catch {
+    return null
+  }
+  return { tableStart: pos + 1, tablePos: pos, rect, cellPos: pos + 1 + cellRel }
 }
 
 /** Fingerprint of the table that contains `cellPos`. Used at drag start to snapshot the dragged
@@ -346,11 +530,19 @@ function cellContextAt(view: EditorView, clientX: number, clientY: number): Cell
  * re-derived from the (remapped) `cellPos` via `resolveDragSource` at hover/drop time, so a
  * collaborator changing the grid above the dragged row/column can never leave us moving a stale
  * index (octo-docs-backend#76 review fix). */
+/** State captured at drag start. Identity is anchored to survive the coarse whole-document ReplaceStep
+ * that y-tiptap emits for a remote edit (which collapses any absolute position): `ordinal` is the dragged
+ * table's index among tables in document order, and `sourceIndex` is the row/column being dragged. Both
+ * are position-independent, so the drop still targets the right row/column after a concurrent remote edit
+ * — and they stay valid because ANY structural change to the dragged table aborts the drag (the guard),
+ * so if we reach a drop the dragged table's grid is exactly as it was at drag start. Source resolution,
+ * the probe clamp and the move all re-derive the table's live position from `ordinal` (see
+ * `resolveDragSourceByOrdinal`); nothing here stores an absolute position that a ReplaceStep could
+ * collapse. */
 interface DragState {
   kind: 'row' | 'col'
-  tableStart: number
-  tablePos: number
-  cellPos: number
+  ordinal: number
+  sourceIndex: number
 }
 
 /** Table row/column reorder extension. */
@@ -367,19 +559,22 @@ export const TableReorderHandle = Extension.create({
     let drag: DragState | null = null
     // Resolved drop target row/column index during a drag (null = no valid target yet).
     let dropIndex: number | null = null
-    // Plan-B concurrency guard. `dragBaselineSigs` is the ordered signature of every table at drag
-    // start and `dragTableIndex` the dragged table's ordinal within it — together a stable,
-    // position-independent identity for the dragged table (see `draggedTableConflict`).
-    // `concurrentEdit` latches true when a transaction landing during the drag changes the signature
-    // at that ordinal — i.e. the dragged table's own structure/content changed (a remote reorder /
-    // add·delete row·column / merge·split / cell edit on THAT table), or a whole table was added/
-    // deleted so the ordinals no longer align (see the plugin `state.apply`). Edits to prose or to a
-    // different table (even an identical twin) leave that slot unchanged, so they never latch. When
-    // latched, `runMove` aborts the reorder rather than committing a whole-table replace that would
+    // Concurrency guard (octo-docs-backend#76 / XIN-1225). `concurrentEdit` latches true when a
+    // transaction landing during the drag changes the DRAGGED table's own structure/content — a remote
+    // reorder / add·delete row·column / merge·split / cell edit on THAT table (see the plugin
+    // `state.apply`, which drives the decision through `analyzeDraggedTableConflict`). Runtime evidence
+    // (`window.__reorderAbortDebug`) showed remote edits arrive as ONE coarse whole-document ReplaceStep,
+    // so the dragged table is pinned by its stable ORDINAL (drag.ordinal) and compared against the
+    // drag-start signature list `dragBaselineSigs`; an edit to prose or to another table (even an
+    // identical twin, a different ordinal) leaves the dragged slot byte-identical and never latches.
+    // When latched, `runMove` aborts the reorder rather than committing a whole-table replace that would
     // silently corrupt against the concurrent edit.
-    let dragBaselineSigs: (string | null)[] | null = null
-    let dragTableIndex = -1
     let concurrentEdit = false
+    let dragBaselineSigs: (string | null)[] = []
+    // True only while WE dispatch the reorder move itself, so the guard below does not mistake our own
+    // whole-table replace for a concurrent remote conflict (the local move lands while `drag` is still
+    // set, and it obviously changes the dragged table).
+    let committing = false
     // Latches true once we have seen a mid-drag mousemove that actually reports the primary button
     // held (`buttons & 1`). It gates the "released outside the window" abort below: that abort must
     // only fire on a genuine release, i.e. AFTER the button was observed down. Some event sources
@@ -434,16 +629,11 @@ export const TableReorderHandle = Extension.create({
     // a higher index lands AFTER it. A drop on the source itself shows nothing (it's a no-op).
     const showIndicator = (view: EditorView, ctx: CellContext) => {
       if (!indicator || !drag) return
-      // Re-derive the source index from the (remapped) cellPos against the CURRENT doc, so a
-      // concurrent remote insert/delete above the dragged row/column shifts the caret and the
-      // drop-direction test onto the row/column the user actually grabbed.
-      const source = resolveDragSource(view.state.doc, drag.cellPos)
-      if (!source) {
-        dropIndex = null
-        hideIndicator()
-        return
-      }
-      const srcIndex = drag.kind === 'col' ? source.rect.left : source.rect.top
+      // The source row/column index is fixed at drag start (`drag.sourceIndex`) and stays valid: any
+      // structural change to the dragged table aborts the drag, so while a drop is still possible the
+      // grid is unchanged. This is coarse-ReplaceStep-proof — unlike re-deriving it from a remapped
+      // cellPos, which a whole-document remote ReplaceStep collapses (octo-docs-backend#76 XIN-1225).
+      const srcIndex = drag.sourceIndex
       const hovered = drag.kind === 'col' ? ctx.rect.left : ctx.rect.top
       if (hovered === srcIndex) {
         dropIndex = null
@@ -492,12 +682,14 @@ export const TableReorderHandle = Extension.create({
         notifyReorderConflict()
         return
       }
-      // Re-resolve the source cell against the CURRENT doc from its remapped position, then take
-      // the move's `from` from the live grid rect — never the drag-start index. Under concurrent
-      // collaboration a remote peer may have inserted/deleted rows or columns above the dragged
-      // one during the drag; the stale index would move the wrong row/column, but the remapped
-      // cellPos still identifies the original cell (octo-docs-backend#76 review fix).
-      const source = resolveDragSource(view.state.doc, drag.cellPos)
+      // Re-resolve the source cell against the CURRENT doc by the dragged table's stable ORDINAL plus
+      // the drag-start row/column index — NOT a remapped position. Runtime evidence showed remote edits
+      // arrive as a coarse whole-document ReplaceStep that collapses any absolute cell/table anchor, so
+      // the old `resolveDragSource(remapped cellPos)` returned null and the drop silently no-op'd even
+      // when the guard correctly allowed it — the real cause of TC01/TC02 "reorder didn't happen"
+      // (octo-docs-backend#76 XIN-1225). The ordinal survives the ReplaceStep; the source index is valid
+      // because any structural change to the dragged table would have aborted above.
+      const source = resolveDragSourceByOrdinal(view.state.doc, drag.ordinal, drag.kind, drag.sourceIndex)
       if (!source) {
         reorderDebug({ phase: 'drop', dispatched: false, reason: 'source no longer resolves', drag, dropIndex })
         return
@@ -518,7 +710,9 @@ export const TableReorderHandle = Extension.create({
         drag.kind === 'col'
           ? moveTableColumn({ from: fromIndex, to: dropIndex })
           : moveTableRow({ from: fromIndex, to: dropIndex })
+      committing = true
       const dispatched = command(view.state, view.dispatch)
+      committing = false
       reorderDebug({ phase: 'dispatch', kind: drag.kind, from: fromIndex, to: dropIndex, dispatched })
       view.focus()
     }
@@ -541,9 +735,9 @@ export const TableReorderHandle = Extension.create({
     const resetDragState = () => {
       drag = null
       dropIndex = null
-      dragBaselineSigs = null
-      dragTableIndex = -1
       concurrentEdit = false
+      committing = false
+      dragBaselineSigs = []
       pointerHeldSeen = false
       document.body.classList.remove('octo-table-reordering')
       hideIndicator()
@@ -605,14 +799,17 @@ export const TableReorderHandle = Extension.create({
       // over no cell, which is why the column axis was a silent no-op (octo-docs-backend#76 rework).
       let probeX = event.clientX
       let probeY = event.clientY
-      const tableDom = tableElementAt(activeView, drag.tablePos)
+      // Resolve the dragged table's CURRENT position by its stable ordinal (drag.tablePos would be a
+      // drag-start position that a coarse remote ReplaceStep has since invalidated — XIN-1225).
+      const live = resolveDragSourceByOrdinal(activeView.state.doc, drag.ordinal, drag.kind, drag.sourceIndex)
+      const tableDom = live ? tableElementAt(activeView, live.tablePos) : null
       if (tableDom) {
         const t = tableDom.getBoundingClientRect()
         probeX = Math.min(Math.max(probeX, t.left + 1), t.right - 1)
         probeY = Math.min(Math.max(probeY, t.top + 1), t.bottom - 1)
       }
       const ctx = cellContextAt(activeView, probeX, probeY)
-      if (!ctx || ctx.tableStart !== drag.tableStart) {
+      if (!ctx || !live || ctx.tableStart !== live.tableStart) {
         reorderDebug({
           phase: 'move',
           x: event.clientX,
@@ -655,15 +852,13 @@ export const TableReorderHandle = Extension.create({
       event.preventDefault()
       drag = {
         kind,
-        tableStart: hover.tableStart,
-        tablePos: hover.tablePos,
-        cellPos: hover.cellPos,
+        // Stable, coarse-ReplaceStep-proof identity for the dragged table + source line.
+        ordinal: draggedTableIndex(view.state.doc, hover.cellPos),
+        sourceIndex: kind === 'col' ? hover.rect.left : hover.rect.top,
       }
-      // Snapshot the dragged table's stable identity so the plan-B guard can detect a concurrent
-      // edit to it during the drag: the ordered signature of every table plus the dragged table's
-      // ordinal within that list. Reset the latch for this fresh drag.
+      // Snapshot every table's signature so the guard can compare the dragged table's slot (by ordinal)
+      // against it on each mid-drag transaction. Reset the latch for this fresh drag.
       dragBaselineSigs = tableSignatures(view.state.doc)
-      dragTableIndex = draggedTableIndex(view.state.doc, hover.cellPos)
       concurrentEdit = false
       pointerHeldSeen = false
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
@@ -680,36 +875,36 @@ export const TableReorderHandle = Extension.create({
     return [
       new Plugin({
         key: tableReorderPluginKey,
-        // Keep an in-flight drag's captured positions valid across every transaction that lands
-        // during the drag — crucially the REMOTE ones y-prosemirror applies for collaborators.
-        // Mapping `cellPos`/`tablePos`/`tableStart` through `tr.mapping` means a peer inserting or
-        // deleting rows/columns above the dragged one shifts our anchors with the document, so the
-        // drop still targets the original row/column (octo-docs-backend#76 review fix). This state
-        // holds no value of its own; it exists only for the mapping side effect on the drag anchor.
+        // Detect a concurrent edit to the DRAGGED table on every transaction that lands during the drag
+        // — crucially the REMOTE ones y-prosemirror applies for collaborators. The dragged table is
+        // pinned by its stable ORDINAL (drag.ordinal), which survives the coarse whole-document
+        // ReplaceStep y-tiptap emits for a remote edit; source resolution and the move also key off that
+        // ordinal + drag.sourceIndex, so no absolute position needs remapping here (octo-docs-backend#76
+        // XIN-1225). This plugin state holds no value of its own; it exists only for the guard side
+        // effect on each transaction.
         state: {
           init: () => null,
-          apply: (tr, _value, _oldState, newState) => {
-            if (drag && tr.docChanged) {
-              drag = {
-                ...drag,
-                cellPos: tr.mapping.map(drag.cellPos),
-                tablePos: tr.mapping.map(drag.tablePos),
-                tableStart: tr.mapping.map(drag.tableStart),
-              }
-              // Plan-B conflict detection, scoped to the dragged table only by STABLE IDENTITY.
-              // Re-select the dragged table by its drag-start ordinal and compare its signature to
-              // the baseline; a change means the dragged table's own structure/content changed (or
-              // the table set changed) — latch a conflict so `runMove` aborts. This is fully
-              // position-independent, so it does NOT depend on the remapped `cellPos`/`tablePos`
-              // (which a coarse y-prosemirror ReplaceStep collapses to a boundary even when the table
-              // is untouched) — that anchor drift, and the earlier global-count heuristic that
-              // false-aborted whenever an identical twin table was edited, are exactly what made
-              // edits OUTSIDE the dragged table cancel the reorder before (octo-docs-backend#76
-              // FAIL-2 / XIN-1221). Benign edits to prose or another table leave that slot unchanged,
-              // so the latch stays clear.
-              if (!concurrentEdit && dragBaselineSigs !== null) {
-                if (draggedTableConflict(newState.doc, dragBaselineSigs, dragTableIndex)) concurrentEdit = true
-              }
+          apply: (tr, _value, oldState, newState) => {
+            if (drag && tr.docChanged && !concurrentEdit && !committing) {
+              // Compare the dragged table's signature at its drag-start ordinal against the baseline.
+              // An edit to prose or another table (even an identical twin — a different ordinal) leaves
+              // that slot byte-identical and never aborts (real-browser TC01/TC02); a reorder / add·
+              // delete row·column / merge·split / cell edit on the dragged table itself flips it and
+              // aborts (TC03, data-safety). `stepsTouchRange` inside is an exact fast path for the
+              // fine-grained case + the `window.__reorderAbortDebug` evidence trail; it needs the
+              // dragged table's CURRENT position (by ordinal) in the pre-transaction doc, not a
+              // drag-start position a prior coarse ReplaceStep may have invalidated.
+              const liveOld = resolveDragSourceByOrdinal(oldState.doc, drag.ordinal, drag.kind, drag.sourceIndex)
+              const decision = analyzeDraggedTableConflict(
+                tr,
+                oldState.doc,
+                newState.doc,
+                liveOld ? liveOld.tablePos : -1,
+                drag.ordinal,
+                dragBaselineSigs,
+              )
+              reorderAbortDebug(decision)
+              if (decision.conflict) concurrentEdit = true
             }
             return null
           },
@@ -757,8 +952,6 @@ export const TableReorderHandle = Extension.create({
               rowHandle = colHandle = indicator = null
               activeView = null
               drag = null
-              dragBaselineSigs = null
-              dragTableIndex = -1
               concurrentEdit = false
               pointerHeldSeen = false
             },

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -142,33 +142,13 @@ export function resolveDragSource(
   }
 }
 
-/** Fingerprint of the table that contains `cellPos`, used by the plan-B concurrency guard to tell
- * whether a transaction arriving mid-drag changed the dragged table. The signature folds in exactly
- * the things a corrupting concurrent edit would move: the grid dimensions (add/delete row·column),
- * each cell's colspan/rowspan (merge·split) and each cell's text in grid order (a remote reorder
- * reshuffles the text, a concurrent cell edit rewrites it). Anything OUTSIDE this table — edits to
- * other tables or prose — leaves the signature untouched, so the guard only fires on same-table
- * races. Returns null when `cellPos` no longer resolves to a table cell (e.g. a peer deleted it),
- * which the guard also treats as a conflict. Deliberately conservative: any same-table change aborts
- * the reorder, because the coarse whole-table replace can silently corrupt against any of them until
- * the fine-grained plan-A move lands. */
-export function tableStructureSignature(doc: PMNode, cellPos: number): string | null {
-  if (cellPos < 0 || cellPos + 1 > doc.content.size) return null
-  let $inside
-  try {
-    $inside = doc.resolve(cellPos + 1)
-  } catch {
-    return null
-  }
-  let depth = -1
-  for (let d = $inside.depth; d > 0; d--) {
-    if ($inside.node(d).type.spec.tableRole === 'table') {
-      depth = d
-      break
-    }
-  }
-  if (depth < 0) return null
-  const table = $inside.node(depth)
+/** Fingerprint of a single table NODE. Folds in exactly the things a corrupting concurrent edit
+ * would move: the grid dimensions (add/delete row·column), each cell's colspan/rowspan (merge·split)
+ * and each cell's text in grid order (a remote reorder reshuffles the text, a concurrent cell edit
+ * rewrites it). Returns null when the node isn't a laid-out table. Keyed only off the node's own
+ * content, so it is independent of the node's document position — see `countTableSignature`. */
+export function signatureOfTable(table: PMNode): string | null {
+  if (table.type.spec.tableRole !== 'table') return null
   let map: TableMap
   try {
     map = TableMap.get(table)
@@ -189,6 +169,59 @@ export function tableStructureSignature(doc: PMNode, cellPos: number): string | 
     }
   }
   return parts.join('|')
+}
+
+/** Fingerprint of the table that contains `cellPos`. Used at drag start to snapshot the dragged
+ * table's structure (the plan-B baseline). Returns null when `cellPos` no longer resolves to a
+ * table cell. Thin wrapper over `signatureOfTable` that first locates the enclosing table. */
+export function tableStructureSignature(doc: PMNode, cellPos: number): string | null {
+  if (cellPos < 0 || cellPos + 1 > doc.content.size) return null
+  let $inside
+  try {
+    $inside = doc.resolve(cellPos + 1)
+  } catch {
+    return null
+  }
+  let depth = -1
+  for (let d = $inside.depth; d > 0; d--) {
+    if ($inside.node(d).type.spec.tableRole === 'table') {
+      depth = d
+      break
+    }
+  }
+  if (depth < 0) return null
+  return signatureOfTable($inside.node(depth))
+}
+
+/** How many tables in `doc` currently have structure signature `sig`. The plan-B guard uses this
+ * instead of re-fingerprinting a single remapped anchor. WHY: under real collaboration y-prosemirror
+ * applies a remote update as one coarse `ReplaceStep`, and mapping an interior anchor (the dragged
+ * cell) through that replace collapses it to the replace boundary — so the anchor no longer resolves
+ * to its cell even when the dragged table is UNTOUCHED, and the old anchor+null==conflict check then
+ * false-aborted on any edit elsewhere in the doc (octo-docs-backend#76 FAIL-2). Counting tables that
+ * still carry the drag-start signature is position-independent, so an edit to OTHER tables or prose
+ * leaves the count unchanged, while a structural change to the dragged table drops it. */
+export function countTableSignature(doc: PMNode, sig: string): number {
+  let n = 0
+  doc.descendants((node) => {
+    if (node.type.spec.tableRole === 'table') {
+      if (signatureOfTable(node) === sig) n++
+      return false // tables don't nest; don't descend
+    }
+    return true
+  })
+  return n
+}
+
+/** Plan-B conflict decision, scoped to the DRAGGED table only. `baselineSig` is the dragged table's
+ * signature at drag start and `baselineCount` how many tables shared it then. A conflict is latched
+ * only when the number of tables carrying that signature DROPS — i.e. the dragged table's structure
+ * (or content) actually changed, or it was deleted. Concurrent edits to other tables or to prose
+ * leave the dragged table's signature present, so they no longer trigger a false abort. A null
+ * baseline (drag never fingerprinted a table) disables the guard rather than aborting blindly. */
+export function draggedTableConflict(doc: PMNode, baselineSig: string | null, baselineCount: number): boolean {
+  if (baselineSig === null) return false
+  return countTableSignature(doc, baselineSig) < baselineCount
 }
 
 /** Transient, document-external toast telling the user their reorder was cancelled because a
@@ -256,11 +289,14 @@ export const TableReorderHandle = Extension.create({
     // Resolved drop target row/column index during a drag (null = no valid target yet).
     let dropIndex: number | null = null
     // Plan-B concurrency guard. `dragBaseline` is the dragged table's structure signature captured
-    // at drag start; `concurrentEdit` latches true when any transaction that lands during the drag
-    // changes that table (a remote reorder / add·delete row·column / merge·split / cell edit — see
-    // the plugin `state.apply`). When latched, `runMove` aborts the reorder rather than committing a
-    // whole-table replace that would silently corrupt against the concurrent edit.
+    // at drag start and `dragBaselineCount` how many tables shared it then; `concurrentEdit` latches
+    // true when a transaction landing during the drag drops that count — i.e. the dragged table's own
+    // structure/content changed (a remote reorder / add·delete row·column / merge·split / cell edit
+    // on THAT table — see the plugin `state.apply`). Edits to other tables or prose leave the count
+    // unchanged, so they never latch. When latched, `runMove` aborts the reorder rather than
+    // committing a whole-table replace that would silently corrupt against the concurrent edit.
     let dragBaseline: string | null = null
+    let dragBaselineCount = 0
     let concurrentEdit = false
 
     const hideHandles = () => {
@@ -416,6 +452,7 @@ export const TableReorderHandle = Extension.create({
       drag = null
       dropIndex = null
       dragBaseline = null
+      dragBaselineCount = 0
       concurrentEdit = false
       document.body.classList.remove('octo-table-reordering')
       hideIndicator()
@@ -445,6 +482,16 @@ export const TableReorderHandle = Extension.create({
     let activeView: EditorView | null = null
     const onDocMove = (event: MouseEvent) => {
       if (!drag || !activeView) return
+      // The primary button was released while we could not see it — the classic "let go outside the
+      // window" interruption: the pointer left the window mid-drag, the mouseup fired over another
+      // app (so our document `mouseup` listener never ran), and the button is now up as the pointer
+      // re-enters. Treat it as an interruption, NOT a drop: abort with zero dispatch. Without this
+      // the drag stays armed and the NEXT stray mouseup would wrongly commit the reorder — the
+      // "interrupted drag still reordered the table" defect (octo-docs-backend#76 FAIL-1).
+      if (event.buttons === 0) {
+        cancelDrag()
+        return
+      }
       event.preventDefault()
       // The grab handles sit in the gutter OUTSIDE the table (left of a row, above a column), and
       // a drag naturally travels along that gutter — so the raw pointer point is usually not over
@@ -511,8 +558,10 @@ export const TableReorderHandle = Extension.create({
         cellPos: hover.cellPos,
       }
       // Snapshot the dragged table's structure so the plan-B guard can detect a concurrent edit to
-      // it during the drag. Reset the latch for this fresh drag.
+      // it during the drag: its signature plus how many tables currently share that signature. Reset
+      // the latch for this fresh drag.
       dragBaseline = tableStructureSignature(view.state.doc, hover.cellPos)
+      dragBaselineCount = dragBaseline === null ? 0 : countTableSignature(view.state.doc, dragBaseline)
       concurrentEdit = false
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
       dropIndex = null
@@ -544,14 +593,16 @@ export const TableReorderHandle = Extension.create({
                 tablePos: tr.mapping.map(drag.tablePos),
                 tableStart: tr.mapping.map(drag.tableStart),
               }
-              // Plan-B conflict detection. Re-fingerprint the dragged table (via the just-remapped
-              // cellPos, against the post-transaction doc) and latch a conflict if it diverges from
-              // the drag-start baseline — i.e. this transaction changed the table we are dragging in.
-              // A benign edit elsewhere leaves the signature equal, so the latch stays clear. Once
-              // latched it stays latched for the rest of the drag; `runMove` then aborts.
+              // Plan-B conflict detection, scoped to the dragged table only. Count the tables that
+              // still carry the drag-start signature; a DROP means the dragged table's own structure
+              // or content changed (or it was deleted) — latch a conflict so `runMove` aborts. This
+              // is position-independent, so it does NOT depend on the remapped `cellPos` (which a
+              // coarse y-prosemirror ReplaceStep can collapse to a boundary even when the table is
+              // untouched) — that anchor drift is exactly what made edits OUTSIDE the dragged table
+              // false-abort before (octo-docs-backend#76 FAIL-2). Benign edits elsewhere leave the
+              // count unchanged, so the latch stays clear.
               if (!concurrentEdit && dragBaseline !== null) {
-                const current = tableStructureSignature(newState.doc, drag.cellPos)
-                if (current === null || current !== dragBaseline) concurrentEdit = true
+                if (draggedTableConflict(newState.doc, dragBaseline, dragBaselineCount)) concurrentEdit = true
               }
             }
             return null
@@ -601,6 +652,7 @@ export const TableReorderHandle = Extension.create({
               activeView = null
               drag = null
               dragBaseline = null
+              dragBaselineCount = 0
               concurrentEdit = false
             },
           }

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -67,6 +67,21 @@ interface CellContext {
   cellPos: number
 }
 
+// Resolve the real `<table>` element for a table node position. `view.nodeDOM(tablePos)` returns
+// prosemirror-tables' `.tableWrapper` div, whose box INCLUDES the table's `margin: 12px 0` — the
+// wrapper is a block-formatting context (`overflow-x: auto`), so the child table's vertical margin
+// sits inside it and the wrapper's top edge is ~12px ABOVE the first row. Clamping / caret geometry
+// must use the inner table's rect, not the wrapper's, or vertical positions land in that margin gap
+// (this is what made column drags a no-op while rows — whose left margin is 0 — worked). Returns
+// null when the node view isn't laid out yet.
+function tableElementAt(view: EditorView, tablePos: number): HTMLElement | null {
+  const dom = view.nodeDOM(tablePos)
+  if (!(dom instanceof HTMLElement)) return null
+  if (dom.tagName === 'TABLE') return dom
+  const inner = dom.querySelector('table')
+  return inner instanceof HTMLElement ? inner : dom
+}
+
 function cellContextAt(view: EditorView, clientX: number, clientY: number): CellContext | null {
   const found = view.posAtCoords({ left: clientX, top: clientY })
   if (!found) return null
@@ -129,8 +144,8 @@ export const TableReorderHandle = Extension.create({
     const placeHandles = (view: EditorView, ctx: CellContext) => {
       if (!rowHandle || !colHandle) return
       const cellDom = view.nodeDOM(ctx.cellPos)
-      const tableDom = view.nodeDOM(ctx.tablePos)
-      if (!(cellDom instanceof HTMLElement) || !(tableDom instanceof HTMLElement)) {
+      const tableDom = tableElementAt(view, ctx.tablePos)
+      if (!(cellDom instanceof HTMLElement) || !tableDom) {
         hideHandles()
         return
       }
@@ -167,8 +182,8 @@ export const TableReorderHandle = Extension.create({
         return
       }
       const cellDom = view.nodeDOM(ctx.cellPos)
-      const tableDom = view.nodeDOM(ctx.tablePos)
-      if (!(cellDom instanceof HTMLElement) || !(tableDom instanceof HTMLElement)) return
+      const tableDom = tableElementAt(view, ctx.tablePos)
+      if (!(cellDom instanceof HTMLElement) || !tableDom) return
       const base = (view.dom as HTMLElement).getBoundingClientRect()
       const cell = cellDom.getBoundingClientRect()
       const table = tableDom.getBoundingClientRect()
@@ -238,12 +253,14 @@ export const TableReorderHandle = Extension.create({
       // a drag naturally travels along that gutter — so the raw pointer point is usually not over
       // any table cell and posAtCoords resolves nothing. Probe the drop target with the pointer
       // clamped into the table's interior instead: for a row drag the pointer's Y still selects the
-      // row (X is pulled inside), for a column drag its X still selects the column. Without this the
-      // drop target is never found and the move is a silent no-op (octo-docs-backend#76 rework).
+      // row (X is pulled inside), for a column drag its X still selects the column. Clamp against
+      // the real <table> rect (not the wrapper, whose box includes the table's 12px top/bottom
+      // margin) — clamping to the wrapper's top lands ~12px above the first row, in the margin gap
+      // over no cell, which is why the column axis was a silent no-op (octo-docs-backend#76 rework).
       let probeX = event.clientX
       let probeY = event.clientY
-      const tableDom = activeView.nodeDOM(drag.tablePos)
-      if (tableDom instanceof HTMLElement) {
+      const tableDom = tableElementAt(activeView, drag.tablePos)
+      if (tableDom) {
         const t = tableDom.getBoundingClientRect()
         probeX = Math.min(Math.max(probeX, t.left + 1), t.right - 1)
         probeY = Math.min(Math.max(probeY, t.top + 1), t.bottom - 1)

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -34,6 +34,22 @@ import type { Node as PMNode } from '@tiptap/pm/model'
 
 export const tableReorderPluginKey = new PluginKey('octoTableReorder')
 
+// Opt-in runtime tracing for diagnosing the drag wiring (octo-docs-backend#76). The reorder is
+// DOM/pointer-driven, so a jsdom unit test cannot exercise the wiring that connects a real drag to
+// moveTableRow / moveTableColumn — this hook captures that path in a real browser. It is inert and
+// zero-cost unless a page explicitly opts in with `window.__tableReorderDebug = []` before
+// dragging, so it is safe to leave in place: each drag phase then pushes a structured record you
+// can read back to confirm dragstart / drop / command dispatch actually fired.
+interface ReorderDebugEvent {
+  phase: 'begin' | 'move' | 'drop' | 'dispatch'
+  [key: string]: unknown
+}
+function reorderDebug(event: ReorderDebugEvent): void {
+  if (typeof window === 'undefined') return
+  const sink = (window as unknown as { __tableReorderDebug?: ReorderDebugEvent[] }).__tableReorderDebug
+  if (Array.isArray(sink)) sink.push(event)
+}
+
 // Thickness (px) of the grab bar that sits in the gutter above a column / left of a row. Kept
 // slim so it hugs the table edge and stays clear of the column-resize handle (interior, right
 // edge of each cell) and the block drag handle (further out in the left gutter).
@@ -80,6 +96,7 @@ interface DragState {
   kind: 'row' | 'col'
   index: number
   tableStart: number
+  tablePos: number
   cellPos: number
 }
 
@@ -179,7 +196,10 @@ export const TableReorderHandle = Extension.create({
     // source row/column — a pure selection change (no doc edit, so y-prosemirror ignores it) —
     // then dispatch the single-transaction move on the updated state.
     const runMove = (view: EditorView) => {
-      if (!drag || dropIndex == null || dropIndex === drag.index) return
+      if (!drag || dropIndex == null || dropIndex === drag.index) {
+        reorderDebug({ phase: 'drop', dispatched: false, reason: 'no valid target', drag, dropIndex })
+        return
+      }
       const { doc } = view.state
       if (drag.cellPos + 1 > doc.content.size) return
       let $inside
@@ -193,7 +213,8 @@ export const TableReorderHandle = Extension.create({
         drag.kind === 'col'
           ? moveTableColumn({ from: drag.index, to: dropIndex })
           : moveTableRow({ from: drag.index, to: dropIndex })
-      command(view.state, view.dispatch)
+      const dispatched = command(view.state, view.dispatch)
+      reorderDebug({ phase: 'dispatch', kind: drag.kind, from: drag.index, to: dropIndex, dispatched })
       view.focus()
     }
 
@@ -213,13 +234,44 @@ export const TableReorderHandle = Extension.create({
     const onDocMove = (event: MouseEvent) => {
       if (!drag || !activeView) return
       event.preventDefault()
-      const ctx = cellContextAt(activeView, event.clientX, event.clientY)
+      // The grab handles sit in the gutter OUTSIDE the table (left of a row, above a column), and
+      // a drag naturally travels along that gutter — so the raw pointer point is usually not over
+      // any table cell and posAtCoords resolves nothing. Probe the drop target with the pointer
+      // clamped into the table's interior instead: for a row drag the pointer's Y still selects the
+      // row (X is pulled inside), for a column drag its X still selects the column. Without this the
+      // drop target is never found and the move is a silent no-op (octo-docs-backend#76 rework).
+      let probeX = event.clientX
+      let probeY = event.clientY
+      const tableDom = activeView.nodeDOM(drag.tablePos)
+      if (tableDom instanceof HTMLElement) {
+        const t = tableDom.getBoundingClientRect()
+        probeX = Math.min(Math.max(probeX, t.left + 1), t.right - 1)
+        probeY = Math.min(Math.max(probeY, t.top + 1), t.bottom - 1)
+      }
+      const ctx = cellContextAt(activeView, probeX, probeY)
       if (!ctx || ctx.tableStart !== drag.tableStart) {
+        reorderDebug({
+          phase: 'move',
+          x: event.clientX,
+          y: event.clientY,
+          probeX,
+          probeY,
+          resolved: false,
+          reason: !ctx ? 'no cell under pointer' : 'different table',
+        })
         dropIndex = null
         hideIndicator()
         return
       }
       showIndicator(activeView, ctx)
+      reorderDebug({
+        phase: 'move',
+        x: event.clientX,
+        y: event.clientY,
+        resolved: true,
+        hovered: drag.kind === 'col' ? ctx.rect.left : ctx.rect.top,
+        dropIndex,
+      })
     }
     const onDocUp = () => {
       if (activeView) endDrag(activeView)
@@ -232,8 +284,10 @@ export const TableReorderHandle = Extension.create({
         kind,
         index: kind === 'col' ? hover.rect.left : hover.rect.top,
         tableStart: hover.tableStart,
+        tablePos: hover.tablePos,
         cellPos: hover.cellPos,
       }
+      reorderDebug({ phase: 'begin', kind, index: drag.index })
       dropIndex = null
       activeView = view
       document.body.classList.add('octo-table-reordering')

--- a/packages/docs/src/editor/TableReorderHandleUsable.test.ts
+++ b/packages/docs/src/editor/TableReorderHandleUsable.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TableMap } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableReorderHandle } from './TableReorderHandle.ts'
+
+// octo-docs-backend#76 handle-usability regression (XIN-1215 → XIN-1216). XIN-1206 added a
+// "released outside the window" abort: a document mousemove reporting `buttons === 0` mid-drag is
+// treated as an interruption. The trap it introduced: a drag whose moves do NOT carry `buttons`
+// reports 0 for the WHOLE drag even though the button is logically down — a hand-built MouseEvent,
+// or an automated headed-Chromium drag driven by raw CDP mouse events that omit the field. The
+// first such move then cancelled a perfectly good reorder, so QA saw the reorder handle as
+// "unusable" on a fresh document while a genuine held-button drag (buttons === 1) worked. The
+// existing FAIL-1 suite hid the gap because its drag helper dispatches the mid-drag move with
+// `buttons: 1`, exercising only the held-button path.
+//
+// These tests cover the path unit-42 missed: (1) the static handle actually RENDERS on a fresh
+// document, and (2) a drag whose mid-drag move carries no `buttons` still initiates and reorders —
+// while the genuine "release outside the window" (a held move, THEN an unheld move) still aborts,
+// so the FAIL-1 fix is preserved.
+
+const TABLE_3x2 =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>'
+
+let editor: Editor | null = null
+let host: HTMLElement | null = null
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+  host?.remove()
+  host = null
+})
+
+function mount(content: string): Editor {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  return new Editor({
+    element: host,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+    ],
+    content,
+  })
+}
+
+function firstTable(ed: Editor): { node: PMNode; pos: number } {
+  let node: PMNode | null = null
+  let pos = -1
+  ed.state.doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+function insideCell(ed: Editor, row: number, col: number): number {
+  const { node, pos } = firstTable(ed)
+  const map = TableMap.get(node)
+  return pos + 1 + map.map[row * map.width + col] + 2
+}
+function grid(ed: Editor): string[][] {
+  const { node } = firstTable(ed)
+  const map = TableMap.get(node)
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const rowArr: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cell = node.nodeAt(map.map[r * map.width + c])
+      rowArr.push(cell ? cell.textContent : '')
+    }
+    out.push(rowArr)
+  }
+  return out
+}
+
+let stubPos = 0
+function pointPosAt(ed: Editor): void {
+  ;(ed.view as unknown as { posAtCoords: (c: { left: number; top: number }) => { pos: number; inside: number } }).posAtCoords =
+    () => ({ pos: stubPos, inside: stubPos })
+}
+
+/** Hover the source cell so `placeHandles` records it as the drag source and shows the handle. */
+function hoverCell(ed: Editor, row: number, col: number): void {
+  pointPosAt(ed)
+  stubPos = insideCell(ed, row, col)
+  ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3, bubbles: true }))
+}
+
+describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
+  it('renders the static row and column handles on a fresh document when a cell is hovered', () => {
+    editor = mount(TABLE_3x2)
+    hoverCell(editor, 2, 0)
+    const rowHandle = host?.querySelector('.octo-table-reorder--row') as HTMLElement | null
+    const colHandle = host?.querySelector('.octo-table-reorder--col') as HTMLElement | null
+    expect(rowHandle, 'row handle element exists').toBeTruthy()
+    expect(colHandle, 'column handle element exists').toBeTruthy()
+    // Hovering a cell must make them visible (not display:none) — the "handle rendered" path.
+    expect(rowHandle?.style.display).not.toBe('none')
+    expect(colHandle?.style.display).not.toBe('none')
+  })
+
+  it('a drag whose mid-drag move carries no `buttons` still initiates and reorders (XIN-1215)', () => {
+    editor = mount(TABLE_3x2)
+    hoverCell(editor, 2, 0) // hover row 3
+    const handle = host?.querySelector('.octo-table-reorder--row')
+    if (!handle) throw new Error('row handle not rendered')
+    handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+    // Move over row 1 with NO `buttons` set (defaults to 0) — this is the automation / synthetic
+    // path. Before the fix the guard aborted here; now the reorder proceeds.
+    stubPos = insideCell(editor, 0, 0)
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9 }))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+  })
+
+  it('still aborts a genuine release outside the window: held move, then an unheld move (FAIL-1 preserved)', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    hoverCell(editor, 2, 0)
+    const handle = host?.querySelector('.octo-table-reorder--row')
+    if (!handle) throw new Error('row handle not rendered')
+    handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+    // A real held-button move (buttons:1) arms the drag...
+    stubPos = insideCell(editor, 0, 0)
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 1 }))
+    // ...then the pointer re-enters with the button released outside the window (buttons:0): abort.
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 0 }))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+})

--- a/packages/docs/src/editor/TableReorderInterrupt.test.ts
+++ b/packages/docs/src/editor/TableReorderInterrupt.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TableMap } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableReorderHandle } from './TableReorderHandle.ts'
+
+// octo-docs-backend#76 FAIL-1 (XIN-1206): an INTERRUPTED drag must be a pure abort — zero dispatch,
+// the table order unchanged. These tests drive the real document/window listeners the plugin installs
+// (mousedown on a handle → drag; document mousemove → drop target; then an interruption) and assert
+// the document never changes. jsdom has no layout, so geometry is stubbed: `posAtCoords` is pointed at
+// a chosen cell and element rects read as zero (harmless — the handlers still resolve the target cell
+// through the stub). The positive control proves this harness CAN commit a reorder on a real mouseup,
+// so the interruption tests genuinely show the commit was suppressed.
+//
+// The headline regression is "let go outside the window": the pointer leaves mid-drag, the button is
+// released over another app (no document `mouseup` reaches us), and the drag was left armed so the
+// NEXT stray mouseup committed a reorder the user had abandoned. The guard is a `buttons === 0` check
+// in the document mousemove handler that aborts as the pointer re-enters with no button pressed.
+
+const TABLE_3x2 =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>'
+
+let editor: Editor | null = null
+let host: HTMLElement | null = null
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+  host?.remove()
+  host = null
+})
+
+function mount(content: string): Editor {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  return new Editor({
+    element: host,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+    ],
+    content,
+  })
+}
+
+function firstTable(ed: Editor): { node: PMNode; pos: number } {
+  let node: PMNode | null = null
+  let pos = -1
+  ed.state.doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+/** A document position INSIDE the (row,col) cell's paragraph — what posAtCoords is pointed at. */
+function insideCell(ed: Editor, row: number, col: number): number {
+  const { node, pos } = firstTable(ed)
+  const map = TableMap.get(node)
+  return pos + 1 + map.map[row * map.width + col] + 2
+}
+/** Cell text grid, read from the current TableMap. */
+function grid(ed: Editor): string[][] {
+  const { node } = firstTable(ed)
+  const map = TableMap.get(node)
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const rowArr: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cell = node.nodeAt(map.map[r * map.width + c])
+      rowArr.push(cell ? cell.textContent : '')
+    }
+    out.push(rowArr)
+  }
+  return out
+}
+
+// Mutable target for the stubbed posAtCoords.
+let stubPos = 0
+function pointPosAt(ed: Editor): void {
+  ;(ed.view as unknown as { posAtCoords: (c: { left: number; top: number }) => { pos: number; inside: number } }).posAtCoords =
+    () => ({ pos: stubPos, inside: stubPos })
+}
+
+/** Arm a row drag: hover the source cell (sets the handle's source), press the handle, then move
+ * over the target cell so a drop target (dropIndex) is resolved. Leaves the drag in flight. */
+function armRowDrag(ed: Editor, srcRow: number, dstRow: number): void {
+  pointPosAt(ed)
+  // 1. hover source cell → placeHandles records it as the drag source.
+  stubPos = insideCell(ed, srcRow, 0)
+  ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3, bubbles: true }))
+  // 2. press the row handle (primary button) → beginDrag.
+  const handle = host?.querySelector('.octo-table-reorder--row')
+  if (!handle) throw new Error('row handle not rendered')
+  handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+  // 3. move over the target cell (button held) → resolves a drop target.
+  stubPos = insideCell(ed, dstRow, 0)
+  document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 1 }))
+}
+
+describe('FAIL-1: interrupted drag is a pure abort (no reorder)', () => {
+  it('positive control: a real mouseup after the drag DOES reorder', () => {
+    editor = mount(TABLE_3x2)
+    armRowDrag(editor, 2, 0) // drag row 3 toward the top
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    // The drop committed: row "r3" moved above the others.
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+  })
+
+  it('Escape aborts: table order unchanged, later mouseup is inert', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    armRowDrag(editor, 2, 0)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    // A stray mouseup after the interruption must not commit anything.
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+
+  it('window blur aborts: table order unchanged, later mouseup is inert', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    armRowDrag(editor, 2, 0)
+    window.dispatchEvent(new Event('blur'))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+
+  it('pointercancel aborts: table order unchanged, later mouseup is inert', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    armRowDrag(editor, 2, 0)
+    document.dispatchEvent(new Event('pointercancel'))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+
+  it('released outside the window (buttons === 0 on re-entry) aborts: no reorder', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    armRowDrag(editor, 2, 0)
+    // Pointer re-enters the window with no button pressed — the mouseup happened outside and was
+    // never delivered. This is the FAIL-1 headline case: old code left the drag armed and the next
+    // mouseup committed a reorder; the guard now aborts here.
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 0 }))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+})

--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -37,6 +37,7 @@ import TableHeader from '@tiptap/extension-table-header'
 import TableCell from '@tiptap/extension-table-cell'
 import { TableCellView } from './TableCellView.ts'
 import { TableFreeze } from './TableFreeze.ts'
+import { TableReorderHandle } from './TableReorderHandle.ts'
 import { OctoImage } from './ImageNode.ts'
 import { CommentHighlight } from '../comments/CommentDecorations.ts'
 import { buildEmoji } from './emoji.ts'
@@ -255,6 +256,12 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // rows / columns sticky, nothing is written to the Y.Doc (see TableFreeze.ts). Registered on the
     // live editor only; the static/export editor below has no interactive freeze.
     TableFreeze,
+    // octo-docs-backend#76: table row/column drag-to-reorder. A self-built plugin renders
+    // grab handles at the row-left / column-top edges and drives prosemirror-tables'
+    // moveTableRow / moveTableColumn (single-transaction, TableMap-based, merge-aware) — see
+    // TableReorderHandle.ts. Registered AFTER the Table series so its plugin sits above the
+    // column-resize / tableEditing plugins. No schema change (pure reorder).
+    TableReorderHandle,
     // SCHEMA-SPEC §2 (SCHEMA_VERSION 2): image node. Extends @tiptap/extension-image
     // (pinned 2.27.2, single core) with the backend-aligned attr set + parse/render
     // mapping and a self-built NodeView. docId is threaded so the NodeView and the

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -682,6 +682,62 @@
   background: var(--octo-hover);
   color: var(--octo-fg);
 }
+/* Table row/column reorder handles (octo-docs-backend#76). Slim grab bars pinned to the
+   row-left / column-top edges of the hovered cell by the TableReorderHandle plugin; dragging
+   one reorders that row/column. They live in the editor wrapper (outside the document) and are
+   positioned inline by the plugin. Kept clear of the column-resize handle (interior right edge)
+   and the block drag handle (further out in the left gutter). */
+.octo-table-reorder {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: var(--octo-hover);
+  border: 1px solid var(--octo-border);
+  border-radius: 4px;
+  color: var(--octo-muted, #8a919e);
+  z-index: 5;
+  box-sizing: border-box;
+}
+.octo-table-reorder:hover {
+  background: var(--octo-accent, #3370ff);
+  border-color: var(--octo-accent, #3370ff);
+  color: #fff;
+}
+.octo-table-reorder--col {
+  cursor: grab;
+}
+.octo-table-reorder--row {
+  cursor: grab;
+}
+.octo-table-reorder:active {
+  cursor: grabbing;
+}
+/* Grip dots: a row of dots on the column bar, a column of dots on the row bar. */
+.octo-table-reorder--col::before {
+  content: '⋯';
+  font-size: 14px;
+  line-height: 1;
+}
+.octo-table-reorder--row::before {
+  content: '⋮';
+  font-size: 14px;
+  line-height: 1;
+}
+/* Insertion caret shown while dragging: an accent line at the boundary the row/column lands on. */
+.octo-table-reorder-indicator {
+  display: none;
+  background: var(--octo-accent, #3370ff);
+  border-radius: 1px;
+  z-index: 6;
+  pointer-events: none;
+}
+/* While a reorder drag is in flight, suppress text selection everywhere so dragging over the
+   prose does not paint a selection, and force the grabbing cursor. */
+body.octo-table-reordering {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+
 /* Document outline / table of contents (LEFT rail, #3). Rendered before the editor main
    column so it sits to its left; default collapsed to a slim title bar. */
 .octo-outline {

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2934,7 +2934,8 @@ body.octo-table-reordering {
 .octo-file-status,
 .octo-file-error,
 .octo-bookmark-status,
-.octo-bookmark-error {
+.octo-bookmark-error,
+.octo-table-reorder-error {
   position: fixed;
   bottom: 16px;
   left: 50%;
@@ -2951,7 +2952,8 @@ body.octo-table-reordering {
   background: var(--octo-accent, #1664ff);
 }
 .octo-file-error,
-.octo-bookmark-error {
+.octo-bookmark-error,
+.octo-table-reorder-error {
   background: #e03131;
 }
 

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -213,7 +213,8 @@
     "freezeThroughRow": "Freeze up to this row",
     "freezeFirstColumn": "Freeze first column",
     "freezeThroughColumn": "Freeze up to this column",
-    "unfreeze": "Unfreeze"
+    "unfreeze": "Unfreeze",
+    "reorderConflict": "The table was changed by a collaborator, so the reorder was cancelled. Please try again."
   },
   "callout": {
     "info": "Info",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -213,7 +213,8 @@
     "freezeThroughRow": "冻结到当前行",
     "freezeFirstColumn": "冻结首列",
     "freezeThroughColumn": "冻结到当前列",
-    "unfreeze": "取消冻结"
+    "unfreeze": "取消冻结",
+    "reorderConflict": "表格已被协同修改，换序已取消，请重试。"
   },
   "callout": {
     "info": "信息",


### PR DESCRIPTION
## Summary

Adds table **row and column drag-to-reorder** to the docs editor. Until now tables only supported column-width resize (#749) — there was no way to change the order of rows or columns. This adds grab handles at the **row-left** and **column-top** edges; dragging one reorders that row/column within the table, with a live insertion caret showing where it will land.

Frontend implementation for **octo-docs-backend#76**. Pure frontend, in `packages/docs`.

## What changed

- **`TableReorderHandle.ts`** — a self-built ProseMirror plugin (registered right after the Table series). It renders the two grab bars + the drop-insertion caret as plugin-managed DOM in the editor wrapper (outside the document, like `BlockDragHandle`), hit-tests the pointer against the `TableMap` grid, and on drop drives the reorder command.
- **`extensions.ts`** — register `TableReorderHandle` in the live editor extension set.
- **`styles.css`** — handle + insertion-caret styling, using the existing design-system tokens (`--octo-accent`, `--octo-border`, `--octo-hover`). Kept clear of the interior column-resize handle and the left-gutter block drag handle.
- **`TableReorderHandle.test.ts`** — unit tests for the reorder behavior (row + column move, content preserved, single transaction, schema untouched, merged-cell no-op safety).

## Approach — analysis before implementation

The issue proposed a *self-developed reorder command based on `TableMap`, rebuilding row/column order in a single transaction*, and asked us to verify feasibility and note pitfalls (selection/decoration recovery after a `TableMap` rebuild; merged-cell colspan/rowspan boundaries).

**Key finding:** `prosemirror-tables@1.8.5` (bundled with `@tiptap/pm@3.22.2`, re-exported by `@tiptap/pm/tables`) already ships `moveTableRow` / `moveTableColumn` — which are *exactly* the "TableMap-based reorder in a single transaction" the issue describes, and they already solve both flagged pitfalls:

- **Single transaction / content preserved.** The move rebuilds the table with one `tr.replaceWith(tablePos, …, newTable)`; cell nodes are re-created with their original attrs/content/marks.
- **Selection & decoration recovery after the rebuild.** With `select: true` (the default) the command re-resolves a `CellSelection` on the moved row/column against the *rebuilt* map (`CellSelection.rowSelection` / `colSelection`). Verified in the browser — the moved row is highlighted after the drop (see screenshots), i.e. the selection is correctly recovered, not lost or pointing at a stale position.
- **Merged-cell colspan/rowspan boundaries.** `getSelectionRangeInColumn` / `…InRow` expand the moved index range to cover any merge group, so a merged cell moves as a unit; a drop that would *split* a merge (target index inside the moved merge group) makes the command return `false` — a safe no-op rather than a corrupt grid. Covered by a unit test with a `colspan=2` cell.

**Adjustment made:** rather than hand-rolling ~150 lines of subtle merged-cell array logic (and risking exactly the colspan/rowspan bugs the issue warns about), the reorder **command** is the library's `moveTableRow` / `moveTableColumn`, and the self-built part is the **drag-handle UI + hit-testing** that drives them. This satisfies every constraint (single transaction, TableMap-based, no schema change) with far less surface area for bugs.

One integration detail worth flagging for review: `moveTableRow`/`moveTableColumn` resolve the target table from the **current selection** (`getCellsInColumn`/`…InRow` read `selection.$from`), not from a `pos` argument. So on drop the plugin first drops the caret into a cell of the source row/column (a pure selection change — no doc edit, so y-prosemirror ignores it) and then dispatches the single-transaction move.

## Constraints checklist

- [x] Row drag-to-reorder (row-left handle)
- [x] Column drag-to-reorder (column-top handle), distinct from column-width resize (handles sit *outside* the cells; resize handle is interior/right — verified they coexist)
- [x] Reorder completes in a single transaction; content/formatting preserved
- [x] **No schema change** — `SCHEMA_VERSION` untouched (pure reorder)
- [x] Collab-safe — reorder is an ordinary `tr.replaceWith`, synced by `y-prosemirror` like any other edit; no bespoke collab code
- [x] Does not break column-width resize / freeze / context menu (reuses the existing NodeView + TableMap; no shared hit-area)

## Verification

- Unit tests: `TableReorderHandle.test.ts` (6) + existing table tests (`TableCellView`, `TableControls`, `BlockDragHandle`) all green. `tsc` typecheck clean for the changed files (two pre-existing, unrelated errors in `dmworkbase/i18n/format.ts` and `members/sort.ts` exist on `main` as well).
- Browser: drove real drag interactions with Playwright against the live extension set + real CSS — row reorder, column reorder, content preserved, moved-row selection restored, and column-resize handles still present. Screenshots below.

### Notes for reviewers

- Collaborative *multi-client* sync is not exercised in the standalone dev harness (M1 has no collab backend). Correctness there follows by construction (ordinary transaction through y-prosemirror, same path as the already-shipped `BlockDragHandle`); worth a quick two-client sanity check during QA before this goes to a ready PR.
- Minor stacking note: at the table's top-left corner the column handle, row handle, and the block drag handle share a small region. They are visually distinct and the reorder handles sit at `z-index` above the block handle; call out if reviewers want the block handle suppressed inside tables.

## Draft — do not merge

Opened as a **draft** to carry review only. Promotion to a ready PR (and merge/deploy) is out of scope for this task and will be done by the PM after review + green CI + sign-off.

Refs: octo-docs-backend#76
