### PR TITLE
fix(docs): refetch comments when the comment panel opens

### DIFF
--- a/packages/docs/src/comments/useDocComments.ts
+++ b/packages/docs/src/comments/useDocComments.ts
@@ -150,3 +150,25 @@ export function useDocComments(docId: string): UseDocComments {
     remove,
   }
 }
+
+// Re-read comments the moment the panel goes from closed → open (XIN-1323). Comments live in a
+// mount-only REST hook with no realtime push, so a session-long open panel — or one reopened after
+// someone else added a comment — would otherwise keep showing stale threads. Both the docs
+// CommentPanel and the sheet SheetCommentPanel are driven off their shell's drawer state and share a
+// single useDocComments instance, so wiring this one hook into each shell covers both from one place.
+//
+// We refresh only on the false → true edge (not on every render, not when the panel is already open),
+// so opening once triggers exactly one fetch and no duplicate concurrent loads. `refresh` is read
+// through a ref so its identity changing (docId / includeResolved) never re-fires this effect —
+// those already have their own refresh in useDocComments — and we avoid a stale-closure over it.
+export function useRefreshCommentsOnOpen(comments: UseDocComments, open: boolean): void {
+  const refreshRef = useRef(comments.refresh)
+  refreshRef.current = comments.refresh
+  // Seed with the initial `open` so a panel that starts open doesn't double-fetch on top of the
+  // hook's own mount-time load; only a genuine closed → open transition triggers a refresh.
+  const prevOpen = useRef(open)
+  useEffect(() => {
+    if (open && !prevOpen.current) void refreshRef.current()
+    prevOpen.current = open
+  }, [open])
+}

