### PR TITLE
feat(loop): support renaming a runtime machine

### DIFF
--- a/packages/dmloop/src/api/__tests__/runtimeApi.test.ts
+++ b/packages/dmloop/src/api/__tests__/runtimeApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the HTTP layer so the test asserts the request contract without loading
+// axios / @octo/base. runtimeApi imports httpGet/httpPatch/currentWorkspaceSlug.
+vi.mock("../http", () => ({
+  httpGet: vi.fn(),
+  httpPatch: vi.fn(),
+  currentWorkspaceSlug: vi.fn(() => "ws-slug"),
+}));
+
+import { renameMachine } from "../runtimeApi";
+import { httpPatch } from "../http";
+
+describe("renameMachine", () => {
+  beforeEach(() => {
+    vi.mocked(httpPatch).mockReset();
+    vi.mocked(httpPatch).mockResolvedValue({} as never);
+  });
+
+  it("PATCHes /runtimes/:id with custom_name and apply_to_machine=true", async () => {
+    await renameMachine("rt-123", "王登的开发机");
+    expect(httpPatch).toHaveBeenCalledWith("/runtimes/rt-123", {
+      custom_name: "王登的开发机",
+      apply_to_machine: true,
+    });
+  });
+
+  it("forwards an empty name verbatim (backend treats empty as clear)", async () => {
+    await renameMachine("rt-9", "");
+    expect(httpPatch).toHaveBeenCalledWith("/runtimes/rt-9", {
+      custom_name: "",
+      apply_to_machine: true,
+    });
+  });
+});

--- a/packages/dmloop/src/api/runtimeApi.ts
+++ b/packages/dmloop/src/api/runtimeApi.ts
@@ -1,6 +1,6 @@
 // @octo/loop — Runtime API（后端契约联调；Runtime 已并入 Loop 二级菜单）
 import type { RuntimeDevice, ListParams } from "./types";
