### PR TITLE
feat(card): support versioned Forge render profiles

### DIFF
--- a/docs/render-profile-local-validation.md
+++ b/docs/render-profile-local-validation.md
@@ -1,0 +1,44 @@
+# Card Forge Render Profile 本地联调说明
+
+## Behavior List
+
+- Entry：不新增生产菜单或路由；通过 Interactive Card Story 和本地 Mock 消息验证。
+- Legacy path：消息缺少 `render_profile` 时，继续使用现有 HostConfig、`wk-interactive-card-sdk` 根类与线上 CSS。
+- Forge path：消息显式携带 `render_profile: "octo-chat/v1"` 时，使用 Forge 制品内 HostConfig、主题与作用域 CSS。
+- Unsupported path：未知的非空 `render_profile` 不套用 legacy 样式，回退现有客户端升级提示。
+- Interaction：OpenUrl、ToggleVisibility、Submit 的既有安全与权限逻辑保持不变。
+- Error state：卡片结构、Wire Profile 或 Render Profile 不受支持时继续整卡回退 plain/hint。
+
+## File Map
+
+- `packages/dmworkbase/package.json`：固定安装 npm 发布的 Forge `1.2.0-rc.1` 制品。
+- `Messages/InteractiveCard/InteractiveCardContent.ts`：容忍解析/编码可选 `render_profile`。
+- `Messages/InteractiveCard/renderDecision.ts`：在原 Wire Profile 协商之外选择 legacy/Forge 渲染档位。
+- `Messages/InteractiveCard/sdk/renderOctoCard.ts`：按档位选择现有 HostConfig 或制品 HostConfig。
+- `Messages/InteractiveCard/InteractiveCardCell.tsx`：legacy/Forge 根类互斥。
+- `Messages/InteractiveCard/index.css`：仅保留 Forge 宿主布局壳；业务视觉来自制品 CSS。
+- `Messages/InteractiveCard/*.stories.tsx`：320/480/640 下展示新旧卡及两张 Forge 卡。
+- `Messages/InteractiveCard/__tests__/*`：锁定缺字段兼容、未知档位和根类/HostConfig 选择。
+
+## PR Scope
+
+This PR does:
+
+- 接入单一 `octo-chat/v1` Render Profile 兼容代际。
+- 保持历史消息默认走 legacy。
+- 提供本地可复现的 Forge/legacy 并排验证入口。
+
+This PR does not do:
+
+- 不修改后端消息模板或启用生产 `render_profile`。
+- 不处理明暗双主题。
+- 不发布 npm 正式版本，不调整 Card Action 服务端语义。
+
+Impact：共享消息渲染层，仅影响 type-17 Interactive Card；其他消息类型不变。
+
+## Verification Plan
+
+- 自动化：运行 InteractiveCard 定向 Vitest、`pnpm --filter @octo/base test` 和类型检查。
+- Story：在 320/480/640 查看 legacy、行动决策 0.2、文档申请 0.3。
+- 手工：确认 legacy DOM 根类与 Forge 根类互斥；确认按钮、Header、Footer、分割线一致。
+- 回归：缺 `render_profile` 的现有线上卡片 DOM、HostConfig 与交互保持不变。

--- a/packages/dmworkbase/package.json
+++ b/packages/dmworkbase/package.json
@@ -6,6 +6,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@mlt-org/octo-card-profile-octo-chat": "1.2.0-rc.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
@@ -35,6 +35,9 @@ import {
 } from "./sdk/renderOctoCard";
 import { classifyCardSender, fetchSenderChannelInfo } from "./senderTrust";
 import "./index.css";
+import "@mlt-org/octo-card-profile-octo-chat/theme.css";
+import "@mlt-org/octo-card-profile-octo-chat/styles.css";
+import { cardMountRootClass } from "./renderProfile";
 
 export { InteractiveCardContent } from "./InteractiveCardContent";
 
@@ -162,6 +165,7 @@ export class InteractiveCardCell extends MessageCell {
       profile: effective.profile,
       cardVersion: effective.cardVersion,
       card: effective.card,
+      renderProfile: effective.renderProfile,
     });
     return { plain, decision };
   }
@@ -182,9 +186,9 @@ export class InteractiveCardCell extends MessageCell {
       this.renderedKey = null;
       return;
     }
-    const key = `${decision.allowInteractive ? "v2" : "v1"}:${JSON.stringify(
-      decision.card
-    )}`;
+    const key = `${decision.renderProfile}:${
+      decision.allowInteractive ? "v2" : "v1"
+    }:${JSON.stringify(decision.card)}`;
     if (key === this.renderedKey) return;
     this.renderedKey = key;
     // 新帧到达：作废在飞提交（响应/超时不再生效）并重置交互态（loading/错误/超时）。
