### PR TITLE
feat(contacts): refactor search and directory sections

### DIFF
--- a/packages/dmworkcontacts/src/Contacts/index.css
+++ b/packages/dmworkcontacts/src/Contacts/index.css
@@ -65,129 +65,57 @@
 }
 
 /* ============================================================
-   搜索框
-   ============================================================ */
-.wk-contacts-search {
-    padding: var(--wk-sp-2) var(--wk-sp-3);
-    flex-shrink: 0;
-}
-
-.wk-contacts-search-input {
-    display: flex;
-    align-items: center;
-    gap: var(--wk-sp-2);
-    padding: var(--wk-sp-2) var(--wk-sp-3);
-    background: var(--wk-bg-elevated);
-    border: 1.5px solid transparent;
-    border-radius: var(--wk-r-md);
-    transition: border-color var(--wk-dur-fast);
-}
-
-.wk-contacts-search-input:focus-within {
-    border-color: var(--wk-brand-primary);
-}
-
-.wk-contacts-search-icon {
-    flex-shrink: 0;
-    color: var(--wk-text-tertiary);
-}
-
-.wk-contacts-search-input input {
-    flex: 1;
-    border: none;
-    outline: none;
-    background: transparent;
-    font-size: 12px;
-    color: var(--wk-text-primary);
-    min-width: 0;
-}
-
-.wk-contacts-search-input input::placeholder {
-    color: var(--wk-text-tertiary);
-}
-
-.wk-contacts-search-clear {
-    flex-shrink: 0;
-    cursor: pointer;
-    color: var(--wk-text-tertiary);
-    font-size: 16px;
-    line-height: 1;
-    padding: 0 2px;
-}
-
-.wk-contacts-search-clear:hover {
-    color: var(--wk-text-secondary);
-}
-
-/* ============================================================
-   搜索结果
-   ============================================================ */
-.wk-contacts-search-results {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-    padding: var(--wk-sp-1) 0;
-}
-
-.wk-contacts-search-section {
-    margin-bottom: var(--wk-sp-2);
-}
-
-.wk-contacts-search-section-title {
-    padding: var(--wk-sp-1) var(--wk-sp-4);
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--wk-text-tertiary);
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-}
-
-/* ============================================================
    筛选标签
    ============================================================ */
 .wk-contacts-filters {
     display: flex;
-    gap: 6px;
+    gap: var(--wk-sp-2);
     padding: var(--wk-sp-1) var(--wk-sp-4) var(--wk-sp-2);
 }
 
 .wk-contacts-chip {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 5px 12px;
+    gap: var(--wk-sp-1);
+    min-height: var(--wk-sp-6);
+    padding: 0 var(--wk-sp-3);
+    box-sizing: border-box;
     border-radius: var(--wk-r-full);
     border: 1px solid var(--wk-border-default);
-    background: transparent;
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--semi-color-text-2);
+    background: var(--wk-bg-surface);
+    font-size: var(--wk-text-size-sm);
+    font-weight: 400;
+    color: var(--wk-text-secondary);
     cursor: pointer;
