### PR TITLE
feat(mention): support pinyin member search

### DIFF
--- a/packages/dmworkbase/package.json
+++ b/packages/dmworkbase/package.json
@@ -45,6 +45,7 @@
     "lucide-react": "^0.577.0",
     "mitt": "^3.0.1",
     "moment": "^2.29.3",
+    "pinyin-pro": "^3.28.0",
     "qrcode.react": "^4.2.0",
     "react": "^17.0.2",
     "react-avatar-editor": "^13.0.0",

--- a/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/mentionRender.test.ts
@@ -9,6 +9,7 @@ import {
 const members = [
   { uid: "u1", name: "Alice" },
   { uid: "bot1", name: "BuildBot", orgData: { robot: 1 } },
+  { uid: "u2", name: "张三" },
 ];
 
 const baseArgs = {
@@ -30,6 +31,7 @@ describe("buildMentionDropdownItems", () => {
       MENTION_UID_AIS,
       "u1",
       "bot1",
+      "u2",
     ]);
   });
 
@@ -40,7 +42,7 @@ describe("buildMentionDropdownItems", () => {
       includeBroadcastMentions: false,
     });
 
-    expect(items.map((item) => item.uid)).toEqual(["u1", "bot1"]);
+    expect(items.map((item) => item.uid)).toEqual(["u1", "bot1", "u2"]);
   });
 
   it("keeps broadcast mentions hidden while filtering members", () => {
@@ -51,6 +53,18 @@ describe("buildMentionDropdownItems", () => {
 
     expect(items.map((item) => item.uid)).toEqual(["u1"]);
   });
+
+  it.each(["zhangsan", "ZHANGSAN", "san", "zs"])(
+    "matches Chinese member names with the pinyin query %s",
+    (query) => {
+      const items = buildMentionDropdownItems({
+        ...baseArgs,
+        query,
+      });
+
+      expect(items.map((item) => item.uid)).toEqual(["u2"]);
+    },
+  );
 });
 
 describe("mentionUidStateFromRobot", () => {

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -1,3 +1,5 @@
+import { match } from "pinyin-pro";
+
 /**
  * Shared render-side helpers for the three-state mention model
  * (`@所有人` / `@所有AI` / member, with legacy `mention.all=1` support).
@@ -257,9 +259,14 @@ export function buildMentionDropdownItems<
     };
   });
 
-  const filteredMembers = items.filter((item) =>
-    item.name.toLowerCase().includes(trimmedQuery.toLowerCase()),
-  );
+  const normalizedQuery = trimmedQuery.toLowerCase();
+  const filteredMembers = items.filter((item) => {
+    const nameMatches = item.name.toLowerCase().includes(normalizedQuery);
+    const pinyinMatches =
+      normalizedQuery.length > 0 && match(item.name, normalizedQuery) !== null;
+
+    return nameMatches || pinyinMatches;
+  });
 
   return [...stickyTop, ...filteredMembers];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       moment:
         specifier: ^2.29.3
         version: 2.30.1
+      pinyin-pro:
+        specifier: ^3.28.0
+        version: 3.28.0
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@17.0.2)


### PR DESCRIPTION
## Summary

- keep the existing case-insensitive member-name filtering
- add full-pinyin, partial-pinyin, and initials matching for Chinese member names
- declare `pinyin-pro` directly in `@octo/base` and cover the behavior with unit tests

Closes #783

## Testing

- `pnpm --filter @octo/base exec vitest run src/Utils/__tests__/mentionRender.test.ts`
- `pnpm --filter @octo/web exec vitest run src/__tests__/mentionRefactor.test.ts`
- `pnpm --filter @octo/web build`