### PR TITLE
feat(dmworksummary): 两个 agent 总结入口显式传 origin_channel_id (#930)

### DIFF
--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -5,8 +5,8 @@ import { WKApp, I18nContext } from '@octo/base';
 import VoiceInputButton from '@octo/base/src/Components/VoiceInputButton';
 import type { ReplaceMode, SelectionRange } from '@octo/base/src/Components/VoiceInputButton';
 import type { TopicTemplate, ChatCandidate, ScheduleConfig, CreateAgentSummaryParams, ChatMessage } from '../types/summary';
-import { SourceType, SummaryMode } from '../types/summary';
-import { getSourceType, getOriginChannelType } from '../utils/channelType';
+import { SummaryMode } from '../types/summary';
+import { getSourceType, getOriginChannelType, chatTypeToOriginChannelType } from '../utils/channelType';
 import { channelToChatCandidate } from '../utils/channelConvert';
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from '../utils/templateResolver';
 
@@ -391,11 +391,7 @@ export default class ChatSummaryNewModal extends Component<
                 // 不传 source_name：让后端按 source_id 现查 IM 库最新群名（带类型后缀），
                 // 与下方 fallback 分支一致，避免把群名冻结进配置。
                 ? selectedChats.map((c) => ({
-                    source_type: (c.chat_type === 'group'
-                        ? SourceType.GROUP_CHAT
-                        : c.chat_type === 'thread'
-                        ? SourceType.THREAD
-                        : SourceType.DIRECT_MESSAGE),
+                    source_type: chatTypeToOriginChannelType(c.chat_type),
                     source_id: c.chat_id,
                 }))
                 : [{
@@ -611,24 +607,25 @@ export default class ChatSummaryNewModal extends Component<
 
         this.setState({ savingSummary: true });
         try {
-            // sources 保留原逻辑:若用户在别处显式选过 chats,把它们透传成 sources;
-            // 否则不传,后端会自己从 tool_calls 反推 origin,sources 留空由后续版本
-            // 的 deliverable_context 快照补齐。
+            // sources：若用户在别处显式选过 chats,把它们透传成 sources;否则不传。
             const sources = selectedChats.length > 0
                 ? selectedChats.map((c) => ({
-                    source_type: (c.chat_type === 'group'
-                        ? SourceType.GROUP_CHAT
-                        : c.chat_type === 'thread'
-                        ? SourceType.THREAD
-                        : SourceType.DIRECT_MESSAGE),
+                    source_type: chatTypeToOriginChannelType(c.chat_type),
                     source_id: c.chat_id,
                 }))
                 : undefined;
 
+            // origin_channel_id / origin_channel_type：本入口是从群/子区右上角触发,
+            // channel prop 天然就是用户心里的 origin —— 直接明确传给后端(#930,入口即
+            // 语义),不再依赖后端从 tool_calls 反查。映射与传统路径 (getOriginChannelType)
+            // 完全一致。
+            const { channel } = this.props;
             const res = await summaryApi.createAgentSummary({
                 session_id: sessionId,
                 title,
                 sources,
+                origin_channel_id: channel.channelID,
+                origin_channel_type: getOriginChannelType(channel),
             });
 
             Toast.success(t('summary.create.agentSummaryCreated'));

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -588,12 +588,11 @@ export default class ChatSummaryNewModal extends Component<
 
     /** 保存为总结（agent 模式）。将当前 session 的产出落库为可检索的交付物。返回成功/失败。
      *
-     * origin_channel_id / origin_channel_type 不再由前端传入 —— agent 对话入口在
-     * e5a8eee 起就特意隐藏了"选择聊天/参与者/定时更新"三个控件,前端此时既没有
-     * currentChannel 也没有让用户手选来源的地方。后端 handler 会按 session_id 从
-     * agent_message 的 tool_calls 记录反查 agent 实际读过的第一个 channel_id
-     * 作为 origin(见 agent_summary.go inferOriginChannelFromToolCalls),这样
-     * 用户完全无感,来源和 agent 实际引用的数据严格一致。
+     * origin_channel_id / origin_channel_type：本入口是从群/子区右上角触发,channel
+     * prop 天然就是用户心里的 origin —— 直接明确传给后端(#930,入口即语义),不再依赖
+     * 后端从 tool_calls 反查。若前端没传(如整页入口),后端仍会按 session_id 从
+     * agent_message 的 tool_calls 反查作为 fallback(见 agent_summary.go
+     * resolveOriginChannelFromSession)。
      */
     handleSaveAsSummary = async (title: string): Promise<boolean> => {
         const { sessionId, selectedChats } = this.state;
@@ -630,9 +629,9 @@ export default class ChatSummaryNewModal extends Component<
 
             Toast.success(t('summary.create.agentSummaryCreated'));
 
-            // dispatch 刷新事件。agent 保存路径下前端已不再持有具体 channel
-            // (origin 由后端从 tool_calls 反查),下游刷新监听按 taskId 走即可,
-            // channelId 传空串以保持事件字段结构不变、避免 undefined 引用崩溃。
+            // dispatch 刷新事件。下游刷新监听按 taskId 走即可;channelId 传空串以
+            // 保持事件字段结构不变、避免 undefined 引用崩溃(origin 已在上面的
+            // createAgentSummary 请求里显式传给后端,与此刷新事件无关)。
             window.dispatchEvent(
                 new CustomEvent('chat-summary-created', {
                     detail: { taskId: res.task_id, channelId: '' },

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -72,11 +72,14 @@ vi.mock('../../utils/channelConvert', () => ({
 
 vi.mock('../../utils/channelType', () => ({
     getSourceType: () => 1,
+    getOriginChannelType: (ch: any) => (ch.channelType === 2 ? 1 : ch.channelType === 5 ? 2 : 3),
+    chatTypeToOriginChannelType: (t: string) => (t === 'group' ? 1 : t === 'thread' ? 2 : 3),
 }));
 
 vi.mock('../../api/summaryApi', () => ({
     getTopicTemplatesConfig: vi.fn().mockResolvedValue({ templates: [], custom_template_limit: 30 }),
     createSummary: vi.fn().mockResolvedValue({ task_id: 1 }),
+    createAgentSummary: vi.fn().mockResolvedValue({ task_id: 1 }),
     agentChat: vi.fn(),
     getAgentChatHistory: vi.fn().mockResolvedValue({ session_id: '', messages: [] }),
 }));
@@ -688,5 +691,39 @@ describe('ChatSummaryNewModal agent SSE session_id sync', () => {
         const lastMessage = instance.state.messages[instance.state.messages.length - 1];
         expect(lastMessage.role).toBe('assistant');
         expect(lastMessage.content).toBe('Server response');
+    });
+});
+
+describe('ChatSummaryNewModal agent save — explicit origin_channel_id (#930)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('fills origin_channel_id + type from the channel prop (group → 1)', async () => {
+        const ref = React.createRef<ChatSummaryNewModal>();
+        await act(async () => {
+            render(
+                <ChatSummaryNewModal
+                    visible
+                    channel={{ channelID: 'ch1', channelType: 2 }}
+                    onClose={vi.fn()}
+                    onSubmit={vi.fn()}
+                    ref={ref}
+                />,
+            );
+            await flushPromises();
+        });
+
+        await act(async () => {
+            (ref.current as any).setState({ sessionId: 'sess-modal-1' });
+        });
+        await act(async () => {
+            await (ref.current as any).handleSaveAsSummary('t');
+            await flushPromises();
+        });
+
+        expect(summaryApi.createAgentSummary).toHaveBeenCalledWith(
+            expect.objectContaining({ origin_channel_id: 'ch1', origin_channel_type: 1 }),
+        );
     });
 });

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -16,7 +16,7 @@ import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
 import { getTopicTemplatesConfig, getTopicTemplates } from "../api/summaryApi";
-import { getOriginChannelType, chatTypeToOriginChannelType } from "../utils/channelType";
+import { chatTypeToOriginChannelType } from "../utils/channelType";
 import SummaryDetailPage from "./SummaryDetailPage";
 import ChatSelectorModal from "../components/ChatSelectorModal";
 import MemberSelectorModal from "../components/MemberSelectorModal";

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -16,7 +16,7 @@ import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
 import { getTopicTemplatesConfig, getTopicTemplates } from "../api/summaryApi";
-import { getOriginChannelType } from "../utils/channelType";
+import { getOriginChannelType, chatTypeToOriginChannelType } from "../utils/channelType";
 import SummaryDetailPage from "./SummaryDetailPage";
 import ChatSelectorModal from "../components/ChatSelectorModal";
 import MemberSelectorModal from "../components/MemberSelectorModal";
@@ -38,7 +38,7 @@ import type {
     SummaryListItem,
     CreateAgentSummaryParams,
 } from "../types/summary";
-import { SummaryMode, SourceType } from "../types/summary";
+import { SummaryMode } from "../types/summary";
 import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession, readAgentChatReferenced, writeAgentChatReferenced, clearAgentChatReferenced } from "../utils/summaryHelpers";
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from "../utils/templateResolver";
 
@@ -436,9 +436,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 // 不传 source_name：让后端按 source_id 现查 IM 库最新群名（带类型后缀）。
                 // 避免把创建那一刻的群名冻结进定时配置，从而群改名后定时仍显示旧名。
                 params.sources = selectedChats.map((c) => ({
-                    source_type: c.chat_type === "group" ? SourceType.GROUP_CHAT
-                               : c.chat_type === "thread" ? SourceType.THREAD
-                               : SourceType.DIRECT_MESSAGE,
+                    source_type: chatTypeToOriginChannelType(c.chat_type),
                     source_id: c.chat_id,
                 }));
             }
@@ -709,20 +707,22 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
         this.setState({ savingSummary: true });
         try {
-            // origin_channel_id / origin_channel_type 不再由前端传入 —— 后端会从
-            // session 的 tool_calls 反查 agent 实际读过的第一个 channel_id 作为
-            // origin(见 handler/agent_summary.go)。整页入口 currentChannel 一定
-            // 是 undefined,弹窗入口也不再依赖 channel prop,统一走后端反查。
+            // origin_channel_id / origin_channel_type：整页入口没有 channel prop，
+            // 但用户可能在「选择聊天」里选了 chat。若选了，就把第一个 selectedChat
+            // 作为 origin 明确传给后端（#930），其余进 sources；用户没选（例如纯
+            // refine，只依赖 referenced_task）则不传，回退后端从 session tool_calls
+            // 反查（见 handler/agent_summary.go resolveOriginChannelFromSession）。
             const params: CreateAgentSummaryParams = {
                 session_id: sessionId,
                 title,
             };
 
             if (selectedChats.length > 0) {
+                const origin = selectedChats[0];
+                params.origin_channel_id = origin.chat_id;
+                params.origin_channel_type = chatTypeToOriginChannelType(origin.chat_type);
                 params.sources = selectedChats.map((c) => ({
-                    source_type: c.chat_type === "group" ? SourceType.GROUP_CHAT
-                               : c.chat_type === "thread" ? SourceType.THREAD
-                               : SourceType.DIRECT_MESSAGE,
+                    source_type: chatTypeToOriginChannelType(c.chat_type),
                     source_id: c.chat_id,
                 }));
             }

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -691,3 +691,60 @@ describe('SummaryCreatePage derivedFromTask cross-session isolation (#907 P1 Jer
         ).toEqual({ task_id: 7, title: 'Reference C' });
     });
 });
+
+describe('SummaryCreatePage agent save — explicit origin_channel_id (#930)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(summaryHelpers, 'writeAgentChatSession').mockImplementation(() => {});
+    });
+
+    async function mountInstance() {
+        const ref = React.createRef<SummaryCreatePage>();
+        await act(async () => {
+            render(<SummaryCreatePage ref={ref} />);
+            await flushPromises();
+        });
+        return ref.current as any;
+    }
+
+    it('passes group selectedChat[0] as origin_channel_id + type=1', async () => {
+        const instance = await mountInstance();
+        await act(async () => {
+            instance.setState({
+                sessionId: 'sess-1',
+                mode: 'agent',
+                selectedChats: [{ chat_id: 'grp-1', chat_type: 'group', name: 'G', member_count: 3 }],
+            });
+        });
+        await act(async () => { await instance.handleSaveAsSummary('t'); });
+        expect(api.createAgentSummary).toHaveBeenCalledWith(
+            expect.objectContaining({ origin_channel_id: 'grp-1', origin_channel_type: 1 }),
+        );
+    });
+
+    it('maps a thread selectedChat[0] to origin_channel_type=2', async () => {
+        const instance = await mountInstance();
+        await act(async () => {
+            instance.setState({
+                sessionId: 'sess-2',
+                mode: 'agent',
+                selectedChats: [{ chat_id: 'grp____thr', chat_type: 'thread', name: 'T', member_count: 2 }],
+            });
+        });
+        await act(async () => { await instance.handleSaveAsSummary('t'); });
+        expect(api.createAgentSummary).toHaveBeenCalledWith(
+            expect.objectContaining({ origin_channel_id: 'grp____thr', origin_channel_type: 2 }),
+        );
+    });
+
+    it('omits origin when no chat is selected (refine → backend infers)', async () => {
+        const instance = await mountInstance();
+        await act(async () => {
+            instance.setState({ sessionId: 'sess-3', mode: 'agent', selectedChats: [] });
+        });
+        await act(async () => { await instance.handleSaveAsSummary('t'); });
+        const arg = (api.createAgentSummary as any).mock.calls[0][0];
+        expect(arg.origin_channel_id).toBeUndefined();
+        expect(arg.origin_channel_type).toBeUndefined();
+    });
+});

