### PR TITLE
fix(dmworkbase): align system notice with capsule message style

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -49,6 +49,11 @@ body[theme-mode="dark"] .wk-conversation-content {
   padding: var(--wk-sp-2) var(--wk-sp-4);
 }
 
+.wk-message-item-system > .wk-message-system,
+.wk-message-item:has(.wk-message-system) > .wk-message-system {
+  max-width: 100%;
+}
+
 .wk-message-item-fold-session {
   justify-content: flex-start;
   padding: 24px 0 0;

--- a/packages/dmworkbase/src/Messages/ApproveGroupMember/index.css
+++ b/packages/dmworkbase/src/Messages/ApproveGroupMember/index.css
@@ -1,25 +1,23 @@
 
 .wk-message-system {
     display: block;
+    box-sizing: border-box;
     width: fit-content;
-    max-width: min(100%, var(--wk-width-max-message));
+    max-width: 100%;
     margin: 0 auto;
     text-align: center;
-    font-size: var(--wk-text-size-xs, 11px);
-    font-weight: var(--wk-font-medium, 500);
-    line-height: var(--wk-leading-normal, 1.5);
-    color: var(--wk-text-tertiary, #9498A8);
-    background: var(--wk-border-subtle, rgba(0,0,0,0.03));
-    border-radius: var(--wk-r-full, 9999px);
-    padding: calc(var(--wk-sp-1, 4px) / 2) calc(var(--wk-sp-2, 8px) + (var(--wk-sp-1, 4px) / 2));
-    white-space: pre-line;
+    font-size: var(--wk-text-size-xs);
+    font-weight: var(--wk-font-regular);
+    line-height: var(--wk-leading-normal);
+    color: var(--wk-text-tertiary);
+    background: var(--wk-border-subtle);
+    border-radius: min(var(--wk-r-full), var(--wk-r-xl));
+    padding: var(--wk-sp-1) var(--wk-sp-2);
+    white-space: normal;
     overflow-wrap: anywhere;
 }
 .wk-message-approve {
-    margin-left: var(--wk-sp-1, 4px);
+    margin-left: var(--wk-sp-1);
     color: var(--wk-text-accent);
     text-decoration: none;
-}
-body[theme-mode=dark] .wk-message-system  {
-    color: var(--wk-text-tertiary, #7A7F96);
 }

--- a/packages/dmworkbase/src/Messages/System/index.css
+++ b/packages/dmworkbase/src/Messages/System/index.css
@@ -1,20 +1,17 @@
 .wk-message-system {
     display: block;
+    box-sizing: border-box;
     width: fit-content;
-    max-width: min(100%, var(--wk-width-max-message));
+    max-width: 100%;
     margin: 0 auto;
     text-align: center;
-    font-size: var(--wk-text-size-xs, 11px);
-    font-weight: var(--wk-font-medium, 500);
-    line-height: var(--wk-leading-normal, 1.5);
-    color: var(--wk-text-tertiary, #9498A8);
-    background: var(--wk-border-subtle, rgba(0,0,0,0.03));
-    border-radius: var(--wk-r-full, 9999px);
-    padding: calc(var(--wk-sp-1, 4px) / 2) calc(var(--wk-sp-2, 8px) + (var(--wk-sp-1, 4px) / 2));
-    white-space: pre-line;
+    font-size: var(--wk-text-size-xs);
+    font-weight: var(--wk-font-regular);
+    line-height: var(--wk-leading-normal);
+    color: var(--wk-text-tertiary);
+    background: var(--wk-border-subtle);
+    border-radius: min(var(--wk-r-full), var(--wk-r-xl));
+    padding: var(--wk-sp-1) var(--wk-sp-2);
+    white-space: normal;
     overflow-wrap: anywhere;
-}
-
-body[theme-mode=dark] .wk-message-system {
-    color: var(--wk-text-tertiary, #7A7F96);
 }


### PR DESCRIPTION
## Summary

Update system and approval notice styles to match the compact capsule message design.

## Changes

- Use normal whitespace handling so notice text is rendered as compact inline copy.
- Keep `max-width: 100%` and `overflow-wrap: anywhere` to avoid horizontal overflow.
- Adjust typography, padding, and radius to align system notices with the capsule visual style.
- Synchronize the duplicate `.wk-message-system` styles used by system notices and approval notices.

## Product Intent

The `white-space` change from `pre-line` to `normal` is intentional. System notices are treated as compact capsule messages, so server-provided line breaks are not preserved. Long text can still wrap through `overflow-wrap: anywhere` as a layout fallback.

## Verification

- Confirmed the change in the local dev server at `http://localhost:5185/`.
- Ran `git diff --check origin/main...HEAD` successfully.

Closes #985
