### PR TITLE
refactor(dmworkbase): route GlobalSearch tabs/VM through current im-runtime accessors

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-all.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-all.tsx
@@ -4,13 +4,13 @@ import Section from "./section";
 import ItemMessage from "./item-message";
 import WKApp from "../../App";
 import "./tab-all.css"
-import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson, MessageContentType } from "wukongimjssdk";
+import { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson, MessageContentType } from "wukongimjssdk";
 import { MessageContentTypeConst } from "../../Service/Const";
 import { debounce, throttle } from "../../Utils/rateLimit";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import VisibilityTrigger from "../VisibilityTrigger";
 import { I18nContext } from "../../i18n";
-import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { addCurrentImChannelInfoListener, fetchCurrentImChannelInfo, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 
 
 interface TabAllProps {
@@ -47,7 +47,7 @@ export default class TabAll extends Component<TabAllProps> {
                 this._forceUpdateDebounced()
             }
         }
-        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this._channelInfoListener)
     }
 
     componentWillUnmount() {
@@ -59,9 +59,9 @@ export default class TabAll extends Component<TabAllProps> {
     private requestSenderChannelInfoIfNeeded = (fromUid: string) => {
         if (!fromUid || this.fetchedUids.has(fromUid)) return
         const senderChannel = new Channel(fromUid, ChannelTypePerson)
-        if (getImChannelInfo(WKSDK.shared(), senderChannel)) return
+        if (getCurrentImChannelInfo(senderChannel)) return
         this.fetchedUids.add(fromUid)
-        void fetchImChannelInfo(WKSDK.shared(), senderChannel)
+        void fetchCurrentImChannelInfo(senderChannel)
     }
 
     /**
@@ -85,7 +85,7 @@ export default class TabAll extends Component<TabAllProps> {
         // 兜底：从发送者 channelInfo.orgData 取（tab-all 已经 fetch/获取过）
         if (!homeId && (isExternalLegacy === undefined || isExternalLegacy === null) && item.from_uid) {
             const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-            const ci = getImChannelInfo(WKSDK.shared(), senderChannel)
+            const ci = getCurrentImChannelInfo(senderChannel)
             const org = ci?.orgData
             if (org) {
                 // homeId / isExternalLegacy 已经过 !homeId / undefined|null 判据，
@@ -142,7 +142,7 @@ export default class TabAll extends Component<TabAllProps> {
                                 let sender;
                                 if (item.channel?.channel_type !== ChannelTypePerson && item.from_uid && item.from_uid !== "") {
                                     const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-                                    const channelInfo = getImChannelInfo(WKSDK.shared(), senderChannel)
+                                    const channelInfo = getCurrentImChannelInfo(senderChannel)
                                     if (channelInfo) {
                                         sender = channelInfo.title
                                     }

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-contacts.tsx
@@ -5,10 +5,10 @@ import ItemContacts from "./item-contacts";
 import WKApp from "../../App";
 import { isBot } from "../WKAvatar";
 import BotDetailModal from "../BotDetailModal";
-import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
+import { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
 import { resolveExternalForViewer } from "../../Utils/externalViewer";
 import { debounce } from "../../Utils/rateLimit";
-import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { addCurrentImChannelInfoListener, fetchCurrentImChannelInfo, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 import "./tab-contacts.css"
 
 interface TabContactsProps {
@@ -49,7 +49,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
                 this._forceUpdateDebounced()
             }
         }
-        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this._channelInfoListener)
     }
 
     componentWillUnmount() {
@@ -72,9 +72,9 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
         if (!(missingHome && missingLegacy)) return
         if (this.fetchedUids.has(friend.channel_id)) return
         const ch = new Channel(friend.channel_id, ChannelTypePerson)
-        if (getImChannelInfo(WKSDK.shared(), ch)) return
+        if (getCurrentImChannelInfo(ch)) return
         this.fetchedUids.add(friend.channel_id)
-        void fetchImChannelInfo(WKSDK.shared(), ch)
+        void fetchCurrentImChannelInfo(ch)
     }
 
     /**
@@ -100,7 +100,7 @@ export default class TabContacts extends Component<TabContactsProps, TabContacts
             isExternalLegacy === undefined || isExternalLegacy === null
         if (missingHome && missingLegacy && friend?.channel_id) {
             const ch = new Channel(friend.channel_id, ChannelTypePerson)
-            const ci = getImChannelInfo(WKSDK.shared(), ch)
+            const ci = getCurrentImChannelInfo(ch)
             const ciOrg = ci?.orgData
             if (ciOrg) {
                 homeId = ciOrg.home_space_id as string | undefined

--- a/packages/dmworkbase/src/Components/GlobalSearch/tab-file.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/tab-file.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from "react";
 import ItemFile from "./item-file";
 import WKApp from "../../App";
 import "./tab-file.css"
-import WKSDK, { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
+import { Channel, ChannelInfo, ChannelInfoListener, ChannelTypePerson } from "wukongimjssdk";
 import { debounce } from "../../Utils/rateLimit";
 import VisibilityTrigger from "../VisibilityTrigger";
-import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { addCurrentImChannelInfoListener, fetchCurrentImChannelInfo, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 
 interface TabFileProps {
     keyword?: string;
@@ -30,7 +30,7 @@ export default class TabFile extends Component<TabFileProps> {
                 this._forceUpdateDebounced()
             }
         }
-        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this._channelInfoListener)
+        this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this._channelInfoListener)
     }
 
     componentWillUnmount() {
@@ -42,9 +42,9 @@ export default class TabFile extends Component<TabFileProps> {
     private requestSenderChannelInfoIfNeeded = (fromUid: string) => {
         if (!fromUid || this.fetchedUids.has(fromUid)) return
         const senderChannel = new Channel(fromUid, ChannelTypePerson)
-        if (getImChannelInfo(WKSDK.shared(), senderChannel)) return
+        if (getCurrentImChannelInfo(senderChannel)) return
         this.fetchedUids.add(fromUid)
-        void fetchImChannelInfo(WKSDK.shared(), senderChannel)
+        void fetchCurrentImChannelInfo(senderChannel)
     }
 
     // Sticky files：父层 tab 切换中途会把 files 置为 undefined，保留上次非空
@@ -70,7 +70,7 @@ export default class TabFile extends Component<TabFileProps> {
                 files?.map((item: any) => {
                     let sender;
                     const senderChannel = new Channel(item.from_uid, ChannelTypePerson)
-                    const channelInfo = getImChannelInfo(WKSDK.shared(), senderChannel)
+                    const channelInfo = getCurrentImChannelInfo(senderChannel)
                     if (channelInfo) {
                         sender = channelInfo.title
                     }

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -1,4 +1,4 @@
-import WKSDK, {
+import {
   Channel,
   ChannelInfo,
   ChannelInfoListener,
@@ -12,7 +12,7 @@ import { MessageContentTypeConst } from "../../Service/Const";
 import { ProviderListener } from "../../Service/Provider";
 import { debounce } from "../../Utils/rateLimit";
 import { t } from "../../i18n";
-import { addImChannelInfoListener, getImChannelInfo } from "../../im-runtime/channelRuntime";
+import { addCurrentImChannelInfoListener, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 
 /** Legacy contacts/groups bridge retained while the aggregated tabs migrate. */
 export default class GlobalSearchVM extends ProviderListener {
@@ -64,8 +64,7 @@ export default class GlobalSearchVM extends ProviderListener {
   // 搜索标题
   public get searchTitle() {
     if (this.searchInChannel) {
-      const channelInfo = getImChannelInfo(
-        WKSDK.shared(),
+      const channelInfo = getCurrentImChannelInfo(
         this.channel!
       );
       if (channelInfo) {
@@ -116,8 +115,7 @@ export default class GlobalSearchVM extends ProviderListener {
       }
     };
 
-    this.unsubscribeChannelInfoListener = addImChannelInfoListener(
-      WKSDK.shared(),
+    this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(
       this.channelInfoListener
     );
   }


### PR DESCRIPTION
## Summary
Finish the un-caught tail of the GlobalSearch migration: the legacy tab components (`tab-all` / `tab-contacts` / `tab-file`) and the bridge-layer `GlobalSearchVM` still reached into `WKSDK.shared()` directly, via the lower-level `im-runtime/channelRuntime` helpers that require an explicit SDK argument.

They now use the SDK-free `im-runtime/currentChannelRuntime` accessors:
- `getImChannelInfo(WKSDK.shared(), x)` → `getCurrentImChannelInfo(x)`
- `fetchImChannelInfo(WKSDK.shared(), x)` → `fetchCurrentImChannelInfo(x)`
- `addImChannelInfoListener(WKSDK.shared(), l)` → `addCurrentImChannelInfoListener(l)`

These wrappers call `WKSDK.shared()` internally — the same convention `WKAvatar`, `ChannelSetting` and the migrated `channelSearch` feature already follow. The default `import WKSDK` is dropped from all four files.

## Scope
- `Components/GlobalSearch/tab-all.tsx`, `tab-contacts.tsx`, `tab-file.tsx`
- `bridge/globalSearch/GlobalSearchVM.ts`

`Channel` construction and the `ChannelTypePerson` / `MessageContentType` / `MessageContentManager` / `SystemContent` named imports are kept — no im-runtime replacement exists for them, consistent with the rest of the migrated code.

## Out of scope
- `bridge/globalSearch/createGlobalSearchDataSource.ts`: its `WKSDK.shared().conversationManager.conversations` has no `current*` accessor, so swapping wouldn't remove the `WKSDK` import — left for later.
- Physically relocating tab/item components into `ui/`, deleting the legacy `Components/GlobalSearch/` dir, and pushing VM message decoding down into Service/mapper.

## Risk areas
No behavior change — the `current*` accessors only move the `WKSDK.shared()` call inside the seam.

## Verification
- `vitest run src/Components/GlobalSearch` — 9 files / 91 tests pass.
- `tsc --noEmit` — zero new type errors in the four touched files.
- Manual: open global search modal, exercise contacts / chat (all) / files tabs — avatars, sender names, source-space suffixes render; in-channel search title works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)