### PR TITLE
fix(onboarding): stabilize intro skip transition

### DIFF
--- a/apps/web/src/Components/Onboarding/Intro.tsx
+++ b/apps/web/src/Components/Onboarding/Intro.tsx
@@ -212,7 +212,7 @@ export const OnboardingIntro: React.FC<OnboardingIntroProps> = ({
         type="button"
         onClick={onSkip}
         aria-label={t("app.onboarding.intro.actions.skipAria")}
-        data-cursor-interactive="true"
+        data-cursor-native="true"
       >
         <span>{t("app.onboarding.intro.actions.skip")}</span>
         <X size={15} aria-hidden="true" />

--- a/apps/web/src/Components/Onboarding/index.css
+++ b/apps/web/src/Components/Onboarding/index.css
@@ -31,6 +31,13 @@
     animation: wkIntroToPanelOut 620ms var(--wk-ease) forwards;
 }
 
+.wk-onboarding-skip-transition-target {
+    padding: 0;
+    background: var(--wk-bg-surface);
+    backdrop-filter: none;
+    transition: none;
+}
+
 .wk-onboarding-overlay-panel {
     animation: wkOverlayPanelIn 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
@@ -1316,7 +1323,6 @@ html[data-octo-onboarding-vt="active"]::view-transition-new(root) {
     to {
         opacity: 0.78;
         filter: blur(2px);
-        transform: scale(0.985);
     }
 }
 

--- a/apps/web/src/Components/Onboarding/index.test.tsx
+++ b/apps/web/src/Components/Onboarding/index.test.tsx
@@ -8,14 +8,26 @@ import {
 } from "./content";
 import { Onboarding } from ".";
 
-const { runOnboardingViewTransition } = vi.hoisted(() => ({
-  runOnboardingViewTransition: vi.fn(
-    ({ onTransition }: { onTransition: () => void }) => {
-      onTransition();
-      return true;
-    }
-  ),
-}));
+const { runOnboardingViewTransition, viewTransitionState } = vi.hoisted(() => {
+  const viewTransitionState: { onFinished?: () => void } = {};
+
+  return {
+    viewTransitionState,
+    runOnboardingViewTransition: vi.fn(
+      ({
+        onFinished,
+        onTransition,
+      }: {
+        onFinished?: () => void;
+        onTransition: () => void;
+      }) => {
+        viewTransitionState.onFinished = onFinished;
+        onTransition();
+        return true;
+      }
+    ),
+  };
+});
 
 const translations: Record<string, string> = {
   "app.onboarding.dialog.introAria": "Octo onboarding introduction",
@@ -66,6 +78,7 @@ vi.mock("./viewTransition", () => ({
 describe("Onboarding", () => {
   beforeEach(() => {
     runOnboardingViewTransition.mockClear();
+    delete viewTransitionState.onFinished;
     localStorageMock.clear();
     Object.defineProperty(window, "localStorage", {
       configurable: true,
@@ -79,7 +92,7 @@ describe("Onboarding", () => {
     vi.unstubAllGlobals();
   });
 
-  it("dismisses and persists the onboarding when the intro is skipped", () => {
+  it("keeps a neutral transition target mounted until the intro skip transition finishes", () => {
     const onDismiss = vi.fn();
 
     render(<Onboarding forceVisible onDismiss={onDismiss} />);
@@ -89,6 +102,33 @@ describe("Onboarding", () => {
     expect(window.localStorage.getItem(getOnboardingSeenStorageKey())).toBe(
       "seen"
     );
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(
+      document.querySelector(".wk-onboarding-skip-transition-target")
+    ).toBeInTheDocument();
+
+    act(() => viewTransitionState.onFinished?.());
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".wk-onboarding-skip-transition-target")
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the timed intro skip fallback when view transitions are unavailable", () => {
+    vi.useFakeTimers();
+    runOnboardingViewTransition.mockImplementationOnce(() => false);
+    const onDismiss = vi.fn();
+
+    render(<Onboarding forceVisible onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(620));
+
     expect(onDismiss).toHaveBeenCalledOnce();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });

--- a/apps/web/src/Components/Onboarding/index.tsx
+++ b/apps/web/src/Components/Onboarding/index.tsx
@@ -200,11 +200,14 @@ export const Onboarding: React.FC<OnboardingProps> = ({
     return !!config.intro.enabled;
   });
   const [introLeaving, setIntroLeaving] = useState(false);
+  const [isIntroSkipTransitionTarget, setIsIntroSkipTransitionTarget] =
+    useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
   const finishButtonRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const completionStartedRef = useRef(false);
+  const introTransitionStartedRef = useRef(false);
   const completionTimerRef = useRef<number | null>(null);
   const introFallbackTimerRef = useRef<number | null>(null);
   const focusTimerRef = useRef<number | null>(null);
@@ -296,13 +299,15 @@ export const Onboarding: React.FC<OnboardingProps> = ({
   };
 
   const handleIntroContinue = () => {
-    if (introLeaving) return;
+    if (introLeaving || introTransitionStartedRef.current) return;
+    introTransitionStartedRef.current = true;
 
     const transitioned = runOnboardingViewTransition({
       duration: 1240,
       onTransition: () => {
         setShowIntro(false);
         setIntroLeaving(false);
+        introTransitionStartedRef.current = false;
       },
     });
     if (transitioned) return;
@@ -312,21 +317,26 @@ export const Onboarding: React.FC<OnboardingProps> = ({
       introFallbackTimerRef.current = null;
       setShowIntro(false);
       setIntroLeaving(false);
+      introTransitionStartedRef.current = false;
     }, 620);
   };
 
   const handleIntroSkip = () => {
-    if (introLeaving) return;
+    if (introLeaving || introTransitionStartedRef.current) return;
+    introTransitionStartedRef.current = true;
 
     const closeIntro = () => {
-      persistDismissed();
       hideOnboarding();
+      setIsIntroSkipTransitionTarget(false);
       setIntroLeaving(false);
+      introTransitionStartedRef.current = false;
     };
 
+    persistDismissed();
     const transitioned = runOnboardingViewTransition({
       duration: 1240,
-      onTransition: closeIntro,
+      onTransition: () => setIsIntroSkipTransitionTarget(true),
+      onFinished: closeIntro,
     });
     if (transitioned) return;
 
@@ -417,6 +427,15 @@ export const Onboarding: React.FC<OnboardingProps> = ({
   }
 
   if (showIntro) {
+    if (isIntroSkipTransitionTarget) {
+      return (
+        <div
+          className="wk-onboarding-overlay wk-onboarding-skip-transition-target"
+          aria-hidden="true"
+        />
+      );
+    }
+
     return (
       <div
         ref={dialogRef}

--- a/apps/web/src/Components/Onboarding/viewTransition.test.ts
+++ b/apps/web/src/Components/Onboarding/viewTransition.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runOnboardingViewTransition } from "./viewTransition";
+
+describe("runOnboardingViewTransition", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(document, "startViewTransition");
+    Reflect.deleteProperty(document.documentElement, "animate");
+    delete document.documentElement.dataset.octoOnboardingVt;
+    document.documentElement.style.removeProperty(
+      "--wk-onboarding-vt-duration"
+    );
+    document.documentElement.style.removeProperty(
+      "--wk-onboarding-vt-clip-from"
+    );
+  });
+
+  it("waits for the captured transition to finish before running onFinished", async () => {
+    let resolveFinished: (() => void) | undefined;
+    const finished = new Promise<void>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const onTransition = vi.fn();
+    const onFinished = vi.fn();
+    const animate = vi.fn();
+
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      value: vi.fn((callback: () => void) => {
+        callback();
+        return { ready: Promise.resolve(), finished };
+      }),
+    });
+    Object.defineProperty(document.documentElement, "animate", {
+      configurable: true,
+      value: animate,
+    });
+
+    expect(runOnboardingViewTransition({ onFinished, onTransition })).toBe(
+      true
+    );
+    expect(onTransition).toHaveBeenCalledOnce();
+    expect(onFinished).not.toHaveBeenCalled();
+    expect(document.documentElement.dataset.octoOnboardingVt).toBe("active");
+
+    await Promise.resolve();
+    expect(animate).toHaveBeenCalledOnce();
+
+    resolveFinished?.();
+    await finished;
+    await Promise.resolve();
+
+    expect(onFinished).toHaveBeenCalledOnce();
+    expect(document.documentElement.dataset.octoOnboardingVt).toBeUndefined();
+  });
+});

--- a/apps/web/src/Components/Onboarding/viewTransition.ts
+++ b/apps/web/src/Components/Onboarding/viewTransition.ts
@@ -2,6 +2,7 @@ import { flushSync } from "react-dom";
 
 type OnboardingViewTransitionOptions = {
     duration?: number;
+    onFinished?: () => void;
     onTransition: () => void;
 };
 
@@ -16,7 +17,11 @@ function getCircleClipPaths(cx: number, cy: number, maxRadius: number): [string,
     return [`circle(0px at ${cx}px ${cy}px)`, `circle(${maxRadius}px at ${cx}px ${cy}px)`];
 }
 
-export function runOnboardingViewTransition({ duration = 1240, onTransition }: OnboardingViewTransitionOptions) {
+export function runOnboardingViewTransition({
+    duration = 1240,
+    onFinished,
+    onTransition,
+}: OnboardingViewTransitionOptions) {
     const transitionDocument = document as ViewTransitionDocument;
 
     if (typeof transitionDocument.startViewTransition !== "function") {
@@ -52,10 +57,15 @@ export function runOnboardingViewTransition({ duration = 1240, onTransition }: O
         return false;
     }
 
-    if (typeof transition.finished?.finally === "function") {
-        transition.finished.finally(cleanup).catch(() => {});
-    } else {
+    const finish = () => {
         cleanup();
+        onFinished?.();
+    };
+
+    if (typeof transition.finished?.finally === "function") {
+        transition.finished.finally(finish).catch(() => {});
+    } else {
+        finish();
     }
     transition.ready?.then(() => {
         document.documentElement.animate(


### PR DESCRIPTION
## Summary

- keep an opaque onboarding surface mounted as the Skip view-transition target so the underlying app is not captured or revealed mid-transition
- dismiss onboarding only after the root view transition finishes, while preserving the existing timed fallback when View Transitions are unavailable
- remove old-root scaling that exposed viewport edges and opt Skip into the native cursor path without changing keyboard focus visibility
- add focused coverage for transition completion timing and the fallback path

## Verification

- `pnpm --filter @octo/web exec vitest run src/Components/Onboarding/index.test.tsx src/Components/Onboarding/viewTransition.test.ts`
- `pnpm i18n:check`
- `pnpm exec stylelint apps/web/src/Components/Onboarding/index.css --config stylelint.config.mjs` (0 errors; existing rgba warnings only)
- `pnpm --filter @octo/web build`
- Storybook manual check: immediate Skip shows a uniform circular surface with no app content or viewport-edge bleed; transition state cleans up after completion

Fixes #896