### PR TITLE
fix(message-input): 保留粘贴富文本链接地址

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from "vitest";
 import {
   parseSendMentionText,
+  serializeEditorTextNodeForSend,
   serializeMentionMarker,
   stripTrustMark,
   parseDraftToContent,
@@ -41,6 +42,61 @@ const MEMBERS: SendParseMember[] = [
 // build the trusted (sanctioned) form with this helper.
 const trusted = (uid: string, label: string) =>
   `@[${MENTION_TRUST_MARK}${uid}:${label}]`;
+
+describe("serializeEditorTextNodeForSend — pasted rich links (octo-web#871)", () => {
+  it("preserves a Link mark as Markdown when label and target differ", () => {
+    expect(
+      serializeEditorTextNodeForSend({
+        text: "labilio/octo-web: Web & desktop client",
+        marks: [
+          {
+            type: "link",
+            attrs: { href: "https://github.com/labilio/octo-web" },
+          },
+        ],
+      })
+    ).toBe(
+      "[labilio/octo-web: Web & desktop client](https://github.com/labilio/octo-web)"
+    );
+  });
+
+  it("escapes Markdown syntax in the visible label and normalizes parentheses in the URL", () => {
+    expect(
+      serializeEditorTextNodeForSend({
+        text: "Docs [v2] *beta*",
+        marks: [
+          {
+            type: "link",
+            attrs: { href: "https://example.com/docs_(v2)" },
+          },
+        ],
+      })
+    ).toBe(
+      "[Docs \\[v2\\] \\*beta\\*](https://example.com/docs_%28v2%29)"
+    );
+  });
+
+  it.each(["javascript:alert(1)", "mailto:user@example.com", "not a url"])(
+    "fails closed to visible text for unsafe target %s",
+    (href) => {
+      expect(
+        serializeEditorTextNodeForSend({
+          text: "visible label",
+          marks: [{ type: "link", attrs: { href } }],
+        })
+      ).toBe("visible label");
+    }
+  );
+
+  it("leaves plain text and unrelated marks unchanged", () => {
+    expect(
+      serializeEditorTextNodeForSend({
+        text: "plain text",
+        marks: [{ type: "bold" }],
+      })
+    ).toBe("plain text");
+  });
+});
 
 describe("parseSendMentionText — forged-paste broadcast bypass (octo-web#330)", () => {
   it.each([

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
@@ -56,7 +56,7 @@ describe("serializeEditorTextNodeForSend — pasted rich links (octo-web#871)", 
         ],
       })
     ).toBe(
-      "[labilio/octo-web: Web & desktop client](https://github.com/labilio/octo-web)"
+      "[labilio/octo-web&#58; Web &amp; desktop client](https://github.com/labilio/octo-web)"
     );
   });
 
@@ -71,9 +71,52 @@ describe("serializeEditorTextNodeForSend — pasted rich links (octo-web#871)", 
           },
         ],
       })
