### PR TITLE
fix(context-menu): preserve hover corner radius

### DIFF
--- a/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
@@ -6,7 +6,7 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import ContextMenus, { ContextMenusContext } from "../index"
+import ContextMenus, { ContextMenusContext, ContextMenusData } from "../index"
 
 let container: HTMLDivElement
 let originalRequestAnimationFrame: typeof requestAnimationFrame | undefined
@@ -153,5 +153,40 @@ describe("ContextMenus native contextmenu suppression", () => {
 
         const unguardedEvent = dispatchContextMenu(document.body)
         expect(unguardedEvent.defaultPrevented).toBe(false)
+    })
+})
+
+describe("ContextMenus rounded hover boundaries", () => {
+    it("keeps the first and last menu items selectable around separators at every level", () => {
+        act(() => {
+            ReactDOM.render(
+                <ContextMenus
+                    onContext={() => undefined}
+                    menus={[
+                        { separator: true } as ContextMenusData,
+                        {
+                            title: "Move to",
+                            children: [
+                                { separator: true } as ContextMenusData,
+                                { title: "First group" },
+                                { title: "Last group" },
+                                { separator: true } as ContextMenusData,
+                            ],
+                        },
+                        { title: "Delete" },
+                        { separator: true } as ContextMenusData,
+                    ]}
+                />,
+                container
+            )
+        })
+
+        const rootList = container.querySelector(".wk-contextmenus > ul")!
+        const submenu = container.querySelector(".wk-ctx-submenu")!
+
+        expect(rootList.querySelector(":scope > li:first-of-type")?.textContent).toContain("Move to")
+        expect(rootList.querySelector(":scope > li:last-of-type")?.textContent).toBe("Delete")
+        expect(submenu.querySelector(":scope > li:first-of-type")?.textContent).toBe("First group")
+        expect(submenu.querySelector(":scope > li:last-of-type")?.textContent).toBe("Last group")
     })
 })

--- a/packages/dmworkbase/src/Components/ContextMenus/index.css
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.css
@@ -55,6 +55,16 @@ body[theme-mode=dark] .wk-contextmenus {
     background: #F2F3F5;
 }
 
+.wk-contextmenus ul > li:first-of-type {
+    border-top-left-radius: var(--wk-r-md);
+    border-top-right-radius: var(--wk-r-md);
+}
+
+.wk-contextmenus ul > li:last-of-type {
+    border-bottom-right-radius: var(--wk-r-md);
+    border-bottom-left-radius: var(--wk-r-md);
+}
+
 body[theme-mode=dark] .wk-contextmenus li {
     color: var(--wk-text-primary);
 }


### PR DESCRIPTION
## Summary

Preserve the outer corner radius when hovering the first or last actionable item in context menus, including nested menus and menus containing separators.

## Related Issue

Fixes #869

## Changes

- Apply the existing semantic radius token to the top and bottom actionable menu boundaries.
- Add regression coverage for root and nested menu boundaries around separators.

## Architecture / Module Boundary

- Affected module(s): `@octo/base` ContextMenus
- New or changed user-visible entry point: no
- Shared layer touched: Components
- If shared code changed, impact scope: all existing ContextMenus callers receive the same boundary rounding fix; menu data, actions, positioning, and submenu behavior are unchanged.
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands and results:

- `pnpm --dir packages/dmworkbase test src/Components/ContextMenus/__tests__/ContextMenus.test.tsx` — 4 tests passed.
- `pnpm --dir apps/web build` — passed.
- `git diff --check` — passed.
- Manually verified the root and nested context-menu hover behavior against the online backend.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — not required because no API, entry point, or documented workflow changed.
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)