### PR TITLE
fix(dmworksummary): agent-summary UX fast-follow — persist referencedTask + fix forward-to-chat + hide unsupported buttons

### DIFF
--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -195,7 +195,8 @@
         "titleRequired": "Title is required",
         "saving": "Saving...",
         "noOutputToSave": "No summary content to save yet. Please chat with AI first to generate content.",
-        "agentSummaryCreated": "AI summary saved"
+        "agentSummaryCreated": "AI summary saved",
+        "savedReferenceLostRetry": "Save failed: please re-select the referenced summary, or start a new session"
     },
     "chatSummary": {
         "panelTitle": "Summaries in this chat",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -195,7 +195,8 @@
         "titleRequired": "标题不能为空",
         "saving": "保存中...",
         "noOutputToSave": "当前对话还没有可保存的总结，请先与 AI 对话产出内容",
-        "agentSummaryCreated": "AI 总结已保存"
+        "agentSummaryCreated": "AI 总结已保存",
+        "savedReferenceLostRetry": "保存失败：请重新选择引用总结，或点「新会话」重来"
     },
     "chatSummary": {
         "panelTitle": "聊天内的智能总结",

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -39,7 +39,7 @@ import type {
     CreateAgentSummaryParams,
 } from "../types/summary";
 import { SummaryMode, SourceType } from "../types/summary";
-import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession } from "../utils/summaryHelpers";
+import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession, readAgentChatReferenced, writeAgentChatReferenced, clearAgentChatReferenced } from "../utils/summaryHelpers";
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, type ResolvableTemplate } from "../utils/templateResolver";
 
 const { Text } = Typography;
@@ -161,6 +161,12 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             this.setState({
                 mode: 'agent',
                 referencedTask: this.props.derivedFromTask,
+            });
+            // 与 session_id 同生命周期持久化引用总结，避免 refresh/重进后
+            // referencedTask 只活在 React state 里而丢失 → 保存时 400。
+            writeAgentChatReferenced(this.agentChannelId(), {
+                task_id: this.props.derivedFromTask.task_id,
+                title: this.props.derivedFromTask.title ?? '',
             });
         }
     }
@@ -575,9 +581,15 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
      */
     private enterAgentMode() {
         const stored = readAgentChatSession(this.agentChannelId());
+        // 恢复引用总结与 session 同生命周期：storage 里有 → 自动回填。
+        // 无 → 保持 state 现值（可能是 mount 时 derivedFromTask 塞进来的）。
+        const storedRef = readAgentChatReferenced(this.agentChannelId());
         this.setState((prev) => ({
             mode: 'agent',
             sessionId: stored || prev.sessionId,
+            referencedTask: storedRef
+                ? { task_id: storedRef.task_id, title: storedRef.title } as SummaryListItem
+                : prev.referencedTask,
         }));
         if (stored) void this.loadAgentHistory(stored);
     }
