### PR TITLE
fix(loop): role-gate project webhook and delete controls for non-admins

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -420,6 +420,8 @@
     "urlPlaceholder": "https://example.com/webhooks/octo",
     "add": "Add",
     "empty": "No webhooks yet.",
+    "adminOnly": "Only workspace admins can manage webhooks.",
+    "loadFailed": "Failed to load webhooks — click to retry.",
     "enabled": "Enabled",
     "delete": "Delete webhook",
     "deleteConfirm": "Delete this webhook?",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -420,6 +420,8 @@
     "urlPlaceholder": "https://example.com/webhooks/octo",
     "add": "添加",
     "empty": "还没有 webhook。",
+    "adminOnly": "仅工作区管理员可管理 Webhook。",
+    "loadFailed": "加载 webhook 失败，点击重试。",
     "enabled": "启用",
     "delete": "删除 webhook",
     "deleteConfirm": "删除这个 webhook？",

--- a/packages/dmloop/src/pages/ProjectPage.tsx
+++ b/packages/dmloop/src/pages/ProjectPage.tsx
@@ -12,6 +12,7 @@ import AssigneePicker from "../ui/AssigneePicker";
 import { confirmDelete } from "../ui/confirmDelete";
 import { formatRelativeTime } from "../ui/time";
 import { readView, writeView } from "../ui/viewMode";
+import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
 
 const { Title, Text } = Typography;
 
@@ -44,6 +45,7 @@ function Ring({ done, total }: { done: number; total: number }) {
 
 export default function ProjectPage() {
   const { t, format } = useI18n();
+  const isAdmin = useIsWorkspaceAdmin();
   const [rows, setRows] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [keyword, setKeyword] = useState("");
@@ -146,14 +148,16 @@ export default function ProjectPage() {
           <span className="loop-project-list__cell loop-project-list__time loop-project-list__cell--muted">
             {formatRelativeTime(p.created_at, format)}
           </span>
-          <Button
-            theme="borderless"
-            type="danger"
-            size="small"
-            className="loop-project-list__del"
-            icon={<Trash2 size={14} />}
-            onClick={(e) => { e.stopPropagation(); confirmRemove(p.id); }}
-          />
+          {isAdmin && (
+            <Button
+              theme="borderless"
+              type="danger"
+              size="small"
+              className="loop-project-list__del"
+              icon={<Trash2 size={14} />}
+              onClick={(e) => { e.stopPropagation(); confirmRemove(p.id); }}
+            />
+          )}
         </div>
       ))}
     </div>
@@ -174,14 +178,16 @@ export default function ProjectPage() {
             </div>
             <div className="loop-project-card__sub">{p.lead_name ?? t("loop.assignee.unassigned")}</div>
           </div>
-          <Button
-            theme="borderless"
-            type="danger"
-            size="small"
-            className="loop-project-card__del"
-            icon={<Trash2 size={14} />}
-            onClick={(e) => { e.stopPropagation(); confirmRemove(p.id); }}
-          />
+          {isAdmin && (
+            <Button
+              theme="borderless"
+              type="danger"
+              size="small"
+              className="loop-project-card__del"
+              icon={<Trash2 size={14} />}
+              onClick={(e) => { e.stopPropagation(); confirmRemove(p.id); }}
+            />
+          )}
         </div>
       ))}
     </div>

--- a/packages/dmloop/src/panel/ProjectDetailPage.tsx
+++ b/packages/dmloop/src/panel/ProjectDetailPage.tsx
@@ -6,6 +6,7 @@ import { useI18n, WKApp } from "@octo/base";
 import type { Project } from "../api/types";
 import { getProject, updateProject, deleteProject } from "../api/projectApi";
 import ProjectWebhooksSection from "./ProjectWebhooksSection";
+import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
 import "./sideDetail.css";
 
 const { Text } = Typography;
