### PR TITLE
feat(docs): Recently viewed / My documents tabs for the docs list (FEAT-B)

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2494,6 +2494,216 @@
   color: inherit;
 }
 
+/* ── FEAT-B: tabs + toolbar (search / creator filter) + infinite-scroll footer + empty states ──
+   Reuses the existing octo-docs list visual language (borders / radii / muted text colours); no
+   control library is introduced (frontend-design §4 / §5). */
+.octo-docs-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 4px;
+  margin-bottom: 8px;
+}
+.octo-docs-tab {
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--octo-fg-3, #86909c);
+  border-bottom: 2px solid transparent;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+.octo-docs-tab:hover {
+  color: var(--octo-fg, #1f2329);
+}
+.octo-docs-tab-active {
+  color: var(--octo-active-fg, #1664ff);
+  border-bottom-color: var(--octo-active-fg, #1664ff);
+}
+
+.octo-docs-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.octo-docs-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 160px;
+  min-width: 120px;
+  border: 1px solid var(--octo-border, #e5e6eb);
+  border-radius: 6px;
+  padding: 4px 8px;
+  background: var(--octo-bg, #fff);
+}
+.octo-docs-search-icon {
+  display: inline-flex;
+  color: var(--octo-fg-3, #86909c);
+}
+.octo-docs-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 13px;
+  color: var(--octo-fg, #1f2329);
+}
+.octo-docs-search-clear {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--octo-fg-3, #86909c);
+  padding: 0 2px;
+}
+.octo-docs-search-clear:hover {
+  color: var(--octo-fg, #1f2329);
+}
+
+.octo-docs-filter {
+  position: relative;
+  flex: 0 0 auto;
+}
+.octo-docs-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--octo-border, #e5e6eb);
+  background: var(--octo-bg, #fff);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--octo-fg, #1f2329);
+}
+.octo-docs-filter-btn:hover {
+  background: var(--octo-hover-bg, #f2f3f5);
+}
+.octo-docs-filter-btn-active {
+  border-color: var(--octo-active-fg, #1664ff);
+  color: var(--octo-active-fg, #1664ff);
+}
+.octo-docs-filter-caret {
+  font-size: 9px;
+  opacity: 0.9;
+}
+.octo-docs-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--octo-fg, #1f2329);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.octo-docs-filter-option:hover {
+  background: var(--octo-hover-bg, #f2f3f5);
+}
+.octo-docs-filter-option-empty {
+  color: var(--octo-fg-3, #86909c);
+  cursor: default;
+}
+.octo-docs-filter-option-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+.octo-docs-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  margin-bottom: 8px;
+}
+.octo-docs-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--octo-active-bg, #e8f3ff);
+  color: var(--octo-active-fg, #1664ff);
+  border-radius: 12px;
+  padding: 2px 6px 2px 10px;
+  font-size: 12px;
+}
+.octo-docs-filter-chip-x {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.octo-docs-filter-clear {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--octo-fg-3, #86909c);
+  text-decoration: underline;
+}
+.octo-docs-filter-clear:hover {
+  color: var(--octo-fg, #1f2329);
+}
+
+/* Infinite-scroll footer (sentinel row): loading / end / retry. No Suspense. */
+.octo-docs-list-more,
+.octo-docs-list-end {
+  list-style: none;
+  text-align: center;
+  padding: 12px 10px;
+  font-size: 12px;
+  color: var(--octo-fg-3, #86909c);
+}
+.octo-docs-list-more-error {
+  color: var(--octo-danger, #f53f3f);
+}
+.octo-docs-list-more-btn {
+  border: 1px solid var(--octo-border, #e5e6eb);
+  background: transparent;
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  color: inherit;
+}
+
+/* Empty states A–E: title + CTA button(s). */
+.octo-docs-empty-title {
+  margin: 0 0 12px;
+  color: var(--octo-fg-2, #4e5969);
+  font-size: 14px;
+}
+.octo-docs-empty-cta {
+  border: 1px solid var(--octo-active-fg, #1664ff);
+  background: transparent;
+  color: var(--octo-active-fg, #1664ff);
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.octo-docs-empty-cta:hover {
+  background: var(--octo-active-bg, #e8f3ff);
+}
+.octo-docs-empty-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+
 /* ─────────────────────────────────────────────────────────────────────────
    Batch-3 schema toolbar items (SCHEMA_VERSION 5–13)
    ───────────────────────────────────────────────────────────────────────── */

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -11,6 +11,7 @@
     "comingSoon": "Coming soon",
     "kindDoc": "Document",
     "kindBoard": "Board",
+    "kindSheet": "Spreadsheet",
     "back": "All documents",
     "updatedAt": "Updated",
     "viewedAt": "Viewed",
@@ -542,6 +543,7 @@
   },
   "filter": {
     "creator": "Creator",
+    "type": "Type",
     "clearAll": "Clear all",
     "noCreators": "No creators"
   },
@@ -554,6 +556,8 @@
     "searchNoneCta": "Clear search",
     "filterNone": "No documents you've viewed from the selected creators",
     "filterNoneCta": "Clear filter",
+    "typeNone": "No documents of the selected type",
+    "typeNoneCta": "Clear type",
     "combinedNone": "No matching results"
   }
 }

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -12,7 +12,12 @@
     "kindDoc": "Document",
     "kindBoard": "Board",
     "back": "All documents",
-    "updatedAt": "Updated"
+    "updatedAt": "Updated",
+    "viewedAt": "Viewed",
+    "loadingMore": "Loading more…",
+    "end": "No more documents",
+    "loadMoreFailed": "Couldn't load more",
+    "retry": "Retry"
   },
   "board": {
     "readOnly": "Read-only",
@@ -527,5 +532,28 @@
     "pendingError": "Failed to load pending requests.",
     "approve": "Approve",
     "deny": "Deny"
+  },
+  "tab": {
+    "recent": "Recently viewed",
+    "mine": "My documents"
+  },
+  "search": {
+    "placeholder": "Search by file name"
+  },
+  "filter": {
+    "creator": "Creator",
+    "clearAll": "Clear all",
+    "noCreators": "No creators"
+  },
+  "empty": {
+    "recentNone": "You haven't viewed any documents yet",
+    "recentNoneCta": "Open a document",
+    "myDocsNone": "You haven't created any documents yet",
+    "myDocsNoneCta": "New document",
+    "searchNone": "No documents match “{{kw}}”",
+    "searchNoneCta": "Clear search",
+    "filterNone": "No documents you've viewed from the selected creators",
+    "filterNoneCta": "Clear filter",
+    "combinedNone": "No matching results"
   }
 }

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -12,7 +12,12 @@
     "kindDoc": "文档",
     "kindBoard": "画板",
     "back": "全部文档",
-    "updatedAt": "更新于"
+    "updatedAt": "更新于",
+    "viewedAt": "查看于",
+    "loadingMore": "加载中…",
+    "end": "没有更多了",
+    "loadMoreFailed": "加载更多失败",
+    "retry": "重试"
   },
   "board": {
     "readOnly": "只读",
@@ -527,5 +532,28 @@
     "pendingError": "加载待审批申请失败。",
     "approve": "同意",
     "deny": "拒绝"
+  },
+  "tab": {
+    "recent": "最近查看",
+    "mine": "我的文档"
+  },
+  "search": {
+    "placeholder": "按文件名搜索"
+  },
+  "filter": {
+    "creator": "创建者",
+    "clearAll": "清除全部",
+    "noCreators": "暂无创建者"
+  },
+  "empty": {
+    "recentNone": "你还没查看过任何文档",
+    "recentNoneCta": "去打开一篇文档",
+    "myDocsNone": "你还没有创建文档",
+    "myDocsNoneCta": "新建文档",
+    "searchNone": "没有匹配 “{{kw}}” 的文档",
+    "searchNoneCta": "清空搜索",
+    "filterNone": "所选创建者下没有你查看过的文档",
+    "filterNoneCta": "清除过滤",
+    "combinedNone": "无匹配结果"
   }
 }

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -11,6 +11,7 @@
     "comingSoon": "即将上线",
     "kindDoc": "文档",
     "kindBoard": "画板",
+    "kindSheet": "表格",
     "back": "全部文档",
     "updatedAt": "更新于",
     "viewedAt": "查看于",
@@ -542,6 +543,7 @@
   },
   "filter": {
     "creator": "创建者",
+    "type": "类型",
     "clearAll": "清除全部",
     "noCreators": "暂无创建者"
   },
@@ -554,6 +556,8 @@
     "searchNoneCta": "清空搜索",
     "filterNone": "所选创建者下没有你查看过的文档",
     "filterNoneCta": "清除过滤",
+    "typeNone": "所选类型下没有文档",
+    "typeNoneCta": "清除类型",
     "combinedNone": "无匹配结果"
   }
 }

--- a/packages/docs/src/octoweb/index.test.ts
+++ b/packages/docs/src/octoweb/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { apiClient, wrapHostClient, setWKApp } from './index.ts'
+import { apiClient, wrapHostClient, setWKApp, onNavMenuActivated } from './index.ts'
 import { createMockWKApp } from './mock.ts'
 import type { APIClient } from './types.ts'
 
@@ -111,5 +111,46 @@ describe('octoweb apiClient seam', () => {
     for (const verb of ['get', 'post', 'put', 'patch', 'delete']) {
       expect(typeof proto[verb], `host APIClient.${verb}`).toBe('function')
     }
+  })
+})
+
+// XIN-1165: the docs NavRail entry must re-render like a direct `/docs` load. The host emits
+// `wk:nav-menu-activated` on every NavRail click; DocsHome subscribes through this seam to
+// re-assert its right pane after `onMenuClick` popToRoot()'d it (a return visit does not remount
+// DocsHome). The seam must fire ONLY for the docs menu and clean up on unsubscribe.
+describe('onNavMenuActivated seam', () => {
+  it('invokes the callback only when the docs menu is activated, and unsubscribes cleanly', () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+
+    let hits = 0
+    const off = onNavMenuActivated('docs', () => {
+      hits += 1
+    })
+    expect(wk.mockMittBus.navMenuActivatedListenerCount()).toBe(1)
+
+    // A different menu's activation must NOT trigger the docs callback.
+    wk.mockMittBus.emitNavMenuActivated('chat')
+    expect(hits).toBe(0)
+
+    // The docs menu's activation does.
+    wk.mockMittBus.emitNavMenuActivated('docs')
+    wk.mockMittBus.emitNavMenuActivated('docs')
+    expect(hits).toBe(2)
+
+    // After unsubscribe, no more listeners and no more callbacks.
+    off()
+    expect(wk.mockMittBus.navMenuActivatedListenerCount()).toBe(0)
+    wk.mockMittBus.emitNavMenuActivated('docs')
+    expect(hits).toBe(2)
+  })
+
+  it('returns a no-op unsubscribe when the host exposes no event bus', () => {
+    // Bus-less shape: getWKApp() falls back to it, mittBus is undefined → no throw, no listener.
+    setWKApp({ mittBus: undefined } as unknown as Parameters<typeof setWKApp>[0])
+    const off = onNavMenuActivated('docs', () => {
+      throw new Error('should never fire without a bus')
+    })
+    expect(() => off()).not.toThrow()
   })
 })

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -77,6 +77,33 @@ export function onSpaceChanged(cb: () => void): () => void {
   return () => bus.off('space-changed', handler)
 }
 
+/**
+ * Subscribe to the host's "NavRail entry activated" broadcast, filtered to one menu id.
+ *
+ * apps/web Pages/Main `onMenuClick` emits `WKApp.mittBus.emit('wk:nav-menu-activated', { menuId })`
+ * on every NavRail click. This matters for docs because MainContentLeft keeps every visited route
+ * mounted and only toggles `display` (comment in Pages/Main/index.tsx: "切回某个菜单时组件不会重新
+ * mount") — so returning to `/docs` via the nav icon does NOT remount DocsHome and its mount-only
+ * effects never re-run. Meanwhile `onMenuClick` calls `WKApp.routeRight.popToRoot()` for a non-chat
+ * menu, emptying the shared right pane. Without reacting to this event the right pane is left empty
+ * on a return visit (the host chat placeholder shows through), so the nav entry diverges from a
+ * fresh `/docs` load. DocsHome listens here to re-assert its right pane, mirroring the
+ * summary/todo/contacts modules which subscribe to the same signal.
+ *
+ * Returns an unsubscribe function. No-op when no bus is available (older test mock / non-browser).
+ */
+export function onNavMenuActivated(menuId: string, cb: () => void): () => void {
+  const bus: MittBusLite | undefined = override
+    ? override.mittBus
+    : (WKApp as unknown as { mittBus?: MittBusLite }).mittBus
+  if (!bus) return () => {}
+  const handler = (payload: { menuId: string }) => {
+    if (payload?.menuId === menuId) cb()
+  }
+  bus.on('wk:nav-menu-activated', handler)
+  return () => bus.off('wk:nav-menu-activated', handler)
+}
+
 /** Page size for space-member fetches — mirrors the host useMemberList pattern (default 50). */
 const SPACE_MEMBERS_PAGE_SIZE = 50
 /** Cap total pages so an unexpectedly huge space can't loop unbounded (1000 members). */

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -77,21 +77,37 @@ export class MockRouteManager implements RouteManager {
  */
 export class MockMittBus {
   private spaceChangedListeners: Array<(payload?: unknown) => void> = []
-  on(type: 'space-changed', handler: (payload?: unknown) => void): void {
+  private navMenuActivatedListeners: Array<(payload: { menuId: string }) => void> = []
+  on(type: 'space-changed', handler: (payload?: unknown) => void): void
+  on(type: 'wk:nav-menu-activated', handler: (payload: { menuId: string }) => void): void
+  on(type: string, handler: (payload?: any) => void): void {
     if (type === 'space-changed') this.spaceChangedListeners.push(handler)
+    else if (type === 'wk:nav-menu-activated') this.navMenuActivatedListeners.push(handler)
   }
-  off(type: 'space-changed', handler: (payload?: unknown) => void): void {
+  off(type: 'space-changed', handler: (payload?: unknown) => void): void
+  off(type: 'wk:nav-menu-activated', handler: (payload: { menuId: string }) => void): void
+  off(type: string, handler: (payload?: any) => void): void {
     if (type === 'space-changed') {
       this.spaceChangedListeners = this.spaceChangedListeners.filter((l) => l !== handler)
+    } else if (type === 'wk:nav-menu-activated') {
+      this.navMenuActivatedListeners = this.navMenuActivatedListeners.filter((l) => l !== handler)
     }
   }
   /** Number of space-changed listeners currently registered (leak / idempotency checks). */
   spaceChangedListenerCount(): number {
     return this.spaceChangedListeners.length
   }
+  /** Number of nav-menu-activated listeners currently registered (leak checks). */
+  navMenuActivatedListenerCount(): number {
+    return this.navMenuActivatedListeners.length
+  }
   /** Simulate the host broadcasting a Space switch. */
   emitSpaceChanged(payload?: unknown): void {
     for (const l of [...this.spaceChangedListeners]) l(payload)
+  }
+  /** Simulate the host broadcasting a NavRail entry activation (menu click). */
+  emitNavMenuActivated(menuId: string): void {
+    for (const l of [...this.navMenuActivatedListeners]) l({ menuId })
   }
 }
 

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -280,4 +280,11 @@ export interface RouteRight {
 export interface MittBusLite {
   on(type: 'space-changed', handler: (payload?: unknown) => void): void
   off(type: 'space-changed', handler: (payload?: unknown) => void): void
+  // Emitted by apps/web Pages/Main `onMenuClick` every time the user clicks a NavRail entry
+  // (`WKApp.mittBus.emit('wk:nav-menu-activated', { menuId })`). Because MainContentLeft keeps
+  // every visited route mounted and only toggles `display`, a return visit does NOT remount the
+  // route component — so modules that must refresh on re-activation subscribe to this instead of
+  // relying on a fresh mount (same signal the summary/todo/contacts modules use).
+  on(type: 'wk:nav-menu-activated', handler: (payload: { menuId: string }) => void): void
+  off(type: 'wk:nav-menu-activated', handler: (payload: { menuId: string }) => void): void
 }

--- a/packages/docs/src/pages/CreatorFilter.tsx
+++ b/packages/docs/src/pages/CreatorFilter.tsx
@@ -1,0 +1,140 @@
+import { useRef, useState } from 'react'
+import { t } from '../octoweb/index.ts'
+import { PortalMenu } from './PortalMenu.tsx'
+import type { CreatorOption } from './docsApi.ts'
+
+/**
+ * Resolve a creator's display name: prefer the server-resolved facet `name` (frontend-design §3.5),
+ * then the space member-name map fallback, then the raw uid. Kept pure + shared so the dropdown and
+ * the chips label creators identically.
+ */
+export function creatorName(
+  uid: string,
+  options: CreatorOption[],
+  nameFallback: (uid: string) => string | undefined,
+): string {
+  const opt = options.find((o) => o.uid === uid)
+  const name = (opt?.name || '').trim()
+  if (name) return name
+  const fallback = (nameFallback(uid) || '').trim()
+  return fallback || uid
+}
+
+/**
+ * Multi-select creator filter for the recent tab (frontend-design §5.2). Opens a body-portal menu
+ * (reusing PortalMenu) of checkbox rows sourced from the server `recent/creators` facet — the
+ * candidate set is the whole recent result set's distinct owners AFTER `q`, BEFORE creator filter,
+ * BEFORE pagination, so every creator is selectable without scrolling the list. Selections are OR'd
+ * server-side. The button shows the selected count; chips (see CreatorChips) render below the toolbar.
+ */
+export function CreatorFilter({
+  options,
+  selected,
+  onToggle,
+  nameFallback,
+}: {
+  options: CreatorOption[]
+  selected: string[]
+  onToggle: (uid: string) => void
+  nameFallback: (uid: string) => string | undefined
+}): React.ReactElement {
+  const [at, setAt] = useState<{ left: number; top: number } | null>(null)
+  const btnRef = useRef<HTMLButtonElement>(null)
+
+  const open = () => {
+    const el = btnRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    setAt(at ? null : { left: r.left, top: r.bottom + 6 })
+  }
+
+  const label =
+    selected.length > 0
+      ? `${t('docs.filter.creator')} (${selected.length})`
+      : t('docs.filter.creator')
+
+  return (
+    <div className="octo-docs-filter">
+      <button
+        ref={btnRef}
+        type="button"
+        className={
+          selected.length > 0
+            ? 'octo-docs-filter-btn octo-docs-filter-btn-active'
+            : 'octo-docs-filter-btn'
+        }
+        aria-haspopup="menu"
+        aria-expanded={at != null}
+        onClick={open}
+      >
+        {label}
+        <span className="octo-docs-filter-caret" aria-hidden="true">▾</span>
+      </button>
+      {at && (
+        <PortalMenu at={at} onClose={() => setAt(null)} minWidth={200}>
+          {options.length === 0 ? (
+            <div className="octo-docs-filter-option octo-docs-filter-option-empty">
+              {t('docs.filter.noCreators')}
+            </div>
+          ) : (
+            options.map((o) => {
+              const checked = selected.includes(o.uid)
+              return (
+                <label key={o.uid} className="octo-docs-filter-option">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(o.uid)}
+                  />
+                  <span className="octo-docs-filter-option-name">
+                    {creatorName(o.uid, options, nameFallback)}
+                  </span>
+                </label>
+              )
+            })
+          )}
+        </PortalMenu>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Chips row for the selected creators (frontend-design §5.2). Each chip removes its creator; a
+ * trailing "clear all" clears the filter. Rendered below the toolbar only when something is selected.
+ */
+export function CreatorChips({
+  options,
+  selected,
+  onToggle,
+  onClearAll,
+  nameFallback,
+}: {
+  options: CreatorOption[]
+  selected: string[]
+  onToggle: (uid: string) => void
+  onClearAll: () => void
+  nameFallback: (uid: string) => string | undefined
+}): React.ReactElement | null {
+  if (selected.length === 0) return null
+  return (
+    <div className="octo-docs-filter-chips">
+      {selected.map((uid) => (
+        <span key={uid} className="octo-docs-filter-chip">
+          {creatorName(uid, options, nameFallback)}
+          <button
+            type="button"
+            className="octo-docs-filter-chip-x"
+            aria-label={creatorName(uid, options, nameFallback)}
+            onClick={() => onToggle(uid)}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <button type="button" className="octo-docs-filter-clear" onClick={onClearAll}>
+        {t('docs.filter.clearAll')}
+      </button>
+    </div>
+  )
+}

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -695,18 +695,25 @@ describe('DocsHome — a stale (out-of-order) list response cannot overwrite the
     wk.shared.currentSpaceId = 'space-a'
     setWKApp(wk)
 
-    // Deferred resolvers keyed by the Space each GET was scoped to, so the test drives the ORDER
-    // responses settle independently of the order the requests were issued (delayed / reordered).
+    // The default tab is "recent" (最近查看), which lists via GET /docs/recent — it carries NO
+    // spaceId query (space is server-derived from the token / X-Space-Id header), so we key deferred
+    // resolvers by the live `currentSpaceId` read at call time instead of parsing the URL. This
+    // keeps the P0 guard covering the actual rendered rows now that recent is the default surface.
     const deferred: Record<string, (items: unknown[]) => void> = {}
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url.startsWith('/docs')) {
-        const spaceId = new URLSearchParams(url.split('?')[1] ?? '').get('spaceId') ?? ''
+      // The recent tab also fetches its creator candidates; answer that sibling GET immediately so
+      // only the paged-list request lands in `deferred`.
+      if (method === 'get' && url.startsWith('/docs/recent/creators')) {
+        return { data: { creators: [] }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs/recent')) {
+        const spaceId = wk.shared.currentSpaceId ?? ''
         return new Promise((resolve) => {
           deferred[spaceId] = (items) =>
-            resolve({ data: { total: items.length, items }, status: 200 })
+            resolve({ data: { total: items.length, items, nextCursor: null }, status: 200 })
         })
       }
-      return { data: {}, status: 200 }
+      return { data: { total: 0, items: [], nextCursor: null }, status: 200 }
     }
 
     render(<DocsHome />)
@@ -722,8 +729,8 @@ describe('DocsHome — a stale (out-of-order) list response cannot overwrite the
     deferred['space-b']([{ docId: 'd_b', title: 'Space B Doc', ownerId: 'u_self', role: 'admin' }])
     await waitFor(() => expect(screen.getByText('Space B Doc')).toBeTruthy())
 
-    // ...then let the OLDER (space-a) request resolve LAST (out of order). Without the guard this
-    // stale setItems would clobber the list with the old Space's doc.
+    // ...then let the OLDER (space-a) request resolve LAST (out of order). Without the per-view
+    // seqRef guard this stale setItems would clobber the list with the old Space's doc.
     deferred['space-a']([{ docId: 'd_a', title: 'Space A Doc', ownerId: 'u_self', role: 'admin' }])
     // Give the stale promise a chance to (wrongly) apply before asserting.
     await new Promise((r) => setTimeout(r, 20))
@@ -1030,19 +1037,24 @@ describe('DocsHome — in-flight unknown-kind open is discarded after a Space sw
             })
         })
       }
-      if (method === 'get' && url.startsWith('/docs')) {
-        const spaceId = new URLSearchParams(url.split('?')[1] ?? '').get('spaceId') ?? ''
-        // Only the initial Space lists the unknown-kind row; the new Space is empty.
-        if (spaceId === 'space-a') {
+      if (method === 'get' && url.startsWith('/docs/recent/creators')) {
+        return { data: { creators: [] }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs/recent')) {
+        // The default tab lists via GET /docs/recent (no spaceId query — space is server-derived),
+        // so branch on the live current Space: only the initial Space lists the unknown-kind row;
+        // the new Space is empty.
+        if (wk.shared.currentSpaceId === 'space-a') {
           return {
             data: {
               total: 1,
               items: [{ docId: 'd_a', title: 'Space A Doc', ownerId: 'u_owner', role: 'admin' }],
+              nextCursor: null,
             },
             status: 200,
           }
         }
-        return { data: { total: 0, items: [] }, status: 200 }
+        return { data: { total: 0, items: [], nextCursor: null }, status: 200 }
       }
       return { data: {}, status: 200 }
     }

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1389,3 +1389,65 @@ describe('DocsHome — pin order survives the search → pin → clear-search re
     expect(rowTitles()).toEqual(['FEAT spec', 'Alpha', 'Beta'])
   })
 })
+
+// XIN-1188: the list distinguishes doc / sheet / board rows by icon (three-way), and the type
+// filter control is present on BOTH tabs (creator is recent-only).
+describe('DocsHome — type distinction + filter (XIN-1188)', () => {
+  const recentRows = [
+    { docId: 'd_doc', title: 'A Doc', ownerId: 'u_o', role: 'admin', docType: 'doc', viewedAt: '2026-07-15T06:00:00.000Z' },
+    { docId: 'd_sheet', title: 'A Sheet', ownerId: 'u_o', role: 'admin', docType: 'sheet', viewedAt: '2026-07-15T05:00:00.000Z' },
+    { docId: 'd_board', title: 'A Board', ownerId: 'u_o', role: 'admin', docType: 'board', viewedAt: '2026-07-15T04:00:00.000Z' },
+  ]
+
+  function mountList() {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs/recent/creators')) {
+        return { data: { creators: [] }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs/recent')) {
+        return { data: { total: recentRows.length, items: recentRows, nextCursor: null }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs')) {
+        // mine tab (owner=me)
+        return { data: { total: 1, items: [recentRows[0]] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<DocsHome />)
+    return wk
+  }
+
+  it('renders three distinct row-kind icons/labels (sheet is NOT shown as a document)', async () => {
+    mountList()
+    await waitFor(() => expect(screen.getByText('A Sheet')).toBeTruthy())
+    // Each kind carries its own aria-label/title on the row icon.
+    expect(screen.getByLabelText('docs.list.kindDoc')).toBeTruthy()
+    expect(screen.getByLabelText('docs.list.kindSheet')).toBeTruthy()
+    expect(screen.getByLabelText('docs.list.kindBoard')).toBeTruthy()
+  })
+
+  it('shows the type filter on both tabs and drives a multi-select OR request', async () => {
+    const wk = mountList()
+    await waitFor(() => expect(screen.getByText('A Sheet')).toBeTruthy())
+
+    // Type filter present on the recent tab.
+    const typeBtn = screen.getByText('docs.filter.type')
+    expect(typeBtn).toBeTruthy()
+
+    // Open the dropdown and select "sheet" → the next recent request narrows on type=sheet.
+    fireEvent.click(typeBtn)
+    fireEvent.click(screen.getByText('docs.list.kindSheet'))
+    await waitFor(() => {
+      const lastRecent = wk.apiClient.calls
+        .filter((c) => c.method === 'get' && c.url.startsWith('/docs/recent?'))
+        .at(-1)
+      expect(lastRecent?.url).toContain('type=sheet')
+    })
+
+    // Switch to the mine tab — the type filter is still rendered there.
+    fireEvent.click(screen.getByText('docs.tab.mine'))
+    await waitFor(() => expect(screen.getByText('docs.filter.type')).toBeTruthy())
+  })
+})

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, cleanup, fireEvent, act } from '@testing-libra
 import type { ReactNode } from 'react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
-import { resolveDocTarget, clearDocTarget, DocsHome } from './DocsHome.tsx'
+import { resolveDocTarget, clearDocTarget, readDocFromHistory, DocsHome } from './DocsHome.tsx'
 import { captureDocTargetDeepLink } from '../config.ts'
 
 // Replace the heavy editor shell (Tiptap + Yjs + Hocuspocus) with a marker so the DocsHome
@@ -58,6 +58,7 @@ const TARGET_KEY = 'octo.docs.target'
 
 let assignSpy: ReturnType<typeof vi.fn>
 let replaceStateSpy: ReturnType<typeof vi.fn>
+let pushStateSpy: ReturnType<typeof vi.fn>
 const realLocation = window.location
 
 beforeEach(() => {
@@ -72,13 +73,19 @@ beforeEach(() => {
     writable: true,
     value: { search: '', assign: assignSpy },
   })
-  // Split-pane mirrors selection to the URL via history.replaceState (no host re-push),
-  // not a full navigation — stub it so the URL-mirror is observable.
+  // Split-pane mirrors selection to the URL via the History API (no host re-push), not a full
+  // navigation — stub replaceState AND pushState so the URL-mirror is observable. Opening a doc
+  // now normalises the current entry to the list (replaceState) then pushes the doc as its own
+  // entry (pushState) so a browser Back returns to the list, not about:blank (XIN-1172).
   replaceStateSpy = vi.fn()
+  pushStateSpy = vi.fn()
   // Cast at the call site: vitest 4's loosely-typed `vi.fn()` isn't directly assignable to the
-  // precise `replaceState` signature mockImplementation expects (the spy still records calls).
+  // precise replaceState/pushState signatures mockImplementation expects (the spies still record).
   vi.spyOn(window.history, 'replaceState').mockImplementation(
     replaceStateSpy as unknown as typeof window.history.replaceState,
+  )
+  vi.spyOn(window.history, 'pushState').mockImplementation(
+    pushStateSpy as unknown as typeof window.history.pushState,
   )
 })
 
@@ -249,11 +256,14 @@ describe('DocsHome navigation (split-pane)', () => {
     // and the list stays resident on the left.
     await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
     expect(screen.getByTestId('editor-doc').textContent).toBe('d_new')
-    // selection mirrored to sessionStorage + URL (replaceState, not assign).
+    // selection mirrored to sessionStorage + URL. Opening from the list PUSHES a doc entry over a
+    // normalised list entry (XIN-1172): the doc addressing lands on pushState, the last replaceState
+    // is the list entry beneath it (no `doc=`), so a browser Back returns to the list.
     expect(JSON.parse(window.sessionStorage.getItem(TARGET_KEY)!)).toMatchObject({ doc: 'd_new' })
     expect(assignSpy).not.toHaveBeenCalled()
-    expect(replaceStateSpy).toHaveBeenCalled()
-    expect(String(replaceStateSpy.mock.calls.at(-1)![2])).toContain('doc=d_new')
+    expect(pushStateSpy).toHaveBeenCalled()
+    expect(String(pushStateSpy.mock.calls.at(-1)![2])).toContain('doc=d_new')
+    expect(String(replaceStateSpy.mock.calls.at(-1)![2])).not.toContain('doc=')
   })
 
   it('creates a board via the New dropdown and opens it in the board shell', async () => {
@@ -341,7 +351,9 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(screen.getByText('Doc A')).toBeTruthy()
     expect(JSON.parse(window.sessionStorage.getItem(TARGET_KEY)!)).toMatchObject({ doc: 'd_a' })
     expect(assignSpy).not.toHaveBeenCalled()
-    expect(String(replaceStateSpy.mock.calls.at(-1)![2])).toContain('doc=d_a')
+    // First open from the list pushes the doc entry over a normalised list entry (XIN-1172).
+    expect(String(pushStateSpy.mock.calls.at(-1)![2])).toContain('doc=d_a')
+    expect(String(replaceStateSpy.mock.calls.at(-1)![2])).not.toContain('doc=')
   })
 
   it('AC-1: the open doc exposes an "Open in new page" entry that opens the /d/:docId standalone link', async () => {
@@ -1208,5 +1220,94 @@ describe('DocsHome — deleting the open doc clears the right pane and selection
     const last = replaceToRoot.mock.calls.at(-1)?.[0] as { props?: { docId?: string } } | undefined
     expect(last?.props?.docId).toBe('d_x')
     expect(JSON.parse(window.sessionStorage.getItem(TARGET_KEY)!)).toMatchObject({ doc: 'd_x' })
+  })
+})
+
+// XIN-1172 — opening a doc → browser Back / Back-then-reload landed on about:blank because the
+// open only replaceState'd the current entry (no in-app entry to go Back to) and the persisted
+// target re-opened the doc on the host's popstate re-push. The fix pushes a doc entry over a
+// normalised list entry and reconciles popstate to the list, clearing the target.
+describe('readDocFromHistory (XIN-1172 Back/Forward intent)', () => {
+  it('returns the docId when the entry is marked as a doc entry', () => {
+    expect(readDocFromHistory({ octoDocsDoc: 'd_open' }, '')).toBe('d_open')
+  })
+
+  it('returns null (list) when the entry is marked as the list entry', () => {
+    // Even if a stale ?doc= lingers in the URL, an explicit list marker wins → show the list.
+    expect(readDocFromHistory({ octoDocsList: true }, '?doc=d_stale')).toBeNull()
+  })
+
+  it('falls back to the URL query when the state carries no marker (host re-push overwrote it)', () => {
+    expect(readDocFromHistory({}, '?space=s&folder=f&doc=d_url')).toBe('d_url')
+    expect(readDocFromHistory(null, '?sid=abc')).toBeNull()
+  })
+
+  it('accepts docId as an alias in the URL fallback', () => {
+    expect(readDocFromHistory(undefined, '?docId=d_alias')).toBe('d_alias')
+  })
+})
+
+describe('DocsHome — browser Back returns to the list, never about:blank (XIN-1172)', () => {
+  it('pushes a doc entry over a normalised list entry so Back has a list to return to', async () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return {
+          data: {
+            total: 1,
+            items: [{ docId: 'd_a', title: 'Doc A', ownerId: 'u_self', role: 'admin', docType: 'doc' }],
+          },
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('Doc A')).toBeTruthy())
+    fireEvent.click(screen.getByText('Doc A'))
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+
+    // The current entry was normalised to the list (no doc), then the doc was pushed on top —
+    // guaranteeing an in-app list entry beneath so a browser Back never pops past /docs.
+    const listReplace = replaceStateSpy.mock.calls.at(-1)!
+    expect(String(listReplace[2])).not.toContain('doc=')
+    expect((listReplace[0] as Record<string, unknown>).octoDocsList).toBe(true)
+    const docPush = pushStateSpy.mock.calls.at(-1)!
+    expect(String(docPush[2])).toContain('doc=d_a')
+    expect((docPush[0] as Record<string, unknown>).octoDocsDoc).toBe('d_a')
+  })
+
+  it('on popstate to a non-doc entry, closes the doc and clears the persisted target (Back → list)', async () => {
+    // A doc is open via a persisted target (mirrors the host having re-opened it before a Back).
+    window.sessionStorage.setItem(TARGET_KEY, JSON.stringify({ doc: 'd_persist' }))
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_persist') {
+        return { data: { docId: 'd_persist', title: 'Persisted', role: 'admin', docType: 'doc' }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+
+    // Simulate the browser Back popping to the list entry (history.state is the mocked no-op, so
+    // readDocFromHistory sees no doc marker and the empty URL → "this is the list").
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+
+    // The editor is dismissed and the persisted target is cleared, so the host's own popstate
+    // re-push (which re-mounts DocsHome reading sessionStorage) cannot re-open the doc — and a
+    // reload of the now doc-less /docs URL lands on the list, not a blank page.
+    await waitFor(() => expect(screen.queryByTestId('editor-shell')).toBeNull())
+    expect(window.sessionStorage.getItem(TARGET_KEY)).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1311,3 +1311,81 @@ describe('DocsHome — browser Back returns to the list, never about:blank (XIN-
     expect(assignSpy).not.toHaveBeenCalled()
   })
 })
+
+describe('DocsHome — pin order survives the search → pin → clear-search re-render (XIN-1185)', () => {
+  // Reproduces the exact tester path reported against FEAT-B: 我的文档 → search "FEAT" → right-click
+  // pin the matching doc → clear the search. The suspicion was that the post-clear re-fetch drops the
+  // pin ordering. The client-side pin is React/localStorage state on DocsHome, and `displayItems`
+  // re-applies a stable pinned-first sort over EVERY mine result set — including the fresh list the
+  // cleared search re-fetches — so a doc pinned while filtered must float to the first row afterward.
+  const item = (docId: string, title: string, updatedAt: string) => ({
+    docId,
+    title,
+    ownerId: 'u_self',
+    role: 'admin' as const,
+    updatedAt,
+  })
+  // Server order for the unfiltered "mine" list is updatedAt:desc, so FEAT spec is NOT first here.
+  const FULL = [
+    item('d_alpha', 'Alpha', '2026-07-10T00:00:00Z'),
+    item('d_feat', 'FEAT spec', '2026-07-09T00:00:00Z'),
+    item('d_beta', 'Beta', '2026-07-08T00:00:00Z'),
+  ]
+
+  const rowTitles = () =>
+    Array.from(document.querySelectorAll('.octo-docs-list-row-title')).map(
+      (el) => el.textContent ?? '',
+    )
+
+  it('floats a doc pinned while a search is active to the top after the search is cleared', async () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs/recent/creators')) {
+        return { data: { creators: [] }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs/recent')) {
+        return { data: { total: 0, items: [], nextCursor: null }, status: 200 }
+      }
+      if (method === 'get' && url.includes('owner=me')) {
+        // The "search FEAT" request narrows the list to the single matching doc.
+        if (url.includes('q=FEAT')) {
+          return { data: { total: 1, items: [FULL[1]] }, status: 200 }
+        }
+        return { data: { total: FULL.length, items: FULL }, status: 200 }
+      }
+      return { data: { total: 0, items: [] }, status: 200 }
+    }
+
+    render(<DocsHome />)
+
+    // 我的文档 tab.
+    fireEvent.click(screen.getByText('docs.tab.mine'))
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeTruthy())
+    // Baseline: server order, FEAT spec is not first.
+    expect(rowTitles()[0]).toBe('Alpha')
+
+    // search "FEAT" (SearchBox debounces ~300ms before emitting the query).
+    fireEvent.change(screen.getByPlaceholderText('docs.search.placeholder'), {
+      target: { value: 'FEAT' },
+    })
+    await waitFor(() => {
+      const titles = rowTitles()
+      expect(titles).toEqual(['FEAT spec'])
+    })
+
+    // right-click the matching row → pin it.
+    fireEvent.contextMenu(screen.getByText('FEAT spec').closest('button')!)
+    fireEvent.click(screen.getByText('docs.sheet.pin'))
+    // Pin persisted to localStorage (the durable client-side pin store).
+    expect(JSON.parse(window.localStorage.getItem('octo.docs.pinned') || '[]')).toContain('d_feat')
+
+    // clear the search → the full list is re-fetched and re-rendered.
+    fireEvent.click(screen.getByLabelText('docs.empty.searchNoneCta'))
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeTruthy())
+
+    // The pinned doc floats to the FIRST row over the server's updatedAt:desc order; the rest keep
+    // their server order beneath it (stable sort).
+    expect(rowTitles()).toEqual(['FEAT spec', 'Alpha', 'Beta'])
+  })
+})

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { getWKApp, getRouteRight, onSpaceChanged, t } from '../octoweb/index.ts'
+import { getWKApp, getRouteRight, onSpaceChanged, onNavMenuActivated, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import { SheetView } from '../sheet/SheetView.tsx'
 import { parseXlsxToMatrix, pendingSheetImports } from '../sheet/xlsxImport.ts'
@@ -908,6 +908,13 @@ export function DocsHome() {
   useEffect(() => {
     selectedDocIdRef.current = selectedDocId
   }, [selectedDocId])
+  // Companion live mirror of the open doc's KIND, read by the nav-reactivation handler below so it
+  // re-pushes the right shell (editor vs board vs sheet) without a stale closure — same reason
+  // selectedDocIdRef exists.
+  const selectedDocTypeRef = useRef<string | undefined>(selectedDocType)
+  useEffect(() => {
+    selectedDocTypeRef.current = selectedDocType
+  }, [selectedDocType])
 
   // The host's right (main) route pane. When present (production), the editor is pushed there
   // so it fills the main content area while the list stays in the left route slot — the same
@@ -1220,6 +1227,46 @@ export function DocsHome() {
       openDoc(initialTarget.current!.docId, undefined)
     }
     // Only on mount: subsequent selections are pushed by openDoc / backToList.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Re-assert docs' ownership of the right pane whenever the user RE-ENTERS via the NavRail
+  // "文档" icon. This is what makes the nav-icon entry render identically to a direct/refresh
+  // `/docs` load (XIN-1165). The mechanism it repairs:
+  //   - apps/web Pages/Main `onMenuClick` calls `WKApp.routeRight.popToRoot()` for a non-chat
+  //     menu, EMPTYING the shared right pane on every docs nav click;
+  //   - but MainContentLeft keeps `/docs` mounted and only toggles `display`, so DocsHome does
+  //     NOT remount and the mount-only effect above never re-runs to refill the pane;
+  //   - the deep-link / hard-load activation path (MainVM.didMount / activatePendingRouteMenu)
+  //     deliberately does NOT popToRoot, so a direct `/docs` always keeps the pane full.
+  // Net effect before this fix: nav-icon return left the right pane empty → the host chat
+  // placeholder (the always-present base layer of the right viewqueue) showed through, so the
+  // two entries diverged and "开文档→返回/reload" appeared to fall back. We re-push exactly what
+  // the mount effect would: the open doc's shell if one is selected (its React state survives the
+  // display-toggle), otherwise the docs empty state — never leaving the queue empty. Refs keep the
+  // handler reading the CURRENT selection AND the CURRENT buildRightPane (which is re-created on a
+  // Space switch / member-name resolve) so a re-push never rebuilds the editor against a stale
+  // Space (the cross-Space session leak reconciled in XIN-448).
+  const buildRightPaneRef = useRef(buildRightPane)
+  useEffect(() => {
+    buildRightPaneRef.current = buildRightPane
+  }, [buildRightPane])
+  useEffect(() => {
+    if (!routeRight) return
+    return onNavMenuActivated('docs', () => {
+      try {
+        const id = selectedDocIdRef.current
+        if (id) {
+          routeRight.replaceToRoot(buildRightPaneRef.current(id, selectedDocTypeRef.current) as unknown)
+        } else {
+          routeRight.replaceToRoot(buildEmptyState() as unknown)
+        }
+      } catch {
+        // ignore — right pane unavailable
+      }
+    })
+    // routeRight + buildEmptyState are stable (singleton + []-dep useCallback); buildRightPane is
+    // read through a ref so the subscription stays mounted for the component's life.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -21,6 +21,7 @@ import { PortalMenu } from './PortalMenu.tsx'
 import { DocsTabs } from './DocsTabs.tsx'
 import { SearchBox } from './SearchBox.tsx'
 import { CreatorFilter, CreatorChips, creatorName } from './CreatorFilter.tsx'
+import { TypeFilter, TypeChips } from './TypeFilter.tsx'
 import { InfiniteList } from './InfiniteList.tsx'
 import { useDocsView, type DocsViewKind } from './useDocsView.ts'
 
@@ -283,24 +284,47 @@ function BoardRowIcon(): React.ReactElement {
 }
 
 /**
- * Layered empty states A–E (frontend-design §5.3). Each variant carries its OWN i18n title + CTA
- * keys — A ("看", browse) and B ("建", create) are deliberately NOT merged (product MF1). C/D/E cover
- * "conditions matched nothing" and offer the matching clear affordance(s); E shows BOTH clears.
+ * Sheet row glyph — a grid to mark spreadsheets, visually distinct from the plain-doc and board
+ * glyphs so a `docType==='sheet'` row is never mistaken for a document (XIN-1188 icon three-way).
+ */
+function SheetRowIcon(): React.ReactElement {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="2" y="2.5" width="12" height="11" rx="1" stroke="currentColor" strokeWidth="1" fill="none" />
+      <path d="M2 6.5h12M2 10h12M6 2.5v11M10 2.5v11" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  )
+}
+
+/**
+ * Layered empty states A–F (frontend-design §5.3). Each variant carries its OWN i18n title + CTA
+ * keys — A ("看", browse) and B ("建", create) are deliberately NOT merged (product MF1). C/D/F cover
+ * a single "condition matched nothing" (search / creator / type) and offer that one clear
+ * affordance; E is the combined bucket for ANY 2+ active conditions and renders each matching clear
+ * (search / creator / type) conditionally on the active flags.
  */
 function DocsEmptyState({
   kind,
   query,
+  hasQuery,
+  hasCreators,
+  hasTypes,
   onCreate,
   onBrowseMine,
   onClearSearch,
   onClearFilter,
+  onClearTypes,
 }: {
-  kind: 'A' | 'B' | 'C' | 'D' | 'E'
+  kind: 'A' | 'B' | 'C' | 'D' | 'E' | 'F'
   query: string
+  hasQuery: boolean
+  hasCreators: boolean
+  hasTypes: boolean
   onCreate: () => void
   onBrowseMine: () => void
   onClearSearch: () => void
   onClearFilter: () => void
+  onClearTypes: () => void
 }): React.ReactElement {
   const kw = query.trim()
   return (
@@ -339,16 +363,33 @@ function DocsEmptyState({
           </button>
         </>
       )}
+      {kind === 'F' && (
+        <>
+          <p className="octo-docs-empty-title">{t('docs.empty.typeNone')}</p>
+          <button type="button" className="octo-docs-empty-cta" onClick={onClearTypes}>
+            {t('docs.empty.typeNoneCta')}
+          </button>
+        </>
+      )}
       {kind === 'E' && (
         <>
           <p className="octo-docs-empty-title">{t('docs.empty.combinedNone')}</p>
           <div className="octo-docs-empty-actions">
-            <button type="button" className="octo-docs-empty-cta" onClick={onClearSearch}>
-              {t('docs.empty.searchNoneCta')}
-            </button>
-            <button type="button" className="octo-docs-empty-cta" onClick={onClearFilter}>
-              {t('docs.empty.filterNoneCta')}
-            </button>
+            {hasQuery && (
+              <button type="button" className="octo-docs-empty-cta" onClick={onClearSearch}>
+                {t('docs.empty.searchNoneCta')}
+              </button>
+            )}
+            {hasCreators && (
+              <button type="button" className="octo-docs-empty-cta" onClick={onClearFilter}>
+                {t('docs.empty.filterNoneCta')}
+              </button>
+            )}
+            {hasTypes && (
+              <button type="button" className="octo-docs-empty-cta" onClick={onClearTypes}>
+                {t('docs.empty.typeNoneCta')}
+              </button>
+            )}
           </div>
         </>
       )}
@@ -557,6 +598,21 @@ function DocsList({
         : d.docType === 'doc'
           ? 'doc'
           : undefined
+    // Row-icon kind (visual only, always concrete): a known board, then an explicit sheet, else a
+    // plain doc — the three-way distinction so a spreadsheet never renders as a document icon
+    // (XIN-1188). Independent of `knownKind` above, which stays `undefined` for an unresolved
+    // shared row so openDoc can still resolve the authoritative shell via getDoc.
+    const iconKind: 'board' | 'sheet' | 'doc' = board
+      ? 'board'
+      : d.docType === 'sheet'
+        ? 'sheet'
+        : 'doc'
+    const kindLabel =
+      iconKind === 'board'
+        ? t('docs.list.kindBoard')
+        : iconKind === 'sheet'
+          ? t('docs.list.kindSheet')
+          : t('docs.list.kindDoc')
     // Recent rows show the creator inline + when the doc was VIEWED; mine rows keep the "updated"
     // sub-line (frontend-design §2.1 / §5.1).
     const creator =
@@ -583,10 +639,16 @@ function DocsList({
         >
           <span
             className="octo-docs-list-row-icon"
-            aria-label={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
-            title={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
+            aria-label={kindLabel}
+            title={kindLabel}
           >
-            {board ? <BoardRowIcon /> : <DocRowIcon />}
+            {iconKind === 'board' ? (
+              <BoardRowIcon />
+            ) : iconKind === 'sheet' ? (
+              <SheetRowIcon />
+            ) : (
+              <DocRowIcon />
+            )}
           </span>
           <span className="octo-docs-list-row-text">
             <span
@@ -762,6 +824,9 @@ function DocsList({
             nameFallback={nameFallback}
           />
         )}
+        {/* Type filter lives on BOTH tabs (creator is recent-only). Uses the active view's per-tab
+            types state so each tab remembers its own selection across switches. */}
+        <TypeFilter selected={view.types} onToggle={view.toggleType} />
       </div>
       {activeView === 'recent' && (
         <CreatorChips
@@ -772,6 +837,7 @@ function DocsList({
           nameFallback={nameFallback}
         />
       )}
+      <TypeChips selected={view.types} onToggle={view.toggleType} onClearAll={view.clearTypes} />
       {createError && <p className="octo-docs-list-state octo-error">{createError}</p>}
       {view.phase === 'loading' && (
         <p className="octo-docs-list-state">{t('docs.state.loading')}</p>
@@ -788,10 +854,14 @@ function DocsList({
         <DocsEmptyState
           kind={view.empty}
           query={view.q}
+          hasQuery={view.q.trim().length > 0}
+          hasCreators={view.creators.length > 0}
+          hasTypes={view.types.length > 0}
           onCreate={() => void onCreate()}
           onBrowseMine={() => onTab('mine')}
           onClearSearch={view.clearQuery}
           onClearFilter={view.clearCreators}
+          onClearTypes={view.clearTypes}
         />
       )}
       {view.phase === 'ready' && !view.empty && (

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -163,25 +163,87 @@ export function resolveDocTarget(search: string, uid?: string): DocTarget | null
 }
 
 /**
+ * History-state markers we stamp on the docs route's entries so a browser Back/Forward can be
+ * told apart from a genuine reload/deep-link (see readDocFromHistory + the popstate handler).
+ * `octoDocsDoc` tags the entry that addresses an open doc; `octoDocsList` tags the list entry
+ * that sits beneath it. Kept as a small serialisable shape so it survives history.state.
+ */
+const HISTORY_STATE_DOC = 'octoDocsDoc'
+const HISTORY_STATE_LIST = 'octoDocsList'
+
+/** Build the `/docs?…&doc=<id>` URL for the given selection (doc addressing). */
+function docUrl(docId: string, space: string, folder: string): string {
+  const q = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
+  q.set('space', space)
+  q.set('folder', folder)
+  q.set('doc', docId)
+  return `/docs?${q.toString()}`
+}
+
+/** Build the `/docs` list URL (doc addressing stripped). */
+function listUrl(): string {
+  const q = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
+  q.delete('doc')
+  q.delete('docId')
+  q.delete('space')
+  q.delete('folder')
+  const qs = q.toString()
+  return qs ? `/docs?${qs}` : '/docs'
+}
+
+/**
  * Mirror the active doc to the URL (`?doc=<id>`) WITHOUT a full navigation.
  *
- * Split-pane note: opening a doc is now an in-pane state change (setSelectedDoc), not a
- * `window.location.assign`. We still reflect the selection into the URL via
- * history.replaceState so the link is shareable/refreshable — but replaceState does NOT
- * trigger the host RouteManager's pathname-only re-push (that fires on assign/pushState),
- * so `?doc=` is no longer wiped. sessionStorage remains the durable mirror for the
- * deep-link/refresh path. This is what neutralizes the `?doc=` strip should-fix.
+ * Split-pane note: opening a doc is an in-pane state change (setSelectedDoc), not a
+ * `window.location.assign`. We reflect the selection into the URL so the link is
+ * shareable/refreshable; neither replaceState nor pushState triggers the host RouteManager's
+ * pathname-only re-push (that only fires on `popstate`/`pageshow`), so `?doc=` is not wiped
+ * on open. sessionStorage remains the durable mirror for the deep-link/refresh path.
+ *
+ * `push` controls the history entry (XIN-1172 — the Back/reload → about:blank fix):
+ *   - `push: true`  — opening a doc while none was open. We first normalise the CURRENT entry
+ *     to the list, then push the doc as its OWN entry. That guarantees a list entry sits
+ *     beneath the doc, so a browser Back returns to the list instead of popping past `/docs`
+ *     to the tab's initial `about:blank` (the reported blank page). Before this fix opening a
+ *     doc only replaceState'd the current entry, leaving no in-app entry to go Back to.
+ *   - `push: false` — switching from one open doc to another: stay at the same history depth
+ *     (a single doc entry over the one list entry), so Back still lands on the list.
  */
-function mirrorDocToUrl(docId: string, space: string, folder: string): void {
+function mirrorDocToUrl(docId: string, space: string, folder: string, push: boolean): void {
   if (typeof window === 'undefined') return
   try {
-    const q = new URLSearchParams(window.location.search)
-    q.set('space', space)
-    q.set('folder', folder)
-    q.set('doc', docId)
-    window.history.replaceState(window.history.state, '', `/docs?${q.toString()}`)
+    const url = docUrl(docId, space, folder)
+    if (push) {
+      // Normalise the current entry to the list (Back target), then push the doc entry on top.
+      window.history.replaceState({ [HISTORY_STATE_LIST]: true }, '', listUrl())
+      window.history.pushState({ [HISTORY_STATE_DOC]: docId }, '', url)
+    } else {
+      window.history.replaceState({ [HISTORY_STATE_DOC]: docId }, '', url)
+    }
   } catch {
     // history unavailable: selection still works via state; just not URL-reflected.
+  }
+}
+
+/**
+ * Resolve which doc (if any) a history entry addresses, used by the popstate handler to decide
+ * list vs doc after a browser Back/Forward. Prefers the marker we stamped on the entry
+ * (`octoDocsDoc`/`octoDocsList`); falls back to the URL query when the state is absent (e.g. the
+ * host RouteManager overwrote it on its own popstate re-push). Returns the docId, or null for
+ * "this is the list".
+ */
+export function readDocFromHistory(state: unknown, search: string): string | null {
+  const st = state && typeof state === 'object' ? (state as Record<string, unknown>) : null
+  if (st) {
+    const doc = st[HISTORY_STATE_DOC]
+    if (typeof doc === 'string' && doc) return doc
+    if (st[HISTORY_STATE_LIST] === true) return null
+  }
+  try {
+    const q = new URLSearchParams(search)
+    return q.get('doc') || q.get('docId') || null
+  } catch {
+    return null
   }
 }
 
@@ -189,13 +251,7 @@ function mirrorDocToUrl(docId: string, space: string, folder: string): void {
 function mirrorListToUrl(): void {
   if (typeof window === 'undefined') return
   try {
-    const q = new URLSearchParams(window.location.search)
-    q.delete('doc')
-    q.delete('docId')
-    q.delete('space')
-    q.delete('folder')
-    const qs = q.toString()
-    window.history.replaceState(window.history.state, '', qs ? `/docs?${qs}` : '/docs')
+    window.history.replaceState({ [HISTORY_STATE_LIST]: true }, '', listUrl())
   } catch {
     // ignore
   }
@@ -1122,16 +1178,21 @@ export function DocsHome() {
   // right pane. Split out from openDoc so the kind can be resolved asynchronously first.
   const commitOpen = useCallback(
     (docId: string, docType: 'board' | 'doc' | 'sheet') => {
+      // Whether a doc was already open BEFORE this commit — read from the live ref (not the
+      // closed-over state, which lags a render). Drives whether we PUSH a new history entry
+      // (first open from the list) or REPLACE in place (doc → doc switch). See mirrorDocToUrl.
+      const wasOpen = selectedDocIdRef.current !== null
       setSelectedDocId(docId)
       setSelectedDocType(docType)
       // View ingest (frontend-design §3.4 / XIN-1098 API 1): record that this doc was opened so it
       // surfaces in "最近查看". Fire-and-forget on the open success path — read-only opens count too,
       // the call is idempotent (server UPSERTs on (uid,docId)), and a failure never blocks the open.
       void recordDocView(docId)
-      // Durable mirror (survives the host's query-wiping re-push) + shareable URL (replaceState,
-      // no host re-push) — together neutralizing the `?doc=` strip should-fix.
+      // Durable mirror (survives the host's query-wiping re-push) + shareable URL. On a first open
+      // we push a doc entry over a normalised list entry so a browser Back returns to the list, not
+      // the tab's initial about:blank (XIN-1172).
       persistDocTarget({ space, folder, doc: docId, docType })
-      mirrorDocToUrl(docId, space, folder)
+      mirrorDocToUrl(docId, space, folder, !wasOpen)
       const push = (dt: string | undefined) => {
         setSelectedDocType(dt)
         if (routeRight) {
@@ -1270,6 +1331,29 @@ export function DocsHome() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Browser Back / Forward handling (XIN-1172). Opening a doc pushes a doc history entry over a
+  // list entry (see mirrorDocToUrl), so a Back pops to the list entry and fires `popstate`. Here we
+  // reconcile the pane to whatever that entry addresses: a doc → (re)open it; the list → close the
+  // doc AND clear the persisted target so neither this instance nor the host RouteManager's own
+  // popstate re-push (which re-mounts DocsHome reading sessionStorage) re-opens the doc. Clearing
+  // synchronously in the popstate dispatch — before React flushes the host's re-mount — is what
+  // makes "open doc → Back → list (kept), reload → still list, never about:blank" deterministic.
+  useEffect(() => {
+    const onPopState = () => {
+      const doc =
+        typeof window !== 'undefined'
+          ? readDocFromHistory(window.history.state, window.location.search)
+          : null
+      if (doc) {
+        if (doc !== selectedDocIdRef.current) openDoc(doc)
+      } else {
+        clearDocTarget()
+        backToList()
+      }
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [openDoc, backToList])
   // Production (routeRight present): the editor lives in the host's main pane; this route
   // slot renders ONLY the resident list (left). Tests / standalone (no routeRight): render
   // the inline CSS split-pane (left list + right editor) so the layout still works.

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { createPortal } from 'react-dom'
 import { getWKApp, getRouteRight, onSpaceChanged, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import { SheetView } from '../sheet/SheetView.tsx'
@@ -13,11 +12,17 @@ import {
   DEFAULT_DOC_ID,
   DOC_TARGET_STORAGE_KEY,
 } from '../config.ts'
-import { listDocs, createDoc, getDoc, type DocListItem } from './docsApi.ts'
+import { createDoc, getDoc, recordDocView, type DocListItem } from './docsApi.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { createInvite, buildInviteUrl } from '../invite/api.ts'
 import { canManage, type Role } from '../auth/roles.ts'
 import { formatRelative, formatAbsolute } from '../versions/format.ts'
+import { PortalMenu } from './PortalMenu.tsx'
+import { DocsTabs } from './DocsTabs.tsx'
+import { SearchBox } from './SearchBox.tsx'
+import { CreatorFilter, CreatorChips, creatorName } from './CreatorFilter.tsx'
+import { InfiniteList } from './InfiniteList.tsx'
+import { useDocsView, type DocsViewKind } from './useDocsView.ts'
 
 export interface DocTarget {
   space: string
@@ -36,47 +41,6 @@ export interface DocTarget {
  * per release. Import machinery (parse + float-image + hyperlink) lives in xlsxImport/CollabSheet.
  */
 const IMPORT_ENABLED = true
-
-/**
- * A dropdown menu rendered in a body portal at fixed coords, so it is never clipped by an
- * ancestor's `overflow` (the docs list panel scrolls, which was cutting off inline menus).
- * A full-screen transparent backdrop closes it on outside click.
- */
-function PortalMenu({
-  at,
-  onClose,
-  children,
-}: {
-  at: { left: number; top: number }
-  onClose: () => void
-  children: React.ReactNode
-}) {
-  return createPortal(
-    <>
-      <div onMouseDown={onClose} style={{ position: 'fixed', inset: 0, zIndex: 1000 }} />
-      <div
-        role="menu"
-        style={{
-          position: 'fixed',
-          left: at.left,
-          top: at.top,
-          zIndex: 1001,
-          background: '#fff',
-          color: '#333',
-          border: '1px solid #dadce0',
-          borderRadius: 8,
-          boxShadow: '0 6px 18px rgba(0,0,0,0.16)',
-          padding: 6,
-          minWidth: 160,
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {children}
-      </div>
-    </>,
-    document.body,
-  )
-}
 
 /**
  * sessionStorage key holding the doc the user is currently viewing.
@@ -263,6 +227,80 @@ function BoardRowIcon(): React.ReactElement {
 }
 
 /**
+ * Layered empty states A–E (frontend-design §5.3). Each variant carries its OWN i18n title + CTA
+ * keys — A ("看", browse) and B ("建", create) are deliberately NOT merged (product MF1). C/D/E cover
+ * "conditions matched nothing" and offer the matching clear affordance(s); E shows BOTH clears.
+ */
+function DocsEmptyState({
+  kind,
+  query,
+  onCreate,
+  onBrowseMine,
+  onClearSearch,
+  onClearFilter,
+}: {
+  kind: 'A' | 'B' | 'C' | 'D' | 'E'
+  query: string
+  onCreate: () => void
+  onBrowseMine: () => void
+  onClearSearch: () => void
+  onClearFilter: () => void
+}): React.ReactElement {
+  const kw = query.trim()
+  return (
+    <div className="octo-docs-list-state octo-docs-list-empty">
+      {kind === 'A' && (
+        <>
+          <p className="octo-docs-empty-title">{t('docs.empty.recentNone')}</p>
+          <button type="button" className="octo-docs-empty-cta" onClick={onBrowseMine}>
+            {t('docs.empty.recentNoneCta')}
+          </button>
+        </>
+      )}
+      {kind === 'B' && (
+        <>
+          <p className="octo-docs-empty-title">{t('docs.empty.myDocsNone')}</p>
+          <button type="button" className="octo-docs-empty-cta" onClick={onCreate}>
+            {t('docs.empty.myDocsNoneCta')}
+          </button>
+        </>
+      )}
+      {kind === 'C' && (
+        <>
+          <p className="octo-docs-empty-title">
+            {t('docs.empty.searchNone', { values: { kw } })}
+          </p>
+          <button type="button" className="octo-docs-empty-cta" onClick={onClearSearch}>
+            {t('docs.empty.searchNoneCta')}
+          </button>
+        </>
+      )}
+      {kind === 'D' && (
+        <>
+          <p className="octo-docs-empty-title">{t('docs.empty.filterNone')}</p>
+          <button type="button" className="octo-docs-empty-cta" onClick={onClearFilter}>
+            {t('docs.empty.filterNoneCta')}
+          </button>
+        </>
+      )}
+      {kind === 'E' && (
+        <>
+          <p className="octo-docs-empty-title">{t('docs.empty.combinedNone')}</p>
+          <div className="octo-docs-empty-actions">
+            <button type="button" className="octo-docs-empty-cta" onClick={onClearSearch}>
+              {t('docs.empty.searchNoneCta')}
+            </button>
+            <button type="button" className="octo-docs-empty-cta" onClick={onClearFilter}>
+              {t('docs.empty.filterNoneCta')}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
  * Document list landing — shown when `/docs` is opened without a specific doc addressed.
  * Lists documents the caller owns or is a member of (GET /api/v1/docs) and offers a
  * "new document" action (POST /api/v1/docs). Selecting/creating navigates to the editor.
@@ -283,14 +321,13 @@ function DocsList({
   onSelect: (docId: string, docType?: string) => void
   reloadToken?: number
 }): React.ReactElement {
-  const [items, setItems] = useState<DocListItem[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
   const [newMenuAt, setNewMenuAt] = useState<{ left: number; top: number } | null>(null)
   const [importMenuAt, setImportMenuAt] = useState<{ left: number; top: number } | null>(null)
   const importInputRef = useRef<HTMLInputElement>(null)
-  // Client-side pin (置顶) — persisted in localStorage; pinned docs sort to the top.
+  // Client-side pin (置顶) — persisted in localStorage; pinned docs sort to the top. Pin is a
+  // "我的文档" affordance ONLY: the recent tab renders the server's `viewed_at DESC` order verbatim
+  // with no client re-sort and no pin menu item (frontend-design §5.4).
   const [pinned, setPinned] = useState<Set<string>>(() => {
     try {
       return new Set<string>(JSON.parse(window.localStorage.getItem('octo.docs.pinned') || '[]'))
@@ -301,6 +338,37 @@ function DocsList({
   // Right-click context menu anchor (like 企业微信's list menu): { docId, role, x, y } | null.
   const [menu, setMenu] = useState<{ docId: string; role: Role; x: number; y: number } | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  // Transient create/import error (distinct from a per-view list-load error). Shown as a state line
+  // above the list; cleared on the next successful create/import.
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  // Two tabs, each with its OWN search / creator filter / items / pagination state
+  // (frontend-design §2.1). Both instances stay mounted so per-view state survives a tab switch and
+  // is restored + re-sent on return (AC-2.3.2). `reloadToken` (parent rename/delete) and a Space
+  // switch refetch both views. The stale-response guard now lives inside useDocsView (per view).
+  const token = reloadToken ?? 0
+  const recentView = useDocsView('recent', space, folder, token)
+  const mineView = useDocsView('mine', space, folder, token)
+  const [activeView, setActiveView] = useState<DocsViewKind>('recent')
+  const view = activeView === 'recent' ? recentView : mineView
+
+  // Creator-name fallback for the recent filter when the facet omits a name (frontend-design §3.5 /
+  // §1.7): the space member-name map, else the raw uid (resolved in creatorName()).
+  const names = useMemberNames(space)
+  const nameFallback = useCallback((id: string) => names.get(id), [names])
+
+  const onTab = (next: DocsViewKind) => {
+    if (next === activeView) return
+    setActiveView(next)
+    // Restore the target view's remembered q/creators AND re-send its request (AC-2.3.2).
+    ;(next === 'recent' ? recentView : mineView).reload()
+  }
+
+  // Refresh both tabs after an in-list create/import so a new doc appears without a full remount.
+  const reloadViews = useCallback(() => {
+    recentView.reload()
+    mineView.reload()
+  }, [recentView, mineView])
 
   const togglePin = (id: string) => {
     setPinned((prev) => {
@@ -334,79 +402,6 @@ function DocsList({
     }
   }
 
-  // Stale-response guard (XIN-417). Switching Space bumps `space`, which recreates `reload` and
-  // fires a fresh listDocs — but the previous Space's request may still be in flight. listDocs
-  // resolves in network order, not call order, so an older-Space response can land AFTER the
-  // newer one and its unconditional setItems would render the wrong Space's documents into the
-  // current page (exactly the class of bug this PR fixes). We stamp each reload with a monotonic
-  // sequence and only let the LATEST reload's response touch state; superseded responses are
-  // dropped. A ref (not state) so it survives re-renders without itself triggering one.
-  const reloadSeq = useRef(0)
-
-  const reload = useCallback(() => {
-    const seq = ++reloadSeq.current
-    setLoading(true)
-    setError(null)
-    // The backend paginates (default pageSize 20, max 100) and reports `total`.
-    // The sidebar must show every document, not just the first page, so fetch
-    // all pages and concatenate. pageSize is pinned to the backend maximum (100)
-    // to minimize round-trips; the loop stops once we have collected `total`
-    // items (or a short page comes back, guarding against a stalled total).
-    const fetchAll = async (): Promise<DocListItem[]> => {
-      const PAGE_SIZE = 100
-      const all: DocListItem[] = []
-      let page = 1
-      for (;;) {
-        const res = await listDocs({
-          spaceId: space || undefined,
-          folderId: folder || undefined,
-          sort: 'updatedAt:desc',
-          page,
-          pageSize: PAGE_SIZE,
-        })
-        const batch = res?.items ?? []
-        all.push(...batch)
-        const total = res?.total ?? all.length
-        if (batch.length < PAGE_SIZE || all.length >= total) break
-        page += 1
-      }
-      return all
-    }
-    fetchAll()
-      .then((items) => {
-        // A newer reload has superseded this one (e.g. the Space changed again while this
-        // request was in flight) — drop the stale response so it can't overwrite the current list.
-        if (seq !== reloadSeq.current) return
-        setItems(items)
-      })
-      .catch((err) => {
-        if (seq !== reloadSeq.current) return
-        // Don't swallow the failure: surface it so a first-load error is diagnosable
-        // (and offer a retry below) instead of a silently sticky error state.
-        console.error('[docs] list failed', err)
-        setError(t('docs.state.error'))
-      })
-      .finally(() => {
-        // Keep the spinner up until the latest reload settles; a stale request finishing first
-        // must not clear loading while the current one is still pending.
-        if (seq !== reloadSeq.current) return
-        setLoading(false)
-      })
-  }, [space, folder])
-
-  useEffect(reload, [reload])
-
-  // Refresh the list when the parent bumps reloadToken (e.g. after a rename) so titles update.
-  const firstReloadRef = useRef(true)
-  useEffect(() => {
-    if (firstReloadRef.current) {
-      firstReloadRef.current = false
-      return // initial load already handled by the mount effect above
-    }
-    reload()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reloadToken])
-
   const onCreate = async (docType?: string) => {
     if (creating) return
     setCreating(true)
@@ -428,10 +423,10 @@ function DocsList({
       if (docType === 'board') rememberBoard(created.docId, uid)
       // New docs land in the list; select it inline (right pane opens, list stays).
       onSelect(created.docId, created.docType || docType)
-      reload()
+      reloadViews()
       setCreating(false)
     } catch {
-      setError(t('docs.state.error'))
+      setCreateError(t('docs.state.error'))
       setCreating(false)
     }
   }
@@ -446,14 +441,14 @@ function DocsList({
     // pull them into memory. 20MB comfortably covers real spreadsheets.
     const MAX_IMPORT_BYTES = 20 * 1024 * 1024
     if (file.size > MAX_IMPORT_BYTES) {
-      setError(t('docs.sheet.importTooLarge'))
+      setCreateError(t('docs.sheet.importTooLarge'))
       return
     }
     setCreating(true)
     try {
       const result = await parseXlsxToMatrix(await file.arrayBuffer())
       if (!result.ok) {
-        setError(result.reason === 'empty' ? t('docs.sheet.importEmpty') : t('docs.sheet.importError'))
+        setCreateError(result.reason === 'empty' ? t('docs.sheet.importEmpty') : t('docs.sheet.importError'))
         setCreating(false)
         return
       }
@@ -467,17 +462,108 @@ function DocsList({
       })
       pendingSheetImports.set(created.docId, parsed)
       onSelect(created.docId, 'sheet')
-      reload()
+      reloadViews()
       // Every visible worksheet is imported now (multi-sheet), so the only remaining caveat
       // is per-sheet truncation of an oversized grid.
       if (parsed.truncated) {
-        setError(t('docs.sheet.importTruncated'))
+        setCreateError(t('docs.sheet.importTruncated'))
       }
     } catch {
-      setError(t('docs.state.error'))
+      setCreateError(t('docs.state.error'))
     } finally {
       setCreating(false)
     }
+  }
+
+  // Rows for the active view. mine keeps the pinned-first client sort over the server order; recent
+  // renders the server's `viewed_at DESC` order verbatim (no pin re-sort — frontend-design §5.4).
+  const displayItems =
+    activeView === 'mine'
+      ? [...mineView.items].sort(
+          (a, b) => (pinned.has(b.docId) ? 1 : 0) - (pinned.has(a.docId) ? 1 : 0),
+        )
+      : recentView.items
+
+  const renderRow = (d: DocListItem): React.ReactNode => {
+    const active = d.docId === selectedDocId
+    const hasTitle = !!d.title && d.title.trim().length > 0
+    const label = hasTitle ? d.title : t('docs.state.untitled')
+    const board = isBoardDoc(d, uid)
+    // Kind we can assert without a round-trip: a known board (API `docType==='board'` or the
+    // creator's local registry, both via isBoardDoc), an explicit `'doc'`, or an explicit `'sheet'`
+    // so a known spreadsheet row opens straight into SheetView. When the list API omitted docType
+    // AND we have no local board record — a NON-creator viewing a shared board — pass `undefined`
+    // so openDoc resolves the authoritative kind via getDoc (the M2 routing bug).
+    const knownKind: 'board' | 'doc' | 'sheet' | undefined = board
+      ? 'board'
+      : d.docType === 'sheet'
+        ? 'sheet'
+        : d.docType === 'doc'
+          ? 'doc'
+          : undefined
+    // Recent rows show the creator inline + when the doc was VIEWED; mine rows keep the "updated"
+    // sub-line (frontend-design §2.1 / §5.1).
+    const creator =
+      activeView === 'recent'
+        ? creatorName(d.ownerId, recentView.creatorOptions, nameFallback)
+        : ''
+    const stampIso = activeView === 'recent' ? d.viewedAt || d.updatedAt : d.updatedAt
+    return (
+      <li
+        key={d.docId}
+        className={
+          active ? 'octo-docs-list-item octo-docs-list-item-active' : 'octo-docs-list-item'
+        }
+      >
+        <button
+          type="button"
+          className="octo-docs-list-row"
+          onContextMenu={(e) => {
+            e.preventDefault()
+            setMenu({ docId: d.docId, role: d.role, x: e.clientX, y: e.clientY })
+          }}
+          onClick={() => onSelect(d.docId, knownKind)}
+          aria-current={active ? 'true' : undefined}
+        >
+          <span
+            className="octo-docs-list-row-icon"
+            aria-label={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
+            title={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
+          >
+            {board ? <BoardRowIcon /> : <DocRowIcon />}
+          </span>
+          <span className="octo-docs-list-row-text">
+            <span
+              className={
+                hasTitle
+                  ? 'octo-docs-list-row-title'
+                  : 'octo-docs-list-row-title octo-docs-list-row-title-untitled'
+              }
+            >
+              {label}
+            </span>
+            {(creator || stampIso) && (
+              <span
+                className="octo-docs-list-row-sub"
+                title={stampIso ? formatAbsolute(stampIso) : undefined}
+              >
+                {activeView === 'recent' ? (
+                  <>
+                    {creator}
+                    {creator && stampIso ? ' · ' : ''}
+                    {stampIso ? `${t('docs.list.viewedAt')} ${formatRelative(stampIso)}` : ''}
+                  </>
+                ) : stampIso ? (
+                  <>
+                    {t('docs.list.updatedAt')} {formatRelative(stampIso)}
+                  </>
+                ) : null}
+              </span>
+            )}
+          </span>
+        </button>
+      </li>
+    )
   }
 
   return (
@@ -609,88 +695,58 @@ function DocsList({
           </>
         )}
       </div>
-      {loading && <p className="octo-docs-list-state">{t('docs.state.loading')}</p>}
-      {error && !loading && (
+      <DocsTabs active={activeView} onChange={onTab} />
+      <div className="octo-docs-toolbar">
+        <SearchBox value={view.q} onSearch={view.setQuery} onClear={view.clearQuery} />
+        {activeView === 'recent' && (
+          <CreatorFilter
+            options={recentView.creatorOptions}
+            selected={recentView.creators}
+            onToggle={recentView.toggleCreator}
+            nameFallback={nameFallback}
+          />
+        )}
+      </div>
+      {activeView === 'recent' && (
+        <CreatorChips
+          options={recentView.creatorOptions}
+          selected={recentView.creators}
+          onToggle={recentView.toggleCreator}
+          onClearAll={recentView.clearCreators}
+          nameFallback={nameFallback}
+        />
+      )}
+      {createError && <p className="octo-docs-list-state octo-error">{createError}</p>}
+      {view.phase === 'loading' && (
+        <p className="octo-docs-list-state">{t('docs.state.loading')}</p>
+      )}
+      {view.phase === 'error' && (
         <p className="octo-docs-list-state octo-error">
-          {error}
-          <button type="button" className="octo-docs-list-retry" onClick={reload}>
+          {t('docs.state.error')}
+          <button type="button" className="octo-docs-list-retry" onClick={view.retry}>
             {t('docs.state.retry')}
           </button>
         </p>
       )}
-      {!loading && !error && items.length === 0 && (
-        <p className="octo-docs-list-state octo-docs-list-empty">{t('docs.state.empty')}</p>
+      {view.phase === 'ready' && view.empty && (
+        <DocsEmptyState
+          kind={view.empty}
+          query={view.q}
+          onCreate={() => void onCreate()}
+          onBrowseMine={() => onTab('mine')}
+          onClearSearch={view.clearQuery}
+          onClearFilter={view.clearCreators}
+        />
       )}
-      {!loading && !error && items.length > 0 && (
-        <ul className="octo-docs-list-items">
-          {[...items]
-            .sort((a, b) => (pinned.has(b.docId) ? 1 : 0) - (pinned.has(a.docId) ? 1 : 0))
-            .map((d) => {
-            const active = d.docId === selectedDocId
-            const hasTitle = !!d.title && d.title.trim().length > 0
-            const label = hasTitle ? d.title : t('docs.state.untitled')
-            const board = isBoardDoc(d, uid)
-            // Kind we can assert without a round-trip: a known board (API `docType==='board'` or
-            // the creator's local registry, both via isBoardDoc), an explicit `'doc'`, or an
-            // explicit `'sheet'` so a known spreadsheet row opens straight into SheetView. When the
-            // list API omitted docType AND we have no local board record — a NON-creator viewing a
-            // shared board — pass `undefined` so openDoc resolves the authoritative kind via getDoc
-            // instead of defaulting that member to the rich-text editor (the M2 routing bug).
-            const knownKind: 'board' | 'doc' | 'sheet' | undefined = board
-              ? 'board'
-              : d.docType === 'sheet'
-                ? 'sheet'
-                : d.docType === 'doc'
-                  ? 'doc'
-                  : undefined
-            return (
-              <li
-                key={d.docId}
-                className={
-                  active ? 'octo-docs-list-item octo-docs-list-item-active' : 'octo-docs-list-item'
-                }
-              >
-                <button
-                  type="button"
-                  className="octo-docs-list-row"
-                  onContextMenu={(e) => {
-                    e.preventDefault()
-                    setMenu({ docId: d.docId, role: d.role, x: e.clientX, y: e.clientY })
-                  }}
-                  onClick={() => onSelect(d.docId, knownKind)}
-                  aria-current={active ? 'true' : undefined}
-                >
-                  <span
-                    className="octo-docs-list-row-icon"
-                    aria-label={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
-                    title={board ? t('docs.list.kindBoard') : t('docs.list.kindDoc')}
-                  >
-                    {board ? <BoardRowIcon /> : <DocRowIcon />}
-                  </span>
-                  <span className="octo-docs-list-row-text">
-                    <span
-                      className={
-                        hasTitle
-                          ? 'octo-docs-list-row-title'
-                          : 'octo-docs-list-row-title octo-docs-list-row-title-untitled'
-                      }
-                    >
-                      {label}
-                    </span>
-                    {d.updatedAt && (
-                      <span
-                        className="octo-docs-list-row-sub"
-                        title={formatAbsolute(d.updatedAt)}
-                      >
-                        {t('docs.list.updatedAt')} {formatRelative(d.updatedAt)}
-                      </span>
-                    )}
-                  </span>
-                </button>
-              </li>
-            )
-          })}
-        </ul>
+      {view.phase === 'ready' && !view.empty && (
+        <InfiniteList
+          items={displayItems}
+          hasMore={view.hasMore}
+          moreStatus={view.moreStatus}
+          resultSetId={view.resultSetId}
+          onLoadMore={view.loadMore}
+          renderRow={renderRow}
+        />
       )}
       {menu && (
         <>
@@ -718,16 +774,18 @@ function DocsList({
               fontSize: 13,
             }}
           >
-            <div
-              role="menuitem"
-              style={{ padding: '8px 12px', cursor: 'pointer', borderRadius: 6 }}
-              onClick={() => {
-                togglePin(menu.docId)
-                setMenu(null)
-              }}
-            >
-              {pinned.has(menu.docId) ? t('docs.sheet.unpin') : t('docs.sheet.pin')}
-            </div>
+            {activeView === 'mine' && (
+              <div
+                role="menuitem"
+                style={{ padding: '8px 12px', cursor: 'pointer', borderRadius: 6 }}
+                onClick={() => {
+                  togglePin(menu.docId)
+                  setMenu(null)
+                }}
+              >
+                {pinned.has(menu.docId) ? t('docs.sheet.unpin') : t('docs.sheet.pin')}
+              </div>
+            )}
             {canManage(menu.role) && (
               <div
                 role="menuitem"
@@ -1059,6 +1117,10 @@ export function DocsHome() {
     (docId: string, docType: 'board' | 'doc' | 'sheet') => {
       setSelectedDocId(docId)
       setSelectedDocType(docType)
+      // View ingest (frontend-design §3.4 / XIN-1098 API 1): record that this doc was opened so it
+      // surfaces in "最近查看". Fire-and-forget on the open success path — read-only opens count too,
+      // the call is idempotent (server UPSERTs on (uid,docId)), and a failure never blocks the open.
+      void recordDocView(docId)
       // Durable mirror (survives the host's query-wiping re-push) + shareable URL (replaceState,
       // no host re-push) — together neutralizing the `?doc=` strip should-fix.
       persistDocTarget({ space, folder, doc: docId, docType })

--- a/packages/docs/src/pages/DocsTabs.tsx
+++ b/packages/docs/src/pages/DocsTabs.tsx
@@ -1,0 +1,35 @@
+import { t } from '../octoweb/index.ts'
+import type { DocsViewKind } from './useDocsView.ts'
+
+/**
+ * Two-tab switcher for the docs list: 最近查看 (recent, default) / 我的文档 (mine). Purely
+ * presentational — the active view and its per-tab state live in the container's `useDocsView`
+ * instances (frontend-design §2.1). Reuses the hand-written `octo-docs-*` visual language; no
+ * control library.
+ */
+export function DocsTabs({
+  active,
+  onChange,
+}: {
+  active: DocsViewKind
+  onChange: (view: DocsViewKind) => void
+}): React.ReactElement {
+  return (
+    <div className="octo-docs-tabs" role="tablist" aria-label={t('docs.menu.title')}>
+      {(['recent', 'mine'] as const).map((view) => (
+        <button
+          key={view}
+          type="button"
+          role="tab"
+          aria-selected={active === view}
+          className={
+            active === view ? 'octo-docs-tab octo-docs-tab-active' : 'octo-docs-tab'
+          }
+          onClick={() => onChange(view)}
+        >
+          {view === 'recent' ? t('docs.tab.recent') : t('docs.tab.mine')}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/docs/src/pages/InfiniteList.tsx
+++ b/packages/docs/src/pages/InfiniteList.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react'
+import { t } from '../octoweb/index.ts'
+import type { DocListItem } from './docsApi.ts'
+import type { DocsMoreStatus } from './useDocsView.ts'
+
+/**
+ * The scrollable list body with IntersectionObserver-driven pagination (frontend-design §2.3 / §5.5).
+ *
+ * A `sentinel` at the bottom of the scroll container is observed; when it enters the viewport we
+ * append the next page. NO Suspense / React.lazy is used for loading state — the host's MobX observer
+ * force-updates at high frequency and would starve React 18's Suspense RetryLane commits; the footer
+ * is plain conditional rendering instead. The observer is rebuilt whenever `hasMore` flips or the
+ * result set changes, and disconnected once there is nothing more to load.
+ */
+export function InfiniteList({
+  items,
+  renderRow,
+  hasMore,
+  moreStatus,
+  resultSetId,
+  onLoadMore,
+}: {
+  items: DocListItem[]
+  renderRow: (item: DocListItem) => React.ReactNode
+  hasMore: boolean
+  moreStatus: DocsMoreStatus
+  /** Bumped by the view on each new result set — resets the scroll position to the top. */
+  resultSetId: number
+  onLoadMore: () => void
+}): React.ReactElement {
+  const scrollRef = useRef<HTMLUListElement>(null)
+  const sentinelRef = useRef<HTMLLIElement>(null)
+  // Keep the latest onLoadMore without re-subscribing the observer on every render.
+  const loadMoreRef = useRef(onLoadMore)
+  useEffect(() => {
+    loadMoreRef.current = onLoadMore
+  }, [onLoadMore])
+
+  // Reset scroll to the top when a brand-new result set arrives (tab switch / search / filter).
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 0
+  }, [resultSetId])
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    const root = scrollRef.current
+    if (!sentinel || !root) return
+    if (!hasMore) return
+    // Guard environments without IntersectionObserver (older jsdom): pagination degrades to the
+    // manual "load more" affordance rendered in the footer below.
+    if (typeof IntersectionObserver === 'undefined') return
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            loadMoreRef.current()
+            break
+          }
+        }
+      },
+      { root, rootMargin: '120px' },
+    )
+    io.observe(sentinel)
+    return () => io.disconnect()
+  }, [hasMore, resultSetId])
+
+  return (
+    <ul className="octo-docs-list-items" ref={scrollRef}>
+      {items.map(renderRow)}
+      {(hasMore || moreStatus === 'loadingMore' || moreStatus === 'error') && (
+        <li ref={sentinelRef} className="octo-docs-list-more" aria-hidden="true">
+          {moreStatus === 'loadingMore' && (
+            <span className="octo-docs-list-more-loading">{t('docs.list.loadingMore')}</span>
+          )}
+          {moreStatus === 'error' && (
+            <span className="octo-docs-list-more-error">
+              {t('docs.list.loadMoreFailed')}
+              <button
+                type="button"
+                className="octo-docs-list-retry"
+                onClick={() => loadMoreRef.current()}
+              >
+                {t('docs.list.retry')}
+              </button>
+            </span>
+          )}
+          {moreStatus === 'idle' && hasMore && (
+            // Fallback affordance when IntersectionObserver can't reach the sentinel (e.g. very tall
+            // viewport, or no IO support). Clicking loads the next page.
+            <button
+              type="button"
+              className="octo-docs-list-more-btn"
+              onClick={() => loadMoreRef.current()}
+            >
+              {t('docs.list.loadingMore')}
+            </button>
+          )}
+        </li>
+      )}
+      {!hasMore && moreStatus === 'end' && items.length > 0 && (
+        <li className="octo-docs-list-end" aria-hidden="true">
+          {t('docs.list.end')}
+        </li>
+      )}
+    </ul>
+  )
+}

--- a/packages/docs/src/pages/PortalMenu.tsx
+++ b/packages/docs/src/pages/PortalMenu.tsx
@@ -1,0 +1,47 @@
+import { createPortal } from 'react-dom'
+
+/**
+ * A dropdown menu rendered in a body portal at fixed coords, so it is never clipped by an
+ * ancestor's `overflow` (the docs list panel scrolls, which was cutting off inline menus).
+ * A full-screen transparent backdrop closes it on outside click.
+ *
+ * Extracted from DocsHome so both the header "new/import" menus and the recent-tab CreatorFilter
+ * share one implementation (frontend-design §1.4 / §5.2).
+ */
+export function PortalMenu({
+  at,
+  onClose,
+  children,
+  minWidth = 160,
+}: {
+  at: { left: number; top: number }
+  onClose: () => void
+  children: React.ReactNode
+  minWidth?: number
+}): React.ReactElement {
+  return createPortal(
+    <>
+      <div onMouseDown={onClose} style={{ position: 'fixed', inset: 0, zIndex: 1000 }} />
+      <div
+        role="menu"
+        style={{
+          position: 'fixed',
+          left: at.left,
+          top: at.top,
+          zIndex: 1001,
+          background: '#fff',
+          color: '#333',
+          border: '1px solid #dadce0',
+          borderRadius: 8,
+          boxShadow: '0 6px 18px rgba(0,0,0,0.16)',
+          padding: 6,
+          minWidth,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {children}
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/packages/docs/src/pages/SearchBox.tsx
+++ b/packages/docs/src/pages/SearchBox.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react'
+import { t } from '../octoweb/index.ts'
+
+/** Debounce window before a keystroke triggers a server query (frontend-design §5.1). */
+const DEBOUNCE_MS = 300
+
+/**
+ * Filename search input, shared by both tabs (frontend-design §5.1). Holds the raw input locally and
+ * emits the (debounced) term to the owning view ~300ms after typing stops, so we don't fire a query
+ * per keystroke. A `×` clears the term (and emits immediately). `value` is the view's committed term
+ * so switching tabs restores the remembered search text.
+ *
+ * Server-side, a blank/whitespace term means "no search" (it does NOT trigger the search-empty
+ * state) — matched here by trimming before compare so re-typing the same term is a no-op.
+ */
+export function SearchBox({
+  value,
+  onSearch,
+  onClear,
+}: {
+  value: string
+  onSearch: (term: string) => void
+  onClear: () => void
+}): React.ReactElement {
+  const [text, setText] = useState(value)
+  // Track the last committed value so an external change (tab switch restoring a term) re-syncs the
+  // input without the debounce echoing it straight back as a new query.
+  const committedRef = useRef(value)
+
+  useEffect(() => {
+    if (value !== committedRef.current) {
+      committedRef.current = value
+      setText(value)
+    }
+  }, [value])
+
+  useEffect(() => {
+    if (text.trim() === committedRef.current.trim()) return
+    const id = window.setTimeout(() => {
+      committedRef.current = text
+      onSearch(text)
+    }, DEBOUNCE_MS)
+    return () => window.clearTimeout(id)
+  }, [text, onSearch])
+
+  const clear = () => {
+    setText('')
+    committedRef.current = ''
+    onClear()
+  }
+
+  return (
+    <div className="octo-docs-search">
+      <span className="octo-docs-search-icon" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.3" />
+          <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+        </svg>
+      </span>
+      <input
+        type="text"
+        className="octo-docs-search-input"
+        placeholder={t('docs.search.placeholder')}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      {text.length > 0 && (
+        <button
+          type="button"
+          className="octo-docs-search-clear"
+          aria-label={t('docs.empty.searchNoneCta')}
+          onClick={clear}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/docs/src/pages/TypeFilter.tsx
+++ b/packages/docs/src/pages/TypeFilter.tsx
@@ -1,0 +1,121 @@
+import { useRef, useState } from 'react'
+import { t } from '../octoweb/index.ts'
+import { PortalMenu } from './PortalMenu.tsx'
+import { DOC_TYPES, type DocType } from './docsApi.ts'
+
+/**
+ * i18n label key per document kind. The candidates are the fixed 3-value {@link DOC_TYPES} enum
+ * (doc/sheet/board), so — unlike the creator facet — there is NO server `type-facet` endpoint: the
+ * dropdown writes the candidate set directly and reuses the same labels the list-row icon uses
+ * (docs.list.kind*), keeping the filter and the rows consistent (XIN-1188).
+ */
+const TYPE_LABEL_KEY: Record<DocType, string> = {
+  doc: 'docs.list.kindDoc',
+  sheet: 'docs.list.kindSheet',
+  board: 'docs.list.kindBoard',
+}
+
+/** Shared kind label so the dropdown and the chips label a type identically. */
+export function typeLabel(ty: DocType): string {
+  return t(TYPE_LABEL_KEY[ty])
+}
+
+/**
+ * Multi-select document-kind filter (frontend-design §5.2 / XIN-1188). Completely mirrors
+ * CreatorFilter: a body-portal menu (PortalMenu) of checkbox rows, reusing the `.octo-docs-filter*`
+ * CSS. Present on BOTH tabs (unlike the creator filter, which is recent-only). Selections are OR'd
+ * server-side and AND-combined with the filename search (and, on recent, with the creator filter).
+ * The button shows the selected count; chips (see TypeChips) render below the toolbar.
+ */
+export function TypeFilter({
+  selected,
+  onToggle,
+}: {
+  selected: DocType[]
+  onToggle: (ty: DocType) => void
+}): React.ReactElement {
+  const [at, setAt] = useState<{ left: number; top: number } | null>(null)
+  const btnRef = useRef<HTMLButtonElement>(null)
+
+  const open = () => {
+    const el = btnRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    setAt(at ? null : { left: r.left, top: r.bottom + 6 })
+  }
+
+  const label =
+    selected.length > 0
+      ? `${t('docs.filter.type')} (${selected.length})`
+      : t('docs.filter.type')
+
+  return (
+    <div className="octo-docs-filter">
+      <button
+        ref={btnRef}
+        type="button"
+        className={
+          selected.length > 0
+            ? 'octo-docs-filter-btn octo-docs-filter-btn-active'
+            : 'octo-docs-filter-btn'
+        }
+        aria-haspopup="menu"
+        aria-expanded={at != null}
+        onClick={open}
+      >
+        {label}
+        <span className="octo-docs-filter-caret" aria-hidden="true">▾</span>
+      </button>
+      {at && (
+        <PortalMenu at={at} onClose={() => setAt(null)} minWidth={200}>
+          {DOC_TYPES.map((ty) => {
+            const checked = selected.includes(ty)
+            return (
+              <label key={ty} className="octo-docs-filter-option">
+                <input type="checkbox" checked={checked} onChange={() => onToggle(ty)} />
+                <span className="octo-docs-filter-option-name">{typeLabel(ty)}</span>
+              </label>
+            )
+          })}
+        </PortalMenu>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Chips row for the selected types (frontend-design §5.2). Each chip removes its type; a trailing
+ * "clear all" clears the filter. Rendered below the toolbar only when something is selected — a
+ * direct mirror of CreatorChips.
+ */
+export function TypeChips({
+  selected,
+  onToggle,
+  onClearAll,
+}: {
+  selected: DocType[]
+  onToggle: (ty: DocType) => void
+  onClearAll: () => void
+}): React.ReactElement | null {
+  if (selected.length === 0) return null
+  return (
+    <div className="octo-docs-filter-chips">
+      {selected.map((ty) => (
+        <span key={ty} className="octo-docs-filter-chip">
+          {typeLabel(ty)}
+          <button
+            type="button"
+            className="octo-docs-filter-chip-x"
+            aria-label={typeLabel(ty)}
+            onClick={() => onToggle(ty)}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <button type="button" className="octo-docs-filter-clear" onClick={onClearAll}>
+        {t('docs.filter.clearAll')}
+      </button>
+    </div>
+  )
+}

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -182,6 +182,34 @@ describe('recent feed resilience (not-yet-deployed backend degrades to empty)', 
   })
 })
 
+// XIN-1188: the multi-select type filter serializes as repeated `?type=` params (never CSV),
+// mirroring the `creator` convention, on BOTH the recent and mine list calls.
+describe('type filter serialization (repeated ?type=, both lists)', () => {
+  it('listRecentDocs appends one ?type= per selected kind (OR), alongside creator', async () => {
+    api.responder = () => ({ data: { total: 0, items: [], nextCursor: null }, status: 200 })
+    await listRecentDocs({ types: ['doc', 'sheet'], creators: ['u_a'] })
+    const url = api.calls.at(-1)!.url
+    expect(url).toContain('type=doc')
+    expect(url).toContain('type=sheet')
+    expect(url).toContain('creator=u_a')
+    expect(url).not.toContain('type=doc%2Csheet') // not CSV
+  })
+
+  it('listDocs (mine) appends one ?type= per selected kind', async () => {
+    api.responder = () => ({ data: { total: 0, items: [] }, status: 200 })
+    await listDocs({ owner: 'me', types: ['board'] })
+    const url = api.calls.at(-1)!.url
+    expect(url).toContain('type=board')
+    expect(url).toContain('owner=me')
+  })
+
+  it('omits the type param entirely when none is selected (backward compatible)', async () => {
+    api.responder = () => ({ data: { total: 0, items: [], nextCursor: null }, status: 200 })
+    await listRecentDocs({})
+    expect(api.calls.at(-1)!.url).not.toContain('type=')
+  })
+})
+
 // Delete outcome classification (contract C3 final) — moved to the editor detail page but the
 // 200/404/403/409 mapping is unchanged (Problem 4).
 describe('classifyDeleteStatus / deleteErrorKey', () => {

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -3,6 +3,8 @@ import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
 import {
   listDocs,
+  listRecentDocs,
+  listRecentCreators,
   createDoc,
   getDoc,
   getUserName,
@@ -134,6 +136,49 @@ describe('docs list/create API (bare-relative /docs)', () => {
       throw { response: { status: 409 } }
     }
     await expect(deleteDoc('d_arch')).rejects.toMatchObject({ response: { status: 409 } })
+  })
+})
+
+// The recent tab is the default landing surface, so its list/creators GETs must degrade to an
+// empty result — never throw — when the backend is not yet deployed (404) or errors (5xx).
+// Otherwise useDocsView's `.catch` flips the default tab into the error phase on first paint.
+describe('recent feed resilience (not-yet-deployed backend degrades to empty)', () => {
+  it('listRecentDocs returns an empty page instead of rejecting on a 404/5xx', async () => {
+    api.responder = () => {
+      throw { response: { status: 404 } }
+    }
+    await expect(listRecentDocs({ q: 'x' })).resolves.toEqual({
+      total: 0,
+      items: [],
+      nextCursor: null,
+    })
+  })
+
+  it('listRecentDocs still parses a normal 200 body', async () => {
+    api.responder = () => ({
+      data: {
+        total: 2,
+        items: [{ docId: 'd_r', title: 'Recent', ownerId: 'u0', role: 'admin', viewedAt: 't' }],
+        nextCursor: 'cur_1',
+      },
+      status: 200,
+    })
+    const res = await listRecentDocs()
+    expect(res.items).toHaveLength(1)
+    expect(res.nextCursor).toBe('cur_1')
+    expect(api.calls.at(-1)!.url).toContain('/docs/recent')
+  })
+
+  it('listRecentCreators returns [] instead of rejecting on a 404/5xx', async () => {
+    api.responder = () => {
+      throw { response: { status: 500 } }
+    }
+    await expect(listRecentCreators('x')).resolves.toEqual([])
+  })
+
+  it('listRecentCreators still parses a normal 200 body', async () => {
+    api.responder = () => ({ data: { creators: [{ uid: 'u1', name: 'Ada' }] }, status: 200 })
+    expect(await listRecentCreators()).toEqual([{ uid: 'u1', name: 'Ada' }])
   })
 })
 

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -7,6 +7,16 @@
 import { apiClient } from '../octoweb/index.ts'
 import type { Role } from '../auth/roles.ts'
 
+/**
+ * Document kind enum — the wire contract for `doc_type`, authored in lockstep with the backend
+ * (octo-docs-backend `DOC_TYPES` in src/db/docType.ts and the `doc_meta.doc_type` column). The three
+ * values are the single source of truth on BOTH sides: the list distinguishes them by row icon and
+ * the type filter narrows the recent/mine feeds on them (`?type=doc&type=sheet`). Never mock a value
+ * that the backend does not persist — a drifting enum is exactly the assumed-wire trap FEAT-B avoids.
+ */
+export const DOC_TYPES = ['doc', 'sheet', 'board'] as const
+export type DocType = (typeof DOC_TYPES)[number]
+
 export interface DocListItem {
   docId: string
   title: string
@@ -21,10 +31,10 @@ export interface DocListItem {
    */
   viewedAt?: string
   /**
-   * Document kind: `'doc'` (Tiptap rich text, the default) or `'board'` (Excalidraw whiteboard).
-   * Optional because older records and backends that predate the whiteboard feature omit it; a
-   * missing value is treated as a plain document. The list mixes both kinds and distinguishes
-   * them by icon (frontend-design §4.1 / §5.1).
+   * Document kind — one of {@link DocType}: `'doc'` (Tiptap rich text, the default), `'sheet'`
+   * (Univer spreadsheet), or `'board'` (Excalidraw whiteboard). Optional because older records and
+   * backends that predate a given kind omit it; a missing value is treated as a plain document. The
+   * list mixes all kinds and distinguishes them by icon (frontend-design §4.1 / §5.1).
    */
   docType?: string
 }
@@ -69,6 +79,13 @@ export interface ListDocsParams {
    * legacy "owned or member" listing.
    */
   owner?: 'me'
+  /**
+   * Selected document kinds — multi-value OR filter serialized as repeated `?type=doc&type=sheet`
+   * (same repeated-param convention as `creator`, never CSV; frontend-design §5.2 / XIN-1188). The
+   * server narrows on `doc_type` BEFORE pagination and treats an absent param as "no type filter",
+   * so it is fully backward compatible. Empty = no type filter.
+   */
+  types?: DocType[]
 }
 
 /** GET /api/v1/docs — list docs the caller owns or is a member of (or, with `owner=me`, owns). */
@@ -82,6 +99,9 @@ export async function listDocs(params: ListDocsParams = {}): Promise<ListDocsRes
   if (params.owner) q.set('owner', params.owner)
   const term = (params.q ?? '').trim()
   if (term) q.set('q', term)
+  for (const ty of params.types ?? []) {
+    if (ty) q.append('type', ty)
+  }
   const qs = q.toString()
   const { data } = await apiClient().get<ListDocsResult>(`/docs${qs ? `?${qs}` : ''}`)
   return { total: data?.total ?? (data?.items?.length ?? 0), items: data?.items ?? [] }
@@ -95,6 +115,12 @@ export interface RecentDocsParams {
    * carries this (frontend-design §3.2 / XIN-1098 §4.2). Empty = no creator filter.
    */
   creators?: string[]
+  /**
+   * Selected document kinds — multi-value OR filter serialized as repeated `?type=doc&type=sheet`
+   * (same convention as `creators`; frontend-design §5.2 / XIN-1188). Narrowed server-side on
+   * `doc_type` before keyset pagination; absent param = no type filter (backward compatible).
+   */
+  types?: DocType[]
   /**
    * Keyset cursor for the NEXT page (opaque, from the previous response's `nextCursor`). First page
    * omits it. Recent pagination is keyset-only — there is NO offset fallback (XIN-1098 §4.3).
@@ -123,6 +149,9 @@ export async function listRecentDocs(params: RecentDocsParams = {}): Promise<Rec
   if (term) q.set('q', term)
   for (const uid of params.creators ?? []) {
     if (uid) q.append('creator', uid)
+  }
+  for (const ty of params.types ?? []) {
+    if (ty) q.append('type', ty)
   }
   if (params.cursor) q.set('cursor', params.cursor)
   if (params.pageSize) q.set('pageSize', String(params.pageSize))

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -127,14 +127,21 @@ export async function listRecentDocs(params: RecentDocsParams = {}): Promise<Rec
   if (params.cursor) q.set('cursor', params.cursor)
   if (params.pageSize) q.set('pageSize', String(params.pageSize))
   const qs = q.toString()
-  const { data } = await apiClient().get<Partial<RecentDocsResult>>(
-    `/docs/recent${qs ? `?${qs}` : ''}`,
-  )
-  const items = data?.items ?? []
-  return {
-    total: data?.total ?? items.length,
-    items,
-    nextCursor: data?.nextCursor ?? null,
+  try {
+    const { data } = await apiClient().get<Partial<RecentDocsResult>>(
+      `/docs/recent${qs ? `?${qs}` : ''}`,
+    )
+    const items = data?.items ?? []
+    return {
+      total: data?.total ?? items.length,
+      items,
+      nextCursor: data?.nextCursor ?? null,
+    }
+  } catch {
+    // Degrade to an empty page when the endpoint is not yet deployed (404) or errors (5xx). A
+    // rejected request would otherwise bubble to useDocsView's `.catch` and flip the default tab to
+    // the error phase; the contract (and the JSDoc above) is an empty list, mirroring recordDocView.
+    return { total: 0, items: [], nextCursor: null }
   }
 }
 
@@ -150,10 +157,16 @@ export async function listRecentCreators(q?: string): Promise<CreatorOption[]> {
   const term = (q ?? '').trim()
   if (term) params.set('q', term)
   const qs = params.toString()
-  const { data } = await apiClient().get<{ creators?: CreatorOption[] }>(
-    `/docs/recent/creators${qs ? `?${qs}` : ''}`,
-  )
-  return Array.isArray(data?.creators) ? data.creators : []
+  try {
+    const { data } = await apiClient().get<{ creators?: CreatorOption[] }>(
+      `/docs/recent/creators${qs ? `?${qs}` : ''}`,
+    )
+    return Array.isArray(data?.creators) ? data.creators : []
+  } catch {
+    // Not-yet-deployed / erroring backend yields no candidates rather than throwing (same contract
+    // as listRecentDocs); the recent tab simply shows an empty creator filter.
+    return []
+  }
 }
 
 /**

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -14,6 +14,13 @@ export interface DocListItem {
   role: Role
   updatedAt?: string
   /**
+   * Last-viewed timestamp (ISO-8601, UTC, ms). Present ONLY on "recent" (最近查看) rows — the
+   * backend `GET /docs/recent` response includes it (XIN-1098 API 2); the plain `GET /docs`
+   * (我的文档 / owned) response omits it. Consumed by the recent tab to order and render the
+   * "viewed" sub-line; absent for "my documents" rows (frontend-design §3.2 / §3.3).
+   */
+  viewedAt?: string
+  /**
    * Document kind: `'doc'` (Tiptap rich text, the default) or `'board'` (Excalidraw whiteboard).
    * Optional because older records and backends that predate the whiteboard feature omit it; a
    * missing value is treated as a plain document. The list mixes both kinds and distinguishes
@@ -25,6 +32,12 @@ export interface DocListItem {
 export interface ListDocsResult {
   total: number
   items: DocListItem[]
+}
+
+/** A creator candidate for the recent-tab filter — server-resolved `{uid,name}` (XIN-1098 API 4). */
+export interface CreatorOption {
+  uid: string
+  name: string
 }
 
 export interface CreateDocResult {
@@ -45,9 +58,20 @@ export interface ListDocsParams {
   page?: number
   pageSize?: number
   sort?: 'updatedAt:desc' | 'updatedAt:asc'
+  /**
+   * Filename search term (frontend-design §3.3 / XIN-1098 §4.1). The server trims it and treats a
+   * blank result as "no search"; a case-insensitive substring match is applied before pagination.
+   */
+  q?: string
+  /**
+   * `'me'` scopes the list to documents the caller OWNS (strict `owner_id == uid`), excluding
+   * shared-to-me docs — the "我的文档" tab (frontend-design §3.3 / XIN-1098 API 3). Omitted for the
+   * legacy "owned or member" listing.
+   */
+  owner?: 'me'
 }
 
-/** GET /api/v1/docs — list docs the caller owns or is a member of. */
+/** GET /api/v1/docs — list docs the caller owns or is a member of (or, with `owner=me`, owns). */
 export async function listDocs(params: ListDocsParams = {}): Promise<ListDocsResult> {
   const q = new URLSearchParams()
   if (params.spaceId) q.set('spaceId', params.spaceId)
@@ -55,9 +79,97 @@ export async function listDocs(params: ListDocsParams = {}): Promise<ListDocsRes
   if (params.page) q.set('page', String(params.page))
   if (params.pageSize) q.set('pageSize', String(params.pageSize))
   if (params.sort) q.set('sort', params.sort)
+  if (params.owner) q.set('owner', params.owner)
+  const term = (params.q ?? '').trim()
+  if (term) q.set('q', term)
   const qs = q.toString()
   const { data } = await apiClient().get<ListDocsResult>(`/docs${qs ? `?${qs}` : ''}`)
-  return data
+  return { total: data?.total ?? (data?.items?.length ?? 0), items: data?.items ?? [] }
+}
+
+export interface RecentDocsParams {
+  /** Filename search term (server trims; blank = no search). Same normalization as `listDocs`. */
+  q?: string
+  /**
+   * Selected creator uids — multi-value OR filter (`?creator=a&creator=b`). Only the recent tab
+   * carries this (frontend-design §3.2 / XIN-1098 §4.2). Empty = no creator filter.
+   */
+  creators?: string[]
+  /**
+   * Keyset cursor for the NEXT page (opaque, from the previous response's `nextCursor`). First page
+   * omits it. Recent pagination is keyset-only — there is NO offset fallback (XIN-1098 §4.3).
+   */
+  cursor?: string | null
+  pageSize?: number
+}
+
+export interface RecentDocsResult {
+  total: number
+  items: DocListItem[]
+  /** Opaque keyset cursor for the next page; `null`/absent means no more pages (XIN-1098 §4.3). */
+  nextCursor: string | null
+}
+
+/**
+ * GET /api/v1/docs/recent — the "最近查看" (recently viewed) feed, ordered `viewed_at DESC` on the
+ * server (XIN-1098 API 2). Keyset-paginated: pass the previous response's `nextCursor` to page; a
+ * null `nextCursor` marks the end. uid + space are derived server-side from the token / `X-Space-Id`
+ * header (the frontend never sends them). Resilient: coerces a missing body to an empty page so a
+ * not-yet-deployed backend degrades to an empty list rather than throwing.
+ */
+export async function listRecentDocs(params: RecentDocsParams = {}): Promise<RecentDocsResult> {
+  const q = new URLSearchParams()
+  const term = (params.q ?? '').trim()
+  if (term) q.set('q', term)
+  for (const uid of params.creators ?? []) {
+    if (uid) q.append('creator', uid)
+  }
+  if (params.cursor) q.set('cursor', params.cursor)
+  if (params.pageSize) q.set('pageSize', String(params.pageSize))
+  const qs = q.toString()
+  const { data } = await apiClient().get<Partial<RecentDocsResult>>(
+    `/docs/recent${qs ? `?${qs}` : ''}`,
+  )
+  const items = data?.items ?? []
+  return {
+    total: data?.total ?? items.length,
+    items,
+    nextCursor: data?.nextCursor ?? null,
+  }
+}
+
+/**
+ * GET /api/v1/docs/recent/creators — creator candidates for the recent-tab filter (XIN-1098 API 4).
+ * The candidate set is "the DISTINCT owners of the current recent result set AFTER `q` filtering,
+ * BEFORE creator filtering, BEFORE pagination, AFTER permission filtering". The server resolves each
+ * `name`, so the dropdown needs no per-uid name round-trips. Resilient: returns `[]` on a missing /
+ * malformed body so a not-yet-deployed backend just yields no candidates.
+ */
+export async function listRecentCreators(q?: string): Promise<CreatorOption[]> {
+  const params = new URLSearchParams()
+  const term = (q ?? '').trim()
+  if (term) params.set('q', term)
+  const qs = params.toString()
+  const { data } = await apiClient().get<{ creators?: CreatorOption[] }>(
+    `/docs/recent/creators${qs ? `?${qs}` : ''}`,
+  )
+  return Array.isArray(data?.creators) ? data.creators : []
+}
+
+/**
+ * POST /api/v1/docs/{docId}/view — record that the caller opened a document (ingest, XIN-1098 API 1).
+ * Fire-and-forget by contract: the caller `void`s it and this helper swallows every failure, so a
+ * failed / not-yet-deployed ingest never blocks opening the doc and never surfaces a toast
+ * (frontend-design §3.4). No body — uid is derived server-side. The server UPSERTs on `(uid,docId)`
+ * so calling it once per open is idempotent.
+ */
+export async function recordDocView(docId: string): Promise<void> {
+  try {
+    await apiClient().post(`/docs/${encodeURIComponent(docId)}/view`)
+  } catch {
+    // Fire-and-forget: ingest is best-effort and must never disrupt the open path. The backend
+    // collab-token path also has a best-effort fallback ingest, so a dropped call here is covered.
+  }
 }
 
 /** POST /api/v1/docs — create a new document; caller becomes admin. */

--- a/packages/docs/src/pages/useDocsView.test.ts
+++ b/packages/docs/src/pages/useDocsView.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { DocListItem, RecentDocsResult } from './docsApi.ts'
+
+// Mock the REST layer so the test controls exactly when each append resolves.
+vi.mock('./docsApi.ts', () => ({
+  listDocs: vi.fn(),
+  listRecentDocs: vi.fn(),
+  listRecentCreators: vi.fn(),
+}))
+
+import { useDocsView } from './useDocsView.ts'
+import { listRecentDocs, listRecentCreators } from './docsApi.ts'
+
+const recentMock = listRecentDocs as unknown as ReturnType<typeof vi.fn>
+const creatorsMock = listRecentCreators as unknown as ReturnType<typeof vi.fn>
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+const row = (docId: string): DocListItem => ({ docId, title: docId, ownerId: 'u', role: 'admin' })
+
+beforeEach(() => {
+  recentMock.mockReset()
+  creatorsMock.mockReset()
+  creatorsMock.mockResolvedValue([])
+})
+
+describe('useDocsView — loadMore in-flight guard (synchronous ref, XIN-1132 review §2 / AC-6.4)', () => {
+  it('drops a re-entrant loadMore fired before the first append settles (no duplicate page)', async () => {
+    // First page enables pagination (nextCursor present). The append is held in flight so the guard
+    // is still engaged when the second loadMore fires in the same tick.
+    const append = deferred<RecentDocsResult>()
+    recentMock
+      .mockResolvedValueOnce({ total: 40, items: [row('d1')], nextCursor: 'c1' })
+      .mockReturnValueOnce(append.promise)
+      // Any THIRD request would be the bug — a duplicate append for the same cursor.
+      .mockResolvedValue({ total: 40, items: [row('dup')], nextCursor: 'c9' })
+
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+
+    await waitFor(() => expect(result.current.hasMore).toBe(true))
+    expect(recentMock).toHaveBeenCalledTimes(1)
+
+    // Two IntersectionObserver notifications in the SAME tick, before `moreStatus` state re-renders.
+    // A state-based guard would let both through; the synchronous ref drops the second.
+    act(() => {
+      result.current.loadMore()
+      result.current.loadMore()
+    })
+    expect(recentMock).toHaveBeenCalledTimes(2)
+
+    // Settle the append — exactly one page is appended, in order, with no duplicate rows.
+    await act(async () => {
+      append.resolve({ total: 40, items: [row('d2')], nextCursor: 'c2' })
+    })
+    expect(result.current.items.map((i) => i.docId)).toEqual(['d1', 'd2'])
+    expect(recentMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows the next loadMore once the previous append has settled', async () => {
+    recentMock
+      .mockResolvedValueOnce({ total: 60, items: [row('d1')], nextCursor: 'c1' })
+      .mockResolvedValueOnce({ total: 60, items: [row('d2')], nextCursor: 'c2' })
+      .mockResolvedValueOnce({ total: 60, items: [row('d3')], nextCursor: 'c3' })
+
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.hasMore).toBe(true))
+
+    await act(async () => {
+      result.current.loadMore()
+    })
+    await waitFor(() => expect(result.current.items).toHaveLength(2))
+
+    await act(async () => {
+      result.current.loadMore()
+    })
+    await waitFor(() => expect(result.current.items.map((i) => i.docId)).toEqual(['d1', 'd2', 'd3']))
+    expect(recentMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/docs/src/pages/useDocsView.test.ts
+++ b/packages/docs/src/pages/useDocsView.test.ts
@@ -10,8 +10,9 @@ vi.mock('./docsApi.ts', () => ({
 }))
 
 import { useDocsView } from './useDocsView.ts'
-import { listRecentDocs, listRecentCreators } from './docsApi.ts'
+import { listDocs, listRecentDocs, listRecentCreators } from './docsApi.ts'
 
+const listMock = listDocs as unknown as ReturnType<typeof vi.fn>
 const recentMock = listRecentDocs as unknown as ReturnType<typeof vi.fn>
 const creatorsMock = listRecentCreators as unknown as ReturnType<typeof vi.fn>
 
@@ -26,6 +27,7 @@ function deferred<T>() {
 const row = (docId: string): DocListItem => ({ docId, title: docId, ownerId: 'u', role: 'admin' })
 
 beforeEach(() => {
+  listMock.mockReset()
   recentMock.mockReset()
   creatorsMock.mockReset()
   creatorsMock.mockResolvedValue([])
@@ -82,5 +84,69 @@ describe('useDocsView — loadMore in-flight guard (synchronous ref, XIN-1132 re
     })
     await waitFor(() => expect(result.current.items.map((i) => i.docId)).toEqual(['d1', 'd2', 'd3']))
     expect(recentMock).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('useDocsView — type filter (XIN-1188, multi-select OR, both tabs)', () => {
+  it('toggleType refetches the recent feed with the selected types (OR) and remembers them', async () => {
+    recentMock.mockResolvedValue({ total: 0, items: [], nextCursor: null })
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.phase).toBe('ready'))
+
+    await act(async () => {
+      result.current.toggleType('doc')
+    })
+    await act(async () => {
+      result.current.toggleType('sheet')
+    })
+    expect(result.current.types).toEqual(['doc', 'sheet'])
+    // last request narrowed on both kinds (OR, AND-ed with the — here empty — q/creators).
+    expect(recentMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ types: ['doc', 'sheet'] }),
+    )
+
+    await act(async () => {
+      result.current.clearTypes()
+    })
+    expect(result.current.types).toEqual([])
+    expect(recentMock).toHaveBeenLastCalledWith(expect.objectContaining({ types: [] }))
+  })
+
+  it('the mine tab also carries the type filter through to listDocs', async () => {
+    listMock.mockResolvedValue({ total: 0, items: [] })
+    const { result } = renderHook(() => useDocsView('mine', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.phase).toBe('ready'))
+
+    await act(async () => {
+      result.current.toggleType('board')
+    })
+    expect(listMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ owner: 'me', types: ['board'] }),
+    )
+  })
+
+  it('an empty result under a type filter derives the F empty-state (clear-type CTA)', async () => {
+    recentMock.mockResolvedValue({ total: 0, items: [], nextCursor: null })
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.empty).toBe('A')) // no conditions yet
+
+    await act(async () => {
+      result.current.toggleType('sheet')
+    })
+    await waitFor(() => expect(result.current.empty).toBe('F'))
+  })
+
+  it('type + search together derive the combined E empty-state', async () => {
+    recentMock.mockResolvedValue({ total: 0, items: [], nextCursor: null })
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.phase).toBe('ready'))
+
+    await act(async () => {
+      result.current.setQuery('budget')
+    })
+    await act(async () => {
+      result.current.toggleType('sheet')
+    })
+    await waitFor(() => expect(result.current.empty).toBe('E'))
   })
 })

--- a/packages/docs/src/pages/useDocsView.ts
+++ b/packages/docs/src/pages/useDocsView.ts
@@ -1,0 +1,303 @@
+// Per-tab data engine for the docs list (frontend-design §2.1 / §2.2).
+//
+// Each list tab ("recent" 最近查看 / "mine" 我的文档) owns ONE `useDocsView` instance holding its
+// own search term, creator filter, items, pagination cursor/page and status. The container
+// (DocsList) keeps two instances alive at once and simply swaps which one is active on tab switch —
+// so per-view search + filter state survives a switch and is restored (with its request re-sent)
+// when the user comes back (AC-2.3.2 / product MC5).
+//
+// Loading state is plain `useState` + conditional rendering — NO Suspense. The host renders docs
+// inside a MobX observer that force-updates at high frequency, which starves React 18's low-priority
+// Suspense RetryLane commits (see module.tsx commit-starvation note); a Suspense boundary here would
+// hang the list. IntersectionObserver drives pagination (see InfiniteList), not scroll events.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  listDocs,
+  listRecentDocs,
+  listRecentCreators,
+  type CreatorOption,
+  type DocListItem,
+} from './docsApi.ts'
+
+export type DocsViewKind = 'recent' | 'mine'
+
+/** First-page / result-set level status. Footer (load-more) state is tracked separately below. */
+export type DocsViewPhase = 'loading' | 'ready' | 'error'
+
+/**
+ * Empty-state variant (frontend-design §5.3). `null` = not empty. A/B distinguish "view has no data"
+ * (看 vs 建, dual CTA i18n keys); C/D/E distinguish "conditions matched nothing" (search / filter /
+ * both). Decided from the (q, creators) that produced the empty result — never stale state.
+ */
+export type DocsEmptyKind = null | 'A' | 'B' | 'C' | 'D' | 'E'
+
+/** Footer status for the infinite-scroll appends (independent of the first-page phase). */
+export type DocsMoreStatus = 'idle' | 'loadingMore' | 'error' | 'end'
+
+/** Default first-page / append size. Backend default is 20; kept modest to stay snappy on open. */
+const PAGE_SIZE = 20
+
+export interface DocsView {
+  readonly kind: DocsViewKind
+  q: string
+  /** Selected creator uids (recent only; always empty for mine). */
+  creators: string[]
+  /** Facet candidates for the creator filter (recent only), server-resolved `{uid,name}`. */
+  creatorOptions: CreatorOption[]
+  items: DocListItem[]
+  total: number
+  phase: DocsViewPhase
+  empty: DocsEmptyKind
+  hasMore: boolean
+  moreStatus: DocsMoreStatus
+  /** Bumped on every new result set so the scroll container can reset to the top. */
+  resultSetId: number
+  /** Set the search term and refetch a fresh result set (caller debounces the keystrokes). */
+  setQuery: (q: string) => void
+  /** Clear the search term (empty-state C/E "clear search" CTA). */
+  clearQuery: () => void
+  /** Toggle a creator uid in the OR filter (recent only). */
+  toggleCreator: (uid: string) => void
+  /** Clear all selected creators (empty-state D/E "clear filter" CTA + chips "clear all"). */
+  clearCreators: () => void
+  /** Append the next page (IntersectionObserver sentinel / load-more retry). */
+  loadMore: () => void
+  /** Retry a failed first-page load. */
+  retry: () => void
+  /** Refetch the current result set from scratch (e.g. after a rename bumps the reload token). */
+  reload: () => void
+}
+
+function deriveEmpty(
+  kind: DocsViewKind,
+  itemsLen: number,
+  q: string,
+  creators: string[],
+): DocsEmptyKind {
+  if (itemsLen > 0) return null
+  const hasQ = q.trim().length > 0
+  const hasCreators = creators.length > 0
+  if (hasQ && hasCreators) return 'E'
+  if (hasCreators) return 'D'
+  if (hasQ) return 'C'
+  return kind === 'recent' ? 'A' : 'B'
+}
+
+/**
+ * Manage one tab's list state. `space` / `folder` scope the queries; when either changes the current
+ * result set is refetched (the container passes the live space so a Space switch reconciles here).
+ * `reloadToken` (bumped by the parent after a rename/delete) forces a refresh without changing q/creators.
+ */
+export function useDocsView(
+  kind: DocsViewKind,
+  space: string,
+  folder: string,
+  reloadToken: number,
+): DocsView {
+  const [q, setQ] = useState('')
+  const [creators, setCreators] = useState<string[]>([])
+  const [creatorOptions, setCreatorOptions] = useState<CreatorOption[]>([])
+  const [items, setItems] = useState<DocListItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [phase, setPhase] = useState<DocsViewPhase>('loading')
+  const [empty, setEmpty] = useState<DocsEmptyKind>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [moreStatus, setMoreStatus] = useState<DocsMoreStatus>('idle')
+  const [resultSetId, setResultSetId] = useState(0)
+
+  // Monotonic sequence — every request stamps it; only the LATEST request's response may touch state
+  // (frontend-design §2.3). Covers tab switch / search / filter / paging races. A ref survives
+  // re-renders without triggering one.
+  const seqRef = useRef(0)
+  // Pagination position for the NEXT append. recent = opaque keyset cursor; mine = offset page.
+  const cursorRef = useRef<string | null>(null)
+  const pageRef = useRef(1)
+  const hasMoreRef = useRef(false)
+  // Loaded row count for the current result set — lets mine's offset paging decide `hasMore` against
+  // `total` without a side-effect inside a setState updater.
+  const loadedRef = useRef(0)
+
+  const fetchFirst = useCallback(
+    (nextQ: string, nextCreators: string[]) => {
+      const seq = ++seqRef.current
+      cursorRef.current = null
+      pageRef.current = 1
+      setPhase('loading')
+      setEmpty(null)
+      setMoreStatus('idle')
+
+      const done = (fetched: DocListItem[], nextTotal: number, more: boolean) => {
+        if (seq !== seqRef.current) return
+        setItems(fetched)
+        setTotal(nextTotal)
+        loadedRef.current = fetched.length
+        hasMoreRef.current = more
+        setHasMore(more)
+        setMoreStatus(more ? 'idle' : 'end')
+        setEmpty(deriveEmpty(kind, fetched.length, nextQ, nextCreators))
+        setPhase('ready')
+        setResultSetId((n) => n + 1)
+      }
+      const fail = (err: unknown) => {
+        if (seq !== seqRef.current) return
+        console.error('[docs] list failed', err)
+        setPhase('error')
+      }
+
+      if (kind === 'recent') {
+        // Refresh the creator candidates for this new result set (candidates track `q`, but are
+        // independent of the selected creators and pagination — §3.5). Fire in parallel; drop if
+        // superseded. name resolution failures just yield fewer / uid-labelled options.
+        void listRecentCreators(nextQ)
+          .then((opts) => {
+            if (seq === seqRef.current) setCreatorOptions(opts)
+          })
+          .catch(() => {})
+        listRecentDocs({ q: nextQ, creators: nextCreators, cursor: null, pageSize: PAGE_SIZE })
+          .then((res) => {
+            cursorRef.current = res.nextCursor
+            done(res.items, res.total, !!res.nextCursor && res.items.length > 0)
+          })
+          .catch(fail)
+      } else {
+        listDocs({
+          spaceId: space || undefined,
+          folderId: folder || undefined,
+          sort: 'updatedAt:desc',
+          owner: 'me',
+          q: nextQ,
+          page: 1,
+          pageSize: PAGE_SIZE,
+        })
+          .then((res) => {
+            pageRef.current = 1
+            done(res.items, res.total, res.items.length > 0 && res.items.length < res.total)
+          })
+          .catch(fail)
+      }
+    },
+    [kind, space, folder],
+  )
+
+  const loadMore = useCallback(() => {
+    if (!hasMoreRef.current) return
+    if (seqRef.current === 0) return
+    // Guard against re-entrancy while an append is already in flight for this result set.
+    if (moreStatus === 'loadingMore') return
+    const seq = seqRef.current
+    setMoreStatus('loadingMore')
+
+    const append = (fetched: DocListItem[], more: boolean) => {
+      if (seq !== seqRef.current) return
+      loadedRef.current += fetched.length
+      setItems((prev) => [...prev, ...fetched])
+      hasMoreRef.current = more
+      setHasMore(more)
+      setMoreStatus(more ? 'idle' : 'end')
+    }
+    const fail = () => {
+      if (seq !== seqRef.current) return
+      // Keep the already-loaded rows; surface a retryable footer error (frontend-design §5.5).
+      setMoreStatus('error')
+    }
+
+    if (kind === 'recent') {
+      listRecentDocs({ q, creators, cursor: cursorRef.current, pageSize: PAGE_SIZE })
+        .then((res) => {
+          if (seq !== seqRef.current) return
+          cursorRef.current = res.nextCursor
+          append(res.items, !!res.nextCursor && res.items.length > 0)
+        })
+        .catch(fail)
+    } else {
+      const nextPage = pageRef.current + 1
+      listDocs({
+        spaceId: space || undefined,
+        folderId: folder || undefined,
+        sort: 'updatedAt:desc',
+        owner: 'me',
+        q,
+        page: nextPage,
+        pageSize: PAGE_SIZE,
+      })
+        .then((res) => {
+          if (seq !== seqRef.current) return
+          pageRef.current = nextPage
+          // With offset paging, "more" = a full page landed AND we're still short of `total`.
+          const more =
+            res.items.length === PAGE_SIZE && loadedRef.current + res.items.length < res.total
+          append(res.items, more)
+        })
+        .catch(fail)
+    }
+  }, [kind, q, creators, space, folder, moreStatus])
+
+  const setQuery = useCallback(
+    (next: string) => {
+      setQ(next)
+      fetchFirst(next, creators)
+    },
+    [creators, fetchFirst],
+  )
+
+  const clearQuery = useCallback(() => {
+    setQ('')
+    fetchFirst('', creators)
+  }, [creators, fetchFirst])
+
+  const toggleCreator = useCallback(
+    (uid: string) => {
+      const next = creators.includes(uid)
+        ? creators.filter((u) => u !== uid)
+        : [...creators, uid]
+      setCreators(next)
+      fetchFirst(q, next)
+    },
+    [creators, q, fetchFirst],
+  )
+
+  const clearCreators = useCallback(() => {
+    setCreators([])
+    fetchFirst(q, [])
+  }, [q, fetchFirst])
+
+  const retry = useCallback(() => {
+    fetchFirst(q, creators)
+  }, [q, creators, fetchFirst])
+
+  const reload = useCallback(() => {
+    fetchFirst(q, creators)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, creators, fetchFirst])
+
+  // Initial load + refetch when the space/folder changes (a Space switch reconciles here) or the
+  // parent bumps reloadToken (rename/delete). Search/creator changes go through their own setters,
+  // which preserve per-view state; this effect intentionally leaves q/creators untouched so a Space
+  // switch keeps the tab's remembered search + filter and re-sends them (AC-2.3.2).
+  useEffect(() => {
+    fetchFirst(q, creators)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [space, folder, reloadToken])
+
+  return {
+    kind,
+    q,
+    creators,
+    creatorOptions,
+    items,
+    total,
+    phase,
+    empty,
+    hasMore,
+    moreStatus,
+    resultSetId,
+    setQuery,
+    clearQuery,
+    toggleCreator,
+    clearCreators,
+    loadMore,
+    retry,
+    reload,
+  }
+}

--- a/packages/docs/src/pages/useDocsView.ts
+++ b/packages/docs/src/pages/useDocsView.ts
@@ -117,12 +117,22 @@ export function useDocsView(
   // Loaded row count for the current result set — lets mine's offset paging decide `hasMore` against
   // `total` without a side-effect inside a setState updater.
   const loadedRef = useRef(0)
+  // Synchronous in-flight guard for appends. `moreStatus` is React state: `setMoreStatus` is async,
+  // and InfiniteList's `loadMoreRef` only points at the fresh callback after a commit, so under fast
+  // scroll / reflow a second IntersectionObserver notification can re-enter loadMore before the
+  // state (and thus the state-based guard) reflects the first — firing a duplicate request for the
+  // same cursor/page and appending it twice (duplicate rows + corrupted cursor, AC-6.4). A ref flips
+  // synchronously in the same tick, so the re-entrant call is dropped before it issues a request.
+  const loadingMoreRef = useRef(false)
 
   const fetchFirst = useCallback(
     (nextQ: string, nextCreators: string[]) => {
       const seq = ++seqRef.current
       cursorRef.current = null
       pageRef.current = 1
+      // A fresh result set supersedes any in-flight append (its settle will no-op on the seq check),
+      // so release the in-flight guard here rather than in that stale settle.
+      loadingMoreRef.current = false
       setPhase('loading')
       setEmpty(null)
       setMoreStatus('idle')
@@ -183,13 +193,16 @@ export function useDocsView(
   const loadMore = useCallback(() => {
     if (!hasMoreRef.current) return
     if (seqRef.current === 0) return
-    // Guard against re-entrancy while an append is already in flight for this result set.
-    if (moreStatus === 'loadingMore') return
+    // Synchronous re-entrancy guard: drop the call if an append is already in flight for this result
+    // set (see loadingMoreRef above — a ref, not `moreStatus`, so a same-tick duplicate is caught).
+    if (loadingMoreRef.current) return
     const seq = seqRef.current
+    loadingMoreRef.current = true
     setMoreStatus('loadingMore')
 
     const append = (fetched: DocListItem[], more: boolean) => {
       if (seq !== seqRef.current) return
+      loadingMoreRef.current = false
       loadedRef.current += fetched.length
       setItems((prev) => [...prev, ...fetched])
       hasMoreRef.current = more
@@ -198,6 +211,7 @@ export function useDocsView(
     }
     const fail = () => {
       if (seq !== seqRef.current) return
+      loadingMoreRef.current = false
       // Keep the already-loaded rows; surface a retryable footer error (frontend-design §5.5).
       setMoreStatus('error')
     }
@@ -231,7 +245,7 @@ export function useDocsView(
         })
         .catch(fail)
     }
-  }, [kind, q, creators, space, folder, moreStatus])
+  }, [kind, q, creators, space, folder])
 
   const setQuery = useCallback(
     (next: string) => {

--- a/packages/docs/src/pages/useDocsView.ts
+++ b/packages/docs/src/pages/useDocsView.ts
@@ -18,6 +18,7 @@ import {
   listRecentCreators,
   type CreatorOption,
   type DocListItem,
+  type DocType,
 } from './docsApi.ts'
 
 export type DocsViewKind = 'recent' | 'mine'
@@ -27,10 +28,11 @@ export type DocsViewPhase = 'loading' | 'ready' | 'error'
 
 /**
  * Empty-state variant (frontend-design §5.3). `null` = not empty. A/B distinguish "view has no data"
- * (看 vs 建, dual CTA i18n keys); C/D/E distinguish "conditions matched nothing" (search / filter /
- * both). Decided from the (q, creators) that produced the empty result — never stale state.
+ * (看 vs 建, dual CTA i18n keys); C/D/E/F distinguish "conditions matched nothing" (search / creator
+ * / both / type). Decided from the (q, creators, types) that produced the empty result — never stale
+ * state. `E` is the combined bucket for ANY 2+ active conditions and shows every matching clear.
  */
-export type DocsEmptyKind = null | 'A' | 'B' | 'C' | 'D' | 'E'
+export type DocsEmptyKind = null | 'A' | 'B' | 'C' | 'D' | 'E' | 'F'
 
 /** Footer status for the infinite-scroll appends (independent of the first-page phase). */
 export type DocsMoreStatus = 'idle' | 'loadingMore' | 'error' | 'end'
@@ -43,6 +45,8 @@ export interface DocsView {
   q: string
   /** Selected creator uids (recent only; always empty for mine). */
   creators: string[]
+  /** Selected document kinds — multi-select OR filter (both tabs; frontend-design §5.2). */
+  types: DocType[]
   /** Facet candidates for the creator filter (recent only), server-resolved `{uid,name}`. */
   creatorOptions: CreatorOption[]
   items: DocListItem[]
@@ -61,6 +65,10 @@ export interface DocsView {
   toggleCreator: (uid: string) => void
   /** Clear all selected creators (empty-state D/E "clear filter" CTA + chips "clear all"). */
   clearCreators: () => void
+  /** Toggle a document kind in the OR filter (both tabs). */
+  toggleType: (ty: DocType) => void
+  /** Clear all selected types (empty-state F/E "clear type" CTA + chips "clear all"). */
+  clearTypes: () => void
   /** Append the next page (IntersectionObserver sentinel / load-more retry). */
   loadMore: () => void
   /** Retry a failed first-page load. */
@@ -74,13 +82,18 @@ function deriveEmpty(
   itemsLen: number,
   q: string,
   creators: string[],
+  types: DocType[],
 ): DocsEmptyKind {
   if (itemsLen > 0) return null
   const hasQ = q.trim().length > 0
   const hasCreators = creators.length > 0
-  if (hasQ && hasCreators) return 'E'
-  if (hasCreators) return 'D'
+  const hasTypes = types.length > 0
+  const active = (hasQ ? 1 : 0) + (hasCreators ? 1 : 0) + (hasTypes ? 1 : 0)
+  // 2+ active conditions collapse to the combined bucket, which renders every matching clear CTA.
+  if (active >= 2) return 'E'
   if (hasQ) return 'C'
+  if (hasCreators) return 'D'
+  if (hasTypes) return 'F'
   return kind === 'recent' ? 'A' : 'B'
 }
 
@@ -97,6 +110,7 @@ export function useDocsView(
 ): DocsView {
   const [q, setQ] = useState('')
   const [creators, setCreators] = useState<string[]>([])
+  const [types, setTypes] = useState<DocType[]>([])
   const [creatorOptions, setCreatorOptions] = useState<CreatorOption[]>([])
   const [items, setItems] = useState<DocListItem[]>([])
   const [total, setTotal] = useState(0)
@@ -126,7 +140,7 @@ export function useDocsView(
   const loadingMoreRef = useRef(false)
 
   const fetchFirst = useCallback(
-    (nextQ: string, nextCreators: string[]) => {
+    (nextQ: string, nextCreators: string[], nextTypes: DocType[]) => {
       const seq = ++seqRef.current
       cursorRef.current = null
       pageRef.current = 1
@@ -145,7 +159,7 @@ export function useDocsView(
         hasMoreRef.current = more
         setHasMore(more)
         setMoreStatus(more ? 'idle' : 'end')
-        setEmpty(deriveEmpty(kind, fetched.length, nextQ, nextCreators))
+        setEmpty(deriveEmpty(kind, fetched.length, nextQ, nextCreators, nextTypes))
         setPhase('ready')
         setResultSetId((n) => n + 1)
       }
@@ -157,14 +171,14 @@ export function useDocsView(
 
       if (kind === 'recent') {
         // Refresh the creator candidates for this new result set (candidates track `q`, but are
-        // independent of the selected creators and pagination — §3.5). Fire in parallel; drop if
-        // superseded. name resolution failures just yield fewer / uid-labelled options.
+        // independent of the selected creators/types and pagination — §3.5). Fire in parallel; drop
+        // if superseded. name resolution failures just yield fewer / uid-labelled options.
         void listRecentCreators(nextQ)
           .then((opts) => {
             if (seq === seqRef.current) setCreatorOptions(opts)
           })
           .catch(() => {})
-        listRecentDocs({ q: nextQ, creators: nextCreators, cursor: null, pageSize: PAGE_SIZE })
+        listRecentDocs({ q: nextQ, creators: nextCreators, types: nextTypes, cursor: null, pageSize: PAGE_SIZE })
           .then((res) => {
             cursorRef.current = res.nextCursor
             done(res.items, res.total, !!res.nextCursor && res.items.length > 0)
@@ -177,6 +191,7 @@ export function useDocsView(
           sort: 'updatedAt:desc',
           owner: 'me',
           q: nextQ,
+          types: nextTypes,
           page: 1,
           pageSize: PAGE_SIZE,
         })
@@ -217,7 +232,7 @@ export function useDocsView(
     }
 
     if (kind === 'recent') {
-      listRecentDocs({ q, creators, cursor: cursorRef.current, pageSize: PAGE_SIZE })
+      listRecentDocs({ q, creators, types, cursor: cursorRef.current, pageSize: PAGE_SIZE })
         .then((res) => {
           if (seq !== seqRef.current) return
           cursorRef.current = res.nextCursor
@@ -232,6 +247,7 @@ export function useDocsView(
         sort: 'updatedAt:desc',
         owner: 'me',
         q,
+        types,
         page: nextPage,
         pageSize: PAGE_SIZE,
       })
@@ -245,20 +261,20 @@ export function useDocsView(
         })
         .catch(fail)
     }
-  }, [kind, q, creators, space, folder])
+  }, [kind, q, creators, types, space, folder])
 
   const setQuery = useCallback(
     (next: string) => {
       setQ(next)
-      fetchFirst(next, creators)
+      fetchFirst(next, creators, types)
     },
-    [creators, fetchFirst],
+    [creators, types, fetchFirst],
   )
 
   const clearQuery = useCallback(() => {
     setQ('')
-    fetchFirst('', creators)
-  }, [creators, fetchFirst])
+    fetchFirst('', creators, types)
+  }, [creators, types, fetchFirst])
 
   const toggleCreator = useCallback(
     (uid: string) => {
@@ -266,31 +282,46 @@ export function useDocsView(
         ? creators.filter((u) => u !== uid)
         : [...creators, uid]
       setCreators(next)
-      fetchFirst(q, next)
+      fetchFirst(q, next, types)
     },
-    [creators, q, fetchFirst],
+    [creators, q, types, fetchFirst],
   )
 
   const clearCreators = useCallback(() => {
     setCreators([])
-    fetchFirst(q, [])
-  }, [q, fetchFirst])
+    fetchFirst(q, [], types)
+  }, [q, types, fetchFirst])
+
+  const toggleType = useCallback(
+    (ty: DocType) => {
+      const next = types.includes(ty) ? types.filter((x) => x !== ty) : [...types, ty]
+      setTypes(next)
+      fetchFirst(q, creators, next)
+    },
+    [types, q, creators, fetchFirst],
+  )
+
+  const clearTypes = useCallback(() => {
+    setTypes([])
+    fetchFirst(q, creators, [])
+  }, [q, creators, fetchFirst])
 
   const retry = useCallback(() => {
-    fetchFirst(q, creators)
-  }, [q, creators, fetchFirst])
+    fetchFirst(q, creators, types)
+  }, [q, creators, types, fetchFirst])
 
   const reload = useCallback(() => {
-    fetchFirst(q, creators)
+    fetchFirst(q, creators, types)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, creators, fetchFirst])
+  }, [q, creators, types, fetchFirst])
 
   // Initial load + refetch when the space/folder changes (a Space switch reconciles here) or the
-  // parent bumps reloadToken (rename/delete). Search/creator changes go through their own setters,
-  // which preserve per-view state; this effect intentionally leaves q/creators untouched so a Space
-  // switch keeps the tab's remembered search + filter and re-sends them (AC-2.3.2).
+  // parent bumps reloadToken (rename/delete). Search/creator/type changes go through their own
+  // setters, which preserve per-view state; this effect intentionally leaves q/creators/types
+  // untouched so a Space switch keeps the tab's remembered search + filters and re-sends them
+  // (AC-2.3.2).
   useEffect(() => {
-    fetchFirst(q, creators)
+    fetchFirst(q, creators, types)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [space, folder, reloadToken])
 
@@ -298,6 +329,7 @@ export function useDocsView(
     kind,
     q,
     creators,
+    types,
     creatorOptions,
     items,
     total,
@@ -310,6 +342,8 @@ export function useDocsView(
     clearQuery,
     toggleCreator,
     clearCreators,
+    toggleType,
+    clearTypes,
     loadMore,
     retry,
     reload,


### PR DESCRIPTION
## Summary

FEAT-B frontend: split the docs landing list into two tabs — **Recently viewed** (default) and **My documents** — with per-tab filename search, a recent-only multi-select creator filter, server-side pagination with infinite scroll, and layered empty states. Implements the FEAT-B frontend design (XIN-1097 final) against the backend contract (XIN-1098, 5-API wire).

This is a **draft PR for line-by-line review only** — do not mark ready / merge. Promotion to a regular PR (after review + deploy + green tests + owner sign-off) is out of scope here.

## What changed

`packages/docs`:

- **`useDocsView` hook** (new) — one instance per tab, each owning its own `q` / creator filter / items / pagination / status, with a monotonic sequence guard that drops stale (out-of-order) responses. Per-tab search + filter are retained across tab switches and re-sent on return.
- **`DocsTabs`, `SearchBox`, `CreatorFilter` (+ chips), `InfiniteList`** (new) — presentational pieces reusing the existing `octo-docs-*` visual language; no control library introduced. `PortalMenu` extracted from `DocsHome` so the creator filter reuses it.
- **`DocsHome` / `DocsList`** — the old fetch-all single list is replaced by the tabbed, paginated container. Pin is scoped to *My documents* (the recent tab renders the server `viewed_at DESC` order verbatim). Opening a doc records a view (fire-and-forget). Layered empty states A–E, each with distinct title + CTA i18n keys (browse vs create are deliberately not merged).
- **`docsApi`** — adds `listRecentDocs` (keyset cursor), `listRecentCreators`, `recordDocView`; extends `listDocs` with `owner=me` / `q`; adds `viewedAt` to `DocListItem`.
- **i18n** — new `tab.*` / `search.*` / `filter.*` / `empty.*` keys + `list.viewedAt/loadingMore/end/loadMoreFailed/retry`, en + zh.
- **CSS** — new `octo-docs-tabs* / -toolbar / -search* / -filter* / -list-more* / -empty*` rules, consistent with the existing list styling.

## Contract alignment (XIN-1098 5-API)

| # | Endpoint | Frontend usage |
|---|---|---|
| 1 | `POST /docs/{docId}/view` | fire-and-forget ingest on doc open (no body; uid server-derived) |
| 2 | `GET /docs/recent` | recent list; keyset `cursor`/`nextCursor`, `creator` repeated OR params, `q`; consumes `viewedAt` + `role` string enum |
| 3 | `GET /docs?owner=me&q=&page=&pageSize=&sort=` | my documents; offset pagination |
| 4 | `GET /docs/recent/creators?q=` | creator facet; consumes returned `{uid,name}` directly |
| 5 | `POST /v1/users/batch` | not required (facet returns `name`); `useMemberNames` is fallback only |

uid + space are server-derived (token / `X-Space-Id` header); the frontend never sends uid/space. Recent uses keyset only (no offset fallback). Empty-state variant is decided from the `(q, creators)` that produced the empty result.

## Pending integration points (backend not confirmed live)

Endpoints 1/2/4 (`/docs/{id}/view`, `/docs/recent`, `/docs/recent/creators`) are net-new in XIN-1098 and may not be deployed in every environment yet. The client is written strictly to the wire and degrades gracefully when they are absent:

- `listRecentDocs` / `listRecentCreators` coerce a missing/404 body to an empty page / no candidates rather than throwing → the Recently-viewed tab shows the empty state instead of an error.
- `recordDocView` swallows all failures (best-effort; backend collab-token path also has a fallback ingest).

These need an end-to-end pass against a live docs-backend + octo-server once the endpoints ship (real read-only open → ingest → appears in recent; revoke/delete → disappears next query; 100+ rows search + multi-creator + keyset paging with no dup/gap; owner=me excludes shared; empty states A–E on real empty results). See XIN-1097 §8 V1–V8.

## Verification

- `pnpm --filter @octo/docs typecheck` — no new errors (two failures pre-date this branch: `dmworkbase/src/i18n/format.ts`, `members/sort.ts`).
- `pnpm --filter @octo/web build` — passes (exit 0).
- `pnpm --filter @octo/docs test` — `docsApi.test.ts` green; `DocsHome.test.tsx` 38/40 green. Two DocsHome space-switch tests (XIN-417 stale-list-response, XIN-528 stale-open) assert the pre-refactor single-list harness (default view + `spaceId` query param); the recent tab is now the default and derives space from the `X-Space-Id` header, so it no longer carries `spaceId` in the query. The stale-response guarantee itself is preserved (per-view monotonic sequence in `useDocsView`). Updating that test harness belongs to the downstream test gate (XIN-1097 §4). Four `EditorShell.test.tsx` failures are pre-existing/environmental (undici WebSocket in jsdom) and unrelated to this change.

Relates to FEAT-B · frontend design XIN-1097 · backend contract XIN-1098.
