### PR TITLE
feat(summary): modernize citation badge UX (reading-order + tokens + hover pin)

### DIFF
--- a/packages/dmworksummary/src/components/CitationBadge.css
+++ b/packages/dmworksummary/src/components/CitationBadge.css
@@ -1,0 +1,126 @@
+/* Citation badge (inline [n] token in summary body).
+ *
+ * Wraps a <sup> so it participates in surrounding text flow but sits slightly
+ * raised. Uses brand-tinted background so it visually anchors to the site
+ * primary color (currently near-black) rather than the previous hard-coded
+ * Ant-blue. All colors / spacing / radius come from --wk-* semantic tokens
+ * so light/dark themes track automatically (per DEVELOPMENT.md §2).
+ */
+.citation-badge {
+    display: inline-flex;
+    align-items: center;
+    background: var(--wk-brand-tint-08);
+    color: var(--wk-text-strong);
+    border-radius: var(--wk-r-xs);
+    padding: 0 var(--wk-sp-1);
+    margin-left: var(--wk-sp-0-5);
+    font-size: var(--wk-text-size-xs);
+    line-height: 1.4;
+    vertical-align: super;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+    user-select: none;
+}
+
+.citation-badge:hover,
+.citation-badge:focus-visible {
+    background: var(--wk-brand-tint-15);
+    color: var(--wk-brand-primary);
+    outline: none;
+}
+
+/* Popover content wrappers (shared by CitationBadge, CitationGroupBadge,
+ * TeamCitationBadge, and their internal message rows). Extracted from the
+ * old inline React.CSSProperties objects so tokens work + dark theme.
+ */
+.citation-popover {
+    max-width: 340px;
+    max-height: 400px;
+    padding: var(--wk-sp-2) var(--wk-sp-1);
+    overflow-y: auto;
+}
+
+.citation-popover--wide {
+    max-width: 360px;
+}
+
+.citation-mini-preview {
+    max-width: 320px;
+    padding: var(--wk-sp-2);
+}
+
+.citation-cited-msg {
+    padding: var(--wk-sp-1) var(--wk-sp-2);
+    border-left: 3px solid var(--wk-brand-primary);
+    font-size: var(--wk-text-size-base);
+    line-height: 1.5;
+    word-break: break-word;
+}
+
+.citation-context-msg {
+    padding: var(--wk-sp-1) var(--wk-sp-2);
+    font-size: var(--wk-text-size-sm);
+    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+    font-style: italic;
+    line-height: 1.5;
+    word-break: break-word;
+}
+
+.citation-msg-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: var(--wk-sp-0-5);
+}
+
+.citation-msg-sender {
+    font-weight: 600;
+    font-size: var(--wk-text-size-base);
+}
+
+.citation-msg-sender--context {
+    font-weight: 500;
+    font-size: var(--wk-text-size-sm);
+}
+
+.citation-msg-time {
+    font-size: var(--wk-text-size-sm);
+    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+}
+
+.citation-msg-time--context {
+    font-size: var(--wk-text-size-xs);
+    color: var(--wk-text-muted, rgba(28, 28, 35, 0.45));
+}
+
+.citation-msg-source {
+    font-size: var(--wk-text-size-sm);
+    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+    margin-bottom: var(--wk-sp-1);
+}
+
+.citation-msg-body {
+    font-size: var(--wk-text-size-base);
+    line-height: 1.5;
+}
+
+.citation-msg-body--context {
+    font-size: var(--wk-text-size-sm);
+    line-height: 1.5;
+}
+
+.citation-jumplink {
+    margin-top: var(--wk-sp-2);
+    padding-top: var(--wk-sp-1-5);
+    border-top: 1px solid var(--wk-brand-tint-08);
+    text-align: right;
+}
+
+.citation-jumplink-btn {
+    color: var(--wk-brand-primary);
+    font-size: var(--wk-text-size-sm);
+    cursor: pointer;
+}
+
+.citation-jumplink-btn:hover {
+    text-decoration: underline;
+}

--- a/packages/dmworksummary/src/components/CitationBadge.css
+++ b/packages/dmworksummary/src/components/CitationBadge.css
@@ -60,7 +60,7 @@
 .citation-context-msg {
     padding: var(--wk-sp-1) var(--wk-sp-2);
     font-size: var(--wk-text-size-sm);
-    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+    color: var(--wk-text-tertiary, rgba(28, 28, 35, 0.55));
     font-style: italic;
     line-height: 1.5;
     word-break: break-word;
@@ -84,17 +84,17 @@
 
 .citation-msg-time {
     font-size: var(--wk-text-size-sm);
-    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+    color: var(--wk-text-tertiary, rgba(28, 28, 35, 0.55));
 }
 
 .citation-msg-time--context {
     font-size: var(--wk-text-size-xs);
-    color: var(--wk-text-muted, rgba(28, 28, 35, 0.45));
+    color: var(--wk-text-tertiary, rgba(28, 28, 35, 0.45));
 }
 
 .citation-msg-source {
     font-size: var(--wk-text-size-sm);
-    color: var(--wk-text-muted, rgba(28, 28, 35, 0.55));
+    color: var(--wk-text-tertiary, rgba(28, 28, 35, 0.55));
     margin-bottom: var(--wk-sp-1);
 }
 

--- a/packages/dmworksummary/src/components/CitationBadge.tsx
+++ b/packages/dmworksummary/src/components/CitationBadge.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useRef, useState, useCallback, useEffect } from 'react';
 import { Popover } from '@douyinfe/semi-ui';
 import { i18n, useI18n } from '@octo/base';
 import { Channel, ChannelTypeGroup, ChannelTypePerson } from 'wukongimjssdk';
@@ -7,15 +7,33 @@ import { ShowConversationOptions } from '@octo/base/src/EndpointCommon';
 import { ChannelTypeCommunityTopic } from '@octo/base/src/Service/Const';
 import CitationText, { CitationContext } from './CitationText';
 import { CitationItem, CitationContextMessage, TeamCitationItem, MemberStatus } from '../types/summary';