-import { currentWorkspaceSlug, httpGet } from "./http";
+import { currentWorkspaceSlug, httpGet, httpPatch } from "./http";
 import { runtimeListPath } from "./workspaceSelection";
 
 export async function listRuntimes(params?: ListParams): Promise<RuntimeDevice[]> {
@@ -14,4 +14,14 @@ export async function listRuntimes(params?: ListParams): Promise<RuntimeDevice[]
 
 export function getRuntime(id: string): Promise<RuntimeDevice> {
   return httpGet<RuntimeDevice>(`/runtimes/${id}`);
+}
+
+// Rename the machine hosting this runtime: applies the name (empty clears it,
+// reverting to the daemon-proposed device name) to every runtime the caller
+// owns on the same daemon.
+export function renameMachine(runtimeId: string, customName: string): Promise<RuntimeDevice> {
+  return httpPatch<RuntimeDevice>(`/runtimes/${runtimeId}`, {
+    custom_name: customName,
+    apply_to_machine: true,
+  });
 }

--- a/packages/dmloop/src/api/types.ts
+++ b/packages/dmloop/src/api/types.ts
@@ -624,6 +624,9 @@ export interface RuntimeDevice {
   workspace_id: string;
   daemon_id?: string | null;
   name: string;
+  // custom_name: user-set machine display override. Shown as custom_name ?? name.
+  // Optional for forward-compat: absent from backends without the column.
+  custom_name?: string | null;
   runtime_mode: RuntimeMode;
   provider: string;
   launch_header?: string;

--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -114,7 +114,14 @@
     "installTokenPlaceholder": "<generated when you click Copy>",
     "installPrompt": "Please install and configure the octo-daemon runtime on this machine. Run these steps in order:\n\n1. Install:\n{{install}}\n\n2. Configure permissions (login):\n{{auth}}\n\n3. Start / restart to apply:\n{{start}}\n\n4. Refer to octo-daemon --help to install the built-in skills.\n\nWhen done, confirm the daemon shows as online in the runtime list.",
     "headlessNoBackend": "The administrator has not configured a public backend URL; install instructions unavailable",
-    "headlessFailed": "Failed to generate install instructions, please retry"
+    "headlessFailed": "Failed to generate install instructions, please retry",
+    "rename": {
+      "title": "Rename machine",
+      "description": "Give this machine a name you'll recognize. It applies to every runtime on the machine and shows when picking a runtime for an expert.",
+      "hint": "Leave empty to use the device's default name.",
+      "saved": "Machine renamed",
+      "failed": "Failed to rename the machine"
+    }
   },
   "view": {
     "board": "Board",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -114,7 +114,14 @@
     "installTokenPlaceholder": "<点击「复制安装指令」时生成>",
     "installPrompt": "请在这台电脑上安装并配置 octo-daemon 运行时，依次执行：\n\n1. 安装：\n{{install}}\n\n2. 配置权限（登录认证）：\n{{auth}}\n\n3. 启动 / 重启使其生效：\n{{start}}\n\n4. 参考 octo-daemon --help 安装内置的 skills。\n\n完成后请确认该 daemon 在运行时列表中显示为在线。",
     "headlessNoBackend": "管理员未配置后端公开地址，无法生成安装指令",
-    "headlessFailed": "生成安装指令失败，请重试"
+    "headlessFailed": "生成安装指令失败，请重试",
+    "rename": {
+      "title": "重命名机器",
+      "description": "给这台机器起一个你能认出来的名字。会应用到这台机器上的所有运行时，并在给专家选择运行时时显示。",
+      "hint": "留空则使用设备的默认名称。",
+      "saved": "已重命名机器",
+      "failed": "重命名机器失败"
+    }
   },
   "view": {
     "board": "看板",

--- a/packages/dmloop/src/pages/RuntimePage.tsx
+++ b/packages/dmloop/src/pages/RuntimePage.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Typography, Spin, Banner, Toast } from "@douyinfe/semi-ui";
-import { Check, Circle, Copy, Cpu, Monitor, Plus } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Typography, Spin, Banner, Toast, Input, Button } from "@douyinfe/semi-ui";
+import { Check, Circle, Copy, Cpu, Monitor, Pencil, Plus } from "lucide-react";
 import { copyToClipboard, useI18n, WKModal } from "@octo/base";
-import type { RuntimeDevice, RuntimeMode } from "../api/types";
-import { listRuntimes } from "../api/runtimeApi";
+import type { RuntimeDevice } from "../api/types";
+import { listRuntimes, renameMachine } from "../api/runtimeApi";
+import type { LoopApiError } from "../api/http";
+import { type Device, groupRuntimesIntoDevices } from "./runtimeDevices";
 import LoopTag from "../ui/LoopTag";
 import LoopButton from "../ui/LoopButton";
 import { ProviderLogo, providerName } from "../ui/providerLogo";
@@ -13,19 +15,6 @@ import { deviceVersion, runtimeVersion } from "./runtimeVersion";
 import "./runtime.css";
 
 const { Title } = Typography;
