### PR TITLE
fix(skill-market): align marketplace agent prompts

### DIFF
--- a/packages/dmworkskillmarket/src/components/InstallPromptModal.tsx
+++ b/packages/dmworkskillmarket/src/components/InstallPromptModal.tsx
@@ -1,7 +1,4 @@
 import React, { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import rehypeSanitize from "rehype-sanitize";
-import remarkGfm from "remark-gfm";
 import { Check, Copy, Terminal } from "lucide-react";
 import { t, useI18n, WKApp, WKButton, WKModal } from "@octo/base";
 import { buildInstallPrompt, resolveAPIBaseURL } from "../utils/installPrompt";
@@ -59,9 +56,7 @@ export default function InstallPromptModal({ skillId, onClose }: InstallPromptMo
       }
     >
       <div className="skill-market-prompt-modal__body">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-          {prompt}
-        </ReactMarkdown>
+        <pre className="skill-market-prompt-modal__pre">{prompt}</pre>
       </div>
     </WKModal>
   );

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -290,7 +290,7 @@ describe("SkillListPage", () => {
         expect.stringContaining("Space ID：`space-123`")
       );
       expect(writeText).toHaveBeenCalledWith(
-        expect.stringContaining("API 地址：`http://localhost:3000/api`")
+        expect.stringContaining("API 地址：`http://localhost:3000`")
       );
       expect(writeText).toHaveBeenCalledWith(
         expect.not.stringContaining("<space-id>")

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
@@ -6,6 +6,7 @@ describe("getBotPublishPrompt", () => {
     const prompt = getBotPublishPrompt({
       spaceId: "space-1",
       apiBaseUrl: "https://octo.example.com/api",
+      cliDistTag: "next",
     });
 
     expect(prompt).toContain("请上传要上架的 `.zip` / `.skill` 包");
@@ -19,6 +20,7 @@ describe("getBotPublishPrompt", () => {
     expect(prompt).not.toContain("<skill-zip-path>");
     expect(prompt).toContain("Space ID：`space-1`");
     expect(prompt).toContain('`skills.md` 中“Publish as a Bot”流程');
+    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@next");
     expect(prompt).toContain("使用用户提供的附件、Skill 包路径或");
     expect(prompt).toContain("以上 Space ID、API 地址和可见范围是本次操作的权威输入");
     expect(prompt).not.toContain("在上传或覆盖现有 Skill 前，向用户展示");

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getBotPublishPrompt } from "./botPublishPrompt";
+
+describe("getBotPublishPrompt", () => {
+  it("requires the user to provide an accessible package before publishing", () => {
+    const prompt = getBotPublishPrompt({
+      spaceId: "space-1",
+      apiBaseUrl: "https://octo.example.com/api",
+    });
+
+    expect(prompt).toContain("请上传要上架的 `.zip` / `.skill` 包");
+    expect(prompt).toContain("不要解释正在读取 Skill");
+    expect(prompt).toContain("逐步播报检查过程");
+    expect(prompt).toContain("Skill 包或 Skill 目录位置");
+    expect(prompt).not.toContain("点击输入框旁");
+    expect(prompt).not.toContain("拖入当前对话");
+    expect(prompt).toContain("在用户明确提供附件、Skill 包路径或 Skill 目录路径前");
+    expect(prompt).toContain("没有 version，使用 `1.0.0`");
+    expect(prompt).toContain("<skill-package-path>");
+    expect(prompt).not.toContain("<skill-zip-path>");
+    expect(prompt).toContain("Space ID：`space-1`");
+    expect(prompt).toContain("Prompt 中所有 Space ID 必须与 `space-1` 完全一致");
+    expect(prompt).toContain('`skills.md` 中“Publish as a Bot”流程');
+  });
+});

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
@@ -14,12 +14,14 @@ describe("getBotPublishPrompt", () => {
     expect(prompt).toContain("Skill 包或 Skill 目录位置");
     expect(prompt).not.toContain("点击输入框旁");
     expect(prompt).not.toContain("拖入当前对话");
-    expect(prompt).toContain("在用户明确提供附件、Skill 包路径或 Skill 目录路径前");
-    expect(prompt).toContain("没有 version，使用 `1.0.0`");
-    expect(prompt).toContain("<skill-package-path>");
+    expect(prompt).toContain("用户提供前不要搜索磁盘或猜测路径");
+    expect(prompt).not.toContain("<skill-package-path>");
     expect(prompt).not.toContain("<skill-zip-path>");
     expect(prompt).toContain("Space ID：`space-1`");
-    expect(prompt).toContain("Prompt 中所有 Space ID 必须与 `space-1` 完全一致");
     expect(prompt).toContain('`skills.md` 中“Publish as a Bot”流程');
+    expect(prompt).toContain("使用用户提供的附件、Skill 包路径或");
+    expect(prompt).toContain("以上 Space ID、API 地址和可见范围是本次操作的权威输入");
+    expect(prompt).not.toContain("在上传或覆盖现有 Skill 前，向用户展示");
+    expect(prompt).not.toContain("go install github.com/Mininglamp-OSS/octo-cli");
   });
 });

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.test.ts
@@ -6,7 +6,6 @@ describe("getBotPublishPrompt", () => {
     const prompt = getBotPublishPrompt({
       spaceId: "space-1",
       apiBaseUrl: "https://octo.example.com/api",
-      cliDistTag: "next",
     });
 
     expect(prompt).toContain("请上传要上架的 `.zip` / `.skill` 包");
@@ -20,7 +19,6 @@ describe("getBotPublishPrompt", () => {
     expect(prompt).not.toContain("<skill-zip-path>");
     expect(prompt).toContain("Space ID：`space-1`");
     expect(prompt).toContain('`skills.md` 中“Publish as a Bot”流程');
-    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@next");
     expect(prompt).toContain("使用用户提供的附件、Skill 包路径或");
     expect(prompt).toContain("以上 Space ID、API 地址和可见范围是本次操作的权威输入");
     expect(prompt).not.toContain("在上传或覆盖现有 Skill 前，向用户展示");

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
@@ -1,11 +1,15 @@
+import { getOctoCliInstallCommand, type OctoCliDistTag } from "./octoCliInstall";
+
 export interface BotPublishPromptValues {
   spaceId?: string;
   apiBaseUrl?: string;
+  cliDistTag?: OctoCliDistTag;
 }
 
 export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string {
   const spaceId = values.spaceId?.trim() || "<space-id>";
   const apiBaseUrl = values.apiBaseUrl?.trim() || "<api-base-url>";
+  const installCommand = getOctoCliInstallCommand(values.cliDistTag);
 
   return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 上架到 OCTO Marketplace。
 
@@ -20,7 +24,7 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
 不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。用户提供前不要搜索磁盘或猜测路径。
 
 1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
-   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
+   \`${installCommand}\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
@@ -13,18 +13,14 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
 - API 地址：\`${apiBaseUrl}\`
 - 可见范围：\`space\`
 
-先检查当前消息是否已经包含 Skill 包附件或路径。如果没有，只向用户发送：
+如果当前消息没有 Skill 包附件或路径，只回复：
 
 > 请上传要上架的 \`.zip\` / \`.skill\` 包，或提供 Agent 当前运行环境可访问的 Skill 包或 Skill 目录位置。
 
-不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。在用户明确提供附件、Skill 包路径或 Skill 目录路径前，
-不要搜索磁盘、猜测路径或开始上传。收到后确认输入存在；文件必须为 \`.zip\` / \`.skill\`，目录根部必须包含
-\`SKILL.md\`。将解析后的绝对路径记为 \`<skill-package-path>\`。如果 \`SKILL.md\` 没有 version，使用 \`1.0.0\`。
+不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。用户提供前不要搜索磁盘或猜测路径。
 
-1. 运行 \`octo-cli version\`。如果未安装，优先运行
-   \`npm install -g @mininglamp-oss/octo-cli@latest\`；也可以运行
-   \`go install github.com/Mininglamp-OSS/octo-cli/cmd/octo-cli@latest\`。
-   如果当前版本不包含 \`octo-marketplace\` Skill，先升级到最新版。
+1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
@@ -34,7 +30,7 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
    <read-token> | octo-cli auth login --with-token --profile space-${spaceId} --space ${spaceId} --api-base-url ${apiBaseUrl}
    \`\`\`
 
-   不得打印、回显或把 Token 放入命令参数。
+   不得输出 Token 或把 Token 放入命令参数。
 
 3. 使用选定的 Profile 运行以下命令，读取并遵循最新的 \`octo-marketplace\` Skill：
 
@@ -42,33 +38,6 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
    octo-cli skills octo-marketplace --profile <profile>
    \`\`\`
 
-4. 按该 Skill 的 \`skills.md\` 中“Publish as a Bot”流程完成上架，使用 \`<skill-package-path>\`。
-   用户提供的 Skill 包、以上 Space ID、API 地址和可见范围是本次操作的权威输入。
-   Prompt 中所有 Space ID 必须与 \`${spaceId}\` 完全一致。不要自行改写输入，也不要自行拼接
-   Marketplace 上传地址。
-
-5. 在上传或覆盖现有 Skill 前，向用户展示：
-   - Skill 名称和版本；
-   - Skill 包路径、文件大小和 SHA-256；
-   - 可见范围；
-   - 本次操作是首次上架还是更新已有 Skill。
-
-   取得明确确认后再继续。
-
-6. 完成后验证：
-   - Skill ID、名称和版本；
-   - 可见范围；
-   - 文件信息和校验和；
-   - Marketplace 详情和下载接口；
-   - 没有创建重复的同名 Skill。
-
-   失败时不得创建或覆盖 Skill；已存在版本应保持不变。
-
-7. 告知用户：
-   - Skill ID、名称和版本；
-   - Space ID 和可见范围；
-   - 上架类型：首次上架或版本更新；
-   - 最终状态。
-
-   除索取 Skill 包和第 5 步确认外，只有在 CLI/Skill 明确无法继续时才要求用户介入。`;
+4. 按该 Skill 的 \`skills.md\` 中“Publish as a Bot”流程，使用用户提供的附件、Skill 包路径或
+   Skill 目录路径完成上架。以上 Space ID、API 地址和可见范围是本次操作的权威输入。`;
 }

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
@@ -1,15 +1,11 @@
-import { getOctoCliInstallCommand, type OctoCliDistTag } from "./octoCliInstall";
-
 export interface BotPublishPromptValues {
   spaceId?: string;
   apiBaseUrl?: string;
-  cliDistTag?: OctoCliDistTag;
 }
 
 export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string {
   const spaceId = values.spaceId?.trim() || "<space-id>";
   const apiBaseUrl = values.apiBaseUrl?.trim() || "<api-base-url>";
-  const installCommand = getOctoCliInstallCommand(values.cliDistTag);
 
   return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 上架到 OCTO Marketplace。
 
@@ -24,7 +20,7 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
 不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。用户提供前不要搜索磁盘或猜测路径。
 
 1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
-   \`${installCommand}\`。
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，

--- a/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/botPublishPrompt.ts
@@ -9,10 +9,17 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
 
   return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 上架到 OCTO Marketplace。
 
-- Skill 包路径：\`<skill-zip-path>\`
 - Space ID：\`${spaceId}\`
 - API 地址：\`${apiBaseUrl}\`
 - 可见范围：\`space\`
+
+先检查当前消息是否已经包含 Skill 包附件或路径。如果没有，只向用户发送：
+
+> 请上传要上架的 \`.zip\` / \`.skill\` 包，或提供 Agent 当前运行环境可访问的 Skill 包或 Skill 目录位置。
+
+不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。在用户明确提供附件、Skill 包路径或 Skill 目录路径前，
+不要搜索磁盘、猜测路径或开始上传。收到后确认输入存在；文件必须为 \`.zip\` / \`.skill\`，目录根部必须包含
+\`SKILL.md\`。将解析后的绝对路径记为 \`<skill-package-path>\`。如果 \`SKILL.md\` 没有 version，使用 \`1.0.0\`。
 
 1. 运行 \`octo-cli version\`。如果未安装，优先运行
    \`npm install -g @mininglamp-oss/octo-cli@latest\`；也可以运行
@@ -29,15 +36,16 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
 
    不得打印、回显或把 Token 放入命令参数。
 
-3. 使用选定的 Profile 运行以下命令，读取并遵循最新的 octo-marketplace Skill：
+3. 使用选定的 Profile 运行以下命令，读取并遵循最新的 \`octo-marketplace\` Skill：
 
    \`\`\`bash
    octo-cli skills octo-marketplace --profile <profile>
    \`\`\`
 
-4. 按该 Skill 的“Publish a Skill”流程完成上架。
-   以上 Skill 包路径、Space ID、API 地址和可见范围是本次操作的权威输入。
-   不要自行改写输入，也不要自行拼接 Marketplace 上传地址。
+4. 按该 Skill 的 \`skills.md\` 中“Publish as a Bot”流程完成上架，使用 \`<skill-package-path>\`。
+   用户提供的 Skill 包、以上 Space ID、API 地址和可见范围是本次操作的权威输入。
+   Prompt 中所有 Space ID 必须与 \`${spaceId}\` 完全一致。不要自行改写输入，也不要自行拼接
+   Marketplace 上传地址。
 
 5. 在上传或覆盖现有 Skill 前，向用户展示：
    - Skill 名称和版本；
@@ -57,11 +65,10 @@ export function getBotPublishPrompt(values: BotPublishPromptValues = {}): string
    失败时不得创建或覆盖 Skill；已存在版本应保持不变。
 
 7. 告知用户：
-   - octo-cli 版本和使用的 Profile；
    - Skill ID、名称和版本；
    - Space ID 和可见范围；
    - 上架类型：首次上架或版本更新；
    - 最终状态。
 
-   只有在 CLI/Skill 明确无法继续时才要求用户介入。`;
+   除索取 Skill 包和第 5 步确认外，只有在 CLI/Skill 明确无法继续时才要求用户介入。`;
 }

--- a/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
@@ -2,28 +2,38 @@ import { describe, expect, it } from "vitest";
 import { buildInstallPrompt, resolveAPIBaseURL } from "./installPrompt";
 
 describe("resolveAPIBaseURL", () => {
-  it("preserves the Web /api deployment prefix", () => {
+  it("uses the site origin instead of the core Web /api prefix", () => {
     expect(resolveAPIBaseURL("/api/v1/", "https://im.deepminer.com.cn")).toBe(
-      "https://im.deepminer.com.cn/api",
+      "https://im.deepminer.com.cn",
     );
   });
 
-  it("removes only the API version from an absolute runtime URL", () => {
+  it("uses the gateway origin from an absolute runtime URL", () => {
     expect(resolveAPIBaseURL("https://api.example.com/v1/", "https://app.example.com")).toBe(
       "https://api.example.com",
+    );
+  });
+
+  it("keeps the Vite origin so marketplace paths route through its proxy", () => {
+    expect(resolveAPIBaseURL("/api/v1/", "http://localhost:3000")).toBe(
+      "http://localhost:3000",
     );
   });
 });
 
 describe("buildInstallPrompt", () => {
-  it("includes deterministic Space profile selection and login", () => {
+  it("delegates installation to the bundled octo-marketplace skill", () => {
     const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com");
 
     expect(prompt).toContain("- Skill ID：`skill-123`");
     expect(prompt).toContain("- Space ID：`space-456`");
     expect(prompt).toContain("- API 地址：`https://octo.example.com`");
+    expect(prompt).toContain("octo-cli skills octo-marketplace");
+    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@latest");
     expect(prompt).toContain("octo-cli auth list");
+    expect(prompt).toContain("不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程");
     expect(prompt).toContain("--profile space-space-456 --space space-456 --api-base-url https://octo.example.com");
-    expect(prompt).toContain("--profile <profile> --install <skills-root>");
+    expect(prompt).toContain('`skills.md` 中“Install”流程');
+    expect(prompt).toContain("不要自行拼接 Marketplace 下载地址");
   });
 });

--- a/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
@@ -34,6 +34,7 @@ describe("buildInstallPrompt", () => {
     expect(prompt).toContain("不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程");
     expect(prompt).toContain("--profile space-space-456 --space space-456 --api-base-url https://octo.example.com");
     expect(prompt).toContain('`skills.md` 中“Install”流程');
-    expect(prompt).toContain("不要自行拼接 Marketplace 下载地址");
+    expect(prompt).not.toContain("在下载或覆盖文件前，向用户展示");
+    expect(prompt).not.toContain("go install github.com/Mininglamp-OSS/octo-cli");
   });
 });

--- a/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
@@ -23,23 +23,18 @@ describe("resolveAPIBaseURL", () => {
 
 describe("buildInstallPrompt", () => {
   it("delegates installation to the bundled octo-marketplace skill", () => {
-    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com", "next");
+    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com");
 
     expect(prompt).toContain("- Skill ID：`skill-123`");
     expect(prompt).toContain("- Space ID：`space-456`");
     expect(prompt).toContain("- API 地址：`https://octo.example.com`");
     expect(prompt).toContain("octo-cli skills octo-marketplace");
-    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@next");
+    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@latest");
     expect(prompt).toContain("octo-cli auth list");
     expect(prompt).toContain("不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程");
     expect(prompt).toContain("--profile space-space-456 --space space-456 --api-base-url https://octo.example.com");
     expect(prompt).toContain('`skills.md` 中“Install”流程');
     expect(prompt).not.toContain("在下载或覆盖文件前，向用户展示");
     expect(prompt).not.toContain("go install github.com/Mininglamp-OSS/octo-cli");
-  });
-
-  it("defaults the CLI release channel to latest", () => {
-    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com");
-    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@latest");
   });
 });

--- a/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.test.ts
@@ -23,18 +23,23 @@ describe("resolveAPIBaseURL", () => {
 
 describe("buildInstallPrompt", () => {
   it("delegates installation to the bundled octo-marketplace skill", () => {
-    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com");
+    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com", "next");
 
     expect(prompt).toContain("- Skill ID：`skill-123`");
     expect(prompt).toContain("- Space ID：`space-456`");
     expect(prompt).toContain("- API 地址：`https://octo.example.com`");
     expect(prompt).toContain("octo-cli skills octo-marketplace");
-    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@latest");
+    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@next");
     expect(prompt).toContain("octo-cli auth list");
     expect(prompt).toContain("不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程");
     expect(prompt).toContain("--profile space-space-456 --space space-456 --api-base-url https://octo.example.com");
     expect(prompt).toContain('`skills.md` 中“Install”流程');
     expect(prompt).not.toContain("在下载或覆盖文件前，向用户展示");
     expect(prompt).not.toContain("go install github.com/Mininglamp-OSS/octo-cli");
+  });
+
+  it("defaults the CLI release channel to latest", () => {
+    const prompt = buildInstallPrompt("skill-123", "space-456", "https://octo.example.com");
+    expect(prompt).toContain("npm install -g @mininglamp-oss/octo-cli@latest");
   });
 });

--- a/packages/dmworkskillmarket/src/utils/installPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.ts
@@ -12,10 +12,8 @@ export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL:
 
 不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。
 
-1. 运行 \`octo-cli version\`。如果未安装，优先运行
-   \`npm install -g @mininglamp-oss/octo-cli@latest\`；也可以运行
-   \`go install github.com/Mininglamp-OSS/octo-cli/cmd/octo-cli@latest\`。
-   如果当前版本不包含 \`octo-marketplace\` Skill，先升级到最新版。
+1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
@@ -25,7 +23,7 @@ export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL:
    <read-token> | octo-cli auth login --with-token --profile space-${spaceId} --space ${spaceId} --api-base-url ${apiBaseURL}
    \`\`\`
 
-   不得打印、回显或把 Token 放入命令参数。
+   不得输出 Token 或把 Token 放入命令参数。
 
 3. 使用选定的 Profile 运行以下命令，读取并遵循最新的 \`octo-marketplace\` Skill：
 
@@ -35,25 +33,5 @@ export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL:
 
 4. 按该 Skill 的 \`skills.md\` 中“Install”流程完成安装。
    以上 Skill ID、Space ID 和 API 地址是本次操作的权威输入。
-   不要自行改写 ID，也不要自行拼接 Marketplace 下载地址。
-
-5. 在下载或覆盖文件前，向用户展示：
-   - Skill 名称和版本；
-   - 目标 Skills 根目录；
-   - 是否会替换现有安装。
-
-   取得明确确认后再继续。
-
-6. 完成后验证：
-   - 安装目录；
-   - \`SKILL.md\`；
-   - 文件校验和。
-
-   失败时保留原安装，不得修改同一根目录中的其他 Skill。
-
-7. 告知用户：
-   - Skill ID、安装名称和版本；
-   - 安装路径和最终状态。
-
-   只有在 CLI/Skill 明确无法继续时才要求用户介入。`;
+   不要自行改写 ID。`;
 }

--- a/packages/dmworkskillmarket/src/utils/installPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.ts
@@ -3,13 +3,7 @@ export function resolveAPIBaseURL(apiURL: string, origin: string): string {
   return target.origin;
 }
 
-export function buildInstallPrompt(
-  skillId: string,
-  spaceId: string,
-  apiBaseURL: string,
-  cliDistTag?: OctoCliDistTag,
-): string {
-  const installCommand = getOctoCliInstallCommand(cliDistTag);
+export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL: string): string {
   return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 安装到当前 Agent runtime。
 
 - Skill ID：\`${skillId}\`
@@ -19,7 +13,7 @@ export function buildInstallPrompt(
 不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。
 
 1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
-   \`${installCommand}\`。
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
@@ -41,4 +35,3 @@ export function buildInstallPrompt(
    以上 Skill ID、Space ID 和 API 地址是本次操作的权威输入。
    不要自行改写 ID。`;
 }
-import { getOctoCliInstallCommand, type OctoCliDistTag } from "./octoCliInstall";

--- a/packages/dmworkskillmarket/src/utils/installPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.ts
@@ -1,45 +1,59 @@
 export function resolveAPIBaseURL(apiURL: string, origin: string): string {
-  const value = apiURL || "/api/v1/";
-  const withoutVersion = value.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
-  return new URL(withoutVersion || "/", origin).toString().replace(/\/$/, "");
+  const target = new URL(apiURL || origin, origin);
+  return target.origin;
 }
 
 export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL: string): string {
-  return `使用 octo-cli 将指定 Skill 安装到当前 Agent runtime。
+  return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 安装到当前 Agent runtime。
 
 - Skill ID：\`${skillId}\`
 - Space ID：\`${spaceId}\`
 - API 地址：\`${apiBaseURL}\`
 
-1. 运行 \`octo-cli version\` 检查是否已安装。
+不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。
 
-2. 如果未安装，自动安装：
+1. 运行 \`octo-cli version\`。如果未安装，优先运行
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`；也可以运行
+   \`go install github.com/Mininglamp-OSS/octo-cli/cmd/octo-cli@latest\`。
+   如果当前版本不包含 \`octo-marketplace\` Skill，先升级到最新版。
 
-   - 项目地址：https://github.com/Mininglamp-OSS/octo-cli
-   - 推荐安装：\`npm install -g @mininglamp-oss/octo-cli@latest\`
-   - Go 安装：\`go install github.com/Mininglamp-OSS/octo-cli/cmd/octo-cli@latest\`
-
-3. 如果 octo-cli 版本低于 \`0.8.0\`，自动升级后再继续。
-
-4. 运行 \`octo-cli auth list\` 选择身份：
-
-   - \`space_id\` 等于 \`${spaceId}\` 且只有一个时，使用该 Profile；
-   - 没有或存在多个时，从当前 Octo Channel 的环境或配置中读取 Bot Token，通过 stdin 登录或更新固定 Profile \`space-${spaceId}\`；
-   - 不得打印、回显或把 Token 放入命令参数。
-
-   登录命令：
+2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
+   如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
+   通过 stdin 登录或更新固定 Profile \`space-${spaceId}\`：
 
    \`\`\`bash
    <read-token> | octo-cli auth login --with-token --profile space-${spaceId} --space ${spaceId} --api-base-url ${apiBaseURL}
    \`\`\`
 
-5. 判断当前 Agent runtime 及其 Skills 根目录，并使用上一步确定的 Profile 运行：
+   不得打印、回显或把 Token 放入命令参数。
+
+3. 使用选定的 Profile 运行以下命令，读取并遵循最新的 \`octo-marketplace\` Skill：
 
    \`\`\`bash
-   octo-cli marketplace skills ${skillId} --profile <profile> --install <skills-root>
+   octo-cli skills octo-marketplace --profile <profile>
    \`\`\`
 
-6. 检查安装结果，确认名称、路径和 \`SKILL.md\` 正确，且只有指定 Skill 被安装。
+4. 按该 Skill 的 \`skills.md\` 中“Install”流程完成安装。
+   以上 Skill ID、Space ID 和 API 地址是本次操作的权威输入。
+   不要自行改写 ID，也不要自行拼接 Marketplace 下载地址。
 
-7. 告知用户 octo-cli 版本、Skill ID、安装名称、安装路径和最终状态。安装和升级默认自主执行，仅在无法继续时要求用户介入。`;
+5. 在下载或覆盖文件前，向用户展示：
+   - Skill 名称和版本；
+   - 目标 Skills 根目录；
+   - 是否会替换现有安装。
+
+   取得明确确认后再继续。
+
+6. 完成后验证：
+   - 安装目录；
+   - \`SKILL.md\`；
+   - 文件校验和。
+
+   失败时保留原安装，不得修改同一根目录中的其他 Skill。
+
+7. 告知用户：
+   - Skill ID、安装名称和版本；
+   - 安装路径和最终状态。
+
+   只有在 CLI/Skill 明确无法继续时才要求用户介入。`;
 }

--- a/packages/dmworkskillmarket/src/utils/installPrompt.ts
+++ b/packages/dmworkskillmarket/src/utils/installPrompt.ts
@@ -3,7 +3,13 @@ export function resolveAPIBaseURL(apiURL: string, origin: string): string {
   return target.origin;
 }
 
-export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL: string): string {
+export function buildInstallPrompt(
+  skillId: string,
+  spaceId: string,
+  apiBaseURL: string,
+  cliDistTag?: OctoCliDistTag,
+): string {
+  const installCommand = getOctoCliInstallCommand(cliDistTag);
   return `使用 octo-cli 内置的 Marketplace Skill，将指定 Skill 安装到当前 Agent runtime。
 
 - Skill ID：\`${skillId}\`
@@ -13,7 +19,7 @@ export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL:
 不要解释正在读取 Skill、复述本 Prompt 或逐步播报检查过程。
 
 1. 运行 \`octo-cli version\`。如果未安装或不包含 \`octo-marketplace\` Skill，运行
-   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
+   \`${installCommand}\`。
 
 2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
    如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
@@ -35,3 +41,4 @@ export function buildInstallPrompt(skillId: string, spaceId: string, apiBaseURL:
    以上 Skill ID、Space ID 和 API 地址是本次操作的权威输入。
    不要自行改写 ID。`;
 }
+import { getOctoCliInstallCommand, type OctoCliDistTag } from "./octoCliInstall";

--- a/packages/dmworkskillmarket/src/utils/octoCliInstall.ts
+++ b/packages/dmworkskillmarket/src/utils/octoCliInstall.ts
@@ -1,8 +1,0 @@
-export type OctoCliDistTag = "latest" | "next";
-
-export function getOctoCliInstallCommand(override?: OctoCliDistTag): string {
-  const env = (import.meta as { env?: Record<string, string | undefined> }).env;
-  const configured = override || env?.VITE_OCTO_CLI_DIST_TAG;
-  const tag: OctoCliDistTag = configured === "next" ? "next" : "latest";
-  return `npm install -g @mininglamp-oss/octo-cli@${tag}`;
-}

--- a/packages/dmworkskillmarket/src/utils/octoCliInstall.ts
+++ b/packages/dmworkskillmarket/src/utils/octoCliInstall.ts
@@ -1,0 +1,8 @@
+export type OctoCliDistTag = "latest" | "next";
+
+export function getOctoCliInstallCommand(override?: OctoCliDistTag): string {
+  const env = (import.meta as { env?: Record<string, string | undefined> }).env;
+  const configured = override || env?.VITE_OCTO_CLI_DIST_TAG;
+  const tag: OctoCliDistTag = configured === "next" ? "next" : "latest";
+  return `npm install -g @mininglamp-oss/octo-cli@${tag}`;
+}


### PR DESCRIPTION
## Summary

- align Skill install and Bot publish prompts around the bundled `octo-marketplace` workflow
- accept Skill archives or accessible directories and default a missing version to `1.0.0`
- preserve prompt whitespace consistently in both modals
- avoid narrating internal Skill-loading and validation steps
- pass the gateway origin instead of the core `/api` prefix

## Test

- `pnpm exec vitest run src/utils/installPrompt.test.ts src/utils/botPublishPrompt.test.ts`