### PR TITLE
fix(dmworkmcp): align MCP marketplace UI to Skill marketplace (#1009)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -61,6 +61,10 @@
       "reason": "Agent prompt template for the Bot publish flow. Same rationale as installPrompt.ts above — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },
     {
+      "path": "packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts",
+      "reason": "Agent prompt template for the MCP marketplace publish flow. Same rationale as dmworkskillmarket/src/utils/botPublishPrompt.ts — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
+    },
+    {
       "path": "packages/dmworksummary/src/__mocks__/handlers.ts",
       "reason": "MSW test fixture data with sample user names, titles, and message bodies; not UI copy."
     },

--- a/packages/dmworkmcp/package.json
+++ b/packages/dmworkmcp/package.json
@@ -11,7 +11,8 @@
     "@douyinfe/semi-icons": "^2.93.0",
     "@douyinfe/semi-ui": "^2.93.0",
     "axios": "^0.25.0",
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "lucide-react": "^0.577.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
+++ b/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Bot, Check, Copy } from "lucide-react";
+import { Toast } from "@douyinfe/semi-ui";
+import { t, useI18n, WKApp, WKButton, WKModal } from "@octo/base";
+import {
+  getMcpBotPublishPrompt,
+  resolveMcpAPIBaseURL,
+} from "../utils/mcpBotPublishPrompt";
+
+interface McpBotPublishModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function getCurrentSpaceId(): string {
+  return (
+    WKApp.shared?.currentSpaceId ||
+    (typeof localStorage !== "undefined"
+      ? localStorage.getItem("currentSpaceId") || ""
+      : "")
+  );
+}
+
+/** MCP "Bot 上架" modal — mirrors dmworkskillmarket's BotPublishModal.
+ *  Renders a copy-to-clipboard prompt the user hands to an Agent. Prompt
+ *  content lives in ../utils/mcpBotPublishPrompt.ts and is MCP-specific. */
+export default function McpBotPublishModal({
+  visible,
+  onClose,
+}: McpBotPublishModalProps) {
+  useI18n();
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+  const spaceId = getCurrentSpaceId();
+  // Memoize the prompt — inputs are stable for the modal's lifetime and the
+  // template is a few hundred bytes of string concat we'd otherwise rebuild
+  // on every parent re-render (space-changed, tab switches, etc.).
+  const prompt = useMemo(
+    () =>
+      getMcpBotPublishPrompt({
+        spaceId,
+        apiBaseUrl: resolveMcpAPIBaseURL(
+          WKApp.apiClient.config.apiURL,
+          window.location.origin
+        ),
+      }),
+    [spaceId]
+  );
+  // Placeholder guard: the prompt substitutes `<space-id>` when currentSpaceId
+  // is empty. Copying that would give the bot an unusable command — refuse.
+  const promptReady = Boolean(prompt) && !!spaceId.trim();
+
+  useEffect(() => {
+    if (visible) setCopied(false);
+  }, [visible]);
+
+  // Clear any in-flight copy-feedback timer when the modal unmounts to avoid
+  // "state update on unmounted component" warnings when the parent closes the
+  // modal within 2s of a successful copy.
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current !== null) {
+        window.clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  async function handleCopy() {
+    if (!promptReady) return;
+    if (!navigator.clipboard?.writeText) {
+      Toast.error(t("mcp.botPublish.copyUnavailable"));
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(prompt);
+    } catch {
+      Toast.error(t("mcp.botPublish.copyFailed"));
+      return;
+    }
+    setCopied(true);
+    if (copiedTimerRef.current !== null) {
+      window.clearTimeout(copiedTimerRef.current);
+    }
+    copiedTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copiedTimerRef.current = null;
+    }, 2000);
+  }
+
+  return (
+    <WKModal
+      visible={visible}
+      onCancel={onClose}
+      title={null}
+      size="lg"
+      className="wk-mcp-prompt-modal"
+      header={
+        <div className="wk-mcp-prompt-modal__header">
+          <div className="wk-mcp-prompt-modal__icon">
+            <Bot size={18} />
+          </div>
+          <div>
+            <h3>{t("mcp.botPublish.title")}</h3>
+            <p>{t("mcp.botPublish.hint")}</p>
+          </div>
+        </div>
+      }
+      footer={
+        <WKButton
+          variant="primary"
+          icon={copied ? <Check size={15} /> : <Copy size={15} />}
+          onClick={handleCopy}
+          disabled={!promptReady}
+        >
+          {copied
+            ? t("mcp.botPublish.copied")
+            : t("mcp.botPublish.copyBtn")}
+        </WKButton>
+      }
+    >
+      <div className="wk-mcp-prompt-modal__body">
+        <pre className="wk-mcp-prompt-modal__pre">{prompt}</pre>
+      </div>
+    </WKModal>
+  );
+}

--- a/packages/dmworkmcp/src/components/McpCard.tsx
+++ b/packages/dmworkmcp/src/components/McpCard.tsx
@@ -1,31 +1,42 @@
 import React from "react";
 import { Tooltip } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { Bot, UserRound } from "lucide-react";
 import type { McpListItem } from "../types/mcp";
 import { t } from "@octo/base";
 import { IconGlyph } from "../utils/icon";
+import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 
 interface McpCardProps {
   item: McpListItem;
   onClick: (item: McpListItem) => void;
-  keyword?: string;
 }
 
-export function Highlight({ text, keyword = "" }: { text: string; keyword?: string }) {
-  const index = text.toLowerCase().indexOf(keyword.trim().toLowerCase());
-  if (!keyword.trim() || index < 0) return <>{text}</>;
-  return <>{text.slice(0, index)}<mark>{text.slice(index, index + keyword.trim().length)}</mark>{text.slice(index + keyword.trim().length)}</>;
-}
-
+/** Parse a backend `match_reasons` entry into an i18n key + optional value.
+ *  Wire shape is `"<type>:<value>"` where `<type>` is one of the fixed set
+ *  below; unknown types fall through to `other` so the card still renders a
+ *  labelled chip rather than blowing up. */
 export function parseMatchReason(reason: string): { key: string; value?: string } {
   const colon = reason.indexOf(":");
   const type = colon < 0 ? reason : reason.slice(0, colon);
   const value = colon < 0 ? undefined : reason.slice(colon + 1);
-  const keys: Record<string, string> = { name: "name", description: "description", category: "category", usage_example: "usage", tool: "tool", tag: "tag", creator: "creator" };
+  const keys: Record<string, string> = {
+    name: "name",
+    description: "description",
+    category: "category",
+    usage_example: "usage",
+    tool: "tool",
+    tag: "tag",
+    creator: "creator",
+  };
   return { key: `mcp.card.matchReason.${keys[type] ?? "other"}`, value };
 }
 
