### PR TITLE
fix(search): close search modal on bot profile card "send message" (#989)

### DIFF
--- a/apps/web/e2e-kit/_kit/mock-im-runtime/README.md
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/README.md
@@ -1,0 +1,112 @@
+# mock-im-runtime
+
+Playwright e2e-research 用的完整 IM mock 服务。install 之后 WKSDK 视为已连接、
+所有 IM 数据（会话 / 频道 / 消息 / 成员）由 seed 派生,**不发任何真实 HTTP,
+不连 WebSocket**。
+
+## 用法
+
+```typescript
+import { installMockImRuntime } from "e2e-research/shared/mock-im-runtime";
+
+await installMockImRuntime(page, {
+  currentUid: "e2e-user-1",
+  spaceId: "e2e-space-001",
+  users: [
+    { uid: "u-alice", name: "Alice" },
+    { uid: "u-bob", name: "Bob", robot: 0 },
+  ],
+  groups: [{ group_no: "g-1", name: "测试群" }],
+  conversations: [{ channelId: "g-1", channelType: 2, unread: 3, timestamp: 1783320000 }],
+  messages: [
+    {
+      channelId: "g-1",
+      channelType: 2,
+      messageSeq: 1,
+      fromUid: "u-alice",
+      content: { type: 1, text: "hi" },
+    },
+  ],
+  subscribers: [
+    { uid: "u-alice", channelId: "g-1", channelType: 2 },
+    { uid: "u-bob", channelId: "g-1", channelType: 2 },
+  ],
+});
+```
+
+Fixture (`fixtures-authed.ts`) 会在 goto '/' 之后自动装一次 **empty seed**,让 IM
+立即进入 Connected 状态；case 里再调 `installMockImRuntime` 覆盖 seed 补数据。
+
+## Seed 契约
+
+见 `seed-types.ts`,顶层字段:
+
+| 字段            | 类型                   | 说明                                     |
+| --------------- | ---------------------- | ---------------------------------------- |
+| `currentUid`    | string                 | 登录用户 uid,fake ConnectManager 用      |
+| `spaceId`       | string                 | 当前 spaceId,写入 group orgData.space_id |
+| `users`         | MockUserSeed[]         | 用户预热到 channelInfoCache              |
+| `groups`        | MockGroupSeed[]        | 群预热到 channelInfoCache                |
+| `conversations` | MockConversationSeed[] | conversationManager.sync() 返回值        |
+| `messages`      | MockMessageSeed[]      | syncMessagesCallback 数据源              |
+| `subscribers`   | MockSubscriberSeed[]   | syncSubscribersCallback 数据源           |
+
+## Baseline 侵入清单
+
+`VITE_E2E_MOCK_IM=1` 触发（dev only,prod build tree-shake）:
+
+- `src/main.tsx`
+  - 跳过 `registerImCallbacks()` (真实 provider)
+  - 挂 `window.__installMockImRuntime__ = installFakeProvider`
+- `src/features/base/providers/im-provider.tsx`
+  - 跳过 `sdk.connect()` / `sdk.disconnect()`(否则会真去建 WebSocket)
+
+`playwright.config.ts` TARGET=local 时设 `VITE_E2E_MOCK_IM=1`。
+
+## Fake Provider 覆盖的 SDK Callback
+
+| Callback                         | 数据源              | 备注                                            |
+| -------------------------------- | ------------------- | ----------------------------------------------- |
+| `syncConversationsCallback`      | seed.conversations  | 返 Conversation[]                               |
+| `syncConversationExtrasCallback` | —                   | 返 []                                           |
+| `channelInfoCallback`            | seed.groups / users | fallback (预热已覆盖大多数场景)                 |
+| `syncSubscribersCallback`        | seed.subscribers    | SDK 走标准 append + notify 流程                 |
+| `syncMessagesCallback`           | seed.messages       | 按 startMessageSeq / limit 分页派发 (Down 语义) |
+| `syncMessageExtraCallback`       | —                   | 返 []                                           |
+| `syncRemindersCallback`          | —                   | 返 []                                           |
+| `reminderDoneCallback`           | —                   | no-op                                           |
+| `messageReadedCallback`          | —                   | no-op                                           |
+
+## Spy 钩子
+
+Test 里可以断言 fake provider 收到什么调用:
+
+- `window.__mockImSyncMessageLog__`: `Array<{ channelId, channelType,
+startMessageSeq, limit, returnedSeqs }>`
+  每次 `syncMessagesCallback` 调用一条,C3 分页断言用。install 时会清空。
+- `window.__mockImSeed__`: 当前 seed（覆盖前最后一次 install 的）,调试用。
+
+## 扩展指南
+
+新 case 数据缺什么就往 seed 加。Seed 顶层字段不够就:
+
+1. 在 `seed-types.ts` 加 field
+2. 在 `fake-provider.ts` 的对应 callback 里派生
+3. 别忘了更新本 README 的 Seed 契约表
+
+如果需要模拟"IM 推送消息"（新消息实时到达）,call
+`WKSDK.shared().chatManager.notifyMessageListeners(msg)` from test 侧
+(fake ConnectManager 不主动 push,test 决定何时推)。
+
+## 已迁 case
+
+- C1 创建分组 (empty seed,只需 IM=Connected)
+- C2 创建事项 (empty seed)
+- C3 消息滚动分页 (50 messages seed,分页派发)
+- C4 @提及自动补全 (1 group + 4 subscribers)
+- C5 bot 详情二级菜单 (走 HTTP mock,IM=empty seed)
+- C6 未读徽章视觉 (3 conversations + 3 groups)
+- C7 全局搜索高亮 (走 HTTP mock,IM=empty seed)
+- C8 UI 微改动 (empty seed,复用 C1 拓扑)
+
+验证: 8 case × 10 run = 80/80 全绿 (v2.0 全 mock)。

--- a/apps/web/e2e-kit/_kit/mock-im-runtime/fake-provider.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/fake-provider.ts
@@ -1,0 +1,241 @@
+/**
+ * mock-im-runtime — fake WKSDK provider。
+ *
+ * 覆盖 WKSDK.shared().config.provider 的全部 *Callback,数据完全从 seed 派发。
+ * 不发任何真实 HTTP,不连 WebSocket。install 后 IMProvider 视为已 Connected。
+ *
+ * 与真实 provider (`src/features/base/providers/im-callbacks.ts`) 的关系:
+ *   - 真实 provider 走 HTTP + SDK 内部推送
+ *   - fake provider 走 seed → 直接构造 SDK model 实例返回
+ *   - 唯一 subclass 关系:两者产出的 model 通过同一套 model 类 (ChannelInfo /
+ *     Conversation / Message 等),所以业务 selector / listener 对二者透明。
+ *
+ * install 流程 (main.tsx 里 VITE_E2E_MOCK_IM=1 触发):
+ *   1. WKSDK.shared().config.provider = fakeProvider(seed)
+ *   2. WKSDK.shared().connectManager.status = Connected
+ *   3. queueMicrotask(() => notifyConnectStatusListeners(0))
+ *      让 IMProvider useImConnection 里的 status listener 收到 Connected → 业务
+ *      认为已连接,"连接中"文案消失。
+ *
+ * seed 更新:test 里可以通过 window.__mockImUpdateSeed__(partial) 补数据,
+ * 但暂不实装 —— C6 用 install 一次性喂完足够。P1+ 遇到"要往已连接的 SDK 里补
+ * seed"再加。
+ */
+/* eslint-disable no-undef -- e2e code, window/globalThis available */
+/* eslint-disable @typescript-eslint/no-explicit-any -- SDK provider signature 用了大量 any */
+
+import WKSDK, {
+  Channel,
+  ChannelInfo,
+  ChannelTypeGroup,
+  ChannelTypePerson,
+  ConnectStatus,
+  Conversation,
+  Message,
+  MessageText,
+  Subscriber,
+} from "wukongimjssdk";
+import type {
+  MockConversationSeed,
+  MockGroupSeed,
+  MockMessageSeed,
+  MockSeed,
+  MockSubscriberSeed,
+  MockUserSeed,
+} from "./seed-types";
+
+function groupToChannelInfo(g: MockGroupSeed, spaceId: string): ChannelInfo {
+  const info = new ChannelInfo();
+  info.channel = new Channel(g.group_no, ChannelTypeGroup);
+  info.title = g.name;
+  info.mute = g.mute === 1;
+  info.top = g.top === 1;
+  info.logo = g.logo && g.logo !== "" ? g.logo : `groups/${g.group_no}/avatar`;
+  const orgData: Record<string, unknown> = { ...g.extra };
+  orgData.remark = g.remark ?? "";
+  orgData.displayName = g.remark && g.remark !== "" ? g.remark : g.name;
+  orgData.space_id = spaceId;
+  info.orgData = orgData;
+  return info;
+}
+
+function userToChannelInfo(u: MockUserSeed): ChannelInfo {
+  const info = new ChannelInfo();
+  info.channel = new Channel(u.uid, ChannelTypePerson);
+  info.title = u.name;
+  info.logo = u.logo && u.logo !== "" ? u.logo : `users/${u.uid}/avatar`;
+  const orgData: Record<string, unknown> = { ...u.extra };
+  orgData.remark = u.remark ?? "";
+  orgData.realname_verified = u.realname_verified ?? 0;
+  orgData.real_name = u.real_name ?? "";
+  orgData.short_no = u.short_no ?? "";
+  orgData.robot = u.robot ?? 0;
+  orgData.online = u.online;
+  orgData.last_offline = u.last_offline;
+  orgData.displayName = u.remark && u.remark !== "" ? u.remark : u.name;
+  info.online = u.online === 1;
+  info.lastOffline = u.last_offline ?? 0;
+  info.orgData = orgData;
+  return info;
+}
+
+function toConversation(c: MockConversationSeed): Conversation {
+  const conv = new Conversation();
+  conv.channel = new Channel(c.channelId, c.channelType);
+  conv.unread = c.unread ?? 0;
+  conv.timestamp = c.timestamp ?? 0;
+  (conv as any).extra = {
+    top: c.stick ?? 0,
+    categoryId: c.categoryId ?? null,
+    categorySort: c.categorySort ?? 0,
+  };
+  return conv;
+}
+
+function toMessage(m: MockMessageSeed): Message {
+  const msg = new Message();
+  msg.channel = new Channel(m.channelId, m.channelType);
+  msg.messageSeq = m.messageSeq;
+  msg.fromUID = m.fromUid;
+  msg.timestamp = m.timestamp ?? Math.floor(Date.now() / 1000);
+  msg.messageID = `mock-${m.channelId}-${m.messageSeq}`;
+  // clientMsgNo 必须唯一——业务(chat-selection、fold-session、reply 等)都用它做
+  // Map/Set key。SDK 默认 Message 构造赋 uuid,但 fake provider 直连 setter 后
+  // 有时不覆盖(SDK 内部初值可能就是空串或同 uuid)。这里强制唯一。
+  msg.clientMsgNo = `mock-${m.channelId}-${m.messageSeq}`;
+  // 默认走 MessageText;seed 里如果传 type=其它,test 侧自己处理 renderer
+  if (m.content.type === 1 && typeof m.content.text === "string") {
+    const c = new MessageText();
+    c.text = m.content.text;
+    msg.content = c;
+  } else {
+    (msg as any).content = m.content;
+  }
+  return msg;
+}
+
+function toSubscriber(s: MockSubscriberSeed): Subscriber {
+  const sub = new Subscriber();
+  sub.uid = s.uid;
+  (sub as any).name = s.name ?? s.uid;
+  (sub as any).role = s.role ?? 0;
+  (sub as any).version = 1; // 增量 sync 需要,SDK 内部读 lastMember.version
+  (sub as any).orgData = { ...s.orgData, robot: s.robot ?? 0 };
+  return sub;
+}
+
+/**
+ * install fake provider + short-circuit 到 Connected。
+ * 幂等:重复 install 直接覆盖旧 provider + seed（test 之间隔离用）。
+ */
+export function installFakeProvider(seed: MockSeed): void {
+  const sdk = WKSDK.shared();
+  const cm = sdk.channelManager;
+
+  // 1. groups[] / users[] 预热到 channelInfoCache — 侧栏立刻显示真名,不用等 fetch
+  for (const g of seed.groups) cm.setChannleInfoForCache(groupToChannelInfo(g, seed.spaceId));
+  for (const u of seed.users) cm.setChannleInfoForCache(userToChannelInfo(u));
+
+  // 2. subscribers 索引 —— 不预塞 subscribeCacheMap,让业务侧调 syncSubscribes
+  //    时经 syncSubscribersCallback 走 SDK 标准流程（append + notify listener）。
+  const subsByChannel = new Map<string, Subscriber[]>();
+  for (const s of seed.subscribers ?? []) {
+    const key = `${s.channelId}-${s.channelType}`;
+    const list = subsByChannel.get(key) ?? [];
+    list.push(toSubscriber(s));
+    subsByChannel.set(key, list);
+  }
+
+  // 3. 覆盖 provider 全部 callback
+  const provider = sdk.config.provider;
+
+  provider.syncConversationsCallback = async () => seed.conversations.map(toConversation);
+
+  provider.syncConversationExtrasCallback = async () => [];
+
+  provider.channelInfoCallback = async (channel: Channel): Promise<ChannelInfo> => {
+    // groups + users 已在 cache 里,fetchChannelInfo 命中 cache 后不会走 callback;
+    // 走到这里说明 seed 没覆盖 —— 返一个 fallback,避免业务写空 ChannelInfo。
+    const g = seed.groups.find((x) => x.group_no === channel.channelID);
+    if (g) return groupToChannelInfo(g, seed.spaceId);
+    const u = seed.users.find((x) => x.uid === channel.channelID);
+    if (u) return userToChannelInfo(u);
+    const fallback = new ChannelInfo();
+    fallback.channel = channel;
+    fallback.title = channel.channelID;
+    return fallback;
+  };
+
+  provider.syncSubscribersCallback = async (channel: Channel) => {
+    const key = `${channel.channelID}-${channel.channelType}`;
+    return subsByChannel.get(key) ?? [];
+  };
+
+  provider.syncMessagesCallback = async (channel: Channel, opts: any) => {
+    // 分页派发:
+    //   startSeq == 0 && endSeq == 0  → 返最新一页 (Down 语义: SDK 首屏)
+    //   startSeq > 0  && endSeq == 0  → 返 seq < startSeq 的更老一页 (SDK 翻旧页)
+    //   startSeq >= 0 && endSeq > 0   → 返 [startSeq, endSeq] 区间内的消息
+    //                                    (locate-reply-message 双向窗口, 修完 bug 后走这个分支)
+    // pullMode 忽略: 前端仍传 Down/Up, 但真实后端 server 也常 echo pullMode=0 无视传入值,
+    //                我们按 seq range 语义派发, 是对齐后端真实行为的最小 mock。
+    const limit = (opts?.limit as number) ?? 30;
+    const startSeq = (opts?.startMessageSeq as number) ?? 0;
+    const endSeq = (opts?.endMessageSeq as number) ?? 0;
+    const allForChannel = (seed.messages ?? []).filter(
+      (m) => m.channelId === channel.channelID && m.channelType === channel.channelType,
+    );
+    let filtered: typeof allForChannel;
+    if (endSeq > 0) {
+      // 双向窗口: 明确的 [startSeq, endSeq] 区间, 按 seq 升序返 (客户端会自排, 但保序更少歧义)
+      filtered = allForChannel
+        .filter((m) => m.messageSeq >= startSeq && m.messageSeq <= endSeq)
+        .sort((a, b) => a.messageSeq - b.messageSeq);
+    } else if (startSeq === 0) {
+      // 首屏: 最新一页 (新到老)
+      filtered = allForChannel.sort((a, b) => b.messageSeq - a.messageSeq);
+    } else {
+      // 翻更老: seq < startSeq (新到老)
+      filtered = allForChannel
+        .filter((m) => m.messageSeq < startSeq)
+        .sort((a, b) => b.messageSeq - a.messageSeq);
+    }
+    const page = filtered.slice(0, limit).map(toMessage);
+    // spy log 供 test 断言 (start/end/limit/返 seq 集)
+    const log = (window as unknown as { __mockImSyncMessageLog__?: Array<Record<string, unknown>> })
+      .__mockImSyncMessageLog__;
+    if (log) {
+      log.push({
+        channelId: channel.channelID,
+        channelType: channel.channelType,
+        startMessageSeq: startSeq,
+        endMessageSeq: endSeq,
+        limit,
+        returnedSeqs: page.map((m) => m.messageSeq),
+      });
+    }
+    return page;
+  };
+
+  provider.syncMessageExtraCallback = async () => [];
+  provider.syncRemindersCallback = async () => [];
+  provider.reminderDoneCallback = async () => undefined;
+  provider.messageReadedCallback = async () => undefined;
+
+  // 4. short-circuit connect → Connected
+  const conn = sdk.connectManager;
+  // SDK 内部 status 是 setter,直接赋值可能被拦;这里保留标准 assign
+  (conn as any).status = ConnectStatus.Connected;
+  // 让当前 microtask 结束、IMProvider 挂完 listener 后再 notify
+  queueMicrotask(() => conn.notifyConnectStatusListeners(0));
+
+  // 5. hook 到 window,让 baseline main.tsx 可以再拉 seed 更新（P1+）
+  (window as any).__mockImSeed__ = seed;
+  // spy: 初始化 syncMessages 调用日志（test 断言分页请求语义用）
+  if (!(window as unknown as { __mockImSyncMessageLog__?: unknown[] }).__mockImSyncMessageLog__) {
+    (window as unknown as { __mockImSyncMessageLog__: unknown[] }).__mockImSyncMessageLog__ = [];
+  } else {
+    (window as unknown as { __mockImSyncMessageLog__: unknown[] }).__mockImSyncMessageLog__.length =
+      0;
+  }
+}

--- a/apps/web/e2e-kit/_kit/mock-im-runtime/index.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/index.ts
@@ -1,0 +1,40 @@
+/**
+ * mock-im-runtime — 门面。
+ *
+ * test 侧只 import 这里的两个东西:
+ *   - `installMockImRuntime(page, seed)` — 在 Playwright test 里安装,序列化 seed
+ *     后传到浏览器,浏览器侧调 baseline main.tsx 挂到 window 上的 install 钩子。
+ *   - `MockSeed` 类型
+ *
+ * baseline main.tsx 在 DEV + VITE_E2E_MOCK_IM=1 时,
+ * import fakeProvider 并挂钩子到 `window.__installMockImRuntime__` 上。
+ */
+/* eslint-disable no-undef -- e2e code */
+
+import type { Page } from "@playwright/test";
+import type { MockSeed } from "./seed-types";
+
+export type { MockSeed } from "./seed-types";
+export type {
+  MockUserSeed,
+  MockGroupSeed,
+  MockConversationSeed,
+  MockMessageSeed,
+  MockSubscriberSeed,
+} from "./seed-types";
+
+export async function installMockImRuntime(page: Page, seed: MockSeed): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      typeof (globalThis as { __installMockImRuntime__?: unknown }).__installMockImRuntime__ ===
+      "function",
+    undefined,
+    { timeout: 10_000 },
+  );
+  await page.evaluate((seedJson: MockSeed) => {
+    const install = (globalThis as { __installMockImRuntime__?: (s: MockSeed) => void })
+      .__installMockImRuntime__;
+    if (!install) throw new Error("[mock-im-runtime] __installMockImRuntime__ 未挂载");
+    install(seedJson);
+  }, seed);
+}

