### PR TITLE
fix(onboarding): remove global Escape exit path (#998)

### DIFF
--- a/apps/web/src/Components/Onboarding/index.tsx
+++ b/apps/web/src/Components/Onboarding/index.tsx
@@ -267,12 +267,6 @@ export const Onboarding: React.FC<OnboardingProps> = ({
     onDismiss?.();
   };
 
-  const dismissOnEscape = () => {
-    if (isCompleting) return;
-    persistDismissed();
-    hideOnboarding();
-  };
-
   const handleClose = () => {
     if (isCompleting) return;
 
@@ -348,13 +342,6 @@ export const Onboarding: React.FC<OnboardingProps> = ({
   };
 
   const handleDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      event.stopPropagation();
-      dismissOnEscape();
-      return;
-    }
-
     if (event.key !== "Tab") return;
 
     const dialog = dialogRef.current;


### PR DESCRIPTION
Fixes #998.

## Summary

`handleDialogKeyDown` 捕获 `Escape` 后调用 `dismissOnEscape → persistDismissed → hideOnboarding`,导致用户在 Intro 或后续 Panel 任一页按 `Escape` 都会立即关闭整个 Onboarding 并写入已看标记,后续白色目录页从此不再显示。这条路径没有对应可见按钮,等于给每一页塞了一个隐藏的 Skip,违反"只允许通过当前页面明确展示的 `Skip`、关闭或完成按钮退出"的产品规则。

修法:从 `handleDialogKeyDown` 移除 Escape 分支,并删除不再被引用的 `dismissOnEscape` 函数。Tab / Shift+Tab 焦点循环、Intro 的 Skip、Panel 的关闭 (`handleClose`) 和完成 (`handleFinish`) 按钮路径全部保持不变;`persistDismissed` 仍被 `handleClose` / `handleFinish` / `handleIntroSkip` 使用,只是不再被 Escape 触发。

附带解决 [#924 review](https://github.com/Mininglamp-OSS/octo-web/pull/924#pullrequestreview-4735250332) 提到的附带风险:Skip 转场期间按 Escape 会提前卸载本应保留到 `transition.finished` 的 Intro/Strands WebGL —— Escape 退出路径整体移除后该风险自然消除。

## Test plan

- [ ] 在 InPrivate 窗口打开 Onboarding,进入黑色 Intro Page 1,按 `Escape`,确认 Onboarding **不关闭**、localStorage 未写入已看标记
- [ ] 在 Intro Page 2 / Page 3 按 `Escape`,确认同样不关闭、不持久化
- [ ] 通过 Skip 转场后进入白色 Panel,按 `Escape`,确认同样不关闭
- [ ] Skip 转场期间按 `Escape`,确认 Intro/Strands WebGL 不再提前卸载
- [ ] 显式退出路径仍正常:Intro Page 1 的 `Skip` 按钮、Panel 的关闭按钮、最后一页的完成按钮均能退出并写入已看状态
- [ ] Tab / Shift+Tab 焦点循环在 Intro 和 Panel 上均正常
- [ ] 回归:localStorage `onboarding-seen` 写入时机保持与主线一致