### PR TITLE
fix(docs): freeze toolbar tooltip shows raw key docs.toolbar.freeze

### DIFF
--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -147,6 +147,7 @@
     "hexInput": "Hex color",
     "hexPlaceholder": "#rrggbb",
     "table": "Table",
+    "freeze": "Freeze",
     "image": "Image",
     "file": "File",
     "bookmark": "Bookmark",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -147,6 +147,7 @@
     "hexInput": "十六进制颜色",
     "hexPlaceholder": "#rrggbb",
     "table": "表格",
+    "freeze": "冻结",
     "image": "图片",
     "file": "文件",
     "bookmark": "书签",


### PR DESCRIPTION
## Problem

The docs table **Freeze** toolbar button (added in #755) rendered its hover tooltip and `aria-label` as the raw i18n key `docs.toolbar.freeze` instead of a translated label.

Root cause: `TableFreezeControl` reads its label via `t('docs.toolbar.freeze')`, but no `freeze` key existed under the `toolbar` group in either locale file. `I18nService.t()` falls back to returning the key string verbatim when a key is missing, so the raw key leaked into the UI.

## Fix

Register the missing `docs.toolbar.freeze` key in both locale files:

- `zh-CN.json` → `"freeze": "冻结"`
- `en-US.json` → `"freeze": "Freeze"`

The freeze dropdown menu items (freeze header row / up to this row / first column / up to this column / unfreeze) already resolve correctly through the existing `docs.table.*` keys and are unchanged.

## Verification

Verified in a real browser (standalone docs harness) by inserting a table, hovering the freeze button, and toggling locale:

| | Tooltip | Dropdown menu |
| --- | --- | --- |
| zh-CN | 冻结 | 冻结首行 / 冻结到当前行 / 冻结首列 / 冻结到当前列 / 取消冻结 |
| en-US | Freeze | Freeze header row / Freeze up to this row / Freeze first column / Freeze up to this column / Unfreeze |

No more raw `docs.toolbar.freeze` in the UI; the label switches correctly with the active locale. The i18n key-parity test (`src/i18n/i18n.test.ts`) passes.

Scope is limited to i18n resources — no change to freeze behavior (#755) or the column-width / reorder / font-color features.

Opened as **draft** to carry review; promote after review + deploy verification.
