### PR TITLE
release v1.9.1: backport login updater hotfixes

### DIFF
--- a/packages/dmworklogin/src/AndroidDownloadButton.stories.tsx
+++ b/packages/dmworklogin/src/AndroidDownloadButton.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof AndroidDownloadButton> = {
     docs: {
       description: {
         component:
-          "登录页 Android 下载入口。悬停入口展示当前部署域名下的 APK 下载二维码，并保留 GitHub 最新 Release 备用入口。",
+          "登录页 Android 下载入口。二维码与直接下载按钮共用 updater 接口返回的 APK 地址，并保留 GitHub 最新 Release 备用入口。",
       },
     },
   },

--- a/packages/dmworklogin/src/AndroidDownloadButton.tsx
+++ b/packages/dmworklogin/src/AndroidDownloadButton.tsx
@@ -1,20 +1,21 @@
 import React from "react";
 import { IconGithubLogo } from "@douyinfe/semi-icons";
-import { Popover } from "@douyinfe/semi-ui";
+import { Popover, Spin } from "@douyinfe/semi-ui";
 import { WKButton } from "@octo/base";
 import { QRCodeSVG } from "qrcode.react";
 import { loginT as t } from "./i18n";
+import {
+  resolveMobileUpdaterUrl,
+  useMobileDownloadUrl,
+} from "./mobileDownloadUpdater";
 import "./MobileDownloadPopover.css";
 
-export const ANDROID_APK_PATH = "/download/dmwork.apk";
+export const ANDROID_UPDATER_PATH = "common/updater/android/1.0";
 export const ANDROID_RELEASES_URL =
   "https://github.com/Mininglamp-OSS/octo-android/releases/latest";
 
