### PR TITLE
fix(html-doc): right-align owner AI handoff button and clarify wording (#911)

### DIFF
--- a/packages/docs/src/html/HtmlDocView.css
+++ b/packages/docs/src/html/HtmlDocView.css
@@ -141,6 +141,12 @@
 .octo-html-doc-comment-reply-text {
   margin: 2px 0;
 }
+/* Owner-only 转 AI 按钮：右靠齐，避免改父容器为 flex 影响 quote/meta/text 既有排布。 */
+.octo-html-doc-comment-ai {
+  display: block;
+  margin-left: auto;
+  width: fit-content;
+}
 /* Single viewer avatar in the title bar (no connection state). */
 .octo-html-doc-presence {
   display: flex;

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -383,7 +383,7 @@
     "clearAnchor": "Clear target",
     "placeholder": "Write a comment…",
     "send": "Send",
-    "handleWithAI": "Ask AI to handle",
+    "handleWithAI": "Hand off to AI",
     "anonymous": "Anonymous",
     "agentInstructionTitle": "Ask AI to handle comment: {{request}} (doc {{slug}} · {{target}})"
   },

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -383,7 +383,7 @@
     "clearAnchor": "取消定位",
     "placeholder": "写下评论…",
     "send": "发送",
-    "handleWithAI": "转交 AI 跟进",
+    "handleWithAI": "转交AI",
     "anonymous": "匿名",
     "agentInstructionTitle": "让 AI 处理评论：{{request}} (doc {{slug}} · {{target}})"
   },

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -383,7 +383,7 @@
     "clearAnchor": "取消定位",
     "placeholder": "写下评论…",
     "send": "发送",
-    "handleWithAI": "转交 AI 跟进",
+    "handleWithAI": "立即处理",
     "anonymous": "匿名",
     "agentInstructionTitle": "让 AI 处理评论：{{request}} (doc {{slug}} · {{target}})"
   },

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -383,7 +383,7 @@
     "clearAnchor": "取消定位",
     "placeholder": "写下评论…",
     "send": "发送",
-    "handleWithAI": "让 AI 处理",
+    "handleWithAI": "转交 AI 跟进",
     "anonymous": "匿名",
     "agentInstructionTitle": "让 AI 处理评论：{{request}} (doc {{slug}} · {{target}})"
   },

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -383,7 +383,7 @@
     "clearAnchor": "取消定位",
     "placeholder": "写下评论…",
     "send": "发送",
-    "handleWithAI": "转交AI",
+    "handleWithAI": "转交 AI 跟进",
     "anonymous": "匿名",
     "agentInstructionTitle": "让 AI 处理评论：{{request}} (doc {{slug}} · {{target}})"
   },


### PR DESCRIPTION
Relates: Mininglamp-OSS/octo-web#911 (agent-html), Multica OCT-177.

Scope: FE-only. No backend touched. No behaviour change for non-authors (button is still gated on `isAuthor` upstream).

## Changes

- **CSS**: add `.octo-html-doc-comment-ai { display: block; margin-left: auto; width: fit-content }` in `packages/docs/src/html/HtmlDocView.css`. The owner-only handoff button now right-aligns per comment card without turning the parent `.octo-html-doc-comment` into a flex container — the quote / meta / text vertical stacking is untouched on purpose.
- **i18n**: reword `docs.comment.handleWithAI` so the action reads as an explicit, immediate action. Key is unchanged; call sites and tests use the key and are unaffected.
  - zh: `让 AI 处理` → `立即处理`
  - en: `Ask AI to handle` → `Hand off to AI`
- `agentInstructionTitle` is deliberately NOT changed — that's the internal instruction body forwarded to chat, not a button label.

## Verification

```
$ pnpm i18n:check
i18n check passed: 0 candidates within baseline; locale keys healthy

$ cd packages/docs && pnpm exec vitest run src/html/HtmlDocCommentPanel.test.tsx
 ✓ src/html/HtmlDocCommentPanel.test.tsx (12 tests) 124ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

- Repo-wide `pnpm typecheck` still surfaces the same pre-existing errors under `editor/`, `sheet/`, `import/`, `members/`, `dmworkbase/` — none of them touch `html/` or the two i18n JSON files this PR changes.
- Non-author view: `HtmlDocCommentPanel.test.tsx` `hides the handoff button from non-authors` continues to pass, confirming viewer surface is unchanged.

## Notes

Draft PR by policy. Not for merge. Awaiting reviewer double-review via dev-work01.