-export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; keyword?: string }) {
+/** Renders the "为什么命中" chips under the card tags. Only reveals fields
+ *  the card itself doesn't already show (tool / usage_example / creator) —
+ *  matches on name / description / tag are visible in the card body and
+ *  don't need their own chip. */
+export function MatchReasons({ reasons }: { reasons: string[] }) {
   const revealing = reasons.filter((reason) => {
     const type = reason.split(":", 1)[0];
     return type === "tool" || type === "usage_example" || type === "creator";
@@ -35,11 +46,10 @@ export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; key
     <div className="wk-mcp-card__reasons">
       {revealing.map((reason) => {
         const parsed = parseMatchReason(reason);
-        const value = parsed.value || keyword;
         return (
           <span className="wk-mcp-card__reason" key={reason}>
             <span className="wk-mcp-card__reason-label">{t(parsed.key)}</span>
-            {value ? <Highlight text={value} keyword={keyword} /> : null}
+            {parsed.value ? <span>{parsed.value}</span> : null}
           </span>
         );
       })}
@@ -47,15 +57,41 @@ export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; key
   );
 }
 
-/** How many tags the card renders before collapsing the rest into a `+N`
- *  chip. Product decision: 3 keeps the tag row on a single line for typical
- *  cases while still surfacing the most-relevant tags on a real record. */
 const CARD_TAG_LIMIT = 3;
 
+/** Compute what the card's meta-row shows for the "who published this" slot.
+ *  Mirrors dmworkskillmarket's owner rendering:
+ *   - bot rows: bot icon + bot 名 · human icon + human 名（两段用中点分隔）
+ *   - human rows / legacy rows with only creatorName: human icon + human 名
+ *   - `import` rows and rows with no attribution at all: return null so the
+ *     meta-row folds — imports don't come from a marketplace user and must
+ *     not be labelled with a human/bot chip. */
+export function resolveOwner(item: McpListItem): { botName?: string; humanName?: string } | null {
+  if (item.createdByType === "bot") {
+    const botName = item.createdByBotName || t("mcp.source.bot");
+    return {
+      botName,
+      humanName: item.creatorName || undefined,
+    };
+  }
+  if (item.createdByType === "import") {
+    return null;
+  }
+  if (item.creatorName) {
+    return { humanName: item.creatorName };
+  }
+  return null;
+}
+
 /** A single MCP server card in the list grid. */
-const McpCard: React.FC<McpCardProps> = ({ item, onClick, keyword }) => {
+const McpCard: React.FC<McpCardProps> = ({ item, onClick }) => {
   const visibleTags = item.tags.slice(0, CARD_TAG_LIMIT);
   const overflowTags = item.tags.slice(CARD_TAG_LIMIT);
+  const owner = resolveOwner(item);
+  // `.trim()` gates the fallback avatar so a whitespace-only icon string
+  // (paste artifact, backend quirk) doesn't slip past the truthiness check
+  // and render an empty box via IconGlyph.
+  const hasIcon = !!item.icon?.trim();
   return (
     <div
       className="wk-mcp-card"
@@ -69,126 +105,89 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, keyword }) => {
         }
       }}
     >
-      <div className="wk-mcp-card__header">
+      <div className="wk-mcp-card__top">
         <div className="wk-mcp-card__icon">
-          <IconGlyph icon={item.icon} className="wk-mcp-card__icon-img" alt={item.name} />
-        </div>
-        <div className="wk-mcp-card__heading">
-          <div className="wk-mcp-card__name">
-            {/* Wrap the highlighted text in its own span so the ellipsis
-                clamp only applies to the name — not the source chip that
-                sits alongside it. `title` on the wrapper is the plain
-                browser tooltip (fine here: users deliberately hover for
-                a long name, and clicking still opens the detail modal
-                with the full name in the header). */}
-            <span className="wk-mcp-card__name-text" title={item.name}>
-              <Highlight text={item.name} keyword={keyword} />
+          {hasIcon ? (
+            <IconGlyph icon={item.icon} className="wk-mcp-card__icon-img" alt={item.name} />
+          ) : (
+            <span
+              className="wk-mcp-card__icon-default"
+              style={{ background: getMcpAvatarColor(item.id) }}
+            >
+              {getMcpAvatarText(item.name)}
             </span>
-            {/* Cards get an icon-only chip — real estate is tight and the
-                name of the bot rarely helps disambiguation in a grid. Hover
-                exposes the full "由 X 的 Bot 创建" tooltip. */}
-            <SourceBadge item={item} variant="icon-only" />
+          )}
+        </div>
+        <div className="wk-mcp-card__header">
+          <div className="wk-mcp-card__title-row">
+            <h3 className="wk-mcp-card__name" title={item.name}>
+              {item.name}
+            </h3>
           </div>
-          <div className="wk-mcp-card__tags">
-            {visibleTags.map((tag) => (
-              <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                <Highlight text={tag} keyword={keyword} />
-              </span>
-            ))}
-            {overflowTags.length > 0 && (
-              /* +N chip: hover reveals the truncated tags via Semi Tooltip
-                 as a mini pill cloud — matches the visual language of the
-                 card's own tags so it reads as "the rest of the tag row".
-                 100 ms delay so the reveal feels near-instant. Click still
-                 bubbles up to the card's onClick — no separate detail path
-                 for the +N. */
-              <Tooltip
-                content={
-                  <div className="wk-mcp-tag-overflow">
-                    {overflowTags.map((tag) => (
-                      <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                }
-                className="wk-mcp-tooltip-light"
-                mouseEnterDelay={100}
-                position="top"
-              >
-                <span className="wk-mcp-tag wk-mcp-tag--more" aria-label={overflowTags.join(", ")}>
-                  +{overflowTags.length}
+          {owner && (
+            <div className="wk-mcp-card__meta-row">
+              {owner.botName && (
+                <span className="wk-mcp-card__owner" title={owner.botName}>
+                  <Bot className="wk-mcp-card__owner-bot-icon" size={13} aria-hidden="true" />
+                  <span className="wk-mcp-card__owner-name">{owner.botName}</span>
                 </span>
-              </Tooltip>
-            )}
-          </div>
+              )}
+              {owner.botName && owner.humanName && (
+                <span className="wk-mcp-card__meta-separator">·</span>
+              )}
+              {owner.humanName && (
+                <span className="wk-mcp-card__owner" title={owner.humanName}>
+                  <UserRound className="wk-mcp-card__owner-user-icon" size={13} aria-hidden="true" />
+                  <span className="wk-mcp-card__owner-name">{owner.humanName}</span>
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
-      <div className="wk-mcp-card__slogan"><Highlight text={item.slogan} keyword={keyword} /></div>
-      {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} keyword={keyword} /> : null}
+      <div className="wk-mcp-card__slogan">{item.slogan}</div>
+      <div className="wk-mcp-card__tags">
+        {visibleTags.map((tag) => (
+          <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+            {tag}
+          </span>
+        ))}
+        {overflowTags.length > 0 && (
+          <Tooltip
+            content={
+              <div className="wk-mcp-tag-overflow">
+                {overflowTags.map((tag) => (
+                  <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            }
+            className="wk-mcp-tooltip-light"
+            mouseEnterDelay={100}
+            position="top"
+          >
+            <span className="wk-mcp-tag wk-mcp-tag--more" aria-label={overflowTags.join(", ")}>
+              +{overflowTags.length}
+            </span>
+          </Tooltip>
+        )}
+      </div>
+      {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} /> : null}
       <div className="wk-mcp-card__footer">
-        <span
-          className="wk-mcp-card__stat"
-          title={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
-          aria-label={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
-        >
-          <IconWrenchStroked size="small" />
-          {item.toolCount}
-        </span>
+        <div className="wk-mcp-card__stats">
+          <span
+            className="wk-mcp-card__stat"
+            title={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
+            aria-label={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
+          >
+            <IconWrenchStroked size="small" />
+            {item.toolCount}
+          </span>
+        </div>
       </div>
     </div>
   );
 };
-
-/**
- * Small "created by whom" chip for bot-authored MCPs (issue #894). Two shapes:
- *   - `icon-only` (card grid): just the 🤖 glyph; hover for the full tooltip
- *     naming the bot and its owner. Keeps the list compact.
- *   - `labeled` (detail modal): 🤖 + bot name, so the source is legible
- *     without a hover — the detail page has the room.
- * Human/import/legacy rows never render a chip either way.
- */
-export function SourceBadge({
-  item,
-  variant = "labeled",
-}: {
-  item: McpListItem;
-  variant?: "icon-only" | "labeled";
-}) {
-  if (item.createdByType !== "bot") return null;
-  const botName = item.createdByBotName || t("mcp.source.bot");
-  const ownerHint = item.creatorName
-    ? t("mcp.source.botTooltip", { values: { owner: item.creatorName } })
-    : "";
-  // Same tooltip shape for both variants — the labeled chip clips long bot
-  // names with an ellipsis, so hover MUST reveal the full name (plus owner)
-  // no matter which variant the caller picks.
-  const tooltip = ownerHint ? `${botName} · ${ownerHint}` : botName;
-  const chip = (
-    <span
-      className={
-        variant === "icon-only"
-          ? "wk-mcp-tag wk-mcp-source wk-mcp-source--bot wk-mcp-source--icon"
-          : "wk-mcp-tag wk-mcp-source wk-mcp-source--bot"
-      }
-      aria-label={tooltip}
-    >
-      <span className="wk-mcp-source__icon" aria-hidden="true">🤖</span>
-      {variant === "labeled" && (
-        <span className="wk-mcp-source__label">{botName}</span>
-      )}
-    </span>
-  );
-  // Semi UI Tooltip — near-instant reveal (100 ms) instead of the browser's
-  // sluggish 500-2000ms native title. Stopping propagation on the trigger
-  // wrapper is unnecessary: the tooltip layer sits above but the click
-  // bubble path still reaches the card, so clicking the chip still opens
-  // the detail like any other card area.
-  return (
-    <Tooltip content={tooltip} mouseEnterDelay={100} position="top">
-      {chip}
-    </Tooltip>
-  );
-}
 
 export default McpCard;

--- a/packages/dmworkmcp/src/components/McpCreateModal.tsx
+++ b/packages/dmworkmcp/src/components/McpCreateModal.tsx
@@ -15,6 +15,11 @@ import {
   slugifyServerName,
 } from "../utils/constants";
 import { parseImportJSON } from "../utils/importJson";
+import {
+  MAX_MCP_TAGS,
+  validateMcpTag,
+  validateMcpTags,
+} from "../utils/mcpTagValidation";
 import type {
   CreateMcpParams,
   McpDetail,
@@ -393,7 +398,11 @@ function Segments<T extends string>({
   );
 }
 
-/** Chip-based tag input — Enter/comma add, Backspace on empty removes last. */
+/** Chip-based tag input — Enter/comma add, Backspace on empty removes last.
+ *  Also enforces MAX_MCP_TAGS + per-tag length/charset (mirrors dmworkskillmarket
+ *  after PR #1026). Invalid tags are rejected inline with a Toast so the user
+ *  gets immediate feedback; the outer submit path re-validates as a defense
+ *  against legacy oversized rows loaded into the edit form. */
 function TagsInput({
   value,
   onChange,
@@ -406,14 +415,43 @@ function TagsInput({
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const commit = (raw: string) => {
+  const commitOne = (raw: string, existing: string[]): string[] | null => {
     const trimmed = raw.trim().replace(/,+$/, "");
-    if (!trimmed) return;
-    if (value.includes(trimmed)) {
+    if (!trimmed) return null;
+    if (existing.includes(trimmed)) return null;
+    if (existing.length >= MAX_MCP_TAGS) {
+      Toast.warning(t("mcp.form.tagLimit", { values: { count: MAX_MCP_TAGS } }));
+      return null;
+    }
+    const tagError = validateMcpTag(trimmed);
+    if (tagError) {
+      Toast.warning(tagError);
+      return null;
+    }
+    return [...existing, trimmed];
+  };
+
+  /** Accepts either a single tag or a comma-separated batch (from paste).
+   *  Splits on commas, validates each segment, and drops the whole batch's
+   *  draft only after processing so a mid-batch validation error still
+   *  clears the input (matches the keyboard-comma UX). */
+  const commit = (raw: string) => {
+    const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    if (parts.length === 0) {
       setDraft("");
       return;
     }
-    onChange([...value, trimmed]);
+    let next = value;
+    for (const part of parts) {
+      const result = commitOne(part, next);
+      if (result === null) {
+        // Batch aborted on the first invalid segment; keep whatever we already
+        // appended (parity with per-keystroke behavior).
+        break;
+      }
+      next = result;
+    }
+    if (next !== value) onChange(next);
     setDraft("");
   };
 
@@ -423,7 +461,7 @@ function TagsInput({
     <div className="wk-mcp-tags" onClick={() => inputRef.current?.focus()}>
       {value.map((tag, i) => (
         <span className="wk-mcp-tags__chip" key={`${tag}-${i}`}>
-          {tag}
+          <span className="wk-mcp-tags__chip-text" title={tag}>{tag}</span>
           <button
             type="button"
             className="wk-mcp-tags__chip-remove"
@@ -772,6 +810,12 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
   };
 
   const handleSubmit = async () => {
+    const tagError = validateMcpTags(form.tags);
+    if (tagError) {
+      Toast.warning(tagError);
+      setStep(0);
+      return;
+    }
     const err = firstValidationError();
     if (err) {
       Toast.warning(

--- a/packages/dmworkmcp/src/components/McpDetailModal.tsx
+++ b/packages/dmworkmcp/src/components/McpDetailModal.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import { WKModal, WKButton, t } from "@octo/base";
 import { Toast, Spin } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { Bot, UserRound } from "lucide-react";
 import { deleteMcp, fetchMcpDetail } from "../api/mcpService";
 import { buildQuickStartTabs, TOKEN_PLACEHOLDER } from "../api/quickStartTemplates";
 import type { McpDetail, McpQuickStart } from "../types/mcp";
 import { IconGlyph } from "../utils/icon";
-import { SourceBadge } from "./McpCard";
+import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
+import { resolveOwner } from "./McpCard";
 
 interface McpDetailModalProps {
   /** The id of the MCP to show; null closes the modal. */
@@ -187,6 +189,113 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
     onClose();
   };
 
+  /** Local relative-time formatter — mirrors dmworkskillmarket's
+   *  `formatRelativeTime` but reads from the MCP i18n namespace so we don't
+   *  pull the whole skillmarket utils package for one helper.
+   *
+   *  Negative diffMs (server clock ahead / bad ISO with wrong timezone) would
+   *  otherwise land in the `< minute` branch and stamp every stale future
+   *  date as "just now"; treat any non-positive diff as "just now" only for
+   *  small skew (< 1 min) and fall through to the absolute-date fallback
+   *  otherwise so the tooltip surfaces the raw date instead of a lie. */
+  const formatUpdatedTime = (iso: string): string => {
+    const parsed = new Date(iso).getTime();
+    if (Number.isNaN(parsed)) return "";
+    const diffMs = Date.now() - parsed;
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+    if (diffMs < 0) {
+      // Small clock-skew: still say "just now"; large future skew: show date.
+      if (-diffMs < minute) return t("mcp.time.justNow");
+      return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(parsed));
+    }
+    if (diffMs < minute) return t("mcp.time.justNow");
+    if (diffMs < hour) return t("mcp.time.minutesAgo", { values: { count: Math.max(1, Math.floor(diffMs / minute)) } });
+    if (diffMs < day) return t("mcp.time.hoursAgo", { values: { count: Math.max(1, Math.floor(diffMs / hour)) } });
+    if (diffMs < 30 * day) return t("mcp.time.daysAgo", { values: { count: Math.max(1, Math.floor(diffMs / day)) } });
+    return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(parsed));
+  };
+
+  /** Resolve category display label. `t()` returns the key string when a
+   *  translation is missing, so a backend-added category slug the frontend
+   *  bundle hasn't shipped yet would otherwise render "mcp.category.foo" in
+   *  the badge. Fall back to the raw slug — ugly but truthful — instead. */
+  const resolveCategoryLabel = (key: string): string => {
+    const i18nKey = `mcp.category.${key}`;
+    const label = t(i18nKey);
+    return label === i18nKey ? key : label;
+  };
+
+  const detailHeader = detail ? (
+    <div className="wk-mcp-detail-header">
+      <div className="wk-mcp-detail-header__icon">
+        {detail.icon?.trim() ? (
+          <IconGlyph
+            icon={detail.icon}
+            className="wk-mcp-detail__icon-img"
+            alt={detail.name}
+          />
+        ) : (
+          <span
+            className="wk-mcp-card__icon-default"
+            style={{ background: getMcpAvatarColor(detail.id) }}
+          >
+            {getMcpAvatarText(detail.name)}
+          </span>
+        )}
+      </div>
+      <div className="wk-mcp-detail-header__main">
+        <div className="wk-mcp-detail-header__title-row">
+          <h2 className="wk-mcp-detail-header__title" title={detail.name}>
+            {detail.name}
+          </h2>
+          {detail.category && (
+            <span className="wk-mcp-detail-header__badge" title={resolveCategoryLabel(detail.category)}>
+              {resolveCategoryLabel(detail.category)}
+            </span>
+          )}
+        </div>
+        {(() => {
+          const owner = resolveOwner(detail);
+          const parts: React.ReactNode[] = [];
+          if (owner?.botName) {
+            parts.push(
+              <span key="bot" className="wk-mcp-detail__owner" title={owner.botName}>
+                <Bot className="wk-mcp-card__owner-bot-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{owner.botName}</span>
+              </span>
+            );
+          }
+          if (owner?.humanName) {
+            parts.push(
+              <span key="human" className="wk-mcp-detail__owner" title={owner.humanName}>
+                <UserRound className="wk-mcp-card__owner-user-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{owner.humanName}</span>
+              </span>
+            );
+          }
+          if (detail.updatedAt) {
+            parts.push(
+              <span key="updated" className="wk-mcp-detail-header__updated" title={detail.updatedAt}>
+                {t("mcp.detail.updatedAt", { values: { time: formatUpdatedTime(detail.updatedAt) } })}
+              </span>
+            );
+          }
+          if (parts.length === 0) return null;
+          const withSeparators: React.ReactNode[] = [];
+          parts.forEach((p, i) => {
+            if (i > 0) {
+              withSeparators.push(<span key={`sep-${i}`} className="wk-mcp-card__meta-separator">·</span>);
+            }
+            withSeparators.push(p);
+          });
+          return <div className="wk-mcp-detail-header__meta">{withSeparators}</div>;
+        })()}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <WKModal
       visible={!!mcpId}
@@ -194,7 +303,8 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
       width={900}
       className="wk-mcp-detail-modal"
       bodyStyle={{ height: "70vh", overflowY: "auto" }}
-      title={detail ? detail.name : t("mcp.detail.title")}
+      title={detail ? null : t("mcp.detail.title")}
+      header={detailHeader}
       footer={
         showActions ? (
           confirmingDelete ? (
@@ -236,56 +346,35 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
         </div>
       ) : (
         <div className="wk-mcp-detail">
-          <div className="wk-mcp-detail__meta">
-            <div className="wk-mcp-detail__icon">
-              <IconGlyph
-                icon={detail.icon}
-                className="wk-mcp-detail__icon-img"
-                alt={detail.name}
-              />
-            </div>
-            <div className="wk-mcp-detail__meta-main">
-              <div className="wk-mcp-card__tags">
-                {detail.tags.map((tag) => (
-                  <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              {(detail.creatorName || detail.createdByType === "bot") && (
-                <div className="wk-mcp-detail__meta-line">
-                  {detail.creatorName && (
-                    <span className="wk-mcp-detail__owner">
-                      @{detail.creatorName}
-                    </span>
-                  )}
-                  {/* Bot 徽章跟着 @owner 放在同一行；human/legacy 情况下
-                      SourceBadge 自己会返回 null。 */}
-                  <SourceBadge item={detail} />
-                </div>
-              )}
-              {/* Slogan / 简介 — 详情页空间够，不 clamp。 */}
-              {detail.slogan && (
-                <div className="wk-mcp-detail__slogan">{detail.slogan}</div>
-              )}
-              {/* 工具数量下沉到简介之下，图标 + 数字，与卡片 footer 及
-                  dmworkskillmarket 的 .skill-market-card__stat 一致。 */}
-              <div className="wk-mcp-detail__stats">
-                <span
-                  className="wk-mcp-card__stat"
-                  title={t("mcp.card.toolCount", {
-                    values: { count: detail.toolCount },
-                  })}
-                  aria-label={t("mcp.card.toolCount", {
-                    values: { count: detail.toolCount },
-                  })}
-                >
-                  <IconWrenchStroked size="small" />
-                  {detail.toolCount}
-                </span>
-              </div>
-            </div>
+          {/* Slogan / 简介 — 详情页空间够，不 clamp。 */}
+          {detail.slogan && (
+            <div className="wk-mcp-detail__slogan">{detail.slogan}</div>
+          )}
+          {/* 工具数量：与卡片 footer 及 dmworkskillmarket 的 stats 一致。 */}
+          <div className="wk-mcp-detail__stats">
+            <span
+              className="wk-mcp-card__stat"
+              title={t("mcp.card.toolCount", {
+                values: { count: detail.toolCount },
+              })}
+              aria-label={t("mcp.card.toolCount", {
+                values: { count: detail.toolCount },
+              })}
+            >
+              <IconWrenchStroked size="small" />
+              {detail.toolCount}
+            </span>
           </div>
+          {/* Tags — 放到最下面，与 dmworkskillmarket 的详情弹窗一致。 */}
+          {detail.tags.length > 0 && (
+            <div className="wk-mcp-detail__tags">
+              {detail.tags.map((tag) => (
+                <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
 
           {/* 1. ⚡快速接入 */}
           <section className="wk-mcp-section">

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -40,7 +40,7 @@
   },
   "list": {
     "desc": "Browse and connect MCP servers to extend your agent's tools.",
-    "create": "New MCP",
+    "create": "Publish MCP",
     "searchPlaceholder": "Search MCPs, tools, tags, or capabilities",
     "searchClear": "Clear",
     "errorTitle": "Failed to load MCPs",
@@ -60,20 +60,43 @@
     "mode": {
       "all": "All",
       "mine": "Mine"
-    },
-    "source": {
-      "filterLabel": "Filter by source",
-      "all": "All sources"
     }
   },
+  "publishMenu": {
+    "botTitle": "Publish via Bot",
+    "botHint": "Copy the prompt for an Agent",
+    "manualTitle": "Manual",
+    "manualHint": "Fill in the form to create an MCP"
+  },
+  "botPublish": {
+    "title": "Publish via Bot",
+    "hint": "Copy the prompt to an Agent and let it publish for you",
+    "copyBtn": "Copy prompt",
+    "copied": "Copied",
+    "copyFailed": "Copy failed. Select the text manually.",
+    "copyUnavailable": "Automatic copy is not available here. Select the text manually."
+  },
+  "form": {
+    "tagLimit": "At most {{count}} tags",
+    "tagLengthLimit": "A tag can have at most {{count}} characters",
+    "tagInvalidChars": "Tags can only contain letters, digits, spaces, and - _ . / # +"
+  },
   "card": {
-    "hitTool": "Matched tool",
-    "hitTag": "Matched tag",
-    "matchReason": { "name": "Matched name", "description": "Matched summary", "tool": "Matched tool", "tag": "Matched tag", "category": "Matched category", "usage": "Matched usage example", "creator": "Matched publisher", "other": "Matched content" },
+    "matchReason": {
+      "name": "Matched name",
+      "description": "Matched summary",
+      "tool": "Matched tool",
+      "tag": "Matched tag",
+      "category": "Matched category",
+      "usage": "Matched usage example",
+      "creator": "Matched publisher",
+      "other": "Matched content"
+    },
     "toolCount": "Tools: {{count}}"
   },
   "detail": {
     "title": "MCP Details",
+    "updatedAt": "Updated {{time}}",
     "quickAccess": "Quick access",
     "qsTab": {
       "prompt": "Prompt",
@@ -251,5 +274,11 @@
     "submit": "Submit",
     "success": "Created",
     "failed": "Create failed"
+  },
+  "time": {
+    "justNow": "just now",
+    "minutesAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}} hours ago",
+    "daysAgo": "{{count}} days ago"
   }
 }

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -40,7 +40,7 @@
   },
   "list": {
     "desc": "浏览并接入 MCP 服务，为你的智能体扩展工具能力。",
-    "create": "新建 MCP",
+    "create": "上架 MCP",
     "searchPlaceholder": "搜索 MCP、工具、标签或能力",
     "searchClear": "清除",
     "errorTitle": "加载 MCP 失败",
@@ -60,20 +60,43 @@
     "mode": {
       "all": "全部",
       "mine": "我的"
-    },
-    "source": {
-      "filterLabel": "按来源筛选",
-      "all": "全部来源"
     }
   },
+  "publishMenu": {
+    "botTitle": "Bot 上架",
+    "botHint": "复制提示词给 Agent",
+    "manualTitle": "手动上架",
+    "manualHint": "填写表单创建 MCP"
+  },
+  "botPublish": {
+    "title": "Bot 上架",
+    "hint": "复制提示词给 Agent，让它帮你完成上架",
+    "copyBtn": "复制提示词",
+    "copied": "已复制",
+    "copyFailed": "复制失败，请手动选中文本复制",
+    "copyUnavailable": "当前环境不支持自动复制，请手动选中文本复制"
+  },
+  "form": {
+    "tagLimit": "最多添加 {{count}} 个标签",
+    "tagLengthLimit": "单个标签最多 {{count}} 个字符",
+    "tagInvalidChars": "标签仅支持文字、数字、空格和 - _ . / # +"
+  },
   "card": {
-    "hitTool": "命中工具",
-    "hitTag": "命中标签",
-    "matchReason": { "name": "命中名称", "description": "命中简介", "tool": "命中工具", "tag": "命中标签", "category": "命中分类", "usage": "命中使用示例", "creator": "命中发布者", "other": "命中内容" },
+    "matchReason": {
+      "name": "命中名称",
+      "description": "命中简介",
+      "tool": "命中工具",
+      "tag": "命中标签",
+      "category": "命中分类",
+      "usage": "命中使用示例",
+      "creator": "命中发布者",
+      "other": "命中内容"
+    },
     "toolCount": "工具数量: {{count}} 个"
   },
   "detail": {
     "title": "MCP 详情",
+    "updatedAt": "{{time}}更新",
     "quickAccess": "快速接入",
     "qsTab": {
       "prompt": "提示词",
@@ -251,5 +274,11 @@
     "submit": "提交",
     "success": "创建成功",
     "failed": "创建失败"
+  },
+  "time": {
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前",
+    "daysAgo": "{{count}} 天前"
   }
 }

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -39,6 +39,149 @@
   gap: var(--wk-sp-2);
 }
 
+/* Publish 按钮 + Bot/手动 下拉 —— 与 dmworkskillmarket 的
+   .skill-market-publish-menu 一致。 */
+.wk-mcp-publish-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.wk-mcp-publish-menu__panel {
+  position: absolute;
+  z-index: var(--wk-z-dropdown);
+  top: calc(100% + var(--wk-sp-2));
+  right: 0;
+  display: grid;
+  gap: var(--wk-sp-1);
+  width: 220px;
+  padding: var(--wk-sp-1);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  box-shadow: var(--wk-shadow-md);
+}
+
+.wk-mcp-publish-menu__panel button {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--wk-sp-2);
+  width: 100%;
+  min-width: 0;
+  padding: var(--wk-sp-2);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-text-secondary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.wk-mcp-publish-menu__panel button:hover,
+.wk-mcp-publish-menu__panel button:focus-visible {
+  outline: none;
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-primary);
+}
+
+.wk-mcp-publish-menu__panel button > svg {
+  color: var(--wk-icon-default);
+}
+
+.wk-mcp-publish-menu__panel span,
+.wk-mcp-publish-menu__panel strong,
+.wk-mcp-publish-menu__panel small {
+  display: block;
+  min-width: 0;
+}
+
+.wk-mcp-publish-menu__panel strong {
+  overflow: hidden;
+  color: var(--wk-text-strong);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-publish-menu__panel small {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Bot 上架 modal — mirrors dmworkskillmarket's .skill-market-prompt-modal.
+   头部 icon + 标题/副标题，body 灰底代码框，footer 复制按钮。 */
+.wk-mcp-prompt-modal__header {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+}
+
+.wk-mcp-prompt-modal__header h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--wk-text-strong);
+}
+
+.wk-mcp-prompt-modal__header p {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-prompt-modal__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--wk-r-md);
+  background: var(--wk-accent-tint-06, rgba(127, 59, 245, 0.06));
+  color: var(--wk-color-accent);
+}
+
+.wk-mcp-prompt-modal__body {
+  padding: var(--wk-sp-3);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  font-size: 13px;
+  line-height: 1.7;
+  max-height: 55vh;
+  overflow: auto;
+  scrollbar-width: none;
+}
+
+.wk-mcp-prompt-modal__body::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide the outer modal-body scrollbar too — the inner code area handles its
+   own scroll via max-height + overflow. Keeps the modal chrome flat. */
+.wk-mcp-prompt-modal .wk-modal-body {
+  scrollbar-width: none;
+}
+
+.wk-mcp-prompt-modal .wk-modal-body::-webkit-scrollbar {
+  display: none;
+}
+
+.wk-mcp-prompt-modal__pre {
+  margin: 0;
+  color: var(--wk-text-primary);
+  font: 13px/1.7 var(--wk-font-sans);
+  white-space: pre-wrap;
+}
+
 /* Underline-style tabs — matches skill-market-tabs. Active tab uses
    --wk-text-accent with a 2px underline pseudo-element. */
 .wk-mcp__tabs {
@@ -120,43 +263,6 @@
   align-items: center;
   gap: var(--wk-sp-3);
   flex-wrap: wrap;
-}
-
-/* 来源分段控件（issue #894）。现在落位在结果摘要行的右侧，与
-   dmworkskillmarket 的 sort 位置对齐；由父级 result-summary 的
-   justify-content: space-between 自动推到右边。 */
-.wk-mcp__source-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px;
-  border-radius: var(--wk-r-full);
-  background: var(--wk-bg-elevated);
-}
-
-.wk-mcp__source-btn {
-  display: inline-flex;
-  align-items: center;
-  height: 24px;
-  padding: 0 var(--wk-sp-3);
-  border: none;
-  border-radius: var(--wk-r-full);
-  background: transparent;
-  color: var(--wk-text-secondary);
-  font-size: var(--wk-text-size-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.wk-mcp__source-btn:hover {
-  color: var(--wk-text-primary);
-}
-
-.wk-mcp__source-btn--active {
-  background: var(--wk-bg-surface);
-  color: var(--wk-text-primary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 /* 结果摘要行 — 与 dmworkskillmarket 的 .skill-market-result-summary
@@ -305,11 +411,16 @@
   font-size: var(--wk-text-size-xs);
   opacity: 0.7;
 }
+
+/* Match-reasons chips — rendered between the card body and the footer to
+   explain WHY a search hit landed on this row when the matched field
+   (tool / usage_example / creator) isn't already visible on the card.
+   Uses a dashed accent border to distinguish from regular tags. */
 .wk-mcp-card__reasons {
   display: flex;
   flex-wrap: wrap;
   gap: var(--wk-sp-1);
-  margin-bottom: var(--wk-sp-3);
+  margin-top: var(--wk-sp-2);
 }
 
 .wk-mcp-card__reason {
@@ -330,8 +441,6 @@
   color: var(--wk-text-tertiary);
 }
 
-.wk-mcp-card mark, .wk-mcp-tag mark { background: #f59e0b; color: #fff; font-weight: var(--wk-font-semibold); padding: 0 3px; border-radius: 3px; }
-
 /* ── Card grid ───────────────────────────────────────────────────────────── */
 .wk-mcp__grid {
   display: grid;
@@ -342,7 +451,9 @@
 .wk-mcp-card {
   display: flex;
   flex-direction: column;
-  padding: var(--wk-sp-4);
+  min-width: 0;
+  min-height: 184px;
+  padding: var(--wk-sp-3);
   border: 1px solid var(--wk-border-subtle);
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-base);
@@ -353,120 +464,154 @@
     box-shadow var(--wk-dur-fast) var(--wk-ease);
 }
 
-.wk-mcp-card:hover {
+.wk-mcp-card:hover,
+.wk-mcp-card:focus-visible {
+  outline: none;
   border-color: var(--wk-border-strong);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
-.wk-mcp-card__header {
+/* Row 1: icon + header column. Matches `.skill-market-card__top`. */
+.wk-mcp-card__top {
   display: flex;
   align-items: flex-start;
-  gap: var(--wk-sp-3);
-  margin-bottom: var(--wk-sp-3);
+  gap: var(--wk-sp-2);
 }
 
 .wk-mcp-card__icon {
-  flex: none;
-  width: 40px;
-  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 22px;
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-elevated);
+  color: var(--wk-icon-default);
+  font-size: 24px;
+  overflow: hidden;
 }
 
-.wk-mcp-card__heading {
+/* Empty-icon fallback — 与 dmworkskillmarket 的 .skill-market-card__icon-default
+   一致：hash 出的实心底色 + 首两字母，白字 15px/600。 */
+.wk-mcp-card__icon-default {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  color: #fff;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+}
+
+.wk-mcp-card__header {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
   flex: 1;
+  min-width: 0;
+  min-height: 48px;
+}
+
+.wk-mcp-card__title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--wk-sp-2);
   min-width: 0;
 }
 
 .wk-mcp-card__name {
-  font-size: var(--wk-text-size-lg);
-  font-weight: var(--wk-font-semibold);
-  color: var(--wk-text-primary);
-  margin-bottom: var(--wk-sp-1);
+  display: -webkit-box;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  color: var(--wk-text-strong);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.wk-mcp-card__meta-row {
   display: flex;
   align-items: center;
-  gap: var(--wk-sp-1);
-  /* Ellipsis-clip the name so a runaway MCP name doesn't wrap and blow the
-     card height out. min-width:0 lets the text span shrink inside its
-     flex parent (the .wk-mcp-card__heading), which is a required
-     incantation for flex ellipsis to work. */
+  gap: 5px;
   min-width: 0;
-}
-
-.wk-mcp-card__name-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
-/* Provenance badge (issue #894). Rendered next to the MCP name for bot-
-   authored rows only; human/legacy rows show no chip. Reuses `.wk-mcp-tag`
-   as the base primitive (size / padding / radius / typography) and only
-   layers on the bot-specific colour and the icon-shape variant, so any
-   design-token nudge to the tag chip lands here for free. Cursor is
-   intentionally unset — the badge has no click handler; on the card it
-   inherits the parent card's pointer, and clicking still opens the detail
-   as usual. */
-.wk-mcp-source {
-  gap: 4px;
-  white-space: nowrap;
-}
-
-.wk-mcp-source__icon {
-  font-size: var(--wk-text-size-xs);
-  line-height: 1;
-}
-
-.wk-mcp-source__label {
-  max-width: 96px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.wk-mcp-source--bot {
-  /* Slightly bluer surface than plain tags to distinguish "meta" from "tag". */
-  background: rgba(56, 132, 255, 0.10);
-  color: rgba(56, 132, 255, 0.95);
-}
-
-/* Icon-only variant used in the card grid — square-ish chip, no label,
-   tooltip on hover carries the full "bot name · owner" context. */
-.wk-mcp-source--icon {
-  width: 22px;
-  padding: 0;
-  justify-content: center;
-}
-
-.wk-mcp-source--icon .wk-mcp-source__icon {
+  color: var(--wk-text-tertiary);
   font-size: 13px;
+  line-height: 1.35;
+}
+
+/* @creator / bot 名 — 与 dmworkskillmarket 的 .skill-market-card__owner 一致：
+   accent 色 + 600 字重，把发布者从灰色 meta 行里挑出来。 */
+.wk-mcp-card__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--wk-color-accent);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-card__owner-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-card__owner-bot-icon,
+.wk-mcp-card__owner-user-icon {
+  flex: 0 0 auto;
+}
+
+.wk-mcp-card__meta-separator {
+  flex: 0 0 auto;
+  color: var(--wk-text-quaternary, var(--wk-text-tertiary));
 }
 
 .wk-mcp-card__tags {
   display: flex;
-  gap: var(--wk-sp-1);
+  gap: 6px;
+  min-height: 24px;
+  margin-top: var(--wk-sp-3);
+  overflow: hidden;
+  align-items: center;
+  white-space: nowrap;
   flex-wrap: wrap;
 }
 
 .wk-mcp-tag {
   display: inline-flex;
   align-items: center;
-  height: 18px;
-  padding: 0 var(--wk-sp-1-5);
-  border-radius: var(--wk-r-sm);
+  flex: 0 1 auto;
+  max-width: 108px;
+  min-width: 0;
+  padding: 3px 8px;
+  border-radius: var(--wk-r-full);
   background: var(--wk-bg-elevated);
   color: var(--wk-text-tertiary);
-  font-size: var(--wk-text-size-xs);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wk-mcp-tag--accent {
-  background: var(--wk-ai-glow);
-  color: var(--wk-text-accent);
+  background: var(--wk-accent-tint-06, rgba(127, 59, 245, 0.06));
+  color: var(--wk-color-accent);
 }
 
 /* Detail modal slogan — same voice as the card slogan but no line clamp,
@@ -534,10 +679,11 @@
 }
 
 .wk-mcp-card__slogan {
-  font-size: var(--wk-text-size-base);
+  min-height: 42px;
+  margin: var(--wk-sp-3) 0 0;
+  font-size: 13px;
   color: var(--wk-text-secondary);
-  line-height: 1.5;
-  margin-bottom: var(--wk-sp-3);
+  line-height: 1.55;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -547,12 +693,23 @@
 .wk-mcp-card__footer {
   display: flex;
   align-items: center;
+  gap: var(--wk-sp-2);
   justify-content: space-between;
   margin-top: auto;
   padding-top: var(--wk-sp-3);
   border-top: 1px solid var(--wk-border-subtle);
   font-size: var(--wk-text-size-sm);
   color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-card__stats {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  min-width: 0;
+  color: var(--wk-text-secondary);
+  font-size: 12px;
+  line-height: 1;
 }
 
 /* 与 dmworkskillmarket 的 .skill-market-card__stat 视觉一致：
@@ -587,15 +744,20 @@
 }
 
 /* ═══ Detail modal ═════════════════════════════════════════════════════════ */
-.wk-mcp-detail__meta {
+/* ═══ Detail modal ═════════════════════════════════════════════════════════ */
+
+/* Detail modal custom header — 与 dmworkskillmarket 的
+   .skill-market-detail-header 对齐：图标 + 标题行（h2 + 分类 chip）+
+   meta 行（作者 · 更新时间）。 */
+.wk-mcp-detail-header {
   display: flex;
   align-items: flex-start;
   gap: var(--wk-sp-3);
-  margin-bottom: var(--wk-sp-5);
+  padding: var(--wk-sp-4) var(--wk-sp-5) var(--wk-sp-3);
 }
 
-.wk-mcp-detail__icon {
-  flex: none;
+.wk-mcp-detail-header__icon {
+  flex: 0 0 48px;
   width: 48px;
   height: 48px;
   display: flex;
@@ -604,26 +766,73 @@
   font-size: 26px;
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-elevated);
+  overflow: hidden;
 }
 
-.wk-mcp-detail__meta-main {
+.wk-mcp-detail-header__main {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wk-mcp-detail-header__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
   min-width: 0;
 }
 
-/* meta 行：@owner + Bot 徽章。工具数量已下沉到 slogan 之下的 stats 行。 */
-.wk-mcp-detail__meta-line {
+.wk-mcp-detail-header__title {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--wk-text-strong);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-detail-header__badge {
   display: inline-flex;
   align-items: center;
-  gap: var(--wk-sp-1);
-  font-size: var(--wk-text-size-sm);
+  flex: 0 0 auto;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: var(--wk-r-full);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.wk-mcp-detail-header__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
   color: var(--wk-text-tertiary);
-  margin-top: var(--wk-sp-1);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.wk-mcp-detail-header__updated {
+  flex: 0 0 auto;
+  color: var(--wk-text-tertiary);
 }
 
 /* @creator 段 — 与 dmworkskillmarket 的 .skill-market-card__owner 视觉一致：
    accent 色 + 600 字重，把发布者从灰色 meta 行里挑出来。 */
 .wk-mcp-detail__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--wk-color-accent);
   font-weight: 600;
 }
@@ -634,16 +843,19 @@
   display: flex;
   align-items: center;
   gap: var(--wk-sp-3);
-  margin-top: var(--wk-sp-2);
+  margin-top: var(--wk-sp-3);
   font-size: var(--wk-text-size-sm);
   color: var(--wk-text-tertiary);
 }
 
-.wk-mcp-detail__desc {
-  font-size: var(--wk-text-size-base);
-  color: var(--wk-text-secondary);
-  line-height: 1.6;
-  margin-bottom: var(--wk-sp-5);
+/* 详情页尾部的 tags — 与 dmworkskillmarket 的详情弹窗一致，放在
+   slogan + stats 后面，作为标签兜底展示。 */
+.wk-mcp-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--wk-sp-3);
+  margin-bottom: var(--wk-sp-3);
 }
 
 .wk-mcp-section {
@@ -1199,6 +1411,9 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  max-width: 140px;
+  min-width: 0;
+  overflow: hidden;
   height: 22px;
   padding: 0 var(--wk-sp-2);
   border-radius: var(--wk-r-full);
@@ -1207,7 +1422,15 @@
   font-size: var(--wk-text-size-xs);
 }
 
+.wk-mcp-tags__chip-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .wk-mcp-tags__chip-remove {
+  flex: 0 0 auto;
   background: none;
   border: none;
   padding: 0;

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -519,13 +519,12 @@
 
 .wk-mcp-card__title-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--wk-sp-2);
   min-width: 0;
 }
 
 .wk-mcp-card__name {
-  display: -webkit-box;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -534,8 +533,8 @@
   font-size: 16px;
   font-weight: 700;
   line-height: 1.35;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wk-mcp-card__meta-row {

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -1,13 +1,15 @@
 import React, { Component } from "react";
 import { Spin, Toast } from "@douyinfe/semi-ui";
-import { IconSearch, IconPlus, IconClose } from "@douyinfe/semi-icons";
+import { IconSearch, IconClose } from "@douyinfe/semi-icons";
+import { Bot, ChevronDown, Upload } from "lucide-react";
 import { I18nContext, t, WKApp, WKButton } from "@octo/base";
 import { fetchMcpList, fetchMcpMine } from "../api/mcpService";
 import { mcpListErrorI18nKey } from "../api/mcpListError";
-import type { McpCategory, McpCreatedByType, McpDetail, McpListItem } from "../types/mcp";
+import type { McpCategory, McpDetail, McpListItem } from "../types/mcp";
 import McpCard from "../components/McpCard";
 import McpDetailModal from "../components/McpDetailModal";
 import McpCreateModal from "../components/McpCreateModal";
+import McpBotPublishModal from "../components/McpBotPublishModal";
 import "../index.css";
 import { parseMcpListQuery, serializeMcpListQuery } from "./mcpListQuery";
 
@@ -19,18 +21,6 @@ const PAGE_SIZE = 20;
 /** Fire the next page when the user scrolls within this many px of bottom. */
 const SCROLL_THRESHOLD_PX = 200;
 
-/** Source (来源) segmented control options. Module-level const so the array
- *  is stable across renders — otherwise every parent update re-allocates it
- *  and defeats any downstream memoisation on the pills. */
-const SOURCE_FILTER_OPTIONS: ReadonlyArray<{
-  value: McpCreatedByType | undefined;
-  labelKey: string;
-}> = [
-  { value: undefined, labelKey: "mcp.list.source.all" },
-  { value: "human", labelKey: "mcp.source.human" },
-  { value: "bot", labelKey: "mcp.source.bot" },
-];
-
 interface McpMarketListPageState {
   items: McpListItem[];
   categories: McpCategory[];
@@ -39,13 +29,16 @@ interface McpMarketListPageState {
   error: string | null;
   keyword: string;
   categoriesSelected: string[];
-  /** Provenance filter (issue #894). Single-select; undefined = 全部来源. */
-  createdByType?: McpCreatedByType;
   mode: ListMode;
   offset: number;
   total: number;
   detailId: string | null;
   createVisible: boolean;
+  /** Dropdown-menu open state for the "上架 MCP" button. Mirrors Skill's
+   *  `publishMenuOpen`. */
+  publishMenuOpen: boolean;
+  /** Bot 上架 modal open state. */
+  botPublishVisible: boolean;
   /** When set, the create/edit modal opens in EDIT mode prefilled from this
    *  detail. Cleared on modal close. Distinct from `createVisible` — this
    *  drives the "editing" branch of the shared modal component. */
@@ -71,14 +64,17 @@ export default class McpMarketListPage extends Component<
     error: null,
     keyword: "",
     categoriesSelected: [],
-    createdByType: undefined,
     mode: "all",
     offset: 0,
     total: 0,
     detailId: null,
     createVisible: false,
+    publishMenuOpen: false,
+    botPublishVisible: false,
     editingDetail: null,
   };
+
+  private publishMenuRef = React.createRef<HTMLDivElement>();
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private requestVersion = 0;
@@ -90,11 +86,47 @@ export default class McpMarketListPage extends Component<
     WKApp.mittBus.on("space-changed", this.handleSpaceChanged_);
   }
 
+  componentDidUpdate(_prevProps: {}, prevState: McpMarketListPageState) {
+    // Only own the two global listeners while the publish dropdown is open —
+    // mirrors dmworkskillmarket's SkillListPage. Attaching in componentDidMount
+    // unconditionally forces every card click / scroll on the page to trip
+    // through a no-op guard for the 99% of the session where the menu is
+    // closed.
+    if (prevState.publishMenuOpen !== this.state.publishMenuOpen) {
+      if (this.state.publishMenuOpen) {
+        document.addEventListener("pointerdown", this.handleGlobalPointerDown_);
+        document.addEventListener("keydown", this.handleGlobalKeyDown_);
+      } else {
+        document.removeEventListener("pointerdown", this.handleGlobalPointerDown_);
+        document.removeEventListener("keydown", this.handleGlobalKeyDown_);
+      }
+    }
+  }
+
   componentWillUnmount() {
     WKApp.mittBus.off("wk:nav-menu-activated", this.handleNavMenuActivated_);
     WKApp.mittBus.off("space-changed", this.handleSpaceChanged_);
+    // Idempotent — safe if the menu was closed at unmount.
+    document.removeEventListener("pointerdown", this.handleGlobalPointerDown_);
+    document.removeEventListener("keydown", this.handleGlobalKeyDown_);
     if (this.searchTimer) clearTimeout(this.searchTimer);
   }
+
+  /** Close the publish dropdown on outside click. Attached only while
+   *  publishMenuOpen (see componentDidUpdate). */
+  private handleGlobalPointerDown_ = (e: PointerEvent) => {
+    if (!this.publishMenuRef.current?.contains(e.target as Node)) {
+      this.setState({ publishMenuOpen: false });
+    }
+  };
+
+  /** Close the publish dropdown on Escape. Attached only while
+   *  publishMenuOpen (see componentDidUpdate). */
+  private handleGlobalKeyDown_ = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      this.setState({ publishMenuOpen: false });
+    }
+  };
 
   private handleSpaceChanged_ = () => this.loadData();
 
@@ -114,7 +146,6 @@ export default class McpMarketListPage extends Component<
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
-        createdByType: this.state.createdByType,
         limit: PAGE_SIZE,
         offset: 0,
       });
@@ -151,22 +182,19 @@ export default class McpMarketListPage extends Component<
     const requestVersion = this.requestVersion;
     const requestKeyword = this.state.keyword;
     const requestCategories = this.state.categoriesSelected.join(",");
-    const requestCreatedBy = this.state.createdByType ?? "";
     this.setState({ loadingMore: true });
     try {
       const fetcher = this.state.mode === "mine" ? fetchMcpMine : fetchMcpList;
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
-        createdByType: this.state.createdByType,
         limit: PAGE_SIZE,
         offset,
       });
       if (
         requestVersion !== this.requestVersion ||
         requestKeyword !== this.state.keyword ||
-        requestCategories !== this.state.categoriesSelected.join(",") ||
-        requestCreatedBy !== (this.state.createdByType ?? "")
+        requestCategories !== this.state.categoriesSelected.join(",")
       ) {
         return;
       }
@@ -200,7 +228,7 @@ export default class McpMarketListPage extends Component<
 
   private handleMode = (mode: ListMode) => {
     if (mode === this.state.mode) return;
-    this.setState({ mode, categoriesSelected: [], createdByType: undefined }, () => this.loadData());
+    this.setState({ mode, categoriesSelected: [] }, () => this.loadData());
   };
 
   /** Patch a single row after a successful edit — keeps scroll position
@@ -265,13 +293,6 @@ export default class McpMarketListPage extends Component<
     }), () => this.loadData());
   };
 
-  /** Toggle the "来源" segmented filter (issue #894). value === undefined
-   *  means the 全部 pill. */
-  private handleCreatedBy = (value: McpCreatedByType | undefined) => {
-    if (value === this.state.createdByType) return;
-    this.setState({ createdByType: value }, () => this.loadData());
-  };
-
   render() {
     const {
       items,
@@ -281,7 +302,6 @@ export default class McpMarketListPage extends Component<
       error,
       keyword,
       categoriesSelected,
-      createdByType,
       mode,
       total,
       detailId,
@@ -335,13 +355,50 @@ export default class McpMarketListPage extends Component<
                 )}
               </div>
             </div>
-            <WKButton
-              variant="primary"
-              icon={<IconPlus />}
-              onClick={() => this.setState({ createVisible: true })}
-            >
-              {t("mcp.list.create")}
-            </WKButton>
+            <div className="wk-mcp-publish-menu" ref={this.publishMenuRef}>
+              <WKButton
+                variant="primary"
+                icon={<Upload size={15} />}
+                onClick={() =>
+                  this.setState((prev) => ({ publishMenuOpen: !prev.publishMenuOpen }))
+                }
+                aria-haspopup="menu"
+                aria-expanded={this.state.publishMenuOpen}
+              >
+                {t("mcp.list.create")}
+                <ChevronDown size={14} />
+              </WKButton>
+              {this.state.publishMenuOpen && (
+                <div className="wk-mcp-publish-menu__panel" role="menu">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() =>
+                      this.setState({ publishMenuOpen: false, botPublishVisible: true })
+                    }
+                  >
+                    <Bot size={16} />
+                    <span>
+                      <strong>{t("mcp.publishMenu.botTitle")}</strong>
+                      <small>{t("mcp.publishMenu.botHint")}</small>
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() =>
+                      this.setState({ publishMenuOpen: false, createVisible: true })
+                    }
+                  >
+                    <Upload size={16} />
+                    <span>
+                      <strong>{t("mcp.publishMenu.manualTitle")}</strong>
+                      <small>{t("mcp.publishMenu.manualHint")}</small>
+                    </span>
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </header>
 
@@ -390,35 +447,6 @@ export default class McpMarketListPage extends Component<
                   >
                     {t("mcp.list.total", { values: { count: total } })}
                   </span>
-                  {/* 来源筛选 — 单选分段控件，放在结果摘要的右侧，跟
-                      dmworkskillmarket 的 sort 位置一致。「全部来源」= 清除筛选。
-                      即使当前结果为空也保留，方便用户放宽筛选。 */}
-                  <div
-                    className="wk-mcp__source-filter"
-                    role="group"
-                    aria-label={t("mcp.list.source.filterLabel")}
-                  >
-                    {SOURCE_FILTER_OPTIONS.map(({ value, labelKey }) => {
-                      const active =
-                        value === undefined
-                          ? createdByType === undefined
-                          : createdByType === value;
-                      return (
-                        <button
-                          key={value ?? "all"}
-                          type="button"
-                          className={
-                            active
-                              ? "wk-mcp__source-btn wk-mcp__source-btn--active"
-                              : "wk-mcp__source-btn"
-                          }
-                          onClick={() => this.handleCreatedBy(value)}
-                        >
-                          {t(labelKey)}
-                        </button>
-                      );
-                    })}
-                  </div>
                 </div>
                 {items.length === 0 ? (
                   <div className="wk-mcp__state">{t("mcp.list.empty")}</div>
@@ -429,7 +457,6 @@ export default class McpMarketListPage extends Component<
                         <McpCard
                           key={item.id}
                           item={item}
-                          keyword={keyword}
                           onClick={(it) => this.setState({ detailId: it.id })}
                         />
                       ))}
@@ -468,6 +495,10 @@ export default class McpMarketListPage extends Component<
             this.setState({ createVisible: false, editingDetail: null })
           }
           onSaved={this.handleSaved}
+        />
+        <McpBotPublishModal
+          visible={this.state.botPublishVisible}
+          onClose={() => this.setState({ botPublishVisible: false })}
         />
       </div>
     );

--- a/packages/dmworkmcp/src/pages/mcpListQuery.ts
+++ b/packages/dmworkmcp/src/pages/mcpListQuery.ts
@@ -1,36 +1,22 @@
-import type { McpCreatedByType } from "../types/mcp";
-
 export interface McpListQueryState {
   keyword: string;
   categoriesSelected: string[];
-  /** Provenance filter (issue #894). Single-select — undefined = 全部来源.
-   *  Only `human` and `bot` round-trip today because those are the only
-   *  segmented-control pills the toolbar renders; `import` from the wire
-   *  enum is intentionally dropped on parse so we can't end up with an
-   *  active filter that no pill can display or clear (a shared URL with
-   *  ?created_by_type=import would otherwise render every pill inactive
-   *  while the list is silently filtered). When #867 lands and the toolbar
-   *  gains an "Imported" pill, add `import` to the allowlist below. */
-  createdByType?: McpCreatedByType;
 }
 
 export function parseMcpListQuery(search: string): McpListQueryState {
   const q = new URLSearchParams(search);
-  const raw = q.get("created_by_type");
-  const createdByType: McpCreatedByType | undefined =
-    raw === "human" || raw === "bot" ? raw : undefined;
   return {
     keyword: q.get("keyword") ?? "",
     categoriesSelected: q.getAll("category"),
-    createdByType,
   };
 }
 
 export function serializeMcpListQuery(state: McpListQueryState, current = ""): string {
   const q = new URLSearchParams(current);
+  // `created_by_type` scrubbed too — legacy bookmarks land silently on
+  // the unfiltered list rather than carrying a filter no UI can toggle.
   ["keyword", "category", "created_by_type"].forEach((key) => q.delete(key));
   if (state.keyword.trim()) q.set("keyword", state.keyword.trim());
   state.categoriesSelected.forEach((value) => q.append("category", value));
-  if (state.createdByType) q.set("created_by_type", state.createdByType);
   return q.toString();
 }

--- a/packages/dmworkmcp/src/utils/mcpAvatar.ts
+++ b/packages/dmworkmcp/src/utils/mcpAvatar.ts
@@ -1,0 +1,74 @@
+// Hash-based color + text generation for MCP default avatars, used when
+// item.icon is empty. Mirrors dmworkskillmarket's skillAvatar.ts approach
+// but keys color off `id` (per issue #1009 clarification) so two MCPs with
+// the same display name still get distinct backgrounds.
+
+const AVATAR_COLORS = [
+  "#34C759", // 绿
+  "#6569E8", // 紫
+  "#FA8C16", // 橙
+  "#1AC4B3", // 青
+  "#B3D600", // 黄绿
+  "#5B9BF5", // 蓝
+];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (const ch of s) {
+    h = (h * 31 + (ch.codePointAt(0) ?? 0)) >>> 0;
+  }
+  return h;
+}
+
+/** Deterministic background color for an MCP with no icon. Keyed on id
+ *  (not name) so duplicate-named rows still get distinct swatches. */
+export function getMcpAvatarColor(id: string): string {
+  return AVATAR_COLORS[hashString(id || "") % AVATAR_COLORS.length];
+}
+
+function isWideChar(ch: string): boolean {
+  const c = ch.codePointAt(0) ?? 0;
+  return (
+    (c >= 0x1100 && c <= 0x115f) ||
+    (c >= 0x2e80 && c <= 0xa4cf) ||
+    (c >= 0xac00 && c <= 0xd7a3) ||
+    (c >= 0xf900 && c <= 0xfaff) ||
+    (c >= 0xff00 && c <= 0xff60)
+  );
+}
+
+function visibleChars(s: string): string[] {
+  const out: string[] = [];
+  for (const ch of s) {
+    if (!/\s/.test(ch)) out.push(ch);
+  }
+  return out;
+}
+
+/**
+ * Extract 1-2 display chars for the MCP avatar fallback:
+ *   - Contains CJK → first 2 wide chars
+ *   - All digits → first 2 digits
+ *   - Contains letters → up to 2 uppercase initials (split on `- _ . space`)
+ *   - Otherwise → first char uppercase
+ */
+export function getMcpAvatarText(name: string): string {
+  const chars = visibleChars(name);
+  if (chars.length === 0) return "M";
+
+  const wide = chars.filter(isWideChar);
+  if (wide.length > 0) return wide.slice(0, 2).join("");
+
+  if (chars.every((c) => /[0-9]/.test(c))) return chars.slice(0, 2).join("");
+
+  if (chars.some((c) => /[a-zA-Z]/.test(c))) {
+    const parts = name.split(/[-_\s.]+/).filter(Boolean);
+    const initials = parts
+      .slice(0, 2)
+      .map((p) => p.charAt(0).toUpperCase())
+      .join("");
+    return initials || chars[0].toUpperCase();
+  }
+
+  return chars[0].toUpperCase();
+}

--- a/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
+++ b/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
@@ -1,0 +1,73 @@
+export interface McpBotPublishPromptValues {
+  spaceId?: string;
+  apiBaseUrl?: string;
+}
+
+/** Normalize the API base URL: trust the configured API URL when it's a full
+ *  origin, otherwise fall back to the page origin. Mirrors dmworkskillmarket's
+ *  resolveAPIBaseURL so Skill and MCP bot prompts point at the same backend. */
+export function resolveMcpAPIBaseURL(apiURL: string, origin: string): string {
+  const target = new URL(apiURL || origin, origin);
+  return target.origin;
+}
+
+/** Build the prompt handed to a bot to publish an MCP server listing.
+ *
+ *  Command surface is verified against octo-cli's embedded `octo-marketplace`
+ *  Skill (`skills/octo-marketplace/mcp.md`). Unlike Skill publishing there is
+ *  no dedicated bot endpoint — the bot uses the same `marketplace mcp create`
+ *  command as any owner, so this prompt directs it to that Skill's Create
+ *  workflow instead of a "Publish as a Bot" section that doesn't exist for
+ *  MCP. */
+export function getMcpBotPublishPrompt(values: McpBotPublishPromptValues = {}): string {
+  const spaceId = values.spaceId?.trim() || "<space-id>";
+  const apiBaseUrl = values.apiBaseUrl?.trim() || "<api-base-url>";
+
+  return `使用 octo-cli 内置的 \`octo-marketplace\` Skill，将指定 MCP 服务器上架到 OCTO Marketplace。
+
+- Space ID：\`${spaceId}\`
+- API 地址：\`${apiBaseUrl}\`
+- 可见范围：\`space\`
+
+如果当前消息没有 MCP 配置信息或路径，只回复：
+
+> 请提供要上架的 MCP 服务器信息（名称、传输方式 stdio/streamable-http/sse、URL 或启动命令、可选 headers / env），
+> 或提供一个 Agent 当前运行环境可访问的 MCP 配置文件路径。
+
+不要解释正在读取内容、复述本 Prompt 或逐步播报检查过程。用户提供前不要搜索磁盘或猜测路径。
+
+1. 运行 \`octo-cli version\`。如果未安装，运行
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
+
+2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
+   如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
+   通过 stdin 登录或更新固定 Profile \`space-${spaceId}\`：
+
+   \`\`\`bash
+   <read-token> | octo-cli auth login --with-token --profile space-${spaceId} --space ${spaceId} --api-base-url ${apiBaseUrl}
+   \`\`\`
+
+   不得输出 Token 或把 Token 放入命令参数。
+
+3. 读取并遵循最新的 \`octo-marketplace\` Skill 中的 \`mcp.md\`：
+
+   \`\`\`bash
+   octo-cli skills octo-marketplace --profile <profile>
+   \`\`\`
+
+4. 按 \`mcp.md\` 的 Create 流程完成上架：
+
+   - 运行 \`octo-cli marketplace mcp-category list --mode all --profile <profile>\`
+     拿到合法的 \`category\` key（不要用 \`all\` 或空串作分类）。
+   - \`streamable-http\` / \`sse\` 传输：先把 \`transport\` / \`url\` / 可选 \`headers\` / \`env\`
+     写入 \`connection.json\`，运行
+     \`octo-cli marketplace mcp probe --data @connection.json --profile <profile>\`，
+     确认 \`is_ok=true\` 再继续。\`stdio\` 传输不要调用 probe。
+   - 编写 \`mcp.json\`：目录字段（\`name\` / \`slogan\` / \`category\` / \`tags\` / \`icon\` 等）
+     + \`transport\` + 对应连接字段。消费者需自行填入的密钥放进
+     \`env_user_supplied\` / \`headers_user_supplied\`，对应值提交空字符串。
+   - 运行 \`octo-cli marketplace mcp create --data @mcp.json --profile <profile>\` 完成上架，
+     用返回的 \`mcp_id\` 通过 \`marketplace mcp get <mcp-id>\` 复核。
+
+以上 Space ID、API 地址和可见范围是本次操作的权威输入。`;
+}

--- a/packages/dmworkmcp/src/utils/mcpTagValidation.ts
+++ b/packages/dmworkmcp/src/utils/mcpTagValidation.ts
@@ -1,0 +1,45 @@
+import { t } from "@octo/base";
+
+/** Max number of tags allowed on a single MCP entry (mirrors dmworkskillmarket
+ *  after PR #1026 raised it from 5 to 10). Applied both in the create/edit
+ *  form and as a defensive submit-time guard for legacy oversized sets. */
+export const MAX_MCP_TAGS = 10;
+export const MAX_MCP_TAG_LENGTH = 24;
+
+/** Same allowlist as dmworkskillmarket — letters, digits, whitespace,
+ *  and `- _ / . # +`. Anything else is rejected. */
+const MCP_TAG_PATTERN = /^[\p{L}\p{N} _./#+-]+$/u;
+
+/** Count characters as visible code points (so wide CJK chars each count as 1
+ *  toward MAX_MCP_TAG_LENGTH instead of by UTF-16 units). */
+export function tagLength(value: string): number {
+  return Array.from(value).length;
+}
+
+/** Validate a single tag string. Returns an error message or null when OK.
+ *  Empty tags return null so callers can decide whether to add them. */
+export function validateMcpTag(value: string): string | null {
+  const tag = value.trim();
+  if (!tag) return null;
+  if (tagLength(tag) > MAX_MCP_TAG_LENGTH) {
+    return t("mcp.form.tagLengthLimit", { values: { count: MAX_MCP_TAG_LENGTH } });
+  }
+  if (!MCP_TAG_PATTERN.test(tag)) {
+    return t("mcp.form.tagInvalidChars");
+  }
+  return null;
+}
+
+/** Validate the full tags array — blocks the save button when a legacy row
+ *  is loaded with too many tags or a tag that violates the pattern/length
+ *  rule. Returns the first error message encountered, or null when clean. */
+export function validateMcpTags(tags: string[]): string | null {
+  if (tags.length > MAX_MCP_TAGS) {
+    return t("mcp.form.tagLimit", { values: { count: MAX_MCP_TAGS } });
+  }
+  for (const tag of tags) {
+    const error = validateMcpTag(tag);
+    if (error) return error;
+  }
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,6 +768,9 @@ importers:
       classnames:
         specifier: ^2.3.1
         version: 2.5.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@17.0.2)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -10261,7 +10264,6 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
@@ -17802,7 +17804,7 @@ snapshots:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -17827,7 +17829,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.28.0(eslint@7.32.0)
@@ -17861,7 +17863,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 7.32.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.11
@@ -17880,6 +17882,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
@@ -17888,7 +17900,7 @@ snapshots:
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17912,6 +17924,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Summary

Aligns the MCP marketplace page (list card, detail modal, top toolbar) with the Skill marketplace so the two tabs render as siblings under one shell. Adds a Bot 上架 dropdown / prompt modal mirroring Skill's, backports the tag / title overflow guards from PR #1026, and drops the 来源 segmented filter (人工/Bot were identical to users).

Highlights:

- **McpCard**: 2-line title clamp, 48px icon, 12px card padding, rounded-pill accent tags. Empty-icon fallback = hash-color square + first 2 name chars. Owner meta row shows `<Bot> botname · <UserRound> humanname` for bot rows and `<UserRound> humanname` for human rows; `import` rows show no owner chip. MatchReasons chips restored for tool / usage / creator hits (fields the card body doesn't already show).
- **McpDetailModal**: custom WKModal header (icon + h3 + category chip + owner/updated meta row). Slogan / stats / tags moved into the body under the header. `formatUpdatedTime` guards future timestamps. Category badge falls back to the raw slug when i18n is missing.
- **Top toolbar**: `上架 MCP` primary button + dropdown (`Bot 上架` / `手动上架`), matching Skill's shape. 来源筛选器整段删除。
- **Bot publish flow**: new `McpBotPublishModal` + `mcpBotPublishPrompt`. Prompt content is verified against octo-cli's embedded `octo-marketplace` Skill (`skills/octo-marketplace/mcp.md`) — uses `marketplace mcp create` / `mcp probe` / `mcp-category list`, not the Skill-specific `bot skills publish`. Handles clipboard rejection, missing-space-id, and timer-cleanup edge cases.
- **Tag validation (PR #1026 backport)**: `MAX_MCP_TAGS = 10`, `MAX_MCP_TAG_LENGTH = 24`, allowlist matches Skill's. TagsInput splits paste on commas, per-tag validation gates commit, `handleSubmit` re-validates the full array so legacy oversized rows can't save silently.

## Linked Spec

- Fixes https://github.com/Mininglamp-OSS/octo-web/issues/1009 (\"[UI一致性] MCP市场页面UI需与Skill市场保持一致\")
- Refs https://github.com/Mininglamp-OSS/octo-web/issues/1017 (Skill tag/title overflow), backported via https://github.com/Mininglamp-OSS/octo-web/pull/1026

## How verified

Manual verification on test env (\`https://im-test.deepminer.com.cn/mcp-market/mcp\`) via a local Vite dev server proxied to the same backend. Golden paths exercised:

- List renders 40+ MCPs across bot / human / empty-icon rows; owner row displays correctly for each provenance
- Search \`tool\` returns \`mixreach-mcp-tools\` variants with MatchReasons chips showing hit fields
- Category chip switches (`全部` / `开发工具` / etc.) update the count and re-fetch
- Detail modal opens for Slack Notifier Bot and other rows; header + owner + tags + slogan + tool count render in Skill-parity order
- Publish dropdown opens; `Bot 上架` shows the copy-prompt modal with the current Space ID substituted; `手动上架` opens the create form
- Create-form tag input rejects `>10` tags, `>24` char tags, non-allowlisted chars, and paste of `a,b,c` splits into three chips
- No new TS errors introduced (verified via \`git stash\` + baseline compare); Vite HMR compiles all touched files

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

    - Card + detail modal render structure changes (DOM + CSS). Search + list fetch flow is unchanged; the removed `createdByType` filter param is still accepted by `fetchMcpList`/`fetchMcpMine`, just no longer sent.
    - New save-time validation in `McpCreateModal.handleSubmit` blocks submit when `validateMcpTags(form.tags)` returns an error, so legacy MCP records with `>10` tags or invalid tag content cannot be saved via the edit form until fixed. Toast surfaces the specific error.
    - `mcpListQuery.ts` no longer round-trips `created_by_type` — legacy bookmarked URLs with `?created_by_type=bot` render the unfiltered list.

2. **What could break** (dependents + failure mode)?

    - **`McpDetailModal` header prop** — WKModal receives both `title={null}` and `header={detailHeader}` when detail loads; verified in `packages/dmworkbase/src/Components/WKModal/index.tsx` that `customHeader` takes precedence over `title`. Loading state (detail=null) passes `title=t('mcp.detail.title')` with `header={null}` and falls back to the default title bar.
    - **Bot 上架 prompt correctness** — the prompt hard-codes `octo-cli marketplace mcp create` and references the `octo-marketplace` Skill's `mcp.md`. If octo-cli renames those commands or extracts a dedicated `octo-mcp-marketplace` Skill, the prompt drifts. Change site is a single template string in `utils/mcpBotPublishPrompt.ts`.
    - **Tag validation UX** — a user opening an existing MCP with legacy `>10` tags or a legacy oversize tag will see save blocked and a Toast until they trim. Documented in the file comment; matches PR #1026's Skill behavior.
    - **Clipboard availability** — on `http://` origins or older WebViews the copy button calls `Toast.error(t('mcp.botPublish.copyUnavailable'))` instead of silently no-oping.

3. **How do you know it works**?

    - Local Vite dev server against real test backend (`im-test.deepminer.com.cn`) — every card variant (bot / human / empty-icon / long-title) rendered correctly across 40 real MCP rows
    - Detail modal opened for Slack Notifier Bot: header shows `[icon] Slack Notifier Bot [效率协作]` + `🤖 Slack Notifier · 👤 Developer · 1 天前更新`, tags at the bottom
    - Search `tool` shows MatchReasons chips (`命中工具 curve_result_file_query`) on the three matching rows
    - Create modal tag input tested for paste-split (`a,b,c` → 3 chips), over-limit (`>10` blocks with Toast), invalid chars (`foo!bar` blocks)
    - Cross-package code-review pass (Agents A / B / C / D / E / F / G): 10 findings surfaced and all applied in the same commit (whitespace-icon fallback, timer cleanup, clipboard error handling, listener attach-when-open, category label fallback, provenance import guard, future-timestamp guard, paste-tag split, copy button disabled when spaceId empty, dead-code deletion for `.wk-mcp-source*` / `.wk-mcp__source-filter*` / `.wk-mcp-detail__meta*` / `SourceBadge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)