### PR TITLE
fix(loop): remove the list-view sort control

### DIFF
--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -47,8 +47,6 @@ export function listIssues(params?: ListParams): Promise<{ issues: Issue[]; tota
     date_field: params?.date_field,
     date_start: params?.date_start,
     date_end: params?.date_end,
-    sort: params?.sort_by,
-    direction: params?.sort_direction,
     limit: params?.limit,
     offset: params?.offset,
   });

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -49,10 +49,6 @@ export interface Invitation {
   created_at?: string;
 }
 
-// 后端 /issues sort 白名单(单一来源,派生类型 + 供 UI 枚举)。
-export const ISSUE_SORT_FIELDS = ["position", "priority", "title", "created_at", "start_date", "due_date"] as const;
-export type IssueSortField = (typeof ISSUE_SORT_FIELDS)[number];
-
 // 时间范围筛选可选字段(后端仅接受这两列)。
 export const ISSUE_DATE_FIELDS = ["created_at", "updated_at"] as const;
 export type IssueDateField = (typeof ISSUE_DATE_FIELDS)[number];
@@ -78,10 +74,6 @@ export interface ListParams {
   date_field?: IssueDateField;
   date_start?: string;
   date_end?: string;
-  // 后端白名单 sort：position(默认)|priority|title|created_at|start_date|due_date。
-  // direction 仅在 sort_by != position 时被后端采纳(asc|desc)。
-  sort_by?: IssueSortField;
-  sort_direction?: "asc" | "desc";
   limit?: number;
   offset?: number;
 }

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -154,15 +154,6 @@
     "created_at": "Created",
     "updated_at": "Updated"
   },
-  "sort": {
-    "direction": "Asc/desc",
-    "position": "Manual",
-    "priority": "Priority",
-    "title": "Title",
-    "created_at": "Created",
-    "start_date": "Start date",
-    "due_date": "Due date"
-  },
   "action": {
     "newIssue": "New Loop",
     "newSkill": "New Skill",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -154,15 +154,6 @@
     "created_at": "创建时间",
     "updated_at": "更新时间"
   },
-  "sort": {
-    "direction": "升/降序",
-    "position": "手动排序",
-    "priority": "优先级",
-    "title": "标题",
-    "created_at": "创建时间",
-    "start_date": "开始日期",
-    "due_date": "截止日期"
-  },
   "action": {
     "newIssue": "新建回路",
     "newSkill": "新建技能",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Input,
-  Button,
   Spin,
   Select,
   Pagination,
@@ -11,7 +10,7 @@ import {
   Toast,
 } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
-import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, ArrowUp, ArrowDown, SlidersHorizontal, Filter } from "lucide-react";
+import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, SlidersHorizontal, Filter } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type {
   Issue,
@@ -19,11 +18,10 @@ import type {
   IssueScope,
   IssueStatus,
   IssuePriority,
-  IssueSortField,
   IssueDateField,
   IssueLabel,
 } from "../api/types";
-import { ISSUE_SORT_FIELDS, ISSUE_DATE_FIELDS } from "../api/types";
+import { ISSUE_DATE_FIELDS } from "../api/types";
 import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAgentTaskSnapshot } from "../api/issueApi";
 import { groupIssuesByAssignee } from "../api/issueGrouping";
 import { listProjectOptions } from "../api/directory";
@@ -61,8 +59,6 @@ interface Filters {
   labelIds: string[];
   dateField: IssueDateField; // 时间范围筛选的列(created_at|updated_at)
   dateRange?: Date[];        // [start, end];为空则不按时间筛选
-  sortBy: IssueSortField;
-  sortDir: "asc" | "desc";
 }
 
 const PAGE_SIZE = 50;
@@ -91,7 +87,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<ViewMode>(() => isMyLoop ? "grouped" : (viewKey ? readView(viewKey, ["board", "grouped", "list"], defaultView ?? "board") : (defaultView ?? "board")));
   const [scope, setScope] = useState<IssueScope>(defaultScope ?? "all");
-  const [f, setF] = useState<Filters>({ keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false, creatorIds: [], projectIds: [], noProject: false, labelIds: [], sortBy: "position", sortDir: "desc", dateField: "created_at" });
+  const [f, setF] = useState<Filters>({ keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false, creatorIds: [], projectIds: [], noProject: false, labelIds: [], dateField: "created_at" });
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   // 「无负责人」仅在 scope=全部 时有效(与 assignee_types 组合恒空)。单一来源:发送/勾选态/计数共用,防漂移。
   const noAssigneeActive = scope === "all" && f.noAssignee;
