### PR TITLE
fix(onboarding): stabilize Page 3 silk auto-continue timer (#999)

### DIFF
--- a/apps/web/src/Components/Onboarding/Intro.tsx
+++ b/apps/web/src/Components/Onboarding/Intro.tsx
@@ -168,6 +168,9 @@ export const OnboardingIntro: React.FC<OnboardingIntroProps> = ({
     onContinue();
   }, [isSilkRevealed, onContinue, phase]);
 
+  const continueFromSilkRef = useRef(continueFromSilk);
+  continueFromSilkRef.current = continueFromSilk;
+
   const handleSilkKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "Enter" && event.key !== " ") return;
 
@@ -178,12 +181,15 @@ export const OnboardingIntro: React.FC<OnboardingIntroProps> = ({
   useEffect(() => {
     if (phase !== "silk" || !isSilkRevealed) return;
 
+    // Depend only on phase/isSilkRevealed so parent re-renders (which change
+    // onContinue → continueFromSilk identity) don't keep resetting this timer
+    // and stranding the user on the last frame in foreground (issue #999).
     const timer = window.setTimeout(() => {
-      continueFromSilk();
+      continueFromSilkRef.current();
     }, SILK_AUTO_CONTINUE_MS);
 
     return () => window.clearTimeout(timer);
-  }, [continueFromSilk, isSilkRevealed, phase]);
+  }, [isSilkRevealed, phase]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Fixes #999.

## Summary

Intro 的 silk 阶段用一个 7200ms `useEffect` timer 触发从 Page 3 到目录页的自动切换,依赖列表里带上了 `continueFromSilk`。`continueFromSilk` 是一个 `useCallback`,依赖父组件 `Onboarding` 传入的未 memoize 的 `onContinue`(`handleIntroContinue`);父组件任何 state 变化都会让 `continueFromSilk` identity 变化,effect cleanup 后重新执行,timer 被清掉重新计时。前台事件驱动的 re-render 累积后 timer 永远无法触发,页面卡在最后一帧;切到后台事件被节流,timer 才有机会完成 —— 这也解释了 issue 中"前台卡死、切后台反而能自动切换"的现象。

修法:把 `continueFromSilk` 存进 ref,timer effect 依赖收敛为 `[isSilkRevealed, phase]`(silk 阶段内两者稳定不变),timer 只在进入/离开 silk-revealed 状态时 arm 或 disarm。点击容器和键盘 Enter/Space 路径仍调用 `continueFromSilk` 本体,现有 `continueStartedRef` guard 保持双触发防护。不修改自动继续行为的语义、guard 条件或 `SILK_AUTO_CONTINUE_MS` 常量,不影响 Page 1 / Page 2 及 skip 转场路径。

## Test plan

- [ ] 在 InPrivate 窗口进入 Onboarding,依次完成 Page 1 → Page 2 → Page 3
- [ ] 保持 Page 3 在前台、不点击、不切窗口,等待 ~8 秒
- [ ] 确认页面自动进入白色目录页,不再卡在最后一帧
- [ ] 复现原报告路径:Page 3 后立即 Alt+Tab 切后台再切回,同样能进入目录页
- [ ] 点击 silk 容器区域仍可立即继续
- [ ] 键盘 Enter / Space 在 silk 容器 focus 时仍可继续
- [ ] 回归:Page 1 / Page 2 的 skip 转场、hover 按钮、TrueFocus 交互无影响