### PR TITLE
fix(docs): persist sheet auto row-height so text-wrap survives reload (WS-28)

### DIFF
--- a/packages/docs/src/sheet/binding.test.ts
+++ b/packages/docs/src/sheet/binding.test.ts
@@ -464,6 +464,24 @@ describe('UniverYjsBinding — column/row dimensions', () => {
     expect(dimMap.get('default:r5')).toBe(30)
   })
 
+  it('persists an auto-recomputed row height (e.g. from toggling text-wrap) — WS-28', () => {
+    // Toggling 自动换行 grows the row to fit; Univer emits set-worksheet-row-auto-height (NOT the
+    // manual set-worksheet-row-height), carrying per-row heights in rowsAutoHeightInfo. Without
+    // syncing it the grown height never reaches the Y.Doc and the row snaps back on reload.
+    const { univer, dimMap } = setup()
+    univer.fire({
+      id: 'sheet.mutation.set-worksheet-row-auto-height',
+      params: {
+        rowsAutoHeightInfo: [
+          { row: 0, autoHeight: 48 },
+          { row: 2, autoHeight: 66 },
+        ],
+      },
+    })
+    expect(dimMap.get('default:r0')).toBe(48)
+    expect(dimMap.get('default:r2')).toBe(66)
+  })
+
   it('applies a remote column width into the sheet', () => {
     const { univer, doc } = setup()
     applyRemote(doc, (peer) => peer.getMap(SHEET_DIMS_FIELD).set('default:c1', 88))

--- a/packages/docs/src/sheet/binding.test.ts
+++ b/packages/docs/src/sheet/binding.test.ts
@@ -466,12 +466,14 @@ describe('UniverYjsBinding — column/row dimensions', () => {
 
   it('persists an auto-recomputed row height (e.g. from toggling text-wrap) — WS-28', () => {
     // Toggling 自动换行 grows the row to fit; Univer emits set-worksheet-row-auto-height (NOT the
-    // manual set-worksheet-row-height), carrying per-row heights in rowsAutoHeightInfo. Without
-    // syncing it the grown height never reaches the Y.Doc and the row snaps back on reload.
+    // manual set-worksheet-row-height), carrying per-row heights in rowsAutoHeightInfo keyed by the
+    // mutation's own subUnitId. Without syncing it the grown height never reaches the Y.Doc and the
+    // row snaps back on reload.
     const { univer, dimMap } = setup()
     univer.fire({
       id: 'sheet.mutation.set-worksheet-row-auto-height',
       params: {
+        subUnitId: 'local-1', // the first sheet, logical 'default'
         rowsAutoHeightInfo: [
           { row: 0, autoHeight: 48 },
           { row: 2, autoHeight: 66 },
@@ -480,6 +482,34 @@ describe('UniverYjsBinding — column/row dimensions', () => {
     })
     expect(dimMap.get('default:r0')).toBe(48)
     expect(dimMap.get('default:r2')).toBe(66)
+  })
+
+  it('routes an auto-height mutation to its OWN subUnitId sheet, not the active sheet — WS-28', () => {
+    // An auto-height recompute can fire against a non-focused sheet. The mutation's subUnitId is the
+    // authoritative target; using the active sheet would persist the height under the wrong sheet's
+    // key (right sheet stays clipped on reload, wrong sheet gets over-tall).
+    const { univer, dimMap } = setup()
+    const s2 = univer.addSheet('Sheet2')
+    univer.setActive(s2.getSheetId())
+    univer.fire({ id: 'sheet.command.insert-sheet' }) // register Sheet2 into the logical map
+    univer.setActive('local-1') // active sheet is now the FIRST sheet ('default')
+    // Auto-height targets Sheet2 while 'default' is active.
+    univer.fire({
+      id: 'sheet.mutation.set-worksheet-row-auto-height',
+      params: { subUnitId: s2.getSheetId(), rowsAutoHeightInfo: [{ row: 1, autoHeight: 52 }] },
+    })
+    expect(dimMap.get(`${s2.getSheetId()}:r1`)).toBe(52) // written under Sheet2's logical id
+    expect(dimMap.has('default:r1')).toBe(false) // NOT under the active sheet
+  })
+
+  it('ignores an auto-height mutation whose subUnitId maps to no known sheet — WS-28', () => {
+    const { univer, dimMap } = setup()
+    univer.fire({
+      id: 'sheet.mutation.set-worksheet-row-auto-height',
+      params: { subUnitId: 'ghost-sheet', rowsAutoHeightInfo: [{ row: 0, autoHeight: 48 }] },
+    })
+    expect(dimMap.has('default:r0')).toBe(false)
+    expect(dimMap.has('ghost-sheet:r0')).toBe(false)
   })
 
   it('applies a remote column width into the sheet', () => {

--- a/packages/docs/src/sheet/binding.ts
+++ b/packages/docs/src/sheet/binding.ts
@@ -824,22 +824,25 @@ export class UniverYjsBinding {
   /** Persist Univer's auto-recomputed row heights into the SAME dim map + key shape as a manual
    * row-height resize, so reload restores them via applyRemoteDims. Params differ from the manual
    * set-worksheet-row-height: heights arrive per-row in `rowsAutoHeightInfo` ({ row, autoHeight })
-   * rather than one `rowHeight` spanning `ranges`. Keyed by the ACTIVE sheet's logical id, matching
-   * syncDimFromCommand (an interactive wrap toggle acts on the active sheet). */
+   * rather than one `rowHeight` spanning `ranges`. Keyed off the mutation's OWN `subUnitId` (the
+   * worksheet the recompute actually targeted) — NOT the active sheet, since an auto-height pass can
+   * fire against a non-focused sheet and must not write its heights under the active sheet's keys.
+   * Bounds mirror the restore path (applyRemoteDims): row within grid, height finite/positive/≤cap. */
   private syncAutoRowHeightFromCommand(command: { id: string; params?: unknown }): void {
-    const p = command.params as { rowsAutoHeightInfo?: Array<{ row?: number; autoHeight?: number }> } | undefined
+    const p = command.params as
+      | { subUnitId?: string; rowsAutoHeightInfo?: Array<{ row?: number; autoHeight?: number }> }
+      | undefined
     const infos = p?.rowsAutoHeightInfo
     if (!infos || infos.length === 0) return
-    const wb = this.workbook()
-    const sheet = wb?.getActiveSheet()
-    if (!wb || !sheet) return
-    const logical = this.localToLogical.get(sheet.getSheetId())
+    if (typeof p?.subUnitId !== 'string') return
+    const logical = this.localToLogical.get(p.subUnitId)
     if (!logical) return
     const entries: Array<[string, number]> = []
     for (const info of infos) {
       const row = info?.row
       const h = info?.autoHeight
-      if (!Number.isInteger(row) || typeof h !== 'number' || !Number.isFinite(h) || h <= 0) continue
+      if (!Number.isInteger(row) || (row as number) < 0 || (row as number) >= SHEET_MAX_ROWS) continue
+      if (typeof h !== 'number' || !Number.isFinite(h) || h <= 0 || h > SHEET_MAX_DIM_PX) continue
       entries.push([`${logical}:r${row}`, h])
     }
     if (entries.length === 0) return

--- a/packages/docs/src/sheet/binding.ts
+++ b/packages/docs/src/sheet/binding.ts
@@ -46,10 +46,20 @@ const TRIGGER_IDS = new Set<string>([
   'sheet.command.set-border-style',
 ])
 
-/** Column-width / row-height mutations. */
+/** Column-width / row-height mutations (a manual resize drag). */
 const DIM_TRIGGER_IDS = new Set<string>([
   'sheet.mutation.set-worksheet-col-width',
   'sheet.mutation.set-worksheet-row-height',
+])
+
+/** Row auto-height recompute. Univer fires THIS mutation (not set-worksheet-row-height) when a
+ * layout-affecting cell style — text-wrap (`tb`), font family/size (`ff`/`fs`), rotation (`tr`) —
+ * grows a row to fit its content. Heights arrive per-row in `rowsAutoHeightInfo`, a different param
+ * shape than the manual resize above. Without syncing it, toggling 自动换行 updates the local model
+ * (row grows, UI looks right) but the new height never lands in the Y.Doc, so on reload the row
+ * snaps back to the default height and clips the wrapped text (WS-28). */
+const AUTO_ROW_HEIGHT_TRIGGER_IDS = new Set<string>([
+  'sheet.mutation.set-worksheet-row-auto-height',
 ])
 
 /** Add/remove merge mutations. */
@@ -314,6 +324,7 @@ export class UniverYjsBinding {
         if (!this.canWrite()) return
         if (TRIGGER_IDS.has(command.id)) this.syncLocalToYmap()
         else if (DIM_TRIGGER_IDS.has(command.id)) this.syncDimFromCommand(command)
+        else if (AUTO_ROW_HEIGHT_TRIGGER_IDS.has(command.id)) this.syncAutoRowHeightFromCommand(command)
         else if (MERGE_TRIGGER_IDS.has(command.id)) this.syncMergesToYmap()
         else if (DRAWING_TRIGGER_IDS.has(command.id)) this.syncDrawingsToYmap()
         else if (SHEET_LIFECYCLE_IDS.has(command.id)) {
@@ -800,6 +811,36 @@ export class UniverYjsBinding {
     for (const rg of p.ranges) {
       if (isCol) for (let c = rg.startColumn; c <= rg.endColumn; c++) entries.push([`${logical}:c${c}`, size])
       else for (let r = rg.startRow; r <= rg.endRow; r++) entries.push([`${logical}:r${r}`, size])
+    }
+    if (entries.length === 0) return
+    this.dimMap.doc?.transact(() => {
+      for (const [k, v] of entries) {
+        this.lastSeenDims.set(k, v)
+        this.dimMap.set(k, v)
+      }
+    })
+  }
+
+  /** Persist Univer's auto-recomputed row heights into the SAME dim map + key shape as a manual
+   * row-height resize, so reload restores them via applyRemoteDims. Params differ from the manual
+   * set-worksheet-row-height: heights arrive per-row in `rowsAutoHeightInfo` ({ row, autoHeight })
+   * rather than one `rowHeight` spanning `ranges`. Keyed by the ACTIVE sheet's logical id, matching
+   * syncDimFromCommand (an interactive wrap toggle acts on the active sheet). */
+  private syncAutoRowHeightFromCommand(command: { id: string; params?: unknown }): void {
+    const p = command.params as { rowsAutoHeightInfo?: Array<{ row?: number; autoHeight?: number }> } | undefined
+    const infos = p?.rowsAutoHeightInfo
+    if (!infos || infos.length === 0) return
+    const wb = this.workbook()
+    const sheet = wb?.getActiveSheet()
+    if (!wb || !sheet) return
+    const logical = this.localToLogical.get(sheet.getSheetId())
+    if (!logical) return
+    const entries: Array<[string, number]> = []
+    for (const info of infos) {
+      const row = info?.row
+      const h = info?.autoHeight
+      if (!Number.isInteger(row) || typeof h !== 'number' || !Number.isFinite(h) || h <= 0) continue
+      entries.push([`${logical}:r${row}`, h])
     }
     if (entries.length === 0) return
     this.dimMap.doc?.transact(() => {


### PR DESCRIPTION
## WS-28 — Sheet 单元格「自动换行」reload 后失效

### 现象
在电子表格（Sheet）里给单元格开「自动换行」后，UI 立即正确（行自动撑高、文本折行），但离开文档再回来，行高恢复默认、把折行文本裁掉。

### 根因
换行状态本身（Univer cell style 的 `tb`）走的是通用样式同步通道，已经能持久化。真正丢的是**换行触发的行高自动增长**：Univer 用 `SetWorksheetRowAutoHeightMutation`（`sheet.mutation.set-worksheet-row-auto-height`）应用这次撑高，它跟手动拖拽的 `set-worksheet-row-height` 是两条不同的 mutation，行高以 per-row 的 `rowsAutoHeightInfo` 携带。协同 binding 的 `DIM_TRIGGER_IDS` 只监听了手动 resize，没监听 auto-height，所以撑高只改了本地模型（UI 看着对），从没进 Y.Doc → reload 从 Y.Doc 重建时行高回落。

### 改动
`packages/docs/src/sheet/binding.ts`：新增对 `sheet.mutation.set-worksheet-row-auto-height` 的监听，把重算出的行高写进**与手动 resize 完全相同的 dim map、相同 key 形状**（`${logical}:r<idx>`），reload 时沿用现有 `applyRemoteDims` 恢复。改动最小、边界清晰，不动其它同步路径。

- 前端 only，不涉及 doc schema / 后端（Sheet 走 content-agnostic 的 Yjs + Hocuspocus）。
- 无 migration：存量文档缺该 key 时行为与今天一致（内容撑开）。

### 验证
- `packages/docs` 单测全绿（42 passed，含新增 auto-height 持久化用例）。
- `pnpm typecheck` 改动文件零新增报错（仓库既有的两处无关报错不在本改动文件）。

Fixes WS-28