@@ -192,9 +188,6 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       : listIssues({
           ...common,
           assignee_types: scopeToAssigneeTypes(scope),
-          // 排序仅用于列表视图;看板按 status 分列 + 100 上限,叠加全局排序会把某状态整列截没,故看板固定后端默认(position)。
-          sort_by: paged ? f.sortBy : undefined,
-          sort_direction: paged ? f.sortDir : undefined,
           // ponytail: 看板不分页——按 status 分列需全量，取后端上限 100；超量请用筛选或列表视图。
           limit: paged ? PAGE_SIZE : 100,
           offset: paged ? page * PAGE_SIZE : 0,
@@ -247,8 +240,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
   const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
-  // 切视图后关闭「显示」面板;但列表视图会露出「升/降序」子选项,保持面板打开让用户接着选。
-  const switchView = (v: ViewMode) => { setView(v); setPage(0); if (viewKey) writeView(viewKey, v); if (v !== "list") setShowOpen(false); };
+  const switchView = (v: ViewMode) => { setView(v); setPage(0); if (viewKey) writeView(viewKey, v); setShowOpen(false); };
 
   // 点击 Issue → 跳转独立详情页（push 到右主栏，返回可 pop）。
   // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
@@ -363,7 +355,6 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     </div>
   );
 
-  // 「显示」面板：视图切换 + 列表排序。
   const showPanel = (
     <div className="loop-fields loop-show-panel">
       <div className="loop-filter-panel__head"><span>{t("loop.action.show")}</span></div>
@@ -378,17 +369,6 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
           ))}
         </div>
       </div>
-      {view === "list" && (
-        <div className="loop-fields__row">
-          <div className="loop-fields__label">{t("loop.sort.direction")}</div>
-          <div className="loop-fields__inline">
-            <Select value={f.sortBy} onChange={(v) => update({ sortBy: v as IssueSortField })} disabled={searching} {...FIELD_POPUP} style={{ flex: 1 }}>
-              {ISSUE_SORT_FIELDS.map((s) => (<Select.Option key={s} value={s}>{t(`loop.sort.${s}`)}</Select.Option>))}
-            </Select>
-            <Button theme="borderless" disabled={searching || f.sortBy === "position"} icon={f.sortDir === "asc" ? <ArrowUp size={14} /> : <ArrowDown size={14} />} aria-label={t("loop.sort.direction")} onClick={() => update({ sortDir: f.sortDir === "asc" ? "desc" : "asc" })} />
-          </div>
-        </div>
-      )}
     </div>
   );
 


### PR DESCRIPTION
## What

Removes the list-view sort control (`升/降序`: field `Select` + asc/desc toggle) from the Loop issue page.

## Why

The sort control existed **only** in the list view; the board and grouped views never had one. It's not broken on the backend — `GET /issues?sort=…&direction=…` sorts correctly — but the list view renders rows **grouped into fixed status sections** (`IssueList` buckets by `ISSUE_STATUS_ORDER`), so a global sort only reorders rows *within* each status group. With 2–3 issues per group the effect is near-invisible, so it reads as "not working", and it's inconsistent with the other two views. Removing it makes all three views consistent (backend default `position` / manual order within status grouping).

## Changes (frontend-only, `packages/dmloop`)

- `pages/IssuePage.tsx`: drop the sort `Select` + direction toggle from the show panel; remove `sortBy`/`sortDir` from `Filters` state; remove `sort_by`/`sort_direction` from the `listIssues` call; `switchView` now closes the show panel for every view (previously kept open for the list's sort sub-options); drop the now-unused `Button`/`ArrowUp`/`ArrowDown`/`IssueSortField`/`ISSUE_SORT_FIELDS` imports.
- `api/types.ts`: remove `ISSUE_SORT_FIELDS` + `IssueSortField` + `ListParams.sort_by`/`sort_direction`.
- `api/issueApi.ts`: remove the `sort`/`direction` query mapping in `listIssues`.
- `i18n/{zh-CN,en-US}.json`: remove the now-unused `loop.sort` block.

Net: **+4 / −52**. The backend sort params stay supported for other consumers; only the Loop UI stops sending them.

## Blast radius

- `IssueSortField`/`ISSUE_SORT_FIELDS`/`sort_by`/`sort_direction`/`loop.sort.*` — zero remaining references anywhere in `packages/dmloop` (verified by grep + two independent reviews).
- `SquadPage` has its **own** local sort (`loop.squad.sort*`, its own `sortDir`/`ArrowUp`/`ArrowDown`) — a separate implementation, untouched.
- `Select`/`FIELD_POPUP`/`loop-fields__inline` still used by the surviving filter controls — retained.
- Board & grouped views, filtering, pagination — unaffected (nothing else read `f.sortBy`/`f.sortDir`).

## Verification

- Live regression in the dev Loop UI: the "显示" panel now shows only the view toggle (board/grouped/list); switching to list closes the panel; the list renders + paginates correctly in default order. No console/compile errors.
- Adversarial review: codex (`approve`, no findings) + Claude code-reviewer + a simplification pass. The one finding — a dead `Button` import left after removing the direction toggle — is fixed in this PR.
- De-brand scan: pure deletion, no upstream-brand exposure introduced.

Closes #798