### PR TITLE
fix(docs): make table row/column reorder handle stable and discoverable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ packages/docs/dev-dist/
 packages/docs/dev/smoke-out/
 packages/docs/dev/presence-out/
 packages/docs/dev/reorder-out/
+packages/docs/dev/handle-ux-out/
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ packages/docs/dev/smoke-out/
 packages/docs/dev/presence-out/
 packages/docs/dev/reorder-out/
 packages/docs/dev/handle-ux-out/
+packages/docs/dev/coexist-out/
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ packages/docs/dev/presence-out/
 packages/docs/dev/reorder-out/
 packages/docs/dev/handle-ux-out/
 packages/docs/dev/coexist-out/
+packages/docs/dev/multipointer-out/
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/

--- a/packages/docs/coexist.html
+++ b/packages/docs/coexist.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Table reorder handle coexistence gate (XIN-1253)</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dev/coexist.harness.tsx"></script>
+  </body>
+</html>

--- a/packages/docs/dev/coexist.harness.tsx
+++ b/packages/docs/dev/coexist.harness.tsx
@@ -1,0 +1,219 @@
+// Real-browser COEXISTENCE gate for the table reorder handle (octo-docs-backend#76 / XIN-1253).
+//
+// The reorder handle was reported hidden (display:none / 0x0) and un-grabbable on the real :3000
+// build once it shipped in the SAME build as the row-height resize handle (#823). Root cause: both
+// controls are absolutely-positioned SIBLINGS of the ProseMirror DOM inside the editor wrapper and
+// sit ON TOP of the table cells; when the pointer moved onto the row-resize bar straddling a row's
+// bottom edge, the editor's `mouseleave` fired and the reorder plugin hid its handles, then never
+// saw the moves to bring them back. The standalone build (this file's predecessor dev/reorder.harness)
+// had no such overlay, so review passed while real use failed.
+//
+// This harness reproduces the hazard WITHOUT depending on #823's code: a minimal stand-in plugin
+// (`overlayStandIn`) renders exactly the kind of sibling overlay #823 adds — a full-width, z-index 5
+// bar pinned to the hovered row's bottom edge, outside the editor DOM — so the gate exercises the
+// generic "sibling overlay steals the pointer" condition the fix must survive. Real editor/styles.css
+// is loaded so the reorder handle's real CSS applies. window.__coexistHarness exposes the driver seams.
+
+import { useEffect, useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { Extension } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { TableMap } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { setWKApp } from '../src/octoweb/index.ts'
+import { createMockWKApp } from '../src/octoweb/mock.ts'
+import { TableReorderHandle } from '../src/editor/TableReorderHandle.ts'
+import '../src/editor/styles.css'
+
+setWKApp(createMockWKApp({ uid: 'u_coexist', token: 'dev' }))
+
+const BAND = 12
+
+// Minimal stand-in for #823's row-height resize overlay: a full-table-width bar on the hovered row's
+// bottom edge, an absolutely-positioned sibling of the ProseMirror DOM (z-index 5, on top of cells).
+// It reproduces the ONLY property that matters for XIN-1253 — a sibling overlay the pointer can land
+// on, which makes the editor fire mouseleave — without pulling in the real (separate-branch) plugin.
+const overlayStandIn = Extension.create({
+  name: 'rowResizeOverlayStandIn',
+  addProseMirrorPlugins() {
+    let bar: HTMLElement | null = null
+    return [
+      new Plugin({
+        view(view) {
+          const wrapper = view.dom.parentElement
+          bar = document.createElement('div')
+          bar.className = 'octo-row-resize-standin'
+          bar.style.position = 'absolute'
+          bar.style.display = 'none'
+          bar.style.zIndex = '5'
+          bar.style.background = 'transparent'
+          if (wrapper) wrapper.appendChild(bar)
+          return {
+            destroy() {
+              bar?.remove()
+              bar = null
+            },
+          }
+        },
+        props: {
+          handleDOMEvents: {
+            mousemove(view, event) {
+              if (!bar) return false
+              const found = view.posAtCoords({ left: event.clientX, top: event.clientY })
+              if (!found) {
+                bar.style.display = 'none'
+                return false
+              }
+              const $pos = view.state.doc.resolve(found.pos)
+              let rowDom: HTMLElement | null = null
+              let tableDom: HTMLElement | null = null
+              for (let d = $pos.depth; d > 0; d--) {
+                if ($pos.node(d).type.name === 'tableRow') {
+                  const dom = view.nodeDOM($pos.before(d))
+                  if (dom instanceof HTMLElement) {
+                    rowDom = dom
+                    tableDom = dom.closest('table')
+                  }
+                  break
+                }
+              }
+              if (!rowDom || !tableDom) {
+                bar.style.display = 'none'
+                return false
+              }
+              const base = (view.dom as HTMLElement).getBoundingClientRect()
+              const row = rowDom.getBoundingClientRect()
+              const table = tableDom.getBoundingClientRect()
+              if (Math.abs(event.clientY - row.bottom) > BAND) {
+                bar.style.display = 'none'
+                return false
+              }
+              bar.style.display = 'block'
+              bar.style.left = `${table.left - base.left}px`
+              bar.style.top = `${row.bottom - base.top - BAND / 2}px`
+              bar.style.width = `${table.width}px`
+              bar.style.height = `${BAND}px`
+              return false
+            },
+          },
+        },
+      }),
+    ]
+  },
+})
+
+const DOC =
+  '<p>heading paragraph</p>' +
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td><td><p>r1c3</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td><td><p>r2c3</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td><td><p>r3c3</p></td></tr>' +
+  '</tbody></table>' +
+  '<p>trailing paragraph</p>'
+
+function makeEditor(element: HTMLElement): Editor {
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+      overlayStandIn, // registered AFTER the reorder handle, like #823's TableRowResize in the merged build
+    ],
+    content: DOC,
+  })
+}
+
+function firstTable(editor: Editor): { node: PMNode; pos: number } {
+  let node: PMNode | null = null
+  let pos = -1
+  editor.state.doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+
+function Harness(): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!ref.current) return
+    let ed: Editor | null = null
+    const mount = () => {
+      ed?.destroy()
+      ref.current!.innerHTML = ''
+      ed = makeEditor(ref.current!)
+    }
+    mount()
+
+    const harness = {
+      reset: () => mount(),
+      gridA: (): string[][] => {
+        const { node } = firstTable(ed!)
+        const map = TableMap.get(node)
+        const out: string[][] = []
+        for (let r = 0; r < map.height; r++) {
+          const row: string[] = []
+          for (let c = 0; c < map.width; c++) {
+            const cell = node.nodeAt(map.map[r * map.width + c])
+            row.push(cell ? cell.textContent : '')
+          }
+          out.push(row)
+        }
+        return out
+      },
+      cellRectA: (row: number, col: number) => {
+        const { node, pos } = firstTable(ed!)
+        const map = TableMap.get(node)
+        const cellPos = pos + 1 + map.map[row * map.width + col]
+        const dom = ed!.view.nodeDOM(cellPos)
+        if (!(dom instanceof HTMLElement)) return null
+        const r = dom.getBoundingClientRect()
+        return { left: r.left, top: r.top, width: r.width, height: r.height }
+      },
+      handleRect: (kind: 'row' | 'col') => {
+        const el = document.querySelector(`.octo-table-reorder--${kind}`) as HTMLElement | null
+        if (!el || el.style.display === 'none') return null
+        const r = el.getBoundingClientRect()
+        return { left: r.left, top: r.top, width: r.width, height: r.height }
+      },
+    }
+    ;(window as unknown as { __coexistHarness: typeof harness }).__coexistHarness = harness
+
+    return () => {
+      ed?.destroy()
+    }
+  }, [])
+
+  // Real EditorShell DOM nesting so production CSS + a scroll container apply as they do live.
+  return (
+    <div className="octo-doc octo-doc--editor octo-theme" style={{ height: '100vh' }}>
+      <div className="octo-doc-body">
+        <div className="octo-doc-scroll">
+          <div className="octo-editor-region">
+            <div className="octo-editor-main">
+              <div className="octo-prose" ref={ref} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<Harness />)

--- a/packages/docs/dev/run-coexist.mjs
+++ b/packages/docs/dev/run-coexist.mjs
@@ -1,0 +1,105 @@
+// Playwright driver for the reorder-handle COEXISTENCE gate (octo-docs-backend#76 / XIN-1253).
+// Real Chromium, real mouse, real editor/styles.css. Reproduces the reported :3000 FAIL and proves
+// the fix: hover a cell → reorder handles appear → glide the pointer DOWN onto the sibling row-resize
+// overlay at the row's bottom edge and wait PAST the hide grace period → the reorder handles must
+// STAY visible (before the fix the editor's mouseleave hid them and they could not be grabbed) → then
+// grab the column handle and complete a reorder.
+//
+// RED (pre-fix TableReorderHandle.ts): "reorder handles VANISHED …". GREEN (fixed): all ✓.
+// Usage: node dev/run-coexist.mjs   (expects the standalone dev server; pass HARNESS_PORT)
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const PORT = process.env.HARNESS_PORT || '4178'
+const URL = `http://localhost:${PORT}/coexist.html`
+const OUT = 'dev/coexist-out'
+mkdirSync(OUT, { recursive: true })
+
+let failed = 0
+const fail = (msg) => {
+  console.error('  ✗ FAIL:', msg)
+  failed++
+}
+const ok = (msg) => console.log('  ✓', msg)
+const center = (r) => ({ x: r.left + r.width / 2, y: r.top + r.height / 2 })
+const vis = (page) =>
+  page.evaluate(() => ({
+    row: !!window.__coexistHarness.handleRect('row'),
+    col: !!window.__coexistHarness.handleRect('col'),
+    overlay: (document.querySelector('.octo-row-resize-standin') || {}).style?.display !== 'none',
+  }))
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+page.on('pageerror', (e) => console.log('[pageerror]', e.message))
+
+await page.goto(URL, { waitUntil: 'networkidle' })
+await page.waitForFunction(() => !!window.__coexistHarness, { timeout: 30000 })
+await page.waitForTimeout(300)
+
+console.log('\nXIN-1253 — reorder handle survives the sibling row-resize overlay + still reorders')
+await page.evaluate(() => window.__coexistHarness.reset())
+await page.waitForTimeout(200)
+
+const cell = await page.evaluate(() => window.__coexistHarness.cellRectA(1, 1))
+if (!cell) throw new Error('cell rect not found — table did not render')
+
+// 1) hover the cell centre → reorder handles must appear (baseline).
+await page.mouse.move(...Object.values(center(cell)))
+await page.waitForTimeout(180)
+let s = await vis(page)
+if (!s.row || !s.col) fail(`handles did not appear on cell hover: ${JSON.stringify(s)}`)
+else ok('handles appear on cell hover')
+await page.screenshot({ path: `${OUT}/1-hover.png` })
+
+// 2) glide DOWN onto the sibling row-resize overlay at the row's bottom edge, past the grace period.
+for (let y = cell.top + cell.height / 2; y <= cell.top + cell.height + 1; y += 4) {
+  await page.mouse.move(cell.left + cell.width / 2, y)
+  await page.waitForTimeout(20)
+}
+await page.waitForTimeout(400) // > HIDE_DELAY (220ms)
+const topEl = await page.evaluate(
+  ([x, y]) => {
+    const e = document.elementFromPoint(x, y)
+    return e ? e.className || e.tagName : null
+  },
+  [cell.left + cell.width / 2, cell.top + cell.height],
+)
+s = await vis(page)
+console.log(`    topmost element at row bottom edge: ${topEl} | handles: ${JSON.stringify(s)}`)
+await page.screenshot({ path: `${OUT}/2-over-overlay.png` })
+if (!s.overlay) fail('stand-in overlay did not arm at the row bottom edge — gate not exercising the hazard')
+if (!s.row || !s.col) fail('reorder handles VANISHED when the pointer moved onto the row-resize overlay (XIN-1253 defect)')
+else ok('reorder handles stay visible over the overlay (no display:none regression)')
+
+// 3) the reorder must still be triggerable via the column handle.
+await page.evaluate(() => window.__coexistHarness.reset())
+await page.waitForTimeout(200)
+const c3 = await page.evaluate(() => window.__coexistHarness.cellRectA(0, 2))
+await page.mouse.move(...Object.values(center(c3)))
+await page.waitForTimeout(180)
+const handle = await page.evaluate(() => window.__coexistHarness.handleRect('col'))
+if (!handle) fail('column handle not visible — cannot start a reorder')
+else {
+  const h = center(handle)
+  await page.mouse.move(h.x, h.y, { steps: 10 })
+  await page.waitForTimeout(60)
+  await page.mouse.down()
+  const dst = await page.evaluate(() => window.__coexistHarness.cellRectA(0, 0))
+  await page.mouse.move(...Object.values(center(dst)), { steps: 10 })
+  await page.waitForTimeout(60)
+  await page.mouse.up()
+  await page.waitForTimeout(180)
+  const grid = await page.evaluate(() => window.__coexistHarness.gridA())
+  if (grid[0][0] === 'r1c3') ok('column 3 reorder completes via the handle')
+  else fail(`column reorder did not complete: ${JSON.stringify(grid[0])}`)
+  await page.screenshot({ path: `${OUT}/3-reordered.png` })
+}
+
+await browser.close()
+if (failed) {
+  console.error(`\n=== COEXISTENCE GATE FAILED (${failed}) ===`)
+  process.exitCode = 1
+} else {
+  console.log('\n=== COEXISTENCE GATE PASSED: handle survives the overlay + reorder works ===')
+}

