### PR TITLE
fix(login): trim updater download URLs

### DIFF
--- a/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
+++ b/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
@@ -189,9 +189,9 @@ describe("IOSDownloadButton", () => {
     expect(html).not.toContain("手机扫码安装");
   });
 
-  it("renders the updater-provided iOS URL as a scannable QR code", async () => {
+  it("trims Unicode whitespace from the updater URL before rendering the QR code", async () => {
     const updaterUrl = "https://testflight.apple.com/join/backendCode";
-    apiFetchJsonMock.mockResolvedValue({ url: updaterUrl });
+    apiFetchJsonMock.mockResolvedValue({ url: `\u2004${updaterUrl}\u2004` });
     const container = document.createElement("div");
     document.body.appendChild(container);
     mountedContainers.push(container);

--- a/packages/dmworklogin/src/mobileDownloadUpdater.ts
+++ b/packages/dmworklogin/src/mobileDownloadUpdater.ts
@@ -9,9 +9,11 @@ export function resolveMobileUpdaterUrl(
 }
 
 function resolveSafeDownloadUrl(value: unknown) {
-  if (typeof value !== "string" || !value.trim()) return undefined;
+  if (typeof value !== "string") return undefined;
+  const normalizedValue = value.trim();
+  if (!normalizedValue) return undefined;
   try {
-    const url = new URL(value, window.location.origin);
+    const url = new URL(normalizedValue, window.location.origin);
     if (url.protocol === "http:" || url.protocol === "https:") {
       return url.toString();
     }


### PR DESCRIPTION
## Summary

- trim leading and trailing Unicode whitespace from updater-provided download URLs before parsing
- prevent an iOS App Store URL prefixed with `U+2004` from being misparsed as a same-origin relative path
- add a regression test covering the real Unicode-whitespace response shape

## Root cause

The test updater returned a URL beginning with `U+2004` (`e2 80 84`). The existing guard checked `value.trim()` for emptiness but passed the original untrimmed value to `new URL()`, producing a URL such as `https://im-test.deepminer.com.cn/%E2%80%84https://apps.apple.com/...`.

## Testing

- `pnpm --filter @octo/login test -- src/__tests__/ios_download_button.test.tsx` (19 files, 209 tests)
- `pnpm i18n:check`
- `git diff --check`