### PR TITLE
fix(profile): restore thread context and align bot actions

### DIFF
--- a/packages/dmworkbase/src/Components/BotDetailModal/BotDetailModal.stories.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/BotDetailModal.stories.tsx
@@ -3,6 +3,7 @@ import { IconAlertCircle, IconChevronRight, IconTickCircle } from "@douyinfe/sem
 import React from "react";
 import AiBadge from "../AiBadge";
 import WKButton from "../WKButton";
+import { ProfileDetailFooter } from "../../ui/profileDetail/ProfileDetailShell";
 import "./index.css";
 
 interface BotDetailPreviewProps {
@@ -129,11 +130,15 @@ function BotDetailPreview({
                 </div>}
             </div>
 
-            <div className="wk-bot-detail-actions">
-                <WKButton type="button" variant="primary">
-                    {isFriend ? "发送消息" : "添加好友"}
-                </WKButton>
-            </div>
+            <ProfileDetailFooter
+                className="wk-bot-detail-footer"
+                actionClassName="wk-bot-detail-actions"
+                action={
+                    <WKButton type="button" variant="primary">
+                        {isFriend ? "发送消息" : "添加好友"}
+                    </WKButton>
+                }
+            />
         </div>
     </div>
 }

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.css
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.css
@@ -373,25 +373,20 @@
 }
 
 .wk-bot-detail-actions {
-    flex: 0 0 auto;
-    padding: var(--wk-sp-3) var(--wk-sp-5);
-    border-top: 1px solid var(--wk-border-subtle);
-    background: var(--wk-bg-surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .wk-bot-detail-actions .wk-bot-detail-primary-action,
 .wk-bot-detail-actions .wk-btn {
-    min-width: calc(var(--wk-sp-12) * 3);
-    min-height: var(--wk-sp-10);
-}
-
-.wk-bot-detail-actions > .wk-bot-detail-primary-action {
-    display: flex;
-    margin: 0 auto;
+    width: 100%;
+    height: var(--wk-profile-detail-action-height, var(--wk-sp-10));
 }
 
 .wk-bot-detail-apply {
     display: flex;
+    width: 100%;
     flex-direction: column;
     gap: var(--wk-sp-3);
 }

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1142,7 +1142,10 @@ export class Conversation
   showUser(uid: string) {
     let fromChannel: Channel | undefined;
     let vercode: string | undefined;
-    if (this.vm.channel.channelType === ChannelTypeGroup) {
+    if (
+      this.vm.channel.channelType === ChannelTypeGroup ||
+      this.vm.channel.channelType === ChannelTypeCommunityTopic
+    ) {
       fromChannel = this.vm.channel;
       const subscriber = this.vm.subscriberWithUID(uid);
       if (subscriber?.orgData?.vercode) {
@@ -3458,7 +3461,10 @@ export class Conversation
                       }
                       let fromChannel: Channel | undefined;
                       let vercode: string | undefined;
-                      if (this.vm.channel.channelType === ChannelTypeGroup) {
+                      if (
+                        this.vm.channel.channelType === ChannelTypeGroup ||
+                        this.vm.channel.channelType === ChannelTypeCommunityTopic
+                      ) {
                         fromChannel = this.vm.channel;
                         const subscriber = this.vm.subscriberWithUID(
                           this.vm.selectUID

--- a/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
+++ b/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
@@ -160,20 +160,48 @@ export class UserInfoVM extends ProviderListener {
   }
 
   reloadSubscribers() {
+    const sourceChannel =
+      this.fromChannel && this.fromChannel.channelType !== ChannelTypePerson
+        ? this.fromChannel
+        : undefined;
     const memberChannel = this.memberContextChannel();
-    if (memberChannel) {
-      const subscribers = WKSDK.shared().channelManager.getSubscribes(
-        memberChannel
-      );
-      if (subscribers && subscribers.length > 0) {
-        for (const subscriber of subscribers) {
-          if (subscriber.uid === this.uid) {
-            this.fromSubscriberOfUser = subscriber;
-          } else if (subscriber.uid === WKApp.loginInfo.uid) {
-            this.subscriberOfMy = subscriber;
-          }
+    const applySubscribers = (
+      subscribers: Subscriber[] | undefined,
+      options: { replaceUser?: boolean; replaceMe?: boolean } = {}
+    ) => {
+      if (!subscribers || subscribers.length === 0) return;
+      for (const subscriber of subscribers) {
+        if (
+          subscriber.uid === this.uid &&
+          (options.replaceUser || !this.fromSubscriberOfUser)
+        ) {
+          this.fromSubscriberOfUser = subscriber;
+        } else if (
+          subscriber.uid === WKApp.loginInfo.uid &&
+          (options.replaceMe || !this.subscriberOfMy)
+        ) {
+          this.subscriberOfMy = subscriber;
         }
       }
+    };
+
+    if (sourceChannel) {
+      applySubscribers(WKSDK.shared().channelManager.getSubscribes(sourceChannel), {
+        replaceUser: true,
+        replaceMe: true,
+      });
+    }
+    if (
+      memberChannel &&
+      (!sourceChannel ||
+        memberChannel.channelID !== sourceChannel.channelID ||
+        memberChannel.channelType !== sourceChannel.channelType)
+    ) {
+      applySubscribers(WKSDK.shared().channelManager.getSubscribes(memberChannel), {
+        replaceMe: true,
+      });
+    }
+    if (sourceChannel || memberChannel) {
       this.notifyListener();
     }
   }

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
@@ -118,7 +118,10 @@ describe("UserInfoVM profile actions", () => {
   });
 
   it("uses parent group_no when loading profile from a thread", async () => {
-    const vm = new UserInfoVM("u1", { channelID: "group-a____thread-1", channelType: 5 } as any);
+    const vm = new UserInfoVM("u1", {
+      channelID: "group-a____thread-1",
+      channelType: 5,
+    } as any);
 
     await vm.reloadChannelInfo();
 
@@ -126,7 +129,10 @@ describe("UserInfoVM profile actions", () => {
   });
 
   it("uses parent group subscribers when opened from a thread", () => {
-    const vm = new UserInfoVM("u1", { channelID: "group-a____thread-1", channelType: 5 } as any);
+    const vm = new UserInfoVM("u1", {
+      channelID: "group-a____thread-1",
+      channelType: 5,
+    } as any);
 
     vm.reloadSubscribers();
 
@@ -135,6 +141,72 @@ describe("UserInfoVM profile actions", () => {
         channelID: "group-a",
         channelType: 2,
       })
+    );
+  });
+
+  it("prefers the source thread subscriber for displayed member info", () => {
+    const vm = new UserInfoVM("u1", {
+      channelID: "group-a____thread-1",
+      channelType: 5,
+    } as any);
+    mocks.getSubscribes.mockImplementation((channel: any) => {
+      if (channel.channelID === "group-a____thread-1") {
+        return [
+          {
+            uid: "u1",
+            remark: "Thread Name",
+            orgData: { created_at: "2026-07-18T10:00:00Z" },
+          },
+        ];
+      }
+      if (channel.channelID === "group-a") {
+        return [
+          {
+            uid: "u1",
+            remark: "Group Name",
+            orgData: { created_at: "2026-07-19T10:00:00Z" },
+          },
+          { uid: "me", role: 1 },
+        ];
+      }
+      return [];
+    });
+
+    vm.reloadSubscribers();
+
+    expect(vm.fromSubscriberOfUser?.remark).toBe("Thread Name");
+    expect(vm.fromSubscriberOfUser?.orgData?.created_at).toBe(
+      "2026-07-18T10:00:00Z"
+    );
+    expect(vm.subscriberOfMy?.role).toBe(1);
+  });
+
+  it("falls back to the parent group subscriber when thread subscriber is missing", () => {
+    const vm = new UserInfoVM("u1", {
+      channelID: "group-a____thread-1",
+      channelType: 5,
+    } as any);
+    mocks.getSubscribes.mockImplementation((channel: any) => {
+      if (channel.channelID === "group-a____thread-1") {
+        return [];
+      }
+      if (channel.channelID === "group-a") {
+        return [
+          {
+            uid: "u1",
+            remark: "Group Name",
+            orgData: { created_at: "2026-07-19T10:00:00Z" },
+          },
+        ];
+      }
+      return [];
+    });
+
+    vm.reloadSubscribers();
+
+    expect(vm.fromSubscriberOfUser?.remark).toBe("Group Name");
+    expect(vm.fromSubscriberOfUser?.orgData?.created_at).toBe(
+      "2026-07-19T10:00:00Z"
     );
   });
 });

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/userInfoMembership.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/userInfoMembership.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("wukongimjssdk", () => ({
+  ChannelTypePerson: 1,
+}));
+
+import {
+  userInfoMembershipCreatedAt,
+  userInfoMembershipOrgData,
+} from "../userInfoMembership";
+
+describe("userInfoMembershipOrgData", () => {
+  it("prefers subscriber membership data when available", () => {
+    const orgData = userInfoMembershipOrgData({
+      fromChannel: { channelID: "group-a", channelType: 2 } as any,
+      channelInfo: {
+        orgData: {
+          created_at: "2026-07-19T10:00:00Z",
+          invite_uid: "from-profile",
+        },
+      } as any,
+      fromSubscriberOfUser: {
+        orgData: {
+          created_at: "2026-07-18T10:00:00Z",
+          invite_uid: "from-subscriber",
+        },
+      } as any,
+    });
+
+    expect(orgData?.created_at).toBe("2026-07-18T10:00:00Z");
+    expect(orgData?.invite_uid).toBe("from-subscriber");
+  });
+
+  it("falls back to profile membership data for group or thread entry", () => {
+    const orgData = userInfoMembershipOrgData({
+      fromChannel: { channelID: "group-a____thread-1", channelType: 5 } as any,
+      channelInfo: {
+        orgData: { created_at: "2026-07-19T10:00:00Z", invite_uid: "u2" },
+      } as any,
+    });
+
+    expect(orgData?.created_at).toBe("2026-07-19T10:00:00Z");
+    expect(orgData?.invite_uid).toBe("u2");
+  });
+
+  it("does not treat direct person profile data as group membership data", () => {
+    const orgData = userInfoMembershipOrgData({
+      fromChannel: { channelID: "u1", channelType: 1 } as any,
+      channelInfo: {
+        orgData: { created_at: "2026-07-19T10:00:00Z" },
+      } as any,
+    });
+
+    expect(orgData).toBeUndefined();
+  });
+});
+
+describe("userInfoMembershipCreatedAt", () => {
+  it("returns only non-empty string timestamps", () => {
+    expect(
+      userInfoMembershipCreatedAt({ created_at: "2026-07-19T10:00:00Z" })
+    ).toBe("2026-07-19T10:00:00Z");
+    expect(userInfoMembershipCreatedAt({ created_at: "" })).toBe("");
+    expect(userInfoMembershipCreatedAt({ created_at: 123 })).toBe("");
+    expect(userInfoMembershipCreatedAt()).toBe("");
+  });
+});

--- a/packages/dmworkbase/src/bridge/profileDetail/userInfoMembership.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/userInfoMembership.ts
@@ -1,0 +1,27 @@
+import {
+  ChannelTypePerson,
+  type Channel,
+  type ChannelInfo,
+  type Subscriber,
+} from "wukongimjssdk";
+
+export function userInfoMembershipOrgData(args: {
+  fromChannel?: Channel;
+  channelInfo?: ChannelInfo;
+  fromSubscriberOfUser?: Subscriber;
+}): Record<string, any> | undefined {
+  if (args.fromSubscriberOfUser?.orgData) {
+    return args.fromSubscriberOfUser.orgData as Record<string, any>;
+  }
+  if (!args.fromChannel || args.fromChannel.channelType === ChannelTypePerson) {
+    return undefined;
+  }
+  return args.channelInfo?.orgData as Record<string, any> | undefined;
+}
+
+export function userInfoMembershipCreatedAt(
+  orgData?: Record<string, any>
+): string {
+  const createdAt = orgData?.created_at;
+  return typeof createdAt === "string" && createdAt !== "" ? createdAt : "";
+}

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -90,6 +90,10 @@ import EmojiToolbar from "./Components/EmojiToolbar";
 import MergeforwardContent, { MergeforwardCell } from "./Messages/Mergeforward";
 import { wkConfirm } from "./Components/WKModal";
 import { UserInfoRouteData } from "./bridge/profileDetail/UserInfoVM";
+import {
+  userInfoMembershipCreatedAt,
+  userInfoMembershipOrgData,
+} from "./bridge/profileDetail/userInfoMembership";
 import { IconAlertCircle } from "@douyinfe/semi-icons";
 import { TypingManager } from "./Service/TypingManager";
 import APIClient from "./Service/APIClient";
@@ -1163,17 +1167,20 @@ export default class BaseModule implements IModule {
             },
           })
         );
-        if (fromSubscriberOfUser) {
-          let joinDesc = `${fromSubscriberOfUser.orgData.created_at.substr(
-            0,
-            10
-          )}`;
+        const membershipOrgData = userInfoMembershipOrgData({
+          fromChannel: data.fromChannel,
+          channelInfo,
+          fromSubscriberOfUser,
+        });
+        const membershipCreatedAt = userInfoMembershipCreatedAt(membershipOrgData);
+        if (membershipCreatedAt) {
+          let joinDesc = `${membershipCreatedAt.substr(0, 10)}`;
           if (
-            fromSubscriberOfUser.orgData?.invite_uid &&
-            fromSubscriberOfUser.orgData?.invite_uid !== ""
+            membershipOrgData?.invite_uid &&
+            membershipOrgData?.invite_uid !== ""
           ) {
             const inviterChannel = new Channel(
-              fromSubscriberOfUser.orgData?.invite_uid,
+              membershipOrgData?.invite_uid,
               ChannelTypePerson
             );
             const inviteChannelInfo =

--- a/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/BotDetailView/index.tsx
@@ -8,11 +8,15 @@ import {
   IconTickCircle,
 } from "@douyinfe/semi-icons";
 import AiBadge from "../../../Components/AiBadge";
+import WKButton from "../../../Components/WKButton";
 import VoiceInputButton, {
   type ReplaceMode,
   type SelectionRange,
 } from "../../../Components/VoiceInputButton";
-import ProfileDetailShell, { ProfileDetailHeader } from "../ProfileDetailShell";
+import ProfileDetailShell, {
+  ProfileDetailFooter,
+  ProfileDetailHeader,
+} from "../ProfileDetailShell";
 import "./index.css";
 
 export interface BotDetailViewCommand {
@@ -169,48 +173,52 @@ export function BotDetailView({
       closeLabel={labels.close}
       onClose={onClose}
       footer={
-        <div className="wk-bot-detail-actions">
-          {isFriend ? (
-            <Button
-              className="wk-bot-detail-primary-action"
-              theme="solid"
-              type="primary"
-              onClick={onChat}
-            >
-              {labels.sendMessage}
-            </Button>
-          ) : showApplyInput ? (
-            <div className="wk-bot-detail-apply">
-              <div className="wk-bot-detail-apply-label">
-                {labels.applyMessageLabel}
-              </div>
-              <Input
-                value={applyRemark}
-                onChange={onApplyRemarkChange}
-                placeholder={labels.applyMessagePlaceholder}
-              />
-              <Button
+        <ProfileDetailFooter
+          className="wk-bot-detail-footer"
+          actionClassName="wk-bot-detail-actions"
+          action={
+            isFriend ? (
+              <WKButton
                 className="wk-bot-detail-primary-action"
-                theme="solid"
-                type="primary"
-                loading={applying}
-                disabled={!applyRemark}
-                onClick={onSubmitApply}
+                type="button"
+                variant="primary"
+                onClick={onChat}
               >
-                {labels.applySend}
-              </Button>
-            </div>
-          ) : (
-            <Button
-              className="wk-bot-detail-primary-action"
-              theme="solid"
-              type="primary"
-              onClick={onShowApply}
-            >
-              {labels.addFriend}
-            </Button>
-          )}
-        </div>
+                {labels.sendMessage}
+              </WKButton>
+            ) : showApplyInput ? (
+              <div className="wk-bot-detail-apply">
+                <div className="wk-bot-detail-apply-label">
+                  {labels.applyMessageLabel}
+                </div>
+                <Input
+                  value={applyRemark}
+                  onChange={onApplyRemarkChange}
+                  placeholder={labels.applyMessagePlaceholder}
+                />
+                <WKButton
+                  className="wk-bot-detail-primary-action"
+                  type="button"
+                  variant="primary"
+                  loading={applying}
+                  disabled={!applyRemark}
+                  onClick={onSubmitApply}
+                >
+                  {labels.applySend}
+                </WKButton>
+              </div>
+            ) : (
+              <WKButton
+                className="wk-bot-detail-primary-action"
+                type="button"
+                variant="primary"
+                onClick={onShowApply}
+              >
+                {labels.addFriend}
+              </WKButton>
+            )
+          }
+        />
       }
     >
       <ProfileDetailHeader


### PR DESCRIPTION
## Summary
- Restore group/thread context when opening user profile details from community topics.
- Preserve source thread subscriber data while using parent group data as a fallback for membership context.
- Align bot detail footer actions with the shared profile detail footer and WKButton styling.
- Keep BotDetail Storybook preview aligned with the runtime footer structure.

## Verification
- git diff --check
- pnpm --dir packages/dmworkbase exec vitest run src/bridge/profileDetail/__tests__/UserInfoVM.test.ts src/bridge/profileDetail/__tests__/userInfoMembership.test.ts
- pnpm lint:css
- pnpm --dir apps/web build
- pnpm --dir apps/web build-storybook