--- a/packages/docs/src/comments/useRefreshCommentsOnOpen.test.ts
+++ b/packages/docs/src/comments/useRefreshCommentsOnOpen.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useRefreshCommentsOnOpen, type UseDocComments } from './useDocComments.ts'
+
+// A minimal UseDocComments stand-in — the hook only reads `.refresh`, so we stub the rest.
+function makeComments(refresh: () => Promise<void>): UseDocComments {
+  return {
+    threads: [],
+    loading: false,
+    error: null,
+    nextCursor: null,
+    includeResolved: false,
+    setIncludeResolved: () => {},
+    refresh,
+    loadMore: async () => {},
+    createRoot: async () => {},
+    reply: async () => {},
+    editBody: async () => {},
+    resolve: async () => {},
+    remove: async () => {},
+  }
+}
+
+describe('useRefreshCommentsOnOpen — refetch on panel open (XIN-1323)', () => {
+  let refresh: ReturnType<typeof vi.fn<() => Promise<void>>>
+
+  beforeEach(() => {
+    refresh = vi.fn<() => Promise<void>>(async () => {})
+  })
+
+  it('does not refresh while the panel stays closed', () => {
+    const comments = makeComments(refresh)
+    renderHook(({ open }) => useRefreshCommentsOnOpen(comments, open), {
+      initialProps: { open: false },
+    })
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('refreshes once on the closed → open transition', () => {
+    const comments = makeComments(refresh)
+    const { rerender } = renderHook(({ open }) => useRefreshCommentsOnOpen(comments, open), {
+      initialProps: { open: false },
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    rerender({ open: true })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-refresh on re-renders while the panel stays open', () => {
+    const comments = makeComments(refresh)
+    const { rerender } = renderHook(({ open }) => useRefreshCommentsOnOpen(comments, open), {
+      initialProps: { open: false },
+    })
+    rerender({ open: true })
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    // Extra renders with no open-state change must not trigger further fetches.
+    rerender({ open: true })
+    rerender({ open: true })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes again when the panel is closed and reopened', () => {
+    const comments = makeComments(refresh)
+    const { rerender } = renderHook(({ open }) => useRefreshCommentsOnOpen(comments, open), {
+      initialProps: { open: false },
+    })
+    rerender({ open: true })
+    rerender({ open: false })
+    rerender({ open: true })
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not double-fetch when the panel starts already open (seeds prevOpen)', () => {
+    const comments = makeComments(refresh)
+    // A panel opened immediately (e.g. deep-linked) relies on useDocComments own mount refresh;
+    // this hook must not add a second concurrent fetch on top of it.
+    renderHook(({ open }) => useRefreshCommentsOnOpen(comments, open), {
+      initialProps: { open: true },
+    })
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('reads the latest refresh via ref — no stale closure, no re-fire on identity change', () => {
+    const first = vi.fn<() => Promise<void>>(async () => {})
+    const second = vi.fn<() => Promise<void>>(async () => {})
+    const { rerender } = renderHook(
+      ({ open, refreshFn }) => useRefreshCommentsOnOpen(makeComments(refreshFn), open),
+      { initialProps: { open: false, refreshFn: first } },
+    )
+
+    // refresh identity changes (as it does when docId/includeResolved change) while closed —
+    // must NOT trigger a fetch on its own.
+    rerender({ open: false, refreshFn: second })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).not.toHaveBeenCalled()
+
+    // Opening now must call the CURRENT refresh, not the stale first one.
+    rerender({ open: true, refreshFn: second })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/docs/src/editor/EditorShell.badge.test.tsx
+++ b/packages/docs/src/editor/EditorShell.badge.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../comments/CommentPanel.tsx', () => ({ CommentPanel: () => null }))
 vi.mock('../versions/VersionPanel.tsx', () => ({ VersionPanel: () => null }))
 vi.mock('../comments/useDocComments.ts', () => ({
   useDocComments: () => ({ threads: [], createRoot: vi.fn() }),
+  useRefreshCommentsOnOpen: () => undefined,
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
 vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))

--- a/packages/docs/src/editor/EditorShell.shareSeed.test.tsx
+++ b/packages/docs/src/editor/EditorShell.shareSeed.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../comments/CommentPanel.tsx', () => ({ CommentPanel: () => null }))
 vi.mock('../versions/VersionPanel.tsx', () => ({ VersionPanel: () => null }))
 vi.mock('../comments/useDocComments.ts', () => ({
   useDocComments: () => ({ threads: [], createRoot: vi.fn() }),
+  useRefreshCommentsOnOpen: () => undefined,
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
 vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../versions/VersionPanel.tsx', () => ({ VersionPanel: () => null }))
 vi.mock('../members/MemberPanel.tsx', () => ({ MemberPanel: () => null }))
 vi.mock('../comments/useDocComments.ts', () => ({
   useDocComments: () => ({ threads: [], createRoot: vi.fn() }),
+  useRefreshCommentsOnOpen: () => undefined,
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
 // useMemberNames drives the creator-name resolution's PRIMARY source (the space-member map). Kept

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -11,7 +11,7 @@ import { MemberPanel } from '../members/MemberPanel.tsx'
 import { VersionPanel } from '../versions/VersionPanel.tsx'
 import { CommentPanel } from '../comments/CommentPanel.tsx'
 import { CommentBubble } from '../comments/CommentBubble.tsx'
-import { useDocComments } from '../comments/useDocComments.ts'
+import { useDocComments, useRefreshCommentsOnOpen } from '../comments/useDocComments.ts'
 import { useCommentHighlights } from '../comments/useCommentHighlights.ts'
 import { useDocDelete } from './useDocDelete.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -432,6 +432,8 @@ export function EditorShell(props: EditorShellProps) {
   // share it; highlights paint regardless of whether the panel is open.
   const comments = useDocComments(docId)
   useCommentHighlights(instance?.editor ?? null, comments.threads)
+  // Pull the latest threads each time the comments drawer opens (XIN-1323).
+  useRefreshCommentsOnOpen(comments, activePanel === 'comments')
 
   // A click on a comment highlight (decoration layer) opens the comments drawer on that thread.
   useEffect(() => {

--- a/packages/docs/src/sheet/SheetView.tsx
+++ b/packages/docs/src/sheet/SheetView.tsx
@@ -16,7 +16,7 @@ import { type Role, canManage } from '../auth/roles.ts'
 import { MemberPanel } from '../members/MemberPanel.tsx'
 import { SheetVersionPanel } from './SheetVersionPanel.tsx'
 import { SheetCommentPanel, parseCell as parseCommentAnchor } from './SheetCommentPanel.tsx'
-import { useDocComments } from '../comments/useDocComments.ts'
+import { useDocComments, useRefreshCommentsOnOpen } from '../comments/useDocComments.ts'
 import { pendingSheetImports } from './xlsxImport.ts'
 import { buildSheetDims, buildSheetMerges, excelSheetName } from './sheetExport.ts'
 import { sanitizeLinkHref } from '../editor/sanitize.ts'
@@ -205,6 +205,9 @@ export function SheetView(props: SheetViewProps) {
   // Comments are owned here (not inside the panel) so the cell markers stay visible
   // even when the panel is closed, and refresh as comments are added/removed.
   const comments = useDocComments(docId)
+  // Pull the latest threads each time the comments drawer opens (XIN-1323); shares the same
+  // useRefreshCommentsOnOpen hook as the docs editor since both drive one useDocComments instance.
+  useRefreshCommentsOnOpen(comments, panel === 'comments')
   const [commentFocus, setCommentFocus] = useState<{ row: number; col: number; sheetId: string } | null>(null)
   const [composer, setComposer] = useState<CellAnchor | null>(null)
 


### PR DESCRIPTION
## What

The comment panel reused a mount-only REST hook (`useDocComments`) with no realtime push, so once the panel was opened it never re-read the thread list. If another user added a comment during the session, or you closed and reopened the panel, it kept showing stale content.

## Fix

Refetch the comment list the moment the panel transitions from closed → open. The refresh lives in one shared hook, `useRefreshCommentsOnOpen`, wired into both surfaces that drive a single `useDocComments` instance:

- **Docs** — `EditorShell`, keyed off `activePanel === 'comments'`
- **Sheets** — `SheetView`, keyed off `panel === 'comments'` (the sheet panel reuses the docs comment REST layer wholesale, so one hook covers both)

Whiteboards have no comments, so they are unaffected.

### Notes on correctness

- Fires only on the **false → true edge** — not on every render and not while the panel stays open — so opening once triggers exactly one fetch, with no duplicate concurrent loads.
- `refresh` is read through a ref, so its identity changing (`docId` / `includeResolved`, which already refresh on their own inside `useDocComments`) never re-fires the effect and there is no stale closure.
- `prevOpen` is seeded with the initial `open` value, so a panel that mounts already open does not double-fetch on top of the hook's own mount-time load.
- No change to the comment mutation / anchor / REST layers — mutation-triggered refreshes (add / reply / resolve / delete) still work as before.

## Tests

New `useRefreshCommentsOnOpen.test.ts` covers: no fetch while closed, exactly one fetch on open, no re-fetch on re-render while open, re-fetch on close→reopen, no double-fetch when mounted already open, and latest-`refresh`-via-ref (no stale closure / no re-fire on identity change).

- `pnpm --filter @octo/docs typecheck` — clean for the touched files
- `pnpm --filter @octo/docs test` (comments suite) — 24 passed

## Acceptance

- Docs: opening the comment panel shows the latest comments (including ones others just added); closing and reopening refreshes; add / reply / resolve / delete still update immediately.
- Sheets: same behavior via `SheetCommentPanel`.
- No redundant fetches (one open = one refresh).
