### PR TITLE
feat(summary): add unread and invitation attention indicators

### DIFF
--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -291,6 +291,13 @@ export async function getSummaryDetail(taskId: number | string): Promise<Summary
     return get(`/summaries/${encodeURIComponent(String(taskId))}`);
 }
 
+export async function markSummaryRead(
+    taskId: number,
+    cursors: { team_result_id?: number; personal_version_id?: number },
+): Promise<{ is_unread: boolean; has_pending_invitation: boolean; needs_attention: boolean }> {
+    return post(`/summaries/${taskId}/read`, cursors);
+}
+
 export async function deleteSummary(taskId: number): Promise<void> {
     return del(`/summaries/${taskId}`);
 }

--- a/packages/dmworksummary/src/components/SummaryCard.test.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.test.tsx
@@ -65,6 +65,22 @@ function makeItem(overrides: Record<string, unknown> = {}) {
 
 const noop = () => {};
 
+describe('SummaryCard attention dot', () => {
+    it('needs_attention=true 时显示关注红点', () => {
+        const { container } = render(
+            <SummaryCard task={makeItem({ needs_attention: true }) as any} onClick={noop} onDelete={noop} />,
+        );
+        expect(container.querySelector('.summary-card-attention-dot')).not.toBeNull();
+    });
+
+    it('无需关注时不显示红点', () => {
+        const { container } = render(
+            <SummaryCard task={makeItem({ needs_attention: false }) as any} onClick={noop} onDelete={noop} />,
+        );
+        expect(container.querySelector('.summary-card-attention-dot')).toBeNull();
+    });
+});
+
 describe('SummaryCard isScheduledTask', () => {
     it('schedule_id > 0 时使用定时删除确认文案', () => {
         render(

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -37,6 +37,7 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, onClick, onDelete, onRe
 
     return (
         <div className="summary-card" onClick={() => onClick(task.task_id)}>
+            {task.needs_attention && <span className="summary-card-attention-dot" aria-label={t("summary.list.needsAttention")} />}
             <div className="summary-card-header">
                 <OverflowTooltip className="summary-card-title" title={task.title || task.task_no}>
                     {task.title || task.task_no}

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -122,6 +122,7 @@
     "title": "AI Summary"
   },
   "list": {
+    "needsAttention": "Needs attention",
     "title": "AI Summary",
     "allStatus": "All statuses",
     "createTooltip": "New summary",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -122,6 +122,7 @@
     "title": "智能总结"
   },
   "list": {
+    "needsAttention": "需要关注",
     "title": "智能总结",
     "allStatus": "全部状态",
     "createTooltip": "新建总结",

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -132,6 +132,7 @@
 
 /* ========== Summary Card ========== */
 .summary-card {
+    position: relative;
     border: 1px solid var(--semi-color-border);
     border-radius: 12px;
     padding: 18px;
@@ -139,6 +140,20 @@
     transition: all 0.2s;
     background: transparent;
     box-shadow: none;
+}
+
+.summary-card-attention-dot {
+    position: absolute;
+    top: var(--wk-sp-2);
+    right: var(--wk-sp-2);
+    width: var(--wk-sp-2);
+    height: var(--wk-sp-2);
+    border-radius: 50%;
+    background: var(--semi-color-danger);
+}
+
+.summary-card .summary-card-header {
+    padding-right: var(--wk-sp-3);
 }
 
 .summary-card:hover {

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -7,7 +7,7 @@ import SummaryCreatePage from "./pages/SummaryCreatePage";
 import SummaryDetailPage from "./pages/SummaryDetailPage";
 import SummaryConfirmPage from "./pages/SummaryConfirmPage";
 import ScheduleListPage from "./pages/ScheduleListPage";
-import { getChatCandidates } from "./api/summaryApi";
+import { getChatCandidates, listSummaries } from "./api/summaryApi";
 import { notifyChatSummaryCreated } from "./utils/chatSummaryActions";
 import { isSupportedChannelType } from "./utils/channelType";
 import ChatSummaryStarButton from "./components/ChatSummaryStarButton";
@@ -18,6 +18,46 @@ import zhCN from "./i18n/zh-CN.json";
 import "./index.css";
 
 let _spaceChangedHandler: (() => void) | null = null;
+let _attentionRefreshTimer: ReturnType<typeof setInterval> | null = null;
+let _attentionFocusHandler: (() => void) | null = null;
+let _attentionRefreshRequestHandler: (() => void) | null = null;
+let _attentionBootstrapTimer: ReturnType<typeof setTimeout> | null = null;
+let _attentionRequest: Promise<boolean> | null = null;
+
+async function refreshSummaryAttentionCount(): Promise<boolean> {
+    if (!WKApp.loginInfo.isLogined() || !WKApp.shared.currentSpaceId) return false;
+    if (_attentionRequest) return _attentionRequest;
+    _attentionRequest = (async () => {
+      try {
+        const response = await listSummaries({ page: 1, page_size: 1 });
+        WKApp.mittBus.emit("summary-badge-update" as any, {
+            count: response.attention_count ?? 0,
+        });
+        WKApp.mittBus.emit("summary-attention-count-refreshed" as any, {
+            count: response.attention_count ?? 0,
+        });
+        return true;
+      } catch {
+        // Navigation badge is best-effort and must not block application startup.
+        return false;
+      } finally {
+        _attentionRequest = null;
+      }
+    })();
+    return _attentionRequest;
+}
+
+function bootstrapSummaryAttentionCount(attempt = 0) {
+    void refreshSummaryAttentionCount().then((loaded) => {
+        if (loaded || attempt >= 50) return;
+        // Module initialization can precede login/Space restoration on a cold
+        // page load. Retry quickly until both are ready instead of waiting for
+        // the five-second background poll.
+        _attentionBootstrapTimer = setTimeout(() => {
+            bootstrapSummaryAttentionCount(attempt + 1);
+        }, 100);
+    });
+}
 
 /**
  * NavRail 顶层菜单图标（智能总结）。与 dmworktodo / dmworkappbot 的菜单图标同构：
@@ -107,8 +147,23 @@ export class SummaryModule implements IModule {
 
         _spaceChangedHandler = () => {
             WKApp.mittBus.emit('summary-space-changed');
+            void refreshSummaryAttentionCount();
         };
         WKApp.mittBus.on('space-changed', _spaceChangedHandler);
+
+        // SummaryListPage is mounted only after the menu is opened. Keep the
+        // global navigation badge fresh independently so invitations are
+        // visible before the invitee enters Smart Summary.
+        bootstrapSummaryAttentionCount();
+        _attentionRefreshTimer = setInterval(() => {
+            if (document.visibilityState === "visible") {
+                void refreshSummaryAttentionCount();
+            }
+        }, 5000);
+        _attentionFocusHandler = () => void refreshSummaryAttentionCount();
+        window.addEventListener("focus", _attentionFocusHandler);
+        _attentionRefreshRequestHandler = () => void refreshSummaryAttentionCount();
+        WKApp.mittBus.on("summary-attention-refresh-requested" as any, _attentionRefreshRequestHandler);
 
         WKApp.searchChatCandidates = async (params) => {
             return getChatCandidates(params);
@@ -145,6 +200,22 @@ if (import.meta.hot) {
         if (_spaceChangedHandler) {
             WKApp.mittBus.off('space-changed', _spaceChangedHandler);
             _spaceChangedHandler = null;
+        }
+        if (_attentionRefreshTimer) {
+            clearInterval(_attentionRefreshTimer);
+            _attentionRefreshTimer = null;
+        }
+        if (_attentionFocusHandler) {
+            window.removeEventListener("focus", _attentionFocusHandler);
+            _attentionFocusHandler = null;
+        }
+        if (_attentionRefreshRequestHandler) {
+            WKApp.mittBus.off("summary-attention-refresh-requested" as any, _attentionRefreshRequestHandler);
+            _attentionRefreshRequestHandler = null;
+        }
+        if (_attentionBootstrapTimer) {
+            clearTimeout(_attentionBootstrapTimer);
+            _attentionBootstrapTimer = null;
         }
         _globalSummaryModalRoot?.unmount();
         _globalSummaryModalRoot = null;

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -491,8 +491,16 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             if (detail.status === TaskStatus.COMPLETED && detail.result_id) {
                 const markRead = api.markSummaryRead;
                 if (markRead) void markRead(detail.task_id, { team_result_id: detail.result_id }).then((attention) => {
-                    if (this.taskId === requestTaskId && !attention.needs_attention) {
-                        window.dispatchEvent(new CustomEvent("summary-read", { detail: { taskId: detail.task_id } }));
+                    // Guard with the request sequence/lookup key rather than
+                    // comparing numeric detail.task_id with a task_no deep-link.
+                    if (this.scheduleLoadSeq === seq && this.detailLookupId === requestTaskId) {
+                        window.dispatchEvent(new CustomEvent("summary-read", {
+                            detail: {
+                                taskId: detail.task_id,
+                                isUnread: attention.is_unread,
+                                needsAttention: attention.needs_attention,
+                            },
+                        }));
                     }
                 }).catch(() => { /* keep unread on failure */ });
             }
@@ -608,11 +616,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             if (result.current_version_id && result.content?.trim()) {
                 const markRead = api.markSummaryRead;
                 if (markRead) void markRead(requestTaskId, { personal_version_id: result.current_version_id }).then((attention) => {
-                    if (this.taskId === requestTaskId && !attention.needs_attention) {
-                        const numericTaskId = this.state.detail?.task_id;
-                        if (numericTaskId) {
-                            window.dispatchEvent(new CustomEvent("summary-read", { detail: { taskId: numericTaskId } }));
-                        }
+                    if (this.scheduleLoadSeq === reqSeq && (this.taskId == null || this.taskId === requestTaskId)) {
+                        window.dispatchEvent(new CustomEvent("summary-read", {
+                            detail: {
+                                taskId: requestTaskId,
+                                isUnread: attention.is_unread,
+                                needsAttention: attention.needs_attention,
+                            },
+                        }));
                     }
                 }).catch(() => { /* keep unread on failure */ });
             }

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -488,6 +488,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 lastKnownStatus: detail.status,
                 workflowGateContent: false,
             });
+            if (detail.status === TaskStatus.COMPLETED && detail.result_id) {
+                const markRead = api.markSummaryRead;
+                if (markRead) void markRead(detail.task_id, { team_result_id: detail.result_id }).then((attention) => {
+                    if (this.taskId === requestTaskId && !attention.needs_attention) {
+                        window.dispatchEvent(new CustomEvent("summary-read", { detail: { taskId: detail.task_id } }));
+                    }
+                }).catch(() => { /* keep unread on failure */ });
+            }
             if (detail.status === TaskStatus.COMPLETED && detail.result) {
                 this.loadVersions(detail.task_id);
             }
@@ -597,6 +605,17 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 });
             }
             this.startPersonalPoll(result.worker_status);
+            if (result.current_version_id && result.content?.trim()) {
+                const markRead = api.markSummaryRead;
+                if (markRead) void markRead(requestTaskId, { personal_version_id: result.current_version_id }).then((attention) => {
+                    if (this.taskId === requestTaskId && !attention.needs_attention) {
+                        const numericTaskId = this.state.detail?.task_id;
+                        if (numericTaskId) {
+                            window.dispatchEvent(new CustomEvent("summary-read", { detail: { taskId: numericTaskId } }));
+                        }
+                    }
+                }).catch(() => { /* keep unread on failure */ });
+            }
             if (result.content?.trim()) {
                 this.loadPersonalVersions(requestTaskId);
             } else if (this.taskId == null || this.taskId === requestTaskId) {
@@ -3109,6 +3128,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             // 迟到（已切 task）：不回显新 task（confirmingSchedule 由 finally 复位）。
             if (this.taskId !== requestTaskId) return;
             Toast.success(t("summary.detail.scheduleConfirmed"));
+            WKApp.mittBus.emit("summary-attention-refresh-requested" as any);
             // 复用现有加载路径刷新（不新增任何出站推送）：重拉 schedule 让按钮消失。
             this.loadSchedule(scheduleItem.schedule_id);
         } catch (err: any) {

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -62,10 +62,32 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
     private searchTimer: ReturnType<typeof setTimeout> | null = null;
     private batchPollTimer: ReturnType<typeof setInterval> | null = null;
     private isBatchPolling = false;
+    private attentionCount = 0;
+    private attentionRefreshLoading = false;
 
     private handleSpaceChanged_ = () => this.loadData();
 
     private handleTaskRegenerated_ = () => this.loadData();
+
+    private handleAttentionCountRefreshed_ = ({ count }: { count: number }) => {
+        const nextCount = count ?? 0;
+        if (nextCount === this.attentionCount || this.attentionRefreshLoading) return;
+        this.attentionRefreshLoading = true;
+        void this.loadData().finally(() => {
+            this.attentionRefreshLoading = false;
+        });
+    };
+
+    private handleSummaryRead_ = (event: Event) => {
+        const taskId = (event as CustomEvent<{ taskId: number }>).detail?.taskId;
+        if (!taskId) return;
+        this.setState(({ items }) => ({
+            items: items.map(item => item.task_id === taskId
+                ? { ...item, is_unread: false, needs_attention: Boolean(item.has_pending_invitation) }
+                : item),
+        }));
+        this.emitBadgeUpdate();
+    };
 
     private handleNavMenuActivated_ = ({ menuId }: { menuId: string }) => {
         if (menuId === "summary") {
@@ -77,7 +99,9 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
         this.loadData();
         WKApp.mittBus.on("summary-space-changed", this.handleSpaceChanged_);
         WKApp.mittBus.on("wk:nav-menu-activated", this.handleNavMenuActivated_);
+        WKApp.mittBus.on("summary-attention-count-refreshed" as any, this.handleAttentionCountRefreshed_);
         window.addEventListener("summary-task-regenerated", this.handleTaskRegenerated_);
+        window.addEventListener("summary-read", this.handleSummaryRead_);
     }
 
     componentWillUnmount() {
@@ -86,7 +110,9 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
         this.stopBatchPoll();
         WKApp.mittBus.off("summary-space-changed", this.handleSpaceChanged_);
         WKApp.mittBus.off("wk:nav-menu-activated", this.handleNavMenuActivated_);
+        WKApp.mittBus.off("summary-attention-count-refreshed" as any, this.handleAttentionCountRefreshed_);
         window.removeEventListener("summary-task-regenerated", this.handleTaskRegenerated_);
+        window.removeEventListener("summary-read", this.handleSummaryRead_);
     }
 
     async loadData() {
@@ -100,9 +126,10 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
                 keyword: keyword || undefined,
             };
             const resp = await api.listSummaries(params);
+            this.attentionCount = resp.attention_count ?? 0;
             this.setState({ items: resp.items, total: resp.total, loading: false }, () => {
                 this.maybeStartBatchPoll();
-                this.emitBadgeUpdate();
+                this.emitBadgeUpdate(resp.attention_count);
             });
         } catch (err: any) {
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
@@ -188,13 +215,14 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
      * (summary ready, waiting for user to confirm).
      * Uses a separate unfiltered query so badge is independent of list filter.
      */
-    private emitBadgeUpdate() {
-        // Fire-and-forget: fetch total WAITING_CONFIRM count unfiltered
-        api.listSummaries({ status: TaskStatus.WAITING_CONFIRM, page_size: 1 })
-            .then(resp => {
-                WKApp.mittBus.emit("summary-badge-update" as any, { count: resp.total });
-            })
-            .catch(() => { /* ignore */ });
+    private emitBadgeUpdate(count?: number) {
+        if (count != null) {
+            WKApp.mittBus.emit("summary-badge-update" as any, { count });
+            return;
+        }
+        api.listSummaries({ page_size: 1 }).then(resp => {
+            WKApp.mittBus.emit("summary-badge-update" as any, { count: resp.attention_count ?? 0 });
+        }).catch(() => { /* ignore */ });
     }
 
     handleStatusChange = (value: string | number) => {

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -79,11 +79,28 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
     };
 
     private handleSummaryRead_ = (event: Event) => {
-        const taskId = (event as CustomEvent<{ taskId: number }>).detail?.taskId;
-        if (!taskId) return;
+        const detail = (event as CustomEvent<{
+            taskId: number;
+            isUnread?: boolean;
+            needsAttention?: boolean;
+        }>).detail;
+        const taskId = detail?.taskId;
+        if (!detail || !taskId) return;
+        const current = this.state.items.find(item => item.task_id === taskId);
+        const nextNeedsAttention = detail.needsAttention ?? Boolean(current?.has_pending_invitation);
+        if (current?.needs_attention && !nextNeedsAttention) {
+            // Keep the local count aligned with the successful mark-read
+            // response so the next global poll does not trigger a redundant
+            // full-list reload and lose the user's scroll position.
+            this.attentionCount = Math.max(0, this.attentionCount - 1);
+        }
         this.setState(({ items }) => ({
             items: items.map(item => item.task_id === taskId
-                ? { ...item, is_unread: false, needs_attention: Boolean(item.has_pending_invitation) }
+                ? {
+                    ...item,
+                    is_unread: detail.isUnread ?? false,
+                    needs_attention: detail.needsAttention ?? Boolean(item.has_pending_invitation),
+                }
                 : item),
         }));
         this.emitBadgeUpdate();
@@ -221,7 +238,9 @@ export default class SummaryListPage extends Component<{}, SummaryListPageState>
             return;
         }
         api.listSummaries({ page_size: 1 }).then(resp => {
-            WKApp.mittBus.emit("summary-badge-update" as any, { count: resp.attention_count ?? 0 });
+            const count = resp.attention_count ?? 0;
+            this.attentionCount = count;
+            WKApp.mittBus.emit("summary-badge-update" as any, { count });
         }).catch(() => { /* ignore */ });
     }
 

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
@@ -172,6 +172,40 @@ describe('SummaryDetailPage — Blocking 5: scheduleItem must track current deta
     });
 });
 