--- a/packages/dmworksummary/src/utils/channelType.ts
+++ b/packages/dmworksummary/src/utils/channelType.ts
@@ -33,3 +33,26 @@ export function getOriginChannelType(channel: { channelType: number; channelID: 
     }
     return sourceType;
 }
+
+/**
+ * 把 ChatCandidate 的字符串 chat_type 映射成 SourceType 数值(1=群/2=子区/3=私聊),
+ * 用于 origin_channel_type 与 sources[].source_type。
+ *
+ * 与 getOriginChannelType 是同一套数值语义,但入口不同:getOriginChannelType 吃
+ * IM 的 numeric channelType(ChatSummaryNewModal 的 channel prop 有),而
+ * SummaryCreatePage 只有 selectedChats 的字符串 chat_type,没有 numeric
+ * channelType —— 这个 helper 专门收字符串侧,避免两处各写一份内联 map。
+ * @throws Error 当 chat_type 不认识时抛出,而非静默发错值。
+ */
+export function chatTypeToOriginChannelType(chatType: 'group' | 'thread' | 'direct'): number {
+    switch (chatType) {
+        case 'group':
+            return SourceType.GROUP_CHAT;
+        case 'thread':
+            return SourceType.THREAD;
+        case 'direct':
+            return SourceType.DIRECT_MESSAGE;
+        default:
+            throw new Error(`不支持的 chat_type: ${chatType}`);
+    }
+}

