### PR TITLE
feat(contacts): add cached pinyin search

### DIFF
--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -24,7 +24,12 @@ import { shouldShowOnlineStatus, selectOnlineStatusUids } from "./onlineStatusGa
 import ContactsSearch from "../ui/ContactsSearch";
 import { ContactsDirectory, ContactsDirectorySection } from "../ui/ContactsDirectory";
 import type { ContactsDirectorySectionKey } from "../ui/ContactsDirectory/types";
-import { searchContacts } from "../bridge/contactsSearch/searchContacts";
+import {
+    buildContactsSearchIndex,
+    createEmptyContactsSearchIndex,
+    searchContacts,
+} from "../bridge/contactsSearch/searchContacts";
+import type { ContactsSearchIndex } from "../bridge/contactsSearch/types";
 
 function OverflowTooltip({ text, children }: { text: string; children: React.ReactNode }) {
     const [visible, setVisible] = useState(false)
@@ -211,6 +216,7 @@ export default class ContactsList extends Component<any, ContactsState> {
     private spaceChangedHandler!: (space: any) => void
     private flatItems: Contacts[] = []
     private indexCache = new Map<ContactFilterMode, ContactIndexData>()
+    private contactsSearchIndex: ContactsSearchIndex = createEmptyContactsSearchIndex()
     private filterScrollTops: Record<ContactFilterMode, number> = { all: 0, bots: 0, humans: 0 }
     // 已预取过 channelInfo（含在线态）的 uid 集合，跨 filter/滚动去重，避免重复请求
     private prefetchedUids = new Set<string>()
@@ -233,10 +239,14 @@ export default class ContactsList extends Component<any, ContactsState> {
             )
             if (idx !== -1) {
                 const members = [...this.state.spaceMembers]
+                const nameChanged = members[idx].name !== channelInfo.title
                 members[idx] = { ...members[idx], name: channelInfo.title }
                 this.setState({ spaceMembers: members }, () => {
-                    this.clearIndexCache()
-                    this.rebuildIndex()
+                    if (nameChanged) {
+                        this.rebuildContactsSearchIndex()
+                        this.clearIndexCache()
+                        this.rebuildIndex()
+                    }
                 })
                 return
             }
@@ -251,6 +261,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         this.spaceChangedHandler = (space: any) => {
             const sp = space as Space | undefined
             this.clearIndexCache()
+            this.contactsSearchIndex = createEmptyContactsSearchIndex()
             this.resetFilterScrollTops()
             this.prefetchedUids.clear()
             if (sp) {
@@ -345,6 +356,7 @@ export default class ContactsList extends Component<any, ContactsState> {
                 myGroups: myGroups || [],
                 loading: false,
             }, () => {
+                this.rebuildContactsSearchIndex()
                 this.clearIndexCache()
                 this.rebuildIndex()
                 // 「已添加AI」列表数量有界，数据就绪时整批预取一次在线态。
@@ -357,6 +369,15 @@ export default class ContactsList extends Component<any, ContactsState> {
 
     private clearIndexCache() {
         this.indexCache.clear()
+    }
+
+    private rebuildContactsSearchIndex() {
+        this.contactsSearchIndex = buildContactsSearchIndex({
+            spaceMembers: this.state.spaceMembers,
+            spaceBots: this.state.spaceBots,
+            myGroups: this.state.myGroups,
+            currentUid: WKApp.loginInfo.uid || "",
+        })
     }
 
     private resetFilterScrollTops() {
@@ -484,7 +505,8 @@ export default class ContactsList extends Component<any, ContactsState> {
         const pinyinCache = new Map<string, string>()
         for (const item of items) {
             let name = (item.remark || item.name || '').replace(/\*\*/g, '')
-            pinyinCache.set(item.uid, getPinyin(toSimplized(name)).toUpperCase())
+            const cachedPinyin = this.contactsSearchIndex.pinyinByUid.get(item.uid)
+            pinyinCache.set(item.uid, (cachedPinyin || getPinyin(toSimplized(name))).toUpperCase())
         }
 
         // 按拼音排序
@@ -538,12 +560,7 @@ export default class ContactsList extends Component<any, ContactsState> {
             return
         }
 
-        const { contacts, groups } = searchContacts(keyword, {
-            spaceMembers: this.state.spaceMembers,
-            spaceBots: this.state.spaceBots,
-            myGroups: this.state.myGroups,
-            currentUid: WKApp.loginInfo.uid || "",
-        })
+        const { contacts, groups } = searchContacts(keyword, this.contactsSearchIndex)
 
         this.setState({
             isSearching: true,
@@ -934,7 +951,11 @@ export default class ContactsList extends Component<any, ContactsState> {
                             const spaceId = WKApp.shared.currentSpaceId
                             if (spaceId) {
                                 WKApp.apiClient.get("/robot/space_bots", { param: { space_id: spaceId } }).then((res: any) => {
-                                    this.setState({ spaceBots: res || [] }, () => this.rebuildIndex())
+                                    this.setState({ spaceBots: res || [] }, () => {
+                                        this.rebuildContactsSearchIndex()
+                                        this.clearIndexCache()
+                                        this.rebuildIndex()
+                                    })
                                 }).catch(() => {})
                             }
                         }}

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.test.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.test.ts
@@ -1,29 +1,77 @@
-import { describe, expect, it } from "vitest";
-import { searchContacts } from "./searchContacts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildContactsSearchIndex,
+  createEmptyContactsSearchIndex,
+  searchContacts,
+} from "./searchContacts";
 
-describe("searchContacts", () => {
+describe("contacts search index", () => {
   const source = {
     currentUid: "self",
     spaceMembers: [
       { uid: "self", name: "Self" },
-      { uid: "human", name: "**Alice**", robot: 0 },
+      { uid: "human", name: "**魏娇莹**", robot: 0 },
       { uid: "member-bot", name: "Helper AI", robot: 1 },
     ],
     spaceBots: [
       { uid: "member-bot", name: "Helper AI" },
       { uid: "extra-bot", name: "Extra AI" },
     ],
-    myGroups: [{ group_no: "group-1", name: "Alice Group" }],
+    myGroups: [{ group_no: "group-1", name: "魏娇莹 Group" }],
   };
 
-  it("keeps current matching, exclusion and extra-bot dedup behavior", () => {
-    expect(searchContacts("alice", source)).toEqual({
-      contacts: [{ uid: "human", name: "**Alice**", robot: 0 }],
-      groups: [{ group_no: "group-1", name: "Alice Group" }],
-    });
+  it("matches Chinese names, full pinyin and case-insensitive pinyin", () => {
+    const index = buildContactsSearchIndex(source);
+
     expect(
-      searchContacts("ai", source).contacts.map((item) => item.uid)
+      searchContacts("魏娇", index).contacts.map((item) => item.uid)
+    ).toEqual(["human"]);
+    expect(
+      searchContacts("weijiao", index).contacts.map((item) => item.uid)
+    ).toEqual(["human"]);
+    expect(
+      searchContacts("WEIJIAO", index).groups.map((item) => item.group_no)
+    ).toEqual(["group-1"]);
+  });
+
+  it("preserves current-user exclusion and extra-bot deduplication", () => {
+    const index = buildContactsSearchIndex(source);
+
+    expect(
+      searchContacts("ai", index).contacts.map((item) => item.uid)
     ).toEqual(["member-bot", "extra-bot"]);
-    expect(searchContacts("self", source).contacts).toEqual([]);
+    expect(searchContacts("self", index).contacts).toEqual([]);
+  });
+
+  it("returns no results before the current Space index is ready", () => {
+    expect(searchContacts("alice", createEmptyContactsSearchIndex())).toEqual({
+      contacts: [],
+      groups: [],
+    });
+  });
+
+  it("converts 10,000 names once and reuses the index for repeated queries", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "魏娇莹" ? "weijiaoying" : name
+    );
+    const largeSource = {
+      currentUid: "self",
+      spaceMembers: Array.from({ length: 10_000 }, (_, index) => ({
+        uid: `user-${index}`,
+        name: index === 9_999 ? "魏娇莹" : `User ${index}`,
+      })),
+      spaceBots: [],
+      myGroups: [],
+    };
+    const index = buildContactsSearchIndex(largeSource, toPinyin);
+    const startedAt = performance.now();
+
+    for (let count = 0; count < 20; count += 1) {
+      expect(searchContacts("weijiao", index).contacts).toHaveLength(1);
+    }
+
+    expect(toPinyin).toHaveBeenCalledTimes(10_000);
+    const averageQueryMs = (performance.now() - startedAt) / 20;
+    expect(averageQueryMs).toBeLessThan(15);
   });
 });

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/searchContacts.ts
@@ -1,33 +1,81 @@
+import { getPinyin } from "@octo/base/src/Utils/pinYin";
+import { toSimplized } from "@octo/base/src/Utils/t2s";
 import type {
   ContactsSearchBot,
+  ContactsSearchIndex,
   ContactsSearchResult,
   ContactsSearchSource,
 } from "./types";
+
+export type ContactsPinyinConverter = (value: string) => string;
 
 function normalizeName(value?: string): string {
   return (value || "").replace(/\*\*/g, "").toLowerCase();
 }
 
-export function searchContacts(
-  keyword: string,
-  source: ContactsSearchSource
-): ContactsSearchResult {
-  const normalizedKeyword = keyword.toLowerCase();
+function defaultPinyinConverter(value: string): string {
+  return getPinyin(toSimplized(value)).toLowerCase();
+}
+
+function buildSearchText(
+  value: string | undefined,
+  toPinyin: ContactsPinyinConverter
+): { pinyin: string; searchText: string } {
+  const normalizedName = normalizeName(value);
+  const pinyin = toPinyin(normalizedName).toLowerCase();
+  return {
+    pinyin,
+    searchText: `${normalizedName}\n${pinyin}`,
+  };
+}
+
+export function buildContactsSearchIndex(
+  source: ContactsSearchSource,
+  toPinyin: ContactsPinyinConverter = defaultPinyinConverter
+): ContactsSearchIndex {
   const memberUids = new Set(source.spaceMembers.map((member) => member.uid));
-  const memberResults = source.spaceMembers
+  const pinyinByUid = new Map<string, string>();
+
+  const people = source.spaceMembers
     .filter((member) => member.uid !== source.currentUid)
-    .filter((member) => normalizeName(member.name).includes(normalizedKeyword));
-  const extraBotResults = source.spaceBots
+    .map((member) => {
+      const text = buildSearchText(member.name, toPinyin);
+      pinyinByUid.set(member.uid, text.pinyin);
+      return { item: member, searchText: text.searchText };
+    });
+
+  const extraBots = source.spaceBots
     .filter((bot) => bot.uid !== source.currentUid && !memberUids.has(bot.uid))
-    .filter((bot) => normalizeName(bot.name).includes(normalizedKeyword))
     .map((bot) => {
       const item: ContactsSearchBot = { ...bot, robot: 1 };
-      return item;
+      const text = buildSearchText(bot.name, toPinyin);
+      pinyinByUid.set(bot.uid, text.pinyin);
+      return { item, searchText: text.searchText };
     });
-  const groups = source.myGroups.filter(
-    (group) =>
-      group.name && normalizeName(group.name).includes(normalizedKeyword)
-  );
 
-  return { contacts: [...memberResults, ...extraBotResults], groups };
+  const groups = source.myGroups.map((group) => ({
+    item: group,
+    searchText: buildSearchText(group.name, toPinyin).searchText,
+  }));
+
+  return { people: [...people, ...extraBots], groups, pinyinByUid };
+}
+
+export function createEmptyContactsSearchIndex(): ContactsSearchIndex {
+  return { people: [], groups: [], pinyinByUid: new Map() };
+}
+
+export function searchContacts(
+  keyword: string,
+  index: ContactsSearchIndex
+): ContactsSearchResult {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  return {
+    contacts: index.people
+      .filter((entry) => entry.searchText.includes(normalizedKeyword))
+      .map((entry) => entry.item),
+    groups: index.groups
+      .filter((entry) => entry.searchText.includes(normalizedKeyword))
+      .map((entry) => entry.item),
+  };
 }

--- a/packages/dmworkcontacts/src/bridge/contactsSearch/types.ts
+++ b/packages/dmworkcontacts/src/bridge/contactsSearch/types.ts
@@ -26,3 +26,16 @@ export interface ContactsSearchResult {
   contacts: Array<SpaceMember | ContactsSearchBot>;
   groups: ContactsSearchGroup[];
 }
+
+export type ContactsSearchPerson = SpaceMember | ContactsSearchBot;
+
+export interface ContactsSearchEntry<T> {
+  item: T;
+  searchText: string;
+}
+
+export interface ContactsSearchIndex {
+  people: Array<ContactsSearchEntry<ContactsSearchPerson>>;
+  groups: Array<ContactsSearchEntry<ContactsSearchGroup>>;
+  pinyinByUid: Map<string, string>;
+}


### PR DESCRIPTION
## Summary

Add cached pinyin matching to the existing Contacts search so users can find contacts, AI members, and groups with Chinese names or full-pinyin input without changing the current search UI or interaction flow.

The pinyin index is built only when the Space search source changes and is reused by debounced search and contact sorting, keeping repeated queries fast for the current data scale.

## Related Issue

None.

## Changes

- Add a typed, reusable Contacts search index in `bridge/contactsSearch` for normalized names and full pinyin.
- Support Chinese, full pinyin, partial full pinyin, and case-insensitive pinyin queries.
- Rebuild the index when Space/member source data changes, clear it on Space switches, and avoid rebuilds for online-status-only updates.
- Reuse cached pinyin values for contact sorting.
- Extend focused regression tests, including a 10,000-entry performance case.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkcontacts` Contacts search.
- New or changed user-visible entry point: No. The existing Contacts search box remains the only entry point.
- Shared layer touched: `bridge/contactsSearch` and its existing Contacts container caller.
- If shared code changed, impact scope: Limited to Contacts search matching, search-index lifecycle, and pinyin-assisted contact sorting.
- Duplicate entry point checked: Yes.
- API/service impact: None. No backend endpoint or request contract changes.

## Scope Boundaries

- Preserves the existing 300 ms debounce, current-user exclusion, AI deduplication, result clicks, selected state, organization tree, and hidden entries.
- Does not change the Contacts UI.
- Does not add initials matching such as `wjy`.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- Focused contacts-search tests: 11/11 passed.
- 10,000-entry regression coverage: average query time asserted below 15 ms.
- `pnpm i18n:check`: passed.
- Web production build: passed with existing third-party warnings.
- `git diff --check`: passed.
- Manual verification with online data: `zhangjiao` matched `张娇`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — not applicable; no documentation or public API contract changed
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
