### PR TITLE
feat(html-doc): DocMoreMenu real avatar + consume __ODOC__ creator fields (OCT-184)

### DIFF
--- a/packages/docs/src/editor/DocMoreMenu.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { t } from '../octoweb/index.ts'
+import { avatarUrlFromUid } from '../html/avatarUrl.ts'
 
 /**
  * A single row in the header "more" (≡) dropdown. `danger` paints the row red (delete);
@@ -23,6 +24,10 @@ export interface DocMoreMenuItem {
 export interface DocMoreMenuProps {
   /** Resolved creator display name. The parent handles the resolution + fallback (short uid). */
   creatorName: string
+  /** Creator uid from __ODOC__.creator_uid — used only to fetch the head avatar image via
+   *  /api/v1/users/<uid>/avatar. Missing / broken image falls back to the initial-letter chip.
+   *  Never used for authorship checks (authorship comes from __ODOC_CAP__.isAuthor). */
+  creatorUid?: string
   /** Creation timestamp (RFC3339). Rendered as "Created on YYYY-MM-DD"; omitted when absent/invalid. */
   createdAt?: string
   /** Neutral action rows, rendered top-to-bottom in the given order. */
@@ -183,10 +188,18 @@ function MenuRow({ item, onSelect }: { item: DocMoreMenuItem; onSelect: () => vo
  * Self-contained plain-React popover (no antd, no portal): a relatively-positioned wrapper anchors
  * an absolutely-positioned panel below the trigger. Closes on outside pointer-down and on Escape.
  */
-export function DocMoreMenu({ creatorName, createdAt, items, dangerItem }: DocMoreMenuProps) {
+export function DocMoreMenu({ creatorName, creatorUid, createdAt, items, dangerItem }: DocMoreMenuProps) {
   const [open, setOpen] = useState(false)
+  // Head avatar: try /api/v1/users/<uid>/avatar; onError falls back to the initial-letter chip.
+  const avatarUrl = avatarUrlFromUid(creatorUid)
+  const [avatarFailed, setAvatarFailed] = useState(false)
+  const showAvatarImg = !!avatarUrl && !avatarFailed
   const wrapRef = useRef<HTMLDivElement>(null)
   const close = () => setOpen(false)
+
+  useEffect(() => {
+    setAvatarFailed(false)
+  }, [avatarUrl])
 
   useEffect(() => {
     if (!open) return
@@ -223,9 +236,19 @@ export function DocMoreMenu({ creatorName, createdAt, items, dangerItem }: DocMo
         <div className="octo-doc-more-panel" role="menu">
           <div className="octo-doc-more-head">
             <div className="octo-doc-more-creator">
-              <span className="octo-doc-more-avatar" aria-hidden="true">
-                {avatarInitial(creatorName)}
-              </span>
+              {showAvatarImg ? (
+                <img
+                  className="octo-doc-more-avatar"
+                  src={avatarUrl!}
+                  alt=""
+                  title={creatorName}
+                  onError={() => setAvatarFailed(true)}
+                />
+              ) : (
+                <span className="octo-doc-more-avatar" aria-hidden="true">
+                  {avatarInitial(creatorName)}
+                </span>
+              )}
               <span className="octo-doc-more-name" title={creatorName}>
                 {creatorName}
               </span>

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -2132,6 +2132,14 @@ body.octo-row-resizing {
   justify-content: center;
   text-transform: uppercase;
 }
+/* When a real avatar image is available (creator_uid → /api/v1/users/<uid>/avatar) we swap
+   the span for an img with the same class. object-fit keeps it circular even for non-square
+   sources; background stays as the fallback tint if the image is transparent. */
+img.octo-doc-more-avatar {
+  object-fit: cover;
+  display: block;
+  border: none;
+}
 .octo-doc-more-name {
   font-size: 14px;
   font-weight: 600;

--- a/packages/docs/src/html/HtmlDocCommentPanel.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.tsx
@@ -10,7 +10,7 @@
 // "让 AI 处理" click forwards an instruction to chat (openDocForward). The two are decoupled.
 
 import { useCallback, useEffect, useState } from 'react'
-import { canForwardToChat, openDocForward, t, getWKApp } from '../octoweb/index.ts'
+import { canForwardToChat, openDocForward, t } from '../octoweb/index.ts'
 import {
   createComment,
   formatCommentTime,
@@ -21,6 +21,7 @@ import {
   type OctoDocCommentThread,
 } from './htmlDocComments.ts'
 import { buildAgentInstruction, truncateAnchorText, type AgentInstructionDoc } from './htmlDocAnchor.ts'
+import { avatarUrlFromUid } from './avatarUrl.ts'
 
 export interface HtmlDocCommentPanelProps {
   docId: string
@@ -69,16 +70,7 @@ function authorName(author: OctoDocAuthor | null | undefined): string {
  */
 function avatarUrlFor(author: OctoDocAuthor | null | undefined): string | null {
   if (author?.avatar_url) return author.avatar_url
-  let uid = author?.login?.trim()
-  if (!uid) return null
-  // Strip the Space-scoped prefix (s<spaceId>_) so we address the raw uid, mirroring
-  // WKApp.avatarUser()'s handling of person channel ids.
-  const spaceId = getWKApp().shared?.currentSpaceId
-  if (spaceId && uid.startsWith(`s${spaceId}_`)) {
-    uid = uid.substring(spaceId.length + 2)
-  }
-  if (!uid) return null
-  return `/api/v1/users/${encodeURIComponent(uid)}/avatar`
+  return avatarUrlFromUid(author?.login)
 }
 
 /** Author + time line shown under each root comment and reply. */

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -240,9 +240,10 @@ type LoadState =
 
 // Minimal metadata the render page injects as window.__ODOC__ (see doc-side render).
 // ⚠️ identity here is the CURRENT VIEWER's session identity (identityFromSession), NOT the
-// doc creator. __ODOC__ (core.OverlayConfig) does NOT carry creator_uid — so never derive
-// authorship by comparing viewer uid against identity.login (that is always the viewer =
-// always true). Authorship comes from window.__ODOC_CAP__.isAuthor (see parseOdocCap).
+// doc creator. __ODOC__ carries creator_uid / creator_name / created_at **for display only**
+// (header creator name + avatar image); authorship still comes from window.__ODOC_CAP__.isAuthor
+// (see parseOdocCap). Never write `viewer.login === meta.creator_uid` to gate author-only UI —
+// that both bypasses the backend cap check and lets any viewer forge author capability.
 interface OctoDocMeta {
   slug?: string
   title?: string
@@ -495,6 +496,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
           )}
           <DocMoreMenu
             creatorName={headerCreator}
+            creatorUid={meta?.creator_uid}
             createdAt={meta?.created_at}
             items={[
               {

--- a/packages/docs/src/html/avatarUrl.ts
+++ b/packages/docs/src/html/avatarUrl.ts
@@ -1,0 +1,23 @@
+// Resolve an octo-server avatar URL from a raw user uid. Shared by comment authors
+// (HtmlDocCommentPanel) and the doc header creator (DocMoreMenu via HtmlDocView).
+// Kept in one place so the Space-prefix stripping stays consistent — both surfaces
+// route through the same-origin `/api/v1/users/<uid>/avatar` proxy.
+
+import { getWKApp } from '../octoweb/index.ts'
+
+/**
+ * Build `/api/v1/users/<uid>/avatar` from a raw user uid. Strips the Space-scoped
+ * `s<spaceId>_` prefix (mirrors WKApp.avatarUser()'s handling of person channel ids)
+ * so we address the underlying user, not the Space-scoped alias. Returns null when
+ * no uid is available — caller should fall back to the initial-letter chip.
+ */
+export function avatarUrlFromUid(uid?: string | null): string | null {
+  let u = uid?.trim()
+  if (!u) return null
+  const spaceId = getWKApp().shared?.currentSpaceId
+  if (spaceId && u.startsWith(`s${spaceId}_`)) {
+    u = u.substring(spaceId.length + 2)
+  }
+  if (!u) return null
+  return `/api/v1/users/${encodeURIComponent(u)}/avatar`
+}


### PR DESCRIPTION
Parent: OCT-179 · Spec: OCT-182 · Backend contract (OCT-183, parallel).

## What

Consume the new `__ODOC__.creator_uid` / `creator_name` / `created_at` fields to render a real creator avatar in the DocMoreMenu head. Previously we only had an initial-letter chip; now we try `/api/v1/users/<uid>/avatar` and fall back to the chip on missing uid / broken image.

## Design highlights

- **Auth boundary preserved.** The head avatar is display-only. Authorship still comes from `window.__ODOC_CAP__.isAuthor`. The stale comment in `HtmlDocView.tsx` warning that `__ODOC__` has no `creator_uid` is updated to say the field exists **for display only** and must not be used for cap checks (would let any viewer forge author capability).
- **Single avatar-URL builder.** New `packages/docs/src/html/avatarUrl.ts` exports `avatarUrlFromUid(uid)` with the same Space-prefix-stripping logic that `HtmlDocCommentPanel.avatarUrlFor` had inlined. Comment panel now delegates to it — the two surfaces cannot drift.
- **Failed-load isolation.** `DocMoreMenu` resets its `avatarFailed` state when the uid changes so switching docs re-tries the image.
- **CSS.** New `img.octo-doc-more-avatar` selector, `object-fit: cover`, keeps the circle for non-square sources; fallback tint stays visible for transparent images.

## Files

- `packages/docs/src/html/avatarUrl.ts` (new)
- `packages/docs/src/editor/DocMoreMenu.tsx`
- `packages/docs/src/editor/styles.css`
- `packages/docs/src/html/HtmlDocCommentPanel.tsx`
- `packages/docs/src/html/HtmlDocView.tsx`

## Tests

```
npx vitest run src/editor/DocMoreMenu.test.tsx src/html/HtmlDocView.test.tsx src/html/HtmlDocCommentPanel.test.tsx
# 3 files, 67 tests all pass
```

Full `pnpm test` shows 25 file failures — all pre-existing environment issues (`@univerjs/design` / `markdown-it` not installed), unrelated to this PR. The 1168 executable tests pass. `pnpm typecheck` produces no new errors on the touched files.

## Open item (from spec §3)

Behavior of `/api/v1/users/<uid>/avatar` for an unknown uid needs one manual check on a live env:

- If octo-server returns 4xx → `img.onError` fires → chip fallback. ✅
- If it returns 200 with an empty / non-image body → `img.onError` won't fire and we render a blank frame.

Requires OCT-183 to be deployed to verify against a real endpoint. If 200-empty-image happens, we tighten (size/MIME check on the client, or lock 4xx on the backend).

Draft until that check is done.