+describe('SummaryDetailPage — mark-read list synchronization', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('dispatches the numeric task id for a task_no deep-link and preserves server attention state', async () => {
+        vi.mocked(api.getSummaryDetail).mockResolvedValue(baseDetail({
+            task_id: 740,
+            task_no: 'SUM-740',
+            status: 3,
+            result_id: 91,
+            result: 'summary',
+        }) as any);
+        vi.mocked(api.markSummaryRead).mockResolvedValue({
+            is_unread: false,
+            has_pending_invitation: true,
+            needs_attention: true,
+        });
+        const listener = vi.fn();
+        window.addEventListener('summary-read', listener);
+
+        const page = makePage('SUM-740');
+        await page.loadDetail();
+        await Promise.resolve();
+
+        expect(api.markSummaryRead).toHaveBeenCalledWith(740, { team_result_id: 91 });
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+            taskId: 740,
+            isUnread: false,
+            needsAttention: true,
+        });
+        window.removeEventListener('summary-read', listener);
+    });
+});
+
 // ─── FE-1（blocking）：切任务竞态——旧任务 members/personalResult 迟到返回不得 setState 到新任务 ───
 //
 // 背景：loadDetail 拿到 detail 后，loadPersonalResult / loadMembers 是二次异步请求。

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.attention.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.attention.test.tsx
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return { ...actual };
+});
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: () => null,
+    Input: () => null,
+    Select: () => null,
+    Spin: () => null,
+    Pagination: () => null,
+    Toast: { success: vi.fn(), error: vi.fn() },
+    Banner: () => null,
+    Tooltip: () => null,
+}));
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconSearch: () => null,
+    IconPlus: () => null,
+    IconRefresh: () => null,
+}));
+vi.mock('../../components/SummaryCard', () => ({ default: () => null }));
+vi.mock('../SummaryCreatePage', () => ({ default: () => null }));
+vi.mock('../SummaryDetailPage', () => ({ default: () => null }));
+vi.mock('../../api/summaryApi');
+
+import * as api from '../../api/summaryApi';
+import SummaryListPage from '../SummaryListPage';
+
+function makePage(item: Record<string, unknown>, attentionCount: number) {
+    const page = new SummaryListPage({});
+    (page as any).state = {
+        ...(page.state as any),
+        items: [{ task_id: 1, ...item }],
+    };
+    (page as any).attentionCount = attentionCount;
+    (page as any).setState = function (this: any, patch: any) {
+        this.state = { ...this.state, ...(typeof patch === 'function' ? patch(this.state) : patch) };
+    };
+    return page;
+}
+
+describe('SummaryListPage attention synchronization', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('keeps the optimistic count aligned so the next poll does not reload the list', async () => {
+        vi.mocked(api.listSummaries).mockResolvedValue({ attention_count: 2, items: [], total: 0 } as any);
+        const page = makePage({ is_unread: true, has_pending_invitation: false, needs_attention: true }, 3);
+        const loadData = vi.spyOn(page, 'loadData').mockResolvedValue(undefined);
+
+        (page as any).handleSummaryRead_(new CustomEvent('summary-read', {
+            detail: { taskId: 1, isUnread: false, needsAttention: false },
+        }));
+        (page as any).handleAttentionCountRefreshed_({ count: 2 });
+        await Promise.resolve();
+
+        expect((page as any).attentionCount).toBe(2);
+        expect((page.state as any).items[0]).toMatchObject({ is_unread: false, needs_attention: false });
+        expect(loadData).not.toHaveBeenCalled();
+    });
+
+    it('uses the server response instead of clearing other unread cursors or pending attention', () => {
+        vi.mocked(api.listSummaries).mockResolvedValue({ attention_count: 3, items: [], total: 0 } as any);
+        const page = makePage({ is_unread: true, has_pending_invitation: true, needs_attention: true }, 3);
+
+        // A team cursor may be read while a personal cursor remains unread.
+        (page as any).handleSummaryRead_(new CustomEvent('summary-read', {
+            detail: { taskId: 1, isUnread: true, needsAttention: true },
+        }));
+
+        expect((page.state as any).items[0]).toMatchObject({ is_unread: true, needs_attention: true });
+        expect((page as any).attentionCount).toBe(3);
+    });
+});

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -150,6 +150,7 @@ export interface PersonalResult {
     submitted_at: string | null;
     generated_at: string | null;
     msg_count: number;
+    current_version_id?: number | null;
 }
 
 /** 成员状态（BY_PERSON 模式） */
