### PR TITLE
fix(docs): forward real board title to chat

### DIFF
--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -266,6 +266,12 @@ function boardTerminalForAccessLoss(err: unknown): BoardTerminal | null {
 export function BoardShell(props: BoardShellProps): ReactElement {
   const { docId, title, space, folder, onBack, onExit, onTitleSaved, onDeleted, collabSession, collab, user, creatorNicknameOnly, onOpenInNewPage } = props
 
+  // The live board title, lifted out of DocTitle so "forward to chat" sends the REAL name rather
+  // than the static `title` prop (XIN-1306). Seeded from the fallback prop, then updated when
+  // DocTitle fetches the real title on mount (onTitleLoaded) and when the user renames the board
+  // (onSaved). Mirrors EditorShell's currentTitle lift.
+  const [currentTitle, setCurrentTitle] = useState(title)
+
   const [Excalidraw, setExcalidraw] = useState<ExcalidrawComponent | null>(null)
   // Excalidraw's `MainMenu` compound component, captured off the same dynamic import. Rendered as a
   // child of the canvas so our de-branded menu (no "Excalidraw links" group) replaces the built-in
@@ -633,14 +639,17 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     if (!role) return
     startDocForward({
       docId,
-      title,
+      // Forward the LIVE title (XIN-1306) — the static `title` prop is only the pre-fetch fallback,
+      // so sending it made the chat card read "无标题文档". An empty live title falls back to the
+      // board-specific "未命名画板" rather than the generic doc key.
+      title: currentTitle?.trim() || t('docs.board.untitled'),
       role,
       currentUid: getCurrentUid(),
       ownerId,
       space,
       folder,
     })
-  }, [docId, title, role, ownerId, space, folder])
+  }, [docId, currentTitle, role, ownerId, space, folder])
 
   // Resolve the caller's role for THIS board so a reader gets a read-only canvas.
   //
@@ -1094,7 +1103,16 @@ export function BoardShell(props: BoardShellProps): ReactElement {
             ← {t('docs.list.back')}
           </button>
         )}
-        <DocTitle docId={docId} initialTitle={title} canEdit={manage} onSaved={onTitleSaved} />
+        <DocTitle
+          docId={docId}
+          initialTitle={title}
+          canEdit={manage}
+          onSaved={(id, newTitle) => {
+            setCurrentTitle(newTitle)
+            onTitleSaved?.(id, newTitle)
+          }}
+          onTitleLoaded={setCurrentTitle}
+        />
         <div className="octo-doc-header-right">
           {/* Board-specific status badges (no doc counterpart) lead the cluster. */}
           {readOnly && <span className="octo-board-readonly">{t('docs.board.readOnly')}</span>}