-    transition: all var(--wk-dur) var(--wk-ease);
+    transition:
+        background var(--wk-dur-fast) var(--wk-ease),
+        border-color var(--wk-dur-fast) var(--wk-ease),
+        color var(--wk-dur-fast) var(--wk-ease);
     user-select: none;
     line-height: 1;
 }
 
 .wk-contacts-chip:hover {
-    background: var(--semi-color-fill-0);
-    border-color: var(--semi-color-fill-0);
+    background: var(--wk-bg-elevated);
+    border-color: var(--wk-border-strong);
+    color: var(--wk-text-primary);
 }
 
 .wk-contacts-chip.active {
-    background: color-mix(in srgb, var(--wk-brand-primary) 8%, transparent);
-    border-color: color-mix(in srgb, var(--wk-brand-primary) 20%, transparent);
-    color: var(--wk-text-accent);
+    background: color-mix(in srgb, var(--wk-bg-active) 45%, var(--wk-bg-surface));
+    border-color: var(--wk-border-strong);
+    color: var(--wk-text-primary);
     font-weight: 600;
 }
 
 .wk-contacts-chip-count {
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--semi-color-text-3);
+    font-size: var(--wk-text-size-sm);
+    font-weight: inherit;
+    color: var(--wk-text-tertiary);
 }
 
 .wk-contacts-chip.active .wk-contacts-chip-count {
-    color: var(--wk-brand-primary);
+    color: var(--wk-text-primary);
 }
 
 /* ============================================================
@@ -202,68 +130,6 @@
     font-weight: 500;
     background: var(--wk-bg-active, #E2E3EA);
     color: var(--wk-text-secondary, #5C6070);
-}
-
-/* ============================================================
-   手风琴分组
-   ============================================================ */
-.wk-contacts-accordion {
-    margin-bottom: var(--wk-sp-1);
-    flex-shrink: 0;
-}
-
-.wk-contacts-accordion--expanded {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-}
-
-.wk-contacts-accordion-header {
-    display: flex;
-    align-items: center;
-    height: 36px;
-    padding: 0 var(--wk-sp-3);
-    cursor: pointer;
-    user-select: none;
-    border-radius: var(--wk-r-sm);
-    margin: 0 var(--wk-sp-2);
-    transition: background var(--wk-dur-fast) var(--wk-ease);
-}
-
-.wk-contacts-accordion-header:hover {
-    background: var(--wk-bg-hover);
-}
-
-.wk-contacts-accordion-arrow {
-    display: inline-flex;
-    align-items: center;
-    color: var(--wk-text-tertiary);
-    margin-right: var(--wk-sp-2);
-    flex-shrink: 0;
-}
-
-.wk-contacts-accordion-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    margin-right: var(--wk-sp-2);
-    color: var(--wk-text-secondary);
-    flex-shrink: 0;
-}
-
-.wk-contacts-accordion-label {
-    flex: 1;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--wk-text-secondary);
-    letter-spacing: 0.01em;
-}
-
-.wk-contacts-accordion-count {
-    font-size: 12px;
-    color: var(--wk-text-tertiary);
-    font-weight: 400;
 }
 
 .wk-contacts-accordion-body {

--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -6,7 +6,7 @@ import { toSimplized } from "@octo/base";
 import { getPinyin } from "@octo/base";
 import classnames from "classnames";
 import { Toast, Tooltip } from "@douyinfe/semi-ui";
-import { ChevronRight, ChevronDown, Users, Bot, UsersRound, Search as SearchIcon } from "lucide-react";
+import { ChevronRight, Users, Bot, UsersRound } from "lucide-react";
 
 import { Channel, ChannelTypePerson, ChannelTypeGroup, WKSDK, ChannelInfoListener, ChannelInfo } from "wukongimjssdk";
 import { ContactsListManager } from "../Service/ContactsListManager";
@@ -21,6 +21,10 @@ import { debounce } from "@octo/base/src/Utils/rateLimit";
 import { OnlineStatusBadge, needShowOnlineStatus, getOnlineTip } from "@octo/base/src/Components/ConversationList";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { shouldShowOnlineStatus, selectOnlineStatusUids } from "./onlineStatusGate";
+import ContactsSearch from "../ui/ContactsSearch";
+import { ContactsDirectory, ContactsDirectorySection } from "../ui/ContactsDirectory";
+import type { ContactsDirectorySectionKey } from "../ui/ContactsDirectory/types";
+import { searchContacts } from "../bridge/contactsSearch/searchContacts";
 
 function OverflowTooltip({ text, children }: { text: string; children: React.ReactNode }) {
     const [visible, setVisible] = useState(false)
@@ -534,23 +538,12 @@ export default class ContactsList extends Component<any, ContactsState> {
             return
         }
 
-        const { spaceMembers, spaceBots, myGroups } = this.state
-        const myUID = WKApp.loginInfo.uid || ""
-        const kw = keyword.toLowerCase()
-
-        const memberUids = new Set(spaceMembers.map(m => m.uid))
-        const memberResults = spaceMembers
-            .filter(m => m.uid !== myUID)
-            .filter(m => m.name.replace(/\*\*/g, '').toLowerCase().includes(kw))
-        // spaceBots 中不在 members 里的 AI 也参与搜索
-        const extraBotResults = (spaceBots || [])
-            .filter((b: any) => b.uid !== myUID && !memberUids.has(b.uid))
-            .filter((b: any) => (b.name || '').toLowerCase().includes(kw))
-            .map((b: any) => ({ ...b, robot: 1 }))
-        const contacts = [...memberResults, ...extraBotResults]
-
-        const groups = (myGroups || [])
-            .filter((g: any) => g.name && g.name.toLowerCase().includes(kw))
+        const { contacts, groups } = searchContacts(keyword, {
+            spaceMembers: this.state.spaceMembers,
+            spaceBots: this.state.spaceBots,
+            myGroups: this.state.myGroups,
+            currentUid: WKApp.loginInfo.uid || "",
+        })
 
         this.setState({
             isSearching: true,
@@ -568,7 +561,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         this.setState({ keyword: '', isSearching: false, searchContacts: [], searchGroups: [] })
     }
 
-    private toggleSection = (section: 'groups' | 'myBots' | 'allContacts') => {
+    private toggleSection = (section: ContactsDirectorySectionKey) => {
         const willExpand = this.state.expandedSection !== section
         this.setState({
             expandedSection: willExpand ? section : null,
@@ -630,43 +623,25 @@ export default class ContactsList extends Component<any, ContactsState> {
         )
     }
 
-    renderSearchBox() {
-        return (
-            <div className="wk-contacts-search">
-                <div className="wk-contacts-search-input">
-                    <SearchIcon size={14} className="wk-contacts-search-icon" />
-                    <input
-                        type="text"
-                        placeholder={t("contacts.search.placeholder")}
-                        value={this.state.keyword || ''}
-                        onChange={(e) => this.handleSearchChange(e.target.value)}
-                    />
-                    {this.state.keyword && (
-                        <span className="wk-contacts-search-clear" onClick={this.handleClearSearch}>&times;</span>
-                    )}
-                </div>
-            </div>
-        )
-    }
-
-    renderSearchResults() {
+    renderSearch() {
         const { searchContacts, searchGroups } = this.state
-
-        if (searchContacts.length === 0 && searchGroups.length === 0) {
-            return (
-                <div className="wk-contacts-empty">
-                    <SearchIcon size={28} className="wk-contacts-empty-icon" />
-                    <div className="wk-contacts-empty-text">{t("contacts.search.noResults")}</div>
-                </div>
-            )
-        }
-
         return (
-            <div className="wk-contacts-search-results">
-                {searchContacts.length > 0 && (
-                    <div className="wk-contacts-search-section">
-                        <div className="wk-contacts-search-section-title">{t("contacts.section.contacts")}</div>
-                        {searchContacts.map((m: any) => (
+            <ContactsSearch
+                copy={{
+                    placeholder: t("contacts.search.placeholder"),
+                    emptyText: t("contacts.search.noResults"),
+                    contactsTitle: t("contacts.section.contacts"),
+                    groupsTitle: t("contacts.section.groups"),
+                }}
+                state={{
+                    keyword: this.state.keyword || '',
+                    isSearching: this.state.isSearching,
+                    hasResults: searchContacts.length > 0 || searchGroups.length > 0,
+                }}
+                onKeywordChange={this.handleSearchChange}
+                onClear={this.handleClearSearch}
+                results={{
+                    contacts: searchContacts.length > 0 ? searchContacts.map((m: any) => (
                             <div key={m.uid} className="wk-contacts-section-item" onClick={() => {
                                 this.handleContactClick(m.uid, m.robot === 1)
                             }}>
@@ -678,13 +653,8 @@ export default class ContactsList extends Component<any, ContactsState> {
                                     {m.robot === 1 && <AiBadge />}
                                 </div>
                             </div>
-                        ))}
-                    </div>
-                )}
-                {searchGroups.length > 0 && (
-                    <div className="wk-contacts-search-section">
-                        <div className="wk-contacts-search-section-title">{t("contacts.section.groups")}</div>
-                        {searchGroups.map((g: any) => (
+                        )) : undefined,
+                    groups: searchGroups.length > 0 ? searchGroups.map((g: any) => (
                             <div key={g.group_no} className="wk-contacts-section-item" onClick={() => {
                                 this.handleGroupClick(g.group_no, g.name, g.member_count)
                             }}>
@@ -695,10 +665,9 @@ export default class ContactsList extends Component<any, ContactsState> {
                                     <span className="wk-contacts-group-tag">{t("contacts.tag.group")}</span>
                                 </OverflowTooltip>
                             </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+                        )) : undefined,
+                }}
+            />
         )
     }
 
@@ -731,27 +700,13 @@ export default class ContactsList extends Component<any, ContactsState> {
         )
     }
 
-    renderAccordionHeader(section: 'groups' | 'myBots' | 'allContacts', icon: React.ReactNode, label: string, count: number) {
-        const isExpanded = this.state.expandedSection === section
-        return (
-            <div className="wk-contacts-accordion-header" onClick={() => this.toggleSection(section)}>
-                <span className="wk-contacts-accordion-arrow">{isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}</span>
-                <span className="wk-contacts-accordion-icon">{icon}</span>
-                <span className="wk-contacts-accordion-label">{label}</span>
-                {count > 0 && <span className="wk-contacts-accordion-count">({count})</span>}
-            </div>
-        )
-    }
-
     renderGroupsSection() {
         const { expandedSection, myGroups } = this.state
         const isExpanded = expandedSection === 'groups'
         const groups = myGroups || []
 
         return (
-            <div className={classnames("wk-contacts-accordion", isExpanded && "wk-contacts-accordion--expanded")}>
-                {this.renderAccordionHeader('groups', <UsersRound size={16} />, t("contacts.section.groups"), groups.length)}
-                {isExpanded && (
+            <ContactsDirectorySection sectionKey="groups" expanded={isExpanded} icon={<UsersRound size={16} />} label={t("contacts.section.groups")} count={groups.length} onToggle={this.toggleSection}>
                     <div className="wk-contacts-accordion-body">
                         {groups.length === 0 ? (
                             <div className="wk-contacts-empty">
@@ -771,8 +726,7 @@ export default class ContactsList extends Component<any, ContactsState> {
                             </div>
                         ))}
                     </div>
-                )}
-            </div>
+            </ContactsDirectorySection>
         )
     }
 
@@ -782,9 +736,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         const bots = myBots || []
 
         return (
-            <div className={classnames("wk-contacts-accordion", isExpanded && "wk-contacts-accordion--expanded")}>
-                {this.renderAccordionHeader('myBots', <Bot size={16} />, t("contacts.section.addedAi"), bots.length)}
-                {isExpanded && (
+            <ContactsDirectorySection sectionKey="myBots" expanded={isExpanded} icon={<Bot size={16} />} label={t("contacts.section.addedAi")} count={bots.length} onToggle={this.toggleSection}>
                     <div className="wk-contacts-accordion-body">
                         {bots.length === 0 ? (
                             <div className="wk-contacts-empty">
@@ -806,8 +758,7 @@ export default class ContactsList extends Component<any, ContactsState> {
                             </div>
                         ))}
                     </div>
-                )}
-            </div>
+            </ContactsDirectorySection>
         )
     }
 
@@ -817,9 +768,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         const totalCount = this.flatItems.length
 
         return (
-            <div className={classnames("wk-contacts-accordion", isExpanded && "wk-contacts-accordion--expanded")}>
-                {this.renderAccordionHeader('allContacts', <Users size={16} />, t("contacts.section.allContacts"), totalCount)}
-                {isExpanded && (
+            <ContactsDirectorySection sectionKey="allContacts" expanded={isExpanded} icon={<Users size={16} />} label={t("contacts.section.allContacts")} count={totalCount} onToggle={this.toggleSection}>
                     <>
                         {this.renderFilterChips()}
                         {totalCount === 0 ? (
@@ -829,8 +778,7 @@ export default class ContactsList extends Component<any, ContactsState> {
                             </div>
                         ) : this.renderContactListWithLetters()}
                     </>
-                )}
-            </div>
+            </ContactsDirectorySection>
         )
     }
 
@@ -910,16 +858,14 @@ export default class ContactsList extends Component<any, ContactsState> {
                 <div className="wk-contacts">
                     <div className="wk-contacts-content">
                         {this.renderBotFatherBanner()}
-                        {this.renderSearchBox()}
+                        {this.renderSearch()}
 
-                        {isSearching ? (
-                            this.renderSearchResults()
-                        ) : (
-                            <>
+                        {!isSearching && (
+                            <ContactsDirectory>
                                 {this.renderGroupsSection()}
                                 {this.renderMyBotsSection()}
                                 {this.renderAllContactsSection()}
-                            </>
+                            </ContactsDirectory>
                         )}
                     </div>
 

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.test.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { searchContacts } from "./searchContacts";
+
+describe("searchContacts", () => {
+  const source = {
+    currentUid: "self",
+    spaceMembers: [
+      { uid: "self", name: "Self" },
+      { uid: "human", name: "**Alice**", robot: 0 },
+      { uid: "member-bot", name: "Helper AI", robot: 1 },
+    ],
+    spaceBots: [
+      { uid: "member-bot", name: "Helper AI" },
+      { uid: "extra-bot", name: "Extra AI" },
+    ],
+    myGroups: [{ group_no: "group-1", name: "Alice Group" }],
+  };
+
+  it("keeps current matching, exclusion and extra-bot dedup behavior", () => {
+    expect(searchContacts("alice", source)).toEqual({
+      contacts: [{ uid: "human", name: "**Alice**", robot: 0 }],
+      groups: [{ group_no: "group-1", name: "Alice Group" }],
+    });
+    expect(
+      searchContacts("ai", source).contacts.map((item) => item.uid)
+    ).toEqual(["member-bot", "extra-bot"]);
+    expect(searchContacts("self", source).contacts).toEqual([]);
+  });
+});

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.ts
@@ -1,0 +1,33 @@
+import type {
+  ContactsSearchBot,
+  ContactsSearchResult,
+  ContactsSearchSource,
+} from "./types";
+
+function normalizeName(value?: string): string {
+  return (value || "").replace(/\*\*/g, "").toLowerCase();
+}
+
+export function searchContacts(
+  keyword: string,
+  source: ContactsSearchSource
+): ContactsSearchResult {
+  const normalizedKeyword = keyword.toLowerCase();
+  const memberUids = new Set(source.spaceMembers.map((member) => member.uid));
+  const memberResults = source.spaceMembers
+    .filter((member) => member.uid !== source.currentUid)
+    .filter((member) => normalizeName(member.name).includes(normalizedKeyword));
+  const extraBotResults = source.spaceBots
+    .filter((bot) => bot.uid !== source.currentUid && !memberUids.has(bot.uid))
+    .filter((bot) => normalizeName(bot.name).includes(normalizedKeyword))
+    .map((bot) => {
+      const item: ContactsSearchBot = { ...bot, robot: 1 };
+      return item;
+    });
+  const groups = source.myGroups.filter(
+    (group) =>
+      group.name && normalizeName(group.name).includes(normalizedKeyword)
+  );
+
+  return { contacts: [...memberResults, ...extraBotResults], groups };
+}

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/types.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/types.ts
@@ -1,0 +1,28 @@
+import type { SpaceMember } from "@octo/base/src/Service/SpaceService";
+
+export interface ContactsSearchBot {
+  uid: string;
+  name?: string;
+  robot?: number;
+  avatar?: string;
+  status?: string;
+  description?: string;
+}
+
+export interface ContactsSearchGroup {
+  group_no: string;
+  name?: string;
+  member_count?: number;
+}
+
+export interface ContactsSearchSource {
+  spaceMembers: SpaceMember[];
+  spaceBots: ContactsSearchBot[];
+  myGroups: ContactsSearchGroup[];
+  currentUid: string;
+}
+
+export interface ContactsSearchResult {
+  contacts: Array<SpaceMember | ContactsSearchBot>;
+  groups: ContactsSearchGroup[];
+}

--- a/packages/dmworkcontacts/src/ui/ContactsDirectory/ContactsDirectory.stories.tsx
+++ b/packages/dmworkcontacts/src/ui/ContactsDirectory/ContactsDirectory.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import { Bot, Users, UsersRound } from "lucide-react";
+import ContactsDirectory, { ContactsDirectorySection } from "./index";
+
+const meta: Meta<typeof ContactsDirectory> = {
+  title: "Contacts/ContactsDirectory",
+  component: ContactsDirectory,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "通讯录群聊、已添加 AI 和全部联系人三个手风琴区的纯 UI 外壳，不读取 WKSDK 或业务数据。",
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ContactsDirectory>;
+
+const onToggle = () => undefined;
+
+function sectionSet(expanded: "groups" | "myBots" | "allContacts" | null) {
+  return (
+    <>
+      <ContactsDirectorySection
+        sectionKey="groups"
+        expanded={expanded === "groups"}
+        icon={<UsersRound size={16} />}
+        label="群聊"
+        count={8}
+        onToggle={onToggle}
+      >
+        <div className="wk-contacts-section-item">产品交流群</div>
+      </ContactsDirectorySection>
+      <ContactsDirectorySection
+        sectionKey="myBots"
+        expanded={expanded === "myBots"}
+        icon={<Bot size={16} />}
+        label="已添加 AI"
+        count={3}
+        onToggle={onToggle}
+      >
+        <div className="wk-contacts-section-item">Octo AI</div>
+      </ContactsDirectorySection>
+      <ContactsDirectorySection
+        sectionKey="allContacts"
+        expanded={expanded === "allContacts"}
+        icon={<Users size={16} />}
+        label="全部联系人"
+        count={128}
+        onToggle={onToggle}
+      >
+        <div className="wk-contacts-section-item">联系人列表区域</div>
+      </ContactsDirectorySection>
+    </>
+  );
+}
+
+export const Default: Story = { args: { children: sectionSet("allContacts") } };
+
+export const AllVariants: Story = { args: { children: sectionSet("groups") } };
+
+export const States: Story = { args: { children: sectionSet(null) } };
+
+export const EdgeCases: Story = {
+  args: {
+    children: (
+      <ContactsDirectorySection
+        sectionKey="allContacts"
+        expanded
+        icon={<Users size={16} />}
+        label="名称很长的全部联系人分组"
+        count={10_000}
+        onToggle={onToggle}
+      >
+        <div className="wk-contacts-section-item">名称很长的联系人内容区域</div>
+      </ContactsDirectorySection>
+    ),
+  },
+};

--- a/packages/dmworkcontacts/src/ui/ContactsDirectory/index.css
+++ b/packages/dmworkcontacts/src/ui/ContactsDirectory/index.css
@@ -1,0 +1,51 @@
+.wk-contacts-accordion {
+  margin-bottom: var(--wk-sp-1);
+  flex-shrink: 0;
+}
+.wk-contacts-accordion--expanded {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.wk-contacts-accordion-header {
+  display: flex;
+  align-items: center;
+  height: calc(var(--wk-sp-8) + var(--wk-sp-1));
+  padding: 0 var(--wk-sp-3);
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--wk-r-sm);
+  margin: 0 var(--wk-sp-2);
+  transition: background var(--wk-dur-fast) var(--wk-ease);
+}
+.wk-contacts-accordion-header:hover {
+  background: var(--wk-bg-hover);
+}
+.wk-contacts-accordion-arrow {
+  display: inline-flex;
+  align-items: center;
+  color: var(--wk-text-tertiary);
+  margin-right: var(--wk-sp-2);
+  flex-shrink: 0;
+}
+.wk-contacts-accordion-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--wk-sp-5);
+  margin-right: var(--wk-sp-2);
+  color: var(--wk-text-secondary);
+  flex-shrink: 0;
+}
+.wk-contacts-accordion-label {
+  flex: 1;
+  font-size: var(--wk-text-size-base);
+  font-weight: 600;
+  color: var(--wk-text-secondary);
+  letter-spacing: 0.01em;
+}
+.wk-contacts-accordion-count {
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-text-tertiary);
+  font-weight: 400;
+}

--- a/packages/dmworkcontacts/src/ui/ContactsDirectory/index.tsx
+++ b/packages/dmworkcontacts/src/ui/ContactsDirectory/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import classnames from "classnames";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type {
+  ContactsDirectoryProps,
+  ContactsDirectorySectionProps,
+} from "./types";
+import "./index.css";
+
+export function ContactsDirectory({ children }: ContactsDirectoryProps) {
+  return <>{children}</>;
+}
+
+export default ContactsDirectory;
+
+export function ContactsDirectorySection({
+  sectionKey,
+  expanded,
+  icon,
+  label,
+  count,
+  children,
+  onToggle,
+}: ContactsDirectorySectionProps) {
+  return (
+    <div
+      className={classnames(
+        "wk-contacts-accordion",
+        expanded && "wk-contacts-accordion--expanded"
+      )}
+    >
+      <div
+        className="wk-contacts-accordion-header"
+        onClick={() => onToggle(sectionKey)}
+      >
+        <span className="wk-contacts-accordion-arrow">
+          {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <span className="wk-contacts-accordion-icon">{icon}</span>
+        <span className="wk-contacts-accordion-label">{label}</span>
+        {count > 0 && (
+          <span className="wk-contacts-accordion-count">({count})</span>
+        )}
+      </div>
+      {expanded && children}
+    </div>
+  );
+}

--- a/packages/dmworkcontacts/src/ui/ContactsDirectory/types.ts
+++ b/packages/dmworkcontacts/src/ui/ContactsDirectory/types.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+export type ContactsDirectorySectionKey = "groups" | "myBots" | "allContacts";
+
+export interface ContactsDirectorySectionProps {
+  sectionKey: ContactsDirectorySectionKey;
+  expanded: boolean;
+  icon: ReactNode;
+  label: string;
+  count: number;
+  children?: ReactNode;
+  onToggle: (section: ContactsDirectorySectionKey) => void;
+}
+
+export interface ContactsDirectoryProps {
+  children: ReactNode;
+}

--- a/packages/dmworkcontacts/src/ui/ContactsSearch/ContactsSearch.stories.tsx
+++ b/packages/dmworkcontacts/src/ui/ContactsSearch/ContactsSearch.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import ContactsSearch from "./index";
+
+const copy = {
+  placeholder: "搜索联系人、AI 或群聊",
+  emptyText: "未找到结果",
+  contactsTitle: "联系人",
+  groupsTitle: "群聊",
+};
+
+const meta: Meta<typeof ContactsSearch> = {
+  title: "Contacts/ContactsSearch",
+  component: ContactsSearch,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "通讯录搜索的纯 UI，包括默认、结果、空状态和长文本状态。数据与点击行为由 Contacts 容器提供。",
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ContactsSearch>;
+
+const handlers = {
+  onKeywordChange: () => undefined,
+  onClear: () => undefined,
+};
+
+export const Default: Story = {
+  args: {
+    copy,
+    state: { keyword: "", isSearching: false, hasResults: false },
+    results: {},
+    ...handlers,
+  },
+};
+
+export const AllVariants: Story = {
+  args: {
+    copy,
+    state: { keyword: "Octo", isSearching: true, hasResults: true },
+    results: {
+      contacts: <div className="wk-contacts-section-item">Octo AI</div>,
+      groups: <div className="wk-contacts-section-item">Octo 群聊</div>,
+    },
+    ...handlers,
+  },
+};
+
+export const States: Story = {
+  args: {
+    copy,
+    state: { keyword: "missing", isSearching: true, hasResults: false },
+    results: {},
+    ...handlers,
+  },
+};
+
+export const EdgeCases: Story = {
+  args: {
+    copy: { ...copy, placeholder: "搜索名称很长的联系人、AI 助手或群聊" },
+    state: {
+      keyword: "very-long-search-keyword-for-contact",
+      isSearching: true,
+      hasResults: true,
+    },
+    results: {
+      contacts: (
+        <div className="wk-contacts-section-item">名称非常长的联系人示例</div>
+      ),
+    },
+    ...handlers,
+  },
+};

--- a/packages/dmworkcontacts/src/ui/ContactsSearch/index.css
+++ b/packages/dmworkcontacts/src/ui/ContactsSearch/index.css
@@ -1,0 +1,63 @@
+.wk-contacts-search {
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  flex-shrink: 0;
+}
+
+.wk-contacts-search-input {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  background: var(--wk-bg-elevated);
+  border: 1.5px solid transparent;
+  border-radius: var(--wk-r-md);
+  transition: border-color var(--wk-dur-fast);
+}
+
+.wk-contacts-search-input:focus-within {
+  border-color: var(--wk-brand-primary);
+}
+.wk-contacts-search-icon {
+  flex-shrink: 0;
+  color: var(--wk-text-tertiary);
+}
+.wk-contacts-search-input input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-text-primary);
+  min-width: 0;
+}
+.wk-contacts-search-input input::placeholder {
+  color: var(--wk-text-tertiary);
+}
+.wk-contacts-search-clear {
+  flex-shrink: 0;
+  cursor: pointer;
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-xl);
+  line-height: 1;
+  padding: 0 var(--wk-sp-1);
+}
+.wk-contacts-search-clear:hover {
+  color: var(--wk-text-secondary);
+}
+.wk-contacts-search-results {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--wk-sp-1) 0;
+}
+.wk-contacts-search-section {
+  margin-bottom: var(--wk-sp-2);
+}
+.wk-contacts-search-section-title {
+  padding: var(--wk-sp-1) var(--wk-sp-4);
+  font-size: var(--wk-text-size-xs);
+  font-weight: 600;
+  color: var(--wk-text-tertiary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}

--- a/packages/dmworkcontacts/src/ui/ContactsSearch/index.tsx
+++ b/packages/dmworkcontacts/src/ui/ContactsSearch/index.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Search as SearchIcon } from "lucide-react";
+import type { ContactsSearchProps } from "./types";
+import "./index.css";
+
+function ContactsSearch({
+  copy,
+  state,
+  results,
+  onKeywordChange,
+  onClear,
+}: ContactsSearchProps) {
+  return (
+    <>
+      <div className="wk-contacts-search">
+        <div className="wk-contacts-search-input">
+          <SearchIcon size={14} className="wk-contacts-search-icon" />
+          <input
+            type="text"
+            placeholder={copy.placeholder}
+            value={state.keyword}
+            onChange={(event) => onKeywordChange(event.target.value)}
+          />
+          {state.keyword && (
+            <span className="wk-contacts-search-clear" onClick={onClear}>
+              &times;
+            </span>
+          )}
+        </div>
+      </div>
+      {state.isSearching &&
+        (state.hasResults ? (
+          <div className="wk-contacts-search-results">
+            {results.contacts && (
+              <div className="wk-contacts-search-section">
+                <div className="wk-contacts-search-section-title">
+                  {copy.contactsTitle}
+                </div>
+                {results.contacts}
+              </div>
+            )}
+            {results.groups && (
+              <div className="wk-contacts-search-section">
+                <div className="wk-contacts-search-section-title">
+                  {copy.groupsTitle}
+                </div>
+                {results.groups}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="wk-contacts-empty">
+            <SearchIcon size={28} className="wk-contacts-empty-icon" />
+            <div className="wk-contacts-empty-text">{copy.emptyText}</div>
+          </div>
+        ))}
+    </>
+  );
+}
+
+export default ContactsSearch;
+export { ContactsSearch };

--- a/packages/dmworkcontacts/src/ui/ContactsSearch/types.ts
+++ b/packages/dmworkcontacts/src/ui/ContactsSearch/types.ts
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+export interface ContactsSearchCopy {
+  placeholder: string;
+  emptyText: string;
+  contactsTitle: string;
+  groupsTitle: string;
+}
+
+export interface ContactsSearchState {
+  keyword: string;
+  isSearching: boolean;
+  hasResults: boolean;
+}
+
+export interface ContactsSearchResults {
+  contacts?: ReactNode;
+  groups?: ReactNode;
+}
+
+export interface ContactsSearchProps {
+  copy: ContactsSearchCopy;
+  state: ContactsSearchState;
+  results: ContactsSearchResults;
+  onKeywordChange: (value: string) => void;
+  onClear: () => void;
+}


### PR DESCRIPTION
Extract props-only search and accordion UI boundaries while preserving existing contacts behavior. Add focused search regression coverage and Storybook states, and align filter tabs with the approved neutral style.

## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Architecture / Module Boundary

<!-- Fill this when the PR changes business code, shared components, service APIs, routing, or user-visible entry points. -->

- Affected module(s):
- New or changed user-visible entry point: <!-- yes / no; if yes, describe it -->
- Shared layer touched: <!-- ui / Components / Messages / bridge / service / none -->
- If shared code changed, impact scope:
- Duplicate entry point checked: <!-- yes / no / not applicable -->

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [ ] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [ ] Described impact scope when shared components, messages, bridge, or services are changed
- [ ] Followed commit message conventions (Conventional Commits)
