### PR TITLE
fix(docs): open forwarded HTML docs via path-style /d link + record recent view

### DIFF
--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import DOMPurify from 'dompurify'
 import { canForwardToChat, openDocForward, t, getWKApp } from '../octoweb/index.ts'
+import { buildDocLink } from '../forward/link.ts'
 import { HtmlDocCommentPanel } from './HtmlDocCommentPanel.tsx'
 import { HtmlMemberPanel } from './HtmlMemberPanel.tsx'
 import { HtmlPresenceBar } from './HtmlPresenceBar.tsx'
@@ -305,12 +306,13 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
   // Author-only affordances (member management, delete) gate on the backend flag, never on uid math.
   const creatorUid = meta?.creator_uid
   const canManage = isAuthor
-  // Browser-openable address for this doc (new-page / forward). window.location keeps whatever
-  // route the viewer is on; buildOctoDocUrl is the canonical /d/{slug}/v/{version} fallback.
-  const docUrl =
-    typeof window !== 'undefined' && window.location?.href
-      ? window.location.href
-      : buildOctoDocUrl(effectiveSlug, version)
+  // Browser-openable address for forwarding this doc to chat. Build the PATH-style standalone
+  // link (/d/<docId>?sp=<space>) like every other kind (buildDocLink), NOT window.location.href:
+  // the in-shell address is the legacy /docs?doc= query form, whose docId is wiped by the host's
+  // pathname-only route re-push, so a forwarded query link lands the recipient on the wrong page.
+  // The path form carries the docId in the path (survives the re-push), routes through
+  // StandaloneDocPage's html branch (reader preflight + auto recordDocView), and needs no JS rescue.
+  const docUrl = buildDocLink({ docId, space })
   const canForward = canForwardToChat()
 
   const doForward = useCallback(() => {

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -3,6 +3,7 @@ import { getWKApp, t } from '../octoweb/index.ts'
 import { EditorShell } from '../editor/EditorShell.tsx'
 import { SheetView } from '../sheet/SheetView.tsx'
 import { BoardSession } from '../board/BoardSession.tsx'
+import { HtmlDocView } from '../html/HtmlDocView.tsx'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { LinkIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
@@ -590,6 +591,23 @@ export function StandaloneDocPage({
   // that isn't an explicit `'board'` falls through to the rich-text editor (the safe default for
   // plain docs and legacy backends that omit docType). This mirrors DocsHome's buildRightPane
   // dispatch so both open paths agree on the shell for every member.
+  // Read-only HTML doc ('html'): render the view-only HtmlDocView (its content lives in octo-doc,
+  // not the yjs collab store), mirroring DocsHome.buildRightPane. Without this branch an html doc
+  // falls through to the collab EditorShell, which has no yjs data for it and reports "not found".
+  // The preflight already ran (reader gate) and recordDocView above logged the view, so a shared
+  // /d/<docId> html link opens AND lands in "recently viewed" like every other kind.
+  if (meta.docType === 'html') {
+    return (
+      <div className="octo-doc-standalone">
+        <HtmlDocView
+          key={editorDocId}
+          docId={editorDocId}
+          slug={meta.octoDocSlug}
+          space={addressing.space}
+        />
+      </div>
+    )
+  }
   if (meta.docType === 'board') {
     // The whiteboard {board} segment is BoardSession's `docId` (it becomes octo:{space}:{folder}:
     // wb:{board}). Prefer the authoritative segment parsed from the preflight documentName so the


### PR DESCRIPTION
## 背景 / 问题

HTML 文档转发到聊天用的是 in-shell 的 `/docs?doc=` query 式链接，其 docId 会被宿主 RouteManager 的 pathname-only re-push 抹掉；收件人落到的页面把 HTML 分发进了协同编辑器（EditorShell），而 HTML 文档没有 yjs 协同数据 → 报「文档不存在或已被删除」。

对照：普通 doc 用路径式 `/d/<docId>?sp=` 能正常打开（docId 在路径里，survive re-push；StandaloneDocPage 有对应分流）。HTML 缺的就是这套。

## 改动（纯前端，2 处，1 commit）

1. **StandaloneDocPage 加 `docType === 'html'` 分支** → 挂只读 `HtmlDocView`（HTML 正文在 octo-doc，不在 yjs store）。原来 html 掉进 EditorShell 报「不存在」。preflight（reader gate）已跑、ready 阶段的 `recordDocView` 无条件触发，所以 `/d/<docId>` html 链现在也进「最近查看」——零额外接线。

2. **HtmlDocView 转发链改用 `buildDocLink`**（路径式 `/d/<docId>?sp=<space>`），替代 `window.location.href`（旧 query 式）。docId 走路径不被抹、路由进上面的 html 分支、reader 开链得 preflight + 自动最近查看、不依赖 JS deep-link 兜底。

## 验证
- docs 包 `vitest run` **155 tests 全绿**（StandaloneDocPage 54 + HtmlDocView 48 等），改动文件 typecheck 零错。
- 本地增量重建镜像+容器(3002)自测：nginx 合法、首页 200、`/docs-html/v1/comments` 单条 rewrite 正确透传 doc-app。
- 端到端（真 bot token 实测）：doc-app `/d/<slug>/v/latest` 渲染 200（167KB HTML）、backend `GET /v1/bot/docs/{id}` 200、`POST /view` 200 且写入 doc_view_history。

## 后端 / octo-docs-html
**不改**：html 文档的 GET meta / POST view / `/d` 渲染后端全支持（已实测）。

## 已知限制（reader 权限面分裂，本 PR 不涉及、需后续单独处理）
HTML 文档的 reader grant 写在 **octo-doc（doc-app）的 grants**，而普通 doc 的成员权限在 **docs-backend 的 doc_member**。走 StandaloneDocPage 时 preflight 打 docs-backend——若某 reader 的授权只写在 doc-app grants、docs-backend doc_member 无对应行，preflight 会判无权限。本 PR 只修「链接形态 + 分流 + 最近查看」；reader 跨后端授权对齐是独立议题（建议后续：授 grant 时同步回写 docs-backend doc_member，或 preflight 对 html 回查 doc-app grants）。space 成员 / owner / bot 走 space 兜底不受影响。

## 部署前提 / 必配环境变量
本 PR 不新增环境变量，沿用现有 web 容器配置（`DOC_APP_URL` / `DOCS_BACKEND_URL` / `API_URL`）。