### PR TITLE
feat(summary): increase template content limit

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -8,13 +8,13 @@ import type { TopicTemplate, ChatCandidate, ScheduleConfig, CreateAgentSummaryPa
 import { SourceType, SummaryMode } from '../types/summary';
 import { getSourceType, getOriginChannelType } from '../utils/channelType';
 import { channelToChatCandidate } from '../utils/channelConvert';
-import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, type ResolvableTemplate } from '../utils/templateResolver';
+import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from '../utils/templateResolver';
 
 import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession } from '../utils/summaryHelpers';
 import * as summaryApi from '../api/summaryApi';
 import { getTopicTemplatesConfig } from '../api/summaryApi';
 import { TOPIC_TEMPLATES } from '../constants/templates';
-import { MAX_CHAT_SELECT } from '../constants/limits';
+import { MAX_CHAT_SELECT, SUMMARY_INPUT_MAX_LENGTH, TEMPLATE_CONTENT_MAX_LENGTH, TEMPLATE_NAME_MAX_LENGTH } from '../constants/limits';
 import TemplateCard from './TemplateCard';
 import AgentChatPanel from './AgentChatPanel';
 import ChatSelectorModal from './ChatSelectorModal';
@@ -67,18 +67,30 @@ export default class ChatSummaryNewModal extends Component<
         mode: ReplaceMode,
         savedRange?: SelectionRange
     ) => {
+        const limitTopic = (topic: string, appliedTemplateLabel: string) => appliedTemplateLabel
+            ? limitTemplateSummaryContent(topic, TEMPLATE_CONTENT_MAX_LENGTH)
+            : topic.slice(0, SUMMARY_INPUT_MAX_LENGTH);
         if (mode === 'all') {
-            this.setState({ topic: text, templatePlaceholderRange: null });
+            this.setState((prev) => ({
+                topic: limitTopic(text, prev.appliedTemplateLabel),
+                templatePlaceholderRange: null,
+            }));
         } else if (mode === 'selection' && savedRange) {
             this.setState((prev) => ({
-                topic: prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to),
+                topic: limitTopic(
+                    prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to),
+                    prev.appliedTemplateLabel,
+                ),
                 templatePlaceholderRange: null,
             }));
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.topic.length;
                 return {
-                    topic: prev.topic.slice(0, pos) + text + prev.topic.slice(pos),
+                    topic: limitTopic(
+                        prev.topic.slice(0, pos) + text + prev.topic.slice(pos),
+                        prev.appliedTemplateLabel,
+                    ),
                     templatePlaceholderRange: null,
                 };
             });
@@ -780,7 +792,13 @@ export default class ChatSummaryNewModal extends Component<
                                         className="chat-summary-modal-input"
                                         placeholder={t('summary.create.topicPlaceholderInChat')}
                                         value={topic}
-                                        onChange={(e) => this.setState({ topic: e.target.value, templatePlaceholderRange: null })}
+                                        onChange={(e) => {
+                                            const nextTopic = appliedTemplateLabel
+                                                ? limitTemplateSummaryContent(e.target.value, TEMPLATE_CONTENT_MAX_LENGTH)
+                                                : e.target.value.slice(0, SUMMARY_INPUT_MAX_LENGTH);
+                                            this.setState({ topic: nextTopic, templatePlaceholderRange: null });
+                                        }}
+                                        maxLength={appliedTemplateLabel ? undefined : SUMMARY_INPUT_MAX_LENGTH}
                                         onFocus={this.handleInputFocus}
                                         onKeyDown={(e) => {
                                             if (e.key === 'Enter' && !e.shiftKey && !submitting) {
@@ -1006,10 +1024,10 @@ export default class ChatSummaryNewModal extends Component<
                         <input
                             className="summary-template-edit-input"
                             value={editingTemplateLabel}
-                            maxLength={100}
+                            maxLength={TEMPLATE_NAME_MAX_LENGTH}
                             disabled={savingTemplate}
                             placeholder={t('summary.templates.custom.namePlaceholder')}
-                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 100) })}
+                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, TEMPLATE_NAME_MAX_LENGTH) })}
                         />
                     </div>
                     <div className="summary-template-edit-field">
