### PR TITLE
fix(docs): record a view when a shared doc opens on the standalone page

### DIFF
--- a/apps/web/e2e/standalone-doc.spec.ts
+++ b/apps/web/e2e/standalone-doc.spec.ts
@@ -174,3 +174,64 @@ test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', 
     await expect(page.locator('.octo-doc-standalone')).toHaveCount(0)
   })
 })
+
+test.describe('standalone /d/:docId — records a view in the viewer space (XIN-1238)', () => {
+  test('opening a cross-space share link fires POST /docs/:id/view with X-Space-Id = viewer current space, not the doc space', async ({
+    page,
+  }) => {
+    await seedSignedInSession(page)
+    // The viewer is currently in `space-viewer`; the shell persists that under the shared
+    // `currentSpaceId` key. On a cold `/d/:docId` deep link this is the only source of the viewer's
+    // real space (the live space is not yet restored).
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('currentSpaceId', 'space-viewer')
+      } catch {
+        /* noop */
+      }
+    })
+    await stubBackend(page)
+    // Cross-space share: the link carries the DOC's own space (`?sp=space-doc`), which the page uses
+    // to address the preflight — deliberately different from the viewer's current space.
+    await routeDocPreflight(page, 'd_ok', 200, {
+      docId: 'd_ok',
+      title: 'Shared Doc',
+      ownerId: 'u_owner',
+      role: 'reader',
+    })
+
+    // Capture the view-ingest call. Registered after the catch-all so it wins (Playwright runs the
+    // most-recently-added matching handler first).
+    let viewSpaceHeader: string | undefined
+    let viewCalls = 0
+    await page.route('**/api/v1/docs/d_ok/view', (route: Route) => {
+      viewCalls += 1
+      viewSpaceHeader = route.request().headers()['x-space-id']
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/d/d_ok?sp=space-doc')
+
+    // The view was recorded once, addressed to the VIEWER's current space so it surfaces in the
+    // viewer's 最近查看 (XIN-1237 write/read contract) — NOT the doc's own space.
+    await expect.poll(() => viewCalls).toBe(1)
+    expect(viewSpaceHeader).toBe('space-viewer')
+  })
+
+  test('does not record a view when the preflight fails to a terminal (403)', async ({ page }) => {
+    await seedSignedInSession(page)
+    await stubBackend(page)
+    await routeDocPreflight(page, 'd_forbidden', 403)
+
+    let viewCalls = 0
+    await page.route('**/api/v1/docs/d_forbidden/view', (route: Route) => {
+      viewCalls += 1
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/d/d_forbidden')
+
+    await expect(page.locator('.octo-terminal')).toBeVisible()
+    expect(viewCalls).toBe(0)
+  })
+})

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -974,3 +974,53 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
     expect(wk.apiClient.calls.some((c) => c.url === '/docs/d_forbidden/view')).toBe(false)
   })
 })
+
+describe('StandaloneDocPage — restores the viewer current space on teardown so 最近查看 is not left scoped to the doc space (XIN-1254)', () => {
+  it('reverts the doc-link space it seeded back to the viewer current space when the page unmounts', async () => {
+    // Cross-space share (老板 real-device repro): the viewer (大棍子) is in space-viewer; the link
+    // carries the DOC owner's (大背头) space `?sp=space-doc`. On this cold deep link
+    // wk.shared.currentSpaceId is empty, so the seed effect overwrites it with space-doc for the
+    // interceptor to address the editor's cross-space collab requests. Left in place, returning to
+    // the docs list scopes 最近查看's read (derived from the live currentSpaceId via the interceptor)
+    // to space-doc — but the view was recorded under space-viewer (viewerSpaceRef), so it stays
+    // invisible: the XIN-1234 write/read space split reintroduced by the seed.
+    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
+    window.localStorage.setItem('currentSpaceId', 'space-viewer')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { unmount } = render(<StandaloneDocPage docId="d_ok" />)
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    // Seed applied while the standalone editor is mounted (cross-space collab addressing).
+    expect(wk.shared.currentSpaceId).toBe('space-doc')
+
+    // On teardown the viewer's real space is restored, so the shell's recent-view read matches the
+    // space the view was written to (space-viewer) and the doc surfaces in 最近查看.
+    unmount()
+    expect(wk.shared.currentSpaceId).toBe('space-viewer')
+  })
+
+  it('only reverts the value it seeded — never clobbers a space the shell switched to meanwhile', async () => {
+    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
+    window.localStorage.setItem('currentSpaceId', 'space-viewer')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { unmount } = render(<StandaloneDocPage docId="d_ok" />)
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    expect(wk.shared.currentSpaceId).toBe('space-doc')
+
+    // A genuine space switch happened while the page was open; the teardown restore must be a no-op.
+    wk.shared.currentSpaceId = 'space-switched'
+    unmount()
+    expect(wk.shared.currentSpaceId).toBe('space-switched')
+  })
+})

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -65,6 +65,7 @@ import {
   parseStandaloneDocId,
   isStandaloneDocPath,
   standaloneFallbackSpace,
+  viewerCurrentSpace,
   standaloneLinkSpace,
   persistStandaloneReturn,
   consumeStandaloneReturn,
@@ -512,6 +513,26 @@ describe('standaloneFallbackSpace — cold-start cross-space addressing (blocker
   })
 })
 
