### PR TITLE
fix(onboarding): avoid default focus on Skip in Intro (#997)

### DIFF
--- a/apps/web/src/Components/Onboarding/index.tsx
+++ b/apps/web/src/Components/Onboarding/index.tsx
@@ -359,7 +359,11 @@ export const Onboarding: React.FC<OnboardingProps> = ({
     const activeElement = document.activeElement;
 
     if (event.shiftKey) {
-      if (activeElement === firstElement || !dialog.contains(activeElement)) {
+      if (
+        activeElement === firstElement ||
+        activeElement === dialog ||
+        !dialog.contains(activeElement)
+      ) {
         event.preventDefault();
         focusElement(lastElement);
       }
@@ -400,6 +404,11 @@ export const Onboarding: React.FC<OnboardingProps> = ({
       focusTimerRef.current = null;
       const dialog = dialogRef.current;
       if (!dialog) return;
+
+      if (showIntro) {
+        focusElement(dialog);
+        return;
+      }
 
       focusElement(getFocusableElements(dialog)[0] || dialog);
     }, 0);


### PR DESCRIPTION
Fixes #997.

## Summary

- Onboarding's focus-management effect always focuses the first tabbable element inside the dialog. In the Intro screen the first tabbable element is the `Skip` button, so on first paint every user — mouse and keyboard — sees the purple `:focus-visible` ring painted around `Skip`, visually promoting the secondary exit action as the default before onboarding has even started.
- Fix: focus the Intro dialog container directly (it already has `tabIndex={-1}`) instead of the first focusable descendant. Panel screens keep the existing first-element focus behavior.
- Extended the existing Tab trap so `Shift+Tab` from the dialog itself wraps to the last focusable element — otherwise focus would escape to the page background whenever the initial focus sits on the dialog container.
- `:focus-visible` styling is untouched, so keyboard users still see a clear focus ring once they start navigating with Tab.

## Test plan

- [ ] Open the app in a fresh Edge InPrivate window: no purple ring on `Skip` at first paint of Intro Page 1.
- [ ] Press `Tab` from the initial state: focus lands on `Skip` and the purple `:focus-visible` ring appears normally.
- [ ] Continue pressing `Tab` through the Intro: focus cycles through all interactive elements and wraps forward from the last back to the first.
- [ ] Press `Shift+Tab` immediately after the Intro opens (initial focus on the dialog itself): focus wraps to the last focusable element inside the dialog rather than escaping to the page background.
- [ ] Advance to the Panel screens (after `Continue`): first focusable element still receives focus as before (no regression to the Panel focus behavior).
- [ ] Screen reader announces the Intro dialog on open (dialog receives focus, still labelled via `aria-label`).