### PR TITLE
refactor: extract channel setting service boundaries

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/__tests__/vm.persona.test.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/__tests__/vm.persona.test.ts
@@ -53,6 +53,18 @@ vi.mock("../../../App", () => ({
     __esModule: true,
 }))
 
+vi.mock("../../../Service/APIClient", () => ({
+    default: {
+        shared: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+    },
+    __esModule: true,
+}))
+
 vi.mock("@douyinfe/semi-ui", () => ({
     Toast: {
         error: hoisted.toastError,

--- a/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
+++ b/packages/dmworkbase/src/Components/ChannelSetting/vm.ts
@@ -16,11 +16,16 @@ import {
     getCurrentImChannelSubscribers,
 } from "../../im-runtime/currentChannelRuntime";
 import {
-    OboGrant,
-    OboScope,
     hasAnyActiveGrant,
     refreshActiveGrantCache,
 } from "../PersonaSettings/vm";
+import {
+    createOboScope,
+    deleteOboScope,
+    listOboGrants,
+    listOboGrantScopes,
+    type OboScope,
+} from "../../Service/OboService";
 import { t } from "../../i18n";
 
 
@@ -202,17 +207,17 @@ export class ChannelSettingVM extends ProviderListener {
         try {
             if (this._oboScope) {
                 // 已有 scope 记录：先 DELETE，再视情况决定是否 POST。
-                await WKApp.apiClient.delete(`obo/scopes/${this._oboScope.id}`)
+                await deleteOboScope(this._oboScope.id)
                 if (this._disposed) return
                 this._oboScope = null
                 if (enable !== this._activeGrantGlobalEnabled) {
                     // global 不能直接表达 enable → 还需 POST 一条 override。
-                    const created = await WKApp.apiClient.post(`obo/scopes`, {
+                    const created = await createOboScope({
                         grant_id: this._activeGrantId,
                         channel_id: this.channel.channelID,
                         channel_type: this.channel.channelType,
                         enabled: enable,
-                    }) as OboScope
+                    })
                     if (this._disposed) return
                     this._oboScope = created
                 }
@@ -222,12 +227,12 @@ export class ChannelSettingVM extends ProviderListener {
                 //   enable === global → 已经匹配（理论上 UI 不应允许点击；保险起见 no-op）。
                 //   enable !== global → POST 一条 override（关闭=排除/打开=单点启用）。
                 if (enable === this._activeGrantGlobalEnabled) return
-                const created = await WKApp.apiClient.post(`obo/scopes`, {
+                const created = await createOboScope({
                     grant_id: this._activeGrantId,
                     channel_id: this.channel.channelID,
                     channel_type: this.channel.channelType,
                     enabled: enable,
-                }) as OboScope
+                })
                 if (this._disposed) return
                 this._oboScope = created
             }
@@ -263,8 +268,7 @@ export class ChannelSettingVM extends ProviderListener {
      */
     private async refreshOboScope(): Promise<void> {
         try {
-            const grants = await WKApp.apiClient.get<OboGrant[]>(`obo/grants`)
-            const list: OboGrant[] = Array.isArray(grants) ? grants : ((grants as any)?.items ?? [])
+            const list = await listOboGrants()
             const active = list.find((g) => g.active)
             if (this._disposed) return
             if (!active) {
@@ -279,9 +283,8 @@ export class ChannelSettingVM extends ProviderListener {
             // Round-2 P1（YUJ-1193）：保留 global_enabled，否则 toggle 在 global=true /
             // 无 scope 场景会渲染成 OFF，与服务端实际行为相反。
             this._activeGrantGlobalEnabled = !!active.global_enabled
-            const scopes = await WKApp.apiClient.get<OboScope[]>(`obo/grants/${active.id}/scopes`)
+            const arr = await listOboGrantScopes(active.id)
             if (this._disposed) return
-            const arr: OboScope[] = Array.isArray(scopes) ? scopes : ((scopes as any)?.items ?? [])
             const match = arr.find((s) =>
                 s.channel_id === this.channel.channelID && s.channel_type === this.channel.channelType,
             )

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -10,7 +10,7 @@ import {
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import { parseThreadChannelId } from "../../Service/Thread";
 import React, { Component } from "react";
-import { Tag } from "@douyinfe/semi-ui";
+import { Tag, Toast } from "@douyinfe/semi-ui";
 import { ConversationWrap, MessageWrap } from "../../Service/Model";
 import { getTimeStringAutoShort2 } from "../../Utils/time";
 import classNames from "classnames";
@@ -27,7 +27,6 @@ import ContextMenus, {
   ContextMenusContext,
   ContextMenusData,
 } from "../ContextMenus";
-import { ChannelSettingManager } from "../../Service/ChannelSetting";
 import { TypingListener, TypingManager } from "../../Service/TypingManager";
 import { BeatLoader } from "react-spinners";
 import { RevokeCell } from "../../Messages/Revoke";
@@ -44,6 +43,10 @@ import {
   fetchImChannelInfo,
   getImChannelInfo,
 } from "../../im-runtime/channelRuntime";
+import {
+  muteChannelSetting,
+  topChannelSetting,
+} from "../../bridge/channelSetting/channelSettingActions";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
 // ── 在线态判定/渲染 helper ──────────────────────────────────────────────
@@ -898,7 +901,13 @@ export default class ConversationList extends Component<
   }
 
   onTop(channelInfo: ChannelInfo) {
-    ChannelSettingManager.shared.top(!channelInfo.top, channelInfo.channel);
+    topChannelSetting({
+      channel: channelInfo.channel,
+      top: !channelInfo.top,
+    })
+      .catch((err) => {
+        Toast.error(err?.msg);
+      });
   }
 
   onMute(channelInfo: ChannelInfo) {
@@ -906,12 +915,18 @@ export default class ConversationList extends Component<
   }
 
   onMuteWithValue(value: boolean, channelInfo: ChannelInfo) {
-    ChannelSettingManager.shared.mute(value, channelInfo.channel)
+    muteChannelSetting({
+      channel: channelInfo.channel,
+      mute: value,
+    })
       .then(() => {
         // 直接重拉（不删缓存），新数据覆盖旧缓存，避免删除期间出现 loading 骨架
         fetchImChannelInfo(WKSDK.shared(), channelInfo.channel)
           .then(() => this.setState({}))
       })
+      .catch((err) => {
+        Toast.error(err?.msg);
+      });
   }
 
   onCloseChat(channel: Channel) {

--- a/packages/dmworkbase/src/Components/GroupManagement/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/index.tsx
@@ -366,9 +366,9 @@ export class GroupManagement extends Component<
         allowNoMentionSaving: false,
       });
     } catch (err: any) {
-      // 失败回滚到改前状态。Toast 已由底层设置动作弹出，
-      // 这里不再重复弹（避免双 Toast）。仅当本次仍是最新操作时才回滚 + 解锁，
+      // 失败回滚到改前状态。仅当本次仍是最新操作时才回滚 + 解锁，
       // 否则尊重更新的 toggle（它接管 saving 锁）。
+      Toast.error(err?.msg || t("base.groupManagement.operationFailed"));
       if (this.unmounted) return;
       if (myOp !== this.opSeq) return;
       this.setState({ allowNoMention: prev, allowNoMentionSaving: false });

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx
@@ -53,6 +53,20 @@ vi.mock("../../../App", () => ({
     __esModule: true,
 }))
 
+vi.mock("../../../Service/APIClient", () => ({
+    extractErrorMsg: (err: any) =>
+        err && typeof err === "object" && typeof err.msg === "string" ? err.msg : "",
+    default: {
+        shared: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+    },
+    __esModule: true,
+}))
+
 vi.mock("@douyinfe/semi-ui", () => ({
     Toast: {
         error: hoisted.toastError,

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx
@@ -46,6 +46,20 @@ vi.mock("../../../App", () => ({
     __esModule: true,
 }))
 
+vi.mock("../../../Service/APIClient", () => ({
+    extractErrorMsg: (err: any) =>
+        err && typeof err === "object" && typeof err.msg === "string" ? err.msg : "",
+    default: {
+        shared: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+    },
+    __esModule: true,
+}))
+
 vi.mock("@douyinfe/semi-ui", () => ({
     // 最小 Switch stub：渲染一个普通 checkbox，避免拉起 Semi 的样式 / portal 系统。
     Switch: (props: any) =>

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaSettings.test.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/PersonaSettings.test.tsx
@@ -45,6 +45,20 @@ vi.mock("../../../App", () => ({
     __esModule: true,
 }))
 
+vi.mock("../../../Service/APIClient", () => ({
+    extractErrorMsg: (err: any) =>
+        err && typeof err === "object" && typeof err.msg === "string" ? err.msg : "",
+    default: {
+        shared: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+    },
+    __esModule: true,
+}))
+
 vi.mock("@douyinfe/semi-ui", () => ({
     Button: (props: any) =>
         React.createElement("button", { ...props, "data-testid": props["data-testid"] || "btn" }, props.children),

--- a/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
+++ b/packages/dmworkbase/src/Components/PersonaSettings/__tests__/vm.test.ts
@@ -55,6 +55,20 @@ vi.mock("../../../App", () => ({
     __esModule: true,
 }))
 
+vi.mock("../../../Service/APIClient", () => ({
+    extractErrorMsg: (err: any) =>
+        err && typeof err === "object" && typeof err.msg === "string" ? err.msg : "",
+    default: {
+        shared: {
+            get: hoisted.get,
+            post: hoisted.post,
+            delete: hoisted.del,
+            put: hoisted.put,
+        },
+    },
+    __esModule: true,
+}))
+
 vi.mock("@douyinfe/semi-ui", () => ({
     Toast: {
         error: hoisted.toastError,

--- a/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
+++ b/packages/dmworkbase/src/Components/PersonaSettings/vm.tsx
@@ -3,6 +3,20 @@ import { ProviderListener } from "../../Service/Provider"
 import { Toast } from "@douyinfe/semi-ui"
 import { extractErrorMsg } from "../../Service/APIClient"
 import { t } from "../../i18n"
+import {
+    createOboGrant,
+    createOboScope,
+    deleteOboGrant as deleteOboGrantApi,
+    deleteOboScope,
+    listOboGrantScopes,
+    listOboGrants,
+    updateOboGrant,
+    type CreateOboGrantRequest,
+    type OboGrant,
+    type OboScope,
+} from "../../Service/OboService"
+
+export type { OboGrant, OboScope } from "../../Service/OboService"
 
 /**
  * PersonaSettings — AI 分身（On-Behalf-Of / OBO）页面 ViewModel
@@ -37,35 +51,6 @@ import { t } from "../../i18n"
  *     点开关 → 后端 mutex 自动把其他 grant 的 active 置为 false（同一用户最多 1 个
  *     active grant 接管会话）。前端只需 PUT `{active: true|false}`，不必关心互斥逻辑。
  */
-export interface OboGrant {
-    id: number
-    grantor_uid: string
-    grantee_bot_uid: string
-    grantee_bot_name?: string
-    mode: "auto" | "draft"
-    global_enabled: boolean
-    active: boolean
-    /**
-     * v2：自定义回复风格 prompt。可空（旧 grant 未填写时为 undefined / 空串）。
-     * 前端表单为可选填写，提交时若空则不放进 POST/PUT body（让后端保持 NULL/未改）。
-     */
-    persona_prompt?: string
-    created_at?: number
-    updated_at?: number
-}
-
-/**
- * Scope 实体 — per-channel 白名单。
- * channel_type 与 wukongimjssdk Channel 类型保持一致 (1=Person/DM, 2=Group)。
- */
-export interface OboScope {
-    id: number
-    grant_id: number
-    channel_id: string
-    channel_type: number
-    enabled: boolean
-}
-
 /**
  * MyBot — 用于「新建分身」时选择关联 bot 的下拉数据源。
  *
@@ -149,10 +134,7 @@ export class PersonaSettingsVM extends ProviderListener {
             this.isBackendMissing = false
             this.notifyListener()
             try {
-                const res = await WKApp.apiClient.get<any>(`obo/grants`)
-                // API returns {items: [...]} envelope; unwrap it.
-                const arr = Array.isArray(res) ? res : (res && Array.isArray(res.items) ? res.items : [])
-                this.grants = arr as OboGrant[]
+                this.grants = await listOboGrants()
             } catch (e: any) {
                 this.grants = []
                 if (e && typeof e === "object" && "status" in e && (e as any).status === 404) {
@@ -289,7 +271,7 @@ export class PersonaSettingsVM extends ProviderListener {
         try {
             // v2 (octo-web#73)：persona_prompt 可选；只有用户实际填写了非空内容时才放进 body，
             // 否则空串会让后端把 NULL 覆盖成 ''，影响 fan-out 的 system prompt 拼装逻辑。
-            const body: Record<string, any> = {
+            const body: CreateOboGrantRequest = {
                 grantee_bot_uid: granteeBotUid,
                 mode: "auto",
                 global_enabled: false,
@@ -298,7 +280,7 @@ export class PersonaSettingsVM extends ProviderListener {
             if (trimmed) {
                 body.persona_prompt = trimmed
             }
-            const res = await WKApp.apiClient.post(`obo/grants`, body)
+            const res = await createOboGrant(body)
             await this.loadGrants()
             // 已绑定的 bot 必须从下一次 PersonaCreate 的 picker 中消失：
             // 清缓存让 useEffect 的 length===0 守卫重新触发 loadMyBots()。
@@ -315,7 +297,7 @@ export class PersonaSettingsVM extends ProviderListener {
     /** 撤销（软删除）一个 grant。删除成功后 UI 应自行 pop / reload。 */
     async deleteGrant(id: number): Promise<boolean> {
         try {
-            await WKApp.apiClient.delete(`obo/grants/${id}`)
+            await deleteOboGrantApi(id)
             await this.loadGrants()
             return true
         } catch (e) {
@@ -339,7 +321,7 @@ export class PersonaSettingsVM extends ProviderListener {
         patch: Partial<Pick<OboGrant, "global_enabled" | "mode" | "active" | "persona_prompt">>,
     ): Promise<boolean> {
         try {
-            await WKApp.apiClient.put(`obo/grants/${id}`, patch)
+            await updateOboGrant(id, patch)
             await this.loadGrants()
             return true
         } catch (e) {
@@ -353,7 +335,7 @@ export class PersonaSettingsVM extends ProviderListener {
  * PersonaEdit 子页面 VM —— 单 grant 的 scope 编辑。
  *
  * 单独抽出一个 VM 避免顶层 PersonaSettingsVM 持有 per-grant 状态（避免 deep state，
- * 离开 edit 子页时自然 GC）。scopes 的写操作通过 WKApp.apiClient 直接调，
+ * 离开 edit 子页时自然 GC）。scopes 的写操作通过 OboService 统一收口，
  * 不做本地乐观更新（v0 接口慢但请求量小，简单可靠 > 体感丝滑）。
  */
 export class PersonaEditVM extends ProviderListener {
@@ -378,10 +360,7 @@ export class PersonaEditVM extends ProviderListener {
         this.isBackendMissing = false
         this.notifyListener()
         try {
-            const res = await WKApp.apiClient.get<any>(`obo/grants/${this.grant.id}/scopes`)
-            // API returns {items: [...]} envelope; unwrap it.
-            const arr = Array.isArray(res) ? res : (res && Array.isArray(res.items) ? res.items : [])
-            this.scopes = arr as OboScope[]
+            this.scopes = await listOboGrantScopes(this.grant.id)
         } catch (e: any) {
             this.scopes = []
             if (e && typeof e === "object" && "status" in e && (e as any).status === 404) {
@@ -397,7 +376,7 @@ export class PersonaEditVM extends ProviderListener {
 
     async addScope(channelId: string, channelType: number): Promise<boolean> {
         try {
-            await WKApp.apiClient.post(`obo/scopes`, {
+            await createOboScope({
                 grant_id: this.grant.id,
                 channel_id: channelId,
                 channel_type: channelType,
@@ -413,7 +392,7 @@ export class PersonaEditVM extends ProviderListener {
 
     async removeScope(id: number): Promise<boolean> {
         try {
-            await WKApp.apiClient.delete(`obo/scopes/${id}`)
+            await deleteOboScope(id)
             await this.loadScopes()
             return true
         } catch (e) {
@@ -424,7 +403,7 @@ export class PersonaEditVM extends ProviderListener {
 
     async toggleGlobal(enabled: boolean): Promise<boolean> {
         try {
-            await WKApp.apiClient.put(`obo/grants/${this.grant.id}`, { global_enabled: enabled ? 1 : 0 })
+            await updateOboGrant(this.grant.id, { global_enabled: enabled ? 1 : 0 })
             this.grant = { ...this.grant, global_enabled: enabled }
             this.notifyListener()
             return true
@@ -452,7 +431,7 @@ export class PersonaEditVM extends ProviderListener {
             if (typeof active === "boolean") {
                 body.active = active
             }
-            await WKApp.apiClient.put(`obo/grants/${this.grant.id}`, body)
+            await updateOboGrant(this.grant.id, body)
             this.grant = {
                 ...this.grant,
                 persona_prompt: personaPrompt,
@@ -468,7 +447,7 @@ export class PersonaEditVM extends ProviderListener {
 
     async deleteGrant(): Promise<boolean> {
         try {
-            await WKApp.apiClient.delete(`obo/grants/${this.grant.id}`)
+            await deleteOboGrantApi(this.grant.id)
             return true
         } catch (e) {
             Toast.error(extractErrorMsg(e) || t("base.persona.delete.failed"))
@@ -531,10 +510,7 @@ export function refreshActiveGrantCache(): Promise<boolean> {
     if (inFlight) return inFlight
     const p: Promise<boolean> = (async () => {
         try {
-            const res = await WKApp.apiClient.get<any>(`obo/grants`)
-            // API returns {items: [...]} envelope; unwrap it.
-            const raw = Array.isArray(res) ? res : (res && Array.isArray(res.items) ? res.items : [])
-            const list: OboGrant[] = raw
+            const list = await listOboGrants()
             // P1-2: 仅看 active，不再耦合 global_enabled，否则纯 per-channel scope
             // 模式下 toggle 永远不显示。
             const v = list.some((g) => g.active)

--- a/packages/dmworkbase/src/Service/ChannelSetting.ts
+++ b/packages/dmworkbase/src/Service/ChannelSetting.ts
@@ -1,6 +1,5 @@
-import { Toast } from "@douyinfe/semi-ui";
 import { Channel } from "wukongimjssdk";
-import WKApp from "../App";
+import { updateChannelSetting } from "./ChannelSettingService";
 
 
 export class ChannelSettingManager {
@@ -60,9 +59,8 @@ export class ChannelSettingManager {
     }
 
     _onSetting(setting: any, channel: Channel): Promise<void> {
-        return WKApp.dataSource.channelDataSource.updateSetting(setting, channel).catch((err) => {
+        return updateChannelSetting(setting, channel).catch((err) => {
             console.error('Setting update failed:', err);
-            Toast.error(err.msg)
             throw err;
         })
     }

--- a/packages/dmworkbase/src/Service/ChannelSettingService.ts
+++ b/packages/dmworkbase/src/Service/ChannelSettingService.ts
@@ -1,0 +1,154 @@
+import {
+  Channel,
+  ChannelTypeGroup,
+  ChannelTypePerson,
+} from "wukongimjssdk";
+
+import APIClient from "./APIClient";
+import { ChannelTypeCommunityTopic } from "./Const";
+import { hasSpacePrefix } from "./SpacePrefix";
+import { parseThreadChannelId } from "./Thread";
+
+export type ChannelSettingPayload = Record<string, any>;
+
+export interface CreateChannelOptions {
+  categoryId?: string;
+  name?: string;
+  avatarText?: string;
+  avatarColor?: number;
+  spaceId?: string;
+}
+
+function stripSpacePrefix(uid: string) {
+  if (!hasSpacePrefix(uid)) {
+    return uid;
+  }
+  return uid.substring(uid.indexOf("_") + 1);
+}
+
+function isPersonChannel(channel: Channel) {
+  return channel.channelType === ChannelTypePerson;
+}
+
+export async function updateChannelSetting(
+  setting: ChannelSettingPayload,
+  channel: Channel
+): Promise<void> {
+  if (channel.channelType === ChannelTypeGroup) {
+    return APIClient.shared.put(`groups/${channel.channelID}/setting`, setting);
+  }
+
+  if (channel.channelType === ChannelTypePerson) {
+    return APIClient.shared.put(
+      `users/${stripSpacePrefix(channel.channelID)}/setting`,
+      setting
+    );
+  }
+
+  if (channel.channelType === ChannelTypeCommunityTopic) {
+    const threadInfo = parseThreadChannelId(channel.channelID);
+    if (!threadInfo) {
+      return;
+    }
+    return APIClient.shared.put(
+      `groups/${threadInfo.groupNo}/threads/${threadInfo.shortId}/setting`,
+      setting
+    );
+  }
+}
+
+export function createChannel(
+  uids: string[],
+  options?: CreateChannelOptions
+): Promise<{ group_no?: string } | undefined> {
+  const body: Record<string, any> = { members: uids };
+  if (options?.spaceId) {
+    body.space_id = options.spaceId;
+  }
+  if (options?.categoryId) {
+    body.category_id = options.categoryId;
+  }
+  if (options?.name) {
+    body.name = options.name;
+  }
+  if (options?.avatarText) {
+    body.avatar_text = options.avatarText;
+  }
+  if (typeof options?.avatarColor === "number" && options.avatarColor >= 0) {
+    body.avatar_color = options.avatarColor;
+  }
+  return APIClient.shared.post("group/create", body);
+}
+
+export async function addChannelSubscribers(
+  channel: Channel,
+  uids: string[]
+): Promise<void> {
+  await APIClient.shared.post(`groups/${channel.channelID}/members`, {
+    members: uids,
+  });
+}
+
+export async function removeChannelSubscribers(
+  channel: Channel,
+  uids: string[]
+): Promise<void> {
+  await APIClient.shared.delete(`groups/${channel.channelID}/members`, {
+    data: {
+      members: uids,
+    },
+  });
+}
+
+export function updateChannelField(
+  channel: Channel,
+  field: string,
+  value: string
+): Promise<void> {
+  return APIClient.shared.put(`groups/${channel.channelID}`, {
+    [field]: value,
+  });
+}
+
+export function transferChannelOwner(
+  channel: Channel,
+  uid: string
+): Promise<void> {
+  if (isPersonChannel(channel)) {
+    return Promise.resolve();
+  }
+  return APIClient.shared.post(`groups/${channel.channelID}/transfer/${uid}`);
+}
+
+export function updateChannelSubscriberAttr(
+  channel: Channel,
+  subscriberUID: string,
+  attr: Record<string, any>
+): Promise<any> {
+  if (isPersonChannel(channel)) {
+    return Promise.resolve();
+  }
+  return APIClient.shared.put(
+    `groups/${channel.channelID}/members/${subscriberUID}`,
+    attr
+  );
+}
+
+export function exitChannel(channel: Channel): Promise<void> {
+  if (isPersonChannel(channel)) {
+    return Promise.resolve();
+  }
+  return APIClient.shared.post(`groups/${channel.channelID}/exit`);
+}
+
+export function updateThread(
+  groupNo: string,
+  shortId: string,
+  data: Record<string, any>
+): Promise<void> {
+  return APIClient.shared.put(`groups/${groupNo}/threads/${shortId}`, data);
+}
+
+export function leaveThread(shortId: string): Promise<void> {
+  return APIClient.shared.post(`threads/${shortId}/leave`);
+}

--- a/packages/dmworkbase/src/Service/GroupManagementService.ts
+++ b/packages/dmworkbase/src/Service/GroupManagementService.ts
@@ -1,0 +1,99 @@
+import { Channel, ChannelTypePerson, Subscriber } from "wukongimjssdk";
+
+import APIClient from "./APIClient";
+
+export interface GroupSubscriberMap {
+  uid: string;
+  name?: string;
+  remark?: string;
+  role?: number;
+  version?: number;
+  is_deleted?: number;
+  status?: number;
+  bot_admin?: number;
+  [key: string]: unknown;
+}
+
+export interface GroupSubscriberListParams {
+  keyword?: string;
+  limit?: number;
+  page?: number;
+}
+
+export type GroupSubscriberAvatarResolver = (uid: string) => string;
+
+export function toGroupManagementSubscriber(
+  memberMap: GroupSubscriberMap,
+  avatarUser?: GroupSubscriberAvatarResolver
+): Subscriber {
+  const member = new Subscriber();
+  member.uid = memberMap.uid;
+  member.name = memberMap.name;
+  member.remark = memberMap.remark;
+  member.role = memberMap.role;
+  member.version = memberMap.version;
+  member.isDeleted = memberMap.is_deleted;
+  member.status = memberMap.status;
+  member.orgData = memberMap;
+  member.orgData.bot_admin = memberMap.bot_admin || 0;
+  if (avatarUser) {
+    member.avatar = avatarUser(member.uid);
+  }
+  return member;
+}
+
+export async function listGroupManagementSubscribers(params: {
+  channel: Channel;
+  request: GroupSubscriberListParams;
+  avatarUser?: GroupSubscriberAvatarResolver;
+}): Promise<Subscriber[]> {
+  const resp = await APIClient.shared.get<GroupSubscriberMap[]>(
+    `groups/${params.channel.channelID}/members`,
+    {
+      param: params.request,
+    }
+  );
+  if (!Array.isArray(resp)) {
+    return [];
+  }
+  return resp.map((item) =>
+    toGroupManagementSubscriber(item, params.avatarUser)
+  );
+}
+
+export function addGroupManagementManagers(
+  channel: Channel,
+  uids: string[]
+): Promise<void> {
+  return APIClient.shared.post(`groups/${channel.channelID}/managers`, uids);
+}
+
+export function removeGroupManagementManagers(
+  channel: Channel,
+  uids: string[]
+): Promise<void> {
+  return APIClient.shared.delete(`groups/${channel.channelID}/managers`, {
+    data: uids,
+  });
+}
+
+export function disbandGroupManagement(channel: Channel): Promise<void> {
+  if (channel.channelType === ChannelTypePerson) {
+    return Promise.resolve();
+  }
+  return APIClient.shared.delete(`groups/${channel.channelID}/disband`);
+}
+
+export function setGroupManagementBotAdmin(
+  channel: Channel,
+  uid: string
+): Promise<void> {
+  return APIClient.shared.put(`groups/${channel.channelID}/bot_admin/${uid}`);
+}
+
+export function removeGroupManagementBotAdmin(
+  channel: Channel,
+  uid: string
+): Promise<void> {
+  return APIClient.shared.delete(`groups/${channel.channelID}/bot_admin/${uid}`);
+}

--- a/packages/dmworkbase/src/Service/OboService.ts
+++ b/packages/dmworkbase/src/Service/OboService.ts
@@ -1,0 +1,91 @@
+import APIClient from "./APIClient";
+
+export interface OboGrant {
+  id: number;
+  grantor_uid: string;
+  grantee_bot_uid: string;
+  grantee_bot_name?: string;
+  mode: "auto" | "draft";
+  global_enabled: boolean;
+  active: boolean;
+  persona_prompt?: string;
+  created_at?: number;
+  updated_at?: number;
+}
+
+export interface OboScope {
+  id: number;
+  grant_id: number;
+  channel_id: string;
+  channel_type: number;
+  enabled: boolean;
+}
+
+export interface CreateOboScopeRequest {
+  grant_id: number;
+  channel_id: string;
+  channel_type: number;
+  enabled: boolean;
+}
+
+export interface CreateOboGrantRequest {
+  grantee_bot_uid: string;
+  mode: "auto" | "draft";
+  global_enabled: boolean;
+  persona_prompt?: string;
+}
+
+export type UpdateOboGrantRequest = Record<string, any>;
+
+function asList<T>(value: T[] | { items?: T[] } | undefined): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (Array.isArray(value?.items)) {
+    return value.items;
+  }
+  return [];
+}
+
+export async function listOboGrants(): Promise<OboGrant[]> {
+  const grants = await APIClient.shared.get<OboGrant[] | { items?: OboGrant[] }>(
+    "obo/grants"
+  );
+  return asList(grants);
+}
+
+export async function listOboGrantScopes(
+  grantId: number
+): Promise<OboScope[]> {
+  const scopes = await APIClient.shared.get<OboScope[] | { items?: OboScope[] }>(
+    `obo/grants/${grantId}/scopes`
+  );
+  return asList(scopes);
+}
+
+export function createOboGrant(
+  request: CreateOboGrantRequest
+): Promise<OboGrant> {
+  return APIClient.shared.post("obo/grants", request);
+}
+
+export function updateOboGrant(
+  grantId: number,
+  request: UpdateOboGrantRequest
+): Promise<void> {
+  return APIClient.shared.put(`obo/grants/${grantId}`, request);
+}
+
+export function deleteOboGrant(grantId: number): Promise<void> {
+  return APIClient.shared.delete(`obo/grants/${grantId}`);
+}
+
+export function createOboScope(
+  request: CreateOboScopeRequest
+): Promise<OboScope> {
+  return APIClient.shared.post("obo/scopes", request);
+}
+
+export function deleteOboScope(scopeId: number): Promise<void> {
+  return APIClient.shared.delete(`obo/scopes/${scopeId}`);
+}

--- a/packages/dmworkbase/src/Service/__tests__/ChannelSettingService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/ChannelSettingService.test.ts
@@ -1,0 +1,175 @@
+import {
+  Channel,
+  ChannelTypeGroup,
+  ChannelTypePerson,
+} from "wukongimjssdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import APIClient from "../APIClient";
+import { ChannelTypeCommunityTopic } from "../Const";
+import { buildThreadChannelId } from "../Thread";
+import {
+  addChannelSubscribers,
+  createChannel,
+  exitChannel,
+  leaveThread,
+  removeChannelSubscribers,
+  transferChannelOwner,
+  updateChannelField,
+  updateChannelSetting,
+  updateChannelSubscriberAttr,
+  updateThread,
+} from "../ChannelSettingService";
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      delete: vi.fn(() => Promise.resolve()),
+      post: vi.fn(() => Promise.resolve()),
+      put: vi.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+vi.mock("../SpacePrefix", () => ({
+  hasSpacePrefix: vi.fn((id: string) => id.startsWith("s123_")),
+}));
+
+const apiDelete = APIClient.shared.delete as unknown as ReturnType<typeof vi.fn>;
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>;
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>;
+
+describe("ChannelSettingService", () => {
+  beforeEach(() => {
+    apiDelete.mockClear();
+    apiPost.mockClear();
+    apiPut.mockClear();
+    apiDelete.mockResolvedValue(undefined);
+    apiPost.mockResolvedValue(undefined);
+    apiPut.mockResolvedValue(undefined);
+  });
+
+  it("updates group settings with group endpoint", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+    const setting = { mute: 1 };
+
+    await updateChannelSetting(setting, channel);
+
+    expect(apiPut).toHaveBeenCalledWith("groups/group-1/setting", setting);
+  });
+
+  it("updates person settings and strips space prefix", async () => {
+    const channel = new Channel("s123_alice", ChannelTypePerson);
+    const setting = { top: 1 };
+
+    await updateChannelSetting(setting, channel);
+
+    expect(apiPut).toHaveBeenCalledWith("users/alice/setting", setting);
+  });
+
+  it("updates thread settings with parent group endpoint", async () => {
+    const channel = new Channel(
+      buildThreadChannelId("group-1", "thread-1"),
+      ChannelTypeCommunityTopic
+    );
+    const setting = { allow_no_mention: 0 };
+
+    await updateChannelSetting(setting, channel);
+
+    expect(apiPut).toHaveBeenCalledWith(
+      "groups/group-1/threads/thread-1/setting",
+      setting
+    );
+  });
+
+  it("keeps invalid thread channel ids as no-op for compatibility", async () => {
+    const channel = new Channel("bad-thread-id", ChannelTypeCommunityTopic);
+
+    await updateChannelSetting({ mute: 1 }, channel);
+
+    expect(apiPut).not.toHaveBeenCalled();
+  });
+
+  it("creates channels with optional metadata and space id", async () => {
+    apiPost.mockResolvedValue({ group_no: "group-1" });
+
+    const result = await createChannel(["self", "alice"], {
+      avatarColor: 2,
+      avatarText: "SA",
+      categoryId: "cat-1",
+      name: "Team",
+      spaceId: "space-1",
+    });
+
+    expect(apiPost).toHaveBeenCalledWith("group/create", {
+      members: ["self", "alice"],
+      avatar_color: 2,
+      avatar_text: "SA",
+      category_id: "cat-1",
+      name: "Team",
+      space_id: "space-1",
+    });
+    expect(result).toEqual({ group_no: "group-1" });
+  });
+
+  it("adds and removes channel subscribers with legacy payloads", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await addChannelSubscribers(channel, ["alice"]);
+    await removeChannelSubscribers(channel, ["bob"]);
+
+    expect(apiPost).toHaveBeenCalledWith("groups/group-1/members", {
+      members: ["alice"],
+    });
+    expect(apiDelete).toHaveBeenCalledWith("groups/group-1/members", {
+      data: {
+        members: ["bob"],
+      },
+    });
+  });
+
+  it("updates channel fields and subscriber attributes", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await updateChannelField(channel, "name", "New name");
+    await updateChannelSubscriberAttr(channel, "alice", { remark: "A" });
+
+    expect(apiPut).toHaveBeenCalledWith("groups/group-1", {
+      name: "New name",
+    });
+    expect(apiPut).toHaveBeenCalledWith("groups/group-1/members/alice", {
+      remark: "A",
+    });
+  });
+
+  it("keeps person-only group mutations as no-op for compatibility", async () => {
+    const channel = new Channel("alice", ChannelTypePerson);
+
+    await transferChannelOwner(channel, "bob");
+    await updateChannelSubscriberAttr(channel, "alice", { remark: "A" });
+    await exitChannel(channel);
+
+    expect(apiPost).not.toHaveBeenCalled();
+    expect(apiPut).not.toHaveBeenCalled();
+  });
+
+  it("routes group owner transfer and exit to group endpoints", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await transferChannelOwner(channel, "alice");
+    await exitChannel(channel);
+
+    expect(apiPost).toHaveBeenCalledWith("groups/group-1/transfer/alice");
+    expect(apiPost).toHaveBeenCalledWith("groups/group-1/exit");
+  });
+
+  it("updates and leaves threads", async () => {
+    await updateThread("group-1", "thread-1", { name: "Thread" });
+    await leaveThread("thread-1");
+
+    expect(apiPut).toHaveBeenCalledWith("groups/group-1/threads/thread-1", {
+      name: "Thread",
+    });
+    expect(apiPost).toHaveBeenCalledWith("threads/thread-1/leave");
+  });
+});

--- a/packages/dmworkbase/src/Service/__tests__/GroupManagementService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/GroupManagementService.test.ts
@@ -1,0 +1,130 @@
+import {
+  Channel,
+  ChannelTypeGroup,
+  ChannelTypePerson,
+} from "wukongimjssdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import APIClient from "../APIClient";
+import {
+  addGroupManagementManagers,
+  disbandGroupManagement,
+  listGroupManagementSubscribers,
+  removeGroupManagementBotAdmin,
+  removeGroupManagementManagers,
+  setGroupManagementBotAdmin,
+} from "../GroupManagementService";
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      delete: vi.fn(() => Promise.resolve()),
+      get: vi.fn(() => Promise.resolve([])),
+      post: vi.fn(() => Promise.resolve()),
+      put: vi.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+const apiDelete = APIClient.shared.delete as unknown as ReturnType<typeof vi.fn>;
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>;
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>;
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>;
+
+describe("GroupManagementService", () => {
+  beforeEach(() => {
+    apiDelete.mockClear();
+    apiGet.mockClear();
+    apiPost.mockClear();
+    apiPut.mockClear();
+    apiDelete.mockResolvedValue(undefined);
+    apiGet.mockResolvedValue([]);
+    apiPost.mockResolvedValue(undefined);
+    apiPut.mockResolvedValue(undefined);
+  });
+
+  it("lists subscribers with paging params and maps member fields", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+    apiGet.mockResolvedValue([
+      {
+        uid: "alice",
+        name: "Alice",
+        remark: "A",
+        role: 2,
+        version: 3,
+        is_deleted: 0,
+        status: 1,
+      },
+    ]);
+
+    const members = await listGroupManagementSubscribers({
+      channel,
+      request: { limit: 50, page: 1 },
+      avatarUser: (uid) => `avatar:${uid}`,
+    });
+
+    expect(apiGet).toHaveBeenCalledWith("groups/group-1/members", {
+      param: { limit: 50, page: 1 },
+    });
+    expect(members).toHaveLength(1);
+    expect(members[0].uid).toBe("alice");
+    expect(members[0].name).toBe("Alice");
+    expect(members[0].remark).toBe("A");
+    expect(members[0].role).toBe(2);
+    expect(members[0].version).toBe(3);
+    expect(members[0].isDeleted).toBe(0);
+    expect(members[0].status).toBe(1);
+    expect(members[0].orgData.bot_admin).toBe(0);
+    expect(members[0].avatar).toBe("avatar:alice");
+  });
+
+  it("keeps bot_admin from subscriber payload", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+    apiGet.mockResolvedValue([{ uid: "bot", bot_admin: 1 }]);
+
+    const members = await listGroupManagementSubscribers({
+      channel,
+      request: { limit: 50, page: 1 },
+    });
+
+    expect(members[0].orgData.bot_admin).toBe(1);
+  });
+
+  it("routes manager mutations to group manager endpoints", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await addGroupManagementManagers(channel, ["alice", "bob"]);
+    await removeGroupManagementManagers(channel, ["alice"]);
+
+    expect(apiPost).toHaveBeenCalledWith("groups/group-1/managers", [
+      "alice",
+      "bob",
+    ]);
+    expect(apiDelete).toHaveBeenCalledWith("groups/group-1/managers", {
+      data: ["alice"],
+    });
+  });
+
+  it("routes bot admin mutations to bot admin endpoints", async () => {
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await setGroupManagementBotAdmin(channel, "bot-a");
+    await removeGroupManagementBotAdmin(channel, "bot-a");
+
+    expect(apiPut).toHaveBeenCalledWith("groups/group-1/bot_admin/bot-a");
+    expect(apiDelete).toHaveBeenCalledWith(
+      "groups/group-1/bot_admin/bot-a"
+    );
+  });
+
+  it("disbands groups and keeps person channels as no-op", async () => {
+    const group = new Channel("group-1", ChannelTypeGroup);
+    const person = new Channel("alice", ChannelTypePerson);
+
+    await disbandGroupManagement(group);
+    await disbandGroupManagement(person);
+
+    expect(apiDelete).toHaveBeenCalledTimes(1);
+    expect(apiDelete).toHaveBeenCalledWith("groups/group-1/disband");
+  });
+});

--- a/packages/dmworkbase/src/Service/__tests__/OboService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/OboService.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import APIClient from "../APIClient";
+import {
+  createOboGrant,
+  createOboScope,
+  deleteOboGrant,
+  deleteOboScope,
+  listOboGrants,
+  listOboGrantScopes,
+  updateOboGrant,
+} from "../OboService";
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      delete: vi.fn(() => Promise.resolve()),
+      get: vi.fn(() => Promise.resolve([])),
+      post: vi.fn(() => Promise.resolve()),
+      put: vi.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+const apiDelete = APIClient.shared.delete as unknown as ReturnType<typeof vi.fn>;
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>;
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>;
+const apiPut = APIClient.shared.put as unknown as ReturnType<typeof vi.fn>;
+
+describe("OboService", () => {
+  beforeEach(() => {
+    apiDelete.mockClear();
+    apiGet.mockClear();
+    apiPost.mockClear();
+    apiPut.mockClear();
+    apiDelete.mockResolvedValue(undefined);
+    apiGet.mockResolvedValue([]);
+    apiPost.mockResolvedValue(undefined);
+    apiPut.mockResolvedValue(undefined);
+  });
+
+  it("lists OBO grants from array responses", async () => {
+    apiGet.mockResolvedValue([{ id: 1, active: true }]);
+
+    const grants = await listOboGrants();
+
+    expect(apiGet).toHaveBeenCalledWith("obo/grants");
+    expect(grants).toEqual([{ id: 1, active: true }]);
+  });
+
+  it("lists OBO grant scopes from items responses", async () => {
+    apiGet.mockResolvedValue({ items: [{ id: 7, grant_id: 1 }] });
+
+    const scopes = await listOboGrantScopes(1);
+
+    expect(apiGet).toHaveBeenCalledWith("obo/grants/1/scopes");
+    expect(scopes).toEqual([{ id: 7, grant_id: 1 }]);
+  });
+
+  it("creates and deletes OBO scopes", async () => {
+    const request = {
+      grant_id: 1,
+      channel_id: "ch-1",
+      channel_type: 2,
+      enabled: false,
+    };
+
+    await createOboScope(request);
+    await deleteOboScope(7);
+
+    expect(apiPost).toHaveBeenCalledWith("obo/scopes", request);
+    expect(apiDelete).toHaveBeenCalledWith("obo/scopes/7");
+  });
+
+  it("creates, updates, and deletes OBO grants", async () => {
+    const request = {
+      grantee_bot_uid: "bot-1",
+      mode: "auto" as const,
+      global_enabled: false,
+      persona_prompt: "friendly",
+    };
+
+    await createOboGrant(request);
+    await updateOboGrant(3, { active: true });
+    await deleteOboGrant(3);
+
+    expect(apiPost).toHaveBeenCalledWith("obo/grants", request);
+    expect(apiPut).toHaveBeenCalledWith("obo/grants/3", { active: true });
+    expect(apiDelete).toHaveBeenCalledWith("obo/grants/3");
+  });
+});

--- a/packages/dmworkbase/src/bridge/channelSetting/__tests__/groupManagementActions.test.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/__tests__/groupManagementActions.test.ts
@@ -16,14 +16,6 @@ vi.mock("../../../App", () => ({
   },
 }));
 
-vi.mock("../../../Service/ChannelSetting", () => ({
-  ChannelSettingManager: {
-    shared: {
-      setAllowNoMention: vi.fn(),
-    },
-  },
-}));
-
 vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
   addCurrentImChannelInfoListener: vi.fn(),
   fetchCurrentImChannelInfo: vi.fn(),

--- a/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
@@ -1,7 +1,18 @@
 import { Channel, ChannelTypeGroup, WKSDK } from "wukongimjssdk";
 
 import WKApp from "../../App";
-import { ChannelSettingManager } from "../../Service/ChannelSetting";
+import {
+  addChannelSubscribers as addChannelSubscribersApi,
+  createChannel as createChannelApi,
+  exitChannel as exitChannelApi,
+  leaveThread as leaveThreadApi,
+  removeChannelSubscribers as removeChannelSubscribersApi,
+  transferChannelOwner,
+  updateChannelField as updateChannelFieldApi,
+  updateChannelSetting,
+  updateChannelSubscriberAttr,
+  updateThread as updateThreadApi,
+} from "../../Service/ChannelSettingService";
 import { EndpointID } from "../../Service/Const";
 import { ChannelField } from "../../Service/DataSource/DataSource";
 import {
@@ -51,13 +62,17 @@ export interface ChannelSettingActionRuntime {
 function defaultRuntime(): ChannelSettingActionRuntime {
   return {
     addSubscribers(channel, uids) {
-      return WKApp.dataSource.channelDataSource.addSubscribers(channel, uids);
+      return addChannelSubscribersApi(channel, uids).then(() =>
+        syncChannelSubscribersAfterMemberMutation(channel, "addSubscribers")
+      );
     },
     clearConversationMessages(conversation) {
       return WKApp.conversationProvider.clearConversationMessages(conversation);
     },
     createChannel(uids) {
-      return WKApp.dataSource.channelDataSource.createChannel(uids);
+      return createChannelApi(uids, {
+        spaceId: WKApp.shared.currentSpaceId,
+      });
     },
     deleteConversation(channel) {
       return WKApp.conversationProvider.deleteConversation(channel);
@@ -66,7 +81,7 @@ function defaultRuntime(): ChannelSettingActionRuntime {
       deleteCurrentImChannelInfo(channel);
     },
     exitChannel(channel) {
-      return WKApp.dataSource.channelDataSource.exitChannel(channel);
+      return exitChannelApi(channel);
     },
     fetchCurrentChannelInfo(channel) {
       return fetchCurrentImChannelInfo(channel);
@@ -81,10 +96,10 @@ function defaultRuntime(): ChannelSettingActionRuntime {
       WKApp.endpointManager.invoke(EndpointID.clearChannelMessages, channel);
     },
     leaveThread(shortId) {
-      return WKApp.apiClient.post(`threads/${shortId}/leave`);
+      return leaveThreadApi(shortId);
     },
     muteChannel(channel, mute) {
-      return ChannelSettingManager.shared.mute(mute, channel);
+      return updateChannelSetting({ mute: mute ? 1 : 0 }, channel);
     },
     removeLocalConversationAndCloseIfOpen(channel) {
       WKSDK.shared().conversationManager.removeConversation(channel);
@@ -96,13 +111,15 @@ function defaultRuntime(): ChannelSettingActionRuntime {
       WKApp.shared.notifyListener();
     },
     removeSubscribers(channel, uids) {
-      return WKApp.dataSource.channelDataSource.removeSubscribers(channel, uids);
+      return removeChannelSubscribersApi(channel, uids).then(() =>
+        syncChannelSubscribersAfterMemberMutation(channel, "removeSubscribers")
+      );
     },
     remarkChannel(channel, remark) {
-      return ChannelSettingManager.shared.remark(remark, channel);
+      return updateChannelSetting({ remark }, channel);
     },
     saveChannel(channel, save) {
-      return ChannelSettingManager.shared.save(save, channel);
+      return updateChannelSetting({ save: save ? 1 : 0 }, channel);
     },
     showConversation(channel) {
       WKApp.endpoints.showConversation(channel);
@@ -111,36 +128,32 @@ function defaultRuntime(): ChannelSettingActionRuntime {
       return syncCurrentImChannelSubscribers(channel);
     },
     topChannel(channel, top) {
-      return ChannelSettingManager.shared.top(top, channel);
+      return updateChannelSetting({ top: top ? 1 : 0 }, channel);
     },
     transferOwner(channel, uid) {
-      return WKApp.dataSource.channelDataSource.channelTransferOwner(
-        channel,
-        uid
-      );
+      return transferChannelOwner(channel, uid);
     },
     updateChannelField(channel, field, value) {
-      return WKApp.dataSource.channelDataSource.updateField(
-        channel,
-        field,
-        value
-      );
+      return updateChannelFieldApi(channel, field, value);
     },
     updateSubscriberAttr(channel, uid, attr) {
-      return WKApp.dataSource.channelDataSource.subscriberAttrUpdate(
-        channel,
-        uid,
-        attr
-      );
+      return updateChannelSubscriberAttr(channel, uid, attr);
     },
     updateThread(groupNo, shortId, data) {
-      return WKApp.dataSource.channelDataSource.threadUpdate(
-        groupNo,
-        shortId,
-        data
-      );
+      return updateThreadApi(groupNo, shortId, data);
     },
   };
+}
+
+async function syncChannelSubscribersAfterMemberMutation(
+  channel: Channel,
+  action: "addSubscribers" | "removeSubscribers"
+) {
+  try {
+    await syncCurrentImChannelSubscribers(channel);
+  } catch (err) {
+    console.warn(`[${action}] syncSubscribes failed`, err);
+  }
 }
 
 function runtimeOrDefault(runtime?: ChannelSettingActionRuntime) {

--- a/packages/dmworkbase/src/bridge/channelSetting/groupManagementActions.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/groupManagementActions.ts
@@ -2,7 +2,15 @@ import { Channel, ChannelInfo, Subscriber } from "wukongimjssdk";
 
 import WKApp from "../../App";
 import { GroupRole } from "../../Service/Const";
-import { ChannelSettingManager } from "../../Service/ChannelSetting";
+import { updateChannelSetting } from "../../Service/ChannelSettingService";
+import {
+  addGroupManagementManagers as addGroupManagementManagersApi,
+  disbandGroupManagement,
+  listGroupManagementSubscribers,
+  removeGroupManagementBotAdmin as removeGroupManagementBotAdminApi,
+  removeGroupManagementManagers,
+  setGroupManagementBotAdmin as setGroupManagementBotAdminApi,
+} from "../../Service/GroupManagementService";
 import {
   addCurrentImChannelInfoListener,
   fetchCurrentImChannelInfo,
@@ -40,10 +48,10 @@ function defaultRuntime(): GroupManagementActionRuntime {
       return addCurrentImChannelInfoListener(listener);
     },
     addManagers(channel, uids) {
-      return WKApp.dataSource.channelDataSource.managerAdd(channel, uids);
+      return addGroupManagementManagersApi(channel, uids);
     },
     disbandGroup(channel) {
-      return WKApp.dataSource.channelDataSource.groupDisband(channel);
+      return disbandGroupManagement(channel);
     },
     fetchChannelInfo(channel) {
       return fetchCurrentImChannelInfo(channel);
@@ -52,19 +60,23 @@ function defaultRuntime(): GroupManagementActionRuntime {
       return getCurrentImChannelInfo(channel);
     },
     listSubscribers(channel, params) {
-      return WKApp.dataSource.channelDataSource.subscribers(channel, params);
+      return listGroupManagementSubscribers({
+        channel,
+        request: params,
+        avatarUser: (uid) => WKApp.shared.avatarUser(uid),
+      });
     },
     removeBotAdmin(channel, uid) {
-      return WKApp.dataSource.channelDataSource.removeBotAdmin(channel, uid);
+      return removeGroupManagementBotAdminApi(channel, uid);
     },
     removeManagers(channel, uids) {
-      return WKApp.dataSource.channelDataSource.managerRemove(channel, uids);
+      return removeGroupManagementManagers(channel, uids);
     },
     setAllowNoMention(allow, channel) {
-      return ChannelSettingManager.shared.setAllowNoMention(allow, channel);
+      return updateChannelSetting({ allow_no_mention: allow ? 1 : 0 }, channel);
     },
     setBotAdmin(channel, uid) {
-      return WKApp.dataSource.channelDataSource.setBotAdmin(channel, uid);
+      return setGroupManagementBotAdminApi(channel, uid);
     },
     syncDisbandState(channel) {
       syncGroupDisbandState(channel);

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupInfoSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupInfoSection.tsx
@@ -366,11 +366,14 @@ export function buildChannelGroupInfoSection(
             context,
             channelInfo?.orgData?.remark || "",
             (value: string) => {
-              return remarkChannelSetting({ channel, remark: value }).then(
-                () => {
+              return remarkChannelSetting({ channel, remark: value })
+                .then(() => {
                   data.refresh();
-                }
-              );
+                })
+                .catch((err) => {
+                  Toast.error(err?.msg);
+                  throw err;
+                });
             },
             t("base.module.channelSettings.remarkPlaceholder"),
             15,

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingSections.ts
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingSections.ts
@@ -69,7 +69,8 @@ export function buildChannelPreferenceSection(
                 ctx.loading = false;
                 data.refresh();
               })
-              .catch(() => {
+              .catch((err) => {
+                Toast.error(err?.msg);
                 ctx.loading = false;
               });
           },
@@ -91,7 +92,8 @@ export function buildChannelPreferenceSection(
               ctx.loading = false;
               data.refresh();
             })
-            .catch(() => {
+            .catch((err) => {
+              Toast.error(err?.msg);
               ctx.loading = false;
             });
         },
@@ -113,7 +115,8 @@ export function buildChannelPreferenceSection(
                 ctx.loading = false;
                 data.refresh();
               })
-              .catch(() => {
+              .catch((err) => {
+                Toast.error(err?.msg);
                 ctx.loading = false;
               });
           },


### PR DESCRIPTION
## Summary
- Extract channel setting, group management, and OBO API calls into service-layer modules.
- Keep WKApp/WKSDK runtime responsibilities in bridge and VM layers.
- Preserve existing UI behavior while adding focused service and bridge regression coverage.

## Tests
- pnpm --dir packages/dmworkbase test -- src/Service/__tests__/OboService.test.ts src/Service/__tests__/GroupManagementService.test.ts src/Service/__tests__/ChannelSettingService.test.ts src/bridge/channelSetting/__tests__/channelSettingActions.test.ts src/features/channelSetting/__tests__/channelSettingSections.test.ts src/bridge/channelSetting/__tests__/groupManagementActions.test.ts src/Components/GroupManagement/__tests__/allowNoMention.test.ts src/Components/GroupManagement/__tests__/botAdmins.test.ts src/im-runtime/currentChannelRuntime.test.ts src/Components/ChannelSetting/__tests__/vm.persona.test.ts src/Components/PersonaSettings/__tests__/vm.test.ts src/Components/PersonaSettings/__tests__/PersonaEdit.test.tsx src/Components/PersonaSettings/__tests__/PersonaCreate.test.tsx src/Components/PersonaSettings/__tests__/PersonaSettings.test.tsx
- pnpm --dir packages/dmworkbase exec esbuild src/Service/OboService.ts src/Service/ChannelSettingService.ts src/Service/GroupManagementService.ts src/Components/ChannelSetting/vm.ts src/Components/PersonaSettings/vm.tsx src/bridge/channelSetting/channelSettingActions.ts src/bridge/channelSetting/groupManagementActions.ts src/Components/ConversationList/index.tsx --outdir=/private/tmp/octo-web-esbuild-check --format=esm --log-level=error
- git diff --check