+import { formatGroupLabel } from './citationFormat';
+import './CitationBadge.css';
+
+/** Hover-preview delay (ms) tuned to match Perplexity/Kimi: long enough that
+ * casual mouse traversal does not fire, short enough to feel instant when the
+ * reader stops to look. */
+const HOVER_OPEN_DELAY_MS = 400;
+const HOVER_CLOSE_DELAY_MS = 200;
 
 interface CitationBadgeProps {
     index: number;
+    /**
+     * Display index rendered inside the [n] label. When omitted, falls back
+     * to `index`. Callers pass a re-numbered value (starting at 1 in reading
+     * order) so users don't see raw pool positions like [37]. The internal
+     * `index` still keys into the citations array — see remarkCitation in
+     * CitationText for the mapping construction.
+     */
+    displayIndex?: number;
     citations: CitationItem[];
     badgeKey: string;
 }
 
 interface CitationGroupBadgeProps {
     indices: number[];
+    /** Display indices, one per original index (same length as `indices`). */
+    displayIndices?: number[];
     citations: CitationItem[];
     badgeKey: string;
 }
@@ -33,37 +51,6 @@ function resolveChannelType(channelType?: number) {
     if (channelType === 5) return ChannelTypeCommunityTopic;
     return ChannelTypeGroup;
 }
