### PR TITLE
fix(loop): rename issue work-item to Task, add Beta badges, unify page titles

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -1,16 +1,17 @@
 {
+  "beta": "Beta",
   "menu": {
     "title": "Loop",
     "changeStatus": "Change status",
     "changePriority": "Change priority",
     "changeAssignee": "Change assignee",
-    "deleteIssue": "Delete Loop",
+    "deleteIssue": "Delete Task",
     "editProps": "Edit properties"
   },
   "nav": {
-    "myloop": "My loops",
+    "myloop": "My tasks",
     "workspaceGroup": "Workspace",
-    "issue": "Loop",
+    "issue": "Task",
     "skill": "Skill",
     "project": "Project",
     "automation": "Automation",
@@ -38,7 +39,7 @@
     "runNow": "Run now",
     "runNowConfirm": "Run this automation now?",
     "runNowConfirmDesc": "This triggers a run immediately and hands the task to the executor.",
-    "viewIssue": "View loop",
+    "viewIssue": "View task",
     "runStarted": "Run triggered",
     "runFailed": "Failed to trigger",
     "triggerFailed": "Automation created, but scheduling failed — retry from Edit",
@@ -59,7 +60,7 @@
     "retry": "Retry",
     "noTaskDesc": "No task instructions",
     "runStatus": {
-      "issue_created": "Loop created",
+      "issue_created": "Task created",
       "running": "Running",
       "completed": "Succeeded",
       "failed": "Failed",
@@ -130,10 +131,10 @@
   "batch": {
     "selected": "{{count}} selected",
     "done": "Updated",
-    "deleteConfirm": "Delete {{count}} selected issue(s)? This cannot be undone."
+    "deleteConfirm": "Delete {{count}} selected task(s)? This cannot be undone."
   },
   "search": {
-    "issue": "Search Loop / id",
+    "issue": "Search Task / id",
     "skill": "Search skill",
     "project": "Search project",
     "agent": "Search AI teammate",
@@ -155,7 +156,7 @@
     "updated_at": "Updated"
   },
   "action": {
-    "newIssue": "New Loop",
+    "newIssue": "New Task",
     "newSkill": "New Skill",
     "newProject": "New Project",
     "newAgent": "New AI teammate",
@@ -207,17 +208,17 @@
     "cancelled": "Cancelled"
   },
   "empty": {
-    "issue": "No Loops",
+    "issue": "No Tasks",
     "skill": "No skills",
     "project": "No projects",
     "agent": "No AI teammates",
     "squad": "No AI squads",
-    "issueTitle": "No Loops yet",
-    "issueDesc": "Create your first Loop to start tracking work.",
+    "issueTitle": "No Tasks yet",
+    "issueDesc": "Create your first Task to start tracking work.",
     "skillTitle": "No skills yet",
     "skillDesc": "Create or import a skill for your AI teammates to reuse.",
     "projectTitle": "No projects yet",
-    "projectDesc": "Create a project to organize related Loops.",
+    "projectDesc": "Create a project to organize related Tasks.",
     "agentTitle": "No AI teammates yet",
     "agentDesc": "Create an AI teammate to automate your tasks.",
     "squadTitle": "No AI squads yet",
@@ -238,7 +239,7 @@
     "labels": "Labels",
     "startDate": "Start date",
     "dueDate": "Due date",
-    "parent": "Parent issue",
+    "parent": "Parent task",
     "noParent": "No parent",
     "stage": "Stage",
     "progress": "Progress",
@@ -280,7 +281,7 @@
     "unassigned": "Unassigned"
   },
   "detail": {
-    "issueTitle": "Loop detail",
+    "issueTitle": "Task detail",
     "skillTitle": "Skill detail",
     "projectTitle": "Project detail",
     "agentTitle": "AI teammate detail",
@@ -347,7 +348,7 @@
   },
   "confirm": {
     "delete": "Delete?",
-    "deleteIssue": "Delete this Loop? This cannot be undone."
+    "deleteIssue": "Delete this Task? This cannot be undone."
   },
   "skill": {
     "source": "Source",
@@ -416,7 +417,7 @@
   },
   "webhook": {
     "title": "Webhooks",
-    "hint": "Fires on issue status changes. Each request is signed with HMAC-SHA256 in the X-Octo-Signature-256 header.",
+    "hint": "Fires on task status changes. Each request is signed with HMAC-SHA256 in the X-Octo-Signature-256 header.",
     "urlPlaceholder": "https://example.com/webhooks/octo",
     "add": "Add",
     "empty": "No webhooks yet.",
@@ -446,21 +447,21 @@
   },
   "subscribe": {
     "label": "Subscribers",
-    "subscribe": "Subscribe to issue",
+    "subscribe": "Subscribe to task",
     "unsubscribe": "Unsubscribe",
     "subscribed": "Subscribed",
     "unsubscribed": "Unsubscribed"
   },
   "subIssue": {
-    "title": "Sub-issues",
-    "create": "New sub-issue"
+    "title": "Sub-tasks",
+    "create": "New sub-task"
   },
   "reaction": {
     "add": "Add reaction"
   },
   "mention": {
     "groupUsers": "Users",
-    "groupIssues": "Loops",
+    "groupIssues": "Tasks",
     "allMembers": "All members"
   },
   "agent": {
@@ -581,7 +582,7 @@
     "filterCreator": "Creator",
     "clearFilters": "Clear",
     "noMatches": "No matching squads",
-    "createDesc": "Group agents and members to collaborate on issues.",
+    "createDesc": "Group agents and members to collaborate on tasks.",
     "membersLabel": "Members",
     "membersOptional": "optional",
     "membersHint": "Add more agents or members to the squad.",
@@ -642,7 +643,7 @@
     "wsName": "Workspace name",
     "wsSlug": "Workspace slug",
     "slugHint": "Slug cannot be changed after creation",
-    "issuePrefix": "Loop prefix",
+    "issuePrefix": "Task prefix",
     "role": "Role",
     "removeMember": "Remove member",
     "revokeInvite": "Revoke invitation",
@@ -684,7 +685,7 @@
     "ex3Prompt": "Fix the slow inbox loading in the Web project"
   },
   "activityAction": {
-    "created": "created this loop",
+    "created": "created this task",
     "statusChanged": "updated the status",
     "priorityChanged": "updated the priority",
     "assigneeChanged": "changed the assignee",
@@ -695,6 +696,6 @@
     "dateChanged": "updated dates",
     "reopened": "reopened",
     "completed": "marked complete",
-    "generic": "updated this loop"
+    "generic": "updated this task"
   }
 }

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -1,16 +1,17 @@
 {
+  "beta": "Beta",
   "menu": {
     "title": "回路",
     "changeStatus": "修改状态",
     "changePriority": "修改优先级",
     "changeAssignee": "修改负责人",
-    "deleteIssue": "删除回路",
+    "deleteIssue": "删除任务",
     "editProps": "编辑属性"
   },
   "nav": {
-    "myloop": "我的回路",
+    "myloop": "我的任务",
     "workspaceGroup": "工作区",
-    "issue": "回路",
+    "issue": "任务",
     "skill": "技能",
     "project": "项目",
     "automation": "自动化",
@@ -38,7 +39,7 @@
     "runNow": "手动运行",
     "runNowConfirm": "立即执行这个自动化？",
     "runNowConfirmDesc": "将立即触发一次运行，把任务交给执行方。",
-    "viewIssue": "查看回路",
+    "viewIssue": "查看任务",
     "runStarted": "已触发运行",
     "runFailed": "触发失败",
     "triggerFailed": "自动化已创建，但排程设置失败，请在编辑里重试",
@@ -59,7 +60,7 @@
     "retry": "重试",
     "noTaskDesc": "暂无任务说明",
     "runStatus": {
-      "issue_created": "已建回路",
+      "issue_created": "已建任务",
       "running": "运行中",
       "completed": "成功",
       "failed": "失败",
@@ -133,7 +134,7 @@
     "deleteConfirm": "确定删除选中的 {{count}} 项？此操作不可撤销。"
   },
   "search": {
-    "issue": "搜索回路/ 编号",
+    "issue": "搜索任务/ 编号",
     "skill": "搜索技能",
     "project": "搜索项目",
     "agent": "搜索 AI队友",
@@ -155,7 +156,7 @@
     "updated_at": "更新时间"
   },
   "action": {
-    "newIssue": "新建回路",
+    "newIssue": "新建任务",
     "newSkill": "新建技能",
     "newProject": "新建项目",
     "newAgent": "新建 AI队友",
@@ -207,17 +208,17 @@
     "cancelled": "已取消"
   },
   "empty": {
-    "issue": "暂无回路",
+    "issue": "暂无任务",
     "skill": "暂无技能",
     "project": "暂无项目",
     "agent": "暂无 AI队友",
     "squad": "暂无 AI小队",
-    "issueTitle": "还没有回路",
-    "issueDesc": "创建第一个回路，开始跟踪你的工作。",
+    "issueTitle": "还没有任务",
+    "issueDesc": "创建第一个任务，开始跟踪你的工作。",
     "skillTitle": "还没有技能",
     "skillDesc": "创建或导入技能，供 AI队友复用。",
     "projectTitle": "还没有项目",
-    "projectDesc": "创建项目来组织相关的回路。",
+    "projectDesc": "创建项目来组织相关的任务。",
     "agentTitle": "还没有 AI队友",
     "agentDesc": "创建 AI队友来自动处理你的任务。",
     "squadTitle": "还没有 AI小队",
@@ -238,8 +239,8 @@
     "labels": "标签",
     "startDate": "开始日期",
     "dueDate": "截止日期",
-    "parent": "父 Issue",
-    "noParent": "无父 Issue",
+    "parent": "父任务",
+    "noParent": "无父任务",
     "stage": "阶段",
     "progress": "进度",
     "createdAt": "创建时间"
@@ -280,7 +281,7 @@
     "unassigned": "未指派"
   },
   "detail": {
-    "issueTitle": "回路详情",
+    "issueTitle": "任务详情",
     "skillTitle": "技能详情",
     "projectTitle": "项目详情",
     "agentTitle": "AI队友详情",
@@ -347,7 +348,7 @@
   },
   "confirm": {
     "delete": "确定删除？",
-    "deleteIssue": "确定删除该回路？此操作不可撤销。"
+    "deleteIssue": "确定删除该任务？此操作不可撤销。"
   },
   "skill": {
     "source": "来源",
@@ -416,7 +417,7 @@
   },
   "webhook": {
     "title": "Webhook",
-    "hint": "在 issue 状态变化时触发。每个请求都用 HMAC-SHA256 签名，放在 X-Octo-Signature-256 请求头里。",
+    "hint": "在任务状态变化时触发。每个请求都用 HMAC-SHA256 签名，放在 X-Octo-Signature-256 请求头里。",
     "urlPlaceholder": "https://example.com/webhooks/octo",
     "add": "添加",
     "empty": "还没有 webhook。",
@@ -446,21 +447,21 @@
   },
   "subscribe": {
     "label": "订阅者",
-    "subscribe": "订阅此 Issue",
+    "subscribe": "订阅此任务",
     "unsubscribe": "取消订阅",
     "subscribed": "已订阅",
     "unsubscribed": "已取消订阅"
   },
   "subIssue": {
-    "title": "子 Issue",
-    "create": "新建子 Issue"
+    "title": "子任务",
+    "create": "新建子任务"
   },
   "reaction": {
     "add": "添加反应"
   },
   "mention": {
     "groupUsers": "用户",
-    "groupIssues": "回路",
+    "groupIssues": "任务",
     "allMembers": "所有成员"
   },
   "agent": {
@@ -642,7 +643,7 @@
     "wsName": "工作区名称",
     "wsSlug": "工作区 slug",
     "slugHint": "slug 创建后不可修改",
-    "issuePrefix": "回路前缀",
+    "issuePrefix": "任务前缀",
     "role": "角色",
     "removeMember": "移除成员",
     "revokeInvite": "撤销邀请",
@@ -684,7 +685,7 @@
     "ex3Prompt": "修一下 Web 项目里收件箱加载慢的问题"
   },
   "activityAction": {
-    "created": "创建了这个回路",
+    "created": "创建了这个任务",
     "statusChanged": "更新了状态",
     "priorityChanged": "更新了优先级",
     "assigneeChanged": "变更了负责人",
@@ -695,6 +696,6 @@
     "dateChanged": "更新了时间",
     "reopened": "重新打开",
     "completed": "标记完成",
-    "generic": "更新了这个回路"
+    "generic": "更新了这个任务"
   }
 }

--- a/packages/dmloop/src/pages/AgentPage.tsx
+++ b/packages/dmloop/src/pages/AgentPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Typography, Input, Button, Select, Avatar, Spin, Modal, Toast, Banner } from "@douyinfe/semi-ui";
+import { Input, Button, Select, Avatar, Spin, Modal, Toast, Banner } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import { Search, Plus, Trash2, Bot, RotateCcw } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -10,8 +10,6 @@ import AgentDetailPage from "../panel/AgentDetailPage";
 import { confirmDelete } from "../ui/confirmDelete";
 import { avatarColor } from "../ui/meta";
 import { formatRelativeTime } from "../ui/time";
-
-const { Title } = Typography;
 
 type Scope = "mine" | "all" | "archived";
 const SCOPES: Scope[] = ["mine", "all", "archived"];
@@ -101,7 +99,7 @@ export default function AgentPage() {
   return (
     <div className="loop-page">
       <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.agent")}</Title>
+        <h2 className="loop-page__title">{t("loop.nav.agent")}</h2>
         <div className="loop-page__spacer" />
         <Input className="loop-search" prefix={<Search size={14} />} placeholder={t("loop.search.agent")} value={keyword} onChange={setKeyword} showClear style={{ width: 220 }} />
         <LoopButton icon={<Plus size={14} />} onClick={openCreate}>{t("loop.action.newAgent")}</LoopButton>

--- a/packages/dmloop/src/pages/AutomationPage.tsx
+++ b/packages/dmloop/src/pages/AutomationPage.tsx
@@ -16,7 +16,7 @@ import { formatNextRunAt } from "../ui/autopilotSchedule";
 import CreateAutomationModal from "../ui/CreateAutomationModal";
 import AutopilotDetailPage from "../panel/AutopilotDetailPage";
 
-const { Title, Text } = Typography;
+const { Text } = Typography;
 
 export default function AutomationPage() {
   const { t } = useI18n();
@@ -117,7 +117,7 @@ export default function AutomationPage() {
   return (
     <div className="loop-page">
       <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.automation")}</Title>
+        <h2 className="loop-page__title">{t("loop.nav.automation")}</h2>
         <Text type="tertiary" style={{ fontSize: 13 }}>{rows.length}</Text>
         <div className="loop-page__spacer" />
         <LoopButton icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>{t("loop.automation.create")}</LoopButton>

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -377,6 +377,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       <div className="loop-page__head loop-page__head--stack">
         <div className="loop-page__title-row">
           <h2 className="loop-page__title">{title}</h2>
+          <span className="loop-page__title-beta">{t("loop.beta")}</span>
         </div>
         <div className="loop-page__toolbar">
           {/* 作用域 tab:全部/成员/AI,贯三视图,走后端 assignee_types。

--- a/packages/dmloop/src/pages/ProjectPage.tsx
+++ b/packages/dmloop/src/pages/ProjectPage.tsx
@@ -14,7 +14,7 @@ import { formatRelativeTime } from "../ui/time";
 import { readView, writeView } from "../ui/viewMode";
 import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
 
-const { Title, Text } = Typography;
+const { Text } = Typography;
 
 type ViewMode = "list" | "card";
 const VIEW_KEY = "loop.project.viewMode";
@@ -196,7 +196,7 @@ export default function ProjectPage() {
   return (
     <div className="loop-page">
       <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.project")}</Title>
+        <h2 className="loop-page__title">{t("loop.nav.project")}</h2>
         <Text type="tertiary" style={{ fontSize: 13 }}>{rows.length}</Text>
         <div className="loop-page__spacer" />
         <LoopButton icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>{t("loop.action.newProject")}</LoopButton>

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -14,7 +14,7 @@ import { invalidateDirectory } from "../api/directory";
 import LoopTag from "../ui/LoopTag";
 import LoopButton from "../ui/LoopButton";
 
-const { Title, Text } = Typography;
+const { Text } = Typography;
 const ROLES = ["admin", "member"];
 
 /**
@@ -32,7 +32,7 @@ export default function SettingsPage({
   if (!workspace) {
     return (
       <div className="loop-page">
-        <div className="loop-page__head"><Title heading={4}>{t("loop.nav.settings")}</Title></div>
+        <div className="loop-page__head"><h2 className="loop-page__title">{t("loop.nav.settings")}</h2></div>
         <div className="loop-page__center"><Text type="tertiary">{t("loop.settings.noWorkspace")}</Text></div>
       </div>
     );
@@ -40,7 +40,7 @@ export default function SettingsPage({
 
   return (
     <div className="loop-page">
-      <div className="loop-page__head"><Title heading={4}>{t("loop.nav.settings")}</Title></div>
+      <div className="loop-page__head"><h2 className="loop-page__title">{t("loop.nav.settings")}</h2></div>
       <div className="loop-page__body">
         <Tabs type="line">
           <TabPane tab={t("loop.settings.general")} itemKey="general">

--- a/packages/dmloop/src/pages/SquadPage.tsx
+++ b/packages/dmloop/src/pages/SquadPage.tsx
@@ -11,7 +11,7 @@ import { confirmDelete } from "../ui/confirmDelete";
 import { avatarColor } from "../ui/meta";
 import { formatRelativeTime } from "../ui/time";
 
-const { Title, Text } = Typography;
+const { Text } = Typography;
 
 type Scope = "mine" | "all";
 type SortField = "name" | "members" | "created";
@@ -206,7 +206,7 @@ export default function SquadPage() {
   return (
     <div className="loop-page">
       <div className="loop-page__head">
-        <Title heading={4}>{t("loop.nav.squad")}</Title>
+        <h2 className="loop-page__title">{t("loop.nav.squad")}</h2>
         {rows.length > 0 && <Text type="tertiary" style={{ fontSize: 13 }}>{rows.length}</Text>}
         <div className="loop-page__spacer" />
         <LoopButton icon={<Plus size={14} />} onClick={openCreate}>{t("loop.action.newSquad")}</LoopButton>

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -115,10 +115,6 @@
   padding: 16px 20px 12px;
 }
 
-.loop-page__head h4 {
-  margin: 0;
-}
-
 .loop-page__spacer {
   flex: 1;
 }

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -147,7 +147,24 @@
 
 .loop-page__title-row {
   display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+/* Beta 标识：静音灰色小标签，贴在「任务」大标题的右下角（baseline 对齐） */
+.loop-page__title-beta {
+  display: inline-flex;
   align-items: center;
+  padding: 0 6px;
+  height: 16px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--loop-tag-grey-fg, #5d626f);
+  background: var(--loop-tag-grey-bg, #f1f2f4);
+  border: 1px solid var(--loop-tag-grey-bd, #dddfe3);
 }
 
 .loop-page__title {

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -139,7 +139,10 @@ export default function PersonalPage() {
 
   return (
     <div className="dmpersonal-sidebar">
-      <div className="dmpersonal-sidebar__title">{t("personal.menu.title")}</div>
+      <div className="dmpersonal-sidebar__title">
+        <span>{t("personal.menu.title")}</span>
+        <span className="dmpersonal-sidebar__beta">{t("personal.beta")}</span>
+      </div>
       <nav className="dmpersonal-sidebar__menu">
         {PERSONAL_TABS.map((item) => (
           <button

--- a/packages/dmpersonal/src/i18n/en-US.json
+++ b/packages/dmpersonal/src/i18n/en-US.json
@@ -2,6 +2,7 @@
   "menu": {
     "title": "Personal"
   },
+  "beta": "Beta",
   "nav": {
     "runtime": "Runtimes",
     "skill": "Skills"

--- a/packages/dmpersonal/src/i18n/zh-CN.json
+++ b/packages/dmpersonal/src/i18n/zh-CN.json
@@ -2,6 +2,7 @@
   "menu": {
     "title": "我的"
   },
+  "beta": "Beta",
   "nav": {
     "runtime": "运行时",
     "skill": "Skills"

--- a/packages/dmpersonal/src/personal.css
+++ b/packages/dmpersonal/src/personal.css
@@ -8,10 +8,29 @@
 }
 
 .dmpersonal-sidebar__title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--wk-sp-2);
   padding: var(--wk-sp-5) var(--wk-sp-5) var(--wk-sp-3);
   font-size: var(--wk-text-size-xl);
   font-weight: 600;
   color: var(--semi-color-text-0);
+}
+
+/* Beta 标识：静音灰色小标签，坐落在标题右下（baseline 对齐 → 视觉贴底） */
+.dmpersonal-sidebar__beta {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  height: 16px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--loop-tag-grey-fg, #5d626f);
+  background: var(--loop-tag-grey-bg, #f1f2f4);
+  border: 1px solid var(--loop-tag-grey-bd, #dddfe3);
 }
 
 .dmpersonal-sidebar__menu {


### PR DESCRIPTION
## Summary
Copy & UI polish for the Loop and Personal modules (i18n + styling only, no architecture / data-model / API changes):

- **Rename issue work-item → Task**: resolves the naming collision where the issue sub-tab shared the word "Loop"/"回路" with the product. Renamed the work-item concept to "Task"/"任务" across `zh-CN` and `en-US` (sub-tab, new/my/detail/empty/search/mention/subscribe/sub-task strings and related "Issue"-worded copy). Kept the module name, product references, and the "running loop" metaphor unchanged.
- **Beta badges**: muted grey "Beta" badge next to the "我的" sidebar title in `dmpersonal`, and at the bottom-right of the "任务" page title in `dmloop`. Wired via i18n in all four locale files; styled with the existing `--loop-tag-grey-*` tokens.
- **Unified title typography**: all six workspace page main titles now use the single `loop-page__title` style (22px/700), replacing the mismatched Semi `Title heading={4}`. Removed the orphaned `Title`/`Typography` imports and the dead `.loop-page__head h4` rule.

## Scope
- Affected packages: `packages/dmloop`, `packages/dmpersonal`.
- Follow-up (not in this PR): unify page-header layout/padding rhythm, and bring Runtime/Skill (Personal panel) titles in line.

## Test plan
- [x] `pnpm --filter @octo/loop test` — 63/63 pass
- [ ] Visual check: 任务 sub-tab + all issue copy reads "任务"/"Task"; module name still "回路"/"Loop"
- [ ] Visual check: Beta badge renders on 我的 title and 任务 title
- [ ] Visual check: all six workspace page titles share the same 22px/700 size

Closes #819