### PR TITLE
fix(sheet): add always-visible comment entry button + fix cell selection label

### DIFF
--- a/packages/docs/src/sheet/SheetCommentPanel.test.ts
+++ b/packages/docs/src/sheet/SheetCommentPanel.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { cellMatches, parseCell, type SheetCell } from './SheetCommentPanel.tsx'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { createElement } from 'react'
+import { cellMatches, parseCell, SheetCommentPanel, type SheetCell } from './SheetCommentPanel.tsx'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+import type { UseDocComments } from '../comments/useDocComments.ts'
+import type { CollabSheet } from './CollabSheet.ts'
 
 // Locks the cross-sheet active-thread selection contract: highlighting a thread must match
 // the logical sheet id, not just row/col. Regression guard for the panel active-thread path
@@ -70,5 +76,103 @@ describe('parseCell — legacy V1 anchor normalization', () => {
     expect(parseCell('')).toBeNull()
     expect(parseCell(btoa('default!x:y'))).toBeNull()
     expect(parseCell(btoa('no-bang-segment'))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Compose entry-button + selection-label UX (XIN-1337).
+//
+// The sheet panel used to render the compose textarea and a `!body.trim()`-locked submit
+// button up-front, so the only visible control read as a permanently-disabled button. The
+// fix mirrors the doc CommentBubble two-step interaction: an always-visible, always-clickable
+// entry button that reveals the composer on click. These render tests lock (1) the entry
+// button is present and clickable before composing, (2) clicking it reveals the composer,
+// and (3) the submit label reflects the selected cell ("Comment A1") rather than the generic
+// "current cell" label, seeded from the live selection on mount.
+// ---------------------------------------------------------------------------
+
+function makeComments(overrides: Partial<UseDocComments> = {}): UseDocComments {
+  return {
+    threads: [],
+    loading: false,
+    error: null,
+    nextCursor: null,
+    includeResolved: false,
+    setIncludeResolved: () => {},
+    refresh: async () => {},
+    loadMore: async () => {},
+    createRoot: async () => {},
+    reply: async () => {},
+    editBody: async () => {},
+    resolve: async () => {},
+    remove: async () => {},
+    ...overrides,
+  }
+}
+
+function makeSheet(activeCell: { key: string; a1: string; sheetId: string } | null): CollabSheet {
+  return {
+    getActiveCellRef: () => activeCell,
+    onActiveCell: () => () => {},
+    focusCell: () => {},
+    setCommentedCells: () => {},
+  } as unknown as CollabSheet
+}
+
+function renderPanel(sheet: CollabSheet | null, comments: UseDocComments = makeComments()) {
+  return render(
+    createElement(SheetCommentPanel, {
+      docId: 'doc-1',
+      sheet,
+      role: 'reader' as const,
+      comments,
+    }),
+  )
+}
+
+describe('SheetCommentPanel — compose entry button (XIN-1337)', () => {
+  beforeEach(() => {
+    setWKApp(createMockWKApp())
+  })
+  afterEach(() => cleanup())
+
+  it('shows an always-clickable entry button, not the compose box, before composing', () => {
+    renderPanel(makeSheet({ key: 'default!0:0', a1: 'A1', sheetId: 'default' }))
+    // Entry button (mirrors CommentBubble: "💬 <commentButton>") is present and NOT disabled…
+    const entry = screen.getByRole('button', { name: /docs\.comment\.commentButton/ }) as HTMLButtonElement
+    expect(entry).toBeTruthy()
+    expect(entry.disabled).toBe(false)
+    // …and the composer textarea is hidden until the user clicks it.
+    expect(document.querySelector('textarea.octo-comment-input')).toBeNull()
+  })
+
+  it('reveals the composer + submit button when the entry button is clicked', () => {
+    renderPanel(makeSheet({ key: 'default!0:0', a1: 'A1', sheetId: 'default' }))
+    fireEvent.click(screen.getByRole('button', { name: /docs\.comment\.commentButton/ }))
+    // The composer now renders…
+    expect(document.querySelector('textarea.octo-comment-input')).not.toBeNull()
+    // …and the submit button appears, disabled while the body is empty (spam guard kept).
+    const submit = screen.getByRole('button', { name: /docs\.sheet\.comment\.menu A1/ }) as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+  })
+
+  it('disables the entry button while the sheet is not connected', () => {
+    renderPanel(null)
+    const entry = screen.getByRole('button', { name: /docs\.comment\.commentButton/ }) as HTMLButtonElement
+    expect(entry.disabled).toBe(true)
+  })
+
+  it('submit label reads "Comment A1" when a cell is selected (seeded from live selection)', () => {
+    renderPanel(makeSheet({ key: 'default!4:2', a1: 'C5', sheetId: 'default' }))
+    fireEvent.click(screen.getByRole('button', { name: /docs\.comment\.commentButton/ }))
+    // Seeded on mount from getActiveCellRef → label carries the A1 ref, not the generic fallback.
+    expect(screen.getByRole('button', { name: /docs\.sheet\.comment\.menu C5/ })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /docs\.sheet\.comment\.current/ })).toBeNull()
+  })
+
+  it('falls back to the generic "current cell" label when no cell is selected', () => {
+    renderPanel(makeSheet(null))
+    fireEvent.click(screen.getByRole('button', { name: /docs\.comment\.commentButton/ }))
+    expect(screen.getByRole('button', { name: /docs\.sheet\.comment\.current/ })).toBeTruthy()
   })
 })

--- a/packages/docs/src/sheet/SheetCommentPanel.tsx
+++ b/packages/docs/src/sheet/SheetCommentPanel.tsx
@@ -324,6 +324,7 @@ export function SheetCommentPanel({
   const { threads, loading, error, nextCursor, includeResolved, setIncludeResolved, loadMore, createRoot } = comments
 
   const [body, setBody] = useState('')
+  const [composing, setComposing] = useState(false)
   const [activeId, setActiveId] = useState<number | null>(null)
   const [activeCellKey, setActiveCellKey] = useState<string | null>(null)
   const [composeError, setComposeError] = useState<string | null>(null)
@@ -343,6 +344,11 @@ export function SheetCommentPanel({
   // When the user selects a cell, highlight the thread anchored to it (if any).
   useEffect(() => {
     if (!sheet) return
+    // Seed from the CURRENT selection so the compose label reads "评论 A1" the moment the
+    // panel mounts (or the sheet changes), instead of falling back to "评论当前单元格" until
+    // the next selection change fires. Without this, opening the panel with a cell already
+    // selected shows the generic label even though a concrete cell is targeted.
+    setActiveCellKey(sheet.getActiveCellRef()?.a1 ?? null)
     return sheet.onActiveCell((r) => {
       setActiveCellKey(r?.a1 ?? null)
       if (!r) return
@@ -388,6 +394,10 @@ export function SheetCommentPanel({
       await createRoot({ body: body.trim(), anchorStart: encoded, anchorEnd: encoded, anchorText: ref.a1 })
       setBody('')
       setComposeError(null)
+      // Collapse back to the always-visible entry button (two-step interaction, mirrors the
+      // doc CommentBubble). Keeping the composer open would re-disable the submit button on the
+      // now-empty body — exactly the "looks permanently disabled" confusion we're fixing.
+      setComposing(false)
     } catch {
       setComposeError(t('docs.sheet.comment.failed'))
     } finally {
@@ -412,35 +422,69 @@ export function SheetCommentPanel({
 
       {canComment(role) && (
         <div className="octo-comment-compose">
-          <div style={{ position: 'relative' }}>
-            <textarea
-              ref={bodyRef}
-              className="octo-comment-input"
-              placeholder={t('docs.sheet.comment.placeholder')}
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
-              rows={2}
-            />
-            <VoiceInputButton
-              inputRef={bodyRef}
-              onTranscribed={(text, mode, savedRange) =>
-                setBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
-              }
-              getCurrentText={() => body}
-              showModeMenu
-              size="sm"
-              className="wk-vib--textarea-corner"
-            />
-          </div>
-          <div className="octo-comment-compose-actions">
-            <button type="button" className="octo-tb-btn" disabled={busy || !body.trim()} onClick={() => void submit()}>
-              {activeCellKey ? `${t('docs.sheet.comment.menu')} ${activeCellKey}` : t('docs.sheet.comment.current')}
+          {composing ? (
+            <>
+              <div style={{ position: 'relative' }}>
+                <textarea
+                  ref={bodyRef}
+                  className="octo-comment-input"
+                  placeholder={t('docs.sheet.comment.placeholder')}
+                  value={body}
+                  autoFocus
+                  onChange={(e) => setBody(e.target.value)}
+                  rows={2}
+                />
+                <VoiceInputButton
+                  inputRef={bodyRef}
+                  onTranscribed={(text, mode, savedRange) =>
+                    setBody((prev) => applyVoiceTranscription(prev, text, mode, savedRange))
+                  }
+                  getCurrentText={() => body}
+                  showModeMenu
+                  size="sm"
+                  className="wk-vib--textarea-corner"
+                />
+              </div>
+              <div className="octo-comment-compose-actions">
+                <button type="button" className="octo-tb-btn" disabled={busy || !body.trim()} onClick={() => void submit()}>
+                  {activeCellKey ? `${t('docs.sheet.comment.menu')} ${activeCellKey}` : t('docs.sheet.comment.current')}
+                </button>
+                <button
+                  type="button"
+                  className="octo-tb-btn"
+                  disabled={busy}
+                  onClick={() => {
+                    setComposing(false)
+                    setBody('')
+                    setComposeError(null)
+                  }}
+                >
+                  {t('docs.comment.cancel')}
+                </button>
+              </div>
+              {composeError && (
+                <p className="octo-member-error" role="alert">
+                  {composeError}
+                </p>
+              )}
+            </>
+          ) : (
+            // Always-visible, always-clickable entry affordance (disabled only while the sheet
+            // is not yet connected). Clicking it reveals the composer and focuses the input —
+            // the two-step interaction the doc CommentBubble already uses. This replaces the
+            // old layout where the compose box + a `!body.trim()`-locked submit button showed
+            // up-front, which read as a permanently-disabled control (XIN-1337).
+            <button
+              type="button"
+              className="octo-tb-btn"
+              disabled={!sheet}
+              onClick={() => {
+                setComposeError(null)
+                setComposing(true)
+              }}
+            >
+              💬 {t('docs.comment.commentButton')}
             </button>
-          </div>
-          {composeError && (
-            <p className="octo-member-error" role="alert">
-              {composeError}
-            </p>
           )}
         </div>
       )}


### PR DESCRIPTION
## Problem

In the spreadsheet comment side panel, the compose textarea and its submit button were rendered up-front. The submit button is gated by `busy || !body.trim()`, so before typing anything the only visible control is a greyed-out button labelled "评论当前单元格" / "Comment on current cell". Users read that disabled button as a permanent restriction — "I can't comment here" — even though commenting is fully available (any role with access can comment; the gate is identical to the document path).

By contrast, the document editor uses a two-step affordance (`CommentBubble`): an always-visible "💬 Comment" entry button that expands the composer on click. The sheet panel was missing that entry layer.

A secondary polish issue: the submit-button label is driven by `activeCellKey`, which was only populated on the next `set-selections` event. Opening the panel with a cell already selected showed the generic "Comment on current cell" label instead of "Comment A1".

## Changes

- **Always-visible entry button** in the sheet comment panel, mirroring the doc `CommentBubble` two-step interaction. It is always clickable (disabled only while the sheet is not yet connected) and reveals the composer + submit button on click; the composer collapses back to the entry button after a successful post. The submit button keeps its existing `!body.trim()` empty-body guard.
- **Seed the cell label from the live selection on mount**, so the submit button reads "Comment A1" immediately when a cell is already selected, instead of falling back to the generic label until the next selection change.
- Added render regression tests: entry button present + clickable before composing, composer + submit revealed on click, entry disabled when the sheet is disconnected, and the selection-label translation ("Comment A1" vs. the generic fallback).

Comment submission, permission (`canComment(role)`), and REST logic are untouched.

## Verification

- `pnpm test` in `packages/docs` — `SheetCommentPanel.test.ts` 14/14 green.
- `pnpm run typecheck` in `packages/docs` — no new errors introduced (the two pre-existing errors in `dmworkbase/src/i18n/format.ts` and `members/sort.ts` are present on `main` and unrelated to this change).

Closes XIN-1337.
