### PR TITLE
WS-20 fix(forward): 最近群列表改用 SidebarService recent 权威源

### DIFF
--- a/packages/dmworkbase/src/Components/ChatSelector/__tests__/tabFilter.test.ts
+++ b/packages/dmworkbase/src/Components/ChatSelector/__tests__/tabFilter.test.ts
@@ -64,6 +64,43 @@ describe("filterChatSelectorItems — Tab 作用域", () => {
     expect(run("recent", "", [], [key("group", "g1"), key("direct", "d2")])).toEqual(["g1", "d2"])
   })
 
+  it("recent Tab 提供 recentOrder 时按后端 timestamp 降序（对齐 ChatSelectorModal）", () => {
+    // g1 传入顺序在前，但 d2 timestamp 更大 → d2 应排在 g1 之前。
+    const recentOrder = new Map<string, number>([
+      [key("group", "g1"), 100],
+      [key("direct", "d2"), 200],
+    ])
+    const out = filterChatSelectorItems(
+      ITEMS,
+      {
+        activeTab: "recent",
+        keyword: "",
+        followedKeys: new Set(),
+        recentKeys: new Set([key("group", "g1"), key("direct", "d2")]),
+        recentOrder,
+      },
+      acc,
+    )
+    expect(out.map((i) => i.id)).toEqual(["d2", "g1"])
+  })
+
+  it("recent Tab recentOrder 缺失的项排序权重按 0 处理", () => {
+    // g1 无权重(→0)，d2 有权重(50) → d2 在前，g1 在后。
+    const recentOrder = new Map<string, number>([[key("direct", "d2"), 50]])
+    const out = filterChatSelectorItems(
+      ITEMS,
+      {
+        activeTab: "recent",
+        keyword: "",
+        followedKeys: new Set(),
+        recentKeys: new Set([key("group", "g1"), key("direct", "d2")]),
+        recentOrder,
+      },
+      acc,
+    )
+    expect(out.map((i) => i.id)).toEqual(["d2", "g1"])
+  })
+
   it("复合 key 跨类型不碰撞：同 id 不同类型互不干扰", () => {
     const items: TestItem[] = [
       { id: "42", name: "Group42", kind: "group" },

--- a/packages/dmworkbase/src/Components/ChatSelector/tabFilter.ts
+++ b/packages/dmworkbase/src/Components/ChatSelector/tabFilter.ts
@@ -8,7 +8,8 @@
  *
  * Tab 语义（对齐 dmworksummary/ChatSelectorModal）：
  *   - followed 关注：仅复合 key 命中关注集合的项（群/子区/私聊皆可）。
- *   - recent   最近：仅复合 key 命中最近集合的项，保持输入顺序（调用方已按时间排好）。
+ *   - recent   最近：仅复合 key 命中最近集合的项，按后端 recentOrder 时间戳降序
+ *               （与 ChatSelectorModal 一致）；未提供 recentOrder 时保持传入顺序。
  *   - group    全部群聊：群 + 子区（子区嵌套在父群下），不含私聊。
  *   - direct   全部私聊：仅私聊。
  *
@@ -44,6 +45,9 @@ export interface ChatSelectorFilterOptions {
   followedKeys: Set<string>
   /** 最近集合（复合 key）。 */
   recentKeys: Set<string>
+  /** 最近集合排序权重（复合 key → 后端 timestamp）。提供时「最近」Tab 按其降序，
+   *  与 ChatSelectorModal 对齐；省略时保持传入顺序。 */
+  recentOrder?: Map<string, number>
 }
 
 /** 按 Tab 把整表收敛到当前作用域，保持传入顺序（转发列表已是「父群→子区」树序）。 */
@@ -55,8 +59,15 @@ function scopeByTab<T>(
   switch (opts.activeTab) {
     case "followed":
       return items.filter((i) => opts.followedKeys.has(acc.getKey(i)))
-    case "recent":
-      return items.filter((i) => opts.recentKeys.has(acc.getKey(i)))
+    case "recent": {
+      const scoped = items.filter((i) => opts.recentKeys.has(acc.getKey(i)))
+      // 有后端排序权重时按 timestamp 降序（对齐 ChatSelectorModal）；否则保持传入顺序。
+      if (!opts.recentOrder) return scoped
+      const order = opts.recentOrder
+      return [...scoped].sort(
+        (a, b) => (order.get(acc.getKey(b)) ?? 0) - (order.get(acc.getKey(a)) ?? 0),
+      )
+    }
     case "direct":
       return items.filter((i) => acc.getKind(i) === "direct")
     case "group":

--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -830,19 +830,87 @@ describe("useForwardModal — four-Tab selector (issue #661)", () => {
         return { channel: { channelID, channelType: 1 }, orgData: { displayName } }
     }
 
-    it("default tab is 'recent' and scopes to local recent conversations (directs from friends excluded)", async () => {
-        hoisted.conversations = [makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 })]
+    it("default tab is 'recent' and scopes to the SidebarService recent set (not local conversations)", async () => {
+        hoisted.deviceId = "dev-uuid"
+        hoisted.conversations = [
+            makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 }),
+            makeConv("g2", CT_GROUP, "Group 2", { timestamp: 90 }),
+        ]
         hoisted.searchFriends.mockResolvedValue([makeFriend("d1", "Alice")] as any)
+        // 后端 recent 只含 g1（复合 key = 群类型 2 :: g1）；g2 是本地会话但不在后端最近集合。
+        hoisted.sidebarSync.mockImplementation(async (req: any) => {
+            if (req.tab === "recent") {
+                return {
+                    items: [{ target_type: 2, target_id: "g1", timestamp: 500 }],
+                    version: 0,
+                    follow_version: 0,
+                }
+            }
+            return { items: [], version: 0, follow_version: 0 }
+        })
 
         const view = await renderForward()
 
         expect(view.current.activeTab).toBe("recent")
         const ids = view.current.items.map((i) => i.channelID)
-        // 最近 = 本地最近会话 → 含群 g1；好友 d1 不在最近会话集合内 → 不出现在最近 Tab。
+        // 最近 = 后端权威最近集合 → 含 g1；本地会话 g2 不在后端最近集合 → 不出现。
         expect(ids).toContain("g1")
+        expect(ids).not.toContain("g2")
+        // 好友 d1 也不在最近集合内 → 不出现在最近 Tab。
         expect(ids).not.toContain("d1")
-        // 但 allItems（已选头像区）仍是全量，含好友。
+        // 但 allItems（已选头像区）仍是全量，含本地会话与好友。
+        expect(view.current.allItems.map((i) => i.channelID)).toContain("g2")
         expect(view.current.allItems.map((i) => i.channelID)).toContain("d1")
+        // 最近同步以 recent tab + 设备 UUID 发起。
+        expect(hoisted.sidebarSync).toHaveBeenCalledWith(
+            expect.objectContaining({ tab: "recent", device_uuid: "dev-uuid" }),
+        )
+
+        view.unmount()
+    })
+
+    it("recent tab is empty when deviceId is empty (doomed request guard, no local fallback)", async () => {
+        hoisted.deviceId = ""
+        hoisted.conversations = [makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 })]
+
+        const view = await renderForward()
+
+        expect(view.current.activeTab).toBe("recent")
+        // deviceId 空 → 跳过 recent 同步，最近集合为空，本地会话不再兜底。
+        expect(hoisted.sidebarSync).not.toHaveBeenCalled()
+        expect(view.current.items.map((i) => i.channelID)).not.toContain("g1")
+        // 但 g1 仍在全量 allItems 里（供其他 Tab / 已选区）。
+        expect(view.current.allItems.map((i) => i.channelID)).toContain("g1")
+
+        view.unmount()
+    })
+
+    it("recent tab orders items by the backend timestamp (descending), not local conversation order", async () => {
+        hoisted.deviceId = "dev-uuid"
+        // 本地会话顺序 g1 → g2（g1 timestamp 更大），但后端 recent 让 g2 更靠前。
+        hoisted.conversations = [
+            makeConv("g1", CT_GROUP, "Group 1", { timestamp: 100 }),
+            makeConv("g2", CT_GROUP, "Group 2", { timestamp: 90 }),
+        ]
+        hoisted.sidebarSync.mockImplementation(async (req: any) => {
+            if (req.tab === "recent") {
+                return {
+                    items: [
+                        { target_type: 2, target_id: "g1", timestamp: 100 },
+                        { target_type: 2, target_id: "g2", timestamp: 999 },
+                    ],
+                    version: 0,
+                    follow_version: 0,
+                }
+            }
+            return { items: [], version: 0, follow_version: 0 }
+        })
+
+        const view = await renderForward()
+
+        const ids = view.current.items.map((i) => i.channelID)
+        // g2 后端 timestamp 更大 → 排在 g1 之前（与本地 timestamp 顺序相反）。
+        expect(ids).toEqual(["g2", "g1"])
 
         view.unmount()
     })

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -139,13 +139,16 @@ export function useForwardModal(
   const [keyword, setKeyword] = useState("")
   const [loading, setLoading] = useState(true)
   // 四 Tab：关注 / 最近 / 全部群聊 / 全部私聊（对齐智能纪要选择器）。默认「最近」，
-  // 因转发本地数据源以最近会话为主，落地即有内容，避免默认「关注」空集。
+  // 与转发的高频使用场景一致（多数转发目标是最近聊过的会话）。「最近」集合走
+  // SidebarService recent 服务端权威源（见下方同步 effect），与纪要选择器一致。
   const [activeTab, setActiveTab] = useState<ChatSelectorTab>("recent")
   // 关注集合（复合 key）：来自 SidebarService follow 同步，供「关注」Tab 过滤。
   const [followedKeys, setFollowedKeys] = useState<Set<string>>(new Set())
-  // 最近集合（复合 key）：由本地最近会话（wrapsRef）派生，供「最近」Tab 过滤。
-  // 方案 (b) 下「最近」直接等价于最近会话，不依赖后端 recent 同步。
+  // 最近集合（复合 key）：来自 SidebarService recent 同步（服务端权威「最近访问」），
+  // 供「最近」Tab 过滤，与 ChatSelectorModal 完全对齐；不再由本地会话列表派生。
   const [recentKeys, setRecentKeys] = useState<Set<string>>(new Set())
+  // 最近集合排序权重（复合 key → 后端 timestamp）：「最近」Tab 按其降序，与纪要一致。
+  const [recentOrder, setRecentOrder] = useState<Map<string, number>>(new Map())
   // 授权区状态：开关默认关闭（不勾选，需用户主动打开才走授权），角色默认 reader。
   // 仅在传入 grantOptions 时生效。
   const grantActive = !!grantOptions
@@ -215,11 +218,8 @@ export function useForwardModal(
     const spaceId = WKApp.shared.currentSpaceId
     // 已并入的群 ID（recents 群 + extraGroups 群），用于去重与子区挂回。
     const seenGroupIDs = new Set<string>()
-    // 最近集合：最近会话即「最近」Tab 的作用域，用复合 key 记录（含群/子区/私聊）。
-    const recentKeySet = new Set<string>()
     for (const wrap of wrapsRef.current) {
       channelMapRef.current.set(wrap.channel.channelID, wrap.channel)
-      recentKeySet.add(`${wrap.channel.channelType}::${wrap.channel.channelID}`)
       if (wrap.channel.channelType === ChannelTypeCommunityTopic) {
         threadWraps.push(wrap)
       } else {
@@ -322,7 +322,6 @@ export function useForwardModal(
     }
 
     setConversationItems(items)
-    setRecentKeys(recentKeySet)
   }, [])
 
   useEffect(() => {
@@ -402,16 +401,19 @@ export function useForwardModal(
     }
   }, [rebuildConvItems])
 
-  // 关注集合同步：与智能纪要选择器一致，走 SidebarService follow 同步。
-  // 数据源采用方案 (b)：转发列表主体仍复用本地会话 + group/my + 好友装配
-  // （保证零权限回归、无新后端依赖），仅「关注」Tab 需要额外的关注集合，故
-  // 这里只拉 follow（不拉 recent —— 转发「最近」直接映射本地最近会话/群列表）。
-  // deviceId 为空时后端 validateSidebarRequest 必拒，跳过注定失败的请求，
-  // 关注集合退化为空集（关注 Tab 显示空态）。
+  // 关注 / 最近集合同步：与智能纪要选择器（ChatSelectorModal）完全对齐，均走
+  // SidebarService 服务端权威源——「关注」拉 follow tab，「最近」拉 recent tab
+  // （服务端维护的「最近访问」，而非本地 IM 会话列表）。转发列表主体仍复用本地
+  // 会话 + group/my + 好友装配（零权限回归、无新后端依赖），这两个集合只用于对应
+  // Tab 的作用域过滤：命中集合的本地 item 才展示，故不引入新的可转发目标。
+  // deviceId 为空时后端 validateSidebarRequest 必拒，跳过注定失败的请求，两个集合
+  // 退化为空集（对应 Tab 显示空态）。
   useEffect(() => {
     const deviceUuid = WKApp.shared.deviceId || ""
     if (deviceUuid === "") {
       setFollowedKeys(new Set())
+      setRecentKeys(new Set())
+      setRecentOrder(new Map())
       return
     }
     let cancelled = false
@@ -426,6 +428,25 @@ export function useForwardModal(
       })
       .catch(() => {
         if (!cancelled) setFollowedKeys(new Set())
+      })
+    SidebarService.sync({ tab: "recent", device_uuid: deviceUuid })
+      .then((resp) => {
+        if (cancelled) return
+        const keys = new Set<string>()
+        const order = new Map<string, number>()
+        for (const item of resp?.items ?? []) {
+          const key = `${item.target_type}::${item.target_id}`
+          keys.add(key)
+          order.set(key, item.timestamp)
+        }
+        setRecentKeys(keys)
+        setRecentOrder(order)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRecentKeys(new Set())
+          setRecentOrder(new Map())
+        }
       })
     return () => {
       cancelled = true
@@ -479,7 +500,7 @@ export function useForwardModal(
   // 集合过滤（搜后端全库群不应污染关注/最近作用域），与纪要行为一致。
   const filtered = filterChatSelectorItems(
     allItems,
-    { activeTab, keyword, followedKeys, recentKeys },
+    { activeTab, keyword, followedKeys, recentKeys, recentOrder },
     FORWARD_ITEM_ACCESSORS,
   )
 


### PR DESCRIPTION
## WS-20 消息转发选择群：最近群列表显示不对

### 根因
转发选群弹窗的「最近」Tab 与智能总结选群弹窗（`ChatSelectorModal`）的取数源不一致：

- **智能总结（正确）**：走后端权威源 `SidebarService.sync({ tab: "recent" })`，用返回 items 构建 `recentIds` + `recentOrder`，按后端 `timestamp` 降序。
- **转发（有 bug）**：`recentKeys` 从本地 `WKSDK.conversationManager.conversations`（IM 会话列表）现推，排序走本地会话 timestamp + 置顶加权。

两者的成员、顺序、置顶加权都会偏离，所以「最近」看起来不对。

### 修复
让转发「最近」也走 `SidebarService.sync({ tab: "recent" })`，与 `ChatSelectorModal` 完全对齐：
- `useForwardModal` 同步 effect 同时拉 `follow` 与 `recent`，用 recent items 填 `recentKeys` + `recentOrder`；不再由本地会话派生 recent 集合。
- 共享纯函数 `tabFilter` 新增可选 `recentOrder`，「最近」Tab 按后端 timestamp 降序（省略时保持传入顺序，行为不变）。
- `deviceId` 为空时跳过注定失败的请求，最近集合退化为空集（与关注 Tab 同策略）。

转发列表主体仍复用本地会话 + group/my + 好友装配（零权限回归、无新后端依赖），两个集合只用于对应 Tab 的作用域过滤，不引入新的可转发目标。

### 测试
- `tabFilter.test.ts`：新增 recentOrder 降序 + 缺权重按 0 处理用例。
- `useForwardModal.test.tsx`：默认「最近」Tab 改为断言取自后端 recent 集合（本地会话不再兜底）、deviceId 空时为空、按后端 timestamp 降序。
- 相关 46 项测试全绿；其余失败均为 base 分支既有失败（Claw*/GlobalSearch/PersonaSettings 等），与本改动无关。
