### PR TITLE
fix(dev): restore local Fleet proxy default

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -163,11 +163,10 @@ export default defineConfig(({ mode }) => {
             : undefined,
         },
         // Loop (fleet) service API — 真实 multica-server/fleet 联调。
-        // 默认复用主网关 origin，让只配置 VITE_API_URL 的本地 Web 也能读取
-        // `/fleet/api/v1/...`；需要直连本地 fleet 时再显式设置 VITE_FLEET_API_URL。
+        // dev fleet 在 127.0.0.1:8091 直接提供完整 /fleet/api/v1/... 路径（不 strip）。
         // 必须放在下面通用 /fleet/api/ 规则之前（vite first-match）。
         "/fleet/api/v1": {
-          target: env.VITE_FLEET_API_URL || apiOrigin,
+          target: env.VITE_FLEET_API_URL || "http://127.0.0.1:8091",
           changeOrigin: true,
           secure: false,
         },


### PR DESCRIPTION
## Summary

- Restore the default Vite development proxy target for `/fleet/api/v1` to `http://127.0.0.1:8091`.
- Keep `VITE_FLEET_API_URL` as the explicit override for developers who need to use another local Fleet service or a remote gateway.

## Context

This is a follow-up to #966. That PR unintentionally changed the default Fleet development target from the local service to the main API origin. The Webhook issue preview does not require that global development-environment change.

## Impact

- Restores the existing local Fleet development workflow for developers who do not set `VITE_FLEET_API_URL`.
- Does not affect production routing or the Webhook issue preview implementation.

## Verification

- `pnpm --dir apps/web build` with Node.js 20.19.5: passed.
- `git diff --check`: passed.
