### PR TITLE
feat(dmworksummary): pass selected chats into agent context

### DIFF
--- a/packages/dmworksummary/src/components/AgentChatPanel.tsx
+++ b/packages/dmworksummary/src/components/AgentChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from 'react';
 import { Button, Modal, Input, Toast } from '@douyinfe/semi-ui';
 import { I18nContext } from '@octo/base';
-import type { ChatMessage, AgentProgressEvent, AgentDoneEvent, AgentErrorEvent } from '../types/summary';
+import type { ChatMessage, ChatCandidate, AgentProgressEvent, AgentDoneEvent, AgentErrorEvent } from '../types/summary';
 import { agentChatStream, agentChat } from '../api/summaryApi';
 import { genSessionId } from '../utils/summaryHelpers';
 import './AgentChatPanel.css';
@@ -24,6 +24,8 @@ interface AgentChatPanelProps {
      * 第一个 chat 请求发给后端;后续轮次此字段被忽略(引用一次锁定)。
      */
     referencedTaskIds?: number[];
+    /** 用户在选择器中明确指定的默认工作对象；每轮都传给后端。 */
+    selectedChannels?: ChatCandidate[];
     /**
      * 引用锁定后由 header/入口渲染的可视化元素(如"已引用总结 A"卡片)。
      * 传入即渲染在顶部标题栏(newSession 按钮同排);为 null 或不传时不渲染。
@@ -152,12 +154,14 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
             const refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
                 ? this.props.referencedTaskIds
                 : undefined;
+            const selectedChannels = this.requestSelectedChannels();
 
             const { close } = agentChatStream({
                 session_id: sessionId,
                 message: text,
                 profile,
                 referenced_task_ids: refIds,
+                selected_channels: selectedChannels,
             }, {
                 onProgress: (evt: AgentProgressEvent) => {
                     this.setState(prev => {
@@ -235,6 +239,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 message: text,
                 profile,
                 referenced_task_ids: refIds,
+                selected_channels: this.requestSelectedChannels(),
             });
             const reply = result.reply || t('summary.common.agentPanel.noReply');
             // 上抛 sessionId 让父组件持久化(和 SSE onDone 一致)
@@ -245,6 +250,17 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         } finally {
             this.setState({ isStreaming: false });
         }
+    };
+
+    private requestSelectedChannels = () => {
+        const channels = this.props.selectedChannels;
+        if (!channels || channels.length === 0) return undefined;
+        return channels.map(({ chat_id, chat_type, name, is_archived }) => ({
+            chat_id,
+            chat_type,
+            name,
+            ...(is_archived ? { is_archived: true } : {}),
+        }));
     };
 
     private handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -782,6 +782,7 @@ export default class ChatSummaryNewModal extends Component<
                                     onSaveAsSummary={this.handleSaveAsSummary}
                                     savingSummary={this.state.savingSummary}
                                     onNewSession={this.handleNewSession}
+                                    selectedChannels={selectedChats}
                                 />
                             </div>
                         ) : (

--- a/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
@@ -36,6 +36,63 @@ describe('AgentChatPanel SSE Mode', () => {
         vi.clearAllMocks();
     });
 
+    it('forwards structured selected channels on stream and fallback requests', async () => {
+        const selectedChannels = [
+            { chat_id: 'group-1', chat_type: 'group' as const, name: '项目群', member_count: 3 },
+            { chat_id: 'group-1____thread-1', chat_type: 'thread' as const, name: '归档复盘', member_count: 2, is_archived: true },
+        ];
+        (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            expect(params.selected_channels).toEqual([
+                { chat_id: 'group-1', chat_type: 'group', name: '项目群' },
+                { chat_id: 'group-1____thread-1', chat_type: 'thread', name: '归档复盘', is_archived: true },
+            ]);
+            setImmediate(() => handlers.onError({ code: 0, message: 'transport closed', transient: true }));
+            return { close: vi.fn() };
+        });
+        (summaryApi.agentChat as any).mockResolvedValue({ reply: 'ok', session_id: 'selected-session' });
+
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel
+                    messages={[]}
+                    onSend={vi.fn()}
+                    sending={false}
+                    useStream
+                    sessionId="selected-session"
+                    profile="summary"
+                    selectedChannels={selectedChannels}
+                    onUserMessage={vi.fn()}
+                    onAssistantMessage={vi.fn()}
+                />
+            </I18nContext.Provider>,
+        );
+
+        fireEvent.change(screen.getByPlaceholderText('summary.create.agentChatPlaceholder'), { target: { value: '总结它们' } });
+        fireEvent.click(screen.getByText('summary.create.send'));
+
+        await waitFor(() => expect(summaryApi.agentChat).toHaveBeenCalledWith(expect.objectContaining({
+            selected_channels: [
+                { chat_id: 'group-1', chat_type: 'group', name: '项目群' },
+                { chat_id: 'group-1____thread-1', chat_type: 'thread', name: '归档复盘', is_archived: true },
+            ],
+        })), { timeout: 2000 });
+    });
+
+    it('keeps old request behavior when no chat is selected', async () => {
+        (summaryApi.agentChatStream as any).mockImplementation((params: any) => {
+            expect(params.selected_channels).toBeUndefined();
+            return { close: vi.fn() };
+        });
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel messages={[]} onSend={vi.fn()} sending={false} useStream sessionId="empty-selection" profile="summary" />
+            </I18nContext.Provider>,
+        );
+        fireEvent.change(screen.getByPlaceholderText('summary.create.agentChatPlaceholder'), { target: { value: '你好' } });
+        fireEvent.click(screen.getByText('summary.create.send'));
+        await waitFor(() => expect(summaryApi.agentChatStream).toHaveBeenCalled(), { timeout: 1000 });
+    });
+
     it('should handle backend error without fallback (P2.4)', async () => {
         const onUserMessage = vi.fn();
         const onAssistantMessage = vi.fn();

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -880,6 +880,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                             ? [this.state.referencedTask.task_id]
                                             : undefined
                                     }
+                                    selectedChannels={selectedChats}
                                     referenceHeader={this.renderReferenceHeader(translate)}
                                 />
                             </div>

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1040,22 +1040,25 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                     {/* Action bar */}
                     <div className="summary-workbench-actions">
                         <div className="summary-workbench-actions-left">
