### PR TITLE
fix(interactive-card): submit peer channel_id when bot DM channelID collapses to self

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
@@ -9,7 +9,11 @@ import MessageRow from "../../ui/message/MessageRow";
 import ReplyBlock from "../../ui/message/ReplyBlock";
 import { MessageCell } from "../MessageCell";
 import { t } from "../../i18n";
-import { isRetryableCardActionError, submitCardAction } from "./cardAction";
+import {
+  isRetryableCardActionError,
+  resolveCardActionChannelId,
+  submitCardAction,
+} from "./cardAction";
 import { isAgentProgressCard } from "./cardLayout";
 import { InteractiveCardContent } from "./InteractiveCardContent";
 import { decideCardBody, type CardDecision } from "./renderDecision";
@@ -289,6 +293,16 @@ export class InteractiveCardCell extends MessageCell {
     const channel = message.channel;
     if (!channel) return;
 
+    // person DM 与系统 bot（notification 等）的 recv 包 channelID 可能塌缩为接收人
+    // 自身 uid，直接回传会让服务端 fakeChannel(self,self) miss → 400。回退到权威对端
+    // message.fromUID，确保 channel_id 与服务端存储键一致（群/普通 DM 为 no-op）。
+    const channelId = resolveCardActionChannelId({
+      channelType: channel.channelType,
+      channelID: channel.channelID,
+      fromUID: message.fromUID,
+      selfUID: WKApp.loginInfo.uid,
+    });
+
     // 本次提交代次：使此前提交/超时/新帧作废，且异步回调据此判活。
     const gen = ++this.submitGen;
     this.submitError = null;
@@ -298,7 +312,7 @@ export class InteractiveCardCell extends MessageCell {
 
     submitCardAction({
       messageId: message.messageID,
-      channelId: channel.channelID,
+      channelId,
       channelType: channel.channelType,
       actionId,
       inputs,

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/cardAction.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/cardAction.test.ts
@@ -14,7 +14,16 @@ vi.mock("../../../App", () => ({
   },
 }));
 
-import { submitCardAction, isRetryableCardActionError } from "../cardAction";
+// person=1，与真实 ChannelTypePerson 一致（避免测试拉起重型 SDK）。
+vi.mock("wukongimjssdk", () => ({
+  ChannelTypePerson: 1,
+}));
+
+import {
+  submitCardAction,
+  isRetryableCardActionError,
+  resolveCardActionChannelId,
+} from "../cardAction";
 
 const params = {
   messageId: "m1",
@@ -55,6 +64,65 @@ describe("submitCardAction — 请求体（D11 no-data）", () => {
   it("缺字段保守视为已受理", async () => {
     postMock.mockResolvedValue({});
     expect((await submitCardAction(params)).accepted).toBe(true);
+  });
+});
+
+describe("resolveCardActionChannelId — person DM 对端塌缩兜底", () => {
+  const SELF = "self-uid";
+
+  it("person DM channelID 塌缩为 self → 回退到 fromUID（对端 bot）", () => {
+    expect(
+      resolveCardActionChannelId({
+        channelType: 1,
+        channelID: SELF,
+        fromUID: "notification",
+        selfUID: SELF,
+      })
+    ).toBe("notification");
+  });
+
+  it("person DM channelID 已是对端 → 原样返回（既有路径不变）", () => {
+    expect(
+      resolveCardActionChannelId({
+        channelType: 1,
+        channelID: "peer-uid",
+        fromUID: "peer-uid",
+        selfUID: SELF,
+      })
+    ).toBe("peer-uid");
+  });
+
+  it("group（channelType=2）任意 channelID → 原样返回（既有路径不变）", () => {
+    expect(
+      resolveCardActionChannelId({
+        channelType: 2,
+        channelID: SELF,
+        fromUID: "notification",
+        selfUID: SELF,
+      })
+    ).toBe(SELF);
+  });
+
+  it("防御：channelID===self 但 fromUID 缺失 → 保留 channelID，不崩", () => {
+    expect(
+      resolveCardActionChannelId({
+        channelType: 1,
+        channelID: SELF,
+        fromUID: undefined,
+        selfUID: SELF,
+      })
+    ).toBe(SELF);
+  });
+
+  it("防御：selfUID 缺失 → 保留 channelID（无法判定塌缩）", () => {
+    expect(
+      resolveCardActionChannelId({
+        channelType: 1,
+        channelID: "peer-uid",
+        fromUID: "notification",
+        selfUID: undefined,
+      })
+    ).toBe("peer-uid");
   });
 });
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/cardAction.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/cardAction.ts
@@ -1,4 +1,38 @@
+import { ChannelTypePerson } from "wukongimjssdk";
 import WKApp from "../../App";
+
+/**
+ * 解析卡片动作上行请求的 `channel_id`（person DM 对端塌缩兜底）。
+ *
+ * 服务端把 person 频道的 `channel_id` 当作**对端 uid**，按 `fakeChannel(loginUID,
+ * channel_id)` 定位存储行。正常 1v1 里 `message.channel.channelID` 已是对端；但与
+ * 系统 bot（如 `notification`，docs / smart-summary 审批卡都经它下发）的 DM，其 recv
+ * 包 channelID 会塌缩为**接收人自身 uid**（WuKongIM「receiver as container」路径，未做
+ * 常规 personal 对端翻转），此时若直接回传 channelID=self，服务端算出 `fakeChannel(self,
+ * self)` 必然 miss → 400 `card_action_invalid`。
+ *
+ * received 消息的权威对端是 `message.fromUID`（与 WKSDK `message.send` getter 同源），
+ * 故当 person 频道 channelID 塌缩为 self 时回退到 fromUID。group/topic（channelID=群号）
+ * 与 channelID 已是对端的普通 DM 条件均不成立 → 原样返回（fallback 为 no-op，无需 per-bot
+ * 白名单）。selfUID / fromUID 缺失时同样保守保留 channelID，不崩。
+ */
+export function resolveCardActionChannelId(params: {
+  channelType: number;
+  channelID: string;
+  fromUID?: string;
+  selfUID?: string;
+}): string {
+  const { channelType, channelID, fromUID, selfUID } = params;
+  if (
+    channelType === ChannelTypePerson &&
+    !!selfUID &&
+    channelID === selfUID &&
+    !!fromUID
+  ) {
+    return fromUID;
+  }
+  return channelID;
+}
 
 /**
  * 卡片动作提交（octo/v2 交互闭环，契约 §7.1）。


### PR DESCRIPTION
## Summary

Personal DMs with system bots (e.g. `notification`, which dispatches the **docs** and smart-summary approval cards) can deliver a recv packet whose `message.channel.channelID` collapses to the **receiver's own uid** instead of the peer bot. Clicking a card button then submits `channel_id = self`, so octo-server computes `fakeChannel(self, self)`, misses the stored row, and returns `400 err.server.message.card_action_invalid` — the card stays in the loading state until the 10s timeout tick. This is not specific to `notification`: it scopes to every bot delivered over the same recv path (`docs` / `smart-summary` approval cards, and future `OCTO_CARD_ACTION_ROUTES` consumers).

## Related Issue

Fixes #831

## Changes

- Add `resolveCardActionChannelId(...)` in `cardAction.ts`: for a **person** channel whose `channelID === loginUID`, fall back to `message.fromUID` (the authoritative peer for received messages, same source WKSDK's `message.send` getter uses) so the submitted `channel_id` matches server-side storage.
- Wire it into `InteractiveCardCell.handleSubmit` (`selfUID = WKApp.loginInfo.uid`); the submit body now sends the derived `channelId`.
- The fallback is a **no-op** for group/topic (channelID is the group/topic id) and for normal DMs where `channelID` is already the peer — so no per-bot allowlist is needed. Missing `selfUID`/`fromUID` conservatively preserves `channelID` (never crashes).
- Add 5 unit cases: collapse→`fromUID`, already-peer unchanged, group unchanged, and the two defensive fallbacks.

## Architecture / Module Boundary

- Affected module(s): `@octo/base` (`dmworkbase`) — `Messages/InteractiveCard`
- New or changed user-visible entry point: no
- Shared layer touched: Messages
- If shared code changed, impact scope: only the InteractiveCard `Action.Submit` closed loop. Rendering, sender-trust gating, and all other message cells are untouched. `resolveCardActionChannelId` is additive and returns the prior value (`channel.channelID`) for every non-collapse case, so existing behavior is preserved.
- Duplicate entry point checked: not applicable

## Testing

- `cd packages/dmworkbase && vitest run src/Messages/InteractiveCard/` → **20 files, 215 tests pass** (incl. the 5 new cases).
- `tsc --noEmit` shows no new type errors in the changed files (residual errors are pre-existing environment noise, identical on untouched cells).

- [x] Unit tests added/updated
- [ ] Manually verified <!-- the full bot-DM round-trip needs a running stack; covered here by unit tests + the server-side card-action contract test -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy <!-- no UI copy added -->
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6NQFjcxFaNQRHXPs6PV6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6NQFjcxFaNQRHXPs6PV6i)_