### PR TITLE
feat(docs): open in-chat doc links inline in a sidebar (WS-17)

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -692,6 +692,13 @@ export default class WKApp extends ProviderListener {
   // Callback to switch the active sidebar menu by id (set by Main page)
   static switchToMenuById?: (menuId: string) => void;
   static openSummaryDetail?: (taskId: number | string, spaceId?: string) => void;
+  /**
+   * Open a document inline in the chat's right-side sidebar (WS-17). Set by ChatContentPage while it
+   * is mounted and cleared on unmount, so it is present only when the sidebar host exists; a doc-link
+   * click helper (Utils/docLinkNavigation) calls it to open `/d/<docId>?sp=` inline instead of a new
+   * page, and falls back to opening the standalone page when it is absent.
+   */
+  static openDocPreview?: (docId: string, space?: string) => void;
   static searchChatCandidates?: (params: { keyword?: string; chat_type?: string; space_id?: string }) => Promise<any[]>;
   // Id of the currently active sidebar menu (kept in sync by Main page)
   static currentMenuId?: string;

--- a/packages/dmworkbase/src/EndpointCommon.tsx
+++ b/packages/dmworkbase/src/EndpointCommon.tsx
@@ -422,6 +422,16 @@ export class EndpointCommon {
     return EndpointManager.shared.invoke(EndpointCategory.chatDocPreviewPane, opts);
   }
 
+  /**
+   * Whether the docs module has registered the `chatDocPreviewPane` endpoint (WS-17). The in-chat
+   * `/d/<docId>` link interception gates on this so a host that mounts the chat but NOT the docs
+   * module (e.g. the extension side panel) never intercepts a doc link into an empty, uncloseable
+   * panel — it falls through to opening the standalone page instead.
+   */
+  hasChatDocPreviewPane(): boolean {
+    return !!EndpointManager.shared.get(EndpointCategory.chatDocPreviewPane)?.handler;
+  }
+
   registerChatDocPreviewPane(
     sid: string,
     callback: (param: any) => JSX.Element | undefined

--- a/packages/dmworkbase/src/EndpointCommon.tsx
+++ b/packages/dmworkbase/src/EndpointCommon.tsx
@@ -407,6 +407,36 @@ export class EndpointCommon {
     );
   }
 
+  /**
+   * In-chat document sidebar pane (WS-17). The docs module registers the implementation (it may
+   * depend on @octo/base; base must not depend on it), and ChatContentPage invokes this to render the
+   * live document editor inside its reused right-side panel. Returns undefined when the docs module
+   * has not registered (endpoint absent) so the caller can no-op gracefully.
+   */
+  chatDocPreviewPane(opts: {
+    docId: string;
+    space?: string;
+    onClose: () => void;
+    onExpandFullPage: () => void;
+  }): JSX.Element | undefined {
+    return EndpointManager.shared.invoke(EndpointCategory.chatDocPreviewPane, opts);
+  }
+
+  registerChatDocPreviewPane(
+    sid: string,
+    callback: (param: any) => JSX.Element | undefined
+  ) {
+    EndpointManager.shared.setMethod(
+      EndpointCategory.chatDocPreviewPane,
+      (param) => {
+        return callback(param);
+      },
+      {
+        category: EndpointCategory.chatDocPreviewPane,
+      }
+    );
+  }
+
   callOnLogin() {
     [...this._onLogins].forEach(fn => fn());
   }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openSummaryDetailMock, wkAppMock } = vi.hoisted(() => {
+const { openSummaryDetailMock, openDocPreviewMock, wkAppMock } = vi.hoisted(() => {
   const openSummaryDetailMock = vi.fn();
+  const openDocPreviewMock = vi.fn();
   return {
     openSummaryDetailMock,
+    openDocPreviewMock,
     wkAppMock: {
       openSummaryDetail: openSummaryDetailMock as ((taskId: number | string, spaceId?: string) => void) | undefined,
+      openDocPreview: openDocPreviewMock as ((docId: string, space?: string) => void) | undefined,
     },
   };
 });
@@ -20,7 +23,9 @@ describe("openUrl", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     openSummaryDetailMock.mockReset();
+    openDocPreviewMock.mockReset();
     wkAppMock.openSummaryDetail = openSummaryDetailMock;
+    wkAppMock.openDocPreview = openDocPreviewMock;
     vi.spyOn(window, "open").mockImplementation(() => null);
   });
 
@@ -56,6 +61,26 @@ describe("openUrl", () => {
 
     expect(openSummaryDetailMock).not.toHaveBeenCalled();
     expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("routes a same-origin /d/<docId>?sp= document link to the in-chat sidebar", () => {
+    openUrl(`${window.location.origin}/d/doc123?sp=space-1`);
+
+    expect(openDocPreviewMock).toHaveBeenCalledWith("doc123", "space-1");
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("opens a document link in a new tab when the sidebar host is unavailable", () => {
+    wkAppMock.openDocPreview = undefined;
+
+    openUrl(`${window.location.origin}/d/doc123?sp=space-1`);
+
+    expect(openDocPreviewMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      `${window.location.origin}/d/doc123?sp=space-1`,
+      "_blank",
+      "noopener,noreferrer"
+    );
   });
 
   it("falls back to window.open when summary routing is unavailable", () => {

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actions.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openSummaryDetailMock, openDocPreviewMock, wkAppMock } = vi.hoisted(() => {
+const { openSummaryDetailMock, openDocPreviewMock, hasDocPaneMock, wkAppMock } = vi.hoisted(() => {
   const openSummaryDetailMock = vi.fn();
   const openDocPreviewMock = vi.fn();
+  const hasDocPaneMock = vi.fn(() => true);
   return {
     openSummaryDetailMock,
     openDocPreviewMock,
+    hasDocPaneMock,
     wkAppMock: {
       openSummaryDetail: openSummaryDetailMock as ((taskId: number | string, spaceId?: string) => void) | undefined,
       openDocPreview: openDocPreviewMock as ((docId: string, space?: string) => void) | undefined,
+      endpoints: {
+        hasChatDocPreviewPane: hasDocPaneMock as () => boolean,
+      },
     },
   };
 });
@@ -24,6 +29,8 @@ describe("openUrl", () => {
     vi.restoreAllMocks();
     openSummaryDetailMock.mockReset();
     openDocPreviewMock.mockReset();
+    hasDocPaneMock.mockReset();
+    hasDocPaneMock.mockReturnValue(true);
     wkAppMock.openSummaryDetail = openSummaryDetailMock;
     wkAppMock.openDocPreview = openDocPreviewMock;
     vi.spyOn(window, "open").mockImplementation(() => null);
@@ -72,6 +79,19 @@ describe("openUrl", () => {
 
   it("opens a document link in a new tab when the sidebar host is unavailable", () => {
     wkAppMock.openDocPreview = undefined;
+
+    openUrl(`${window.location.origin}/d/doc123?sp=space-1`);
+
+    expect(openDocPreviewMock).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(
+      `${window.location.origin}/d/doc123?sp=space-1`,
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens a document link in a new tab when the docs pane endpoint is not registered", () => {
+    hasDocPaneMock.mockReturnValue(false);
 
     openUrl(`${window.location.origin}/d/doc123?sp=space-1`);
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/renderer/actions.ts
@@ -1,5 +1,6 @@
 import WKApp from "../../../App";
 import { isSafeUrl } from "../../../Utils/security";
+import { tryOpenDocLinkInSidebar } from "../../../Utils/docLinkNavigation";
 
 const SUMMARY_DETAIL_PATH_RE = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
 
@@ -29,6 +30,12 @@ export function openUrl(url: string): void {
   if (summaryTaskNo && WKApp.openSummaryDetail) {
     // 卡片深链可能来自 https 生产域，本地调试是 http/端口；/s/<taskNo> 路径本身是内部详情信号。
     WKApp.openSummaryDetail(summaryTaskNo, summarySpace);
+    return;
+  }
+
+  // WS-17: 卡片里的文档链接 `/d/<docId>?sp=` 在聊天内点击时，走侧边栏内联打开（仅当聊天侧边栏宿主已挂载）；
+  // 其余情况回退到新标签打开整页，与总结 `/s/` 深链的处理对称。
+  if (tryOpenDocLinkInSidebar(url)) {
     return;
   }
 

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -14,6 +14,7 @@ import "katex/dist/katex.min.css";
 import "./markdown.css";
 import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
+import { tryOpenDocLinkInSidebar } from "../../Utils/docLinkNavigation";
 import { linkifySafeUrls } from "../../Utils/linkify";
 import { downloadFile } from "../../Utils/download";
 import { t } from "../../i18n";
@@ -303,6 +304,32 @@ function segmentText(
   return segments;
 }
 
+/**
+ * Intercept a plain left-click on an in-chat link (WS-17). When the href is a same-origin document
+ * share link (`/d/<docId>?sp=`) and the chat doc sidebar host is mounted, open the document inline in
+ * the sidebar instead of navigating away. Modifier / middle clicks (cmd/ctrl/shift/alt, or a
+ * non-primary button) are left alone so "open in new tab" keeps working, and any non-doc link falls
+ * through to the anchor's default `target="_blank"` behavior.
+ */
+function handleMarkdownLinkClick(
+  e: React.MouseEvent<HTMLAnchorElement>,
+  href: string | undefined,
+): void {
+  if (
+    e.defaultPrevented ||
+    e.button !== 0 ||
+    e.metaKey ||
+    e.ctrlKey ||
+    e.shiftKey ||
+    e.altKey
+  ) {
+    return;
+  }
+  if (tryOpenDocLinkInSidebar(href)) {
+    e.preventDefault();
+  }
+}
+
 const baseComponents: any = {
   a: ({ href, children, ...props }: any) => {
     // AC-13b (feature #511): middle-ellipsize the DISPLAY text only when it is itself a long bare
@@ -316,13 +343,26 @@ const baseComponents: any = {
           : null;
     if (text != null && shouldEllipsizeLinkText(text, href)) {
       return (
-        <a href={href} target="_blank" rel="noopener noreferrer" title={text} {...props}>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={text}
+          {...props}
+          onClick={(e) => handleMarkdownLinkClick(e, href)}
+        >
           {middleEllipsizeUrl(text)}
         </a>
       );
     }
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+        onClick={(e) => handleMarkdownLinkClick(e, href)}
+      >
         {children}
       </a>
     );

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -53,6 +53,7 @@ import SpaceCreate from "../../Components/SpaceCreate";
 import { Space, SpaceService } from "../../Service/SpaceService";
 import NavSignalBadge from "../../Components/NavRail/NavSignalBadge";
 import ThreadPanel from "../../Components/ThreadPanel";
+import { buildDocLink } from "../../Utils/docLink";
 import {
   Thread,
   ThreadStatus,
@@ -281,6 +282,11 @@ export interface ChatContentPageState {
   previewReturnChannelSearch: boolean;
   /** 当前正在右侧预览的 Webhook Fleet 任务链接。 */
   webhookIssuePreviewTarget: WebhookIssuePreviewTarget | null;
+  /**
+   * 聊天内点击文档链接 `/d/<docId>?sp=` 时内联打开的文档目标（WS-17）。非空时在复用的右侧面板槽位
+   * 内挂载文档编辑器侧边栏；与子区/文件预览/事项/总结/搜索面板互斥。
+   */
+  previewDoc: { docId: string; space?: string } | null;
 }
 export class ChatContentPage extends Component<
   ChatContentPageProps,
@@ -320,6 +326,7 @@ export class ChatContentPage extends Component<
       channelSearchPreviewFile: null,
       previewReturnChannelSearch: false,
       webhookIssuePreviewTarget: null,
+      previewDoc: null,
     };
   }
 
@@ -421,7 +428,35 @@ export class ChatContentPage extends Component<
       previewHadThreadShell: fromChannelSearch
         ? false
         : this.state.showThreadPanel,
+      previewDoc: null, // WS-17: 打开文件预览时关掉文档侧边栏，保持右侧面板互斥
     });
+  };
+
+  /**
+   * Open a document inline in the right-side sidebar (WS-17). Bound to `WKApp.openDocPreview` while
+   * this page is mounted so a `/d/<docId>?sp=` link clicked in a conversation opens the live editor
+   * here instead of a new page. Mutually exclusive with the other right-side panels — opening it
+   * closes file preview / thread / matter / summary / channel-search, mirroring how those close each
+   * other, so two panels never fight for the same slot.
+   */
+  private _openDocPreview = (docId: string, space?: string) => {
+    if (!docId) return;
+    this.setState({
+      previewDoc: { docId, space },
+      previewFile: null,
+      activePreviewMessageId: null,
+      showThreadPanel: false,
+      activeThread: null,
+      showChannelSetting: false,
+      showChannelSearch: false,
+      showMatterPanel: false,
+      showMatterDetailPanel: false,
+      showSummaryPanel: false,
+    });
+  };
+
+  private _closeDocPreview = () => {
+    this.setState({ previewDoc: null });
   };
 
   private getChannelSearchDataSource(
@@ -565,6 +600,10 @@ export class ChatContentPage extends Component<
 
     // 监听文件预览事件
     WKApp.mittBus.on("wk:file-preview", this._onFilePreview);
+
+    // WS-17: 暴露"聊天内文档链接侧边栏内联打开"的入口，仅在聊天页挂载期间可用。
+    // 文档链接点击助手 (Utils/docLinkNavigation) 据此判断是否内联打开；未挂载时链接照常开整页。
+    WKApp.openDocPreview = this._openDocPreview;
 
     this.channelInfoListener = (channelInfo: ChannelInfo) => {
       // 监听当前频道或父群组的变化
@@ -942,6 +981,11 @@ export class ChatContentPage extends Component<
 
   componentWillUnmount() {
     WKApp.mittBus.off("wk:file-preview", this._onFilePreview);
+    // WS-17: 撤下本页注册的文档侧边栏入口，避免卸载后仍指向已销毁的实例；仅在仍是本实例时清除，
+    // 防止竞态下清掉后一个已挂载页面注册的入口。
+    if (WKApp.openDocPreview === this._openDocPreview) {
+      WKApp.openDocPreview = undefined;
+    }
     if (this._onPendingThread) {
       WKApp.mittBus.off("wk:pending-thread", this._onPendingThread);
     }
@@ -1069,6 +1113,7 @@ export class ChatContentPage extends Component<
       showChannelSearch,
       channelSearchPreviewFile,
       webhookIssuePreviewTarget,
+      previewDoc,
     } = this.state;
     // 子区页面不显示讨论串按钮
     const isThreadChannel = channel.channelType === ChannelTypeCommunityTopic;
@@ -1083,7 +1128,7 @@ export class ChatContentPage extends Component<
           "wk-chat-content-right",
           showChannelSetting ? "wk-chat-channelsetting-open" : "",
           showChannelSearch ? "wk-chat-channel-search-open" : "",
-          showThreadPanel || previewFile || showMatterPanel
+          showThreadPanel || previewFile || showMatterPanel || previewDoc
             ? "wk-chat-threadpanel-open"
             : "",
           showMatterDetailPanel ? "wk-chat-matter-detail-panel-open" : "",
@@ -1550,6 +1595,36 @@ export class ChatContentPage extends Component<
             />
           </ErrorBoundary>
         )}
+
+        {/* WS-17: 聊天内点击文档链接时，在复用的右侧面板槽位里内联打开文档编辑器（侧边栏）。
+            与其它面板互斥（仅在无其它面板打开时渲染），内容由 docs 模块注册的 chatDocPreviewPane
+            端点提供；未注册（endpoint 缺失）时安全降级为空。 */}
+        {previewDoc &&
+          !showThreadPanel &&
+          !previewFile &&
+          !showMatterPanel &&
+          !showMatterDetailPanel &&
+          !showSummaryPanel &&
+          !showChannelSearch &&
+          !showChannelSetting && (
+            <div className="wk-thread-panel wk-doc-preview-panel">
+              <div className="wk-thread-panel-main">
+                {WKApp.endpoints.chatDocPreviewPane({
+                  docId: previewDoc.docId,
+                  space: previewDoc.space,
+                  onClose: this._closeDocPreview,
+                  onExpandFullPage: () => {
+                    // 展开为整页：打开现有整页文档路由 `/d/<docId>?sp=`，按辉哥定的在新标签页打开。
+                    const url = buildDocLink({
+                      docId: previewDoc.docId,
+                      space: previewDoc.space,
+                    });
+                    window.open(url, "_blank", "noopener,noreferrer");
+                  },
+                })}
+              </div>
+            </div>
+          )}
       </div>
     );
   }

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -347,6 +347,7 @@ export class ChatContentPage extends Component<
       showChannelSearch: false,
       channelSearchPreviewFile: null,
       previewReturnChannelSearch: false,
+      previewDoc: null, // WS-17: 打开 webhook 预览时关掉文档侧边栏，保持右侧面板互斥
     });
   };
 
@@ -452,6 +453,7 @@ export class ChatContentPage extends Component<
       showMatterPanel: false,
       showMatterDetailPanel: false,
       showSummaryPanel: false,
+      webhookIssuePreviewTarget: null,
     });
   };
 
@@ -968,7 +970,8 @@ export class ChatContentPage extends Component<
         this.state.showMatterDetailPanel ||
         this.state.showSummaryPanel ||
         this.state.showChannelSearch ||
-        this.state.showChannelSetting)
+        this.state.showChannelSetting ||
+        this.state.webhookIssuePreviewTarget)
     ) {
       this.setState({ previewDoc: null });
     }
@@ -1626,6 +1629,7 @@ export class ChatContentPage extends Component<
           !showSummaryPanel &&
           !showChannelSearch &&
           !showChannelSetting &&
+          !webhookIssuePreviewTarget &&
           this._renderDocPreviewPanel(previewDoc)}
       </div>
     );

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -953,6 +953,25 @@ export class ChatContentPage extends Component<
         }
       }
     }
