### PR TITLE
feat(summary): 群内总结 tip (#289)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -2240,6 +2240,7 @@ export class Conversation
     const isSystemMessage =
       message.revoke ||
       message.contentType === MessageContentTypeConst.screenshot ||
+      message.contentType === MessageContentTypeConst.summaryNotify ||
       (message.contentType >= 1000 &&
         message.contentType <= 2000 &&
         message.contentType !== MessageContentTypeConst.threadCreated);

--- a/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const channelManager = vi.hoisted(() => ({
+  getChannelInfo: vi.fn(),
+}));
+
+vi.mock("wukongimjssdk", () => {
+  const ChannelTypePerson = 1;
+  const ChannelTypeGroup = 2;
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  }
+  class MessageContent {
+    contentObj: any = {};
+    decodeJSON(_content: any): void {}
+    encodeJSON(): any {
+      return {};
+    }
+  }
+  const sdk = { shared: () => ({ channelManager }) };
+  return {
+    default: sdk,
+    WKSDK: sdk,
+    Channel,
+    ChannelTypePerson,
+    ChannelTypeGroup,
+    MessageContent,
+  };
+});
+
+vi.mock("../../../App", () => ({
+  default: { loginInfo: { uid: "me" } },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string, opts?: any) => {
+    if (key === "base.message.summaryNotify.you") return "你";
+    if (key === "base.message.summaryNotify.text") {
+      return `${opts?.values?.name}总结了群聊内容`;
+    }
+    return key;
+  },
+}));
+
+import { MessageContentTypeConst } from "../../../Service/Const";
+import { SummaryNotifyContent } from "../index";
+
+describe("SummaryNotifyContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    channelManager.getChannelInfo.mockReturnValue(undefined);
+  });
+
+  it("reports contentType 21 (summaryNotify)", () => {
+    const content = new SummaryNotifyContent();
+    expect(content.contentType).toBe(21);
+    expect(content.contentType).toBe(MessageContentTypeConst.summaryNotify);
+  });
+
+  it("round-trips fromUID/fromName through encodeJSON/decodeJSON", () => {
+    const content = new SummaryNotifyContent();
+    content.fromUID = "alice";
+    content.fromName = "Alice";
+    const encoded = content.encodeJSON();
+    expect(encoded).toEqual({ from_uid: "alice", from_name: "Alice" });
+
+    const decoded = new SummaryNotifyContent();
+    decoded.decodeJSON(encoded);
+    expect(decoded.fromUID).toBe("alice");
+    expect(decoded.fromName).toBe("Alice");
+  });
+
+  it("shows «你» when the sender is the current user", () => {
+    const content = new SummaryNotifyContent();
+    content.fromUID = "me";
+    content.fromName = "Me";
+    expect(content.tip).toBe("你总结了群聊内容");
+    expect(content.conversationDigest).toBe("你总结了群聊内容");
+  });
+
+  it("falls back to fromName when the sender is someone else", () => {
+    const content = new SummaryNotifyContent();
+    content.fromUID = "alice";
+    content.fromName = "Alice";
+    expect(content.tip).toBe("Alice总结了群聊内容");
+  });
+
+  it("prefers channel displayName over fromName when available", () => {
+    channelManager.getChannelInfo.mockReturnValue({
+      orgData: { displayName: "Alice (Sales)" },
+    });
+    const content = new SummaryNotifyContent();
+    content.fromUID = "alice";
+    content.fromName = "Alice";
+    expect(content.tip).toBe("Alice (Sales)总结了群聊内容");
+  });
+
+  it("falls back to fromName when channelInfo exists but displayName is missing", () => {
+    // channelInfo 命中但 orgData.displayName 缺失时，不能渲染成 undefined。
+    channelManager.getChannelInfo.mockReturnValue({ orgData: {} });
+    const content = new SummaryNotifyContent();
+    content.fromUID = "alice";
+    content.fromName = "Alice";
+    expect(content.tip).toBe("Alice总结了群聊内容");
+  });
+});

