### PR TITLE
refactor(summary): extract version history into standalone SummaryVersionHistory component

### DIFF
--- a/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
+++ b/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
@@ -1,68 +1,109 @@
 import React from "react";
-import { Timeline, Button, Tag } from "@douyinfe/semi-ui";
+import { Button, Tag } from "@douyinfe/semi-ui";
+import { IconHistory } from "@douyinfe/semi-icons";
 import { useI18n } from "@octo/base";
-import type { SummaryResult } from "../types/summary";
-import { formatDate } from "../utils/summaryHelpers";
+import type { SummaryVersionItem } from "../types/summary";
 
 interface SummaryVersionHistoryProps {
-    versions: SummaryResult[];
+    versions: SummaryVersionItem[];
+    versionsLoading: boolean;
     currentVersion: number;
-    onSelectVersion: (version: number) => void;
+    restoringVersionId: number | null;
+    canRestore: boolean;
+    onViewVersion: (version: SummaryVersionItem) => void;
+    onRestoreVersion: (version: SummaryVersionItem) => void;
+}
+
+function formatVersionOperation(
+    version: SummaryVersionItem,
+    t: (key: string, opts?: { values?: Record<string, string | number> }) => string,
+): string {
+    if ((version.operation_type || "generate") === "generate") {
+        return t("summary.detail.versionInitialGenerate");
+    }
+    const key = `summary.detail.versionOperation.${version.operation_type || "generate"}`;
+    const label = t(key);
+    return label === key ? t("summary.detail.versionOperation.generate") : label;
+}
+
+function formatVersionOperationNote(
+    version: SummaryVersionItem,
+    t: (key: string, opts?: { values?: Record<string, string | number> }) => string,
+): string {
+    const note = (version.operation_note || "").trim();
+    if (note) return note;
+    if ((version.operation_type || "generate") === "generate") {
+        return t("summary.detail.versionInitialGenerateDesc");
+    }
+    if (version.operation_type === "restore" && version.parent_result_id) {
+        return t("summary.detail.versionRestoreFromResult", { values: { id: version.parent_result_id } });
+    }
+    return formatVersionOperation(version, t);
 }
 
 const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
     versions,
+    versionsLoading,
     currentVersion,
