### PR TITLE
fix(search): close search modal on bot profile card "send message" (#989)

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tabContactsHideModal.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tabContactsHideModal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// #989: 在 IM 顶部搜索里点 bot → 打开资料卡 → 点「发送消息」跳到会话后，
+// 搜索弹窗应自动关闭。修前 TabContacts 的 BotDetailModal.onChat 只关名片、
+// 没关外层搜索弹窗，因此 hideModal 必须一路从 GlobalSearchPanel 透传到
+// TabContacts 并在 onChat 里调用。这里锁死这条契约，防止后续重构悄悄拆掉。
+
+const tabContactsSrc = fs.readFileSync(
+  path.join(__dirname, "..", "tab-contacts.tsx"),
+  "utf8"
+);
+
+const panelSrc = fs.readFileSync(
+  path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "features",
+    "globalSearch",
+    "GlobalSearchPanel.tsx"
+  ),
+  "utf8"
+);
+
+describe("#989 search popup closes on bot 'send message' (source guard)", () => {
+  it("TabContactsProps declares hideModal", () => {
+    expect(
+      /interface TabContactsProps[\s\S]*?hideModal\??:\s*\(\)\s*=>\s*void/.test(
+        tabContactsSrc
+      ),
+      "TabContacts should accept a hideModal prop"
+    ).toBe(true);
+  });
+
+  it("TabContacts.BotDetailModal.onChat invokes this.props.hideModal", () => {
+    const onChatMatch = tabContactsSrc.match(
+      /<BotDetailModal[\s\S]*?onChat=\{\(channel\)\s*=>\s*\{([\s\S]*?)\}\}/
+    );
+    expect(onChatMatch, "BotDetailModal.onChat block should exist").toBeTruthy();
+    const body = onChatMatch![1];
+    expect(
+      /this\.props\.hideModal\?\.\(\)/.test(body),
+      "onChat must call hideModal() so the outer search WKModal dismisses"
+    ).toBe(true);
+  });
+
+  it("GlobalSearchPanel forwards hideModal to TabContacts", () => {
+    const match = panelSrc.match(/<TabContacts[\s\S]*?\/>/);
+    expect(match, "TabContacts usage should exist in GlobalSearchPanel").toBeTruthy();
+    expect(
+      /hideModal=\{this\.props\.hideModal\}/.test(match![0]),
+      "GlobalSearchPanel must thread hideModal down to TabContacts"
+    ).toBe(true);
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
@@ -15,6 +15,8 @@ interface TabContactsProps {
     keyword?: string;
     friends?: any[];
     onClick?: (item: any) => void;
+    // #989: bot 名片"发送消息"跳转会话后，外层搜索弹窗需要一起关掉
+    hideModal?: () => void;
 }
 
 interface TabContactsState {
@@ -146,6 +148,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
                 onChat={(channel) => {
                     WKApp.endpoints.showConversation(channel);
                     this.setState({ botDetailVisible: false });
+                    this.props.hideModal?.();
                 }}
             />
         </div>

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -201,6 +201,7 @@ export default class GlobalSearch extends Component<
             friends={vm.searchResult?.friends}
             keyword={vm.keyword}
             onClick={onClickOf("contacts")}
+            hideModal={this.props.hideModal}
           />
         </div>
         <div className="wk-search-tabs__panel" style={panelStyle("groups")}>


### PR DESCRIPTION
## Summary

Fixes #989.

在 IM 顶部搜索里搜到某个 bot → 打开资料卡 → 点「发送消息」跳转会话后，外层搜索弹窗仍留在页面上没关。

**Root cause**：`TabContacts` 里的 `BotDetailModal.onChat` 只关掉了资料卡自己（`setState({botDetailVisible: false})`），外层 `vm.showGlobalSearch` 无人切回 `false`。

**Fix**：`GlobalSearchPanel` 已经有 `hideModal` prop（原本给 content-tab 的 `handleLocate` 用），把它继续透传到 `TabContacts`；`BotDetailModal.onChat` 在跳转 + 关名片之后再调用一次 `hideModal()`，让 `Chat/index.tsx` 里包住整个搜索的外层 `WKModal` 一起关闭。

Non-bot contacts 走的是 `onClick("contacts")` → `handleGlobalSearchClick`，路径里已经调过 `hideModal`，本次改动不动它。

## Test plan

- [x] 新增 `tabContactsHideModal.test.ts` source-level guard（`hideModal` prop 存在 + `onChat` 调用它 + `GlobalSearchPanel` 透传）
- [x] `pnpm --filter @octo/base test`：201 files / 1893 tests 全绿
- [ ] 手动复现：搜 bot → 名片 →「发送消息」→ 搜索弹窗消失，进入 DM 会话