--- a/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
@@ -1,0 +1,52 @@
+import { Channel, ChannelTypePerson, WKSDK, MessageContent } from "wukongimjssdk";
+import React from "react";
+import WKApp from "../../App";
+import { MessageContentTypeConst } from "../../Service/Const";
+import { MessageCell } from "../MessageCell";
+import { t } from "../../i18n";
+
+
+export class SummaryNotifyContent extends MessageContent {
+    fromUID!: string
+    fromName!: string
+
+
+    get tip() {
+        let name = ""
+        if (this.fromUID === WKApp.loginInfo.uid) {
+            name = t("base.message.summaryNotify.you")
+        } else {
+            let channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(this.fromUID, ChannelTypePerson))
+            // channelInfo 命中但 orgData.displayName 缺失时，回退到消息自带的 fromName，
+            // 避免渲染成「undefined总结了群聊内容」。
+            name = channelInfo?.orgData?.displayName || this.fromName
+        }
+        return t("base.message.summaryNotify.text", { values: { name } })
+    }
+
+    decodeJSON(content: any): void {
+        this.fromUID = content["from_uid"]
+        this.fromName = content["from_name"]
+    }
+
+    encodeJSON(): any {
+        return { from_uid: this.fromUID || "", from_name: this.fromName || "" }
+    }
+
+    get contentType() {
+        return MessageContentTypeConst.summaryNotify
+    }
+
+    get conversationDigest() {
+        return this.tip
+    }
+
+}
+
+export class SummaryNotifyCell extends MessageCell {
+    render() {
+        const { message } = this.props
+        let content = message.content as SummaryNotifyContent
+        return <div className="wk-message-system">{content.tip}</div>
+    }
+}

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -70,6 +70,7 @@ export class MessageContentTypeConst {
   static newGroupOwner: number = 1008 // 新的管理员
   static approveGroupMember: number = 1009 // 审批群成员
   static screenshot:number = 20 // 截屏消息
+  static summaryNotify:number = 21 // 群内总结完成 tip
 
   // 音频通话消息号段 9900 - 9999
   static rtcResult:number = 9989 // 音视频通话结果

--- a/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
@@ -61,4 +61,18 @@ describe("isMessageContinuation", () => {
             msg("u1", 1_030, { contentType: MessageContentTypeConst.screenshot }),
         )).toBe(false)
     })
+
+    it("breaks on summaryNotify system tip (same fromUID should not hide avatar)", () => {
+        // 群内总结 tip 与截屏 tip 同类：居中 system tip，fromUID 是发起人，
+        // 不能和发起人相邻的正常消息合并连续性（#289）。
+        expect(isMessageContinuation(
+            msg("u1", 1_000, { contentType: MessageContentTypeConst.summaryNotify }),
+            msg("u1", 1_030),
+        )).toBe(false)
+
+        expect(isMessageContinuation(
+            msg("u1", 1_000),
+            msg("u1", 1_030, { contentType: MessageContentTypeConst.summaryNotify }),
+        )).toBe(false)
+    })
 })

--- a/packages/dmworkbase/src/Service/messageContinuity.ts
+++ b/packages/dmworkbase/src/Service/messageContinuity.ts
@@ -22,6 +22,7 @@ function isBoundaryMessage(message: ContinuityMessage): boolean {
         || contentType === MessageContentTypeConst.historySplit
         || contentType === MessageContentTypeConst.typing
         || contentType === MessageContentTypeConst.screenshot
+        || contentType === MessageContentTypeConst.summaryNotify
         || !!message.revoke
 }
 

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1041,6 +1041,8 @@
   "message.mergeForward.chatRecord": "Chat history",
   "message.screenshot.text": "{{name}} took a screenshot in the chat",
   "message.screenshot.you": "You",
