### PR TITLE
feat(loop): standardize workspace shell and issue links

### DIFF
--- a/apps/web/src/__tests__/loopIssueDeepLink.test.ts
+++ b/apps/web/src/__tests__/loopIssueDeepLink.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildFleetIssueDeepLink,
+  consumePendingLoopIssueDeepLink,
+  normalizeCurrentLoopIssueDeepLink,
+  parseLoopIssueDeepLink,
+  readPendingLoopIssueDeepLink,
+  pushFleetIssueDeepLink,
+  replaceFleetIssueDeepLink,
+  replaceLoopRootPath,
+  savePendingLoopIssueDeepLink,
+} from "../../../../packages/dmloop/src/issueDeepLink";
+
+describe("Loop issue deep links", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("builds and parses agent-friendly fleet issue paths", () => {
+    const path = buildFleetIssueDeepLink("hmhsiyou-r7xw", "HMH-3");
+    expect(path).toBe("/fleet/hmhsiyou-r7xw/issues/HMH-3");
+    expect(parseLoopIssueDeepLink(path)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-3",
+    });
+    expect(parseLoopIssueDeepLink("/loop")).toBeNull();
+    expect(parseLoopIssueDeepLink("/loop/issue/ws-1/issue-1")).toBeNull();
+  });
+
+  it("stores and consumes a pending deep link once", () => {
+    savePendingLoopIssueDeepLink(
+      {
+        workspaceSlug: "hmhsiyou-r7xw",
+        issueIdentifier: "HMH-3",
+      },
+      sessionStorage
+    );
+
+    expect(readPendingLoopIssueDeepLink(sessionStorage)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-3",
+    });
+    expect(consumePendingLoopIssueDeepLink(sessionStorage)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-3",
+    });
+    expect(readPendingLoopIssueDeepLink(sessionStorage)).toBeNull();
+  });
+
+  it("keeps a pending target in memory when sessionStorage is unavailable", () => {
+    const unavailableStore = {
+      getItem: () => {
+        throw new Error("storage unavailable");
+      },
+      setItem: () => {
+        throw new Error("storage unavailable");
+      },
+      removeItem: () => {
+        throw new Error("storage unavailable");
+      },
+    };
+
+    expect(() =>
+      savePendingLoopIssueDeepLink(
+        {
+          workspaceSlug: "hmhsiyou-r7xw",
+          issueIdentifier: "HMH-4",
+        },
+        unavailableStore
+      )
+    ).toThrow("storage unavailable");
+
+    expect(readPendingLoopIssueDeepLink(unavailableStore)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-4",
+    });
+    expect(consumePendingLoopIssueDeepLink(unavailableStore)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-4",
+    });
+    expect(readPendingLoopIssueDeepLink(unavailableStore)).toBeNull();
+  });
+
+  it("normalizes a cold issue path to the loop route and stores the target", () => {
+    window.history.replaceState({}, "", "/fleet/hmhsiyou-r7xw/issues/HMH-3");
+
+    expect(normalizeCurrentLoopIssueDeepLink()).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-3",
+    });
+    expect(window.location.pathname).toBe("/loop");
+    expect(readPendingLoopIssueDeepLink(sessionStorage)).toMatchObject({
+      workspaceSlug: "hmhsiyou-r7xw",
+      issueIdentifier: "HMH-3",
+    });
+  });
+
+  it("writes browser URLs without adding sid query parameters", () => {
+    pushFleetIssueDeepLink("hmhsiyou-r7xw", "HMH-3");
+    expect(window.location.pathname).toBe("/fleet/hmhsiyou-r7xw/issues/HMH-3");
+    expect(window.location.search).toBe("");
+
+    replaceFleetIssueDeepLink("demo", "DMO-1");
+    expect(window.location.pathname).toBe("/fleet/demo/issues/DMO-1");
+
+    replaceLoopRootPath();
+    expect(window.location.pathname).toBe("/loop");
+  });
+
+  it("wires module capture, workspace restore, and issue click URL updates", () => {
+    const root = path.join(__dirname, "../../../../packages/dmloop/src");
+    const moduleSource = fs.readFileSync(path.join(root, "module.tsx"), "utf-8");
+    const bridgeSource = fs.readFileSync(
+      path.join(root, "bridge/useLoopWorkspace.tsx"),
+      "utf-8"
+    );
+    const issuePageSource = fs.readFileSync(
+      path.join(root, "pages/IssuePage.tsx"),
+      "utf-8"
+    );
+
+    expect(moduleSource).toContain("normalizeCurrentLoopIssueDeepLink()");
+    expect(bridgeSource).toContain("consumePendingLoopIssueDeepLink");
+    expect(bridgeSource).toContain("if (applyPendingIssueDeepLink(list)) return;");
+    expect(bridgeSource).toContain("resolveIssueByIdentifier");
+    expect(bridgeSource).toContain("const seq = spaceResolveSeqRef.current;");
+    expect(bridgeSource).toContain("if (!canWriteLoopPane(seq)) return;");
+    expect(bridgeSource).toContain('WKApp.currentMenuId !== "loop"');
+    expect(bridgeSource).toContain("replaceFleetIssueDeepLink(workspace.slug, issue.identifier)");
+    expect(bridgeSource).toContain("return false;");
+    expect(bridgeSource).toContain("replaceLoopRootPath()");
+    expect(issuePageSource).toContain("pushFleetIssueDeepLink(workspaceSlug, issue.identifier)");
+  });
+});

