### PR TITLE
refactor(contacts): split group creation UI

### DIFF
--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.tsx
@@ -1,32 +1,18 @@
-import React from "react";
-import { Component, ReactNode } from "react";
+import React, { Component, ReactNode } from "react";
+import { Toast } from "@douyinfe/semi-ui";
 
-import {
-  Button,
-  Space,
-  Tree,
-  Input,
-  CheckboxGroup,
-  Checkbox,
-  Toast,
-} from "@douyinfe/semi-ui";
-import { BasicTreeNodeData } from "@douyinfe/semi-foundation/lib/cjs/tree/foundation";
-import { WKApp, ThemeMode, WKViewQueueHeader, WKModal, I18nContext, t, GroupAvatarPreview, GroupAvatarEditModal } from "@octo/base";
-import WKAvatar from "@octo/base/src/Components/WKAvatar";
-import AiBadge from "@octo/base/src/Components/AiBadge";
-import "./index.css";
+import { I18nContext, t, WKApp } from "@octo/base";
 import { GROUP_NAME_MAX_LENGTH } from "@octo/base/src/Service/nameLimits";
-import {
-  loadGroupCreateCandidates,
-  submitGroupCreateAction,
-} from "../../bridge/groupCreate/groupCreateRuntime";
+
+import { useGroupCreate } from "../../bridge/groupCreate/useGroupCreate";
+import GroupCreateDialog from "../../ui/GroupCreateDialog";
 
 export enum OrganizationalGroupNewAction {
-  createGroup, // 创建群聊
-  AddMember // 添加成员
+  createGroup,
+  AddMember,
 }
 
