### PR TITLE
fix: 群成员退群等系统消息在最近 Tab 未读无法消除

### DIFF
--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -48,18 +48,19 @@ export class ConversationWrap {
     public get channelInfo() {
         return this.conversation.channelInfo
     }
-    // System/event message content types that should not contribute to unread count
-    private static systemContentTypes: Set<number> = new Set([
-        MessageContentTypeConst.addMembers,       // 1002 添加群成员
-        MessageContentTypeConst.removeMembers,     // 1003 删除群成员
-        MessageContentTypeConst.channelUpdate,     // 1005 频道更新
-        MessageContentTypeConst.newGroupOwner,     // 1008 新的管理员
-        MessageContentTypeConst.approveGroupMember,// 1009 审批群成员
-    ])
+    // System/event message content types that should not contribute to unread count.
+    // 使用 1000-2000 区间判断，与 SDK `WKSDK.isSystemMessage` 以及 Message 列表的
+    // 系统消息 UI 渲染逻辑（Conversation/index.tsx）保持一致，避免未来新增系统消息类型
+    // （如 1004 退群、1006 频道禁言变更等）因白名单遗漏而在最近 Tab 留下消不掉的未读。
+    // threadCreated(1100) 例外：子区创建通知属于可导航事件，保留未读提示。
+    private static isSystemContentType(contentType: number | undefined): boolean {
+        if (contentType === undefined || contentType === null) return false
+        return contentType >= 1000 && contentType <= 2000 && contentType !== MessageContentTypeConst.threadCreated
+    }
 
     private isSystemMessage(message: Message | undefined): boolean {
         if (!message) return false
-        return ConversationWrap.systemContentTypes.has(message.contentType)
+        return ConversationWrap.isSystemContentType(message.contentType)
     }
 
     public get unread() {


### PR DESCRIPTION
## 问题

群聊有人退出群聊后，左侧最近 Tab 该会话会产生 1 条无法消除的未读（点进去没有新消息，但红点一直存在）。

## 根因

`ConversationWrap.unread` 里维护了一个 `systemContentTypes` 硬编码白名单，当 unread=1 且最后一条消息属于白名单中的系统消息类型时，自动返回 0 以隐藏未读红点。但白名单只列了 5 种类型：

- 1002 addMembers（添加成员）
- 1003 removeMembers（移除成员）
- 1005 channelUpdate（频道更新）
- 1008 newGroupOwner（新群主）
- 1009 approveGroupMember（审批入群）

**遗漏了 1004（成员主动退群）** 等其他 1000-2000 区间的系统消息类型，导致退群消息产生的 1 条未读永远不会被归零。

## 修复

把硬编码白名单改成区间判断 `contentType >= 1000 && contentType <= 2000`，与以下两处逻辑保持一致：

1. SDK 层 `WKSDK.isSystemMessage` —— 通知弹窗过滤（不弹系统消息通知）
2. UI 渲染层 `Conversation/index.tsx` —— 系统消息居中胶囊样式

`threadCreated`(1100) 作为可导航事件例外，保留未读提示（点击可跳转到子区）。

这样未来新增任何系统消息类型（如退群、频道禁言变更等）都不会再踩这个坑。