### PR TITLE
fix(html-doc): show pending requests and viewer name

### DIFF
--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -593,12 +593,15 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     setWKApp(undefined as never)
   })
 
-  it('renders exactly one viewer avatar and no Synced/Connecting connection text', async () => {
+  it('renders exactly one viewer avatar using the current viewer name initial', async () => {
+    wk.spaceMembers.push({ uid: 'u_viewer', name: '王留超' })
     serveDoc('<p>body</p>')
-    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const { container } = render(<HtmlDocView docId="d1" space="sp_viewer_name" />)
     await waitForFrame(container)
     const presence = screen.getByTestId('html-doc-presence')
     expect(presence.querySelectorAll('.octo-avatar')).toHaveLength(1)
+    await waitFor(() => expect(presence.querySelector('.octo-avatar')?.textContent).toBe('王'))
+    expect(presence.querySelector('.octo-avatar')?.getAttribute('title')).toBe('王留超')
     expect(container.textContent).not.toContain('Synced')
     expect(container.textContent).not.toContain('Connecting')
   })
@@ -647,6 +650,24 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     // Clicking the overlay backdrop closes the modal (parity with EditorShell #A4).
     fireEvent.mouseDown(container.querySelector('.octo-modal-overlay') as HTMLElement)
     expect(container.querySelector('.octo-modal-overlay')).toBeNull()
+  })
+
+  it('shows the pending access-request count on the HTML Members button', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d1') {
+        return { data: { docId: 'd1', ownerId: 'u_owner', role: 'admin' }, status: 200 }
+      }
+      if (method === 'get' && url === '/docs/d1/access-requests?status=pending') {
+        return { data: { items: [{ requestId: 'r1', uid: 'u1' }, { requestId: 'r2', uid: 'u2' }] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    serveDoc('<p>body</p>', { creator_uid: 'u_owner' }, { isAuthor: true })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    await waitForFrame(container)
+
+    const membersButton = screen.getByTitle('docs.toolbar.members')
+    await waitFor(() => expect(membersButton.querySelector('.octo-access-badge')?.textContent).toBe('2'))
   })
 
   it('admin-not-author viewer never sees author-only slots and never lists octo-doc grants (OCT-216 regression)', async () => {

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -23,6 +23,7 @@ import { useMemberNames } from '../members/useMemberNames.ts'
 import { startDocForward } from '../forward/startDocForward.ts'
 import { avatarUrlForUid } from './htmlAvatar.ts'
 import { canManage, type Role } from '../auth/roles.ts'
+import { useAccessRequests } from '../access-request/useAccessRequests.ts'
 import { buildDocLink } from '../forward/link.ts'
 import { HtmlDocCommentPanel } from './HtmlDocCommentPanel.tsx'
 import { HtmlMemberPanel } from './HtmlMemberPanel.tsx'
@@ -357,6 +358,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
   // standalone surface (creatorNicknameOnly) SKIPS the member map entirely and forces nickname-
   // only so a link holder never sees the creator's verified real_name (XIN-392 P2-1).
   const names = useMemberNames(space)
+  const viewerName = names.get(getCurrentUid())
   const [creatorName, setCreatorName] = useState<string | undefined>(undefined)
   useEffect(() => {
     setCreatorName(undefined)
@@ -402,6 +404,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
   const creatorUid = ownerId
   const canManageBackend = role != null && canManage(role)
   const canOpenPanel = isAuthor || canManageBackend
+  const pendingAccess = useAccessRequests(docId, canManageBackend)
   // Browser-openable address for forwarding this doc to chat. Build the PATH-style standalone
   // link (/d/<docId>?sp=<space>) like every other kind (buildDocLink), NOT window.location.href:
   // the in-shell address is the legacy /docs?doc= query form, whose docId is wiped by the host's
@@ -562,7 +565,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
           {headerTitle}
         </div>
         <div className="octo-doc-header-right">
-          <HtmlPresenceBar />
+          <HtmlPresenceBar displayName={viewerName} />
           <button
             type="button"
             className={commentsOpen ? 'octo-tb-btn is-active' : 'octo-tb-btn'}
@@ -598,6 +601,11 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
               onClick={() => setMembersOpen((v) => !v)}
             >
               {t('docs.toolbar.members')}
+              {pendingAccess.count > 0 && (
+                <span className="octo-access-badge" aria-label={t('docs.forward.pendingTitle')}>
+                  {pendingAccess.count}
+                </span>
+              )}
             </button>
           )}
           <DocMoreMenu
@@ -678,6 +686,7 @@ export function HtmlDocView({ docId, space, slug, version = 'latest', onDeleted,
               docId={docId}
               role={role}
               isAuthor={isAuthor}
+              accessRequests={pendingAccess}
             />
           </div>
         </div>

--- a/packages/docs/src/html/HtmlMemberPanel.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.tsx
@@ -7,7 +7,7 @@ import { useMemberNames } from '../members/useMemberNames.ts'
 import { listGrants, addGrant, removeGrant, type HtmlGrant } from './htmlGrantsApi.ts'
 import { ShareScopePanel } from '../share/ShareScopePanel.tsx'
 import { InvitePanel } from '../invite/InvitePanel.tsx'
-import { useAccessRequests } from '../access-request/useAccessRequests.ts'
+import { useAccessRequests, type UseAccessRequestsResult } from '../access-request/useAccessRequests.ts'
 import { PendingRequests } from '../access-request/PendingRequests.tsx'
 
 // Member panel for HTML docs. Two backends live behind one modal:
@@ -34,6 +34,7 @@ export function HtmlMemberPanel({
   docId,
   role,
   isAuthor,
+  accessRequests: sharedAccessRequests,
 }: {
   slug: string
   /** Space id for the member picker roster. */
@@ -54,6 +55,7 @@ export function HtmlMemberPanel({
   /** octo-doc author flag from HtmlDocView (parseOdocCap). Same authority as the legacy
    *  canManage prop; passing both is redundant but harmless. */
   isAuthor: boolean
+  accessRequests?: UseAccessRequestsResult
 }) {
   // uid → display name for member rows (falls back to uid until the roster resolves).
   const names = useMemberNames(space ?? '')
@@ -88,7 +90,8 @@ export function HtmlMemberPanel({
 
   // Access-request hook: enabled only when the backend says we can manage; a non-admin never hits
   // the pending endpoint (it would 403).
-  const accessRequests = useAccessRequests(docId, canManageBackend)
+  const localAccessRequests = useAccessRequests(docId, sharedAccessRequests ? false : canManageBackend)
+  const accessRequests = sharedAccessRequests ?? localAccessRequests
 
   // reader is the only grantable role today; MemberPicker returns a Role but we
   // pin it to reader before calling the backend.

--- a/packages/docs/src/html/HtmlPresenceBar.tsx
+++ b/packages/docs/src/html/HtmlPresenceBar.tsx
@@ -8,18 +8,15 @@
 import { getCurrentUid } from '../octoweb/index.ts'
 import { colorFromId } from '../awareness/presence.ts'
 
-export function HtmlPresenceBar() {
+export function HtmlPresenceBar({ displayName }: { displayName?: string }) {
   const uid = getCurrentUid()
   // No identity → render nothing (the viewer isn't resolvable, so an avatar would be misleading).
   if (!uid) return null
-  // The viewer's display name is not exposed to the frontend (LoginInfo is uid/token only).
-  // NEVER fall back to the doc's publisher identity here — that would show the owner's name on
-  // an invited viewer's page (they'd appear to be the owner). uid initial is the safe identity.
-  const displayName = uid
-  const initial = displayName.slice(0, 1).toUpperCase()
+  const resolvedName = displayName || uid
+  const initial = resolvedName.slice(0, 1).toUpperCase()
   return (
     <div className="octo-html-doc-presence" data-testid="html-doc-presence">
-      <span className="octo-avatar" style={{ backgroundColor: colorFromId(uid) }} title={displayName}>
+      <span className="octo-avatar" style={{ backgroundColor: colorFromId(uid) }} title={resolvedName}>
         {initial}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- show the pending access-request count on the HTML document Members button
- share one access-request state between the toolbar badge and member panel, avoiding duplicate requests and keeping the count synchronized after approval or denial
- render the current viewer name initial and tooltip in the lightweight HTML avatar, falling back to the viewer UID when unresolved
- keep HTML documents single-viewer/read-only without Yjs awareness or connection state

## Linked Spec
- N/A — this is a scoped parity fix for the existing HTML-document toolbar and reuses the established access-request and avatar behavior; it does not introduce a new product or architectural specification.

## COMPREHENSION
### What changes in the load-bearing path?
Before, the HTML member panel owned its request state, so the toolbar could not display the pending count and a second consumer could cause duplicate or unsynchronized requests. After, `HtmlDocView` owns one permission-gated `useAccessRequests` instance and passes it to `HtmlMemberPanel`; the badge and panel therefore share the same state. The avatar resolves only the current viewer's name and falls back to that viewer's UID.

### What could break?
- Permission gating: a non-manager must not fetch or see pending access requests.
- State synchronization: approving or denying in the panel must update the toolbar badge without another independent request state.
- Viewer identity: the avatar must never fall back to the document owner/publisher identity.
- Existing rich-document, API, backend, CSS, Yjs awareness, and connection-state behavior are outside this change.

### How do we know it works?
- targeted HTML document tests pass: 71/71
- production web build passes
- `git diff --check` passes
- GitHub Build and e2e-p0 checks pass
- independent code review approved the permission gate, shared-state flow, and viewer-identity fallback

## How verified
- `cd packages/docs && pnpm vitest run src/html/HtmlDocView.test.tsx src/html/HtmlMemberPanel.test.tsx` — 71 tests passed
- `pnpm --filter @octo/web build` — passed
- `git diff --check` — passed
- `python3 scripts/check_octo_prototype.py <changed-file>` against the four changed files:
  - production files (`HtmlDocView.tsx`, `HtmlMemberPanel.tsx`, `HtmlPresenceBar.tsx`): 0 errors, 0 warnings
  - `HtmlDocView.test.tsx`: one pre-existing false positive at line 496, where an inline `onclick` string is intentionally used as an XSS sanitization fixture; the line predates and is unchanged by this PR
- GitHub CI: Build, e2e-p0, dependency review, secret scan, OSV scan, and history check passed

## Scope
- frontend only
- no API, backend, CSS, or rich-document behavior changes