### PR TITLE
feat(loop): workspace webhooks, project emoji picker, and UI polish

### DIFF
--- a/packages/dmloop/package.json
+++ b/packages/dmloop/package.json
@@ -7,6 +7,7 @@
     "@octo/base": "workspace:*",
     "@douyinfe/semi-icons": "^2.93.0",
     "@douyinfe/semi-ui": "^2.93.0",
+    "@emoji-mart/data": "^1.2.1",
     "@tiptap/core": "3.22.2",
     "@tiptap/extension-mention": "^3.22.2",
     "@tiptap/extension-placeholder": "^3.22.4",
@@ -15,6 +16,7 @@
     "@tiptap/starter-kit": "^3.22.2",
     "@tiptap/suggestion": "^3.22.2",
     "axios": "^1.18.1",
+    "emoji-mart": "^5.6.0",
     "lucide-react": "^0.577.0",
     "react-markdown": "8",
     "remark-gfm": "3"

--- a/packages/dmloop/src/api/webhookApi.ts
+++ b/packages/dmloop/src/api/webhookApi.ts
@@ -2,7 +2,8 @@
 import type { WebhookSubscription, CreateWebhookReq, UpdateWebhookReq } from "./types";
 import { httpGet, httpPost, httpPatch, httpDelete } from "./http";
 