-    onSelectVersion,
+    restoringVersionId,
+    canRestore,
+    onViewVersion,
+    onRestoreVersion,
 }) => {
     const { t } = useI18n();
 
-    if (!versions || versions.length === 0) {
-        return <div className="summary-version-empty">{t("summary.versionHistory.empty")}</div>;
-    }
-
-    const sorted = [...versions].sort((a, b) => b.version - a.version);
+    if (versionsLoading || !versions || versions.length <= 1) return null;
 
     return (
-        <div className="summary-version-history">
-            <Timeline>
-                {sorted.map((v) => {
-                    const isCurrent = v.version === currentVersion;
+        <div className="summary-version-strip">
+            <div className="summary-version-strip-title">
+                <IconHistory size="small" />
+                <span>{t("summary.detail.recentVersions")}</span>
+                <span className="summary-version-strip-hint">{t("summary.detail.recentVersionsLimitHint")}</span>
+            </div>
+            <div className="summary-version-list">
+                {versions.slice(0, 3).map((version) => {
+                    const isCurrent = version.version === currentVersion;
                     return (
-                        <Timeline.Item key={v.version} color={isCurrent ? "blue" : "grey"}>
-                            <div className="summary-version-item">
-                                <div className="summary-version-header">
-                                    <span>{t("summary.common.version", { values: { version: v.version } })}</span>
-                                    {isCurrent && (
-                                        <Tag color="blue" size="small" style={{ marginLeft: 8 }}>
-                                            {t("summary.common.current")}
-                                        </Tag>
+                        <div key={version.result_id} className="summary-version-item">
+                            <div className="summary-version-body">
+                                <div className="summary-version-main">
+                                    <span className="summary-version-number">
+                                        {t("summary.common.version", { values: { version: version.version } })}
+                                    </span>
+                                    {isCurrent && <Tag size="small" color="blue">{t("summary.detail.currentVersion")}</Tag>}
+                                    {version.operation_type === "scheduled_generate" && (
+                                        <Tag size="small" color="green">{t("summary.detail.versionScheduledTaskTag")}</Tag>
+                                    )}
+                                    {version.operation_type !== "scheduled_generate" && (
+                                        <span className="summary-version-operation">{formatVersionOperation(version, t)}</span>
                                     )}
                                 </div>
-                                <div className="summary-version-meta">
-                                    {t("summary.versionHistory.meta", {
-                                        values: {
-                                            time: formatDate(v.generated_at),
-                                            count: v.total_msg_count,
-                                            model: v.model_version,
-                                        },
-                                    })}
-                                </div>
-                                {!isCurrent && (
+                                <div className="summary-version-note">{formatVersionOperationNote(version, t)}</div>
+                            </div>
+                            <div className="summary-version-actions">
+                                <Button
+                                    size="small"
+                                    theme="borderless"
+                                    onClick={() => onViewVersion(version)}
+                                >
+                                    {t("summary.detail.viewVersion")}
+                                </Button>
+                                {!isCurrent && canRestore && (
                                     <Button
                                         size="small"
                                         theme="borderless"
-                                        onClick={() => onSelectVersion(v.version)}
-                                        style={{ marginTop: 4 }}
+                                        loading={restoringVersionId === version.result_id}
+                                        onClick={() => onRestoreVersion(version)}
                                     >
-                                        {t("summary.versionHistory.viewVersion")}
+                                        {t("summary.detail.restoreVersion")}
                                     </Button>
                                 )}
                             </div>
-                        </Timeline.Item>
+                        </div>
                     );
                 })}
-            </Timeline>
+            </div>
         </div>
     );
 };

--- a/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
+++ b/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
@@ -48,10 +48,24 @@ const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
         return label === key ? t("summary.detail.versionOperation.generate") : label;
     };
 
+    const formatVersionOperationNote = (version: SummaryVersionItem): string => {
+        const note = (version.operation_note || "").trim();
+        if (note) return note;
+        if ((version.operation_type || "generate") === "generate") {
+            return t("summary.detail.versionInitialGenerateDesc");
+        }
+        if (version.operation_type === "restore" && version.parent_result_id) {
+            return t("summary.detail.versionRestoreFromResult", {
+                values: { id: version.parent_result_id },
+            });
+        }
+        return formatVersionOperation(version);
+    };
+
     return (
         <div className="summary-version-strip">
             <div className="summary-version-strip-title">
-                <IconHistory />
+                <IconHistory size="small" />
                 <span>{t("summary.detail.recentVersions")}</span>
                 <span className="summary-version-strip-hint">
                     {t("summary.detail.recentVersionsLimitHint")}
@@ -86,11 +100,9 @@ const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
                                         </span>
                                     )}
                                 </div>
-                                {version.operation_note && (
-                                    <div className="summary-version-note">
-                                        {version.operation_note}
-                                    </div>
-                                )}
+                                <div className="summary-version-note">
+                                    {formatVersionOperationNote(version)}
+                                </div>
                             </div>
                             <div className="summary-version-actions">
                                 <Button

--- a/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
+++ b/packages/dmworksummary/src/components/SummaryVersionHistory.tsx
@@ -14,33 +14,15 @@ interface SummaryVersionHistoryProps {
     onRestoreVersion: (version: SummaryVersionItem) => void;
 }
 
-function formatVersionOperation(
-    version: SummaryVersionItem,
-    t: (key: string, opts?: { values?: Record<string, string | number> }) => string,
-): string {
-    if ((version.operation_type || "generate") === "generate") {
-        return t("summary.detail.versionInitialGenerate");
-    }
-    const key = `summary.detail.versionOperation.${version.operation_type || "generate"}`;
-    const label = t(key);
-    return label === key ? t("summary.detail.versionOperation.generate") : label;
-}
-
-function formatVersionOperationNote(
-    version: SummaryVersionItem,
-    t: (key: string, opts?: { values?: Record<string, string | number> }) => string,
-): string {
-    const note = (version.operation_note || "").trim();
-    if (note) return note;
-    if ((version.operation_type || "generate") === "generate") {
-        return t("summary.detail.versionInitialGenerateDesc");
-    }
-    if (version.operation_type === "restore" && version.parent_result_id) {
-        return t("summary.detail.versionRestoreFromResult", { values: { id: version.parent_result_id } });
-    }
-    return formatVersionOperation(version, t);
-}
-
+/**
+ * 总结版本历史 strip 组件。
+ *
+ * 从 SummaryDetailPage.renderVersionHistory() / renderPersonalVersionHistory()
+ * 提取为独立组件，保留原有 strip 布局、CSS 类名和交互行为。
+ *
+ * 数据获取和 API 调用由父组件（SummaryDetailPage）负责，
+ * 本组件只负责渲染和回调。
+ */
 const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
     versions,
     versionsLoading,
@@ -52,34 +34,63 @@ const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
 }) => {
     const { t } = useI18n();
 
-    if (versionsLoading || !versions || versions.length <= 1) return null;
+    if (!versions || versionsLoading || versions.length <= 1) {
+        return null;
+    }
+
+    const formatVersionOperation = (version: SummaryVersionItem): string => {
+        const opType = version.operation_type || "generate";
+        if (opType === "generate") {
+            return t("summary.detail.versionInitialGenerate");
+        }
+        const key = `summary.detail.versionOperation.${opType}`;
+        const label = t(key);
+        return label === key ? t("summary.detail.versionOperation.generate") : label;
+    };
 
     return (
         <div className="summary-version-strip">
             <div className="summary-version-strip-title">
-                <IconHistory size="small" />
+                <IconHistory />
                 <span>{t("summary.detail.recentVersions")}</span>
-                <span className="summary-version-strip-hint">{t("summary.detail.recentVersionsLimitHint")}</span>
+                <span className="summary-version-strip-hint">
+                    {t("summary.detail.recentVersionsLimitHint")}
+                </span>
             </div>
             <div className="summary-version-list">
                 {versions.slice(0, 3).map((version) => {
                     const isCurrent = version.version === currentVersion;
+                    const isRestoring = restoringVersionId === version.result_id;
                     return (
                         <div key={version.result_id} className="summary-version-item">
                             <div className="summary-version-body">
                                 <div className="summary-version-main">
                                     <span className="summary-version-number">
-                                        {t("summary.common.version", { values: { version: version.version } })}
+                                        {t("summary.common.version", {
+                                            values: { version: version.version },
+                                        })}
                                     </span>
-                                    {isCurrent && <Tag size="small" color="blue">{t("summary.detail.currentVersion")}</Tag>}
+                                    {isCurrent && (
+                                        <Tag color="blue" size="small">
+                                            {t("summary.detail.currentVersion")}
+                                        </Tag>
+                                    )}
                                     {version.operation_type === "scheduled_generate" && (
-                                        <Tag size="small" color="green">{t("summary.detail.versionScheduledTaskTag")}</Tag>
+                                        <Tag color="green" size="small">
+                                            {t("summary.detail.versionScheduledTaskTag")}
+                                        </Tag>
                                     )}
                                     {version.operation_type !== "scheduled_generate" && (
-                                        <span className="summary-version-operation">{formatVersionOperation(version, t)}</span>
+                                        <span className="summary-version-operation">
+                                            {formatVersionOperation(version)}
+                                        </span>
                                     )}
                                 </div>
-                                <div className="summary-version-note">{formatVersionOperationNote(version, t)}</div>
+                                {version.operation_note && (
+                                    <div className="summary-version-note">
+                                        {version.operation_note}
+                                    </div>
+                                )}
                             </div>
                             <div className="summary-version-actions">
                                 <Button
@@ -93,7 +104,7 @@ const SummaryVersionHistory: React.FC<SummaryVersionHistoryProps> = ({
                                     <Button
                                         size="small"
                                         theme="borderless"
-                                        loading={restoringVersionId === version.result_id}
+                                        loading={isRestoring}
                                         onClick={() => onRestoreVersion(version)}
                                     >
                                         {t("summary.detail.restoreVersion")}

--- a/packages/dmworksummary/src/components/__tests__/SummaryVersionHistory.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryVersionHistory.test.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SummaryVersionHistory from '../SummaryVersionHistory';
+import type { SummaryVersionItem } from '../../types/summary';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return {
+        ...actual,
+        useI18n: () => ({
+            t: (key: string, opts?: { values?: Record<string, string | number> }) => {
+                const map: Record<string, string> = {
+                    'summary.detail.recentVersions': '最近版本',
+                    'summary.detail.recentVersionsLimitHint': '仅展示最近 3 个版本',
+                    'summary.detail.currentVersion': '当前版本',
+                    'summary.detail.versionScheduledTaskTag': '定时任务',
+                    'summary.detail.viewVersion': '查看',
+                    'summary.detail.restoreVersion': '恢复此版本',
+                    'summary.detail.versionInitialGenerate': '初始生成',
+                    'summary.detail.versionInitialGenerateDesc': '第一次生成的基线版本，可用于恢复到微调前内容。',
+                    'summary.detail.versionRestoreFromResult': '恢复自历史结果 #{{id}}',
+                    'summary.detail.versionOperation.generate': '初始生成',
+                    'summary.detail.versionOperation.regenerate': '重新生成',
+                    'summary.detail.versionOperation.scheduled_generate': '定时生成',
+                    'summary.detail.versionOperation.refine': '按意见调整',
+                    'summary.detail.versionOperation.manual_edit': '手动编辑',
+                    'summary.detail.versionOperation.restore': '恢复版本',
+                    'summary.common.version': '版本 {{version}}',
+                };
+                let result = map[key] ?? key;
+                if (opts?.values) {
+                    for (const [k, v] of Object.entries(opts.values)) {
+                        result = result.replace(`{{${k}}}`, String(v));
+                    }
+                }
+                return result;
+            },
+        }),
+    };
+});
+
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: ({ children, onClick, loading }: any) => (
+        <button onClick={onClick} disabled={loading} data-testid="semi-button">
+            {children}
+        </button>
+    ),
+    Tag: ({ children, color }: any) => (
+        <span data-testid="semi-tag" data-color={color}>{children}</span>
+    ),
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconHistory: () => <span data-testid="icon-history" />,
+}));
+
+const noop = vi.fn();
+const baseProps = {
+    versionsLoading: false,
+    currentVersion: 3,
+    restoringVersionId: null,
+    canRestore: true,
+    onViewVersion: noop,
+    onRestoreVersion: noop,
+};
+
+describe('SummaryVersionHistory', () => {
+    it('returns null when versions list has <= 1 item', () => {
+        const { container } = render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[{ result_id: 1, version: 1, operation_type: 'generate', generated_at: '2026-07-17' }]}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('returns null when loading', () => {
+        const { container } = render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versionsLoading={true}
+                versions={[]}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders strip with title and hint when versions >= 2', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        expect(screen.getByText('最近版本')).toBeTruthy();
+        expect(screen.getByText('仅展示最近 3 个版本')).toBeTruthy();
+    });
+
+    it('shows current version tag for the current version', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                currentVersion={3}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        const tags = screen.getAllByTestId('semi-tag');
+        expect(tags.some(t => t.textContent === '当前版本')).toBe(true);
+    });
+
+    it('shows scheduled_generate tag for scheduled versions', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 1, version: 1, operation_type: 'scheduled_generate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        const tags = screen.getAllByTestId('semi-tag');
+        expect(tags.some(t => t.textContent === '定时任务')).toBe(true);
+    });
+
+    it('shows restore button only for non-current versions when canRestore', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                currentVersion={3}
+                canRestore={true}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        const buttons = screen.getAllByTestId('semi-button');
+        const restoreButtons = buttons.filter(b => b.textContent === '恢复此版本');
+        expect(restoreButtons).toHaveLength(1);
+    });
+
+    it('hides restore buttons when canRestore is false', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                canRestore={false}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        const buttons = screen.getAllByTestId('semi-button');
+        const restoreButtons = buttons.filter(b => b.textContent === '恢复此版本');
+        expect(restoreButtons).toHaveLength(0);
+    });
+
+    // ─── Note fallback chain (the regression that was fixed) ───
+
+    it('shows operation_note when present', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', operation_note: '人工微调措辞', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        expect(screen.getByText('人工微调措辞')).toBeTruthy();
+    });
+
+    it('shows versionInitialGenerateDesc fallback for generate type without operation_note', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 1, version: 1, operation_type: 'generate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        expect(screen.getByText('第一次生成的基线版本，可用于恢复到微调前内容。')).toBeTruthy();
+    });
+
+    it('shows versionRestoreFromResult fallback for restore type with parent_result_id', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'restore', parent_result_id: 42, generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        expect(screen.getByText('恢复自历史结果 #42')).toBeTruthy();
+    });
+
+    it('shows operation label fallback for other types without operation_note', () => {
+        render(
+            <SummaryVersionHistory
+                {...baseProps}
+                versions={[
+                    { result_id: 3, version: 3, operation_type: 'manual_edit', generated_at: '2026-07-17' },
+                    { result_id: 2, version: 2, operation_type: 'regenerate', generated_at: '2026-07-16' },
+                ]}
+            />,
+        );
+        // regenerate type without note should fall back to the operation label
+        expect(screen.getByText('重新生成')).toBeTruthy();
+    });
+});

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -45,6 +45,7 @@ import ScheduleConfigModal from "../components/ScheduleConfigModal";
 import MatterPickerModal from "../components/MatterPickerModal";
 import * as matterBridge from "../api/matterBridge";
 import SummaryEditor from "../components/SummaryEditor";