-interface IPorpsOrganizationalGroupNew {
+interface OrganizationalGroupNewProps {
   channel: {
     channelID: string;
     channelType: number;
@@ -41,808 +27,175 @@ interface IPorpsOrganizationalGroupNew {
   keepSidebarTab?: boolean;
 }
 
-interface ISateOrganizationalGroupNew {
-  showModal: boolean;
-  optTitle: string;
-  organizationInfo: {
-    name: string;
-    is_upload_logo?: number;
-    org_id?: string;
-    short_no?: string;
-  };
-  treeData: any[];
-  optPersonnelData: any[];
-  isFriend: boolean;
-  friendData: any[];
-  friendSearchData: any[];
-  searchVaule: string;
-  // 发起群聊（createGroup）专用：群名 + 自定义头像态 + 二次弹窗开关。
-  groupName: string;
-  avatarText: string;
-  avatarColorIndex?: number;
-  showAvatarEdit: boolean;
+interface OrganizationalGroupNewState {
+  isOpen: boolean;
+}
+
+function GroupCreateFeature({
+  props,
+  isOpen,
+  onClose,
+}: {
+  props: OrganizationalGroupNewProps;
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const mode =
+    props.action === OrganizationalGroupNewAction.createGroup
+      ? "createGroup"
+      : "addMember";
+  const model = useGroupCreate({
+    action: mode,
+    channel: props.channel,
+    isOpen,
+    defaultCategoryId: props.defaultCategoryId,
+    keepSidebarTab: props.keepSidebarTab,
+    onClose,
+    onSuccess: props.onSuccess,
+    notice: {
+      onError: (message) => Toast.error(message),
+      onNameRequired: () =>
+        Toast.warning(t("contacts.groupCreate.nameRequired")),
+      onMembersRequired: () =>
+        Toast.warning(t("contacts.groupNew.selectContactsWarning")),
+    },
+  });
+
+  const selectedTitle =
+    mode === "createGroup"
+      ? t("contacts.groupCreate.selectedCount", {
+          values: { count: model.selected.length },
+        })
+      : t(
+          props.channel.channelType === 1
+            ? "contacts.groupNew.title.createGroup"
+            : "contacts.groupNew.title.selectContacts"
+        );
+
+  return (
+    <GroupCreateDialog
+      mode={mode}
+      isOpen={isOpen}
+      copy={{
+        title: t("contacts.groupCreate.title"),
+        avatarLabel: t("contacts.groupCreate.avatarLabel"),
+        editAvatar: t("contacts.groupCreate.editAvatar"),
+        nameLabel: t("contacts.groupCreate.nameLabel"),
+        namePlaceholder: t("contacts.groupCreate.namePlaceholder"),
+        membersLabel: t("contacts.groupCreate.membersLabel"),
+        confirm: t("contacts.common.confirm"),
+        cancel: t("contacts.common.cancel"),
+      }}
+      form={{
+        groupName: model.groupName,
+        avatarText: model.avatar.text,
+        avatarColorIndex: model.avatar.colorIndex,
+        maxNameLength: GROUP_NAME_MAX_LENGTH,
+        isAvatarEditorOpen: model.avatar.isEditorOpen,
+      }}
+      memberPicker={{
+        mode,
+        candidates: model.candidates,
+        selected: model.selected,
+        selectedUids: model.selectedUidSet,
+        keyword: model.keyword,
+        copy: {
+          searchPlaceholder: t("contacts.common.search"),
+          selectedTitle,
+          confirm: t("contacts.common.confirm"),
+          cancel: t("contacts.common.cancel"),
+        },
+        avatarForUid: (uid) => WKApp.shared.avatarUser(uid),
+        actions: {
+          onKeywordChange: model.setKeyword,
+          onToggleMember: model.toggleMember,
+          onCancel: onClose,
+          onConfirm: model.submit,
+        },
+      }}
+      actions={{
+        onCancel: onClose,
+        onConfirm: model.submit,
+        onGroupNameChange: model.setGroupName,
+        onOpenAvatarEditor: model.avatar.openEditor,
+        onCloseAvatarEditor: model.avatar.closeEditor,
+        onSaveAvatar: model.avatar.save,
+      }}
+    />
+  );
 }
 
 export class OrganizationalGroupNew extends Component<
-  IPorpsOrganizationalGroupNew,
-  ISateOrganizationalGroupNew
+  OrganizationalGroupNewProps,
+  OrganizationalGroupNewState
 > {
   static contextType = I18nContext;
   declare context: React.ContextType<typeof I18nContext>;
 
-  state: ISateOrganizationalGroupNew = {
-    showModal: false,
-    optTitle: "",
-    organizationInfo: {
-      name: "",
-    },
-    treeData: [],
-    optPersonnelData: [],
-    isFriend: true,
-    friendData: [],
-    friendSearchData: [],
-    searchVaule: "",
-    groupName: "",
-    avatarText: "",
-    avatarColorIndex: undefined,
-    showAvatarEdit: false,
-  };
-  treeRef: any = React.createRef();
-
-  constructor(props: IPorpsOrganizationalGroupNew) {
-    super(props);
-  }
+  state: OrganizationalGroupNewState = { isOpen: false };
 
   componentDidMount(): void {
-    if (this.props.autoShow) {
-      this.onShowModal();
-    }
+    if (this.props.autoShow) this.open();
   }
 
-  // 获取加入公司
-  async getJoinOrganization() {
-    const res = await WKApp.apiClient.get("/organization/joined");
-    if (res && res.length > 0) {
-      const organizationInfo = res[0];
-      this.setState({
-        organizationInfo: organizationInfo,
-      });
-      if (organizationInfo) {
-        this.getOrganizationDepartment(organizationInfo.org_id);
-      }
-    }
-  }
-  // 获取加入公司所有部门
-  async getOrganizationDepartment(org_id: string) {
-    const res = await WKApp.apiClient.get(
-      `/organizations/${org_id}/department`
-    );
-    if (!res) return;
-    // 部门
-    const departments: any = Array.isArray(res.departments)
-      ? this.handleTree(res.departments)
-      : [];
-    // 人员
-    const employees: any[] = [];
-    if (!Array.isArray(res.employees)) {
-      this.setState({ treeData: [...departments] });
-      return;
-    }
-    res.employees.forEach((y: any) => {
-      employees.push({
-        label: y.employee_name,
-        value: y.employee_id,
-        key: `uid_${y.uid}`,
-        icon: (
-          <WKAvatar
-            src={WKApp.shared.avatarUser(y.uid as string)}
-            style={{ width: "20px", height: "20px", marginRight: "6px" }}
-          />
-        ),
-        is_employee: true,
-        ...y,
-      });
-    });
-    this.setState({
-      treeData: [...departments, ...employees],
-    });
-  }
-  // 处理全部子部门人数
-  handelEmployeesNum(arr: any[]) {
-    let employeesNums: number[] = [];
-    arr.forEach((item) => {
-      if (item.employees && item.employees.length > 0) {
-        employeesNums.push(item.employees.length);
-      }
-      if (item.children && item.children.length > 0) {
-        const employeesNum = this.handelEmployeesNum(item.children);
-        employeesNums = [...employeesNums, ...employeesNum];
-      }
-    });
-    return employeesNums;
-  }
+  open = () => this.setState({ isOpen: true });
 
-  handleTree(arr: any[]) {
-    const OTree: any = [];
-    arr.forEach((item: any) => {
-      let children: any[] = [];
-      let employeesNum: number = 0;
-      // 获取当前部门人数
-      if (item.employees) {
-        employeesNum = parseInt(item.employees.length);
-      }
-      // 获取全部子部门人数
-      if (item.children) {
-        const employeesNums = this.handelEmployeesNum(item.children);
-        employeesNums.forEach((num) => {
-          employeesNum += num;
-        });
-      }
-      // 有组织和人员
-      if (item.children && item.employees) {
-        children = this.handleTree(item.children);
-        const employees: any[] = [];
-        item.employees.forEach((y: any) => {
-          employees.push({
-            label: y.employee_name,
-            value: y.employee_id,
-            key: `${item.dept_id}_${y.employee_id}`,
-            icon: (
-              <WKAvatar
-                src={WKApp.shared.avatarUser(y.uid as string)}
-                style={{ width: "24px", height: "24px", marginRight: "6px" }}
-              />
-            ),
-            is_employee: true,
-            ...y,
-          });
-        });
-        children = [...children, ...employees];
-      }
-      // 只有人员
-      if (!item.children && item.employees) {
-        const employees: any[] = [];
-        item.employees.forEach((y: any) => {
-          employees.push({
-            label: y.employee_name,
-            value: y.employee_id,
-            key: `${item.dept_id}_${y.employee_id}`,
-            icon: (
-              <WKAvatar
-                src={WKApp.shared.avatarUser(y.uid as string)}
-                style={{ width: "20px", height: "20px", marginRight: "6px" }}
-              />
-            ),
-            is_employee: true,
-            ...y,
-          });
-        });
-        children = [...children, ...employees];
-      }
+  close = () => {
+    this.setState({ isOpen: false });
+    this.props.remove?.();
+  };
 
-      OTree.push({
-        label: employeesNum > 0 ? `${item.name}(${employeesNum})` : `${item.name}`,
-        value: item.dept_id,
-        key: item.short_no,
-        icon: (
-          <span
-            className="department-icon"
-            style={{ display: "flex", marginRight: "6px" }}
-          >
-            <svg
-              width="24px"
-              height="18px"
-              viewBox="0 0 24 18"
-              version="1.1"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                id="page-1"
-                stroke="none"
-                strokeWidth="1"
-                fill="none"
-                fillRule="evenodd"
-              >
-                <g
-                  id="02"
-                  transform="translate(-98.000000, -131.000000)"
-                  fill="currentColor"
-                  fillRule="nonzero"
-                >
-                  <g
-                    id="wenjianjia"
-                    transform="translate(98.000000, 131.000000)"
-                  >
-                    <path
-                      d="M21.343573,4.88046647 C21.6937698,4.9154519 22.0439666,5.00291545 22.3941634,5.14285714 C22.7443602,5.28279883 23.0484784,5.47959184 23.3065182,5.73323615 C23.5645579,5.98688047 23.7580877,6.30612245 23.8871076,6.6909621 C24.0161275,7.07580175 24.0345589,7.5393586 23.9424018,8.08163265 C23.905539,8.22157434 23.8318134,8.56705539 23.7212249,9.1180758 C23.6106365,9.66909621 23.4816166,10.303207 23.3341653,11.0204082 C23.186714,11.7376093 23.0208313,12.4766764 22.8365172,13.2376093 C22.6522031,13.9985423 22.4771047,14.6501458 22.311222,15.1924198 C22.219065,15.5072886 22.0854373,15.8309038 21.9103389,16.1632653 C21.7352405,16.4956268 21.5094557,16.7973761 21.2329845,17.0685131 C20.9565134,17.3396501 20.624748,17.5626822 20.2376884,17.7376093 C19.8506288,17.9125364 19.3898435,18 18.8553326,18 L3.53883076,18 C3.15177114,18 2.75088797,17.9212828 2.33618124,17.7638484 C1.92147451,17.606414 1.53902275,17.3833819 1.18882596,17.0947522 C0.838629164,16.8061224 0.552942306,16.4562682 0.331765384,16.0451895 C0.110588461,15.6341108 0,15.1749271 0,14.6676385 L0,3.41107872 C0,2.34402332 0.304118268,1.50874636 0.912354805,0.905247813 C1.52059134,0.301749271 2.37765192,0 3.48353653,0 L17.0859173,0 C17.4914083,0 17.9107229,0.0743440233 18.343861,0.22303207 C18.7769991,0.371720117 19.1686666,0.577259475 19.5188634,0.839650146 C19.8690602,1.10204082 20.154747,1.40816327 20.375924,1.75801749 C20.5971009,2.10787172 20.7076894,2.48396501 20.7076894,2.88629738 L20.7076894,3.17492711 L19.2700394,3.17492711 C18.532783,3.17492711 17.6711145,3.17055394 16.6850341,3.16180758 C15.6989536,3.15306122 14.6483633,3.14868805 13.5332629,3.14868805 C12.4181626,3.14868805 11.3767879,3.14431487 10.4091389,3.13556851 C9.44148987,3.12682216 8.60746856,3.12244898 7.90707497,3.12244898 L6.63530767,3.12244898 C6.15609101,3.12244898 5.78285495,3.26676385 5.5155995,3.55539359 C5.24834405,3.84402332 5.04099069,4.2244898 4.89353941,4.696793 C4.74608813,5.20408163 4.58020543,5.74198251 4.39589133,6.31049563 C4.21157723,6.87900875 4.04569454,7.40816327 3.89824326,7.89795918 C3.71392915,8.47521866 3.52961505,9.03498542 3.34530095,9.57725948 C3.30843813,9.71720117 3.29000672,9.83090379 3.29000672,9.91836735 C3.29000672,10.2157434 3.39598733,10.4650146 3.60794855,10.6661808 C3.81990976,10.8673469 4.08255736,10.96793 4.39589133,10.96793 C4.96726505,10.96793 5.35432466,10.6268222 5.55707017,9.94460641 L7.02236728,4.85422741 C9.41845061,4.87172012 11.6117884,4.88046647 13.6023807,4.88046647 L21.343573,4.88046647 L21.343573,4.88046647 Z"
-                      id="folder-path"
-                    ></path>
-                  </g>
-                </g>
-              </g>
-            </svg>
-          </span>
-        ),
-        dept_id: item.dept_id,
-        org_id: item.org_id,
-        name: item.name,
-        is_department: true,
-        children: children,
-      });
-    });
-    return OTree;
-  }
+  renderTrigger(): ReactNode {
+    if (this.props.render) return this.props.render;
+    if (!this.props.showAdd) return null;
 
-  onSelectOrganization(
-    selectedKey: string,
-    selected: boolean,
-    selectedNode: BasicTreeNodeData
-  ) {
-    if (selected) {
-      const getOptTreeData = [];
-      getOptTreeData.push(selectedNode);
-
-      const newOptTreeData = [
-        ...this.state.optPersonnelData,
-        ...this.handOptTree(getOptTreeData),
-      ];
-      // 处理去重
-      const uniqueArr = Object.values(
-        newOptTreeData.reduce((acc, curr) => {
-          acc[curr.uid] = curr;
-          return acc;
-        }, {})
-      );
-      this.setState({
-        optPersonnelData: [...uniqueArr],
-      });
-    }
-  }
-
-  handOptTree(arr: any[]) {
-    let OTree: any = [];
-    arr.forEach((item: any) => {
-      if (item.children && item.is_department) {
-        const res = this.handOptTree(item.children);
-        OTree = [...OTree, ...res];
-      }
-      if (item.is_employee) {
-        OTree.push({
-          name: item.employee_name,
-          uid: item.uid,
-        });
-      }
-    });
-    return OTree;
-  }
-
-  onDelOptPersonnel(uid: string) {
-    const newOpt = this.state.optPersonnelData.filter((item) => {
-      return item.uid !== uid;
-    });
-    const newFriendData = this.state.friendData.map((item) => {
-      if (item.uid === uid) {
-        return { ...item, checked: false };
-      }
-      return item;
-    });
-    this.setState({
-      optPersonnelData: newOpt,
-      friendData: newFriendData
-    });
-  }
-
-  async getFriendData() {
-    const setFriendData = await loadGroupCreateCandidates({
-      channel: this.props.channel,
-    });
-    this.setState({
-      friendData: [...setFriendData],
-      friendSearchData: [...setFriendData],
-    });
-  }
-
-  onFriendChange(values: string[]) {
-    const getFriendOpt: any[] = [];
-    const { friendData } = this.state;
-    let { optPersonnelData } = this.state;
-
-    // Use immutable update pattern - create new objects instead of mutating
-    const newFriendData = friendData.map(item => {
-      const isSelected = values.includes(item.uid);
-      if (isSelected) {
-        const updatedItem = { ...item, checked: true };
-        getFriendOpt.push(updatedItem);
-        return updatedItem;
-      } else {
-        // Remove from optPersonnelData if unchecked
-        optPersonnelData = optPersonnelData.filter(p => p.uid !== item.uid);
-        return { ...item, checked: false };
-      }
-    });
-
-    const newPersonnelData = [...getFriendOpt, ...optPersonnelData];
-
-    // 处理去重
-    const uniqueArr = Object.values(
-      newPersonnelData.reduce((acc, curr) => {
-        acc[curr.uid] = curr;
-        return acc;
-      }, {})
-    );
-    this.setState({
-      optPersonnelData: [...uniqueArr],
-      friendData: newFriendData
-    });
-  }
-
-  onOrginzational() {
-    this.setState({
-      isFriend: false,
-      searchVaule: "",
-    });
-  }
-
-  onShowModal() {
-    const { channelType } = this.props.channel;
-    // this.getJoinOrganization();
-    this.getFriendData();
-    this.setState({
-      showModal: true,
-      optTitle: channelType === 1 ? "contacts.groupNew.title.createGroup" : "contacts.groupNew.title.selectContacts",
-      groupName: "",
-      avatarText: "",
-      avatarColorIndex: undefined,
-      showAvatarEdit: false,
-    });
-  }
-
-  onCancel() {
-    this.setState({
-      showModal: false,
-      isFriend: true,
-      optPersonnelData: [],
-      groupName: "",
-      avatarText: "",
-      avatarColorIndex: undefined,
-      showAvatarEdit: false,
-    });
-    this.props.remove && this.props.remove();
-  }
-
-  async onOK() {
-    const channel = this.props.channel as any;
-    const { optPersonnelData } = this.state;
-    const isCreate =
-      this.props.action === OrganizationalGroupNewAction.createGroup;
-    const name = this.state.groupName.trim();
-    // 群名必填（创建群）——先于成员校验，匹配「群名在上、选人在下」的视觉顺序。
-    if (isCreate && !name) {
-      return Toast.warning(t("contacts.groupCreate.nameRequired"));
-    }
-    if (optPersonnelData.length === 0) {
-      return Toast.warning(t("contacts.groupNew.selectContactsWarning"));
-    }
-
-    const getOptPersonnelData = optPersonnelData.map((item) => {
-      return item.uid;
-    });
-
-    // 创建群
-    if (isCreate) {
-      try {
-        await submitGroupCreateAction({
-          action: "createGroup",
-          channel: this.props.channel,
-          selectedUids: [...getOptPersonnelData],
-          createOptions: {
-            categoryId: this.props.defaultCategoryId,
-            name,
-            // 仅在用户显式设置时下发；缺省由服务端渲染默认双人图标。
-            avatarText: this.state.avatarText || undefined,
-            avatarColor: this.state.avatarColorIndex,
-          },
-          keepSidebarTab: this.props.keepSidebarTab,
-        });
-        this.props.onSuccess?.()
-      } catch (error: any) {
-        Toast.error(error.msg);
-        return
-      }
-    }
-    // 添加联系人
-    if (this.props.action === OrganizationalGroupNewAction.AddMember) {
-      try {
-        await submitGroupCreateAction({
-          action: "addMember",
-          channel,
-          selectedUids: getOptPersonnelData,
-        });
-      } catch (error: any) {
-        Toast.error(error.msg);
-        return
-      }
-
-    }
-    this.onCancel();
-  }
-
-  onChangeSearch(value: string) {
-    const { friendSearchData, isFriend } = this.state;
-
-    if (isFriend) {
-      this.setState({
-        searchVaule: value,
-        friendData: friendSearchData.filter((item) => {
-          return item.name.toLowerCase().indexOf(value.toLowerCase()) !== -1;
-        }),
-      });
-    }
-    if (!isFriend) {
-      this.setState({
-        searchVaule: value,
-      });
-      this.treeRef && this.treeRef.current.search(value);
-    }
-  }
-
-  // 选人左栏（搜索 + 好友/组织架构列表）—— 发起群聊与添加成员两种布局共用。
-  renderMemberLeft(): ReactNode {
-    const {
-      treeData,
-      organizationInfo,
-      isFriend,
-      friendData,
-      searchVaule,
-      optPersonnelData,
-    } = this.state;
     return (
-      <div className="wk-organizational-group-new-left">
-        <div className="group-new-left-search">
-          <Input
-            className="group-new-left-search-input"
-            placeholder={t("contacts.common.search")}
-            value={searchVaule}
-            showClear
-            onChange={(value) => {
-              this.onChangeSearch(value);
-            }}
-          />
-        </div>
-        <div className="group-new-left-main">
-          {isFriend ? (
-            <div className="friend-opt">
-              {/* 组织架构 */}
-              {organizationInfo?.org_id && (
-                <div
-                  className="organization-name"
-                  onClick={() => {
-                    this.onOrginzational();
-                  }}
-                >
-                  <img
-                    style={{ width: "24px", height: "24px", marginRight: "6px" }}
-                    src={require("../../assets/organizational_new.png")}
-                    alt=""
-                  />
-                  <span>{organizationInfo?.name}</span>
-                </div>
-              )}
-
-              <div className="friend-opt-main">
-                <CheckboxGroup
-                  style={{ width: "100%" }}
-                  value={optPersonnelData.map((item) => item.uid)}
-                  onChange={(value) => {
-                    this.onFriendChange(value);
-                  }}
-                >
-                  {friendData.map((friend) => (
-                    <Checkbox
-                      key={friend.uid}
-                      value={friend.uid}
-                      className="friend-opt-item"
-                    >
-                      <WKAvatar
-                        src={
-                          friend.avatar ||
-                          WKApp.shared.avatarUser(friend.uid as string)
-                        }
-                        style={{
-                          width: "24px",
-                          height: "24px",
-                          marginRight: "6px",
-                        }}
-                      />
-                      <span>{friend.name}</span>
-                      {friend.robot && <AiBadge size="small" />}
-                    </Checkbox>
-                  ))}
-                </CheckboxGroup>
-              </div>
-            </div>
-          ) : (
-            <div className="organizational-opt">
-              <div className="organizational-opt-header">
-                <WKViewQueueHeader
-                  title={organizationInfo.name}
-                  onBack={() => {
-                    this.setState({ isFriend: true, searchVaule: "" });
-                  }}
-                />
-              </div>
-              <div className="organizational-opt-main">
-                <Tree
-                  ref={this.treeRef}
-                  treeData={treeData}
-                  filterTreeNode
-                  searchRender={false}
-                  multiple
-                  showFilteredOnly={true}
-                  className="organizational-tree"
-                  onSelect={(
-                    selectedKey: string,
-                    selected: boolean,
-                    selectedNode: BasicTreeNodeData
-                  ) => {
-                    this.onSelectOrganization(
-                      selectedKey,
-                      selected,
-                      selectedNode
-                    );
-                  }}
-                />
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  // 右侧「已选成员」列表项 —— 两种布局共用。
-  renderSelectedList(): ReactNode {
-    const { optPersonnelData } = this.state;
-    return optPersonnelData?.map((item) => (
-      <div key={item.uid} className="opt-personnel-item">
-        <div className="user-info">
-          <WKAvatar
-            src={item.avatar || WKApp.shared.avatarUser(item.uid as string)}
-            style={{ width: "24px", height: "24px", marginRight: "6px" }}
-          />
-          <span>{item.name}</span>
-          {item.robot && <AiBadge size="small" />}
-        </div>
-        <div
-          className="close-icon"
-          onClick={() => {
-            this.onDelOptPersonnel(item.uid);
-          }}
+      <>
+        <svg
+          viewBox="0 0 22 22"
+          fill={WKApp.config.themeColor}
+          width="20px"
+          height="20px"
+          focusable="false"
+          aria-hidden="true"
         >
-          <span className="semi-icon semi-icon-default semi-icon-close">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              focusable="false"
-              aria-hidden="true"
-            >
-              <path
-                d="M17.6568 19.7782C18.2426 20.3639 19.1924 20.3639 19.7782 19.7782C20.3639 19.1924 20.3639 18.2426 19.7782 17.6568L14.1213 12L19.7782 6.34313C20.3639 5.75734 20.3639 4.8076 19.7782 4.22181C19.1924 3.63602 18.2426 3.63602 17.6568 4.22181L12 9.87866L6.34313 4.22181C5.75734 3.63602 4.8076 3.63602 4.22181 4.22181C3.63602 4.8076 3.63602 5.75734 4.22181 6.34313L9.87866 12L4.22181 17.6568C3.63602 18.2426 3.63602 19.1924 4.22181 19.7782C4.8076 20.3639 5.75734 20.3639 6.34313 19.7782L12 14.1213L17.6568 19.7782Z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </span>
-        </div>
-      </div>
-    ));
-  }
-
-  // 发起群聊布局：群头像（预览 + 修改头像）+ 群名（必填）+ 选人。
-  renderCreateModal(): ReactNode {
-    const { showModal, groupName, avatarText, avatarColorIndex, optPersonnelData } =
-      this.state;
-    return (
-      <WKModal
-        size="lg"
-        className="wk-main-modal-group-create"
-        visible={showModal}
-        title={t("contacts.groupCreate.title")}
-        options={{ closable: true, maskClosable: false }}
-        onCancel={() => {
-          this.onCancel();
-        }}
-        footerConfig={{
-          onOk: () => {
-            this.onOK();
-          },
-          okText: t("contacts.common.confirm"),
-          cancelText: t("contacts.common.cancel"),
-        }}
-      >
-        <div className="group-create-body">
-          <div className="group-create-field">
-            <div className="group-create-label">
-              {t("contacts.groupCreate.avatarLabel")}
-            </div>
-            <div className="group-create-avatar-row">
-              <GroupAvatarPreview
-                avatarText={avatarText}
-                colorIndex={avatarColorIndex}
-                name={groupName}
-                size={48}
-              />
-              <span
-                className="group-create-edit-avatar"
-                onClick={() => this.setState({ showAvatarEdit: true })}
-              >
-                {t("contacts.groupCreate.editAvatar")}
-              </span>
-            </div>
-          </div>
-
-          <div className="group-create-field">
-            <div className="group-create-label group-create-required">
-              {t("contacts.groupCreate.nameLabel")}
-            </div>
-            <Input
-              value={groupName}
-              maxLength={GROUP_NAME_MAX_LENGTH}
-              placeholder={t("contacts.groupCreate.namePlaceholder")}
-              onChange={(value) => this.setState({ groupName: value })}
+          <g clipPath="url(#clip_user_add)">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M19.0796 19.8369C17.7027 17.6014 14.7559 15.5 10.4593 15.5C6.16267 15.5 3.21588 17.6014 1.83892 19.8369C1.19533 20.8817 2.10818 22 3.33535 22H17.5832C18.8104 22 19.7232 20.8817 19.0796 19.8369Z"
             />
-            <div className={`group-create-input-count ${groupName.length > GROUP_NAME_MAX_LENGTH ? "group-create-input-count--exceeded" : ""}`}>
-              {groupName.length} / {GROUP_NAME_MAX_LENGTH}
-            </div>
-          </div>
-
-          <div className="group-create-field">
-            <div className="group-create-label group-create-required">
-              {t("contacts.groupCreate.membersLabel")}
-            </div>
-            <div className="group-create-members">
-              {this.renderMemberLeft()}
-              <div className="group-create-selected">
-                <div className="organizational-group-new-right-title">
-                  {t("contacts.groupCreate.selectedCount", {
-                    values: { count: optPersonnelData.length },
-                  })}
-                </div>
-                <div className="organizational-group-new-right-body">
-                  {this.renderSelectedList()}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </WKModal>
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M14.0499 10.4204C14.5723 10.2065 15.0693 9.55774 15.2962 8.71085C15.5913 7.60959 15.5327 6.62629 14.7285 6.3203C14.6504 2.48444 13.1369 1 9.96023 1C6.7838 1 5.27021 2.48424 5.19199 6.31952C4.38589 6.62467 4.32701 7.60866 4.62233 8.7108C4.84958 9.55892 5.34768 10.2083 5.87087 10.4213C6.71146 12.5727 8.24123 14.013 9.96023 14.013C11.6795 14.013 13.2094 12.5723 14.0499 10.4204Z"
+            />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M20 1C19.4478 1 19 1.44772 19 2V4H17C16.4478 4 16 4.44772 16 5C16 5.55228 16.4478 6 17 6H19V8C19 8.55228 19.4478 9 20 9C20.5523 9 21 8.55228 21 8V6H23C23.5523 6 24 5.55228 24 5C24 4.44772 23.5523 4 23 4H21V2C21 1.44772 20.5523 1 20 1Z"
+            />
+          </g>
+          <defs>
+            <clipPath id="clip_user_add">
+              <rect width="24" height="24" fill="currentColor" />
+            </clipPath>
+          </defs>
+        </svg>
+        <div className="wk-conversation-header-mask" />
+      </>
     );
   }
 
   render(): ReactNode {
-    const { showModal, optTitle } = this.state;
-    const { showAdd, render } = this.props;
-    const isCreate =
-      this.props.action === OrganizationalGroupNewAction.createGroup;
+    const trigger = this.renderTrigger();
     return (
-      <div
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        {showAdd && (
-          <div
-            onClick={() => {
-              this.onShowModal();
-            }}
-          >
-            <svg
-              viewBox="0 0 22 22"
-              fill={WKApp.config.themeColor}
-              width="20px"
-              height="20px"
-              focusable="false"
-              aria-hidden="true"
-            >
-              <g clipPath="url(#clip_user_add)">
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M19.0796 19.8369C17.7027 17.6014 14.7559 15.5 10.4593 15.5C6.16267 15.5 3.21588 17.6014 1.83892 19.8369C1.19533 20.8817 2.10818 22 3.33535 22H17.5832C18.8104 22 19.7232 20.8817 19.0796 19.8369Z"
-                ></path>
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M14.0499 10.4204C14.5723 10.2065 15.0693 9.55774 15.2962 8.71085C15.5913 7.60959 15.5327 6.62629 14.7285 6.3203C14.6504 2.48444 13.1369 1 9.96023 1C6.7838 1 5.27021 2.48424 5.19199 6.31952C4.38589 6.62467 4.32701 7.60866 4.62233 8.7108C4.84958 9.55892 5.34768 10.2083 5.87087 10.4213C6.71146 12.5727 8.24123 14.013 9.96023 14.013C11.6795 14.013 13.2094 12.5723 14.0499 10.4204Z"
-                ></path>
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M20 1C19.4478 1 19 1.44772 19 2V4H17C16.4478 4 16 4.44772 16 5C16 5.55228 16.4478 6 17 6H19V8C19 8.55228 19.4478 9 20 9C20.5523 9 21 8.55228 21 8V6H23C23.5523 6 24 5.55228 24 5C24 4.44772 23.5523 4 23 4H21V2C21 1.44772 20.5523 1 20 1Z"
-                ></path>
-              </g>
-              <defs>
-                <clipPath id="clip_user_add">
-                  <rect width="24" height="24" fill="currentColor"></rect>
-                </clipPath>
-              </defs>
-            </svg>
-            <div className="wk-conversation-header-mask"></div>
-          </div>
-        )}
-
-        {render && (
-          <div
-            onClick={() => {
-              this.onShowModal();
-            }}
-          >
-            {render}
-          </div>
-        )}
-
-        {isCreate ? (
-          this.renderCreateModal()
-        ) : (
-          <WKModal
-            size="lg"
-            className="wk-main-modal-organizational-group-new"
-            visible={showModal}
-            options={{ closable: false, maskClosable: false }}
-            onCancel={() => {
-              this.onCancel();
-            }}
-          >
-            {this.renderMemberLeft()}
-            <div className="wk-organizational-group-new-right">
-              <div className="organizational-group-new-right-title">
-                {optTitle ? t(optTitle) : ""}
-              </div>
-              <div className="organizational-group-new-right-body">
-                {this.renderSelectedList()}
-              </div>
-              <div className="organizational-group-new-right-footer">
-                <Space spacing="medium">
-                  <Button
-                    style={{ width: 80 }}
-                    onClick={() => {
-                      this.onCancel();
-                    }}
-                  >
-                    {t("contacts.common.cancel")}
-                  </Button>
-                  <Button
-                    style={{ width: 80 }}
-                    className="wk-but-ok"
-                    theme="solid"
-                    type="primary"
-                    onClick={() => {
-                      this.onOK();
-                    }}
-                  >
-                    {t("contacts.common.confirm")}
-                  </Button>
-                </Space>
-              </div>
-            </div>
-          </WKModal>
-        )}
-
-        <GroupAvatarEditModal
-          visible={this.state.showAvatarEdit}
-          name={this.state.groupName}
-          initialAvatarText={this.state.avatarText}
-          initialColorIndex={this.state.avatarColorIndex}
-          onCancel={() => this.setState({ showAvatarEdit: false })}
-          onSave={(r) =>
-            this.setState({
-              avatarText: r.avatarText,
-              avatarColorIndex: r.colorIndex,
-              showAvatarEdit: false,
-            })
-          }
+      <div onClick={(event) => event.stopPropagation()}>
+        {trigger && <div onClick={this.open}>{trigger}</div>}
+        <GroupCreateFeature
+          props={this.props}
+          isOpen={this.state.isOpen}
+          onClose={this.close}
         />
       </div>
     );

--- a/packages/dmworkcontacts/src/bridge/groupCreate/organizationCompatibility.test.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/organizationCompatibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGroupCreateOrganizationTree,
+  collectGroupCreateOrganizationMembers,
+} from "./organizationCompatibility";
+
+describe("group create organization compatibility", () => {
+  it("keeps nested department counts and employee ordering", () => {
+    const tree = buildGroupCreateOrganizationTree([
+      {
+        dept_id: "root",
+        name: "Engineering",
+        org_id: "org-1",
+        short_no: "engineering",
+        employees: [{ employee_id: "1", employee_name: "Alice", uid: "alice" }],
+        children: [
+          {
+            dept_id: "child",
+            name: "Frontend",
+            org_id: "org-1",
+            short_no: "frontend",
+            employees: [{ employee_id: "2", employee_name: "Bob", uid: "bob" }],
+          },
+        ],
+      },
+    ]);
+
+    expect(tree[0].label).toBe("Engineering(2)");
+    expect(tree[0].children?.map((node) => node.key)).toEqual([
+      "frontend",
+      "root_1",
+    ]);
+    expect(collectGroupCreateOrganizationMembers(tree)).toEqual([
+      { uid: "bob", name: "Bob", avatar: undefined },
+      { uid: "alice", name: "Alice", avatar: undefined },
+    ]);
+  });
+});

--- a/packages/dmworkcontacts/src/bridge/groupCreate/organizationCompatibility.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/organizationCompatibility.ts
@@ -1,0 +1,123 @@
+import type { GroupCreateCandidateContact } from "./types";
+
+export interface GroupCreateOrganizationInfo {
+  name: string;
+  org_id?: string;
+  short_no?: string;
+  is_upload_logo?: number;
+}
+
+export interface GroupCreateOrganizationEmployee {
+  employee_id: string;
+  employee_name: string;
+  uid: string;
+  avatar?: string;
+}
+
+export interface GroupCreateOrganizationDepartment {
+  dept_id: string;
+  name: string;
+  org_id: string;
+  short_no: string;
+  children?: GroupCreateOrganizationDepartment[];
+  employees?: GroupCreateOrganizationEmployee[];
+}
+
+export interface GroupCreateOrganizationNode {
+  key: string;
+  label: string;
+  value: string;
+  name: string;
+  org_id?: string;
+  dept_id?: string;
+  is_department?: boolean;
+  is_employee?: boolean;
+  employee_name?: string;
+  uid?: string;
+  avatar?: string;
+  children?: GroupCreateOrganizationNode[];
+}
+
+function countDepartmentEmployees(
+  departments: GroupCreateOrganizationDepartment[]
+): number {
+  return departments.reduce((count, department) => {
+    const directEmployees = department.employees?.length ?? 0;
+    const childEmployees = department.children
+      ? countDepartmentEmployees(department.children)
+      : 0;
+    return count + directEmployees + childEmployees;
+  }, 0);
+}
+
+function employeeNode(
+  employee: GroupCreateOrganizationEmployee,
+  key: string
+): GroupCreateOrganizationNode {
+  return {
+    ...employee,
+    key,
+    label: employee.employee_name,
+    value: employee.employee_id,
+    name: employee.employee_name,
+    is_employee: true,
+  };
+}
+
+export function buildGroupCreateOrganizationTree(
+  departments: GroupCreateOrganizationDepartment[]
+): GroupCreateOrganizationNode[] {
+  return departments.map((department) => {
+    const childDepartments = buildGroupCreateOrganizationTree(
+      department.children ?? []
+    );
+    const employees = (department.employees ?? []).map((employee) =>
+      employeeNode(employee, `${department.dept_id}_${employee.employee_id}`)
+    );
+    const employeeCount =
+      (department.employees?.length ?? 0) +
+      countDepartmentEmployees(department.children ?? []);
+
+    return {
+      key: department.short_no,
+      label:
+        employeeCount > 0
+          ? `${department.name}(${employeeCount})`
+          : department.name,
+      value: department.dept_id,
+      name: department.name,
+      org_id: department.org_id,
+      dept_id: department.dept_id,
+      is_department: true,
+      children: [...childDepartments, ...employees],
+    };
+  });
+}
+
+export function collectGroupCreateOrganizationMembers(
+  nodes: GroupCreateOrganizationNode[]
+): GroupCreateCandidateContact[] {
+  return nodes.flatMap((node) => {
+    if (node.is_department) {
+      return collectGroupCreateOrganizationMembers(node.children ?? []);
+    }
+    if (node.is_employee && node.uid) {
+      return [
+        {
+          uid: node.uid,
+          name: node.employee_name ?? node.name,
+          avatar: node.avatar,
+        },
+      ];
+    }
+    return [];
+  });
+}
+
+export function buildGroupCreateOrganizationRootEmployees(
+  employees: GroupCreateOrganizationEmployee[]
+): GroupCreateOrganizationNode[] {
+  return employees.map((employee) =>
+    employeeNode(employee, `uid_${employee.uid}`)
+  );
+}

--- a/packages/dmworkcontacts/src/bridge/groupCreate/organizationRuntimeCompatibility.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/organizationRuntimeCompatibility.ts
@@ -1,0 +1,42 @@
+import { WKApp } from "@octo/base";
+
+import {
+  buildGroupCreateOrganizationRootEmployees,
+  buildGroupCreateOrganizationTree,
+} from "./organizationCompatibility";
+import type {
+  GroupCreateOrganizationDepartment,
+  GroupCreateOrganizationEmployee,
+  GroupCreateOrganizationInfo,
+  GroupCreateOrganizationNode,
+} from "./organizationCompatibility";
+
+interface GroupCreateOrganizationResponse {
+  departments?: GroupCreateOrganizationDepartment[];
+  employees?: GroupCreateOrganizationEmployee[];
+}
+
+export async function loadGroupCreateOrganization(): Promise<{
+  info?: GroupCreateOrganizationInfo;
+  tree: GroupCreateOrganizationNode[];
+}> {
+  const joined = await WKApp.apiClient.get("/organization/joined");
+  const info = Array.isArray(joined)
+    ? (joined[0] as GroupCreateOrganizationInfo | undefined)
+    : undefined;
+  if (!info?.org_id) return { info, tree: [] };
+
+  const response = (await WKApp.apiClient.get(
+    `/organizations/${info.org_id}/department`
+  )) as GroupCreateOrganizationResponse | undefined;
+  if (!response) return { info, tree: [] };
+
+  const departments = Array.isArray(response.departments)
+    ? buildGroupCreateOrganizationTree(response.departments)
+    : [];
+  const employees = Array.isArray(response.employees)
+    ? buildGroupCreateOrganizationRootEmployees(response.employees)
+    : [];
+
+  return { info, tree: [...departments, ...employees] };
+}

--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
@@ -1,0 +1,153 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { filterGroupCreateCandidates, useGroupCreate } from "./useGroupCreate";
+
+const loadCandidates = vi.fn();
+const submitAction = vi.fn();
+
+vi.mock("./groupCreateRuntime", () => ({
+  loadGroupCreateCandidates: (...args: unknown[]) => loadCandidates(...args),
+  submitGroupCreateAction: (...args: unknown[]) => submitAction(...args),
+}));
+
+function createOptions(action: "createGroup" | "addMember" = "createGroup") {
+  return {
+    action,
+    channel: { channelID: "group-1", channelType: 2 },
+    isOpen: true,
+    defaultCategoryId: "category-1",
+    keepSidebarTab: true,
+    notice: {
+      onError: vi.fn(),
+      onNameRequired: vi.fn(),
+      onMembersRequired: vi.fn(),
+    },
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  loadCandidates.mockReset();
+  submitAction.mockReset();
+  loadCandidates.mockResolvedValue([
+    { uid: "alice", name: "Alice" },
+    { uid: "bot", name: "Octo Bot", robot: true },
+  ]);
+  submitAction.mockResolvedValue(undefined);
+});
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => ReactDOM.unmountComponentAtNode(container));
+  container.remove();
+});
+
+function renderGroupCreateHook(options: ReturnType<typeof createOptions>) {
+  let current: ReturnType<typeof useGroupCreate> | undefined;
+  function Harness() {
+    current = useGroupCreate(options);
+    return null;
+  }
+  act(() => ReactDOM.render(<Harness />, container));
+  return {
+    get current() {
+      if (!current) throw new Error("Hook did not render");
+      return current;
+    },
+  };
+}
+
+async function flushLoad() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("useGroupCreate", () => {
+  it("filters candidates without changing the candidate order", () => {
+    const candidates = [
+      { uid: "alice", name: "Alice" },
+      { uid: "bob", name: "Bob" },
+    ];
+    expect(filterGroupCreateCandidates(candidates, "LI")).toEqual([
+      candidates[0],
+    ]);
+  });
+
+  it("keeps name validation before member validation", async () => {
+    const options = createOptions();
+    const result = renderGroupCreateHook(options);
+
+    await flushLoad();
+    expect(result.current.candidates).toHaveLength(2);
+    await act(async () => result.current.submit());
+    expect(options.notice.onNameRequired).toHaveBeenCalledTimes(1);
+    expect(options.notice.onMembersRequired).not.toHaveBeenCalled();
+
+    act(() => result.current.setGroupName("Project Octo"));
+    await act(async () => result.current.submit());
+    expect(options.notice.onMembersRequired).toHaveBeenCalledTimes(1);
+    expect(submitAction).not.toHaveBeenCalled();
+  });
+
+  it("submits the existing create options and closes after success", async () => {
+    const options = createOptions();
+    const result = renderGroupCreateHook(options);
+
+    await flushLoad();
+    expect(result.current.candidates).toHaveLength(2);
+    act(() => {
+      result.current.setGroupName(" Project Octo ");
+      result.current.toggleMember("alice");
+      result.current.avatar.save("PO", 2);
+    });
+    await act(async () => result.current.submit());
+
+    expect(submitAction).toHaveBeenCalledWith({
+      action: "createGroup",
+      channel: options.channel,
+      selectedUids: ["alice"],
+      createOptions: {
+        categoryId: "category-1",
+        name: "Project Octo",
+        avatarText: "PO",
+        avatarColor: 2,
+      },
+      keepSidebarTab: true,
+    });
+    expect(options.onSuccess).toHaveBeenCalledTimes(1);
+    expect(options.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits add-member without create metadata", async () => {
+    const options = createOptions("addMember");
+    const result = renderGroupCreateHook(options);
+
+    await flushLoad();
+    expect(result.current.candidates).toHaveLength(2);
+    act(() => result.current.toggleMember("bot"));
+    await act(async () => result.current.submit());
+
+    expect(submitAction).toHaveBeenCalledWith({
+      action: "addMember",
+      channel: options.channel,
+      selectedUids: ["bot"],
+      createOptions: undefined,
+      keepSidebarTab: true,
+    });
+    expect(options.onSuccess).not.toHaveBeenCalled();
+    expect(options.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  loadGroupCreateCandidates,
+  submitGroupCreateAction,
+} from "./groupCreateRuntime";
+import type {
+  GroupCreateCandidateContact,
+  GroupCreateChannelInput,
+  GroupCreateSubmitAction,
+} from "./types";
+
+interface GroupCreateNotice {
+  onError: (message: string) => void;
+  onNameRequired: () => void;
+  onMembersRequired: () => void;
+}
+
+export interface UseGroupCreateOptions {
+  action: GroupCreateSubmitAction;
+  channel: GroupCreateChannelInput;
+  isOpen: boolean;
+  defaultCategoryId?: string;
+  keepSidebarTab?: boolean;
+  notice: GroupCreateNotice;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+function errorMessage(error: unknown) {
+  if (error && typeof error === "object" && "msg" in error) {
+    return String((error as { msg?: unknown }).msg || "");
+  }
+  return error instanceof Error ? error.message : "";
+}
+
+export function filterGroupCreateCandidates(
+  candidates: GroupCreateCandidateContact[],
+  keyword: string
+) {
+  const normalized = keyword.toLowerCase();
+  if (!normalized) return candidates;
+  return candidates.filter((candidate) =>
+    candidate.name.toLowerCase().includes(normalized)
+  );
+}
+
+export function useGroupCreate(options: UseGroupCreateOptions) {
+  const [candidates, setCandidates] = useState<GroupCreateCandidateContact[]>(
+    []
+  );
+  const [visibleCandidates, setVisibleCandidates] = useState<
+    GroupCreateCandidateContact[]
+  >([]);
+  const [selected, setSelected] = useState<GroupCreateCandidateContact[]>([]);
+  const [keyword, setKeyword] = useState("");
+  const [groupName, setGroupName] = useState("");
+  const [avatarText, setAvatarText] = useState("");
+  const [avatarColorIndex, setAvatarColorIndex] = useState<
+    number | undefined
+  >();
+  const [isAvatarEditorOpen, setAvatarEditorOpen] = useState(false);
+  const [isSubmitting, setSubmitting] = useState(false);
+  const loadSequence = useRef(0);
+
+  useEffect(() => {
+    if (!options.isOpen) {
+      setSelected([]);
+      setGroupName("");
+      setAvatarText("");
+      setAvatarColorIndex(undefined);
+      setAvatarEditorOpen(false);
+      return;
+    }
+
+    const sequence = ++loadSequence.current;
+    setGroupName("");
+    setAvatarText("");
+    setAvatarColorIndex(undefined);
+    setAvatarEditorOpen(false);
+
+    void loadGroupCreateCandidates({ channel: options.channel }).then(
+      (next) => {
+        if (loadSequence.current === sequence) {
+          setCandidates(next);
+          setVisibleCandidates(next);
+        }
+      }
+    );
+
+    return () => {
+      loadSequence.current += 1;
+    };
+  }, [options.channel.channelID, options.channel.channelType, options.isOpen]);
+
+  const selectedUidSet = useMemo(
+    () => new Set(selected.map((member) => member.uid)),
+    [selected]
+  );
+
+  const toggleMember = useCallback(
+    (uid: string) => {
+      setSelected((current) => {
+        if (current.some((member) => member.uid === uid)) {
+          return current.filter((member) => member.uid !== uid);
+        }
+        const candidate = candidates.find((member) => member.uid === uid);
+        return candidate ? [...current, candidate] : current;
+      });
+    },
+    [candidates]
+  );
+
+  const changeKeyword = useCallback(
+    (value: string) => {
+      setKeyword(value);
+      setVisibleCandidates(filterGroupCreateCandidates(candidates, value));
+    },
+    [candidates]
+  );
+
+  const submit = useCallback(async () => {
+    const name = groupName.trim();
+    if (options.action === "createGroup" && !name) {
+      options.notice.onNameRequired();
+      return;
+    }
+    if (selected.length === 0) {
+      options.notice.onMembersRequired();
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await submitGroupCreateAction({
+        action: options.action,
+        channel: options.channel,
+        selectedUids: selected.map((member) => member.uid),
+        createOptions:
+          options.action === "createGroup"
+            ? {
+                categoryId: options.defaultCategoryId,
+                name,
+                avatarText: avatarText || undefined,
+                avatarColor: avatarColorIndex,
+              }
+            : undefined,
+        keepSidebarTab: options.keepSidebarTab,
+      });
+      if (options.action === "createGroup") options.onSuccess?.();
+      options.onClose();
+    } catch (error) {
+      options.notice.onError(errorMessage(error));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [avatarColorIndex, avatarText, groupName, options, selected]);
+
+  return {
+    avatar: {
+      colorIndex: avatarColorIndex,
+      isEditorOpen: isAvatarEditorOpen,
+      text: avatarText,
+      closeEditor: () => setAvatarEditorOpen(false),
+      openEditor: () => setAvatarEditorOpen(true),
+      save: (text: string, colorIndex?: number) => {
+        setAvatarText(text);
+        setAvatarColorIndex(colorIndex);
+        setAvatarEditorOpen(false);
+      },
+    },
+    candidates: visibleCandidates,
+    groupName,
+    isSubmitting,
+    keyword,
+    selected,
+    selectedUidSet,
+    setGroupName,
+    setKeyword: changeKeyword,
+    submit,
+    toggleMember,
+  };
+}

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/GroupCreateDialog.stories.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/GroupCreateDialog.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+
+import GroupCreateDialog from "./index";
+
+const members = [
+  { uid: "alice", name: "Alice" },
+  { uid: "assistant", name: "Octo Assistant", robot: true },
+];
+
+const meta: Meta<typeof GroupCreateDialog> = {
+  title: "Contacts/GroupCreateDialog",
+  component: GroupCreateDialog,
+};
+export default meta;
+type Story = StoryObj<typeof GroupCreateDialog>;
+
+const common = {
+  isOpen: true,
+  copy: {
+    title: "New group chat",
+    avatarLabel: "Group avatar",
+    editAvatar: "Edit avatar",
+    nameLabel: "Group name",
+    namePlaceholder: "e.g. Project name",
+    membersLabel: "Select members",
+    confirm: "Confirm",
+    cancel: "Cancel",
+  },
+  form: {
+    groupName: "Project Octo",
+    avatarText: "PO",
+    avatarColorIndex: 1,
+    maxNameLength: 20,
+    isAvatarEditorOpen: false,
+  },
+  memberPicker: {
+    mode: "createGroup" as const,
+    candidates: members,
+    selected: [members[0]],
+    selectedUids: new Set(["alice"]),
+    keyword: "",
+    copy: {
+      searchPlaceholder: "Search",
+      selectedTitle: "1 selected",
+      confirm: "Confirm",
+      cancel: "Cancel",
+    },
+    avatarForUid: (uid: string) => `https://example.com/avatar/${uid}.png`,
+    actions: {
+      onKeywordChange: () => undefined,
+      onToggleMember: () => undefined,
+      onCancel: () => undefined,
+      onConfirm: () => undefined,
+    },
+  },
+  actions: {
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+    onGroupNameChange: () => undefined,
+    onOpenAvatarEditor: () => undefined,
+    onCloseAvatarEditor: () => undefined,
+    onSaveAvatar: () => undefined,
+  },
+};
+
+export const CreateGroup: Story = { args: { ...common, mode: "createGroup" } };
+
+export const AddMembers: Story = {
+  args: {
+    ...common,
+    mode: "addMember",
+    memberPicker: {
+      ...common.memberPicker,
+      mode: "addMember",
+      copy: { ...common.memberPicker.copy, selectedTitle: "Select contacts" },
+    },
+  },
+};
+
+export const EmptySelection: Story = {
+  args: {
+    ...common,
+    mode: "createGroup",
+    memberPicker: {
+      ...common.memberPicker,
+      selected: [],
+      selectedUids: new Set<string>(),
+      copy: { ...common.memberPicker.copy, selectedTitle: "0 selected" },
+    },
+  },
+};

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.css
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.css
@@ -1,0 +1,1 @@
+@import "../../Organizational/GroupNew/index.css";

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { Input } from "@douyinfe/semi-ui";
+
+import { GroupAvatarEditModal, GroupAvatarPreview, WKModal } from "@octo/base";
+
+import GroupMemberPicker from "../GroupMemberPicker";
+import type { GroupCreateDialogProps } from "./types";
+import "./index.css";
+
+function GroupCreateDialog({
+  mode,
+  isOpen,
+  copy,
+  form,
+  memberPicker,
+  actions,
+}: GroupCreateDialogProps) {
+  const isCreate = mode === "createGroup";
+
+  return (
+    <>
+      {isCreate ? (
+        <WKModal
+          size="lg"
+          className="wk-main-modal-group-create"
+          visible={isOpen}
+          title={copy.title}
+          options={{ closable: true, maskClosable: false }}
+          onCancel={actions.onCancel}
+          footerConfig={{
+            onOk: actions.onConfirm,
+            okText: copy.confirm,
+            cancelText: copy.cancel,
+          }}
+        >
+          <div className="group-create-body">
+            <div className="group-create-field">
+              <div className="group-create-label">{copy.avatarLabel}</div>
+              <div className="group-create-avatar-row">
+                <GroupAvatarPreview
+                  avatarText={form.avatarText}
+                  colorIndex={form.avatarColorIndex}
+                  name={form.groupName}
+                  size={48}
+                />
+                <span
+                  className="group-create-edit-avatar"
+                  onClick={actions.onOpenAvatarEditor}
+                >
+                  {copy.editAvatar}
+                </span>
+              </div>
+            </div>
+
+            <div className="group-create-field">
+              <div className="group-create-label group-create-required">
+                {copy.nameLabel}
+              </div>
+              <Input
+                value={form.groupName}
+                maxLength={form.maxNameLength}
+                placeholder={copy.namePlaceholder}
+                onChange={actions.onGroupNameChange}
+              />
+              <div
+                className={`group-create-input-count ${
+                  form.groupName.length > form.maxNameLength
+                    ? "group-create-input-count--exceeded"
+                    : ""
+                }`}
+              >
+                {form.groupName.length} / {form.maxNameLength}
+              </div>
+            </div>
+
+            <div className="group-create-field">
+              <div className="group-create-label group-create-required">
+                {copy.membersLabel}
+              </div>
+              <div className="group-create-members">
+                <GroupMemberPicker {...memberPicker} />
+              </div>
+            </div>
+          </div>
+        </WKModal>
+      ) : (
+        <WKModal
+          size="lg"
+          className="wk-main-modal-organizational-group-new"
+          visible={isOpen}
+          options={{ closable: false, maskClosable: false }}
+          onCancel={actions.onCancel}
+        >
+          <GroupMemberPicker {...memberPicker} />
+        </WKModal>
+      )}
+
+      <GroupAvatarEditModal
+        visible={form.isAvatarEditorOpen}
+        name={form.groupName}
+        initialAvatarText={form.avatarText}
+        initialColorIndex={form.avatarColorIndex}
+        onCancel={actions.onCloseAvatarEditor}
+        onSave={(result) =>
+          actions.onSaveAvatar(result.avatarText, result.colorIndex)
+        }
+      />
+    </>
+  );
+}
+
+export default GroupCreateDialog;
+export { GroupCreateDialog };
+export type { GroupCreateDialogProps } from "./types";

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/types.ts
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/types.ts
@@ -1,0 +1,32 @@
+import type { GroupMemberPickerProps } from "../GroupMemberPicker";
+
+export interface GroupCreateDialogProps {
+  mode: "createGroup" | "addMember";
+  isOpen: boolean;
+  copy: {
+    title: string;
+    avatarLabel: string;
+    editAvatar: string;
+    nameLabel: string;
+    namePlaceholder: string;
+    membersLabel: string;
+    confirm: string;
+    cancel: string;
+  };
+  form: {
+    groupName: string;
+    avatarText: string;
+    avatarColorIndex?: number;
+    maxNameLength: number;
+    isAvatarEditorOpen: boolean;
+  };
+  memberPicker: GroupMemberPickerProps;
+  actions: {
+    onCancel: () => void;
+    onConfirm: () => void;
+    onGroupNameChange: (value: string) => void;
+    onOpenAvatarEditor: () => void;
+    onCloseAvatarEditor: () => void;
+    onSaveAvatar: (avatarText: string, colorIndex?: number) => void;
+  };
+}

--- a/packages/dmworkcontacts/src/ui/GroupMemberPicker/GroupMemberPicker.stories.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupMemberPicker/GroupMemberPicker.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+
+import GroupMemberPicker from "./index";
+
+const candidates = [
+  { uid: "alice", name: "Alice" },
+  { uid: "assistant", name: "Octo Assistant", robot: true },
+  { uid: "long", name: "A very long member name used to verify truncation" },
+];
+
+const meta: Meta<typeof GroupMemberPicker> = {
+  title: "Contacts/GroupMemberPicker",
+  component: GroupMemberPicker,
+};
+export default meta;
+type Story = StoryObj<typeof GroupMemberPicker>;
+
+const common = {
+  mode: "createGroup" as const,
+  candidates,
+  selected: [],
+  selectedUids: new Set<string>(),
+  keyword: "",
+  copy: {
+    searchPlaceholder: "Search",
+    selectedTitle: "0 selected",
+    confirm: "Confirm",
+    cancel: "Cancel",
+  },
+  avatarForUid: (uid: string) => `https://example.com/avatar/${uid}.png`,
+  actions: {
+    onKeywordChange: () => undefined,
+    onToggleMember: () => undefined,
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+  },
+};
+
+export const Default: Story = { args: common };
+
+export const Selected: Story = {
+  args: {
+    ...common,
+    selected: candidates.slice(0, 2),
+    selectedUids: new Set(["alice", "assistant"]),
+    copy: { ...common.copy, selectedTitle: "2 selected" },
+  },
+};
+
+export const Empty: Story = {
+  args: { ...common, candidates: [], keyword: "missing" },
+};
+
+export const LongText: Story = {
+  args: {
+    ...common,
+    selected: [candidates[2]],
+    selectedUids: new Set(["long"]),
+    copy: { ...common.copy, selectedTitle: "1 selected" },
+  },
+};
+
+export const AddMembers: Story = {
+  args: {
+    ...common,
+    mode: "addMember",
+    copy: { ...common.copy, selectedTitle: "Select contacts" },
+  },
+};

--- a/packages/dmworkcontacts/src/ui/GroupMemberPicker/index.css
+++ b/packages/dmworkcontacts/src/ui/GroupMemberPicker/index.css
@@ -1,0 +1,22 @@
+@import "../../Organizational/GroupNew/index.css";
+
+.group-member-remove-icon {
+  display: flex;
+  width: var(--wk-sp-6);
+  height: var(--wk-sp-6);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--wk-r-sm);
+  color: var(--wk-icon-muted);
+  cursor: pointer;
+}
+
+.group-member-remove-icon svg {
+  width: var(--wk-sp-3);
+  height: var(--wk-sp-3);
+}
+
+.group-member-remove-icon:hover {
+  color: var(--wk-icon-hover);
+  background-color: var(--semi-color-fill-1);
+}

--- a/packages/dmworkcontacts/src/ui/GroupMemberPicker/index.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupMemberPicker/index.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import {
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Input,
+  Space,
+} from "@douyinfe/semi-ui";
+
+import WKAvatar from "@octo/base/src/Components/WKAvatar";
+import AiBadge from "@octo/base/src/Components/AiBadge";
+
+import type { GroupMemberPickerProps } from "./types";
+import "./index.css";
+
+function GroupMemberPicker({
+  mode,
+  candidates,
+  selected,
+  selectedUids,
+  keyword,
+  copy,
+  avatarForUid,
+  actions,
+}: GroupMemberPickerProps) {
+  const memberList = (
+    <div className="wk-organizational-group-new-left">
+      <div className="group-new-left-search">
+        <Input
+          className="group-new-left-search-input"
+          placeholder={copy.searchPlaceholder}
+          value={keyword}
+          showClear
+          onChange={actions.onKeywordChange}
+        />
+      </div>
+      <div className="group-new-left-main">
+        <div className="friend-opt">
+          <div className="friend-opt-main">
+            <CheckboxGroup
+              style={{ width: "100%" }}
+              value={Array.from(selectedUids)}
+              onChange={(values) => {
+                const next = new Set(values);
+                candidates.forEach((member) => {
+                  if (next.has(member.uid) !== selectedUids.has(member.uid)) {
+                    actions.onToggleMember(member.uid);
+                  }
+                });
+              }}
+            >
+              {candidates.map((member) => (
+                <Checkbox
+                  key={member.uid}
+                  value={member.uid}
+                  className="friend-opt-item"
+                >
+                  <WKAvatar
+                    src={member.avatar || avatarForUid(member.uid)}
+                    style={{
+                      width: "24px",
+                      height: "24px",
+                      marginRight: "6px",
+                    }}
+                  />
+                  <span>{member.name}</span>
+                  {member.robot && <AiBadge size="small" />}
+                </Checkbox>
+              ))}
+            </CheckboxGroup>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const selectedList = selected.map((member) => (
+    <div key={member.uid} className="opt-personnel-item">
+      <div className="user-info">
+        <WKAvatar
+          src={member.avatar || avatarForUid(member.uid)}
+          style={{ width: "24px", height: "24px", marginRight: "6px" }}
+        />
+        <span>{member.name}</span>
+        {member.robot && <AiBadge size="small" />}
+      </div>
+      <div
+        className="close-icon"
+        onClick={() => actions.onToggleMember(member.uid)}
+      >
+        <span className="group-member-remove-icon">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M17.6568 19.7782C18.2426 20.3639 19.1924 20.3639 19.7782 19.7782C20.3639 19.1924 20.3639 18.2426 19.7782 17.6568L14.1213 12L19.7782 6.34313C20.3639 5.75734 20.3639 4.8076 19.7782 4.22181C19.1924 3.63602 18.2426 3.63602 17.6568 4.22181L12 9.87866L6.34313 4.22181C5.75734 3.63602 4.8076 3.63602 4.22181 4.22181L9.87866 12L4.22181 17.6568C3.63602 18.2426 3.63602 19.1924 4.22181 19.7782C4.8076 20.3639 5.75734 20.3639 6.34313 19.7782L12 14.1213L17.6568 19.7782Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  ));
+
+  if (mode === "createGroup") {
+    return (
+      <>
+        {memberList}
+        <div className="group-create-selected">
+          <div className="organizational-group-new-right-title">
+            {copy.selectedTitle}
+          </div>
+          <div className="organizational-group-new-right-body">
+            {selectedList}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {memberList}
+      <div className="wk-organizational-group-new-right">
+        <div className="organizational-group-new-right-title">
+          {copy.selectedTitle}
+        </div>
+        <div className="organizational-group-new-right-body">
+          {selectedList}
+        </div>
+        <div className="organizational-group-new-right-footer">
+          <Space spacing="medium">
+            <Button style={{ width: 80 }} onClick={actions.onCancel}>
+              {copy.cancel}
+            </Button>
+            <Button
+              style={{ width: 80 }}
+              className="wk-but-ok"
+              theme="solid"
+              type="primary"
+              loading={false}
+              onClick={actions.onConfirm}
+            >
+              {copy.confirm}
+            </Button>
+          </Space>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default GroupMemberPicker;
+export { GroupMemberPicker };
+export type { GroupMemberPickerProps } from "./types";

--- a/packages/dmworkcontacts/src/ui/GroupMemberPicker/types.ts
+++ b/packages/dmworkcontacts/src/ui/GroupMemberPicker/types.ts
@@ -1,0 +1,22 @@
+import type { GroupCreateCandidateContact } from "../../bridge/groupCreate/types";
+
+export interface GroupMemberPickerProps {
+  mode: "createGroup" | "addMember";
+  candidates: GroupCreateCandidateContact[];
+  selected: GroupCreateCandidateContact[];
+  selectedUids: Set<string>;
+  keyword: string;
+  copy: {
+    searchPlaceholder: string;
+    selectedTitle: string;
+    confirm: string;
+    cancel: string;
+  };
+  avatarForUid: (uid: string) => string;
+  actions: {
+    onKeywordChange: (value: string) => void;
+    onToggleMember: (uid: string) => void;
+    onCancel: () => void;
+    onConfirm: () => void;
+  };
+}


### PR DESCRIPTION
Refactor the existing group creation and add-member flow into a bridge hook and props-driven UI components while preserving the current product behavior and user entry points.

## Summary

The legacy `Organizational/GroupNew` class now acts as a thin entry container. Group creation state and submission orchestration live in `useGroupCreate`, while the existing dialog and member-selection layouts are split into focused UI components. The selected-member remove icon is refined to match the approved smaller default and hover states.

## Related Issue

N/A — behavior-preserving structural refactor.

## Changes

- Extract group creation and add-member state, validation, filtering, candidate loading, and submission orchestration into `useGroupCreate`.
- Extract props-driven `GroupCreateDialog` and `GroupMemberPicker` UI components with Storybook coverage.
- Preserve the dormant organization endpoints, nested tree conversion, employee counting, and member collection as compatibility bridge helpers without restoring the hidden organization entry or triggering organization requests.
- Keep the current group avatar, group name, member selection, search, validation order, close/reset behavior, and create/add-member submission semantics.
- Reduce the selected-member remove glyph to 12px inside its existing 24px hit area, with token-based default and hover states.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkcontacts`
- New or changed user-visible entry point: no
- Shared layer touched: `bridge/` and `ui/`
- Runtime boundaries unchanged: `groupCreateRuntime.ts`, `memberUids.ts`, `types.ts`, `WKSDK`, `channelDataSource`, `SpaceService`, and `showConversation` have no diff.
- Duplicate entry point checked: yes; the organization entry remains hidden.
- Impact scope: existing create-group and add-member callers of `OrganizationalGroupNew` only.

## Testing

- [x] `pnpm --dir packages/dmworkcontacts test` — 25 tests passed.
- [x] `pnpm i18n:check` — passed with locale keys healthy.
- [x] `pnpm --dir apps/web build` — passed after rebasing onto the latest `main`.
- [x] `pnpm lint:css` — 0 errors; existing repository warnings remain.
- [x] `git diff --check` — passed.
- [x] Runtime boundary zero-diff check — passed.
- [x] Manually verified the create-group flow and selected-member remove icon in the local app.
- [ ] `pnpm --dir apps/web build-storybook` — all 10,089 modules transform successfully, then the repository-level process exits with code 132, matching the existing full Storybook build behavior.

## Checklist

- [x] I have read the repository development and contribution rules.
- [x] PR description is in English.
- [x] Added focused tests and Stories for the changed boundaries.
- [x] Documentation is not required because no public API or user workflow changed.
- [x] Ran `pnpm i18n:check` and confirmed no user-visible copy changed.
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points.
- [x] Described the bridge/UI impact scope and unchanged runtime boundaries.
- [x] Followed Conventional Commit conventions.
