### PR TITLE
fix(e2e): fail on proxy leaks

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -68,10 +68,13 @@ jobs:
         # 组合语义: grep AND grep-invert (playwright 官方支持)
         shell: bash
         run: |
+          E2E_LOG="e2e-kit/playwright-report/e2e-nightly.log"
+          mkdir -p "$(dirname "$E2E_LOG")"
+
           set +e
           pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts \
-            --grep "@p[0-9]" --grep-invert "@visual"
-          PW_EXIT=$?
+            --grep "@p[0-9]" --grep-invert "@visual" 2>&1 | tee "$E2E_LOG"
+          PW_EXIT=${PIPESTATUS[0]}
           set -e
 
           JUNIT="e2e-kit/playwright-report/junit.xml"
@@ -80,6 +83,7 @@ jobs:
             exit 1
           fi
           TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
+          PROXY_ERRORS=$(grep -c "http proxy error:" "$E2E_LOG" || true)
           # nightly 也加 tests=0 guard: 防 grep drift 让 nightly 静默"全绿"
           EXPECTED_P0=29
           if [[ "$TOTAL_TESTS" -eq 0 ]]; then
@@ -87,6 +91,10 @@ jobs:
             exit 1
           elif [[ "$TOTAL_TESTS" -lt "$EXPECTED_P0" ]]; then
             echo "❌ nightly tests=$TOTAL_TESTS < EXPECTED_P0=$EXPECTED_P0 (有 case 掉 @p tag), fail"
+            exit 1
+          elif [[ "$PROXY_ERRORS" -gt 0 ]]; then
+            echo "❌ nightly 出现 $PROXY_ERRORS 条 Vite proxy error, 说明 mock 覆盖漏网, fail"
+            grep "http proxy error:" "$E2E_LOG" | sed -E 's/.*http proxy error: //g' | sort | uniq -c
             exit 1
           fi
           echo "✅ nightly ran $TOTAL_TESTS tests (playwright exit=$PW_EXIT)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,9 +71,12 @@ jobs:
         working-directory: apps/web
         shell: bash
         run: |
+          E2E_LOG="e2e-kit/playwright-report/e2e-p0.log"
+          mkdir -p "$(dirname "$E2E_LOG")"
+
           set +e
-          pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts --grep "@p0"
-          PW_EXIT=$?
+          pnpm exec playwright test --config=e2e-kit/playwright.ci.config.ts --grep "@p0" 2>&1 | tee "$E2E_LOG"
+          PW_EXIT=${PIPESTATUS[0]}
           set -e
 
           JUNIT="e2e-kit/playwright-report/junit.xml"
@@ -94,6 +97,7 @@ jobs:
           VISUAL_FAIL=$(echo "$FAILED_NAMES" | grep "@visual" | grep -vc "@p0" || true)
           BUSINESS_FAIL=$((TOTAL_FAIL - VISUAL_FAIL))
           TOTAL_TESTS=$(grep -oE 'tests="[0-9]+"' "$JUNIT" | head -1 | grep -oE '[0-9]+' || echo 0)
+          PROXY_ERRORS=$(grep -c "http proxy error:" "$E2E_LOG" || true)
           echo ""
           echo "═════════════════════════════════════════════════════════════"
           echo "📊 e2e @p0 summary (playwright exit=$PW_EXIT):"
@@ -101,6 +105,7 @@ jobs:
           echo "   total fail:    $TOTAL_FAIL"
           echo "   business fail: $BUSINESS_FAIL"
           echo "   visual fail:   $VISUAL_FAIL"
+          echo "   proxy errors:  $PROXY_ERRORS"
           if [[ "$TOTAL_FAIL" -gt 0 ]]; then
             echo ""
             echo "   fail case names:"
@@ -111,10 +116,11 @@ jobs:
           # 判定顺序 (fail-closed, PW_EXIT 检查在 visual allow 之前避免掩盖 crash):
           #  1. tests=0 → webServer / playwright 挂了根本没跑, block
           #  2. tests < EXPECTED_P0 → 有 case 静默掉了 @p0 tag / grep 漂了, block
-          #  3. 有业务 fail (含 @p0+@visual 交叉 case) → block
-          #  4. PW_EXIT!=0 但 junit 无 business fail → playwright 本身 crash/OOM/timeout, block
-          #  5. 仅视觉 fail (无 @p0 交叉) 且 playwright 干净退出 → allow
-          #  6. 全绿 → success
+          #  3. Vite proxy error → MSW 漏 mock, case 虽过也是假绿, block
+          #  4. 有业务 fail (含 @p0+@visual 交叉 case) → block
+          #  5. PW_EXIT!=0 但 junit 无 business fail → playwright 本身 crash/OOM/timeout, block
+          #  6. 仅视觉 fail (无 @p0 交叉) 且 playwright 干净退出 → allow
+          #  7. 全绿 → success
           EXPECTED_P0=29
           if [[ "$TOTAL_TESTS" -eq 0 ]]; then
             echo "❌ tests=0 (playwright 没跑起 test, 通常是 preview server timeout), block PR"
@@ -122,6 +128,10 @@ jobs:
           elif [[ "$TOTAL_TESTS" -lt "$EXPECTED_P0" ]]; then
             echo "❌ tests=$TOTAL_TESTS < EXPECTED_P0=$EXPECTED_P0 (有 case 掉了 @p0 tag 或 grep 漂了), block PR"
             echo "   若确认减 case, 请同步下调 EXPECTED_P0."
