### PR TITLE
refactor(appbot): split module service bridge and ui

### DIFF
--- a/packages/dmworkappbot/src/AppBotPage.css
+++ b/packages/dmworkappbot/src/AppBotPage.css
@@ -3,203 +3,33 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  background: var(--wk-color-bg, #fff);
+  background: var(--wk-bg-surface);
 }
 
-.appbot-page-header {
-  flex-shrink: 0;
-  padding: 16px 16px 12px;
-  border-bottom: 1px solid var(--wk-color-border, #f0f0f0);
-}
-
-.appbot-page-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--wk-color-text, #1f2937);
-  margin-bottom: 10px;
-}
-
-.appbot-search-input {
-  width: 100%;
-  height: 32px;
-  padding: 0 12px;
-  font-size: 13px;
-  color: var(--wk-color-text, #1f2937);
-  background: var(--wk-color-bg-subtle, #f3f4f6);
-  border: 1px solid transparent;
-  border-radius: 6px;
-  outline: none;
-  box-sizing: border-box;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.appbot-search-input:focus {
-  border-color: var(--wk-color-primary, #5b6abf);
-  background: var(--wk-color-bg, #fff);
-}
-
-.appbot-page-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px 0;
-}
-
-.appbot-list-section {
-  margin-bottom: 4px;
-}
-
-.appbot-list-section-title {
-  padding: 8px 16px 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--wk-color-text-tertiary, #9ca3af);
-}
-
-.appbot-list-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
-  cursor: pointer;
-  transition: background 0.1s;
-}
-
-.appbot-list-item:hover {
-  background: var(--wk-color-bg-hover, #f9fafb);
-}
-
-.appbot-page .appbot-list-item.appbot-list-item-active {
-  background: var(--wk-color-primary-light, #eef2ff);
-}
-
-.appbot-list-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: var(--wk-avatar-radius, 50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  overflow: hidden;
-  background: #6366f1;
-}
-
-.appbot-list-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.appbot-list-avatar .wk-avatar {
-  border-radius: var(--wk-avatar-radius, 50%);
-}
-
-.appbot-list-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.appbot-list-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--wk-color-text, #1f2937);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 1.3;
-}
-
-.appbot-list-desc {
-  font-size: 12px;
-  color: var(--wk-color-text-secondary, #6b7280);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 1.4;
-  margin-top: 2px;
-}
-
-.appbot-list-status {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 40px 16px;
-  font-size: 13px;
-  color: var(--wk-color-text-secondary, #6b7280);
-}
-
-.appbot-spinner {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 2px solid var(--wk-color-border, #e5e7eb);
-  border-top-color: var(--wk-color-primary, #5b6abf);
-  animation: appbot-spin 0.8s linear infinite;
-}
-
-@keyframes appbot-spin {
-  to { transform: rotate(360deg); }
-}
-
-.appbot-retry-btn {
-  padding: 4px 12px;
-  font-size: 12px;
-  border: 1px solid var(--wk-color-border, #d1d5db);
-  border-radius: 4px;
-  background: var(--wk-color-bg, #fff);
-  color: var(--wk-color-text, #374151);
-  cursor: pointer;
-}
-
-.appbot-retry-btn:hover {
-  border-color: var(--wk-color-primary, #5b6abf);
-  color: var(--wk-color-primary, #5b6abf);
-}
-
-/* Bot chat header — direct render, no SDK dependency */
-.appbot-chat-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  height: 48px;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--wk-color-border, #f0f0f0);
-  background: var(--wk-color-bg, #fff);
-  flex-shrink: 0;
-}
-
-.appbot-chat-header-avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: var(--wk-avatar-radius, 50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.appbot-chat-header-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.appbot-chat-header-name {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--wk-color-text, #1f2937);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Wrap Conversation component with our header */
 .appbot-chat-wrap {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.appbot-toast {
+  position: fixed;
+  top: var(--wk-sp-4);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--wk-z-toast);
+  padding: var(--wk-sp-2) var(--wk-sp-4);
+  border-radius: var(--wk-r-sm);
+  font-size: var(--wk-text-size-base);
+  font-weight: var(--wk-font-medium);
+  color: var(--wk-color-error);
+  background: var(--wk-color-error-bg);
+  border: 1px solid var(--wk-color-danger-border);
+  box-shadow: var(--wk-shadow-md);
+  opacity: 0;
+  transition: opacity var(--wk-dur) var(--wk-ease);
+}
+
+.appbot-toast-visible {
+  opacity: 1;
 }

--- a/packages/dmworkappbot/src/AppBotPage.tsx
+++ b/packages/dmworkappbot/src/AppBotPage.tsx
@@ -1,249 +1,58 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
-import { Channel, ChannelTypePerson, ChannelInfo, WKSDK } from "wukongimjssdk"
-import { WKApp, Conversation, SpaceService, useI18n } from "@octo/base"
-import WKAvatar from "@octo/base/src/Components/WKAvatar"
+import React, { useMemo } from "react"
+import { useI18n } from "@octo/base"
+import { useAppBots } from "./bridge/useAppBots"
+import { useAppBotConversation } from "./features/appBotConversation"
+import AppBotAvatar from "./features/AppBotAvatar"
+import AppBotListView, { AppBotListSection } from "./ui/AppBotListView"
+import type { AppBotViewItem } from "./bridge/types"
 import "./AppBotPage.css"
-
-interface AppBotInfo {
-  id: string
-  uid: string
-  display_name: string
-  description: string
-  avatar: string
-  scope: "platform" | "space"
-}
-
-type LoadState = "loading" | "ready" | "error"
-
-/** Lightweight error toast — self-removing DOM element, no external dependency. */
-function showErrorToast(message: string) {
-  const el = document.createElement("div")
-  Object.assign(el.style, {
-    position: "fixed",
-    top: "16px",
-    left: "50%",
-    transform: "translateX(-50%)",
-    zIndex: "10000",
-    padding: "8px 16px",
-    borderRadius: "6px",
-    fontSize: "13px",
-    fontWeight: "500",
-    color: "#dc2626",
-    background: "#fef2f2",
-    border: "1px solid #fecaca",
-    boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-    opacity: "0",
-    transition: "opacity 200ms ease",
-  })
-  el.textContent = message
-  document.body.appendChild(el)
-  requestAnimationFrame(() => { el.style.opacity = "1" })
-  setTimeout(() => {
-    el.style.opacity = "0"
-    setTimeout(() => el.remove(), 200)
-  }, 3000)
-}
-
-/** Bot chat header — renders directly from bot data, bypasses SDK channelInfo */
-function BotChatHeader({ bot }: { bot: AppBotInfo }) {
-  const channel = new Channel(bot.uid, ChannelTypePerson)
-  return (
-    <div className="appbot-chat-header">
-      <div className="appbot-chat-header-avatar">
-        <WKAvatar channel={channel} style={{ width: "100%", height: "100%" }} />
-      </div>
-      <div className="appbot-chat-header-name">{bot.display_name}</div>
-    </div>
-  )
-}
 
 export default function AppBotPage() {
   const { t } = useI18n()
-  const [bots, setBots] = useState<AppBotInfo[]>([])
-  const [state, setState] = useState<LoadState>("loading")
-  const [spaceName, setSpaceName] = useState("")
-  const [keyword, setKeyword] = useState("")
-  const [selectedUid, setSelectedUid] = useState<string | null>(null)
-  const [reloadTick, setReloadTick] = useState(0)
+  const conversation = useAppBotConversation({
+    connectFailedMessage: t("appbot.error.connectFailed"),
+  })
+  const appBots = useAppBots({
+    onSpaceChanged: conversation.resetSelection,
+  })
 
-  useEffect(() => {
-    let stale = false
-    let requestId = 0
+  const sections: AppBotListSection[] = useMemo(() => [
+    {
+      key: "platform",
+      title: t("appbot.section.platform"),
+      bots: appBots.sections.platformBots,
+    },
+    {
+      key: "space",
+      title: appBots.spaceName
+        ? t("appbot.section.spaceWithName", { values: { name: appBots.spaceName } })
+        : t("appbot.section.space"),
+      bots: appBots.sections.spaceBots,
+    },
+  ], [appBots.sections.platformBots, appBots.sections.spaceBots, appBots.spaceName, t])
 
-    const loadData = async () => {
-      const thisRequest = ++requestId
-      setState("loading")
-      try {
-        const spaceId = WKApp.shared.currentSpaceId
-        const params = spaceId ? { param: { space_id: spaceId } } : undefined
-        const res = await WKApp.apiClient.get("/app_bot/available", params)
-        if (stale || thisRequest !== requestId) return
-        const items = Array.isArray(res) ? res.filter((b: AppBotInfo) => b && b.uid && b.id) : []
-        setBots(items)
-        setState("ready")
-      } catch (err) {
-        console.warn("[AppBotPage] Failed to load bots:", err)
-        if (stale || thisRequest !== requestId) return
-        setBots([])
-        setState("error")
-      }
-    }
-
-    const resolveSpaceName = async () => {
-      const spaceId = WKApp.shared.currentSpaceId
-      if (!spaceId) { if (!stale) setSpaceName(""); return }
-      try {
-        const spaces = await SpaceService.shared.getMySpaces()
-        if (stale) return
-        const found = spaces?.find((s: { space_id: string; name?: string }) => s.space_id === spaceId)
-        setSpaceName(found?.name || "")
-      } catch { if (!stale) setSpaceName("") }
-    }
-
-    loadData()
-    resolveSpaceName()
-
-    const handler = () => {
-      isSelectingRef.current = false
-      setSelectedUid(null)
-      WKApp.routeRight.popToRoot()
-      loadData()
-      resolveSpaceName()
-    }
-    WKApp.mittBus.on("space-changed", handler)
-    return () => { stale = true; WKApp.mittBus.off("space-changed", handler) }
-  }, [reloadTick])
-
-  const filtered = useMemo(() => {
-    const kw = keyword.trim().toLowerCase()
-    if (!kw) return bots
-    return bots.filter((b) =>
-      (b.display_name || "").toLowerCase().includes(kw) ||
-      (b.description || "").toLowerCase().includes(kw)
-    )
-  }, [bots, keyword])
-
-  const platformBots = useMemo(() => filtered.filter((b) => b.scope === "platform"), [filtered])
-  const spaceBots = useMemo(() => filtered.filter((b) => b.scope === "space"), [filtered])
-
-  const isSelectingRef = useRef(false)
-
-  const handleSelect = async (bot: AppBotInfo) => {
-    if (isSelectingRef.current) return
-    isSelectingRef.current = true
-    try {
-      // Ensure friend relationship with bot (opt-in consent).
-      // This is idempotent — already-friends returns OK immediately.
-      await WKApp.apiClient.post("/app_bot/apply", { robot_uid: bot.uid })
-
-      setSelectedUid(bot.uid)
-
-      const channel = new Channel(bot.uid, ChannelTypePerson)
-
-      // Write bot identity to channelManager FIRST — Conversation component
-      // reads this for message row avatars/names. Must be set before any
-      // component renders or triggers fetchChannelInfo.
-      const info = new ChannelInfo()
-      info.channel = channel
-      info.title = bot.display_name
-      // Use relative path to match channelInfo convention — avatarChannel()
-      // calls getImageURL() which prepends the API base URL for relative paths.
-      info.logo = `users/${bot.uid}/avatar`
-      info.orgData = { displayName: bot.display_name, robot: 1, name: bot.display_name }
-      WKSDK.shared().channelManager.setChannleInfoForCache(info)
-
-      // Ensure conversation exists in SDK
-      const convMgr = WKSDK.shared().conversationManager
-      if (!convMgr.findConversation(channel) && convMgr.createEmptyConversation) {
-        convMgr.createEmptyConversation(channel)
-      }
-
-      // Render bot chat: our header + Conversation (messages + input only)
-      WKApp.routeRight.replaceToRoot(
-        <div key={channel.getChannelKey()} className="appbot-chat-wrap">
-          <BotChatHeader bot={bot} />
-          <Conversation channel={channel} />
-        </div>
-      )
-    } catch (err) {
-      console.error("[AppBotPage] handleSelect failed:", err)
-      showErrorToast(t("appbot.error.connectFailed"))
-    } finally {
-      isSelectingRef.current = false
-    }
-  }
-
-  const renderItem = (bot: AppBotInfo) => {
-    const isActive = selectedUid === bot.uid
-    return (
-      <div
-        key={bot.id}
-        className={`appbot-list-item ${isActive ? "appbot-list-item-active" : ""}`}
-        onClick={() => handleSelect(bot)}
-      >
-        <div className="appbot-list-avatar">
-          <WKAvatar channel={new Channel(bot.uid, ChannelTypePerson)} style={{ width: "100%", height: "100%" }} />
-        </div>
-        <div className="appbot-list-info">
-          <div className="appbot-list-name">{bot.display_name}</div>
-          <div className="appbot-list-desc">{bot.description || t("appbot.list.defaultDescription")}</div>
-        </div>
-      </div>
-    )
-  }
-
-  const renderSection = (title: string, list: AppBotInfo[]) => {
-    if (list.length === 0) return null
-    return (
-      <div className="appbot-list-section" key={title}>
-        <div className="appbot-list-section-title">{title}</div>
-        {list.map(renderItem)}
-      </div>
-    )
-  }
+  const renderAvatar = (bot: AppBotViewItem) => <AppBotAvatar uid={bot.uid} />
 
   return (
     <div className="appbot-page">
-      <div className="appbot-page-header">
-        <div className="appbot-page-title">{t("appbot.page.title")}</div>
-        <input
-          type="search"
-          className="appbot-search-input"
-          placeholder={t("appbot.page.searchPlaceholder")}
-          value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
-        />
-      </div>
-      <div className="appbot-page-list">
-        {state === "loading" && (
-          <div className="appbot-list-status">
-            <div className="appbot-spinner" />
-            <span>{t("appbot.state.loading")}</span>
-          </div>
-        )}
-        {state === "error" && (
-          <div className="appbot-list-status">
-            <span>{t("appbot.state.loadFailed")}</span>
-            <button className="appbot-retry-btn" onClick={() => setReloadTick((t) => t + 1)}>{t("appbot.action.retry")}</button>
-          </div>
-        )}
-        {state === "ready" && filtered.length === 0 && (
-          <div className="appbot-list-status">
-            <span>{keyword ? t("appbot.state.noMatches") : t("appbot.state.empty")}</span>
-          </div>
-        )}
-        {state === "ready" && (
-          <>
-            {renderSection(t("appbot.section.platform"), platformBots)}
-            {renderSection(
-              spaceName
-                ? t("appbot.section.spaceWithName", { values: { name: spaceName } })
-                : t("appbot.section.space"),
-              spaceBots
-            )}
-          </>
-        )}
-      </div>
+      <AppBotListView
+        title={t("appbot.page.title")}
+        searchPlaceholder={t("appbot.page.searchPlaceholder")}
+        keyword={appBots.keyword}
+        state={appBots.state}
+        sections={sections}
+        selectedUid={conversation.selectedUid}
+        loadingText={t("appbot.state.loading")}
+        loadFailedText={t("appbot.state.loadFailed")}
+        retryLabel={t("appbot.action.retry")}
+        emptyText={t("appbot.state.empty")}
+        noMatchesText={t("appbot.state.noMatches")}
+        defaultDescription={t("appbot.list.defaultDescription")}
+        onKeywordChange={appBots.setKeyword}
+        onRetry={appBots.reload}
+        onSelect={conversation.selectBot}
+        renderAvatar={renderAvatar}
+      />
     </div>
   )
 }

--- a/packages/dmworkappbot/src/Service/AppBotService.ts
+++ b/packages/dmworkappbot/src/Service/AppBotService.ts
@@ -1,0 +1,32 @@
+import APIClient from "@octo/base/src/Service/APIClient"
+
+export type AppBotScope = "platform" | "space"
+
+export interface AppBotInfo {
+  id: string
+  uid: string
+  display_name: string
+  description?: string
+  avatar?: string
+  scope: AppBotScope
+}
+
+function isAppBotInfo(value: unknown): value is AppBotInfo {
+  if (!value || typeof value !== "object") return false
+  const bot = value as Partial<AppBotInfo>
+  return Boolean(bot.id && bot.uid)
+}
+
+const AppBotService = {
+  async getAvailableBots(spaceId?: string): Promise<AppBotInfo[]> {
+    const config = spaceId ? { param: { space_id: spaceId } } : undefined
+    const res = await APIClient.shared.get("/app_bot/available", config)
+    return Array.isArray(res) ? res.filter(isAppBotInfo) : []
+  },
+
+  applyBot(robotUid: string): Promise<void> {
+    return APIClient.shared.post("/app_bot/apply", { robot_uid: robotUid })
+  },
+}
+
+export default AppBotService

--- a/packages/dmworkappbot/src/__tests__/AppBotListView.test.tsx
+++ b/packages/dmworkappbot/src/__tests__/AppBotListView.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { fireEvent, screen } from "@testing-library/dom"
+import "@testing-library/jest-dom/vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import AppBotListView, { AppBotListViewProps } from "../ui/AppBotListView"
+
+let container: HTMLDivElement
+
+const baseProps = (overrides: Partial<AppBotListViewProps> = {}): AppBotListViewProps => ({
+  title: "Apps",
+  searchPlaceholder: "Search",
+  keyword: "",
+  state: "ready",
+  sections: [{
+    key: "platform",
+    title: "Platform apps",
+    bots: [{
+      id: "bot-1",
+      uid: "robot_1",
+      displayName: "Docs Bot",
+      description: "Search docs",
+      scope: "platform",
+    }],
+  }],
+  selectedUid: null,
+  loadingText: "Loading",
+  loadFailedText: "Failed",
+  retryLabel: "Retry",
+  emptyText: "Empty",
+  noMatchesText: "No matches",
+  defaultDescription: "App Bot",
+  onKeywordChange: vi.fn(),
+  onRetry: vi.fn(),
+  onSelect: vi.fn(),
+  renderAvatar: () => React.createElement("span", null, "D"),
+  ...overrides,
+})
+
+const renderView = (props: AppBotListViewProps) => {
+  act(() => {
+    ReactDOM.render(React.createElement(AppBotListView, props), container)
+  })
+}
+
+describe("AppBotListView", () => {
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("emits search and select interactions through props", () => {
+    const onKeywordChange = vi.fn()
+    const onSelect = vi.fn()
+    renderView(baseProps({ onKeywordChange, onSelect }))
+
+    act(() => {
+      fireEvent.change(screen.getByRole("searchbox"), { target: { value: "docs" } })
+    })
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Docs Bot/ }))
+    })
+
+    expect(onKeywordChange).toHaveBeenCalledWith("docs")
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ uid: "robot_1" }))
+  })
+
+  it("shows the retry action in error state", () => {
+    const onRetry = vi.fn()
+    renderView(baseProps({ state: "error", onRetry }))
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    })
+
+    expect(screen.getByText("Failed")).toBeInTheDocument()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dmworkappbot/src/__tests__/AppBotService.test.ts
+++ b/packages/dmworkappbot/src/__tests__/AppBotService.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@octo/base/src/Service/APIClient", () => ({
+  default: {
+    shared: {
+      get: vi.fn(),
+      post: vi.fn(),
+    },
+  },
+}))
+
+import APIClient from "@octo/base/src/Service/APIClient"
+import AppBotService from "../Service/AppBotService"
+
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  apiGet.mockReset()
+  apiPost.mockReset()
+})
+
+describe("AppBotService", () => {
+  it("loads available bots without space params when no space is selected", async () => {
+    apiGet.mockResolvedValueOnce([{ id: "1", uid: "robot_1", display_name: "Bot", scope: "platform" }])
+
+    const bots = await AppBotService.getAvailableBots("")
+
+    expect(apiGet).toHaveBeenCalledWith("/app_bot/available", undefined)
+    expect(bots).toHaveLength(1)
+  })
+
+  it("loads available bots with current space id", async () => {
+    apiGet.mockResolvedValueOnce([])
+
+    await AppBotService.getAvailableBots("space-a")
+
+    expect(apiGet).toHaveBeenCalledWith("/app_bot/available", {
+      param: { space_id: "space-a" },
+    })
+  })
+
+  it("keeps the legacy list filter for invalid bot rows", async () => {
+    apiGet.mockResolvedValueOnce([
+      { id: "1", uid: "robot_1", display_name: "Bot", scope: "platform" },
+      { id: "missing-uid", display_name: "Bad", scope: "space" },
+      null,
+    ])
+
+    const bots = await AppBotService.getAvailableBots("space-a")
+
+    expect(bots).toEqual([
+      { id: "1", uid: "robot_1", display_name: "Bot", scope: "platform" },
+    ])
+  })
+
+  it("applies a bot through the existing endpoint and payload", async () => {
+    apiPost.mockResolvedValueOnce(undefined)
+
+    await AppBotService.applyBot("robot_1")
+
+    expect(apiPost).toHaveBeenCalledWith("/app_bot/apply", { robot_uid: "robot_1" })
+  })
+})

--- a/packages/dmworkappbot/src/__tests__/appBotConversation.test.tsx
+++ b/packages/dmworkappbot/src/__tests__/appBotConversation.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@octo/base", () => ({
+  Conversation: ({ channel }: { channel: { channelID: string } }) =>
+    React.createElement("div", { "data-channel": channel.channelID }),
+  WKApp: {
+    routeRight: {
+      popToRoot: vi.fn(),
+      replaceToRoot: vi.fn(),
+    },
+  },
+}))
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string
+    channelType: number
+
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID
+      this.channelType = channelType
+    }
+
+    getChannelKey() {
+      return `${this.channelID}-${this.channelType}`
+    }
+  }
+
+  class ChannelInfo {
+    channel: unknown
+    title = ""
+    logo = ""
+    orgData: Record<string, unknown> = {}
+  }
+
+  return {
+    Channel,
+    ChannelInfo,
+    ChannelTypePerson: 1,
+    WKSDK: {
+      shared: vi.fn(),
+    },
+  }
+})
+
+vi.mock("../features/AppBotAvatar", () => ({
+  default: ({ uid }: { uid: string }) => React.createElement("span", null, uid),
+}))
+
+vi.mock("../Service/AppBotService", () => ({
+  default: {
+    applyBot: vi.fn(),
+  },
+}))
+
+import { openAppBotConversation } from "../features/appBotConversation"
+
+describe("openAppBotConversation", () => {
+  it("keeps apply, SDK cache, empty conversation, and route rendering in order", async () => {
+    const calls: string[] = []
+    const setChannelInfo = vi.fn((info) => {
+      calls.push("cache")
+      expect(info.title).toBe("Docs Bot")
+      expect(info.logo).toBe("users/robot_1/avatar")
+      expect(info.orgData).toEqual({
+        displayName: "Docs Bot",
+        robot: 1,
+        name: "Docs Bot",
+      })
+    })
+    const replaceToRoot = vi.fn((element: React.ReactElement) => {
+      calls.push("route")
+      expect(element.props.className).toBe("appbot-chat-wrap")
+    })
+
+    await openAppBotConversation({
+      id: "bot-1",
+      uid: "robot_1",
+      displayName: "Docs Bot",
+      description: "Search docs",
+      scope: "platform",
+    }, {
+      applyBot: async (uid) => {
+        calls.push(`apply:${uid}`)
+      },
+      setChannelInfo,
+      findConversation: () => undefined,
+      createEmptyConversation: () => {
+        calls.push("create")
+      },
+      replaceToRoot,
+    })
+
+    expect(calls).toEqual(["apply:robot_1", "cache", "create", "route"])
+    expect(setChannelInfo).toHaveBeenCalledTimes(1)
+    expect(replaceToRoot).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dmworkappbot/src/__tests__/appBotList.test.ts
+++ b/packages/dmworkappbot/src/__tests__/appBotList.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { filterAppBots, groupAppBots, toAppBotViewItem } from "../bridge/appBotList"
+import type { AppBotInfo } from "../Service/AppBotService"
+
+const bots: AppBotInfo[] = [
+  {
+    id: "platform-doc",
+    uid: "robot_doc",
+    display_name: "Docs Bot",
+    description: "Search platform docs",
+    scope: "platform",
+  },
+  {
+    id: "space-report",
+    uid: "robot_report",
+    display_name: "Report Bot",
+    description: "Weekly space update",
+    scope: "space",
+  },
+]
+
+describe("appBotList bridge helpers", () => {
+  it("maps API rows into UI view items", () => {
+    expect(toAppBotViewItem(bots[0])).toEqual({
+      id: "platform-doc",
+      uid: "robot_doc",
+      displayName: "Docs Bot",
+      description: "Search platform docs",
+      scope: "platform",
+    })
+  })
+
+  it("filters by display name and description case-insensitively", () => {
+    const viewItems = bots.map(toAppBotViewItem)
+
+    expect(filterAppBots(viewItems, "weekly")).toEqual([viewItems[1]])
+    expect(filterAppBots(viewItems, "DOCS")).toEqual([viewItems[0]])
+  })
+
+  it("groups platform and space bots separately", () => {
+    const grouped = groupAppBots(bots.map(toAppBotViewItem))
+
+    expect(grouped.platformBots.map((bot) => bot.uid)).toEqual(["robot_doc"])
+    expect(grouped.spaceBots.map((bot) => bot.uid)).toEqual(["robot_report"])
+  })
+})

--- a/packages/dmworkappbot/src/bridge/appBotList.ts
+++ b/packages/dmworkappbot/src/bridge/appBotList.ts
@@ -1,0 +1,31 @@
+import type { AppBotInfo } from "../Service/AppBotService"
+import type { AppBotSections, AppBotViewItem } from "./types"
+
+export function toAppBotViewItem(bot: AppBotInfo): AppBotViewItem {
+  return {
+    id: bot.id,
+    uid: bot.uid,
+    displayName: bot.display_name || bot.uid,
+    description: bot.description || "",
+    scope: bot.scope,
+  }
+}
+
+export function filterAppBots(
+  bots: AppBotViewItem[],
+  keyword: string,
+): AppBotViewItem[] {
+  const kw = keyword.trim().toLowerCase()
+  if (!kw) return bots
+  return bots.filter((bot) =>
+    bot.displayName.toLowerCase().includes(kw) ||
+    bot.description.toLowerCase().includes(kw)
+  )
+}
+
+export function groupAppBots(bots: AppBotViewItem[]): AppBotSections {
+  return {
+    platformBots: bots.filter((bot) => bot.scope === "platform"),
+    spaceBots: bots.filter((bot) => bot.scope === "space"),
+  }
+}

--- a/packages/dmworkappbot/src/bridge/types.ts
+++ b/packages/dmworkappbot/src/bridge/types.ts
@@ -1,0 +1,18 @@
+import type { AppBotInfo, AppBotScope } from "../Service/AppBotService"
+
+export type { AppBotInfo, AppBotScope }
+
+export type AppBotLoadState = "loading" | "ready" | "error"
+
+export interface AppBotViewItem {
+  id: string
+  uid: string
+  displayName: string
+  description: string
+  scope: AppBotScope
+}
+
+export interface AppBotSections {
+  platformBots: AppBotViewItem[]
+  spaceBots: AppBotViewItem[]
+}

--- a/packages/dmworkappbot/src/bridge/useAppBots.ts
+++ b/packages/dmworkappbot/src/bridge/useAppBots.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { SpaceService, WKApp } from "@octo/base"
+import AppBotService from "../Service/AppBotService"
+import { filterAppBots, groupAppBots, toAppBotViewItem } from "./appBotList"
+import type { AppBotLoadState } from "./types"
+
+interface UseAppBotsOptions {
+  onSpaceChanged?: () => void
+}
+
+export function useAppBots({ onSpaceChanged }: UseAppBotsOptions = {}) {
+  const [bots, setBots] = useState(() => [] as ReturnType<typeof toAppBotViewItem>[])
+  const [state, setState] = useState<AppBotLoadState>("loading")
+  const [spaceName, setSpaceName] = useState("")
+  const [keyword, setKeyword] = useState("")
+  const [reloadTick, setReloadTick] = useState(0)
+  const requestIdRef = useRef(0)
+
+  const reload = useCallback(() => {
+    setReloadTick((tick) => tick + 1)
+  }, [])
+
+  useEffect(() => {
+    let stale = false
+
+    const loadData = async () => {
+      const thisRequest = ++requestIdRef.current
+      setState("loading")
+      try {
+        const items = await AppBotService.getAvailableBots(WKApp.shared.currentSpaceId)
+        if (stale || thisRequest !== requestIdRef.current) return
+        setBots(items.map(toAppBotViewItem))
+        setState("ready")
+      } catch (err) {
+        console.warn("[AppBotPage] Failed to load bots:", err)
+        if (stale || thisRequest !== requestIdRef.current) return
+        setBots([])
+        setState("error")
+      }
+    }
+
+    const resolveSpaceName = async () => {
+      const spaceId = WKApp.shared.currentSpaceId
+      if (!spaceId) {
+        if (!stale) setSpaceName("")
+        return
+      }
+      try {
+        const spaces = await SpaceService.shared.getMySpaces()
+        if (stale) return
+        const found = spaces?.find((s: { space_id: string; name?: string }) => s.space_id === spaceId)
+        setSpaceName(found?.name || "")
+      } catch {
+        if (!stale) setSpaceName("")
+      }
+    }
+
+    loadData()
+    resolveSpaceName()
+
+    const handler = () => {
+      onSpaceChanged?.()
+      loadData()
+      resolveSpaceName()
+    }
+    WKApp.mittBus.on("space-changed", handler)
+    return () => {
+      stale = true
+      WKApp.mittBus.off("space-changed", handler)
+    }
+  }, [onSpaceChanged, reloadTick])
+
+  const filteredBots = useMemo(() => filterAppBots(bots, keyword), [bots, keyword])
+  const sections = useMemo(() => groupAppBots(filteredBots), [filteredBots])
+
+  return {
+    state,
+    keyword,
+    setKeyword,
+    reload,
+    spaceName,
+    filteredBots,
+    sections,
+  }
+}

--- a/packages/dmworkappbot/src/features/AppBotAvatar.tsx
+++ b/packages/dmworkappbot/src/features/AppBotAvatar.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { Channel, ChannelTypePerson } from "wukongimjssdk"
+import WKAvatar from "@octo/base/src/Components/WKAvatar"
+
+interface AppBotAvatarProps {
+  uid: string
+}
+
+export default function AppBotAvatar({ uid }: AppBotAvatarProps) {
+  return (
+    <WKAvatar
+      channel={new Channel(uid, ChannelTypePerson)}
+      style={{ width: "100%", height: "100%" }}
+    />
+  )
+}
+
+export { AppBotAvatar }

--- a/packages/dmworkappbot/src/features/appBotConversation.tsx
+++ b/packages/dmworkappbot/src/features/appBotConversation.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useRef, useState } from "react"
+import { Channel, ChannelInfo, ChannelTypePerson, WKSDK } from "wukongimjssdk"
+import { Conversation, WKApp } from "@octo/base"
+import AppBotService from "../Service/AppBotService"
+import type { AppBotViewItem } from "../bridge/types"
+import AppBotAvatar from "./AppBotAvatar"
+import { showErrorToast } from "./appBotToast"
+import AppBotChatHeader from "../ui/AppBotChatHeader"
+
+interface OpenAppBotConversationDeps {
+  applyBot: (robotUid: string) => Promise<unknown>
+  setChannelInfo: (info: ChannelInfo) => void
+  findConversation: (channel: Channel) => unknown
+  createEmptyConversation?: (channel: Channel) => unknown
+  replaceToRoot: (element: React.ReactElement) => void
+}
+
+function createAppBotChannel(bot: AppBotViewItem) {
+  return new Channel(bot.uid, ChannelTypePerson)
+}
+
+function createAppBotChannelInfo(bot: AppBotViewItem, channel: Channel) {
+  const info = new ChannelInfo()
+  info.channel = channel
+  info.title = bot.displayName
+  info.logo = `users/${bot.uid}/avatar`
+  info.orgData = {
+    displayName: bot.displayName,
+    robot: 1,
+    name: bot.displayName,
+  }
+  return info
+}
+
+function renderAppBotConversation(bot: AppBotViewItem, channel: Channel) {
+  return (
+    <div key={channel.getChannelKey()} className="appbot-chat-wrap">
+      <AppBotChatHeader
+        avatar={<AppBotAvatar uid={bot.uid} />}
+        displayName={bot.displayName}
+      />
+      <Conversation channel={channel} />
+    </div>
+  )
+}
+
+function defaultOpenConversationDeps(): OpenAppBotConversationDeps {
+  return {
+    applyBot: AppBotService.applyBot,
+    setChannelInfo: (info) => WKSDK.shared().channelManager.setChannleInfoForCache(info),
+    findConversation: (channel) => WKSDK.shared().conversationManager.findConversation(channel),
+    createEmptyConversation: (channel) => {
+      const convMgr = WKSDK.shared().conversationManager
+      return convMgr.createEmptyConversation?.(channel)
+    },
+    replaceToRoot: (element) => WKApp.routeRight.replaceToRoot(element),
+  }
+}
+
+export async function openAppBotConversation(
+  bot: AppBotViewItem,
+  deps: OpenAppBotConversationDeps = defaultOpenConversationDeps(),
+  callbacks: { onApplied?: () => void } = {},
+) {
+  await deps.applyBot(bot.uid)
+  callbacks.onApplied?.()
+
+  const channel = createAppBotChannel(bot)
+  const info = createAppBotChannelInfo(bot, channel)
+  deps.setChannelInfo(info)
+
+  if (!deps.findConversation(channel) && deps.createEmptyConversation) {
+    deps.createEmptyConversation(channel)
+  }
+
+  deps.replaceToRoot(renderAppBotConversation(bot, channel))
+}
+
+interface UseAppBotConversationOptions {
+  connectFailedMessage: string
+  onError?: (message: string) => void
+}
+
+export function useAppBotConversation({
+  connectFailedMessage,
+  onError = showErrorToast,
+}: UseAppBotConversationOptions) {
+  const [selectedUid, setSelectedUid] = useState<string | null>(null)
+  const isSelectingRef = useRef(false)
+
+  const resetSelection = useCallback(() => {
+    isSelectingRef.current = false
+    setSelectedUid(null)
+    WKApp.routeRight.popToRoot()
+  }, [])
+
+  const selectBot = useCallback(async (bot: AppBotViewItem) => {
+    if (isSelectingRef.current) return
+    isSelectingRef.current = true
+    try {
+      await openAppBotConversation(bot, undefined, {
+        onApplied: () => setSelectedUid(bot.uid),
+      })
+    } catch (err) {
+      console.error("[AppBotPage] handleSelect failed:", err)
+      onError(connectFailedMessage)
+    } finally {
+      isSelectingRef.current = false
+    }
+  }, [connectFailedMessage, onError])
+
+  return {
+    selectedUid,
+    selectBot,
+    resetSelection,
+  }
+}

--- a/packages/dmworkappbot/src/features/appBotToast.ts
+++ b/packages/dmworkappbot/src/features/appBotToast.ts
@@ -1,0 +1,13 @@
+export function showErrorToast(message: string) {
+  const el = document.createElement("div")
+  el.className = "appbot-toast appbot-toast-error"
+  el.textContent = message
+  document.body.appendChild(el)
+  requestAnimationFrame(() => {
+    el.classList.add("appbot-toast-visible")
+  })
+  setTimeout(() => {
+    el.classList.remove("appbot-toast-visible")
+    setTimeout(() => el.remove(), 200)
+  }, 3000)
+}

--- a/packages/dmworkappbot/src/ui/AppBotChatHeader/index.css
+++ b/packages/dmworkappbot/src/ui/AppBotChatHeader/index.css
@@ -1,0 +1,36 @@
+.appbot-chat-header {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  height: var(--wk-sp-12);
+  padding: 0 var(--wk-sp-4);
+  border-bottom: 1px solid var(--wk-border-default);
+  background: var(--wk-bg-surface);
+  flex-shrink: 0;
+}
+
+.appbot-chat-header-avatar {
+  width: var(--wk-sp-8);
+  height: var(--wk-sp-8);
+  border-radius: var(--wk-avatar-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.appbot-chat-header-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.appbot-chat-header-name {
+  font-size: var(--wk-text-size-lg);
+  font-weight: var(--wk-font-semibold);
+  color: var(--wk-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/dmworkappbot/src/ui/AppBotChatHeader/index.tsx
+++ b/packages/dmworkappbot/src/ui/AppBotChatHeader/index.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import "./index.css"
+
+export interface AppBotChatHeaderProps {
+  avatar: React.ReactNode
+  displayName: string
+}
+
+const AppBotChatHeader: React.FC<AppBotChatHeaderProps> = ({
+  avatar,
+  displayName,
+}) => {
+  return (
+    <div className="appbot-chat-header">
+      <div className="appbot-chat-header-avatar">{avatar}</div>
+      <div className="appbot-chat-header-name">{displayName}</div>
+    </div>
+  )
+}
+
+export default AppBotChatHeader
+export { AppBotChatHeader }

--- a/packages/dmworkappbot/src/ui/AppBotListView/AppBotListView.stories.tsx
+++ b/packages/dmworkappbot/src/ui/AppBotListView/AppBotListView.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import React from "react"
+import AppBotListView, { AppBotListViewProps } from "."
+import "./index.css"
+
+const sampleBots = [
+  {
+    id: "platform-doc",
+    uid: "robot_platform_doc",
+    displayName: "Knowledge Assistant",
+    description: "Answers questions from platform documentation and workspace notes.",
+    scope: "platform" as const,
+  },
+  {
+    id: "space-report",
+    uid: "robot_space_report",
+    displayName: "Weekly Report Bot",
+    description: "Creates recurring project updates for the current Space.",
+    scope: "space" as const,
+  },
+]
+
+function PreviewAvatar({ name }: { name: string }) {
+  return <div className="appbot-story-avatar">{name.slice(0, 1)}</div>
+}
+
+function Preview(args: AppBotListViewProps) {
+  return (
+    <div className="appbot-story-frame">
+      <AppBotListView {...args} />
+    </div>
+  )
+}
+
+const baseArgs: AppBotListViewProps = {
+  title: "Apps",
+  searchPlaceholder: "Search",
+  keyword: "",
+  state: "ready",
+  sections: [
+    { key: "platform", title: "Platform apps", bots: [sampleBots[0]] },
+    { key: "space", title: "Space apps · Product", bots: [sampleBots[1]] },
+  ],
+  selectedUid: "",
+  loadingText: "Loading...",
+  loadFailedText: "Failed to load",
+  retryLabel: "Retry",
+  emptyText: "No apps available",
+  noMatchesText: "No matching apps found",
+  defaultDescription: "App Bot",
+  onKeywordChange: () => undefined,
+  onRetry: () => undefined,
+  onSelect: () => undefined,
+  renderAvatar: (bot) => <PreviewAvatar name={bot.displayName} />,
+}
+
+const meta: Meta<typeof Preview> = {
+  title: "Business/AppBot/AppBotListView",
+  component: Preview,
+  args: baseArgs,
+}
+
+export default meta
+type Story = StoryObj<typeof Preview>
+
+export const Default: Story = {
+  name: "Default",
+}
+
+export const Loading: Story = {
+  name: "Loading",
+  args: {
+    state: "loading",
+  },
+}
+
+export const Error: Story = {
+  name: "Error",
+  args: {
+    state: "error",
+  },
+}
+
+export const Empty: Story = {
+  name: "Empty",
+  args: {
+    sections: [
+      { key: "platform", title: "Platform apps", bots: [] },
+      { key: "space", title: "Space apps", bots: [] },
+    ],
+  },
+}
+
+export const NoMatches: Story = {
+  name: "No matches",
+  args: {
+    keyword: "finance",
+    sections: [
+      { key: "platform", title: "Platform apps", bots: [] },
+      { key: "space", title: "Space apps", bots: [] },
+    ],
+  },
+}
+
+export const LongText: Story = {
+  name: "Long text",
+  args: {
+    sections: [
+      {
+        key: "platform",
+        title: "Platform apps",
+        bots: [{
+          ...sampleBots[0],
+          displayName: "A very long application bot name that should truncate cleanly",
+          description: "A long description that explains a complicated automation flow without expanding the sidebar or pushing controls out of place.",
+        }],
+      },
+      { key: "space", title: "Space apps · Product", bots: [sampleBots[1]] },
+    ],
+  },
+}

--- a/packages/dmworkappbot/src/ui/AppBotListView/index.css
+++ b/packages/dmworkappbot/src/ui/AppBotListView/index.css
@@ -1,0 +1,184 @@
+.appbot-list-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--wk-bg-surface);
+}
+
+.appbot-page-header {
+  flex-shrink: 0;
+  padding: var(--wk-sp-4) var(--wk-sp-4) var(--wk-sp-3);
+  border-bottom: 1px solid var(--wk-border-default);
+}
+
+.appbot-page-title {
+  font-size: var(--wk-text-size-xl);
+  font-weight: var(--wk-font-semibold);
+  color: var(--wk-text-primary);
+  margin-bottom: var(--wk-sp-2);
+}
+
+.appbot-search-input {
+  width: 100%;
+  height: var(--wk-sp-8);
+  padding: 0 var(--wk-sp-3);
+  font-size: var(--wk-text-size-base);
+  color: var(--wk-text-primary);
+  background: var(--wk-bg-elevated);
+  border: 1px solid transparent;
+  border-radius: var(--wk-r-sm);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--wk-dur-fast), background var(--wk-dur-fast);
+}
+
+.appbot-search-input:focus {
+  border-color: var(--wk-brand-primary);
+  background: var(--wk-bg-surface);
+}
+
+.appbot-page-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--wk-sp-2) 0;
+}
+
+.appbot-list-section {
+  margin-bottom: var(--wk-sp-1);
+}
+
+.appbot-list-section-title {
+  padding: var(--wk-sp-2) var(--wk-sp-4) var(--wk-sp-1);
+  font-size: var(--wk-text-size-xs);
+  font-weight: var(--wk-font-semibold);
+  text-transform: uppercase;
+  color: var(--wk-text-tertiary);
+}
+
+.appbot-list-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  padding: 10px var(--wk-sp-4);
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--wk-dur-fast);
+}
+
+.appbot-list-item:hover {
+  background: var(--wk-bg-hover);
+}
+
+.appbot-list-view .appbot-list-item.appbot-list-item-active {
+  background: var(--wk-bg-selected);
+}
+
+.appbot-list-avatar {
+  width: var(--wk-sp-10);
+  height: var(--wk-sp-10);
+  border-radius: var(--wk-avatar-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--wk-bg-elevated);
+}
+
+.appbot-list-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.appbot-list-avatar .wk-avatar {
+  border-radius: var(--wk-avatar-radius);
+}
+
+.appbot-list-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.appbot-list-name {
+  font-size: var(--wk-text-size-md);
+  font-weight: var(--wk-font-medium);
+  color: var(--wk-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: var(--wk-leading-snug);
+}
+
+.appbot-list-desc {
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: var(--wk-leading-normal);
+  margin-top: var(--wk-sp-0-5);
+}
+
+.appbot-list-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  padding: var(--wk-sp-10) var(--wk-sp-4);
+  font-size: var(--wk-text-size-base);
+  color: var(--wk-text-secondary);
+}
+
+.appbot-spinner {
+  width: var(--wk-sp-5);
+  height: var(--wk-sp-5);
+  border-radius: var(--wk-r-circle);
+  border: 2px solid var(--wk-border-default);
+  border-top-color: var(--wk-brand-primary);
+  animation: appbot-spin 0.8s linear infinite;
+}
+
+@keyframes appbot-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.appbot-retry-btn {
+  padding: var(--wk-sp-1) var(--wk-sp-3);
+  font-size: var(--wk-text-size-sm);
+  border: 1px solid var(--wk-border-default);
+  border-radius: var(--wk-r-xs);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  cursor: pointer;
+}
+
+.appbot-retry-btn:hover {
+  border-color: var(--wk-brand-primary);
+  color: var(--wk-brand-primary);
+}
+
+.appbot-story-frame {
+  width: 320px;
+  height: 560px;
+  border: 1px solid var(--wk-border-default);
+  background: var(--wk-bg-surface);
+}
+
+.appbot-story-avatar {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--wk-text-on-brand);
+  background: var(--wk-brand-primary);
+  font-size: var(--wk-text-size-md);
+  font-weight: var(--wk-font-semibold);
+}