--- a/apps/web/src/__tests__/loopIssueDeepLink.test.ts
+++ b/apps/web/src/__tests__/loopIssueDeepLink.test.ts
@@ -124,10 +124,13 @@ describe("Loop issue deep links", () => {
 
     expect(moduleSource).toContain("normalizeCurrentLoopIssueDeepLink()");
     expect(bridgeSource).toContain("consumePendingLoopIssueDeepLink");
+    expect(bridgeSource).toContain("readPendingLoopIssueDeepLink");
     expect(bridgeSource).toContain("if (applyPendingIssueDeepLink(list)) return;");
     expect(bridgeSource).toContain("resolveIssueByIdentifier");
-    expect(bridgeSource).toContain("const seq = spaceResolveSeqRef.current;");
-    expect(bridgeSource).toContain("if (!canWriteLoopPane(seq)) return;");
+    expect(bridgeSource).toContain("const spaceSeq = spaceResolveSeqRef.current;");
+    expect(bridgeSource).toContain("const paneSeq = paneResolveSeqRef.current;");
+    expect(bridgeSource).toContain("if (!canWriteLoopPane(spaceSeq, paneSeq)) return;");
+    expect(bridgeSource).toContain("paneResolveSeqRef.current += 1;");
     expect(bridgeSource).toContain('WKApp.currentMenuId !== "loop"');
     expect(bridgeSource).toContain("replaceFleetIssueDeepLink(workspace.slug, issue.identifier)");
     expect(bridgeSource).toContain("return false;");

--- a/apps/web/src/__tests__/loopWorkspaceStaleWrite.test.tsx
+++ b/apps/web/src/__tests__/loopWorkspaceStaleWrite.test.tsx
@@ -1,0 +1,240 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Workspace } from "../../../../packages/dmloop/src/api/types";
+import {
+  readPendingLoopIssueDeepLink,
+  savePendingLoopIssueDeepLink,
+} from "../../../../packages/dmloop/src/issueDeepLink";
+import { useLoopWorkspace } from "../../../../packages/dmloop/src/bridge/useLoopWorkspace";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const hoisted = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(payload?: unknown) => void>>();
+  let workspaceId = "";
+  const routeRight = {
+    replaceToRoot: vi.fn(),
+  };
+  return {
+    listWorkspaces: vi.fn(),
+    createWorkspace: vi.fn(),
+    resolveIssueByIdentifier: vi.fn(),
+    setWorkspaceContext: vi.fn((slug: string, id: string) => {
+      workspaceId = id;
+    }),
+    currentWorkspaceId: vi.fn(() => workspaceId),
+    resetWorkspaceId: () => {
+      workspaceId = "";
+    },
+    WKApp: {
+      currentMenuId: "loop",
+      routeRight,
+      mittBus: {
+        on: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+          if (!listeners.has(event)) listeners.set(event, new Set());
+          listeners.get(event)!.add(handler);
+        }),
+        off: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+          listeners.get(event)?.delete(handler);
+        }),
+        emit: vi.fn((event: string, payload?: unknown) => {
+          listeners.get(event)?.forEach((handler) => handler(payload));
+        }),
+      },
+    },
+    reset: () => {
+      listeners.clear();
+      workspaceId = "";
+      routeRight.replaceToRoot.mockClear();
+    },
+  };
+});
+
+vi.mock("@octo/base", () => ({
+  WKApp: hoisted.WKApp,
+  getPinyin: (value: string) => value.toLowerCase(),
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    warning: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../packages/dmloop/src/api/workspaceApi", () => ({
+  listWorkspaces: hoisted.listWorkspaces,
+  createWorkspace: hoisted.createWorkspace,
+}));
+
+vi.mock("../../../../packages/dmloop/src/api/issueApi", () => ({
+  resolveIssueByIdentifier: hoisted.resolveIssueByIdentifier,
+}));
+
+vi.mock("../../../../packages/dmloop/src/api/http", () => ({
+  currentWorkspaceId: hoisted.currentWorkspaceId,
+  setWorkspaceContext: hoisted.setWorkspaceContext,
+}));
+
+vi.mock("../../../../packages/dmloop/src/api/agentApi", () => ({
+  invalidateRuntimeMap: vi.fn(),
+  invalidateAgentStatus: vi.fn(),
+}));
+
+vi.mock("../../../../packages/dmloop/src/api/directory", () => ({
+  invalidateDirectory: vi.fn(),
+}));
+
+const workspaceA: Workspace = {
+  id: "ws-a",
+  slug: "alpha",
+  name: "Alpha",
+  created_at: "",
+  updated_at: "",
+};
+
+const workspaceB: Workspace = {
+  id: "ws-b",
+  slug: "beta",
+  name: "Beta",
+  created_at: "",
+  updated_at: "",
+};
+
+function lastPaneKind() {
+  const calls = hoisted.WKApp.routeRight.replaceToRoot.mock.calls;
+  const element = calls[calls.length - 1]?.[0] as React.ReactElement | undefined;
+  return element?.props?.["data-kind"] as string | undefined;
+}
+
+describe("useLoopWorkspace stale-write guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.reset();
+    hoisted.resetWorkspaceId();
+    hoisted.WKApp.currentMenuId = "loop";
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/loop");
+  });
+
+  it("drops an in-flight issue deep link when the user switches workspace", async () => {
+    const issueResolve = deferred<{ id: string; identifier: string } | null>();
+    hoisted.listWorkspaces.mockResolvedValue([workspaceA, workspaceB]);
+    hoisted.resolveIssueByIdentifier.mockReturnValue(issueResolve.promise);
+    savePendingLoopIssueDeepLink(
+      { workspaceSlug: workspaceA.slug, issueIdentifier: "HMH-3" },
+      sessionStorage
+    );
+    const renderIssueDetail = vi.fn((issueId: string) => (
+      <div data-kind={`detail:${issueId}`} />
+    ));
+
+    const { result } = renderHook(() =>
+      useLoopWorkspace({
+        t: (key) => key,
+        renderTab: (key, workspace) => (
+          <div data-kind={`tab:${key}:${workspace?.id ?? "none"}`} />
+        ),
+        renderIssueDetail,
+        renderEmptyGuide: () => <div data-kind="empty" />,
+      })
+    );
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+
+    act(() => {
+      result.current.switchWorkspace(workspaceB);
+    });
+    expect(lastPaneKind()).toBe("tab:issue:ws-b");
+
+    await act(async () => {
+      issueResolve.resolve({ id: "issue-a", identifier: "HMH-3" });
+      await issueResolve.promise;
+    });
+
+    expect(renderIssueDetail).not.toHaveBeenCalled();
+    expect(lastPaneKind()).toBe("tab:issue:ws-b");
+    expect(window.location.pathname).toBe("/loop");
+  });
+
+  it("drops a stale reloadWorkspaces result after a space switch", async () => {
+    const reloadResolve = deferred<Workspace[]>();
+    hoisted.listWorkspaces
+      .mockResolvedValueOnce([workspaceA])
+      .mockReturnValueOnce(reloadResolve.promise)
+      .mockResolvedValueOnce([workspaceB]);
+    let reloadWorkspaces: (() => Promise<Workspace[]>) | null = null;
+
+    const { result } = renderHook(() =>
+      useLoopWorkspace({
+        t: (key) => key,
+        renderTab: (key, workspace, helpers) => {
+          reloadWorkspaces = helpers.reloadWorkspaces;
+          return <div data-kind={`tab:${key}:${workspace?.id ?? "none"}`} />;
+        },
+        renderIssueDetail: (issueId) => <div data-kind={`detail:${issueId}`} />,
+        renderEmptyGuide: () => <div data-kind="empty" />,
+      })
+    );
+
+    await waitFor(() => expect(result.current.currentWorkspace?.id).toBe("ws-a"));
+    expect(reloadWorkspaces).not.toBeNull();
+
+    let reloadPromise!: Promise<Workspace[]>;
+    act(() => {
+      reloadPromise = reloadWorkspaces!();
+    });
+    act(() => {
+      hoisted.WKApp.mittBus.emit("space-changed");
+    });
+
+    await waitFor(() => expect(result.current.currentWorkspace?.id).toBe("ws-b"));
+
+    await act(async () => {
+      reloadResolve.resolve([workspaceA]);
+      await reloadPromise;
+    });
+
+    await waitFor(() =>
+      expect(result.current.workspaces.map((workspace) => workspace.id)).toEqual(["ws-b"])
+    );
+  });
+
+  it("keeps a pending issue deep link when the workspace is not in the current space", async () => {
+    hoisted.listWorkspaces.mockResolvedValue([workspaceB]);
+    savePendingLoopIssueDeepLink(
+      { workspaceSlug: workspaceA.slug, issueIdentifier: "HMH-3" },
+      sessionStorage
+    );
+
+    renderHook(() =>
+      useLoopWorkspace({
+        t: (key) => key,
+        renderTab: (key, workspace) => (
+          <div data-kind={`tab:${key}:${workspace?.id ?? "none"}`} />
+        ),
+        renderIssueDetail: (issueId) => <div data-kind={`detail:${issueId}`} />,
+        renderEmptyGuide: () => <div data-kind="empty" />,
+      })
+    );
+
+    await waitFor(() =>
+      expect(readPendingLoopIssueDeepLink(sessionStorage)).toMatchObject({
+        workspaceSlug: workspaceA.slug,
+        issueIdentifier: "HMH-3",
+      })
+    );
+    expect(hoisted.resolveIssueByIdentifier).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
+++ b/apps/web/src/__tests__/personalPageSpaceChanged.test.ts
@@ -46,7 +46,7 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
 
   beforeAll(() => {
     personalPage = fs.readFileSync(
-      path.join(__dirname, '../../../../packages/dmpersonal/src/PersonalPage.tsx'),
+      path.join(__dirname, '../../../../packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx'),
       'utf-8',
     );
   });
@@ -133,6 +133,17 @@ describe('PersonalPage — re-resolve workspace on space switch', () => {
     const checks = (body.match(/WKApp\.currentMenuId\s*!==\s*["']dmpersonal["']/g) || []).length;
     expect(checks).toBeGreaterThanOrEqual(2); // .then and .catch
   });
+
+  it('keeps PersonalPage as a thin container over bridge and UI', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmpersonal/src/PersonalPage.tsx'),
+      'utf-8',
+    );
+    expect(source).toContain('usePersonalWorkspace');
+    expect(source).toContain('PersonalSidebarView');
+    expect(source).not.toContain('workspaceApi.listWorkspaces');
+    expect(source).not.toContain('WKApp.routeRight.replaceToRoot');
+  });
 });
 
 /**
@@ -148,7 +159,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
 
   beforeAll(() => {
     loopPage = fs.readFileSync(
-      path.join(__dirname, '../../../../packages/dmloop/src/pages/LoopPage.tsx'),
+      path.join(__dirname, '../../../../packages/dmloop/src/bridge/useLoopWorkspace.tsx'),
       'utf-8',
     );
   });
@@ -199,7 +210,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // applyWorkspace runs from a mount-once (deps []) handler; it must read the
     // live tab via a ref, else switching space while on a non-issue tab paints
     // the wrong pane. Assert applyWorkspace renders via tabRef, not closure tab.
-    expect(loopPage).toMatch(/renderTab\(\s*tabRef\.current/);
+    expect(loopPage).toMatch(/renderTabView\(\s*tabRef\.current/);
   });
 
   it('guards the mount initial resolve with the same seq (cross-entry race)', () => {
@@ -239,14 +250,14 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     expect(body.search(/routeRight\.replaceToRoot/)).toBeLessThan(body.search(/listWorkspaces\(/));
   });
 
-  it('guards doCreateWs against a space switch mid-create without wedging loaded', () => {
-    // doCreateWs writes workspace context after awaits, so it must drop that
+  it('guards submitCreateWorkspace against a space switch mid-create without wedging loaded', () => {
+    // submitCreateWorkspace writes workspace context after awaits, so it must drop that
     // write when a space switch happened during creation. It CAPTURES the
     // generation (does not bump it): bumping would invalidate onSpaceChanged's
     // own resolve, whose .then/.catch are the only paths that restore loaded —
     // leaving the page stuck !loaded. So: a stale-seq guard must exist, but no
-    // ++ bump inside doCreateWs.
-    const start = loopPage.search(/const\s+doCreateWs\s*=/);
+    // ++ bump inside submitCreateWorkspace.
+    const start = loopPage.search(/const\s+submitCreateWorkspace\s*=/);
     expect(start).toBeGreaterThanOrEqual(0);
     const end = loopPage.slice(start).search(/\n  const\s+\w+\s*=/);
     const body = end < 0 ? loopPage.slice(start) : loopPage.slice(start, start + end);
@@ -262,7 +273,7 @@ describe('LoopPage — re-resolve workspace on space switch', () => {
     // Create entry must be blocked during the re-resolve window, and any open
     // create modal must close on space-changed, so no create can land while the
     // page is re-resolving a new space.
-    const openBody = loopPage.slice(loopPage.search(/const\s+openCreateWs\s*=/), loopPage.search(/const\s+openCreateWs\s*=/) + 160);
+    const openBody = loopPage.slice(loopPage.search(/const\s+openCreateWorkspace\s*=/), loopPage.search(/const\s+openCreateWorkspace\s*=/) + 160);
     expect(openBody).toMatch(/if\s*\(\s*!loaded\s*\)\s*return/);
     const onSpaceBody = reResolveSpaceBody(loopPage);
     expect(onSpaceBody).toMatch(/setWsModalOpen\(\s*false\s*\)/);

--- a/packages/dmloop/README.md
+++ b/packages/dmloop/README.md
@@ -1,0 +1,82 @@
+# @octo/loop Module Notes
+
+This package owns the Loop workspace experience: issues, projects, automations,
+agents, squads, workspace settings, CLI authorization, and shared Loop runtime
+helpers.
+
+## Current Entry Points
+
+- `src/module.tsx` registers the `/loop` route and the Loop navigation entry.
+- The navigation entry is controlled by `WKApp.remoteConfig.dmloopOn`.
+- The route remains registered even when the navigation entry is hidden.
+- `src/pages/LoopPage.tsx` is the left-pane container for the Loop workspace
+  shell. It should stay thin.
+
+## Directory Boundaries
+
+- `src/api/` is the current Loop Service boundary. It owns HTTP calls, endpoint
+  construction, workspace context helpers, cache invalidation helpers, and API
+  model types.
+- `src/bridge/` owns runtime state that connects the host app to Loop UI:
+  workspace resolution, Space switching, shared right-pane writes, create-modal
+  state, and tab actions.
+- `src/ui/` owns presentational UI and UI-only helpers. UI files must not call
+  Loop APIs, write `WKApp.routeRight`, or resolve workspace context.
+- `src/pages/` owns route/page containers. A page may compose bridge state and
+  UI, but should not grow new API calls or large interaction state directly.
+- `src/panel/` contains existing feature panels and detail views. These can be
+  migrated gradually; do not move all legacy code in one PR.
+- `src/i18n/` owns user-visible Loop copy.
+
+## Current Standardization Status
+
+`LoopPage` has been split into:
+
+- `src/pages/LoopPage.tsx`: thin page container and tab renderer.
+- `src/bridge/useLoopWorkspace.tsx`: workspace selection, Space re-resolution,
+  shared `routeRight` updates, workspace creation, and create-issue shell state.
+- `src/bridge/types.ts`: tab and bridge helper types.
+- `src/ui/LoopSidebarView.tsx`: pure sidebar rendering.
+- `src/ui/LoopCreateWorkspaceModal.tsx`: pure create-workspace modal rendering.
+- `src/ui/LoopWorkspaceEmptyState.tsx`: pure empty-state rendering.
+
+The key behavior to preserve is the Space-switch guard:
+
+- Clear the old workspace context before re-listing workspaces.
+- Ignore stale async responses with the resolve sequence guard.
+- Do not write the shared right pane when Loop is backgrounded.
+- Gate sidebar actions while `loaded` is false.
+- Close create modals during Space re-resolution.
+
+## Rules For Future Changes
+
+- New Loop API calls should go in `src/api/` first. Pages and UI should not build
+  raw API paths.
+- New reusable views should go in `src/ui/` and include Story coverage.
+- New runtime state or host-app coordination should go in `src/bridge/`.
+- Keep one visible entry per user capability. Do not add duplicate menu or route
+  entries while refactoring.
+- Preserve the route/right-pane behavior on refresh, direct route load,
+  navigation reactivation, and Space switching.
+
+## Known Remaining Work
+
+- Several feature pages under `src/pages/` still mix data loading, local state,
+  and rendering. Migrate them gradually, one feature path per PR.
+- `src/api/` already acts as the Service boundary, but it has not been renamed
+  to `Service/`. Treat renaming as a separate architecture decision.
+- `src/panel/` still contains legacy feature panels. Prefer focused migrations
+  over broad directory reshuffles.
+- Private/module extraction is not part of the current standardization work.
+  Keep new changes structurally clean so extraction remains possible later.
+
+## Verification
+
+For Loop shell changes, run:
+
+```bash
+pnpm --dir apps/web exec vitest run src/__tests__/personalPageSpaceChanged.test.ts
+pnpm exec vitest run packages/dmloop/src/api/__tests__/workspaceSelection.test.ts packages/dmloop/src/api/__tests__/issueFilterQuery.test.ts packages/dmloop/src/api/__tests__/issueGrouping.test.ts packages/dmloop/src/pages/__tests__/runtimeVersion.test.ts packages/dmloop/src/pages/__tests__/headlessCommand.test.ts packages/dmloop/src/ui/__tests__/slug.test.ts packages/dmloop/src/ui/__tests__/attachmentSrc.test.ts packages/dmloop/src/ui/__tests__/downloadAttachment.test.ts packages/dmloop/src/ui/__tests__/objectUrl.test.ts packages/dmloop/src/ui/__tests__/threadReplies.test.ts packages/dmloop/src/ui/__tests__/cliCallback.test.ts packages/dmloop/src/ui/__tests__/attachmentPreview.test.ts
+pnpm --dir apps/web build
+pnpm --dir apps/web build-storybook
+```

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -75,6 +75,22 @@ export async function getIssue(id: string): Promise<Issue> {
   return enrichIssue(issue);
 }
 
+export async function resolveIssueByIdentifier(identifier: string): Promise<Issue | null> {
+  const key = identifier.trim();
+  if (!key) return null;
+
+  const direct = await getIssue(key).catch(() => null);
+  if (direct?.identifier?.toLowerCase() === key.toLowerCase()) return direct;
+
+  const searched = await searchIssues(key, { limit: 50, includeClosed: true }).catch(
+    () => ({ issues: [] as Issue[], total: 0 })
+  );
+  return (
+    searched.issues.find((issue) => issue.identifier.toLowerCase() === key.toLowerCase()) ??
+    null
+  );
+}
+
 // 子 issue 列表(GET /issues/:id/children):后端包裹 { issues }。子项含 status,
 // 进度(done/total)由页面本地算,不再调批量 /child-progress(那是列表/看板用的)。
 export async function listChildren(id: string): Promise<Issue[]> {

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -71,7 +71,7 @@ export async function enrichIssue(issue: Issue): Promise<Issue> {
 }
 
 export async function getIssue(id: string): Promise<Issue> {
-  const issue = await httpGet<Issue>(`/issues/${id}`);
+  const issue = await httpGet<Issue>(`/issues/${encodeURIComponent(id)}`);
   return enrichIssue(issue);
 }
 

--- a/packages/dmloop/src/bridge/types.ts
+++ b/packages/dmloop/src/bridge/types.ts
@@ -1,0 +1,26 @@
+import type React from "react";
+import type { Workspace } from "../api/types";
+
+export type LoopTabKey =
+  | "myloop"
+  | "issue"
+  | "project"
+  | "automation"
+  | "agent"
+  | "squad"
+  | "settings";
+
+export interface LoopTabItem {
+  key: LoopTabKey;
+  icon: React.ReactNode;
+  label: string;
+}
+
+export interface LoopWorkspaceRenderHelpers {
+  reloadWorkspaces: () => Promise<Workspace[]>;
+}
+
+export interface LoopIssueDetailRenderHelpers extends LoopWorkspaceRenderHelpers {
+  onIssueChanged: () => void;
+  onClose: () => boolean | void;
+}

--- a/packages/dmloop/src/bridge/useLoopWorkspace.tsx
+++ b/packages/dmloop/src/bridge/useLoopWorkspace.tsx
@@ -9,6 +9,7 @@ import { resolveIssueByIdentifier } from "../api/issueApi";
 import { createWorkspace, listWorkspaces } from "../api/workspaceApi";
 import {
   consumePendingLoopIssueDeepLink,
+  readPendingLoopIssueDeepLink,
   replaceFleetIssueDeepLink,
   replaceLoopRootPath,
 } from "../issueDeepLink";
@@ -97,15 +98,20 @@ export function useLoopWorkspace({
   // nav-menu-activated handler consumes it to force a fresh re-resolve instead
   // of painting the stale old-space workspaces/wsId it still holds in state.
   const pendingSpaceReresolveRef = useRef(false);
+  const paneResolveSeqRef = useRef(0);
   const renderTabRef = useRef(renderTab);
   const renderIssueDetailRef = useRef(renderIssueDetail);
   const renderEmptyGuideRef = useRef(renderEmptyGuide);
+  const workspacesRef = useRef<Workspace[]>([]);
   renderTabRef.current = renderTab;
   renderIssueDetailRef.current = renderIssueDetail;
   renderEmptyGuideRef.current = renderEmptyGuide;
+  workspacesRef.current = workspaces;
 
   const reloadWorkspaces = async (): Promise<Workspace[]> => {
+    const seq = spaceResolveSeqRef.current;
     const list = await listWorkspaces().catch(() => [] as Workspace[]);
+    if (seq !== spaceResolveSeqRef.current) return workspacesRef.current;
     setWorkspaces(list);
     return list;
   };
@@ -117,8 +123,9 @@ export function useLoopWorkspace({
     setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
   };
 
-  const canWriteLoopPane = (seq: number) => {
-    if (seq !== spaceResolveSeqRef.current) return false;
+  const canWriteLoopPane = (spaceSeq: number, paneSeq: number) => {
+    if (paneSeq !== paneResolveSeqRef.current) return false;
+    if (spaceSeq !== spaceResolveSeqRef.current) return false;
     if (WKApp.currentMenuId !== "loop") {
       pendingSpaceReresolveRef.current = true;
       return false;
@@ -131,7 +138,8 @@ export function useLoopWorkspace({
     issueIdentifier: string,
     list: Workspace[]
   ) => {
-    const seq = spaceResolveSeqRef.current;
+    const spaceSeq = spaceResolveSeqRef.current;
+    const paneSeq = paneResolveSeqRef.current;
     setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
     setWsId(workspace.id);
     setTab("issue");
@@ -141,7 +149,7 @@ export function useLoopWorkspace({
     WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
 
     const issue = await resolveIssueByIdentifier(issueIdentifier);
-    if (!canWriteLoopPane(seq)) return;
+    if (!canWriteLoopPane(spaceSeq, paneSeq)) return;
     if (!issue) {
       WKApp.routeRight.replaceToRoot(renderTabView("issue", workspace));
       replaceLoopRootPath();
@@ -165,13 +173,18 @@ export function useLoopWorkspace({
   const applyPendingIssueDeepLink = (list: Workspace[]): boolean => {
     let pending = null;
     try {
-      pending = consumePendingLoopIssueDeepLink(window.sessionStorage);
+      pending = readPendingLoopIssueDeepLink(window.sessionStorage);
     } catch {
       pending = null;
     }
     if (!pending) return false;
     const workspace = list.find((w) => w.slug === pending.workspaceSlug) ?? null;
     if (!workspace) return false;
+    try {
+      consumePendingLoopIssueDeepLink(window.sessionStorage);
+    } catch {
+      // Storage can be unavailable; the in-memory fallback is cleared by consume when possible.
+    }
     void openIssueDeepLink(workspace, pending.issueIdentifier, list);
     return true;
   };
@@ -198,6 +211,8 @@ export function useLoopWorkspace({
     // 重解析窗口期(切 space 后 loaded=false 直到新 space 的 workspace 解析完成)不响应:
     // 此时 workspaces/wsId 尚属旧 space,点击会用旧作用域渲染 workspace 级页面。
     if (!loaded) return;
+    // User navigation wins over any pending deep-link resolve.
+    paneResolveSeqRef.current += 1;
     replaceLoopRootPath();
     setTab(key);
     WKApp.routeRight.replaceToRoot(renderTabView(key, findWorkspace(workspaces, wsId)));
@@ -356,6 +371,8 @@ export function useLoopWorkspace({
   const switchWorkspace = (workspace: Workspace) => {
     // 重解析窗口期不响应:下拉里的 w 属于旧 space 的 workspaces,选它会把旧 slug 写回。
     if (!loaded) return;
+    // User navigation wins over any pending deep-link resolve.
+    paneResolveSeqRef.current += 1;
     replaceLoopRootPath();
     setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
     setWsId(workspace.id);

--- a/packages/dmloop/src/bridge/useLoopWorkspace.tsx
+++ b/packages/dmloop/src/bridge/useLoopWorkspace.tsx
@@ -1,0 +1,488 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Toast } from "@douyinfe/semi-ui";
+import { getPinyin, WKApp } from "@octo/base";
+import type { Workspace } from "../api/types";
+import { invalidateRuntimeMap, invalidateAgentStatus } from "../api/agentApi";
+import { invalidateDirectory } from "../api/directory";
+import { currentWorkspaceId, setWorkspaceContext } from "../api/http";
+import { resolveIssueByIdentifier } from "../api/issueApi";
+import { createWorkspace, listWorkspaces } from "../api/workspaceApi";
+import {
+  consumePendingLoopIssueDeepLink,
+  replaceFleetIssueDeepLink,
+  replaceLoopRootPath,
+} from "../issueDeepLink";
+import { slugSuffix, withRandomSuffix } from "../ui/slug";
+import type {
+  LoopIssueDetailRenderHelpers,
+  LoopTabKey,
+  LoopWorkspaceRenderHelpers,
+} from "./types";
+
+export interface UseLoopWorkspaceOptions {
+  t: (key: string) => string;
+  renderTab: (
+    key: LoopTabKey,
+    workspace: Workspace | null,
+    helpers: LoopWorkspaceRenderHelpers
+  ) => JSX.Element;
+  renderIssueDetail: (
+    issueId: string,
+    helpers: LoopIssueDetailRenderHelpers
+  ) => JSX.Element;
+  renderEmptyGuide: () => JSX.Element;
+}
+
+export interface UseLoopWorkspaceResult {
+  tab: LoopTabKey;
+  workspaces: Workspace[];
+  currentWorkspace: Workspace | null;
+  hasWorkspace: boolean;
+  loaded: boolean;
+  wsModalOpen: boolean;
+  wsName: string;
+  wsSlug: string;
+  wsBusy: boolean;
+  createOpen: boolean;
+  openTab: (key: LoopTabKey) => void;
+  openNewLoop: () => void;
+  switchWorkspace: (workspace: Workspace) => void;
+  openCreateWorkspace: () => void;
+  closeCreateWorkspace: () => void;
+  submitCreateWorkspace: () => Promise<void>;
+  changeWorkspaceName: (name: string) => void;
+  changeWorkspaceSlug: (slug: string) => void;
+  closeCreateIssue: () => void;
+  handleIssueCreated: () => void;
+}
+
+// 切换工作区时统一重置所有工作区级缓存(目录/运行时/agent 状态),避免残留上个工作区数据。
+function resetWorkspaceCaches() {
+  invalidateDirectory();
+  invalidateRuntimeMap();
+  invalidateAgentStatus();
+}
+
+function findWorkspace(list: Workspace[], id: string) {
+  return list.find((w) => w.id === id) ?? null;
+}
+
+export function useLoopWorkspace({
+  t,
+  renderTab,
+  renderIssueDetail,
+  renderEmptyGuide,
+}: UseLoopWorkspaceOptions): UseLoopWorkspaceResult {
+  const [tab, setTab] = useState<LoopTabKey>("issue");
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [wsId, setWsId] = useState<string>(currentWorkspaceId());
+  const [loaded, setLoaded] = useState(false);
+  const [wsModalOpen, setWsModalOpen] = useState(false);
+  const [wsName, setWsName] = useState("");
+  const [wsSlug, setWsSlug] = useState("");
+  const [wsSlugTouched, setWsSlugTouched] = useState(false);
+  const [wsSlugSuffix, setWsSlugSuffix] = useState("");
+  const [wsBusy, setWsBusy] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // tab 的同步镜像:mount-once 的 space-changed 副作用闭包(deps=[])会冻结当时的 tab,
+  // 用 ref 让 applyWorkspace 始终读到最新 tab,避免切 space 后右栏恒被铺成初始 issue。
+  const tabRef = useRef<LoopTabKey>("issue");
+  tabRef.current = tab;
+  // space-changed 重解析的过期守卫:快速连切 space 时并发的 listWorkspaces 可能乱序返回,
+  // 只有最后一次解析允许写回 workspace context,否则慢的旧响应会把旧 slug 落回、撞新 space 的 403。
+  const spaceResolveSeqRef = useRef(0);
+  // Set when a space change arrives while LoopPage is backgrounded (its
+  // space-changed handler is gated to the active menu). On reactivation the
+  // nav-menu-activated handler consumes it to force a fresh re-resolve instead
+  // of painting the stale old-space workspaces/wsId it still holds in state.
+  const pendingSpaceReresolveRef = useRef(false);
+  const renderTabRef = useRef(renderTab);
+  const renderIssueDetailRef = useRef(renderIssueDetail);
+  const renderEmptyGuideRef = useRef(renderEmptyGuide);
+  renderTabRef.current = renderTab;
+  renderIssueDetailRef.current = renderIssueDetail;
+  renderEmptyGuideRef.current = renderEmptyGuide;
+
+  const reloadWorkspaces = async (): Promise<Workspace[]> => {
+    const list = await listWorkspaces().catch(() => [] as Workspace[]);
+    setWorkspaces(list);
+    return list;
+  };
+
+  const renderTabView = (key: LoopTabKey, workspace: Workspace | null) =>
+    renderTabRef.current(key, workspace, { reloadWorkspaces });
+
+  const notifyIssueChanged = () => {
+    setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
+  };
+
+  const canWriteLoopPane = (seq: number) => {
+    if (seq !== spaceResolveSeqRef.current) return false;
+    if (WKApp.currentMenuId !== "loop") {
+      pendingSpaceReresolveRef.current = true;
+      return false;
+    }
+    return true;
+  };
+
+  const openIssueDeepLink = async (
+    workspace: Workspace,
+    issueIdentifier: string,
+    list: Workspace[]
+  ) => {
+    const seq = spaceResolveSeqRef.current;
+    setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
+    setWsId(workspace.id);
+    setTab("issue");
+    tabRef.current = "issue";
+    resetWorkspaceCaches();
+    setWorkspaces(list);
+    WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
+
+    const issue = await resolveIssueByIdentifier(issueIdentifier);
+    if (!canWriteLoopPane(seq)) return;
+    if (!issue) {
+      WKApp.routeRight.replaceToRoot(renderTabView("issue", workspace));
+      replaceLoopRootPath();
+      return;
+    }
+
+    WKApp.routeRight.replaceToRoot(
+      renderIssueDetailRef.current(issue.id, {
+        reloadWorkspaces,
+        onIssueChanged: notifyIssueChanged,
+        onClose: () => {
+          replaceLoopRootPath();
+          WKApp.routeRight.replaceToRoot(renderTabView("issue", workspace));
+          return false;
+        },
+      })
+    );
+    replaceFleetIssueDeepLink(workspace.slug, issue.identifier);
+  };
+
+  const applyPendingIssueDeepLink = (list: Workspace[]): boolean => {
+    let pending = null;
+    try {
+      pending = consumePendingLoopIssueDeepLink(window.sessionStorage);
+    } catch {
+      pending = null;
+    }
+    if (!pending) return false;
+    const workspace = list.find((w) => w.slug === pending.workspaceSlug) ?? null;
+    if (!workspace) return false;
+    void openIssueDeepLink(workspace, pending.issueIdentifier, list);
+    return true;
+  };
+
+  const showEmptyGuide = () => {
+    WKApp.routeRight.replaceToRoot(renderEmptyGuideRef.current());
+  };
+
+  const applyWorkspace = (workspace: Workspace | null, list: Workspace[]) => {
+    if (workspace) {
+      setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
+      setWsId(workspace.id);
+      resetWorkspaceCaches();
+      WKApp.routeRight.replaceToRoot(renderTabView(tabRef.current, workspace));
+    } else {
+      setWorkspaceContext("", "");
+      setWsId("");
+      showEmptyGuide();
+    }
+    setWorkspaces(list);
+  };
+
+  const openTab = (key: LoopTabKey) => {
+    // 重解析窗口期(切 space 后 loaded=false 直到新 space 的 workspace 解析完成)不响应:
+    // 此时 workspaces/wsId 尚属旧 space,点击会用旧作用域渲染 workspace 级页面。
+    if (!loaded) return;
+    replaceLoopRootPath();
+    setTab(key);
+    WKApp.routeRight.replaceToRoot(renderTabView(key, findWorkspace(workspaces, wsId)));
+  };
+
+  // 新建回路 → 唤起统一建单弹窗（对齐 multica，不再拉起独立 AI 页）。成功后落回路看板并刷新。
+  const openNewLoop = () => {
+    if (!loaded) return;
+    setCreateOpen(true);
+  };
+
+  // Re-resolve the workspace scope for the current octo space: clear the old
+  // scope, unmount the stale right pane, re-list, and repaint. Shared by the
+  // space-changed handler (when LoopPage is active) and by reactivation
+  // (nav-menu-activated) when a space change happened while it was backgrounded.
+  const reResolveSpace = () => {
+    const seq = ++spaceResolveSeqRef.current;
+    setWorkspaceContext("", "");
+    setWsId("");
+    // Close any open create modals so a submit cannot land during the
+    // re-resolve window and write a workspace under the wrong space.
+    setWsModalOpen(false);
+    setCreateOpen(false);
+    // setLoaded(false): mark not-ready for the re-resolve window so the
+    // wk:nav-menu-activated `if (!loaded) return` guard holds and no entry uses
+    // the old space's workspaces closure.
+    setLoaded(false);
+    resetWorkspaceCaches();
+    // Unmount the stale right pane immediately so the previous space's IssuePage
+    // (and its polling / create entry) stops firing during the re-resolve window.
+    WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
+    listWorkspaces()
+      .then((list) => {
+        // Out-of-order guard: only the latest resolve applies, dropping a stale
+        // response that would write the old slug back and hit the new space's 403.
+        if (seq !== spaceResolveSeqRef.current) return;
+        // If the user navigated away while this resolve was in flight, do NOT
+        // write the shared pane/context (would clobber the now-active page).
+        // Defer to reactivation instead.
+        if (WKApp.currentMenuId !== "loop") {
+          pendingSpaceReresolveRef.current = true;
+          return;
+        }
+        setLoaded(true);
+        if (applyPendingIssueDeepLink(list)) return;
+        const first = findWorkspace(list, currentWorkspaceId()) ?? list[0] ?? null;
+        applyWorkspace(first, list);
+      })
+      .catch(() => {
+        if (seq !== spaceResolveSeqRef.current) return;
+        if (WKApp.currentMenuId !== "loop") {
+          pendingSpaceReresolveRef.current = true;
+          return;
+        }
+        setLoaded(true);
+        // Clear the stale old-space list on a failed re-resolve — otherwise the
+        // switcher dropdown keeps the previous space's workspaces, re-enabled by
+        // setLoaded(true) and clickable, so switchWorkspace would bind an
+        // old-space slug under the new space's X-Space-Id → cross-space 403.
+        setWorkspaces([]);
+        showEmptyGuide();
+      });
+  };
+
+  useEffect(() => {
+    // mount 初始解析也纳入 spaceResolveSeqRef 域:若初始 listWorkspaces 尚未返回、
+    // 用户就切了 space,space-changed 会递增 seq 使这次 mount 响应过期被丢弃,避免旧 space
+    // 的 workspace slug 被写回 http 层、撞新 space 的隔离 403(与 space-changed 共享守卫)。
+    const seq = ++spaceResolveSeqRef.current;
+    listWorkspaces()
+      .then((list) => {
+        if (seq !== spaceResolveSeqRef.current) return;
+        // If the page was backgrounded before this mount resolve landed, don't
+        // write the shared pane/context; defer to reactivation.
+        if (WKApp.currentMenuId !== "loop") {
+          pendingSpaceReresolveRef.current = true;
+          return;
+        }
+        setLoaded(true);
+        if (applyPendingIssueDeepLink(list)) return;
+        const first = findWorkspace(list, currentWorkspaceId()) ?? list[0] ?? null;
+        applyWorkspace(first, list);
+      })
+      .catch(() => {
+        if (seq !== spaceResolveSeqRef.current) return;
+        if (WKApp.currentMenuId !== "loop") {
+          pendingSpaceReresolveRef.current = true;
+          return;
+        }
+        setLoaded(true);
+        // Clear the switcher list on a failed resolve: showEmptyGuide only
+        // repaints the right pane, so without this the dropdown would keep the
+        // previous list, re-enabled by setLoaded(true) and clickable.
+        setWorkspaces([]);
+        showEmptyGuide();
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 顶部一级导航「Loop」被再次点击时，onMenuClick 会先 routeRight.popToRoot() 清空右栏
+  // （LoopPage 常驻不重挂，useEffect 不会重跑）。这里监听激活事件，把体验对齐「首次进入」
+  // ——重置到默认的 Issue（回路）视图，避免右栏残留空白/报错。
+  useEffect(() => {
+    const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
+      if (menuId !== "loop") return;
+      // A space change arrived while this page was backgrounded: its handler was
+      // deferred, so state still holds the old space. Force a fresh re-resolve
+      // instead of painting stale workspaces/wsId.
+      if (pendingSpaceReresolveRef.current) {
+        pendingSpaceReresolveRef.current = false;
+        reResolveSpace();
+        return;
+      }
+      // workspace 列表尚未加载完时不处理：挂载副作用会在加载完成后自行铺默认视图，
+      // 避免 workspaces 还是 [] 时误闪空态引导。
+      if (!loaded) return;
+      const workspace = findWorkspace(workspaces, wsId);
+      if (!workspace) {
+        showEmptyGuide();
+        return;
+      }
+      replaceLoopRootPath();
+      setTab("issue");
+      WKApp.routeRight.replaceToRoot(renderTabView("issue", workspace));
+      // 已停在 issue tab 时 key(issue:wsId) 不变不会重挂 → 补发刷新事件，让当前 IssuePage 重新拉数(data→view)。
+      setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
+    };
+    WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
+    return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaces, wsId, loaded]);
+
+  // 切换 octo space 时,当前 wsId + @octo/loop 模块级 workspace 全局属于上一个 space,
+  // 必须作废重判 —— 否则会带旧 workspace 作用域向新 space 发 workspace 维度请求,撞后端
+  // space 隔离闸门(workspace does not belong to this space / not a member of this space)。
+  // 先 setWorkspaceContext("","") 清 http 层旧 slug,避免重列期间任何请求带旧作用域;再重新
+  // listWorkspaces 并铺新 space 的默认 workspace,新 space 无 workspace 时 applyWorkspace(null)
+  // 自然落入空态引导(showEmptyGuide)。
+  useEffect(() => {
+    const onSpaceChanged = () => {
+      // Only the active page may touch the single shared right pane / http-layer
+      // workspace context. When LoopPage is backgrounded (kept mounted), defer:
+      // flag a pending re-resolve that reactivation (below) consumes, so we never
+      // fight the active page for the pane nor paint stale old-space data.
+      if (WKApp.currentMenuId !== "loop") {
+        pendingSpaceReresolveRef.current = true;
+        return;
+      }
+      reResolveSpace();
+    };
+    WKApp.mittBus.on("space-changed", onSpaceChanged);
+    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const switchWorkspace = (workspace: Workspace) => {
+    // 重解析窗口期不响应:下拉里的 w 属于旧 space 的 workspaces,选它会把旧 slug 写回。
+    if (!loaded) return;
+    replaceLoopRootPath();
+    setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
+    setWsId(workspace.id);
+    resetWorkspaceCaches();
+    WKApp.routeRight.replaceToRoot(renderTabView(tabRef.current, workspace));
+  };
+
+  const openCreateWorkspace = () => {
+    if (!loaded) return;
+    setWsName("");
+    setWsSlug("");
+    setWsSlugTouched(false);
+    setWsSlugSuffix(slugSuffix());
+    setWsModalOpen(true);
+  };
+
+  const closeCreateWorkspace = () => setWsModalOpen(false);
+
+  const changeWorkspaceName = (name: string) => {
+    setWsName(name);
+    if (!wsSlugTouched) {
+      setWsSlug(name.trim() ? withRandomSuffix(getPinyin(name), wsSlugSuffix) : "");
+    }
+  };
+
+  const changeWorkspaceSlug = (slug: string) => {
+    setWsSlug(slug);
+    setWsSlugTouched(true);
+  };
+
+  const submitCreateWorkspace = async () => {
+    const name = wsName.trim();
+    if (!name) {
+      Toast.warning(t("loop.workspace.nameRequired"));
+      return;
+    }
+    const autoSlug = !wsSlugTouched;
+    let slug = wsSlug.trim() || withRandomSuffix(getPinyin(name), wsSlugSuffix);
+    if (!slug) {
+      Toast.warning(t("loop.workspace.slugRequired"));
+      return;
+    }
+    // Capture (do NOT bump) the resolve generation: creating a workspace writes
+    // workspace context after awaits, so if the user switches octo space
+    // mid-create, space-changed bumps the seq and the post-await applyWorkspace
+    // below is dropped (would otherwise bind this space's slug under the new
+    // space's X-Space-Id → isolation 403). Capturing rather than bumping is
+    // deliberate: onSpaceChanged owns `loaded` restoration through its own
+    // generation, and a create must not invalidate that resolve (else `loaded`
+    // could stay false forever, wedging the page).
+    const seq = spaceResolveSeqRef.current;
+    setWsBusy(true);
+    try {
+      // auto slug re-rolls its random suffix on the backend's 409 (slug is
+      // globally unique) so the happy path needs no manual input; a user-typed
+      // slug is surfaced as taken, never silently changed.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          // Re-check before each create so a space switch during a 409 retry
+          // doesn't create a stray workspace in the newly-selected space.
+          if (seq !== spaceResolveSeqRef.current) return;
+          const created = await createWorkspace({ name, slug });
+          setWsModalOpen(false);
+          const list = await reloadWorkspaces();
+          // A space switch during creation invalidates this write; the
+          // space-changed resolve owns the pane now.
+          if (seq !== spaceResolveSeqRef.current) return;
+          // Navigated away mid-create (no space-changed, so seq is unchanged):
+          // don't write the shared pane/context in the background; defer.
+          if (WKApp.currentMenuId !== "loop") {
+            pendingSpaceReresolveRef.current = true;
+            return;
+          }
+          const createdWorkspace = findWorkspace(list, created.id) ?? created;
+          applyWorkspace(createdWorkspace, list);
+          setTab("issue");
+          WKApp.routeRight.replaceToRoot(renderTabView("issue", createdWorkspace));
+          Toast.success(t("loop.workspace.created"));
+          return;
+        } catch (e) {
+          if ((e as { status?: number })?.status !== 409) throw e;
+          if (!autoSlug || attempt === 2) {
+            Toast.error(t("loop.workspace.slugTaken"));
+            return;
+          }
+          slug = withRandomSuffix(getPinyin(name), slugSuffix());
+        }
+      }
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? "create failed");
+    } finally {
+      setWsBusy(false);
+    }
+  };
+
+  const closeCreateIssue = () => setCreateOpen(false);
+
+  const handleIssueCreated = () => {
+    setCreateOpen(false);
+    openTab("issue");
+    // 若已在 issue tab（同 key 不重挂），补发刷新使新回路即时出现。
+    setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
+    Toast.success(t("loop.toast.created"));
+  };
+
+  const currentWorkspace = findWorkspace(workspaces, wsId);
+
+  return {
+    tab,
+    workspaces,
+    currentWorkspace,
+    hasWorkspace: workspaces.length > 0,
+    loaded,
+    wsModalOpen,
+    wsName,
+    wsSlug,
+    wsBusy,
+    createOpen,
+    openTab,
+    openNewLoop,
+    switchWorkspace,
+    openCreateWorkspace,
+    closeCreateWorkspace,
+    submitCreateWorkspace,
+    changeWorkspaceName,
+    changeWorkspaceSlug,
+    closeCreateIssue,
+    handleIssueCreated,
+  };
+}

--- a/packages/dmloop/src/issueDeepLink.ts
+++ b/packages/dmloop/src/issueDeepLink.ts
@@ -1,0 +1,133 @@
+export const LOOP_ROUTE_PATH = "/loop";
+export const FLEET_ISSUE_DEEP_LINK_PREFIX = "/fleet";
+
+const PENDING_ISSUE_DEEP_LINK_KEY = "octo.loop.pendingIssueDeepLink";
+
+type SessionStorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+let inMemoryPendingIssueDeepLink: LoopIssueDeepLink | null = null;
+
+export interface LoopIssueDeepLink {
+  workspaceSlug: string;
+  issueIdentifier: string;
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function parseLoopIssueDeepLink(pathname: string): LoopIssueDeepLink | null {
+  const [pathOnly] = pathname.split(/[?#]/);
+  const segments = pathOnly.replace(/\/+$/, "").split("/").filter(Boolean);
+  if (
+    segments.length === 4 &&
+    segments[0] === "fleet" &&
+    segments[2] === "issues"
+  ) {
+    const workspaceSlug = decodeSegment(segments[1]);
+    const issueIdentifier = decodeSegment(segments[3]);
+    if (!workspaceSlug || !issueIdentifier) return null;
+    return {
+      workspaceSlug,
+      issueIdentifier,
+    };
+  }
+  return null;
+}
+
+export function buildFleetIssueDeepLink(workspaceSlug: string, issueIdentifier: string): string {
+  return `${FLEET_ISSUE_DEEP_LINK_PREFIX}/${encodeURIComponent(workspaceSlug)}/issues/${encodeURIComponent(issueIdentifier)}`;
+}
+
+export function savePendingLoopIssueDeepLink(
+  link: LoopIssueDeepLink,
+  sessionStore: SessionStorageLike
+): void {
+  inMemoryPendingIssueDeepLink = link;
+  sessionStore.setItem(PENDING_ISSUE_DEEP_LINK_KEY, JSON.stringify(link));
+}
+
+export function readPendingLoopIssueDeepLink(
+  sessionStore: SessionStorageLike
+): LoopIssueDeepLink | null {
+  let raw: string | null = null;
+  try {
+    raw = sessionStore.getItem(PENDING_ISSUE_DEEP_LINK_KEY);
+  } catch {
+    return inMemoryPendingIssueDeepLink;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<LoopIssueDeepLink>;
+    if (typeof parsed.workspaceSlug !== "string" || typeof parsed.issueIdentifier !== "string") {
+      return null;
+    }
+    if (!parsed.workspaceSlug || !parsed.issueIdentifier) {
+      return null;
+    }
+    return {
+      workspaceSlug: parsed.workspaceSlug,
+      issueIdentifier: parsed.issueIdentifier,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function consumePendingLoopIssueDeepLink(
+  sessionStore: SessionStorageLike
+): LoopIssueDeepLink | null {
+  const pending = readPendingLoopIssueDeepLink(sessionStore);
+  try {
+    sessionStore.removeItem(PENDING_ISSUE_DEEP_LINK_KEY);
+  } catch {
+    // Storage can be unavailable; clear the in-memory fallback below.
+  }
+  inMemoryPendingIssueDeepLink = null;
+  return pending;
+}
+
+export function normalizeCurrentLoopIssueDeepLink(): LoopIssueDeepLink | null {
+  if (typeof window === "undefined") return null;
+  const link = parseLoopIssueDeepLink(window.location.pathname);
+  if (!link) return null;
+  try {
+    savePendingLoopIssueDeepLink(link, window.sessionStorage);
+  } catch {
+    // Storage can be unavailable; the live path can still be parsed during this boot.
+  }
+  try {
+    window.history.replaceState(window.history.state, "", LOOP_ROUTE_PATH);
+  } catch {
+    // Keep the original URL when History is unavailable.
+  }
+  return link;
+}
+
+function writeBrowserPath(path: string, mode: "push" | "replace"): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (mode === "push") window.history.pushState(window.history.state, "", path);
+    else window.history.replaceState(window.history.state, "", path);
+  } catch {
+    // Best effort: routeRight still opens the issue even if browser history is unavailable.
+  }
+}
+
+export function pushFleetIssueDeepLink(workspaceSlug: string, issueIdentifier: string): void {
+  if (!workspaceSlug || !issueIdentifier) return;
+  writeBrowserPath(buildFleetIssueDeepLink(workspaceSlug, issueIdentifier), "push");
+}
+
+export function replaceFleetIssueDeepLink(workspaceSlug: string, issueIdentifier: string): void {
+  if (!workspaceSlug || !issueIdentifier) return;
+  writeBrowserPath(buildFleetIssueDeepLink(workspaceSlug, issueIdentifier), "replace");
+}
+
+export function replaceLoopRootPath(): void {
+  writeBrowserPath(LOOP_ROUTE_PATH, "replace");
+}

--- a/packages/dmloop/src/issueDeepLink.ts
+++ b/packages/dmloop/src/issueDeepLink.ts
@@ -101,6 +101,8 @@ export function normalizeCurrentLoopIssueDeepLink(): LoopIssueDeepLink | null {
     // Storage can be unavailable; the live path can still be parsed during this boot.
   }
   try {
+    // Fleet issue links are standalone product links; query-based flows such as
+    // CLI authorization are handled by their own route before this normalization.
     window.history.replaceState(window.history.state, "", LOOP_ROUTE_PATH);
   } catch {
     // Keep the original URL when History is unavailable.

--- a/packages/dmloop/src/module.tsx
+++ b/packages/dmloop/src/module.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { WKApp, Menus, i18n, t as translate } from "@octo/base";
 import type { IModule } from "@octo/base";
+import { Workflow } from "lucide-react";
 import LoopPage from "./pages/LoopPage";
 import LoopCliAuthorizePage from "./pages/LoopCliAuthorizePage";
 import {
@@ -9,6 +10,7 @@ import {
   resolveLoopCliAuthorizeSearch,
   visibleLoopCliAuthorizeSearch,
 } from "./cliAuthorizeSession";
+import { normalizeCurrentLoopIssueDeepLink } from "./issueDeepLink";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 
@@ -27,23 +29,7 @@ if (import.meta.hot) {
 
 function LoopIcon({ active }: { active?: boolean }) {
   const color = active ? "var(--wk-brand-primary, #7C5CFC)" : "currentColor";
-  return (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke={color}
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M17 2l4 4-4 4" />
-      <path d="M3 11v-1a4 4 0 014-4h14" />
-      <path d="M7 22l-4-4 4-4" />
-      <path d="M21 13v1a4 4 0 01-4 4H3" />
-    </svg>
-  );
+  return <Workflow size={22} color={color} strokeWidth={2} />;
 }
 
 /** LoopModule — Loop 一级 Panel（二级菜单：Issue/Skill/Project/Agent/Squad）。 */
@@ -60,6 +46,11 @@ export default class LoopModule implements IModule {
       "zh-CN": zhCN,
       "en-US": enUS,
     });
