### PR TITLE
fix(docs): let HTML doc owner grant reader on forward (#913)

### DIFF
--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -649,14 +649,67 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     expect(container.querySelector('.octo-modal-overlay')).toBeNull()
   })
 
-  it('forwards the whole-doc link via openDocForward from the header forward button', async () => {
-    serveDoc('<p>body</p>', { title: 'My Doc' })
+  it('forwards a non-owner (isAuthor=false) with canGrant=false and no grantAccess', async () => {
+    // Non-owner path: link only, no grant callback (parity with startDocForward). disabledReason is
+    // supplied so the host can grey the 授权区 with the same i18n text as rich docs.
+    serveDoc('<p>body</p>', { title: 'My Doc' }, { isAuthor: false })
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
     await waitForFrame(container)
     fireEvent.click(screen.getByTitle('docs.forward.entry'))
     expect(wk.openDocForwardCalls).toHaveLength(1)
-    expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', title: 'My Doc', canGrant: false })
-    expect(typeof wk.openDocForwardCalls[0].link).toBe('string')
+    const call = wk.openDocForwardCalls[0]
+    expect(call).toMatchObject({
+      docId: 'd1',
+      title: 'My Doc',
+      canGrant: false,
+      defaultRole: 'reader',
+      disabledReason: 'docs.forward.grantDisabledReason',
+    })
+    expect(call.grantAccess).toBeUndefined()
+    expect(typeof call.link).toBe('string')
+  })
+
+  it('forwards an owner (isAuthor=true) with canGrant=true, defaultRole=reader, and a grantAccess wrapper', async () => {
+    // Owner path: the backend-authoritative isAuthor flag flips canGrant on and injects the
+    // htmlGrantForwardMany wrapper (not the rich-doc grantForwardMany — different backend).
+    serveDoc('<p>body</p>', { title: 'Owner Doc' }, { isAuthor: true })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
+    await waitForFrame(container)
+    fireEvent.click(screen.getByTitle('docs.forward.entry'))
+    expect(wk.openDocForwardCalls).toHaveLength(1)
+    const call = wk.openDocForwardCalls[0]
+    expect(call).toMatchObject({
+      canGrant: true,
+      defaultRole: 'reader',
+      disabledReason: 'docs.forward.grantDisabledReason',
+    })
+    expect(typeof call.grantAccess).toBe('function')
+  })
+
+  it('grantAccess aggregates addGrant per-uid results into {granted, failed, failures}', async () => {
+    // Round-trip the wrapper: intercept the per-uid PUT /v1/docs/{slug}/grants and prove that
+    // one 200 + one 500 collapses to {granted:1, failed:1, failures:['u_bad']} — no rollback.
+    const grantHits: Array<{ uid: string }> = []
+    const cap = '<script>window.__ODOC_CAP__ = {isAuthor: true};</script>'
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/comments')) return jsonResponse({ data: [] })
+      if (url.includes('/v1/docs/') && url.endsWith('/grants') && init?.method === 'PUT') {
+        const body = JSON.parse(String(init.body ?? '{}')) as { uid: string }
+        grantHits.push({ uid: body.uid })
+        return jsonResponse({}, body.uid !== 'u_bad', body.uid === 'u_bad' ? 500 : 200)
+      }
+      return htmlResponse(`${cap}<p>body</p>`)
+    }) as unknown as typeof fetch)
+    const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
+    await waitForFrame(container)
+    fireEvent.click(screen.getByTitle('docs.forward.entry'))
+    await waitFor(() => expect(wk.openDocForwardCalls).toHaveLength(1))
+    const { grantAccess } = wk.openDocForwardCalls[0]
+    expect(typeof grantAccess).toBe('function')
+    const res = await grantAccess!(['u_good', ' u_good ', '', 'u_bad'], 'reader')
+    expect(res).toEqual({ granted: 1, failed: 1, failures: ['u_bad'] })
+    expect(grantHits.map((g) => g.uid).sort()).toEqual(['u_bad', 'u_good'])
   })
 
   it('offers delete only to the author in the ≡ menu', async () => {

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -23,6 +23,7 @@ import { HtmlDocCommentPanel } from './HtmlDocCommentPanel.tsx'
 import { HtmlMemberPanel } from './HtmlMemberPanel.tsx'
 import { HtmlPresenceBar } from './HtmlPresenceBar.tsx'
 import { deleteDoc } from './htmlDocAdmin.ts'
+import { htmlGrantForwardMany } from './htmlGrantsApi.ts'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import {
   DocMoreMenu,
@@ -317,10 +318,19 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
 
   const doForward = useCallback(() => {
     if (!canForward) return
-    // Doc-level forward: the whole document link (not a specific comment). canGrant=false — this
-    // shares a read link, not an access grant.
-    openDocForward({ docId, title: headerTitle, link: docUrl, canGrant: false })
-  }, [canForward, docId, headerTitle, docUrl])
+    // Owner (isAuthor) may grant reader on forward; others only send the link. isAuthor is the
+    // backend-authoritative flag — __ODOC__ carries no creator_uid, so a viewer-uid compare is a bug.
+    const canGrant = isAuthor
+    openDocForward({
+      docId,
+      title: headerTitle,
+      link: docUrl,
+      canGrant,
+      defaultRole: 'reader',
+      disabledReason: t('docs.forward.grantDisabledReason'),
+      grantAccess: canGrant ? (uids, role) => htmlGrantForwardMany(effectiveSlug, uids, role) : undefined,
+    })
+  }, [canForward, docId, headerTitle, docUrl, isAuthor, effectiveSlug])
 
   const confirmDeleteDoc = useCallback(() => {
     setDeleting(true)

--- a/packages/docs/src/html/htmlGrantsApi.ts
+++ b/packages/docs/src/html/htmlGrantsApi.ts
@@ -13,6 +13,7 @@
 
 import { resolveOctoDocBase } from './HtmlDocView.tsx'
 import { getWKApp } from '../octoweb/index.ts'
+import type { DocForwardGrantResult } from '../octoweb/types.ts'
 
 // octo-doc verifies identity via the `token` header (octo convention, not
 // Authorization) — same scheme as the render/comment fetches.
@@ -71,4 +72,25 @@ export async function removeGrant(slug: string, uid: string): Promise<void> {
     headers: grantHeaders({ Accept: 'application/json' }),
   })
   if (!res.ok) throw new Error(`octo-doc removeGrant failed: ${res.status}`)
+}
+
+// Aggregate per-uid addGrant (throw-on-error) into openDocForward's grantAccess contract
+// {granted, failed, failures?}; part-failures do not roll back (parity with forward/api.grantForwardMany).
+export async function htmlGrantForwardMany(
+  slug: string,
+  uids: string[],
+  role: 'reader' | 'writer',
+): Promise<DocForwardGrantResult> {
+  const unique = [...new Set(uids.map((u) => u?.trim()).filter(Boolean) as string[])]
+  let granted = 0
+  const failures: string[] = []
+  for (const uid of unique) {
+    try {
+      await addGrant(slug, uid, role)
+      granted++
+    } catch {
+      failures.push(uid)
+    }
+  }
+  return failures.length ? { granted, failed: failures.length, failures } : { granted, failed: 0 }
 }


### PR DESCRIPTION
Fixes upstream issue Mininglamp-OSS/octo-web#913 (agent-html): HTML doc `≡ → 转发` currently forces `canGrant:false`, so even the doc owner sees a disabled 授权区 and can only send the link.

## Root cause

`packages/docs/src/html/HtmlDocView.tsx` `doForward` hard-codes:

```ts
openDocForward({ docId, title: headerTitle, link: docUrl, canGrant: false })
```

So every viewer (owner included) is treated as non-grantor and `grantAccess`/`defaultRole` are never wired.

## Fix (three files, no behaviour change outside forward)

- `packages/docs/src/html/HtmlDocView.tsx`
  - `canGrant = isAuthor` — the backend-authoritative flag already parsed into component state from `window.__ODOC_CAP__.isAuthor`. We **do not** compare viewer uid against any `__ODOC__` field (`identity.login` is the viewer itself and `creator_uid` is absent — a client-side compare would make every viewer an "owner", the historical invited-viewer bug).
  - Set `defaultRole: 'reader'` (octo-doc backend rejects anything else on `PUT /v1/docs/{slug}/grants`).
  - Preserve `disabledReason: t('docs.forward.grantDisabledReason')` for the non-owner grey-out path, matching `startDocForward.ts`.
  - Wire `grantAccess` only when `canGrant`; the callback delegates to the new `htmlGrantForwardMany` wrapper below.
  - Add `isAuthor` + `effectiveSlug` to the `useCallback` deps.

- `packages/docs/src/html/htmlGrantsApi.ts`
  - Add `htmlGrantForwardMany(slug, uids, role)` that aggregates the per-uid `addGrant` (throw-on-error) into `openDocForward`'s `grantAccess` contract `{granted, failed, failures?}`. De-dupes/trims uids; part-failures do NOT roll back (parity with `forward/api.ts` `grantForwardMany`).
  - Role type kept as `'reader' | 'writer'` to precisely match `OpenDocForwardOptions.grantAccess`; the backend rejects non-reader with 400 so the client-side wrapper does not need a second gate.

- `packages/docs/src/html/HtmlDocView.test.tsx`
  - Tighten the existing header-forward test to cover the non-owner path (`canGrant:false` + `grantAccess === undefined` + `defaultRole:'reader'` + `disabledReason` set).
  - Add owner-path test (`canGrant:true`, `defaultRole:'reader'`, `grantAccess` is a function).
  - Add round-trip test for the aggregator: intercept `PUT /v1/docs/{slug}/grants`, feed one 200 + one 500, and assert `{granted:1, failed:1, failures:['u_bad']}` plus dedup/trim.

### Not touched (deliberately)

- `HtmlDocCommentPanel.handleWithAI` — that's a comment-to-AI instruction, not an access grant. Keeps `canGrant:false`.
- Rich-doc `forward/api.ts` `grantForwardMany` — different backend (Yjs `/docs/{docId}/forward-grant`). Not reused.
- No i18n changes; no backend contract changes.

## Verification

Local (this branch, `packages/docs`):

```
$ pnpm exec vitest run src/html/HtmlDocView.test.tsx
 ✓ src/html/HtmlDocView.test.tsx (50 tests) 1512ms
 Test Files  1 passed (1)
      Tests  50 passed (50)
```

All 50 `HtmlDocView` tests pass, including the three cases added here.

`pnpm typecheck` on `packages/docs` reports two errors that pre-exist on `upstream/main` (verified by re-running with the working tree stashed):

- `../dmworkbase/src/i18n/format.ts(38,3): TS2322 fractionalSecondDigits`
- `src/members/sort.ts(26,9): TS2741 Member.grantedBy missing`

Neither touches the changed surface. No new type errors introduced by this PR.

## Acceptance checks (issue AC 1–5)

1. Owner (`isAuthor=true`) forwarding an HTML doc: 授权区 enabled, no more `grantDisabledReason` on owner path. ✅
2. Owner forward defaults to `reader`; backing `addGrant` is called per uid. ✅ (covered by aggregator test)
3. Non-owner forward: 授权区 disabled (`canGrant:false`), link only. ✅ (covered by non-owner test)
4. `HtmlDocCommentPanel.handleWithAI` unchanged. ✅ (not touched)
5. Backend `requireDocAuthor` still guards `PUT /v1/docs/{slug}/grants`; a non-author flipped to `canGrant:true` client-side would land in `failures`. ✅ (defense-in-depth by upstream backend)

## Draft status

Kept as draft on purpose — this is the review-carrier PR, not a merge candidate. Do not merge from here; the PM will promote after review + deploy + QA.