-export async function listWebhooks(projectId: string): Promise<WebhookSubscription[]> {
+// projectId 省略 = workspace 级：后端对无 project_id 过滤只返回 project_id IS NULL 的订阅。
+export async function listWebhooks(projectId?: string): Promise<WebhookSubscription[]> {
   const data = await httpGet<{ subscriptions: WebhookSubscription[] }>(
     "/webhook-subscriptions",
     { project_id: projectId },

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -642,6 +642,7 @@
   "settings": {
     "general": "General",
     "members": "Members",
+    "webhooks": "Webhook",
     "noWorkspace": "Select or create a workspace first",
     "wsName": "Workspace name",
     "wsSlug": "Workspace slug",

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -416,7 +416,8 @@
     "lead": "Lead",
     "descPlaceholder": "Add a description...",
     "namePlaceholder": "Project name, e.g. Growth experiments",
-    "descHint": "Provided to agents as project context and applied to every task in this project."
+    "descHint": "Provided to agents as project context and applied to every task in this project.",
+    "changeIcon": "Change icon"
   },
   "webhook": {
     "title": "Webhooks",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -642,6 +642,7 @@
   "settings": {
     "general": "通用",
     "members": "成员管理",
+    "webhooks": "Webhook",
     "noWorkspace": "请先选择或创建工作区",
     "wsName": "工作区名称",
     "wsSlug": "工作区 slug",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -416,7 +416,8 @@
     "lead": "负责人",
     "descPlaceholder": "添加描述...",
     "namePlaceholder": "项目名称，例如 增长实验",
-    "descHint": "会作为项目上下文提供给智能体，应用于该项目下的每个任务。"
+    "descHint": "会作为项目上下文提供给智能体，应用于该项目下的每个任务。",
+    "changeIcon": "更换图标"
   },
   "webhook": {
     "title": "Webhook",

--- a/packages/dmloop/src/pages/AutomationPage.tsx
+++ b/packages/dmloop/src/pages/AutomationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Typography, Button, Spin, Toast, Switch, Avatar, Dropdown } from "@douyinfe/semi-ui";
+import { Button, Spin, Toast, Switch, Avatar, Dropdown } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import { Zap, Plus, MoreHorizontal, Play, Trash2 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -16,7 +16,6 @@ import { formatNextRunAt } from "../ui/autopilotSchedule";
 import CreateAutomationModal from "../ui/CreateAutomationModal";
 import AutopilotDetailPage from "../panel/AutopilotDetailPage";
 
-const { Text } = Typography;
 
 export default function AutomationPage() {
   const { t } = useI18n();
@@ -118,7 +117,6 @@ export default function AutomationPage() {
     <div className="loop-page">
       <div className="loop-page__head">
         <h2 className="loop-page__title">{t("loop.nav.automation")}</h2>
-        <Text type="tertiary" style={{ fontSize: 13 }}>{rows.length}</Text>
         <div className="loop-page__spacer" />
         <LoopButton icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>{t("loop.automation.create")}</LoopButton>
       </div>

--- a/packages/dmloop/src/pages/ProjectPage.tsx
+++ b/packages/dmloop/src/pages/ProjectPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Typography, Input, Button, Spin, Modal, Toast } from "@douyinfe/semi-ui";
+import { Input, Button, Spin, Modal, Toast } from "@douyinfe/semi-ui";
 import { Search, Plus, Trash2, Briefcase, List, LayoutGrid, ListChecks } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { Project, UpsertProjectReq } from "../api/types";
@@ -14,7 +14,6 @@ import { formatRelativeTime } from "../ui/time";
 import { readView, writeView } from "../ui/viewMode";
 import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
 
-const { Text } = Typography;
 
 type ViewMode = "list" | "card";
 const VIEW_KEY = "loop.project.viewMode";
@@ -197,7 +196,6 @@ export default function ProjectPage() {
     <div className="loop-page">
       <div className="loop-page__head">
         <h2 className="loop-page__title">{t("loop.nav.project")}</h2>
-        <Text type="tertiary" style={{ fontSize: 13 }}>{rows.length}</Text>
         <div className="loop-page__spacer" />
         <LoopButton icon={<Plus size={14} />} onClick={() => setCreateOpen(true)}>{t("loop.action.newProject")}</LoopButton>
       </div>

--- a/packages/dmloop/src/pages/ProjectPage.tsx
+++ b/packages/dmloop/src/pages/ProjectPage.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Input, Button, Spin, Modal, Toast } from "@douyinfe/semi-ui";
+import { Input, Button, Spin, Modal, Toast, Popover } from "@douyinfe/semi-ui";
 import { Search, Plus, Trash2, Briefcase, List, LayoutGrid, ListChecks } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { Project, UpsertProjectReq } from "../api/types";
 import { listProjects, createProject, updateProject, deleteProject } from "../api/projectApi";
 import ProjectDetailPage from "../panel/ProjectDetailPage";
 import LoopButton from "../ui/LoopButton";
+import EmojiPicker from "../ui/EmojiPicker";
 import ProjectStatusBadge from "../ui/ProjectStatusBadge";
 import ProjectPriorityBadge from "../ui/ProjectPriorityBadge";
 import AssigneePicker from "../ui/AssigneePicker";
@@ -52,6 +53,8 @@ export default function ProjectPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [nTitle, setNTitle] = useState("");
   const [nDesc, setNDesc] = useState("");
+  // 当前打开 emoji 选择器的项目 id（列表/卡片共用一个，打开新的会关掉旧的）。
+  const [iconPickerFor, setIconPickerFor] = useState<string | null>(null);
 
   const reload = useCallback(() => {
     setLoading(true);
@@ -110,6 +113,37 @@ export default function ProjectPage() {
     }
   };
 
+  // 项目图标：点击 emoji 唤起选择器，选中即存（PUT 全量，复用 patchProject 回传其它字段）。
+  // stopPropagation 阻止冒泡到行的 openDetail；trigger="custom" + onClickOutSide 完全受控。
+  const renderIcon = (p: Project, className: string) => (
+    <Popover
+      trigger="custom"
+      visible={iconPickerFor === p.id}
+      onClickOutSide={() => setIconPickerFor(null)}
+      position="bottomLeft"
+      content={
+        iconPickerFor === p.id ? (
+          // React 事件按组件树冒泡：Popover 内容虽 portal 到 body，click 仍会冒泡到行的 onClick(openDetail)。
+          // 在内容容器 stopPropagation，避免选 emoji 时误入详情页。
+          <div className="loop-emoji-pop" onClick={(e) => e.stopPropagation()}>
+            <EmojiPicker
+              onSelect={(emoji) => { setIconPickerFor(null); patchProject(p, { icon: emoji }); }}
+            />
+          </div>
+        ) : null
+      }
+    >
+      <span
+        className={`${className} loop-project-icon--btn`}
+        role="button"
+        aria-label={t("loop.project.changeIcon")}
+        onClick={(e) => { e.stopPropagation(); setIconPickerFor((cur) => (cur === p.id ? null : p.id)); }}
+      >
+        {p.icon || "📁"}
+      </span>
+    </Popover>
+  );
+
   const renderList = () => (
     <div className="loop-project-list" role="table">
       <div className="loop-ptable__head" role="row">
@@ -124,7 +158,7 @@ export default function ProjectPage() {
       {filtered.map((p) => (
         <div key={p.id} className="loop-project-list__row" role="row" onClick={() => openDetail(p.id)}>
           <div className="loop-project-list__namecell">
-            <span className="loop-project-list__icon">{p.icon || "📁"}</span>
+            {renderIcon(p, "loop-project-list__icon")}
             <span className="loop-project-list__name">{p.title}</span>
           </div>
           <div className="loop-project-list__cell" onClick={(e) => e.stopPropagation()}>
@@ -169,7 +203,7 @@ export default function ProjectPage() {
           <Ring done={p.done_count} total={p.issue_count} />
           <div className="loop-project-card__body">
             <div className="loop-project-card__title">
-              <span>{p.icon || "📁"}</span>
+              {renderIcon(p, "loop-project-card__icon")}
               <strong>{p.title}</strong>
             </div>
             <div className="loop-project-card__sub">

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Typography, Spin, Banner, Button, Toast } from "@douyinfe/semi-ui";
+import { Typography, Spin, Banner, Toast } from "@douyinfe/semi-ui";
 import { Check, Circle, Copy, Cpu, Monitor, Plus } from "lucide-react";
 import { copyToClipboard, useI18n, WKModal } from "@octo/base";
 import type { RuntimeDevice, RuntimeMode } from "../api/types";
@@ -210,9 +210,9 @@ export default function RuntimePage() {
         title={t("loop.runtime.addComputerTitle")}
         size="lg"
         footer={(
-          <Button theme="borderless" type="tertiary" onClick={closeAddDialog}>
+          <LoopButton variant="secondary" onClick={closeAddDialog}>
             {t("loop.action.cancel")}
-          </Button>
+          </LoopButton>
         )}
       >
         <div className="loop-runtime-add">

--- a/packages/dmloop/src/pages/SettingsPage.tsx
+++ b/packages/dmloop/src/pages/SettingsPage.tsx
@@ -13,6 +13,8 @@ import {
 import { invalidateDirectory } from "../api/directory";
 import LoopTag from "../ui/LoopTag";
 import LoopButton from "../ui/LoopButton";
+import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
+import WebhooksSection from "../panel/WebhooksSection";
 
 const { Text } = Typography;
 const ROLES = ["admin", "member"];
@@ -48,6 +50,9 @@ export default function SettingsPage({
           </TabPane>
           <TabPane tab={t("loop.settings.members")} itemKey="members">
             <MembersTab workspaceId={workspace.id} />
+          </TabPane>
+          <TabPane tab={t("loop.settings.webhooks")} itemKey="webhooks">
+            <WebhooksTab />
           </TabPane>
         </Tabs>
       </div>
@@ -100,6 +105,16 @@ function GeneralTab({ workspace, onUpdated }: { workspace: Workspace; onUpdated?
       <div className="loop-fields__row">
         <LoopButton icon={<Save size={14} />} loading={saving} onClick={save}>{t("loop.action.save")}</LoopButton>
       </div>
+    </div>
+  );
+}
+
+/* ---------- Webhook（workspace 级） ---------- */
+function WebhooksTab() {
+  const isAdmin = useIsWorkspaceAdmin();
+  return (
+    <div className="loop-fields" style={{ maxWidth: 560, paddingTop: 12 }}>
+      <WebhooksSection isAdmin={isAdmin} />
     </div>
   );
 }

--- a/packages/dmloop/src/pages/SkillPage.tsx
+++ b/packages/dmloop/src/pages/SkillPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Typography, Input, Button, Spin, Modal, Toast, Banner,
+  Typography, Input, Spin, Modal, Toast, Banner,
   Select, Checkbox, Tooltip, Popover,
 } from "@douyinfe/semi-ui";
 import { Search, Plus, Trash2, Sparkles, Download, FileText, Link2, Copy, Clock3, Users } from "lucide-react";
@@ -249,10 +249,9 @@ export default function SkillPage() {
                     <div className="loop-skill-list__meta">
                       {renderUsedBy(row.id)}
                       <span className="loop-skill-list__time"><Clock3 size={13} />{formatRelativeTime(row.updated_at ?? row.created_at, format)}</span>
-                      <Button
-                        theme="borderless"
-                        type="danger"
-                        size="small"
+                      <LoopButton
+                        variant="danger"
+                        size="sm"
                         icon={<Trash2 size={14} />}
                         className="loop-skill-list__delete"
                         onClick={(e) => {
@@ -343,7 +342,7 @@ export default function SkillPage() {
                     <Select value={rtId} onChange={(v) => setRtId(v as string)} dropdownClassName="loop-fields__dropdown" style={{ flex: 1 }} placeholder={t("loop.agent.runtime")}>
                       {runtimes.map((r) => <Select.Option key={r.id} value={r.id}>{r.name}（{r.provider}）</Select.Option>)}
                     </Select>
-                    <Button loading={rtBusy} onClick={loadRuntimeSkills}>{t("loop.skill.fetch")}</Button>
+                    <LoopButton variant="secondary" loading={rtBusy} onClick={loadRuntimeSkills}>{t("loop.skill.fetch")}</LoopButton>
                   </div>
                   {rtErr && <Banner type="warning" description={rtErr} closeIcon={null} />}
                   {rtBusy && rtSkills.length === 0 && !rtErr && <div className="loop-nsk__rtloading"><Spin /></div>}
@@ -415,7 +414,7 @@ export default function SkillPage() {
 
           {/* 底部操作 */}
           <div className="loop-nsk__footer">
-            <Button onClick={() => setCreateOpen(false)}>{t("loop.action.cancel")}</Button>
+            <LoopButton variant="secondary" onClick={() => setCreateOpen(false)}>{t("loop.action.cancel")}</LoopButton>
             {createTab === "local" && (
               <LoopButton icon={<Plus size={14} />} disabled={!nName.trim()} onClick={createLocal}>{t("loop.action.create")}</LoopButton>
             )}

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -1688,6 +1688,26 @@
   font-size: 15px;
   line-height: 1;
 }
+/* 卡片图标与列表图标同尺寸 */
+.loop-project-card__icon {
+  flex: none;
+  font-size: 15px;
+  line-height: 1;
+}
+/* 可点击的项目图标：hover 出浅灰底提示可改，位移用负 margin 抵消 padding 不撑行 */
+.loop-project-icon--btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: -3px;
+  padding: 3px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+.loop-project-icon--btn:hover { background: var(--semi-color-fill-1, #f0f1f4); }
+/* emoji-mart picker 容器：去掉行高留白，让弹层贴合 */
+.loop-emoji-pop { line-height: 0; }
 .loop-project-list__name {
   min-width: 0;
   overflow: hidden;

--- a/packages/dmloop/src/panel/AgentDetailPage.tsx
+++ b/packages/dmloop/src/panel/AgentDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Typography, Button, Spin, Toast, Tooltip } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import { ChevronRight, Archive, Save, Eraser, Plus, Trash2, FileText, Pencil, Eye } from "lucide-react";
@@ -233,6 +233,13 @@ export default function AgentDetailPage({
     return cols;
   }, [contribs]);
 
+  // 贡献日历默认滚到最右（最新）：小屏放不下会横向溢出，用户只关心最近，故进页面对齐最新一列。
+  const calRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = calRef.current;
+    if (el) el.scrollLeft = el.scrollWidth;
+  }, [weeks, tab]);
+
   // ---- 履历标题/跳转：按 issue_id 二次拉取 issue（标题取 issue.title） ----
   useEffect(() => {
     const ids = Array.from(new Set(stats.recent.map((r) => r.issue_id).filter(Boolean)));
@@ -313,7 +320,7 @@ export default function AgentDetailPage({
                     {t("loop.agent.successAvg", { values: { pct: stats.successPct, avg: formatDurationMs(stats.avgMs) } })}
                   </div>
                 </div>
-                <div className="loop-adp__cal">
+                <div className="loop-adp__cal" ref={calRef}>
                   {weeks.map((w, wi) => (
                     <div key={wi} className="loop-adp__cal-col">
                       {w.map((d) => (

--- a/packages/dmloop/src/panel/ModelPicker.tsx
+++ b/packages/dmloop/src/panel/ModelPicker.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Dropdown, Input, Toast } from "@douyinfe/semi-ui";
 import { Plus } from "lucide-react";
 import { useI18n } from "@octo/base";
+import EllipsisText from "../ui/EllipsisText";
 
 /**
  * Agent 详情页模型选择（对齐 multica 的 model-picker 体验）：
@@ -26,7 +27,7 @@ export default function ModelPicker({
 
   // 非 owner 只读：静态展示当前模型或「默认」，无弹框。
   if (!canEdit) {
-    return <span className="loop-adp__ro loop-mono-text">{value || t("loop.agent.modelDefault")}</span>;
+    return <EllipsisText className="loop-adp__ro loop-mono-text" text={value || t("loop.agent.modelDefault")} />;
   }
 
   const commit = async (next: string) => {
@@ -89,7 +90,7 @@ export default function ModelPicker({
       render={menu}
     >
       <button type="button" className="loop-adp__edit" aria-label={t("loop.agent.model")}>
-        <span className="loop-adp__edit-val loop-mono-text">{value || t("loop.agent.modelDefault")}</span>
+        <EllipsisText className="loop-adp__edit-val loop-mono-text" text={value || t("loop.agent.modelDefault")} />
       </button>
     </Dropdown>
   );

--- a/packages/dmloop/src/panel/ProjectDetailPage.tsx
+++ b/packages/dmloop/src/panel/ProjectDetailPage.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Save, Trash2 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import type { Project } from "../api/types";
 import { getProject, updateProject, deleteProject } from "../api/projectApi";
-import ProjectWebhooksSection from "./ProjectWebhooksSection";
+import WebhooksSection from "./WebhooksSection";
 import { useIsWorkspaceAdmin } from "../ui/useWorkspaceAdmin";
 import "./sideDetail.css";
 
@@ -93,7 +93,7 @@ export default function ProjectDetailPage({ projectId, onChanged }: { projectId:
             </div>
             <div className="loop-fields__row">
               <div className="loop-fields__label">{t("loop.webhook.title")}</div>
-              <ProjectWebhooksSection projectId={row.id} isAdmin={isAdmin} />
+              <WebhooksSection projectId={row.id} isAdmin={isAdmin} />
             </div>
           </div>
         </section>

--- a/packages/dmloop/src/panel/RuntimePicker.tsx
+++ b/packages/dmloop/src/panel/RuntimePicker.tsx
@@ -4,6 +4,7 @@ import { Cloud, Monitor, Lock, Check } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { RuntimeDevice } from "../api/types";
 import { ProviderLogo } from "../ui/providerLogo";
+import EllipsisText from "../ui/EllipsisText";
 
 type Filter = "mine" | "all";
 
@@ -97,7 +98,7 @@ export default function RuntimePicker({
     return (
       <span className="loop-adp__rt-ro">
         <TriggerIcon size={13} className="loop-adp__rt-ico" />
-        <span className="loop-adp__edit-val loop-mono-text">{selected?.name ?? "—"}</span>
+        <EllipsisText className="loop-adp__edit-val loop-mono-text" text={selected?.name ?? "—"} />
         {selected && dot(selected.status === "online")}
       </span>
     );
@@ -173,7 +174,7 @@ export default function RuntimePicker({
     <Dropdown trigger="click" position="bottomRight" visible={open} onVisibleChange={setOpen} render={menu}>
       <button type="button" className="loop-adp__edit loop-adp__rt-trigger" aria-label={t("loop.agent.runtime")}>
         <TriggerIcon size={13} className="loop-adp__rt-ico" />
-        <span className="loop-adp__edit-val loop-mono-text">{selected?.name ?? "—"}</span>
+        <EllipsisText className="loop-adp__edit-val loop-mono-text" text={selected?.name ?? "—"} />
         {selected && dot(selected.status === "online")}
       </button>
     </Dropdown>

--- a/packages/dmloop/src/panel/SkillDetailPage.tsx
+++ b/packages/dmloop/src/panel/SkillDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Typography, Input, Button, Spin, Toast, Banner, Tooltip } from "@douyinfe/semi-ui";
+import { Typography, Input, Spin, Toast, Banner, Tooltip } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import { ArrowLeft, BookOpen, Clock3, ExternalLink, Save, Trash2, Plus, Users } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
@@ -180,7 +180,7 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
   if (loading) return <div className="loop-sd"><div className="loop-sd__center"><Spin /></div></div>;
   if (error || !row) return (
     <div className="loop-sd">
-      <div className="loop-sd__topbar"><Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>{t("loop.detail.back")}</Button></div>
+      <div className="loop-sd__topbar"><LoopButton variant="ghost" icon={<ArrowLeft size={16} />} onClick={back}>{t("loop.detail.back")}</LoopButton></div>
       <div className="loop-sd__center">{error ? <Banner type="danger" description={error} /> : <Text type="tertiary">{t("loop.detail.notFound")}</Text>}</div>
     </div>
   );
@@ -190,10 +190,10 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
   return (
     <div className="loop-sd">
       <div className="loop-sd__topbar">
-        <Button icon={<ArrowLeft size={16} />} theme="borderless" onClick={back}>{t("loop.detail.back")}</Button>
+        <LoopButton variant="ghost" icon={<ArrowLeft size={16} />} onClick={back}>{t("loop.detail.back")}</LoopButton>
         <Text type="tertiary" style={{ fontSize: 12 }}>{t("loop.detail.skillTitle")}</Text>
         <div style={{ flex: 1 }} />
-        <Button theme="borderless" type="danger" icon={<Trash2 size={14} />} onClick={remove}>{t("loop.action.delete")}</Button>
+        <LoopButton variant="danger" icon={<Trash2 size={14} />} onClick={remove}>{t("loop.action.delete")}</LoopButton>
         <LoopButton icon={<Save size={14} />} disabled={!dirty} onClick={save}>{t("loop.action.save")}</LoopButton>
       </div>
 
@@ -246,7 +246,7 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
             <div className="loop-skill-files__head">
               <span className="loop-skill-files__label">{t("loop.skill.detail.files")}（{filePaths.length}）</span>
               <Tooltip content={t("loop.skill.detail.addFile.add")}>
-                <Button theme="borderless" size="small" icon={<Plus size={14} />} onClick={() => setAddingFile(true)} />
+                <LoopButton variant="ghost" size="sm" icon={<Plus size={14} />} onClick={() => setAddingFile(true)} />
               </Tooltip>
             </div>
             {addingFile && (
@@ -262,7 +262,7 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
                 {addError && <div className="loop-skill-files__adderr">{addError}</div>}
                 <div className="loop-skill-files__addbtns">
                   <LoopButton size="sm" onClick={submitNewFile}>{t("loop.skill.detail.addFile.add")}</LoopButton>
-                  <Button size="small" theme="borderless" onClick={cancelNewFile}>{t("loop.action.cancel")}</Button>
+                  <LoopButton variant="ghost" size="sm" onClick={cancelNewFile}>{t("loop.action.cancel")}</LoopButton>
                 </div>
               </div>
             )}
@@ -276,9 +276,9 @@ export default function SkillDetailPage({ skillId, onChanged }: { skillId: strin
             </div>
             {selectedPath !== SKILL_MD && (
               <div className="loop-skill-files__foot">
-                <Button theme="borderless" type="danger" size="small" icon={<Trash2 size={13} />} onClick={deleteSelectedFile}>
+                <LoopButton variant="danger" size="sm" icon={<Trash2 size={13} />} onClick={deleteSelectedFile}>
                   {t("loop.skill.detail.deleteFile")}
-                </Button>
+                </LoopButton>
               </div>
             )}
           </section>

--- a/packages/dmloop/src/panel/WebhooksSection.tsx
+++ b/packages/dmloop/src/panel/WebhooksSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Button, Input, Switch, Spin, Toast, Modal, Typography } from "@douyinfe/semi-ui";
+import { Input, Switch, Spin, Toast, Modal, Typography } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
 import { Plus, Trash2, Copy } from "lucide-react";
 import { useI18n } from "@octo/base";
@@ -9,9 +9,10 @@ import { confirmDelete } from "../ui/confirmDelete";
 
 const { Text } = Typography;
 
-/** 项目 Webhook 配置分区：列表 + 启用开关 + 删除 + 新增（创建后一次性展示 secret）。
+/** Webhook 配置分区：列表 + 启用开关 + 删除 + 新增（创建后一次性展示 secret）。
+ *  projectId 省略 = workspace 级；给了 = 项目级。二者交互一致，仅作用域不同。
  *  Webhook 端点限 owner/admin，故非管理员只展示占位、不发任何请求。 */
-export default function ProjectWebhooksSection({ projectId, isAdmin }: { projectId: string; isAdmin?: boolean }) {
+export default function WebhooksSection({ projectId, isAdmin }: { projectId?: string; isAdmin?: boolean }) {
   const { t } = useI18n();
   const [rows, setRows] = useState<WebhookSubscription[]>([]);
   const [loading, setLoading] = useState(true);
@@ -33,7 +34,7 @@ export default function ProjectWebhooksSection({ projectId, isAdmin }: { project
     if (!value) { Toast.warning(t("loop.webhook.urlRequired")); return; }
     setBusy(true);
     try {
-      const created = await createWebhook({ url: value, project_id: projectId });
+      const created = await createWebhook({ url: value, ...(projectId ? { project_id: projectId } : {}) });
       setUrl("");
       Toast.success(t("loop.webhook.created"));
       if (created.secret) setSecret(created.secret);
@@ -101,10 +102,9 @@ export default function ProjectWebhooksSection({ projectId, isAdmin }: { project
               onChange={(v) => toggle(row, v)}
               aria-label={t("loop.webhook.enabled")}
             />
-            <Button
-              theme="borderless"
-              type="danger"
-              size="small"
+            <LoopButton
+              variant="danger"
+              size="sm"
               icon={<Trash2 size={14} />}
               aria-label={t("loop.webhook.delete")}
               onClick={() =>
@@ -149,7 +149,7 @@ export default function ProjectWebhooksSection({ projectId, isAdmin }: { project
         </Text>
         <div className="loop-wh__secret">
           <code>{secret}</code>
-          <Button icon={<Copy size={14} />} onClick={copySecret}>{t("loop.webhook.copy")}</Button>
+          <LoopButton variant="secondary" size="sm" icon={<Copy size={14} />} onClick={copySecret}>{t("loop.webhook.copy")}</LoopButton>
         </div>
       </Modal>
     </div>

--- a/packages/dmloop/src/panel/agentDetail.css
+++ b/packages/dmloop/src/panel/agentDetail.css
@@ -134,7 +134,11 @@
   overflow-x: auto;
   padding-bottom: 2px;
   flex: 0 1 auto;
+  /* 小屏放不下时仍可横向滚动，但隐藏丑陋的滚动条（默认滚到最右=最新，见 AgentDetailPage） */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
+.loop-adp__cal::-webkit-scrollbar { display: none; }
 .loop-adp__cal-col { display: flex; flex-direction: column; gap: 3px; flex: 0 0 auto; }
 .loop-adp__cal-cell {
   width: 12px;
@@ -441,7 +445,7 @@
 
 .loop-adp__props {
   display: grid;
-  grid-template-columns: 72px 1fr;
+  grid-template-columns: 72px minmax(0, 1fr);
   gap: 0 8px;
   align-items: baseline;
   margin: 0;
@@ -481,6 +485,15 @@
 }
 .loop-adp__edit:hover { background: var(--semi-color-fill-0, #f5f6f8); }
 .loop-adp__edit-val { min-width: 0; word-break: break-word; }
+/* 单行省略工具类（配合 EllipsisText：仅截断时 hover title 全名）。定义在 __edit-val 之后以覆盖其 word-break。 */
+.loop-ellipsis-1 {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 .loop-adp__edit--empty .loop-adp__edit-val { font-style: italic; color: var(--semi-color-text-3, #b8bcc8); }
 .loop-adp__edit-ico {
   flex: 0 0 auto;

--- a/packages/dmloop/src/ui/EllipsisText.tsx
+++ b/packages/dmloop/src/ui/EllipsisText.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * 单行省略文本：仅当文本被真正截断时，hover 显示原生 title 全名；完整显示则不挂 title。
+ * 用原生 title（而非 Semi Tooltip）：Tooltip 会 cloneElement 抢 child ref，和溢出测量的 ref 冲突，
+ * 会导致测量失效/条件包裹抖动；原生 title 无结构变化、ResizeObserver 常驻，窄宽下也稳定。
+ */
+export default function EllipsisText({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = ref.current;
+    if (el) setTruncated(el.scrollWidth > el.clientWidth + 1);
+  }, []);
+
+  useEffect(() => {
+    measure();
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return undefined;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [text, measure]);
+
+  return (
+    <span
+      ref={ref}
+      className={`loop-ellipsis-1${className ? ` ${className}` : ""}`}
+      title={truncated ? text : undefined}
+    >
+      {text}
+    </span>
+  );
+}

--- a/packages/dmloop/src/ui/EmojiPicker.tsx
+++ b/packages/dmloop/src/ui/EmojiPicker.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+import { useI18n } from "@octo/base";
+
+/**
+ * Emoji 选择器：包装开源 emoji-mart 的 vanilla Picker（set:"native"，纯系统字形、不下载图片、不碰 CDN）。
+ * emoji-mart 与其数据都用动态 import 加载——Vite 会切成独立 chunk（~80KB gzip 数据 + ~33KB 库），
+ * 首屏不加载，点开选择器时才拉本地 chunk。界面语言跟随 octo 的 useI18n().locale（zh 传中文 i18n，
+ * 否则 emoji-mart 默认英文）；搜索关键词是 emoji-mart 自带的英文，故中文下可正常选、但需用英文词搜。
+ */
+export default function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {
+  const { locale } = useI18n();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+
+  useEffect(() => {
+    let cancelled = false;
+    const container = containerRef.current;
+    (async () => {
+      const [emojiMart, dataMod, i18nMod] = await Promise.all([
+        import("emoji-mart"),
+        import("@emoji-mart/data"),
+        locale.startsWith("zh")
+          ? import("@emoji-mart/data/i18n/zh.json")
+          : Promise.resolve(null),
+      ]);
+      if (cancelled || !container) return;
+      const { Picker } = emojiMart as unknown as { Picker: new (opts: unknown) => Node };
+      const picker = new Picker({
+        data: (dataMod as { default: unknown }).default,
+        i18n: i18nMod ? (i18nMod as { default: unknown }).default : undefined,
+        onEmojiSelect: (e: { native: string }) => onSelectRef.current(e.native),
+        theme: "auto",
+        set: "native",
+        previewPosition: "none",
+        skinTonePosition: "search",
+        maxFrequentRows: 2,
+      });
+      container.appendChild(picker);
+    })();
+    return () => {
+      cancelled = true;
+      container?.replaceChildren();
+    };
+  }, [locale]);
+
+  return <div ref={containerRef} />;
+}

--- a/packages/dmloop/src/ui/LoopButton.tsx
+++ b/packages/dmloop/src/ui/LoopButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Loader2 } from "lucide-react";
 
-type LoopButtonVariant = "primary" | "secondary" | "ghost";
+type LoopButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 type LoopButtonSize = "sm" | "md";
 
 export interface LoopButtonProps

--- a/packages/dmloop/src/ui/loopControls.css
+++ b/packages/dmloop/src/ui/loopControls.css
@@ -369,6 +369,14 @@
   color: var(--semi-color-text-0, #1c1f23);
 }
 
+/* danger：无边框红字（删除/破坏性内联操作），hover 叠浅红底、色相锁死只加深 */
+.loop-btn--danger { background: transparent; color: var(--semi-color-danger, #d0453e); }
+.loop-btn--danger:hover:not(:disabled) {
+  background: var(--semi-color-danger-light-default, #fdeceb);
+  color: var(--semi-color-danger-hover, #b83a34);
+}
+.loop-btn--danger:active:not(:disabled) { color: var(--semi-color-danger-active, #a1322d); }
+
 .loop-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .loop-btn__spin { animation: loop-btn-spin 0.7s linear infinite; }

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Cpu, Loader2, Sparkles } from "lucide-react";
 import { currentWorkspaceId, resolveWorkspaceSelection, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
 import { useI18n, WKApp } from "@octo/base";
 import "@octo/loop/src/pages/loop.css";
+import "@octo/loop/src/ui/loopControls.css";
 import "./personal.css";
 
 type PersonalTabKey = "runtime" | "skill";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@douyinfe/semi-ui':
         specifier: ^2.93.0
         version: 2.93.0(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@octo/base':
         specifier: workspace:*
         version: link:../dmworkbase
@@ -372,6 +375,9 @@ importers:
       axios:
         specifier: ^1.18.1
         version: 1.18.1
+      emoji-mart:
+        specifier: ^5.6.0
+        version: 5.6.0
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@17.0.2)
@@ -1955,6 +1961,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -6103,6 +6112,9 @@ packages:
     resolution: {integrity: sha512-x57bdCaDvgnlc41VOm/UWihJCCiI3OxJKiBgB/e5F7Zd6avo+61mO6IzQS7Bu/k/a1KPjou25EUORR6UPKznBQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
+
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -12314,6 +12326,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emoji-mart/data@1.2.1': {}
+
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
@@ -17182,6 +17196,8 @@ snapshots:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  emoji-mart@5.6.0: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
Closes #847

## Goal
Improve the loop workspace UI: add workspace-level webhooks, make the Personal module visually consistent with the loop design system, fix agent-detail overflow/scroll rough edges, and let users set a project icon emoji from the list.

## Changes
**Workspace webhooks**
- New "Webhook" tab in workspace settings (next to member management), owner/admin-gated.
- `listWebhooks(projectId?)` omits `project_id` for workspace scope; project webhook panel generalized into a scope-agnostic `WebhooksSection`.
- Added a `danger` variant to `LoopButton`.

**dmpersonal loop consistency**
- Load `loopControls.css` in the Personal module so Semi Select/Input/Modal pick up the loop skin (root cause of the "Semi-flavored" look).
- Convert remaining raw Semi buttons on Personal-visible pages (Runtime, Skill, Skill detail) to `LoopButton`.

**Agent detail**
- New `EllipsisText` helper: runtime/model values show the full name via native `title` only when actually truncated; properties grid track uses `minmax(0, 1fr)` so ellipsis engages.
- Contribution calendar: hide the scrollbar (still scrollable) and default-scroll to the latest week.

**Project pages**
- Remove the item-count badges from the Project and Automation page titles.
- Project list/card icon is now a clickable emoji picker (emoji-mart, native set, dynamic import so it is code-split, no CDN); UI language follows the app locale; selecting saves inline and does not navigate into the detail page.

## Verification
- `tsc --noEmit` clean for the changed files in `packages/dmloop` and `packages/dmpersonal` (only a pre-existing unrelated `matchAll` lib-target warning remains).
- Manual: workspace webhook add/delete/toggle; Personal Runtime/Skill dropdowns, modals and buttons render in loop style; agent-detail runtime/model tooltip appears only when clipped; contribution calendar has no scrollbar and opens at the latest week; project icon emoji picker opens on the list, follows zh/en, saves inline without opening the detail page.