### PR TITLE
fix(docs): merge recent-row creator/viewed/updated into a single latest-event line

### DIFF
--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -15,6 +15,8 @@
     "back": "All documents",
     "updatedAt": "Updated",
     "viewedAt": "Viewed",
+    "createdBy": "Created by",
+    "viewedBySelf": "You viewed",
     "loadingMore": "Loading more…",
     "end": "No more documents",
     "loadMoreFailed": "Couldn't load more",

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -17,6 +17,7 @@
     "viewedAt": "Viewed",
     "createdBy": "Created by",
     "viewedBySelf": "You viewed",
+    "updatedBy": "Updated by {{name}} ·",
     "loadingMore": "Loading more…",
     "end": "No more documents",
     "loadMoreFailed": "Couldn't load more",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -15,6 +15,8 @@
     "back": "全部文档",
     "updatedAt": "更新于",
     "viewedAt": "查看于",
+    "createdBy": "创建者",
+    "viewedBySelf": "你查看于",
     "loadingMore": "加载中…",
     "end": "没有更多了",
     "loadMoreFailed": "加载更多失败",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -17,6 +17,7 @@
     "viewedAt": "查看于",
     "createdBy": "创建者",
     "viewedBySelf": "你查看于",
+    "updatedBy": "{{name}} 更新于",
     "loadingMore": "加载中…",
     "end": "没有更多了",
     "loadMoreFailed": "加载更多失败",

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1451,3 +1451,78 @@ describe('DocsHome — type distinction + filter (XIN-1188)', () => {
     await waitFor(() => expect(screen.getByText('docs.filter.type')).toBeTruthy())
   })
 })
+
+// XIN-1236: recent rows surface three DISTINCT facts on their own lines so none is misread —
+// (1) who created the doc, (2) when the current user viewed it, (3) when the doc was last updated.
+describe('DocsHome — recent row shows creator / viewed / updated on separate lines (XIN-1236)', () => {
+  const recentRows = [
+    {
+      docId: 'd_doc',
+      title: 'A Doc',
+      ownerId: 'u_owner',
+      role: 'admin',
+      docType: 'doc',
+      viewedAt: '2026-07-15T06:00:00.000Z',
+      updatedAt: '2026-07-14T06:00:00.000Z',
+    },
+  ]
+
+  function mountList() {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs/recent/creators')) {
+        return { data: { creators: [{ uid: 'u_owner', name: 'Owner Name' }] }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs/recent')) {
+        return { data: { total: recentRows.length, items: recentRows, nextCursor: null }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<DocsHome />)
+    return wk
+  }
+
+  it('renders creator, viewed, and updated as three separate sub-lines', async () => {
+    mountList()
+    const row = await waitFor(() => {
+      const el = screen.getByText('A Doc').closest('.octo-docs-list-item')
+      expect(el).toBeTruthy()
+      return el as HTMLElement
+    })
+
+    // Three distinct sub-lines, each in its own marked span (never concatenated on one line).
+    const creator = row.querySelector('.octo-docs-list-row-creator')
+    const viewed = row.querySelector('.octo-docs-list-row-viewed')
+    const updated = row.querySelector('.octo-docs-list-row-updated')
+    expect(creator).toBeTruthy()
+    expect(viewed).toBeTruthy()
+    expect(updated).toBeTruthy()
+
+    // Correct label prefix on each line (keys resolve to themselves under the test translator).
+    expect(creator!.textContent).toContain('docs.list.createdBy')
+    expect(creator!.textContent).toContain('Owner Name')
+    expect(viewed!.textContent).toContain('docs.list.viewedBySelf')
+    expect(updated!.textContent).toContain('docs.list.updatedAt')
+
+    // The updated line hovers the absolute update time, distinct from the viewed line's title.
+    expect(updated!.getAttribute('title')).toBeTruthy()
+    expect(updated!.getAttribute('title')).not.toBe(viewed!.getAttribute('title'))
+  })
+
+  it('omits the updated line on the "mine" tab (updated is shown inline there instead)', async () => {
+    mountList()
+    await waitFor(() => expect(screen.getByText('A Doc')).toBeTruthy())
+
+    fireEvent.click(screen.getByText('docs.tab.mine'))
+    // The mine tab lists nothing here, so no recent-only markers should linger on screen.
+    await waitFor(() => {
+      expect(document.querySelector('.octo-docs-list-row-creator')).toBeNull()
+      expect(document.querySelector('.octo-docs-list-row-viewed')).toBeNull()
+      expect(document.querySelector('.octo-docs-list-row-updated')).toBeNull()
+    })
+  })
+})

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1452,22 +1452,12 @@ describe('DocsHome — type distinction + filter (XIN-1188)', () => {
   })
 })
 