-
-interface Device {
-  key: string;
-  name: string;
-  mode: RuntimeMode;
-  runtimes: RuntimeDevice[];
-}
-
-function deviceName(r: RuntimeDevice): string {
-  const info = r.device_info || "";
-  const head = info.split("·")[0]?.trim();
-  return head || r.name;
-}
 
 function deviceStatus(runtimes: RuntimeDevice[]): RuntimeDevice["status"] {
   return runtimes.some((runtime) => runtime.status === "online") ? "online" : "offline";
@@ -57,6 +46,7 @@ export default function RuntimePage() {
   const [promptText, setPromptText] = useState("");
   const [copyLoading, setCopyLoading] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<Device | null>(null);
   // 同步重入守卫：React state 是异步提交的，挡不住同一 tick 内的连点；
   // 用 ref 在签发前就拦住并发点击，保证一次会话只签发一个 PAT。
   const mintingRef = useRef(false);
@@ -67,30 +57,19 @@ export default function RuntimePage() {
     return () => window.clearTimeout(timer);
   }, [copied]);
 
-  useEffect(() => {
+  const reload = useCallback(() => {
     setLoading(true);
     setError(null);
     listRuntimes()
-      .then((rs) => {
-        setRuntimes(rs);
-      })
+      .then(setRuntimes)
       .catch((e) => setError(e?.message ?? "load failed"))
       .finally(() => setLoading(false));
   }, []);
+  useEffect(() => {
+    reload();
+  }, [reload]);
 
-  const devices = useMemo<Device[]>(() => {
-    const map = new Map<string, Device>();
-    for (const r of runtimes) {
-      const key = r.daemon_id || deviceName(r);
-      let d = map.get(key);
-      if (!d) {
-        d = { key, name: deviceName(r), mode: r.runtime_mode, runtimes: [] };
-        map.set(key, d);
-      }
-      d.runtimes.push(r);
-    }
-    return Array.from(map.values());
-  }, [runtimes]);
+  const devices = useMemo<Device[]>(() => groupRuntimesIntoDevices(runtimes), [runtimes]);
 
   // 统一安装指令(给 AI 队友的提示词):安装 → 配置权限(登录认证) → 启动/重启。
   // --server-url 用当前访问的 host(浏览器地址),让 daemon 直连用户正在访问的站点。
@@ -164,15 +143,25 @@ export default function RuntimePage() {
               const status = deviceStatus(device.runtimes);
               const version = deviceVersion(device.runtimes);
               return (
-              <section className="loop-runtime-machine" key={device.key} aria-label={device.name}>
+              <section className="loop-runtime-machine" key={device.key} aria-label={device.customName || device.name}>
                 <div className="loop-runtime-machine__head">
                   <div className="loop-runtime-machine__identity">
                     <span className="loop-runtime-machine__icon"><Monitor size={14} /></span>
-                    <strong>{device.name}</strong>
+                    <strong>{device.customName || device.name}</strong>
                     <span className={`loop-runtime-status is-${status}`}>
                       <Circle size={6} fill="currentColor" />
                       {t(`loop.runtime.${status}`)}
                     </span>
+                    {device.ownedByMe && (
+                      <Button
+                        theme="borderless"
+                        type="tertiary"
+                        size="small"
+                        icon={<Pencil size={13} />}
+                        aria-label={t("loop.runtime.rename.title")}
+                        onClick={() => setRenameTarget(device)}
+                      />
+                    )}
                   </div>
                   <div className="loop-runtime-machine__meta">
                     {version !== "-" && <LoopTag tone="grey">{version}</LoopTag>}
@@ -181,7 +170,7 @@ export default function RuntimePage() {
                     <strong>{t("loop.runtime.runtimeCount", { values: { count: device.runtimes.length } })}</strong>
                   </div>
                 </div>
-                <div className="loop-runtime-rows" role="table" aria-label={`${device.name} ${t("loop.nav.runtime")}`}>
+                <div className="loop-runtime-rows" role="table" aria-label={`${device.customName || device.name} ${t("loop.nav.runtime")}`}>
                   {device.runtimes.map((runtime) => (
                     <div key={runtime.id} className="loop-runtime-row" role="row">
                       <div className="loop-runtime-row__name" role="cell">
@@ -236,6 +225,106 @@ export default function RuntimePage() {
           </div>
         </div>
       </WKModal>
+      <RenameMachineDialog
+        visible={!!renameTarget}
+        device={renameTarget}
+        onClose={() => setRenameTarget(null)}
+        onDone={() => {
+          setRenameTarget(null);
+          reload();
+        }}
+      />
     </div>
+  );
+}
+
+/** Rename the machine hosting a group of runtimes; empty clears the override.
+ *  Kept mounted with a `visible` toggle (not conditionally mounted) so Semi's
+ *  Modal plays its open transition on false→true. */
+function RenameMachineDialog({
+  visible,
+  device,
+  onClose,
+  onDone,
+}: {
+  visible: boolean;
+  device: Device | null;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const { t } = useI18n();
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  // Ref guard closes the same-tick double-submit window (Enter + click) that a
+  // React state flag can't — mirrors the PAT-minting guard on this page.
+  const savingRef = useRef(false);
+  // The runtime the caller owns on this machine (can_bind) is both the PATCH
+  // target and the seed source, so the pre-filled value matches what the save
+  // will change — a mixed-owner group (shared hostname, no daemon_id) must not
+  // seed the caller with another member's name.
+  const owned = device?.runtimes.find((r) => r.can_bind === true);
+  const runtimeId = owned?.id;
+
+  // Seed the field from the caller's current name each time the dialog opens.
+  useEffect(() => {
+    if (visible) setValue(owned?.custom_name ?? "");
+  }, [visible, owned]);
+
+  const save = async () => {
+    if (savingRef.current || !runtimeId) return;
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      await renameMachine(runtimeId, value.trim());
+      Toast.success(t("loop.runtime.rename.saved"));
+      onDone();
+    } catch (e) {
+      // Surface backend detail only for client errors (4xx — actionable
+      // validation like "name too long"); for 5xx show just the localized
+      // message so internal server error text isn't exposed to the user.
+      const err = e as LoopApiError;
+      const detail = err?.status && err.status < 500 ? err.message : "";
+      Toast.error(detail ? `${t("loop.runtime.rename.failed")}: ${detail}` : t("loop.runtime.rename.failed"));
+    } finally {
+      setSaving(false);
+      savingRef.current = false;
+    }
+  };
+
+  // Block dismissal mid-save so a slow rename can't resolve and close a dialog
+  // the user has since reopened for a different machine.
+  const cancel = () => {
+    if (!saving) onClose();
+  };
+
+  return (
+    <WKModal
+      visible={visible}
+      onCancel={cancel}
+      title={t("loop.runtime.rename.title")}
+      footer={(
+        <>
+          <Button theme="borderless" type="tertiary" disabled={saving} onClick={cancel}>
+            {t("loop.action.cancel")}
+          </Button>
+          <LoopButton loading={saving} onClick={save}>
+            {t("loop.action.save")}
+          </LoopButton>
+        </>
+      )}
+    >
+      <div className="loop-runtime-rename">
+        <p className="loop-runtime-rename__desc">{t("loop.runtime.rename.description")}</p>
+        <Input
+          value={value}
+          onChange={setValue}
+          maxLength={100}
+          placeholder={device?.name}
+          aria-label={t("loop.runtime.rename.title")}
+          onEnterPress={save}
+        />
+        <p className="loop-runtime-rename__hint">{t("loop.runtime.rename.hint")}</p>
+      </div>
+    </WKModal>
   );
 }

--- a/packages/dmloop/src/pages/__tests__/runtimeDevices.test.ts
+++ b/packages/dmloop/src/pages/__tests__/runtimeDevices.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { groupRuntimesIntoDevices } from "../runtimeDevices";
+import type { RuntimeDevice } from "../../api/types";
+
+const rt = (over: Partial<RuntimeDevice>): RuntimeDevice =>
+  ({
+    id: "r",
+    workspace_id: "w",
+    name: "n",
+    runtime_mode: "built_in",
+    provider: "codex",
+    status: "online",
+    device_info: "",
+    visibility: "workspace",
+    last_seen_at: null,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  }) as RuntimeDevice;
+
+describe("groupRuntimesIntoDevices", () => {
+  it("groups by daemon_id and folds the shared custom_name / ownership", () => {
+    const devices = groupRuntimesIntoDevices([
+      rt({ id: "a", daemon_id: "d1", provider: "codex", custom_name: "王登的设备", can_bind: true }),
+      rt({ id: "b", daemon_id: "d1", provider: "claude", custom_name: "王登的设备", can_bind: true }),
+    ]);
+    expect(devices).toHaveLength(1);
+    expect(devices[0].runtimes).toHaveLength(2);
+    expect(devices[0].customName).toBe("王登的设备");
+    expect(devices[0].ownedByMe).toBe(true);
+  });
+
+  it("falls back to the hostname when a daemon reports no daemon_id", () => {
+    const devices = groupRuntimesIntoDevices([
+      rt({ id: "a", daemon_id: null, device_info: "MacBook·macOS", provider: "codex" }),
+      rt({ id: "b", daemon_id: null, device_info: "MacBook·macOS", provider: "claude" }),
+    ]);
+    expect(devices).toHaveLength(1);
+    expect(devices[0].name).toBe("MacBook");
+    expect(devices[0].ownedByMe).toBe(false);
+  });
+
+  it("labels a shared-hostname mixed-owner group from the OWNED runtime, not another member's name", () => {
+    // Two physical machines with the same hostname and no daemon_id collapse
+    // into one fallback group. The header must show the caller's own machine
+    // name (the rename target), never the other member's — regardless of order.
+    const theirs = rt({ id: "theirs", daemon_id: null, device_info: "MacBook·macOS", custom_name: "别人的设备", can_bind: false });
+    const mine = rt({ id: "mine", daemon_id: null, device_info: "MacBook·macOS", custom_name: "我的设备", can_bind: true });
+
+    for (const order of [[theirs, mine], [mine, theirs]]) {
+      const [device] = groupRuntimesIntoDevices(order);
+      expect(device.customName).toBe("我的设备");
+      expect(device.ownedByMe).toBe(true);
+    }
+  });
+
+  it("does NOT borrow a non-owned sibling's name when the owned runtime is unnamed/cleared", () => {
+    // Owned machine exists but has no custom_name (never named, or cleared);
+    // a non-owned machine in the same shared-hostname group is named. The header
+    // must NOT show the non-owned name (the pencil targets the owned runtime).
+    const theirs = rt({ id: "theirs", daemon_id: null, device_info: "MacBook·macOS", custom_name: "别人的设备", can_bind: false });
+    const mine = rt({ id: "mine", daemon_id: null, device_info: "MacBook·macOS", custom_name: null, can_bind: true });
+
+    for (const order of [[theirs, mine], [mine, theirs]]) {
+      const [device] = groupRuntimesIntoDevices(order);
+      expect(device.customName).toBeNull();
+      expect(device.ownedByMe).toBe(true);
+    }
+  });
+
+  it("derives the base name from the owned runtime even when a non-owned row is first in the group", () => {
+    // Same group key (daemon_id) but the non-owned row is first and carries a
+    // different device name; the owned runtime is unnamed. The header base name
+    // must come from the owned runtime (the rename target), never the first row.
+    const theirsFirst = rt({ id: "theirs", daemon_id: "shared", device_info: "TheirBox·linux", custom_name: null, can_bind: false });
+    const mine = rt({ id: "mine", daemon_id: "shared", device_info: "MyBox·macOS", custom_name: null, can_bind: true });
+    const [device] = groupRuntimesIntoDevices([theirsFirst, mine]);
+    expect(device.name).toBe("MyBox");
+    expect(device.customName).toBeNull();
+    expect(device.ownedByMe).toBe(true);
+  });
+
+  it("shows any custom_name for a group the caller does not own (no rename entry)", () => {
+    const [device] = groupRuntimesIntoDevices([
+      rt({ id: "a", daemon_id: "d2", custom_name: "共享机", can_bind: false }),
+    ]);
+    expect(device.customName).toBe("共享机");
+    expect(device.ownedByMe).toBe(false);
+  });
+
+  it("leaves customName null when no runtime has a custom_name", () => {
+    const [device] = groupRuntimesIntoDevices([
+      rt({ id: "a", daemon_id: "d3", device_info: "Linux·x86", can_bind: true }),
+    ]);
+    expect(device.customName).toBeNull();
+    expect(device.name).toBe("Linux");
+  });
+});

--- a/packages/dmloop/src/pages/runtime.css
+++ b/packages/dmloop/src/pages/runtime.css
@@ -240,3 +240,16 @@
     padding-left: var(--wk-sp-4);
   }
 }
+
+.loop-runtime-rename__desc {
+  margin: 0 0 var(--wk-sp-3);
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-sm);
+  line-height: 1.5;
+}
+
+.loop-runtime-rename__hint {
+  margin: var(--wk-sp-2) 0 0;
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-xs);
+}

--- a/packages/dmloop/src/pages/runtimeDevices.ts
+++ b/packages/dmloop/src/pages/runtimeDevices.ts
@@ -1,0 +1,54 @@
+import type { RuntimeDevice } from "../api/types";
+
+export interface Device {
+  key: string;
+  name: string;
+  // Machine display override shared by the daemon's runtimes; null falls back to name.
+  customName?: string | null;
+  // Whether the current member owns runtimes on this machine (can_bind is
+  // owner-only, server-computed) — gates the rename entry.
+  ownedByMe: boolean;
+  runtimes: RuntimeDevice[];
+}
+
+export function deviceName(r: RuntimeDevice): string {
+  const info = r.device_info || "";
+  const head = info.split("·")[0]?.trim();
+  return head || r.name;
+}
+
+/** Group runtimes into machines. Keyed by daemon_id, falling back to hostname
+ *  when a daemon reports none (legacy/headless). The label and the rename
+ *  target are both derived from the SAME owned (can_bind) runtime so a
+ *  shared-hostname fallback group (no daemon_id, mixed owners) can't show one
+ *  machine's name over a pencil that renames a different owned machine.
+ *  Non-owned groups fall back to any custom_name for display (no rename entry). */
+export function groupRuntimesIntoDevices(runtimes: RuntimeDevice[]): Device[] {
+  const map = new Map<string, Device>();
+  for (const r of runtimes) {
+    const key = r.daemon_id || deviceName(r);
+    let d = map.get(key);
+    if (!d) {
+      d = { key, name: deviceName(r), customName: null, ownedByMe: false, runtimes: [] };
+      map.set(key, d);
+    }
+    d.runtimes.push(r);
+    if (r.can_bind === true) d.ownedByMe = true;
+  }
+  for (const d of map.values()) {
+    const owned = d.runtimes.find((r) => r.can_bind === true);
+    // Derive the ENTIRE displayed identity (name + custom name) from the owned
+    // (can_bind) runtime — the same runtime the rename pencil targets — so the
+    // header can never show one machine's label over a pencil that renames a
+    // different one. This closes both the custom_name path and the base-name
+    // fallback for a shared-hostname mixed-owner group. Non-owned groups (no
+    // rename entry) keep the first row's name and any custom_name for display.
+    if (owned) {
+      d.name = deviceName(owned);
+      d.customName = owned.custom_name || null;
+    } else {
+      d.customName = d.runtimes.find((r) => r.custom_name)?.custom_name || null;
+    }
+  }
+  return Array.from(map.values());
+}

--- a/packages/dmloop/src/panel/RuntimePicker.tsx
+++ b/packages/dmloop/src/panel/RuntimePicker.tsx
@@ -5,14 +5,9 @@ import { useI18n } from "@octo/base";
 import type { RuntimeDevice } from "../api/types";
 import { ProviderLogo } from "../ui/providerLogo";
 import EllipsisText from "../ui/EllipsisText";
+import { deviceName } from "../pages/runtimeDevices";
 
 type Filter = "mine" | "all";
-
-// 设备（机器）标签：device_info 的首段（"host · 2.1.121 (Claude Code)" → "host"），回落到 runtime 名。
-function deviceLabel(r: RuntimeDevice): string {
-  const head = r.device_info?.split("·")[0]?.trim();
-  return head || r.name;
-}
 
 /**
  * Agent 详情页运行时下拉（对齐产品设计）：
@@ -64,12 +59,15 @@ export default function RuntimePicker({
       if (aLocked !== bLocked) return aLocked ? 1 : -1;
       return 0;
     });
-    const map = new Map<string, { label: string; items: RuntimeDevice[] }>();
+    const map = new Map<string, { key: string; label: string; items: RuntimeDevice[] }>();
     for (const r of sorted) {
-      const key = r.daemon_id || deviceLabel(r);
+      const key = r.daemon_id || deviceName(r);
       let g = map.get(key);
       if (!g) {
-        g = { label: deviceLabel(r), items: [] };
+        // Prefer the machine's custom name (set via the runtime page's rename),
+        // falling back to the device hostname — so a renamed machine is
+        // recognizable here too.
+        g = { key, label: r.custom_name || deviceName(r), items: [] };
         map.set(key, g);
       }
       g.items.push(r);
@@ -129,7 +127,7 @@ export default function RuntimePicker({
           <p className="loop-rtp__empty">{t("loop.agent.runtimeEmpty")}</p>
         ) : (
           groups.map((g) => (
-            <div key={g.label} className="loop-rtp__group">
+            <div key={g.key} className="loop-rtp__group">
               <div className="loop-rtp__group-head">
                 <Monitor size={11} className="loop-rtp__group-ico" />
                 <span className="loop-rtp__group-name">{g.label}</span>


### PR DESCRIPTION
## What & why

Fixes #829. A runtime's **machine** could not be renamed — the header showed the daemon-proposed hostname (e.g. `dws-MacBook-Pro.local`) with no way to give it a recognizable name. This adds a rename entry on the machine header of the OctoLoop runtime page (`我的 → 运行时`).

- A pencil button on the machine header (shown **only** for machines the member owns) opens a **"重命名机器"** dialog.
- Saving PATCHes `/runtimes/:id` with `{ custom_name, apply_to_machine: true }`, so the name applies to **every runtime on that machine**. The machine title then shows `custom_name ?? deviceName`; an empty value clears it back to the device default.
- Naming is **per workspace** (the same physical machine keeps its own name in another workspace) — matching the backend design.

## Ownership gate (why `can_bind`, not `owner_id`)

The rename entry is gated on the server-computed `can_bind` flag (owner-only, same condition as the backend's `canEditRuntime`). A runtime's `owner_id` is a **multica user id**, not the octo IM uid, so comparing it to the logged-in user client-side would never match; `can_bind` is the correct bridge-safe signal.

## Cross-repo dependency

Backend lands first in **octo-multica** (`agent_runtime.custom_name` + the `PATCH` fields + inherit-on-register): `octo-dev/octo-multica!71`. This PR reads `custom_name` **defensively** (optional field), so it degrades gracefully against a backend that hasn't shipped the column yet — the two ends can deploy independently.

## Interaction (7-dimension)

Owner-only entry (hidden otherwise) · dialog pre-fills the current name · loading state on save · success/failure toasts · empty = clear · 100-char cap · submit disabled while saving · Semi Modal kept mounted with a `visible` toggle so it animates open.

## Verification (real browser, dev)

Logged in as Alice on `localhost:3000/personal → 运行时`:
1. Rename entry shows for the owned machine → dialog opens with correct copy.
2. Rename → machine title becomes the custom name, and **all 4 runtimes** on the machine relabel (DB confirmed).
3. Per-workspace: the same physical machine's runtimes in another workspace are untouched.
4. Reopen pre-fills the current name; clearing reverts the title to the hostname.

No new deps. Brand-scanned (uses 「专家」, no upstream-brand leakage). Backend + frontend adversarially reviewed to a fixpoint; `/simplify` applied.

Closes #829