### PR TITLE
refactor(dmworkbase): route channel runtime access

### DIFF
--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -21,6 +21,7 @@ import ConversationListGrouped, { ValidCategoryItem, isValidCategoryItem } from 
 import CreateCategoryModal from "../CreateCategoryModal"
 import { ContextMenusData } from "../ContextMenus"
 import { useI18n } from "../../i18n"
+import { getImChannelInfo } from "../../im-runtime/channelRuntime"
 
 export function isMutedForRecentConversation(conv: ConversationWrap): boolean {
     const isThread = conv.channel.channelType === ChannelTypeCommunityTopic
@@ -30,7 +31,8 @@ export function isMutedForRecentConversation(conv: ConversationWrap): boolean {
             (conv.channelInfo?.orgData?.parentGroupNo as string | undefined) ||
             parseThreadChannelId(conv.channel.channelID)?.groupNo
         if (parentGroupNo) {
-            parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+            parentChannelInfo = getImChannelInfo(
+                WKSDK.shared(),
                 new Channel(parentGroupNo, ChannelTypeGroup)
             )
         }

--- a/packages/dmworkbase/src/Components/ClawInfoModal/__tests__/ClawInfoModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ClawInfoModal/__tests__/ClawInfoModal.test.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import "@testing-library/jest-dom";
 import ClawInfoModal from "../ClawInfoModal";
-import type { AgentCardData } from "../../Service/AgentCardService";
+import type { AgentCardData, RuntimeInfo } from "../../../Service/AgentCardService";
 
 // Mock AgentCardService
-vi.mock("../../Service/AgentCardService", () => ({
+vi.mock("../../../Service/AgentCardService", () => ({
   default: {
     getAgentCard: vi.fn(),
   },
 }));
 
-import AgentCardService from "../../Service/AgentCardService";
+import AgentCardService from "../../../Service/AgentCardService";
 
 // Mock WKModal
 vi.mock("../../WKModal", () => ({
@@ -25,6 +25,28 @@ vi.mock("../../ClawSessionItem", () => ({
     <div data-testid="claw-session-card">{session.key}</div>
   ),
 }));
+
+const mockRuntimeInfo: RuntimeInfo = {
+  os_version: "macOS 13.2.1",
+  arch: "arm64",
+  disk_space_gb: 68,
+  memory_gb: 32,
+  app_data_dir: ".octopush/octopush-58d651",
+  claw_version: "v2026.4.11",
+  admin_url: "http://localhost:3100",
+  team_name: "DeepMiner Team",
+  process_status: "running",
+  gateway_status: "connected",
+  gateway_name: "Gateway-1",
+  claw_id: "claw-a8f3d2e1",
+  gateway_total_agents: 10,
+  gateway_alive_agents: 8,
+  nodejs_version: "v22.22.2",
+  network_latency_ms: 45.2,
+  last_heartbeat_at: "2026-05-07T10:31:00Z",
+  memory_retention_count: 50,
+  memory_retention_note: "保留最近50天记忆，已清理3条过期记录",
+};
 
 describe("ClawInfoModal", () => {
   beforeEach(() => {
@@ -40,7 +62,7 @@ describe("ClawInfoModal", () => {
       session_total: 3,
       session_running_count: 2,
       last_report_at: "2026-05-07T10:30:00Z",
-      runtime_info: {} as any,
+      runtime_info: mockRuntimeInfo,
       sessions: [
         {
           session_id: "s1",
@@ -95,6 +117,7 @@ describe("ClawInfoModal", () => {
     vi.mocked(AgentCardService.getAgentCard).mockResolvedValueOnce(mockData);
 
     render(<ClawInfoModal botId="test_bot" visible={true} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("tab-session"));
 
     // 等待数据加载
     await waitFor(() => {
@@ -119,7 +142,7 @@ describe("ClawInfoModal", () => {
       session_total: 0,
       session_running_count: 0,
       last_report_at: "2026-05-07T10:30:00Z",
-      runtime_info: {} as any,
+      runtime_info: mockRuntimeInfo,
       sessions: [],
       core_files: [],
       memory_files: [],
@@ -128,6 +151,7 @@ describe("ClawInfoModal", () => {
     vi.mocked(AgentCardService.getAgentCard).mockResolvedValueOnce(mockData);
 
     render(<ClawInfoModal botId="empty_bot" visible={true} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("tab-session"));
 
     await waitFor(() => {
       expect(screen.getByText(/0 running/)).toBeInTheDocument();
@@ -135,7 +159,7 @@ describe("ClawInfoModal", () => {
 
     // 检查空态文案
     expect(
-      screen.getByText(/最近 1 小时内没有活跃的会话，有新对话产生后会出现在这里/)
+      screen.getByText(/暂无活跃的会话，有新对话产生后会出现在这里/)
     ).toBeInTheDocument();
   });
 
@@ -160,6 +184,7 @@ describe("ClawInfoModal", () => {
     vi.mocked(AgentCardService.getAgentCard).mockRejectedValueOnce(new Error("网络错误"));
 
     render(<ClawInfoModal botId="error_bot" visible={true} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("tab-session"));
 
     await waitFor(() => {
       expect(screen.getByText(/网络错误/)).toBeInTheDocument();
@@ -175,7 +200,7 @@ describe("ClawInfoModal", () => {
       session_total: 3,
       session_running_count: 2,
       last_report_at: "2026-05-07T10:30:00Z",
-      runtime_info: {} as any,
+      runtime_info: mockRuntimeInfo,
       sessions: [
         {
           session_id: "idle_1",
@@ -230,6 +255,7 @@ describe("ClawInfoModal", () => {
     vi.mocked(AgentCardService.getAgentCard).mockResolvedValueOnce(mockData);
 
     render(<ClawInfoModal botId="sort_bot" visible={true} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("tab-session"));
 
     await waitFor(() => {
       const sessionCards = screen.getAllByTestId("claw-session-card");

--- a/packages/dmworkbase/src/Components/ClawOverviewTab/ClawOverviewTab.test.tsx
+++ b/packages/dmworkbase/src/Components/ClawOverviewTab/ClawOverviewTab.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/resyncSubscribers.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/resyncSubscribers.test.ts
@@ -100,6 +100,10 @@ vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
 vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
 vi.mock("../historyScroll", () => ({ getPulldownRestoredScrollTop: () => 0 }))
 vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+vi.mock("../../../i18n", () => ({
+    t: (key: string) => key,
+    useI18n: () => ({ t: (key: string) => key }),
+}))
 
 import ConversationVM from "../vm"
 import { Channel } from "wukongimjssdk"

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/subscribersReady.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/subscribersReady.test.ts
@@ -77,6 +77,10 @@ vi.mock("../../../Utils/const", () => ({ SuperGroup: 1 }))
 vi.mock("../foldSessionSummary", () => ({ getFoldSessionExpandedMessages: () => [] }))
 vi.mock("../historyScroll", () => ({ getPulldownRestoredScrollTop: () => 0 }))
 vi.mock("../../../Service/Convert", () => ({ applyMsgLevelExternalFieldsWithFallback: () => {} }))
+vi.mock("../../../i18n", () => ({
+    t: (key: string) => key,
+    useI18n: () => ({ t: (key: string) => key }),
+}))
 
 import ConversationVM from "../vm"
 import { Channel } from "wukongimjssdk"

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -120,6 +120,12 @@ import {
   classifyCardSender,
   isTrustedCardSender,
 } from "../../Messages/InteractiveCard/senderTrust";
+import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
 
 /**
  * 取消息的有效内容：如果消息被编辑过，返回编辑后的 contentEdit；否则返回原始 content
@@ -294,7 +300,7 @@ function offsetMentionEntities(
  * WuKongIM SDK 的 Message 只带 fromUID, 不带 fromName; name 必须前端自己解析。
  * 参考 useMessageRow.ts + Messages/Base/index.tsx 的群成员名字解析路径:
  *
- *   1. 群消息: 从 channelManager.getSubscribes(groupChannel) 拉群成员列表,
+ *   1. 群消息: 从 channel runtime 拉群成员列表,
  *      按 uid 匹配后用 subscriberDisplayName (real_name(verified) > remark > name)
  *      — 群内用户大概率没开过 1v1, Person channelInfo 缓存常 miss,
  *      群成员列表缓存命中率高得多, 是主路径
@@ -312,7 +318,7 @@ function resolveFromUName(m: Message | undefined | null): string {
   try {
     const ch = m.channel;
     if (ch && ch.channelType === ChannelTypeGroup) {
-      const subs = WKSDK.shared().channelManager.getSubscribes(ch) as
+      const subs = getImChannelSubscribers(WKSDK.shared(), ch) as
         | {
             uid?: string;
             name?: string;
@@ -333,7 +339,8 @@ function resolveFromUName(m: Message | undefined | null): string {
 
   // 2. Person channelInfo 兜底
   try {
-    const info = WKSDK.shared().channelManager.getChannelInfo(
+    const info = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(fromUID, ChannelTypePerson)
     );
     if (info?.title) return info.title;
@@ -435,6 +442,7 @@ export class Conversation
   private _guardId: symbol = Symbol("pendingAttachmentGuard");
   // 监听 channelInfo 变化：群解散时 status 翻转为 2，需重渲染以隐藏成员栏/置灰发送框
   private _channelInfoListener?: (channelInfo: ChannelInfo) => void;
+  private _unsubscribeChannelInfoListener?: () => void;
   private draftSaveGeneration = 0;
   private latestSavedDraft = "";
   private _addAttachmentFn?: (
@@ -574,7 +582,8 @@ export class Conversation
     ) {
       return;
     }
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(fromUID, ChannelTypePerson)
     );
     this._messageInputContext?.addMention(fromUID, channelInfo?.title || "");
@@ -1380,15 +1389,19 @@ export class Conversation
         this.forceUpdate();
       }
     };
-    WKSDK.shared().channelManager.addListener(this._channelInfoListener);
+    this._unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this._channelInfoListener
+    );
     // 进入会话时主动拉取一次最新 channelInfo，确保解散状态(status)不依赖陈旧缓存。
     // 群聊查自身；子区(CommunityTopic)解散状态在父群上，需拉父群。
     if (channel.channelType === ChannelTypeGroup) {
-      WKSDK.shared().channelManager.fetchChannelInfo(channel);
+      fetchImChannelInfo(WKSDK.shared(), channel);
     } else if (channel.channelType === ChannelTypeCommunityTopic) {
       const parsed = parseThreadChannelId(channel.channelID);
       if (parsed) {
-        WKSDK.shared().channelManager.fetchChannelInfo(
+        fetchImChannelInfo(
+          WKSDK.shared(),
           new Channel(parsed.groupNo, ChannelTypeGroup)
         );
       }
@@ -1417,7 +1430,8 @@ export class Conversation
     }
     window.removeEventListener("beforeunload", this._beforeUnloadHandler);
     if (this._channelInfoListener) {
-      WKSDK.shared().channelManager.removeListener(this._channelInfoListener);
+      this._unsubscribeChannelInfoListener?.();
+      this._unsubscribeChannelInfoListener = undefined;
       this._channelInfoListener = undefined;
     }
     // 注销附件守卫：只清除自己注册的，防止新实例 guard 被旧实例 unmount 覆盖
@@ -2457,7 +2471,7 @@ export class Conversation
   render() {
     const { chatBg, channel, initLocateMessageSeq } = this.props;
 
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
 
     // 群已解散（企业微信式只读态）：保留历史，但禁发消息/建子区、收起成员栏。
     // 覆盖群聊与子区（子区随父群解散一并只读）。
@@ -2828,8 +2842,10 @@ export class Conversation
                           channel.channelType !== ChannelTypeCommunityTopic
                         )
                           return;
-                        const channelInfo =
-                          WKSDK.shared().channelManager.getChannelInfo(channel);
+                        const channelInfo = getImChannelInfo(
+                          WKSDK.shared(),
+                          channel
+                        );
                         // 传原始文本（含 @[uid:name] 占位符），由 GlobalMatterModal 先 parse 再截断
                         // 避免 slice 截断位置落在占位符中间导致 mention 残留乱码
                         const rawText = (
@@ -2865,8 +2881,10 @@ export class Conversation
                         const { channel } = this.props;
                         await this.vm.ensureSubscribersLoaded();
 
-                        const channelInfo =
-                          WKSDK.shared().channelManager.getChannelInfo(channel);
+                        const channelInfo = getImChannelInfo(
+                          WKSDK.shared(),
+                          channel
+                        );
                         let groupName: string | undefined;
                         let threadName: string | undefined;
 
@@ -2876,10 +2894,10 @@ export class Conversation
                             channel.channelID
                           );
                           if (parsed) {
-                            const parentInfo =
-                              WKSDK.shared().channelManager.getChannelInfo(
-                                new Channel(parsed.groupNo, ChannelTypeGroup)
-                              );
+                            const parentInfo = getImChannelInfo(
+                              WKSDK.shared(),
+                              new Channel(parsed.groupNo, ChannelTypeGroup)
+                            );
                             groupName = parentInfo?.title;
                           }
                         } else if (channel.channelType === ChannelTypeGroup) {
@@ -2896,7 +2914,8 @@ export class Conversation
                           loginUID: WKApp.loginInfo.uid,
                           channelInfo:
                             channel.channelType === ChannelTypePerson
-                              ? (WKSDK.shared().channelManager.getChannelInfo(
+                              ? (getImChannelInfo(
+                                  WKSDK.shared(),
                                   channel
                                 ) as ChatContextChannelInfo | null)
                               : undefined,
@@ -2951,13 +2970,13 @@ export class Conversation
                           reply.messageID = vm.currentReplyMessage.messageID;
                           reply.messageSeq = vm.currentReplyMessage.messageSeq;
                           reply.fromUID = vm.currentReplyMessage.fromUID;
-                          const channelInfo =
-                            WKSDK.shared().channelManager.getChannelInfo(
-                              new Channel(
-                                vm.currentReplyMessage.fromUID,
-                                ChannelTypePerson
-                              )
-                            );
+                          const channelInfo = getImChannelInfo(
+                            WKSDK.shared(),
+                            new Channel(
+                              vm.currentReplyMessage.fromUID,
+                              ChannelTypePerson
+                            )
+                          );
                           if (channelInfo) {
                             reply.fromName = channelInfo.title;
                           }
@@ -3397,8 +3416,10 @@ export class Conversation
                         this.vm.selectUID,
                         ChannelTypePerson
                       );
-                      const channelInfo =
-                        WKSDK.shared().channelManager.getChannelInfo(channel);
+                      const channelInfo = getImChannelInfo(
+                        WKSDK.shared(),
+                        channel
+                      );
 
                       this.messageInputContext()?.addMention(
                         this.vm.selectUID,
@@ -3604,7 +3625,8 @@ interface ReplyViewProps {
 class ReplyView extends Component<ReplyViewProps> {
   render(): React.ReactNode {
     const { message, onClose, vm } = this.props;
-    const fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const fromChannelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(message.fromUID, ChannelTypePerson)
     );
     const isEdit = vm.currentHandlerType === 2;

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -32,6 +32,16 @@ import {
     handleImReconnectRefresh,
     removeImConnectStatusListener,
 } from "../../im-runtime/connectStatus";
+import {
+    addImChannelInfoListener,
+    addImSubscriberChangeListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+    getImChannelSubscribers,
+    notifyImSubscriberChangeListeners,
+    setImChannelSubscribersCache,
+    syncImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
 
 export interface FoldSessionParticipant {
     uid: string
@@ -114,7 +124,9 @@ export default class ConversationVM extends ProviderListener {
     messageStatusListener!: MessageStatusListener // 消息状态监听
     conversationListener!: ConversationListener // 会话监听
     private channelInfoListener!: ChannelInfoListener // channelInfo 变化监听（bot 身份识别）
-    subscriberChangeListener!: (channel: Channel) => void // 订阅者变化监听
+    private unsubscribeChannelInfoListener?: () => void
+    subscriberChangeListener?: (channel: Channel) => void // 订阅者变化监听
+    private unsubscribeSubscriberChangeListener?: () => void
     lastMessage?: MessageWrap // 此会话的最后一条最新的消息
     lastLocalMessageElement?: HTMLElement | null // 最后一条消息的dom元素
     private _showScrollToBottomBtn?: boolean = false // 是否显示底部按钮
@@ -297,7 +309,7 @@ export default class ConversationVM extends ProviderListener {
             || message.contentType === MessageContentTypeConst.typing) {
             return false
         }
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(message.fromUID, ChannelTypePerson))
+        const channelInfo = getImChannelInfo(WKSDK.shared(), new Channel(message.fromUID, ChannelTypePerson))
         return channelInfo?.orgData?.robot === 1
     }
 
@@ -329,7 +341,7 @@ export default class ConversationVM extends ProviderListener {
             }
             seenUIDs.add(message.fromUID)
             const channel = new Channel(message.fromUID, ChannelTypePerson)
-            const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
+            const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
             // 优先使用 message.from.title, 再用 channelInfo.title, 最后用 fromUID
             const name = message.from?.title || channelInfo?.title || message.fromUID
             participants.push({
@@ -469,7 +481,7 @@ export default class ConversationVM extends ProviderListener {
             const lastItem = renderItems[renderItems.length - 1]
             // isBotMessage() excludes typing content type, so check fromUID directly
             const typingFromBot = typingMessage.fromUID &&
-                WKSDK.shared().channelManager.getChannelInfo(new Channel(typingMessage.fromUID, ChannelTypePerson))?.orgData?.robot === 1
+                getImChannelInfo(WKSDK.shared(), new Channel(typingMessage.fromUID, ChannelTypePerson))?.orgData?.robot === 1
             if (lastItem?.type === "foldSession" && lastItem.session.isActive && typingFromBot) {
                 lastItem.session.typing = typingMessage
                 lastItem.session.expandedMessages = getFoldSessionExpandedMessages({
@@ -519,10 +531,10 @@ export default class ConversationVM extends ProviderListener {
         for (const msg of this.messagesOfOrigin) {
             if (!msg.send && msg.fromUID && !seenUIDs.has(msg.fromUID)) {
                 seenUIDs.add(msg.fromUID)
-                const ci = WKSDK.shared().channelManager.getChannelInfo(new Channel(msg.fromUID, ChannelTypePerson))
+                const ci = getImChannelInfo(WKSDK.shared(), new Channel(msg.fromUID, ChannelTypePerson))
                 if (!ci) {
                     // channelInfo 还没缓存，fetch 后触发 channelInfoListener 自然 rebuild
-                    WKSDK.shared().channelManager.fetchChannelInfo(new Channel(msg.fromUID, ChannelTypePerson))
+                    fetchImChannelInfo(WKSDK.shared(), new Channel(msg.fromUID, ChannelTypePerson))
                 } else if (ci.orgData?.robot === 1) {
                     botUIDs.add(msg.fromUID)
                 }
@@ -647,7 +659,7 @@ export default class ConversationVM extends ProviderListener {
             for (const message of checkedMessages) {
                 if (addedUIDs.has(message.fromUID)) continue
                 addedUIDs.add(message.fromUID)
-                const channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(message.fromUID, ChannelTypePerson))
+                const channelInfo = getImChannelInfo(WKSDK.shared(), new Channel(message.fromUID, ChannelTypePerson))
                 users.push({ uid: message.fromUID, name: channelInfo?.title })
             }
         }
@@ -940,7 +952,7 @@ export default class ConversationVM extends ProviderListener {
                 this.notifyListener()
             }
         }
-        WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
 
         WKApp.endpointManager.setMethod(EndpointID.clearChannelMessages, (channel: Channel) => {
             if (channel.isEqual(this.channel)) {
@@ -965,12 +977,12 @@ export default class ConversationVM extends ProviderListener {
         if (this.supportsFolding) {
 
             // 加载频道信息
-            this.channelInfo = WKSDK.shared().channelManager.getChannelInfo(this.channel)
+            this.channelInfo = getImChannelInfo(WKSDK.shared(), this.channel)
             if (this.channelInfo) {
                 this.loadChannelInfoFinished()
             } else {
-                WKSDK.shared().channelManager.fetchChannelInfo(this.channel).then(() => {
-                    this.channelInfo = WKSDK.shared().channelManager.getChannelInfo(this.channel)
+                fetchImChannelInfo(WKSDK.shared(), this.channel).then((channelInfo) => {
+                    this.channelInfo = channelInfo
                     this.loadChannelInfoFinished()
                 }).catch((err) => {
                     console.error('[ConversationVM] fetchChannelInfo failed:', err)
@@ -1090,8 +1102,10 @@ export default class ConversationVM extends ProviderListener {
         TypingManager.shared.removeTypingListener(this.typingListener)
         removeImConnectStatusListener(WKSDK.shared(), this.connectStatusListener)
         WKSDK.shared().conversationManager.removeConversationListener(this.conversationListener)
-        WKSDK.shared().channelManager.removeSubscriberChangeListener(this.subscriberChangeListener)
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeSubscriberChangeListener?.()
+        this.unsubscribeSubscriberChangeListener = undefined
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         if (this.foldSessionActiveTimer) {
             clearTimeout(this.foldSessionActiveTimer)
             this.foldSessionActiveTimer = null
@@ -1110,7 +1124,7 @@ export default class ConversationVM extends ProviderListener {
             const parentGroupNo = this.channelInfo?.orgData?.parentGroupNo
             if (parentGroupNo) {
                 const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
-                const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+                const parentChannelInfo = getImChannelInfo(WKSDK.shared(), parentChannel)
                 const isSuperGroup = parentChannelInfo?.orgData?.group_type == SuperGroup
                 if (isSuperGroup) {
                     // 超级群：只取第一页
@@ -1121,25 +1135,27 @@ export default class ConversationVM extends ProviderListener {
                     this._resolveSubscribersReady()
                 } else {
                     // 普通群：从缓存拿，没有则同步
-                    const cached = WKSDK.shared().channelManager.getSubscribes(parentChannel)
+                    const cached = getImChannelSubscribers(WKSDK.shared(), parentChannel)
                     if (cached && cached.length > 0) {
                         this.subscribers = cached
                         this._resolveSubscribersReady()
                     } else {
-                        await WKSDK.shared().channelManager.syncSubscribes(parentChannel)
-                        this.subscribers = WKSDK.shared().channelManager.getSubscribes(parentChannel) || []
+                        await syncImChannelSubscribers(WKSDK.shared(), parentChannel)
+                        this.subscribers = getImChannelSubscribers(WKSDK.shared(), parentChannel)
                         this._resolveSubscribersReady()
                         // 注册前先移除旧监听器，避免多次调用时重复注册
-                        if (this.subscriberChangeListener) {
-                            WKSDK.shared().channelManager.removeSubscriberChangeListener(this.subscriberChangeListener)
-                        }
+                        this.unsubscribeSubscriberChangeListener?.()
+                        this.unsubscribeSubscriberChangeListener = undefined
                         this.subscriberChangeListener = (channel: Channel) => {
                             if (channel.channelID !== parentGroupNo) return
-                            this.subscribers = WKSDK.shared().channelManager.getSubscribes(parentChannel) || []
+                            this.subscribers = getImChannelSubscribers(WKSDK.shared(), parentChannel)
                             this._resolveSubscribersReady()
                             this.notifyListener()
                         }
-                        WKSDK.shared().channelManager.addSubscriberChangeListener(this.subscriberChangeListener)
+                        this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(
+                            WKSDK.shared(),
+                            this.subscriberChangeListener
+                        )
                     }
                 }
                 this.notifyListener()
@@ -1157,17 +1173,21 @@ export default class ConversationVM extends ProviderListener {
             this.reloadSubscribers()
             this._resolveSubscribersReady()
         }
-        WKSDK.shared().channelManager.addSubscriberChangeListener(this.subscriberChangeListener)
+        this.unsubscribeSubscriberChangeListener?.()
+        this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(
+            WKSDK.shared(),
+            this.subscriberChangeListener
+        )
 
         if (this.channelInfo?.orgData?.group_type == SuperGroup) {
             // 如果是超级群则只获取第一页成员
             this.subscribers = await this.getFirstPageMembers()
             this._resolveSubscribersReady()
-            WKSDK.shared().channelManager.subscribeCacheMap.set(this.channel.getChannelKey(), this.subscribers)
-            WKSDK.shared().channelManager.notifySubscribeChangeListeners(this.channel)
+            setImChannelSubscribersCache(WKSDK.shared(), this.channel, this.subscribers)
+            notifyImSubscriberChangeListeners(WKSDK.shared(), this.channel)
             this.notifyListener()
         } else {
-            WKSDK.shared().channelManager.syncSubscribes(this.channel)
+            syncImChannelSubscribers(WKSDK.shared(), this.channel)
         }
 
     }
@@ -1274,7 +1294,7 @@ export default class ConversationVM extends ProviderListener {
 
     // 重新加载订阅者
     reloadSubscribers() {
-        this.subscribers = WKSDK.shared().channelManager.getSubscribes(this.channel)
+        this.subscribers = getImChannelSubscribers(WKSDK.shared(), this.channel)
         if (this.subscribers.length > 0) {
             this._resolveSubscribersReady()
         }
@@ -1308,7 +1328,7 @@ export default class ConversationVM extends ProviderListener {
                     return
                 }
                 const parentChannel = new Channel(parentGroupNo, ChannelTypeGroup)
-                const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+                const parentChannelInfo = getImChannelInfo(WKSDK.shared(), parentChannel)
                 const isSuperGroup = parentChannelInfo?.orgData?.group_type == SuperGroup
                 if (isSuperGroup) {
                     // 超级群父群：只拉第一页（与进频道时一致）
@@ -1318,8 +1338,8 @@ export default class ConversationVM extends ProviderListener {
                     })
                 } else {
                     // 普通父群：全量同步后取缓存
-                    await WKSDK.shared().channelManager.syncSubscribes(parentChannel)
-                    this.subscribers = WKSDK.shared().channelManager.getSubscribes(parentChannel) || []
+                    await syncImChannelSubscribers(WKSDK.shared(), parentChannel)
+                    this.subscribers = getImChannelSubscribers(WKSDK.shared(), parentChannel)
                 }
                 this._resolveSubscribersReady()
                 this.notifyListener()
@@ -1332,12 +1352,12 @@ export default class ConversationVM extends ProviderListener {
                 // 超级群只拉第一页（与进频道时一致）
                 this.subscribers = await this.getFirstPageMembers()
                 this._resolveSubscribersReady()
-                WKSDK.shared().channelManager.subscribeCacheMap.set(this.channel.getChannelKey(), this.subscribers)
-                WKSDK.shared().channelManager.notifySubscribeChangeListeners(this.channel)
+                setImChannelSubscribersCache(WKSDK.shared(), this.channel, this.subscribers)
+                notifyImSubscriberChangeListeners(WKSDK.shared(), this.channel)
                 this.notifyListener()
             } else {
                 // 普通群走服务端全量同步，完成后 subscriberChangeListener 回调刷新
-                await WKSDK.shared().channelManager.syncSubscribes(this.channel)
+                await syncImChannelSubscribers(WKSDK.shared(), this.channel)
                 this.reloadSubscribers()
             }
         } catch (e) {
@@ -2344,7 +2364,7 @@ export default class ConversationVM extends ProviderListener {
             mentionHumans: !!(mentionAny && mentionAny.humans),
             mentionAis: !!(mentionAny && mentionAny.ais),
         })
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel)
+        const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
         let setting = new Setting()
         if (channelInfo?.orgData.receipt === 1) {
             setting.receiptEnabled = true

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -39,6 +39,11 @@ import { I18nContext, t, useI18n } from "../../i18n";
 import { formatDraftPreview } from "../../Utils/draftPreview";
 import { wkConfirm } from "../WKModal";
 import { collapsedThreadUnread } from "./unread";
+import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
 // ── 在线态判定/渲染 helper ──────────────────────────────────────────────
@@ -110,7 +115,7 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
   // channelInfo 未加载时主动拉取，加载完触发 re-render
   React.useEffect(() => {
     if (!channelInfo) {
-      WKSDK.shared().channelManager.fetchChannelInfo(conversationWrap.channel);
+      void fetchImChannelInfo(WKSDK.shared(), conversationWrap.channel);
     }
   }, [conversationWrap.channel.channelID]);
 
@@ -125,7 +130,8 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
     ? (channelInfo?.orgData?.parentGroupNo as string | undefined)
     : undefined;
   const parentChannelInfo = parentGroupNo
-    ? WKSDK.shared().channelManager.getChannelInfo(
+    ? getImChannelInfo(
+        WKSDK.shared(),
         new Channel(parentGroupNo, ChannelTypeGroup)
       )
     : undefined;
@@ -332,6 +338,7 @@ export default class ConversationList extends Component<
   channelListener!: ChannelInfoListener;
   contextMenusContext!: ContextMenusContext;
   typingListener!: TypingListener;
+  private unsubscribeChannelInfoListener?: () => void;
   private listRef = React.createRef<HTMLDivElement>();
   private itemRefs = new Map<string, HTMLDivElement>();
   private lastRenderableItems: ConversationWrap[] = [];
@@ -366,7 +373,10 @@ export default class ConversationList extends Component<
     this.channelListener = (channelInfo: ChannelInfo) => {
       this.setState({});
     };
-    WKSDK.shared().channelManager.addListener(this.channelListener);
+    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this.channelListener
+    );
 
     this.typingListener = (channel: Channel, add: boolean) => {
       this.setState({});
@@ -400,7 +410,8 @@ export default class ConversationList extends Component<
       window.clearTimeout(this.unreadNudgeTimer);
       this.unreadNudgeTimer = null;
     }
-    WKSDK.shared().channelManager.removeListener(this.channelListener);
+    this.unsubscribeChannelInfoListener?.();
+    this.unsubscribeChannelInfoListener = undefined;
     TypingManager.shared.removeTypingListener(this.typingListener);
   }
 
@@ -601,11 +612,11 @@ export default class ConversationList extends Component<
       if (lastMessage.fromUID && lastMessage.fromUID !== "") {
         const fromChannel = new Channel(lastMessage.fromUID, ChannelTypePerson);
         const fromChannelInfo =
-          WKSDK.shared().channelManager.getChannelInfo(fromChannel);
+          getImChannelInfo(WKSDK.shared(), fromChannel);
         if (fromChannelInfo) {
           from = `${fromChannelInfo.title}: `;
         } else {
-          WKSDK.shared().channelManager.fetchChannelInfo(fromChannel);
+          void fetchImChannelInfo(WKSDK.shared(), fromChannel);
         }
       }
 
@@ -629,7 +640,7 @@ export default class ConversationList extends Component<
   ) {
     let channelInfo = conversationWrap.channelInfo;
     if (!channelInfo) {
-      WKSDK.shared().channelManager.fetchChannelInfo(conversationWrap.channel);
+      void fetchImChannelInfo(WKSDK.shared(), conversationWrap.channel);
     }
 
     const { compact } = this.props;
@@ -648,10 +659,10 @@ export default class ConversationList extends Component<
       ? new Channel(parentGroupNo, ChannelTypeGroup)
       : undefined;
     const parentChannelInfo = parentChannel
-      ? WKSDK.shared().channelManager.getChannelInfo(parentChannel)
+      ? getImChannelInfo(WKSDK.shared(), parentChannel)
       : undefined;
     if (parentChannel && !parentChannelInfo) {
-      WKSDK.shared().channelManager.fetchChannelInfo(parentChannel);
+      void fetchImChannelInfo(WKSDK.shared(), parentChannel);
     }
 
     // ── Compact 模式（群聊 Tab）：用 CompactGroupItem 函数组件（支持拖拽） ──
@@ -898,7 +909,7 @@ export default class ConversationList extends Component<
     ChannelSettingManager.shared.mute(value, channelInfo.channel)
       .then(() => {
         // 直接重拉（不删缓存），新数据覆盖旧缓存，避免删除期间出现 loading 骨架
-        WKSDK.shared().channelManager.fetchChannelInfo(channelInfo.channel)
+        fetchImChannelInfo(WKSDK.shared(), channelInfo.channel)
           .then(() => this.setState({}))
       })
   }
@@ -1231,7 +1242,8 @@ export default class ConversationList extends Component<
         if (!hasThreads) return 0;
         if (this._isThreadExpanded(conv.channel.channelID)) return 0;
         const threads = threadsByParent.get(conv.channel.channelID) ?? [];
-        const parentInfo = WKSDK.shared().channelManager.getChannelInfo(
+        const parentInfo = getImChannelInfo(
+          WKSDK.shared(),
           new Channel(conv.channel.channelID, ChannelTypeGroup)
         );
         return collapsedThreadUnread(threads, !!parentInfo?.mute, !!compact);
@@ -1328,7 +1340,7 @@ export default class ConversationList extends Component<
               ? (channelInfo?.orgData?.parentGroupNo as string | undefined)
               : undefined
             const menuParentChannelInfo = menuParentGroupNo
-              ? WKSDK.shared().channelManager.getChannelInfo(new Channel(menuParentGroupNo, ChannelTypeGroup))
+              ? getImChannelInfo(WKSDK.shared(), new Channel(menuParentGroupNo, ChannelTypeGroup))
               : undefined
             const menuRawMute = menuIsThread
               ? (channelInfo?.orgData?.thread as any)?.mute as number | null | undefined

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/categoriesFallback.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/categoriesFallback.test.ts
@@ -92,7 +92,7 @@ describe("computeEffectiveCategories", () => {
         const [virtualCat] = result
         expect(virtualCat.category_id).toBe(VIRTUAL_DEFAULT_CATEGORY_ID)
         expect(virtualCat.is_default).toBe(true)
-        expect(virtualCat.name).toBe("默认")
+        expect(virtualCat.name).toBe("分组")
         expect(virtualCat.groups).toEqual([])
         expect(isVirtualCategory(virtualCat.category_id)).toBe(true)
     })

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -34,6 +34,7 @@ import {
 import { filterArchivedThreads, isArchivedThreadConversation, type ThreadSidebarStatusMap } from "./archivedThreads"
 import { useI18n } from "../../i18n"
 import { wkConfirm } from "../WKModal"
+import { getImChannelInfo } from "../../im-runtime/channelRuntime"
 
 // 兜底相关 helper 迁移至 ./categoriesFallback 独立模块，便于无依赖地单元测试。
 // 这里保留 re-export 以保持对外 API 不变（ConversationList.tsx / storybook 可直接从本模块引用）。
@@ -607,7 +608,8 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
                 const parentGroupNo = c.channelInfo?.orgData?.parentGroupNo
                     || parseThreadChannelId(c.channel.channelID)?.groupNo
                 if (parentGroupNo) {
-                    parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+                    parentChannelInfo = getImChannelInfo(
+                        WKSDK.shared(),
                         new Channel(parentGroupNo, ChannelTypeGroup)
                     )
                 }

--- a/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
@@ -12,6 +12,7 @@ import WKSDK, { Channel, ChannelTypePerson } from "wukongimjssdk"
 import { ForwardModal } from "../ForwardModal/ForwardModal"
 import { useForwardModal } from "../ForwardModal/useForwardModal"
 import type { ForwardFinished, ForwardGrantConfig, ForwardGrantRole } from "../ForwardModal/grant"
+import { getImChannelSubscribers, syncImChannelSubscribers } from "../../im-runtime/channelRuntime"
 
 export interface ConversationSelectGrant {
   canGrant: boolean
@@ -79,16 +80,12 @@ export default function ConversationSelect({
       }
       for (const ch of groups) {
         try {
-          await Promise.resolve(WKSDK.shared().channelManager.syncSubscribes(ch))
+          await syncImChannelSubscribers(WKSDK.shared(), ch)
         } catch {
           // best-effort：拉取失败时退回已缓存的成员快照。
         }
         if (cancelled) return
-        const subs =
-          (WKSDK.shared().channelManager.getSubscribes(ch) as
-            | { uid?: string }[]
-            | null
-            | undefined) ?? []
+        const subs = getImChannelSubscribers(WKSDK.shared(), ch) as { uid?: string }[]
         for (const s of subs) {
           if (s?.uid) uids.add(s.uid)
         }

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterSearchSelect.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterSearchSelect.test.tsx
@@ -65,9 +65,9 @@ const MEMBERS: FilterSearchOption[] = [
   { id: "m2", name: "Niaj" },
 ];
 
-const openDropdown = () => fireEvent.focus(screen.getByRole("textbox"));
 const listbox = () => screen.getByRole("listbox");
 const field = () => screen.getByRole("combobox");
+const openDropdown = () => fireEvent.click(field());
 
 describe("FilterSearchSelect — 发送者 (multi)", () => {
   it("输入过滤候选：typing narrows the dropdown to matching options", () => {

--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
@@ -31,6 +31,7 @@ import "yet-another-react-lightbox/styles.css";
 import { I18nContext } from "../../i18n";
 
 import MergeforwardCard from "../../ui/message/MergeforwardCard";
+import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 import "./index.css";
 
@@ -305,7 +306,7 @@ export default class MergeforwardMessageList extends Component<
       });
       const previewMsgs = (nestedContent.msgs || []).slice(0, 4).map((m) => {
         const name = userNameMap.get(m.fromUID)
-          || WKSDK.shared().channelManager.getChannelInfo(new Channel(m.fromUID, ChannelTypePerson))?.title
+          || getImChannelInfo(WKSDK.shared(), new Channel(m.fromUID, ChannelTypePerson))?.title
           || "";
         const digest = m.content?.conversationDigest || "";
         return {
@@ -421,9 +422,9 @@ export default class MergeforwardMessageList extends Component<
             {currentContent.msgs.map((m, i) => {
               const fromChannel = new Channel(m.fromUID, ChannelTypePerson);
               let fromChannelInfo =
-                WKSDK.shared().channelManager.getChannelInfo(fromChannel);
+                getImChannelInfo(WKSDK.shared(), fromChannel);
               if (!fromChannelInfo) {
-                WKSDK.shared().channelManager.fetchChannelInfo(fromChannel);
+                void fetchImChannelInfo(WKSDK.shared(), fromChannel);
               }
               const showAvatar =
                 i === 0 ||

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -47,6 +47,11 @@ import {
   restoreOctoRichTextClipboardToEditor,
 } from "./richTextPaste";
 import { handleSecretPaste } from "./secretPasteDetect";
+import {
+  addImChannelInfoListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 
 const MAX_MESSAGE_LENGTH = 5000;
 
@@ -414,7 +419,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
   // 动态生成 placeholder（channelInfo 异步加载后通过 listener 自动更新）
   const [placeholder, setPlaceholder] = useState(() => {
     const channel = props.context.channel();
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
     return buildPlaceholder(channel, channelInfo?.title || "", t);
   });
 
@@ -433,19 +438,19 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         updateName(channelInfo.title || "");
       }
     };
-    WKSDK.shared().channelManager.addListener(listener);
+    const unsubscribeChannelInfo = addImChannelInfoListener(WKSDK.shared(), listener);
 
     // 检查本地缓存；没有则主动 fetch（fetch 完成后 listener 会收到通知）
-    const cached = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const cached = getImChannelInfo(WKSDK.shared(), channel);
     if (cached) {
       updateName(cached.title || "");
     } else {
-      WKSDK.shared().channelManager.fetchChannelInfo(channel).catch(() => {});
+      fetchImChannelInfo(WKSDK.shared(), channel).catch(() => {});
     }
 
     return () => {
       aborted = true;
-      WKSDK.shared().channelManager.removeListener(listener);
+      unsubscribeChannelInfo();
     };
   }, [props.context, t]);
 

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
@@ -274,7 +274,7 @@ describe("PersonaEditVM", () => {
         const ok = await vm.toggleGlobal(true)
         expect(ok).toBe(true)
         expect(vm.grant.global_enabled).toBe(true)
-        expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", { global_enabled: true })
+        expect(hoisted.put).toHaveBeenCalledWith("obo/grants/99", { global_enabled: 1 })
     })
 
     it("addScope POST then reloads", async () => {

--- a/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/__tests__/ThreadPanel.archive.test.tsx
@@ -36,6 +36,10 @@ vi.mock("../../../App", () => ({
       },
     },
     loginInfo: { uid: "owner-uid" },
+    remoteConfig: {
+      messagesSearchOn: false,
+      addConfigChangeListener: vi.fn(() => vi.fn()),
+    },
     shared: { deviceId: "dev-1", currentSpaceId: "space-1" },
     mittBus: { emit: hoisted.emit },
     endpoints: { showConversation: vi.fn() },
@@ -53,6 +57,11 @@ vi.mock("@douyinfe/semi-ui", () => ({
   Popover: ({ children }: any) => React.createElement(React.Fragment, null, children),
 }));
 
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: () => null,
+  TableVirtuoso: () => null,
+}));
+
 vi.mock("wukongimjssdk", () => {
   class Channel {
     channelID: string;
@@ -62,22 +71,26 @@ vi.mock("wukongimjssdk", () => {
       this.channelType = type;
     }
   }
+  const sdk = {
+    shared: () => ({
+      channelManager: {
+        getSubscribes: hoisted.getSubscribes,
+        getChannelInfo: hoisted.getChannelInfo,
+        deleteChannelInfo: hoisted.deleteChannelInfo,
+        fetchChannelInfo: hoisted.fetchChannelInfo,
+        setChannleInfoForCache: hoisted.setChannleInfoForCache,
+        notifyListeners: hoisted.notifyListeners,
+      },
+    }),
+  };
   return {
+    default: sdk,
     Channel,
+    MessageContent: class {},
+    MediaMessageContent: class {},
     ChannelTypePerson: 1,
     ChannelTypeGroup: 2,
-    WKSDK: {
-      shared: () => ({
-        channelManager: {
-          getSubscribes: hoisted.getSubscribes,
-          getChannelInfo: hoisted.getChannelInfo,
-          deleteChannelInfo: hoisted.deleteChannelInfo,
-          fetchChannelInfo: hoisted.fetchChannelInfo,
-          setChannleInfoForCache: hoisted.setChannleInfoForCache,
-          notifyListeners: hoisted.notifyListeners,
-        },
-      }),
-    },
+    WKSDK: sdk,
   };
 });
 
@@ -92,6 +105,13 @@ vi.mock("../../FilePreviewPanel/renderers/ImageRenderer", () => ({ ImageRenderer
 vi.mock("../../../Service/SidebarService", () => ({ __esModule: true, default: { sync: vi.fn().mockResolvedValue(null) } }));
 vi.mock("../../../Service/FollowService", () => ({ __esModule: true, default: {} }));
 vi.mock("../../../Service/CategoryService", () => ({ __esModule: true, default: {} }));
+vi.mock("../../../bridge/thread/createThread", () => ({
+  createThreadByNameAndNotify: vi.fn(),
+}));
+vi.mock("../../../ui/ThreadCreateDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
 
 import ThreadPanel from "../index";
 
@@ -221,9 +241,9 @@ describe("ThreadPanel inline archive button", () => {
       })
     );
     // 已归档分组默认折叠，需先展开
-    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("已归档")).toBeTruthy());
     await act(async () => {
-      fireEvent.click(screen.getByText("Archived"));
+      fireEvent.click(screen.getByText("已归档"));
     });
     await waitFor(() => expect(archiveButton()).toBeTruthy());
 
@@ -391,9 +411,9 @@ describe("ThreadPanel inline archive button", () => {
         onThreadSelect: vi.fn(),
       })
     );
-    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("已归档")).toBeTruthy());
     await act(async () => {
-      fireEvent.click(screen.getByText("Archived"));
+      fireEvent.click(screen.getByText("已归档"));
     });
     await waitFor(() => expect(archiveButton()).toBeTruthy());
 
@@ -554,9 +574,9 @@ describe("ThreadPanel inline archive sidebar sync (issue #345)", () => {
         onThreadSelect: vi.fn(),
       })
     );
-    await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("已归档")).toBeTruthy());
     await act(async () => {
-      fireEvent.click(screen.getByText("Archived"));
+      fireEvent.click(screen.getByText("已归档"));
     });
     await waitFor(() => expect(archiveButton()).toBeTruthy());
 

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -67,6 +67,11 @@ import {
   restoreThreadWidth,
   persistThreadWidth,
 } from "../WKLayout/layoutWidth";
+import {
+  deleteImChannelInfo,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 import "./index.css";
 
 /**
@@ -1000,8 +1005,8 @@ export default class ThreadPanel extends Component<
         : "");
     if (!channelID) return;
     const threadChannel = new Channel(channelID, ChannelTypeCommunityTopic);
-    WKSDK.shared().channelManager.deleteChannelInfo(threadChannel);
-    WKSDK.shared().channelManager.fetchChannelInfo(threadChannel);
+    deleteImChannelInfo(WKSDK.shared(), threadChannel);
+    void fetchImChannelInfo(WKSDK.shared(), threadChannel);
   }
 
   /**
@@ -1538,7 +1543,8 @@ export default class ThreadPanel extends Component<
       return thread.creator_name;
     }
     if (thread.creator_uid) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      const channelInfo = getImChannelInfo(
+        WKSDK.shared(),
         new Channel(thread.creator_uid, ChannelTypePerson)
       );
       return channelInfo?.title || thread.creator_uid;

--- a/packages/dmworkbase/src/Messages/Base/head.tsx
+++ b/packages/dmworkbase/src/Messages/Base/head.tsx
@@ -7,6 +7,7 @@ import WebhookBadge from "../../Components/WebhookBadge";
 import WKApp from "../../App";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { resolveWebhookRowDisplay, webhookFromOfMessage } from "../../Service/IncomingWebhook";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 const titleColors = ["#8C8DFF", "#7983C2", "#6D8DDE", "#5979F0", "#6695DF", "#8F7AC5",
     "#9D77A5", "#8A64D0", "#AA66C3", "#A75C96", "#C8697D", "#B74D62",
@@ -69,7 +70,7 @@ export default class MessageHead extends Component<MessageHeadProps> {
                 ) : null}
             </>
         }
-        const channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(message.fromUID, ChannelTypePerson))
+        const channelInfo = getImChannelInfo(WKSDK.shared(), new Channel(message.fromUID, ChannelTypePerson))
         const isGroupMsg = message.channel.channelType === ChannelTypeGroup
         const isBot = channelInfo?.orgData?.robot === 1
         // 外部群成员来源标记：

--- a/packages/dmworkbase/src/Messages/Base/index.tsx
+++ b/packages/dmworkbase/src/Messages/Base/index.tsx
@@ -45,6 +45,13 @@ import { isMessageContinuation } from "../../Service/messageContinuity";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { I18nContext } from "../../i18n";
 import { formatMessageTimestamp } from "../../Utils/time";
+import {
+  addImChannelInfoListener,
+  addImSubscriberChangeListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+} from "../../im-runtime/channelRuntime";
 
 interface MessageBaseProps extends HTMLProps<any> {
   message: MessageWrap;
@@ -64,6 +71,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
   channelInfoListener!: ChannelInfoListener;
   subscriberChangeListener!: (channel: Channel) => void;
   conversationProvider: IConversationProvider;
+  private unsubscribeChannelInfoListener?: () => void;
+  private unsubscribeSubscriberChangeListener?: () => void;
 
   constructor(props: any) {
     super(props);
@@ -87,11 +96,9 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
       msgChannel.channelType === ChannelTypePerson &&
       !(msgFromUID && msgChannel.channelID === msgFromUID)
     ) {
-      const convCached = WKSDK.shared().channelManager.getChannelInfo(
-        msgChannel
-      );
+      const convCached = getImChannelInfo(WKSDK.shared(), msgChannel);
       if (!convCached) {
-        WKSDK.shared().channelManager.fetchChannelInfo(msgChannel);
+        void fetchImChannelInfo(WKSDK.shared(), msgChannel);
       }
     }
 
@@ -116,7 +123,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
         self.setState({});
       }
     };
-    WKSDK.shared().channelManager.addListener(this.channelInfoListener);
+    this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener);
 
     // 群成员到达 / 更新时触发重渲染：群消息发送者名字优先从群成员列表取，
     // 成员列表是异步同步的，消息可能先于成员列表到达，需要通知一次。
@@ -126,16 +133,17 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
         self.setState({});
       }
     };
-    WKSDK.shared().channelManager.addSubscriberChangeListener(
+    this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(
+      WKSDK.shared(),
       this.subscriberChangeListener
     );
   }
 
   componentWillUnmount() {
-    WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
-    WKSDK.shared().channelManager.removeSubscriberChangeListener(
-      this.subscriberChangeListener
-    );
+    this.unsubscribeChannelInfoListener?.();
+    this.unsubscribeChannelInfoListener = undefined;
+    this.unsubscribeSubscriberChangeListener?.();
+    this.unsubscribeSubscriberChangeListener = undefined;
   }
 
   forceStandalone() {
@@ -265,7 +273,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
   isAiMessage() {
     const { message } = this.props;
     if (message.send) return false;
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(message.fromUID, ChannelTypePerson)
     );
     return channelInfo?.orgData?.robot === 1;
@@ -301,7 +310,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
         if (context) {
           const ch = context.channel();
           if (ch && ch.channelType === ChannelTypePerson) {
-            const chInfo = WKSDK.shared().channelManager.getChannelInfo(ch);
+            const chInfo = getImChannelInfo(WKSDK.shared(), ch);
             if (chInfo?.orgData?.robot === 1) {
               return this.context.t("base.messageBase.error.addBotFriendFirst");
             }
@@ -317,7 +326,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
   render() {
     const { message, context, hiddeBubble, bubbleStyle } = this.props;
     const hasContinue = this.isContinue();
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(message.fromUID, ChannelTypePerson)
     );
     const avatarChannel =
@@ -332,10 +342,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     let groupMember: any = undefined;
     if (message.channel.channelType === ChannelTypeGroup && message.fromUID) {
       try {
-        const subs = WKSDK.shared().channelManager.getSubscribes(
-          message.channel
-        ) as any[] | null | undefined;
-        const member = subs?.find((s) => s && s.uid === message.fromUID);
+        const subs = getImChannelSubscribers(WKSDK.shared(), message.channel) as any[];
+        const member = subs.find((s) => s && s.uid === message.fromUID);
         groupMemberName = subscriberDisplayName(member);
         groupMember = member;
       } catch {
@@ -379,7 +387,8 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
         channelInfo?.title ||
         "";
     if (!channelInfo && !webhookFrom && message.fromUID && message.fromUID !== "") {
-      WKSDK.shared().channelManager.fetchChannelInfo(
+      void fetchImChannelInfo(
+        WKSDK.shared(),
         new Channel(message.fromUID, ChannelTypePerson)
       );
     }
@@ -436,7 +445,7 @@ export default class MessageBase extends Component<MessageBaseProps, any> {
     // isBotSender → groupMember orgData → channelInfo orgData → self-fallback。
     // 判定维度对齐 `src/bridge/message/useMessageRow.ts`，任何规则改动请同步两处。
     const conversationChannelInfo = message.channel
-      ? WKSDK.shared().channelManager.getChannelInfo(message.channel)
+      ? getImChannelInfo(WKSDK.shared(), message.channel)
       : undefined;
     const isOwnMessage = message.fromUID === WKApp.loginInfo.uid;
     // Legacy dir 例外：和 bridge 路径 useMessageRow.ts 对齐。

--- a/packages/dmworkbase/src/Messages/InteractiveCard/senderTrust.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/senderTrust.ts
@@ -1,5 +1,6 @@
 import WKSDK, { Channel, ChannelTypePerson } from "wukongimjssdk";
 import { isIncomingWebhookSender } from "../../Service/IncomingWebhook";
+import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 /**
  * InteractiveCard(=17) 发送者信任分类（render gate）。
@@ -31,7 +32,8 @@ export function classifyCardSender(
   if (!fromUID) {
     return "human";
   }
-  const info = WKSDK.shared().channelManager.getChannelInfo(
+  const info = getImChannelInfo(
+    WKSDK.shared(),
     new Channel(fromUID, ChannelTypePerson)
   );
   // cache miss：fail-closed。返回 pending，调用方负责 fetch + 到达后重渲。
@@ -48,7 +50,8 @@ export function isTrustedCardSender(trust: CardSenderTrust): boolean {
 
 /** pending 时需主动拉取发送者 channelInfo；到达后由 MessageCell 基类 listener 重渲。 */
 export function fetchSenderChannelInfo(fromUID: string): void {
-  WKSDK.shared().channelManager.fetchChannelInfo(
+  void fetchImChannelInfo(
+    WKSDK.shared(),
     new Channel(fromUID, ChannelTypePerson)
   );
 }

--- a/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.depth-limit.test.ts
+++ b/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.depth-limit.test.ts
@@ -94,8 +94,15 @@ vi.mock("../../../bridge/message/useMergeforwardMessageUI", () => ({
   getMergeforwardMessageUI: () => null,
 }));
 vi.mock("../../../Components/WKModal", () => ({ default: () => null }));
+vi.mock("@douyinfe/semi-ui", () => ({
+  Modal: () => null,
+  Popconfirm: ({ children }: any) => children ?? null,
+}));
 vi.mock("@douyinfe/semi-icons", () => ({
+  default: () => null,
+  IconAlertTriangle: () => null,
   IconArrowLeft: () => null,
+  IconChevronDown: () => null,
   IconClose: () => null,
 }));
 vi.mock("../index.css", () => ({}));

--- a/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
@@ -88,7 +88,17 @@ vi.mock("../../../bridge/message/useMergeforwardMessageUI", () => ({
   getMergeforwardMessageUI: () => null,
 }));
 vi.mock("../../../Components/WKModal", () => ({ default: () => null }));
-vi.mock("@douyinfe/semi-icons", () => ({ IconArrowLeft: () => null, IconClose: () => null }));
+vi.mock("@douyinfe/semi-ui", () => ({
+  Modal: () => null,
+  Popconfirm: ({ children }: any) => children ?? null,
+}));
+vi.mock("@douyinfe/semi-icons", () => ({
+  default: () => null,
+  IconAlertTriangle: () => null,
+  IconArrowLeft: () => null,
+  IconChevronDown: () => null,
+  IconClose: () => null,
+}));
 vi.mock("../index.css", () => ({}));
 
 import MergeforwardContent from "../index";

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
@@ -22,6 +22,7 @@ import MessageRow from "../../ui/message/MessageRow";
 import MergeforwardCard from "../../ui/message/MergeforwardCard";
 import { getMergeforwardMessageUI } from "../../bridge/message/useMergeforwardMessageUI";
 import { I18nContext, t } from "../../i18n";
+import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 import "./index.css";
 
@@ -273,12 +274,12 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
     }
     return newMsgs.map((m: Message) => {
       const channel = new Channel(m.fromUID, ChannelTypePerson);
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+      const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
       let name = "";
       if (channelInfo) {
         name = channelInfo.title;
       } else {
-        WKSDK.shared().channelManager.fetchChannelInfo(channel);
+        void fetchImChannelInfo(WKSDK.shared(), channel);
       }
       return (
         <div key={m.messageID} className="wk-mergeforwards-content-item">

--- a/packages/dmworkbase/src/Messages/MessageCell.tsx
+++ b/packages/dmworkbase/src/Messages/MessageCell.tsx
@@ -8,6 +8,12 @@ import WKSDK, {
 } from "wukongimjssdk";
 import ConversationContext from "../Components/Conversation/context";
 import { MessageWrap } from "../Service/Model";
+import {
+    addImChannelInfoListener,
+    addImSubscriberChangeListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+} from "../im-runtime/channelRuntime";
 
 
 export interface MessageBaseCellProps {
@@ -28,6 +34,8 @@ export class MessageBaseCell<P extends MessageBaseCellProps = MessageBaseCellPro
 export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsImp, S = {}> extends MessageBaseCell<P, S> {
     private _channelInfoListener!: ChannelInfoListener
     private _subscriberChangeListener?: (channel: Channel) => void
+    private _unsubscribeChannelInfoListener?: () => void
+    private _unsubscribeSubscriberChangeListener?: () => void
 
     componentDidMount() {
         const { message } = this.props
@@ -56,13 +64,13 @@ export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsIm
                 this.setState({})
             }
         }
-        WKSDK.shared().channelManager.addListener(this._channelInfoListener)
+        this._unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
 
         // 没有缓存时主动拉取 sender Person channelInfo
         if (message.fromUID) {
             const channel = new Channel(message.fromUID, ChannelTypePerson)
-            if (!WKSDK.shared().channelManager.getChannelInfo(channel)) {
-                WKSDK.shared().channelManager.fetchChannelInfo(channel)
+            if (!getImChannelInfo(WKSDK.shared(), channel)) {
+                void fetchImChannelInfo(WKSDK.shared(), channel)
             }
         }
 
@@ -77,8 +85,8 @@ export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsIm
             convChannel.channelType === ChannelTypePerson &&
             !(message.fromUID && convChannel.channelID === message.fromUID)
         ) {
-            if (!WKSDK.shared().channelManager.getChannelInfo(convChannel)) {
-                WKSDK.shared().channelManager.fetchChannelInfo(convChannel)
+            if (!getImChannelInfo(WKSDK.shared(), convChannel)) {
+                void fetchImChannelInfo(WKSDK.shared(), convChannel)
             }
         }
 
@@ -90,15 +98,15 @@ export class MessageCell<P extends MessageBaseCellProps = MessageBaseCellPropsIm
                     this.setState({})
                 }
             }
-            WKSDK.shared().channelManager.addSubscriberChangeListener(this._subscriberChangeListener)
+            this._unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(WKSDK.shared(), this._subscriberChangeListener)
         }
     }
 
     componentWillUnmount() {
-        WKSDK.shared().channelManager.removeListener(this._channelInfoListener)
-        if (this._subscriberChangeListener) {
-            WKSDK.shared().channelManager.removeSubscriberChangeListener(this._subscriberChangeListener)
-        }
+        this._unsubscribeChannelInfoListener?.()
+        this._unsubscribeChannelInfoListener = undefined
+        this._unsubscribeSubscriberChangeListener?.()
+        this._unsubscribeSubscriberChangeListener = undefined
     }
 
     render() {

--- a/packages/dmworkbase/src/Messages/Revoke/index.tsx
+++ b/packages/dmworkbase/src/Messages/Revoke/index.tsx
@@ -6,6 +6,11 @@ import React from 'react'
 import "./index.css"
 import { ChannelInfoListener } from "wukongimjssdk"
 import { I18nContext, t } from "../../i18n"
+import {
+    addImChannelInfoListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+} from "../../im-runtime/channelRuntime"
 
 
 export class RevokeCell extends MessageCell {
@@ -13,6 +18,7 @@ export class RevokeCell extends MessageCell {
     declare context: React.ContextType<typeof I18nContext>
 
     channelInfoListener!:ChannelInfoListener
+    private unsubscribeChannelInfoListener?: () => void
 
     componentDidMount() {
         super.componentDidMount()
@@ -23,12 +29,13 @@ export class RevokeCell extends MessageCell {
                 this.setState({})
             }
         }
-        WKSDK.shared().channelManager.addListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
     }
 
     componentWillUnmount() {
         super.componentWillUnmount()
-        WKSDK.shared().channelManager.removeListener(this.channelInfoListener)
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
     }
 
     static tip(message: MessageWrap) {
@@ -40,7 +47,7 @@ export class RevokeCell extends MessageCell {
                 if (message.from) {
                     memberFromName = message.from.title;
                 } else {
-                    WKSDK.shared().channelManager.fetchChannelInfo(new Channel(message.fromUID, ChannelTypePerson))
+                    void fetchImChannelInfo(WKSDK.shared(), new Channel(message.fromUID, ChannelTypePerson))
                 }
                 return t("base.revoke.revokedMemberMessageByYou", {
                     values: { member: memberFromName },
@@ -50,11 +57,11 @@ export class RevokeCell extends MessageCell {
 
         } else {
             const channel = new Channel(revoker ?? "", ChannelTypePerson)
-            let channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(revoker ?? "", ChannelTypePerson))
+            let channelInfo = getImChannelInfo(WKSDK.shared(), channel)
             if (channelInfo) {
                 name = channelInfo.title
             } else {
-                WKSDK.shared().channelManager.fetchChannelInfo(channel)
+                void fetchImChannelInfo(WKSDK.shared(), channel)
                 name = "--"
             }
             if (revoker !== message.fromUID) {

--- a/packages/dmworkbase/src/Messages/Screenshot/index.tsx
+++ b/packages/dmworkbase/src/Messages/Screenshot/index.tsx
@@ -4,6 +4,7 @@ import WKApp from "../../App";
 import { MessageContentTypeConst } from "../../Service/Const";
 import { MessageCell } from "../MessageCell";
 import { t } from "../../i18n";
+import { getImChannelInfo } from "../../im-runtime/channelRuntime";
 
 
 export class ScreenshotContent extends MessageContent {
@@ -16,7 +17,7 @@ export class ScreenshotContent extends MessageContent {
         if (this.fromUID === WKApp.loginInfo.uid) {
             name = t("base.message.screenshot.you")
         } else {
-            let channelInfo = WKSDK.shared().channelManager.getChannelInfo(new Channel(this.fromUID, ChannelTypePerson))
+            let channelInfo = getImChannelInfo(WKSDK.shared(), new Channel(this.fromUID, ChannelTypePerson))
             if (channelInfo) {
                 name = channelInfo?.orgData?.displayName
             } else {

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 const hoisted = vi.hoisted(() => ({
     channelListener: undefined as undefined | ((channelInfo: any) => void),
     spaceChangedHandler: undefined as undefined | ((space: any) => void),
+    removeChannelListener: vi.fn(),
     popToRoot: vi.fn(),
 }))
 
@@ -29,7 +30,7 @@ vi.mock("wukongimjssdk", () => ({
                 addListener: (listener: (channelInfo: any) => void) => {
                     hoisted.channelListener = listener
                 },
-                removeListener: () => {},
+                removeListener: hoisted.removeChannelListener,
             },
         }),
     },
@@ -221,6 +222,17 @@ describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", 
         // status 变化（1 → 2 归档）：再次 notify
         hoisted.channelListener!({ channel, orgData: { thread: { status: 2 } } })
         expect(notifySpy).toHaveBeenCalledTimes(2)
+    })
+
+    it("卸载时反注册 channelInfo listener", () => {
+        const vm = mountVM()
+        expect(hoisted.channelListener).toBeTypeOf("function")
+        hoisted.removeChannelListener.mockClear()
+
+        vm.didUnMount()
+
+        expect(hoisted.removeChannelListener).toHaveBeenCalledTimes(1)
+        expect(hoisted.removeChannelListener).toHaveBeenCalledWith(hoisted.channelListener)
     })
 })
 

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -70,6 +70,12 @@ import {
 } from "../../Hooks/useFollowSidebar";
 import { SidebarTargetType } from "../../Service/SidebarService";
 import { I18nContext, t } from "../../i18n";
+import {
+  addImChannelInfoListener,
+  deleteImChannelInfo,
+  fetchImChannelInfo,
+  getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 
 // 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
 // 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
@@ -107,7 +113,7 @@ interface SidebarTabBarWithBadgesProps {
  *   不再 sum IM 缓存——sidebar-only 的关注（用户关注但还没聊过，IM 缓存里没有）会被丢掉。
  * - 最近 tab：sum IM 缓存里非勿扰的 conversations，和 recent tab filter='all' 一致。
  *
- * 勿扰判定：通过 WKSDK.channelManager 查 channelInfo.mute（拿不到当作非勿扰）；
+ * 勿扰判定：通过 IM runtime 查 channelInfo.mute（拿不到当作非勿扰）；
  * 子区未显式 mute 时回看父群组的 mute（与列表渲染保持一致）。
  *
  * 数据源由 <FollowSidebarProvider> 统一注入，避免双 hook 实例导致的重复
@@ -134,7 +140,8 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
     else if (it.target_type === SidebarTargetType.THREAD)
       channelType = ChannelTypeCommunityTopic;
     if (channelType == null) return false;
-    const info = WKSDK.shared().channelManager.getChannelInfo(
+    const info = getImChannelInfo(
+      WKSDK.shared(),
       new Channel(it.target_id, channelType)
     );
     const isThread = it.target_type === SidebarTargetType.THREAD;
@@ -143,7 +150,8 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
       const parentGroupNo =
         it.parent_channel_id || parseThreadChannelId(it.target_id)?.groupNo;
       if (parentGroupNo) {
-        parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+        parentChannelInfo = getImChannelInfo(
+          WKSDK.shared(),
           new Channel(parentGroupNo, ChannelTypeGroup)
         );
       }
@@ -283,6 +291,7 @@ export class ChatContentPage extends Component<
   private channelSearchDataSourceKey = "";
   private channelSearchDataSource?: ChannelSearchDataSource;
   private channelSearchPanelState?: ChannelSearchPanelState;
+  private _unsubscribeChannelInfoListener?: () => void;
   private _unsubscribeChannelSearchConfig?: () => void;
 
   constructor(props: any) {
@@ -540,7 +549,10 @@ export class ChatContentPage extends Component<
         this.setState({});
       }
     };
-    WKSDK.shared().channelManager.addListener(this.channelInfoListener);
+    this._unsubscribeChannelInfoListener = addImChannelInfoListener(
+      WKSDK.shared(),
+      this.channelInfoListener
+    );
     this._unsubscribeChannelSearchConfig =
       WKApp.remoteConfig.addConfigChangeListener(() => {
         if (
@@ -752,16 +764,12 @@ export class ChatContentPage extends Component<
 
     // 子区：预先获取父群组信息
     if (channel.channelType === ChannelTypeCommunityTopic) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+      const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
       const parentGroupNo = channelInfo?.orgData?.parentGroupNo;
       if (parentGroupNo) {
         this.parentGroupChannel = new Channel(parentGroupNo, ChannelTypeGroup);
-        if (
-          !WKSDK.shared().channelManager.getChannelInfo(this.parentGroupChannel)
-        ) {
-          WKSDK.shared().channelManager.fetchChannelInfo(
-            this.parentGroupChannel
-          );
+        if (!getImChannelInfo(WKSDK.shared(), this.parentGroupChannel)) {
+          void fetchImChannelInfo(WKSDK.shared(), this.parentGroupChannel);
         }
       }
     }
@@ -852,16 +860,12 @@ export class ChatContentPage extends Component<
       channel.channelType === ChannelTypeCommunityTopic &&
       !this.parentGroupChannel
     ) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+      const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
       const parentGroupNo = channelInfo?.orgData?.parentGroupNo;
       if (parentGroupNo) {
         this.parentGroupChannel = new Channel(parentGroupNo, ChannelTypeGroup);
-        if (
-          !WKSDK.shared().channelManager.getChannelInfo(this.parentGroupChannel)
-        ) {
-          WKSDK.shared().channelManager.fetchChannelInfo(
-            this.parentGroupChannel
-          );
+        if (!getImChannelInfo(WKSDK.shared(), this.parentGroupChannel)) {
+          void fetchImChannelInfo(WKSDK.shared(), this.parentGroupChannel);
         }
       }
     }
@@ -916,7 +920,8 @@ export class ChatContentPage extends Component<
     }
     this._unsubscribeChannelSearchConfig?.();
     this._unsubscribeChannelSearchConfig = undefined;
-    WKSDK.shared().channelManager.removeListener(this.channelInfoListener);
+    this._unsubscribeChannelInfoListener?.();
+    this._unsubscribeChannelInfoListener = undefined;
   }
 
   private getThreadStatus(channelInfo?: ChannelInfo | null) {
@@ -929,7 +934,7 @@ export class ChatContentPage extends Component<
     const { channel } = this.props;
     if (channel.channelType !== ChannelTypeCommunityTopic) return;
 
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
     if (this.getThreadStatus(channelInfo) !== ThreadStatus.Archived) return;
 
     const threadInfo = parseThreadChannelId(channel.channelID);
@@ -995,8 +1000,8 @@ export class ChatContentPage extends Component<
   }
 
   private async refreshCurrentThreadChannelInfo(channel: Channel) {
-    WKSDK.shared().channelManager.deleteChannelInfo(channel);
-    await WKSDK.shared().channelManager.fetchChannelInfo(channel);
+    deleteImChannelInfo(WKSDK.shared(), channel);
+    await fetchImChannelInfo(WKSDK.shared(), channel);
   }
 
   private sleep(ms: number): Promise<void> {
@@ -1021,9 +1026,9 @@ export class ChatContentPage extends Component<
     } = this.state;
     // 子区页面不显示讨论串按钮
     const isThreadChannel = channel.channelType === ChannelTypeCommunityTopic;
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(channel);
+    const channelInfo = getImChannelInfo(WKSDK.shared(), channel);
     if (!channelInfo) {
-      WKSDK.shared().channelManager.fetchChannelInfo(channel);
+      void fetchImChannelInfo(WKSDK.shared(), channel);
     }
     const threadStatus = this.getThreadStatus(channelInfo);
     return (
@@ -1129,7 +1134,8 @@ export class ChatContentPage extends Component<
                                   }
                                 }}
                               >
-                                {WKSDK.shared().channelManager.getChannelInfo(
+                                {getImChannelInfo(
+                                  WKSDK.shared(),
                                   new Channel(
                                     channelInfo.orgData.parentGroupNo,
                                     ChannelTypeGroup

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -21,6 +21,11 @@ import {
     isImConnected,
     removeImConnectStatusListener,
 } from "../../im-runtime/connectStatus";
+import {
+    addImChannelInfoListener,
+    fetchImChannelInfo,
+    getImChannelInfo,
+} from "../../im-runtime/channelRuntime";
 
 
 const TOP_CONVERSATION_SCORE_BOOST = 1000000000000;
@@ -35,6 +40,7 @@ export class ChatVM extends ProviderListener {
     private connectStatusListener!: ConnectStatusListener
     private conversationListener!: ConversationListener
     private channelListener!: ChannelInfoListener
+    private unsubscribeChannelInfoListener?: () => void
     private messageDeleteListener!: MessageDeleteListener
     private conversationListID = "wk-conversationlist"
     private _showGlobalSearch = false // 是否显示全局搜索
@@ -184,9 +190,9 @@ export class ChatVM extends ProviderListener {
         // ---------- 最近会话 ----------
         this.conversationListener = (conversation: Conversation, action: ConversationAction) => {
 
-            const channelInfo = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
+            const channelInfo = getImChannelInfo(WKSDK.shared(), conversation.channel)
             if (!channelInfo) {
-                WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
+                void fetchImChannelInfo(WKSDK.shared(), conversation.channel)
             }
             if (action === ConversationAction.add) {
                 // 新群补写 channelSpaceMap 缓存（WS 推送新群时缓存可能未命中）
@@ -194,7 +200,7 @@ export class ChatVM extends ProviderListener {
                     const key = `${conversation.channel.channelID}_${conversation.channel.channelType}`
                     if (!WKApp.shared.channelSpaceMap.has(key)) {
                         // 尝试从多个来源同步获取 space_id
-                        const info = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
+                        const info = getImChannelInfo(WKSDK.shared(), conversation.channel)
                         const sid = info?.orgData?.space_id
                             || conversation.channelInfo?.orgData?.space_id
                             || (conversation as any).extra?.spaceId
@@ -207,7 +213,7 @@ export class ChatVM extends ProviderListener {
                             // 与 update handler 一致：暂存到待定队列，等 channelInfoListener
                             // 回调拿到权威 space_id 后再二次检查并展示。
                             this._pendingSpaceConversations.set(key, conversation)
-                            WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
+                            void fetchImChannelInfo(WKSDK.shared(), conversation.channel)
                             return
                         }
                     }
@@ -222,7 +228,8 @@ export class ChatVM extends ProviderListener {
                     if (parsed) {
                         const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
                         if (!WKApp.shared.channelSpaceMap.has(parentKey) && WKApp.shared.currentSpaceId) {
-                            WKSDK.shared().channelManager.fetchChannelInfo(
+                            void fetchImChannelInfo(
+                                WKSDK.shared(),
                                 new Channel(parsed.groupNo, ChannelTypeGroup),
                             )
                         }
@@ -250,7 +257,7 @@ export class ChatVM extends ProviderListener {
                     if (!WKApp.shared.channelSpaceMap.has(key)) {
                         // 缓存未命中：暂存 conversation，等 channelInfoListener 回调补写缓存后再处理
                         this._pendingSpaceConversations.set(key, conversation)
-                        WKSDK.shared().channelManager.fetchChannelInfo(conversation.channel)
+                        void fetchImChannelInfo(WKSDK.shared(), conversation.channel)
                         return // 等待 channelInfoListener 回调处理
                     }
                 } else if (conversation.channel.channelType === ChannelTypeCommunityTopic) {
@@ -262,7 +269,8 @@ export class ChatVM extends ProviderListener {
                     if (parsed) {
                         const parentKey = `${parsed.groupNo}_${ChannelTypeGroup}`
                         if (!WKApp.shared.channelSpaceMap.has(parentKey) && WKApp.shared.currentSpaceId) {
-                            WKSDK.shared().channelManager.fetchChannelInfo(
+                            void fetchImChannelInfo(
+                                WKSDK.shared(),
                                 new Channel(parsed.groupNo, ChannelTypeGroup),
                             )
                         }
@@ -360,7 +368,7 @@ export class ChatVM extends ProviderListener {
                 }
             }
         }
-        WKSDK.shared().channelManager.addListener(this.channelListener)
+        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelListener)
 
         this.messageDeleteListener = (message: Message, preMessage?: Message) => {
             const conversation = WKSDK.shared().conversationManager.findConversation(message.channel)
@@ -377,7 +385,8 @@ export class ChatVM extends ProviderListener {
     didUnMount(): void {
         removeImConnectStatusListener(WKSDK.shared(), this.connectStatusListener)
         WKSDK.shared().conversationManager.removeConversationListener(this.conversationListener)
-        WKSDK.shared().channelManager.removeListener(this.channelListener)
+        this.unsubscribeChannelInfoListener?.()
+        this.unsubscribeChannelInfoListener = undefined
         WKApp.shared.removeMessageDeleteListener(this.messageDeleteListener)
         if (this.spaceChangedHandler) {
             WKApp.mittBus.off('space-changed', this.spaceChangedHandler)
@@ -512,7 +521,7 @@ export class ChatVM extends ProviderListener {
                 const extra: any = conv.extra
                 const sid = extra?.spaceId
                     || (conv as any).channelInfo?.orgData?.space_id
-                    || WKSDK.shared().channelManager.getChannelInfo(ch)?.orgData?.space_id
+                    || getImChannelInfo(WKSDK.shared(), ch)?.orgData?.space_id
                 if (sid && !WKApp.shared.channelSpaceMap.has(key)) {
                     WKApp.shared.channelSpaceMap.set(key, sid)
                 }

--- a/packages/dmworkbase/src/__tests__/setup.ts
+++ b/packages/dmworkbase/src/__tests__/setup.ts
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { localeCookieName, localeStorageKey } from "../i18n/detectLocale";
+import { afterEach } from "vitest";
+import { cleanup } from "./testingLibraryReact17";
+
+afterEach(() => {
+  cleanup();
+});
+
+if (typeof HTMLCanvasElement !== "undefined") {
+  const canvasContext = new Proxy({}, { get: () => () => undefined });
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: () => canvasContext,
+  });
+}
+
+try {
+  window.localStorage.setItem(localeStorageKey, "zh-CN");
+  document.cookie = `${localeCookieName}=zh-CN`;
+} catch (_) {
+  // Tests that stub window/document can ignore locale persistence.
+}

--- a/packages/dmworkbase/src/__tests__/testingLibraryReact17.ts
+++ b/packages/dmworkbase/src/__tests__/testingLibraryReact17.ts
@@ -1,0 +1,87 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import {
+  configure,
+  getQueriesForElement,
+  prettyDOM,
+  queries,
+  type Queries,
+} from "@testing-library/dom";
+
+export * from "@testing-library/dom";
+export { act };
+
+const mountedContainers = new Set<Element | DocumentFragment>();
+
+configure({
+  eventWrapper: (callback) => {
+    let result: unknown;
+    act(() => {
+      result = callback();
+    });
+    return result;
+  },
+});
+
+interface RenderOptions<Q extends Queries = typeof queries> {
+  container?: Element;
+  baseElement?: Element | DocumentFragment;
+  queries?: Q;
+}
+
+export function cleanup() {
+  mountedContainers.forEach((container) => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    if (container instanceof Element && container.parentNode === document.body) {
+      document.body.removeChild(container);
+    }
+  });
+  mountedContainers.clear();
+}
+
+export function render<Q extends Queries = typeof queries>(
+  ui: React.ReactElement,
+  options: RenderOptions<Q> = {}
+) {
+  const baseElement = options.baseElement || document.body;
+  const container =
+    options.container || baseElement.appendChild(document.createElement("div"));
+  const boundQueries = getQueriesForElement(
+    baseElement,
+    options.queries || queries
+  );
+
+  act(() => {
+    ReactDOM.render(ui, container);
+  });
+  mountedContainers.add(container);
+
+  return {
+    container,
+    baseElement,
+    ...boundQueries,
+    debug: (element: Element | DocumentFragment = baseElement) => {
+      console.log(prettyDOM(element));
+    },
+    rerender: (nextUi: React.ReactElement) => {
+      act(() => {
+        ReactDOM.render(nextUi, container);
+      });
+    },
+    unmount: () => {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+      });
+      mountedContainers.delete(container);
+    },
+    asFragment: () => {
+      const template = document.createElement("template");
+      template.innerHTML =
+        container instanceof Element ? container.innerHTML : "";
+      return template.content;
+    },
+  };
+}

--- a/packages/dmworkbase/src/bridge/message/useMessageRow.ts
+++ b/packages/dmworkbase/src/bridge/message/useMessageRow.ts
@@ -15,6 +15,13 @@ import {
 import moment from 'moment'
 import { isMessageContinuation } from '../../Service/messageContinuity'
 import { formatMessageTimestamp } from '../../Utils/time'
+import {
+  addImChannelInfoListener,
+  addImSubscriberChangeListener,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+} from '../../im-runtime/channelRuntime'
 
 export interface MessageRowSelectionState {
   /** 当前会话是否处于多选模式（不可选消息也需要知道，用于禁用行内操作） */
@@ -63,8 +70,8 @@ function getGroupMemberInfo(message: MessageWrap): { member: any | undefined; me
     return { member: undefined, memberName: '' }
   }
   try {
-    const subs = WKSDK.shared().channelManager.getSubscribes(message.channel) as any[] | null | undefined
-    const member = subs?.find((s) => s && s.uid === message.fromUID)
+    const subs = getImChannelSubscribers(WKSDK.shared(), message.channel) as any[]
+    const member = subs.find((s) => s && s.uid === message.fromUID)
     return { member, memberName: subscriberDisplayName(member) }
   } catch {
     return { member: undefined, memberName: '' }
@@ -85,7 +92,8 @@ export function getMessageRow(
   selection?: MessageRowSelectionState,
   interaction?: MessageRowInteractionState
 ): Omit<MessageRowUIProps, 'children'> {
-  const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+  const channelInfo = getImChannelInfo(
+    WKSDK.shared(),
     new Channel(message.fromUID, ChannelTypePerson)
   )
 
@@ -210,7 +218,7 @@ export function getMessageRow(
   //   再 rerender 决定真实值。这样不会把「你发给朋友」也压下去（若朋友的
   //   Person channelInfo 已缓存，conversationChannelInfo !== undefined）。
   const conversationChannelInfo = message.channel
-    ? WKSDK.shared().channelManager.getChannelInfo(message.channel)
+    ? getImChannelInfo(WKSDK.shared(), message.channel)
     : undefined
   const isOwnMessage = message.fromUID === WKApp.loginInfo.uid
   const isPersonConversation =
@@ -296,9 +304,9 @@ export function useMessageRow(
     const channel = new Channel(fromUID, ChannelTypePerson)
 
     // 没有缓存时发起请求
-    const cached = WKSDK.shared().channelManager.getChannelInfo(channel)
+    const cached = getImChannelInfo(WKSDK.shared(), channel)
     if (!cached) {
-      WKSDK.shared().channelManager.fetchChannelInfo(channel)
+      void fetchImChannelInfo(WKSDK.shared(), channel)
     }
 
     // R4（Jerry R3 timing race）：会话对端（message.channel，Person
@@ -319,9 +327,9 @@ export function useMessageRow(
       convChannel.channelType === ChannelTypePerson &&
       !convChannel.isEqual(channel)
     ) {
-      const convCached = WKSDK.shared().channelManager.getChannelInfo(convChannel)
+      const convCached = getImChannelInfo(WKSDK.shared(), convChannel)
       if (!convCached) {
-        WKSDK.shared().channelManager.fetchChannelInfo(convChannel)
+        void fetchImChannelInfo(WKSDK.shared(), convChannel)
       }
     }
 
@@ -341,7 +349,7 @@ export function useMessageRow(
         forceUpdate()
       }
     }
-    WKSDK.shared().channelManager.addListener(listener)
+    const unsubscribeChannelInfo = addImChannelInfoListener(WKSDK.shared(), listener)
 
     // 群成员到达 / 更新时触发重渲染：群消息发送者名字主路径读群成员列表，
     // 成员列表是异步同步的，消息可能先于成员列表到达，需要通知一次。
@@ -351,11 +359,11 @@ export function useMessageRow(
         forceUpdate()
       }
     }
-    WKSDK.shared().channelManager.addSubscriberChangeListener(subListener)
+    const unsubscribeSubscriberChange = addImSubscriberChangeListener(WKSDK.shared(), subListener)
 
     return () => {
-      WKSDK.shared().channelManager.removeListener(listener)
-      WKSDK.shared().channelManager.removeSubscriberChangeListener(subListener)
+      unsubscribeChannelInfo()
+      unsubscribeSubscriberChange()
     }
   }, [message.fromUID, message.channel, forceUpdate])
 

--- a/packages/dmworkbase/src/im-runtime/channelRuntime.test.ts
+++ b/packages/dmworkbase/src/im-runtime/channelRuntime.test.ts
@@ -5,10 +5,13 @@ import {
   deleteImChannelInfo,
   fetchImChannelInfo,
   getImChannelInfo,
+  getImChannelSubscriberOfMe,
   getImChannelSubscribers,
   getImSubscribeCacheMap,
   notifyImChannelInfoListeners,
+  notifyImSubscriberChangeListeners,
   patchImChannelInfoOrgData,
+  setImChannelSubscribersCache,
   setImChannelInfoCache,
   syncImChannelSubscribers,
   type ImChannelInfoLike,
@@ -29,10 +32,12 @@ function createSdk() {
       removeListener: vi.fn(),
       deleteChannelInfo: vi.fn(),
       getSubscribes: vi.fn(),
+      getSubscribeOfMe: vi.fn(),
       syncSubscribes: vi.fn(),
       subscribeCacheMap: new Map(),
       addSubscriberChangeListener: vi.fn(),
       removeSubscriberChangeListener: vi.fn(),
+      notifySubscribeChangeListeners: vi.fn(),
     },
   } satisfies ImChannelRuntimeSdk &
     ImChannelCacheRuntimeSdk &
@@ -136,6 +141,16 @@ describe("channelRuntime", () => {
     expect(getImChannelSubscribers(sdk, channel)).toEqual([]);
   });
 
+  it("reads the current user's subscriber through the SDK channel manager", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+    const subscriber = { uid: "me", role: 1 };
+    sdk.channelManager.getSubscribeOfMe.mockReturnValue(subscriber);
+
+    expect(getImChannelSubscriberOfMe(sdk, channel)).toBe(subscriber);
+    expect(sdk.channelManager.getSubscribeOfMe).toHaveBeenCalledWith(channel);
+  });
+
   it("syncs subscribers through the SDK channel manager", async () => {
     const sdk = createSdk();
     const channel = { channelID: "g1", channelType: 2 };
@@ -154,6 +169,20 @@ describe("channelRuntime", () => {
     );
   });
 
+  it("writes subscribers to the SDK subscribe cache", () => {
+    const sdk = createSdk();
+    const channel = {
+      channelID: "g1",
+      channelType: 2,
+      getChannelKey: () => "2@g1",
+    };
+    const subscribers = [{ uid: "u1" }, { uid: "u2" }];
+
+    setImChannelSubscribersCache(sdk, channel, subscribers);
+
+    expect(sdk.channelManager.subscribeCacheMap.get("2@g1")).toBe(subscribers);
+  });
+
   it("returns an unsubscribe when adding a subscriber change listener", () => {
     const sdk = createSdk();
     const listener = vi.fn();
@@ -167,6 +196,17 @@ describe("channelRuntime", () => {
     expect(
       sdk.channelManager.removeSubscriberChangeListener
     ).toHaveBeenCalledWith(listener);
+  });
+
+  it("notifies SDK subscriber change listeners", () => {
+    const sdk = createSdk();
+    const channel = { channelID: "g1", channelType: 2 };
+
+    notifyImSubscriberChangeListeners(sdk, channel);
+
+    expect(
+      sdk.channelManager.notifySubscribeChangeListeners
+    ).toHaveBeenCalledWith(channel);
   });
 
   it("patches orgData while preserving existing fields", () => {

--- a/packages/dmworkbase/src/im-runtime/channelRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/channelRuntime.ts
@@ -3,6 +3,10 @@ export interface ImChannelLike {
   channelType: number;
 }
 
+export interface ImChannelCacheKeyLike extends ImChannelLike {
+  getChannelKey: () => string;
+}
+
 export interface ImChannelInfoLike {
   channel: ImChannelLike;
   title?: string;
@@ -64,11 +68,13 @@ export interface ImChannelSubscribersRuntimeSdk<
 > {
   channelManager: {
     getSubscribes: (channel: TChannel) => TSubscriber[] | undefined | null;
+    getSubscribeOfMe: (channel: TChannel) => TSubscriber | null | undefined;
     syncSubscribes: (channel: TChannel) => Promise<void> | void;
     addSubscriberChangeListener: (listener: ImSubscriberChangeListener) => void;
     removeSubscriberChangeListener: (
       listener: ImSubscriberChangeListener
     ) => void;
+    notifySubscribeChangeListeners: (channel: TChannel) => void;
   };
 }
 
@@ -142,6 +148,16 @@ export function getImChannelSubscribers<
   return sdk.channelManager.getSubscribes(channel) || [];
 }
 
+export function getImChannelSubscriberOfMe<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(
+  sdk: ImChannelSubscribersRuntimeSdk<TChannel, TSubscriber>,
+  channel: TChannel
+) {
+  return sdk.channelManager.getSubscribeOfMe(channel);
+}
+
 export function syncImChannelSubscribers<
   TChannel extends ImChannelLike,
   TSubscriber = ImSubscriberLike
@@ -158,6 +174,17 @@ export function getImSubscribeCacheMap<TSubscriber = ImSubscriberLike>(
   return sdk.channelManager.subscribeCacheMap;
 }
 
+export function setImChannelSubscribersCache<
+  TChannel extends ImChannelCacheKeyLike,
+  TSubscriber = ImSubscriberLike
+>(
+  sdk: ImSubscribeCacheRuntimeSdk<TSubscriber>,
+  channel: TChannel,
+  subscribers: TSubscriber[]
+) {
+  sdk.channelManager.subscribeCacheMap.set(channel.getChannelKey(), subscribers);
+}
+
 export function addImSubscriberChangeListener<
   TChannel extends ImChannelLike,
   TSubscriber = ImSubscriberLike
@@ -169,6 +196,13 @@ export function addImSubscriberChangeListener<
   return () => {
     sdk.channelManager.removeSubscriberChangeListener(listener);
   };
+}
+
+export function notifyImSubscriberChangeListeners<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(sdk: ImChannelSubscribersRuntimeSdk<TChannel, TSubscriber>, channel: TChannel) {
+  sdk.channelManager.notifySubscribeChangeListeners(channel);
 }
 
 export function patchImChannelInfoOrgData<

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -134,6 +134,18 @@ import {
 } from "./Service/threadPermission";
 import { runChannelSettingThreadArchive } from "./Service/threadArchiveAction";
 import { canShowRevokeMenu } from "./Service/revokePermission";
+import {
+  addImChannelInfoListener,
+  deleteImChannelInfo,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscriberOfMe,
+  getImChannelSubscribers,
+  notifyImChannelInfoListeners,
+  notifyImSubscriberChangeListeners,
+  setImChannelSubscribersCache,
+  syncImChannelSubscribers,
+} from "./im-runtime/channelRuntime";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
 function fallbackCopy(text: string) {
@@ -163,18 +175,18 @@ function removeLocalConversationAndCloseIfOpen(channel: Channel) {
 const pendingRevokeRoleFetches = new Set<string>();
 
 function findSubscriber(channel: Channel, uid: string): Subscriber | undefined {
-  const subscribers = WKSDK.shared().channelManager.getSubscribes(channel) as
-    | Subscriber[]
-    | null
-    | undefined;
-  return subscribers?.find(
+  const subscribers = getImChannelSubscribers(
+    WKSDK.shared(),
+    channel
+  ) as Subscriber[];
+  return subscribers.find(
     (subscriber) => subscriber && subscriber.uid === uid
   );
 }
 
 function mergeSubscriberIntoCache(channel: Channel, subscriber: Subscriber) {
-  const channelManager = WKSDK.shared().channelManager;
-  const cached = (channelManager.getSubscribes(channel) || []) as Subscriber[];
+  const sdk = WKSDK.shared();
+  const cached = getImChannelSubscribers(sdk, channel) as Subscriber[];
   const nextSubscribers = [...cached];
   const index = nextSubscribers.findIndex(
     (item) => item.uid === subscriber.uid
@@ -190,11 +202,8 @@ function mergeSubscriberIntoCache(channel: Channel, subscriber: Subscriber) {
     nextSubscribers.push(subscriber);
   }
 
-  channelManager.subscribeCacheMap.set(
-    channel.getChannelKey(),
-    nextSubscribers
-  );
-  channelManager.notifySubscribeChangeListeners(channel);
+  setImChannelSubscribersCache(sdk, channel, nextSubscribers);
+  notifyImSubscriberChangeListeners(sdk, channel);
 }
 
 function warmRevokeTargetRole(channel: Channel, uid: string) {
@@ -417,7 +426,8 @@ export default class BaseModule implements IModule {
         // 不能盲目调用 syncGroupDisbandState（会把正常群标记为已解散）。
         // 操作者本人的解散走 GroupManagement.handleDisband → syncGroupDisbandState
         // （本地直写规避 SDK 去重竞态），远程端依赖服务端推送的 channelUpdate 事件。
-        WKSDK.shared().channelManager.fetchChannelInfo(
+        void fetchImChannelInfo(
+          WKSDK.shared(),
           new Channel(param.channel_id, param.channel_type)
         );
       } else if (cmdContent.cmd === "typing") {
@@ -435,7 +445,8 @@ export default class BaseModule implements IModule {
           new Channel(param.group_no, ChannelTypeGroup)
         );
         // 通过触发channelInfoListener来更新UI
-        WKSDK.shared().channelManager.fetchChannelInfo(
+        void fetchImChannelInfo(
+          WKSDK.shared(),
           new Channel(param.group_no, ChannelTypeGroup)
         );
       } else if (cmdContent.cmd === "unreadClear") {
@@ -483,7 +494,8 @@ export default class BaseModule implements IModule {
           return;
         }
         if (param.from_uid) {
-          WKSDK.shared().channelManager.fetchChannelInfo(
+          void fetchImChannelInfo(
+            WKSDK.shared(),
             new Channel(param.from_uid, ChannelTypePerson)
           );
         }
@@ -512,21 +524,21 @@ export default class BaseModule implements IModule {
           cmdContent.param.group_no,
           ChannelTypeGroup
         );
-        WKSDK.shared().channelManager.syncSubscribes(channel);
+        void syncImChannelSubscribers(WKSDK.shared(), channel);
       } else if (cmdContent.cmd === "onlineStatus") {
         // 好友在线状态改变
         const channel = new Channel(cmdContent.param.uid, ChannelTypePerson);
         const online = param.online === 1;
         const onlineChannelInfo =
-          WKSDK.shared().channelManager.getChannelInfo(channel);
+          getImChannelInfo(WKSDK.shared(), channel);
         if (onlineChannelInfo) {
           onlineChannelInfo.online = online;
           if (!online) {
             onlineChannelInfo.lastOffline = new Date().getTime() / 1000;
           }
-          WKSDK.shared().channelManager.notifyListeners(onlineChannelInfo);
+          notifyImChannelInfoListeners(WKSDK.shared(), onlineChannelInfo);
         } else {
-          WKSDK.shared().channelManager.fetchChannelInfo(channel);
+          void fetchImChannelInfo(WKSDK.shared(), channel);
         }
       } else if (cmdContent.cmd === "syncConversationExtra") {
         // 同步最近会话扩展
@@ -569,18 +581,19 @@ export default class BaseModule implements IModule {
         case MessageContentTypeConst.channelUpdate:
           // 同 CMD channelUpdate：通用事件，无法区分是否解散，fetch 最新态。
           // 操作者本人的解散走 GroupManagement.handleDisband → syncGroupDisbandState。
-          WKSDK.shared().channelManager.fetchChannelInfo(message.channel);
+          void fetchImChannelInfo(WKSDK.shared(), message.channel);
           break;
         case MessageContentTypeConst.addMembers:
         case MessageContentTypeConst.removeMembers:
-          WKSDK.shared().channelManager.syncSubscribes(message.channel);
+          void syncImChannelSubscribers(WKSDK.shared(), message.channel);
           break;
       }
 
       if (this.allowNotify(message)) {
         let from = "";
         if (message.channel.channelType === ChannelTypeGroup) {
-          const fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+          const fromChannelInfo = getImChannelInfo(
+            WKSDK.shared(),
             new Channel(message.fromUID, ChannelTypePerson)
           );
           if (fromChannelInfo) {
@@ -595,7 +608,7 @@ export default class BaseModule implements IModule {
       }
     });
 
-    WKSDK.shared().channelManager.addListener((channelInfo: ChannelInfo) => {
+    addImChannelInfoListener(WKSDK.shared(), (channelInfo: ChannelInfo) => {
       if (channelInfo.channel.channelType === ChannelTypePerson) {
         if (WKApp.loginInfo.uid === channelInfo.channel.channelID) {
           WKApp.loginInfo.name = channelInfo.title;
@@ -712,7 +725,8 @@ export default class BaseModule implements IModule {
     }
 
     // 已屏蔽（免打扰）的 channel 不播提示音、不发通知
-    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(
+    const channelInfo = getImChannelInfo(
+      WKSDK.shared(),
       message.channel
     );
     if (channelInfo?.mute) {
@@ -723,7 +737,8 @@ export default class BaseModule implements IModule {
       | string
       | undefined;
     if (parentGroupNo) {
-      const parentChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+      const parentChannelInfo = getImChannelInfo(
+        WKSDK.shared(),
         new Channel(parentGroupNo, ChannelTypeGroup)
       );
       if (parentChannelInfo?.mute) {
@@ -954,7 +969,8 @@ export default class BaseModule implements IModule {
         // Bot 创建者可撤回自己创建的 Bot 发送的消息（与群管理员同等待遇，
         // 不受 message.send 和 24h 时间窗口限制，与后端行为一致）
         let isBotOwner = false;
-        const fromChannelInfo = WKSDK.shared().channelManager.getChannelInfo(
+        const fromChannelInfo = getImChannelInfo(
+          WKSDK.shared(),
           new Channel(message.fromUID, ChannelTypePerson)
         );
         if (fromChannelInfo?.orgData?.robot === 1) {
@@ -980,8 +996,7 @@ export default class BaseModule implements IModule {
 
         if (isGroup || isThread) {
           // 获取当前用户在群/子区父群中的角色
-          const sub =
-            WKSDK.shared().channelManager.getSubscribeOfMe(roleChannel);
+          const sub = getImChannelSubscriberOfMe(WKSDK.shared(), roleChannel);
           myRole = sub?.role;
 
           // 管理员撤回别人消息时必须确认发送者不是群主/管理员；角色未知时默认隐藏。
@@ -1182,14 +1197,16 @@ export default class BaseModule implements IModule {
               membershipOrgData?.invite_uid,
               ChannelTypePerson
             );
-            const inviteChannelInfo =
-              WKSDK.shared().channelManager.getChannelInfo(inviterChannel);
+            const inviteChannelInfo = getImChannelInfo(
+              WKSDK.shared(),
+              inviterChannel
+            );
             if (inviteChannelInfo) {
               joinDesc += t("base.module.userInfo.invitedBy", {
                 values: { name: inviteChannelInfo.title },
               });
             } else {
-              WKSDK.shared().channelManager.fetchChannelInfo(inviterChannel);
+              void fetchImChannelInfo(WKSDK.shared(), inviterChannel);
             }
           } else {
             joinDesc += t("base.module.userInfo.joinedGroup");
@@ -1283,7 +1300,8 @@ export default class BaseModule implements IModule {
                             channel
                           );
 
-                          WKSDK.shared().channelManager.fetchChannelInfo(
+                          void fetchImChannelInfo(
+                            WKSDK.shared(),
                             new Channel(data.uid, ChannelTypePerson)
                           );
                         })
@@ -1845,12 +1863,11 @@ export default class BaseModule implements IModule {
                                 )
                               );
                               context.pop();
-                              void WKSDK.shared().channelManager.syncSubscribes(
+                              void syncImChannelSubscribers(
+                                WKSDK.shared(),
                                 channel
                               );
-                              void WKSDK.shared().channelManager.fetchChannelInfo(
-                                channel
-                              );
+                              void fetchImChannelInfo(WKSDK.shared(), channel);
                               data.refresh();
                             } catch (err: any) {
                               Toast.error(
@@ -2357,10 +2374,8 @@ export default class BaseModule implements IModule {
                       return; // 失败时 inputEditPush 正常关闭，不刷新缓存
                     }
                     // 清除缓存后重新拉取，拿到新数据再刷新 UI
-                    WKSDK.shared().channelManager.deleteChannelInfo(channel);
-                    await WKSDK.shared().channelManager.fetchChannelInfo(
-                      channel
-                    );
+                    deleteImChannelInfo(WKSDK.shared(), channel);
+                    await fetchImChannelInfo(WKSDK.shared(), channel);
                     data.refresh();
                   },
                   t("base.module.thread.name"),
@@ -2391,10 +2406,9 @@ export default class BaseModule implements IModule {
             threadInfo.groupNo,
             ChannelTypeGroup
           );
-          const groupInfo =
-            WKSDK.shared().channelManager.getChannelInfo(groupChannel);
+          const groupInfo = getImChannelInfo(WKSDK.shared(), groupChannel);
           if (!groupInfo) {
-            WKSDK.shared().channelManager.fetchChannelInfo(groupChannel);
+            void fetchImChannelInfo(WKSDK.shared(), groupChannel);
           }
           const groupName = groupInfo?.title || threadInfo.groupNo;
           rows.push(

--- a/packages/dmworkbase/vitest.config.ts
+++ b/packages/dmworkbase/vitest.config.ts
@@ -1,8 +1,47 @@
 import { defineConfig } from 'vitest/config'
+import path from 'node:path'
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@testing-library/react',
+        replacement: path.resolve(__dirname, 'src/__tests__/testingLibraryReact17.ts'),
+      },
+      {
+        find: 'react',
+        replacement: path.resolve(__dirname, 'node_modules/react'),
+      },
+      {
+        find: 'react-dom',
+        replacement: path.resolve(__dirname, 'node_modules/react-dom'),
+      },
+      {
+        find: '@douyinfe/semi-ui',
+        replacement: path.resolve(__dirname, 'node_modules/@douyinfe/semi-ui'),
+      },
+      {
+        find: '@douyinfe/semi-icons',
+        replacement: path.resolve(__dirname, 'node_modules/@douyinfe/semi-icons'),
+      },
+      {
+        find: /^react\/jsx-runtime$/,
+        replacement: path.resolve(__dirname, 'node_modules/react/jsx-runtime.js'),
+      },
+      {
+        find: /^react\/jsx-dev-runtime$/,
+        replacement: path.resolve(__dirname, 'node_modules/react/jsx-dev-runtime.js'),
+      },
+    ],
+  },
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+    server: {
+      deps: {
+        inline: [/@tiptap\/react/, /@douyinfe\/semi-icons/, /@douyinfe\/semi-ui/],
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Add a dmworkbase channel runtime facade for channel info, subscriber cache, subscriber sync, and listener operations.
- Route chat, conversation list, message rendering, forwarding, thread panel, and base module channelManager usage through the facade.
- Add React 17-compatible dmworkbase Vitest setup so the package test suite runs consistently.

## Verification
- pnpm --dir packages/dmworkbase test
- git diff --check
- Confirmed production code has no direct WKSDK.shared().channelManager calls outside the facade.