+
+    // Capture issue deep-links before the host tries to activate a menu route.
+    // Only `/loop` has a NavRail entry, so dynamic issue paths are normalized
+    // first and restored after Loop resolves the target workspace.
+    normalizeCurrentLoopIssueDeepLink();
 
     if (
       typeof window !== "undefined" &&

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -12,6 +12,7 @@ import {
 import LoopButton from "../ui/LoopButton";
 import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, SlidersHorizontal, Filter } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
+import { currentWorkspaceSlug } from "../api/http";
 import type {
   Issue,
   IssueGroup,
@@ -33,6 +34,7 @@ import IssueGroupBoard from "../panel/IssueGroupBoard";
 import IssueList from "../panel/IssueList";
 import IssueDetailPage from "../panel/IssueDetailPage";
 import CreateIssueModal from "../ui/CreateIssueModal";
+import { pushFleetIssueDeepLink, replaceLoopRootPath } from "../issueDeepLink";
 import { readView, writeView } from "../ui/viewMode";
 
 type ViewMode = "board" | "grouped" | "list";
@@ -246,7 +248,21 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
   // (如未来点子 issue 原地切换时,慢请求无法把旧 issue 数据写进新 issue 视图)。
   const openDetail = (id: string) => {
-    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onMutated} />);
+    const workspaceSlug = currentWorkspaceSlug();
+    const issue =
+      issues.find((item) => item.id === id) ??
+      groups.flatMap((group) => group.issues).find((item) => item.id === id);
+    if (workspaceSlug && issue?.identifier) {
+      pushFleetIssueDeepLink(workspaceSlug, issue.identifier);
+    }
+    WKApp.routeRight.push(
+      <IssueDetailPage
+        key={id}
+        issueId={id}
+        onChanged={onMutated}
+        onClose={replaceLoopRootPath}
+      />
+    );
   };
 
   const [createOpen, setCreateOpen] = useState(false);

