### PR TITLE
fix(docs): widen table column-resize grab zone so the last column resizes (#749)

### DIFF
--- a/packages/docs/src/editor/extensions.ts
+++ b/packages/docs/src/editor/extensions.ts
@@ -230,7 +230,15 @@ export function buildExtensions(opts: BuildExtensionsOptions): Extensions {
     // self-built NodeView (TableCellView) that gives ProseMirror explicit
     // ignoreMutation/stopEvent rules so resize/remote DOM writes don't desync
     // collaborative cursors (§3.2 requirement).
-    Table.configure({ resizable: true }),
+    // #749: the default prosemirror-tables `handleWidth` (5px) only arms a ~10px band
+    // straddling each column border, and the LAST column's right border sits flush with
+    // the visible edge so its arm zone is effectively unreachable — dragging it did
+    // nothing. Widen the arm band to 12px so every border, including the last column's
+    // right edge, has a comfortable grab zone. `cellMinWidth` is pinned to prosemirror's
+    // default (25) — kept explicit because it must stay >= handleWidth * 2 so adjacent
+    // borders' arm bands never overlap on the narrowest columns (which would make a small
+    // column impossible to grab/shrink).
+    Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 }),
     TableRow,
     TableHeader.extend({
       addNodeView() {

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1919,15 +1919,37 @@
   opacity: 0.12;
   pointer-events: none;
 }
+/* #749: the resize handle is the visible drag affordance. Keep the coloured bar thin
+   (2px) but stretch the interactive box to ~10px via a transparent hit area straddling
+   the border, so the pointer grabs the border comfortably instead of needing pixel-exact
+   aim. The visible bar is painted by the ::before pseudo-element; the element itself is
+   transparent padding. right:-5px centres the 10px box on the cell border (last column's
+   right edge included). z-index is intentionally NOT set here — the #755 freeze feature
+   owns lifting this handle above sticky frozen cells. */
 .octo-prose table .column-resize-handle {
   position: absolute;
-  right: -2px;
+  right: -5px;
   top: 0;
   bottom: 0;
-  width: 4px;
-  background: var(--octo-accent);
+  width: 10px;
+  background: transparent;
   cursor: col-resize;
   user-select: none;
+}
+.octo-prose table .column-resize-handle::before {
+  content: '';
+  position: absolute;
+  right: 3px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--octo-accent);
+}
+/* prosemirror-tables toggles `resize-cursor` on the editor root while the pointer is
+   armed over a column border. Without an explicit rule the col-resize cursor feedback
+   was missing, so users had no signal where the grab zone was (#749). */
+.octo-prose .ProseMirror.resize-cursor {
+  cursor: col-resize;
 }
 .octo-prose .tableWrapper {
   overflow-x: auto;


### PR DESCRIPTION
## Summary

Fixes #749 — table column widths were very hard to drag, and the **last column's right border could not be dragged at all**.

This is the **second layer** of the fix, on top of #715. #715 fixed `TableCellView.stopEvent` (return `false`) so the resize drag could *start*; it did not change *where* the drag arms. The remaining problem is the grab zone itself:

- `Table.configure` never passed `handleWidth`, so prosemirror-tables used its default of `5px`. That arms only a ~10px band straddling each column border, and the last column's right border sits flush with the table edge, so its arm zone was effectively unreachable — dragging it did nothing.
- The `.column-resize-handle` was a 4px painted bar with no extra hit area, and the repo was missing the `.ProseMirror.resize-cursor { cursor: col-resize }` rule, so there was almost no `col-resize` cursor feedback telling the user where to grab.

## Changes

- **`packages/docs/src/editor/extensions.ts`** — `Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 })`. `handleWidth: 12` gives every border, including the last column's right edge, a comfortable grab zone. `cellMinWidth` is pinned to prosemirror's default (25), kept explicit because it must stay `>= handleWidth * 2` so adjacent borders' arm bands never overlap on the narrowest columns (which would make a small column impossible to grab/shrink).
- **`packages/docs/src/editor/styles.css`** — keep the coloured resize bar thin (2px, painted via a `::before`) but stretch the interactive `.column-resize-handle` box to 10px of transparent hit area centred on the border; add the missing `.ProseMirror.resize-cursor { cursor: col-resize }` rule. `z-index` is intentionally left to the freeze feature (#755), which lifts the handle above sticky frozen cells.

## Verification

Driven in real headless Chromium with a minimal Tiptap editor using the exact config + CSS under test, measuring the last column's arm zone (offset from the right border):

- `handleWidth: 5` (old default): arms only at ~−3px…−1px — a ~3px band, practically unreachable.
- `handleWidth: 12` (this PR): arms across ~−11px…−1px — a comfortable ~11px band. Drag applies the expected width delta once armed.

Internal borders drag as before. `pnpm typecheck` shows no new errors (two pre-existing errors in unrelated files remain); the table test suites (`TableCellView`, `TableControls`, docx `table-layout`) pass (42/42). No change to freeze (#755) stacking, `stopEvent` (#715), the right-click menu (#761), or the table toolbar (#625).

## Notes

Draft on purpose — parks review; not for merge yet.