@@ -200,6 +204,7 @@ export class InteractiveCardCell extends MessageCell {
         onAction: (action, card) => this.handleCardAction(action, card),
         tableCopyLabel: t("base.message.interactiveCard.copyTable"),
         onTableCopy: (text) => this.handleTableCopy(text),
+        renderProfile: decision.renderProfile,
       });
     } catch {
       // 已过 octo 预校验仍渲染失败属极端边角 → fail-safe 渲纯文本（不走 markdown/HTML）。
@@ -229,6 +234,7 @@ export class InteractiveCardCell extends MessageCell {
       onAction: (action, card) => this.handleCardAction(action, card),
       tableCopyLabel: t("base.message.interactiveCard.copyTable"),
       onTableCopy: (text) => this.handleTableCopy(text),
+      renderProfile: decision.renderProfile,
     });
   }
 
@@ -485,7 +491,7 @@ export class InteractiveCardCell extends MessageCell {
     switch (decision.kind) {
       case "card": {
         const cls =
-          "wk-interactive-card-sdk" +
+          cardMountRootClass(decision.renderProfile) +
           (agentProgress ? " wk-interactive-card-sdk--agent-progress" : "") +
           (this.submitting ? " wk-interactive-card-sdk--submitting" : "") +
           // webhook 卡展示-only：输入置灰不可交互（提交侧另有 handleSubmit 双保险）。

--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardContent.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardContent.ts
@@ -34,6 +34,7 @@ export class InteractiveCardContent extends MessageContent {
   plain = "";
   cardVersion = "";
   profile = "";
+  renderProfile = "";
   /** P2 tolerant-only，波 1 不读取行为，仅保留避免丢字段。 */
   cardSeq?: number;
   transient?: boolean;
@@ -50,6 +51,7 @@ export class InteractiveCardContent extends MessageContent {
     this.plain = asString(raw?.plain);
     this.cardVersion = asString(raw?.card_version);
     this.profile = asString(raw?.profile);
+    this.renderProfile = asString(raw?.render_profile);
     if (typeof raw?.card_seq === "number") this.cardSeq = raw.card_seq;
     if (typeof raw?.transient === "boolean") this.transient = raw.transient;
     this.forwardedFromUID = asString(raw?.forwarded_from_uid);
@@ -62,6 +64,9 @@ export class InteractiveCardContent extends MessageContent {
       plain: this.plain,
       card_version: this.cardVersion,
       profile: this.profile,
+      ...(this.renderProfile.trim() === ""
+        ? {}
+        : { render_profile: this.renderProfile }),
     };
     if (this.cardSeq !== undefined) out.card_seq = this.cardSeq;
     if (this.transient !== undefined) out.transient = this.transient;
@@ -97,6 +102,7 @@ export function cloneInteractiveCardContentForForward(
   cloned.plain = content.plain;
   cloned.cardVersion = content.cardVersion;
   cloned.profile = content.profile;
+  cloned.renderProfile = content.renderProfile;
   cloned.cardSeq = content.cardSeq;
   cloned.transient = content.transient;
   cloned.forwardedFromUID = forwardedFromUID;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardRenderProfile.stories.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardRenderProfile.stories.css
@@ -1,0 +1,14 @@
+.wk-card-profile-story-item {
+  display: grid;
+  gap: var(--wk-sp-2);
+  max-width: 100%;
+}
+
+.wk-card-profile-story-label {
+  font-size: var(--wk-text-size-sm);
+  color: var(--wk-text-secondary);
+}
+
+.wk-card-profile-story-preview {
+  max-width: 100%;
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardRenderProfile.stories.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardRenderProfile.stories.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import "@mlt-org/octo-card-profile-octo-chat/theme.css";
+import "@mlt-org/octo-card-profile-octo-chat/styles.css";
+import decisionCard from "./fixtures/decision-0.2.json";
+import docsLegacyCard from "./fixtures/docs-access-0.2.json";
+import docsForgeCard from "./fixtures/docs-access-0.3.json";
+import {
+  cardMountRootClass,
+  type ResolvedCardRenderProfile,
+} from "./renderProfile";
+import { renderOctoCard } from "./sdk/renderOctoCard";
+import "./index.css";
+import "./InteractiveCardRenderProfile.stories.css";
+
+interface PreviewProps {
+  card: Record<string, unknown>;
+  label: string;
+  profile: ResolvedCardRenderProfile;
+  width: number;
+}
+
+function CardPreview({ card, label, profile, width }: PreviewProps) {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+    renderOctoCard({
+      card,
+      target,
+      renderProfile: profile,
+      onAction: () => {},
+    });
+  }, [card, profile]);
+
+  return (
+    <section className="wk-card-profile-story-item">
+      <span className="wk-card-profile-story-label">
+        {label} · {width}px
+      </span>
+      <div
+        className={`wk-card-profile-story-preview ${cardMountRootClass(
+          profile
+        )}`}
+        ref={targetRef}
+        style={{ width }}
+      />
+    </section>
+  );
+}
+
+interface StoryArgs {
+  width: 320 | 480 | 640;
+}
+
+const meta: Meta<StoryArgs> = {
+  title: "Messages/InteractiveCard/Render Profile",
+  parameters: { layout: "padded" },
+  args: { width: 480 },
+  argTypes: {
+    width: { control: "inline-radio", options: [320, 480, 640] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+export const LegacyCompatibility: Story = {
+  render: ({ width }) => (
+    <CardPreview
+      card={docsLegacyCard}
+      label="Legacy docs 0.2"
+      profile="legacy"
+      width={width}
+    />
+  ),
+};
+
+export const DecisionForgeProfile: Story = {
+  render: ({ width }) => (
+    <CardPreview
+      card={decisionCard}
+      label="Decision 0.2 · octo-chat/v1"
+      profile="octo-chat/v1"
+      width={width}
+    />
+  ),
+};
+
+export const DocsForgeProfile: Story = {
+  render: ({ width }) => (
+    <CardPreview
+      card={docsForgeCard}
+      label="Docs access 0.3 · octo-chat/v1"
+      profile="octo-chat/v1"
+      width={width}
+    />
+  ),
+};

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/InteractiveCardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/InteractiveCardContent.test.ts
@@ -34,18 +34,21 @@ function decode(raw: unknown): InteractiveCardContent {
 }
 
 describe("InteractiveCardContent.decodeJSON", () => {
-  it("正常 payload：逐字段解析 card/plain/card_version/profile", () => {
+  it("正常 payload：逐字段解析 card/plain/card_version/profile/render_profile", () => {
     const c = decode({
       type: 17,
       card: { type: "AdaptiveCard", body: [] },
       plain: "订单已发货",
       card_version: "1.5",
       profile: "octo/v1",
+      render_profile: "octo-chat/v1",
     });
     expect(c.card).toEqual({ type: "AdaptiveCard", body: [] });
     expect(c.plain).toBe("订单已发货");
     expect(c.cardVersion).toBe("1.5");
     expect(c.profile).toBe("octo/v1");
+    expect(c.renderProfile).toBe("octo-chat/v1");
+    expect(c.encodeJSON().render_profile).toBe("octo-chat/v1");
   });
 
   it("缺 card：归一为空对象，不抛错", () => {
@@ -56,6 +59,12 @@ describe("InteractiveCardContent.decodeJSON", () => {
   it("缺 plain：归一为空串", () => {
     const c = decode({ card: {}, card_version: "1.5", profile: "octo/v1" });
     expect(c.plain).toBe("");
+  });
+
+  it("缺 render_profile：保持 legacy 语义且编码时不新增字段", () => {
+    const c = decode({ card: {}, card_version: "1.5", profile: "octo/v1" });
+    expect(c.renderProfile).toBe("");
+    expect(c.encodeJSON()).not.toHaveProperty("render_profile");
   });
 
   it("字段类型异常：非字符串 plain / 非对象 card 全部安全归一", () => {
@@ -130,6 +139,7 @@ describe("cloneInteractiveCardContentForForward", () => {
     expect(cloned.plain).toBe("展示卡");
     expect(cloned.cardVersion).toBe("1.5");
     expect(cloned.profile).toBe("octo/v1");
+    expect(cloned.renderProfile).toBe("");
     expect(cloned.cardSeq).toBe(9);
     expect(cloned.transient).toBe(true);
     expect(cloned.forwardedFromUID).toBe("iwh_original");

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderDecision.test.tsx
@@ -229,6 +229,37 @@ describe("decideCardBody — 协商（第二道闸，可信 sender 前提）", (
   });
 });
 
+describe("decideCardBody — Render Profile 协商", () => {
+  const base = {
+    fromUID: "iwh_x",
+    profile: "octo/v1",
+    cardVersion: "1.5",
+    card: validCard,
+  };
+
+  it("缺 render_profile 永久走 legacy", () => {
+    const decision = decideCardBody(base);
+    expect(decision.kind).toBe("card");
+    if (decision.kind === "card") {
+      expect(decision.renderProfile).toBe("legacy");
+    }
+  });
+
+  it("octo-chat/v1 显式选择 Forge", () => {
+    const decision = decideCardBody({ ...base, renderProfile: "octo-chat/v1" });
+    expect(decision.kind).toBe("card");
+    if (decision.kind === "card") {
+      expect(decision.renderProfile).toBe("octo-chat/v1");
+    }
+  });
+
+  it("未知非空 render_profile 不回退 legacy", () => {
+    expect(
+      decideCardBody({ ...base, renderProfile: "octo-chat/v2" }).kind
+    ).toBe("hint");
+  });
+});
+
 describe("decideCardBody — card_version 1.6（对齐 SDK 上限，版本放宽但元素门禁不放松）", () => {
   const trusted = { fromUID: "iwh_x", profile: "octo/v1" as const };
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -5,6 +5,7 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+  createCardHostConfig,
   enhanceRenderedOctoCard,
   renderOctoCard,
 } from "../sdk/renderOctoCard";
@@ -50,6 +51,17 @@ function mountTarget(): HTMLDivElement {
 }
 
 describe("renderOctoCard", () => {
+  it("Forge 使用制品 HostConfig，legacy 仍使用宿主 HostConfig", () => {
+    const target = mountTarget();
+    target.style.setProperty("--wk-text-primary", "rgb(1, 2, 3)");
+    const legacy = createCardHostConfig(target, "legacy");
+    const forge = createCardHostConfig(target, "octo-chat/v1");
+    expect(legacy.fontSizes.extraLarge).toBe(20);
+    expect(forge.fontSizes.extraLarge).toBe(18);
+    expect(forge.actions.actionAlignment).toBe(2);
+    target.remove();
+  });
+
   it("渲染 octo/v2 子集：markdown 正文 + input/select + 按钮", () => {
     const target = mountTarget();
     renderOctoCard({ card: V2, target, onAction: () => {} });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderProfile.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderProfile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { cardMountRootClass, resolveCardRenderProfile } from "../renderProfile";
+
+describe("render profile selection", () => {
+  it("keeps legacy and Forge root classes mutually exclusive", () => {
+    expect(cardMountRootClass("legacy")).toBe("wk-interactive-card-sdk");
+    const forge = cardMountRootClass("octo-chat/v1");
+    expect(forge).toContain("wk-interactive-card-forge");
+    expect(forge).toContain("octo-card-profile");
+    expect(forge).not.toContain("wk-interactive-card-sdk");
+  });
+
+  it("accepts only the declared compatibility generation", () => {
+    expect(resolveCardRenderProfile("")).toEqual({
+      ok: true,
+      profile: "legacy",
+    });
+    expect(resolveCardRenderProfile("octo-chat/v1")).toEqual({
+      ok: true,
+      profile: "octo-chat/v1",
+    });
+    expect(resolveCardRenderProfile("octo-chat@1.2.0-rc.1")).toEqual({
+      ok: false,
+      reason: "unsupported-render-profile",
+    });
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/decision-0.2.json
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/decision-0.2.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "需要你选择",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "spacing": "None",
+                  "wrap": true
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "回复 @Octo 智能助手",
+                  "size": "Small",
+                  "weight": "Bolder",
+                  "isSubtle": true,
+                  "spacing": "None",
+                  "wrap": true,
+                  "horizontalAlignment": "Right"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "下一步从哪个方向继续？",
+          "size": "Large",
+          "weight": "Bolder",
+          "spacing": "Small",
+          "wrap": true
+        },
+        {
+          "type": "TextBlock",
+          "text": "选择只会生成一条新的用户消息，不会在这张卡内直接执行。",
+          "size": "Small",
+          "isSubtle": true,
+          "spacing": "Small",
+          "wrap": true
+        }
+      ]
+    },
+    {
+      "type": "Input.ChoiceSet",
+      "id": "decision_choice",
+      "style": "expanded",
+      "isRequired": true,
+      "errorMessage": "请选择一个方向",
+      "value": "interaction",
+      "spacing": "Large",
+      "wrap": true,
+      "choices": [
+        {
+          "title": "补全消息交互（推荐）\n明确卡片、独立用户消息与后续 AI 回复的边界。",
+          "value": "interaction"
+        },
+        {
+          "title": "完善移动端布局\n检查窄屏卡片、长按钮与建议输入区的排列。",
+          "value": "mobile"
+        },
+        {
+          "title": "输出开发规格\n整理组件结构、提交字段与消息关联契约。",
+          "value": "handoff"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "将作为新消息发送给 @Octo 智能助手",
+          "size": "Small",
+          "isSubtle": true,
+          "spacing": "None",
+          "wrap": true
+        },
+        {
+          "type": "TextBlock",
+          "text": "我选择「补全消息交互」，请按这个方向继续。",
+          "spacing": "Small",
+          "wrap": true
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "decision_send",
+              "title": "发送选择",
+              "style": "positive",
+              "data": {
+                "action": "decision_send",
+                "effect": "append_user_message",
+                "decision_id": "decision-next-step-001",
+                "reply_target_uid": "octo-assistant"
+              }
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "发送后将新增一条独立用户消息 · @Octo 智能助手",
+          "size": "Small",
+          "isSubtle": true,
+          "horizontalAlignment": "Right",
+          "spacing": "Small",
+          "wrap": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/docs-access-0.2.json
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/docs-access-0.2.json
@@ -1,0 +1,503 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "spacing": "None",
+      "verticalContentAlignment": "Center",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "verticalContentAlignment": "Center",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "verticalContentAlignment": "Center",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://api.iconify.design/lucide/file-text.svg?color=%236b7075",
+                      "altText": "文档",
+                      "width": "16px",
+                      "height": "16px",
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "文档申请",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "spacing": "Small",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "·  Q3 产品规划",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "待你处理",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "color": "Warning",
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "协作权限",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "bleed": true,
+      "separator": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "verticalContentAlignment": "Center",
+          "selectAction": {
+            "type": "Action.OpenUrl",
+            "title": "打开文档",
+            "url": "https://example.com/documents/2026-q3-okr"
+          },
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "2026 Q3 OKR",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder",
+                  "spacing": "None",
+                  "wrap": true
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://api.iconify.design/lucide/external-link.svg?color=%236b7075",
+                  "altText": "在新窗口打开",
+                  "width": "13px",
+                  "height": "13px",
+                  "spacing": "None"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": []
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "spacing": "Small",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "张三 ",
+              "weight": "Bolder",
+              "size": "Medium"
+            },
+            {
+              "type": "TextRun",
+              "text": "申请成为此文档的协作者。",
+              "isSubtle": true,
+              "size": "Medium"
+            }
+          ]
+        },
+        {
+          "type": "ColumnSet",
+          "spacing": "Medium",
+          "verticalContentAlignment": "Center",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://api.dicebear.com/9.x/initials/svg?seed=Zhang%20San&backgroundColor=f2f3f4&fontSize=40",
+                  "altText": "张三",
+                  "style": "Person",
+                  "width": "28px",
+                  "height": "28px",
+                  "spacing": "None"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "spacing": "Default",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "张三",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "spacing": "None",
+                  "wrap": false
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://api.iconify.design/lucide/user-round.svg?color=%236b7075",
+                          "altText": "",
+                          "width": "12px",
+                          "height": "12px",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "spacing": "Small",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "申请人",
+                          "size": "Small",
+                          "isSubtle": true,
+                          "spacing": "None",
+                          "wrap": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Bottom",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://api.iconify.design/lucide/clock-3.svg?color=%236b7075",
+                          "altText": "",
+                          "width": "13px",
+                          "height": "13px",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "spacing": "Small",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "2026-07-16 11:00",
+                          "size": "Small",
+                          "isSubtle": true,
+                          "spacing": "None",
+                          "wrap": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "style": "emphasis",
+          "spacing": "Large",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://api.iconify.design/lucide/message-square.svg?color=%23555b61",
+                      "altText": "",
+                      "width": "18px",
+                      "height": "18px",
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "申请原因",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "希望加入协作，以补充 KR3 数据。",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "Small",
+                      "wrap": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "deny_panel",
+          "style": "attention",
+          "isVisible": false,
+          "spacing": "Large",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "拒绝文档访问申请",
+              "size": "Medium",
+              "weight": "Bolder",
+              "spacing": "None",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "拒绝后，张三 将无法获得“2026 Q3 OKR”的协作权限。",
+              "isSubtle": true,
+              "spacing": "Medium",
+              "wrap": true
+            },
+            {
+              "type": "Input.Text",
+              "id": "deny_reason",
+              "label": "拒绝原因",
+              "placeholder": "说明原因，便于申请人调整后重新申请",
+              "isMultiline": true,
+              "isRequired": true,
+              "errorMessage": "请填写拒绝原因",
+              "maxLength": 200,
+              "spacing": "Medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "最多 200 个字",
+              "size": "Small",
+              "isSubtle": true,
+              "spacing": "Small"
+            },
+            {
+              "type": "ActionSet",
+              "spacing": "Medium",
+              "horizontalAlignment": "Right",
+              "actions": [
+                {
+                  "type": "Action.ToggleVisibility",
+                  "title": "取消",
+                  "targetElements": [
+                    {
+                      "elementId": "deny_panel",
+                      "isVisible": false
+                    },
+                    {
+                      "elementId": "primary_actions",
+                      "isVisible": true
+                    }
+                  ]
+                },
+                {
+                  "type": "Action.Submit",
+                  "id": "deny",
+                  "title": "确认拒绝",
+                  "style": "destructive",
+                  "iconUrl": "https://api.iconify.design/lucide/x.svg?color=%23f54a45",
+                  "data": {
+                    "action": "deny",
+                    "request_id": "DOC-REQ-024"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "verticalContentAlignment": "Center",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "申请于 11:03",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "spacing": "None",
+                  "wrap": false
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "id": "primary_actions",
+                  "spacing": "None",
+                  "actions": [
+                    {
+                      "type": "Action.OpenUrl",
+                      "id": "view_document",
+                      "title": "查看详情",
+                      "url": "https://example.com/documents/2026-q3-okr",
+                      "iconUrl": "https://api.iconify.design/lucide/eye.svg?color=%23555b61"
+                    },
+                    {
+                      "type": "Action.ToggleVisibility",
+                      "title": "拒绝",
+                      "style": "destructive",
+                      "iconUrl": "https://api.iconify.design/lucide/x.svg?color=%23f54a45",
+                      "targetElements": [
+                        {
+                          "elementId": "deny_panel",
+                          "isVisible": true
+                        },
+                        {
+                          "elementId": "primary_actions",
+                          "isVisible": false
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Action.Submit",
+                      "id": "approve",
+                      "title": "允许",
+                      "style": "positive",
+                      "associatedInputs": "none",
+                      "iconUrl": "https://api.iconify.design/lucide/check.svg?color=%23ffffff",
+                      "data": {
+                        "action": "approve",
+                        "request_id": "DOC-REQ-024"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/docs-access-0.3.json
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/docs-access-0.3.json
@@ -1,0 +1,506 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "spacing": "None",
+      "minHeight": "28px",
+      "verticalContentAlignment": "Center",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch",
+          "verticalContentAlignment": "Center",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "verticalContentAlignment": "Center",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://api.iconify.design/lucide/file-text.svg?color=%236b7075",
+                      "altText": "文档",
+                      "width": "16px",
+                      "height": "16px",
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "文档申请",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "spacing": "Small",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "·  Q3 产品规划",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "id": "octo-badge-warning-request-state",
+                      "text": "待你处理",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "color": "Warning",
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "id": "octo-badge-neutral-permission",
+                      "text": "协作权限",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "None",
+                      "wrap": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "accent",
+      "bleed": true,
+      "separator": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "verticalContentAlignment": "Center",
+          "selectAction": {
+            "type": "Action.OpenUrl",
+            "title": "打开文档",
+            "url": "https://example.com/documents/2026-q3-okr"
+          },
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "2026 Q3 OKR",
+                  "size": "ExtraLarge",
+                  "weight": "Bolder",
+                  "spacing": "None",
+                  "wrap": true
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://api.iconify.design/lucide/external-link.svg?color=%236b7075",
+                  "altText": "在新窗口打开",
+                  "width": "13px",
+                  "height": "13px",
+                  "spacing": "None"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": []
+            }
+          ]
+        },
+        {
+          "type": "RichTextBlock",
+          "spacing": "Small",
+          "inlines": [
+            {
+              "type": "TextRun",
+              "text": "张三 ",
+              "weight": "Bolder",
+              "size": "Medium"
+            },
+            {
+              "type": "TextRun",
+              "text": "申请成为此文档的协作者。",
+              "isSubtle": true,
+              "size": "Medium"
+            }
+          ]
+        },
+        {
+          "type": "ColumnSet",
+          "spacing": "Medium",
+          "verticalContentAlignment": "Center",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "https://api.dicebear.com/9.x/initials/svg?seed=Zhang%20San&backgroundColor=f2f3f4&fontSize=40",
+                  "altText": "张三",
+                  "style": "Person",
+                  "width": "28px",
+                  "height": "28px",
+                  "spacing": "None"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "spacing": "Default",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "张三",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "spacing": "None",
+                  "wrap": false
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://api.iconify.design/lucide/user-round.svg?color=%236b7075",
+                          "altText": "",
+                          "width": "12px",
+                          "height": "12px",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "spacing": "Small",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "申请人",
+                          "size": "Small",
+                          "isSubtle": true,
+                          "spacing": "None",
+                          "wrap": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Bottom",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "url": "https://api.iconify.design/lucide/clock-3.svg?color=%236b7075",
+                          "altText": "",
+                          "width": "13px",
+                          "height": "13px",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "spacing": "Small",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "2026-07-16 11:00",
+                          "size": "Small",
+                          "isSubtle": true,
+                          "spacing": "None",
+                          "wrap": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "style": "emphasis",
+          "spacing": "Large",
+          "items": [
+            {
+              "type": "ColumnSet",
+              "spacing": "None",
+              "columns": [
+                {
+                  "type": "Column",
+                  "width": "auto",
+                  "items": [
+                    {
+                      "type": "Image",
+                      "url": "https://api.iconify.design/lucide/message-square.svg?color=%23555b61",
+                      "altText": "",
+                      "width": "18px",
+                      "height": "18px",
+                      "spacing": "None"
+                    }
+                  ]
+                },
+                {
+                  "type": "Column",
+                  "width": "stretch",
+                  "spacing": "Default",
+                  "items": [
+                    {
+                      "type": "TextBlock",
+                      "text": "申请原因",
+                      "size": "Small",
+                      "weight": "Bolder",
+                      "spacing": "None"
+                    },
+                    {
+                      "type": "TextBlock",
+                      "text": "希望加入协作，以补充 KR3 数据。",
+                      "size": "Small",
+                      "isSubtle": true,
+                      "spacing": "Small",
+                      "wrap": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "rejection_form",
+          "style": "attention",
+          "isVisible": false,
+          "spacing": "Large",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "拒绝文档访问申请",
+              "size": "Medium",
+              "weight": "Bolder",
+              "spacing": "None",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "text": "拒绝后，张三 将无法获得“2026 Q3 OKR”的协作权限。",
+              "isSubtle": true,
+              "spacing": "Medium",
+              "wrap": true
+            },
+            {
+              "type": "Input.Text",
+              "id": "rejection_reason",
+              "label": "拒绝原因",
+              "placeholder": "说明原因，便于申请人调整后重新申请",
+              "isMultiline": true,
+              "isRequired": true,
+              "errorMessage": "请填写拒绝原因",
+              "maxLength": 200,
+              "spacing": "Medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "最多 200 个字",
+              "size": "Small",
+              "isSubtle": true,
+              "spacing": "Small"
+            },
+            {
+              "type": "ActionSet",
+              "spacing": "Medium",
+              "horizontalAlignment": "Right",
+              "actions": [
+                {
+                  "type": "Action.ToggleVisibility",
+                  "title": "取消",
+                  "targetElements": [
+                    {
+                      "elementId": "rejection_form",
+                      "isVisible": false
+                    },
+                    {
+                      "elementId": "approval_actions",
+                      "isVisible": true
+                    }
+                  ]
+                },
+                {
+                  "type": "Action.Submit",
+                  "id": "deny",
+                  "title": "确认拒绝",
+                  "style": "destructive",
+                  "iconUrl": "https://api.iconify.design/lucide/x.svg?color=%23f54a45",
+                  "data": {
+                    "action": "deny",
+                    "request_id": "DOC-REQ-024"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "verticalContentAlignment": "Center",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "申请于 11:03",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "spacing": "None",
+                  "wrap": false
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "id": "approval_actions",
+                  "spacing": "None",
+                  "actions": [
+                    {
+                      "type": "Action.OpenUrl",
+                      "id": "view_document",
+                      "title": "查看详情",
+                      "url": "https://example.com/documents/2026-q3-okr",
+                      "iconUrl": "https://api.iconify.design/lucide/eye.svg?color=%23555b61"
+                    },
+                    {
+                      "type": "Action.ToggleVisibility",
+                      "title": "拒绝",
+                      "style": "destructive",
+                      "iconUrl": "https://api.iconify.design/lucide/x.svg?color=%23f54a45",
+                      "targetElements": [
+                        {
+                          "elementId": "rejection_form",
+                          "isVisible": true
+                        },
+                        {
+                          "elementId": "approval_actions",
+                          "isVisible": false
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Action.Submit",
+                      "id": "approve",
+                      "title": "允许",
+                      "style": "positive",
+                      "associatedInputs": "none",
+                      "iconUrl": "https://api.iconify.design/lucide/check.svg?color=%23ffffff",
+                      "data": {
+                        "action": "approve",
+                        "request_id": "DOC-REQ-024"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/index.css
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/index.css
@@ -25,6 +25,7 @@
 }
 
 .wk-interactive-card > .wk-interactive-card-sdk,
+.wk-interactive-card > .wk-interactive-card-forge,
 .wk-interactive-card > .wk-interactive-card-plain {
   width: 100%;
 }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/renderDecision.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/renderDecision.ts
@@ -2,6 +2,10 @@ import { negotiate } from "./guards";
 import { classifyCardSender, isTrustedCardSender } from "./senderTrust";
 import { CARD_PROFILE_OCTO_V2 } from "./types";
 import { validateCardForOcto } from "./validateCardForOcto";
+import {
+  resolveCardRenderProfile,
+  type ResolvedCardRenderProfile,
+} from "./renderProfile";
 
 /**
  * 卡片主体渲染决策（纯策略，独立于 SDK 挂载）。集中兜底，对齐服务端
@@ -34,6 +38,7 @@ export type CardDecision =
       card: Record<string, unknown>;
       allowInteractive: boolean;
       interactive: boolean;
+      renderProfile: ResolvedCardRenderProfile;
     };
 
 export interface DecideCardInput {
@@ -44,6 +49,7 @@ export interface DecideCardInput {
    */
   forwardedFromUID?: string;
   profile: string;
+  renderProfile?: string;
   cardVersion: string;
   card: Record<string, unknown>;
 }
@@ -56,12 +62,18 @@ export function decideCardBody(input: DecideCardInput): CardDecision {
     return { kind: "plain" };
   }
 
-  // 2. profile / card_version 协商：不支持 → plain + 更新提示。
+  // 2. Render Profile 协商：缺失走 legacy，未知非空值提示升级。
+  const renderProfile = resolveCardRenderProfile(input.renderProfile ?? "");
+  if (!renderProfile.ok) {
+    return { kind: "hint" };
+  }
+
+  // 3. Wire profile / card_version 协商：不支持 → plain + 更新提示。
   if (!negotiate(input.profile, input.cardVersion).ok) {
     return { kind: "hint" };
   }
 
-  // 3. octo 预校验（整卡降级守门）。通过才交 SDK 渲染。
+  // 4. octo 预校验（整卡降级守门）。通过才交 SDK 渲染。
   const allowInteractive = input.profile === CARD_PROFILE_OCTO_V2;
   if (!validateCardForOcto(input.card, { allowInteractive }).ok) {
     return { kind: "plain" };
@@ -72,5 +84,6 @@ export function decideCardBody(input: DecideCardInput): CardDecision {
     card: input.card,
     allowInteractive,
     interactive: trust === "bot",
+    renderProfile: renderProfile.profile,
   };
 }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/renderProfile.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/renderProfile.ts
@@ -1,0 +1,28 @@
+export const FORGE_RENDER_PROFILE = "octo-chat/v1";
+
+export type ResolvedCardRenderProfile = "legacy" | typeof FORGE_RENDER_PROFILE;
+
+export type RenderProfileResolution =
+  | { ok: true; profile: ResolvedCardRenderProfile }
+  | { ok: false; reason: "unsupported-render-profile" };
+
+/**
+ * 缺字段永久代表 legacy；只有显式 octo-chat/v1 才启用 Forge 制品。
+ * 未知非空值不能套用 legacy，否则新模板可能被旧样式错误渲染。
+ */
+export function resolveCardRenderProfile(
+  value: string
+): RenderProfileResolution {
+  const normalized = value.trim();
+  if (normalized === "") return { ok: true, profile: "legacy" };
+  if (normalized === FORGE_RENDER_PROFILE) {
+    return { ok: true, profile: FORGE_RENDER_PROFILE };
+  }
+  return { ok: false, reason: "unsupported-render-profile" };
+}
+
+export function cardMountRootClass(profile: ResolvedCardRenderProfile): string {
+  return profile === FORGE_RENDER_PROFILE
+    ? "wk-interactive-card-forge octo-card-profile"
+    : "wk-interactive-card-sdk";
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
@@ -1,10 +1,15 @@
-import { AdaptiveCard, type Action } from "adaptivecards";
+import { AdaptiveCard, HostConfig, type Action } from "adaptivecards";
+import forgeHostConfig from "@mlt-org/octo-card-profile-octo-chat/host-config.json";
 import { cardMarkdownToSafeHtml } from "../renderer/cardMarkdownHtml";
 import { browserCssVarResolver, buildOctoHostConfig } from "./octoHostConfig";
 import { createOctoSerializationContext } from "./octoSerialization";
 import { sanitizeCardTree } from "./sanitizeCardTree";
 import { enhanceAgentProgressLayout } from "./agentProgressLayout";
 import { attachTableCopyButtons } from "./tableCopy";
+import {
+  FORGE_RENDER_PROFILE,
+  type ResolvedCardRenderProfile,
+} from "../renderProfile";
 
 /**
  * 用官方 AdaptiveCards SDK 渲染一张**已通过 octo 预校验**的卡片进目标元素。
@@ -37,6 +42,16 @@ export interface RenderOctoCardOptions {
   onAction: (action: Action, card: AdaptiveCard) => void;
   tableCopyLabel?: string;
   onTableCopy?: (text: string) => void;
+  renderProfile?: ResolvedCardRenderProfile;
+}
+
+export function createCardHostConfig(
+  target: HTMLElement,
+  renderProfile: ResolvedCardRenderProfile = "legacy"
+): HostConfig {
+  return renderProfile === FORGE_RENDER_PROFILE
+    ? new HostConfig(forgeHostConfig)
+    : buildOctoHostConfig(browserCssVarResolver(target));
 }
 
 export function enhanceRenderedOctoCard(options: RenderOctoCardOptions): void {
@@ -53,10 +68,17 @@ export function enhanceRenderedOctoCard(options: RenderOctoCardOptions): void {
 }
 
 export function renderOctoCard(options: RenderOctoCardOptions): void {
-  const { card, target, onAction, tableCopyLabel, onTableCopy } = options;
+  const {
+    card,
+    target,
+    onAction,
+    tableCopyLabel,
+    onTableCopy,
+    renderProfile = "legacy",
+  } = options;
   ensureMarkdownHook();
   const ac = new AdaptiveCard();
-  ac.hostConfig = buildOctoHostConfig(browserCssVarResolver(target));
+  ac.hostConfig = createCardHostConfig(target, renderProfile);
   ac.onExecuteAction = (action) => onAction(action, ac);
   // 图片类 URL 消毒（https-only），在 parse 前——SDK 自身不做 scheme 检查。
   ac.parse(sanitizeCardTree(card), createOctoSerializationContext());

--- a/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/types.ts
@@ -51,6 +51,8 @@ export interface InteractiveCardPayload {
   plain: string;
   card_version: string;
   profile: string;
+  /** 可选视觉兼容代际；缺失永久表示 legacy。 */
+  render_profile?: string;
   /** P2 tolerant-only，波 1 不实现任何行为。 */
   card_seq?: number;
   /** P2 tolerant-only，波 1 不实现任何行为。 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@lottiefiles/lottie-player':
         specifier: ^1.5.5
         version: 1.7.1
+      '@mlt-org/octo-card-profile-octo-chat':
+        specifier: 1.2.0-rc.1
+        version: 1.2.0-rc.1
       '@react-pdf-viewer/bookmark':
         specifier: ^3.12.0
         version: 3.12.0(pdfjs-dist@3.11.174(encoding@0.1.13))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -2644,6 +2647,9 @@ packages:
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.1':
+    resolution: {integrity: sha512-rzaO97RpRgGStMKEVBOsxt1F2/v7MTQOZwN64vkPIgi37090ng125XNNfB9D9TD+pOF46I4OBmPo/rjrNcQl6A==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -10255,6 +10261,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
@@ -13180,6 +13187,8 @@ snapshots:
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.1': {}
 
   '@mswjs/interceptors@0.41.9':
     dependencies:
@@ -17793,7 +17802,7 @@ snapshots:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -17818,7 +17827,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.28.0(eslint@7.32.0)
@@ -17852,7 +17861,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 7.32.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.11
@@ -17871,16 +17880,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
-      eslint: 7.32.0
-      eslint-import-resolver-node: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
@@ -17889,7 +17888,7 @@ snapshots:
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17913,35 +17912,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 7.32.0
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Summary
- add opt-in `render_profile: "octo-chat/v1"` negotiation for Interactive Cards
- consume the published `@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.1` HostConfig and scoped styles
- keep messages without `render_profile` permanently on the existing legacy renderer
- add Storybook comparisons and local validation documentation

## Compatibility
- existing backend templates are unchanged
- existing cards without `render_profile` retain the current HostConfig, root class, CSS, and interactions
- unknown non-empty render profiles show the existing upgrade hint instead of falling back to mismatched legacy styling
- Forge CSS is scoped under `.octo-card-profile`

## Verification
- `pnpm install --frozen-lockfile --registry=https://registry.npmjs.org/`
- `pnpm --filter @octo/base test` (213 files, 1972 tests)
- `pnpm --filter @octo/web build`
- published dependency name, version, integrity, tarball, and provenance verified