### PR TITLE
feat(summary): add /s/:taskNo standalone deep-link route to summary detail (rebased on main, no conflict)

### DIFF
--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -14,6 +14,7 @@ import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
 import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
+import { SummaryDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 import { isLoopCliAuthorizePath, LOOP_CLI_AUTHORIZE_PATH } from "@octo/loop";
 
@@ -75,6 +76,28 @@ function clearExpiredStandaloneSessionAndReload(): void {
     if (typeof window !== "undefined") window.location.reload();
 }
 
+/** `/s/:taskNo` — summary taskNo is a single URL path segment, optional trailing slash. */
+const STANDALONE_SUMMARY_PATH = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
+
+export function parseStandaloneSummaryTaskNo(pathname: string): string | null {
+    if (typeof pathname !== "string") return null;
+    const m = STANDALONE_SUMMARY_PATH.exec(pathname);
+    return m ? m[1] : null;
+}
+
+// Only a well-formed single-segment `/s/<taskNo>` counts as standalone; `/s`,
+// `/s/`, and nested `/s/a/b` must fall through (else the render branch mounts
+// SummaryDetailPage with an undefined taskId).
+export function isStandaloneSummaryPath(pathname: string): boolean {
+    return parseStandaloneSummaryTaskNo(pathname) !== null;
+}
+
+function applyStandaloneSummarySpaceFromQuery(): void {
+    const params = new URLSearchParams(window.location.search);
+    const spaceId = params.get("sp") || params.get("space") || "";
+    if (spaceId) WKApp.shared.currentSpaceId = spaceId;
+}
+
 export default class AppLayout extends Component<{}, AppLayoutState> {
     state: AppLayoutState = { showJoinSpace: false };
 
@@ -124,12 +147,18 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const forwardDoc = getQueryParam("doc") || ""
             const forwardSpace = getQueryParam("space") || ""
             const forwardFolder = getQueryParam("folder") || ""
+            const forwardSp = getQueryParam("sp") || ""
             const redirectQuery = new URLSearchParams()
             if (existingSid) redirectQuery.set("sid", existingSid)
             if (forwardDoc) {
                 redirectQuery.set("doc", forwardDoc)
                 if (forwardSpace) redirectQuery.set("space", forwardSpace)
                 if (forwardFolder) redirectQuery.set("folder", forwardFolder)
+            }
+            if (isStandaloneSummaryPath(window.location.pathname)) {
+                // 与 applyStandaloneSummarySpaceFromQuery(sp||space) 对称：登录重定向也一并透传 space。
+                if (forwardSp) redirectQuery.set("sp", forwardSp)
+                if (forwardSpace) redirectQuery.set("space", forwardSpace)
             }
             const redirectQs = redirectQuery.toString()
             const sidParam = redirectQs ? `?${redirectQs}` : ""
@@ -404,6 +433,25 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             // the login screen (below) without navigating away. The standalone page itself only
             // mounts once a token exists, so the anonymous path is the ONLY place this key gets
             // written for a first-time visitor — onLogin consumes it via consumeStandaloneReturn.
+            persistStandaloneReturn();
+            // Anonymous: fall through to the login screen (below) without navigating away.
+        }
+
+        // Standalone summary deep-link (`/s/:taskNo`): notification cards use task_no (not numeric
+        // task_id), so pass the raw path segment into the detail fetch. Auth/session recovery mirrors
+        // `/d/:docId`; anonymous visitors stash the exact target and return after login.
+        if (isStandaloneSummaryPath(window.location.pathname)) {
+            if (!WKApp.loginInfo.token) {
+                WKApp.loginInfo.load();
+            }
+            if (!WKApp.loginInfo.token) {
+                recoverOctoSessionFromStorage(true);
+            }
+            if (WKApp.loginInfo.token) {
+                applyStandaloneSummarySpaceFromQuery();
+                const standaloneTaskNo = parseStandaloneSummaryTaskNo(window.location.pathname);
+                return <SummaryDetailPage taskId={standaloneTaskNo ?? undefined} />;
+            }
             persistStandaloneReturn();
             // Anonymous: fall through to the login screen (below) without navigating away.
         }

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -71,3 +71,54 @@ describe('Layout — standalone /d/:docId clean cold-load path', () => {
     expect(layout).toMatch(/window\.location\.reload\(\)/)
   })
 })