-// XIN-1236: recent rows surface three DISTINCT facts on their own lines so none is misread —
-// (1) who created the doc, (2) when the current user viewed it, (3) when the doc was last updated.
-describe('DocsHome — recent row shows creator / viewed / updated on separate lines (XIN-1236)', () => {
-  const recentRows = [
-    {
-      docId: 'd_doc',
-      title: 'A Doc',
-      ownerId: 'u_owner',
-      role: 'admin',
-      docType: 'doc',
-      viewedAt: '2026-07-15T06:00:00.000Z',
-      updatedAt: '2026-07-14T06:00:00.000Z',
-    },
-  ]
-
-  function mountList() {
+// XIN-1236 (merged design): recent rows keep the creator on its own line, then show ONE merged
+// time line reporting only the LATEST event — "<updater> updated X" when the doc was updated after
+// the user last viewed it, otherwise "you viewed X". The two timestamps are never stacked, so the
+// creator's name can never be misread as the viewer/updater.
+describe('DocsHome — recent row merges viewed/updated into the latest event (XIN-1236)', () => {
+  function mountList(rows: Array<Record<string, unknown>>) {
     const wk = createMockWKApp()
     setWKApp(wk)
     wk.apiClient.responder = (method, url) => {
@@ -1475,7 +1465,7 @@ describe('DocsHome — recent row shows creator / viewed / updated on separate l
         return { data: { creators: [{ uid: 'u_owner', name: 'Owner Name' }] }, status: 200 }
       }
       if (method === 'get' && url.startsWith('/docs/recent')) {
-        return { data: { total: recentRows.length, items: recentRows, nextCursor: null }, status: 200 }
+        return { data: { total: rows.length, items: rows, nextCursor: null }, status: 200 }
       }
       if (method === 'get' && url.startsWith('/docs')) {
         return { data: { total: 0, items: [] }, status: 200 }
@@ -1486,36 +1476,124 @@ describe('DocsHome — recent row shows creator / viewed / updated on separate l
     return wk
   }
 
-  it('renders creator, viewed, and updated as three separate sub-lines', async () => {
-    mountList()
-    const row = await waitFor(() => {
-      const el = screen.getByText('A Doc').closest('.octo-docs-list-item')
+  async function rowFor(title: string): Promise<HTMLElement> {
+    return waitFor(() => {
+      const el = screen.getByText(title).closest('.octo-docs-list-item')
       expect(el).toBeTruthy()
       return el as HTMLElement
     })
+  }
 
-    // Three distinct sub-lines, each in its own marked span (never concatenated on one line).
+  it('shows the creator line plus a single "you viewed" line when the view is the latest event', async () => {
+    // viewedAt (07-15) is newer than updatedAt (07-14): the merged line is the VIEW.
+    mountList([
+      {
+        docId: 'd_view',
+        title: 'Viewed Latest',
+        ownerId: 'u_owner',
+        role: 'admin',
+        docType: 'doc',
+        viewedAt: '2026-07-15T06:00:00.000Z',
+        updatedAt: '2026-07-14T06:00:00.000Z',
+        updatedBy: { uid: 'u_editor', name: 'Editor Name' },
+      },
+    ])
+    const row = await rowFor('Viewed Latest')
+
     const creator = row.querySelector('.octo-docs-list-row-creator')
-    const viewed = row.querySelector('.octo-docs-list-row-viewed')
-    const updated = row.querySelector('.octo-docs-list-row-updated')
     expect(creator).toBeTruthy()
-    expect(viewed).toBeTruthy()
-    expect(updated).toBeTruthy()
-
-    // Correct label prefix on each line (keys resolve to themselves under the test translator).
     expect(creator!.textContent).toContain('docs.list.createdBy')
     expect(creator!.textContent).toContain('Owner Name')
-    expect(viewed!.textContent).toContain('docs.list.viewedBySelf')
-    expect(updated!.textContent).toContain('docs.list.updatedAt')
 
-    // The updated line hovers the absolute update time, distinct from the viewed line's title.
-    expect(updated!.getAttribute('title')).toBeTruthy()
-    expect(updated!.getAttribute('title')).not.toBe(viewed!.getAttribute('title'))
+    // The view wins → a single "you viewed" line, and NO updated line stacked beneath it.
+    const viewed = row.querySelector('.octo-docs-list-row-viewed')
+    expect(viewed).toBeTruthy()
+    expect(viewed!.textContent).toContain('docs.list.viewedBySelf')
+    expect(row.querySelector('.octo-docs-list-row-updated')).toBeNull()
   })
 
-  it('omits the updated line on the "mine" tab (updated is shown inline there instead)', async () => {
-    mountList()
-    await waitFor(() => expect(screen.getByText('A Doc')).toBeTruthy())
+  it('shows "<updater> updated X" (with the updater name) when the update is the latest event', async () => {
+    // updatedAt (07-16) is newer than viewedAt (07-15): the merged line is the UPDATE, labelled
+    // with the last-updater's name (XIN-1240 updatedBy), never the creator's.
+    mountList([
+      {
+        docId: 'd_upd',
+        title: 'Updated Latest',
+        ownerId: 'u_owner',
+        role: 'admin',
+        docType: 'doc',
+        viewedAt: '2026-07-15T06:00:00.000Z',
+        updatedAt: '2026-07-16T06:00:00.000Z',
+        updatedBy: { uid: 'u_editor', name: 'Editor Name' },
+      },
+    ])
+    const row = await rowFor('Updated Latest')
+
+    // The update wins → the updated line uses the named "updatedBy" label; no viewed line remains.
+    const updated = row.querySelector('.octo-docs-list-row-updated')
+    expect(updated).toBeTruthy()
+    expect(updated!.textContent).toContain('docs.list.updatedBy')
+    expect(updated!.getAttribute('title')).toBeTruthy()
+    expect(row.querySelector('.octo-docs-list-row-viewed')).toBeNull()
+    // Creator line still present and independent.
+    expect(row.querySelector('.octo-docs-list-row-creator')).toBeTruthy()
+  })
+
+  it('falls back to an unnamed "updated X" line when the update wins but updatedBy is null', async () => {
+    mountList([
+      {
+        docId: 'd_upd_anon',
+        title: 'Updated No Author',
+        ownerId: 'u_owner',
+        role: 'admin',
+        docType: 'doc',
+        viewedAt: '2026-07-15T06:00:00.000Z',
+        updatedAt: '2026-07-16T06:00:00.000Z',
+        updatedBy: null,
+      },
+    ])
+    const row = await rowFor('Updated No Author')
+
+    const updated = row.querySelector('.octo-docs-list-row-updated')
+    expect(updated).toBeTruthy()
+    // No updater name to show → the plain "updated" label, NOT the named "updatedBy" one.
+    expect(updated!.textContent).toContain('docs.list.updatedAt')
+    expect(updated!.textContent).not.toContain('docs.list.updatedBy')
+    expect(row.querySelector('.octo-docs-list-row-viewed')).toBeNull()
+  })
+
+  it('prefers the view when the two timestamps are equal (equal/very-close → viewed)', async () => {
+    mountList([
+      {
+        docId: 'd_eq',
+        title: 'Equal Times',
+        ownerId: 'u_owner',
+        role: 'admin',
+        docType: 'doc',
+        viewedAt: '2026-07-15T06:00:00.000Z',
+        updatedAt: '2026-07-15T06:00:00.000Z',
+        updatedBy: { uid: 'u_editor', name: 'Editor Name' },
+      },
+    ])
+    const row = await rowFor('Equal Times')
+
+    expect(row.querySelector('.octo-docs-list-row-viewed')).toBeTruthy()
+    expect(row.querySelector('.octo-docs-list-row-updated')).toBeNull()
+  })
+
+  it('omits recent-only markers on the "mine" tab (updated is shown inline there instead)', async () => {
+    mountList([
+      {
+        docId: 'd_view',
+        title: 'Viewed Latest',
+        ownerId: 'u_owner',
+        role: 'admin',
+        docType: 'doc',
+        viewedAt: '2026-07-15T06:00:00.000Z',
+        updatedAt: '2026-07-14T06:00:00.000Z',
+      },
+    ])
+    await waitFor(() => expect(screen.getByText('Viewed Latest')).toBeTruthy())
 
     fireEvent.click(screen.getByText('docs.tab.mine'))
     // The mine tab lists nothing here, so no recent-only markers should linger on screen.

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -614,18 +614,31 @@ function DocsList({
         : iconKind === 'sheet'
           ? t('docs.list.kindSheet')
           : t('docs.list.kindDoc')
-    // Recent rows show the creator inline + when the doc was VIEWED; mine rows keep the "updated"
-    // sub-line (frontend-design §2.1 / §5.1).
+    // Recent rows put the creator on its OWN line, then a SINGLE merged time line reporting only
+    // the LATEST event (XIN-1236 merged design). Mine rows keep the plain "updated" sub-line
+    // (frontend-design §2.1 / §5.1).
     const creator =
       activeView === 'recent'
         ? creatorName(d.ownerId, recentView.creatorOptions, nameFallback)
         : ''
-    const stampIso = activeView === 'recent' ? d.viewedAt || d.updatedAt : d.updatedAt
-    // Recent rows also surface when the DOCUMENT itself was last updated — distinct from when the
-    // current user viewed it. The backend `GET /docs/recent` response carries `updatedAt` per row
-    // (docs-backend listRecentHandler), so this is a pure display addition (XIN-1236 follow-up).
-    // Undefined on "mine" rows, which already show the updated time inline via `stampIso`.
-    const updatedIso = activeView === 'recent' ? d.updatedAt : undefined
+    // Compare the current user's view time against the document's own update time; the later of
+    // the two is the event we surface. Equal / very-close / missing-update all prefer the VIEW
+    // (boss decision), so the update only "wins" when it is strictly newer than the view.
+    const viewedTime = d.viewedAt ? Date.parse(d.viewedAt) : NaN
+    const updatedTime = d.updatedAt ? Date.parse(d.updatedAt) : NaN
+    const updateIsLatest =
+      activeView === 'recent' &&
+      Number.isFinite(updatedTime) &&
+      (!Number.isFinite(viewedTime) || updatedTime > viewedTime)
+    // When the update wins, label it with WHO last updated the doc (XIN-1240 `updatedBy`={uid,name}).
+    // Prefer the backend-resolved name, fall back to the space member-name map by uid, and when no
+    // updater is known drop to an unnamed "更新于 X" line rather than guessing (never borrow the
+    // creator's name for the updater).
+    const updaterName =
+      (d.updatedBy?.name || '').trim() ||
+      (d.updatedBy?.uid ? nameFallback(d.updatedBy.uid) || '' : '')
+    // "mine" rows keep their existing single "updated" sub-line, unchanged.
+    const mineStampIso = activeView === 'mine' ? d.updatedAt : undefined
     return (
       <li
         key={d.docId}
@@ -667,37 +680,39 @@ function DocsList({
               {label}
             </span>
             {activeView === 'recent' ? (
-              // Recent rows split the creator and the viewer onto SEPARATE lines so the creator's
-              // name never sits next to "viewed at X" (which misread as "the creator viewed it").
-              // Line 1 states who created the doc; line 2 states when the current user viewed it;
-              // line 3 states when the document itself was last updated (XIN-1236).
+              // Recent rows: creator on its own line, then ONE merged time line showing only the
+              // latest event — "<updater> 更新于 X" when the doc was updated AFTER the user last
+              // viewed it, otherwise "你查看于 X". Collapsing the two timestamps into a single
+              // most-recent line keeps the creator's name away from any "…于 X" time so the row can
+              // never be misread as "the creator viewed it" (XIN-1236 merged design).
               <>
                 {creator && (
                   <span className="octo-docs-list-row-sub octo-docs-list-row-creator">
                     {t('docs.list.createdBy')} {creator}
                   </span>
                 )}
-                {stampIso && (
-                  <span
-                    className="octo-docs-list-row-sub octo-docs-list-row-viewed"
-                    title={formatAbsolute(stampIso)}
-                  >
-                    {t('docs.list.viewedBySelf')} {formatRelative(stampIso)}
-                  </span>
-                )}
-                {updatedIso && (
+                {updateIsLatest && d.updatedAt ? (
                   <span
                     className="octo-docs-list-row-sub octo-docs-list-row-updated"
-                    title={formatAbsolute(updatedIso)}
+                    title={formatAbsolute(d.updatedAt)}
                   >
-                    {t('docs.list.updatedAt')} {formatRelative(updatedIso)}
+                    {updaterName
+                      ? `${t('docs.list.updatedBy', { values: { name: updaterName } })} ${formatRelative(d.updatedAt)}`
+                      : `${t('docs.list.updatedAt')} ${formatRelative(d.updatedAt)}`}
                   </span>
-                )}
+                ) : d.viewedAt ? (
+                  <span
+                    className="octo-docs-list-row-sub octo-docs-list-row-viewed"
+                    title={formatAbsolute(d.viewedAt)}
+                  >
+                    {t('docs.list.viewedBySelf')} {formatRelative(d.viewedAt)}
+                  </span>
+                ) : null}
               </>
             ) : (
-              stampIso && (
-                <span className="octo-docs-list-row-sub" title={formatAbsolute(stampIso)}>
-                  {t('docs.list.updatedAt')} {formatRelative(stampIso)}
+              mineStampIso && (
+                <span className="octo-docs-list-row-sub" title={formatAbsolute(mineStampIso)}>
+                  {t('docs.list.updatedAt')} {formatRelative(mineStampIso)}
                 </span>
               )
             )}

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -621,6 +621,11 @@ function DocsList({
         ? creatorName(d.ownerId, recentView.creatorOptions, nameFallback)
         : ''
     const stampIso = activeView === 'recent' ? d.viewedAt || d.updatedAt : d.updatedAt
+    // Recent rows also surface when the DOCUMENT itself was last updated — distinct from when the
+    // current user viewed it. The backend `GET /docs/recent` response carries `updatedAt` per row
+    // (docs-backend listRecentHandler), so this is a pure display addition (XIN-1236 follow-up).
+    // Undefined on "mine" rows, which already show the updated time inline via `stampIso`.
+    const updatedIso = activeView === 'recent' ? d.updatedAt : undefined
     return (
       <li
         key={d.docId}
@@ -664,8 +669,8 @@ function DocsList({
             {activeView === 'recent' ? (
               // Recent rows split the creator and the viewer onto SEPARATE lines so the creator's
               // name never sits next to "viewed at X" (which misread as "the creator viewed it").
-              // Line 1 states who created the doc; line 2 states when the current user viewed it
-              // (XIN-1236).
+              // Line 1 states who created the doc; line 2 states when the current user viewed it;
+              // line 3 states when the document itself was last updated (XIN-1236).
               <>
                 {creator && (
                   <span className="octo-docs-list-row-sub octo-docs-list-row-creator">
@@ -678,6 +683,14 @@ function DocsList({
                     title={formatAbsolute(stampIso)}
                   >
                     {t('docs.list.viewedBySelf')} {formatRelative(stampIso)}
+                  </span>
+                )}
+                {updatedIso && (
+                  <span
+                    className="octo-docs-list-row-sub octo-docs-list-row-updated"
+                    title={formatAbsolute(updatedIso)}
+                  >
+                    {t('docs.list.updatedAt')} {formatRelative(updatedIso)}
                   </span>
                 )}
               </>

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -661,23 +661,32 @@ function DocsList({
             >
               {label}
             </span>
-            {(creator || stampIso) && (
-              <span
-                className="octo-docs-list-row-sub"
-                title={stampIso ? formatAbsolute(stampIso) : undefined}
-              >
-                {activeView === 'recent' ? (
-                  <>
-                    {creator}
-                    {creator && stampIso ? ' · ' : ''}
-                    {stampIso ? `${t('docs.list.viewedAt')} ${formatRelative(stampIso)}` : ''}
-                  </>
-                ) : stampIso ? (
-                  <>
-                    {t('docs.list.updatedAt')} {formatRelative(stampIso)}
-                  </>
-                ) : null}
-              </span>
+            {activeView === 'recent' ? (
+              // Recent rows split the creator and the viewer onto SEPARATE lines so the creator's
+              // name never sits next to "viewed at X" (which misread as "the creator viewed it").
+              // Line 1 states who created the doc; line 2 states when the current user viewed it
+              // (XIN-1236).
+              <>
+                {creator && (
+                  <span className="octo-docs-list-row-sub octo-docs-list-row-creator">
+                    {t('docs.list.createdBy')} {creator}
+                  </span>
+                )}
+                {stampIso && (
+                  <span
+                    className="octo-docs-list-row-sub octo-docs-list-row-viewed"
+                    title={formatAbsolute(stampIso)}
+                  >
+                    {t('docs.list.viewedBySelf')} {formatRelative(stampIso)}
+                  </span>
+                )}
+              </>
+            ) : (
+              stampIso && (
+                <span className="octo-docs-list-row-sub" title={formatAbsolute(stampIso)}>
+                  {t('docs.list.updatedAt')} {formatRelative(stampIso)}
+                </span>
+              )
             )}
           </span>
         </button>

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -31,6 +31,14 @@ export interface DocListItem {
    */
   viewedAt?: string
   /**
+   * Last-updater identity, resolved server-side to `{uid, name}` (XIN-1240, sourced from
+   * `doc_meta.updated_by`). Present ONLY on "recent" (最近查看) rows; `null` when the document has
+   * no recorded last-updater. The recent tab uses it to label the merged time line — when the doc
+   * was updated after the current user last viewed it, the line reads "<name> 更新于 X" instead of
+   * "你查看于 X". A missing / null value degrades to an unnamed "更新于 X" line (never guesses).
+   */
+  updatedBy?: { uid: string; name: string } | null
+  /**
    * Document kind — one of {@link DocType}: `'doc'` (Tiptap rich text, the default), `'sheet'`
    * (Univer spreadsheet), or `'board'` (Excalidraw whiteboard). Optional because older records and
    * backends that predate a given kind omit it; a missing value is treated as a plain document. The


### PR DESCRIPTION
## Problem

In the docs home **Recent** list, each row's sub-line placed the document
creator's name directly before "viewed at X". A row like `大背头 · 查看于 刚刚`
read as *"the creator viewed it just now"*, when it actually means *"created by
大背头, viewed by the current user just now"*. The recent list is meant to show
documents the **signed-in user** has viewed, so this was a confusing misread.

## Fix

Recent rows now show two things, and the time collapses to a single
most-recent-event line so two timestamps are never stacked together:

- **Creator line** — who created the document: `创建者 <name>` / `Created by <name>`.
- **Merged time line** — only the *later* of the current user's view time and
  the document's own update time:
  - update newer than the last view → `<last updater> 更新于 <time>` /
    `Updated by <name> · <time>`, naming the updater from the recent API's
    `updatedBy = {uid, name}` field;
  - view newer, equal, or no update recorded → `你查看于 <time>` / `You viewed <time>`.

Equal / very-close timestamps prefer the view. When `updatedBy` is `null`
(no recorded editor) the update line degrades to the unnamed `更新于 <time>`
label rather than borrowing the creator's name. Display-only: `updatedBy`,
`updatedAt`, and `viewedAt` are all carried per row by `GET /docs/recent`; no
data-fetch, filtering, or backend logic is touched here. The "My documents" tab
sub-line ("Updated X") is unchanged.

### Changes
- `packages/docs/src/pages/DocsHome.tsx` — render the recent sub-line as a
  creator span (`octo-docs-list-row-creator`) plus one merged time span
  (`octo-docs-list-row-updated` when the update is newest, otherwise
  `octo-docs-list-row-viewed`).
- `packages/docs/src/pages/docsApi.ts` — add the `updatedBy: { uid, name } | null`
  field to `DocListItem` (recent rows only).
- `packages/docs/src/i18n/{zh-CN,en-US}.json` — add `list.updatedBy`
  (`{{name}} 更新于` / `Updated by {{name}} ·`) in both locales; reuse existing
  `list.createdBy`, `list.viewedBySelf`, `list.updatedAt`.

## Verification
- `@octo/docs` unit tests green (`DocsHome.test.tsx`, `docsApi.test.ts`,
  `i18n.test.ts` — 81 passing), covering view-latest, update-latest-with-name,
  update-latest-with-null-updatedBy fallback, equal-prefers-view, and the
  mine-tab exclusion, plus the zh/en key-parity guard.
- Real-environment end-to-end check: logged in as the test user, opened the
  Recent list against a backend that returns `updatedBy`, and confirmed both
  cases render correctly — view-newer rows show "你查看于 刚刚" and update-newer
  rows show "<updater> 更新于 X" with the updater name distinct from the creator.
