### PR TITLE
ci: fix osv-scan job outputs exceeding 1MB on scan-pr

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,11 +26,16 @@ jobs:
 
   scan-pr:
     if: github.event_name == 'pull_request'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    # Pinned to a main-branch SHA (not a tag) because the export-results input is not yet
+    # in a released tag; re-pin to v2.3.9+ once the flag ships in a tagged release.
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@a82132c0bd6c7261ffcb78e754c46c70ab57ad9a # main
     with:
       scan-args: |-
         -r
         ./
+      # Gate exporting base/head scan results as job outputs. On large repos the combined
+      # JSON exceeds GitHub's ~1MB per-output limit and fails the job (upstream #129).
+      export-results: false
       # Skip SARIF upload when GITHUB_TOKEN is read-only:
       # - Fork PRs: token is inherently read-only
       # - Dependabot PRs: GitHub enforces read-only token for dependabot[bot]


### PR DESCRIPTION
## Problem

The `scan-pr` job fails at the post-job step with `Maximum object size exceeded` / `Fail to evaluate job outputs`, so the OSV-Scanner check is red on every pull request.

Root cause: `scan-pr` consumes `osv-scanner-reusable-pr.yml`, which since osv-scanner-action **v2.3.6** exports the full base **and** head scan results as job outputs (`old-results` / `new-results`). This repo has ~2700 dependencies (npm + Rust), so the combined JSON blows past GitHub Actions' ~1MB per-output limit. The failure happens while GitHub evaluates the reusable workflow's outputs, so `fail-on-vuln: false` does not help — the job dies before that matters. This is upstream [google/osv-scanner-action#129](https://github.com/google/osv-scanner-action/issues/129).

## Fix

Upstream commit [`3a7550f4`](https://github.com/google/osv-scanner-action/commit/3a7550f43ba5b58905a821ce3a0ed24c4858b3f4) ("feat: gate reusable workflow outputs with a flag", Fixes #129) added an `export-results` input (default `false`) to both reusable workflows, which gates the output-export step behind `if: ${{ inputs.export-results }}`.

That change is not in a tagged release yet, so this PR:

- Re-pins `scan-pr` from `9a498708…` (v2.3.8) to `a82132c0bd6c7261ffcb78e754c46c70ab57ad9a` (the current `main` SHA that includes the flag).
- Sets `export-results: false` explicitly to keep the large scan results out of job outputs.

`scan-scheduled` is intentionally left untouched — the 1MB failure only reproduces on the PR path (base + head double scan), and this keeps the change minimal.

### Verification of the pinned SHA

At `a82132c0…`, `.github/workflows/osv-scanner-reusable-pr.yml` declares the input under `workflow_call.inputs`:

```yaml
export-results:
  description: "Whether to export the scan results as job outputs (can fail for large repositories due to size limits)"
  type: boolean
  default: false
```

and the export step is guarded by `if: ${{ inputs.export-results }}`, so passing `false` (or relying on the default) skips it entirely. The SHA is the merge commit of upstream PR #135 and sits on `main` after `3a7550f4`.

## Diff

Only `.github/workflows/osv-scanner.yml`, `scan-pr` job:

```yaml
  scan-pr:
    if: github.event_name == 'pull_request'
    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@a82132c0bd6c7261ffcb78e754c46c70ab57ad9a # main
    with:
      scan-args: |-
        -r
        ./
      export-results: false
      ...
```

## TODO

Pinning to a raw `main` SHA is a stopgap. **Re-pin to a tagged release (v2.3.9+) once `export-results` ships in a tag**, restoring a version-tagged pin.

Opened as a **draft** for review before it goes to `ready`.
