### PR TITLE
feat(mcp): show and track view counts

### DIFF
--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -285,6 +285,7 @@ function buildDetailFromCreate(id: string, params: CreateMcpParams): McpDetail {
     category: params.category,
     tags: params.tags ?? [],
     toolCount: params.tools.length,
+    viewCount: 0,
     icon: params.icon,
     creatorName: WKApp.loginInfo?.name || "",
     quickStart,
@@ -306,6 +307,7 @@ function projectListItem(d: McpDetail): McpListItem {
     category: d.category,
     tags: d.tags,
     toolCount: d.toolCount,
+    viewCount: d.viewCount,
     icon: d.icon,
     createdByType: d.createdByType,
     createdByBotUid: d.createdByBotUid,
@@ -394,7 +396,10 @@ mcpAxios.interceptors.request.use((config) => {
 mcpAxios.interceptors.response.use(
   (resp) => resp,
   (err) => {
-    if (err?.response?.status === 401) {
+    const config = err?.config as (AxiosRequestConfig & {
+      skipGlobalAuthFailure?: boolean;
+    }) | undefined;
+    if (err?.response?.status === 401 && !config?.skipGlobalAuthFailure) {
       WKApp.shared.logout();
     }
     return Promise.reject(err);
@@ -508,6 +513,7 @@ interface McpListItemWire {
   icon: string;
   tags: string[];
   tool_count: number;
+  view_count?: number;
   visibility?: McpListItem["visibility"];
   creator_name?: string;
   created_by_type?: McpListItem["createdByType"];
@@ -566,6 +572,7 @@ function mapListItem(raw: McpListItemWire): McpListItem {
     icon: raw.icon,
     tags: raw.tags ?? [],
     toolCount: raw.tool_count ?? 0,
+    viewCount: normalizeCount(raw.view_count),
     visibility: raw.visibility,
     creatorName: raw.creator_name,
     createdByType: raw.created_by_type,
@@ -576,6 +583,12 @@ function mapListItem(raw: McpListItemWire): McpListItem {
     matchReasons: raw.match_reasons ?? [], relevance: raw.relevance,
     updatedAt: raw.updated_at,
   };
+}
+
+export function normalizeCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
 }
 
 function mapDetail(raw: McpDetailWire): McpDetail {
@@ -705,6 +718,16 @@ async function fetchMcpListPath(
 
 async function fetchMcpDetailReal(id: string): Promise<McpDetail> {
   return get<McpDetailWire>(`/mcps/${encodeURIComponent(id)}`).then(mapDetail);
+}
+
+async function trackMcpViewReal(id: string): Promise<void> {
+  await mcpAxios.post(
+    `${BASE}/metrics/track`,
+    { resource_type: "mcp", resource_id: id, event_type: "view" },
+    { skipGlobalAuthFailure: true } as AxiosRequestConfig & {
+      skipGlobalAuthFailure: boolean;
+    }
+  );
 }
 
 async function probeMcpToolsReal(
@@ -872,6 +895,11 @@ export function fetchMcpMine(
 
 export function fetchMcpDetail(id: string): Promise<McpDetail> {
   return USE_MOCK ? fetchMcpDetailMock(id) : fetchMcpDetailReal(id);
+}
+
+export async function trackMcpView(id: string): Promise<void> {
+  if (USE_MOCK) return;
+  await trackMcpViewReal(id);
 }
 
 /** One tag suggestion in the tag-filter popover (mcp-v1.md §4.8). */

--- a/packages/dmworkmcp/src/api/mcpService.viewCount.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.viewCount.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const post = vi.fn();
-const get = vi.fn();
-const logout = vi.fn();
-let responseRejected: ((error: unknown) => Promise<never>) | undefined;
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+  get: vi.fn(),
+  logout: vi.fn(),
+  responseRejected: undefined as ((error: unknown) => Promise<never>) | undefined,
+}));
 
 vi.mock("axios", () => ({
   default: {
@@ -13,12 +15,12 @@ vi.mock("axios", () => ({
         request: { use: vi.fn() },
         response: {
           use: vi.fn((_fulfilled, rejected) => {
-            responseRejected = rejected;
+            mocks.responseRejected = rejected;
           }),
         },
       },
-      get,
-      post,
+      get: mocks.get,
+      post: mocks.post,
       patch: vi.fn(),
       delete: vi.fn(),
     }),
@@ -30,7 +32,7 @@ vi.mock("@octo/base", () => ({
   WKApp: {
     apiClient: { config: {} },
     loginInfo: {},
-    shared: { currentSpaceId: "space-a", logout },
+    shared: { currentSpaceId: "space-a", logout: mocks.logout },
     mittBus: { on: () => {}, off: () => {}, emit: () => {} },
   },
   buildAcceptLanguage: () => "en-US",
@@ -58,7 +60,7 @@ describe("MCP view count service", () => {
   });
 
   it("maps view_count for list and detail responses", async () => {
-    get
+    mocks.get
       .mockResolvedValueOnce({
         data: {
           data: [{ mcp_id: "m1", name: "MCP", slogan: "", category: "dev", icon: "", tags: [], tool_count: 1, view_count: 7.8 }],
@@ -80,18 +82,18 @@ describe("MCP view count service", () => {
   });
 
   it("posts the metrics payload and suppresses global logout for its 401", async () => {
-    post.mockResolvedValue({ data: { data: null } });
+    mocks.post.mockResolvedValue({ data: { data: null } });
     await trackMcpView("mcp/1");
 
-    expect(post).toHaveBeenCalledWith(
+    expect(mocks.post).toHaveBeenCalledWith(
       "/market/api/v1/metrics/track",
       { resource_type: "mcp", resource_id: "mcp/1", event_type: "view" },
       { skipGlobalAuthFailure: true }
     );
 
-    await expect(responseRejected?.({ response: { status: 401 }, config: { skipGlobalAuthFailure: true } })).rejects.toBeTruthy();
-    expect(logout).not.toHaveBeenCalled();
-    await expect(responseRejected?.({ response: { status: 401 }, config: {} })).rejects.toBeTruthy();
-    expect(logout).toHaveBeenCalledTimes(1);
+    await expect(mocks.responseRejected?.({ response: { status: 401 }, config: { skipGlobalAuthFailure: true } })).rejects.toBeTruthy();
+    expect(mocks.logout).not.toHaveBeenCalled();
+    await expect(mocks.responseRejected?.({ response: { status: 401 }, config: {} })).rejects.toBeTruthy();
+    expect(mocks.logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.viewCount.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.viewCount.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const post = vi.fn();
+const get = vi.fn();
+const logout = vi.fn();
+let responseRejected: ((error: unknown) => Promise<never>) | undefined;
+
+vi.mock("axios", () => ({
+  default: {
+    create: () => ({
+      defaults: {},
+      interceptors: {
+        request: { use: vi.fn() },
+        response: {
+          use: vi.fn((_fulfilled, rejected) => {
+            responseRejected = rejected;
+          }),
+        },
+      },
+      get,
+      post,
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }),
+    isCancel: () => false,
+  },
+}));
+
+vi.mock("@octo/base", () => ({
+  WKApp: {
+    apiClient: { config: {} },
+    loginInfo: {},
+    shared: { currentSpaceId: "space-a", logout },
+    mittBus: { on: () => {}, off: () => {}, emit: () => {} },
+  },
+  buildAcceptLanguage: () => "en-US",
+  t: (key: string) => key,
+  DEFAULT_REQUEST_TIMEOUT_MS: 20000,
+}));
+
+import { fetchMcpDetail, fetchMcpList, normalizeCount, trackMcpView } from "./mcpService";
+
+describe("MCP view count service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [undefined, 0],
+    [null, 0],
+    [Number.NaN, 0],
+    [Number.POSITIVE_INFINITY, 0],
+    [-3, 0],
+    [3.9, 3],
+    [42, 42],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizeCount(input)).toBe(expected);
+  });
+
+  it("maps view_count for list and detail responses", async () => {
+    get
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ mcp_id: "m1", name: "MCP", slogan: "", category: "dev", icon: "", tags: [], tool_count: 1, view_count: 7.8 }],
+          pagination: { total: 1, page: 1, page_size: 20 },
+        },
+      })
+      .mockResolvedValueOnce({ data: { data: [] } })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            mcp_id: "m1", name: "MCP", slogan: "", category: "dev", icon: "", tags: [], tool_count: 1, view_count: -9,
+            quick_start: { transport: "streamable-http", server_name: "MCP" }, tools: [], usage_examples: [], faqs: [], notes: [],
+          },
+        },
+      });
+
+    await expect(fetchMcpList()).resolves.toMatchObject({ items: [{ viewCount: 7 }] });
+    await expect(fetchMcpDetail("m1")).resolves.toMatchObject({ viewCount: 0 });
+  });
+
+  it("posts the metrics payload and suppresses global logout for its 401", async () => {
+    post.mockResolvedValue({ data: { data: null } });
+    await trackMcpView("mcp/1");
+
+    expect(post).toHaveBeenCalledWith(
+      "/market/api/v1/metrics/track",
+      { resource_type: "mcp", resource_id: "mcp/1", event_type: "view" },
+      { skipGlobalAuthFailure: true }
+    );
+
+    await expect(responseRejected?.({ response: { status: 401 }, config: { skipGlobalAuthFailure: true } })).rejects.toBeTruthy();
+    expect(logout).not.toHaveBeenCalled();
+    await expect(responseRejected?.({ response: { status: 401 }, config: {} })).rejects.toBeTruthy();
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dmworkmcp/src/components/McpCard.tsx
+++ b/packages/dmworkmcp/src/components/McpCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Tooltip } from "@douyinfe/semi-ui";
-import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { IconEyeOpened, IconWrenchStroked } from "@douyinfe/semi-icons";
+import { formatCount } from "@dmwork/skillmarket";
 import { Bot, Pencil, Trash2, UserRound } from "lucide-react";
 import type { McpListItem } from "../types/mcp";
 import { t } from "@octo/base";
@@ -185,6 +186,14 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, onEdit, onDelete }) =>
       {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} /> : null}
       <div className="wk-mcp-card__footer">
         <div className="wk-mcp-card__stats">
+          <span
+            className="wk-mcp-card__stat"
+            title={t("mcp.card.viewCount", { values: { count: item.viewCount } })}
+            aria-label={t("mcp.card.viewCount", { values: { count: item.viewCount } })}
+          >
+            <IconEyeOpened size="small" />
+            {formatCount(item.viewCount)}
+          </span>
           <span
             className="wk-mcp-card__stat"
             title={t("mcp.card.toolCount", { values: { count: item.toolCount } })}

--- a/packages/dmworkmcp/src/components/McpDetailModal.tsx
+++ b/packages/dmworkmcp/src/components/McpDetailModal.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { WKModal, WKButton, t } from "@octo/base";
 import { Toast, Spin } from "@douyinfe/semi-ui";
-import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { IconEyeOpened, IconWrenchStroked } from "@douyinfe/semi-icons";
+import { formatCount } from "@dmwork/skillmarket";
 import { Bot, UserRound } from "lucide-react";
-import { deleteMcp, fetchMcpDetail } from "../api/mcpService";
+import { deleteMcp, fetchMcpDetail, trackMcpView } from "../api/mcpService";
 import { buildQuickStartTabs, TOKEN_PLACEHOLDER_RE } from "../api/quickStartTemplates";
 import type { McpDetail, McpQuickStart } from "../types/mcp";
 import { IconGlyph } from "../utils/icon";
@@ -139,7 +140,10 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
     setLoading(true);
     fetchMcpDetail(mcpId)
       .then((d) => {
-        if (!cancelled) setDetail(d);
+        if (!cancelled) {
+          setDetail(d);
+          void trackMcpView(mcpId).catch(() => undefined);
+        }
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -361,6 +365,18 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
           )}
           {/* 工具数量：与卡片 footer 及 dmworkskillmarket 的 stats 一致。 */}
           <div className="wk-mcp-detail__stats">
+            <span
+              className="wk-mcp-card__stat"
+              title={t("mcp.card.viewCount", {
+                values: { count: detail.viewCount },
+              })}
+              aria-label={t("mcp.card.viewCount", {
+                values: { count: detail.viewCount },
+              })}
+            >
+              <IconEyeOpened size="small" />
+              {formatCount(detail.viewCount)}
+            </span>
             <span
               className="wk-mcp-card__stat"
               title={t("mcp.card.toolCount", {

--- a/packages/dmworkmcp/src/components/__tests__/McpCard.viewCount.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpCard.viewCount.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@octo/base", () => ({ t: (_key: string, options?: { values?: { count?: number } }) => `views:${options?.values?.count ?? ""}` }));
 vi.mock("@douyinfe/semi-ui", () => ({ Tooltip: ({ children }: { children: React.ReactNode }) => children }));
@@ -9,14 +10,29 @@ vi.mock("../../utils/icon", () => ({ IconGlyph: () => null }));
 
 import McpCard from "../McpCard";
 
+let container: HTMLDivElement | null = null;
+afterEach(() => {
+  if (container) {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  }
+});
+
 describe("McpCard view count", () => {
   it("renders the compact count with an accessible label", () => {
-    render(
-      <McpCard
-        item={{ id: "m1", name: "MCP", slogan: "", category: "dev", tags: [], toolCount: 2, viewCount: 1250, icon: "" }}
-        onClick={vi.fn()}
-      />
-    );
-    expect(screen.getByLabelText("views:1250")).toHaveTextContent("1.3K");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => {
+      ReactDOM.render(
+        <McpCard
+          item={{ id: "m1", name: "MCP", slogan: "", category: "dev", tags: [], toolCount: 2, viewCount: 1250, icon: "" }}
+          onClick={vi.fn()}
+        />,
+        container
+      );
+    });
+    const stat = container.querySelector('[aria-label="views:1250"]');
+    expect(stat?.textContent).toContain("1.3K");
   });
 });

--- a/packages/dmworkmcp/src/components/__tests__/McpCard.viewCount.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpCard.viewCount.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@octo/base", () => ({ t: (_key: string, options?: { values?: { count?: number } }) => `views:${options?.values?.count ?? ""}` }));
+vi.mock("@douyinfe/semi-ui", () => ({ Tooltip: ({ children }: { children: React.ReactNode }) => children }));
+vi.mock("../../utils/icon", () => ({ IconGlyph: () => null }));
+
+import McpCard from "../McpCard";
+
+describe("McpCard view count", () => {
+  it("renders the compact count with an accessible label", () => {
+    render(
+      <McpCard
+        item={{ id: "m1", name: "MCP", slogan: "", category: "dev", tags: [], toolCount: 2, viewCount: 1250, icon: "" }}
+        onClick={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("views:1250")).toHaveTextContent("1.3K");
+  });
+});

--- a/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
@@ -118,7 +118,9 @@ describe("McpDetailModal 就地内联删除确认（方案A）", () => {
     expect(trackMcpView).toHaveBeenCalledTimes(1);
     expect(trackMcpView).toHaveBeenCalledWith("m1");
 
-    ReactDOM.unmountComponentAtNode(root);
+    act(() => {
+      ReactDOM.unmountComponentAtNode(root);
+    });
     root.remove();
     container = null;
     await act(async () => {
@@ -141,7 +143,9 @@ describe("McpDetailModal 就地内联删除确认（方案A）", () => {
       resolveDetail = resolve;
     }));
     const root = render(React.createElement(McpDetailModal, { mcpId: "cancelled", onClose: vi.fn() }));
-    ReactDOM.unmountComponentAtNode(root);
+    act(() => {
+      ReactDOM.unmountComponentAtNode(root);
+    });
     root.remove();
     container = null;
     await act(async () => {

--- a/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
@@ -7,10 +7,12 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 // ── Mocks ──────────────────────────────────────────────────────────────────
 const deleteMcp = vi.fn();
 const fetchMcpDetail = vi.fn();
+const trackMcpView = vi.fn();
 
 vi.mock("../../api/mcpService", () => ({
   deleteMcp: (...a: unknown[]) => deleteMcp(...a),
   fetchMcpDetail: (...a: unknown[]) => fetchMcpDetail(...a),
+  trackMcpView: (...a: unknown[]) => trackMcpView(...a),
 }));
 vi.mock("../../api/quickStartTemplates", () => ({
   buildQuickStartTabs: () => [
@@ -89,6 +91,69 @@ function clickButtonByText(root: HTMLElement, text: string) {
 }
 
 describe("McpDetailModal 就地内联删除确认（方案A）", () => {
+  it("详情成功后每次打开仅上报一次查看", async () => {
+    fetchMcpDetail.mockResolvedValue({
+      id: "m1",
+      name: "MCP",
+      slogan: "",
+      category: "dev",
+      icon: "",
+      tags: [],
+      toolCount: 0,
+      viewCount: 12,
+      quickStart: { transport: "streamable-http", serverName: "MCP" },
+      tools: [],
+      usageExamples: [],
+      faqs: [],
+      notes: [],
+    });
+    trackMcpView.mockRejectedValue(new Error("metrics unavailable"));
+
+    let root!: HTMLElement;
+    await act(async () => {
+      root = render(React.createElement(McpDetailModal, { mcpId: "m1", onClose: vi.fn() }));
+      await Promise.resolve();
+    });
+    expect(root.textContent).toContain("12");
+    expect(trackMcpView).toHaveBeenCalledTimes(1);
+    expect(trackMcpView).toHaveBeenCalledWith("m1");
+
+    ReactDOM.unmountComponentAtNode(root);
+    root.remove();
+    container = null;
+    await act(async () => {
+      render(React.createElement(McpDetailModal, { mcpId: "m1", onClose: vi.fn() }));
+      await Promise.resolve();
+    });
+    expect(trackMcpView).toHaveBeenCalledTimes(2);
+  });
+
+  it("详情请求失败或已取消时不上报查看", async () => {
+    fetchMcpDetail.mockRejectedValueOnce(new Error("load failed"));
+    await act(async () => {
+      render(React.createElement(McpDetailModal, { mcpId: "failed", onClose: vi.fn() }));
+      await Promise.resolve();
+    });
+    expect(trackMcpView).not.toHaveBeenCalled();
+
+    let resolveDetail!: (value: unknown) => void;
+    fetchMcpDetail.mockReturnValueOnce(new Promise((resolve) => {
+      resolveDetail = resolve;
+    }));
+    const root = render(React.createElement(McpDetailModal, { mcpId: "cancelled", onClose: vi.fn() }));
+    ReactDOM.unmountComponentAtNode(root);
+    root.remove();
+    container = null;
+    await act(async () => {
+      resolveDetail({
+        id: "cancelled", name: "MCP", slogan: "", category: "dev", icon: "", tags: [], toolCount: 0, viewCount: 1,
+        quickStart: { transport: "streamable-http", serverName: "MCP" }, tools: [], usageExamples: [], faqs: [], notes: [],
+      });
+      await Promise.resolve();
+    });
+    expect(trackMcpView).not.toHaveBeenCalled();
+  });
+
   it("点删除→footer 就地切确认态，不弹新窗；确认→调用 deleteMcp", async () => {
     fetchMcpDetail.mockResolvedValue({
       id: "m1",
@@ -98,6 +163,7 @@ describe("McpDetailModal 就地内联删除确认（方案A）", () => {
       icon: "",
       tags: [],
       toolCount: 0,
+      viewCount: 12,
       visibility: "private",
       creatorName: "dev",
       quickStart: { transport: "streamable-http", serverName: "测试666" },

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -98,6 +98,7 @@
       "other": "Matched content"
     },
     "toolCount": "Tools: {{count}}",
+    "viewCount": "Views: {{count}}",
     "editAriaLabel": "Edit {{name}}",
     "deleteAriaLabel": "Delete {{name}}",
     "edit": "Edit",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -98,6 +98,7 @@
       "other": "命中内容"
     },
     "toolCount": "工具数量: {{count}} 个",
+    "viewCount": "查看次数: {{count}} 次",
     "editAriaLabel": "编辑 {{name}}",
     "deleteAriaLabel": "删除 {{name}}",
     "edit": "编辑",

--- a/packages/dmworkmcp/src/mock/mcpMock.ts
+++ b/packages/dmworkmcp/src/mock/mcpMock.ts
@@ -81,6 +81,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "dev",
     tags: ["官方", "热门"],
     toolCount: 8,
+    viewCount: 1280,
     icon: "🐙",
     quickStart: remoteQuickStart("github"),
     tools: tools([
@@ -121,6 +122,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "data",
     tags: ["数据库"],
     toolCount: 5,
+    viewCount: 999,
     icon: "🐘",
     quickStart: stdioQuickStart("postgres", [
       "-y",
@@ -154,6 +156,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "search",
     tags: ["官方", "联网"],
     toolCount: 3,
+    viewCount: 0,
     icon: "🦁",
     quickStart: stdioQuickStart(
       "brave-search",
@@ -182,6 +185,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "dev",
     tags: ["官方", "基础"],
     toolCount: 6,
+    viewCount: 24600,
     icon: "📁",
     quickStart: stdioQuickStart("filesystem", [
       "-y",
@@ -213,6 +217,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "productivity",
     tags: ["协作"],
     toolCount: 4,
+    viewCount: 412,
     icon: "💬",
     quickStart: stdioQuickStart(
       "slack",
@@ -243,6 +248,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "dev",
     tags: ["浏览器"],
     toolCount: 5,
+    viewCount: 7350,
     icon: "🎭",
     quickStart: stdioQuickStart("puppeteer", [
       "-y",
@@ -272,6 +278,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "productivity",
     tags: ["云盘"],
     toolCount: 3,
+    viewCount: 87,
     icon: "📄",
     quickStart: remoteQuickStart("gdrive"),
     tools: tools([
@@ -296,6 +303,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "ai",
     tags: ["官方"],
     toolCount: 4,
+    viewCount: 1600,
     icon: "🧠",
     quickStart: stdioQuickStart("memory", [
       "-y",
@@ -324,6 +332,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "search",
     tags: ["官方", "联网"],
     toolCount: 1,
+    viewCount: 14,
     icon: "🌐",
     quickStart: remoteQuickStart("fetch"),
     tools: tools([["fetch", "抓取 URL 并转为 Markdown"]]),
@@ -344,6 +353,7 @@ export const MOCK_MCP_DETAILS: McpDetail[] = [
     category: "data",
     tags: ["官方", "数据库"],
     toolCount: 4,
+    viewCount: 530,
     icon: "🗃️",
     quickStart: stdioQuickStart("sqlite", [
       "-y",

--- a/packages/dmworkmcp/src/mock/mcpMock.ts
+++ b/packages/dmworkmcp/src/mock/mcpMock.ts
@@ -387,6 +387,7 @@ export const MOCK_MCP_LIST: McpListItem[] = MOCK_MCP_DETAILS.map((d) => ({
   category: d.category,
   tags: d.tags,
   toolCount: d.toolCount,
+  viewCount: d.viewCount,
   icon: d.icon,
   createdByType: d.createdByType,
   createdByBotUid: d.createdByBotUid,

--- a/packages/dmworkmcp/src/types/mcp.ts
+++ b/packages/dmworkmcp/src/types/mcp.ts
@@ -69,6 +69,8 @@ export interface McpListItem {
   tags: string[];
   /** Number of tools this server exposes (shown on the card footer). */
   toolCount: number;
+  /** Persisted detail-view count returned by Marketplace. */
+  viewCount: number;
   /** Icon: single emoji/char OR image URL / data URL. */
   icon: string;
   /** Visibility scope, echoed by the wire (mcp-v1.md §0). Optional so legacy

--- a/packages/dmworkskillmarket/src/index.tsx
+++ b/packages/dmworkskillmarket/src/index.tsx
@@ -4,3 +4,4 @@ export { SkillMarketModule } from "./module";
 // Keeps the coupling to a single named export instead of dmworkmcp reaching
 // into the internal folder tree.
 export { default as SkillListPage } from "./pages/SkillListPage";
+export { formatCount } from "./utils/format";


### PR DESCRIPTION
## Summary

Add MCP marketplace view-count display and best-effort view tracking, using the server-provided count as the authoritative value.

## Related Issue

- Octo: LSC-12
- API counterpart: https://github.com/Mininglamp-OSS/octo-marketplace/pull/22

## Changes

- Map and normalize `view_count` across list/detail/mock create projections.
- Display compact accessible view counts on MCP cards and the detail modal.
- Track one best-effort MCP view only after a successful detail load; close/reopen creates a new view.
- Keep metrics failures isolated: a metrics-only 401 does not trigger the shared global logout interceptor.
- Add regression coverage for normalization, payload, 401 isolation, failed/cancelled loads, reopen, card display, and DOM cleanup.

## Rebase

- Rebased onto `upstream/main` `8f8a19c2bc3a2add5ed88473d9bf661aae1aa233`.
- Current head: `259215797debe72b138a252426b0d2b0a0a823b5`.
- The explicitly waived 390px mobile adaptation remains absent.

## Testing

- `pnpm --filter @dmwork/mcp test` — 141 passed.
- `pnpm i18n:check` — passed.
- `pnpm lint` — passed (repository defines no lint tasks).
- `pnpm build` — passed; existing third-party eval/chunk warnings only.
- Package `tsc --noEmit` remains unsuitable as a merge gate because the current package config reports broad pre-existing React/Semi/dependency type errors. The PR-introduced required `viewCount` construction gaps are fixed and covered by tests.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Ran repository-standard tests/build/i18n checks
- [x] Kept the PR Draft
- [x] No production deployment or merge
