### PR TITLE
feat(html-doc): source creator display and forward-grant from docs-backend (OCT-194)

### DIFF
--- a/packages/docs/src/editor/DocMoreMenu.test.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.test.tsx
@@ -89,3 +89,35 @@ describe('DocMoreMenu', () => {
     expect(screen.queryByText(/docs\.moreMenu\.createdPrefix/)).toBeNull()
   })
 })
+describe('DocMoreMenu — creator avatar (OCT-194)', () => {
+  it('renders an <img> when creatorAvatarUrl is present', () => {
+    render(
+      <DocMoreMenu creatorName="Alice" creatorAvatarUrl="/api/v1/users/u1/avatar" items={[]} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    const img = document.querySelector('img.octo-doc-more-avatar') as HTMLImageElement | null
+    expect(img).toBeTruthy()
+    expect(img?.getAttribute('src')).toBe('/api/v1/users/u1/avatar')
+    // Fallback initial chip is NOT rendered when the image is showing (avoid double head).
+    expect(document.querySelector('span.octo-doc-more-avatar')).toBeNull()
+  })
+
+  it('falls back to the initial-letter chip when the avatar image fails to load', () => {
+    render(
+      <DocMoreMenu creatorName="Alice" creatorAvatarUrl="/api/v1/users/u1/avatar" items={[]} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    const img = document.querySelector('img.octo-doc-more-avatar') as HTMLImageElement
+    fireEvent.error(img)
+    expect(document.querySelector('img.octo-doc-more-avatar')).toBeNull()
+    expect(document.querySelector('span.octo-doc-more-avatar')?.textContent).toBe('A')
+  })
+
+  it('renders the initial-letter chip when creatorAvatarUrl is absent (existing behaviour)', () => {
+    render(<DocMoreMenu creatorName="Bob" items={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.more' }))
+    expect(document.querySelector('img.octo-doc-more-avatar')).toBeNull()
+    expect(document.querySelector('span.octo-doc-more-avatar')?.textContent).toBe('B')
+  })
+})
+

--- a/packages/docs/src/editor/DocMoreMenu.tsx
+++ b/packages/docs/src/editor/DocMoreMenu.tsx
@@ -23,6 +23,11 @@ export interface DocMoreMenuItem {
 export interface DocMoreMenuProps {
   /** Resolved creator display name. The parent handles the resolution + fallback (short uid). */
   creatorName: string
+  /**
+   * Optional avatar URL for the creator (parent-resolved). Rendered as an <img>; falls back to
+   * the initial-letter chip when absent or when the image fails to load (e.g. missing user).
+   */
+  creatorAvatarUrl?: string | null
   /** Creation timestamp (RFC3339). Rendered as "Created on YYYY-MM-DD"; omitted when absent/invalid. */
   createdAt?: string
   /** Neutral action rows, rendered top-to-bottom in the given order. */
@@ -175,6 +180,22 @@ function MenuRow({ item, onSelect }: { item: DocMoreMenuItem; onSelect: () => vo
   )
 }
 
+/** Avatar cell for the ≡ menu head: <img> when URL loads, initial-letter chip otherwise (also on onError). */
+function CreatorAvatar({ name, url }: { name: string; url?: string | null }) {
+  const [failed, setFailed] = useState(false)
+  const showImg = !!url && !failed
+  if (showImg) {
+    return (
+      <img className="octo-doc-more-avatar" src={url} alt="" title={name} onError={() => setFailed(true)} />
+    )
+  }
+  return (
+    <span className="octo-doc-more-avatar" aria-hidden="true">
+      {avatarInitial(name)}
+    </span>
+  )
+}
+
 /**
  * Header "more" (≡) dropdown for the document editor. Collapses the low-frequency title-bar
  * actions (open in new page / version history / export / delete) behind a single ≡ affordance at
@@ -183,7 +204,7 @@ function MenuRow({ item, onSelect }: { item: DocMoreMenuItem; onSelect: () => vo
  * Self-contained plain-React popover (no antd, no portal): a relatively-positioned wrapper anchors
  * an absolutely-positioned panel below the trigger. Closes on outside pointer-down and on Escape.
  */
-export function DocMoreMenu({ creatorName, createdAt, items, dangerItem }: DocMoreMenuProps) {
+export function DocMoreMenu({ creatorName, creatorAvatarUrl, createdAt, items, dangerItem }: DocMoreMenuProps) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
   const close = () => setOpen(false)
@@ -223,9 +244,7 @@ export function DocMoreMenu({ creatorName, createdAt, items, dangerItem }: DocMo
         <div className="octo-doc-more-panel" role="menu">
           <div className="octo-doc-more-head">
             <div className="octo-doc-more-creator">
-              <span className="octo-doc-more-avatar" aria-hidden="true">
-                {avatarInitial(creatorName)}
-              </span>
+              <CreatorAvatar name={creatorName} url={creatorAvatarUrl} />
               <span className="octo-doc-more-name" title={creatorName}>
                 {creatorName}
               </span>

--- a/packages/docs/src/html/HtmlDocCommentPanel.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.tsx
@@ -10,7 +10,8 @@
 // "让 AI 处理" click forwards an instruction to chat (openDocForward). The two are decoupled.
 
 import { useCallback, useEffect, useState } from 'react'
-import { canForwardToChat, openDocForward, t, getWKApp } from '../octoweb/index.ts'
+import { canForwardToChat, openDocForward, t } from '../octoweb/index.ts'
+import { avatarUrlForUid } from './htmlAvatar.ts'
 import {
   createComment,
   formatCommentTime,
@@ -61,24 +62,14 @@ function authorName(author: OctoDocAuthor | null | undefined): string {
 }
 
 /**
- * Resolve a comment author's avatar URL. Prefer the backend-supplied avatar_url when present;
- * otherwise derive it from the author uid (author.login) the same way collaborator avatars do:
- * the octo-server `/v1/users/<uid>/avatar` image endpoint, reached via the same-origin `/api/v1/`
- * proxy. This makes comment avatars work for ALL comments (incl. history) without the verify API
- * having to return an avatar. Returns null when no uid is available (→ initial-letter fallback).
+ * Resolve a comment author's avatar URL. Backend-supplied `avatar_url` wins; otherwise fall back
+ * to the shared `/api/v1/users/<uid>/avatar` endpoint via avatarUrlForUid (same helper the header
+ * ≡ menu uses for the doc creator). Order matters: never invert — an incoming avatar_url is the
+ * only path that carries a non-avatar-endpoint image the panel must respect.
  */
 function avatarUrlFor(author: OctoDocAuthor | null | undefined): string | null {
   if (author?.avatar_url) return author.avatar_url
-  let uid = author?.login?.trim()
-  if (!uid) return null
-  // Strip the Space-scoped prefix (s<spaceId>_) so we address the raw uid, mirroring
-  // WKApp.avatarUser()'s handling of person channel ids.
-  const spaceId = getWKApp().shared?.currentSpaceId
-  if (spaceId && uid.startsWith(`s${spaceId}_`)) {
-    uid = uid.substring(spaceId.length + 2)
-  }
-  if (!uid) return null
-  return `/api/v1/users/${encodeURIComponent(uid)}/avatar`
+  return avatarUrlForUid(author?.login)
 }
 
 /** Author + time line shown under each root comment and reply. */

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -649,14 +649,56 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     expect(container.querySelector('.octo-modal-overlay')).toBeNull()
   })
 
-  it('forwards the whole-doc link via openDocForward from the header forward button', async () => {
+  it('forwards the whole-doc link via startDocForward from the header forward button (non-admin viewer: canGrant=false)', async () => {
+    // docs-backend GET /docs/:id supplies the LIVE role + ownerId startDocForward consumes; a reader
+    // whose uid ≠ owner produces canGrant=false, matching the prior sharing-only behaviour.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/the-slug') {
+        return { data: { docId: 'the-slug', ownerId: 'u_owner', role: 'reader' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>', { title: 'My Doc' })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
+    await waitForFrame(container)
+    // Wait for the role to land so the click is not early-returned by the `!role` guard.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/the-slug')).toBe(true))
+    fireEvent.click(screen.getByTitle('docs.forward.entry'))
+    await waitFor(() => expect(wk.openDocForwardCalls).toHaveLength(1))
+    expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', title: 'My Doc', canGrant: false })
+    expect(typeof wk.openDocForwardCalls[0].link).toBe('string')
+    // Sharing-only: no grantAccess executor when canGrant is false.
+    expect(wk.openDocForwardCalls[0].grantAccess).toBeUndefined()
+  })
+
+  it('opens forward with canGrant=true and wires a grantAccess executor when the viewer is owner/admin (computeCanGrant)', async () => {
+    // Owner (uid === ownerId) satisfies computeCanGrant regardless of role; grantAccess must be
+    // wired to the /docs/{docId}/forward-grant loop so the modal授权区 fires the per-uid grants.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/the-slug') {
+        return { data: { docId: 'the-slug', ownerId: 'u_viewer', role: 'admin' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>', { title: 'My Doc' })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
+    await waitForFrame(container)
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/the-slug')).toBe(true))
+    fireEvent.click(screen.getByTitle('docs.forward.entry'))
+    await waitFor(() => expect(wk.openDocForwardCalls).toHaveLength(1))
+    expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', canGrant: true })
+    expect(typeof wk.openDocForwardCalls[0].grantAccess).toBe('function')
+  })
+
+  it('forward click is a no-op while docs-backend role is still loading (fail-soft, no premature canGrant=false send)', async () => {
+    // A never-resolving getDoc keeps role=null; startDocForward must not fire (mirrors EditorShell
+    // `if (!role) return`) so a demoted admin never gets a stale canGrant snapshot.
+    wk.apiClient.responder = () => new Promise(() => {})
     serveDoc('<p>body</p>', { title: 'My Doc' })
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
     await waitForFrame(container)
     fireEvent.click(screen.getByTitle('docs.forward.entry'))
-    expect(wk.openDocForwardCalls).toHaveLength(1)
-    expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', title: 'My Doc', canGrant: false })
-    expect(typeof wk.openDocForwardCalls[0].link).toBe('string')
+    expect(wk.openDocForwardCalls).toHaveLength(0)
   })
 
   it('offers delete only to the author in the ≡ menu', async () => {
@@ -685,3 +727,95 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     expect(frame.getAttribute('srcdoc')).toContain('<base href="https://od.test/">')
   })
 })
+
+describe('HtmlDocView — creator/created head sourced from docs-backend (OCT-194)', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  function serveDoc(htmlBody: string) {
+    // Header-only tests: the __ODOC__ / __ODOC_CAP__ inline blobs are irrelevant here because the
+    // creator display now reads exclusively from docs-backend (getDoc + getUserName).
+    return stubFetch((url) => {
+      if (url.includes('/comments')) return jsonResponse({ data: [] })
+      return htmlResponse(htmlBody)
+    })
+  }
+
+  beforeEach(() => {
+    ;(window as unknown as { __OCTO_DOC_BASE__?: string }).__OCTO_DOC_BASE__ = 'https://od.test'
+    wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    setWKApp(wk)
+  })
+  afterEach(() => {
+    delete (window as unknown as { __OCTO_DOC_BASE__?: unknown }).__OCTO_DOC_BASE__
+    setWKApp(undefined as never)
+  })
+
+  it('renders the creator name (from getUserName) and created-on date (from getDoc.createdAt) in the ≡ menu head', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d1') {
+        return {
+          data: { docId: 'd1', ownerId: 'u_owner', createdAt: '2026-07-15T04:09:00Z' },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url === '/users/u_owner') {
+        return { data: { name: 'Nick', real_name: 'Alice Owner' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>')
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    await waitForFrame(container)
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(true))
+    // Open the ≡ menu.
+    fireEvent.click(container.querySelector('.octo-doc-more-btn') as HTMLElement)
+    // In-shell (creatorNicknameOnly unset) prefers real_name — the verified name lands in the head.
+    await waitFor(() => expect(screen.getByText('Alice Owner')).toBeTruthy())
+    // Created-on is a lexical YYYY-MM-DD slice (no tz drift).
+    expect(screen.getByText(/2026-07-15/)).toBeTruthy()
+  })
+
+  it('passes X-Space-Id on the docs-backend GET so the standalone /d/:docId space-required middleware accepts it', async () => {
+    wk.apiClient.responder = () => ({ data: {}, status: 200 })
+    serveDoc('<p>body</p>')
+    render(<HtmlDocView docId="d1" space="sp_42" />)
+    await waitFor(() => {
+      const call = wk.apiClient.calls.find((c) => c.url === '/docs/d1')
+      expect(call).toBeTruthy()
+      expect(call?.config?.headers).toMatchObject({ 'X-Space-Id': 'sp_42' })
+    })
+  })
+
+  it('standalone (creatorNicknameOnly) resolves nickname-only — real_name never surfaces to the link holder', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d1') {
+        return { data: { docId: 'd1', ownerId: 'u_owner' }, status: 200 }
+      }
+      if (method === 'get' && url === '/users/u_owner') {
+        // Server returns both; the standalone surface must ignore real_name (preferRealName:false).
+        return { data: { name: 'Nick', real_name: 'Real Legal Name' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>')
+    const { container } = render(<HtmlDocView docId="d1" space="sp" creatorNicknameOnly />)
+    await waitForFrame(container)
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(true))
+    fireEvent.click(container.querySelector('.octo-doc-more-btn') as HTMLElement)
+    await waitFor(() => expect(screen.getByText('Nick')).toBeTruthy())
+    expect(screen.queryByText('Real Legal Name')).toBeNull()
+  })
+
+  it('fails soft when docs-backend rejects (404/network) — header falls back to slug initial, ≡ menu still opens, no crash', async () => {
+    wk.apiClient.responder = () => Promise.reject(new Error('not found'))
+    serveDoc('<p>body</p>')
+    const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" />)
+    await waitForFrame(container)
+    // Header title falls through to the slug (no meta.title).
+    expect(container.querySelector('.octo-html-doc-title')?.textContent).toBe('the-slug')
+    // ≡ menu opens without crashing; the creator row shows the '—' placeholder (ownerId undefined).
+    fireEvent.click(container.querySelector('.octo-doc-more-btn') as HTMLElement)
+    expect(document.querySelector('.octo-doc-more-name')?.textContent).toBe('—')
+  })
+})
+

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -653,8 +653,9 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     // docs-backend GET /docs/:id supplies the LIVE role + ownerId startDocForward consumes; a reader
     // whose uid ≠ owner produces canGrant=false, matching the prior sharing-only behaviour.
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/the-slug') {
-        return { data: { docId: 'the-slug', ownerId: 'u_owner', role: 'reader' }, status: 200 }
+      // docs-backend is keyed by docId (d1), NEVER by the octo-doc slug (the-slug).
+      if (method === 'get' && url === '/docs/d1') {
+        return { data: { docId: 'd1', ownerId: 'u_owner', role: 'reader' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -662,7 +663,7 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
     await waitForFrame(container)
     // Wait for the role to land so the click is not early-returned by the `!role` guard.
-    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/the-slug')).toBe(true))
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/d1')).toBe(true))
     fireEvent.click(screen.getByTitle('docs.forward.entry'))
     await waitFor(() => expect(wk.openDocForwardCalls).toHaveLength(1))
     expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', title: 'My Doc', canGrant: false })
@@ -675,15 +676,16 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     // Owner (uid === ownerId) satisfies computeCanGrant regardless of role; grantAccess must be
     // wired to the /docs/{docId}/forward-grant loop so the modal授权区 fires the per-uid grants.
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/the-slug') {
-        return { data: { docId: 'the-slug', ownerId: 'u_viewer', role: 'admin' }, status: 200 }
+      // docs-backend is keyed by docId (d1), NEVER by the octo-doc slug (the-slug).
+      if (method === 'get' && url === '/docs/d1') {
+        return { data: { docId: 'd1', ownerId: 'u_viewer', role: 'admin' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
     serveDoc('<p>body</p>', { title: 'My Doc' })
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="the-slug" version="v2" />)
     await waitForFrame(container)
-    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/the-slug')).toBe(true))
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/d1')).toBe(true))
     fireEvent.click(screen.getByTitle('docs.forward.entry'))
     await waitFor(() => expect(wk.openDocForwardCalls).toHaveLength(1))
     expect(wk.openDocForwardCalls[0]).toMatchObject({ docId: 'd1', canGrant: true })
@@ -816,6 +818,47 @@ describe('HtmlDocView — creator/created head sourced from docs-backend (OCT-19
     // ≡ menu opens without crashing; the creator row shows the '—' placeholder (ownerId undefined).
     fireEvent.click(container.querySelector('.octo-doc-more-btn') as HTMLElement)
     expect(document.querySelector('.octo-doc-more-name')?.textContent).toBe('—')
+  })
+
+  it('OCT-198 regression: standalone slug≠docId hits docs-backend by docId (not slug); owner/created/role resolve', async () => {
+    // StandaloneDocPage passes docId=meta.docId + slug=meta.octoDocSlug as TWO different ids.
+    // The bug: getDoc was called with effectiveSlug (=slug), so `/docs/{slug}` 404'd and silently
+    // wiped ownerId/createdAt/role — creator display + forward授权 broke on every published html
+    // doc with a distinct octo-doc slug. Guard the fix: docs-backend receives docId, slug is
+    // reserved for octo-doc render (`/d/{slug}/v/{ver}`) + comment/asset/grant paths.
+    wk.apiClient.responder = (method, url) => {
+      // docs-backend keyed by docId. A slug-shaped call here is the pre-fix bug returning.
+      if (method === 'get' && url === '/docs/doc_abc') {
+        return {
+          data: { docId: 'doc_abc', ownerId: 'u_owner', role: 'admin', createdAt: '2026-07-20T00:00:00Z' },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url === '/users/u_owner') {
+        return { data: { name: 'Nick', real_name: 'Alice Owner' }, status: 200 }
+      }
+      // Explicit trap: a call to `/docs/{slug}` means the bug regressed.
+      if (method === 'get' && url === '/docs/published-slug-xyz') {
+        throw new Error('OCT-198 regression: getDoc called with slug instead of docId')
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>')
+    const { container } = render(
+      <HtmlDocView docId="doc_abc" space="sp_1" slug="published-slug-xyz" version="v2" />
+    )
+    await waitForFrame(container)
+    // 1) docs-backend addressed by docId, never by slug.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/doc_abc')).toBe(true))
+    expect(wk.apiClient.calls.some((c) => c.url === '/docs/published-slug-xyz')).toBe(false)
+    // 2) octo-doc render path still uses the slug (unchanged).
+    const octoCalls = (globalThis.fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls
+    expect(octoCalls.some(([u]) => String(u).includes('/d/published-slug-xyz/v/v2'))).toBe(true)
+    // 3) ownerId/createdAt/role landed — so the creator name resolves and forward授权 unblocks.
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/users/u_owner')).toBe(true))
+    fireEvent.click(container.querySelector('.octo-doc-more-btn') as HTMLElement)
+    await waitFor(() => expect(screen.getByText('Alice Owner')).toBeTruthy())
+    expect(screen.getByText(/2026-07-20/)).toBeTruthy()
   })
 })
 

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -17,7 +17,12 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import DOMPurify from 'dompurify'
-import { canForwardToChat, openDocForward, t, getWKApp } from '../octoweb/index.ts'
+import { canForwardToChat, t, getWKApp, getCurrentUid } from '../octoweb/index.ts'
+import { getDoc, getUserName } from '../pages/docsApi.ts'
+import { useMemberNames } from '../members/useMemberNames.ts'
+import { startDocForward } from '../forward/startDocForward.ts'
+import { avatarUrlForUid } from './htmlAvatar.ts'
+import type { Role } from '../auth/roles.ts'
 import { buildDocLink } from '../forward/link.ts'
 import { HtmlDocCommentPanel } from './HtmlDocCommentPanel.tsx'
 import { HtmlMemberPanel } from './HtmlMemberPanel.tsx'
@@ -195,6 +200,12 @@ export interface HtmlDocViewProps {
   version?: string
   /** Called after the doc is deleted so the shell returns to the list + refreshes it (mirror of SheetView). */
   onDeleted?: (docId: string) => void
+  /**
+   * Standalone /d/:docId (externally shared) surface flag. When true the creator name resolves
+   * nickname-only (skips the member map, forces `preferRealName:false`) so a link holder never
+   * sees the creator's verified real_name — mirrors EditorShell/BoardShell's XIN-392 P2-1 gate.
+   */
+  creatorNicknameOnly?: boolean
 }
 
 /**
@@ -243,13 +254,21 @@ type LoadState =
 // doc creator. __ODOC__ (core.OverlayConfig) does NOT carry creator_uid — so never derive
 // authorship by comparing viewer uid against identity.login (that is always the viewer =
 // always true). Authorship comes from window.__ODOC_CAP__.isAuthor (see parseOdocCap).
+//
+// creator_uid / creator_name / created_at fields are DEPRECATED — the header now reads
+// ownerId/createdAt from docs-backend getDoc (single source of truth, same as EditorShell).
+// Interface entries retained only so a payload that still carries them parses cleanly; DO NOT
+// reintroduce readers of these fields — future backends may drop them without notice.
 interface OctoDocMeta {
   slug?: string
   title?: string
   version?: number
   identity?: { login?: string; name?: string } | null
+  /** @deprecated use docs-backend getDoc().ownerId */
   creator_uid?: string
+  /** @deprecated use docs-backend getUserName(ownerId) */
   creator_name?: string
+  /** @deprecated use docs-backend getDoc().createdAt */
   created_at?: string
 }
 
@@ -275,7 +294,7 @@ function parseOdocCap(html: string): boolean {
   return m?.[1] === 'true'
 }
 
-export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted }: HtmlDocViewProps) {
+export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted, creatorNicknameOnly }: HtmlDocViewProps) {
   const [state, setState] = useState<LoadState>({ status: 'loading' })
   // Guards a late fetch resolve from overwriting state after the docId/slug changed.
   const reqSeq = useRef(0)
@@ -299,12 +318,71 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
   // viewer uid to any __ODOC__ field: identity there is the viewer itself and creator_uid is absent,
   // so a client-side comparison would make every viewer an "author" (the invited-viewer-as-owner bug).
   const isAuthor = state.status === 'ready' ? state.isAuthor : false
-  // Title: backend does not expose a human title yet → fall back to slug. Creator: prefer a
-  // display name, else the creator/login uid.
+
+  // Creator + role now come from docs-backend (getDoc → resolveRole), not from the inlined
+  // __ODOC__ blob. Keeps HTML docs on the same data source as EditorShell/BoardShell/SheetView so
+  // creator display and forward-grant capability are computed identically across doc kinds.
+  // Fail-soft: 404 (裸 doc, no doc_meta) / 403 leaves everything undefined → header falls back to
+  // the slug/initial and forward授权 stays greyed, without crashing.
+  const [ownerId, setOwnerId] = useState<string | undefined>(undefined)
+  const [createdAt, setCreatedAt] = useState<string | undefined>(undefined)
+  const [role, setRole] = useState<Role | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    // standalone /d/:docId mounts before the space is restored, so the request interceptor injects
+    // no X-Space-Id; pass it explicitly (same as EditorShell's getDoc call).
+    const opts = space ? { spaceId: space } : undefined
+    getDoc(effectiveSlug, opts)
+      .then((m) => {
+        if (cancelled) return
+        if (typeof m?.ownerId === 'string' && m.ownerId) setOwnerId(m.ownerId)
+        if (typeof m?.createdAt === 'string' && m.createdAt) setCreatedAt(m.createdAt)
+        if (m?.role) setRole(m.role)
+      })
+      .catch(() => {
+        /* fail-soft: creator/created/role stay undefined; header uses fallbacks, canGrant=false */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [effectiveSlug, space])
+
+  // Resolve creator display name (parity with EditorShell): in-shell prefers the already-loaded
+  // space-member map (free), then falls back to GET /users/:uid for a verified real name. The
+  // standalone surface (creatorNicknameOnly) SKIPS the member map entirely and forces nickname-
+  // only so a link holder never sees the creator's verified real_name (XIN-392 P2-1).
+  const names = useMemberNames(space)
+  const [creatorName, setCreatorName] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    setCreatorName(undefined)
+    if (!ownerId) return
+    if (!creatorNicknameOnly) {
+      const fromMembers = names.get(ownerId)
+      if (fromMembers && fromMembers !== ownerId) {
+        setCreatorName(fromMembers)
+        return
+      }
+    }
+    let cancelled = false
+    getUserName(ownerId, { preferRealName: !creatorNicknameOnly })
+      .then((name) => {
+        if (!cancelled && name) setCreatorName(name)
+      })
+      .catch(() => {
+        /* keep the uid fallback */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [ownerId, names, creatorNicknameOnly])
+
+  // Title: backend does not expose a human title yet → fall back to slug.
   const headerTitle = meta?.title || effectiveSlug
-  const headerCreator = meta?.creator_name || meta?.creator_uid || '—'
+  // Creator display: resolved name → short uid → placeholder. Never blank, never crashes.
+  const headerCreator = creatorName || (ownerId ? ownerId.slice(0, 8) : '—')
+  const creatorAvatarUrl = avatarUrlForUid(ownerId)
   // Author-only affordances (member management, delete) gate on the backend flag, never on uid math.
-  const creatorUid = meta?.creator_uid
+  const creatorUid = ownerId
   const canManage = isAuthor
   // Browser-openable address for forwarding this doc to chat. Build the PATH-style standalone
   // link (/d/<docId>?sp=<space>) like every other kind (buildDocLink), NOT window.location.href:
@@ -315,12 +393,21 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
   const docUrl = buildDocLink({ docId, space })
   const canForward = canForwardToChat()
 
+  // Forward-to-chat: unified with EditorShell/BoardShell/SheetView via startDocForward — it computes
+  // canGrant = computeCanGrant(role, currentUid, ownerId) and wires the per-uid grant executor
+  // against POST /docs/{docId}/forward-grant. Early-return while role is still loading so we never
+  // send canGrant=false before resolveRole has spoken (mirrors EditorShell's `if (!role) return`).
   const doForward = useCallback(() => {
-    if (!canForward) return
-    // Doc-level forward: the whole document link (not a specific comment). canGrant=false — this
-    // shares a read link, not an access grant.
-    openDocForward({ docId, title: headerTitle, link: docUrl, canGrant: false })
-  }, [canForward, docId, headerTitle, docUrl])
+    if (!canForward || !role) return
+    startDocForward({
+      docId,
+      title: headerTitle,
+      role,
+      currentUid: getCurrentUid(),
+      ownerId,
+      space,
+    })
+  }, [canForward, docId, headerTitle, role, ownerId, space])
 
   const confirmDeleteDoc = useCallback(() => {
     setDeleting(true)
@@ -495,7 +582,8 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted 
           )}
           <DocMoreMenu
             creatorName={headerCreator}
-            createdAt={meta?.created_at}
+            creatorAvatarUrl={creatorAvatarUrl}
+            createdAt={createdAt}
             items={[
               {
                 key: 'open-new-page',

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -332,7 +332,12 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
     // standalone /d/:docId mounts before the space is restored, so the request interceptor injects
     // no X-Space-Id; pass it explicitly (same as EditorShell's getDoc call).
     const opts = space ? { spaceId: space } : undefined
-    getDoc(effectiveSlug, opts)
+    // docs-backend `/docs/{docId}` is keyed by docId — MUST NOT be effectiveSlug/slug. Standalone
+    // /d/:docId passes docId=meta.docId + slug=meta.octoDocSlug as two distinct identifiers, so a
+    // slug lookup 404s and silently zeroes ownerId/createdAt/role (creator display + forward授权
+    // break). octo-doc render/comment/asset paths keep using effectiveSlug; only this docs-backend
+    // hop is docId-keyed.
+    getDoc(docId, opts)
       .then((m) => {
         if (cancelled) return
         if (typeof m?.ownerId === 'string' && m.ownerId) setOwnerId(m.ownerId)
@@ -345,7 +350,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
     return () => {
       cancelled = true
     }
-  }, [effectiveSlug, space])
+  }, [docId, space])
 
   // Resolve creator display name (parity with EditorShell): in-shell prefers the already-loaded
   // space-member map (free), then falls back to GET /users/:uid for a verified real name. The

--- a/packages/docs/src/html/htmlAvatar.ts
+++ b/packages/docs/src/html/htmlAvatar.ts
@@ -1,0 +1,27 @@
+// Shared helper: uid → octo-server avatar URL for the read-only HTML doc surface.
+//
+// Pulled out of HtmlDocCommentPanel so both the comment rail (per-comment author avatar) and the
+// HtmlDocView header ≡ menu (creator avatar) resolve avatars via the same fallback path — the
+// same-origin `/api/v1/users/<uid>/avatar` endpoint the collaborator avatars already use.
+// Consumers stack their own preferred source (backend-supplied avatar_url etc.) in front of this;
+// this helper only handles the uid → URL branch and returns null when there is no usable uid so
+// the caller can fall back to an initial-letter chip.
+
+import { getWKApp } from '../octoweb/index.ts'
+
+/**
+ * Turn a raw uid into the `/api/v1/users/<uid>/avatar` URL. Strips the Space-scoped `s<spaceId>_`
+ * prefix (mirrors WKApp.avatarUser handling of person channel ids) so `s5_alice` still resolves
+ * to `alice`. Returns null when the uid is empty/whitespace after trimming so the caller can pick
+ * the initial-letter fallback without a truthy string that would trigger a broken <img>.
+ */
+export function avatarUrlForUid(uid?: string | null): string | null {
+  let id = uid?.trim()
+  if (!id) return null
+  const spaceId = getWKApp().shared?.currentSpaceId
+  if (spaceId && id.startsWith(`s${spaceId}_`)) {
+    id = id.substring(spaceId.length + 2)
+  }
+  if (!id) return null
+  return `/api/v1/users/${encodeURIComponent(id)}/avatar`
+}

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -604,6 +604,7 @@ export function StandaloneDocPage({
           docId={editorDocId}
           slug={meta.octoDocSlug}
           space={addressing.space}
+          creatorNicknameOnly
         />
       </div>
     )


### PR DESCRIPTION
Closes upstream octo-web #914. Multica issue: OCT-194.

## Summary

Unify HtmlDocView's header creator display and forward-to-chat authorization flow with the rich-doc / sheet / board shells so both surfaces read from docs-backend as the single source of truth — dropping the last dependency on the deprecated `__ODOC__.creator_name / creator_avatar / created_at` fields.

## Changes

- **Creator display in the ≡ menu head is docs-backend sourced.** `HtmlDocView` now calls `getDoc(effectiveSlug, { spaceId: space })` for `ownerId` + `createdAt` + `role`, `getUserName(ownerId)` for the name, and a shared `avatarUrlForUid` helper for the head avatar. In-shell keeps the space-member map as the free primary source; standalone `/d/:docId` passes `creatorNicknameOnly` so the name resolves nickname-only and a link holder never sees the creator's verified `real_name` (XIN-392 P2-1 parity).
- **Forward-to-chat aligned with EditorShell/BoardShell/SheetView.** `doForward` now calls `startDocForward({ docId, title, role, currentUid, ownerId, space })` — `canGrant` = `computeCanGrant(role, currentUid, ownerId)`, `grantAccess` wired to the per-uid `POST /docs/{docId}/forward-grant` loop. Click is a no-op while `role` is still loading so a demoted admin never sends a stale `canGrant=false` snapshot (mirrors EditorShell's `if (!role) return`).
- **Shared avatar helper.** Extract `avatarUrlForUid` into `packages/docs/src/html/htmlAvatar.ts`. `HtmlDocCommentPanel` layers `author.avatar_url` in front of it (order preserved so backend-supplied avatar URLs still win).
- **DocMoreMenu.** New optional `creatorAvatarUrl` prop renders an `<img>` with an `onError` fallback to the existing initial-letter chip; unset callers keep the prior chip-only behaviour.
- **`__ODOC__` interface fields** `creator_uid` / `creator_name` / `created_at` retained only as `@deprecated` so a payload that still carries them parses cleanly; no code reads them. `__ODOC_CAP__.isAuthor` (backend-authoritative author signal) is untouched.

## Fail-soft

`getDoc` 404 / 403 / network → `ownerId` / `createdAt` / `role` stay undefined → header falls back to slug initial, created-on row hides, `canGrant` stays greyed, no crash.

## Tests

- `HtmlDocView.test.tsx`: docs-backend-sourced header (creator name from `getUserName`, created-on from `getDoc.createdAt`); `X-Space-Id` on the standalone-surface preflight; `creatorNicknameOnly` privacy path; fail-soft on `getDoc` reject. Refresh the header forward test into three cases — reader → `canGrant=false`, owner/admin → `canGrant=true` + `grantAccess` executor wired, `role` not-loaded → click is a no-op.
- `DocMoreMenu.test.tsx`: `<img>` renders when `creatorAvatarUrl` present; `onError` falls back to the initial-letter chip; unset prop keeps the original chip-only behaviour.
- `pnpm --filter @octo/docs test` (whole package): all HTML-doc + DocMoreMenu tests green. The 4 pre-existing failures in `EditorShell.test.tsx` (export-filename, header-injection, more-menu order) reproduce on unmodified `upstream/main` and are unrelated to this PR.

## Non-goals

- No new backend endpoints. Backend octo-docs-html PR #16 is closed; this is pure frontend.
- No changes to `__ODOC_CAP__` authorship signal or member-panel gating.
