### PR TITLE
refactor(contacts): prepare group creation runtime boundary

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Spin } from "@douyinfe/semi-ui";
 import classNames from "classnames";
-import { Channel, ChannelInfo, WKSDK, Subscriber } from "wukongimjssdk";
+import { Channel, ChannelInfo, Subscriber } from "wukongimjssdk";
 import React from "react";
 import { Component } from "react";
 import WKApp from "../../App";
@@ -12,7 +12,7 @@ import RoutePage from "../RoutePage";
 import ConversationContext from "../Conversation/context";
 import { ChannelTypeCustomerService } from "../../Service/Const";
 import { I18nContext } from "../../i18n";
-import { getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 
 export interface ChannelSettingProps {
     onClose?: () => void
@@ -50,7 +50,7 @@ export default class ChannelSetting extends Component<ChannelSettingProps> {
 
            let  memberCount = vm.subscribers.length
 
-            const channelInfo = getImChannelInfo(WKSDK.shared(), channel)
+            const channelInfo = getCurrentImChannelInfo(channel)
             if(channelInfo?.orgData?.member_count) {
                 memberCount = channelInfo.orgData.member_count
             }

--- a/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
@@ -1,5 +1,5 @@
 import { ChannelInfoListener, SubscriberChangeListener } from "wukongimjssdk";
-import { Channel, ChannelInfo, ChannelTypePerson, WKSDK, Subscriber } from "wukongimjssdk";
+import { Channel, ChannelInfo, ChannelTypePerson, Subscriber } from "wukongimjssdk";
 import { GroupRole, SubscriberStatus } from "../../Service/Const";
 import RouteContext from "../../Service/Context";
 import WKApp from "../../App";
@@ -9,12 +9,12 @@ import { Row, Section } from "../../Service/Section";
 import { ListItemSwitch, ListItemSwitchContext } from "../ListItem";
 import { Toast } from "@douyinfe/semi-ui";
 import {
-    addImChannelInfoListener,
-    addImSubscriberChangeListener,
-    fetchImChannelInfo,
-    getImChannelInfo,
-    getImChannelSubscribers,
-} from "../../im-runtime/channelRuntime";
+    addCurrentImChannelInfoListener,
+    addCurrentImSubscriberChangeListener,
+    fetchCurrentImChannelInfo,
+    getCurrentImChannelInfo,
+    getCurrentImChannelSubscribers,
+} from "../../im-runtime/currentChannelRuntime";
 import {
     OboGrant,
     OboScope,
@@ -306,8 +306,7 @@ export class ChannelSettingVM extends ProviderListener {
     }
 
     didMount(): void {
-        const sdk = WKSDK.shared()
-        void fetchImChannelInfo(sdk, this.channel)
+        void fetchCurrentImChannelInfo(this.channel)
 
         this.reloadSubscribers()
 
@@ -315,7 +314,7 @@ export class ChannelSettingVM extends ProviderListener {
             this.subscriberChangeListener = () => {
                 this.reloadSubscribers()
             }
-            this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(sdk, this.subscriberChangeListener)
+            this.unsubscribeSubscriberChangeListener = addCurrentImSubscriberChangeListener(this.subscriberChangeListener)
 
             // Subscriber sync is still delegated to the existing channel lifecycle.
 
@@ -326,7 +325,7 @@ export class ChannelSettingVM extends ProviderListener {
                 return
             }
         }
-        this.unsubscribeChannelInfoListener = addImChannelInfoListener(sdk, this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this.channelInfoListener)
 
         this.reloadChannelInfo()
 
@@ -360,7 +359,7 @@ export class ChannelSettingVM extends ProviderListener {
 
     reloadSubscribers() {
         if(this.channel.channelType !== ChannelTypePerson) {
-            this.subscribers = getImChannelSubscribers(WKSDK.shared(), this.channel)
+            this.subscribers = getCurrentImChannelSubscribers(this.channel)
             if(this.subscribers && this.subscribers.length>0) {
                 for (const subscriber of this.subscribers) {
                     subscriber.channel = this.channel
@@ -379,7 +378,7 @@ export class ChannelSettingVM extends ProviderListener {
     }
 
     reloadChannelInfo() {
-        this.channelInfo = getImChannelInfo(WKSDK.shared(), this.channel)
+        this.channelInfo = getCurrentImChannelInfo(this.channel)
         this.routeData.channelInfo = this.channelInfo
 
         if(this.channelInfo && this.channel.channelType === ChannelTypePerson) {

--- a/packages/dmworkbase/src/Components/GroupManagement/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Button, Spin, Switch, Tag, Toast } from "@douyinfe/semi-ui";
-import { Channel, ChannelInfo, Subscriber, WKSDK } from "wukongimjssdk";
+import { Channel, ChannelInfo, Subscriber } from "wukongimjssdk";
 import WKApp from "../../App";
 import WKAvatar from "../WKAvatar";
 import { SubscriberList } from "../Subscribers/list";
@@ -11,10 +11,10 @@ import { syncGroupDisbandState } from "../../Utils/groupDisband";
 import { I18nContext, t } from "../../i18n";
 import { wkConfirm } from "../WKModal";
 import {
-  addImChannelInfoListener,
-  fetchImChannelInfo,
-  getImChannelInfo,
-} from "../../im-runtime/channelRuntime";
+  addCurrentImChannelInfoListener,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+} from "../../im-runtime/currentChannelRuntime";
 import {
   readAllowNoMention as parseAllowNoMention,
   shouldApplyFetchResult,
@@ -70,7 +70,7 @@ export class GroupManagement extends Component<
 
   // 从 SDK 频道缓存读「允许免@」开关当前值；缺省（老后端无字段）回退 true（允许），零回归。
   readAllowNoMention = (): boolean => {
-    const info = getImChannelInfo(WKSDK.shared(), this.props.channel);
+    const info = getCurrentImChannelInfo(this.props.channel);
     return parseAllowNoMention(info?.orgData);
   };
 
@@ -94,8 +94,7 @@ export class GroupManagement extends Component<
       if (!shouldListenerApply(this.inflightFetch, this.state.allowNoMentionSaving)) return;
       this.setState({ allowNoMention: this.readAllowNoMention() });
     };
-    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
-      WKSDK.shared(),
+    this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(
       this.channelInfoListener
     );
 
@@ -108,7 +107,7 @@ export class GroupManagement extends Component<
   private refreshAllowNoMention = () => {
     const myOp = ++this.opSeq;
     this.inflightFetch++;
-    void fetchImChannelInfo(WKSDK.shared(), this.props.channel)
+    void fetchCurrentImChannelInfo(this.props.channel)
       .then(() => {
         if (this.unmounted) return;
         // 已被更新的操作超越，或正处于一次 toggle 保存中 → 丢弃这次回写。
@@ -356,7 +355,7 @@ export class GroupManagement extends Component<
     try {
       await ChannelSettingManager.shared.setAllowNoMention(next, channel);
       // 回读 server 真实值（refresh 后弹回的根因已在 server 端修复）。
-      await fetchImChannelInfo(WKSDK.shared(), channel);
+      await fetchCurrentImChannelInfo(channel);
       if (this.unmounted) return;
       // 期间又有更新的 toggle 发起 → 那次操作接管 state（含 saving 锁），本次静默退出。
       if (myOp !== this.opSeq) return;

--- a/packages/dmworkbase/src/im-runtime/currentChannelRuntime.test.ts
+++ b/packages/dmworkbase/src/im-runtime/currentChannelRuntime.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  addCurrentImChannelInfoListener,
+  addCurrentImSubscriberChangeListener,
+  deleteCurrentImChannelInfo,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+} from "./currentChannelRuntime";
+
+const hoisted = vi.hoisted(() => {
+  const sdk = {
+    channelManager: {
+      addListener: vi.fn(),
+      deleteChannelInfo: vi.fn(),
+      fetchChannelInfo: vi.fn(),
+      getChannelInfo: vi.fn(),
+      getSubscribes: vi.fn(),
+      addSubscriberChangeListener: vi.fn(),
+      removeListener: vi.fn(),
+      removeSubscriberChangeListener: vi.fn(),
+      syncSubscribes: vi.fn(),
+    },
+  };
+  return {
+    sdk,
+    shared: vi.fn(() => sdk),
+  };
+});
+
+vi.mock("wukongimjssdk", () => ({
+  default: {
+    shared: hoisted.shared,
+  },
+}));
+
+describe("currentChannelRuntime", () => {
+  beforeEach(() => {
+    hoisted.shared.mockClear();
+    hoisted.sdk.channelManager.addListener.mockReset();
+    hoisted.sdk.channelManager.deleteChannelInfo.mockReset();
+    hoisted.sdk.channelManager.fetchChannelInfo.mockReset();
+    hoisted.sdk.channelManager.getChannelInfo.mockReset();
+    hoisted.sdk.channelManager.getSubscribes.mockReset();
+    hoisted.sdk.channelManager.addSubscriberChangeListener.mockReset();
+    hoisted.sdk.channelManager.removeListener.mockReset();
+    hoisted.sdk.channelManager.removeSubscriberChangeListener.mockReset();
+    hoisted.sdk.channelManager.syncSubscribes.mockReset();
+  });
+
+  it("reads channel info from the current SDK runtime", () => {
+    const channel = { channelID: "g1", channelType: 2 };
+    const info = { channel, title: "Group" };
+    hoisted.sdk.channelManager.getChannelInfo.mockReturnValueOnce(info);
+
+    expect(getCurrentImChannelInfo(channel)).toBe(info);
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.getChannelInfo).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("fetches channel info from the current SDK runtime", async () => {
+    const channel = { channelID: "g1", channelType: 2 };
+    const info = { channel, title: "Group" };
+    hoisted.sdk.channelManager.fetchChannelInfo.mockResolvedValueOnce(info);
+
+    await expect(fetchCurrentImChannelInfo(channel)).resolves.toBe(info);
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.fetchChannelInfo).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("deletes channel info from the current SDK runtime", () => {
+    const channel = { channelID: "g1", channelType: 2 };
+
+    deleteCurrentImChannelInfo(channel);
+
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.deleteChannelInfo).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("reads subscribers from the current SDK runtime", () => {
+    const channel = { channelID: "g1", channelType: 2 };
+    const subscribers = [{ uid: "u1" }];
+    hoisted.sdk.channelManager.getSubscribes.mockReturnValueOnce(subscribers);
+
+    expect(getCurrentImChannelSubscribers(channel)).toBe(subscribers);
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.getSubscribes).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("syncs subscribers through the current SDK runtime", async () => {
+    const channel = { channelID: "g1", channelType: 2 };
+    hoisted.sdk.channelManager.syncSubscribes.mockResolvedValueOnce(undefined);
+
+    await syncCurrentImChannelSubscribers(channel);
+
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.syncSubscribes).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("adds and removes channel info listeners through the current SDK runtime", () => {
+    const listener = vi.fn();
+
+    const unsubscribe = addCurrentImChannelInfoListener(listener);
+    unsubscribe();
+
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.channelManager.addListener).toHaveBeenCalledWith(
+      listener
+    );
+    expect(hoisted.sdk.channelManager.removeListener).toHaveBeenCalledWith(
+      listener
+    );
+  });
+
+  it("adds and removes subscriber listeners through the current SDK runtime", () => {
+    const listener = vi.fn();
+
+    const unsubscribe = addCurrentImSubscriberChangeListener(listener);
+    unsubscribe();
+
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(
+      hoisted.sdk.channelManager.addSubscriberChangeListener
+    ).toHaveBeenCalledWith(listener);
+    expect(
+      hoisted.sdk.channelManager.removeSubscriberChangeListener
+    ).toHaveBeenCalledWith(listener);
+  });
+});

--- a/packages/dmworkbase/src/im-runtime/currentChannelRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/currentChannelRuntime.ts
@@ -1,0 +1,87 @@
+import WKSDK from "wukongimjssdk";
+import {
+  addImChannelInfoListener,
+  addImSubscriberChangeListener,
+  deleteImChannelInfo,
+  fetchImChannelInfo,
+  getImChannelInfo,
+  getImChannelSubscribers,
+  syncImChannelSubscribers,
+  type ImChannelInfoFetchResult,
+  type ImChannelInfoListener,
+  type ImChannelCacheRuntimeSdk,
+  type ImChannelInfoLike,
+  type ImChannelLike,
+  type ImSubscriberChangeListener,
+  type ImSubscriberLike,
+} from "./channelRuntime";
+
+function currentImRuntime() {
+  return WKSDK.shared();
+}
+
+export function getCurrentImChannelInfo<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike = ImChannelInfoLike
+>(channel: TChannel) {
+  return getImChannelInfo<TChannel, TChannelInfo>(currentImRuntime(), channel);
+}
+
+export function fetchCurrentImChannelInfo<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike = ImChannelInfoLike
+>(channel: TChannel): Promise<ImChannelInfoFetchResult<TChannelInfo>> {
+  return fetchImChannelInfo<TChannel, TChannelInfo>(
+    currentImRuntime(),
+    channel
+  );
+}
+
+export function deleteCurrentImChannelInfo<TChannel extends ImChannelLike>(
+  channel: TChannel
+) {
+  deleteImChannelInfo(
+    currentImRuntime() as ImChannelCacheRuntimeSdk<TChannel>,
+    channel
+  );
+}
+
+export function getCurrentImChannelSubscribers<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(channel: TChannel) {
+  return getImChannelSubscribers<TChannel, TSubscriber>(
+    currentImRuntime(),
+    channel
+  );
+}
+
+export function syncCurrentImChannelSubscribers<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(channel: TChannel) {
+  return syncImChannelSubscribers<TChannel, TSubscriber>(
+    currentImRuntime(),
+    channel
+  );
+}
+
+export function addCurrentImChannelInfoListener<
+  TChannel extends ImChannelLike,
+  TChannelInfo extends ImChannelInfoLike = ImChannelInfoLike
+>(listener: ImChannelInfoListener<TChannelInfo>) {
+  return addImChannelInfoListener<TChannel, TChannelInfo>(
+    currentImRuntime(),
+    listener
+  );
+}
+
+export function addCurrentImSubscriberChangeListener<
+  TChannel extends ImChannelLike,
+  TSubscriber = ImSubscriberLike
+>(listener: ImSubscriberChangeListener) {
+  return addImSubscriberChangeListener<TChannel, TSubscriber>(
+    currentImRuntime(),
+    listener
+  );
+}

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -22,6 +22,7 @@ export * from './Service/IncomingWebhook'
 export * from './Service/ForwardService'
 export * from './Service/forwardResultToast'
 export * from './im-runtime/channelRuntime'
+export * from './im-runtime/currentChannelRuntime'
 export * from './Components/WKLayout'
 
 export * from './Components/Conversation/context'

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -148,6 +148,12 @@ import {
   setImChannelSubscribersCache,
   syncImChannelSubscribers,
 } from "./im-runtime/channelRuntime";
+import {
+  deleteCurrentImChannelInfo,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+  syncCurrentImChannelSubscribers,
+} from "./im-runtime/currentChannelRuntime";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
 function fallbackCopy(text: string) {
@@ -1897,11 +1903,8 @@ export default class BaseModule implements IModule {
                                 )
                               );
                               context.pop();
-                              void syncImChannelSubscribers(
-                                WKSDK.shared(),
-                                channel
-                              );
-                              void fetchImChannelInfo(WKSDK.shared(), channel);
+                              void syncCurrentImChannelSubscribers(channel);
+                              void fetchCurrentImChannelInfo(channel);
                               data.refresh();
                             } catch (err: any) {
                               Toast.error(
@@ -2408,8 +2411,8 @@ export default class BaseModule implements IModule {
                       return; // 失败时 inputEditPush 正常关闭，不刷新缓存
                     }
                     // 清除缓存后重新拉取，拿到新数据再刷新 UI
-                    deleteImChannelInfo(WKSDK.shared(), channel);
-                    await fetchImChannelInfo(WKSDK.shared(), channel);
+                    deleteCurrentImChannelInfo(channel);
+                    await fetchCurrentImChannelInfo(channel);
                     data.refresh();
                   },
                   t("base.module.thread.name"),
@@ -2440,9 +2443,9 @@ export default class BaseModule implements IModule {
             threadInfo.groupNo,
             ChannelTypeGroup
           );
-          const groupInfo = getImChannelInfo(WKSDK.shared(), groupChannel);
+          const groupInfo = getCurrentImChannelInfo(groupChannel);
           if (!groupInfo) {
-            void fetchImChannelInfo(WKSDK.shared(), groupChannel);
+            void fetchCurrentImChannelInfo(groupChannel);
           }
           const groupName = groupInfo?.title || threadInfo.groupNo;
           rows.push(

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Component, ReactNode } from "react";
-import WKSDK, { Channel, ChannelTypeGroup, ChannelTypePerson, Subscriber } from "wukongimjssdk";
 
 import {
   Button,
@@ -12,13 +11,15 @@ import {
   Toast,
 } from "@douyinfe/semi-ui";
 import { BasicTreeNodeData } from "@douyinfe/semi-foundation/lib/cjs/tree/foundation";
-import { WKApp, ThemeMode, WKViewQueueHeader, WKModal, I18nContext, t, GroupAvatarPreview, GroupAvatarEditModal, getImChannelInfo, getImChannelSubscribers, syncImChannelSubscribers } from "@octo/base";
+import { WKApp, ThemeMode, WKViewQueueHeader, WKModal, I18nContext, t, GroupAvatarPreview, GroupAvatarEditModal } from "@octo/base";
 import WKAvatar from "@octo/base/src/Components/WKAvatar";
 import AiBadge from "@octo/base/src/Components/AiBadge";
 import "./index.css";
-import { SuperGroup } from "@octo/base/src/Utils/const";
 import { GROUP_NAME_MAX_LENGTH } from "@octo/base/src/Service/nameLimits";
-import { buildPrivateChatGroupMemberUids } from "./memberUids";
+import {
+  loadGroupCreateCandidates,
+  submitGroupCreateAction,
+} from "../../bridge/groupCreate/groupCreateRuntime";
 
 export enum OrganizationalGroupNewAction {
   createGroup, // 创建群聊
@@ -332,80 +333,9 @@ export class OrganizationalGroupNew extends Component<
   }
 
   async getFriendData() {
-
-    let subscribers = new Array<Subscriber>();
-
-    // 群聊
-    if (this.props.channel.channelID.trim() !== "") {
-      const channel = new Channel(this.props.channel.channelID, this.props.channel.channelType)
-
-      // 个人聊天，对方不可选
-      if (this.props.channel.channelType === ChannelTypePerson) {
-        const sub = new Subscriber()
-        sub.uid = this.props.channel.channelID
-        subscribers.push(sub)
-      } else {
-        // 群聊
-        const channelInfo = getImChannelInfo(WKSDK.shared(), channel); // 获取频道信息
-        if (channelInfo?.orgData?.group_type === SuperGroup) {
-          subscribers = await WKApp.dataSource.channelDataSource.subscribers(channel, {
-            limit: 5000,
-            page: 1
-          })
-        } else {
-          await syncImChannelSubscribers(WKSDK.shared(), channel); // 同步订阅者
-          subscribers = getImChannelSubscribers(WKSDK.shared(), channel); // 获取订阅者
-        }
-      }
-
-    }
-
-    let subscriberUids = new Array<string>()
-    if (subscribers) {
-      subscriberUids = subscribers.map((item) => {
-        return item.uid;
-      })
-    }
-
-    // 系统账号不可被拉入群聊
-    const systemUids = ["botfather", "fileHelper"];
-    const setFriendData: any[] = [];
-
-    // Space 模式：从 Space 成员列表获取可选联系人
-    const spaceId = WKApp.shared.currentSpaceId;
-    if (spaceId) {
-      try {
-        const { SpaceService } = await import("@octo/base/src/Service/SpaceService");
-        // 翻页拉取空间全部成员：getMembers 单次 limit 上限 10000，超大空间只请求一页会把第
-        // 10000 名之后的成员静默丢弃。10000/页循环到取尽，最多 20 页兜底（20 万）。同一
-        // getMembers 接口、page/limit 传参不变，不碰后端、不影响移动端。
-        const members: any[] = [];
-        for (let page = 1; page <= 20; page++) {
-          const batch = await SpaceService.shared.getMembers(spaceId, page, 10000);
-          if (!batch || batch.length === 0) break;
-          members.push(...batch);
-          if (batch.length < 10000) break; // 最后一页
-        }
-        members.forEach((m: any) => {
-          if (!subscriberUids.includes(m.uid) && !systemUids.includes(m.uid) && m.uid !== WKApp.loginInfo.uid) {
-            setFriendData.push({ name: m.name, uid: m.uid, avatar: m.avatar, robot: m.robot === 1 });
-          }
-        });
-      } catch {
-        // fallback to contacts list
-        WKApp.dataSource.contactsList.forEach((item) => {
-          if (!subscriberUids.includes(item.uid) && !systemUids.includes(item.uid)) {
-            setFriendData.push({ name: item.name, uid: item.uid, avatar: WKApp.shared.avatarUser(item.uid), robot: item.robot });
-          }
-        });
-      }
-    } else {
-      WKApp.dataSource.contactsList.forEach((item) => {
-        if (!subscriberUids.includes(item.uid) && !systemUids.includes(item.uid)) {
-          setFriendData.push({ name: item.name, uid: item.uid, avatar: WKApp.shared.avatarUser(item.uid), robot: item.robot });
-        }
-      });
-    }
+    const setFriendData = await loadGroupCreateCandidates({
+      channel: this.props.channel,
+    });
     this.setState({
       friendData: [...setFriendData],
       friendSearchData: [...setFriendData],
@@ -501,22 +431,19 @@ export class OrganizationalGroupNew extends Component<
     // 创建群
     if (isCreate) {
       try {
-        const result = await WKApp.dataSource.channelDataSource.createChannel(
-          [...getOptPersonnelData],
-          {
+        await submitGroupCreateAction({
+          action: "createGroup",
+          channel: this.props.channel,
+          selectedUids: [...getOptPersonnelData],
+          createOptions: {
             categoryId: this.props.defaultCategoryId,
             name,
             // 仅在用户显式设置时下发；缺省由服务端渲染默认双人图标。
             avatarText: this.state.avatarText || undefined,
             avatarColor: this.state.avatarColorIndex,
-          }
-        )
-        if (result?.group_no) {
-          WKApp.endpoints.showConversation(
-            new Channel(result.group_no, ChannelTypeGroup),
-            this.props.keepSidebarTab ? { fromSidebarList: true } : undefined,
-          )
-        }
+          },
+          keepSidebarTab: this.props.keepSidebarTab,
+        });
         this.props.onSuccess?.()
       } catch (error: any) {
         Toast.error(error.msg);
@@ -526,26 +453,11 @@ export class OrganizationalGroupNew extends Component<
     // 添加联系人
     if (this.props.action === OrganizationalGroupNewAction.AddMember) {
       try {
-        if (channel.channelType === ChannelTypePerson) {
-          const memberUids = buildPrivateChatGroupMemberUids(
-            WKApp.loginInfo.uid,
-            channel.channelID,
-            getOptPersonnelData
-          );
-          const result = await WKApp.dataSource.channelDataSource.createChannel(
-            memberUids
-          );
-          if (result?.group_no) {
-            WKApp.endpoints.showConversation(
-              new Channel(result.group_no, ChannelTypeGroup)
-            );
-          }
-        } else {
-          await WKApp.dataSource.channelDataSource.addSubscribers(
-            channel,
-            getOptPersonnelData
-          );
-        }
+        await submitGroupCreateAction({
+          action: "addMember",
+          channel,
+          selectedUids: getOptPersonnelData,
+        });
       } catch (error: any) {
         Toast.error(error.msg);
         return

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/memberUids.ts
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/memberUids.ts
@@ -1,11 +1,1 @@
-export function buildPrivateChatGroupMemberUids(
-  loginUid: string | undefined,
-  peerUid: string,
-  selectedUids: string[]
-) {
-  const memberUids = [loginUid, peerUid, ...selectedUids].filter(
-    (uid): uid is string => typeof uid === "string" && uid.length > 0
-  );
-
-  return Array.from(new Set(memberUids));
-}
+export { buildPrivateChatGroupMemberUids } from "../../bridge/groupCreate/memberUids";

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
@@ -1,0 +1,215 @@
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildGroupCreateCandidateContacts,
+  collectSpaceMembers,
+  loadGroupCreateCandidates,
+  submitGroupCreateAction,
+} from "./groupCreateRuntime";
+import type { GroupCreateRuntime } from "./types";
+
+vi.mock("@octo/base", () => ({
+  WKApp: {},
+  getCurrentImChannelInfo: vi.fn(),
+  getCurrentImChannelSubscribers: vi.fn(),
+  syncCurrentImChannelSubscribers: vi.fn(),
+}));
+
+vi.mock("@octo/base/src/Utils/const", () => ({
+  SuperGroup: "super-group",
+}));
+
+function createRuntime(
+  overrides: Partial<GroupCreateRuntime> = {}
+): GroupCreateRuntime {
+  return {
+    addSubscribers: vi.fn(),
+    createChannel: vi.fn(),
+    getAvatarUser: vi.fn((uid) => `avatar:${uid}`),
+    getContactsList: vi.fn(() => []),
+    getCurrentChannelInfo: vi.fn(() => ({})),
+    getCurrentChannelSubscribers: vi.fn(() => []),
+    getCurrentSpaceId: vi.fn(() => undefined),
+    getLoginUid: vi.fn(() => "self"),
+    getSpaceMembers: vi.fn(() => Promise.resolve([])),
+    getSuperGroupSubscribers: vi.fn(() => Promise.resolve([])),
+    showConversation: vi.fn(),
+    syncCurrentChannelSubscribers: vi.fn(() => Promise.resolve(undefined)),
+    ...overrides,
+  };
+}
+
+describe("group create runtime bridge", () => {
+  it("filters existing subscribers, system accounts and current user when requested", () => {
+    expect(
+      buildGroupCreateCandidateContacts({
+        contacts: [
+          { uid: "existing", name: "Existing" },
+          { uid: "botfather", name: "Botfather" },
+          { uid: "fileHelper", name: "File Helper" },
+          { uid: "self", name: "Self" },
+          { uid: "alice", name: "Alice", robot: 1 },
+        ],
+        excludedUids: ["existing"],
+        currentUid: "self",
+        excludeCurrentUid: true,
+        avatarForUid: (uid) => `avatar:${uid}`,
+      })
+    ).toEqual([
+      {
+        uid: "alice",
+        name: "Alice",
+        avatar: "avatar:alice",
+        robot: 1,
+      },
+    ]);
+  });
+
+  it("collects space members by page until the last page", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { uid: "u1", name: "User 1" },
+        { uid: "u2", name: "User 2" },
+      ])
+      .mockResolvedValueOnce([{ uid: "u3", name: "User 3" }]);
+
+    await expect(
+      collectSpaceMembers(fetchPage, { pageSize: 2, maxPages: 5 })
+    ).resolves.toEqual([
+      { uid: "u1", name: "User 1" },
+      { uid: "u2", name: "User 2" },
+      { uid: "u3", name: "User 3" },
+    ]);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
+  it("loads space candidates after syncing current group subscribers", async () => {
+    const runtime = createRuntime({
+      getCurrentSpaceId: vi.fn(() => "space-1"),
+      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "existing" }]),
+      getSpaceMembers: vi.fn((spaceId, page) =>
+        Promise.resolve(
+          page === 1
+            ? [
+                { uid: "existing", name: "Existing" },
+                { uid: "self", name: "Self" },
+                { uid: "botfather", name: "Botfather" },
+                { uid: "alice", name: "Alice", avatar: "alice.png", robot: 1 },
+              ]
+            : []
+        )
+      ),
+    });
+
+    await expect(
+      loadGroupCreateCandidates({
+        channel: { channelID: "group-1", channelType: ChannelTypeGroup },
+        runtime,
+      })
+    ).resolves.toEqual([
+      {
+        uid: "alice",
+        name: "Alice",
+        avatar: "alice.png",
+        robot: true,
+      },
+    ]);
+    expect(runtime.syncCurrentChannelSubscribers).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to contacts list when space members cannot be loaded", async () => {
+    const runtime = createRuntime({
+      getCurrentSpaceId: vi.fn(() => "space-1"),
+      getContactsList: vi.fn(() => [{ uid: "alice", name: "Alice", robot: 0 }]),
+      getSpaceMembers: vi.fn(() => Promise.reject(new Error("network"))),
+    });
+
+    await expect(
+      loadGroupCreateCandidates({
+        channel: { channelID: "", channelType: ChannelTypePerson },
+        runtime,
+      })
+    ).resolves.toEqual([
+      {
+        uid: "alice",
+        name: "Alice",
+        avatar: "avatar:alice",
+        robot: 0,
+      },
+    ]);
+  });
+
+  it("creates a group with avatar options and opens the created conversation", async () => {
+    const runtime = createRuntime({
+      createChannel: vi.fn(() => Promise.resolve({ group_no: "group-created" })),
+    });
+
+    await submitGroupCreateAction({
+      action: "createGroup",
+      channel: { channelID: "", channelType: ChannelTypePerson },
+      selectedUids: ["alice"],
+      createOptions: {
+        categoryId: "category-1",
+        name: "Team",
+        avatarText: "T",
+        avatarColor: 2,
+      },
+      keepSidebarTab: true,
+      runtime,
+    });
+
+    expect(runtime.createChannel).toHaveBeenCalledWith(["alice"], {
+      categoryId: "category-1",
+      name: "Team",
+      avatarText: "T",
+      avatarColor: 2,
+    });
+    expect(runtime.showConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-created" }),
+      { fromSidebarList: true }
+    );
+  });
+
+  it("creates a group from a private chat by including self and peer", async () => {
+    const runtime = createRuntime({
+      createChannel: vi.fn(() => Promise.resolve({ group_no: "group-created" })),
+    });
+
+    await submitGroupCreateAction({
+      action: "addMember",
+      channel: { channelID: "peer", channelType: ChannelTypePerson },
+      selectedUids: ["alice", "peer"],
+      runtime,
+    });
+
+    expect(runtime.createChannel).toHaveBeenCalledWith([
+      "self",
+      "peer",
+      "alice",
+    ]);
+    expect(runtime.showConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-created" })
+    );
+  });
+
+  it("adds subscribers directly for an existing group", async () => {
+    const runtime = createRuntime();
+
+    await submitGroupCreateAction({
+      action: "addMember",
+      channel: { channelID: "group-1", channelType: ChannelTypeGroup },
+      selectedUids: ["alice", "bob"],
+      runtime,
+    });
+
+    expect(runtime.addSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      ["alice", "bob"]
+    );
+    expect(runtime.createChannel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
@@ -1,0 +1,237 @@
+import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+
+import {
+  getCurrentImChannelInfo,
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+  WKApp,
+} from "@octo/base";
+import { SuperGroup } from "@octo/base/src/Utils/const";
+
+import { buildPrivateChatGroupMemberUids } from "./memberUids";
+import type {
+  GroupCreateCandidateContact,
+  GroupCreateChannelInput,
+  GroupCreateContactRecord,
+  GroupCreateRuntime,
+  GroupCreateSpaceMember,
+  GroupCreateSubmitAction,
+  GroupCreateSubmitOptions,
+} from "./types";
+
+const GROUP_CREATE_SYSTEM_UIDS = ["botfather", "fileHelper"];
+const SPACE_MEMBER_PAGE_SIZE = 10000;
+const MAX_SPACE_MEMBER_PAGES = 20;
+
+function createDefaultGroupCreateRuntime(): GroupCreateRuntime {
+  return {
+    addSubscribers(channel, uids) {
+      return WKApp.dataSource.channelDataSource.addSubscribers(channel, uids);
+    },
+    createChannel(uids, options) {
+      return WKApp.dataSource.channelDataSource.createChannel(uids, options);
+    },
+    getAvatarUser(uid) {
+      return WKApp.shared.avatarUser(uid);
+    },
+    getContactsList() {
+      return WKApp.dataSource.contactsList;
+    },
+    getCurrentChannelInfo(channel) {
+      return getCurrentImChannelInfo(channel);
+    },
+    getCurrentChannelSubscribers(channel) {
+      return getCurrentImChannelSubscribers(channel);
+    },
+    getCurrentSpaceId() {
+      return WKApp.shared.currentSpaceId;
+    },
+    getLoginUid() {
+      return WKApp.loginInfo.uid;
+    },
+    async getSpaceMembers(spaceId, page, limit) {
+      const { SpaceService } = await import(
+        "@octo/base/src/Service/SpaceService"
+      );
+      return SpaceService.shared.getMembers(spaceId, page, limit);
+    },
+    getSuperGroupSubscribers(channel) {
+      return WKApp.dataSource.channelDataSource.subscribers(channel, {
+        limit: 5000,
+        page: 1,
+      });
+    },
+    showConversation(channel, options) {
+      WKApp.endpoints.showConversation(channel, options);
+    },
+    syncCurrentChannelSubscribers(channel) {
+      return syncCurrentImChannelSubscribers(channel);
+    },
+  };
+}
+
+function toUidSet(uids: string[]) {
+  return new Set(
+    uids.filter((uid) => typeof uid === "string" && uid.length > 0)
+  );
+}
+
+export async function collectSpaceMembers(
+  fetchPage: (page: number, limit: number) => Promise<GroupCreateSpaceMember[]>,
+  options: { pageSize?: number; maxPages?: number } = {}
+) {
+  const pageSize = options.pageSize ?? SPACE_MEMBER_PAGE_SIZE;
+  const maxPages = options.maxPages ?? MAX_SPACE_MEMBER_PAGES;
+  const members: GroupCreateSpaceMember[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const batch = await fetchPage(page, pageSize);
+    if (!batch || batch.length === 0) break;
+
+    members.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+
+  return members;
+}
+
+export function buildGroupCreateCandidateContacts(params: {
+  contacts: GroupCreateContactRecord[];
+  excludedUids: string[];
+  currentUid?: string;
+  excludeCurrentUid?: boolean;
+  avatarForUid?: (uid: string) => string | undefined;
+  systemUids?: string[];
+}): GroupCreateCandidateContact[] {
+  const excludedUids = toUidSet(params.excludedUids);
+  const systemUids = toUidSet(params.systemUids ?? GROUP_CREATE_SYSTEM_UIDS);
+  const shouldExcludeCurrentUid = params.excludeCurrentUid && params.currentUid;
+
+  return params.contacts
+    .filter((contact) => {
+      if (!contact.uid) return false;
+      if (excludedUids.has(contact.uid)) return false;
+      if (systemUids.has(contact.uid)) return false;
+      if (shouldExcludeCurrentUid && contact.uid === params.currentUid) {
+        return false;
+      }
+      return true;
+    })
+    .map((contact) => ({
+      name: contact.name,
+      uid: contact.uid,
+      avatar: params.avatarForUid?.(contact.uid) ?? contact.avatar,
+      robot: contact.robot,
+    }));
+}
+
+async function loadExcludedSubscriberUids(
+  channelInput: GroupCreateChannelInput,
+  runtime: GroupCreateRuntime
+) {
+  if (channelInput.channelID.trim() === "") {
+    return [];
+  }
+
+  const channel = new Channel(channelInput.channelID, channelInput.channelType);
+
+  if (channelInput.channelType === ChannelTypePerson) {
+    return [channelInput.channelID];
+  }
+
+  const channelInfo = runtime.getCurrentChannelInfo(channel);
+  const subscribers =
+    channelInfo?.orgData?.group_type === SuperGroup
+      ? await runtime.getSuperGroupSubscribers(channel)
+      : await runtime
+          .syncCurrentChannelSubscribers(channel)
+          .then(() => runtime.getCurrentChannelSubscribers(channel));
+
+  return Array.from(
+    new Set((subscribers || []).map((subscriber) => subscriber.uid))
+  );
+}
+
+export async function loadGroupCreateCandidates(params: {
+  channel: GroupCreateChannelInput;
+  runtime?: GroupCreateRuntime;
+}) {
+  const runtime = params.runtime ?? createDefaultGroupCreateRuntime();
+  const excludedUids = await loadExcludedSubscriberUids(params.channel, runtime);
+  const spaceId = runtime.getCurrentSpaceId();
+
+  if (spaceId) {
+    try {
+      const members = await collectSpaceMembers((page, limit) =>
+        runtime.getSpaceMembers(spaceId, page, limit)
+      );
+
+      return buildGroupCreateCandidateContacts({
+        contacts: members.map((member) => ({
+          name: member.name,
+          uid: member.uid,
+          avatar: member.avatar,
+          robot: member.robot === 1,
+        })),
+        excludedUids,
+        currentUid: runtime.getLoginUid(),
+        excludeCurrentUid: true,
+        systemUids: GROUP_CREATE_SYSTEM_UIDS,
+      });
+    } catch {
+      // Keep the legacy fallback path: if Space members fail, use contactsList.
+    }
+  }
+
+  return buildGroupCreateCandidateContacts({
+    contacts: runtime.getContactsList(),
+    excludedUids,
+    avatarForUid: runtime.getAvatarUser,
+    systemUids: GROUP_CREATE_SYSTEM_UIDS,
+  });
+}
+
+export async function submitGroupCreateAction(params: {
+  action: GroupCreateSubmitAction;
+  channel: GroupCreateChannelInput;
+  selectedUids: string[];
+  createOptions?: GroupCreateSubmitOptions;
+  keepSidebarTab?: boolean;
+  runtime?: GroupCreateRuntime;
+}) {
+  const runtime = params.runtime ?? createDefaultGroupCreateRuntime();
+
+  if (params.action === "createGroup") {
+    const result = await runtime.createChannel(
+      params.selectedUids,
+      params.createOptions
+    );
+    if (result?.group_no) {
+      runtime.showConversation(
+        new Channel(result.group_no, ChannelTypeGroup),
+        params.keepSidebarTab ? { fromSidebarList: true } : undefined
+      );
+    }
+    return result;
+  }
+
+  const channel = new Channel(
+    params.channel.channelID,
+    params.channel.channelType
+  );
+  if (params.channel.channelType === ChannelTypePerson) {
+    const memberUids = buildPrivateChatGroupMemberUids(
+      runtime.getLoginUid(),
+      params.channel.channelID,
+      params.selectedUids
+    );
+    const result = await runtime.createChannel(memberUids);
+    if (result?.group_no) {
+      runtime.showConversation(new Channel(result.group_no, ChannelTypeGroup));
+    }
+    return result;
+  }
+
+  await runtime.addSubscribers(channel, params.selectedUids);
+  return undefined;
+}

--- a/packages/dmworkcontacts/src/bridge/groupCreate/memberUids.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/memberUids.ts
@@ -1,0 +1,11 @@
+export function buildPrivateChatGroupMemberUids(
+  loginUid: string | undefined,
+  peerUid: string,
+  selectedUids: string[]
+) {
+  const memberUids = [loginUid, peerUid, ...selectedUids].filter(
+    (uid): uid is string => typeof uid === "string" && uid.length > 0
+  );
+
+  return Array.from(new Set(memberUids));
+}

--- a/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
@@ -1,0 +1,61 @@
+import type { Channel } from "wukongimjssdk";
+
+export interface GroupCreateChannelInput {
+  channelID: string;
+  channelType: number;
+}
+
+export interface GroupCreateCandidateContact {
+  name: string;
+  uid: string;
+  avatar?: string;
+  robot?: boolean | number;
+}
+
+export interface GroupCreateContactRecord {
+  name: string;
+  uid: string;
+  avatar?: string;
+  robot?: boolean | number;
+}
+
+export interface GroupCreateSpaceMember {
+  name: string;
+  uid: string;
+  avatar?: string;
+  robot?: boolean | number;
+}
+
+export interface GroupCreateSubmitOptions {
+  categoryId?: string;
+  name?: string;
+  avatarText?: string;
+  avatarColor?: number;
+}
+
+export type GroupCreateSubmitAction = "createGroup" | "addMember";
+
+export interface GroupCreateRuntime {
+  addSubscribers(channel: Channel, uids: string[]): Promise<void>;
+  createChannel(
+    uids: string[],
+    options?: GroupCreateSubmitOptions
+  ): Promise<{ group_no?: string } | undefined>;
+  getAvatarUser(uid: string): string;
+  getContactsList(): GroupCreateContactRecord[];
+  getCurrentChannelInfo(channel: Channel): any;
+  getCurrentChannelSubscribers(channel: Channel): Array<{ uid: string }>;
+  getCurrentSpaceId(): string | undefined;
+  getLoginUid(): string | undefined;
+  getSpaceMembers(
+    spaceId: string,
+    page: number,
+    limit: number
+  ): Promise<GroupCreateSpaceMember[]>;
+  getSuperGroupSubscribers(channel: Channel): Promise<Array<{ uid: string }>>;
+  showConversation(
+    channel: Channel,
+    options?: { fromSidebarList?: boolean }
+  ): void;
+  syncCurrentChannelSubscribers(channel: Channel): Promise<any>;
+}


### PR DESCRIPTION
## Summary
- add a current channel runtime facade for channel info and subscriber access
- move group creation candidate loading and submit actions into a contacts bridge
- update GroupNew, ChannelSetting, and GroupManagement to use the narrowed runtime boundary

## Verification
- pnpm --dir packages/dmworkcontacts test -- src/Organizational/GroupNew/__tests__/memberUids.test.ts src/bridge/groupCreate/groupCreateRuntime.test.ts
- pnpm --dir packages/dmworkbase test -- src/im-runtime/currentChannelRuntime.test.ts src/Components/ChannelSetting/__tests__/vm.persona.test.ts src/Components/GroupManagement/__tests__/allowNoMention.test.ts src/Components/GroupManagement/__tests__/botAdmins.test.ts
- git diff --check