### PR TITLE
fix(docs): creator filter selection alignment + toolbar three-control single-row layout

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2413,6 +2413,11 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  /* Establish an inline-size container so the toolbar can compact its filter
+     buttons based on the list's own width (it may render in a narrow panel,
+     not just the full viewport). Width is parent-driven, so this is layout-safe. */
+  container-type: inline-size;
+  container-name: octo-docs-list;
 }
 .octo-docs-list-header {
   display: flex;
@@ -2663,8 +2668,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  flex: 1 1 160px;
-  min-width: 120px;
+  flex: 1 1 140px;
+  min-width: 96px;
   border: 1px solid var(--octo-border, #e5e6eb);
   border-radius: 6px;
   padding: 4px 8px;
@@ -2696,6 +2701,12 @@
   color: var(--octo-fg, #1f2329);
 }
 
+.octo-docs-filter-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
 .octo-docs-filter {
   position: relative;
   flex: 0 0 auto;
@@ -2718,6 +2729,14 @@
 .octo-docs-filter-btn-active {
   border-color: var(--octo-active-fg, #1664ff);
   color: var(--octo-active-fg, #1664ff);
+}
+/* Narrow tier: tighten the filter buttons so search + both filters hold one
+   more width step before the filter group wraps to a second row. */
+@container octo-docs-list (max-width: 340px) {
+  .octo-docs-filter-btn {
+    padding: 4px 8px;
+    gap: 3px;
+  }
 }
 .octo-docs-filter-caret {
   font-size: 9px;

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -816,17 +816,22 @@ function DocsList({
       <DocsTabs active={activeView} onChange={onTab} />
       <div className="octo-docs-toolbar">
         <SearchBox value={view.q} onSearch={view.setQuery} onClear={view.clearQuery} />
-        {activeView === 'recent' && (
-          <CreatorFilter
-            options={recentView.creatorOptions}
-            selected={recentView.creators}
-            onToggle={recentView.toggleCreator}
-            nameFallback={nameFallback}
-          />
-        )}
-        {/* Type filter lives on BOTH tabs (creator is recent-only). Uses the active view's per-tab
-            types state so each tab remembers its own selection across switches. */}
-        <TypeFilter selected={view.types} onToggle={view.toggleType} />
+        {/* Creator + Type wrap together as one unit so a narrow toolbar drops the whole
+            group to a second row (search stays on row 1) instead of stranding Type alone.
+            On the my-docs tab the group holds only the Type filter and still lays out fine. */}
+        <div className="octo-docs-filter-group">
+          {activeView === 'recent' && (
+            <CreatorFilter
+              options={recentView.creatorOptions}
+              selected={recentView.creators}
+              onToggle={recentView.toggleCreator}
+              nameFallback={nameFallback}
+            />
+          )}
+          {/* Type filter lives on BOTH tabs (creator is recent-only). Uses the active view's per-tab
+              types state so each tab remembers its own selection across switches. */}
+          <TypeFilter selected={view.types} onToggle={view.toggleType} />
+        </div>
       </div>
       {activeView === 'recent' && (
         <CreatorChips

--- a/packages/docs/src/pages/useDocsView.test.ts
+++ b/packages/docs/src/pages/useDocsView.test.ts
@@ -150,3 +150,47 @@ describe('useDocsView — type filter (XIN-1188, multi-select OR, both tabs)', (
     await waitFor(() => expect(result.current.empty).toBe('E'))
   })
 })
+
+describe('useDocsView — creator facet candidates stay stable during selection (align with type filter)', () => {
+  it('does NOT reload the creator facet on a selection toggle (creator or type), only on a q change', async () => {
+    recentMock.mockResolvedValue({ total: 0, items: [], nextCursor: null })
+    creatorsMock.mockResolvedValue([{ uid: 'u1', name: 'Alice' }])
+    const { result } = renderHook(() => useDocsView('recent', 'space', 'folder', 0))
+    await waitFor(() => expect(result.current.phase).toBe('ready'))
+
+    // Initial load fetched the facet once (candidates track `q`, here empty).
+    await waitFor(() => expect(creatorsMock).toHaveBeenCalledTimes(1))
+
+    // Toggling a creator keeps `q`, so the open dropdown's candidate list must NOT churn — matching
+    // the type filter, whose candidate set is a fixed enum that never reloads mid-select.
+    await act(async () => {
+      result.current.toggleCreator('u1')
+    })
+    expect(creatorsMock).toHaveBeenCalledTimes(1)
+
+    // Toggling a type on the recent tab must not reload the creator facet either.
+    await act(async () => {
+      result.current.toggleType('doc')
+    })
+    expect(creatorsMock).toHaveBeenCalledTimes(1)
+
+    // Clearing selections keeps `q` → still no facet reload.
+    await act(async () => {
+      result.current.clearCreators()
+    })
+    await act(async () => {
+      result.current.clearTypes()
+    })
+    expect(creatorsMock).toHaveBeenCalledTimes(1)
+
+    // A real `q` change DOES refresh the candidate set (the preserved facet semantic).
+    await act(async () => {
+      result.current.setQuery('plan')
+    })
+    await waitFor(() => expect(creatorsMock).toHaveBeenCalledTimes(2))
+    expect(creatorsMock).toHaveBeenLastCalledWith('plan')
+
+    // Selections still refetch the DOCUMENT list (only the facet fetch is decoupled).
+    expect(recentMock).toHaveBeenLastCalledWith(expect.objectContaining({ q: 'plan' }))
+  })
+})

--- a/packages/docs/src/pages/useDocsView.ts
+++ b/packages/docs/src/pages/useDocsView.ts
@@ -140,7 +140,7 @@ export function useDocsView(
   const loadingMoreRef = useRef(false)
 
   const fetchFirst = useCallback(
-    (nextQ: string, nextCreators: string[], nextTypes: DocType[]) => {
+    (nextQ: string, nextCreators: string[], nextTypes: DocType[], refreshCreatorFacet = true) => {
       const seq = ++seqRef.current
       cursorRef.current = null
       pageRef.current = 1
@@ -170,14 +170,22 @@ export function useDocsView(
       }
 
       if (kind === 'recent') {
-        // Refresh the creator candidates for this new result set (candidates track `q`, but are
-        // independent of the selected creators/types and pagination — §3.5). Fire in parallel; drop
+        // Refresh the creator candidates only when `q` actually changed (or on a full reconcile:
+        // mount / space / folder / reload / retry) — candidates track `q` and are independent of the
+        // selected creators/types and pagination (§3.5). Selection toggles keep the SAME `q`, so they
+        // pass refreshCreatorFacet=false: this aligns the creator filter's selection behaviour with
+        // the type filter (whose candidate set is a fixed enum and never reloads mid-select), keeping
+        // the open dropdown's candidate list stable while multi-selecting instead of re-fetching and
+        // reordering it on every checkbox click. The server-facet source and `q`-tracking semantics
+        // are unchanged — only the redundant refetch on selection is dropped. Fire in parallel; drop
         // if superseded. name resolution failures just yield fewer / uid-labelled options.
-        void listRecentCreators(nextQ)
-          .then((opts) => {
-            if (seq === seqRef.current) setCreatorOptions(opts)
-          })
-          .catch(() => {})
+        if (refreshCreatorFacet) {
+          void listRecentCreators(nextQ)
+            .then((opts) => {
+              if (seq === seqRef.current) setCreatorOptions(opts)
+            })
+            .catch(() => {})
+        }
         listRecentDocs({ q: nextQ, creators: nextCreators, types: nextTypes, cursor: null, pageSize: PAGE_SIZE })
           .then((res) => {
             cursorRef.current = res.nextCursor
@@ -282,28 +290,30 @@ export function useDocsView(
         ? creators.filter((u) => u !== uid)
         : [...creators, uid]
       setCreators(next)
-      fetchFirst(q, next, types)
+      // Selection toggle keeps `q` — don't reload the creator facet candidates (aligns with the
+      // type filter's stable candidate set; see fetchFirst's recent branch).
+      fetchFirst(q, next, types, false)
     },
     [creators, q, types, fetchFirst],
   )
 
   const clearCreators = useCallback(() => {
     setCreators([])
-    fetchFirst(q, [], types)
+    fetchFirst(q, [], types, false)
   }, [q, types, fetchFirst])
 
   const toggleType = useCallback(
     (ty: DocType) => {
       const next = types.includes(ty) ? types.filter((x) => x !== ty) : [...types, ty]
       setTypes(next)
-      fetchFirst(q, creators, next)
+      fetchFirst(q, creators, next, false)
     },
     [types, q, creators, fetchFirst],
   )
 
   const clearTypes = useCallback(() => {
     setTypes([])
-    fetchFirst(q, creators, [])
+    fetchFirst(q, creators, [], false)
   }, [q, creators, fetchFirst])
 
   const retry = useCallback(() => {


### PR DESCRIPTION
## What

Two related docs-list front-end repairs on the FEAT-B document list, shipped on one branch:

1. **Creator filter selection alignment** (XIN-1208) — align the creator filter's selection/interaction with the type filter (type is the baseline), per boss feedback.
2. **Toolbar three-control single-row layout** (XIN-1209) — keep search + creator + type on one row and, when width is genuinely insufficient, wrap the two filters together instead of stranding Type on its own line. Implements the boss-confirmed design from XIN-1207.

---

## 1. Creator filter selection alignment (XIN-1208)

### Inconsistency

Comparing `CreatorFilter`/`CreatorChips` against `TypeFilter`/`TypeChips` and the shared `useDocsView` engine:

- **Presentation / selection layer**: already identical (portal dropdown, immediate-effect checkbox rows, multi-select accumulate, per-item remove + clear-all chips, count badge). No change needed.
- **State engine** (`useDocsView.fetchFirst`): the recent tab re-fetched the creator facet candidates (`listRecentCreators`) on **every selection toggle** — a redundant round-trip that reloaded and reordered the open creator dropdown mid-multi-select. The type filter's candidate set is a fixed enum that never reloads during selection, so the two behaved differently.

### Fix

Gate the creator facet fetch on an actual `q` change (or a full reconcile: mount / space / folder / reload / retry). Selection toggles pass `refreshCreatorFacet=false`, so the candidate set stays stable during a multi-select session — matching the type filter. Preserved: creator filter remains recent-tab only; candidates still come from the server facet and track `q`; multi-select OR, AND-combined with search; the document list still refetches on every selection (only the *facet* refetch is decoupled).

## 2. Toolbar three-control single-row layout (XIN-1209)

### Root cause

The toolbar is a wrapping flex row. `.octo-docs-search` was `flex:1 1 160px; min-width:120px` (a hard 120px floor) and each filter wrapper was `flex:0 0 auto` (never shrinks). Once available width dropped below ~290px the flex engine wrapped the **last** child — Type — to its own line, producing the reported lopsided "search + creator / type-alone" state.

### Fix (in-place, no component-tree restructure)

- **Search yields first**: `.octo-docs-search` → `flex:1 1 140px; min-width:96px`, recovering ~24px so both filters stay on row 1 through the mid tier (the broken tier).
- **Filters wrap as a unit**: wrap `CreatorFilter` + `TypeFilter` in a single `.octo-docs-filter-group` (`display:flex; gap:8px; flex:0 0 auto`). When a wrap is unavoidable the whole group drops to row 2 together — a deliberate, symmetric "search on row 1, `[Creator][Type]` on row 2" — instead of Type alone.
- **Narrow-tier compaction**: a container query on the docs-list inline size tightens the filter buttons (`padding:4px 8px`) below 340px, buying one more width step before any wrap.

The my-docs tab (search + type only) keeps the group holding a single Type child and lays out normally. Selected-filter chips still occupy their own dedicated row on every tier, unchanged.

### Behaviour across width tiers (verified in-browser)

| Tier | Recent tab (search + creator + type) | My-docs tab (search + type) |
|------|--------------------------------------|-----------------------------|
| **Wide** (~520px) | all three on one row; search flexes to fill | one row |
| **Mid** (~400px) | search shrinks, **both filters stay on row 1** (was broken) | one row |
| **Narrow** (~300px) | search full-width on row 1, `[Creator][Type]` together on row 2 | still one row (only 2 controls) |

## Tests / build

- `useDocsView` suite green (30/30), incl. the test asserting selection toggles do **not** reload the facet while a real `q` change does.
- Docs `typecheck`: the only errors are pre-existing on `main` (`dmworkbase/i18n/format.ts`, `members/sort.ts`) and don't reference the changed files.
- Docs unit tests: identical pass/fail counts with and without this change (the `EditorShell.test.tsx`/`Toolbar.test.tsx` tiptap-jsdom failures are pre-existing on `main`, unrelated to docs-list layout).
- Layout verified in a headless browser at all three tiers on both tabs (position measurements + screenshot), not just build/typecheck.

## Related

- Design: XIN-1207 (boss-confirmed) · XIN-1208 · XIN-1209 · builds on merged FEAT-B PR #781
