### PR TITLE
refactor(route): clean up URLs and session scoping

### DIFF
--- a/apps/web/src/Components/InviteLanding/index.tsx
+++ b/apps/web/src/Components/InviteLanding/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { I18nContext, WKApp, apiFetchJson, computeAndSaveJoinSuccess, t, toJoinApprovalStatus } from "@octo/base";
+import { I18nContext, WKApp, apiFetchJson, computeAndSaveJoinSuccess, setSessionSid, t, toJoinApprovalStatus } from "@octo/base";
 import type { JoinSpaceStatus } from "@octo/base";
 import { Button, Spin, Toast } from "@douyinfe/semi-ui";
 import "./index.css";
@@ -275,11 +275,12 @@ export default class InviteLanding extends Component<InviteLandingProps, InviteL
             if (!crossSpace && joinedSpaceId) {
                 localStorage.setItem('currentSpaceId', joinedSpaceId);
             }
-            // 跳转回主界面，带上正确的 sid
+            // 跳转回主界面；sid 写入当前 tab 的 SessionScope，不再暴露到 URL。
             const sid = this.findSid();
             // 使用安全的 basePath，避免当 pathname 为 /api/ 时跳到后端 API 路径（#1006）
             const basePath = this.getAppBasePath();
-            window.location.href = `${window.location.origin}${basePath}/${sid ? `?sid=${sid}` : ''}`;
+            if (sid) setSessionSid(sid);
+            window.location.href = `${window.location.origin}${basePath}/`;
         } catch (e: any) {
             const body = this.getApiErrorData(e);
             if (this.isNeedSpaceResponse(this.getApiErrorStatus(e), body)) {

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -7,13 +7,13 @@ import { Notification as NotificationUI, Button } from '@douyinfe/semi-ui';
 import { checkUpdate, installUpdate, UpdateManifest } from '@tauri-apps/api/updater'
 import { relaunch } from '@tauri-apps/api/process'
 import { os } from "@tauri-apps/api";
-import { getSid, getQueryParam, computeAndSaveJoinSuccess } from "@octo/base";
+import { getQueryParam, computeAndSaveJoinSuccess, removeSidFromPath, setSessionSid } from "@octo/base";
 import type { JoinApprovalStatus } from "@octo/base";
 import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
-import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from "@octo/docs";
+import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn } from "@octo/docs";
 import { SummaryDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 import { isLoopCliAuthorizePath, LOOP_CLI_AUTHORIZE_PATH } from "@octo/loop";
@@ -137,8 +137,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const basePath = rawPath
                 .replace(/^\/api(?:\/v\d+)?(?=\/|$)/, '')
                 .replace(/\/+$/, '')
-            // 保留原始 sid（如果有），不随机生成新的
-            const existingSid = getQueryParam("sid") || ""
             // #511 problem 2 (附带必修): a forwarded-doc link is `/docs?...&doc=<id>&sid=<space>`.
             // A first-time recipient logs in, then the post-login redirect used to keep only ?sid=
             // and drop ?doc=, landing them on the empty document list instead of the document they
@@ -149,7 +147,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             const forwardFolder = getQueryParam("folder") || ""
             const forwardSp = getQueryParam("sp") || ""
             const redirectQuery = new URLSearchParams()
-            if (existingSid) redirectQuery.set("sid", existingSid)
             if (forwardDoc) {
                 redirectQuery.set("doc", forwardDoc)
                 if (forwardSpace) redirectQuery.set("space", forwardSpace)
@@ -161,7 +158,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 if (forwardSpace) redirectQuery.set("space", forwardSpace)
             }
             const redirectQs = redirectQuery.toString()
-            const sidParam = redirectQs ? `?${redirectQs}` : ""
+            const redirectSearch = redirectQs ? `?${redirectQs}` : ""
 
             const goMain = () => {
                 // A user who signed in from a shared /d/:docId link (local OR SSO/OIDC, where the
@@ -170,27 +167,22 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 // clears the key and only returns SAFE same-origin relative paths (open-redirect
                 // guard), so a tampered value can never redirect off-origin.
                 //
-                // Carry the just-authenticated session's own sid on the reload (XIN-398): the
-                // stashed target has no `?sid=`, so the reloaded /d/:docId's sid-keyed load() would
-                // read only the empty-sid bucket and — for a multi-session user — fall through to a
-                // recovery that (XIN-392 P1-2) refuses to guess an identity, bouncing them back to
-                // login in a loop. withReturnSid appends the sid of the bucket that already holds the
-                // current token (findSidForToken — the known identity, never a guess), so the reload
-                // hits the right session directly instead of relying on the now-strict recovery. It
-                // no-ops when the target already carries a sid or the session lives in the empty-sid
-                // bucket (where a no-sid reload already resolves it), and the appended target still
-                // passes the isSafeReturnPath / parseStandaloneDocId gates.
+                // Carry the just-authenticated session's own sid on the reload (XIN-398), but keep
+                // the URL clean: store the known bucket sid in SessionScope, then navigate to the
+                // sid-less return path. The reloaded page still hits the right sid-keyed session
+                // bucket, without exposing `?sid=` in the address bar.
                 const standaloneReturn = consumeStandaloneReturn();
                 if (standaloneReturn) {
                     const sessionSid = findSidForToken(localStorage, WKApp.loginInfo.token || "");
-                    window.location.assign(withReturnSid(standaloneReturn, sessionSid))
+                    if (sessionSid) setSessionSid(sessionSid);
+                    window.location.assign(removeSidFromPath(standaloneReturn))
                     return
                 }
                 if ((window as any).__POWERED_EXTENSION__) {
                     window.location.reload()
                     return
                 }
-                window.location.href = `${window.location.origin}${basePath}/${sidParam}`
+                window.location.href = `${window.location.origin}${basePath}/${redirectSearch}`
             }
 
             // 检查是否有待处理的邀请码（验证格式防止 XSS/Open Redirect）
@@ -430,7 +422,8 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             }
             // Anonymous: stash the exact /d/:docId target so the post-login flow (local OR SSO/OIDC)
             // can bounce the user back to the document instead of the app root, then fall through to
-            // the login screen (below) without navigating away. The standalone page itself only
+            // the login screen (below) without navigating away. SessionScope keeps the session bucket
+            // available without exposing sid in the return URL. The standalone page itself only
             // mounts once a token exists, so the anonymous path is the ONLY place this key gets
             // written for a first-time visitor — onLogin consumes it via consumeStandaloneReturn.
             persistStandaloneReturn();

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -251,6 +251,7 @@ export class MainPage extends Component<{}, MainPageState> {
                                             const prevMenuId = vm.currentMenus?.id;
                                             vm.currentMenus = menus;
                                             WKApp.currentMenuId = menus.id;
+                                            WKApp.route.syncPath(menus.routePath);
                                             if (menus.onPress) {
                                                 menus.onPress();
                                             } else {
@@ -312,6 +313,7 @@ export class MainPage extends Component<{}, MainPageState> {
                                         if (target && vm.currentMenus?.id !== menuId) {
                                             vm.currentMenus = target;
                                             WKApp.currentMenuId = menuId;
+                                            WKApp.route.syncPath(target.routePath);
                                             // NOTE: do NOT popToRoot() here. routeLeft is a shared
                                             // stack across tabs; popping it would destroy the detail
                                             // view (e.g. summary detail page) the user was on,

--- a/apps/web/src/Pages/Main/tab_low_screen.tsx
+++ b/apps/web/src/Pages/Main/tab_low_screen.tsx
@@ -20,6 +20,7 @@ export class TabLowScreen extends Component<TabLowScreenProps> {
                             return <li key={menus.id} onClick={() => {
                                 vm.currentMenus = menus
                                 if (menus.onPress) {
+                                    WKApp.route.syncPath(menus.routePath)
                                     menus.onPress()
                                 } else {
                                     WKApp.route.push(menus.routePath)

--- a/apps/web/src/Pages/Main/vm.ts
+++ b/apps/web/src/Pages/Main/vm.ts
@@ -1,4 +1,4 @@
-import { WKApp, Menus, ProviderListener, startVersionCheck, t } from "@octo/base";
+import { WKApp, Menus, ProviderListener, normalizeRoutePath, startVersionCheck, t } from "@octo/base";
 import { Toast } from "@douyinfe/semi-ui";
 import { reconcileMenuState, resolvePendingRouteActivation } from "./menuReconcile";
 
@@ -64,10 +64,13 @@ export default class MainVM extends ProviderListener {
   // first appconfig load, then cleared. Any explicit user navigation also clears it (see the
   // currentMenus setter) so a late toggle never yanks the user off a view they chose.
   private _pendingRouteActivation?: string;
+  private _onBrowserRouteChange = () => {
+    this.syncMenuFromBrowserPath();
+  };
 
   didMount(): void {
     let found = false;
-    const bootPath = WKApp.route.currentPath;
+    const bootPath = normalizeRoutePath(window.location.pathname || WKApp.route.currentPath);
     if (bootPath) {
       for (const menus of this.menusList) {
         if (menus.routePath === bootPath) {
@@ -104,6 +107,7 @@ export default class MainVM extends ProviderListener {
         this.notifyListener();
       }
     });
+    window.addEventListener("popstate", this._onBrowserRouteChange);
 
     if ((window as any).__POWERED_ELECTRON__) {
       this.appUpdateInit();
@@ -184,6 +188,30 @@ export default class MainVM extends ProviderListener {
     this.ipcListeners = [];
     this.stopVersionCheck?.();
     this._unsubscribeMenuReconcile?.();
+    window.removeEventListener("popstate", this._onBrowserRouteChange);
+  }
+
+  private syncMenuFromBrowserPath(): boolean {
+    const routePath = normalizeRoutePath(window.location.pathname);
+    const target = this.menusList.find((menus) => menus.routePath === routePath);
+    if (!target) {
+      if (routePath !== "/") {
+        this._pendingRouteActivation = routePath;
+      }
+      return false;
+    }
+    if (this._currentMenus?.id === target.id) {
+      return false;
+    }
+    this._currentMenus = target;
+    if (this._historyRoutePaths.indexOf(target.routePath) === -1) {
+      this._historyRoutePaths.push(target.routePath);
+    }
+    WKApp.currentMenuId = target.id;
+    this._pendingRouteActivation = undefined;
+    this.notifyListener();
+    WKApp.mittBus.emit("wk:nav-menu-activated", { menuId: target.id });
+    return true;
   }
 
   /**

--- a/apps/web/src/__tests__/docsDeepLinkCapture.test.ts
+++ b/apps/web/src/__tests__/docsDeepLinkCapture.test.ts
@@ -5,9 +5,9 @@ import * as path from 'path'
  * Regression for the forwarded-doc deep-link capture (feature #511, XIN-328 / XIN-332 / XIN-333).
  *
  * The forwarded-doc card link opens a new tab at `/docs?...&doc=<docId>`, but the octo host's
- * RouteManager re-pushes pathname-only on pageshow/popstate and wipes `?doc=` to `/docs?sid=…`
- * before the code-split docs chunk mounts — XIN-332 proved DocsModule.init() runs AFTER that
- * wipe on device. The fix moves the primary capture into an inline <script> at the top of
+ * RouteManager / host route normalization can wipe `?doc=` before the code-split docs chunk
+ * mounts — XIN-332 proved DocsModule.init() runs AFTER that wipe on device.
+ * The fix moves the primary capture into an inline <script> at the top of
  * index.html, which runs during HTML parse (earliest synchronous entry). These tests extract that
  * inline script and execute it against jsdom so the behaviour and the observability marker cannot
  * silently regress or drift from the `octo.docs.target` key the docs module reads.

--- a/apps/web/src/__tests__/externalStandaloneRoutes.test.ts
+++ b/apps/web/src/__tests__/externalStandaloneRoutes.test.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+describe("external standalone routes", () => {
+  it("opens space management as a standalone document route, not a host app route", () => {
+    const source = readRepoFile("packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx");
+
+    expect(source).toContain('window.location.assign("/space")');
+    expect(source).not.toContain('WKApp.route.push("/space")');
+    expect(source).not.toContain('window.location.href = "/space"');
+  });
+});

--- a/apps/web/src/__tests__/inviteLandingRedirectPath.test.ts
+++ b/apps/web/src/__tests__/inviteLandingRedirectPath.test.ts
@@ -16,27 +16,27 @@ function getAppBasePath(pathname: string): string {
   return stripped.replace(/\/+$/, '')
 }
 
-function buildRedirect(pathname: string, sid: string): string {
+function buildRedirect(pathname: string): string {
   const basePath = getAppBasePath(pathname)
-  return `https://host${basePath}/${sid ? `?sid=${sid}` : ''}`
+  return `https://host${basePath}/`
 }
 
 describe('InviteLanding redirect basePath (#1006)', () => {
   it('normal root pathname → redirects to "/"', () => {
-    expect(buildRedirect('/', 'abc')).toBe('https://host/?sid=abc')
+    expect(buildRedirect('/')).toBe('https://host/')
   })
 
   it('"/api/" pathname no longer lands on backend 404 route', () => {
     // Bug repro: before the fix this returned "/api/?sid=abc" → 404.
-    expect(buildRedirect('/api/', 'abc')).toBe('https://host/?sid=abc')
+    expect(buildRedirect('/api/')).toBe('https://host/')
   })
 
   it('"/api" (no trailing slash) is also stripped', () => {
-    expect(buildRedirect('/api', 'abc')).toBe('https://host/?sid=abc')
+    expect(buildRedirect('/api')).toBe('https://host/')
   })
 
   it('"/api/v1/" is stripped (versioned API path)', () => {
-    expect(buildRedirect('/api/v1/', 'abc')).toBe('https://host/?sid=abc')
+    expect(buildRedirect('/api/v1/')).toBe('https://host/')
   })
 
   it('"/api/v2/space/invite/xxx" strips the /api/vN prefix only', () => {
@@ -44,23 +44,18 @@ describe('InviteLanding redirect basePath (#1006)', () => {
     // never accidentally chop off a legitimate sibling deployment path.
     // For the #1006 repro, this branch is defensive; the user normally lands
     // on /api/?invite=xxx, which fully collapses to '/' (covered above).
-    expect(buildRedirect('/api/v2/space/invite/xxx', 'abc')).toBe(
-      'https://host/space/invite/xxx/?sid=abc'
+    expect(buildRedirect('/api/v2/space/invite/xxx')).toBe(
+      'https://host/space/invite/xxx/'
     )
   })
 
   it('subpath deployment ("/web/") is preserved', () => {
     // Non-/api subpath must still be preserved for legacy deployments.
-    expect(buildRedirect('/web/', 'abc')).toBe('https://host/web/?sid=abc')
+    expect(buildRedirect('/web/')).toBe('https://host/web/')
   })
 
   it('"/apiary/" is NOT stripped (only matches exact /api segment)', () => {
     // Regex uses boundary `(?=\/|$)` so /apiary is left alone.
-    expect(buildRedirect('/apiary/', 'abc')).toBe('https://host/apiary/?sid=abc')
-  })
-
-  it('empty sid produces no query string', () => {
-    expect(buildRedirect('/', '')).toBe('https://host/')
-    expect(buildRedirect('/api/', '')).toBe('https://host/')
+    expect(buildRedirect('/apiary/')).toBe('https://host/apiary/')
   })
 })

--- a/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
+++ b/apps/web/src/__tests__/layoutStandaloneDocPath.test.ts
@@ -119,6 +119,7 @@ describe('Layout — standalone /s/:taskNo summary clean cold-load path', () => 
     expect(layout).toMatch(/const\s+forwardSp\s*=\s*getQueryParam\("sp"\)\s*\|\|\s*""/)
     expect(layout).toMatch(/redirectQuery\.set\("sp",\s*forwardSp\)/)
     expect(layout).toMatch(/consumeStandaloneReturn\(\)/)
-    expect(layout).toMatch(/withReturnSid\(standaloneReturn,\s*sessionSid\)/)
+    expect(layout).toMatch(/setSessionSid\(sessionSid\)/)
+    expect(layout).toMatch(/removeSidFromPath\(standaloneReturn\)/)
   })
 })

--- a/apps/web/src/__tests__/mainMenuReconcile.test.tsx
+++ b/apps/web/src/__tests__/mainMenuReconcile.test.tsx
@@ -260,6 +260,10 @@ describe("resolvePendingRouteActivation — deep-link appears after appconfig re
 describe("MainVM — pending deep-link wiring", () => {
   it("records the unsatisfied boot route and clears it on explicit navigation", () => {
     const source = readRepoFile("apps/web/src/Pages/Main/vm.ts");
+    // Clean deep links such as /appbot no longer carry ?sid=. Boot activation must use the live
+    // URL path as the source of truth, not only RouteManager.currentPath, which can be touched by
+    // pageshow/popstate during startup.
+    expect(source).toContain("normalizeRoutePath(window.location.pathname || WKApp.route.currentPath)");
     // didMount stashes the boot route when the fallback fired (no menu matched it)...
     expect(source).toContain("this._pendingRouteActivation = bootPath");
     // ...and the config-change listener tries to activate it as menus appear.
@@ -267,11 +271,25 @@ describe("MainVM — pending deep-link wiring", () => {
     // Any explicit menu selection (the currentMenus setter) must cancel the pending activation so
     // a late docs_on toggle never yanks a user off a view they chose.
     expect(source).toContain("this._pendingRouteActivation = undefined");
-    const setterClearIdx = source.indexOf(
-      "this._pendingRouteActivation = undefined"
-    );
+    expect(source).toContain('window.addEventListener("popstate", this._onBrowserRouteChange)');
+    expect(source).toContain('window.removeEventListener("popstate", this._onBrowserRouteChange)');
+    expect(source).toContain("syncMenuFromBrowserPath()");
+    expect(source).toContain('WKApp.mittBus.emit("wk:nav-menu-activated", { menuId: target.id })');
     const setterIdx = source.indexOf("set currentMenus(");
     expect(setterIdx).toBeGreaterThan(-1);
+    const setterClearIdx = source.indexOf(
+      "this._pendingRouteActivation = undefined",
+      setterIdx
+    );
     expect(setterClearIdx).toBeGreaterThan(setterIdx);
+  });
+
+  it("syncs the browser URL when menu selection changes", () => {
+    const source = readRepoFile("apps/web/src/Pages/Main/index.tsx");
+    const lowScreenSource = readRepoFile("apps/web/src/Pages/Main/tab_low_screen.tsx");
+
+    expect(source).toContain("WKApp.route.syncPath(menus.routePath)");
+    expect(source).toContain("WKApp.route.syncPath(target.routePath)");
+    expect(lowScreenSource).toContain("WKApp.route.syncPath(menus.routePath)");
   });
 });

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,7 +4,7 @@ import '@octo/base/src/theme/tokens.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import  { BaseModule, I18nProvider, i18n, WKApp } from '@octo/base';
+import  { BaseModule, I18nProvider, ensureSessionSid, i18n, stripSessionSidFromUrl, WKApp } from '@octo/base';
 import  { LoginModule, BindModule } from '@octo/login';
 import  { DataSourceModule } from '@octo/datasource';
 import {ContactsModule} from '@octo/contacts';
@@ -53,6 +53,8 @@ WKApp.apiClient.config.spaceIdCallback = () => {
 WKApp.config.appVersion = import.meta.env.VITE_VERSION || pkgVersion
 WKApp.config.appName = "Octo"
 
+ensureSessionSid()
+stripSessionSidFromUrl()
 WKApp.loginInfo.load() // 加载登录信息
 i18n.registerNamespace("app", {
   "zh-CN": appZhCN,

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -71,8 +71,8 @@ export default class LoopModule implements IModule {
         window.sessionStorage
       );
 
-      // RouteManager keeps only `sid` on pageshow. Capture the callback above,
-      // then remove it from the address bar before it can remain in history.
+      // Capture the callback above, then remove it from the address bar before
+      // host route normalization can leave a callback-bearing entry in history.
       if (new URLSearchParams(window.location.search).get("cli_callback")) {
         try {
           window.history.replaceState(

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -1,4 +1,5 @@
 import mitt, { Emitter } from "mitt";
+import { getSessionSid, setSessionSid } from "./Service/SessionScope";
 
 /** mittBus 全局事件类型表 */
 export type MittEvents = {
@@ -543,8 +544,7 @@ export class LoginInfo {
   }
 
   public getSID(): string {
-    let sid = this.getQueryVariable("sid") || "";
-    return sid;
+    return getSessionSid();
   }
 
   public setStorageItem(key: string, value: string) {
@@ -987,6 +987,7 @@ export default class WKApp extends ProviderListener {
   private clearLocalLoginState() {
     WKApp.loginInfo.logout();
     clearAuthStorage();
+    setSessionSid("");
     this.currentSpaceId = "";
     this.channelSpaceMap.clear();
     this.channelMySourceSpaceMap.clear();
@@ -996,7 +997,7 @@ export default class WKApp extends ProviderListener {
   // 登出
   logout() {
     this.clearLocalLoginState();
-    window.location.reload();
+    window.location.replace("/login");
   }
 
   async logoutUserInitiated() {

--- a/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
@@ -174,7 +174,7 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                             onToggleSetting();
                             // /space 是独立打包的 admin SPA（同源），React Router 不识别，必须整页跳转；
                             // 真实鉴权由 admin 后端负责，此处仅用于 UI 可见性控制。
-                            window.location.href = "/space";
+                            window.location.assign("/space");
                         }}>
                             {t("base.navRail.settingsPanel.spaceManagement")}
                         </li>

--- a/packages/dmworkbase/src/Service/Route.tsx
+++ b/packages/dmworkbase/src/Service/Route.tsx
@@ -2,21 +2,23 @@ import React from "react";
 import WKApp from "../App";
 import { EndpointCategory, EndpointID } from "./Const";
 import { EndpointManager } from "./Module";
-import { getSid } from "../Utils/search";
+import { normalizeRoutePath } from "./RoutePath";
+import { ensureSessionSid } from "./SessionScope";
 
 export default class RouteManager {
   private handlePopState = () => {
-    RouteManager.shared.push(window.location.pathname)
+    RouteManager.shared.renderCurrentPath(window.location.pathname)
   }
 
   private handlePageShow = () => {
-    RouteManager.shared.push(window.location.pathname)
+    RouteManager.shared.renderCurrentPath(window.location.pathname)
   }
 
   private constructor() {
     window.addEventListener('popstate', this.handlePopState);
     window.addEventListener('pageshow', this.handlePageShow);
-    this.currentPath = "/"
+    ensureSessionSid()
+    this.currentPath = normalizeRoutePath(window.location.pathname)
   }
   public static shared = new RouteManager()
 
@@ -28,24 +30,52 @@ export default class RouteManager {
   currentPath?:string // 当前路由path
 
   register(path: string, handler: (param: any) => JSX.Element| React.ElementType) {
-    EndpointManager.shared.setMethod(`${EndpointID.routePrefix}${path}`, (param) => {
+    const routePath = normalizeRoutePath(path)
+    EndpointManager.shared.setMethod(`${EndpointID.routePrefix}${routePath}`, (param) => {
       return handler(param);
     }, { category: EndpointCategory.routes });
   }
 
   get(path: string, param?: any): JSX.Element| React.ElementType {
-    const component = EndpointManager.shared.invoke(`${EndpointID.routePrefix}${path}`, param)
+    const routePath = normalizeRoutePath(path)
+    const component = EndpointManager.shared.invoke(`${EndpointID.routePrefix}${routePath}`, param)
     return component
   }
 
-  push(path: string, param?: any) {
-    this.currentPath = path
-    const component = EndpointManager.shared.invoke(`${EndpointID.routePrefix}${path}`, param)
+  syncPath(path: string, mode: "push" | "replace" = "push") {
+    const routePath = normalizeRoutePath(path)
+    this.currentPath = routePath
+
+    const currentUrl = window.location.pathname + window.location.search
+    if (currentUrl === routePath) return
+
+    if (mode === "replace") {
+      window.history.replaceState({}, "title", routePath)
+      return
+    }
+    window.history.pushState({}, "title", routePath)
+  }
+
+  renderCurrentPath(path: string, param?: any) {
+    const routePath = normalizeRoutePath(path)
+    this.currentPath = routePath
+    const component = EndpointManager.shared.invoke(`${EndpointID.routePrefix}${routePath}`, param)
     if (component) {
-      let sid = getSid()
-      const url = new URL(path, window.location.origin)
-      url.searchParams.set('sid', sid)
-      window.history.pushState({}, "title", url.pathname + url.search)
+      WKApp.shared.restContent(component)
+    }
+  }
+
+  push(path: string, param?: any) {
+    const routePath = normalizeRoutePath(path)
+    this.currentPath = routePath
+    const component = EndpointManager.shared.invoke(`${EndpointID.routePrefix}${routePath}`, param)
+    if (component) {
+      const url = new URL(routePath, window.location.origin)
+      const nextUrl = url.pathname + url.search
+      const currentUrl = window.location.pathname + window.location.search
+      if (currentUrl !== nextUrl) {
+        window.history.pushState({}, "title", nextUrl)
+      }
       WKApp.shared.restContent(component)
     }
   }

--- a/packages/dmworkbase/src/Service/RoutePath.ts
+++ b/packages/dmworkbase/src/Service/RoutePath.ts
@@ -1,0 +1,18 @@
+export function normalizeRoutePath(path?: string): string {
+  if (!path) return "/";
+
+  let routePath = path.trim();
+  if (!routePath) return "/";
+
+  const searchStart = routePath.search(/[?#]/);
+  if (searchStart >= 0) {
+    routePath = routePath.slice(0, searchStart);
+  }
+
+  if (!routePath.startsWith("/")) {
+    routePath = `/${routePath}`;
+  }
+
+  routePath = routePath.replace(/\/+$/, "");
+  return routePath || "/";
+}

--- a/packages/dmworkbase/src/Service/SessionScope.ts
+++ b/packages/dmworkbase/src/Service/SessionScope.ts
@@ -1,0 +1,122 @@
+const SESSION_SID_KEY = "octo.session.sid";
+
+let memorySid = "";
+
+function randomSid(): string {
+  return Math.random().toString(36).slice(-6);
+}
+
+function safeSessionStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeLocalStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function findReusableStoredSessionSid(store: Pick<Storage, "length" | "key" | "getItem"> | undefined): string {
+  if (!store) return "";
+
+  const sessions: { sid: string; uid: string }[] = [];
+  for (let i = 0; i < store.length; i++) {
+    const key = store.key(i);
+    if (!key || !key.startsWith("token") || key === "token" || key === "tokenCallback") {
+      continue;
+    }
+    const token = store.getItem(key);
+    if (!token) continue;
+
+    const sid = key.slice("token".length);
+    if (!sid) continue;
+    sessions.push({
+      sid,
+      uid: store.getItem(`uid${sid}`) || "",
+    });
+  }
+
+  if (sessions.length === 1) return sessions[0].sid;
+
+  const uid = sessions[0]?.uid;
+  if (uid && sessions.every((session) => session.uid === uid)) {
+    return sessions[0].sid;
+  }
+
+  return "";
+}
+
+export function getSidFromSearch(search: string): string {
+  const params = new URLSearchParams(search || "");
+  return params.get("sid") || "";
+}
+
+export function removeSidFromSearch(search: string): string {
+  const params = new URLSearchParams(search || "");
+  params.delete("sid");
+  const next = params.toString();
+  return next ? `?${next}` : "";
+}
+
+export function removeSidFromPath(path: string): string {
+  try {
+    const url = new URL(
+      path,
+      typeof window === "undefined" ? "https://octo.local" : window.location.origin
+    );
+    url.searchParams.delete("sid");
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return path;
+  }
+}
+
+export function setSessionSid(sid: string | null | undefined): string {
+  const nextSid = sid || "";
+  memorySid = nextSid;
+  const store = safeSessionStorage();
+  if (store) {
+    if (nextSid) {
+      store.setItem(SESSION_SID_KEY, nextSid);
+    } else {
+      store.removeItem(SESSION_SID_KEY);
+    }
+  }
+  return nextSid;
+}
+
+export function ensureSessionSid(): string {
+  const urlSid = typeof window === "undefined" ? "" : getSidFromSearch(window.location.search);
+  if (urlSid) return setSessionSid(urlSid);
+
+  const store = safeSessionStorage();
+  const storedSid = store?.getItem(SESSION_SID_KEY) || memorySid;
+  if (storedSid) return setSessionSid(storedSid);
+
+  const reusableSid = findReusableStoredSessionSid(safeLocalStorage());
+  if (reusableSid) return setSessionSid(reusableSid);
+
+  return setSessionSid(randomSid());
+}
+
+export function getSessionSid(): string {
+  return ensureSessionSid();
+}
+
+export function stripSessionSidFromUrl(): boolean {
+  if (typeof window === "undefined") return false;
+  const search = window.location.search || "";
+  if (!getSidFromSearch(search)) return false;
+
+  const nextUrl = window.location.pathname + removeSidFromSearch(search) + window.location.hash;
+  window.history.replaceState(window.history.state, document.title, nextUrl);
+  return true;
+}

--- a/packages/dmworkbase/src/Service/__tests__/RoutePath.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/RoutePath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRoutePath } from "../RoutePath";
+
+describe("normalizeRoutePath", () => {
+  it("keeps the root route as root", () => {
+    expect(normalizeRoutePath("/")).toBe("/");
+    expect(normalizeRoutePath("")).toBe("/");
+    expect(normalizeRoutePath(undefined)).toBe("/");
+  });
+
+  it("removes trailing slashes from non-root routes", () => {
+    expect(normalizeRoutePath("/appbot/")).toBe("/appbot");
+    expect(normalizeRoutePath("/appbot///")).toBe("/appbot");
+  });
+
+  it("adds the leading slash when callers pass a bare route", () => {
+    expect(normalizeRoutePath("appbot")).toBe("/appbot");
+  });
+
+  it("drops query and hash fragments before matching route handlers", () => {
+    expect(normalizeRoutePath("/appbot/?sid=abc")).toBe("/appbot");
+    expect(normalizeRoutePath("/appbot#section")).toBe("/appbot");
+  });
+});

--- a/packages/dmworkbase/src/Service/__tests__/SessionScope.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SessionScope.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureSessionSid,
+  findReusableStoredSessionSid,
+  getSidFromSearch,
+  removeSidFromPath,
+  removeSidFromSearch,
+  setSessionSid,
+  stripSessionSidFromUrl,
+} from "../SessionScope";
+
+describe("SessionScope", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    setSessionSid("");
+    vi.restoreAllMocks();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("extracts sid from query strings", () => {
+    expect(getSidFromSearch("?sid=abc")).toBe("abc");
+    expect(getSidFromSearch("?doc=d1&sid=abc")).toBe("abc");
+    expect(getSidFromSearch("?doc=d1")).toBe("");
+  });
+
+  it("removes only sid from query strings", () => {
+    expect(removeSidFromSearch("?sid=abc")).toBe("");
+    expect(removeSidFromSearch("?doc=d1&sid=abc&space=s1")).toBe("?doc=d1&space=s1");
+  });
+
+  it("absorbs a URL sid into sessionStorage and keeps using it after the URL is clean", () => {
+    window.history.replaceState({}, "", "/appbot?sid=abc");
+
+    expect(ensureSessionSid()).toBe("abc");
+    expect(stripSessionSidFromUrl()).toBe(true);
+    expect(window.location.pathname + window.location.search).toBe("/appbot");
+    expect(ensureSessionSid()).toBe("abc");
+  });
+
+  it("creates a per-tab sid when neither URL nor sessionStorage has one", () => {
+    const sid = ensureSessionSid();
+
+    expect(sid).toMatch(/^[a-z0-9]{1,6}$/);
+    expect(ensureSessionSid()).toBe(sid);
+  });
+
+  it("reuses one stored login bucket for clean links opened in a new tab", () => {
+    localStorage.setItem("tokenabc", "token-value");
+    localStorage.setItem("uidabc", "u1");
+
+    expect(ensureSessionSid()).toBe("abc");
+  });
+
+  it("reuses same-identity buckets but refuses ambiguous different identities", () => {
+    localStorage.setItem("tokenabc", "token-a");
+    localStorage.setItem("uidabc", "u1");
+    localStorage.setItem("tokendef", "token-b");
+    localStorage.setItem("uiddef", "u1");
+
+    expect(findReusableStoredSessionSid(localStorage)).toBe("abc");
+
+    localStorage.setItem("uiddef", "u2");
+    expect(findReusableStoredSessionSid(localStorage)).toBe("");
+  });
+
+  it("removes sid from relative return paths while preserving other query params", () => {
+    expect(removeSidFromPath("/d/d_abc?sid=fresh6&sp=space-1")).toBe("/d/d_abc?sp=space-1");
+    expect(removeSidFromPath("/s/TN_1?sp=space-1&sid=fresh6#x")).toBe("/s/TN_1?sp=space-1#x");
+  });
+});

--- a/packages/dmworkbase/src/Utils/search.ts
+++ b/packages/dmworkbase/src/Utils/search.ts
@@ -1,4 +1,4 @@
-
+import { getSessionSid } from "../Service/SessionScope";
 
 export function getQueryParam(key: string) {
   const params = new URLSearchParams(window.location.search);
@@ -6,10 +6,5 @@ export function getQueryParam(key: string) {
 }
 
 export function getSid() {
-  let sid = getQueryParam("sid");
-  if (!sid || sid === "") {
-   // 如果为空 则随机生成一个6位数的字符串
-   sid = Math.random().toString(36).slice(-6);
-  }
-  return sid;
+  return getSessionSid();
 }

--- a/packages/dmworkbase/src/__tests__/App.logoutRoute.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.logoutRoute.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const packageRoot = path.resolve(__dirname, "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(packageRoot, relativePath), "utf-8");
+}
+
+describe("WKApp logout route reset", () => {
+  it("does not reload the pre-logout business route", () => {
+    const source = readRepoFile("src/App.tsx");
+    const logoutStart = source.indexOf("  logout() {");
+    const logoutEnd = source.indexOf("  async logoutUserInitiated()", logoutStart);
+    const logoutSource = source.slice(logoutStart, logoutEnd);
+
+    expect(logoutSource).toContain('window.location.replace("/login")');
+    expect(source).toContain('setSessionSid("")');
+    expect(logoutSource).not.toContain("window.location.reload()");
+  });
+});
+
+describe("RouteManager browser history handling", () => {
+  it("renders browser history events without pushing a new history entry", () => {
+    const source = readRepoFile("src/Service/Route.tsx");
+    const popStart = source.indexOf("  private handlePopState");
+    const constructorStart = source.indexOf("  private constructor()", popStart);
+    const historyHandlersSource = source.slice(popStart, constructorStart);
+    const renderStart = source.indexOf("  renderCurrentPath(");
+    const pushStart = source.indexOf("  push(", renderStart);
+    const renderSource = source.slice(renderStart, pushStart);
+
+    expect(historyHandlersSource).toContain("renderCurrentPath(window.location.pathname)");
+    expect(historyHandlersSource).not.toContain(".push(window.location.pathname)");
+    expect(renderSource).toContain("WKApp.shared.restContent(component)");
+    expect(renderSource).not.toContain("window.history.pushState");
+  });
+});

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -12,6 +12,8 @@ export * from './Service/apiFetch'
 export { default as Provider } from './Service/Provider'
 export * from './Service/Provider'
 export * from './Service/Route'
+export * from './Service/SessionScope'
+export * from './Service/RoutePath'
 export * from './Service/DataSource/DataProvider'
 export { default as ChatPage } from "./Pages/Chat"
 export * from './Components/ChannelSetting/context'

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -66,8 +66,7 @@ function deriveCreateState(info: BindInfoResp): CreateState {
 interface BindPageProps {
   // 由 BindModule.init() 在 RouteManager 的 pageshow handler 冲掉 URL 之前
   // 抓到的 location.search 快照. 不直接读 window.location.search 是因为
-  // RouteManager 会在 pageshow 时 push 一个带 sid= 的 URL, 把 bind 入口参数
-  // 全部丢掉.
+  // RouteManager 曾在 pageshow 时改写 URL, 可能把 bind 入口参数全部丢掉.
   initialSearch: string
 }
 

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -3,9 +3,9 @@ import { WKApp, IModule } from '@octo/base'
 import BindPage from './BindPage'
 
 // 在 module init 时 (startup 同步阶段, 早于 RouteManager 的 pageshow handler)
-// 抓住 location.search 快照. RouteManager 的 pageshow 监听器会 push 一个带
-// sid= 的新 URL, 把 bind 入口参数 (token / authcode / return_to / provider)
-// 一起冲掉; BindPage 再去读 window.location.search 就拿不到了.
+// 抓住 location.search 快照。RouteManager / 宿主路由后续可能把地址归一到
+// pathname，导致 bind 入口参数 (token / authcode / return_to / provider) 从
+// live URL 消失；BindPage 再去读 window.location.search 就拿不到了。
 //
 // 这个 snapshot 在 BindModule.init() 调用瞬间 capture, 然后通过 prop 注入,
 // 比 useEffect 里读 window.location.search 更早, 也更确定.
@@ -27,11 +27,10 @@ export default class BindModule implements IModule {
     if (typeof window !== 'undefined' && window.location.pathname === '/oidc/bind') {
       bindInitialSearch = window.location.search
       // Scrub the live URL *synchronously* here, before RouteManager's
-      // pageshow handler runs window.history.pushState to add the sid URL on
-      // top. If we wait for BindPage's useEffect, the current entry is
-      // already the sid URL (see Route.tsx push()), and replaceState there
-      // leaves the original `?token=...` entry behind in the Back stack —
-      // pressing Back exposes the bind token via address bar / referrer.
+      // pageshow handler has a chance to normalize or push another route entry.
+      // If we wait for BindPage's useEffect, replaceState there can leave the
+      // original `?token=...` entry behind in the Back stack — pressing Back
+      // exposes the bind token via address bar / referrer.
       // The snapshot above keeps the params available to BindPage via prop,
       // so wiping window.location.search is safe.
       try {

--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -171,8 +171,8 @@ export const DOC_TARGET_STORAGE_KEY = 'octo.docs.target'
  *
  * A forwarded-doc link is `${origin}/docs?...&doc=<docId>`, but the octo host's self-built
  * RouteManager (dmworkbase Service/Route.tsx) handles `pageshow`/`popstate` by re-pushing
- * `window.location.pathname` ONLY — it drops the query and re-stamps the URL to `/docs?sid=…`,
- * wiping `?doc=` before the docs module mounts. The recipient's mirror is empty (they never
+ * `window.location.pathname` ONLY — it drops the query and can wipe `?doc=` before the docs
+ * module mounts. The recipient's mirror is empty (they never
  * opened the doc), so resolveDocTarget fell through to the empty document list — the XIN-328
  * symptom (link opens the list, not the document).
  *

--- a/packages/docs/src/module.test.tsx
+++ b/packages/docs/src/module.test.tsx
@@ -191,9 +191,9 @@ describe('DocsModule (octo-web same-origin integration)', () => {
 
   it('captures a /docs?doc=<id> deep-link into sessionStorage on init() so it survives the host query-wipe (XIN-328)', () => {
     // A forwarded-doc link is `${origin}/docs?...&doc=<docId>`, but the host RouteManager's
-    // pageshow/popstate handler re-pushes pathname-only and re-stamps the URL to `/docs?sid=…`,
-    // wiping `?doc=` before the code-split DocsHome mounts. init() must stash the target BEFORE
-    // that re-push (same window as normalizeInviteDeepLink) so resolveDocTarget's persisted-target
+    // pageshow/popstate handler can normalize the URL to pathname-only, wiping `?doc=` before
+    // the code-split DocsHome mounts. init() must stash the target BEFORE that normalization
+    // (same window as normalizeInviteDeepLink) so resolveDocTarget's persisted-target
     // fallback opens the document instead of the empty list.
     window.history.replaceState(null, '', '/docs?space=s_1&folder=f_1&doc=d_forwarded')
     try {

--- a/packages/docs/src/module.tsx
+++ b/packages/docs/src/module.tsx
@@ -267,8 +267,8 @@ export class DocsModule implements IModule {
 
     // Secondary/redundant `/docs?doc=<id>` capture. The PRIMARY, real-device-verified capture is
     // the inline <script> at the top of apps/web/index.html, which runs during HTML parse — before
-    // this module chunk loads and before the host's pageshow re-push wipes the query to
-    // `/docs?sid=…`. XIN-332 proved this init() runs AFTER that re-push on device, so we no longer
+    // this module chunk loads and before the host's pageshow route normalization can wipe the
+    // query. XIN-332 proved this init() runs AFTER that normalization on device, so we no longer
     // rely on it; it stays as an idempotent same-origin fallback (and covers the standalone dev
     // bootstrap in main.tsx). See captureDocTargetDeepLink in config.ts.
     captureDocTargetDeepLink()

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -161,8 +161,8 @@ describe('resolveDocTarget', () => {
   it('captures a forwarded /docs?doc= link at boot so a first-time recipient opens the doc, not the empty list (XIN-328)', () => {
     // End-to-end regression for the forward defect: unlike the "second blocker" test above,
     // the RECIPIENT has never opened this doc, so nothing is pre-persisted. The code-split
-    // DocsHome only mounts AFTER the host's pageshow re-push has already collapsed the URL to
-    // `/docs?sid=…`, so resolveDocTarget at mount time sees no `?doc=` and — without the boot
+    // DocsHome only mounts AFTER the host's pageshow route normalization has already removed
+    // the query, so resolveDocTarget at mount time sees no `?doc=` and — without the boot
     // capture — would return null → empty document list (the reported symptom).
     //
     // captureDocTargetDeepLink() runs at DocsModule.init() (app boot, BEFORE the re-push) and
@@ -170,7 +170,7 @@ describe('resolveDocTarget', () => {
     // the doc from that mirror even though the query is already wiped.
     window.location.search = '?space=sp9&folder=fd9&doc=d_forwarded'
     captureDocTargetDeepLink()
-    // Host RouteManager re-pushes pathname-only → URL collapses to /docs?sid=… (no doc).
+    // Host RouteManager re-pushes pathname-only → URL no longer carries doc addressing.
     window.location.search = '?sid=abc123'
     const opened = resolveDocTarget(window.location.search)
     expect(opened).toEqual({
@@ -391,11 +391,10 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
-  it('XIN-513/519: the standalone link opens with `?sp` (doc space) but no `?sid`, even when the in-shell URL carries a sid', async () => {
+  it('XIN-513/519: the standalone link opens with `?sp` (doc space) but no `?sid`, even when the shell has a session sid', async () => {
     const openSpy = vi.fn()
     Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
-    // In-shell URL carries the active session's sid (the host's RouteManager re-push collapses the
-    // docs route to `/docs?sid=…`). The opened standalone link must NOT copy that sid forward: an
+    // The shell has an active session sid. The opened standalone link must NOT copy that sid forward: an
     // already-logged-in user's session is recovered from storage independently of the URL (XIN-513),
     // so a sid-less `/d/:docId` opens the document directly. It MUST, however, carry `?sp` (the doc's
     // real space) so the recipient's standalone preflight can address the doc's own space — dropping

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -49,8 +49,8 @@ const IMPORT_ENABLED = true
  *
  * Why this exists: the octo host's self-built RouteManager (dmworkbase Service/Route.tsx)
  * handles `pageshow`/`popstate` by re-pushing `window.location.pathname` ONLY — it drops the
- * query string. So immediately after we navigate to `/docs?…&doc=<id>` the host re-pushes
- * `/docs` and the browser URL collapses to `/docs?sid=…`, wiping `?doc=`. That re-push fires
+ * query string. So immediately after we navigate to `/docs?…&doc=<id>` the host can normalize
+ * the browser URL back to the route pathname, wiping `?doc=`. That re-push fires
  * repeatedly, each time re-rendering DocsHome with an empty query. We cannot patch the host
  * (shared infra), so we mirror the target here: a deep-link or an in-app open writes it, and
  * resolveDocTarget falls back to it whenever the query no longer carries a doc. It is cleared
@@ -142,7 +142,7 @@ export function resolveDocTarget(search: string, uid?: string): DocTarget | null
   }
 
   // 1. Deep-link via query. Persist it so the editor stays addressable after the host's
-  //    pathname-only re-push wipes `?doc=` (the second-blocker root cause). Addressing stays a
+  //    pathname-only route normalization wipes `?doc=` (the second-blocker root cause). Addressing stays a
   //    single `?doc=` param (three-party-fixed), so the kind is resolved from the local board
   //    registry rather than a separate query param.
   if (queryDoc) {


### PR DESCRIPTION
## Summary
- move sid handling out of visible route URLs into a tab-scoped session helper
- normalize host route paths and keep main menu state in sync with browser history
- keep standalone/external routes such as space management out of the host app router
- update docs, invite, login bind, and loop route comments/tests for the clean URL behavior

## Risk Areas
- host route navigation, browser Back/Forward, and direct route refreshes
- login/logout and sid-scoped storage recovery
- standalone docs and invite landing redirects
- external same-origin routes such as /space

## Verification
- pnpm --dir apps/web exec vitest run src/__tests__/externalStandaloneRoutes.test.ts src/__tests__/mainMenuReconcile.test.tsx src/__tests__/inviteLandingRedirectPath.test.ts src/__tests__/layoutStandaloneDocPath.test.ts src/__tests__/docsDeepLinkCapture.test.ts
- pnpm --dir packages/dmworkbase exec vitest run src/Service/__tests__/RoutePath.test.ts src/Service/__tests__/SessionScope.test.ts src/__tests__/App.logoutRoute.test.ts
- pnpm --dir packages/dmworklogin exec vitest run src/oidc/__tests__/url.test.ts src/oidc/bind/__tests__/url.test.ts src/__tests__/login_vm_oidc.test.ts
- pnpm --dir packages/docs exec vitest run src/module.test.tsx src/pages/DocsHome.test.tsx
- pnpm --dir apps/web build
- git diff --check
- manual smoke: direct /appbot opens the app page without sid in the URL; returning to / keeps sid out of the URL