@@ -184,6 +185,12 @@ export interface SummaryListItem {
     origin_channel_type: number;
     created_at: string;
     completed_at: string | null;
+    is_unread?: boolean;
+    has_pending_invitation?: boolean;
+    needs_attention?: boolean;
+    current_result_id?: number | null;
+    current_personal_version_id?: number | null;
+    activity_at?: string | null;
 }
 
 /** 详情 */
@@ -260,6 +267,9 @@ export interface ListSummariesParams {
 export interface ListSummariesResponse {
     items: SummaryListItem[];
     total: number;
+    attention_count: number;
+    unread_count: number;
+    pending_invitation_count: number;
 }
 
 /** 定时配置参与者（participant_config 内嵌，含 V5 一次性确认态） */


### PR DESCRIPTION
## Summary

Add attention indicators for unread Smart Summary results and pending collaboration invitations. The navigation badge now reflects tasks that require attention, while individual cards display a red dot until the relevant result is read or the invitation is handled.

## Related Issue

Closes #845

## Changes

- Display an attention dot on summary cards with unread results or pending invitations.
- Use the server-provided attention count for the Smart Summary navigation badge.
- Refresh attention state after login and Space initialization, on Space changes, window focus, and background polling.
- Refresh the visible list when the global attention count changes.
- Mark team and personal results as read after their content is rendered successfully.
- Keep invitation attention independent from result read state.
- Synchronize read state when summaries are opened through `/s/:taskNo` notification links.
- Resolve the numeric task ID before clearing the matching list-card indicator.
- Keep the visible list position stable after marking a result as read.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworksummary`
- New or changed user-visible entry point: No new entry point; existing navigation and cards now expose attention state.
- Shared layer touched: none
- If shared code changed, impact scope: Not applicable
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands:

- `pnpm exec vitest run src/components/SummaryCard.test.tsx src/api/__tests__/summaryApi.test.ts --pool=forks`
- `git diff --check`

Manual verification covered navigation badge initialization, card updates while the list is open, collaboration and scheduled-summary invitations, notification-link navigation, and detail-to-list read-state synchronization.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated localized UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Followed commit message conventions