### PR TITLE
fix(docs): top-align table cell content so shrunk rows don't slice the first line

### DIFF
--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2052,6 +2052,21 @@ body.octo-row-resizing {
   /* Inert by default: a plain block wrapper around the cell's content (matches the pre-v19 flow). */
   display: block;
 }
+/* XIN-1289: keep the cell's content flush to the top edge so a shrunk (clipped) row shows its FIRST
+   line from the top and clips the overflow at the row's bottom edge — the Sheets/Word behaviour the
+   product signed off on. Without this the block child's default vertical margin (paragraphs carry
+   `margin: 1em 0`) pushes the first line down INSIDE the clip window; and because the fixed-row clip
+   below sets `overflow:hidden` it forms a block-formatting context that suppresses margin-collapse, so
+   that top margin becomes real space and the first line ends up sliced mid-glyph ("露半截") instead of
+   starting at the top. Zeroing the leading/trailing margins (not the inter-block gaps) lands the first
+   line on the cell top in all three states (editor, read-only preview, version diff — all share this
+   NodeView wrapper) while preserving spacing between stacked paragraphs. */
+.octo-cell-clip > :first-child {
+  margin-top: 0;
+}
+.octo-cell-clip > :last-child {
+  margin-bottom: 0;
+}
 .octo-prose table tr.octo-row-fixed .octo-cell-clip {
   max-height: calc(var(--octo-row-h) - 12px);
   overflow: hidden;


### PR DESCRIPTION
## Problem

Dragging a table row shorter than its content slices the first line of cell text mid-glyph (on a row shrunk to the minimum, the text is pushed out of view entirely). The row-height clip introduced in #823 (`.octo-cell-clip`, SCHEMA_VERSION 19) is doing its job, but the text lands in the wrong place inside the clip window.

## Root cause

The clip wrapper caps the cell content with `overflow: hidden` on height-fixed rows. `overflow:hidden` establishes a **block-formatting context**, which suppresses margin-collapse on the cell's block children. A paragraph's default `margin: 1em 0` then becomes *real* space that pushes the first line **down** inside the clip window instead of collapsing away. Measured on a 24px (minimum) row: the clip window spans y=113–125, but the paragraph's text box starts at y=128 — below the clip — so the visible slice is empty or a fractional glyph.

`vertical-align: top` on the `<td>` was already correct; the culprit was the leading margin on the content inside the clip.

## Fix

Zero the leading/trailing margins of `.octo-cell-clip`'s direct children so the content sits flush to the cell's top edge:

```css
.octo-cell-clip > :first-child { margin-top: 0; }
.octo-cell-clip > :last-child  { margin-bottom: 0; }
```

The first line now renders from the top and the overflow is clipped at the row's bottom edge — the behaviour Sheets/Word use. Spacing between stacked paragraphs is preserved (only the leading/trailing margins are removed). The wrapper is shared by the editor, the read-only preview and the version diff, so all three states stay consistent.

CSS-only: no data/schema changes, and the #823 clip mechanism itself is untouched.

## Verification (:3000-equivalent prod-faithful harness)

Drove the production editor wiring (`TableCellView` NodeView + real `styles.css`) with a real Chromium drag:

- **Single-line row shrunk to min** — first line now flush to clip top (offset 0px; was +15px, pushed out of the 12px window before).
- **Multi-line row shrunk** — first paragraph flush at top, remaining lines clipped at the bottom edge; inter-paragraph spacing intact.
- Existing `TableRow*` tests: **26 passed**. Row grow/shrink, persistence, reorder, and column-resize-on-clipped-row behaviour unchanged.

Before → after (single-line row dragged to minimum height):

Before: the shrunk row shows an empty/half-cut cell (text pushed below the clip window).
After: the shrunk row shows the first line from its top, clipped cleanly at the bottom edge.