--- a/packages/docs/dev/run-handle-ux.mjs
+++ b/packages/docs/dev/run-handle-ux.mjs
@@ -1,0 +1,135 @@
+// Playwright driver for the table reorder HANDLE UX gate (octo-docs-backend#76 / XIN-1233).
+// Real Chromium, real mouse. Reproduces the reported defect and proves the fix:
+//   "hover table → handle appears → move the pointer onto the handle → it must NOT disappear →
+//    trigger the move successfully."
+// Before the fix the handle was hidden the instant the pointer left a cell for the gutter, so the
+// pointer never reached it; step (3) below would find the handle hidden. With the deferred-hide +
+// flush placement the handle stays put and the drag completes.
+// Usage: node dev/run-handle-ux.mjs   (expects the standalone dev server on :4178)
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const PORT = process.env.HARNESS_PORT || '4178'
+const URL = `http://localhost:${PORT}/reorder.html`
+const OUT = 'dev/handle-ux-out'
+mkdirSync(OUT, { recursive: true })
+
+let failed = 0
+const fail = (msg) => {
+  console.error('  ✗ FAIL:', msg)
+  failed++
+}
+const ok = (msg) => console.log('  ✓', msg)
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+page.on('pageerror', (e) => console.log('[pageerror]', e.message))
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('[page error]', m.text())
+})
+
+await page.goto(URL, { waitUntil: 'networkidle' })
+await page.waitForFunction(() => !!window.__reorderHarness, { timeout: 30000 })
+
+const center = (r) => ({ x: r.left + r.width / 2, y: r.top + r.height / 2 })
+
+/** Hover a cell, then glide onto the handle of `kind` in small steps (crossing the gutter dead
+ *  space), pausing on the handle LONGER than the hide grace period, and assert it stays visible. */
+async function handleStaysVisibleOnApproach(kind, srcRow, srcCol) {
+  await page.evaluate(() => window.__reorderHarness.mountNewDoc())
+  await page.waitForTimeout(200)
+
+  // 1) Hover the source cell → the handle should appear for that row/column.
+  const cell = await page.evaluate((rc) => window.__reorderHarness.cellRectA(rc[0], rc[1]), [srcRow, srcCol])
+  if (!cell) throw new Error('source cell rect not found')
+  const c = center(cell)
+  await page.mouse.move(c.x, c.y)
+  await page.waitForTimeout(120)
+  const shown = await page.evaluate((k) => window.__reorderHarness.handleRect(k), kind)
+  if (!shown) {
+    fail(`[${kind}] handle did not appear on cell hover`)
+    return null
+  }
+  ok(`[${kind}] handle appears on cell hover`)
+
+  // 2) Glide from the cell onto the handle in several steps — this is the path that used to hide it.
+  const h = center(shown)
+  await page.mouse.move(h.x, h.y, { steps: 12 })
+
+  // 3) Rest on the handle PAST the grace period (220ms). It must remain visible — the core gate.
+  await page.waitForTimeout(400)
+  const stillThere = await page.evaluate((k) => window.__reorderHarness.handleRect(k), kind)
+  if (!stillThere) {
+    fail(`[${kind}] handle DISAPPEARED after the pointer moved onto it (the XIN-1233 defect)`)
+    return null
+  }
+  ok(`[${kind}] handle stays visible after the pointer rests on it (no "移开就消失")`)
+  return stillThere
+}
+
+// ── UX01 — row handle: hover → stable → move onto handle → drag → reorder ────────────────────────
+console.log('\nUX01 — ROW handle stays reachable and completes a move')
+{
+  const handle = await handleStaysVisibleOnApproach('row', 2, 0) // hover row 3
+  if (handle) {
+    const h = center(handle)
+    await page.mouse.down()
+    const dst = await page.evaluate(() => window.__reorderHarness.cellRectA(0, 0)) // toward row 1
+    const d = center(dst)
+    await page.mouse.move(d.x, d.y, { steps: 8 })
+    await page.waitForTimeout(40)
+    await page.mouse.up()
+    await page.waitForTimeout(120)
+    await page.screenshot({ path: `${OUT}/ux01-row-after.png` })
+    const grid = await page.evaluate(() => window.__reorderHarness.gridA())
+    if (grid[0][0] === 'r3c1') ok('row 3 moved to the top — reorder triggered via the handle')
+    else fail(`row reorder did not complete: ${JSON.stringify(grid.map((r) => r[0]))}`)
+  }
+}
+
+// ── UX02 — column handle: hover → stable → move onto handle → drag → reorder ─────────────────────
+console.log('\nUX02 — COLUMN handle stays reachable and completes a move')
+{
+  const handle = await handleStaysVisibleOnApproach('col', 0, 1) // hover column 2
+  if (handle) {
+    const h = center(handle)
+    await page.mouse.down()
+    const dst = await page.evaluate(() => window.__reorderHarness.cellRectA(0, 0)) // toward column 1
+    const d = center(dst)
+    await page.mouse.move(d.x, d.y, { steps: 8 })
+    await page.waitForTimeout(40)
+    await page.mouse.up()
+    await page.waitForTimeout(120)
+    await page.screenshot({ path: `${OUT}/ux02-col-after.png` })
+    const grid = await page.evaluate(() => window.__reorderHarness.gridA())
+    if (grid[0][0] === 'r1c2') ok('column 2 moved to the left — reorder triggered via the handle')
+    else fail(`column reorder did not complete: ${JSON.stringify(grid[0])}`)
+  }
+}
+
+// ── UX03 — a real departure still hides the handle (no sticky handle) ─────────────────────────────
+console.log('\nUX03 — moving the pointer far away still clears the handle (grace period is bounded)')
+{
+  await page.evaluate(() => window.__reorderHarness.mountNewDoc())
+  await page.waitForTimeout(150)
+  const cell = await page.evaluate(() => window.__reorderHarness.cellRectA(1, 0))
+  const c = center(cell)
+  await page.mouse.move(c.x, c.y)
+  await page.waitForTimeout(120)
+  if (!(await page.evaluate(() => window.__reorderHarness.handleRect('row')))) fail('handle not shown before departure test')
+  // Move well away from the table and wait past the grace period.
+  await page.mouse.move(1350, 850, { steps: 6 })
+  await page.waitForTimeout(400)
+  const gone = !(await page.evaluate(() => window.__reorderHarness.handleRect('row')))
+  if (gone) ok('handle hides after the pointer genuinely leaves the table')
+  else fail('handle stayed visible after the pointer left the table (sticky handle)')
+  await page.screenshot({ path: `${OUT}/ux03-departed.png` })
+}
+
+await browser.close()
+if (failed) {
+  console.error(`\n=== HANDLE UX GATE FAILED (${failed}) ===`)
+  process.exitCode = 1
+} else {
+  console.log('\n=== HANDLE UX GATE PASSED: handle reachable + stable + triggers move (row & col), clears on real departure ===')
+}