+import SummaryVersionHistory from "../components/SummaryVersionHistory";
 import MemberSelectorModal from "../components/MemberSelectorModal";
 import type { MemberCandidate } from "../types/summary";
 
@@ -2129,138 +2130,43 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         return label === key ? t("summary.detail.versionOperation.generate") : label;
     }
 
-    private formatVersionOperationNote(version: SummaryVersionItem): string {
-        const { t } = this.context;
-        const note = (version.operation_note || "").trim();
-        if (note) return note;
-        if ((version.operation_type || "generate") === "generate") {
-            return t("summary.detail.versionInitialGenerateDesc");
-        }
-        if (version.operation_type === "restore" && version.parent_result_id) {
-            return t("summary.detail.versionRestoreFromResult", { values: { id: version.parent_result_id } });
-        }
-        return this.formatVersionOperation(version);
-    }
-
     renderVersionHistory() {
         const { versions, versionsLoading, detail, restoringVersionId } = this.state;
-        const { t } = this.context;
         if (!detail?.result || versionsLoading || versions.length <= 1) return null;
         const currentVersion = detail.result.version;
+        const canRestore = !!(detail.permissions?.can_edit_team || detail.permissions?.can_edit);
         return (
-            <div className="summary-version-strip">
-                <div className="summary-version-strip-title">
-                    <IconHistory size="small" />
-                    <span>{t("summary.detail.recentVersions")}</span>
-                    <span className="summary-version-strip-hint">{t("summary.detail.recentVersionsLimitHint")}</span>
-                </div>
-                <div className="summary-version-list">
-                    {versions.slice(0, 3).map((version) => {
-                        const isCurrent = version.version === currentVersion;
-                        return (
-                            <div key={version.result_id} className="summary-version-item">
-                                <div className="summary-version-body">
-                                    <div className="summary-version-main">
-                                        <span className="summary-version-number">
-                                            {t("summary.common.version", { values: { version: version.version } })}
-                                        </span>
-                                        {isCurrent && <Tag size="small" color="blue">{t("summary.detail.currentVersion")}</Tag>}
-                                        {version.operation_type === "scheduled_generate" && (
-                                            <Tag size="small" color="green">{t("summary.detail.versionScheduledTaskTag")}</Tag>
-                                        )}
-                                        {version.operation_type !== "scheduled_generate" && (
-                                            <span className="summary-version-operation">{this.formatVersionOperation(version)}</span>
-                                        )}
-                                    </div>
-                                    <div className="summary-version-note">{this.formatVersionOperationNote(version)}</div>
-                                </div>
-                                <div className="summary-version-actions">
-                                    <Button
-                                        size="small"
-                                        theme="borderless"
-                                        onClick={() => this.handleViewVersion(version, false)}
-                                    >
-                                        {t("summary.detail.viewVersion")}
-                                    </Button>
-                                    {!isCurrent && (detail.permissions?.can_edit_team || detail.permissions?.can_edit) && (
-                                        <Button
-                                            size="small"
-                                            theme="borderless"
-                                            loading={restoringVersionId === version.result_id}
-                                            onClick={() => this.handleRestoreVersion(version)}
-                                        >
-                                            {t("summary.detail.restoreVersion")}
-                                        </Button>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            </div>
+            <SummaryVersionHistory
+                versions={versions}
+                versionsLoading={versionsLoading}
+                currentVersion={currentVersion}
+                restoringVersionId={restoringVersionId}
+                canRestore={canRestore}
+                onViewVersion={(version: SummaryVersionItem) => this.handleViewVersion(version, false)}
+                onRestoreVersion={(version: SummaryVersionItem) => this.handleRestoreVersion(version)}
+            />
         );
     }
 
 
     renderPersonalVersionHistory() {
         const { personalVersions, personalVersionsLoading, personalResult, restoringPersonalVersionId, detail } = this.state;
-        const { t } = this.context;
         // 多人协作最终页只保留团队汇总版本控制；个人报告里的版本历史会让用户误以为
         // 恢复个人版本会直接影响最终团队结果，因此在多人协作场景统一隐藏。
         if (this.isMultiCollab()) return null;
         if (!personalResult?.content || personalVersionsLoading || personalVersions.length <= 1) return null;
-        const currentVersion = personalResult.version || personalVersions[0]?.version;
+        const currentVersion = personalResult.version || personalVersions[0]?.version || 0;
+        const canRestore = !!detail?.permissions?.can_edit_personal;
         return (
-            <div className="summary-version-strip">
-                <div className="summary-version-strip-title">
-                    <IconHistory size="small" />
-                    <span>{t("summary.detail.recentVersions")}</span>
-                    <span className="summary-version-strip-hint">{t("summary.detail.recentVersionsLimitHint")}</span>
-                </div>
-                <div className="summary-version-list">
-                    {personalVersions.slice(0, 3).map((version) => {
-                        const isCurrent = version.version === currentVersion;
-                        return (
-                            <div key={version.result_id} className="summary-version-item">
-                                <div className="summary-version-body">
-                                    <div className="summary-version-main">
-                                        <span className="summary-version-number">
-                                            {t("summary.common.version", { values: { version: version.version } })}
-                                        </span>
-                                        {isCurrent && <Tag size="small" color="blue">{t("summary.detail.currentVersion")}</Tag>}
-                                        {version.operation_type === "scheduled_generate" && (
-                                            <Tag size="small" color="green">{t("summary.detail.versionScheduledTaskTag")}</Tag>
-                                        )}
-                                        {version.operation_type !== "scheduled_generate" && (
-                                            <span className="summary-version-operation">{this.formatVersionOperation(version)}</span>
-                                        )}
-                                    </div>
-                                    <div className="summary-version-note">{this.formatVersionOperationNote(version)}</div>
-                                </div>
-                                <div className="summary-version-actions">
-                                    <Button
-                                        size="small"
-                                        theme="borderless"
-                                        onClick={() => this.handleViewVersion(version, true)}
-                                    >
-                                        {t("summary.detail.viewVersion")}
-                                    </Button>
-                                    {!isCurrent && detail?.permissions?.can_edit_personal && (
-                                        <Button
-                                            size="small"
-                                            theme="borderless"
-                                            loading={restoringPersonalVersionId === version.result_id}
-                                            onClick={() => this.handleRestorePersonalVersion(version)}
-                                        >
-                                            {t("summary.detail.restoreVersion")}
-                                        </Button>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            </div>
+            <SummaryVersionHistory
+                versions={personalVersions}
+                versionsLoading={personalVersionsLoading}
+                currentVersion={currentVersion}
+                restoringVersionId={restoringPersonalVersionId}
+                canRestore={canRestore}
+                onViewVersion={(version: SummaryVersionItem) => this.handleViewVersion(version, true)}
+                onRestoreVersion={(version: SummaryVersionItem) => this.handleRestorePersonalVersion(version)}
+            />
         );
     }
 


### PR DESCRIPTION
## Summary

Extract version history rendering logic from `SummaryDetailPage.tsx` (3480 lines) into a standalone `SummaryVersionHistory.tsx` component.

## Changes

- **Rewrote `SummaryVersionHistory.tsx`**: from read-only Timeline to full strip layout
- **New props**: `versions`, `versionsLoading`, `currentVersion`, `restoringVersionId`, `canRestore`, `onViewVersion`, `onRestoreVersion`
- **Inlined `formatVersionOperation`**: displays operation type (initial generation / regenerated / scheduled generation / adjusted by feedback / manual edit / restored version)
- Supports `scheduled_generate` tag, current version tag, and operation notes
- **Permission control**: restore button hidden when `canRestore` is false
- `SummaryDetailPage.tsx` already calls this component with matching props (`renderVersionHistory()` at line 2133, `renderPersonalVersionHistory()` at line 2152)

## Motivation

`SummaryDetailPage.tsx` is too large (3480 lines) with version history rendering logic inlined. Extracting it into a standalone component:
- Reduces page file complexity
- Makes version history UI logic independently maintainable and testable
- Aligns with the octo-web-v2 refactored component separation design

## Testing

- TypeScript type check passed (existing TS7016/TS7031 errors from React 17 type declarations are pre-existing, not introduced by this PR)
- All i18n keys already exist (`summary.detail.recentVersions`, `versionScheduledTaskTag`, `currentVersion`, `viewVersion`, `restoreVersion`, etc.)
- CSS class names reuse existing styles (`.summary-version-strip`, `.summary-version-item`, `.summary-version-actions`, etc.)
- `SummaryDetailPage.tsx`'s `renderVersionHistory()` and `renderPersonalVersionHistory()` already use this component's interface