+  "message.summaryNotify.text": "{{name}} summarized the chat",
+  "message.summaryNotify.you": "You",
   "message.signal.unavailable": "This message uses end-to-end encryption and cannot be decrypted on web. View it on mobile.",
   "message.unknown.unsupportedWithType": "[This message cannot be viewed here. Open it on mobile for details ({{type}})]",
   "message.unsupport.tip": "[Received a message type not supported on web. View it on mobile.]",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1041,6 +1041,8 @@
   "message.mergeForward.chatRecord": "聊天记录",
   "message.screenshot.text": "{{name}}在聊天中截屏了",
   "message.screenshot.you": "你",
+  "message.summaryNotify.text": "{{name}}总结了群聊内容",
+  "message.summaryNotify.you": "你",
   "message.signal.unavailable": "此消息已采用端对端加密，web端无法解密，请在手机端查看",
   "message.unknown.unsupportedWithType": "[此消息不支持查看，请至手机端查看详情({{type}})]",
   "message.unsupport.tip": "[收到一条网页版暂不支持的消息类型，请在手机上查看]",

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -70,6 +70,8 @@ export { default as MessageBase } from "./Messages/Base"
 export  * from "./Messages/Image"
 export * from "./Messages/File"
 export * from "./Messages/Base"
+export * from "./Messages/SummaryNotify"
+export { isConversationDisbanded } from "./Utils/groupDisband"
 
 export * from "./Messages/MessageCell"
 

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -93,6 +93,7 @@ import { patchSdkDecodeForExternalFields } from "./Service/Convert";
 import { isMessageSelectable } from "./Service/messageSelection";
 import ConversationVM from "./Components/Conversation/vm";
 import { ScreenshotCell, ScreenshotContent } from "./Messages/Screenshot";
+import { SummaryNotifyCell, SummaryNotifyContent } from "./Messages/SummaryNotify";
 import FileToolbar from "./Components/FileToolbar";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { ApproveGroupMemberCell } from "./Messages/ApproveGroupMember";
