### PR TITLE
fix(summary-share): composite-key grant revoke + surface revoke failures (#1002 follow-up)

### DIFF
--- a/packages/dmworkbase/src/Service/ForwardService.ts
+++ b/packages/dmworkbase/src/Service/ForwardService.ts
@@ -266,6 +266,7 @@ export class ForwardService {
                 } catch (error) {
                     result.failures.push({
                         channelID: channel.channelID,
+                        channelType: channel.channelType,
                         messageIndex: contents.length > 1 ? index : undefined,
                         reason: "send-error",
                         error,
@@ -291,6 +292,7 @@ export class ForwardService {
                         for (let j = i + 1; j < contents.length; j++) {
                             result.failures.push({
                                 channelID: channel.channelID,
+                                channelType: channel.channelType,
                                 messageIndex: j,
                                 reason: "send-error",
                             });

--- a/packages/dmworkbase/src/Service/ForwardService.ts
+++ b/packages/dmworkbase/src/Service/ForwardService.ts
@@ -51,6 +51,9 @@ export type ForwardFailureReason = "disbanded" | "send-error";
 
 export interface ForwardFailure {
     channelID: string;
+    /** 目标频道类型。与 channelID 一起构成复合键，供调用方精确匹配失败目标
+     * （同一 channelID 可能同时存在 DM 与群，仅凭 channelID 会误判）。 */
+    channelType?: number;
     /** 多 content 场景（同一 channel 多条消息）标识具体是第几条；单 content 场景省略。 */
     messageIndex?: number;
     reason: ForwardFailureReason;
@@ -201,6 +204,7 @@ export class ForwardService {
             for (let i = 0; i < plan.contents.length; i++) {
                 result.failures.push({
                     channelID: plan.channel.channelID,
+                    channelType: plan.channel.channelType,
                     messageIndex: multi ? i : undefined,
                     reason: "disbanded",
                 });
@@ -225,6 +229,7 @@ export class ForwardService {
             for (let i = 0; i < contents.length; i++) {
                 result.failures.push({
                     channelID: channel.channelID,
+                    channelType: channel.channelType,
                     messageIndex: multi ? i : undefined,
                     reason: "send-error",
                     error,

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -1960,8 +1960,11 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 void Promise.all(grants.map(async (grant) => {
                     try {
                         await api.revokeSummaryShare(grant.share_id);
-                    } catch {
-                        // Best effort only: cleanup must not mask the send result.
+                    } catch (e) {
+                        // Best effort: cleanup must not mask the send result. But a silent
+                        // failure leaves an orphan grant with no card behind it, so log it
+                        // to make the leak observable (#1002 follow-up).
+                        console.warn("[summary-share] failed to revoke orphan grant", grant.share_id, e);
                     }
                 }));
             };
@@ -2001,8 +2004,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     { channelMode: "serial", spaceId: WKApp.shared.currentSpaceId },
                 );
 
-                const failedChannelIDs = new Set(result.failures.map((failure) => failure.channelID));
-                revokeGrants(share.grants.filter((grant) => failedChannelIDs.has(grant.channel_id)));
+                const failedKeys = new Set(result.failures.map((failure) => `${failure.channelType}:${failure.channelID}`));
+                revokeGrants(share.grants.filter((grant) => failedKeys.has(`${grant.channel_type}:${grant.channel_id}`)));
 
                 const state = interpretForwardResult(result, "targets");
                 if (state.kind === "all-failed") Toast.error(t("summary.detail.forwardFailed"));


### PR DESCRIPTION
## Summary
#1002 之后的收尾修复,针对 agent 总结「转发到聊天」分享流程的两个问题(逐行核过 #1002 已合入代码):

1. **复合键撤销(正确性)** — 部分目标发送失败后,撤销授权时用 `channel_id` 单键过滤:
   ```js
   share.grants.filter((grant) => failedChannelIDs.has(grant.channel_id))
   ```
   而发送路径本身用的是复合键 `channel_type:channel_id`。DM 与群可能共用同一 `channel_id`,极端情况下会**撤错授权**。现改为按复合键匹配。为此 `ForwardService.ForwardFailure` 补上 `channelType`(两处失败构造点均已填充),让调用方能区分。
2. **撤销可观测性** — 尽力撤销的 `catch {}` 静默吞错,失败会留下**无卡片对应的孤立授权**且无人可知。现改为 `console.warn` 记录,便于发现泄漏。

## How verified
- `pnpm i18n:check` 通过(无新增用户文案)。
- 现有测试全绿:`dmworkbase` 400 tests(含 SummaryCard),`dmworksummary` SummaryDetailPage 142 tests。
- 类型安全:`ForwardFailure.channelType` 为可选字段,向后兼容既有 ForwardService 消费方。

## 备注
属 #1002 的小型收尾正确性修复。仍未覆盖的收尾项(另行处理):非创建者转发策略(需产品定)、分享深链按 `source_accessible` 回跳、`source_name` 超长截断、已撤销快照清理。
