### PR TITLE
feat(summary): render smart summary output incrementally

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -86,6 +86,11 @@ server {
             # forwards the rewritten request as-is.
             rewrite ^/summary/api/v1/(.*)$ /api/v1/$1 break;
             proxy_pass  $summary_api_url;
+            # SSE endpoints under /summary/api/v1 require unbuffered streaming.
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -132,6 +132,150 @@ async function del<T>(path: string): Promise<T> {
 
 // ─── Core Summary Operations ───────────────────────────
 
+
+export interface SummaryStreamEvent {
+    type: "start" | "stage" | "delta" | "snapshot" | "done" | "error" | string;
+    task_id?: number;
+    run_id?: string;
+    scope?: "personal" | "team" | string;
+    stage?: string;
+    delta?: string;
+    content?: string;
+    message?: string;
+    status?: number;
+    result_id?: number;
+    version_id?: number;
+    version?: number;
+    citations?: unknown[];
+    team_citations?: unknown[];
+    msg_count?: number;
+    total_msg_count?: number;
+    total_token_used?: number;
+    model_version?: string;
+    operation_type?: string;
+    operation_note?: string;
+    parent_result_id?: number | null;
+    generated_at?: string;
+}
+
+function buildSummaryURL(path: string): string {
+    return `${resolveSummaryBaseURL()}${BASE}${path}`;
+}
+
+function parseSSEBlock(block: string): SummaryStreamEvent | null {
+    let eventType = "message";
+    const dataLines: string[] = [];
+    for (const rawLine of block.split(/\r?\n/)) {
+        const line = rawLine.trimEnd();
+        if (!line || line.startsWith(":")) continue;
+        if (line.startsWith("event:")) {
+            eventType = line.slice("event:".length).trim();
+        } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice("data:".length).trimStart());
+        }
+    }
+    if (dataLines.length === 0) return null;
+    const data = dataLines.join("\n");
+    if (data === "[DONE]") return { type: "done" };
+    try {
+        const parsed = JSON.parse(data) as SummaryStreamEvent;
+        return { ...parsed, type: parsed.type || eventType };
+    } catch {
+        return { type: eventType, delta: data };
+    }
+}
+
+function buildStreamHeaders(hasBody = false): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: "text/event-stream",
+        "Accept-Language": buildAcceptLanguage(),
+    };
+    if (hasBody) headers["Content-Type"] = "application/json";
+    const token = WKApp.loginInfo.token;
+    if (token) headers.token = token;
+    const spaceId = WKApp.shared.currentSpaceId;
+    if (spaceId) headers["X-Space-Id"] = spaceId;
+    return headers;
+}
+
+async function consumeSSE(resp: Response, onEvent: (event: SummaryStreamEvent) => void): Promise<void> {
+    if (!resp.body) return;
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let completed = false;
+    try {
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let match = buffer.match(/\r?\n\r?\n/);
+            while (match?.index != null) {
+                const block = buffer.slice(0, match.index);
+                buffer = buffer.slice(match.index + match[0].length);
+                const event = parseSSEBlock(block);
+                if (event) onEvent(event);
+                match = buffer.match(/\r?\n\r?\n/);
+            }
+        }
+        const tail = buffer.trim();
+        if (tail) {
+            const event = parseSSEBlock(tail);
+            if (event) onEvent(event);
+        }
+        completed = true;
+    } finally {
+        if (!completed) {
+            try {
+                await reader.cancel();
+            } catch {
+                // ignore cleanup errors
+            }
+        }
+        reader.releaseLock();
+    }
+}
+
+async function streamRequest(
+    path: string,
+    init: RequestInit,
+    onEvent: (event: SummaryStreamEvent) => void,
+): Promise<void> {
+    const resp = await fetch(buildSummaryURL(path), init);
+    if (resp.status === 401) {
+        WKApp.shared.logout();
+    }
+    if (!resp.ok) {
+        let message = `Summary stream failed (${resp.status})`;
+        try {
+            const data = await resp.json();
+            message = data?.message || data?.msg || data?.error || message;
+        } catch {
+            // ignore non-json error body
+        }
+        throw new Error(message);
+    }
+    await consumeSSE(resp, onEvent);
+}
+
+export async function streamSummary(
+    taskId: number,
+    options: {
+        scope?: "personal" | "team";
+        signal?: AbortSignal;
+        onEvent: (event: SummaryStreamEvent) => void;
+    },
+): Promise<void> {
+    const params = new URLSearchParams();
+    if (options.scope) params.set("scope", options.scope);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    await streamRequest(`/summaries/${taskId}/stream${suffix}`, {
+        method: "GET",
+        headers: buildStreamHeaders(),
+        signal: options.signal,
+    }, options.onEvent);
+}
+
 export async function createSummary(params: CreateSummaryParams): Promise<{ task_id: number }> {
     return post('/summaries', params);
 }
