### PR TITLE
feat(summary): 美化聊天与参与者选择器

### DIFF
--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -8,6 +8,7 @@ import AiBadge from "@octo/base/src/Components/AiBadge";
 import WKApp from "@octo/base/src/App";
 import SidebarService, { SidebarTargetType } from "@octo/base/src/Service/SidebarService";
 import { MAX_CHAT_SELECT } from "../constants/limits";
+import "./SummarySelectors.css";
 
 interface Props {
     visible: boolean;
@@ -254,31 +255,23 @@ export default class ChatSelectorModal extends Component<Props, State> {
             <div
                 key={item.chat_id}
                 onClick={() => !disabled && this.handleToggle(item)}
-                style={{
-                    display: "flex",
-                    alignItems: "center",
-                    padding: indent ? "6px 0" : "10px 0",
-                    paddingLeft: indent ? 32 : 0,
-                    borderBottom: "1px solid var(--semi-color-border)",
-                    cursor: disabled ? "not-allowed" : "pointer",
-                    opacity: disabled ? 0.5 : 1,
-                }}
+                className={`summary-selector-item${checked ? " summary-selector-item--selected" : ""}${indent ? " summary-selector-item--indented" : ""}${disabled ? " summary-selector-item--disabled" : ""}`}
             >
-                <Checkbox checked={checked} disabled={disabled} style={{ marginRight: 10 }} />
-                <div style={{ flex: 1 }}>
-                    <div style={{ fontSize: indent ? 13 : 14, display: "flex", alignItems: "center" }}>
+                <Checkbox checked={checked} disabled={disabled} />
+                <div className="summary-selector-item-main">
+                    <div className="summary-selector-item-title">
                         {item.name}
                         {item.chat_type === "direct" && item.is_bot && (
-                            <span style={{ marginLeft: 4 }}><AiBadge size="small" /></span>
+                            <AiBadge size="small" />
                         )}
                         {item.is_archived && (
-                            <Tag size="small" color="grey" style={{ marginLeft: 6 }}>
+                            <Tag size="small" color="grey">
                                 {t("summary.chatSelector.archivedTag")}
                             </Tag>
                         )}
                     </div>
                     {item.member_count !== null && (
-                        <div style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>
+                        <div className="summary-selector-item-meta">
                             {t("summary.common.peopleCount", { values: { count: item.member_count } })}
                         </div>
                     )}
@@ -303,12 +296,12 @@ export default class ChatSelectorModal extends Component<Props, State> {
         const displayList = this.getDisplayList();
 
         const footer = (
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
-                <span style={{ fontSize: 13, color: "var(--semi-color-text-2)" }}>
+            <div className="summary-selector-footer">
+                <span className="summary-selector-footer-count">
                     {t("summary.common.selectedCount", { values: { count: localSelected.length, max: maxSelect } })}
                 </span>
-                <div>
-                    <Button onClick={onCancel} style={{ marginRight: 8 }}>{t("summary.common.cancel")}</Button>
+                <div className="summary-selector-footer-actions">
+                    <Button onClick={onCancel}>{t("summary.common.cancel")}</Button>
                     <Button theme="solid" onClick={this.handleConfirm}>{t("summary.common.confirm")}</Button>
                 </div>
             </div>
@@ -322,41 +315,44 @@ export default class ChatSelectorModal extends Component<Props, State> {
                 footer={footer}
                 width={480}
                 bodyStyle={{ padding: "0 24px" }}
+                className="summary-selector-modal"
             >
-                <Input
-                    prefix={<IconSearch />}
-                    placeholder={t("summary.chatSelector.searchPlaceholder")}
-                    value={keyword}
-                    onChange={this.handleKeywordChange}
-                    showClear
-                    style={{ marginBottom: 12 }}
-                />
-                <Tabs activeKey={activeTab} onChange={this.handleTabChange} size="small">
-                    <TabPane tab={t("summary.chatSelector.followed")} itemKey="followed" />
-                    <TabPane tab={t("summary.chatSelector.recent")} itemKey="recent" />
-                    <TabPane tab={t("summary.chatSelector.allGroups")} itemKey="group" />
-                    <TabPane tab={t("summary.chatSelector.allDirects")} itemKey="direct" />
-                </Tabs>
-                <div style={{ display: "flex", alignItems: "center", padding: "8px 0", gap: 8 }}>
-                    <Switch
-                        checked={includeArchived}
-                        onChange={this.handleIncludeArchivedChange}
-                        size="small"
-                        aria-label={t("summary.chatSelector.includeArchived")}
+                <div className="summary-selector-modal-body">
+                    <Input
+                        prefix={<IconSearch />}
+                        placeholder={t("summary.chatSelector.searchPlaceholder")}
+                        value={keyword}
+                        onChange={this.handleKeywordChange}
+                        showClear
+                        className="summary-selector-search"
                     />
-                    <span style={{ fontSize: 13 }}>{t("summary.chatSelector.includeArchived")}</span>
-                    <span style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>
-                        {t("summary.chatSelector.includeArchivedHelper")}
-                    </span>
-                </div>
-                <div style={{ minHeight: 240, maxHeight: 360, overflowY: "auto" }}>
-                    {loading ? (
-                        <div style={{ textAlign: "center", paddingTop: 60 }}><Spin /></div>
-                    ) : displayList.length === 0 ? (
-                        <Empty description={t("summary.chatSelector.noData")} style={{ paddingTop: 40 }} />
-                    ) : (
-                        displayList.map((entry) => this.renderItem(entry))
-                    )}
+                    <Tabs activeKey={activeTab} onChange={this.handleTabChange} size="small">
+                        <TabPane tab={t("summary.chatSelector.followed")} itemKey="followed" />
+                        <TabPane tab={t("summary.chatSelector.recent")} itemKey="recent" />
+                        <TabPane tab={t("summary.chatSelector.allGroups")} itemKey="group" />
+                        <TabPane tab={t("summary.chatSelector.allDirects")} itemKey="direct" />
+                    </Tabs>
+                    <div className="summary-selector-archive-option">
+                        <Switch
+                            checked={includeArchived}
+                            onChange={this.handleIncludeArchivedChange}
+                            size="small"
+                            aria-label={t("summary.chatSelector.includeArchived")}
+                        />
+                        <span className="summary-selector-archive-label">{t("summary.chatSelector.includeArchived")}</span>
+                        <span className="summary-selector-archive-helper">
+                            {t("summary.chatSelector.includeArchivedHelper")}
+                        </span>
+                    </div>
+                    <div className="summary-selector-list">
+                        {loading ? (
+                            <div className="summary-selector-loading"><Spin /></div>
+                        ) : displayList.length === 0 ? (
+                            <Empty description={t("summary.chatSelector.noData")} className="summary-selector-empty" />
+                        ) : (
+                            displayList.map((entry) => this.renderItem(entry))
+                        )}
+                    </div>
                 </div>
             </Modal>
         );

--- a/packages/dmworksummary/src/components/ConfirmParticipantList.tsx
+++ b/packages/dmworksummary/src/components/ConfirmParticipantList.tsx
@@ -5,6 +5,7 @@ import { useI18n } from "@octo/base";
 import type { Participant } from "../types/summary";
 import { ParticipantStatus } from "../types/summary";
 import { formatDate, getParticipantStatusLabel } from "../utils/summaryHelpers";
+import "./SummarySelectors.css";
 
 interface ConfirmParticipantListProps {
     participants: Participant[];
@@ -13,11 +14,11 @@ interface ConfirmParticipantListProps {
 function statusIcon(status: number) {
     switch (status) {
         case ParticipantStatus.CONFIRMED:
-            return <IconTickCircle style={{ color: "var(--semi-color-success)" }} />;
+            return <span className="summary-confirm-participant-icon summary-confirm-participant-icon--confirmed"><IconTickCircle /></span>;
         case ParticipantStatus.DECLINED:
-            return <IconClose style={{ color: "var(--semi-color-danger)" }} />;
+            return <span className="summary-confirm-participant-icon summary-confirm-participant-icon--declined"><IconClose /></span>;
         default:
-            return <IconClock style={{ color: "var(--semi-color-warning)" }} />;
+            return <span className="summary-confirm-participant-icon summary-confirm-participant-icon--pending"><IconClock /></span>;
     }
 }
 
@@ -41,15 +42,17 @@ const ConfirmParticipantList: React.FC<ConfirmParticipantListProps> = ({
     return (
         <List
             dataSource={participants}
+            className="summary-confirm-participant-list"
             renderItem={(p: Participant) => (
                 <List.Item
                     key={p.user_id}
+                    className="summary-confirm-participant-item"
                     header={statusIcon(p.status ?? 0)}
                     main={
                         <div>
-                            <span style={{ fontWeight: 500 }}>{p.user_name || t("summary.common.userFallback", { values: { id: p.user_id } })}</span>
+                            <span className="summary-confirm-participant-name">{p.user_name || t("summary.common.userFallback", { values: { id: p.user_id } })}</span>
                             {p.confirmed_at && (
-                                <span style={{ color: "var(--semi-color-text-2)", marginLeft: 8, fontSize: 12 }}>
+                                <span className="summary-confirm-participant-time">
                                     {formatDate(p.confirmed_at)}
                                 </span>
                             )}

--- a/packages/dmworksummary/src/components/MemberSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/MemberSelectorModal.tsx
@@ -4,6 +4,7 @@ import { IconSearch } from "@douyinfe/semi-icons";
 import { I18nContext } from "@octo/base";
 import type { MemberCandidate } from "../types/summary";
 import * as api from "../api/summaryApi";
+import "./SummarySelectors.css";
 
 interface Props {
     visible: boolean;
@@ -88,12 +89,12 @@ export default class MemberSelectorModal extends Component<Props, State> {
         const visibleCandidates = candidates.filter((c) => !excludeSet.has(c.user_id));
 
         const footer = (
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
-                <span style={{ fontSize: 13, color: "var(--semi-color-text-2)" }}>
+            <div className="summary-selector-footer">
+                <span className="summary-selector-footer-count">
                     {t("summary.common.selectedPeopleCount", { values: { count: localSelected.length } })}
                 </span>
-                <div>
-                    <Button onClick={onCancel} disabled={confirmLoading} style={{ marginRight: 8 }}>{t("summary.common.cancel")}</Button>
+                <div className="summary-selector-footer-actions">
+                    <Button onClick={onCancel} disabled={confirmLoading}>{t("summary.common.cancel")}</Button>
                     <Button theme="solid" loading={confirmLoading} disabled={confirmLoading} onClick={this.handleConfirm}>{t("summary.common.confirm")}</Button>
                 </div>
             </div>
@@ -107,51 +108,48 @@ export default class MemberSelectorModal extends Component<Props, State> {
                 footer={footer}
                 width={480}
                 bodyStyle={{ padding: "0 24px" }}
+                className="summary-selector-modal"
             >
-                <Input
-                    prefix={<IconSearch />}
-                    placeholder={t("summary.memberSelector.searchPlaceholder")}
-                    value={keyword}
-                    onChange={this.handleKeywordChange}
-                    showClear
-                    style={{ marginBottom: 12 }}
-                />
-                <div style={{ minHeight: 240, maxHeight: 360, overflowY: "auto" }}>
-                    {loading ? (
-                        <div style={{ textAlign: "center", paddingTop: 60 }}><Spin /></div>
-                    ) : visibleCandidates.length === 0 ? (
-                        <Empty description={t("summary.memberSelector.empty")} style={{ paddingTop: 40 }} />
-                    ) : (
-                        visibleCandidates.map((item) => {
-                            const checked = !!localSelected.find((s) => s.user_id === item.user_id);
-                            return (
-                                <div
-                                    key={item.user_id}
-                                    onClick={() => this.handleToggle(item)}
-                                    style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        padding: "10px 0",
-                                        borderBottom: "1px solid var(--semi-color-border)",
-                                        cursor: "pointer",
-                                    }}
-                                >
-                                    <Checkbox checked={checked} style={{ marginRight: 10 }} />
-                                    <Avatar size="small" style={{ marginRight: 10, background: "var(--semi-color-primary)" }}>
-                                        {item.name.slice(0, 1)}
-                                    </Avatar>
-                                    <div style={{ flex: 1 }}>
-                                        <div style={{ fontSize: 14 }}>{item.name}</div>
-                                        {item.department && (
-                                            <div style={{ fontSize: 12, color: "var(--semi-color-text-2)" }}>
-                                                {item.department}
-                                            </div>
-                                        )}
+                <div className="summary-selector-modal-body">
+                    <Input
+                        prefix={<IconSearch />}
+                        placeholder={t("summary.memberSelector.searchPlaceholder")}
+                        value={keyword}
+                        onChange={this.handleKeywordChange}
+                        showClear
+                        className="summary-selector-search"
+                    />
+                    <div className="summary-selector-list">
+                        {loading ? (
+                            <div className="summary-selector-loading"><Spin /></div>
+                        ) : visibleCandidates.length === 0 ? (
+                            <Empty description={t("summary.memberSelector.empty")} className="summary-selector-empty" />
+                        ) : (
+                            visibleCandidates.map((item) => {
+                                const checked = !!localSelected.find((s) => s.user_id === item.user_id);
+                                return (
+                                    <div
+                                        key={item.user_id}
+                                        onClick={() => this.handleToggle(item)}
+                                        className={`summary-selector-item${checked ? " summary-selector-item--selected" : ""}`}
+                                    >
+                                        <Checkbox checked={checked} />
+                                        <Avatar size="small" className="summary-selector-item-avatar">
+                                            {item.name.slice(0, 1)}
+                                        </Avatar>
+                                        <div className="summary-selector-item-main">
+                                            <div className="summary-selector-item-title">{item.name}</div>
+                                            {item.department && (
+                                                <div className="summary-selector-item-meta">
+                                                    {item.department}
+                                                </div>
+                                            )}
+                                        </div>
                                     </div>
-                                </div>
-                            );
-                        })
-                    )}
+                                );
+                            })
+                        )}
+                    </div>
                 </div>
             </Modal>
         );

--- a/packages/dmworksummary/src/components/ParticipantSelector.tsx
+++ b/packages/dmworksummary/src/components/ParticipantSelector.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from "react";
 import { Tag, Button, Input } from "@douyinfe/semi-ui";
 import { IconPlus } from "@douyinfe/semi-icons";
 import { useI18n } from "@octo/base";
+import "./SummarySelectors.css";
 
 interface ParticipantItem {
     user_id: number;
@@ -53,7 +54,8 @@ const ParticipantSelector: React.FC<ParticipantSelectorProps> = ({
                         closable
                         onClose={() => handleRemove(index)}
                         size="large"
-                        style={{ marginBottom: 4, marginRight: 4 }}
+                        color="violet"
+                        className="summary-participant-tag"
                     >
                         {p.user_name || t("summary.common.userFallback", { values: { id: p.user_id } })}
                     </Tag>
@@ -67,7 +69,7 @@ const ParticipantSelector: React.FC<ParticipantSelectorProps> = ({
                         onChange={setUserId}
                         placeholder={t("summary.participant.userIdPlaceholder")}
                         size="small"
-                        style={{ width: 120 }}
+                        className="summary-participant-input"
                         type="number"
                     />
                     <Input
@@ -75,12 +77,12 @@ const ParticipantSelector: React.FC<ParticipantSelectorProps> = ({
                         onChange={setUserName}
                         placeholder={t("summary.participant.userNamePlaceholder")}
                         size="small"
-                        style={{ width: 120, marginLeft: 8 }}
+                        className="summary-participant-input"
                     />
-                    <Button size="small" theme="solid" onClick={handleAdd} style={{ marginLeft: 8 }}>
+                    <Button size="small" theme="solid" onClick={handleAdd}>
                         {t("summary.common.add")}
                     </Button>
-                    <Button size="small" theme="borderless" onClick={() => setAdding(false)} style={{ marginLeft: 4 }}>
+                    <Button size="small" theme="borderless" onClick={() => setAdding(false)}>
                         {t("summary.common.cancel")}
                     </Button>
                 </div>
@@ -91,7 +93,7 @@ const ParticipantSelector: React.FC<ParticipantSelectorProps> = ({
                         size="small"
                         theme="borderless"
                         onClick={() => setAdding(true)}
-                        style={{ marginTop: 4 }}
+                        className="summary-participant-add-trigger"
                     >
                         {t("summary.participant.addParticipant")}
                     </Button>

--- a/packages/dmworksummary/src/components/SummarySelectors.css
+++ b/packages/dmworksummary/src/components/SummarySelectors.css
@@ -1,0 +1,222 @@
+/* 智能总结选择器共享视觉：只使用语义 token，自动适配 light / dark 主题。 */
+.summary-selector-modal,
+.summary-participant-selector,
+.summary-confirm-participant-list {
+    --semi-color-primary: var(--wk-color-accent);
+    --semi-color-primary-hover: var(--wk-color-accent-hover);
+}
+
+.summary-selector-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wk-sp-3);
+}
+
+.summary-selector-search {
+    margin-bottom: 0;
+}
+
+.summary-selector-archive-option {
+    display: flex;
+    align-items: center;
+    gap: var(--wk-sp-2);
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    border: 1px solid var(--wk-ai-border);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-ai-surface);
+}
+
+.summary-selector-archive-label {
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-base);
+    font-weight: var(--wk-font-medium);
+}
+
+.summary-selector-archive-helper {
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-sm);
+}
+
+.summary-selector-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wk-sp-1);
+    min-height: calc(var(--wk-sp-10) * 6);
+    max-height: calc(var(--wk-sp-10) * 9);
+    overflow-y: auto;
+    padding: var(--wk-sp-1) 0;
+}
+
+.summary-selector-item {
+    display: flex;
+    align-items: center;
+    gap: var(--wk-sp-3);
+    min-width: 0;
+    padding: var(--wk-sp-2) var(--wk-sp-3);
+    border: 1px solid transparent;
+    border-radius: var(--wk-r-md);
+    background: var(--wk-bg-surface);
+    cursor: pointer;
+    transition:
+        background-color var(--wk-dur-fast) var(--wk-ease),
+        border-color var(--wk-dur-fast) var(--wk-ease),
+        box-shadow var(--wk-dur-fast) var(--wk-ease);
+}
+
+.summary-selector-item:hover {
+    border-color: var(--wk-ai-border);
+    background: var(--wk-ai-surface);
+}
+
+.summary-selector-item--selected {
+    border-color: var(--wk-border-glow);
+    background: var(--wk-accent-tint-08);
+    box-shadow: inset var(--wk-sp-1) 0 0 var(--wk-color-accent);
+}
+
+.summary-selector-item--indented {
+    padding-left: var(--wk-sp-8);
+}
+
+.summary-selector-item--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.summary-selector-item-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.summary-selector-item-title {
+    display: flex;
+    align-items: center;
+    gap: var(--wk-sp-1);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-md);
+    font-weight: var(--wk-font-medium);
+    line-height: var(--wk-leading-normal);
+}
+
+.summary-selector-item--indented .summary-selector-item-title {
+    font-size: var(--wk-text-size-base);
+}
+
+.summary-selector-item-meta {
+    margin-top: var(--wk-sp-0-5);
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-sm);
+    line-height: var(--wk-leading-normal);
+}
+
+.summary-selector-item-avatar {
+    flex: 0 0 auto;
+    color: var(--wk-text-on-brand);
+    background: var(--wk-color-accent);
+    box-shadow: 0 0 0 var(--wk-sp-0-5) var(--wk-accent-tint-12);
+}
+
+.summary-selector-loading,
+.summary-selector-empty {
+    padding-top: var(--wk-sp-10);
+    text-align: center;
+}
+
+.summary-selector-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: var(--wk-sp-3);
+}
+
+.summary-selector-footer-count {
+    padding: var(--wk-sp-1) var(--wk-sp-2);
+    border-radius: var(--wk-r-full);
+    color: var(--wk-text-accent);
+    background: var(--wk-accent-tint-08);
+    font-size: var(--wk-text-size-base);
+    font-weight: var(--wk-font-medium);
+}
+
+.summary-selector-footer-actions {
+    display: flex;
+    gap: var(--wk-sp-2);
+}
+
+.summary-participant-selector {
+    padding: var(--wk-sp-3);
+    border: 1px solid var(--wk-ai-border);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-ai-surface);
+}
+
+.summary-participant-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--wk-sp-1);
+}
+
+.summary-participant-tag {
+    margin: 0;
+}
+
+.summary-participant-add-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--wk-sp-2);
+    margin-top: var(--wk-sp-2);
+}
+
+.summary-participant-input {
+    width: calc(var(--wk-sp-10) * 3);
+}
+
+.summary-participant-add-trigger {
+    margin-top: var(--wk-sp-1);
+    color: var(--wk-text-accent);
+}
+
+.summary-confirm-participant-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wk-sp-2);
+}
+
+.summary-confirm-participant-item {
+    padding: var(--wk-sp-3);
+    border: 1px solid var(--wk-ai-border);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-ai-surface);
+}
+
+.summary-confirm-participant-icon {
+    display: inline-flex;
+    padding: var(--wk-sp-1);
+    border-radius: var(--wk-r-full);
+    background: var(--wk-bg-surface);
+}
+
+.summary-confirm-participant-icon--confirmed {
+    color: var(--wk-color-success);
+}
+
+.summary-confirm-participant-icon--declined {
+    color: var(--wk-color-error);
+}
+
+.summary-confirm-participant-icon--pending {
+    color: var(--wk-color-warning);
+}
+
+.summary-confirm-participant-name {
+    color: var(--wk-text-primary);
+    font-weight: var(--wk-font-medium);
+}
+
+.summary-confirm-participant-time {
+    margin-left: var(--wk-sp-2);
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-sm);
+}


### PR DESCRIPTION
## 变更

- 为聊天、成员、参与者与确认列表统一智能总结 AI 紫色视觉
- 增强选中、悬停、禁用、类型和状态反馈层次
- 全部使用现有语义 token，自动适配 light / dark 主题
- 保持选择、搜索、分组和接口行为不变

## 验证

- pnpm exec stylelint packages/dmworksummary/src/components/SummarySelectors.css --config stylelint.config.mjs
- pnpm --dir packages/dmworksummary exec vitest run src/components/__tests__/ChatSelectorModal.test.tsx src/pages/__tests__/SummaryDetailPage.schedule.test.tsx（154 tests）
- pnpm --dir apps/web build
- git diff --check

Closes #953