### PR TITLE
feat(contacts): add pinyin search to group member picker

### DIFF
--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateSearch.test.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateSearch.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildGroupCreateSearchIndex,
+  createEmptyGroupCreateSearchIndex,
+  filterGroupCreateCandidates,
+} from "./groupCreateSearch";
+
+describe("group create candidate search", () => {
+  const candidates = [
+    { uid: "weijiaoying", name: "魏娇莹" },
+    { uid: "alice", name: "Alice" },
+  ];
+
+  it("matches Chinese, full pinyin and case-insensitive pinyin", () => {
+    const index = buildGroupCreateSearchIndex(candidates);
+
+    expect(
+      filterGroupCreateCandidates(index, "魏娇").map((item) => item.uid)
+    ).toEqual(["weijiaoying"]);
+    expect(
+      filterGroupCreateCandidates(index, "weijiao").map((item) => item.uid)
+    ).toEqual(["weijiaoying"]);
+    expect(
+      filterGroupCreateCandidates(index, "WEIJIAO").map((item) => item.uid)
+    ).toEqual(["weijiaoying"]);
+  });
+
+  it("preserves English matching, empty-query results and candidate order", () => {
+    const index = buildGroupCreateSearchIndex(candidates);
+
+    expect(filterGroupCreateCandidates(index, "ali")).toEqual([candidates[1]]);
+    expect(filterGroupCreateCandidates(index, "")).toEqual(candidates);
+    expect(filterGroupCreateCandidates(index, "missing")).toEqual([]);
+  });
+
+  it("returns no candidates before the index is ready", () => {
+    expect(
+      filterGroupCreateCandidates(createEmptyGroupCreateSearchIndex(), "alice")
+    ).toEqual([]);
+  });
+
+  it("converts 10,000 names once and reuses the index for repeated queries", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "魏娇莹" ? "weijiaoying" : name
+    );
+    const largeCandidates = Array.from({ length: 10_000 }, (_, index) => ({
+      uid: `user-${index}`,
+      name: index === 9_999 ? "魏娇莹" : `User ${index}`,
+    }));
+    const index = buildGroupCreateSearchIndex(largeCandidates, toPinyin);
+    const startedAt = performance.now();
+
+    for (let count = 0; count < 20; count += 1) {
+      expect(filterGroupCreateCandidates(index, "weijiao")).toHaveLength(1);
+    }
+
+    expect(toPinyin).toHaveBeenCalledTimes(10_000);
+    expect((performance.now() - startedAt) / 20).toBeLessThan(15);
+  });
+});

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateSearch.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateSearch.ts
@@ -1,0 +1,52 @@
+import { getPinyin } from "@octo/base/src/Utils/pinYin";
+import { toSimplized } from "@octo/base/src/Utils/t2s";
+
+import type { GroupCreateCandidateContact } from "./types";
+
+export type GroupCreatePinyinConverter = (value: string) => string;
+
+export interface GroupCreateSearchEntry {
+  candidate: GroupCreateCandidateContact;
+  searchText: string;
+}
+
+export interface GroupCreateSearchIndex {
+  entries: GroupCreateSearchEntry[];
+}
+
+function defaultPinyinConverter(value: string): string {
+  return getPinyin(toSimplized(value)).toLowerCase();
+}
+
+export function buildGroupCreateSearchIndex(
+  candidates: GroupCreateCandidateContact[],
+  toPinyin: GroupCreatePinyinConverter = defaultPinyinConverter
+): GroupCreateSearchIndex {
+  return {
+    entries: candidates.map((candidate) => {
+      const normalizedName = candidate.name.toLowerCase();
+      const pinyin = toPinyin(normalizedName).toLowerCase();
+      return {
+        candidate,
+        searchText: `${normalizedName}\n${pinyin}`,
+      };
+    }),
+  };
+}
+
+export function createEmptyGroupCreateSearchIndex(): GroupCreateSearchIndex {
+  return { entries: [] };
+}
+
+export function filterGroupCreateCandidates(
+  index: GroupCreateSearchIndex,
+  keyword: string
+): GroupCreateCandidateContact[] {
+  const normalizedKeyword = keyword.toLowerCase();
+  if (!normalizedKeyword) {
+    return index.entries.map((entry) => entry.candidate);
+  }
+  return index.entries
+    .filter((entry) => entry.searchText.includes(normalizedKeyword))
+    .map((entry) => entry.candidate);
+}

