### PR TITLE
feat(loop): Agent Runtime UI — streaming client, verbose rendering, rich diff, checkpoints

### DIFF
--- a/packages/dmloop/src/agentRuntime/AgentRuntimePanel.tsx
+++ b/packages/dmloop/src/agentRuntime/AgentRuntimePanel.tsx
@@ -1,0 +1,179 @@
+// @octo/loop — Agent Runtime 面板（顶层装配）
+//
+// 把会话列表 / prompt 输入 / verbose 三档 / chat⇄code 一键切 / 富 diff / checkpoint
+// 时间线接到 useAgentStream 上。diff / checkpoint / rollback 相关端点「待后端确认」，
+// 这里按契约调用，失败降级为空态 + 错误提示，不阻断聊天主流程。
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Send, Square, MessagesSquare, Code2, AlertTriangle } from "lucide-react";
+import { useAgentStream } from "./useAgentStream";
+import * as runtimeApi from "../api/agentRuntime/agentRuntimeApi";
+import type { AgentSessionSummary, FileDiff, Checkpoint } from "../api/agentRuntime/contracts";
+import SessionList from "./SessionList";
+import VerboseRenderer, { type VerboseLevel } from "./VerboseRenderer";
+import DiffView from "./DiffView";
+import CheckpointTimeline from "./CheckpointTimeline";
+import "./panel.css";
+
+type Mode = "chat" | "code";
+
+export interface AgentRuntimePanelProps {
+  agentId?: string;
+  initialSessionKey?: string;
+}
+
+export default function AgentRuntimePanel({ agentId, initialSessionKey }: AgentRuntimePanelProps) {
+  const [sessions, setSessions] = useState<AgentSessionSummary[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [activeKey, setActiveKey] = useState<string | undefined>(initialSessionKey);
+  const [verbose, setVerbose] = useState<VerboseLevel>("on");
+  const [mode, setMode] = useState<Mode>("chat");
+  const [draft, setDraft] = useState("");
+
+  const [diffs, setDiffs] = useState<FileDiff[]>([]);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
+  const [ckptLoading, setCkptLoading] = useState(false);
+
+  const stream = useAgentStream({ sessionKey: activeKey, agentId });
+
+  // 会话列表。
+  useEffect(() => {
+    let alive = true;
+    setSessionsLoading(true);
+    runtimeApi
+      .listSessions({ agentId })
+      .then((rows) => alive && setSessions(rows))
+      .catch(() => alive && setSessions([]))
+      .finally(() => alive && setSessionsLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [agentId]);
+
+  const selectSession = useCallback(
+    (key: string) => {
+      setActiveKey(key);
+      void stream.loadHistory(key);
+    },
+    [stream],
+  );
+
+  // code 模式：拉 diff + checkpoint（端点待后端确认，失败静默降级）。
+  const refreshCode = useCallback(async () => {
+    if (!activeKey) return;
+    setDiffLoading(true);
+    setCkptLoading(true);
+    const [d, c] = await Promise.all([
+      runtimeApi.getDiff({ sessionKey: activeKey }).catch(() => [] as FileDiff[]),
+      runtimeApi.listCheckpoints(activeKey).catch(() => [] as Checkpoint[]),
+    ]);
+    setDiffs(d);
+    setCheckpoints(c);
+    setDiffLoading(false);
+    setCkptLoading(false);
+  }, [activeKey]);
+
+  useEffect(() => {
+    if (mode === "code") void refreshCode();
+  }, [mode, refreshCode]);
+
+  const onRollback = useCallback(
+    async (checkpointId: string) => {
+      if (!activeKey) return;
+      await runtimeApi.rollback(activeKey, checkpointId).catch(() => { /* 待后端确认：失败提示交由上层 */ });
+      await refreshCode();
+    },
+    [activeKey, refreshCode],
+  );
+
+  const submit = useCallback(() => {
+    const text = draft.trim();
+    if (!text || stream.running) return;
+    setDraft("");
+    stream.send(text);
+  }, [draft, stream]);
+
+  return (
+    <div className="loop-art-root">
+      <aside className="loop-art-sidebar">
+        <SessionList sessions={sessions} activeKey={activeKey} onSelect={selectSession} loading={sessionsLoading} />
+      </aside>
+
+      <main className="loop-art-main">
+        <header className="loop-art-toolbar">
+          {/* chat ⇄ code 一键切 */}
+          <div className="loop-art-modes">
+            <button type="button" className={`loop-art-mode ${mode === "chat" ? "active" : ""}`} onClick={() => setMode("chat")}>
+              <MessagesSquare size={14} /> Chat
+            </button>
+            <button type="button" className={`loop-art-mode ${mode === "code" ? "active" : ""}`} onClick={() => setMode("code")}>
+              <Code2 size={14} /> Code
+            </button>
+          </div>
+
+          {/* verbose 三档 */}
+          <div className="loop-art-verbose">
+            {(["off", "on", "full"] as VerboseLevel[]).map((lv) => (
+              <button key={lv} type="button" className={`loop-art-vbtn ${verbose === lv ? "active" : ""}`} onClick={() => setVerbose(lv)}>
+                {lv}
+              </button>
+            ))}
+          </div>
+
+          {/* abort 在跑 turn */}
+          {stream.running && (
+            <button type="button" className="loop-art-abort" onClick={stream.abort} title="Abort current turn">
+              <Square size={13} /> Stop
+            </button>
+          )}
+        </header>
+
+        {/* 回放不可用降级：可能有事件缺失 */}
+        {stream.state.maybeMissingEvents && (
+          <div className="loop-art-warn">
+            <AlertTriangle size={14} /> Some events may be missing (stream replay unavailable — reconciled from server state).
+          </div>
+        )}
+        {stream.error && <div className="loop-art-error">{stream.error}</div>}
+
+        <div className="loop-art-content">
+          {mode === "chat" ? (
+            <VerboseRenderer state={stream.state} level={verbose} />
+          ) : (
+            <div className="loop-art-code">
+              <section className="loop-art-diff">
+                <h4>Changes</h4>
+                {diffLoading ? <div className="loop-art-hint">Loading diff…</div> : <DiffView diffs={diffs} />}
+              </section>
+              <section className="loop-art-ckpt">
+                <h4>Checkpoints</h4>
+                <CheckpointTimeline checkpoints={checkpoints} loading={ckptLoading} onRollback={onRollback} />
+              </section>
+            </div>
+          )}
+        </div>
+
+        {mode === "chat" && (
+          <footer className="loop-art-composer">
+            <textarea
+              className="loop-art-input"
+              value={draft}
+              placeholder="Send a prompt…"
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+            />
+            <button type="button" className="loop-art-send" onClick={submit} disabled={!draft.trim() || stream.running}>
+              <Send size={14} /> Send
+            </button>
+          </footer>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/packages/dmloop/src/agentRuntime/CheckpointTimeline.tsx
+++ b/packages/dmloop/src/agentRuntime/CheckpointTimeline.tsx
@@ -1,0 +1,72 @@
+// @octo/loop — checkpoint 时间线 + 回滚
+//
+// ⚠️ checkpoint / rollback 端点与字段「待后端确认」（见 agentRuntimeApi）。本组件仅按
+// 前端预期契约渲染时间线并暴露回滚入口；回滚是破坏性操作，点按前需二次确认。
+
+import React, { useState } from "react";
+import { GitCommitHorizontal, RotateCcw, Loader2 } from "lucide-react";
+import type { Checkpoint } from "../api/agentRuntime/contracts";
+import "./checkpoint.css";
+
+export interface CheckpointTimelineProps {
+  checkpoints: Checkpoint[];
+  loading?: boolean;
+  // 回滚回调（由上层调 rollback 端点）。返回 Promise 以驱动行内 loading。
+  onRollback: (checkpointId: string) => Promise<void> | void;
+}
+
+export default function CheckpointTimeline({ checkpoints, loading, onRollback }: CheckpointTimelineProps) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const doRollback = async (id: string) => {
+    setBusyId(id);
+    try {
+      await onRollback(id);
+    } finally {
+      setBusyId(null);
+      setConfirmId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="loop-ckpt-loading">
+        <Loader2 size={14} className="loop-spin" /> Loading checkpoints…
+      </div>
+    );
+  }
+  if (!checkpoints.length) return <div className="loop-ckpt-empty">No checkpoints</div>;
+
+  return (
+    <div className="loop-ckpt-timeline">
+      {checkpoints.map((c) => (
+        <div className="loop-ckpt-node" key={c.id}>
+          <div className="loop-ckpt-rail">
+            <GitCommitHorizontal size={16} className="loop-ckpt-dot" />
+          </div>
+          <div className="loop-ckpt-body">
+            <div className="loop-ckpt-label">{c.label || `Checkpoint ${c.seq ?? ""}`}</div>
+            <div className="loop-ckpt-meta">
+              {c.created_at && <span>{c.created_at}</span>}
+              {typeof c.files_changed === "number" && <span>{c.files_changed} files</span>}
+            </div>
+          </div>
+          {confirmId === c.id ? (
+            <div className="loop-ckpt-confirm">
+              <span>Roll back to here?</span>
+              <button type="button" className="loop-ckpt-btn danger" disabled={busyId === c.id} onClick={() => doRollback(c.id)}>
+                {busyId === c.id ? <Loader2 size={12} className="loop-spin" /> : "Confirm"}
+              </button>
+              <button type="button" className="loop-ckpt-btn" onClick={() => setConfirmId(null)}>Cancel</button>
+            </div>
+          ) : (
+            <button type="button" className="loop-ckpt-btn" onClick={() => setConfirmId(c.id)} title="Roll back to this checkpoint">
+              <RotateCcw size={13} /> Rollback
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/dmloop/src/agentRuntime/DiffView.tsx
+++ b/packages/dmloop/src/agentRuntime/DiffView.tsx
@@ -1,0 +1,204 @@
+// @octo/loop — 富 diff 视图
+//
+// 按研发设计文档的 diff JSON 契约 {path,changeType,hunks,binary,truncated} 渲染，
+// 支持 split（并排）/ unified（单栏）切换 + 行内 word diff 高亮。
+//
+// 关于库选型：设计文档指定「react-diff-view（默认）+ 大文件切 Monaco DiffEditor」。
+// 当前 dmloop 未引入这两个依赖（package.json 仅有 lucide-react/react-markdown 等），
+// 为保持增量 PR 可构建、不擅自扩容依赖树，这里先用零依赖的自渲染实现（词级高亮走
+// 本包 wordDiff）。已按契约把「大文件 / 二进制 / 截断」的降级分支与渲染 seam 留好：
+// 后续引入 react-diff-view / @monaco-editor/react 时，仅替换 <FileDiffBody> 内部渲染，
+// 上层 props（FileDiff 契约）与交互（split/unified、阈值切换）不变。
+
+import React, { useMemo, useState } from "react";
+import { FileCode, FilePlus, FileMinus, FileText, Columns2, AlignJustify } from "lucide-react";
+import type { FileDiff, DiffHunkLine } from "../api/agentRuntime/contracts";
+import { wordDiff } from "./wordDiff";
+import "./diffView.css";
+
+// 超过该行数视为「大文件」，提示切换到重型编辑器（Monaco，待依赖引入）。
+const LARGE_FILE_LINES = 800;
+
+type ViewMode = "split" | "unified";
+
+function changeIcon(t: FileDiff["changeType"]) {
+  if (t === "added") return <FilePlus size={14} className="loop-diff-ic add" />;
+  if (t === "deleted") return <FileMinus size={14} className="loop-diff-ic del" />;
+  if (t === "renamed" || t === "copied") return <FileText size={14} className="loop-diff-ic mod" />;
+  return <FileCode size={14} className="loop-diff-ic mod" />;
+}
+
+// 把一对 delete/insert 行做词级 diff，渲染成带高亮 span 的行内内容。
+function InlineWord({ oldLine, newLine, side }: { oldLine: string; newLine: string; side: "old" | "new" }) {
+  const segs = useMemo(() => wordDiff(oldLine, newLine), [oldLine, newLine]);
+  return (
+    <>
+      {segs
+        .filter((s) => (side === "old" ? s.kind !== "insert" : s.kind !== "delete"))
+        .map((s, i) => (
+          <span
+            key={i}
+            className={s.kind === "equal" ? undefined : side === "old" ? "loop-diff-word-del" : "loop-diff-word-ins"}
+          >
+            {s.value}
+          </span>
+        ))}
+    </>
+  );
+}
+
+// 把 hunk 行配成 unified 或 split 的可渲染行。
+interface PairedRow {
+  oldLine?: DiffHunkLine;
+  newLine?: DiffHunkLine;
+}
+
+// 在一段连续变更块内，按顺序把 delete 与 insert 配对（用于 split 并排 + 行内 word diff）。
+function pairHunkLines(lines: DiffHunkLine[]): PairedRow[] {
+  const rows: PairedRow[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.type === "normal") {
+      rows.push({ oldLine: line, newLine: line });
+      i++;
+      continue;
+    }
+    // 收集连续的 delete 块与其后连续的 insert 块。
+    const dels: DiffHunkLine[] = [];
+    const ins: DiffHunkLine[] = [];
+    while (i < lines.length && lines[i].type === "delete") dels.push(lines[i++]);
+    while (i < lines.length && lines[i].type === "insert") ins.push(lines[i++]);
+    const n = Math.max(dels.length, ins.length);
+    for (let k = 0; k < n; k++) rows.push({ oldLine: dels[k], newLine: ins[k] });
+  }
+  return rows;
+}
+
+function SplitBody({ diff }: { diff: FileDiff }) {
+  return (
+    <table className="loop-diff-table split">
+      <tbody>
+        {diff.hunks.map((h, hi) => (
+          <React.Fragment key={hi}>
+            <tr className="loop-diff-hunk-header">
+              <td colSpan={4}>{h.header || `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`}</td>
+            </tr>
+            {pairHunkLines(h.lines).map((row, ri) => {
+              const paired = row.oldLine?.type === "delete" && row.newLine?.type === "insert";
+              return (
+                <tr key={ri}>
+                  <td className="loop-diff-ln">{row.oldLine?.oldLine ?? ""}</td>
+                  <td className={`loop-diff-code ${row.oldLine?.type ?? "empty"}`}>
+                    {row.oldLine
+                      ? paired
+                        ? <InlineWord oldLine={row.oldLine.content} newLine={row.newLine!.content} side="old" />
+                        : row.oldLine.content
+                      : ""}
+                  </td>
+                  <td className="loop-diff-ln">{row.newLine?.newLine ?? ""}</td>
+                  <td className={`loop-diff-code ${row.newLine?.type ?? "empty"}`}>
+                    {row.newLine
+                      ? paired
+                        ? <InlineWord oldLine={row.oldLine!.content} newLine={row.newLine.content} side="new" />
+                        : row.newLine.content
+                      : ""}
+                  </td>
+                </tr>
+              );
+            })}
+          </React.Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function UnifiedBody({ diff }: { diff: FileDiff }) {
+  return (
+    <table className="loop-diff-table unified">
+      <tbody>
+        {diff.hunks.map((h, hi) => (
+          <React.Fragment key={hi}>
+            <tr className="loop-diff-hunk-header">
+              <td colSpan={3}>{h.header || `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`}</td>
+            </tr>
+            {h.lines.map((line, li) => (
+              <tr key={li}>
+                <td className="loop-diff-ln">{line.oldLine ?? ""}</td>
+                <td className="loop-diff-ln">{line.newLine ?? ""}</td>
+                <td className={`loop-diff-code ${line.type}`}>
+                  <span className="loop-diff-sign">{line.type === "insert" ? "+" : line.type === "delete" ? "-" : " "}</span>
+                  {line.content}
+                </td>
+              </tr>
+            ))}
+          </React.Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function FileDiffBody({ diff, mode }: { diff: FileDiff; mode: ViewMode }) {
+  if (diff.binary) return <div className="loop-diff-notice">Binary file not shown</div>;
+  const lineCount = diff.hunks.reduce((n, h) => n + h.lines.length, 0);
+  return (
+    <>
+      {lineCount > LARGE_FILE_LINES && (
+        // 大文件降级提示：设计文档要求切 Monaco DiffEditor，依赖引入后在此挂载。
+        <div className="loop-diff-notice warn">
+          Large file ({lineCount} lines) — rendered in lightweight mode. A Monaco-based
+          side-by-side editor is planned once the editor dependency is added.
+        </div>
+      )}
+      {mode === "split" ? <SplitBody diff={diff} /> : <UnifiedBody diff={diff} />}
+      {diff.truncated && <div className="loop-diff-notice warn">Diff truncated by server</div>}
+    </>
+  );
+}
+
+export interface DiffViewProps {
+  diffs: FileDiff[];
+  defaultMode?: ViewMode;
+}
+
+export default function DiffView({ diffs, defaultMode = "split" }: DiffViewProps) {
+  const [mode, setMode] = useState<ViewMode>(defaultMode);
+  if (!diffs.length) return <div className="loop-diff-empty">No changes</div>;
+  return (
+    <div className="loop-diff-root">
+      <div className="loop-diff-toolbar">
+        <button
+          type="button"
+          className={`loop-diff-modebtn ${mode === "split" ? "active" : ""}`}
+          onClick={() => setMode("split")}
+          title="Split view"
+        >
+          <Columns2 size={14} /> Split
+        </button>
+        <button
+          type="button"
+          className={`loop-diff-modebtn ${mode === "unified" ? "active" : ""}`}
+          onClick={() => setMode("unified")}
+          title="Unified view"
+        >
+          <AlignJustify size={14} /> Unified
+        </button>
+      </div>
+      {diffs.map((d, i) => (
+        <div className="loop-diff-file" key={`${d.path}-${i}`}>
+          <div className="loop-diff-file-header">
+            {changeIcon(d.changeType)}
+            <span className="loop-diff-path">
+              {d.changeType === "renamed" && d.oldPath ? `${d.oldPath} → ${d.path}` : d.path}
+            </span>
+            {typeof d.additions === "number" && <span className="loop-diff-add">+{d.additions}</span>}
+            {typeof d.deletions === "number" && <span className="loop-diff-del">-{d.deletions}</span>}
+          </div>
+          <FileDiffBody diff={d} mode={mode} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/dmloop/src/agentRuntime/SessionList.tsx
+++ b/packages/dmloop/src/agentRuntime/SessionList.tsx
@@ -1,0 +1,39 @@
+// @octo/loop — 会话列表（切换会话）
+import React from "react";
+import { MessageSquare, Loader2 } from "lucide-react";
+import type { AgentSessionSummary } from "../api/agentRuntime/contracts";
+import "./sessionList.css";
+
+export interface SessionListProps {
+  sessions: AgentSessionSummary[];
+  activeKey?: string;
+  onSelect: (sessionKey: string) => void;
+  loading?: boolean;
+}
+
+export default function SessionList({ sessions, activeKey, onSelect, loading }: SessionListProps) {
+  return (
+    <div className="loop-session-list">
+      {loading && (
+        <div className="loop-session-loading">
+          <Loader2 size={14} className="loop-spin" /> Loading…
+        </div>
+      )}
+      {!loading && sessions.length === 0 && (
+        <div className="loop-session-empty">No sessions</div>
+      )}
+      {sessions.map((s) => (
+        <button
+          type="button"
+          key={s.session_key}
+          className={`loop-session-item ${s.session_key === activeKey ? "active" : ""}`}
+          onClick={() => onSelect(s.session_key)}
+        >
+          <MessageSquare size={14} className="loop-session-ic" />
+          <span className="loop-session-title">{s.title || s.session_key}</span>
+          {s.running && <span className="loop-session-running">running</span>}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/dmloop/src/agentRuntime/VerboseRenderer.tsx
+++ b/packages/dmloop/src/agentRuntime/VerboseRenderer.tsx
@@ -1,0 +1,127 @@
+// @octo/loop — verbose 三档渲染
+//
+// off  : 只显示 assistant 最终文本
+// on   : + 工具调用摘要（折叠：只显示工具名 + 一行入参摘要）
+// full : + reasoning（thinking）+ 原始入参/出参 + 完整事件流（原样 JSON）
+//
+// 数据来自 streamReducer 归约后的 AgentStreamState，本组件只负责按档位挑选与展示。
+
+import React, { useState } from "react";
+import { ChevronRight, ChevronDown, Wrench, Brain, MessageSquare } from "lucide-react";
+import type { AgentStreamState, StreamToolCall } from "./streamReducer";
+import "./verbose.css";
+
+export type VerboseLevel = "off" | "on" | "full";
+
+function summarizeInput(input: unknown): string {
+  if (input == null) return "";
+  if (typeof input === "string") return input.length > 80 ? `${input.slice(0, 80)}…` : input;
+  try {
+    const s = JSON.stringify(input);
+    return s.length > 80 ? `${s.slice(0, 80)}…` : s;
+  } catch {
+    return String(input);
+  }
+}
+
+function pretty(v: unknown): string {
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function ToolCallRow({ call, level }: { call: StreamToolCall; level: VerboseLevel }) {
+  const [open, setOpen] = useState(false);
+  const expandable = level === "full";
+  return (
+    <div className={`loop-verbose-tool status-${call.status}`}>
+      <button
+        type="button"
+        className="loop-verbose-tool-head"
+        onClick={() => expandable && setOpen((o) => !o)}
+        disabled={!expandable}
+      >
+        {expandable ? (open ? <ChevronDown size={13} /> : <ChevronRight size={13} />) : <Wrench size={13} />}
+        <span className="loop-verbose-tool-name">{call.name || "tool"}</span>
+        <span className="loop-verbose-tool-summary">{summarizeInput(call.input)}</span>
+        <span className={`loop-verbose-tool-status ${call.status}`}>{call.status}</span>
+      </button>
+      {expandable && open && (
+        <div className="loop-verbose-tool-body">
+          <div className="loop-verbose-kv">
+            <div className="loop-verbose-k">input</div>
+            <pre className="loop-verbose-pre">{pretty(call.input)}</pre>
+          </div>
+          {call.output !== undefined && (
+            <div className="loop-verbose-kv">
+              <div className="loop-verbose-k">output</div>
+              <pre className="loop-verbose-pre">{pretty(call.output)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface VerboseRendererProps {
+  state: AgentStreamState;
+  level: VerboseLevel;
+  // full 档「完整事件流」原样区（可选传入原始事件 JSON 列表）。
+  rawEvents?: unknown[];
+}
+
+export default function VerboseRenderer({ state, level, rawEvents }: VerboseRendererProps) {
+  const finalMessages = state.messages.filter((m) => m.role === "assistant" && m.text.trim());
+
+  return (
+    <div className="loop-verbose-root">
+      {/* thinking：仅 full 档 */}
+      {level === "full" && state.thinking.length > 0 && (
+        <section className="loop-verbose-section">
+          <div className="loop-verbose-section-title"><Brain size={13} /> Reasoning</div>
+          {state.thinking.map((t) => (
+            <pre key={t.id} className="loop-verbose-thinking">{t.text}</pre>
+          ))}
+        </section>
+      )}
+
+      {/* 工具调用：on / full 档 */}
+      {level !== "off" && state.toolCalls.length > 0 && (
+        <section className="loop-verbose-section">
+          <div className="loop-verbose-section-title"><Wrench size={13} /> Tool calls</div>
+          {state.toolCalls.map((c) => (
+            <ToolCallRow key={c.id} call={c} level={level} />
+          ))}
+        </section>
+      )}
+
+      {/* 最终文本：所有档位都显示 */}
+      <section className="loop-verbose-section">
+        {level !== "off" && (
+          <div className="loop-verbose-section-title"><MessageSquare size={13} /> Response</div>
+        )}
+        {finalMessages.length ? (
+          finalMessages.map((m) => (
+            <div key={m.id} className="loop-verbose-message">{m.text}</div>
+          ))
+        ) : (
+          <div className="loop-verbose-empty">No response yet</div>
+        )}
+      </section>
+
+      {/* 完整事件流：仅 full 档，原样 JSON */}
+      {level === "full" && rawEvents && rawEvents.length > 0 && (
+        <section className="loop-verbose-section">
+          <div className="loop-verbose-section-title">Raw event stream ({rawEvents.length})</div>
+          <pre className="loop-verbose-pre raw">{rawEvents.map((e) => pretty(e)).join("\n")}</pre>
+        </section>
+      )}
+
+      {state.errorMessage && <div className="loop-verbose-error">{state.errorMessage}</div>}
+    </div>
+  );
+}

--- a/packages/dmloop/src/agentRuntime/__tests__/streamReducer.test.ts
+++ b/packages/dmloop/src/agentRuntime/__tests__/streamReducer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialStreamState,
+  reduceEvent,
+  reduceAll,
+  markAborted,
+  reconcileMissing,
+} from "../streamReducer";
+import type { AgentEvent } from "../../api/agentRuntime/contracts";
+
+const ev = (e: Partial<AgentEvent> & { type: AgentEvent["type"] }): AgentEvent => e;
+
+describe("streamReducer — 基本归约", () => {
+  it("拼接 message_delta 成一条消息", () => {
+    const s = reduceAll([
+      ev({ type: "message_delta", seq: 0, messageId: "m1", text: "Hel" }),
+      ev({ type: "message_delta", seq: 1, messageId: "m1", text: "lo" }),
+    ]);
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].text).toBe("Hello");
+    expect(s.phase).toBe("acting");
+  });
+
+  it("tool_call → tool_result 归约为一行并置 done", () => {
+    const s = reduceAll([
+      ev({ type: "tool_call", seq: 0, toolCallId: "t1", toolName: "read", input: { path: "a.ts" } }),
+      ev({ type: "tool_result", seq: 1, toolCallId: "t1", output: "content" }),
+    ]);
+    expect(s.toolCalls).toHaveLength(1);
+    expect(s.toolCalls[0].status).toBe("done");
+    expect(s.toolCalls[0].name).toBe("read");
+    expect(s.toolCalls[0].output).toBe("content");
+  });
+
+  it("thinking 只在 full 档由 UI 展示，但归约器始终收集", () => {
+    const s = reduceAll([ev({ type: "thinking", seq: 0, messageId: "r1", text: "reason" })]);
+    expect(s.thinking).toHaveLength(1);
+    expect(s.phase).toBe("thinking");
+  });
+
+  it("done 事件置 finalized + done 相位", () => {
+    const s = reduceAll([
+      ev({ type: "message", seq: 0, messageId: "m1", text: "hi" }),
+      ev({ type: "done", seq: 1 }),
+    ]);
+    expect(s.finalized).toBe(true);
+    expect(s.phase).toBe("done");
+  });
+});
+
+describe("streamReducer — 乱序", () => {
+  it("低 seq 后到时按 seq 插到正确位置", () => {
+    const s = reduceAll([
+      ev({ type: "message", seq: 2, messageId: "m2", text: "second" }),
+      ev({ type: "message", seq: 0, messageId: "m0", text: "zero" }),
+      ev({ type: "message", seq: 1, messageId: "m1", text: "first" }),
+    ]);
+    expect(s.messages.map((m) => m.id)).toEqual(["m0", "m1", "m2"]);
+  });
+
+  it("tool_result 先于 tool_call 到达（乱序）：先占位，调用帧补齐 name/input", () => {
+    const s = reduceAll([
+      ev({ type: "tool_result", seq: 5, toolCallId: "t1", output: "out" }),
+      ev({ type: "tool_call", seq: 4, toolCallId: "t1", toolName: "grep", input: { q: "x" } }),
+    ]);
+    expect(s.toolCalls).toHaveLength(1);
+    expect(s.toolCalls[0].name).toBe("grep");
+    expect(s.toolCalls[0].output).toBe("out");
+    expect(s.toolCalls[0].status).toBe("done");
+  });
+});
+
+describe("streamReducer — 重连去重", () => {
+  it("相同 seq 事件重复到达时幂等（不重复追加文本）", () => {
+    let s = initialStreamState();
+    const delta = ev({ type: "message_delta", seq: 0, messageId: "m1", text: "Hi" });
+    s = reduceEvent(s, delta);
+    s = reduceEvent(s, delta); // 重连回放：同一帧再来一次
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0].text).toBe("Hi");
+  });
+
+  it("无 seq 但有 id 的事件也能去重", () => {
+    let s = initialStreamState();
+    const e = ev({ type: "tool_call", id: "abc", toolCallId: "t1", toolName: "ls" });
+    s = reduceEvent(s, e);
+    s = reduceEvent(s, e);
+    expect(s.toolCalls).toHaveLength(1);
+  });
+
+  it("重连续推补齐后续增量，历史不丢", () => {
+    let s = reduceAll([
+      ev({ type: "message_delta", seq: 0, messageId: "m1", text: "Hel" }),
+      ev({ type: "message_delta", seq: 1, messageId: "m1", text: "lo" }),
+    ]);
+    // 模拟断线重连：seq 0/1 回放（去重）+ 新 seq 2
+    s = reduceEvent(s, ev({ type: "message_delta", seq: 0, messageId: "m1", text: "Hel" }));
+    s = reduceEvent(s, ev({ type: "message_delta", seq: 2, messageId: "m1", text: "!" }));
+    expect(s.messages[0].text).toBe("Hello!");
+  });
+});
+
+describe("streamReducer — 中断", () => {
+  it("markAborted 后迟到的 message_delta 不再改写", () => {
+    let s = reduceAll([ev({ type: "message_delta", seq: 0, messageId: "m1", text: "partial" })]);
+    s = markAborted(s);
+    expect(s.phase).toBe("aborted");
+    expect(s.finalized).toBe(true);
+    const before = s.messages[0].text;
+    s = reduceEvent(s, ev({ type: "message_delta", seq: 1, messageId: "m1", text: " more" }));
+    expect(s.messages[0].text).toBe(before); // 未追加
+    expect(s.phase).toBe("aborted"); // 相位不被 late 帧改写
+  });
+
+  it("error 事件置 error 终态，done 不会覆盖成 done", () => {
+    let s = reduceAll([ev({ type: "error", seq: 0, errorMessage: "boom" })]);
+    expect(s.phase).toBe("error");
+    expect(s.errorMessage).toBe("boom");
+    s = reduceEvent(s, ev({ type: "done", seq: 1 }));
+    expect(s.phase).toBe("error");
+  });
+});
+
+describe("streamReducer — 对账丢帧", () => {
+  it("服务端 last_seq 超过本地 maxSeq 时置 maybeMissingEvents", () => {
+    const s = reduceAll([ev({ type: "message", seq: 3, messageId: "m", text: "x" })]);
+    expect(reconcileMissing(s, 10).maybeMissingEvents).toBe(true);
+    expect(reconcileMissing(s, 3).maybeMissingEvents).toBe(false);
+    expect(reconcileMissing(s, undefined).maybeMissingEvents).toBe(false);
+  });
+});

--- a/packages/dmloop/src/agentRuntime/__tests__/wordDiff.test.ts
+++ b/packages/dmloop/src/agentRuntime/__tests__/wordDiff.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { tokenize, wordDiff } from "../wordDiff";
+
+describe("wordDiff", () => {
+  it("tokenize 保留分隔符，可无损拼回", () => {
+    const s = "const x = foo(a, b);";
+    expect(tokenize(s).join("")).toBe(s);
+  });
+
+  it("完全相同的行只有 equal 片段", () => {
+    const segs = wordDiff("hello world", "hello world");
+    expect(segs.every((s) => s.kind === "equal")).toBe(true);
+    expect(segs.map((s) => s.value).join("")).toBe("hello world");
+  });
+
+  it("只标出变化的词", () => {
+    const segs = wordDiff("const x = 1", "const x = 2");
+    // old 侧重建
+    const oldText = segs.filter((s) => s.kind !== "insert").map((s) => s.value).join("");
+    const newText = segs.filter((s) => s.kind !== "delete").map((s) => s.value).join("");
+    expect(oldText).toBe("const x = 1");
+    expect(newText).toBe("const x = 2");
+    // "1" 被删、"2" 被插，其余 equal
+    expect(segs.some((s) => s.kind === "delete" && s.value === "1")).toBe(true);
+    expect(segs.some((s) => s.kind === "insert" && s.value === "2")).toBe(true);
+  });
+
+  it("纯新增 / 纯删除", () => {
+    expect(wordDiff("", "new")).toEqual([{ kind: "insert", value: "new" }]);
+    expect(wordDiff("old", "")).toEqual([{ kind: "delete", value: "old" }]);
+  });
+
+  it("相邻同类片段被合并", () => {
+    const segs = wordDiff("a b c", "a x y c");
+    // 中间 "b" → "x y" 段应合并为紧凑输出（不逐字符碎片化）
+    const inserts = segs.filter((s) => s.kind === "insert");
+    expect(inserts.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/dmloop/src/agentRuntime/bootstrap.ts
+++ b/packages/dmloop/src/agentRuntime/bootstrap.ts
@@ -1,0 +1,16 @@
+// @octo/loop — Agent Runtime 鉴权接入
+//
+// 宿主（octo-web）启动时调用一次，把 Bearer token 的取值来源接到既有登录态上，
+// 并注册 401 处理钩子。与既有 axios http.ts 的 token/X-Space-Id 头解耦：Agent Runtime
+// 后端走 Bearer，token 复用同一登录态取值来源。
+
+import { setAuthTokenProvider, setUnauthorizedHandler } from "../api/agentRuntime/httpClient";
+
+// tokenProvider 由宿主注入（避免本包直接依赖 @octo/base 的登录态形状，便于单测）。
+export function initAgentRuntimeAuth(opts: {
+  getToken: () => string | null | undefined;
+  onUnauthorized?: (path: string) => void;
+}): void {
+  setAuthTokenProvider(opts.getToken);
+  if (opts.onUnauthorized) setUnauthorizedHandler(opts.onUnauthorized);
+}

--- a/packages/dmloop/src/agentRuntime/checkpoint.css
+++ b/packages/dmloop/src/agentRuntime/checkpoint.css
@@ -1,0 +1,20 @@
+/* @octo/loop — checkpoint timeline */
+.loop-ckpt-timeline { display: flex; flex-direction: column; }
+.loop-ckpt-loading, .loop-ckpt-empty {
+  display: flex; align-items: center; gap: 6px; color: var(--semi-color-text-2); font-size: 12px; padding: 8px 0;
+}
+.loop-ckpt-node { display: flex; align-items: center; gap: 10px; padding: 8px 0; position: relative; }
+.loop-ckpt-rail { position: relative; width: 20px; display: flex; justify-content: center; }
+.loop-ckpt-rail::before {
+  content: ""; position: absolute; top: -8px; bottom: -8px; width: 1px; background: var(--semi-color-border); left: 50%;
+}
+.loop-ckpt-dot { color: var(--semi-color-primary); background: var(--semi-color-bg-0); z-index: 1; }
+.loop-ckpt-body { flex: 1; min-width: 0; }
+.loop-ckpt-label { font-size: 13px; color: var(--semi-color-text-0); }
+.loop-ckpt-meta { display: flex; gap: 10px; font-size: 11px; color: var(--semi-color-text-2); }
+.loop-ckpt-btn {
+  display: inline-flex; align-items: center; gap: 4px; cursor: pointer; font-size: 12px; border-radius: 4px;
+  border: 1px solid var(--semi-color-border); background: var(--semi-color-bg-0); color: var(--semi-color-text-1); padding: 4px 8px;
+}
+.loop-ckpt-btn.danger { border-color: var(--semi-color-danger); color: var(--semi-color-danger); }
+.loop-ckpt-confirm { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--semi-color-text-1); }

--- a/packages/dmloop/src/agentRuntime/diffView.css
+++ b/packages/dmloop/src/agentRuntime/diffView.css
@@ -1,0 +1,35 @@
+/* @octo/loop — rich diff view */
+.loop-diff-root { display: flex; flex-direction: column; gap: 12px; }
+.loop-diff-empty { color: var(--semi-color-text-2); font-size: 13px; }
+.loop-diff-toolbar { display: inline-flex; gap: 2px; background: var(--semi-color-fill-0); border-radius: 6px; padding: 2px; align-self: flex-start; }
+.loop-diff-modebtn {
+  display: inline-flex; align-items: center; gap: 4px; border: none; background: transparent;
+  color: var(--semi-color-text-2); font-size: 12px; padding: 4px 10px; border-radius: 4px; cursor: pointer;
+}
+.loop-diff-modebtn.active { background: var(--semi-color-bg-0); color: var(--semi-color-text-0); }
+
+.loop-diff-file { border: 1px solid var(--semi-color-border); border-radius: 6px; overflow: hidden; }
+.loop-diff-file-header {
+  display: flex; align-items: center; gap: 6px; padding: 6px 10px; background: var(--semi-color-fill-0);
+  font-size: 12px; font-family: var(--code-font, monospace); border-bottom: 1px solid var(--semi-color-border);
+}
+.loop-diff-path { flex: 1; color: var(--semi-color-text-0); overflow: hidden; text-overflow: ellipsis; }
+.loop-diff-add { color: var(--semi-color-success, #52c41a); }
+.loop-diff-del { color: var(--semi-color-danger); }
+.loop-diff-ic.add { color: var(--semi-color-success, #52c41a); }
+.loop-diff-ic.del { color: var(--semi-color-danger); }
+.loop-diff-ic.mod { color: var(--semi-color-info); }
+
+.loop-diff-table { width: 100%; border-collapse: collapse; font-family: var(--code-font, monospace); font-size: 12px; line-height: 1.5; }
+.loop-diff-hunk-header td { background: var(--semi-color-fill-1, #f0f0f0); color: var(--semi-color-text-2); padding: 2px 10px; font-size: 11px; }
+.loop-diff-ln { width: 44px; text-align: right; padding: 0 8px; color: var(--semi-color-text-2); user-select: none; vertical-align: top; white-space: nowrap; }
+.loop-diff-code { padding: 0 8px; white-space: pre-wrap; word-break: break-word; vertical-align: top; }
+.loop-diff-code.insert { background: rgba(82, 196, 26, 0.12); }
+.loop-diff-code.delete { background: rgba(255, 77, 79, 0.12); }
+.loop-diff-code.empty { background: var(--semi-color-fill-0); }
+.loop-diff-sign { display: inline-block; width: 10px; color: var(--semi-color-text-2); }
+.loop-diff-word-ins { background: rgba(82, 196, 26, 0.35); border-radius: 2px; }
+.loop-diff-word-del { background: rgba(255, 77, 79, 0.35); border-radius: 2px; }
+
+.loop-diff-notice { padding: 6px 10px; font-size: 12px; color: var(--semi-color-text-2); }
+.loop-diff-notice.warn { background: var(--semi-color-warning-light-default, #fff7e6); color: var(--semi-color-warning, #d48806); }

--- a/packages/dmloop/src/agentRuntime/index.ts
+++ b/packages/dmloop/src/agentRuntime/index.ts
@@ -1,0 +1,26 @@
+// @octo/loop — Agent Runtime UI 对外出口
+//
+// 汇总「Agent Runtime UI」新增能力：运行期 API 客户端、事件流 hook 与归约器、
+// verbose / 富 diff / checkpoint 组件、顶层面板。
+//
+// 注意：这是相对既有 loop 面板的增量特性，尚未挂进主路由（顶层 <AgentRuntimePanel>
+// 需要一个已选定的会话上下文）。宿主接入时先调用 initAgentRuntimeAuth() 注入鉴权。
+
+export { default as AgentRuntimePanel } from "./AgentRuntimePanel";
+export type { AgentRuntimePanelProps } from "./AgentRuntimePanel";
+export { default as VerboseRenderer } from "./VerboseRenderer";
+export type { VerboseLevel } from "./VerboseRenderer";
+export { default as DiffView } from "./DiffView";
+export { default as CheckpointTimeline } from "./CheckpointTimeline";
+export { default as SessionList } from "./SessionList";
+
+export { useAgentStream, entriesToEvents } from "./useAgentStream";
+export type { UseAgentStreamResult } from "./useAgentStream";
+export * from "./streamReducer";
+export { wordDiff, tokenize } from "./wordDiff";
+export type { WordDiffSegment, WordDiffKind } from "./wordDiff";
+
+export * as agentRuntimeApi from "../api/agentRuntime/agentRuntimeApi";
+export * from "../api/agentRuntime/contracts";
+export { AgentRuntimeError, setAuthTokenProvider, setUnauthorizedHandler } from "../api/agentRuntime/httpClient";
+export { initAgentRuntimeAuth } from "./bootstrap";

--- a/packages/dmloop/src/agentRuntime/panel.css
+++ b/packages/dmloop/src/agentRuntime/panel.css
@@ -1,0 +1,40 @@
+/* @octo/loop — Agent Runtime panel layout */
+.loop-art-root { display: flex; height: 100%; min-height: 0; background: var(--semi-color-bg-0); }
+.loop-art-sidebar { width: 220px; flex: none; border-right: 1px solid var(--semi-color-border); overflow-y: auto; }
+.loop-art-main { flex: 1; display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+
+.loop-art-toolbar { display: flex; align-items: center; gap: 16px; padding: 8px 12px; border-bottom: 1px solid var(--semi-color-border); }
+.loop-art-modes, .loop-art-verbose { display: inline-flex; gap: 2px; background: var(--semi-color-fill-0); border-radius: 6px; padding: 2px; }
+.loop-art-mode, .loop-art-vbtn {
+  display: inline-flex; align-items: center; gap: 4px; border: none; background: transparent;
+  color: var(--semi-color-text-2); font-size: 12px; padding: 4px 10px; border-radius: 4px; cursor: pointer;
+}
+.loop-art-mode.active, .loop-art-vbtn.active { background: var(--semi-color-bg-0); color: var(--semi-color-text-0); box-shadow: 0 1px 2px rgba(0,0,0,0.08); }
+.loop-art-vbtn { text-transform: uppercase; letter-spacing: 0.03em; }
+.loop-art-abort {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 4px; cursor: pointer;
+  border: 1px solid var(--semi-color-danger); color: var(--semi-color-danger); background: transparent;
+  border-radius: 4px; padding: 4px 10px; font-size: 12px;
+}
+
+.loop-art-warn, .loop-art-error {
+  display: flex; align-items: center; gap: 6px; padding: 6px 12px; font-size: 12px;
+}
+.loop-art-warn { background: var(--semi-color-warning-light-default, #fff7e6); color: var(--semi-color-warning, #d48806); }
+.loop-art-error { background: var(--semi-color-danger-light-default); color: var(--semi-color-danger); }
+
+.loop-art-content { flex: 1; overflow-y: auto; padding: 12px 16px; min-height: 0; }
+.loop-art-hint { color: var(--semi-color-text-2); font-size: 12px; }
+.loop-art-code { display: flex; flex-direction: column; gap: 20px; }
+.loop-art-code h4 { margin: 0 0 8px; font-size: 13px; color: var(--semi-color-text-1); }
+
+.loop-art-composer { display: flex; gap: 8px; padding: 10px 12px; border-top: 1px solid var(--semi-color-border); }
+.loop-art-input {
+  flex: 1; resize: none; min-height: 40px; max-height: 140px; padding: 8px 10px; font-size: 13px;
+  border: 1px solid var(--semi-color-border); border-radius: 6px; background: var(--semi-color-bg-0); color: var(--semi-color-text-0);
+}
+.loop-art-send {
+  align-self: flex-end; display: inline-flex; align-items: center; gap: 4px; cursor: pointer;
+  border: none; background: var(--semi-color-primary); color: #fff; border-radius: 6px; padding: 8px 14px; font-size: 13px;
+}
+.loop-art-send:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/packages/dmloop/src/agentRuntime/sessionList.css
+++ b/packages/dmloop/src/agentRuntime/sessionList.css
@@ -1,0 +1,17 @@
+/* @octo/loop — session list */
+.loop-session-list { display: flex; flex-direction: column; padding: 6px; gap: 2px; }
+.loop-session-loading, .loop-session-empty {
+  display: flex; align-items: center; gap: 6px; padding: 12px; color: var(--semi-color-text-2); font-size: 12px;
+}
+.loop-session-item {
+  display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; cursor: pointer;
+  border: none; background: transparent; padding: 7px 8px; border-radius: 5px; font-size: 13px; color: var(--semi-color-text-1);
+}
+.loop-session-item:hover { background: var(--semi-color-fill-0); }
+.loop-session-item.active { background: var(--semi-color-primary-light-default); color: var(--semi-color-primary); }
+.loop-session-ic { flex: none; }
+.loop-session-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-session-running { font-size: 10px; color: var(--semi-color-info); background: var(--semi-color-info-light-default); padding: 1px 6px; border-radius: 8px; }
+
+.loop-spin { animation: loop-spin 0.9s linear infinite; }
+@keyframes loop-spin { to { transform: rotate(360deg); } }

--- a/packages/dmloop/src/agentRuntime/streamReducer.ts
+++ b/packages/dmloop/src/agentRuntime/streamReducer.ts
@@ -1,0 +1,217 @@
+// @octo/loop — Agent 事件流归约器（纯函数）
+//
+// 把后端 SSE 事件序列归约成 UI 直接可渲染的 {messages, toolCalls, thinking, phase}。
+// 抽成纯函数（不依赖 React）以便单测覆盖三大边界：
+//   - 乱序：事件按 seq 排序落位，后到的低 seq 也能插对位置
+//   - 重连：同一事件（seq / id）重复到达时幂等去重，不产生重复消息/工具行
+//   - 中断：abort 后进入 aborted 相位，后续迟到帧不再改写终态
+//
+// useAgentStream 只是把它接到 SSE + React state 上。
+
+import type { AgentEvent, AgentPhase } from "../api/agentRuntime/contracts";
+
+export interface StreamMessage {
+  id: string; // messageId 或合成 id
+  role: "user" | "assistant" | "system" | "tool";
+  text: string;
+  seq: number; // 首个增量的 seq，用于排序
+}
+
+export interface StreamToolCall {
+  id: string; // toolCallId
+  name?: string;
+  input?: unknown;
+  output?: unknown;
+  status: "running" | "done" | "error";
+  seq: number;
+}
+
+export interface ThinkingEntry {
+  id: string;
+  text: string;
+  seq: number;
+}
+
+export interface AgentStreamState {
+  messages: StreamMessage[];
+  toolCalls: StreamToolCall[];
+  thinking: ThinkingEntry[];
+  phase: AgentPhase;
+  // 已处理过的事件 key（seq 优先，否则 id），用于重连去重。
+  seen: Set<string>;
+  // 已知最大 seq，用于对账丢帧判断。
+  maxSeq: number;
+  // 是否可能丢帧（回放不可用降级对账时置位，UI 展示「可能有事件缺失」）。
+  maybeMissingEvents: boolean;
+  // 终态锁：中断 / 结束后置位，迟到帧不再改写相位。
+  finalized: boolean;
+  errorMessage?: string;
+}
+
+export function initialStreamState(): AgentStreamState {
+  return {
+    messages: [],
+    toolCalls: [],
+    thinking: [],
+    phase: "idle",
+    seen: new Set(),
+    maxSeq: -1,
+    maybeMissingEvents: false,
+    finalized: false,
+  };
+}
+
+// 事件去重 key：优先 seq（后端单调递增、最可靠），否则用 id，都没有则不可去重（返回 null）。
+function eventKey(ev: AgentEvent): string | null {
+  if (typeof ev.seq === "number") return `seq:${ev.seq}`;
+  if (ev.id) return `id:${ev.id}`;
+  return null;
+}
+
+// 按 seq 升序插入（乱序保护）：无 seq 的追加到末尾。
+function insertBySeq<T extends { seq: number }>(list: T[], item: T): T[] {
+  if (item.seq < 0) return [...list, item];
+  const next = [...list];
+  let i = next.length;
+  while (i > 0 && next[i - 1].seq > item.seq) i -= 1;
+  next.splice(i, 0, item);
+  return next;
+}
+
+// 归约单个事件，返回新状态（不可变）。
+export function reduceEvent(state: AgentStreamState, ev: AgentEvent): AgentStreamState {
+  // 1) 去重：重连回放时相同事件会再次到达。
+  const key = eventKey(ev);
+  if (key && state.seen.has(key)) return state;
+
+  // 2) 终态锁：aborted/done 之后到达的内容帧不再改写消息（迟到的 tool_result 可仍记录，
+  //    但不解除终态）。这里对 message/thinking/phase 一律忽略，保持终态稳定。
+  const seq = typeof ev.seq === "number" ? ev.seq : -1;
+  const seen = key ? new Set(state.seen).add(key) : state.seen;
+  const maxSeq = seq > state.maxSeq ? seq : state.maxSeq;
+
+  const base: AgentStreamState = { ...state, seen, maxSeq };
+
+  switch (ev.type) {
+    case "message":
+    case "message_delta": {
+      if (state.finalized && ev.type === "message_delta") return base;
+      const mid = ev.messageId || (ev.id ? `msg:${ev.id}` : `msg:seq:${seq}`);
+      const role = ev.role || "assistant";
+      const existing = base.messages.find((m) => m.id === mid);
+      let messages: StreamMessage[];
+      if (existing) {
+        // 同一条消息的增量：message_delta 追加，message（整段）覆盖。
+        const nextText = ev.type === "message" ? ev.text ?? "" : existing.text + (ev.text ?? "");
+        messages = base.messages.map((m) =>
+          m.id === mid ? { ...m, text: nextText, role } : m,
+        );
+      } else {
+        messages = insertBySeq(base.messages, {
+          id: mid,
+          role,
+          text: ev.text ?? "",
+          seq,
+        });
+      }
+      return {
+        ...base,
+        messages,
+        phase: base.finalized ? base.phase : "acting",
+      };
+    }
+
+    case "thinking": {
+      const tid = ev.messageId || (ev.id ? `think:${ev.id}` : `think:seq:${seq}`);
+      const existing = base.thinking.find((t) => t.id === tid);
+      let thinking: ThinkingEntry[];
+      if (existing) {
+        thinking = base.thinking.map((t) =>
+          t.id === tid ? { ...t, text: t.text + (ev.text ?? "") } : t,
+        );
+      } else {
+        thinking = insertBySeq(base.thinking, { id: tid, text: ev.text ?? "", seq });
+      }
+      return { ...base, thinking, phase: base.finalized ? base.phase : "thinking" };
+    }
+
+    case "tool_call": {
+      const cid = ev.toolCallId || (ev.id ? `tool:${ev.id}` : `tool:seq:${seq}`);
+      const existing = base.toolCalls.find((t) => t.id === cid);
+      let toolCalls: StreamToolCall[];
+      if (existing) {
+        toolCalls = base.toolCalls.map((t) =>
+          t.id === cid ? { ...t, name: ev.toolName ?? t.name, input: ev.input ?? t.input } : t,
+        );
+      } else {
+        toolCalls = insertBySeq(base.toolCalls, {
+          id: cid,
+          name: ev.toolName,
+          input: ev.input,
+          status: "running",
+          seq,
+        });
+      }
+      return { ...base, toolCalls, phase: base.finalized ? base.phase : "acting" };
+    }
+
+    case "tool_result": {
+      const cid = ev.toolCallId || (ev.id ? `tool:${ev.id}` : `tool:seq:${seq}`);
+      const existing = base.toolCalls.find((t) => t.id === cid);
+      let toolCalls: StreamToolCall[];
+      if (existing) {
+        toolCalls = base.toolCalls.map((t) =>
+          t.id === cid ? { ...t, output: ev.output, status: "done" } : t,
+        );
+      } else {
+        // 结果先于调用到达（乱序）：先建占位行，调用帧到达时补 input/name。
+        toolCalls = insertBySeq(base.toolCalls, {
+          id: cid,
+          name: ev.toolName,
+          output: ev.output,
+          status: "done",
+          seq,
+        });
+      }
+      return { ...base, toolCalls };
+    }
+
+    case "phase": {
+      if (base.finalized) return base;
+      return { ...base, phase: ev.phase ?? base.phase };
+    }
+
+    case "error": {
+      return {
+        ...base,
+        phase: "error",
+        finalized: true,
+        errorMessage: ev.errorMessage || "Agent run failed",
+      };
+    }
+
+    case "done": {
+      return { ...base, phase: base.phase === "error" ? "error" : "done", finalized: true };
+    }
+
+    default:
+      return base; // unknown：已计入 seen/maxSeq，内容不改（full 档由原始事件流单独展示）
+  }
+}
+
+// 批量归约（重放历史条目 / 初始化）。
+export function reduceAll(events: AgentEvent[], from = initialStreamState()): AgentStreamState {
+  return events.reduce(reduceEvent, from);
+}
+
+// 主动中断：标记 aborted 终态（迟到帧不再改写）。
+export function markAborted(state: AgentStreamState): AgentStreamState {
+  return { ...state, phase: "aborted", finalized: true };
+}
+
+// 断线对账：拿服务端 last_seq 与本地 maxSeq 比对，缺口则置「可能丢帧」。
+export function reconcileMissing(state: AgentStreamState, serverLastSeq?: number): AgentStreamState {
+  if (typeof serverLastSeq !== "number") return state;
+  const missing = serverLastSeq > state.maxSeq;
+  return missing ? { ...state, maybeMissingEvents: true } : state;
+}

--- a/packages/dmloop/src/agentRuntime/useAgentStream.ts
+++ b/packages/dmloop/src/agentRuntime/useAgentStream.ts
@@ -1,0 +1,188 @@
+// @octo/loop — useAgentStream
+//
+// 把 sseClient + streamReducer + 会话读取接口接到 React：
+//   - send(prompt)：发起流式 turn，事件实时归约进 state
+//   - abort()：中断当前 turn（本地立即置 aborted，并调后端 abort）
+//   - loadHistory(sessionKey)：切会话时用 get_entries 重建历史
+//   - SSE replay 续推：断线由 sseClient 自动带 Last-Event-ID 重连
+//   - 回放不可用降级：SSE 重连彻底失败时，用 get_state + get_entries 对账兜底，
+//     并把「可能有事件缺失」暴露给 UI
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SseConnection } from "../api/agentRuntime/sseClient";
+import * as runtimeApi from "../api/agentRuntime/agentRuntimeApi";
+import type { AgentEvent, SessionEntry } from "../api/agentRuntime/contracts";
+import {
+  AgentStreamState,
+  initialStreamState,
+  reduceEvent,
+  reduceAll,
+  markAborted,
+  reconcileMissing,
+} from "./streamReducer";
+
+// 把 get_entries 的历史条目转成事件，喂给同一个归约器重建历史。
+export function entriesToEvents(entries: SessionEntry[]): AgentEvent[] {
+  return entries.map((e) => {
+    const type: AgentEvent["type"] =
+      e.kind === "tool_call"
+        ? "tool_call"
+        : e.kind === "tool_result"
+          ? "tool_result"
+          : e.kind === "thinking"
+            ? "thinking"
+            : "message";
+    return {
+      type,
+      seq: e.seq,
+      id: e.id,
+      messageId: e.messageId,
+      role: e.role,
+      text: e.text,
+      toolCallId: e.toolCallId,
+      toolName: e.toolName,
+      input: e.input,
+      output: e.output,
+    };
+  });
+}
+
+export interface UseAgentStreamResult {
+  state: AgentStreamState;
+  running: boolean;
+  error?: string;
+  send: (prompt: string) => void;
+  abort: () => void;
+  loadHistory: (sessionKey: string) => Promise<void>;
+  reset: () => void;
+}
+
+export function useAgentStream(opts: {
+  sessionKey?: string;
+  agentId?: string;
+}): UseAgentStreamResult {
+  const [state, setState] = useState<AgentStreamState>(initialStreamState);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const connRef = useRef<SseConnection | null>(null);
+  // 用 ref 镜像最新 state，供 done 回调里对账（避免闭包读到陈旧 state）。
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      connRef.current?.close();
+    };
+  }, []);
+
+  const safeSet = useCallback((updater: (s: AgentStreamState) => AgentStreamState) => {
+    if (!mountedRef.current) return;
+    setState((prev) => {
+      const next = updater(prev);
+      stateRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    connRef.current?.close();
+    connRef.current = null;
+    setState(initialStreamState());
+    setRunning(false);
+    setError(undefined);
+  }, []);
+
+  // 回放不可用降级：用 get_state + get_entries 对账兜底。
+  const reconcileFallback = useCallback(async (sessionKey: string) => {
+    try {
+      const [st, entries] = await Promise.all([
+        runtimeApi.getState(sessionKey),
+        runtimeApi.getEntries(sessionKey),
+      ]);
+      if (!mountedRef.current) return;
+      // 用权威历史重建，再按 server last_seq 判断是否仍可能缺失。
+      let rebuilt = reduceAll(entriesToEvents(entries));
+      rebuilt = reconcileMissing(rebuilt, st.last_seq);
+      // 保留本地已置位的「可能丢帧」标记。
+      rebuilt = { ...rebuilt, maybeMissingEvents: rebuilt.maybeMissingEvents || stateRef.current.maybeMissingEvents };
+      safeSet(() => rebuilt);
+    } catch {
+      // 兜底也失败：只置「可能丢帧」提示，不清空既有内容。
+      safeSet((s) => ({ ...s, maybeMissingEvents: true }));
+    }
+  }, [safeSet]);
+
+  const send = useCallback(
+    (prompt: string) => {
+      const sessionKey = opts.sessionKey;
+      setError(undefined);
+      setRunning(true);
+      connRef.current?.close();
+
+      const conn = runtimeApi.prompt({
+        prompt,
+        sessionKey,
+        agentId: opts.agentId,
+        // 断线续推由 sseClient 内部记录最近事件 id 后自动带 Last-Event-ID，
+        // 这里首发不需要显式游标。
+        onEvent: (ev: AgentEvent) => safeSet((s) => reduceEvent(s, ev)),
+        onError: (_err, willRetry) => {
+          if (!willRetry) {
+            // 重连耗尽：标记可能丢帧，触发对账兜底。
+            safeSet((s) => ({ ...s, maybeMissingEvents: true }));
+          }
+        },
+        onClose: () => {
+          if (!mountedRef.current) return;
+          setRunning(false);
+        },
+      });
+      connRef.current = conn;
+
+      conn.done
+        .catch((e) => {
+          if (!mountedRef.current) return;
+          setError((e as Error)?.message || "Stream error");
+          // SSE 彻底失败：若有会话，走 get_state + get_entries 对账兜底。
+          if (sessionKey) void reconcileFallback(sessionKey);
+        })
+        .finally(() => {
+          if (mountedRef.current) setRunning(false);
+        });
+    },
+    [opts.sessionKey, opts.agentId, safeSet, reconcileFallback],
+  );
+
+  const abort = useCallback(() => {
+    connRef.current?.close();
+    connRef.current = null;
+    safeSet((s) => markAborted(s));
+    setRunning(false);
+    const sessionKey = opts.sessionKey;
+    if (sessionKey) void runtimeApi.abort(sessionKey).catch(() => { /* 本地已置终态，后端失败忽略 */ });
+  }, [opts.sessionKey, safeSet]);
+
+  const loadHistory = useCallback(
+    async (sessionKey: string) => {
+      connRef.current?.close();
+      connRef.current = null;
+      setError(undefined);
+      setRunning(false);
+      try {
+        const entries = await runtimeApi.getEntries(sessionKey);
+        if (!mountedRef.current) return;
+        setState(reduceAll(entriesToEvents(entries)));
+      } catch (e) {
+        if (!mountedRef.current) return;
+        setError((e as Error)?.message || "Failed to load session history");
+        setState(initialStreamState());
+      }
+    },
+    [],
+  );
+
+  return { state, running, error, send, abort, loadHistory, reset };
+}

--- a/packages/dmloop/src/agentRuntime/verbose.css
+++ b/packages/dmloop/src/agentRuntime/verbose.css
@@ -1,0 +1,37 @@
+/* @octo/loop — verbose renderer */
+.loop-verbose-root { display: flex; flex-direction: column; gap: 16px; }
+.loop-verbose-section { display: flex; flex-direction: column; gap: 6px; }
+.loop-verbose-section-title {
+  display: flex; align-items: center; gap: 5px; font-size: 11px; text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--semi-color-text-2);
+}
+.loop-verbose-message { font-size: 14px; line-height: 1.6; color: var(--semi-color-text-0); white-space: pre-wrap; }
+.loop-verbose-empty { font-size: 13px; color: var(--semi-color-text-2); font-style: italic; }
+
+.loop-verbose-thinking {
+  margin: 0; padding: 8px 10px; font-size: 12px; line-height: 1.5; white-space: pre-wrap;
+  background: var(--semi-color-fill-0); border-left: 2px solid var(--semi-color-info); border-radius: 0 4px 4px 0;
+  color: var(--semi-color-text-1);
+}
+
+.loop-verbose-tool { border: 1px solid var(--semi-color-border); border-radius: 6px; overflow: hidden; }
+.loop-verbose-tool-head {
+  display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; cursor: pointer;
+  border: none; background: var(--semi-color-fill-0); padding: 6px 10px; font-size: 12px; color: var(--semi-color-text-1);
+}
+.loop-verbose-tool-head:disabled { cursor: default; }
+.loop-verbose-tool-name { font-weight: 600; color: var(--semi-color-text-0); }
+.loop-verbose-tool-summary { flex: 1; color: var(--semi-color-text-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--code-font, monospace); }
+.loop-verbose-tool-status { font-size: 10px; text-transform: uppercase; padding: 1px 6px; border-radius: 8px; }
+.loop-verbose-tool-status.running { color: var(--semi-color-info); background: var(--semi-color-info-light-default); }
+.loop-verbose-tool-status.done { color: var(--semi-color-success, #52c41a); background: var(--semi-color-success-light-default, #f6ffed); }
+.loop-verbose-tool-status.error { color: var(--semi-color-danger); background: var(--semi-color-danger-light-default); }
+.loop-verbose-tool-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 8px; }
+.loop-verbose-kv { display: flex; flex-direction: column; gap: 2px; }
+.loop-verbose-k { font-size: 10px; text-transform: uppercase; color: var(--semi-color-text-2); }
+.loop-verbose-pre {
+  margin: 0; padding: 8px; font-size: 12px; line-height: 1.45; overflow-x: auto; white-space: pre-wrap;
+  background: var(--semi-color-fill-0); border-radius: 4px; font-family: var(--code-font, monospace); color: var(--semi-color-text-1);
+}
+.loop-verbose-pre.raw { max-height: 320px; overflow-y: auto; }
+.loop-verbose-error { color: var(--semi-color-danger); font-size: 13px; padding: 6px 0; }

--- a/packages/dmloop/src/agentRuntime/wordDiff.ts
+++ b/packages/dmloop/src/agentRuntime/wordDiff.ts
@@ -1,0 +1,61 @@
+// @octo/loop — 行内 word diff（纯函数，供富 diff split/unified 行内高亮）
+//
+// 对一对「删除行 / 新增行」做词级最长公共子序列（LCS）比对，标出真正变化的片段，
+// 避免整行标红/标绿。纯函数，无 React 依赖，单测直接覆盖。
+
+export type WordDiffKind = "equal" | "insert" | "delete";
+export interface WordDiffSegment {
+  kind: WordDiffKind;
+  value: string;
+}
+
+// 按「词 + 空白 + 标点」切分，保留分隔符（diff 结果可无损拼回原文）。
+export function tokenize(s: string): string[] {
+  const m = s.match(/(\s+|[A-Za-z0-9_]+|[^\sA-Za-z0-9_])/g);
+  return m ?? [];
+}
+
+// 计算两串 token 的 LCS 长度表（滚动不了，需回溯，故存全表）。
+function lcsTable(a: string[], b: string[]): number[][] {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  return dp;
+}
+
+// 返回从 oldLine 变到 newLine 的词级片段序列。
+export function wordDiff(oldLine: string, newLine: string): WordDiffSegment[] {
+  const a = tokenize(oldLine);
+  const b = tokenize(newLine);
+  const dp = lcsTable(a, b);
+  const segs: WordDiffSegment[] = [];
+  let i = 0;
+  let j = 0;
+  // 相邻同类片段合并，输出更紧凑。
+  const push = (kind: WordDiffKind, value: string) => {
+    const last = segs[segs.length - 1];
+    if (last && last.kind === kind) last.value += value;
+    else segs.push({ kind, value });
+  };
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      push("equal", a[i]);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      push("delete", a[i]);
+      i++;
+    } else {
+      push("insert", b[j]);
+      j++;
+    }
+  }
+  while (i < a.length) push("delete", a[i++]);
+  while (j < b.length) push("insert", b[j++]);
+  return segs;
+}

--- a/packages/dmloop/src/api/agentRuntime/__tests__/httpClient.test.ts
+++ b/packages/dmloop/src/api/agentRuntime/__tests__/httpClient.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  httpClient,
+  request,
+  AgentRuntimeError,
+  setAuthTokenProvider,
+  setUnauthorizedHandler,
+  buildAuthHeaders,
+} from "../httpClient";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe("httpClient", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = fetchMock;
+    setAuthTokenProvider(() => "secret-token");
+    setUnauthorizedHandler(null);
+  });
+  afterEach(() => {
+    setAuthTokenProvider(() => null);
+  });
+
+  it("注入 Bearer 鉴权头", () => {
+    const h = buildAuthHeaders({ Accept: "application/json" });
+    expect(h["Authorization"]).toBe("Bearer secret-token");
+    expect(h["Accept"]).toBe("application/json");
+  });
+
+  it("解包 {ok:true,data} 返回 data", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, data: { id: "s1" } }));
+    const out = await httpClient.get<{ id: string }>("/agent/sessions/s1");
+    expect(out).toEqual({ id: "s1" });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer secret-token");
+  });
+
+  it("{ok:false,error} 抛结构化错误（message + code）", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ ok: false, error: { message: "nope", code: "bad_request" } }, 400),
+    );
+    await expect(httpClient.get("/x")).rejects.toMatchObject({
+      name: "AgentRuntimeError",
+      message: "nope",
+      code: "bad_request",
+      status: 400,
+    });
+  });
+
+  it("401 抛 AgentRuntimeError 并触发 onUnauthorized", async () => {
+    const onUnauth = vi.fn();
+    setUnauthorizedHandler(onUnauth);
+    fetchMock.mockResolvedValue(jsonResponse({ ok: false }, 401));
+    await expect(httpClient.get("/agent/sessions")).rejects.toBeInstanceOf(AgentRuntimeError);
+    expect(onUnauth).toHaveBeenCalledWith("/agent/sessions");
+  });
+
+  it("未信封化的 2xx 对象原样返回", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ session_key: "a" }]));
+    const out = await httpClient.get<Array<{ session_key: string }>>("/agent/sessions");
+    expect(out).toEqual([{ session_key: "a" }]);
+  });
+
+  it("query 参数剔除 undefined/null/空串", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, data: [] }));
+    await httpClient.get("/agent/sessions", { agent_id: "a1", limit: undefined, foo: "" });
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("agent_id=a1");
+    expect(url).not.toContain("limit");
+    expect(url).not.toContain("foo");
+  });
+
+  it("POST 带 body 时注入 Content-Type 并序列化", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, data: null }, 200));
+    await request("/agent/prompt", { method: "POST", body: { prompt: "hi" } });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ prompt: "hi" }));
+  });
+
+  it("非 JSON 且非 2xx 抛错", async () => {
+    fetchMock.mockResolvedValue(jsonResponse("Internal Error", 500));
+    await expect(httpClient.get("/x")).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/packages/dmloop/src/api/agentRuntime/__tests__/sseClient.test.ts
+++ b/packages/dmloop/src/api/agentRuntime/__tests__/sseClient.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import { SseFrameParser, connectSse } from "../sseClient";
+import { setAuthTokenProvider } from "../httpClient";
+
+describe("SseFrameParser", () => {
+  it("解析单帧 event/data/id", () => {
+    const p = new SseFrameParser();
+    const frames = p.push("event: message\ndata: hello\nid: 7\n\n");
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual({ event: "message", data: "hello", id: "7", retry: undefined });
+  });
+
+  it("多行 data 拼接（换行连接）", () => {
+    const p = new SseFrameParser();
+    const [f] = p.push("data: line1\ndata: line2\n\n");
+    expect(f.data).toBe("line1\nline2");
+  });
+
+  it("半包：跨 push 的帧能续上", () => {
+    const p = new SseFrameParser();
+    expect(p.push("data: par")).toHaveLength(0);
+    const frames = p.push("tial\n\n");
+    expect(frames).toHaveLength(1);
+    expect(frames[0].data).toBe("partial");
+  });
+
+  it("CRLF / CR 归一为 LF", () => {
+    const p = new SseFrameParser();
+    const [f] = p.push("data: a\r\ndata: b\r\n\r\n");
+    expect(f.data).toBe("a\nb");
+  });
+
+  it("冒号后单个前导空格被去掉，其余保留", () => {
+    const p = new SseFrameParser();
+    const [f] = p.push("data:  two-leading\n\n"); // 两个空格 → 去一个留一个
+    expect(f.data).toBe(" two-leading");
+  });
+
+  it("注释行(:)被忽略", () => {
+    const p = new SseFrameParser();
+    const [f] = p.push(": keep-alive\ndata: real\n\n");
+    expect(f.data).toBe("real");
+  });
+
+  it("flush 冲刷末尾无空行的残帧", () => {
+    const p = new SseFrameParser();
+    expect(p.push("data: tail\n")).toHaveLength(0);
+    const frames = p.flush();
+    expect(frames).toHaveLength(1);
+    expect(frames[0].data).toBe("tail");
+  });
+});
+
+// 用 chunks 构造一个可读流的 Response。
+function streamResponse(chunks: string[], ok = true, status = 200): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return { ok, status, body } as unknown as Response;
+}
+
+describe("connectSse", () => {
+  it("解析流中的多帧并追踪 lastEventId", async () => {
+    setAuthTokenProvider(() => "tok");
+    const frames: string[] = [];
+    const fetchImpl = vi.fn().mockResolvedValue(
+      streamResponse(["data: a\nid: 1\n\n", "data: b\nid: 2\n\n"]),
+    );
+    const conn = connectSse("/agent/prompt", {
+      body: { prompt: "hi" },
+      onFrame: (f) => frames.push(f.data),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+    });
+    await conn.done;
+    expect(frames).toEqual(["a", "b"]);
+    expect(conn.lastEventId()).toBe("2");
+    // Bearer 头注入
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer tok");
+  });
+
+  it("断线后重连并显式注入 Last-Event-ID 头", async () => {
+    const frames: string[] = [];
+    let call = 0;
+    const fetchImpl = vi.fn().mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        // 首次：先给一帧(id:5)再让流出错。用 pull 分两步：先投递 chunk，再 error，
+        // 避免 start() 内同步 enqueue+error 导致已入队 chunk 被丢弃。
+        const enc = new TextEncoder();
+        let step = 0;
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (step === 0) {
+              controller.enqueue(enc.encode("data: first\nid: 5\n\n"));
+              step = 1;
+            } else {
+              controller.error(new Error("network drop"));
+            }
+          },
+        });
+        return Promise.resolve({ ok: true, status: 200, body } as unknown as Response);
+      }
+      // 重连：正常收尾
+      return Promise.resolve(streamResponse(["data: second\nid: 6\n\n"]));
+    });
+
+    const conn = connectSse("/agent/prompt", {
+      body: {},
+      onFrame: (f) => frames.push(f.data),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+      maxRetries: 3,
+    });
+    await conn.done;
+
+    expect(frames).toEqual(["first", "second"]);
+    // 第二次调用应带上 Last-Event-ID: 5
+    const retryHeaders = (fetchImpl.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(retryHeaders["Last-Event-ID"]).toBe("5");
+    expect(conn.lastEventId()).toBe("6");
+  });
+
+  it("close() 主动中断不触发重连", async () => {
+    // 真实 fetch 在 signal abort 时 reject AbortError；mock 照此语义。
+    const fetchImpl = vi.fn().mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init.signal;
+          signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+    const conn = connectSse("/agent/prompt", {
+      body: {},
+      onFrame: () => {},
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+    });
+    conn.close();
+    await conn.done; // 应正常 resolve（AbortError 被识别为主动中断，不 reject、不重连）
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmloop/src/api/agentRuntime/agentRuntimeApi.ts
+++ b/packages/dmloop/src/api/agentRuntime/agentRuntimeApi.ts
@@ -1,0 +1,167 @@
+// @octo/loop — Agent Runtime API（会话运行期）
+//
+// 与既有 agentApi.ts（agent 实体 CRUD）相互独立：本模块面向「一次会话里跑 turn」的
+// 运行期操作——发起 prompt（流式）、列会话、取会话历史、中断当前 turn，以及
+// 差异 / 检查点 / 回滚（均标注「待后端确认」）。
+//
+// 路径基于研发设计文档的前端预期；带 SSE 的 prompt 走 sseClient，其余走 httpClient。
+// ⚠️ diff / checkpoint / rollback 端点与字段后端未定，仅按前端契约预留，联调再对齐。
+
+import { httpClient } from "./httpClient";
+import { connectSse, type SseConnection, type SseFrame } from "./sseClient";
+import type {
+  AgentEvent,
+  AgentSessionSummary,
+  SessionEntry,
+  SessionState,
+  FileDiff,
+  Checkpoint,
+} from "./contracts";
+
+/* ============================ 会话读取 ============================ */
+
+// 列出会话（GET /agent/sessions）。用于会话列表 UI。
+export async function listSessions(params?: {
+  agentId?: string;
+  limit?: number;
+}): Promise<AgentSessionSummary[]> {
+  const rows = await httpClient.get<AgentSessionSummary[]>("/agent/sessions", {
+    agent_id: params?.agentId,
+    limit: params?.limit,
+  });
+  return rows ?? [];
+}
+
+// 取单个会话元信息（GET /agent/sessions/:key）。
+export function getSession(sessionKey: string): Promise<AgentSessionSummary> {
+  return httpClient.get<AgentSessionSummary>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}`,
+  );
+}
+
+// 重建历史（GET /agent/sessions/:key/entries）：切会话时用它拉全量已归约条目。
+export async function getEntries(
+  sessionKey: string,
+  params?: { since_seq?: number; limit?: number },
+): Promise<SessionEntry[]> {
+  const rows = await httpClient.get<SessionEntry[]>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}/entries`,
+    { since_seq: params?.since_seq, limit: params?.limit },
+  );
+  return rows ?? [];
+}
+
+// 取会话运行态（GET /agent/sessions/:key/state）：
+// SSE 回放不可用时，用它 + getEntries 对账兜底、判断是否可能丢帧。
+export function getState(sessionKey: string): Promise<SessionState> {
+  return httpClient.get<SessionState>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}/state`,
+  );
+}
+
+/* ============================ prompt（流式跑 turn） ============================ */
+
+export interface PromptOptions {
+  sessionKey?: string;
+  agentId?: string;
+  prompt: string;
+  // 续推游标（重连或恢复时带上）。
+  lastEventId?: string;
+  // 解析后的领域事件回调。
+  onEvent: (event: AgentEvent) => void;
+  onOpen?: (info: { reconnect: boolean; attempt: number }) => void;
+  onError?: (err: unknown, willRetry: boolean) => void;
+  onClose?: () => void;
+}
+
+// 把 SSE 帧解析为领域事件：data 是 JSON；event 名对齐 type；无法解析时兜底 unknown。
+export function frameToEvent(frame: SseFrame): AgentEvent | null {
+  if (!frame.data && !frame.event) return null;
+  let parsed: Record<string, unknown> = {};
+  if (frame.data) {
+    try {
+      parsed = JSON.parse(frame.data) as Record<string, unknown>;
+    } catch {
+      // 非 JSON data：当作纯文本消息增量。
+      parsed = { type: frame.event || "message_delta", text: frame.data };
+    }
+  }
+  const type = (frame.event || (parsed.type as string) || "unknown") as AgentEvent["type"];
+  const seqRaw = parsed.seq;
+  return {
+    type,
+    seq: typeof seqRaw === "number" ? seqRaw : undefined,
+    id: frame.id ?? (parsed.id as string | undefined),
+    messageId: parsed.message_id as string | undefined,
+    role: parsed.role as AgentEvent["role"],
+    text: parsed.text as string | undefined,
+    toolCallId: parsed.tool_call_id as string | undefined,
+    toolName: parsed.tool_name as string | undefined,
+    input: parsed.input,
+    output: parsed.output,
+    phase: parsed.phase as AgentEvent["phase"],
+    errorMessage: parsed.error as string | undefined,
+    raw: parsed,
+  };
+}
+
+// 发起一次流式 prompt。返回 SseConnection（含 close 中断、done、lastEventId）。
+export function prompt(opts: PromptOptions): SseConnection {
+  const { onEvent, prompt: text, sessionKey, agentId, lastEventId, ...cbs } = opts;
+  return connectSse("/agent/prompt", {
+    method: "POST",
+    body: { prompt: text, session_key: sessionKey, agent_id: agentId },
+    lastEventId,
+    onFrame: (frame) => {
+      const ev = frameToEvent(frame);
+      if (ev) onEvent(ev);
+    },
+    onOpen: cbs.onOpen,
+    onError: cbs.onError,
+    onClose: cbs.onClose,
+  });
+}
+
+/* ============================ 中断当前 turn ============================ */
+
+// 中断正在运行的 turn（POST /agent/sessions/:key/abort）。
+export function abort(sessionKey: string): Promise<void> {
+  return httpClient.post<void>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}/abort`,
+    {},
+  );
+}
+
+/* ============================ 富 diff（待后端确认） ============================ */
+// ⚠️ 以下端点 / 字段后端尚未确认，仅按前端 diff JSON 契约预留。联调后以后端为准。
+
+// 取一次会话（或某检查点）的文件差异集合。
+export async function getDiff(params: {
+  sessionKey: string;
+  // 待后端确认：是否支持按检查点 / turn 过滤。
+  checkpointId?: string;
+  path?: string;
+}): Promise<FileDiff[]> {
+  const rows = await httpClient.get<FileDiff[]>(
+    `/agent/sessions/${encodeURIComponent(params.sessionKey)}/diff`,
+    { checkpoint_id: params.checkpointId, path: params.path },
+  );
+  return rows ?? [];
+}
+
+/* ============================ 检查点 / 回滚（待后端确认） ============================ */
+
+export async function listCheckpoints(sessionKey: string): Promise<Checkpoint[]> {
+  const rows = await httpClient.get<Checkpoint[]>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}/checkpoints`,
+  );
+  return rows ?? [];
+}
+
+// 回滚到某检查点。待后端确认：是否幂等、回滚粒度（工作区 / 会话）。
+export function rollback(sessionKey: string, checkpointId: string): Promise<void> {
+  return httpClient.post<void>(
+    `/agent/sessions/${encodeURIComponent(sessionKey)}/rollback`,
+    { checkpoint_id: checkpointId },
+  );
+}

--- a/packages/dmloop/src/api/agentRuntime/contracts.ts
+++ b/packages/dmloop/src/api/agentRuntime/contracts.ts
@@ -1,0 +1,159 @@
+// @octo/loop — Agent Runtime 契约类型
+//
+// 这是「Agent Runtime UI」新增能力的类型层，与既有 agentApi.ts（agent 实体 CRUD）
+// 相互独立：本文件描述的是「一次会话（session）里 agent 跑 turn 时流式吐出的事件」
+// 以及会话/差异/检查点等运行期数据结构。
+//
+// ⚠️ 契约边界：凡涉及 diff / checkpoint / rollback 的端点与字段均标注「待后端确认」，
+// 下面这些接口是按研发设计文档（DESIGN-frontend-devdesign.md, APPROVED）的前端预期
+// 建模，后端字段最终以联调为准；对不确定字段一律用可选属性 + 宽松解析，不脑补必填。
+
+/* ============================ 通用响应封装 ============================ */
+
+// 后端统一响应信封：{ ok, data, error }。httpClient 负责解包，业务层只拿到 data。
+export interface Envelope<T> {
+  ok: boolean;
+  data?: T;
+  error?: { code?: string; message?: string } | string | null;
+}
+
+/* ============================ 事件流（SSE） ============================ */
+
+// 一次 turn 内后端通过 SSE 推送的事件类型。名称与后端事件 `type` 字段对齐；
+// 遇到未知类型时归约器保底当作 `unknown` 透传，不丢帧（利于 full 档排障）。
+export type AgentEventType =
+  | "message" // assistant 文本增量或整段
+  | "message_delta" // assistant 文本增量（token 级）
+  | "thinking" // reasoning / 思考过程（full 档展开）
+  | "tool_call" // 工具调用发起（含入参）
+  | "tool_result" // 工具调用返回（出参）
+  | "phase" // 阶段变更（thinking/acting/waiting/done…）
+  | "error" // turn 内错误
+  | "done" // turn 结束
+  | "unknown";
+
+// 单个事件的标准形状。`seq` 与 `id` 用于排序 / 去重 / 断线续推：
+// - seq：后端单调递增序号（用于本地乱序重排、去重）
+// - id：SSE 帧 id（用作 Last-Event-ID 续推游标）
+export interface AgentEvent {
+  type: AgentEventType;
+  seq?: number;
+  id?: string;
+  // 会话内消息归属：同一条 assistant 消息的多个增量共享 messageId。
+  messageId?: string;
+  role?: "user" | "assistant" | "system" | "tool";
+  // 文本（message / message_delta / thinking）。
+  text?: string;
+  // 工具调用（tool_call / tool_result）。
+  toolCallId?: string;
+  toolName?: string;
+  // 原始入参 / 出参：full 档原样展示，不做裁剪。
+  input?: unknown;
+  output?: unknown;
+  // phase 事件的目标阶段。
+  phase?: AgentPhase;
+  // error 事件。
+  errorMessage?: string;
+  // 任意后端附加字段（full 档「完整事件流」原样保留）。
+  raw?: Record<string, unknown>;
+}
+
+export type AgentPhase =
+  | "idle"
+  | "thinking"
+  | "acting"
+  | "waiting"
+  | "done"
+  | "aborted"
+  | "error";
+
+/* ============================ 会话（session） ============================ */
+
+export interface AgentSessionSummary {
+  session_key: string;
+  title?: string;
+  agent_id?: string;
+  updated_at?: string;
+  created_at?: string;
+  // 该会话是否有 turn 正在运行（用于「abort 在跑 turn」按钮的可用态）。
+  running?: boolean;
+}
+
+// getSession / get_entries 重建历史用的一条条目（已归约的消息/工具调用）。
+export interface SessionEntry {
+  seq?: number;
+  id?: string;
+  messageId?: string;
+  role?: "user" | "assistant" | "system" | "tool";
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  output?: unknown;
+  kind?: "message" | "thinking" | "tool_call" | "tool_result";
+}
+
+export interface SessionState {
+  session_key: string;
+  phase?: AgentPhase;
+  running?: boolean;
+  // 服务端已知的最大事件序号 / 最后一个事件 id：
+  // 断线重连回放不可用时，用它与本地对账、判断是否可能丢帧。
+  last_seq?: number;
+  last_event_id?: string;
+}
+
+/* ============================ 富 diff（待后端确认） ============================ */
+
+// diff JSON 契约（研发设计文档指定；后端字段待确认）。
+// changeType 用后端常见枚举，解析时对未知值宽松兜底为 "modified"。
+export type DiffChangeType =
+  | "added"
+  | "deleted"
+  | "modified"
+  | "renamed"
+  | "copied";
+
+export interface DiffHunkLine {
+  // 行类型：insert / delete / normal（上下文）。
+  type: "insert" | "delete" | "normal";
+  // 旧/新文件行号（normal 两者都有，insert 只有新，delete 只有旧）。
+  oldLine?: number | null;
+  newLine?: number | null;
+  content: string;
+}
+
+export interface DiffHunk {
+  oldStart?: number;
+  oldLines?: number;
+  newStart?: number;
+  newLines?: number;
+  header?: string;
+  lines: DiffHunkLine[];
+}
+
+// 单文件 diff。binary / truncated 用于大文件与二进制的降级展示。
+export interface FileDiff {
+  path: string;
+  oldPath?: string; // renamed 时的原路径
+  changeType: DiffChangeType;
+  hunks: DiffHunk[];
+  binary?: boolean;
+  truncated?: boolean;
+  // 行数规模（用于「大文件切 Monaco」阈值判断，后端可选提供）。
+  additions?: number;
+  deletions?: number;
+}
+
+/* ============================ 检查点 / 回滚（待后端确认） ============================ */
+
+export interface Checkpoint {
+  id: string;
+  session_key?: string;
+  // 关联的 turn / 消息序号，用于时间线定位。
+  seq?: number;
+  label?: string;
+  created_at?: string;
+  // 该检查点相对上一个的文件改动摘要（可选）。
+  files_changed?: number;
+}

--- a/packages/dmloop/src/api/agentRuntime/httpClient.ts
+++ b/packages/dmloop/src/api/agentRuntime/httpClient.ts
@@ -1,0 +1,157 @@
+// @octo/loop — Agent Runtime httpClient
+//
+// 独立于既有 axios http.ts：Agent Runtime 后端走 Bearer 鉴权 + `{ok,data,error}`
+// 统一信封，与 loop 全域接口（token / X-Space-Id header）契约不同，故单独建客户端。
+// 基于原生 fetch（sseClient 也用 fetch 流式，保持同栈），无第三方依赖，便于单测 mock。
+//
+// 职责：
+//   1) 注入 Bearer 鉴权头（token 来源可注入，默认读 loop 既有登录态）
+//   2) 401 拦截：统一抛 AgentRuntimeError(401)，并触发可注册的 onUnauthorized 回调
+//   3) 解包 {ok,data,error}：ok=false 或 HTTP 非 2xx 抛结构化错误，成功返回 data
+
+import type { Envelope } from "./contracts";
+
+export const AGENT_RUNTIME_BASE =
+  (import.meta as { env?: Record<string, string> }).env?.VITE_AGENT_RUNTIME_BASE ||
+  "/fleet/api/v1";
+
+/* ---------------------- 鉴权 token 提供者 ---------------------- */
+// token 解耦：默认空，宿主（octo-web）在启动时注入真实取值来源（复用登录态），
+// 单测里直接 setAuthTokenProvider(() => "t") 即可，无需拉起 @octo/base。
+type TokenProvider = () => string | null | undefined;
+let _tokenProvider: TokenProvider = () => null;
+export function setAuthTokenProvider(fn: TokenProvider): void {
+  _tokenProvider = fn;
+}
+
+// 401 处理钩子：宿主可注册（如跳登录 / 刷新态）。返回值忽略。
+type UnauthorizedHandler = (path: string) => void;
+let _onUnauthorized: UnauthorizedHandler | null = null;
+export function setUnauthorizedHandler(fn: UnauthorizedHandler | null): void {
+  _onUnauthorized = fn;
+}
+
+/* ---------------------- 结构化错误 ---------------------- */
+export class AgentRuntimeError extends Error {
+  status?: number;
+  code?: string;
+  constructor(message: string, status?: number, code?: string) {
+    super(message);
+    this.name = "AgentRuntimeError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function normalizeError(err: Envelope<unknown>["error"]): { message: string; code?: string } {
+  if (!err) return { message: "Request failed" };
+  if (typeof err === "string") return { message: err };
+  return { message: err.message || "Request failed", code: err.code };
+}
+
+/* ---------------------- 请求头 ---------------------- */
+export function buildAuthHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { ...(extra ?? {}) };
+  const token = _tokenProvider();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+/* ---------------------- 核心请求 ---------------------- */
+interface RequestOpts {
+  method?: string;
+  body?: unknown;
+  // 查询参数（会剔除 undefined/null/空串）。
+  params?: Record<string, unknown>;
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
+function buildUrl(path: string, params?: Record<string, unknown>): string {
+  const base = path.startsWith("http") ? path : `${AGENT_RUNTIME_BASE}${path}`;
+  if (!params) return base;
+  const qs: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== "") {
+      qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+    }
+  }
+  if (!qs.length) return base;
+  return `${base}${base.includes("?") ? "&" : "?"}${qs.join("&")}`;
+}
+
+// 发起请求并解包信封。始终解析为业务数据 T；异常一律抛 AgentRuntimeError。
+export async function request<T>(path: string, opts: RequestOpts = {}): Promise<T> {
+  const url = buildUrl(path, opts.params);
+  const headers = buildAuthHeaders({
+    Accept: "application/json",
+    ...(opts.body !== undefined ? { "Content-Type": "application/json" } : {}),
+    ...(opts.headers ?? {}),
+  });
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: opts.method ?? "GET",
+      headers,
+      credentials: "include",
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: opts.signal,
+    });
+  } catch (e) {
+    // 网络层错误（含 AbortError）：统一包装，AbortError 保留 name 供上层识别。
+    if ((e as { name?: string })?.name === "AbortError") throw e;
+    throw new AgentRuntimeError((e as Error)?.message || "Network error");
+  }
+
+  // 401 拦截：先触发钩子，再抛结构化错误。
+  if (resp.status === 401) {
+    _onUnauthorized?.(path);
+    throw new AgentRuntimeError("Unauthorized", 401, "unauthorized");
+  }
+
+  // 解析响应体（可能为空，如 204）。
+  let payload: unknown = undefined;
+  const raw = await resp.text();
+  if (raw) {
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      // 非 JSON 响应：非 2xx 视为错误文本，2xx 原样返回。
+      if (!resp.ok) throw new AgentRuntimeError(raw || `HTTP ${resp.status}`, resp.status);
+      return raw as unknown as T;
+    }
+  }
+
+  // 信封解包：优先按 {ok,data,error} 处理；后端未包信封时（直接返回对象）兜底。
+  const env = payload as Envelope<T> | T;
+  const looksEnveloped =
+    env !== null && typeof env === "object" && "ok" in (env as object);
+
+  if (looksEnveloped) {
+    const e = env as Envelope<T>;
+    if (!resp.ok || e.ok === false) {
+      const { message, code } = normalizeError(e.error);
+      throw new AgentRuntimeError(message, resp.status, code);
+    }
+    return (e.data as T) ?? (undefined as unknown as T);
+  }
+
+  // 未信封化：非 2xx 抛错，2xx 原样返回。
+  if (!resp.ok) {
+    throw new AgentRuntimeError(`HTTP ${resp.status}`, resp.status);
+  }
+  return env as T;
+}
+
+/* ---------------------- 便捷方法 ---------------------- */
+export const httpClient = {
+  get: <T>(path: string, params?: Record<string, unknown>, signal?: AbortSignal) =>
+    request<T>(path, { method: "GET", params, signal }),
+  post: <T>(path: string, body?: unknown, signal?: AbortSignal) =>
+    request<T>(path, { method: "POST", body, signal }),
+  put: <T>(path: string, body?: unknown, signal?: AbortSignal) =>
+    request<T>(path, { method: "PUT", body, signal }),
+  del: <T>(path: string, body?: unknown, signal?: AbortSignal) =>
+    request<T>(path, { method: "DELETE", body, signal }),
+};

--- a/packages/dmloop/src/api/agentRuntime/sseClient.ts
+++ b/packages/dmloop/src/api/agentRuntime/sseClient.ts
@@ -1,0 +1,229 @@
+// @octo/loop — Agent Runtime sseClient
+//
+// SSE over POST：agent 跑 turn 需要 POST 请求体（prompt/参数），原生 EventSource 只支持
+// GET，故用 fetch + ReadableStream 手写 SSE 解析。特性：
+//   1) POST + fetch 流式读取
+//   2) 逐帧解析（event/data/id/retry 字段，多行 data 拼接，空行分隔）
+//   3) 断线重连（指数退避 + 上限），重连时显式注入 Last-Event-ID
+//   4) 显式 Last-Event-ID：不依赖浏览器原生续推（fetch 无此语义），由本客户端手动带
+//
+// 帧解析拆成纯函数 SseFrameParser，便于单测覆盖乱序拼帧/半包/CRLF 等边界。
+
+import { AGENT_RUNTIME_BASE, buildAuthHeaders } from "./httpClient";
+
+/* ============================ 纯帧解析器 ============================ */
+
+export interface SseFrame {
+  event?: string;
+  data: string;
+  id?: string;
+  retry?: number;
+}
+
+// 增量喂入原始文本、吐出完整帧。处理半包（跨 chunk 的帧）与 CRLF/CR/LF 三种换行。
+export class SseFrameParser {
+  private buf = "";
+
+  // 喂入一段原始文本，返回本次能完整解析出的帧（可能为空）。
+  push(chunk: string): SseFrame[] {
+    this.buf += chunk;
+    // 统一换行为 \n，便于用双换行切分事件。
+    this.buf = this.buf.replace(/\r\n|\r/g, "\n");
+    const frames: SseFrame[] = [];
+    let sep: number;
+    // SSE 以空行（\n\n）分隔事件；只切出已完整的部分，残余留在 buf。
+    while ((sep = this.buf.indexOf("\n\n")) !== -1) {
+      const block = this.buf.slice(0, sep);
+      this.buf = this.buf.slice(sep + 2);
+      const frame = this.parseBlock(block);
+      if (frame) frames.push(frame);
+    }
+    return frames;
+  }
+
+  // 流结束时冲刷残余（末尾无空行的最后一帧）。
+  flush(): SseFrame[] {
+    const rest = this.buf.trim();
+    this.buf = "";
+    if (!rest) return [];
+    const frame = this.parseBlock(rest);
+    return frame ? [frame] : [];
+  }
+
+  private parseBlock(block: string): SseFrame | null {
+    const lines = block.split("\n");
+    const dataLines: string[] = [];
+    let event: string | undefined;
+    let id: string | undefined;
+    let retry: number | undefined;
+    let sawField = false;
+    for (const line of lines) {
+      if (line === "" || line.startsWith(":")) continue; // 注释行 / 空行
+      const idx = line.indexOf(":");
+      const field = idx === -1 ? line : line.slice(0, idx);
+      // 规范：冒号后单个前导空格要去掉。
+      let value = idx === -1 ? "" : line.slice(idx + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+      switch (field) {
+        case "event":
+          event = value;
+          sawField = true;
+          break;
+        case "data":
+          dataLines.push(value);
+          sawField = true;
+          break;
+        case "id":
+          id = value;
+          sawField = true;
+          break;
+        case "retry": {
+          const n = Number(value);
+          if (!Number.isNaN(n)) retry = n;
+          sawField = true;
+          break;
+        }
+        default:
+          break; // 未知字段忽略
+      }
+    }
+    if (!sawField) return null;
+    return { event, data: dataLines.join("\n"), id, retry };
+  }
+}
+
+/* ============================ 流式连接 ============================ */
+
+export interface SseConnectOptions {
+  // 请求方法，默认 POST。
+  method?: string;
+  // POST 请求体（如 { prompt, session_key, ... }）。
+  body?: unknown;
+  // 续推游标：首次连接可为空，重连时客户端自动带上最近收到的 id。
+  lastEventId?: string;
+  // 收到一帧。
+  onFrame: (frame: SseFrame) => void;
+  // 每次（重）连接建立时回调，reconnect=true 表示这是断线后的重连。
+  onOpen?: (info: { reconnect: boolean; attempt: number }) => void;
+  // 连接错误（含中途断流）。返回后由客户端决定是否重连。
+  onError?: (err: unknown, willRetry: boolean) => void;
+  // 正常收到「流结束」（服务端关闭）后回调。
+  onClose?: () => void;
+  // 最大重连次数，默认 5；<=0 表示不重连。
+  maxRetries?: number;
+  // 退避基数 ms，默认 500（第 n 次退避 = base * 2^(n-1)，上限 maxBackoffMs）。
+  backoffBaseMs?: number;
+  maxBackoffMs?: number;
+  // 注入的 sleep（单测可替换为立即 resolve）。
+  sleep?: (ms: number) => Promise<void>;
+  // 注入的 fetch（单测可替换）。
+  fetchImpl?: typeof fetch;
+}
+
+export interface SseConnection {
+  // 主动中断（abort 当前 turn / 组件卸载）。
+  close: () => void;
+  // 已完成的 promise（正常关闭 resolve；不可恢复错误 reject）。
+  done: Promise<void>;
+  // 当前已知的 Last-Event-ID。
+  lastEventId: () => string | undefined;
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// 建立一条带自动重连的 SSE 连接。
+export function connectSse(path: string, opts: SseConnectOptions): SseConnection {
+  const {
+    method = "POST",
+    body,
+    onFrame,
+    onOpen,
+    onError,
+    onClose,
+    maxRetries = 5,
+    backoffBaseMs = 500,
+    maxBackoffMs = 10_000,
+    sleep = defaultSleep,
+    fetchImpl = fetch,
+  } = opts;
+
+  let lastId = opts.lastEventId;
+  let aborted = false;
+  let controller: AbortController | null = null;
+
+  const url = path.startsWith("http") ? path : `${AGENT_RUNTIME_BASE}${path}`;
+
+  async function runOnce(reconnect: boolean, attempt: number): Promise<void> {
+    controller = new AbortController();
+    const headers = buildAuthHeaders({
+      Accept: "text/event-stream",
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      // 显式续推：把最近的事件 id 作为 Last-Event-ID 头带上（fetch 不会自动带）。
+      ...(lastId ? { "Last-Event-ID": lastId } : {}),
+    });
+
+    const resp = await fetchImpl(url, {
+      method,
+      headers,
+      credentials: "include",
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    if (!resp.ok || !resp.body) {
+      throw new Error(`SSE connect failed: HTTP ${resp.status}`);
+    }
+    onOpen?.({ reconnect, attempt });
+
+    const parser = new SseFrameParser();
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const text = decoder.decode(value, { stream: true });
+      for (const frame of parser.push(text)) {
+        if (frame.id) lastId = frame.id;
+        onFrame(frame);
+      }
+    }
+    for (const frame of parser.flush()) {
+      if (frame.id) lastId = frame.id;
+      onFrame(frame);
+    }
+  }
+
+  const done = (async () => {
+    let attempt = 0;
+    for (;;) {
+      try {
+        await runOnce(attempt > 0, attempt);
+        // 正常结束（服务端关流）。
+        if (!aborted) onClose?.();
+        return;
+      } catch (e) {
+        if (aborted || (e as { name?: string })?.name === "AbortError") {
+          // 主动中断：不算错误，不重连。
+          return;
+        }
+        const willRetry = attempt < maxRetries;
+        onError?.(e, willRetry);
+        if (!willRetry) throw e;
+        const backoff = Math.min(backoffBaseMs * 2 ** attempt, maxBackoffMs);
+        attempt += 1;
+        await sleep(backoff);
+        if (aborted) return;
+      }
+    }
+  })();
+
+  return {
+    close: () => {
+      aborted = true;
+      controller?.abort();
+    },
+    done,
+    lastEventId: () => lastId,
+  };
+}


### PR DESCRIPTION
## Agent Runtime UI (incremental)

Adds an incremental **Agent Runtime UI** layer to `@octo/loop` — the HTTP/SSE client
stack, event-stream reduction, and the verbose / rich-diff / checkpoint components
needed to drive an agent session from the web app. No existing files are modified;
everything is additive under `packages/dmloop/src/agentRuntime/` and
`packages/dmloop/src/api/agentRuntime/`, and the public package surface
(`src/index.tsx`) is unchanged.

> **Draft — not for merge.** Opened for review of the frontend contract. The
> diff / checkpoint / rollback endpoints and fields are still pending backend
> confirmation; wiring the top-level panel into a route and live end-to-end runs
> depend on those endpoints landing.

### What's here

**API layer (`src/api/agentRuntime`)**
- `httpClient` — fetch-based, injects `Authorization: Bearer <token>`, intercepts
  401 (structured error + `onUnauthorized` hook), and unwraps the `{ok,data,error}`
  envelope (with a lenient fallback for non-enveloped responses).
- `sseClient` — SSE **over POST** (agent turns need a request body, which native
  `EventSource` can't do): a pure, unit-tested frame parser (multi-line `data`,
  CRLF, half-packets, comments), exponential-backoff reconnect, and **explicit
  `Last-Event-ID`** injection on resume (fetch has no native replay semantics).
- `agentRuntimeApi` — `prompt` (streaming), `listSessions`, `getSession`,
  `getEntries`, `getState`, `abort`, plus `getDiff` / `listCheckpoints` /
  `rollback` (**pending backend confirmation**).

**Event stream**
- `streamReducer` — a pure function folding SSE events into
  `{messages, toolCalls, thinking, phase}`. Handles **out-of-order** events
  (ordered by `seq`), **reconnect de-duplication** (idempotent on repeated
  `seq`/`id`), and **interrupt/finalize** (late frames can't rewrite a terminal
  state).
- `useAgentStream` — wires the reducer to `sseClient`, exposes
  `send/abort/loadHistory`, and on replay failure falls back to
  `get_state + get_entries` reconciliation, surfacing a *possible event loss*
  banner.

**UI**
- `VerboseRenderer` — three levels: `off` (final text only), `on` (+ collapsed
  tool-call summaries), `full` (+ reasoning, raw input/output, raw event stream).
- `SessionList` — session listing + switch.
- `DiffView` — rich file diff honouring the `{path,changeType,hunks,binary,truncated}`
  contract: split / unified toggle, inline word-diff, and large-file / binary /
  truncated degradation. See note below on the diff library.
- `CheckpointTimeline` — checkpoint timeline with guarded (confirm-before) rollback.
- `AgentRuntimePanel` — top-level assembly with a **chat ⇄ code** mode toggle.

### Notes for reviewers

- **Diff rendering library.** The design specifies `react-diff-view` (default) with a
  Monaco `DiffEditor` for large files. Those deps aren't currently in the tree, so to
  keep this incremental PR buildable without expanding the dependency graph, the diff
  body uses a zero-dependency self-rendered view (word-level highlighting via the
  package's own `wordDiff`). The `FileDiff` contract, the split/unified interaction,
  and the large-file/binary/truncated branches are already in place, so dropping in
  `react-diff-view` / `@monaco-editor/react` later only replaces the `<FileDiffBody>`
  internals — props and interactions stay the same.
- **Pending-backend endpoints.** `diff`, `checkpoint` and `rollback` paths/fields are
  modelled from the frontend's expectation and parsed leniently (optional fields, no
  assumed required schema). They will be reconciled against the backend during
  integration.

### Testing

- 35 new unit tests: reducer (out-of-order / reconnect / interrupt / reconciliation),
  `httpClient` (Bearer / 401 / envelope / params), `sseClient` (frame parsing /
  reconnect / `Last-Event-ID`), and word diff.
- Full `@octo/loop` suite green: **107/107**.
- Type-checks clean (no new errors introduced in the package).
- Live end-to-end run against a running backend is deferred until the runtime
  endpoints are available.
