### PR TITLE
fix(docs): keep table row height stable when hovering a column border

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ packages/docs/dev/reorder-out/
 packages/docs/dev/handle-ux-out/
 packages/docs/dev/coexist-out/
 packages/docs/dev/multipointer-out/
+packages/docs/dev/colhover-out/
 
 # Loop V1 内部设计文档仅保留在本地 workspace，不纳入版本库
 docs/loop-v1/

--- a/packages/docs/colhover.html
+++ b/packages/docs/colhover.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Column-hover row-jump repro (XIN-1322)</title>
+    <style>
+      html, body, #root { height: 100%; margin: 0; }
+      /* Make the column-resize handle visible (production accent is a faint hover gradient). */
+      .column-resize-handle { background: rgba(66, 99, 235, 0.6) !important; z-index: 20; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dev/colhover.harness.tsx"></script>
+  </body>
+</html>

--- a/packages/docs/dev/colhover.harness.tsx
+++ b/packages/docs/dev/colhover.harness.tsx
@@ -1,0 +1,128 @@
+// PROD-faithful repro for XIN-1322 (column-hover row jump). Same editor wiring as production
+// extensions.ts (real Table.configure({ resizable, handleWidth, cellMinWidth }), TableCellView node
+// views, real editor/styles.css, wrapped in .octo-theme .octo-prose), so the browser exercises the
+// exact CSS the tester hit. The defect: hovering a column's RIGHT border arms prosemirror-tables'
+// columnResizing, which mounts a `.column-resize-handle` (also `.ProseMirror-widget`) DIV at the END
+// of the cell's `.octo-cell-clip` content hole. A bare `:last-child` margin-zero rule then loses the
+// trailing <p>, whose `margin-bottom` (1em) springs back and pushes every row ~15px taller until the
+// pointer leaves the border. window.__colHoverHarness exposes the seams the runner drives.
+import { useEffect, useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import * as Y from 'yjs'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import { Table } from '@tiptap/extension-table'
+import TableHeader from '@tiptap/extension-table-header'
+import TableCell from '@tiptap/extension-table-cell'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TableRowHeight, TableRowResize } from '../src/editor/TableRowHeight.ts'
+import { TableCellView } from '../src/editor/TableCellView.ts'
+import '../src/editor/styles.css'
+
+const FIELD = 'default'
+
+function makeEditor(ydoc: Y.Doc, element: HTMLElement): Editor {
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Collaboration.configure({ document: ydoc, field: FIELD }),
+      // Exact production table config (extensions.ts:242) — resizable columns with the #749 grab band.
+      Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 }),
+      TableRowHeight,
+      TableHeader.extend({ addNodeView() { return ({ node }: { node: PMNode }) => new TableCellView(node, 'th') } }),
+      TableCell.extend({ addNodeView() { return ({ node }: { node: PMNode }) => new TableCellView(node, 'td') } }),
+      TableRowResize,
+    ],
+  })
+}
+
+function rowsOf(editor: Editor): { pos: number; node: PMNode }[] {
+  const rows: { pos: number; node: PMNode }[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'tableRow') rows.push({ pos, node })
+    return true
+  })
+  return rows
+}
+
+// Two content-driven rows (NO explicit height → no clip; height is pure content), two columns each.
+// Each cell holds two paragraphs, so the trailing <p> is unambiguous and its margin-bottom is the
+// thing under test. Mixed-content cell in col 2 (a <p> then a <ul>) guards the `:last-of-type`
+// over-match trap: the nth-child(of :not(widget)) rule must zero only the true trailing block.
+const DOC =
+  '<p>column-hover repro — hover the border between the two columns of row 1</p>' +
+  '<table><tbody>' +
+  '<tr>' +
+  '<td><p>r1c1 line a</p><p>r1c1 line b</p></td>' +
+  '<td><p>r1c2 line a</p><ul><li><p>r1c2 bullet</p></li></ul></td>' +
+  '</tr>' +
+  '<tr><td><p>r2c1</p></td><td><p>r2c2</p></td></tr>' +
+  '</tbody></table>'
+
+function Harness(): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!ref.current) return
+    let ed: Editor | null = null
+    const mount = () => {
+      ed?.destroy()
+      ref.current!.innerHTML = ''
+      const ydoc = new Y.Doc()
+      ed = makeEditor(ydoc, ref.current!)
+      ed.commands.insertContent(DOC)
+    }
+    const firstCellDOM = (): HTMLElement | null => {
+      const row = rowsOf(ed!)[0]
+      if (!row) return null
+      const dom = ed!.view.nodeDOM(row.pos)
+      if (!(dom instanceof HTMLElement)) return null
+      return dom.querySelector('td') as HTMLElement | null
+    }
+    const harness = {
+      mount,
+      rowRect: (i: number) => {
+        const row = rowsOf(ed!)[i]
+        if (!row) return null
+        const dom = ed!.view.nodeDOM(row.pos)
+        if (!(dom instanceof HTMLElement)) return null
+        const r = dom.getBoundingClientRect()
+        return { top: r.top, height: r.height }
+      },
+      // The x of the border between column 1 and column 2 (right edge of row-1's first cell), and a y
+      // safely inside that row — where the runner parks the pointer to arm columnResizing.
+      colBorderPoint: () => {
+        const cell = firstCellDOM()
+        if (!cell) return null
+        const r = cell.getBoundingClientRect()
+        return { x: r.right, y: r.top + r.height / 2 }
+      },
+      // Is the columnResizing widget currently mounted? (the render transient's trigger)
+      hasResizeHandle: (): boolean => !!document.querySelector('.octo-prose .column-resize-handle'),
+      // Diagnostic: computed margin-bottom of the LAST real <p> in row-1's first cell — the value the
+      // rule protects. Stays ~0 with the fix even while a widget is mounted after it.
+      lastParaMarginBottom: (): number | null => {
+        const cell = firstCellDOM()
+        if (!cell) return null
+        const clip = cell.querySelector('.octo-cell-clip')
+        if (!clip) return null
+        const paras = clip.querySelectorAll(':scope > p')
+        const last = paras[paras.length - 1] as HTMLElement | undefined
+        if (!last) return null
+        return parseFloat(getComputedStyle(last).marginBottom)
+      },
+    }
+    ;(window as unknown as { __colHoverHarness: typeof harness }).__colHoverHarness = harness
+    return () => { ed?.destroy() }
+  }, [])
+
+  return (
+    <div className="octo-theme" style={{ padding: 40, height: '100vh', boxSizing: 'border-box' }}>
+      <div className="octo-prose" ref={ref} style={{ position: 'relative' }} />
+    </div>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<Harness />)

