### PR TITLE
fix(docs): localize member source label (direct/invite)

### DIFF
--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -385,6 +385,10 @@
     "remove": "Remove",
     "owner": "owner",
     "ownerBadge": "Owner",
+    "source": {
+      "direct": "Direct",
+      "invite": "Invite"
+    },
     "ownerCannotRemove": "The owner cannot be removed",
     "errorAdd": "Failed to add member.",
     "errorRemove": "Failed to remove member.",

--- a/packages/docs/src/i18n/i18n.test.ts
+++ b/packages/docs/src/i18n/i18n.test.ts
@@ -48,6 +48,16 @@ describe('docs i18n', () => {
     expect(zhCN.toolbar.fontFamilyDefault).not.toBe(zhCN.toolbar.fontSizeDefault)
     expect(enUS.toolbar.fontFamilyDefault).not.toBe(enUS.toolbar.fontSizeDefault)
   })
+
+  // The member row shows the join source ("direct" / "invite") after a non-owner's name. Those
+  // values were rendered as the raw enum key, so a zh-CN user saw the English word " · direct".
+  // They are now localized through docs.member.source.*.
+  it('localizes the member source label in both locales', () => {
+    expect(zhCN.member.source.direct).toBe('直接添加')
+    expect(zhCN.member.source.invite).toBe('邀请加入')
+    expect(enUS.member.source.direct).toBe('Direct')
+    expect(enUS.member.source.invite).toBe('Invite')
+  })
 })
 
 describe('DocsModule i18n registration', () => {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -385,6 +385,10 @@
     "remove": "移除",
     "owner": "所有者",
     "ownerBadge": "所有者",
+    "source": {
+      "direct": "直接添加",
+      "invite": "邀请加入"
+    },
     "ownerCannotRemove": "无法移除所有者",
     "errorAdd": "添加成员失败。",
     "errorRemove": "移除成员失败。",

--- a/packages/docs/src/members/MemberPanel.tsx
+++ b/packages/docs/src/members/MemberPanel.tsx
@@ -195,7 +195,9 @@ export function MemberPanel({
               <span className="octo-uid">
                 {displayName(m.uid)}{' '}
                 {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
-                {!isOwner && <small style={{ color: 'var(--octo-muted)' }}> · {m.source}</small>}
+                {!isOwner && (
+                  <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${m.source}`)}</small>
+                )}
               </span>
               <select
                 value={m.role}


### PR DESCRIPTION
## What

Non-owner members in the docs member list show their join source after the name (e.g. ` · direct` / ` · invite`). That suffix was rendered from the raw `Member.source` enum value, so a zh-CN user saw the English word instead of a localized label. Owners don't show this tag.

## Change

- Add `docs.member.source.direct` / `docs.member.source.invite` to both `zh-CN.json` and `en-US.json` (key parity preserved by the existing i18n parity guard).
  - `direct` → `直接添加` / `Direct`
  - `invite` → `邀请加入` / `Invite`
- Render the label through `t('docs.member.source.<source>')` in `MemberPanel.tsx` instead of printing the raw enum.

No changes to member-source logic, the enum, data, or schema — this is a text-only i18n fix.

## Notes on wording

Chinese wording (`直接添加` / `邀请加入`) is aligned with the existing member-management copy. Happy to adjust to a product-preferred term if there's an established one.

## Verification

- `packages/docs` i18n + MemberPanel tests pass; added a value guard asserting the new labels in both locales.
- Verified the exact runtime path: registered the docs namespace against the real `I18nService` and confirmed `t('docs.member.source.direct'|'invite')` resolves to the Chinese strings under zh-CN and the English strings under en-US (nested keys flatten to dotted paths, so `docs.member.source.*` resolves correctly).
