### PR TITLE
fix(docs): promote member-picker add button to primary style (WS-18)

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1193,6 +1193,24 @@
   color: var(--octo-fg, #1f2329);
   font-size: 13px;
 }
+.octo-member-add-btn {
+  border: none;
+  background: var(--wk-brand-primary, #7c5cfc);
+  color: #fff;
+  padding: 6px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 500;
+}
+.octo-member-add-btn:hover:not(:disabled) {
+  filter: brightness(0.94);
+}
+.octo-member-add-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
 
 /* Multi-select checkbox indicator (#A2). */
 .octo-member-picker-check {

--- a/packages/docs/src/members/MemberPicker.tsx
+++ b/packages/docs/src/members/MemberPicker.tsx
@@ -160,7 +160,7 @@ export function MemberPicker({
             </option>
           ))}
         </select>
-        <button type="button" className="octo-tb-btn" disabled={count === 0 || busy} onClick={add}>
+        <button type="button" className="octo-member-add-btn" disabled={count === 0 || busy} onClick={add}>
           {count > 1 ? t('docs.member.addCount', { values: { count } }) : t('docs.member.add')}
         </button>
       </div>


### PR DESCRIPTION
## What & Why

Docs 权限管理弹窗里的「添加」按钮此前使用 `.octo-tb-btn`（ghost/文字按钮，`border:none; background:transparent`），视觉太弱、看起来像禁用态，与左侧带边框白底的「可编辑 ▼」下拉并排时被压成占位文字。作为权限弹窗的主操作，升级为 primary 主按钮。

## Changes

- `packages/docs/src/members/MemberPicker.tsx`：「添加」按钮 `className` 由 `octo-tb-btn` 改为 `octo-member-add-btn`，`disabled` 逻辑不变。
- `packages/docs/src/editor/styles.css`：新增 `.octo-member-add-btn` 样式，复用既有品牌 token `--wk-brand-primary`（#7c5cfc），品牌紫底 + 白字，含 hover 与 disabled 态。未引入新 token。

## Verification

- `MemberPicker.test.tsx` 6 项测试全部通过。
- typecheck 仅剩两处与本改动无关的既有报错（`dmworkbase/format.ts`、`members/sort.ts`），已 stash 验证在干净基线上同样存在。

Closes WS-18
