### PR TITLE
fix(docs): unify octo-doc html API URLs under /v1 so nginx needs a single /docs-html strip rewrite

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -105,34 +105,20 @@ server {
         }
 
         # ── octo-doc HTML: single unified prefix /docs-html/* ─────────────────────
-        # All web→octo-doc traffic is namespaced under ONE prefix (evaluator ask:
-        # the previously scattered top-level paths /d/, /comments, /reactions,
-        # /grants/, /docs-admin/, /docs/{slug}/versions used generic words that risk
-        # colliding with SPA / other service routes and are hard to govern). The
-        # frontend now prepends /docs-html (resolveOctoDocBase default); this block
-        # strips it and rewrites each sub-path to octo-doc's native route, then
-        # forwards to $doc_app_url with the octo `token` header for identity.
+        # All web→octo-doc traffic is namespaced under ONE prefix. The frontend now builds
+        # octo-doc's REAL backend paths under this prefix (resolveOctoDocBase + /v1/...):
+        #   /docs-html/v1/comments, /docs-html/v1/reactions, /docs-html/v1/docs/{slug}/grants,
+        #   /docs-html/v1/docs/{slug}, /docs-html/v1/docs/{slug}/versions, and the render page
+        #   /docs-html/d/{slug}/v/{ver}.
+        # So this block only STRIPS the /docs-html prefix and forwards the already-correct path
+        # to $doc_app_url with the octo `token` header for identity — no per-path alias rewrites.
         # resolver + runtime-variable proxy_pass: doc host resolves per-request, so an
         # unset/unresolvable DOC_APP_URL 503s this route instead of failing nginx startup.