--- a/packages/dmloop/src/pages/LoopPage.tsx
+++ b/packages/dmloop/src/pages/LoopPage.tsx
@@ -1,424 +1,180 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Typography, Dropdown, Avatar, Modal, Toast } from "@douyinfe/semi-ui";
-import LoopButton from "../ui/LoopButton";
+import React from "react";
 import {
-  ClipboardList, Briefcase, Bot, Users, Settings,
-  ChevronDown, Check, Plus, SquarePen, FolderPlus,
-  Zap, CircleUserRound,
+  Bot,
+  Briefcase,
+  CircleUserRound,
+  ClipboardList,
+  Settings,
+  Users,
+  Zap,
 } from "lucide-react";
-import { useI18n, WKApp, getPinyin } from "@octo/base";
+import { useI18n } from "@octo/base";
 import type { Workspace } from "../api/types";
-import { listWorkspaces, createWorkspace } from "../api/workspaceApi";
-import { setWorkspaceContext, currentWorkspaceId } from "../api/http";
-import { invalidateDirectory } from "../api/directory";
-import { invalidateRuntimeMap, invalidateAgentStatus } from "../api/agentApi";
-import { slugSuffix, withRandomSuffix } from "../ui/slug";
-import IssuePage from "./IssuePage";
+import type { LoopTabItem, LoopTabKey } from "../bridge/types";
+import { useLoopWorkspace } from "../bridge/useLoopWorkspace";
 import CreateIssueModal from "../ui/CreateIssueModal";
-import ProjectPage from "./ProjectPage";
+import LoopCreateWorkspaceModal from "../ui/LoopCreateWorkspaceModal";
+import LoopSidebarView from "../ui/LoopSidebarView";
+import LoopWorkspaceEmptyState from "../ui/LoopWorkspaceEmptyState";
 import AgentPage from "./AgentPage";
-import SquadPage from "./SquadPage";
 import AutomationPage from "./AutomationPage";
+import IssueDetailPage from "../panel/IssueDetailPage";
+import IssuePage from "./IssuePage";
+import ProjectPage from "./ProjectPage";
 import SettingsPage from "./SettingsPage";
+import SquadPage from "./SquadPage";
 import "./loop.css";
 import "../ui/loopControls.css";
 
