### PR TITLE
fix(onboarding): reveal app page inside skip circle transition (#996)

### DIFF
--- a/apps/web/src/Components/Onboarding/index.css
+++ b/apps/web/src/Components/Onboarding/index.css
@@ -31,10 +31,9 @@
     animation: wkIntroToPanelOut 620ms var(--wk-ease) forwards;
 }
 
-.wk-onboarding-skip-transition-target {
-    padding: 0;
-    background: var(--wk-bg-surface);
-    backdrop-filter: none;
+.wk-onboarding-overlay-intro.is-skip-transition-target {
+    visibility: hidden;
+    pointer-events: none;
     transition: none;
 }
 

--- a/apps/web/src/Components/Onboarding/index.test.tsx
+++ b/apps/web/src/Components/Onboarding/index.test.tsx
@@ -92,7 +92,7 @@ describe("Onboarding", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps the intro mounted behind the skip target until the transition finishes", () => {
+  it("hides but keeps the intro mounted during the skip transition until it finishes", () => {
     const onDismiss = vi.fn();
 
     render(<Onboarding forceVisible onDismiss={onDismiss} />);
@@ -106,17 +106,12 @@ describe("Onboarding", () => {
     expect(onDismiss).not.toHaveBeenCalled();
     expect(introDialog).toBeInTheDocument();
     expect(introDialog).toHaveAttribute("aria-hidden", "true");
-    expect(
-      document.querySelector(".wk-onboarding-skip-transition-target")
-    ).toBeInTheDocument();
+    expect(introDialog).toHaveClass("is-skip-transition-target");
 
     act(() => viewTransitionState.onFinished?.());
 
     expect(onDismiss).toHaveBeenCalledOnce();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(
-      document.querySelector(".wk-onboarding-skip-transition-target")
-    ).not.toBeInTheDocument();
   });
 
   it("keeps the timed intro skip fallback when view transitions are unavailable", () => {

--- a/apps/web/src/Components/Onboarding/index.tsx
+++ b/apps/web/src/Components/Onboarding/index.tsx
@@ -415,31 +415,23 @@ export const Onboarding: React.FC<OnboardingProps> = ({
 
   if (showIntro) {
     return (
-      <>
-        <div
-          ref={dialogRef}
-          className={`wk-onboarding-overlay wk-onboarding-overlay-intro${
-            introLeaving ? " is-intro-leaving" : ""
-          }`}
-          role="dialog"
-          aria-modal="true"
-          aria-hidden={isIntroSkipTransitionTarget ? true : undefined}
-          aria-label={t("app.onboarding.dialog.introAria")}
-          tabIndex={-1}
-          onKeyDown={handleDialogKeyDown}
-        >
-          <OnboardingIntro
-            onContinue={handleIntroContinue}
-            onSkip={handleIntroSkip}
-          />
-        </div>
-        {isIntroSkipTransitionTarget ? (
-          <div
-            className="wk-onboarding-overlay wk-onboarding-skip-transition-target"
-            aria-hidden="true"
-          />
-        ) : null}
-      </>
+      <div
+        ref={dialogRef}
+        className={`wk-onboarding-overlay wk-onboarding-overlay-intro${
+          introLeaving ? " is-intro-leaving" : ""
+        }${isIntroSkipTransitionTarget ? " is-skip-transition-target" : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-hidden={isIntroSkipTransitionTarget ? true : undefined}
+        aria-label={t("app.onboarding.dialog.introAria")}
+        tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
+      >
+        <OnboardingIntro
+          onContinue={handleIntroContinue}
+          onSkip={handleIntroSkip}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
Fixes #996.

## Summary

- Clicking `Skip` triggered the circular View Transition, but the captured new snapshot was a fullscreen opaque `.wk-onboarding-skip-transition-target` overlay (`background: var(--wk-bg-surface)`) that `handleIntroSkip` mounted inside `onTransition`. The circle therefore expanded revealing plain white, and the standard app page only appeared all at once at animation-end when `closeIntro()` unmounted Onboarding.
- Drop the separate white target overlay. Reuse the same `isIntroSkipTransitionTarget` state to add an `is-skip-transition-target` modifier class on the existing Intro overlay itself, which applies `visibility: hidden` + `pointer-events: none`. The Intro DOM stays mounted (preserves #924's WebGL retention until `transition.finished`) but is not painted for the new-snapshot capture, so the app page underneath becomes the new snapshot and is progressively revealed as the circle expands.
- #919's opaque old-snapshot rule is untouched, so the black Intro remains fullscreen outside the circle. The non-view-transition fallback path (`setIntroLeaving(true)` + 620ms timer) is not affected because it never sets `isIntroSkipTransitionTarget`.

## Test plan

- [ ] Fresh Edge InPrivate on the production URL: click `Skip` from Intro Page 1 and record the 1240ms transition. Circle expands from center; standard app page is progressively revealed inside the circle, no plain-white frame at ~200ms / ~620ms.
- [ ] Confirm outside-the-circle still shows the unchanged black Intro snapshot for the full duration (no horizontal white band, no black corners) — regression check on #919 / #924 / #896.
- [ ] Chromium build without View Transition support (or the codepath where `runOnboardingViewTransition` returns `false`): `Skip` still closes Onboarding via the 620ms fallback timer, no visual regression.
- [ ] `Continue` flow into Page 2 unchanged (transition still runs, Panel still receives focus).
- [ ] `prefers-reduced-motion: reduce`: `Skip` still closes Onboarding without regressions in the accessibility path.
- [ ] `pnpm test` inside `apps/web` — the updated `hides but keeps the intro mounted during the skip transition until it finishes` test passes.