+
+    // WS-17: keep the doc sidebar mutually exclusive with every other right-side panel. Opening a
+    // rival panel (thread / file preview / matter / summary / channel-search / settings) only sets
+    // its own flag; the render guard then hides the doc pane but leaves `previewDoc` set, so closing
+    // that rival would resurrect the doc pane the user had moved on from. Clearing it here — a single
+    // choke point — keeps exclusivity total regardless of which rival opened (current or future),
+    // without hand-clearing `previewDoc` in every opener and risking one being missed.
+    if (
+      this.state.previewDoc &&
+      (this.state.showThreadPanel ||
+        this.state.previewFile ||
+        this.state.showMatterPanel ||
+        this.state.showMatterDetailPanel ||
+        this.state.showSummaryPanel ||
+        this.state.showChannelSearch ||
+        this.state.showChannelSetting)
+    ) {
+      this.setState({ previewDoc: null });
+    }
   }
 
   private _onPendingThread?: (detail: {
@@ -1597,8 +1616,8 @@ export class ChatContentPage extends Component<
         )}
 
         {/* WS-17: 聊天内点击文档链接时，在复用的右侧面板槽位里内联打开文档编辑器（侧边栏）。
-            与其它面板互斥（仅在无其它面板打开时渲染），内容由 docs 模块注册的 chatDocPreviewPane
-            端点提供；未注册（endpoint 缺失）时安全降级为空。 */}
+            与其它右侧面板互斥（仅在无其它面板打开时渲染）；内容由 docs 模块注册的 chatDocPreviewPane
+            端点提供。 */}
         {previewDoc &&
           !showThreadPanel &&
           !previewFile &&
@@ -1606,25 +1625,39 @@ export class ChatContentPage extends Component<
           !showMatterDetailPanel &&
           !showSummaryPanel &&
           !showChannelSearch &&
-          !showChannelSetting && (
-            <div className="wk-thread-panel wk-doc-preview-panel">
-              <div className="wk-thread-panel-main">
-                {WKApp.endpoints.chatDocPreviewPane({
-                  docId: previewDoc.docId,
-                  space: previewDoc.space,
-                  onClose: this._closeDocPreview,
-                  onExpandFullPage: () => {
-                    // 展开为整页：打开现有整页文档路由 `/d/<docId>?sp=`，按辉哥定的在新标签页打开。
-                    const url = buildDocLink({
-                      docId: previewDoc.docId,
-                      space: previewDoc.space,
-                    });
-                    window.open(url, "_blank", "noopener,noreferrer");
-                  },
-                })}
-              </div>
-            </div>
-          )}
+          !showChannelSetting &&
+          this._renderDocPreviewPanel(previewDoc)}
+      </div>
+    );
+  }
+
+  /**
+   * WS-17: render the in-chat document sidebar for `previewDoc`. Returns null when the docs module
+   * has not registered the `chatDocPreviewPane` endpoint (endpoint returns undefined) so we never
+   * leave an empty, uncloseable panel shell in the slot — the interception in docLinkNavigation
+   * already gates on endpoint availability, this is defense in depth for the render path.
+   */
+  private _renderDocPreviewPanel(previewDoc: {
+    docId: string;
+    space?: string;
+  }): React.ReactNode {
+    const pane = WKApp.endpoints.chatDocPreviewPane({
+      docId: previewDoc.docId,
+      space: previewDoc.space,
+      onClose: this._closeDocPreview,
+      onExpandFullPage: () => {
+        // 展开为整页：打开现有整页文档路由 `/d/<docId>?sp=`，按辉哥定的在新标签页打开。
+        const url = buildDocLink({
+          docId: previewDoc.docId,
+          space: previewDoc.space,
+        });
+        window.open(url, "_blank", "noopener,noreferrer");
+      },
+    });
+    if (!pane) return null;
+    return (
+      <div className="wk-thread-panel wk-doc-preview-panel">
+        <div className="wk-thread-panel-main">{pane}</div>
       </div>
     );
   }

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -29,6 +29,7 @@ export class EndpointCategory {
   static chatMatterDetailPanel = "chatMatterDetailPanel" // 事项详情面板 (v0.7)
   static chatSummaryPanel = "chatSummaryPanel"
   static chatWebhookIssuePreview = "chatWebhookIssuePreview"
+  static chatDocPreviewPane = "chatDocPreviewPane" // 聊天内文档链接侧边栏内联编辑面板 (WS-17)
 }
 
 