+describe('viewerCurrentSpace — the space a recorded view is written to (XIN-1237, no deploy-default tail)', () => {
+  it('prefers the live currentSpaceId when the shell has one', () => {
+    window.localStorage.setItem('currentSpaceId', 's_cached')
+    expect(viewerCurrentSpace('s_live')).toBe('s_live')
+  })
+
+  it('falls back to the cached localStorage currentSpaceId when the shell has none', () => {
+    window.localStorage.setItem('currentSpaceId', 's_cached')
+    expect(viewerCurrentSpace('')).toBe('s_cached')
+    expect(viewerCurrentSpace(undefined)).toBe('s_cached')
+  })
+
+  it('returns empty (NOT the deploy default) when there is no viewer signal, so the caller omits the header', () => {
+    // Unlike standaloneFallbackSpace (used for room addressing, where a default is a safe last
+    // resort), the view record must never be written to a space we cannot confirm the viewer is in.
+    expect(viewerCurrentSpace('')).toBe('')
+    expect(viewerCurrentSpace(undefined)).toBe('')
+  })
+})
+
 describe('StandaloneDocPage — cold-start addressing uses the cached space, not the deploy default (blocker 3)', () => {
   it('addresses the EditorShell to the cached currentSpaceId when the preflight carries no documentName', async () => {
     // Repro: 200 preflight WITHOUT documentName + a cached currentSpaceId in localStorage. Before
@@ -917,6 +938,55 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
     const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
     expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
     expect(view!.config?.headers?.['X-Space-Id']).toBe('space-viewer')
+  })
+
+  it('same-space share (老板 real-device acceptance): opening a doc from a same-space group link records the view under that space so it surfaces in 最近查看', async () => {
+    // The acceptance scenario (三叉戟大队): the viewer opens a doc shared in the space they are
+    // already in. The link's `?sp=` and the viewer's current space are the SAME space, so the view
+    // is recorded under that space and the shell's recent-view read (scoped to the same current
+    // space) surfaces it — the exact "点链接开同 space 文档→回→最近查看可见" flow.
+    window.history.pushState({}, '', '/d/d_ok?sp=space-team')
+    window.localStorage.setItem('currentSpaceId', 'space-team')
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Team Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/docs/d_ok/view')).toBe(true),
+    )
+    const view = wk.apiClient.calls.find((c) => c.method === 'post' && c.url === '/docs/d_ok/view')
+    expect(view!.config?.headers?.['X-Space-Id']).toBe('space-team')
+  })
+
+  it('per-space safety: with no live and no cached viewer space, the view record omits the explicit X-Space-Id instead of forcing the deploy default', async () => {
+    // No viewer signal at all (no live currentSpaceId, no cached one). Recording the view under the
+    // deploy-default space would write it into a space the viewer isn't in — polluting that space's
+    // recent list and still never surfacing in the viewer's own. Omit the explicit header and let
+    // the global interceptor decide, exactly as the in-shell entry does.
+    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/docs/d_ok/view')).toBe(true),
+    )
+    const view = wk.apiClient.calls.find((c) => c.method === 'post' && c.url === '/docs/d_ok/view')
+    // No explicit header forced: never the deploy default, never the doc link space.
+    expect(view!.config?.headers?.['X-Space-Id']).toBeUndefined()
   })
 
   it('uses the live current space as the viewer space when the shell already restored it (in-shell mount)', async () => {

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -886,3 +886,91 @@ describe('StandaloneDocPage — creator name is nickname-only on the shared surf
     expect(screen.getByTestId('editor-creator-nickname-only').textContent).toBe('true')
   })
 })
