### PR TITLE
fix(docs): include friend-added agents in doc-authorize candidate roster

### DIFF
--- a/packages/docs/src/members/MemberPicker.test.tsx
+++ b/packages/docs/src/members/MemberPicker.test.tsx
@@ -89,3 +89,45 @@ describe('MemberPicker (Problem 1)', () => {
     expect(addBtn.disabled).toBe(true)
   })
 })
+
+// #839: the candidate roster merges the caller's friend-added agents (GET /robot/my_bots) with
+// the space members, so an agent owned by someone else but befriended by the caller — which the
+// space-member query filters out — becomes selectable, while non-friend agents never appear.
+describe('MemberPicker friend-agent roster (#839)', () => {
+  it('merges friend agents from my_bots and dedups by uid', async () => {
+    // my_bots returns a friend agent owned by someone else (not in spaceMembers) plus a duplicate
+    // of an existing space bot (u_bot) that must NOT render twice.
+    wk.apiClient.responder = (_m, url) =>
+      url.startsWith('/robot/my_bots')
+        ? {
+            data: [
+              { uid: 'u_friendbot', name: 'Friend Bot' },
+              { uid: 'u_bot', name: 'Helper Bot (dup)' },
+            ],
+            status: 200,
+          }
+        : { data: {}, status: 200 }
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Friend Bot')).toBeTruthy())
+    // The space-member entry wins on the uid collision (its name, rendered once).
+    expect(screen.getAllByText('Helper Bot')).toHaveLength(1)
+    expect(screen.queryByText('Helper Bot (dup)')).toBeNull()
+    // The friend agent carries the AI badge (one for u_bot, one for u_friendbot).
+    expect(screen.getAllByText('docs.member.aiTag')).toHaveLength(2)
+    // It is selectable and adds by its uid.
+    const addBtn = screen.getByText('docs.member.add').closest('button') as HTMLButtonElement
+    fireEvent.click(screen.getByText('Friend Bot'))
+    expect(addBtn.disabled).toBe(false)
+  })
+
+  it('renders the space roster unchanged when my_bots fails', async () => {
+    wk.apiClient.responder = (_m, url) => {
+      if (url.startsWith('/robot/my_bots')) throw new Error('boom')
+      return { data: {}, status: 200 }
+    }
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Grace Hopper')).toBeTruthy())
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy()
+    expect(screen.getByText('Helper Bot')).toBeTruthy()
+  })
+})

--- a/packages/docs/src/members/MemberPicker.tsx
+++ b/packages/docs/src/members/MemberPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Role } from '../auth/roles.ts'
-import { fetchAllSpaceMembers, t, type SpaceMemberLite } from '../octoweb/index.ts'
+import { fetchAllSpaceMembers, fetchMyBots, t, type SpaceMemberLite } from '../octoweb/index.ts'
 import { colorFromId } from '../awareness/presence.ts'
 import { sortPickerMembers } from './sort.ts'
 