@@ -1019,10 +1037,10 @@ export default class ChatSummaryNewModal extends Component<
                         <textarea
                             className="summary-template-edit-input summary-template-edit-desc"
                             value={editingTemplateDescription}
-                            maxLength={200}
+                            maxLength={TEMPLATE_CONTENT_MAX_LENGTH}
                             disabled={savingTemplate}
                             placeholder={t('summary.templates.custom.descriptionPlaceholder')}
-                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 200) })}
+                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, TEMPLATE_CONTENT_MAX_LENGTH) })}
                         />
                     </div>
                     <div className="summary-template-edit-hint">

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -154,6 +154,66 @@ describe('ChatSummaryNewModal', () => {
         expect(screen.getByTestId('template-chat_content')).toBeInTheDocument();
     });
 
+    it('allows up to 2000 characters in custom template summary content', async () => {
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        fireEvent.click(screen.getByText('新建模板'));
+        const textarea = screen.getByPlaceholderText('例如：总结任务的进度和负责人') as HTMLTextAreaElement;
+        expect(textarea.maxLength).toBe(2000);
+
+        fireEvent.change(textarea, { target: { value: '总'.repeat(2001) } });
+        expect(textarea.value).toHaveLength(2000);
+    });
+
+    it('caps voice insertion at the 2000-character summary input limit', () => {
+        const modal = new ChatSummaryNewModal(defaultProps as any);
+        (modal as any).setState = function (this: any, patch: any) {
+            this.state = { ...this.state, ...(typeof patch === 'function' ? patch(this.state) : patch) };
+        };
+        modal.state = { ...modal.state, topic: '总'.repeat(1999), appliedTemplateLabel: '' };
+
+        (modal as any).handleVoiceTranscribed('语音内容', 'insert', { from: 1999, to: 1999 });
+
+        expect(modal.state.topic).toHaveLength(2000);
+        expect(modal.state.topic.endsWith('语')).toBe(true);
+    });
+
+    it('preserves a max-length template description when applying and submitting it', async () => {
+        const paragraphs = '第一段\n\n第二段\n';
+        const description = paragraphs + '总'.repeat(2000 - paragraphs.length);
+        vi.mocked(summaryApi.getTopicTemplatesConfig).mockResolvedValueOnce({ custom_template_limit: 30, templates: [
+            { id: 'custom_long', label: '长内容模板', icon: 'FileText', description, type: 'fixed', pattern: description, is_custom: true },
+        ] } as any);
+
+        await act(async () => {
+            render(<ChatSummaryNewModal {...defaultProps} />);
+            await flushPromises();
+        });
+
+        fireEvent.click(screen.getByTestId('template-custom_long'));
+        const textarea = screen.getByPlaceholderText('输入聊天内你想总结的主题') as HTMLTextAreaElement;
+        expect(textarea.value).toContain(description);
+        expect(textarea.value.length).toBeGreaterThan(1000);
+        const editedDescription = `已${description.slice(1)}`;
+        fireEvent.change(textarea, { target: { value: textarea.value.replace(description, editedDescription) } });
+        expect(textarea.value).toContain(editedDescription);
+        const submittedTopic = textarea.value;
+
+        await act(async () => {
+            const submit = document.querySelector('.chat-summary-modal-footer .chat-summary-modal-split > button') as HTMLButtonElement;
+            fireEvent.click(submit);
+            await flushPromises();
+        });
+
+        expect(summaryApi.createSummary).toHaveBeenCalledWith(expect.objectContaining({
+            topic: submittedTopic,
+            title: '已一段',
+        }));
+    });
+
     it('hides templates when input has content', async () => {
         await act(async () => {
             render(<ChatSummaryNewModal {...defaultProps} />);
@@ -181,6 +241,7 @@ describe('ChatSummaryNewModal', () => {
         expect(screen.getByText('试试这些总结模板')).toBeInTheDocument();
         expect(screen.getByTestId('template-weekly_report')).toBeInTheDocument();
     });
+
 
     it('renders templates inside the unified input-area container', async () => {
         await act(async () => {

--- a/packages/dmworksummary/src/constants/limits.ts
+++ b/packages/dmworksummary/src/constants/limits.ts
@@ -1,2 +1,11 @@
 /** Max number of chats a user can select as sources for a summary. */
 export const MAX_CHAT_SELECT = 30;
+
+/** Max number of characters allowed in a summary template name. */
+export const TEMPLATE_NAME_MAX_LENGTH = 100;
+
+/** Max number of characters allowed in fixed/custom template summary content. */
+export const TEMPLATE_CONTENT_MAX_LENGTH = 2000;
+
+/** Max number of characters users can enter as summary instructions. */
+export const SUMMARY_INPUT_MAX_LENGTH = 2000;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -27,7 +27,7 @@ import SummaryReferencePicker from "../components/SummaryReferencePicker";
 import SummaryPreviewModal from "../components/SummaryPreviewModal";
 import SummaryReferenceSidePanel from "../components/SummaryReferenceSidePanel";
 import { TOPIC_TEMPLATES } from "../constants/templates";
-import { MAX_CHAT_SELECT } from "../constants/limits";
+import { MAX_CHAT_SELECT, SUMMARY_INPUT_MAX_LENGTH, TEMPLATE_CONTENT_MAX_LENGTH, TEMPLATE_NAME_MAX_LENGTH } from "../constants/limits";
 import type {
     CreateSummaryParams,
     ChatMessage,
@@ -40,7 +40,7 @@ import type {
 } from "../types/summary";
 import { SummaryMode, SourceType } from "../types/summary";
 import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession, readAgentChatReferenced, writeAgentChatReferenced, clearAgentChatReferenced } from "../utils/summaryHelpers";
-import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, type ResolvableTemplate } from "../utils/templateResolver";
+import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from "../utils/templateResolver";
 
 const { Text } = Typography;
 
@@ -392,18 +392,29 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     handleVoiceTranscribed = (text: string, mode: ReplaceMode, savedRange?: SelectionRange) => {
         if (mode === "all") {
-            this.setState({ topic: text.slice(0, 1000) }, this.autoResizeTextarea);
+            const topic = this.state.appliedTemplateLabel
+                ? limitTemplateSummaryContent(text, TEMPLATE_CONTENT_MAX_LENGTH)
+                : text.slice(0, SUMMARY_INPUT_MAX_LENGTH);
+            this.setState({ topic }, this.autoResizeTextarea);
         } else if (mode === "selection" && savedRange) {
             // Note: savedRange indices are from recording start; assumes input is read-only during recording
             this.setState((prev) => {
                 const updated = prev.topic.slice(0, savedRange.from) + text + prev.topic.slice(savedRange.to);
-                return { topic: updated.slice(0, 1000) };
+                return {
+                    topic: prev.appliedTemplateLabel
+                        ? limitTemplateSummaryContent(updated, TEMPLATE_CONTENT_MAX_LENGTH)
+                        : updated.slice(0, SUMMARY_INPUT_MAX_LENGTH),
+                };
             }, this.autoResizeTextarea);
         } else {
             this.setState((prev) => {
                 const pos = savedRange?.from ?? prev.topic.length;
                 const updated = prev.topic.slice(0, pos) + text + prev.topic.slice(pos);
-                return { topic: updated.slice(0, 1000) };
+                return {
+                    topic: prev.appliedTemplateLabel
+                        ? limitTemplateSummaryContent(updated, TEMPLATE_CONTENT_MAX_LENGTH)
+                        : updated.slice(0, SUMMARY_INPUT_MAX_LENGTH),
+                };
             }, this.autoResizeTextarea);
         }
     };
@@ -909,7 +920,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             className="summary-workbench-textarea"
                             value={topic}
                             onChange={(e) => {
-                                this.setState({ topic: e.target.value.slice(0, 1000), templatePlaceholderRange: null });
+                                const nextTopic = appliedTemplateLabel
+                                    ? limitTemplateSummaryContent(e.target.value, TEMPLATE_CONTENT_MAX_LENGTH)
+                                    : e.target.value.slice(0, SUMMARY_INPUT_MAX_LENGTH);
+                                this.setState({ topic: nextTopic, templatePlaceholderRange: null });
                                 this.autoResizeTextarea();
                             }}
                             onFocus={this.handleInputFocus}
@@ -917,7 +931,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                 ? translate("summary.create.agentTopicPlaceholder")
                                 : translate("summary.create.topicPlaceholder")}
                             rows={3}
-                            maxLength={1000}
+                            maxLength={appliedTemplateLabel ? undefined : SUMMARY_INPUT_MAX_LENGTH}
                         />
                         <VoiceInputButton
                             inputRef={this.textareaRef}
@@ -929,11 +943,11 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         />
                     </div>
                     <div className="summary-workbench-char-count">
-                        {topic.length}/1000
+                        {topic.length}/{SUMMARY_INPUT_MAX_LENGTH}
                     </div>
-                    {topic.length >= 1000 && (
+                    {topic.length >= SUMMARY_INPUT_MAX_LENGTH && (
                         <div style={{ color: "var(--semi-color-warning)", fontSize: 12, marginTop: 4, padding: "0 16px 8px" }}>
-                            {translate("summary.common.charLimitReached", { values: { count: 1000 } })}
+                            {translate("summary.common.charLimitReached", { values: { count: SUMMARY_INPUT_MAX_LENGTH } })}
                         </div>
                     )}
                     {topic.trim() && appliedTemplateLabel && (
@@ -1199,10 +1213,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         <input
                             className="summary-template-edit-input"
                             value={editingTemplateLabel}
-                            maxLength={100}
+                            maxLength={TEMPLATE_NAME_MAX_LENGTH}
                             disabled={savingTemplate}
                             placeholder={translate("summary.templates.custom.namePlaceholder")}
-                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, 100) })}
+                            onChange={(e) => this.setState({ editingTemplateLabel: e.target.value.slice(0, TEMPLATE_NAME_MAX_LENGTH) })}
                         />
                     </div>
                     <div className="summary-template-edit-field">
@@ -1212,10 +1226,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         <textarea
                             className="summary-template-edit-input summary-template-edit-desc"
                             value={editingTemplateDescription}
-                            maxLength={200}
+                            maxLength={TEMPLATE_CONTENT_MAX_LENGTH}
                             disabled={savingTemplate}
                             placeholder={translate("summary.templates.custom.descriptionPlaceholder")}
-                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, 200) })}
+                            onChange={(e) => this.setState({ editingTemplateDescription: e.target.value.slice(0, TEMPLATE_CONTENT_MAX_LENGTH) })}
                         />
                     </div>
                     <div className="summary-template-edit-hint">

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -18,6 +18,7 @@ import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/Voic
 import { splitSummaryText } from "../utils/splitMessage";
 import SummaryConfirmPage from "./SummaryConfirmPage";
 import * as api from "../api/summaryApi";
+import { SUMMARY_INPUT_MAX_LENGTH } from "../constants/limits";
 // RefineSection 已移除 — 反馈修改改为在智能总结 chat 里引用总结迭代
 // (见 CHAT-REFERENCE-BASED-DESIGN-v1)
 import OverflowTooltip from "../components/OverflowTooltip";
@@ -148,12 +149,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         savedRange?: SelectionRange
     ) => {
         if (mode === "all") {
-            this.setState({ regenerateTopic: text.slice(0, 1000) });
+            this.setState({ regenerateTopic: text.slice(0, SUMMARY_INPUT_MAX_LENGTH) });
         } else if (mode === "selection" && savedRange) {
             this.setState((prev) => {
                 const before = prev.regenerateTopic.slice(0, savedRange.from);
                 const after = prev.regenerateTopic.slice(savedRange.to);
-                const budget = Math.max(0, 1000 - before.length - after.length);
+                const budget = Math.max(0, SUMMARY_INPUT_MAX_LENGTH - before.length - after.length);
                 return { regenerateTopic: before + text.slice(0, budget) + after };
             });
         } else {
@@ -161,7 +162,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 const pos = savedRange?.from ?? prev.regenerateTopic.length;
                 const before = prev.regenerateTopic.slice(0, pos);
                 const after = prev.regenerateTopic.slice(pos);
-                const budget = Math.max(0, 1000 - before.length - after.length);
+                const budget = Math.max(0, SUMMARY_INPUT_MAX_LENGTH - before.length - after.length);
                 return { regenerateTopic: before + text.slice(0, budget) + after };
             });
         }
