### PR TITLE
style(interactive-card): render Action.OpenUrl as a hyperlink

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -137,6 +137,36 @@ describe("renderOctoCard", () => {
     target.remove();
   });
 
+  it("Action.OpenUrl 渲染出 role=link、Submit 渲染出 role=button（查看详情超链样式依赖此 SDK 契约）", () => {
+    const target = mountTarget();
+    renderOctoCard({
+      card: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          {
+            type: "ActionSet",
+            actions: [
+              { type: "Action.OpenUrl", id: "open", title: "查看详情", url: "https://example.com" },
+            ],
+          },
+        ],
+        actions: [{ type: "Action.Submit", id: "ok", title: "允许" }],
+      },
+      target,
+      onAction: () => {},
+    });
+    // index.css 的 .ac-pushButton[role="link"] 超链样式依赖 SDK 给 Action.OpenUrl 打
+    // role="link"、给 Submit/Toggle/Copy 打 role="button"；SDK 升级若改了 role，超链会
+    // 失效或误伤决策按钮——此测试兜底锁死该契约。
+    const roles = Array.from(
+      target.querySelectorAll<HTMLButtonElement>(".ac-pushButton")
+    ).map((b) => b.getAttribute("role"));
+    expect(roles).toContain("link"); // Action.OpenUrl → 超链
+    expect(roles).toContain("button"); // Action.Submit → 按钮
+    target.remove();
+  });
+
   it("Action.ToggleVisibility 由 SDK 原生切换 isVisible", () => {
     const target = mountTarget();
     const types: string[] = [];

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -159,11 +159,18 @@ describe("renderOctoCard", () => {
     // index.css 的 .ac-pushButton[role="link"] 超链样式依赖 SDK 给 Action.OpenUrl 打
     // role="link"、给 Submit/Toggle/Copy 打 role="button"；SDK 升级若改了 role，超链会
     // 失效或误伤决策按钮——此测试兜底锁死该契约。
-    const roles = Array.from(
-      target.querySelectorAll<HTMLButtonElement>(".ac-pushButton")
-    ).map((b) => b.getAttribute("role"));
-    expect(roles).toContain("link"); // Action.OpenUrl → 超链
-    expect(roles).toContain("button"); // Action.Submit → 按钮
+    // 按 title 绑定 role↔action：只断言「有一个 link + 一个 button」不够——SDK 若把两者
+    // role 对调（OpenUrl→button、Submit→link）仍会误过；这里钉死到具体按钮。
+    const roleByTitle = new Map(
+      Array.from(
+        target.querySelectorAll<HTMLButtonElement>(".ac-pushButton")
+      ).map((b) => [
+        b.getAttribute("title") ?? b.textContent?.trim() ?? "",
+        b.getAttribute("role"),
+      ])
+    );
+    expect(roleByTitle.get("查看详情")).toBe("link"); // Action.OpenUrl → 超链
+    expect(roleByTitle.get("允许")).toBe("button"); // Action.Submit → 按钮
     target.remove();
   });
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/index.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/index.css
@@ -636,7 +636,7 @@
 }
 
 .wk-interactive-card-sdk .ac-pushButton[role="link"]:hover {
-  color: var(--wk-color-accent-hover, var(--wk-text-accent));
+  color: var(--wk-color-accent-hover, var(--wk-text-accent, var(--wk-brand-primary)));
   background: transparent;
   border: 0;
   box-shadow: none;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/index.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/index.css
@@ -614,6 +614,41 @@
   border-color: var(--wk-border-strong);
 }
 
+/* ── Action.OpenUrl → HTML 超链 ──
+ * AdaptiveCards 给 Action.OpenUrl 的按钮打 role="link"（Submit/ToggleVisibility/
+ * CopyToClipboard 都是 role="button"）。导航类动作渲成经典超链接：语义更贴，也不再
+ * 和主/次决策按钮抢视觉（如审批卡的「查看详情」夹在 允许/拒绝 中间过于抢眼）。
+ * 用 role 精准命中——决策按钮(style-positive/destructive)、推理卡展开按钮
+ * (ToggleVisibility)、复制按钮(CopyToClipboard) 均为 role="button"，完全不受影响。 */
+.wk-interactive-card-sdk .ac-pushButton[role="link"] {
+  display: inline;
+  min-height: auto;
+  height: auto;
+  padding: 0;
+  font-weight: var(--wk-font-regular);
+  color: var(--wk-text-accent, var(--wk-brand-primary));
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.wk-interactive-card-sdk .ac-pushButton[role="link"]:hover {
+  color: var(--wk-color-accent-hover, var(--wk-text-accent));
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  text-decoration: underline;
+}
+
+.wk-interactive-card-sdk .ac-pushButton[role="link"]:focus-visible {
+  outline: 2px solid var(--wk-border-glow);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
 .wk-interactive-card-sdk .ac-textInput,
 .wk-interactive-card-sdk .ac-numberInput,
 .wk-interactive-card-sdk .ac-dateInput,


### PR DESCRIPTION
## Summary

Interactive-card `Action.OpenUrl` buttons (查看详情, 在 GitLab 查看, …) rendered as the base accent **pill**, which out-shouts the primary/secondary decision buttons on approval cards and reads wrong for what is really a *navigation* action.

AdaptiveCards marks `Action.OpenUrl` buttons with `role="link"` (Submit / ToggleVisibility / CopyToClipboard are `role="button"`), so this targets `.ac-pushButton[role="link"]` and renders it as a classic underlined **hyperlink** — link colour + underline, no button chrome. Precise, CSS-only, and semantic.

Before → after (approval card): 查看详情 pill competing with 允许/拒绝 → a quiet link above the decision buttons.

## Related Issue

N/A

## Changes

- `packages/dmworkbase/src/Messages/InteractiveCard/index.css`: add `.ac-pushButton[role="link"]` (+ `:hover` / `:focus-visible`) rendering OpenUrl buttons as an underlined link (accent colour, `--wk-color-accent-hover` on hover, focus outline for a11y).
- `packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx`: add a render test locking the SDK contract — `Action.OpenUrl` → `role="link"`, `Action.Submit` → `role="button"`.

## Architecture / Module Boundary

- Affected module(s): `dmworkbase` — `Messages/InteractiveCard`
- New or changed user-visible entry point: no (visual refinement of existing card buttons)
- Shared layer touched: Messages
- If shared code changed, impact scope: **only** `Action.OpenUrl` buttons (`role="link"`). Everything else is `role="button"` and untouched — audited against every `.ac-pushButton` rule in `index.css`: decision buttons (`.style-positive`/`.style-destructive`), the agent-progress **展开推理** toggle (`ToggleVisibility`, and a more-specific selector), the table copy button (different class), and `CopyToClipboard`. No regression to any intentional styling.
- Duplicate entry point checked: not applicable (CSS + test only, no new component)

## Testing

- New render test asserts the `role` contract (`link` for OpenUrl, `button` for Submit) the CSS keys off.
- Verified through the real AdaptiveCards 3.0.6 SDK + this stylesheet across four card shapes — approval (查看详情 link, 允许/拒绝 buttons), custom-action approval (执行/取消 stay buttons, **not** links), agent-progress reasoning (展开推理 keeps its bordered toggle), and pipeline (在 GitLab 查看 link). Computed-style assertions confirm the reasoning toggle stays `role="button"` with its border and no underline.
- CSS + test only; no component logic touched.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2FHToMTWZnMq6cbQyTjqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2FHToMTWZnMq6cbQyTjqg)_