### PR TITLE
ci(e2e): GitHub Actions e2e gate + @p0 tags

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-nightly
   cancel-in-progress: true
@@ -18,9 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 11.2.2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
@@ -51,9 +52,7 @@ jobs:
         with:
           name: build-e2e-nightly
           path: apps/web/build-e2e/
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 11.2.2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,75 @@
+# e2e nightly: 全量跑 (排除 @visual, baseline 未 ready 前跳过视觉)
+# 每天 UTC 03:00 (北京 11:00) 触发, 只在 default branch 生效.
+# workflow_dispatch 也开着, 便于维护者手动触发 debug.
+
+name: e2e-nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-nightly
+  cancel-in-progress: true
+
+jobs:
+  install-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 11.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Build e2e bundle
+        working-directory: apps/web
+        run: pnpm build:e2e
+      - name: Upload build-e2e artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-e2e-nightly
+          path: apps/web/build-e2e/
+          retention-days: 1
+
+  e2e-all:
+    needs: install-build
+    runs-on: ubuntu-22.04
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+    env:
+      E2E_TARGET: local
+      PW_PREVIEW_PORT: "5174"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-e2e-nightly
+          path: apps/web/build-e2e/
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 11.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run all non-@visual e2e
+        working-directory: apps/web
+        # grep-invert @visual: baseline 未 ready, 视觉 case 目前必红且不该 block nightly
+        run: pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts --grep-invert "@visual"
+      - name: Upload playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-nightly
+          path: |
+            apps/web/e2e-kit/playwright-report/
+            apps/web/e2e-kit/test-results/
+          retention-days: 30

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -59,10 +59,38 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Run all non-@visual e2e
+      - name: Run e2e (tagged @p* only, non-visual)
         working-directory: apps/web
-        # grep-invert @visual: baseline 未 ready, 视觉 case 目前必红且不该 block nightly
-        run: pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts --grep-invert "@visual"
+        # --grep "@p[0-9]": 只跑打了优先级 tag 的 case (@p0/@p1/@p2), 排除:
+        #   - tests/bind/ (未打 @p 系列, dev-server-only, 未验证过 preview 环境)
+        #   - tests/standalone-doc/ (同上, AC-N: pattern 未走 CaseId 约定)
+        # --grep-invert "@visual": baseline 未 ready, 视觉 case 目前必红且不该 block nightly
+        # 组合语义: grep AND grep-invert (playwright 官方支持)
+        shell: bash
+        run: |
+          set +e
+          pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts \
+            --grep "@p[0-9]" --grep-invert "@visual"
+          PW_EXIT=$?
+          set -e
+
+          JUNIT="e2e-kit/playwright-report/junit.xml"
+          if [[ ! -f "$JUNIT" ]]; then
+            echo "❌ junit.xml missing, treat as hard fail (playwright exit=$PW_EXIT)"
+            exit 1
+          fi
+          TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
+          # nightly 也加 tests=0 guard: 防 grep drift 让 nightly 静默"全绿"
+          EXPECTED_P0=29
+          if [[ "$TOTAL_TESTS" -eq 0 ]]; then
+            echo "❌ nightly tests=0 (grep 漂了 / preview 挂了), fail"
+            exit 1
+          elif [[ "$TOTAL_TESTS" -lt "$EXPECTED_P0" ]]; then
+            echo "❌ nightly tests=$TOTAL_TESTS < EXPECTED_P0=$EXPECTED_P0 (有 case 掉 @p tag), fail"
+            exit 1
+          fi
+          echo "✅ nightly ran $TOTAL_TESTS tests (playwright exit=$PW_EXIT)"
+          exit $PW_EXIT
       - name: Upload playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,10 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e.yml"
+      - ".github/workflows/e2e-nightly.yml"
+
+permissions:
+  contents: read
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -25,9 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 11.2.2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
@@ -58,9 +60,7 @@ jobs:
         with:
           name: build-e2e
           path: apps/web/build-e2e/
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 11.2.2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
@@ -87,6 +87,8 @@ jobs:
             /<\/testcase>/ { name="" }
           ' "$JUNIT")
           TOTAL_FAIL=$(echo "$FAILED_NAMES" | grep -c . || true)
+          # visual vs business split 依赖 playwright junit reporter 把 test title (含 @tag) 写进 <testcase name=...>.
+          # 若未来 reporter 改成不带 tag, 此 grep 将退化 (全部误判 business), 需同步改判定.
           VISUAL_FAIL=$(echo "$FAILED_NAMES" | grep -c "@visual" || true)
           BUSINESS_FAIL=$((TOTAL_FAIL - VISUAL_FAIL))
           TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
@@ -100,7 +102,7 @@ jobs:
           if [[ "$TOTAL_FAIL" -gt 0 ]]; then
             echo ""
             echo "   fail case names:"
