### PR TITLE
feat(docs): HtmlMemberPanel full role dropdown, reader-only submit (#912)

### DIFF
--- a/packages/docs/src/html/HtmlMemberPanel.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.tsx
@@ -110,7 +110,8 @@ export function HtmlMemberPanel({
           space={space}
           existingUids={existingUids}
           hideUids={new Set([creatorUid].filter(Boolean) as string[])}
-          roles={['reader']}
+          roles={['reader', 'writer', 'admin']}
+          disabledRoles={['writer', 'admin']}
           onAdd={(uids: string[], _role: Role) => onAdd(uids)}
           busy={busy}
         />

--- a/packages/docs/src/members/MemberPicker.test.tsx
+++ b/packages/docs/src/members/MemberPicker.test.tsx
@@ -115,6 +115,44 @@ describe('MemberPicker (Problem 1)', () => {
     expect(onAdd).toHaveBeenCalledWith(['u_ada'], 'reader')
   })
 
+  it('renders disabledRoles as greyed <option>s (HTML: reader/writer/admin + disabled writer/admin)', async () => {
+    render(
+      <MemberPicker
+        space="s_1"
+        existingUids={new Set()}
+        roles={['reader', 'writer', 'admin']}
+        disabledRoles={['writer', 'admin']}
+        onAdd={() => {}}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    const roleOptions = (screen.getAllByRole('option') as HTMLElement[]).filter(
+      (o) => o.tagName === 'OPTION',
+    ) as HTMLOptionElement[]
+    expect(roleOptions.map((o) => o.value)).toEqual(['reader', 'writer', 'admin'])
+    const byValue = Object.fromEntries(roleOptions.map((o) => [o.value, o]))
+    expect(byValue.reader.disabled).toBe(false)
+    expect(byValue.writer.disabled).toBe(true)
+    expect(byValue.admin.disabled).toBe(true)
+  })
+
+  it('initial role skips disabledRoles so onAdd carries reader (HTML three-fence)', async () => {
+    const onAdd = vi.fn()
+    render(
+      <MemberPicker
+        space="s_1"
+        existingUids={new Set()}
+        roles={['reader', 'writer', 'admin']}
+        disabledRoles={['writer', 'admin']}
+        onAdd={onAdd}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    fireEvent.click(screen.getByText('Ada Lovelace'))
+    fireEvent.click(screen.getByText('docs.member.add').closest('button') as HTMLButtonElement)
+    expect(onAdd).toHaveBeenCalledWith(['u_ada'], 'reader')
+  })
+
   it('falls back to the three default roles when roles={[]} (empty is a no-op, not a foot-gun)', async () => {
     const onAdd = vi.fn()
     render(<MemberPicker space="s_1" existingUids={new Set()} roles={[]} onAdd={onAdd} />)

--- a/packages/docs/src/members/MemberPicker.tsx
+++ b/packages/docs/src/members/MemberPicker.tsx
@@ -44,6 +44,7 @@ export function MemberPicker({
   existingUids,
   hideUids,
   roles = DEFAULT_ROLES,
+  disabledRoles,
   onAdd,
   busy,
 }: {
@@ -57,6 +58,10 @@ export function MemberPicker({
   /** Grantable roles for the dropdown. Default = all three (rich-doc unchanged). HTML docs pass
    *  ['reader'] so only the single "只读" option shows — backend grants only accept reader there. */
   roles?: Role[]
+  /** Roles rendered but non-selectable (option shown greyed). HTML surfaces writer/admin here
+   *  so the dropdown communicates the role model without letting the caller pick one — the
+   *  backend still only accepts reader (three fences: dropdown, initial state, addGrant literal). */
+  disabledRoles?: Role[]
   /** Add the chosen members (one or many) with the chosen role. */
   onAdd: (uids: string[], role: Role) => Promise<void> | void
   /** True while a parent add/refresh is in flight (disables the Add button). */
@@ -64,15 +69,20 @@ export function MemberPicker({
 }) {
   // An empty roles={[]} would yield an undefined role + empty dropdown; fall back to defaults.
   const effectiveRoles = roles.length > 0 ? roles : DEFAULT_ROLES
+  const disabledSet = useMemo(() => new Set(disabledRoles ?? []), [disabledRoles])
   const [members, setMembers] = useState<SpaceMemberLite[]>([])
   const [loading, setLoading] = useState(false)
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
-  // Default to 'writer' when offered (keeps rich-doc's prior initial), else the sole/first role
-  // so a single-role dropdown ('reader' for HTML) is selected without an empty state.
-  const [role, setRole] = useState<Role>(
-    effectiveRoles.includes('writer') ? 'writer' : effectiveRoles[0],
-  )
+  // Initial role: prefer 'writer' (rich-doc's prior default), else the first offered role.
+  // Skip disabledRoles first so HTML (roles=[reader,writer,admin] + disabled=[writer,admin])
+  // starts at reader instead of a greyed writer; fall back to effectiveRoles if the filter
+  // empties the pool (caller misconfig — a valid role beats undefined).
+  const [role, setRole] = useState<Role>(() => {
+    const selectable = effectiveRoles.filter((r) => !disabledSet.has(r))
+    const pool = selectable.length > 0 ? selectable : effectiveRoles
+    return pool.includes('writer') ? 'writer' : pool[0]
+  })
 
   useEffect(() => {
     let active = true
@@ -186,7 +196,7 @@ export function MemberPicker({
       <div className="octo-member-picker-actions">
         <select value={role} onChange={(e) => setRole(e.target.value as Role)}>
           {effectiveRoles.map((r) => (
-            <option key={r} value={r}>
+            <option key={r} value={r} disabled={disabledSet.has(r)}>
               {t(`docs.role.${r}`)}
             </option>
           ))}


### PR DESCRIPTION
Refs #912.

## Change

HTML member panel now shows the full `reader / writer / admin` role dropdown, but only `reader` is selectable — `writer` and `admin` render as greyed `<option disabled>` so users see the role model without being able to pick a role the backend will not honor.

## Approach (Option A: disabled options)

- `MemberPicker` gains an optional `disabledRoles?: Role[]` prop.
  - Renders each disabled role as `<option disabled>`.
  - The initial `role` state skips disabled roles first, then applies the existing "prefer `writer`, else the first offered role" rule — so HTML (`roles=[reader,writer,admin]`, `disabledRoles=[writer,admin]`) starts at `reader` instead of a greyed `writer`.
  - Default (`disabledRoles` absent) → empty set → zero behavior change for rich-doc callers.
- `HtmlMemberPanel` passes `roles={['reader','writer','admin']}` + `disabledRoles={['writer','admin']}`, and `addGrant(slug, uid, 'reader')` stays a hard-coded literal.

## Reader-only, three fences

Even if any single layer were bypassed, the next one still blocks a non-reader grant:

1. Dropdown: `writer` / `admin` `<option>`s carry `disabled` and cannot be selected via the native picker.
2. Initial state: the initial `role` state filters out disabled roles, so the first Add always carries `reader`.
3. Call site: `HtmlMemberPanel.onAdd` ignores the `role` argument and calls `addGrant(..., 'reader')` with a string literal.

## Scope

- UI-only, no backend changes.
- Only three files touched: `MemberPicker.tsx`, `MemberPicker.test.tsx`, `HtmlMemberPanel.tsx`.
- Rich-doc `MemberPanel` path is untouched (no `disabledRoles` passed → identical behavior).

## Tests

`pnpm --filter @octo/docs test` — `MemberPicker.test.tsx` 13/13 pass, including two new cases:

- `disabledRoles` renders greyed `<option>`s (reader enabled, writer/admin disabled).
- Initial `role` state skips disabled roles → `onAdd` receives `'reader'` without any user interaction.

The full `@octo/docs` suite has 4 pre-existing failures in `EditorShell.test.tsx` (tiptap `coordsAtPos` on an unmounted view); these reproduce on `upstream/main` without this change and are unrelated.

Draft: intentionally kept draft per the plan; will be promoted after the follow-up docker end-to-end verification sub-issue lands.