+
+describe('StandaloneDocPage — records a view so share-link opens surface in 最近查看 (XIN-1238)', () => {
+  it('fires POST /docs/:id/view once the doc is ready, written to the VIEWER current space, not the doc link space', async () => {
+    // XIN-1234 root cause: the standalone page never recorded a view, so a doc opened from a chat
+    // share link never appeared in the opener's 最近查看. XIN-1237 write/read space contract: the
+    // view must be written under the VIEWER's current space (X-Space-Id), which 最近查看 reads back
+    // by — NOT the doc's own space the standalone page seeds for preflight addressing.
+    // Cross-space share: the link carries the doc space `?sp=space-doc`, but the viewer is currently
+    // in space-viewer (their cached/live current space).
+    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
+    window.localStorage.setItem('currentSpaceId', 'space-viewer')
+
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/docs/d_ok/view')).toBe(true),
+    )
+    const view = wk.apiClient.calls.find((c) => c.method === 'post' && c.url === '/docs/d_ok/view')
+    // The preflight is addressed to the doc's own space (link `?sp`), but the view ingest must go to
+    // the viewer's current space so it surfaces in the viewer's recent list.
+    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
+    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
+    expect(view!.config?.headers?.['X-Space-Id']).toBe('space-viewer')
+  })
+
+  it('uses the live current space as the viewer space when the shell already restored it (in-shell mount)', async () => {
+    wk.shared.currentSpaceId = 'space-live'
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/docs/d_ok/view')).toBe(true),
+    )
+    const view = wk.apiClient.calls.find((c) => c.method === 'post' && c.url === '/docs/d_ok/view')
+    expect(view!.config?.headers?.['X-Space-Id']).toBe('space-live')
+  })
+
+  it('records the view at most once (idempotent — never in a render loop)', async () => {
+    window.localStorage.setItem('currentSpaceId', 'space-viewer')
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_ok" />)
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    await waitFor(() =>
+      expect(wk.apiClient.calls.filter((c) => c.method === 'post' && c.url === '/docs/d_ok/view').length).toBe(1),
+    )
+    // Give any stray re-render a chance to double-fire, then re-assert the single call.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(wk.apiClient.calls.filter((c) => c.method === 'post' && c.url === '/docs/d_ok/view').length).toBe(1)
+  })
+
+  it('does NOT record a view when the preflight fails to a terminal (forbidden / not-found)', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_forbidden') {
+        return Promise.reject(apiError(403))
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_forbidden" />)
+
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'get' && c.url === '/docs/d_forbidden')).toBe(true),
+    )
+    expect(wk.apiClient.calls.some((c) => c.url === '/docs/d_forbidden/view')).toBe(false)
+  })
+})

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -7,7 +7,7 @@ import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { LinkIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
-import { getDoc, type DocMeta } from './docsApi.ts'
+import { getDoc, recordDocView, type DocMeta } from './docsApi.ts'
 import { parseDocumentName } from '../documentName/index.ts'
 import { DEFAULT_DOC_SPACE, DEFAULT_DOC_FOLDER } from '../config.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -310,6 +310,20 @@ export function StandaloneDocPage({
   // addresses the doc correctly when the opener is already in the doc's space (owner / same-space).
   const preflightSpace = standaloneLinkSpace() || standaloneFallbackSpace(wk.shared?.currentSpaceId)
 
+  // XIN-1237 write/read space contract: a view is written into the space carried by the request's
+  // X-Space-Id and "最近查看" reads back by that SAME viewer space. recordDocView must therefore be
+  // written to the VIEWER's current space, NOT the doc's own space. But the seed effect below
+  // overwrites wk.shared.currentSpaceId to the doc's link space (`?sp=`) for preflight/room
+  // addressing, so by the time the doc is ready that value no longer reflects the viewer. Capture
+  // the viewer's real current space ONCE on first render — before the seed effect runs — resolving
+  // live currentSpaceId → cached localStorage → deploy default (the viewer resolution of
+  // standaloneFallbackSpace, WITHOUT the link-space override that preflightSpace applies). Lazy
+  // null-init so the resolution runs exactly once and is immune to the later seed mutation.
+  const viewerSpaceRef = useRef<string | null>(null)
+  if (viewerSpaceRef.current === null) {
+    viewerSpaceRef.current = standaloneFallbackSpace(wk.shared?.currentSpaceId)
+  }
+
   // Genuine defense in depth (second, independent path — NOT the only working one): the standalone
   // page mounts via the Layout early-return, before the app shell restores currentSpaceId from
   // localStorage, so any in-shell-shared logic the EditorShell touches would see an empty space. If —
@@ -384,6 +398,22 @@ export function StandaloneDocPage({
       cancelled = true
     }
   }, [docId, onSessionExpired, preflightSpace])