@@ -312,6 +313,8 @@ export default class BaseModule implements IModule {
             return LocationCell;
           case MessageContentTypeConst.screenshot:
             return ScreenshotCell;
+          case MessageContentTypeConst.summaryNotify:
+            return SummaryNotifyCell;
           case MessageContentType.signalMessage: // 端对端加密错误消息
           case MessageContentTypeConst.approveGroupMember: // 审批群成员
             return ApproveGroupMemberCell;
@@ -381,6 +384,10 @@ export default class BaseModule implements IModule {
     registerCurrentImMessageContent(
       MessageContentTypeConst.screenshot,
       () => new ScreenshotContent()
+    );
+    WKSDK.shared().register(
+      MessageContentTypeConst.summaryNotify,
+      () => new SummaryNotifyContent()
     );
     // 加入组织
     registerCurrentImMessageContent(

--- a/packages/dmworksummary/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworksummary/src/__mocks__/dmworkBase.ts
@@ -70,3 +70,16 @@ export default WKApp;
 export const buildAcceptLanguage = () => 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7';
 
 export const isSafeUrl = (url: string) => /^https?:\/\//.test(url);
+
+// 群内总结 tip 的消息内容体，测试里只需要能 new + set 字段 + encodeJSON。
+export class SummaryNotifyContent {
+  fromUID = '';
+  fromName = '';
+  contentObj: Record<string, unknown> = {};
+  encodeJSON() {
+    return { from_uid: this.fromUID || '', from_name: this.fromName || '' };
+  }
+}
+
+// 群解散判定：测试默认返回 false（未解散）。需要覆盖解散分支的用例可 vi.mocked 覆盖。
+export const isConversationDisbanded = (_channel?: unknown) => false;

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -12,8 +12,8 @@ import {
 } from "@douyinfe/semi-ui";
 import { IconEdit, IconSend, IconClock, IconTick, IconClose, IconInfoCircle, IconHistory, IconUser, IconPlus, IconMinusCircle, IconExit, IconDelete, IconMore } from "@douyinfe/semi-icons";
 import { ChevronDown, Check, X } from "lucide-react";
-import { Channel, MessageText } from "wukongimjssdk";
-import { I18nContext, t, ForwardService, interpretForwardResult } from "@octo/base";
+import { Channel, ChannelTypeGroup, MessageText, WKSDK } from "wukongimjssdk";
+import { I18nContext, t, ForwardService, interpretForwardResult, SummaryNotifyContent, isConversationDisbanded } from "@octo/base";
 import WKApp from "@octo/base/src/App";
 import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
@@ -39,7 +39,7 @@ import type {
     SummaryVersionDetail,
     SummaryVersionItem,
 } from "../types/summary";
-import { TaskStatus, SummaryMode, ParticipantStatus, TriggerType } from "../types/summary";
+import { TaskStatus, SummaryMode, ParticipantStatus, SourceType, TriggerType } from "../types/summary";
 import {
     formatDate,
     canCancel,
@@ -48,6 +48,8 @@ import {
     scheduleToParams,
     formatScheduleSummary,
     shouldReactivateOnSave,
+    readSummaryNotifySentSources,
+    markSummaryNotifySent,
 } from "../utils/summaryHelpers";
 import CitationText from "../components/CitationText";
 import SelectedSourcesPanel from "../components/SelectedSourcesPanel";
@@ -235,6 +237,10 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     private teamStreamClosedTaskId: number | null = null;
     private refineStreamAbortController: AbortController | null = null;
     private unmounted = false;
+    // 群内总结 tip：同一实例内正在发送中的 (task_id:source_id)，防止本组件三个触发点
+    // （状态事件 / 兜底轮询 / loadDetail 首次见 COMPLETED）并发重复发。跨 tab / reload
+    // 的去重由持久标记（summary-notify-sent:*，见 summaryHelpers）负责。
+    private summaryNotifyInFlight = new Set<string>();
     private workflowTargetIndex = -1;
     private listPageActive = false;
     private lastEventTime = 0;
@@ -886,6 +892,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         this.loadPersonalResult(seq);
                         this.loadMembers(seq);
                     }
+                    if (newStatus === TaskStatus.COMPLETED) {
+                        void this.sendGroupSummaryNotify(detail);
+                    }
                 }
             }
         } catch {
@@ -960,6 +969,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         }
                         if (detail.schedule_id && detail.schedule_id > 0) {
                             this.loadSchedule(detail.schedule_id, seq);
+                        }
+                        if (newStatus === TaskStatus.COMPLETED) {
+                            void this.sendGroupSummaryNotify(detail);
                         }
                     }
                 } catch {
@@ -1944,6 +1956,56 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             Toast.error(err.message || t("summary.common.operationFailed"));
         }
     };
