### PR TITLE
fix(skillmarket): refine skill card workflow

### DIFF
--- a/packages/dmworkskillmarket/src/components/EditSkillModal.tsx
+++ b/packages/dmworkskillmarket/src/components/EditSkillModal.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, Box, Loader2, Upload, XCircle } from "lucide-react";
+import { AlertCircle, Box, ImagePlus, Loader2, Upload, XCircle } from "lucide-react";
 import { t, useI18n, WKButton, WKInput, WKModal } from "@octo/base";
 import type { Category, Skill } from "../types/skill";
 import { updateSkill, uploadIcon, initReupload, uploadFile, triggerParse, pollParse, getSkillTags } from "../api/skillApi";
 import { MAX_SKILL_TAGS, validateSkillTag } from "../utils/format";
+import { getSkillAvatarColor, getSkillAvatarText } from "../utils/skillAvatar";
 import IconCropModal from "./IconCropModal";
 
 interface EditSkillModalProps {
@@ -40,6 +41,7 @@ export default function EditSkillModal({ skill, categories, onClose, onUpdated }
     [categories],
   );
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const iconInputRef = useRef<HTMLInputElement | null>(null);
   const tagFieldRef = useRef<HTMLDivElement | null>(null);
   const abortRef = useRef(false);
   const [name, setName] = useState("");
@@ -158,6 +160,19 @@ export default function EditSkillModal({ skill, categories, onClose, onUpdated }
       width: rect.width,
       maxHeight,
     });
+  }
+
+  function handleIconClick() {
+    iconInputRef.current?.click();
+  }
+
+  function handleIconInputClick(event: React.MouseEvent<HTMLInputElement>) {
+    event.currentTarget.value = "";
+  }
+
+  function handleIconFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const f = event.currentTarget.files?.[0];
+    if (f) setIconCropFile(f);
   }
 
   function requestClose() {
@@ -487,22 +502,35 @@ export default function EditSkillModal({ skill, categories, onClose, onUpdated }
           <h3 className="skill-market-form__section-title">{t("skillMarket.form.basicInfoSection")}</h3>
 
           <div className="skill-market-form__icon-row">
-            <label className="skill-market-icon-upload" title={t("skillMarket.form.uploadIcon")}>
-              <input
-                type="file"
-                accept="image/png,image/jpeg,image/svg+xml"
-                onChange={(event) => {
-                  const f = event.target.files?.[0];
-                  if (f) setIconCropFile(f);
-                  event.target.value = "";
-                }}
-              />
+            <button
+              type="button"
+              className="skill-market-icon-upload"
+              title={t("skillMarket.form.uploadIcon")}
+              onClick={handleIconClick}
+              aria-label={t("skillMarket.form.uploadIcon")}
+            >
               {iconPreview ? (
                 <img src={iconPreview} alt="icon" />
+              ) : name ? (
+                <span
+                  className="skill-market-icon-upload__default"
+                  style={{ background: getSkillAvatarColor(name) }}
+                >
+                  {getSkillAvatarText(name)}
+                </span>
               ) : (
-                <Box size={24} />
+                <ImagePlus size={24} />
               )}
-            </label>
+            </button>
+            <input
+              ref={iconInputRef}
+              className="skill-market-icon-upload__input"
+              type="file"
+              accept="image/*"
+              multiple={false}
+              onClick={handleIconInputClick}
+              onChange={handleIconFileChange}
+            />
             <label>
               <span>{t("skillMarket.form.displayName")}<i className="skill-market-required">*</i></span>
               <WKInput value={displayName} onChange={(v: string) => setDisplayName(v.slice(0, 20))} placeholder={t("skillMarket.form.displayNamePlaceholder")} maxLength={20} />

--- a/packages/dmworkskillmarket/src/components/EditSkillModal.tsx
+++ b/packages/dmworkskillmarket/src/components/EditSkillModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, Box, FileArchive, Loader2, XCircle } from "lucide-react";
+import { AlertCircle, Box, Loader2, Upload, XCircle } from "lucide-react";
 import { t, useI18n, WKButton, WKInput, WKModal } from "@octo/base";
 import type { Category, Skill } from "../types/skill";
 import { updateSkill, uploadIcon, initReupload, uploadFile, triggerParse, pollParse, getSkillTags } from "../api/skillApi";
@@ -412,13 +412,22 @@ export default function EditSkillModal({ skill, categories, onClose, onUpdated }
               <span>{error}</span>
             </div>
           )}
-          <div className="skill-market-upload-file">
-            <FileArchive size={18} />
-            <div>
-              <strong>{uploadedFile?.name ?? skill?.fileName}</strong>
-              <span>{uploadedFile ? t("skillMarket.upload.newVersionParsedWithName", { values: { name } }) : t("skillMarket.upload.currentPackageWithName", { values: { name } })}</span>
+          <div className="skill-market-upload-file skill-market-upload-file--identity">
+            <span className="skill-market-upload-file__identity-icon" aria-hidden="true">
+              <Box size={16} />
+            </span>
+            <div className="skill-market-upload-file__identity">
+              <span>{t("skillMarket.upload.skillName")}</span>
+              <strong title={name}>{name}</strong>
             </div>
-            <button type="button" onClick={() => fileInputRef.current?.click()}>{t("skillMarket.upload.reupload")}</button>
+            <button
+              type="button"
+              aria-label={t("skillMarket.upload.reupload")}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload size={14} aria-hidden="true" />
+              {t("skillMarket.upload.reuploadShort")}
+            </button>
             <input
               ref={fileInputRef}
               aria-label={t("skillMarket.upload.selectNewFileAriaLabel")}

--- a/packages/dmworkskillmarket/src/components/IconCropModal.tsx
+++ b/packages/dmworkskillmarket/src/components/IconCropModal.tsx
@@ -22,13 +22,13 @@ export default function IconCropModal({ visible, file, onCancel, onConfirm }: Ic
     }, "image/png");
   }
 