+
+  // XIN-1238 / XIN-1234: the standalone `/d/:docId` page never recorded a view, so a doc opened from
+  // a chat share link never surfaced in the opener's "最近查看". Mirror the in-shell entry
+  // (DocsHome.commitOpen): once the doc is READY, fire a single view ingest. It is written to the
+  // VIEWER's real current space (viewerSpaceRef), per the XIN-1237 write/read space contract — NOT
+  // the doc space the page seeds for addressing. Guarded by docId so React re-renders and
+  // strict-mode double-invocation record at most once per opened doc, matching the timing of the
+  // normal entry (on open success, not in a render loop). Fire-and-forget: recordDocView swallows
+  // every failure, so a failed / not-yet-deployed ingest never affects the open path.
+  const recordedDocRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (phase.status !== 'ready' || !docId) return
+    if (recordedDocRef.current === docId) return
+    recordedDocRef.current = docId
+    void recordDocView(docId, { spaceId: viewerSpaceRef.current ?? undefined })
+  }, [phase.status, docId])
 
   useEffect(
     () => () => {

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -209,6 +209,35 @@ export function standaloneFallbackSpace(currentSpaceId: string | undefined): str
 }
 
 /**
+ * The VIEWER's real current space, resolved from a genuine viewer signal ONLY: the live
+ * `currentSpaceId`, else the cached `currentSpaceId` localStorage key the shell persists. Returns
+ * '' when neither exists — deliberately WITHOUT standaloneFallbackSpace's DEFAULT_DOC_SPACE tail.
+ *
+ * This is the space recordDocView writes the "最近查看" ingest into (XIN-1237 write/read contract):
+ * the backend writes and reads the recent list by X-Space-Id = the viewer's current space, so the
+ * view MUST be recorded under the viewer's space, NOT the doc's link space (`?sp=`). Where the doc
+ * space is used (preflight/room addressing) the deploy default is a safe last resort, but for the
+ * view record it is NOT: recording into DEFAULT_DOC_SPACE when we cannot confirm the viewer is
+ * actually there would (a) write the view into a space the viewer isn't in — breaking the
+ * per-space isolation the recent list relies on — and (b) still never surface in the viewer's own
+ * recent list. So when there is no real viewer signal we return '' and the caller omits the
+ * explicit header, letting the global interceptor decide (exactly as the in-shell entry does),
+ * rather than forcing a wrong space.
+ */
+export function viewerCurrentSpace(currentSpaceId: string | undefined): string {
+  if (currentSpaceId) return currentSpaceId
+  if (typeof window !== 'undefined') {
+    try {
+      const cached = window.localStorage.getItem('currentSpaceId')
+      if (cached) return cached
+    } catch {
+      // localStorage unavailable (private mode / disabled): no viewer signal → '' (omit the header).
+    }
+  }
+  return ''
+}
+
+/**
  * The doc's OWN space, as carried by the standalone share link's dedicated `?sp=` query param.
  *
  * buildDocLink (forward/link.ts) embeds the shared document's REAL space id as `?sp=` — the space
@@ -316,12 +345,13 @@ export function StandaloneDocPage({
   // overwrites wk.shared.currentSpaceId to the doc's link space (`?sp=`) for preflight/room
   // addressing, so by the time the doc is ready that value no longer reflects the viewer. Capture
   // the viewer's real current space ONCE on first render — before the seed effect runs — resolving
-  // live currentSpaceId → cached localStorage → deploy default (the viewer resolution of
-  // standaloneFallbackSpace, WITHOUT the link-space override that preflightSpace applies). Lazy
-  // null-init so the resolution runs exactly once and is immune to the later seed mutation.
+  // live currentSpaceId → cached localStorage (viewerCurrentSpace). Do NOT source it from the link
+  // `?sp=` and do NOT fall through to the deploy default: an empty result means "no viewer signal",
+  // which the record path treats as "omit the explicit header", never as "write to DEFAULT space".
+  // Lazy null-init so the resolution runs exactly once and is immune to the later seed mutation.
   const viewerSpaceRef = useRef<string | null>(null)
   if (viewerSpaceRef.current === null) {
-    viewerSpaceRef.current = standaloneFallbackSpace(wk.shared?.currentSpaceId)
+    viewerSpaceRef.current = viewerCurrentSpace(wk.shared?.currentSpaceId)
   }
 
   // Genuine defense in depth (second, independent path — NOT the only working one): the standalone
@@ -423,16 +453,20 @@ export function StandaloneDocPage({
   // a chat share link never surfaced in the opener's "最近查看". Mirror the in-shell entry
   // (DocsHome.commitOpen): once the doc is READY, fire a single view ingest. It is written to the
   // VIEWER's real current space (viewerSpaceRef), per the XIN-1237 write/read space contract — NOT
-  // the doc space the page seeds for addressing. Guarded by docId so React re-renders and
-  // strict-mode double-invocation record at most once per opened doc, matching the timing of the
-  // normal entry (on open success, not in a render loop). Fire-and-forget: recordDocView swallows
-  // every failure, so a failed / not-yet-deployed ingest never affects the open path.
+  // the doc space (`?sp=`) the page seeds for addressing. When no viewer signal was resolvable
+  // (viewerSpaceRef === ''), omit the explicit X-Space-Id and let the global interceptor decide,
+  // exactly as the in-shell entry does — never force the deploy-default space, which would record
+  // the view under a space the viewer isn't in and break per-space isolation. Guarded by docId so
+  // React re-renders and strict-mode double-invocation record at most once per opened doc, matching
+  // the timing of the normal entry (on open success, not in a render loop). Fire-and-forget:
+  // recordDocView swallows every failure, so a failed / not-yet-deployed ingest never affects open.
   const recordedDocRef = useRef<string | null>(null)
   useEffect(() => {
     if (phase.status !== 'ready' || !docId) return
     if (recordedDocRef.current === docId) return
     recordedDocRef.current = docId
-    void recordDocView(docId, { spaceId: viewerSpaceRef.current ?? undefined })
+    const viewerSpace = viewerSpaceRef.current
+    void recordDocView(docId, viewerSpace ? { spaceId: viewerSpace } : undefined)
   }, [phase.status, docId])
 
   useEffect(

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -345,16 +345,36 @@ export function StandaloneDocPage({
     // header used (XIN-501); fall back to the cached last space when the link carries no `?sp`.
     // Never overwrite a real live space, so in-shell mounts (where it is already set) are unaffected.
     const linkSpace = standaloneLinkSpace()
+    let seeded: string | undefined
     if (linkSpace) {
-      shared.currentSpaceId = linkSpace
-      return
+      seeded = linkSpace
+    } else if (typeof window !== 'undefined') {
+      try {
+        const cached = window.localStorage.getItem('currentSpaceId')
+        if (cached) seeded = cached
+      } catch {
+        // localStorage unavailable: the explicit preflight header (primary fix) still carries the space.
+      }
     }
-    if (typeof window === 'undefined') return
-    try {
-      const cached = window.localStorage.getItem('currentSpaceId')
-      if (cached) shared.currentSpaceId = cached
-    } catch {
-      // localStorage unavailable: the explicit preflight header (primary fix) still carries the space.
+    if (!seeded) return
+    shared.currentSpaceId = seeded
+
+    // XIN-1254 (XIN-1234 variant): the seed above overwrites the shared `currentSpaceId` — which the
+    // app shell reads as "the VIEWER's current space" — with the DOC's link space so the global
+    // interceptor addresses the standalone editor's cross-space collab requests. Left in place after
+    // the page tears down, returning to the docs list scopes "最近查看"'s read to the DOC space (the
+    // recent feed derives its space from the live currentSpaceId via the interceptor). A view we
+    // recorded under the VIEWER's real space (viewerSpaceRef) is then invisible in that read — the
+    // exact write/read space split of XIN-1234, reintroduced by this seed for a CROSS-space share
+    // (opening someone else's doc, `?sp=` ≠ the viewer's space). Restore the viewer's real space on
+    // teardown so the shell's recent-view read matches the space the view was written to. React runs
+    // an unmounted tree's effect cleanups before the newly-mounted tree's effects within the same
+    // commit, so this restore lands before DocsHome's recent-view request fires. Only revert the
+    // value WE seeded — never clobber a space the shell legitimately switched to meanwhile.
+    return () => {
+      if (shared.currentSpaceId === seeded) {
+        shared.currentSpaceId = viewerSpaceRef.current ?? ''
+      }
     }
   }, [wk.shared])
 

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -204,10 +204,19 @@ export async function listRecentCreators(q?: string): Promise<CreatorOption[]> {
  * failed / not-yet-deployed ingest never blocks opening the doc and never surfaces a toast
  * (frontend-design §3.4). No body — uid is derived server-side. The server UPSERTs on `(uid,docId)`
  * so calling it once per open is idempotent.
+ *
+ * `opts.spaceId` (standalone need, XIN-1237): the backend writes the view into the space carried by
+ * the request's `X-Space-Id` and "最近查看" reads back by that same viewer space. In-shell callers
+ * omit it and rely on the global interceptor (spaceIdCallback → currentSpaceId, the viewer's live
+ * space). The standalone `/d/:docId` page seeds currentSpaceId to the DOC's own space for preflight
+ * addressing, so it must pass the viewer's real current space here explicitly — otherwise the view
+ * would be written under the doc space and never surface in a cross-space recipient's recent list.
+ * Axios merges this header over (and thus wins against) the interceptor's value.
  */
-export async function recordDocView(docId: string): Promise<void> {
+export async function recordDocView(docId: string, opts?: { spaceId?: string }): Promise<void> {
   try {
-    await apiClient().post(`/docs/${encodeURIComponent(docId)}/view`)
+    const config = opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined
+    await apiClient().post(`/docs/${encodeURIComponent(docId)}/view`, undefined, config)
   } catch {
     // Fire-and-forget: ingest is best-effort and must never disrupt the open path. The backend
     // collab-token path also has a best-effort fallback ingest, so a dropped call here is covered.


### PR DESCRIPTION
## Problem

A document opened from a chat **share link** (the standalone `/d/:docId` page, `StandaloneDocPage`) never showed up in the opener's **"recently viewed"** list. Root cause: the standalone page never calls `recordDocView` — unlike the in-shell `DocsHome` entry, which records a view on open.

## Change

- **`StandaloneDocPage`**: once the doc reaches the `ready` phase, record a single view (mirrors `DocsHome.commitOpen`). Fire-and-forget, guarded by `docId` so it fires at most once per opened doc and never in a render loop.
- The view is written to the **viewer's current space** via an explicit `X-Space-Id` header — **not** the doc's own space that the standalone page seeds for preflight/room addressing. The backend writes and reads the recent-view list by the viewer's current space, so writing under the doc space would keep a cross-space share invisible in the recipient's recent list. The viewer space is captured once on first render, before the seed effect overwrites the shared current space.
- **`recordDocView`** gains an optional `spaceId` to carry that explicit header, mirroring the existing `getDoc` opts.

The space semantics follow the backend write/read space contract (viewer-current-space for both write and read).

## Tests

- **Unit (`StandaloneDocPage.test.tsx`)**: view is recorded once on `ready` with `X-Space-Id` = viewer current space (cross-space share) and = live space (in-shell mount); idempotent (single call, never in a render loop); not recorded when the preflight fails to a terminal.
- **E2E (`apps/web/e2e/standalone-doc.spec.ts`)**: real-browser coverage that opening a cross-space `/d/:docId` link fires `POST /docs/:id/view` with the viewer-space header, and that a 403 preflight records no view.

## Notes

Draft — carries review while backend deploy + device verification are coordinated.