--- a/packages/dmworkbase/src/Utils/__tests__/docLink.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/docLink.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildDocLink, parseDocLink } from "../docLink";
+
+// jsdom serves window.location.origin (default http://localhost); build same-origin links from it so
+// the tests do not hard-code a host.
+const ORIGIN = window.location.origin;
+
+describe("parseDocLink", () => {
+  it("parses a same-origin /d/<docId>?sp=<space> link", () => {
+    expect(parseDocLink(`${ORIGIN}/d/doc123?sp=space-1`)).toEqual({
+      docId: "doc123",
+      space: "space-1",
+    });
+  });
+
+  it("parses a relative /d/ link (resolved against the current origin)", () => {
+    expect(parseDocLink("/d/doc123?sp=space-1")).toEqual({
+      docId: "doc123",
+      space: "space-1",
+    });
+  });
+
+  it("returns space undefined when the link carries no ?sp", () => {
+    expect(parseDocLink(`${ORIGIN}/d/doc123`)).toEqual({ docId: "doc123", space: undefined });
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(parseDocLink(`${ORIGIN}/d/doc123/`)).toEqual({ docId: "doc123", space: undefined });
+  });
+
+  it("rejects a cross-origin link that merely uses a /d/ path", () => {
+    expect(parseDocLink("https://evil.example.com/d/doc123?sp=space-1")).toBeNull();
+  });
+
+  it("rejects non-document paths", () => {
+    expect(parseDocLink(`${ORIGIN}/s/ST123`)).toBeNull();
+    expect(parseDocLink(`${ORIGIN}/docs?doc=doc123`)).toBeNull();
+    expect(parseDocLink(`${ORIGIN}/d/`)).toBeNull();
+    expect(parseDocLink(`${ORIGIN}/d/a:b`)).toBeNull();
+  });
+
+  it("rejects empty / non-string input", () => {
+    expect(parseDocLink(undefined)).toBeNull();
+    expect(parseDocLink("")).toBeNull();
+    expect(parseDocLink("not a url")).toBeNull();
+  });
+
+  it("round-trips with buildDocLink", () => {
+    const link = buildDocLink({ docId: "doc123", space: "space-1" });
+    expect(parseDocLink(link)).toEqual({ docId: "doc123", space: "space-1" });
+  });
+});

