### PR TITLE
fix(loop): re-resolve workspace when octo space changes

### DIFF
--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -13,6 +13,16 @@ function onSpaceChangedBody(src: string): string {
   return end < 0 ? rest : rest.slice(0, end);
 }
 
+// LoopPage's actual re-resolve logic lives in reResolveSpace (shared by the
+// space-changed handler and reactivation). Extract its body for assertions.
+function reResolveSpaceBody(src: string): string {
+  const start = src.search(/const\s+reResolveSpace\s*=/);
+  if (start < 0) return '';
+  const rest = src.slice(start);
+  const end = rest.search(/\n  const\s+\w+\s*=|\n  useEffect\(/);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
 /**
  * Switching octo space must refresh the Personal (我的/运行时) right pane.
  *
@@ -70,8 +80,9 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
     expect(body).toMatch(/selectedWsRef\.current\s*=\s*null/);
     expect(body).toMatch(/machineModeRef\.current\s*=\s*false/);
     expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
-    // Each clear must precede resolveRef.current(...).
-    const resolveIdx = body.search(/resolveRef\.current\(/);
+    // Each clear must precede the resolveRef.current(...) CALL. Anchor on a
+    // statement line (newline + indent) so a comment mention doesn't match.
+    const resolveIdx = body.search(/\n\s*resolveRef\.current\(/);
     expect(resolveIdx).toBeGreaterThan(0);
     expect(body.search(/selectedWsRef\.current\s*=\s*null/)).toBeLessThan(resolveIdx);
     expect(body.search(/machineModeRef\.current\s*=\s*false/)).toBeLessThan(resolveIdx);
@@ -86,6 +97,41 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
     // openTab bails on !workspaceReady; the handler must flip it false during the
     // window so the Skills/runtime tabs cannot open against the old space's scope.
     expect(onSpaceChangedBody(personalPage)).toMatch(/setWorkspaceReady\(\s*false\s*\)/);
+  });
+
+  it('only re-resolves when it is the active menu (no shared-pane fight)', () => {
+    // PersonalPage and LoopPage share the single routeRight and stay mounted; a
+    // backgrounded page must not touch the shared pane/context on space-changed.
+    // PersonalPage re-resolves lazily on reactivation (nav-menu-activated →
+    // resolveRef), so gating out when backgrounded is sufficient.
+    expect(onSpaceChangedBody(personalPage)).toMatch(/WKApp\.currentMenuId\s*!==\s*["']dmpersonal["']/);
+  });
+
+  it('resets private state + drops ready when backgrounded (gated reactivation window)', () => {
+    // The backgrounded branch must NOT clear the shared http context (would wipe
+    // the active page's slug), but must reset its own private state and drop
+    // workspaceReady so the reactivation window is gated (openTab bails) instead
+    // of letting a click write the old space's slug back → 403.
+    const body = onSpaceChangedBody(personalPage);
+    const guardIdx = body.search(/WKApp\.currentMenuId\s*!==\s*["']dmpersonal["']/);
+    expect(guardIdx).toBeGreaterThanOrEqual(0);
+    const afterGuard = body.slice(guardIdx);
+    const bgBranch = afterGuard.slice(0, afterGuard.search(/return;/) + 7);
+    expect(bgBranch).toMatch(/setWorkspaceReady\(\s*false\s*\)/);
+    expect(bgBranch).toMatch(/selectedWsRef\.current\s*=\s*null/);
+    expect(bgBranch).not.toMatch(/setWorkspaceContext\(/);
+  });
+
+  it('resolveAndPaint bails on shared writes when backgrounded', () => {
+    // Any async resolve that lands after the user navigated away must not write
+    // the shared pane/context. resolveAndPaint's .then and .catch re-check the
+    // active menu (after the seq/mounted guard) before touching them.
+    const start = personalPage.search(/const\s+resolveAndPaint\s*=/);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = personalPage.slice(start).search(/\n  const\s+\w+\s*=|\n  useEffect\(/);
+    const body = end < 0 ? personalPage.slice(start) : personalPage.slice(start, start + end);
+    const checks = (body.match(/WKApp\.currentMenuId\s*!==\s*["']dmpersonal["']/g) || []).length;
+    expect(checks).toBeGreaterThanOrEqual(2); // .then and .catch
   });
 });
 
@@ -115,9 +161,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // Clearing setWorkspaceContext("","") first prevents any request during the
     // re-list window from carrying the old space's workspace slug (which would
     // hit the backend isolation gate). It must precede listWorkspaces().
-    const handlerIdx = loopPage.search(/const\s+onSpaceChanged\s*=/);
-    expect(handlerIdx).toBeGreaterThanOrEqual(0);
-    const body = onSpaceChangedBody(loopPage);
+    const body = reResolveSpaceBody(loopPage);
     expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
     expect(body).toMatch(/listWorkspaces\(/);
     expect(body.search(/setWorkspaceContext\(\s*["']["']/)).toBeLessThan(body.search(/listWorkspaces\(/));
@@ -127,10 +171,28 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // Fast consecutive space switches race their listWorkspaces() responses; a
     // stale one landing last would write the old slug back and re-trigger 403.
     // Only the latest resolve may apply — assert a seq/generation guard exists.
-    const body = onSpaceChangedBody(loopPage);
+    const body = reResolveSpaceBody(loopPage);
     expect(body).toMatch(/spaceResolveSeqRef/);
     // The .then must bail when its captured seq is no longer current.
     expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
+  });
+
+  it('only re-resolves when it is the active menu; defers when backgrounded', () => {
+    // Both LoopPage and PersonalPage write the single shared routeRight and stay
+    // mounted. The space-changed handler must not repaint the pane when the page
+    // is backgrounded (that clobbers the active page); it flags a pending
+    // re-resolve that reactivation consumes.
+    const body = onSpaceChangedBody(loopPage);
+    expect(body).toMatch(/WKApp\.currentMenuId\s*!==\s*["']loop["']/);
+    expect(body).toMatch(/pendingSpaceReresolveRef\.current\s*=\s*true/);
+    // Reactivation (nav-menu-activated) consumes the pending flag and re-resolves.
+    expect(loopPage).toMatch(/if\s*\(\s*pendingSpaceReresolveRef\.current\s*\)/);
+    // The resolve callbacks re-check the active menu before writing the shared
+    // pane/context — an in-flight resolve that lands after navigating away must
+    // defer (set pending) instead of clobbering the now-active page.
+    const rr = reResolveSpaceBody(loopPage);
+    const menuChecks = (rr.match(/WKApp\.currentMenuId\s*!==\s*["']loop["']/g) || []).length;
+    expect(menuChecks).toBeGreaterThanOrEqual(2); // .then and .catch
   });
 
   it('renders the current tab (not a frozen mount-time tab) after re-resolve', () => {
@@ -170,9 +232,9 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
   });
 
   it('unmounts the stale right pane during the re-resolve window', () => {
-    // The previous space's IssuePage keeps polling until unmounted; onSpaceChanged
-    // must replace the right pane before awaiting the new resolve.
-    const body = onSpaceChangedBody(loopPage);
+    // The previous space's IssuePage keeps polling until unmounted; the resolve
+    // must replace the right pane before awaiting the new list.
+    const body = reResolveSpaceBody(loopPage);
     expect(body).toMatch(/routeRight\.replaceToRoot/);
     expect(body.search(/routeRight\.replaceToRoot/)).toBeLessThan(body.search(/listWorkspaces\(/));
   });
@@ -191,6 +253,9 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     expect(body).toMatch(/const\s+seq\s*=\s*spaceResolveSeqRef\.current/); // capture
     expect(body).not.toMatch(/\+\+\s*spaceResolveSeqRef\.current/);        // never bump
     expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);             // still guarded
+    // And it must also bail on shared writes if navigated away mid-create
+    // (no space-changed → seq unchanged, so the seq guard alone is insufficient).
+    expect(body).toMatch(/WKApp\.currentMenuId\s*!==\s*["']loop["']/);
   });
 
   it('gates workspace-create entry on !loaded and closes modals on space switch', () => {
@@ -199,7 +264,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // page is re-resolving a new space.
     const openBody = loopPage.slice(loopPage.search(/const\s+openCreateWs\s*=/), loopPage.search(/const\s+openCreateWs\s*=/) + 160);
     expect(openBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
-    const onSpaceBody = onSpaceChangedBody(loopPage);
+    const onSpaceBody = reResolveSpaceBody(loopPage);
     expect(onSpaceBody).toMatch(/setWsModalOpen\(\s*false\s*\)/);
   });
 

--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -177,15 +177,30 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     expect(body.search(/routeRight\.replaceToRoot/)).toBeLessThan(body.search(/listWorkspaces\(/));
   });
 
-  it('guards doCreateWs against a space switch mid-create', () => {
-    // Creating a workspace writes workspace context after awaits; a space switch
-    // during creation must drop that stale write (same generation guard).
+  it('guards doCreateWs against a space switch mid-create without wedging loaded', () => {
+    // doCreateWs writes workspace context after awaits, so it must drop that
+    // write when a space switch happened during creation. It CAPTURES the
+    // generation (does not bump it): bumping would invalidate onSpaceChanged's
+    // own resolve, whose .then/.catch are the only paths that restore loaded —
+    // leaving the page stuck !loaded. So: a stale-seq guard must exist, but no
+    // ++ bump inside doCreateWs.
     const start = loopPage.search(/const\s+doCreateWs\s*=/);
     expect(start).toBeGreaterThanOrEqual(0);
     const end = loopPage.slice(start).search(/\n  const\s+\w+\s*=/);
     const body = end < 0 ? loopPage.slice(start) : loopPage.slice(start, start + end);
-    expect(body).toMatch(/\+\+\s*spaceResolveSeqRef\.current/);
-    expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
+    expect(body).toMatch(/const\s+seq\s*=\s*spaceResolveSeqRef\.current/); // capture
+    expect(body).not.toMatch(/\+\+\s*spaceResolveSeqRef\.current/);        // never bump
+    expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);             // still guarded
+  });
+
+  it('gates workspace-create entry on !loaded and closes modals on space switch', () => {
+    // Create entry must be blocked during the re-resolve window, and any open
+    // create modal must close on space-changed, so no create can land while the
+    // page is re-resolving a new space.
+    const openBody = loopPage.slice(loopPage.search(/const\s+openCreateWs\s*=/), loopPage.search(/const\s+openCreateWs\s*=/) + 160);
+    expect(openBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
+    const onSpaceBody = onSpaceChangedBody(loopPage);
+    expect(onSpaceBody).toMatch(/setWsModalOpen\(\s*false\s*\)/);
   });
 
   it('clears the workspace list on a failed re-resolve (no stale clickable dropdown)', () => {

--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -187,6 +187,21 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     expect(body).toMatch(/\+\+\s*spaceResolveSeqRef\.current/);
     expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
   });
+
+  it('clears the workspace list on a failed re-resolve (no stale clickable dropdown)', () => {
+    // showEmptyGuide only repaints the right pane; without setWorkspaces([]) in
+    // the .catch branches, a failed listWorkspaces() during a space switch leaves
+    // the old space's workspaces in the switcher dropdown — re-enabled by
+    // setLoaded(true) and still clickable → switchWorkspace binds an old-space
+    // slug under the new space → cross-space 403. Both resolve paths (mount +
+    // space-changed) must clear the list on error.
+    const catchBlocks = loopPage.match(/\.catch\(\(\)\s*=>\s*\{[\s\S]*?\}\)/g) || [];
+    const resolveCatches = catchBlocks.filter((b) => b.includes('showEmptyGuide'));
+    expect(resolveCatches.length).toBeGreaterThanOrEqual(2);
+    for (const b of resolveCatches) {
+      expect(b).toMatch(/setWorkspaces\(\s*\[\s*\]\s*\)/);
+    }
+  });
 });
 
 /**

--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -1,0 +1,154 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Switching octo space must refresh the Personal (我的/运行时) right pane.
+ *
+ * PersonalPage keeps a page-local workspace selection (selectedWsRef +
+ * @octo/loop's module-level workspace globals). When the user switches octo
+ * space, MainPage emits mittBus('space-changed'), but the page previously only
+ * re-resolved on mount and on 'wk:nav-menu-activated'. So after a space switch
+ * the pane kept the PREVIOUS space's workspace context and issued
+ * workspace-scoped requests against the new space — the backend space-isolation
+ * gate then rejected them ("workspace does not belong to this space" /
+ * "not a member of this space") instead of the page showing the correct empty
+ * (machine-mode) state with an "add computer" prompt.
+ *
+ * resolveAndPaint already handles the new space correctly: it re-lists
+ * workspaces and, when the new space has none, falls into machine mode
+ * (clears the workspace scope, lists /machine-runtimes, disables Skills). The
+ * fix is simply to trigger that re-resolution on 'space-changed' too.
+ */
+describe('PersonalPage — re-resolve workspace on space switch', () => {
+  let personalPage: string;
+
+  beforeAll(() => {
+    personalPage = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmpersonal/src/PersonalPage.tsx'),
+      'utf-8',
+    );
+  });
+
+  it('subscribes to the space-changed mittBus event', () => {
+    expect(personalPage).toMatch(/mittBus\.on\(\s*["']space-changed["']/);
+  });
+
+  it('re-resolves the workspace selection when space-changed fires', () => {
+    // The space-changed handler must call resolveRef.current(...) so the pane
+    // re-lists workspaces for the new space (and falls into machine mode when
+    // the new space has none), rather than reusing the old space's workspace.
+    // Anchor on the handler declaration, then assert the body re-resolves.
+    const handlerIdx = personalPage.search(/const\s+onSpaceChanged\s*=/);
+    expect(handlerIdx).toBeGreaterThanOrEqual(0);
+    expect(personalPage.slice(handlerIdx, handlerIdx + 400)).toMatch(/resolveRef\.current\(/);
+  });
+
+  it('resets all three workspace states before re-resolving', () => {
+    // The three workspace states are separate and must all be cleared, or a tab
+    // click during the re-resolve loading window re-issues a request with the
+    // previous space's workspace scope and hits the backend isolation gate (403):
+    //  - selectedWsRef (page-local, preferred over the shared global)
+    //  - machineModeRef (drives openTab's branch)
+    //  - setWorkspaceContext("","") (@octo/loop http-layer module-level slug/id)
+    // They must also come BEFORE the re-resolve call — moving the re-resolve
+    // ahead of the clears would reopen the bug, so assert order too.
+    const handlerIdx = personalPage.search(/const\s+onSpaceChanged\s*=/);
+    expect(handlerIdx).toBeGreaterThanOrEqual(0);
+    const body = personalPage.slice(handlerIdx, handlerIdx + 400);
+    expect(body).toMatch(/selectedWsRef\.current\s*=\s*null/);
+    expect(body).toMatch(/machineModeRef\.current\s*=\s*false/);
+    expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
+    // Each clear must precede resolveRef.current(...).
+    const resolveIdx = body.search(/resolveRef\.current\(/);
+    expect(resolveIdx).toBeGreaterThan(0);
+    expect(body.search(/selectedWsRef\.current\s*=\s*null/)).toBeLessThan(resolveIdx);
+    expect(body.search(/machineModeRef\.current\s*=\s*false/)).toBeLessThan(resolveIdx);
+    expect(body.search(/setWorkspaceContext\(\s*["']["']/)).toBeLessThan(resolveIdx);
+  });
+
+  it('unsubscribes the space-changed handler on cleanup', () => {
+    expect(personalPage).toMatch(/mittBus\.off\(\s*["']space-changed["']/);
+  });
+});
+
+/**
+ * LoopPage (回路) has the SAME root cause as PersonalPage: it only re-lists
+ * workspaces on mount (deps []) and on 'wk:nav-menu-activated', not on
+ * 'space-changed'. After switching octo space the 回路 page kept the previous
+ * space's wsId + @octo/loop http-layer workspace slug and issued
+ * workspace-scoped requests against the new space, producing the stacked
+ * "加载失败" toasts. It must also re-resolve on 'space-changed'.
+ */
+describe('LoopPage — re-resolve workspace on space switch', () => {
+  let loopPage: string;
+
+  beforeAll(() => {
+    loopPage = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmloop/src/pages/LoopPage.tsx'),
+      'utf-8',
+    );
+  });
+
+  it('subscribes to the space-changed mittBus event', () => {
+    expect(loopPage).toMatch(/mittBus\.on\(\s*["']space-changed["']/);
+  });
+
+  it('clears the http-layer workspace scope before re-listing', () => {
+    // Clearing setWorkspaceContext("","") first prevents any request during the
+    // re-list window from carrying the old space's workspace slug (which would
+    // hit the backend isolation gate). It must precede listWorkspaces().
+    const handlerIdx = loopPage.search(/const\s+onSpaceChanged\s*=/);
+    expect(handlerIdx).toBeGreaterThanOrEqual(0);
+    const body = loopPage.slice(handlerIdx, handlerIdx + 600);
+    expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
+    expect(body).toMatch(/listWorkspaces\(/);
+    expect(body.search(/setWorkspaceContext\(\s*["']["']/)).toBeLessThan(body.search(/listWorkspaces\(/));
+  });
+
+  it('guards the re-resolve against out-of-order responses (seq guard)', () => {
+    // Fast consecutive space switches race their listWorkspaces() responses; a
+    // stale one landing last would write the old slug back and re-trigger 403.
+    // Only the latest resolve may apply — assert a seq/generation guard exists.
+    const handlerIdx = loopPage.search(/const\s+onSpaceChanged\s*=/);
+    const body = loopPage.slice(handlerIdx, handlerIdx + 600);
+    expect(body).toMatch(/spaceResolveSeqRef/);
+    // The .then must bail when its captured seq is no longer current.
+    expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
+  });
+
+  it('renders the current tab (not a frozen mount-time tab) after re-resolve', () => {
+    // applyWorkspace runs from a mount-once (deps []) handler; it must read the
+    // live tab via a ref, else switching space while on a non-issue tab paints
+    // the wrong pane. Assert applyWorkspace renders via tabRef, not closure tab.
+    expect(loopPage).toMatch(/renderTab\(\s*tabRef\.current/);
+  });
+
+  it('guards the mount initial resolve with the same seq (cross-entry race)', () => {
+    // If the mount listWorkspaces is still in flight when the user switches
+    // space, the stale mount response must be discarded too — otherwise it
+    // writes the old space's slug back and re-triggers 403. The mount effect
+    // must join the same spaceResolveSeqRef domain.
+    // Both the mount effect and the space-changed handler bump the seq...
+    const bumps = loopPage.match(/\+\+\s*spaceResolveSeqRef\.current/g) || [];
+    expect(bumps.length).toBeGreaterThanOrEqual(2);
+    // ...and there must be at least two guarded bail-outs (mount + space-changed).
+    const guards = loopPage.match(/!==\s*spaceResolveSeqRef\.current/g) || [];
+    expect(guards.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('gates the click entries during the re-resolve window (!loaded)', () => {
+    // setLoaded(false) alone only gates wk:nav-menu-activated. The direct click
+    // entries (openTab / switchWorkspace / openNewLoop) must also bail while the
+    // window is open, or a click there uses the old space's workspaces/slug.
+    const openTabBody = loopPage.slice(loopPage.search(/const\s+openTab\s*=/), loopPage.search(/const\s+openTab\s*=/) + 200);
+    expect(openTabBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
+    const switchBody = loopPage.slice(loopPage.search(/const\s+switchWorkspace\s*=/), loopPage.search(/const\s+switchWorkspace\s*=/) + 200);
+    expect(switchBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
+    const newLoopBody = loopPage.slice(loopPage.search(/const\s+openNewLoop\s*=/), loopPage.search(/const\s+openNewLoop\s*=/) + 120);
+    expect(newLoopBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
+  });
+
+  it('unsubscribes the space-changed handler on cleanup', () => {
+    expect(loopPage).toMatch(/mittBus\.off\(\s*["']space-changed["']/);
+  });
+});

--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -1,6 +1,18 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+// Extract the body of the space-changed handler: from `const onSpaceChanged =`
+// up to the `mittBus.on("space-changed"` registration that follows it. Bounding
+// on the registration line (not a fixed char window) keeps these assertions
+// stable as the handler grows with comments/guards.
+function onSpaceChangedBody(src: string): string {
+  const start = src.search(/const\s+onSpaceChanged\s*=/);
+  if (start < 0) return '';
+  const rest = src.slice(start);
+  const end = rest.search(/mittBus\.on\(\s*["']space-changed["']/);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
 /**
  * Switching octo space must refresh the Personal (我的/运行时) right pane.
  *
@@ -40,7 +52,7 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
     // Anchor on the handler declaration, then assert the body re-resolves.
     const handlerIdx = personalPage.search(/const\s+onSpaceChanged\s*=/);
     expect(handlerIdx).toBeGreaterThanOrEqual(0);
-    expect(personalPage.slice(handlerIdx, handlerIdx + 400)).toMatch(/resolveRef\.current\(/);
+    expect(onSpaceChangedBody(personalPage)).toMatch(/resolveRef\.current\(/);
   });
 
   it('resets all three workspace states before re-resolving', () => {
@@ -54,7 +66,7 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
     // ahead of the clears would reopen the bug, so assert order too.
     const handlerIdx = personalPage.search(/const\s+onSpaceChanged\s*=/);
     expect(handlerIdx).toBeGreaterThanOrEqual(0);
-    const body = personalPage.slice(handlerIdx, handlerIdx + 400);
+    const body = onSpaceChangedBody(personalPage);
     expect(body).toMatch(/selectedWsRef\.current\s*=\s*null/);
     expect(body).toMatch(/machineModeRef\.current\s*=\s*false/);
     expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
@@ -68,6 +80,12 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
 
   it('unsubscribes the space-changed handler on cleanup', () => {
     expect(personalPage).toMatch(/mittBus\.off\(\s*["']space-changed["']/);
+  });
+
+  it('gates the re-resolve window by marking workspace not-ready', () => {
+    // openTab bails on !workspaceReady; the handler must flip it false during the
+    // window so the Skills/runtime tabs cannot open against the old space's scope.
+    expect(onSpaceChangedBody(personalPage)).toMatch(/setWorkspaceReady\(\s*false\s*\)/);
   });
 });
 
@@ -99,7 +117,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // hit the backend isolation gate). It must precede listWorkspaces().
     const handlerIdx = loopPage.search(/const\s+onSpaceChanged\s*=/);
     expect(handlerIdx).toBeGreaterThanOrEqual(0);
-    const body = loopPage.slice(handlerIdx, handlerIdx + 600);
+    const body = onSpaceChangedBody(loopPage);
     expect(body).toMatch(/setWorkspaceContext\(\s*["']["']\s*,\s*["']["']\s*\)/);
     expect(body).toMatch(/listWorkspaces\(/);
     expect(body.search(/setWorkspaceContext\(\s*["']["']/)).toBeLessThan(body.search(/listWorkspaces\(/));
@@ -109,8 +127,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // Fast consecutive space switches race their listWorkspaces() responses; a
     // stale one landing last would write the old slug back and re-trigger 403.
     // Only the latest resolve may apply — assert a seq/generation guard exists.
-    const handlerIdx = loopPage.search(/const\s+onSpaceChanged\s*=/);
-    const body = loopPage.slice(handlerIdx, handlerIdx + 600);
+    const body = onSpaceChangedBody(loopPage);
     expect(body).toMatch(/spaceResolveSeqRef/);
     // The .then must bail when its captured seq is no longer current.
     expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
@@ -150,5 +167,45 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
 
   it('unsubscribes the space-changed handler on cleanup', () => {
     expect(loopPage).toMatch(/mittBus\.off\(\s*["']space-changed["']/);
+  });
+
+  it('unmounts the stale right pane during the re-resolve window', () => {
+    // The previous space's IssuePage keeps polling until unmounted; onSpaceChanged
+    // must replace the right pane before awaiting the new resolve.
+    const body = onSpaceChangedBody(loopPage);
+    expect(body).toMatch(/routeRight\.replaceToRoot/);
+    expect(body.search(/routeRight\.replaceToRoot/)).toBeLessThan(body.search(/listWorkspaces\(/));
+  });
+
+  it('guards doCreateWs against a space switch mid-create', () => {
+    // Creating a workspace writes workspace context after awaits; a space switch
+    // during creation must drop that stale write (same generation guard).
+    const start = loopPage.search(/const\s+doCreateWs\s*=/);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = loopPage.slice(start).search(/\n  const\s+\w+\s*=/);
+    const body = end < 0 ? loopPage.slice(start) : loopPage.slice(start, start + end);
+    expect(body).toMatch(/\+\+\s*spaceResolveSeqRef\.current/);
+    expect(body).toMatch(/!==\s*spaceResolveSeqRef\.current/);
+  });
+});
+
+/**
+ * The agent runtime picker must not offer runtimes the CreateAgent write would
+ * reject. Backend canBindRuntimeAsOwner is owner-only; the list endpoint now
+ * returns can_bind per runtime, and the picker filters on it (forward-compat:
+ * undefined from an older backend is kept, so the picker never goes empty).
+ */
+describe('AgentPage — runtime picker filters to bindable runtimes', () => {
+  let agentPage: string;
+
+  beforeAll(() => {
+    agentPage = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmloop/src/pages/AgentPage.tsx'),
+      'utf-8',
+    );
+  });
+
+  it('drops runtimes explicitly marked can_bind === false', () => {
+    expect(agentPage).toMatch(/can_bind\s*!==\s*false/);
   });
 });

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -629,6 +629,11 @@ export interface RuntimeDevice {
   metadata?: Record<string, unknown>;
   owner_id?: string | null;
   visibility: string;
+  // can_bind: whether the current member may bind an agent to this runtime as
+  // owner (owner-only, matches backend canBindRuntimeAsOwner). Set on the
+  // visibility-scoped /runtimes list. Optional for forward-compat: absent from
+  // older backends, in which case the picker shows the runtime (no regression).
+  can_bind?: boolean;
   profile_id?: string | null;
   last_seen_at: string | null;
   created_at: string;

--- a/packages/dmloop/src/pages/AgentPage.tsx
+++ b/packages/dmloop/src/pages/AgentPage.tsx
@@ -69,7 +69,19 @@ export default function AgentPage() {
 
   const openCreate = () => {
     setCreateOpen(true);
-    listRuntimesForAgent().then((rs) => { setRuntimes(rs); if (rs[0]) setNRuntimeId(rs[0].id); }).catch(() => setRuntimes([]));
+    // Only bindable runtimes (owner-only, per backend canBindRuntimeAsOwner):
+    // can_bind === false is hidden; undefined (older backend) is kept so the
+    // picker never goes empty on a backend that predates the flag.
+    listRuntimesForAgent()
+      .then((rs) => {
+        const bindable = rs.filter((r) => r.can_bind !== false);
+        setRuntimes(bindable);
+        // Always resync the selection to the filtered list — else a stale
+        // nRuntimeId from a previous open could be submitted and 403 on the
+        // owner-only bind. Empty when nothing is bindable (doCreate then warns).
+        setNRuntimeId(bindable[0]?.id ?? "");
+      })
+      .catch(() => { setRuntimes([]); setNRuntimeId(""); });
   };
 
   const doCreate = async () => {

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -144,6 +144,10 @@ export default function LoopPage() {
       .catch(() => {
         if (seq !== spaceResolveSeqRef.current) return;
         setLoaded(true);
+        // Clear the switcher list on a failed resolve: showEmptyGuide only
+        // repaints the right pane, so without this the dropdown would keep the
+        // previous list, re-enabled by setLoaded(true) and clickable.
+        setWorkspaces([]);
         showEmptyGuide();
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -201,6 +205,11 @@ export default function LoopPage() {
         .catch(() => {
           if (seq !== spaceResolveSeqRef.current) return;
           setLoaded(true);
+          // Clear the stale old-space list on a failed re-resolve — otherwise the
+          // switcher dropdown keeps the previous space's workspaces, re-enabled by
+          // setLoaded(true) and clickable, so switchWorkspace would bind an
+          // old-space slug under the new space's X-Space-Id → cross-space 403.
+          setWorkspaces([]);
           showEmptyGuide();
         });
     };

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Typography, Dropdown, Avatar, Modal, Toast } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import {
@@ -61,6 +61,14 @@ export default function LoopPage() {
   const [wsBusy, setWsBusy] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
 
+  // tab 的同步镜像:mount-once 的 space-changed 副作用闭包(deps=[])会冻结当时的 tab,
+  // 用 ref 让 applyWorkspace 始终读到最新 tab,避免切 space 后右栏恒被铺成初始 issue。
+  const tabRef = useRef<TabKey>("issue");
+  tabRef.current = tab;
+  // space-changed 重解析的过期守卫:快速连切 space 时并发的 listWorkspaces 可能乱序返回,
+  // 只有最后一次解析允许写回 workspace context,否则慢的旧响应会把旧 slug 落回、撞新 space 的 403。
+  const spaceResolveSeqRef = useRef(0);
+
   const findWs = (list: Workspace[], id: string) => list.find((w) => w.id === id) ?? null;
 
   const renderTab = (key: TabKey, ws: Workspace | null): JSX.Element => {
@@ -80,12 +88,15 @@ export default function LoopPage() {
   };
 
   const openTab = (key: TabKey) => {
+    // 重解析窗口期(切 space 后 loaded=false 直到新 space 的 workspace 解析完成)不响应:
+    // 此时 workspaces/wsId 尚属旧 space,点击会用旧作用域渲染 workspace 级页面。
+    if (!loaded) return;
     setTab(key);
     WKApp.routeRight.replaceToRoot(renderTab(key, findWs(workspaces, wsId)));
   };
 
   // 新建回路 → 唤起统一建单弹窗（对齐 multica，不再拉起独立 AI 页）。成功后落回路看板并刷新。
-  const openNewLoop = () => setCreateOpen(true);
+  const openNewLoop = () => { if (!loaded) return; setCreateOpen(true); };
 
   // 空态引导：无 workspace 时右栏提示创建
   const showEmptyGuide = () => {
@@ -103,7 +114,7 @@ export default function LoopPage() {
       setWorkspaceContext(ws.slug, ws.id, ws.name);
       setWsId(ws.id);
       resetWorkspaceCaches();
-      WKApp.routeRight.replaceToRoot(renderTab(tab, ws));
+      WKApp.routeRight.replaceToRoot(renderTab(tabRef.current, ws));
     } else {
       setWorkspaceContext("", "");
       setWsId("");
@@ -119,13 +130,22 @@ export default function LoopPage() {
   };
 
   useEffect(() => {
+    // mount 初始解析也纳入 spaceResolveSeqRef 域:若初始 listWorkspaces 尚未返回、
+    // 用户就切了 space,space-changed 会递增 seq 使这次 mount 响应过期被丢弃,避免旧 space
+    // 的 workspace slug 被写回 http 层、撞新 space 的隔离 403(与 space-changed 共享守卫)。
+    const seq = ++spaceResolveSeqRef.current;
     listWorkspaces()
       .then((list) => {
+        if (seq !== spaceResolveSeqRef.current) return;
         setLoaded(true);
         const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
         applyWorkspace(first, list);
       })
-      .catch(() => { setLoaded(true); showEmptyGuide(); });
+      .catch(() => {
+        if (seq !== spaceResolveSeqRef.current) return;
+        setLoaded(true);
+        showEmptyGuide();
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -150,11 +170,48 @@ export default function LoopPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaces, wsId, loaded]);
 
+  // 切换 octo space 时,当前 wsId + @octo/loop 模块级 workspace 全局属于上一个 space,
+  // 必须作废重判 —— 否则会带旧 workspace 作用域向新 space 发 workspace 维度请求,撞后端
+  // space 隔离闸门(workspace does not belong to this space / not a member of this space)。
+  // 先 setWorkspaceContext("","") 清 http 层旧 slug,避免重列期间任何请求带旧作用域;再重新
+  // listWorkspaces 并铺新 space 的默认 workspace,新 space 无 workspace 时 applyWorkspace(null)
+  // 自然落入空态引导(showEmptyGuide)。
+  useEffect(() => {
+    const onSpaceChanged = () => {
+      const seq = ++spaceResolveSeqRef.current;
+      setWorkspaceContext("", "");
+      setWsId("");
+      // setLoaded(false):重解析窗口期把页面标回"未加载",wk:nav-menu-activated 的
+      // `if (!loaded) return` 守卫随之生效,避免窗口期用旧 workspaces 闭包渲染 workspace 级页面。
+      setLoaded(false);
+      resetWorkspaceCaches();
+      listWorkspaces()
+        .then((list) => {
+          // 过期守卫:快速连切 space 时只让最后一次解析落地,丢弃乱序返回的旧响应,
+          // 否则旧响应的 applyWorkspace 会把旧 slug 落回 http 层、撞新 space 的隔离 403。
+          if (seq !== spaceResolveSeqRef.current) return;
+          setLoaded(true);
+          const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
+          applyWorkspace(first, list);
+        })
+        .catch(() => {
+          if (seq !== spaceResolveSeqRef.current) return;
+          setLoaded(true);
+          showEmptyGuide();
+        });
+    };
+    WKApp.mittBus.on("space-changed", onSpaceChanged);
+    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const switchWorkspace = (w: Workspace) => {
+    // 重解析窗口期不响应:下拉里的 w 属于旧 space 的 workspaces,选它会把旧 slug 写回。
+    if (!loaded) return;
     setWorkspaceContext(w.slug, w.id, w.name);
     setWsId(w.id);
     resetWorkspaceCaches();
-    WKApp.routeRight.replaceToRoot(renderTab(tab, w));
+    WKApp.routeRight.replaceToRoot(renderTab(tabRef.current, w));
   };
 
   const openCreateWs = () => {

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -185,6 +185,10 @@ export default function LoopPage() {
       // `if (!loaded) return` 守卫随之生效,避免窗口期用旧 workspaces 闭包渲染 workspace 级页面。
       setLoaded(false);
       resetWorkspaceCaches();
+      // Unmount the stale right pane immediately so the previous space's
+      // IssuePage (and its polling / create entry) stops firing requests during
+      // the re-resolve window; applyWorkspace repaints once the new space resolves.
+      WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
       listWorkspaces()
         .then((list) => {
           // 过期守卫:快速连切 space 时只让最后一次解析落地,丢弃乱序返回的旧响应,
@@ -223,6 +227,12 @@ export default function LoopPage() {
     const autoSlug = !wsSlugTouched;
     let slug = wsSlug.trim() || withRandomSuffix(getPinyin(name), wsSlugSuffix);
     if (!slug) { Toast.warning(t("loop.workspace.slugRequired")); return; }
+    // Join the resolve generation: creating a workspace writes workspace context
+    // after awaits, so if the user switches octo space mid-create, the space-changed
+    // handler bumps the seq and the post-await applyWorkspace below is dropped —
+    // otherwise it would write this space's workspace slug under the new space's
+    // X-Space-Id and re-trigger the isolation 403.
+    const seq = ++spaceResolveSeqRef.current;
     setWsBusy(true);
     try {
       // auto slug re-rolls its random suffix on the backend's 409 (slug is
@@ -230,9 +240,15 @@ export default function LoopPage() {
       // slug is surfaced as taken, never silently changed.
       for (let attempt = 0; attempt < 3; attempt++) {
         try {
+          // Re-check before each create so a space switch during a 409 retry
+          // doesn't create a stray workspace in the newly-selected space.
+          if (seq !== spaceResolveSeqRef.current) return;
           const created = await createWorkspace({ name, slug });
           setWsModalOpen(false);
           const list = await reloadWorkspaces();
+          // A space switch during creation invalidates this write; the
+          // space-changed resolve owns the pane now.
+          if (seq !== spaceResolveSeqRef.current) return;
           applyWorkspace(findWs(list, created.id) ?? created, list);
           setTab("issue");
           WKApp.routeRight.replaceToRoot(<IssuePage viewKey="loop.view.issue" />);

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -185,6 +185,10 @@ export default function LoopPage() {
       const seq = ++spaceResolveSeqRef.current;
       setWorkspaceContext("", "");
       setWsId("");
+      // Close any open create modals so a submit cannot land during the
+      // re-resolve window and write a workspace under the wrong space.
+      setWsModalOpen(false);
+      setCreateOpen(false);
       // setLoaded(false):重解析窗口期把页面标回"未加载",wk:nav-menu-activated 的
       // `if (!loaded) return` 守卫随之生效,避免窗口期用旧 workspaces 闭包渲染 workspace 级页面。
       setLoaded(false);
@@ -228,6 +232,7 @@ export default function LoopPage() {
   };
 
   const openCreateWs = () => {
+    if (!loaded) return;
     setWsName(""); setWsSlug(""); setWsSlugTouched(false); setWsSlugSuffix(slugSuffix()); setWsModalOpen(true);
   };
   const doCreateWs = async () => {
@@ -236,12 +241,15 @@ export default function LoopPage() {
     const autoSlug = !wsSlugTouched;
     let slug = wsSlug.trim() || withRandomSuffix(getPinyin(name), wsSlugSuffix);
     if (!slug) { Toast.warning(t("loop.workspace.slugRequired")); return; }
-    // Join the resolve generation: creating a workspace writes workspace context
-    // after awaits, so if the user switches octo space mid-create, the space-changed
-    // handler bumps the seq and the post-await applyWorkspace below is dropped —
-    // otherwise it would write this space's workspace slug under the new space's
-    // X-Space-Id and re-trigger the isolation 403.
-    const seq = ++spaceResolveSeqRef.current;
+    // Capture (do NOT bump) the resolve generation: creating a workspace writes
+    // workspace context after awaits, so if the user switches octo space
+    // mid-create, space-changed bumps the seq and the post-await applyWorkspace
+    // below is dropped (would otherwise bind this space's slug under the new
+    // space's X-Space-Id → isolation 403). Capturing rather than bumping is
+    // deliberate: onSpaceChanged owns `loaded` restoration through its own
+    // generation, and a create must not invalidate that resolve (else `loaded`
+    // could stay false forever, wedging the page).
+    const seq = spaceResolveSeqRef.current;
     setWsBusy(true);
     try {
       // auto slug re-rolls its random suffix on the backend's 409 (slug is

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -68,6 +68,11 @@ export default function LoopPage() {
   // space-changed 重解析的过期守卫:快速连切 space 时并发的 listWorkspaces 可能乱序返回,
   // 只有最后一次解析允许写回 workspace context,否则慢的旧响应会把旧 slug 落回、撞新 space 的 403。
   const spaceResolveSeqRef = useRef(0);
+  // Set when a space change arrives while LoopPage is backgrounded (its
+  // space-changed handler is gated to the active menu). On reactivation the
+  // nav-menu-activated handler consumes it to force a fresh re-resolve instead
+  // of painting the stale old-space workspaces/wsId it still holds in state.
+  const pendingSpaceReresolveRef = useRef(false);
 
   const findWs = (list: Workspace[], id: string) => list.find((w) => w.id === id) ?? null;
 
@@ -129,6 +134,52 @@ export default function LoopPage() {
     return list;
   };
 
+  // Re-resolve the workspace scope for the current octo space: clear the old
+  // scope, unmount the stale right pane, re-list, and repaint. Shared by the
+  // space-changed handler (when LoopPage is active) and by reactivation
+  // (nav-menu-activated) when a space change happened while it was backgrounded.
+  const reResolveSpace = () => {
+    const seq = ++spaceResolveSeqRef.current;
+    setWorkspaceContext("", "");
+    setWsId("");
+    // Close any open create modals so a submit cannot land during the
+    // re-resolve window and write a workspace under the wrong space.
+    setWsModalOpen(false);
+    setCreateOpen(false);
+    // setLoaded(false): mark not-ready for the re-resolve window so the
+    // wk:nav-menu-activated `if (!loaded) return` guard holds and no entry uses
+    // the old space's workspaces closure.
+    setLoaded(false);
+    resetWorkspaceCaches();
+    // Unmount the stale right pane immediately so the previous space's IssuePage
+    // (and its polling / create entry) stops firing during the re-resolve window.
+    WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
+    listWorkspaces()
+      .then((list) => {
+        // Out-of-order guard: only the latest resolve applies, dropping a stale
+        // response that would write the old slug back and hit the new space's 403.
+        if (seq !== spaceResolveSeqRef.current) return;
+        // If the user navigated away while this resolve was in flight, do NOT
+        // write the shared pane/context (would clobber the now-active page).
+        // Defer to reactivation instead.
+        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
+        setLoaded(true);
+        const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
+        applyWorkspace(first, list);
+      })
+      .catch(() => {
+        if (seq !== spaceResolveSeqRef.current) return;
+        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
+        setLoaded(true);
+        // Clear the stale old-space list on a failed re-resolve — otherwise the
+        // switcher dropdown keeps the previous space's workspaces, re-enabled by
+        // setLoaded(true) and clickable, so switchWorkspace would bind an
+        // old-space slug under the new space's X-Space-Id → cross-space 403.
+        setWorkspaces([]);
+        showEmptyGuide();
+      });
+  };
+
   useEffect(() => {
     // mount 初始解析也纳入 spaceResolveSeqRef 域:若初始 listWorkspaces 尚未返回、
     // 用户就切了 space,space-changed 会递增 seq 使这次 mount 响应过期被丢弃,避免旧 space
@@ -137,12 +188,16 @@ export default function LoopPage() {
     listWorkspaces()
       .then((list) => {
         if (seq !== spaceResolveSeqRef.current) return;
+        // If the page was backgrounded before this mount resolve landed, don't
+        // write the shared pane/context; defer to reactivation.
+        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
         setLoaded(true);
         const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
         applyWorkspace(first, list);
       })
       .catch(() => {
         if (seq !== spaceResolveSeqRef.current) return;
+        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
         setLoaded(true);
         // Clear the switcher list on a failed resolve: showEmptyGuide only
         // repaints the right pane, so without this the dropdown would keep the
@@ -159,6 +214,14 @@ export default function LoopPage() {
   useEffect(() => {
     const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
       if (menuId !== "loop") return;
+      // A space change arrived while this page was backgrounded: its handler was
+      // deferred, so state still holds the old space. Force a fresh re-resolve
+      // instead of painting stale workspaces/wsId.
+      if (pendingSpaceReresolveRef.current) {
+        pendingSpaceReresolveRef.current = false;
+        reResolveSpace();
+        return;
+      }
       // workspace 列表尚未加载完时不处理：挂载副作用会在加载完成后自行铺默认视图，
       // 避免 workspaces 还是 [] 时误闪空态引导。
       if (!loaded) return;
@@ -182,40 +245,15 @@ export default function LoopPage() {
   // 自然落入空态引导(showEmptyGuide)。
   useEffect(() => {
     const onSpaceChanged = () => {
-      const seq = ++spaceResolveSeqRef.current;
-      setWorkspaceContext("", "");
-      setWsId("");
-      // Close any open create modals so a submit cannot land during the
-      // re-resolve window and write a workspace under the wrong space.
-      setWsModalOpen(false);
-      setCreateOpen(false);
-      // setLoaded(false):重解析窗口期把页面标回"未加载",wk:nav-menu-activated 的
-      // `if (!loaded) return` 守卫随之生效,避免窗口期用旧 workspaces 闭包渲染 workspace 级页面。
-      setLoaded(false);
-      resetWorkspaceCaches();
-      // Unmount the stale right pane immediately so the previous space's
-      // IssuePage (and its polling / create entry) stops firing requests during
-      // the re-resolve window; applyWorkspace repaints once the new space resolves.
-      WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
-      listWorkspaces()
-        .then((list) => {
-          // 过期守卫:快速连切 space 时只让最后一次解析落地,丢弃乱序返回的旧响应,
-          // 否则旧响应的 applyWorkspace 会把旧 slug 落回 http 层、撞新 space 的隔离 403。
-          if (seq !== spaceResolveSeqRef.current) return;
-          setLoaded(true);
-          const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
-          applyWorkspace(first, list);
-        })
-        .catch(() => {
-          if (seq !== spaceResolveSeqRef.current) return;
-          setLoaded(true);
-          // Clear the stale old-space list on a failed re-resolve — otherwise the
-          // switcher dropdown keeps the previous space's workspaces, re-enabled by
-          // setLoaded(true) and clickable, so switchWorkspace would bind an
-          // old-space slug under the new space's X-Space-Id → cross-space 403.
-          setWorkspaces([]);
-          showEmptyGuide();
-        });
+      // Only the active page may touch the single shared right pane / http-layer
+      // workspace context. When LoopPage is backgrounded (kept mounted), defer:
+      // flag a pending re-resolve that reactivation (below) consumes, so we never
+      // fight the active page for the pane nor paint stale old-space data.
+      if (WKApp.currentMenuId !== "loop") {
+        pendingSpaceReresolveRef.current = true;
+        return;
+      }
+      reResolveSpace();
     };
     WKApp.mittBus.on("space-changed", onSpaceChanged);
     return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
@@ -266,6 +304,9 @@ export default function LoopPage() {
           // A space switch during creation invalidates this write; the
           // space-changed resolve owns the pane now.
           if (seq !== spaceResolveSeqRef.current) return;
+          // Navigated away mid-create (no space-changed, so seq is unchanged):
+          // don't write the shared pane/context in the background; defer.
+          if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
           applyWorkspace(findWs(list, created.id) ?? created, list);
           setTab("issue");
           WKApp.routeRight.replaceToRoot(<IssuePage viewKey="loop.view.issue" />);

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -137,6 +137,31 @@ export default function PersonalPage() {
     return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
   }, []);
 
+  // 切换 octo space 时,本页存的 workspace 归属(selectedWsRef + @octo/loop 模块级
+  // workspace 全局)属于上一个 space,必须作废重判 —— 否则会带旧 workspace 作用域向新
+  // space 发 workspace 维度请求,撞后端 space 隔离闸门(workspace does not belong to
+  // this space / not a member of this space)。
+  //
+  // 三份 workspace 状态必须一起复位,缺一不可:
+  //  - selectedWsRef:本页自留、优先于共享全局的选择(#619 防污染),不清则重解析仍选中旧 ws;
+  //  - machineModeRef:决定 openTab 的分支,不清则窗口期分支判断用旧值;
+  //  - setWorkspaceContext("",""):清 @octo/loop 的 http 层模块级 slug/id。这一步关键——
+  //    resolveAndPaint(showLoading=true) 不置 workspaceReady=false,从 emit 到重解析完成的
+  //    loading 窗口内 nav 按钮不禁用,用户此刻点 tab 会走 openTab;若 http 层仍留旧 slug,
+  //    RuntimePage 会用旧 slug 打 /runtimes(consistency group 内)→ 403 重现本 bug。
+  //    先把 http 作用域降为空(machine),窗口期任何请求都无 slug 发出、安全走 /machine-runtimes。
+  // 复位后 resolveAndPaint 重新 listWorkspaces:新 space 无 workspace 时自然落入 machine 空态。
+  useEffect(() => {
+    const onSpaceChanged = () => {
+      selectedWsRef.current = null;
+      machineModeRef.current = false;
+      setWorkspaceContext("", "");
+      resolveRef.current(true);
+    };
+    WKApp.mittBus.on("space-changed", onSpaceChanged);
+    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
+  }, []);
+
   return (
     <div className="dmpersonal-sidebar">
       <div className="dmpersonal-sidebar__title">{t("personal.menu.title")}</div>

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -156,6 +156,10 @@ export default function PersonalPage() {
       selectedWsRef.current = null;
       machineModeRef.current = false;
       setWorkspaceContext("", "");
+      // Gate the re-resolve window: openTab bails on !workspaceReady, so the
+      // Skills / runtime tabs cannot be opened against the old space's workspace
+      // scope until resolveAndPaint re-establishes the new space's selection.
+      setWorkspaceReady(false);
       resolveRef.current(true);
     };
     WKApp.mittBus.on("space-changed", onSpaceChanged);

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -55,6 +55,10 @@ export default function PersonalPage() {
     workspaceApi.listWorkspaces()
       .then((workspaces) => {
         if (!mountedRef.current || seq !== resolveSeqRef.current) return;
+        // If the page was backgrounded before this resolve landed, don't write
+        // the shared pane/context (would clobber the now-active page). Bail;
+        // reactivation re-resolves via wk:nav-menu-activated (resolveRef).
+        if (WKApp.currentMenuId !== "dmpersonal") return;
         // 优先用本页自己存的 workspace,仅当它不存在(如在别处被删)时才回落到共享全局。
         // 直接读 currentWorkspaceId() 会让 Personal 跟随 Loop 最后选中的 workspace(#619 污染)。
         const targetId = selectedWsRef.current?.id ?? currentWorkspaceId();
@@ -83,6 +87,8 @@ export default function PersonalPage() {
       })
       .catch((error) => {
         if (!mountedRef.current || seq !== resolveSeqRef.current) return;
+        // Backgrounded before the failure landed → don't paint the shared pane.
+        if (WKApp.currentMenuId !== "dmpersonal") return;
         const message = error?.message ? String(error.message) : t("personal.workspace.loadFailed");
         setWorkspaceError(message);
         setWorkspaceReady(false);
@@ -153,6 +159,19 @@ export default function PersonalPage() {
   // 复位后 resolveAndPaint 重新 listWorkspaces:新 space 无 workspace 时自然落入 machine 空态。
   useEffect(() => {
     const onSpaceChanged = () => {
+      // Only the active page may touch the single shared right pane / http-layer
+      // workspace context. When backgrounded, do NOT clear the shared context
+      // (that would wipe the active Loop page's slug) — but still reset our own
+      // PRIVATE state and drop workspaceReady, so the reactivation window is
+      // gated by !workspaceReady (openTab bails) instead of letting a click
+      // write the old space's slug back → 403. Reactivation re-resolves via
+      // wk:nav-menu-activated (resolveRef.current(true)).
+      if (WKApp.currentMenuId !== "dmpersonal") {
+        selectedWsRef.current = null;
+        machineModeRef.current = false;
+        setWorkspaceReady(false);
+        return;
+      }
       selectedWsRef.current = null;
       machineModeRef.current = false;
       setWorkspaceContext("", "");


### PR DESCRIPTION
## Summary

Both the Personal (我的/运行时) and Loop (回路) pages failed to react to octo space switches: they only re-listed workspaces on mount and on `wk:nav-menu-activated`, not on `space-changed`. After switching space they kept the previous space's workspace context and issued workspace-scoped requests against the new space, so the backend space-isolation gate rejected them (`workspace does not belong to this space` / `not a member of this space`) instead of the page showing the correct empty state. This PR makes both pages re-resolve on `space-changed`.

## Related Issue

Fixes #817

## Changes

- `packages/dmpersonal/src/PersonalPage.tsx`: subscribe to `space-changed`; on switch, reset all three workspace states before re-resolving — `selectedWsRef`, `machineModeRef`, and the `@octo/loop` http-layer slug via `setWorkspaceContext("", "")` — then reuse `resolveAndPaint` (empty space falls into machine mode).
- `packages/dmloop/src/pages/LoopPage.tsx`: subscribe to `space-changed`; clear the http-layer workspace slug first, then re-list workspaces (empty space → empty-state guide). Mirror the current tab via `tabRef` so the mount-once handler paints the live tab; share one generation guard (`spaceResolveSeqRef`) across the mount and space-changed resolves to drop out-of-order responses; gate click entries (`openTab` / `switchWorkspace` / `openNewLoop`) with `!loaded` during the re-resolve window.
- `apps/web/src/__tests__/personalPageSpaceChanged.test.ts`: new tests asserting the subscription, the state resets and their ordering, the shared seq guard, the tabRef render, and the window-period entry guards.

## Architecture / Module Boundary

- Affected module(s): `packages/dmloop`, `packages/dmpersonal`.
- New or changed user-visible entry point: no (fixes existing space-switch behavior on existing pages).
- Shared layer touched: none (uses existing `@octo/loop` workspace helpers and `WKApp.mittBus`).
- If shared code changed, impact scope: n/a.
- Duplicate entry point checked: yes.

## Testing

- `cd apps/web && npx vitest run src/__tests__/personalPageSpaceChanged.test.ts` — 11 passed.
- Manually verified against a local self-hosted stack: switching between a space with a workspace and a space without one now shows the correct content / empty state, with no space-isolation error toast.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points