+                            {/* 「选择聊天」两种模式都需要:normal 用来 pick 目标聊天做总结;agent
+                                模式下用户也可能想在开始对话前先明确指定聊天(尤其归档子区依赖前端
+                                selected_channel_ids 桥接才能访问)。所以移出 mode !== 'agent' gate。
+                                参与者 / 定时是传统 workflow 特有的产品能力,保持仅 normal 显示。 */}
+                            <Button
+                                theme="borderless"
+                                icon={<IconPlus />}
+                                size="small"
+                                onClick={() => this.setState({ showChatSelector: true })}
+                                style={{ color: selectedChats.length > 0 ? "var(--semi-color-primary)" : undefined }}
+                            >
+                                {selectedChats.length > 0
+                                    ? translate("summary.create.selectedChats", { values: { count: selectedChats.length } })
+                                    : translate("summary.create.selectChat")}
+                            </Button>
                             {mode !== 'agent' && (
                                 <>
-                                {/* 选择聊天 */}
-                                <Button
-                                    theme="borderless"
-                                    icon={<IconPlus />}
-                                    size="small"
-                                    onClick={() => this.setState({ showChatSelector: true })}
-                                    style={{ color: selectedChats.length > 0 ? "var(--semi-color-primary)" : undefined }}
-                                >
-                                    {selectedChats.length > 0
-                                        ? translate("summary.create.selectedChats", { values: { count: selectedChats.length } })
-                                        : translate("summary.create.selectChat")}
-                                </Button>
-                                {/* 选择参与者：多人协作入口。打开 MemberSelectorModal 选 participants，
-                                    与「选择聊天 / 定时」并列在创建页操作栏，确保多人入口在 UI 上可达。 */}
+                                {/* 选择参与者:多人协作入口。打开 MemberSelectorModal 选 participants,
+                                    与「选择聊天 / 定时」并列在创建页操作栏,确保多人入口在 UI 上可达。 */}
                                 <Button
                                     theme="borderless"
                                     icon={<IconUserGroup />}

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -299,6 +299,8 @@ export interface AgentChatParams {
      * 后续轮次此字段被忽略(引用一次锁定)。见 CHAT-REFERENCE-BASED-DESIGN-v1。
      */
     referenced_task_ids?: number[];
+    /** 用户在 UI 中明确选定、希望 agent 默认处理的聊天。 */
+    selected_channels?: Array<Pick<ChatCandidate, 'chat_id' | 'chat_type' | 'name' | 'is_archived'>>;
 }
 
 /** Agent 对话响应（post() 已解包 data） */

--- a/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/channelConvert.test.ts
@@ -24,6 +24,9 @@ vi.mock('wukongimjssdk', () => {
                 channelManager: {
                     getChannelInfo: (ch: any) => {
                         if (ch.channelID === 'unknown-channel') return null;
+                        if (ch.channelID === 'group1____archived') {
+                            return { title: 'Archived thread', orgData: { member_count: 4, thread: { status: 2 } } };
+                        }
                         return { title: `Name of ${ch.channelID}`, orgData: { member_count: 10 } };
                     },
                 },
@@ -71,6 +74,11 @@ describe('channelToChatCandidate', () => {
     it('detects thread from channelID with ____ separator', () => {
         const result = channelToChatCandidate({ channelID: 'group1____thread1', channelType: 2 });
         expect(result.chat_type).toBe('thread');
+    });
+
+    it('preserves archived status from thread channel metadata', () => {
+        const result = channelToChatCandidate({ channelID: 'group1____archived', channelType: 5 });
+        expect(result.is_archived).toBe(true);
     });
 
     it('falls back to channelID when channelInfo is null', () => {

--- a/packages/dmworksummary/src/utils/channelConvert.ts
+++ b/packages/dmworksummary/src/utils/channelConvert.ts
@@ -30,5 +30,11 @@ export function channelToChatCandidate(channel: {
         chat_type: chatType,
         name: info?.title || channel.channelID,
         member_count: (info?.orgData as any)?.member_count ?? null,
+        // ThreadStatus.Archived = 2. The chat-entry modal builds its default
+        // candidate from WK channel metadata rather than the summary API, so
+        // preserve the archived bit here for the agent access bridge.
+        ...(chatType === 'thread' && (info?.orgData as any)?.thread?.status === 2
+            ? { is_archived: true }
+            : {}),
     };
 }


### PR DESCRIPTION
## Summary

完成“用户选定聊天 → Agent 默认工作对象”的前端闭环：Agent 模式可选择聊天，并在每轮 SSE/降级请求中发送结构化 `selected_channels`。

## Changes

- `SummaryCreatePage`：Agent 模式显示聊天选择器，并将 `selectedChats` 传入 `AgentChatPanel`。
- `ChatSummaryNewModal`：将当前频道生成的默认 candidate 传入 `AgentChatPanel`。
- `AgentChatPanel`：SSE 主链和非流式 fallback 每轮都发送：

  ```json
  {
    "selected_channels": [
      { "chat_id": "...", "chat_type": "thread", "name": "...", "is_archived": true }
    ]
  }
  ```

- `channelToChatCandidate`：从 thread channel metadata 保留归档状态，保证聊天入口打开归档子区时也能触发后端权限桥接。
- 未选择聊天时字段为 `undefined`，旧行为不变。

## Behavior

- 任务型请求：后端直接使用选定聊天，不再询问“要总结哪个聊天”。
- 能力/权限澄清问题：仍可查看完整可见范围。
- 选中归档子区：后端只对该选中 thread 做 request-scoped 放宽，并继续校验 membership。

## Verification

- Selected channel SSE + fallback 透传测试 ✅
- 空选择向后兼容测试 ✅
- Thread archived metadata 转换测试 ✅
- 相关测试：15/15 ✅
- CI Build ✅

## Dependencies

- 配套后端：Mininglamp-OSS/octo-smart-summary#164
- 数据落库：#939（已合并）
