### PR TITLE
fix(chat): stop mixed content max-width from constraining text (#948)

### DIFF
--- a/packages/dmworkbase/src/ui/message/MixedContent/index.css
+++ b/packages/dmworkbase/src/ui/message/MixedContent/index.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--wk-sp-1-5);
-  max-width: min(100%, 680px);
   word-break: break-word;
 }
 
@@ -17,7 +16,7 @@
 
 .wk-msg-mixed-image {
   display: flex;
-  max-width: 100%;
+  max-width: min(100%, 680px);
 }
 
 .wk-msg-mixed-file {


### PR DESCRIPTION
## Summary

Fixes #948.

The `680px` cap on `.wk-msg-mixed-content` was applied to the shared parent of both the image block and the text block, so image+text messages wrapped noticeably earlier than pure text messages on wide screens.

- Removed `max-width: min(100%, 680px)` from `.wk-msg-mixed-content`.
- Moved the same cap onto `.wk-msg-mixed-image` so images keep their max render width.
- `.wk-msg-mixed-file` already has its own `width: min(100%, 300px)` and is untouched.

## Test plan

- [ ] Send a long text-only message in a wide chat window; note the line-break position.
- [ ] Send the same text with an attached image; verify text wraps at the same position as the pure-text case.
- [ ] Verify the image still caps at ~680px on wide screens.
- [ ] Verify the file card still renders at ~300px width.