--- a/apps/web/e2e-kit/_kit/mock-im-runtime/seed-types.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/seed-types.ts
@@ -1,0 +1,75 @@
+/**
+ * mock-im-runtime — Seed 数据类型。
+ *
+ * test 里喂给 installMockImRuntime 的完整数据契约。以业务 API 的 shape 命名,
+ * 而不是 SDK 内部字段,方便未来在不同 case 里复用。
+ */
+
+export interface MockUserSeed {
+  uid: string;
+  name: string;
+  logo?: string;
+  robot?: 0 | 1;
+  category?: string;
+  remark?: string;
+  realname_verified?: 0 | 1;
+  real_name?: string;
+  short_no?: string;
+  online?: 0 | 1;
+  last_offline?: number;
+  extra?: Record<string, unknown>;
+}
+
+export interface MockGroupSeed {
+  group_no: string;
+  name: string;
+  mute?: 0 | 1;
+  top?: 0 | 1;
+  logo?: string;
+  remark?: string;
+  forbidden?: 0 | 1;
+  invite?: 0 | 1;
+  extra?: Record<string, unknown>;
+}
+
+export interface MockConversationSeed {
+  channelId: string;
+  channelType: number;
+  unread?: number;
+  timestamp?: number;
+  stick?: 0 | 1;
+  categoryId?: string | null;
+  categorySort?: number;
+  spaceId?: string;
+}
+
+export interface MockMessageSeed {
+  channelId: string;
+  channelType: number;
+  messageSeq: number;
+  fromUid: string;
+  timestamp?: number;
+  content: { type: number; text?: string; [k: string]: unknown };
+}
+
+export interface MockSubscriberSeed {
+  uid: string;
+  name?: string;
+  channelId: string;
+  channelType: number;
+  role?: number;
+  robot?: 0 | 1;
+  orgData?: Record<string, unknown>;
+}
+
+export interface MockSeed {
+  /** 登录用户 uid,fake ConnectManager 会用 */
+  currentUid: string;
+  /** 当前 spaceId,给 orgData.space_id 用 */
+  spaceId: string;
+  users: MockUserSeed[];
+  groups: MockGroupSeed[];
+  conversations: MockConversationSeed[];
+  messages?: MockMessageSeed[];
+  subscribers?: MockSubscriberSeed[];
+}