-  if (!file) return null;
-
   return (
     <WKModal
       title={t("skillMarket.crop.title")}
       visible={visible}
       onCancel={onCancel}
+      width={460}
+      zIndex={1100}
       className="skill-market-crop-modal"
       footer={
         <div className="skill-market-crop-modal__footer">
@@ -38,28 +38,32 @@ export default function IconCropModal({ visible, file, onCancel, onConfirm }: Ic
       }
     >
       <div className="skill-market-crop-editor">
-        <AvatarEditor
-          ref={editorRef}
-          image={file}
-          width={200}
-          height={200}
-          border={40}
-          borderRadius={16}
-          color={[0, 0, 0, 0.4]}
-          scale={scale}
-          rotate={0}
-        />
-        <label className="skill-market-crop-scale">
-          <span>{t("skillMarket.crop.scale")}</span>
-          <input
-            type="range"
-            min="1"
-            max="3"
-            step="0.05"
-            value={scale}
-            onChange={(e) => setScale(Number(e.target.value))}
-          />
-        </label>
+        {file && (
+          <>
+            <AvatarEditor
+              ref={editorRef}
+              image={file}
+              width={200}
+              height={200}
+              border={40}
+              borderRadius={16}
+              color={[0, 0, 0, 0.4]}
+              scale={scale}
+              rotate={0}
+            />
+            <label className="skill-market-crop-scale">
+              <span>{t("skillMarket.crop.scale")}</span>
+              <input
+                type="range"
+                min="1"
+                max="3"
+                step="0.05"
+                value={scale}
+                onChange={(e) => setScale(Number(e.target.value))}
+              />
+            </label>
+          </>
+        )}
       </div>
     </WKModal>
   );

--- a/packages/dmworkskillmarket/src/components/NewSkillModal.tsx
+++ b/packages/dmworkskillmarket/src/components/NewSkillModal.tsx
@@ -4,6 +4,7 @@ import { t, useI18n, WKButton, WKInput, WKModal } from "@octo/base";
 import type { Category, NewSkillForm } from "../types/skill";
 import { createSkill, getSkillTags, initUpload, uploadFile, uploadIcon, triggerParse, pollParse } from "../api/skillApi";
 import { MAX_SKILL_TAGS, validateSkillTag } from "../utils/format";
+import { getSkillAvatarColor, getSkillAvatarText } from "../utils/skillAvatar";
 import IconCropModal from "./IconCropModal";
 
 interface NewSkillModalProps {
@@ -37,6 +38,7 @@ export default function NewSkillModal({ visible, categories, onClose, onCreated 
     [categories],
   );
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const iconInputRef = useRef<HTMLInputElement | null>(null);
   const tagFieldRef = useRef<HTMLDivElement | null>(null);
   const abortRef = useRef(false);
   const [stage, setStage] = useState<UploadStage>("idle");
@@ -129,6 +131,19 @@ export default function NewSkillModal({ visible, categories, onClose, onCreated 
       width: rect.width,
       maxHeight,
     });
+  }
+
+  function handleIconClick() {
+    iconInputRef.current?.click();
+  }
+
+  function handleIconInputClick(event: React.MouseEvent<HTMLInputElement>) {
+    event.currentTarget.value = "";
+  }
+
+  function handleIconFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const f = event.currentTarget.files?.[0];
+    if (f) setIconCropFile(f);
   }
 
   useEffect(() => () => { abortRef.current = true; }, []);
@@ -488,22 +503,35 @@ export default function NewSkillModal({ visible, categories, onClose, onCreated 
           <h3 className="skill-market-form__section-title">{t("skillMarket.form.basicInfoSection")}</h3>
 
           <div className="skill-market-form__icon-row">
-            <label className="skill-market-icon-upload" title={t("skillMarket.form.uploadIcon")}>
-              <input
-                type="file"
-                accept="image/png,image/jpeg,image/svg+xml"
-                onChange={(event) => {
-                  const f = event.target.files?.[0];
-                  if (f) setIconCropFile(f);
-                  event.target.value = "";
-                }}
-              />
+            <button
+              type="button"
+              className="skill-market-icon-upload"
+              title={t("skillMarket.form.uploadIcon")}
+              onClick={handleIconClick}
+              aria-label={t("skillMarket.form.uploadIcon")}
+            >
               {iconPreview ? (
                 <img src={iconPreview} alt="icon" />
+              ) : name ? (
+                <span
+                  className="skill-market-icon-upload__default"
+                  style={{ background: getSkillAvatarColor(name) }}
+                >
+                  {getSkillAvatarText(name)}
+                </span>
               ) : (
                 <ImagePlus size={24} />
               )}
-            </label>
+            </button>
+            <input
+              ref={iconInputRef}
+              className="skill-market-icon-upload__input"
+              type="file"
+              accept="image/*"
+              multiple={false}
+              onClick={handleIconInputClick}
+              onChange={handleIconFileChange}
+            />
             <label>
               <span>{t("skillMarket.form.displayName")}<i className="skill-market-required">*</i></span>
               <WKInput value={displayName} onChange={(v: string) => setDisplayName(v.slice(0, 20))} placeholder={t("skillMarket.form.displayNamePlaceholder")} maxLength={20} />

--- a/packages/dmworkskillmarket/src/components/SearchBar.tsx
+++ b/packages/dmworkskillmarket/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Search, SlidersHorizontal } from "lucide-react";
+import { Check, Search, SlidersHorizontal, X } from "lucide-react";
 import { t, useI18n } from "@octo/base";
 import { getSkillTags } from "../api/skillApi";
 
@@ -111,6 +111,11 @@ const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
       onSelectedTagsChange?.([]);
     }
 
+    function clearSearch() {
+      onChange("");
+      inputRef.current?.focus();
+    }
+
     return (
       <div ref={rootRef} className="skill-market-search">
         <div className="skill-market-search__control">
@@ -124,6 +129,17 @@ const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
             aria-label={placeholder}
             autoFocus={autoFocus}
           />
+          {value && (
+            <button
+              type="button"
+              className="skill-market-search__clear"
+              aria-label={t("skillMarket.filter.clear")}
+              title={t("skillMarket.filter.clear")}
+              onClick={clearSearch}
+            >
+              <X size={18} aria-hidden="true" />
+            </button>
+          )}
           {tagEnabled && (
             <div className="skill-market-tag-filter">
               <button

--- a/packages/dmworkskillmarket/src/components/SkillCard.tsx
+++ b/packages/dmworkskillmarket/src/components/SkillCard.tsx
@@ -118,6 +118,10 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
     });
   }, [descriptionTooltip.visible, skill.description]);
 