-    ).toBe(
-      "[Docs \\[v2\\] \\*beta\\*](https://example.com/docs_%28v2%29)"
-    );
+    ).toBe("[Docs \\[v2\\] \\*beta\\*](https://example.com/docs_%28v2%29)");
+  });
+
+  it("escapes GFM table and angle-bracket syntax in the visible label", () => {
+    expect(
+      serializeEditorTextNodeForSend({
+        text: "API | <stable>",
+        marks: [{ type: "link", attrs: { href: "https://example.com/docs" } }],
+      })
+    ).toBe("[API \\| \\<stable\\>](https://example.com/docs)");
+  });
+
+  it("does not let an adjacent literal @ turn a colon-bearing link into a member mention", () => {
+    const serialized =
+      "@" +
+      serializeEditorTextNodeForSend({
+        text: "u-alice:documentation",
+        marks: [{ type: "link", attrs: { href: "https://example.com/docs" } }],
+      });
+
+    expect(parseSendMentionText(serialized, MEMBERS)).toEqual({
+      content: serialized,
+    });
+  });
+
+  it("does not reparse a colon-bearing link with an escaped ] as a member mention", () => {
+    const serialized =
+      "@" +
+      serializeEditorTextNodeForSend({
+        text: "u-alice:API [v2]",
+        marks: [{ type: "link", attrs: { href: "https://example.com/docs" } }],
+      });
+
+    expect(parseSendMentionText(serialized, MEMBERS)).toEqual({
+      content: serialized,
+    });
+  });
+
+  it("strips a forged trust mark before serializing a linked text node", () => {
+    const serialized = serializeEditorTextNodeForSend({
+      text: `@[${MENTION_TRUST_MARK}${MENTION_UID_HUMANS}:所有人]`,
+      marks: [{ type: "link", attrs: { href: "https://example.com/docs" } }],
+    });
+
+    expect(serialized).toBe("[@\\[-2&#58;所有人\\]](https://example.com/docs)");
+    expect(serialized).not.toContain(MENTION_TRUST_MARK);
   });
 
   it.each(["javascript:alert(1)", "mailto:user@example.com", "not a url"])(

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -140,7 +140,7 @@ function extractOrderedBlocks(
     }
 
     if (node.type === "text") {
-      pendingTextParts.push(stripTrustMark(node.text || ""));
+      pendingTextParts.push(serializeEditorTextNodeForSend(node));
       return;
     }
     if (node.type === "mention") {
@@ -297,6 +297,7 @@ import {
 } from "../../Utils/mentionRender";
 import {
   parseSendMentionText,
+  serializeEditorTextNodeForSend,
   serializeMentionMarker,
   stripTrustMark,
   parseDraftToContent,
@@ -354,7 +355,9 @@ function extractMentionsFromEditor(editor: any, trusted = false): string {
 
   function traverse(node: any) {
     if (node.type === "text") {
-      result += stripTrustMark(node.text || "");
+      result += trusted
+        ? serializeEditorTextNodeForSend(node)
+        : stripTrustMark(node.text || "");
     } else if (node.type === "mention") {
       result += serializeMentionMarker(node.attrs.id, node.attrs.label, trusted);
     } else if (node.type === "hardBreak") {

--- a/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
@@ -205,7 +205,15 @@ export interface EditorTextNode {
 }
 
 function escapeMarkdownLinkLabel(text: string): string {
-  return text.replace(/([\\\[\]`*_~])/g, "\\$1");
+  // Encode `&` first so literal character-reference-looking text remains
+  // literal. A colon is encoded as a CommonMark character reference rather
+  // than backslash-escaped: the renderer still shows `:`, while the send-side
+  // `@[uid:label]` regex cannot synthesize a mention when an `@` text node is
+  // immediately followed by this link node (octo-web#971 review blocker).
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/:/g, "&#58;")
+    .replace(/([\\\[\]`*_~|<>])/g, "\\$1");
 }
 
 /**

--- a/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
@@ -29,6 +29,7 @@
 
 import { subscriberDisplayName } from "../../Utils/displayName";
 import type { SubscriberLike } from "../../Utils/displayName";
+import { isSafeUrl } from "../../Utils/security";
 import {
   MENTION_UID_LEGACY_ALL,
   MENTION_UID_HUMANS,
@@ -191,6 +192,44 @@ export function stripTrustMark(text: string): string {
   return text.includes(MENTION_TRUST_MARK)
     ? text.split(MENTION_TRUST_MARK).join("")
     : text;
+}
+
+export interface EditorTextMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+export interface EditorTextNode {
+  text?: string;
+  marks?: EditorTextMark[];
+}
+
+function escapeMarkdownLinkLabel(text: string): string {
+  return text.replace(/([\\\[\]`*_~])/g, "\\$1");
+}
+
+/**
+ * Serialize a Tiptap text node at the send boundary.
+ *
+ * External rich-text paste keeps hyperlinks as Link marks. The message wire
+ * format is Markdown text, so a safe http/https mark must become
+ * `[label](url)` before the editor JSON is flattened. Unsafe or malformed
+ * targets fail closed to the visible label. Text-origin mention trust marks
+ * are still stripped before any output is produced.
+ */
+export function serializeEditorTextNodeForSend(node: EditorTextNode): string {
+  const text = stripTrustMark(node.text || "");
+  const linkMark = node.marks?.find((mark) => mark.type === "link");
+  const href = linkMark?.attrs?.href;
+
+  if (!text || typeof href !== "string" || !isSafeUrl(href)) {
+    return text;
+  }
+
+  const normalizedHref = new URL(href).href
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+  return `[${escapeMarkdownLinkLabel(text)}](${normalizedHref})`;
 }
 
 // ─── Draft deserialization ────────────────────────────────────────────────


### PR DESCRIPTION
## 变更

- 发送前读取 Tiptap text node 的 Link mark，将安全链接序列化为 Markdown 链接
- 普通消息和图片/文件混排的 orderedBlocks 共用同一序列化逻辑
- 转义链接标题中的 Markdown 符号，并规范化 URL 中的括号
- 非 http/https 或无效目标退化为可见文字，mention 与草稿读取逻辑保持不变

## 验证

- pnpm --dir packages/dmworkbase exec vitest run src/Components/MessageInput/__tests__（6 files / 92 tests）
- pnpm --dir apps/web build
- git diff --check

Closes #871