@@ -18,6 +19,7 @@ export default function ProjectDetailPage({ projectId, onChanged }: { projectId:
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
   const [dirty, setDirty] = useState(false);
+  const isAdmin = useIsWorkspaceAdmin();
 
   const load = () => {
     setLoading(true);
@@ -67,7 +69,7 @@ export default function ProjectDetailPage({ projectId, onChanged }: { projectId:
         <Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>{t("loop.detail.back")}</Button>
         <Text type="tertiary" style={{ fontSize: 12 }}>{row.icon} {t("loop.detail.projectTitle")}</Text>
         <div style={{ flex: 1 }} />
-        <Button theme="borderless" type="danger" icon={<Trash2 size={14} />} onClick={remove}>{t("loop.action.delete")}</Button>
+        {isAdmin && <Button theme="borderless" type="danger" icon={<Trash2 size={14} />} onClick={remove}>{t("loop.action.delete")}</Button>}
         <LoopButton icon={<Save size={14} />} disabled={!dirty} onClick={save}>{t("loop.action.save")}</LoopButton>
       </div>
       <div className="loop-sd__body" style={{ gridTemplateColumns: "minmax(0, 1fr)" }}>
@@ -91,7 +93,7 @@ export default function ProjectDetailPage({ projectId, onChanged }: { projectId:
             </div>
             <div className="loop-fields__row">
               <div className="loop-fields__label">{t("loop.webhook.title")}</div>
-              <ProjectWebhooksSection projectId={row.id} />
+              <ProjectWebhooksSection projectId={row.id} isAdmin={isAdmin} />
             </div>
           </div>
         </section>

--- a/packages/dmloop/src/panel/ProjectWebhooksSection.tsx
+++ b/packages/dmloop/src/panel/ProjectWebhooksSection.tsx
@@ -9,20 +9,24 @@ import { confirmDelete } from "../ui/confirmDelete";
 
 const { Text } = Typography;
 
-/** 项目 Webhook 配置分区：列表 + 启用开关 + 删除 + 新增（创建后一次性展示 secret）。 */
-export default function ProjectWebhooksSection({ projectId }: { projectId: string }) {
+/** 项目 Webhook 配置分区：列表 + 启用开关 + 删除 + 新增（创建后一次性展示 secret）。
+ *  Webhook 端点限 owner/admin，故非管理员只展示占位、不发任何请求。 */
+export default function ProjectWebhooksSection({ projectId, isAdmin }: { projectId: string; isAdmin?: boolean }) {
   const { t } = useI18n();
   const [rows, setRows] = useState<WebhookSubscription[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [url, setUrl] = useState("");
   const [busy, setBusy] = useState(false);
   const [secret, setSecret] = useState<string | null>(null);
 
+  // 失败不静默当空态:否则一次瞬时故障会让管理员以为"没有 webhook"而重复创建。
   const reload = () => {
     setLoading(true);
-    listWebhooks(projectId).then(setRows).finally(() => setLoading(false));
+    setLoadFailed(false);
+    listWebhooks(projectId).then(setRows).catch(() => setLoadFailed(true)).finally(() => setLoading(false));
   };
-  useEffect(reload, [projectId]);
+  useEffect(() => { if (isAdmin) reload(); }, [projectId, isAdmin]);
 
   const add = async () => {
     const value = url.trim();
@@ -70,12 +74,21 @@ export default function ProjectWebhooksSection({ projectId }: { projectId: strin
     }
   };
 
+  if (isAdmin === undefined) {
+    return <div className="loop-wh"><div style={{ padding: "8px 0" }}><Spin size="small" /></div></div>;
+  }
+  if (!isAdmin) {
+    return <div className="loop-wh"><div className="loop-wh__empty">{t("loop.webhook.adminOnly")}</div></div>;
+  }
+
   return (
     <div className="loop-wh">
       <div className="loop-wh__hint">{t("loop.webhook.hint")}</div>
 
       {loading ? (
         <div style={{ padding: "8px 0" }}><Spin size="small" /></div>
+      ) : loadFailed ? (
+        <div className="loop-wh__empty" style={{ cursor: "pointer" }} onClick={reload}>{t("loop.webhook.loadFailed")}</div>
       ) : rows.length === 0 ? (
         <div className="loop-wh__empty">{t("loop.webhook.empty")}</div>
       ) : (
@@ -108,6 +121,7 @@ export default function ProjectWebhooksSection({ projectId }: { projectId: strin
         ))
       )}
 
+      {!loadFailed && (
       <div className="loop-wh__add">
         <Input
           value={url}
@@ -119,6 +133,7 @@ export default function ProjectWebhooksSection({ projectId }: { projectId: strin
           {t("loop.webhook.add")}
         </LoopButton>
       </div>
+      )}
 
       <Modal
         className="loop-modal"

--- a/packages/dmloop/src/ui/useWorkspaceAdmin.ts
+++ b/packages/dmloop/src/ui/useWorkspaceAdmin.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { WKApp } from "@octo/base";
+import { listWorkspaceMembers } from "../api/workspaceApi";
+import { currentWorkspaceId } from "../api/http";
+
+/**
+ * Whether the signed-in user is an owner/admin of the current workspace;
+ * `undefined` while resolving. The roster endpoint is membership-gated (not
+ * role-gated), so every role can read it to learn its own role. Fails closed
+ * (`false`) on any error or an unresolved identity.
+ */
+export function useIsWorkspaceAdmin(): boolean | undefined {
+  const [isAdmin, setIsAdmin] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    const wsId = currentWorkspaceId();
+    const uid = WKApp.loginInfo?.uid;
+    if (!wsId || !uid) { setIsAdmin(false); return; }
+    let cancelled = false;
+    listWorkspaceMembers(wsId)
+      .then((members) => {
+        if (cancelled) return;
+        const me = members.find((m) => m.octo_uid === uid);
+        setIsAdmin(me?.role === "owner" || me?.role === "admin");
+      })
+      .catch(() => { if (!cancelled) setIsAdmin(false); });
+    return () => { cancelled = true; };
+  }, []);
+  return isAdmin;
+}


### PR DESCRIPTION
## What

Role-gates the Loop **project** surface so a non-admin workspace member no longer sees owner/admin-only controls that always 403.

Fixes #802.

## Why

Webhook CRUD and project delete are **owner/admin-only** server-side (they return HTTP 403 `insufficient permissions`); project create/update are open to any member. But the UI showed those admin-only controls to everyone:
- The project **detail** page rendered the Delete button + the whole Webhook section unconditionally.
- The project **list & card** views rendered a per-row Delete button unconditionally.
- On open, `ProjectWebhooksSection` fired `listWebhooks` (owner/admin-only) with **no `.catch`** → for a member it 403'd as a silent unhandled rejection that rendered as "no webhooks yet".

A member only learned the restriction from a raw backend error toast.

## Changes (frontend-only, `packages/dmloop`)

- **`ui/useWorkspaceAdmin.ts` (new)** — `useIsWorkspaceAdmin()` resolves the signed-in user's workspace role from the membership-gated roster (`listWorkspaceMembers`), returns `true` for `owner`/`admin`, `undefined` while loading, and **fails closed** (`false`) on error / unresolved identity. The `octo_uid === WKApp.loginInfo.uid` match mirrors the existing `myMemberId` resolution already used in `IssuePage`/`SettingsPage`.
- **`panel/ProjectDetailPage.tsx`** — Delete button renders only for admins; passes `isAdmin` to the webhook section.
- **`pages/ProjectPage.tsx`** — the list-row and card Delete buttons render only for admins (fixes the class across **every** `deleteProject` entrypoint, not just the detail panel).
- **`panel/ProjectWebhooksSection.tsx`** — gates on `isAdmin`: non-admins get an `adminOnly` placeholder and **no request is sent**; admins keep the full list/add/toggle/delete flow. `listWebhooks` failure now surfaces a retryable error placeholder instead of masquerading as empty (so an admin never creates a duplicate on an unknown state).
- i18n `loop.webhook.adminOnly` + `loop.webhook.loadFailed` (zh-CN + en-US).

The backend is intentionally correct (webhooks can exfiltrate issue data → owner/admin-only) and is **not changed**; the UI just stops offering actions it can't perform.

## Blast radius

- `useIsWorkspaceAdmin` is new; `ProjectWebhooksSection`'s new `isAdmin?` prop has a single caller (`ProjectDetailPage`).
- `deleteProject` entrypoints audited repo-wide — all three (detail panel, list row, card) are now gated; no other caller exists.
- Board / grouped / issue views, project create/update/save, and admin behavior are unaffected.

## Testing (dev, live)

- **Admin path (owner, live):** open a project → detail shows Delete + full Webhook section; list/card rows show Delete; `listWebhooks` succeeds; create/delete project works. No regression.
- **Member path (role forced to non-admin):** detail hides Delete, Webhook section shows the `adminOnly` placeholder, **0 `webhook-subscriptions` requests fire** (verified via `performance.getEntriesByType('resource')`), no `insufficient permissions` toast. Save name/description still works (correct — members may edit projects).
- Dev has no member-role account in the loop workspace (the owner is the only member), so the non-admin path was exercised by forcing the role signal; the admin path is fully live.

## Adversarial review

Two-model, two rounds (codex `adversarial-review` + Claude code-reviewer):
- Round 1 (both models) flagged that the project **list/card** delete buttons were still ungated — a sibling of the same class. Fixed here (gated all entrypoints).
- Round 2 codex flagged that matching on `octo_uid` could lock out an owner/admin whose member row has `octo_uid: null` (a "native member"). This is a false-positive in practice: the current user is always an octo-web login (`WKApp.loginInfo.uid`), and such members are octo-bridged with `octo_uid` set (verified on dev: the workspace owner's row carries `octo_uid`); a null-`octo_uid` "native member" is a backend-only artifact that can't be the current web user. `octo_uid` is the only client-side identity signal (there's no backend `user_id` for the current user client-side), and this is the same match the shipped `myMemberId`/`SettingsPage` code uses. Fail-closed is the safe default (never fail-open, which would re-expose the controls); the backend enforces regardless.

## Docs

No doc change: UI-only permission gating, no new command/config/API surface.