### PR TITLE
fix(mcp): inline shared-secret warning instead of window.confirm

### DIFF
--- a/packages/dmworkmcp/src/components/McpCreateModal.tsx
+++ b/packages/dmworkmcp/src/components/McpCreateModal.tsx
@@ -786,36 +786,12 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
     // Collapse the structured editors down to the wire pair. Backend no
     // longer rejects secret-shaped shared values (rule 2 was removed);
     // non-owner blanking (§5.3) is the sole guard keeping author tokens
-    // out of consumer-facing responses.
+    // out of consumer-facing responses. The inline warning next to the
+    // Submit button (see sharedSecretLeaks below) is the frontend's
+    // advisory signal for the edge case where the operator explicitly
+    // published a secret-shape shared value; non-blocking on purpose.
     const envWire = entriesToWire(envEntries);
     const headersWire = entriesToWire(headersEntries);
-
-    // Front-line safety net for the (unusual) case where the operator
-    // manually flipped the toggle OFF on a secret-shape key AND typed a
-    // real value: they've signalled "this is a shared value". Backend
-    // will accept and store it (§5.1 rule 2 was removed); the record
-    // still round-trips fine to owner but non-owners see blanks. Warn
-    // and require an explicit OK so pasting a personal token by mistake
-    // doesn't silently ship. Keys already ON (toggle set to
-    // user_supplied) are safe by design — placeholder rendering + wire
-    // blanking both apply.
-    const suppliedH = new Set(headersWire.userSupplied);
-    const suppliedE = new Set(envWire.userSupplied);
-    const sharedSecretKeys: string[] = [];
-    for (const [k, v] of Object.entries(headersWire.values)) {
-      if (v && isSecretKey(k) && !suppliedH.has(k)) sharedSecretKeys.push(k);
-    }
-    for (const [k, v] of Object.entries(envWire.values)) {
-      if (v && isSecretKey(k) && !suppliedE.has(k)) sharedSecretKeys.push(k);
-    }
-    if (sharedSecretKeys.length > 0) {
-      const ok = window.confirm(
-        t("mcp.create.sharedSecretConfirm", {
-          values: { keys: sharedSecretKeys.join(", ") },
-        })
-      );
-      if (!ok) return;
-    }
 
     setSubmitting(true);
     // Upload icon FIRST so the URL can ride in the create/update body. The
@@ -936,6 +912,25 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
       "tools",
       form.tools.map((tool, i) => (i === idx ? { ...tool, ...patch } : tool))
     );
+
+  // Derived warning list: secret-shape keys the operator kept toggled OFF
+  // (i.e. published as shared values) with a non-empty value. Rendered
+  // inline next to the Submit button so the operator sees the exposure
+  // before clicking, without a blocking modal. Non-blocking on purpose —
+  // the KvEditor auto-toggles ON when a secret-shape key is typed into a
+  // fresh row, so hitting this state requires an explicit override; the
+  // warning is here for the operator's own audit, not to gate publish.
+  const sharedSecretLeaks = useMemo(() => {
+    const leaks: string[] = [];
+    for (const e of [...headersEntries, ...envEntries]) {
+      const k = e.key.trim();
+      if (!k) continue;
+      if (e.userSupplied) continue;
+      if (!e.value) continue;
+      if (isSecretKey(k)) leaks.push(k);
+    }
+    return leaks;
+  }, [headersEntries, envEntries]);
 
   // ── Static options ─────────────────────────────────────────────────────
   const categoryOptions = useMemo(
@@ -1120,13 +1115,28 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
                 {t("mcp.create.next")} →
               </WKButton>
             ) : (
-              <WKButton
-                variant="primary"
-                loading={submitting}
-                onClick={handleSubmit}
-              >
-                {isEdit ? t("mcp.edit.submit") : t("mcp.create.submit")}
-              </WKButton>
+              <>
+                {sharedSecretLeaks.length > 0 && (
+                  <span
+                    className="wk-mcp-form-footer__warning"
+                    title={t("mcp.create.sharedSecretWarning", {
+                      values: { keys: sharedSecretLeaks.join(", ") },
+                    })}
+                  >
+                    ⚠️{" "}
+                    {t("mcp.create.sharedSecretWarning", {
+                      values: { keys: sharedSecretLeaks.join(", ") },
+                    })}
+                  </span>
+                )}
+                <WKButton
+                  variant="primary"
+                  loading={submitting}
+                  onClick={handleSubmit}
+                >
+                  {isEdit ? t("mcp.edit.submit") : t("mcp.create.submit")}
+                </WKButton>
+              </>
             )}
           </div>
         </div>

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -181,7 +181,7 @@
     "headerAdd": "Add",
     "headerRemove": "Remove",
     "kvUserSuppliedToggle": "User fills locally",