+  function hideDescriptionTooltip() {
+    setDescriptionTooltip({ visible: false, style: {} });
+  }
+
   function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
     if (event.target instanceof HTMLElement && event.target.closest("button")) {
       return;
@@ -240,27 +244,50 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
           </span>
         </div>
         <div className="skill-market-card__footer-actions">
-          {(onEdit || onDelete) && (
-            <div className="skill-market-card__actions">
+          {!isOwnerCard && onInstall && (
+            <button
+              type="button"
+              className="skill-market-card__install"
+              onClick={() => {
+                hideDescriptionTooltip();
+                onInstall(skill);
+              }}
+            >
+              {t("skillMarket.card.install")}
+            </button>
+          )}
+          {isOwnerCard && (
+            <>
               {onEdit && (
-                <button type="button" aria-label={t("skillMarket.card.editAriaLabel", { values: { name: skill.name } })} title={t("skillMarket.common.edit")} onClick={() => onEdit(skill)}>
+                <button
+                  type="button"
+                  className="skill-market-card__action-button"
+                  aria-label={t("skillMarket.card.editAriaLabel", { values: { name: skill.name } })}
+                  title={t("skillMarket.common.edit")}
+                  onClick={() => {
+                    hideDescriptionTooltip();
+                    onEdit(skill);
+                  }}
+                >
                   <Pencil size={15} />
                 </button>
               )}
               {onDelete && (
-                <button type="button" className="is-danger" aria-label={t("skillMarket.card.deleteAriaLabel", { values: { name: skill.name } })} title={t("skillMarket.common.delete")} onClick={() => onDelete(skill)}>
+                <button
+                  type="button"
+                  className="skill-market-card__action-button is-danger"
+                  aria-label={t("skillMarket.card.deleteAriaLabel", { values: { name: skill.name } })}
+                  title={t("skillMarket.common.delete")}
+                  onClick={() => {
+                    hideDescriptionTooltip();
+                    onDelete(skill);
+                  }}
+                >
                   <Trash2 size={15} />
                 </button>
               )}
-            </div>
+            </>
           )}
-          <button
-            type="button"
-            className="skill-market-card__install"
-            onClick={() => onInstall?.(skill)}
-          >
-            {t("skillMarket.card.install")}
-          </button>
         </div>
       </div>
     </article>

--- a/packages/dmworkskillmarket/src/components/SkillCard.tsx
+++ b/packages/dmworkskillmarket/src/components/SkillCard.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
-import { Download, Eye, Pencil, Trash2 } from "lucide-react";
+import { Bot, Download, Eye, Pencil, Trash2 } from "lucide-react";
 import { t, useI18n } from "@octo/base";
 import type { Category, Skill } from "../types/skill";
 import { formatCount } from "../utils/format";
@@ -87,8 +87,13 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
   const isOwnerCard = Boolean(onEdit || onDelete);
   const descriptionTooltipId = `skill-card-desc-${skill.id}`;
   const displayName = skill.displayName || skill.name;
+  const hasSeparateCreator = Boolean(skill.creatorId && skill.ownerId && skill.creatorId !== skill.ownerId);
+  const creatorId = skill.creatorId || skill.ownerId;
   const creatorName = skill.creatorName || skill.ownerName;
-  const ownerLabel = `@${creatorName}`;
+  const isBotCreator = hasSeparateCreator && creatorId.endsWith("_bot");
+  const ownerLabel = hasSeparateCreator
+    ? (isBotCreator ? creatorName : `@${creatorName} · @${skill.ownerName}`)
+    : `@${skill.ownerName}`;
   const showOwner = skill.visibility !== "public";
   const ariaLabel = showOwner ? `${skill.name} ${ownerLabel}` : skill.name;
   const rawViewCount = skill.viewCount ?? 0;
@@ -182,11 +187,14 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
             )}
           </div>
           <div className="skill-market-card__meta-row">
-            <span className="skill-market-card__name" title={skill.name}>{skill.name}</span>
+            <span className="skill-market-card__name">{skill.name}</span>
             {showOwner && (
               <>
-                <span className="skill-market-card__meta-separator">·</span>
-                <span className="skill-market-card__owner" title={ownerLabel}>{ownerLabel}</span>
+                {!isBotCreator && <span className="skill-market-card__meta-separator">·</span>}
+                <span className="skill-market-card__owner" title={ownerLabel}>
+                  {isBotCreator && <Bot className="skill-market-card__owner-bot-icon" size={13} aria-hidden="true" />}
+                  {ownerLabel}
+                </span>
               </>
             )}
           </div>

--- a/packages/dmworkskillmarket/src/components/SkillCard.tsx
+++ b/packages/dmworkskillmarket/src/components/SkillCard.tsx
@@ -187,7 +187,9 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
             )}
           </div>
           <div className="skill-market-card__meta-row">