--- a/packages/dmworkbase/src/Utils/__tests__/docLinkNavigation.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/docLinkNavigation.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openDocPreviewMock, wkAppMock } = vi.hoisted(() => {
+const { openDocPreviewMock, hasPaneMock, wkAppMock } = vi.hoisted(() => {
   const openDocPreviewMock = vi.fn();
+  const hasPaneMock = vi.fn(() => true);
   return {
     openDocPreviewMock,
+    hasPaneMock,
     wkAppMock: {
       openDocPreview: openDocPreviewMock as
         | ((docId: string, space?: string) => void)
         | undefined,
+      endpoints: {
+        hasChatDocPreviewPane: hasPaneMock as () => boolean,
+      },
     },
   };
 });
@@ -23,6 +28,8 @@ const ORIGIN = window.location.origin;
 describe("tryOpenDocLinkInSidebar", () => {
   beforeEach(() => {
     openDocPreviewMock.mockReset();
+    hasPaneMock.mockReset();
+    hasPaneMock.mockReturnValue(true);
     wkAppMock.openDocPreview = openDocPreviewMock;
   });
 
@@ -50,5 +57,11 @@ describe("tryOpenDocLinkInSidebar", () => {
   it("falls back (returns false) when no sidebar host is mounted", () => {
     wkAppMock.openDocPreview = undefined;
     expect(tryOpenDocLinkInSidebar(`${ORIGIN}/d/doc123?sp=space-1`)).toBe(false);
+  });
+
+  it("falls back (returns false) when the docs pane endpoint is not registered", () => {
+    hasPaneMock.mockReturnValue(false);
+    expect(tryOpenDocLinkInSidebar(`${ORIGIN}/d/doc123?sp=space-1`)).toBe(false);
+    expect(openDocPreviewMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/dmworkbase/src/Utils/__tests__/docLinkNavigation.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/docLinkNavigation.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openDocPreviewMock, wkAppMock } = vi.hoisted(() => {
+  const openDocPreviewMock = vi.fn();
+  return {
+    openDocPreviewMock,
+    wkAppMock: {
+      openDocPreview: openDocPreviewMock as
+        | ((docId: string, space?: string) => void)
+        | undefined,
+    },
+  };
+});
+
+vi.mock("../../App", () => ({
+  default: wkAppMock,
+}));
+
+import { tryOpenDocLinkInSidebar } from "../docLinkNavigation";
+
+const ORIGIN = window.location.origin;
+
+describe("tryOpenDocLinkInSidebar", () => {
+  beforeEach(() => {
+    openDocPreviewMock.mockReset();
+    wkAppMock.openDocPreview = openDocPreviewMock;
+  });
+
+  it("opens a same-origin doc link inline and reports handled", () => {
+    const handled = tryOpenDocLinkInSidebar(`${ORIGIN}/d/doc123?sp=space-1`);
+    expect(handled).toBe(true);
+    expect(openDocPreviewMock).toHaveBeenCalledWith("doc123", "space-1");
+  });
+
+  it("passes undefined space when the link omits ?sp", () => {
+    expect(tryOpenDocLinkInSidebar(`${ORIGIN}/d/doc123`)).toBe(true);
+    expect(openDocPreviewMock).toHaveBeenCalledWith("doc123", undefined);
+  });
+
+  it("does not intercept a non-document link", () => {
+    expect(tryOpenDocLinkInSidebar(`${ORIGIN}/s/ST123`)).toBe(false);
+    expect(openDocPreviewMock).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept a cross-origin /d/ link", () => {
+    expect(tryOpenDocLinkInSidebar("https://evil.example.com/d/doc123")).toBe(false);
+    expect(openDocPreviewMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back (returns false) when no sidebar host is mounted", () => {
+    wkAppMock.openDocPreview = undefined;
+    expect(tryOpenDocLinkInSidebar(`${ORIGIN}/d/doc123?sp=space-1`)).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Utils/docLink.ts
+++ b/packages/dmworkbase/src/Utils/docLink.ts
@@ -72,3 +72,39 @@ export function buildDocLink({ docId, space }: DocLinkTarget): string {
   const query = docSpace ? `?sp=${encodeURIComponent(docSpace)}` : ''
   return `${origin()}${path}${query}`
 }
+
+/** A parsed in-app document share link — the inverse of {@link buildDocLink}. */
+export interface ParsedDocLink {
+  docId: string
+  /** The doc's own space carried by `?sp=`, or undefined when the link omits it. */
+  space?: string
+}
+
+/** `/d/<docId>` — docId is a single documentName segment (A-Z a-z 0-9 _ -), optional trailing slash. */
+const DOC_LINK_PATH_RE = /^\/d\/([A-Za-z0-9_-]+)\/?$/
+
+/**
+ * Parse a same-origin in-app document share link (`<origin>/d/<docId>?sp=<spaceId>`) into
+ * `{ docId, space }`, or return null when `href` is not such a link. The inverse of
+ * {@link buildDocLink}, used to decide whether an in-chat link click should open the doc inline in
+ * the sidebar (WS-17) instead of following the anchor to a new page.
+ *
+ * SAME-ORIGIN ONLY: a link whose origin differs from the current one (an external site that merely
+ * happens to use a `/d/…` path) is rejected, so interception never hijacks a foreign URL — it stays
+ * a plain outbound link. Relative hrefs resolve against the current origin and are accepted.
+ */
+export function parseDocLink(href: string | undefined): ParsedDocLink | null {
+  if (typeof href !== 'string' || href.length === 0) return null
+  if (typeof window === 'undefined' || !window.location?.origin) return null
+  let url: URL
+  try {
+    url = new URL(href, window.location.origin)
+  } catch {
+    return null
+  }
+  if (url.origin !== window.location.origin) return null
+  const m = DOC_LINK_PATH_RE.exec(url.pathname)
+  if (!m) return null
+  const space = (url.searchParams.get('sp') || '').trim()
+  return { docId: m[1], space: space || undefined }
+}

--- a/packages/dmworkbase/src/Utils/docLinkNavigation.ts
+++ b/packages/dmworkbase/src/Utils/docLinkNavigation.ts
@@ -19,6 +19,10 @@ export function tryOpenDocLinkInSidebar(href: string | undefined): boolean {
   if (!open) return false;
   const parsed = parseDocLink(href);
   if (!parsed) return false;
+  // Only intercept when the docs pane can actually render (docs module registered). A host that
+  // mounts the chat but not the docs module (e.g. the extension side panel) would otherwise swallow
+  // the link into an empty, uncloseable panel; fall through so it opens the standalone page instead.
+  if (!WKApp.endpoints?.hasChatDocPreviewPane?.()) return false;
   open(parsed.docId, parsed.space);
   return true;
 }

--- a/packages/dmworkbase/src/Utils/docLinkNavigation.ts
+++ b/packages/dmworkbase/src/Utils/docLinkNavigation.ts
@@ -1,0 +1,24 @@
+import WKApp from "../App";
+import { parseDocLink } from "./docLink";
+
+/**
+ * If `href` is a same-origin in-app document share link (`/d/<docId>?sp=<spaceId>`) AND an in-chat
+ * doc sidebar host is currently mounted, open the document inline in the sidebar and return true.
+ * Otherwise return false so the caller falls back to its default behavior (follow the anchor / open
+ * the standalone page in a new tab).
+ *
+ * WS-17: clicking a forwarded document link inside a conversation should open the live document in a
+ * right-side sidebar — so the user can read the rendered doc while continuing to chat with the agent
+ * to edit it — instead of navigating away to a new page. The sidebar only exists on the chat page, so
+ * `WKApp.openDocPreview` is set by ChatContentPage while it is mounted and cleared on unmount; gating
+ * on its presence means a `/d/` link clicked anywhere else (or before the chat page mounts) is left
+ * untouched and opens the full standalone page as before, matching "只在聊天里内联，其他情况开新页面".
+ */
+export function tryOpenDocLinkInSidebar(href: string | undefined): boolean {
+  const open = WKApp.openDocPreview;
+  if (!open) return false;
+  const parsed = parseDocLink(href);
+  if (!parsed) return false;
+  open(parsed.docId, parsed.space);
+  return true;
+}

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -511,6 +511,10 @@
     "linkCopied": "Link copied",
     "openInNewPage": "Open in new page"
   },
+  "sidebar": {
+    "expandFullPage": "Expand to full page",
+    "close": "Close"
+  },
   "moreMenu": {
     "createdPrefix": "Created on",
     "unknownCreator": "Unknown creator"

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -511,6 +511,10 @@
     "linkCopied": "链接已复制",
     "openInNewPage": "在新页面打开"
   },
+  "sidebar": {
+    "expandFullPage": "展开为整页",
+    "close": "关闭"
+  },
   "moreMenu": {
     "createdPrefix": "创建于",
     "unknownCreator": "未知创建者"

--- a/packages/docs/src/module.tsx
+++ b/packages/docs/src/module.tsx
@@ -12,9 +12,10 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { getWKApp, i18n, t, Menus } from './octoweb/index.ts'
+import { getWKApp, i18n, t, Menus, registerChatDocPreviewPane } from './octoweb/index.ts'
 import type { IModule } from './octoweb/index.ts'
 import { InviteAcceptPage } from './invite/InviteAcceptPage.tsx'
+import { DocPreviewPane } from './pages/DocPreviewPane.tsx'
 import { captureDocTargetDeepLink } from './config.ts'
 import zhCN from './i18n/zh-CN.json'
 import enUS from './i18n/en-US.json'
@@ -278,6 +279,18 @@ export class DocsModule implements IModule {
     // `/docs` renders the invite-accept page when a pending invite token exists, else docs home.
     wk.route.register('/docs', () => docsRouteElement)
     wk.route.register('/docs/invite/:token', () => <InviteAcceptRoute />)
+
+    // In-chat sidebar document pane (WS-17). Register the pane the host chat renders when a
+    // `/d/:docId` link is clicked inside a conversation — the live editor inline for preview + edit
+    // + comment, without opening a new page. No-op under test overrides / hosts without endpoints.
+    registerChatDocPreviewPane(({ docId, space, onClose, onExpandFullPage }) => (
+      <DocPreviewPane
+        docId={docId}
+        space={space ?? ''}
+        onClose={onClose}
+        onExpandFullPage={onExpandFullPage}
+      />
+    ))
 
     // Register the Docs entry in the octo-web NavRail (sidebar). Without this the
     // /docs route is registered but unreachable: the main view is menu-driven

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -104,6 +104,37 @@ export function onNavMenuActivated(menuId: string, cb: () => void): () => void {
   return () => bus.off('wk:nav-menu-activated', handler)
 }
 
+/**
+ * Register the docs pane the host chat renders inside its reused right-side panel when a `/d/:docId`
+ * link is clicked in chat (WS-17). Mirrors the `chatSummaryPanel` endpoint contract (dmworksummary):
+ * dmworkbase declares the `chatDocPreviewPane` endpoint category + invoke method, and the docs module
+ * — which is allowed to depend on `@octo/base` — registers the implementation here. The host invokes
+ * it with `{ docId, space, onClose, onExpandFullPage }` and renders whatever ReactNode we return.
+ *
+ * No-op when a test override is set (unit tests have no host endpoint registry) or the host exposes no
+ * endpoints surface, so this stays a safe production-only side effect.
+ */
+export function registerChatDocPreviewPane(
+  render: (opts: {
+    docId: string
+    space?: string
+    onClose: () => void
+    onExpandFullPage: () => void
+  }) => import('react').ReactNode,
+): void {
+  if (override) return
+  const endpoints = (
+    WKApp as unknown as {
+      endpoints?: {
+        registerChatDocPreviewPane?: (sid: string, cb: (param: unknown) => import('react').ReactNode) => void
+      }
+    }
+  ).endpoints
+  endpoints?.registerChatDocPreviewPane?.('docsdocpreviewpane', (param) =>
+    render(param as { docId: string; space?: string; onClose: () => void; onExpandFullPage: () => void }),
+  )
+}
+
 /** Page size for a single member page (getSpaceMembers default). */
 const SPACE_MEMBERS_PAGE_SIZE = 50
 /** Safety cap on page count so a pathological space can't loop unbounded. */

--- a/packages/docs/src/pages/DocPreviewPane.css
+++ b/packages/docs/src/pages/DocPreviewPane.css
@@ -1,0 +1,62 @@
+/* In-chat sidebar document pane (WS-17). Fills the host's reused right-side panel slot; the
+   collaborative editor / sheet / board inside supplies its own scrolling, so this only owns the
+   column layout and the slim control bar used in the non-editor states. */
+
+.octo-doc-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--octo-bg, #fff);
+}
+
+/* The editor case lets EditorShell fill the whole slot (its own header hosts the controls). */
+.octo-doc-sidebar--editor {
+  height: 100%;
+}
+
+.octo-doc-sidebar--editor > .octo-doc {
+  height: 100%;
+}
+
+/* Slim top bar carrying 展开为整页 + 关闭 for the loading / terminal / sheet / board states. */
+.octo-doc-sidebar-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: none;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--octo-border, #e5e6eb);
+}
+
+.octo-doc-sidebar-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  position: relative;
+}
+
+.octo-doc-sidebar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.octo-doc-sidebar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--octo-text-secondary, #4e5969);
+  cursor: pointer;
+}
+
+.octo-doc-sidebar-btn:hover {
+  background: var(--octo-fill-hover, #f2f3f5);
+  color: var(--octo-text, #1d2129);
+}

--- a/packages/docs/src/pages/DocPreviewPane.css
+++ b/packages/docs/src/pages/DocPreviewPane.css
@@ -10,16 +10,8 @@
   background: var(--octo-bg, #fff);
 }
 
-/* The editor case lets EditorShell fill the whole slot (its own header hosts the controls). */
-.octo-doc-sidebar--editor {
-  height: 100%;
-}
-
-.octo-doc-sidebar--editor > .octo-doc {
-  height: 100%;
-}
-
-/* Slim top bar carrying 展开为整页 + 关闭 for the loading / terminal / sheet / board states. */
+/* Slim top bar carrying 展开为整页 + 关闭 across every state (loading / terminal / sheet / board /
+   document), so the close control is always reachable regardless of the inner editor's render state. */
 .octo-doc-sidebar-bar {
   display: flex;
   align-items: center;

--- a/packages/docs/src/pages/DocPreviewPane.tsx
+++ b/packages/docs/src/pages/DocPreviewPane.tsx
@@ -21,13 +21,13 @@ import './DocPreviewPane.css'
  * comment WITHOUT leaving the conversation, instead of opening a new browser page.
  *
  * The host (dmworkbase ChatContentPage) mounts this via the `chatDocPreviewPane` endpoint and owns
- * the panel shell (the reused `wk-thread-panel` right-side slot). This component adds only the two
- * sidebar affordances on top of the reused editor:
+ * the panel shell (the reused `wk-thread-panel` right-side slot). This component adds a slim top bar
+ * with the two sidebar affordances above the reused editor, in EVERY state (loading / terminal /
+ * sheet / board / document):
  *   - 展开为整页 (onExpandFullPage): the host opens the standalone `/d/:docId?sp=` route in a new tab.
  *   - 关闭 (onClose): the host closes the sidebar slot.
- * For a document the controls are injected into the editor's own header (single header, no stacking);
- * for the loading / terminal / sheet / board states — which have no EditorShell header to host them —
- * a slim top bar carries the same two controls so they stay reachable in every state.
+ * The bar is host-owned (not injected into EditorShell's header), so close stays reachable even when
+ * the inner editor is on its terminal / loading path and renders no header.
  *
  * Entry is role-driven (writer/admin edit, reader read-only), exactly like the standalone page: the
  * collab token resolves the role and EditorShell renders editable or read-only accordingly, and the
@@ -191,22 +191,24 @@ export function DocPreviewPane({ docId, space, onClose, onExpandFullPage }: DocP
     )
   }
 
-  // Document (the WS-17 target case): inject the two controls into the editor's own header so the
-  // sidebar has a single header, and the 展开为整页 button sits at the top exactly as designed.
-  return (
-    <div className="octo-doc-sidebar octo-doc-sidebar--editor">
-      <EditorShell
-        key={editorDocId}
-        docId={editorDocId}
-        title={meta.title || t('docs.state.untitled')}
-        uid={uid}
-        space={addressing.space}
-        folder={addressing.folder}
-        doc={addressing.doc}
-        user={{ id: uid, name: names.get(uid) || uid }}
-        headerRight={actions}
-        creatorNicknameOnly
-      />
-    </div>
+  // Document (the WS-17 target case). Route through the slim top bar like every other state rather
+  // than injecting the controls into EditorShell's own header: EditorShell renders `headerRight`
+  // ONLY on its healthy editor path and skips it on its terminal (forbidden / expired / network) and
+  // loading (`!instance`) early-returns — which are reached independently of this pane's own getDoc
+  // preflight (e.g. the collab connection fails after preflight passed). Keeping close + 展开 in the
+  // host-owned bar guarantees they are always reachable, so the pane can never get stuck open.
+  return withBar(
+    <EditorShell
+      key={editorDocId}
+      docId={editorDocId}
+      title={meta.title || t('docs.state.untitled')}
+      uid={uid}
+      space={addressing.space}
+      folder={addressing.folder}
+      doc={addressing.doc}
+      user={{ id: uid, name: names.get(uid) || uid }}
+      onOpenInNewPage={onExpandFullPage}
+      creatorNicknameOnly
+    />,
   )
 }

--- a/packages/docs/src/pages/DocPreviewPane.tsx
+++ b/packages/docs/src/pages/DocPreviewPane.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react'
 import { getWKApp, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import { SheetView } from '../sheet/SheetView.tsx'
 import { BoardSession } from '../board/BoardSession.tsx'
+import { HtmlDocView } from '../html/HtmlDocView.tsx'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { OpenNewPageIcon } from '../editor/DocMoreMenu.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
-import { getDoc, type DocMeta } from './docsApi.ts'
+import { getDoc, recordDocView, type DocMeta } from './docsApi.ts'
 import { parseDocumentName } from '../documentName/index.ts'
 import { DEFAULT_DOC_FOLDER } from '../config.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -23,7 +24,7 @@ import './DocPreviewPane.css'
  * The host (dmworkbase ChatContentPage) mounts this via the `chatDocPreviewPane` endpoint and owns
  * the panel shell (the reused `wk-thread-panel` right-side slot). This component adds a slim top bar
  * with the two sidebar affordances above the reused editor, in EVERY state (loading / terminal /
- * sheet / board / document):
+ * sheet / board / html / document):
  *   - 展开为整页 (onExpandFullPage): the host opens the standalone `/d/:docId?sp=` route in a new tab.
  *   - 关闭 (onClose): the host closes the sidebar slot.
  * The bar is host-owned (not injected into EditorShell's header), so close stays reachable even when
@@ -83,6 +84,23 @@ export function DocPreviewPane({ docId, space, onClose, onExpandFullPage }: DocP
       cancelled = true
     }
   }, [docId, space])
+
+  // Log the "最近查看" view ingest once the doc is READY (parity with StandaloneDocPage and the
+  // in-shell DocsHome.commitOpen entry — WS-17 review P1-2). Guarded by docId via a ref so React
+  // re-renders and strict-mode double-invocation record at most once per opened doc. Fire-and-forget:
+  // recordDocView swallows every failure, so a failed / not-yet-deployed ingest never affects open.
+  //
+  // Unlike the standalone page, we pass NO explicit viewer space: inside the live chat shell the
+  // global request interceptor already carries the viewer's real `currentSpaceId` as X-Space-Id, so
+  // the view is recorded under the viewer's own space (the XIN-1237 write/read contract) without any
+  // seeding. Forcing the doc's `?sp=` space here would record under a space the viewer may not be in.
+  const recordedDocRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (phase.status !== 'ready' || !docId) return
+    if (recordedDocRef.current === docId) return
+    recordedDocRef.current = docId
+    void recordDocView(docId)
+  }, [phase.status, docId])
 
   // Address the room from the preflight's canonical documentName when available (so a doc in a
   // non-default folder / a whiteboard key resolves correctly), else fall back to the link's space
@@ -157,6 +175,22 @@ export function DocPreviewPane({ docId, space, onClose, onExpandFullPage }: DocP
 
   const meta = phase.meta
   const editorDocId = meta.docId || docId
+
+  // Read-only HTML doc ('html'): its content lives in octo-doc (not the yjs collab store), so it must
+  // render via HtmlDocView, mirroring StandaloneDocPage / DocsHome.buildRightPane. The chat click
+  // interceptor is docType-agnostic, so without this branch an html doc opened in the sidebar would
+  // fall through to the collab EditorShell — which has no yjs data for it and reports "not found"
+  // (WS-17 review P1-1). Pass the octo-doc slug so it addresses the published doc.
+  if (meta.docType === 'html') {
+    return withBar(
+      <HtmlDocView
+        key={editorDocId}
+        docId={editorDocId}
+        slug={meta.octoDocSlug}
+        space={addressing.space}
+      />,
+    )
+  }
 
   if (meta.docType === 'board') {
     const boardId = addressing.board || editorDocId

--- a/packages/docs/src/pages/DocPreviewPane.tsx
+++ b/packages/docs/src/pages/DocPreviewPane.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react'
+import { getWKApp, t } from '../octoweb/index.ts'
+import { EditorShell } from '../editor/EditorShell.tsx'
+import { SheetView } from '../sheet/SheetView.tsx'
+import { BoardSession } from '../board/BoardSession.tsx'
+import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
+import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
+import { OpenNewPageIcon } from '../editor/DocMoreMenu.tsx'
+import { terminalForCreateError } from '../collab/useCollabEditor.ts'
+import { getDoc, type DocMeta } from './docsApi.ts'
+import { parseDocumentName } from '../documentName/index.ts'
+import { DEFAULT_DOC_FOLDER } from '../config.ts'
+import { useMemberNames } from '../members/useMemberNames.ts'
+import '../editor/styles.css'
+import './DocPreviewPane.css'
+
+/**
+ * In-chat sidebar document pane (WS-17). Renders the SAME collaborative editor the full-page
+ * standalone view uses (EditorShell / SheetView / BoardSession — parity with StandaloneDocPage),
+ * so a `/d/:docId` link clicked inside chat opens the live document inline for preview + edit +
+ * comment WITHOUT leaving the conversation, instead of opening a new browser page.
+ *
+ * The host (dmworkbase ChatContentPage) mounts this via the `chatDocPreviewPane` endpoint and owns
+ * the panel shell (the reused `wk-thread-panel` right-side slot). This component adds only the two
+ * sidebar affordances on top of the reused editor:
+ *   - 展开为整页 (onExpandFullPage): the host opens the standalone `/d/:docId?sp=` route in a new tab.
+ *   - 关闭 (onClose): the host closes the sidebar slot.
+ * For a document the controls are injected into the editor's own header (single header, no stacking);
+ * for the loading / terminal / sheet / board states — which have no EditorShell header to host them —
+ * a slim top bar carries the same two controls so they stay reachable in every state.
+ *
+ * Entry is role-driven (writer/admin edit, reader read-only), exactly like the standalone page: the
+ * collab token resolves the role and EditorShell renders editable or read-only accordingly, and the
+ * preflight GET /docs/{docId} gates the boundary states (forbidden → request access, not-found,
+ * archived/locked, expired session) so a permissionless click degrades gracefully, never white-screens.
+ */
+export interface DocPreviewPaneProps {
+  docId: string
+  /** The document's own space (`?sp=` from the share link) used to address the preflight + room. */
+  space: string
+  /** Close the sidebar slot (host-owned). */
+  onClose: () => void
+  /** Open the standalone full page in a new tab (host-owned; carries `/d/:docId?sp=`). */
+  onExpandFullPage: () => void
+}
+
+type Phase =
+  | { status: 'loading' }
+  | { status: 'ready'; meta: DocMeta }
+  | { status: 'terminal'; kind: TerminalKind }
+
+/** ✕ close glyph, matching the line-icon style used across the docs header. */
+function CloseIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 20 20" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden="true">
+      <path d="M5 5l10 10M15 5L5 15" />
+    </svg>
+  )
+}
+
+export function DocPreviewPane({ docId, space, onClose, onExpandFullPage }: DocPreviewPaneProps): ReactElement {
+  const wk = getWKApp()
+  const uid = wk.loginInfo?.uid ?? ''
+  const [phase, setPhase] = useState<Phase>({ status: 'loading' })
+
+  // Preflight the doc BEFORE mounting the collaborative editor — the single deterministic gate for
+  // every boundary state (200 → editor; 403/404/401/409 → terminal), mirroring StandaloneDocPage.
+  useEffect(() => {
+    let cancelled = false
+    if (!docId) {
+      setPhase({ status: 'terminal', kind: 'not-found' })
+      return
+    }
+    setPhase({ status: 'loading' })
+    getDoc(docId, { spaceId: space })
+      .then((meta) => {
+        if (!cancelled) setPhase({ status: 'ready', meta })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setPhase({ status: 'terminal', kind: terminalForCreateError(err) })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [docId, space])
+
+  // Address the room from the preflight's canonical documentName when available (so a doc in a
+  // non-default folder / a whiteboard key resolves correctly), else fall back to the link's space
+  // + default folder. Same resolution as StandaloneDocPage.
+  const addressing = useMemo(() => {
+    if (phase.status === 'ready' && phase.meta.documentName) {
+      try {
+        const parsed = parseDocumentName(phase.meta.documentName)
+        if (parsed.kind === 'document') {
+          return { space: parsed.space, folder: parsed.folder, doc: parsed.doc, board: undefined }
+        }
+        if (parsed.kind === 'whiteboard') {
+          return { space: parsed.space, folder: parsed.folder, doc: docId, board: parsed.board }
+        }
+      } catch {
+        // Malformed documentName: fall back to the link space + default folder below.
+      }
+    }
+    return { space, folder: DEFAULT_DOC_FOLDER, doc: docId, board: undefined }
+  }, [phase, space, docId])
+
+  const names = useMemberNames(addressing.space)
+
+  // The two sidebar controls, reused both as the editor's injected headerRight (document case) and
+  // as the slim top bar (loading / terminal / sheet / board).
+  const actions: ReactNode = (
+    <div className="octo-doc-sidebar-actions">
+      <button
+        type="button"
+        className="octo-doc-sidebar-btn"
+        title={t('docs.sidebar.expandFullPage')}
+        aria-label={t('docs.sidebar.expandFullPage')}
+        onClick={onExpandFullPage}
+      >
+        {OpenNewPageIcon}
+      </button>
+      <button
+        type="button"
+        className="octo-doc-sidebar-btn"
+        title={t('docs.sidebar.close')}
+        aria-label={t('docs.sidebar.close')}
+        onClick={onClose}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  )
+
+  const withBar = (body: ReactNode): ReactElement => (
+    <div className="octo-doc-sidebar">
+      <div className="octo-doc-sidebar-bar">{actions}</div>
+      <div className="octo-doc-sidebar-body">{body}</div>
+    </div>
+  )
+
+  if (phase.status === 'loading') {
+    return withBar(<p className="octo-loading">{t('docs.state.loading')}</p>)
+  }
+
+  if (phase.status === 'terminal') {
+    if (phase.kind === 'forbidden' && docId) {
+      return withBar(
+        <div className="octo-standalone-card octo-standalone-forbidden" role="alert">
+          <h1 className="octo-standalone-card-title">{t('docs.forward.forbiddenTitle')}</h1>
+          <p className="octo-standalone-card-msg">{t('docs.error.permission.forbidden')}</p>
+          <RequestAccessButton docId={docId} spaceId={space} />
+        </div>,
+      )
+    }
+    return withBar(<DocTerminal title={t('docs.state.untitled')} kind={phase.kind} />)
+  }
+
+  const meta = phase.meta
+  const editorDocId = meta.docId || docId
+
+  if (meta.docType === 'board') {
+    const boardId = addressing.board || editorDocId
+    return withBar(
+      <BoardSession
+        key={boardId}
+        docId={boardId}
+        title={meta.title || t('docs.state.untitled')}
+        uid={uid}
+        space={addressing.space}
+        folder={addressing.folder}
+        userName={names.get(uid) || uid}
+        onOpenInNewPage={onExpandFullPage}
+        creatorNicknameOnly
+      />,
+    )
+  }
+
+  if (meta.docType === 'sheet') {
+    return withBar(
+      <SheetView
+        key={editorDocId}
+        docId={editorDocId}
+        uid={uid}
+        space={addressing.space}
+        folder={addressing.folder}
+        doc={addressing.doc}
+        user={{ id: uid, name: names.get(uid) || uid }}
+        onOpenInNewPage={onExpandFullPage}
+        creatorNicknameOnly
+      />,
+    )
+  }
+
+  // Document (the WS-17 target case): inject the two controls into the editor's own header so the
+  // sidebar has a single header, and the 展开为整页 button sits at the top exactly as designed.
+  return (
+    <div className="octo-doc-sidebar octo-doc-sidebar--editor">
+      <EditorShell
+        key={editorDocId}
+        docId={editorDocId}
+        title={meta.title || t('docs.state.untitled')}
+        uid={uid}
+        space={addressing.space}
+        folder={addressing.folder}
+        doc={addressing.doc}
+        user={{ id: uid, name: names.get(uid) || uid }}
+        headerRight={actions}
+        creatorNicknameOnly
+      />
+    </div>
+  )
+}

--- a/packages/docs/src/pages/DocPreviewPane.tsx
+++ b/packages/docs/src/pages/DocPreviewPane.tsx
@@ -86,21 +86,26 @@ export function DocPreviewPane({ docId, space, onClose, onExpandFullPage }: DocP
   }, [docId, space])
 
   // Log the "最近查看" view ingest once the doc is READY (parity with StandaloneDocPage and the
-  // in-shell DocsHome.commitOpen entry — WS-17 review P1-2). Guarded by docId via a ref so React
-  // re-renders and strict-mode double-invocation record at most once per opened doc. Fire-and-forget:
-  // recordDocView swallows every failure, so a failed / not-yet-deployed ingest never affects open.
+  // in-shell DocsHome.commitOpen entry — WS-17 review P1-2). Gate on the RESOLVED meta id, not just
+  // phase.status: in the sidebar this pane instance is reused across doc switches (no per-doc remount),
+  // so on an A→B switch `phase` can still hold A's `ready` meta while `docId` is already B. Keying on
+  // `phase.meta.docId === docId` (DocMeta.docId is the id the backend echoed for the preflight we ran)
+  // ensures we only record once B's OWN preflight succeeds — never recording B before it resolves, and
+  // never recording a doc that then turns out forbidden / not-found. Ref-deduped so re-renders and
+  // strict-mode double-invocation record at most once per doc.
   //
-  // Unlike the standalone page, we pass NO explicit viewer space: inside the live chat shell the
-  // global request interceptor already carries the viewer's real `currentSpaceId` as X-Space-Id, so
-  // the view is recorded under the viewer's own space (the XIN-1237 write/read contract) without any
-  // seeding. Forcing the doc's `?sp=` space here would record under a space the viewer may not be in.
+  // We pass NO explicit viewer space: inside the live chat shell the global request interceptor already
+  // carries the viewer's real `currentSpaceId` as X-Space-Id, so the view records under the viewer's own
+  // space (the XIN-1237 write/read contract) without seeding. Forcing the doc's `?sp=` space here would
+  // record under a space the viewer may not be in.
   const recordedDocRef = useRef<string | null>(null)
+  const readyDocId = phase.status === 'ready' ? phase.meta.docId : undefined
   useEffect(() => {
-    if (phase.status !== 'ready' || !docId) return
+    if (!docId || readyDocId !== docId) return
     if (recordedDocRef.current === docId) return
     recordedDocRef.current = docId
     void recordDocView(docId)
-  }, [phase.status, docId])
+  }, [readyDocId, docId])
 
   // Address the room from the preflight's canonical documentName when available (so a doc in a
   // non-default folder / a whiteboard key resolves correctly), else fall back to the link's space


### PR DESCRIPTION
## WS-17 文档链接点击在 Octo 内侧边栏内联编辑（不开新网页）

在 Octo 客户端内点击文档分享链接 `/d/<docId>?sp=<spaceId>` 时，直接在**聊天右侧侧边栏**内联打开该文档（预览 + 编辑 + 评论），不离开当前会话、不打开新网页；顶部提供「展开为整页」按钮再跳整页。交互取向、进入态、展开行为均按辉哥在 issue 内确认。

### 改动
- **拦截点击**（dmworkbase）：`MarkdownContent` 聊天正文链接 + 交互卡片 `openUrl` 识别同源 `/d/<docId>?sp=` → 侧边栏内联打开（仅当聊天侧边栏宿主已挂载）。普通左键才拦截，`cmd/ctrl/shift/alt`、中键仍照常新标签打开；非文档链接、跨域链接、聊天外场景一律回退现有整页/新页面行为。
- **复用面板外壳**：沿用文件预览侧边栏的 `wk-thread-panel` 右侧槽位，与子区/文件预览/事项/总结/搜索面板互斥。
- **在线协同编辑器**：内容由 docs 模块注册的新端点 `chatDocPreviewPane` 提供，渲染既有 `EditorShell`/`SheetView`/`BoardSession`（仿 `chatSummaryPanel` 解耦，base 不反依赖 docs）。按角色进入（writer/admin 可编辑、reader 只读），preflight 网关 forbidden（内联 RequestAccess）/ not-found / archived / 会话过期，不白屏。
- **展开为整页**：侧边栏内小按钮 → `window.open('/d/<docId>?sp=', '_blank')`（新标签页）。

### 不变
- 外部浏览器直接打开 `/d/` 链接、非聊天场景点击 → 现有整页 `StandaloneDocPage` 行为完全不变。
- 7/13 锁死的 shareUrl 格式契约未改动；未改 docs-backend。

### 验证
- 新增单测：`docLink.parseDocLink`、`tryOpenDocLinkInSidebar`、卡片 `openUrl` 文档链接路由 —— 全绿。
- 受影响既有测试全绿：`MarkdownContent`（24）、docs 包（1225）。docs 包 typecheck 干净（仅 2 处与本改动无关的既有报错）；`apps/web` typecheck 下本改动新增符号零报错。
- 说明：仓库未配置 per-package lint 脚本（`turbo run lint` 为空），故无可执行的 lint 门禁；`EditorShell.test.tsx` 的 4 个失败经 `git stash` 验证为改动前既有失败，与本 PR 无关。

Closes #860

(Octo loop issue: WS-17)