+
+describe('Layout — standalone /s/:taskNo summary clean cold-load path', () => {
+  let layout: string
+
+  beforeAll(() => {
+    layout = fs.readFileSync(path.join(__dirname, '../Layout/index.tsx'), 'utf-8')
+  })
+
+  it('matches only a well-formed single-segment /s/<taskNo>, not /s, /s/, or nested paths', () => {
+    expect(layout).toMatch(/isStandaloneSummaryPath\(\s*window\.location\.pathname\s*\)/)
+    expect(layout).toMatch(/function\s+parseStandaloneSummaryTaskNo/)
+    // The matcher must delegate to the strict parser (single segment) rather than a
+    // loose /s namespace regex, so /s, /s/, and /s/a/b fall through instead of
+    // mounting SummaryDetailPage with an undefined taskId.
+    expect(layout).toMatch(/return\s+parseStandaloneSummaryTaskNo\(pathname\)\s*!==\s*null/)
+    expect(layout).not.toMatch(/STANDALONE_SUMMARY_NAMESPACE/)
+    expect(layout).not.toMatch(/if\s*\(\s*standaloneTaskNo\s*\)/)
+    // The strict single-segment path regex is the sole source of truth.
+    expect(layout).toMatch(/STANDALONE_SUMMARY_PATH\s*=\s*\/\^\\\/s\\\/\(\[A-Za-z0-9_-\]\+\)/)
+  })
+
+  it('recovers a stored session before rendering the summary detail page', () => {
+    const branchIdx = layout.indexOf('Standalone summary deep-link')
+    expect(branchIdx).toBeGreaterThan(0)
+    const nsIdx = layout.indexOf('isStandaloneSummaryPath(window.location.pathname)', branchIdx)
+    expect(nsIdx).toBeGreaterThan(0)
+    const recoverIdx = layout.indexOf('recoverOctoSessionFromStorage(true)', nsIdx)
+    const renderIdx = layout.indexOf('<SummaryDetailPage', nsIdx)
+    expect(recoverIdx).toBeGreaterThan(nsIdx)
+    expect(renderIdx).toBeGreaterThan(recoverIdx)
+  })
+
+  it('renders summary detail only with a token, passing the raw task_no string through', () => {
+    expect(layout).toMatch(/if\s*\(\s*WKApp\.loginInfo\.token\s*\)\s*\{[\s\S]*?<SummaryDetailPage/)
+    expect(layout).toMatch(/const\s+standaloneTaskNo\s*=\s*parseStandaloneSummaryTaskNo\(window\.location\.pathname\)/)
+    expect(layout).toMatch(/<SummaryDetailPage\s+taskId=\{standaloneTaskNo\s*\?\?\s*undefined\}/)
+  })
+
+  it('stashes anonymous /s targets and carries sp through post-login return', () => {
+    const branchIdx = layout.indexOf('Standalone summary deep-link')
+    expect(branchIdx).toBeGreaterThan(0)
+    const nsIdx = layout.indexOf('isStandaloneSummaryPath(window.location.pathname)', branchIdx)
+    expect(nsIdx).toBeGreaterThan(0)
+    const stashIdx = layout.indexOf('persistStandaloneReturn()', nsIdx)
+    expect(stashIdx).toBeGreaterThan(nsIdx)
+    expect(layout).toMatch(/const\s+forwardSp\s*=\s*getQueryParam\("sp"\)\s*\|\|\s*""/)
+    expect(layout).toMatch(/redirectQuery\.set\("sp",\s*forwardSp\)/)
+    expect(layout).toMatch(/consumeStandaloneReturn\(\)/)
+    expect(layout).toMatch(/withReturnSid\(standaloneReturn,\s*sessionSid\)/)
+  })
+})

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -703,7 +703,7 @@ export default class WKApp extends ProviderListener {
   static menus = MenusManager.shared; // 菜单
   // Callback to switch the active sidebar menu by id (set by Main page)
   static switchToMenuById?: (menuId: string) => void;
-  static openSummaryDetail?: (taskId: number) => void;
+  static openSummaryDetail?: (taskId: number | string, spaceId?: string) => void;
   static searchChatCandidates?: (params: { keyword?: string; chat_type?: string; space_id?: string }) => Promise<any[]>;
   // Id of the currently active sidebar menu (kept in sync by Main page)
   static currentMenuId?: string;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openSummaryDetailMock, wkAppMock } = vi.hoisted(() => {
+  const openSummaryDetailMock = vi.fn();
+  return {
+    openSummaryDetailMock,
+    wkAppMock: {
+      openSummaryDetail: openSummaryDetailMock as ((taskId: number | string, spaceId?: string) => void) | undefined,
+    },
+  };
+});
+
+vi.mock("../../../App", () => ({
+  default: wkAppMock,
+}));
+
+import { openUrl } from "../renderer/actions";
+
+describe("openUrl", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    openSummaryDetailMock.mockReset();
+    wkAppMock.openSummaryDetail = openSummaryDetailMock;
+    vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  it("routes /s/<taskNo> summary links internally", () => {
+    openUrl("https://web.example.com/s/ST202607145kstyh08?sp=space-1");
+
+    expect(openSummaryDetailMock).toHaveBeenCalledTimes(1);
+    expect(openSummaryDetailMock).toHaveBeenCalledWith("ST202607145kstyh08", "space-1");
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("routes /s/<taskNo> without sp with undefined space", () => {
+    openUrl("https://web.example.com/s/ST202607145kstyh08");
+
+    expect(openSummaryDetailMock).toHaveBeenCalledTimes(1);
+    expect(openSummaryDetailMock).toHaveBeenCalledWith("ST202607145kstyh08", undefined);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("opens external https links in a new tab", () => {
+    openUrl("https://web.example.com/docs/ST202607145kstyh08");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      "https://web.example.com/docs/ST202607145kstyh08",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("ignores unsafe urls", () => {
+    openUrl("javascript:alert(1)");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("falls back to window.open when summary routing is unavailable", () => {
+    wkAppMock.openSummaryDetail = undefined;
+
+    openUrl("https://web.example.com/s/ST202607145kstyh08?sp=space-1");
+
+    expect(openSummaryDetailMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      "https://web.example.com/s/ST202607145kstyh08?sp=space-1",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
@@ -1,4 +1,7 @@
+import WKApp from "../../../App";
 import { isSafeUrl } from "../../../Utils/security";
+
+const SUMMARY_DETAIL_PATH_RE = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
 
 /**
  * Action.OpenUrl 导航。
@@ -11,6 +14,24 @@ import { isSafeUrl } from "../../../Utils/security";
 /** 在新标签打开 URL；提交前二次 isSafeUrl 校验（http/https），非法直接忽略。 */
 export function openUrl(url: string): void {
   if (!isSafeUrl(url)) return;
+
+  // isSafeUrl 已保证 http/https 绝对 URL（new URL 不会抛）；try 兼容未来 isSafeUrl 放宽相对路径的情况。
+  let summaryTaskNo: string | null = null;
+  let summarySpace: string | undefined;
+  try {
+    const u = new URL(url);
+    summaryTaskNo = u.pathname.match(SUMMARY_DETAIL_PATH_RE)?.[1] ?? null;
+    // 深链带的空间（sp||space）随任务号一起透传，避免跨空间详情解析到当前空间→404。
+    summarySpace = u.searchParams.get("sp") || u.searchParams.get("space") || undefined;
+  } catch {
+    summaryTaskNo = null;
+  }
+  if (summaryTaskNo && WKApp.openSummaryDetail) {
+    // 卡片深链可能来自 https 生产域，本地调试是 http/端口；/s/<taskNo> 路径本身是内部详情信号。
+    WKApp.openSummaryDetail(summaryTaskNo, summarySpace);
+    return;
+  }
+
   window.open(url, "_blank", "noopener,noreferrer");
 }
 

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -143,8 +143,8 @@ export async function listSummaries(
     return get('/summaries', params as Record<string, unknown>, config);
 }
 
-export async function getSummaryDetail(taskId: number): Promise<SummaryDetail> {
-    return get(`/summaries/${taskId}`);
+export async function getSummaryDetail(taskId: number | string): Promise<SummaryDetail> {
+    return get(`/summaries/${encodeURIComponent(String(taskId))}`);
 }
 
 export async function deleteSummary(taskId: number): Promise<void> {

--- a/packages/dmworksummary/src/hooks/useSummaryDetail.ts
+++ b/packages/dmworksummary/src/hooks/useSummaryDetail.ts
@@ -12,7 +12,7 @@ interface UseSummaryDetailReturn {
     cancel: () => Promise<void>;
 }
 
-export function useSummaryDetail(taskId: number | null): UseSummaryDetailReturn {
+export function useSummaryDetail(taskId: number | string | null): UseSummaryDetailReturn {
     const [detail, setDetail] = useState<SummaryDetail | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -41,13 +41,13 @@ export function useSummaryDetail(taskId: number | null): UseSummaryDetailReturn 
     }, []);
 
     const regenerate = useCallback(async () => {
-        if (taskId == null) return;
+        if (typeof taskId !== "number") return;
         await api.regenerateSummary(taskId);
         refresh();
     }, [taskId, refresh]);
 
     const cancel = useCallback(async () => {
-        if (taskId == null) return;
+        if (typeof taskId !== "number") return;
         await api.cancelSummary(taskId);
         refresh();
     }, [taskId, refresh]);

--- a/packages/dmworksummary/src/index.tsx
+++ b/packages/dmworksummary/src/index.tsx
@@ -1,1 +1,2 @@
 export { SummaryModule } from "./module";
+export { default as SummaryDetailPage } from "./pages/SummaryDetailPage";

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -55,7 +55,9 @@ export class SummaryModule implements IModule {
             "en-US": enUS,
         });
 
-        WKApp.openSummaryDetail = (taskId: number) => {
+        WKApp.openSummaryDetail = (taskId: number | string, spaceId?: string) => {
+            // 卡片深链带的空间可能≠当前空间，路由前先切目标空间，与浏览器路由 applyStandaloneSummarySpaceFromQuery 对称。
+            if (spaceId) WKApp.shared.currentSpaceId = spaceId;
             WKApp.switchToMenuById?.("summary");
             WKApp.routeLeft.popToRoot();
             WKApp.routeRight.replaceToRoot(

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -49,7 +49,7 @@ import MemberSelectorModal from "../components/MemberSelectorModal";
 import type { MemberCandidate } from "../types/summary";
 
 interface SummaryDetailPageProps {
-    taskId?: number;
+    taskId?: number | string;
 }
 
 type RegenerateMode = "refine" | "full";
@@ -225,7 +225,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
 
     componentDidUpdate(prevProps: any, prevState?: SummaryDetailPageState) {
         const prevTaskId = prevProps.taskId;
-        const currentTaskId = this.taskId;
+        const currentTaskId = this.detailLookupId;
         if (prevTaskId !== currentTaskId && currentTaskId != null) {
             this.listPageActive = false;
             this.clearAllTimers();
@@ -371,6 +371,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     get taskId(): number | null {
+        // 数字 taskId 直接用；字符串 taskNo 深链时先返回 null，待 detail 落库后回填 detail.task_id。
+        return typeof this.props.taskId === "number" ? this.props.taskId : this.state.detail?.task_id ?? null;
+    }
+
+    // 深链原始标识：数字 task_id 或字符串 task_no，仅用于首次 detail 拉取与切换检测。
+    private get detailLookupId(): number | string | null {
         return this.props.taskId ?? null;
     }
 
@@ -394,11 +400,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     async loadDetail() {
-        if (this.taskId == null) return;
+        const lookupId = this.detailLookupId;
+        if (lookupId == null) return;
         // Blocking 5：每轮 detail 加载开始就 bump 序列号。这样旧 task 未完成的
         // loadSchedule（包括本函数下面发起的）都会被后续轮作废，不会回填到新 task。
         const seq = this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
+        const requestTaskId = lookupId;
         // F1：切 task / 重拉 detail 时复位全部编辑态，避免旧 task 编辑态（尤其
         // editingTeamSummary）被带入新 task——否则切到非 creator 新 task 会绕过权限进编辑器。
         // FE-1（切任务竞态）：开始新 task 加载时同步清空上一 task 的 personalResult/members，
@@ -436,9 +443,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             restoringPersonalVersionId: null,
         });
         try {
-            const detail = await api.getSummaryDetail(this.taskId);
+            const detail = await api.getSummaryDetail(lookupId);
             // detail 本身也可能是旧请求：期间切了 task / 又发了一轮 loadDetail 就丢弃。
-            if (this.scheduleLoadSeq !== seq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== seq || this.detailLookupId !== requestTaskId) return;
             this.setState({
                 detail,
                 loading: false,
@@ -472,13 +479,15 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             // Load BY_PERSON data
             if (detail.summary_mode === SummaryMode.BY_PERSON) {
                 // FE-1：把本轮 seq 传给二次异步加载，迟到响应按 seq/taskId 校验后才 setState。
-                this.loadPersonalResult(seq);
-                this.loadMembers(seq);
+                // 字符串 taskNo 深链时 this.taskId 依赖 state.detail（setState 未提交会为 null），
+                // 故显式传入刚拿到的 detail.task_id（数字），避开 setState 竞态。
+                this.loadPersonalResult(seq, false, detail.task_id);
+                this.loadMembers(seq, detail.task_id);
             }
         } catch (err: any) {
             // FE-1（切 task 竞态）：迟到的失败响应也要校验归属，否则旧 task 的加载失败
             // 会把错误/loading 状态写到已切换的新 task 上。
-            if (this.scheduleLoadSeq !== seq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== seq || this.detailLookupId !== requestTaskId) return;
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
         }
     }
@@ -514,15 +523,17 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      * 仍一致才能 setState。过期响应（期间切了 task / 又发了一轮加载）一律
      * 忽略（return），绝不把旧任务的 personalResult 写到新任务界面（泄漏他人报告）。
      */
-    async loadPersonalResult(seq?: number, suppressWorkflow = false) {
-        if (this.taskId == null) return;
+    async loadPersonalResult(seq?: number, suppressWorkflow = false, taskIdOverride?: number) {
+        const requestTaskId = taskIdOverride ?? this.taskId;
+        if (requestTaskId == null) return;
         const reqSeq = seq ?? this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
         this.setState({ personalLoading: true });
         try {
-            const result = await api.getPersonalResult(this.taskId);
+            const result = await api.getPersonalResult(requestTaskId);
             // 迟到响应（期间切 task / 重新加载）：丢弃，不污染新 task。
-            if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
+            // 字符串 taskNo 首次加载时 detail 的 setState 可能未提交，this.taskId 为 null；
+            // seq 已能盖住真切 task，故 taskId 只在「已提交且确实不同」时才丢弃，避免静默丢掉首载。
+            if (this.scheduleLoadSeq !== reqSeq || (this.taskId != null && this.taskId !== requestTaskId)) return;
             const shouldGateWorkflow = !suppressWorkflow && this.shouldGateWorkflowForPersonalResult(result);
             if (shouldGateWorkflow) {
                 this.setState({
@@ -542,11 +553,11 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             this.startPersonalPoll(result.worker_status);
             if (result.content?.trim()) {
                 this.loadPersonalVersions(requestTaskId);
-            } else if (this.taskId === requestTaskId) {
+            } else if (this.taskId == null || this.taskId === requestTaskId) {
                 this.setState({ personalVersions: [], personalVersionsLoading: false });
             }
         } catch {
-            if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== reqSeq || (this.taskId != null && this.taskId !== requestTaskId)) return;
             this.setState({ personalLoading: false });
         }
     }
@@ -556,17 +567,17 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      * 把旧 task 的成员名单 setState 到新 task（否则泄漏他人报告 / 污染 team
      * citations、schedule participant 写入）。seq/taskId 不一致一律忽略。
      */
-    async loadMembers(seq?: number) {
-        if (this.taskId == null) return;
+    async loadMembers(seq?: number, taskIdOverride?: number) {
+        const requestTaskId = taskIdOverride ?? this.taskId;
+        if (requestTaskId == null) return;
         const reqSeq = seq ?? this.nextScheduleSeq();
-        const requestTaskId = this.taskId;
         this.setState({ membersLoading: true });
         try {
-            const members = await api.getMembers(this.taskId);
-            if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
+            const members = await api.getMembers(requestTaskId);
+            if (this.scheduleLoadSeq !== reqSeq || (this.taskId != null && this.taskId !== requestTaskId)) return;
             this.setState({ members, membersLoading: false });
         } catch {
-            if (this.scheduleLoadSeq !== reqSeq || this.taskId !== requestTaskId) return;
+            if (this.scheduleLoadSeq !== reqSeq || (this.taskId != null && this.taskId !== requestTaskId)) return;
             this.setState({ membersLoading: false });
         }
     }

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
@@ -53,7 +53,7 @@ import SummaryDetailPage from '../SummaryDetailPage';
 
 vi.mock('../../api/summaryApi');
 
-function makePage(taskId: number) {
+function makePage(taskId: number | string) {
     const page = new SummaryDetailPage({ taskId } as any);
     (page as any).context = { t: (k: string) => k };
     (page as any).setState = function (this: any, patch: any) {
@@ -182,6 +182,35 @@ describe('SummaryDetailPage — Blocking 5: scheduleItem must track current deta
 // 且 loadDetail 入口同步清空 stale personalResult/members。
 describe('SummaryDetailPage — FE-1: 切任务竞态，旧 members/personalResult 迟到返回被忽略', () => {
     beforeEach(() => vi.clearAllMocks());
+
+    it('string task_no detail load starts BY_PERSON secondary fetches with numeric detail.task_id', async () => {
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2 }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: '我的报告', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid'), member('u_b')] as any);
+
+        const page = makePage('SUM-740');
+        const queuedSetStates: any[] = [];
+        (page as any).setState = function (this: any, patch: any, callback?: () => void) {
+            queuedSetStates.push({ patch, callback });
+        };
+
+        await page.loadDetail();
+
+        expect(api.getSummaryDetail).toHaveBeenCalledWith('SUM-740');
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);
+        expect(api.getMembers).toHaveBeenCalledWith(740);
+        expect(queuedSetStates.some(({ patch }) => patch?.detail?.task_id === 740)).toBe(true);
+        // M1 回归：detail 的 setState 在本 mock 下永不提交（this.taskId 一直为 null），
+        // 模拟字符串深链首载时 secondary fetch 先于 detail 提交返回的竞态窗口。
+        // 修复前旧守卫 this.taskId!==requestTaskId 会把 null!==740 判为切 task、
+        // 静默丢弃 personalResult/members；修复后必须仍将其 setState。
+        expect(queuedSetStates.some(({ patch }) => patch?.personalResult?.content === '我的报告')).toBe(true);
+        expect(queuedSetStates.some(({ patch }) => Array.isArray(patch?.members) && patch.members.length === 2)).toBe(true);
+    });
 
     // loadDetail 入口必须同步清空上一 task 的 personalResult/members，避免新 detail 返回前残留显示。
     it('loadDetail clears stale personalResult/members at entry (no leak before new detail resolves)', async () => {
@@ -2654,5 +2683,112 @@ describe('MemberSelectorModal — 问题3b: 防重复提交（confirmLoading 禁
         expect(confirmBtn).toBeTruthy();
         expect(confirmBtn.props.loading).toBeFalsy();
         expect(confirmBtn.props.disabled).toBeFalsy();
+    });
+});
+
+// ─── 深链 /s/:taskNo：loadPersonalResult 的四个入口在字符串 taskNo 场景下都以数字 task_id 生效 ───
+// 背景：/s/:taskNo 深链传入的是字符串 task_no。首载 (loadDetail) 拿到 detail 后，this.taskId
+// 回填为 detail.task_id（数字）。此后 handleSubmitPersonal / handleStatusChangeEvent /
+// doFallbackPollOnce 三个入口都基于 this.taskId（=数字）驱动 loadPersonalResult，
+// 不得再把字符串 task_no 传给 getPersonalResult/getMembers/batchStatus 等数字接口。
+describe('SummaryDetailPage — 深链 string taskNo：loadPersonalResult 四入口均以数字 task_id 生效', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // 入口1：loadDetail（首载）——字符串 taskNo，detail 已提交后 this.taskId=数字。
+    it('入口1 loadDetail: string taskNo 首载后 this.taskId 回填为数字 detail.task_id', async () => {
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2 }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: 'r', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid')] as any);
+
+        const page = makePage('SUM-740'); // 同步提交型 setState：detail 落地后 taskId=740
+        await page.loadDetail();
+
+        expect(api.getSummaryDetail).toHaveBeenCalledWith('SUM-740'); // 首载用字符串深链标识
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);      // 二次加载用数字
+        expect(api.getMembers).toHaveBeenCalledWith(740);
+        expect(page.taskId).toBe(740);
+    });
+
+    // 入口2：handleSubmitPersonal——提交个人报告后刷新，必须用数字 taskId。
+    it('入口2 handleSubmitPersonal: 用数字 task_id 提交并刷新 personalResult/members', async () => {
+        vi.mocked(api.submitPersonalResult).mockResolvedValue(undefined as any);
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2 }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: 'r', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid')] as any);
+
+        const page = makePage('SUM-740');
+        // 模拟深链首载已完成：detail 已就位，this.taskId=740。
+        page.state = { ...(page.state as any), detail: baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2 }) };
+
+        await page.handleSubmitPersonal();
+
+        expect(api.submitPersonalResult).toHaveBeenCalledWith(740);
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);
+        expect(api.getMembers).toHaveBeenCalledWith(740);
+        // 绝不把字符串 task_no 传给数字接口
+        expect(api.submitPersonalResult).not.toHaveBeenCalledWith('SUM-740');
+        expect(api.getPersonalResult).not.toHaveBeenCalledWith('SUM-740');
+    });
+
+    // 入口3：handleStatusChangeEvent——状态变更事件（携数字 taskIds）触发刷新。
+    it('入口3 handleStatusChangeEvent: 数字 taskIds 命中当前深链 task 时刷新 personalResult', async () => {
+        // 事件前状态 processing，事件后 completed → 触发终态刷新分支。
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2, status: 5 /* COMPLETED */ }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: 'r', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid')] as any);
+
+        const page = makePage('SUM-740');
+        page.state = {
+            ...(page.state as any),
+            detail: baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2, status: 2 /* PROCESSING */ }),
+            lastKnownStatus: 2,
+        };
+
+        // 事件 detail.taskIds 是数字 task_id；this.taskId 必须解析为 740 才能命中。
+        await (page as any).handleStatusChangeEvent(
+            new CustomEvent('summary-status-change', { detail: { taskIds: [740] } }),
+        );
+
+        expect(api.getSummaryDetail).toHaveBeenCalledWith(740);
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);
+        expect(api.getPersonalResult).not.toHaveBeenCalledWith('SUM-740');
+    });
+
+    // 入口4：doFallbackPollOnce——兜底轮询，batchStatus 用数字 id，终态触发刷新。
+    it('入口4 doFallbackPollOnce: batchStatus 用数字 id，终态刷新 personalResult 用数字', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([{ id: 740, status: 5 /* COMPLETED */ }] as any);
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(
+            baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2, status: 5 }) as any,
+        );
+        vi.mocked(api.getPersonalResult).mockResolvedValue(
+            { content: 'r', worker_status: 2, submitted_at: null } as any,
+        );
+        vi.mocked(api.getMembers).mockResolvedValue([member('test-uid')] as any);
+
+        const page = makePage('SUM-740');
+        page.state = {
+            ...(page.state as any),
+            detail: baseDetail({ task_id: 740, task_no: 'SUM-740', summary_mode: 2, status: 2 /* PROCESSING */ }),
+            lastKnownStatus: 2,
+        };
+
+        await (page as any).doFallbackPollOnce();
+
+        expect(api.batchStatus).toHaveBeenCalledWith([740]);        // 轮询用数字
+        expect(api.getPersonalResult).toHaveBeenCalledWith(740);    // 终态刷新用数字
+        expect(api.batchStatus).not.toHaveBeenCalledWith(['SUM-740']);
+        expect(api.getPersonalResult).not.toHaveBeenCalledWith('SUM-740');
     });
 });

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -800,6 +800,13 @@ describe('standalone return target — open-redirect-safe post-login bounce (blo
     }
   })
 
+  it('accepts a safe same-origin /s/:taskNo target for summary notification returns', () => {
+    for (const good of ['/s/TN_20260713_abcd', '/s/TN-9_x?sp=space-1']) {
+      window.sessionStorage.setItem(STANDALONE_RETURN_KEY, good)
+      expect(consumeStandaloneReturn()).toBe(good)
+    }
+  })
+
   it('AC-11 anonymous entry: the sign-in terminal stashes a safe, consumable return target', async () => {
     window.history.pushState({}, '', '/d/d_locked_out')
     wk.apiClient.responder = (method, url) => {
@@ -824,6 +831,7 @@ describe('withReturnSid — carry the current session sid on the post-login /d/:
     // now-strict multi-session recovery (which would loop back to login).
     expect(withReturnSid('/d/d_abc', 'fresh6')).toBe('/d/d_abc?sid=fresh6')
     expect(withReturnSid('/d/d_abc/', 'fresh6')).toBe('/d/d_abc/?sid=fresh6')
+    expect(withReturnSid('/s/TN_20260713_abcd?sp=space-1', 'fresh6')).toBe('/s/TN_20260713_abcd?sp=space-1&sid=fresh6')
   })
 
   it('leaves a target that already carries a sid untouched (no doubling)', () => {

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -25,6 +25,9 @@ export const STANDALONE_RETURN_KEY = 'octo.docs.standaloneReturn'
 /** `/d/:docId` — docId is a single documentName segment (A-Z a-z 0-9 _ -), optional trailing slash. */
 const STANDALONE_PATH = /^\/d\/([A-Za-z0-9_-]+)\/?$/
 
+/** `/s/:taskNo` — summary notification deep-link target, same segment safety as `/d/:docId`. */
+const STANDALONE_SUMMARY_PATH = /^\/s\/([A-Za-z0-9_-]+)\/?$/
+
 /** The standalone-doc URL namespace: `/d`, `/d/`, or `/d/<anything>` (top-level only). */
 const STANDALONE_NAMESPACE = /^\/d(?:\/|$)/
 
@@ -65,7 +68,7 @@ export function persistStandaloneReturn(): void {
 }
 
 /**
- * Whether a stashed return target is a SAFE same-origin link that lands on a standalone doc page.
+ * Whether a stashed return target is a SAFE same-origin standalone link.
  *
  * Open-redirect guard (hardened, XIN-392). The value lives in sessionStorage, so it is
  * attacker-influenceable, and it is later fed to `window.location.assign` — it must clear three
@@ -80,10 +83,9 @@ export function persistStandaloneReturn(): void {
  *   2. Same origin. Resolve against the current origin and require `url.origin === origin`. This
  *      rejects absolute (`https://evil`), scheme-relative (`//host`), and backslash-smuggled
  *      (`/\host`) targets structurally, instead of hand-checking leading characters.
- *   3. Standalone-doc target only (P2-2). Even a same-origin path must resolve to `/d/:docId`
- *      (`parseStandaloneDocId(url.pathname) !== null`), so a tampered value can't bounce the user to
- *      another same-origin page (`/settings`, `/oidc/bind`, …) after login — the post-login return
- *      is scoped to the standalone document the user actually opened.
+ *   3. Standalone target only (P2-2). Even a same-origin path must resolve to `/d/:docId` or the
+ *      summary notification target `/s/:taskNo`, so a tampered value can't bounce the user to another
+ *      same-origin page (`/settings`, `/oidc/bind`, …) after login.
  */
 function isSafeReturnPath(path: string | null): path is string {
   if (typeof path !== 'string' || path.length === 0) return false
@@ -103,7 +105,7 @@ function isSafeReturnPath(path: string | null): path is string {
     return false
   }
   if (url.origin !== origin) return false
-  return parseStandaloneDocId(url.pathname) !== null
+  return parseStandaloneDocId(url.pathname) !== null || STANDALONE_SUMMARY_PATH.test(url.pathname)
 }
 
 /**


### PR DESCRIPTION
## Summary
Re-implements PR #740's思路 (smart-summary notification card → click → land on detail page) on **latest `main`**, on a fresh branch off `main` to avoid the merge conflict #740 now has.

#740 conflicts with `main` only in `SummaryDetailPage.tsx` (the refine/regenerate/version-restore feature merged 841 lines there). This PR hand-weaves the same taskNo-support logic into the current file, so there is **no conflict**. The other 12 files are functionally identical to #740.

Supersedes #740 and the older #680 (`/summary/detail?taskId=` landing). Pairs with octo-smart-summary #153 (notify card) and #154 (resolve detail by `task_no`).

## What & why
The completed-summary notification card links to `/s/{task_no}?sp={space_id}`, but octo-web had no such route, so a click bounced to login and lost the target. Also, the card carries a **string `task_no`** (not the numeric `task_id`), which the detail page previously couldn't consume.

## Changes
- `apps/web/src/Layout/index.tsx`: new `/s/:taskNo` standalone route, mirrors `/d/:docId` incl. login-redirect fallback + `sp` space forwarding.
- `packages/dmworkbase/.../InteractiveCard/renderer/actions.ts`: intercept `/s/<taskNo>` card clicks → internal `WKApp.openSummaryDetail(taskNo)`.
- `SummaryDetailPage.tsx`: accept `string` task_no. `detailLookupId` (raw prop) drives the initial fetch + change-detection; numeric `taskId` is derived from `detail.task_id`. BY_PERSON secondary loads (`loadPersonalResult`/`loadMembers`) take the explicit numeric `detail.task_id` to avoid a setState race (this was a known trap: string prop → `this.taskId` null before `setState({detail})` commits).
- `StandaloneDocPage.tsx`: extend the post-login safe-return open-redirect guard to also allow `/s/:taskNo`.
- widen `taskId` types across `summaryApi.getSummaryDetail`, `useSummaryDetail`, `module.tsx`, `App.tsx`.
- tests: route parsing (`layoutStandaloneDocPath`), card-action routing (`InteractiveCard/actions`), and a `string task_no` detail-load race test.

## Testing (local, latest main)
- `pnpm turbo run build --filter=@octo/web` → ✓ built (production bundle clean).
- `packages/dmworksummary` full suite: **377 passed** (incl. new string-task_no test).
- `packages/dmworkbase` InteractiveCard actions: 4 passed.
- `apps/web` layoutStandaloneDocPath: 9 passed.

## 部署前提 / 必配环境变量
本 PR 为**纯前端路由/交互改动，不新增任何必配环境变量**。端到端生效依赖已有的两侧配套：
- octo-smart-summary #153（worker 发卡片）+ #154（server 按 `task_no` 解析详情）需一并部署，否则卡片链接/详情查询不通。
- 无新增 build-time / runtime env。