-        # Rewrites are ordered most-specific-first; each ends in `break`.
         location /docs-html/ {
             resolver 127.0.0.11 ipv6=off valid=30s;
             if ($doc_app_url = "") { return 503 '{"status":503,"msg":"octo-doc is not configured"}'; }
-            # per-doc grants: /docs-html/grants/{slug}[/{uid}] → /v1/docs/{slug}/grants[/{uid}]
-            # ({uid} form must precede the bare form)
-            rewrite ^/docs-html/grants/([^/]+)/(.+)$ /v1/docs/$1/grants/$2 break;
-            rewrite ^/docs-html/grants/([^/]+)$       /v1/docs/$1/grants      break;
-            # doc admin (delete): /docs-html/docs-admin/{slug} → /v1/docs/{slug}
-            rewrite ^/docs-html/docs-admin/(.+)$      /v1/docs/$1             break;
-            # versions: /docs-html/docs/{slug}/versions → /v1/docs/{slug}/versions
-            rewrite ^/docs-html/docs/(.+)$            /v1/docs/$1            break;
-            # comments / reactions: /docs-html/comments… → /v1/comments…
-            rewrite ^/docs-html/comments(.*)$         /v1/comments$1         break;
-            rewrite ^/docs-html/reactions(.*)$        /v1/reactions$1        break;
-            # render page: /docs-html/d/{slug}/v/{ver} → /d/{slug}/v/{ver} (verbatim)
-            rewrite ^/docs-html/(d/.*)$               /$1                    break;
-            # anything else under the prefix: strip /docs-html, forward as-is
-            rewrite ^/docs-html/(.*)$                 /$1                    break;
+            # Single strip: /docs-html/<real-path> → /<real-path> (already /v1/... or d/...).
+            rewrite ^/docs-html/(.*)$ /$1 break;
             proxy_pass $doc_app_url;
             proxy_set_header token $http_token;
             proxy_set_header Host $host;

--- a/packages/docs/src/html/HtmlDocCommentPanel.test.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.test.tsx
@@ -146,7 +146,7 @@ describe('HtmlDocCommentPanel — list + compose (octo-doc data layer)', () => {
       string,
       RequestInit
     ]
-    expect(String(post[0])).toBe('https://od.test/comments')
+    expect(String(post[0])).toBe('https://od.test/v1/comments')
     const body = JSON.parse(String(post[1].body))
     expect(body).toMatchObject({
       slug: 'my-slug',

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -205,10 +205,12 @@ export interface HtmlDocViewProps {
  *      same bundle points at different octo-doc origins per environment without a rebuild.
  *   2. `import.meta.env.VITE_OCTO_DOC_BASE` — build-time override.
  *   3. Default `/docs-html` — a same-origin unified prefix. All web→octo-doc traffic
- *      (render `/d/…`, comments, reactions, grants, docs-admin, versions) is namespaced
+ *      (render `/d/…`, and the real backend paths `/v1/comments`, `/v1/reactions`,
+ *      `/v1/docs/{slug}/grants`, `/v1/docs/{slug}`, `/v1/docs/{slug}/versions`) is namespaced
  *      under this one prefix so it is easy to govern and cannot collide with SPA or other
- *      service routes. The web nginx reverse-proxies `/docs-html/*` to octo-doc (stripping
- *      the prefix). A deployment where octo-doc lives elsewhere sets one of the overrides above.
+ *      service routes. The web nginx strips `/docs-html/` with a single rewrite and forwards
+ *      the remaining real path to octo-doc. A deployment where octo-doc lives elsewhere sets
+ *      one of the overrides above.
  */
 export function resolveOctoDocBase(): string {
   const runtime =

--- a/packages/docs/src/html/htmlDocAdmin.ts
+++ b/packages/docs/src/html/htmlDocAdmin.ts
@@ -12,11 +12,11 @@ function octoDocHeaders(base: Record<string, string>): Record<string, string> {
   return tok ? { ...base, token: tok } : base
 }
 
-/** DELETE <base>/docs-admin/{slug} — remove the published doc (nginx rewrites to the doc's
- * /v1/docs/{slug} and attaches the octo token; the bare /v1/ path is proxied to octo-server,
- * which has no doc delete endpoint). Throws on a non-ok response. */
+/** DELETE <base>/v1/docs/{slug} — remove the published doc (nginx strips the /docs-html prefix
+ * and forwards to octo-doc's /v1/docs/{slug}, attaching the octo token). Throws on a non-ok
+ * response. */
 export async function deleteDoc(slug: string): Promise<void> {
-  const url = `${resolveOctoDocBase()}/docs-admin/${encodeURIComponent(slug)}`
+  const url = `${resolveOctoDocBase()}/v1/docs/${encodeURIComponent(slug)}`
   const res = await fetch(url, {
     method: 'DELETE',
     credentials: 'include',

--- a/packages/docs/src/html/htmlDocComments.test.ts
+++ b/packages/docs/src/html/htmlDocComments.test.ts
@@ -26,15 +26,15 @@ afterEach(() => {
 })
 
 describe('listComments (octo-doc backend)', () => {
-  it('GETs <base>/comments?slug&version with credentials and returns data', async () => {
+  it('GETs <base>/v1/comments?slug&version with credentials and returns data', async () => {
     const spy = stubFetch(() =>
       jsonResponse({ data: [{ id: 'c1', text: 'hi', replies: [] }] }),
     )
     const roots = await listComments('my-slug', 'v3')
     expect(roots).toHaveLength(1)
     expect(roots[0].id).toBe('c1')
-    // Hit the octo-doc /comments endpoint (resolveOctoDocBase), NOT /api/v1.
-    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/comments?slug=my-slug&version=v3')
+    // Hit the octo-doc /v1/comments endpoint (resolveOctoDocBase), NOT /api/v1.
+    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/v1/comments?slug=my-slug&version=v3')
     expect(spy.mock.calls[0][1]).toMatchObject({ credentials: 'include' })
   })
 
@@ -50,7 +50,7 @@ describe('listComments (octo-doc backend)', () => {
 })
 
 describe('createComment (octo-doc backend)', () => {
-  it('POSTs <base>/comments with {slug,text,version,anchor} and credentials', async () => {
+  it('POSTs <base>/v1/comments with {slug,text,version,anchor} and credentials', async () => {
     const spy = stubFetch(() => jsonResponse({ id: 'new1' }))
     const res = await createComment('my-slug', {
       text: 'please fix',
@@ -58,7 +58,7 @@ describe('createComment (octo-doc backend)', () => {
       anchor: { kind: 'element', aid: 'a42', selector: '[data-odoc-aid="a42"]', label: 'p' },
     })
     expect(res.id).toBe('new1')
-    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/comments')
+    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/v1/comments')
     const init = spy.mock.calls[0][1] as RequestInit
     expect(init.method).toBe('POST')
     expect(init.credentials).toBe('include')

--- a/packages/docs/src/html/htmlDocComments.ts
+++ b/packages/docs/src/html/htmlDocComments.ts
@@ -3,7 +3,7 @@
 // SEPARATE BACKEND: comments for an html doc live in octo-doc — the SAME distinct deployment
 // that serves the published HTML (see HtmlDocView.resolveOctoDocBase) — NOT the same-origin Yjs
 // `/api/v1` docs backend. So every call here is a raw `fetch` (credentials:'include' to carry the
-// octo-doc share-code cookie / write-token session) against resolveOctoDocBase() + `/comments`,
+// octo-doc share-code cookie / write-token session) against resolveOctoDocBase() + `/v1/comments`,
 // exactly like the read-only render fetch. This must never route through the octoweb apiClient.
 //
 // DISTINCT ANCHOR MODEL: octo-doc anchors are text/element descriptors (see Anchor below), a
@@ -87,19 +87,19 @@ export interface OctoDocCommentThread extends OctoDocComment {
   replies: OctoDocComment[]
 }
 
-/** GET /comments response: roots (each with its `replies`). */
+/** GET /v1/comments response: roots (each with its `replies`). */
 export interface ListCommentsResponse {
   roots: OctoDocCommentThread[]
 }
 
-/** POST /comments response: the created comment id. */
+/** POST /v1/comments response: the created comment id. */
 export interface CreateCommentResponse {
   id: string
 }
 
-/** Build `<octo-doc-base>/comments` — the single comment endpoint (verb differs GET vs POST). */
+/** Build `<octo-doc-base>/v1/comments` — the single comment endpoint (verb differs GET vs POST). */
 function commentsUrl(): string {
-  return `${resolveOctoDocBase()}/comments`
+  return `${resolveOctoDocBase()}/v1/comments`
 }
 
 /**

--- a/packages/docs/src/html/htmlDocVersions.test.ts
+++ b/packages/docs/src/html/htmlDocVersions.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 })
 
 describe('listVersions (octo-doc backend)', () => {
-  it('GETs <base>/docs/{slug}/versions and parses data.data.versions', async () => {
+  it('GETs <base>/v1/docs/{slug}/versions and parses data.data.versions', async () => {
     const spy = stubFetch(() =>
       jsonResponse({
         data: {
@@ -42,14 +42,14 @@ describe('listVersions (octo-doc backend)', () => {
     expect(versions).toHaveLength(2)
     expect(versions[0]).toMatchObject({ n: 3 })
     // PATH slug, not a query param; credentialed.
-    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/docs/my-slug/versions')
+    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/v1/docs/my-slug/versions')
     expect(spy.mock.calls[0][1]).toMatchObject({ credentials: 'include' })
   })
 
   it('encodes the slug in the path', async () => {
     const spy = stubFetch(() => jsonResponse({ data: { versions: [] } }))
     await listVersions('a/b?c')
-    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/docs/a%2Fb%3Fc/versions')
+    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/v1/docs/a%2Fb%3Fc/versions')
   })
 
   it('returns [] when the payload has no versions', async () => {
@@ -64,10 +64,10 @@ describe('listVersions (octo-doc backend)', () => {
 })
 
 describe('deleteDoc (octo-doc backend)', () => {
-  it('DELETEs <base>/docs-admin/{slug} with credentials', async () => {
+  it('DELETEs <base>/v1/docs/{slug} with credentials', async () => {
     const spy = stubFetch(() => jsonResponse({}, true, 204))
     await deleteDoc('my-slug')
-    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/docs-admin/my-slug')
+    expect(String(spy.mock.calls[0][0])).toBe('https://od.test/v1/docs/my-slug')
     const init = spy.mock.calls[0][1] as RequestInit
     expect(init.method).toBe('DELETE')
     expect(init.credentials).toBe('include')

--- a/packages/docs/src/html/htmlDocVersions.ts
+++ b/packages/docs/src/html/htmlDocVersions.ts
@@ -2,7 +2,7 @@
 //
 // SEPARATE BACKEND: like htmlDocComments, versions live in octo-doc (not the /api/v1 Yjs
 // backend), so this is a raw credentialed fetch against resolveOctoDocBase(). The version
-// list is addressed by a PATH slug — GET <base>/docs/{slug}/versions — per the octo-doc
+// list is addressed by a PATH slug — GET <base>/v1/docs/{slug}/versions — per the octo-doc
 // contract {data:{slug,title,versions:[{n,created_at}]}}, distinct from the query-param
 // /comments endpoint.
 
@@ -21,9 +21,9 @@ export interface HtmlDocVersion {
   created_at?: string | null
 }
 
-/** GET <base>/docs/{slug}/versions → published version numbers (newest-first per backend). */
+/** GET <base>/v1/docs/{slug}/versions → published version numbers (newest-first per backend). */
 export async function listVersions(slug: string): Promise<HtmlDocVersion[]> {
-  const url = `${resolveOctoDocBase()}/docs/${encodeURIComponent(slug)}/versions`
+  const url = `${resolveOctoDocBase()}/v1/docs/${encodeURIComponent(slug)}/versions`
   const res = await fetch(url, {
     credentials: 'include',
     headers: octoDocHeaders({ Accept: 'application/json' }),

--- a/packages/docs/src/html/htmlGrantsApi.ts
+++ b/packages/docs/src/html/htmlGrantsApi.ts
@@ -3,7 +3,7 @@
 // SEPARATE BACKEND: like htmlDocComments, grants for an html doc live in octo-doc
 // (the deployment that serves the published HTML), NOT the same-origin Yjs
 // `/api/v1` docs backend. Every call is a raw credentialed `fetch` against
-// resolveOctoDocBase() + `/grants`, carrying the octo `token` header so octo-doc
+// resolveOctoDocBase() + `/v1/docs/{slug}/grants`, carrying the octo `token` header so octo-doc
 // resolves the caller to the doc's author (only an author may manage grants).
 // This must never route through the octoweb apiClient.
 //
@@ -21,12 +21,11 @@ function grantHeaders(base: Record<string, string>): Record<string, string> {
   return tok ? { ...base, token: tok } : base
 }
 
-// Backend route is /v1/docs/{slug}/grants (+ /{uid} for DELETE). The web nginx
-// exposes it under a dedicated top-level /grants/{slug} prefix (NOT /docs/... —
-// that collides with the SPA's own /docs route) and rewrites it to the doc's
-// /v1/docs/{slug}/grants, forwarding the token header — same scheme as /comments.
+// Backend route is /v1/docs/{slug}/grants (+ /{uid} for DELETE). The web nginx now
+// forwards the /docs-html prefix through a single strip rewrite, so the frontend
+// builds the real backend path directly and carries the token header.
 function grantsUrl(slug: string): string {
-  return `${resolveOctoDocBase()}/grants/${encodeURIComponent(slug)}`
+  return `${resolveOctoDocBase()}/v1/docs/${encodeURIComponent(slug)}/grants`
 }
 
 /** One grant row, matching the rich-doc Member shape MemberPanel expects. */


### PR DESCRIPTION
## 背景 / 问题

octo-doc(HTML 文档系统) 的前端此前为「绕开 SPA 自己的 /docs 路由」自造了一批扁平化 URL 别名（`/docs-html/grants/{slug}`、`/docs-html/docs-admin/{slug}`、`/docs-html/docs/{slug}/versions`、`/docs-html/comments`…），逼得 web nginx 必须维护 **8 条 per-path rewrite** 把每个别名逐一翻译回 octo-doc 真实的 REST 结构。

后端 API 本身是标准 RESTful 层级设计（grants/versions 是 `/v1/docs/{slug}/子资源`，comments/reactions 是顶级 `/v1/...`），无需改动。问题只在前端别名层。

## 改动

**前端**：让所有 html-doc API 直接拼 octo-doc 的真实后端路径 `${base}/v1/...`：
- grants:   `${base}/grants/{slug}`        → `${base}/v1/docs/{slug}/grants` (+`/{uid}`)
- delete:   `${base}/docs-admin/{slug}`    → `${base}/v1/docs/{slug}`
- versions: `${base}/docs/{slug}/versions` → `${base}/v1/docs/{slug}/versions`
- comments: `${base}/comments`             → `${base}/v1/comments`
- render `/d/...` 路径不变

**nginx (`nginx.conf.template`)**：`/docs-html/*` 块从 8 条别名 rewrite 收敛为**单条 strip**：
```
rewrite ^/docs-html/(.*)$ /$1 break;
```
前缀剥掉后即为已正确的 `/v1/...`（或 `d/...`），带 `token` 头转发给 `$doc_app_url`。

## 验证
- docs 包 `vitest run` **84 tests 全绿**（断言同步更新为新 URL）。
- 本地增量重建镜像+容器(3001)自测：首页 200；`/docs-html/v1/comments`、`/docs-html/v1/docs/{slug}/grants`、`/docs-html/d/...` 均正确经单条 rewrite 透传到 doc-app 后端（返回 doc 的业务 JSON，非 SPA index.html），与直连 doc-app 一致。

## 部署前提 / 必配环境变量（web 容器）
本 PR 不新增环境变量，沿用现有：
- `DOC_APP_URL`（如 `http://doc-app:8080`）—— octo-doc 上游。**不配则 `/docs-html/*` 返回 503**（模板内 `if ($doc_app_url = "")` 守卫，不会 fatal nginx，但 html 文档全不可用）。
- `DOCS_BACKEND_URL` / `API_URL` —— 既有，未改。

## 兼容性
- 后端 octo-doc **零改动**。
- 前后端需同版本部署：前端拼 `/v1/...` + nginx 单条 strip 必须配套。旧前端(裸别名) 配新 nginx，或反之，会 404。建议前端产物与 nginx.conf.template 同批发布。