--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
@@ -5,7 +5,7 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { filterGroupCreateCandidates, useGroupCreate } from "./useGroupCreate";
+import { useGroupCreate } from "./useGroupCreate";
 
 const loadCandidates = vi.fn();
 const submitAction = vi.fn();
@@ -37,6 +37,7 @@ beforeEach(() => {
   submitAction.mockReset();
   loadCandidates.mockResolvedValue([
     { uid: "alice", name: "Alice" },
+    { uid: "weijiaoying", name: "魏娇莹" },
     { uid: "bot", name: "Octo Bot", robot: true },
   ]);
   submitAction.mockResolvedValue(undefined);
@@ -76,13 +77,14 @@ async function flushLoad() {
 }
 
 describe("useGroupCreate", () => {
-  it("filters candidates without changing the candidate order", () => {
-    const candidates = [
-      { uid: "alice", name: "Alice" },
-      { uid: "bob", name: "Bob" },
-    ];
-    expect(filterGroupCreateCandidates(candidates, "LI")).toEqual([
-      candidates[0],
+  it("filters loaded candidates by full pinyin", async () => {
+    const result = renderGroupCreateHook(createOptions());
+
+    await flushLoad();
+    act(() => result.current.setKeyword("weijiao"));
+
+    expect(result.current.candidates.map((item) => item.uid)).toEqual([
+      "weijiaoying",
     ]);
   });
 
@@ -91,7 +93,7 @@ describe("useGroupCreate", () => {
     const result = renderGroupCreateHook(options);
 
     await flushLoad();
-    expect(result.current.candidates).toHaveLength(2);
+    expect(result.current.candidates).toHaveLength(3);
     await act(async () => result.current.submit());
     expect(options.notice.onNameRequired).toHaveBeenCalledTimes(1);
     expect(options.notice.onMembersRequired).not.toHaveBeenCalled();
@@ -107,7 +109,7 @@ describe("useGroupCreate", () => {
     const result = renderGroupCreateHook(options);
 
     await flushLoad();
-    expect(result.current.candidates).toHaveLength(2);
+    expect(result.current.candidates).toHaveLength(3);
     act(() => {
       result.current.setGroupName(" Project Octo ");
       result.current.toggleMember("alice");
@@ -136,7 +138,7 @@ describe("useGroupCreate", () => {
     const result = renderGroupCreateHook(options);
 
     await flushLoad();
-    expect(result.current.candidates).toHaveLength(2);
+    expect(result.current.candidates).toHaveLength(3);
     act(() => result.current.toggleMember("bot"));
     await act(async () => result.current.submit());
 

--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
@@ -4,6 +4,11 @@ import {
   loadGroupCreateCandidates,
   submitGroupCreateAction,
 } from "./groupCreateRuntime";
+import {
+  buildGroupCreateSearchIndex,
+  createEmptyGroupCreateSearchIndex,
+  filterGroupCreateCandidates,
+} from "./groupCreateSearch";
 import type {
   GroupCreateCandidateContact,
   GroupCreateChannelInput,
@@ -34,17 +39,6 @@ function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : "";
 }
 
-export function filterGroupCreateCandidates(
-  candidates: GroupCreateCandidateContact[],
-  keyword: string
-) {
-  const normalized = keyword.toLowerCase();
-  if (!normalized) return candidates;
-  return candidates.filter((candidate) =>
-    candidate.name.toLowerCase().includes(normalized)
-  );
-}
-
 export function useGroupCreate(options: UseGroupCreateOptions) {
   const [candidates, setCandidates] = useState<GroupCreateCandidateContact[]>(
     []
@@ -62,6 +56,7 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
   const [isAvatarEditorOpen, setAvatarEditorOpen] = useState(false);
   const [isSubmitting, setSubmitting] = useState(false);
   const loadSequence = useRef(0);
+  const searchIndex = useRef(createEmptyGroupCreateSearchIndex());
 
   useEffect(() => {
     if (!options.isOpen) {
@@ -82,6 +77,7 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
     void loadGroupCreateCandidates({ channel: options.channel }).then(
       (next) => {
         if (loadSequence.current === sequence) {
+          searchIndex.current = buildGroupCreateSearchIndex(next);
           setCandidates(next);
           setVisibleCandidates(next);
         }
@@ -111,13 +107,12 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
     [candidates]
   );
 
-  const changeKeyword = useCallback(
-    (value: string) => {
-      setKeyword(value);
-      setVisibleCandidates(filterGroupCreateCandidates(candidates, value));
-    },
-    [candidates]
-  );
+  const changeKeyword = useCallback((value: string) => {
+    setKeyword(value);
+    setVisibleCandidates(
+      filterGroupCreateCandidates(searchIndex.current, value)
+    );
+  }, []);
 
   const submit = useCallback(async () => {
     const name = groupName.trim();


### PR DESCRIPTION
Add cached pinyin matching to the existing create-group and add-member candidate search without changing the current UI or group runtime behavior.

## Summary

The group member picker can now find Chinese member names through their full pinyin. For example, typing `weijiao` or `WEIJIAO` matches `魏娇莹`. Candidate pinyin is generated once when the candidate list loads and reused for subsequent input, avoiding repeated conversion on every keypress.

## Related Issue

N/A — focused follow-up to the merged GroupCreate bridge/UI refactor.

## Changes

- Add a GroupCreate-specific cached search index for original-name and full-pinyin matching.
- Build the index once after group candidate loading and reuse it for every search input.
- Preserve case-insensitive Chinese, pinyin, and existing English substring matching.
- Add focused Chinese/full-pinyin/uppercase/empty/no-result/order coverage.
- Add a 10,000-candidate regression test proving pinyin conversion occurs once and repeated queries reuse the index.

## Architecture / Module Boundary

- Affected module: `packages/dmworkcontacts/src/bridge/groupCreate`
- New or changed user-visible entry point: no
- Shared layer touched: GroupCreate bridge only
- UI/styles changed: no
- Contacts directory search changed: no
- Runtime boundaries unchanged: `groupCreateRuntime.ts`, `memberUids.ts`, `types.ts`, `WKSDK`, `channelDataSource`, `SpaceService`, and `showConversation` have no diff.
- Existing candidate exclusions, ordering, selection, create-group, and add-member semantics remain unchanged.

## Testing

- [x] `pnpm --dir packages/dmworkcontacts test` — 29 tests passed.
- [x] `pnpm i18n:check` — passed with locale keys healthy.
- [x] `pnpm --dir apps/web build` — passed after rebasing onto the latest `main`.
- [x] `git diff --check` — passed.
- [x] Runtime/UI/Contacts zero-diff scope check — passed.
- [x] Manually verified Chinese, lowercase pinyin, uppercase pinyin, English, empty, and no-result searches in both create-group and add-member flows.

## Checklist

- [x] I have read the repository development and contribution rules.
- [x] PR description is in English.
- [x] Added focused tests for the changed search behavior.
- [x] Documentation is not required because no public API or workflow changed.
- [x] Ran `pnpm i18n:check` and confirmed no user-visible copy changed.
- [x] Confirmed no duplicate entry point was added.
- [x] Described the GroupCreate bridge-only impact scope and unchanged runtime boundaries.
- [x] Followed Conventional Commit conventions.