@@ -603,6 +615,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     /** 「新会话」：清 localStorage 的 session_id、清空消息，下次发送重新生成新 session_id。 */
     handleNewSession = () => {
         clearAgentChatSession(this.agentChannelId());
+        // 引用总结跟 session 同生命周期 → 一起清。
+        clearAgentChatReferenced(this.agentChannelId());
         // 作废在途历史拉取，避免旧会话历史回灌到新会话。
         this.historyLoadToken++;
         this.setState({
@@ -646,6 +660,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             e.stopPropagation();
                             // 移除引用同时强制关闭 SidePanel(引用没了没意义再显示)
                             this.setState({ referencedTask: null, sidePanelOpen: false });
+                            // 引用同步清持久化，避免 refresh 后又回填。
+                            clearAgentChatReferenced(this.agentChannelId());
                         }}
                         title={translate('summary.chatReference.remove')}
                     >
@@ -718,6 +734,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             //   2. 重置组件内 state(messages/sessionId/referencedTask)
             //   3. 后端会在保存事务里 DELETE agent_message 表对应行
             clearAgentChatSession(this.agentChannelId());
+            // 引用总结跟 session 同生命周期 → 一起清。
+            clearAgentChatReferenced(this.agentChannelId());
             this.historyLoadToken++;
             this.setState({
                 messages: [],
@@ -747,6 +765,14 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 // 40004: session 无产出
                 if (code === 40004) {
                     Toast.error(t('summary.create.noOutputToSave'));
+                    return false;
+                }
+                // 40001: origin_channel_id 反查失败(通常是引用总结退出重进后
+                // referencedTask 丢失,前端没发 referenced_task_ids,后端 fallback
+                // 借 origin 无路可走)。给友好文案指导用户下一步动作。
+                // 见 SUM-161 fast-follow · CHAT-REFERENCE-BASED-DESIGN-v1。
+                if (code === 40001) {
+                    Toast.error(t('summary.create.savedReferenceLostRetry'));
                     return false;
                 }
             }
@@ -844,10 +870,17 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             <SummaryReferencePicker
                                 visible={this.state.showReferencePicker}
                                 onCancel={() => this.setState({ showReferencePicker: false })}
-                                onSelect={(task) => this.setState({
-                                    referencedTask: task,
-                                    showReferencePicker: false,
-                                })}
+                                onSelect={(task) => {
+                                    this.setState({
+                                        referencedTask: task,
+                                        showReferencePicker: false,
+                                    });
+                                    // 用户选择新引用 → 同步持久化 → refresh 后仍在。
+                                    writeAgentChatReferenced(this.agentChannelId(), {
+                                        task_id: task.task_id,
+                                        title: task.title ?? '',
+                                    });
+                                }}
                                 selectedTaskId={this.state.referencedTask?.task_id}
                             />
                             {/* Modal 保留:未来其他触发点(比如详情页快照预览)可复用;主 UI 已改用 SidePanel */}

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -158,9 +158,20 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         // 从详情页「继续优化」打开时:自动切 agent 模式 + 预填引用。
         // 见 CHAT-REFERENCE-BASED-DESIGN-v1 决策 1B(详情页显眼按钮入口)。
         if (this.props.derivedFromTask) {
+            // #907 review (Jerry-Xin) P1 cross-session contamination:
+            // 走「继续优化」= 用户明确要针对当前 task 开新一轮 · 复用工作台
+            // 上一次残留的 session_id 语义完全不匹配(旧 chat 讨论的是别的
+            // 总结 · 现在换了 reference)。如果只 overwrite referenced 不清
+            // session · refresh-before-send 会 restore「旧 session_id + 新
+            // reference」的错配组合 · loadAgentHistory 灌回旧 messages ·
+            // 保存时血统被污染。所以进入时先原子清一遍 session · 再 write
+            // 新 reference · 保证 storage 里的两条永远一致。
+            clearAgentChatSession(this.agentChannelId());
             this.setState({
                 mode: 'agent',
                 referencedTask: this.props.derivedFromTask,
+                sessionId: '',
+                messages: [],
             });
             // 与 session_id 同生命周期持久化引用总结，避免 refresh/重进后
             // referencedTask 只活在 React state 里而丢失 → 保存时 400。

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -1887,10 +1887,17 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     handleForwardToChat = () => {
-        const { detail } = this.state;
-        if (!detail?.result?.content?.trim()) return;
+        const { detail, personalResult } = this.state;
+        // #158/#161 agent 总结 fallback:agent workflow 只写 personal_result 表,
+        // 不写 summary_result 表(agent_summary.go: creatorPR 是 deliverable,没有
+        // 单独的 SummaryResult 行)。所以 GET /summaries/:id 返 detail.result=null,
+        // 但 detail.personal_result 有 content(前端渲染正文也是走这个 fallback)。
+        // 传统 workflow 优先走 detail.result;agent workflow 走 personalResult。
+        // 两者的 content 语义都是"给用户看的最终交付文本",转发到聊天的姿势一致。
+        const sourceContent = detail?.result?.content ?? personalResult?.content ?? '';
+        if (!sourceContent.trim()) return;
         WKApp.shared.baseContext.showConversationSelect(async (channels: Channel[]) => {
-            const cleanContent = (detail?.result?.content ?? '').replace(/\[\d+\]/g, '').replace(/  +/g, ' ').trim();
+            const cleanContent = sourceContent.replace(/\[\d+\]/g, '').replace(/  +/g, ' ').trim();
             const chunks = splitSummaryText(cleanContent);
             const errors: string[] = [];
 
@@ -2453,7 +2460,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         {/* need5：单人 BY_PERSON 定时按钮放「编辑」按钮左边。多人协作不在此区渲染
                             （need1 不显示我的总结区；need5 多人定时按钮在团队框）。 */}
                         {!this.isMultiCollab() && this.renderScheduleButton()}
-                        {detail && detail.status === TaskStatus.COMPLETED && detail.permissions?.can_edit && !this.state.isEditing && (
+                        {/* #158/#161 fast-follow：agent 总结不支持 edit —— 后端 PUT /edit
+                            走的是 SummaryResult 表更新，但 agent 保存路径只写
+                            personal_result 表（agent_summary.go 里 creatorPR 是唯一
+                            deliverable，不建 summary_result 行）。用户点击编辑保存后
+                            会 404 "总结结果不存在"。前端直接不渲染。
+                            如果未来后端为 agent 建 SummaryResult 行，只需删除下面
+                            这行 trigger_type 判断即可。 */}
+                        {detail && detail.status === TaskStatus.COMPLETED && detail.permissions?.can_edit && !this.state.isEditing && detail.trigger_type !== TriggerType.AGENT && (
                             <Button
                                 size="small"
                                 theme="borderless"
@@ -3087,6 +3101,11 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         const { t } = this.context;
         // OCT-21 / GPT-S1：草稿编辑态也隐藏 schedule 按钮，与其它编辑态保持一致约束。
         if (!detail?.permissions?.can_schedule || isEditing || editingTeamSummary || editingPersonalReport || editingMyDraft) return null;
+        // #158/#161 fast-follow：agent 总结不支持 schedule —— schedule 到点会 trigger
+        // 后端 pipeline 走传统 map-reduce 重跑，但 agent 总结的产出是 chat 交互生成，
+        // 没有可 replay 的 sources/participants。触发后任务会卡在 Pending 或 fail，
+        // 用户体验很差。前端直接不渲染这个按钮，避免用户误点。
+        if (detail?.trigger_type === TriggerType.AGENT) return null;
 
         // 任务3：hasSchedule 仅在存在且 is_active 时为 true。
         // 停用后文案回到「设置定时更新」。
@@ -3267,7 +3286,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
 
         // Build "..." menu items
         const menuItems: { node: string; key: string; onClick: () => void; danger?: boolean }[] = [];
-        if (detail && canRegenerate(detail.status)) {
+        // #158/#161 fast-follow：agent 总结不支持 regenerate —— 传统 regenerate 走
+        // POST /summaries/:id/regenerate → triggerWorker("personal_summary")，会尝试重跑
+        // pipeline 但 agent 任务无 participants / sources 可 replay，任务会卡死或 fail。
+        // 语义上 "重生成" 对 agent 总结应该是 "重开一次 chat"，那是主人的 continueRefine
+        // 已经覆盖的入口。这里直接不给 menu 项，避免用户走错路径。
+        if (detail && canRegenerate(detail.status) && detail.trigger_type !== TriggerType.AGENT) {
             menuItems.push({ node: t("summary.detail.regenerate"), key: "regenerate", onClick: this.handleRegenerate });
         }
         if (detail && canCancel(detail.status)) {

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -1941,10 +1941,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     handleForwardToMatter = () => {
-        const { detail } = this.state;
+        const { detail, personalResult } = this.state;
         if (!detail || detail.status !== TaskStatus.COMPLETED) return;
 
-        const content = detail.result?.content;
+        // #907 review (yujiawei P2): mirror handleForwardToChat's agent
+        // summary fallback so this path won't ship broken when
+        // SHOW_FORWARD_TO_MATTER is flipped back on. See handleForwardToChat
+        // for the full rationale (agent workflow only writes personal_result).
+        const content = detail.result?.content ?? personalResult?.content;
         if (!content?.trim()) {
             Toast.warning(t("summary.detail.noForwardContent"));
             return;
@@ -1954,10 +1958,11 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     handleMatterSelected = async (matterId: string, matterTitle: string) => {
-        const { detail } = this.state;
+        const { detail, personalResult } = this.state;
         if (!detail) return;
 
-        const content = detail.result?.content;
+        // Same fallback as handleForwardToMatter (they must stay in sync).
+        const content = detail.result?.content ?? personalResult?.content;
         if (!content?.trim()) return;
 
         this.setState({ forwardingToMatter: true, showMatterPicker: false });
@@ -3314,15 +3319,29 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                 {t("summary.detail.continueRefine")}
                             </Button>
                         )}
-                        {detail && detail.status === TaskStatus.COMPLETED && (
-                            <Button
-                                theme="borderless"
-                                icon={<IconSend />}
-                                onClick={this.handleForwardToChat}
-                            >
-                                {t("summary.detail.forwardToChat")}
-                            </Button>
-                        )}
+                        {detail && detail.status === TaskStatus.COMPLETED && (() => {
+                            // #907 review (yujiawei P2-1): agent summary forward
+                            // sources fall through to personalResult.content, which
+                            // is fetched async by loadPersonalResult. During that
+                            // load window a click would silently no-op. Disable +
+                            // loading state until the fallback content is in.
+                            // Traditional workflow has detail.result inline, so it
+                            // is never gated here.
+                            const isAgent = detail.trigger_type === TriggerType.AGENT;
+                            const agentContentReady = !!this.state.personalResult?.content?.trim();
+                            const waitingForFallback = isAgent && !detail.result?.content?.trim() && !agentContentReady;
+                            return (
+                                <Button
+                                    theme="borderless"
+                                    icon={<IconSend />}
+                                    onClick={this.handleForwardToChat}
+                                    loading={waitingForFallback && this.state.personalLoading}
+                                    disabled={waitingForFallback}
+                                >
+                                    {t("summary.detail.forwardToChat")}
+                                </Button>
+                            );
+                        })()}
                         {SHOW_FORWARD_TO_MATTER && detail && detail.status === TaskStatus.COMPLETED && (
                             <Button
                                 theme="borderless"

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -509,3 +509,57 @@ describe('SummaryCreatePage agent SSE session_id sync', () => {
         expect(lastMessage.content).toBe('Server response');
     });
 });
+
+describe('SummaryCreatePage handleSubmit error handling', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows friendly toast for 40001 (referenced summary lost after refresh)', async () => {
+        const { Toast } = await import('@douyinfe/semi-ui');
+
+        // Mock createAgentSummary to reject with axios-style 40001 error.
+        // This is the exact shape the backend returns when
+        //   session_id has no fetch_channel tool trace AND
+        //   referenced_task_ids is empty AND
+        //   origin_channel_id was not supplied by the front-end.
+        // See internal/api/handler/agent_summary.go: "origin_channel_id 未传且无法从 session 反查".
+        const err = {
+            response: { data: { code: 40001, message: 'origin_channel_id 未传且无法从 session 反查' } },
+        };
+        (api.createAgentSummary as any).mockRejectedValueOnce(err);
+
+        const ref = React.createRef<any>();
+        await act(async () => {
+            render(<SummaryCreatePage ref={ref} />);
+            await flushPromises();
+        });
+
+        const instance = ref.current as any;
+
+        // Simulate a completed agent chat session ready to save.
+        await act(async () => {
+            instance.setState({
+                sessionId: 'session-abc',
+                mode: 'agent',
+                messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'summary' }],
+            });
+        });
+
+        (Toast.error as any).mockClear();
+
+        // Trigger the save flow directly on the instance.
+        let result: boolean | undefined;
+        await act(async () => {
+            result = await instance.handleSaveAsSummary('a title');
+            await flushPromises();
+        });
+
+        // Whichever method the component exposes, the 40001 branch should
+        // surface the friendly, actionable copy — NOT the raw backend message.
+        expect(Toast.error).toHaveBeenCalled();
+        const shown = (Toast.error as any).mock.calls[0]?.[0] ?? '';
+        expect(shown).toBe('保存失败：请重新选择引用总结，或点「新会话」重来');
+        expect(result).toBe(false);
+    });
+});

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -563,3 +563,80 @@ describe('SummaryCreatePage handleSubmit error handling', () => {
         expect(result).toBe(false);
     });
 });
+
+describe('SummaryCreatePage derivedFromTask cross-session isolation (#907 P1 Jerry-Xin)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+    });
+
+    it('clears leftover workbench session_id + messages when mounted with derivedFromTask', async () => {
+        // Pre-seed leftover state from a previous chat about a DIFFERENT summary:
+        //   - session_id survived from earlier workbench chat
+        //   - referencedTask points to the old summary (task_id=99)
+        // This mirrors the exact bug scenario Jerry-Xin flagged:
+        //   user chats about A, closes without saving, opens "continue refine"
+        //   from summary B's detail page → new mount receives derivedFromTask=B
+        //   → old session_id (about A) must be discarded, else refresh-before-send
+        //   restores A's history alongside B's reference and save corrupts derivation.
+        localStorage.setItem('agent-chat-session:__workbench__', 'old-session-about-A');
+        localStorage.setItem(
+            'agent-chat-referenced:__workbench__',
+            JSON.stringify({ task_id: 99, title: 'Old Summary A' }),
+        );
+
+        const derivedFromTaskB = {
+            task_id: 42,
+            task_no: 'ST-B',
+            title: 'New Summary B',
+            summary_mode: 1 as const,
+            status: 3 as const,
+            trigger_type: 3,
+        };
+
+        const ref = React.createRef<any>();
+        await act(async () => {
+            render(<SummaryCreatePage ref={ref} derivedFromTask={derivedFromTaskB as any} />);
+            await flushPromises();
+        });
+
+        const instance = ref.current as any;
+
+        // 1. Old session_id storage key MUST be gone — no restore of the stale A chat.
+        expect(localStorage.getItem('agent-chat-session:__workbench__')).toBeNull();
+
+        // 2. Referenced storage key MUST point to B (the new derivation target), not A.
+        const storedRef = JSON.parse(localStorage.getItem('agent-chat-referenced:__workbench__') || 'null');
+        expect(storedRef).toEqual({ task_id: 42, title: 'New Summary B' });
+
+        // 3. React state must reflect a fresh session for B, not resumed A.
+        expect(instance.state.sessionId).toBe('');
+        expect(instance.state.messages).toEqual([]);
+        expect(instance.state.referencedTask?.task_id).toBe(42);
+        expect(instance.state.mode).toBe('agent');
+    });
+
+    it('when derivedFromTask is absent, does NOT touch existing workbench session (bare workbench entry unchanged)', async () => {
+        // Reverse guard: bare full-page workbench entry (no derivedFromTask prop)
+        // must NOT clear the user's in-progress session. This test protects the
+        // #158/#161 resume-after-refresh scenario from being broken by the
+        // #907 P1 fix — the two behaviours are orthogonal.
+        localStorage.setItem('agent-chat-session:__workbench__', 'in-progress-session');
+        localStorage.setItem(
+            'agent-chat-referenced:__workbench__',
+            JSON.stringify({ task_id: 7, title: 'Reference C' }),
+        );
+
+        await act(async () => {
+            render(<SummaryCreatePage />);
+            await flushPromises();
+        });
+
+        // Both storage keys survive the mount — enterAgentMode will restore them
+        // when the user actually switches into agent mode.
+        expect(localStorage.getItem('agent-chat-session:__workbench__')).toBe('in-progress-session');
+        expect(
+            JSON.parse(localStorage.getItem('agent-chat-referenced:__workbench__') || 'null'),
+        ).toEqual({ task_id: 7, title: 'Reference C' });
+    });
+});

--- a/packages/dmworksummary/src/utils/agentChatReferenced.test.ts
+++ b/packages/dmworksummary/src/utils/agentChatReferenced.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    agentChatReferencedKey,
+    readAgentChatReferenced,
+    writeAgentChatReferenced,
+    clearAgentChatReferenced,
+} from './summaryHelpers';
+
+describe('agent chat referencedTask localStorage helpers', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('scopes the key by channelId', () => {
+        expect(agentChatReferencedKey('ch1')).toBe('agent-chat-referenced:ch1');
+        expect(agentChatReferencedKey('ch2')).toBe('agent-chat-referenced:ch2');
+    });
+
+    it('falls back to a shared key when channelId is missing', () => {
+        expect(agentChatReferencedKey()).toBe('agent-chat-referenced:__workbench__');
+        expect(agentChatReferencedKey('')).toBe('agent-chat-referenced:__workbench__');
+        expect(agentChatReferencedKey(null)).toBe('agent-chat-referenced:__workbench__');
+    });
+
+    it('writes and reads a referenced task per channel without bleed', () => {
+        writeAgentChatReferenced('ch1', { task_id: 111, title: 'Alpha' });
+        writeAgentChatReferenced('ch2', { task_id: 222, title: 'Beta' });
+        expect(readAgentChatReferenced('ch1')).toEqual({ task_id: 111, title: 'Alpha' });
+        expect(readAgentChatReferenced('ch2')).toEqual({ task_id: 222, title: 'Beta' });
+    });
+
+    it('returns null when nothing is stored', () => {
+        expect(readAgentChatReferenced('nope')).toBeNull();
+    });
+
+    it('returns null and does not throw on malformed JSON', () => {
+        // Simulate a corrupted / unrelated payload written under our key.
+        localStorage.setItem('agent-chat-referenced:ch1', 'not-json{{{');
+        expect(readAgentChatReferenced('ch1')).toBeNull();
+    });
+
+    it('returns null when payload shape is wrong (missing task_id or title)', () => {
+        localStorage.setItem('agent-chat-referenced:ch1', JSON.stringify({ foo: 'bar' }));
+        expect(readAgentChatReferenced('ch1')).toBeNull();
+
+        localStorage.setItem('agent-chat-referenced:ch2', JSON.stringify({ task_id: 'not-a-number', title: 'x' }));
+        expect(readAgentChatReferenced('ch2')).toBeNull();
+    });
+
+    it('writing null clears the entry (convenience shortcut)', () => {
+        writeAgentChatReferenced('ch1', { task_id: 111, title: 'Alpha' });
+        writeAgentChatReferenced('ch1', null);
+        expect(readAgentChatReferenced('ch1')).toBeNull();
+    });
+
+    it('clears only the targeted channel', () => {
+        writeAgentChatReferenced('ch1', { task_id: 111, title: 'Alpha' });
+        writeAgentChatReferenced('ch2', { task_id: 222, title: 'Beta' });
+        clearAgentChatReferenced('ch1');
+        expect(readAgentChatReferenced('ch1')).toBeNull();
+        expect(readAgentChatReferenced('ch2')).toEqual({ task_id: 222, title: 'Beta' });
+    });
+
+    it('persists only task_id and title (drops extra fields to keep snapshot minimal)', () => {
+        writeAgentChatReferenced('ch1', {
+            task_id: 333,
+            title: 'Gamma',
+            // @ts-expect-error extra fields intentionally passed to verify they don't survive
+            summary: 'extra field',
+        });
+        expect(readAgentChatReferenced('ch1')).toEqual({ task_id: 333, title: 'Gamma' });
+    });
+});

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -60,6 +60,86 @@ export function clearAgentChatSession(channelId?: string | null): void {
     }
 }
 
+// ─── Agent 对话 referencedTask 持久化（「退出不丢引用」） ──────────────
+// referencedTask 与 session_id 同生命周期：session 存活时它也存活，session
+// 清掉（新会话/保存成功）时它也被清。修 SUM-161 fast-follow：未保存的
+// 引用总结 chat 退出重进后，session_id 从 localStorage 恢复了、消息也
+// 通过 GET /agent/chat/history 拉回来了，但 referencedTask 只活在 React
+// state 里，重进后丢失。用户随后点保存 → 前端不发 referenced_task_ids
+// → 后端 CreateAgentSummary 走 fallback 借 origin 失败 → 40001。持久化
+// 它到 localStorage 让 refresh/重进后自动回填。
+//
+// 只存最小可恢复信息：task_id + title（UI 显示用）。task_id 是唯一必要
+// 键，title 是显示用的 snapshot（可能 stale，但不影响功能——后端保存时
+// 会用 task_id 走 canAccessTaskDB 校验）。
+const AGENT_CHAT_REFERENCED_KEY_PREFIX = 'agent-chat-referenced:';
+
+/** 持久化的引用总结精简结构（只存 UI 恢复必需的字段）。 */
+export interface PersistedReferencedTask {
+    task_id: number;
+    title: string;
+}
+
+/** 构造 referencedTask localStorage key。channelId 缺省时用统一兜底段。 */
+export function agentChatReferencedKey(channelId?: string | null): string {
+    return AGENT_CHAT_REFERENCED_KEY_PREFIX + (channelId || AGENT_CHAT_SESSION_FALLBACK);
+}
+
+/**
+ * 读取该入口已持久化的引用总结；无则返回 null。
+ * localStorage 在隐私模式/禁用时可能抛错、JSON 损坏时可能解析失败，
+ * 一律吞掉降级为「无引用」，不影响正常打开会话。
+ */
+export function readAgentChatReferenced(channelId?: string | null): PersistedReferencedTask | null {
+    try {
+        const raw = localStorage.getItem(agentChatReferencedKey(channelId));
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+            parsed && typeof parsed === 'object'
+            && typeof (parsed as PersistedReferencedTask).task_id === 'number'
+            && typeof (parsed as PersistedReferencedTask).title === 'string'
+        ) {
+            return parsed as PersistedReferencedTask;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 写入引用总结（null 清除）。异常静默降级。
+ * 传 null 时清除，与 clearAgentChatReferenced 等价——统一入口方便调用点。
+ */
+export function writeAgentChatReferenced(
+    channelId: string | null | undefined,
+    task: PersistedReferencedTask | null,
+): void {
+    if (!task) {
+        clearAgentChatReferenced(channelId);
+        return;
+    }
+    try {
+        localStorage.setItem(
+            agentChatReferencedKey(channelId),
+            JSON.stringify({ task_id: task.task_id, title: task.title }),
+        );
+    } catch {
+        // 同 writeAgentChatSession：localStorage 不可用（隐私模式/配额）
+        // 时静默降级，本次会话仍然可用，只是 refresh 后不恢复。
+    }
+}
+
+/** 清除该入口的引用总结（「新会话」或「保存成功」用）。异常静默降级。 */
+export function clearAgentChatReferenced(channelId?: string | null): void {
+    try {
+        localStorage.removeItem(agentChatReferencedKey(channelId));
+    } catch {
+        // 同上。
+    }
+}
+
 /** 周对应天数 */
 export const DAYS_PER_WEEK = 7;
 /** interval_days 上界（与后端 MaxIntervalDays 对齐） */


### PR DESCRIPTION
## Summary

Three agent-summary UX gaps discovered while testing the merged smart-summary #158 / #161 in local octo-alex stack:

1. **Referenced-task lost after refresh** → save fails with opaque 400
   ("Request failed with status code 400").
   Root cause: `referencedTask` lived only in React state while
   `session_id` was persisted in localStorage; on resume, session +
   history came back but referencedTask didn't, so
   `referenced_task_ids` was empty in the save request, backend
   fallback for borrowing origin from the referenced task had nothing
   to borrow → 40001 `origin_channel_id 未传且无法从 session 反查`.

2. **Forward-to-chat button silently does nothing on agent summaries**.
   Root cause: guard `!detail?.result?.content` returned early because
   `detail.result` is null for agent summaries (backend
   `agent_summary.go` writes to `personal_result` only, not
   `summary_result`).

3. **Regenerate / Set schedule / Edit buttons render but backend
   doesn't support them for agent tasks** — clicking either sends the
   task to a pipeline path with no participants/sources (worker either
   loops empty → task stuck at Pending or crashes → task Failed), or
   for edit, returns 40008 "总结结果不存在".

## Linked Spec

Follow-up to CHAT-REFERENCE-BASED-DESIGN-v1 and smart-summary #158 / #161.
No separate brief — three focused fixes traceable to specific reproducer scenarios.

## How verified

Local test in octo-alex compose stack (rebuild octo-web image, hard refresh, all 4 scenarios):

- **Reference persistence**: open "继续优化" from a summary detail page, chat,
  refresh, referenced badge auto-restored, save works.
- **Storage fallback**: `localStorage.clear()` mid-session, save now shows friendly
  toast instead of raw 400.
- **Forward-to-chat on agent summary**: opens conversation picker, sends to
  selected group successfully (previously no-op / no console output).
- **Regenerate / Schedule / Edit buttons**: hidden on agent summary
  (`trigger_type === TriggerType.AGENT`), preserved on traditional
  (trigger_type=MANUAL) summary — reverse-verified against a MANUAL task.

Automated:
- `pnpm test` — 457/457 tests pass across 33 files, including 9 new
  storage-helper tests + 1 new save-time 40001 handler test.
- `pnpm build` — turbo build 2/2 pass, no rolldown warnings introduced.

## COMPREHENSION

1. **What does this change actually do**: makes agent-summary UX
   feature-parity with what the frontend already renders — either the
   backend path works (persist + forward), or the button is hidden so
   users can't step on the broken paths (regenerate / schedule / edit).
2. **What could break**: `referencedTask` snapshot in localStorage may
   drift (referenced summary renamed / deleted) → title shown may be
   stale but save still works because backend re-validates by `task_id`
   via `canAccessTaskDB`; malformed storage payloads are defended
   against with typed shape checks in the read helper.
3. **How do you know it works**: three-scenario local walkthrough + full
   pnpm test suite green + build green + reverse-tested that traditional
   summaries retain the three gated buttons.