@@ -3628,9 +3629,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                     aria-labelledby="regenerate-topic-label"
                                     className="summary-regenerate-topic-textarea"
                                     rows={3}
-                                    maxLength={1000}
+                                    maxLength={SUMMARY_INPUT_MAX_LENGTH}
                                     value={this.state.regenerateTopic}
-                                    onChange={(e) => this.setState({ regenerateTopic: e.target.value.slice(0, 1000) })}
+                                    onChange={(e) => this.setState({ regenerateTopic: e.target.value.slice(0, SUMMARY_INPUT_MAX_LENGTH) })}
                                 />
                                 <VoiceInputButton
                                     inputRef={this.regenerateTopicRef}

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -191,6 +191,61 @@ describe('SummaryCreatePage templates', () => {
         expect(screen.getByText('新建模板').closest('button')).toBeDisabled();
     });
 
+    it('allows up to 2000 characters in template summary content', async () => {
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        fireEvent.click(screen.getByText('新建模板'));
+        const textarea = screen.getByPlaceholderText('例如：总结任务的进度和负责人') as HTMLTextAreaElement;
+        expect(textarea.maxLength).toBe(2000);
+
+        fireEvent.change(textarea, { target: { value: '总'.repeat(2001) } });
+        expect(textarea.value).toHaveLength(2000);
+    });
+
+    it('preserves a max-length template description when applying and submitting it', async () => {
+        const pageRef = React.createRef<SummaryCreatePage>();
+        const paragraphs = '第一段\n\n第二段\n';
+        const description = paragraphs + '总'.repeat(2000 - paragraphs.length);
+        vi.mocked(getTopicTemplatesConfig).mockResolvedValueOnce({ custom_template_limit: 30, templates: [
+            { id: 'custom_long', label: '长内容模板', icon: 'FileText', description, type: 'fixed', pattern: description, is_custom: true },
+        ] });
+
+        await act(async () => {
+            render(<SummaryCreatePage ref={pageRef} />);
+            await flushPromises();
+        });
+
+        fireEvent.click(screen.getByText('长内容模板'));
+        const textarea = document.querySelector('.summary-workbench-textarea') as HTMLTextAreaElement;
+        expect(textarea.value).toContain(description);
+        expect(textarea.value.length).toBeGreaterThan(1000);
+        const editedDescription = `已${description.slice(1)}`;
+        fireEvent.change(textarea, { target: { value: textarea.value.replace(description, editedDescription) } });
+        expect(textarea.value).toContain(editedDescription);
+
+        const voiceEditAt = textarea.value.indexOf(editedDescription) + 1;
+        await act(async () => {
+            pageRef.current?.handleVoiceTranscribed('语', 'selection', { from: voiceEditAt, to: voiceEditAt + 1 });
+        });
+        const voiceEditedDescription = `已语${editedDescription.slice(2)}`;
+        expect(textarea.value).toContain(voiceEditedDescription);
+        const submittedTopic = textarea.value;
+
+        await act(async () => {
+            const submit = document.querySelector('.summary-workbench-actions .chat-summary-modal-split > button') as HTMLButtonElement;
+            fireEvent.click(submit);
+            await flushPromises();
+        });
+
+        expect(api.createSummary).toHaveBeenCalledWith(expect.objectContaining({
+            topic: submittedTopic,
+            title: '已语段',
+        }));
+    });
+
 });
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
@@ -65,6 +65,16 @@ function makePage(taskId: number | string) {
     return page;
 }
 
