### PR TITLE
refactor(docs): merge import entries into the New-doc dropdown

### DIFF
--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -375,6 +375,33 @@ describe('DocsHome navigation (split-pane)', () => {
     })
   })
 
+  it('exposes the three import entries inside the "New" dropdown and drops the standalone import button', async () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('docs.state.empty')).toBeTruthy())
+
+    // The standalone "Import" button (its label was docs.sheet.import) no longer exists in the header.
+    expect(screen.queryByText('docs.sheet.import')).toBeNull()
+    // Import entries are not rendered until the "New" dropdown is opened.
+    expect(screen.queryByText('docs.sheet.importExcel', { exact: false })).toBeNull()
+
+    // Opening the single "New" dropdown surfaces both the create entries and the three import entries.
+    fireEvent.click(screen.getByLabelText('docs.list.newMenu'))
+    expect(screen.getByText('docs.list.newBoard')).toBeTruthy()
+    expect(screen.getByText('docs.sheet.new', { exact: false })).toBeTruthy()
+    expect(screen.getByText('docs.sheet.importExcel', { exact: false })).toBeTruthy()
+    expect(screen.getByText('docs.import.word', { exact: false })).toBeTruthy()
+    expect(screen.getByText('docs.import.markdown', { exact: false })).toBeTruthy()
+  })
+
   it('opens an existing document inline in the right pane and marks it active', async () => {
     const wk = createMockWKApp()
     setWKApp(wk)

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -471,7 +471,6 @@ function DocsList({
 }): React.ReactElement {
   const [creating, setCreating] = useState(false)
   const [newMenuAt, setNewMenuAt] = useState<{ left: number; top: number } | null>(null)
-  const [importMenuAt, setImportMenuAt] = useState<{ left: number; top: number } | null>(null)
   const importInputRef = useRef<HTMLInputElement>(null)
   // Client-side pin (置顶) — persisted in localStorage; pinned docs sort to the top. Pin is a
   // "我的文档" affordance ONLY: the recent tab renders the server's `viewed_at DESC` order verbatim
@@ -937,64 +936,54 @@ function DocsList({
             >
               ▦ {t('docs.sheet.new')}
             </button>
-          </PortalMenu>
-        )}
-        {/* Import entry — flag ON; formal owner sign-off on this PR still PENDING, gated by needs-human-review (was hidden in #583). Toggle via IMPORT_ENABLED. */}
-        {IMPORT_ENABLED && (
-          <>
-        <button
-          type="button"
-          className="octo-docs-list-new"
-          disabled={creating}
-          title={t('docs.sheet.import')}
-          aria-haspopup="menu"
-          aria-expanded={importMenuAt != null}
-          onClick={(e) => {
-            const r = e.currentTarget.getBoundingClientRect()
-            setImportMenuAt(importMenuAt ? null : { left: r.left, top: r.bottom + 6 })
-          }}
-        >
-          {t('docs.sheet.import')}
-          <span style={{ marginLeft: 6, fontSize: 9, opacity: 0.9 }}>▾</span>
-        </button>
-        {importMenuAt && (
-          <PortalMenu at={importMenuAt} onClose={() => setImportMenuAt(null)}>
-            <button
-              type="button"
-              className="octo-tb-btn"
-              disabled={creating}
-              style={{ display: 'block', width: '100%', textAlign: 'left' }}
-              onClick={() => {
-                setImportMenuAt(null)
-                importInputRef.current?.click()
-              }}
-            >
-              📄 {t('docs.sheet.importExcel')}
-            </button>
-            <button
-              type="button"
-              className="octo-tb-btn"
-              disabled={creating}
-              style={{ display: 'block', width: '100%', textAlign: 'left' }}
-              onClick={() => {
-                setImportMenuAt(null)
-                void onImportWord()
-              }}
-            >
-              📃 {t('docs.import.word')}
-            </button>
-            <button
-              type="button"
-              className="octo-tb-btn"
-              disabled={creating}
-              style={{ display: 'block', width: '100%', textAlign: 'left' }}
-              onClick={() => {
-                setImportMenuAt(null)
-                void onImportMarkdown()
-              }}
-            >
-              📝 {t('docs.import.markdown')}
-            </button>
+            {/* Import entries merged into the "New" dropdown (was a standalone "Import" button).
+                Flag ON; formal owner sign-off still PENDING, gated by needs-human-review (was hidden
+                in #583). Toggle via IMPORT_ENABLED. Handlers unchanged — this only moves the entry. */}
+            {IMPORT_ENABLED && (
+              <>
+                <div
+                  role="separator"
+                  aria-hidden="true"
+                  style={{ borderTop: '1px solid #ebebeb', margin: '6px 0' }}
+                />
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={creating}
+                  style={{ display: 'block', width: '100%', textAlign: 'left' }}
+                  onClick={() => {
+                    setNewMenuAt(null)
+                    importInputRef.current?.click()
+                  }}
+                >
+                  📄 {t('docs.sheet.importExcel')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={creating}
+                  style={{ display: 'block', width: '100%', textAlign: 'left' }}
+                  onClick={() => {
+                    setNewMenuAt(null)
+                    void onImportWord()
+                  }}
+                >
+                  📃 {t('docs.import.word')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={creating}
+                  style={{ display: 'block', width: '100%', textAlign: 'left' }}
+                  onClick={() => {
+                    setNewMenuAt(null)
+                    void onImportMarkdown()
+                  }}
+                >
+                  📝 {t('docs.import.markdown')}
+                </button>
+              </>
+            )}
           </PortalMenu>
         )}
         <input
@@ -1008,8 +997,6 @@ function DocsList({
             e.currentTarget.value = ''
           }}
         />
-          </>
-        )}
       </div>
       <DocsTabs active={activeView} onChange={onTab} />
       <div className="octo-docs-toolbar">


### PR DESCRIPTION
## What

Merge the document import entries into the **New document** dropdown and remove the standalone **Import** button, so the list header carries a single dropdown.

Before: `+ New document ▾` (New board / New sheet) **and** a separate `Import ▾` (Excel / Word / Markdown).
After: one `+ New document ▾` whose menu shows the create entries, a divider, then the three import entries.

## Changes

- `DocsHome.tsx`: move the Excel / Word / Markdown import items into the New-document `PortalMenu`, separated from the create entries by a divider. Remove the standalone Import button and its menu, and drop the now-unused `importMenuAt` state.
- Import handlers are untouched — the items reuse the existing `importInputRef` click (Excel), `onImportWord`, and `onImportMarkdown`, and the same i18n keys (`docs.sheet.importExcel`, `docs.import.word`, `docs.import.markdown`). The hidden Excel file input is retained.
- Test: add a case asserting the three import entries live inside the New dropdown and the standalone Import button is gone.

## Scope

Pure entry-point relocation — no import logic or i18n keys changed. The `IMPORT_ENABLED` flag still gates the import entries.

## Verification

- `tsc` typecheck: no new errors from this change (two pre-existing errors in `dmworkbase/i18n/format.ts` and `members/sort.ts` are unrelated and present on `main`).
- Vitest: `DocsHome.test.tsx` all green, including the new case.