-const { Title, Text } = Typography;
-
-// 切换工作区时统一重置所有工作区级缓存(目录/运行时/agent 状态),避免残留上个工作区数据。
-function resetWorkspaceCaches() {
-  invalidateDirectory();
-  invalidateRuntimeMap();
-  invalidateAgentStatus();
-}
-
-type TabKey = "myloop" | "issue" | "project" | "automation" | "agent" | "squad" | "settings";
-
-
-// 顶部独立入口：我的回路（复用 Issue 视图的「与我相关」分组）。
-const MY_TAB: { key: TabKey; icon: React.ReactNode } = { key: "myloop", icon: <CircleUserRound size={16} /> };
-// 工作区分组：回路 / 项目 / 自动化 / AI队友 / AI小队。
-const WORKSPACE_TABS: { key: TabKey; icon: React.ReactNode }[] = [
-  { key: "issue", icon: <ClipboardList size={16} /> },
-  { key: "project", icon: <Briefcase size={16} /> },
-  { key: "automation", icon: <Zap size={16} /> },
-  { key: "agent", icon: <Bot size={16} /> },
-  { key: "squad", icon: <Users size={16} /> },
-];
-const SETTINGS_TAB: { key: TabKey; icon: React.ReactNode } = { key: "settings", icon: <Settings size={16} /> };
-
 export default function LoopPage() {
   const { t } = useI18n();
-  const [tab, setTab] = useState<TabKey>("issue");
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [wsId, setWsId] = useState<string>(currentWorkspaceId());
-  const [loaded, setLoaded] = useState(false);
-  const [wsModalOpen, setWsModalOpen] = useState(false);
-  const [wsName, setWsName] = useState("");
-  const [wsSlug, setWsSlug] = useState("");
-  const [wsSlugTouched, setWsSlugTouched] = useState(false);
-  const [wsSlugSuffix, setWsSlugSuffix] = useState("");
-  const [wsBusy, setWsBusy] = useState(false);
-  const [createOpen, setCreateOpen] = useState(false);
 
-  // tab 的同步镜像:mount-once 的 space-changed 副作用闭包(deps=[])会冻结当时的 tab,
-  // 用 ref 让 applyWorkspace 始终读到最新 tab,避免切 space 后右栏恒被铺成初始 issue。
-  const tabRef = useRef<TabKey>("issue");
-  tabRef.current = tab;
-  // space-changed 重解析的过期守卫:快速连切 space 时并发的 listWorkspaces 可能乱序返回,
-  // 只有最后一次解析允许写回 workspace context,否则慢的旧响应会把旧 slug 落回、撞新 space 的 403。
-  const spaceResolveSeqRef = useRef(0);
-  // Set when a space change arrives while LoopPage is backgrounded (its
-  // space-changed handler is gated to the active menu). On reactivation the
-  // nav-menu-activated handler consumes it to force a fresh re-resolve instead
-  // of painting the stale old-space workspaces/wsId it still holds in state.
-  const pendingSpaceReresolveRef = useRef(false);
-
-  const findWs = (list: Workspace[], id: string) => list.find((w) => w.id === id) ?? null;
-
-  const renderTab = (key: TabKey, ws: Workspace | null): JSX.Element => {
+  const renderTab = (
+    key: LoopTabKey,
+    workspace: Workspace | null,
+    helpers: { reloadWorkspaces: () => Promise<Workspace[]> }
+  ): JSX.Element => {
     // 以「当前 workspace」为 key 驱动整颗子页面：切换 workspace → key 变化 → React 强制
     // 重挂子页面 → useEffect 重新以新的 x-workspace-slug 拉取数据，避免残留旧 workspace 数据。
-    const k = `${key}:${ws?.id ?? "none"}`;
+    const tabKey = `${key}:${workspace?.id ?? "none"}`;
     switch (key) {
-      case "myloop": return <IssuePage key={k} viewKey="loop.view.myloop" defaultView="grouped" defaultScope="involves" />;
-      case "issue": return <IssuePage key={k} viewKey="loop.view.issue" />;
-      case "project": return <ProjectPage key={k} />;
-      case "automation": return <AutomationPage key={k} />;
-      case "agent": return <AgentPage key={k} />;
-      case "squad": return <SquadPage key={k} />;
-      case "settings": return <SettingsPage key={k} workspace={ws} onUpdated={() => reloadWorkspaces()} />;
-      default: return <IssuePage key={k} viewKey="loop.view.issue" />;
+      case "myloop":
+        return (
+          <IssuePage
+            key={tabKey}
+            viewKey="loop.view.myloop"
+            defaultView="grouped"
+            defaultScope="involves"
+          />
+        );
+      case "issue":
+        return <IssuePage key={tabKey} viewKey="loop.view.issue" />;
+      case "project":
+        return <ProjectPage key={tabKey} />;
+      case "automation":
+        return <AutomationPage key={tabKey} />;
+      case "agent":
+        return <AgentPage key={tabKey} />;
+      case "squad":
+        return <SquadPage key={tabKey} />;
+      case "settings":
+        return (
+          <SettingsPage
+            key={tabKey}
+            workspace={workspace}
+            onUpdated={helpers.reloadWorkspaces}
+          />
+        );
+      default:
+        return <IssuePage key={tabKey} viewKey="loop.view.issue" />;
     }
   };
 
-  const openTab = (key: TabKey) => {
-    // 重解析窗口期(切 space 后 loaded=false 直到新 space 的 workspace 解析完成)不响应:
-    // 此时 workspaces/wsId 尚属旧 space,点击会用旧作用域渲染 workspace 级页面。
-    if (!loaded) return;
-    setTab(key);
-    WKApp.routeRight.replaceToRoot(renderTab(key, findWs(workspaces, wsId)));
+  const loop = useLoopWorkspace({
+    t,
+    renderTab,
+    renderIssueDetail: (issueId, helpers) => (
+      <IssueDetailPage
+        key={`issue-detail:${issueId}`}
+        issueId={issueId}
+        onChanged={helpers.onIssueChanged}
+        onClose={helpers.onClose}
+      />
+    ),
+    renderEmptyGuide: () => (
+      <LoopWorkspaceEmptyState
+        title={t("loop.workspace.emptyTitle")}
+        desc={t("loop.workspace.emptyDesc")}
+      />
+    ),
+  });
+
+  const myTab: LoopTabItem = {
+    key: "myloop",
+    icon: <CircleUserRound size={16} />,
+    label: t("loop.nav.myloop"),
   };
-
-  // 新建回路 → 唤起统一建单弹窗（对齐 multica，不再拉起独立 AI 页）。成功后落回路看板并刷新。
-  const openNewLoop = () => { if (!loaded) return; setCreateOpen(true); };
-
-  // 空态引导：无 workspace 时右栏提示创建
-  const showEmptyGuide = () => {
-    WKApp.routeRight.replaceToRoot(
-      <div className="loop-page"><div className="loop-empty">
-        <FolderPlus size={44} className="loop-empty__icon" />
-        <div className="loop-empty__title">{t("loop.workspace.emptyTitle")}</div>
-        <div className="loop-empty__desc">{t("loop.workspace.emptyDesc")}</div>
-      </div></div>,
-    );
+  const workspaceTabs: LoopTabItem[] = [
+    {
+      key: "issue",
+      icon: <ClipboardList size={16} />,
+      label: t("loop.nav.issue"),
+    },
+    {
+      key: "project",
+      icon: <Briefcase size={16} />,
+      label: t("loop.nav.project"),
+    },
+    {
+      key: "automation",
+      icon: <Zap size={16} />,
+      label: t("loop.nav.automation"),
+    },
+    {
+      key: "agent",
+      icon: <Bot size={16} />,
+      label: t("loop.nav.agent"),
+    },
+    {
+      key: "squad",
+      icon: <Users size={16} />,
+      label: t("loop.nav.squad"),
+    },
+  ];
+  const settingsTab: LoopTabItem = {
+    key: "settings",
+    icon: <Settings size={16} />,
+    label: t("loop.nav.settings"),
   };
-
-  const applyWorkspace = (ws: Workspace | null, list: Workspace[]) => {
-    if (ws) {
-      setWorkspaceContext(ws.slug, ws.id, ws.name);
-      setWsId(ws.id);
-      resetWorkspaceCaches();
-      WKApp.routeRight.replaceToRoot(renderTab(tabRef.current, ws));
-    } else {
-      setWorkspaceContext("", "");
-      setWsId("");
-      showEmptyGuide();
-    }
-    setWorkspaces(list);
-  };
-
-  const reloadWorkspaces = async (): Promise<Workspace[]> => {
-    const list = await listWorkspaces().catch(() => [] as Workspace[]);
-    setWorkspaces(list);
-    return list;
-  };
-
-  // Re-resolve the workspace scope for the current octo space: clear the old
-  // scope, unmount the stale right pane, re-list, and repaint. Shared by the
-  // space-changed handler (when LoopPage is active) and by reactivation
-  // (nav-menu-activated) when a space change happened while it was backgrounded.
-  const reResolveSpace = () => {
-    const seq = ++spaceResolveSeqRef.current;
-    setWorkspaceContext("", "");
-    setWsId("");
-    // Close any open create modals so a submit cannot land during the
-    // re-resolve window and write a workspace under the wrong space.
-    setWsModalOpen(false);
-    setCreateOpen(false);
-    // setLoaded(false): mark not-ready for the re-resolve window so the
-    // wk:nav-menu-activated `if (!loaded) return` guard holds and no entry uses
-    // the old space's workspaces closure.
-    setLoaded(false);
-    resetWorkspaceCaches();
-    // Unmount the stale right pane immediately so the previous space's IssuePage
-    // (and its polling / create entry) stops firing during the re-resolve window.
-    WKApp.routeRight.replaceToRoot(<div className="loop-page" />);
-    listWorkspaces()
-      .then((list) => {
-        // Out-of-order guard: only the latest resolve applies, dropping a stale
-        // response that would write the old slug back and hit the new space's 403.
-        if (seq !== spaceResolveSeqRef.current) return;
-        // If the user navigated away while this resolve was in flight, do NOT
-        // write the shared pane/context (would clobber the now-active page).
-        // Defer to reactivation instead.
-        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
-        setLoaded(true);
-        const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
-        applyWorkspace(first, list);
-      })
-      .catch(() => {
-        if (seq !== spaceResolveSeqRef.current) return;
-        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
-        setLoaded(true);
-        // Clear the stale old-space list on a failed re-resolve — otherwise the
-        // switcher dropdown keeps the previous space's workspaces, re-enabled by
-        // setLoaded(true) and clickable, so switchWorkspace would bind an
-        // old-space slug under the new space's X-Space-Id → cross-space 403.
-        setWorkspaces([]);
-        showEmptyGuide();
-      });
-  };
-
-  useEffect(() => {
-    // mount 初始解析也纳入 spaceResolveSeqRef 域:若初始 listWorkspaces 尚未返回、
-    // 用户就切了 space,space-changed 会递增 seq 使这次 mount 响应过期被丢弃,避免旧 space
-    // 的 workspace slug 被写回 http 层、撞新 space 的隔离 403(与 space-changed 共享守卫)。
-    const seq = ++spaceResolveSeqRef.current;
-    listWorkspaces()
-      .then((list) => {
-        if (seq !== spaceResolveSeqRef.current) return;
-        // If the page was backgrounded before this mount resolve landed, don't
-        // write the shared pane/context; defer to reactivation.
-        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
-        setLoaded(true);
-        const first = findWs(list, currentWorkspaceId()) ?? list[0] ?? null;
-        applyWorkspace(first, list);
-      })
-      .catch(() => {
-        if (seq !== spaceResolveSeqRef.current) return;
-        if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
-        setLoaded(true);
-        // Clear the switcher list on a failed resolve: showEmptyGuide only
-        // repaints the right pane, so without this the dropdown would keep the
-        // previous list, re-enabled by setLoaded(true) and clickable.
-        setWorkspaces([]);
-        showEmptyGuide();
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // 顶部一级导航「Loop」被再次点击时，onMenuClick 会先 routeRight.popToRoot() 清空右栏
-  // （LoopPage 常驻不重挂，useEffect 不会重跑）。这里监听激活事件，把体验对齐「首次进入」
-  // ——重置到默认的 Issue（回路）视图，避免右栏残留空白/报错。
-  useEffect(() => {
-    const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
-      if (menuId !== "loop") return;
-      // A space change arrived while this page was backgrounded: its handler was
-      // deferred, so state still holds the old space. Force a fresh re-resolve
-      // instead of painting stale workspaces/wsId.
-      if (pendingSpaceReresolveRef.current) {
-        pendingSpaceReresolveRef.current = false;
-        reResolveSpace();
-        return;
-      }
-      // workspace 列表尚未加载完时不处理：挂载副作用会在加载完成后自行铺默认视图，
-      // 避免 workspaces 还是 [] 时误闪空态引导。
-      if (!loaded) return;
-      const ws = findWs(workspaces, wsId);
-      if (!ws) { showEmptyGuide(); return; }
-      setTab("issue");
-      WKApp.routeRight.replaceToRoot(renderTab("issue", ws));
-      // 已停在 issue tab 时 key(issue:wsId) 不变不会重挂 → 补发刷新事件，让当前 IssuePage 重新拉数(data→view)。
-      setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
-    };
-    WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
-    return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaces, wsId, loaded]);
-
-  // 切换 octo space 时,当前 wsId + @octo/loop 模块级 workspace 全局属于上一个 space,
-  // 必须作废重判 —— 否则会带旧 workspace 作用域向新 space 发 workspace 维度请求,撞后端
-  // space 隔离闸门(workspace does not belong to this space / not a member of this space)。
-  // 先 setWorkspaceContext("","") 清 http 层旧 slug,避免重列期间任何请求带旧作用域;再重新
-  // listWorkspaces 并铺新 space 的默认 workspace,新 space 无 workspace 时 applyWorkspace(null)
-  // 自然落入空态引导(showEmptyGuide)。
-  useEffect(() => {
-    const onSpaceChanged = () => {
-      // Only the active page may touch the single shared right pane / http-layer
-      // workspace context. When LoopPage is backgrounded (kept mounted), defer:
-      // flag a pending re-resolve that reactivation (below) consumes, so we never
-      // fight the active page for the pane nor paint stale old-space data.
-      if (WKApp.currentMenuId !== "loop") {
-        pendingSpaceReresolveRef.current = true;
-        return;
-      }
-      reResolveSpace();
-    };
-    WKApp.mittBus.on("space-changed", onSpaceChanged);
-    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const switchWorkspace = (w: Workspace) => {
-    // 重解析窗口期不响应:下拉里的 w 属于旧 space 的 workspaces,选它会把旧 slug 写回。
-    if (!loaded) return;
-    setWorkspaceContext(w.slug, w.id, w.name);
-    setWsId(w.id);
-    resetWorkspaceCaches();
-    WKApp.routeRight.replaceToRoot(renderTab(tabRef.current, w));
-  };
-
-  const openCreateWs = () => {
-    if (!loaded) return;
-    setWsName(""); setWsSlug(""); setWsSlugTouched(false); setWsSlugSuffix(slugSuffix()); setWsModalOpen(true);
-  };
-  const doCreateWs = async () => {
-    const name = wsName.trim();
-    if (!name) { Toast.warning(t("loop.workspace.nameRequired")); return; }
-    const autoSlug = !wsSlugTouched;
-    let slug = wsSlug.trim() || withRandomSuffix(getPinyin(name), wsSlugSuffix);
-    if (!slug) { Toast.warning(t("loop.workspace.slugRequired")); return; }
-    // Capture (do NOT bump) the resolve generation: creating a workspace writes
-    // workspace context after awaits, so if the user switches octo space
-    // mid-create, space-changed bumps the seq and the post-await applyWorkspace
-    // below is dropped (would otherwise bind this space's slug under the new
-    // space's X-Space-Id → isolation 403). Capturing rather than bumping is
-    // deliberate: onSpaceChanged owns `loaded` restoration through its own
-    // generation, and a create must not invalidate that resolve (else `loaded`
-    // could stay false forever, wedging the page).
-    const seq = spaceResolveSeqRef.current;
-    setWsBusy(true);
-    try {
-      // auto slug re-rolls its random suffix on the backend's 409 (slug is
-      // globally unique) so the happy path needs no manual input; a user-typed
-      // slug is surfaced as taken, never silently changed.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          // Re-check before each create so a space switch during a 409 retry
-          // doesn't create a stray workspace in the newly-selected space.
-          if (seq !== spaceResolveSeqRef.current) return;
-          const created = await createWorkspace({ name, slug });
-          setWsModalOpen(false);
-          const list = await reloadWorkspaces();
-          // A space switch during creation invalidates this write; the
-          // space-changed resolve owns the pane now.
-          if (seq !== spaceResolveSeqRef.current) return;
-          // Navigated away mid-create (no space-changed, so seq is unchanged):
-          // don't write the shared pane/context in the background; defer.
-          if (WKApp.currentMenuId !== "loop") { pendingSpaceReresolveRef.current = true; return; }
-          applyWorkspace(findWs(list, created.id) ?? created, list);
-          setTab("issue");
-          WKApp.routeRight.replaceToRoot(<IssuePage viewKey="loop.view.issue" />);
-          Toast.success(t("loop.workspace.created"));
-          return;
-        } catch (e) {
-          if ((e as { status?: number })?.status !== 409) throw e;
-          if (!autoSlug || attempt === 2) { Toast.error(t("loop.workspace.slugTaken")); return; }
-          slug = withRandomSuffix(getPinyin(name), slugSuffix());
-        }
-      }
-    } catch (e) { Toast.error((e as Error)?.message ?? "create failed"); }
-    finally { setWsBusy(false); }
-  };
-
-  const current = findWs(workspaces, wsId);
-  const hasWs = workspaces.length > 0;
-
-  const wsMenu = (
-    <Dropdown.Menu>
-      <Dropdown.Title>{t("loop.workspace.title")}</Dropdown.Title>
-      {workspaces.map((w) => (
-        <Dropdown.Item key={w.id} onClick={() => switchWorkspace(w)}
-          icon={<Avatar size="extra-extra-small" color="blue" shape="square">{w.name.slice(0, 1)}</Avatar>}>
-          <span style={{ flex: 1 }}>{w.name}</span>
-          {w.id === wsId && <Check size={14} />}
-        </Dropdown.Item>
-      ))}
-      <Dropdown.Divider />
-      <Dropdown.Item icon={<FolderPlus size={14} />} onClick={openCreateWs}>
-        {t("loop.workspace.create")}
-      </Dropdown.Item>
-    </Dropdown.Menu>
-  );
 
   return (
-    <div className="loop-sidebar">
-      <div className="loop-sidebar__ws">
-        <Dropdown render={wsMenu} trigger="click" position="bottomLeft" clickToHide>
-          <button className="loop-sidebar__ws-btn">
-            <Avatar size="extra-extra-small" color="blue" shape="square">{(current?.name ?? "L").slice(0, 1)}</Avatar>
-            <span className="loop-sidebar__ws-name">{current?.name ?? (loaded && !hasWs ? t("loop.workspace.none") : t("loop.menu.title"))}</span>
-            <ChevronDown size={14} style={{ opacity: 0.5 }} />
-          </button>
-        </Dropdown>
-      </div>
-
-      {!hasWs && loaded ? (
-        <div className="loop-sidebar__new">
-          <LoopButton block icon={<FolderPlus size={14} />} onClick={openCreateWs}>{t("loop.workspace.create")}</LoopButton>
-        </div>
-      ) : (
-        <>
-          <div className="loop-sidebar__new">
-            <button className="loop-sidebar__new-btn" onClick={openNewLoop}>
-              <SquarePen size={15} />
-              <span>{t("loop.action.newIssue")}</span>
-              <Plus size={14} style={{ marginLeft: "auto", opacity: 0.5 }} />
-            </button>
-          </div>
-          <nav className="loop-sidebar__menu">
-            <button className={`loop-sidebar__item ${tab === MY_TAB.key ? "is-active" : ""}`} onClick={() => openTab(MY_TAB.key)}>
-              {MY_TAB.icon}
-              <span>{t(`loop.nav.${MY_TAB.key}`)}</span>
-            </button>
-            <div className="loop-sidebar__group-label">{t("loop.nav.workspaceGroup")}</div>
-            {WORKSPACE_TABS.map((it) => (
-              <button key={it.key} className={`loop-sidebar__item ${tab === it.key ? "is-active" : ""}`} onClick={() => openTab(it.key)}>
-                {it.icon}
-                <span>{t(`loop.nav.${it.key}`)}</span>
-              </button>
-            ))}
-            <button className={`loop-sidebar__item ${tab === SETTINGS_TAB.key ? "is-active" : ""}`} onClick={() => openTab(SETTINGS_TAB.key)}>
-              {SETTINGS_TAB.icon}
-              <span>{t(`loop.nav.${SETTINGS_TAB.key}`)}</span>
-            </button>
-          </nav>
-        </>
-      )}
-
-      <Modal
-        className="loop-modal"
-        title={t("loop.workspace.create")}
-        visible={wsModalOpen}
-        onOk={doCreateWs}
-        onCancel={() => setWsModalOpen(false)}
-        okText={t("loop.action.create")}
-        cancelText={t("loop.action.cancel")}
-        okButtonProps={{ loading: wsBusy }}
-      >
-        <div className="loop-fields">
-          <div className="loop-fields__row">
-            <div className="loop-fields__label">{t("loop.settings.wsName")}</div>
-            <input autoFocus className="loop-field" value={wsName} onChange={(e) => { setWsName(e.target.value); if (!wsSlugTouched) setWsSlug(e.target.value.trim() ? withRandomSuffix(getPinyin(e.target.value), wsSlugSuffix) : ""); }} placeholder={t("loop.workspace.namePlaceholder")} />
-          </div>
-          <div className="loop-fields__row">
-            <div className="loop-fields__label">{t("loop.settings.wsSlug")}</div>
-            <input className="loop-field" value={wsSlug} onChange={(e) => { setWsSlug(e.target.value); setWsSlugTouched(true); }} placeholder="my-workspace" />
-          </div>
-        </div>
-      </Modal>
-      <CreateIssueModal
-        visible={createOpen}
-        onClose={() => setCreateOpen(false)}
-        onCreated={() => {
-          setCreateOpen(false);
-          openTab("issue");
-          // 若已在 issue tab（同 key 不重挂），补发刷新使新回路即时出现。
-          setTimeout(() => WKApp.mittBus.emit("wk:loop-issues-refresh"), 0);
-          Toast.success(t("loop.toast.created"));
+    <>
+      <LoopSidebarView
+        activeTab={loop.tab}
+        workspaces={loop.workspaces}
+        currentWorkspace={loop.currentWorkspace}
+        hasWorkspace={loop.hasWorkspace}
+        loaded={loop.loaded}
+        myTab={myTab}
+        workspaceTabs={workspaceTabs}
+        settingsTab={settingsTab}
+        labels={{
+          title: t("loop.menu.title"),
+          workspaceTitle: t("loop.workspace.title"),
+          noWorkspace: t("loop.workspace.none"),
+          createWorkspace: t("loop.workspace.create"),
+          newIssue: t("loop.action.newIssue"),
+          workspaceGroup: t("loop.nav.workspaceGroup"),
         }}
+        onTabClick={loop.openTab}
+        onNewLoop={loop.openNewLoop}
+        onCreateWorkspace={loop.openCreateWorkspace}
+        onSwitchWorkspace={loop.switchWorkspace}
       />
-    </div>
+      <LoopCreateWorkspaceModal
+        visible={loop.wsModalOpen}
+        busy={loop.wsBusy}
+        name={loop.wsName}
+        slug={loop.wsSlug}
+        labels={{
+          title: t("loop.workspace.create"),
+          create: t("loop.action.create"),
+          cancel: t("loop.action.cancel"),
+          name: t("loop.settings.wsName"),
+          slug: t("loop.settings.wsSlug"),
+          namePlaceholder: t("loop.workspace.namePlaceholder"),
+          slugPlaceholder: "my-workspace",
+        }}
+        onSubmit={loop.submitCreateWorkspace}
+        onCancel={loop.closeCreateWorkspace}
+        onNameChange={loop.changeWorkspaceName}
+        onSlugChange={loop.changeWorkspaceSlug}
+      />
+      <CreateIssueModal
+        visible={loop.createOpen}
+        onClose={loop.closeCreateIssue}
+        onCreated={loop.handleIssueCreated}
+      />
+    </>
   );
 }

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -44,6 +44,10 @@
   white-space: nowrap;
 }
 
+.loop-sidebar__ws-menu-name {
+  flex: 1;
+}
+
 /* 新建入口 */
 .loop-sidebar__new {
   padding: 2px 10px 8px;
@@ -65,6 +69,11 @@
 
 .loop-sidebar__new-btn:hover {
   background: var(--semi-color-fill-0, #f0f1f3);
+}
+
+.loop-sidebar__new-plus {
+  margin-left: auto;
+  opacity: 0.5;
 }
 
 .loop-sidebar__menu {

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -32,6 +32,7 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
+import { currentWorkspaceSlug } from "../api/http";
 import type {
   Issue,
   IssueComment,
@@ -78,6 +79,10 @@ import { useCommentTriggerPreview } from "../ui/useCommentTriggerPreview";
 import { buildRepliesByParent, collectThreadReplies } from "../ui/threadReplies";
 import LoopAttachments from "../ui/LoopAttachments";
 import { confirmDelete } from "../ui/confirmDelete";
+import {
+  pushFleetIssueDeepLink,
+  replaceFleetIssueDeepLink,
+} from "../issueDeepLink";
 import RunDetailModal from "./RunDetailModal";
 import CreateIssueModal from "../ui/CreateIssueModal";
 import {
@@ -261,13 +266,14 @@ function fmt(iso?: string | null): string {
 export interface IssueDetailPageProps {
   issueId: string;
   onChanged?: () => void;
+  onClose?: () => boolean | void;
 }
 
 /**
  * Issue 独立详情页（对齐产品设计）：主体(标题/描述/评论) + 右侧属性栏 + 执行日志。
  * 渲染在右主栏（routeRight.push），顶部返回按钮 pop 回列表/看板。
  */
-export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageProps) {
+export default function IssueDetailPage({ issueId, onChanged, onClose }: IssueDetailPageProps) {
   const { t } = useI18n();
   const [issue, setIssue] = useState<Issue | null>(null);
   const [comments, setComments] = useState<IssueComment[]>([]);
@@ -607,7 +613,10 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
     });
   };
 
-  const back = () => WKApp.routeRight.pop();
+  const back = () => {
+    if (onClose?.() === false) return;
+    WKApp.routeRight.pop();
+  };
 
   const openRun = (run: TaskRun) => {
     setActiveRun(run);
@@ -616,7 +625,22 @@ export default function IssueDetailPage({ issueId, onChanged }: IssueDetailPageP
 
   // 打开子回路详情（递归复用本页，key 隔离跨 issue 陈旧写入）。
   const openChild = (id: string) => {
-    WKApp.routeRight.push(<IssueDetailPage key={id} issueId={id} onChanged={onChanged} />);
+    const workspaceSlug = currentWorkspaceSlug();
+    const child = children.find((item) => item.id === id);
+    if (workspaceSlug && child?.identifier) {
+      pushFleetIssueDeepLink(workspaceSlug, child.identifier);
+    }
+    WKApp.routeRight.push(
+      <IssueDetailPage
+        key={id}
+        issueId={id}
+        onChanged={onChanged}
+        onClose={() => {
+          if (workspaceSlug && issue?.identifier) replaceFleetIssueDeepLink(workspaceSlug, issue.identifier);
+          else onClose?.();
+        }}
+      />
+    );
   };
 
   const reloadRuns = () => listRuns(issueId).then(setRuns).catch(() => {});

--- a/packages/dmloop/src/ui/LoopCreateWorkspaceModal.stories.tsx
+++ b/packages/dmloop/src/ui/LoopCreateWorkspaceModal.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LoopCreateWorkspaceModal from "./LoopCreateWorkspaceModal";
+import "../pages/loop.css";
+
+const meta = {
+  title: "Loop/LoopCreateWorkspaceModal",
+  component: LoopCreateWorkspaceModal,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    visible: true,
+    busy: false,
+    name: "Alpha Workspace",
+    slug: "alpha-workspace",
+    labels: {
+      title: "Create workspace",
+      create: "Create",
+      cancel: "Cancel",
+      name: "Name",
+      slug: "Slug",
+      namePlaceholder: "Workspace name",
+      slugPlaceholder: "my-workspace",
+    },
+    onSubmit: () => undefined,
+    onCancel: () => undefined,
+    onNameChange: () => undefined,
+    onSlugChange: () => undefined,
+  },
+} satisfies Meta<typeof LoopCreateWorkspaceModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Busy: Story = {
+  args: {
+    busy: true,
+  },
+};

--- a/packages/dmloop/src/ui/LoopCreateWorkspaceModal.tsx
+++ b/packages/dmloop/src/ui/LoopCreateWorkspaceModal.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Modal } from "@douyinfe/semi-ui";
+
+export interface LoopCreateWorkspaceModalLabels {
+  title: string;
+  create: string;
+  cancel: string;
+  name: string;
+  slug: string;
+  namePlaceholder: string;
+  slugPlaceholder: string;
+}
+
+export interface LoopCreateWorkspaceModalProps {
+  visible: boolean;
+  busy: boolean;
+  name: string;
+  slug: string;
+  labels: LoopCreateWorkspaceModalLabels;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onNameChange: (name: string) => void;
+  onSlugChange: (slug: string) => void;
+}
+
+export default function LoopCreateWorkspaceModal({
+  visible,
+  busy,
+  name,
+  slug,
+  labels,
+  onSubmit,
+  onCancel,
+  onNameChange,
+  onSlugChange,
+}: LoopCreateWorkspaceModalProps) {
+  return (
+    <Modal
+      className="loop-modal"
+      title={labels.title}
+      visible={visible}
+      onOk={onSubmit}
+      onCancel={onCancel}
+      okText={labels.create}
+      cancelText={labels.cancel}
+      okButtonProps={{ loading: busy }}
+    >
+      <div className="loop-fields">
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{labels.name}</div>
+          <input
+            autoFocus
+            className="loop-field"
+            value={name}
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder={labels.namePlaceholder}
+          />
+        </div>
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">{labels.slug}</div>
+          <input
+            className="loop-field"
+            value={slug}
+            onChange={(event) => onSlugChange(event.target.value)}
+            placeholder={labels.slugPlaceholder}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/dmloop/src/ui/LoopSidebarView.stories.tsx
+++ b/packages/dmloop/src/ui/LoopSidebarView.stories.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Bot,
+  Briefcase,
+  CircleUserRound,
+  ClipboardList,
+  Settings,
+  Users,
+  Zap,
+} from "lucide-react";
+import type { Workspace } from "../api/types";
+import type { LoopTabItem } from "../bridge/types";
+import LoopSidebarView from "./LoopSidebarView";
+import "../pages/loop.css";
+import "./loopControls.css";
+
+const workspaces: Workspace[] = [
+  {
+    id: "workspace-alpha",
+    name: "Alpha Workspace",
+    slug: "alpha-workspace",
+  },
+  {
+    id: "workspace-research",
+    name: "Research Workspace",
+    slug: "research-workspace",
+  },
+] as Workspace[];
+
+const myTab: LoopTabItem = {
+  key: "myloop",
+  icon: <CircleUserRound size={16} />,
+  label: "My Loop",
+};
+
+const workspaceTabs: LoopTabItem[] = [
+  { key: "issue", icon: <ClipboardList size={16} />, label: "Issues" },
+  { key: "project", icon: <Briefcase size={16} />, label: "Projects" },
+  { key: "automation", icon: <Zap size={16} />, label: "Automation" },
+  { key: "agent", icon: <Bot size={16} />, label: "Agents" },
+  { key: "squad", icon: <Users size={16} />, label: "Squads" },
+];
+
+const settingsTab: LoopTabItem = {
+  key: "settings",
+  icon: <Settings size={16} />,
+  label: "Settings",
+};
+
+const meta = {
+  title: "Loop/LoopSidebarView",
+  component: LoopSidebarView,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Pure Loop sidebar presentation component. Workspace loading, routeRight writes, and API access stay in the bridge layer.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 260, height: 620 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    activeTab: "issue",
+    workspaces,
+    currentWorkspace: workspaces[0],
+    hasWorkspace: true,
+    loaded: true,
+    myTab,
+    workspaceTabs,
+    settingsTab,
+    labels: {
+      title: "Loop",
+      workspaceTitle: "Workspace",
+      noWorkspace: "No workspace",
+      createWorkspace: "Create workspace",
+      newIssue: "New loop",
+      workspaceGroup: "Workspace",
+    },
+    onTabClick: () => undefined,
+    onNewLoop: () => undefined,
+    onCreateWorkspace: () => undefined,
+    onSwitchWorkspace: () => undefined,
+  },
+} satisfies Meta<typeof LoopSidebarView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const MyLoopActive: Story = {
+  args: {
+    activeTab: "myloop",
+  },
+};
+
+export const NoWorkspace: Story = {
+  args: {
+    activeTab: "issue",
+    workspaces: [],
+    currentWorkspace: null,
+    hasWorkspace: false,
+    loaded: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    activeTab: "issue",
+    workspaces: [],
+    currentWorkspace: null,
+    hasWorkspace: false,
+    loaded: false,
+  },
+};

--- a/packages/dmloop/src/ui/LoopSidebarView.tsx
+++ b/packages/dmloop/src/ui/LoopSidebarView.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { Avatar, Dropdown } from "@douyinfe/semi-ui";
+import {
+  Check,
+  ChevronDown,
+  FolderPlus,
+  Plus,
+  SquarePen,
+} from "lucide-react";
+import type { Workspace } from "../api/types";
+import type { LoopTabItem, LoopTabKey } from "../bridge/types";
+import LoopButton from "./LoopButton";
+
+export interface LoopSidebarLabels {
+  title: string;
+  workspaceTitle: string;
+  noWorkspace: string;
+  createWorkspace: string;
+  newIssue: string;
+  workspaceGroup: string;
+}
+
+export interface LoopSidebarViewProps {
+  activeTab: LoopTabKey;
+  workspaces: Workspace[];
+  currentWorkspace: Workspace | null;
+  hasWorkspace: boolean;
+  loaded: boolean;
+  myTab: LoopTabItem;
+  workspaceTabs: LoopTabItem[];
+  settingsTab: LoopTabItem;
+  labels: LoopSidebarLabels;
+  onTabClick: (key: LoopTabKey) => void;
+  onNewLoop: () => void;
+  onCreateWorkspace: () => void;
+  onSwitchWorkspace: (workspace: Workspace) => void;
+}
+
+export default function LoopSidebarView({
+  activeTab,
+  workspaces,
+  currentWorkspace,
+  hasWorkspace,
+  loaded,
+  myTab,
+  workspaceTabs,
+  settingsTab,
+  labels,
+  onTabClick,
+  onNewLoop,
+  onCreateWorkspace,
+  onSwitchWorkspace,
+}: LoopSidebarViewProps) {
+  const workspaceName =
+    currentWorkspace?.name ?? (loaded && !hasWorkspace ? labels.noWorkspace : labels.title);
+  const workspaceInitial = (currentWorkspace?.name ?? "L").slice(0, 1);
+  const workspaceMenu = (
+    <Dropdown.Menu>
+      <Dropdown.Title>{labels.workspaceTitle}</Dropdown.Title>
+      {workspaces.map((workspace) => (
+        <Dropdown.Item
+          key={workspace.id}
+          onClick={() => onSwitchWorkspace(workspace)}
+          icon={
+            <Avatar size="extra-extra-small" color="blue" shape="square">
+              {workspace.name.slice(0, 1)}
+            </Avatar>
+          }
+        >
+          <span className="loop-sidebar__ws-menu-name">{workspace.name}</span>
+          {workspace.id === currentWorkspace?.id && <Check size={14} />}
+        </Dropdown.Item>
+      ))}
+      <Dropdown.Divider />
+      <Dropdown.Item icon={<FolderPlus size={14} />} onClick={onCreateWorkspace}>
+        {labels.createWorkspace}
+      </Dropdown.Item>
+    </Dropdown.Menu>
+  );
+
+  return (
+    <div className="loop-sidebar">
+      <div className="loop-sidebar__ws">
+        <Dropdown
+          render={workspaceMenu}
+          trigger="click"
+          position="bottomLeft"
+          clickToHide
+        >
+          <button className="loop-sidebar__ws-btn">
+            <Avatar size="extra-extra-small" color="blue" shape="square">
+              {workspaceInitial}
+            </Avatar>
+            <span className="loop-sidebar__ws-name">{workspaceName}</span>
+            <ChevronDown size={14} style={{ opacity: 0.5 }} />
+          </button>
+        </Dropdown>
+      </div>
+
+      {!hasWorkspace && loaded ? (
+        <div className="loop-sidebar__new">
+          <LoopButton
+            block
+            icon={<FolderPlus size={14} />}
+            onClick={onCreateWorkspace}
+          >
+            {labels.createWorkspace}
+          </LoopButton>
+        </div>
+      ) : (
+        <>
+          <div className="loop-sidebar__new">
+            <button className="loop-sidebar__new-btn" onClick={onNewLoop}>
+              <SquarePen size={15} />
+              <span>{labels.newIssue}</span>
+              <Plus size={14} className="loop-sidebar__new-plus" />
+            </button>
+          </div>
+          <nav className="loop-sidebar__menu">
+            <button
+              className={`loop-sidebar__item ${
+                activeTab === myTab.key ? "is-active" : ""
+              }`}
+              onClick={() => onTabClick(myTab.key)}
+            >
+              {myTab.icon}
+              <span>{myTab.label}</span>
+            </button>
+            <div className="loop-sidebar__group-label">
+              {labels.workspaceGroup}
+            </div>
+            {workspaceTabs.map((item) => (
+              <button
+                key={item.key}
+                className={`loop-sidebar__item ${
+                  activeTab === item.key ? "is-active" : ""
+                }`}
+                onClick={() => onTabClick(item.key)}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </button>
+            ))}
+            <button
+              className={`loop-sidebar__item ${
+                activeTab === settingsTab.key ? "is-active" : ""
+              }`}
+              onClick={() => onTabClick(settingsTab.key)}
+            >
+              {settingsTab.icon}
+              <span>{settingsTab.label}</span>
+            </button>
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/dmloop/src/ui/LoopWorkspaceEmptyState.stories.tsx
+++ b/packages/dmloop/src/ui/LoopWorkspaceEmptyState.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LoopWorkspaceEmptyState from "./LoopWorkspaceEmptyState";
+import "../pages/loop.css";
+
+const meta = {
+  title: "Loop/LoopWorkspaceEmptyState",
+  component: LoopWorkspaceEmptyState,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "100%", height: 520 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    title: "No workspace yet",
+    desc: "Create a workspace before managing loops, projects, agents, or squads.",
+  },
+} satisfies Meta<typeof LoopWorkspaceEmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/dmloop/src/ui/LoopWorkspaceEmptyState.tsx
+++ b/packages/dmloop/src/ui/LoopWorkspaceEmptyState.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { FolderPlus } from "lucide-react";
+
+export interface LoopWorkspaceEmptyStateProps {
+  title: string;
+  desc: string;
+}
+
+export default function LoopWorkspaceEmptyState({
+  title,
+  desc,
+}: LoopWorkspaceEmptyStateProps) {
+  return (
+    <div className="loop-page">
+      <div className="loop-empty">
+        <FolderPlus size={44} className="loop-empty__icon" />
+        <div className="loop-empty__title">{title}</div>
+        <div className="loop-empty__desc">{desc}</div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dmpersonal/README.md
+++ b/packages/dmpersonal/README.md
@@ -1,0 +1,76 @@
+# @octo/personal Module Notes
+
+This package owns the Personal workspace entry. It currently exposes the
+personal runtime and skill views by reusing Loop runtime pages.
+
+## Current Entry Points
+
+- `src/module.tsx` registers the `/personal` route and the Personal navigation
+  entry.
+- The navigation entry is controlled by `WKApp.remoteConfig.dmpersonalOn`.
+- The route remains registered even when the navigation entry is hidden.
+- `src/PersonalPage.tsx` is the Personal left-pane container. It should stay
+  thin.
+
+## Directory Boundaries
+
+- `src/bridge/` owns runtime state and host-app coordination: workspace
+  resolution, machine/workspace mode, Space switching, shared right-pane writes,
+  and tab actions.
+- `src/ui/` owns presentational UI only. UI files must not call APIs, import
+  `WKApp`, write `routeRight`, or resolve workspace context.
+- `src/PersonalPage.tsx` composes bridge state, i18n labels, and UI components.
+- `src/i18n/` owns user-visible Personal copy.
+
+## Current Standardization Status
+
+`PersonalPage` has been split into:
+
+- `src/PersonalPage.tsx`: thin page container and tab renderer.
+- `src/bridge/usePersonalWorkspace.tsx`: workspace selection, machine mode,
+  Space switching, shared `routeRight` updates, and tab actions.
+- `src/bridge/types.ts`: Personal tab and workspace-state render types.
+- `src/ui/PersonalSidebarView.tsx`: pure sidebar rendering.
+- `src/ui/PersonalWorkspaceState.tsx`: pure loading/error state rendering.
+
+The key behavior to preserve is the Personal/Loop shared workspace isolation:
+
+- Personal stores its own selected workspace instead of blindly following Loop's
+  latest workspace.
+- Personal clears its own state on Space changes.
+- When Personal is backgrounded, it must not clear the shared Loop workspace
+  context or write the shared right pane.
+- Machine mode disables the Skill tab and clears workspace-scoped HTTP context.
+
+## Current Dependency On Loop
+
+Personal intentionally imports from `@octo/loop` today:
+
+- `RuntimePage`
+- `SkillPage`
+- workspace selection helpers and workspace context helpers
+- Loop CSS used by the reused runtime/skill pages
+
+Do not remove this dependency casually. If Personal runtime/skill behavior needs
+to become independent later, split that as a separate PR with its own behavior
+list, file map, PR scope, and verification plan.
+
+## Rules For Future Changes
+
+- Keep UI rendering under `src/ui/`; add Story coverage for new UI components.
+- Keep host-app coordination and workspace state under `src/bridge/`.
+- Do not add direct API calls or `WKApp.routeRight` writes to
+  `src/PersonalPage.tsx` or `src/ui/`.
+- Preserve direct route load, navigation reactivation, and Space switching.
+- Private/module extraction is not part of the current standardization work.
+  Keep new changes structurally clean so extraction remains possible later.
+
+## Verification
+
+For Personal shell changes, run:
+
+```bash
+pnpm --dir apps/web exec vitest run src/__tests__/personalPageSpaceChanged.test.ts
+pnpm --dir apps/web build
+pnpm --dir apps/web build-storybook
+```

--- a/packages/dmpersonal/src/PersonalPage.tsx
+++ b/packages/dmpersonal/src/PersonalPage.tsx
@@ -1,17 +1,16 @@
-import React, { useEffect, useRef, useState } from "react";
-import { AlertCircle, Cpu, Loader2, Sparkles } from "lucide-react";
-import { currentWorkspaceId, resolveWorkspaceSelection, RuntimePage, setWorkspaceContext, SkillPage, workspaceApi } from "@octo/loop";
-import { useI18n, WKApp } from "@octo/base";
+import React from "react";
+import { Cpu, Sparkles } from "lucide-react";
+import { RuntimePage, SkillPage } from "@octo/loop";
+import { useI18n } from "@octo/base";
+import {
+  type PersonalTabKey,
+  usePersonalWorkspace,
+} from "./bridge/usePersonalWorkspace";
+import PersonalSidebarView from "./ui/PersonalSidebarView";
+import PersonalWorkspaceState from "./ui/PersonalWorkspaceState";
 import "@octo/loop/src/pages/loop.css";
 import "@octo/loop/src/ui/loopControls.css";
 import "./personal.css";
-
-type PersonalTabKey = "runtime" | "skill";
-
-const PERSONAL_TABS: { key: PersonalTabKey; icon: React.ReactNode }[] = [
-  { key: "runtime", icon: <Cpu size={16} /> },
-  { key: "skill", icon: <Sparkles size={16} /> },
-];
 
 function renderTab(key: PersonalTabKey): JSX.Element {
   switch (key) {
@@ -26,208 +25,36 @@ function renderTab(key: PersonalTabKey): JSX.Element {
 
 export default function PersonalPage() {
   const { t } = useI18n();
-  const [tab, setTab] = useState<PersonalTabKey>("runtime");
-  const [workspaceReady, setWorkspaceReady] = useState(false);
-  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
-  // machine 模式(0 workspace)标记:machine 模式禁用 Skills、清空 workspace 作用域。
-  // 用 state 驱动 tab 禁用渲染,用 ref 供导航激活副作用同步读取。
-  const [machineMode, setMachineMode] = useState(false);
-  // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
-  // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
-  const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
-  const machineModeRef = useRef(false);
-  const tabRef = useRef<PersonalTabKey>("runtime");
-  tabRef.current = tab;
-  const mountedRef = useRef(true);
-  // 请求代号:resolveAndPaint 由导航事件驱动,快速切换可能并发多个 listWorkspaces;
-  // 每次进入自增,回来时若代号已过期就丢弃,保证"最后一次点击胜出"、不被慢的旧响应覆盖。
-  const resolveSeqRef = useRef(0);
+  const { tab, workspaceReady, workspaceError, machineMode, openTab } =
+    usePersonalWorkspace({
+      t,
+      renderTab,
+      renderWorkspaceState: (state) => <PersonalWorkspaceState {...state} />,
+    });
 
-  // 解析当前 workspace 归属并铺右栏。每次调用都重新 listWorkspaces —— 本页常驻不重挂,
-  // 且 workspace 可能在别处(如 Loop)被创建/删除,machine↔workspace 模式必须每次重判,
-  // 不能沿用挂载时缓存的判断(#729 评审:否则建了 workspace 仍卡在 machine 模式)。
-  const resolveAndPaint = (showLoading: boolean) => {
-    const seq = ++resolveSeqRef.current;
-    if (showLoading) {
-      WKApp.routeRight.replaceToRoot(
-        <PersonalWorkspaceState icon={<Loader2 size={36} />} title={t("personal.workspace.loading")} />,
-      );
-    }
-    workspaceApi.listWorkspaces()
-      .then((workspaces) => {
-        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
-        // If the page was backgrounded before this resolve landed, don't write
-        // the shared pane/context (would clobber the now-active page). Bail;
-        // reactivation re-resolves via wk:nav-menu-activated (resolveRef).
-        if (WKApp.currentMenuId !== "dmpersonal") return;
-        // 优先用本页自己存的 workspace,仅当它不存在(如在别处被删)时才回落到共享全局。
-        // 直接读 currentWorkspaceId() 会让 Personal 跟随 Loop 最后选中的 workspace(#619 污染)。
-        const targetId = selectedWsRef.current?.id ?? currentWorkspaceId();
-        const selection = resolveWorkspaceSelection(workspaces, targetId);
-        if (selection.mode === "machine") {
-          // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
-          // 运行时列表走 /machine-runtimes;Skills 需 workspace,禁用。
-          machineModeRef.current = true;
-          setMachineMode(true);
-          selectedWsRef.current = null;
-          setWorkspaceContext("", "");
-          // machine 模式禁用 Skills:若当前正停在 Skills tab,回落到 runtime。
-          if (tabRef.current === "skill") {
-            tabRef.current = "runtime";
-            setTab("runtime");
-          }
-        } else {
-          machineModeRef.current = false;
-          setMachineMode(false);
-          selectedWsRef.current = { slug: selection.slug, id: selection.id };
-          setWorkspaceContext(selection.slug, selection.id);
-        }
-        setWorkspaceReady(true);
-        setWorkspaceError(null);
-        WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
-      })
-      .catch((error) => {
-        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
-        // Backgrounded before the failure landed → don't paint the shared pane.
-        if (WKApp.currentMenuId !== "dmpersonal") return;
-        const message = error?.message ? String(error.message) : t("personal.workspace.loadFailed");
-        setWorkspaceError(message);
-        setWorkspaceReady(false);
-        WKApp.routeRight.replaceToRoot(
-          <PersonalWorkspaceState
-            icon={<AlertCircle size={40} />}
-            title={t("personal.workspace.loadFailed")}
-            desc={message}
-          />,
-        );
-      });
-  };
-  // 始终指向最新的 resolveAndPaint,供 []-依赖的副作用调用(避免陈旧闭包,同时不让
-  // 副作用因 t 变化而重挂——对齐 LoopPage 的 mount-once 行为,切语言不闪回加载态)。
-  const resolveRef = useRef(resolveAndPaint);
-  resolveRef.current = resolveAndPaint;
-
-  const openTab = (key: PersonalTabKey) => {
-    if (!workspaceReady) return;
-    if (machineModeRef.current && key === "skill") return; // skill 需 workspace,机器级模式禁用
-    const ws = selectedWsRef.current;
-    if (machineModeRef.current) {
-      setWorkspaceContext("", "");
-    } else if (ws) {
-      setWorkspaceContext(ws.slug, ws.id);
-    }
-    setTab(key);
-    WKApp.routeRight.replaceToRoot(renderTab(key));
-  };
-
-  useEffect(() => {
-    mountedRef.current = true;
-    resolveRef.current(true);
-    return () => {
-      mountedRef.current = false;
-    };
-    // 只在挂载时跑一次(对齐 LoopPage):依赖 [t] 会让切语言时重跑,闪回加载态、丢失当前 tab/弹框。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // 顶部一级导航「Personal」被再次点击时,onMenuClick 会先 popToRoot 清空右栏,且本页常驻不重挂
-  // (挂载副作用不会重跑)。这里监听激活事件:重新解析 workspace 归属(machine↔workspace 可能已变)
-  // 并铺回当前 tab,修复「切回后右栏空白」「用别处 workspace 上下文拉数据」以及「建 workspace 后
-  // 仍卡在机器级模式」(#729 评审)。
-  useEffect(() => {
-    const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
-      if (menuId !== "dmpersonal") return;
-      // showLoading=true:框架会先 popToRoot 清空右栏,重解析是异步的,先铺加载态避免空白闪一下。
-      resolveRef.current(true);
-    };
-    WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
-    return () => WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
-  }, []);
-
-  // 切换 octo space 时,本页存的 workspace 归属(selectedWsRef + @octo/loop 模块级
-  // workspace 全局)属于上一个 space,必须作废重判 —— 否则会带旧 workspace 作用域向新
-  // space 发 workspace 维度请求,撞后端 space 隔离闸门(workspace does not belong to
-  // this space / not a member of this space)。
-  //
-  // 三份 workspace 状态必须一起复位,缺一不可:
-  //  - selectedWsRef:本页自留、优先于共享全局的选择(#619 防污染),不清则重解析仍选中旧 ws;
-  //  - machineModeRef:决定 openTab 的分支,不清则窗口期分支判断用旧值;
-  //  - setWorkspaceContext("",""):清 @octo/loop 的 http 层模块级 slug/id。这一步关键——
-  //    resolveAndPaint(showLoading=true) 不置 workspaceReady=false,从 emit 到重解析完成的
-  //    loading 窗口内 nav 按钮不禁用,用户此刻点 tab 会走 openTab;若 http 层仍留旧 slug,
-  //    RuntimePage 会用旧 slug 打 /runtimes(consistency group 内)→ 403 重现本 bug。
-  //    先把 http 作用域降为空(machine),窗口期任何请求都无 slug 发出、安全走 /machine-runtimes。
-  // 复位后 resolveAndPaint 重新 listWorkspaces:新 space 无 workspace 时自然落入 machine 空态。
-  useEffect(() => {
-    const onSpaceChanged = () => {
-      // Only the active page may touch the single shared right pane / http-layer
-      // workspace context. When backgrounded, do NOT clear the shared context
-      // (that would wipe the active Loop page's slug) — but still reset our own
-      // PRIVATE state and drop workspaceReady, so the reactivation window is
-      // gated by !workspaceReady (openTab bails) instead of letting a click
-      // write the old space's slug back → 403. Reactivation re-resolves via
-      // wk:nav-menu-activated (resolveRef.current(true)).
-      if (WKApp.currentMenuId !== "dmpersonal") {
-        selectedWsRef.current = null;
-        machineModeRef.current = false;
-        setWorkspaceReady(false);
-        return;
-      }
-      selectedWsRef.current = null;
-      machineModeRef.current = false;
-      setWorkspaceContext("", "");
-      // Gate the re-resolve window: openTab bails on !workspaceReady, so the
-      // Skills / runtime tabs cannot be opened against the old space's workspace
-      // scope until resolveAndPaint re-establishes the new space's selection.
-      setWorkspaceReady(false);
-      resolveRef.current(true);
-    };
-    WKApp.mittBus.on("space-changed", onSpaceChanged);
-    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
-  }, []);
+  const tabs = [
+    {
+      key: "runtime" as const,
+      icon: <Cpu size={16} />,
+      label: t("personal.nav.runtime"),
+    },
+    {
+      key: "skill" as const,
+      icon: <Sparkles size={16} />,
+      label: t("personal.nav.skill"),
+    },
+  ];
 
   return (
-    <div className="dmpersonal-sidebar">
-      <div className="dmpersonal-sidebar__title">
-        <span>{t("personal.menu.title")}</span>
-        <span className="dmpersonal-sidebar__beta">{t("personal.beta")}</span>
-      </div>
-      <nav className="dmpersonal-sidebar__menu">
-        {PERSONAL_TABS.map((item) => (
-          <button
-            key={item.key}
-            className={`dmpersonal-sidebar__item ${tab === item.key ? "is-active" : ""}`}
-            disabled={!workspaceReady || (machineMode && item.key === "skill")}
-            onClick={() => openTab(item.key)}
-          >
-            {item.icon}
-            <span>{t(`personal.nav.${item.key}`)}</span>
-          </button>
-        ))}
-      </nav>
-      {workspaceError && (
-        <div className="dmpersonal-sidebar__hint">{workspaceError}</div>
-      )}
-    </div>
-  );
-}
-
-function PersonalWorkspaceState({
-  icon,
-  title,
-  desc,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  desc?: string;
-}) {
-  return (
-    <div className="loop-page">
-      <div className="dmpersonal-state">
-        <div className="dmpersonal-state__icon">{icon}</div>
-        <div className="dmpersonal-state__title">{title}</div>
-        {desc && <div className="dmpersonal-state__desc">{desc}</div>}
-      </div>
-    </div>
+    <PersonalSidebarView
+      title={t("personal.menu.title")}
+      betaLabel={t("personal.beta")}
+      tabs={tabs}
+      activeTab={tab}
+      workspaceReady={workspaceReady}
+      machineMode={machineMode}
+      workspaceError={workspaceError}
+      onTabClick={openTab}
+    />
   );
 }

--- a/packages/dmpersonal/src/bridge/types.ts
+++ b/packages/dmpersonal/src/bridge/types.ts
@@ -1,0 +1,7 @@
+export type PersonalTabKey = "runtime" | "skill";
+
+export interface PersonalWorkspaceStateRenderArgs {
+  status: "loading" | "error";
+  title: string;
+  desc?: string;
+}

--- a/packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx
+++ b/packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  currentWorkspaceId,
+  resolveWorkspaceSelection,
+  setWorkspaceContext,
+  workspaceApi,
+} from "@octo/loop";
+import { WKApp } from "@octo/base";
+import type {
+  PersonalTabKey,
+  PersonalWorkspaceStateRenderArgs,
+} from "./types";
+
+export type {
+  PersonalTabKey,
+  PersonalWorkspaceStateRenderArgs,
+} from "./types";
+
+export interface UsePersonalWorkspaceOptions {
+  t: (key: string) => string;
+  renderTab: (key: PersonalTabKey) => JSX.Element;
+  renderWorkspaceState: (
+    args: PersonalWorkspaceStateRenderArgs
+  ) => JSX.Element;
+}
+
+export interface UsePersonalWorkspaceResult {
+  tab: PersonalTabKey;
+  workspaceReady: boolean;
+  workspaceError: string | null;
+  machineMode: boolean;
+  openTab: (key: PersonalTabKey) => void;
+}
+
+export function usePersonalWorkspace({
+  t,
+  renderTab,
+  renderWorkspaceState,
+}: UsePersonalWorkspaceOptions): UsePersonalWorkspaceResult {
+  const [tab, setTab] = useState<PersonalTabKey>("runtime");
+  const [workspaceReady, setWorkspaceReady] = useState(false);
+  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  // machine 模式(0 workspace)标记:machine 模式禁用 Skills、清空 workspace 作用域。
+  // 用 state 驱动 tab 禁用渲染,用 ref 供导航激活副作用同步读取。
+  const [machineMode, setMachineMode] = useState(false);
+  // Loop 与 Personal 共享 @octo/loop 里的模块级 workspace 全局。存下本页选定的 workspace,
+  // 以便在 tab 切换 / 导航再激活时重新断言,避免被 Loop 的选择污染(#619 评审)。
+  const selectedWsRef = useRef<{ slug: string; id: string } | null>(null);
+  const machineModeRef = useRef(false);
+  const tabRef = useRef<PersonalTabKey>("runtime");
+  tabRef.current = tab;
+  const mountedRef = useRef(true);
+  // 请求代号:resolveAndPaint 由导航事件驱动,快速切换可能并发多个 listWorkspaces;
+  // 每次进入自增,回来时若代号已过期就丢弃,保证"最后一次点击胜出"、不被慢的旧响应覆盖。
+  const resolveSeqRef = useRef(0);
+
+  // 解析当前 workspace 归属并铺右栏。每次调用都重新 listWorkspaces —— 本页常驻不重挂,
+  // 且 workspace 可能在别处(如 Loop)被创建/删除,machine↔workspace 模式必须每次重判,
+  // 不能沿用挂载时缓存的判断(#729 评审:否则建了 workspace 仍卡在 machine 模式)。
+  const resolveAndPaint = (showLoading: boolean) => {
+    const seq = ++resolveSeqRef.current;
+    if (showLoading) {
+      WKApp.routeRight.replaceToRoot(
+        renderWorkspaceState({
+          status: "loading",
+          title: t("personal.workspace.loading"),
+        })
+      );
+    }
+    workspaceApi
+      .listWorkspaces()
+      .then((workspaces) => {
+        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
+        // If the page was backgrounded before this resolve landed, don't write
+        // the shared pane/context (would clobber the now-active page). Bail;
+        // reactivation re-resolves via wk:nav-menu-activated (resolveRef).
+        if (WKApp.currentMenuId !== "dmpersonal") return;
+        // 优先用本页自己存的 workspace,仅当它不存在(如在别处被删)时才回落到共享全局。
+        // 直接读 currentWorkspaceId() 会让 Personal 跟随 Loop 最后选中的 workspace(#619 污染)。
+        const targetId = selectedWsRef.current?.id ?? currentWorkspaceId();
+        const selection = resolveWorkspaceSelection(workspaces, targetId);
+        if (selection.mode === "machine") {
+          // 0 workspace:机器级模式。清空 workspace 作用域(不发 x-workspace-slug),
+          // 运行时列表走 /machine-runtimes;Skills 需 workspace,禁用。
+          machineModeRef.current = true;
+          setMachineMode(true);
+          selectedWsRef.current = null;
+          setWorkspaceContext("", "");
+          // machine 模式禁用 Skills:若当前正停在 Skills tab,回落到 runtime。
+          if (tabRef.current === "skill") {
+            tabRef.current = "runtime";
+            setTab("runtime");
+          }
+        } else {
+          machineModeRef.current = false;
+          setMachineMode(false);
+          selectedWsRef.current = { slug: selection.slug, id: selection.id };
+          setWorkspaceContext(selection.slug, selection.id);
+        }
+        setWorkspaceReady(true);
+        setWorkspaceError(null);
+        WKApp.routeRight.replaceToRoot(renderTab(tabRef.current));
+      })
+      .catch((error) => {
+        if (!mountedRef.current || seq !== resolveSeqRef.current) return;
+        // Backgrounded before the failure landed → don't paint the shared pane.
+        if (WKApp.currentMenuId !== "dmpersonal") return;
+        const message = error?.message
+          ? String(error.message)
+          : t("personal.workspace.loadFailed");
+        setWorkspaceError(message);
+        setWorkspaceReady(false);
+        WKApp.routeRight.replaceToRoot(
+          renderWorkspaceState({
+            status: "error",
+            title: t("personal.workspace.loadFailed"),
+            desc: message,
+          })
+        );
+      });
+  };
+  // 始终指向最新的 resolveAndPaint,供 []-依赖的副作用调用(避免陈旧闭包,同时不让
+  // 副作用因 t 变化而重挂——对齐 LoopPage 的 mount-once 行为,切语言不闪回加载态)。
+  const resolveRef = useRef(resolveAndPaint);
+  resolveRef.current = resolveAndPaint;
+
+  const openTab = (key: PersonalTabKey) => {
+    if (!workspaceReady) return;
+    if (machineModeRef.current && key === "skill") return; // skill 需 workspace,机器级模式禁用
+    const ws = selectedWsRef.current;
+    if (machineModeRef.current) {
+      setWorkspaceContext("", "");
+    } else if (ws) {
+      setWorkspaceContext(ws.slug, ws.id);
+    }
+    setTab(key);
+    WKApp.routeRight.replaceToRoot(renderTab(key));
+  };
+
+  useEffect(() => {
+    mountedRef.current = true;
+    resolveRef.current(true);
+    return () => {
+      mountedRef.current = false;
+    };
+    // 只在挂载时跑一次(对齐 LoopPage):依赖 [t] 会让切语言时重跑,闪回加载态、丢失当前 tab/弹框。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 顶部一级导航「Personal」被再次点击时,onMenuClick 会先 popToRoot 清空右栏,且本页常驻不重挂
+  // (挂载副作用不会重跑)。这里监听激活事件:重新解析 workspace 归属(machine↔workspace 可能已变)
+  // 并铺回当前 tab,修复「切回后右栏空白」「用别处 workspace 上下文拉数据」以及「建 workspace 后
+  // 仍卡在机器级模式」(#729 评审)。
+  useEffect(() => {
+    const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
+      if (menuId !== "dmpersonal") return;
+      // showLoading=true:框架会先 popToRoot 清空右栏,重解析是异步的,先铺加载态避免空白闪一下。
+      resolveRef.current(true);
+    };
+    WKApp.mittBus.on("wk:nav-menu-activated", onNavMenuActivated);
+    return () =>
+      WKApp.mittBus.off("wk:nav-menu-activated", onNavMenuActivated);
+  }, []);
+
+  // 切换 octo space 时,本页存的 workspace 归属(selectedWsRef + @octo/loop 模块级
+  // workspace 全局)属于上一个 space,必须作废重判 —— 否则会带旧 workspace 作用域向新
+  // space 发 workspace 维度请求,撞后端 space 隔离闸门(workspace does not belong to
+  // this space / not a member of this space)。
+  //
+  // 三份 workspace 状态必须一起复位,缺一不可:
+  //  - selectedWsRef:本页自留、优先于共享全局的选择(#619 防污染),不清则重解析仍选中旧 ws;
+  //  - machineModeRef:决定 openTab 的分支,不清则窗口期分支判断用旧值;
+  //  - setWorkspaceContext("",""):清 @octo/loop 的 http 层模块级 slug/id。这一步关键——
+  //    resolveAndPaint(showLoading=true) 不置 workspaceReady=false,从 emit 到重解析完成的
+  //    loading 窗口内 nav 按钮不禁用,用户此刻点 tab 会走 openTab;若 http 层仍留旧 slug,
+  //    RuntimePage 会用旧 slug 打 /runtimes(consistency group 内)→ 403 重现本 bug。
+  //    先把 http 作用域降为空(machine),窗口期任何请求都无 slug 发出、安全走 /machine-runtimes。
+  // 复位后 resolveAndPaint 重新 listWorkspaces:新 space 无 workspace 时自然落入 machine 空态。
+  useEffect(() => {
+    const onSpaceChanged = () => {
+      // Only the active page may touch the single shared right pane / http-layer
+      // workspace context. When backgrounded, do NOT clear the shared context
+      // (that would wipe the active Loop page's slug) — but still reset our own
+      // PRIVATE state and drop workspaceReady, so the reactivation window is
+      // gated by !workspaceReady (openTab bails) instead of letting a click
+      // write the old space's slug back → 403. Reactivation re-resolves via
+      // wk:nav-menu-activated (resolveRef.current(true)).
+      if (WKApp.currentMenuId !== "dmpersonal") {
+        selectedWsRef.current = null;
+        machineModeRef.current = false;
+        setWorkspaceReady(false);
+        return;
+      }
+      selectedWsRef.current = null;
+      machineModeRef.current = false;
+      setWorkspaceContext("", "");
+      // Gate the re-resolve window: openTab bails on !workspaceReady, so the
+      // Skills / runtime tabs cannot be opened against the old space's workspace
+      // scope until resolveAndPaint re-establishes the new space's selection.
+      setWorkspaceReady(false);
+      resolveRef.current(true);
+    };
+    WKApp.mittBus.on("space-changed", onSpaceChanged);
+    return () => WKApp.mittBus.off("space-changed", onSpaceChanged);
+  }, []);
+
+  return {
+    tab,
+    workspaceReady,
+    workspaceError,
+    machineMode,
+    openTab,
+  };
+}

--- a/packages/dmpersonal/src/module.tsx
+++ b/packages/dmpersonal/src/module.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { WKApp, Menus, i18n, t as translate } from "@octo/base";
 import type { IModule } from "@octo/base";
+import { Cpu } from "lucide-react";
 import PersonalPage from "./PersonalPage";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
@@ -19,23 +20,7 @@ if (import.meta.hot) {
 function PersonalIcon({ active }: { active?: boolean }) {
   const color = active ? "var(--wk-brand-primary)" : "currentColor";
 
-  return (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke={color}
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M16 21v-2a4 4 0 00-4-4H7a4 4 0 00-4 4v2" />
-      <circle cx="9.5" cy="7" r="4" />
-      <path d="M22 21v-2a4 4 0 00-3-3.87" />
-      <path d="M16 3.13a4 4 0 010 7.75" />
-    </svg>
-  );
+  return <Cpu size={22} color={color} strokeWidth={2} />;
 }
 
 export default class PersonalModule implements IModule {

--- a/packages/dmpersonal/src/ui/PersonalSidebarView.stories.tsx
+++ b/packages/dmpersonal/src/ui/PersonalSidebarView.stories.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Cpu, Sparkles } from "lucide-react";
+import PersonalSidebarView from "./PersonalSidebarView";
+import "../personal.css";
+
+const tabs = [
+  {
+    key: "runtime" as const,
+    icon: <Cpu size={16} />,
+    label: "Runtime",
+  },
+  {
+    key: "skill" as const,
+    icon: <Sparkles size={16} />,
+    label: "Skill",
+  },
+];
+
+const meta = {
+  title: "Personal/PersonalSidebarView",
+  component: PersonalSidebarView,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Pure Personal sidebar presentation component. Workspace resolution, routeRight writes, and API access stay in the bridge layer.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 240, height: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    title: "Personal",
+    betaLabel: "Beta",
+    tabs,
+    activeTab: "runtime",
+    workspaceReady: true,
+    machineMode: false,
+    workspaceError: null,
+    onTabClick: () => undefined,
+  },
+} satisfies Meta<typeof PersonalSidebarView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SkillActive: Story = {
+  args: {
+    activeTab: "skill",
+  },
+};
+
+export const MachineMode: Story = {
+  args: {
+    machineMode: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    workspaceReady: false,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    workspaceReady: false,
+    workspaceError: "Failed to load workspace information.",
+  },
+};

--- a/packages/dmpersonal/src/ui/PersonalSidebarView.tsx
+++ b/packages/dmpersonal/src/ui/PersonalSidebarView.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import type { PersonalTabKey } from "../bridge/types";
+
+export interface PersonalSidebarTab {
+  key: PersonalTabKey;
+  icon: React.ReactNode;
+  label: string;
+}
+
+export interface PersonalSidebarViewProps {
+  title: string;
+  betaLabel: string;
+  tabs: PersonalSidebarTab[];
+  activeTab: PersonalTabKey;
+  workspaceReady: boolean;
+  machineMode: boolean;
+  workspaceError: string | null;
+  onTabClick: (key: PersonalTabKey) => void;
+}
+
+export default function PersonalSidebarView({
+  title,
+  betaLabel,
+  tabs,
+  activeTab,
+  workspaceReady,
+  machineMode,
+  workspaceError,
+  onTabClick,
+}: PersonalSidebarViewProps) {
+  return (
+    <div className="dmpersonal-sidebar">
+      <div className="dmpersonal-sidebar__title">
+        <span>{title}</span>
+        <span className="dmpersonal-sidebar__beta">{betaLabel}</span>
+      </div>
+      <nav className="dmpersonal-sidebar__menu">
+        {tabs.map((item) => (
+          <button
+            key={item.key}
+            className={`dmpersonal-sidebar__item ${
+              activeTab === item.key ? "is-active" : ""
+            }`}
+            disabled={!workspaceReady || (machineMode && item.key === "skill")}
+            onClick={() => onTabClick(item.key)}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+      {workspaceError && (
+        <div className="dmpersonal-sidebar__hint">{workspaceError}</div>
+      )}
+    </div>
+  );
+}

--- a/packages/dmpersonal/src/ui/PersonalWorkspaceState.stories.tsx
+++ b/packages/dmpersonal/src/ui/PersonalWorkspaceState.stories.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PersonalWorkspaceState from "./PersonalWorkspaceState";
+import "@octo/loop/src/pages/loop.css";
+import "../personal.css";
+
+const meta = {
+  title: "Personal/PersonalWorkspaceState",
+  component: PersonalWorkspaceState,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Pure Personal workspace state view. It renders bridge-provided loading or error state without reading app runtime context.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "100%", height: 520 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PersonalWorkspaceState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: {
+    status: "loading",
+    title: "Loading workspace...",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    status: "error",
+    title: "Failed to load workspace",
+    desc: "Check the current Space and retry.",
+  },
+};

--- a/packages/dmpersonal/src/ui/PersonalWorkspaceState.tsx
+++ b/packages/dmpersonal/src/ui/PersonalWorkspaceState.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { AlertCircle, Loader2 } from "lucide-react";
+import type { PersonalWorkspaceStateRenderArgs } from "../bridge/types";
+
+export default function PersonalWorkspaceState({
+  status,
+  title,
+  desc,
+}: PersonalWorkspaceStateRenderArgs) {
+  const icon =
+    status === "loading" ? <Loader2 size={36} /> : <AlertCircle size={40} />;
+
+  return (
+    <div className="loop-page">
+      <div className="dmpersonal-state">
+        <div className="dmpersonal-state__icon">{icon}</div>
+        <div className="dmpersonal-state__title">{title}</div>
+        {desc && <div className="dmpersonal-state__desc">{desc}</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Split Loop and Personal shell state into bridge hooks and presentational UI components.
- Add Loop issue deep links using `/fleet/{workspaceSlug}/issues/{issueIdentifier}` so chat and product links can open issue detail directly.
- Add module README notes, Storybook stories, and regression coverage for Space switching and issue deep links.

## Scope
- Loop workspace shell, issue detail URL sync, and issue deep-link capture/restore.
- Personal runtime shell standardization and workspace isolation against Loop workspace context.
- NavRail icon updates for Loop and Personal.

## Out of scope
- No Vite proxy, `.env`, or local server configuration changes.
- No private repository extraction or closed-source module split in this PR.
- Browser Back/Forward does not implement a full right-pane history model; this PR covers direct links, refresh, in-app issue opens, and detail return buttons.

## Risk areas
- Loop and Personal both coordinate with the shared `WKApp.routeRight` pane.
- Loop and Personal share the Loop workspace context, so Space switching and backgrounded pages need stale-write guards.
- Deep-link issue resolution is asynchronous; stale resolves are guarded by the Loop resolve sequence and active-menu check.

## Verification
- `git diff --check`
- `pnpm --dir apps/web exec vitest run src/__tests__/loopIssueDeepLink.test.ts src/__tests__/loopCliAuthorizeDeepLink.test.ts src/__tests__/personalPageSpaceChanged.test.ts`
- `pnpm --dir apps/web build`

Build completed with existing Vite/lottie/pdfjs/chunk-size warnings only.
