### PR TITLE
fix(message-input): disable Tiptap autolink to keep filenames as text (#870)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -506,6 +506,10 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         horizontalRule: false,
         codeBlock: false,
         strike: false,
+        // StarterKit 3.x 内置 Link 扩展的 linkifyjs 会把 xxx.md / README.md
+        // 识别为 .md 顶级域名并补成超链接（issue #870）。输入框只保留纯文本，
+        // 链接由消息渲染层的 markdown 解析生成。
+        link: false,
       }),
       Placeholder.configure({
         placeholder,


### PR DESCRIPTION
## Summary

Fixes #870.

StarterKit 3.x bundles the Link extension whose linkifyjs autolink recognizes `.md` as a valid TLD, so typing `xxx.md` / `README.md` in the message input renders as a clickable `http://xxx.md` link. This is misleading and can direct users to unintended hosts.

- Added `link: false` to `StarterKit.configure` in `MessageInput`.
- Safe because `extractMentionsFromEditor` only serializes text/mention/hardBreak nodes — link marks are not preserved on send, so real URLs typed as `http://…` still round-trip as plain text and are rendered as links by the receiving markdown layer.

## Test plan

- [ ] Type `xxx.md` / `README.md` in the message input; verify it stays plain text (no underline, not clickable).
- [ ] Type `http://example.com`; verify it can still be sent and renders as a link in the received message.
- [ ] Verify @mentions still work (mention nodes are unaffected).
- [ ] Verify paste of plain text with URLs still sends correctly.