@@ -153,6 +297,19 @@ export async function deleteSummary(taskId: number): Promise<void> {
 
 export async function regenerateSummary(taskId: number, body?: { topic?: string }): Promise<{ task_id: number }> {
     return post(`/summaries/${taskId}/regenerate`, body);
+}
+
+export async function streamRefineSummary(
+    taskId: number,
+    body: { feedback: string; base_result_id: number },
+    options: { signal?: AbortSignal; onEvent: (event: SummaryStreamEvent) => void },
+): Promise<void> {
+    await streamRequest(`/summaries/${taskId}/refine/stream`, {
+        method: "POST",
+        headers: buildStreamHeaders(true),
+        body: JSON.stringify(body),
+        signal: options.signal,
+    }, options.onEvent);
 }
 
 export async function refineSummary(
@@ -194,6 +351,19 @@ export async function regeneratePersonalSummary(
     body?: { topic?: string },
 ): Promise<{ task_id: number; result_id: number; status: number }> {
     return post(`/summaries/${taskId}/personal-regenerate`, body);
+}
+
+export async function streamRefinePersonalSummary(
+    taskId: number,
+    body: { feedback: string; base_result_id: number; base_version?: number },
+    options: { signal?: AbortSignal; onEvent: (event: SummaryStreamEvent) => void },
+): Promise<void> {
+    await streamRequest(`/summaries/${taskId}/personal-refine/stream`, {
+        method: "POST",
+        headers: buildStreamHeaders(true),
+        body: JSON.stringify(body),
+        signal: options.signal,
+    }, options.onEvent);
 }
 
 export async function refinePersonalSummary(

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -52,6 +52,9 @@ interface SummaryDetailPageProps {
     taskId?: number;
 }
 
+// Matters 转发入口暂时隐藏，保留相关代码和弹窗，后续需要时打开此开关即可。
+const SHOW_FORWARD_TO_MATTER = false;
+
 type RegenerateMode = "refine" | "full";
 type RefineLoadingTarget = "personal" | "team" | "summary";
 
@@ -105,6 +108,12 @@ interface SummaryDetailPageState {
     workflowDisplayIndex: number;
     workflowGateContent: boolean;
     workflowRevealDone: boolean;
+    streaming: boolean;
+    streamingContent: string;
+    streamError: string | null;
+    teamStreaming: boolean;
+    teamStreamingContent: string;
+    teamStreamError: string | null;
 }
 
 const INTER_MESSAGE_DELAY_MS = 200;
@@ -193,6 +202,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         workflowDisplayIndex: -1,
         workflowGateContent: false,
         workflowRevealDone: false,
+        streaming: false,
+        streamingContent: "",
+        streamError: null,
+        teamStreaming: false,
+        teamStreamingContent: "",
+        teamStreamError: null,
     };
 
     private personalPollTimer: ReturnType<typeof setInterval> | null = null;
@@ -200,6 +215,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     private fallbackStartTimeout: ReturnType<typeof setTimeout> | null = null;
     private workflowAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
     private workflowCompleteTimer: ReturnType<typeof setTimeout> | null = null;
+    private streamAbortController: AbortController | null = null;
+    private streamingTaskId: number | null = null;
+    private streamClosedTaskId: number | null = null;
+    private teamStreamAbortController: AbortController | null = null;
+    private teamStreamingTaskId: number | null = null;
+    private teamStreamClosedTaskId: number | null = null;
+    private refineStreamAbortController: AbortController | null = null;
+    private unmounted = false;
     private workflowTargetIndex = -1;
     private listPageActive = false;
     private lastEventTime = 0;
@@ -217,6 +240,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     componentDidMount() {
+        this.unmounted = false;
         window.addEventListener("summary-status-change", this.handleStatusChangeEvent);
         window.addEventListener("summary-batch-heartbeat", this.handleBatchHeartbeat);
         window.addEventListener("summary-list-unmount", this.handleListPageUnmount);
@@ -243,7 +267,15 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 restoringVersionId: null,
                 restoringPersonalVersionId: null,
                 pendingScheduleInstruction: "",
+                streamingContent: "",
+                streamError: null,
+                streaming: false,
+                teamStreamingContent: "",
+                teamStreamError: null,
+                teamStreaming: false,
             });
+            this.streamClosedTaskId = null;
+            this.teamStreamClosedTaskId = null;
             this.loadDetail();
         }
         if (prevState && prevState.showVersionDetailModal !== this.state.showVersionDetailModal) {
@@ -252,6 +284,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     componentWillUnmount() {
+        this.unmounted = true;
         window.removeEventListener("summary-status-change", this.handleStatusChangeEvent);
         window.removeEventListener("summary-batch-heartbeat", this.handleBatchHeartbeat);
         window.removeEventListener("summary-list-unmount", this.handleListPageUnmount);
@@ -260,6 +293,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     private clearAllTimers() {
+        this.stopSummaryStream();
+        this.stopTeamSummaryStream();
+        this.stopRefineStream();
         if (this.personalPollTimer) {
             clearInterval(this.personalPollTimer);
             this.personalPollTimer = null;
@@ -466,8 +502,18 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 detail.status === TaskStatus.WAITING_CONFIRM
             ) {
                 this.startFallbackPoll();
+                if (detail.summary_mode === SummaryMode.BY_PERSON && this.streamClosedTaskId !== detail.task_id) {
+                    this.startSummaryStream(detail.task_id);
+                }
+                const isMultiByPerson = detail.summary_mode === SummaryMode.BY_PERSON && ((detail.participants?.length || 0) > 1);
+                if (isMultiByPerson && this.teamStreamClosedTaskId !== detail.task_id) {
+                    this.startTeamSummaryStream(detail.task_id);
+                }
             } else {
                 this.stopFallbackPoll();
+                this.stopSummaryStream(true);
+                this.stopTeamSummaryStream();
+                this.setState({ teamStreaming: false, teamStreamingContent: "", teamStreamError: null });
             }
             // Load BY_PERSON data
             if (detail.summary_mode === SummaryMode.BY_PERSON) {
@@ -813,6 +859,199 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         }
     }
 
+
+    private startSummaryStream(taskId: number) {
+        if (this.streamClosedTaskId === taskId) return;
+        if (this.streamingTaskId === taskId && this.streamAbortController) return;
+        this.stopSummaryStream();
+        const controller = new AbortController();
+        this.streamAbortController = controller;
+        this.streamingTaskId = taskId;
+        this.setState({ streaming: true, streamError: null, streamingContent: "" });
+        let terminalReceived = false;
+        void api.streamSummary(taskId, {
+            scope: "personal",
+            signal: controller.signal,
+            onEvent: (event) => {
+                if (this.taskId !== taskId) return;
+                if (event.type === "start") {
+                    this.setState({ streamingContent: "", streamError: null });
+                    return;
+                }
+                if (event.type === "stage" && event.stage) {
+                    const idx = this.workflowStageIndex(event.stage);
+                    if (idx >= 0) this.setWorkflowStageDirectly(idx);
+                    return;
+                }
+                if (event.type === "delta") {
+                    if (event.content) {
+                        this.setState({ streamingContent: event.content });
+                    } else if (event.delta) {
+                        this.setState((prev) => ({ streamingContent: prev.streamingContent + event.delta }));
+                    }
+                    return;
+                }
+                if (event.type === "snapshot") {
+                    this.setState({ streamingContent: event.content || "" });
+                    return;
+                }
+                if (event.type === "done") {
+                    terminalReceived = true;
+                    this.streamAbortController = null;
+                    this.streamingTaskId = null;
+                    this.streamClosedTaskId = taskId;
+                    this.setState({ streaming: false });
+                    this.loadDetail();
+                    return;
+                }
+                if (event.type === "error") {
+                    terminalReceived = true;
+                    this.streamAbortController = null;
+                    this.streamingTaskId = null;
+                    this.streamClosedTaskId = taskId;
+                    this.setState({ streaming: false, streamError: event.message || null });
+                    this.loadDetail();
+                }
+            },
+        }).then(() => {
+            if (terminalReceived || controller.signal.aborted || this.taskId !== taskId) return;
+            this.streamAbortController = null;
+            this.streamingTaskId = null;
+            this.streamClosedTaskId = taskId;
+            this.setState({ streaming: false });
+            this.startFallbackPoll();
+        }).catch((err: any) => {
+            if (controller.signal.aborted || this.taskId !== taskId) return;
+            this.streamAbortController = null;
+            this.streamingTaskId = null;
+            this.streamClosedTaskId = taskId;
+            this.setState({ streaming: false, streamError: err?.message || null });
+            // Keep the existing polling path as the reliability fallback.
+            this.startFallbackPoll();
+        });
+    }
+
+    private stopSummaryStream(resetState = false) {
+        if (this.streamAbortController) {
+            this.streamAbortController.abort();
+            this.streamAbortController = null;
+        }
+        this.streamingTaskId = null;
+        if (resetState && !this.unmounted) {
+            this.setState({ streaming: false, streamingContent: "", streamError: null });
+        }
+    }
+
+    private stopRefineStream() {
+        if (this.refineStreamAbortController) {
+            this.refineStreamAbortController.abort();
+            this.refineStreamAbortController = null;
+        }
+    }
+
+    private isRefineDonePayload(event: api.SummaryStreamEvent) {
+        return event.type === "done" && (
+            event.result_id != null ||
+            event.version != null ||
+            event.version_id != null ||
+            event.content != null ||
+            event.citations != null ||
+            event.team_citations != null ||
+            event.generated_at != null
+        );
+    }
+
+    private resetSummaryStreamForNewRun(taskId: number) {
+        this.stopSummaryStream();
+        this.streamClosedTaskId = null;
+        this.setState({ streaming: false, streamingContent: "", streamError: null });
+        if (this.taskId === taskId) {
+            this.startSummaryStream(taskId);
+        }
+    }
+
+    private startTeamSummaryStream(taskId: number) {
+        if (this.teamStreamClosedTaskId === taskId) return;
+        if (this.teamStreamingTaskId === taskId && this.teamStreamAbortController) return;
+        this.stopTeamSummaryStream();
+        const controller = new AbortController();
+        this.teamStreamAbortController = controller;
+        this.teamStreamingTaskId = taskId;
+        this.setState({ teamStreaming: true, teamStreamError: null, teamStreamingContent: "" });
+        let terminalReceived = false;
+        void api.streamSummary(taskId, {
+            scope: "team",
+            signal: controller.signal,
+            onEvent: (event) => {
+                if (this.taskId !== taskId) return;
+                if (event.type === "start") {
+                    this.setState({ teamStreamingContent: "", teamStreamError: null });
+                    return;
+                }
+                if (event.type === "delta") {
+                    if (event.content) {
+                        this.setState({ teamStreamingContent: event.content });
+                    } else if (event.delta) {
+                        this.setState((prev) => ({ teamStreamingContent: prev.teamStreamingContent + event.delta }));
+                    }
+                    return;
+                }
+                if (event.type === "snapshot") {
+                    this.setState({ teamStreamingContent: event.content || "" });
+                    return;
+                }
+                if (event.type === "done") {
+                    terminalReceived = true;
+                    this.teamStreamAbortController = null;
+                    this.teamStreamingTaskId = null;
+                    this.teamStreamClosedTaskId = taskId;
+                    this.setState({ teamStreaming: false });
+                    this.loadDetail();
+                    return;
+                }
+                if (event.type === "error") {
+                    terminalReceived = true;
+                    this.teamStreamAbortController = null;
+                    this.teamStreamingTaskId = null;
+                    this.teamStreamClosedTaskId = taskId;
+                    this.setState({ teamStreaming: false, teamStreamError: event.message || null });
+                    this.loadDetail();
+                }
+            },
+        }).then(() => {
+            if (terminalReceived || controller.signal.aborted || this.taskId !== taskId) return;
+            this.teamStreamAbortController = null;
+            this.teamStreamingTaskId = null;
+            this.teamStreamClosedTaskId = taskId;
+            this.setState({ teamStreaming: false });
+            this.startFallbackPoll();
+        }).catch((err: any) => {
+            if (controller.signal.aborted || this.taskId !== taskId) return;
+            this.teamStreamAbortController = null;
+            this.teamStreamingTaskId = null;
+            this.teamStreamClosedTaskId = taskId;
+            this.setState({ teamStreaming: false, teamStreamError: err?.message || null });
+            this.startFallbackPoll();
+        });
+    }
+
+    private stopTeamSummaryStream() {
+        if (this.teamStreamAbortController) {
+            this.teamStreamAbortController.abort();
+            this.teamStreamAbortController = null;
+        }
+        this.teamStreamingTaskId = null;
+    }
+
+    private resetTeamSummaryStreamForNewRun(taskId: number) {
+        this.stopTeamSummaryStream();
+        this.teamStreamClosedTaskId = null;
+        this.setState({ teamStreaming: false, teamStreamingContent: "", teamStreamError: null });
+        if (this.taskId === taskId) {
+            this.startTeamSummaryStream(taskId);
+        }
+    }
+
     handleRegenerate = () => {
         const { detail } = this.state;
         if (this.taskId == null) return;
@@ -858,32 +1097,77 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             ? this.state.refineFeedback.trim()
             : this.state.regenerateTopic.trim();
         if (!trimmed) return;
+        this.stopRefineStream();
         this.setState({ regenerateSubmitting: true });
+        let restoreRefineDraft: (() => void) | null = null;
+        let currentRefineController: AbortController | null = null;
         try {
             const operateOnTeamSummary = this.shouldOperateOnTeamSummary();
             if (regenerateMode === "refine") {
                 if (detail?.summary_mode === SummaryMode.BY_PERSON && !operateOnTeamSummary) {
                     const baseResultId = this.state.personalResult?.id;
                     if (!baseResultId) return;
+                    const previousPersonalResult = this.state.personalResult;
+                    const previousMembers = this.state.members;
+                    restoreRefineDraft = () => {
+                        if (this.taskId === requestTaskId) this.setState({ personalResult: previousPersonalResult, members: previousMembers });
+                    };
                     this.setState({ showRegenerateModal: false, refineLoadingTarget: "personal" });
-                    const refined = await api.refinePersonalSummary(requestTaskId, {
+                    const refineController = new AbortController();
+                    currentRefineController = refineController;
+                    this.refineStreamAbortController = refineController;
+                    let draft = "";
+                    let refined: api.SummaryStreamEvent | null = null;
+                    await api.streamRefinePersonalSummary(requestTaskId, {
                         feedback: trimmed,
                         base_result_id: baseResultId,
                         base_version: this.state.personalResult?.version,
+                    }, {
+                        signal: refineController.signal,
+                        onEvent: (event) => {
+                            if (this.taskId !== requestTaskId || refineController.signal.aborted) return;
+                            if (event.type === "delta") {
+                                draft = event.content || (draft + (event.delta || ""));
+                                const myUid = WKApp.loginInfo.uid;
+                                this.setState((prev) => ({
+                                    personalResult: prev.personalResult ? { ...prev.personalResult, content: draft } : prev.personalResult,
+                                    members: prev.members.map((m) => m.user_id === myUid ? { ...m, content: draft } : m),
+                                } as Pick<SummaryDetailPageState, "personalResult" | "members">));
+                                return;
+                            }
+                            if (event.type === "snapshot") {
+                                draft = event.content || "";
+                                const myUid = WKApp.loginInfo.uid;
+                                this.setState((prev) => ({
+                                    personalResult: prev.personalResult ? { ...prev.personalResult, content: draft } : prev.personalResult,
+                                    members: prev.members.map((m) => m.user_id === myUid ? { ...m, content: draft } : m),
+                                } as Pick<SummaryDetailPageState, "personalResult" | "members">));
+                                return;
+                            }
+                            if (event.type === "error") {
+                                throw new Error(event.message || t("summary.common.operationFailed"));
+                            }
+                            if (this.isRefineDonePayload(event)) {
+                                refined = event;
+                            }
+                        },
                     });
-                    if (this.taskId !== requestTaskId) return;
+                    if (this.refineStreamAbortController === refineController) this.refineStreamAbortController = null;
+                    if (this.taskId !== requestTaskId || refineController.signal.aborted) return;
+                    if (!refined) throw new Error(t("summary.common.operationFailed"));
+                    restoreRefineDraft = null;
                     Toast.success(t("summary.detail.refineSuccess"));
                     this.appendLocalScheduleInstruction(trimmed);
                     this.reloadScheduleAfterInstructionChange(requestTaskId);
                     this.setState((prev) => {
                         const nextPersonal = prev.personalResult ? {
                             ...prev.personalResult,
-                            id: refined.result_id || prev.personalResult.id,
-                            version: refined.version,
-                            content: refined.content,
-                            citations: (refined.citations as any) || prev.personalResult.citations,
-                            msg_count: refined.msg_count ?? prev.personalResult.msg_count,
-                            generated_at: refined.generated_at || prev.personalResult.generated_at,
+                            id: refined!.result_id || prev.personalResult.id,
+                            version: refined!.version || prev.personalResult.version,
+                            content: refined!.content || draft,
+                            citations: (refined!.citations as any) || prev.personalResult.citations,
+                            msg_count: refined!.msg_count ?? prev.personalResult.msg_count,
+                            generated_at: refined!.generated_at || prev.personalResult.generated_at,
                         } : prev.personalResult;
                         const myUid = WKApp.loginInfo.uid;
                         return {
@@ -892,8 +1176,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             personalResult: nextPersonal,
                             members: prev.members.map((m) => m.user_id === myUid ? {
                                 ...m,
-                                content: refined.content,
-                                citations: (refined.citations as any) || m.citations,
+                                content: refined!.content || draft,
+                                citations: (refined!.citations as any) || m.citations,
                             } : m),
                         } as Pick<SummaryDetailPageState, "showRegenerateModal" | "refineLoadingTarget" | "personalResult" | "members">;
                     });
@@ -901,12 +1185,61 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 } else {
                     const baseResultId = detail?.result_id;
                     if (!baseResultId) return;
+                    const previousDetail = this.state.detail;
+                    restoreRefineDraft = () => {
+                        if (this.taskId === requestTaskId) this.setState({ detail: previousDetail });
+                    };
                     this.setState({
                         showRegenerateModal: false,
                         refineLoadingTarget: operateOnTeamSummary ? "team" : "summary",
                     });
-                    const refined = await api.refineSummary(requestTaskId, { feedback: trimmed, base_result_id: baseResultId });
-                    if (this.taskId !== requestTaskId) return;
+                    const refineController = new AbortController();
+                    currentRefineController = refineController;
+                    this.refineStreamAbortController = refineController;
+                    let draft = "";
+                    let refined: api.SummaryStreamEvent | null = null;
+                    await api.streamRefineSummary(requestTaskId, { feedback: trimmed, base_result_id: baseResultId }, {
+                        signal: refineController.signal,
+                        onEvent: (event) => {
+                            if (this.taskId !== requestTaskId || refineController.signal.aborted) return;
+                            if (event.type === "delta") {
+                                draft = event.content || (draft + (event.delta || ""));
+                                this.setState((prev) => {
+                                    if (!prev.detail?.result) return null;
+                                    return {
+                                        detail: {
+                                            ...prev.detail,
+                                            result: { ...prev.detail.result, content: draft },
+                                        },
+                                    } as Pick<SummaryDetailPageState, "detail">;
+                                });
+                                return;
+                            }
+                            if (event.type === "snapshot") {
+                                draft = event.content || "";
+                                this.setState((prev) => {
+                                    if (!prev.detail?.result) return null;
+                                    return {
+                                        detail: {
+                                            ...prev.detail,
+                                            result: { ...prev.detail.result, content: draft },
+                                        },
+                                    } as Pick<SummaryDetailPageState, "detail">;
+                                });
+                                return;
+                            }
+                            if (event.type === "error") {
+                                throw new Error(event.message || t("summary.common.operationFailed"));
+                            }
+                            if (this.isRefineDonePayload(event)) {
+                                refined = event;
+                            }
+                        },
+                    });
+                    if (this.refineStreamAbortController === refineController) this.refineStreamAbortController = null;
+                    if (this.taskId !== requestTaskId || refineController.signal.aborted) return;
+                    if (!refined) throw new Error(t("summary.common.operationFailed"));
+                    restoreRefineDraft = null;
                     Toast.success(t("summary.detail.refineSuccess"));
                     this.appendLocalScheduleInstruction(trimmed);
                     this.reloadScheduleAfterInstructionChange(requestTaskId);
@@ -917,20 +1250,20 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             refineLoadingTarget: null,
                             detail: {
                                 ...prev.detail,
-                                result_id: refined.result_id,
+                                result_id: refined!.result_id || prev.detail.result_id,
                                 result: {
                                     ...prev.detail.result,
-                                    content: refined.content,
-                                    version: refined.version,
-                                    citations: (refined.citations as any) || prev.detail.result.citations,
-                                    team_citations: (refined.team_citations as any) || prev.detail.result.team_citations,
-                                    total_msg_count: refined.total_msg_count ?? prev.detail.result.total_msg_count,
-                                    total_token_used: refined.total_token_used ?? prev.detail.result.total_token_used,
-                                    model_version: refined.model_version || prev.detail.result.model_version,
-                                    operation_type: refined.operation_type,
-                                    operation_note: refined.operation_note,
-                                    parent_result_id: refined.parent_result_id,
-                                    generated_at: refined.generated_at || prev.detail.result.generated_at,
+                                    content: refined!.content || draft,
+                                    version: refined!.version || prev.detail.result.version,
+                                    citations: (refined!.citations as any) || prev.detail.result.citations,
+                                    team_citations: (refined!.team_citations as any) || prev.detail.result.team_citations,
+                                    total_msg_count: refined!.total_msg_count ?? prev.detail.result.total_msg_count,
+                                    total_token_used: refined!.total_token_used ?? prev.detail.result.total_token_used,
+                                    model_version: refined!.model_version || prev.detail.result.model_version,
+                                    operation_type: refined!.operation_type,
+                                    operation_note: refined!.operation_note,
+                                    parent_result_id: refined!.parent_result_id,
+                                    generated_at: refined!.generated_at || prev.detail.result.generated_at,
                                 },
                             },
                         } as Pick<SummaryDetailPageState, "showRegenerateModal" | "refineLoadingTarget" | "detail">;
@@ -942,6 +1275,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     await api.regenerateSummary(requestTaskId, { topic: trimmed });
                     if (this.taskId !== requestTaskId) return;
                     Toast.success(t("summary.detail.regenerateStarted"));
+                    this.resetTeamSummaryStreamForNewRun(requestTaskId);
                     this.resetLocalScheduleInstruction(trimmed);
                     this.setState((prev) => prev.detail ? {
                         showRegenerateModal: false,
@@ -956,6 +1290,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     await api.regeneratePersonalSummary(requestTaskId, { topic: trimmed });
                     if (this.taskId !== requestTaskId) return;
                     Toast.success(t("summary.detail.regenerateStarted"));
+                    this.resetSummaryStreamForNewRun(requestTaskId);
                     this.resetLocalScheduleInstruction(trimmed);
                     this.setState((prev) => ({
                         showRegenerateModal: false,
@@ -986,6 +1321,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     await api.regenerateSummary(requestTaskId, { topic: trimmed });
                     if (this.taskId !== requestTaskId) return;
                     Toast.success(t("summary.detail.regenerateStarted"));
+                    if (detail?.summary_mode === SummaryMode.BY_PERSON) {
+                        this.resetSummaryStreamForNewRun(requestTaskId);
+                    }
                     this.resetLocalScheduleInstruction(trimmed);
                     this.setState({ showRegenerateModal: false });
                     this.loadDetail();
@@ -994,10 +1332,18 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             if (this.taskId !== requestTaskId) return;
             window.dispatchEvent(new CustomEvent("summary-task-regenerated", { detail: { taskId: requestTaskId } }));
         } catch (err: any) {
+            if (err?.name === "AbortError" || this.taskId !== requestTaskId || this.unmounted) return;
+            restoreRefineDraft?.();
             this.setState({ refineLoadingTarget: null });
             Toast.error(err.message || t("summary.common.operationFailed"));
         } finally {
-            this.setState({ regenerateSubmitting: false });
+            if (currentRefineController && this.refineStreamAbortController === currentRefineController) {
+                this.refineStreamAbortController.abort();
+                this.refineStreamAbortController = null;
+            }
+            if (this.taskId === requestTaskId && !this.unmounted) {
+                this.setState({ regenerateSubmitting: false });
+            }
         }
     };
 
@@ -1678,6 +2024,33 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 <div className="summary-detail-team-generating">
                     <Spin size="small" />
                     <span>{t(descKey)}</span>
+                </div>
+            </div>
+        );
+    }
+
+    renderStreamingContent() {
+        const content = this.state.streamingContent.trim();
+        if (!this.state.streaming || !content) return null;
+        return (
+            <div className="summary-detail-personal summary-detail-streaming">
+                <div className="summary-detail-content-box">
+                    <CitationText content={this.state.streamingContent} citations={[]} />
+                </div>
+            </div>
+        );
+    }
+
+    renderTeamStreamingContent() {
+        const content = this.state.teamStreamingContent.trim();
+        if (!this.state.teamStreaming || !content) return null;
+        return (
+            <div className="summary-detail-team summary-detail-streaming">
+                <div className="summary-detail-section-header">
+                    <span>{this.context.t("summary.detail.teamSummary")}</span>
+                </div>
+                <div className="summary-detail-content-box">
+                    <CitationText content={this.state.teamStreamingContent} citations={[]} members={this.state.members} />
                 </div>
             </div>
         );
@@ -2839,7 +3212,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                 {t("summary.detail.forwardToChat")}
                             </Button>
                         )}
-                        {detail && detail.status === TaskStatus.COMPLETED && (
+                        {SHOW_FORWARD_TO_MATTER && detail && detail.status === TaskStatus.COMPLETED && (
                             <Button
                                 theme="borderless"
                                 icon={<IconSend />}
@@ -2942,20 +3315,23 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                         {/* need1：多人协作不再单独显示「我的总结」区块（自己内容改到参与者报告
                                             里我那条，need3）；单人 BY_PERSON 维持显示「我的总结」及其行内编辑。 */}
                                         {!this.isMultiCollab() && (
-                                            this.state.isEditing && this.state.personalResult && detail.result_id ? (
-                                                <div className="summary-detail-personal">
-                                                    <h3>{t("summary.detail.mySummaryPlain")}</h3>
-                                                    <SummaryEditor
-                                                        taskId={detail.task_id}
-                                                        baseResultId={detail.result_id}
-                                                        initialContent={this.state.personalResult.content || ""}
-                                                        onSave={this.handleEditSave}
-                                                        onCancel={this.handleEditCancel}
-                                                    />
-                                                </div>
-                                            ) : (
-                                                this.renderPersonalSummary()
-                                            )
+                                            <>
+                                                {this.shouldShowProcessingCard() && !this.personalReady && this.renderProcessing()}
+                                                {this.state.isEditing && this.state.personalResult && detail.result_id ? (
+                                                    <div className="summary-detail-personal">
+                                                        <h3>{t("summary.detail.mySummaryPlain")}</h3>
+                                                        <SummaryEditor
+                                                            taskId={detail.task_id}
+                                                            baseResultId={detail.result_id}
+                                                            initialContent={this.state.personalResult.content || ""}
+                                                            onSave={this.handleEditSave}
+                                                            onCancel={this.handleEditCancel}
+                                                        />
+                                                    </div>
+                                                ) : (
+                                                    this.renderPersonalSummary()
+                                                )}
+                                            </>
                                         )}
                                         {/* 回归修复：多人协作页给「我自己」补回「提交给全部」轻量入口。
                                             不违反 need1（不恢复我的总结正文区），仅一句提示 + 提交按钮。
@@ -2963,17 +3339,28 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                         {this.isMultiCollabRegenerating() && this.shouldShowWorkflowCard() && this.renderProcessing()}
                                         {this.isMultiCollabRegenerating() && !this.shouldShowWorkflowCard() && this.renderTeamGeneratingStatus()}
                                         {this.renderMySubmitBar()}
-                                        {this.renderTeamSummary()}
+                                        {this.state.teamStreaming && this.state.teamStreamingContent.trim() ? (
+                                            <>
+                                                {this.renderTeamStreamingContent()}
+                                                {this.renderStreamingContent()}
+                                            </>
+                                        ) : (
+                                            <>
+                                                {this.renderStreamingContent()}
+                                                {this.renderTeamSummary()}
+                                            </>
+                                        )}
                                         {this.renderMemberStatus()}
                                         {this.renderParticipantReports()}
                                     </>
                                 )}
 
-                                {this.shouldShowProcessingCard() &&
-                                    !this.isMultiCollabRegenerating() &&
+                                {detail.summary_mode !== SummaryMode.BY_PERSON &&
+                                    this.shouldShowProcessingCard() &&
                                     !this.personalReady &&
                                     this.renderProcessing()
                                 }
+                                {detail.summary_mode !== SummaryMode.BY_PERSON && this.renderStreamingContent()}
 
                                 {detail.status === TaskStatus.FAILED && this.renderFailed()}
 


### PR DESCRIPTION
## Summary

- Consume backend streaming endpoints for smart-summary output.
- Render summary content incrementally while generation is in progress.
- Support streaming display for personal summary, team summary, regenerate, and refine flows where available.
- Fall back to existing polling when streaming is interrupted or unavailable.
- Refresh final detail/result after stream completion and use the persisted result as the source of truth.
- Keep workflow/progress display order stable while streaming content updates.
- Hide the forward-to-matter action on summary detail behind a local feature flag.
- Update nginx summary API proxy settings for streaming responses.

## Implementation

- Add summary stream API helpers.
- Add incremental rendering state and stream handling in the summary detail page.
- Keep polling as fallback and final result refresh path.
- Configure nginx buffering/timeout settings for summary streaming.

## Testing

- `pnpm --filter @octo/web build`

Closes #786