--- a/packages/dmworksummary/src/utils/channelType.ts
+++ b/packages/dmworksummary/src/utils/channelType.ts
@@ -1,6 +1,7 @@
 import { ChannelTypeCommunityTopic, parseThreadChannelId } from '@octo/base';
 import { ChannelTypeGroup, ChannelTypePerson } from 'wukongimjssdk';
 import { SourceType } from '../types/summary';
+import type { SourceTypeValue } from '../types/summary';
 
 export function isSupportedChannelType(channel: { channelType: number }): boolean {
     return channel.channelType === ChannelTypePerson
@@ -44,7 +45,7 @@ export function getOriginChannelType(channel: { channelType: number; channelID: 
  * channelType —— 这个 helper 专门收字符串侧,避免两处各写一份内联 map。
  * @throws Error 当 chat_type 不认识时抛出,而非静默发错值。
  */
-export function chatTypeToOriginChannelType(chatType: 'group' | 'thread' | 'direct'): number {
+export function chatTypeToOriginChannelType(chatType: 'group' | 'thread' | 'direct'): SourceTypeValue {
     switch (chatType) {
         case 'group':
             return SourceType.GROUP_CHAT;


### PR DESCRIPTION
## Linked Spec
Closes #930 — 两个 agent 总结入口显式传 `origin_channel_id`。

## 改动（严格照 #930 提议 + 核对现状后精简）
- **入口 2 · ChatSummaryNewModal（A 方案）**：agent save 路径补 `origin_channel_id = channel.channelID` + `origin_channel_type = getOriginChannelType(channel)`，与该文件传统 `handleSubmit` 路径一致。
- **入口 1 · SummaryCreatePage（C 方案）**：`selectedChats` 非空时用 `selectedChats[0]` 作 origin（id + type）；为空（refine）不传，回退后端 `resolveOriginChannelFromSession`。
- **新 helper `channelType.ts#chatTypeToOriginChannelType`**：字符串 `chat_type → SourceType`，取代 3 处内联 ladder（字符串侧单一真源；numeric 侧仍用 `getOriginChannelType`）。两入口输入不同：全页只有字符串 chat_type，弹窗有 numeric channel prop——这是本 issue 最易写错处，抽 helper 消除。

**无需改动**：`CreateAgentSummaryParams` 已有 `origin_channel_id?`/`origin_channel_type?`；`createAgentSummary` 原样透传——API/类型零改。

## COMPREHENSION（边界 / 不回退）
- 默认/refine（不选 chat）不传 origin → 后端反查 fallback 不变。
- 传统 workflow（非 agent）行为不变（仅把其内联 chat_type map 复用为同一 helper，输出等价）。
- 越权/鉴权不变。多选用 `selectedChats[0]` 为主、其余进 sources（Phase 1）。
- 后端 1406（thread 长 id 撞列宽）是 octo-smart-summary#165 职责，不在本 PR。

## 自验
- `pnpm --filter @dmwork/summary test`：480 passed（新增 4 个 origin 用例全过）。唯一 1 个失败是既有无关用例 `SummaryVersionHistory.test.tsx > operation label fallback`（在未改的 upstream/main 上同样失败，已复现确认）。
- `pnpm turbo run build --filter=@octo/web`：✓ built。
- 新增：`SummaryCreatePage.test.tsx`（group→1 / thread→2 / 不选→不带 origin）；`ChatSummaryNewModal.test.tsx`（channel group→1，并补上此前缺失的 `createAgentSummary` mock）。