+
+    /**
+     * 群内总结 tip：总结变 COMPLETED 时，向每个「群聊」源发一条系统 tip
+     *「{发起人}总结了群聊内容」（照抄截屏 tip，不可回复）。
+     * - 仅发起人（creator）发送，避免每个查看者都发一遍；
+     * - 去重按 (task_id, source_id) 粒度，持久化到 localStorage（summary-notify-sent:*）：
+     *   跨 tab / reload / 多实例共享，且**仅在发送成功后**落标记——某源群瞬时失败不落标记,
+     *   下次（再次转 COMPLETED）还能重试，不会永久静默漏发；
+     * - 同一实例内用 summaryNotifyInFlight 防止两条触发点并发重复发同一 source；
+     * - 已解散的群跳过（沿用 isConversationDisbanded 这条既有发送不变量）；
+     * - 发送走 chatManager.send，与 handleForwardToChat 一致；群频道无需注入 space_id。
+     *
+     * 只由状态事件 / 兜底轮询检测到的 PROCESSING→COMPLETED 迁移触发（真正「刚完成」）。
+     * 刻意不在 loadDetail「首次载入即 COMPLETED」补发：那条无迁移语义，会把「打开历史 /
+     * 跨端已完成总结」误当成刚完成而误发过时 tip（localStorage 去重挡不住无标记的那两类）。
+     */
+    private async sendGroupSummaryNotify(detail: SummaryDetail) {
+        if (detail.status !== TaskStatus.COMPLETED) return;
+        const myUid = WKApp.loginInfo.uid;
+        // 只有发起人发；非 creator 视角不触发（文案主语是发起人）。
+        if (!myUid || detail.creator_id !== myUid) return;
+        const groupSources = (detail.sources || []).filter(
+            (src) => src.source_type === SourceType.GROUP_CHAT && !!src.source_id
+        );
+        if (groupSources.length === 0) return;
+
+        const sentSources = readSummaryNotifySentSources(detail.task_id);
+        for (const src of groupSources) {
+            const inFlightKey = `${detail.task_id}:${src.source_id}`;
+            if (sentSources.has(src.source_id)) continue; // 已成功发过（跨 tab / reload）
+            if (this.summaryNotifyInFlight.has(inFlightKey)) continue; // 本实例正在发
+            const ch = new Channel(src.source_id, ChannelTypeGroup);
+            // 已解散群不发（保持与既有发送路径一致的只读不变量）。
+            if (isConversationDisbanded(ch)) continue;
+
+            this.summaryNotifyInFlight.add(inFlightKey);
+            try {
+                const msg = new SummaryNotifyContent();
+                msg.fromUID = myUid;
+                msg.fromName = WKApp.loginInfo.name || "";
+                await WKSDK.shared().chatManager.send(msg, ch);
+                // 仅成功后落持久标记；失败则不落，下次可重试。
+                markSummaryNotifySent(detail.task_id, src.source_id);
+            } catch {
+                // 单个群失败不影响其余群，也不落标记（可重试）。
+            } finally {
+                this.summaryNotifyInFlight.delete(inFlightKey);
+            }
+        }
+    }
 
     /**
      * 「继续优化」按钮 — 打开一个新的智能总结 chat session,预置引用当前总结。

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.groupNotify.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.groupNotify.test.tsx
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// octo-web#289 (review 返工): 群内总结 tip 的可靠性口径。
+// 覆盖 sendGroupSummaryNotify:
+//  - 仅发起人（creator）、仅群聊源、COMPLETED 才发；
+//  - 去重按 (task_id, source_id) 持久化到 localStorage —— 跨实例(多 tab / reload)不重发；
+//  - 单个源失败不落标记，下次可重试（不永久漏发）;
+//  - 已解散群跳过;
+//  - 同实例并发触发不重复发。
+
+const sendMock = vi.hoisted(() => vi.fn());
+const disbandedMock = vi.hoisted(() => vi.fn((_ch?: any) => false));
+
+vi.mock('wukongimjssdk', () => ({
+    Channel: class {
+        channelID: string;
+        channelType: number;
+        constructor(channelID: string, channelType: number) {
+            this.channelID = channelID;
+            this.channelType = channelType;
+        }
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    MessageText: class {},
+    WKSDK: { shared: () => ({ chatManager: { send: sendMock } }) },
+}));
+
+// @octo/base 在 vitest.config 里已被 alias 到 __mocks__/dmworkBase.ts；这里只覆盖
+// isConversationDisbanded 为可控 mock，其余（WKApp / t / SummaryNotifyContent）保持原样。
+vi.mock('@octo/base', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, isConversationDisbanded: disbandedMock };
+});
+
+vi.mock('@douyinfe/semi-ui', () => {
+    const Passthrough = ({ children }: any) => children ?? null;
+    const Typography: any = Passthrough;
+    Typography.Text = Passthrough;
+    const Dropdown: any = Passthrough;
+    Dropdown.Menu = Passthrough;
+    Dropdown.Item = Passthrough;
+    return {
+        Button: Passthrough,
+        Typography,
+        Tag: Passthrough,
+        Avatar: Passthrough,
+        Spin: Passthrough,
+        Modal: Passthrough,
+        Banner: Passthrough,
+        Input: Passthrough,
+        Checkbox: Passthrough,
+        Empty: Passthrough,
+        Dropdown,
+        Popover: Passthrough,
+        Toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    };
+});
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconEdit: () => null,
+    IconMore: () => null,
+    IconSend: () => null,
+    IconClock: () => null,
+    IconTick: () => null,
+    IconClose: () => null,
+    IconInfoCircle: () => null,
+    IconHistory: () => null,
+    IconUser: () => null,
+    IconPlus: () => null,
+    IconMinusCircle: () => null,
+    IconExit: () => null,
+}));
+vi.mock('../../components/CitationText', () => ({ default: () => null }));
+vi.mock('../../components/SummaryEditor', () => ({ default: () => null }));
+
+import SummaryDetailPage from '../SummaryDetailPage';
+import { SummaryMode, TaskStatus, SourceType } from '../../types/summary';
+
+// creator = "test-uid"（见 __mocks__/dmworkBase.ts 的 WKApp.loginInfo.uid）
+const ME = 'test-uid';
+
+function makeDetail(over: any = {}) {
+    return {
+        task_id: 1,
+        summary_mode: SummaryMode.BY_GROUP,
+        status: TaskStatus.COMPLETED,
+        creator_id: ME,
+        sources: [
+            { source_type: SourceType.GROUP_CHAT, source_id: 'group-a' },
+            { source_type: SourceType.GROUP_CHAT, source_id: 'group-b' },
+            { source_type: SourceType.DIRECT_MESSAGE, source_id: 'dm-c' },
+        ],
+        ...over,
+    };
+}
+
+function newPage() {
+    const page: any = new SummaryDetailPage({ taskId: 1 });
+    return page;
+}
+
+describe('SummaryDetailPage.sendGroupSummaryNotify (octo-web#289)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        sendMock.mockResolvedValue(undefined);
+        disbandedMock.mockReturnValue(false);
+    });
+
+    it('sends one tip per group source, skips non-group sources', async () => {
+        await newPage().sendGroupSummaryNotify(makeDetail());
+        expect(sendMock).toHaveBeenCalledTimes(2);
+        const channelIds = sendMock.mock.calls.map((c) => c[1].channelID).sort();
+        expect(channelIds).toEqual(['group-a', 'group-b']);
+        sendMock.mock.calls.forEach((c) => expect(c[1].channelType).toBe(2));
+    });
+
+    it('does not send when the current user is not the creator', async () => {
+        await newPage().sendGroupSummaryNotify(makeDetail({ creator_id: 'someone-else' }));
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('does not send when status is not COMPLETED', async () => {
+        await newPage().sendGroupSummaryNotify(makeDetail({ status: TaskStatus.PROCESSING }));
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('does not send when there are no group sources', async () => {
+        await newPage().sendGroupSummaryNotify(
+            makeDetail({ sources: [{ source_type: SourceType.DIRECT_MESSAGE, source_id: 'dm-c' }] })
+        );
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('does not resend across instances (multi-tab / reload) via persistent marker', async () => {
+        const detail = makeDetail();
+        await newPage().sendGroupSummaryNotify(detail);
+        expect(sendMock).toHaveBeenCalledTimes(2);
+        // 新实例（模拟 reload / 另一个 tab）：持久标记已记录 → 不再重发。
+        await newPage().sendGroupSummaryNotify(detail);
+        expect(sendMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a source that failed to send (no marker on failure)', async () => {
+        // group-b 首次发送失败、之后成功；其余源始终成功。
+        let bAttempts = 0;
+        sendMock.mockImplementation((_msg: any, ch: any) => {
+            if (ch.channelID === 'group-b') {
+                bAttempts += 1;
+                if (bAttempts === 1) return Promise.reject(new Error('transient'));
+            }
+            return Promise.resolve(undefined);
+        });
+        const detail = makeDetail();
+        await newPage().sendGroupSummaryNotify(detail); // a ok, b fail
+        // 再次触发（同 task）：a 已标记跳过，b 未标记 → 只重试 b，且这次成功。
+        await newPage().sendGroupSummaryNotify(detail);
+        const targets = sendMock.mock.calls.map((c) => c[1].channelID);
+        expect(targets.filter((id) => id === 'group-a')).toEqual(['group-a']); // a 只发一次
+        expect(targets.filter((id) => id === 'group-b').length).toBe(2); // b 失败后重试
+        // 重试成功后再触发不应再发。
+        sendMock.mockClear();
+        await newPage().sendGroupSummaryNotify(detail);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('skips disbanded group sources and does not mark them', async () => {
+        disbandedMock.mockImplementation((ch: any) => ch.channelID === 'group-b');
+        const detail = makeDetail();
+        await newPage().sendGroupSummaryNotify(detail);
+        const targets = sendMock.mock.calls.map((c) => c[1].channelID);
+        expect(targets).toEqual(['group-a']); // group-b 已解散被跳过
+        // group-b 未落标记：若之后恢复（不再解散），仍可补发。
+        disbandedMock.mockReturnValue(false);
+        sendMock.mockClear();
+        await newPage().sendGroupSummaryNotify(detail);
+        expect(sendMock.mock.calls.map((c) => c[1].channelID)).toEqual(['group-b']);
+    });
+
+    it('does not double-send under concurrent invocations on the same instance', async () => {
+        const page = newPage();
+        const detail = makeDetail();
+        await Promise.all([
+            page.sendGroupSummaryNotify(detail),
+            page.sendGroupSummaryNotify(detail),
+        ]);
+        expect(sendMock).toHaveBeenCalledTimes(2);
+        expect(sendMock.mock.calls.map((c) => c[1].channelID).sort()).toEqual(['group-a', 'group-b']);
+    });
+});

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -140,6 +140,47 @@ export function clearAgentChatReferenced(channelId?: string | null): void {
     }
 }
 
+// ─── 群内总结 tip 的「已发送」持久标记（per-task / per-source） ──────────────
+// #289 review：单纯用组件实例内存态去重，会在多 tab / reload / 多实例同时观察到
+// 完成时各自向所有源群重复发 tip。改用 localStorage 持久化「(task_id, source_id) 已发」
+// 标记，跨 tab / reload 共享，且按 source 粒度记录——失败的 source 不落标记，下次可重试。
+const SUMMARY_NOTIFY_SENT_KEY_PREFIX = 'summary-notify-sent:';
+
+function summaryNotifySentKey(taskId: number): string {
+    return SUMMARY_NOTIFY_SENT_KEY_PREFIX + taskId;
+}
+
+/**
+ * 读取某 task 已成功发过 tip 的源群 id 集合。localStorage 不可用/解析失败时返回空集，
+ * 降级为「未发过」（可能重发，但不会永久漏发）。
+ */
+export function readSummaryNotifySentSources(taskId: number): Set<string> {
+    try {
+        const raw = localStorage.getItem(summaryNotifySentKey(taskId));
+        if (!raw) return new Set();
+        const arr = JSON.parse(raw);
+        return Array.isArray(arr) ? new Set(arr.filter((x): x is string => typeof x === 'string')) : new Set();
+    } catch {
+        return new Set();
+    }
+}
+
+/**
+ * 记录某 task 的某源群 tip「已成功发送」。读-改-写合并，避免并发 tab 互相覆盖丢标记。
+ * 仅在发送成功后调用；异常静默降级（最坏情况是下次重发，不会永久漏发）。
+ */
+export function markSummaryNotifySent(taskId: number, sourceId: string): void {
+    if (!sourceId) return;
+    try {
+        const set = readSummaryNotifySentSources(taskId);
+        if (set.has(sourceId)) return;
+        set.add(sourceId);
+        localStorage.setItem(summaryNotifySentKey(taskId), JSON.stringify([...set]));
+    } catch {
+        // localStorage 不可用（隐私模式/配额）：不持久化，不影响本次发送。
+    }
+}
+
 /** 周对应天数 */
 export const DAYS_PER_WEEK = 7;
 /** interval_days 上界（与后端 MaxIntervalDays 对齐） */