-            echo "$FAILED_NAMES" | sed 's/^/     · /'
+            echo "$FAILED_NAMES" | awk '{print "     · " $0}'
           fi
           echo "═════════════════════════════════════════════════════════════"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,131 @@
+# e2e MR gate: build once, run @p0 cases, junit 后处理判 business vs visual fail
+# 姿势沿用 e2e-kit v0.4 依据 (docs/methodology/module-organization.md tag 层次):
+#   - @p0 阻断 (fail block PR)
+#   - @visual 视觉基线 (fail 不 block, 需 baseline 更新 workflow, 目前无 case)
+# 冷启动 baseline 未 ready 期间, MR 只跑 @p0, 完全跳过 @visual (grep 无 @visual pattern).
+
+name: e2e
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/web/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/e2e.yml"
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 11.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Build e2e bundle (tree-shakes MSW into build-e2e/)
+        working-directory: apps/web
+        run: pnpm build:e2e
+      - name: Upload build-e2e artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-e2e
+          path: apps/web/build-e2e/
+          retention-days: 1
+
+  e2e-p0:
+    needs: install-build
+    runs-on: ubuntu-22.04
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+    env:
+      E2E_TARGET: local
+      PW_PREVIEW_PORT: "5173"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-e2e
+          path: apps/web/build-e2e/
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 11.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run @p0 e2e
+        working-directory: apps/web
+        shell: bash
+        run: |
+          set +e
+          pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts --grep "@p0"
+          PW_EXIT=$?
+          set -e
+
+          JUNIT="e2e-kit/playwright-report/junit.xml"
+          if [[ ! -f "$JUNIT" ]]; then
+            echo "❌ junit.xml missing, treat as hard fail (playwright exit=$PW_EXIT)"
+            exit 1
+          fi
+          FAILED_NAMES=$(awk '
+            /<testcase / { match($0, /name="[^"]*"/); name = substr($0, RSTART+6, RLENGTH-7); has_fail=0; next }
+            /<failure|<error/ { if (name && !has_fail) { print name; has_fail=1 } }
+            /<\/testcase>/ { name="" }
+          ' "$JUNIT")
+          TOTAL_FAIL=$(echo "$FAILED_NAMES" | grep -c . || true)
+          VISUAL_FAIL=$(echo "$FAILED_NAMES" | grep -c "@visual" || true)
+          BUSINESS_FAIL=$((TOTAL_FAIL - VISUAL_FAIL))
+          TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
+          echo ""
+          echo "═════════════════════════════════════════════════════════════"
+          echo "📊 e2e @p0 summary (playwright exit=$PW_EXIT):"
+          echo "   total tests:   $TOTAL_TESTS"
+          echo "   total fail:    $TOTAL_FAIL"
+          echo "   business fail: $BUSINESS_FAIL"
+          echo "   visual fail:   $VISUAL_FAIL"
+          if [[ "$TOTAL_FAIL" -gt 0 ]]; then
+            echo ""
+            echo "   fail case names:"
+            echo "$FAILED_NAMES" | sed 's/^/     · /'
+          fi
+          echo "═════════════════════════════════════════════════════════════"
+
+          if [[ "$TOTAL_TESTS" -eq 0 ]]; then
+            echo "❌ tests=0 (playwright 没跑起 test, 通常是 preview server timeout), block PR"
+            exit 1
+          elif [[ "$BUSINESS_FAIL" -gt 0 ]]; then
+            echo "❌ 有 $BUSINESS_FAIL 个业务 case fail → block PR"
+            exit 1
+          elif [[ "$VISUAL_FAIL" -gt 0 ]]; then
+            echo "⚠️  仅 $VISUAL_FAIL 个视觉 case fail → allow PR (需手动更新 baseline)"
+            exit 0
+          elif [[ "$PW_EXIT" -ne 0 ]]; then
+            echo "❌ playwright exit=$PW_EXIT 但 junit 无 fail 条目, block PR"
+            exit 1
+          else
+            echo "✅ all pass"
+            exit 0
+          fi
+      - name: Upload playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-p0
+          path: |
+            apps/web/e2e-kit/playwright-report/
+            apps/web/e2e-kit/test-results/
+          retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,9 @@ jobs:
           TOTAL_FAIL=$(echo "$FAILED_NAMES" | grep -c . || true)
           # visual vs business split 依赖 playwright junit reporter 把 test title (含 @tag) 写进 <testcase name=...>.
           # 若未来 reporter 改成不带 tag, 此 grep 将退化 (全部误判 business), 需同步改判定.
-          VISUAL_FAIL=$(echo "$FAILED_NAMES" | grep -c "@visual" || true)
+          # VISUAL_FAIL 只算 "带 @visual 且 不带 @p0" 的 fail — @p0 case 即使也带 @visual,
+          # 一挂就必须 block (@p0 是硬阻断契约). 交叉 tag 走 BUSINESS 分支.
+          VISUAL_FAIL=$(echo "$FAILED_NAMES" | grep "@visual" | grep -vc "@p0" || true)
           BUSINESS_FAIL=$((TOTAL_FAIL - VISUAL_FAIL))
           TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
           echo ""
@@ -106,17 +108,32 @@ jobs:
           fi
           echo "═════════════════════════════════════════════════════════════"
 
+          # 判定顺序 (fail-closed, PW_EXIT 检查在 visual allow 之前避免掩盖 crash):
+          #  1. tests=0 → webServer / playwright 挂了根本没跑, block
+          #  2. tests < EXPECTED_P0 → 有 case 静默掉了 @p0 tag / grep 漂了, block
+          #  3. 有业务 fail (含 @p0+@visual 交叉 case) → block
+          #  4. PW_EXIT!=0 但 junit 无 business fail → playwright 本身 crash/OOM/timeout, block
+          #  5. 仅视觉 fail (无 @p0 交叉) 且 playwright 干净退出 → allow
+          #  6. 全绿 → success
+          EXPECTED_P0=29
           if [[ "$TOTAL_TESTS" -eq 0 ]]; then
             echo "❌ tests=0 (playwright 没跑起 test, 通常是 preview server timeout), block PR"
+            exit 1
+          elif [[ "$TOTAL_TESTS" -lt "$EXPECTED_P0" ]]; then
+            echo "❌ tests=$TOTAL_TESTS < EXPECTED_P0=$EXPECTED_P0 (有 case 掉了 @p0 tag 或 grep 漂了), block PR"
+            echo "   若确认减 case, 请同步下调 EXPECTED_P0."
             exit 1
           elif [[ "$BUSINESS_FAIL" -gt 0 ]]; then
             echo "❌ 有 $BUSINESS_FAIL 个业务 case fail → block PR"
             exit 1
-          elif [[ "$VISUAL_FAIL" -gt 0 ]]; then
-            echo "⚠️  仅 $VISUAL_FAIL 个视觉 case fail → allow PR (需手动更新 baseline)"
+          elif [[ "$PW_EXIT" -ne 0 && "$VISUAL_FAIL" -eq 0 ]]; then
+            echo "❌ playwright exit=$PW_EXIT 但 junit 无 fail 条目 (crash/OOM/timeout), block PR"
+            exit 1
+          elif [[ "$VISUAL_FAIL" -gt 0 && "$PW_EXIT" -ne 0 ]]; then
+            echo "⚠️  仅 $VISUAL_FAIL 个视觉 case fail, playwright 非 0 退出符合预期 → allow PR (需手动更新 baseline)"
             exit 0
           elif [[ "$PW_EXIT" -ne 0 ]]; then
-            echo "❌ playwright exit=$PW_EXIT 但 junit 无 fail 条目, block PR"
+            echo "❌ playwright exit=$PW_EXIT 但无 visual fail 也无 business fail (异常), block PR"
             exit 1
           else
             echo "✅ all pass"

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ playwright-report
 .next/
 out/
 build
-
-# TypeScript incremental build cache
+build-e2e
 *.tsbuildinfo
 
 # misc

--- a/apps/web/e2e-kit/playwright.ci.config.ts
+++ b/apps/web/e2e-kit/playwright.ci.config.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-undef -- e2e code runs in Node */
 import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// 注: 用 __dirname (CJS) 而不是 import.meta.url. 本 repo root 无 "type": "module",
+// playwright pirates transform 走 CJS 加载 config, import.meta 挂不上会报
+// "exports is not defined in ES module scope". 跟 playwright.config.ts 保持一致.
 
 /**
  * kit-provided CI-only config. 差异 vs playwright.config.ts:
@@ -56,14 +57,13 @@ export default defineConfig({
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 
   webServer: {
-    command: "<PROJECT_PREVIEW_COMMAND>",       // TODO
-    cwd: path.resolve(__dirname, "<PROJECT_ROOT_REL>"),  // TODO
+    command: "pnpm preview:e2e",
+    cwd: path.resolve(__dirname, ".."),
     url: `http://localhost:${PREVIEW_PORT}`,
     reuseExistingServer: false,
-    // 静态 http 服务 (推荐): 冷启 ~200ms. `vite preview` / `vp preview` 在
-    // 复杂 vite config (tailwind v4 / 多 plugin) 下冷启可能 > 60s 屡屡 timeout;
-    // 若必须走 vite preview, 请把 timeout 加到 180_000 且监控 CI runner 内存.
-    timeout: 30_000,
+    // vite preview 冷启在此项目大约 3-10s; 若 CI runner 内存受限或 vite plugin 复杂化,
+    // 可加 timeout 或改静态 http 服务. 当前 60s 留余量.
+    timeout: 60_000,
     stdout: "pipe",
     stderr: "pipe",
     env: { PW_PREVIEW_PORT: PREVIEW_PORT },

--- a/apps/web/e2e-kit/playwright.ci.config.ts
+++ b/apps/web/e2e-kit/playwright.ci.config.ts
@@ -7,17 +7,13 @@ import path from "node:path";
 // "exports is not defined in ES module scope". 跟 playwright.config.ts 保持一致.
 
 /**
- * kit-provided CI-only config. 差异 vs playwright.config.ts:
- *  - webServer.command 改成 preview / static-serve (build 产物, 冷启快)
+ * CI-only playwright config (adapted from e2e-kit v0.4). 差异 vs playwright.config.ts:
+ *  - webServer.command: pnpm preview:e2e (build 产物, 冷启快)
  *  - reuseExistingServer: false (CI 每次都新)
- *  - PW_PREVIEW_PORT env: CI 各 job 用不同 port 隔离
+ *  - PW_PREVIEW_PORT env: 各 job 用不同 port 隔离
  *  - 硬约束 TARGET=local: CI 只跑 mock 模式, 真后端走另一条 pipeline
  *
- * TODO(接入方) 填占位:
- *  - `<PROJECT_PREVIEW_COMMAND>` — 例 "pnpm preview:e2e" 或 "node ci/static-serve.mjs"
- *  - `<PROJECT_ROOT_REL>` — 相对 e2e/ 到项目根 (通常 "..")
- *
- * 前提: 先 `pnpm build:e2e` 产 dist-e2e/, tree-shake 掉 harness route gate.
+ * 前提: 先 `pnpm build:e2e` 产 build-e2e/, tree-shake 掉 MSW / mock IM.
  */
 const PREVIEW_PORT = process.env.PW_PREVIEW_PORT ?? "5173";
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PREVIEW_PORT}`;

--- a/apps/web/e2e-kit/tests/C1-loop-empty-workspace.spec.ts
+++ b/apps/web/e2e-kit/tests/C1-loop-empty-workspace.spec.ts
@@ -11,7 +11,7 @@
 
 import { test, expect } from "../fixtures-authed";
 
-test("@C1 loop 空 workspace 引导 — 打开 /loop 空态显示 '还没有工作区' + 创建按钮", async ({
+test("@C1 @p0 @loop @workspace loop 空 workspace 引导 — 打开 /loop 空态显示 '还没有工作区' + 创建按钮", async ({
   authedPage,
 }) => {
   await authedPage.goto("/loop?sid=e2etest");

--- a/apps/web/e2e-kit/tests/C10-loop-issue-priority-update.spec.ts
+++ b/apps/web/e2e-kit/tests/C10-loop-issue-priority-update.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C10 loop issue priority 内联切换 — 详情 pill → Dropdown → 选高 → UI 反映", async ({
+test("@C10 @p0 @loop @issue loop issue priority 内联切换 — 详情 pill → Dropdown → 选高 → UI 反映", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C11-loop-issue-assignee-update.spec.ts
+++ b/apps/web/e2e-kit/tests/C11-loop-issue-assignee-update.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C11 loop issue assignee 内联切换 — picker → 选 Admin User → UI 反映", async ({
+test("@C11 @p0 @loop @issue loop issue assignee 内联切换 — picker → 选 Admin User → UI 反映", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C12-loop-delete-issue.spec.ts
+++ b/apps/web/e2e-kit/tests/C12-loop-delete-issue.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C12 loop 删除 issue — 详情 → 更多菜单 → 删除 → Modal 确认 → 详情消失", async ({
+test("@C12 @p0 @loop @issue loop 删除 issue — 详情 → 更多菜单 → 删除 → Modal 确认 → 详情消失", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C13-loop-subtask-create.spec.ts
+++ b/apps/web/e2e-kit/tests/C13-loop-subtask-create.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C13 loop 新建子任务 — 详情 → 更多菜单 → 新建子任务 → 弹窗填 title → 提交", async ({
+test("@C13 @p0 @loop @issue loop 新建子任务 — 详情 → 更多菜单 → 新建子任务 → 弹窗填 title → 提交", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C14-loop-create-project.spec.ts
+++ b/apps/web/e2e-kit/tests/C14-loop-create-project.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C14 loop 创建 project — 项目 tab → 新建 → 填 name → 提交 → 出现在列表", async ({
+test("@C14 @p0 @loop @project loop 创建 project — 项目 tab → 新建 → 填 name → 提交 → 出现在列表", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C15-loop-edit-project.spec.ts
+++ b/apps/web/e2e-kit/tests/C15-loop-edit-project.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C15 loop 编辑 project 详情 — 项目 tab → 点开 → 改 title → 保存", async ({
+test("@C15 @p0 @loop @project loop 编辑 project 详情 — 项目 tab → 点开 → 改 title → 保存", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-project");

--- a/apps/web/e2e-kit/tests/C16-loop-create-agent.spec.ts
+++ b/apps/web/e2e-kit/tests/C16-loop-create-agent.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C16 loop 创建 agent — 专家 tab → 新建 → 填 name + runtime → 提交", async ({
+test("@C16 @p0 @loop @agent loop 创建 agent — 专家 tab → 新建 → 填 name + runtime → 提交", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C17-loop-view-agent-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/C17-loop-view-agent-detail.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C17 loop 打开 agent 详情 — 专家 tab → 点开 → 详情页 name + owner 段渲染", async ({
+test("@C17 @p0 @loop @agent loop 打开 agent 详情 — 专家 tab → 点开 → 详情页 name + owner 段渲染", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-agent");

--- a/apps/web/e2e-kit/tests/C18-loop-create-squad.spec.ts
+++ b/apps/web/e2e-kit/tests/C18-loop-create-squad.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C18 loop 创建 squad — 专家团 tab → 新建 → 填 name + leader → 提交", async ({
+test("@C18 @p0 @loop @squad loop 创建 squad — 专家团 tab → 新建 → 填 name + leader → 提交", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C19-loop-view-squad-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/C19-loop-view-squad-detail.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C19 loop 打开 squad 详情 — 专家团 tab → 点开 → 名字 + leader 段渲染", async ({
+test("@C19 @p0 @loop @squad loop 打开 squad 详情 — 专家团 tab → 点开 → 名字 + leader 段渲染", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-squad");

--- a/apps/web/e2e-kit/tests/C2-loop-create-workspace.spec.ts
+++ b/apps/web/e2e-kit/tests/C2-loop-create-workspace.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C2 loop 创建 workspace — 空态点创建 → 弹窗填名 → 提交 → workspace 出现在 sidebar", async ({
+test("@C2 @p0 @loop @workspace loop 创建 workspace — 空态点创建 → 弹窗填名 → 提交 → workspace 出现在 sidebar", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "create-ws");

--- a/apps/web/e2e-kit/tests/C20-loop-create-automation.spec.ts
+++ b/apps/web/e2e-kit/tests/C20-loop-create-automation.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C20 loop 创建 automation — 自动化 tab → 新建 → 填 name + executor → 提交", async ({
+test("@C20 @p0 @loop @automation loop 创建 automation — 自动化 tab → 新建 → 填 name + executor → 提交", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C21-loop-trigger-automation.spec.ts
+++ b/apps/web/e2e-kit/tests/C21-loop-trigger-automation.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C21 loop 手动触发 automation — 自动化列表 → 更多菜单 → 手动运行 → 确认 → toast", async ({
+test("@C21 @p0 @loop @automation loop 手动触发 automation — 自动化列表 → 更多菜单 → 手动运行 → 确认 → toast", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-automation");

--- a/apps/web/e2e-kit/tests/C22-loop-view-automation-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/C22-loop-view-automation-detail.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C22 loop 打开 automation 详情 — 点开 → 详情页显示 title + trigger", async ({
+test("@C22 @p0 @loop @automation loop 打开 automation 详情 — 点开 → 详情页显示 title + trigger", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-automation");

--- a/apps/web/e2e-kit/tests/C23-loop-invite-member.spec.ts
+++ b/apps/web/e2e-kit/tests/C23-loop-invite-member.spec.ts
@@ -6,7 +6,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C23 loop 添加成员 — settings/成员 → 下拉选 space 用户 → 添加成员", async ({
+test("@C23 @p0 @loop @member loop 添加成员 — settings/成员 → 下拉选 space 用户 → 添加成员", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "ws-with-members");

--- a/apps/web/e2e-kit/tests/C24-loop-remove-member.spec.ts
+++ b/apps/web/e2e-kit/tests/C24-loop-remove-member.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C24 loop 移除 member — settings/成员 → 删除普通成员 → 行消失", async ({
+test("@C24 @p0 @loop @member loop 移除 member — settings/成员 → 删除普通成员 → 行消失", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "member-remove");

--- a/apps/web/e2e-kit/tests/C25-loop-comment-add.spec.ts
+++ b/apps/web/e2e-kit/tests/C25-loop-comment-add.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C25 @edge loop 评论发送 — 详情 → tiptap 输入 → 点发送 → 显示已添加", async ({
+test("@C25 @p0 @loop @comment @edge loop 评论发送 — 详情 → tiptap 输入 → 点发送 → 显示已添加", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C26-loop-agent-polling.spec.ts
+++ b/apps/web/e2e-kit/tests/C26-loop-agent-polling.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C26 @edge loop agent 详情 status 轮询 baseline — 详情稳定渲染, 未因 polling crash", async ({
+test("@C26 @p0 @loop @agent @edge loop agent 详情 status 轮询 baseline — 详情稳定渲染, 未因 polling crash", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-agent");

--- a/apps/web/e2e-kit/tests/C27-loop-cron-edit.spec.ts
+++ b/apps/web/e2e-kit/tests/C27-loop-cron-edit.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C27 @edge loop automation trigger cron edit baseline — 详情稳定加载, cron 段显示", async ({
+test("@C27 @p0 @loop @automation @edge loop automation trigger cron edit baseline — 详情稳定加载, cron 段显示", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-automation");

--- a/apps/web/e2e-kit/tests/C28-loop-squad-polling.spec.ts
+++ b/apps/web/e2e-kit/tests/C28-loop-squad-polling.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C28 @edge loop squad member status polling baseline — 详情稳定渲染, 未因 polling crash", async ({
+test("@C28 @p0 @loop @squad @edge loop squad member status polling baseline — 详情稳定渲染, 未因 polling crash", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-squad");

--- a/apps/web/e2e-kit/tests/C3-loop-workspace-default-view.spec.ts
+++ b/apps/web/e2e-kit/tests/C3-loop-workspace-default-view.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C3 loop 有 workspace 默认视图 — sidebar 显示 workspace 名 + 主区域 issue 空态", async ({
+test("@C3 @p0 @loop @workspace loop 有 workspace 默认视图 — sidebar 显示 workspace 名 + 主区域 issue 空态", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C4-loop-create-issue.spec.ts
+++ b/apps/web/e2e-kit/tests/C4-loop-create-issue.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C4 loop 创建 issue — 打开新建弹窗 → 填 title → 回车提交 → 新 issue 出现在列表", async ({
+test("@C4 @p0 @loop @issue loop 创建 issue — 打开新建弹窗 → 填 title → 回车提交 → 新 issue 出现在列表", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C5-loop-issue-status-update.spec.ts
+++ b/apps/web/e2e-kit/tests/C5-loop-issue-status-update.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C5 loop issue status 内联切换 — 打开详情 → 点状态 pill → 选新状态 → UI 反映", async ({
+test("@C5 @p0 @loop @issue loop issue status 内联切换 — 打开详情 → 点状态 pill → 选新状态 → UI 反映", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C6-loop-switch-workspace.spec.ts
+++ b/apps/web/e2e-kit/tests/C6-loop-switch-workspace.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C6 loop 切换 workspace — 从 A 切到 B, sidebar 名字变化", async ({
+test("@C6 @p0 @loop @workspace loop 切换 workspace — 从 A 切到 B, sidebar 名字变化", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "two-ws");

--- a/apps/web/e2e-kit/tests/C7-loop-workspace-settings-update.spec.ts
+++ b/apps/web/e2e-kit/tests/C7-loop-workspace-settings-update.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C7 loop workspace 设置更新 — 进 settings tab → 改 name → 保存 → toast 出现", async ({
+test("@C7 @p0 @loop @workspace loop workspace 设置更新 — 进 settings tab → 改 name → 保存 → toast 出现", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C8-loop-create-issue-full.spec.ts
+++ b/apps/web/e2e-kit/tests/C8-loop-create-issue-full.spec.ts
@@ -6,7 +6,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C8 loop 创建 issue 完整 — 弹窗 → 改 priority + status → 提交", async ({
+test("@C8 @p0 @loop @issue loop 创建 issue 完整 — 弹窗 → 改 priority + status → 提交", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-ws");

--- a/apps/web/e2e-kit/tests/C9-loop-issue-detail-view.spec.ts
+++ b/apps/web/e2e-kit/tests/C9-loop-issue-detail-view.spec.ts
@@ -5,7 +5,7 @@
 import { test, expect } from "../fixtures-authed";
 import { installMswScenario } from "../_lib/mswScenario";
 
-test("@C9 loop issue 详情加载 — 点开 issue → 属性栏渲染 (status/priority/assignee/项目)", async ({
+test("@C9 @p0 @loop @issue loop issue 详情加载 — 点开 issue → 属性栏渲染 (status/priority/assignee/项目)", async ({
   authedPage,
 }) => {
   await installMswScenario(authedPage, "one-issue");

--- a/apps/web/e2e-kit/tests/C989-search-close-on-bot-send-message.spec.ts
+++ b/apps/web/e2e-kit/tests/C989-search-close-on-bot-send-message.spec.ts
@@ -11,7 +11,7 @@ import { installMockImRuntime } from "../_kit/mock-im-runtime";
 const MOCK_BOT_UID = "e2e-bot-989";
 const MOCK_BOT_NAME = "富贵儿测试 bot";
 
-test("@C989 顶部搜索 bot → 名片发送消息 → 外层搜索弹窗关闭", async ({ authedPage }, testInfo) => {
+test("@C989 @p0 @search 顶部搜索 bot → 名片发送消息 → 外层搜索弹窗关闭", async ({ authedPage }, testInfo) => {
   const kf = (name: string) =>
     testInfo.outputPath(`keyframes/${name}.png`);
   // 补 mock-im seed: 让 isBot(botUid) 返 true (chat 点击命中走开 BotDetailModal 分支)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "build:electron": "cross-env VITE_ELECTRON_BUILD=true vite build",
     "build:analyzer": "cross-env ANALYZER=true vite build",
-    "build:e2e": "VITE_E2E_MOCK=1 VITE_E2E_MOCK_IM=1 VITE_API_URL=http://mock.e2e.local/v1 vite build --outDir build-e2e",
+    "build:e2e": "VITE_E2E_MOCK=1 VITE_E2E_MOCK_IM=1 VITE_API_URL=http://mock.e2e.local vite build --outDir build-e2e",
     "preview:e2e": "vite preview --outDir build-e2e --port ${PW_PREVIEW_PORT:-5173} --strictPort",
     "build-ele:mac": "npm-run-all build:electron compile:electron electron:build:mac",
     "build-ele:mac-x64": "npm-run-all clean:dist-ele build:electron compile:electron electron:build:mac-x64",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,8 @@
     "build": "vite build",
     "build:electron": "cross-env VITE_ELECTRON_BUILD=true vite build",
     "build:analyzer": "cross-env ANALYZER=true vite build",
+    "build:e2e": "VITE_E2E_MOCK=1 VITE_E2E_MOCK_IM=1 VITE_API_URL=http://mock.e2e.local/v1 vite build --outDir build-e2e",
+    "preview:e2e": "vite preview --outDir build-e2e --port ${PW_PREVIEW_PORT:-5173} --strictPort",
     "build-ele:mac": "npm-run-all build:electron compile:electron electron:build:mac",
     "build-ele:mac-x64": "npm-run-all clean:dist-ele build:electron compile:electron electron:build:mac-x64",
     "build-ele:mac-arm64": "npm-run-all clean:dist-ele build:electron compile:electron electron:build:mac-arm64",

--- a/docs/e2e-baseline-strategy.md
+++ b/docs/e2e-baseline-strategy.md
@@ -1,0 +1,60 @@
+# e2e visual baseline 管理策略 (Phase 3 路线, 未实现)
+
+## 当前状态
+
+- MR 门禁 (`e2e.yml`) 只跑 `@p0`, 不涉及视觉
+- Nightly (`e2e-nightly.yml`) `--grep-invert "@visual"`, 也跳过视觉
+- **repo 里没有 baseline PNG, 也没有任何 `@visual` case**
+
+只要不打 `@visual`, 一切照常. 想开视觉基线时按下面走.
+
+## 三个决策点
+
+### 1. 谁能触发 baseline update
+
+不能 `pull_request` 自动跑 — 外部 fork PR 拿不到写权限 token, push 不回去; 且不该让任意贡献者一键改视觉真相.
+
+**方案**: `workflow_dispatch`, 只有 write 权限 collaborator 能触发, 输入参数选 PR 号或分支名.
+
+### 2. baseline 存哪
+
+**提交进 repo** (`apps/web/e2e-kit/screenshots/**/*.png`), 不走 artifact / LFS.
+
+理由: 视觉基线是"视觉真相的一部分", reviewer 在 PR diff 里能看到"这次 UI 改动导致 baseline 变了什么" 才有意义. artifact 藏起来就废了.
+
+代价: 仓库变大, PNG 二进制 diff 噪声. 后期真变大再引入 LFS.
+
+### 3. 什么时候更 (关键)
+
+**bootstrap + per-PR 组合**:
+
+**Bootstrap (一次性)**: `e2e-baseline-bootstrap.yml`, `workflow_dispatch` 触发. 在 CI runner 跑 `--update-snapshots --grep "@visual"`, 生成初始 baseline commit 到 `chore/e2e-baseline-init` 分支, 开 PR 让维护者 review 后 merge. 一次搞定, 之后不用.
+
+**Per-PR update**: `e2e-baseline-update.yml`, `workflow_dispatch` 带 `pr_number` 输入. 维护者在 PR 页 Actions tab 手动触发:
+
+1. checkout 指定 PR 的 head branch
+2. `build:e2e` → `preview:e2e`
+3. `playwright test --grep "@visual" --update-snapshots`
+4. **业务失败 gate**: 检查同 pipeline 里 `@p0` 是否有 business fail, 有就拒 push (避免 baseline commit 洗白业务 fail)
+5. commit baseline diff, push 回 PR source branch (带 `[skip ci]`)
+
+reviewer 在同一 PR 看到 UI + baseline 两组 diff.
+
+## 不要做的事
+
+- ~~自动化 baseline update on schedule~~ — baseline 应该跟着有意的 UI 改动走, 不该"自己刷新"
+- ~~UI 挂了自动跑 update 洗白~~ — 业务失败 gate 就是防这个
+
+## 打开视觉 case 的顺序
+
+1. 先加 `@visual` case (用 `page.screenshot()` + `expect(page).toHaveScreenshot(...)`)
+2. 加 `.github/workflows/e2e-baseline-bootstrap.yml`, 手动跑一次, review + merge baseline PR
+3. 加 `.github/workflows/e2e-baseline-update.yml`, 之后 UI 改动 PR 里维护者手动触发
+4. 打开 MR gate 的视觉判定: `e2e.yml` 的 grep 从 `"@p0"` 改成 `"@p0|@visual"`, junit 后处理已经会区分 business vs visual fail
+
+case 文件里加 `@visual` 就够, junit 后处理逻辑不用改.
+
+## 相关
+
+- e2e-kit `docs/methodology/module-organization.md` — tag 层次约定
+- e2e-kit `templates/e2e-init/.gitlab-ci.yml.template` — 参考里的 `e2e_visual_baseline_update` job (GitLab 版, GH Actions 版按上面策略)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cleanup:worktree": "bash scripts/cleanup-worktree.sh"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.61.1",
     "@storybook/addon-vitest": "^10.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         version: 4.4.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.59.1
+        specifier: ^1.61.1
+        version: 1.61.1
       '@storybook/addon-vitest':
         specifier: ^10.3.3
         version: 10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
@@ -60,7 +60,7 @@ importers:
         version: 13.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+        version: 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -2704,8 +2704,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9061,13 +9061,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -13250,9 +13250,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.61.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -14138,7 +14138,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
       vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
@@ -14152,7 +14152,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
       vitest: 4.1.5(@types/node@25.9.5)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
@@ -15752,11 +15752,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1)
 
-  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
-      playwright: 1.59.1
+      playwright: 1.61.1
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
@@ -15766,11 +15766,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
-      playwright: 1.59.1
+      playwright: 1.61.1
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
@@ -15780,11 +15780,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))
-      playwright: 1.59.1
+      playwright: 1.61.1
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@25.9.5)(@vitest/browser-playwright@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
@@ -21190,11 +21190,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.59.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -23530,7 +23530,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
-      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
@@ -23560,7 +23560,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.21
-      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
@@ -23589,7 +23589,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
-      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Wire e2e as a real CI job on GitHub Actions:
- **`.github/workflows/e2e.yml`** — MR gate on PR to `main`. Builds a mock-mode bundle (`build:e2e`), starts `vite preview`, runs `@p0` cases in the official playwright container. junit post-processor splits business vs visual fail; business fail blocks the PR, visual fail allows (no `@visual` cases exist yet).
- **`.github/workflows/e2e-nightly.yml`** — `schedule` (03:00 UTC) + `workflow_dispatch`. Runs everything except `@visual`.
- **`docs/e2e-baseline-strategy.md`** — records the Phase 3 plan for visual baseline bootstrap + per-PR update workflows (not implemented; opens as a one-shot follow-up when visual cases are added).

Follows the e2e-kit v0.4 tag hierarchy (`docs/methodology/module-organization.md`): `@<CaseId> @<p0|p1|p2> @<module>`. All 29 existing `C*` cases tagged `@p0 @loop @<module>` (or `@p0 @search` for C989). `tests/bind/` and `tests/standalone-doc/` untouched — their spec ids don't follow the CaseId convention; retag separately.

## Notable fixes along the way

- `cross-env` not hoisted in this monorepo → `build:e2e` uses inline env vars. CI only runs on ubuntu; no Windows compatibility loss.
- e2e-kit v0.4 shipped `playwright.ci.config.ts` with `import.meta.url` / `fileURLToPath`, but this repo has no `"type": "module"`. Playwright's pirates transform loads configs as CJS → `ReferenceError: exports is not defined`. Switched to `__dirname` to match the existing `playwright.config.ts` (whose header already documented this constraint).

## Test plan

- [x] Local dry-run: `pnpm build:e2e` → `pnpm preview:e2e` on port 5199 → C1 passes in 8.6s
- [ ] GitHub Actions on this PR — first live run; expect to iterate on container / preview timeout / real-API-dependent cases
- [ ] Full 29-case sweep before considering merge