### PR TITLE
refactor: introduce channel runtime facade

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -154,6 +154,7 @@ import StorageService from "./Service/StorageService";
 import { ProhibitwordsService } from "./Service/ProhibitwordsService";
 import { TypingManager } from "./Service/TypingManager";
 import { syncClientMsgDeviceId } from "./im-runtime/clientMsgDevice";
+import { getImChannelInfo } from "./im-runtime/channelRuntime";
 import {
   ImConnectAddressManager,
   registerImConnectAddressProvider,
@@ -1032,7 +1033,7 @@ export default class WKApp extends ProviderListener {
       return "";
     }
     let avatarTag = this.getChannelAvatarTag(channel);
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
     // 群已解散（企业微信式只读态）：用默认灰色头像替代群 logo，视觉上"群已遣散"。
     // 放在 logo 判断之前，确保即便缓存里残留旧 logo 也会被覆盖（A 数据 + B 皮肤）。
     if (

--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -17,6 +17,7 @@ import BotDetailVM, {
     stripBotDetailDisplayName,
 } from "../../bridge/profileDetail/BotDetailVM";
 import BotDetailView from "../../ui/profileDetail/BotDetailView";
+import { fetchImChannelInfo } from "../../im-runtime/channelRuntime";
 import "./index.css";
 
 interface BotDetailModalProps {
@@ -42,15 +43,17 @@ export default class BotDetailModal extends Component<BotDetailModalProps> {
             getLoginUid: () => WKApp.loginInfo.uid,
             getToken: () => WKApp.loginInfo.token || "",
             getSpaceId: () => WKApp.shared.currentSpaceId,
-            fetchChannelInfo: (uid) => WKSDK.shared().channelManager.fetchChannelInfo(
+            fetchChannelInfo: (uid) => fetchImChannelInfo(
+                WKSDK.shared(),
                 new Channel(uid, ChannelTypePerson)
             ),
-            refreshChannelInfo: (uid) => WKSDK.shared().channelManager.fetchChannelInfo(
+            refreshChannelInfo: (uid) => fetchImChannelInfo(
+                WKSDK.shared(),
                 new Channel(uid, ChannelTypePerson)
             ),
             onAvatarChanged: (uid) => {
                 WKApp.shared.changeChannelAvatarTag(new Channel(uid, ChannelTypePerson));
-                WKSDK.shared().channelManager.fetchChannelInfo(new Channel(uid, ChannelTypePerson));
+                void fetchImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson));
                 this.forceUpdate();
             },
         });

--- a/packages/dmworkbase/src/Components/ChannelAvatar/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelAvatar/index.tsx
@@ -9,6 +9,7 @@ import { WKAvatarEditor } from "../WKAvatarEditor";
 import { I18nContext } from "../../i18n";
 import { canvasToPngFile, isAvatarFileTooLarge } from "../avatarUpload";
 import WKModal from "../WKModal";
+import { fetchImChannelInfo } from "../../im-runtime/channelRuntime";
 import "./index.css"
 
 export interface ChannelAvatarProps {
@@ -90,7 +91,7 @@ export class ChannelAvatar extends Component<ChannelAvatarProps, ChannelAvatarSt
                 await this.uploadAvatar(file)
                 WKApp.shared.changeChannelAvatarTag(channel)
                 // 触发 channelInfoListener，通知 Chat 等组件刷新头像
-                WKSDK.shared().channelManager.fetchChannelInfo(channel)
+                void fetchImChannelInfo(WKSDK.shared(), channel)
             }
             this.setState({ cropFile: null })
         } catch {

--- a/packages/dmworkbase/src/Components/ChannelQRCode/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelQRCode/index.tsx
@@ -8,6 +8,7 @@ import { ChannelQRCodeVM } from "./vm";
 import { Button, Spin, Toast } from "@douyinfe/semi-ui";
 import { copyToClipboard } from "../../Utils/clipboard";
 import { I18nContext } from "../../i18n";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 export interface ChannelQRCodeProps {
     channel: Channel
@@ -29,7 +30,7 @@ export default class ChannelQRCode extends Component<ChannelQRCodeProps> {
     render() {
         const { channel } = this.props
         const { t } = this.context
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
+        const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
         return <Provider create={() => {
             return new ChannelQRCodeVM(channel)
         }} render={(vm: ChannelQRCodeVM) => {

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
@@ -12,6 +12,7 @@ import RoutePage from "../RoutePage";
 import ConversationContext from "../Conversation/context";
 import { ChannelTypeCustomerService } from "../../Service/Const";
 import { I18nContext } from "../../i18n";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 export interface ChannelSettingProps {
     onClose?: () => void
@@ -49,7 +50,7 @@ export default class ChannelSetting extends Component<ChannelSettingProps> {
 
            let  memberCount = vm.subscribers.length
 
-            const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
+            const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
             if(channelInfo?.orgData?.member_count) {
                 memberCount = channelInfo.orgData.member_count
             }

--- a/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
@@ -9,6 +9,13 @@ import { Row, Section } from "../../Service/Section";
 import { ListItemSwitch, ListItemSwitchContext } from "../ListItem";
 import { Toast } from "@douyinfe/semi-ui";
 import {
+    addImChannelInfoListener,
+    addImSubscriberChangeListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+    getImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
+import {
     OboGrant,
     OboScope,
     hasAnyActiveGrant,
@@ -25,6 +32,8 @@ export class ChannelSettingVM extends ProviderListener {
     subscribersTop: Subscriber[] = [] // 显示的成员
     subscriberChangeListener?: SubscriberChangeListener
     channelInfoListener!:ChannelInfoListener
+    unsubscribeSubscriberChangeListener?: () => void
+    unsubscribeChannelInfoListener?: () => void
     subscriberOfMe?: Subscriber
     routeData:ChannelSettingRouteData = new ChannelSettingRouteData()
 
@@ -297,7 +306,8 @@ export class ChannelSettingVM extends ProviderListener {
     }
 
     didMount(): void {
-        WKSDK.shared().channelManager.fetchChannelInfo(this.channel)
+        const sdk = WKSDK.shared()
+        void fetchImChannelInfo(sdk, this.channel)
 
         this.reloadSubscribers()
 
@@ -305,9 +315,9 @@ export class ChannelSettingVM extends ProviderListener {
             this.subscriberChangeListener = () => {
                 this.reloadSubscribers()
             }
-            WKSDK.shared().channelManager.addSubscriberChangeListener(this.subscriberChangeListener)
+            this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(sdk, this.subscriberChangeListener)
 
-            // WKSDK.shared().channelManager.syncSubscribes(this.channel)
+            // Subscriber sync is still delegated to the existing channel lifecycle.
 
         }
         this.channelInfoListener = (channelInfo:ChannelInfo) => {
@@ -316,7 +326,7 @@ export class ChannelSettingVM extends ProviderListener {
                 return
             }
         }
-        WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(sdk, this.channelInfoListener)
 
         this.reloadChannelInfo()
 
@@ -341,16 +351,16 @@ export class ChannelSettingVM extends ProviderListener {
         // 标记销毁，让所有进行中的异步分支（refreshActiveGrantCache /
         // refreshOboScope）resolve 后 early-return，不再去 notifyListener。
         this._disposed = true
-        if(this.subscriberChangeListener) {
-            WKSDK.shared().channelManager.removeSubscriberChangeListener(this.subscriberChangeListener)
-        }
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeSubscriberChangeListener?.()
+        this.unsubscribeSubscriberChangeListener = undefined
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
     }
 
 
     reloadSubscribers() {
         if(this.channel.channelType !== ChannelTypePerson) {
-            this.subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel)
+            this.subscribers = getImChannelSubscribers(WKSDK.shared(), this.channel)
             if(this.subscribers && this.subscribers.length>0) {
                 for (const subscriber of this.subscribers) {
                     subscriber.channel = this.channel
@@ -369,7 +379,7 @@ export class ChannelSettingVM extends ProviderListener {
     }
 
     reloadChannelInfo() {
-        this.channelInfo = WKSDK.shared().channelManager.getChannelInfo(this.channel)
+        this.channelInfo = getImChannelInfo(WKSDK.shared(), this.channel)
         this.routeData.channelInfo = this.channelInfo
 
         if(this.channelInfo && this.channel.channelType === ChannelTypePerson) {

--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -10,6 +10,11 @@ import { useI18n } from "../../i18n";
 import { extractErrorMsg } from "../../Service/APIClient";
 import { subscriberDisplayName } from "../../Utils/displayName";
 import {
+    getImChannelInfo,
+    getImChannelSubscribers,
+    syncImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
+import {
     buildWebhookUpsertReq,
     IncomingWebhook,
     IncomingWebhookCreateResp,
@@ -69,7 +74,8 @@ type GroupSubscriber = {
 function isBotMember(uid: string, sub: GroupSubscriber): boolean {
     if (isFlagOn(sub.orgData?.robot)) return true;
     try {
-        const info = WKSDK.shared().channelManager.getChannelInfo(
+        const info = getImChannelInfo(
+            WKSDK.shared(),
             new Channel(uid, ChannelTypePerson)
         ) as { orgData?: { robot?: unknown } } | null | undefined;
         return isFlagOn(info?.orgData?.robot);
@@ -85,12 +91,9 @@ function isBotMember(uid: string, sub: GroupSubscriber): boolean {
  * 兜底；同步读缓存，调用方在 syncSubscribes 完成后再读一次以刷新。
  */
 function readGroupMemberOptions(channel: Channel): MentionMemberOption[] {
-    let subs: GroupSubscriber[] | null | undefined;
+    let subs: GroupSubscriber[];
     try {
-        subs = WKSDK.shared().channelManager.getSubscribes(channel) as
-            | GroupSubscriber[]
-            | null
-            | undefined;
+        subs = getImChannelSubscribers(WKSDK.shared(), channel) as GroupSubscriber[];
     } catch {
         return [];
     }
@@ -163,7 +166,7 @@ export default function WebhookEditModal({
     // 成员可能未同步：拉一次后刷新候选，挂载即触发，channel 变更重拉。
     useEffect(() => {
         let alive = true;
-        Promise.resolve(WKSDK.shared().channelManager.syncSubscribes(channel))
+        syncImChannelSubscribers(WKSDK.shared(), channel)
             .then(() => {
                 if (alive) setMemberOptions(readGroupMemberOptions(channel));
             })

--- a/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
@@ -3,6 +3,7 @@ import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import { parseThreadChannelId } from "../../Service/Thread"
 import { chatTypeToChannelType } from "./chatTypeToChannelType"
 import type { ForwardItem } from "./ForwardModal"
+import { getImChannelInfo } from "../../im-runtime/channelRuntime"
 
 /** searchChatCandidates 后端返回的单条候选（只取本模块用到的字段）。 */
 export interface SearchChatCandidate {
@@ -28,7 +29,7 @@ export interface SearchChatCandidate {
 export function candidateToForwardItem(
   candidate: SearchChatCandidate,
   getCachedChannelInfo: (channel: Channel) => ChannelInfo | undefined = (ch) =>
-    WKSDK.shared().channelManager.getChannelInfo(ch),
+    getImChannelInfo(WKSDK.shared(), ch),
 ): ForwardItem {
   const chType = chatTypeToChannelType(candidate.chat_type)
   const ch = new Channel(candidate.chat_id, chType)

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -17,6 +17,7 @@ import {
   type ChatKind,
 } from "../ChatSelector/tabFilter"
 import type { ForwardFinished, ForwardGrantRole } from "./grant"
+import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime"
 
 // 复合 key：${channelType}::${channelID}，防跨类型 id 碰撞。channelType 取值
 // (个人=1 / 群=2 / 子区=5) 恰与 SidebarTargetType(DM/CHANNEL/THREAD) 一致，
@@ -61,7 +62,7 @@ function conversationWrapToForwardItem(wrap: ConversationWrap, parentChannelID?:
   // hasThreads: 判断该群聊下是否有子区（子区会出现在 conversations 里，其 orgData.parentGroupNo 指向父群）
   const hasThreads = !isThread && WKSDK.shared().conversationManager.conversations?.some(
     (c) => c.channel.channelType === ChannelTypeCommunityTopic
-      && (WKSDK.shared().channelManager.getChannelInfo(c.channel)?.orgData?.parentGroupNo === wrap.channel.channelID)
+      && (getImChannelInfo(WKSDK.shared(), c.channel)?.orgData?.parentGroupNo === wrap.channel.channelID)
   )
   return {
     channelID: wrap.channel.channelID,
@@ -203,9 +204,9 @@ export function useForwardModal(
     if (fetchedRef.current.has(item.channelID)) return
     const ch = channelMapRef.current.get(item.channelID)
       ?? new Channel(item.channelID, item.channelType)
-    if (WKSDK.shared().channelManager.getChannelInfo(ch)) return
+    if (getImChannelInfo(WKSDK.shared(), ch)) return
     fetchedRef.current.add(item.channelID)
-    WKSDK.shared().channelManager.fetchChannelInfo(ch)
+    void fetchImChannelInfo(WKSDK.shared(), ch)
   }, [])
 
   const rebuildConvItems = useCallback(() => {
@@ -383,7 +384,7 @@ export function useForwardModal(
     const channelListener: ChannelInfoListener = (_channelInfo: ChannelInfo) => {
       rebuildDebounced()
     }
-    WKSDK.shared().channelManager.addListener(channelListener)
+    const unsubscribeChannelListener = addImChannelInfoListener(WKSDK.shared(), channelListener)
 
     // 切 Space 后 conversationManager.conversations 会被先清空再回填,
     // 如果 modal 在回填前打开,初次 load() 会读到空 cache（缺最近会话/子区）。
@@ -396,7 +397,7 @@ export function useForwardModal(
     load()
 
     return () => {
-      WKSDK.shared().channelManager.removeListener(channelListener)
+      unsubscribeChannelListener()
       WKApp.mittBus.off('conversation-list-refreshed', onConversationListRefreshed)
       rebuildDebounced.cancel()
     }

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-all.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-all.tsx
@@ -10,6 +10,7 @@ import { debounce, throttle } from "../../Utils/rateLimit";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import VisibilityTrigger from "../VisibilityTrigger";
 import { I18nContext } from "../../i18n";
+import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 
 interface TabAllProps {
@@ -36,6 +37,7 @@ export default class TabAll extends Component<TabAllProps> {
     // 懒加载：仅视口内的消息才拉发送者 channelInfo。debounce 合批 forceUpdate，
     // fetchedUids 防止同 uid 重复请求。
     private _channelInfoListener!: ChannelInfoListener
+    private unsubscribeChannelInfoListener?: () => void
     private _forceUpdateDebounced = debounce(() => this.forceUpdate(), 150)
     private fetchedUids = new Set<string>()
 
@@ -45,22 +47,21 @@ export default class TabAll extends Component<TabAllProps> {
                 this._forceUpdateDebounced()
             }
         }
-        WKSDK.shared().channelManager.addListener(this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
     }
 
     componentWillUnmount() {
-        if (this._channelInfoListener) {
-            WKSDK.shared().channelManager.removeListener(this._channelInfoListener)
-        }
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         this._forceUpdateDebounced.cancel()
     }
 
     private requestSenderChannelInfoIfNeeded = (fromUid: string) => {
         if (!fromUid || this.fetchedUids.has(fromUid)) return
         const senderChannel = new Channel(fromUid, ChannelTypePerson)
-        if (WKSDK.shared().channelManager.getChannelInfo(senderChannel)) return
+        if (getImChannelInfo(WKSDK.shared(), senderChannel)) return
         this.fetchedUids.add(fromUid)
-        WKSDK.shared().channelManager.fetchChannelInfo(senderChannel)
+        void fetchImChannelInfo(WKSDK.shared(), senderChannel)
     }
 
     /**
@@ -84,7 +85,7 @@ export default class TabAll extends Component<TabAllProps> {
         // 兜底：从发送者 channelInfo.orgData 取（tab-all 已经 fetch/获取过）
         if (!homeId && (isExternalLegacy === undefined || isExternalLegacy === null) && item.from_uid) {
             const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-            const ci = WKSDK.shared().channelManager.getChannelInfo(senderChannel)
+            const ci = getImChannelInfo(WKSDK.shared(), senderChannel)
             const org = ci?.orgData
             if (org) {
                 // homeId / isExternalLegacy 已经过 !homeId / undefined|null 判据，
@@ -141,7 +142,7 @@ export default class TabAll extends Component<TabAllProps> {
                                 let sender;
                                 if (item.channel?.channel_type !== ChannelTypePerson && item.from_uid && item.from_uid !== "") {
                                     const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-                                    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(senderChannel)
+                                    const channelInfo = getImChannelInfo(WKSDK.shared(), senderChannel)
                                     if (channelInfo) {
                                         sender = channelInfo.title
                                     }

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
@@ -8,6 +8,7 @@ import BotDetailModal from "../BotDetailModal";
 import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { debounce } from "../../Utils/rateLimit";
+import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 import "./tab-contacts.css"
 
 interface TabContactsProps {
@@ -32,6 +33,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
     // 懒加载重构：使用 debounce 合批 forceUpdate，避免视口内多个 uid 集中返回
     // 时触发 N 次重渲；并用 fetchedUids 记录已发起过的 uid，避免重复请求。
     private _channelInfoListener!: ChannelInfoListener
+    private unsubscribeChannelInfoListener?: () => void
     private _forceUpdateDebounced = debounce(() => this.forceUpdate(), 150)
     private fetchedUids = new Set<string>()
     // Sticky friends：files tab 切换时父层会把 friends 置为 undefined 触发
@@ -45,13 +47,12 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
                 this._forceUpdateDebounced()
             }
         }
-        WKSDK.shared().channelManager.addListener(this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
     }
 
     componentWillUnmount() {
-        if (this._channelInfoListener) {
-            WKSDK.shared().channelManager.removeListener(this._channelInfoListener)
-        }
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         this._forceUpdateDebounced.cancel()
     }
 
@@ -69,9 +70,9 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
         if (!(missingHome && missingLegacy)) return
         if (this.fetchedUids.has(friend.channel_id)) return
         const ch = new Channel(friend.channel_id, ChannelTypePerson)
-        if (WKSDK.shared().channelManager.getChannelInfo(ch)) return
+        if (getImChannelInfo(WKSDK.shared(), ch)) return
         this.fetchedUids.add(friend.channel_id)
-        WKSDK.shared().channelManager.fetchChannelInfo(ch)
+        void fetchImChannelInfo(WKSDK.shared(), ch)
     }
 
     /**
@@ -97,7 +98,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
             isExternalLegacy === undefined || isExternalLegacy === null
         if (missingHome && missingLegacy && friend?.channel_id) {
             const ch = new Channel(friend.channel_id, ChannelTypePerson)
-            const ci = WKSDK.shared().channelManager.getChannelInfo(ch)
+            const ci = getImChannelInfo(WKSDK.shared(), ch)
             const ciOrg = ci?.orgData
             if (ciOrg) {
                 homeId = ciOrg.home_space_id as string | undefined

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-file.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-file.tsx
@@ -6,6 +6,7 @@ import "./tab-file.css"
 import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
 import { debounce } from "../../Utils/rateLimit";
 import VisibilityTrigger from "../VisibilityTrigger";
+import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 interface TabFileProps {
     keyword?: string;
@@ -19,6 +20,7 @@ export default class TabFile extends Component<TabFileProps> {
     // 懒加载：仅视口内的文件才拉发送者 channelInfo。debounce 合批 forceUpdate，
     // fetchedUids 防止同 uid 重复请求。
     private _channelInfoListener!: ChannelInfoListener
+    private unsubscribeChannelInfoListener?: () => void
     private _forceUpdateDebounced = debounce(() => this.forceUpdate(), 150)
     private fetchedUids = new Set<string>()
 
@@ -28,22 +30,21 @@ export default class TabFile extends Component<TabFileProps> {
                 this._forceUpdateDebounced()
             }
         }
-        WKSDK.shared().channelManager.addListener(this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
     }
 
     componentWillUnmount() {
-        if (this._channelInfoListener) {
-            WKSDK.shared().channelManager.removeListener(this._channelInfoListener)
-        }
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         this._forceUpdateDebounced.cancel()
     }
 
     private requestSenderChannelInfoIfNeeded = (fromUid: string) => {
         if (!fromUid || this.fetchedUids.has(fromUid)) return
         const senderChannel = new Channel(fromUid, ChannelTypePerson)
-        if (WKSDK.shared().channelManager.getChannelInfo(senderChannel)) return
+        if (getImChannelInfo(WKSDK.shared(), senderChannel)) return
         this.fetchedUids.add(fromUid)
-        WKSDK.shared().channelManager.fetchChannelInfo(senderChannel)
+        void fetchImChannelInfo(WKSDK.shared(), senderChannel)
     }
 
     // Sticky files：父层 tab 切换中途会把 files 置为 undefined，保留上次非空
@@ -69,7 +70,7 @@ export default class TabFile extends Component<TabFileProps> {
                 files?.map((item: any) => {
                     let sender;
                     const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-                    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(senderChannel)
+                    const channelInfo = getImChannelInfo(WKSDK.shared(), senderChannel)
                     if (channelInfo) {
                         sender = channelInfo.title
                     }

--- a/packages/dmworkbase/src/Components/GroupCard/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupCard/index.tsx
@@ -4,6 +4,7 @@ import WKModal from "../WKModal";
 import { Channel, ChannelTypeGroup, WKSDK } from "wukongimjssdk";
 import WKAvatar from "../WKAvatar";
 import { I18nContext } from "../../i18n";
+import { fetchImChannelInfo } from "../../im-runtime/channelRuntime";
 import "./index.css";
 
 interface GroupCardProps {
@@ -47,7 +48,8 @@ export default class GroupCard extends Component<GroupCardProps, GroupCardState>
 
         this.setState({ loading: true });
         try {
-            const channelInfo = await WKSDK.shared().channelManager.fetchChannelInfo(
+            const channelInfo = await fetchImChannelInfo(
+                WKSDK.shared(),
                 new Channel(groupNo, ChannelTypeGroup)
             );
             this.setState({

--- a/packages/dmworkbase/src/Components/GroupManagement/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/index.tsx
@@ -11,6 +11,11 @@ import { syncGroupDisbandState } from "../../Utils/groupDisband";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
 import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
+import {
   readAllowNoMention as parseAllowNoMention,
   shouldApplyFetchResult,
   shouldListenerApply,
@@ -43,6 +48,7 @@ export class GroupManagement extends Component<
   // unmount 守卫：异步 fetch / listener resolve 时若组件已卸载，不再 setState。
   private unmounted = false;
   private channelInfoListener?: (channelInfo: ChannelInfo) => void;
+  private unsubscribeChannelInfoListener?: () => void;
   // 请求版本号：每次「权威读/写」自增。较早发起的 fetch resolve 后比对此值，
   // 若已被更新的 toggle/fetch 超越则丢弃其回写，杜绝 stale fetch 覆盖新状态。
   private opSeq = 0;
@@ -64,7 +70,7 @@ export class GroupManagement extends Component<
 
   // 从 SDK 频道缓存读「允许免@」开关当前值；缺省（老后端无字段）回退 true（允许），零回归。
   readAllowNoMention = (): boolean => {
-    const info = WKSDK.shared().channelManager.getChannelInfo(this.props.channel);
+    const info = getImChannelInfo(WKSDK.shared(), this.props.channel);
     return parseAllowNoMention(info?.orgData);
   };
 
@@ -88,7 +94,10 @@ export class GroupManagement extends Component<
       if (!shouldListenerApply(this.inflightFetch, this.state.allowNoMentionSaving)) return;
       this.setState({ allowNoMention: this.readAllowNoMention() });
     };
-    WKSDK.shared().channelManager.addListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this.channelInfoListener
+    );
 
     this.refreshAllowNoMention();
   }
@@ -99,8 +108,7 @@ export class GroupManagement extends Component<
   private refreshAllowNoMention = () => {
     const myOp = ++this.opSeq;
     this.inflightFetch++;
-    void WKSDK.shared()
-      .channelManager.fetchChannelInfo(this.props.channel)
+    void fetchImChannelInfo(WKSDK.shared(), this.props.channel)
       .then(() => {
         if (this.unmounted) return;
         // 已被更新的操作超越，或正处于一次 toggle 保存中 → 丢弃这次回写。
@@ -117,10 +125,9 @@ export class GroupManagement extends Component<
 
   componentWillUnmount() {
     this.unmounted = true;
-    if (this.channelInfoListener) {
-      WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
-      this.channelInfoListener = undefined;
-    }
+    this.unsubscribeChannelInfoListener?.();
+    this.unsubscribeChannelInfoListener = undefined;
+    this.channelInfoListener = undefined;
   }
 
   loadMembers = async () => {
@@ -349,7 +356,7 @@ export class GroupManagement extends Component<
     try {
       await ChannelSettingManager.shared.setAllowNoMention(next, channel);
       // 回读 server 真实值（refresh 后弹回的根因已在 server 端修复）。
-      await WKSDK.shared().channelManager.fetchChannelInfo(channel);
+      await fetchImChannelInfo(WKSDK.shared(), channel);
       if (this.unmounted) return;
       // 期间又有更新的 toggle 发起 → 那次操作接管 state（含 saving 锁），本次静默退出。
       if (myOp !== this.opSeq) return;

--- a/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupMdEditor/index.tsx
@@ -9,6 +9,13 @@ import { I18nContext } from "../../i18n";
 import { wkConfirm } from "../WKModal";
 import MarkdownContent from "../../Messages/Text/MarkdownContent";
 import VoiceInputButton, { ReplaceMode, SelectionRange } from "../VoiceInputButton";
+import {
+  fetchImChannelInfo,
+  getImChannelInfo,
+  notifyImChannelInfoListeners,
+  patchImChannelInfoOrgData,
+  setImChannelInfoCache,
+} from "../../im-runtime/channelRuntime";
 import { withMdFlags } from "./mdFlagCache";
 import "./index.css";
 
@@ -113,22 +120,22 @@ export class GroupMdEditor extends Component<
   private applyMdFlagToCache = (configured: boolean, version: number) => {
     const { channel } = this.props;
     try {
-      const channelManager = WKSDK.shared().channelManager;
-      const channelInfo = channelManager.getChannelInfo(channel);
+      const sdk = WKSDK.shared();
+      const channelInfo = getImChannelInfo(sdk, channel);
       // 缓存未命中（罕见：设置面板通常已 fetch 过）：无本地权威可原地写回，
       // 退回 SDK 拉取兜底，仍以后端为准。
       if (!channelInfo) {
-        void channelManager.fetchChannelInfo(channel);
+        void fetchImChannelInfo(sdk, channel);
         return;
       }
-      channelInfo.orgData = withMdFlags(
+      patchImChannelInfoOrgData(channelInfo, withMdFlags(
         (channelInfo.orgData as Record<string, unknown>) || {},
         this.isThreadMd(),
         configured,
         version
-      );
-      channelManager.setChannleInfoForCache(channelInfo);
-      channelManager.notifyListeners(channelInfo);
+      ));
+      setImChannelInfoCache(sdk, channelInfo);
+      notifyImChannelInfoListeners(sdk, channelInfo);
     } catch {
       // 缓存写回失败不影响本次保存/删除结果：面板下次进入会重新拉取。
     }

--- a/packages/dmworkbase/src/Components/MeInfo/vm.tsx
+++ b/packages/dmworkbase/src/Components/MeInfo/vm.tsx
@@ -9,6 +9,7 @@ import { isRealnameVerified } from "../../Utils/displayName";
 import { resolveRealnameVerifyUrl } from "./realnameVerifyUrl";
 import { t } from "../../i18n";
 import UserService from "../../Service/UserService";
+import { addImChannelInfoListener } from "../../im-runtime/channelRuntime";
 
 /**
  * 「实验性功能」入口在 MeInfo 默认隐藏 —— 通过连击「OCTO 号」行 5 次解锁
@@ -64,6 +65,7 @@ const LAB_MODE_STORAGE_KEY = "lab_mode_enabled";
 export class MeInfoVM extends ProviderListener {
 
     channelInfoListener!:ChannelInfoListener
+    unsubscribeChannelInfoListener?: () => void
     /** 本页加载时主动拉取的自身 profile（含 realname_verified / real_name） */
     selfChannelInfo?: ChannelInfo
 
@@ -91,7 +93,7 @@ export class MeInfoVM extends ProviderListener {
             this.selfChannelInfo = channelInfo
             this.notifyListener()
         }
-        WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
 
         // pull-from-idp endpoint 已废弃(dmworkim 侧),本页打开时仅做两件事:
         //   1. 同步清掉 ?verified=1 query(回跳兜底,避免二次进入重复触发)
@@ -118,7 +120,8 @@ export class MeInfoVM extends ProviderListener {
     }
 
     didUnMount(): void {
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
     }
 
     /**

--- a/packages/dmworkbase/src/Components/Subscribers/list.tsx
+++ b/packages/dmworkbase/src/Components/Subscribers/list.tsx
@@ -18,6 +18,11 @@ import { isRealnameVerified } from "../../Utils/displayName";
 import { OnlineStatusBadge } from "../ConversationList";
 import RealnameVerifiedBadge from "../RealnameVerifiedBadge";
 import { I18nContext } from "../../i18n";
+import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 
 export interface SubscriberListProps {
   channel: Channel;
@@ -43,6 +48,7 @@ export class SubscriberList extends Component<
   declare context: React.ContextType<typeof I18nContext>;
 
   private channelInfoListener!: ChannelInfoListener;
+  private unsubscribeChannelInfoListener?: () => void;
   // 当前已预取过 channelInfo 的 uid 集合，避免重复发请求
   private prefetchedUids = new Set<string>();
 
@@ -64,16 +70,21 @@ export class SubscriberList extends Component<
         this.setState({});
       }
     };
-    WKSDK.shared().channelManager.addListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this.channelInfoListener
+    );
   }
 
   componentWillUnmount() {
-    WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener?.();
+    this.unsubscribeChannelInfoListener = undefined;
     this.prefetchedUids.clear();
   }
 
   needShowOnlineStatus(uid: string): boolean {
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(uid, ChannelTypePerson)
     );
     if (!channelInfo) return false;
@@ -83,7 +94,8 @@ export class SubscriberList extends Component<
   }
 
   getOnlineTip(uid: string): string | undefined {
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(uid, ChannelTypePerson)
     );
     if (!channelInfo || channelInfo.online) return undefined;
@@ -136,7 +148,8 @@ export class SubscriberList extends Component<
   // 获取显示名称
   getShowName = (subscriber: Subscriber) => {
     // 优先显示个人备注
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(subscriber.uid, ChannelTypePerson)
     );
     if (
@@ -219,8 +232,8 @@ export class SubscriberList extends Component<
       if (this.prefetchedUids.has(item.uid)) continue;
       this.prefetchedUids.add(item.uid);
       const ch = new Channel(item.uid, ChannelTypePerson);
-      if (!WKSDK.shared().channelManager.getChannelInfo(ch)) {
-        WKSDK.shared().channelManager.fetchChannelInfo(ch);
+      if (!getImChannelInfo(WKSDK.shared(), ch)) {
+        void fetchImChannelInfo(WKSDK.shared(), ch);
       }
     }
   };

--- a/packages/dmworkbase/src/Components/WKAvatar/index.tsx
+++ b/packages/dmworkbase/src/Components/WKAvatar/index.tsx
@@ -3,14 +3,15 @@ import React from "react";
 import { Component, CSSProperties } from "react";
 import classNames from "classnames";
 import WKApp from "../../App";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 import "./index.css"
 
 /**
  * Check if a user is a bot by looking up channelInfo.
- * Centralizes the repeated WKSDK.shared().channelManager.getChannelInfo(...) pattern.
+ * Centralizes the repeated channelInfo lookup pattern.
  */
 export function isBot(uid: string): boolean {
-    const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson))
+    const info = getImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson))
     return info?.orgData?.robot === 1
 }
 
@@ -180,7 +181,7 @@ export default class WKAvatar extends Component<WKAvatarProps, WKAvatarState> {
         if (!channel) return ""
         if (channel.channelType === ChannelTypeGroup) return "wk-avatar-group"
         if (channel.channelType === ChannelTypePerson) {
-            const info = WKSDK.shared().channelManager.getChannelInfo(channel)
+            const info = getImChannelInfo(WKSDK.shared(), channel)
             if (info?.orgData?.robot === 1) return "wk-avatar-ai"
         }
         return ""

--- a/packages/dmworkbase/src/Components/WKBase/index.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "./userInfoRouter";
 import { I18nContext } from "../../i18n";
 import { isIncomingWebhookSender } from "../../Service/IncomingWebhook";
+import { getImChannelSubscribers, syncImChannelSubscribers } from "../../im-runtime/channelRuntime";
 import "./index.css";
 
 /**
@@ -50,11 +51,8 @@ export function createDefaultExternalViewerGate(): ExternalViewerGate {
     isExternal: (uid, fromChannel, channelInfo) => {
       // 1) Group subscriber orgData (primary source, matches UserInfoVM step 1).
       if (fromChannel && fromChannel.channelType !== ChannelTypePerson) {
-        const subscribers =
-          (WKSDK.shared().channelManager.getSubscribes(fromChannel) as
-            | { uid?: string; orgData?: ChannelInfoOrgDataLike }[]
-            | null
-            | undefined) ?? [];
+        const subscribers = getImChannelSubscribers(WKSDK.shared(), fromChannel) as
+          { uid?: string; orgData?: ChannelInfoOrgDataLike }[];
         const sub = subscribers.find((s) => s && s.uid === uid);
         const org = sub?.orgData;
         if (org) {
@@ -280,15 +278,11 @@ export default class WKBase
         continue;
       }
       try {
-        await Promise.resolve(WKSDK.shared().channelManager.syncSubscribes(ch));
+        await syncImChannelSubscribers(WKSDK.shared(), ch);
       } catch {
         // best-effort: fall back to whatever is already cached
       }
-      const subs =
-        (WKSDK.shared().channelManager.getSubscribes(ch) as
-          | { uid?: string }[]
-          | null
-          | undefined) ?? [];
+      const subs = getImChannelSubscribers(WKSDK.shared(), ch) as { uid?: string }[];
       for (const s of subs) {
         if (s?.uid) uids.add(s.uid);
       }

--- a/packages/dmworkbase/src/Components/WKBase/userInfoRouter.ts
+++ b/packages/dmworkbase/src/Components/WKBase/userInfoRouter.ts
@@ -1,4 +1,5 @@
 import WKSDK, { Channel, ChannelTypePerson } from "wukongimjssdk";
+import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 /**
  * Production routing helper for "view user profile" entry (GH#1112, PR#1113).
@@ -202,9 +203,9 @@ export function createUserInfoRouter(
 ): UserInfoRouter {
     const channelManager: ChannelManagerLike = {
         getChannelInfo: (channel) =>
-            WKSDK.shared().channelManager.getChannelInfo(channel) as ChannelInfoLike | undefined,
+            getImChannelInfo(WKSDK.shared(), channel) as ChannelInfoLike | undefined,
         fetchChannelInfo: (channel) =>
-            WKSDK.shared().channelManager.fetchChannelInfo(channel) as Promise<ChannelInfoLike | undefined>,
+            fetchImChannelInfo(WKSDK.shared(), channel) as Promise<ChannelInfoLike | undefined>,
     };
     return new UserInfoRouter(channelManager, dispatch, externalGate);
 }

--- a/packages/dmworkbase/src/Service/Convert.ts
+++ b/packages/dmworkbase/src/Service/Convert.ts
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { Setting } from "wukongimjssdk";
 import { WKSDK, ChannelInfo, Channel, Conversation, Message, MessageStatus, ChannelTypePerson, ChannelTypeGroup,ConversationExtra,Reminder, MessageExtra, Reply } from "wukongimjssdk";
 import { displayName as resolveDisplayName } from "../Utils/displayName";
+import { getImChannelInfo, getImChannelSubscribers } from "../im-runtime/channelRuntime";
 
 
 /**
@@ -133,7 +134,7 @@ export function applyMsgLevelExternalFieldsWithFallback(target: any, msgMap: any
     const groupChannel = resolveGroupChannel(target, msgMap)
     if (groupChannel) {
         try {
-            const subs: any = WKSDK.shared().channelManager.getSubscribes(groupChannel)
+            const subs: any = getImChannelSubscribers(WKSDK.shared(), groupChannel)
             if (subs && typeof subs.length === "number" && subs.length > 0) {
                 const member = subs.find((s: any) => s && s.uid === fromUID)
                 fillHomeSpaceFromOrg(target, member?.orgData, need)
@@ -148,7 +149,7 @@ export function applyMsgLevelExternalFieldsWithFallback(target: any, msgMap: any
     // 3) Person 频道兜底（R4 原逻辑，保留为最后防线）：仅当 fromUID 对应的
     //    1v1 Channel 已缓存过才会有值（用户真的跟对方私聊过）。
     try {
-        const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(fromUID, ChannelTypePerson))
+        const info = getImChannelInfo(WKSDK.shared(), new Channel(fromUID, ChannelTypePerson))
         fillHomeSpaceFromOrg(target, info?.orgData, need)
     } catch (_e) {
         // channelManager 未初始化或查询失败：静默兜底失败，上层保留既有字段

--- a/packages/dmworkbase/src/Service/ForwardService.ts
+++ b/packages/dmworkbase/src/Service/ForwardService.ts
@@ -45,6 +45,7 @@ import { isConversationDisbanded } from "../Utils/groupDisband";
 import { wrapSendContentForInjection } from "../Utils/sendContentProxy";
 import { applyMsgLevelExternalFieldsWithFallback } from "./Convert";
 import { ChannelTypePerson } from "wukongimjssdk";
+import { getImChannelInfo } from "../im-runtime/channelRuntime";
 
 export type ForwardFailureReason = "disbanded" | "send-error";
 
@@ -135,7 +136,7 @@ function readMention(content: MessageContent): { humans: boolean; ais: boolean }
 
 function buildSetting(channel: Channel): Setting {
     const setting = new Setting();
-    const info = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const info = getImChannelInfo(WKSDK.shared(), channel);
     if (info?.orgData?.receipt === 1) {
         setting.receiptEnabled = true;
     }

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -15,6 +15,7 @@ import {
     mentionUidStateFromRobot,
     type MentionUidState,
 } from "../Utils/mentionRender"
+import { getImChannelInfo, getImChannelSubscribers } from "../im-runtime/channelRuntime"
 
 export class ConversationWrap {
     conversation: Conversation
@@ -280,7 +281,7 @@ export class MessageWrap {
 
 
     public get from(): ChannelInfo | undefined {
-        return WKSDK.shared().channelManager.getChannelInfo(new Channel(this.fromUID, ChannelTypePerson))
+        return getImChannelInfo(WKSDK.shared(), new Channel(this.fromUID, ChannelTypePerson))
     }
 
     public get channel() {
@@ -614,7 +615,7 @@ export class MessageWrap {
         const state = new Map<string, MentionUidState>()
         const uidSet = new Set(uids)
         try {
-            const subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel) || []
+            const subscribers = getImChannelSubscribers(WKSDK.shared(), this.channel)
             for (const sub of subscribers as any[]) {
                 if (sub?.uid && uidSet.has(sub.uid)) {
                     const uidState = mentionUidStateFromRobot(sub.orgData?.robot)
@@ -631,7 +632,7 @@ export class MessageWrap {
 
     private getChannelInfoMentionUidState(uid: string): MentionUidState {
         try {
-            const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson))
+            const info = getImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson))
             if (!info) return "unknown"
             return mentionUidStateFromRobot(info.orgData?.robot)
         } catch {

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -3,6 +3,7 @@ import { ChannelTypePerson, ChannelTypeGroup, Channel, Conversation, Message, WK
 import { hasSpacePrefix } from "./SpacePrefix"
 import { ChannelTypeCommunityTopic } from "./Const"
 import { parseThreadChannelId } from "./Thread"
+import { getImChannelInfo, getImChannelSubscribers } from "../im-runtime/channelRuntime"
 
 export type JoinSpaceStatus = "NEED_APPROVAL" | "PENDING"
 
@@ -90,7 +91,7 @@ function getMyMembershipSourceSpaceId(channel: Channel): string | undefined {
 
     const myUid = WKApp.loginInfo?.uid
     if (!myUid) return undefined
-    const subs = WKSDK.shared().channelManager.getSubscribes(channel)
+    const subs = getImChannelSubscribers(WKSDK.shared(), channel)
     if (!subs || subs.length === 0) return undefined
     const mine = subs.find((s: any) => s?.uid === myUid) as any
     if (!mine) return undefined
@@ -152,7 +153,7 @@ export function shouldSkipChannelForSpace(channel: Channel): boolean {
             return true
         }
         // 缓存未命中 → 尝试从已缓存的 channelInfo 获取 space_id
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
+        const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
         const infoSpaceId = channelInfo?.orgData?.space_id
         if (infoSpaceId) {
             // 回填 channelSpaceMap 避免下次再查
@@ -186,7 +187,7 @@ export function shouldSkipChannelForSpace(channel: Channel): boolean {
         }
         // 父群 channelInfo 兜底
         const parentChannel = new Channel(parsed.groupNo, ChannelTypeGroup)
-        const parentInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+        const parentInfo = getImChannelInfo(WKSDK.shared(), parentChannel)
         const parentInfoSpaceId = parentInfo?.orgData?.space_id
         if (parentInfoSpaceId) {
             WKApp.shared.channelSpaceMap.set(parentKey, parentInfoSpaceId)

--- a/packages/dmworkbase/src/Service/threadArchiveSync.ts
+++ b/packages/dmworkbase/src/Service/threadArchiveSync.ts
@@ -1,5 +1,11 @@
 import { Channel, WKSDK } from "wukongimjssdk";
 import WKApp from "../App";
+import {
+  getImChannelInfo,
+  notifyImChannelInfoListeners,
+  patchImChannelInfoOrgData,
+  setImChannelInfoCache,
+} from "../im-runtime/channelRuntime";
 import { ChannelTypeCommunityTopic } from "./Const";
 import { ThreadStatus } from "./Thread";
 
@@ -42,16 +48,17 @@ export function syncThreadArchiveState(
       : threadChannel;
   if (!channel.channelID) return;
 
-  const channelManager = WKSDK.shared().channelManager;
+  const sdk = WKSDK.shared();
   // 权威写回：在既有 channelInfo 上原地更新 thread.status，避免被归档前发起、
   // 在途的旧 fetchChannelInfo（携 Active）覆盖。没有 live channelInfo 时不伪造
   // 缓存（会丢 title/logo 等），交由下面的 sidebar-reload 兜底。
-  const channelInfo = channelManager.getChannelInfo(channel);
+  const channelInfo = getImChannelInfo(sdk, channel);
   if (channelInfo) {
-    const orgData = (channelInfo.orgData = channelInfo.orgData || {});
-    orgData.thread = { ...(orgData.thread || {}), status };
-    channelManager.setChannleInfoForCache(channelInfo);
-    channelManager.notifyListeners(channelInfo);
+    patchImChannelInfoOrgData(channelInfo, {
+      thread: { ...(channelInfo.orgData?.thread || {}), status },
+    });
+    setImChannelInfoCache(sdk, channelInfo);
+    notifyImChannelInfoListeners(sdk, channelInfo);
   }
 
   // sidebar-reload 是 sidebar-only 关注子区的唯一兜底，无论有无 live channelInfo

--- a/packages/dmworkbase/src/Service/threadPermission.ts
+++ b/packages/dmworkbase/src/Service/threadPermission.ts
@@ -2,6 +2,7 @@ import { Channel, ChannelTypeGroup, WKSDK } from "wukongimjssdk";
 import { GroupRole } from "./Const";
 import { ThreadStatus } from "./Thread";
 import WKApp from "../App";
+import { getImChannelSubscribers } from "../im-runtime/channelRuntime";
 
 /**
  * 当前登录用户在指定群是否为群主 / 管理员 —— 子区所有权限判定的共同底座（#451 review）。
@@ -11,7 +12,7 @@ import WKApp from "../App";
  */
 function isGroupOwnerOrManager(groupNo: string): boolean {
   const groupChannel = new Channel(groupNo, ChannelTypeGroup);
-  const subscribers = WKSDK.shared().channelManager.getSubscribes(groupChannel);
+  const subscribers = getImChannelSubscribers(WKSDK.shared(), groupChannel);
   const me = subscribers?.find((s) => s.uid === WKApp.loginInfo.uid);
   return me?.role === GroupRole.owner || me?.role === GroupRole.manager;
 }

--- a/packages/dmworkbase/src/Utils/NotificationUtil.ts
+++ b/packages/dmworkbase/src/Utils/NotificationUtil.ts
@@ -2,6 +2,7 @@ import { Message, Channel, ChannelTypeGroup } from "wukongimjssdk";
 import WKApp from "../App";
 import WKSDK from "wukongimjssdk";
 import { t } from "../i18n";
+import { getImChannelInfo } from "../im-runtime/channelRuntime";
 
 // Extend window interface for Electron APIs
 declare global {
@@ -188,7 +189,7 @@ export class NotificationUtil {
    * Send a message notification
    */
   public async sendMessageNotification(message: Message, description?: string): Promise<void> {
-    let channelInfo = WKSDK.shared().channelManager.getChannelInfo(message.channel);
+    let channelInfo = getImChannelInfo(WKSDK.shared(), message.channel);
 
     // Check if channel is muted
     if (channelInfo && channelInfo.mute) {
@@ -199,7 +200,7 @@ export class NotificationUtil {
     const parentGroupNo = channelInfo?.orgData?.parentGroupNo as string | undefined
     if (parentGroupNo) {
       const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
-      const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+      const parentChannelInfo = getImChannelInfo(WKSDK.shared(), parentChannel)
       if (parentChannelInfo?.mute) {
         return
       }

--- a/packages/dmworkbase/src/Utils/groupDisband.ts
+++ b/packages/dmworkbase/src/Utils/groupDisband.ts
@@ -5,6 +5,13 @@ import WKSDK, {
 } from "wukongimjssdk";
 import { ChannelTypeCommunityTopic } from "../Service/Const";
 import { parseThreadChannelId } from "../Service/Thread";
+import {
+  fetchImChannelInfo,
+  getImChannelInfo,
+  notifyImChannelInfoListeners,
+  patchImChannelInfoOrgData,
+  setImChannelInfoCache,
+} from "../im-runtime/channelRuntime";
 
 /**
  * 群聊状态枚举，与后端 group.GroupStatus 对齐：
@@ -35,7 +42,7 @@ export function isChannelDisbanded(channel?: Channel | null): boolean {
   if (!channel || channel.channelType !== ChannelTypeGroup) {
     return false;
   }
-  const info = WKSDK.shared().channelManager.getChannelInfo(channel);
+  const info = getImChannelInfo(WKSDK.shared(), channel);
   return isGroupDisbanded(info);
 }
 
@@ -80,22 +87,20 @@ export function isConversationDisbanded(channel?: Channel | null): boolean {
  */
 export function syncGroupDisbandState(channel: Channel): void {
   if (!channel?.channelID) return;
-  const channelManager = WKSDK.shared().channelManager;
+  const sdk = WKSDK.shared();
   // 非群频道（个人 / 子区等）：解散态只挂在群频道上，这里无直写语义，
   // 退回常规 fetchChannelInfo，保持 channelUpdate 对这些频道的刷新行为不变。
   if (channel.channelType !== ChannelTypeGroup) {
-    channelManager.fetchChannelInfo(channel);
+    void fetchImChannelInfo(sdk, channel);
     return;
   }
-  const channelInfo = channelManager.getChannelInfo(channel);
+  const channelInfo = getImChannelInfo(sdk, channel);
   if (channelInfo) {
-    channelInfo.orgData = channelInfo.orgData || {};
-    channelInfo.orgData.status = GroupStatusDisband;
-    channelManager.setChannleInfoForCache(channelInfo);
-    channelManager.notifyListeners(channelInfo);
+    patchImChannelInfoOrgData(channelInfo, { status: GroupStatusDisband });
+    setImChannelInfoCache(sdk, channelInfo);
+    notifyImChannelInfoListeners(sdk, channelInfo);
     return;
   }
   // 群频道无 live 缓存：交给 SDK 异步拉取兜底（此分支不存在可被旧请求覆盖的本地态）。
-  channelManager.fetchChannelInfo(channel);
+  void fetchImChannelInfo(sdk, channel);
 }
-

--- a/packages/dmworkbase/src/bridge/channelSearch/createChannelSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/channelSearch/createChannelSearchDataSource.ts
@@ -5,6 +5,7 @@ import {
   WKSDK,
 } from "wukongimjssdk";
 import WKApp from "../../App";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 import { createSearchAssetResolver } from "../search/createSearchAssetResolver";
 import {
   cleanFilters,
@@ -69,7 +70,7 @@ export function createChannelSearchApiDataSource(
           avatarUrl: selfUid ? WKApp.shared.avatarUser(selfUid) : undefined,
           isCurrentMember: true,
         };
-        const peerInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+        const peerInfo = getImChannelInfo(WKSDK.shared(), channel);
         const peer: ChannelSearchSender = {
           uid: channel.channelID,
           name: peerInfo?.title || channel.channelID,

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
@@ -3,6 +3,7 @@ import { Channel, WKSDK } from "wukongimjssdk";
 import WKApp from "../../App";
 import { IncomingWebhook, IncomingWebhookService } from "../../Service/IncomingWebhook";
 import { subscriberDisplayName, SubscriberLike } from "../../Utils/displayName";
+import { getImChannelSubscribers } from "../../im-runtime/channelRuntime";
 
 export interface UseChannelWebhookListOptions {
     channel: Channel;
@@ -66,11 +67,10 @@ export function useChannelWebhookList({
         const wanted = new Set(items.map((item) => item.creator_uid));
         const names = new Map<string, string>();
         try {
-            const subscribers = WKSDK.shared().channelManager.getSubscribes(channel) as
-                | Array<({ uid?: string } & SubscriberLike)>
-                | null
-                | undefined;
-            for (const subscriber of subscribers || []) {
+            const subscribers = getImChannelSubscribers(WKSDK.shared(), channel) as Array<
+                { uid?: string } & SubscriberLike
+            >;
+            for (const subscriber of subscribers) {
                 if (!subscriber?.uid || !wanted.has(subscriber.uid) || names.has(subscriber.uid)) continue;
                 const name = subscriberDisplayName(subscriber);
                 if (name) names.set(subscriber.uid, name);

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -12,6 +12,7 @@ import { MessageContentTypeConst } from "../../Service/Const";
 import { ProviderListener } from "../../Service/Provider";
 import { debounce } from "../../Utils/rateLimit";
 import { t } from "../../i18n";
+import { addImChannelInfoListener, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 /** Legacy contacts/groups bridge retained while the aggregated tabs migrate. */
 export default class GlobalSearchVM extends ProviderListener {
@@ -27,6 +28,7 @@ export default class GlobalSearchVM extends ProviderListener {
   public loadFinish = false; // 是否加载完成
   public contentTypes = new Array<number>(); // 内容类型
   private channelInfoListener!: ChannelInfoListener;
+  private unsubscribeChannelInfoListener?: () => void;
   public channel?: Channel; // 查询指定频道的消息
   private requestId = 0; // 请求计数器，用于处理竞态条件
   public searchError: string | null = null; // 搜索失败错误信息
@@ -62,7 +64,8 @@ export default class GlobalSearchVM extends ProviderListener {
   // 搜索标题
   public get searchTitle() {
     if (this.searchInChannel) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      const channelInfo = getImChannelInfo(
+        WKSDK.shared(),
         this.channel!
       );
       if (channelInfo) {
@@ -113,11 +116,15 @@ export default class GlobalSearchVM extends ProviderListener {
       }
     };
 
-    WKSDK.shared().channelManager.addListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this.channelInfoListener
+    );
   }
 
   didUnMount(): void {
-    WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener?.();
+    this.unsubscribeChannelInfoListener = undefined;
   }
 
   // 输入框输入事件 (debounced to reduce API calls)

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -1,6 +1,7 @@
 import { Channel, ChannelTypeGroup, WKSDK } from "wukongimjssdk";
 import WKApp from "../../App";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 import type { ChannelSearchSender } from "../../Service/SearchTypes";
 import SearchService from "../../Service/SearchService";
 import { createSearchAssetResolver } from "../search/createSearchAssetResolver";
@@ -61,7 +62,7 @@ async function loadReadableChannelOptions(
     ) {
       continue;
     }
-    const info = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const info = getImChannelInfo(WKSDK.shared(), channel);
     const name =
       info?.orgData?.displayName || (info as any)?.title || channel.channelID;
     push({

--- a/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
+++ b/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
@@ -17,6 +17,12 @@ import UserService from "../../Service/UserService";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { isRealnameVerified, displayName as resolveDisplayName } from "../../Utils/displayName";
 import { parseThreadChannelId } from "../../Service/Thread";
+import {
+  addImSubscriberChangeListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
 
 export class UserInfoRouteData {
   uid!: string;
@@ -36,6 +42,7 @@ export class UserInfoVM extends ProviderListener {
   channelInfo?: ChannelInfo;
   vercode?: string;
   subscriberChangeListener?: SubscriberChangeListener;
+  unsubscribeSubscriberChangeListener?: () => void;
   editingRemark = false;
   remarkDraft = "";
   savingRemark = false;
@@ -64,11 +71,12 @@ export class UserInfoVM extends ProviderListener {
       this.subscriberChangeListener = () => {
         this.reloadSubscribers();
       };
-      WKSDK.shared().channelManager.addSubscriberChangeListener(
+      this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(
+        WKSDK.shared(),
         this.subscriberChangeListener
       );
 
-      // WKSDK.shared().channelManager.syncSubscribes(this.channel)
+      // Subscriber sync is still delegated to the existing channel lifecycle.
     }
 
     this.reloadFromChannelInfo();
@@ -78,11 +86,8 @@ export class UserInfoVM extends ProviderListener {
 
   didUnMount(): void {
     this.mounted = false;
-    if (this.subscriberChangeListener) {
-      WKSDK.shared().channelManager.removeSubscriberChangeListener(
-        this.subscriberChangeListener
-      );
-    }
+    this.unsubscribeSubscriberChangeListener?.();
+    this.unsubscribeSubscriberChangeListener = undefined;
   }
 
   getRemark() {
@@ -125,9 +130,7 @@ export class UserInfoVM extends ProviderListener {
       this.editingRemark = false;
       this.remarkDraft = "";
       this.notifyListener();
-      Promise.resolve(
-        WKSDK.shared().channelManager.fetchChannelInfo(new Channel(requestedUid, ChannelTypePerson))
-      ).catch((error: unknown) => {
+      fetchImChannelInfo(WKSDK.shared(), new Channel(requestedUid, ChannelTypePerson)).catch((error: unknown) => {
         console.warn("[UserInfo] refresh channel after remark failed:", error);
       });
       Promise.resolve(this.reloadChannelInfo()).catch((error: unknown) => {
@@ -186,7 +189,7 @@ export class UserInfoVM extends ProviderListener {
     };
 
     if (sourceChannel) {
-      applySubscribers(WKSDK.shared().channelManager.getSubscribes(sourceChannel), {
+      applySubscribers(getImChannelSubscribers(WKSDK.shared(), sourceChannel), {
         replaceUser: true,
         replaceMe: true,
       });
@@ -197,7 +200,7 @@ export class UserInfoVM extends ProviderListener {
         memberChannel.channelID !== sourceChannel.channelID ||
         memberChannel.channelType !== sourceChannel.channelType)
     ) {
-      applySubscribers(WKSDK.shared().channelManager.getSubscribes(memberChannel), {
+      applySubscribers(getImChannelSubscribers(WKSDK.shared(), memberChannel), {
         replaceMe: true,
       });
     }
@@ -374,7 +377,8 @@ export class UserInfoVM extends ProviderListener {
   }
   reloadFromChannelInfo() {
     if (this.fromChannel) {
-      this.fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      this.fromChannelInfo = getImChannelInfo(
+        WKSDK.shared(),
         this.fromChannel
       );
       this.notifyListener();

--- a/packages/dmworkbase/src/im-runtime/channelRuntime.test.ts
+++ b/packages/dmworkbase/src/im-runtime/channelRuntime.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  addImChannelInfoListener,
+  addImSubscriberChangeListener,
+  deleteImChannelInfo,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+  getImSubscribeCacheMap,
+  notifyImChannelInfoListeners,
+  patchImChannelInfoOrgData,
+  setImChannelInfoCache,
+  syncImChannelSubscribers,
+  type ImChannelInfoLike,
+  type ImChannelCacheRuntimeSdk,
+  type ImChannelRuntimeSdk,
+  type ImChannelSubscribersRuntimeSdk,
+  type ImSubscribeCacheRuntimeSdk,
+} from "./channelRuntime";
+
+function createSdk() {
+  return {
+    channelManager: {
+      getChannelInfo: vi.fn(),
+      fetchChannelInfo: vi.fn(),
+      setChannleInfoForCache: vi.fn(),
+      notifyListeners: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      deleteChannelInfo: vi.fn(),
+      getSubscribes: vi.fn(),
+      syncSubscribes: vi.fn(),
+      subscribeCacheMap: new Map(),
+      addSubscriberChangeListener: vi.fn(),
+      removeSubscriberChangeListener: vi.fn(),
+    },
+  } satisfies ImChannelRuntimeSdk &
+    ImChannelCacheRuntimeSdk &
+    ImChannelSubscribersRuntimeSdk &
+    ImSubscribeCacheRuntimeSdk;
+}
+
+describe("channelRuntime", () => {
+  it("reads channel info through the SDK channel manager", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    const channelInfo = { channel, title: "Group" };
+    sdk.channelManager.getChannelInfo.mockReturnValue(channelInfo);
+
+    expect(getImChannelInfo(sdk, channel)).toBe(channelInfo);
+    expect(sdk.channelManager.getChannelInfo).toHaveBeenCalledWith(channel);
+  });
+
+  it("fetches channel info through the SDK channel manager", async () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    const channelInfo = { channel, title: "Group" };
+    sdk.channelManager.fetchChannelInfo.mockResolvedValue(channelInfo);
+
+    await expect(fetchImChannelInfo(sdk, channel)).resolves.toBe(channelInfo);
+    expect(sdk.channelManager.fetchChannelInfo).toHaveBeenCalledWith(channel);
+  });
+
+  it("returns cached channel info when SDK fetch resolves without a value", async () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    const channelInfo = { channel, title: "Group" };
+    sdk.channelManager.fetchChannelInfo.mockResolvedValue(undefined);
+    sdk.channelManager.getChannelInfo.mockReturnValue(channelInfo);
+
+    await expect(fetchImChannelInfo(sdk, channel)).resolves.toBe(channelInfo);
+    expect(sdk.channelManager.getChannelInfo).toHaveBeenCalledWith(channel);
+  });
+
+  it("writes channel info to the SDK channel cache", () => {
+    const sdk = createSdk();
+    const channelInfo = {
+      channel: { channelID: "g1", channelType: 2 },
+      title: "Group",
+    };
+
+    setImChannelInfoCache(sdk, channelInfo);
+
+    expect(sdk.channelManager.setChannleInfoForCache).toHaveBeenCalledWith(
+      channelInfo
+    );
+  });
+
+  it("notifies SDK channel listeners", () => {
+    const sdk = createSdk();
+    const channelInfo = {
+      channel: { channelID: "g1", channelType: 2 },
+      title: "Group",
+    };
+
+    notifyImChannelInfoListeners(sdk, channelInfo);
+
+    expect(sdk.channelManager.notifyListeners).toHaveBeenCalledWith(channelInfo);
+  });
+
+  it("returns an unsubscribe when adding a channel info listener", () => {
+    const sdk = createSdk();
+    const listener = vi.fn();
+
+    const unsubscribe = addImChannelInfoListener(sdk, listener);
+    unsubscribe();
+
+    expect(sdk.channelManager.addListener).toHaveBeenCalledWith(listener);
+    expect(sdk.channelManager.removeListener).toHaveBeenCalledWith(listener);
+  });
+
+  it("deletes channel info through the SDK channel manager", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+
+    deleteImChannelInfo(sdk, channel);
+
+    expect(sdk.channelManager.deleteChannelInfo).toHaveBeenCalledWith(channel);
+  });
+
+  it("reads subscribers through the SDK channel manager", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    const subscribers = [{ uid: "u1" }, { uid: "u2" }];
+    sdk.channelManager.getSubscribes.mockReturnValue(subscribers);
+
+    expect(getImChannelSubscribers(sdk, channel)).toBe(subscribers);
+    expect(sdk.channelManager.getSubscribes).toHaveBeenCalledWith(channel);
+  });
+
+  it("normalizes missing subscribers to an empty list", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    sdk.channelManager.getSubscribes.mockReturnValue(undefined);
+
+    expect(getImChannelSubscribers(sdk, channel)).toEqual([]);
+  });
+
+  it("syncs subscribers through the SDK channel manager", async () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    sdk.channelManager.syncSubscribes.mockResolvedValue(undefined);
+
+    await syncImChannelSubscribers(sdk, channel);
+
+    expect(sdk.channelManager.syncSubscribes).toHaveBeenCalledWith(channel);
+  });
+
+  it("returns the SDK subscribe cache map", () => {
+    const sdk = createSdk();
+
+    expect(getImSubscribeCacheMap(sdk)).toBe(
+      sdk.channelManager.subscribeCacheMap
+    );
+  });
+
+  it("returns an unsubscribe when adding a subscriber change listener", () => {
+    const sdk = createSdk();
+    const listener = vi.fn();
+
+    const unsubscribe = addImSubscriberChangeListener(sdk, listener);
+    unsubscribe();
+
+    expect(sdk.channelManager.addSubscriberChangeListener).toHaveBeenCalledWith(
+      listener
+    );
+    expect(
+      sdk.channelManager.removeSubscriberChangeListener
+    ).toHaveBeenCalledWith(listener);
+  });
+
+  it("patches orgData while preserving existing fields", () => {
+    const channelInfo: ImChannelInfoLike = {
+      channel: { channelID: "g1____t1", channelType: 5 },
+      title: "Thread",
+      orgData: {
+        displayName: "Thread",
+        thread: { status: 0, seq: 1 },
+      },
+    };
+
+    const result = patchImChannelInfoOrgData(channelInfo, {
+      thread: { status: 1 },
+    });
+
+    expect(result).toBe(channelInfo);
+    expect(channelInfo.orgData).toEqual({
+      displayName: "Thread",
+      thread: { status: 1 },
+    });
+  });
+
+  it("creates orgData when patching a channel info without orgData", () => {
+    const channelInfo: ImChannelInfoLike = {
+      channel: { channelID: "g1____t1", channelType: 5 },
+    };
+
+    patchImChannelInfoOrgData(channelInfo, {
+      thread: { status: 1 },
+    });
+
+    expect(channelInfo.orgData).toEqual({
+      thread: { status: 1 },
+    });
+  });
+});

--- a/packages/dmworkbase/src/im-runtime/channelRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/channelRuntime.ts
@@ -1,0 +1,185 @@
+export interface ImChannelLike {
+  channelID: string;
+  channelType: number;
+}
+
+export interface ImChannelInfoLike {
+  channel: ImChannelLike;
+  title?: string;
+  logo?: string;
+  orgData?: Record<string, any>;
+  [key: string]: any;
+}
+
+export type ImChannelInfoListener<TChannelInfo = ImChannelInfoLike> = (
+  channelInfo: TChannelInfo
+) => void;
+
+export type ImChannelInfoFetchResult<TChannelInfo> =
+  | TChannelInfo
+  | undefined
+  | void;
+
+export interface ImChannelManagerRuntime<
+  TChannel extends ImChannelLike = ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike = ImChannelInfoLike
+> {
+  getChannelInfo: (channel: TChannel) => TChannelInfo | undefined;
+  fetchChannelInfo: (
+    channel: TChannel
+  ) =>
+    | Promise<ImChannelInfoFetchResult<TChannelInfo>>
+    | ImChannelInfoFetchResult<TChannelInfo>;
+  setChannleInfoForCache: (channelInfo: TChannelInfo) => void;
+  notifyListeners: (channelInfo: TChannelInfo) => void;
+  addListener: (listener: ImChannelInfoListener<TChannelInfo>) => void;
+  removeListener: (listener: ImChannelInfoListener<TChannelInfo>) => void;
+}
+
+export interface ImChannelRuntimeSdk<
+  TChannel extends ImChannelLike = ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike = ImChannelInfoLike
+> {
+  channelManager: ImChannelManagerRuntime<TChannel, TChannelInfo>;
+}
+
+export interface ImChannelCacheRuntimeSdk<
+  TChannel extends ImChannelLike = ImChannelLike
+> {
+  channelManager: {
+    deleteChannelInfo: (channel: TChannel) => void;
+  };
+}
+
+export interface ImSubscriberLike {
+  uid?: string;
+  [key: string]: any;
+}
+
+export type ImSubscriberChangeListener = (event: any) => void;
+
+export interface ImChannelSubscribersRuntimeSdk<
+  TChannel extends ImChannelLike = ImChannelLike,
+  TSubscriber = ImSubscriberLike
+> {
+  channelManager: {
+    getSubscribes: (channel: TChannel) => TSubscriber[] | undefined | null;
+    syncSubscribes: (channel: TChannel) => Promise<void> | void;
+    addSubscriberChangeListener: (listener: ImSubscriberChangeListener) => void;
+    removeSubscriberChangeListener: (
+      listener: ImSubscriberChangeListener
+    ) => void;
+  };
+}
+
+export interface ImSubscribeCacheRuntimeSdk<
+  TSubscriber = ImSubscriberLike
+> {
+  channelManager: {
+    subscribeCacheMap: Map<string, TSubscriber[]>;
+  };
+}
+
+export function getImChannelInfo<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike
+>(sdk: ImChannelRuntimeSdk<TChannel, TChannelInfo>, channel: TChannel) {
+  return sdk.channelManager.getChannelInfo(channel);
+}
+
+export function fetchImChannelInfo<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike
+>(sdk: ImChannelRuntimeSdk<TChannel, TChannelInfo>, channel: TChannel) {
+  return Promise.resolve(sdk.channelManager.fetchChannelInfo(channel)).then(
+    (channelInfo) => {
+      return channelInfo || sdk.channelManager.getChannelInfo(channel);
+    }
+  );
+}
+
+export function setImChannelInfoCache<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike
+>(sdk: ImChannelRuntimeSdk<TChannel, TChannelInfo>, channelInfo: TChannelInfo) {
+  sdk.channelManager.setChannleInfoForCache(channelInfo);
+}
+
+export function notifyImChannelInfoListeners<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike
+>(sdk: ImChannelRuntimeSdk<TChannel, TChannelInfo>, channelInfo: TChannelInfo) {
+  sdk.channelManager.notifyListeners(channelInfo);
+}
+
+export function addImChannelInfoListener<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike
+>(
+  sdk: ImChannelRuntimeSdk<TChannel, TChannelInfo>,
+  listener: ImChannelInfoListener<TChannelInfo>
+) {
+  sdk.channelManager.addListener(listener);
+  return () => {
+    sdk.channelManager.removeListener(listener);
+  };
+}
+
+export function deleteImChannelInfo<TChannel extends ImChannelLike>(
+  sdk: ImChannelCacheRuntimeSdk<TChannel>,
+  channel: TChannel
+) {
+  sdk.channelManager.deleteChannelInfo(channel);
+}
+
+export function getImChannelSubscribers<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(
+  sdk: ImChannelSubscribersRuntimeSdk<TChannel, TSubscriber>,
+  channel: TChannel
+) {
+  return sdk.channelManager.getSubscribes(channel) || [];
+}
+
+export function syncImChannelSubscribers<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(
+  sdk: ImChannelSubscribersRuntimeSdk<TChannel, TSubscriber>,
+  channel: TChannel
+) {
+  return Promise.resolve(sdk.channelManager.syncSubscribes(channel));
+}
+
+export function getImSubscribeCacheMap<TSubscriber = ImSubscriberLike>(
+  sdk: ImSubscribeCacheRuntimeSdk<TSubscriber>
+) {
+  return sdk.channelManager.subscribeCacheMap;
+}
+
+export function addImSubscriberChangeListener<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(
+  sdk: ImChannelSubscribersRuntimeSdk<TChannel, TSubscriber>,
+  listener: ImSubscriberChangeListener
+) {
+  sdk.channelManager.addSubscriberChangeListener(listener);
+  return () => {
+    sdk.channelManager.removeSubscriberChangeListener(listener);
+  };
+}
+
+export function patchImChannelInfoOrgData<
+  TChannelInfo extends ImChannelInfoLike
+>(
+  channelInfo: TChannelInfo,
+  patch: Record<string, any>
+) {
+  channelInfo.orgData = {
+    ...(channelInfo.orgData || {}),
+    ...patch,
+  };
+  return channelInfo;
+}

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -21,6 +21,7 @@ export * from './Service/DataSource/DataSource'
 export * from './Service/IncomingWebhook'
 export * from './Service/ForwardService'
 export * from './Service/forwardResultToast'
+export * from './im-runtime/channelRuntime'
 export * from './Components/WKLayout'
 
 export * from './Components/Conversation/context'

--- a/packages/dmworkcontacts/src/Contacts/__tests__/onlineBadgeSync.test.tsx
+++ b/packages/dmworkcontacts/src/Contacts/__tests__/onlineBadgeSync.test.tsx
@@ -128,6 +128,14 @@ beforeAll(async () => {
     t: (k: string) => k,
     toSimplized: (s: string) => s,
     getPinyin: () => "#",
+    addImChannelInfoListener: (_sdk: any, listener: any) => {
+      channelManager.addListener(listener);
+      return () => channelManager.removeListener(listener);
+    },
+    fetchImChannelInfo: (_sdk: any, channel: any) =>
+      channelManager.fetchChannelInfo(channel),
+    getImChannelInfo: (_sdk: any, channel: any) =>
+      channelManager.getChannelInfo(channel),
   }));
 
   vi.doMock("@octo/base/src/Messages/Card", () => ({ Card: class {} }));

--- a/packages/dmworkcontacts/src/Contacts/__tests__/visibilityHeal.test.tsx
+++ b/packages/dmworkcontacts/src/Contacts/__tests__/visibilityHeal.test.tsx
@@ -108,6 +108,14 @@ beforeAll(async () => {
     t: (k: string) => k,
     toSimplized: (s: string) => s,
     getPinyin: () => "#",
+    addImChannelInfoListener: (_sdk: any, listener: any) => {
+      channelManager.addListener(listener);
+      return () => channelManager.removeListener(listener);
+    },
+    fetchImChannelInfo: (_sdk: any, channel: any) =>
+      channelManager.fetchChannelInfo(channel),
+    getImChannelInfo: (_sdk: any, channel: any) =>
+      channelManager.getChannelInfo(channel),
   }));
 
   vi.doMock("@octo/base/src/Messages/Card", () => ({ Card: class {} }));

--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Component } from "react";
-import { Contacts, ContextMenus, ContextMenusContext, WKApp, WKBase, WKBaseContext, ErrorBoundary, WKModal, I18nContext, t, ForwardService, interpretForwardResult } from "@octo/base"
+import { Contacts, ContextMenus, ContextMenusContext, WKApp, WKBase, WKBaseContext, ErrorBoundary, WKModal, I18nContext, t, ForwardService, interpretForwardResult, addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "@octo/base"
 import "./index.css"
 import { toSimplized } from "@octo/base";
 import { getPinyin } from "@octo/base";
@@ -214,6 +214,7 @@ export default class ContactsList extends Component<any, ContactsState> {
     private filterScrollTops: Record<ContactFilterMode, number> = { all: 0, bots: 0, humans: 0 }
     // 已预取过 channelInfo（含在线态）的 uid 集合，跨 filter/滚动去重，避免重复请求
     private prefetchedUids = new Set<string>()
+    private unsubscribeChannelInfoListener?: () => void
     private visibilityHandler!: () => void
     // 组件是否仍挂载：refreshTrackedOnlineStatus 是异步的，回包后 setState 前需确认未卸载
     private mounted = false
@@ -264,7 +265,7 @@ export default class ContactsList extends Component<any, ContactsState> {
             }
         }
         WKApp.mittBus.on('space-changed', this.spaceChangedHandler)
-        WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
 
         // 页面重新可见时对已追踪的 AI 在线态做一次自愈重拉：正常情况下在线态靠
         // WKSDK 的 onlineStatus WS 回调实时重渲，但推送若因断连/节流被延迟或丢失，
@@ -301,7 +302,8 @@ export default class ContactsList extends Component<any, ContactsState> {
     componentWillUnmount() {
         this.mounted = false
         ContactsListManager.shared.setRefreshList = undefined
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         WKApp.mittBus.off('space-changed', this.spaceChangedHandler)
         if (typeof document !== 'undefined' && this.visibilityHandler) {
             document.removeEventListener('visibilitychange', this.visibilityHandler)
@@ -320,8 +322,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         if (uids.length === 0) return
         await Promise.all(
             uids.map((uid) =>
-                WKSDK.shared().channelManager
-                    .fetchChannelInfo(new Channel(uid, ChannelTypePerson))
+                fetchImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson))
                     .catch(() => undefined)
             )
         )
@@ -373,8 +374,8 @@ export default class ContactsList extends Component<any, ContactsState> {
             if (this.prefetchedUids.has(uid)) continue
             this.prefetchedUids.add(uid)
             const ch = new Channel(uid, ChannelTypePerson)
-            if (!WKSDK.shared().channelManager.getChannelInfo(ch)) {
-                WKSDK.shared().channelManager.fetchChannelInfo(ch)
+            if (!getImChannelInfo(WKSDK.shared(), ch)) {
+                void fetchImChannelInfo(WKSDK.shared(), ch)
             }
         }
     }
@@ -389,7 +390,8 @@ export default class ContactsList extends Component<any, ContactsState> {
 
     // 复用会话列表/群成员列表同一份在线态判定与文案，渲染在线绿点。
     private renderOnlineBadge(uid: string): React.ReactNode {
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+        const channelInfo = getImChannelInfo(
+            WKSDK.shared(),
             new Channel(normalizeOnlineUid(uid), ChannelTypePerson)
         )
         if (!needShowOnlineStatus(channelInfo)) return null

--- a/packages/dmworkcontacts/src/GroupSave/vm.tsx
+++ b/packages/dmworkcontacts/src/GroupSave/vm.tsx
@@ -1,9 +1,10 @@
-import { WKApp, ProviderListener } from "@octo/base";
+import { WKApp, ProviderListener, addImChannelInfoListener } from "@octo/base";
 import { ChannelInfo,WKSDK } from "wukongimjssdk";
 import { ChannelInfoListener } from "wukongimjssdk";
 export class GroupSaveVM extends ProviderListener {
     groups:ChannelInfo[] = []
     channelInfoListener!:ChannelInfoListener
+    unsubscribeChannelInfoListener?: () => void
 
 
     didMount(): void {
@@ -20,11 +21,12 @@ export class GroupSaveVM extends ProviderListener {
           }
        }
 
-       WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+       this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
     }
 
     didUnMount(): void {
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
     }
 
    async request() {

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -12,7 +12,7 @@ import {
   Toast,
 } from "@douyinfe/semi-ui";
 import { BasicTreeNodeData } from "@douyinfe/semi-foundation/lib/cjs/tree/foundation";
-import { WKApp, ThemeMode, WKViewQueueHeader, WKModal, I18nContext, t, GroupAvatarPreview, GroupAvatarEditModal } from "@octo/base";
+import { WKApp, ThemeMode, WKViewQueueHeader, WKModal, I18nContext, t, GroupAvatarPreview, GroupAvatarEditModal, getImChannelInfo, getImChannelSubscribers, syncImChannelSubscribers } from "@octo/base";
 import WKAvatar from "@octo/base/src/Components/WKAvatar";
 import AiBadge from "@octo/base/src/Components/AiBadge";
 import "./index.css";
@@ -346,15 +346,15 @@ export class OrganizationalGroupNew extends Component<
         subscribers.push(sub)
       } else {
         // 群聊
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel); // 获取频道信息
+        const channelInfo = getImChannelInfo(WKSDK.shared(), channel); // 获取频道信息
         if (channelInfo?.orgData?.group_type === SuperGroup) {
           subscribers = await WKApp.dataSource.channelDataSource.subscribers(channel, {
             limit: 5000,
             page: 1
           })
         } else {
-          await WKSDK.shared().channelManager.syncSubscribes(channel); // 同步订阅者
-          subscribers = WKSDK.shared().channelManager.getSubscribes(channel); // 获取订阅者
+          await syncImChannelSubscribers(WKSDK.shared(), channel); // 同步订阅者
+          subscribers = getImChannelSubscribers(WKSDK.shared(), channel); // 获取订阅者
         }
       }
 

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -1,4 +1,4 @@
-import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ThreadListStatus, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId, IncomingWebhook, IncomingWebhookCreateResp, IncomingWebhookUpsertReq, IncomingWebhookService, StickerItem } from "@octo/base";
+import { ChannelQrcodeResp, Contacts, IChannelDataSource, ICommonDataSource, WKApp, RequestConfig, GroupRole, hasSpacePrefix, Thread, ThreadListStatus, ChannelTypeCommunityTopic, buildThreadChannelId, ChannelFilesResp, parseThreadChannelId, IncomingWebhook, IncomingWebhookCreateResp, IncomingWebhookUpsertReq, IncomingWebhookService, StickerItem, deleteImChannelInfo, getImChannelInfo, syncImChannelSubscribers } from "@octo/base";
 import axios from "axios";
 import { Channel, ChannelInfo, ChannelTypeGroup, ChannelTypePerson, WKSDK, Message, MessageContentType,ConversationExtra,Subscriber } from "wukongimjssdk";
 
@@ -132,7 +132,7 @@ export class ChannelDataSource implements IChannelDataSource {
         // itself (members are already removed on the server); worst case degrades back to
         // needing a manual refresh.
         try {
-            await WKSDK.shared().channelManager.syncSubscribes(channel)
+            await syncImChannelSubscribers(WKSDK.shared(), channel)
         } catch (e) {
             console.warn("[removeSubscribers] syncSubscribes failed", e)
         }
@@ -147,7 +147,7 @@ export class ChannelDataSource implements IChannelDataSource {
         // (members are already added on the server); worst case degrades back to needing a
         // manual refresh.
         try {
-            await WKSDK.shared().channelManager.syncSubscribes(channel)
+            await syncImChannelSubscribers(WKSDK.shared(), channel)
         } catch (e) {
             console.warn("[addSubscribers] syncSubscribes failed", e)
         }
@@ -350,7 +350,7 @@ export class ChannelDataSource implements IChannelDataSource {
         await WKApp.apiClient.delete(`groups/${groupNo}/threads/${shortId}`)
         const threadChannelId = buildThreadChannelId(groupNo, shortId)
         const threadChannel = new Channel(threadChannelId, ChannelTypeCommunityTopic)
-        WKSDK.shared().channelManager.deleteChannelInfo(threadChannel)
+        deleteImChannelInfo(WKSDK.shared(), threadChannel)
         WKSDK.shared().conversationManager.removeConversation(threadChannel)
         WKApp.mittBus.emit("wk:thread-deleted", {
             groupNo,
@@ -526,7 +526,7 @@ export class CommonDataSource implements ICommonDataSource {
         } else if (message.contentType === MessageContentType.image) {
             content = message.content.contentObj.url;
         }
-        const fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(message.fromUID, ChannelTypePerson))
+        const fromChannelInfo = getImChannelInfo(WKSDK.shared(), new Channel(message.fromUID, ChannelTypePerson))
         return WKApp.apiClient.post(`favorites`, {
             type: message.contentType,
             unique_key: message.messageID,

--- a/packages/dmworkdatasource/src/module.ts
+++ b/packages/dmworkdatasource/src/module.ts
@@ -1,4 +1,4 @@
-import { Convert, IModule, WKApp, hasSpacePrefix, ChannelTypeCommunityTopic } from "@octo/base"
+import { Convert, IModule, WKApp, hasSpacePrefix, ChannelTypeCommunityTopic, getImChannelInfo, getImSubscribeCacheMap, setImChannelInfoCache } from "@octo/base"
 import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
 import { ConversationProvider } from "./conversation";
 import { ChannelDataSource, CommonDataSource } from "./datasource";
@@ -50,7 +50,7 @@ export default class DataSourceModule implements IModule {
             threadGet: (groupNo, shortId) =>
                 WKApp.dataSource.channelDataSource.threadGet(groupNo, shortId),
             extractUID: DataSourceModule.extractUID,
-            getSubscribeCacheMap: () => WKSDK.shared().channelManager.subscribeCacheMap,
+            getSubscribeCacheMap: () => getImSubscribeCacheMap(WKSDK.shared()),
         })
     }
 
@@ -59,9 +59,9 @@ export default class DataSourceModule implements IModule {
             getMembers: (path) => WKApp.apiClient.get(path),
             avatarUser: (uid) => WKApp.shared.avatarUser(uid),
             getPersonChannelInfo: (uid) =>
-                WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson)),
+                getImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson)),
             setChannelInfoForCache: (channelInfo) =>
-                WKSDK.shared().channelManager.setChannleInfoForCache(channelInfo),
+                setImChannelInfoCache(WKSDK.shared(), channelInfo),
         })
     }
 
@@ -118,7 +118,7 @@ export default class DataSourceModule implements IModule {
             toUserChannelInfo: (user) => Convert.userToChannelInfo(user),
             toGroupChannelInfo: (group) => Convert.groupToChannelInfo(group),
             setChannelInfoForCache: (channelInfo) =>
-                WKSDK.shared().channelManager.setChannleInfoForCache(channelInfo),
+                setImChannelInfoCache(WKSDK.shared(), channelInfo),
         })
     }
 }

--- a/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@octo/base', () => ({
     ChannelTypeCommunityTopic: 5,
+    getImChannelInfo: (sdk: any, channel: any) =>
+        sdk.channelManager.getChannelInfo(channel),
     parseThreadChannelId: (channelId: string) => {
         const parts = channelId.split('____');
         if (parts.length !== 2) return null;

--- a/packages/dmworksummary/src/utils/channelConvert.ts
+++ b/packages/dmworksummary/src/utils/channelConvert.ts
@@ -1,4 +1,4 @@
-import { ChannelTypeCommunityTopic, parseThreadChannelId } from '@octo/base';
+import { ChannelTypeCommunityTopic, getImChannelInfo, parseThreadChannelId } from '@octo/base';
 import { ChannelTypeGroup, ChannelTypePerson } from 'wukongimjssdk';
 import WKSDK from 'wukongimjssdk';
 import { Channel } from 'wukongimjssdk';
@@ -9,7 +9,7 @@ export function channelToChatCandidate(channel: {
     channelType: number;
 }): ChatCandidate {
     const ch = new Channel(channel.channelID, channel.channelType);
-    const info = WKSDK.shared().channelManager.getChannelInfo(ch);
+    const info = getImChannelInfo(WKSDK.shared(), ch);
 
     let chatType: ChatCandidate['chat_type'];
     if (

--- a/packages/dmworktodo/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworktodo/src/__mocks__/dmworkBase.ts
@@ -20,6 +20,17 @@ export const buildAcceptLanguage = () => 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7';
 
 export const isSafeUrl = (url: string) => /^https?:\/\//.test(url);
 
+export const getImChannelInfo = (sdk: any, channel: any) =>
+  sdk.channelManager.getChannelInfo(channel);
+
+export const fetchImChannelInfo = (sdk: any, channel: any) =>
+  sdk.channelManager.fetchChannelInfo(channel);
+
+export const addImChannelInfoListener = (sdk: any, listener: any) => {
+  sdk.channelManager.addListener(listener);
+  return () => sdk.channelManager.removeListener(listener);
+};
+
 // Thread enum / type re-exports — production code imports these from
 // '@octo/base' (re-exported via dmworkbase/src/index.tsx). The vitest
 // alias points '@octo/base' at this mock file, so we re-export the

--- a/packages/dmworktodo/src/hooks/useChannelName.ts
+++ b/packages/dmworktodo/src/hooks/useChannelName.ts
@@ -1,4 +1,9 @@
 import { useState, useEffect } from 'react';
+import {
+    addImChannelInfoListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+} from '@octo/base';
 import WKSDK, { Channel } from 'wukongimjssdk';
 import type { ChannelInfo } from 'wukongimjssdk';
 
@@ -19,7 +24,8 @@ export function useChannelName(
 ): string {
     const [name, setName] = useState<string>(() => {
         if (!channelId || !channelType) return '';
-        const info = WKSDK.shared().channelManager.getChannelInfo(
+        const info = getImChannelInfo(
+            WKSDK.shared(),
             new Channel(channelId, channelType),
         );
         return info?.title || '';
@@ -33,7 +39,8 @@ export function useChannelName(
         let aborted = false;
 
         const channel = new Channel(channelId, channelType);
-        const cached = WKSDK.shared().channelManager.getChannelInfo(channel);
+        const sdk = WKSDK.shared();
+        const cached = getImChannelInfo(sdk, channel);
         if (cached?.title) {
             setName(cached.title);
         }
@@ -49,11 +56,11 @@ export function useChannelName(
             }
         };
 
-        WKSDK.shared().channelManager.addListener(listener);
+        const unsubscribe = addImChannelInfoListener(sdk, listener);
 
         // 缓存未命中时触发异步 fetch
         if (!cached?.title) {
-            WKSDK.shared().channelManager.fetchChannelInfo(channel).catch(() => {
+            fetchImChannelInfo(sdk, channel).catch(() => {
                 // fetch 失败不 fallback 到 channelId; 调用方视觉上 "#{xxx...}" 不友好,
                 // 保持空串让上层决定显示 "未知群聊" 或隐藏整块
             });
@@ -61,7 +68,7 @@ export function useChannelName(
 
         return () => {
             aborted = true;
-            WKSDK.shared().channelManager.removeListener(listener);
+            unsubscribe();
         };
     }, [channelId, channelType]);
 

--- a/packages/dmworktodo/src/hooks/useUserName.ts
+++ b/packages/dmworktodo/src/hooks/useUserName.ts
@@ -1,4 +1,9 @@
 import { useState, useEffect } from 'react';
+import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from '@octo/base';
 import WKSDK, { Channel, ChannelTypePerson } from 'wukongimjssdk';
 import type { ChannelInfo } from 'wukongimjssdk';
 
@@ -9,7 +14,7 @@ import type { ChannelInfo } from 'wukongimjssdk';
  */
 export function useUserName(uid: string): string {
   const [name, setName] = useState<string>(() => {
-    const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson));
+    const info = getImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson));
     return info?.title || '';
   });
 
@@ -18,7 +23,8 @@ export function useUserName(uid: string): string {
     let aborted = false;
 
     const channel = new Channel(uid, ChannelTypePerson);
-    const cached = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const sdk = WKSDK.shared();
+    const cached = getImChannelInfo(sdk, channel);
     if (cached?.title) {
       setName(cached.title);
       return;
@@ -35,15 +41,15 @@ export function useUserName(uid: string): string {
       }
     };
 
-    WKSDK.shared().channelManager.addListener(listener);
+    const unsubscribe = addImChannelInfoListener(sdk, listener);
     // Trigger async fetch; on failure set fallback name
-    WKSDK.shared().channelManager.fetchChannelInfo(channel).catch(() => {
+    fetchImChannelInfo(sdk, channel).catch(() => {
       if (!aborted) setName((prev) => prev || uid);
     });
 
     return () => {
       aborted = true;
-      WKSDK.shared().channelManager.removeListener(listener);
+      unsubscribe();
     };
   }, [uid]);
 
@@ -59,7 +65,7 @@ export function useUserNames(uids: string[]): Map<string, string> {
   const [nameMap, setNameMap] = useState<Map<string, string>>(() => {
     const m = new Map<string, string>();
     for (const uid of uids) {
-      const info = WKSDK.shared().channelManager.getChannelInfo(new Channel(uid, ChannelTypePerson));
+      const info = getImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson));
       m.set(uid, info?.title || '');
     }
     return m;
@@ -70,12 +76,13 @@ export function useUserNames(uids: string[]): Map<string, string> {
     let aborted = false;
 
     const channels = uids.map((uid) => new Channel(uid, ChannelTypePerson));
+    const sdk = WKSDK.shared();
 
     // Initial resolve from cache
     const m = new Map<string, string>();
     const toFetch: Channel[] = [];
     for (let i = 0; i < uids.length; i++) {
-      const info = WKSDK.shared().channelManager.getChannelInfo(channels[i]);
+      const info = getImChannelInfo(sdk, channels[i]);
       if (info?.title) {
         m.set(uids[i], info.title);
       } else {
@@ -98,7 +105,7 @@ export function useUserNames(uids: string[]): Map<string, string> {
       }
     };
 
-    WKSDK.shared().channelManager.addListener(listener);
+    const unsubscribe = addImChannelInfoListener(sdk, listener);
 
     // Fetch uncached in batches of 5 to avoid flooding the IM SDK
     const BATCH_SIZE = 5;
@@ -108,7 +115,7 @@ export function useUserNames(uids: string[]): Map<string, string> {
         const batch = toFetch.slice(i, i + BATCH_SIZE);
         await Promise.all(
           batch.map((ch) =>
-            WKSDK.shared().channelManager.fetchChannelInfo(ch).catch(() => {
+            fetchImChannelInfo(sdk, ch).catch(() => {
               if (aborted) return;
               setNameMap((prev) => {
                 const next = new Map(prev);
@@ -125,7 +132,7 @@ export function useUserNames(uids: string[]): Map<string, string> {
 
     return () => {
       aborted = true;
-      WKSDK.shared().channelManager.removeListener(listener);
+      unsubscribe();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uids.join('\0')]);

--- a/packages/dmworktodo/src/module.tsx
+++ b/packages/dmworktodo/src/module.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { WKApp, Menus, ChannelTypeCommunityTopic, i18n, t as translate, useI18n } from "@octo/base";
+import { WKApp, Menus, ChannelTypeCommunityTopic, i18n, t as translate, useI18n, getImChannelInfo } from "@octo/base";
 import type { IModule, ConversationContext } from "@octo/base";
 import { ChannelTypeGroup } from "wukongimjssdk";
 import WKSDK from "wukongimjssdk";
@@ -209,7 +209,8 @@ export default class MatterModule implements IModule {
             const raw = effectiveContent.conversationDigest ?? "";
             const { title: parsedTitle } = parseMentionText(raw);
             const prefillTitle = parsedTitle.slice(0, 200);
-            const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+            const channelInfo = getImChannelInfo(
+              WKSDK.shared(),
               message.channel,
             );
             WKApp.mittBus.emit("wk:open-create-matter-modal", {
@@ -312,7 +313,7 @@ export default class MatterModule implements IModule {
 function ChatToolbarTodoButton({ ctx }: { ctx: ConversationContext }) {
   const { t } = useI18n();
   const channel = ctx.channel();
-  const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+  const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
 
   const handleOpen = () => {
     const inputCtx = ctx.messageInputContext();

--- a/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
+++ b/packages/dmworktodo/src/panel/MatterDetailPanel/index.tsx
@@ -44,7 +44,7 @@ import { OutputsPanel } from "../../ui/OutputsPanel";
 import WKAvatar from "@octo/base/src/Components/WKAvatar";
 import WKSDK, { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
 import type { ChannelInfoListener } from "wukongimjssdk";
-import { WKApp, i18n, useI18n, t as translate } from "@octo/base";
+import { WKApp, i18n, useI18n, t as translate, addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "@octo/base";
 import { downloadFile } from "@octo/base/src/Utils/download";
 import {
   getFileIcon,
@@ -744,17 +744,17 @@ export default function MatterDetailPanel({
       );
       if (matched) setChannelNameTick((t) => t + 1);
     };
-    WKSDK.shared().channelManager.addListener(listener);
+    const unsubscribe = addImChannelInfoListener(WKSDK.shared(), listener);
     // 缓存没命中的群主动 fetch, 防止 listener 永远不触发
     for (const c of channels) {
       const ch = new Channel(c.channel_id, c.channel_type);
-      const cached = WKSDK.shared().channelManager.getChannelInfo(ch);
+      const cached = getImChannelInfo(WKSDK.shared(), ch);
       if (!cached?.title) {
-        WKSDK.shared().channelManager.fetchChannelInfo(ch).catch(() => {});
+        fetchImChannelInfo(WKSDK.shared(), ch).catch(() => {});
       }
     }
     return () => {
-      WKSDK.shared().channelManager.removeListener(listener);
+      unsubscribe();
     };
   }, [matter?.channels]);
 
@@ -764,7 +764,8 @@ export default function MatterDetailPanel({
     void channelNameTick;
     const map = new Map<string, string>();
     for (const ch of matter?.channels || []) {
-      const live = WKSDK.shared().channelManager.getChannelInfo(
+      const live = getImChannelInfo(
+        WKSDK.shared(),
         new Channel(ch.channel_id, ch.channel_type),
       )?.title;
       const name = live || ch.channel_name || "";

--- a/packages/dmworktodo/src/ui/AssigneeEditor/index.tsx
+++ b/packages/dmworktodo/src/ui/AssigneeEditor/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer } from 'react';
-import { WKApp, isSafeUrl, resolveExternalForViewer } from '@octo/base';
+import { WKApp, isSafeUrl, resolveExternalForViewer, addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from '@octo/base';
 import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from 'wukongimjssdk';
 import type { MatterAssignee } from '../../bridge/types';
 import { useUserName } from '../../hooks/useUserName';
@@ -113,10 +113,7 @@ export default function AssigneeEditor({ matterId, assignees, onChanged }: Assig
         bumpTick();
       }
     };
-    WKSDK.shared().channelManager.addListener(listener);
-    return () => {
-      WKSDK.shared().channelManager.removeListener(listener);
-    };
+    return addImChannelInfoListener(WKSDK.shared(), listener);
   }, []);
 
   // Close dropdown on outside click
@@ -156,7 +153,7 @@ export default function AssigneeEditor({ matterId, assignees, onChanged }: Assig
         let sourceSpaceName = '';
         try {
           const ch = new Channel(c.uid, ChannelTypePerson);
-          const ci = WKSDK.shared().channelManager.getChannelInfo(ch);
+          const ci = getImChannelInfo(WKSDK.shared(), ch);
           const org = ci?.orgData;
           if (org) {
             const ext = resolveExternalForViewer({
@@ -209,7 +206,7 @@ export default function AssigneeEditor({ matterId, assignees, onChanged }: Assig
     const missing: Channel[] = [];
     for (const c of candidates) {
       const ch = new Channel(c.uid, ChannelTypePerson);
-      const ci = WKSDK.shared().channelManager.getChannelInfo(ch);
+      const ci = getImChannelInfo(WKSDK.shared(), ch);
       if (!ci?.orgData) missing.push(ch);
     }
     if (missing.length === 0) return;
@@ -218,8 +215,7 @@ export default function AssigneeEditor({ matterId, assignees, onChanged }: Assig
     const abortController = new AbortController();
     Promise.all(
       missing.map((ch): Promise<FetchOutcome> =>
-        WKSDK.shared()
-          .channelManager.fetchChannelInfo(ch)
+        fetchImChannelInfo(WKSDK.shared(), ch)
           .then((): FetchOutcome => ({ ok: true }))
           .catch((reason: unknown): FetchOutcome => ({ ok: false, reason }))
       )


### PR DESCRIPTION
## Summary
- add a thin channel runtime facade for channel info, subscriber, cache, and listener access
- migrate low-to-medium-risk channelManager call sites across base, contacts, datasource, summary, and todo to the facade
- keep Chat, Conversation, Messages, MessageInput, ThreadPanel, and dmworkbase module runtime paths out of this PR for a later focused migration

## Verification
- git diff --check upstream/main...HEAD
- pnpm --dir packages/dmworkbase exec vitest run src/im-runtime src/Service/__tests__/ForwardService.test.ts src/Service/__tests__/PatchSdkDecode.test.ts src/Service/__tests__/SpaceService.test.ts src/Utils/__tests__/groupDisband.test.ts src/Service/__tests__/threadArchiveSync.test.ts src/Service/__tests__/threadPermission.test.ts src/Components/ChannelSearch/__tests__/apiAdapter.test.ts src/Components/GroupMdEditor/__tests__/GroupMdEditor.test.tsx src/Components/ChannelSetting/__tests__/vm.persona.test.ts src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx src/Components/ForwardModal/__tests__/useForwardModal.test.tsx src/bridge/profileDetail/__tests__/UserInfoVM.test.ts src/Components/MeInfo/__tests__/vm.test.tsx
- pnpm --dir packages/dmworkdatasource exec vitest run src/im-callbacks
- pnpm --dir packages/dmworkcontacts exec vitest run src/Contacts/__tests__/onlineBadgeSync.test.tsx src/Contacts/__tests__/visibilityHeal.test.tsx
- pnpm --dir packages/dmworksummary exec vitest run src/utils/__tests__/channelConvert.test.ts
- pnpm --dir packages/dmworktodo exec vitest run src/utils/__tests__/buildLinkableChannels.test.ts src/utils/__tests__/fileUrl.test.ts src/api/__tests__/todoApi.test.ts
- pnpm --dir packages/dmworkbase exec vitest run src/Components/ChannelSearch/__tests__/apiAdapter.test.ts src/Components/GlobalSearch/__tests__/filterState.test.ts