### PR DESCRIPTION
## What

给「群聊总结」加**群内系统级总结 tip**：当一次总结首次进入 `COMPLETED` 状态时，向每个「群聊」源自动发送一条灰色系统 tip「{发起人}总结了群聊内容」，不可回复、不可 @，样式与现有的「截屏 tip」一致。

Closes Mininglamp-OSS/octo-web#289

## Why

#289 要的是**群内所有人可见**的注意力信号（谁总结了这个群）。这不同于：

- 线上「总结完成通知助手」——只推给发起人自己的后端行为（不在本仓）；
- 现有「转发到聊天」按钮（`SummaryDetailPage.handleForwardToChat`）——用户手动点击、发普通文本。

以上两者本 PR **均保留不动**，只新增「群内自动 tip」这一条路径。

## How

照抄「截屏 tip」（`Messages/Screenshot`）的 4 个锚点：

1. **`Const.ts`**：新增 `summaryNotify = 21`（20 已被截屏占用）。
2. **新增 `Messages/SummaryNotify/index.tsx`**：`SummaryNotifyContent`（字段 `from_uid` / `from_name`，`contentType=21`，`tip` getter），以及渲染用的 `SummaryNotifyCell`（`wk-message-system`）。因为本类型需要**发送**，额外实现了 `encodeJSON`。
3. **`module.tsx`**：渲染分发新增 `case summaryNotify` → `SummaryNotifyCell`；工厂注册 `register(summaryNotify, () => new SummaryNotifyContent())`。
4. **`SummaryDetailPage.tsx`**：在真正的「首次 PROCESSING→COMPLETED」迁移点（状态事件 `handleStatusChangeEvent` 与兜底轮询 `doFallbackPollOnce`）触发 `sendGroupSummaryNotify`，对每个 `source_type=群聊` 的源发一条 tip。

