### PR TITLE
refactor: route runtime tails through IM facades

### DIFF
--- a/packages/dmworkappbot/src/__tests__/appBotConversation.test.tsx
+++ b/packages/dmworkappbot/src/__tests__/appBotConversation.test.tsx
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from "vitest"
 vi.mock("@octo/base", () => ({
   Conversation: ({ channel }: { channel: { channelID: string } }) =>
     React.createElement("div", { "data-channel": channel.channelID }),
+  createCurrentEmptyImConversation: vi.fn(),
+  findCurrentImConversation: vi.fn(),
+  setCurrentImChannelInfoCache: vi.fn(),
   WKApp: {
     routeRight: {
       popToRoot: vi.fn(),

--- a/packages/dmworkappbot/src/features/appBotConversation.tsx
+++ b/packages/dmworkappbot/src/features/appBotConversation.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useRef, useState } from "react"
-import { Channel, ChannelInfo, ChannelTypePerson, WKSDK } from "wukongimjssdk"
-import { Conversation, WKApp } from "@octo/base"
+import { Channel, ChannelInfo, ChannelTypePerson } from "wukongimjssdk"
+import {
+  Conversation,
+  WKApp,
+  createCurrentEmptyImConversation,
+  findCurrentImConversation,
+  setCurrentImChannelInfoCache,
+} from "@octo/base"
 import AppBotService from "../Service/AppBotService"
 import type { AppBotViewItem } from "../bridge/types"
 import AppBotAvatar from "./AppBotAvatar"
@@ -47,12 +53,9 @@ function renderAppBotConversation(bot: AppBotViewItem, channel: Channel) {
 function defaultOpenConversationDeps(): OpenAppBotConversationDeps {
   return {
     applyBot: AppBotService.applyBot,
-    setChannelInfo: (info) => WKSDK.shared().channelManager.setChannleInfoForCache(info),
-    findConversation: (channel) => WKSDK.shared().conversationManager.findConversation(channel),
-    createEmptyConversation: (channel) => {
-      const convMgr = WKSDK.shared().conversationManager
-      return convMgr.createEmptyConversation?.(channel)
-    },
+    setChannelInfo: (info) => setCurrentImChannelInfoCache(info),
+    findConversation: (channel) => findCurrentImConversation(channel),
+    createEmptyConversation: (channel) => createCurrentEmptyImConversation(channel),
     replaceToRoot: (element) => WKApp.routeRight.replaceToRoot(element),
   }
 }

--- a/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
@@ -8,11 +8,14 @@
  * 不传 → 行为与之前完全一致。
  */
 import React from "react"
-import WKSDK, { Channel, ChannelTypePerson } from "wukongimjssdk"
+import { Channel, ChannelTypePerson } from "wukongimjssdk"
 import { ForwardModal } from "../ForwardModal/ForwardModal"
 import { useForwardModal } from "../ForwardModal/useForwardModal"
 import type { ForwardFinished, ForwardGrantConfig, ForwardGrantRole } from "../ForwardModal/grant"
-import { getImChannelSubscribers, syncImChannelSubscribers } from "../../im-runtime/channelRuntime"
+import {
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+} from "../../im-runtime/currentChannelRuntime"
 
 export interface ConversationSelectGrant {
   canGrant: boolean
@@ -80,12 +83,12 @@ export default function ConversationSelect({
       }
       for (const ch of groups) {
         try {
-          await syncImChannelSubscribers(WKSDK.shared(), ch)
+          await syncCurrentImChannelSubscribers(ch)
         } catch {
           // best-effort：拉取失败时退回已缓存的成员快照。
         }
         if (cancelled) return
-        const subs = getImChannelSubscribers(WKSDK.shared(), ch) as { uid?: string }[]
+        const subs = getCurrentImChannelSubscribers(ch) as { uid?: string }[]
         for (const s of subs) {
           if (s?.uid) uids.add(s.uid)
         }

--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardModal.test.tsx
@@ -85,21 +85,29 @@ vi.mock("wukongimjssdk", () => {
             this.channelType = channelType
         }
     }
+    const sdk = {
+        conversationManager: {
+            get conversations() {
+                return hoisted.conversations
+            },
+        },
+        channelManager: {
+            getChannelInfo: hoisted.getChannelInfo,
+            addListener: (fn: any) => {
+                hoisted.addListener(fn)
+                hoisted.channelListeners.push(fn)
+            },
+            removeListener: hoisted.removeListener,
+            fetchChannelInfo: hoisted.fetchChannelInfo,
+        },
+    }
     return {
         __esModule: true,
+        default: {
+            shared: () => sdk,
+        },
         WKSDK: {
-            shared: () => ({
-                conversationManager: { conversations: hoisted.conversations },
-                channelManager: {
-                    getChannelInfo: hoisted.getChannelInfo,
-                    addListener: (fn: any) => {
-                        hoisted.addListener(fn)
-                        hoisted.channelListeners.push(fn)
-                    },
-                    removeListener: hoisted.removeListener,
-                    fetchChannelInfo: hoisted.fetchChannelInfo,
-                },
-            }),
+            shared: () => sdk,
         },
         Channel,
         ChannelInfo: class {},

--- a/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts
@@ -1,9 +1,9 @@
-import { WKSDK, Channel, ChannelInfo, ChannelTypeGroup } from "wukongimjssdk"
+import { Channel, ChannelInfo, ChannelTypeGroup } from "wukongimjssdk"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import { parseThreadChannelId } from "../../Service/Thread"
 import { chatTypeToChannelType } from "./chatTypeToChannelType"
 import type { ForwardItem } from "./ForwardModal"
-import { getImChannelInfo } from "../../im-runtime/channelRuntime"
+import { getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime"
 
 /** searchChatCandidates 后端返回的单条候选（只取本模块用到的字段）。 */
 export interface SearchChatCandidate {
@@ -29,7 +29,7 @@ export interface SearchChatCandidate {
 export function candidateToForwardItem(
   candidate: SearchChatCandidate,
   getCachedChannelInfo: (channel: Channel) => ChannelInfo | undefined = (ch) =>
-    getImChannelInfo(WKSDK.shared(), ch),
+    getCurrentImChannelInfo<Channel, ChannelInfo>(ch),
 ): ForwardItem {
   const chType = chatTypeToChannelType(candidate.chat_type)
   const ch = new Channel(candidate.chat_id, chType)

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react"
-import { WKSDK, Channel, ChannelInfo, ChannelInfoListener, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+import { Channel, ChannelInfo, ChannelInfoListener, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
 import { ConversationWrap } from "../../Service/Model"
 import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import { shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace } from "../../Service/SpaceService"
@@ -17,7 +17,12 @@ import {
   type ChatKind,
 } from "../ChatSelector/tabFilter"
 import type { ForwardFinished, ForwardGrantRole } from "./grant"
-import { addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRuntime"
+import {
+  addCurrentImChannelInfoListener,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+} from "../../im-runtime/currentChannelRuntime"
+import { getCurrentImConversationsDirectly } from "../../im-runtime/currentConversationRuntime"
 
 // 复合 key：${channelType}::${channelID}，防跨类型 id 碰撞。channelType 取值
 // (个人=1 / 群=2 / 子区=5) 恰与 SidebarTargetType(DM/CHANNEL/THREAD) 一致，
@@ -68,9 +73,9 @@ function conversationWrapToForwardItem(wrap: ConversationWrap, parentChannelID?:
   const channelInfo = wrap.channelInfo
   const isThread = wrap.channel.channelType === ChannelTypeCommunityTopic
   // hasThreads: 判断该群聊下是否有子区（子区会出现在 conversations 里，其 orgData.parentGroupNo 指向父群）
-  const hasThreads = !isThread && WKSDK.shared().conversationManager.conversations?.some(
+  const hasThreads = !isThread && getCurrentImConversationsDirectly<ConversationWrap["conversation"]>().some(
     (c) => c.channel.channelType === ChannelTypeCommunityTopic
-      && (getImChannelInfo(WKSDK.shared(), c.channel)?.orgData?.parentGroupNo === wrap.channel.channelID)
+      && (getCurrentImChannelInfo(c.channel)?.orgData?.parentGroupNo === wrap.channel.channelID)
   )
   return {
     channelID: wrap.channel.channelID,
@@ -212,9 +217,9 @@ export function useForwardModal(
     if (fetchedRef.current.has(item.channelID)) return
     const ch = channelMapRef.current.get(item.channelID)
       ?? new Channel(item.channelID, item.channelType)
-    if (getImChannelInfo(WKSDK.shared(), ch)) return
+    if (getCurrentImChannelInfo(ch)) return
     fetchedRef.current.add(item.channelID)
-    void fetchImChannelInfo(WKSDK.shared(), ch)
+    void fetchCurrentImChannelInfo(ch)
   }, [])
 
   const rebuildConvItems = useCallback(() => {
@@ -342,7 +347,7 @@ export function useForwardModal(
         // 最近会话：仅构造 wrap，不再对每个 conv 主动 fetchChannelInfo。
         // channelInfo 由 ForwardModal 中每个 ItemRow 的 VisibilityTrigger 在
         // 进入视口时按需拉取（去重 + debounce 合批 forceUpdate）。
-        const conversations = WKSDK.shared().conversationManager.conversations ?? []
+        const conversations = getCurrentImConversationsDirectly<ConversationWrap["conversation"]>()
         const wraps: ConversationWrap[] = []
         for (const conv of conversations) {
           if (shouldSkipChannelForSpace(conv.channel)) continue
@@ -388,7 +393,7 @@ export function useForwardModal(
     const channelListener: ChannelInfoListener = (_channelInfo: ChannelInfo) => {
       rebuildDebounced()
     }
-    const unsubscribeChannelListener = addImChannelInfoListener(WKSDK.shared(), channelListener)
+    const unsubscribeChannelListener = addCurrentImChannelInfoListener(channelListener)
 
     // 切 Space 后 conversationManager.conversations 会被先清空再回填,
     // 如果 modal 在回填前打开,初次 load() 会读到空 cache（缺最近会话/子区）。

--- a/packages/dmworkbase/src/im-runtime/chatRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/chatRuntime.ts
@@ -2,6 +2,7 @@ export type ImChatListener<TMessage = unknown> = (message: TMessage) => void;
 
 export interface ImChatManagerRuntime<TMessage = unknown> {
   addCMDListener: (listener: ImChatListener<TMessage>) => void;
+  removeCMDListener: (listener: ImChatListener<TMessage>) => void;
   addMessageListener: (listener: ImChatListener<TMessage>) => void;
 }
 
@@ -21,4 +22,11 @@ export function addImMessageListener<TMessage>(
   listener: ImChatListener<TMessage>
 ) {
   sdk.chatManager.addMessageListener(listener);
+}
+
+export function removeImCommandListener<TMessage>(
+  sdk: ImChatRuntimeSdk<TMessage>,
+  listener: ImChatListener<TMessage>
+) {
+  sdk.chatManager.removeCMDListener(listener);
 }

--- a/packages/dmworkbase/src/im-runtime/conversationRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/conversationRuntime.ts
@@ -4,6 +4,7 @@ export interface ImConversationManagerRuntime<
   TChannel extends ImChannelLike = ImChannelLike,
   TConversation = any
 > {
+  createEmptyConversation?: (channel: TChannel) => TConversation | undefined;
   findConversation: (channel: TChannel) => TConversation | undefined;
   notifyConversationListeners: (
     conversation: TConversation,
@@ -28,6 +29,13 @@ export function findImConversation<
   channel: TChannel
 ) {
   return sdk.conversationManager.findConversation(channel);
+}
+
+export function createEmptyImConversation<
+  TChannel extends ImChannelLike,
+  TConversation = any
+>(sdk: ImConversationRuntimeSdk<TChannel, TConversation>, channel: TChannel) {
+  return sdk.conversationManager.createEmptyConversation?.(channel);
 }
 
 export function removeImConversation<TChannel extends ImChannelLike>(

--- a/packages/dmworkbase/src/im-runtime/currentChatRuntime.test.ts
+++ b/packages/dmworkbase/src/im-runtime/currentChatRuntime.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addCurrentImCommandListener,
   addCurrentImMessageListener,
+  removeCurrentImCommandListener,
 } from "./currentChatRuntime";
 
 const hoisted = vi.hoisted(() => {
   const sdk = {
     chatManager: {
       addCMDListener: vi.fn(),
+      removeCMDListener: vi.fn(),
       addMessageListener: vi.fn(),
     },
   };
@@ -28,6 +30,7 @@ describe("currentChatRuntime", () => {
   beforeEach(() => {
     hoisted.shared.mockClear();
     hoisted.sdk.chatManager.addCMDListener.mockReset();
+    hoisted.sdk.chatManager.removeCMDListener.mockReset();
     hoisted.sdk.chatManager.addMessageListener.mockReset();
   });
 
@@ -49,6 +52,17 @@ describe("currentChatRuntime", () => {
 
     expect(hoisted.shared).toHaveBeenCalledTimes(1);
     expect(hoisted.sdk.chatManager.addMessageListener).toHaveBeenCalledWith(
+      listener
+    );
+  });
+
+  it("removes command listeners on the current SDK runtime", () => {
+    const listener = vi.fn();
+
+    removeCurrentImCommandListener(listener);
+
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(hoisted.sdk.chatManager.removeCMDListener).toHaveBeenCalledWith(
       listener
     );
   });

--- a/packages/dmworkbase/src/im-runtime/currentChatRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/currentChatRuntime.ts
@@ -3,6 +3,7 @@ import WKSDK from "wukongimjssdk";
 import {
   addImCommandListener,
   addImMessageListener,
+  removeImCommandListener,
   type ImChatListener,
   type ImChatRuntimeSdk,
 } from "./chatRuntime";
@@ -25,4 +26,10 @@ export function addCurrentImMessageListener<TMessage>(
   listener: ImChatListener<TMessage>
 ) {
   addImMessageListener(currentImChatRuntime<TMessage>(), listener);
+}
+
+export function removeCurrentImCommandListener<TMessage>(
+  listener: ImChatListener<TMessage>
+) {
+  removeImCommandListener(currentImChatRuntime<TMessage>(), listener);
 }

--- a/packages/dmworkbase/src/im-runtime/currentConversationRuntime.test.ts
+++ b/packages/dmworkbase/src/im-runtime/currentConversationRuntime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  createCurrentEmptyImConversation,
   findCurrentImConversation,
   getCurrentImConversationsDirectly,
   notifyCurrentImConversationListeners,
@@ -12,6 +13,7 @@ const hoisted = vi.hoisted(() => {
   const sdk = {
     conversationManager: {
       conversations: [] as unknown[],
+      createEmptyConversation: vi.fn(),
       findConversation: vi.fn(),
       notifyConversationListeners: vi.fn(),
       removeConversation: vi.fn(),
@@ -34,6 +36,7 @@ describe("currentConversationRuntime", () => {
   beforeEach(() => {
     hoisted.shared.mockClear();
     hoisted.sdk.conversationManager.conversations = [];
+    hoisted.sdk.conversationManager.createEmptyConversation.mockReset();
     hoisted.sdk.conversationManager.findConversation.mockReset();
     hoisted.sdk.conversationManager.notifyConversationListeners.mockReset();
     hoisted.sdk.conversationManager.removeConversation.mockReset();
@@ -51,6 +54,20 @@ describe("currentConversationRuntime", () => {
     expect(hoisted.shared).toHaveBeenCalledTimes(1);
     expect(
       hoisted.sdk.conversationManager.findConversation
+    ).toHaveBeenCalledWith(channel);
+  });
+
+  it("creates an empty conversation from the current SDK runtime", () => {
+    const channel = { channelID: "g1", channelType: 2 };
+    const conversation = { channel };
+    hoisted.sdk.conversationManager.createEmptyConversation.mockReturnValueOnce(
+      conversation
+    );
+
+    expect(createCurrentEmptyImConversation(channel)).toBe(conversation);
+    expect(hoisted.shared).toHaveBeenCalledTimes(1);
+    expect(
+      hoisted.sdk.conversationManager.createEmptyConversation
     ).toHaveBeenCalledWith(channel);
   });
 

--- a/packages/dmworkbase/src/im-runtime/currentConversationRuntime.ts
+++ b/packages/dmworkbase/src/im-runtime/currentConversationRuntime.ts
@@ -2,6 +2,7 @@ import WKSDK from "wukongimjssdk";
 
 import type { ImChannelLike } from "./channelRuntime";
 import {
+  createEmptyImConversation,
   findImConversation,
   notifyImConversationListeners,
   removeImConversation,
@@ -28,6 +29,16 @@ export function findCurrentImConversation<
   TConversation = any
 >(channel: TChannel) {
   return findImConversation<TChannel, TConversation>(
+    currentImConversationRuntime<TChannel, TConversation>(),
+    channel
+  );
+}
+
+export function createCurrentEmptyImConversation<
+  TChannel extends ImChannelLike,
+  TConversation = any
+>(channel: TChannel) {
+  return createEmptyImConversation<TChannel, TConversation>(
     currentImConversationRuntime<TChannel, TConversation>(),
     channel
   );

--- a/packages/dmworkcontacts/src/Contacts/__tests__/onlineBadgeSync.test.tsx
+++ b/packages/dmworkcontacts/src/Contacts/__tests__/onlineBadgeSync.test.tsx
@@ -128,13 +128,13 @@ beforeAll(async () => {
     t: (k: string) => k,
     toSimplized: (s: string) => s,
     getPinyin: () => "#",
-    addImChannelInfoListener: (_sdk: any, listener: any) => {
+    addCurrentImChannelInfoListener: (listener: any) => {
       channelManager.addListener(listener);
       return () => channelManager.removeListener(listener);
     },
-    fetchImChannelInfo: (_sdk: any, channel: any) =>
+    fetchCurrentImChannelInfo: (channel: any) =>
       channelManager.fetchChannelInfo(channel),
-    getImChannelInfo: (_sdk: any, channel: any) =>
+    getCurrentImChannelInfo: (channel: any) =>
       channelManager.getChannelInfo(channel),
   }));
 

--- a/packages/dmworkcontacts/src/Contacts/__tests__/visibilityHeal.test.tsx
+++ b/packages/dmworkcontacts/src/Contacts/__tests__/visibilityHeal.test.tsx
@@ -108,13 +108,13 @@ beforeAll(async () => {
     t: (k: string) => k,
     toSimplized: (s: string) => s,
     getPinyin: () => "#",
-    addImChannelInfoListener: (_sdk: any, listener: any) => {
+    addCurrentImChannelInfoListener: (listener: any) => {
       channelManager.addListener(listener);
       return () => channelManager.removeListener(listener);
     },
-    fetchImChannelInfo: (_sdk: any, channel: any) =>
+    fetchCurrentImChannelInfo: (channel: any) =>
       channelManager.fetchChannelInfo(channel),
-    getImChannelInfo: (_sdk: any, channel: any) =>
+    getCurrentImChannelInfo: (channel: any) =>
       channelManager.getChannelInfo(channel),
   }));
 

--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Component } from "react";
-import { Contacts, ContextMenus, ContextMenusContext, WKApp, WKBase, WKBaseContext, ErrorBoundary, WKModal, I18nContext, t, ForwardService, interpretForwardResult, addImChannelInfoListener, fetchImChannelInfo, getImChannelInfo } from "@octo/base"
+import { Contacts, ContextMenus, ContextMenusContext, WKApp, WKBase, WKBaseContext, ErrorBoundary, WKModal, I18nContext, t, ForwardService, interpretForwardResult, addCurrentImChannelInfoListener, fetchCurrentImChannelInfo, getCurrentImChannelInfo } from "@octo/base"
 import "./index.css"
 import { toSimplized } from "@octo/base";
 import { getPinyin } from "@octo/base";
@@ -8,7 +8,7 @@ import classnames from "classnames";
 import { Toast, Tooltip } from "@douyinfe/semi-ui";
 import { ChevronRight, Users, Bot, UsersRound } from "lucide-react";
 
-import { Channel, ChannelTypePerson, ChannelTypeGroup, WKSDK, ChannelInfoListener, ChannelInfo } from "wukongimjssdk";
+import { Channel, ChannelTypePerson, ChannelTypeGroup, ChannelInfoListener, ChannelInfo } from "wukongimjssdk";
 import { ContactsListManager } from "../Service/ContactsListManager";
 import { Card } from "@octo/base/src/Messages/Card";
 import WKAvatar from "@octo/base/src/Components/WKAvatar";
@@ -276,7 +276,7 @@ export default class ContactsList extends Component<any, ContactsState> {
             }
         }
         WKApp.mittBus.on('space-changed', this.spaceChangedHandler)
-        this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
+        this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this.channelInfoListener)
 
         // 页面重新可见时对已追踪的 AI 在线态做一次自愈重拉：正常情况下在线态靠
         // WKSDK 的 onlineStatus WS 回调实时重渲，但推送若因断连/节流被延迟或丢失，
@@ -333,7 +333,7 @@ export default class ContactsList extends Component<any, ContactsState> {
         if (uids.length === 0) return
         await Promise.all(
             uids.map((uid) =>
-                fetchImChannelInfo(WKSDK.shared(), new Channel(uid, ChannelTypePerson))
+                fetchCurrentImChannelInfo(new Channel(uid, ChannelTypePerson))
                     .catch(() => undefined)
             )
         )
@@ -412,8 +412,8 @@ export default class ContactsList extends Component<any, ContactsState> {
             if (this.prefetchedUids.has(uid)) continue
             this.prefetchedUids.add(uid)
             const ch = new Channel(uid, ChannelTypePerson)
-            if (!getImChannelInfo(WKSDK.shared(), ch)) {
-                void fetchImChannelInfo(WKSDK.shared(), ch)
+            if (!getCurrentImChannelInfo(ch)) {
+                void fetchCurrentImChannelInfo(ch)
             }
         }
     }
@@ -428,10 +428,7 @@ export default class ContactsList extends Component<any, ContactsState> {
 
     // 复用会话列表/群成员列表同一份在线态判定与文案，渲染在线绿点。
     private renderOnlineBadge(uid: string): React.ReactNode {
-        const channelInfo = getImChannelInfo(
-            WKSDK.shared(),
-            new Channel(normalizeOnlineUid(uid), ChannelTypePerson)
-        )
+        const channelInfo = getCurrentImChannelInfo(new Channel(normalizeOnlineUid(uid), ChannelTypePerson))
         if (!needShowOnlineStatus(channelInfo)) return null
         return <OnlineStatusBadge tip={getOnlineTip(channelInfo!)} />
     }

--- a/packages/dmworkcontacts/src/GroupSave/vm.tsx
+++ b/packages/dmworkcontacts/src/GroupSave/vm.tsx
@@ -1,5 +1,5 @@
-import { WKApp, ProviderListener, addImChannelInfoListener } from "@octo/base";
-import { ChannelInfo,WKSDK } from "wukongimjssdk";
+import { WKApp, ProviderListener, addCurrentImChannelInfoListener } from "@octo/base";
+import { ChannelInfo } from "wukongimjssdk";
 import { ChannelInfoListener } from "wukongimjssdk";
 export class GroupSaveVM extends ProviderListener {
     groups:ChannelInfo[] = []
@@ -21,7 +21,7 @@ export class GroupSaveVM extends ProviderListener {
           }
        }
 
-       this.unsubscribeChannelInfoListener = addImChannelInfoListener(WKSDK.shared(), this.channelInfoListener)
+       this.unsubscribeChannelInfoListener = addCurrentImChannelInfoListener(this.channelInfoListener)
     }
 
     didUnMount(): void {

--- a/packages/dmworkcontacts/src/NewFriend/vm.tsx
+++ b/packages/dmworkcontacts/src/NewFriend/vm.tsx
@@ -1,5 +1,5 @@
-import { WKSDK, Message, CMDContent } from "wukongimjssdk";
-import { FriendApplyState, WKApp, ProviderListener } from "@octo/base";
+import { Message, CMDContent } from "wukongimjssdk";
+import { FriendApplyState, WKApp, ProviderListener, addCurrentImCommandListener, removeCurrentImCommandListener } from "@octo/base";
 import { FriendApply } from "@octo/base";
 
 export class NewFriendVM extends ProviderListener {
@@ -16,12 +16,12 @@ export class NewFriendVM extends ProviderListener {
     }
     this.notifyListener();
     // 监听好友申请
-    WKSDK.shared().chatManager.addCMDListener(this.friendRequestCMDListener);
+    addCurrentImCommandListener(this.friendRequestCMDListener);
   }
 
   didUnMount(): void {
     // 监听好友申请
-    WKSDK.shared().chatManager.removeCMDListener(this.friendRequestCMDListener);
+    removeCurrentImCommandListener(this.friendRequestCMDListener);
   }
 
   friendSure(apply: FriendApply) {


### PR DESCRIPTION
## Summary

- Add current IM runtime facades for command listener removal and conversation cache access.
- Route ForwardModal, ConversationSelect, Contacts, and AppBot conversation through current runtime facades.
- Update targeted tests for the facade-backed runtime access.

## Verification

- `git diff --check`
- `pnpm --filter @octo/base test -- src/im-runtime/currentChatRuntime.test.ts src/im-runtime/currentConversationRuntime.test.ts src/Components/ForwardModal/__tests__/useForwardModal.test.tsx src/Components/ForwardModal/__tests__/forwardMessageText.test.ts`
- `pnpm --filter @octo/contacts test -- src/Contacts/__tests__/onlineBadgeSync.test.tsx src/Contacts/__tests__/visibilityHeal.test.tsx`
- `pnpm exec vitest run packages/dmworkappbot/src/__tests__/appBotConversation.test.tsx`
- `pnpm exec esbuild packages/dmworkbase/src/im-runtime/chatRuntime.ts packages/dmworkbase/src/im-runtime/currentChatRuntime.ts packages/dmworkbase/src/im-runtime/conversationRuntime.ts packages/dmworkbase/src/im-runtime/currentConversationRuntime.ts packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts packages/dmworkbase/src/Components/ForwardModal/candidateToForwardItem.ts packages/dmworkbase/src/Components/ConversationSelect/index.tsx packages/dmworkcontacts/src/Contacts/index.tsx packages/dmworkcontacts/src/NewFriend/vm.tsx packages/dmworkcontacts/src/GroupSave/vm.tsx packages/dmworkappbot/src/features/appBotConversation.tsx --bundle=false --format=esm --platform=browser --outdir=/private/tmp/octo-runtime-tail-esbuild`
- `pnpm --filter @octo/web build`