-    "sharedSecretConfirm": "These keys look sensitive but their \"user fills locally\" toggle is OFF, so the values will be submitted verbatim: {{keys}}. Publish anyway?",
+    "sharedSecretWarning": "{{keys}} will be published in cleartext",
     "icon": "Icon",
     "iconEmpty": "Upload",
     "iconUpload": "Upload image",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -181,7 +181,7 @@
     "headerAdd": "添加",
     "headerRemove": "删除",
     "kvUserSuppliedToggle": "需要用户自行配置",
-    "sharedSecretConfirm": "以下 key 是敏感字段，但你没打开「需要用户自行配置」开关，值会以明文提交到市场：{{keys}}。确认发布？",
+    "sharedSecretWarning": "{{keys}} 将以明文公开发布",
     "icon": "图标",
     "iconEmpty": "点击上传",
     "iconUpload": "上传图片",

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -969,7 +969,20 @@
 
 .wk-mcp-form-footer__right {
   display: flex;
+  align-items: center;
   gap: var(--wk-sp-2);
+}
+
+/* Inline advisory shown next to the Submit button when the operator kept
+   a secret-shape key toggled OFF with a real value. Non-blocking; the
+   colour reads as a warning without stealing the button's affordance. */
+.wk-mcp-form-footer__warning {
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-color-warning, #d97706);
+  max-width: 24em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Detail-modal footer row for owner actions (edit/delete). */


### PR DESCRIPTION
## Summary

Follow-up to #995. The submit-time guard added in that PR (advises the operator when a secret-shape key is being published as a shared value) shipped as a `window.confirm` — the browser-native "im-test.deepminer.com.cn 显示" alert, visually out of place against the Semi UI marketplace form.

This PR replaces it with a non-blocking inline advisory rendered next to the Submit button. Same trigger and same intent; the KvEditor's smart-default-on-secret-key-input still catches the common accidental case, so this advisory is the persistent, quiet reminder for the explicit-override case.

## Related Issue

Follow-up to #995. No new spec surface — the toggle model, wire contract (`env_user_supplied` / `headers_user_supplied`), and marketplace §5.1 semantics are unchanged.

## Changes

- Add \`sharedSecretLeaks\` memo scanning env + headers entries for `!userSupplied && value && isSecretKey(k)`.
- Render an inline `⚠️ <keys> will be published in cleartext` span between the primary Submit button and any prior footer content; title tooltip carries the full text.
- Drop \`window.confirm\` block from \`handleSubmit\`.
- Drop obsolete i18n keys \`sharedSecretConfirm{,Title,Ok,Cancel}\`; replace with a single \`sharedSecretWarning\` line.
- CSS: `.wk-mcp-form-footer__warning` (warning color, ellipsis on overflow, hover tooltip via `title`).

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkmcp` (MCP marketplace create/edit modal only).
- New or changed user-visible entry point: no.
- Shared layer touched: none.
- Duplicate entry point checked: yes; no duplication.

## Testing

- `pnpm --filter @dmwork/mcp test` — 4 files / 56 tests passing.
- `pnpm --filter web build` — green.
- Manually: opened create modal, typed `Authorization: Bearer sk-xxx` without flipping the toggle, saw the amber warning next to Submit; hitting Submit went straight through (non-blocking). Toggling ON cleared the warning.

- [x] Unit tests still pass
- [x] Manually verified in dev
- [x] No new user-visible entry point
- [x] Followed commit message conventions (Conventional Commits)