+it('keeps regeneration voice insertion within the 2000-character limit', () => {
+    const page = makePage(1);
+    page.state = { ...page.state, regenerateTopic: '总'.repeat(1999) };
+
+    (page as any).handleRegenerateTopicVoice('语音内容', 'insert', { from: 1999, to: 1999 });
+
+    expect(page.state.regenerateTopic).toHaveLength(2000);
+    expect(page.state.regenerateTopic.endsWith('语')).toBe(true);
+});
+
 const baseDetail = (over: any = {}) => ({
     task_id: 1,
     task_no: 'T1',

--- a/packages/dmworksummary/src/utils/__tests__/templateResolver.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/templateResolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle } from '../templateResolver';
-import { TOPIC_TEMPLATES } from '../../constants/templates';
+import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent } from '../templateResolver';
 import type { TopicTemplate } from '../../types/summary';
+import { TOPIC_TEMPLATES } from '../../constants/templates';
 
 // 读 zh-CN 资源的简易 t（与 dmworkBase mock 行为一致）：把 `summary.<path>` 映射到明文。
 import zhCN from '../../i18n/zh-CN.json';
@@ -109,6 +109,14 @@ describe('deriveSummaryTitle', () => {
     });
 });
 
+describe('limitTemplateSummaryContent', () => {
+    it('preserves framing and limits only the summary content', () => {
+        const framing = '总结主题: 周报\n内容重点: ';
+        expect(limitTemplateSummaryContent(framing + '总'.repeat(2001), 2000))
+            .toBe(framing + '总'.repeat(2000));
+    });
+});
+
 describe('computeTemplateSelection', () => {
     it('locates the placeholder token for legacy parameterized templates', () => {
         const legacy: TopicTemplate = {
@@ -173,4 +181,5 @@ describe('computeTemplateSelection', () => {
         expect(text).toBe('总结主题: 任务划分总结\n内容重点: 每个任务都是谁负责，什么进度');
         expect(range).toBeNull();
     });
+
 });

--- a/packages/dmworksummary/src/utils/templateResolver.ts
+++ b/packages/dmworksummary/src/utils/templateResolver.ts
@@ -33,6 +33,14 @@ export function deriveSummaryTitle(topic: string): string {
     return (match?.[2] || source).trim();
 }
 
+/** Keep template framing visible while limiting only the editable summary content. */
+export function limitTemplateSummaryContent(topic: string, maxLength: number): string {
+    const contentMatch = /(?:^|\n)(?:内容重点|总结内容|Content focus|Summary content)\s*[:：]\s*/i.exec(topic);
+    if (!contentMatch) return topic.slice(0, maxLength);
+    const contentStart = contentMatch.index + contentMatch[0].length;
+    return topic.slice(0, contentStart) + topic.slice(contentStart).slice(0, maxLength);
+}
+
 /** 以 `labelKey` 是否存在判别是否为前端兜底（需解析 i18n key）类型。 */
 function isLocalTemplate(template: ResolvableTemplate): template is LocalTopicTemplate {
     return typeof (template as LocalTopicTemplate).labelKey === 'string';


### PR DESCRIPTION
## Summary

Increase smart-summary template content from 200 to 2000 characters for both built-in template overrides and custom templates while preserving the existing template display and submission format.

## Related Issue

Fixes #899

## Changes

- Add shared constants for the 100-character template name limit and 2000-character template content limit.
- Apply the 2000-character content limit in the summary workbench and chat summary modal.
- Preserve the existing `总结主题 / 内容重点` framing, topic payload, and title behavior.
- Limit only the template content when editing an applied template, so framing text does not truncate valid content.
- Add boundary and apply-edit-submit coverage for both template entry points.

## Backend Compatibility

The companion service change in Mininglamp-OSS/octo-smart-summary#163 expands template `description` validation and storage to 2000 Unicode characters. It also expands the summary `topic` safety limit and the task/schedule title storage to 2300 Unicode characters, safely accommodating a 2000-character description, a 100-character template name, and the existing localized framing labels.

Deploy the service change and its database migrations before or together with this frontend change.

## Architecture / Module Boundary

- Affected module(s): dmworksummary
- New or changed user-visible entry point: no
- Shared layer touched: summary template utilities and limits
- Impact scope: summary workbench and chat summary modal only
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Template content accepts 2000 characters and rejects overflow
- [x] Applied 2000-character content remains intact after editing
- [x] Existing template display and submission format remain unchanged
- [x] Existing textarea vertical-scroll behavior remains unchanged

## Checklist

- [x] PR description is in English
- [x] Added tests for the changes
- [x] Confirmed the change does not alter UI copy or add a new entry point
- [x] Followed Conventional Commits

