### PR TITLE
refactor(profile): restructure profile detail layers

### DIFF
--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -73,8 +73,8 @@ export default class BotDetailModal extends Component<BotDetailModalProps> {
     }
 
     componentDidUpdate(prevProps: BotDetailModalProps) {
-        if (prevProps.uid !== this.props.uid && this.props.uid) {
-            this.vm.setUid(this.props.uid);
+        if (prevProps.uid !== this.props.uid) {
+            this.vm.setUid(this.props.uid || "");
         }
         if (prevProps.visible && !this.props.visible) {
             this.vm.resetTransientState();

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -7,7 +7,6 @@ import {
     IconEdit,
     IconTickCircle,
 } from "@douyinfe/semi-icons";
-import axios from "axios";
 import WKModal from "../WKModal";
 import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
 import WKApp from "../../App";
@@ -19,6 +18,7 @@ import AiBadge from "../AiBadge";
 import ClawInfoModal from "../ClawInfoModal/ClawInfoModal";
 import BotManageModal from "../BotManage";
 import AgentCardService from "../../Service/AgentCardService";
+import BotProfileService from "../../Service/BotProfileService";
 import { I18nContext, t } from "../../i18n";
 import { canvasToPngFile, isAvatarFileTooLarge, isGifImageFile } from "../avatarUpload";
 import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
@@ -224,7 +224,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
 
         try {
             // 用 user detail API 获取完整信息（包含 follow）
-            const data = await WKApp.apiClient.get(`users/${requestedUid}`);
+            const data = await BotProfileService.getBotProfile(requestedUid);
             if (isStale()) return;
             const creatorUid = data.bot_creator_uid || "";
             this.setState({
@@ -344,16 +344,9 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
 
     uploadBotAvatar = async (file: File): Promise<boolean> => {
         const { uid } = this.props;
-        const param = new FormData();
-        param.append("file", file);
         this.setState({ uploadingAvatar: true });
         try {
-            await axios.post(`users/${uid}/avatar`, param, {
-                headers: {
-                    "Content-Type": "multipart/form-data",
-                    "token": WKApp.loginInfo.token || "",
-                },
-            });
+            await BotProfileService.uploadAvatar(uid, file, WKApp.loginInfo.token || "");
             if (!this.isCurrentUid(uid)) return false;
             WKApp.shared.changeChannelAvatarTag(new Channel(uid, ChannelTypePerson));
             // 触发 channelInfoListener，通知其他组件刷新头像
@@ -441,9 +434,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
         const isCurrent = () => this.isCurrentUid(requestedUid);
         this.setState({ savingDescription: true });
         try {
-            await WKApp.apiClient.put(`robot/${requestedUid}/description`, {
-                description: descriptionDraft,
-            });
+            await BotProfileService.updateDescription(requestedUid, descriptionDraft);
             if (!isCurrent()) return;
             Toast.success(t("base.botDetail.descriptionUpdated"));
             this.setState({
@@ -481,7 +472,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
         const isCurrent = () => this.mounted && this.props.uid === requestedUid;
         this.setState({ savingRemark: true });
         try {
-            await WKApp.apiClient.put("friend/remark", { uid: requestedUid, remark });
+            await BotProfileService.updateRemark(requestedUid, remark);
             if (!isCurrent()) return;
             Toast.success(t("base.botDetail.remarkUpdated"));
             this.setState({
@@ -527,12 +518,11 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
         const isCurrent = () => this.isCurrentUid(requestedUid);
         this.setState({ applying: true });
         try {
-            const body: any = { to_uid: requestedUid, remark: applyRemark };
-            const spaceId = WKApp.shared.currentSpaceId;
-            if (spaceId) {
-                body.space_id = spaceId;
-            }
-            await WKApp.apiClient.post("friend/apply", body);
+            await BotProfileService.applyFriend({
+                uid: requestedUid,
+                remark: applyRemark,
+                spaceId: WKApp.shared.currentSpaceId,
+            });
             if (!isCurrent()) return;
             Toast.success(t("base.botDetail.apply.sent"));
             this.setState({ showApplyInput: false });

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -17,11 +17,13 @@ import WKAvatarPreviewImage from "../WKAvatarPreviewImage";
 import AiBadge from "../AiBadge";
 import ClawInfoModal from "../ClawInfoModal/ClawInfoModal";
 import BotManageModal from "../BotManage";
-import AgentCardService from "../../Service/AgentCardService";
-import BotProfileService from "../../Service/BotProfileService";
 import { I18nContext, t } from "../../i18n";
 import { canvasToPngFile, isAvatarFileTooLarge, isGifImageFile } from "../avatarUpload";
 import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
+import BotDetailVM, {
+    parseBotCommands,
+    stripBotDetailDisplayName,
+} from "../../bridge/profileDetail/BotDetailVM";
 import "./index.css";
 
 interface BotDetailModalProps {
@@ -31,266 +33,68 @@ interface BotDetailModalProps {
     onChat: (channel: Channel) => void;
 }
 
-interface BotDetailModalState {
-    loading: boolean;
-    name: string;
-    remark: string;
-    username: string;
-    description: string;
-    creatorName: string;
-    creatorUid: string;
-    botCommands: string;
-    isFriend: boolean;
-    applying: boolean;
-    showApplyInput: boolean;
-    applyRemark: string;
-    uploadingAvatar: boolean;
-    editingDescription: boolean;
-    descriptionDraft: string;
-    savingDescription: boolean;
-    editingRemark: boolean;
-    remarkDraft: string;
-    savingRemark: boolean;
-    // Agent Card 上报状态（true=已上报，false=未上报，null=加载中）
-    reported: boolean | null;
-    reportStatusLoading: boolean;
-    showClawInfo: boolean;
-    showBotManage: boolean;
-    avatarCropFile: File | null;
-    avatarPreviewFile: File | null;
-}
-
-export default class BotDetailModal extends Component<BotDetailModalProps, BotDetailModalState> {
+export default class BotDetailModal extends Component<BotDetailModalProps> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
 
-    private refreshTimer: ReturnType<typeof setTimeout> | null = null;
     private $fileInput: HTMLInputElement | null = null;
     private avatarEdit: WKAvatarEditor | null = null;
-    private mounted = false;
     private descriptionRef = React.createRef<HTMLTextAreaElement>();
+    private vm: BotDetailVM;
+    private unsubscribeVM?: () => void;
 
-    private isCurrentUid = (uid: string) => {
-        return this.mounted && this.props.uid === uid;
-    };
+    constructor(props: BotDetailModalProps) {
+        super(props);
+        this.vm = new BotDetailVM(props.uid, {
+            getLoginUid: () => WKApp.loginInfo.uid,
+            getToken: () => WKApp.loginInfo.token || "",
+            getSpaceId: () => WKApp.shared.currentSpaceId,
+            fetchChannelInfo: (uid) => WKSDK.shared().channelManager.fetchChannelInfo(
+                new Channel(uid, ChannelTypePerson)
+            ),
+            refreshChannelInfo: (uid) => WKSDK.shared().channelManager.fetchChannelInfo(
+                new Channel(uid, ChannelTypePerson)
+            ),
+            onAvatarChanged: (uid) => {
+                WKApp.shared.changeChannelAvatarTag(new Channel(uid, ChannelTypePerson));
+                WKSDK.shared().channelManager.fetchChannelInfo(new Channel(uid, ChannelTypePerson));
+                this.forceUpdate();
+            },
+        });
+    }
 
     private handleDescriptionVoiceTranscribed = (
         text: string,
         mode: ReplaceMode,
         savedRange?: SelectionRange
     ) => {
-        if (mode === "all") {
-            this.setState({ descriptionDraft: text.slice(0, 200) });
-        } else if (mode === "selection" && savedRange) {
-            this.setState((prev) => {
-                const before = prev.descriptionDraft.slice(0, savedRange.from);
-                const after = prev.descriptionDraft.slice(savedRange.to);
-                const budget = Math.max(0, 200 - before.length - after.length);
-                return { descriptionDraft: before + text.slice(0, budget) + after };
-            });
-        } else {
-            this.setState((prev) => {
-                const pos = savedRange?.from ?? prev.descriptionDraft.length;
-                const before = prev.descriptionDraft.slice(0, pos);
-                const after = prev.descriptionDraft.slice(pos);
-                const budget = Math.max(0, 200 - before.length - after.length);
-                return { descriptionDraft: before + text.slice(0, budget) + after };
-            });
-        }
-    };
-
-    state: BotDetailModalState = {
-        loading: true,
-        name: "",
-        remark: "",
-        username: "",
-        description: "",
-        creatorName: "",
-        creatorUid: "",
-        botCommands: "",
-        isFriend: false,
-        applying: false,
-        showApplyInput: false,
-        applyRemark: "",
-        uploadingAvatar: false,
-        editingDescription: false,
-        descriptionDraft: "",
-        savingDescription: false,
-        editingRemark: false,
-        remarkDraft: "",
-        savingRemark: false,
-        reported: null,
-        reportStatusLoading: false,
-        showClawInfo: false,
-        showBotManage: false,
-        avatarCropFile: null,
-        avatarPreviewFile: null,
+        this.vm.updateDescriptionDraftWithTranscription(text, mode, savedRange);
     };
 
     componentDidMount() {
-        this.mounted = true;
+        this.unsubscribeVM = this.vm.addListener(() => this.forceUpdate());
+        this.vm.mount();
         if (this.props.uid) {
-            this.loadBotInfo();
+            this.vm.loadBotInfo();
         }
     }
 
     componentDidUpdate(prevProps: BotDetailModalProps) {
         if (prevProps.uid !== this.props.uid && this.props.uid) {
-            // 复用同一 BotDetailModal 实例切到新 bot 时，先关掉「Bot 管理」子模态。
-            // 否则在 loadBotInfo() 重算 isOwner 之前会有一帧用「旧 bot 的 creatorUid」
-            // 判定 owner，却把「新 uid」透传给 BotManageModal —— 可能让用户在所有权
-            // 重新校验前对一个未必属于自己的 bot 触发一次群数据加载（codex P2）。
-            this.setState({ showBotManage: false });
-            this.loadBotInfo();
+            this.vm.setUid(this.props.uid);
         }
         if (prevProps.visible && !this.props.visible) {
-            this.setState({
-                avatarCropFile: null,
-                avatarPreviewFile: null,
-                showBotManage: false,
-                showClawInfo: false,
-            });
+            this.vm.resetTransientState();
         }
     }
 
     componentWillUnmount() {
-        this.mounted = false;
-        if (this.refreshTimer) {
-            clearTimeout(this.refreshTimer);
-            this.refreshTimer = null;
-        }
+        this.unsubscribeVM?.();
+        this.vm.unmount();
     }
 
-    loadReportStatus = async () => {
-        const requestedUid = this.props.uid;
-        if (!requestedUid) return;
-
-        const isStale = () => !this.isCurrentUid(requestedUid);
-
-        this.setState({ reported: null, reportStatusLoading: true });
-        try {
-            const result = await AgentCardService.getReportStatus(requestedUid);
-            if (isStale()) return; // 如果已切换到其他 bot，忽略旧请求
-            this.setState({ reported: result });
-        } catch (error) {
-            if (isStale()) return;
-            console.error("[BotDetailModal] loadReportStatus failed:", error);
-            // 网络错误时不设置 reported，避免误导用户
-            // reported 保持 null，不显示 OctoPush chip 和龙虾按钮
-        } finally {
-            if (!isStale()) {
-                this.setState({ reportStatusLoading: false });
-            }
-        }
-    };
-
-    loadBotInfo = async () => {
-        const requestedUid = this.props.uid;
-        if (!requestedUid) return;
-
-        // Reset all bot-specific state at the start of each load so that
-        // a new uid (e.g. when the modal instance is reused by BotStore /
-        // GlobalSearch / Subscribers) cannot see leftover state from the
-        // previously displayed bot.
-        this.setState({
-            loading: true,
-            name: "",
-            remark: "",
-            username: "",
-            description: "",
-            creatorName: "",
-            creatorUid: "",
-            botCommands: "",
-            isFriend: false,
-            applying: false,
-            showApplyInput: false,
-            applyRemark: "",
-            uploadingAvatar: false,
-            editingDescription: false,
-            descriptionDraft: "",
-            savingDescription: false,
-            avatarCropFile: null,
-            avatarPreviewFile: null,
-            editingRemark: false,
-            remarkDraft: "",
-            savingRemark: false,
-            reported: null,
-            reportStatusLoading: false,
-            showClawInfo: false,
-            showBotManage: false,
-        });
-
-        const isStale = () => !this.isCurrentUid(requestedUid);
-
-        try {
-            // 用 user detail API 获取完整信息（包含 follow）
-            const data = await BotProfileService.getBotProfile(requestedUid);
-            if (isStale()) return;
-            const creatorUid = data.bot_creator_uid || "";
-            this.setState({
-                loading: false,
-                name: data.name || requestedUid,
-                remark: data.remark || "",
-                username: data.username || requestedUid,
-                description: data.bot_description || "",
-                creatorName: data.bot_creator_name || "",
-                creatorUid: creatorUid,
-                botCommands: data.bot_commands || "",
-                isFriend: data.follow === 1,
-                editingDescription: false,
-            }, () => {
-                // 只有当前用户是 bot 的创建者时才加载上报状态
-                if (this.isOwner()) {
-                    this.loadReportStatus();
-                }
-            });
-        } catch {
-            // fallback to channel info
-            try {
-                const channelInfo = await WKSDK.shared().channelManager.fetchChannelInfo(
-                    new Channel(requestedUid, ChannelTypePerson)
-                );
-                if (isStale()) return;
-                const creatorUid = channelInfo?.orgData?.bot_creator_uid || "";
-                this.setState({
-                    loading: false,
-                    name: channelInfo?.title || requestedUid,
-                    remark: channelInfo?.orgData?.remark || "",
-                    username: requestedUid,
-                    description: channelInfo?.orgData?.bot_description || "",
-                    creatorName: channelInfo?.orgData?.bot_creator_name || "",
-                    creatorUid: creatorUid,
-                    botCommands: channelInfo?.orgData?.bot_commands || "",
-                    isFriend: channelInfo?.orgData?.follow === 1,
-                    editingDescription: false,
-                }, () => {
-                    // 只有当前用户是 bot 的创建者时才加载上报状态
-                    if (this.isOwner()) {
-                        this.loadReportStatus();
-                    }
-                });
-            } catch {
-                if (isStale()) return;
-                // Keep the reset done above (creatorUid="") so isOwner()
-                // can never return true for a bot we failed to load.
-                this.setState({
-                    loading: false,
-                    name: requestedUid,
-                    remark: "",
-                    username: requestedUid,
-                    description: "",
-                    creatorName: "",
-                    creatorUid: "",
-                    botCommands: "",
-                    isFriend: false,
-                    editingDescription: false,
-                });
-            }
-        }
-    };
-
     stripDisplayName = (value: string) => {
-        return value.replace(/\*\*/g, "");
+        return stripBotDetailDisplayName(value);
     };
 
     handleChat = () => {
@@ -301,18 +105,13 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
     };
 
     handleClose = () => {
-        this.setState({
-            avatarCropFile: null,
-            avatarPreviewFile: null,
-            showBotManage: false,
-            showClawInfo: false,
-        });
+        this.vm.resetTransientState();
         this.props.onClose();
     };
 
     // === Owner 头像编辑 ===
     handleAvatarClick = () => {
-        if (!this.isOwner() || this.state.uploadingAvatar) return;
+        if (!this.vm.isOwner() || this.vm.state.uploadingAvatar) return;
         this.$fileInput?.click();
     };
 
@@ -343,27 +142,16 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
     };
 
     uploadBotAvatar = async (file: File): Promise<boolean> => {
-        const { uid } = this.props;
-        this.setState({ uploadingAvatar: true });
-        try {
-            await BotProfileService.uploadAvatar(uid, file, WKApp.loginInfo.token || "");
-            if (!this.isCurrentUid(uid)) return false;
-            WKApp.shared.changeChannelAvatarTag(new Channel(uid, ChannelTypePerson));
-            // 触发 channelInfoListener，通知其他组件刷新头像
-            WKSDK.shared().channelManager.fetchChannelInfo(new Channel(uid, ChannelTypePerson));
+        const result = await this.vm.uploadAvatar(file);
+        if (result === "ok") {
             Toast.success(t("base.botDetail.avatarUpdated"));
             this.forceUpdate();
             return true;
-        } catch (err) {
-            if (this.isCurrentUid(uid)) {
-                Toast.error(t("base.botDetail.avatarUploadFailed"));
-            }
-            return false;
-        } finally {
-            if (this.isCurrentUid(uid)) {
-                this.setState({ uploadingAvatar: false });
-            }
         }
+        if (result === "failed") {
+            Toast.error(t("base.botDetail.avatarUploadFailed"));
+        }
+        return false;
     };
 
     handleAvatarFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -375,28 +163,28 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
             return;
         }
         if (isGifImageFile(file)) {
-            this.setState({ avatarPreviewFile: file });
+            this.vm.setAvatarPreviewFile(file);
             return;
         }
-        this.setState({ avatarCropFile: file });
+        this.vm.setAvatarCropFile(file);
     };
 
     handleAvatarCropCancel = () => {
-        if (this.state.uploadingAvatar) return;
-        this.setState({ avatarCropFile: null });
+        if (this.vm.state.uploadingAvatar) return;
+        this.vm.setAvatarCropFile(null);
     };
 
     handleAvatarPreviewCancel = () => {
-        if (this.state.uploadingAvatar) return;
-        this.setState({ avatarPreviewFile: null });
+        if (this.vm.state.uploadingAvatar) return;
+        this.vm.setAvatarPreviewFile(null);
     };
 
     handleAvatarPreviewSave = async () => {
-        const { avatarPreviewFile } = this.state;
+        const { avatarPreviewFile } = this.vm.state;
         if (!avatarPreviewFile) return;
         const uploaded = await this.uploadBotAvatar(avatarPreviewFile);
         if (uploaded) {
-            this.setState({ avatarPreviewFile: null });
+            this.vm.setAvatarPreviewFile(null);
         }
     };
 
@@ -412,146 +200,75 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
         }
         const uploaded = await this.uploadBotAvatar(file);
         if (uploaded) {
-            this.setState({ avatarCropFile: null });
+            this.vm.setAvatarCropFile(null);
         }
     };
 
     // === Owner 简介编辑 ===
     handleStartEditDescription = () => {
-        if (!this.isOwner()) return;
-        const { description } = this.state;
-        const raw = description.replace(/\*\*/g, "");
-        this.setState({ editingDescription: true, descriptionDraft: raw });
+        this.vm.startEditDescription();
     };
 
     handleCancelEditDescription = () => {
-        this.setState({ editingDescription: false, descriptionDraft: "" });
+        this.vm.cancelEditDescription();
     };
 
     handleSaveDescription = async () => {
-        const requestedUid = this.props.uid;
-        const { descriptionDraft } = this.state;
-        const isCurrent = () => this.isCurrentUid(requestedUid);
-        this.setState({ savingDescription: true });
-        try {
-            await BotProfileService.updateDescription(requestedUid, descriptionDraft);
-            if (!isCurrent()) return;
+        const result = await this.vm.saveDescription();
+        if (result === "ok") {
             Toast.success(t("base.botDetail.descriptionUpdated"));
-            this.setState({
-                description: descriptionDraft,
-                editingDescription: false,
-                descriptionDraft: "",
-            });
-        } catch {
-            if (isCurrent()) {
-                Toast.error(t("base.botDetail.descriptionUpdateFailed"));
-            }
-        } finally {
-            if (isCurrent()) {
-                this.setState({ savingDescription: false });
-            }
+        } else if (result === "failed") {
+            Toast.error(t("base.botDetail.descriptionUpdateFailed"));
         }
     };
 
     // === 个人备注编辑 ===
     handleStartEditRemark = () => {
-        this.setState({
-            editingRemark: true,
-            remarkDraft: this.stripDisplayName(this.state.remark),
-        });
+        this.vm.startEditRemark();
     };
 
     handleCancelEditRemark = () => {
-        this.setState({ editingRemark: false, remarkDraft: "" });
+        this.vm.cancelEditRemark();
     };
 
     handleSaveRemark = async () => {
-        const requestedUid = this.props.uid;
-        const { remarkDraft } = this.state;
-        const remark = remarkDraft.trim();
-        const isCurrent = () => this.mounted && this.props.uid === requestedUid;
-        this.setState({ savingRemark: true });
-        try {
-            await BotProfileService.updateRemark(requestedUid, remark);
-            if (!isCurrent()) return;
+        const result = await this.vm.saveRemark();
+        if (result === "ok") {
             Toast.success(t("base.botDetail.remarkUpdated"));
-            this.setState({
-                remark,
-                editingRemark: false,
-                remarkDraft: "",
-            });
-            Promise.resolve(
-                WKSDK.shared().channelManager.fetchChannelInfo(new Channel(requestedUid, ChannelTypePerson))
-            ).catch((error: unknown) => {
-                console.warn("[BotDetailModal] refresh channel after remark failed:", error);
-            });
-        } catch {
-            if (isCurrent()) {
-                Toast.error(t("base.botDetail.remarkUpdateFailed"));
-            }
-        } finally {
-            if (isCurrent()) {
-                this.setState({ savingRemark: false });
-            }
+        } else if (result === "failed") {
+            Toast.error(t("base.botDetail.remarkUpdateFailed"));
         }
     };
 
     isOwner = () => {
-        const { creatorUid } = this.state;
-        const loginUid = WKApp.loginInfo.uid;
-        return !!creatorUid && !!loginUid && creatorUid === loginUid;
+        return this.vm.isOwner();
     };
 
     handleShowApply = () => {
-        const { name } = this.state;
-        this.setState({
-            showApplyInput: true,
-            applyRemark: t("base.botDetail.apply.defaultMessage", {
+        const { name } = this.vm.state;
+        this.vm.showApplyInput(
+            t("base.botDetail.apply.defaultMessage", {
                 values: { name: this.stripDisplayName(name) },
             }),
-        });
+        );
     };
 
     handleSubmitApply = async () => {
-        const requestedUid = this.props.uid;
-        const { applyRemark } = this.state;
-        const isCurrent = () => this.isCurrentUid(requestedUid);
-        this.setState({ applying: true });
-        try {
-            await BotProfileService.applyFriend({
-                uid: requestedUid,
-                remark: applyRemark,
-                spaceId: WKApp.shared.currentSpaceId,
-            });
-            if (!isCurrent()) return;
+        const result = await this.vm.submitApply();
+        if (result === "ok") {
             Toast.success(t("base.botDetail.apply.sent"));
-            this.setState({ showApplyInput: false });
-            if (this.refreshTimer) {
-                clearTimeout(this.refreshTimer);
-            }
-            this.refreshTimer = setTimeout(() => {
-                if (this.isCurrentUid(requestedUid)) {
-                    this.loadBotInfo();
-                }
-            }, 500);
-        } catch {
-            if (isCurrent()) {
-                Toast.error(t("base.botDetail.apply.failed"));
-            }
-        } finally {
-            if (isCurrent()) {
-                this.setState({ applying: false });
-            }
+        } else if (result === "failed") {
+            Toast.error(t("base.botDetail.apply.failed"));
         }
     };
 
     handleViewClawInfo = () => {
-        this.setState({ showClawInfo: true });
+        this.vm.openClawInfo();
     };
 
     handleOpenBotManage = (event?: React.MouseEvent) => {
         event?.stopPropagation();
-        this.setState({ showBotManage: true });
+        this.vm.openBotManage();
     };
 
     render() {
@@ -580,7 +297,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
             showBotManage,
             avatarCropFile,
             avatarPreviewFile,
-        } = this.state;
+        } = this.vm.state;
         const isOwner = this.isOwner();
         const botName = this.stripDisplayName(name);
         const displayName = this.stripDisplayName(remark || name);
@@ -588,10 +305,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
             ? this.stripDisplayName(description)
             : t("base.botDetail.noDescription");
 
-        let commands: { cmd: string; remark: string }[] = [];
-        try {
-            if (botCommands) commands = JSON.parse(botCommands);
-        } catch {}
+        const commands = parseBotCommands(botCommands);
 
         return (
             <>
@@ -704,7 +418,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                                             <div className="wk-bot-detail-editor">
                                                 <Input
                                                     value={remarkDraft}
-                                                    onChange={(v) => this.setState({ remarkDraft: v })}
+                                                    onChange={(v) => this.vm.setRemarkDraft(v)}
                                                     placeholder={t("base.botDetail.remarkPlaceholder")}
                                                     maxLength={30}
                                                 />
@@ -781,7 +495,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                                                     ref={this.descriptionRef}
                                                     className="wk-bot-detail-textarea"
                                                     value={descriptionDraft}
-                                                    onChange={(e) => this.setState({ descriptionDraft: e.target.value.slice(0, 200) })}
+                                                    onChange={(e) => this.vm.setDescriptionDraft(e.target.value)}
                                                     placeholder={t("base.botDetail.descriptionPlaceholder")}
                                                     maxLength={200}
                                                     rows={3}
@@ -789,7 +503,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                                                 <VoiceInputButton
                                                     inputRef={this.descriptionRef}
                                                     onTranscribed={this.handleDescriptionVoiceTranscribed}
-                                                    getCurrentText={() => this.state.descriptionDraft}
+                                                    getCurrentText={() => this.vm.state.descriptionDraft}
                                                     showModeMenu
                                                     size="sm"
                                                     className="wk-vib--textarea-corner"
@@ -891,7 +605,7 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                                     <div className="wk-bot-detail-apply-label">{t("base.botDetail.apply.messageLabel")}</div>
                                     <Input
                                         value={applyRemark}
-                                        onChange={(v) => this.setState({ applyRemark: v })}
+                                        onChange={(v) => this.vm.setApplyRemark(v)}
                                         placeholder={t("base.botDetail.apply.messagePlaceholder")}
                                     />
                                     <Button
@@ -926,13 +640,13 @@ export default class BotDetailModal extends Component<BotDetailModalProps, BotDe
                 botId={uid}
                 botName={name}
                 visible={showClawInfo}
-                onClose={() => this.setState({ showClawInfo: false })}
+                onClose={() => this.vm.closeClawInfo()}
             />
             {isOwner && (
                 <BotManageModal
                     robotId={uid}
                     visible={visible && showBotManage}
-                    onClose={() => this.setState({ showBotManage: false })}
+                    onClose={() => this.vm.closeBotManage()}
                 />
             )}
             <WKModal

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -1,12 +1,5 @@
 import React, { Component } from "react";
-import { Button, Spin, Toast, Input } from "@douyinfe/semi-ui";
-import {
-    IconAlertCircle,
-    IconCamera,
-    IconChevronRight,
-    IconEdit,
-    IconTickCircle,
-} from "@douyinfe/semi-icons";
+import { Toast } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
 import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
 import WKApp from "../../App";
@@ -14,16 +7,16 @@ import WKAvatar from "../WKAvatar";
 import { WKAvatarEditor } from "../WKAvatarEditor";
 import { WKAvatarUploadPreview } from "../WKAvatarUploadPreview";
 import WKAvatarPreviewImage from "../WKAvatarPreviewImage";
-import AiBadge from "../AiBadge";
 import ClawInfoModal from "../ClawInfoModal/ClawInfoModal";
 import BotManageModal from "../BotManage";
 import { I18nContext, t } from "../../i18n";
 import { canvasToPngFile, isAvatarFileTooLarge, isGifImageFile } from "../avatarUpload";
-import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
+import type { ReplaceMode, SelectionRange } from "../VoiceInputButton";
 import BotDetailVM, {
     parseBotCommands,
     stripBotDetailDisplayName,
 } from "../../bridge/profileDetail/BotDetailVM";
+import BotDetailView from "../../ui/profileDetail/BotDetailView";
 import "./index.css";
 
 interface BotDetailModalProps {
@@ -316,325 +309,85 @@ export default class BotDetailModal extends Component<BotDetailModalProps> {
                 className="wk-bot-detail-modal"
                 options={{ closable: false }}
             >
-                <div className="wk-bot-detail-content">
-                    <div className="wk-bot-detail-route-header">
-                        <button
-                            type="button"
-                            className="wk-bot-detail-route-close"
-                            onClick={this.handleClose}
-                            aria-label={t("base.common.close")}
-                        >
-                            <span className="wk-bot-detail-route-close-icon" aria-hidden="true" />
-                        </button>
-                    </div>
-                    {loading ? (
-                        <div className="wk-bot-detail-loading">
-                            <Spin size="large" />
-                        </div>
-                    ) : (
-                        <>
-                        <div className="wk-bot-detail-scroll">
-                            <div className="wk-bot-detail-header">
-                                {isOwner ? (
-                                    <div
-                                        className="wk-bot-detail-avatar wk-bot-detail-avatar--owner"
-                                        onClick={this.handleAvatarClick}
-                                        onKeyDown={this.handleAvatarKeyDown}
-                                        role="button"
-                                        tabIndex={0}
-                                        aria-label={t("base.botDetail.changeAvatar")}
-                                    >
-                                        <WKAvatar channel={new Channel(uid, ChannelTypePerson)} />
-                                        <div className="wk-bot-detail-avatar-overlay" aria-hidden="true">
-                                            <IconCamera />
-                                        </div>
-                                        {uploadingAvatar && (
-                                            <div className="wk-bot-detail-avatar-loading">
-                                                <Spin />
-                                            </div>
-                                        )}
-                                        <input
-                                            ref={(ref) => { this.$fileInput = ref; }}
-                                            type="file"
-                                            accept="image/*"
-                                            multiple={false}
-                                            className="wk-bot-detail-file-input"
-                                            onClick={this.handleAvatarInputClick}
-                                            onChange={this.handleAvatarFileChange}
-                                        />
-                                    </div>
-                                ) : (
-                                    <div className="wk-bot-detail-avatar wk-bot-detail-avatar--preview">
-                                        <WKAvatarPreviewImage channel={new Channel(uid, ChannelTypePerson)} />
-                                    </div>
-                                )}
-                                <div className="wk-bot-detail-heading">
-                                    <div className="wk-bot-detail-name">
-                                        <span className="wk-bot-detail-name-text">{displayName}</span>
-                                        <AiBadge />
-                                    </div>
-                                    <div className="wk-bot-detail-id">@{username}</div>
-                                    {isOwner && reported !== null && (
-                                        <div
-                                            className={`wk-bot-detail-octopush-chip ${
-                                                reported
-                                                    ? "wk-bot-detail-octopush-chip--reported"
-                                                    : "wk-bot-detail-octopush-chip--unmanaged"
-                                            }`}
-                                        >
-                                            <span className="wk-bot-detail-octopush-status">
-                                                <span className="wk-bot-detail-octopush-chip-icon">
-                                                    {reported ? <IconTickCircle /> : <IconAlertCircle />}
-                                                </span>
-                                                <span className="wk-bot-detail-octopush-chip-text">
-                                                    {reported
-                                                        ? t("base.botDetail.reported")
-                                                        : t("base.botDetail.notReported")}
-                                                </span>
-                                                {!reported && (
-                                                    <button
-                                                        type="button"
-                                                        className="wk-bot-detail-help-btn"
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                        }}
-                                                        title={t("base.botDetail.reportHelp")}
-                                                        aria-label={t("base.botDetail.help")}
-                                                    >
-                                                        ?
-                                                    </button>
-                                                )}
-                                            </span>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-
-                            <div className="wk-bot-detail-section">
-                                <div className="wk-bot-detail-row wk-bot-detail-row--editable">
-                                    <div className="wk-bot-detail-row-main">
-                                        <div className="wk-bot-detail-label">{t("base.botDetail.remark")}</div>
-                                        {editingRemark ? (
-                                            <div className="wk-bot-detail-editor">
-                                                <Input
-                                                    value={remarkDraft}
-                                                    onChange={(v) => this.vm.setRemarkDraft(v)}
-                                                    placeholder={t("base.botDetail.remarkPlaceholder")}
-                                                    maxLength={30}
-                                                />
-                                                <div className="wk-bot-detail-editor-actions">
-                                                    <Button
-                                                        size="small"
-                                                        onClick={this.handleCancelEditRemark}
-                                                        disabled={savingRemark}
-                                                    >
-                                                        {t("base.common.cancel")}
-                                                    </Button>
-                                                    <Button
-                                                        size="small"
-                                                        theme="solid"
-                                                        type="primary"
-                                                        loading={savingRemark}
-                                                        onClick={this.handleSaveRemark}
-                                                    >
-                                                        {t("base.botDetail.save")}
-                                                    </Button>
-                                                </div>
-                                            </div>
-                                        ) : (
-                                            <div className="wk-bot-detail-value">
-                                                {remark ? this.stripDisplayName(remark) : <span className="wk-bot-detail-empty">{t("base.botDetail.noRemark")}</span>}
-                                            </div>
-                                        )}
-                                    </div>
-                                    {!editingRemark && (
-                                        <Button
-                                            className="wk-bot-detail-value-edit"
-                                            theme="borderless"
-                                            type="tertiary"
-                                            size="small"
-                                            icon={<IconEdit />}
-                                            onClick={this.handleStartEditRemark}
-                                            onKeyDown={this.handleEditRemarkKeyDown}
-                                            aria-label={t("base.botDetail.editRemark")}
-                                            title={t("base.botDetail.editRemark")}
-                                        />
-                                    )}
-                                </div>
-                                {remark && (
-                                    <div className="wk-bot-detail-row">
-                                        <div className="wk-bot-detail-label">{t("base.botDetail.nickname")}</div>
-                                        <div className="wk-bot-detail-value wk-bot-detail-value--right">{botName}</div>
-                                    </div>
-                                )}
-                            </div>
-
-                            <div className="wk-bot-detail-section">
-                                <div className="wk-bot-detail-description">
-                                    <div className="wk-bot-detail-field-header">
-                                        <div className="wk-bot-detail-label">{t("base.botDetail.description")}</div>
-                                        {isOwner && !editingDescription && (
-                                            <Button
-                                                className="wk-bot-detail-edit-action"
-                                                theme="borderless"
-                                                type="tertiary"
-                                                size="small"
-                                                icon={<IconEdit />}
-                                                onClick={this.handleStartEditDescription}
-                                                onKeyDown={this.handleEditDescriptionKeyDown}
-                                                aria-label={t("base.botDetail.editDescription")}
-                                            >
-                                                {t("base.botDetail.edit")}
-                                            </Button>
-                                        )}
-                                    </div>
-                                    {isOwner && editingDescription ? (
-                                        <div>
-                                            <div className="wk-bot-detail-textarea-wrap">
-                                                <textarea
-                                                    ref={this.descriptionRef}
-                                                    className="wk-bot-detail-textarea"
-                                                    value={descriptionDraft}
-                                                    onChange={(e) => this.vm.setDescriptionDraft(e.target.value)}
-                                                    placeholder={t("base.botDetail.descriptionPlaceholder")}
-                                                    maxLength={200}
-                                                    rows={3}
-                                                />
-                                                <VoiceInputButton
-                                                    inputRef={this.descriptionRef}
-                                                    onTranscribed={this.handleDescriptionVoiceTranscribed}
-                                                    getCurrentText={() => this.vm.state.descriptionDraft}
-                                                    showModeMenu
-                                                    size="sm"
-                                                    className="wk-vib--textarea-corner"
-                                                />
-                                            </div>
-                                            <div className="wk-bot-detail-editor-actions">
-                                                <Button
-                                                    size="small"
-                                                    onClick={this.handleCancelEditDescription}
-                                                    disabled={savingDescription}
-                                                >
-                                                    {t("base.common.cancel")}
-                                                </Button>
-                                                <Button
-                                                    size="small"
-                                                    theme="solid"
-                                                    type="primary"
-                                                    loading={savingDescription}
-                                                    onClick={this.handleSaveDescription}
-                                                >
-                                                    {t("base.botDetail.save")}
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <div className="wk-bot-detail-description-text">{displayDescription}</div>
-                                    )}
-                                </div>
-                            </div>
-
-                            {(creatorName || commands.length > 0) && (
-                                <div className="wk-bot-detail-section">
-                                    {creatorName && (
-                                        <div className="wk-bot-detail-row">
-                                            <div className="wk-bot-detail-label">{t("base.botDetail.creator")}</div>
-                                            <div className="wk-bot-detail-value wk-bot-detail-value--right">{creatorName}</div>
-                                        </div>
-                                    )}
-                                    {commands.length > 0 && (
-                                        <div className="wk-bot-detail-command-block">
-                                            <div className="wk-bot-detail-label">{t("base.botDetail.commands")}</div>
-                                            <div className="wk-bot-detail-command-list">
-                                                {commands.map((cmd, i) => (
-                                                    <div key={i} className="wk-bot-detail-cmd">
-                                                        <span className="wk-bot-detail-cmd-name">{cmd.cmd}</span>
-                                                        <span className="wk-bot-detail-cmd-desc">{cmd.remark}</span>
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-
-                            {isOwner && (
-                                <div className="wk-bot-detail-section">
-                                    <button
-                                        type="button"
-                                        onClick={this.handleOpenBotManage}
-                                        className="wk-bot-detail-nav-row"
-                                        aria-label={t("base.botManage.title")}
-                                    >
-                                        <span>{t("base.botManage.title")}</span>
-                                        <IconChevronRight className="wk-bot-detail-nav-chevron" />
-                                    </button>
-                                    {reported !== null && (
-                                        <button
-                                            type="button"
-                                            onClick={this.handleViewClawInfo}
-                                            className={`wk-bot-detail-nav-row${!reported ? " wk-bot-detail-nav-row--disabled" : ""}`}
-                                            disabled={!reported}
-                                            aria-label={t("base.botDetail.viewClawInfo")}
-                                            title={!reported ? t("base.botDetail.reportHelp") : undefined}
-                                        >
-                                            <span className="wk-bot-detail-nav-main">
-                                                <span className="wk-bot-detail-claw-action-icon" aria-hidden="true">🦞</span>
-                                                <span>{t("base.botDetail.viewClawInfo")}</span>
-                                            </span>
-                                            {reported && <IconChevronRight className="wk-bot-detail-nav-chevron" />}
-                                        </button>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-
-                        <div className="wk-bot-detail-actions">
-                            {isFriend ? (
-                                <Button
-                                    className="wk-bot-detail-primary-action"
-                                    theme="solid"
-                                    type="primary"
-                                    block
-                                    onClick={this.handleChat}
-                                >
-                                    {t("base.botDetail.sendMessage")}
-                                </Button>
-                            ) : showApplyInput ? (
-                                <div className="wk-bot-detail-apply">
-                                    <div className="wk-bot-detail-apply-label">{t("base.botDetail.apply.messageLabel")}</div>
-                                    <Input
-                                        value={applyRemark}
-                                        onChange={(v) => this.vm.setApplyRemark(v)}
-                                        placeholder={t("base.botDetail.apply.messagePlaceholder")}
-                                    />
-                                    <Button
-                                        className="wk-bot-detail-primary-action"
-                                        theme="solid"
-                                        type="primary"
-                                        block
-                                        loading={applying}
-                                        disabled={!applyRemark}
-                                        onClick={this.handleSubmitApply}
-                                    >
-                                        {t("base.botDetail.apply.send")}
-                                    </Button>
-                                </div>
-                            ) : (
-                                <Button
-                                    className="wk-bot-detail-primary-action"
-                                    theme="solid"
-                                    type="primary"
-                                    block
-                                    onClick={this.handleShowApply}
-                                >
-                                    {t("base.botDetail.addFriend")}
-                                </Button>
-                            )}
-                        </div>
-                        </>
-                    )}
-                </div>
+                <BotDetailView
+                    loading={loading}
+                    displayName={displayName}
+                    botName={botName}
+                    username={username}
+                    remark={remark ? this.stripDisplayName(remark) : ""}
+                    displayDescription={displayDescription}
+                    creatorName={creatorName}
+                    commands={commands}
+                    isOwner={isOwner}
+                    isFriend={isFriend}
+                    reported={reported}
+                    uploadingAvatar={uploadingAvatar}
+                    editingRemark={editingRemark}
+                    remarkDraft={remarkDraft}
+                    savingRemark={savingRemark}
+                    editingDescription={editingDescription}
+                    descriptionDraft={descriptionDraft}
+                    savingDescription={savingDescription}
+                    showApplyInput={showApplyInput}
+                    applyRemark={applyRemark}
+                    applying={applying}
+                    ownerAvatar={<WKAvatar channel={new Channel(uid, ChannelTypePerson)} />}
+                    previewAvatar={<WKAvatarPreviewImage channel={new Channel(uid, ChannelTypePerson)} />}
+                    fileInputRef={(ref) => { this.$fileInput = ref; }}
+                    descriptionRef={this.descriptionRef}
+                    labels={{
+                        close: t("base.common.close"),
+                        changeAvatar: t("base.botDetail.changeAvatar"),
+                        reported: t("base.botDetail.reported"),
+                        notReported: t("base.botDetail.notReported"),
+                        reportHelp: t("base.botDetail.reportHelp"),
+                        help: t("base.botDetail.help"),
+                        remark: t("base.botDetail.remark"),
+                        noRemark: t("base.botDetail.noRemark"),
+                        remarkPlaceholder: t("base.botDetail.remarkPlaceholder"),
+                        editRemark: t("base.botDetail.editRemark"),
+                        nickname: t("base.botDetail.nickname"),
+                        description: t("base.botDetail.description"),
+                        editDescription: t("base.botDetail.editDescription"),
+                        edit: t("base.botDetail.edit"),
+                        descriptionPlaceholder: t("base.botDetail.descriptionPlaceholder"),
+                        noDescription: t("base.botDetail.noDescription"),
+                        creator: t("base.botDetail.creator"),
+                        commands: t("base.botDetail.commands"),
+                        botManageTitle: t("base.botManage.title"),
+                        viewClawInfo: t("base.botDetail.viewClawInfo"),
+                        sendMessage: t("base.botDetail.sendMessage"),
+                        addFriend: t("base.botDetail.addFriend"),
+                        applyMessageLabel: t("base.botDetail.apply.messageLabel"),
+                        applyMessagePlaceholder: t("base.botDetail.apply.messagePlaceholder"),
+                        applySend: t("base.botDetail.apply.send"),
+                        save: t("base.botDetail.save"),
+                        cancel: t("base.common.cancel"),
+                    }}
+                    onClose={this.handleClose}
+                    onAvatarClick={this.handleAvatarClick}
+                    onAvatarKeyDown={this.handleAvatarKeyDown}
+                    onAvatarInputClick={this.handleAvatarInputClick}
+                    onAvatarFileChange={this.handleAvatarFileChange}
+                    onRemarkDraftChange={(value) => this.vm.setRemarkDraft(value)}
+                    onStartEditRemark={this.handleStartEditRemark}
+                    onEditRemarkKeyDown={this.handleEditRemarkKeyDown}
+                    onCancelEditRemark={this.handleCancelEditRemark}
+                    onSaveRemark={this.handleSaveRemark}
+                    onStartEditDescription={this.handleStartEditDescription}
+                    onEditDescriptionKeyDown={this.handleEditDescriptionKeyDown}
+                    onDescriptionDraftChange={(value) => this.vm.setDescriptionDraft(value)}
+                    onDescriptionTranscribed={this.handleDescriptionVoiceTranscribed}
+                    getCurrentDescriptionText={() => this.vm.state.descriptionDraft}
+                    onCancelEditDescription={this.handleCancelEditDescription}
+                    onSaveDescription={this.handleSaveDescription}
+                    onOpenBotManage={this.handleOpenBotManage}
+                    onViewClawInfo={this.handleViewClawInfo}
+                    onChat={this.handleChat}
+                    onShowApply={this.handleShowApply}
+                    onApplyRemarkChange={(value) => this.vm.setApplyRemark(value)}
+                    onSubmitApply={this.handleSubmitApply}
+                />
             </WKModal>
             <ClawInfoModal
                 botId={uid}

--- a/packages/dmworkbase/src/Components/BotManage/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/BotManage/__tests__/vm.test.ts
@@ -26,18 +26,12 @@ const hoisted = vi.hoisted(() => {
     return { get, post, del, put, toastError }
 })
 
-vi.mock("../../../App", () => ({
+vi.mock("../../../Service/BotManageService", () => ({
     default: {
-        apiClient: {
-            get: hoisted.get,
-            post: hoisted.post,
-            delete: hoisted.del,
-            put: hoisted.put,
-        },
-        shared: { currentSpaceId: "" },
-        loginInfo: { uid: "" },
+        listGroups: hoisted.get,
+        enableMentionFree: hoisted.put,
+        disableMentionFree: hoisted.del,
     },
-    __esModule: true,
 }))
 
 vi.mock("@douyinfe/semi-ui", () => ({
@@ -78,8 +72,9 @@ describe("MentionFreeVM.loadGroups", () => {
         expect(vm.nextCursor).toBe("CURSOR2")
         expect(vm.hasMore).toBe(true)
         expect(vm.loading).toBe(false)
-        expect(hoisted.get).toHaveBeenCalledWith("robot/bot1/groups", {
-            param: { limit: 30 },
+        expect(hoisted.get).toHaveBeenCalledWith({
+            robotId: "bot1",
+            limit: 30,
         })
     })
 
@@ -141,8 +136,10 @@ describe("MentionFreeVM.loadMore (cursor pagination)", () => {
         await vm.loadMore()
         expect(vm.groups.map((g) => g.group_no)).toEqual(["g1", "g2"])
         expect(vm.hasMore).toBe(false)
-        expect(hoisted.get).toHaveBeenLastCalledWith("robot/bot1/groups", {
-            param: { limit: 30, cursor: "C2" },
+        expect(hoisted.get).toHaveBeenLastCalledWith({
+            robotId: "bot1",
+            limit: 30,
+            cursor: "C2",
         })
     })
 
@@ -185,9 +182,7 @@ describe("MentionFreeVM.toggleMentionFree", () => {
         hoisted.put.mockResolvedValueOnce({})
         const ok = await vm.toggleMentionFree("g1", true)
         expect(ok).toBe(true)
-        expect(hoisted.put).toHaveBeenCalledWith("robot/bot1/groups/g1/mention_pref", {
-            no_mention: 1,
-        })
+        expect(hoisted.put).toHaveBeenCalledWith("bot1", "g1")
         expect(vm.groups.find((g) => g.group_no === "g1")?.no_mention).toBe(true)
     })
 
@@ -202,7 +197,7 @@ describe("MentionFreeVM.toggleMentionFree", () => {
         hoisted.del.mockResolvedValueOnce({})
         const ok = await vm.toggleMentionFree("g1", false)
         expect(ok).toBe(true)
-        expect(hoisted.del).toHaveBeenCalledWith("robot/bot1/groups/g1/mention_pref")
+        expect(hoisted.del).toHaveBeenCalledWith("bot1", "g1")
         expect(vm.groups.find((g) => g.group_no === "g1")?.no_mention).toBe(false)
     })
 

--- a/packages/dmworkbase/src/Components/BotManage/vm.tsx
+++ b/packages/dmworkbase/src/Components/BotManage/vm.tsx
@@ -1,8 +1,11 @@
-import WKApp from "../../App"
 import { ProviderListener } from "../../Service/Provider"
 import { Toast } from "@douyinfe/semi-ui"
 import { extractErrorMsg } from "../../Service/APIClient"
 import { t } from "../../i18n"
+import BotManageService, {
+    type BotGroupsListResponse,
+    type BotGroupItem,
+} from "../../Service/BotManageService"
 
 /**
  * BotManage — 独立「Bot 管理」模块 ViewModel（octo-web#235 / YUJ-2838）。
@@ -25,23 +28,7 @@ import { t } from "../../i18n"
  * robotId 丢弃，绝不把上一个 bot 的群灌进当前 bot 的列表。
  */
 
-/**
- * 群列表单项。镜像后端 groupListItem JSON：
- *   { group_no: string, name: string, no_mention: bool }
- */
-export interface BotGroupItem {
-    group_no: string
-    name: string
-    /** 是否已对本群开启「免@回答」（no_mention=1）。 */
-    no_mention: boolean
-}
-
-/** 列群响应 envelope（后端 listGroups 返回）。 */
-interface GroupsListResp {
-    list?: BotGroupItem[]
-    next_cursor?: string | null
-    has_more?: boolean
-}
+export type { BotGroupItem } from "../../Service/BotManageService"
 
 /** 单页拉取条数。与后端 groupsListDefaultLimit 对齐。 */
 const GROUPS_PAGE_LIMIT = 30
@@ -158,10 +145,10 @@ export class MentionFreeVM extends ProviderListener {
         this.isBackendMissing = false
         this.notifyListener()
         try {
-            const res = await WKApp.apiClient.get<GroupsListResp>(
-                `robot/${requestedUid}/groups`,
-                { param: { limit: GROUPS_PAGE_LIMIT } },
-            )
+            const res = await BotManageService.listGroups({
+                robotId: requestedUid,
+                limit: GROUPS_PAGE_LIMIT,
+            })
             if (isStale()) return
             const { list, nextCursor, hasMore } = parseGroupsResp(res)
             this.groups = list
@@ -204,10 +191,11 @@ export class MentionFreeVM extends ProviderListener {
         this.loadingMore = true
         this.notifyListener()
         try {
-            const res = await WKApp.apiClient.get<GroupsListResp>(
-                `robot/${requestedUid}/groups`,
-                { param: { limit: GROUPS_PAGE_LIMIT, cursor: requestedCursor } },
-            )
+            const res = await BotManageService.listGroups({
+                robotId: requestedUid,
+                limit: GROUPS_PAGE_LIMIT,
+                cursor: requestedCursor,
+            })
             if (isStale()) return
             const { list, nextCursor, hasMore } = parseGroupsResp(res)
             // 去重 append：极端并发下后端可能回放边界项，按 group_no 去重防重复 key。
@@ -252,14 +240,9 @@ export class MentionFreeVM extends ProviderListener {
         const isStale = () => this.generation !== gen
         try {
             if (next) {
-                await WKApp.apiClient.put(
-                    `robot/${requestedUid}/groups/${groupNo}/mention_pref`,
-                    { no_mention: 1 },
-                )
+                await BotManageService.enableMentionFree(requestedUid, groupNo)
             } else {
-                await WKApp.apiClient.delete(
-                    `robot/${requestedUid}/groups/${groupNo}/mention_pref`,
-                )
+                await BotManageService.disableMentionFree(requestedUid, groupNo)
             }
             if (isStale()) return false
             // 局部更新 + 重排：只改命中项的 no_mention，visibleGroups 会重新分区置顶。
@@ -280,7 +263,7 @@ export class MentionFreeVM extends ProviderListener {
  * 解析列群响应 envelope。后端返回 {list, next_cursor, has_more}；做防御性兜底：
  * 非数组 list → []，next_cursor 仅接受非空字符串，has_more 强制布尔。
  */
-function parseGroupsResp(res: GroupsListResp | undefined): {
+function parseGroupsResp(res: BotGroupsListResponse | undefined): {
     list: BotGroupItem[]
     nextCursor: string | null
     hasMore: boolean

--- a/packages/dmworkbase/src/Components/UserInfo/index.tsx
+++ b/packages/dmworkbase/src/Components/UserInfo/index.tsx
@@ -1,23 +1,20 @@
-import { Input, Spin, Toast } from "@douyinfe/semi-ui";
-import { IconEdit } from "@douyinfe/semi-icons";
+import { Toast } from "@douyinfe/semi-ui";
 import { Channel, ChannelTypePerson } from "wukongimjssdk";
-import React, { Component, HTMLProps } from "react";
+import React, { Component, type HTMLProps } from "react";
 import { UserRelation } from "../../Service/Const";
 import WKApp from "../../App";
-import Provider, { IProviderListener } from "../../Service/Provider";
+import Provider from "../../Service/Provider";
 import { Section } from "../../Service/Section";
 import RoutePage from "../RoutePage";
-import Sections from "../Sections";
 import "./index.css"
 import { UserInfoRouteData, UserInfoVM } from "../../bridge/profileDetail/UserInfoVM";
 import FriendApplyUI from "../FriendApply";
-import RouteContext, { FinishButtonContext } from "../../Service/Context";
+import RouteContext, { type FinishButtonContext } from "../../Service/Context";
 import { I18nContext } from "../../i18n";
 import WKAvatarPreviewImage from "../WKAvatarPreviewImage";
 import WKButton from "../WKButton";
-import UserInfoHeader from "./UserInfoHeader";
-import UserInfoFooter from "./UserInfoFooter";
-import { UserInfoMetaItem } from "./UserInfoMetaList";
+import type { UserInfoMetaItem } from "./UserInfoMetaList";
+import UserInfoView, { type UserInfoViewFooter } from "../../ui/profileDetail/UserInfoView";
 
 
 export interface UserInfoProps extends HTMLProps<any> {
@@ -72,67 +69,7 @@ export default class UserInfo extends Component<UserInfoProps> {
             });
     }
 
-    renderRemarkEditor(vm: UserInfoVM) {
-        const { t } = this.context;
-        if (vm.isSelf()) {
-            return null;
-        }
-
-        const { editingRemark, remarkDraft, savingRemark } = vm;
-        const remark = this.getRemark(vm);
-        return <div className="wk-userinfo-remark-section">
-            <div className="wk-userinfo-remark-row">
-                <div className="wk-userinfo-remark-main">
-                    <div className="wk-userinfo-remark-label">{t("base.userInfo.remark")}</div>
-                    {
-                        editingRemark ? <div className="wk-userinfo-remark-editor">
-                            <Input
-                                value={remarkDraft}
-                                onChange={(value) => vm.setRemarkDraft(value)}
-                                placeholder={t("base.userInfo.remarkPlaceholder")}
-                                maxLength={30}
-                            />
-                            <div className="wk-userinfo-remark-actions">
-                                <WKButton
-                                    type="button"
-                                    variant="secondary"
-                                    size="sm"
-                                    disabled={savingRemark}
-                                    onClick={() => this.cancelEditRemark(vm)}
-                                >
-                                    {t("base.common.cancel")}
-                                </WKButton>
-                                <WKButton
-                                    type="button"
-                                    variant="primary"
-                                    size="sm"
-                                    loading={savingRemark}
-                                    onClick={() => this.saveRemark(vm)}
-                                >
-                                    {t("base.common.save")}
-                                </WKButton>
-                            </div>
-                        </div> : <div className="wk-userinfo-remark-value">
-                            {remark || <span className="wk-userinfo-remark-empty">{t("base.common.notSet")}</span>}
-                        </div>
-                    }
-                </div>
-                {!editingRemark && (
-                    <button
-                        type="button"
-                        className="wk-userinfo-remark-edit"
-                        onClick={() => this.startEditRemark(vm)}
-                        aria-label={t("base.userInfo.editRemark")}
-                        title={t("base.userInfo.editRemark")}
-                    >
-                        <IconEdit />
-                    </button>
-                )}
-            </div>
-        </div>
-    }
-
-    getBottomPanel(vm: UserInfoVM, context: RouteContext<any>) {
+    getFooter(vm: UserInfoVM, context: RouteContext<any>): UserInfoViewFooter | undefined {
         if (vm.isSelf()) {
             return undefined
         }
@@ -147,7 +84,7 @@ export default class UserInfo extends Component<UserInfoProps> {
         const isExternalToViewer = vm.isExternalToViewer()
         const { t } = this.context
         if (isExternalToViewer) {
-            return <UserInfoFooter hint={t("base.userInfo.externalOnlyGroup")} />
+            return { hint: t("base.userInfo.externalOnlyGroup") }
         }
 
         let content = <></>
@@ -249,7 +186,7 @@ export default class UserInfo extends Component<UserInfoProps> {
             }} >{t("base.userInfo.addFriend")}</WKButton>
         }
 
-        return <UserInfoFooter action={content} />
+        return { action: content }
     }
 
     render() {
@@ -264,7 +201,7 @@ export default class UserInfo extends Component<UserInfoProps> {
                     onClose()
                 }
             }} render={(context) => {
-                const bottomPanel = this.getBottomPanel(vm, context)
+                const footer = this.getFooter(vm, context)
                 const sections = vm.channelInfo ? this.getVisibleSections(vm, context) : []
                 const metaItems: UserInfoMetaItem[] = []
                 if (vm.showNickname()) {
@@ -288,31 +225,36 @@ export default class UserInfo extends Component<UserInfoProps> {
                     })
                 }
 
-                return <div className={`wk-userinfo ${bottomPanel ? "wk-userinfo--with-footer" : ""}`}>
-                    <div className="wk-userinfo-content">
-                        {
-                            !vm.channelInfo ? <div className="wk-userinfo-loading">
-                                <Spin></Spin>
-                            </div> : (<>
-                                <UserInfoHeader
-                                    avatar={<WKAvatarPreviewImage channel={new Channel(uid, ChannelTypePerson)} />}
-                                    displayName={vm.displayName()}
-                                    isBot={vm.channelInfo?.orgData?.robot === 1}
-                                    isRealnameVerified={vm.isRealnameVerified()}
-                                    metaItems={metaItems}
-                                />
-                                {this.renderRemarkEditor(vm)}
-                                <div className="wk-userinfo-sections">
-                                    <Sections sections={sections}></Sections>
-                                </div>
-                            </>)
-                        }
-                    </div>
-                    {
-                        bottomPanel
-                    }
-
-                </div>
+                return <UserInfoView
+                    loading={!vm.channelInfo}
+                    avatar={<WKAvatarPreviewImage channel={new Channel(uid, ChannelTypePerson)} />}
+                    displayName={vm.displayName()}
+                    isBot={vm.channelInfo?.orgData?.robot === 1}
+                    isRealnameVerified={vm.isRealnameVerified()}
+                    metaItems={metaItems}
+                    showRemarkEditor={!vm.isSelf()}
+                    editingRemark={vm.editingRemark}
+                    remark={this.getRemark(vm)}
+                    remarkDraft={vm.remarkDraft}
+                    savingRemark={vm.savingRemark}
+                    sections={sections}
+                    footerAction={footer?.action}
+                    footerHint={footer?.hint}
+                    labels={{
+                        remark: t("base.userInfo.remark"),
+                        remarkPlaceholder: t("base.userInfo.remarkPlaceholder"),
+                        editRemark: t("base.userInfo.editRemark"),
+                        cancel: t("base.common.cancel"),
+                        save: t("base.common.save"),
+                        notSet: t("base.common.notSet"),
+                    }}
+                    onRemarkDraftChange={(value) => vm.setRemarkDraft(value)}
+                    onStartEditRemark={() => this.startEditRemark(vm)}
+                    onCancelEditRemark={() => this.cancelEditRemark(vm)}
+                    onSaveRemark={() => {
+                        void this.saveRemark(vm)
+                    }}
+                />
             }}></RoutePage>
         }}></Provider>
 

--- a/packages/dmworkbase/src/Components/UserInfo/index.tsx
+++ b/packages/dmworkbase/src/Components/UserInfo/index.tsx
@@ -3,13 +3,14 @@ import { IconEdit } from "@douyinfe/semi-icons";
 import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
 import React, { Component, HTMLProps } from "react";
 import { UserRelation } from "../../Service/Const";
-import WKApp, { FriendApply } from "../../App";
+import WKApp from "../../App";
 import Provider, { IProviderListener } from "../../Service/Provider";
 import { Section } from "../../Service/Section";
 import RoutePage from "../RoutePage";
 import Sections from "../Sections";
 import "./index.css"
 import { UserInfoRouteData, UserInfoVM } from "./vm";
+import UserService from "../../Service/UserService";
 import FriendApplyUI from "../FriendApply";
 import RouteContext, { FinishButtonContext } from "../../Service/Context";
 import { I18nContext } from "../../i18n";
@@ -88,7 +89,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
         const remark = this.state.remarkDraft.trim();
         this.setState({ savingRemark: true });
         try {
-            await WKApp.dataSource.commonDataSource.userRemark(requestedUid, remark);
+            await UserService.updateRemark(requestedUid, remark);
             if (!isCurrent()) return;
             if (vm.channelInfo) {
                 vm.channelInfo.orgData = {
@@ -259,10 +260,11 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                     onFinish: async () => {
                         if (!finishButtonContext) return
                         finishButtonContext.loading(true)
-                        await WKApp.dataSource.commonDataSource.friendApply({
+                        await UserService.applyFriend({
                             uid: vm.uid,
                             remark: msg,
-                            vercode: vm.vercode || ""
+                            vercode: vm.vercode || "",
+                            spaceId: WKApp.shared.currentSpaceId,
                         }).then(() => {
                             Toast.success(t("base.userInfo.friendApplySent"))
                             WKApp.shared.baseContext.hideUserInfo()
@@ -310,10 +312,11 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                     onFinish: async () => {
                         if (!finishButtonContext) return
                         finishButtonContext.loading(true)
-                        await WKApp.dataSource.commonDataSource.friendApply({
+                        await UserService.applyFriend({
                             uid: vm.uid,
                             remark: msg,
-                            vercode: vm.vercode || ""
+                            vercode: vm.vercode || "",
+                            spaceId: WKApp.shared.currentSpaceId,
                         }).then(() => {
                             WKApp.shared.baseContext.hideUserInfo()
                         }).catch((err) => {

--- a/packages/dmworkbase/src/Components/UserInfo/index.tsx
+++ b/packages/dmworkbase/src/Components/UserInfo/index.tsx
@@ -1,6 +1,6 @@
 import { Input, Spin, Toast } from "@douyinfe/semi-ui";
 import { IconEdit } from "@douyinfe/semi-icons";
-import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
+import { Channel, ChannelTypePerson } from "wukongimjssdk";
 import React, { Component, HTMLProps } from "react";
 import { UserRelation } from "../../Service/Const";
 import WKApp from "../../App";
@@ -9,8 +9,7 @@ import { Section } from "../../Service/Section";
 import RoutePage from "../RoutePage";
 import Sections from "../Sections";
 import "./index.css"
-import { UserInfoRouteData, UserInfoVM } from "./vm";
-import UserService from "../../Service/UserService";
+import { UserInfoRouteData, UserInfoVM } from "../../bridge/profileDetail/UserInfoVM";
 import FriendApplyUI from "../FriendApply";
 import RouteContext, { FinishButtonContext } from "../../Service/Context";
 import { I18nContext } from "../../i18n";
@@ -29,97 +28,29 @@ export interface UserInfoProps extends HTMLProps<any> {
     onClose?: () => void
 }
 
-interface UserInfoState {
-    editingRemark: boolean;
-    remarkDraft: string;
-    savingRemark: boolean;
-}
-
-export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
+export default class UserInfo extends Component<UserInfoProps> {
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
-    private mounted = false;
-
-    state: UserInfoState = {
-        editingRemark: false,
-        remarkDraft: "",
-        savingRemark: false,
-    };
-
-    componentDidMount() {
-        this.mounted = true;
-    }
-
-    componentDidUpdate(prevProps: UserInfoProps) {
-        if (prevProps.uid !== this.props.uid) {
-            this.setState({
-                editingRemark: false,
-                remarkDraft: "",
-                savingRemark: false,
-            });
-        }
-    }
-
-    componentWillUnmount() {
-        this.mounted = false;
-    }
 
     getRemark(vm: UserInfoVM) {
-        return vm.channelInfo?.orgData?.remark || "";
+        return vm.getRemark();
     }
 
     startEditRemark = (vm: UserInfoVM) => {
-        this.setState({
-            editingRemark: true,
-            remarkDraft: this.getRemark(vm),
-        });
+        vm.startEditRemark();
     };
 
-    cancelEditRemark = () => {
-        this.setState({
-            editingRemark: false,
-            remarkDraft: "",
-        });
+    cancelEditRemark = (vm: UserInfoVM) => {
+        vm.cancelEditRemark();
     };
 
     saveRemark = async (vm: UserInfoVM) => {
         const { t } = this.context;
-        const requestedUid = vm.uid;
-        const isCurrent = () => this.mounted && this.props.uid === requestedUid;
-        const remark = this.state.remarkDraft.trim();
-        this.setState({ savingRemark: true });
-        try {
-            await UserService.updateRemark(requestedUid, remark);
-            if (!isCurrent()) return;
-            if (vm.channelInfo) {
-                vm.channelInfo.orgData = {
-                    ...vm.channelInfo.orgData,
-                    remark,
-                    displayName: remark || vm.channelInfo.title,
-                };
-            }
-            vm.notifyListener();
+        const result = await vm.saveRemark();
+        if (result === "ok") {
             Toast.success(t("base.userInfo.remarkUpdated"));
-            this.setState({
-                editingRemark: false,
-                remarkDraft: "",
-            });
-            Promise.resolve(
-                WKSDK.shared().channelManager.fetchChannelInfo(new Channel(requestedUid, ChannelTypePerson))
-            ).catch((error: unknown) => {
-                console.warn("[UserInfo] refresh channel after remark failed:", error);
-            });
-            Promise.resolve(vm.reloadChannelInfo()).catch((error: unknown) => {
-                console.warn("[UserInfo] reload profile after remark failed:", error);
-            });
-        } catch (err: any) {
-            if (isCurrent()) {
-                Toast.error(err?.msg || t("base.userInfo.remarkUpdateFailed"));
-            }
-        } finally {
-            if (isCurrent()) {
-                this.setState({ savingRemark: false });
-            }
+        } else if (result === "failed") {
+            Toast.error(t("base.userInfo.remarkUpdateFailed"));
         }
     };
 
@@ -147,7 +78,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
             return null;
         }
 
-        const { editingRemark, remarkDraft, savingRemark } = this.state;
+        const { editingRemark, remarkDraft, savingRemark } = vm;
         const remark = this.getRemark(vm);
         return <div className="wk-userinfo-remark-section">
             <div className="wk-userinfo-remark-row">
@@ -157,7 +88,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                         editingRemark ? <div className="wk-userinfo-remark-editor">
                             <Input
                                 value={remarkDraft}
-                                onChange={(value) => this.setState({ remarkDraft: value })}
+                                onChange={(value) => vm.setRemarkDraft(value)}
                                 placeholder={t("base.userInfo.remarkPlaceholder")}
                                 maxLength={30}
                             />
@@ -167,7 +98,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                                     variant="secondary"
                                     size="sm"
                                     disabled={savingRemark}
-                                    onClick={this.cancelEditRemark}
+                                    onClick={() => this.cancelEditRemark(vm)}
                                 >
                                     {t("base.common.cancel")}
                                 </WKButton>
@@ -260,12 +191,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                     onFinish: async () => {
                         if (!finishButtonContext) return
                         finishButtonContext.loading(true)
-                        await UserService.applyFriend({
-                            uid: vm.uid,
-                            remark: msg,
-                            vercode: vm.vercode || "",
-                            spaceId: WKApp.shared.currentSpaceId,
-                        }).then(() => {
+                        await vm.applyFriend(msg, WKApp.shared.currentSpaceId).then(() => {
                             Toast.success(t("base.userInfo.friendApplySent"))
                             WKApp.shared.baseContext.hideUserInfo()
                         }).catch((err: any) => {
@@ -312,12 +238,7 @@ export default class UserInfo extends Component<UserInfoProps, UserInfoState> {
                     onFinish: async () => {
                         if (!finishButtonContext) return
                         finishButtonContext.loading(true)
-                        await UserService.applyFriend({
-                            uid: vm.uid,
-                            remark: msg,
-                            vercode: vm.vercode || "",
-                            spaceId: WKApp.shared.currentSpaceId,
-                        }).then(() => {
+                        await vm.applyFriend(msg, WKApp.shared.currentSpaceId).then(() => {
                             WKApp.shared.baseContext.hideUserInfo()
                         }).catch((err) => {
                             Toast.error(err.msg)

--- a/packages/dmworkbase/src/Components/UserInfo/index.tsx
+++ b/packages/dmworkbase/src/Components/UserInfo/index.tsx
@@ -47,7 +47,7 @@ export default class UserInfo extends Component<UserInfoProps> {
         if (result === "ok") {
             Toast.success(t("base.userInfo.remarkUpdated"));
         } else if (result === "failed") {
-            Toast.error(t("base.userInfo.remarkUpdateFailed"));
+            Toast.error(vm.remarkSaveError || t("base.userInfo.remarkUpdateFailed"));
         }
     };
 

--- a/packages/dmworkbase/src/Service/BotManageService.ts
+++ b/packages/dmworkbase/src/Service/BotManageService.ts
@@ -1,0 +1,46 @@
+import APIClient from "./APIClient"
+
+export interface BotGroupItem {
+  group_no: string
+  name: string
+  no_mention: boolean
+}
+
+export interface BotGroupsListResponse {
+  list?: BotGroupItem[]
+  next_cursor?: string | null
+  has_more?: boolean
+}
+
+export interface ListBotGroupsRequest {
+  robotId: string
+  limit: number
+  cursor?: string | null
+}
+
+const BotManageService = {
+  listGroups(request: ListBotGroupsRequest): Promise<BotGroupsListResponse> {
+    const param: Record<string, string | number> = {
+      limit: request.limit,
+    }
+    if (request.cursor) {
+      param.cursor = request.cursor
+    }
+    return APIClient.shared.get(`robot/${request.robotId}/groups`, { param })
+  },
+
+  enableMentionFree(robotId: string, groupNo: string): Promise<void> {
+    return APIClient.shared.put(
+      `robot/${robotId}/groups/${groupNo}/mention_pref`,
+      { no_mention: 1 },
+    )
+  },
+
+  disableMentionFree(robotId: string, groupNo: string): Promise<void> {
+    return APIClient.shared.delete(
+      `robot/${robotId}/groups/${groupNo}/mention_pref`,
+    )
+  },
+}
+
+export default BotManageService

--- a/packages/dmworkbase/src/Service/BotProfileService.ts
+++ b/packages/dmworkbase/src/Service/BotProfileService.ts
@@ -1,0 +1,60 @@
+import axios from "axios"
+import APIClient from "./APIClient"
+
+export interface BotProfile {
+  bot_creator_uid?: string
+  bot_creator_name?: string
+  bot_description?: string
+  bot_commands?: string
+  follow?: number
+  name?: string
+  remark?: string
+  username?: string
+  [key: string]: any
+}
+
+export interface BotFriendApplyRequest {
+  uid: string
+  remark: string
+  spaceId?: string
+}
+
+const BotProfileService = {
+  getBotProfile(uid: string): Promise<BotProfile> {
+    return APIClient.shared.get(`users/${uid}`)
+  },
+
+  updateDescription(uid: string, description: string): Promise<void> {
+    return APIClient.shared.put(`robot/${uid}/description`, { description })
+  },
+
+  updateRemark(uid: string, remark: string): Promise<void> {
+    return APIClient.shared.put("friend/remark", { uid, remark })
+  },
+
+  applyFriend(request: BotFriendApplyRequest): Promise<void> {
+    const body: Record<string, string> = {
+      to_uid: request.uid,
+      remark: request.remark,
+    }
+    if (request.spaceId) {
+      body.space_id = request.spaceId
+    }
+    return APIClient.shared.post("friend/apply", body)
+  },
+
+  uploadAvatar(uid: string, file: File, token?: string): Promise<void> {
+    const form = new FormData()
+    form.append("file", file)
+    return axios
+      .post(`users/${uid}/avatar`, form, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+          token: token || "",
+        },
+      })
+      .then(() => undefined)
+  },
+}
+
+export default BotProfileService

--- a/packages/dmworkbase/src/Service/UserService.ts
+++ b/packages/dmworkbase/src/Service/UserService.ts
@@ -5,11 +5,34 @@ export interface UserProfile {
   [key: string]: any
 }
 
+export interface FriendApplyRequest {
+  uid: string
+  remark: string
+  vercode?: string
+  spaceId?: string
+}
+
 const UserService = {
   getUserProfile(uid: string, groupNo?: string): Promise<UserProfile> {
     return APIClient.shared.get(`users/${uid}`, {
       param: { group_no: groupNo || "" },
     })
+  },
+
+  updateRemark(uid: string, remark: string): Promise<void> {
+    return APIClient.shared.put("friend/remark", { uid, remark })
+  },
+
+  applyFriend(request: FriendApplyRequest): Promise<void> {
+    const body: Record<string, string> = {
+      to_uid: request.uid,
+      remark: request.remark,
+      vercode: request.vercode || "",
+    }
+    if (request.spaceId) {
+      body.space_id = request.spaceId
+    }
+    return APIClient.shared.post("friend/apply", body)
   },
 }
 

--- a/packages/dmworkbase/src/Service/__tests__/BotManageService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/BotManageService.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      delete: vi.fn(),
+      get: vi.fn(),
+      put: vi.fn(),
+    },
+  },
+}))
+
+import APIClient from "../APIClient"
+import BotManageService from "../BotManageService"
+
+const apiDelete = APIClient.shared.delete as unknown as ReturnType<typeof vi.fn>
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  apiDelete.mockReset()
+  apiGet.mockReset()
+  apiPut.mockReset()
+})
+
+describe("BotManageService", () => {
+  it("listGroups calls robot groups endpoint with limit", async () => {
+    apiGet.mockResolvedValueOnce({ list: [] })
+
+    await BotManageService.listGroups({ robotId: "bot1", limit: 30 })
+
+    expect(apiGet).toHaveBeenCalledWith("robot/bot1/groups", {
+      param: { limit: 30 },
+    })
+  })
+
+  it("listGroups includes cursor when provided", async () => {
+    apiGet.mockResolvedValueOnce({ list: [] })
+
+    await BotManageService.listGroups({
+      robotId: "bot1",
+      limit: 30,
+      cursor: "C2",
+    })
+
+    expect(apiGet).toHaveBeenCalledWith("robot/bot1/groups", {
+      param: { limit: 30, cursor: "C2" },
+    })
+  })
+
+  it("enableMentionFree calls mention preference endpoint", async () => {
+    apiPut.mockResolvedValueOnce(undefined)
+
+    await BotManageService.enableMentionFree("bot1", "group-a")
+
+    expect(apiPut).toHaveBeenCalledWith(
+      "robot/bot1/groups/group-a/mention_pref",
+      { no_mention: 1 },
+    )
+  })
+
+  it("disableMentionFree deletes mention preference", async () => {
+    apiDelete.mockResolvedValueOnce(undefined)
+
+    await BotManageService.disableMentionFree("bot1", "group-a")
+
+    expect(apiDelete).toHaveBeenCalledWith(
+      "robot/bot1/groups/group-a/mention_pref",
+    )
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/BotProfileService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/BotProfileService.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { get, post, put, axiosPost } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  axiosPost: vi.fn(),
+}))
+
+vi.mock("axios", () => ({
+  default: {
+    post: axiosPost,
+  },
+}))
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      get,
+      post,
+      put,
+    },
+  },
+}))
+
+import axios from "axios"
+import APIClient from "../APIClient"
+import BotProfileService from "../BotProfileService"
+
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>
+const rawPost = axios.post as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  apiGet.mockReset()
+  apiPost.mockReset()
+  apiPut.mockReset()
+  rawPost.mockReset()
+})
+
+describe("BotProfileService", () => {
+  it("getBotProfile calls users/:uid", async () => {
+    apiGet.mockResolvedValueOnce({ uid: "bot1" })
+
+    await expect(BotProfileService.getBotProfile("bot1")).resolves.toEqual({
+      uid: "bot1",
+    })
+
+    expect(apiGet).toHaveBeenCalledWith("users/bot1")
+  })
+
+  it("updateDescription calls robot description endpoint", async () => {
+    apiPut.mockResolvedValueOnce(undefined)
+
+    await BotProfileService.updateDescription("bot1", "desc")
+
+    expect(apiPut).toHaveBeenCalledWith("robot/bot1/description", {
+      description: "desc",
+    })
+  })
+
+  it("updateRemark calls friend remark endpoint", async () => {
+    apiPut.mockResolvedValueOnce(undefined)
+
+    await BotProfileService.updateRemark("bot1", "nick")
+
+    expect(apiPut).toHaveBeenCalledWith("friend/remark", {
+      uid: "bot1",
+      remark: "nick",
+    })
+  })
+
+  it("applyFriend includes space when provided", async () => {
+    apiPost.mockResolvedValueOnce(undefined)
+
+    await BotProfileService.applyFriend({
+      uid: "bot1",
+      remark: "apply",
+      spaceId: "space-a",
+    })
+
+    expect(apiPost).toHaveBeenCalledWith("friend/apply", {
+      to_uid: "bot1",
+      remark: "apply",
+      space_id: "space-a",
+    })
+  })
+
+  it("applyFriend omits blank space", async () => {
+    apiPost.mockResolvedValueOnce(undefined)
+
+    await BotProfileService.applyFriend({
+      uid: "bot1",
+      remark: "apply",
+      spaceId: "",
+    })
+
+    expect(apiPost).toHaveBeenCalledWith("friend/apply", {
+      to_uid: "bot1",
+      remark: "apply",
+    })
+  })
+
+  it("uploadAvatar posts multipart form with token", async () => {
+    const file = new File(["avatar"], "avatar.png", { type: "image/png" })
+    rawPost.mockResolvedValueOnce({ data: {} })
+
+    await BotProfileService.uploadAvatar("bot1", file, "token-a")
+
+    expect(rawPost).toHaveBeenCalledWith(
+      "users/bot1/avatar",
+      expect.any(FormData),
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+          token: "token-a",
+        },
+      },
+    )
+  })
+})

--- a/packages/dmworkbase/src/Service/__tests__/UserService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/UserService.test.ts
@@ -4,6 +4,8 @@ vi.mock("../APIClient", () => ({
   default: {
     shared: {
       get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
     },
   },
 }))
@@ -12,9 +14,13 @@ import APIClient from "../APIClient"
 import UserService from "../UserService"
 
 const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   apiGet.mockReset()
+  apiPost.mockReset()
+  apiPut.mockReset()
 })
 
 describe("UserService", () => {
@@ -43,6 +49,51 @@ describe("UserService", () => {
     await UserService.getUserProfile("u3", "")
     expect(apiGet).toHaveBeenCalledWith("users/u3", {
       param: { group_no: "" },
+    })
+  })
+
+  it("updateRemark calls friend remark endpoint", async () => {
+    apiPut.mockResolvedValueOnce(undefined)
+
+    await UserService.updateRemark("u4", "Nick")
+
+    expect(apiPut).toHaveBeenCalledWith("friend/remark", {
+      uid: "u4",
+      remark: "Nick",
+    })
+  })
+
+  it("applyFriend includes vercode and space when provided", async () => {
+    apiPost.mockResolvedValueOnce(undefined)
+
+    await UserService.applyFriend({
+      uid: "u5",
+      remark: "hello",
+      vercode: "v1",
+      spaceId: "space-a",
+    })
+
+    expect(apiPost).toHaveBeenCalledWith("friend/apply", {
+      to_uid: "u5",
+      remark: "hello",
+      vercode: "v1",
+      space_id: "space-a",
+    })
+  })
+
+  it("applyFriend normalizes missing vercode and omits blank space", async () => {
+    apiPost.mockResolvedValueOnce(undefined)
+
+    await UserService.applyFriend({
+      uid: "u6",
+      remark: "hello",
+      spaceId: "",
+    })
+
+    expect(apiPost).toHaveBeenCalledWith("friend/apply", {
+      to_uid: "u6",
+      remark: "hello",
+      vercode: "",
     })
   })
 })

--- a/packages/dmworkbase/src/bridge/profileDetail/BotDetailVM.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/BotDetailVM.ts
@@ -124,7 +124,8 @@ export default class BotDetailVM extends ProviderListener {
     this.uid = uid;
     this.clearRefreshTimer();
     this.patchState({ showBotManage: false });
-    void this.loadBotInfo();
+    if (!uid) return;
+    return this.loadBotInfo();
   }
 
   currentUid() {

--- a/packages/dmworkbase/src/bridge/profileDetail/BotDetailVM.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/BotDetailVM.ts
@@ -1,0 +1,444 @@
+import AgentCardService from "../../Service/AgentCardService";
+import BotProfileService from "../../Service/BotProfileService";
+import { ProviderListener } from "../../Service/Provider";
+
+export interface BotDetailState {
+  loading: boolean;
+  name: string;
+  remark: string;
+  username: string;
+  description: string;
+  creatorName: string;
+  creatorUid: string;
+  botCommands: string;
+  isFriend: boolean;
+  applying: boolean;
+  showApplyInput: boolean;
+  applyRemark: string;
+  uploadingAvatar: boolean;
+  editingDescription: boolean;
+  descriptionDraft: string;
+  savingDescription: boolean;
+  editingRemark: boolean;
+  remarkDraft: string;
+  savingRemark: boolean;
+  reported: boolean | null;
+  reportStatusLoading: boolean;
+  showClawInfo: boolean;
+  showBotManage: boolean;
+  avatarCropFile: File | null;
+  avatarPreviewFile: File | null;
+}
+
+export interface BotDetailChannelInfo {
+  title?: string;
+  orgData?: {
+    remark?: string;
+    bot_description?: string;
+    bot_creator_name?: string;
+    bot_creator_uid?: string;
+    bot_commands?: string;
+    follow?: number;
+    [key: string]: any;
+  };
+}
+
+export interface BotDetailRuntime {
+  getLoginUid: () => string | undefined;
+  getToken: () => string | undefined;
+  getSpaceId: () => string | undefined;
+  fetchChannelInfo: (uid: string) => Promise<BotDetailChannelInfo | undefined>;
+  refreshChannelInfo: (uid: string) => Promise<unknown>;
+  onAvatarChanged: (uid: string) => void;
+}
+
+export type BotDetailActionResult = "ok" | "stale" | "failed";
+
+export function createInitialBotDetailState(): BotDetailState {
+  return {
+    loading: true,
+    name: "",
+    remark: "",
+    username: "",
+    description: "",
+    creatorName: "",
+    creatorUid: "",
+    botCommands: "",
+    isFriend: false,
+    applying: false,
+    showApplyInput: false,
+    applyRemark: "",
+    uploadingAvatar: false,
+    editingDescription: false,
+    descriptionDraft: "",
+    savingDescription: false,
+    editingRemark: false,
+    remarkDraft: "",
+    savingRemark: false,
+    reported: null,
+    reportStatusLoading: false,
+    showClawInfo: false,
+    showBotManage: false,
+    avatarCropFile: null,
+    avatarPreviewFile: null,
+  };
+}
+
+export function stripBotDetailDisplayName(value: string) {
+  return value.replace(/\*\*/g, "");
+}
+
+export function parseBotCommands(value: string): { cmd: string; remark: string }[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export default class BotDetailVM extends ProviderListener {
+  state: BotDetailState = createInitialBotDetailState();
+  private uid: string;
+  private mounted = false;
+  private generation = 0;
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(uid: string, private runtime: BotDetailRuntime) {
+    super();
+    this.uid = uid;
+  }
+
+  mount() {
+    this.mounted = true;
+  }
+
+  unmount() {
+    this.mounted = false;
+    this.clearRefreshTimer();
+  }
+
+  setUid(uid: string) {
+    if (this.uid === uid) return;
+    this.uid = uid;
+    this.clearRefreshTimer();
+    this.patchState({ showBotManage: false });
+    void this.loadBotInfo();
+  }
+
+  currentUid() {
+    return this.uid;
+  }
+
+  isCurrentUid(uid: string) {
+    return this.mounted && this.uid === uid;
+  }
+
+  isOwner() {
+    const { creatorUid } = this.state;
+    const loginUid = this.runtime.getLoginUid();
+    return !!creatorUid && !!loginUid && creatorUid === loginUid;
+  }
+
+  resetTransientState() {
+    this.patchState({
+      avatarCropFile: null,
+      avatarPreviewFile: null,
+      showBotManage: false,
+      showClawInfo: false,
+    });
+  }
+
+  async loadReportStatus() {
+    const requestedUid = this.uid;
+    if (!requestedUid) return;
+    const gen = this.generation;
+
+    this.patchState({ reported: null, reportStatusLoading: true });
+    try {
+      const result = await AgentCardService.getReportStatus(requestedUid);
+      if (this.isStale(requestedUid, gen)) return;
+      this.patchState({ reported: result });
+    } catch (error) {
+      if (this.isStale(requestedUid, gen)) return;
+      console.error("[BotDetailModal] loadReportStatus failed:", error);
+    } finally {
+      if (!this.isStale(requestedUid, gen)) {
+        this.patchState({ reportStatusLoading: false });
+      }
+    }
+  }
+
+  async loadBotInfo() {
+    const requestedUid = this.uid;
+    if (!requestedUid) return;
+    const gen = ++this.generation;
+    this.clearRefreshTimer();
+    this.state = createInitialBotDetailState();
+    this.notifyListener();
+
+    try {
+      const data = await BotProfileService.getBotProfile(requestedUid);
+      if (this.isStale(requestedUid, gen)) return;
+      this.patchState({
+        loading: false,
+        name: data.name || requestedUid,
+        remark: data.remark || "",
+        username: data.username || requestedUid,
+        description: data.bot_description || "",
+        creatorName: data.bot_creator_name || "",
+        creatorUid: data.bot_creator_uid || "",
+        botCommands: data.bot_commands || "",
+        isFriend: data.follow === 1,
+        editingDescription: false,
+      });
+      if (this.isOwner()) {
+        void this.loadReportStatus();
+      }
+    } catch {
+      await this.loadFromChannelInfo(requestedUid, gen);
+    }
+  }
+
+  async uploadAvatar(file: File): Promise<BotDetailActionResult> {
+    const requestedUid = this.uid;
+    this.patchState({ uploadingAvatar: true });
+    try {
+      await BotProfileService.uploadAvatar(
+        requestedUid,
+        file,
+        this.runtime.getToken() || "",
+      );
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      this.runtime.onAvatarChanged(requestedUid);
+      return "ok";
+    } catch {
+      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } finally {
+      if (this.isCurrentUid(requestedUid)) {
+        this.patchState({ uploadingAvatar: false });
+      }
+    }
+  }
+
+  setAvatarCropFile(file: File | null) {
+    this.patchState({ avatarCropFile: file });
+  }
+
+  setAvatarPreviewFile(file: File | null) {
+    this.patchState({ avatarPreviewFile: file });
+  }
+
+  startEditDescription() {
+    if (!this.isOwner()) return;
+    this.patchState({
+      editingDescription: true,
+      descriptionDraft: stripBotDetailDisplayName(this.state.description),
+    });
+  }
+
+  cancelEditDescription() {
+    this.patchState({ editingDescription: false, descriptionDraft: "" });
+  }
+
+  setDescriptionDraft(value: string) {
+    this.patchState({ descriptionDraft: value.slice(0, 200) });
+  }
+
+  updateDescriptionDraftWithTranscription(
+    text: string,
+    mode: "all" | "selection" | "cursor",
+    savedRange?: { from: number; to: number },
+  ) {
+    const current = this.state.descriptionDraft;
+    if (mode === "all") {
+      this.setDescriptionDraft(text);
+      return;
+    }
+    if (mode === "selection" && savedRange) {
+      const before = current.slice(0, savedRange.from);
+      const after = current.slice(savedRange.to);
+      const budget = Math.max(0, 200 - before.length - after.length);
+      this.patchState({ descriptionDraft: before + text.slice(0, budget) + after });
+      return;
+    }
+    const pos = savedRange?.from ?? current.length;
+    const before = current.slice(0, pos);
+    const after = current.slice(pos);
+    const budget = Math.max(0, 200 - before.length - after.length);
+    this.patchState({ descriptionDraft: before + text.slice(0, budget) + after });
+  }
+
+  async saveDescription(): Promise<BotDetailActionResult> {
+    const requestedUid = this.uid;
+    const { descriptionDraft } = this.state;
+    this.patchState({ savingDescription: true });
+    try {
+      await BotProfileService.updateDescription(requestedUid, descriptionDraft);
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      this.patchState({
+        description: descriptionDraft,
+        editingDescription: false,
+        descriptionDraft: "",
+      });
+      return "ok";
+    } catch {
+      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } finally {
+      if (this.isCurrentUid(requestedUid)) {
+        this.patchState({ savingDescription: false });
+      }
+    }
+  }
+
+  startEditRemark() {
+    this.patchState({
+      editingRemark: true,
+      remarkDraft: stripBotDetailDisplayName(this.state.remark),
+    });
+  }
+
+  cancelEditRemark() {
+    this.patchState({ editingRemark: false, remarkDraft: "" });
+  }
+
+  setRemarkDraft(value: string) {
+    this.patchState({ remarkDraft: value });
+  }
+
+  async saveRemark(): Promise<BotDetailActionResult> {
+    const requestedUid = this.uid;
+    const remark = this.state.remarkDraft.trim();
+    this.patchState({ savingRemark: true });
+    try {
+      await BotProfileService.updateRemark(requestedUid, remark);
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      this.patchState({
+        remark,
+        editingRemark: false,
+        remarkDraft: "",
+      });
+      Promise.resolve(this.runtime.refreshChannelInfo(requestedUid)).catch((error: unknown) => {
+        console.warn("[BotDetailModal] refresh channel after remark failed:", error);
+      });
+      return "ok";
+    } catch {
+      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } finally {
+      if (this.isCurrentUid(requestedUid)) {
+        this.patchState({ savingRemark: false });
+      }
+    }
+  }
+
+  showApplyInput(defaultMessage: string) {
+    this.patchState({
+      showApplyInput: true,
+      applyRemark: defaultMessage,
+    });
+  }
+
+  setApplyRemark(value: string) {
+    this.patchState({ applyRemark: value });
+  }
+
+  async submitApply(): Promise<BotDetailActionResult> {
+    const requestedUid = this.uid;
+    const { applyRemark } = this.state;
+    this.patchState({ applying: true });
+    try {
+      await BotProfileService.applyFriend({
+        uid: requestedUid,
+        remark: applyRemark,
+        spaceId: this.runtime.getSpaceId(),
+      });
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      this.patchState({ showApplyInput: false });
+      this.clearRefreshTimer();
+      this.refreshTimer = setTimeout(() => {
+        if (this.isCurrentUid(requestedUid)) {
+          void this.loadBotInfo();
+        }
+      }, 500);
+      return "ok";
+    } catch {
+      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } finally {
+      if (this.isCurrentUid(requestedUid)) {
+        this.patchState({ applying: false });
+      }
+    }
+  }
+
+  openClawInfo() {
+    this.patchState({ showClawInfo: true });
+  }
+
+  closeClawInfo() {
+    this.patchState({ showClawInfo: false });
+  }
+
+  openBotManage() {
+    this.patchState({ showBotManage: true });
+  }
+
+  closeBotManage() {
+    this.patchState({ showBotManage: false });
+  }
+
+  private async loadFromChannelInfo(requestedUid: string, gen: number) {
+    try {
+      const channelInfo = await this.runtime.fetchChannelInfo(requestedUid);
+      if (this.isStale(requestedUid, gen)) return;
+      this.patchState({
+        loading: false,
+        name: channelInfo?.title || requestedUid,
+        remark: channelInfo?.orgData?.remark || "",
+        username: requestedUid,
+        description: channelInfo?.orgData?.bot_description || "",
+        creatorName: channelInfo?.orgData?.bot_creator_name || "",
+        creatorUid: channelInfo?.orgData?.bot_creator_uid || "",
+        botCommands: channelInfo?.orgData?.bot_commands || "",
+        isFriend: channelInfo?.orgData?.follow === 1,
+        editingDescription: false,
+      });
+      if (this.isOwner()) {
+        void this.loadReportStatus();
+      }
+    } catch {
+      if (this.isStale(requestedUid, gen)) return;
+      this.patchState({
+        loading: false,
+        name: requestedUid,
+        remark: "",
+        username: requestedUid,
+        description: "",
+        creatorName: "",
+        creatorUid: "",
+        botCommands: "",
+        isFriend: false,
+        editingDescription: false,
+      });
+    }
+  }
+
+  private isStale(uid: string, gen: number) {
+    return !this.isCurrentUid(uid) || this.generation !== gen;
+  }
+
+  private patchState(patch: Partial<BotDetailState>) {
+    this.state = {
+      ...this.state,
+      ...patch,
+    };
+    this.notifyListener();
+  }
+
+  private clearRefreshTimer() {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+}

--- a/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
+++ b/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
@@ -34,6 +34,10 @@ export class UserInfoVM extends ProviderListener {
   channelInfo?: ChannelInfo;
   vercode?: string;
   subscriberChangeListener?: SubscriberChangeListener;
+  editingRemark = false;
+  remarkDraft = "";
+  savingRemark = false;
+  private mounted = false;
 
   constructor(uid: string, fromChannel?: Channel, vercode?: string) {
     super();
@@ -43,6 +47,7 @@ export class UserInfoVM extends ProviderListener {
   }
 
   didMount(): void {
+    this.mounted = true;
     this.reloadSubscribers();
 
     WKApp.shared.changeChannelAvatarTag(
@@ -69,11 +74,83 @@ export class UserInfoVM extends ProviderListener {
   }
 
   didUnMount(): void {
+    this.mounted = false;
     if (this.subscriberChangeListener) {
       WKSDK.shared().channelManager.removeSubscriberChangeListener(
         this.subscriberChangeListener
       );
     }
+  }
+
+  getRemark() {
+    return this.channelInfo?.orgData?.remark || "";
+  }
+
+  startEditRemark() {
+    this.editingRemark = true;
+    this.remarkDraft = this.getRemark();
+    this.notifyListener();
+  }
+
+  cancelEditRemark() {
+    this.editingRemark = false;
+    this.remarkDraft = "";
+    this.notifyListener();
+  }
+
+  setRemarkDraft(value: string) {
+    this.remarkDraft = value;
+    this.notifyListener();
+  }
+
+  async saveRemark(): Promise<"ok" | "stale" | "failed"> {
+    const requestedUid = this.uid;
+    const remark = this.remarkDraft.trim();
+    this.savingRemark = true;
+    this.notifyListener();
+    try {
+      await UserService.updateRemark(requestedUid, remark);
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      if (this.channelInfo) {
+        this.channelInfo.orgData = {
+          ...this.channelInfo.orgData,
+          remark,
+          displayName: remark || this.channelInfo.title,
+        };
+      }
+      this.editingRemark = false;
+      this.remarkDraft = "";
+      this.notifyListener();
+      Promise.resolve(
+        WKSDK.shared().channelManager.fetchChannelInfo(new Channel(requestedUid, ChannelTypePerson))
+      ).catch((error: unknown) => {
+        console.warn("[UserInfo] refresh channel after remark failed:", error);
+      });
+      Promise.resolve(this.reloadChannelInfo()).catch((error: unknown) => {
+        console.warn("[UserInfo] reload profile after remark failed:", error);
+      });
+      return "ok";
+    } catch {
+      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } finally {
+      if (this.isCurrentUid(requestedUid)) {
+        this.savingRemark = false;
+        this.notifyListener();
+      }
+    }
+  }
+
+  applyFriend(remark: string, spaceId?: string) {
+    return UserService.applyFriend({
+      uid: this.uid,
+      remark,
+      vercode: this.vercode || "",
+      spaceId,
+    });
+  }
+
+  private isCurrentUid(uid: string) {
+    return this.mounted && this.uid === uid;
   }
 
   reloadSubscribers() {

--- a/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
+++ b/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
@@ -37,6 +37,7 @@ export class UserInfoVM extends ProviderListener {
   editingRemark = false;
   remarkDraft = "";
   savingRemark = false;
+  remarkSaveError = "";
   private mounted = false;
 
   constructor(uid: string, fromChannel?: Channel, vercode?: string) {
@@ -107,6 +108,7 @@ export class UserInfoVM extends ProviderListener {
     const requestedUid = this.uid;
     const remark = this.remarkDraft.trim();
     this.savingRemark = true;
+    this.remarkSaveError = "";
     this.notifyListener();
     try {
       await UserService.updateRemark(requestedUid, remark);
@@ -130,8 +132,10 @@ export class UserInfoVM extends ProviderListener {
         console.warn("[UserInfo] reload profile after remark failed:", error);
       });
       return "ok";
-    } catch {
-      return this.isCurrentUid(requestedUid) ? "failed" : "stale";
+    } catch (error: any) {
+      if (!this.isCurrentUid(requestedUid)) return "stale";
+      this.remarkSaveError = error?.msg || "";
+      return "failed";
     } finally {
       if (this.isCurrentUid(requestedUid)) {
         this.savingRemark = false;

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotDetailVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotDetailVM.test.ts
@@ -136,6 +136,36 @@ describe("BotDetailVM", () => {
     expect(vm.state.username).toBe("bot_two");
   });
 
+  it("reloads the same bot after uid is cleared on close", async () => {
+    mocks.getBotProfile
+      .mockResolvedValueOnce({
+        name: "Bot One",
+        username: "bot_one",
+        bot_creator_uid: "owner-1",
+        follow: 1,
+      })
+      .mockResolvedValueOnce({
+        name: "Bot One Reloaded",
+        username: "bot_one",
+        bot_creator_uid: "owner-1",
+        follow: 0,
+      });
+    mocks.getReportStatus.mockResolvedValue(false);
+    const vm = new BotDetailVM("bot1", createRuntime());
+    vm.mount();
+
+    await vm.loadBotInfo();
+    vm.setUid("");
+    await vm.setUid("bot1");
+    await Promise.resolve();
+
+    expect(mocks.getBotProfile).toHaveBeenCalledTimes(2);
+    expect(mocks.getBotProfile).toHaveBeenNthCalledWith(1, "bot1");
+    expect(mocks.getBotProfile).toHaveBeenNthCalledWith(2, "bot1");
+    expect(vm.state.name).toBe("Bot One Reloaded");
+    expect(vm.state.isFriend).toBe(false);
+  });
+
   it("saves remark and refreshes channel info", async () => {
     mocks.updateRemark.mockResolvedValueOnce(undefined);
     const runtime = createRuntime();

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotDetailVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotDetailVM.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getBotProfile: vi.fn(),
+  updateDescription: vi.fn(),
+  updateRemark: vi.fn(),
+  applyFriend: vi.fn(),
+  uploadAvatar: vi.fn(),
+  getReportStatus: vi.fn(),
+}));
+
+vi.mock("../../../Service/BotProfileService", () => ({
+  default: {
+    getBotProfile: mocks.getBotProfile,
+    updateDescription: mocks.updateDescription,
+    updateRemark: mocks.updateRemark,
+    applyFriend: mocks.applyFriend,
+    uploadAvatar: mocks.uploadAvatar,
+  },
+}));
+
+vi.mock("../../../Service/AgentCardService", () => ({
+  default: {
+    getReportStatus: mocks.getReportStatus,
+  },
+}));
+
+import BotDetailVM, {
+  parseBotCommands,
+  stripBotDetailDisplayName,
+  type BotDetailRuntime,
+} from "../BotDetailVM";
+
+function createRuntime(overrides: Partial<BotDetailRuntime> = {}): BotDetailRuntime {
+  return {
+    getLoginUid: () => "owner-1",
+    getToken: () => "token-a",
+    getSpaceId: () => "space-a",
+    fetchChannelInfo: vi.fn(),
+    refreshChannelInfo: vi.fn().mockResolvedValue(undefined),
+    onAvatarChanged: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  Object.values(mocks).forEach((mock) => mock.mockReset());
+});
+
+describe("BotDetailVM", () => {
+  it("loads bot profile and report status for owner", async () => {
+    mocks.getBotProfile.mockResolvedValueOnce({
+      name: "Bot One",
+      username: "bot_one",
+      remark: "Work Bot",
+      bot_description: "desc",
+      bot_creator_uid: "owner-1",
+      bot_creator_name: "Owner",
+      bot_commands: "[]",
+      follow: 1,
+    });
+    mocks.getReportStatus.mockResolvedValueOnce(true);
+    const vm = new BotDetailVM("bot1", createRuntime());
+    vm.mount();
+
+    await vm.loadBotInfo();
+    await Promise.resolve();
+
+    expect(vm.state.loading).toBe(false);
+    expect(vm.state.name).toBe("Bot One");
+    expect(vm.state.isFriend).toBe(true);
+    expect(vm.isOwner()).toBe(true);
+    expect(mocks.getReportStatus).toHaveBeenCalledWith("bot1");
+    expect(vm.state.reported).toBe(true);
+  });
+
+  it("falls back to channel info when profile load fails", async () => {
+    mocks.getBotProfile.mockRejectedValueOnce(new Error("boom"));
+    const runtime = createRuntime({
+      fetchChannelInfo: vi.fn().mockResolvedValueOnce({
+        title: "Cached Bot",
+        orgData: {
+          remark: "Cached Remark",
+          bot_description: "cached desc",
+          bot_creator_uid: "someone",
+          bot_creator_name: "Someone",
+          bot_commands: "[]",
+          follow: 0,
+        },
+      }),
+    });
+    const vm = new BotDetailVM("bot1", runtime);
+    vm.mount();
+
+    await vm.loadBotInfo();
+
+    expect(vm.state.loading).toBe(false);
+    expect(vm.state.name).toBe("Cached Bot");
+    expect(vm.state.remark).toBe("Cached Remark");
+    expect(vm.isOwner()).toBe(false);
+  });
+
+  it("drops stale profile responses after uid changes", async () => {
+    let resolveFirst!: (value: unknown) => void;
+    mocks.getBotProfile
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        name: "Bot Two",
+        username: "bot_two",
+        bot_creator_uid: "owner-1",
+        follow: 0,
+      });
+    mocks.getReportStatus.mockResolvedValue(false);
+    const vm = new BotDetailVM("bot1", createRuntime());
+    vm.mount();
+
+    const firstLoad = vm.loadBotInfo();
+    vm.setUid("bot2");
+    resolveFirst({
+      name: "Bot One",
+      username: "bot_one",
+      bot_creator_uid: "owner-1",
+      follow: 1,
+    });
+    await firstLoad;
+    await Promise.resolve();
+
+    expect(vm.currentUid()).toBe("bot2");
+    expect(vm.state.name).toBe("Bot Two");
+    expect(vm.state.username).toBe("bot_two");
+  });
+
+  it("saves remark and refreshes channel info", async () => {
+    mocks.updateRemark.mockResolvedValueOnce(undefined);
+    const runtime = createRuntime();
+    const vm = new BotDetailVM("bot1", runtime);
+    vm.mount();
+    vm.state.remark = "Old";
+    vm.startEditRemark();
+    vm.setRemarkDraft(" New ");
+
+    await expect(vm.saveRemark()).resolves.toBe("ok");
+
+    expect(mocks.updateRemark).toHaveBeenCalledWith("bot1", "New");
+    expect(vm.state.remark).toBe("New");
+    expect(vm.state.editingRemark).toBe(false);
+    expect(runtime.refreshChannelInfo).toHaveBeenCalledWith("bot1");
+  });
+
+  it("submits friend apply with current space", async () => {
+    mocks.applyFriend.mockResolvedValueOnce(undefined);
+    const vm = new BotDetailVM("bot1", createRuntime());
+    vm.mount();
+    vm.showApplyInput("hello");
+
+    await expect(vm.submitApply()).resolves.toBe("ok");
+
+    expect(mocks.applyFriend).toHaveBeenCalledWith({
+      uid: "bot1",
+      remark: "hello",
+      spaceId: "space-a",
+    });
+    expect(vm.state.showApplyInput).toBe(false);
+    expect(vm.state.applying).toBe(false);
+  });
+
+  it("uploads avatar with token and reports avatar refresh", async () => {
+    const file = new File(["avatar"], "avatar.png", { type: "image/png" });
+    mocks.uploadAvatar.mockResolvedValueOnce(undefined);
+    const runtime = createRuntime();
+    const vm = new BotDetailVM("bot1", runtime);
+    vm.mount();
+
+    await expect(vm.uploadAvatar(file)).resolves.toBe("ok");
+
+    expect(mocks.uploadAvatar).toHaveBeenCalledWith("bot1", file, "token-a");
+    expect(runtime.onAvatarChanged).toHaveBeenCalledWith("bot1");
+    expect(vm.state.uploadingAvatar).toBe(false);
+  });
+});
+
+describe("BotDetailVM helpers", () => {
+  it("strips markdown display markers", () => {
+    expect(stripBotDetailDisplayName("**Bot**")).toBe("Bot");
+  });
+
+  it("parses command arrays defensively", () => {
+    expect(parseBotCommands('[{"cmd":"/help","remark":"Help"}]')).toEqual([
+      { cmd: "/help", remark: "Help" },
+    ]);
+    expect(parseBotCommands("{bad")).toEqual([]);
+    expect(parseBotCommands("{}")).toEqual([]);
+  });
+});

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
@@ -81,6 +81,19 @@ describe("UserInfoVM profile actions", () => {
     expect(vm.savingRemark).toBe(false);
   });
 
+  it("keeps backend remark error message on save failure", async () => {
+    mocks.updateRemark.mockRejectedValueOnce({ msg: "remark is too long" });
+    const vm = new UserInfoVM("u1");
+    (vm as any).mounted = true;
+    vm.startEditRemark();
+    vm.setRemarkDraft("invalid");
+
+    await expect(vm.saveRemark()).resolves.toBe("failed");
+
+    expect(vm.remarkSaveError).toBe("remark is too long");
+    expect(vm.savingRemark).toBe(false);
+  });
+
   it("applies friend with vercode and space", async () => {
     mocks.applyFriend.mockResolvedValueOnce(undefined);
     const vm = new UserInfoVM("u1", undefined, "vc-1");

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  updateRemark: vi.fn(),
+  applyFriend: vi.fn(),
+  getUserProfile: vi.fn(),
+  fetchChannelInfo: vi.fn(),
+  changeChannelAvatarTag: vi.fn(),
+  userInfos: vi.fn(),
+}));
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class {
+    channelID: string;
+    channelType: number;
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  },
+  ChannelTypePerson: 1,
+  WKSDK: {
+    shared: () => ({
+      channelManager: {
+        fetchChannelInfo: mocks.fetchChannelInfo,
+        getSubscribes: vi.fn(() => []),
+        addSubscriberChangeListener: vi.fn(),
+        removeSubscriberChangeListener: vi.fn(),
+        getChannelInfo: vi.fn(),
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    shared: {
+      changeChannelAvatarTag: mocks.changeChannelAvatarTag,
+      userInfos: mocks.userInfos,
+    },
+    loginInfo: {
+      uid: "me",
+    },
+  },
+}));
+
+vi.mock("../../../Service/UserService", () => ({
+  default: {
+    updateRemark: mocks.updateRemark,
+    applyFriend: mocks.applyFriend,
+    getUserProfile: mocks.getUserProfile,
+  },
+}));
+
+import { UserInfoVM } from "../UserInfoVM";
+
+beforeEach(() => {
+  Object.values(mocks).forEach((mock) => mock.mockReset());
+  mocks.fetchChannelInfo.mockResolvedValue(undefined);
+  mocks.getUserProfile.mockResolvedValue({ uid: "u1", name: "User One" });
+});
+
+describe("UserInfoVM profile actions", () => {
+  it("saves remark and updates local channel info", async () => {
+    mocks.updateRemark.mockResolvedValueOnce(undefined);
+    const vm = new UserInfoVM("u1");
+    (vm as any).mounted = true;
+    vm.channelInfo = {
+      title: "User One",
+      orgData: { remark: "Old" },
+    } as any;
+
+    vm.startEditRemark();
+    vm.setRemarkDraft(" New ");
+    await expect(vm.saveRemark()).resolves.toBe("ok");
+
+    expect(mocks.updateRemark).toHaveBeenCalledWith("u1", "New");
+    expect(vm.channelInfo?.orgData?.remark).toBe("New");
+    expect(vm.channelInfo?.orgData?.displayName).toBe("New");
+    expect(vm.editingRemark).toBe(false);
+    expect(vm.savingRemark).toBe(false);
+  });
+
+  it("applies friend with vercode and space", async () => {
+    mocks.applyFriend.mockResolvedValueOnce(undefined);
+    const vm = new UserInfoVM("u1", undefined, "vc-1");
+
+    await vm.applyFriend("hello", "space-a");
+
+    expect(mocks.applyFriend).toHaveBeenCalledWith({
+      uid: "u1",
+      remark: "hello",
+      vercode: "vc-1",
+      spaceId: "space-a",
+    });
+  });
+});

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -89,7 +89,7 @@ import IconClick from "./Components/IconClick";
 import EmojiToolbar from "./Components/EmojiToolbar";
 import MergeforwardContent, { MergeforwardCell } from "./Messages/Mergeforward";
 import { wkConfirm } from "./Components/WKModal";
-import { UserInfoRouteData } from "./Components/UserInfo/vm";
+import { UserInfoRouteData } from "./bridge/profileDetail/UserInfoVM";
 import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
 import APIClient from "./Service/APIClient";

--- a/packages/dmworkbase/src/ui/profileDetail/BotDetailView/BotDetailView.stories.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/BotDetailView/BotDetailView.stories.tsx
@@ -1,0 +1,166 @@
+import React, { useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BotDetailView, {
+  type BotDetailViewLabels,
+  type BotDetailViewProps,
+} from "./index";
+
+const labels: BotDetailViewLabels = {
+  close: "关闭",
+  changeAvatar: "更换头像",
+  reported: "已上报 Agent 信息",
+  notReported: "未上报 Agent 信息",
+  reportHelp: "未上报时不可查看详情",
+  help: "帮助",
+  remark: "备注",
+  noRemark: "未设置",
+  remarkPlaceholder: "请输入备注",
+  editRemark: "编辑备注",
+  nickname: "昵称",
+  description: "简介",
+  editDescription: "编辑简介",
+  edit: "编辑",
+  descriptionPlaceholder: "请输入简介",
+  noDescription: "暂无简介",
+  creator: "创建者",
+  commands: "指令",
+  botManageTitle: "Bot 管理",
+  viewClawInfo: "查看龙虾信息",
+  sendMessage: "发送消息",
+  addFriend: "添加好友",
+  applyMessageLabel: "申请说明",
+  applyMessagePlaceholder: "请输入申请说明",
+  applySend: "发送申请",
+  save: "保存",
+  cancel: "取消",
+};
+
+function StoryAvatar({ text = "AI" }: { text?: string }) {
+  return <div className="wk-bot-detail-story-avatar">{text}</div>;
+}
+
+function BotDetailViewStory(args: Partial<BotDetailViewProps>) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const descriptionRef = useRef<HTMLTextAreaElement | null>(null);
+  const [remarkDraft, setRemarkDraft] = useState(args.remarkDraft ?? "我的 Bot 管家");
+  const [descriptionDraft, setDescriptionDraft] = useState(
+    args.descriptionDraft ?? "用于创建、管理和配置团队内的 AI Bot。",
+  );
+  const [applyRemark, setApplyRemark] = useState(args.applyRemark ?? "希望添加这个 Bot");
+
+  return (
+    <div className="wk-bot-detail-modal wk-bot-detail-story">
+      <BotDetailView
+        loading={false}
+        displayName="我的 Bot 管家"
+        botName="BotFather"
+        username="botfather"
+        remark="我的 Bot 管家"
+        displayDescription="用于创建、管理和配置团队内的 AI Bot。"
+        creatorName="Alice Chen"
+        commands={[
+          { cmd: "/help", remark: "查看 Bot 能力说明" },
+          { cmd: "/summarize", remark: "总结当前上下文中的重点信息" },
+        ]}
+        isOwner
+        isFriend
+        reported
+        uploadingAvatar={false}
+        editingRemark={false}
+        remarkDraft={remarkDraft}
+        savingRemark={false}
+        editingDescription={false}
+        descriptionDraft={descriptionDraft}
+        savingDescription={false}
+        showApplyInput={false}
+        applyRemark={applyRemark}
+        applying={false}
+        ownerAvatar={<StoryAvatar />}
+        previewAvatar={<StoryAvatar />}
+        fileInputRef={fileInputRef}
+        descriptionRef={descriptionRef}
+        labels={labels}
+        onClose={() => undefined}
+        onAvatarClick={() => undefined}
+        onAvatarKeyDown={() => undefined}
+        onAvatarInputClick={() => undefined}
+        onAvatarFileChange={() => undefined}
+        onRemarkDraftChange={setRemarkDraft}
+        onStartEditRemark={() => undefined}
+        onEditRemarkKeyDown={() => undefined}
+        onCancelEditRemark={() => undefined}
+        onSaveRemark={() => undefined}
+        onStartEditDescription={() => undefined}
+        onEditDescriptionKeyDown={() => undefined}
+        onDescriptionDraftChange={setDescriptionDraft}
+        onDescriptionTranscribed={(text) => setDescriptionDraft(text)}
+        getCurrentDescriptionText={() => descriptionDraft}
+        onCancelEditDescription={() => undefined}
+        onSaveDescription={() => undefined}
+        onOpenBotManage={() => undefined}
+        onViewClawInfo={() => undefined}
+        onChat={() => undefined}
+        onShowApply={() => undefined}
+        onApplyRemarkChange={setApplyRemark}
+        onSubmitApply={() => undefined}
+        {...args}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "UI/ProfileDetail/BotDetailView",
+  component: BotDetailViewStory,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Pure Bot detail presentation component. Data loading, Service calls, and modal orchestration stay outside this UI component.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="wk-bot-detail-story-frame">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BotDetailViewStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OwnerFriend: Story = {};
+
+export const StrangerApply: Story = {
+  args: {
+    displayName: "Research Helper",
+    botName: "Research Helper",
+    username: "research_helper",
+    remark: "",
+    creatorName: "",
+    commands: [],
+    isOwner: false,
+    isFriend: false,
+    reported: null,
+    showApplyInput: true,
+  },
+};
+
+export const Editing: Story = {
+  args: {
+    editingRemark: true,
+    editingDescription: true,
+    isFriend: false,
+    showApplyInput: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.css
+++ b/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.css
@@ -1,0 +1,1 @@
+@import "../../../Components/BotDetailModal/index.css";

--- a/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.tsx
@@ -1,0 +1,503 @@
+import React from "react";
+import { Button, Input, Spin } from "@douyinfe/semi-ui";
+import {
+  IconAlertCircle,
+  IconCamera,
+  IconChevronRight,
+  IconEdit,
+  IconTickCircle,
+} from "@douyinfe/semi-icons";
+import AiBadge from "../../../Components/AiBadge";
+import VoiceInputButton, {
+  type ReplaceMode,
+  type SelectionRange,
+} from "../../../Components/VoiceInputButton";
+import "./index.css";
+
+export interface BotDetailViewCommand {
+  cmd: string;
+  remark: string;
+}
+
+export interface BotDetailViewLabels {
+  close: string;
+  changeAvatar: string;
+  reported: string;
+  notReported: string;
+  reportHelp: string;
+  help: string;
+  remark: string;
+  noRemark: string;
+  remarkPlaceholder: string;
+  editRemark: string;
+  nickname: string;
+  description: string;
+  editDescription: string;
+  edit: string;
+  descriptionPlaceholder: string;
+  noDescription: string;
+  creator: string;
+  commands: string;
+  botManageTitle: string;
+  viewClawInfo: string;
+  sendMessage: string;
+  addFriend: string;
+  applyMessageLabel: string;
+  applyMessagePlaceholder: string;
+  applySend: string;
+  save: string;
+  cancel: string;
+}
+
+export interface BotDetailViewProps {
+  loading: boolean;
+  displayName: string;
+  botName: string;
+  username: string;
+  remark: string;
+  displayDescription: string;
+  creatorName: string;
+  commands: BotDetailViewCommand[];
+  isOwner: boolean;
+  isFriend: boolean;
+  reported: boolean | null;
+  uploadingAvatar: boolean;
+  editingRemark: boolean;
+  remarkDraft: string;
+  savingRemark: boolean;
+  editingDescription: boolean;
+  descriptionDraft: string;
+  savingDescription: boolean;
+  showApplyInput: boolean;
+  applyRemark: string;
+  applying: boolean;
+  ownerAvatar: React.ReactNode;
+  previewAvatar: React.ReactNode;
+  fileInputRef: React.Ref<HTMLInputElement>;
+  descriptionRef: React.RefObject<HTMLTextAreaElement>;
+  labels: BotDetailViewLabels;
+  onClose: () => void;
+  onAvatarClick: () => void;
+  onAvatarKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  onAvatarInputClick: (event: React.MouseEvent<HTMLInputElement>) => void;
+  onAvatarFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemarkDraftChange: (value: string) => void;
+  onStartEditRemark: () => void;
+  onEditRemarkKeyDown: (event: React.KeyboardEvent<HTMLSpanElement>) => void;
+  onCancelEditRemark: () => void;
+  onSaveRemark: () => void;
+  onStartEditDescription: () => void;
+  onEditDescriptionKeyDown: (event: React.KeyboardEvent<HTMLSpanElement>) => void;
+  onDescriptionDraftChange: (value: string) => void;
+  onDescriptionTranscribed: (
+    text: string,
+    mode: ReplaceMode,
+    savedRange?: SelectionRange,
+  ) => void;
+  getCurrentDescriptionText: () => string;
+  onCancelEditDescription: () => void;
+  onSaveDescription: () => void;
+  onOpenBotManage: (event?: React.MouseEvent) => void;
+  onViewClawInfo: () => void;
+  onChat: () => void;
+  onShowApply: () => void;
+  onApplyRemarkChange: (value: string) => void;
+  onSubmitApply: () => void;
+}
+
+export function BotDetailView({
+  loading,
+  displayName,
+  botName,
+  username,
+  remark,
+  displayDescription,
+  creatorName,
+  commands,
+  isOwner,
+  isFriend,
+  reported,
+  uploadingAvatar,
+  editingRemark,
+  remarkDraft,
+  savingRemark,
+  editingDescription,
+  descriptionDraft,
+  savingDescription,
+  showApplyInput,
+  applyRemark,
+  applying,
+  ownerAvatar,
+  previewAvatar,
+  fileInputRef,
+  descriptionRef,
+  labels,
+  onClose,
+  onAvatarClick,
+  onAvatarKeyDown,
+  onAvatarInputClick,
+  onAvatarFileChange,
+  onRemarkDraftChange,
+  onStartEditRemark,
+  onEditRemarkKeyDown,
+  onCancelEditRemark,
+  onSaveRemark,
+  onStartEditDescription,
+  onEditDescriptionKeyDown,
+  onDescriptionDraftChange,
+  onDescriptionTranscribed,
+  getCurrentDescriptionText,
+  onCancelEditDescription,
+  onSaveDescription,
+  onOpenBotManage,
+  onViewClawInfo,
+  onChat,
+  onShowApply,
+  onApplyRemarkChange,
+  onSubmitApply,
+}: BotDetailViewProps) {
+  return (
+    <div className="wk-bot-detail-content">
+      <div className="wk-bot-detail-route-header">
+        <button
+          type="button"
+          className="wk-bot-detail-route-close"
+          onClick={onClose}
+          aria-label={labels.close}
+        >
+          <span className="wk-bot-detail-route-close-icon" aria-hidden="true" />
+        </button>
+      </div>
+      {loading ? (
+        <div className="wk-bot-detail-loading">
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          <div className="wk-bot-detail-scroll">
+            <div className="wk-bot-detail-header">
+              {isOwner ? (
+                <div
+                  className="wk-bot-detail-avatar wk-bot-detail-avatar--owner"
+                  onClick={onAvatarClick}
+                  onKeyDown={onAvatarKeyDown}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={labels.changeAvatar}
+                >
+                  {ownerAvatar}
+                  <div className="wk-bot-detail-avatar-overlay" aria-hidden="true">
+                    <IconCamera />
+                  </div>
+                  {uploadingAvatar && (
+                    <div className="wk-bot-detail-avatar-loading">
+                      <Spin />
+                    </div>
+                  )}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple={false}
+                    className="wk-bot-detail-file-input"
+                    onClick={onAvatarInputClick}
+                    onChange={onAvatarFileChange}
+                  />
+                </div>
+              ) : (
+                <div className="wk-bot-detail-avatar wk-bot-detail-avatar--preview">
+                  {previewAvatar}
+                </div>
+              )}
+              <div className="wk-bot-detail-heading">
+                <div className="wk-bot-detail-name">
+                  <span className="wk-bot-detail-name-text">{displayName}</span>
+                  <AiBadge />
+                </div>
+                <div className="wk-bot-detail-id">@{username}</div>
+                {isOwner && reported !== null && (
+                  <div
+                    className={`wk-bot-detail-octopush-chip ${
+                      reported
+                        ? "wk-bot-detail-octopush-chip--reported"
+                        : "wk-bot-detail-octopush-chip--unmanaged"
+                    }`}
+                  >
+                    <span className="wk-bot-detail-octopush-status">
+                      <span className="wk-bot-detail-octopush-chip-icon">
+                        {reported ? <IconTickCircle /> : <IconAlertCircle />}
+                      </span>
+                      <span className="wk-bot-detail-octopush-chip-text">
+                        {reported ? labels.reported : labels.notReported}
+                      </span>
+                      {!reported && (
+                        <button
+                          type="button"
+                          className="wk-bot-detail-help-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          title={labels.reportHelp}
+                          aria-label={labels.help}
+                        >
+                          ?
+                        </button>
+                      )}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="wk-bot-detail-section">
+              <div className="wk-bot-detail-row wk-bot-detail-row--editable">
+                <div className="wk-bot-detail-row-main">
+                  <div className="wk-bot-detail-label">{labels.remark}</div>
+                  {editingRemark ? (
+                    <div className="wk-bot-detail-editor">
+                      <Input
+                        value={remarkDraft}
+                        onChange={onRemarkDraftChange}
+                        placeholder={labels.remarkPlaceholder}
+                        maxLength={30}
+                      />
+                      <div className="wk-bot-detail-editor-actions">
+                        <Button
+                          size="small"
+                          onClick={onCancelEditRemark}
+                          disabled={savingRemark}
+                        >
+                          {labels.cancel}
+                        </Button>
+                        <Button
+                          size="small"
+                          theme="solid"
+                          type="primary"
+                          loading={savingRemark}
+                          onClick={onSaveRemark}
+                        >
+                          {labels.save}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="wk-bot-detail-value">
+                      {remark || (
+                        <span className="wk-bot-detail-empty">
+                          {labels.noRemark}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+                {!editingRemark && (
+                  <Button
+                    className="wk-bot-detail-value-edit"
+                    theme="borderless"
+                    type="tertiary"
+                    size="small"
+                    icon={<IconEdit />}
+                    onClick={onStartEditRemark}
+                    onKeyDown={onEditRemarkKeyDown}
+                    aria-label={labels.editRemark}
+                    title={labels.editRemark}
+                  />
+                )}
+              </div>
+              {remark && (
+                <div className="wk-bot-detail-row">
+                  <div className="wk-bot-detail-label">{labels.nickname}</div>
+                  <div className="wk-bot-detail-value wk-bot-detail-value--right">
+                    {botName}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="wk-bot-detail-section">
+              <div className="wk-bot-detail-description">
+                <div className="wk-bot-detail-field-header">
+                  <div className="wk-bot-detail-label">{labels.description}</div>
+                  {isOwner && !editingDescription && (
+                    <Button
+                      className="wk-bot-detail-edit-action"
+                      theme="borderless"
+                      type="tertiary"
+                      size="small"
+                      icon={<IconEdit />}
+                      onClick={onStartEditDescription}
+                      onKeyDown={onEditDescriptionKeyDown}
+                      aria-label={labels.editDescription}
+                    >
+                      {labels.edit}
+                    </Button>
+                  )}
+                </div>
+                {isOwner && editingDescription ? (
+                  <div>
+                    <div className="wk-bot-detail-textarea-wrap">
+                      <textarea
+                        ref={descriptionRef}
+                        className="wk-bot-detail-textarea"
+                        value={descriptionDraft}
+                        onChange={(e) => onDescriptionDraftChange(e.target.value)}
+                        placeholder={labels.descriptionPlaceholder}
+                        maxLength={200}
+                        rows={3}
+                      />
+                      <VoiceInputButton
+                        inputRef={descriptionRef}
+                        onTranscribed={onDescriptionTranscribed}
+                        getCurrentText={getCurrentDescriptionText}
+                        showModeMenu
+                        size="sm"
+                        className="wk-vib--textarea-corner"
+                      />
+                    </div>
+                    <div className="wk-bot-detail-editor-actions">
+                      <Button
+                        size="small"
+                        onClick={onCancelEditDescription}
+                        disabled={savingDescription}
+                      >
+                        {labels.cancel}
+                      </Button>
+                      <Button
+                        size="small"
+                        theme="solid"
+                        type="primary"
+                        loading={savingDescription}
+                        onClick={onSaveDescription}
+                      >
+                        {labels.save}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="wk-bot-detail-description-text">
+                    {displayDescription}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {(creatorName || commands.length > 0) && (
+              <div className="wk-bot-detail-section">
+                {creatorName && (
+                  <div className="wk-bot-detail-row">
+                    <div className="wk-bot-detail-label">{labels.creator}</div>
+                    <div className="wk-bot-detail-value wk-bot-detail-value--right">
+                      {creatorName}
+                    </div>
+                  </div>
+                )}
+                {commands.length > 0 && (
+                  <div className="wk-bot-detail-command-block">
+                    <div className="wk-bot-detail-label">{labels.commands}</div>
+                    <div className="wk-bot-detail-command-list">
+                      {commands.map((cmd, i) => (
+                        <div key={i} className="wk-bot-detail-cmd">
+                          <span className="wk-bot-detail-cmd-name">{cmd.cmd}</span>
+                          <span className="wk-bot-detail-cmd-desc">
+                            {cmd.remark}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {isOwner && (
+              <div className="wk-bot-detail-section">
+                <button
+                  type="button"
+                  onClick={onOpenBotManage}
+                  className="wk-bot-detail-nav-row"
+                  aria-label={labels.botManageTitle}
+                >
+                  <span>{labels.botManageTitle}</span>
+                  <IconChevronRight className="wk-bot-detail-nav-chevron" />
+                </button>
+                {reported !== null && (
+                  <button
+                    type="button"
+                    onClick={onViewClawInfo}
+                    className={`wk-bot-detail-nav-row${
+                      !reported ? " wk-bot-detail-nav-row--disabled" : ""
+                    }`}
+                    disabled={!reported}
+                    aria-label={labels.viewClawInfo}
+                    title={!reported ? labels.reportHelp : undefined}
+                  >
+                    <span className="wk-bot-detail-nav-main">
+                      <span
+                        className="wk-bot-detail-claw-action-icon"
+                        aria-hidden="true"
+                      >
+                        🦞
+                      </span>
+                      <span>{labels.viewClawInfo}</span>
+                    </span>
+                    {reported && (
+                      <IconChevronRight className="wk-bot-detail-nav-chevron" />
+                    )}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="wk-bot-detail-actions">
+            {isFriend ? (
+              <Button
+                className="wk-bot-detail-primary-action"
+                theme="solid"
+                type="primary"
+                block
+                onClick={onChat}
+              >
+                {labels.sendMessage}
+              </Button>
+            ) : showApplyInput ? (
+              <div className="wk-bot-detail-apply">
+                <div className="wk-bot-detail-apply-label">
+                  {labels.applyMessageLabel}
+                </div>
+                <Input
+                  value={applyRemark}
+                  onChange={onApplyRemarkChange}
+                  placeholder={labels.applyMessagePlaceholder}
+                />
+                <Button
+                  className="wk-bot-detail-primary-action"
+                  theme="solid"
+                  type="primary"
+                  block
+                  loading={applying}
+                  disabled={!applyRemark}
+                  onClick={onSubmitApply}
+                >
+                  {labels.applySend}
+                </Button>
+              </div>
+            ) : (
+              <Button
+                className="wk-bot-detail-primary-action"
+                theme="solid"
+                type="primary"
+                block
+                onClick={onShowApply}
+              >
+                {labels.addFriend}
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default BotDetailView;

--- a/packages/dmworkbase/src/ui/profileDetail/UserInfoView/UserInfoView.stories.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/UserInfoView/UserInfoView.stories.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import WKButton from "../../../Components/WKButton";
+import UserInfoView, {
+  type UserInfoViewLabels,
+  type UserInfoViewProps,
+} from "./index";
+
+const labels: UserInfoViewLabels = {
+  remark: "备注",
+  remarkPlaceholder: "请输入备注",
+  editRemark: "编辑备注",
+  cancel: "取消",
+  save: "保存",
+  notSet: "未设置",
+};
+
+function StoryAvatar({ text }: { text: string }) {
+  return <div className="wk-userinfo-story-avatar">{text}</div>;
+}
+
+function StoryRow({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="wk-list-item wk-list-item-static">
+      <div className="wk-list-item-title">{title}</div>
+      <div className="wk-list-item-subtitle">{subtitle}</div>
+    </div>
+  );
+}
+
+const profileSections = [
+  {
+    rows: [
+      {
+        cell: StoryRow,
+        properties: {
+          title: "来源",
+          subtitle: "通过群聊添加",
+        },
+        sort: 0,
+      },
+    ],
+  },
+] as UserInfoViewProps["sections"];
+
+function UserInfoViewStory(args: Partial<UserInfoViewProps>) {
+  const [remarkDraft, setRemarkDraft] = useState(args.remarkDraft ?? "Alice");
+
+  return (
+    <div className="wk-userinfo-story-frame">
+      <UserInfoView
+        loading={false}
+        avatar={<StoryAvatar text="A" />}
+        displayName="Alice Chen"
+        isBot={false}
+        isRealnameVerified
+        metaItems={[
+          { label: "昵称", value: "Alice" },
+          { label: "Octo号", value: "octo_1001" },
+        ]}
+        showRemarkEditor
+        editingRemark={false}
+        remark="Alice"
+        remarkDraft={remarkDraft}
+        savingRemark={false}
+        sections={profileSections}
+        footerAction={
+          <WKButton type="button" variant="primary">
+            发送消息
+          </WKButton>
+        }
+        labels={labels}
+        onRemarkDraftChange={setRemarkDraft}
+        onStartEditRemark={() => undefined}
+        onCancelEditRemark={() => undefined}
+        onSaveRemark={() => undefined}
+        {...args}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "UI/ProfileDetail/UserInfoView",
+  component: UserInfoViewStory,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Pure user profile detail presentation component. Data loading, Service calls, and route orchestration stay outside this UI component.",
+      },
+    },
+  },
+} satisfies Meta<typeof UserInfoViewStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Friend: Story = {};
+
+export const Stranger: Story = {
+  args: {
+    avatar: <StoryAvatar text="B" />,
+    displayName: "Bob Lee",
+    isRealnameVerified: false,
+    remark: "",
+    metaItems: [
+      { label: "群昵称", value: "产品讨论组里的 Bob" },
+      { label: "Octo号", value: "octo_2048" },
+    ],
+    footerAction: (
+      <WKButton type="button" variant="secondary">
+        添加好友
+      </WKButton>
+    ),
+  },
+};
+
+export const Bot: Story = {
+  args: {
+    avatar: <StoryAvatar text="B" />,
+    displayName: "BotFather",
+    isBot: true,
+    isRealnameVerified: false,
+    remark: "Bot 管家",
+    metaItems: [
+      { label: "昵称", value: "BotFather" },
+      { label: "Octo号", value: "bot_father" },
+    ],
+    footerAction: (
+      <WKButton type="button" variant="primary">
+        添加好友
+      </WKButton>
+    ),
+  },
+};
+
+export const ExternalMember: Story = {
+  args: {
+    avatar: <StoryAvatar text="E" />,
+    displayName: "External User",
+    isRealnameVerified: true,
+    remark: "外部协作人",
+    metaItems: [
+      { label: "昵称", value: "External User" },
+      { label: "群昵称", value: "外部协作成员" },
+    ],
+    footerAction: undefined,
+    footerHint: "外部成员仅可在群内交流",
+  },
+};
+
+export const Editing: Story = {
+  args: {
+    editingRemark: true,
+    remarkDraft: "新的备注",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    footerAction: undefined,
+    footerHint: undefined,
+  },
+};

--- a/packages/dmworkbase/src/ui/profileDetail/UserInfoView/index.css
+++ b/packages/dmworkbase/src/ui/profileDetail/UserInfoView/index.css
@@ -1,0 +1,1 @@
+@import "../../../Components/UserInfo/index.css";

--- a/packages/dmworkbase/src/ui/profileDetail/UserInfoView/index.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/UserInfoView/index.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { Input, Spin } from "@douyinfe/semi-ui";
+import { IconEdit } from "@douyinfe/semi-icons";
+import Sections from "../../../Components/Sections";
+import WKButton from "../../../Components/WKButton";
+import UserInfoHeader from "../../../Components/UserInfo/UserInfoHeader";
+import UserInfoFooter from "../../../Components/UserInfo/UserInfoFooter";
+import type { UserInfoMetaItem } from "../../../Components/UserInfo/UserInfoMetaList";
+import "./index.css";
+
+type UserInfoViewSections = React.ComponentProps<typeof Sections>["sections"];
+
+export interface UserInfoViewLabels {
+  remark: string;
+  remarkPlaceholder: string;
+  editRemark: string;
+  cancel: string;
+  save: string;
+  notSet: string;
+}
+
+export interface UserInfoViewFooter {
+  action?: React.ReactNode;
+  hint?: React.ReactNode;
+}
+
+export interface UserInfoViewProps {
+  loading: boolean;
+  avatar: React.ReactNode;
+  displayName: React.ReactNode;
+  isBot: boolean;
+  isRealnameVerified: boolean;
+  metaItems: UserInfoMetaItem[];
+  showRemarkEditor: boolean;
+  editingRemark: boolean;
+  remark: string;
+  remarkDraft: string;
+  savingRemark: boolean;
+  sections: UserInfoViewSections;
+  footerAction?: React.ReactNode;
+  footerHint?: React.ReactNode;
+  labels: UserInfoViewLabels;
+  onRemarkDraftChange: (value: string) => void;
+  onStartEditRemark: () => void;
+  onCancelEditRemark: () => void;
+  onSaveRemark: () => void;
+}
+
+function UserInfoView({
+  loading,
+  avatar,
+  displayName,
+  isBot,
+  isRealnameVerified,
+  metaItems,
+  showRemarkEditor,
+  editingRemark,
+  remark,
+  remarkDraft,
+  savingRemark,
+  sections,
+  footerAction,
+  footerHint,
+  labels,
+  onRemarkDraftChange,
+  onStartEditRemark,
+  onCancelEditRemark,
+  onSaveRemark,
+}: UserInfoViewProps) {
+  const hasFooter = !!footerAction || !!footerHint;
+
+  return (
+    <div className={`wk-userinfo ${hasFooter ? "wk-userinfo--with-footer" : ""}`}>
+      <div className="wk-userinfo-content">
+        {loading ? (
+          <div className="wk-userinfo-loading">
+            <Spin />
+          </div>
+        ) : (
+          <>
+            <UserInfoHeader
+              avatar={avatar}
+              displayName={displayName}
+              isBot={isBot}
+              isRealnameVerified={isRealnameVerified}
+              metaItems={metaItems}
+            />
+            {showRemarkEditor && (
+              <div className="wk-userinfo-remark-section">
+                <div className="wk-userinfo-remark-row">
+                  <div className="wk-userinfo-remark-main">
+                    <div className="wk-userinfo-remark-label">{labels.remark}</div>
+                    {editingRemark ? (
+                      <div className="wk-userinfo-remark-editor">
+                        <Input
+                          value={remarkDraft}
+                          onChange={onRemarkDraftChange}
+                          placeholder={labels.remarkPlaceholder}
+                          maxLength={30}
+                        />
+                        <div className="wk-userinfo-remark-actions">
+                          <WKButton
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            disabled={savingRemark}
+                            onClick={onCancelEditRemark}
+                          >
+                            {labels.cancel}
+                          </WKButton>
+                          <WKButton
+                            type="button"
+                            variant="primary"
+                            size="sm"
+                            loading={savingRemark}
+                            onClick={onSaveRemark}
+                          >
+                            {labels.save}
+                          </WKButton>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="wk-userinfo-remark-value">
+                        {remark || (
+                          <span className="wk-userinfo-remark-empty">
+                            {labels.notSet}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  {!editingRemark && (
+                    <button
+                      type="button"
+                      className="wk-userinfo-remark-edit"
+                      onClick={onStartEditRemark}
+                      aria-label={labels.editRemark}
+                      title={labels.editRemark}
+                    >
+                      <IconEdit />
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="wk-userinfo-sections">
+              <Sections sections={sections} />
+            </div>
+          </>
+        )}
+      </div>
+      <UserInfoFooter action={footerAction} hint={footerHint} />
+    </div>
+  );
+}
+
+export default UserInfoView;
+export { UserInfoView };


### PR DESCRIPTION
## Summary
- Move profile detail API calls for user info, bot profile, and bot management into Service modules.
- Move user and bot detail state logic into bridge VMs.
- Split UserInfo and BotDetailModal into container components plus presentation-only ui views.
- Add focused unit tests and Storybook stories for the refactored profile detail flow.

## Scope
- In scope: UserInfo, BotDetailModal, BotManage API access, profile detail bridge VMs, Service tests, and view stories.
- Out of scope: visual redesign, MeInfo, route changes, global modal unification, and full CSS ownership migration.

## Verification
- pnpm --dir packages/dmworkbase exec vitest run src/bridge/profileDetail/__tests__/BotDetailVM.test.ts src/bridge/profileDetail/__tests__/UserInfoVM.test.ts src/Service/__tests__/UserService.test.ts src/Service/__tests__/BotProfileService.test.ts src/Service/__tests__/BotManageService.test.ts src/Components/BotManage/__tests__/vm.test.ts
- pnpm --dir apps/web build
- pnpm --dir apps/web build-storybook
- pnpm lint:css

## Notes
- New ui/profileDetail views intentionally reuse legacy CSS entry points to avoid visual changes in this PR.
- WKApp/WKSDK integration remains in the container layer; pure ui views do not depend on runtime services or SDKs.