### PR TITLE
refactor: route profile detail through IM runtime

### DIFF
--- a/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
+++ b/packages/dmworkbase/src/Components/BotDetailModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Toast } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
-import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
+import { Channel, ChannelTypePerson } from "wukongimjssdk";
 import WKApp from "../../App";
 import WKAvatar from "../WKAvatar";
 import { WKAvatarEditor } from "../WKAvatarEditor";
@@ -17,7 +17,7 @@ import BotDetailVM, {
     stripBotDetailDisplayName,
 } from "../../bridge/profileDetail/BotDetailVM";
 import BotDetailView from "../../ui/profileDetail/BotDetailView";
-import { fetchImChannelInfo } from "../../im-runtime/channelRuntime";
+import { fetchCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 import "./index.css";
 
 interface BotDetailModalProps {
@@ -43,17 +43,15 @@ export default class BotDetailModal extends Component<BotDetailModalProps> {
             getLoginUid: () => WKApp.loginInfo.uid,
             getToken: () => WKApp.loginInfo.token || "",
             getSpaceId: () => WKApp.shared.currentSpaceId,
-            fetchChannelInfo: (uid) => fetchImChannelInfo(
-                WKSDK.shared(),
+            fetchChannelInfo: (uid) => fetchCurrentImChannelInfo(
                 new Channel(uid, ChannelTypePerson)
             ),
-            refreshChannelInfo: (uid) => fetchImChannelInfo(
-                WKSDK.shared(),
+            refreshChannelInfo: (uid) => fetchCurrentImChannelInfo(
                 new Channel(uid, ChannelTypePerson)
             ),
             onAvatarChanged: (uid) => {
                 WKApp.shared.changeChannelAvatarTag(new Channel(uid, ChannelTypePerson));
-                void fetchImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson));
+                void fetchCurrentImChannelInfo(new Channel(uid, ChannelTypePerson));
                 this.forceUpdate();
             },
         });

--- a/packages/dmworkbase/src/Components/WKBase/index.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/index.tsx
@@ -1,6 +1,6 @@
 import { Modal, Toast } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
-import WKSDK, { Channel, ChannelTypePerson, MessageText } from "wukongimjssdk";
+import { Channel, ChannelTypePerson, MessageText } from "wukongimjssdk";
 import React, { Component, HTMLProps, ReactNode } from "react";
 import ConversationSelect from "../ConversationSelect";
 import type { ConversationSelectGrant } from "../ConversationSelect";
@@ -22,7 +22,10 @@ import {
 } from "./userInfoRouter";
 import { I18nContext } from "../../i18n";
 import { isIncomingWebhookSender } from "../../Service/IncomingWebhook";
-import { getImChannelSubscribers, syncImChannelSubscribers } from "../../im-runtime/channelRuntime";
+import {
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+} from "../../im-runtime/currentChannelRuntime";
 import "./index.css";
 
 /**
@@ -51,7 +54,7 @@ export function createDefaultExternalViewerGate(): ExternalViewerGate {
     isExternal: (uid, fromChannel, channelInfo) => {
       // 1) Group subscriber orgData (primary source, matches UserInfoVM step 1).
       if (fromChannel && fromChannel.channelType !== ChannelTypePerson) {
-        const subscribers = getImChannelSubscribers(WKSDK.shared(), fromChannel) as
+        const subscribers = getCurrentImChannelSubscribers(fromChannel) as
           { uid?: string; orgData?: ChannelInfoOrgDataLike }[];
         const sub = subscribers.find((s) => s && s.uid === uid);
         const org = sub?.orgData;
@@ -278,11 +281,11 @@ export default class WKBase
         continue;
       }
       try {
-        await syncImChannelSubscribers(WKSDK.shared(), ch);
+        await syncCurrentImChannelSubscribers(ch);
       } catch {
         // best-effort: fall back to whatever is already cached
       }
-      const subs = getImChannelSubscribers(WKSDK.shared(), ch) as { uid?: string }[];
+      const subs = getCurrentImChannelSubscribers(ch) as { uid?: string }[];
       for (const s of subs) {
         if (s?.uid) uids.add(s.uid);
       }

--- a/packages/dmworkbase/src/Components/WKBase/userInfoRouter.ts
+++ b/packages/dmworkbase/src/Components/WKBase/userInfoRouter.ts
@@ -1,5 +1,8 @@
-import WKSDK, { Channel, ChannelTypePerson } from "wukongimjssdk";
-import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { Channel, ChannelTypePerson } from "wukongimjssdk";
+import {
+    fetchCurrentImChannelInfo,
+    getCurrentImChannelInfo,
+} from "../../im-runtime/currentChannelRuntime";
 
 /**
  * Production routing helper for "view user profile" entry (GH#1112, PR#1113).
@@ -57,7 +60,8 @@ export interface ChannelManagerLike {
 
 /**
  * External-viewer decision surface. Abstracted out of the router so
- * unit tests can inject a deterministic answer without standing up WKSDK
+ * unit tests can inject a deterministic answer without standing up the current
+ * IM runtime
  * subscribers + WKApp.currentSpaceId. The default implementation wired in
  * createUserInfoRouter mirrors UserInfoVM.isExternalToViewer exactly:
  *
@@ -186,7 +190,7 @@ export class UserInfoRouter {
 }
 
 /**
- * Convenience factory bound to the global WKSDK singleton — used by WKBase so
+ * Convenience factory bound to the current IM runtime — used by WKBase so
  * callers don't need to know about the underlying channel manager.
  *
  * `externalGate` is optional and must be injected by the caller. It
@@ -203,9 +207,9 @@ export function createUserInfoRouter(
 ): UserInfoRouter {
     const channelManager: ChannelManagerLike = {
         getChannelInfo: (channel) =>
-            getImChannelInfo(WKSDK.shared(), channel) as ChannelInfoLike | undefined,
+            getCurrentImChannelInfo(channel) as ChannelInfoLike | undefined,
         fetchChannelInfo: (channel) =>
-            fetchImChannelInfo(WKSDK.shared(), channel) as Promise<ChannelInfoLike | undefined>,
+            fetchCurrentImChannelInfo(channel) as Promise<ChannelInfoLike | undefined>,
     };
     return new UserInfoRouter(channelManager, dispatch, externalGate);
 }

--- a/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
+++ b/packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx
@@ -1,10 +1,9 @@
-import { ChannelInfoListener, SubscriberChangeListener } from "wukongimjssdk";
+import { SubscriberChangeListener } from "wukongimjssdk";
 import {
   Channel,
   ChannelTypeGroup,
   ChannelInfo,
   ChannelTypePerson,
-  WKSDK,
   Subscriber,
 } from "wukongimjssdk";
 import { Section } from "../../Service/Section";
@@ -18,11 +17,11 @@ import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { isRealnameVerified, displayName as resolveDisplayName } from "../../Utils/displayName";
 import { parseThreadChannelId } from "../../Service/Thread";
 import {
-  addImSubscriberChangeListener,
-  fetchImChannelInfo,
-  getImChannelInfo,
-  getImChannelSubscribers,
-} from "../../im-runtime/channelRuntime";
+  addCurrentImSubscriberChangeListener,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+  getCurrentImChannelSubscribers,
+} from "../../im-runtime/currentChannelRuntime";
 
 export class UserInfoRouteData {
   uid!: string;
@@ -71,8 +70,7 @@ export class UserInfoVM extends ProviderListener {
       this.subscriberChangeListener = () => {
         this.reloadSubscribers();
       };
-      this.unsubscribeSubscriberChangeListener = addImSubscriberChangeListener(
-        WKSDK.shared(),
+      this.unsubscribeSubscriberChangeListener = addCurrentImSubscriberChangeListener(
         this.subscriberChangeListener
       );
 
@@ -130,7 +128,7 @@ export class UserInfoVM extends ProviderListener {
       this.editingRemark = false;
       this.remarkDraft = "";
       this.notifyListener();
-      fetchImChannelInfo(WKSDK.shared(), new Channel(requestedUid, ChannelTypePerson)).catch((error: unknown) => {
+      fetchCurrentImChannelInfo(new Channel(requestedUid, ChannelTypePerson)).catch((error: unknown) => {
         console.warn("[UserInfo] refresh channel after remark failed:", error);
       });
       Promise.resolve(this.reloadChannelInfo()).catch((error: unknown) => {
@@ -189,7 +187,7 @@ export class UserInfoVM extends ProviderListener {
     };
 
     if (sourceChannel) {
-      applySubscribers(getImChannelSubscribers(WKSDK.shared(), sourceChannel), {
+      applySubscribers(getCurrentImChannelSubscribers(sourceChannel), {
         replaceUser: true,
         replaceMe: true,
       });
@@ -200,7 +198,7 @@ export class UserInfoVM extends ProviderListener {
         memberChannel.channelID !== sourceChannel.channelID ||
         memberChannel.channelType !== sourceChannel.channelType)
     ) {
-      applySubscribers(getImChannelSubscribers(WKSDK.shared(), memberChannel), {
+      applySubscribers(getCurrentImChannelSubscribers(memberChannel), {
         replaceMe: true,
       });
     }
@@ -377,10 +375,7 @@ export class UserInfoVM extends ProviderListener {
   }
   reloadFromChannelInfo() {
     if (this.fromChannel) {
-      this.fromChannelInfo = getImChannelInfo(
-        WKSDK.shared(),
-        this.fromChannel
-      );
+      this.fromChannelInfo = getCurrentImChannelInfo(this.fromChannel);
       this.notifyListener();
     }
   }

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/UserInfoVM.test.ts
@@ -10,24 +10,8 @@ const mocks = vi.hoisted(() => ({
   userInfos: vi.fn(),
 }));
 
-vi.mock("wukongimjssdk", () => ({
-  Channel: class {
-    channelID: string;
-    channelType: number;
-    constructor(channelID: string, channelType: number) {
-      this.channelID = channelID;
-      this.channelType = channelType;
-    }
-  },
-  ChannelInfo: class {
-    channel: unknown;
-    title = "";
-    logo = "";
-    orgData: Record<string, unknown> = {};
-  },
-  ChannelTypeGroup: 2,
-  ChannelTypePerson: 1,
-  WKSDK: {
+vi.mock("wukongimjssdk", () => {
+  const sdk = {
     shared: () => ({
       channelManager: {
         fetchChannelInfo: mocks.fetchChannelInfo,
@@ -37,8 +21,28 @@ vi.mock("wukongimjssdk", () => ({
         getChannelInfo: vi.fn(),
       },
     }),
-  },
-}));
+  };
+  return {
+    default: sdk,
+    Channel: class {
+      channelID: string;
+      channelType: number;
+      constructor(channelID: string, channelType: number) {
+        this.channelID = channelID;
+        this.channelType = channelType;
+      }
+    },
+    ChannelInfo: class {
+      channel: unknown;
+      title = "";
+      logo = "";
+      orgData: Record<string, unknown> = {};
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    WKSDK: sdk,
+  };
+});
 
 vi.mock("../../../App", () => ({
   default: {


### PR DESCRIPTION
## Summary
- route Profile/UserInfo/BotDetail channel cache and subscriber access through current IM runtime helpers
- remove direct WKSDK.shared() usage from the profile detail entry path
- update profile detail tests to match the current runtime import shape

## Verification
- pnpm --filter @octo/base test -- src/im-runtime/currentChannelRuntime.test.ts src/bridge/profileDetail/__tests__/UserInfoVM.test.ts src/bridge/profileDetail/__tests__/BotDetailVM.test.ts src/bridge/profileDetail/__tests__/BotManageVM.test.ts src/bridge/profileDetail/__tests__/userInfoMembership.test.ts
- pnpm --filter @octo/web build
- pnpm exec esbuild packages/dmworkbase/src/bridge/profileDetail/UserInfoVM.tsx packages/dmworkbase/src/Components/WKBase/index.tsx packages/dmworkbase/src/Components/WKBase/userInfoRouter.ts packages/dmworkbase/src/Components/BotDetailModal/index.tsx --bundle=false --format=esm --platform=browser --outdir=/private/tmp/octo-profile-runtime-esbuild
- git diff --check