### PR TITLE
refactor(dmworkbase): move channel webhook actions into bridge

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/WebhookEditModal.tsx
@@ -1,116 +1,45 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Channel, ChannelTypePerson, WKSDK } from "wukongimjssdk";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Channel } from "wukongimjssdk";
 import { Switch, Toast } from "@douyinfe/semi-ui";
 import { IconAlertTriangle } from "@douyinfe/semi-icons";
 import WKModal from "../WKModal";
 import WKButton from "../WKButton";
 import AiBadge from "../AiBadge";
-import WKApp from "../../App";
 import { useI18n } from "../../i18n";
 import { extractErrorMsg } from "../../Service/APIClient";
-import { subscriberDisplayName } from "../../Utils/displayName";
 import {
-    getImChannelInfo,
-    getImChannelSubscribers,
-    syncImChannelSubscribers,
-} from "../../im-runtime/channelRuntime";
-import {
-    buildWebhookUpsertReq,
-    IncomingWebhook,
-    IncomingWebhookCreateResp,
-    IncomingWebhookService,
-    isFlagOn,
-    MENTION_UID_MAX_LENGTH,
-    MENTION_UIDS_MAX,
-    normalizeMentionUids,
-    validateMentionUids,
+  IncomingWebhook,
+  IncomingWebhookCreateResp,
+  MENTION_UID_MAX_LENGTH,
+  MENTION_UIDS_MAX,
 } from "../../Service/IncomingWebhook";
+import { useChannelWebhookEditor } from "../../bridge/channelWebhook/useChannelWebhookEditor";
+import { useChannelWebhookMembers } from "../../bridge/channelWebhook/useChannelWebhookMembers";
+import type { ChannelWebhookMemberOption } from "../../bridge/channelWebhook/types";
 import "./index.css";
 
 export interface WebhookEditModalProps {
-    channel: Channel;
-    /** 管理员才渲染头像输入（普通成员传 avatar 服务端直接 400） */
-    isManager: boolean;
-    /** 编辑模式传入现有项；新增模式不传 */
-    webhook?: IncomingWebhook;
-    /** 子区作用域：传入即把创建/更新打到该子区面（#451）；群面不传。channel 始终为父群。 */
-    threadShortId?: string;
-    onClose: () => void;
-    /** 保存成功回调；创建成功时携带含一次性 token/URL 的响应 */
-    onSaved: (created?: IncomingWebhookCreateResp) => void;
+  channel: Channel;
+  /** 管理员才渲染头像输入（普通成员传 avatar 服务端直接 400） */
+  isManager: boolean;
+  /** 编辑模式传入现有项；新增模式不传 */
+  webhook?: IncomingWebhook;
+  /** 子区作用域：传入即把创建/更新打到该子区面（#451）；群面不传。channel 始终为父群。 */
+  threadShortId?: string;
+  onClose: () => void;
+  /** 保存成功回调；创建成功时携带含一次性 token/URL 的响应 */
+  onSaved: (created?: IncomingWebhookCreateResp) => void;
 }
 
 // API 契约里的字段长度上限（OpenAPI schema 常量，非动态配额）
 const NAME_MAX_LENGTH = 64;
 const AVATAR_MAX_LENGTH = 255;
-
-/** mention_uids 选择器的候选项（群成员 / bot）。 */
-interface MentionMemberOption {
-    uid: string;
-    name: string;
-    isBot: boolean;
-}
-
-/** WKSDK Subscriber 运行时用到的子集（SDK 未导出精确字段）。 */
-type GroupSubscriber = {
-    uid?: string;
-    name?: string | null;
-    remark?: string | null;
-    status?: number;
-    orgData?: {
-        robot?: number;
-        real_name?: string | null;
-        realname_verified?: boolean | number | string | null;
-    } | null;
-};
-
-/**
- * 判定群成员是否为 AI/bot。双信号取并集，最大化命中：
- * - `subscriber.orgData.robot`：随订阅数据返回，但不一定被富化（可能缺）；
- * - 该 uid 的 Person `channelInfo.orgData.robot`：WKAvatar / 会话列表等通用判定，
- *   依赖 channelInfo 缓存是否已热。
- * 任一命中即视为 AI；都拿不到则按非 AI（best-effort，与全局头像/徽章判定一致）。
- */
-function isBotMember(uid: string, sub: GroupSubscriber): boolean {
-    if (isFlagOn(sub.orgData?.robot)) return true;
-    try {
-        const info = getImChannelInfo(
-            WKSDK.shared(),
-            new Channel(uid, ChannelTypePerson)
-        ) as { orgData?: { robot?: unknown } } | null | undefined;
-        return isFlagOn(info?.orgData?.robot);
-    } catch {
-        return false;
-    }
-}
-
-/**
- * 从群成员缓存读取 mention_uids 选择器候选：按 uid 去重，展示名走
- * subscriberDisplayName（实名 > 备注 > 昵称），AI 由 {@link isBotMember} 判定。
- * 不按 status 过滤、也不排除自己（自己同样可被 webhook 自动 @），成员资格由服务端
- * 兜底；同步读缓存，调用方在 syncSubscribes 完成后再读一次以刷新。
- */
-function readGroupMemberOptions(channel: Channel): MentionMemberOption[] {
-    let subs: GroupSubscriber[];
-    try {
-        subs = getImChannelSubscribers(WKSDK.shared(), channel) as GroupSubscriber[];
-    } catch {
-        return [];
-    }
-    const out: MentionMemberOption[] = [];
-    const seen = new Set<string>();
-    for (const sub of subs || []) {
-        const uid = sub?.uid;
-        if (!uid || seen.has(uid)) continue;
-        seen.add(uid);
-        out.push({
-            uid,
-            name: subscriberDisplayName(sub) || uid,
-            isBot: isBotMember(uid, sub),
-        });
-    }
-    return out;
-}
 
 /**
  * 新建 / 编辑 webhook 弹窗。
@@ -119,352 +48,301 @@ function readGroupMemberOptions(channel: Channel): MentionMemberOption[] {
  * - 头像仅管理员可设（URL 形式）；空值不随请求发送。
  */
 export default function WebhookEditModal({
+  channel,
+  isManager,
+  webhook,
+  threadShortId,
+  onClose,
+  onSaved,
+}: WebhookEditModalProps) {
+  const { t } = useI18n();
+  const {
+    isEdit,
+    name,
+    setName,
+    avatar,
+    setAvatar,
+    mentionAll,
+    setMentionAll,
+    mentionBots,
+    setMentionBots,
+    mentionUids,
+    saving,
+    toggleMentionUid,
+    submit,
+  } = useChannelWebhookEditor({
     channel,
     isManager,
     webhook,
     threadShortId,
-    onClose,
-    onSaved,
-}: WebhookEditModalProps) {
-    const { t } = useI18n();
-    const isEdit = !!webhook;
+  });
+  const { memberOptionsForSelect, aiOptionCount, optionByUid } =
+    useChannelWebhookMembers({
+      channel,
+      mentionUids,
+      selfFallback: t("base.channelWebhook.meta.me"),
+    });
+  const [memberSearch, setMemberSearch] = useState("");
+  // 本组件由父级条件挂载（{editTarget && <WebhookEditModal/>}），且处于
+  // WKViewQueue 路由栈的滑入动画里。若一挂载就 visible=true，Semi Modal 的
+  // 首次显示会与路由动画/portal 时序竞争，表现为「要点两次才弹出」。
+  // 这里挂载时先 false、effect 翻 true，强制走一次正常的 false→true 过渡，
+  // 与 BotManage 等常驻 + 受控 visible 的可用写法对齐。
+  const [visible, setVisible] = useState(false);
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
-    const [name, setName] = useState<string>(webhook?.name ?? "");
-    const [avatar, setAvatar] = useState<string>(webhook?.avatar ?? "");
-    // 能力位回显：服务端回 0/1（也可能是 "1"/true，见 isFlagOn），表单用 boolean。
-    // 能管理该 webhook 者均可开关（不受 isManager 门控，与头像不同）。
-    const [mentionAll, setMentionAll] = useState<boolean>(
-        isFlagOn(webhook?.allow_mention_all)
-    );
-    const [mentionBots, setMentionBots] = useState<boolean>(
-        isFlagOn(webhook?.allow_mention_bots)
-    );
-    // #465：每次推送自动 @ 的成员/bot。回显恒为数组（老后端不返回时按 [] 处理）。
-    const [mentionUids, setMentionUids] = useState<string[]>(
-        webhook?.mention_uids ?? []
-    );
-    // 候选成员：先同步读缓存，syncSubscribes 完成后再读一次刷新（弹窗可能在
-    // 成员未同步时打开）。
-    const [memberOptions, setMemberOptions] = useState<MentionMemberOption[]>(
-        () => readGroupMemberOptions(channel)
-    );
-    const [saving, setSaving] = useState(false);
-    const [memberSearch, setMemberSearch] = useState("");
-    // 本组件由父级条件挂载（{editTarget && <WebhookEditModal/>}），且处于
-    // WKViewQueue 路由栈的滑入动画里。若一挂载就 visible=true，Semi Modal 的
-    // 首次显示会与路由动画/portal 时序竞争，表现为「要点两次才弹出」。
-    // 这里挂载时先 false、effect 翻 true，强制走一次正常的 false→true 过渡，
-    // 与 BotManage 等常驻 + 受控 visible 的可用写法对齐。
-    const [visible, setVisible] = useState(false);
-    const nameInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    setVisible(true);
+    nameInputRef.current?.focus();
+  }, []);
 
