### PR TITLE
fix(nav): 更新日志按 Markdown 渲染

### DIFF
--- a/packages/dmworkbase/src/Components/NavRail/ChangelogMarkdown.stories.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/ChangelogMarkdown.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import ChangelogMarkdown from "./ChangelogMarkdown";
+import "./index.css";
+import "../../theme/index.css";
+
+const meta: Meta<typeof ChangelogMarkdown> = {
+    title: "Navigation/ChangelogMarkdown",
+    component: ChangelogMarkdown,
+    args: {
+        content: [
+            "## 2026.07.22",
+            "",
+            "**新增**",
+            "",
+            "- 更新日志支持 Markdown 列表",
+            "- 链接会在新窗口安全打开：[查看帮助](https://example.com/help)",
+            "- 行内代码示例：`pnpm build`",
+        ].join("\n"),
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 480, padding: 24, background: "var(--wk-bg-surface)" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component: "设置面板更新说明使用的受限 Markdown 渲染器；原始 HTML 和非 http/https 链接不会渲染。",
+            },
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChangelogMarkdown>;
+
+export const Default: Story = {};

--- a/packages/dmworkbase/src/Components/NavRail/ChangelogMarkdown.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/ChangelogMarkdown.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
+import { isSafeUrl } from "../../Utils/security";
+
+const CHANGELOG_MARKDOWN_ELEMENTS = [
+    "p", "strong", "em", "del", "ul", "ol", "li", "a", "code", "pre", "blockquote", "hr", "br",
+    "h1", "h2", "h3", "h4", "h5", "h6", "table", "thead", "tbody", "tr", "th", "td", "input",
+];
+
+const changelogMarkdownComponents: any = {
+    a: ({ href, children, node: _node, ...props }: any) => {
+        if (typeof href !== "string" || !isSafeUrl(href)) {
+            return <span>{children}</span>;
+        }
+        return <a href={href} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>;
+    },
+};
+
+export interface ChangelogMarkdownProps {
+    content: string;
+}
+
+/** 设置面板更新说明使用的受限 Markdown 渲染器。 */
+export default function ChangelogMarkdown({ content }: ChangelogMarkdownProps) {
+    return (
+        <div className="wk-navrail__changelog-markdown">
+            <ReactMarkdown
+                skipHtml
+                allowedElements={CHANGELOG_MARKDOWN_ELEMENTS}
+                unwrapDisallowed
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+                components={changelogMarkdownComponents}
+            >
+                {content || ""}
+            </ReactMarkdown>
+        </div>
+    );
+}

--- a/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
@@ -6,6 +6,7 @@ import { Toast, Spin, Button, Progress } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
 import NavVoiceSettingsItem from "./NavVoiceSettingsItem";
 import NavSecretsSettingsItem from "./NavSecretsSettingsItem";
+import ChangelogMarkdown from "./ChangelogMarkdown";
 import { i18n, t } from "../../i18n";
 import { apiFetchJson } from "../../Service/apiFetch";
 
@@ -208,21 +209,11 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                             <Spin size="large" />
                         </div>
                     ) : this.state.changelog ? (
-                        <div style={{ overflow: 'auto', maxHeight: 400, padding: '8px 0' }}>
-                            <div style={{ fontSize: 13, color: 'rgba(28,28,35,0.4)', marginBottom: 12 }}>
+                        <div className="wk-navrail__changelog-content">
+                            <div className="wk-navrail__changelog-meta">
                                 {t("base.common.version")} {this.state.changelog.version || t("base.common.unknown")} · {this.state.changelog.pub_date ? i18n.format.date(this.state.changelog.pub_date) : ''}
                             </div>
-                            <pre style={{
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-word',
-                                fontSize: 14,
-                                lineHeight: 1.7,
-                                margin: 0,
-                                fontFamily: "'PingFang SC', sans-serif",
-                                color: 'rgba(28,28,35,0.9)',
-                            }}>
-                                {this.state.changelog.notes}
-                            </pre>
+                            <ChangelogMarkdown content={this.state.changelog.notes} />
                         </div>
                     ) : (
                         <div style={{ textAlign: 'center', padding: '32px', color: 'rgba(28,28,35,0.4)' }}>
@@ -252,7 +243,7 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                                     <ul>
                                         <li>{t("base.navRail.settingsPanel.currentVersion")}: {WKApp.config.appVersion}&nbsp;&nbsp;{t("base.navRail.settingsPanel.targetVersion")}: {lastVersionInfo.appVersion}</li>
                                         <li>{t("base.navRail.settingsPanel.updateContent")}</li>
-                                        <li><pre>{lastVersionInfo.updateDesc}</pre></li>
+                                        <li><ChangelogMarkdown content={lastVersionInfo.updateDesc} /></li>
                                     </ul>
                                 </div>
                             </div>

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavSettingsPanel.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavSettingsPanel.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import ChangelogMarkdown from "../ChangelogMarkdown";
+
+describe("ChangelogMarkdown", () => {
+    it("renders headings, emphasis, lists, links, and inline code", () => {
+        const html = renderToStaticMarkup(
+            <ChangelogMarkdown
+                content={"## 版本说明\n\n**新增**\n\n- 支持列表\n- 查看 [官网](https://example.com)\n\n使用 `code`"}
+            />,
+        );
+
+        expect(html).toContain("<h2>版本说明</h2>");
+        expect(html).toContain("<strong>新增</strong>");
+        expect(html).toContain("<ul>");
+        expect(html).toContain('href="https://example.com"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain("<code>code</code>");
+    });
+
+    it("drops raw HTML and unsafe link targets", () => {
+        const html = renderToStaticMarkup(
+            <ChangelogMarkdown content={'<script>alert(1)</script>\n\n[危险链接](javascript:alert(1))'} />,
+        );
+
+        expect(html).not.toContain("<script");
+        expect(html).not.toContain("javascript:");
+        expect(html).not.toContain("<a");
+        expect(html).toContain("危险链接");
+    });
+});

--- a/packages/dmworkbase/src/Components/NavRail/index.css
+++ b/packages/dmworkbase/src/Components/NavRail/index.css
@@ -238,6 +238,116 @@
     color: var(--wk-icon-default);
 }
 
+/* ── Changelog markdown ── */
+.wk-navrail__changelog-content {
+    max-height: calc(var(--wk-sp-10) * 10);
+    overflow: auto;
+    padding: var(--wk-sp-2) 0;
+}
+
+.wk-navrail__changelog-meta {
+    margin-bottom: var(--wk-sp-3);
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-base);
+}
+
+.wk-navrail__changelog-markdown {
+    color: var(--wk-text-primary);
+    font: var(--wk-text-body);
+    overflow-wrap: anywhere;
+}
+
+.wk-navrail__changelog-markdown > :first-child {
+    margin-top: 0;
+}
+
+.wk-navrail__changelog-markdown > :last-child {
+    margin-bottom: 0;
+}
+
+.wk-navrail__changelog-markdown h1,
+.wk-navrail__changelog-markdown h2,
+.wk-navrail__changelog-markdown h3,
+.wk-navrail__changelog-markdown h4,
+.wk-navrail__changelog-markdown h5,
+.wk-navrail__changelog-markdown h6 {
+    margin: var(--wk-sp-4) 0 var(--wk-sp-2);
+    color: var(--wk-text-primary);
+    font: var(--wk-text-h4);
+}
+
+.wk-navrail__changelog-markdown p,
+.wk-navrail__changelog-markdown ul,
+.wk-navrail__changelog-markdown ol,
+.wk-navrail__changelog-markdown blockquote,
+.wk-navrail__changelog-markdown pre,
+.wk-navrail__changelog-markdown table {
+    margin: 0 0 var(--wk-sp-3);
+}
+
+.wk-navrail__changelog-markdown ul,
+.wk-navrail__changelog-markdown ol {
+    padding-left: var(--wk-sp-6);
+}
+
+.wk-navrail__changelog-markdown li + li {
+    margin-top: var(--wk-sp-1);
+}
+
+.wk-navrail__changelog-markdown a {
+    color: var(--wk-text-accent);
+    text-decoration: none;
+}
+
+.wk-navrail__changelog-markdown a:hover {
+    text-decoration: underline;
+}
+
+.wk-navrail__changelog-markdown code {
+    padding: var(--wk-sp-0-5) var(--wk-sp-1);
+    border-radius: var(--wk-r-xs);
+    background: var(--wk-bg-elevated);
+    font: var(--wk-text-code);
+}
+
+.wk-navrail__changelog-markdown pre {
+    overflow-x: auto;
+    padding: var(--wk-sp-3);
+    border: 1px solid var(--wk-border-default);
+    border-radius: var(--wk-r-md);
+    background: var(--wk-code-bg);
+    color: var(--wk-text-inverse);
+}
+
+.wk-navrail__changelog-markdown pre code {
+    padding: 0;
+    background: transparent;
+    color: inherit;
+}
+
+.wk-navrail__changelog-markdown blockquote {
+    padding-left: var(--wk-sp-3);
+    border-left: var(--wk-sp-1) solid var(--wk-border-glow);
+    color: var(--wk-text-secondary);
+}
+
+.wk-navrail__changelog-markdown table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.wk-navrail__changelog-markdown th,
+.wk-navrail__changelog-markdown td {
+    padding: var(--wk-sp-2);
+    border: 1px solid var(--wk-border-default);
+    text-align: left;
+}
+
+.wk-navrail__changelog-markdown th {
+    background: var(--wk-bg-elevated);
+    font-weight: var(--wk-font-semibold);
+}
+
 .wk-navrail__language .semi-icon {
     display: inline-flex;
     font-size: 20px;


### PR DESCRIPTION
## 变更

- 设置中的更新日志改用受限 Markdown 渲染，支持标题、强调、列表、链接、代码和 GFM 表格
- 版本更新弹窗的 updateDesc 同步复用相同渲染路径
- 禁用原始 HTML，并对链接执行 http/https 白名单校验与安全的新窗口打开属性
- 增加 token 化样式、组件 Story 和安全回归测试

## 验证

- pnpm --dir packages/dmworkbase exec vitest run src/Components/NavRail/__tests__/NavSettingsPanel.test.tsx（2 tests）
- pnpm --dir apps/web build
- pnpm --dir apps/web build-storybook
- stylelint（本次规则无新增告警；目标历史 CSS 仍有 7 条既有颜色告警）
- git diff --check

Closes #876