### PR TITLE
fix(dmworkmcp): align MCP marketplace UI to Skill + tag chip filter (#1009)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -61,6 +61,10 @@
       "reason": "Agent prompt template for the Bot publish flow. Same rationale as installPrompt.ts above — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },
     {
+      "path": "packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts",
+      "reason": "Agent prompt template for the MCP marketplace publish flow. Same rationale as dmworkskillmarket/src/utils/botPublishPrompt.ts — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
+    },
+    {
       "path": "packages/dmworksummary/src/__mocks__/handlers.ts",
       "reason": "MSW test fixture data with sample user names, titles, and message bodies; not UI copy."
     },

--- a/packages/dmworkmcp/package.json
+++ b/packages/dmworkmcp/package.json
@@ -11,7 +11,8 @@
     "@douyinfe/semi-icons": "^2.93.0",
     "@douyinfe/semi-ui": "^2.93.0",
     "axios": "^0.25.0",
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "lucide-react": "^0.577.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+// serializeMcpParams is pure and doesn't call t(), but the file's module
+// graph pulls in @octo/base at import-time via other exports. Stub the
+// module so the test doesn't depend on i18n / IM SDK bootstrap.
+vi.mock("@octo/base", () => ({
+  WKApp: { apiClient: { config: {} }, loginInfo: {}, shared: { currentSpaceId: "" }, mittBus: { on: () => {}, off: () => {}, emit: () => {} } },
+  buildAcceptLanguage: () => "en-US",
+  t: (key: string) => key,
+  DEFAULT_REQUEST_TIMEOUT_MS: 20000,
+}));
+
+import { serializeMcpParams } from "./mcpService";
+
+describe("serializeMcpParams — axios paramsSerializer wire contract", () => {
+  it("emits `?a=1&a=2` for arrays (never `?a[]=1&a[]=2`)", () => {
+    // gin's QueryArray on the marketplace backend only recognises the plain
+    // repeat form — a revert to axios 0.25's default `?a[]=...` shape would
+    // make every multi-tag filter silently return wrong results. Pin.
+    expect(serializeMcpParams({ tag: ["a", "b"] })).toBe("tag=a&tag=b");
+  });
+
+  it("URL-encodes commas inside a value so comma-bearing tags survive", () => {
+    expect(serializeMcpParams({ tag: ["v1.0,beta"] })).toBe("tag=v1.0%2Cbeta");
+  });
+
+  it("preserves multiple keys and multi-value ordering", () => {
+    expect(
+      serializeMcpParams({
+        q: "hello",
+        tag: ["a", "b"],
+        mode: "mine",
+      })
+    ).toBe("q=hello&tag=a&tag=b&mode=mine");
+  });
+
+  it("drops null / undefined values entirely", () => {
+    expect(
+      serializeMcpParams({
+        q: undefined,
+        limit: null,
+        mode: "mine",
+      })
+    ).toBe("mode=mine");
+  });
+
+  it("drops null / undefined inside arrays (keeps a stable position for the rest)", () => {
+    expect(
+      serializeMcpParams({
+        tag: ["a", undefined as unknown as string, "b", null as unknown as string, "c"],
+      })
+    ).toBe("tag=a&tag=b&tag=c");
+  });
+
+  it("handles empty / undefined params argument", () => {
+    expect(serializeMcpParams(undefined)).toBe("");
+    expect(serializeMcpParams({})).toBe("");
+    expect(serializeMcpParams({ tag: [] })).toBe("");
+  });
+
+  it("stringifies non-string primitives (limit, offset)", () => {
+    expect(serializeMcpParams({ limit: 50, offset: 0 })).toBe("limit=50&offset=0");
+  });
+});

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -134,6 +134,7 @@ async function fetchMcpListMockFiltered(
   const keyword = (params.keyword ?? "").trim().toLowerCase();
   const category = params.category ?? "all";
   const createdBy = params.createdByType;
+  const tags = params.tags ?? [];
   const filtered = source.filter((item) => {
     const matchCategory = category === "all" || item.category === category;
     const matchKeyword =
@@ -144,7 +145,11 @@ async function fetchMcpListMockFiltered(
     // read-side default the wire mapper applies for pre-#894 records.
     const rowType = item.createdByType ?? "human";
     const matchCreatedBy = !createdBy || rowType === createdBy;
-    return matchCategory && matchKeyword && matchCreatedBy;
+    // Multi-tag filter is AND: a row must carry every selected tag. Mirrors
+    // the backend semantics in octo-marketplace (mcp-v1.md §4.2).
+    const matchTags =
+      tags.length === 0 || tags.every((tag) => item.tags.includes(tag));
+    return matchCategory && matchKeyword && matchCreatedBy && matchTags;
   });
   const offset = params.offset && params.offset > 0 ? params.offset : 0;
   const limit =
@@ -675,6 +680,12 @@ async function fetchMcpListPath(
   // Relevance is only meaningful with a keyword — every row scores 0 otherwise,
   // making the sort order arbitrary. When browsing, surface freshest first.
   query.sort = keyword ? "relevance" : "updated";
+  // Multi-tag filter — mcp-v1.md §4.2 accepts `tag` as repeatable OR
+  // comma-separated. Use comma-separated for compact wire; the backend
+  // AND-combines the parsed values.
+  if (params.tags?.length) {
+    query.tag = params.tags.join(",");
+  }
   const pageSize = params.limit && params.limit > 0 ? params.limit : 20;
   query.page_size = pageSize;
   query.page = Math.floor((params.offset ?? 0) / pageSize) + 1;
@@ -876,6 +887,62 @@ export function fetchMcpMine(
 
 export function fetchMcpDetail(id: string): Promise<McpDetail> {
   return USE_MOCK ? fetchMcpDetailMock(id) : fetchMcpDetailReal(id);
+}
+
+/** One tag suggestion in the tag-filter popover (mcp-v1.md §4.8). */
+export interface McpTagSuggestion {
+  name: string;
+  count: number;
+}
+
+/** GET /market/api/v1/mcp_tags — tag suggestions for the search-bar
+ *  popover. Backend aggregates across the caller's visible set (system +
+ *  space rows), sorted by descending count. Empty `query` returns every
+ *  visible tag; the backend clamps `limit` to [1, 100] with default 50. */
+export function fetchMcpTags(
+  query = "",
+  opts: { signal?: AbortSignal; limit?: number } = {}
+): Promise<McpTagSuggestion[]> {
+  return USE_MOCK
+    ? fetchMcpTagsMock(query, opts)
+    : fetchMcpTagsReal(query, opts);
+}
+
+async function fetchMcpTagsMock(
+  query: string,
+  _opts: { signal?: AbortSignal; limit?: number }
+): Promise<McpTagSuggestion[]> {
+  // Aggregate from the in-memory mock list — same visibility semantics as
+  // the real backend (everything visible to the caller's space). Count-desc
+  // + name-asc tie-break, case-insensitive query.
+  const counts = new Map<string, number>();
+  for (const item of MOCK_MCP_LIST) {
+    for (const tag of item.tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  const kw = query.trim().toLowerCase();
+  const items: McpTagSuggestion[] = [];
+  counts.forEach((count, name) => {
+    if (kw && !name.toLowerCase().includes(kw)) return;
+    items.push({ name, count });
+  });
+  items.sort((a, b) => (b.count - a.count) || a.name.localeCompare(b.name));
+  return delay(items);
+}
+
+async function fetchMcpTagsReal(
+  query: string,
+  opts: { signal?: AbortSignal; limit?: number }
+): Promise<McpTagSuggestion[]> {
+  const params: Record<string, unknown> = {};
+  if (query.trim()) params.q = query.trim();
+  if (opts.limit && opts.limit > 0) params.limit = opts.limit;
+  const resp = await mcpAxios.get<{ data: McpTagSuggestion[] }>(
+    `${BASE}/mcp_tags`,
+    { params, signal: opts.signal }
+  );
+  return resp.data.data ?? [];
 }
 
 /**

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -681,10 +681,12 @@ async function fetchMcpListPath(
   // making the sort order arbitrary. When browsing, surface freshest first.
   query.sort = keyword ? "relevance" : "updated";
   // Multi-tag filter — mcp-v1.md §4.2 accepts `tag` as repeatable OR
-  // comma-separated. Use comma-separated for compact wire; the backend
-  // AND-combines the parsed values.
+  // comma-separated. We use REPEATED params (`tag=a&tag=b&tag=c`) so a
+  // tag value that happens to contain a comma still round-trips intact;
+  // comma-joining would let the backend re-split "v1.0,beta" into two
+  // wrong tags and produce silent empty results.
   if (params.tags?.length) {
-    query.tag = params.tags.join(",");
+    query.tag = params.tags;
   }
   const pageSize = params.limit && params.limit > 0 ? params.limit : 20;
   query.page_size = pageSize;
@@ -898,10 +900,12 @@ export interface McpTagSuggestion {
 /** GET /market/api/v1/mcp_tags — tag suggestions for the search-bar
  *  popover. Backend aggregates across the caller's visible set (system +
  *  space rows), sorted by descending count. Empty `query` returns every
- *  visible tag; the backend clamps `limit` to [1, 100] with default 50. */
+ *  visible tag; the backend clamps `limit` to [1, 100] with default 50.
+ *  Pass `mode: "mine"` when the popover opens from the "我的" tab so
+ *  suggestions match `GET /mcps/mine`. */
 export function fetchMcpTags(
   query = "",
-  opts: { signal?: AbortSignal; limit?: number } = {}
+  opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" } = {}
 ): Promise<McpTagSuggestion[]> {
   return USE_MOCK
     ? fetchMcpTagsMock(query, opts)
@@ -910,7 +914,7 @@ export function fetchMcpTags(
 
 async function fetchMcpTagsMock(
   query: string,
-  _opts: { signal?: AbortSignal; limit?: number }
+  _opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" }
 ): Promise<McpTagSuggestion[]> {
   // Aggregate from the in-memory mock list — same visibility semantics as
   // the real backend (everything visible to the caller's space). Count-desc
@@ -933,11 +937,12 @@ async function fetchMcpTagsMock(
 
 async function fetchMcpTagsReal(
   query: string,
-  opts: { signal?: AbortSignal; limit?: number }
+  opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" }
 ): Promise<McpTagSuggestion[]> {
   const params: Record<string, unknown> = {};
   if (query.trim()) params.q = query.trim();
   if (opts.limit && opts.limit > 0) params.limit = opts.limit;
+  if (opts.mode === "mine") params.mode = "mine";
   const resp = await mcpAxios.get<{ data: McpTagSuggestion[] }>(
     `${BASE}/mcp_tags`,
     { params, signal: opts.signal }

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -326,6 +326,31 @@ function slugify(s: string): string {
 // <origin>/market/api/v1 (nginx / vite proxy strips the /market prefix to the
 // service's own /api/v1), mirroring the summary + matter service convention.
 
+/** Serialise axios request params as repeated keys (`?a=1&a=2`) instead of
+ *  axios 0.25's default `?a[]=1&a[]=2`. gin's QueryArray on the marketplace
+ *  backend only recognises the plain-repeat form; a bracketed key would
+ *  silently become a single-string param that never matches. Also drops
+ *  undefined/null keys so callers can just pass an optional value without
+ *  pre-filtering. Exported so the wire contract can be pinned in unit
+ *  tests without spinning up an axios instance. */
+export function serializeMcpParams(
+  params: Record<string, unknown> | undefined
+): string {
+  const usp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue;
+        usp.append(key, String(item));
+      }
+    } else {
+      usp.append(key, String(value));
+    }
+  }
+  return usp.toString();
+}
+
 const mcpAxios = axios.create({
   baseURL: "",
   // Isolated instance (no shared interceptors), so it never picks up the
@@ -333,27 +358,7 @@ const mcpAxios = axios.create({
   // the same ceiling explicitly to avoid the UI-hang class of bug that
   // DEFAULT_REQUEST_TIMEOUT_MS was introduced to close.
   timeout: DEFAULT_REQUEST_TIMEOUT_MS,
-  // Serialise array params as repeated keys (`?a=1&a=2`) instead of axios
-  // 0.25's default `?a[]=1&a[]=2`. gin's QueryArray on the marketplace
-  // backend only recognises the plain-repeat form; a bracketed key would
-  // silently become a single-string param that never matches. Also drops
-  // undefined/null keys so callers can just pass an optional value without
-  // pre-filtering.
-  paramsSerializer: (params) => {
-    const usp = new URLSearchParams();
-    for (const [key, value] of Object.entries(params ?? {})) {
-      if (value === undefined || value === null) continue;
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          if (item === undefined || item === null) continue;
-          usp.append(key, String(item));
-        }
-      } else {
-        usp.append(key, String(value));
-      }
-    }
-    return usp.toString();
-  },
+  paramsSerializer: serializeMcpParams,
 });
 
 const BASE = "/market/api/v1";
@@ -914,13 +919,22 @@ export function fetchMcpTags(
 
 async function fetchMcpTagsMock(
   query: string,
-  _opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" }
+  opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" }
 ): Promise<McpTagSuggestion[]> {
-  // Aggregate from the in-memory mock list — same visibility semantics as
-  // the real backend (everything visible to the caller's space). Count-desc
-  // + name-asc tie-break, case-insensitive query.
+  // Aggregate from the in-memory mock list. `mode: "mine"` mirrors
+  // fetchMcpMineMock's owner filter (creatorName === caller). Signal +
+  // limit honored for parity with the real backend so the mock behaves
+  // the same in dev harnesses; the mock body is otherwise unreachable in
+  // production (USE_MOCK is a `const false` at :59).
+  if (opts.signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+  const source =
+    opts.mode === "mine"
+      ? MOCK_MCP_LIST.filter((it) => it.creatorName === (WKApp.loginInfo?.name || ""))
+      : MOCK_MCP_LIST;
   const counts = new Map<string, number>();
-  for (const item of MOCK_MCP_LIST) {
+  for (const item of source) {
     for (const tag of item.tags) {
       counts.set(tag, (counts.get(tag) ?? 0) + 1);
     }
@@ -932,7 +946,16 @@ async function fetchMcpTagsMock(
     items.push({ name, count });
   });
   items.sort((a, b) => (b.count - a.count) || a.name.localeCompare(b.name));
-  return delay(items);
+  // Backend clamps `limit` to [1, 100] with default 50.
+  const limit = Math.min(100, Math.max(1, opts.limit ?? 50));
+  const trimmed = items.slice(0, limit);
+  return new Promise<McpTagSuggestion[]>((resolve, reject) => {
+    const timer = setTimeout(() => resolve(trimmed), MOCK_DELAY_MS);
+    opts.signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  });
 }
 
 async function fetchMcpTagsReal(
@@ -943,11 +966,15 @@ async function fetchMcpTagsReal(
   if (query.trim()) params.q = query.trim();
   if (opts.limit && opts.limit > 0) params.limit = opts.limit;
   if (opts.mode === "mine") params.mode = "mine";
-  const resp = await mcpAxios.get<{ data: McpTagSuggestion[] }>(
-    `${BASE}/mcp_tags`,
-    { params, signal: opts.signal }
-  );
-  return resp.data.data ?? [];
+  // Route through the shared get<T>() helper so 4xx/5xx/network failures
+  // are classified into McpListError like every other read endpoint. The
+  // helper re-throws axios cancels unchanged, so the caller's abort branch
+  // still fires. Array.isArray guard covers a non-list envelope (`{}` or
+  // `{data:null}`) surfacing as an empty suggestions list.
+  const data = await get<McpTagSuggestion[] | null>(`/mcp_tags`, params, {
+    signal: opts.signal,
+  });
+  return Array.isArray(data) ? data : [];
 }
 
 /**

--- a/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
+++ b/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Bot, Check, Copy } from "lucide-react";
+import { Toast } from "@douyinfe/semi-ui";
+import { t, useI18n, WKApp, WKButton, WKModal } from "@octo/base";
+import {
+  getMcpBotPublishPrompt,
+  resolveMcpAPIBaseURL,
+} from "../utils/mcpBotPublishPrompt";
+
+interface McpBotPublishModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function getCurrentSpaceId(): string {
+  return (
+    WKApp.shared?.currentSpaceId ||
+    (typeof localStorage !== "undefined"
+      ? localStorage.getItem("currentSpaceId") || ""
+      : "")
+  );
+}
+
+/** MCP "Bot 上架" modal — mirrors dmworkskillmarket's BotPublishModal.
+ *  Renders a copy-to-clipboard prompt the user hands to an Agent. Prompt
+ *  content lives in ../utils/mcpBotPublishPrompt.ts and is MCP-specific. */
+export default function McpBotPublishModal({
+  visible,
+  onClose,
+}: McpBotPublishModalProps) {
+  useI18n();
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+  const spaceId = getCurrentSpaceId();
+  // Memoize the prompt — inputs are stable for the modal's lifetime and the
+  // template is a few hundred bytes of string concat we'd otherwise rebuild
+  // on every parent re-render (space-changed, tab switches, etc.).
+  const prompt = useMemo(
+    () =>
+      getMcpBotPublishPrompt({
+        spaceId,
+        apiBaseUrl: resolveMcpAPIBaseURL(
+          WKApp.apiClient.config.apiURL,
+          window.location.origin
+        ),
+      }),
+    [spaceId]
+  );
+  // Placeholder guard: the prompt substitutes `<space-id>` when currentSpaceId
+  // is empty. Copying that would give the bot an unusable command — refuse.
+  const promptReady = Boolean(prompt) && !!spaceId.trim();
+
+  useEffect(() => {
+    if (visible) setCopied(false);
+  }, [visible]);
+
+  // Clear any in-flight copy-feedback timer when the modal unmounts to avoid
+  // "state update on unmounted component" warnings when the parent closes the
+  // modal within 2s of a successful copy.
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current !== null) {
+        window.clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  async function handleCopy() {
+    if (!promptReady) return;
+    if (!navigator.clipboard?.writeText) {
+      Toast.error(t("mcp.botPublish.copyUnavailable"));
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(prompt);
+    } catch {
+      Toast.error(t("mcp.botPublish.copyFailed"));
+      return;
+    }
+    setCopied(true);
+    if (copiedTimerRef.current !== null) {
+      window.clearTimeout(copiedTimerRef.current);
+    }
+    copiedTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copiedTimerRef.current = null;
+    }, 2000);
+  }
+
+  return (
+    <WKModal
+      visible={visible}
+      onCancel={onClose}
+      title={null}
+      size="lg"
+      className="wk-mcp-prompt-modal"
+      header={
+        <div className="wk-mcp-prompt-modal__header">
+          <div className="wk-mcp-prompt-modal__icon">
+            <Bot size={18} />
+          </div>
+          <div>
+            <h3>{t("mcp.botPublish.title")}</h3>
+            <p>{t("mcp.botPublish.hint")}</p>
+          </div>
+        </div>
+      }
+      footer={
+        <WKButton
+          variant="primary"
+          icon={copied ? <Check size={15} /> : <Copy size={15} />}
+          onClick={handleCopy}
+          disabled={!promptReady}
+        >
+          {copied
+            ? t("mcp.botPublish.copied")
+            : t("mcp.botPublish.copyBtn")}
+        </WKButton>
+      }
+    >
+      <div className="wk-mcp-prompt-modal__body">
+        <pre className="wk-mcp-prompt-modal__pre">{prompt}</pre>
+      </div>
+    </WKModal>
+  );
+}

--- a/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
+++ b/packages/dmworkmcp/src/components/McpBotPublishModal.tsx
@@ -4,6 +4,7 @@ import { Toast } from "@douyinfe/semi-ui";
 import { t, useI18n, WKApp, WKButton, WKModal } from "@octo/base";
 import {
   getMcpBotPublishPrompt,
+  isValidMcpSpaceId,
   resolveMcpAPIBaseURL,
 } from "../utils/mcpBotPublishPrompt";
 
@@ -32,31 +33,44 @@ export default function McpBotPublishModal({
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<number | null>(null);
   const spaceId = getCurrentSpaceId();
-  // Memoize the prompt — inputs are stable for the modal's lifetime and the
-  // template is a few hundred bytes of string concat we'd otherwise rebuild
-  // on every parent re-render (space-changed, tab switches, etc.).
+  const apiURL = WKApp.apiClient.config.apiURL;
+  // Memoize the prompt. Depend on BOTH spaceId and the configured apiURL —
+  // resolveMcpAPIBaseURL derives from apiURL first and falls back to
+  // window.location.origin, so a runtime apiURL change (unusual, but the
+  // client config is a mutable object) must bust the cache. window.origin
+  // is treated as stable-for-session and intentionally omitted.
   const prompt = useMemo(
     () =>
       getMcpBotPublishPrompt({
         spaceId,
-        apiBaseUrl: resolveMcpAPIBaseURL(
-          WKApp.apiClient.config.apiURL,
-          window.location.origin
-        ),
+        apiBaseUrl: resolveMcpAPIBaseURL(apiURL, window.location.origin),
       }),
-    [spaceId]
+    [spaceId, apiURL]
   );
   // Placeholder guard: the prompt substitutes `<space-id>` when currentSpaceId
-  // is empty. Copying that would give the bot an unusable command — refuse.
-  const promptReady = Boolean(prompt) && !!spaceId.trim();
+  // is empty OR fails the UUID check (see sanitizeSpaceId in
+  // mcpBotPublishPrompt.ts — defense against a poisoned localStorage
+  // fallback flowing into a shell command example). Copying that would give
+  // the bot an unusable command — refuse.
+  const promptReady = Boolean(prompt) && isValidMcpSpaceId(spaceId);
 
+  // Clear the "copied" flag AND cancel any pending 2s reset timer whenever
+  // the modal transitions to hidden. Guarantees a fresh state on next open
+  // and stops a timer from firing setCopied(false) on a hidden-but-mounted
+  // component (harmless, but a lint- and audit-friendly cleanup).
   useEffect(() => {
-    if (visible) setCopied(false);
+    if (!visible) {
+      setCopied(false);
+      if (copiedTimerRef.current !== null) {
+        window.clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    }
   }, [visible]);
 
-  // Clear any in-flight copy-feedback timer when the modal unmounts to avoid
-  // "state update on unmounted component" warnings when the parent closes the
-  // modal within 2s of a successful copy.
+  // Also clear the timer on unmount — covers the parent unmounting the
+  // whole modal within 2s of a successful copy (the visible=false effect
+  // above covers the mounted-but-hidden path).
   useEffect(() => {
     return () => {
       if (copiedTimerRef.current !== null) {
@@ -75,6 +89,13 @@ export default function McpBotPublishModal({
     try {
       await navigator.clipboard.writeText(prompt);
     } catch {
+      // Reset the "copied" indicator on failure — otherwise a prior success
+      // would leave the checkmark showing after a subsequent failed attempt.
+      setCopied(false);
+      if (copiedTimerRef.current !== null) {
+        window.clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
       Toast.error(t("mcp.botPublish.copyFailed"));
       return;
     }

--- a/packages/dmworkmcp/src/components/McpCard.tsx
+++ b/packages/dmworkmcp/src/components/McpCard.tsx
@@ -1,31 +1,42 @@
 import React from "react";
 import { Tooltip } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { Bot, UserRound } from "lucide-react";
 import type { McpListItem } from "../types/mcp";
 import { t } from "@octo/base";
 import { IconGlyph } from "../utils/icon";
+import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 
 interface McpCardProps {
   item: McpListItem;
   onClick: (item: McpListItem) => void;
-  keyword?: string;
 }
 
-export function Highlight({ text, keyword = "" }: { text: string; keyword?: string }) {
-  const index = text.toLowerCase().indexOf(keyword.trim().toLowerCase());
-  if (!keyword.trim() || index < 0) return <>{text}</>;
-  return <>{text.slice(0, index)}<mark>{text.slice(index, index + keyword.trim().length)}</mark>{text.slice(index + keyword.trim().length)}</>;
-}
-
+/** Parse a backend `match_reasons` entry into an i18n key + optional value.
+ *  Wire shape is `"<type>:<value>"` where `<type>` is one of the fixed set
+ *  below; unknown types fall through to `other` so the card still renders a
+ *  labelled chip rather than blowing up. */
 export function parseMatchReason(reason: string): { key: string; value?: string } {
   const colon = reason.indexOf(":");
   const type = colon < 0 ? reason : reason.slice(0, colon);
   const value = colon < 0 ? undefined : reason.slice(colon + 1);
-  const keys: Record<string, string> = { name: "name", description: "description", category: "category", usage_example: "usage", tool: "tool", tag: "tag", creator: "creator" };
+  const keys: Record<string, string> = {
+    name: "name",
+    description: "description",
+    category: "category",
+    usage_example: "usage",
+    tool: "tool",
+    tag: "tag",
+    creator: "creator",
+  };
   return { key: `mcp.card.matchReason.${keys[type] ?? "other"}`, value };
 }
 
-export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; keyword?: string }) {
+/** Renders the "为什么命中" chips under the card tags. Only reveals fields
+ *  the card itself doesn't already show (tool / usage_example / creator) —
+ *  matches on name / description / tag are visible in the card body and
+ *  don't need their own chip. */
+export function MatchReasons({ reasons }: { reasons: string[] }) {
   const revealing = reasons.filter((reason) => {
     const type = reason.split(":", 1)[0];
     return type === "tool" || type === "usage_example" || type === "creator";
@@ -35,11 +46,10 @@ export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; key
     <div className="wk-mcp-card__reasons">
       {revealing.map((reason) => {
         const parsed = parseMatchReason(reason);
-        const value = parsed.value || keyword;
         return (
           <span className="wk-mcp-card__reason" key={reason}>
             <span className="wk-mcp-card__reason-label">{t(parsed.key)}</span>
-            {value ? <Highlight text={value} keyword={keyword} /> : null}
+            {parsed.value ? <span>{parsed.value}</span> : null}
           </span>
         );
       })}
@@ -47,15 +57,41 @@ export function MatchReasons({ reasons, keyword = "" }: { reasons: string[]; key
   );
 }
 
-/** How many tags the card renders before collapsing the rest into a `+N`
- *  chip. Product decision: 3 keeps the tag row on a single line for typical
- *  cases while still surfacing the most-relevant tags on a real record. */
 const CARD_TAG_LIMIT = 3;
 
+/** Compute what the card's meta-row shows for the "who published this" slot.
+ *  Mirrors dmworkskillmarket's owner rendering:
+ *   - bot rows: bot icon + bot 名 · human icon + human 名（两段用中点分隔）
+ *   - human rows / legacy rows with only creatorName: human icon + human 名
+ *   - `import` rows and rows with no attribution at all: return null so the
+ *     meta-row folds — imports don't come from a marketplace user and must
+ *     not be labelled with a human/bot chip. */
+export function resolveOwner(item: McpListItem): { botName?: string; humanName?: string } | null {
+  if (item.createdByType === "bot") {
+    const botName = item.createdByBotName || t("mcp.source.bot");
+    return {
+      botName,
+      humanName: item.creatorName || undefined,
+    };
+  }
+  if (item.createdByType === "import") {
+    return null;
+  }
+  if (item.creatorName) {
+    return { humanName: item.creatorName };
+  }
+  return null;
+}
+
 /** A single MCP server card in the list grid. */
-const McpCard: React.FC<McpCardProps> = ({ item, onClick, keyword }) => {
+const McpCard: React.FC<McpCardProps> = ({ item, onClick }) => {
   const visibleTags = item.tags.slice(0, CARD_TAG_LIMIT);
   const overflowTags = item.tags.slice(CARD_TAG_LIMIT);
+  const owner = resolveOwner(item);
+  // `.trim()` gates the fallback avatar so a whitespace-only icon string
+  // (paste artifact, backend quirk) doesn't slip past the truthiness check
+  // and render an empty box via IconGlyph.
+  const hasIcon = !!item.icon?.trim();
   return (
     <div
       className="wk-mcp-card"
@@ -69,126 +105,89 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, keyword }) => {
         }
       }}
     >
-      <div className="wk-mcp-card__header">
+      <div className="wk-mcp-card__top">
         <div className="wk-mcp-card__icon">
-          <IconGlyph icon={item.icon} className="wk-mcp-card__icon-img" alt={item.name} />
-        </div>
-        <div className="wk-mcp-card__heading">
-          <div className="wk-mcp-card__name">
-            {/* Wrap the highlighted text in its own span so the ellipsis
-                clamp only applies to the name — not the source chip that
-                sits alongside it. `title` on the wrapper is the plain
-                browser tooltip (fine here: users deliberately hover for
-                a long name, and clicking still opens the detail modal
-                with the full name in the header). */}
-            <span className="wk-mcp-card__name-text" title={item.name}>
-              <Highlight text={item.name} keyword={keyword} />
+          {hasIcon ? (
+            <IconGlyph icon={item.icon} className="wk-mcp-card__icon-img" alt={item.name} />
+          ) : (
+            <span
+              className="wk-mcp-card__icon-default"
+              style={{ background: getMcpAvatarColor(item.id) }}
+            >
+              {getMcpAvatarText(item.name)}
             </span>
-            {/* Cards get an icon-only chip — real estate is tight and the
-                name of the bot rarely helps disambiguation in a grid. Hover
-                exposes the full "由 X 的 Bot 创建" tooltip. */}
-            <SourceBadge item={item} variant="icon-only" />
+          )}
+        </div>
+        <div className="wk-mcp-card__header">
+          <div className="wk-mcp-card__title-row">
+            <h3 className="wk-mcp-card__name" title={item.name}>
+              {item.name}
+            </h3>
           </div>
-          <div className="wk-mcp-card__tags">
-            {visibleTags.map((tag) => (
-              <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                <Highlight text={tag} keyword={keyword} />
-              </span>
-            ))}
-            {overflowTags.length > 0 && (
-              /* +N chip: hover reveals the truncated tags via Semi Tooltip
-                 as a mini pill cloud — matches the visual language of the
-                 card's own tags so it reads as "the rest of the tag row".
-                 100 ms delay so the reveal feels near-instant. Click still
-                 bubbles up to the card's onClick — no separate detail path
-                 for the +N. */
-              <Tooltip
-                content={
-                  <div className="wk-mcp-tag-overflow">
-                    {overflowTags.map((tag) => (
-                      <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                }
-                className="wk-mcp-tooltip-light"
-                mouseEnterDelay={100}
-                position="top"
-              >
-                <span className="wk-mcp-tag wk-mcp-tag--more" aria-label={overflowTags.join(", ")}>
-                  +{overflowTags.length}
+          {owner && (
+            <div className="wk-mcp-card__meta-row">
+              {owner.botName && (
+                <span className="wk-mcp-card__owner" title={owner.botName}>
+                  <Bot className="wk-mcp-card__owner-bot-icon" size={13} aria-hidden="true" />
+                  <span className="wk-mcp-card__owner-name">{owner.botName}</span>
                 </span>
-              </Tooltip>
-            )}
-          </div>
+              )}
+              {owner.botName && owner.humanName && (
+                <span className="wk-mcp-card__meta-separator">·</span>
+              )}
+              {owner.humanName && (
+                <span className="wk-mcp-card__owner" title={owner.humanName}>
+                  <UserRound className="wk-mcp-card__owner-user-icon" size={13} aria-hidden="true" />
+                  <span className="wk-mcp-card__owner-name">{owner.humanName}</span>
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
-      <div className="wk-mcp-card__slogan"><Highlight text={item.slogan} keyword={keyword} /></div>
-      {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} keyword={keyword} /> : null}
+      <div className="wk-mcp-card__slogan">{item.slogan}</div>
+      <div className="wk-mcp-card__tags">
+        {visibleTags.map((tag) => (
+          <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+            {tag}
+          </span>
+        ))}
+        {overflowTags.length > 0 && (
+          <Tooltip
+            content={
+              <div className="wk-mcp-tag-overflow">
+                {overflowTags.map((tag) => (
+                  <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            }
+            className="wk-mcp-tooltip-light"
+            mouseEnterDelay={100}
+            position="top"
+          >
+            <span className="wk-mcp-tag wk-mcp-tag--more" aria-label={overflowTags.join(", ")}>
+              +{overflowTags.length}
+            </span>
+          </Tooltip>
+        )}
+      </div>
+      {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} /> : null}
       <div className="wk-mcp-card__footer">
-        <span
-          className="wk-mcp-card__stat"
-          title={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
-          aria-label={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
-        >
-          <IconWrenchStroked size="small" />
-          {item.toolCount}
-        </span>
+        <div className="wk-mcp-card__stats">
+          <span
+            className="wk-mcp-card__stat"
+            title={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
+            aria-label={t("mcp.card.toolCount", { values: { count: item.toolCount } })}
+          >
+            <IconWrenchStroked size="small" />
+            {item.toolCount}
+          </span>
+        </div>
       </div>
     </div>
   );
 };
-
-/**
- * Small "created by whom" chip for bot-authored MCPs (issue #894). Two shapes:
- *   - `icon-only` (card grid): just the 🤖 glyph; hover for the full tooltip
- *     naming the bot and its owner. Keeps the list compact.
- *   - `labeled` (detail modal): 🤖 + bot name, so the source is legible
- *     without a hover — the detail page has the room.
- * Human/import/legacy rows never render a chip either way.
- */
-export function SourceBadge({
-  item,
-  variant = "labeled",
-}: {
-  item: McpListItem;
-  variant?: "icon-only" | "labeled";
-}) {
-  if (item.createdByType !== "bot") return null;
-  const botName = item.createdByBotName || t("mcp.source.bot");
-  const ownerHint = item.creatorName
-    ? t("mcp.source.botTooltip", { values: { owner: item.creatorName } })
-    : "";
-  // Same tooltip shape for both variants — the labeled chip clips long bot
-  // names with an ellipsis, so hover MUST reveal the full name (plus owner)
-  // no matter which variant the caller picks.
-  const tooltip = ownerHint ? `${botName} · ${ownerHint}` : botName;
-  const chip = (
-    <span
-      className={
-        variant === "icon-only"
-          ? "wk-mcp-tag wk-mcp-source wk-mcp-source--bot wk-mcp-source--icon"
-          : "wk-mcp-tag wk-mcp-source wk-mcp-source--bot"
-      }
-      aria-label={tooltip}
-    >
-      <span className="wk-mcp-source__icon" aria-hidden="true">🤖</span>
-      {variant === "labeled" && (
-        <span className="wk-mcp-source__label">{botName}</span>
-      )}
-    </span>
-  );
-  // Semi UI Tooltip — near-instant reveal (100 ms) instead of the browser's
-  // sluggish 500-2000ms native title. Stopping propagation on the trigger
-  // wrapper is unnecessary: the tooltip layer sits above but the click
-  // bubble path still reaches the card, so clicking the chip still opens
-  // the detail like any other card area.
-  return (
-    <Tooltip content={tooltip} mouseEnterDelay={100} position="top">
-      {chip}
-    </Tooltip>
-  );
-}
 
 export default McpCard;

--- a/packages/dmworkmcp/src/components/McpCreateModal.tsx
+++ b/packages/dmworkmcp/src/components/McpCreateModal.tsx
@@ -15,6 +15,11 @@ import {
   slugifyServerName,
 } from "../utils/constants";
 import { parseImportJSON } from "../utils/importJson";
+import {
+  MAX_MCP_TAGS,
+  validateMcpTag,
+  validateMcpTags,
+} from "../utils/mcpTagValidation";
 import type {
   CreateMcpParams,
   McpDetail,
@@ -393,7 +398,11 @@ function Segments<T extends string>({
   );
 }
 
-/** Chip-based tag input — Enter/comma add, Backspace on empty removes last. */
+/** Chip-based tag input — Enter/comma add, Backspace on empty removes last.
+ *  Also enforces MAX_MCP_TAGS + per-tag length/charset (mirrors dmworkskillmarket
+ *  after PR #1026). Invalid tags are rejected inline with a Toast so the user
+ *  gets immediate feedback; the outer submit path re-validates as a defense
+ *  against legacy oversized rows loaded into the edit form. */
 function TagsInput({
   value,
   onChange,
@@ -406,14 +415,43 @@ function TagsInput({
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const commit = (raw: string) => {
+  const commitOne = (raw: string, existing: string[]): string[] | null => {
     const trimmed = raw.trim().replace(/,+$/, "");
-    if (!trimmed) return;
-    if (value.includes(trimmed)) {
+    if (!trimmed) return null;
+    if (existing.includes(trimmed)) return null;
+    if (existing.length >= MAX_MCP_TAGS) {
+      Toast.warning(t("mcp.form.tagLimit", { values: { count: MAX_MCP_TAGS } }));
+      return null;
+    }
+    const tagError = validateMcpTag(trimmed);
+    if (tagError) {
+      Toast.warning(tagError);
+      return null;
+    }
+    return [...existing, trimmed];
+  };
+
+  /** Accepts either a single tag or a comma-separated batch (from paste).
+   *  Splits on commas, validates each segment, and drops the whole batch's
+   *  draft only after processing so a mid-batch validation error still
+   *  clears the input (matches the keyboard-comma UX). */
+  const commit = (raw: string) => {
+    const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    if (parts.length === 0) {
       setDraft("");
       return;
     }
-    onChange([...value, trimmed]);
+    let next = value;
+    for (const part of parts) {
+      const result = commitOne(part, next);
+      if (result === null) {
+        // Batch aborted on the first invalid segment; keep whatever we already
+        // appended (parity with per-keystroke behavior).
+        break;
+      }
+      next = result;
+    }
+    if (next !== value) onChange(next);
     setDraft("");
   };
 
@@ -423,7 +461,7 @@ function TagsInput({
     <div className="wk-mcp-tags" onClick={() => inputRef.current?.focus()}>
       {value.map((tag, i) => (
         <span className="wk-mcp-tags__chip" key={`${tag}-${i}`}>
-          {tag}
+          <span className="wk-mcp-tags__chip-text" title={tag}>{tag}</span>
           <button
             type="button"
             className="wk-mcp-tags__chip-remove"
@@ -772,6 +810,12 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
   };
 
   const handleSubmit = async () => {
+    const tagError = validateMcpTags(form.tags);
+    if (tagError) {
+      Toast.warning(tagError);
+      setStep(0);
+      return;
+    }
     const err = firstValidationError();
     if (err) {
       Toast.warning(

--- a/packages/dmworkmcp/src/components/McpDetailModal.tsx
+++ b/packages/dmworkmcp/src/components/McpDetailModal.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import { WKModal, WKButton, t } from "@octo/base";
 import { Toast, Spin } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
+import { Bot, UserRound } from "lucide-react";
 import { deleteMcp, fetchMcpDetail } from "../api/mcpService";
 import { buildQuickStartTabs, TOKEN_PLACEHOLDER } from "../api/quickStartTemplates";
 import type { McpDetail, McpQuickStart } from "../types/mcp";
 import { IconGlyph } from "../utils/icon";
-import { SourceBadge } from "./McpCard";
+import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
+import { resolveOwner } from "./McpCard";
 
 interface McpDetailModalProps {
   /** The id of the MCP to show; null closes the modal. */
@@ -187,6 +189,113 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
     onClose();
   };
 
+  /** Local relative-time formatter — mirrors dmworkskillmarket's
+   *  `formatRelativeTime` but reads from the MCP i18n namespace so we don't
+   *  pull the whole skillmarket utils package for one helper.
+   *
+   *  Negative diffMs (server clock ahead / bad ISO with wrong timezone) would
+   *  otherwise land in the `< minute` branch and stamp every stale future
+   *  date as "just now"; treat any non-positive diff as "just now" only for
+   *  small skew (< 1 min) and fall through to the absolute-date fallback
+   *  otherwise so the tooltip surfaces the raw date instead of a lie. */
+  const formatUpdatedTime = (iso: string): string => {
+    const parsed = new Date(iso).getTime();
+    if (Number.isNaN(parsed)) return "";
+    const diffMs = Date.now() - parsed;
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+    if (diffMs < 0) {
+      // Small clock-skew: still say "just now"; large future skew: show date.
+      if (-diffMs < minute) return t("mcp.time.justNow");
+      return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(parsed));
+    }
+    if (diffMs < minute) return t("mcp.time.justNow");
+    if (diffMs < hour) return t("mcp.time.minutesAgo", { values: { count: Math.max(1, Math.floor(diffMs / minute)) } });
+    if (diffMs < day) return t("mcp.time.hoursAgo", { values: { count: Math.max(1, Math.floor(diffMs / hour)) } });
+    if (diffMs < 30 * day) return t("mcp.time.daysAgo", { values: { count: Math.max(1, Math.floor(diffMs / day)) } });
+    return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(parsed));
+  };
+
+  /** Resolve category display label. `t()` returns the key string when a
+   *  translation is missing, so a backend-added category slug the frontend
+   *  bundle hasn't shipped yet would otherwise render "mcp.category.foo" in
+   *  the badge. Fall back to the raw slug — ugly but truthful — instead. */
+  const resolveCategoryLabel = (key: string): string => {
+    const i18nKey = `mcp.category.${key}`;
+    const label = t(i18nKey);
+    return label === i18nKey ? key : label;
+  };
+
+  const detailHeader = detail ? (
+    <div className="wk-mcp-detail-header">
+      <div className="wk-mcp-detail-header__icon">
+        {detail.icon?.trim() ? (
+          <IconGlyph
+            icon={detail.icon}
+            className="wk-mcp-detail__icon-img"
+            alt={detail.name}
+          />
+        ) : (
+          <span
+            className="wk-mcp-card__icon-default"
+            style={{ background: getMcpAvatarColor(detail.id) }}
+          >
+            {getMcpAvatarText(detail.name)}
+          </span>
+        )}
+      </div>
+      <div className="wk-mcp-detail-header__main">
+        <div className="wk-mcp-detail-header__title-row">
+          <h2 className="wk-mcp-detail-header__title" title={detail.name}>
+            {detail.name}
+          </h2>
+          {detail.category && (
+            <span className="wk-mcp-detail-header__badge" title={resolveCategoryLabel(detail.category)}>
+              {resolveCategoryLabel(detail.category)}
+            </span>
+          )}
+        </div>
+        {(() => {
+          const owner = resolveOwner(detail);
+          const parts: React.ReactNode[] = [];
+          if (owner?.botName) {
+            parts.push(
+              <span key="bot" className="wk-mcp-detail__owner" title={owner.botName}>
+                <Bot className="wk-mcp-card__owner-bot-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{owner.botName}</span>
+              </span>
+            );
+          }
+          if (owner?.humanName) {
+            parts.push(
+              <span key="human" className="wk-mcp-detail__owner" title={owner.humanName}>
+                <UserRound className="wk-mcp-card__owner-user-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{owner.humanName}</span>
+              </span>
+            );
+          }
+          if (detail.updatedAt) {
+            parts.push(
+              <span key="updated" className="wk-mcp-detail-header__updated" title={detail.updatedAt}>
+                {t("mcp.detail.updatedAt", { values: { time: formatUpdatedTime(detail.updatedAt) } })}
+              </span>
+            );
+          }
+          if (parts.length === 0) return null;
+          const withSeparators: React.ReactNode[] = [];
+          parts.forEach((p, i) => {
+            if (i > 0) {
+              withSeparators.push(<span key={`sep-${i}`} className="wk-mcp-card__meta-separator">·</span>);
+            }
+            withSeparators.push(p);
+          });
+          return <div className="wk-mcp-detail-header__meta">{withSeparators}</div>;
+        })()}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <WKModal
       visible={!!mcpId}
@@ -194,7 +303,8 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
       width={900}
       className="wk-mcp-detail-modal"
       bodyStyle={{ height: "70vh", overflowY: "auto" }}
-      title={detail ? detail.name : t("mcp.detail.title")}
+      title={detail ? null : t("mcp.detail.title")}
+      header={detailHeader}
       footer={
         showActions ? (
           confirmingDelete ? (
@@ -236,56 +346,35 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
         </div>
       ) : (
         <div className="wk-mcp-detail">
-          <div className="wk-mcp-detail__meta">
-            <div className="wk-mcp-detail__icon">
-              <IconGlyph
-                icon={detail.icon}
-                className="wk-mcp-detail__icon-img"
-                alt={detail.name}
-              />
-            </div>
-            <div className="wk-mcp-detail__meta-main">
-              <div className="wk-mcp-card__tags">
-                {detail.tags.map((tag) => (
-                  <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              {(detail.creatorName || detail.createdByType === "bot") && (
-                <div className="wk-mcp-detail__meta-line">
-                  {detail.creatorName && (
-                    <span className="wk-mcp-detail__owner">
-                      @{detail.creatorName}
-                    </span>
-                  )}
-                  {/* Bot 徽章跟着 @owner 放在同一行；human/legacy 情况下
-                      SourceBadge 自己会返回 null。 */}
-                  <SourceBadge item={detail} />
-                </div>
-              )}
-              {/* Slogan / 简介 — 详情页空间够，不 clamp。 */}
-              {detail.slogan && (
-                <div className="wk-mcp-detail__slogan">{detail.slogan}</div>
-              )}
-              {/* 工具数量下沉到简介之下，图标 + 数字，与卡片 footer 及
-                  dmworkskillmarket 的 .skill-market-card__stat 一致。 */}
-              <div className="wk-mcp-detail__stats">
-                <span
-                  className="wk-mcp-card__stat"
-                  title={t("mcp.card.toolCount", {
-                    values: { count: detail.toolCount },
-                  })}
-                  aria-label={t("mcp.card.toolCount", {
-                    values: { count: detail.toolCount },
-                  })}
-                >
-                  <IconWrenchStroked size="small" />
-                  {detail.toolCount}
-                </span>
-              </div>
-            </div>
+          {/* Slogan / 简介 — 详情页空间够，不 clamp。 */}
+          {detail.slogan && (
+            <div className="wk-mcp-detail__slogan">{detail.slogan}</div>
+          )}
+          {/* 工具数量：与卡片 footer 及 dmworkskillmarket 的 stats 一致。 */}
+          <div className="wk-mcp-detail__stats">
+            <span
+              className="wk-mcp-card__stat"
+              title={t("mcp.card.toolCount", {
+                values: { count: detail.toolCount },
+              })}
+              aria-label={t("mcp.card.toolCount", {
+                values: { count: detail.toolCount },
+              })}
+            >
+              <IconWrenchStroked size="small" />
+              {detail.toolCount}
+            </span>
           </div>
+          {/* Tags — 放到最下面，与 dmworkskillmarket 的详情弹窗一致。 */}
+          {detail.tags.length > 0 && (
+            <div className="wk-mcp-detail__tags">
+              {detail.tags.map((tag) => (
+                <span key={tag} className="wk-mcp-tag wk-mcp-tag--accent">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
 
           {/* 1. ⚡快速接入 */}
           <section className="wk-mcp-section">

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -33,10 +33,7 @@
     "ai": "AI"
   },
   "source": {
-    "human": "Human",
-    "bot": "Bot",
-    "import": "Imported",
-    "botTooltip": "Created by {{owner}}'s bot"
+    "bot": "Bot"
   },
   "list": {
     "desc": "Browse and connect MCP servers to extend your agent's tools.",
@@ -80,6 +77,14 @@
     "tagLimit": "At most {{count}} tags",
     "tagLengthLimit": "A tag can have at most {{count}} characters",
     "tagInvalidChars": "Tags can only contain letters, digits, spaces, and - _ . / # +"
+  },
+  "filter": {
+    "tags": "Tags",
+    "searchTags": "Search tags",
+    "noTags": "No tags available yet",
+    "noTagsSelected": "No tags selected",
+    "tagsSelected": "{{count}} tag(s) selected",
+    "clear": "Clear"
   },
   "card": {
     "matchReason": {

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -40,7 +40,7 @@
   },
   "list": {
     "desc": "Browse and connect MCP servers to extend your agent's tools.",
-    "create": "New MCP",
+    "create": "Publish MCP",
     "searchPlaceholder": "Search MCPs, tools, tags, or capabilities",
     "searchClear": "Clear",
     "errorTitle": "Failed to load MCPs",
@@ -60,20 +60,43 @@
     "mode": {
       "all": "All",
       "mine": "Mine"
-    },
-    "source": {
-      "filterLabel": "Filter by source",
-      "all": "All sources"
     }
   },
+  "publishMenu": {
+    "botTitle": "Publish via Bot",
+    "botHint": "Copy the prompt for an Agent",
+    "manualTitle": "Manual",
+    "manualHint": "Fill in the form to create an MCP"
+  },
+  "botPublish": {
+    "title": "Publish via Bot",
+    "hint": "Copy the prompt to an Agent and let it publish for you",
+    "copyBtn": "Copy prompt",
+    "copied": "Copied",
+    "copyFailed": "Copy failed. Select the text manually.",
+    "copyUnavailable": "Automatic copy is not available here. Select the text manually."
+  },
+  "form": {
+    "tagLimit": "At most {{count}} tags",
+    "tagLengthLimit": "A tag can have at most {{count}} characters",
+    "tagInvalidChars": "Tags can only contain letters, digits, spaces, and - _ . / # +"
+  },
   "card": {
-    "hitTool": "Matched tool",
-    "hitTag": "Matched tag",
-    "matchReason": { "name": "Matched name", "description": "Matched summary", "tool": "Matched tool", "tag": "Matched tag", "category": "Matched category", "usage": "Matched usage example", "creator": "Matched publisher", "other": "Matched content" },
+    "matchReason": {
+      "name": "Matched name",
+      "description": "Matched summary",
+      "tool": "Matched tool",
+      "tag": "Matched tag",
+      "category": "Matched category",
+      "usage": "Matched usage example",
+      "creator": "Matched publisher",
+      "other": "Matched content"
+    },
     "toolCount": "Tools: {{count}}"
   },
   "detail": {
     "title": "MCP Details",
+    "updatedAt": "Updated {{time}}",
     "quickAccess": "Quick access",
     "qsTab": {
       "prompt": "Prompt",
@@ -251,5 +274,11 @@
     "submit": "Submit",
     "success": "Created",
     "failed": "Create failed"
+  },
+  "time": {
+    "justNow": "just now",
+    "minutesAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}} hours ago",
+    "daysAgo": "{{count}} days ago"
   }
 }

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -140,7 +140,7 @@
     "failed": "Delete failed"
   },
   "create": {
-    "title": "New MCP",
+    "title": "Publish MCP",
     "sectionBasics": "Basics",
     "sectionBasicsDesc": "Shown on the market card and detail header",
     "sectionConnect": "Connection",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -140,7 +140,7 @@
     "failed": "删除失败"
   },
   "create": {
-    "title": "新建 MCP",
+    "title": "上架 MCP",
     "sectionBasics": "基本信息",
     "sectionBasicsDesc": "展示在市场卡片和详情页顶部",
     "sectionConnect": "接入方式",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -33,10 +33,7 @@
     "ai": "AI 能力"
   },
   "source": {
-    "human": "人工创建",
-    "bot": "Bot 创建",
-    "import": "从仓库导入",
-    "botTooltip": "由 {{owner}} 的 Bot 创建"
+    "bot": "Bot 创建"
   },
   "list": {
     "desc": "浏览并接入 MCP 服务，为你的智能体扩展工具能力。",
@@ -80,6 +77,14 @@
     "tagLimit": "最多添加 {{count}} 个标签",
     "tagLengthLimit": "单个标签最多 {{count}} 个字符",
     "tagInvalidChars": "标签仅支持文字、数字、空格和 - _ . / # +"
+  },
+  "filter": {
+    "tags": "标签",
+    "searchTags": "搜索标签",
+    "noTags": "还没有可选标签",
+    "noTagsSelected": "未选择标签",
+    "tagsSelected": "已选 {{count}} 个标签",
+    "clear": "清空"
   },
   "card": {
     "matchReason": {

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -40,7 +40,7 @@
   },
   "list": {
     "desc": "浏览并接入 MCP 服务，为你的智能体扩展工具能力。",
-    "create": "新建 MCP",
+    "create": "上架 MCP",
     "searchPlaceholder": "搜索 MCP、工具、标签或能力",
     "searchClear": "清除",
     "errorTitle": "加载 MCP 失败",
@@ -60,20 +60,43 @@
     "mode": {
       "all": "全部",
       "mine": "我的"
-    },
-    "source": {
-      "filterLabel": "按来源筛选",
-      "all": "全部来源"
     }
   },
+  "publishMenu": {
+    "botTitle": "Bot 上架",
+    "botHint": "复制提示词给 Agent",
+    "manualTitle": "手动上架",
+    "manualHint": "填写表单创建 MCP"
+  },
+  "botPublish": {
+    "title": "Bot 上架",
+    "hint": "复制提示词给 Agent，让它帮你完成上架",
+    "copyBtn": "复制提示词",
+    "copied": "已复制",
+    "copyFailed": "复制失败，请手动选中文本复制",
+    "copyUnavailable": "当前环境不支持自动复制，请手动选中文本复制"
+  },
+  "form": {
+    "tagLimit": "最多添加 {{count}} 个标签",
+    "tagLengthLimit": "单个标签最多 {{count}} 个字符",
+    "tagInvalidChars": "标签仅支持文字、数字、空格和 - _ . / # +"
+  },
   "card": {
-    "hitTool": "命中工具",
-    "hitTag": "命中标签",
-    "matchReason": { "name": "命中名称", "description": "命中简介", "tool": "命中工具", "tag": "命中标签", "category": "命中分类", "usage": "命中使用示例", "creator": "命中发布者", "other": "命中内容" },
+    "matchReason": {
+      "name": "命中名称",
+      "description": "命中简介",
+      "tool": "命中工具",
+      "tag": "命中标签",
+      "category": "命中分类",
+      "usage": "命中使用示例",
+      "creator": "命中发布者",
+      "other": "命中内容"
+    },
     "toolCount": "工具数量: {{count}} 个"
   },
   "detail": {
     "title": "MCP 详情",
+    "updatedAt": "{{time}}更新",
     "quickAccess": "快速接入",
     "qsTab": {
       "prompt": "提示词",
@@ -251,5 +274,11 @@
     "submit": "提交",
     "success": "创建成功",
     "failed": "创建失败"
+  },
+  "time": {
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前",
+    "daysAgo": "{{count}} 天前"
   }
 }

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -359,6 +359,193 @@
   color: var(--wk-text-secondary);
 }
 
+/* Tag filter — trigger sits inside the search control (right of the input,
+   next to the clear button). Popover is anchored below the trigger and
+   mirrors dmworkskillmarket's `.skill-market-tag-filter__popover`. */
+.wk-mcp-tag-filter {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  margin-right: var(--wk-sp-2);
+}
+
+.wk-mcp-tag-filter__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 var(--wk-sp-2);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-text-secondary);
+  font: 500 12px/1 var(--wk-font-sans);
+  cursor: pointer;
+  transition: background var(--wk-dur-fast) var(--wk-ease),
+    color var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-mcp-tag-filter__trigger:hover,
+.wk-mcp-tag-filter__trigger:focus-visible {
+  outline: none;
+  background: var(--wk-bg-item-hover);
+  color: var(--wk-text-primary);
+}
+
+.wk-mcp-tag-filter__trigger.is-active {
+  color: var(--wk-color-accent);
+}
+
+.wk-mcp-tag-filter__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--wk-r-full);
+  background: var(--wk-color-accent);
+  color: var(--wk-text-inverse);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.wk-mcp-tag-filter__popover {
+  position: absolute;
+  z-index: var(--wk-z-dropdown);
+  top: calc(100% + var(--wk-sp-2));
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  width: 260px;
+  max-height: 320px;
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  box-shadow: var(--wk-shadow-md);
+  overflow: hidden;
+}
+
+/* In-popover fuzzy search input — mirrors dmworkskillmarket's
+   .skill-market-tag-filter__search so users get the same UX in both
+   markets. Bound to `tagQuery` state; debounced fetch fires on change. */
+.wk-mcp-tag-filter__search {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border-bottom: 1px solid var(--wk-border-subtle);
+  color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-tag-filter__search input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--wk-text-primary);
+  font: inherit;
+}
+
+.wk-mcp-tag-filter__search input::placeholder {
+  color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-tag-filter__option-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-tag-filter__option-count {
+  flex: 0 0 auto;
+  color: var(--wk-text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.wk-mcp-tag-filter__list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--wk-sp-1);
+  scrollbar-width: none;
+}
+
+.wk-mcp-tag-filter__list::-webkit-scrollbar {
+  display: none;
+}
+
+.wk-mcp-tag-filter__option {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  width: 100%;
+  padding: var(--wk-sp-2);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.wk-mcp-tag-filter__option:hover,
+.wk-mcp-tag-filter__option:focus-visible {
+  outline: none;
+  background: var(--wk-bg-item-hover);
+}
+
+.wk-mcp-tag-filter__option.is-active {
+  color: var(--wk-color-accent);
+  font-weight: 500;
+}
+
+.wk-mcp-tag-filter__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--wk-color-accent);
+}
+
+.wk-mcp-tag-filter__empty {
+  padding: var(--wk-sp-3);
+  color: var(--wk-text-tertiary);
+  font-size: 13px;
+  text-align: center;
+}
+
+.wk-mcp-tag-filter__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--wk-sp-2);
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border-top: 1px solid var(--wk-border-subtle);
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+}
+
+.wk-mcp-tag-filter__footer button {
+  padding: 4px var(--wk-sp-2);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-color-accent);
+  font: inherit;
+  cursor: pointer;
+}
+
+.wk-mcp-tag-filter__footer button:disabled {
+  color: var(--wk-text-disabled);
+  cursor: not-allowed;
+}
+
 /* 分类条 — 与 dmworkskillmarket 的分类胶囊保持一致。 */
 .wk-mcp__pills {
   display: flex;

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -39,6 +39,149 @@
   gap: var(--wk-sp-2);
 }
 
+/* Publish 按钮 + Bot/手动 下拉 —— 与 dmworkskillmarket 的
+   .skill-market-publish-menu 一致。 */
+.wk-mcp-publish-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.wk-mcp-publish-menu__panel {
+  position: absolute;
+  z-index: var(--wk-z-dropdown);
+  top: calc(100% + var(--wk-sp-2));
+  right: 0;
+  display: grid;
+  gap: var(--wk-sp-1);
+  width: 220px;
+  padding: var(--wk-sp-1);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  box-shadow: var(--wk-shadow-md);
+}
+
+.wk-mcp-publish-menu__panel button {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--wk-sp-2);
+  width: 100%;
+  min-width: 0;
+  padding: var(--wk-sp-2);
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: var(--wk-text-secondary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.wk-mcp-publish-menu__panel button:hover,
+.wk-mcp-publish-menu__panel button:focus-visible {
+  outline: none;
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-primary);
+}
+
+.wk-mcp-publish-menu__panel button > svg {
+  color: var(--wk-icon-default);
+}
+
+.wk-mcp-publish-menu__panel span,
+.wk-mcp-publish-menu__panel strong,
+.wk-mcp-publish-menu__panel small {
+  display: block;
+  min-width: 0;
+}
+
+.wk-mcp-publish-menu__panel strong {
+  overflow: hidden;
+  color: var(--wk-text-strong);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-publish-menu__panel small {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Bot 上架 modal — mirrors dmworkskillmarket's .skill-market-prompt-modal.
+   头部 icon + 标题/副标题，body 灰底代码框，footer 复制按钮。 */
+.wk-mcp-prompt-modal__header {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+}
+
+.wk-mcp-prompt-modal__header h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--wk-text-strong);
+}
+
+.wk-mcp-prompt-modal__header p {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-prompt-modal__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--wk-r-md);
+  background: var(--wk-accent-tint-06, rgba(127, 59, 245, 0.06));
+  color: var(--wk-color-accent);
+}
+
+.wk-mcp-prompt-modal__body {
+  padding: var(--wk-sp-3);
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-md);
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  font-size: 13px;
+  line-height: 1.7;
+  max-height: 55vh;
+  overflow: auto;
+  scrollbar-width: none;
+}
+
+.wk-mcp-prompt-modal__body::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide the outer modal-body scrollbar too — the inner code area handles its
+   own scroll via max-height + overflow. Keeps the modal chrome flat. */
+.wk-mcp-prompt-modal .wk-modal-body {
+  scrollbar-width: none;
+}
+
+.wk-mcp-prompt-modal .wk-modal-body::-webkit-scrollbar {
+  display: none;
+}
+
+.wk-mcp-prompt-modal__pre {
+  margin: 0;
+  color: var(--wk-text-primary);
+  font: 13px/1.7 var(--wk-font-sans);
+  white-space: pre-wrap;
+}
+
 /* Underline-style tabs — matches skill-market-tabs. Active tab uses
    --wk-text-accent with a 2px underline pseudo-element. */
 .wk-mcp__tabs {
@@ -120,43 +263,6 @@
   align-items: center;
   gap: var(--wk-sp-3);
   flex-wrap: wrap;
-}
-
-/* 来源分段控件（issue #894）。现在落位在结果摘要行的右侧，与
-   dmworkskillmarket 的 sort 位置对齐；由父级 result-summary 的
-   justify-content: space-between 自动推到右边。 */
-.wk-mcp__source-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px;
-  border-radius: var(--wk-r-full);
-  background: var(--wk-bg-elevated);
-}
-
-.wk-mcp__source-btn {
-  display: inline-flex;
-  align-items: center;
-  height: 24px;
-  padding: 0 var(--wk-sp-3);
-  border: none;
-  border-radius: var(--wk-r-full);
-  background: transparent;
-  color: var(--wk-text-secondary);
-  font-size: var(--wk-text-size-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.wk-mcp__source-btn:hover {
-  color: var(--wk-text-primary);
-}
-
-.wk-mcp__source-btn--active {
-  background: var(--wk-bg-surface);
-  color: var(--wk-text-primary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 /* 结果摘要行 — 与 dmworkskillmarket 的 .skill-market-result-summary
@@ -305,11 +411,16 @@
   font-size: var(--wk-text-size-xs);
   opacity: 0.7;
 }
+
+/* Match-reasons chips — rendered between the card body and the footer to
+   explain WHY a search hit landed on this row when the matched field
+   (tool / usage_example / creator) isn't already visible on the card.
+   Uses a dashed accent border to distinguish from regular tags. */
 .wk-mcp-card__reasons {
   display: flex;
   flex-wrap: wrap;
   gap: var(--wk-sp-1);
-  margin-bottom: var(--wk-sp-3);
+  margin-top: var(--wk-sp-2);
 }
 
 .wk-mcp-card__reason {
@@ -330,8 +441,6 @@
   color: var(--wk-text-tertiary);
 }
 
-.wk-mcp-card mark, .wk-mcp-tag mark { background: #f59e0b; color: #fff; font-weight: var(--wk-font-semibold); padding: 0 3px; border-radius: 3px; }
-
 /* ── Card grid ───────────────────────────────────────────────────────────── */
 .wk-mcp__grid {
   display: grid;
@@ -342,7 +451,9 @@
 .wk-mcp-card {
   display: flex;
   flex-direction: column;
-  padding: var(--wk-sp-4);
+  min-width: 0;
+  min-height: 184px;
+  padding: var(--wk-sp-3);
   border: 1px solid var(--wk-border-subtle);
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-base);
@@ -353,120 +464,154 @@
     box-shadow var(--wk-dur-fast) var(--wk-ease);
 }
 
-.wk-mcp-card:hover {
+.wk-mcp-card:hover,
+.wk-mcp-card:focus-visible {
+  outline: none;
   border-color: var(--wk-border-strong);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
-.wk-mcp-card__header {
+/* Row 1: icon + header column. Matches `.skill-market-card__top`. */
+.wk-mcp-card__top {
   display: flex;
   align-items: flex-start;
-  gap: var(--wk-sp-3);
-  margin-bottom: var(--wk-sp-3);
+  gap: var(--wk-sp-2);
 }
 
 .wk-mcp-card__icon {
-  flex: none;
-  width: 40px;
-  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 22px;
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-elevated);
+  color: var(--wk-icon-default);
+  font-size: 24px;
+  overflow: hidden;
 }
 
-.wk-mcp-card__heading {
+/* Empty-icon fallback — 与 dmworkskillmarket 的 .skill-market-card__icon-default
+   一致：hash 出的实心底色 + 首两字母，白字 15px/600。 */
+.wk-mcp-card__icon-default {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  color: #fff;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+}
+
+.wk-mcp-card__header {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
   flex: 1;
+  min-width: 0;
+  min-height: 48px;
+}
+
+.wk-mcp-card__title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--wk-sp-2);
   min-width: 0;
 }
 
 .wk-mcp-card__name {
-  font-size: var(--wk-text-size-lg);
-  font-weight: var(--wk-font-semibold);
-  color: var(--wk-text-primary);
-  margin-bottom: var(--wk-sp-1);
+  display: -webkit-box;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  color: var(--wk-text-strong);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.wk-mcp-card__meta-row {
   display: flex;
   align-items: center;
-  gap: var(--wk-sp-1);
-  /* Ellipsis-clip the name so a runaway MCP name doesn't wrap and blow the
-     card height out. min-width:0 lets the text span shrink inside its
-     flex parent (the .wk-mcp-card__heading), which is a required
-     incantation for flex ellipsis to work. */
+  gap: 5px;
   min-width: 0;
-}
-
-.wk-mcp-card__name-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
-/* Provenance badge (issue #894). Rendered next to the MCP name for bot-
-   authored rows only; human/legacy rows show no chip. Reuses `.wk-mcp-tag`
-   as the base primitive (size / padding / radius / typography) and only
-   layers on the bot-specific colour and the icon-shape variant, so any
-   design-token nudge to the tag chip lands here for free. Cursor is
-   intentionally unset — the badge has no click handler; on the card it
-   inherits the parent card's pointer, and clicking still opens the detail
-   as usual. */
-.wk-mcp-source {
-  gap: 4px;
-  white-space: nowrap;
-}
-
-.wk-mcp-source__icon {
-  font-size: var(--wk-text-size-xs);
-  line-height: 1;
-}
-
-.wk-mcp-source__label {
-  max-width: 96px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.wk-mcp-source--bot {
-  /* Slightly bluer surface than plain tags to distinguish "meta" from "tag". */
-  background: rgba(56, 132, 255, 0.10);
-  color: rgba(56, 132, 255, 0.95);
-}
-
-/* Icon-only variant used in the card grid — square-ish chip, no label,
-   tooltip on hover carries the full "bot name · owner" context. */
-.wk-mcp-source--icon {
-  width: 22px;
-  padding: 0;
-  justify-content: center;
-}
-
-.wk-mcp-source--icon .wk-mcp-source__icon {
+  color: var(--wk-text-tertiary);
   font-size: 13px;
+  line-height: 1.35;
+}
+
+/* @creator / bot 名 — 与 dmworkskillmarket 的 .skill-market-card__owner 一致：
+   accent 色 + 600 字重，把发布者从灰色 meta 行里挑出来。 */
+.wk-mcp-card__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--wk-color-accent);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-card__owner-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-card__owner-bot-icon,
+.wk-mcp-card__owner-user-icon {
+  flex: 0 0 auto;
+}
+
+.wk-mcp-card__meta-separator {
+  flex: 0 0 auto;
+  color: var(--wk-text-quaternary, var(--wk-text-tertiary));
 }
 
 .wk-mcp-card__tags {
   display: flex;
-  gap: var(--wk-sp-1);
+  gap: 6px;
+  min-height: 24px;
+  margin-top: var(--wk-sp-3);
+  overflow: hidden;
+  align-items: center;
+  white-space: nowrap;
   flex-wrap: wrap;
 }
 
 .wk-mcp-tag {
   display: inline-flex;
   align-items: center;
-  height: 18px;
-  padding: 0 var(--wk-sp-1-5);
-  border-radius: var(--wk-r-sm);
+  flex: 0 1 auto;
+  max-width: 108px;
+  min-width: 0;
+  padding: 3px 8px;
+  border-radius: var(--wk-r-full);
   background: var(--wk-bg-elevated);
   color: var(--wk-text-tertiary);
-  font-size: var(--wk-text-size-xs);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wk-mcp-tag--accent {
-  background: var(--wk-ai-glow);
-  color: var(--wk-text-accent);
+  background: var(--wk-accent-tint-06, rgba(127, 59, 245, 0.06));
+  color: var(--wk-color-accent);
 }
 
 /* Detail modal slogan — same voice as the card slogan but no line clamp,
@@ -534,10 +679,11 @@
 }
 
 .wk-mcp-card__slogan {
-  font-size: var(--wk-text-size-base);
+  min-height: 42px;
+  margin: var(--wk-sp-3) 0 0;
+  font-size: 13px;
   color: var(--wk-text-secondary);
-  line-height: 1.5;
-  margin-bottom: var(--wk-sp-3);
+  line-height: 1.55;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -547,12 +693,23 @@
 .wk-mcp-card__footer {
   display: flex;
   align-items: center;
+  gap: var(--wk-sp-2);
   justify-content: space-between;
   margin-top: auto;
   padding-top: var(--wk-sp-3);
   border-top: 1px solid var(--wk-border-subtle);
   font-size: var(--wk-text-size-sm);
   color: var(--wk-text-tertiary);
+}
+
+.wk-mcp-card__stats {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wk-sp-3);
+  min-width: 0;
+  color: var(--wk-text-secondary);
+  font-size: 12px;
+  line-height: 1;
 }
 
 /* 与 dmworkskillmarket 的 .skill-market-card__stat 视觉一致：
@@ -587,15 +744,20 @@
 }
 
 /* ═══ Detail modal ═════════════════════════════════════════════════════════ */
-.wk-mcp-detail__meta {
+/* ═══ Detail modal ═════════════════════════════════════════════════════════ */
+
+/* Detail modal custom header — 与 dmworkskillmarket 的
+   .skill-market-detail-header 对齐：图标 + 标题行（h2 + 分类 chip）+
+   meta 行（作者 · 更新时间）。 */
+.wk-mcp-detail-header {
   display: flex;
   align-items: flex-start;
   gap: var(--wk-sp-3);
-  margin-bottom: var(--wk-sp-5);
+  padding: var(--wk-sp-4) var(--wk-sp-5) var(--wk-sp-3);
 }
 
-.wk-mcp-detail__icon {
-  flex: none;
+.wk-mcp-detail-header__icon {
+  flex: 0 0 48px;
   width: 48px;
   height: 48px;
   display: flex;
@@ -604,26 +766,73 @@
   font-size: 26px;
   border-radius: var(--wk-r-md);
   background: var(--wk-bg-elevated);
+  overflow: hidden;
 }
 
-.wk-mcp-detail__meta-main {
+.wk-mcp-detail-header__main {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wk-mcp-detail-header__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
   min-width: 0;
 }
 
-/* meta 行：@owner + Bot 徽章。工具数量已下沉到 slogan 之下的 stats 行。 */
-.wk-mcp-detail__meta-line {
+.wk-mcp-detail-header__title {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--wk-text-strong);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wk-mcp-detail-header__badge {
   display: inline-flex;
   align-items: center;
-  gap: var(--wk-sp-1);
-  font-size: var(--wk-text-size-sm);
+  flex: 0 0 auto;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: var(--wk-r-full);
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.wk-mcp-detail-header__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
   color: var(--wk-text-tertiary);
-  margin-top: var(--wk-sp-1);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.wk-mcp-detail-header__updated {
+  flex: 0 0 auto;
+  color: var(--wk-text-tertiary);
 }
 
 /* @creator 段 — 与 dmworkskillmarket 的 .skill-market-card__owner 视觉一致：
    accent 色 + 600 字重，把发布者从灰色 meta 行里挑出来。 */
 .wk-mcp-detail__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--wk-color-accent);
   font-weight: 600;
 }
@@ -634,16 +843,19 @@
   display: flex;
   align-items: center;
   gap: var(--wk-sp-3);
-  margin-top: var(--wk-sp-2);
+  margin-top: var(--wk-sp-3);
   font-size: var(--wk-text-size-sm);
   color: var(--wk-text-tertiary);
 }
 
-.wk-mcp-detail__desc {
-  font-size: var(--wk-text-size-base);
-  color: var(--wk-text-secondary);
-  line-height: 1.6;
-  margin-bottom: var(--wk-sp-5);
+/* 详情页尾部的 tags — 与 dmworkskillmarket 的详情弹窗一致，放在
+   slogan + stats 后面，作为标签兜底展示。 */
+.wk-mcp-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--wk-sp-3);
+  margin-bottom: var(--wk-sp-3);
 }
 
 .wk-mcp-section {
@@ -1199,6 +1411,9 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  max-width: 140px;
+  min-width: 0;
+  overflow: hidden;
   height: 22px;
   padding: 0 var(--wk-sp-2);
   border-radius: var(--wk-r-full);
@@ -1207,7 +1422,15 @@
   font-size: var(--wk-text-size-xs);
 }
 
+.wk-mcp-tags__chip-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .wk-mcp-tags__chip-remove {
+  flex: 0 0 auto;
   background: none;
   border: none;
   padding: 0;

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -519,13 +519,12 @@
 
 .wk-mcp-card__title-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--wk-sp-2);
   min-width: 0;
 }
 
 .wk-mcp-card__name {
-  display: -webkit-box;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -534,8 +533,8 @@
   font-size: 16px;
   font-weight: 700;
   line-height: 1.35;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wk-mcp-card__meta-row {

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -1,13 +1,15 @@
 import React, { Component } from "react";
 import { Spin, Toast } from "@douyinfe/semi-ui";
-import { IconSearch, IconPlus, IconClose } from "@douyinfe/semi-icons";
+import { IconSearch, IconClose } from "@douyinfe/semi-icons";
+import { Bot, ChevronDown, Upload } from "lucide-react";
 import { I18nContext, t, WKApp, WKButton } from "@octo/base";
 import { fetchMcpList, fetchMcpMine } from "../api/mcpService";
 import { mcpListErrorI18nKey } from "../api/mcpListError";
-import type { McpCategory, McpCreatedByType, McpDetail, McpListItem } from "../types/mcp";
+import type { McpCategory, McpDetail, McpListItem } from "../types/mcp";
 import McpCard from "../components/McpCard";
 import McpDetailModal from "../components/McpDetailModal";
 import McpCreateModal from "../components/McpCreateModal";
+import McpBotPublishModal from "../components/McpBotPublishModal";
 import "../index.css";
 import { parseMcpListQuery, serializeMcpListQuery } from "./mcpListQuery";
 
@@ -19,18 +21,6 @@ const PAGE_SIZE = 20;
 /** Fire the next page when the user scrolls within this many px of bottom. */
 const SCROLL_THRESHOLD_PX = 200;
 
-/** Source (来源) segmented control options. Module-level const so the array
- *  is stable across renders — otherwise every parent update re-allocates it
- *  and defeats any downstream memoisation on the pills. */
-const SOURCE_FILTER_OPTIONS: ReadonlyArray<{
-  value: McpCreatedByType | undefined;
-  labelKey: string;
-}> = [
-  { value: undefined, labelKey: "mcp.list.source.all" },
-  { value: "human", labelKey: "mcp.source.human" },
-  { value: "bot", labelKey: "mcp.source.bot" },
-];
-
 interface McpMarketListPageState {
   items: McpListItem[];
   categories: McpCategory[];
@@ -39,13 +29,16 @@ interface McpMarketListPageState {
   error: string | null;
   keyword: string;
   categoriesSelected: string[];
-  /** Provenance filter (issue #894). Single-select; undefined = 全部来源. */
-  createdByType?: McpCreatedByType;
   mode: ListMode;
   offset: number;
   total: number;
   detailId: string | null;
   createVisible: boolean;
+  /** Dropdown-menu open state for the "上架 MCP" button. Mirrors Skill's
+   *  `publishMenuOpen`. */
+  publishMenuOpen: boolean;
+  /** Bot 上架 modal open state. */
+  botPublishVisible: boolean;
   /** When set, the create/edit modal opens in EDIT mode prefilled from this
    *  detail. Cleared on modal close. Distinct from `createVisible` — this
    *  drives the "editing" branch of the shared modal component. */
@@ -71,14 +64,17 @@ export default class McpMarketListPage extends Component<
     error: null,
     keyword: "",
     categoriesSelected: [],
-    createdByType: undefined,
     mode: "all",
     offset: 0,
     total: 0,
     detailId: null,
     createVisible: false,
+    publishMenuOpen: false,
+    botPublishVisible: false,
     editingDetail: null,
   };
+
+  private publishMenuRef = React.createRef<HTMLDivElement>();
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private requestVersion = 0;
@@ -90,11 +86,47 @@ export default class McpMarketListPage extends Component<
     WKApp.mittBus.on("space-changed", this.handleSpaceChanged_);
   }
 
+  componentDidUpdate(_prevProps: {}, prevState: McpMarketListPageState) {
+    // Only own the two global listeners while the publish dropdown is open —
+    // mirrors dmworkskillmarket's SkillListPage. Attaching in componentDidMount
+    // unconditionally forces every card click / scroll on the page to trip
+    // through a no-op guard for the 99% of the session where the menu is
+    // closed.
+    if (prevState.publishMenuOpen !== this.state.publishMenuOpen) {
+      if (this.state.publishMenuOpen) {
+        document.addEventListener("pointerdown", this.handleGlobalPointerDown_);
+        document.addEventListener("keydown", this.handleGlobalKeyDown_);
+      } else {
+        document.removeEventListener("pointerdown", this.handleGlobalPointerDown_);
+        document.removeEventListener("keydown", this.handleGlobalKeyDown_);
+      }
+    }
+  }
+
   componentWillUnmount() {
     WKApp.mittBus.off("wk:nav-menu-activated", this.handleNavMenuActivated_);
     WKApp.mittBus.off("space-changed", this.handleSpaceChanged_);
+    // Idempotent — safe if the menu was closed at unmount.
+    document.removeEventListener("pointerdown", this.handleGlobalPointerDown_);
+    document.removeEventListener("keydown", this.handleGlobalKeyDown_);
     if (this.searchTimer) clearTimeout(this.searchTimer);
   }
+
+  /** Close the publish dropdown on outside click. Attached only while
+   *  publishMenuOpen (see componentDidUpdate). */
+  private handleGlobalPointerDown_ = (e: PointerEvent) => {
+    if (!this.publishMenuRef.current?.contains(e.target as Node)) {
+      this.setState({ publishMenuOpen: false });
+    }
+  };
+
+  /** Close the publish dropdown on Escape. Attached only while
+   *  publishMenuOpen (see componentDidUpdate). */
+  private handleGlobalKeyDown_ = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      this.setState({ publishMenuOpen: false });
+    }
+  };
 
   private handleSpaceChanged_ = () => this.loadData();
 
@@ -114,7 +146,6 @@ export default class McpMarketListPage extends Component<
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
-        createdByType: this.state.createdByType,
         limit: PAGE_SIZE,
         offset: 0,
       });
@@ -151,22 +182,19 @@ export default class McpMarketListPage extends Component<
     const requestVersion = this.requestVersion;
     const requestKeyword = this.state.keyword;
     const requestCategories = this.state.categoriesSelected.join(",");
-    const requestCreatedBy = this.state.createdByType ?? "";
     this.setState({ loadingMore: true });
     try {
       const fetcher = this.state.mode === "mine" ? fetchMcpMine : fetchMcpList;
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
-        createdByType: this.state.createdByType,
         limit: PAGE_SIZE,
         offset,
       });
       if (
         requestVersion !== this.requestVersion ||
         requestKeyword !== this.state.keyword ||
-        requestCategories !== this.state.categoriesSelected.join(",") ||
-        requestCreatedBy !== (this.state.createdByType ?? "")
+        requestCategories !== this.state.categoriesSelected.join(",")
       ) {
         return;
       }
@@ -200,7 +228,7 @@ export default class McpMarketListPage extends Component<
 
   private handleMode = (mode: ListMode) => {
     if (mode === this.state.mode) return;
-    this.setState({ mode, categoriesSelected: [], createdByType: undefined }, () => this.loadData());
+    this.setState({ mode, categoriesSelected: [] }, () => this.loadData());
   };
 
   /** Patch a single row after a successful edit — keeps scroll position
@@ -265,13 +293,6 @@ export default class McpMarketListPage extends Component<
     }), () => this.loadData());
   };
 
-  /** Toggle the "来源" segmented filter (issue #894). value === undefined
-   *  means the 全部 pill. */
-  private handleCreatedBy = (value: McpCreatedByType | undefined) => {
-    if (value === this.state.createdByType) return;
-    this.setState({ createdByType: value }, () => this.loadData());
-  };
-
   render() {
     const {
       items,
@@ -281,7 +302,6 @@ export default class McpMarketListPage extends Component<
       error,
       keyword,
       categoriesSelected,
-      createdByType,
       mode,
       total,
       detailId,
@@ -335,13 +355,50 @@ export default class McpMarketListPage extends Component<
                 )}
               </div>
             </div>
-            <WKButton
-              variant="primary"
-              icon={<IconPlus />}
-              onClick={() => this.setState({ createVisible: true })}
-            >
-              {t("mcp.list.create")}
-            </WKButton>
+            <div className="wk-mcp-publish-menu" ref={this.publishMenuRef}>
+              <WKButton
+                variant="primary"
+                icon={<Upload size={15} />}
+                onClick={() =>
+                  this.setState((prev) => ({ publishMenuOpen: !prev.publishMenuOpen }))
+                }
+                aria-haspopup="menu"
+                aria-expanded={this.state.publishMenuOpen}
+              >
+                {t("mcp.list.create")}
+                <ChevronDown size={14} />
+              </WKButton>
+              {this.state.publishMenuOpen && (
+                <div className="wk-mcp-publish-menu__panel" role="menu">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() =>
+                      this.setState({ publishMenuOpen: false, botPublishVisible: true })
+                    }
+                  >
+                    <Bot size={16} />
+                    <span>
+                      <strong>{t("mcp.publishMenu.botTitle")}</strong>
+                      <small>{t("mcp.publishMenu.botHint")}</small>
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() =>
+                      this.setState({ publishMenuOpen: false, createVisible: true })
+                    }
+                  >
+                    <Upload size={16} />
+                    <span>
+                      <strong>{t("mcp.publishMenu.manualTitle")}</strong>
+                      <small>{t("mcp.publishMenu.manualHint")}</small>
+                    </span>
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </header>
 
@@ -390,35 +447,6 @@ export default class McpMarketListPage extends Component<
                   >
                     {t("mcp.list.total", { values: { count: total } })}
                   </span>
-                  {/* 来源筛选 — 单选分段控件，放在结果摘要的右侧，跟
-                      dmworkskillmarket 的 sort 位置一致。「全部来源」= 清除筛选。
-                      即使当前结果为空也保留，方便用户放宽筛选。 */}
-                  <div
-                    className="wk-mcp__source-filter"
-                    role="group"
-                    aria-label={t("mcp.list.source.filterLabel")}
-                  >
-                    {SOURCE_FILTER_OPTIONS.map(({ value, labelKey }) => {
-                      const active =
-                        value === undefined
-                          ? createdByType === undefined
-                          : createdByType === value;
-                      return (
-                        <button
-                          key={value ?? "all"}
-                          type="button"
-                          className={
-                            active
-                              ? "wk-mcp__source-btn wk-mcp__source-btn--active"
-                              : "wk-mcp__source-btn"
-                          }
-                          onClick={() => this.handleCreatedBy(value)}
-                        >
-                          {t(labelKey)}
-                        </button>
-                      );
-                    })}
-                  </div>
                 </div>
                 {items.length === 0 ? (
                   <div className="wk-mcp__state">{t("mcp.list.empty")}</div>
@@ -429,7 +457,6 @@ export default class McpMarketListPage extends Component<
                         <McpCard
                           key={item.id}
                           item={item}
-                          keyword={keyword}
                           onClick={(it) => this.setState({ detailId: it.id })}
                         />
                       ))}
@@ -468,6 +495,10 @@ export default class McpMarketListPage extends Component<
             this.setState({ createVisible: false, editingDetail: null })
           }
           onSaved={this.handleSaved}
+        />
+        <McpBotPublishModal
+          visible={this.state.botPublishVisible}
+          onClose={() => this.setState({ botPublishVisible: false })}
         />
       </div>
     );

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import axios from "axios";
 import { Spin, Toast } from "@douyinfe/semi-ui";
 import { IconSearch, IconClose } from "@douyinfe/semi-icons";
 import { Bot, Check, ChevronDown, SlidersHorizontal, Upload } from "lucide-react";
@@ -193,6 +194,7 @@ export default class McpMarketListPage extends Component<
       tagSuggestions: [],
       categoriesSelected: [],
       publishMenuOpen: false,
+      botPublishVisible: false,
     }, () => this.loadData());
   };
 
@@ -249,10 +251,20 @@ export default class McpMarketListPage extends Component<
           this.setState({ tagSuggestions: items });
         })
         .catch((err) => {
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          // Silent fall-through: leave whatever the popover had before.
-          // The tag chips still work off tagsSelected, so a fetch failure
-          // is a degraded but not broken state.
+          // Stale request: newer fetch or cancellation already superseded us.
+          if (this.tagFetchController !== controller) return;
+          // Abort path: axios cancellation (get<T>() re-throws unchanged) OR
+          // the mock's DOMException. Either way, silently drop.
+          if (
+            axios.isCancel(err) ||
+            (err instanceof DOMException && err.name === "AbortError")
+          ) {
+            return;
+          }
+          // Surface the classified failure so the popover doesn't leave
+          // stale suggestions on a real backend/network problem — matches
+          // loadMore()'s Toast pattern one method away.
+          Toast.error(t(mcpListErrorI18nKey(err)));
         });
     }, 160);
   }
@@ -320,8 +332,13 @@ export default class McpMarketListPage extends Component<
     if (items.length >= total) return;
     const requestVersion = this.requestVersion;
     const requestKeyword = this.state.keyword;
-    const requestCategories = this.state.categoriesSelected.join(",");
-    const requestTags = this.state.tagsSelected.join(",");
+    // Snapshot the filter state by array reference — setState always allocates
+    // a fresh array on toggle/clear, so an identity mismatch after the await
+    // is a reliable "the user changed filters mid-request" signal. Avoids
+    // `join(",")` collisions between e.g. ["v1.0,beta"] and ["v1.0","beta"]
+    // (tags may themselves contain commas — see mcpListQuery.ts).
+    const requestCategoriesRef = this.state.categoriesSelected;
+    const requestTagsRef = this.state.tagsSelected;
     this.setState({ loadingMore: true });
     try {
       const fetcher = this.state.mode === "mine" ? fetchMcpMine : fetchMcpList;
@@ -335,8 +352,8 @@ export default class McpMarketListPage extends Component<
       if (
         requestVersion !== this.requestVersion ||
         requestKeyword !== this.state.keyword ||
-        requestCategories !== this.state.categoriesSelected.join(",") ||
-        requestTags !== this.state.tagsSelected.join(",")
+        requestCategoriesRef !== this.state.categoriesSelected ||
+        requestTagsRef !== this.state.tagsSelected
       ) {
         return;
       }
@@ -388,7 +405,10 @@ export default class McpMarketListPage extends Component<
   /** Patch a single row after a successful edit — keeps scroll position
    *  intact (a full loadData() would reset offset to 0 and rebuild the grid).
    *  Category-pill counts may go slightly stale until the next full reload,
-   *  which is an acceptable tradeoff for not losing the user's scroll spot. */
+   *  which is an acceptable tradeoff for not losing the user's scroll spot.
+   *  Also refreshes updatedAt + owner attribution so re-opening the detail
+   *  modal doesn't show pre-edit metadata, and drops matchReasons since the
+   *  edited fields may no longer align with the current search hit. */
   private handleItemUpdated = (updated: McpDetail) => {
     this.setState((prev) => {
       const idx = prev.items.findIndex((it) => it.id === updated.id);
@@ -404,6 +424,10 @@ export default class McpMarketListPage extends Component<
         icon: updated.icon,
         visibility: updated.visibility,
         creatorName: updated.creatorName,
+        updatedAt: updated.updatedAt,
+        createdByType: updated.createdByType,
+        createdByBotName: updated.createdByBotName,
+        matchReasons: undefined,
       };
       return { items: next };
     });

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -94,6 +94,7 @@ export default class McpMarketListPage extends Component<
 
   private publishMenuRef = React.createRef<HTMLDivElement>();
   private tagFilterRef = React.createRef<HTMLDivElement>();
+  private tagSearchInputRef = React.createRef<HTMLInputElement>();
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private requestVersion = 0;
@@ -130,6 +131,13 @@ export default class McpMarketListPage extends Component<
     const queryChanged = prevState.tagQuery !== this.state.tagQuery && this.state.tagFilterOpen;
     if (openedNow || queryChanged) {
       this.scheduleTagFetch_();
+    }
+    if (openedNow) {
+      // Focus the popover search input WITHOUT letting the browser scroll
+      // the ancestor list container — the input lives inside `.wk-mcp__body`
+      // which owns the near-bottom scroll listener; a scrollIntoView nudge
+      // there would trip loadMore() at the worst possible time.
+      this.tagSearchInputRef.current?.focus({ preventScroll: true });
     }
     if (prevState.tagFilterOpen && !this.state.tagFilterOpen) {
       this.cancelTagFetch_();
@@ -191,6 +199,38 @@ export default class McpMarketListPage extends Component<
   private tagFetchTimer: ReturnType<typeof setTimeout> | null = null;
   private tagFetchController: AbortController | null = null;
 
+  /** Identity-keyed memo for the popover's `tagRows`. Recomputing the
+   *  selected+suggestions union + sort on every parent re-render was
+   *  O(n*m) — measurable when the caller has typed several keystrokes into
+   *  the primary search input while the tag popover is open. Keying on the
+   *  array references is fine: state updates always produce new refs, so a
+   *  hit is a genuine "nothing changed" reuse. */
+  private tagRowsCacheKey_: [string[], McpTagSuggestion[]] | null = null;
+  private tagRowsCache_: Array<{ name: string; count?: number }> = [];
+
+  private memoizedTagRows_(
+    selected: string[],
+    suggestions: McpTagSuggestion[]
+  ): Array<{ name: string; count?: number }> {
+    if (
+      this.tagRowsCacheKey_ &&
+      this.tagRowsCacheKey_[0] === selected &&
+      this.tagRowsCacheKey_[1] === suggestions
+    ) {
+      return this.tagRowsCache_;
+    }
+    const suggestionNames = new Set(suggestions.map((s) => s.name));
+    const rows: Array<{ name: string; count?: number }> = [];
+    for (const name of selected) {
+      if (!suggestionNames.has(name)) rows.push({ name });
+    }
+    for (const s of suggestions) rows.push(s);
+    rows.sort((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.name.localeCompare(b.name));
+    this.tagRowsCacheKey_ = [selected, suggestions];
+    this.tagRowsCache_ = rows;
+    return rows;
+  }
+
   /** Debounce + fire a /mcp_tags fetch, wiring the response into
    *  tagSuggestions. Cancels any in-flight request via AbortController so a
    *  fast typist doesn't clobber a fresh response with a stale one. */
@@ -202,7 +242,8 @@ export default class McpMarketListPage extends Component<
       const controller = new AbortController();
       this.tagFetchController = controller;
       const query = this.state.tagQuery;
-      fetchMcpTags(query, { signal: controller.signal, limit: 100 })
+      const mode = this.state.mode;
+      fetchMcpTags(query, { signal: controller.signal, limit: 100, mode })
         .then((items) => {
           if (this.tagFetchController !== controller) return;
           this.setState({ tagSuggestions: items });
@@ -329,7 +370,19 @@ export default class McpMarketListPage extends Component<
 
   private handleMode = (mode: ListMode) => {
     if (mode === this.state.mode) return;
-    this.setState({ mode, categoriesSelected: [], tagsSelected: [] }, () => this.loadData());
+    // Full reset — tag suggestions are mode-scoped on the backend (see
+    // /mcp_tags?mode=mine), so keeping stale suggestions after a tab switch
+    // paints suggestions the just-loaded list can't produce. Mirrors
+    // handleSpaceChanged_ for the same reason.
+    this.cancelTagFetch_();
+    this.setState({
+      mode,
+      categoriesSelected: [],
+      tagsSelected: [],
+      tagFilterOpen: false,
+      tagQuery: "",
+      tagSuggestions: [],
+    }, () => this.loadData());
   };
 
   /** Patch a single row after a successful edit — keeps scroll position
@@ -432,13 +485,12 @@ export default class McpMarketListPage extends Component<
     // Tag popover options: backend-authoritative via /mcp_tags (mcp-v1.md
     // §4.8). Union with tagsSelected so a chip the user selected before the
     // fetch completes (or from a stale query) still shows up so they can
-    // un-select it.
+    // un-select it. Cached on the class instance keyed on the identity of
+    // (tagsSelected, tagSuggestions) — recomputing the union+sort on every
+    // parent re-render (keyword keystroke, hover, etc.) was measurable at
+    // 100+ suggestions.
     const selectedNames = new Set<string>(tagsSelected);
-    const tagRows: Array<{ name: string; count?: number }> = tagsSelected
-      .filter((name) => !this.state.tagSuggestions.some((s) => s.name === name))
-      .map((name) => ({ name }));
-    for (const s of this.state.tagSuggestions) tagRows.push(s);
-    tagRows.sort((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.name.localeCompare(b.name));
+    const tagRows = this.memoizedTagRows_(tagsSelected, this.state.tagSuggestions);
 
     const hasMore = items.length < total;
     // Ownership check: the "mine" tab is defined as caller-owned records
@@ -513,12 +565,12 @@ export default class McpMarketListPage extends Component<
                       <label className="wk-mcp-tag-filter__search">
                         <IconSearch aria-hidden />
                         <input
+                          ref={this.tagSearchInputRef}
                           type="search"
                           value={this.state.tagQuery}
                           onChange={(e) => this.setState({ tagQuery: e.target.value })}
                           placeholder={t("mcp.filter.searchTags")}
                           aria-label={t("mcp.filter.searchTags")}
-                          autoFocus
                         />
                       </label>
                       <div

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import { Spin, Toast } from "@douyinfe/semi-ui";
 import { IconSearch, IconClose } from "@douyinfe/semi-icons";
-import { Bot, ChevronDown, Upload } from "lucide-react";
+import { Bot, Check, ChevronDown, SlidersHorizontal, Upload } from "lucide-react";
 import { I18nContext, t, WKApp, WKButton } from "@octo/base";
-import { fetchMcpList, fetchMcpMine } from "../api/mcpService";
+import { fetchMcpList, fetchMcpMine, fetchMcpTags, McpTagSuggestion } from "../api/mcpService";
 import { mcpListErrorI18nKey } from "../api/mcpListError";
 import type { McpCategory, McpDetail, McpListItem } from "../types/mcp";
 import McpCard from "../components/McpCard";
@@ -29,6 +29,20 @@ interface McpMarketListPageState {
   error: string | null;
   keyword: string;
   categoriesSelected: string[];
+  /** Multi-tag filter (mcp-v1.md §4.2, AND semantics). Populated from
+   *  `?tag=` URL params on mount; the tag popover in the search bar drives
+   *  updates. Empty = no tag filter. */
+  tagsSelected: string[];
+  /** Whether the search-bar tag popover is open. Kept in class state so the
+   *  outside-click listener + Escape handler can toggle it. */
+  tagFilterOpen: boolean;
+  /** Fuzzy filter typed into the tag-popover search input. Debounced fetch
+   *  against `/mcp_tags` populates `tagSuggestions`. */
+  tagQuery: string;
+  /** Backend-supplied tag suggestions (mcp-v1.md §4.8). Repopulated whenever
+   *  the popover opens or `tagQuery` changes; empty until the first fetch
+   *  resolves. */
+  tagSuggestions: McpTagSuggestion[];
   mode: ListMode;
   offset: number;
   total: number;
@@ -64,6 +78,10 @@ export default class McpMarketListPage extends Component<
     error: null,
     keyword: "",
     categoriesSelected: [],
+    tagsSelected: [],
+    tagFilterOpen: false,
+    tagQuery: "",
+    tagSuggestions: [],
     mode: "all",
     offset: 0,
     total: 0,
@@ -75,6 +93,7 @@ export default class McpMarketListPage extends Component<
   };
 
   private publishMenuRef = React.createRef<HTMLDivElement>();
+  private tagFilterRef = React.createRef<HTMLDivElement>();
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private requestVersion = 0;
@@ -87,13 +106,15 @@ export default class McpMarketListPage extends Component<
   }
 
   componentDidUpdate(_prevProps: {}, prevState: McpMarketListPageState) {
-    // Only own the two global listeners while the publish dropdown is open —
-    // mirrors dmworkskillmarket's SkillListPage. Attaching in componentDidMount
-    // unconditionally forces every card click / scroll on the page to trip
-    // through a no-op guard for the 99% of the session where the menu is
-    // closed.
-    if (prevState.publishMenuOpen !== this.state.publishMenuOpen) {
-      if (this.state.publishMenuOpen) {
+    // Only own the two global listeners while EITHER the publish dropdown or
+    // the tag filter popover is open — mirrors dmworkskillmarket's
+    // SkillListPage. Attaching in componentDidMount unconditionally forces
+    // every card click / scroll on the page to trip through a no-op guard
+    // for the 99% of the session where both are closed.
+    const wasOpen = prevState.publishMenuOpen || prevState.tagFilterOpen;
+    const isOpen = this.state.publishMenuOpen || this.state.tagFilterOpen;
+    if (wasOpen !== isOpen) {
+      if (isOpen) {
         document.addEventListener("pointerdown", this.handleGlobalPointerDown_);
         document.addEventListener("keydown", this.handleGlobalKeyDown_);
       } else {
@@ -101,34 +122,110 @@ export default class McpMarketListPage extends Component<
         document.removeEventListener("keydown", this.handleGlobalKeyDown_);
       }
     }
+    // Fetch tag suggestions whenever the popover just opened or the fuzzy
+    // query changed while it's open. Debounced by 160ms — mirrors Skill's
+    // SearchBar (dmworkskillmarket/SearchBar.tsx) so the two markets pace
+    // the tag catalog the same way.
+    const openedNow = !prevState.tagFilterOpen && this.state.tagFilterOpen;
+    const queryChanged = prevState.tagQuery !== this.state.tagQuery && this.state.tagFilterOpen;
+    if (openedNow || queryChanged) {
+      this.scheduleTagFetch_();
+    }
+    if (prevState.tagFilterOpen && !this.state.tagFilterOpen) {
+      this.cancelTagFetch_();
+    }
   }
 
   componentWillUnmount() {
     WKApp.mittBus.off("wk:nav-menu-activated", this.handleNavMenuActivated_);
     WKApp.mittBus.off("space-changed", this.handleSpaceChanged_);
-    // Idempotent — safe if the menu was closed at unmount.
+    this.cancelTagFetch_();
+    // Idempotent — safe if both popovers were closed at unmount.
     document.removeEventListener("pointerdown", this.handleGlobalPointerDown_);
     document.removeEventListener("keydown", this.handleGlobalKeyDown_);
     if (this.searchTimer) clearTimeout(this.searchTimer);
   }
 
-  /** Close the publish dropdown on outside click. Attached only while
-   *  publishMenuOpen (see componentDidUpdate). */
+  /** Close either open dropdown on outside click. Attached only while at
+   *  least one is open (see componentDidUpdate). */
   private handleGlobalPointerDown_ = (e: PointerEvent) => {
-    if (!this.publishMenuRef.current?.contains(e.target as Node)) {
+    if (
+      this.state.publishMenuOpen &&
+      !this.publishMenuRef.current?.contains(e.target as Node)
+    ) {
       this.setState({ publishMenuOpen: false });
+    }
+    if (
+      this.state.tagFilterOpen &&
+      !this.tagFilterRef.current?.contains(e.target as Node)
+    ) {
+      this.setState({ tagFilterOpen: false });
     }
   };
 
-  /** Close the publish dropdown on Escape. Attached only while
-   *  publishMenuOpen (see componentDidUpdate). */
+  /** Close either open dropdown on Escape. Attached only while at least one
+   *  is open (see componentDidUpdate). */
   private handleGlobalKeyDown_ = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
-      this.setState({ publishMenuOpen: false });
+      this.setState({ publishMenuOpen: false, tagFilterOpen: false });
     }
   };
 
-  private handleSpaceChanged_ = () => this.loadData();
+  /** Reset per-space UI state on space switch — dropped selections + closed
+   *  popovers before refetching. Tags / categories are space-scoped so a
+   *  filter from space A stays with space A; leaving it selected across a
+   *  switch produces a request the new backend will silently return zero
+   *  rows for. Matches dmworkskillmarket's SkillListPage handler. */
+  private handleSpaceChanged_ = () => {
+    this.cancelTagFetch_();
+    this.setState({
+      tagsSelected: [],
+      tagFilterOpen: false,
+      tagQuery: "",
+      tagSuggestions: [],
+      categoriesSelected: [],
+      publishMenuOpen: false,
+    }, () => this.loadData());
+  };
+
+  private tagFetchTimer: ReturnType<typeof setTimeout> | null = null;
+  private tagFetchController: AbortController | null = null;
+
+  /** Debounce + fire a /mcp_tags fetch, wiring the response into
+   *  tagSuggestions. Cancels any in-flight request via AbortController so a
+   *  fast typist doesn't clobber a fresh response with a stale one. */
+  private scheduleTagFetch_() {
+    if (this.tagFetchTimer) window.clearTimeout(this.tagFetchTimer);
+    this.tagFetchTimer = window.setTimeout(() => {
+      this.tagFetchTimer = null;
+      this.cancelTagFetch_();
+      const controller = new AbortController();
+      this.tagFetchController = controller;
+      const query = this.state.tagQuery;
+      fetchMcpTags(query, { signal: controller.signal, limit: 100 })
+        .then((items) => {
+          if (this.tagFetchController !== controller) return;
+          this.setState({ tagSuggestions: items });
+        })
+        .catch((err) => {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          // Silent fall-through: leave whatever the popover had before.
+          // The tag chips still work off tagsSelected, so a fetch failure
+          // is a degraded but not broken state.
+        });
+    }, 160);
+  }
+
+  private cancelTagFetch_() {
+    if (this.tagFetchTimer) {
+      window.clearTimeout(this.tagFetchTimer);
+      this.tagFetchTimer = null;
+    }
+    if (this.tagFetchController) {
+      this.tagFetchController.abort();
+      this.tagFetchController = null;
+    }
+  }
 
   private handleNavMenuActivated_ = ({ menuId }: { menuId: string }) => {
     if (menuId === "mcp-market") {
@@ -146,6 +243,7 @@ export default class McpMarketListPage extends Component<
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
+        tags: this.state.tagsSelected,
         limit: PAGE_SIZE,
         offset: 0,
       });
@@ -182,19 +280,22 @@ export default class McpMarketListPage extends Component<
     const requestVersion = this.requestVersion;
     const requestKeyword = this.state.keyword;
     const requestCategories = this.state.categoriesSelected.join(",");
+    const requestTags = this.state.tagsSelected.join(",");
     this.setState({ loadingMore: true });
     try {
       const fetcher = this.state.mode === "mine" ? fetchMcpMine : fetchMcpList;
       const resp = await fetcher({
         keyword: this.state.keyword,
         categories: this.state.categoriesSelected,
+        tags: this.state.tagsSelected,
         limit: PAGE_SIZE,
         offset,
       });
       if (
         requestVersion !== this.requestVersion ||
         requestKeyword !== this.state.keyword ||
-        requestCategories !== this.state.categoriesSelected.join(",")
+        requestCategories !== this.state.categoriesSelected.join(",") ||
+        requestTags !== this.state.tagsSelected.join(",")
       ) {
         return;
       }
@@ -228,7 +329,7 @@ export default class McpMarketListPage extends Component<
 
   private handleMode = (mode: ListMode) => {
     if (mode === this.state.mode) return;
-    this.setState({ mode, categoriesSelected: [] }, () => this.loadData());
+    this.setState({ mode, categoriesSelected: [], tagsSelected: [] }, () => this.loadData());
   };
 
   /** Patch a single row after a successful edit — keeps scroll position
@@ -293,6 +394,23 @@ export default class McpMarketListPage extends Component<
     }), () => this.loadData());
   };
 
+  /** Multi-tag filter — clicking a tag in the popover toggles membership.
+   *  AND semantics: a row must carry every selected tag (mcp-v1.md §4.2).
+   *  Refetches on every change; the tag popover stays open so the user can
+   *  toggle several tags in one interaction. */
+  private handleToggleTag = (tag: string) => {
+    this.setState((prev) => ({
+      tagsSelected: prev.tagsSelected.includes(tag)
+        ? prev.tagsSelected.filter((t) => t !== tag)
+        : [...prev.tagsSelected, tag],
+    }), () => this.loadData());
+  };
+
+  private handleClearTags = () => {
+    if (this.state.tagsSelected.length === 0) return;
+    this.setState({ tagsSelected: [] }, () => this.loadData());
+  };
+
   render() {
     const {
       items,
@@ -302,12 +420,25 @@ export default class McpMarketListPage extends Component<
       error,
       keyword,
       categoriesSelected,
+      tagsSelected,
+      tagFilterOpen,
       mode,
       total,
       detailId,
       createVisible,
       editingDetail,
     } = this.state;
+
+    // Tag popover options: backend-authoritative via /mcp_tags (mcp-v1.md
+    // §4.8). Union with tagsSelected so a chip the user selected before the
+    // fetch completes (or from a stale query) still shows up so they can
+    // un-select it.
+    const selectedNames = new Set<string>(tagsSelected);
+    const tagRows: Array<{ name: string; count?: number }> = tagsSelected
+      .filter((name) => !this.state.tagSuggestions.some((s) => s.name === name))
+      .map((name) => ({ name }));
+    for (const s of this.state.tagSuggestions) tagRows.push(s);
+    tagRows.sort((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.name.localeCompare(b.name));
 
     const hasMore = items.length < total;
     // Ownership check: the "mine" tab is defined as caller-owned records
@@ -353,6 +484,102 @@ export default class McpMarketListPage extends Component<
                     <IconClose aria-hidden />
                   </button>
                 )}
+                <div className="wk-mcp-tag-filter" ref={this.tagFilterRef}>
+                  <button
+                    type="button"
+                    className={
+                      tagsSelected.length > 0
+                        ? "wk-mcp-tag-filter__trigger is-active"
+                        : "wk-mcp-tag-filter__trigger"
+                    }
+                    aria-expanded={tagFilterOpen}
+                    aria-haspopup="listbox"
+                    onClick={() =>
+                      this.setState((prev) => ({
+                        tagFilterOpen: !prev.tagFilterOpen,
+                      }))
+                    }
+                  >
+                    <SlidersHorizontal size={15} aria-hidden="true" />
+                    {t("mcp.filter.tags")}
+                    {tagsSelected.length > 0 && (
+                      <span className="wk-mcp-tag-filter__count">
+                        {tagsSelected.length}
+                      </span>
+                    )}
+                  </button>
+                  {tagFilterOpen && (
+                    <div className="wk-mcp-tag-filter__popover">
+                      <label className="wk-mcp-tag-filter__search">
+                        <IconSearch aria-hidden />
+                        <input
+                          type="search"
+                          value={this.state.tagQuery}
+                          onChange={(e) => this.setState({ tagQuery: e.target.value })}
+                          placeholder={t("mcp.filter.searchTags")}
+                          aria-label={t("mcp.filter.searchTags")}
+                          autoFocus
+                        />
+                      </label>
+                      <div
+                        className="wk-mcp-tag-filter__list"
+                        role="listbox"
+                        aria-label={t("mcp.filter.tags")}
+                      >
+                        {tagRows.length > 0 ? (
+                          tagRows.map((row) => {
+                            const selected = selectedNames.has(row.name);
+                            return (
+                              <button
+                                key={row.name}
+                                type="button"
+                                className={
+                                  selected
+                                    ? "wk-mcp-tag-filter__option is-active"
+                                    : "wk-mcp-tag-filter__option"
+                                }
+                                role="option"
+                                aria-selected={selected}
+                                title={row.name}
+                                onClick={() => this.handleToggleTag(row.name)}
+                              >
+                                <span className="wk-mcp-tag-filter__check">
+                                  {selected && (
+                                    <Check size={15} aria-hidden="true" />
+                                  )}
+                                </span>
+                                <span className="wk-mcp-tag-filter__option-name">{row.name}</span>
+                                {typeof row.count === "number" && (
+                                  <span className="wk-mcp-tag-filter__option-count">{row.count}</span>
+                                )}
+                              </button>
+                            );
+                          })
+                        ) : (
+                          <div className="wk-mcp-tag-filter__empty">
+                            {t("mcp.filter.noTags")}
+                          </div>
+                        )}
+                      </div>
+                      <div className="wk-mcp-tag-filter__footer">
+                        <span>
+                          {tagsSelected.length > 0
+                            ? t("mcp.filter.tagsSelected", {
+                                values: { count: tagsSelected.length },
+                              })
+                            : t("mcp.filter.noTagsSelected")}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={this.handleClearTags}
+                          disabled={tagsSelected.length === 0}
+                        >
+                          {t("mcp.filter.clear")}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
             <div className="wk-mcp-publish-menu" ref={this.publishMenuRef}>

--- a/packages/dmworkmcp/src/pages/mcpListQuery.test.ts
+++ b/packages/dmworkmcp/src/pages/mcpListQuery.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpListQuery, serializeMcpListQuery } from "./mcpListQuery";
+
+describe("parseMcpListQuery — URL → state", () => {
+  it("collects repeated `tag` params (not comma-split)", () => {
+    const parsed = parseMcpListQuery("?tag=v1.0&tag=beta&tag=v1.0,rc");
+    expect(parsed.tagsSelected).toEqual(["v1.0", "beta", "v1.0,rc"]);
+  });
+
+  it("collects repeated `category` params the same way", () => {
+    const parsed = parseMcpListQuery("?category=dev&category=data");
+    expect(parsed.categoriesSelected).toEqual(["dev", "data"]);
+  });
+
+  it("preserves URL-encoded tag values on the way in", () => {
+    // %2C encodes ',', %20 encodes ' ', %23 encodes '#'
+    const parsed = parseMcpListQuery("?tag=v1.0%2Cbeta&tag=%23net&tag=c%2B%2B");
+    expect(parsed.tagsSelected).toEqual(["v1.0,beta", "#net", "c++"]);
+  });
+
+  it("returns empty arrays when no filter params are set", () => {
+    const parsed = parseMcpListQuery("");
+    expect(parsed.tagsSelected).toEqual([]);
+    expect(parsed.categoriesSelected).toEqual([]);
+    expect(parsed.keyword).toBe("");
+  });
+});
+
+describe("serializeMcpListQuery — state → URL", () => {
+  it("emits one `tag=` key per tag (never comma-joined, never `tag[]=`)", () => {
+    const q = serializeMcpListQuery({
+      keyword: "",
+      categoriesSelected: [],
+      tagsSelected: ["v1.0", "beta"],
+    });
+    expect(q).toBe("tag=v1.0&tag=beta");
+  });
+
+  it("URL-encodes commas inside a tag value so the wire form stays unambiguous", () => {
+    const q = serializeMcpListQuery({
+      keyword: "",
+      categoriesSelected: [],
+      tagsSelected: ["v1.0,beta"],
+    });
+    expect(q).toBe("tag=v1.0%2Cbeta");
+  });
+
+  it("scrubs legacy `created_by_type` (removed provenance filter)", () => {
+    const q = serializeMcpListQuery(
+      { keyword: "", categoriesSelected: [], tagsSelected: [] },
+      "?created_by_type=bot&other=keep"
+    );
+    // The known keys are stripped even when no new value replaces them; the
+    // unknown `other` param survives.
+    expect(q).toContain("other=keep");
+    expect(q).not.toContain("created_by_type");
+  });
+
+  it("scrubs stale `tag`/`category`/`keyword` before appending fresh ones", () => {
+    const q = serializeMcpListQuery(
+      { keyword: "new", categoriesSelected: ["data"], tagsSelected: ["beta"] },
+      "?keyword=old&tag=alpha&category=dev"
+    );
+    expect(q).toBe("keyword=new&category=data&tag=beta");
+  });
+});
+
+describe("URL round-trip — parse ∘ serialize is identity for query-hostile chars", () => {
+  it.each([
+    ["v1.0,beta"],
+    ["c++"],
+    ["#net"],
+    ["api/v1"],
+    ["with space"],
+    ["数据服务"],
+  ])("preserves %s", (tag) => {
+    const q = serializeMcpListQuery({
+      keyword: "",
+      categoriesSelected: [],
+      tagsSelected: [tag],
+    });
+    expect(parseMcpListQuery("?" + q).tagsSelected).toEqual([tag]);
+  });
+
+  it("preserves multi-tag ordering and multiplicity", () => {
+    const tags = ["v1.0", "beta", "v1.0,rc", "c++"];
+    const q = serializeMcpListQuery({
+      keyword: "",
+      categoriesSelected: [],
+      tagsSelected: tags,
+    });
+    expect(parseMcpListQuery("?" + q).tagsSelected).toEqual(tags);
+  });
+});

--- a/packages/dmworkmcp/src/pages/mcpListQuery.ts
+++ b/packages/dmworkmcp/src/pages/mcpListQuery.ts
@@ -1,6 +1,7 @@
 export interface McpListQueryState {
   keyword: string;
   categoriesSelected: string[];
+  tagsSelected: string[];
 }
 
 export function parseMcpListQuery(search: string): McpListQueryState {
@@ -8,6 +9,7 @@ export function parseMcpListQuery(search: string): McpListQueryState {
   return {
     keyword: q.get("keyword") ?? "",
     categoriesSelected: q.getAll("category"),
+    tagsSelected: q.getAll("tag"),
   };
 }
 
@@ -15,8 +17,9 @@ export function serializeMcpListQuery(state: McpListQueryState, current = ""): s
   const q = new URLSearchParams(current);
   // `created_by_type` scrubbed too — legacy bookmarks land silently on
   // the unfiltered list rather than carrying a filter no UI can toggle.
-  ["keyword", "category", "created_by_type"].forEach((key) => q.delete(key));
+  ["keyword", "category", "tag", "created_by_type"].forEach((key) => q.delete(key));
   if (state.keyword.trim()) q.set("keyword", state.keyword.trim());
   state.categoriesSelected.forEach((value) => q.append("category", value));
+  state.tagsSelected.forEach((value) => q.append("tag", value));
   return q.toString();
 }

--- a/packages/dmworkmcp/src/pages/mcpListQuery.ts
+++ b/packages/dmworkmcp/src/pages/mcpListQuery.ts
@@ -1,36 +1,22 @@
-import type { McpCreatedByType } from "../types/mcp";
-
 export interface McpListQueryState {
   keyword: string;
   categoriesSelected: string[];
-  /** Provenance filter (issue #894). Single-select — undefined = 全部来源.
-   *  Only `human` and `bot` round-trip today because those are the only
-   *  segmented-control pills the toolbar renders; `import` from the wire
-   *  enum is intentionally dropped on parse so we can't end up with an
-   *  active filter that no pill can display or clear (a shared URL with
-   *  ?created_by_type=import would otherwise render every pill inactive
-   *  while the list is silently filtered). When #867 lands and the toolbar
-   *  gains an "Imported" pill, add `import` to the allowlist below. */
-  createdByType?: McpCreatedByType;
 }
 
 export function parseMcpListQuery(search: string): McpListQueryState {
   const q = new URLSearchParams(search);
-  const raw = q.get("created_by_type");
-  const createdByType: McpCreatedByType | undefined =
-    raw === "human" || raw === "bot" ? raw : undefined;
   return {
     keyword: q.get("keyword") ?? "",
     categoriesSelected: q.getAll("category"),
-    createdByType,
   };
 }
 
 export function serializeMcpListQuery(state: McpListQueryState, current = ""): string {
   const q = new URLSearchParams(current);
+  // `created_by_type` scrubbed too — legacy bookmarks land silently on
+  // the unfiltered list rather than carrying a filter no UI can toggle.
   ["keyword", "category", "created_by_type"].forEach((key) => q.delete(key));
   if (state.keyword.trim()) q.set("keyword", state.keyword.trim());
   state.categoriesSelected.forEach((value) => q.append("category", value));
-  if (state.createdByType) q.set("created_by_type", state.createdByType);
   return q.toString();
 }

--- a/packages/dmworkmcp/src/utils/mcpAvatar.test.ts
+++ b/packages/dmworkmcp/src/utils/mcpAvatar.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { getMcpAvatarColor, getMcpAvatarText } from "./mcpAvatar";
+
+describe("getMcpAvatarColor — id-keyed, deterministic", () => {
+  it("returns the same color for the same id across calls", () => {
+    const a = getMcpAvatarColor("mcp-42");
+    const b = getMcpAvatarColor("mcp-42");
+    expect(a).toBe(b);
+  });
+
+  it("keys on id, not display name — two MCPs with the same name still get distinct-looking backgrounds", () => {
+    // The palette has only 6 slots so we can't guarantee two ids collide to
+    // DIFFERENT colors, but the contract is `color = f(id)` — a regression to
+    // `f(name)` would return the same color for these two rows regardless of
+    // id, and this asserts that at least SOME id pair produces a different
+    // color to prove the id is being read.
+    const swatches = new Set<string>();
+    for (let i = 0; i < 24; i++) swatches.add(getMcpAvatarColor(`mcp-${i}`));
+    expect(swatches.size).toBeGreaterThan(1);
+  });
+
+  it("empty id falls back to a fixed slot without throwing", () => {
+    expect(() => getMcpAvatarColor("")).not.toThrow();
+    expect(typeof getMcpAvatarColor("")).toBe("string");
+  });
+});
+
+describe("getMcpAvatarText — display-char extraction", () => {
+  it("empty name → literal M", () => {
+    expect(getMcpAvatarText("")).toBe("M");
+    expect(getMcpAvatarText("   ")).toBe("M");
+  });
+
+  it("CJK name → first TWO wide chars (regression guard against slice(0,1))", () => {
+    expect(getMcpAvatarText("数据服务")).toBe("数据");
+    expect(getMcpAvatarText("数据")).toBe("数据");
+  });
+
+  it("single CJK char → that char alone", () => {
+    expect(getMcpAvatarText("数")).toBe("数");
+  });
+
+  it("all-digit name → first two digits", () => {
+    expect(getMcpAvatarText("12345")).toBe("12");
+    expect(getMcpAvatarText("7")).toBe("7");
+  });
+
+  it("multi-token latin name → uppercase initials of the first two tokens", () => {
+    expect(getMcpAvatarText("my-cool-mcp")).toBe("MC");
+    expect(getMcpAvatarText("hello world")).toBe("HW");
+    expect(getMcpAvatarText("data.service")).toBe("DS");
+    expect(getMcpAvatarText("data_service")).toBe("DS");
+  });
+
+  it("single latin token → first char uppercased", () => {
+    expect(getMcpAvatarText("github")).toBe("G");
+  });
+
+  it("mixed CJK + latin → CJK branch wins (matches design)", () => {
+    expect(getMcpAvatarText("Github 工具")).toBe("工具");
+  });
+});

--- a/packages/dmworkmcp/src/utils/mcpAvatar.ts
+++ b/packages/dmworkmcp/src/utils/mcpAvatar.ts
@@ -1,0 +1,74 @@
+// Hash-based color + text generation for MCP default avatars, used when
+// item.icon is empty. Mirrors dmworkskillmarket's skillAvatar.ts approach
+// but keys color off `id` (per issue #1009 clarification) so two MCPs with
+// the same display name still get distinct backgrounds.
+
+const AVATAR_COLORS = [
+  "#34C759", // 绿
+  "#6569E8", // 紫
+  "#FA8C16", // 橙
+  "#1AC4B3", // 青
+  "#B3D600", // 黄绿
+  "#5B9BF5", // 蓝
+];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (const ch of s) {
+    h = (h * 31 + (ch.codePointAt(0) ?? 0)) >>> 0;
+  }
+  return h;
+}
+
+/** Deterministic background color for an MCP with no icon. Keyed on id
+ *  (not name) so duplicate-named rows still get distinct swatches. */
+export function getMcpAvatarColor(id: string): string {
+  return AVATAR_COLORS[hashString(id || "") % AVATAR_COLORS.length];
+}
+
+function isWideChar(ch: string): boolean {
+  const c = ch.codePointAt(0) ?? 0;
+  return (
+    (c >= 0x1100 && c <= 0x115f) ||
+    (c >= 0x2e80 && c <= 0xa4cf) ||
+    (c >= 0xac00 && c <= 0xd7a3) ||
+    (c >= 0xf900 && c <= 0xfaff) ||
+    (c >= 0xff00 && c <= 0xff60)
+  );
+}
+
+function visibleChars(s: string): string[] {
+  const out: string[] = [];
+  for (const ch of s) {
+    if (!/\s/.test(ch)) out.push(ch);
+  }
+  return out;
+}
+
+/**
+ * Extract 1-2 display chars for the MCP avatar fallback:
+ *   - Contains CJK → first 2 wide chars
+ *   - All digits → first 2 digits
+ *   - Contains letters → up to 2 uppercase initials (split on `- _ . space`)
+ *   - Otherwise → first char uppercase
+ */
+export function getMcpAvatarText(name: string): string {
+  const chars = visibleChars(name);
+  if (chars.length === 0) return "M";
+
+  const wide = chars.filter(isWideChar);
+  if (wide.length > 0) return wide.slice(0, 2).join("");
+
+  if (chars.every((c) => /[0-9]/.test(c))) return chars.slice(0, 2).join("");
+
+  if (chars.some((c) => /[a-zA-Z]/.test(c))) {
+    const parts = name.split(/[-_\s.]+/).filter(Boolean);
+    const initials = parts
+      .slice(0, 2)
+      .map((p) => p.charAt(0).toUpperCase())
+      .join("");
+    return initials || chars[0].toUpperCase();
+  }
+
+  return chars[0].toUpperCase();
+}

--- a/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.test.ts
+++ b/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMcpBotPublishPrompt,
+  isValidMcpSpaceId,
+  resolveMcpAPIBaseURL,
+} from "./mcpBotPublishPrompt";
+
+describe("isValidMcpSpaceId — server UUID gate", () => {
+  it("accepts a canonical UUIDv4", () => {
+    expect(isValidMcpSpaceId("11111111-2222-3333-4444-555555555555")).toBe(true);
+  });
+  it("accepts uppercase / mixed-case hex", () => {
+    expect(isValidMcpSpaceId("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")).toBe(true);
+  });
+  it("trims surrounding whitespace before checking", () => {
+    expect(isValidMcpSpaceId("  11111111-2222-3333-4444-555555555555  ")).toBe(true);
+  });
+  it.each([
+    "",
+    "not-a-uuid",
+    "11111111222233334444555555555555",
+    "11111111-2222-3333-4444-555555555555;rm -rf /",
+    "$(whoami)",
+    "..",
+    "11111111-2222-3333-4444",
+  ])("rejects malformed value %j", (bad) => {
+    expect(isValidMcpSpaceId(bad)).toBe(false);
+  });
+});
+
+describe("getMcpBotPublishPrompt — shell-safe interpolation", () => {
+  const goodId = "11111111-2222-3333-4444-555555555555";
+
+  it("embeds a valid UUID spaceId verbatim into the login example", () => {
+    const p = getMcpBotPublishPrompt({ spaceId: goodId, apiBaseUrl: "https://example.com" });
+    expect(p).toContain(`--profile space-${goodId}`);
+    expect(p).toContain(`--space ${goodId}`);
+    expect(p).toContain("https://example.com");
+  });
+
+  it.each([
+    "$(whoami)",
+    "; rm -rf /",
+    "`whoami`",
+    "|| cat /etc/passwd",
+    "not-a-uuid",
+    "",
+  ])("substitutes the <space-id> placeholder for injection payload %j (never lets it reach a shell example)", (payload) => {
+    const p = getMcpBotPublishPrompt({ spaceId: payload, apiBaseUrl: "https://example.com" });
+    // The payload must NEVER end up in the shell example. The prompt falls
+    // back to the same `<space-id>` placeholder used when no id is set,
+    // forcing the operator to notice and provide a real one.
+    expect(p).not.toContain(payload || "__unreachable__");
+    expect(p).toContain("--profile space-<space-id>");
+    expect(p).toContain("--space <space-id>");
+  });
+
+  it("always ends with the authoritative-inputs footer (guard against Prompt truncation)", () => {
+    const p = getMcpBotPublishPrompt({ spaceId: goodId, apiBaseUrl: "https://example.com" });
+    expect(p).toMatch(/Space ID、API 地址和可见范围是本次操作的权威输入。$/);
+  });
+
+  it("carries the 'do not output token' guard verbatim", () => {
+    // Regression guard: dropping this line would produce an insecure bot run
+    // with no CI signal. Externally observable — a bot receiving the prompt
+    // would then execute shell commands with the token in argv.
+    const p = getMcpBotPublishPrompt({ spaceId: goodId });
+    expect(p).toContain("不得输出 Token");
+  });
+
+  it("uses the placeholder when apiBaseUrl is empty", () => {
+    const p = getMcpBotPublishPrompt({ spaceId: goodId, apiBaseUrl: "" });
+    expect(p).toContain("<api-base-url>");
+  });
+});
+
+describe("resolveMcpAPIBaseURL — origin normalisation", () => {
+  it("returns the origin of an absolute apiURL", () => {
+    expect(resolveMcpAPIBaseURL("https://api.example.com/market/api/v1", "https://x")).toBe(
+      "https://api.example.com"
+    );
+  });
+  it("falls back to origin when apiURL is empty", () => {
+    expect(resolveMcpAPIBaseURL("", "https://page.example.com")).toBe("https://page.example.com");
+  });
+  it("resolves a relative apiURL against origin", () => {
+    expect(resolveMcpAPIBaseURL("/api/v1", "https://page.example.com")).toBe(
+      "https://page.example.com"
+    );
+  });
+});

--- a/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
+++ b/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
@@ -3,6 +3,26 @@ export interface McpBotPublishPromptValues {
   apiBaseUrl?: string;
 }
 
+// Server-issued space IDs are UUIDv4 (36 chars, lowercase hex + hyphens);
+// see server/internal/space/space.go. Reject anything else before embedding
+// into a shell command example so a poisoned localStorage fallback value
+// (see McpBotPublishModal.getCurrentSpaceId) can't inject shell tokens like
+// `$(whoami)` / `;` / backticks into `--space ${spaceId}`. The prompt then
+// falls back to the same `<space-id>` placeholder used when no id is set,
+// forcing the operator to notice and provide a real one.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Whether a caller-supplied space id has the server-issued UUIDv4 shape.
+ *  Callers use this to gate the copy button — an unusable placeholder in the
+ *  prompt should not be copiable. */
+export function isValidMcpSpaceId(raw?: string): boolean {
+  return typeof raw === "string" && UUID_RE.test(raw.trim());
+}
+
+function sanitizeSpaceId(raw?: string): string {
+  return isValidMcpSpaceId(raw) ? (raw as string).trim() : "<space-id>";
+}
+
 /** Normalize the API base URL: trust the configured API URL when it's a full
  *  origin, otherwise fall back to the page origin. Mirrors dmworkskillmarket's
  *  resolveAPIBaseURL so Skill and MCP bot prompts point at the same backend. */
@@ -20,7 +40,7 @@ export function resolveMcpAPIBaseURL(apiURL: string, origin: string): string {
  *  workflow instead of a "Publish as a Bot" section that doesn't exist for
  *  MCP. */
 export function getMcpBotPublishPrompt(values: McpBotPublishPromptValues = {}): string {
-  const spaceId = values.spaceId?.trim() || "<space-id>";
+  const spaceId = sanitizeSpaceId(values.spaceId);
   const apiBaseUrl = values.apiBaseUrl?.trim() || "<api-base-url>";
 
   return `使用 octo-cli 内置的 \`octo-marketplace\` Skill，将指定 MCP 服务器上架到 OCTO Marketplace。

--- a/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
+++ b/packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts
@@ -1,0 +1,73 @@
+export interface McpBotPublishPromptValues {
+  spaceId?: string;
+  apiBaseUrl?: string;
+}
+
+/** Normalize the API base URL: trust the configured API URL when it's a full
+ *  origin, otherwise fall back to the page origin. Mirrors dmworkskillmarket's
+ *  resolveAPIBaseURL so Skill and MCP bot prompts point at the same backend. */
+export function resolveMcpAPIBaseURL(apiURL: string, origin: string): string {
+  const target = new URL(apiURL || origin, origin);
+  return target.origin;
+}
+
+/** Build the prompt handed to a bot to publish an MCP server listing.
+ *
+ *  Command surface is verified against octo-cli's embedded `octo-marketplace`
+ *  Skill (`skills/octo-marketplace/mcp.md`). Unlike Skill publishing there is
+ *  no dedicated bot endpoint — the bot uses the same `marketplace mcp create`
+ *  command as any owner, so this prompt directs it to that Skill's Create
+ *  workflow instead of a "Publish as a Bot" section that doesn't exist for
+ *  MCP. */
+export function getMcpBotPublishPrompt(values: McpBotPublishPromptValues = {}): string {
+  const spaceId = values.spaceId?.trim() || "<space-id>";
+  const apiBaseUrl = values.apiBaseUrl?.trim() || "<api-base-url>";
+
+  return `使用 octo-cli 内置的 \`octo-marketplace\` Skill，将指定 MCP 服务器上架到 OCTO Marketplace。
+
+- Space ID：\`${spaceId}\`
+- API 地址：\`${apiBaseUrl}\`
+- 可见范围：\`space\`
+
+如果当前消息没有 MCP 配置信息或路径，只回复：
+
+> 请提供要上架的 MCP 服务器信息（名称、传输方式 stdio/streamable-http/sse、URL 或启动命令、可选 headers / env），
+> 或提供一个 Agent 当前运行环境可访问的 MCP 配置文件路径。
+
+不要解释正在读取内容、复述本 Prompt 或逐步播报检查过程。用户提供前不要搜索磁盘或猜测路径。
+
+1. 运行 \`octo-cli version\`。如果未安装，运行
+   \`npm install -g @mininglamp-oss/octo-cli@latest\`。
+
+2. 运行 \`octo-cli auth list\`，选择 \`space_id\` 等于 \`${spaceId}\` 的唯一 Profile。
+   如果不存在或无法唯一确定，从当前 Octo Channel 的安全环境或配置读取 Bot Token，
+   通过 stdin 登录或更新固定 Profile \`space-${spaceId}\`：
+
+   \`\`\`bash
+   <read-token> | octo-cli auth login --with-token --profile space-${spaceId} --space ${spaceId} --api-base-url ${apiBaseUrl}
+   \`\`\`
+
+   不得输出 Token 或把 Token 放入命令参数。
+
+3. 读取并遵循最新的 \`octo-marketplace\` Skill 中的 \`mcp.md\`：
+
+   \`\`\`bash
+   octo-cli skills octo-marketplace --profile <profile>
+   \`\`\`
+
+4. 按 \`mcp.md\` 的 Create 流程完成上架：
+
+   - 运行 \`octo-cli marketplace mcp-category list --mode all --profile <profile>\`
+     拿到合法的 \`category\` key（不要用 \`all\` 或空串作分类）。
+   - \`streamable-http\` / \`sse\` 传输：先把 \`transport\` / \`url\` / 可选 \`headers\` / \`env\`
+     写入 \`connection.json\`，运行
+     \`octo-cli marketplace mcp probe --data @connection.json --profile <profile>\`，
+     确认 \`is_ok=true\` 再继续。\`stdio\` 传输不要调用 probe。
+   - 编写 \`mcp.json\`：目录字段（\`name\` / \`slogan\` / \`category\` / \`tags\` / \`icon\` 等）
+     + \`transport\` + 对应连接字段。消费者需自行填入的密钥放进
+     \`env_user_supplied\` / \`headers_user_supplied\`，对应值提交空字符串。
+   - 运行 \`octo-cli marketplace mcp create --data @mcp.json --profile <profile>\` 完成上架，
+     用返回的 \`mcp_id\` 通过 \`marketplace mcp get <mcp-id>\` 复核。
+
+以上 Space ID、API 地址和可见范围是本次操作的权威输入。`;
+}

--- a/packages/dmworkmcp/src/utils/mcpTagValidation.test.ts
+++ b/packages/dmworkmcp/src/utils/mcpTagValidation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The validator calls t() to build its error strings; the test doesn't care
+// about the resolved copy, only that a message was returned (invalid) or was
+// null (valid). Mocking @octo/base to a pass-through t() keeps the tests
+// independent of the i18n runtime.
+vi.mock("@octo/base", () => ({
+  t: (key: string) => key,
+}));
+
+import {
+  MAX_MCP_TAGS,
+  MAX_MCP_TAG_LENGTH,
+  tagLength,
+  validateMcpTag,
+  validateMcpTags,
+} from "./mcpTagValidation";
+
+describe("tagLength — codepoint counting (not UTF-16 units)", () => {
+  it("counts BMP CJK as 1 each", () => {
+    expect(tagLength("数据服务")).toBe(4);
+  });
+  it("counts surrogate-pair (astral) CJK as 1 each", () => {
+    // U+20BB7 (𠮷) is a supplementary-plane codepoint; its .length is 2
+    // (surrogate pair) but visually and semantically it is one character.
+    // Regression guard: `value.length` would produce 2 here and would push
+    // a 24-visual-char CJK tag past MAX_MCP_TAG_LENGTH.
+    const astral = "𠮷";
+    expect(astral.length).toBe(2);
+    expect(tagLength(astral)).toBe(1);
+    expect(tagLength(astral.repeat(24))).toBe(24);
+  });
+});
+
+describe("validateMcpTag — single-tag rules", () => {
+  it("empty / whitespace-only returns null (caller decides whether to add)", () => {
+    expect(validateMcpTag("")).toBeNull();
+    expect(validateMcpTag("   ")).toBeNull();
+  });
+
+  it("length boundary is MAX_MCP_TAG_LENGTH codepoints (inclusive)", () => {
+    const at = "a".repeat(MAX_MCP_TAG_LENGTH);
+    const over = "a".repeat(MAX_MCP_TAG_LENGTH + 1);
+    expect(validateMcpTag(at)).toBeNull();
+    expect(validateMcpTag(over)).not.toBeNull();
+  });
+
+  it("length boundary applies to astral CJK, too (regression guard against value.length)", () => {
+    const at = "𠮷".repeat(MAX_MCP_TAG_LENGTH);
+    expect(validateMcpTag(at)).toBeNull();
+  });
+
+  it("charset allows letters, digits, and - _ / . # + and spaces", () => {
+    expect(validateMcpTag("v1.0")).toBeNull();
+    expect(validateMcpTag("data-service")).toBeNull();
+    expect(validateMcpTag("c++")).toBeNull();
+    expect(validateMcpTag("dev tools")).toBeNull();
+    expect(validateMcpTag("api/v1")).toBeNull();
+    expect(validateMcpTag("#tag")).toBeNull();
+    expect(validateMcpTag("数据服务")).toBeNull();
+  });
+
+  it("charset rejects tab / newline / zero-width-space / emoji / comma", () => {
+    expect(validateMcpTag("a\tb")).not.toBeNull();
+    expect(validateMcpTag("a\nb")).not.toBeNull();
+    expect(validateMcpTag("a​b")).not.toBeNull();
+    expect(validateMcpTag("hi\u{1F600}")).not.toBeNull();
+    expect(validateMcpTag("a,b")).not.toBeNull();
+  });
+});
+
+describe("validateMcpTags — collection rules", () => {
+  it("count boundary is MAX_MCP_TAGS (inclusive)", () => {
+    const at = Array.from({ length: MAX_MCP_TAGS }, (_, i) => `t${i}`);
+    const over = [...at, "extra"];
+    expect(validateMcpTags(at)).toBeNull();
+    expect(validateMcpTags(over)).not.toBeNull();
+  });
+
+  it("propagates the first invalid tag error", () => {
+    expect(validateMcpTags(["ok", "a,b"])).not.toBeNull();
+  });
+
+  it("empty strings in the array do NOT short-circuit later validation", () => {
+    // validateMcpTag("") returns null so a caller that leaked an empty tag
+    // into the array shouldn't accidentally mask a real violation later.
+    expect(validateMcpTags(["", "bad,tag"])).not.toBeNull();
+  });
+});

--- a/packages/dmworkmcp/src/utils/mcpTagValidation.ts
+++ b/packages/dmworkmcp/src/utils/mcpTagValidation.ts
@@ -1,0 +1,45 @@
+import { t } from "@octo/base";
+
+/** Max number of tags allowed on a single MCP entry (mirrors dmworkskillmarket
+ *  after PR #1026 raised it from 5 to 10). Applied both in the create/edit
+ *  form and as a defensive submit-time guard for legacy oversized sets. */
+export const MAX_MCP_TAGS = 10;
+export const MAX_MCP_TAG_LENGTH = 24;
+
+/** Same allowlist as dmworkskillmarket — letters, digits, whitespace,
+ *  and `- _ / . # +`. Anything else is rejected. */
+const MCP_TAG_PATTERN = /^[\p{L}\p{N} _./#+-]+$/u;
+
+/** Count characters as visible code points (so wide CJK chars each count as 1
+ *  toward MAX_MCP_TAG_LENGTH instead of by UTF-16 units). */
+export function tagLength(value: string): number {
+  return Array.from(value).length;
+}
+
+/** Validate a single tag string. Returns an error message or null when OK.
+ *  Empty tags return null so callers can decide whether to add them. */
+export function validateMcpTag(value: string): string | null {
+  const tag = value.trim();
+  if (!tag) return null;
+  if (tagLength(tag) > MAX_MCP_TAG_LENGTH) {
+    return t("mcp.form.tagLengthLimit", { values: { count: MAX_MCP_TAG_LENGTH } });
+  }
+  if (!MCP_TAG_PATTERN.test(tag)) {
+    return t("mcp.form.tagInvalidChars");
+  }
+  return null;
+}
+
+/** Validate the full tags array — blocks the save button when a legacy row
+ *  is loaded with too many tags or a tag that violates the pattern/length
+ *  rule. Returns the first error message encountered, or null when clean. */
+export function validateMcpTags(tags: string[]): string | null {
+  if (tags.length > MAX_MCP_TAGS) {
+    return t("mcp.form.tagLimit", { values: { count: MAX_MCP_TAGS } });
+  }
+  for (const tag of tags) {
+    const error = validateMcpTag(tag);
+    if (error) return error;
+  }
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,6 +768,9 @@ importers:
       classnames:
         specifier: ^2.3.1
         version: 2.5.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@17.0.2)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -10261,7 +10264,6 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
@@ -17802,7 +17804,7 @@ snapshots:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0)(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -17827,7 +17829,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.28.0(eslint@7.32.0)
@@ -17861,7 +17863,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 7.32.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.11
@@ -17880,6 +17882,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@7.32.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
@@ -17888,7 +17900,7 @@ snapshots:
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17912,6 +17924,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@7.32.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Summary

Bring the MCP marketplace page in line with the Skill marketplace (issue #1009), backport the tag/title overflow guards from PR #1026, and wire the new tag chip filter to the backend `/mcp_tags` endpoint added in [octo-marketplace #23](https://github.com/Mininglamp-OSS/octo-marketplace/pull/23).

The commit history reflects three natural chapters:

1. **UI alignment (#1009 body)** — McpCard 2-line owner row (`🐳 bot · 👤 human` for bot rows, `👤 human` for human rows, hidden for import rows), 48px icon + hash-color fallback + 2-char initials, rounded-pill accent tags, MatchReasons chips restored for creator hits only, McpDetailModal custom WKModal header (icon + h3 + category chip + owner/updated meta), publish button → `上架 MCP` primary + Upload icon + dropdown (Bot 上架 / 手动上架), Bot 上架 prompt modal referencing octo-cli's `octo-marketplace` Skill's mcp.md workflow.
2. **PR #1026 backport** — MCP tag input rejects `>10` tags / `>24 chars` / invalid chars with Toast, paste splits on comma, McpCreateModal.handleSubmit re-validates on save (guards legacy oversized rows), tag chip inside input ellipses long tags.
3. **Tag chip filter** — new popover in the search bar mirroring Skill's SearchBar. Reads suggestions from `GET /mcp_tags` (debounced 160ms, AbortController-cancelled), forwards `?mode=mine` when opened from the 我的 tab, memoized `tagRows` on the class instance keyed on `(tagsSelected, tagSuggestions)` identity, `focus({ preventScroll: true })` on open to avoid tripping the infinite-scroll listener, resets state on space + mode change. Selected tags round-trip through the URL as repeated `?tag=X` params (avoids splitting on any tag literal containing a comma).

Also removed the 来源 (人工/Bot) segmented filter per product feedback — both provenance values render identically to end users.

## Linked Spec

Fixes #1009. Refs #1017 + PR #1026 (Skill tag/title overflow backport), and the sibling backend contract at [octo-marketplace #23](https://github.com/Mininglamp-OSS/octo-marketplace/pull/23) for narrow keyword search + AND tag semantics + `/mcp_tags`.

## How verified

Local Vite dev server (`localhost:5174`) proxied to `im-test.deepminer.com.cn`. Full E2E walkthrough:

- List renders 41 real MCPs; every provenance case (bot / human / empty-icon fallback / long-title) displays correctly
- Category chip `开发工具` → 12 rows; count updates + refetch works
- Search `linear` → 2 rows (Linear Sync Bot + Linear MCP); MatchReasons chip appears only when creator matches
- Tag popover: opens, search input focused, empty state \"还没有可选标签\" because the sibling backend PR hasn't deployed to test env yet — once it does, suggestions populate from `/mcp_tags`
- Publish dropdown: opens both `Bot 上架` (copy-prompt modal, 1783-char prompt with real Space ID + API base URL) and `手动上架` (create form) paths
- Detail modal for Slack Notifier Bot: `[icon] Slack Notifier Bot [效率协作]` header + `🐳 Slack Notifier · 👤 Developer · 1 天前更新` meta + slogan + `🔧 1` stats + tags at the bottom
- Create form: tag input rejects `>10` tags, `>24` char tags, non-allowlisted chars, paste-split `a,b,c` → 3 chips
- No new TS errors introduced vs. baseline

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   - **McpCard / McpDetailModal**: DOM + CSS refactor to match Skill layout. Same wire contract (`McpListItem`, `McpDetail`); the resolveOwner helper picks the display shape per `createdByType` (bot/human/import → chip / chip / no-chip).
   - **TagsInput in McpCreateModal**: adds `validateMcpTags(form.tags)` guard on submit + inline per-tag validation; a legacy record with >10 or over-length tags now blocks save until fixed.
   - **List filter API contract**: `params.tags` is now serialised as repeated `?tag=X` params (was comma-joined). Backend `splitQuery` accepts both, so a mid-migration overlap is safe.
   - **New `fetchMcpTags` API call**: hits `GET /market/api/v1/mcp_tags?q=...&limit=100&mode=mine` when the popover opens. Fails silently (empty popover) if backend isn't up.
   - **`mcpListQuery`**: URL round-trips `?tag=X` params so bookmarked filtered views hydrate cleanly.
   - **Removed**: `createdByType` state + `SOURCE_FILTER_OPTIONS` + the source segmented filter UI. The wire field stays on responses; only the client-side filter is gone.

2. **What could break** because of it (dependents + failure mode)?

   - **Bot 上架 prompt correctness**: hard-codes `octo-cli marketplace mcp create` and references the `octo-marketplace` Skill's `mcp.md`. Verified against octo-cli's embedded Skill catalog. If those commands ever rename, the single template string in `utils/mcpBotPublishPrompt.ts` needs a bump.
   - **Tag chip filter on old backend**: octo-marketplace PR must merge + deploy before the popover fills in with real suggestions. Meanwhile the popover shows an empty state; the underlying `?tag=` filter still works if the user selects a chip from a previously-loaded state.
   - **Rebase surface**: this branch was rebased on top of a 7-commit upstream/main window (dmworksummary + docs + globalsearch refactors). No overlap with dmworkmcp files but full-branch force-push happened.
   - **Legacy tag validation UX**: a user opening an existing MCP with `>10` tags will see save blocked and a Toast until they trim; documented in the file comment.
   - **Clipboard availability**: Bot 上架 modal toasts on clipboard rejection or missing `navigator.clipboard`, so users on http:// origins or older WebViews see feedback instead of a silent no-op.

3. **How do you know it works** (specific test/repro/trace)?

   - Full E2E walkthrough against test env (see \"How verified\") — every provenance case, every filter, every modal opened and read
   - Cross-repo code-review pass (5 parallel agents on both branches) applied all findings inline; a second review-pass found 4 more (mode passthrough, sort=updated, comma-tag safety, memo/preventScroll) — all applied in the same diff
   - Vite HMR compiles every touched file; TS baseline errors unchanged (pre-existing React 17/18 type resolution issues)
   - Manual DOM inspection: `resolveOwner` gates the import branch correctly (returns null; card meta-row collapses cleanly); MatchReasons component only fires for `creator` hits after the sibling backend change; category badge falls back to raw slug if i18n misses
   - Load-bearing edge cases explicitly tested during review: whitespace-only icon → fallback avatar; whitespace-only tag → rejected at add; future timestamp → falls to absolute date format not \"just now\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)