--- a/packages/docs/src/board/__tests__/BoardShellForwardTitle.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellForwardTitle.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { BoardTerminal } from '../collab/index.ts'
+import type { WhiteboardSession } from '../collab/connect.ts'
+import { setWKApp } from '../../octoweb/index.ts'
+import { createMockWKApp } from '../../octoweb/mock.ts'
+
+// XIN-1306 regression: the board's "forward to chat" must send the LIVE title, not the static
+// `title` prop. DocTitle fetches the real title on mount and surfaces it via onTitleLoaded;
+// BoardShell lifts it into `currentTitle` and forwards that. An empty title falls back to the
+// board-specific "未命名画板" (docs.board.untitled), not the generic doc key. Mirrors the
+// EditorShell live-title test.
+//
+// Excalidraw stand-in (same shape as BoardShellHeader.test): hands the imperative API up once from
+// a mount effect so BoardShell's excalidrawApi state settles without an update loop.
+vi.mock('@excalidraw/excalidraw', async () => {
+  const { useEffect } = await import('react')
+  const api = { updateScene: () => {}, getAppState: () => ({}), updateLibrary: async () => [] }
+  const Excalidraw = ({
+    children,
+    excalidrawAPI,
+  }: {
+    children?: ReactNode
+    excalidrawAPI?: (api: unknown) => void
+  }) => {
+    useEffect(() => {
+      excalidrawAPI?.(api)
+    }, [excalidrawAPI])
+    return <div data-testid="excalidraw-canvas">{children}</div>
+  }
+  const MainMenu = (() => null) as unknown as { DefaultItems: Record<string, unknown> }
+  MainMenu.DefaultItems = {}
+  return {
+    Excalidraw,
+    MainMenu,
+    restoreElements: (els: readonly unknown[] | null | undefined) => (els ? [...els] : []),
+    reconcileElements: (local: readonly unknown[]) => [...local],
+    loadLibraryFromBlob: async () => [],
+    serializeLibraryAsJSON: () => '[]',
+  }
+})
+vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
+
+import { BoardShell } from '../BoardShell.tsx'
+
+/** Minimal awareness double (PresenceBar + the board presence effect touch only this surface). */
+function makeAwareness() {
+  return {
+    clientID: 1,
+    getStates: () => new Map(),
+    setLocalStateField: () => {},
+    on: () => {},
+    off: () => {},
+  }
+}
+
+/** Session stub exposing just the surface BoardShell reads: an authoritative role + a provider. */
+function makeSession(role: 'admin' | 'writer' | 'reader'): WhiteboardSession {
+  const binding = {
+    setApi: () => {},
+    setRenderAdapter: () => {},
+    setFileSync: () => {},
+    handleLocalChange: () => {},
+    snapshotElements: () => [] as unknown[],
+  }
+  return {
+    getRole: () => role,
+    subscribeRole: () => () => {},
+    subscribeTerminal: (_cb: (t: BoardTerminal) => void) => () => {},
+    binding,
+    provider: {
+      awareness: makeAwareness(),
+      isSynced: true,
+      on: () => {},
+      off: () => {},
+    },
+  } as unknown as WhiteboardSession
+}
+
+let wk: ReturnType<typeof createMockWKApp>
+
+beforeEach(() => {
+  wk = createMockWKApp()
+  setWKApp(wk)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('BoardShell — forward-to-chat sends the live title, not the stale prop (XIN-1306)', () => {
+  it('forwards the real title after DocTitle fetches it (currentTitle), not the static title prop', async () => {
+    // The board's real title differs from the prop the shell was opened with.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/doc-1') {
+        return { data: { docId: 'doc-1', title: 'Live Board Title' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(
+      <BoardShell
+        docId="doc-1"
+        title="Stale Prop Title"
+        space="s1"
+        collabSession={makeSession('admin')}
+        collab
+      />,
+    )
+
+    await screen.findByTestId('excalidraw-canvas')
+    // The header shows the fetched (live) title once DocTitle's mount fetch resolves — proving
+    // onTitleLoaded fired and BoardShell lifted it into currentTitle.
+    await waitFor(() => expect(screen.getByText('Live Board Title')).toBeTruthy())
+
+    fireEvent.click(await screen.findByTitle('docs.forward.entry'))
+
+    await waitFor(() => expect(wk.openDocForwardCalls.length).toBe(1))
+    expect(wk.openDocForwardCalls[0].title).toBe('Live Board Title')
+    expect(wk.openDocForwardCalls[0].title).not.toBe('Stale Prop Title')
+  })
+
+  it('falls back to the board-specific "未命名画板" key when the live title is empty', async () => {
+    // An untitled board: the fetched title is empty, so currentTitle stays empty.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/doc-1') {
+        return { data: { docId: 'doc-1', title: '' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(
+      <BoardShell docId="doc-1" title="" space="s1" collabSession={makeSession('admin')} collab />,
+    )
+
+    await screen.findByTestId('excalidraw-canvas')
+    fireEvent.click(await screen.findByTitle('docs.forward.entry'))
+
+    await waitFor(() => expect(wk.openDocForwardCalls.length).toBe(1))
+    // The board fallback key (t() stub returns the key unchanged), NOT the generic doc key
+    // docs.state.untitled that startDocForward would otherwise apply to an empty title.
+    expect(wk.openDocForwardCalls[0].title).toBe('docs.board.untitled')
+    expect(wk.openDocForwardCalls[0].title).not.toBe('docs.state.untitled')
+  })
+})


### PR DESCRIPTION
## Problem
Forwarding a whiteboard to chat showed 「无标题文档」 instead of the real board name (e.g. 「滴滴滴」). Root cause (XIN-1306): BoardShell forwards the static `title` prop, which is only a pre-fetch fallback (hardcoded to docs.state.untitled). The real title is fetched by the child DocTitle and shown in the header, but never lifted back to BoardShell — so startDocForward sends the placeholder. EditorShell and SheetView both lift the fetched title into their own state and forward that; only BoardShell did neither. Not a backend issue — getDoc returns the real meta.title.

## Fix (mirrors EditorShell)
1. Add `currentTitle` state to BoardShell, seeded from the `title` prop.
2. Wire DocTitle's `onTitleLoaded` (real title fetched on mount) + `onSaved` (rename) to update it.
3. Forward `currentTitle` instead of the static prop; empty live title falls back to the board-specific `docs.board.untitled`「未命名画板」 rather than the generic doc key. Updated the useCallback dep array accordingly.

EditorShell/SheetView untouched.

## Scope
Pure frontend, single file (BoardShell.tsx, +21/-3). No backend, no schema.

## Note
Follow-up: a BoardShell forward-title regression test would round this out (EditorShell already has one); can add on request.