--- a/packages/docs/dev/run-multipointer.mjs
+++ b/packages/docs/dev/run-multipointer.mjs
@@ -1,0 +1,171 @@
+// Playwright driver for the table reorder multi-pointer re-entrancy blockers (octo-docs-backend#76
+// P1-1 / P1-2), the two defects the pointer-event migration introduced and reviewers flagged on #822.
+//
+// The drag now runs on Pointer Events + setPointerCapture. This gate drives a REAL captured pointer
+// (a genuine left-button mouse drag on the row handle — the mouse is a real, capturable pointer in
+// Chromium, so setPointerCapture latches its id) and then fires a SECOND, foreign pointer at the
+// document while that drag is in flight, exactly as a second finger / stylus would during a real
+// multi-pointer interaction:
+//   P1-1 — a second `pointerdown` on the OTHER handle must NOT start a second drag (beginDrag bails on
+//          an active drag). Observable: exactly one `begin` debug event; the original ROW reorder still
+//          commits (identity not clobbered); a following reorder still works (no leaked capture / wedge).
+//   P1-2 — a second, uncaptured pointer's `pointerup` must NOT end the drag (onDocUp filters on the
+//          captured pointer id). Observable: no dispatch / no grid change on the foreign release; the
+//          owning release then commits the intended reorder.
+//
+// The primary pointer is a real captured browser pointer; the interfering second pointer is dispatched
+// as a genuine DOM PointerEvent with a distinct pointerId (a real cross-browser way to inject a second
+// pointer without a touchscreen). Deterministic jsdom coverage of the same two defects lives in
+// src/editor/TableReorderMultiPointer.test.ts.
+// Usage: HARNESS_PORT=<port> node dev/run-multipointer.mjs   (expects the standalone dev server running)
+import { chromium } from '@playwright/test'
+
+const PORT = process.env.HARNESS_PORT || '4178'
+const URL = `http://localhost:${PORT}/reorder.html`
+const OUT = 'dev/multipointer-out'
+import { mkdirSync } from 'node:fs'
+mkdirSync(OUT, { recursive: true })
+
+let failed = 0
+const fail = (msg) => {
+  console.error('  ✗ FAIL:', msg)
+  failed++
+}
+const ok = (msg) => console.log('  ✓', msg)
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+page.on('pageerror', (e) => console.log('[pageerror]', e.message))
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('[page error]', m.text())
+})
+
+await page.goto(URL, { waitUntil: 'networkidle' })
+await page.waitForFunction(() => !!window.__reorderHarness, { timeout: 30000 })
+
+const FOREIGN_ID = 99 // a pointer id that is NOT the captured mouse pointer
+
+/** Hover the source cell and press the row handle with a real left-button drag, then a held move over
+ *  the target so a drop resolves. Leaves the drag in flight (mouse button still down). */
+async function armRealRowDrag() {
+  await page.evaluate(() => {
+    window.__tableReorderDebug = []
+    window.__reorderAbortDebug = []
+  })
+  const src = await page.evaluate(() => window.__reorderHarness.cellRectA(2, 0))
+  if (!src) throw new Error('source cell rect not found')
+  await page.mouse.move(src.left + src.width / 2, src.top + src.height / 2)
+  await page.waitForTimeout(80)
+  const handle = await page.evaluate(() => window.__reorderHarness.handleRect('row'))
+  if (!handle) throw new Error('row handle not visible after hover')
+  await page.mouse.move(handle.left + handle.width / 2, handle.top + handle.height / 2)
+  await page.mouse.down()
+  const dst = await page.evaluate(() => window.__reorderHarness.cellRectA(0, 0))
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 6 })
+  await page.waitForTimeout(30)
+  return { dst }
+}
+
+const firstCol = (grid) => grid.map((r) => r[0])
+const beginCount = (dbg) => dbg.filter((e) => e.phase === 'begin').length
+
+// ── P1-1 ──────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nP1-1 — a second pointerdown on the other handle must not clobber the in-flight drag')
+await page.evaluate(() => window.__reorderHarness.mountSingle())
+await page.waitForTimeout(200)
+{
+  const before = await page.evaluate(() => window.__reorderHarness.gridA())
+  const { dst } = await armRealRowDrag()
+
+  // A second finger presses the COLUMN handle mid-drag (distinct pointerId).
+  await page.evaluate((pid) => {
+    const col = document.querySelector('.octo-table-reorder--col')
+    if (!col) throw new Error('col handle not present')
+    const r = col.getBoundingClientRect()
+    col.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        pointerId: pid,
+        button: 0,
+        buttons: 1,
+        clientX: r.left + r.width / 2,
+        clientY: r.top + r.height / 2,
+        bubbles: true,
+      }),
+    )
+  }, FOREIGN_ID)
+  await page.waitForTimeout(20)
+
+  // Release the OWNING (mouse) pointer inside the window — the original ROW reorder must commit.
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 2 })
+  await page.mouse.up()
+  await page.waitForTimeout(120)
+
+  const dbg = await page.evaluate(() => window.__tableReorderDebug)
+  const grid = await page.evaluate(() => window.__reorderHarness.gridA())
+  const begins = beginCount(dbg)
+  console.log('  begin events:', begins, JSON.stringify(dbg.filter((e) => e.phase === 'begin')))
+  console.log('  grid before:', JSON.stringify(firstCol(before)), '→ after:', JSON.stringify(firstCol(grid)))
+  if (begins !== 1) fail(`P1-1 a second beginDrag ran (${begins} begin events) — active-drag guard missing`)
+  else ok('second pointerdown was a no-op (exactly one begin)')
+  if (grid[0][0] !== 'r3c1') fail(`P1-1 the row reorder did not commit correctly: ${JSON.stringify(firstCol(grid))}`)
+  else ok('original ROW reorder committed (identity not clobbered)')
+
+  // No wedge / capture leak: a following independent reorder still works.
+  await page.evaluate(() => window.__reorderHarness.mountSingle())
+  await page.waitForTimeout(150)
+  const after2 = await (async () => {
+    const { dst } = await armRealRowDrag()
+    await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 2 })
+    await page.mouse.up()
+    await page.waitForTimeout(100)
+    return page.evaluate(() => window.__reorderHarness.gridA())
+  })()
+  if (after2[0][0] !== 'r3c1') fail(`P1-1 handles wedged after the multi-pointer drag: ${JSON.stringify(firstCol(after2))}`)
+  else ok('a subsequent reorder still works (no leaked capture / wedge)')
+  await page.screenshot({ path: `${OUT}/p1-1-after.png` })
+}
+
+// ── P1-2 ──────────────────────────────────────────────────────────────────────────────────────────
+console.log('\nP1-2 — a foreign pointer’s pointerup must not end the drag')
+await page.evaluate(() => window.__reorderHarness.mountSingle())
+await page.waitForTimeout(200)
+{
+  const before = await page.evaluate(() => window.__reorderHarness.gridA())
+  const { dst } = await armRealRowDrag()
+
+  // A second, uncaptured pointer lifts elsewhere in the document. Its pointerup reaches the
+  // capture-phase onDocUp; without the id filter this ends the drag and commits the reorder mid-drag.
+  await page.evaluate((pid) => {
+    document.dispatchEvent(
+      new PointerEvent('pointerup', { pointerId: pid, clientX: 40, clientY: 40, bubbles: true }),
+    )
+  }, FOREIGN_ID)
+  await page.waitForTimeout(40)
+
+  const midGrid = await page.evaluate(() => window.__reorderHarness.gridA())
+  const midDbg = await page.evaluate(() => window.__tableReorderDebug)
+  const committedEarly = midDbg.some((e) => e.phase === 'dispatch' && e.dispatched)
+  if (committedEarly || JSON.stringify(midGrid) !== JSON.stringify(before)) {
+    fail(`P1-2 a foreign pointerup ended the drag / committed early: ${JSON.stringify(firstCol(midGrid))}`)
+  } else {
+    ok('foreign pointerup was ignored — drag still in flight, nothing committed')
+  }
+
+  // The OWNING (mouse) release then commits the intended reorder.
+  await page.mouse.move(dst.left + dst.width / 2, dst.top + dst.height / 2, { steps: 2 })
+  await page.mouse.up()
+  await page.waitForTimeout(120)
+  const finalGrid = await page.evaluate(() => window.__reorderHarness.gridA())
+  console.log('  grid before:', JSON.stringify(firstCol(before)), '→ final:', JSON.stringify(firstCol(finalGrid)))
+  if (finalGrid[0][0] !== 'r3c1') fail(`P1-2 the owning release did not commit the reorder: ${JSON.stringify(firstCol(finalGrid))}`)
+  else ok('the owning pointer’s release committed the reorder')
+  await page.screenshot({ path: `${OUT}/p1-2-after.png` })
+}
+
+await browser.close()
+if (failed) {
+  console.error(`\n=== MULTI-POINTER HARNESS FAILED (${failed}) ===`)
+  process.exitCode = 1
+} else {
+  console.log('\n=== MULTI-POINTER HARNESS PASSED: P1-1 guard + P1-2 pointer-id filter hold in a real browser ===')
+}

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -980,33 +980,69 @@ export const TableReorderHandle = Extension.create({
           rowHandle.addEventListener('mousedown', onRowDown)
           colHandle.addEventListener('mousedown', onColDown)
 
-          // The pointer resting on a handle must keep it (and its sibling) visible. Because the
-          // handles sit outside the editor DOM, the editor's mouseleave fires as the pointer arrives;
-          // this mouseenter cancels the resulting deferred hide so the handle stays put (XIN-1233).
-          const onHandleEnter = () => cancelHide()
-          // Leaving a handle (not back toward the other handle) starts the grace timer; a return to a
-          // cell re-cancels it via placeHandles.
-          const onHandleLeave = (e: MouseEvent) => {
-            const to = e.relatedTarget as Node | null
-            if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) return
-            scheduleHide()
+          // Resting-handle placement is driven from a DOCUMENT-level mousemove, NOT the editor's own
+          // handleDOMEvents (mousemove/mouseleave on view.dom). The reorder handles AND the row-height
+          // resize bar (#823) are absolutely-positioned SIBLINGS of the ProseMirror DOM inside the
+          // editor wrapper, and they sit ON TOP of the table cells (z-index 5). When the pointer moves
+          // onto such an overlay the editor fires `mouseleave` and stops receiving `mousemove`, so a
+          // handler bound to view.dom would hide the reorder handles the instant the pointer grazed
+          // the row-resize bar straddling a row's bottom edge — then never get the moves to bring them
+          // back. That is the #822/#823 first-same-build coexistence regression: handles that showed
+          // in the standalone build stayed hidden (display:none / 0x0) and could not be grabbed on the
+          // real :3000 build (XIN-1253). Reading the pointer at the document level is immune to which
+          // sibling happens to be topmost, so the handles track the table regardless of the overlay.
+          const onIdleDocMove = (event: MouseEvent) => {
+            // While a drag is in flight the document drag listeners own the pointer.
+            if (drag) return
+            if (!rowHandle || !colHandle || !view.editable) return
+            const shown = rowHandle.style.display !== 'none' || colHandle.style.display !== 'none'
+            // Read the editor geometry LIVE from view.dom each move. The `wrapper` captured at view()
+            // time is the temporary detached div tiptap mounts into before @tiptap/react moves the DOM
+            // into `.octo-prose`, so its rect is 0×0 and must not be used here. view.dom is always the
+            // live, correctly-positioned editor element (the same box placeHandles measures against).
+            const liveWrapper = view.dom.parentElement
+            const vr = (view.dom as HTMLElement).getBoundingClientRect()
+            // Cheap bounds gate so we only probe the document near the editor. Expand by BAR to
+            // include the left/top gutters where the handles themselves live.
+            const near =
+              event.clientX >= vr.left - BAR - 4 &&
+              event.clientX <= vr.right + 4 &&
+              event.clientY >= vr.top - BAR - 4 &&
+              event.clientY <= vr.bottom + 4
+            if (!near) {
+              if (shown) scheduleHide()
+              return
+            }
+            const ctx = cellContextAt(view, event.clientX, event.clientY)
+            if (ctx) {
+              placeHandles(view, ctx)
+              return
+            }
+            // No cell resolved under the pointer. If the pointer is over one of the plugin overlays
+            // that sit on top of the table — our own handles, or the #823 row-resize bar — i.e. an
+            // element inside the editor wrapper but OUTSIDE the ProseMirror content, the pointer has
+            // NOT left the table, so keep the handles up (this is also the cell→gutter-handle glide
+            // the XIN-1233 grace period was for). Only a move to genuine editor content that is not a
+            // cell, or off the editor entirely, schedules the hide.
+            const target = document.elementFromPoint(event.clientX, event.clientY) as Node | null
+            const overOverlay =
+              target != null && liveWrapper != null && liveWrapper.contains(target) && !view.dom.contains(target)
+            if (overOverlay) {
+              cancelHide()
+              return
+            }
+            if (shown) scheduleHide()
           }
-          rowHandle.addEventListener('mouseenter', onHandleEnter)
-          colHandle.addEventListener('mouseenter', onHandleEnter)
-          rowHandle.addEventListener('mouseleave', onHandleLeave)
-          colHandle.addEventListener('mouseleave', onHandleLeave)
+          document.addEventListener('mousemove', onIdleDocMove, true)
 
           return {
             destroy() {
               removeDragListeners()
               cancelHide()
               document.body.classList.remove('octo-table-reordering')
+              document.removeEventListener('mousemove', onIdleDocMove, true)
               rowHandle?.removeEventListener('mousedown', onRowDown)
               colHandle?.removeEventListener('mousedown', onColDown)
-              rowHandle?.removeEventListener('mouseenter', onHandleEnter)
-              colHandle?.removeEventListener('mouseenter', onHandleEnter)
-              rowHandle?.removeEventListener('mouseleave', onHandleLeave)
-              colHandle?.removeEventListener('mouseleave', onHandleLeave)
               rowHandle?.remove()
               colHandle?.remove()
               indicator?.remove()
@@ -1017,40 +1053,6 @@ export const TableReorderHandle = Extension.create({
               pointerHeldSeen = false
             },
           }
-        },
-        props: {
-          handleDOMEvents: {
-            mousemove(view, event) {
-              // Freeze the resting handles while a drag is in flight (the document-level
-              // listeners own the pointer then).
-              if (drag) return false
-              if (!view.editable) return false
-              const ctx = cellContextAt(view, event.clientX, event.clientY)
-              if (!ctx) {
-                // Pointer is over the editor but not a table cell. Defer the hide instead of
-                // clearing instantly so a quick glide from a cell to the gutter handle (or into a
-                // neighbouring cell) does not flicker the handle away (XIN-1233).
-                scheduleHide()
-                return false
-              }
-              placeHandles(view, ctx)
-              return false
-            },
-            mouseleave(_view, event) {
-              if (drag) return false
-              // Keep the handles up when the pointer moves onto one of them (they live outside
-              // the editor DOM, so leaving the prose region toward a handle must not hide it).
-              const to = (event as MouseEvent).relatedTarget as Node | null
-              if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) {
-                cancelHide()
-                return false
-              }
-              // Otherwise defer: the pointer may be crossing the sliver of dead space on its way to
-              // the handle. The handle's own mouseenter cancels this if it lands there (XIN-1233).
-              scheduleHide()
-              return false
-            },
-          },
         },
       }),
     ]

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -600,6 +600,13 @@ export const TableReorderHandle = Extension.create({
     // whole drag even though a real button is logically down, and treating the first such move as a
     // release wrongly cancelled the reorder (octo-docs-backend#76 / XIN-1215 headed-Chromium repro).
     let pointerHeldSeen = false
+    // Pointer id + handle we captured at drag start (via setPointerCapture). Capturing routes the
+    // terminal pointerup/pointercancel to us EVEN when the user releases OUTSIDE the window, so a drag
+    // can never be left silently armed for a later stray event to commit (octo-docs-backend#76 FAIL-1 /
+    // XIN-1252). null when capture was unavailable (jsdom / a synthetic pointer with no live id) — the
+    // buttons and release-outside guards below still cover that fallback path.
+    let capturedPointerId: number | null = null
+    let capturedHandle: HTMLElement | null = null
 
     const cancelHide = () => {
       if (hideTimer !== null) {
@@ -760,11 +767,24 @@ export const TableReorderHandle = Extension.create({
     // completed drop), cancelDrag (an interrupted drag) and the plugin destroy all detach the SAME
     // set — a listener left attached after the drag ends would keep firing against stale state.
     const removeDragListeners = () => {
-      document.removeEventListener('mousemove', onDocMove, true)
-      document.removeEventListener('mouseup', onDocUp, true)
+      document.removeEventListener('pointermove', onDocMove, true)
+      document.removeEventListener('pointerup', onDocUp, true)
       document.removeEventListener('pointercancel', onDocCancel, true)
       document.removeEventListener('keydown', onDocKey, true)
       window.removeEventListener('blur', onWindowBlur)
+      // Detach the capture-loss listener BEFORE we release the pointer ourselves, so our own
+      // releasePointerCapture does not re-enter cancelDrag mid-teardown. A genuine external capture loss
+      // still aborts via the listener while it is attached.
+      if (capturedHandle) capturedHandle.removeEventListener('lostpointercapture', onLostCapture)
+      if (capturedHandle && capturedPointerId != null) {
+        try {
+          capturedHandle.releasePointerCapture(capturedPointerId)
+        } catch {
+          /* pointer already gone (release outside / synthetic id) — nothing to release */
+        }
+      }
+      capturedPointerId = null
+      capturedHandle = null
     }
 
     // Clear all drag bookkeeping and restore the resting UI. Critically this un-freezes handle
@@ -778,6 +798,8 @@ export const TableReorderHandle = Extension.create({
       committing = false
       dragBaselineSigs = []
       pointerHeldSeen = false
+      capturedPointerId = null
+      capturedHandle = null
       document.body.classList.remove('octo-table-reordering')
       hideIndicator()
       hideHandles()
@@ -872,17 +894,40 @@ export const TableReorderHandle = Extension.create({
         dropIndex,
       })
     }
-    const onDocUp = () => {
-      if (activeView) endDrag(activeView)
+    // True when a release happened OUTSIDE the window's viewport. Pointer capture (see beginDrag) routes
+    // the terminal pointerup to us even when the user lets go past the window edge. A release outside the
+    // window is an INTERRUPTION, not a drop — the reorder drop target is whatever the mid-drag clamp last
+    // resolved, so committing it moves a row/column the user never intended to drop (octo-docs-backend#76
+    // FAIL-1 / XIN-1252). Abort instead. A drop inside the window resolves normally.
+    const releasedOutsideViewport = (event: MouseEvent): boolean => {
+      if (typeof window === 'undefined') return false
+      return (
+        event.clientX < 0 ||
+        event.clientY < 0 ||
+        event.clientX > window.innerWidth ||
+        event.clientY > window.innerHeight
+      )
+    }
+    const onDocUp = (event: MouseEvent) => {
+      if (!activeView) return
+      if (releasedOutsideViewport(event)) {
+        cancelDrag()
+        return
+      }
+      endDrag(activeView)
     }
     // Interruption handlers: an interrupted drag must abort cleanly, never commit a move.
     const onDocCancel = () => cancelDrag()
+    // The OS/browser revoked our pointer capture (pointer stolen, tab hidden, gesture recognised) without
+    // a pointerup reaching us — treat it exactly like pointercancel and abort. removeDragListeners detaches
+    // this before our own releasePointerCapture, so it only fires for genuine EXTERNAL capture loss.
+    const onLostCapture = () => cancelDrag()
     const onWindowBlur = () => cancelDrag()
     const onDocKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') cancelDrag()
     }
 
-    const beginDrag = (view: EditorView, kind: 'row' | 'col', event: MouseEvent) => {
+    const beginDrag = (view: EditorView, kind: 'row' | 'col', event: PointerEvent) => {
       // Only a primary (left) button starts a reorder. A right/middle-click on the grab handle must
       // not begin a drag — it would fight the context menu and, with no matching left mouseup, could
       // strand the drag state (octo-docs-backend#76 review).
@@ -901,12 +946,34 @@ export const TableReorderHandle = Extension.create({
       dragBaselineSigs = tableSignatures(view.state.doc)
       concurrentEdit = false
       pointerHeldSeen = false
+      capturedPointerId = null
+      capturedHandle = null
       reorderDebug({ phase: 'begin', kind, index: kind === 'col' ? hover.rect.left : hover.rect.top })
       dropIndex = null
       activeView = view
       document.body.classList.add('octo-table-reordering')
-      document.addEventListener('mousemove', onDocMove, true)
-      document.addEventListener('mouseup', onDocUp, true)
+      // Capture the pointer on the grabbed handle so the terminal pointerup/pointercancel is delivered to
+      // US even when the user releases OUTSIDE the window — the real-machine path the old mouse-only drag
+      // lost, leaving the drag armed to commit a wrong move (octo-docs-backend#76 FAIL-1 / XIN-1252).
+      // Best-effort: a synthetic pointer (jsdom / a hand-built event) has no live id, so we swallow the
+      // throw and fall back to the buttons + release-outside guards, which still hold.
+      const grabbed = kind === 'row' ? rowHandle : colHandle
+      if (grabbed && typeof event.pointerId === 'number') {
+        try {
+          grabbed.setPointerCapture(event.pointerId)
+          capturedPointerId = event.pointerId
+          capturedHandle = grabbed
+          grabbed.addEventListener('lostpointercapture', onLostCapture)
+        } catch {
+          capturedPointerId = null
+          capturedHandle = null
+        }
+      }
+      // Drive the drag off POINTER events (not mouse): with capture above, pointerup fires wherever the
+      // release happens, so no interruption path can leave the drag silently armed. Listeners stay at the
+      // document (capture phase) so captured pointer events — retargeted to the handle — still reach them.
+      document.addEventListener('pointermove', onDocMove, true)
+      document.addEventListener('pointerup', onDocUp, true)
       document.addEventListener('pointercancel', onDocCancel, true)
       document.addEventListener('keydown', onDocKey, true)
       window.addEventListener('blur', onWindowBlur)
@@ -975,10 +1042,10 @@ export const TableReorderHandle = Extension.create({
             wrapper.appendChild(indicator)
           }
 
-          const onRowDown = (e: MouseEvent) => beginDrag(view, 'row', e)
-          const onColDown = (e: MouseEvent) => beginDrag(view, 'col', e)
-          rowHandle.addEventListener('mousedown', onRowDown)
-          colHandle.addEventListener('mousedown', onColDown)
+          const onRowDown = (e: PointerEvent) => beginDrag(view, 'row', e)
+          const onColDown = (e: PointerEvent) => beginDrag(view, 'col', e)
+          rowHandle.addEventListener('pointerdown', onRowDown)
+          colHandle.addEventListener('pointerdown', onColDown)
 
           // Resting-handle placement is driven from a DOCUMENT-level mousemove, NOT the editor's own
           // handleDOMEvents (mousemove/mouseleave on view.dom). The reorder handles AND the row-height
@@ -1041,8 +1108,8 @@ export const TableReorderHandle = Extension.create({
               cancelHide()
               document.body.classList.remove('octo-table-reordering')
               document.removeEventListener('mousemove', onIdleDocMove, true)
-              rowHandle?.removeEventListener('mousedown', onRowDown)
-              colHandle?.removeEventListener('mousedown', onColDown)
+              rowHandle?.removeEventListener('pointerdown', onRowDown)
+              colHandle?.removeEventListener('pointerdown', onColDown)
               rowHandle?.remove()
               colHandle?.remove()
               indicator?.remove()
@@ -1051,6 +1118,8 @@ export const TableReorderHandle = Extension.create({
               drag = null
               concurrentEdit = false
               pointerHeldSeen = false
+              capturedPointerId = null
+              capturedHandle = null
             },
           }
         },

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -826,8 +826,16 @@ export const TableReorderHandle = Extension.create({
 
     // Bound once so add/removeEventListener pair up; `activeView` is set on drag start.
     let activeView: EditorView | null = null
-    const onDocMove = (event: MouseEvent) => {
+    const onDocMove = (event: PointerEvent) => {
       if (!drag || !activeView) return
+      // Only the CAPTURED pointer drives the drag. Listeners sit at the document capture phase, and
+      // setPointerCapture only RETARGETS the owning pointer's events to the handle — it does not
+      // suppress a second, uncaptured pointer's events. Without this filter a second finger's
+      // pointermove would drive the drop-target probe (and `releasedOutsideViewport`) against the
+      // wrong pointer's coordinates. When there is no live capture id (`capturedPointerId == null` —
+      // a synthetic / jsdom pointer that could not be captured) we keep the original unfiltered
+      // behaviour so those paths still work (octo-docs-backend#76 P1-2).
+      if (capturedPointerId != null && event.pointerId !== capturedPointerId) return
       // The primary button was released while we could not see it — the classic "let go outside the
       // window" interruption: the pointer left the window mid-drag, the mouseup fired over another
       // app (so our document `mouseup` listener never ran), and the button is now up as the pointer
@@ -908,8 +916,13 @@ export const TableReorderHandle = Extension.create({
         event.clientY > window.innerHeight
       )
     }
-    const onDocUp = (event: MouseEvent) => {
+    const onDocUp = (event: PointerEvent) => {
       if (!activeView) return
+      // Ignore a foreign pointer's release: a second, uncaptured pointer's `pointerup` still reaches
+      // this capture-phase listener, and without the filter it would call endDrag() and commit the
+      // reorder mid-first-pointer-drag. Only the captured pointer ends the drag; the null-capture
+      // (synthetic / jsdom) path keeps the original behaviour (octo-docs-backend#76 P1-2).
+      if (capturedPointerId != null && event.pointerId !== capturedPointerId) return
       if (releasedOutsideViewport(event)) {
         cancelDrag()
         return
@@ -917,7 +930,12 @@ export const TableReorderHandle = Extension.create({
       endDrag(activeView)
     }
     // Interruption handlers: an interrupted drag must abort cleanly, never commit a move.
-    const onDocCancel = () => cancelDrag()
+    const onDocCancel = (event: PointerEvent) => {
+      // A pointercancel for an UNRELATED pointer (a second finger the OS cancelled) must not abort our
+      // drag. Only the captured pointer's cancel aborts; null-capture keeps the original behaviour.
+      if (capturedPointerId != null && event.pointerId !== capturedPointerId) return
+      cancelDrag()
+    }
     // The OS/browser revoked our pointer capture (pointer stolen, tab hidden, gesture recognised) without
     // a pointerup reaching us — treat it exactly like pointercancel and abort. removeDragListeners detaches
     // this before our own releasePointerCapture, so it only fires for genuine EXTERNAL capture loss.
@@ -928,6 +946,14 @@ export const TableReorderHandle = Extension.create({
     }
 
     const beginDrag = (view: EditorView, kind: 'row' | 'col', event: PointerEvent) => {
+      // A drag is already in flight — bail. Both rowHandle and colHandle carry live `pointerdown`
+      // listeners at once, so a SECOND pointerdown (a second finger on the other handle, a stylus, or
+      // a stray re-entry) while a drag is active would otherwise overwrite `drag`/`ordinal`/
+      // `capturedPointerId`/`capturedHandle` in place — leaking the first pointer's setPointerCapture
+      // (never released) and corrupting the drag identity so the move commits to the wrong row/column
+      // (multi-touch re-entrancy). One drag owns the pipeline until it ends; the second pointerdown is
+      // a no-op (octo-docs-backend#76 P1-1).
+      if (drag) return
       // Only a primary (left) button starts a reorder. A right/middle-click on the grab handle must
       // not begin a drag — it would fight the context menu and, with no matching left mouseup, could
       // strand the drag state (octo-docs-backend#76 review).

--- a/packages/docs/src/editor/TableReorderHandle.ts
+++ b/packages/docs/src/editor/TableReorderHandle.ts
@@ -104,10 +104,20 @@ function reorderAbortDebug(event: ReorderAbortDebugEvent): void {
   if (Array.isArray(sink)) sink.push(event)
 }
 
-// Thickness (px) of the grab bar that sits in the gutter above a column / left of a row. Kept
-// slim so it hugs the table edge and stays clear of the column-resize handle (interior, right
-// edge of each cell) and the block drag handle (further out in the left gutter).
-const BAR = 14
+// Thickness (px) of the grab bar that sits in the gutter above a column / left of a row. Wide
+// enough to be an easy pointer target (the XIN-1233 UX gate: "命中区太小" made it hard to hit)
+// while still hugging the table edge and staying clear of the column-resize handle (interior,
+// right edge of each cell) and the block drag handle (further out in the left gutter).
+const BAR = 18
+
+// Grace period (ms) before a handle is hidden after the pointer leaves the table region. Without
+// it the handle vanished the instant the pointer left a cell — and because the handle sits in the
+// gutter OUTSIDE the editor DOM, the pointer must cross a sliver of dead space to reach it, so a
+// user moving toward the handle saw it disappear before arriving ("鼠标一移开就消失", XIN-1233).
+// The delay lets that crossing land on the handle (whose own mouseenter cancels the pending hide)
+// instead of racing it away. Kept short so the handle still clears promptly when the pointer
+// genuinely leaves the table.
+const HIDE_DELAY = 220
 
 /** Resolved geometry for the table cell under a screen point. `rect` holds TableMap grid
  * indices ({left,top,right,bottom} as column/row indices), `cellPos` is the document position
@@ -575,6 +585,13 @@ export const TableReorderHandle = Extension.create({
     // whole-table replace for a concurrent remote conflict (the local move lands while `drag` is still
     // set, and it obviously changes the dragged table).
     let committing = false
+    // Deferred-hide timer for the resting handles (XIN-1233). The handles live in the gutter OUTSIDE
+    // the editor DOM, so moving the pointer from a cell onto a handle briefly crosses dead space and
+    // fires the editor's `mouseleave`. Hiding immediately there made the handle vanish before the
+    // pointer could reach it. Instead we schedule the hide and let the handle's own mouseenter (or the
+    // pointer returning to a cell) cancel it — so a deliberate move toward the handle keeps it up while
+    // an actual departure still clears it after the grace period.
+    let hideTimer: ReturnType<typeof setTimeout> | null = null
     // Latches true once we have seen a mid-drag mousemove that actually reports the primary button
     // held (`buttons & 1`). It gates the "released outside the window" abort below: that abort must
     // only fire on a genuine release, i.e. AFTER the button was observed down. Some event sources
@@ -584,10 +601,27 @@ export const TableReorderHandle = Extension.create({
     // release wrongly cancelled the reorder (octo-docs-backend#76 / XIN-1215 headed-Chromium repro).
     let pointerHeldSeen = false
 
+    const cancelHide = () => {
+      if (hideTimer !== null) {
+        clearTimeout(hideTimer)
+        hideTimer = null
+      }
+    }
     const hideHandles = () => {
+      cancelHide()
       if (rowHandle) rowHandle.style.display = 'none'
       if (colHandle) colHandle.style.display = 'none'
       hover = null
+    }
+    // Hide the resting handles after the grace period unless something cancels first (the pointer
+    // returning to a cell, or landing on a handle). Idempotent — re-arming just resets the clock.
+    const scheduleHide = () => {
+      if (drag) return
+      cancelHide()
+      hideTimer = setTimeout(() => {
+        hideTimer = null
+        hideHandles()
+      }, HIDE_DELAY)
     }
     const hideIndicator = () => {
       if (indicator) indicator.style.display = 'none'
@@ -597,6 +631,8 @@ export const TableReorderHandle = Extension.create({
     // from the DOM each move so the handles track scrolling inside .tableWrapper.
     const placeHandles = (view: EditorView, ctx: CellContext) => {
       if (!rowHandle || !colHandle) return
+      // The pointer is live over the table — keep the handles up and abort any pending hide.
+      cancelHide()
       const cellDom = view.nodeDOM(ctx.cellPos)
       const tableDom = tableElementAt(view, ctx.tablePos)
       if (!(cellDom instanceof HTMLElement) || !tableDom) {
@@ -607,16 +643,19 @@ export const TableReorderHandle = Extension.create({
       const cell = cellDom.getBoundingClientRect()
       const table = tableDom.getBoundingClientRect()
 
-      // Column handle: a bar spanning the hovered column's width, just above the table.
+      // Column handle: a bar spanning the hovered column's width, flush against the top table edge.
+      // No gap between the bar and the table (it used to sit 2px above): the gap was uncovered space
+      // the pointer had to cross to reach the handle, which fired the editor's mouseleave and hid the
+      // handle mid-approach (XIN-1233). Flush + the deferred hide make the cell→handle move seamless.
       colHandle.style.display = 'flex'
       colHandle.style.left = `${cell.left - base.left}px`
-      colHandle.style.top = `${table.top - base.top - BAR - 2}px`
+      colHandle.style.top = `${table.top - base.top - BAR}px`
       colHandle.style.width = `${cell.width}px`
       colHandle.style.height = `${BAR}px`
 
-      // Row handle: a bar spanning the hovered row's height, just left of the table.
+      // Row handle: a bar spanning the hovered row's height, flush against the left table edge.
       rowHandle.style.display = 'flex'
-      rowHandle.style.left = `${table.left - base.left - BAR - 2}px`
+      rowHandle.style.left = `${table.left - base.left - BAR}px`
       rowHandle.style.top = `${cell.top - base.top}px`
       rowHandle.style.width = `${BAR}px`
       rowHandle.style.height = `${cell.height}px`
@@ -850,6 +889,7 @@ export const TableReorderHandle = Extension.create({
       if (event.button !== 0) return
       if (!view.editable || !hover) return
       event.preventDefault()
+      cancelHide()
       drag = {
         kind,
         // Stable, coarse-ReplaceStep-proof identity for the dragged table + source line.
@@ -940,12 +980,33 @@ export const TableReorderHandle = Extension.create({
           rowHandle.addEventListener('mousedown', onRowDown)
           colHandle.addEventListener('mousedown', onColDown)
 
+          // The pointer resting on a handle must keep it (and its sibling) visible. Because the
+          // handles sit outside the editor DOM, the editor's mouseleave fires as the pointer arrives;
+          // this mouseenter cancels the resulting deferred hide so the handle stays put (XIN-1233).
+          const onHandleEnter = () => cancelHide()
+          // Leaving a handle (not back toward the other handle) starts the grace timer; a return to a
+          // cell re-cancels it via placeHandles.
+          const onHandleLeave = (e: MouseEvent) => {
+            const to = e.relatedTarget as Node | null
+            if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) return
+            scheduleHide()
+          }
+          rowHandle.addEventListener('mouseenter', onHandleEnter)
+          colHandle.addEventListener('mouseenter', onHandleEnter)
+          rowHandle.addEventListener('mouseleave', onHandleLeave)
+          colHandle.addEventListener('mouseleave', onHandleLeave)
+
           return {
             destroy() {
               removeDragListeners()
+              cancelHide()
               document.body.classList.remove('octo-table-reordering')
               rowHandle?.removeEventListener('mousedown', onRowDown)
               colHandle?.removeEventListener('mousedown', onColDown)
+              rowHandle?.removeEventListener('mouseenter', onHandleEnter)
+              colHandle?.removeEventListener('mouseenter', onHandleEnter)
+              rowHandle?.removeEventListener('mouseleave', onHandleLeave)
+              colHandle?.removeEventListener('mouseleave', onHandleLeave)
               rowHandle?.remove()
               colHandle?.remove()
               indicator?.remove()
@@ -966,7 +1027,10 @@ export const TableReorderHandle = Extension.create({
               if (!view.editable) return false
               const ctx = cellContextAt(view, event.clientX, event.clientY)
               if (!ctx) {
-                hideHandles()
+                // Pointer is over the editor but not a table cell. Defer the hide instead of
+                // clearing instantly so a quick glide from a cell to the gutter handle (or into a
+                // neighbouring cell) does not flicker the handle away (XIN-1233).
+                scheduleHide()
                 return false
               }
               placeHandles(view, ctx)
@@ -977,8 +1041,13 @@ export const TableReorderHandle = Extension.create({
               // Keep the handles up when the pointer moves onto one of them (they live outside
               // the editor DOM, so leaving the prose region toward a handle must not hide it).
               const to = (event as MouseEvent).relatedTarget as Node | null
-              if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) return false
-              hideHandles()
+              if (to && (rowHandle?.contains(to) || colHandle?.contains(to))) {
+                cancelHide()
+                return false
+              }
+              // Otherwise defer: the pointer may be crossing the sliver of dead space on its way to
+              // the handle. The handle's own mouseenter cancels this if it lands there (XIN-1233).
+              scheduleHide()
               return false
             },
           },

--- a/packages/docs/src/editor/TableReorderHandleUsable.test.ts
+++ b/packages/docs/src/editor/TableReorderHandleUsable.test.ts
@@ -148,23 +148,25 @@ describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
   })
 })
 
-// octo-docs-backend#76 handle-discoverability regression (XIN-1233). The grab handle sits in the
-// gutter OUTSIDE the editor DOM, so moving the pointer from a cell toward the handle briefly crosses
-// dead space and fires the editor's `mouseleave`. The old code hid the handle synchronously there, so
-// the handle vanished before the pointer could reach it ("鼠标一移开就消失") — users could not
-// reliably trigger a move. The fix defers the hide by a grace period that the handle's own mouseenter
-// (or the pointer returning to a cell) cancels. These tests pin that behaviour with fake timers.
-describe('handle stability / discoverability (octo-docs-backend#76 / XIN-1233)', () => {
-  it('does not hide the handle synchronously when the pointer leaves the prose toward the gutter', () => {
+// octo-docs-backend#76 handle-discoverability + coexistence regression (XIN-1233 → XIN-1253). The
+// grab handle and the #823 row-height resize bar are absolutely-positioned SIBLINGS of the editor
+// DOM that sit ON TOP of the table. A hide driven by the editor's own `mouseleave` fired the moment
+// the pointer crossed onto ANY such overlay (the gutter dead space, or #823's full-width bar at a
+// row's bottom edge), so the handle vanished before it could be grabbed. The fix drives resting-handle
+// visibility from a DOCUMENT-level mousemove that reads the pointer directly: it re-places the handle
+// while the pointer resolves to a cell, keeps it while the pointer is over a plugin overlay inside the
+// editor wrapper, and hides it (after a short grace period) only once the pointer genuinely leaves.
+describe('handle stability / discoverability (octo-docs-backend#76 / XIN-1233, XIN-1253)', () => {
+  it('hides the handle after the grace period once the pointer genuinely leaves the table', () => {
     vi.useFakeTimers()
     try {
       editor = mount(TABLE_3x2)
       hoverCell(editor, 2, 0)
       const rowHandle = host?.querySelector('.octo-table-reorder--row') as HTMLElement | null
       expect(rowHandle?.style.display).not.toBe('none')
-      // Pointer leaves the editor prose heading for the gutter handle (relatedTarget is not a handle).
-      editor.view.dom.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }))
-      // Must NOT vanish immediately — this is the regression: it used to hide right here.
+      // Pointer moves well away from the editor (no cell, outside the editor region): schedule hide.
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9999, clientY: 9999 }))
+      // Must NOT vanish synchronously — the grace period keeps it up briefly.
       expect(rowHandle?.style.display, 'handle stays visible during the grace period').not.toBe('none')
       // After the grace period elapses with no rescue, it clears.
       vi.advanceTimersByTime(500)
@@ -174,19 +176,26 @@ describe('handle stability / discoverability (octo-docs-backend#76 / XIN-1233)',
     }
   })
 
-  it('keeps the handle visible when the pointer lands on it (mouseenter cancels the deferred hide)', () => {
+  it('keeps the handle visible while the pointer is over a plugin overlay on top of the table (#823 coexistence, XIN-1253)', () => {
     vi.useFakeTimers()
     try {
       editor = mount(TABLE_3x2)
       hoverCell(editor, 2, 0)
       const rowHandle = host?.querySelector('.octo-table-reorder--row') as HTMLElement | null
       if (!rowHandle) throw new Error('row handle not rendered')
-      // Leave the prose (arms the deferred hide)...
-      editor.view.dom.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }))
-      // ...then the pointer arrives on the handle before the timer fires.
-      rowHandle.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }))
+      // The pointer moves onto a sibling overlay that sits ON TOP of a cell — e.g. #823's row-resize
+      // bar at the row's bottom edge. No cell resolves under the pointer, but elementFromPoint is an
+      // element inside the editor wrapper (here the reorder handle itself stands in for that overlay)
+      // and OUTSIDE the prose. The editor's mouseleave used to hide the handle here; it must not now.
+      ;(editor.view as unknown as { posAtCoords: () => null }).posAtCoords = () => null
+      // jsdom does not implement elementFromPoint; stub it to report the overlay under the pointer.
+      const doc = document as unknown as { elementFromPoint?: (x: number, y: number) => Element | null }
+      const prev = doc.elementFromPoint
+      doc.elementFromPoint = () => rowHandle
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3 }))
       vi.advanceTimersByTime(500)
-      expect(rowHandle.style.display, 'handle stays put while the pointer rests on it').not.toBe('none')
+      expect(rowHandle.style.display, 'handle stays put over the overlay').not.toBe('none')
+      doc.elementFromPoint = prev
     } finally {
       vi.useRealTimers()
     }

--- a/packages/docs/src/editor/TableReorderHandleUsable.test.ts
+++ b/packages/docs/src/editor/TableReorderHandleUsable.test.ts
@@ -104,6 +104,8 @@ function hoverCell(ed: Editor, row: number, col: number): void {
   ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3, bubbles: true }))
 }
 
+const PID = 9
+
 describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
   it('renders the static row and column handles on a fresh document when a cell is hovered', () => {
     editor = mount(TABLE_3x2)
@@ -122,12 +124,12 @@ describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
     hoverCell(editor, 2, 0) // hover row 3
     const handle = host?.querySelector('.octo-table-reorder--row')
     if (!handle) throw new Error('row handle not rendered')
-    handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+    handle.dispatchEvent(new PointerEvent('pointerdown', { pointerId: PID, button: 0, buttons: 1, clientX: 3, clientY: 3, bubbles: true }))
     // Move over row 1 with NO `buttons` set (defaults to 0) — this is the automation / synthetic
     // path. Before the fix the guard aborted here; now the reorder proceeds.
     stubPos = insideCell(editor, 0, 0)
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9 }))
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    document.dispatchEvent(new PointerEvent('pointermove', { pointerId: PID, clientX: 9, clientY: 9 }))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
     expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
   })
 
@@ -137,13 +139,13 @@ describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
     hoverCell(editor, 2, 0)
     const handle = host?.querySelector('.octo-table-reorder--row')
     if (!handle) throw new Error('row handle not rendered')
-    handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+    handle.dispatchEvent(new PointerEvent('pointerdown', { pointerId: PID, button: 0, buttons: 1, clientX: 3, clientY: 3, bubbles: true }))
     // A real held-button move (buttons:1) arms the drag...
     stubPos = insideCell(editor, 0, 0)
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 1 }))
+    document.dispatchEvent(new PointerEvent('pointermove', { pointerId: PID, clientX: 9, clientY: 9, buttons: 1 }))
     // ...then the pointer re-enters with the button released outside the window (buttons:0): abort.
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 0 }))
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    document.dispatchEvent(new PointerEvent('pointermove', { pointerId: PID, clientX: 9, clientY: 9, buttons: 0 }))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
     expect(grid(editor)).toEqual(before)
   })
 })

--- a/packages/docs/src/editor/TableReorderHandleUsable.test.ts
+++ b/packages/docs/src/editor/TableReorderHandleUsable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Table } from '@tiptap/extension-table'
@@ -145,5 +145,50 @@ describe('handle usability (octo-docs-backend#76 / XIN-1216)', () => {
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 0 }))
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
     expect(grid(editor)).toEqual(before)
+  })
+})
+
+// octo-docs-backend#76 handle-discoverability regression (XIN-1233). The grab handle sits in the
+// gutter OUTSIDE the editor DOM, so moving the pointer from a cell toward the handle briefly crosses
+// dead space and fires the editor's `mouseleave`. The old code hid the handle synchronously there, so
+// the handle vanished before the pointer could reach it ("鼠标一移开就消失") — users could not
+// reliably trigger a move. The fix defers the hide by a grace period that the handle's own mouseenter
+// (or the pointer returning to a cell) cancels. These tests pin that behaviour with fake timers.
+describe('handle stability / discoverability (octo-docs-backend#76 / XIN-1233)', () => {
+  it('does not hide the handle synchronously when the pointer leaves the prose toward the gutter', () => {
+    vi.useFakeTimers()
+    try {
+      editor = mount(TABLE_3x2)
+      hoverCell(editor, 2, 0)
+      const rowHandle = host?.querySelector('.octo-table-reorder--row') as HTMLElement | null
+      expect(rowHandle?.style.display).not.toBe('none')
+      // Pointer leaves the editor prose heading for the gutter handle (relatedTarget is not a handle).
+      editor.view.dom.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }))
+      // Must NOT vanish immediately — this is the regression: it used to hide right here.
+      expect(rowHandle?.style.display, 'handle stays visible during the grace period').not.toBe('none')
+      // After the grace period elapses with no rescue, it clears.
+      vi.advanceTimersByTime(500)
+      expect(rowHandle?.style.display, 'handle hides once the grace period lapses').toBe('none')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the handle visible when the pointer lands on it (mouseenter cancels the deferred hide)', () => {
+    vi.useFakeTimers()
+    try {
+      editor = mount(TABLE_3x2)
+      hoverCell(editor, 2, 0)
+      const rowHandle = host?.querySelector('.octo-table-reorder--row') as HTMLElement | null
+      if (!rowHandle) throw new Error('row handle not rendered')
+      // Leave the prose (arms the deferred hide)...
+      editor.view.dom.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }))
+      // ...then the pointer arrives on the handle before the timer fires.
+      rowHandle.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }))
+      vi.advanceTimersByTime(500)
+      expect(rowHandle.style.display, 'handle stays put while the pointer rests on it').not.toBe('none')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/docs/src/editor/TableReorderInterrupt.test.ts
+++ b/packages/docs/src/editor/TableReorderInterrupt.test.ts
@@ -17,10 +17,11 @@ import { TableReorderHandle } from './TableReorderHandle.ts'
 // through the stub). The positive control proves this harness CAN commit a reorder on a real mouseup,
 // so the interruption tests genuinely show the commit was suppressed.
 //
-// The headline regression is "let go outside the window": the pointer leaves mid-drag, the button is
-// released over another app (no document `mouseup` reaches us), and the drag was left armed so the
-// NEXT stray mouseup committed a reorder the user had abandoned. The guard is a `buttons === 0` check
-// in the document mousemove handler that aborts as the pointer re-enters with no button pressed.
+// The headline regression is "let go outside the window": the pointer leaves mid-drag and the button is
+// released OUTSIDE the window. The drag now runs on POINTER events and the handle captures the pointer at
+// drag start, so the terminal pointerup is delivered with out-of-viewport coordinates — we abort on that
+// (a release outside the window is an interruption, not a drop). Pointercancel/blur/Escape and a fallback
+// buttons===0 check on the document pointermove cover the remaining interruption paths.
 
 const TABLE_3x2 =
   '<table><tbody>' +
@@ -99,67 +100,86 @@ function pointPosAt(ed: Editor): void {
 }
 
 /** Arm a row drag: hover the source cell (sets the handle's source), press the handle, then move
- * over the target cell so a drop target (dropIndex) is resolved. Leaves the drag in flight. */
+ * over the target cell so a drop target (dropIndex) is resolved. Leaves the drag in flight. The drag
+ * runs on POINTER events with the handle capturing the pointer, so the terminal release is delivered
+ * even outside the window (octo-docs-backend#76 FAIL-1 / XIN-1252). */
+const PID = 5
 function armRowDrag(ed: Editor, srcRow: number, dstRow: number): void {
   pointPosAt(ed)
-  // 1. hover source cell → placeHandles records it as the drag source.
+  // 1. hover source cell → placeHandles records it as the drag source (hover stays a mousemove).
   stubPos = insideCell(ed, srcRow, 0)
   ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3, bubbles: true }))
   // 2. press the row handle (primary button) → beginDrag.
   const handle = host?.querySelector('.octo-table-reorder--row')
   if (!handle) throw new Error('row handle not rendered')
-  handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }))
+  handle.dispatchEvent(new PointerEvent('pointerdown', { pointerId: PID, button: 0, buttons: 1, clientX: 3, clientY: 3, bubbles: true }))
   // 3. move over the target cell (button held) → resolves a drop target.
   stubPos = insideCell(ed, dstRow, 0)
-  document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 1 }))
+  document.dispatchEvent(new PointerEvent('pointermove', { pointerId: PID, clientX: 9, clientY: 9, buttons: 1 }))
 }
 
 describe('FAIL-1: interrupted drag is a pure abort (no reorder)', () => {
-  it('positive control: a real mouseup after the drag DOES reorder', () => {
+  it('positive control: a real pointerup inside the window DOES reorder', () => {
     editor = mount(TABLE_3x2)
     armRowDrag(editor, 2, 0) // drag row 3 toward the top
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
     // The drop committed: row "r3" moved above the others.
     expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
   })
 
-  it('Escape aborts: table order unchanged, later mouseup is inert', () => {
+  it('Escape aborts: table order unchanged, later pointerup is inert', () => {
     editor = mount(TABLE_3x2)
     const before = grid(editor)
     armRowDrag(editor, 2, 0)
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-    // A stray mouseup after the interruption must not commit anything.
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    // A stray release after the interruption must not commit anything.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
     expect(grid(editor)).toEqual(before)
   })
 
-  it('window blur aborts: table order unchanged, later mouseup is inert', () => {
+  it('window blur aborts: table order unchanged, later pointerup is inert', () => {
     editor = mount(TABLE_3x2)
     const before = grid(editor)
     armRowDrag(editor, 2, 0)
     window.dispatchEvent(new Event('blur'))
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
     expect(grid(editor)).toEqual(before)
   })
 
-  it('pointercancel aborts: table order unchanged, later mouseup is inert', () => {
+  it('pointercancel aborts: table order unchanged, later pointerup is inert', () => {
     editor = mount(TABLE_3x2)
     const before = grid(editor)
     armRowDrag(editor, 2, 0)
     document.dispatchEvent(new Event('pointercancel'))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+
+  it('release OUTSIDE the window (pointerup past the viewport edge) aborts: no reorder', () => {
+    editor = mount(TABLE_3x2)
+    const before = grid(editor)
+    armRowDrag(editor, 2, 0)
+    // The FAIL-1 headline case: the pointer left the window mid-drag and the button was released OUTSIDE
+    // it. Pointer capture routes that terminal pointerup to us with out-of-viewport coordinates — a
+    // release outside the window is an interruption, not a drop, so no reorder commits. A stray plain
+    // mouseup afterwards is inert too (the drag is no longer armed).
+    document.dispatchEvent(
+      new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: window.innerHeight + 500, bubbles: true }),
+    )
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
     expect(grid(editor)).toEqual(before)
   })
 
-  it('released outside the window (buttons === 0 on re-entry) aborts: no reorder', () => {
+  it('a stray plain mouseup during a drag never reorders (only a genuine pointerup can drop)', () => {
     editor = mount(TABLE_3x2)
     const before = grid(editor)
     armRowDrag(editor, 2, 0)
-    // Pointer re-enters the window with no button pressed — the mouseup happened outside and was
-    // never delivered. This is the FAIL-1 headline case: old code left the drag armed and the next
-    // mouseup committed a reorder; the guard now aborts here.
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 9, clientY: 9, buttons: 0 }))
+    // The old mouse-driven drag committed on ANY document mouseup — the exact stray event a recovered
+    // outside-window release delivers. The pointer-driven drag ignores plain mouseups entirely.
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
     expect(grid(editor)).toEqual(before)
+    // …and the genuine pointerup that follows a real drop still reorders.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: PID, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
   })
 })

--- a/packages/docs/src/editor/TableReorderMultiPointer.test.ts
+++ b/packages/docs/src/editor/TableReorderMultiPointer.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Table } from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import { TableMap } from '@tiptap/pm/tables'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableReorderHandle } from './TableReorderHandle.ts'
+
+// octo-docs-backend#76 P1-1 / P1-2 (multi-pointer re-entrancy in the Pointer Events migration).
+//
+// The drag pipeline moved from mouse events to pointer events + `setPointerCapture`. Two defects the
+// reviewers (yujiawei / Jerry-Xin) surfaced on that migration are exercised here:
+//   P1-1 — `beginDrag` had no active-drag guard, so a second `pointerdown` (a second finger / stylus
+//          on the OTHER handle, or a stray re-entry) clobbered the in-flight drag identity and leaked
+//          the first pointer's capture. Fixed by `if (drag) return` at the top of `beginDrag`.
+//   P1-2 — the document capture-phase `pointermove`/`pointerup`/`pointercancel` handlers gated only on
+//          `!drag`/`!activeView`, not on the captured pointer id. `setPointerCapture` only retargets the
+//          OWNING pointer — a second, uncaptured pointer's `pointerup` still reached `onDocUp` and ended
+//          the drag mid-first-pointer. Fixed by filtering each handler on `event.pointerId ===
+//          capturedPointerId` (with the null-capture / synthetic fallback preserved).
+//
+// jsdom has no real pointer capture, so we stub `setPointerCapture`/`releasePointerCapture` on the
+// handle elements. The stub both makes `capturedPointerId` latch (so the id filter is live, as it is in
+// a real browser) and records the set of currently-captured pointer ids so a capture LEAK is observable.
+
+const TABLE_3x2 =
+  '<table><tbody>' +
+  '<tr><td><p>r1c1</p></td><td><p>r1c2</p></td></tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '<tr><td><p>r3c1</p></td><td><p>r3c2</p></td></tr>' +
+  '</tbody></table>'
+
+let editor: Editor | null = null
+let host: HTMLElement | null = null
+
+// Pointer ids currently held via the stubbed capture, and the high-water mark of concurrent captures.
+// A leaked capture (P1-1) shows up as `maxConcurrentCaptures > 1`.
+const capturedIds = new Set<number>()
+let maxConcurrentCaptures = 0
+let originalSet: unknown
+let originalRelease: unknown
+
+beforeEach(() => {
+  capturedIds.clear()
+  maxConcurrentCaptures = 0
+  const proto = HTMLElement.prototype as unknown as {
+    setPointerCapture?: (id: number) => void
+    releasePointerCapture?: (id: number) => void
+  }
+  originalSet = proto.setPointerCapture
+  originalRelease = proto.releasePointerCapture
+  proto.setPointerCapture = function (id: number) {
+    capturedIds.add(id)
+    if (capturedIds.size > maxConcurrentCaptures) maxConcurrentCaptures = capturedIds.size
+  }
+  proto.releasePointerCapture = function (id: number) {
+    capturedIds.delete(id)
+  }
+})
+
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+  host?.remove()
+  host = null
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>
+  proto.setPointerCapture = originalSet
+  proto.releasePointerCapture = originalRelease
+})
+
+function mount(content: string): Editor {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  return new Editor({
+    element: host,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      TableReorderHandle,
+    ],
+    content,
+  })
+}
+
+function firstTable(ed: Editor): { node: PMNode; pos: number } {
+  let node: PMNode | null = null
+  let pos = -1
+  ed.state.doc.descendants((n, p) => {
+    if (!node && n.type.name === 'table') {
+      node = n
+      pos = p
+      return false
+    }
+    return true
+  })
+  if (!node) throw new Error('no table')
+  return { node, pos }
+}
+/** A document position INSIDE the (row,col) cell's paragraph — what posAtCoords is pointed at. */
+function insideCell(ed: Editor, row: number, col: number): number {
+  const { node, pos } = firstTable(ed)
+  const map = TableMap.get(node)
+  return pos + 1 + map.map[row * map.width + col] + 2
+}
+/** Cell text grid, read from the current TableMap. */
+function grid(ed: Editor): string[][] {
+  const { node } = firstTable(ed)
+  const map = TableMap.get(node)
+  const out: string[][] = []
+  for (let r = 0; r < map.height; r++) {
+    const rowArr: string[] = []
+    for (let c = 0; c < map.width; c++) {
+      const cell = node.nodeAt(map.map[r * map.width + c])
+      rowArr.push(cell ? cell.textContent : '')
+    }
+    out.push(rowArr)
+  }
+  return out
+}
+
+let stubPos = 0
+function pointPosAt(ed: Editor): void {
+  ;(ed.view as unknown as { posAtCoords: (c: { left: number; top: number }) => { pos: number; inside: number } }).posAtCoords =
+    () => ({ pos: stubPos, inside: stubPos })
+}
+
+const OWNER = 5 // pointer id of the finger that owns the drag
+const FOREIGN = 9 // a second, uncaptured pointer id
+
+/** Arm a row drag on the OWNER pointer: hover the source cell, press the row handle (captures OWNER),
+ * then a held move over the target cell resolves a drop. Leaves the drag in flight. */
+function armRowDrag(ed: Editor, srcRow: number, dstRow: number): void {
+  pointPosAt(ed)
+  stubPos = insideCell(ed, srcRow, 0)
+  ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 3, bubbles: true }))
+  const handle = host?.querySelector('.octo-table-reorder--row')
+  if (!handle) throw new Error('row handle not rendered')
+  handle.dispatchEvent(
+    new PointerEvent('pointerdown', { pointerId: OWNER, button: 0, buttons: 1, clientX: 3, clientY: 3, bubbles: true }),
+  )
+  stubPos = insideCell(ed, dstRow, 0)
+  document.dispatchEvent(new PointerEvent('pointermove', { pointerId: OWNER, clientX: 9, clientY: 9, buttons: 1 }))
+}
+
+describe('P1-1: beginDrag guards against a second pointer clobbering an in-flight drag', () => {
+  it('a second pointerdown on the other handle is a no-op — row drag identity survives, no capture leak', () => {
+    editor = mount(TABLE_3x2)
+    armRowDrag(editor, 2, 0) // OWNER drags row 3 toward the top
+    expect(capturedIds.has(OWNER)).toBe(true)
+
+    // A second finger presses the COLUMN handle mid-drag. Without the guard this re-ran beginDrag,
+    // overwrote drag/ordinal/capturedPointerId with a column drag and captured a second pointer while
+    // the first capture was never released.
+    const colHandle = host?.querySelector('.octo-table-reorder--col')
+    if (!colHandle) throw new Error('col handle not rendered')
+    colHandle.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerId: FOREIGN, button: 0, buttons: 1, clientX: 3, clientY: 3, bubbles: true }),
+    )
+
+    // No leaked capture: only one pointer was ever held at a time.
+    expect(maxConcurrentCaptures).toBe(1)
+    expect(capturedIds.has(FOREIGN)).toBe(false)
+
+    // The owner releases inside the window: the ORIGINAL row drag commits (row 3 to the top), proving
+    // the drag identity was not corrupted into a column drag.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: OWNER, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+  })
+})
+
+describe('P1-2: document pointer handlers ignore a foreign (uncaptured) pointer', () => {
+  it('a second pointer’s pointerup does NOT end the drag; the owning pointerup still commits', () => {
+    editor = mount(TABLE_3x2)
+    armRowDrag(editor, 2, 0)
+    const before = grid(editor)
+
+    // A second finger lifts elsewhere in the document. Its pointerup reaches the capture-phase
+    // onDocUp; without the id filter this called endDrag() and committed the reorder mid-drag.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: FOREIGN, clientX: 40, clientY: 40, bubbles: true }))
+    expect(grid(editor)).toEqual(before) // still in flight, nothing committed
+
+    // The owning pointer's release then commits the intended reorder.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: OWNER, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+  })
+
+  it('a foreign pointercancel does NOT abort the drag; the owning release still commits', () => {
+    editor = mount(TABLE_3x2)
+    armRowDrag(editor, 2, 0)
+
+    // An unrelated pointer the OS cancels (a second finger) must not abort our drag.
+    document.dispatchEvent(new PointerEvent('pointercancel', { pointerId: FOREIGN, bubbles: true }))
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: OWNER, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)[0]).toEqual(['r3c1', 'r3c2'])
+  })
+
+  it('the owning pointer’s pointercancel still aborts (no reorder)', () => {
+    editor = mount(TABLE_3x2)
+    armRowDrag(editor, 2, 0)
+    const before = grid(editor)
+
+    document.dispatchEvent(new PointerEvent('pointercancel', { pointerId: OWNER, bubbles: true }))
+    // A later release is inert — the drag was aborted.
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: OWNER, clientX: 9, clientY: 9, bubbles: true }))
+    expect(grid(editor)).toEqual(before)
+  })
+})

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -697,6 +697,10 @@
   color: var(--octo-muted, #8a919e);
   z-index: 5;
   box-sizing: border-box;
+  /* A soft shadow lifts the resting bar off the page so it reads as a grabbable control rather
+     than a border artefact — the discoverability half of XIN-1233. */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
 .octo-table-reorder:hover {
   background: var(--octo-accent, #3370ff);
@@ -715,12 +719,12 @@
 /* Grip dots: a row of dots on the column bar, a column of dots on the row bar. */
 .octo-table-reorder--col::before {
   content: '⋯';
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1;
 }
 .octo-table-reorder--row::before {
   content: '⋮';
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1;
 }
 /* Insertion caret shown while dragging: an accent line at the boundary the row/column lands on. */


### PR DESCRIPTION
## What & why

The self-built table row/column reorder handle (#76, merged in #780) works, but a series of
real-use defects made the trigger interaction unreliable. This PR fixes them and, in doing so,
**migrates the reorder drag from mouse events to Pointer Events + `setPointerCapture`**. The
event-model change is called out explicitly below — an earlier version of this description said
the reorder core was "untouched", which was inaccurate and is corrected here.

## Changes (by commit)

1. **Stable, discoverable handle (XIN-1233).** Leaving the prose no longer hides the handle
   instantly; a 220ms grace-period hide is cancelled by the handle's own re-entry or the pointer
   returning to a cell, so a quick glide from a cell to the gutter handle stays seamless. The bars
   sit flush against the table edge (the 2px dead gap is gone) and are widened 14px → 18px, with a
   soft shadow / colour transition / larger grip glyph for discoverability.
2. **Coexistence with the sibling row-resize overlay (XIN-1253).** Resting-handle placement moves
   off ProseMirror's `handleDOMEvents` (bound to `view.dom`) onto a document-level `mousemove`, so a
   sibling overlay sitting on top of the cells (e.g. #823's row-height resize bar) can no longer
   steal the pointer and hide the handles. It also reads `view.dom`'s live rect rather than the
   stale detached mount node.
3. **Event-model migration to Pointer Events (XIN-1259 / octo-docs-backend#76).** The drag pipeline
   moves `mousedown/mousemove/mouseup` → `pointerdown/pointermove/pointerup` (+ `pointercancel`) and
   captures the pointer on the grabbed handle with `setPointerCapture`. Capture routes the terminal
   `pointerup`/`pointercancel` to us even on a release **outside the window**, closing the old
   "release outside → drag left silently armed → next stray mouseup commits an abandoned reorder"
   gap (FAIL-1 / XIN-1252). Aligns the reorder handle with the same event model already used by the
   row-height handle in #823.
4. **Multi-pointer re-entrancy fix (this revision — the two P1 blockers reviewers flagged).** The
   Pointer Events migration exposed two multi-pointer gaps that the old mouse-only path did not have:
   - **`beginDrag` had no active-drag guard.** Both the row and column handles carry live
     `pointerdown` listeners, so a second `pointerdown` (a second finger/stylus on the other handle,
     or a stray re-entry) while a drag was active overwrote `drag`/`ordinal`/`capturedPointerId`/
     `capturedHandle` in place — leaking the first pointer's capture and committing the move to the
     wrong row/column. Fixed with `if (drag) return` at the top of `beginDrag`.
   - **The document pointer handlers didn't filter by the captured `pointerId`.** `onDocMove` /
     `onDocUp` / `onDocCancel` gated only on `!drag`/`!activeView`. `setPointerCapture` only
     retargets the owning pointer, so a second, uncaptured pointer's `pointerup` still reached
     `onDocUp` and ended the drag mid-first-pointer (and a foreign `pointermove` drove the
     release-outside check against the wrong coordinates). Fixed by filtering each handler on
     `event.pointerId === capturedPointerId`, keeping the original behaviour when there is no live
     capture id (synthetic / jsdom).

## Note on #823

The coexistence work (change 2) defends against #823's row-resize overlay, which is **still open /
unmerged**, so the overlay branch can't be exercised end-to-end against `main` yet. It is proven with
a stand-in overlay in the harness plus a unit case that stubs `elementFromPoint` to a sibling
overlay, which validates the generic "sibling overlay steals the pointer" invariant without taking a
build dependency on an unmerged branch.

## Testing

- `packages/docs` unit suite green, including:
  - Grace-period coverage in `TableReorderHandleUsable.test.ts`.
  - `TableReorderInterrupt.test.ts` migrated to the pointer model (release-outside-viewport abort,
    stray-plain-mouseup immunity, Escape/blur/pointercancel aborts, positive control commits).
  - **New `TableReorderMultiPointer.test.ts`** — deterministic jsdom coverage of the two P1 defects
    with pointer capture stubbed so the id filter is live: a second pointerdown on the other handle
    is a no-op with no capture leak; a foreign pointer's pointerup/pointercancel does not end the
    drag; the owning release still commits.
- **Real-browser gates** (Playwright / Chromium against the standalone harness):
  - New `dev/run-multipointer.mjs` drives a real captured mouse drag with an interfering second
    pointer. Both P1-1 (second pointerdown → exactly one drag, row identity preserved, no wedge) and
    P1-2 (foreign pointerup ignored, owning release commits) reproduce **red before the fix and pass
    after** in real Chromium.
  - `dev/run-handle-ux.mjs` (row & col handle reachable + stable + triggers move; grace period
    bounded) passes.
  - `dev/run-coexist.mjs` (handle survives the sibling overlay + reorder works) passes.
  - `dev/run-reorder.mjs` — the #76 concurrency gate (TC01 outside-prose edit / TC02 identical twin
    table / TC03 same-table reorder aborts / TC08 fresh-doc stability) still passes unchanged.

Related: reorder feature #76 (PR #780, merged); coexists with row-height resize #823; XIN-1259
event-model reconcile.
