### PR TITLE
fix(onboarding): prevent skip transition snapshot leak

### DIFF
--- a/apps/web/src/Components/Onboarding/index.css
+++ b/apps/web/src/Components/Onboarding/index.css
@@ -148,6 +148,7 @@
     border-radius: 999px;
 }
 
+/* The old snapshot must stay opaque so the live app cannot leak outside the expanding circle. */
 html[data-octo-onboarding-vt="active"]::view-transition-old(root),
 html[data-octo-onboarding-vt="active"]::view-transition-new(root) {
     animation: none;
@@ -156,10 +157,6 @@ html[data-octo-onboarding-vt="active"]::view-transition-new(root) {
 
 html[data-octo-onboarding-vt="active"]::view-transition-group(root) {
     animation-duration: var(--wk-onboarding-vt-duration);
-}
-
-html[data-octo-onboarding-vt="active"]::view-transition-old(root) {
-    animation: wkOnboardingVtOldOut var(--wk-onboarding-vt-duration) cubic-bezier(0.42, 0, 0.18, 1) both;
 }
 
 html[data-octo-onboarding-vt="active"]::view-transition-new(root) {
@@ -1316,13 +1313,6 @@ html[data-octo-onboarding-vt="active"]::view-transition-new(root) {
     to {
         background: var(--wk-onboarding-overlay-bg);
         backdrop-filter: blur(1.5px);
-    }
-}
-
-@keyframes wkOnboardingVtOldOut {
-    to {
-        opacity: 0.78;
-        filter: blur(2px);
     }
 }
 


### PR DESCRIPTION
## Summary

- keep the old onboarding View Transition snapshot fully opaque while the new snapshot expands through the circular clip
- prevent the live white app surface from leaking outside the circle as a centered rectangle
- preserve the intended black-to-white circular transition introduced by #908

## Root cause

The old root snapshot animated to `opacity: 0.78` while the new snapshot was clipped to a circle. Outside that circle, the partially transparent old snapshot exposed the live white app surface underneath, producing the rectangular flash visible in the recording.

## Validation

- `pnpm --dir apps/web exec vitest run src/Components/Onboarding/viewTransition.test.ts src/Components/Onboarding/index.test.tsx` (2 files, 6 tests)
- `pnpm exec stylelint apps/web/src/Components/Onboarding/index.css --config stylelint.config.mjs` (0 errors; 89 pre-existing rgba warnings)
- `pnpm --dir apps/web build`
- Microsoft Edge Storybook capture at 50 ms intervals: only the circular reveal is visible; no rectangular flash

Follow-up to #908.
Relates to #896.