### PR TITLE
fix(onboarding): preserve WebGL during skip transition

### DIFF
--- a/apps/web/src/Components/Onboarding/index.test.tsx
+++ b/apps/web/src/Components/Onboarding/index.test.tsx
@@ -92,10 +92,11 @@ describe("Onboarding", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps a neutral transition target mounted until the intro skip transition finishes", () => {
+  it("keeps the intro mounted behind the skip target until the transition finishes", () => {
     const onDismiss = vi.fn();
 
     render(<Onboarding forceVisible onDismiss={onDismiss} />);
+    const introDialog = screen.getByRole("dialog");
     fireEvent.click(screen.getByRole("button", { name: "Skip" }));
 
     expect(runOnboardingViewTransition).toHaveBeenCalledOnce();
@@ -103,6 +104,8 @@ describe("Onboarding", () => {
       "seen"
     );
     expect(onDismiss).not.toHaveBeenCalled();
+    expect(introDialog).toBeInTheDocument();
+    expect(introDialog).toHaveAttribute("aria-hidden", "true");
     expect(
       document.querySelector(".wk-onboarding-skip-transition-target")
     ).toBeInTheDocument();

--- a/apps/web/src/Components/Onboarding/index.tsx
+++ b/apps/web/src/Components/Onboarding/index.tsx
@@ -427,32 +427,32 @@ export const Onboarding: React.FC<OnboardingProps> = ({
   }
 
   if (showIntro) {
-    if (isIntroSkipTransitionTarget) {
-      return (
-        <div
-          className="wk-onboarding-overlay wk-onboarding-skip-transition-target"
-          aria-hidden="true"
-        />
-      );
-    }
-
     return (
-      <div
-        ref={dialogRef}
-        className={`wk-onboarding-overlay wk-onboarding-overlay-intro${
-          introLeaving ? " is-intro-leaving" : ""
-        }`}
-        role="dialog"
-        aria-modal="true"
-        aria-label={t("app.onboarding.dialog.introAria")}
-        tabIndex={-1}
-        onKeyDown={handleDialogKeyDown}
-      >
-        <OnboardingIntro
-          onContinue={handleIntroContinue}
-          onSkip={handleIntroSkip}
-        />
-      </div>
+      <>
+        <div
+          ref={dialogRef}
+          className={`wk-onboarding-overlay wk-onboarding-overlay-intro${
+            introLeaving ? " is-intro-leaving" : ""
+          }`}
+          role="dialog"
+          aria-modal="true"
+          aria-hidden={isIntroSkipTransitionTarget ? true : undefined}
+          aria-label={t("app.onboarding.dialog.introAria")}
+          tabIndex={-1}
+          onKeyDown={handleDialogKeyDown}
+        >
+          <OnboardingIntro
+            onContinue={handleIntroContinue}
+            onSkip={handleIntroSkip}
+          />
+        </div>
+        {isIntroSkipTransitionTarget ? (
+          <div
+            className="wk-onboarding-overlay wk-onboarding-skip-transition-target"
+            aria-hidden="true"
+          />
+        ) : null}
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary

- keep the Intro DOM and its `Strands` WebGL canvas mounted while the Skip view transition is running
- layer the neutral transition target above the live Intro instead of replacing the Intro in the transition callback
- unmount the Intro and release its WebGL context only after `transition.finished`
- add a lifecycle regression assertion that the Intro remains mounted behind the target during the transition

## Root cause

The white rectangle in the recording matches the opening `Strands` canvas bounds. The previous implementation replaced the Intro with the neutral target inside `startViewTransition()`, immediately unmounting `Strands` and calling `WEBGL_lose_context`. Edge could capture that released WebGL surface as a white rectangle in the old snapshot.

PRs #908 and #919 addressed the transition target and root snapshot, but did not keep the WebGL canvas alive. This follow-up fixes that lifecycle directly.

## Validation

- `pnpm --dir apps/web exec vitest run src/Components/Onboarding/viewTransition.test.ts src/Components/Onboarding/index.test.tsx` (2 files, 6 tests)
- `pnpm --dir apps/web build`
- `git diff --check`
- Microsoft Edge + Storybook lifecycle sampling: Intro and Strands canvas remain connected with zero context-loss events throughout the 1240 ms transition; both are released after completion

Fixes #896.