@@ -10,6 +10,27 @@ const ROLES: Role[] = ['reader', 'writer', 'admin']
 function initial(name: string): string {
   const ch = name.trim().charAt(0)
   return ch ? ch.toUpperCase() : '?'
+}
+
+/**
+ * Candidate roster = space members (fetchAllSpaceMembers) ∪ the caller's friend-added agents
+ * (fetchMyBots), de-duplicated by uid (octo-web #839). The space-member entry wins on a uid
+ * collision because it carries the richer host data (avatar / robot flag); a friend agent not
+ * already in the space roster is appended, flagged isBot. `my_bots` is a pure friend-dimension
+ * query, so this never surfaces a non-friend agent owned by others — the picker still cannot
+ * offer, and the admin cannot authorize, an agent the user has not befriended and did not create.
+ *
+ * A my_bots failure resolves to [] so it can never break the human-member roster path.
+ */
+async function fetchCandidateRoster(space: string): Promise<SpaceMemberLite[]> {
+  const [members, myBots] = await Promise.all([
+    fetchAllSpaceMembers(space),
+    space ? fetchMyBots(space).catch(() => [] as SpaceMemberLite[]) : Promise.resolve([]),
+  ])
+  const byUid = new Map<string, SpaceMemberLite>()
+  for (const m of members) byUid.set(m.uid, m)
+  for (const b of myBots) if (!byUid.has(b.uid)) byUid.set(b.uid, b)
+  return [...byUid.values()]
 }
 
 /**
@@ -46,7 +67,7 @@ export function MemberPicker({
   useEffect(() => {
     let active = true
     setLoading(true)
-    void fetchAllSpaceMembers(space ?? '')
+    void fetchCandidateRoster(space ?? '')
       .then((list) => {
         if (active) setMembers(list)
       })

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -211,6 +211,44 @@ export async function fetchSpaceBotNames(spaceId: string): Promise<SpaceMemberLi
     .map((b) => ({ uid: b.uid, name: b.name || b.uid }))
 }
 
+/** Minimal view of a `/robot/my_bots` entry the docs seam reads (uid + display name). */
+interface HostMyBot {
+  uid: string
+  name?: string
+}
+
+/**
+ * Fetch the current user's friend-added agents via `GET /robot/my_bots` (octo-server
+ * modules/robot/api.go myBots) and map them to the lite member shape, flagged `isBot`.
+ *
+ * WHY: the doc-authorize candidate roster is sourced from `queryMembers`
+ * (GET /space/{id}/members), whose WHERE clause drops bots the caller did NOT create
+ * (`r.robot_id IS NULL OR r.creator_uid = loginUID`, octo-web #839). So an agent owned by
+ * someone else but added as a friend by the current user never reaches the picker and can
+ * never be authorized, even though the doc write path (PUT /docs/:docId/members) accepts any
+ * uid. `my_bots` is a pure friend-dimension query (`FROM friend WHERE f.uid = loginUID`), so
+ * it returns exactly the caller's friend-added agents and NEVER a non-friend agent owned by
+ * others — merging it into the roster satisfies the security boundary by construction.
+ *
+ * `spaceId`, when supplied, scopes the result to friend agents that are also members of that
+ * space (the backend's optional `space_id` filter), keeping the candidate list relevant to the
+ * doc's space; omit it to list all friend agents.
+ *
+ * Returns `{ uid, name, isBot: true }` triples (name falls back to the uid so an agent with no
+ * display name is never blank). Resolves to an EMPTY list on a non-array body; callers wrap the
+ * call in `.catch(() => [])` so a my_bots failure never breaks the human-member roster path.
+ */
+export async function fetchMyBots(spaceId?: string): Promise<SpaceMemberLite[]> {
+  const path = spaceId
+    ? `/robot/my_bots?space_id=${encodeURIComponent(spaceId)}`
+    : '/robot/my_bots'
+  const { data } = await apiClient().get<HostMyBot[]>(path)
+  const bots = Array.isArray(data) ? data : []
+  return bots
+    .filter((b): b is HostMyBot => !!b && !!b.uid)
+    .map((b) => ({ uid: b.uid, name: b.name || b.uid, isBot: true }))
+}
+
 /**
  * Re-wrap the REAL host APIClient so its responses look axios-style to docs callers.
  *

--- a/packages/docs/src/octoweb/spaceMembers.test.ts
+++ b/packages/docs/src/octoweb/spaceMembers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { setWKApp, getSpaceMembers, fetchAllSpaceMembers, fetchSpaceBotNames } from './index.ts'
+import { setWKApp, getSpaceMembers, fetchAllSpaceMembers, fetchSpaceBotNames, fetchMyBots } from './index.ts'
 import { createMockWKApp } from './mock.ts'
 
 // Seam spike acceptance (#7): prove the docs package can reach the host's space-member source
@@ -101,5 +101,50 @@ describe('octoweb fetchSpaceBotNames seam', () => {
   it('returns an empty list for a blank space id without touching the host', async () => {
     expect(await fetchSpaceBotNames('')).toEqual([])
     expect(wk.apiClient.calls).toHaveLength(0)
+  })
+})
+
+// #839: friend-added agents (including ones owned by others) reach the doc-authorize roster via
+// GET /robot/my_bots, a pure friend-dimension query that never surfaces non-friend agents.
+describe('octoweb fetchMyBots seam', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  it('maps friend agents to {uid, name, isBot} and scopes the request to the space', async () => {
+    wk.apiClient.responder = (_m, url) =>
+      url.startsWith('/robot/my_bots')
+        ? { data: [{ uid: 'bot_friend', name: "Someone's Bot" }, { uid: 'bot_mine', name: 'My Bot' }], status: 200 }
+        : { data: {}, status: 200 }
+    const bots = await fetchMyBots('s_1')
+    expect(bots).toEqual([
+      { uid: 'bot_friend', name: "Someone's Bot", isBot: true },
+      { uid: 'bot_mine', name: 'My Bot', isBot: true },
+    ])
+    const calls = wk.apiClient.calls.filter((c) => c.url.startsWith('/robot/my_bots'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('/robot/my_bots?space_id=s_1')
+  })
+
+  it('omits the space_id param when no space is given', async () => {
+    wk.apiClient.responder = () => ({ data: [], status: 200 })
+    await fetchMyBots()
+    expect(wk.apiClient.calls[0].url).toBe('/robot/my_bots')
+  })
+
+  it('falls back to the uid for an agent with no name and skips entries without a uid', async () => {
+    wk.apiClient.responder = () => ({
+      data: [{ uid: 'bot1', name: '' }, { name: 'ghost' }],
+      status: 200,
+    })
+    expect(await fetchMyBots('s_1')).toEqual([{ uid: 'bot1', name: 'bot1', isBot: true }])
+  })
+
+  it('returns an empty list for a non-array body', async () => {
+    wk.apiClient.responder = () => ({ data: { nope: true }, status: 200 })
+    expect(await fetchMyBots('s_1')).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Closes #839

The document share/authorize member picker sourced its candidate list only from `GET /space/{id}/members` (`queryMembers`), whose `WHERE` clause filters out bots the caller did not create (`r.robot_id IS NULL OR r.creator_uid = loginUID`). As a result, an agent **owned by someone else but added as a friend** by the current user never appeared in the picker and could not be authorized — even though the write path (`PUT /docs/:docId/members`) already accepts any uid.

## Change (frontend only)

- New seam helper `fetchMyBots(spaceId?)` in `packages/docs/src/octoweb/index.ts` calls `GET /robot/my_bots` and maps the result to `{ uid, name, isBot: true }`. When a `spaceId` is passed it scopes the result to friend agents that are also members of that space.
- `MemberPicker` now builds its roster as **space members ∪ the caller's friend-added agents**, de-duplicated by uid. The space-member entry wins on a uid collision (richer host data: avatar / robot flag); a friend agent not already in the space roster is appended, flagged as a bot.
- A `my_bots` failure resolves to an empty list, so it can never break the existing human-member roster path.

## Security boundary

`my_bots` is a pure friend-dimension query (`FROM friend WHERE f.uid = loginUID`), so it only ever returns the caller's own friend edges. Non-friend agents owned by others are **never** surfaced as candidates and cannot be authorized — the isolation requirement holds by construction, with no backend change.

The backend `queryMembers` isolation boundary is left untouched.

### Known limitation (accepted, per #839)

`my_bots` has no `creator_uid` branch, so a self-created agent is covered only via the best-effort "creator→bot friend edge" invariant. Three edge cases can still miss a self-created agent (failed friend-edge creation, later un-friend, disabled bot). These are accepted for this iteration; a future backend hardening could union `creator_uid`.

## Testing

- Added seam tests (`spaceMembers.test.ts`) for `fetchMyBots`: `{uid,name,isBot}` mapping, `space_id` scoping, uid fallback, non-array body.
- Added `MemberPicker` tests: friend agent owned by another appears as a selectable candidate, uid de-duplication (no double render, space entry wins), AI badge, and roster-unchanged-on-my_bots-failure.
- `packages/docs` targeted tests green; production build of `@octo/web` succeeds.

> Draft: opened for review only. Not to be marked ready here — promotion to a regular PR happens after review + deploy verification in a real environment.