--- a/packages/dmworkappbot/src/ui/AppBotListView/index.tsx
+++ b/packages/dmworkappbot/src/ui/AppBotListView/index.tsx
@@ -1,0 +1,127 @@
+import React from "react"
+import type { AppBotLoadState, AppBotViewItem } from "../../bridge/types"
+import "./index.css"
+
+export interface AppBotListSection {
+  key: string
+  title: string
+  bots: AppBotViewItem[]
+}
+
+export interface AppBotListViewProps {
+  title: string
+  searchPlaceholder: string
+  keyword: string
+  state: AppBotLoadState
+  sections: AppBotListSection[]
+  selectedUid?: string | null
+  loadingText: string
+  loadFailedText: string
+  retryLabel: string
+  emptyText: string
+  noMatchesText: string
+  defaultDescription: string
+  onKeywordChange: (keyword: string) => void
+  onRetry: () => void
+  onSelect: (bot: AppBotViewItem) => void
+  renderAvatar: (bot: AppBotViewItem) => React.ReactNode
+}
+
+const AppBotListView: React.FC<AppBotListViewProps> = ({
+  title,
+  searchPlaceholder,
+  keyword,
+  state,
+  sections,
+  selectedUid,
+  loadingText,
+  loadFailedText,
+  retryLabel,
+  emptyText,
+  noMatchesText,
+  defaultDescription,
+  onKeywordChange,
+  onRetry,
+  onSelect,
+  renderAvatar,
+}) => {
+  const hasBots = sections.some((section) => section.bots.length > 0)
+
+  const renderStatus = () => {
+    if (state === "loading") {
+      return (
+        <div className="appbot-list-status">
+          <div className="appbot-spinner" />
+          <span>{loadingText}</span>
+        </div>
+      )
+    }
+
+    if (state === "error") {
+      return (
+        <div className="appbot-list-status">
+          <span>{loadFailedText}</span>
+          <button className="appbot-retry-btn" onClick={onRetry}>{retryLabel}</button>
+        </div>
+      )
+    }
+
+    if (!hasBots) {
+      return (
+        <div className="appbot-list-status">
+          <span>{keyword ? noMatchesText : emptyText}</span>
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  const renderItem = (bot: AppBotViewItem) => {
+    const isActive = selectedUid === bot.uid
+    return (
+      <button
+        key={bot.id}
+        type="button"
+        className={`appbot-list-item ${isActive ? "appbot-list-item-active" : ""}`}
+        onClick={() => onSelect(bot)}
+      >
+        <div className="appbot-list-avatar">{renderAvatar(bot)}</div>
+        <div className="appbot-list-info">
+          <div className="appbot-list-name">{bot.displayName}</div>
+          <div className="appbot-list-desc">{bot.description || defaultDescription}</div>
+        </div>
+      </button>
+    )
+  }
+
+  return (
+    <div className="appbot-list-view">
+      <div className="appbot-page-header">
+        <div className="appbot-page-title">{title}</div>
+        <input
+          type="search"
+          className="appbot-search-input"
+          placeholder={searchPlaceholder}
+          value={keyword}
+          onChange={(e) => onKeywordChange(e.target.value)}
+        />
+      </div>
+      <div className="appbot-page-list">
+        {renderStatus()}
+        {state === "ready" && hasBots && sections.map((section) => {
+          if (section.bots.length === 0) return null
+          return (
+            <div className="appbot-list-section" key={section.key}>
+              <div className="appbot-list-section-title">{section.title}</div>
+              {section.bots.map(renderItem)}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default AppBotListView
+export { AppBotListView }


### PR DESCRIPTION
## Summary

Refactor the AppBot page into clear service, bridge, feature, and pure UI boundaries while preserving the existing user-facing behavior.

## Related Issue

N/A

## Changes

- Move AppBot API access behind a dedicated service boundary.
- Add bridge state for loading, filtering, grouping, reload, and Space changes.
- Extract conversation/apply behavior into feature helpers.
- Add pure AppBot list and chat header UI components with Story coverage.
- Add focused tests for service mapping, list state, UI rendering, and conversation flow.

## Architecture / Module Boundary

- Affected module(s): AppBot
- New or changed user-visible entry point: no
- Shared layer touched: bridge, service, ui
- If shared code changed, impact scope: AppBot module only
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands run:

- pnpm exec vitest run packages/dmworkappbot/src
- pnpm exec stylelint 'packages/dmworkappbot/src/**/*.css' --config stylelint.config.mjs --allow-empty-input
- pnpm i18n:check
- git diff --check
- pnpm --filter @octo/web build

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Ran 
> octo-web@1.5.0 i18n:check /Users/mlamp/Desktop/JOB/octo-web
> node scripts/i18n-scan.mjs check

i18n check passed: 0 candidates within baseline; locale keys healthy or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)