-            <span className="skill-market-card__name">{skill.name}</span>
+            <span className="skill-market-card__name" title={skill.name}>
+              {skill.name}
+            </span>
             {showOwner && (
               <>
                 {!isBotCreator && <span className="skill-market-card__meta-separator">·</span>}

--- a/packages/dmworkskillmarket/src/components/__tests__/EditSkillModal.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/EditSkillModal.test.tsx
@@ -88,8 +88,9 @@ describe("EditSkillModal", () => {
 
     expect(screen.getByDisplayValue("1.1.3")).toBeInTheDocument();
     expect(screen.getByDisplayValue("会议纪要整理")).toBeInTheDocument();
-    expect(screen.getByText("meeting-note-cleaner.zip")).toBeInTheDocument();
-    expect(screen.getByText(reuploadButton)).toBeInTheDocument();
+    expect(screen.getByText(/技能名|skillMarket\.upload\.skillName/)).toBeInTheDocument();
+    expect(screen.queryByText("meeting-note-cleaner.zip")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: reuploadButton })).toHaveTextContent(/重新上传|skillMarket\.upload\.reuploadShort/);
 
     fireEvent.change(screen.getByPlaceholderText(displayNamePlaceholder), { target: { value: "更新展示名" } });
     fireEvent.change(screen.getByLabelText(/分类|skillMarket\.form\.category/), { target: { value: "dev-tools" } });
@@ -158,7 +159,7 @@ describe("EditSkillModal", () => {
   it("can re-upload a Skill package and save the new file metadata", async () => {
     render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={vi.fn()} />);
 
-    fireEvent.click(screen.getByText(reuploadButton));
+    fireEvent.click(screen.getByRole("button", { name: reuploadButton }));
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText(selectNewZipLabel), {
@@ -168,7 +169,7 @@ describe("EditSkillModal", () => {
 
     // Wait for the upload/parse flow to complete
     await waitFor(() => {
-      expect(screen.getByText("updated-skill.skill")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("1.1.4")).toBeInTheDocument();
     });
 
     expect(api.initReupload).toHaveBeenCalledWith("meeting-note-cleaner", "updated-skill.skill", 3);
@@ -176,7 +177,6 @@ describe("EditSkillModal", () => {
     expect(api.triggerParse).toHaveBeenCalledWith("reupload-456");
     expect(api.pollParse).toHaveBeenCalledWith("task-456");
 
-    expect(screen.getByDisplayValue("1.1.4")).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText(changelogPlaceholder), { target: { value: "修复环境检测逻辑" } });
     fireEvent.click(screen.getByRole("button", { name: saveButton }));
 
@@ -207,7 +207,7 @@ describe("EditSkillModal", () => {
 
     render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={vi.fn()} />);
 
-    fireEvent.click(screen.getByText(reuploadButton));
+    fireEvent.click(screen.getByRole("button", { name: reuploadButton }));
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText(selectNewZipLabel), {
@@ -216,7 +216,7 @@ describe("EditSkillModal", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("updated-skill.zip")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("1.1.4")).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByPlaceholderText(changelogPlaceholder), { target: { value: "修复环境检测逻辑" } });
@@ -246,7 +246,7 @@ describe("EditSkillModal", () => {
 
     render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={vi.fn()} />);
 
-    fireEvent.click(screen.getByText(reuploadButton));
+    fireEvent.click(screen.getByRole("button", { name: reuploadButton }));
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText(selectNewZipLabel), {
@@ -258,7 +258,7 @@ describe("EditSkillModal", () => {
       expect(screen.getByText(/SKILL\.md 中的 name 必须保持为 meeting-note-cleaner，当前为 renamed-skill|skillMarket\.upload\.nameMismatch/)).toBeInTheDocument();
     });
 
-    expect(screen.getByText("meeting-note-cleaner.zip")).toBeInTheDocument();
+    expect(screen.queryByText("meeting-note-cleaner.zip")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: saveButton })).toBeDisabled();
     expect(api.updateSkill).not.toHaveBeenCalled();
   });
@@ -271,7 +271,7 @@ describe("EditSkillModal", () => {
 
     render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={vi.fn()} />);
 
-    fireEvent.click(screen.getByText(reuploadButton));
+    fireEvent.click(screen.getByRole("button", { name: reuploadButton }));
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText(selectNewZipLabel), {
@@ -283,7 +283,7 @@ describe("EditSkillModal", () => {
       expect(screen.getByText("zip 包中未找到 SKILL.md")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("meeting-note-cleaner.zip")).toBeInTheDocument();
+    expect(screen.queryByText("meeting-note-cleaner.zip")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: saveButton })).toBeDisabled();
     expect(api.updateSkill).not.toHaveBeenCalled();
   });

--- a/packages/dmworkskillmarket/src/components/__tests__/EditSkillModal.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/EditSkillModal.test.tsx
@@ -43,6 +43,17 @@ const skill: Skill = {
 };
 
 vi.mock("../../api/skillApi");
+vi.mock("react-avatar-editor", async () => {
+  const React = await import("react");
+  const AvatarEditor = React.forwardRef((_props: unknown, ref: React.ForwardedRef<{ getImageScaledToCanvas: () => HTMLCanvasElement }>) => {
+    React.useImperativeHandle(ref, () => ({
+      getImageScaledToCanvas: () => document.createElement("canvas"),
+    }));
+    return React.createElement("canvas", { "data-testid": "avatar-editor" });
+  });
+  AvatarEditor.displayName = "AvatarEditorMock";
+  return { default: AvatarEditor };
+});
 
 describe("EditSkillModal", () => {
   beforeEach(() => {
@@ -103,6 +114,42 @@ describe("EditSkillModal", () => {
     })));
     expect(onUpdated).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("opens the hidden icon file input and shows the crop dialog after selecting an image", async () => {
+    const { container } = render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={vi.fn()} />);
+    const iconInput = container.querySelector<HTMLInputElement>(".skill-market-icon-upload__input");
+    expect(iconInput).toBeTruthy();
+    const clickSpy = vi.spyOn(iconInput!, "click").mockImplementation(() => undefined);
+
+    fireEvent.click(screen.getByRole("button", { name: /上传图标|skillMarket\.form\.uploadIcon/ }));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(iconInput!, {
+      target: { files: [new File(["png"], "icon.png", { type: "image/png" })] },
+    });
+
+    expect(screen.getByRole("dialog", { name: /裁剪图标|skillMarket\.crop\.title/ })).toBeInTheDocument();
+  });
+
+  it("ignores duplicate save clicks while the update is pending", async () => {
+    let resolveUpdate: (value: typeof skill) => void = () => {};
+    vi.mocked(api.updateSkill).mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = resolve;
+      }) as ReturnType<typeof api.updateSkill>,
+    );
+    const onUpdated = vi.fn();
+    render(<EditSkillModal skill={skill} categories={categories} onClose={vi.fn()} onUpdated={onUpdated} />);
+
+    fireEvent.change(screen.getByPlaceholderText(displayNamePlaceholder), { target: { value: "更新展示名" } });
+    const save = screen.getByRole("button", { name: saveButton });
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    expect(api.updateSkill).toHaveBeenCalledTimes(1);
+    resolveUpdate({ ...skill, displayName: "更新展示名" });
+    await waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1));
   });
 
   it("blocks save while a tag validation error is visible", () => {

--- a/packages/dmworkskillmarket/src/components/__tests__/NewSkillModal.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/NewSkillModal.test.tsx
@@ -12,6 +12,17 @@ const categories: Category[] = [
 ];
 
 vi.mock("../../api/skillApi");
+vi.mock("react-avatar-editor", async () => {
+  const React = await import("react");
+  const AvatarEditor = React.forwardRef((_props: unknown, ref: React.ForwardedRef<{ getImageScaledToCanvas: () => HTMLCanvasElement }>) => {
+    React.useImperativeHandle(ref, () => ({
+      getImageScaledToCanvas: () => document.createElement("canvas"),
+    }));
+    return React.createElement("canvas", { "data-testid": "avatar-editor" });
+  });
+  AvatarEditor.displayName = "AvatarEditorMock";
+  return { default: AvatarEditor };
+});
 
 const selectZipLabel = /选择 Skill 包文件|skillMarket\.upload\.selectFileAriaLabel/;
 const displayNamePlaceholder = /请输入展示名称，最多20个字符|skillMarket\.form\.displayNamePlaceholder/;
@@ -115,6 +126,33 @@ describe("NewSkillModal", () => {
     });
     expect(onCreated).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("opens the hidden icon file input and shows the crop dialog after selecting an image", async () => {
+    const { container } = render(<NewSkillModal visible categories={categories} onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(selectZipLabel), {
+        target: { files: [skillFile()] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("skill-pack.skill")).toBeInTheDocument();
+    });
+
+    const iconInput = container.querySelector<HTMLInputElement>(".skill-market-icon-upload__input");
+    expect(iconInput).toBeTruthy();
+    const clickSpy = vi.spyOn(iconInput!, "click").mockImplementation(() => undefined);
+
+    fireEvent.click(screen.getByRole("button", { name: /上传图标|skillMarket\.form\.uploadIcon/ }));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(iconInput!, {
+      target: { files: [new File(["png"], "icon.png", { type: "image/png" })] },
+    });
+
+    expect(screen.getByRole("dialog", { name: /裁剪图标|skillMarket\.crop\.title/ })).toBeInTheDocument();
   });
 
   it("disables create until required fields are filled", async () => {

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
@@ -62,6 +62,46 @@ describe("SkillCard", () => {
     expect(screen.queryByText("@我")).not.toBeInTheDocument();
   });
 
+  it("shows creator and owner when they are different", () => {
+    render(
+      <SkillCard
+        skill={{
+          ...skill,
+          ownerId: "developer",
+          ownerName: "Developer",
+          creatorId: "bot-1",
+          creatorName: "CI Bot",
+        }}
+        categories={categories}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("@CI Bot · @Developer")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ci-helper @CI Bot · @Developer" })).toBeInTheDocument();
+  });
+
+  it("uses a bot icon instead of @ for bot creators", () => {
+    render(
+      <SkillCard
+        skill={{
+          ...skill,
+          ownerId: "developer",
+          ownerName: "Developer",
+          creatorId: "publisher_bot",
+          creatorName: "Publisher Bot",
+        }}
+        categories={categories}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Publisher Bot")).toBeInTheDocument();
+    expect(screen.queryByText("@Publisher Bot · @Developer")).not.toBeInTheDocument();
+    expect(screen.queryByText("@Developer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ci-helper Publisher Bot" })).toBeInTheDocument();
+  });
+
   it("supports keyboard open and exposed owner actions without opening the card", () => {
     const onOpen = vi.fn();
     const onEdit = vi.fn();

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
@@ -62,10 +62,11 @@ describe("SkillCard", () => {
     expect(screen.queryByText("@我")).not.toBeInTheDocument();
   });
 
-  it("supports keyboard open and icon actions without opening the card", () => {
+  it("supports keyboard open and exposed owner actions without opening the card", () => {
     const onOpen = vi.fn();
     const onEdit = vi.fn();
     const onDelete = vi.fn();
+    const onInstall = vi.fn();
 
     render(
       <SkillCard
@@ -74,11 +75,15 @@ describe("SkillCard", () => {
         onOpen={onOpen}
         onEdit={onEdit}
         onDelete={onDelete}
+        onInstall={onInstall}
       />,
     );
 
     fireEvent.keyDown(screen.getByRole("button", { name: "ci-helper @我" }), { key: "Enter" });
     expect(onOpen).toHaveBeenCalledWith(skill);
+
+    expect(screen.queryByRole("button", { name: "安装" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "更多" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "编辑 ci-helper" }));
     expect(onEdit).toHaveBeenCalledWith(skill);
@@ -91,6 +96,7 @@ describe("SkillCard", () => {
     fireEvent.keyDown(screen.getByRole("button", { name: "编辑 ci-helper" }), { key: "Enter" });
     fireEvent.keyDown(screen.getByRole("button", { name: "删除 ci-helper" }), { key: " " });
     expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onInstall).not.toHaveBeenCalled();
   });
 
   it("shows the full description tooltip only when the description is truncated", async () => {
@@ -106,6 +112,27 @@ describe("SkillCard", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent(skill.description);
 
     fireEvent.mouseLeave(description);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("hides the description tooltip before using owner actions", async () => {
+    render(
+      <SkillCard
+        skill={skill}
+        categories={categories}
+        onOpen={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    const description = screen.getByText(skill.description);
+    Object.defineProperty(description, "scrollHeight", { configurable: true, value: 80 });
+    Object.defineProperty(description, "clientHeight", { configurable: true, value: 42 });
+
+    fireEvent.mouseEnter(description);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(skill.description);
+
+    fireEvent.click(screen.getByRole("button", { name: "编辑 ci-helper" }));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 

--- a/packages/dmworkskillmarket/src/i18n/en-US.json
+++ b/packages/dmworkskillmarket/src/i18n/en-US.json
@@ -153,6 +153,7 @@
     "reselect": "Reselect file",
     "reupload": "Re-upload Skill package",
     "reuploadShort": "Re-upload",
+    "skillName": "Skill name",
     "parsed": "SKILL.md parsed",
     "parsedWithName": "SKILL.md parsed · English name {{name}}",
     "currentPackage": "Current Skill package",

--- a/packages/dmworkskillmarket/src/i18n/en-US.json
+++ b/packages/dmworkskillmarket/src/i18n/en-US.json
@@ -60,8 +60,8 @@
     "label": "Sort:",
     "comprehensive": "Recommended",
     "latest": "Latest",
-    "views": "Most viewed",
-    "downloads": "Most downloaded"
+    "views": "Views",
+    "downloads": "Downloads"
   },
   "card": {
     "editAriaLabel": "Edit {{name}}",

--- a/packages/dmworkskillmarket/src/i18n/en-US.json
+++ b/packages/dmworkskillmarket/src/i18n/en-US.json
@@ -57,7 +57,6 @@
   },
   "sort": {
     "ariaLabel": "Skill sort",
-    "label": "Sort:",
     "comprehensive": "Recommended",
     "latest": "Latest",
     "views": "Views",

--- a/packages/dmworkskillmarket/src/i18n/zh-CN.json
+++ b/packages/dmworkskillmarket/src/i18n/zh-CN.json
@@ -59,9 +59,9 @@
     "ariaLabel": "Skill 排序",
     "label": "排序：",
     "comprehensive": "综合",
-    "latest": "最新发布",
-    "views": "浏览最多",
-    "downloads": "下载最多"
+    "latest": "最新",
+    "views": "浏览",
+    "downloads": "下载"
   },
   "card": {
     "editAriaLabel": "编辑 {{name}}",

--- a/packages/dmworkskillmarket/src/i18n/zh-CN.json
+++ b/packages/dmworkskillmarket/src/i18n/zh-CN.json
@@ -57,7 +57,6 @@
   },
   "sort": {
     "ariaLabel": "Skill 排序",
-    "label": "排序：",
     "comprehensive": "综合",
     "latest": "最新",
     "views": "浏览",

--- a/packages/dmworkskillmarket/src/i18n/zh-CN.json
+++ b/packages/dmworkskillmarket/src/i18n/zh-CN.json
@@ -153,6 +153,7 @@
     "reselect": "重新选择文件",
     "reupload": "重新上传 Skill 包",
     "reuploadShort": "重新上传",
+    "skillName": "技能名",
     "parsed": "已解析 SKILL.md",
     "parsedWithName": "已解析 SKILL.md · 英文名 {{name}}",
     "currentPackage": "当前 Skill 包",

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -791,6 +791,9 @@
 }
 
 .skill-market-card__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   flex: 0 1 auto;
   max-width: 112px;
   overflow: hidden;
@@ -798,6 +801,10 @@
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.skill-market-card__owner-bot-icon {
+  flex: 0 0 auto;
 }
 
 .skill-market-card__meta-separator {

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -213,8 +213,11 @@
 }
 
 .skill-market-toolbar {
-  display: grid;
-  gap: var(--wk-sp-1);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--wk-sp-2);
+  flex-wrap: wrap;
   padding: var(--wk-sp-3) var(--wk-sp-4);
   border-bottom: 1px solid var(--wk-border-subtle);
 }
@@ -414,6 +417,7 @@
 
 .skill-market-category-strip {
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   row-gap: var(--wk-sp-1);
   column-gap: clamp(var(--wk-sp-1), 0.6vw, var(--wk-sp-3));
@@ -447,41 +451,57 @@
 }
 
 .skill-market-sort {
-  display: flex;
-  align-items: center;
-  gap: var(--wk-sp-2);
-  min-height: 24px;
-  color: var(--wk-text-tertiary);
-  font: 400 13px/1 var(--wk-font-sans);
+  display: inline-flex;
+  flex: 0 0 auto;
+  min-width: 0;
 }
 
 .skill-market-sort__options {
   display: inline-flex;
   align-items: center;
   gap: var(--wk-sp-1);
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 2px;
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-full);
+  background: var(--wk-bg-base);
+  box-shadow: inset 0 0 0 1px var(--wk-bg-surface);
 }
 
 .skill-market-sort button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  flex: 0 0 auto;
+  height: 28px;
+  min-width: 54px;
+  padding: 0 var(--wk-sp-3);
   border: 0;
+  border-radius: var(--wk-r-full);
   background: transparent;
   color: var(--wk-text-secondary);
-  font: 400 13px/1 var(--wk-font-sans);
+  font: 500 12px/1 var(--wk-font-sans);
   cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--wk-dur-fast) var(--wk-ease),
+    color var(--wk-dur-fast) var(--wk-ease),
+    box-shadow var(--wk-dur-fast) var(--wk-ease);
 }
 
 .skill-market-sort button:hover,
-.skill-market-sort button:focus-visible,
-.skill-market-sort button.is-active {
+.skill-market-sort button:focus-visible {
   outline: none;
+  background: var(--wk-bg-hover);
   color: var(--wk-color-accent);
 }
 
 .skill-market-sort button.is-active {
+  background: var(--wk-bg-surface);
+  color: var(--wk-color-accent);
+  box-shadow: var(--wk-shadow-sm);
   font-weight: 600;
-}
-
-.skill-market-sort__separator {
-  color: var(--wk-text-disabled);
 }
 
 .skill-market-category-label {
@@ -567,14 +587,17 @@
 .skill-market-result-summary {
   display: flex;
   align-items: center;
-  gap: var(--wk-sp-2);
-  min-height: 24px;
+  justify-content: space-between;
+  gap: var(--wk-sp-3);
+  flex-wrap: wrap;
+  min-height: 36px;
   margin-bottom: var(--wk-sp-3);
   color: var(--wk-text-tertiary);
   font: 500 13px/1.4 var(--wk-font-sans);
 }
 
 .skill-market-result-summary__total {
+  flex: 0 0 auto;
   color: var(--wk-text-secondary);
 }
 

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -269,8 +269,34 @@
   font: 500 13px/1 var(--wk-font-sans);
 }
 
+.skill-market-search__control > input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
 .skill-market-search__control > input::placeholder {
   color: var(--wk-text-tertiary);
+}
+
+.skill-market-search__clear {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-right: var(--wk-sp-1);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-text-tertiary);
+  cursor: pointer;
+}
+
+.skill-market-search__clear:hover,
+.skill-market-search__clear:focus-visible {
+  outline: none;
+  background: var(--wk-bg-item-hover);
+  color: var(--wk-text-secondary);
 }
 
 .skill-market-tag-filter {
@@ -2077,6 +2103,32 @@
   border-style: dashed;
 }
 
+.skill-market-upload-file--identity {
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  min-height: 56px;
+  padding: var(--wk-sp-2);
+  background: var(--wk-bg-base);
+}
+
+.skill-market-upload-file__identity {
+  display: grid;
+  align-content: center;
+  min-width: 0;
+  gap: 3px;
+}
+
+.skill-market-upload-file__identity span {
+  margin-top: 0;
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.skill-market-upload-file__identity strong {
+  min-width: 0;
+  line-height: 1.25;
+}
+
 .skill-market-upload-file strong,
 .skill-market-upload-file span {
   display: block;
@@ -2095,7 +2147,23 @@
   font-size: 12px;
 }
 
+.skill-market-upload-file .skill-market-upload-file__identity-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-top: 0;
+  border-radius: var(--wk-r-sm);
+  background: var(--wk-bg-surface);
+  color: var(--wk-icon-muted);
+}
+
 .skill-market-upload-file button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   height: 28px;
   padding: 0 var(--wk-sp-2);
   border: 0;
@@ -2317,9 +2385,17 @@
     grid-template-columns: 20px minmax(0, 1fr);
   }
 
+  .skill-market-upload-file--identity {
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+  }
+
   .skill-market-upload-file button {
     grid-column: 2;
     justify-self: start;
+  }
+
+  .skill-market-upload-file--identity button {
+    justify-self: end;
   }
 
   .skill-market-grid,

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -2484,24 +2484,39 @@
   cursor: pointer;
   overflow: hidden;
   transition: border-color var(--wk-dur-fast) var(--wk-ease);
+  padding: 0;
 }
 
 .skill-market-icon-upload:hover {
   border-color: var(--wk-border-strong);
 }
 
-.skill-market-icon-upload input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+.skill-market-icon-upload:focus-visible {
+  outline: 2px solid var(--wk-border-glow);
+  outline-offset: 2px;
+}
+
+.skill-market-icon-upload__input {
+  display: none;
 }
 
 .skill-market-icon-upload img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.skill-market-icon-upload__default {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  color: #fff;
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: 0.5px;
 }
 
 /* --- Readonly field --- */

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -885,14 +885,7 @@
   border-color: var(--wk-border-strong);
 }
 
-.skill-market-card__actions {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  gap: var(--wk-sp-1);
-}
-
-.skill-market-card__actions button {
+.skill-market-card__action-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -907,14 +900,20 @@
     color var(--wk-dur-fast) var(--wk-ease);
 }
 
-.skill-market-card__actions button:hover,
-.skill-market-card__actions button:focus-visible {
+.skill-market-card__action-button:hover,
+.skill-market-card__action-button:focus-visible {
   outline: none;
   background: var(--wk-bg-hover);
+  border-color: var(--wk-border-strong);
   color: var(--wk-text-primary);
 }
 
-.skill-market-card__actions button.is-danger {
+.skill-market-card__action-button.is-danger {
+  color: var(--wk-color-error);
+}
+
+.skill-market-card__action-button.is-danger:hover,
+.skill-market-card__action-button.is-danger:focus-visible {
   color: var(--wk-color-error);
 }
 

--- a/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
+++ b/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   AlertCircle,
+  ArrowDown,
   Bot,
   ChevronDown,
   PackageOpen,
@@ -25,11 +26,11 @@ import SkillDetailModal from "../components/SkillDetailModal";
 type TabId = "skills" | "mine";
 
 const TOAST_DURATION = 3000;
-const SORT_OPTIONS: Array<{ value: SkillSort; labelKey: string }> = [
+const SORT_OPTIONS: Array<{ value: SkillSort; labelKey: string; descending?: boolean }> = [
   { value: "comprehensive", labelKey: "skillMarket.sort.comprehensive" },
   { value: "latest", labelKey: "skillMarket.sort.latest" },
-  { value: "views", labelKey: "skillMarket.sort.views" },
-  { value: "downloads", labelKey: "skillMarket.sort.downloads" },
+  { value: "downloads", labelKey: "skillMarket.sort.downloads", descending: true },
+  { value: "views", labelKey: "skillMarket.sort.views", descending: true },
 ];
 
 export default function SkillListPage() {
@@ -237,50 +238,45 @@ export default function SkillListPage() {
         }
       >
         {!mine && (
-          <>
-            <CategoryChips
-              categories={list.categories}
-              activeId={list.categoryId}
-              onChange={list.setCategoryId}
-            />
-            <div
-              className="skill-market-sort"
-              aria-label={t("skillMarket.sort.ariaLabel")}
-            >
-              <span className="skill-market-sort__label">
-                {t("skillMarket.sort.label")}
-              </span>
-              <div className="skill-market-sort__options">
-                {SORT_OPTIONS.map((option, index) => (
-                  <React.Fragment key={option.value}>
-                    {index > 0 && (
-                      <span className="skill-market-sort__separator">·</span>
-                    )}
-                    <button
-                      type="button"
-                      className={
-                        sort === option.value ? "is-active" : undefined
-                      }
-                      onClick={() => setSort(option.value)}
-                    >
-                      {t(option.labelKey)}
-                    </button>
-                  </React.Fragment>
-                ))}
-              </div>
-            </div>
-          </>
+          <CategoryChips
+            categories={list.categories}
+            activeId={list.categoryId}
+            onChange={list.setCategoryId}
+          />
         )}
       </section>
 
       <main className="skill-market-content">
         {!list.loading && !list.error && (
-          <div className="skill-market-result-summary" aria-live="polite">
-            <span className="skill-market-result-summary__total">
+          <div className="skill-market-result-summary">
+            <span className="skill-market-result-summary__total" aria-live="polite">
               {t("skillMarket.list.totalCount", {
                 values: { count: list.total },
               })}
             </span>
+            {!mine && (
+              <div
+                className="skill-market-sort"
+                aria-label={t("skillMarket.sort.ariaLabel")}
+              >
+                <div className="skill-market-sort__options">
+                  {SORT_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={
+                        sort === option.value ? "is-active" : undefined
+                      }
+                      aria-pressed={sort === option.value}
+                      onClick={() => setSort(option.value)}
+                    >
+                      <span>{t(option.labelKey)}</span>
+                      {option.descending && <ArrowDown size={12} aria-hidden="true" />}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
         {list.loading && (

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -206,7 +206,7 @@ describe("SkillListPage", () => {
     ).toBeInTheDocument();
     vi.mocked(api.getSkills).mockClear();
 
-    fireEvent.click(screen.getByRole("button", { name: "浏览最多" }));
+    fireEvent.click(screen.getByRole("button", { name: "浏览" }));
 
     await waitFor(() => {
       expect(api.getSkills).toHaveBeenCalledWith(

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -124,14 +124,21 @@ describe("SkillListPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("hides category chips on the mine tab and shows owner actions", async () => {
-    render(<SkillListPage />);
+  it("shows exposed owner actions only on the mine tab", async () => {
+    const { container } = render(<SkillListPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "meeting-note-cleaner @我" })
+    ).toBeInTheDocument();
+    expect(container.querySelector(".skill-market-card__action-button")).not.toBeInTheDocument();
+
     await switchToMineTab();
 
     expect(screen.queryByLabelText(categoryAriaLabel)).not.toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "meeting-note-cleaner @我" })
     ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^安装$/ })).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: editSkillName })
     ).toBeInTheDocument();
@@ -327,11 +334,7 @@ describe("SkillListPage", () => {
     render(<SkillListPage />);
     await switchToMineTab();
 
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: deleteSkillName,
-      })
-    );
+    fireEvent.click(await screen.findByRole("button", { name: deleteSkillName }));
     expect(screen.getByText(deleteConfirmText)).toBeInTheDocument();
     fireEvent.click(
       screen.getAllByRole("button", { name: deleteButtonName }).at(-1)!
@@ -351,11 +354,7 @@ describe("SkillListPage", () => {
     );
     expect(await screen.findByText(skill.description)).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getAllByRole("button", {
-        name: deleteSkillName,
-      })[1]
-    );
+    fireEvent.click(screen.getAllByRole("button", { name: deleteSkillName }).at(-1)!);
     expect(screen.getByText(deleteConfirmText)).toBeInTheDocument();
 
     fireEvent.click(
@@ -403,11 +402,7 @@ describe("SkillListPage", () => {
     );
     expect(await screen.findByText(skill.description)).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getAllByRole("button", {
-        name: editSkillName,
-      })[1]
-    );
+    fireEvent.click(screen.getAllByRole("button", { name: editSkillName }).at(-1)!);
     fireEvent.change(screen.getByPlaceholderText(displayNamePlaceholder), {
       target: { value: updatedSkill.displayName },
     });


### PR DESCRIPTION
## Summary
- add segmented skill sort controls
- expose owner edit/delete actions on owned skill cards
- refine skill edit/search controls and icon upload flow
- preserve latest upstream main as the base branch

## Tests
- pnpm --filter @dmwork/skillmarket test