-export function resolveAndroidApkUrl(
-  origin = typeof window === "undefined" ? "" : window.location.origin
-) {
-  if (!origin) return ANDROID_APK_PATH;
-  return new URL(ANDROID_APK_PATH, `${origin.replace(/\/$/, "")}/`).toString();
+export function resolveAndroidUpdaterUrl(apiUrl?: string) {
+  return resolveMobileUpdaterUrl(ANDROID_UPDATER_PATH, apiUrl);
 }
 
 export function openAndroidReleases() {
@@ -34,43 +35,72 @@ type PopoverHoverProps = Pick<
 
 export const AndroidDownloadPopoverContent: React.FC<PopoverHoverProps> = (
   hoverProps
-) => (
-  <div
-    className="wk-login-mobile-download-popover"
-    role="dialog"
-    aria-label={t("download.androidQrTitle")}
-    {...hoverProps}
-  >
+) => {
+  const { status, downloadUrl, retry } =
+    useMobileDownloadUrl(ANDROID_UPDATER_PATH);
+
+  return (
     <div
-      className="wk-login-mobile-popover-qr"
-      role="img"
+      className="wk-login-mobile-download-popover"
+      role="dialog"
       aria-label={t("download.androidQrTitle")}
+      {...hoverProps}
     >
-      <QRCodeSVG value={resolveAndroidApkUrl()} size={104} />
+      <div
+        className="wk-login-mobile-popover-qr"
+        data-status={status}
+        role={status === "ready" ? "img" : undefined}
+        aria-label={
+          status === "ready" ? t("download.androidQrTitle") : undefined
+        }
+        aria-busy={status === "loading" ? true : undefined}
+      >
+        {status === "loading" && (
+          <Spin aria-label={t("download.loadingAddress")} size="large" />
+        )}
+        {status === "error" && (
+          <div className="wk-login-mobile-download-state" role="alert">
+            <span>{t("download.addressLoadFailed")}</span>
+            <WKButton type="button" variant="ghost" size="sm" onClick={retry}>
+              {t("download.retry")}
+            </WKButton>
+          </div>
+        )}
+        {status === "ready" && <QRCodeSVG value={downloadUrl} size={104} />}
+      </div>
+      <strong className="wk-login-mobile-download-popover-title">
+        {t("download.androidQrTitle")}
+      </strong>
+      {status === "ready" ? (
+        <a
+          className="wk-login-mobile-download-direct-link"
+          href={downloadUrl}
+          download
+        >
+          {t("download.androidDirectDownload")}
+        </a>
+      ) : (
+        <span
+          className="wk-login-mobile-download-direct-link"
+          aria-disabled="true"
+        >
+          {t("download.androidDirectDownload")}
+        </span>
+      )}
+      <WKButton
+        type="button"
+        className="wk-login-android-popover-manual-download"
+        variant="ghost"
+        size="sm"
+        icon={<IconGithubLogo aria-hidden="true" />}
+        aria-label={t("download.openGithubReleases")}
+        onClick={openAndroidReleases}
+      >
+        {t("download.githubManualDownload")}
+      </WKButton>
     </div>
-    <strong className="wk-login-mobile-download-popover-title">
-      {t("download.androidQrTitle")}
-    </strong>
-    <a
-      className="wk-login-mobile-download-direct-link"
-      href={resolveAndroidApkUrl()}
-      download
-    >
-      {t("download.androidDirectDownload")}
-    </a>
-    <WKButton
-      type="button"
-      className="wk-login-android-popover-manual-download"
-      variant="ghost"
-      size="sm"
-      icon={<IconGithubLogo aria-hidden="true" />}
-      aria-label={t("download.openGithubReleases")}
-      onClick={openAndroidReleases}
-    >
-      {t("download.githubManualDownload")}
-    </WKButton>
-  </div>
-);
+  );
+};
 
 export const AndroidDownloadButton: React.FC = () => {
   const [hoverVisible, setHoverVisible] = React.useState(false);

--- a/packages/dmworklogin/src/IOSDownloadButton.stories.tsx
+++ b/packages/dmworklogin/src/IOSDownloadButton.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof IOSDownloadButton> = {
     docs: {
       description: {
         component:
-          "登录页 iOS 二维码入口。悬停或点击入口只展示动态生成的 TestFlight 二维码，触发按钮本身不执行跳转。",
+          "登录页 iOS 二维码入口。悬停或点击入口只展示由 updater 接口地址生成的二维码，触发按钮本身不执行跳转。",
       },
     },
   },

--- a/packages/dmworklogin/src/IOSDownloadButton.tsx
+++ b/packages/dmworklogin/src/IOSDownloadButton.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Popover } from "@douyinfe/semi-ui";
+import { Popover, Spin } from "@douyinfe/semi-ui";
+import { WKButton } from "@octo/base";
 import { QRCodeSVG } from "qrcode.react";
 import { loginT as t } from "./i18n";
+import { useMobileDownloadUrl } from "./mobileDownloadUpdater";
 import "./MobileDownloadPopover.css";
 
-// TestFlight 是公开固定 URL，不需要走 updater 接口
-export const IOS_DOWNLOAD_URL = "https://testflight.apple.com/join/uPrdCcy3";
+export const IOS_UPDATER_PATH = "common/updater/ios/1.0.0";
 
 type PopoverHoverProps = Pick<
   React.HTMLAttributes<HTMLDivElement>,
@@ -14,35 +15,44 @@ type PopoverHoverProps = Pick<
 
 export const IOSDownloadPopoverContent: React.FC<PopoverHoverProps> = (
   hoverProps
-) => (
-  <div
-    className="wk-login-mobile-download-popover"
-    role="dialog"
-    aria-label={t("download.iosQrTitle")}
-    {...hoverProps}
-  >
-    <div
-      className="wk-login-mobile-popover-qr"
-      role="img"
-      aria-label={t("download.iosQrLabel")}
-    >
-      <QRCodeSVG value={IOS_DOWNLOAD_URL} size={104} />
-    </div>
-    <strong className="wk-login-mobile-download-popover-title">
-      {t("download.iosQrTitle")}
-    </strong>
-    <a
-      className="wk-login-mobile-download-direct-link"
-      href={IOS_DOWNLOAD_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {t("download.iosDirectDownload")}
-    </a>
-  </div>
-);
+) => {
+  const { status, downloadUrl, retry } = useMobileDownloadUrl(IOS_UPDATER_PATH);
 
-// iOS 安装入口：按钮只控制二维码浮窗，TestFlight 地址仅用于生成二维码
+  return (
+    <div
+      className="wk-login-mobile-download-popover"
+      role="dialog"
+      aria-label={t("download.iosQrTitle")}
+      {...hoverProps}
+    >
+      <div
+        className="wk-login-mobile-popover-qr"
+        data-status={status}
+        role={status === "ready" ? "img" : undefined}
+        aria-label={status === "ready" ? t("download.iosQrLabel") : undefined}
+        aria-busy={status === "loading" ? true : undefined}
+      >
+        {status === "loading" && (
+          <Spin aria-label={t("download.loadingAddress")} size="large" />
+        )}
+        {status === "error" && (
+          <div className="wk-login-mobile-download-state" role="alert">
+            <span>{t("download.addressLoadFailed")}</span>
+            <WKButton type="button" variant="ghost" size="sm" onClick={retry}>
+              {t("download.retry")}
+            </WKButton>
+          </div>
+        )}
+        {status === "ready" && <QRCodeSVG value={downloadUrl} size={104} />}
+      </div>
+      <strong className="wk-login-mobile-download-popover-title">
+        {t("download.iosQrTitle")}
+      </strong>
+    </div>
+  );
+};
+
+// iOS 安装入口：按钮只控制二维码浮窗，安装地址由 updater 接口提供
 export const IOSDownloadButton: React.FC = () => {
   const [hoverVisible, setHoverVisible] = React.useState(false);
   const [clickPinned, setClickPinned] = React.useState(false);

--- a/packages/dmworklogin/src/MobileDownloadPopover.css
+++ b/packages/dmworklogin/src/MobileDownloadPopover.css
@@ -34,10 +34,25 @@
   background: var(--wk-color-white);
 }
 
-.wk-login-mobile-popover-qr svg {
+.wk-login-mobile-popover-qr[data-status="loading"],
+.wk-login-mobile-popover-qr[data-status="error"] {
+  background: var(--wk-bg-surface);
+}
+
+.wk-login-mobile-popover-qr > svg {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+.wk-login-mobile-download-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  color: var(--wk-text-secondary);
+  font-size: var(--wk-text-size-sm);
+  line-height: var(--wk-leading-normal);
 }
 
 .wk-login-mobile-download-popover-title {
@@ -74,6 +89,13 @@
 .wk-login-mobile-download-direct-link:focus-visible {
   outline: 2px solid var(--wk-border-glow);
   outline-offset: 2px;
+}
+
+.wk-login-mobile-download-direct-link[aria-disabled="true"] {
+  border-color: var(--wk-border-default);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-disabled);
+  cursor: not-allowed;
 }
 
 .wk-login-android-popover-manual-download {

--- a/packages/dmworklogin/src/__tests__/android_download_button.test.tsx
+++ b/packages/dmworklogin/src/__tests__/android_download_button.test.tsx
@@ -5,7 +5,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { act, Simulate } from "react-dom/test-utils";
 import { i18n } from "@octo/base/src/i18n/instance";
 
+const { apiFetchJsonMock } = vi.hoisted(() => ({
+  apiFetchJsonMock: vi.fn(),
+}));
+
 vi.mock("@douyinfe/semi-ui", () => ({
+  Spin: ({ "aria-label": ariaLabel }: { "aria-label"?: string }) =>
+    React.createElement("span", {
+      "data-spin": "true",
+      "aria-label": ariaLabel,
+    }),
   Popover: ({
     children,
     position,
@@ -65,6 +74,12 @@ type MockWKButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 vi.mock("@octo/base", () => ({
+  apiFetchJson: apiFetchJsonMock,
+  WKApp: {
+    apiClient: {
+      config: { apiURL: "/api/v1/" },
+    },
+  },
   WKButton: ({ children, icon, iconOnly, ...props }: MockWKButtonProps) =>
     React.createElement(
       "button",
@@ -79,12 +94,12 @@ vi.mock("@octo/base", () => ({
 }));
 
 import {
-  ANDROID_APK_PATH,
   ANDROID_RELEASES_URL,
+  ANDROID_UPDATER_PATH,
   AndroidDownloadButton,
   AndroidDownloadPopoverContent,
   openAndroidReleases,
-  resolveAndroidApkUrl,
+  resolveAndroidUpdaterUrl,
 } from "../AndroidDownloadButton";
 
 const mountedContainers: HTMLDivElement[] = [];
@@ -103,6 +118,7 @@ describe("AndroidDownloadButton", () => {
   beforeEach(() => {
     i18n.setLocale("zh-CN", { persist: false });
     vi.restoreAllMocks();
+    apiFetchJsonMock.mockReset();
     vi.useFakeTimers();
   });
 
@@ -122,10 +138,13 @@ describe("AndroidDownloadButton", () => {
     );
   });
 
-  it("resolves the legacy APK path against the current deployment origin", () => {
-    expect(ANDROID_APK_PATH).toBe("/download/dmwork.apk");
-    expect(resolveAndroidApkUrl("https://octo.example.com")).toBe(
-      "https://octo.example.com/download/dmwork.apk"
+  it("resolves the Android updater endpoint against the configured API URL", () => {
+    expect(ANDROID_UPDATER_PATH).toBe("common/updater/android/1.0");
+    expect(resolveAndroidUpdaterUrl("/api/v1/")).toBe(
+      "/api/v1/common/updater/android/1.0"
+    );
+    expect(resolveAndroidUpdaterUrl("https://api.example.com/v1")).toBe(
+      "https://api.example.com/v1/common/updater/android/1.0"
     );
   });
 
@@ -201,21 +220,21 @@ describe("AndroidDownloadButton", () => {
     expect(popover?.getAttribute("data-visible")).toBe("false");
   });
 
-  it("renders the same-origin APK URL as a scannable QR code", () => {
+  it("renders a fixed-size loading state without an old QR code or link", () => {
     const html = renderToStaticMarkup(
       React.createElement(AndroidDownloadPopoverContent)
     );
 
-    expect(html).toContain('role="img"');
-    expect(html).toContain(
-      `data-qr-value="${window.location.origin}${ANDROID_APK_PATH}"`
-    );
     expect(html).toContain("wk-login-mobile-popover-qr");
-    expect(html).not.toContain("wk-login-android-popover-placeholder");
-    expect(html).not.toContain("二维码图片待提供");
+    expect(html).not.toContain('role="img"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('data-spin="true"');
+    expect(html).toContain('aria-label="正在获取下载地址"');
+    expect(html).not.toContain("data-qr-value");
     expect(html).toContain(">扫码下载</strong>");
-    expect(html).not.toContain("手机扫码下载");
-    expect(html).not.toContain("扫码直接下载 Android 客户端");
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).not.toContain("/download/dmwork.apk");
+    expect(html).not.toContain(" download");
     expect(html).toContain("或前往 GitHub 手动下载");
     expect(html).toContain('data-icon="github"');
     expect(html).toContain("wk-btn");
@@ -226,20 +245,93 @@ describe("AndroidDownloadButton", () => {
     expect(html).toContain('aria-label="打开 GitHub Releases"');
   });
 
-  it("provides a direct APK download action for same-device mobile users", () => {
+  it("uses one updater-provided APK URL for the QR code and direct action", async () => {
+    const updaterUrl = "https://cdn.example.com/releases/octo-latest.apk";
+    apiFetchJsonMock.mockResolvedValue({ url: updaterUrl });
     const container = document.createElement("div");
-    container.innerHTML = renderToStaticMarkup(
-      React.createElement(AndroidDownloadPopoverContent)
-    );
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+    act(() => {
+      ReactDOM.render(
+        React.createElement(AndroidDownloadPopoverContent),
+        container
+      );
+    });
 
-    const directDownload = container.querySelector<HTMLAnchorElement>(
-      ".wk-login-mobile-download-direct-link"
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(apiFetchJsonMock).toHaveBeenCalledWith(
+      "/api/v1/common/updater/android/1.0"
     );
-    expect(directDownload?.href).toBe(
-      `${window.location.origin}${ANDROID_APK_PATH}`
+    expect(
+      container.querySelector("[data-qr-value]")?.getAttribute("data-qr-value")
+    ).toBe(updaterUrl);
+    expect(
+      container
+        .querySelector(".wk-login-mobile-popover-qr")
+        ?.getAttribute("role")
+    ).toBe("img");
+    expect(
+      container.querySelector<HTMLAnchorElement>(
+        ".wk-login-mobile-download-direct-link"
+      )?.href
+    ).toBe(updaterUrl);
+    expect(
+      container
+        .querySelector<HTMLAnchorElement>(
+          ".wk-login-mobile-download-direct-link"
+        )
+        ?.hasAttribute("download")
+    ).toBe(true);
+    expect(apiFetchJsonMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error without a stale QR code and retries the updater", async () => {
+    const updaterUrl = "https://cdn.example.com/releases/octo-latest.apk";
+    apiFetchJsonMock
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ url: updaterUrl });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+    act(() => {
+      ReactDOM.render(
+        React.createElement(AndroidDownloadPopoverContent),
+        container
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-qr-value]")).toBeNull();
+    expect(container.textContent).toContain("下载地址获取失败");
+    expect(
+      container
+        .querySelector(".wk-login-mobile-download-direct-link")
+        ?.getAttribute("aria-disabled")
+    ).toBe("true");
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "重试"
     );
-    expect(directDownload?.hasAttribute("download")).toBe(true);
-    expect(directDownload?.textContent).toBe("直接下载 APK");
+    expect(retryButton?.tagName).toBe("BUTTON");
+    expect(retryButton?.closest('[role="img"]')).toBeNull();
+
+    act(() => {
+      Simulate.click(retryButton as Element);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector("[data-qr-value]")?.getAttribute("data-qr-value")
+    ).toBe(updaterUrl);
+    expect(apiFetchJsonMock).toHaveBeenCalledTimes(2);
   });
 
   it("opens GitHub Releases safely in a new tab", () => {

--- a/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
+++ b/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
@@ -5,7 +5,32 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { act, Simulate } from "react-dom/test-utils";
 import { i18n } from "@octo/base/src/i18n/instance";
 
+const { apiFetchJsonMock } = vi.hoisted(() => ({
+  apiFetchJsonMock: vi.fn(),
+}));
+
+type MockWKButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: string;
+  size?: string;
+};
+
+vi.mock("@octo/base", () => ({
+  apiFetchJson: apiFetchJsonMock,
+  WKApp: {
+    apiClient: {
+      config: { apiURL: "/api/v1/" },
+    },
+  },
+  WKButton: ({ children, ...props }: MockWKButtonProps) =>
+    React.createElement("button", props, children),
+}));
+
 vi.mock("@douyinfe/semi-ui", () => ({
+  Spin: ({ "aria-label": ariaLabel }: { "aria-label"?: string }) =>
+    React.createElement("span", {
+      "data-spin": "true",
+      "aria-label": ariaLabel,
+    }),
   Popover: ({
     children,
     position,
@@ -52,7 +77,7 @@ vi.mock("qrcode.react", () => ({
 import {
   IOSDownloadButton,
   IOSDownloadPopoverContent,
-  IOS_DOWNLOAD_URL,
+  IOS_UPDATER_PATH,
 } from "../IOSDownloadButton";
 
 const mountedContainers: HTMLDivElement[] = [];
@@ -70,6 +95,7 @@ function renderInteractiveButton() {
 describe("IOSDownloadButton", () => {
   beforeEach(() => {
     i18n.setLocale("zh-CN", { persist: false });
+    apiFetchJsonMock.mockReset();
     vi.useFakeTimers();
   });
 
@@ -83,8 +109,8 @@ describe("IOSDownloadButton", () => {
     vi.useRealTimers();
   });
 
-  it("points at the public TestFlight URL", () => {
-    expect(IOS_DOWNLOAD_URL).toBe("https://testflight.apple.com/join/uPrdCcy3");
+  it("uses the iOS updater endpoint", () => {
+    expect(IOS_UPDATER_PATH).toBe("common/updater/ios/1.0.0");
   });
 
   it("renders a non-navigation button trigger", () => {
@@ -145,32 +171,83 @@ describe("IOSDownloadButton", () => {
     expect(popover?.getAttribute("data-visible")).toBe("false");
   });
 
-  it("renders the TestFlight URL as a scannable QR code", () => {
+  it("renders a loading state without a stale TestFlight QR code", () => {
     const html = renderToStaticMarkup(
       React.createElement(IOSDownloadPopoverContent)
     );
 
     expect(html).toContain('role="dialog"');
-    expect(html).toContain(`data-qr-value="${IOS_DOWNLOAD_URL}"`);
+    expect(html).toContain('data-spin="true"');
+    expect(html).toContain('aria-label="正在获取下载地址"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain('role="img"');
+    expect(html).not.toContain("data-qr-value");
+    expect(html).not.toContain("testflight.apple.com");
     expect(html).toContain("wk-login-mobile-popover-qr");
     expect(html).not.toContain("wk-login-ios-popover-qr");
-    expect(html).toContain("TestFlight 安装二维码");
     expect(html).toContain(">扫码下载</strong>");
     expect(html).not.toContain("手机扫码安装");
   });
 
-  it("provides a direct TestFlight action for same-device mobile users", () => {
+  it("renders the updater-provided iOS URL as a scannable QR code", async () => {
+    const updaterUrl = "https://testflight.apple.com/join/backendCode";
+    apiFetchJsonMock.mockResolvedValue({ url: updaterUrl });
     const container = document.createElement("div");
-    container.innerHTML = renderToStaticMarkup(
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+    act(() => {
+      ReactDOM.render(
+        React.createElement(IOSDownloadPopoverContent),
+        container
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(apiFetchJsonMock).toHaveBeenCalledWith(
+      "/api/v1/common/updater/ios/1.0.0"
+    );
+    expect(
+      container.querySelector("[data-qr-value]")?.getAttribute("data-qr-value")
+    ).toBe(updaterUrl);
+    expect(
+      container
+        .querySelector(".wk-login-mobile-popover-qr")
+        ?.getAttribute("role")
+    ).toBe("img");
+  });
+
+  it("shows an error without a stale QR code when the updater fails", async () => {
+    apiFetchJsonMock.mockRejectedValue(new Error("network error"));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    mountedContainers.push(container);
+    act(() => {
+      ReactDOM.render(
+        React.createElement(IOSDownloadPopoverContent),
+        container
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-qr-value]")).toBeNull();
+    expect(container.textContent).toContain("下载地址获取失败");
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "重试"
+    );
+    expect(retryButton?.tagName).toBe("BUTTON");
+    expect(retryButton?.closest('[role="img"]')).toBeNull();
+  });
+
+  it("does not render the removed direct TestFlight action", () => {
+    const html = renderToStaticMarkup(
       React.createElement(IOSDownloadPopoverContent)
     );
 
-    const directDownload = container.querySelector<HTMLAnchorElement>(
-      ".wk-login-mobile-download-direct-link"
-    );
-    expect(directDownload?.href).toBe(IOS_DOWNLOAD_URL);
-    expect(directDownload?.target).toBe("_blank");
-    expect(directDownload?.rel).toBe("noopener noreferrer");
-    expect(directDownload?.textContent).toBe("打开 TestFlight");
+    expect(html).not.toContain("wk-login-mobile-download-direct-link");
+    expect(html).not.toContain("打开 TestFlight");
   });
 });

--- a/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
+++ b/packages/dmworklogin/src/__tests__/ios_download_button.test.tsx
@@ -189,9 +189,9 @@ describe("IOSDownloadButton", () => {
     expect(html).not.toContain("手机扫码安装");
   });
 
-  it("renders the updater-provided iOS URL as a scannable QR code", async () => {
+  it("trims Unicode whitespace from the updater URL before rendering the QR code", async () => {
     const updaterUrl = "https://testflight.apple.com/join/backendCode";
-    apiFetchJsonMock.mockResolvedValue({ url: updaterUrl });
+    apiFetchJsonMock.mockResolvedValue({ url: `\u2004${updaterUrl}\u2004` });
     const container = document.createElement("div");
     document.body.appendChild(container);
     mountedContainers.push(container);

--- a/packages/dmworklogin/src/i18n/en-US.json
+++ b/packages/dmworklogin/src/i18n/en-US.json
@@ -77,6 +77,7 @@
     "or": "or"
   },
   "download": {
+    "addressLoadFailed": "Could not load download link",
     "android": "Android",
     "androidDirectDownload": "Download APK directly",
     "androidHoverHint": "Hover or click to view the Android download QR code",
@@ -84,10 +85,11 @@
     "githubManualDownload": "Or download manually from GitHub",
     "openGithubReleases": "Open GitHub Releases",
     "ios": "iOS",
-    "iosDirectDownload": "Open TestFlight",
     "iosHoverHint": "Hover or click to view the iOS installation QR code",
     "iosQrLabel": "TestFlight installation QR code",
-    "iosQrTitle": "Scan to download"
+    "iosQrTitle": "Scan to download",
+    "loadingAddress": "Loading download link",
+    "retry": "Retry"
   },
   "form": {
     "code": "Code",

--- a/packages/dmworklogin/src/i18n/zh-CN.json
+++ b/packages/dmworklogin/src/i18n/zh-CN.json
@@ -77,6 +77,7 @@
     "or": "或"
   },
   "download": {
+    "addressLoadFailed": "下载地址获取失败",
     "android": "Android",
     "androidDirectDownload": "直接下载 APK",
     "androidHoverHint": "悬停或点击查看 Android 下载二维码",
@@ -84,10 +85,11 @@
     "githubManualDownload": "或前往 GitHub 手动下载",
     "openGithubReleases": "打开 GitHub Releases",
     "ios": "iOS",
-    "iosDirectDownload": "打开 TestFlight",
     "iosHoverHint": "悬停或点击查看 iOS 安装二维码",
     "iosQrLabel": "TestFlight 安装二维码",
-    "iosQrTitle": "扫码下载"
+    "iosQrTitle": "扫码下载",
+    "loadingAddress": "正在获取下载地址",
+    "retry": "重试"
   },
   "form": {
     "code": "验证码",

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -293,8 +293,8 @@ const LegacyPasswordSection: React.FC<{
     )
 }
 
-// TestFlight 是公开固定 URL，不需要走 updater 接口
-// 实现见 ./IOSDownloadButton.tsx（抽成独立模块便于单测）
+// iOS 下载二维码通过 updater 接口获取；加载失败时不展示过期二维码。
+// 实现见 ./IOSDownloadButton.tsx（抽成独立模块便于单测）。
 
 // Known safe error messages from the server that can be shown to users
 /**

--- a/packages/dmworklogin/src/mobileDownloadUpdater.ts
+++ b/packages/dmworklogin/src/mobileDownloadUpdater.ts
@@ -1,0 +1,69 @@
+import React from "react";
+import { apiFetchJson, WKApp } from "@octo/base";
+
+export function resolveMobileUpdaterUrl(
+  updaterPath: string,
+  apiUrl = WKApp.apiClient.config.apiURL
+) {
+  return `${apiUrl.replace(/\/?$/, "/")}${updaterPath}`;
+}
+
+function resolveSafeDownloadUrl(value: unknown) {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    const url = new URL(value, window.location.origin);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return url.toString();
+    }
+  } catch {
+    // Invalid updater responses are treated as load failures.
+  }
+  return undefined;
+}
+
+export async function fetchMobileDownloadUrl(updaterPath: string) {
+  const result = await apiFetchJson<{ url?: unknown }>(
+    resolveMobileUpdaterUrl(updaterPath)
+  );
+  const downloadUrl = resolveSafeDownloadUrl(result?.url);
+  if (!downloadUrl) throw new Error("Updater returned an invalid download URL");
+  return downloadUrl;
+}
+
+type MobileDownloadUrlState =
+  | { status: "loading"; downloadUrl?: undefined }
+  | { status: "ready"; downloadUrl: string }
+  | { status: "error"; downloadUrl?: undefined };
+
+export function useMobileDownloadUrl(updaterPath: string) {
+  const [state, setState] = React.useState<MobileDownloadUrlState>({
+    status: "loading",
+  });
+  const requestIdRef = React.useRef(0);
+
+  const load = React.useCallback(() => {
+    const requestId = ++requestIdRef.current;
+    setState({ status: "loading" });
+    void fetchMobileDownloadUrl(updaterPath).then(
+      (downloadUrl) => {
+        if (requestId === requestIdRef.current) {
+          setState({ status: "ready", downloadUrl });
+        }
+      },
+      () => {
+        if (requestId === requestIdRef.current) {
+          setState({ status: "error" });
+        }
+      }
+    );
+  }, [updaterPath]);
+
+  React.useEffect(() => {
+    load();
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [load]);
+
+  return { ...state, retry: load };
+}

--- a/packages/dmworklogin/src/mobileDownloadUpdater.ts
+++ b/packages/dmworklogin/src/mobileDownloadUpdater.ts
@@ -9,9 +9,11 @@ export function resolveMobileUpdaterUrl(
 }
 
 function resolveSafeDownloadUrl(value: unknown) {
-  if (typeof value !== "string" || !value.trim()) return undefined;
+  if (typeof value !== "string") return undefined;
+  const normalizedValue = value.trim();
+  if (!normalizedValue) return undefined;
   try {
-    const url = new URL(value, window.location.origin);
+    const url = new URL(normalizedValue, window.location.origin);
     if (url.protocol === "http:" || url.protocol === "https:") {
       return url.toString();
     }


### PR DESCRIPTION
Selective hotfix backport from v1.9.0.

Included upstream PRs:
- #931 fix(login): use updater-backed mobile download links
- #932 fix(login): trim updater download URLs

Do not merge into main.