### PR TITLE
fix(docs): reconcile comment list with server when a mutation is rejected

### DIFF
--- a/packages/docs/src/comments/useDocComments.test.ts
+++ b/packages/docs/src/comments/useDocComments.test.ts
@@ -232,6 +232,78 @@ describe('useDocComments — delete reconciles UI with authoritative backend', (
     expect(result.current.error).toBe('Failed to delete comment.')
   })
 
+  it('does not re-introduce a since-deleted row when an in-flight loadMore page completes after reconcile dropped it', async () => {
+    // Phantom-row race (Jerry-Xin @98dd6762): the third, distinct race.
+    //   1. loadMore() starts and captures a page that still contains comment #30.
+    //   2. Deleting #30 returns 404 (the server had already soft-deleted it), so
+    //      runMutation's catch runs reconcile(), which re-reads the authoritative
+    //      list — now WITHOUT #30 — and installs it.
+    //   3. The older loadMore()'s GET finally resolves and appends its captured
+    //      page → #30 reappears as a phantom row.
+    // reconcile deliberately does not bump reqRef (that would strand the loader's
+    // spinner), so loadMore's reqRef guard still passes on completion. The fix is
+    // an independent dataEpoch that reconcile bumps after installing authoritative
+    // truth; the in-flight loadMore must see it changed and DROP its stale page
+    // (while still clearing its own loading in finally).
+    const page1 = [thread(1, 'a'), thread(2, 'b')]
+    let getCount = 0
+    let releaseLoadMore: (() => void) | null = null
+
+    api.responder = (method: string) => {
+      if (method === 'get') {
+        getCount += 1
+        // 1st GET = initial refresh: page 1 with a cursor so loadMore is enabled.
+        if (getCount === 1) return { data: { items: page1, nextCursor: 25 }, status: 200 }
+        // 2nd GET = loadMore's page fetch — held pending. Its page still contains
+        // the about-to-be-deleted comment #30; released only AFTER reconcile runs.
+        if (getCount === 2) {
+          return new Promise((resolve) => {
+            releaseLoadMore = () =>
+              resolve({ data: { items: [thread(3, 'c'), thread(30, 'phantom')], nextCursor: 50 }, status: 200 })
+          })
+        }
+        // 3rd GET = reconcile's re-read: authoritative page 1, #30 already gone.
+        return { data: { items: page1, nextCursor: 25 }, status: 200 }
+      }
+      if (method === 'delete') {
+        throw { response: { status: 404 } } // #30 already soft-deleted server-side
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+    expect(result.current.nextCursor).toBe(25)
+
+    // Kick off loadMore; its page GET (getCount 2) is now pending.
+    let loadMorePromise: Promise<void>
+    await act(async () => {
+      loadMorePromise = result.current.loadMore()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.loading).toBe(true))
+
+    // While that page is in flight, deleting #30 is rejected 404 → reconcile()
+    // runs to completion (getCount 3), installing the authoritative list w/o #30.
+    await act(async () => {
+      await result.current.remove(30, false)
+    })
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2])
+
+    // Now let the older loadMore GET resolve and append its stale page.
+    await act(async () => {
+      releaseLoadMore!()
+      await loadMorePromise
+    })
+
+    // The phantom row must NOT reappear: the stale page is dropped on the epoch
+    // check. loading settles back to false (loadMore still owns its finally).
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2])
+    expect(result.current.threads.some((t) => t.id === 30)).toBe(false)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe('Failed to delete comment.')
+  })
+
   it('does not regress create/reply/resolve refresh on success', async () => {
     let rows = [thread(1, 'a')]
     api.responder = (method: string, url: string) => {

--- a/packages/docs/src/comments/useDocComments.test.ts
+++ b/packages/docs/src/comments/useDocComments.test.ts
@@ -166,6 +166,72 @@ describe('useDocComments — delete reconciles UI with authoritative backend', (
     expect(getsAfter).toBeGreaterThan(getsBefore)
   })
 
+  it('does not overwrite a newer refresh result with reconcile’s stale snapshot when a mutation is rejected mid-reconcile', async () => {
+    // S1/S2 stale-overwrite race (lml2468 byte-proven repro):
+    //   S1=[1,2] visible → a rejected delete kicks off reconcile() whose GET
+    //   hangs → meanwhile a newer refresh lands S2=[1,2,3] → the hung reconcile
+    //   resolves with its stale S1 snapshot. reconcile MUST bail (a newer
+    //   refresh preempted it, tracked via the shared reqRef) rather than
+    //   setThreads([1,2]) over [1,2,3]; otherwise comment #3 vanishes from the
+    //   UI until the next load. reconcile still must NOT touch loading here (that
+    //   would re-introduce the loading-strand regression covered above).
+    const S1 = [thread(1, 'a'), thread(2, 'b')]
+    const S2 = [thread(1, 'a'), thread(2, 'b'), thread(3, 'c')]
+    let getCount = 0
+    let releaseReconcile: (() => void) | null = null
+
+    api.responder = (method: string) => {
+      if (method === 'get') {
+        getCount += 1
+        // 1st GET = initial refresh → S1.
+        if (getCount === 1) return { data: { items: S1, nextCursor: null }, status: 200 }
+        // 2nd GET = reconcile()'s re-read — hold it pending until AFTER the newer
+        // refresh has landed S2, then resolve it with the now-stale S1 snapshot.
+        if (getCount === 2) {
+          return new Promise((resolve) => {
+            releaseReconcile = () =>
+              resolve({ data: { items: S1, nextCursor: null }, status: 200 })
+          })
+        }
+        // 3rd GET = the newer refresh → resolves immediately with the fresher S2.
+        return { data: { items: S2, nextCursor: null }, status: 200 }
+      }
+      if (method === 'delete') {
+        throw { response: { status: 403 } } // rejected → runMutation catch → reconcile()
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+
+    // Kick off the rejected delete; its reconcile() GET (getCount 2) is now
+    // pending, so remove()'s promise stays unresolved.
+    let removePromise: Promise<void>
+    await act(async () => {
+      removePromise = result.current.remove(1, false)
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(releaseReconcile).not.toBeNull())
+
+    // A newer refresh lands the fresher S2=[1,2,3] while reconcile is still pending.
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2, 3])
+
+    // Release reconcile's hung GET — it resolves with the stale S1 snapshot.
+    await act(async () => {
+      releaseReconcile!()
+      await removePromise
+    })
+
+    // reconcile must have bailed (preempted by the newer refresh) — S2 stays
+    // intact and the delete failure is still surfaced.
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2, 3])
+    expect(result.current.error).toBe('Failed to delete comment.')
+  })
+
   it('does not regress create/reply/resolve refresh on success', async () => {
     let rows = [thread(1, 'a')]
     api.responder = (method: string, url: string) => {

--- a/packages/docs/src/comments/useDocComments.test.ts
+++ b/packages/docs/src/comments/useDocComments.test.ts
@@ -94,6 +94,78 @@ describe('useDocComments — delete reconciles UI with authoritative backend', (
     expect(result.current.error).toBe('Failed to delete comment.')
   })
 
+  it('does not strand loading=true (deadlocking pagination) when a mutation is rejected mid-loadMore', async () => {
+    // Race: a mutation is rejected exactly while a loadMore page fetch is in
+    // flight. reconcile() (the failure fallback re-read) must NOT preempt the
+    // loading-bearing token that loadMore owns — otherwise loadMore's
+    // `finally { if (reqRef===token) setLoading(false) }` is skipped, reconcile
+    // never resets loading, and the spinner stays true forever. With loading
+    // stuck true, loadMore early-returns (`if (nextCursor==null || loading)`),
+    // so pagination is dead for the rest of the session.
+    let rows = [thread(1, 'a'), thread(2, 'b')]
+    let getCount = 0
+    let releaseLoadMore: (() => void) | null = null
+
+    api.responder = (method: string) => {
+      if (method === 'get') {
+        getCount += 1
+        // 1st GET = initial refresh; hand back a non-null cursor so loadMore is enabled.
+        if (getCount === 1) return { data: { items: rows, nextCursor: 25 }, status: 200 }
+        // 2nd GET = loadMore's page fetch — hold it pending until we release it,
+        // AFTER the rejected delete has run reconcile().
+        if (getCount === 2) {
+          return new Promise((resolve) => {
+            releaseLoadMore = () =>
+              resolve({ data: { items: [thread(3, 'c')], nextCursor: 50 }, status: 200 })
+          })
+        }
+        // Later GETs (reconcile, subsequent loadMore) resolve immediately.
+        return { data: { items: rows, nextCursor: 50 }, status: 200 }
+      }
+      if (method === 'delete') {
+        throw { response: { status: 403 } } // rejected; comment still exists
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+    expect(result.current.nextCursor).toBe(25)
+
+    // Kick off loadMore; its page GET is now pending (getCount === 2).
+    let loadMorePromise: Promise<void>
+    await act(async () => {
+      loadMorePromise = result.current.loadMore()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.loading).toBe(true))
+
+    // While that page fetch is in flight, a delete is rejected → runMutation
+    // catch → reconcile() runs.
+    await act(async () => {
+      await result.current.remove(1, false)
+    })
+
+    // Now let the in-flight loadMore GET resolve — its finally runs here.
+    await act(async () => {
+      releaseLoadMore!()
+      await loadMorePromise
+    })
+
+    // Regression assertions: loading must settle back to false...
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.nextCursor).not.toBeNull()
+
+    // ...and pagination must remain usable — a fresh loadMore must actually fire
+    // a new GET rather than being swallowed by a stuck loading flag.
+    const getsBefore = api.calls.filter((c) => c.method === 'get').length
+    await act(async () => {
+      await result.current.loadMore()
+    })
+    const getsAfter = api.calls.filter((c) => c.method === 'get').length
+    expect(getsAfter).toBeGreaterThan(getsBefore)
+  })
+
   it('does not regress create/reply/resolve refresh on success', async () => {
     let rows = [thread(1, 'a')]
     api.responder = (method: string, url: string) => {

--- a/packages/docs/src/comments/useDocComments.test.ts
+++ b/packages/docs/src/comments/useDocComments.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
+import { useDocComments } from './useDocComments.ts'
+
+let api: MockApiClient
+
+beforeEach(() => {
+  const wk = createMockWKApp()
+  api = wk.apiClient
+  setWKApp(wk)
+})
+
+function thread(id: number, body: string) {
+  return { id, parentId: null, body, replies: [] }
+}
+
+/** Build a responder that lists `items` for every GET and defers DELETE handling to `onDelete`. */
+function withList(items: () => unknown[], onDelete: () => { data: unknown; status: number }) {
+  return (method: string, url: string) => {
+    if (method === 'get') return { data: { items: items(), nextCursor: null }, status: 200 }
+    if (method === 'delete') return onDelete()
+    return { data: {}, status: 200 }
+  }
+}
+
+describe('useDocComments — delete reconciles UI with authoritative backend', () => {
+  it('drops the row on a successful delete', async () => {
+    let rows = [thread(1, 'a'), thread(2, 'b')]
+    api.responder = withList(
+      () => rows,
+      () => {
+        rows = rows.filter((r) => r.id !== 1) // server soft-deleted #1; list now filters it
+        return { data: { id: 1 }, status: 200 }
+      },
+    )
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+
+    await act(async () => {
+      await result.current.remove(1, false)
+    })
+
+    expect(result.current.threads.map((t) => t.id)).toEqual([2])
+    expect(result.current.error).toBeNull()
+  })
+
+  it('reconciles to server truth when the delete is rejected (e.g. 404 already-deleted) instead of leaving a stale row', async () => {
+    // The comment was already soft-deleted server-side, so the list no longer
+    // returns it and the DELETE is rejected with 404. The row must still leave
+    // the UI — this is the "deleted but still visible" regression.
+    let rows = [thread(1, 'a'), thread(2, 'b')]
+    api.responder = withList(
+      () => rows,
+      () => {
+        rows = rows.filter((r) => r.id !== 1) // it's gone from the authoritative list
+        throw { response: { status: 404 } }
+      },
+    )
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+
+    await act(async () => {
+      await result.current.remove(1, false)
+    })
+
+    // Row reconciled away (re-read from backend) AND the failure is surfaced.
+    expect(result.current.threads.map((t) => t.id)).toEqual([2])
+    expect(result.current.error).toBe('Failed to delete comment.')
+  })
+
+  it('keeps the row and shows the error when the delete is genuinely rejected and the comment still exists (e.g. 403)', async () => {
+    // Rejected without a server-side state change (permission denial): the
+    // comment truly still exists, so it must stay — but the error is shown.
+    const rows = [thread(1, 'a'), thread(2, 'b')]
+    api.responder = withList(
+      () => rows,
+      () => {
+        throw { response: { status: 403 } }
+      },
+    )
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(2))
+
+    await act(async () => {
+      await result.current.remove(1, false)
+    })
+
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2])
+    expect(result.current.error).toBe('Failed to delete comment.')
+  })
+
+  it('does not regress create/reply/resolve refresh on success', async () => {
+    let rows = [thread(1, 'a')]
+    api.responder = (method: string, url: string) => {
+      if (method === 'get') return { data: { items: rows, nextCursor: null }, status: 200 }
+      if (method === 'post') {
+        rows = [...rows, thread(2, 'b')]
+        return { data: { id: 2 }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { result } = renderHook(() => useDocComments('d_1'))
+    await waitFor(() => expect(result.current.threads).toHaveLength(1))
+
+    await act(async () => {
+      await result.current.reply(1, 'b')
+    })
+
+    expect(result.current.threads.map((t) => t.id)).toEqual([1, 2])
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/packages/docs/src/comments/useDocComments.ts
+++ b/packages/docs/src/comments/useDocComments.ts
@@ -45,7 +45,18 @@ export function useDocComments(docId: string): UseDocComments {
   // Stale-guard: a slow earlier refresh must not overwrite a newer one's result
   // (e.g. toggling includeResolved or a mutation-triggered refresh racing a manual
   // one). Each refresh/loadMore takes a monotonic token; only the latest applies.
+  // This token is also loading-bearing: refresh/loadMore reset the spinner in
+  // `finally` only when it still holds their token.
   const reqRef = useRef(0)
+
+  // Independent stale-guard for reconcile(), deliberately separate from reqRef.
+  // reconcile() must NOT claim a reqRef token: bumping it here would make an
+  // in-flight refresh/loadMore see a superseded token and skip its own
+  // `finally { setLoading(false) }`, while reconcile never touches loading —
+  // stranding the spinner true forever and deadlocking pagination. reconcile is
+  // a best-effort fallback re-read, not a loading-bearing load, so it guards
+  // only against a newer reconcile overwriting it.
+  const reconcileRef = useRef(0)
 
   const refresh = useCallback(async () => {
     const token = ++reqRef.current
@@ -90,12 +101,14 @@ export function useDocComments(docId: string): UseDocComments {
   // mutation is *rejected*: some rejections mean the server state already moved
   // (e.g. deleting a comment the backend had already soft-deleted returns 404),
   // so without re-reading the stale row lingers on screen — the "deleted but
-  // still visible" bug. Shares the latest-wins stale guard with refresh().
+  // still visible" bug. Uses its OWN token (reconcileRef), never reqRef, so it
+  // cannot preempt an in-flight refresh/loadMore's loading-bearing token; and it
+  // never touches `loading`, since it did not set it.
   const reconcile = useCallback(async () => {
-    const token = ++reqRef.current
+    const token = ++reconcileRef.current
     try {
       const res = await listComments(docId, { includeResolved, limit: PAGE_SIZE })
-      if (reqRef.current !== token) return // superseded by a newer load
+      if (reconcileRef.current !== token) return // superseded by a newer reconcile
       setThreads(res.items)
       setNextCursor(res.nextCursor)
     } catch {

--- a/packages/docs/src/comments/useDocComments.ts
+++ b/packages/docs/src/comments/useDocComments.ts
@@ -85,9 +85,29 @@ export function useDocComments(docId: string): UseDocComments {
     }
   }, [docId, includeResolved, nextCursor, loading])
 
+  // Best-effort re-read of the authoritative list that leaves the error banner
+  // untouched (the caller owns the message). Used to reconcile the UI after a
+  // mutation is *rejected*: some rejections mean the server state already moved
+  // (e.g. deleting a comment the backend had already soft-deleted returns 404),
+  // so without re-reading the stale row lingers on screen — the "deleted but
+  // still visible" bug. Shares the latest-wins stale guard with refresh().
+  const reconcile = useCallback(async () => {
+    const token = ++reqRef.current
+    try {
+      const res = await listComments(docId, { includeResolved, limit: PAGE_SIZE })
+      if (reqRef.current !== token) return // superseded by a newer load
+      setThreads(res.items)
+      setNextCursor(res.nextCursor)
+    } catch {
+      // Swallow: keep whatever failure message the caller is about to set.
+    }
+  }, [docId, includeResolved])
+
   // Wrap a mutating action so a failed API call surfaces as a panel error instead of
   // an unhandled rejection (the handlers only had `finally`, not `catch`). On success
-  // we re-read from the authoritative backend.
+  // we re-read from the authoritative backend. On failure we ALSO re-read: the backend
+  // is authoritative, so reconcile the list to server truth before showing the error
+  // (otherwise a delete the server already applied leaves the row on screen).
   const runMutation = useCallback(
     async (fn: () => Promise<unknown>, failMsg: string): Promise<void> => {
       setError(null)
@@ -95,10 +115,11 @@ export function useDocComments(docId: string): UseDocComments {
         await fn()
         await refresh()
       } catch {
+        await reconcile()
         setError(failMsg)
       }
     },
-    [refresh],
+    [refresh, reconcile],
   )
 
   const createRoot = useCallback(

--- a/packages/docs/src/comments/useDocComments.ts
+++ b/packages/docs/src/comments/useDocComments.ts
@@ -58,13 +58,29 @@ export function useDocComments(docId: string): UseDocComments {
   // token only to guard against a newer reconcile overwriting it.
   const reconcileRef = useRef(0)
 
+  // Data-freshness epoch, deliberately independent of both tokens above and of the
+  // loading lifecycle. reconcile() bumps it after it installs the server's
+  // authoritative list; refresh/loadMore snapshot it at start and drop their result
+  // (without touching their own loading reset) if a reconcile bumped it while their
+  // GET was in flight. This is what invalidates a load that was ALREADY in flight when
+  // the reconcile ran: reconcile can't use reqRef for that (it must not bump reqRef, or
+  // it would strand an in-flight loader's spinner — see reconcileRef above), so an
+  // in-flight loadMore capturing a page that still contained a since-deleted row would
+  // otherwise append it back after reconcile dropped it (the "phantom row" race).
+  // dataEpoch closes exactly that gap while keeping loading lifecycle and data freshness
+  // fully decoupled.
+  const dataEpoch = useRef(0)
+
   const refresh = useCallback(async () => {
     const token = ++reqRef.current
+    const startEpoch = dataEpoch.current
     setLoading(true)
     setError(null)
     try {
       const res = await listComments(docId, { includeResolved, limit: PAGE_SIZE })
-      if (reqRef.current !== token) return // superseded by a newer load
+      // Superseded by a newer load, or invalidated by an authoritative reconcile that
+      // landed while this GET was in flight — either way don't apply this (stale) page.
+      if (reqRef.current !== token || dataEpoch.current !== startEpoch) return
       setThreads(res.items)
       setNextCursor(res.nextCursor)
     } catch {
@@ -82,10 +98,14 @@ export function useDocComments(docId: string): UseDocComments {
   const loadMore = useCallback(async () => {
     if (nextCursor == null || loading) return
     const token = ++reqRef.current
+    const startEpoch = dataEpoch.current
     setLoading(true)
     try {
       const res = await listComments(docId, { includeResolved, cursor: nextCursor, limit: PAGE_SIZE })
-      if (reqRef.current !== token) return // superseded
+      // Superseded by a newer load, or invalidated by an authoritative reconcile that
+      // landed while this page was in flight — appending it now would re-introduce a
+      // row reconcile just dropped (the phantom-row race), so discard it.
+      if (reqRef.current !== token || dataEpoch.current !== startEpoch) return
       setThreads((prev) => [...prev, ...res.items])
       setNextCursor(res.nextCursor)
     } catch {
@@ -113,6 +133,14 @@ export function useDocComments(docId: string): UseDocComments {
   // Reading reqRef without bumping it is what lets reconcile guard against a
   // newer load (guard #2) while still leaving that load's loading-bearing token
   // intact, so its `finally { setLoading(false) }` still fires (no strand).
+  //
+  // On the apply path reconcile ALSO bumps dataEpoch: guard #2 only catches loads
+  // that outlived the reconcile's own token snapshot, but a loadMore already
+  // in flight when reconcile started shares that snapshot and would still pass
+  // guard #2 on completion — appending its now-stale page (which may still carry a
+  // row reconcile just removed). Bumping dataEpoch after setThreads makes such an
+  // in-flight load drop its result on the freshness check. The bump is AFTER
+  // setThreads so reconcile does not self-invalidate.
   const reconcile = useCallback(async () => {
     const token = ++reconcileRef.current
     const reqToken = reqRef.current
@@ -123,6 +151,7 @@ export function useDocComments(docId: string): UseDocComments {
       if (reconcileRef.current !== token || reqRef.current !== reqToken) return
       setThreads(res.items)
       setNextCursor(res.nextCursor)
+      dataEpoch.current++ // authoritative truth installed: invalidate in-flight loads
     } catch {
       // Swallow: keep whatever failure message the caller is about to set.
     }

--- a/packages/docs/src/comments/useDocComments.ts
+++ b/packages/docs/src/comments/useDocComments.ts
@@ -54,8 +54,8 @@ export function useDocComments(docId: string): UseDocComments {
   // in-flight refresh/loadMore see a superseded token and skip its own
   // `finally { setLoading(false) }`, while reconcile never touches loading —
   // stranding the spinner true forever and deadlocking pagination. reconcile is
-  // a best-effort fallback re-read, not a loading-bearing load, so it guards
-  // only against a newer reconcile overwriting it.
+  // a best-effort fallback re-read, not a loading-bearing load, so it owns this
+  // token only to guard against a newer reconcile overwriting it.
   const reconcileRef = useRef(0)
 
   const refresh = useCallback(async () => {
@@ -101,14 +101,26 @@ export function useDocComments(docId: string): UseDocComments {
   // mutation is *rejected*: some rejections mean the server state already moved
   // (e.g. deleting a comment the backend had already soft-deleted returns 404),
   // so without re-reading the stale row lingers on screen — the "deleted but
-  // still visible" bug. Uses its OWN token (reconcileRef), never reqRef, so it
-  // cannot preempt an in-flight refresh/loadMore's loading-bearing token; and it
-  // never touches `loading`, since it did not set it.
+  // still visible" bug.
+  //
+  // reconcile carries TWO guards, and NEITHER touches `loading`:
+  //   1. reconcileRef (its own token, bumped) — so a newer reconcile wins over
+  //      an older one.
+  //   2. reqRef (the shared load token, read-only *snapshot*, never bumped) — so
+  //      a refresh/loadMore that started or completed while this GET was in
+  //      flight wins. reconcile bails before setThreads instead of clobbering
+  //      that fresher result with its own stale snapshot.
+  // Reading reqRef without bumping it is what lets reconcile guard against a
+  // newer load (guard #2) while still leaving that load's loading-bearing token
+  // intact, so its `finally { setLoading(false) }` still fires (no strand).
   const reconcile = useCallback(async () => {
     const token = ++reconcileRef.current
+    const reqToken = reqRef.current
     try {
       const res = await listComments(docId, { includeResolved, limit: PAGE_SIZE })
-      if (reconcileRef.current !== token) return // superseded by a newer reconcile
+      // Superseded by a newer reconcile, or preempted by a newer refresh/loadMore
+      // (which already holds fresher data) — either way, don't overwrite.
+      if (reconcileRef.current !== token || reqRef.current !== reqToken) return
       setThreads(res.items)
       setNextCursor(res.nextCursor)
     } catch {


### PR DESCRIPTION
## Problem

Deleting an inline doc comment could leave the comment on screen — the "deleted but still visible" bug. `useDocComments`' `runMutation` only re-read the authoritative comment list on **success**; on failure it set the error banner and returned without re-reading. That is wrong for rejections where the server state has already moved.

Concretely, the delete affordance and the backend contract line up on the happy paths (author → soft delete, admin-on-other → `?hard=1`, both `200`). The rejections that reach the UI are:

- **404** — the comment was already soft-deleted server-side (repeat/double action, or a concurrent delete). The backend rejects with `not_found`, but the comment is already gone from the list. The old code swallowed this and kept the stale row.
- **403** — a genuine permission rejection where the comment still exists.

The old failure path treated both identically (banner only, no re-read), so the 404 case left a phantom row.

## Fix

Re-read the list in the failure path too, via a small best-effort `reconcile()` that updates threads/cursor but leaves the error message to the caller (and shares the existing latest-wins stale guard). The UI now converges on server truth regardless of the rejection:

- already-applied deletes (**404**) → the stale row is dropped
- genuine rejections (**403**) → the row stays and the error banner is shown

This keeps the hook's "backend is authoritative, re-read rather than guess" contract and is generic across create/reply/edit/resolve/delete — not delete-specific.

## Tests

Added `useDocComments.test.ts`:
- successful delete drops the row
- rejected-but-already-applied delete (404) reconciles the row away **and** surfaces the error
- genuine rejection (403) keeps the row and surfaces the error
- create/reply refresh-on-success is unaffected

`tsc -p tsconfig.typecheck.json` and `vitest run src/comments` are green (the only pre-existing typecheck errors are in unrelated files — `dmworkbase/i18n/format.ts`, `members/sort.ts` — and are unchanged by this PR).