--- a/apps/web/e2e-kit/case-specs/C989-search-close-on-bot-send-message.md
+++ b/apps/web/e2e-kit/case-specs/C989-search-close-on-bot-send-message.md
@@ -1,0 +1,67 @@
+# C989 顶部搜索 bot → 名片发送消息 → 外层搜索弹窗关闭
+
+## Metadata
+
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture
+- 优先级: P1 (回归守护 — 守护 issue #989 fix 不回退)
+- Tag: `@C989 @p1 @chat @chat-search @bot-detail`
+
+## 目标
+
+主线保 [issue #989](https://github.com/Mininglamp-OSS/octo-web/issues/989) 的 fix：**IM 顶部搜索命中 bot → 打开资料卡 → 点「发送消息」跳转会话时，外层搜索弹窗自动关闭。**
+
+fix 回退后现象：搜索弹窗仍然停留在页面上，覆盖住会话面板，用户要手动点关闭。
+
+## 前置条件
+
+**Fixture**: `authed`（`apps/web/e2e-kit/fixtures-authed.ts`）
+- localStorage: `octo:locale=zh-CN`、`octo:onboarding:seen=seen`、`currentSpaceId=e2e-space-001`、`{token,uid,name,app_id,short_no,role,is_work,sex,login_provider}e2etest`
+- sessionStorage: `octo.session.sid=e2etest`
+- URL: `?sid=e2etest`
+- MSW: 已 register，chat 页 bootstrap 所有 endpoint 走 baseline handler（`chat-baseline.ts`）
+- mock-im-runtime: 已 install empty seed（IM 状态视为 Connected）
+
+**Case-specific mock**（spec 内 `worker.use(...)` 追加）:
+- `POST /search/global` → 返 1 个 bot 联系人命中：`{channel_id:"e2e-bot-989", channel_type:1, channel_name:"富贵儿测试 bot", is_bot:1}`
+- `GET /users/e2e-bot-989` → 返 `{uid, name, robot:1, follow:1}`（**已加好友** → BotDetailModal 显"发送消息"分支；`follow:0` 会走"添加好友"分支不适用本 case）
+
+**Case-specific seed**（spec 内 `installMockImRuntime` 覆盖 fixture 默认）:
+- users: 一个 `{uid: "e2e-bot-989", name: "富贵儿测试 bot", robot: 1}` — 让 `isBot(uid)` 返 true，TabContacts 点击命中走"打开 BotDetailModal"分支（不是 handleGlobalSearchClick 直进 DM）
+
+## 用户操作步骤
+
+1. 从 sidebar 点「会话」进 chat 页
+2. 顶部 header 点搜索按钮（放大镜图标，无 accessible label）
+3. 搜索框输入"富贵儿"
+4. 联系人 tab 命中出现"富贵儿测试 bot"，点击命中项
+5. BotDetailModal 打开，显示 bot 名片 + 底部「发送消息」按钮
+6. 点「发送消息」按钮
+
+## 预期结果
+
+- 步骤 2 之后：搜索 dialog (`role=dialog` 内含"搜索联系人"placeholder) 可见
+- 步骤 3-4 之后：联系人命中项"富贵儿测试 bot"可见
+- 步骤 5 之后：BotDetailModal 内可见"发送消息"按钮
+- **步骤 6 之后 (核心断言)**：外层搜索 dialog **消失**（`toBeHidden`），会话切换到该 bot 的 DM
+
+## 反例
+
+- **fix 回退**（`TabContacts.BotDetailModal.onChat` 不调 `hideModal`）→ 步骤 6 之后搜索 dialog 仍然可见 → 断言 `toBeHidden` 挂
+- **`GlobalSearchPanel` 停止透传 `hideModal`**（`hideModal={undefined}`）→ 同上，`hideModal?.()` no-op
+- **点错按钮**（BotDetailModal 里点「添加好友」而不是「发送消息」）→ `getByRole("button", {name:"发送消息"})` 找不到 → 前置断言就挂，不会误绿
+
+## 视觉基准
+
+不建 pixel baseline。断言是 DOM 可见性 + 文本，不依赖像素。
+
+## 摸清依据
+
+- `packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx:150-158` — `BotDetailModal.onChat` 里的 fix 点 `this.props.hideModal?.()`
+- `packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx:200-205` — `<TabContacts hideModal={this.props.hideModal} />` 透传点
+- `packages/dmworkbase/src/Pages/Chat/index.tsx:1963-1978` — 外层 `<WKModal className="wk-global-search-modal">` 加 `<GlobalSearch hideModal={()=>vm.showGlobalSearch=false}>`
+- `packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx:167-185` — `renderItem` 里 `isBot(item.channel_id)` 决定走 BotDetailModal 分支
+- `packages/dmworkbase/src/Components/WKAvatar/index.tsx:13-16` — `isBot(uid)` = `channelInfoCache.get(uid).orgData.robot === 1` → 所以 mock 里要把 bot 用 seed 预热到 channelInfoCache
+- `packages/dmworkbase/src/Components/BotDetailModal/index.tsx:95-101` — `handleChat` 调 `onChat(new Channel(uid, ChannelTypePerson))` + `onClose()`
+- `packages/dmworkbase/src/ui/profileDetail/BotDetailView` — "发送消息"按钮由 `isFriend` 决定显示（`isFriend=true` 时 label = "发送消息"，否则 = "添加好友"），`isFriend` 来自 `BotDetailVM.state.isFriend`，源头是 `/users/:uid` 返的 `follow===1`

--- a/apps/web/e2e-kit/fixtures-authed.ts
+++ b/apps/web/e2e-kit/fixtures-authed.ts
@@ -30,6 +30,7 @@ const AUTH_KEYS_SUFFIXED = {
 
 const SPACE_STORAGE_KEY = "currentSpaceId";
 const LOCALE_STORAGE_KEY = "octo:locale";
+const ONBOARDING_STORAGE_KEY = "octo:onboarding:seen";
 const MOCK_SPACE_ID = "e2e-space-001";
 const MOCK_LOCALE = "zh-CN";
 
@@ -57,6 +58,14 @@ export const test = base.extend<Fixtures>({
         (globalThis as unknown as { localStorage: Storage }).localStorage.setItem(key, value);
       },
       { key: LOCALE_STORAGE_KEY, value: MOCK_LOCALE },
+    );
+
+    // 预置 onboarding=seen 跳过首屏 intro 动画 (WebGL <Strands> headless chrome 会 crash).
+    await page.addInitScript(
+      ({ key, value }: { key: string; value: string }) => {
+        (globalThis as unknown as { localStorage: Storage }).localStorage.setItem(key, value);
+      },
+      { key: ONBOARDING_STORAGE_KEY, value: "seen" },
     );
 
     if (target === "local") {
@@ -88,6 +97,47 @@ export const test = base.extend<Fixtures>({
         },
       );
 
+      // 每次页面加载都自动装 empty seed. 用 addInitScript 是因为 SPA 路由切页
+      // (goto /chat) 会 full reload, window scope 的 seed 被清; fixture 装的
+      // 那次只在 goto('/') 生效, 后续 spec goto 别的 URL 会掉线.
+      //
+      // 逻辑: 等 __installMockImRuntime__ hook 挂上 (index.tsx 里 await import 挂),
+      // 然后调一次 install 装 empty seed. spec 里 case-specific handler / seed
+      // 通过再 installMockImRuntime(page, {...}) 覆盖.
+      await page.addInitScript(
+        ({ currentUid, spaceId }: { currentUid: string; spaceId: string }) => {
+          type W = { __installMockImRuntime__?: (s: unknown) => void };
+          const emptySeed = {
+            currentUid,
+            spaceId,
+            users: [],
+            groups: [],
+            conversations: [],
+            messages: [],
+            subscribers: [],
+          };
+          // 轮询等 hook 挂上, 挂上就调 install. 挂不上说明 VITE_E2E_MOCK_IM=0, 静默 no-op.
+          let tries = 0;
+          const timer = setInterval(() => {
+            tries += 1;
+            const w = globalThis as unknown as W;
+            if (typeof w.__installMockImRuntime__ === "function") {
+              try {
+                w.__installMockImRuntime__(emptySeed);
+              } catch (e) {
+                // eslint-disable-next-line no-console
+                console.warn("[fixture] mock-im install failed:", e);
+              }
+              clearInterval(timer);
+            } else if (tries > 200) {
+              // 20s 都没挂上, 放弃 (mock-im 未开)
+              clearInterval(timer);
+            }
+          }, 100);
+        },
+        { currentUid: AUTH_KEYS_SUFFIXED.uid, spaceId: MOCK_SPACE_ID },
+      );
+
       await page.goto(`/?sid=${E2E_SID}`);
 
       // MSW 启动就绪信号 (仅在 VITE_E2E_MOCK=1 场景, index.tsx 会设 __MSW_READY__).
@@ -97,6 +147,26 @@ export const test = base.extend<Fixtures>({
         undefined,
         { timeout: 15_000 }
       );
+
+      // 等 fake provider install 完成 (addInitScript 的轮询已跑一次)
+      await page.waitForFunction(
+        () => !!(globalThis as unknown as { __mockImSeed__?: unknown }).__mockImSeed__,
+        undefined,
+        { timeout: 10_000 }
+      );
+
+      // fake-provider install 时 queueMicrotask 内 notify 一次连接状态,
+      // 但组件挂 listener 早晚不定 (react 首屏未必挂了 listener 就错过通知).
+      // 这里再 notify 一次, 保证 ConnectionStatus 等组件收到 Connected 事件更新 UI.
+      await page.evaluate(() => {
+        type W = { WKSDK?: { shared: () => { connectManager: { notifyConnectStatusListeners: (r: number) => void } } } };
+        const w = globalThis as unknown as W;
+        try {
+          w.WKSDK?.shared().connectManager.notifyConnectStatusListeners(0);
+        } catch {
+          /* WKSDK 未暴露 or 已 disposed, 无所谓 */
+        }
+      });
     } else {
       await page.goto("/");
     }

--- a/apps/web/e2e-kit/manifest.yaml
+++ b/apps/web/e2e-kit/manifest.yaml
@@ -5,6 +5,7 @@ kit_source: https://codex.mlamp.cn/e2e/e2e-kit
 
 # 已装 optional 层 (由 --with-optional 追加, 追加不移除)
 installed_optionals:
+  - mock-im-wksdk
 
 # 每次 sync 时更新的 template checksum, 用于判"接入方是否改过某模板文件"
 template_checksums:

--- a/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
+++ b/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
@@ -1,0 +1,80 @@
+/**
+ * chat / IM 场景 MSW baseline handlers.
+ *
+ * 覆盖 /chat 页面 bootstrap 打的所有 endpoint, 让 chat 页在 mock 模式下能起来.
+ * 数据源尽量返 empty / 单条 fixture, 让业务组件 render 到 "空态 or 单会话"
+ * 的稳定分支; 具体 case (如 C989) 再叠 handler 覆盖.
+ *
+ * 依赖: mock-im-runtime (fake-provider) 已 install (fixtures-authed.ts 里默认装 empty seed).
+ * IM connect / channel info / messages 走 fake-provider, 不走 HTTP.
+ *
+ * URL 匹配约定: 用星号通配前缀 + 模块路径 (例 star-slash-common-slash-appconfig)
+ * 兼容 apiClient.get 的多种前缀. 参考 loop-empty.ts 现有 handler 写法.
+ */
+import { http, HttpResponse } from "msw";
+
+const MOCK_UID = "e2e-user-1";
+const MOCK_SPACE_ID = "e2e-space-001";
+
+// Space fixture (单 space, 用户是 owner).
+const MOCK_SPACE = {
+  space_id: MOCK_SPACE_ID,
+  name: "E2E Space",
+  description: "",
+  logo: "",
+  create_at: "2026-07-20T10:00:00Z",
+  update_at: "2026-07-20T10:00:00Z",
+  space_no: "e2e-space",
+  owner: MOCK_UID,
+  status: 1,
+  role: 1,
+};
+
+export const chatBaselineHandlers = [
+  // === Common / config ===
+  // shape: { version, list: [{ key, name, url }] } - 见 packages/dmworkbase/src/Service/EmojiService.ts:30
+  http.get("http://localhost:3000/api/v1/common/emojis", () =>
+    HttpResponse.json({ version: 0, list: [] })
+  ),
+  http.get("*/voice/config", () =>
+    HttpResponse.json({ enable: 0, provider: "", config: {} })
+  ),
+  http.get("*/message/prohibit_words/sync", () =>
+    HttpResponse.json({ version: 0, words: [] })
+  ),
+
+  // === User / device / avatar ===
+  http.get("*/users/:uid/avatar", () =>
+    // avatar 通常返 image bytes, 但业务只关心是否 200 - 给一个空 buffer 兜底.
+    HttpResponse.arrayBuffer(new Uint8Array([]).buffer, {
+      headers: { "content-type": "image/png" },
+    })
+  ),
+  http.get("*/user/devices/:deviceId", () =>
+    // 400 表示设备未注册, App.tsx 里 syncClientMsgDeviceId 已有静默 fallback.
+    HttpResponse.json({ msg: "device not found" }, { status: 400 })
+  ),
+
+  // === Space ===
+  http.get("*/space/my", () => HttpResponse.json([MOCK_SPACE])),
+  http.get("*/spaces/:spaceId/categories", () => HttpResponse.json([])),
+  http.get("*/user/space/setting", () =>
+    // 用户在 space 里的个人设置 (通知 / 免打扰 / hidden bots 等), 空对象兜底.
+    HttpResponse.json({ mute: 0, hidden_bots: [], notify_level: 0 })
+  ),
+
+  // === Contacts / friends ===
+  http.get("*/friend/sync", () => HttpResponse.json([])),
+  http.delete("*/user/reddot/friendApply", () => HttpResponse.json({})),
+
+  // === Sidebar ===
+  http.post("*/sidebar/sync", () =>
+    HttpResponse.json({ conversations: [], groups: [], users: [] })
+  ),
+
+  // === Summary ===
+  // 空列表, 界面停在"暂无总结"稳定分支; 不返 200 会无限重试打爆 network.
+  http.get("*/summary/api/v1/summaries", () =>
+    HttpResponse.json({ code: 0, message: "ok", data: { items: [], total: 0 } })
+  ),
+];

--- a/apps/web/e2e-kit/playwright.config.ts
+++ b/apps/web/e2e-kit/playwright.config.ts
@@ -81,6 +81,8 @@ export default defineConfig({
     env: {
       // local 模式启动 MSW; test 模式走真后端不启动
       VITE_E2E_MOCK: TARGET === "local" ? "1" : "0",
+      // local 模式挂 fake IM provider (mock-im-wksdk optional)
+      VITE_E2E_MOCK_IM: TARGET === "local" ? "1" : "0",
     },
   },
 });

--- a/apps/web/e2e-kit/tests/C989-search-close-on-bot-send-message.spec.ts
+++ b/apps/web/e2e-kit/tests/C989-search-close-on-bot-send-message.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-disable no-undef */
+// C989: 顶部搜索 bot → 打开名片 → 点「发送消息」→ 断言外层搜索 modal 消失.
+// bug fix: TabContacts BotDetailModal.onChat 加 hideModal 调用.
+import { test, expect } from "../fixtures-authed";
+import { installMockImRuntime } from "../_kit/mock-im-runtime";
+
+// bot fixture: **已加好友的 bot** (issue #989 复现场景).
+//   - TabContacts.renderItem 里 isBot(uid) === true 才走"点击开 BotDetailModal"分支;
+//     isBot 是 channelInfoCache.get(uid).orgData.robot === 1 —— 所以要预热到 mock IM seed.
+//   - BotDetailVM.isFriend=true 才显示"发送消息"按钮 —— follow=1.
+const MOCK_BOT_UID = "e2e-bot-989";
+const MOCK_BOT_NAME = "富贵儿测试 bot";
+
+test("@C989 顶部搜索 bot → 名片发送消息 → 外层搜索弹窗关闭", async ({ authedPage }, testInfo) => {
+  const kf = (name: string) =>
+    testInfo.outputPath(`keyframes/${name}.png`);
+  // 补 mock-im seed: 让 isBot(botUid) 返 true (chat 点击命中走开 BotDetailModal 分支)
+  await installMockImRuntime(authedPage, {
+    currentUid: "e2e-user-1",
+    spaceId: "e2e-space-001",
+    users: [
+      {
+        uid: MOCK_BOT_UID,
+        name: MOCK_BOT_NAME,
+        robot: 1,
+      },
+    ],
+    groups: [],
+    conversations: [],
+    messages: [],
+    subscribers: [],
+  });
+
+  // 装 case-specific handler 覆盖 /search/global 返 bot 命中
+  await authedPage.evaluate(
+    ({ botUid, botName }) => {
+      type MSW = {
+        worker: { use: (...h: unknown[]) => void };
+        http: { get: (u: string, h: unknown) => unknown; post: (u: string, h: unknown) => unknown };
+        HttpResponse: { json: (b: unknown) => unknown };
+      };
+      const w = globalThis as unknown as { __msw?: MSW };
+      if (!w.__msw) throw new Error("MSW not ready");
+      const { worker, http: h, HttpResponse: R } = w.__msw;
+      worker.use(
+        h.post("*/search/global", () =>
+          R.json({
+            friends: [
+              {
+                channel_id: botUid,
+                channel_type: 1,
+                channel_name: botName,
+                is_bot: 1,
+              },
+            ],
+            groups: [],
+            messages: [],
+            files: [],
+          })
+        ),
+        h.get(`*/users/${botUid}`, () =>
+          R.json({
+            uid: botUid,
+            name: botName,
+            robot: 1,
+            follow: 1,
+          })
+        )
+      );
+    },
+    { botUid: MOCK_BOT_UID, botName: MOCK_BOT_NAME }
+  );
+
+  // 打开 chat 页 (fixture 已 goto /), SPA-nav 到 /chat
+  await authedPage.getByRole("button", { name: "会话" }).click();
+
+  // 顶部搜索按钮 (无 accessible name, 走 header 容器 scope)
+  await authedPage.waitForSelector(".wk-chat-header-actions", { timeout: 10_000 });
+  await authedPage.screenshot({ path: kf("01-chat-page"), fullPage: true });
+  await authedPage.locator(".wk-chat-header-actions .wk-chat-header-btn").first().click();
+
+  // 搜索 dialog
+  const searchModal = authedPage.getByRole("dialog").filter({
+    has: authedPage.getByPlaceholder(/搜索联系人/),
+  });
+  await expect(searchModal).toBeVisible({ timeout: 10_000 });
+  await searchModal.getByPlaceholder(/搜索联系人/).fill("富贵儿");
+  await authedPage.screenshot({ path: kf("02-search-hit"), fullPage: true });
+
+  // 联系人命中项 — 点开 BotDetailModal
+  const contactHit = searchModal.getByText(MOCK_BOT_NAME).first();
+  await expect(contactHit).toBeVisible({ timeout: 10_000 });
+  await contactHit.click();
+
+  // BotDetailModal (定位靠 "发送消息" 按钮)
+  const sendMsgBtn = authedPage.getByRole("button", { name: "发送消息" });
+  await expect(sendMsgBtn).toBeVisible({ timeout: 10_000 });
+  await authedPage.screenshot({ path: kf("03-bot-detail-modal"), fullPage: true });
+
+  // 点「发送消息」触发 fix 路径:
+  //   TabContacts.BotDetailModal.onChat → showConversation + setState({modal off}) + hideModal()
+  await sendMsgBtn.click();
+
+  // ⭐ 核心断言: 外层搜索 dialog 消失
+  await expect(searchModal).toBeHidden({ timeout: 5_000 });
+  await authedPage.screenshot({ path: kf("04-modal-closed"), fullPage: true });
+});

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -106,8 +106,29 @@ async function enableMocksIfE2E(): Promise<void> {
   }
 }
 
+// e2e mock: 仅在 VITE_E2E_MOCK_IM=1 时挂 fake IM provider 钩子, 让 spec 里
+// installMockImRuntime(page, seed) 能生效. DataSourceModule.init() 和
+// App.connectIM 已用同一 flag 跳过真实 IM callback / connect.
+// dev / prod 完全走 tree-shake 分支, 无副作用.
+async function enableMockImIfE2E(): Promise<void> {
+  if (import.meta.env.VITE_E2E_MOCK_IM !== "1") return;
+  try {
+    const mod = await import("../e2e-kit/_kit/mock-im-runtime/fake-provider");
+    const wksdk = await import("wukongimjssdk");
+    (window as unknown as {
+      __installMockImRuntime__: (s: unknown) => void;
+      WKSDK: typeof wksdk.WKSDK;
+    }).__installMockImRuntime__ = mod.installFakeProvider as unknown as (s: unknown) => void;
+    // 暴露 WKSDK 让 spec / fixture 直接调 shared().connectManager.notifyConnectStatusListeners 等
+    (window as unknown as { WKSDK: typeof wksdk.WKSDK }).WKSDK = wksdk.WKSDK;
+  } catch (e) {
+    console.warn("[e2e] mock-im-runtime disabled:", e);
+  }
+}
+
 async function main(): Promise<void> {
   await enableMocksIfE2E();
+  await enableMockImIfE2E();
   WKApp.shared.startup(); // app启动
 
   const container = document.getElementById("root")!;

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -3,5 +3,6 @@
 // 桥接层: handler 本体放在 apps/web/e2e-kit/msw-handlers/ (kit 约定的接入方目录),
 // 本文件 re-export 供 apps/web/src/mocks/browser.ts 消费.
 import { loopEmptyHandlers } from "../../e2e-kit/msw-handlers/loop-empty";
+import { chatBaselineHandlers } from "../../e2e-kit/msw-handlers/chat-baseline";
 
-export const handlers = [...loopEmptyHandlers];
+export const handlers = [...loopEmptyHandlers, ...chatBaselineHandlers];

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -968,6 +968,12 @@ export default class WKApp extends ProviderListener {
   }
 
   connectIM() {
+    // e2e: mock-im-runtime 已 short-circuit connect → Connected (fake-provider install 时做),
+    // 这里跳过真实 sdk.connect() 免真去建 WebSocket / 覆盖 mock 的 connect status.
+    // dev / prod 完全走 tree-shake 分支, 无副作用.
+    if (import.meta.env.VITE_E2E_MOCK_IM === "1") {
+      return;
+    }
     connectImClient({
       sdk: WKSDK.shared(),
       loginInfo: WKApp.loginInfo,

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tabContactsHideModal.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/tabContactsHideModal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// #989: 在 IM 顶部搜索里点 bot → 打开资料卡 → 点「发送消息」跳到会话后，
+// 搜索弹窗应自动关闭。修前 TabContacts 的 BotDetailModal.onChat 只关名片、
+// 没关外层搜索弹窗，因此 hideModal 必须一路从 GlobalSearchPanel 透传到
+// TabContacts 并在 onChat 里调用。这里锁死这条契约，防止后续重构悄悄拆掉。
+
+const tabContactsSrc = fs.readFileSync(
+  path.join(__dirname, "..", "tab-contacts.tsx"),
+  "utf8"
+);
+
+const panelSrc = fs.readFileSync(
+  path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "features",
+    "globalSearch",
+    "GlobalSearchPanel.tsx"
+  ),
+  "utf8"
+);
+
+describe("#989 search popup closes on bot 'send message' (source guard)", () => {
+  it("TabContactsProps declares hideModal", () => {
+    expect(
+      /interface TabContactsProps[\s\S]*?hideModal\??:\s*\(\)\s*=>\s*void/.test(
+        tabContactsSrc
+      ),
+      "TabContacts should accept a hideModal prop"
+    ).toBe(true);
+  });
+
+  it("TabContacts.BotDetailModal.onChat invokes this.props.hideModal", () => {
+    const onChatMatch = tabContactsSrc.match(
+      /<BotDetailModal[\s\S]*?onChat=\{\(channel\)\s*=>\s*\{([\s\S]*?)\}\}/
+    );
+    expect(onChatMatch, "BotDetailModal.onChat block should exist").toBeTruthy();
+    const body = onChatMatch![1];
+    expect(
+      /this\.props\.hideModal\?\.\(\)/.test(body),
+      "onChat must call hideModal() so the outer search WKModal dismisses"
+    ).toBe(true);
+  });
+
+  it("GlobalSearchPanel forwards hideModal to TabContacts", () => {
+    const match = panelSrc.match(/<TabContacts[\s\S]*?\/>/);
+    expect(match, "TabContacts usage should exist in GlobalSearchPanel").toBeTruthy();
+    expect(
+      /hideModal=\{this\.props\.hideModal\}/.test(match![0]),
+      "GlobalSearchPanel must thread hideModal down to TabContacts"
+    ).toBe(true);
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
@@ -15,6 +15,8 @@ interface TabContactsProps {
     keyword?: string;
     friends?: any[];
     onClick?: (item: any) => void;
+    // #989: bot 名片"发送消息"跳转会话后，外层搜索弹窗需要一起关掉
+    hideModal?: () => void;
 }
 
 interface TabContactsState {
@@ -146,6 +148,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
                 onChat={(channel) => {
                     WKApp.endpoints.showConversation(channel);
                     this.setState({ botDetailVisible: false });
+                    this.props.hideModal?.();
                 }}
             />
         </div>

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -201,6 +201,7 @@ export default class GlobalSearch extends Component<
             friends={vm.searchResult?.friends}
             keyword={vm.keyword}
             onClick={onClickOf("contacts")}
+            hideModal={this.props.hideModal}
           />
         </div>
         <div className="wk-search-tabs__panel" style={panelStyle("groups")}>

--- a/packages/dmworkdatasource/src/module.ts
+++ b/packages/dmworkdatasource/src/module.ts
@@ -24,6 +24,13 @@ export default class DataSourceModule implements IModule {
         WKApp.dataSource.channelDataSource = new ChannelDataSource()
         WKApp.dataSource.commonDataSource = new CommonDataSource()
 
+        // e2e: 有 mock-im-runtime 顶掉 provider callbacks 时, 不注册真实 IM callbacks,
+        // 否则 fake provider install 后再被真实 callback 覆盖回去 → SDK 又去发 HTTP.
+        // dev / prod 完全走 tree-shake 分支, 无副作用.
+        if (import.meta.env.VITE_E2E_MOCK_IM === "1") {
+            return
+        }
+
         this.setChannelInfoCallback() // 频道信息
         this.setSyncSubscribersCallback() // 订阅者同步
         this.setMessageUploadTaskCallback() // 消息上传任务


### PR DESCRIPTION
## Summary

Fixes #989.

在 IM 顶部搜索里搜到某个 bot → 打开资料卡 → 点「发送消息」跳转会话后，外层搜索弹窗仍留在页面上没关。

**Root cause**：`TabContacts` 里的 `BotDetailModal.onChat` 只关掉了资料卡自己（`setState({botDetailVisible: false})`），外层 `vm.showGlobalSearch` 无人切回 `false`。

**Fix**：`GlobalSearchPanel` 已经有 `hideModal` prop（原本给 content-tab 的 `handleLocate` 用），把它继续透传到 `TabContacts`；`BotDetailModal.onChat` 在跳转 + 关名片之后再调用一次 `hideModal()`，让 `Chat/index.tsx` 里包住整个搜索的外层 `WKModal` 一起关闭。

Non-bot contacts 走的是 `onClick("contacts")` → `handleGlobalSearchClick`，路径里已经调过 `hideModal`，本次改动不动它。

## E2E 覆盖 + Infra 投资

**Fix commit** (`715f7086`) — 4 行改动 + 3 条 source-guard 单测 (`tabContactsHideModal.test.ts`) 锁契约不被后续重构悄悄拆掉

**Infra commit** (`bf35456e`) — 顺带把 octo-web 缺失的 **IM/chat e2e 基础设施**建起来，让所有 chat 相关 e2e case 都能复用：
- kit `mock-im-wksdk` optional 装入 (`apps/web/e2e-kit/_kit/mock-im-runtime/`)
- Baseline 侵入 3 处（`VITE_E2E_MOCK_IM=1` gated，dev/prod tree-shake 干净）:
  - `apps/web/src/index.tsx` — enable mock IM hook + 暴露 WKSDK 给 spec
  - `packages/dmworkdatasource/src/module.ts` — 跳过真实 IM callback 注册
  - `packages/dmworkbase/src/App.tsx:connectIM` — 跳过真实 sdk.connect()
- chat baseline MSW handler（12 endpoint：`common/emojis`、`space/my`、`users/:uid/avatar`、`friend/sync`、`sidebar/sync`、`user/space/setting` 等）
- fixture auto-install empty seed on nav（SPA 全刷新兼容），预置 `octo:onboarding:seen=seen` 跳过 WebGL Strands

**Case**：`apps/web/e2e-kit/tests/C989-search-close-on-bot-send-message.spec.ts` — real-page seed 模式，走生产 `/chat` 页 + 顶部搜索 → BotDetailModal → 发送消息，断言外层搜索 dialog 消失。10x 稳定性 **10/10 pass, avg 8.74s** (含 trace + video + screenshot overhead)。

## Test plan

- [x] `pnpm --filter @octo/base test` — 201 files / 1893 tests 全绿（含新增 3 条 source-guard 单测）
- [x] `pnpm exec playwright test --config=apps/web/e2e-kit/playwright.config.ts C989 --repeat-each=10 --workers=1` — 10/10 pass, avg 8.74s
- [x] 证据包本地生成于 `apps/web/e2e-kit/reports/C989-search-close-20260722-1804/`（4 张关键帧 + webm + trace + report md）
- [ ] Reviewer 手动复现（可选）：`pnpm dev` + goto `/chat` → 搜索 bot → 点资料卡「发送消息」→ 观察搜索弹窗消失