-
-const badgeStyle: React.CSSProperties = {
-    display: 'inline-flex',
-    alignItems: 'center',
-    background: 'rgba(22, 119, 255, 0.13)',
-    color: '#1677ff',
-    borderRadius: 4,
-    padding: '0 4px',
-    fontSize: 11,
-    cursor: 'pointer',
-    marginLeft: 2,
-    lineHeight: '16px',
-    verticalAlign: 'super',
-};
-
-const contextMsgStyle: React.CSSProperties = {
-    padding: '4px 8px',
-    fontSize: 12,
-    color: '#999',
-    fontStyle: 'italic',
-    lineHeight: 1.5,
-    wordBreak: 'break-word',
-};
-
-const citedMsgStyle: React.CSSProperties = {
-    padding: '4px 8px',
-    borderLeft: '3px solid #1677ff',
-    fontSize: 13,
-    lineHeight: 1.5,
-    wordBreak: 'break-word',
-};
 
 interface MergedMessage {
     sender: string;
@@ -121,12 +108,12 @@ function ContextMessages({ messages }: { messages?: CitationContextMessage[] }) 
     return (
         <>
             {messages.map((msg, i) => (
-                <div key={i} style={contextMsgStyle}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
-                        <span style={{ fontSize: 12, fontWeight: 500 }}>{msg.sender}</span>
-                        <span style={{ fontSize: 11, color: '#bbb' }}>{formatTime(msg.sent_at)}</span>
+                <div key={i} className="citation-context-msg">
+                    <div className="citation-msg-header">
+                        <span className="citation-msg-sender--context">{msg.sender}</span>
+                        <span className="citation-msg-time--context">{formatTime(msg.sent_at)}</span>
                     </div>
-                    <div>{msg.content}</div>
+                    <div className="citation-msg-body--context">{msg.content}</div>
                 </div>
             ))}
         </>
@@ -137,9 +124,9 @@ function JumpLink({ citation, badgeKey, closeKey }: { citation: CitationItem; ba
     const { t } = useI18n();
     if (!citation.channel_id || !citation.message_seq || citation.channel_type == null) return null;
     return (
-        <div style={{ marginTop: 8, paddingTop: 6, borderTop: '1px solid #f0f0f0', textAlign: 'right' }}>
+        <div className="citation-jumplink">
             <span
-                style={{ color: '#1677ff', fontSize: 12, cursor: 'pointer' }}
+                className="citation-jumplink-btn"
                 onClick={(e) => {
                     e.stopPropagation();
                     closeKey(badgeKey);
@@ -161,55 +148,129 @@ function JumpLink({ citation, badgeKey, closeKey }: { citation: CitationItem; ba
     );
 }
 
-const CitationBadge: React.FC<CitationBadgeProps> = ({ index, citations, badgeKey }) => {
+/**
+ * Custom hook: delayed hover with an "always visible when pinned" override.
+ *
+ * Click pins the popover (survives mouseleave), click again unpins. Hover
+ * shows a temporary preview that fades on mouseleave. Combines both modes into
+ * a single `visible` boolean the caller passes to Semi Popover in `custom`
+ * trigger mode.
+ */
+function useHoverPin(pinned: boolean) {
+    const [hovering, setHovering] = useState(false);
+    const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearTimers = useCallback(() => {
+        if (openTimer.current) { clearTimeout(openTimer.current); openTimer.current = null; }
+        if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+    }, []);
+
+    const onMouseEnter = useCallback(() => {
+        if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+        if (hovering || pinned) return;
+        openTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS);
+    }, [hovering, pinned]);
+
+    const onMouseLeave = useCallback(() => {
+        if (openTimer.current) { clearTimeout(openTimer.current); openTimer.current = null; }
+        if (pinned) return;
+        closeTimer.current = setTimeout(() => setHovering(false), HOVER_CLOSE_DELAY_MS);
+    }, [pinned]);
+
+    useEffect(() => () => clearTimers(), [clearTimers]);
+
+    // When pinned externally, drop the hover state so it doesn't fight the pin.
+    useEffect(() => {
+        if (pinned && hovering) setHovering(false);
+    }, [pinned, hovering]);
+
+    const visible = pinned || hovering;
+    return { visible, onMouseEnter, onMouseLeave };
+}
+
+const CitationBadge: React.FC<CitationBadgeProps> = ({ index, displayIndex, citations, badgeKey }) => {
     const { t } = useI18n();
     const { activeKey, onBadgeClick, closeKey } = useContext(CitationContext);
     const citation = citations.find(c => c.index === index);
+    const shownIndex = displayIndex ?? index;
+
+    const pinned = activeKey === badgeKey;
+    const { visible, onMouseEnter, onMouseLeave } = useHoverPin(pinned);
 
     if (!citation) {
-        return <sup style={badgeStyle}>[{index}]</sup>;
+        return <sup className="citation-badge">[{shownIndex}]</sup>;
     }
 
-    const isVisible = activeKey === badgeKey;
+    // Hover preview: compact 3-line card, no jump button. Pinned view: full
+    // context (context_before + main + context_after + jump link).
+    const previewContent = !pinned ? (
+        <div className="citation-mini-preview">
+            <div className="citation-cited-msg">
+                <div className="citation-msg-header">
+                    <span className="citation-msg-sender">{citation.sender}</span>
+                    <span className="citation-msg-time">{formatTime(citation.sent_at)}</span>
+                </div>
+                {citation.source && (
+                    <div className="citation-msg-source">
+                        {t("summary.citation.source", { values: { source: citation.source } })}
+                    </div>
+                )}
+                <div className="citation-msg-body">{citation.content}</div>
+            </div>
+        </div>
+    ) : (
+        <div className="citation-popover">
+            <ContextMessages messages={citation.context_before} />
+            <div className="citation-cited-msg">
+                <div className="citation-msg-header">
+                    <span className="citation-msg-sender">{citation.sender}</span>
+                    <span className="citation-msg-time">{formatTime(citation.sent_at)}</span>
+                </div>
+                {citation.source && (
+                    <div className="citation-msg-source">
+                        {t("summary.citation.source", { values: { source: citation.source } })}
+                    </div>
+                )}
+                <div className="citation-msg-body">{citation.content}</div>
+            </div>
+            <ContextMessages messages={citation.context_after} />
+            <JumpLink citation={citation} badgeKey={badgeKey} closeKey={closeKey} />
+        </div>
+    );
 
     return (
         <Popover
             trigger="custom"
-            visible={isVisible}
+            visible={visible}
             position="top"
             showArrow
             onClickOutSide={() => closeKey(badgeKey)}
-            content={
-                <div style={{ maxWidth: 340, padding: '8px 4px', maxHeight: 400, overflowY: 'auto' }}>
-                    <ContextMessages messages={citation.context_before} />
-                    <div style={citedMsgStyle}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
-                            <span style={{ fontWeight: 600, fontSize: 13 }}>{citation.sender}</span>
-                            <span style={{ fontSize: 12, color: '#999' }}>{formatTime(citation.sent_at)}</span>
-                        </div>
-                        {citation.source && (
-                            <div style={{ fontSize: 12, color: '#999', marginBottom: 4 }}>
-                                {t("summary.citation.source", { values: { source: citation.source } })}
-                            </div>
-                        )}
-                        <div style={{ fontSize: 13, lineHeight: 1.5 }}>{citation.content}</div>
-                    </div>
-                    <ContextMessages messages={citation.context_after} />
-                    <JumpLink citation={citation} badgeKey={badgeKey} closeKey={closeKey} />
-                </div>
-            }
+            content={previewContent}
         >
-            <sup className="citation-badge" style={badgeStyle} onClick={() => onBadgeClick(badgeKey)}>[{index}]</sup>
+            <sup
+                className="citation-badge"
+                tabIndex={0}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onClick={() => onBadgeClick(badgeKey)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onBadgeClick(badgeKey); }
+                    if (e.key === 'Escape' && pinned) { e.preventDefault(); closeKey(badgeKey); }
+                }}
+            >[{shownIndex}]</sup>
         </Popover>
     );
 };
 
-export const CitationGroupBadge: React.FC<CitationGroupBadgeProps> = ({ indices, citations, badgeKey }) => {
+export const CitationGroupBadge: React.FC<CitationGroupBadgeProps> = ({ indices, displayIndices, citations, badgeKey }) => {
     const { activeKey, onBadgeClick, closeKey } = useContext(CitationContext);
 
-    const first = indices[0];
-    const last = indices[indices.length - 1];
-    const label = `${first}-${last}`;
+    // Label uses the display indices (post-renumbering) so what the user sees
+    // matches the [n] tokens in the body. Original `indices` still key the
+    // citation lookup below.
+    const shownList = displayIndices && displayIndices.length === indices.length ? displayIndices : indices;
+    const label = formatGroupLabel(shownList);
 
     const indicesKey = indices.join(',');
     const groupCitations = useMemo(
@@ -218,36 +279,64 @@ export const CitationGroupBadge: React.FC<CitationGroupBadgeProps> = ({ indices,
     );
     const mergedMessages = useMemo(() => mergeGroupMessages(groupCitations), [groupCitations]);
 
+    const pinned = activeKey === badgeKey;
+    const { visible, onMouseEnter, onMouseLeave } = useHoverPin(pinned);
+
     if (groupCitations.length === 0) {
-        return <sup style={badgeStyle}>[{label}]</sup>;
+        return <sup className="citation-badge">[{label}]</sup>;
     }
 
-    const isVisible = activeKey === badgeKey;
     const firstCitation = groupCitations[0];
+
+    // Hover preview: show first up-to-3 cited messages (compact, no context),
+    // no jump link. Pinned view: full merged timeline + jump link.
+    const previewContent = !pinned ? (
+        <div className="citation-mini-preview">
+            {groupCitations.slice(0, 3).map((c, i) => (
+                <div key={c.message_seq ?? i} className="citation-cited-msg">
+                    <div className="citation-msg-header">
+                        <span className="citation-msg-sender">{c.sender}</span>
+                        <span className="citation-msg-time">{formatTime(c.sent_at)}</span>
+                    </div>
+                    <div className="citation-msg-body">{c.content}</div>
+                </div>
+            ))}
+        </div>
+    ) : (
+        <div className="citation-popover citation-popover--wide">
+            {mergedMessages.map((msg, i) => (
+                <div key={msg.message_seq ?? i} className={msg.cited ? 'citation-cited-msg' : 'citation-context-msg'}>
+                    <div className="citation-msg-header">
+                        <span className={msg.cited ? 'citation-msg-sender' : 'citation-msg-sender--context'}>{msg.sender}</span>
+                        <span className={msg.cited ? 'citation-msg-time' : 'citation-msg-time--context'}>{formatTime(msg.sent_at)}</span>
+                    </div>
+                    <div className={msg.cited ? 'citation-msg-body' : 'citation-msg-body--context'}>{msg.content}</div>
+                </div>
+            ))}
+            <JumpLink citation={firstCitation} badgeKey={badgeKey} closeKey={closeKey} />
+        </div>
+    );
 
     return (
         <Popover
             trigger="custom"
-            visible={isVisible}
+            visible={visible}
             position="top"
             showArrow
             onClickOutSide={() => closeKey(badgeKey)}
-            content={
-                <div style={{ maxWidth: 360, padding: '8px 4px', maxHeight: 400, overflowY: 'auto' }}>
-                    {mergedMessages.map((msg, i) => (
-                        <div key={msg.message_seq ?? i} style={msg.cited ? citedMsgStyle : contextMsgStyle}>
-                            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
-                                <span style={{ fontWeight: msg.cited ? 600 : 500, fontSize: msg.cited ? 13 : 12 }}>{msg.sender}</span>
-                                <span style={{ fontSize: 11, color: msg.cited ? '#999' : '#bbb' }}>{formatTime(msg.sent_at)}</span>
-                            </div>
-                            <div style={{ fontSize: msg.cited ? 13 : 12, lineHeight: 1.5 }}>{msg.content}</div>
-                        </div>
-                    ))}
-                    <JumpLink citation={firstCitation} badgeKey={badgeKey} closeKey={closeKey} />
-                </div>
-            }
+            content={previewContent}
         >
-            <sup className="citation-badge" style={badgeStyle} onClick={() => onBadgeClick(badgeKey)}>[{label}]</sup>
+            <sup
+                className="citation-badge"
+                tabIndex={0}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onClick={() => onBadgeClick(badgeKey)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onBadgeClick(badgeKey); }
+                    if (e.key === 'Escape' && pinned) { e.preventDefault(); closeKey(badgeKey); }
+                }}
+            >[{label}]</sup>
         </Popover>
     );
 };
@@ -264,14 +353,6 @@ interface TeamCitationBadgeProps {
     /** 历史版本详情不应使用当前成员列表展开个人报告。 */
     disableMemberPreview?: boolean;
 }
-
-const memberRowStyle: React.CSSProperties = {
-    padding: '4px 8px',
-    borderLeft: '3px solid #1677ff',
-    fontSize: 13,
-    lineHeight: 1.5,
-    wordBreak: 'break-word',
-};
 
 // TeamCitationBadge renders a clickable [Pn] reference (V5/§6.2). A team
 // citation points to a PERSON (participant). On click we match that person in
@@ -292,7 +373,7 @@ export const TeamCitationBadge: React.FC<TeamCitationBadgeProps> = ({
     const citation = teamCitations.find(c => c.index === index);
 
     if (!citation) {
-        return <sup style={badgeStyle}>[P{index}]</sup>;
+        return <sup className="citation-badge">[P{index}]</sup>;
     }
 
     // 优先用 user_id 在 members 里匹配同一成员（§6.2/Q4）。
@@ -311,9 +392,9 @@ export const TeamCitationBadge: React.FC<TeamCitationBadgeProps> = ({
             showArrow
             onClickOutSide={() => closeKey(badgeKey)}
             content={
-                <div style={{ maxWidth: 360, padding: '8px 4px', maxHeight: 400, overflowY: 'auto' }}>
-                    <div style={memberRowStyle}>
-                        <div style={{ fontWeight: 600, fontSize: 13, marginBottom: memberContent ? 4 : 0 }}>
+                <div className="citation-popover citation-popover--wide">
+                    <div className="citation-cited-msg">
+                        <div className="citation-msg-sender" style={{ marginBottom: memberContent ? 4 : 0 }}>
                             {t("summary.citation.member", { values: { name: citation.user_name } })}
                         </div>
                         {!disableMemberPreview && memberContent ? (
@@ -326,13 +407,13 @@ export const TeamCitationBadge: React.FC<TeamCitationBadgeProps> = ({
                             // OCT-15 / upstream #495：纵深防御。正常流程里 declined 成员不会被
                             // 后端写进 team_citations（GLM 评审结论），但若数据漂移让 popover
                             // 拿到一个 declined 的 [Pn]，不再误显示「等待提交」。
-                            // 复用已有 i18n key summary.confirmPage.declined（“已拒绝参与” /
-                            // “Participation declined”），不新增翻译。
-                            <div style={{ fontSize: 12, color: '#999' }}>
+                            // 复用已有 i18n key summary.confirmPage.declined（"已拒绝参与" /
+                            // "Participation declined"），不新增翻译。
+                            <div className="citation-msg-source">
                                 {t("summary.confirmPage.declined")}
                             </div>
                         ) : !disableMemberPreview ? (
-                            <div style={{ fontSize: 12, color: '#999' }}>
+                            <div className="citation-msg-source">
                                 {t("summary.detail.waitingSubmit", { values: { name: citation.user_name } })}
                             </div>
                         ) : null}
@@ -340,7 +421,7 @@ export const TeamCitationBadge: React.FC<TeamCitationBadgeProps> = ({
                 </div>
             }
         >
-            <sup className="citation-badge" style={badgeStyle} onClick={() => onBadgeClick(badgeKey)}>[P{index}]</sup>
+            <sup className="citation-badge" onClick={() => onBadgeClick(badgeKey)}>[P{index}]</sup>
         </Popover>
     );
 };

--- a/packages/dmworksummary/src/components/CitationText.tsx
+++ b/packages/dmworksummary/src/components/CitationText.tsx
@@ -7,6 +7,7 @@ import { visit } from 'unist-util-visit';
 import { useI18n } from '@octo/base';
 import CitationBadge, { CitationGroupBadge, TeamCitationBadge } from './CitationBadge';
 import { CitationItem, TeamCitationItem, MemberStatus } from '../types/summary';
+import { buildDisplayIndexMap } from './citationFormat';
 
 export interface CitationContextValue {
     activeKey: string | null;
@@ -45,14 +46,22 @@ const citationSchema = {
     tagNames: [...(defaultSchema.tagNames || []), 'citation', 'citationgroup', 'teamcitation'],
     attributes: {
         ...defaultSchema.attributes,
-        citation: ['index', 'badgekey'],
-        citationgroup: ['indices', 'badgekey'],
+        citation: ['index', 'displayindex', 'badgekey'],
+        citationgroup: ['indices', 'displayindices', 'badgekey'],
         teamcitation: ['index', 'badgekey'],
     },
 };
 
-function remarkCitation(citations: CitationItem[]) {
+/**
+ * @deprecated Use buildDisplayIndexMap from './citationFormat' — this local
+ * wrapper stays only so external callers don't break. Will be removed once
+ * SummaryVersionHistory etc. update their imports.
+ */
+export { buildDisplayIndexMap };
+
+function remarkCitation(citations: CitationItem[], displayIndexMap: Map<number, number>) {
     const getChannelId = (idx: number) => citations.find(c => c.index === idx)?.channel_id;
+    const resolveDisplay = (raw: number) => displayIndexMap.get(raw) ?? raw;
 
     return (tree: any) => {
         let occurrence = 0;
@@ -108,7 +117,11 @@ function remarkCitation(citations: CitationItem[]) {
                         type: 'citation',
                         data: {
                             hName: 'citation',
-                            hProperties: { index: ci, badgekey: `c-${ci}-${occurrence++}` },
+                            hProperties: {
+                                index: ci,
+                                displayindex: resolveDisplay(ci),
+                                badgekey: `c-${ci}-${occurrence++}`,
+                            },
                         },
                         children: [],
                     });
@@ -121,6 +134,7 @@ function remarkCitation(citations: CitationItem[]) {
                             hName: 'citationgroup',
                             hProperties: {
                                 indices: group.indices.join(','),
+                                displayindices: group.indices.map(resolveDisplay).join(','),
                                 badgekey: `cg-${firstIdx}-${lastIdx}-${occurrence++}`,
                             },
                         },
@@ -201,16 +215,21 @@ function markdownComponents(
     return {
         citation: ({ node, ...props }: any) => {
             const idx = node?.properties?.index ?? props?.index;
+            const displayIdx = node?.properties?.displayindex ?? props?.displayindex;
             const badgeKey = node?.properties?.badgekey ?? props?.badgekey ?? `c-${idx}-fallback`;
             if (idx === undefined) return null;
-            return <CitationBadge index={idx} citations={citations} badgeKey={badgeKey} />;
+            return <CitationBadge index={idx} displayIndex={displayIdx} citations={citations} badgeKey={badgeKey} />;
         },
         citationgroup: ({ node, ...props }: any) => {
             const indicesStr = node?.properties?.indices ?? props?.indices;
+            const displayIndicesStr = node?.properties?.displayindices ?? props?.displayindices;
             const badgeKey = node?.properties?.badgekey ?? props?.badgekey ?? 'cg-fallback';
             if (!indicesStr) return null;
             const indices = String(indicesStr).split(',').map(Number);
-            return <CitationGroupBadge indices={indices} citations={citations} badgeKey={badgeKey} />;
+            const displayIndices = displayIndicesStr
+                ? String(displayIndicesStr).split(',').map(Number)
+                : undefined;
+            return <CitationGroupBadge indices={indices} displayIndices={displayIndices} citations={citations} badgeKey={badgeKey} />;
         },
         teamcitation: ({ node, ...props }: any) => {
             const idx = node?.properties?.index ?? props?.index;
@@ -260,7 +279,11 @@ const CitationText: React.FC<CitationTextProps> = ({
 
     const hasCitations = !hidePlainCitations && citations && citations.length > 0;
     const hasTeamCitations = teamCitations && teamCitations.length > 0;
-    const citationPlugin = () => remarkCitation(citations);
+    // Build display-index map from the raw source (reading-order rank starting
+    // at 1) so users don't see raw pool positions like [37]. Data is unchanged
+    // — only the label the badge renders differs from the internal index.
+    const displayIndexMap = hasCitations ? buildDisplayIndexMap(normalized) : new Map<number, number>();
+    const citationPlugin = () => remarkCitation(citations, displayIndexMap);
     const remarkPlugins: any[] = [remarkGfm, remarkBreaks];
     if (hasCitations) remarkPlugins.push(citationPlugin);
     if (hasTeamCitations) remarkPlugins.push(remarkTeamCitation);

--- a/packages/dmworksummary/src/components/CitationText.tsx
+++ b/packages/dmworksummary/src/components/CitationText.tsx
@@ -52,18 +52,18 @@ const citationSchema = {
     },
 };
 
-/**
- * @deprecated Use buildDisplayIndexMap from './citationFormat' — this local
- * wrapper stays only so external callers don't break. Will be removed once
- * SummaryVersionHistory etc. update their imports.
- */
-export { buildDisplayIndexMap };
-
-function remarkCitation(citations: CitationItem[], displayIndexMap: Map<number, number>) {
+function remarkCitation(citations: CitationItem[]) {
     const getChannelId = (idx: number) => citations.find(c => c.index === idx)?.channel_id;
-    const resolveDisplay = (raw: number) => displayIndexMap.get(raw) ?? raw;
 
     return (tree: any) => {
+        // Build the reading-order display map from the visible text nodes only
+        // (visit 'text' never enters code / inlineCode), in document order — so
+        // numbering matches exactly what renders as a badge below (#1003 P1).
+        const textSegments: string[] = [];
+        visit(tree, 'text', (node: any) => { textSegments.push(node.value); });
+        const displayIndexMap = buildDisplayIndexMap(textSegments);
+        const resolveDisplay = (raw: number) => displayIndexMap.get(raw) ?? raw;
+
         let occurrence = 0;
         visit(tree, 'text', (node: any, index: number | undefined, parent: any) => {
             if (!parent || index === undefined) return;
@@ -281,9 +281,10 @@ const CitationText: React.FC<CitationTextProps> = ({
     const hasTeamCitations = teamCitations && teamCitations.length > 0;
     // Build display-index map from the raw source (reading-order rank starting
     // at 1) so users don't see raw pool positions like [37]. Data is unchanged
-    // — only the label the badge renders differs from the internal index.
-    const displayIndexMap = hasCitations ? buildDisplayIndexMap(normalized) : new Map<number, number>();
-    const citationPlugin = () => remarkCitation(citations, displayIndexMap);
+    // — only the label the badge renders differs from the internal index. The
+    // reading-order map is built inside remarkCitation from the AST text nodes
+    // (so code-span `[n]` never pollutes numbering — #1003 P1).
+    const citationPlugin = () => remarkCitation(citations);
     const remarkPlugins: any[] = [remarkGfm, remarkBreaks];
     if (hasCitations) remarkPlugins.push(citationPlugin);
     if (hasTeamCitations) remarkPlugins.push(remarkTeamCitation);

--- a/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
+++ b/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
@@ -19,11 +19,16 @@ describe('formatGroupLabel', () => {
         expect(formatGroupLabel([30, 31, 32, 33, 34, 35])).toBe('30-35');
     });
 
-    it('range uses actual first/last even when caller passes non-contiguous list', () => {
-        // The grouping upstream in remarkCitation only emits adjacent-same-channel
-        // runs, so lists are contiguous in practice — but the label routine must
-        // not rely on that.
-        expect(formatGroupLabel([2, 5, 9, 14])).toBe('2-14');
+    it('falls back to comma list when a >3 display list is non-contiguous', () => {
+        // After reading-order renumbering a group's display indices can be
+        // gapped; range form would imply members that aren't there (#1003 P2).
+        expect(formatGroupLabel([2, 5, 9, 14])).toBe('2,5,9,14');
+    });
+
+    it('falls back to comma list when a >3 display list is not ascending', () => {
+        // e.g. same-channel group whose later members were numbered earlier —
+        // range would render backwards ("4-3") which is nonsense (#1003 P2).
+        expect(formatGroupLabel([4, 1, 2, 3])).toBe('4,1,2,3');
     });
 
     it('RANGE_THRESHOLD is the documented value (guards against silent regressions)', () => {
@@ -31,65 +36,69 @@ describe('formatGroupLabel', () => {
     });
 });
 
-// P1: reading-order display renumbering. Users should never see raw pool
-// positions like [37]; the first citation encountered in the body is [1] and
-// each new raw index picks up the next display number. Repeated references to
-// the same raw index reuse the same display number.
+// P1: reading-order display renumbering. Input is the visible text-node values
+// in document order (as remarkCitation collects via visit(tree,'text',…)), so
+// `[n]` inside code is excluded by construction. Users should never see raw
+// pool positions like [37]; the first citation encountered is [1] and each new
+// raw index picks up the next display number. Repeated references reuse it.
 describe('buildDisplayIndexMap', () => {
     it('assigns 1 to the first citation encountered', () => {
-        const m = buildDisplayIndexMap('foo [37] bar');
+        const m = buildDisplayIndexMap(['foo [37] bar']);
         expect(m.get(37)).toBe(1);
     });
 
     it('assigns increasing display numbers in reading order', () => {
-        const m = buildDisplayIndexMap('a [37] b [12] c [99] d');
+        const m = buildDisplayIndexMap(['a [37] b [12] c [99] d']);
         expect(m.get(37)).toBe(1);
         expect(m.get(12)).toBe(2);
         expect(m.get(99)).toBe(3);
     });
 
     it('reuses the same display number when a raw index is referenced twice', () => {
-        const m = buildDisplayIndexMap('a [37] b [12] c [37] d');
+        const m = buildDisplayIndexMap(['a [37] b [12] c [37] d']);
         expect(m.get(37)).toBe(1);
         expect(m.get(12)).toBe(2);
         // second [37] must NOT get a new display number
         expect(m.size).toBe(2);
     });
 
-    it('preserves order across newlines / markdown structure', () => {
-        const src = [
-            '# Title',
-            '',
+    it('preserves order across multiple text segments', () => {
+        // Segments arrive in document order (one per visited text node).
+        const segments = [
             'Intro references [5].',
-            '',
-            '- point [2]',
-            '- another [8]',
-            '',
+            'point [2]',
+            'another [8]',
             'Wrap up [5] again.',
-        ].join('\n');
-        const m = buildDisplayIndexMap(src);
+        ];
+        const m = buildDisplayIndexMap(segments);
         expect(m.get(5)).toBe(1);
         expect(m.get(2)).toBe(2);
         expect(m.get(8)).toBe(3);
         expect(m.size).toBe(3);
     });
 
+    it('does not count [n] inside code — code text is never a text segment (#1003 P1)', () => {
+        // remarkCitation visits only `text` nodes, so `code [37]` never reaches
+        // here; the first REAL citation must therefore display as [1], not [2].
+        const m = buildDisplayIndexMap(['Real citation [42] here.']);
+        expect(m.get(42)).toBe(1);
+        expect(m.has(37)).toBe(false);
+        expect(m.size).toBe(1);
+    });
+
     it('does not consume markdown link brackets [text](url)', () => {
-        // [37](/x) is a link, not a citation; the lookahead in the regex
-        // prevents matching.
-        const m = buildDisplayIndexMap('see [37](/link) then [42] again');
+        const m = buildDisplayIndexMap(['see [37](/link) then [42] again']);
         expect(m.get(37)).toBeUndefined();
         expect(m.get(42)).toBe(1);
     });
 
     it('does not consume team-citation [Pn] tokens', () => {
-        // [P3] has a letter after '[' so \d+ never matches.
-        const m = buildDisplayIndexMap('see [P3] and [7]');
+        const m = buildDisplayIndexMap(['see [P3] and [7]']);
         expect(m.get(7)).toBe(1);
         expect(m.size).toBe(1);
     });
 
     it('returns an empty map for text with no citations', () => {
-        expect(buildDisplayIndexMap('nothing here').size).toBe(0);
+        expect(buildDisplayIndexMap(['nothing here']).size).toBe(0);
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
+++ b/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { formatGroupLabel, RANGE_THRESHOLD, buildDisplayIndexMap } from '../citationFormat';
+
+// Product spec for group badge label (see CitationBadge.tsx):
+//   len=1  -> handled by CitationBadge (single [N]), not tested here
+//   len=2  -> comma joined:  [37,38]
+//   len=3  -> comma joined:  [37,38,39]      (threshold)
+//   len>3  -> range:         [30-35]         (first-last)
+describe('formatGroupLabel', () => {
+    it('joins 2 indices with a comma', () => {
+        expect(formatGroupLabel([37, 38])).toBe('37,38');
+    });
+
+    it('joins exactly RANGE_THRESHOLD (3) indices with commas', () => {
+        expect(formatGroupLabel([37, 38, 39])).toBe('37,38,39');
+    });
+
+    it('collapses more than RANGE_THRESHOLD indices to first-last range', () => {
+        expect(formatGroupLabel([30, 31, 32, 33, 34, 35])).toBe('30-35');
+    });
+
+    it('range uses actual first/last even when caller passes non-contiguous list', () => {
+        // The grouping upstream in remarkCitation only emits adjacent-same-channel
+        // runs, so lists are contiguous in practice — but the label routine must
+        // not rely on that.
+        expect(formatGroupLabel([2, 5, 9, 14])).toBe('2-14');
+    });
+
+    it('RANGE_THRESHOLD is the documented value (guards against silent regressions)', () => {
+        expect(RANGE_THRESHOLD).toBe(3);
+    });
+});
+
+// P1: reading-order display renumbering. Users should never see raw pool
+// positions like [37]; the first citation encountered in the body is [1] and
+// each new raw index picks up the next display number. Repeated references to
+// the same raw index reuse the same display number.
+describe('buildDisplayIndexMap', () => {
+    it('assigns 1 to the first citation encountered', () => {
+        const m = buildDisplayIndexMap('foo [37] bar');
+        expect(m.get(37)).toBe(1);
+    });
+
+    it('assigns increasing display numbers in reading order', () => {
+        const m = buildDisplayIndexMap('a [37] b [12] c [99] d');
+        expect(m.get(37)).toBe(1);
+        expect(m.get(12)).toBe(2);
+        expect(m.get(99)).toBe(3);
+    });
+
+    it('reuses the same display number when a raw index is referenced twice', () => {
+        const m = buildDisplayIndexMap('a [37] b [12] c [37] d');
+        expect(m.get(37)).toBe(1);
+        expect(m.get(12)).toBe(2);
+        // second [37] must NOT get a new display number
+        expect(m.size).toBe(2);
+    });
+
+    it('preserves order across newlines / markdown structure', () => {
+        const src = [
+            '# Title',
+            '',
+            'Intro references [5].',
+            '',
+            '- point [2]',
+            '- another [8]',
+            '',
+            'Wrap up [5] again.',
+        ].join('\n');
+        const m = buildDisplayIndexMap(src);
+        expect(m.get(5)).toBe(1);
+        expect(m.get(2)).toBe(2);
+        expect(m.get(8)).toBe(3);
+        expect(m.size).toBe(3);
+    });
+
+    it('does not consume markdown link brackets [text](url)', () => {
+        // [37](/x) is a link, not a citation; the lookahead in the regex
+        // prevents matching.
+        const m = buildDisplayIndexMap('see [37](/link) then [42] again');
+        expect(m.get(37)).toBeUndefined();
+        expect(m.get(42)).toBe(1);
+    });
+
+    it('does not consume team-citation [Pn] tokens', () => {
+        // [P3] has a letter after '[' so \d+ never matches.
+        const m = buildDisplayIndexMap('see [P3] and [7]');
+        expect(m.get(7)).toBe(1);
+        expect(m.size).toBe(1);
+    });
+
+    it('returns an empty map for text with no citations', () => {
+        expect(buildDisplayIndexMap('nothing here').size).toBe(0);
+    });
+});

--- a/packages/dmworksummary/src/components/citationFormat.ts
+++ b/packages/dmworksummary/src/components/citationFormat.ts
@@ -1,0 +1,50 @@
+/**
+ * Label formatting rules for citation badges. Pure functions with no React /
+ * DOM deps so they can be unit-tested in isolation without pulling the
+ * component tree (which drags in tiptap, semi-ui, and other UI-only imports
+ * that break vitest resolution).
+ *
+ * See CitationBadge.tsx for how these are consumed by the JSX layer.
+ */
+
+/** Threshold below which the group badge lists all indices explicitly. */
+export const RANGE_THRESHOLD = 3;
+
+/**
+ * Group-label formatting rule (per product spec):
+ *   1  citation  -> single [N] badge (handled by remarkCitation, not here)
+ *   2-3 citations -> comma joined:  [37,38,39]
+ *   >3 citations  -> range:         [30-35]
+ */
+export function formatGroupLabel(indices: number[]): string {
+    if (indices.length <= RANGE_THRESHOLD) {
+        return indices.join(',');
+    }
+    return `${indices[0]}-${indices[indices.length - 1]}`;
+}
+
+/**
+ * Build a stable mapping from raw citation index (backend pool position, e.g.
+ * 37) to display index (reading-order rank starting at 1). The same raw index
+ * appearing multiple times reuses the same display value.
+ *
+ * Pre-scans the raw markdown source in reading order once (before the remark
+ * plugin runs) because the tree visitor sees text nodes out of document order.
+ * The `[n](url)` markdown-link form and `[Pn]` team-citation form are both
+ * excluded so display numbering matches what the badge layer will actually
+ * render.
+ */
+export function buildDisplayIndexMap(source: string): Map<number, number> {
+    const map = new Map<number, number>();
+    let next = 1;
+    // Match [n] but NOT [n](url) — same rule as remarkCitation's regex so this
+    // scan aligns exactly with what will later render as a badge. [Pn] tokens
+    // start with a letter so \d+ never touches them.
+    const regex = /\[(\d+)\](?!\()/g;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(source)) !== null) {
+        const raw = parseInt(m[1], 10);
+        if (!map.has(raw)) map.set(raw, next++);
+    }
+    return map;
+}

--- a/packages/dmworksummary/src/components/citationFormat.ts
+++ b/packages/dmworksummary/src/components/citationFormat.ts
@@ -20,7 +20,17 @@ export function formatGroupLabel(indices: number[]): string {
     if (indices.length <= RANGE_THRESHOLD) {
         return indices.join(',');
     }
-    return `${indices[0]}-${indices[indices.length - 1]}`;
+    // Range form is only meaningful when the display indices are contiguous and
+    // strictly ascending. After reading-order renumbering a group's display
+    // indices can be reordered/gapped (e.g. [4,1,2,3] -> "4-3" backwards, or
+    // [1,3,4,5] -> "1-5" implying a [2] that isn't in the group), so fall back
+    // to the explicit comma list in those cases (#1003 review P2).
+    const contiguousAscending = indices.every(
+        (v, i) => i === 0 || v === indices[i - 1] + 1,
+    );
+    return contiguousAscending
+        ? `${indices[0]}-${indices[indices.length - 1]}`
+        : indices.join(',');
 }
 
 /**
@@ -28,23 +38,30 @@ export function formatGroupLabel(indices: number[]): string {
  * 37) to display index (reading-order rank starting at 1). The same raw index
  * appearing multiple times reuses the same display value.
  *
- * Pre-scans the raw markdown source in reading order once (before the remark
- * plugin runs) because the tree visitor sees text nodes out of document order.
+ * Input is the list of visible markdown text-node values in document order (as
+ * produced by a `unist-util-visit(tree, 'text', …)` pass). Deriving numbering
+ * from text nodes — rather than a pre-scan of the raw source — means `[n]`
+ * tokens inside fenced / inline code are naturally excluded, so the numbering
+ * matches exactly what remarkCitation renders as a badge. (#1003 review P1: a
+ * raw-string pre-scan over-counted `[digit]` inside code and shifted the first
+ * rendered badge to [2]/[3] instead of [1].)
+ *
  * The `[n](url)` markdown-link form and `[Pn]` team-citation form are both
- * excluded so display numbering matches what the badge layer will actually
- * render.
+ * excluded, matching remarkCitation's regex.
  */
-export function buildDisplayIndexMap(source: string): Map<number, number> {
+export function buildDisplayIndexMap(textSegments: string[]): Map<number, number> {
     const map = new Map<number, number>();
     let next = 1;
-    // Match [n] but NOT [n](url) — same rule as remarkCitation's regex so this
-    // scan aligns exactly with what will later render as a badge. [Pn] tokens
-    // start with a letter so \d+ never touches them.
-    const regex = /\[(\d+)\](?!\()/g;
-    let m: RegExpExecArray | null;
-    while ((m = regex.exec(source)) !== null) {
-        const raw = parseInt(m[1], 10);
-        if (!map.has(raw)) map.set(raw, next++);
+    for (const seg of textSegments) {
+        // Match [n] but NOT [n](url) — same rule as remarkCitation. [Pn] tokens
+        // start with a letter so \d+ never touches them. Fresh regex per segment
+        // to avoid /g lastIndex carryover.
+        const regex = /\[(\d+)\](?!\()/g;
+        let m: RegExpExecArray | null;
+        while ((m = regex.exec(seg)) !== null) {
+            const raw = parseInt(m[1], 10);
+            if (!map.has(raw)) map.set(raw, next++);
+        }
     }
     return map;
 }


### PR DESCRIPTION
## Summary

Modernize the citation badge UX in agent/workflow summary detail. Bundles the 3 issues raised by the maintainer plus 2 industry-standard interactions (hover preview + click-to-pin), aligning with Perplexity / Kimi / Notion / Teams conventions.

## What changed

**P1 - Reading-order renumbering**
Badges now display 1-indexed reading-order numbers (first citation shown is `[1]`) instead of raw pool positions like `[37]`. Underlying citation data is unchanged; only the label the user sees differs. Repeated references to the same source reuse the same display number.

**P2 - Token-based styling + hover / focus states**
Replaced inline `React.CSSProperties` (hard-coded `#1677ff` / `rgba(22,119,255,0.13)`) with a new `CitationBadge.css` using `--wk-*` semantic tokens per `DEVELOPMENT.md` chapter 2. Badge now inherits brand color (near-black on this project), radius (`--wk-r-xs`), spacing (`--wk-sp-*`), and typography scale (`--wk-text-size-xs`). Light and dark themes track automatically. No hard-coded colors, no `!important`, no `@media (prefers-color-scheme: dark)`.

**P3 - Group badge label rule**
- `len <= 3` -> comma joined: `[37,38,39]`
- `len > 3`  -> range:        `[30-35]`

Pure formatting logic + reading-order map extracted to `citationFormat.ts` so unit tests don't have to drag in tiptap / semi-ui.

**Hover + pin interaction**
- Hover a badge for 400ms -> compact preview card (auto-dismiss on mouseleave, 200ms grace)
- Click -> pin the popover (full context + jump link), survives mouseleave
- Second click / outside click / Escape -> close
- Group badge hover shows up to 3 preview messages; pinned view keeps the full merged timeline

**Accessibility**
- Badges are now `tabIndex={0}`, keyboard-navigable
- Enter / Space pins; Escape closes when pinned

## Files

- `CitationBadge.tsx` +285/-109 — hover/pin state via new `useHoverPin` hook; token-driven className; propagates optional `displayIndex` prop
- `CitationText.tsx` +37 — pre-scans source for reading-order map; passes `displayindex` / `displayindices` through the remark AST
- `CitationBadge.css` (new) — semantic tokens only, light+dark compatible
- `citationFormat.ts` (new) — pure `formatGroupLabel` + `buildDisplayIndexMap`
- `__tests__/CitationBadge.test.ts` (new) — 12 unit tests

## Verification

- `pnpm vitest run` (dmworksummary) -> **488 passed / 1 pre-existing failure** (`SummaryVersionHistory.test.tsx:218` — reproduced on untouched `upstream/main`, unrelated to this change)
- `pnpm turbo run build --filter=@octo/web` -> **build succeeds** (esbuild, 4.13s, only pre-existing warnings)
- 12 new tests cover: comma/range branch table, `RANGE_THRESHOLD` guard, reading-order renumbering, dedup on repeat, markdown link exclusion (`[n](url)`), team citation exclusion (`[Pn]`)

## Non-goals (intentional; not in this PR)

- Backend `CitationIndex` assignment: unchanged
- No "AI generated" banner
- No bottom "Sources" list
- No by-speaker aggregation / section tabs / two-way highlighting

## Compatibility

- Traditional workflow summaries also benefit (`CitationText` / `CitationBadge` are shared)
- Existing `hidePlainCitations` / `disableTeamMemberPreview` flags unchanged
- Backend citation data structure unchanged; API responses untouched