+            exit 1
+          elif [[ "$PROXY_ERRORS" -gt 0 ]]; then
+            echo "❌ e2e 出现 $PROXY_ERRORS 条 Vite proxy error, 说明 mock 覆盖漏网, block PR"
+            grep "http proxy error:" "$E2E_LOG" | sed -E 's/.*http proxy error: //g' | sort | uniq -c
             exit 1
           elif [[ "$BUSINESS_FAIL" -gt 0 ]]; then
             echo "❌ 有 $BUSINESS_FAIL 个业务 case fail → block PR"

--- a/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
+++ b/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
@@ -33,9 +33,14 @@ const MOCK_SPACE = {
 export const chatBaselineHandlers = [
   // === Common / config ===
   // shape: { version, list: [{ key, name, url }] } - 见 packages/dmworkbase/src/Service/EmojiService.ts:30
-  http.get("http://localhost:3000/api/v1/common/emojis", () =>
+  http.get("*/api/v1/common/emojis", () =>
     HttpResponse.json({ version: 0, list: [] })
   ),
+  http.get("*/common/emojis", () =>
+    HttpResponse.json({ version: 0, list: [] })
+  ),
+  http.get("*/api/v1/health", () => HttpResponse.json({ ok: true })),
+  http.get("*/health", () => HttpResponse.json({ ok: true })),
   http.get("*/voice/config", () =>
     HttpResponse.json({ enable: 0, provider: "", config: {} })
   ),
@@ -49,6 +54,13 @@ export const chatBaselineHandlers = [
     HttpResponse.arrayBuffer(new Uint8Array([]).buffer, {
       headers: { "content-type": "image/png" },
     })
+  ),
+  http.get("*/group/avatar_palette", () =>
+    // 空 colors 会走前端 fallback palette, 但请求本身不该漏到 Vite proxy.
+    HttpResponse.json({ size: 0, colors: [] })
+  ),
+  http.get("*/api/v1/group/avatar_palette", () =>
+    HttpResponse.json({ size: 0, colors: [] })
   ),
   http.get("*/user/devices/:deviceId", () =>
     // 400 表示设备未注册, App.tsx 里 syncClientMsgDeviceId 已有静默 fallback.
@@ -71,6 +83,16 @@ export const chatBaselineHandlers = [
   http.post("*/sidebar/sync", () =>
     HttpResponse.json({ conversations: [], groups: [], users: [] })
   ),
+  http.post("*/message/channel/sync", () =>
+    HttpResponse.json({ messages: [] })
+  ),
+  http.post("*/api/v1/message/channel/sync", () =>
+    HttpResponse.json({ messages: [] })
+  ),
+
+  // === OBO / persona ===
+  http.get("*/api/v1/obo/grants", () => HttpResponse.json([])),
+  http.get("*/obo/grants", () => HttpResponse.json([])),
 
   // === Summary ===
   // 空列表, 界面停在"暂无总结"稳定分支; 不返 200 会无限重试打爆 network.

--- a/apps/web/e2e-kit/playwright.ci.config.ts
+++ b/apps/web/e2e-kit/playwright.ci.config.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 
 /**
  * CI-only playwright config (adapted from e2e-kit v0.4). 差异 vs playwright.config.ts:
- *  - webServer.command: pnpm preview:e2e (build 产物, 冷启快)
+ *  - webServer.command: vite preview (build 产物, 冷启快)
  *  - reuseExistingServer: false (CI 每次都新)
  *  - PW_PREVIEW_PORT env: 各 job 用不同 port 隔离
  *  - 硬约束 TARGET=local: CI 只跑 mock 模式, 真后端走另一条 pipeline
@@ -53,7 +53,7 @@ export default defineConfig({
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 
   webServer: {
-    command: "pnpm preview:e2e",
+    command: `node node_modules/vite/bin/vite.js preview --outDir build-e2e --port ${PREVIEW_PORT} --strictPort`,
     cwd: path.resolve(__dirname, ".."),
     url: `http://localhost:${PREVIEW_PORT}`,
     reuseExistingServer: false,
@@ -62,6 +62,9 @@ export default defineConfig({
     timeout: 60_000,
     stdout: "pipe",
     stderr: "pipe",
-    env: { PW_PREVIEW_PORT: PREVIEW_PORT },
+    env: {
+      PW_PREVIEW_PORT: PREVIEW_PORT,
+      VITE_API_URL: "http://127.0.0.1:9",
+    },
   },
 });

--- a/packages/dmworkbase/src/Service/EmojiService.ts
+++ b/packages/dmworkbase/src/Service/EmojiService.ts
@@ -281,6 +281,9 @@ export class DefaultEmojiService implements EmojiService {
     // 启动时拉取 manifest（fire-and-forget）。成功则刷新清单并落地缓存；失败保持兜底，
     // 保证首屏与降级。token 仍是 [xxx]，不变。
     async load(): Promise<void> {
+        if (import.meta.env.VITE_E2E_MOCK === "1") {
+            return
+        }
         try {
             const manifest = (await APIClient.shared.get("common/emojis")) as EmojiManifest
             // 只要 list 是数组就应用(允许服务端下发空列表 = 清空自定义表情);非数组/缺失则保留兜底。


### PR DESCRIPTION
## Summary
- Run Playwright CI preview directly through local Vite binary instead of the pnpm wrapper
- Mock the CI baseline endpoints that leaked to Vite proxy during e2e runs
- Skip emoji manifest network sync in e2e mock builds so startup does not race SW control
- Fail e2e workflows when Vite reports `http proxy error:` so leaked mocks cannot pass green

## Verification
- `pnpm -C apps/web build:e2e`
- `@C1 @p0`: 1 passed, proxy errors=0
- `@p0`: 29 passed, proxy errors=0

Note: #1025 PR ref stayed pinned to old head `828116f2` even after the fork branch moved to `32a06b77`, so this retry PR uses a fresh head branch.