-    useEffect(() => {
-        setVisible(true);
-        nameInputRef.current?.focus();
-    }, []);
-
-    // 成员可能未同步：拉一次后刷新候选，挂载即触发，channel 变更重拉。
-    useEffect(() => {
-        let alive = true;
-        syncImChannelSubscribers(WKSDK.shared(), channel)
-            .then(() => {
-                if (alive) setMemberOptions(readGroupMemberOptions(channel));
-            })
-            .catch(() => {
-                // 同步失败保持已读缓存，不阻断表单
-            });
-        return () => {
-            alive = false;
-        };
-    }, [channel]);
-
-    // 选择器候选：群成员 + 当前用户（群订阅缓存通常不含 self，但自己也是合法的
-    // 自动 @ 目标，显式补上）+ 「已配置但已不在成员列表（如退群）」的兜底项
-    // （避免编辑时把这些已配置 uid 静默丢弃，让用户能看到并主动移除）。
-    const memberOptionsForSelect = useMemo<MentionMemberOption[]>(() => {
-        const known = new Set(memberOptions.map((m) => m.uid));
-        const base = [...memberOptions];
-        const selfUid = WKApp.loginInfo?.uid;
-        if (selfUid && !known.has(selfUid)) {
-            base.push({
-                uid: selfUid,
-                name:
-                    WKApp.loginInfo.selfDisplayName?.() ||
-                    t("base.channelWebhook.meta.me"),
-                isBot: false,
-            });
-            known.add(selfUid);
-        }
-        // 兜底项从规整后的 mentionUids 取，避免脏回显（含空格/重复）渲染幽灵 chip。
-        const extras = normalizeMentionUids(mentionUids)
-            .filter((uid) => !known.has(uid))
-            .map((uid) => ({ uid, name: uid, isBot: false }));
-        return [...base, ...extras];
-    }, [memberOptions, mentionUids, t]);
-
-    // 下拉顶部人数标识用：总候选数与其中的 AI 数。
-    const aiOptionCount = useMemo(
-        () => memberOptionsForSelect.filter((m) => m.isBot).length,
-        [memberOptionsForSelect]
+  const visibleMemberOptions = useMemo(() => {
+    const keyword = memberSearch.trim().toLocaleLowerCase();
+    if (!keyword) return memberOptionsForSelect;
+    return memberOptionsForSelect.filter((member: ChannelWebhookMemberOption) =>
+      member.name.toLocaleLowerCase().includes(keyword)
     );
+  }, [memberOptionsForSelect, memberSearch]);
 
-    // 选中 chip 回显需要按 value(uid) 反查 isBot，给 renderSelectedItem 用。
-    const optionByUid = useMemo(
-        () => new Map(memberOptionsForSelect.map((m) => [m.uid, m])),
-        [memberOptionsForSelect]
-    );
-    const visibleMemberOptions = useMemo(() => {
-        const keyword = memberSearch.trim().toLocaleLowerCase();
-        if (!keyword) return memberOptionsForSelect;
-        return memberOptionsForSelect.filter((member) =>
-            member.name.toLocaleLowerCase().includes(keyword)
+  const handleSubmit = useCallback(async () => {
+    try {
+      const result = await submit();
+      if (!result.ok) {
+        const isTooMany = result.reason === "tooMany";
+        Toast.error(
+          t(
+            isTooMany
+              ? "base.channelWebhook.form.mentionUidsTooMany"
+              : "base.channelWebhook.form.mentionUidsTooLong",
+            {
+              values: {
+                max: isTooMany ? MENTION_UIDS_MAX : MENTION_UID_MAX_LENGTH,
+              },
+            }
+          )
         );
-    }, [memberOptionsForSelect, memberSearch]);
+        return;
+      }
+      if (result.status === "busy" || result.status === "stale") {
+        return;
+      }
+      if (result.status === "noop") {
+        onClose();
+        return;
+      }
+      if (result.status === "updated") {
+        Toast.success(t("base.channelWebhook.toast.updated"));
+        onSaved();
+        return;
+      }
+      Toast.success(t("base.channelWebhook.toast.created"));
+      onSaved(result.created);
+    } catch (e) {
+      // 配额超限（409，上限由服务端动态配置）等错误的文案已由服务端本地化，
+      // 直接展示，不在前端写死任何数值
+      Toast.error(
+        extractErrorMsg(e) ||
+          t(
+            isEdit
+              ? "base.channelWebhook.error.updateFailed"
+              : "base.channelWebhook.error.createFailed"
+          )
+      );
+    }
+  }, [isEdit, onClose, onSaved, submit, t]);
 
-    const toggleMentionUid = (uid: string) => {
-        setMentionUids((current) =>
-            current.includes(uid)
-                ? current.filter((item) => item !== uid)
-                : [...current, uid]
-        );
-    };
-
-    const handleSubmit = useCallback(async () => {
-        if (saving) return;
-
-        // mention_uids 即时校验：两种失败态都拦下并给对应文案（服务端 400 兜底）。
-        const mentionCheck = validateMentionUids(mentionUids);
-        if (!mentionCheck.ok) {
-            const isTooMany = mentionCheck.reason === "tooMany";
-            Toast.error(
-                t(
-                    isTooMany
-                        ? "base.channelWebhook.form.mentionUidsTooMany"
-                        : "base.channelWebhook.form.mentionUidsTooLong",
-                    {
-                        values: {
-                            max: isTooMany ? MENTION_UIDS_MAX : MENTION_UID_MAX_LENGTH,
-                        },
-                    }
-                )
-            );
-            return;
-        }
-
-        // 请求体构造逻辑抽到纯函数 buildWebhookUpsertReq（已单测）：
-        // 成员不得带 avatar、编辑态仅发变化字段、无变化返回 null。
-        const req = buildWebhookUpsertReq({
-            isEdit,
-            isManager,
-            name,
-            avatar,
-            mentionAll,
-            mentionBots,
-            mentionUids,
-            webhook,
-        });
-        if (req === null) {
-            // 编辑态无任何变化 → 不发请求，直接关闭
-            onClose();
-            return;
-        }
-
-        setSaving(true);
-        try {
-            if (isEdit && webhook) {
-                await IncomingWebhookService.update(
-                    channel.channelID,
-                    webhook.webhook_id,
-                    req,
-                    threadShortId
-                );
-                Toast.success(t("base.channelWebhook.toast.updated"));
-                onSaved();
-            } else {
-                const resp = await IncomingWebhookService.create(
-                    channel.channelID,
-                    req,
-                    threadShortId
-                );
-                Toast.success(t("base.channelWebhook.toast.created"));
-                onSaved(resp);
-            }
-        } catch (e) {
-            // 配额超限（409，上限由服务端动态配置）等错误的文案已由服务端本地化，
-            // 直接展示，不在前端写死任何数值
-            Toast.error(
-                extractErrorMsg(e) ||
-                    t(
-                        isEdit
-                            ? "base.channelWebhook.error.updateFailed"
-                            : "base.channelWebhook.error.createFailed"
-                    )
-            );
-        } finally {
-            setSaving(false);
-        }
-    }, [saving, name, avatar, mentionAll, mentionBots, mentionUids, isEdit, webhook, isManager, channel, threadShortId, t, onClose, onSaved]);
-
-    return (
-        <WKModal
-            visible={visible}
-            size="lg"
-            title={
-                isEdit
-                    ? t("base.channelWebhook.form.editTitle")
-                    : t("base.channelWebhook.form.createTitle")
-            }
-            onCancel={onClose}
-            options={{ closeOnEsc: true, maskClosable: false }}
-            footer={
-                <>
-                    <WKButton variant="ghost" onClick={onClose} disabled={saving}>
-                        {t("base.common.cancel")}
-                    </WKButton>
-                    <WKButton variant="primary" onClick={() => void handleSubmit()} loading={saving}>
-                        {t("base.common.save")}
-                    </WKButton>
-                </>
-            }
-            className="wk-webhook-modal"
-        >
-            <div className="wk-webhook-form">
-                <div className="wk-webhook-form__field">
-                    <label className="wk-webhook-form__label">
-                        {t("base.channelWebhook.form.name")}
-                    </label>
-                    <input
-                        ref={nameInputRef}
-                        className="wk-webhook-form__input"
-                        type="text"
-                        value={name}
-                        maxLength={NAME_MAX_LENGTH}
-                        placeholder={t("base.channelWebhook.form.namePlaceholder")}
-                        onChange={(e) => setName(e.target.value)}
-                        onKeyDown={(e) => {
-                            // 排除输入法组字回车（中文拼音等选词/上屏），仅非组字状态
-                            // 的回车才提交，避免误触发创建（#500）。
-                            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                                void handleSubmit();
-                            }
-                        }}
-                    />
-                </div>
-                {isManager && (
-                    <div className="wk-webhook-form__field">
-                        <label className="wk-webhook-form__label">
-                            {t("base.channelWebhook.form.avatar")}
-                            <span className="wk-webhook-form__optional">
-                                {t("base.channelWebhook.form.optional")}
-                            </span>
-                        </label>
-                        <input
-                            className="wk-webhook-form__input"
-                            type="text"
-                            value={avatar}
-                            maxLength={AVATAR_MAX_LENGTH}
-                            placeholder={t("base.channelWebhook.form.avatarPlaceholder")}
-                            onChange={(e) => setAvatar(e.target.value)}
-                        />
-                        <div className="wk-webhook-form__hint">
-                            {t("base.channelWebhook.form.avatarHint")}
-                        </div>
-                    </div>
-                )}
-                {/* 1️⃣ 自动 @ 成员（定向、噪声小）：#465 每次推送自动 @ 的成员/bot。
-                    候选限本群当前成员；回显 mention_uids，提交前做数量上限校验，服务端 400 兜底。 */}
-                <div className="wk-webhook-form__field">
-                    <div className="wk-webhook-form__label-row">
-                        <label className="wk-webhook-form__label">
-                            {t("base.channelWebhook.form.mentionUids")}
-                            <span className="wk-webhook-form__optional">
-                                {t("base.channelWebhook.form.optional")}
-                            </span>
-                        </label>
-                        <span className="wk-webhook-form__member-count">
-                            {t("base.channelWebhook.form.mentionUidsCount", {
-                                values: { total: memberOptionsForSelect.length, ai: aiOptionCount },
-                            })}
-                        </span>
-                    </div>
-                    <div className="wk-webhook-form__member-picker" data-testid="select">
-                        <input
-                            className="wk-webhook-form__member-search"
-                            value={memberSearch}
-                            onChange={(event) => setMemberSearch(event.target.value)}
-                            placeholder={t("base.channelWebhook.form.mentionUidsPlaceholder")}
-                            aria-label={t("base.channelWebhook.form.mentionUidsPlaceholder")}
-                        />
-                        {mentionUids.length > 0 && (
-                            <div className="wk-webhook-form__selected-members">
-                                {mentionUids.map((uid) => {
-                                    const member = optionByUid.get(uid);
-                                    return (
-                                        <button key={uid} type="button" className="wk-webhook-form__selected-member" onClick={() => toggleMentionUid(uid)}>
-                                            {member?.name || uid}{member?.isBot && <AiBadge size="small" />}<span aria-hidden="true">×</span>
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        )}
-                        <div className="wk-webhook-form__member-list">
-                            {visibleMemberOptions.map((member) => {
-                                const selected = mentionUids.includes(member.uid);
-                                return (
-                                    <button key={member.uid} type="button" data-testid={`opt-${member.uid}`} className="wk-webhook-form__member-option" onClick={() => toggleMentionUid(member.uid)}>
-                                        <span className={`wk-webhook-form__member-check${selected ? " wk-webhook-form__member-check--selected" : ""}`}>{selected ? "✓" : ""}</span>
-                                        <span className="wk-webhook-form__member-name">{member.name}</span>
-                                        {member.isBot && <AiBadge size="small" />}
-                                    </button>
-                                );
-                            })}
-                        </div>
-                    </div>
-                    <div className="wk-webhook-form__hint">
-                        {t("base.channelWebhook.form.mentionUidsHint", {
-                            values: { max: MENTION_UIDS_MAX },
-                        })}
-                    </div>
-                </div>
-                {/* 2️⃣3️⃣ 广播开关（@所有AI / @所有人）：每条推送都会提醒对应全部成员，
-                    易造成消息噪声，单独包进警示块着重标记。能进入本表单即可开关，不受 isManager 门控。 */}
-                <div className="wk-webhook-form__broadcast">
-                    <div className="wk-webhook-form__broadcast-note">
-                        <IconAlertTriangle className="wk-webhook-form__broadcast-icon" />
-                        <span>{t("base.channelWebhook.form.broadcastNoiseHint")}</span>
-                    </div>
-                    <div className="wk-webhook-form__switch-row">
-                        <div className="wk-webhook-form__switch-text">
-                            <label className="wk-webhook-form__label">
-                                {t("base.channelWebhook.form.mentionBots")}
-                            </label>
-                            <div className="wk-webhook-form__hint">
-                                {t("base.channelWebhook.form.mentionBotsHint")}
-                            </div>
-                        </div>
-                        <Switch
-                            checked={mentionBots}
-                            onChange={(v: boolean) => setMentionBots(v)}
-                            aria-label={t("base.channelWebhook.form.mentionBots")}
-                        />
-                    </div>
-                    <div className="wk-webhook-form__switch-row">
-                        <div className="wk-webhook-form__switch-text">
-                            <label className="wk-webhook-form__label">
-                                {t("base.channelWebhook.form.mentionAll")}
-                            </label>
-                            <div className="wk-webhook-form__hint">
-                                {t("base.channelWebhook.form.mentionAllHint")}
-                            </div>
-                        </div>
-                        <Switch
-                            checked={mentionAll}
-                            onChange={(v: boolean) => setMentionAll(v)}
-                            aria-label={t("base.channelWebhook.form.mentionAll")}
-                        />
-                    </div>
-                </div>
+  return (
+    <WKModal
+      visible={visible}
+      size="lg"
+      title={
+        isEdit
+          ? t("base.channelWebhook.form.editTitle")
+          : t("base.channelWebhook.form.createTitle")
+      }
+      onCancel={onClose}
+      options={{ closeOnEsc: true, maskClosable: false }}
+      footer={
+        <>
+          <WKButton variant="ghost" onClick={onClose} disabled={saving}>
+            {t("base.common.cancel")}
+          </WKButton>
+          <WKButton
+            variant="primary"
+            onClick={() => void handleSubmit()}
+            loading={saving}
+          >
+            {t("base.common.save")}
+          </WKButton>
+        </>
+      }
+      className="wk-webhook-modal"
+    >
+      <div className="wk-webhook-form">
+        <div className="wk-webhook-form__field">
+          <label className="wk-webhook-form__label">
+            {t("base.channelWebhook.form.name")}
+          </label>
+          <input
+            ref={nameInputRef}
+            className="wk-webhook-form__input"
+            type="text"
+            value={name}
+            maxLength={NAME_MAX_LENGTH}
+            placeholder={t("base.channelWebhook.form.namePlaceholder")}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              // 排除输入法组字回车（中文拼音等选词/上屏），仅非组字状态
+              // 的回车才提交，避免误触发创建（#500）。
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                void handleSubmit();
+              }
+            }}
+          />
+        </div>
+        {isManager && (
+          <div className="wk-webhook-form__field">
+            <label className="wk-webhook-form__label">
+              {t("base.channelWebhook.form.avatar")}
+              <span className="wk-webhook-form__optional">
+                {t("base.channelWebhook.form.optional")}
+              </span>
+            </label>
+            <input
+              className="wk-webhook-form__input"
+              type="text"
+              value={avatar}
+              maxLength={AVATAR_MAX_LENGTH}
+              placeholder={t("base.channelWebhook.form.avatarPlaceholder")}
+              onChange={(e) => setAvatar(e.target.value)}
+            />
+            <div className="wk-webhook-form__hint">
+              {t("base.channelWebhook.form.avatarHint")}
             </div>
-        </WKModal>
-    );
+          </div>
+        )}
+        {/* 1️⃣ 自动 @ 成员（定向、噪声小）：#465 每次推送自动 @ 的成员/bot。
+                    候选限本群当前成员；回显 mention_uids，提交前做数量上限校验，服务端 400 兜底。 */}
+        <div className="wk-webhook-form__field">
+          <div className="wk-webhook-form__label-row">
+            <label className="wk-webhook-form__label">
+              {t("base.channelWebhook.form.mentionUids")}
+              <span className="wk-webhook-form__optional">
+                {t("base.channelWebhook.form.optional")}
+              </span>
+            </label>
+            <span className="wk-webhook-form__member-count">
+              {t("base.channelWebhook.form.mentionUidsCount", {
+                values: {
+                  total: memberOptionsForSelect.length,
+                  ai: aiOptionCount,
+                },
+              })}
+            </span>
+          </div>
+          <div className="wk-webhook-form__member-picker" data-testid="select">
+            <input
+              className="wk-webhook-form__member-search"
+              value={memberSearch}
+              onChange={(event) => setMemberSearch(event.target.value)}
+              placeholder={t("base.channelWebhook.form.mentionUidsPlaceholder")}
+              aria-label={t("base.channelWebhook.form.mentionUidsPlaceholder")}
+            />
+            {mentionUids.length > 0 && (
+              <div className="wk-webhook-form__selected-members">
+                {mentionUids.map((uid: string) => {
+                  const member = optionByUid.get(uid);
+                  return (
+                    <button
+                      key={uid}
+                      type="button"
+                      className="wk-webhook-form__selected-member"
+                      onClick={() => toggleMentionUid(uid)}
+                    >
+                      {member?.name || uid}
+                      {member?.isBot && <AiBadge size="small" />}
+                      <span aria-hidden="true">×</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <div className="wk-webhook-form__member-list">
+              {visibleMemberOptions.map(
+                (member: ChannelWebhookMemberOption) => {
+                  const selected = mentionUids.includes(member.uid);
+                  return (
+                    <button
+                      key={member.uid}
+                      type="button"
+                      data-testid={`opt-${member.uid}`}
+                      className="wk-webhook-form__member-option"
+                      onClick={() => toggleMentionUid(member.uid)}
+                    >
+                      <span
+                        className={`wk-webhook-form__member-check${
+                          selected
+                            ? " wk-webhook-form__member-check--selected"
+                            : ""
+                        }`}
+                      >
+                        {selected ? "✓" : ""}
+                      </span>
+                      <span className="wk-webhook-form__member-name">
+                        {member.name}
+                      </span>
+                      {member.isBot && <AiBadge size="small" />}
+                    </button>
+                  );
+                }
+              )}
+            </div>
+          </div>
+          <div className="wk-webhook-form__hint">
+            {t("base.channelWebhook.form.mentionUidsHint", {
+              values: { max: MENTION_UIDS_MAX },
+            })}
+          </div>
+        </div>
+        {/* 2️⃣3️⃣ 广播开关（@所有AI / @所有人）：每条推送都会提醒对应全部成员，
+                    易造成消息噪声，单独包进警示块着重标记。能进入本表单即可开关，不受 isManager 门控。 */}
+        <div className="wk-webhook-form__broadcast">
+          <div className="wk-webhook-form__broadcast-note">
+            <IconAlertTriangle className="wk-webhook-form__broadcast-icon" />
+            <span>{t("base.channelWebhook.form.broadcastNoiseHint")}</span>
+          </div>
+          <div className="wk-webhook-form__switch-row">
+            <div className="wk-webhook-form__switch-text">
+              <label className="wk-webhook-form__label">
+                {t("base.channelWebhook.form.mentionBots")}
+              </label>
+              <div className="wk-webhook-form__hint">
+                {t("base.channelWebhook.form.mentionBotsHint")}
+              </div>
+            </div>
+            <Switch
+              checked={mentionBots}
+              onChange={(v: boolean) => setMentionBots(v)}
+              aria-label={t("base.channelWebhook.form.mentionBots")}
+            />
+          </div>
+          <div className="wk-webhook-form__switch-row">
+            <div className="wk-webhook-form__switch-text">
+              <label className="wk-webhook-form__label">
+                {t("base.channelWebhook.form.mentionAll")}
+              </label>
+              <div className="wk-webhook-form__hint">
+                {t("base.channelWebhook.form.mentionAllHint")}
+              </div>
+            </div>
+            <Switch
+              checked={mentionAll}
+              onChange={(v: boolean) => setMentionAll(v)}
+              aria-label={t("base.channelWebhook.form.mentionAll")}
+            />
+          </div>
+        </div>
+      </div>
+    </WKModal>
+  );
 }

--- a/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx
@@ -8,25 +8,27 @@
  *
  * React 17 + ReactDOM.render pattern (matches WebhookUrlModal.test.tsx).
  */
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { i18n } from '../../../i18n';
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { i18n } from "../../../i18n";
 
 const hoisted = vi.hoisted(() => ({
-  create: vi.fn().mockResolvedValue({ webhook_id: 'iwh_new', token: 't', url: '/u' }),
+  create: vi
+    .fn()
+    .mockResolvedValue({ webhook_id: "iwh_new", token: "t", url: "/u" }),
   update: vi.fn().mockResolvedValue(undefined),
   subscribers: [] as any[],
 }));
 
 // 自定义 Select mock：把每个 Option 渲染成可点击按钮（点击切换 value，多选语义）。
 // 若组件传了 renderOptionItem，则用它渲染按钮内容，覆盖真实下拉行（含 AI 徽章）。
-vi.mock('@douyinfe/semi-ui', () => {
+vi.mock("@douyinfe/semi-ui", () => {
   const Select: any = ({ value, onChange, children, renderOptionItem }: any) =>
     React.createElement(
-      'div',
-      { 'data-testid': 'select', 'data-value': (value || []).join(',') },
+      "div",
+      { "data-testid": "select", "data-value": (value || []).join(",") },
       React.Children.map(children, (child: any) => {
         const v = child.props.value;
         const toggle = () => {
@@ -44,43 +46,45 @@ vi.mock('@douyinfe/semi-ui', () => {
             })
           : child.props.children;
         return React.createElement(
-          'button',
-          { 'data-testid': `opt-${v}`, onClick: toggle },
+          "button",
+          { "data-testid": `opt-${v}`, onClick: toggle },
           content
         );
       })
     );
-  Select.Option = ({ children }: any) => React.createElement(React.Fragment, null, children);
+  Select.Option = ({ children }: any) =>
+    React.createElement(React.Fragment, null, children);
   const Switch = ({ checked, onChange }: any) =>
-    React.createElement('button', {
-      'data-testid': 'switch',
-      'data-checked': String(!!checked),
+    React.createElement("button", {
+      "data-testid": "switch",
+      "data-checked": String(!!checked),
       onClick: () => onChange(!checked),
     });
   return { Select, Switch, Toast: { success: vi.fn(), error: vi.fn() } };
 });
 
-vi.mock('@douyinfe/semi-icons', () => ({
-  IconAlertTriangle: () => React.createElement('span', { 'data-testid': 'icon-alert' }),
+vi.mock("@douyinfe/semi-icons", () => ({
+  IconAlertTriangle: () =>
+    React.createElement("span", { "data-testid": "icon-alert" }),
 }));
 
-vi.mock('../../WKModal', () => ({
+vi.mock("../../WKModal", () => ({
   default: ({ children, footer, visible }: any) =>
     visible
-      ? React.createElement('div', { 'data-testid': 'modal' }, children, footer)
+      ? React.createElement("div", { "data-testid": "modal" }, children, footer)
       : null,
   __esModule: true,
 }));
 
-vi.mock('../../WKButton', () => ({
+vi.mock("../../WKButton", () => ({
   default: ({ children, onClick }: any) =>
-    React.createElement('button', { onClick }, children),
+    React.createElement("button", { onClick }, children),
   __esModule: true,
 }));
 
-vi.mock('../../../App', () => ({
+vi.mock("../../../App", () => ({
   default: {
-    loginInfo: { uid: 'me' },
+    loginInfo: { uid: "me" },
     dataSource: {
       channelDataSource: {
         createIncomingWebhook: (...a: any[]) => hoisted.create(...a),
@@ -91,7 +95,7 @@ vi.mock('../../../App', () => ({
   __esModule: true,
 }));
 
-vi.mock('../../../Service/APIClient', () => ({
+vi.mock("../../../Service/APIClient", () => ({
   extractErrorMsg: (e: unknown) => String(e),
   default: {
     shared: {
@@ -101,7 +105,13 @@ vi.mock('../../../Service/APIClient', () => ({
   },
 }));
 
-vi.mock('wukongimjssdk', async (importOriginal) => {
+vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
+  getCurrentImChannelSubscribers: () => hoisted.subscribers,
+  syncCurrentImChannelSubscribers: () => Promise.resolve(),
+  getCurrentImChannelInfo: () => undefined,
+}));
+
+vi.mock("wukongimjssdk", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
@@ -117,31 +127,38 @@ vi.mock('wukongimjssdk', async (importOriginal) => {
   };
 });
 
-import WebhookEditModal from '../WebhookEditModal';
+import WebhookEditModal from "../WebhookEditModal";
 
 let container: HTMLDivElement;
 
 beforeEach(() => {
-  i18n.setLocale('zh-CN', { notify: false, persist: false });
-  hoisted.create.mockReset().mockResolvedValue({ webhook_id: 'iwh_new', token: 't', url: '/u' });
+  i18n.setLocale("zh-CN", { notify: false, persist: false });
+  hoisted.create
+    .mockReset()
+    .mockResolvedValue({ webhook_id: "iwh_new", token: "t", url: "/u" });
   hoisted.update.mockReset().mockResolvedValue(undefined);
   // 注意：订阅列表故意不含 self('me')——验证组件会显式把当前用户补进候选。
   hoisted.subscribers = [
-    { uid: 'u1', name: 'Alice' },
-    { uid: 'u2', name: 'Bob' },
-    { uid: 'bot1', name: 'HelperBot', orgData: { robot: 1 } },
+    { uid: "u1", name: "Alice" },
+    { uid: "u2", name: "Bob" },
+    { uid: "bot1", name: "HelperBot", orgData: { robot: 1 } },
   ];
-  container = document.createElement('div');
+  container = document.createElement("div");
   document.body.appendChild(container);
 });
 
 afterEach(() => {
-  act(() => { ReactDOM.unmountComponentAtNode(container); });
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
   container.remove();
 });
 
 const flush = async (): Promise<void> => {
-  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 };
 
 const render = async (props: any): Promise<void> => {
@@ -161,14 +178,16 @@ const render = async (props: any): Promise<void> => {
 };
 
 const clickSave = (): void => {
-  const saveBtn = Array.from(container.querySelectorAll('button')).find(
-    (b) => b.textContent === '保存'
+  const saveBtn = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "保存"
   )!;
-  act(() => { saveBtn.click(); });
+  act(() => {
+    saveBtn.click();
+  });
 };
 
-describe('WebhookEditModal mention_uids picker', () => {
-  it('lists group members and explicitly includes the current user (not in subscribers)', async () => {
+describe("WebhookEditModal mention_uids picker", () => {
+  it("lists group members and explicitly includes the current user (not in subscribers)", async () => {
     await render({});
     expect(container.querySelector('[data-testid="opt-u1"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="opt-u2"]')).not.toBeNull();
@@ -177,22 +196,26 @@ describe('WebhookEditModal mention_uids picker', () => {
     expect(container.querySelector('[data-testid="opt-me"]')).not.toBeNull();
   });
 
-  it('flags bot members with the AI badge', async () => {
+  it("flags bot members with the AI badge", async () => {
     await render({});
     const botOpt = container.querySelector('[data-testid="opt-bot1"]')!;
-    expect(botOpt.querySelector('.ai-badge')).not.toBeNull();
+    expect(botOpt.querySelector(".ai-badge")).not.toBeNull();
     const humanOpt = container.querySelector('[data-testid="opt-u1"]')!;
-    expect(humanOpt.querySelector('.ai-badge')).toBeNull();
+    expect(humanOpt.querySelector(".ai-badge")).toBeNull();
   });
 
-  it('create: selected members are sent as mention_uids', async () => {
+  it("create: selected members are sent as mention_uids", async () => {
     await render({});
     act(() => {
-      container.querySelector<HTMLButtonElement>('[data-testid="opt-u1"]')!.click();
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="opt-u1"]')!
+        .click();
     });
     await flush();
     act(() => {
-      container.querySelector<HTMLButtonElement>('[data-testid="opt-bot1"]')!.click();
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="opt-bot1"]')!
+        .click();
     });
     await flush();
     clickSave();
@@ -200,31 +223,35 @@ describe('WebhookEditModal mention_uids picker', () => {
 
     expect(hoisted.create).toHaveBeenCalledTimes(1);
     const req = hoisted.create.mock.calls[0][1];
-    expect(req.mention_uids).toEqual(['u1', 'bot1']);
+    expect(req.mention_uids).toEqual(["u1", "bot1"]);
   });
 
-  it('edit: clearing all selections sends an explicit empty array', async () => {
+  it("edit: clearing all selections sends an explicit empty array", async () => {
     await render({
       webhook: {
-        webhook_id: 'iwh_1',
-        group_no: 'g',
-        name: 'CI',
-        avatar: '',
-        creator_uid: 'u9',
+        webhook_id: "iwh_1",
+        group_no: "g",
+        name: "CI",
+        avatar: "",
+        creator_uid: "u9",
         status: 1,
         last_used_at: 0,
         call_count: 0,
         created_at: 0,
-        mention_uids: ['u1', 'u2'],
+        mention_uids: ["u1", "u2"],
       },
     });
     // 取消两个已选 → 清空
     act(() => {
-      container.querySelector<HTMLButtonElement>('[data-testid="opt-u1"]')!.click();
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="opt-u1"]')!
+        .click();
     });
     await flush();
     act(() => {
-      container.querySelector<HTMLButtonElement>('[data-testid="opt-u2"]')!.click();
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="opt-u2"]')!
+        .click();
     });
     await flush();
     clickSave();
@@ -235,19 +262,19 @@ describe('WebhookEditModal mention_uids picker', () => {
     expect(req.mention_uids).toEqual([]);
   });
 
-  it('edit: no changes → no request (modal just closes)', async () => {
+  it("edit: no changes → no request (modal just closes)", async () => {
     await render({
       webhook: {
-        webhook_id: 'iwh_1',
-        group_no: 'g',
-        name: 'CI',
-        avatar: '',
-        creator_uid: 'u9',
+        webhook_id: "iwh_1",
+        group_no: "g",
+        name: "CI",
+        avatar: "",
+        creator_uid: "u9",
         status: 1,
         last_used_at: 0,
         call_count: 0,
         created_at: 0,
-        mention_uids: ['u1'],
+        mention_uids: ["u1"],
       },
     });
     clickSave();
@@ -256,15 +283,15 @@ describe('WebhookEditModal mention_uids picker', () => {
   });
 });
 
-describe('WebhookEditModal name input Enter / IME composition (#500)', () => {
+describe("WebhookEditModal name input Enter / IME composition (#500)", () => {
   const nameInput = (): HTMLInputElement =>
-    container.querySelectorAll<HTMLInputElement>('.wk-webhook-form__input')[0];
+    container.querySelectorAll<HTMLInputElement>(".wk-webhook-form__input")[0];
 
   const pressEnter = (isComposing: boolean): void => {
     act(() => {
       nameInput().dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter',
+        new KeyboardEvent("keydown", {
+          key: "Enter",
           isComposing,
           bubbles: true,
           cancelable: true,
@@ -273,7 +300,7 @@ describe('WebhookEditModal name input Enter / IME composition (#500)', () => {
     });
   };
 
-  it('does NOT submit when Enter fires during IME composition (选词/上屏)', async () => {
+  it("does NOT submit when Enter fires during IME composition (选词/上屏)", async () => {
     await render({});
     // 中文拼音等输入法组字过程中的回车仅用于上屏候选，不应触发创建。
     pressEnter(true);
@@ -281,7 +308,7 @@ describe('WebhookEditModal name input Enter / IME composition (#500)', () => {
     expect(hoisted.create).not.toHaveBeenCalled();
   });
 
-  it('submits when Enter fires outside composition', async () => {
+  it("submits when Enter fires outside composition", async () => {
     await render({});
     // 非组字状态下的回车仍应正常提交创建（名称可留空，服务端自动命名）。
     pressEnter(false);

--- a/packages/dmworkbase/src/Components/ChannelWebhook/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelWebhook/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Channel } from "wukongimjssdk";
 import { Spin, Toast } from "@douyinfe/semi-ui";
 import { IconPlus, IconLink } from "@douyinfe/semi-icons";
@@ -7,38 +7,33 @@ import { wkConfirm } from "../WKModal";
 import { useI18n } from "../../i18n";
 import { extractErrorMsg } from "../../Service/APIClient";
 import {
-    IncomingWebhook,
-    IncomingWebhookCreateResp,
-    IncomingWebhookStatus,
-    IncomingWebhookService,
-    canManageIncomingWebhook,
-    canTestWebhook,
+  IncomingWebhook,
+  IncomingWebhookCreateResp,
+  canManageIncomingWebhook,
 } from "../../Service/IncomingWebhook";
 import WebhookEditModal from "./WebhookEditModal";
 import WebhookUrlModal from "./WebhookUrlModal";
 import ChannelWebhookCard from "./ChannelWebhookCard";
 import { useChannelWebhookList } from "../../bridge/channelWebhook/useChannelWebhookList";
+import { useChannelWebhookActions } from "../../bridge/channelWebhook/useChannelWebhookActions";
 import "./index.css";
 
 export interface ChannelWebhookPanelProps {
-    channel: Channel;
-    /** 当前用户是否群主/管理员：决定可管理范围与是否可设置头像 */
-    isManager: boolean;
-    /**
-     * 子区作用域 short_id（#451）。传入即整个面板切到子区面：list / 创建 / 管理 / 测试全部打到
-     * groups/{group}/threads/{short}/incoming-webhooks，后端按 (group_no, short_id) 作用域隔离。
-     * channel 仍为【父群】channel。群面不传（历史语义不变）。
-     */
-    threadShortId?: string;
+  channel: Channel;
+  /** 当前用户是否群主/管理员：决定可管理范围与是否可设置头像 */
+  isManager: boolean;
+  /**
+   * 子区作用域 short_id（#451）。传入即整个面板切到子区面：list / 创建 / 管理 / 测试全部打到
+   * groups/{group}/threads/{short}/incoming-webhooks，后端按 (group_no, short_id) 作用域隔离。
+   * channel 仍为【父群】channel。群面不传（历史语义不变）。
+   */
+  threadShortId?: string;
 }
 
 type EditTarget =
-    | { mode: "create" }
-    | { mode: "edit"; webhook: IncomingWebhook }
-    | null;
-
-/** 测试推送冷却窗口（毫秒）：防止连点刷屏（每次测试都会向群内发真实消息）。 */
-const TEST_COOLDOWN_MS = 3000;
+  | { mode: "create" }
+  | { mode: "edit"; webhook: IncomingWebhook }
+  | null;
 
 /**
  * 群设置 →「群 Webhook」子页面。
@@ -48,271 +43,269 @@ const TEST_COOLDOWN_MS = 3000;
  * 前端不做本地判断，超限时直接展示服务端 409 的本地化文案。
  */
 export default function ChannelWebhookPanel({
-    channel,
-    isManager,
-    threadShortId,
+  channel,
+  isManager,
+  threadShortId,
 }: ChannelWebhookPanelProps) {
-    const { t, format } = useI18n();
-    const handleLoadError = useCallback((loadError: unknown) => {
-        Toast.error(extractErrorMsg(loadError) || t("base.channelWebhook.error.loadFailed"));
-    }, [t]);
-    const { items, loading, error, myUid, creatorNames, reload: load } =
-        useChannelWebhookList({
-            channel,
-            threadShortId,
-            selfFallback: t("base.channelWebhook.meta.me"),
-            onLoadError: handleLoadError,
-        });
-    const [editTarget, setEditTarget] = useState<EditTarget>(null);
-    // 创建 / 重置 token 后的一次性 URL 展示（token 仅此一次返回）
-    const [urlResult, setUrlResult] = useState<IncomingWebhookCreateResp | null>(null);
-    const [testingId, setTestingId] = useState<string | null>(null);
-    const [togglingId, setTogglingId] = useState<string | null>(null);
-    // 测试推送会向群内发真实消息，连点会刷屏。点一次后该 webhook 进入冷却，
-    // 冷却期间按钮置灰、忽略再次点击。
-    const [coolingTestId, setCoolingTestId] = useState<string | null>(null);
-    const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const scopeKey = `${channel.channelID}:${threadShortId || "group"}`;
+  const { t, format } = useI18n();
+  const handleLoadError = useCallback(
+    (loadError: unknown) => {
+      Toast.error(
+        extractErrorMsg(loadError) || t("base.channelWebhook.error.loadFailed")
+      );
+    },
+    [t]
+  );
+  const {
+    items,
+    loading,
+    error,
+    myUid,
+    creatorNames,
+    reload: load,
+  } = useChannelWebhookList({
+    channel,
+    threadShortId,
+    selfFallback: t("base.channelWebhook.meta.me"),
+    onLoadError: handleLoadError,
+  });
+  const [editTarget, setEditTarget] = useState<EditTarget>(null);
+  // 创建 / 重置 token 后的一次性 URL 展示（token 仅此一次返回）
+  const [urlResult, setUrlResult] = useState<IncomingWebhookCreateResp | null>(
+    null
+  );
+  const scopeKey = `${channel.channelID}:${threadShortId || "group"}`;
+  const {
+    testingId,
+    togglingId,
+    coolingTestId,
+    toggleWebhook,
+    testWebhook,
+    regenerateWebhook,
+    deleteWebhook,
+  } = useChannelWebhookActions({
+    channel,
+    threadShortId,
+    reload: load,
+  });
 
-    useEffect(() => () => {
-        if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
-    }, []);
+  // 群/子区切换时立即清掉旧对象的 UI overlay，避免旧弹窗串台。
+  useEffect(() => {
+    setEditTarget(null);
+    setUrlResult(null);
+  }, [scopeKey]);
 
-    // 群/子区切换时立即清掉旧对象的 UI 状态，避免旧列表、弹窗或 pending 状态串台。
-    useEffect(() => {
-        setEditTarget(null);
-        setUrlResult(null);
-        setTestingId(null);
-        setTogglingId(null);
-        setCoolingTestId(null);
-        if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
-    }, [scopeKey]);
+  const handleToggle = async (item: IncomingWebhook, next: boolean) => {
+    try {
+      await toggleWebhook(item, next);
+    } catch (e) {
+      // 409 mgmt_creator_left（创建者已退群无法启用）等服务端文案已本地化，直接展示
+      Toast.error(
+        extractErrorMsg(e) || t("base.channelWebhook.error.updateFailed")
+      );
+    }
+  };
 
-    const handleToggle = async (item: IncomingWebhook, next: boolean) => {
-        // in-flight 守卫：Semi 的 Switch loading 不保证拦截 onChange，
-        // 疯狂拨动会连发请求，这里与 handleTest 同款，请求未回前直接忽略。
-        if (togglingId) return;
-        setTogglingId(item.webhook_id);
+  const handleTest = async (item: IncomingWebhook) => {
+    try {
+      const sent = await testWebhook(item);
+      if (sent) Toast.success(t("base.channelWebhook.toast.testSent"));
+    } catch (e) {
+      Toast.error(
+        extractErrorMsg(e) || t("base.channelWebhook.error.testFailed")
+      );
+    }
+  };
+
+  const handleRegenerate = (item: IncomingWebhook) => {
+    wkConfirm({
+      title: t("base.channelWebhook.regenerate.title"),
+      content: t("base.channelWebhook.regenerate.content", {
+        values: { name: item.name },
+      }),
+      okText: t("base.channelWebhook.regenerate.confirm"),
+      okType: "danger",
+      onOk: async () => {
         try {
-            await IncomingWebhookService.update(
-                channel.channelID,
-                item.webhook_id,
-                { status: next ? IncomingWebhookStatus.enabled : IncomingWebhookStatus.disabled },
-                threadShortId
-            );
-            void load();
+          const result = await regenerateWebhook(item);
+          if (result.ok) {
+            setUrlResult(result.response);
+          }
         } catch (e) {
-            // 409 mgmt_creator_left（创建者已退群无法启用）等服务端文案已本地化，直接展示
-            Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.updateFailed"));
-        } finally {
-            setTogglingId(null);
+          Toast.error(
+            extractErrorMsg(e) ||
+              t("base.channelWebhook.error.regenerateFailed")
+          );
+          // 重新抛出：wkConfirm 的 onOk 捕获 reject 后保持弹窗打开、按钮复位
+          // 供用户重试（见 WKModal/confirm.tsx 的 .catch(updatePending(null))）。
+          throw e;
         }
-    };
+      },
+    });
+  };
 
-    const handleTest = async (item: IncomingWebhook) => {
-        // 已禁用的 webhook 不允许测试：test 走管理面、绕开推送面的 enabled 检查，
-        // 仍会向群内发真实消息，且「测试成功」会对一个真实推送被 401 挡掉的 webhook
-        // 给出假信心。与「禁用=不再发消息」的语义保持一致。
-        if (!canTestWebhook(item)) return;
-        // 正在切换启停时 item.status 仍是刷新前的旧值，此刻放行会用过期状态发测试，
-        // 故该 webhook 切换在飞期间一并拦截（与按钮 disabled 同源）。
-        if (togglingId === item.webhook_id) return;
-        // 已有测试在飞 / 该 webhook 处于冷却中 → 忽略，避免连点刷屏。
-        if (testingId || coolingTestId === item.webhook_id) return;
-        setTestingId(item.webhook_id);
+  const handleDelete = (item: IncomingWebhook) => {
+    wkConfirm({
+      title: t("base.channelWebhook.delete.title"),
+      content: t("base.channelWebhook.delete.content", {
+        values: { name: item.name },
+      }),
+      okText: t("base.channelWebhook.delete.confirm"),
+      okType: "danger",
+      onOk: async () => {
+        let deleted = false;
         try {
-            await IncomingWebhookService.test(channel.channelID, item.webhook_id, threadShortId);
-            Toast.success(t("base.channelWebhook.toast.testSent"));
+          const result = await deleteWebhook(item);
+          deleted = result.ok;
         } catch (e) {
-            Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.testFailed"));
-        } finally {
-            setTestingId(null);
-            // 进入冷却：本 webhook 的测试按钮置灰若干秒后恢复。
-            setCoolingTestId(item.webhook_id);
-            if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
-            cooldownTimerRef.current = setTimeout(
-                () => setCoolingTestId(null),
-                TEST_COOLDOWN_MS
-            );
+          Toast.error(
+            extractErrorMsg(e) || t("base.channelWebhook.error.deleteFailed")
+          );
+          // 重新抛出：wkConfirm 捕获 reject 后保持弹窗打开供重试（同 handleRegenerate）。
+          throw e;
         }
-    };
+        if (deleted) {
+          Toast.success(t("base.channelWebhook.toast.deleted"));
+        }
+      },
+    });
+  };
 
-    const handleRegenerate = (item: IncomingWebhook) => {
-        wkConfirm({
-            title: t("base.channelWebhook.regenerate.title"),
-            content: t("base.channelWebhook.regenerate.content", {
-                values: { name: item.name },
-            }),
-            okText: t("base.channelWebhook.regenerate.confirm"),
-            okType: "danger",
-            onOk: async () => {
-                try {
-                    const resp = await IncomingWebhookService.regenerate(
-                        channel.channelID,
-                        item.webhook_id,
-                        threadShortId
-                    );
-                    setUrlResult(resp);
-                    void load();
-                } catch (e) {
-                    Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.regenerateFailed"));
-                    // 重新抛出：wkConfirm 的 onOk 捕获 reject 后保持弹窗打开、按钮复位
-                    // 供用户重试（见 WKModal/confirm.tsx 的 .catch(updatePending(null))）。
-                    throw e;
-                }
+  const renderMeta = (item: IncomingWebhook) => {
+    const name = creatorNames.get(item.creator_uid) || "";
+    const created = format.date(item.created_at * 1000);
+    const createdLine = name
+      ? t("base.channelWebhook.meta.createdBy", {
+          values: { name, time: created },
+        })
+      : t("base.channelWebhook.meta.created", { values: { time: created } });
+    // 从未使用时不展示用法行（去掉「从未使用」描述）；仅在有过推送时显示统计。
+    const usage =
+      item.call_count > 0
+        ? t("base.channelWebhook.meta.usage", {
+            values: {
+              count: item.call_count,
+              time: item.last_used_at
+                ? format.dateTime(item.last_used_at * 1000)
+                : "",
             },
-        });
-    };
-
-    const handleDelete = (item: IncomingWebhook) => {
-        wkConfirm({
-            title: t("base.channelWebhook.delete.title"),
-            content: t("base.channelWebhook.delete.content", {
-                values: { name: item.name },
-            }),
-            okText: t("base.channelWebhook.delete.confirm"),
-            okType: "danger",
-            onOk: async () => {
-                try {
-                    await IncomingWebhookService.delete(
-                        channel.channelID,
-                        item.webhook_id,
-                        threadShortId
-                    );
-                } catch (e) {
-                    Toast.error(extractErrorMsg(e) || t("base.channelWebhook.error.deleteFailed"));
-                    // 重新抛出：wkConfirm 捕获 reject 后保持弹窗打开供重试（同 handleRegenerate）。
-                    throw e;
-                }
-                Toast.success(t("base.channelWebhook.toast.deleted"));
-                void load();
-            },
-        });
-    };
-
-    const renderMeta = (item: IncomingWebhook) => {
-        const name = creatorNames.get(item.creator_uid) || "";
-        const created = format.date(item.created_at * 1000);
-        const createdLine = name
-            ? t("base.channelWebhook.meta.createdBy", { values: { name, time: created } })
-            : t("base.channelWebhook.meta.created", { values: { time: created } });
-        // 从未使用时不展示用法行（去掉「从未使用」描述）；仅在有过推送时显示统计。
-        const usage = item.call_count > 0
-            ? t("base.channelWebhook.meta.usage", {
-                  values: {
-                      count: item.call_count,
-                      time: item.last_used_at
-                          ? format.dateTime(item.last_used_at * 1000)
-                          : "",
-                  },
-              })
-            : null;
-        return (
-            <>
-                <div className="wk-webhook-card__meta">{createdLine}</div>
-                {usage && <div className="wk-webhook-card__meta">{usage}</div>}
-            </>
-        );
-    };
-
+          })
+        : null;
     return (
-        <div className="wk-webhook">
-            <div className="wk-webhook__header">
-                <p className="wk-webhook__desc">
-                    {threadShortId
-                        ? t("base.channelWebhook.threadScopeHint")
-                        : t("base.channelWebhook.description")}
-                </p>
-                {/* 列表非空时才显示 header 的新建按钮；空态有自己的醒目 CTA，
-                    避免出现两个「新建」。加载中也不显示。 */}
-                {!loading && items.length > 0 && (
-                    <WKButton
-                        variant="primary"
-                        size="sm"
-                        icon={<IconPlus />}
-                        onClick={() => setEditTarget({ mode: "create" })}
-                    >
-                        {t("base.channelWebhook.add")}
-                    </WKButton>
-                )}
-            </div>
-
-            {loading ? (
-                <div className="wk-webhook__state">
-                    <Spin size="large" />
-                </div>
-            ) : error ? (
-                <div className="wk-webhook__state">
-                    <p className="wk-webhook__state-text">
-                        {t("base.channelWebhook.error.loadFailed")}
-                    </p>
-                    <WKButton variant="secondary" onClick={() => { void load(true); }}>
-                        {t("base.channelWebhook.retry")}
-                    </WKButton>
-                </div>
-            ) : items.length === 0 ? (
-                <div className="wk-webhook__empty">
-                    <div className="wk-webhook__empty-icon">
-                        <IconLink size="extra-large" />
-                    </div>
-                    <p className="wk-webhook__empty-text">{t("base.channelWebhook.empty")}</p>
-                    <WKButton
-                        variant="primary"
-                        icon={<IconPlus />}
-                        onClick={() => setEditTarget({ mode: "create" })}
-                    >
-                        {t("base.channelWebhook.add")}
-                    </WKButton>
-                </div>
-            ) : (
-                <ul className="wk-webhook__list">
-                    {items.map((item) => (
-                        <ChannelWebhookCard
-                            key={item.webhook_id}
-                            item={item}
-                            manageable={canManageIncomingWebhook(item, { isManager, myUid })}
-                            meta={renderMeta(item)}
-                            toggling={togglingId === item.webhook_id}
-                            testingBlocked={!!testingId}
-                            cooling={coolingTestId === item.webhook_id}
-                            labels={{
-                                disabled: t("base.channelWebhook.status.disabled"),
-                                toggle: t("base.channelWebhook.action.toggle"),
-                                edit: t("base.channelWebhook.action.edit"),
-                                regenerate: t("base.channelWebhook.action.regenerate"),
-                                test: t("base.channelWebhook.action.test"),
-                                testDisabledHint: t("base.channelWebhook.action.testDisabledHint"),
-                                delete: t("base.channelWebhook.action.delete"),
-                            }}
-                            onToggle={(enabled) => void handleToggle(item, enabled)}
-                            onEdit={() => setEditTarget({ mode: "edit", webhook: item })}
-                            onRegenerate={() => handleRegenerate(item)}
-                            onTest={() => void handleTest(item)}
-                            onDelete={() => handleDelete(item)}
-                        />
-                    ))}
-                </ul>
-            )}
-
-            {editTarget && (
-                <WebhookEditModal
-                    channel={channel}
-                    isManager={isManager}
-                    threadShortId={threadShortId}
-                    webhook={editTarget.mode === "edit" ? editTarget.webhook : undefined}
-                    onClose={() => setEditTarget(null)}
-                    onSaved={(created) => {
-                        setEditTarget(null);
-                        if (created) {
-                            setUrlResult(created);
-                        }
-                        void load();
-                    }}
-                />
-            )}
-            {urlResult && (
-                <WebhookUrlModal resp={urlResult} onClose={() => setUrlResult(null)} />
-            )}
-        </div>
+      <>
+        <div className="wk-webhook-card__meta">{createdLine}</div>
+        {usage && <div className="wk-webhook-card__meta">{usage}</div>}
+      </>
     );
+  };
+
+  return (
+    <div className="wk-webhook">
+      <div className="wk-webhook__header">
+        <p className="wk-webhook__desc">
+          {threadShortId
+            ? t("base.channelWebhook.threadScopeHint")
+            : t("base.channelWebhook.description")}
+        </p>
+        {/* 列表非空时才显示 header 的新建按钮；空态有自己的醒目 CTA，
+                    避免出现两个「新建」。加载中也不显示。 */}
+        {!loading && items.length > 0 && (
+          <WKButton
+            variant="primary"
+            size="sm"
+            icon={<IconPlus />}
+            onClick={() => setEditTarget({ mode: "create" })}
+          >
+            {t("base.channelWebhook.add")}
+          </WKButton>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="wk-webhook__state">
+          <Spin size="large" />
+        </div>
+      ) : error ? (
+        <div className="wk-webhook__state">
+          <p className="wk-webhook__state-text">
+            {t("base.channelWebhook.error.loadFailed")}
+          </p>
+          <WKButton
+            variant="secondary"
+            onClick={() => {
+              void load(true);
+            }}
+          >
+            {t("base.channelWebhook.retry")}
+          </WKButton>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="wk-webhook__empty">
+          <div className="wk-webhook__empty-icon">
+            <IconLink size="extra-large" />
+          </div>
+          <p className="wk-webhook__empty-text">
+            {t("base.channelWebhook.empty")}
+          </p>
+          <WKButton
+            variant="primary"
+            icon={<IconPlus />}
+            onClick={() => setEditTarget({ mode: "create" })}
+          >
+            {t("base.channelWebhook.add")}
+          </WKButton>
+        </div>
+      ) : (
+        <ul className="wk-webhook__list">
+          {items.map((item: IncomingWebhook) => (
+            <ChannelWebhookCard
+              key={item.webhook_id}
+              item={item}
+              manageable={canManageIncomingWebhook(item, { isManager, myUid })}
+              meta={renderMeta(item)}
+              toggling={togglingId === item.webhook_id}
+              testingBlocked={!!testingId}
+              cooling={coolingTestId === item.webhook_id}
+              labels={{
+                disabled: t("base.channelWebhook.status.disabled"),
+                toggle: t("base.channelWebhook.action.toggle"),
+                edit: t("base.channelWebhook.action.edit"),
+                regenerate: t("base.channelWebhook.action.regenerate"),
+                test: t("base.channelWebhook.action.test"),
+                testDisabledHint: t(
+                  "base.channelWebhook.action.testDisabledHint"
+                ),
+                delete: t("base.channelWebhook.action.delete"),
+              }}
+              onToggle={(enabled) => void handleToggle(item, enabled)}
+              onEdit={() => setEditTarget({ mode: "edit", webhook: item })}
+              onRegenerate={() => handleRegenerate(item)}
+              onTest={() => void handleTest(item)}
+              onDelete={() => handleDelete(item)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {editTarget && (
+        <WebhookEditModal
+          channel={channel}
+          isManager={isManager}
+          threadShortId={threadShortId}
+          webhook={editTarget.mode === "edit" ? editTarget.webhook : undefined}
+          onClose={() => setEditTarget(null)}
+          onSaved={(created) => {
+            setEditTarget(null);
+            if (created) {
+              setUrlResult(created);
+            }
+            void load();
+          }}
+        />
+      )}
+      {urlResult && (
+        <WebhookUrlModal resp={urlResult} onClose={() => setUrlResult(null)} />
+      )}
+    </div>
+  );
 }

--- a/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookActions.test.tsx
+++ b/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookActions.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useChannelWebhookActions,
+  type ChannelWebhookActionsRuntime,
+} from "../useChannelWebhookActions";
+import type { IncomingWebhook } from "../../../Service/IncomingWebhook";
+
+function createWebhook(
+  overrides: Partial<IncomingWebhook> = {}
+): IncomingWebhook {
+  return {
+    webhook_id: "iwh_1",
+    group_no: "g1",
+    name: "CI",
+    avatar: "",
+    creator_uid: "u1",
+    status: 1,
+    last_used_at: 0,
+    call_count: 0,
+    created_at: 0,
+    ...overrides,
+  };
+}
+
+function createRuntime(
+  overrides: Partial<ChannelWebhookActionsRuntime> = {}
+): ChannelWebhookActionsRuntime {
+  return {
+    updateStatus: vi.fn(() => Promise.resolve(createWebhook())),
+    test: vi.fn(() => Promise.resolve()),
+    regenerate: vi.fn(() =>
+      Promise.resolve({
+        ...createWebhook(),
+        token: "token",
+        url: "/v1/incoming-webhooks/iwh_1/token",
+      })
+    ),
+    delete: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let current: ReturnType<typeof useChannelWebhookActions>;
+
+function Probe(props: {
+  runtime: ChannelWebhookActionsRuntime;
+  reload: () => void | Promise<void>;
+  channelId?: string;
+}) {
+  current = useChannelWebhookActions({
+    channel: new Channel(props.channelId || "g1", ChannelTypeGroup),
+    threadShortId: "t1",
+    runtime: props.runtime,
+    reload: props.reload,
+  });
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+function renderProbe(params: {
+  runtime: ChannelWebhookActionsRuntime;
+  reload: () => void | Promise<void>;
+  channelId?: string;
+}) {
+  act(() => {
+    ReactDOM.render(
+      <Probe
+        runtime={params.runtime}
+        reload={params.reload}
+        channelId={params.channelId}
+      />,
+      container
+    );
+  });
+}
+
+describe("useChannelWebhookActions", () => {
+  it("toggles webhook status through runtime and reloads", async () => {
+    const runtime = createRuntime();
+    const reload = vi.fn();
+    renderProbe({ runtime, reload });
+
+    await act(async () => {
+      await current.toggleWebhook(createWebhook(), false);
+    });
+
+    expect(runtime.updateStatus).toHaveBeenCalledWith(
+      "g1",
+      "iwh_1",
+      false,
+      "t1"
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(current.togglingId).toBeNull();
+  });
+
+  it("tests enabled webhooks and enters cooldown", async () => {
+    vi.useFakeTimers();
+    const runtime = createRuntime();
+    const reload = vi.fn();
+    renderProbe({ runtime, reload });
+
+    await act(async () => {
+      await current.testWebhook(createWebhook());
+    });
+
+    expect(runtime.test).toHaveBeenCalledWith("g1", "iwh_1", "t1");
+    expect(current.coolingTestId).toBe("iwh_1");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(current.coolingTestId).toBeNull();
+  });
+
+  it("regenerates and deletes through runtime and reloads", async () => {
+    const runtime = createRuntime();
+    const reload = vi.fn();
+    renderProbe({ runtime, reload });
+
+    await act(async () => {
+      const resp = await current.regenerateWebhook(createWebhook());
+      expect(resp.ok && resp.response.token).toBe("token");
+    });
+    await act(async () => {
+      const result = await current.deleteWebhook(createWebhook());
+      expect(result.ok).toBe(true);
+    });
+
+    expect(runtime.regenerate).toHaveBeenCalledWith("g1", "iwh_1", "t1");
+    expect(runtime.delete).toHaveBeenCalledWith("g1", "iwh_1", "t1");
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps regenerate and delete success when reload rejects", async () => {
+    const runtime = createRuntime();
+    const reload = vi.fn(() => Promise.reject(new Error("reload failed")));
+    renderProbe({ runtime, reload });
+
+    await act(async () => {
+      const result = await current.regenerateWebhook(createWebhook());
+      expect(result.ok && result.response.token).toBe("token");
+    });
+    await act(async () => {
+      const result = await current.deleteWebhook(createWebhook());
+      expect(result.ok).toBe(true);
+    });
+
+    expect(runtime.regenerate).toHaveBeenCalledWith("g1", "iwh_1", "t1");
+    expect(runtime.delete).toHaveBeenCalledWith("g1", "iwh_1", "t1");
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks regenerate and delete results stale after scope changes", async () => {
+    let resolveRegenerate!: (value: any) => void;
+    let resolveDelete!: () => void;
+    const runtime = createRuntime({
+      regenerate: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveRegenerate = resolve;
+          })
+      ),
+      delete: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDelete = resolve;
+          })
+      ),
+    });
+    const reload = vi.fn();
+    renderProbe({ runtime, reload, channelId: "g1" });
+
+    let regeneratePromise!: ReturnType<typeof current.regenerateWebhook>;
+    await act(async () => {
+      regeneratePromise = current.regenerateWebhook(createWebhook());
+      await Promise.resolve();
+    });
+    renderProbe({ runtime, reload, channelId: "g2" });
+    await act(async () => {
+      resolveRegenerate({
+        ...createWebhook(),
+        token: "token",
+        url: "/v1/incoming-webhooks/iwh_1/token",
+      });
+    });
+
+    await expect(regeneratePromise).resolves.toEqual({
+      ok: false,
+      reason: "stale",
+    });
+    expect(reload).not.toHaveBeenCalled();
+
+    renderProbe({ runtime, reload, channelId: "g1" });
+    let deletePromise!: ReturnType<typeof current.deleteWebhook>;
+    await act(async () => {
+      deletePromise = current.deleteWebhook(createWebhook());
+      await Promise.resolve();
+    });
+    renderProbe({ runtime, reload, channelId: "g2" });
+    await act(async () => {
+      resolveDelete();
+    });
+
+    await expect(deletePromise).resolves.toEqual({
+      ok: false,
+      reason: "stale",
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookEditor.test.tsx
+++ b/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookEditor.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useChannelWebhookEditor,
+  type ChannelWebhookEditorRuntime,
+} from "../useChannelWebhookEditor";
+import type {
+  IncomingWebhook,
+  IncomingWebhookCreateResp,
+} from "../../../Service/IncomingWebhook";
+
+function createWebhook(
+  overrides: Partial<IncomingWebhook> = {}
+): IncomingWebhook {
+  return {
+    webhook_id: "iwh_1",
+    group_no: "g1",
+    name: "CI",
+    avatar: "",
+    creator_uid: "u1",
+    status: 1,
+    last_used_at: 0,
+    call_count: 0,
+    created_at: 0,
+    ...overrides,
+  };
+}
+
+function createRuntime(
+  overrides: Partial<ChannelWebhookEditorRuntime> = {}
+): ChannelWebhookEditorRuntime {
+  return {
+    create: vi.fn(() =>
+      Promise.resolve({
+        ...createWebhook({ webhook_id: "iwh_new" }),
+        token: "token",
+        url: "/v1/incoming-webhooks/iwh_new/token",
+      } as IncomingWebhookCreateResp)
+    ),
+    update: vi.fn(() => Promise.resolve(createWebhook())),
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let current: ReturnType<typeof useChannelWebhookEditor>;
+
+function Probe(props: {
+  runtime: ChannelWebhookEditorRuntime;
+  channelId: string;
+}) {
+  current = useChannelWebhookEditor({
+    channel: new Channel(props.channelId, ChannelTypeGroup),
+    isManager: true,
+    runtime: props.runtime,
+  });
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+});
+
+function renderProbe(params: {
+  runtime: ChannelWebhookEditorRuntime;
+  channelId: string;
+}) {
+  act(() => {
+    ReactDOM.render(
+      <Probe runtime={params.runtime} channelId={params.channelId} />,
+      container
+    );
+  });
+}
+
+describe("useChannelWebhookEditor", () => {
+  it("returns stale when a create request resolves after scope changes", async () => {
+    let resolveCreate!: (value: IncomingWebhookCreateResp) => void;
+    const runtime = createRuntime({
+      create: vi.fn(
+        () =>
+          new Promise<IncomingWebhookCreateResp>((resolve) => {
+            resolveCreate = resolve;
+          })
+      ),
+    });
+    renderProbe({ runtime, channelId: "g1" });
+
+    act(() => {
+      current.setName("Deploy");
+    });
+
+    let submitPromise!: ReturnType<typeof current.submit>;
+    await act(async () => {
+      submitPromise = current.submit();
+      await Promise.resolve();
+    });
+
+    renderProbe({ runtime, channelId: "g2" });
+
+    await act(async () => {
+      resolveCreate({
+        ...createWebhook({ webhook_id: "iwh_new", group_no: "g1" }),
+        token: "token",
+        url: "/v1/incoming-webhooks/iwh_new/token",
+      });
+    });
+
+    await expect(submitPromise).resolves.toEqual({
+      ok: true,
+      status: "stale",
+    });
+  });
+});

--- a/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookMembers.test.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/__tests__/useChannelWebhookMembers.test.ts
@@ -1,0 +1,77 @@
+import { Channel, ChannelTypeGroup } from "wukongimjssdk";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../App", () => ({
+  default: {
+    loginInfo: {},
+  },
+}));
+
+vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
+  getCurrentImChannelInfo: vi.fn(),
+  getCurrentImChannelSubscribers: vi.fn(() => []),
+  syncCurrentImChannelSubscribers: vi.fn(() => Promise.resolve()),
+}));
+
+import {
+  buildChannelWebhookMemberOptionsForSelect,
+  readChannelWebhookMemberOptions,
+} from "../useChannelWebhookMembers";
+import type { ChannelWebhookMemberRuntime } from "../types";
+
+function createRuntime(
+  overrides: Partial<ChannelWebhookMemberRuntime> = {}
+): ChannelWebhookMemberRuntime {
+  return {
+    getSubscribers: vi.fn(() => []),
+    syncSubscribers: vi.fn(() => Promise.resolve()),
+    isBotMember: vi.fn(() => false),
+    getSelfUid: vi.fn(() => ""),
+    getSelfDisplayName: vi.fn(() => ""),
+    ...overrides,
+  };
+}
+
+describe("channel webhook members bridge", () => {
+  it("maps subscribers into deduped mention options", () => {
+    const runtime = createRuntime({
+      getSubscribers: vi.fn(() => [
+        { uid: "u1", name: "Alice" },
+        { uid: "u1", name: "Duplicated" },
+        { uid: "bot1", name: "HelperBot", orgData: { robot: 1 } },
+        { uid: "" },
+      ]),
+      isBotMember: vi.fn((uid) => uid === "bot1"),
+    });
+
+    const options = readChannelWebhookMemberOptions({
+      channel: new Channel("g1", ChannelTypeGroup),
+      runtime,
+    });
+
+    expect(options).toEqual([
+      { uid: "u1", name: "Alice", isBot: false },
+      { uid: "bot1", name: "HelperBot", isBot: true },
+    ]);
+  });
+
+  it("adds self and configured fallback uids without duplicating known members", () => {
+    const runtime = createRuntime({
+      getSelfUid: vi.fn(() => "me"),
+      getSelfDisplayName: vi.fn(() => "Me"),
+    });
+
+    const options = buildChannelWebhookMemberOptionsForSelect({
+      memberOptions: [{ uid: "u1", name: "Alice", isBot: false }],
+      mentionUids: ["u1", "left-user", "left-user"],
+      selfFallback: "我",
+      runtime,
+    });
+
+    expect(options).toEqual([
+      { uid: "u1", name: "Alice", isBot: false },
+      { uid: "me", name: "Me", isBot: false },
+      { uid: "left-user", name: "left-user", isBot: false },
+    ]);
+  });
+});

--- a/packages/dmworkbase/src/bridge/channelWebhook/types.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/types.ts
@@ -1,0 +1,27 @@
+import { Channel } from "wukongimjssdk";
+
+export interface ChannelWebhookMemberOption {
+  uid: string;
+  name: string;
+  isBot: boolean;
+}
+
+export type ChannelWebhookGroupSubscriber = {
+  uid?: string;
+  name?: string | null;
+  remark?: string | null;
+  status?: number;
+  orgData?: {
+    robot?: number;
+    real_name?: string | null;
+    realname_verified?: boolean | number | string | null;
+  } | null;
+};
+
+export interface ChannelWebhookMemberRuntime {
+  getSubscribers(channel: Channel): ChannelWebhookGroupSubscriber[];
+  syncSubscribers(channel: Channel): Promise<void>;
+  isBotMember(uid: string, subscriber: ChannelWebhookGroupSubscriber): boolean;
+  getSelfUid(): string;
+  getSelfDisplayName(): string;
+}

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookActions.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookActions.ts
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Channel } from "wukongimjssdk";
+
+import {
+  IncomingWebhook,
+  IncomingWebhookCreateResp,
+  IncomingWebhookService,
+  IncomingWebhookStatus,
+  canTestWebhook,
+} from "../../Service/IncomingWebhook";
+
+const TEST_COOLDOWN_MS = 3000;
+
+export interface ChannelWebhookActionsRuntime {
+  updateStatus(
+    groupNo: string,
+    webhookId: string,
+    enabled: boolean,
+    threadShortId?: string
+  ): Promise<IncomingWebhook>;
+  test(
+    groupNo: string,
+    webhookId: string,
+    threadShortId?: string
+  ): Promise<void>;
+  regenerate(
+    groupNo: string,
+    webhookId: string,
+    threadShortId?: string
+  ): Promise<IncomingWebhookCreateResp>;
+  delete(
+    groupNo: string,
+    webhookId: string,
+    threadShortId?: string
+  ): Promise<void>;
+}
+
+export type ChannelWebhookRegenerateResult =
+  | { ok: true; response: IncomingWebhookCreateResp }
+  | { ok: false; reason: "stale" };
+
+export type ChannelWebhookDeleteResult =
+  | { ok: true }
+  | { ok: false; reason: "stale" };
+
+function defaultActionsRuntime(): ChannelWebhookActionsRuntime {
+  return {
+    updateStatus(groupNo, webhookId, enabled, threadShortId) {
+      return IncomingWebhookService.update(
+        groupNo,
+        webhookId,
+        {
+          status: enabled
+            ? IncomingWebhookStatus.enabled
+            : IncomingWebhookStatus.disabled,
+        },
+        threadShortId
+      );
+    },
+    test(groupNo, webhookId, threadShortId) {
+      return IncomingWebhookService.test(groupNo, webhookId, threadShortId);
+    },
+    regenerate(groupNo, webhookId, threadShortId) {
+      return IncomingWebhookService.regenerate(
+        groupNo,
+        webhookId,
+        threadShortId
+      );
+    },
+    delete(groupNo, webhookId, threadShortId) {
+      return IncomingWebhookService.delete(groupNo, webhookId, threadShortId);
+    },
+  };
+}
+
+function runtimeOrDefault(runtime?: ChannelWebhookActionsRuntime) {
+  return runtime ?? defaultActionsRuntime();
+}
+
+export function useChannelWebhookActions(params: {
+  channel: Channel;
+  threadShortId?: string;
+  reload: () => void | Promise<void>;
+  runtime?: ChannelWebhookActionsRuntime;
+}) {
+  const runtime = useMemo(
+    () => runtimeOrDefault(params.runtime),
+    [params.runtime]
+  );
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [coolingTestId, setCoolingTestId] = useState<string | null>(null);
+  const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  const scopeKey = `${params.channel.channelID}:${
+    params.threadShortId || "group"
+  }`;
+  const scopeKeyRef = useRef(scopeKey);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    scopeKeyRef.current = scopeKey;
+    setTestingId(null);
+    setTogglingId(null);
+    setCoolingTestId(null);
+    if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
+  }, [scopeKey]);
+
+  const isCurrentScope = useCallback(
+    (actionScopeKey: string) =>
+      mountedRef.current && scopeKeyRef.current === actionScopeKey,
+    []
+  );
+
+  const refreshIfCurrentScope = useCallback(
+    (actionScopeKey: string) => {
+      if (!isCurrentScope(actionScopeKey)) return false;
+      try {
+        void Promise.resolve(params.reload()).catch(() => {
+          // Refresh is best-effort; it must not replace a successful mutation.
+        });
+      } catch {
+        // Same rule for synchronous reload implementations.
+      }
+      return true;
+    },
+    [isCurrentScope, params.reload]
+  );
+
+  const toggleWebhook = useCallback(
+    async (item: IncomingWebhook, enabled: boolean) => {
+      if (togglingId) return false;
+      const actionScopeKey = scopeKey;
+      setTogglingId(item.webhook_id);
+      try {
+        await runtime.updateStatus(
+          params.channel.channelID,
+          item.webhook_id,
+          enabled,
+          params.threadShortId
+        );
+        return refreshIfCurrentScope(actionScopeKey);
+      } finally {
+        if (isCurrentScope(actionScopeKey)) {
+          setTogglingId(null);
+        }
+      }
+    },
+    [
+      togglingId,
+      scopeKey,
+      runtime,
+      params.channel.channelID,
+      params.threadShortId,
+      refreshIfCurrentScope,
+      isCurrentScope,
+    ]
+  );
+
+  const testWebhook = useCallback(
+    async (item: IncomingWebhook) => {
+      if (!canTestWebhook(item)) return false;
+      if (togglingId === item.webhook_id) return false;
+      if (testingId || coolingTestId === item.webhook_id) return false;
+
+      const actionScopeKey = scopeKey;
+      setTestingId(item.webhook_id);
+      try {
+        await runtime.test(
+          params.channel.channelID,
+          item.webhook_id,
+          params.threadShortId
+        );
+        return true;
+      } finally {
+        if (isCurrentScope(actionScopeKey)) {
+          setTestingId(null);
+          setCoolingTestId(item.webhook_id);
+          if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
+          cooldownTimerRef.current = setTimeout(() => {
+            if (isCurrentScope(actionScopeKey)) {
+              setCoolingTestId(null);
+            }
+          }, TEST_COOLDOWN_MS);
+        }
+      }
+    },
+    [
+      coolingTestId,
+      isCurrentScope,
+      params.channel.channelID,
+      params.threadShortId,
+      runtime,
+      scopeKey,
+      testingId,
+      togglingId,
+    ]
+  );
+
+  const regenerateWebhook = useCallback(
+    async (item: IncomingWebhook): Promise<ChannelWebhookRegenerateResult> => {
+      const actionScopeKey = scopeKey;
+      const response = await runtime.regenerate(
+        params.channel.channelID,
+        item.webhook_id,
+        params.threadShortId
+      );
+      if (refreshIfCurrentScope(actionScopeKey)) {
+        return { ok: true, response };
+      }
+      return { ok: false, reason: "stale" };
+    },
+    [
+      params.channel.channelID,
+      params.threadShortId,
+      refreshIfCurrentScope,
+      runtime,
+      scopeKey,
+    ]
+  );
+
+  const deleteWebhook = useCallback(
+    async (item: IncomingWebhook): Promise<ChannelWebhookDeleteResult> => {
+      const actionScopeKey = scopeKey;
+      await runtime.delete(
+        params.channel.channelID,
+        item.webhook_id,
+        params.threadShortId
+      );
+      if (refreshIfCurrentScope(actionScopeKey)) {
+        return { ok: true };
+      }
+      return { ok: false, reason: "stale" };
+    },
+    [
+      params.channel.channelID,
+      params.threadShortId,
+      refreshIfCurrentScope,
+      runtime,
+      scopeKey,
+    ]
+  );
+
+  return {
+    testingId,
+    togglingId,
+    coolingTestId,
+    toggleWebhook,
+    testWebhook,
+    regenerateWebhook,
+    deleteWebhook,
+  };
+}

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookEditor.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookEditor.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Channel } from "wukongimjssdk";
+
+import {
+  buildWebhookUpsertReq,
+  IncomingWebhook,
+  IncomingWebhookCreateResp,
+  IncomingWebhookService,
+  isFlagOn,
+  validateMentionUids,
+} from "../../Service/IncomingWebhook";
+
+export type ChannelWebhookEditorSubmitResult =
+  | { ok: true; status: "busy" }
+  | { ok: true; status: "stale" }
+  | { ok: true; status: "noop" }
+  | { ok: true; status: "updated" }
+  | { ok: true; status: "created"; created: IncomingWebhookCreateResp }
+  | { ok: false; reason: "tooMany" | "tooLong" };
+
+export interface ChannelWebhookEditorRuntime {
+  create(
+    groupNo: string,
+    request: Parameters<typeof IncomingWebhookService.create>[1],
+    threadShortId?: string
+  ): Promise<IncomingWebhookCreateResp>;
+  update(
+    groupNo: string,
+    webhookId: string,
+    request: Parameters<typeof IncomingWebhookService.update>[2],
+    threadShortId?: string
+  ): Promise<IncomingWebhook>;
+}
+
+function defaultEditorRuntime(): ChannelWebhookEditorRuntime {
+  return {
+    create(groupNo, request, threadShortId) {
+      return IncomingWebhookService.create(groupNo, request, threadShortId);
+    },
+    update(groupNo, webhookId, request, threadShortId) {
+      return IncomingWebhookService.update(
+        groupNo,
+        webhookId,
+        request,
+        threadShortId
+      );
+    },
+  };
+}
+
+function runtimeOrDefault(runtime?: ChannelWebhookEditorRuntime) {
+  return runtime ?? defaultEditorRuntime();
+}
+
+export function useChannelWebhookEditor(params: {
+  channel: Channel;
+  isManager: boolean;
+  webhook?: IncomingWebhook;
+  threadShortId?: string;
+  runtime?: ChannelWebhookEditorRuntime;
+}) {
+  const runtime = useMemo(
+    () => runtimeOrDefault(params.runtime),
+    [params.runtime]
+  );
+  const isEdit = !!params.webhook;
+  const [name, setName] = useState(params.webhook?.name ?? "");
+  const [avatar, setAvatar] = useState(params.webhook?.avatar ?? "");
+  const [mentionAll, setMentionAll] = useState(
+    isFlagOn(params.webhook?.allow_mention_all)
+  );
+  const [mentionBots, setMentionBots] = useState(
+    isFlagOn(params.webhook?.allow_mention_bots)
+  );
+  const [mentionUids, setMentionUids] = useState<string[]>(
+    params.webhook?.mention_uids ?? []
+  );
+  const [saving, setSaving] = useState(false);
+  const requestSequenceRef = useRef(0);
+  const mountedRef = useRef(true);
+  const scopeKey = `${params.channel.channelID}:${
+    params.threadShortId || "group"
+  }:${params.webhook?.webhook_id || "create"}`;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestSequenceRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    requestSequenceRef.current += 1;
+    setName(params.webhook?.name ?? "");
+    setAvatar(params.webhook?.avatar ?? "");
+    setMentionAll(isFlagOn(params.webhook?.allow_mention_all));
+    setMentionBots(isFlagOn(params.webhook?.allow_mention_bots));
+    setMentionUids(params.webhook?.mention_uids ?? []);
+    setSaving(false);
+  }, [scopeKey, params.webhook]);
+
+  const isCurrentRequest = useCallback(
+    (requestSequence: number) =>
+      mountedRef.current && requestSequence === requestSequenceRef.current,
+    []
+  );
+
+  const toggleMentionUid = useCallback((uid: string) => {
+    setMentionUids((current: string[]) =>
+      current.includes(uid)
+        ? current.filter((item: string) => item !== uid)
+        : [...current, uid]
+    );
+  }, []);
+
+  const submit =
+    useCallback(async (): Promise<ChannelWebhookEditorSubmitResult> => {
+      if (saving) return { ok: true, status: "busy" };
+
+      const mentionCheck = validateMentionUids(mentionUids);
+      if (!mentionCheck.ok) {
+        return { ok: false, reason: mentionCheck.reason };
+      }
+
+      const request = buildWebhookUpsertReq({
+        isEdit,
+        isManager: params.isManager,
+        name,
+        avatar,
+        mentionAll,
+        mentionBots,
+        mentionUids,
+        webhook: params.webhook,
+      });
+      if (request === null) return { ok: true, status: "noop" };
+
+      const requestSequence = ++requestSequenceRef.current;
+      setSaving(true);
+      try {
+        if (isEdit && params.webhook) {
+          await runtime.update(
+            params.channel.channelID,
+            params.webhook.webhook_id,
+            request,
+            params.threadShortId
+          );
+          if (!isCurrentRequest(requestSequence)) {
+            return { ok: true, status: "stale" };
+          }
+          return { ok: true, status: "updated" };
+        }
+        const created = await runtime.create(
+          params.channel.channelID,
+          request,
+          params.threadShortId
+        );
+        if (!isCurrentRequest(requestSequence)) {
+          return { ok: true, status: "stale" };
+        }
+        return { ok: true, status: "created", created };
+      } finally {
+        if (isCurrentRequest(requestSequence)) {
+          setSaving(false);
+        }
+      }
+    }, [
+      saving,
+      mentionUids,
+      isEdit,
+      params.isManager,
+      params.webhook,
+      params.channel.channelID,
+      params.threadShortId,
+      name,
+      avatar,
+      mentionAll,
+      mentionBots,
+      runtime,
+      isCurrentRequest,
+    ]);
+
+  return {
+    isEdit,
+    name,
+    setName,
+    avatar,
+    setAvatar,
+    mentionAll,
+    setMentionAll,
+    mentionBots,
+    setMentionBots,
+    mentionUids,
+    setMentionUids,
+    toggleMentionUid,
+    saving,
+    submit,
+  };
+}

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookList.ts
@@ -1,88 +1,112 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Channel, WKSDK } from "wukongimjssdk";
+import { Channel } from "wukongimjssdk";
 import WKApp from "../../App";
-import { IncomingWebhook, IncomingWebhookService } from "../../Service/IncomingWebhook";
+import {
+  IncomingWebhook,
+  IncomingWebhookService,
+} from "../../Service/IncomingWebhook";
 import { subscriberDisplayName, SubscriberLike } from "../../Utils/displayName";
-import { getImChannelSubscribers } from "../../im-runtime/channelRuntime";
+import { getCurrentImChannelSubscribers } from "../../im-runtime/currentChannelRuntime";
 
 export interface UseChannelWebhookListOptions {
-    channel: Channel;
-    threadShortId?: string;
-    selfFallback: string;
-    onLoadError: (error: unknown) => void;
+  channel: Channel;
+  threadShortId?: string;
+  selfFallback: string;
+  onLoadError: (error: unknown) => void;
 }
 
 /** Runtime bridge for Webhook list data. UI state for edit/confirm overlays stays in the container. */
 export function useChannelWebhookList({
-    channel,
-    threadShortId,
-    selfFallback,
-    onLoadError,
+  channel,
+  threadShortId,
+  selfFallback,
+  onLoadError,
 }: UseChannelWebhookListOptions) {
-    const [items, setItems] = useState<IncomingWebhook[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
-    const requestSequenceRef = useRef(0);
-    const mountedRef = useRef(true);
-    const groupNo = channel.channelID;
-    const scopeKey = `${groupNo}:${threadShortId || "group"}`;
-    const myUid = WKApp.loginInfo.uid || "";
+  const [items, setItems] = useState<IncomingWebhook[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const requestSequenceRef = useRef(0);
+  const mountedRef = useRef(true);
+  const groupNo = channel.channelID;
+  const scopeKey = `${groupNo}:${threadShortId || "group"}`;
+  const myUid = WKApp.loginInfo.uid || "";
 
-    useEffect(() => {
-        mountedRef.current = true;
-        return () => {
-            mountedRef.current = false;
-            requestSequenceRef.current += 1;
-        };
-    }, []);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestSequenceRef.current += 1;
+    };
+  }, []);
 
-    const load = useCallback(async (showLoading = false) => {
-        const requestSequence = ++requestSequenceRef.current;
-        if (showLoading) setLoading(true);
-        setError(false);
-        try {
-            const list = await IncomingWebhookService.list(groupNo, threadShortId);
-            if (!mountedRef.current || requestSequence !== requestSequenceRef.current) return;
-            setItems(list);
-        } catch (loadError) {
-            if (!mountedRef.current || requestSequence !== requestSequenceRef.current) return;
-            setError(true);
-            onLoadError(loadError);
-        } finally {
-            if (mountedRef.current && requestSequence === requestSequenceRef.current) {
-                setLoading(false);
-            }
+  const load = useCallback(
+    async (showLoading = false) => {
+      const requestSequence = ++requestSequenceRef.current;
+      if (showLoading) setLoading(true);
+      setError(false);
+      try {
+        const list = await IncomingWebhookService.list(groupNo, threadShortId);
+        if (
+          !mountedRef.current ||
+          requestSequence !== requestSequenceRef.current
+        )
+          return;
+        setItems(list);
+      } catch (loadError) {
+        if (
+          !mountedRef.current ||
+          requestSequence !== requestSequenceRef.current
+        )
+          return;
+        setError(true);
+        onLoadError(loadError);
+      } finally {
+        if (
+          mountedRef.current &&
+          requestSequence === requestSequenceRef.current
+        ) {
+          setLoading(false);
         }
-    }, [groupNo, onLoadError, threadShortId]);
+      }
+    },
+    [groupNo, onLoadError, threadShortId]
+  );
 
-    useEffect(() => {
-        requestSequenceRef.current += 1;
-        setItems([]);
-        setLoading(true);
-        setError(false);
-        void load();
-    }, [load, scopeKey]);
+  useEffect(() => {
+    requestSequenceRef.current += 1;
+    setItems([]);
+    setLoading(true);
+    setError(false);
+    void load();
+  }, [load, scopeKey]);
 
-    const creatorNames = useMemo(() => {
-        const wanted = new Set(items.map((item) => item.creator_uid));
-        const names = new Map<string, string>();
-        try {
-            const subscribers = getImChannelSubscribers(WKSDK.shared(), channel) as Array<
-                { uid?: string } & SubscriberLike
-            >;
-            for (const subscriber of subscribers) {
-                if (!subscriber?.uid || !wanted.has(subscriber.uid) || names.has(subscriber.uid)) continue;
-                const name = subscriberDisplayName(subscriber);
-                if (name) names.set(subscriber.uid, name);
-            }
-        } catch {
-            // SDK member cache may not be ready; metadata gracefully falls back to creation time.
-        }
-        if (wanted.has(myUid) && !names.has(myUid)) {
-            names.set(myUid, WKApp.loginInfo.selfDisplayName?.() || selfFallback);
-        }
-        return names;
-    }, [channel, items, myUid, selfFallback]);
+  const creatorNames = useMemo(() => {
+    const wanted = new Set(
+      items.map((item: IncomingWebhook) => item.creator_uid)
+    );
+    const names = new Map<string, string>();
+    try {
+      const subscribers = getCurrentImChannelSubscribers(channel) as Array<
+        { uid?: string } & SubscriberLike
+      >;
+      for (const subscriber of subscribers) {
+        if (
+          !subscriber?.uid ||
+          !wanted.has(subscriber.uid) ||
+          names.has(subscriber.uid)
+        )
+          continue;
+        const name = subscriberDisplayName(subscriber);
+        if (name) names.set(subscriber.uid, name);
+      }
+    } catch {
+      // SDK member cache may not be ready; metadata gracefully falls back to creation time.
+    }
+    if (wanted.has(myUid) && !names.has(myUid)) {
+      names.set(myUid, WKApp.loginInfo.selfDisplayName?.() || selfFallback);
+    }
+    return names;
+  }, [channel, items, myUid, selfFallback]);
 
-    return { items, loading, error, myUid, creatorNames, reload: load };
+  return { items, loading, error, myUid, creatorNames, reload: load };
 }

--- a/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookMembers.ts
+++ b/packages/dmworkbase/src/bridge/channelWebhook/useChannelWebhookMembers.ts
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Channel, ChannelTypePerson } from "wukongimjssdk";
+
+import WKApp from "../../App";
+import { isFlagOn, normalizeMentionUids } from "../../Service/IncomingWebhook";
+import { subscriberDisplayName } from "../../Utils/displayName";
+import {
+  getCurrentImChannelInfo,
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+} from "../../im-runtime/currentChannelRuntime";
+import {
+  ChannelWebhookGroupSubscriber,
+  ChannelWebhookMemberOption,
+  ChannelWebhookMemberRuntime,
+} from "./types";
+
+function defaultMemberRuntime(): ChannelWebhookMemberRuntime {
+  return {
+    getSubscribers(channel) {
+      return getCurrentImChannelSubscribers<
+        Channel,
+        ChannelWebhookGroupSubscriber
+      >(channel) as ChannelWebhookGroupSubscriber[];
+    },
+    syncSubscribers(channel) {
+      return syncCurrentImChannelSubscribers<
+        Channel,
+        ChannelWebhookGroupSubscriber
+      >(channel);
+    },
+    isBotMember(uid, subscriber) {
+      if (isFlagOn(subscriber.orgData?.robot)) return true;
+      try {
+        const info = getCurrentImChannelInfo(
+          new Channel(uid, ChannelTypePerson)
+        ) as { orgData?: { robot?: unknown } } | null | undefined;
+        return isFlagOn(info?.orgData?.robot);
+      } catch {
+        return false;
+      }
+    },
+    getSelfUid() {
+      return WKApp.loginInfo?.uid || "";
+    },
+    getSelfDisplayName() {
+      return WKApp.loginInfo?.selfDisplayName?.() || "";
+    },
+  };
+}
+
+function runtimeOrDefault(runtime?: ChannelWebhookMemberRuntime) {
+  return runtime ?? defaultMemberRuntime();
+}
+
+export function readChannelWebhookMemberOptions(params: {
+  channel: Channel;
+  runtime?: ChannelWebhookMemberRuntime;
+}): ChannelWebhookMemberOption[] {
+  const runtime = runtimeOrDefault(params.runtime);
+  let subscribers: ChannelWebhookGroupSubscriber[];
+  try {
+    subscribers = runtime.getSubscribers(params.channel);
+  } catch {
+    return [];
+  }
+
+  const options: ChannelWebhookMemberOption[] = [];
+  const seen = new Set<string>();
+  for (const subscriber of subscribers || []) {
+    const uid = subscriber?.uid;
+    if (!uid || seen.has(uid)) continue;
+    seen.add(uid);
+    options.push({
+      uid,
+      name: subscriberDisplayName(subscriber) || uid,
+      isBot: runtime.isBotMember(uid, subscriber),
+    });
+  }
+  return options;
+}
+
+export function buildChannelWebhookMemberOptionsForSelect(params: {
+  memberOptions: ChannelWebhookMemberOption[];
+  mentionUids: string[];
+  selfFallback: string;
+  runtime?: ChannelWebhookMemberRuntime;
+}): ChannelWebhookMemberOption[] {
+  const runtime = runtimeOrDefault(params.runtime);
+  const known = new Set(params.memberOptions.map((member) => member.uid));
+  const options = [...params.memberOptions];
+  const selfUid = runtime.getSelfUid();
+  if (selfUid && !known.has(selfUid)) {
+    options.push({
+      uid: selfUid,
+      name: runtime.getSelfDisplayName() || params.selfFallback,
+      isBot: false,
+    });
+    known.add(selfUid);
+  }
+
+  const extras = normalizeMentionUids(params.mentionUids)
+    .filter((uid) => !known.has(uid))
+    .map((uid) => ({ uid, name: uid, isBot: false }));
+  return [...options, ...extras];
+}
+
+export function useChannelWebhookMembers(params: {
+  channel: Channel;
+  mentionUids: string[];
+  selfFallback: string;
+  runtime?: ChannelWebhookMemberRuntime;
+}) {
+  const runtime = useMemo(
+    () => runtimeOrDefault(params.runtime),
+    [params.runtime]
+  );
+  const [memberOptions, setMemberOptions] = useState<
+    ChannelWebhookMemberOption[]
+  >(() =>
+    readChannelWebhookMemberOptions({
+      channel: params.channel,
+      runtime,
+    })
+  );
+  const scopeKey = params.channel.getChannelKey?.() || params.channel.channelID;
+  const requestSequenceRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestSequenceRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    const requestSequence = ++requestSequenceRef.current;
+    setMemberOptions(
+      readChannelWebhookMemberOptions({
+        channel: params.channel,
+        runtime,
+      })
+    );
+    runtime
+      .syncSubscribers(params.channel)
+      .then(() => {
+        if (
+          !mountedRef.current ||
+          requestSequence !== requestSequenceRef.current
+        ) {
+          return;
+        }
+        setMemberOptions(
+          readChannelWebhookMemberOptions({
+            channel: params.channel,
+            runtime,
+          })
+        );
+      })
+      .catch(() => {
+        // Keep cached member options. The server still validates membership.
+      });
+  }, [params.channel, runtime, scopeKey]);
+
+  const memberOptionsForSelect = useMemo(
+    () =>
+      buildChannelWebhookMemberOptionsForSelect({
+        memberOptions,
+        mentionUids: params.mentionUids,
+        selfFallback: params.selfFallback,
+        runtime,
+      }),
+    [memberOptions, params.mentionUids, params.selfFallback, runtime]
+  );
+
+  const aiOptionCount = useMemo(
+    () =>
+      memberOptionsForSelect.filter(
+        (member: ChannelWebhookMemberOption) => member.isBot
+      ).length,
+    [memberOptionsForSelect]
+  );
+
+  const optionByUid = useMemo(
+    () =>
+      new Map(
+        memberOptionsForSelect.map((member: ChannelWebhookMemberOption) => [
+          member.uid,
+          member,
+        ])
+      ),
+    [memberOptionsForSelect]
+  );
+
+  return {
+    memberOptionsForSelect,
+    aiOptionCount,
+    optionByUid,
+  };
+}


### PR DESCRIPTION
## Summary

Refactor ChannelWebhook data and action handling so the panel and edit modal no longer directly own runtime subscriber access or webhook management service calls.

## Related Issue

Related to #985

## Changes

- Move ChannelWebhook member candidate loading, subscriber sync, self fallback, and stale configured uid handling into `bridge/channelWebhook`
- Move create/update form state and webhook management actions into bridge hooks
- Keep UI-level confirm dialogs and Toast handling in `Components/ChannelWebhook`
- Add stale scope guards so old save/regenerate/delete requests do not update the UI after group/thread scope changes
- Add bridge tests for member option mapping, action execution, editor submit behavior, and stale request handling

## Architecture / Module Boundary

- Affected module(s): `dmworkbase` ChannelWebhook
- New or changed user-visible entry point: no
- Shared layer touched: `Components`, `bridge`, existing `Service` usage
- If shared code changed, impact scope: limited to ChannelWebhook panel/edit modal and its bridge hooks
- Duplicate entry point checked: yes; this keeps the existing ChannelWebhook entry only

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Commands run:

```bash
./node_modules/.bin/vitest run packages/dmworkbase/src/Components/ChannelWebhook/__tests__/WebhookEditModal.test.tsx packages/dmworkbase/src/Service/__tests__/IncomingWebhook.test.ts packages/dmworkbase/src/Service/__tests__/IncomingWebhookService.test.ts packages/dmworkbase/src/bridge/channelWebhook

git diff --check origin/main...HEAD
```

Notes:

- `pnpm exec` is currently blocked locally by the packageManager/lockfile validation, so the tests were run through the checked-in local Vitest binary.
- This change does not add or change user-visible copy, so `pnpm i18n:check` was not required.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
