### PR TITLE
feat(channel-webhook): refine UI and separate data boundaries

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelWebhook/ChannelWebhook.stories.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/ChannelWebhook.stories.tsx
@@ -7,6 +7,7 @@ import {
     IncomingWebhookCreateResp,
 } from "../../Service/IncomingWebhook";
 import ChannelWebhookPanel from "./index";
+import ChannelWebhookCard from "./ChannelWebhookCard";
 import WebhookEditModal from "./WebhookEditModal";
 import WebhookUrlModal from "./WebhookUrlModal";
 import MessageRow from "../../ui/message/MessageRow";
@@ -151,6 +152,39 @@ export const EmptyState: Story = {
             </div>
         );
     },
+};
+
+/** 纯 UI 卡片：不依赖 WKApp、SDK 或接口，可独立检查截图中的列表状态。 */
+export const CardUi: Story = {
+    name: "Webhook 卡片（纯 UI）",
+    render: () => (
+        <div style={{ width: 360, padding: 16 }}>
+            <ul className="wk-webhook__list">
+                <ChannelWebhookCard
+                    item={mockList[0]}
+                    manageable
+                    meta={<div className="wk-webhook-card__meta">魏娇莹 创建于 2026/7/17 16:13:53</div>}
+                    toggling={false}
+                    testingBlocked={false}
+                    cooling={false}
+                    labels={{
+                        disabled: "已禁用",
+                        toggle: "启用 / 禁用",
+                        edit: "编辑",
+                        regenerate: "重置推送地址",
+                        test: "发送测试消息",
+                        testDisabledHint: "启用后可测试",
+                        delete: "删除",
+                    }}
+                    onToggle={() => undefined}
+                    onEdit={() => undefined}
+                    onRegenerate={() => undefined}
+                    onTest={() => undefined}
+                    onDelete={() => undefined}
+                />
+            </ul>
+        </div>
+    ),
 };
 
 export const CreateModalAdmin: Story = {

--- a/packages/dmworkbase/src/Components/ChannelWebhook/ChannelWebhookCard.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/ChannelWebhookCard.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { Switch } from "@douyinfe/semi-ui";
+import { Edit3, RefreshCw, Send, Trash2 } from "lucide-react";
+import {
+    IncomingWebhook,
+    IncomingWebhookStatus,
+    INCOMING_WEBHOOK_DEFAULT_AVATAR,
+    canTestWebhook,
+} from "../../Service/IncomingWebhook";
+
+export interface ChannelWebhookCardLabels {
+    disabled: string;
+    toggle: string;
+    edit: string;
+    regenerate: string;
+    test: string;
+    testDisabledHint: string;
+    delete: string;
+}
+
+export interface ChannelWebhookCardProps {
+    item: IncomingWebhook;
+    manageable: boolean;
+    meta: React.ReactNode;
+    toggling: boolean;
+    testingBlocked: boolean;
+    cooling: boolean;
+    labels: ChannelWebhookCardLabels;
+    onToggle: (enabled: boolean) => void;
+    onEdit: () => void;
+    onRegenerate: () => void;
+    onTest: () => void;
+    onDelete: () => void;
+}
+
+/** Props-only Webhook list item. Runtime data and mutations stay in the panel container. */
+export default function ChannelWebhookCard({
+    item,
+    manageable,
+    meta,
+    toggling,
+    testingBlocked,
+    cooling,
+    labels,
+    onToggle,
+    onEdit,
+    onRegenerate,
+    onTest,
+    onDelete,
+}: ChannelWebhookCardProps) {
+    const enabled = item.status === IncomingWebhookStatus.enabled;
+    const testAllowed = canTestWebhook(item);
+    const testDisabled = !testAllowed || toggling || testingBlocked || cooling;
+
+    return (
+        <li className="wk-webhook-card">
+            <div className="wk-webhook-card__head">
+                <img
+                    src={item.avatar || INCOMING_WEBHOOK_DEFAULT_AVATAR}
+                    alt=""
+                    className="wk-webhook-card__avatar"
+                />
+                <div className="wk-webhook-card__content">
+                    <div className="wk-webhook-card__titlebox">
+                        <span className="wk-webhook-card__name" title={item.name}>{item.name}</span>
+                        {!enabled && (
+                            <span className="wk-webhook-card__chip wk-webhook-card__chip--off">
+                                {labels.disabled}
+                            </span>
+                        )}
+                    </div>
+                    <div className="wk-webhook-card__meta-wrap">{meta}</div>
+                </div>
+                {manageable && (
+                    <Switch
+                        size="small"
+                        checked={enabled}
+                        loading={toggling}
+                        onChange={onToggle}
+                        aria-label={labels.toggle}
+                    />
+                )}
+            </div>
+            {manageable && (
+                <div className="wk-webhook-card__actions">
+                    <button type="button" className="wk-webhook-card__icon-btn" onClick={onEdit} title={labels.edit} aria-label={labels.edit}>
+                        <Edit3 aria-hidden="true" />
+                    </button>
+                    <button type="button" className="wk-webhook-card__icon-btn" onClick={onRegenerate} title={labels.regenerate} aria-label={labels.regenerate}>
+                        <RefreshCw aria-hidden="true" />
+                    </button>
+                    <button
+                        type="button"
+                        className="wk-webhook-card__icon-btn"
+                        disabled={testDisabled}
+                        onClick={onTest}
+                        title={testAllowed ? labels.test : labels.testDisabledHint}
+                        aria-label={labels.test}
+                    >
+                        <Send aria-hidden="true" />
+                    </button>
+                    <button type="button" className="wk-webhook-card__icon-btn wk-webhook-card__icon-btn--danger" onClick={onDelete} title={labels.delete} aria-label={labels.delete}>
+                        <Trash2 aria-hidden="true" />
+                    </button>
+                </div>
+            )}
+        </li>
+    );
+}

--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
-import { Select, Switch, Toast } from "@douyinfe/semi-ui";
+import { Switch, Toast } from "@douyinfe/semi-ui";
 import { IconAlertTriangle } from "@douyinfe/semi-icons";
 import WKModal from "../WKModal";
 import WKButton from "../WKButton";
@@ -13,6 +13,7 @@ import {
     buildWebhookUpsertReq,
     IncomingWebhook,
     IncomingWebhookCreateResp,
+    IncomingWebhookService,
     isFlagOn,
     MENTION_UID_MAX_LENGTH,
     MENTION_UIDS_MAX,
@@ -145,6 +146,7 @@ export default function WebhookEditModal({
         () => readGroupMemberOptions(channel)
     );
     const [saving, setSaving] = useState(false);
+    const [memberSearch, setMemberSearch] = useState("");
     // 本组件由父级条件挂载（{editTarget && <WebhookEditModal/>}），且处于
     // WKViewQueue 路由栈的滑入动画里。若一挂载就 visible=true，Semi Modal 的
     // 首次显示会与路由动画/portal 时序竞争，表现为「要点两次才弹出」。
@@ -208,6 +210,21 @@ export default function WebhookEditModal({
         () => new Map(memberOptionsForSelect.map((m) => [m.uid, m])),
         [memberOptionsForSelect]
     );
+    const visibleMemberOptions = useMemo(() => {
+        const keyword = memberSearch.trim().toLocaleLowerCase();
+        if (!keyword) return memberOptionsForSelect;
+        return memberOptionsForSelect.filter((member) =>
+            member.name.toLocaleLowerCase().includes(keyword)
+        );
+    }, [memberOptionsForSelect, memberSearch]);
+
+    const toggleMentionUid = (uid: string) => {
+        setMentionUids((current) =>
+            current.includes(uid)
+                ? current.filter((item) => item !== uid)
+                : [...current, uid]
+        );
+    };
 
     const handleSubmit = useCallback(async () => {
         if (saving) return;
@@ -252,8 +269,8 @@ export default function WebhookEditModal({
         setSaving(true);
         try {
             if (isEdit && webhook) {
-                await WKApp.dataSource.channelDataSource.updateIncomingWebhook(
-                    channel,
+                await IncomingWebhookService.update(
+                    channel.channelID,
                     webhook.webhook_id,
                     req,
                     threadShortId
@@ -261,8 +278,8 @@ export default function WebhookEditModal({
                 Toast.success(t("base.channelWebhook.toast.updated"));
                 onSaved();
             } else {
-                const resp = await WKApp.dataSource.channelDataSource.createIncomingWebhook(
-                    channel,
+                const resp = await IncomingWebhookService.create(
+                    channel.channelID,
                     req,
                     threadShortId
                 );
@@ -288,7 +305,7 @@ export default function WebhookEditModal({
     return (
         <WKModal
             visible={visible}
-            width={480}
+            width={448}
             title={
                 isEdit
                     ? t("base.channelWebhook.form.editTitle")
@@ -354,93 +371,52 @@ export default function WebhookEditModal({
                 {/* 1️⃣ 自动 @ 成员（定向、噪声小）：#465 每次推送自动 @ 的成员/bot。
                     候选限本群当前成员；回显 mention_uids，提交前做数量上限校验，服务端 400 兜底。 */}
                 <div className="wk-webhook-form__field">
-                    <label className="wk-webhook-form__label">
-                        {t("base.channelWebhook.form.mentionUids")}
-                        <span className="wk-webhook-form__optional">
-                            {t("base.channelWebhook.form.optional")}
+                    <div className="wk-webhook-form__label-row">
+                        <label className="wk-webhook-form__label">
+                            {t("base.channelWebhook.form.mentionUids")}
+                            <span className="wk-webhook-form__optional">
+                                {t("base.channelWebhook.form.optional")}
+                            </span>
+                        </label>
+                        <span className="wk-webhook-form__member-count">
+                            {t("base.channelWebhook.form.mentionUidsCount", {
+                                values: { total: memberOptionsForSelect.length, ai: aiOptionCount },
+                            })}
                         </span>
-                    </label>
-                    <Select
-                        multiple
-                        filter
-                        showClear
-                        className="wk-webhook-form__select"
-                        value={mentionUids}
-                        onChange={(v) =>
-                            setMentionUids(Array.isArray(v) ? (v as string[]) : [])
-                        }
-                        placeholder={t("base.channelWebhook.form.mentionUidsPlaceholder")}
-                        aria-label={t("base.channelWebhook.form.mentionUids")}
-                        outerTopSlot={
-                            <div className="wk-webhook-form__select-head">
-                                {t("base.channelWebhook.form.mentionUidsCount", {
-                                    values: {
-                                        total: memberOptionsForSelect.length,
-                                        ai: aiOptionCount,
-                                    },
+                    </div>
+                    <div className="wk-webhook-form__member-picker" data-testid="select">
+                        <input
+                            className="wk-webhook-form__member-search"
+                            value={memberSearch}
+                            onChange={(event) => setMemberSearch(event.target.value)}
+                            placeholder={t("base.channelWebhook.form.mentionUidsPlaceholder")}
+                            aria-label={t("base.channelWebhook.form.mentionUidsPlaceholder")}
+                        />
+                        {mentionUids.length > 0 && (
+                            <div className="wk-webhook-form__selected-members">
+                                {mentionUids.map((uid) => {
+                                    const member = optionByUid.get(uid);
+                                    return (
+                                        <button key={uid} type="button" className="wk-webhook-form__selected-member" onClick={() => toggleMentionUid(uid)}>
+                                            {member?.name || uid}{member?.isBot && <AiBadge size="small" />}<span aria-hidden="true">×</span>
+                                        </button>
+                                    );
                                 })}
                             </div>
-                        }
-                        renderSelectedItem={(optionNode: {
-                            value?: string;
-                            label?: React.ReactNode;
-                        }) => ({
-                            isRenderInTag: true,
-                            content: (
-                                <span className="wk-webhook-form__member-tag">
-                                    <span className="wk-webhook-form__member-name">
-                                        {optionNode.label}
-                                    </span>
-                                    {optionByUid.get(optionNode.value ?? "")?.isBot && (
-                                        <AiBadge size="small" />
-                                    )}
-                                </span>
-                            ),
-                        })}
-                        renderOptionItem={(rp: {
-                            value?: string;
-                            label?: React.ReactNode;
-                            selected?: boolean;
-                            focused?: boolean;
-                            style?: React.CSSProperties;
-                            onClick?: (e: React.MouseEvent) => void;
-                            onMouseEnter?: (e: React.MouseEvent) => void;
-                        }) => {
-                            // Semi 下拉项渲染：Option 同时传 label(字符串) 时下拉默认只渲染
-                            // label、吞掉 children 里的徽章，故改用 renderOptionItem 完全
-                            // 接管（名字 + AI 徽章 + 选中态），自行接回点击/悬停/选中样式。
-                            const isBot = optionByUid.get(String(rp.value ?? ""))?.isBot;
-                            const cls = [
-                                "wk-webhook-form__option",
-                                rp.selected ? "wk-webhook-form__option--selected" : "",
-                                rp.focused ? "wk-webhook-form__option--focused" : "",
-                            ]
-                                .filter(Boolean)
-                                .join(" ");
-                            return (
-                                <div
-                                    className={cls}
-                                    style={rp.style}
-                                    onClick={rp.onClick}
-                                    onMouseEnter={rp.onMouseEnter}
-                                >
-                                    <span className="wk-webhook-form__member-name">
-                                        {rp.label}
-                                    </span>
-                                    {isBot && <AiBadge size="small" />}
-                                    {rp.selected && (
-                                        <span className="wk-webhook-form__option-tick">✓</span>
-                                    )}
-                                </div>
-                            );
-                        }}
-                    >
-                        {memberOptionsForSelect.map((m) => (
-                            <Select.Option key={m.uid} value={m.uid} label={m.name}>
-                                {m.name}
-                            </Select.Option>
-                        ))}
-                    </Select>
+                        )}
+                        <div className="wk-webhook-form__member-list">
+                            {visibleMemberOptions.map((member) => {
+                                const selected = mentionUids.includes(member.uid);
+                                return (
+                                    <button key={member.uid} type="button" data-testid={`opt-${member.uid}`} className="wk-webhook-form__member-option" onClick={() => toggleMentionUid(member.uid)}>
+                                        <span className={`wk-webhook-form__member-check${selected ? " wk-webhook-form__member-check--selected" : ""}`}>{selected ? "✓" : ""}</span>
+                                        <span className="wk-webhook-form__member-name">{member.name}</span>
+                                        {member.isBot && <AiBadge size="small" />}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
                     <div className="wk-webhook-form__hint">
                         {t("base.channelWebhook.form.mentionUidsHint", {
                             values: { max: MENTION_UIDS_MAX },

--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -305,7 +305,7 @@ export default function WebhookEditModal({
     return (
         <WKModal
             visible={visible}
-            width={448}
+            size="lg"
             title={
                 isEdit
                     ? t("base.channelWebhook.form.editTitle")

--- a/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
@@ -93,6 +93,12 @@ vi.mock('../../../App', () => ({
 
 vi.mock('../../../Service/APIClient', () => ({
   extractErrorMsg: (e: unknown) => String(e),
+  default: {
+    shared: {
+      post: (...a: any[]) => hoisted.create(...a),
+      put: (...a: any[]) => hoisted.update(...a),
+    },
+  },
 }));
 
 vi.mock('wukongimjssdk', async (importOriginal) => {
@@ -225,7 +231,7 @@ describe('WebhookEditModal mention_uids picker', () => {
     await flush();
 
     expect(hoisted.update).toHaveBeenCalledTimes(1);
-    const req = hoisted.update.mock.calls[0][2];
+    const req = hoisted.update.mock.calls[0][1];
     expect(req.mention_uids).toEqual([]);
   });
 

--- a/packages/dmworkbase/src/Components/ChannelWebhook/index.css
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/index.css
@@ -5,7 +5,7 @@
   flex-direction: column;
   gap: var(--wk-sp-4);
   padding: var(--wk-sp-4);
-  overflow-y: auto;
+  overflow: hidden;
   height: 100%;
   box-sizing: border-box;
 }
@@ -33,6 +33,7 @@
   justify-content: center;
   gap: var(--wk-sp-3);
   padding: var(--wk-sp-8) var(--wk-sp-4);
+  flex: 1;
 }
 
 .wk-webhook__state-text {
@@ -48,9 +49,21 @@
   gap: var(--wk-sp-3);
   padding: var(--wk-sp-8) var(--wk-sp-4);
   text-align: center;
+  flex: 1;
+  min-height: 0;
+  border: 1px dashed var(--wk-border-default);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-base);
 }
 
 .wk-webhook__empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--wk-sp-10);
+  height: var(--wk-sp-10);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-elevated);
   color: var(--wk-text-tertiary);
 }
 
@@ -67,23 +80,32 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--wk-sp-3);
+  gap: var(--wk-sp-2);
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .wk-webhook-card {
   display: flex;
   flex-direction: column;
-  gap: var(--wk-sp-2);
   padding: var(--wk-sp-3);
-  border: 1px solid var(--wk-border-default);
+  border: 1px solid var(--wk-border-subtle);
   border-radius: var(--wk-r-md);
-  background: var(--wk-bg-surface);
+  background: var(--wk-bg-elevated);
 }
 
 .wk-webhook-card__head {
   display: flex;
-  align-items: center;
-  gap: var(--wk-sp-2);
+  align-items: flex-start;
+  gap: var(--wk-sp-3);
+}
+
+.wk-webhook-card__avatar {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  border-radius: var(--wk-r-sm);
+  flex-shrink: 0;
 }
 
 .wk-webhook-card__titlebox {
@@ -94,8 +116,13 @@
   min-width: 0;
 }
 
+.wk-webhook-card__content {
+  flex: 1;
+  min-width: 0;
+}
+
 .wk-webhook-card__name {
-  font-size: var(--wk-text-size-md);
+  font-size: var(--wk-text-size-sm);
   font-weight: var(--wk-font-semibold);
   color: var(--wk-text-primary);
   overflow: hidden;
@@ -105,10 +132,10 @@
 
 .wk-webhook-card__chip {
   flex-shrink: 0;
-  font-size: var(--wk-text-size-xs);
-  line-height: 1.6;
-  padding: 0 var(--wk-sp-2);
-  border-radius: var(--wk-r-sm);
+  font-size: var(--wk-text-size-tiny);
+  line-height: var(--wk-leading-normal);
+  padding: var(--wk-sp-0-5) var(--wk-sp-1-5);
+  border-radius: var(--wk-r-xs);
 }
 
 .wk-webhook-card__chip--off {
@@ -118,10 +145,15 @@
 
 .wk-webhook-card__meta {
   font-size: var(--wk-text-size-xs);
+  line-height: var(--wk-leading-normal);
   color: var(--wk-text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.wk-webhook-card__meta-wrap {
+  margin-top: var(--wk-sp-1);
 }
 
 /* 卡片操作行 */
@@ -129,15 +161,17 @@
   display: flex;
   align-items: center;
   gap: var(--wk-sp-1);
-  margin-top: var(--wk-sp-1);
+  margin-top: var(--wk-sp-3);
+  padding-top: var(--wk-sp-2);
+  border-top: 1px solid var(--wk-border-subtle);
 }
 
 .wk-webhook-card__icon-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border: none;
   border-radius: var(--wk-r-sm);
   background: transparent;
@@ -145,8 +179,19 @@
   cursor: pointer;
 }
 
+.wk-webhook-card__icon-btn svg {
+  width: var(--wk-sp-4);
+  height: var(--wk-sp-4);
+  stroke-width: 1.8;
+}
+
 .wk-webhook-card__icon-btn:hover {
-  background: var(--wk-bg-elevated);
+  background: var(--wk-bg-hover);
+}
+
+.wk-webhook-card__icon-btn:focus-visible {
+  outline: none;
+  background: var(--wk-bg-hover);
 }
 
 .wk-webhook-card__icon-btn:disabled {
@@ -154,15 +199,23 @@
   cursor: not-allowed;
 }
 
-.wk-webhook-card__icon-btn--danger:hover {
+.wk-webhook-card__icon-btn--danger {
   color: var(--wk-color-danger);
+}
+
+.wk-webhook-card__icon-btn--danger:hover {
+  background: var(--wk-color-danger-light);
+}
+
+.wk-webhook-card__icon-btn--danger:focus-visible {
+  background: var(--wk-color-danger-light);
 }
 
 /* 表单（创建 / 编辑弹窗） */
 .wk-webhook-form {
   display: flex;
   flex-direction: column;
-  gap: var(--wk-sp-4);
+  gap: var(--wk-sp-3);
 }
 
 .wk-webhook-form__field {
@@ -188,17 +241,31 @@
 .wk-webhook-form__input {
   box-sizing: border-box;
   width: 100%;
+  min-height: 36px;
   padding: var(--wk-sp-2) var(--wk-sp-3);
   border: 1px solid var(--wk-border-default);
   border-radius: var(--wk-r-sm);
   font-size: var(--wk-text-size-sm);
   color: var(--wk-text-primary);
-  background: var(--wk-bg-surface);
+  background: var(--wk-bg-base);
   outline: none;
 }
 
 .wk-webhook-form__input:focus {
   border-color: var(--wk-brand-primary);
+}
+
+.wk-webhook-form__label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--wk-sp-3);
+}
+
+.wk-webhook-form__member-count {
+  flex-shrink: 0;
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-xs);
 }
 
 .wk-webhook-form__hint {
@@ -226,9 +293,15 @@
 }
 
 /* mention_uids 成员多选器（Semi Select）：撑满宽度 */
-.wk-webhook-form__select {
-  width: 100%;
-}
+.wk-webhook-form__member-picker { overflow: hidden; border: 1px solid var(--wk-border-default); border-radius: var(--wk-r-sm); background: var(--wk-bg-base); }
+.wk-webhook-form__member-search { box-sizing: border-box; width: 100%; min-height: 40px; padding: var(--wk-sp-2) var(--wk-sp-3); border: 0; border-bottom: 1px solid var(--wk-border-subtle); outline: none; background: transparent; color: var(--wk-text-primary); font-size: var(--wk-text-size-sm); }
+.wk-webhook-form__selected-members { display: flex; flex-wrap: wrap; gap: var(--wk-sp-1); padding: var(--wk-sp-2) var(--wk-sp-3); border-bottom: 1px solid var(--wk-border-subtle); }
+.wk-webhook-form__selected-member { display: inline-flex; align-items: center; gap: var(--wk-sp-1); padding: var(--wk-sp-1) var(--wk-sp-2); border: 0; border-radius: var(--wk-r-sm); background: var(--wk-bg-elevated); color: var(--wk-text-primary); cursor: pointer; font-size: var(--wk-text-size-xs); }
+.wk-webhook-form__member-list { max-height: 150px; overflow-y: auto; padding: var(--wk-sp-1) 0; }
+.wk-webhook-form__member-option { display: flex; align-items: center; gap: var(--wk-sp-2); width: 100%; min-height: 30px; padding: var(--wk-sp-1) var(--wk-sp-3); border: 0; background: transparent; color: var(--wk-text-primary); cursor: pointer; text-align: left; font-size: var(--wk-text-size-sm); }
+.wk-webhook-form__member-option:hover { background: var(--wk-bg-item-hover); }
+.wk-webhook-form__member-check { display: inline-flex; align-items: center; justify-content: center; width: var(--wk-sp-4); height: var(--wk-sp-4); flex-shrink: 0; border: 1px solid var(--wk-border-default); border-radius: var(--wk-r-circle); color: var(--wk-text-inverse); font-size: var(--wk-text-size-tiny); }
+.wk-webhook-form__member-check--selected { border-color: var(--wk-brand-primary); background: var(--wk-brand-primary); }
 
 /* 下拉顶部人数标识（outerTopSlot） */
 .wk-webhook-form__select-head {
@@ -281,6 +354,7 @@
   padding: var(--wk-sp-3);
   border-radius: var(--wk-r-md);
   background: var(--wk-color-warning-bg);
+  border: 1px solid var(--wk-color-warning-bg);
 }
 
 .wk-webhook-form__broadcast-note {
@@ -304,7 +378,19 @@
 .wk-webhook-modal .wk-modal-shell {
   display: flex;
   flex-direction: column;
-  max-height: 66vh;
+  max-height: 90vh;
+  padding: var(--wk-sp-5);
+}
+
+.wk-webhook-modal .wk-modal-title {
+  margin-bottom: var(--wk-sp-4);
+  font-size: var(--wk-text-size-lg);
+}
+
+.wk-webhook-modal .wk-modal-footer {
+  margin-top: var(--wk-sp-4);
+  padding-top: var(--wk-sp-4);
+  border-top: 1px solid var(--wk-border-subtle);
 }
 
 .wk-webhook-modal .wk-modal-title,

--- a/packages/dmworkbase/src/Components/ChannelWebhook/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/index.tsx
@@ -1,31 +1,23 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Channel, WKSDK } from "wukongimjssdk";
-import { Spin, Switch, Toast } from "@douyinfe/semi-ui";
-import {
-    IconPlus,
-    IconLink,
-    IconEdit,
-    IconRefresh,
-    IconDelete,
-    IconSend,
-} from "@douyinfe/semi-icons";
-import WKApp from "../../App";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Channel } from "wukongimjssdk";
+import { Spin, Toast } from "@douyinfe/semi-ui";
+import { IconPlus, IconLink } from "@douyinfe/semi-icons";
 import WKButton from "../WKButton";
-import WKAvatar from "../WKAvatar";
 import { wkConfirm } from "../WKModal";
 import { useI18n } from "../../i18n";
 import { extractErrorMsg } from "../../Service/APIClient";
-import { subscriberDisplayName, SubscriberLike } from "../../Utils/displayName";
 import {
     IncomingWebhook,
     IncomingWebhookCreateResp,
     IncomingWebhookStatus,
-    INCOMING_WEBHOOK_DEFAULT_AVATAR,
+    IncomingWebhookService,
     canManageIncomingWebhook,
     canTestWebhook,
 } from "../../Service/IncomingWebhook";
 import WebhookEditModal from "./WebhookEditModal";
 import WebhookUrlModal from "./WebhookUrlModal";
+import ChannelWebhookCard from "./ChannelWebhookCard";
+import { useChannelWebhookList } from "../../bridge/channelWebhook/useChannelWebhookList";
 import "./index.css";
 
 export interface ChannelWebhookPanelProps {
@@ -61,9 +53,16 @@ export default function ChannelWebhookPanel({
     threadShortId,
 }: ChannelWebhookPanelProps) {
     const { t, format } = useI18n();
-    const [items, setItems] = useState<IncomingWebhook[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
+    const handleLoadError = useCallback((loadError: unknown) => {
+        Toast.error(extractErrorMsg(loadError) || t("base.channelWebhook.error.loadFailed"));
+    }, [t]);
+    const { items, loading, error, myUid, creatorNames, reload: load } =
+        useChannelWebhookList({
+            channel,
+            threadShortId,
+            selfFallback: t("base.channelWebhook.meta.me"),
+            onLoadError: handleLoadError,
+        });
     const [editTarget, setEditTarget] = useState<EditTarget>(null);
     // 创建 / 重置 token 后的一次性 URL 展示（token 仅此一次返回）
     const [urlResult, setUrlResult] = useState<IncomingWebhookCreateResp | null>(null);
@@ -73,59 +72,21 @@ export default function ChannelWebhookPanel({
     // 冷却期间按钮置灰、忽略再次点击。
     const [coolingTestId, setCoolingTestId] = useState<string | null>(null);
     const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const scopeKey = `${channel.channelID}:${threadShortId || "group"}`;
 
     useEffect(() => () => {
         if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
     }, []);
 
-    const myUid = WKApp.loginInfo.uid || "";
-
-    const load = useCallback(async () => {
-        setError(false);
-        try {
-            const list = await WKApp.dataSource.channelDataSource.incomingWebhooks(channel, threadShortId);
-            setItems(list);
-        } catch (e) {
-            setError(true);
-            Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.loadFailed"));
-        } finally {
-            setLoading(false);
-        }
-    }, [channel, threadShortId, t]);
-
+    // 群/子区切换时立即清掉旧对象的 UI 状态，避免旧列表、弹窗或 pending 状态串台。
     useEffect(() => {
-        void load();
-    }, [load]);
-
-    // 创建者展示名映射：单次遍历群成员列表（O(成员数+条目数)），避免每个
-    // 卡片每次渲染都对大群成员做全量 .find() 扫描。群成员命中用群内展示名；
-    // 自己兜底 loginInfo（订阅列表通常不含 self）；都拿不到（创建者已退群 /
-    // 成员列表未同步）则缺省为空串，渲染时降级为只显示创建时间。
-    const creatorNames = useMemo(() => {
-        const wanted = new Set(items.map((item) => item.creator_uid));
-        const map = new Map<string, string>();
-        try {
-            const subs = WKSDK.shared().channelManager.getSubscribes(channel) as
-                | Array<({ uid?: string } & SubscriberLike)>
-                | null
-                | undefined;
-            for (const sub of subs || []) {
-                if (sub?.uid && wanted.has(sub.uid) && !map.has(sub.uid)) {
-                    const name = subscriberDisplayName(sub);
-                    if (name) map.set(sub.uid, name);
-                }
-            }
-        } catch {
-            // channelManager 缓存未加载：静默降级
-        }
-        if (wanted.has(myUid) && !map.has(myUid)) {
-            map.set(
-                myUid,
-                WKApp.loginInfo.selfDisplayName?.() || t("base.channelWebhook.meta.me")
-            );
-        }
-        return map;
-    }, [items, channel, myUid, t]);
+        setEditTarget(null);
+        setUrlResult(null);
+        setTestingId(null);
+        setTogglingId(null);
+        setCoolingTestId(null);
+        if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
+    }, [scopeKey]);
 
     const handleToggle = async (item: IncomingWebhook, next: boolean) => {
         // in-flight 守卫：Semi 的 Switch loading 不保证拦截 onChange，
@@ -133,8 +94,8 @@ export default function ChannelWebhookPanel({
         if (togglingId) return;
         setTogglingId(item.webhook_id);
         try {
-            await WKApp.dataSource.channelDataSource.updateIncomingWebhook(
-                channel,
+            await IncomingWebhookService.update(
+                channel.channelID,
                 item.webhook_id,
                 { status: next ? IncomingWebhookStatus.enabled : IncomingWebhookStatus.disabled },
                 threadShortId
@@ -160,7 +121,7 @@ export default function ChannelWebhookPanel({
         if (testingId || coolingTestId === item.webhook_id) return;
         setTestingId(item.webhook_id);
         try {
-            await WKApp.dataSource.channelDataSource.testIncomingWebhook(channel, item.webhook_id, threadShortId);
+            await IncomingWebhookService.test(channel.channelID, item.webhook_id, threadShortId);
             Toast.success(t("base.channelWebhook.toast.testSent"));
         } catch (e) {
             Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.testFailed"));
@@ -186,8 +147,8 @@ export default function ChannelWebhookPanel({
             okType: "danger",
             onOk: async () => {
                 try {
-                    const resp = await WKApp.dataSource.channelDataSource.regenerateIncomingWebhook(
-                        channel,
+                    const resp = await IncomingWebhookService.regenerate(
+                        channel.channelID,
                         item.webhook_id,
                         threadShortId
                     );
@@ -213,8 +174,8 @@ export default function ChannelWebhookPanel({
             okType: "danger",
             onOk: async () => {
                 try {
-                    await WKApp.dataSource.channelDataSource.deleteIncomingWebhook(
-                        channel,
+                    await IncomingWebhookService.delete(
+                        channel.channelID,
                         item.webhook_id,
                         threadShortId
                     );
@@ -285,7 +246,7 @@ export default function ChannelWebhookPanel({
                     <p className="wk-webhook__state-text">
                         {t("base.channelWebhook.error.loadFailed")}
                     </p>
-                    <WKButton variant="secondary" onClick={() => { setLoading(true); void load(); }}>
+                    <WKButton variant="secondary" onClick={() => { void load(true); }}>
                         {t("base.channelWebhook.retry")}
                     </WKButton>
                 </div>
@@ -305,102 +266,31 @@ export default function ChannelWebhookPanel({
                 </div>
             ) : (
                 <ul className="wk-webhook__list">
-                    {items.map((item) => {
-                        const manageable = canManageIncomingWebhook(item, { isManager, myUid });
-                        const enabled = item.status === IncomingWebhookStatus.enabled;
-                        // 测试按钮的可用性单独走 canTestWebhook（与 handleTest 守卫同源）。
-                        const canTest = canTestWebhook(item);
-                        return (
-                            <li key={item.webhook_id} className="wk-webhook-card">
-                                <div className="wk-webhook-card__head">
-                                    <WKAvatar
-                                        src={item.avatar || INCOMING_WEBHOOK_DEFAULT_AVATAR}
-                                        style={{
-                                            width: "32px",
-                                            height: "32px",
-                                            borderRadius: "var(--wk-r-sm)",
-                                            flexShrink: 0,
-                                        }}
-                                    />
-                                    <div className="wk-webhook-card__titlebox">
-                                        <span className="wk-webhook-card__name" title={item.name}>
-                                            {item.name}
-                                        </span>
-                                        {!enabled && (
-                                            <span className="wk-webhook-card__chip wk-webhook-card__chip--off">
-                                                {t("base.channelWebhook.status.disabled")}
-                                            </span>
-                                        )}
-                                    </div>
-                                    {manageable && (
-                                        <Switch
-                                            size="small"
-                                            checked={enabled}
-                                            loading={togglingId === item.webhook_id}
-                                            onChange={(v: boolean) => void handleToggle(item, v)}
-                                            aria-label={t("base.channelWebhook.action.toggle")}
-                                        />
-                                    )}
-                                </div>
-                                {renderMeta(item)}
-                                {manageable && (
-                                    <div className="wk-webhook-card__actions">
-                                        <button
-                                            type="button"
-                                            className="wk-webhook-card__icon-btn"
-                                            onClick={() => setEditTarget({ mode: "edit", webhook: item })}
-                                            title={t("base.channelWebhook.action.edit")}
-                                            aria-label={t("base.channelWebhook.action.edit")}
-                                        >
-                                            <IconEdit />
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="wk-webhook-card__icon-btn"
-                                            onClick={() => handleRegenerate(item)}
-                                            title={t("base.channelWebhook.action.regenerate")}
-                                            aria-label={t("base.channelWebhook.action.regenerate")}
-                                        >
-                                            <IconRefresh />
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="wk-webhook-card__icon-btn"
-                                            disabled={
-                                                // 已禁用的 webhook 不可测试（语义一致 + 避免假信心）；
-                                                // 切换启停在飞期间 status 尚未刷新，一并置灰避免用旧状态测试；
-                                                // handleTest 全局串行化（任一测试在飞即忽略），
-                                                // 故任一在飞时所有测试按钮都置灰，避免点了没反应；
-                                                // 叠加本 webhook 的冷却态。
-                                                !canTest ||
-                                                togglingId === item.webhook_id ||
-                                                !!testingId ||
-                                                coolingTestId === item.webhook_id
-                                            }
-                                            onClick={() => void handleTest(item)}
-                                            title={
-                                                canTest
-                                                    ? t("base.channelWebhook.action.test")
-                                                    : t("base.channelWebhook.action.testDisabledHint")
-                                            }
-                                            aria-label={t("base.channelWebhook.action.test")}
-                                        >
-                                            <IconSend />
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="wk-webhook-card__icon-btn wk-webhook-card__icon-btn--danger"
-                                            onClick={() => handleDelete(item)}
-                                            title={t("base.channelWebhook.action.delete")}
-                                            aria-label={t("base.channelWebhook.action.delete")}
-                                        >
-                                            <IconDelete />
-                                        </button>
-                                    </div>
-                                )}
-                            </li>
-                        );
-                    })}
+                    {items.map((item) => (
+                        <ChannelWebhookCard
+                            key={item.webhook_id}
+                            item={item}
+                            manageable={canManageIncomingWebhook(item, { isManager, myUid })}
+                            meta={renderMeta(item)}
+                            toggling={togglingId === item.webhook_id}
+                            testingBlocked={!!testingId}
+                            cooling={coolingTestId === item.webhook_id}
+                            labels={{
+                                disabled: t("base.channelWebhook.status.disabled"),
+                                toggle: t("base.channelWebhook.action.toggle"),
+                                edit: t("base.channelWebhook.action.edit"),
+                                regenerate: t("base.channelWebhook.action.regenerate"),
+                                test: t("base.channelWebhook.action.test"),
+                                testDisabledHint: t("base.channelWebhook.action.testDisabledHint"),
+                                delete: t("base.channelWebhook.action.delete"),
+                            }}
+                            onToggle={(enabled) => void handleToggle(item, enabled)}
+                            onEdit={() => setEditTarget({ mode: "edit", webhook: item })}
+                            onRegenerate={() => handleRegenerate(item)}
+                            onTest={() => void handleTest(item)}
+                            onDelete={() => handleDelete(item)}
+                        />
+                    ))}
                 </ul>
             )}
 

--- a/packages/dmworkbase/src/Service/IncomingWebhook.ts
+++ b/packages/dmworkbase/src/Service/IncomingWebhook.ts
@@ -1,11 +1,12 @@
+import APIClient from "./APIClient";
+
 /**
  * 群入站 Webhook（Incoming Webhook）类型与纯工具函数。
  *
  * 对应 octo-server 用户管理面 `/v1/groups/{group_no}/incoming-webhooks*`
  * （#250 iwh 身份 / #254 软删除 / #297 平台适配器 / #340 开放给成员与 bot）。
  *
- * 注意：本文件刻意不依赖 WKApp / WKSDK，保持纯函数可单测；
- * 需要运行时配置（apiURL / origin）的调用方自行传入。
+ * 本文件不依赖 WKApp / WKSDK；HTTP 边界统一使用 APIClient，交互状态留给调用方。
  */
 
 /** webhook 发送者 UID 前缀。`FromUID = iwh_*` 的消息发送者永远不是群成员。 */
@@ -125,6 +126,51 @@ export interface IncomingWebhookUpsertReq {
      */
     mention_uids?: string[];
 }
+
+type IncomingWebhookListResponse =
+    | IncomingWebhook[]
+    | { list?: IncomingWebhook[]; items?: IncomingWebhook[]; webhooks?: IncomingWebhook[] }
+    | null
+    | undefined;
+
+/** 群/子区入站 Webhook 的 HTTP 边界。 */
+export const IncomingWebhookService = {
+    basePath(groupNo: string, threadShortId?: string): string {
+        const groupPath = `groups/${encodeURIComponent(groupNo)}`;
+        return threadShortId
+            ? `${groupPath}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks`
+            : `${groupPath}/incoming-webhooks`;
+    },
+
+    async list(groupNo: string, threadShortId?: string): Promise<IncomingWebhook[]> {
+        const response = await APIClient.shared.get<IncomingWebhookListResponse>(
+            this.basePath(groupNo, threadShortId)
+        );
+        if (Array.isArray(response)) return response;
+        if (!response) return [];
+        return response.list || response.items || response.webhooks || [];
+    },
+
+    create(groupNo: string, request: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
+        return APIClient.shared.post(this.basePath(groupNo, threadShortId), request);
+    },
+
+    update(groupNo: string, webhookId: string, request: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhook> {
+        return APIClient.shared.put(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`, request);
+    },
+
+    delete(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
+        return APIClient.shared.delete(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`);
+    },
+
+    regenerate(groupNo: string, webhookId: string, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
+        return APIClient.shared.post(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/regenerate`);
+    },
+
+    test(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
+        return APIClient.shared.post(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/test`);
+    },
+};
 
 /**
  * 权限判断（与服务端权限矩阵 #340 对齐，仅做 UI 门控，服务端兜底）：
@@ -482,17 +528,18 @@ export function webhookFromOfMessage(message: {
     return { kind: "webhook" };
 }
 
-/**
- * webhook 消息 / 列表项的占位头像（内联 SVG，灰底链接节点图形）。
- * 服务端不给 iwh_* 提供头像接口，空 avatar 时用它避免 broken-image。
- */
+/** V2 同款 Webhook 默认头像；服务端 avatar 为空时使用，避免走用户头像链路。 */
 export const INCOMING_WEBHOOK_DEFAULT_AVATAR =
     "data:image/svg+xml;charset=UTF-8," +
     encodeURIComponent(
-        `<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">` +
-            `<rect width="50" height="50" rx="12" fill="#E8EAF0"/>` +
-            `<path d="M20 30 L30 20 M27 17 a5 5 0 0 1 7 7 l-2.5 2.5 M23 33 a5 5 0 0 1 -7 -7 l2.5 -2.5" ` +
-            `stroke="#7A8299" stroke-width="2.6" stroke-linecap="round" fill="none"/>` +
+        `<svg width="50" height="50" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">` +
+            `<rect width="50" height="50" rx="12" fill="#6B3DD8"/>` +
+            `<path d="M25 11v5" stroke="white" stroke-width="2.5" stroke-linecap="round"/>` +
+            `<circle cx="25" cy="10" r="2" fill="white"/>` +
+            `<rect x="14" y="17" width="22" height="20" rx="6" fill="none" stroke="white" stroke-width="2.8"/>` +
+            `<circle cx="21" cy="27" r="2.2" fill="white"/>` +
+            `<circle cx="29" cy="27" r="2.2" fill="white"/>` +
+            `<path d="M20 33h10" stroke="white" stroke-width="2.5" stroke-linecap="round"/>` +
             `</svg>`
     );
 

--- a/packages/dmworkbase/src/Service/__tests__/IncomingWebhookService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/IncomingWebhookService.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../APIClient", () => ({
+    default: {
+        shared: {
+            get: vi.fn(),
+            post: vi.fn(),
+            put: vi.fn(),
+            delete: vi.fn(),
+        },
+    },
+}));
+
+import APIClient from "../APIClient";
+import { IncomingWebhookService } from "../IncomingWebhook";
+
+const client = APIClient.shared as unknown as {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("IncomingWebhookService", () => {
+    it("keeps group and thread collection paths distinct", () => {
+        expect(IncomingWebhookService.basePath("group 1")).toBe("groups/group%201/incoming-webhooks");
+        expect(IncomingWebhookService.basePath("group 1", "thread/1")).toBe(
+            "groups/group%201/threads/thread%2F1/incoming-webhooks"
+        );
+    });
+
+    it("normalizes supported list envelopes", async () => {
+        client.get.mockResolvedValueOnce({ list: [{ webhook_id: "a" }] });
+        await expect(IncomingWebhookService.list("g1")).resolves.toEqual([{ webhook_id: "a" }]);
+
+        client.get.mockResolvedValueOnce([{ webhook_id: "b" }]);
+        await expect(IncomingWebhookService.list("g1", "t1")).resolves.toEqual([{ webhook_id: "b" }]);
+        expect(client.get).toHaveBeenLastCalledWith("groups/g1/threads/t1/incoming-webhooks");
+    });
+
+    it("routes create, update, delete, regenerate and test through APIClient", async () => {
+        const req = { name: "ci" };
+        await IncomingWebhookService.create("g1", req, "t1");
+        await IncomingWebhookService.update("g1", "wh/1", { status: 1 }, "t1");
+        await IncomingWebhookService.delete("g1", "wh/1", "t1");
+        await IncomingWebhookService.regenerate("g1", "wh/1", "t1");
+        await IncomingWebhookService.test("g1", "wh/1", "t1");
+
+        const base = "groups/g1/threads/t1/incoming-webhooks";
+        expect(client.post).toHaveBeenCalledWith(base, req);
+        expect(client.put).toHaveBeenCalledWith(`${base}/wh%2F1`, { status: 1 });
+        expect(client.delete).toHaveBeenCalledWith(`${base}/wh%2F1`);
+        expect(client.post).toHaveBeenCalledWith(`${base}/wh%2F1/regenerate`);
+        expect(client.post).toHaveBeenCalledWith(`${base}/wh%2F1/test`);
+    });
+});

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Channel, WKSDK } from "wukongimjssdk";
+import WKApp from "../../App";
+import { IncomingWebhook, IncomingWebhookService } from "../../Service/IncomingWebhook";
+import { subscriberDisplayName, SubscriberLike } from "../../Utils/displayName";
+
+export interface UseChannelWebhookListOptions {
+    channel: Channel;
+    threadShortId?: string;
+    selfFallback: string;
+    onLoadError: (error: unknown) => void;
+}
+
+/** Runtime bridge for Webhook list data. UI state for edit/confirm overlays stays in the container. */
+export function useChannelWebhookList({
+    channel,
+    threadShortId,
+    selfFallback,
+    onLoadError,
+}: UseChannelWebhookListOptions) {
+    const [items, setItems] = useState<IncomingWebhook[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+    const requestSequenceRef = useRef(0);
+    const mountedRef = useRef(true);
+    const groupNo = channel.channelID;
+    const scopeKey = `${groupNo}:${threadShortId || "group"}`;
+    const myUid = WKApp.loginInfo.uid || "";
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            requestSequenceRef.current += 1;
+        };
+    }, []);
+
+    const load = useCallback(async (showLoading = false) => {
+        const requestSequence = ++requestSequenceRef.current;
+        if (showLoading) setLoading(true);
+        setError(false);
+        try {
+            const list = await IncomingWebhookService.list(groupNo, threadShortId);
+            if (!mountedRef.current || requestSequence !== requestSequenceRef.current) return;
+            setItems(list);
+        } catch (loadError) {
+            if (!mountedRef.current || requestSequence !== requestSequenceRef.current) return;
+            setError(true);
+            onLoadError(loadError);
+        } finally {
+            if (mountedRef.current && requestSequence === requestSequenceRef.current) {
+                setLoading(false);
+            }
+        }
+    }, [groupNo, onLoadError, threadShortId]);
+
+    useEffect(() => {
+        requestSequenceRef.current += 1;
+        setItems([]);
+        setLoading(true);
+        setError(false);
+        void load();
+    }, [load, scopeKey]);
+
+    const creatorNames = useMemo(() => {
+        const wanted = new Set(items.map((item) => item.creator_uid));
+        const names = new Map<string, string>();
+        try {
+            const subscribers = WKSDK.shared().channelManager.getSubscribes(channel) as
+                | Array<({ uid?: string } & SubscriberLike)>
+                | null
+                | undefined;
+            for (const subscriber of subscribers || []) {
+                if (!subscriber?.uid || !wanted.has(subscriber.uid) || names.has(subscriber.uid)) continue;
+                const name = subscriberDisplayName(subscriber);
+                if (name) names.set(subscriber.uid, name);
+            }
+        } catch {
+            // SDK member cache may not be ready; metadata gracefully falls back to creation time.
+        }
+        if (wanted.has(myUid) && !names.has(myUid)) {
+            names.set(myUid, WKApp.loginInfo.selfDisplayName?.() || selfFallback);
+        }
+        return names;
+    }, [channel, items, myUid, selfFallback]);
+
+    return { items, loading, error, myUid, creatorNames, reload: load };
+}

--- a/packages/dmworkdatasource/src/datasource.test.ts
+++ b/packages/dmworkdatasource/src/datasource.test.ts
@@ -60,6 +60,32 @@ vi.mock("@octo/base", () => ({
     GroupRole: {},
     RequestConfig: class {},
     WKApp: hoisted.mockWKApp,
+    IncomingWebhookService: {
+        list: (groupNo: string, threadShortId?: string) =>
+            hoisted.apiGet(threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`).then((resp: { list?: unknown[] }) => resp?.list || []),
+        create: (groupNo: string, req: unknown, threadShortId?: string) =>
+            hoisted.apiPost(threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`, req),
+        update: (groupNo: string, webhookId: string, req: unknown, threadShortId?: string) =>
+            hoisted.apiPut(`${threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`}/${webhookId}`, req),
+        delete: (groupNo: string, webhookId: string, threadShortId?: string) =>
+            hoisted.apiDelete(`${threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`}/${webhookId}`),
+        regenerate: (groupNo: string, webhookId: string, threadShortId?: string) =>
+            hoisted.apiPost(`${threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`}/${webhookId}/regenerate`),
+        test: (groupNo: string, webhookId: string, threadShortId?: string) =>
+            hoisted.apiPost(`${threadShortId
+                ? `groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+                : `groups/${groupNo}/incoming-webhooks`}/${webhookId}/test`),
+    },
     buildThreadChannelId: (groupNo: string, shortId: string) => `${groupNo}____${shortId}`,
     hasSpacePrefix: vi.fn(() => false),
     parseThreadChannelId: vi.fn(() => null),

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -1,4 +1,4 @@
-import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ThreadListStatus, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId, IncomingWebhook, IncomingWebhookCreateResp, IncomingWebhookUpsertReq, StickerItem } from "@octo/base";
+import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ThreadListStatus, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId, IncomingWebhook, IncomingWebhookCreateResp, IncomingWebhookUpsertReq, IncomingWebhookService, StickerItem } from "@octo/base";
 import axios from "axios";
 import { Channel, ChannelInfo, ChannelTypeGroup, ChannelTypePerson, WKSDK, Message, MessageContentType,ConversationExtra,Subscriber } from "wukongimjssdk";
 
@@ -245,36 +245,28 @@ export class ChannelDataSource implements IChannelDataSource {
     // threadShortId 留空即群面（与历史一致）；传入即切到子区作用域 —— 后端据此隔离 list/管理，
     // 并把 webhook 投递目标绑定到子区（#451 / octo-server #454）。channelID 必须是【父群 group_no】
     // （子区面板传父群 channel），推送 URL 不变，仍按 webhook_id/token。
-    private incomingWebhookBase(channelID: string, threadShortId?: string): string {
-        return threadShortId
-            ? `groups/${channelID}/threads/${threadShortId}/incoming-webhooks`
-            : `groups/${channelID}/incoming-webhooks`
-    }
-
     incomingWebhooks(channel: Channel, threadShortId?: string): Promise<IncomingWebhook[]> {
-        return WKApp.apiClient
-            .get(this.incomingWebhookBase(channel.channelID, threadShortId))
-            .then((resp?: { list?: IncomingWebhook[] }) => resp?.list || [])
+        return IncomingWebhookService.list(channel.channelID, threadShortId)
     }
 
     createIncomingWebhook(channel: Channel, req: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
-        return WKApp.apiClient.post(this.incomingWebhookBase(channel.channelID, threadShortId), req)
+        return IncomingWebhookService.create(channel.channelID, req, threadShortId)
     }
 
     updateIncomingWebhook(channel: Channel, webhookId: string, req: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhook> {
-        return WKApp.apiClient.put(`${this.incomingWebhookBase(channel.channelID, threadShortId)}/${webhookId}`, req)
+        return IncomingWebhookService.update(channel.channelID, webhookId, req, threadShortId)
     }
 
     deleteIncomingWebhook(channel: Channel, webhookId: string, threadShortId?: string): Promise<void> {
-        return WKApp.apiClient.delete(`${this.incomingWebhookBase(channel.channelID, threadShortId)}/${webhookId}`)
+        return IncomingWebhookService.delete(channel.channelID, webhookId, threadShortId)
     }
 
     regenerateIncomingWebhook(channel: Channel, webhookId: string, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
-        return WKApp.apiClient.post(`${this.incomingWebhookBase(channel.channelID, threadShortId)}/${webhookId}/regenerate`)
+        return IncomingWebhookService.regenerate(channel.channelID, webhookId, threadShortId)
     }
 
     testIncomingWebhook(channel: Channel, webhookId: string, threadShortId?: string): Promise<void> {
-        return WKApp.apiClient.post(`${this.incomingWebhookBase(channel.channelID, threadShortId)}/${webhookId}/test`)
+        return IncomingWebhookService.test(channel.channelID, webhookId, threadShortId)
     }
 
     getThreadMd(groupNo: string, shortId: string): Promise<{ content: string; version: number }> {


### PR DESCRIPTION
Move incoming webhook requests into a dedicated service and bridge list loading through a scoped hook with stale-request protection.\n\nSplit the list card into a props-only UI component, align the list, empty state, and edit form with the approved design, and preserve the existing permission and request semantics.\n\nValidation: focused Vitest suites, i18n check, web build, Storybook build, and git diff check.

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Architecture / Module Boundary

<!-- Fill this when the PR changes business code, shared components, service APIs, routing, or user-visible entry points. -->

- Affected module(s):
- New or changed user-visible entry point: <!-- yes / no; if yes, describe it -->
- Shared layer touched: <!-- ui / Components / Messages / bridge / service / none -->
- If shared code changed, impact scope:
- Duplicate entry point checked: <!-- yes / no / not applicable -->

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [ ] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [ ] Described impact scope when shared components, messages, bridge, or services are changed
- [ ] Followed commit message conventions (Conventional Commits)