口径：

- **触发**：状态首次变 `COMPLETED` 时；
- **发送方**：仅**发起人（creator）** 发送，避免每个查看者都发一遍（文案主语就是发起人）；
- **去重**：每个 task 只发一次（`summaryNotifySentTaskIds`，兼顾状态事件 + 兜底轮询两条路径都可能命中同一迁移）；
- **目标**：`detail.sources` 里 `source_type === 群聊` 的每个源群；
- **文案**：「{fromName}总结了群聊内容」（i18n：zh-CN / en-US 均已补）；
- 发送走 `chatManager.send`，与 `handleForwardToChat` 一致；后者的 `space_id` 注入只针对 person 频道，本路径只发群聊，故无需注入。

> 说明：#289 描述里把触发点写在 `loadDetail` 的 `useEffect`，但本页是 class 组件、`loadDetail` 每次打开已完成总结都会重跑，放在那里会重复发送。故改挂到真正的状态迁移检测点，并加 task 级去重，严格保证「只发一次」。

## Tests

- `Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts`：`contentType=21`、`encodeJSON`/`decodeJSON` 往返、`tip` 文案（自己 / 他人 / 频道 displayName）。
- `pages/__tests__/SummaryDetailPage.groupNotify.test.tsx`：只对群聊源发送、非 creator 不发、非 COMPLETED 不发、无群聊源不发、同一 task 只发一次。

本地 `dmworksummary` 全量测试通过（391/391）；新增的 `dmworkbase` 用例通过；`apps/web` `vite build` 通过。

## Scope / Follow-ups

- 本 PR **只做 octo-web**；iOS / Android 收到未知 `contentType=21` 的兜底由各自 repo 跟进。
- tip 点击跳回总结详情页本 PR 先不做，后续再评估。

关联任务：Multica WS-21。