--- a/packages/docs/dev/run-colhover.mjs
+++ b/packages/docs/dev/run-colhover.mjs
@@ -1,0 +1,119 @@
+// Playwright driver for the column-hover row-jump gate (XIN-1322). Real Chromium, a real pointer
+// parked on the border between two columns to arm prosemirror-tables' columnResizing (which mounts
+// the `.column-resize-handle` / `.ProseMirror-widget` DIV at the end of the cell's `.octo-cell-clip`).
+// Reproduces the acceptance gate:
+//   CH01 — hovering the column border mounts the resize-handle widget (the transient's trigger fires).
+//   CH02 — while the widget is mounted, every row's rendered height stays within 1px of its rest
+//          height (no ~15px jump). Before the fix the trailing <p> lost `:last-child` and its
+//          margin-bottom sprang back, pushing each row taller.
+//   CH03 — the trailing <p>'s computed margin-bottom stays ~0 even with the widget mounted after it.
+//   CH04 — moving the pointer off the border unmounts the widget and the height fully restores.
+// Usage: node dev/run-colhover.mjs   (expects the standalone dev server on :4178)
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const PORT = process.env.HARNESS_PORT || '4178'
+const URL = `http://localhost:${PORT}/colhover.html`
+const OUT = 'dev/colhover-out'
+mkdirSync(OUT, { recursive: true })
+
+let failed = 0
+const fail = (msg) => {
+  console.error('  ✗ FAIL:', msg)
+  failed++
+}
+const ok = (msg) => console.log('  ✓', msg)
+
+// Allow pinning a specific Chromium binary (e.g. the full build) via env when the default
+// chrome-headless-shell is not present in the cache. No effect when unset.
+const launchOpts = process.env.PW_CHROMIUM_PATH ? { executablePath: process.env.PW_CHROMIUM_PATH } : {}
+const browser = await chromium.launch(launchOpts)
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+page.on('pageerror', (e) => console.log('[pageerror]', e.message))
+page.on('console', (m) => { if (m.type() === 'error') console.log('[page error]', m.text()) })
+
+await page.goto(URL, { waitUntil: 'networkidle' })
+await page.waitForFunction(() => !!window.__colHoverHarness, { timeout: 30000 })
+await page.evaluate(() => window.__colHoverHarness.mount())
+await page.waitForTimeout(300)
+
+console.log('\nColumn-hover row jump — arm columnResizing on the inter-column border, verify no row growth')
+
+// 1) Rest state: widget absent, capture each row's rendered height.
+const rest = await page.evaluate(() => ({
+  handle: window.__colHoverHarness.hasResizeHandle(),
+  r0: window.__colHoverHarness.rowRect(0),
+  r1: window.__colHoverHarness.rowRect(1),
+  margin: window.__colHoverHarness.lastParaMarginBottom(),
+  border: window.__colHoverHarness.colBorderPoint(),
+}))
+console.log('  at rest:', JSON.stringify({ handle: rest.handle, r0h: rest.r0?.height, r1h: rest.r1?.height, margin: rest.margin }))
+if (!rest.r0 || !rest.r1) throw new Error('row rects not found at rest')
+if (!rest.border) throw new Error('column border point not found')
+if (rest.handle) fail('precondition: resize handle should be absent before hovering the border')
+else ok('precondition: no resize handle at rest')
+
+// 2) Park the pointer ON the inter-column border to arm columnResizing. Approach in small steps so the
+//    plugin's mousemove handler sees a move that lands inside the handleWidth band.
+await page.mouse.move(rest.border.x - 40, rest.border.y)
+await page.waitForTimeout(60)
+await page.mouse.move(rest.border.x, rest.border.y, { steps: 6 })
+await page.waitForTimeout(200)
+
+const hover = await page.evaluate(() => ({
+  handle: window.__colHoverHarness.hasResizeHandle(),
+  r0: window.__colHoverHarness.rowRect(0),
+  r1: window.__colHoverHarness.rowRect(1),
+  margin: window.__colHoverHarness.lastParaMarginBottom(),
+}))
+console.log('  while hovering border:', JSON.stringify({ handle: hover.handle, r0h: hover.r0?.height, r1h: hover.r1?.height, margin: hover.margin }))
+
+// CH01 — the widget must actually mount, otherwise the test proves nothing.
+if (hover.handle) ok('CH01 hovering the column border mounted the resize-handle widget')
+else fail('CH01 resize-handle widget did not mount on border hover — cannot exercise the transient')
+
+// CH02 — no row grew while the widget is mounted.
+const d0 = Math.abs((hover.r0?.height ?? 0) - rest.r0.height)
+const d1 = Math.abs((hover.r1?.height ?? 0) - rest.r1.height)
+if (hover.handle && d0 <= 1 && d1 <= 1) {
+  ok(`CH02 rows held their height with the widget mounted (Δrow1=${d0.toFixed(1)}px, Δrow2=${d1.toFixed(1)}px)`)
+} else if (hover.handle) {
+  fail(`CH02 a row grew while the widget was mounted: Δrow1=${d0.toFixed(1)}px, Δrow2=${d1.toFixed(1)}px (expected ≤1px each)`)
+}
+
+// CH03 — the trailing <p> kept its zeroed margin-bottom despite the widget sitting after it.
+if (hover.handle && typeof hover.margin === 'number' && hover.margin <= 1) {
+  ok(`CH03 trailing <p> margin-bottom stayed ~0 with widget mounted (${hover.margin}px)`)
+} else if (hover.handle) {
+  fail(`CH03 trailing <p> margin-bottom sprang back to ${hover.margin}px (expected ~0)`)
+}
+await page.screenshot({ path: `${OUT}/colhover-armed.png` })
+
+// 3) Move the pointer well away so the widget unmounts.
+await page.mouse.move(rest.border.x, rest.border.y - 200, { steps: 4 })
+await page.mouse.move(200, 100, { steps: 4 })
+await page.waitForTimeout(200)
+const after = await page.evaluate(() => ({
+  handle: window.__colHoverHarness.hasResizeHandle(),
+  r0: window.__colHoverHarness.rowRect(0),
+  r1: window.__colHoverHarness.rowRect(1),
+}))
+console.log('  after moving away:', JSON.stringify({ handle: after.handle, r0h: after.r0?.height, r1h: after.r1?.height }))
+
+// CH04 — widget gone and height fully restored (proves no permanent change either way).
+const rd0 = Math.abs((after.r0?.height ?? 0) - rest.r0.height)
+const rd1 = Math.abs((after.r1?.height ?? 0) - rest.r1.height)
+if (!after.handle && rd0 <= 1 && rd1 <= 1) {
+  ok('CH04 widget unmounted and rows restored to rest height on pointer-away')
+} else {
+  fail(`CH04 after pointer-away: handle=${after.handle}, Δrow1=${rd0.toFixed(1)}px, Δrow2=${rd1.toFixed(1)}px`)
+}
+await page.screenshot({ path: `${OUT}/colhover-restored.png` })
+
+await browser.close()
+if (failed) {
+  console.error(`\n=== COLUMN-HOVER HARNESS FAILED (${failed}) ===`)
+  process.exitCode = 1
+} else {
+  console.log('\n=== COLUMN-HOVER HARNESS PASSED: column-border hover mounts the widget without growing any row ===')
+}

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2060,11 +2060,22 @@ body.octo-row-resizing {
    that top margin becomes real space and the first line ends up sliced mid-glyph ("露半截") instead of
    starting at the top. Zeroing the leading/trailing margins (not the inter-block gaps) lands the first
    line on the cell top in all three states (editor, read-only preview, version diff — all share this
-   NodeView wrapper) while preserving spacing between stacked paragraphs. */
-.octo-cell-clip > :first-child {
+   NodeView wrapper) while preserving spacing between stacked paragraphs.
+
+   XIN-1322: match the first/last real CONTENT block, not the first/last DOM child. Hovering a column's
+   right border arms prosemirror-tables' columnResizing, which appends a `.column-resize-handle` widget
+   (a DIV, also classed `.ProseMirror-widget` by prosemirror-view) at the end of the cell's content hole
+   — i.e. as the last child of this wrapper. With a bare `:last-child` that widget STEALS the margin-zero
+   identity from the trailing <p>, which then springs its `margin-bottom` (1em ≈ 15px) back and pushes the
+   row ~15px taller for as long as the pointer hovers the border (pure render transient; the model height
+   never changes). Selecting `1 of :not(.ProseMirror-widget)` skips the widget so the real trailing/leading
+   block keeps its zeroed margin whether or not a widget is mounted. `:nth-child(of S)` is Baseline-supported
+   in the Chromium/evergreen targets and, unlike `:last-of-type`, never over-matches a mixed-type cell
+   (e.g. a trailing <p> before a <ul> would each be a last-of-type and both get zeroed). */
+.octo-cell-clip > :nth-child(1 of :not(.ProseMirror-widget)) {
   margin-top: 0;
 }
-.octo-cell-clip > :last-child {
+.octo-cell-clip > :nth-last-child(1 of :not(.ProseMirror-widget)) {
   margin-bottom: 0;
 }
 .octo-prose table tr.octo-row-fixed .octo-cell-clip {


### PR DESCRIPTION
## Problem

Hovering a table column's **right border** arms prosemirror-tables' `columnResizing`, which mounts a `.column-resize-handle` widget (also classed `.ProseMirror-widget` by prosemirror-view) at the **end of the cell's `.octo-cell-clip` content hole** — i.e. as its last DOM child.

The compact-row rule (`SCHEMA_VERSION 19`, XIN-1289) zeroes the trailing block's margin with a bare `:last-child`. When the widget mounts, it steals that `:last-child` identity, so the real trailing `<p>` springs its `margin-bottom` (`1em ≈ 15px`) back — and **every affected row jumps ~15px taller for as long as the pointer stays on the border**, snapping back on leave. It's a pure render transient: the stored `tableRow.height` / `--octo-row-h` never change.

## Fix

Match the first/last real **content block** instead of the first/last DOM child:

```css
.octo-cell-clip > :nth-child(1 of :not(.ProseMirror-widget))      { margin-top: 0; }
.octo-cell-clip > :nth-last-child(1 of :not(.ProseMirror-widget)) { margin-bottom: 0; }
```

A mounted widget no longer displaces the margin-zero target. Chosen over `:last-of-type`, which over-matches a mixed-type cell (a trailing `<p>` before a `<ul>` would each be a last-of-type and both get zeroed, collapsing the gap between them). `:nth-child(of S)` is Baseline in the Chromium/evergreen targets.

## Verification

Real Chromium (Playwright), added as a PROD-faithful repro (`packages/docs/dev/colhover.harness.tsx` + `dev/run-colhover.mjs`) using the exact production table wiring — `Table.configure({ resizable: true, handleWidth: 12, cellMinWidth: 25 })`, `TableCellView` node views, real `styles.css`. It parks a real pointer on the inter-column border to arm `columnResizing` and asserts no row grows while the widget is mounted.

- **Before the fix** (`:last-child`): border hover → widget mounts → short row `37px → 52px` (**+15px**), trailing `<p>` `margin-bottom` `0 → 15px`. ❌
- **After the fix**: border hover → widget mounts → row stays `37px`, margin stays `0px`; pointer-away restores cleanly. ✅

Existing `TableRowClipPreview` unit test still passes; typecheck shows only pre-existing, unrelated errors.
