### PR TITLE
fix(nginx): repair octo-doc proxy query encoding, restore SPA fallback + unify /docs-html/* prefix

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -112,10 +112,10 @@ server {
         location /d/ {
             resolver 127.0.0.11 ipv6=off valid=30s;
             if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            # No location-prefix rewrite happens with a variable proxy_pass; forward the
-            # original URI verbatim so /d/... reaches the doc unchanged.
-            rewrite ^ $request_uri break;
-            proxy_pass $doc_app_url;
+            # Variable proxy_pass: append the original URI (incl. query) directly so
+            # /d/<slug>?... reaches the doc verbatim. A `rewrite ^ $request_uri break`
+            # would URL-encode the `?` into %3F and break query strings.
+            proxy_pass $doc_app_url$request_uri;
             proxy_set_header token $http_token;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -188,8 +188,11 @@ server {
         location /api/v1/docs {
             resolver 127.0.0.11 ipv6=off valid=30s;
             if ($docs_backend_url = "") { return 503 '{"status":503,"msg":"octo-docs-backend is not configured"}'; }
-            rewrite ^ $request_uri break;
-            proxy_pass $docs_backend_url;
+            # Variable proxy_pass: append the original URI (incl. query) directly.
+            # A `rewrite ^ $request_uri break` would URL-encode the `?` into %3F
+            # (breaking list?owner=me → 404); appending $request_uri to the
+            # variable forwards path+query verbatim, matching the pre-rewrite behavior.
+            proxy_pass $docs_backend_url$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -238,5 +241,9 @@ server {
         location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;
+            # SPA fallback: unknown paths (client-side routes like the docs "my
+            # files" view, deep links, refresh) fall through to index.html so
+            # React Router can handle them, instead of a hard 404.
+            try_files $uri $uri/ /index.html;
         }
 }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -104,71 +104,35 @@ server {
             client_max_body_size 100m;
         }
 
-        # octo-doc HTML render + agent-auth token passthrough. Upstream is env-driven
-        # ($doc_app_url) so the image ports to any environment via .env, no conf edit.
-        # The `token` header carries the octo login token for doc-side identity verify.
-        # resolver + runtime-variable proxy_pass: the doc host resolves per-request, so an
+        # ── octo-doc HTML: single unified prefix /docs-html/* ─────────────────────
+        # All web→octo-doc traffic is namespaced under ONE prefix (evaluator ask:
+        # the previously scattered top-level paths /d/, /comments, /reactions,
+        # /grants/, /docs-admin/, /docs/{slug}/versions used generic words that risk
+        # colliding with SPA / other service routes and are hard to govern). The
+        # frontend now prepends /docs-html (resolveOctoDocBase default); this block
+        # strips it and rewrites each sub-path to octo-doc's native route, then
+        # forwards to $doc_app_url with the octo `token` header for identity.
+        # resolver + runtime-variable proxy_pass: doc host resolves per-request, so an
         # unset/unresolvable DOC_APP_URL 503s this route instead of failing nginx startup.
-        location /d/ {
+        # Rewrites are ordered most-specific-first; each ends in `break`.
+        location /docs-html/ {
             resolver 127.0.0.11 ipv6=off valid=30s;
             if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            # Variable proxy_pass: append the original URI (incl. query) directly so
-            # /d/<slug>?... reaches the doc verbatim. A `rewrite ^ $request_uri break`
-            # would URL-encode the `?` into %3F and break query strings.
-            proxy_pass $doc_app_url$request_uri;
-            proxy_set_header token $http_token;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        # octo-doc HTML comments/reactions: frontend calls same-origin /comments|/reactions
-        # (no /v1); rewrite to the doc's /v1/* and pass the octo token for identity.
-        location /comments {
-            resolver 127.0.0.11 ipv6=off valid=30s;
-            if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            rewrite ^/comments(.*)$ /v1/comments$1 break;
-            proxy_pass $doc_app_url;
-            proxy_set_header token $http_token;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location /reactions {
-            resolver 127.0.0.11 ipv6=off valid=30s;
-            if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            rewrite ^/reactions(.*)$ /v1/reactions$1 break;
-            proxy_pass $doc_app_url;
-            proxy_set_header token $http_token;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        # octo-doc HTML per-doc reader grants: frontend calls same-origin
-        # /grants/{slug}[/{uid}]; rewrite to the doc's /v1/docs/{slug}/grants[/{uid}]
-        # and pass the octo token for identity. Top-level /grants prefix avoids the
-        # SPA's own /docs route. DELETE .../{uid} rewrite must precede GET/PUT.
-        location /grants/ {
-            resolver 127.0.0.11 ipv6=off valid=30s;
-            if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            rewrite ^/grants/([^/]+)/(.+)$ /v1/docs/$1/grants/$2 break;
-            rewrite ^/grants/([^/]+)$      /v1/docs/$1/grants      break;
-            proxy_pass $doc_app_url;
-            proxy_set_header token $http_token;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        # octo-doc HTML doc admin (delete): frontend calls same-origin /docs-admin/{slug};
-        # rewrite to the doc's /v1/docs/{slug} and pass the octo token for identity. Top-level
-        # /docs-admin prefix avoids the SPA's /docs route and the /v1/ block below (proxied to
-        # octo-server, which has no doc delete endpoint).
-        location /docs-admin/ {
-            resolver 127.0.0.11 ipv6=off valid=30s;
-            if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            rewrite ^/docs-admin/(.+)$ /v1/docs/$1 break;
+            # per-doc grants: /docs-html/grants/{slug}[/{uid}] → /v1/docs/{slug}/grants[/{uid}]
+            # ({uid} form must precede the bare form)
+            rewrite ^/docs-html/grants/([^/]+)/(.+)$ /v1/docs/$1/grants/$2 break;
+            rewrite ^/docs-html/grants/([^/]+)$       /v1/docs/$1/grants      break;
+            # doc admin (delete): /docs-html/docs-admin/{slug} → /v1/docs/{slug}
+            rewrite ^/docs-html/docs-admin/(.+)$      /v1/docs/$1             break;
+            # versions: /docs-html/docs/{slug}/versions → /v1/docs/{slug}/versions
+            rewrite ^/docs-html/docs/(.+)$            /v1/docs/$1            break;
+            # comments / reactions: /docs-html/comments… → /v1/comments…
+            rewrite ^/docs-html/comments(.*)$         /v1/comments$1         break;
+            rewrite ^/docs-html/reactions(.*)$        /v1/reactions$1        break;
+            # render page: /docs-html/d/{slug}/v/{ver} → /d/{slug}/v/{ver} (verbatim)
+            rewrite ^/docs-html/(d/.*)$               /$1                    break;
+            # anything else under the prefix: strip /docs-html, forward as-is
+            rewrite ^/docs-html/(.*)$                 /$1                    break;
             proxy_pass $doc_app_url;
             proxy_set_header token $http_token;
             proxy_set_header Host $host;

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -80,8 +80,8 @@ describe('resolveOctoDocBase / buildOctoDocUrl', () => {
     expect(resolveOctoDocBase()).toBe('https://octo-doc.example.com')
   })
 
-  it('defaults to same-origin (empty base) when nothing is configured', () => {
-    expect(resolveOctoDocBase()).toBe('')
+  it('defaults to the same-origin /docs-html unified prefix when nothing is configured', () => {
+    expect(resolveOctoDocBase()).toBe('/docs-html')
   })
 
   it('builds the octo-doc read-only URL `<base>/d/{slug}/v/{version}`', () => {
@@ -232,7 +232,7 @@ describe('HtmlDocView — read-only rendering', () => {
     })
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="published-slug" version="v7" />)
     await waitForFrame(container)
-    expect(String(spy.mock.calls[0][0])).toBe('/d/published-slug/v/v7')
+    expect(String(spy.mock.calls[0][0])).toBe('/docs-html/d/published-slug/v/v7')
   })
 
   it('shows a loading state before the fetch resolves', async () => {

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -109,6 +109,29 @@ describe('absolutizeDocAssetUrls', () => {
     expect(out).toContain('src="https://od.test/d/slug/assets/b.png?exp=9"')
   })
 
+  it('re-roots root-relative /d/ octo-doc assets under the same-origin /docs-html prefix (DEFAULT deploy)', () => {
+    // DEFAULT deploy: no override, resolveOctoDocBase() === '/docs-html'. The doc backend emits
+    // root-relative refs like /d/{slug}/assets/{sha}; without re-rooting they resolve against the
+    // page origin, DROP the /docs-html prefix, and 404 (the nginx only proxies /docs-html/*).
+    expect(resolveOctoDocBase()).toBe('/docs-html')
+    const out = absolutizeDocAssetUrls(
+      '<!doctype html><html><body><img src="/d/slug/assets/a.png?sig=s1&exp=9"></body></html>',
+      // same-origin default docUrl form: {origin}/docs-html/d/{slug}/v/{ver}
+      'http://localhost/docs-html/d/slug/v/latest'
+    )
+    expect(out).toContain('src="http://localhost/docs-html/d/slug/assets/a.png?sig=s1&amp;exp=9"')
+    expect(out).not.toContain('src="http://localhost/d/slug/assets/a.png')
+  })
+
+  it('does not double-prefix an asset already under /docs-html/d/', () => {
+    const out = absolutizeDocAssetUrls(
+      '<!doctype html><html><body><img src="/docs-html/d/slug/assets/a.png"></body></html>',
+      'http://localhost/docs-html/d/slug/v/latest'
+    )
+    expect(out).toContain('src="http://localhost/docs-html/d/slug/assets/a.png"')
+    expect(out).not.toContain('/docs-html/docs-html/')
+  })
+
   it('leaves already absolute asset URLs and ordinary relative links untouched', () => {
     const out = absolutizeDocAssetUrls(
       '<html><head><link href="https://cdn.test/d/slug/assets/doc.css"></head><body><img src="/other/image.png"><a href="chapter.html">next</a></body></html>',

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -189,9 +189,11 @@ export interface HtmlDocViewProps {
  *   1. `window.__OCTO_DOC_BASE__` — runtime injection (host config / index.html), so the
  *      same bundle points at different octo-doc origins per environment without a rebuild.
  *   2. `import.meta.env.VITE_OCTO_DOC_BASE` — build-time override.
- *   3. Empty string — resolve RELATIVE to the page origin (i.e. octo-doc reverse-proxied
- *      under the same host). This is a safe default; a deployment where octo-doc lives
- *      elsewhere must set one of the two overrides above.
+ *   3. Default `/docs-html` — a same-origin unified prefix. All web→octo-doc traffic
+ *      (render `/d/…`, comments, reactions, grants, docs-admin, versions) is namespaced
+ *      under this one prefix so it is easy to govern and cannot collide with SPA or other
+ *      service routes. The web nginx reverse-proxies `/docs-html/*` to octo-doc (stripping
+ *      the prefix). A deployment where octo-doc lives elsewhere sets one of the overrides above.
  */
 export function resolveOctoDocBase(): string {
   const runtime =
@@ -202,8 +204,8 @@ export function resolveOctoDocBase(): string {
       ? (import.meta as unknown as { env?: { VITE_OCTO_DOC_BASE?: string } }).env?.VITE_OCTO_DOC_BASE
       : undefined
   if (typeof env === 'string' && env.trim()) return env.trim().replace(/\/+$/, '')
-  // Same-origin default: octo-doc proxied under the current host.
-  return ''
+  // Same-origin unified prefix: octo-doc reverse-proxied under /docs-html (see web nginx).
+  return '/docs-html'
 }
 
 /** Build the octo-doc read-only render URL: `<base>/d/{slug}/v/{version}`. */

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -78,21 +78,32 @@ function isAbsoluteOrSpecialUrl(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//') || value.startsWith('#')
 }
 
-function resolveDocAssetUrl(value: string, docUrl: string): string | null {
+// basePrefix is the octo-doc same-origin path prefix (resolveOctoDocBase, e.g. '/docs-html'),
+// empty for cross-origin/override deployments. A root-relative octo-doc asset ref like
+// `/d/{slug}/assets/{sha}` (the form the doc backend emits, see signAssetURLs) resolves
+// against the PAGE ORIGIN and would DROP the prefix, hitting a path the nginx no longer
+// proxies — re-root it under basePrefix first so it stays inside /docs-html/*. Only re-root
+// when docUrl itself sits under basePrefix (i.e. the same-origin prefixed deploy); an
+// absolute/override docUrl already carries the doc origin and must be left alone.
+function resolveDocAssetUrl(value: string, docUrl: string, basePrefix = ''): string | null {
   if (!value || isAbsoluteOrSpecialUrl(value)) return null
   try {
-    const url = new URL(value, docUrl)
+    const docPath = new URL(docUrl).pathname
+    const underPrefix = !!basePrefix && (docPath === basePrefix || docPath.startsWith(basePrefix + '/'))
+    const rebased =
+      underPrefix && value.startsWith('/d/') && !value.startsWith(basePrefix + '/') ? basePrefix + value : value
+    const url = new URL(rebased, docUrl)
     return /\/assets\//.test(url.pathname) ? url.href : null
   } catch {
     return null
   }
 }
 
-function absolutizeAssetAttr(el: Element, attr: 'src' | 'href', docUrl: string) {
+function absolutizeAssetAttr(el: Element, attr: 'src' | 'href', docUrl: string, basePrefix = '') {
   const raw = el.getAttribute(attr)
   if (!raw) return
   const value = raw.trim()
-  const resolved = resolveDocAssetUrl(value, docUrl)
+  const resolved = resolveDocAssetUrl(value, docUrl, basePrefix)
   if (resolved) el.setAttribute(attr, resolved)
 }
 
@@ -132,9 +143,13 @@ export function resolveHtmlDocAnchorText(
 export function absolutizeDocAssetUrls(html: string, docUrl = resolveAbsoluteOctoDocBase()): string {
   if (typeof DOMParser === 'undefined') return html
   const absoluteDocUrl = resolveAbsoluteUrl(docUrl)
+  // Same-origin path prefix (e.g. '/docs-html'); '' for absolute/cross-origin bases. Used to
+  // re-root the backend's root-relative `/d/...` asset refs so they keep the prefix.
+  const base = resolveOctoDocBase()
+  const basePrefix = base.startsWith('/') ? base.replace(/\/+$/, '') : ''
   const doc = new DOMParser().parseFromString(html, 'text/html')
-  doc.querySelectorAll('img[src]').forEach((el) => absolutizeAssetAttr(el, 'src', absoluteDocUrl))
-  doc.querySelectorAll('link[href]').forEach((el) => absolutizeAssetAttr(el, 'href', absoluteDocUrl))
+  doc.querySelectorAll('img[src]').forEach((el) => absolutizeAssetAttr(el, 'src', absoluteDocUrl, basePrefix))
+  doc.querySelectorAll('link[href]').forEach((el) => absolutizeAssetAttr(el, 'href', absoluteDocUrl, basePrefix))
   neutralizeEditableControls(doc)
   const doctype = doc.doctype ? `<!doctype ${doc.doctype.name}>` : ''
   return `${doctype}${doc.documentElement.outerHTML}`


### PR DESCRIPTION
## 概述
修复并收敛 nginx 中 web→octo-doc 的代理路由，解决 #846 引入的三处回归，并按评审意见把所有 octo-doc 流量统一到单一 `/docs-html/*` 前缀下。

## 改动
**1. `fix(nginx)`：修复 proxy query 编码 + 恢复 SPA fallback（153d5dfa）**
- `/d/` 与 `/api/v1/docs` 之前用 `rewrite ^ $request_uri break;` 配合变量 proxy_pass，变量上游会对 URI 做 URL 编码，`?` 被转成 `%3F`，导致 `/api/v1/docs?owner=me` 到后端变成 `%3F` 而 404（docs「我的文件」列表、`/d/?code=` 等全挂）。改为 `proxy_pass $var$request_uri;` 逐字转发 path+query，还原 #846 前行为。
- `location /` 丢了 SPA fallback（上游模板缺 `try_files $uri $uri/ /index.html;`），客户端路由/深链/刷新硬 404。恢复之。

**2. `feat(nginx)`：统一 web→octo-doc 到单一 `/docs-html/*` 前缀（291d7a78）**
- 前端 `resolveOctoDocBase()` 默认值从 `''`（同源根）改为 `/docs-html`；所有 octo-doc 请求（render + comments/reactions/grants/docs-admin/versions）自动加前缀（单一收口，无需逐调用改）。运行时/构建覆盖（`__OCTO_DOC_BASE__` / `VITE_OCTO_DOC_BASE`）仍优先。同步更新 2 处单测预期。
- nginx 用单个 `location /docs-html/` 取代原先分散的五个 location，剥掉前缀并把各子路径重写到 octo-doc 原生路由，保留 resolver + 未配置时 503 的安全模式。

## 验证
- `envsubst` 渲染后 `nginx -t` 通过。
- 本地 3001 重建：`/api/v1/docs?owner=me` 返回 401（后端可达，原为 404）、`/d/<slug>?code=` 逐字转发、SPA 深链+刷新 200。
- `/docs-html/*` 打到 octo-doc（与直连 octo-doc 基线一致）；mano-cua（laosan 登录）确认 render + comment POST 走 `/docs-html/*` 均 200。

## 变更文件
- `nginx.conf.template`
- `packages/docs/src/html/HtmlDocView.tsx`
- `packages/docs/src/html/HtmlDocView.test.tsx`
